### PR TITLE
fix(trusty-mpm): idempotent catalog sync — update existing checkout instead of failing on re-clone (closes #1751)

### DIFF
--- a/crates/trusty-mpm/src/content/catalog_sync.rs
+++ b/crates/trusty-mpm/src/content/catalog_sync.rs
@@ -446,13 +446,25 @@ impl<G: GitBackend> CatalogSync<G> {
 
 /// Safely remove the catalog repo directory, refusing to delete outside the catalog root.
 ///
-/// Why: guards against bugs that could accidentally remove an arbitrary path; the
-/// remove target must always be a subdirectory of the catalog root.
-/// What: returns an error if `target` is not rooted under `catalog_dir`, otherwise
-/// calls `remove_dir_all`.
+/// Why: guards against bugs and symlink-escape attacks that could accidentally
+/// remove an arbitrary path; canonicalizing both paths before comparison eliminates
+/// `..` traversal and symlink tricks.
+/// What: canonicalizes `target` and `catalog_dir` (both must exist at call time —
+/// `catalog_dir` was created by `create_dir_all` and `target` exists by caller
+/// precondition), rejects if `canon_target == canon_catalog` (never remove the
+/// catalog root itself), rejects if `canon_target` is not strictly under
+/// `canon_catalog`, then calls `remove_dir_all`.
 /// Test: guard_remove_rejects_path_outside_catalog.
 fn guard_remove(target: &Path, catalog_dir: &Path) -> Result<(), CatalogError> {
-    if !target.starts_with(catalog_dir) {
+    let canon_target = target.canonicalize().map_err(CatalogError::Io)?;
+    let canon_catalog = catalog_dir.canonicalize().map_err(CatalogError::Io)?;
+    if canon_target == canon_catalog {
+        return Err(CatalogError::Git(format!(
+            "safety: refusing to remove catalog root '{}'",
+            target.display()
+        )));
+    }
+    if !canon_target.starts_with(&canon_catalog) {
         return Err(CatalogError::Git(format!(
             "safety: refusing to remove '{}' — not inside catalog dir '{}'",
             target.display(),
@@ -473,8 +485,27 @@ fn urls_match(a: &str, b: &str) -> bool {
     normalize_repo_url(a) == normalize_repo_url(b)
 }
 
+/// Normalise a git remote URL to a canonical form for comparison.
+///
+/// Why: two URLs for the same repository can differ in protocol (ssh vs https),
+/// `.git` suffix, trailing slash, and case — without normalization they falsely
+/// mismatch and trigger a spurious destructive re-clone.
+/// What: converts `git@host:owner/repo` to `https://host/owner/repo`, strips
+/// trailing `/` and `.git`, then lowercases the result.
+/// Test: urls_match_normalises_variants.
 fn normalize_repo_url(url: &str) -> String {
-    url.trim_end_matches('/')
+    // Convert SSH git@ form to HTTPS before further normalization.
+    let https_form = if let Some(rest) = url.strip_prefix("git@") {
+        if let Some((host, path)) = rest.split_once(':') {
+            format!("https://{host}/{path}")
+        } else {
+            url.to_owned()
+        }
+    } else {
+        url.to_owned()
+    };
+    https_form
+        .trim_end_matches('/')
         .trim_end_matches(".git")
         .to_lowercase()
 }
@@ -730,6 +761,71 @@ mod tests {
         assert!(
             agents.contains(&"legacy-agent".to_owned()),
             "agents from legacy path: {agents:?}"
+        );
+    }
+
+    #[test]
+    fn guard_remove_rejects_path_outside_catalog() {
+        // Verify canonicalized guard rejects paths outside the catalog boundary
+        // and also refuses to remove the catalog root itself.
+        let root = TempDir::new().unwrap();
+        let catalog_dir = root.path().join("catalog");
+        std::fs::create_dir_all(&catalog_dir).unwrap();
+        let outside = root.path().join("not-catalog");
+        std::fs::create_dir_all(&outside).unwrap();
+        // Sibling directory outside catalog must be rejected.
+        assert!(
+            guard_remove(&outside, &catalog_dir).is_err(),
+            "path outside catalog must be rejected"
+        );
+        // Removing the catalog root itself must also be rejected.
+        assert!(
+            guard_remove(&catalog_dir, &catalog_dir).is_err(),
+            "catalog root itself must be rejected"
+        );
+    }
+
+    #[test]
+    fn urls_match_normalises_variants() {
+        // SSH and HTTPS forms of the same repo must match.
+        assert!(
+            urls_match(
+                "git@github.com:owner/repo.git",
+                "https://github.com/owner/repo"
+            ),
+            "ssh↔https must match"
+        );
+        // Trailing slash must not prevent a match.
+        assert!(
+            urls_match(
+                "https://github.com/owner/repo/",
+                "https://github.com/owner/repo"
+            ),
+            "trailing slash must be ignored"
+        );
+        // .git suffix must not prevent a match.
+        assert!(
+            urls_match(
+                "https://github.com/owner/repo.git",
+                "https://github.com/owner/repo"
+            ),
+            ".git suffix must be stripped"
+        );
+        // Case insensitivity.
+        assert!(
+            urls_match(
+                "HTTPS://GitHub.com/Owner/Repo",
+                "https://github.com/owner/repo"
+            ),
+            "comparison must be case-insensitive"
+        );
+        // Different repos must NOT match.
+        assert!(
+            !urls_match(
+                "https://github.com/owner/repo-a",
+                "https://github.com/owner/repo-b"
+            ),
+            "distinct repos must not match"
         );
     }
 }

--- a/crates/trusty-mpm/src/content/catalog_sync.rs
+++ b/crates/trusty-mpm/src/content/catalog_sync.rs
@@ -196,9 +196,12 @@ impl<G: GitBackend> CatalogSync<G> {
     /// Why: the session manager calls this on `tm catalog sync` and optionally
     /// on daemon start to ensure agents/skills are available.
     /// What: checks the sentinel file's mtime against the TTL; if the TTL has
-    /// not expired (and force=false), skips the fetch. Otherwise clones the
-    /// catalog repo into catalog_dir and writes the sentinel.
-    /// Test: catalog_sync_fetches_on_first_call, catalog_sync_skips_on_ttl_valid.
+    /// not expired (and force=false), skips the fetch. Otherwise decides whether
+    /// to clone fresh, update in place, or recover a corrupt/wrong-remote checkout
+    /// (see `ensure_repo`) then writes the sentinel.
+    /// Test: catalog_sync_fetches_on_first_call, catalog_sync_skips_on_ttl_valid,
+    /// catalog_sync_second_sync_succeeds, catalog_sync_corrupt_dir_reclones,
+    /// catalog_sync_wrong_remote_reclones.
     pub fn sync(&self, force: bool) -> Result<CatalogSyncResult, CatalogError> {
         if !force && self.ttl_valid() {
             debug!(dir = %self.catalog_dir.display(), "catalog TTL valid; skipping fetch");
@@ -211,13 +214,11 @@ impl<G: GitBackend> CatalogSync<G> {
 
         info!(repo = %self.repo_url, git_ref = %self.git_ref, dir = %self.catalog_dir.display(), "syncing catalog");
 
-        // Clone into a temporary subdir then move, to avoid partial state.
-        let clone_target = self.catalog_dir.join("repo");
-        std::fs::create_dir_all(&clone_target)?;
+        // Ensure the catalog parent directory exists before any git operation.
+        std::fs::create_dir_all(&self.catalog_dir)?;
 
-        self.git
-            .clone_repo(&self.repo_url, &self.git_ref, &clone_target)
-            .map_err(|e| CatalogError::Git(e.to_string()))?;
+        let clone_target = self.catalog_dir.join("repo");
+        self.ensure_repo(&clone_target)?;
 
         // Write the sentinel to record when we last synced.
         let sentinel = self.catalog_dir.join(SYNC_SENTINEL);
@@ -236,6 +237,81 @@ impl<G: GitBackend> CatalogSync<G> {
             agent_count,
             skill_count,
         })
+    }
+
+    /// Idempotently bring the repo checkout at `target` up to date.
+    ///
+    /// Why: this is the core fix for #1751 — the previous code always called
+    /// `git clone` which fails when the directory already exists. This function
+    /// decides clone-vs-update-vs-reclone so a second sync always succeeds.
+    /// What: three cases:
+    ///   1. `target` absent → fresh clone.
+    ///   2. `target` is a git repo whose `origin` matches `repo_url` → fetch +
+    ///      hard-reset (update in place).
+    ///   3. `target` is not a git repo, or has the wrong `origin`, or
+    ///      fetch/reset fails → remove `target` and re-clone.
+    ///
+    /// Test: `catalog_sync_second_sync_succeeds` (case 2),
+    /// `catalog_sync_corrupt_dir_reclones` (case 3, non-git dir),
+    /// `catalog_sync_wrong_remote_reclones` (case 3, wrong remote).
+    fn ensure_repo(&self, target: &Path) -> Result<(), CatalogError> {
+        if !target.exists() {
+            return self.do_clone(target);
+        }
+        if !self.git.is_git_repo(target) {
+            warn!(path = %target.display(), "catalog dir exists but is not a git repo; re-cloning");
+            guard_remove(target, &self.catalog_dir)?;
+            return self.do_clone(target);
+        }
+        match self.git.remote_url(target) {
+            Ok(ref url) if urls_match(url, &self.repo_url) => {
+                info!(dir = %target.display(), "catalog repo up to date remote; fetching updates");
+                self.do_update(target)
+            }
+            Ok(actual) => {
+                warn!(
+                    actual = %actual,
+                    expected = %self.repo_url,
+                    "catalog repo has wrong remote; re-cloning"
+                );
+                guard_remove(target, &self.catalog_dir)?;
+                self.do_clone(target)
+            }
+            Err(e) => {
+                warn!(err = %e, "catalog repo appears corrupt; re-cloning");
+                guard_remove(target, &self.catalog_dir)?;
+                self.do_clone(target)
+            }
+        }
+    }
+
+    /// Clone the repo into `target` (case 1 of `ensure_repo`).
+    ///
+    /// Why: thin wrapper that translates ProvisionError → CatalogError.
+    /// What: delegates to `self.git.clone_repo` with the configured URL and ref.
+    /// Test: exercised by catalog_sync_fetches_on_first_call.
+    fn do_clone(&self, target: &Path) -> Result<(), CatalogError> {
+        self.git
+            .clone_repo(&self.repo_url, &self.git_ref, target)
+            .map_err(|e| CatalogError::Git(e.to_string()))
+    }
+
+    /// Update an existing valid checkout in place (case 2 of `ensure_repo`).
+    ///
+    /// Why: fetch + hard-reset is idempotent and handles local drift without a
+    /// full re-clone; falls back to re-clone if the update itself fails.
+    /// What: calls `self.git.fetch_and_reset`; on failure removes `target` and
+    /// calls `do_clone` to recover.
+    /// Test: exercised by catalog_sync_second_sync_succeeds.
+    fn do_update(&self, target: &Path) -> Result<(), CatalogError> {
+        match self.git.fetch_and_reset(target, &self.git_ref) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                warn!(err = %e, "catalog fetch/reset failed; re-cloning from scratch");
+                guard_remove(target, &self.catalog_dir)?;
+                self.do_clone(target)
+            }
+        }
     }
 
     /// Return true if the catalog was synced within the TTL window.
@@ -366,6 +442,41 @@ impl<G: GitBackend> CatalogSync<G> {
     pub fn catalog_root(&self) -> &Path {
         &self.catalog_dir
     }
+}
+
+/// Safely remove the catalog repo directory, refusing to delete outside the catalog root.
+///
+/// Why: guards against bugs that could accidentally remove an arbitrary path; the
+/// remove target must always be a subdirectory of the catalog root.
+/// What: returns an error if `target` is not rooted under `catalog_dir`, otherwise
+/// calls `remove_dir_all`.
+/// Test: guard_remove_rejects_path_outside_catalog.
+fn guard_remove(target: &Path, catalog_dir: &Path) -> Result<(), CatalogError> {
+    if !target.starts_with(catalog_dir) {
+        return Err(CatalogError::Git(format!(
+            "safety: refusing to remove '{}' — not inside catalog dir '{}'",
+            target.display(),
+            catalog_dir.display()
+        )));
+    }
+    std::fs::remove_dir_all(target).map_err(CatalogError::Io)
+}
+
+/// Return true if two git remote URLs refer to the same repository.
+///
+/// Why: `git remote get-url` and the configured URL may differ by trailing
+/// slash or `.git` suffix; normalising before comparison avoids spurious
+/// re-clones when the URL forms are equivalent.
+/// What: lower-cases both URLs and strips trailing `/` and `.git`.
+/// Test: urls_match_normalises_variants.
+fn urls_match(a: &str, b: &str) -> bool {
+    normalize_repo_url(a) == normalize_repo_url(b)
+}
+
+fn normalize_repo_url(url: &str) -> String {
+    url.trim_end_matches('/')
+        .trim_end_matches(".git")
+        .to_lowercase()
 }
 
 /// Return the file stems in a directory (for flat-file layouts like agents).
@@ -622,3 +733,6 @@ mod tests {
         );
     }
 }
+
+// #1751 idempotency tests (uses public API → lives in crates/trusty-mpm/tests/).
+// See: tests/catalog_sync_idempotent.rs

--- a/crates/trusty-mpm/src/core/update_check/apply/tests.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply/tests.rs
@@ -1,9 +1,10 @@
 //! Unit tests for `apply_catalog` (HR-3 rebuild offer).
 //!
 //! Why: the apply path must be verifiable offline — a `FakeGitBackend` simulates
-//! the catalog checkout (creating only the `repo` dir), the test seeds catalog
-//! agent/skill files into it, and the assertions cover redeploy + staleness-clear
-//! and the opt-in prune (including that prune spares user-owned files).
+//! the catalog checkout, the test seeds catalog agent/skill files into it (along
+//! with a minimal `.git/config` so `ensure_repo` takes the idempotent update path),
+//! and the assertions cover redeploy + staleness-clear and the opt-in prune
+//! (including that prune spares user-owned files).
 //! What: build a hermetic `FrameworkPaths` under a tempdir, write a project
 //! manifest selecting the CATALOG source, run `apply_catalog`, and assert the
 //! deployed files + a subsequent `detect_for_framework` reports fresh.
@@ -16,9 +17,32 @@ use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
 
+/// Mark `<catalog>/repo` as a valid git checkout so `ensure_repo` takes the
+/// idempotent update path (fetch+reset via `FakeGitBackend`, a no-op) rather
+/// than treating the pre-seeded directory as corrupt and wiping it.
+///
+/// Why: `CatalogSync::ensure_repo` (fix for #1751) now checks for `.git/`
+/// before deciding whether to clone or update in place. Test helpers that
+/// pre-seed catalog content must create this marker so the seeded files survive
+/// the sync call inside `apply_catalog`.
+/// What: writes a minimal `.git/config` with the default catalog remote URL at
+/// `<catalog>/repo/.git/config`, idempotently.
+/// Test: called by the seeding helpers below.
+fn mark_catalog_repo_as_valid(catalog_root: &Path) {
+    let git_dir = catalog_root.join("repo/.git");
+    fs::create_dir_all(&git_dir).unwrap();
+    // Use the same URL as DEFAULT_CATALOG_REPO in catalog_sync.rs.
+    fs::write(
+        git_dir.join("config"),
+        "[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = https://github.com/bobmatnyc/claude-mpm\n",
+    )
+    .unwrap();
+}
+
 /// Seed a catalog agent file at the layout `CatalogSync` writes
 /// (`<catalog>/repo/.claude/agents/<stem>.md`).
 fn seed_catalog_agent(catalog_root: &Path, stem: &str, body: &str) {
+    mark_catalog_repo_as_valid(catalog_root);
     let dir = catalog_root.join("repo/.claude/agents");
     fs::create_dir_all(&dir).unwrap();
     fs::write(
@@ -30,6 +54,7 @@ fn seed_catalog_agent(catalog_root: &Path, stem: &str, body: &str) {
 
 /// Seed a catalog skill file at `<catalog>/repo/.claude/skills/<stem>.md`.
 fn seed_catalog_skill(catalog_root: &Path, stem: &str, body: &str) {
+    mark_catalog_repo_as_valid(catalog_root);
     let dir = catalog_root.join("repo/.claude/skills");
     fs::create_dir_all(&dir).unwrap();
     fs::write(

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -92,12 +92,14 @@ pub trait GitBackend: Send + Sync {
     /// Test: FakeGitBackend reads from the `.git/config` it writes during clone.
     fn remote_url(&self, dir: &Path) -> Result<String, ProvisionError>;
 
-    /// Fetch from `origin` and hard-reset the working tree to `origin/<git_ref>`.
+    /// Fetch the specific `git_ref` from `origin` and hard-reset to `FETCH_HEAD`.
     ///
     /// Why: catalog sync updates an existing valid checkout in place so local
-    /// drift (manual edits, partial state) can never block the update.
-    /// What: runs `git -C dir fetch origin` then
-    /// `git -C dir reset --hard origin/<git_ref>`.
+    /// drift (manual edits, partial state) can never block the update; using
+    /// FETCH_HEAD avoids `origin/<ref>` which only works for branches, not tags
+    /// or SHAs.
+    /// What: runs `git -C dir fetch origin <git_ref>` then
+    /// `git -C dir reset --hard FETCH_HEAD` — works for branches, tags, and SHAs.
     /// Test: FakeGitBackend returns Ok(()) without performing real git operations.
     fn fetch_and_reset(&self, dir: &Path, git_ref: &str) -> Result<(), ProvisionError>;
 }
@@ -174,17 +176,20 @@ impl GitBackend for RealGitBackend {
     fn fetch_and_reset(&self, dir: &Path, git_ref: &str) -> Result<(), ProvisionError> {
         use std::process::Command;
         let dir_s = dir.to_string_lossy();
+        // Fetch the specific ref so tags and SHAs work correctly.
+        // `git fetch origin <ref>` writes FETCH_HEAD; `git reset --hard FETCH_HEAD`
+        // then works for branches, tags, and commit SHAs alike — unlike
+        // `origin/<ref>` which only resolves for branches.
         let fetch = Command::new("git")
-            .args(["-C", &dir_s, "fetch", "origin"])
+            .args(["-C", &dir_s, "fetch", "origin", git_ref])
             .output()
             .map_err(|e| ProvisionError::Git(format!("git fetch exec failed: {e}")))?;
         if !fetch.status.success() {
             let stderr = String::from_utf8_lossy(&fetch.stderr);
             return Err(ProvisionError::Git(format!("git fetch failed: {stderr}")));
         }
-        let reset_ref = format!("origin/{git_ref}");
         let reset = Command::new("git")
-            .args(["-C", &dir_s, "reset", "--hard", &reset_ref])
+            .args(["-C", &dir_s, "reset", "--hard", "FETCH_HEAD"])
             .output()
             .map_err(|e| ProvisionError::Git(format!("git reset exec failed: {e}")))?;
         if reset.status.success() {
@@ -200,21 +205,42 @@ impl GitBackend for RealGitBackend {
 ///
 /// Why: unit tests must not require a real git remote or network.
 /// What: records clone calls and creates the target directory to simulate a checkout.
-/// Test: used by every WorkspaceProvisioner unit test.
+/// Use `new()` for a permissive fake; use `new_strict()` to simulate real `git clone`
+/// exit-128 failures when the target directory already exists.
+/// Test: used by every WorkspaceProvisioner unit test and catalog_sync_idempotent tests.
 pub struct FakeGitBackend {
     /// Calls recorded for assertions.
     pub calls: std::sync::Mutex<Vec<(String, String, PathBuf)>>,
+    /// When true, clone_repo returns an error if target_dir already exists,
+    /// mirroring real `git clone` exit 128 behaviour.
+    strict: bool,
 }
 
 impl FakeGitBackend {
-    /// Construct a new FakeGitBackend with an empty call log.
+    /// Construct a new FakeGitBackend with an empty call log (permissive mode).
     ///
     /// Why: tests need a fresh call log for each test case.
-    /// What: initialises the Mutex-guarded vec.
+    /// What: initialises the Mutex-guarded vec with `strict = false`.
     /// Test: used in every provisioner unit test.
     pub fn new() -> Self {
         Self {
             calls: std::sync::Mutex::new(Vec::new()),
+            strict: false,
+        }
+    }
+
+    /// Construct a FakeGitBackend that fails `clone_repo` when the target already exists.
+    ///
+    /// Why: the idempotency regression test (`catalog_sync_second_sync_succeeds`)
+    /// must fail against pre-fix unconditional-clone code and pass only when
+    /// `ensure_repo` routes the second call to the update path instead of re-cloning.
+    /// What: same as `new()` but `strict = true`; clone_repo returns
+    /// `ProvisionError::Git` (simulating exit 128) if the target directory exists.
+    /// Test: catalog_sync_second_sync_succeeds.
+    pub fn new_strict() -> Self {
+        Self {
+            calls: std::sync::Mutex::new(Vec::new()),
+            strict: true,
         }
     }
 }
@@ -237,6 +263,16 @@ impl GitBackend for FakeGitBackend {
             git_ref.to_owned(),
             target_dir.to_owned(),
         ));
+        // In strict mode, mirror real `git clone` exit 128: fail when target exists.
+        // This makes catalog_sync_second_sync_succeeds a genuine regression guard —
+        // it fails against pre-fix unconditional-clone code and passes only when
+        // ensure_repo routes the second call to fetch_and_reset instead of clone.
+        if self.strict && target_dir.exists() {
+            return Err(ProvisionError::Git(format!(
+                "git clone failed (exit 128): destination path '{}' already exists and is not an empty directory",
+                target_dir.display()
+            )));
+        }
         // Simulate a clone: create a minimal .git/config so is_git_repo and
         // remote_url work correctly in subsequent calls (e.g. second sync).
         let git_dir = target_dir.join(".git");

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -55,11 +55,11 @@ pub struct PreparedWorkspace {
     pub branch: String,
 }
 
-/// Trait seam over git operations used by the provisioner.
+/// Trait seam over git operations used by the provisioner and catalog sync.
 ///
-/// Why: the provisioner must be testable without a real git remote or network
-/// access; the trait lets tests inject a FakeGitBackend.
-/// What: clone and checkout operations on a target path.
+/// Why: both the workspace provisioner and catalog sync must be testable without
+/// a real git remote or network; the trait lets tests inject a FakeGitBackend.
+/// What: clone, inspect, and update operations on a target path.
 /// Test: FakeGitBackend in this module's test section.
 pub trait GitBackend: Send + Sync {
     /// Clone repo_url at git_ref into target_dir.
@@ -73,6 +73,33 @@ pub trait GitBackend: Send + Sync {
         git_ref: &str,
         target_dir: &Path,
     ) -> Result<(), ProvisionError>;
+
+    /// Return true if `dir` contains a valid git repository.
+    ///
+    /// Why: catalog sync must distinguish a valid checkout from an absent or
+    /// corrupt directory so it can decide whether to clone, update, or re-clone.
+    /// What: checks for the presence of a `.git` subdirectory (or `.git` file
+    /// for worktrees) inside `dir`.
+    /// Test: FakeGitBackend checks for the `.git/` dir it creates during clone.
+    fn is_git_repo(&self, dir: &Path) -> bool;
+
+    /// Return the URL of the `origin` remote configured in `dir`.
+    ///
+    /// Why: catalog sync verifies the existing checkout points at the expected
+    /// remote before deciding to update in place vs. re-clone.
+    /// What: queries the git configuration of the repository at `dir` for the
+    /// `origin` remote URL.
+    /// Test: FakeGitBackend reads from the `.git/config` it writes during clone.
+    fn remote_url(&self, dir: &Path) -> Result<String, ProvisionError>;
+
+    /// Fetch from `origin` and hard-reset the working tree to `origin/<git_ref>`.
+    ///
+    /// Why: catalog sync updates an existing valid checkout in place so local
+    /// drift (manual edits, partial state) can never block the update.
+    /// What: runs `git -C dir fetch origin` then
+    /// `git -C dir reset --hard origin/<git_ref>`.
+    /// Test: FakeGitBackend returns Ok(()) without performing real git operations.
+    fn fetch_and_reset(&self, dir: &Path, git_ref: &str) -> Result<(), ProvisionError>;
 }
 
 /// Real git backend that shells out to the `git` binary.
@@ -120,6 +147,53 @@ impl GitBackend for RealGitBackend {
             )))
         }
     }
+
+    fn is_git_repo(&self, dir: &Path) -> bool {
+        // `.git` can be a directory (normal clone) or a file (worktree).
+        let dot_git = dir.join(".git");
+        dot_git.is_dir() || dot_git.is_file()
+    }
+
+    fn remote_url(&self, dir: &Path) -> Result<String, ProvisionError> {
+        use std::process::Command;
+        let dir_s = dir.to_string_lossy();
+        let out = Command::new("git")
+            .args(["-C", &dir_s, "remote", "get-url", "origin"])
+            .output()
+            .map_err(|e| ProvisionError::Git(format!("git remote get-url exec failed: {e}")))?;
+        if out.status.success() {
+            Ok(String::from_utf8_lossy(&out.stdout).trim().to_owned())
+        } else {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            Err(ProvisionError::Git(format!(
+                "git remote get-url failed: {stderr}"
+            )))
+        }
+    }
+
+    fn fetch_and_reset(&self, dir: &Path, git_ref: &str) -> Result<(), ProvisionError> {
+        use std::process::Command;
+        let dir_s = dir.to_string_lossy();
+        let fetch = Command::new("git")
+            .args(["-C", &dir_s, "fetch", "origin"])
+            .output()
+            .map_err(|e| ProvisionError::Git(format!("git fetch exec failed: {e}")))?;
+        if !fetch.status.success() {
+            let stderr = String::from_utf8_lossy(&fetch.stderr);
+            return Err(ProvisionError::Git(format!("git fetch failed: {stderr}")));
+        }
+        let reset_ref = format!("origin/{git_ref}");
+        let reset = Command::new("git")
+            .args(["-C", &dir_s, "reset", "--hard", &reset_ref])
+            .output()
+            .map_err(|e| ProvisionError::Git(format!("git reset exec failed: {e}")))?;
+        if reset.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&reset.stderr);
+            Err(ProvisionError::Git(format!("git reset failed: {stderr}")))
+        }
+    }
 }
 
 /// Fake git backend for unit tests.
@@ -163,8 +237,44 @@ impl GitBackend for FakeGitBackend {
             git_ref.to_owned(),
             target_dir.to_owned(),
         ));
-        // Create the directory to simulate a successful clone.
-        std::fs::create_dir_all(target_dir)?;
+        // Simulate a clone: create a minimal .git/config so is_git_repo and
+        // remote_url work correctly in subsequent calls (e.g. second sync).
+        let git_dir = target_dir.join(".git");
+        std::fs::create_dir_all(&git_dir)?;
+        let config = format!(
+            "[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = {repo_url}\n"
+        );
+        std::fs::write(git_dir.join("config"), config)?;
+        Ok(())
+    }
+
+    fn is_git_repo(&self, dir: &Path) -> bool {
+        dir.join(".git").is_dir()
+    }
+
+    fn remote_url(&self, dir: &Path) -> Result<String, ProvisionError> {
+        // Read the URL from the fake .git/config written during clone_repo.
+        let config_path = dir.join(".git").join("config");
+        let content = std::fs::read_to_string(&config_path)
+            .map_err(|e| ProvisionError::Git(format!("no .git/config: {e}")))?;
+        let mut in_origin = false;
+        for line in content.lines() {
+            let t = line.trim();
+            if t == "[remote \"origin\"]" {
+                in_origin = true;
+            } else if t.starts_with('[') {
+                in_origin = false;
+            } else if in_origin && let Some(url) = t.strip_prefix("url = ") {
+                return Ok(url.to_owned());
+            }
+        }
+        Err(ProvisionError::Git(
+            "no origin remote in .git/config".to_owned(),
+        ))
+    }
+
+    fn fetch_and_reset(&self, _dir: &Path, _git_ref: &str) -> Result<(), ProvisionError> {
+        // Fake: always succeeds — no network or filesystem operation needed.
         Ok(())
     }
 }

--- a/crates/trusty-mpm/tests/catalog_sync_idempotent.rs
+++ b/crates/trusty-mpm/tests/catalog_sync_idempotent.rs
@@ -22,12 +22,25 @@ fn make_sync(dir: &std::path::Path) -> CatalogSync<FakeGitBackend> {
 
 /// Why: regression test for #1751 — a second forced sync must succeed via the
 /// update path (fetch+reset), not fail with "already exists" from git clone.
-/// What: first sync clones, second forced sync updates in place.
+/// Uses `FakeGitBackend::new_strict()` so clone_repo returns exit-128 when the
+/// target already exists; the test FAILS against pre-fix unconditional-clone code
+/// and PASSES only when `ensure_repo` routes the second call to fetch_and_reset.
+/// What: first sync clones (target absent → clone path succeeds), second forced
+/// sync detects a valid checkout with the correct remote and takes the update path.
 /// Test: this is the test.
 #[test]
 fn catalog_sync_second_sync_succeeds() {
     let root = tempfile::TempDir::new().unwrap();
-    let sync = make_sync(root.path());
+    // Strict fake: clone_repo returns an error if the target dir already exists,
+    // mirroring real `git clone` exit 128. This turns the test into a genuine
+    // regression guard — it would panic on r2 if ensure_repo called clone_repo
+    // unconditionally (pre-fix behaviour) instead of routing to fetch_and_reset.
+    let sync = CatalogSync::with_repo(
+        FakeGitBackend::new_strict(),
+        root.path().to_owned(),
+        "https://github.com/bobmatnyc/claude-mpm",
+        "main",
+    );
 
     let r1 = sync.sync(false).unwrap();
     assert!(r1.fetched, "first sync must fetch");
@@ -37,7 +50,8 @@ fn catalog_sync_second_sync_succeeds() {
     );
 
     // Force a second sync — repo dir exists with valid .git; must NOT fail with
-    // "already exists" but take the update path (fetch+reset via FakeGitBackend).
+    // "already exists" (strict fake would return Err if clone_repo were called)
+    // but instead take the update path (fetch_and_reset via FakeGitBackend).
     let r2 = sync.sync(true).unwrap();
     assert!(r2.fetched, "forced second sync must report fetched=true");
 }

--- a/crates/trusty-mpm/tests/catalog_sync_idempotent.rs
+++ b/crates/trusty-mpm/tests/catalog_sync_idempotent.rs
@@ -1,0 +1,101 @@
+//! Integration tests for idempotent catalog sync (issue #1751).
+//!
+//! Why: `CatalogSync::sync` previously called `git clone` unconditionally; a
+//! second sync failed with "destination already exists". This file exercises the
+//! three decision branches of `ensure_repo` (clone, update, re-clone) and the
+//! URL-normalisation + safety-guard helpers via the public API.
+//! What: uses only the public surface of `trusty_mpm` so these tests remain
+//! valid across refactors of the private helpers.
+//! Test: all tests in this file are the tests.
+
+use trusty_mpm::content::CatalogSync;
+use trusty_mpm::provisioner::FakeGitBackend;
+
+fn make_sync(dir: &std::path::Path) -> CatalogSync<FakeGitBackend> {
+    CatalogSync::with_repo(
+        FakeGitBackend::new(),
+        dir.to_owned(),
+        "https://github.com/bobmatnyc/claude-mpm",
+        "main",
+    )
+}
+
+/// Why: regression test for #1751 — a second forced sync must succeed via the
+/// update path (fetch+reset), not fail with "already exists" from git clone.
+/// What: first sync clones, second forced sync updates in place.
+/// Test: this is the test.
+#[test]
+fn catalog_sync_second_sync_succeeds() {
+    let root = tempfile::TempDir::new().unwrap();
+    let sync = make_sync(root.path());
+
+    let r1 = sync.sync(false).unwrap();
+    assert!(r1.fetched, "first sync must fetch");
+    assert!(
+        root.path().join("repo").exists(),
+        "repo dir must be created"
+    );
+
+    // Force a second sync — repo dir exists with valid .git; must NOT fail with
+    // "already exists" but take the update path (fetch+reset via FakeGitBackend).
+    let r2 = sync.sync(true).unwrap();
+    assert!(r2.fetched, "forced second sync must report fetched=true");
+}
+
+/// Why: if the repo dir exists but is not a git repo (e.g. leftover temp files),
+/// sync must recover by removing it and re-cloning rather than failing.
+/// What: creates a non-git directory at the repo path, then forces a sync.
+/// Test: this is the test.
+#[test]
+fn catalog_sync_corrupt_dir_reclones() {
+    let root = tempfile::TempDir::new().unwrap();
+    let sync = make_sync(root.path());
+
+    let repo_path = root.path().join("repo");
+    std::fs::create_dir_all(&repo_path).unwrap();
+    std::fs::write(repo_path.join("junk.txt"), "not a git repo").unwrap();
+
+    let result = sync.sync(true).unwrap();
+    assert!(result.fetched, "sync after corrupt dir must report fetched");
+    assert!(
+        repo_path.join(".git").is_dir(),
+        ".git must exist after recovery"
+    );
+}
+
+/// Why: if the existing checkout points at a different remote the catalog would
+/// be stale; sync must detect the mismatch and re-clone from the correct remote.
+/// What: first sync uses URL A, a second CatalogSync with URL B force-syncs into
+/// the same catalog dir and re-clones.
+/// Test: this is the test.
+#[test]
+fn catalog_sync_wrong_remote_reclones() {
+    let root = tempfile::TempDir::new().unwrap();
+
+    let sync_a = CatalogSync::with_repo(
+        FakeGitBackend::new(),
+        root.path().to_owned(),
+        "https://github.com/owner/repo-a",
+        "main",
+    );
+    sync_a.sync(true).unwrap();
+    let repo_path = root.path().join("repo");
+    assert!(
+        repo_path.join(".git").is_dir(),
+        "repo-a clone must create .git"
+    );
+
+    let sync_b = CatalogSync::with_repo(
+        FakeGitBackend::new(),
+        root.path().to_owned(),
+        "https://github.com/owner/repo-b",
+        "main",
+    );
+    let result = sync_b.sync(true).unwrap();
+    assert!(result.fetched, "sync with wrong remote must fetch");
+    let config = std::fs::read_to_string(repo_path.join(".git").join("config")).unwrap();
+    assert!(
+        config.contains("repo-b"),
+        "config must be updated to repo-b URL"
+    );
+}


### PR DESCRIPTION
Closes #1751.

## Bug
`tm catalog sync` did an unconditional `git clone` into `~/.trusty-mpm/catalog/repo`, so the second (and every later) sync failed:
`fatal: destination path '…/catalog/repo' already exists and is not an empty directory` (exit 128).

## Fix
`CatalogSync::ensure_repo` now branches on the destination state:
- absent → `git clone`
- valid git repo with matching `origin` → `git fetch origin` + `git reset --hard origin/<branch>` (update in place)
- corrupt / non-git / wrong-remote → `guard_remove` (refuses any path outside the catalog dir) then re-clone

New `GitBackend` methods (`is_git_repo`, `remote_url`, `fetch_and_reset`) keep the git ops behind a testable seam; `urls_match`/`normalize_repo_url` handle `.git`/trailing-slash/case differences.

## Verification
- Integration tests (`tests/catalog_sync_idempotent.rs`) for all branches: fresh clone, **second-sync-succeeds** (the exact #1751 scenario), corrupt-dir recovery, wrong-remote re-clone — using a local FakeGitBackend.
- Gates green: `cargo test -p trusty-mpm`, clippy, fmt, line-cap (catalog_sync.rs 460 SLOC).

---
🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)