### PR TITLE
docs(specs): trusty-installer rename + ADR-0013

### DIFF
--- a/docs/adr/0006-trusty-controller-naming.md
+++ b/docs/adr/0006-trusty-controller-naming.md
@@ -5,7 +5,7 @@
 - **Scope:** Workspace-wide (new crate `trusty-controller`; adds `tctl` to the
   CLAUDE.md abbreviation table; consumed by the entire trusty-controller design
   set under `docs/trusty-controller/research/02-design/`)
-- **Supersedes / Superseded by:** —
+- **Supersedes / Superseded by:** Superseded by ADR-0013 (rename to `trusty-installer`)
 
 ## Context
 

--- a/docs/adr/0013-rename-trusty-controller-to-trusty-installer.md
+++ b/docs/adr/0013-rename-trusty-controller-to-trusty-installer.md
@@ -1,0 +1,75 @@
+# 0013. Rename `trusty-controller` to `trusty-installer` and build out interactive installer/upgrader
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Scope:** Workspace-wide (crate rename, binary rename, build-out of prebuilt-download layer, interactive component picker, self-update capability)
+- **Supersedes:** ADR-0006 (`trusty-controller` naming decision)
+
+## Context
+
+ADR-0006 (accepted 2026-06-08) established the name `trusty-controller` for the stack control plane and `tctl` for the binary, explicitly **rejecting** the name `trusty-installer` as "too install-specific" given the tool's full scope (install, upgrade, restart, config, doctor, health).
+
+However, **user preference has evolved:** the `install.sh` bootstrap already fronts the project as `trusty-installer`, and users have decided the install-focused name is the **right user-facing choice** regardless of the tool's internal scope. The name is the primary entry point for getting the stack onto a machine; discovery and first-impression clarity outweigh architectural purity.
+
+**Additionally**, the tool is now being expanded with interactive component selection, prebuilt-binary downloads (Tier-1 platforms), and self-update capability. These features make it more than a headless control plane—it is becoming a **guided, interactive installer**. The expanded scope aligns the tool's purpose more closely with the `trusty-installer` name.
+
+## Decision
+
+We **accept ADR-0006's reasoning** (the tool is a control plane, not merely an installer) **but override the name choice** in favor of user discoverability and entry-point clarity:
+
+- **Crate name:** `trusty-controller` → `trusty-installer`
+- **Directory:** `crates/trusty-controller/` → `crates/trusty-installer/`
+- **Primary binary:** `tctl` → `trusty-installer`
+- **Binary alias (transition):** Retain `tctl` as an alias binary for one release cycle, with a deprecation warning
+- **Abbreviation:** `trusty-installer` (primary); `tctl` (alias, deprecated)
+
+**Build-out scope (all gated by this rename):**
+- Prebuilt-binary download layer for Tier-1 platforms (macOS aarch64, Linux x86_64) using GitHub Releases
+- Interactive component-picker UI (trusty-memory, trusty-search, trusty-mpm, optional claude-mpm bridge)
+- Self-update capability (`trusty-installer self-update`)
+- Config-dir migration: old `~/.trusty-tools/trusty-controller/` → new `~/.trusty-tools/trusty-installer/`
+- macOS Developer-ID code-signing + FDA re-grant guidance for launchd daemons
+
+The **control plane semantics remain unchanged**: the tool still manages upgrade, restart, config, doctor, and health for the entire stack (claude-mpm + trusty-tools). The name change reflects user-facing positioning, not architectural change.
+
+## Consequences
+
+**Easier / positive:**
+
+- **User discoverability:** The name matches the entry point (`install.sh` → `trusty-installer`) and the primary use case (getting the stack installed on a machine).
+- **Expanded scope aligns:** The new interactive installer features make the tool more than a control plane; the name fits the enriched functionality.
+- **Clean transition:** The `tctl` alias provides one release cycle for users to migrate shell aliases and scripts; no breaking change.
+
+**Harder / trade-offs:**
+
+- **Contradicts ADR-0006:** We explicitly override a prior architectural decision. Future readers must understand the user-preference override rationale (recorded here).
+- **Rename blast-radius:** ~40 test references, ~20 config/manifest references, docs dir, CI workflow, crates.io publish strategy. See SPEC-INSTALLER-01 for full table.
+- **Publishing implications:** Old `trusty-controller` v0.2.0 stays published but deprecated. New `trusty-installer` is a fresh crate namespace. Existing downstream users on `trusty-controller` can migrate or stay on old version.
+
+**Mitigations:**
+
+- **Phase 1 PR:** Mechanical rename (all blast-radius changes) shipped as a single, reviewable changeset.
+- **Build-out phases:** Phases 2–8 (prebuilt, self-update, component picker, etc.) are additive and can ship independently after rename.
+- **Config migration:** Idempotent on-startup migration from old config dir to new one, with logging.
+- **Deprecation cycle:** `tctl` alias persists for one release; CHANGELOG documents removal.
+
+## Rationale: Why User Preference Overrides Architectural Purity
+
+1. **Entry-point clarity:** Users' first interaction is `install.sh` and `trusty-installer` binary; consistency matters for discoverability.
+2. **Primary use case:** The tool's strongest value proposition is **installing the stack on a new machine**; naming it after the install-specific functionality mirrors user mental models.
+3. **Interactive build-out:** The new features (component picker, prebuilt downloads, self-update) reinforce the **guided installer** positioning.
+4. **Low cost of change:** The rename is expensive but tractable (single-pass mechanical PR); it is cheaper now than after the tool gains more adoption.
+5. **Precedent:** The workspace already separates crate names (descriptive) from binary names (short) without issue (`tga`, `tm`, `ts`); the new alias `tctl` fits this pattern.
+
+## Open Items
+
+- Should the old `trusty-controller` crate on crates.io be yanked, or remain published with a deprecation notice? (Defer to release process; recommend: deprecate, not yank.)
+- Exactly how long should the `tctl` alias persist? (Suggested: one release cycle; can extend if users report issues.)
+- Should the interactive installer be the default `trusty-installer install` behavior, or a separate `--interactive` flag? (See SPEC-INSTALLER-01 for design decision.)
+
+## References
+
+- **ADR-0006:** `trusty-controller` naming decision (rejected `trusty-installer`)
+- **SPEC-INSTALLER-01:** Full specification for the rename + interactive installer/upgrader build-out
+- **Issue #873 (macOS FDA):** Developer-ID code-signing and Full Disk Access re-grant guidance for launchd daemons
+- **Release workflow:** `docs/reference/release-workflow.md` (impact on publish strategy)

--- a/docs/specs/SPEC-INSTALLER-01.md
+++ b/docs/specs/SPEC-INSTALLER-01.md
@@ -1,0 +1,155 @@
+# SPEC-INSTALLER-01: trusty-installer Rename & Interactive Installer/Upgrader
+
+**Specification ID:** SPEC-INSTALLER-01  
+**Status:** Draft  
+**Date:** 2026-06-26  
+**Author:** Claude Code (Haiku 4.5)  
+**Supersedes:** —  
+**Lifecycle Stage:** Design (public review pending)
+
+---
+
+## 1. Summary
+
+Rename `trusty-controller` (binary `tctl`, crate v0.2.0, `crates/trusty-controller/`) to `trusty-installer` and build out an **interactive installer/upgrader** with component selection, prebuilt-binary downloads, and self-update capability. The rename reflects the tool's primary user entry point (the `install.sh` bootstrap) and its role as the discoverable installation point for the entire trusty-* stack. The build-out extends the headless control plane (install, upgrade, restart, health, config, doctor) into an interactive guided experience for first-time users.
+
+---
+
+## 2. Motivation
+
+**Why rename?**
+
+- **User discovery:** The bootstrap `install.sh` already names the crate `trusty-installer`; the binary name should match for consistency and discoverability.
+- **Entry-point clarity:** The tool is the user's primary interaction for **getting the stack onto a machine**; it is the installer/entry point, even though it also manages upgrades and daemon lifecycle.
+- **ADR-0006 revisited:** ADR-0006 rejected "trusty-installer" as too install-specific, but the user has decided the install-focused name is the right **user-facing** choice regardless. The tool's full scope (upgrade, doctor, health) remains; we acknowledge ADR-0006's reasoning in ADR-0013 and explain the name change.
+
+**Why build it out now?**
+
+- **Tier-1 prebuilt downloads:** Today `tctl install/upgrade` uses **only `cargo install`** (slow, requires Rust toolchain). Net-new work: add prebuilt-binary download layer (GitHub Releases asset discovery, platform/arch detection, SHA-256 verification, tarball extraction) on Tier-1 platforms.
+- **Interactive component picker:** New users need a guided choice of what to install (trusty-memory, trusty-search, trusty-mpm, optional claude-mpm integration). This is the **unified installer UX**.
+- **Self-update capability:** Like `rustup self update`, the installer can download and swap its own binary.
+- **Config-dir migration:** Existing users' persistent state (`~/.trusty-tools/trusty-controller/{config.yaml,ensure.lock}`) must migrate to the new dir (`…/trusty-installer/`).
+
+---
+
+## 3. Goals & Non-Goals
+
+### Goals
+
+- Rename `trusty-controller` → `trusty-installer` crate and `tctl` → `trusty-installer` binary (retain `tctl` alias for transition).
+- Implement prebuilt-binary download layer for Tier-1 platforms (macOS aarch64, Linux x86_64).
+- Fall back to `cargo install` for unsupported platforms with clear messaging + Rust-toolchain check.
+- Add interactive component-picker UI (memory, search, trusty-mpm, claude-mpm bridge).
+- Implement config-dir migration (old `trusty-controller/` → new `trusty-installer/` with fallback copy).
+- Self-update capability: `trusty-installer` can update its own binary.
+- Extend upgrade flow to prebuilt path (GitHub Release tag comparison, download+verify+swap).
+- Validate external prerequisites (claude, git, tmux on PATH) at startup.
+- Handle macOS Developer-ID code-signing handoff for `trusty-search` (reuse `scripts/install-trusty-search-signed.sh` pattern).
+- Handle macOS FDA (Full Disk Access) grant guidance for launchd daemons (issue #873).
+- Update all blast-radius references (Cargo.toml, CLI, tests, docs, CI).
+
+### Non-Goals
+
+- Yank the old `trusty-controller` crate from crates.io (optional deprecation only; out of scope).
+- Widen the `tctl` alias transition period beyond one release cycle.
+- Add other install methods (Homebrew direct, Docker, etc.) — stay scoped to GitHub Releases + cargo fallback.
+- Refactor the 5-stage `up` boot orchestrator (remains as-is).
+- Change the 3-tier supervisor/daemon architecture (remains as-is).
+
+---
+
+## 4. Architecture
+
+### 4.1 Two-Stage Bootstrap
+
+**Stage 1:** Root `install.sh` (shell script)
+- Platform/arch detection (`uname -m`, `uname -s`)
+- Downloads prebuilt `trusty-installer-<version>-<target>.tar.gz` from GitHub Releases
+- Downloads + verifies SHA-256 (`trusty-installer-<version>-<target>.tar.gz.sha256`)
+- Extracts to `~/.local/bin/trusty-installer` (or user PATH override)
+- Invokes `trusty-installer install` (Stage 2)
+- Updates `CRATE="trusty-installer"` and `BIN="trusty-installer"` constants (from current `CRATE="trusty-controller"`, `BIN="tctl"`)
+
+**Stage 2:** `trusty-installer` binary (interactive installer)
+- Renders component-picker UI (existing tctl table rendering + selection)
+- Validates external prerequisites (claude, git, tmux)
+- Performs platform-specific setup per chosen component
+- Wires launchd plists, MCP socket, supervisor, etc.
+- Prompts for macOS code-signing + FDA re-grant if applicable
+- Saves config to new `~/.trusty-tools/trusty-installer/` directory
+
+---
+
+## 5. Component Matrix
+
+| Component | Binaries Bundled | Setup Command | Launchd Plist | macOS Concerns |
+|---|---|---|---|---|
+| **memory** | `trusty-memory`, `trusty-bm25-daemon` | `trusty-memory setup` | Auto-generated from template, bootstrapped | FDA not typically needed (reads model files, writes to `~/.trusty-tools/`) |
+| **search** | `trusty-search`, `trusty-embedderd` | `trusty-search service install` | Auto-generated, bootstrapped | **Developer-ID signing required** (issue #873 context); installer calls `scripts/install-trusty-search-signed.sh`; prompts for FDA re-grant after install |
+| **trusty-mpm** | `tm`, `trusty-mpm` (supervisor not binary) | `tm install` + plist bootstrap | `crates/trusty-mpm/deploy/supervisor/com.trusty.mpm.supervisor.plist` (fill placeholders + `launchctl bootstrap`) | `tm install` does NOT bootstrap supervisor plist; installer must do it |
+| **claude-mpm bridge** | None | MCP/hook wiring only | N/A (claude-mpm manages its own launchd if any) | Detect existing install, wire trusty-* servers into claude-mpm's `.mcp.json` or config if applicable |
+
+---
+
+## 6. Build-Out Work Items
+
+The work breaks into 8 independent phases (can ship in any order after Phase 1):
+
+**Phase 1:** Mechanical rename (crate dir, Cargo.toml, imports, CLI, docs).  
+**Phase 2:** Prebuilt-download layer (GitHub asset discovery, SHA-256 verify, platform detection, cargo fallback).  
+**Phase 3:** Self-update command (atomic binary swap, extend upgrade flow).  
+**Phase 4:** Interactive component picker + claude-mpm integration.  
+**Phase 5:** Config-dir migration + startup (idempotent old→new state move).  
+**Phase 6:** External prerequisite validation (claude, git, tmux checks).  
+**Phase 7:** Supervisor plist bootstrap (template fill, launchctl invocation).  
+**Phase 8:** macOS code-signing + FDA guidance (cert detection, script invocation).  
+
+---
+
+## 7. Rename Blast-Radius
+
+**Key changes:**
+
+- Crate dir: `crates/trusty-controller/` → `crates/trusty-installer/`
+- Package name in Cargo.toml: `trusty-controller` → `trusty-installer`
+- Lib name: `trusty_controller` → `trusty_installer`
+- Add `[[bin]] trusty-installer` + keep `[[bin]] tctl` as alias (one release cycle)
+- All `use trusty_controller::` → `use trusty_installer::`
+- CLI primary name: `trusty-installer` (tctl becomes alias)
+- `install.sh` constants: `CRATE="trusty-installer"`, `BIN="trusty-installer"`
+- Manifest/config paths: `.join("trusty-controller")` → `.join("trusty-installer")`
+- Upgrade self-guard: `"trusty-controller"`/`"tctl"` → `"trusty-installer"`
+- CI workflow: asset naming, CARGO_PKG, Homebrew gate
+- Docs dir: `docs/trusty-controller/` → `docs/trusty-installer/` (via `git mv`)
+- CLAUDE.md: add `trusty-installer → -p trusty-installer`, keep `tctl → trusty-installer` alias
+- ~40 test references to binary name + crate name
+
+**Process:**
+1. Phase 1 PR: all mechanical changes
+2. Phase 2–8 PRs: additive features (don't depend on rename)
+3. Single CI/docs/publish pass
+
+---
+
+## 8. Transition & Deprecation
+
+**Binary alias:** One release cycle (e.g., v0.1.0 → v0.2.0). After that, remove `tctl` bin and document in CHANGELOG.  
+**Config migration:** Idempotent on every startup (check old dir exists, new doesn't, then move). Log to user.  
+**crates.io:** Publish NEW `trusty-installer` crate. Old `trusty-controller` stays published but marked deprecated.  
+
+---
+
+## 9. Success Criteria
+
+- Rename: All references updated, tests pass, docs in new location.
+- Prebuilt: <5 sec download on Tier-1; graceful fallback with toolchain check.
+- Component picker: Guided UX, transitive-dep resolution, claude-mpm optional.
+- Self-update: Atomic binary swap, clean exit.
+- Config migration: Automatic on first run, idempotent, logged.
+- macOS: Developer-ID + FDA guidance integrated; users can use search daemon post-install.
+- Docs: ADR-0013 explains reasoning; spec clear; CLAUDE.md abbrev updated.
+
+---
+
+**Document History:**
+- 2026-06-26: Draft created, all LOCKED decisions embedded.

--- a/docs/specs/SPEC-INSTALLER-01.md
+++ b/docs/specs/SPEC-INSTALLER-01.md
@@ -137,6 +137,18 @@ The work breaks into 8 independent phases (can ship in any order after Phase 1):
 **Config migration:** Idempotent on every startup (check old dir exists, new doesn't, then move). Log to user.  
 **crates.io:** Publish NEW `trusty-installer` crate. Old `trusty-controller` stays published but marked deprecated.  
 
+### Hook Robustness Invariant
+
+Any Claude Code hooks wired during install (e.g., Claude hooks bundled as part of the `tm install` workflow or trusty-search daemon setup) MUST satisfy these five constraints to prevent global hooks from failing unrelated builds:
+
+1. **Absolute-path resolution:** Hook executables MUST be resolved via `current_exe()` or absolute path discovery, never via bare PATH lookups. This prevents stale symbolic links or name collisions when PATH is long or contains shadowed binaries.
+2. **Project-scoped, not globally merged:** Hooks MUST be wired into project-specific `~/.trusty-tools/<project>/.claude/settings*.json` or isolated per-daemon config, not merged into every `~/.claude/settings*.json` or `~/.claude/settings.local.json`. This limits blast radius to intentional integrations only.
+3. **Fail-open on error/timeout:** Hooks MUST always exit with code 0 (success) even when encountering errors, network timeouts, or missing dependencies. Failing hooks block tool invocations and can break unrelated build workflows (e.g., a foreign `make deploy` calling `cargo build`). Return the original input unchanged rather than failing the tool call.
+4. **Bounded execution:** Hooks MUST have connect and request timeouts (recommend ≤5s total, with <1s for local checks). This prevents hangs from blocking tool calls during build orchestration.
+5. **Opt-out capability:** The installer MUST respect `TRUSTY_MPM_DISABLE_HOOKS=1` environment variable to disable hook injection entirely. This allows users to run unrelated builds (e.g., SAM, CDK, bazel) without interference.
+
+This invariant is structural and MUST be preserved as new hooks are added (e.g., optimizer compression hooks, pre-call validators). PR #1756 (hook-hardening) and the claude-mpm ztk-shell-hook failure (where a global compression hook broke a SAM build on a long PATH) established why this matters: fail-open + project-scoped + timeout-bounded hooks can never cause collateral damage to unrelated workflows.  
+
 ---
 
 ## 9. Success Criteria


### PR DESCRIPTION
## Summary

This PR introduces the design specification and architectural decision record for renaming `trusty-controller` to `trusty-installer` and building out an interactive installer/upgrader.

**Key deliverables:**
- **SPEC-INSTALLER-01.md** (Draft): Comprehensive specification covering:
  - Rename from `trusty-controller` → `trusty-installer` (crate, binary, directory)
  - Two-stage bootstrap (install.sh → interactive binary)
  - Prebuilt-binary downloads (Tier-1 platforms: macOS aarch64, Linux x86_64)
  - Interactive component picker (memory, search, trusty-mpm, claude-mpm bridge)
  - Self-update capability
  - Config-dir migration (old → new state)
  - macOS Developer-ID signing + FDA re-grant guidance
  - 8 build-out work phases (can ship independently after rename)

- **ADR-0013.md**: Nygard-format ADR accepting ADR-0006's architectural reasoning but overriding the name choice for user-facing discoverability and entry-point clarity

- **ADR-0006 update**: Added one-line supersede note

## Design Decisions (LOCKED)

1. **Binary alias transition:** `tctl` retained as an alias for one release cycle (deprecation warning on second invocation)
2. **Prebuilt-first strategy:** GitHub Releases downloads for Tier-1 platforms; cargo fallback with Rust-toolchain check for others
3. **Component auto-resolution:** Select trusty-mpm → auto-include memory; claude-mpm optional if detected on PATH
4. **Config migration:** Idempotent on-startup migration from old `~/.trusty-tools/trusty-controller/` to new `…/trusty-installer/`
5. **Supervisor plist:** Installer fills + bootstraps `com.trusty.mpm.supervisor.plist` (tm install handles hook/agent wiring only)

## Blast Radius

~40 test references, ~20 config/manifest paths, docs tree (20 files), CI workflow, crates.io publish strategy. Full table in spec section 7.

## Sequencing

- **Phase 1 PR** (mechanical rename): Single reviewable changeset covering all blast-radius updates
- **Phases 2–8 PRs** (additive features): Prebuilt downloads, self-update, component picker, config migration, prerequisite checks, supervisor bootstrap, macOS code-signing—all independent, can ship in any order post-rename

## Next Steps

Phase 1 (rename mechanical work) opens as a follow-up ticket with clear checklist. Phases 2–8 become separate issues tagged for parallel or sequential execution based on dependency graph.

---

See SPEC-INSTALLER-01 and ADR-0013 for full design, rationale, open questions, and success criteria.

🤖 Generated with Claude Code