### PR TITLE
feat(trusty-mpm): two-panel full-width banner (robot left, info right, natural height)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/image.txt
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/image.txt
@@ -1,0 +1,46 @@
+                     ≈ !iiii;:i<<<<!I:,-   ∏                                    
+                     ∂ i;:;:>IiiIiiiIIIili;,>♦                                  
+                   i.I.:;:;.>IIIIIIIIIIIIIIIIi,;♫                               
+                ÷ :iI=,;I::.+IIIIIIIIIIIIIIIIIII; ≠°                            
+           ×  • ;iiiI+,I,;:,>IIIIIIIIIIIIIIIIIIIIIi °                           
+             ∑:IiiiiiI+I,i;;lIiIIIIIIIIIIIIIIIIIIIiI, ♦                         
+           ♫Ii;IIIIiiI+,< iIIIiIIIIIIII!<>><lIIIIIIIII °                        
+          ◦:;iIIiIIIiIIl;,;i >iIIIIl-<   ...  +=IIIIIII.∇                       
+         ♦,iiIIiIIIIIII+.i:l,=IIII=.     ..  .. l!lIIIII,√                      
+         ≥:iIIIIIIiIiIII-:,;:×lII÷    .<•◦⋆◦⋆-  ,.=IIIIIi.                      
+        ⋆.IiIIIIIllIIIIIl>l.iilI!i.  ∇∏±÷÷÷≈±÷∇∏  ;!IIIIIi ◦                    
+        i:III!×-:,,:-×!II!:>l +l>,  √∫±≈≥≤≠≤≤≠÷≈♦. ≤iIIIIiIi∇                   
+       •.iI<i      .   ×ll>::<iI<:  ∏≈≤∑°♦♦♦°∑≤±√i <IIIIIII;⋆                   
+       ∇.i-. .   .°°I   >l>I:l.-I- .∇∑≥∑♦♦♦♦♦∇≥≈√l ±IIIIIIIi;≈:,×⋆              
+       ∇;I<    •∇±÷÷±√•  -l-:.i=I<I  ≥∇≥√•◦◦∏∑≥∫•.:!IIIIIIII:×Ii;;lIi×          
+       ∇;!i.. ◦≈××≤≤≤∑≥•..-I!!.I<II÷ . •⋆∇∑√∇⋆◦,.=!IIIIIIIIII<i>!:!lI,◦         
+       ∏;II..∫≥×≠≤°•◦•∑°. ×Ill.,=IIII÷:... ...i=<lIIIIIIIIIII+:=<-;lI;<         
+       •.i<  ∇±×≠√♦♦♦♦⋆°,,-II×  !IIIIIIIllIlliIIIIIIIIIIIIIIIl+:-<l:;∑⋆         
+        :I± .-∫×≠≤⋆◦♦•∂◦.=lIII≈  =IIIIIIIIIIIIIIIIIIIIIIIIIIIl=.>!I×°           
+        ≈,!×  ∏∫±≈≥∑∑∏≥ >!IIIII+ =IIIIIIIIIIIIIIIIIIIIIIIIIIIII÷.×l,            
+        ◦,il÷.  ∇◦⋆◦l  ≈IIIIIII-,,!IIIIIIIIIIIIIIIIIIIIIIIIIIIIllI>I,⋆          
+         ±iIl!≠I,:,÷≈!IIIIIIIIIl≈.≈IIIIIIIIIIIIIIIIIIIIIIIIIIIIl× ÷I,≥          
+         °iIIIIIIIIIIIIIIIIIIIIII>;lIIIIIIIIIIIIIIIIIIIIIIIIIIIIl÷,+l •         
+        ∏,I!IIIIIIIIIIIIIIIIIIIII!:<IIIIIIIIIIIIIIIIIIIIIIIlIIIl!±i×+;±         
+        ∂,!,!IIiIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIlll<>+!:,,:!+-×÷=->,•        
+      •,l.+i<IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIl!!ll>;<<!llIIIIIIIlIIIl:>        
+      ◦ II<>.!IIIIIIIIIIIIIIIIIIIIIIIIlI!!+!,;!+>lll<:lIIIIIIIIIIIIIIIl ♫       
+       ◦,l:l!IIIIIIIIIIIIIIIIIIIIIl<!I:i<>!lIIIIIIIIlI!IIIIIIIIIIIIIIIII√       
+          ≈.l,>IIIIIIIIIIIIIIl<<I;l<<lIIIIIIIIIIIIIII>!lIIIIIIIIIIIIIIIi        
+          °.i<;lIIIIIIII!>I;i<!llIIIIIIIIIIIIIIIIIIIIl;<lIIIIIIIIIIIIIlI;⋆      
+           °,!;lIIlI<!Ii!!lIIIIIIIIIIIIIIIIIIIIIIIIIII<,<IIIIIIIIIIIIIIi.       
+           ◦ I>l<lI!<i>lIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIl!!IIIIIIIIIIIII!.⋆       
+            √;i;!lIIl>:llIIIIIIIIIIIIIIIIIIIIIIIIIIIIII<.!IIIIIIIIIli:I•        
+            ⋆:IIIIIIIIllIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIl>llIIIIll!÷:≠°          
+            ◦.IIIIIIII!ilIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII<.>lI!--..!:+⋆          
+             i;IIIIIIII;>IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIl!=I×.  . ..             
+             •.iIIIIIII!,<IIIIIIIIIIIIIIIIIIIIIIIIl!=≈<.   ....      ÷ °°° ≤<i .
+              ≠:IIIIIIIlllIIIIIIIIIIIIIIIIIIII-÷×,...,i<>+-==×-I.    .. ..,,....
+              ♫ IIIIIIII+:!IIIIIIIIIIIIl+×<,,;Ii;;;;;;;il<!:,.,.,,,,.,..........
+               ≈:IIIIIIIl<>IIIIIIl<±÷!,,ili;:;;;;l<I,...,:..,.,...,........,,. .
+               •.;IIIIIIl<i-+÷=I.   !l:;;;;l!: ....,,,,.,..,...,..,,,,. .;÷≈>III
+                •<..,..,l+;      l!iii!i.......,,.............,,. .l≥≈<llIIIIIII
+                          > ,.:+<<:..,,,.,.,,,,....,,,,,,. .,±≤+lIIIIIIIIIIIIIII
+                         ⋆ <.,.,,::,,,.....,::,,.   .i+∑±>llIIIIIIIIIIIIIIIIIIII
+                    ⋆ ∫<..,,,.;≈≠≥≥≥≥≤≠×>>!!lIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+              •♫∇<...,,,,,.,±+IlIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -79,17 +79,17 @@ const VERSION_R: u8 = 140;
 const VERSION_G: u8 = 60;
 const VERSION_B: u8 = 20;
 
-/// Build the two-line plain-text wordmark: `trusty` (bold amber) + version (dimmed rust).
+/// Build the two-line plain-text wordmark: `trusty-mpm` (bold amber) + version (dimmed rust).
 ///
 /// Why: replaces the bulky 7-row block-art `BANNER_TITLE` with a single-line
 /// label that is lighter, faster to scan, and stays under the SLOC cap.
-/// What: returns a `[String; 2]` — `lines[0]` is the colourised `"trusty"` label,
+/// What: returns a `[String; 2]` — `lines[0]` is the colourised `"trusty-mpm"` label,
 /// `lines[1]` is the colourised `"v{CARGO_PKG_VERSION}"` version string. Both
 /// degrade gracefully to plain text when `colored` colour is disabled.
 /// Test: `wordmark_lines_contain_trusty_and_version`.
 pub(crate) fn wordmark_lines() -> [String; 2] {
     use colored::Colorize as _;
-    let label = "trusty"
+    let label = "trusty-mpm"
         .truecolor(WORDMARK_R, WORDMARK_G, WORDMARK_B)
         .bold()
         .to_string();

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -6,9 +6,13 @@
 //! What: `render_launch_banner`, `print_launch_banner`,
 //! `print_launch_banner_reconnecting`, `terminal_width`, `detect_memory`,
 //! `detect_tool`, `dirs_config_dir`, `binary_on_path`, `fallback_session_name`,
-//! `normalize_workdir`, `tmux_has_session`.
+//! `normalize_workdir`, `tmux_has_session`. The two-panel compositor lives in
+//! the `two_panel` submodule.
 //! Test: `launch_banner_*`, `terminal_width_is_positive`,
-//! `normalize_workdir_strips_trailing_slash` in `tests.rs`.
+//! `normalize_workdir_strips_trailing_slash` in `tests.rs`;
+//! `two_panel_*` in `two_panel::tests`.
+
+pub(crate) mod two_panel;
 
 use colored::Colorize as _;
 
@@ -78,14 +82,7 @@ pub(crate) const BANNER_TITLE: &[&str] = &[
 /// What: 27-element array of `(r, g, b)` tuples, one per robot row (indexed
 /// by row position 0–26); interpolated across three anchor colors.
 /// Test: `robot_gradient_has_correct_length`.
-const ROBOT_GRADIENT: [(u8, u8, u8); 27] = {
-    // Anchor colors:
-    //   top    → dark rust    (183, 65, 14)
-    //   middle → burnt orange (205,100, 30)
-    //   lower  → amber        (224,140, 60)
-    // Linear interpolation across 27 rows in two segments:
-    //   rows 0–13: dark rust → burnt orange
-    //   rows 14–26: burnt orange → amber
+pub(crate) const ROBOT_GRADIENT: [(u8, u8, u8); 27] = {
     [
         (183, 65, 14),
         (185, 68, 15),
@@ -235,33 +232,6 @@ pub(crate) fn render_launch_banner(
     out
 }
 
-/// Print the banner to stdout for preview — no screen-clear, no sleep.
-///
-/// Why: `tm banner` lets the operator eyeball the colored robot + welcome panel
-/// without launching Claude or waiting a full second. Skipping the
-/// `\x1B[2J\x1B[1;1H` clear preserves the operator's scrollback, and the
-/// absence of the 1-second sleep makes iteration fast.
-/// What: renders the robot art + TRUSTY wordmark (without the screen-clear
-/// escape) followed by the rich info-box welcome panel (without the sleep).
-/// When the daemon is down the panel degrades gracefully (offline row, no HTTP
-/// probes needed). When `reconnecting` is `true`, the panel shows the
-/// reconnecting status row instead of Memory/Search/Prompt.
-/// Test: `banner_preview_does_not_panic` in `tests.rs`.
-pub(crate) fn print_banner_preview(reconnecting: bool) {
-    // Robot art without the full-screen clear so scrollback is preserved.
-    print!("{}", render_robot_splash_no_clear(reconnecting));
-    let _ = std::io::Write::flush(&mut std::io::stdout());
-
-    // Gather env-available data (best-effort; graceful when daemon is down).
-    let workdir = std::env::current_dir()
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| ".".to_string());
-    let session_name = fallback_session_name(std::path::Path::new(&workdir));
-    let daemon = super::info_box::DaemonInfo::from_lock_file();
-    // Print the panel without the 1-second pause.
-    super::info_box::print_welcome_panel_no_sleep(&workdir, &session_name, reconnecting, daemon);
-}
-
 /// Render the robot art + TRUSTY wordmark without the full-screen clear escape.
 ///
 /// Why: `tm banner` preview must not wipe the operator's scrollback. This
@@ -272,7 +242,6 @@ pub(crate) fn print_banner_preview(reconnecting: bool) {
 /// Test: `banner_preview_does_not_panic`.
 pub(crate) fn render_robot_splash_no_clear(reconnecting: bool) -> String {
     let mut out = String::new();
-    // Intentionally no screen-clear here — this is the preview / no-clear variant.
     out.push('\n');
     for (idx, line) in BANNER_ROBOT.iter().enumerate() {
         out.push_str(BANNER_INDENT);
@@ -298,26 +267,32 @@ pub(crate) fn render_robot_splash_no_clear(reconnecting: bool) -> String {
 ///
 /// Why: `tm launch` should give the operator a readable splash screen before
 /// the terminal is taken over by `claude`/`tmux`. The robot clears the screen
-/// for visual impact; the info panel below provides rich operational context
-/// (daemon, session count, services, commits, commands).
-/// What: clears the screen, prints the rust-gradient ASCII robot, the "TRUSTY"
-/// wordmark, and then delegates to `info_box::print_welcome_panel` (which adds
-/// its `╭─╮` box with daemon/service/commit/command info). Pauses 1 s total
-/// (the info-box's own sleep covers it). `prompt_path` is accepted for API
-/// symmetry with the old signature; the path is shown by the info panel.
+/// for visual impact; the info panel below provides rich operational context.
+/// What: clears the screen, then renders the two-panel layout on wide terminals
+/// (≥`two_panel::MIN_WIDTH_TWO_PANEL` cols) or the stacked layout on narrow
+/// terminals. Pauses 1 s total (the info-box's own sleep covers it).
 /// Test: `launch_banner_does_not_panic`.
 pub(crate) fn print_launch_banner(
     workdir: &str,
     tmux_name: &str,
     _prompt_path: Option<&std::path::Path>,
 ) {
-    let _ = terminal_width();
-    // Print screen-clear + robot + title (no 1-s sleep here; info-box sleeps).
-    print!("{}", render_robot_splash(false));
-    let _ = std::io::Write::flush(&mut std::io::stdout());
-    // Render the rich info panel directly below (it owns the 1-s sleep).
+    let w = terminal_width();
     let daemon = super::info_box::DaemonInfo::from_lock_file();
-    super::info_box::print_welcome_panel(workdir, tmux_name, false, daemon);
+    let data = super::info_box::gather_welcome_data(workdir, tmux_name, false, daemon);
+
+    if let Some(panel) = two_panel::render_two_panel_banner(&data, w, false) {
+        println!("\x1B[2J\x1B[1;1H");
+        print!("{panel}");
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    } else {
+        // Narrow fallback: stacked layout.
+        print!("{}", render_robot_splash(false));
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+        let daemon2 = super::info_box::DaemonInfo::from_lock_file();
+        super::info_box::print_welcome_panel(workdir, tmux_name, false, daemon2);
+    }
 }
 
 /// Print the full-screen robot banner without the info panel (for tests/reconnect).
@@ -354,16 +329,62 @@ pub(crate) fn render_robot_splash(reconnecting: bool) -> String {
 ///
 /// Why: when `tm launch` attaches to a pre-existing session the operator should
 /// see that no new session was created.
-/// What: prints the same full-screen robot banner followed by the rich info-box
-/// (reconnect mode) and pauses one second so the banner is legible before
-/// `tmux` takes over.
+/// What: on wide terminals renders the two-panel layout with the reconnecting
+/// state shown in both panels; on narrow terminals falls back to the stacked
+/// layout with the rich info-box (reconnect mode).
 /// Test: `launch_reconnect_banner_does_not_panic`.
 pub(crate) fn print_launch_banner_reconnecting(workdir: &str, tmux_name: &str) {
-    let _ = terminal_width();
-    print!("{}", render_robot_splash(false));
-    let _ = std::io::Write::flush(&mut std::io::stdout());
+    let w = terminal_width();
     let daemon = super::info_box::DaemonInfo::from_lock_file();
-    super::info_box::print_welcome_panel(workdir, tmux_name, true, daemon);
+    let data = super::info_box::gather_welcome_data(workdir, tmux_name, true, daemon);
+
+    if let Some(panel) = two_panel::render_two_panel_banner(&data, w, true) {
+        println!("\x1B[2J\x1B[1;1H");
+        print!("{panel}");
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    } else {
+        print!("{}", render_robot_splash(false));
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+        let daemon2 = super::info_box::DaemonInfo::from_lock_file();
+        super::info_box::print_welcome_panel(workdir, tmux_name, true, daemon2);
+    }
+}
+
+/// Print the banner to stdout for preview — no screen-clear, no sleep.
+///
+/// Why: `tm banner` lets the operator eyeball the colored robot + welcome panel
+/// without launching Claude or waiting a full second. Skipping the
+/// `\x1B[2J\x1B[1;1H` clear preserves the operator's scrollback, and the
+/// absence of the 1-second sleep makes iteration fast.
+/// What: on wide terminals renders the two-panel layout (no screen-clear).
+/// On narrow terminals falls back to robot art + stacked info box.
+/// Test: `banner_preview_does_not_panic` in `tests.rs`.
+pub(crate) fn print_banner_preview(reconnecting: bool) {
+    let w = terminal_width();
+    let workdir = std::env::current_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| ".".to_string());
+    let session_name = fallback_session_name(std::path::Path::new(&workdir));
+    let daemon = super::info_box::DaemonInfo::from_lock_file();
+    let data = super::info_box::gather_welcome_data(&workdir, &session_name, reconnecting, daemon);
+
+    if let Some(panel) = two_panel::render_two_panel_banner(&data, w, reconnecting) {
+        // No screen-clear for preview — preserve scrollback.
+        print!("\n{panel}");
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+    } else {
+        // Narrow fallback: stacked layout (no screen-clear).
+        print!("{}", render_robot_splash_no_clear(reconnecting));
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+        let daemon2 = super::info_box::DaemonInfo::from_lock_file();
+        super::info_box::print_welcome_panel_no_sleep(
+            &workdir,
+            &session_name,
+            reconnecting,
+            daemon2,
+        );
+    }
 }
 
 /// Detect whether the `trusty-memory` MCP integration is available.

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -1,12 +1,12 @@
 //! Launch-banner rendering for `tm launch` and `tm connect`.
 //!
-//! Why: the full-screen ASCII-art banner is ~130 lines of data and ~100 lines
+//! Why: the full-screen ASCII-art banner is ~130 lines of data and ~80 lines
 //! of rendering logic; keeping it separate from the launch handler keeps that
 //! file under the 500-line cap and makes it trivially testable in isolation.
-//! What: `render_launch_banner`, `print_launch_banner`,
-//! `print_launch_banner_reconnecting`, `terminal_width`, `detect_memory`,
-//! `detect_tool`, `dirs_config_dir`, `binary_on_path`, `fallback_session_name`,
-//! `normalize_workdir`, `tmux_has_session`. The two-panel compositor lives in
+//! What: `print_launch_banner`, `print_launch_banner_reconnecting`,
+//! `print_banner_preview`, `terminal_width`, `detect_memory`, `detect_tool`,
+//! `dirs_config_dir`, `binary_on_path`, `fallback_session_name`,
+//! `normalize_workdir`, `tmux_has_session`. The single-box compositor lives in
 //! the `two_panel` submodule.
 //! Test: `launch_banner_*`, `terminal_width_is_positive`,
 //! `normalize_workdir_strips_trailing_slash` in `tests.rs`;
@@ -16,19 +16,12 @@ pub(crate) mod two_panel;
 
 use colored::Colorize as _;
 
-/// Left indent applied to every line of the full-screen launch banner.
-pub(crate) const BANNER_INDENT: &str = "   ";
-
-/// Width of the session-info separator line drawn in the launch banner.
-#[allow(dead_code)]
-pub(crate) const BANNER_SEPARATOR_WIDTH: usize = 53;
-
 /// The ASCII-art robot mascot drawn at the top of the launch banner.
 ///
 /// Why: a recognizable centerpiece gives `tm launch` the same "the tool has
 /// taken over the terminal" feel as claude-mpm's startup screen.
-/// What: a multi-line string-art robot; each line is printed verbatim with the
-/// shared [`BANNER_INDENT`].
+/// What: a multi-line string-art robot; each line is 45 display columns wide.
+/// Test: `robot_shrink_has_fewer_rows` in `two_panel::tests`.
 pub(crate) const BANNER_ROBOT: &[&str] = &[
     "                                             ",
     "                    .}##-                    ",
@@ -59,54 +52,14 @@ pub(crate) const BANNER_ROBOT: &[&str] = &[
     "                                             ",
 ];
 
-/// Amber rust tone used for the plain-text wordmark label.
-///
-/// Why: reuses the warm amber from the bottom of the robot gradient so the
-/// wordmark reads as part of the same brand palette without repeating the full
-/// gradient computation.
-/// What: RGB values `(224, 140, 60)` — the last entry in `ROBOT_GRADIENT`.
-/// Test: visual inspection via `tm banner`.
-const WORDMARK_R: u8 = 224;
-const WORDMARK_G: u8 = 140;
-const WORDMARK_B: u8 = 60;
-
-/// Muted dark-rust tone for the version line beneath the wordmark.
-///
-/// Why: the version number should be present but not compete with the label.
-/// What: RGB values `(140, 60, 20)` — darker than the wordmark amber.
-/// Test: visual inspection via `tm banner`.
-const VERSION_R: u8 = 140;
-const VERSION_G: u8 = 60;
-const VERSION_B: u8 = 20;
-
-/// Build the two-line plain-text wordmark: `trusty-mpm` (bold amber) + version (dimmed rust).
-///
-/// Why: replaces the bulky 7-row block-art `BANNER_TITLE` with a single-line
-/// label that is lighter, faster to scan, and stays under the SLOC cap.
-/// What: returns a `[String; 2]` — `lines[0]` is the colourised `"trusty-mpm"` label,
-/// `lines[1]` is the colourised `"v{CARGO_PKG_VERSION}"` version string. Both
-/// degrade gracefully to plain text when `colored` colour is disabled.
-/// Test: `wordmark_lines_contain_trusty_and_version`.
-pub(crate) fn wordmark_lines() -> [String; 2] {
-    use colored::Colorize as _;
-    let label = "trusty-mpm"
-        .truecolor(WORDMARK_R, WORDMARK_G, WORDMARK_B)
-        .bold()
-        .to_string();
-    let version = format!("v{}", env!("CARGO_PKG_VERSION"))
-        .truecolor(VERSION_R, VERSION_G, VERSION_B)
-        .to_string();
-    [label, version]
-}
-
 /// Rust-color gradient palette applied row-by-row across the robot art.
 ///
 /// Why: a smooth gradient from dark rust (top) through burnt orange (middle)
 /// to amber (lower) turns the monochrome ASCII art into a recognizable brand
 /// color without requiring a terminfo capability beyond 24-bit truecolor.
-/// What: 27-element array of `(r, g, b)` tuples, one per robot row (indexed
-/// by row position 0–26); interpolated across three anchor colors.
-/// Test: `robot_gradient_has_correct_length`.
+/// What: 27-element array of `(r, g, b)` tuples, one per robot row (0–26);
+/// each shrunk row looks up its original index via `colorize_robot_row`.
+/// Test: `robot_gradient_matches_original_row_count` in `two_panel::tests`.
 pub(crate) const ROBOT_GRADIENT: [(u8, u8, u8); 27] = {
     [
         (183, 65, 14),
@@ -147,8 +100,7 @@ pub(crate) const ROBOT_GRADIENT: [(u8, u8, u8); 27] = {
 /// to 26) and applies `colored::Colorize::truecolor` to the line. When color
 /// is disabled (e.g. `NO_COLOR` or non-TTY), `colored` degrades gracefully to
 /// plain text.
-/// Test: `robot_row_colorize_produces_escape_sequences`,
-/// `robot_row_colorize_plain_when_disabled`.
+/// Test: `robot_row_colorize_preserves_text`.
 pub(crate) fn colorize_robot_row(row_idx: usize, line: &str) -> String {
     let idx = row_idx.min(ROBOT_GRADIENT.len() - 1);
     let (r, g, b) = ROBOT_GRADIENT[idx];
@@ -180,122 +132,13 @@ pub(crate) fn terminal_width() -> usize {
     80
 }
 
-/// Render the full-screen `tm launch` banner into a single string.
-///
-/// Why: keeping the banner pure (string in, string out) makes it trivially
-/// testable and lets [`print_launch_banner`] stay a thin print wrapper.
-/// What: builds the cleared-screen escape sequence, the ASCII robot (rust-
-/// gradient colorized), the "TRUSTY" wordmark, and an indented session-info
-/// block. When `reconnect_session` is `Some`, a `Status:` row is added and the
-/// closing action line reads "Reconnecting..." instead of "Launching claude...".
-/// Test: `launch_banner_contains_session_fields`,
-/// `launch_banner_marks_reconnect`.
-#[allow(dead_code)]
-pub(crate) fn render_launch_banner(
-    workdir: &str,
-    tmux_name: &str,
-    prompt_path: Option<&std::path::Path>,
-    reconnect_session: Option<&str>,
-) -> String {
-    let mut out = String::new();
-    // Clear the screen and home the cursor so the banner owns the terminal.
-    out.push_str("\x1B[2J\x1B[1;1H");
-
-    out.push('\n');
-    for (idx, line) in BANNER_ROBOT.iter().enumerate() {
-        out.push_str(BANNER_INDENT);
-        out.push_str(&colorize_robot_row(idx, line));
-        out.push('\n');
-    }
-    out.push('\n');
-    for line in wordmark_lines() {
-        out.push_str(BANNER_INDENT);
-        out.push_str(&line);
-        out.push('\n');
-    }
-    out.push('\n');
-
-    let separator = "─".repeat(BANNER_SEPARATOR_WIDTH);
-    let field =
-        |label: &str, value: &str| -> String { format!("{BANNER_INDENT}{label:<9}:  {value}\n") };
-
-    let memory = detect_memory();
-    let search = detect_tool("trusty-search");
-    let prompt = match prompt_path {
-        Some(p) => p.display().to_string(),
-        None => "(default)".to_string(),
-    };
-
-    out.push_str(BANNER_INDENT);
-    out.push_str(&separator);
-    out.push('\n');
-    out.push_str(&field("Project", workdir));
-    out.push_str(&field("Session", tmux_name));
-    if let Some(session) = reconnect_session {
-        out.push_str(&field(
-            "Status",
-            &format!("↩  reconnecting to existing session ({session})"),
-        ));
-    } else {
-        out.push_str(&field("Memory", &format!("{memory}  ✓")));
-        out.push_str(&field("Search", &format!("{search}  ✓")));
-        out.push_str(&field("Prompt", &prompt));
-    }
-    out.push_str(BANNER_INDENT);
-    out.push_str(&separator);
-    out.push('\n');
-    out.push('\n');
-
-    let action = if reconnect_session.is_some() {
-        "Reconnecting..."
-    } else {
-        "Launching claude..."
-    };
-    out.push_str(BANNER_INDENT);
-    out.push_str(action);
-    out.push('\n');
-    out
-}
-
-/// Render the robot art + TRUSTY wordmark without the full-screen clear escape.
-///
-/// Why: `tm banner` preview must not wipe the operator's scrollback. This
-/// helper is identical to [`render_robot_splash`] except it omits the
-/// `\x1B[2J\x1B[1;1H` sequence at the top.
-/// What: colorized robot rows + TRUSTY title block, optionally followed by
-/// `"Reconnecting..."` when `reconnecting` is `true`.
-/// Test: `banner_preview_does_not_panic`.
-pub(crate) fn render_robot_splash_no_clear(reconnecting: bool) -> String {
-    let mut out = String::new();
-    out.push('\n');
-    for (idx, line) in BANNER_ROBOT.iter().enumerate() {
-        out.push_str(BANNER_INDENT);
-        out.push_str(&colorize_robot_row(idx, line));
-        out.push('\n');
-    }
-    out.push('\n');
-    for line in wordmark_lines() {
-        out.push_str(BANNER_INDENT);
-        out.push_str(&line);
-        out.push('\n');
-    }
-    out.push('\n');
-    if reconnecting {
-        out.push_str(BANNER_INDENT);
-        out.push_str("Reconnecting...");
-        out.push('\n');
-    }
-    out
-}
-
-/// Print the full-screen `tm launch` banner with the rich info panel beneath.
+/// Print the full-screen `tm launch` banner (single outer box).
 ///
 /// Why: `tm launch` should give the operator a readable splash screen before
-/// the terminal is taken over by `claude`/`tmux`. The robot clears the screen
-/// for visual impact; the info panel below provides rich operational context.
-/// What: clears the screen, then renders the two-panel layout on wide terminals
-/// (≥`two_panel::MIN_WIDTH_TWO_PANEL` cols) or the stacked layout on narrow
-/// terminals. Pauses 1 s total (the info-box's own sleep covers it).
+/// the terminal is taken over by `claude`/`tmux`. The single-box banner clears
+/// the screen for visual impact; the info panel provides rich operational context.
+/// What: clears the screen, then renders the single-box layout via
+/// `two_panel::render_two_panel_banner`. Pauses 1 s after rendering.
 /// Test: `launch_banner_does_not_panic`.
 pub(crate) fn print_launch_banner(
     workdir: &str,
@@ -312,55 +155,20 @@ pub(crate) fn print_launch_banner(
         let _ = std::io::Write::flush(&mut std::io::stdout());
         std::thread::sleep(std::time::Duration::from_secs(1));
     } else {
-        // Narrow fallback: stacked layout.
-        print!("{}", render_robot_splash(false));
-        let _ = std::io::Write::flush(&mut std::io::stdout());
-        let daemon2 = super::info_box::DaemonInfo::from_lock_file();
-        super::info_box::print_welcome_panel(workdir, tmux_name, false, daemon2);
+        // Extremely narrow terminal (< 40 cols) — very rare.
+        println!("\x1B[2J\x1B[1;1H");
+        println!("Trusty MPM v{}", env!("CARGO_PKG_VERSION"));
+        println!("Launching...");
     }
-}
-
-/// Print the full-screen robot banner without the info panel (for tests/reconnect).
-///
-/// Why: renders the robot + title block as a pure string so test callers can
-/// assert content without going through the I/O path.
-/// What: `\x1B[2J\x1B[1;1H` clear + colorized robot rows + TRUSTY title.
-/// Test: `launch_banner_does_not_panic`, `launch_reconnect_banner_does_not_panic`.
-pub(crate) fn render_robot_splash(reconnecting: bool) -> String {
-    let mut out = String::new();
-    out.push_str("\x1B[2J\x1B[1;1H");
-    out.push('\n');
-    for (idx, line) in BANNER_ROBOT.iter().enumerate() {
-        out.push_str(BANNER_INDENT);
-        out.push_str(&colorize_robot_row(idx, line));
-        out.push('\n');
-    }
-    out.push('\n');
-    for line in wordmark_lines() {
-        out.push_str(BANNER_INDENT);
-        out.push_str(&line);
-        out.push('\n');
-    }
-    out.push('\n');
-    if reconnecting {
-        out.push_str(BANNER_INDENT);
-        out.push_str("Reconnecting...");
-        out.push('\n');
-    }
-    out
 }
 
 /// Print the full-screen `tm launch` banner with a "reconnecting" status line.
 ///
 /// Why: when `tm launch` attaches to a pre-existing session the operator should
 /// see that no new session was created.
-/// What: on wide terminals renders the two-panel layout with the reconnecting
-/// state shown in both panels; on narrow terminals falls back to the stacked
-/// layout with the rich info-box (reconnect mode).  The narrow fallback passes
-/// `reconnecting=true` to `render_robot_splash` so the "Reconnecting..." text
-/// appears in the robot splash — matching the wide-path presentation.
-/// Test: `launch_reconnect_banner_does_not_panic`,
-/// `narrow_fallback_reconnect_splash_includes_reconnecting_text`.
+/// What: on terminals >= MIN_WIDTH_BOX renders the single-box banner with
+/// reconnecting state shown. On very narrow terminals falls back to plain text.
+/// Test: `launch_reconnect_banner_does_not_panic`.
 pub(crate) fn print_launch_banner_reconnecting(workdir: &str, tmux_name: &str) {
     let w = terminal_width();
     let daemon = super::info_box::DaemonInfo::from_lock_file();
@@ -372,13 +180,9 @@ pub(crate) fn print_launch_banner_reconnecting(workdir: &str, tmux_name: &str) {
         let _ = std::io::Write::flush(&mut std::io::stdout());
         std::thread::sleep(std::time::Duration::from_secs(1));
     } else {
-        // Narrow fallback: stacked layout.  Pass reconnecting=true so the
-        // "Reconnecting..." label appears in the robot splash (matching the
-        // wide-path two-panel where the reconnect state is shown in both panels).
-        print!("{}", render_robot_splash(true));
-        let _ = std::io::Write::flush(&mut std::io::stdout());
-        let daemon2 = super::info_box::DaemonInfo::from_lock_file();
-        super::info_box::print_welcome_panel(workdir, tmux_name, true, daemon2);
+        println!("\x1B[2J\x1B[1;1H");
+        println!("Trusty MPM v{}", env!("CARGO_PKG_VERSION"));
+        println!("Reconnecting...");
     }
 }
 
@@ -388,8 +192,8 @@ pub(crate) fn print_launch_banner_reconnecting(workdir: &str, tmux_name: &str) {
 /// without launching Claude or waiting a full second. Skipping the
 /// `\x1B[2J\x1B[1;1H` clear preserves the operator's scrollback, and the
 /// absence of the 1-second sleep makes iteration fast.
-/// What: on wide terminals renders the two-panel layout (no screen-clear).
-/// On narrow terminals falls back to robot art + stacked info box.
+/// What: on terminals >= MIN_WIDTH_BOX renders the single-box banner (no
+/// screen-clear). On very narrow terminals prints a minimal plain-text banner.
 /// Test: `banner_preview_does_not_panic` in `tests.rs`.
 pub(crate) fn print_banner_preview(reconnecting: bool) {
     let w = terminal_width();
@@ -401,20 +205,13 @@ pub(crate) fn print_banner_preview(reconnecting: bool) {
     let data = super::info_box::gather_welcome_data(&workdir, &session_name, reconnecting, daemon);
 
     if let Some(panel) = two_panel::render_two_panel_banner(&data, w, reconnecting) {
-        // No screen-clear for preview — preserve scrollback.
         print!("\n{panel}");
         let _ = std::io::Write::flush(&mut std::io::stdout());
     } else {
-        // Narrow fallback: stacked layout (no screen-clear).
-        print!("{}", render_robot_splash_no_clear(reconnecting));
-        let _ = std::io::Write::flush(&mut std::io::stdout());
-        let daemon2 = super::info_box::DaemonInfo::from_lock_file();
-        super::info_box::print_welcome_panel_no_sleep(
-            &workdir,
-            &session_name,
-            reconnecting,
-            daemon2,
-        );
+        println!("Trusty MPM v{}", env!("CARGO_PKG_VERSION"));
+        if reconnecting {
+            println!("Reconnecting...");
+        }
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -7,104 +7,117 @@
 //! `print_banner_preview`, `terminal_width`, `detect_memory`, `detect_tool`,
 //! `dirs_config_dir`, `binary_on_path`, `fallback_session_name`,
 //! `normalize_workdir`, `tmux_has_session`. The single-box compositor lives in
-//! the `two_panel` submodule.
+//! the `two_panel` submodule. Image clipping and rust-shading live here.
 //! Test: `launch_banner_*`, `terminal_width_is_positive`,
 //! `normalize_workdir_strips_trailing_slash` in `tests.rs`;
 //! `two_panel_*` in `two_panel::tests`.
 
 pub(crate) mod two_panel;
 
-use colored::Colorize as _;
+// ── Embedded ASCII-art image ──────────────────────────────────────────────────
 
-/// The ASCII-art robot mascot drawn at the top of the launch banner.
+/// Raw ASCII-art image embedded at compile time.
 ///
-/// Why: a recognizable centerpiece gives `tm launch` the same "the tool has
-/// taken over the terminal" feel as claude-mpm's startup screen.
-/// What: a multi-line string-art robot; each line is 45 display columns wide.
-/// Test: `robot_shrink_has_fewer_rows` in `two_panel::tests`.
-pub(crate) const BANNER_ROBOT: &[&str] = &[
-    "                                             ",
-    "                    .}##-                    ",
-    "                    }#+#}                    ",
-    "                   .}#-#}.                   ",
-    "               ^]}#}##+##}#}]^               ",
-    "            ^}}]<^++]#<#]++^^<}}<            ",
-    "          <}]^++++++<#}#<++---+^]}]          ",
-    "        ^}]+--++++++<###<+---+---+<}^        ",
-    "       <}<+---++---+<###<-+--------^}<       ",
-    "      -}<+-+^<<^+---+}##+---+^^<+---^}+      ",
-    "     .]}++<}}<<]}]+-+}##--+]}]<<]}<--]].     ",
-    "   ^#}#]^]].     ^#^-}##-^#<      ]]+]#}#^   ",
-    "   }}]#]<#+       ]]+}#}-]}       -#<]#<}}   ",
-    " ]##}<#]^}^      .}<-<#<.<}-      ^}^<#<}##] ",
-    "<}^}}<#]-^}}-   <#<--<#<--<#<   -}}^-<}^}}+}<",
-    "-#]}}^#]---^]##}^---.^#^-..-^}##]+..-]#^}}]#-",
-    "  +#}^#]-----.----....+..............<#^]#+  ",
-    "   }}^#]-----..--....................<}^}}   ",
-    "   }}<#]--...--........   ........ ..<#^}}   ",
-    "   ]}<#]-....--.........    .........<#^}]   ",
-    "   ^}}#]^^++--------------.-...---++^]#]}^   ",
-    "    }}]]}}}}##}}}}}}}}}}}}}}}}}##}}]]]]}}    ",
-    "    }}+-----<#+     .   .     -#<-.----}]    ",
-    "    -#<-----<}+  ..           -}<-...-<#-    ",
-    "     .}}<+--<#+..             -}<-.-^}}.     ",
-    "        ^}#}##}}}}}}}}}}}}}}}}}##}#}^        ",
-    "                                             ",
-];
+/// Why: shipping the art as a sidecar `.txt` keeps the source file readable
+/// and avoids escaping every special Unicode glyph in a Rust string literal.
+/// What: 46-line × up to 120-col artwork; clipped to the focal figure window
+/// by `clip_and_shade_image`.
+/// Test: `image_embedded_correct_dims` in `two_panel::tests`.
+pub(crate) const BANNER_IMAGE: &str = include_str!("image.txt");
 
-/// Rust-color gradient palette applied row-by-row across the robot art.
-///
-/// Why: a smooth gradient from dark rust (top) through burnt orange (middle)
-/// to amber (lower) turns the monochrome ASCII art into a recognizable brand
-/// color without requiring a terminfo capability beyond 24-bit truecolor.
-/// What: 27-element array of `(r, g, b)` tuples, one per robot row (0–26);
-/// each shrunk row looks up its original index via `colorize_robot_row`.
-/// Test: `robot_gradient_matches_original_row_count` in `two_panel::tests`.
-pub(crate) const ROBOT_GRADIENT: [(u8, u8, u8); 27] = {
-    [
-        (183, 65, 14),
-        (185, 68, 15),
-        (187, 72, 16),
-        (189, 76, 17),
-        (191, 80, 18),
-        (193, 83, 19),
-        (195, 87, 20),
-        (197, 91, 21),
-        (199, 94, 22),
-        (201, 97, 24),
-        (202, 98, 25),
-        (203, 99, 27),
-        (204, 99, 28),
-        (205, 100, 30),
-        (206, 103, 32),
-        (208, 106, 34),
-        (210, 109, 36),
-        (212, 112, 38),
-        (214, 115, 40),
-        (216, 118, 43),
-        (217, 121, 46),
-        (219, 124, 48),
-        (220, 127, 50),
-        (221, 130, 53),
-        (222, 133, 55),
-        (223, 137, 58),
-        (224, 140, 60),
-    ]
-};
+// ── Clip-window constants ─────────────────────────────────────────────────────
 
-/// Colorize a single robot-art row with the rust gradient.
+/// First row to include (0-indexed, inclusive).
+pub(crate) const CLIP_ROW_START: usize = 0;
+/// One-past-the-last row to include (0-indexed, exclusive).
+pub(crate) const CLIP_ROW_END: usize = 34;
+/// First column to include (0-indexed, inclusive).
+pub(crate) const CLIP_COL_START: usize = 9;
+/// One-past-the-last column to include (0-indexed, exclusive).
+pub(crate) const CLIP_COL_END: usize = 61;
+/// Display width of the clipped image in columns.
+pub(crate) const IMAGE_CLIP_COLS: usize = CLIP_COL_END - CLIP_COL_START;
+/// Number of rows in the clipped image.
+pub(crate) const IMAGE_CLIP_ROWS: usize = CLIP_ROW_END - CLIP_ROW_START;
+
+// ── Per-character rust brightness shading ─────────────────────────────────────
+
+/// Map a glyph to its rust-palette RGB triple.
 ///
-/// Why: applying the gradient row-by-row produces a smooth top-to-bottom
-/// color wash without any per-character logic.
-/// What: looks up `(r, g, b)` from [`ROBOT_GRADIENT`] for `row_idx` (clamped
-/// to 26) and applies `colored::Colorize::truecolor` to the line. When color
-/// is disabled (e.g. `NO_COLOR` or non-TTY), `colored` degrades gracefully to
-/// plain text.
-/// Test: `robot_row_colorize_preserves_text`.
-pub(crate) fn colorize_robot_row(row_idx: usize, line: &str) -> String {
-    let idx = row_idx.min(ROBOT_GRADIENT.len() - 1);
-    let (r, g, b) = ROBOT_GRADIENT[idx];
-    line.truecolor(r, g, b).to_string()
+/// Why: dense ink characters should appear lighter (amber) and fine marks
+/// darker (deep rust) so the image reads as a lit 3-D relief.
+/// What: three buckets — dense glyphs → amber `(224,140,60)`,
+/// medium glyphs → mid-rust `(205,100,30)`, light marks → dark rust
+/// `(120,50,10)`, unclassified → base rust `(183,65,14)`.
+/// Test: `image_shading_emits_truecolor` in `two_panel::tests`.
+pub(crate) fn shade_bucket(c: char) -> (u8, u8, u8) {
+    match c {
+        // Dense — heavy ink / filled blocks
+        'I' | '∏' | '♦' | '∇' | '√' | '≥' | '≤' | '█' | '▓' | '▌' | '▐' | '@' | '#' =>
+        {
+            (224, 140, 60) // amber
+        }
+        // Medium — moderate ink
+        'i' | 'l' | '!' | '<' | '>' | '+' | '=' | '/' | '\\' | '≈' | '∫' | '∑' => {
+            (205, 100, 30) // mid rust
+        }
+        // Light — fine marks
+        '.' | ',' | ':' | ';' | '°' | '⋆' | '•' | '◦' | '~' | '-' => {
+            (120, 50, 10) // dark rust
+        }
+        // Unclassified (±, ÷, ×, ∂, ♫, ≠, etc.) — base rust
+        _ => (183, 65, 14),
+    }
+}
+
+/// Clip the ASCII-art image to the focal window and apply per-char rust shading.
+///
+/// Why: the raw image is ~80 cols × 46 rows; clipping to the dense figure
+/// mass gives a ~52 × 34 crop that fits the banner's left column without
+/// downsampling or averaging (native character resolution preserved).
+/// What: slices rows `[CLIP_ROW_START, CLIP_ROW_END)` and chars
+/// `[CLIP_COL_START, CLIP_COL_END)` from `BANNER_IMAGE`; applies
+/// `shade_bucket` per non-space character; pads short lines to `IMAGE_CLIP_COLS`.
+/// Spaces are passed through uncoloured (transparent).  Each row is already
+/// coloured via truecolor escapes; consumers measure display width via
+/// `strip_ansi` + `unicode_width`.
+/// Test: `image_clip_correct_rows`, `image_clip_correct_cols`,
+/// `image_shading_emits_truecolor` in `two_panel::tests`.
+pub(crate) fn clip_and_shade_image() -> Vec<String> {
+    BANNER_IMAGE
+        .lines()
+        .skip(CLIP_ROW_START)
+        .take(IMAGE_CLIP_ROWS)
+        .map(|line| {
+            let chars: Vec<char> = line.chars().collect();
+            let len = chars.len();
+            let col_start = CLIP_COL_START.min(len);
+            let col_end = CLIP_COL_END.min(len);
+
+            let mut row = String::with_capacity(IMAGE_CLIP_COLS * 24);
+            let mut display_cols: usize = 0;
+
+            for &c in &chars[col_start..col_end] {
+                if c == ' ' {
+                    row.push(' ');
+                } else {
+                    // Emit raw truecolor escape directly rather than via the
+                    // `colored` crate so the output is stable regardless of the
+                    // global `colored` override state (which is shared across
+                    // parallel tests and can race). strip_ansi in two_panel.rs
+                    // handles `\x1B[…m` sequences correctly for width math.
+                    let (r, g, b) = shade_bucket(c);
+                    row.push_str(&format!("\x1B[38;2;{r};{g};{b}m{c}\x1B[0m"));
+                }
+                display_cols += 1;
+            }
+            // Pad with spaces to reach IMAGE_CLIP_COLS.
+            for _ in display_cols..IMAGE_CLIP_COLS {
+                row.push(' ');
+            }
+            row
+        })
+        .collect()
 }
 
 /// Query the terminal width in columns, falling back to 80 when unknown.
@@ -188,7 +201,7 @@ pub(crate) fn print_launch_banner_reconnecting(workdir: &str, tmux_name: &str) {
 
 /// Print the banner to stdout for preview — no screen-clear, no sleep.
 ///
-/// Why: `tm banner` lets the operator eyeball the colored robot + welcome panel
+/// Why: `tm banner` lets the operator eyeball the colored image + welcome panel
 /// without launching Claude or waiting a full second. Skipping the
 /// `\x1B[2J\x1B[1;1H` clear preserves the operator's scrollback, and the
 /// absence of the 1-second sleep makes iteration fast.

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -59,20 +59,45 @@ pub(crate) const BANNER_ROBOT: &[&str] = &[
     "                                             ",
 ];
 
-/// The block-character "TRUSTY" wordmark drawn below the robot.
+/// Amber rust tone used for the plain-text wordmark label.
 ///
-/// Why: a large title makes the banner read as a deliberate splash screen
-/// rather than a stray log line.
-/// What: six rows of unicode block-drawing glyphs plus a spaced-out subtitle.
-pub(crate) const BANNER_TITLE: &[&str] = &[
-    "████████╗██████╗ ██╗   ██╗███████╗████████╗██╗   ██╗",
-    "╚══██╔══╝██╔══██╗██║   ██║██╔════╝╚══██╔══╝╚██╗ ██╔╝",
-    "   ██║   ██████╔╝██║   ██║███████╗   ██║    ╚████╔╝ ",
-    "   ██║   ██╔══██╗██║   ██║╚════██║   ██║     ╚██╔╝  ",
-    "   ██║   ██║  ██║╚██████╔╝███████║   ██║      ██║   ",
-    "   ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚══════╝   ╚═╝      ╚═╝   ",
-    "             M U L T I - A G E N T   P M",
-];
+/// Why: reuses the warm amber from the bottom of the robot gradient so the
+/// wordmark reads as part of the same brand palette without repeating the full
+/// gradient computation.
+/// What: RGB values `(224, 140, 60)` — the last entry in `ROBOT_GRADIENT`.
+/// Test: visual inspection via `tm banner`.
+const WORDMARK_R: u8 = 224;
+const WORDMARK_G: u8 = 140;
+const WORDMARK_B: u8 = 60;
+
+/// Muted dark-rust tone for the version line beneath the wordmark.
+///
+/// Why: the version number should be present but not compete with the label.
+/// What: RGB values `(140, 60, 20)` — darker than the wordmark amber.
+/// Test: visual inspection via `tm banner`.
+const VERSION_R: u8 = 140;
+const VERSION_G: u8 = 60;
+const VERSION_B: u8 = 20;
+
+/// Build the two-line plain-text wordmark: `trusty` (bold amber) + version (dimmed rust).
+///
+/// Why: replaces the bulky 7-row block-art `BANNER_TITLE` with a single-line
+/// label that is lighter, faster to scan, and stays under the SLOC cap.
+/// What: returns a `[String; 2]` — `lines[0]` is the colourised `"trusty"` label,
+/// `lines[1]` is the colourised `"v{CARGO_PKG_VERSION}"` version string. Both
+/// degrade gracefully to plain text when `colored` colour is disabled.
+/// Test: `wordmark_lines_contain_trusty_and_version`.
+pub(crate) fn wordmark_lines() -> [String; 2] {
+    use colored::Colorize as _;
+    let label = "trusty"
+        .truecolor(WORDMARK_R, WORDMARK_G, WORDMARK_B)
+        .bold()
+        .to_string();
+    let version = format!("v{}", env!("CARGO_PKG_VERSION"))
+        .truecolor(VERSION_R, VERSION_G, VERSION_B)
+        .to_string();
+    [label, version]
+}
 
 /// Rust-color gradient palette applied row-by-row across the robot art.
 ///
@@ -183,9 +208,9 @@ pub(crate) fn render_launch_banner(
         out.push('\n');
     }
     out.push('\n');
-    for line in BANNER_TITLE {
+    for line in wordmark_lines() {
         out.push_str(BANNER_INDENT);
-        out.push_str(line);
+        out.push_str(&line);
         out.push('\n');
     }
     out.push('\n');
@@ -249,9 +274,9 @@ pub(crate) fn render_robot_splash_no_clear(reconnecting: bool) -> String {
         out.push('\n');
     }
     out.push('\n');
-    for line in BANNER_TITLE {
+    for line in wordmark_lines() {
         out.push_str(BANNER_INDENT);
-        out.push_str(line);
+        out.push_str(&line);
         out.push('\n');
     }
     out.push('\n');
@@ -311,9 +336,9 @@ pub(crate) fn render_robot_splash(reconnecting: bool) -> String {
         out.push('\n');
     }
     out.push('\n');
-    for line in BANNER_TITLE {
+    for line in wordmark_lines() {
         out.push_str(BANNER_INDENT);
-        out.push_str(line);
+        out.push_str(&line);
         out.push('\n');
     }
     out.push('\n');

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -356,8 +356,11 @@ pub(crate) fn render_robot_splash(reconnecting: bool) -> String {
 /// see that no new session was created.
 /// What: on wide terminals renders the two-panel layout with the reconnecting
 /// state shown in both panels; on narrow terminals falls back to the stacked
-/// layout with the rich info-box (reconnect mode).
-/// Test: `launch_reconnect_banner_does_not_panic`.
+/// layout with the rich info-box (reconnect mode).  The narrow fallback passes
+/// `reconnecting=true` to `render_robot_splash` so the "Reconnecting..." text
+/// appears in the robot splash — matching the wide-path presentation.
+/// Test: `launch_reconnect_banner_does_not_panic`,
+/// `narrow_fallback_reconnect_splash_includes_reconnecting_text`.
 pub(crate) fn print_launch_banner_reconnecting(workdir: &str, tmux_name: &str) {
     let w = terminal_width();
     let daemon = super::info_box::DaemonInfo::from_lock_file();
@@ -369,7 +372,10 @@ pub(crate) fn print_launch_banner_reconnecting(workdir: &str, tmux_name: &str) {
         let _ = std::io::Write::flush(&mut std::io::stdout());
         std::thread::sleep(std::time::Duration::from_secs(1));
     } else {
-        print!("{}", render_robot_splash(false));
+        // Narrow fallback: stacked layout.  Pass reconnecting=true so the
+        // "Reconnecting..." label appears in the robot splash (matching the
+        // wide-path two-panel where the reconnect state is shown in both panels).
+        print!("{}", render_robot_splash(true));
         let _ = std::io::Write::flush(&mut std::io::stdout());
         let daemon2 = super::info_box::DaemonInfo::from_lock_file();
         super::info_box::print_welcome_panel(workdir, tmux_name, true, daemon2);

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
@@ -1,0 +1,453 @@
+//! Two-panel full-width launch banner compositor.
+//!
+//! Why: the original stacked layout (robot then info box) leaves the right half
+//! of wide terminals empty. A side-by-side two-panel layout fills the full
+//! terminal width and is more visually polished on modern wide terminals.
+//! What: `render_two_panel_banner` builds two framed boxes side-by-side —
+//! LEFT: robot+wordmark+version; RIGHT: info-box content — spanning the full
+//! terminal width. On narrow terminals (< `MIN_WIDTH_TWO_PANEL` columns) the
+//! function falls back to the stacked layout instead.
+//! Test: `two_panel_compose_alignment`, `two_panel_shorter_panel_padded`,
+//! `two_panel_narrow_fallback`, `two_panel_version_present`,
+//! `two_panel_no_clear_in_preview`.
+
+use colored::Colorize as _;
+use unicode_width::UnicodeWidthStr as _;
+
+use super::{BANNER_ROBOT, BANNER_TITLE, colorize_robot_row};
+use crate::formatters::info_box::{WelcomeData, render_info_box_rows};
+
+// ── Layout constants ──────────────────────────────────────────────────────────
+
+/// Left panel outer width in columns (frame inclusive).
+/// The robot art is 45 display columns wide; +2 for the box frame (│..│).
+/// Actual inner width = `LEFT_PANEL_OUTER_WIDTH - 2`.
+pub(crate) const LEFT_PANEL_OUTER_WIDTH: usize = 49;
+
+/// Minimum terminal width at which two-panel mode is used instead of stacked.
+/// Below this threshold the right panel would be too narrow to read.
+pub(crate) const MIN_WIDTH_TWO_PANEL: usize = 90;
+
+/// Gutter between left and right panel (space between right edge of left frame
+/// and left edge of right frame).
+const GUTTER: usize = 1;
+
+/// Muted rust colour for panel borders (`(120, 50, 10)`).
+const BORDER_R: u8 = 120;
+const BORDER_G: u8 = 50;
+const BORDER_B: u8 = 10;
+
+// ── Box-drawing characters ─────────────────────────────────────────────────────
+const TL: char = '╭'; // top-left
+const TR: char = '╮'; // top-right
+const BL: char = '╰'; // bottom-left
+const BR: char = '╯'; // bottom-right
+const HORIZ: char = '─';
+const VERT: char = '│';
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/// Render the two-panel banner as a `String` (pure — no I/O, no screen-clear).
+///
+/// Why: pure render is unit-testable; the print wrappers add I/O and
+/// (optionally) the `\x1B[2J\x1B[1;1H` screen-clear prefix.
+/// What: builds left (robot+wordmark+version) and right (info-box rows)
+/// framed panels side-by-side to fill `term_width` columns exactly.
+/// When `term_width < MIN_WIDTH_TWO_PANEL` returns `None` (caller falls back).
+/// Test: `two_panel_compose_alignment`, `two_panel_shorter_panel_padded`.
+pub(crate) fn render_two_panel_banner(
+    data: &WelcomeData,
+    term_width: usize,
+    reconnecting: bool,
+) -> Option<String> {
+    if term_width < MIN_WIDTH_TWO_PANEL {
+        return None;
+    }
+
+    let right_outer = term_width.saturating_sub(LEFT_PANEL_OUTER_WIDTH + GUTTER);
+    if right_outer < 10 {
+        return None;
+    }
+
+    let left_inner = LEFT_PANEL_OUTER_WIDTH.saturating_sub(2);
+    let right_inner = right_outer.saturating_sub(2);
+
+    // Build left panel lines (robot + wordmark + version).
+    let left_lines = build_left_lines(left_inner, reconnecting);
+    // Build right panel lines (info-box rows).
+    let right_lines = build_right_lines(data, right_inner);
+
+    let height = left_lines.len().max(right_lines.len());
+
+    let mut out = String::new();
+    // Top borders.
+    out.push_str(&tint_border(&format!(
+        "{TL}{}{TR}",
+        HORIZ.to_string().repeat(left_inner)
+    )));
+    out.push_str(&" ".repeat(GUTTER));
+    out.push_str(&tint_border(&format!(
+        "{TL}{}{TR}",
+        HORIZ.to_string().repeat(right_inner)
+    )));
+    out.push('\n');
+
+    // Content rows.
+    for i in 0..height {
+        // Left cell.
+        let left_cell = left_lines.get(i).cloned().unwrap_or_default();
+        let left_padded = pad_to_cols(&strip_ansi(&left_cell), left_inner, &left_cell);
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push_str(&left_padded);
+        out.push_str(&tint_border(&VERT.to_string()));
+
+        out.push_str(&" ".repeat(GUTTER));
+
+        // Right cell.
+        let right_cell = right_lines.get(i).cloned().unwrap_or_default();
+        let right_padded = pad_to_cols(&strip_ansi(&right_cell), right_inner, &right_cell);
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push_str(&right_padded);
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push('\n');
+    }
+
+    // Bottom borders.
+    out.push_str(&tint_border(&format!(
+        "{BL}{}{BR}",
+        HORIZ.to_string().repeat(left_inner)
+    )));
+    out.push_str(&" ".repeat(GUTTER));
+    out.push_str(&tint_border(&format!(
+        "{BL}{}{BR}",
+        HORIZ.to_string().repeat(right_inner)
+    )));
+    out.push('\n');
+
+    Some(out)
+}
+
+// ── Left panel builder ────────────────────────────────────────────────────────
+
+/// Build the left-panel content lines (robot art + wordmark + version).
+///
+/// Why: each line is a single string padded to `inner_width` display columns;
+/// the compositor centres the robot horizontally within the panel.
+/// What: robot rows (rust-gradient colourised), blank row, wordmark rows,
+/// blank row, version string. Each line is pre-padded to `inner_width` cols.
+/// Test: `two_panel_version_present`, `two_panel_compose_alignment`.
+fn build_left_lines(inner_width: usize, reconnecting: bool) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+
+    // Robot rows — colourised, centred within inner_width.
+    for (idx, &row) in BANNER_ROBOT.iter().enumerate() {
+        let row_display = row; // raw display width (ASCII-only art = byte len)
+        let row_cols = row_display.width();
+        let pad_l = (inner_width.saturating_sub(row_cols)) / 2;
+        let pad_r = inner_width.saturating_sub(row_cols + pad_l);
+        let colored = colorize_robot_row(idx, row_display);
+        lines.push(format!(
+            "{}{}{}",
+            " ".repeat(pad_l),
+            colored,
+            " ".repeat(pad_r)
+        ));
+    }
+
+    // Blank separator.
+    lines.push(" ".repeat(inner_width));
+
+    // TRUSTY wordmark.
+    for &title_row in BANNER_TITLE {
+        let row_cols = title_row.width();
+        let pad_l = (inner_width.saturating_sub(row_cols)) / 2;
+        let pad_r = inner_width.saturating_sub(row_cols + pad_l);
+        lines.push(format!(
+            "{}{}{}",
+            " ".repeat(pad_l),
+            title_row,
+            " ".repeat(pad_r)
+        ));
+    }
+
+    // Blank separator.
+    lines.push(" ".repeat(inner_width));
+
+    // Version line.
+    let version = env!("CARGO_PKG_VERSION");
+    let ver_str = format!("v{version}");
+    let ver_cols = ver_str.width();
+    let pad_l = (inner_width.saturating_sub(ver_cols)) / 2;
+    let pad_r = inner_width.saturating_sub(ver_cols + pad_l);
+    lines.push(format!(
+        "{}{}{}",
+        " ".repeat(pad_l),
+        ver_str,
+        " ".repeat(pad_r)
+    ));
+
+    // Reconnecting indicator.
+    if reconnecting {
+        lines.push(" ".repeat(inner_width));
+        let rcon = "↩ reconnecting";
+        let rcon_cols = rcon.width();
+        let pad_l = (inner_width.saturating_sub(rcon_cols)) / 2;
+        let pad_r = inner_width.saturating_sub(rcon_cols + pad_l);
+        lines.push(format!(
+            "{}{}{}",
+            " ".repeat(pad_l),
+            rcon,
+            " ".repeat(pad_r)
+        ));
+    }
+
+    lines
+}
+
+// ── Right panel builder ───────────────────────────────────────────────────────
+
+/// Build right-panel content lines from the welcome data.
+///
+/// Why: the right panel mirrors the existing info-box content; reusing
+/// `render_info_box_rows` avoids duplicating the row-building logic.
+/// What: calls `render_info_box_rows(data)` to get the content rows, then
+/// truncates each to `inner_width` display columns.
+/// Test: `two_panel_compose_alignment`.
+fn build_right_lines(data: &WelcomeData, inner_width: usize) -> Vec<String> {
+    let rows = render_info_box_rows(data);
+    rows.into_iter()
+        .map(|row| {
+            let cols = row.width();
+            if cols <= inner_width {
+                // Pad to inner_width.
+                format!("{row}{}", " ".repeat(inner_width - cols))
+            } else {
+                // Truncate.
+                truncate_to_cols(row, inner_width)
+            }
+        })
+        .collect()
+}
+
+// ── String utilities ──────────────────────────────────────────────────────────
+
+/// Strip ANSI escape sequences from `s` and return the display-only string.
+///
+/// Why: ANSI escapes are zero display width but have non-zero byte length;
+/// we need the "clean" version to compute display width and padding.
+/// What: walks the string, discarding `\x1B[…m` SGR sequences.
+/// Test: `strip_ansi_removes_color_codes`.
+pub(crate) fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1B' {
+            // Consume `[` then everything up to a letter.
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                while let Some(&nc) = chars.peek() {
+                    chars.next();
+                    if nc.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Pad `colored` (which may contain ANSI escapes) to `width` display columns.
+///
+/// Why: ANSI escapes are zero display width; padding must be based on the
+/// display width of the bare text (`bare`), not the byte length of `colored`.
+/// What: computes `display_len(bare)`, appends trailing spaces if needed.
+/// Test: `two_panel_compose_alignment`.
+fn pad_to_cols(bare: &str, width: usize, colored: &str) -> String {
+    let cols = bare.width();
+    if cols >= width {
+        colored.to_string()
+    } else {
+        format!("{colored}{}", " ".repeat(width - cols))
+    }
+}
+
+/// Truncate `s` (plain text, no ANSI) to at most `max_cols` display columns.
+///
+/// Why: right panel rows wider than `inner_width` would misalign the border.
+/// What: accumulates char widths; stops before exceeding `max_cols - 1`, then
+/// appends `…` (U+2026); returns `s` unchanged when it already fits.
+/// Test: `two_panel_compose_alignment`.
+fn truncate_to_cols(s: String, max_cols: usize) -> String {
+    if s.width() <= max_cols {
+        return s;
+    }
+    let budget = max_cols.saturating_sub(1);
+    let mut used = 0usize;
+    let mut out = String::new();
+    for ch in s.chars() {
+        let w = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(1);
+        if used + w > budget {
+            break;
+        }
+        used += w;
+        out.push(ch);
+    }
+    let pad = max_cols.saturating_sub(used + 1);
+    format!("{out}…{}", " ".repeat(pad))
+}
+
+/// Apply muted rust tint to a border string.
+///
+/// Why: tinted borders give the two-panel layout a cohesive brand color
+/// without overwhelming the content.
+/// What: wraps `s` in the BORDER_R/G/B truecolor escape. When `colored` has
+/// colour disabled (NO_COLOR, non-TTY) the escape degrades to plain text.
+/// Test: indirectly by `two_panel_compose_alignment` (no-color path).
+fn tint_border(s: &str) -> String {
+    s.truecolor(BORDER_R, BORDER_G, BORDER_B).to_string()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::formatters::info_box::{CommitLine, DaemonInfo, WelcomeData};
+
+    fn base_data() -> WelcomeData {
+        WelcomeData {
+            project: "owner/repo".to_string(),
+            workspace: "/home/user/projects/repo".to_string(),
+            user: "alice".to_string(),
+            reconnecting: false,
+            session_name: String::new(),
+            daemon: DaemonInfo::default(),
+            recent_commits: vec![],
+            memory_status: "(not detected)".to_string(),
+            search_status: "(not detected)".to_string(),
+            review_status: "(not detected)".to_string(),
+        }
+    }
+
+    fn reconnect_data() -> WelcomeData {
+        WelcomeData {
+            reconnecting: true,
+            session_name: "tmpm-my-proj".to_string(),
+            ..base_data()
+        }
+    }
+
+    fn data_with_commits() -> WelcomeData {
+        WelcomeData {
+            recent_commits: vec![CommitLine {
+                sha: "abc1234".to_string(),
+                age: "2h".to_string(),
+                subject: "fix: something important".to_string(),
+            }],
+            ..base_data()
+        }
+    }
+
+    /// Two-panel banner renders without panic and produces two │-bordered rows.
+    #[test]
+    fn two_panel_compose_alignment() {
+        let data = base_data();
+        let result = render_two_panel_banner(&data, 120, false);
+        assert!(result.is_some(), "wide terminal should produce two-panel");
+        let out = result.unwrap();
+        // Every content row must start with a border char (after stripping ANSI).
+        for line in out.lines() {
+            let bare = strip_ansi(line);
+            if bare.is_empty() {
+                continue;
+            }
+            let first = bare.chars().next().unwrap_or(' ');
+            assert!(
+                matches!(first, '╭' | '╰' | '│'),
+                "each line must start with a box corner or side: {bare:?}"
+            );
+        }
+    }
+
+    /// Both framed panels close at the same bottom line (equal height).
+    #[test]
+    fn two_panel_shorter_panel_padded_to_equal_height() {
+        let data = data_with_commits();
+        let out = render_two_panel_banner(&data, 130, false).expect("should produce two-panel");
+        // Count content rows (│...│ ... │...│ lines).
+        let content_lines: Vec<&str> = out
+            .lines()
+            .filter(|l| {
+                let bare = strip_ansi(l);
+                bare.starts_with('│')
+            })
+            .collect();
+        // The panels are always equal height, so every content line must have
+        // EXACTLY two │ starting chars (one per panel).
+        for line in &content_lines {
+            let bare = strip_ansi(line);
+            let pipe_count = bare.chars().filter(|&c| c == '│').count();
+            assert!(
+                pipe_count >= 2,
+                "content line must have both panel borders: {bare:?}"
+            );
+        }
+    }
+
+    /// On narrow terminals, returns None (caller falls back to stacked layout).
+    #[test]
+    fn two_panel_narrow_fallback() {
+        let data = base_data();
+        let result = render_two_panel_banner(&data, 80, false);
+        assert!(
+            result.is_none(),
+            "narrow terminal should return None for stacked fallback"
+        );
+    }
+
+    /// Exactly at threshold also falls back.
+    #[test]
+    fn two_panel_at_threshold_boundary() {
+        let data = base_data();
+        // MIN_WIDTH_TWO_PANEL - 1 → fallback.
+        assert!(render_two_panel_banner(&data, MIN_WIDTH_TWO_PANEL - 1, false).is_none());
+        // At MIN_WIDTH_TWO_PANEL → two-panel (if right panel is wide enough).
+        // (May still return None if right panel < 10; just assert no panic.)
+        let _ = render_two_panel_banner(&data, MIN_WIDTH_TWO_PANEL, false);
+    }
+
+    /// Version string must appear in the left panel.
+    #[test]
+    fn two_panel_version_present() {
+        let data = base_data();
+        let out = render_two_panel_banner(&data, 120, false).expect("two-panel");
+        let bare = strip_ansi(&out);
+        assert!(
+            bare.contains(env!("CARGO_PKG_VERSION")),
+            "version must appear in left panel: {bare}"
+        );
+    }
+
+    /// Reconnecting state shows the reconnecting indicator in the left panel.
+    #[test]
+    fn two_panel_reconnecting_shows_indicator() {
+        let data = reconnect_data();
+        let out = render_two_panel_banner(&data, 120, true).expect("two-panel");
+        let bare = strip_ansi(&out);
+        assert!(
+            bare.contains("reconnecting"),
+            "reconnecting indicator must appear: {bare}"
+        );
+    }
+
+    /// `strip_ansi` correctly removes SGR colour escapes.
+    #[test]
+    fn strip_ansi_removes_color_codes() {
+        let colored = "\x1B[38;2;183;65;14mhello\x1B[0m world";
+        let bare = strip_ansi(colored);
+        assert_eq!(bare, "hello world");
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
@@ -157,7 +157,7 @@ fn build_left_lines(inner_width: usize, reconnecting: bool) -> Vec<String> {
     // Blank separator.
     lines.push(" ".repeat(inner_width));
 
-    // Plain-text "trusty" label + version — two lines replacing the old block-art wordmark.
+    // Plain-text "trusty-mpm" label + version — two lines replacing the old block-art wordmark.
     for wm_line in wordmark_lines() {
         let bare = strip_ansi(&wm_line);
         let row_cols = bare.width();

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
@@ -5,11 +5,11 @@
 //! and dropping the inner frames gives more usable width for content.
 //! What: `render_two_panel_banner` (same public signature as before) produces a
 //! single rounded box whose title bar carries `Trusty MPM v{VERSION}`. Inside,
-//! wide terminals (≥ MIN_WIDTH_TWO_PANEL) get the shrunken robot (left) and
+//! wide terminals (≥ MIN_WIDTH_TWO_PANEL) get the clipped art image (left) and
 //! info content (right) separated by a tinted `│` vertical divider (` │ `);
 //! narrow terminals get a stacked layout inside the same box. Very narrow
 //! (< MIN_WIDTH_BOX) returns `None` so callers can fall back to plain output.
-//! Test: `single_box_title_bar_contains_version`, `robot_shrink_has_fewer_rows`,
+//! Test: `single_box_title_bar_contains_version`, `image_clip_correct_rows`,
 //! `right_col_no_inner_border`, `reconnect_label_in_narrow_box`,
 //! `two_panel_compose_alignment`, `two_panel_version_present`,
 //! `wide_layout_has_vertical_divider`.
@@ -17,7 +17,7 @@
 use colored::Colorize as _;
 use unicode_width::UnicodeWidthStr as _;
 
-use super::{BANNER_ROBOT, colorize_robot_row};
+use super::{IMAGE_CLIP_COLS, clip_and_shade_image};
 use crate::formatters::info_box::{WelcomeData, render_info_box_rows};
 
 // ── Layout constants ──────────────────────────────────────────────────────────
@@ -29,7 +29,7 @@ pub(crate) const MIN_WIDTH_TWO_PANEL: usize = 90;
 /// Minimum terminal width to render any outer box at all.
 const MIN_WIDTH_BOX: usize = 40;
 
-/// Three-character gutter between the robot column and the info column: ` │ `.
+/// Three-character gutter between the image column and the info column: ` │ `.
 ///
 /// The middle character is a tinted `│` vertical divider; the flanking spaces
 /// provide visual breathing room. Total gutter width must match the rendered
@@ -57,7 +57,7 @@ const DIVIDER_BOTTOM: char = '┴';
 ///
 /// Why: a single outer box with version in the title bar is more cohesive than
 /// two separate side-by-side frames. Signature is unchanged so callers need no edits.
-/// What: wide terminals (≥ MIN_WIDTH_TWO_PANEL) show the shrunken robot (left),
+/// What: wide terminals (≥ MIN_WIDTH_TWO_PANEL) show the clipped art image (left),
 /// 1-char gutter, and info content (right) inside one `╭─╮` box. Narrow
 /// terminals stack the same content vertically. Very narrow (< MIN_WIDTH_BOX)
 /// returns `None`.
@@ -71,20 +71,20 @@ pub(crate) fn render_two_panel_banner(
         return None;
     }
 
-    let shrunk = shrink_robot();
-    let robot_cols = shrunk.iter().map(|(_, s)| s.width()).max().unwrap_or(36);
+    let image_lines = clip_and_shade_image();
+    let image_cols = IMAGE_CLIP_COLS;
 
     let inner = term_width.saturating_sub(2);
 
     if term_width >= MIN_WIDTH_TWO_PANEL {
-        let right_col = inner.saturating_sub(robot_cols + GUTTER);
+        let right_col = inner.saturating_sub(image_cols + GUTTER);
         if right_col >= 10 {
             return Some(render_wide_box(
                 data,
                 term_width,
                 reconnecting,
-                &shrunk,
-                robot_cols,
+                &image_lines,
+                image_cols,
                 right_col,
             ));
         }
@@ -94,37 +94,9 @@ pub(crate) fn render_two_panel_banner(
         data,
         term_width,
         reconnecting,
-        &shrunk,
-        robot_cols,
+        &image_lines,
+        image_cols,
     ))
-}
-
-// ── Robot shrink ──────────────────────────────────────────────────────────────
-
-/// Shrink the robot art by ~20%: drop every 5th row and every 5th column.
-///
-/// Why: the full 27×45 robot is too wide for the left column of a single outer
-/// box on typical terminals. Dropping 1-in-5 rows and 1-in-5 columns gives
-/// ~22×36, a ~20% linear reduction that preserves the visual shape.
-/// What: keeps rows where `idx % 5 != 4` (22 of 27) and chars where
-/// `col_idx % 5 != 4` (36 of 45). Returns `Vec<(orig_row_idx, text)>` so
-/// callers can look up the original gradient colour via `colorize_robot_row`.
-/// Test: `robot_shrink_has_fewer_rows`.
-fn shrink_robot() -> Vec<(usize, String)> {
-    BANNER_ROBOT
-        .iter()
-        .enumerate()
-        .filter(|(idx, _)| idx % 5 != 4)
-        .map(|(orig_idx, &row)| {
-            let shrunk: String = row
-                .chars()
-                .enumerate()
-                .filter(|(ci, _)| ci % 5 != 4)
-                .map(|(_, c)| c)
-                .collect();
-            (orig_idx, shrunk)
-        })
-        .collect()
 }
 
 // ── Title bar ────────────────────────────────────────────────────────────────
@@ -152,19 +124,19 @@ fn render_title_bar(term_width: usize) -> String {
 
 /// Render the wide (≥ MIN_WIDTH_TWO_PANEL) two-column single-box banner.
 ///
-/// Why: wide terminals have enough room to show robot (left) and info (right)
-/// side by side without wrapping. A tinted vertical divider makes the column
-/// boundary visually explicit without adding a full inner frame.
-/// What: title bar on top, `robot_cols`-wide left col + ` │ ` divider (3 chars,
+/// Why: wide terminals have enough room to show the art image (left) and info
+/// (right) side by side without wrapping. A tinted vertical divider makes the
+/// column boundary visually explicit without adding a full inner frame.
+/// What: title bar on top, `left_col`-wide left col + ` │ ` divider (3 chars,
 /// tinted rust) + `right_col`-wide right col, bottom border with `┴` at the
-/// divider column. Height = max(robot rows, info rows).
+/// divider column. Height = max(image rows, info rows).
 /// Test: `two_panel_compose_alignment`, `right_col_no_inner_border`,
 /// `wide_layout_has_vertical_divider`.
 fn render_wide_box(
     data: &WelcomeData,
     term_width: usize,
     reconnecting: bool,
-    shrunk: &[(usize, String)],
+    image_lines: &[String],
     left_col: usize,
     right_col: usize,
 ) -> String {
@@ -172,14 +144,14 @@ fn render_wide_box(
 
     let right_lines = build_right_lines(data, right_col);
 
-    // Colorize shrunk robot rows and right-pad to left_col.
-    let mut left_lines: Vec<String> = shrunk
+    // Pad image rows to left_col. Image lines are already per-char colorized;
+    // measure display width via strip_ansi.
+    let mut left_lines: Vec<String> = image_lines
         .iter()
-        .map(|(orig_idx, row)| {
-            let raw_cols = row.width();
-            let colored = colorize_robot_row(*orig_idx, row);
+        .map(|row| {
+            let raw_cols = strip_ansi(row).width();
             let pad = left_col.saturating_sub(raw_cols);
-            format!("{colored}{}", " ".repeat(pad))
+            format!("{row}{}", " ".repeat(pad))
         })
         .collect();
 
@@ -239,17 +211,17 @@ fn render_wide_box(
 /// Render the narrow (< MIN_WIDTH_TWO_PANEL) stacked single-box banner.
 ///
 /// Why: on terminals narrower than MIN_WIDTH_TWO_PANEL the right column would
-/// be too narrow to read. Stacking robot then info vertically inside the same
+/// be too narrow to read. Stacking art image then info vertically inside the same
 /// outer box preserves the brand frame while fitting the content.
-/// What: title bar, centred robot rows, optional "Reconnecting..." label,
+/// What: title bar, centred image rows, optional "Reconnecting..." label,
 /// left-aligned info rows, bottom border. All inside the single outer box.
 /// Test: `reconnect_label_in_narrow_box`.
 fn render_narrow_box(
     data: &WelcomeData,
     term_width: usize,
     reconnecting: bool,
-    shrunk: &[(usize, String)],
-    _robot_cols: usize,
+    image_lines: &[String],
+    _image_cols: usize,
 ) -> String {
     let inner = term_width.saturating_sub(2);
 
@@ -257,15 +229,14 @@ fn render_narrow_box(
     out.push_str(&render_title_bar(term_width));
     out.push('\n');
 
-    // Robot rows — centred within inner.
-    for (orig_idx, row) in shrunk {
-        let raw_cols = row.width();
+    // Image rows — centred within inner.
+    for row in image_lines {
+        let raw_cols = strip_ansi(row).width();
         let pad_l = (inner.saturating_sub(raw_cols)) / 2;
         let pad_r = inner.saturating_sub(raw_cols + pad_l);
-        let colored = colorize_robot_row(*orig_idx, row);
         out.push_str(&tint_border(&VERT.to_string()));
         out.push_str(&" ".repeat(pad_l));
-        out.push_str(&colored);
+        out.push_str(row);
         out.push_str(&" ".repeat(pad_r));
         out.push_str(&tint_border(&VERT.to_string()));
         out.push('\n');
@@ -477,33 +448,51 @@ pub(crate) mod tests {
         colored::control::unset_override();
     }
 
-    /// Shrunken robot has fewer rows than the original BANNER_ROBOT.
+    /// Clipped image has exactly IMAGE_CLIP_ROWS rows.
     #[test]
-    fn robot_shrink_has_fewer_rows() {
-        let shrunk = shrink_robot();
-        assert!(
-            shrunk.len() < BANNER_ROBOT.len(),
-            "shrunk robot ({} rows) must have fewer rows than original ({})",
-            shrunk.len(),
-            BANNER_ROBOT.len()
+    fn image_clip_correct_rows() {
+        let lines = super::super::clip_and_shade_image();
+        assert_eq!(
+            lines.len(),
+            super::super::IMAGE_CLIP_ROWS,
+            "clipped image must have exactly IMAGE_CLIP_ROWS ({}) rows, got {}",
+            super::super::IMAGE_CLIP_ROWS,
+            lines.len()
         );
-        // ~20% reduction: expect between 18 and 25 rows.
         assert!(
-            shrunk.len() >= 18 && shrunk.len() <= 25,
-            "shrunk robot must be ~20% smaller: got {} rows",
-            shrunk.len()
+            lines.len() >= 30 && lines.len() <= 36,
+            "clipped rows ({}) must be within 30–36",
+            lines.len()
         );
     }
 
-    /// Shrunken robot rows are narrower than the original rows.
+    /// Each row of the clipped image has exactly IMAGE_CLIP_COLS display columns.
     #[test]
-    fn robot_shrink_narrower_columns() {
-        let shrunk = shrink_robot();
-        let orig_max = BANNER_ROBOT.iter().map(|r| r.len()).max().unwrap_or(0);
-        let shrunk_max = shrunk.iter().map(|(_, s)| s.len()).max().unwrap_or(0);
+    fn image_clip_correct_cols() {
+        colored::control::set_override(false);
+        let lines = super::super::clip_and_shade_image();
+        let expected = super::super::IMAGE_CLIP_COLS;
+        for (i, line) in lines.iter().enumerate() {
+            let bare = strip_ansi(line);
+            let width = bare.width();
+            assert_eq!(
+                width, expected,
+                "row {i} display width ({width}) must equal IMAGE_CLIP_COLS ({expected})"
+            );
+        }
+        colored::control::unset_override();
+    }
+
+    /// Non-space art characters always emit truecolor escapes.
+    #[test]
+    fn image_shading_emits_truecolor() {
+        // clip_and_shade_image emits raw ANSI truecolor escapes directly
+        // (not via the `colored` global state) so this test needs no override.
+        let lines = super::super::clip_and_shade_image();
+        let any_colored = lines.iter().any(|l| l.contains("\x1B[38;2;"));
         assert!(
-            shrunk_max < orig_max,
-            "shrunk robot cols ({shrunk_max}) must be fewer than original ({orig_max})"
+            any_colored,
+            "clipped image must always emit truecolor escapes for non-space chars"
         );
     }
 
@@ -513,15 +502,11 @@ pub(crate) mod tests {
         colored::control::set_override(false);
         let data = base_data();
         let out = render_two_panel_banner(&data, 120, false).expect("banner");
-        // The right-column content rows are the lines between the first and last.
-        // Inner border chars must not appear inside content rows (only the outer │ starts each line).
         for line in out.lines() {
             let bare = strip_ansi(line);
-            // Skip the top/bottom border lines.
             if bare.starts_with('╭') || bare.starts_with('╰') {
                 continue;
             }
-            // Content rows: strip outer │ on each side, check interior for forbidden chars.
             let inner: String = bare.chars().skip(1).collect();
             let inner_trimmed = inner.trim_end_matches('│');
             for ch in ['╭', '╮', '╰', '╯'] {
@@ -568,7 +553,6 @@ pub(crate) mod tests {
         let data = data_with_commits();
         colored::control::set_override(false);
         let out = render_two_panel_banner(&data, 130, false).expect("wide banner");
-        // Every content row (starts with │) must end with │.
         for line in out.lines() {
             let bare = strip_ansi(line);
             if bare.starts_with('│') {
@@ -638,17 +622,6 @@ pub(crate) mod tests {
         colored::control::unset_override();
     }
 
-    /// ROBOT_GRADIENT has an entry for every row of the original BANNER_ROBOT.
-    #[test]
-    fn robot_gradient_matches_original_row_count() {
-        use super::super::ROBOT_GRADIENT;
-        assert_eq!(
-            ROBOT_GRADIENT.len(),
-            BANNER_ROBOT.len(),
-            "ROBOT_GRADIENT length must match BANNER_ROBOT row count"
-        );
-    }
-
     /// `strip_ansi` correctly removes SGR colour escapes.
     #[test]
     fn strip_ansi_removes_color_codes() {
@@ -667,7 +640,9 @@ pub(crate) mod tests {
         let mut checked = 0usize;
         for line in out.lines() {
             let bare = strip_ansi(line);
-            if bare.is_empty() { continue; }
+            if bare.is_empty() {
+                continue;
+            }
             assert_eq!(bare.width(), 120, "line width mismatch: {bare:?}");
             if bare.starts_with('│') {
                 let chars: Vec<char> = bare.chars().collect();

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
@@ -6,12 +6,13 @@
 //! What: `render_two_panel_banner` (same public signature as before) produces a
 //! single rounded box whose title bar carries `Trusty MPM v{VERSION}`. Inside,
 //! wide terminals (≥ MIN_WIDTH_TWO_PANEL) get the shrunken robot (left) and
-//! info content (right) separated by a 1-char gutter; narrow terminals get a
-//! stacked layout inside the same box. Very narrow (< MIN_WIDTH_BOX) returns
-//! `None` so callers can fall back to plain output.
+//! info content (right) separated by a tinted `│` vertical divider (` │ `);
+//! narrow terminals get a stacked layout inside the same box. Very narrow
+//! (< MIN_WIDTH_BOX) returns `None` so callers can fall back to plain output.
 //! Test: `single_box_title_bar_contains_version`, `robot_shrink_has_fewer_rows`,
 //! `right_col_no_inner_border`, `reconnect_label_in_narrow_box`,
-//! `two_panel_compose_alignment`, `two_panel_version_present`.
+//! `two_panel_compose_alignment`, `two_panel_version_present`,
+//! `wide_layout_has_vertical_divider`.
 
 use colored::Colorize as _;
 use unicode_width::UnicodeWidthStr as _;
@@ -28,8 +29,12 @@ pub(crate) const MIN_WIDTH_TWO_PANEL: usize = 90;
 /// Minimum terminal width to render any outer box at all.
 const MIN_WIDTH_BOX: usize = 40;
 
-/// One-character gutter between the robot column and the info column.
-const GUTTER: usize = 1;
+/// Three-character gutter between the robot column and the info column: ` │ `.
+///
+/// The middle character is a tinted `│` vertical divider; the flanking spaces
+/// provide visual breathing room. Total gutter width must match the rendered
+/// ` ` + `│` + ` ` = 3 display columns in every interior row.
+const GUTTER: usize = 3;
 
 /// Muted rust colour for outer-box borders.
 const BORDER_R: u8 = 120;
@@ -43,6 +48,8 @@ const BL: char = '╰';
 const BR: char = '╯';
 const HORIZ: char = '─';
 const VERT: char = '│';
+/// Bottom connector for the vertical divider where it meets the bottom border.
+const DIVIDER_BOTTOM: char = '┴';
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
@@ -146,10 +153,13 @@ fn render_title_bar(term_width: usize) -> String {
 /// Render the wide (≥ MIN_WIDTH_TWO_PANEL) two-column single-box banner.
 ///
 /// Why: wide terminals have enough room to show robot (left) and info (right)
-/// side by side without wrapping.
-/// What: title bar on top, `robot_cols`-wide left col + 1-char gutter +
-/// `right_col`-wide right col, bottom border. Height = max(robot rows, info rows).
-/// Test: `two_panel_compose_alignment`, `right_col_no_inner_border`.
+/// side by side without wrapping. A tinted vertical divider makes the column
+/// boundary visually explicit without adding a full inner frame.
+/// What: title bar on top, `robot_cols`-wide left col + ` │ ` divider (3 chars,
+/// tinted rust) + `right_col`-wide right col, bottom border with `┴` at the
+/// divider column. Height = max(robot rows, info rows).
+/// Test: `two_panel_compose_alignment`, `right_col_no_inner_border`,
+/// `wide_layout_has_vertical_divider`.
 fn render_wide_box(
     data: &WelcomeData,
     term_width: usize,
@@ -204,13 +214,20 @@ fn render_wide_box(
             .unwrap_or_else(|| " ".repeat(right_col));
         out.push_str(&tint_border(&VERT.to_string()));
         out.push_str(&left);
-        out.push_str(&" ".repeat(GUTTER));
+        out.push_str(&format!(" {} ", tint_border(&VERT.to_string())));
         out.push_str(&right);
         out.push_str(&tint_border(&VERT.to_string()));
         out.push('\n');
     }
 
-    let bottom = format!("{BL}{}{BR}", HORIZ.to_string().repeat(inner));
+    // Bottom border: ┴ at the divider column (left_col+1 within inner dashes).
+    // `inner = left_col + GUTTER + right_col` with right_col ≥ 10, so the
+    // subtraction `inner - left_col - 2` is always ≥ right_col - 1 > 0.
+    let bottom = format!(
+        "{BL}{}{DIVIDER_BOTTOM}{}{BR}",
+        HORIZ.to_string().repeat(left_col + 1),
+        HORIZ.to_string().repeat(inner - left_col - 2)
+    );
     out.push_str(&tint_border(&bottom));
     out.push('\n');
 
@@ -638,5 +655,28 @@ pub(crate) mod tests {
         let colored = "\x1B[38;2;183;65;14mhello\x1B[0m world";
         let bare = strip_ansi(colored);
         assert_eq!(bare, "hello world");
+    }
+
+    /// Wide layout has a `│` vertical divider between columns; every line is
+    /// exactly `term_width` display columns wide.
+    #[test]
+    fn wide_layout_has_vertical_divider() {
+        colored::control::set_override(false);
+        let data = base_data();
+        let out = render_two_panel_banner(&data, 120, false).expect("wide banner");
+        let mut checked = 0usize;
+        for line in out.lines() {
+            let bare = strip_ansi(line);
+            if bare.is_empty() { continue; }
+            assert_eq!(bare.width(), 120, "line width mismatch: {bare:?}");
+            if bare.starts_with('│') {
+                let chars: Vec<char> = bare.chars().collect();
+                let inner = &chars[1..chars.len().saturating_sub(1)];
+                assert!(inner.contains(&'│'), "no interior │ divider in: {bare:?}");
+                checked += 1;
+            }
+        }
+        assert!(checked > 0, "no content lines found in wide banner");
+        colored::control::unset_override();
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
@@ -14,7 +14,7 @@
 use colored::Colorize as _;
 use unicode_width::UnicodeWidthStr as _;
 
-use super::{BANNER_ROBOT, BANNER_TITLE, colorize_robot_row};
+use super::{BANNER_ROBOT, colorize_robot_row, wordmark_lines};
 use crate::formatters::info_box::{WelcomeData, render_info_box_rows};
 
 // ── Layout constants ──────────────────────────────────────────────────────────
@@ -157,34 +157,19 @@ fn build_left_lines(inner_width: usize, reconnecting: bool) -> Vec<String> {
     // Blank separator.
     lines.push(" ".repeat(inner_width));
 
-    // TRUSTY wordmark.
-    for &title_row in BANNER_TITLE {
-        let row_cols = title_row.width();
+    // Plain-text "trusty" label + version — two lines replacing the old block-art wordmark.
+    for wm_line in wordmark_lines() {
+        let bare = strip_ansi(&wm_line);
+        let row_cols = bare.width();
         let pad_l = (inner_width.saturating_sub(row_cols)) / 2;
         let pad_r = inner_width.saturating_sub(row_cols + pad_l);
         lines.push(format!(
             "{}{}{}",
             " ".repeat(pad_l),
-            title_row,
+            wm_line,
             " ".repeat(pad_r)
         ));
     }
-
-    // Blank separator.
-    lines.push(" ".repeat(inner_width));
-
-    // Version line.
-    let version = env!("CARGO_PKG_VERSION");
-    let ver_str = format!("v{version}");
-    let ver_cols = ver_str.width();
-    let pad_l = (inner_width.saturating_sub(ver_cols)) / 2;
-    let pad_r = inner_width.saturating_sub(ver_cols + pad_l);
-    lines.push(format!(
-        "{}{}{}",
-        " ".repeat(pad_l),
-        ver_str,
-        " ".repeat(pad_r)
-    ));
 
     // Reconnecting indicator.
     if reconnecting {

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
@@ -1,184 +1,185 @@
-//! Two-panel full-width launch banner compositor.
+//! Single-box full-width banner compositor.
 //!
-//! Why: the original stacked layout (robot then info box) leaves the right half
-//! of wide terminals empty. A side-by-side two-panel layout fills the full
-//! terminal width and is more visually polished on modern wide terminals.
-//! What: `render_two_panel_banner` builds two framed boxes side-by-side —
-//! LEFT: robot+wordmark+version; RIGHT: info-box content — spanning the full
-//! terminal width. On narrow terminals (< `MIN_WIDTH_TWO_PANEL` columns) the
-//! function falls back to the stacked layout instead.
-//! Test: `two_panel_compose_alignment`, `two_panel_shorter_panel_padded`,
-//! `two_panel_narrow_fallback`, `two_panel_version_present`,
-//! `two_panel_no_clear_in_preview`.
+//! Why: the previous two-separate-frames layout left visual gaps between panels.
+//! One outer box with the version embedded in the top border is more cohesive,
+//! and dropping the inner frames gives more usable width for content.
+//! What: `render_two_panel_banner` (same public signature as before) produces a
+//! single rounded box whose title bar carries `Trusty MPM v{VERSION}`. Inside,
+//! wide terminals (≥ MIN_WIDTH_TWO_PANEL) get the shrunken robot (left) and
+//! info content (right) separated by a 1-char gutter; narrow terminals get a
+//! stacked layout inside the same box. Very narrow (< MIN_WIDTH_BOX) returns
+//! `None` so callers can fall back to plain output.
+//! Test: `single_box_title_bar_contains_version`, `robot_shrink_has_fewer_rows`,
+//! `right_col_no_inner_border`, `reconnect_label_in_narrow_box`,
+//! `two_panel_compose_alignment`, `two_panel_version_present`.
 
 use colored::Colorize as _;
 use unicode_width::UnicodeWidthStr as _;
 
-use super::{BANNER_ROBOT, colorize_robot_row, wordmark_lines};
+use super::{BANNER_ROBOT, colorize_robot_row};
 use crate::formatters::info_box::{WelcomeData, render_info_box_rows};
 
 // ── Layout constants ──────────────────────────────────────────────────────────
 
-/// Left panel outer width in columns (frame inclusive).
-/// The robot art is 45 display columns wide; +2 for the box frame (│..│).
-/// Actual inner width = `LEFT_PANEL_OUTER_WIDTH - 2`.
-pub(crate) const LEFT_PANEL_OUTER_WIDTH: usize = 49;
-
-/// Minimum terminal width at which two-panel mode is used instead of stacked.
-/// Below this threshold the right panel would be too narrow to read.
+/// Minimum terminal width for the wide two-column layout.
+/// Below this threshold the narrow stacked layout is used inside the same outer box.
 pub(crate) const MIN_WIDTH_TWO_PANEL: usize = 90;
 
-/// Gutter between left and right panel (space between right edge of left frame
-/// and left edge of right frame).
+/// Minimum terminal width to render any outer box at all.
+const MIN_WIDTH_BOX: usize = 40;
+
+/// One-character gutter between the robot column and the info column.
 const GUTTER: usize = 1;
 
-/// Muted rust colour for panel borders (`(120, 50, 10)`).
+/// Muted rust colour for outer-box borders.
 const BORDER_R: u8 = 120;
 const BORDER_G: u8 = 50;
 const BORDER_B: u8 = 10;
 
 // ── Box-drawing characters ─────────────────────────────────────────────────────
-const TL: char = '╭'; // top-left
-const TR: char = '╮'; // top-right
-const BL: char = '╰'; // bottom-left
-const BR: char = '╯'; // bottom-right
+const TL: char = '╭';
+const TR: char = '╮';
+const BL: char = '╰';
+const BR: char = '╯';
 const HORIZ: char = '─';
 const VERT: char = '│';
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
-/// Render the two-panel banner as a `String` (pure — no I/O, no screen-clear).
+/// Render the single-box banner as a `String` (pure — no I/O, no screen-clear).
 ///
-/// Why: pure render is unit-testable; the print wrappers add I/O and
-/// (optionally) the `\x1B[2J\x1B[1;1H` screen-clear prefix.
-/// What: builds left (robot+wordmark+version) and right (info-box rows)
-/// framed panels side-by-side to fill `term_width` columns exactly.
-/// When `term_width < MIN_WIDTH_TWO_PANEL` returns `None` (caller falls back).
-/// Test: `two_panel_compose_alignment`, `two_panel_shorter_panel_padded`.
+/// Why: a single outer box with version in the title bar is more cohesive than
+/// two separate side-by-side frames. Signature is unchanged so callers need no edits.
+/// What: wide terminals (≥ MIN_WIDTH_TWO_PANEL) show the shrunken robot (left),
+/// 1-char gutter, and info content (right) inside one `╭─╮` box. Narrow
+/// terminals stack the same content vertically. Very narrow (< MIN_WIDTH_BOX)
+/// returns `None`.
+/// Test: `two_panel_compose_alignment`, `single_box_title_bar_contains_version`.
 pub(crate) fn render_two_panel_banner(
     data: &WelcomeData,
     term_width: usize,
     reconnecting: bool,
 ) -> Option<String> {
-    if term_width < MIN_WIDTH_TWO_PANEL {
+    if term_width < MIN_WIDTH_BOX {
         return None;
     }
 
-    let right_outer = term_width.saturating_sub(LEFT_PANEL_OUTER_WIDTH + GUTTER);
-    if right_outer < 10 {
-        return None;
+    let shrunk = shrink_robot();
+    let robot_cols = shrunk.iter().map(|(_, s)| s.width()).max().unwrap_or(36);
+
+    let inner = term_width.saturating_sub(2);
+
+    if term_width >= MIN_WIDTH_TWO_PANEL {
+        let right_col = inner.saturating_sub(robot_cols + GUTTER);
+        if right_col >= 10 {
+            return Some(render_wide_box(
+                data,
+                term_width,
+                reconnecting,
+                &shrunk,
+                robot_cols,
+                right_col,
+            ));
+        }
     }
 
-    let left_inner = LEFT_PANEL_OUTER_WIDTH.saturating_sub(2);
-    let right_inner = right_outer.saturating_sub(2);
-
-    // Build left panel lines (robot + wordmark + version).
-    let left_lines = build_left_lines(left_inner, reconnecting);
-    // Build right panel lines (info-box rows).
-    let right_lines = build_right_lines(data, right_inner);
-
-    let height = left_lines.len().max(right_lines.len());
-
-    let mut out = String::new();
-    // Top borders.
-    out.push_str(&tint_border(&format!(
-        "{TL}{}{TR}",
-        HORIZ.to_string().repeat(left_inner)
-    )));
-    out.push_str(&" ".repeat(GUTTER));
-    out.push_str(&tint_border(&format!(
-        "{TL}{}{TR}",
-        HORIZ.to_string().repeat(right_inner)
-    )));
-    out.push('\n');
-
-    // Content rows.
-    for i in 0..height {
-        // Left cell.
-        let left_cell = left_lines.get(i).cloned().unwrap_or_default();
-        let left_padded = pad_to_cols(&strip_ansi(&left_cell), left_inner, &left_cell);
-        out.push_str(&tint_border(&VERT.to_string()));
-        out.push_str(&left_padded);
-        out.push_str(&tint_border(&VERT.to_string()));
-
-        out.push_str(&" ".repeat(GUTTER));
-
-        // Right cell.
-        let right_cell = right_lines.get(i).cloned().unwrap_or_default();
-        let right_padded = pad_to_cols(&strip_ansi(&right_cell), right_inner, &right_cell);
-        out.push_str(&tint_border(&VERT.to_string()));
-        out.push_str(&right_padded);
-        out.push_str(&tint_border(&VERT.to_string()));
-        out.push('\n');
-    }
-
-    // Bottom borders.
-    out.push_str(&tint_border(&format!(
-        "{BL}{}{BR}",
-        HORIZ.to_string().repeat(left_inner)
-    )));
-    out.push_str(&" ".repeat(GUTTER));
-    out.push_str(&tint_border(&format!(
-        "{BL}{}{BR}",
-        HORIZ.to_string().repeat(right_inner)
-    )));
-    out.push('\n');
-
-    Some(out)
+    Some(render_narrow_box(
+        data,
+        term_width,
+        reconnecting,
+        &shrunk,
+        robot_cols,
+    ))
 }
 
-// ── Left panel builder ────────────────────────────────────────────────────────
+// ── Robot shrink ──────────────────────────────────────────────────────────────
 
-/// Build the left-panel content lines (robot art + wordmark + version).
+/// Shrink the robot art by ~20%: drop every 5th row and every 5th column.
 ///
-/// Why: each line is a single string padded to `inner_width` display columns;
-/// the compositor centres the robot horizontally within the panel.
-/// What: robot rows (rust-gradient colourised), blank row, wordmark rows,
-/// blank row, version string. Each line is pre-padded to `inner_width` cols.
-/// Test: `two_panel_version_present`, `two_panel_compose_alignment`.
-fn build_left_lines(inner_width: usize, reconnecting: bool) -> Vec<String> {
-    let mut lines: Vec<String> = Vec::new();
+/// Why: the full 27×45 robot is too wide for the left column of a single outer
+/// box on typical terminals. Dropping 1-in-5 rows and 1-in-5 columns gives
+/// ~22×36, a ~20% linear reduction that preserves the visual shape.
+/// What: keeps rows where `idx % 5 != 4` (22 of 27) and chars where
+/// `col_idx % 5 != 4` (36 of 45). Returns `Vec<(orig_row_idx, text)>` so
+/// callers can look up the original gradient colour via `colorize_robot_row`.
+/// Test: `robot_shrink_has_fewer_rows`.
+fn shrink_robot() -> Vec<(usize, String)> {
+    BANNER_ROBOT
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| idx % 5 != 4)
+        .map(|(orig_idx, &row)| {
+            let shrunk: String = row
+                .chars()
+                .enumerate()
+                .filter(|(ci, _)| ci % 5 != 4)
+                .map(|(_, c)| c)
+                .collect();
+            (orig_idx, shrunk)
+        })
+        .collect()
+}
 
-    // Robot rows — colourised, centred within inner_width.
-    for (idx, &row) in BANNER_ROBOT.iter().enumerate() {
-        let row_display = row; // raw display width (ASCII-only art = byte len)
-        let row_cols = row_display.width();
-        let pad_l = (inner_width.saturating_sub(row_cols)) / 2;
-        let pad_r = inner_width.saturating_sub(row_cols + pad_l);
-        let colored = colorize_robot_row(idx, row_display);
-        lines.push(format!(
-            "{}{}{}",
-            " ".repeat(pad_l),
-            colored,
-            " ".repeat(pad_r)
-        ));
-    }
+// ── Title bar ────────────────────────────────────────────────────────────────
 
-    // Blank separator.
-    lines.push(" ".repeat(inner_width));
+/// Render the top border with `Trusty MPM v{VERSION}` embedded.
+///
+/// Why: embedding the version in the border line eliminates the separate
+/// wordmark block, saving vertical space and giving the banner a branded frame.
+/// What: produces `╭──── Trusty MPM vX.Y.Z ────…────╮` of exactly `term_width`
+/// display columns. The `─` corners are tinted rust; the label text is plain.
+/// Test: `single_box_title_bar_contains_version`.
+fn render_title_bar(term_width: usize) -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    let label = format!(" Trusty MPM v{version} ");
+    let label_cols = label.len(); // ASCII-only
+    let inner = term_width.saturating_sub(2);
+    let dashes_left = 4usize.min(inner.saturating_sub(label_cols));
+    let dashes_right = inner.saturating_sub(dashes_left + label_cols);
+    let left = tint_border(&format!("{TL}{}", HORIZ.to_string().repeat(dashes_left)));
+    let right = tint_border(&format!("{}{TR}", HORIZ.to_string().repeat(dashes_right)));
+    format!("{left}{label}{right}")
+}
 
-    // Plain-text "trusty-mpm" label + version — two lines replacing the old block-art wordmark.
-    for wm_line in wordmark_lines() {
-        let bare = strip_ansi(&wm_line);
-        let row_cols = bare.width();
-        let pad_l = (inner_width.saturating_sub(row_cols)) / 2;
-        let pad_r = inner_width.saturating_sub(row_cols + pad_l);
-        lines.push(format!(
-            "{}{}{}",
-            " ".repeat(pad_l),
-            wm_line,
-            " ".repeat(pad_r)
-        ));
-    }
+// ── Wide two-column layout ────────────────────────────────────────────────────
 
-    // Reconnecting indicator.
+/// Render the wide (≥ MIN_WIDTH_TWO_PANEL) two-column single-box banner.
+///
+/// Why: wide terminals have enough room to show robot (left) and info (right)
+/// side by side without wrapping.
+/// What: title bar on top, `robot_cols`-wide left col + 1-char gutter +
+/// `right_col`-wide right col, bottom border. Height = max(robot rows, info rows).
+/// Test: `two_panel_compose_alignment`, `right_col_no_inner_border`.
+fn render_wide_box(
+    data: &WelcomeData,
+    term_width: usize,
+    reconnecting: bool,
+    shrunk: &[(usize, String)],
+    left_col: usize,
+    right_col: usize,
+) -> String {
+    let inner = left_col + GUTTER + right_col; // = term_width - 2
+
+    let right_lines = build_right_lines(data, right_col);
+
+    // Colorize shrunk robot rows and right-pad to left_col.
+    let mut left_lines: Vec<String> = shrunk
+        .iter()
+        .map(|(orig_idx, row)| {
+            let raw_cols = row.width();
+            let colored = colorize_robot_row(*orig_idx, row);
+            let pad = left_col.saturating_sub(raw_cols);
+            format!("{colored}{}", " ".repeat(pad))
+        })
+        .collect();
+
     if reconnecting {
-        lines.push(" ".repeat(inner_width));
-        let rcon = "↩ reconnecting";
+        left_lines.push(" ".repeat(left_col));
+        let rcon = "Reconnecting...";
         let rcon_cols = rcon.width();
-        let pad_l = (inner_width.saturating_sub(rcon_cols)) / 2;
-        let pad_r = inner_width.saturating_sub(rcon_cols + pad_l);
-        lines.push(format!(
+        let pad_l = (left_col.saturating_sub(rcon_cols)) / 2;
+        let pad_r = left_col.saturating_sub(rcon_cols + pad_l);
+        left_lines.push(format!(
             "{}{}{}",
             " ".repeat(pad_l),
             rcon,
@@ -186,28 +187,124 @@ fn build_left_lines(inner_width: usize, reconnecting: bool) -> Vec<String> {
         ));
     }
 
-    lines
+    let height = left_lines.len().max(right_lines.len());
+
+    let mut out = String::new();
+    out.push_str(&render_title_bar(term_width));
+    out.push('\n');
+
+    for i in 0..height {
+        let left = left_lines
+            .get(i)
+            .cloned()
+            .unwrap_or_else(|| " ".repeat(left_col));
+        let right = right_lines
+            .get(i)
+            .cloned()
+            .unwrap_or_else(|| " ".repeat(right_col));
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push_str(&left);
+        out.push_str(&" ".repeat(GUTTER));
+        out.push_str(&right);
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push('\n');
+    }
+
+    let bottom = format!("{BL}{}{BR}", HORIZ.to_string().repeat(inner));
+    out.push_str(&tint_border(&bottom));
+    out.push('\n');
+
+    out
 }
 
-// ── Right panel builder ───────────────────────────────────────────────────────
+// ── Narrow stacked layout ─────────────────────────────────────────────────────
 
-/// Build right-panel content lines from the welcome data.
+/// Render the narrow (< MIN_WIDTH_TWO_PANEL) stacked single-box banner.
+///
+/// Why: on terminals narrower than MIN_WIDTH_TWO_PANEL the right column would
+/// be too narrow to read. Stacking robot then info vertically inside the same
+/// outer box preserves the brand frame while fitting the content.
+/// What: title bar, centred robot rows, optional "Reconnecting..." label,
+/// left-aligned info rows, bottom border. All inside the single outer box.
+/// Test: `reconnect_label_in_narrow_box`.
+fn render_narrow_box(
+    data: &WelcomeData,
+    term_width: usize,
+    reconnecting: bool,
+    shrunk: &[(usize, String)],
+    _robot_cols: usize,
+) -> String {
+    let inner = term_width.saturating_sub(2);
+
+    let mut out = String::new();
+    out.push_str(&render_title_bar(term_width));
+    out.push('\n');
+
+    // Robot rows — centred within inner.
+    for (orig_idx, row) in shrunk {
+        let raw_cols = row.width();
+        let pad_l = (inner.saturating_sub(raw_cols)) / 2;
+        let pad_r = inner.saturating_sub(raw_cols + pad_l);
+        let colored = colorize_robot_row(*orig_idx, row);
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push_str(&" ".repeat(pad_l));
+        out.push_str(&colored);
+        out.push_str(&" ".repeat(pad_r));
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push('\n');
+    }
+
+    // Reconnecting label.
+    if reconnecting {
+        let label = "Reconnecting...";
+        let label_cols = label.width();
+        let pad_l = (inner.saturating_sub(label_cols)) / 2;
+        let pad_r = inner.saturating_sub(label_cols + pad_l);
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push_str(&" ".repeat(pad_l));
+        out.push_str(label);
+        out.push_str(&" ".repeat(pad_r));
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push('\n');
+    }
+
+    // Info rows — left-aligned, truncated/padded to inner.
+    for row in build_right_lines(data, inner) {
+        let bare = strip_ansi(&row);
+        let bare_cols = bare.width();
+        let pad = inner.saturating_sub(bare_cols);
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push_str(&row);
+        out.push_str(&" ".repeat(pad));
+        out.push_str(&tint_border(&VERT.to_string()));
+        out.push('\n');
+    }
+
+    let bottom = format!("{BL}{}{BR}", HORIZ.to_string().repeat(inner));
+    out.push_str(&tint_border(&bottom));
+    out.push('\n');
+
+    out
+}
+
+// ── Right-column builder ──────────────────────────────────────────────────────
+
+/// Build right-column content lines from the welcome data, padded to `inner_width`.
 ///
 /// Why: the right panel mirrors the existing info-box content; reusing
 /// `render_info_box_rows` avoids duplicating the row-building logic.
-/// What: calls `render_info_box_rows(data)` to get the content rows, then
-/// truncates each to `inner_width` display columns.
+/// What: calls `render_info_box_rows(data)` to get content rows, then pads
+/// or truncates each to `inner_width` display columns.
 /// Test: `two_panel_compose_alignment`.
 fn build_right_lines(data: &WelcomeData, inner_width: usize) -> Vec<String> {
     let rows = render_info_box_rows(data);
     rows.into_iter()
         .map(|row| {
-            let cols = row.width();
+            let bare = strip_ansi(&row);
+            let cols = bare.width();
             if cols <= inner_width {
-                // Pad to inner_width.
                 format!("{row}{}", " ".repeat(inner_width - cols))
             } else {
-                // Truncate.
                 truncate_to_cols(row, inner_width)
             }
         })
@@ -216,10 +313,10 @@ fn build_right_lines(data: &WelcomeData, inner_width: usize) -> Vec<String> {
 
 // ── String utilities ──────────────────────────────────────────────────────────
 
-/// Strip ANSI escape sequences from `s` and return the display-only string.
+/// Strip ANSI escape sequences from `s`, returning display-only text.
 ///
-/// Why: ANSI escapes are zero display width but have non-zero byte length;
-/// we need the "clean" version to compute display width and padding.
+/// Why: ANSI escapes are zero display width but non-zero byte length; stripping
+/// them lets us compute correct display widths and padding amounts.
 /// What: walks the string, discarding `\x1B[…m` SGR sequences.
 /// Test: `strip_ansi_removes_color_codes`.
 pub(crate) fn strip_ansi(s: &str) -> String {
@@ -227,7 +324,6 @@ pub(crate) fn strip_ansi(s: &str) -> String {
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '\x1B' {
-            // Consume `[` then everything up to a letter.
             if chars.peek() == Some(&'[') {
                 chars.next();
                 while let Some(&nc) = chars.peek() {
@@ -244,26 +340,12 @@ pub(crate) fn strip_ansi(s: &str) -> String {
     out
 }
 
-/// Pad `colored` (which may contain ANSI escapes) to `width` display columns.
+/// Truncate `s` to at most `max_cols` display columns, appending `…`.
 ///
-/// Why: ANSI escapes are zero display width; padding must be based on the
-/// display width of the bare text (`bare`), not the byte length of `colored`.
-/// What: computes `display_len(bare)`, appends trailing spaces if needed.
-/// Test: `two_panel_compose_alignment`.
-fn pad_to_cols(bare: &str, width: usize, colored: &str) -> String {
-    let cols = bare.width();
-    if cols >= width {
-        colored.to_string()
-    } else {
-        format!("{colored}{}", " ".repeat(width - cols))
-    }
-}
-
-/// Truncate `s` (plain text, no ANSI) to at most `max_cols` display columns.
-///
-/// Why: right panel rows wider than `inner_width` would misalign the border.
-/// What: accumulates char widths; stops before exceeding `max_cols - 1`, then
-/// appends `…` (U+2026); returns `s` unchanged when it already fits.
+/// Why: right-panel rows wider than `inner_width` would push the border char
+/// out of position.
+/// What: accumulates char widths, stops before exceeding `max_cols - 1` columns,
+/// then appends `…` (U+2026). Returns `s` unchanged when it already fits.
 /// Test: `two_panel_compose_alignment`.
 fn truncate_to_cols(s: String, max_cols: usize) -> String {
     if s.width() <= max_cols {
@@ -281,15 +363,15 @@ fn truncate_to_cols(s: String, max_cols: usize) -> String {
         out.push(ch);
     }
     let pad = max_cols.saturating_sub(used + 1);
-    format!("{out}…{}", " ".repeat(pad))
+    format!("{out}\u{2026}{}", " ".repeat(pad))
 }
 
 /// Apply muted rust tint to a border string.
 ///
-/// Why: tinted borders give the two-panel layout a cohesive brand color
-/// without overwhelming the content.
-/// What: wraps `s` in the BORDER_R/G/B truecolor escape. When `colored` has
-/// colour disabled (NO_COLOR, non-TTY) the escape degrades to plain text.
+/// Why: tinted borders give the layout a cohesive brand colour without
+/// overwhelming the content.
+/// What: wraps `s` in the BORDER_R/G/B truecolor escape; degrades to plain
+/// text when `colored` has colour disabled (NO_COLOR, non-TTY).
 /// Test: indirectly by `two_panel_compose_alignment` (no-color path).
 fn tint_border(s: &str) -> String {
     s.truecolor(BORDER_R, BORDER_G, BORDER_B).to_string()
@@ -336,14 +418,14 @@ pub(crate) mod tests {
         }
     }
 
-    /// Two-panel banner renders without panic and produces two │-bordered rows.
+    /// Single-box banner renders without panic; every line starts with a border char.
     #[test]
     fn two_panel_compose_alignment() {
+        colored::control::set_override(false);
         let data = base_data();
         let result = render_two_panel_banner(&data, 120, false);
-        assert!(result.is_some(), "wide terminal should produce two-panel");
+        assert!(result.is_some(), "wide terminal should produce a banner");
         let out = result.unwrap();
-        // Every content row must start with a border char (after stripping ANSI).
         for line in out.lines() {
             let bare = strip_ansi(line);
             if bare.is_empty() {
@@ -355,76 +437,198 @@ pub(crate) mod tests {
                 "each line must start with a box corner or side: {bare:?}"
             );
         }
+        colored::control::unset_override();
     }
 
-    /// Both framed panels close at the same bottom line (equal height).
+    /// Title bar must embed the crate version.
     #[test]
-    fn two_panel_shorter_panel_padded_to_equal_height() {
-        let data = data_with_commits();
-        let out = render_two_panel_banner(&data, 130, false).expect("should produce two-panel");
-        // Count content rows (│...│ ... │...│ lines).
-        let content_lines: Vec<&str> = out
-            .lines()
-            .filter(|l| {
-                let bare = strip_ansi(l);
-                bare.starts_with('│')
-            })
-            .collect();
-        // The panels are always equal height, so every content line must have
-        // EXACTLY two │ starting chars (one per panel).
-        for line in &content_lines {
-            let bare = strip_ansi(line);
-            let pipe_count = bare.chars().filter(|&c| c == '│').count();
-            assert!(
-                pipe_count >= 2,
-                "content line must have both panel borders: {bare:?}"
-            );
-        }
-    }
-
-    /// On narrow terminals, returns None (caller falls back to stacked layout).
-    #[test]
-    fn two_panel_narrow_fallback() {
+    fn single_box_title_bar_contains_version() {
+        colored::control::set_override(false);
         let data = base_data();
-        let result = render_two_panel_banner(&data, 80, false);
+        let out =
+            render_two_panel_banner(&data, 120, false).expect("wide terminal produces banner");
+        let first_line = out.lines().next().unwrap_or("");
+        let bare = strip_ansi(first_line);
         assert!(
-            result.is_none(),
-            "narrow terminal should return None for stacked fallback"
+            bare.contains(env!("CARGO_PKG_VERSION")),
+            "title bar must contain CARGO_PKG_VERSION: {bare:?}"
+        );
+        assert!(
+            bare.starts_with('╭'),
+            "title bar must start with ╭: {bare:?}"
+        );
+        colored::control::unset_override();
+    }
+
+    /// Shrunken robot has fewer rows than the original BANNER_ROBOT.
+    #[test]
+    fn robot_shrink_has_fewer_rows() {
+        let shrunk = shrink_robot();
+        assert!(
+            shrunk.len() < BANNER_ROBOT.len(),
+            "shrunk robot ({} rows) must have fewer rows than original ({})",
+            shrunk.len(),
+            BANNER_ROBOT.len()
+        );
+        // ~20% reduction: expect between 18 and 25 rows.
+        assert!(
+            shrunk.len() >= 18 && shrunk.len() <= 25,
+            "shrunk robot must be ~20% smaller: got {} rows",
+            shrunk.len()
         );
     }
 
-    /// Exactly at threshold also falls back.
+    /// Shrunken robot rows are narrower than the original rows.
+    #[test]
+    fn robot_shrink_narrower_columns() {
+        let shrunk = shrink_robot();
+        let orig_max = BANNER_ROBOT.iter().map(|r| r.len()).max().unwrap_or(0);
+        let shrunk_max = shrunk.iter().map(|(_, s)| s.len()).max().unwrap_or(0);
+        assert!(
+            shrunk_max < orig_max,
+            "shrunk robot cols ({shrunk_max}) must be fewer than original ({orig_max})"
+        );
+    }
+
+    /// The right-column content has no inner-box border chars (╭╮╰╯).
+    #[test]
+    fn right_col_no_inner_border() {
+        colored::control::set_override(false);
+        let data = base_data();
+        let out = render_two_panel_banner(&data, 120, false).expect("banner");
+        // The right-column content rows are the lines between the first and last.
+        // Inner border chars must not appear inside content rows (only the outer │ starts each line).
+        for line in out.lines() {
+            let bare = strip_ansi(line);
+            // Skip the top/bottom border lines.
+            if bare.starts_with('╭') || bare.starts_with('╰') {
+                continue;
+            }
+            // Content rows: strip outer │ on each side, check interior for forbidden chars.
+            let inner: String = bare.chars().skip(1).collect();
+            let inner_trimmed = inner.trim_end_matches('│');
+            for ch in ['╭', '╮', '╰', '╯'] {
+                assert!(
+                    !inner_trimmed.contains(ch),
+                    "inner border char {ch:?} must not appear inside content rows: {bare:?}"
+                );
+            }
+        }
+        colored::control::unset_override();
+    }
+
+    /// Reconnecting label appears in the stacked narrow-fallback box.
+    #[test]
+    fn reconnect_label_in_narrow_box() {
+        colored::control::set_override(false);
+        let data = reconnect_data();
+        let out = render_two_panel_banner(&data, 80, true).expect("narrow box");
+        let bare = strip_ansi(&out);
+        assert!(
+            bare.contains("Reconnecting..."),
+            "narrow box must contain 'Reconnecting...' label: {bare:.200}"
+        );
+        colored::control::unset_override();
+    }
+
+    /// Reconnecting label is absent from a normal (non-reconnect) narrow banner.
+    #[test]
+    fn narrow_box_no_reconnect_label_when_not_reconnecting() {
+        colored::control::set_override(false);
+        let data = base_data();
+        let out = render_two_panel_banner(&data, 80, false).expect("narrow box");
+        let bare = strip_ansi(&out);
+        assert!(
+            !bare.contains("Reconnecting..."),
+            "normal narrow box must not contain 'Reconnecting...' label"
+        );
+        colored::control::unset_override();
+    }
+
+    /// Both panels reach equal height (shorter one is padded).
+    #[test]
+    fn two_panel_shorter_panel_padded_to_equal_height() {
+        let data = data_with_commits();
+        colored::control::set_override(false);
+        let out = render_two_panel_banner(&data, 130, false).expect("wide banner");
+        // Every content row (starts with │) must end with │.
+        for line in out.lines() {
+            let bare = strip_ansi(line);
+            if bare.starts_with('│') {
+                assert!(
+                    bare.ends_with('│'),
+                    "content line must end with │: {bare:?}"
+                );
+            }
+        }
+        colored::control::unset_override();
+    }
+
+    /// Very narrow terminal (< MIN_WIDTH_BOX) returns None.
+    #[test]
+    fn two_panel_narrow_fallback() {
+        let data = base_data();
+        assert!(
+            render_two_panel_banner(&data, MIN_WIDTH_BOX - 1, false).is_none(),
+            "very narrow terminal must return None"
+        );
+    }
+
+    /// Terminals narrower than MIN_WIDTH_TWO_PANEL but ≥ MIN_WIDTH_BOX get a stacked box.
+    #[test]
+    fn two_panel_stacked_on_medium_width() {
+        let data = base_data();
+        let result = render_two_panel_banner(&data, 80, false);
+        assert!(
+            result.is_some(),
+            "80-col terminal must produce a stacked box (not None)"
+        );
+    }
+
+    /// At the wide-mode threshold boundary, no panic.
     #[test]
     fn two_panel_at_threshold_boundary() {
         let data = base_data();
-        // MIN_WIDTH_TWO_PANEL - 1 → fallback.
-        assert!(render_two_panel_banner(&data, MIN_WIDTH_TWO_PANEL - 1, false).is_none());
-        // At MIN_WIDTH_TWO_PANEL → two-panel (if right panel is wide enough).
-        // (May still return None if right panel < 10; just assert no panic.)
+        let _ = render_two_panel_banner(&data, MIN_WIDTH_TWO_PANEL - 1, false);
         let _ = render_two_panel_banner(&data, MIN_WIDTH_TWO_PANEL, false);
     }
 
-    /// Version string must appear in the left panel.
+    /// Version string must appear in the output (in the title bar).
     #[test]
     fn two_panel_version_present() {
+        colored::control::set_override(false);
         let data = base_data();
         let out = render_two_panel_banner(&data, 120, false).expect("two-panel");
         let bare = strip_ansi(&out);
         assert!(
             bare.contains(env!("CARGO_PKG_VERSION")),
-            "version must appear in left panel: {bare}"
+            "version must appear in banner: {bare:.100}"
         );
+        colored::control::unset_override();
     }
 
-    /// Reconnecting state shows the reconnecting indicator in the left panel.
+    /// Reconnecting state shows the reconnecting label in the wide layout.
     #[test]
     fn two_panel_reconnecting_shows_indicator() {
+        colored::control::set_override(false);
         let data = reconnect_data();
         let out = render_two_panel_banner(&data, 120, true).expect("two-panel");
         let bare = strip_ansi(&out);
         assert!(
-            bare.contains("reconnecting"),
-            "reconnecting indicator must appear: {bare}"
+            bare.contains("Reconnecting..."),
+            "reconnecting indicator must appear: {bare:.200}"
+        );
+        colored::control::unset_override();
+    }
+
+    /// ROBOT_GRADIENT has an entry for every row of the original BANNER_ROBOT.
+    #[test]
+    fn robot_gradient_matches_original_row_count() {
+        use super::super::ROBOT_GRADIENT;
+        assert_eq!(
+            ROBOT_GRADIENT.len(),
+            BANNER_ROBOT.len(),
+            "ROBOT_GRADIENT length must match BANNER_ROBOT row count"
         );
     }
 

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
@@ -11,7 +11,7 @@
 //! backward-compat `info_box_renders_*` in the inline tests below.
 
 mod probes;
-mod render;
+pub(crate) mod render;
 
 use std::path::Path;
 use std::time::Duration;
@@ -295,6 +295,20 @@ fn read_lock_addr() -> Option<String> {
     }
     let _ = pid;
     addr
+}
+
+// ── Two-panel compositor bridge ───────────────────────────────────────────────
+
+/// Return the welcome-panel content rows without drawing a box frame.
+///
+/// Why: the two-panel banner compositor (`banner::two_panel`) needs the raw
+/// row strings to fill the right panel at the compositor-determined width,
+/// without the fixed-width `╭─╮` box that `render_welcome_panel` draws.
+/// What: delegates to `render::build_rows(data)` — the same row builder used
+/// by `render_welcome_panel`, so content is identical in both layouts.
+/// Test: `two_panel_compose_alignment` in `banner::two_panel::tests`.
+pub(crate) fn render_info_box_rows(data: &WelcomeData) -> Vec<String> {
+    render::build_rows(data)
 }
 
 // ── Backward-compat render wrapper ────────────────────────────────────────────

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
@@ -205,26 +205,6 @@ pub(crate) fn print_welcome_panel(
     std::thread::sleep(Duration::from_secs(1));
 }
 
-/// Print the welcome panel to stdout and flush — without the 1-second sleep.
-///
-/// Why: `tm banner` preview renders the same panel as the launch path but
-/// must exit immediately so the operator can iterate quickly. Factoring out
-/// the no-sleep variant avoids duplicating the gather+render logic and keeps
-/// the sleep strictly inside `print_welcome_panel` (the launch path).
-/// What: calls `gather_welcome_data` + `render_welcome_panel`, prints to
-/// stdout, flushes, and returns — no sleep.
-/// Test: `banner_preview_does_not_panic` in `tests.rs`.
-pub(crate) fn print_welcome_panel_no_sleep(
-    workdir: &str,
-    session_name: &str,
-    reconnecting: bool,
-    daemon: DaemonInfo,
-) {
-    let data = gather_welcome_data(workdir, session_name, reconnecting, daemon);
-    print!("{}", render::render_welcome_panel(&data));
-    let _ = std::io::Write::flush(&mut std::io::stdout());
-}
-
 /// Backward-compatible alias — calls `print_welcome_panel`.
 ///
 /// Why: existing call sites in `launch.rs` and `guided.rs` use `print_info_box`;

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/render.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/render.rs
@@ -54,11 +54,13 @@ pub(crate) fn render_welcome_panel(data: &WelcomeData) -> String {
 /// Build all right-column rows for the welcome panel.
 ///
 /// Why: separating row construction from box-drawing keeps each part small
-/// and independently testable.
+/// and independently testable. Also consumed by the two-panel compositor
+/// (`banner::two_panel`) to populate the right panel without re-implementing
+/// the row-building logic.
 /// What: returns rows in display order: header, project/workspace, optional
 /// reconnecting, optional commit section, service section, commands section.
-/// Test: covered by `render_welcome_panel` tests.
-fn build_rows(data: &WelcomeData) -> Vec<String> {
+/// Test: covered by `render_welcome_panel` tests; `two_panel_compose_alignment`.
+pub(crate) fn build_rows(data: &WelcomeData) -> Vec<String> {
     let version = env!("CARGO_PKG_VERSION");
     let workspace = super::abbreviate_home(&data.workspace);
 

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1687,6 +1687,45 @@ fn robot_splash_gradient_rows_present() {
 }
 
 #[test]
+fn narrow_fallback_reconnect_splash_includes_reconnecting_text() {
+    // Why: `print_launch_banner_reconnecting` narrow fallback must pass
+    // `reconnecting=true` to `render_robot_splash` so the "Reconnecting..."
+    // label appears in the robot splash — matching the wide two-panel path
+    // where reconnect state shows in both panels.  Before the fix this branch
+    // incorrectly passed `false`, silently dropping the reconnect label.
+    // What: render the splash with reconnecting=true and assert the label is
+    // present; also confirm screen-clear is still there.
+    // Test: pure string assertion, no I/O side-effects.
+    colored::control::set_override(false);
+    let splash = render_robot_splash(true);
+    assert!(
+        splash.starts_with("\x1B[2J\x1B[1;1H"),
+        "narrow reconnect splash must still clear the screen"
+    );
+    assert!(
+        splash.contains("Reconnecting..."),
+        "narrow reconnect splash must contain 'Reconnecting...' label"
+    );
+    colored::control::unset_override();
+}
+
+#[test]
+fn narrow_fallback_launch_splash_does_not_include_reconnecting_text() {
+    // Why: the narrow launch path (non-reconnecting) must NOT show
+    // "Reconnecting..." in the robot splash — only the info panel below it
+    // shows launch context.
+    // What: render with reconnecting=false and confirm the label is absent.
+    // Test: pure string assertion.
+    colored::control::set_override(false);
+    let splash = render_robot_splash(false);
+    assert!(
+        !splash.contains("Reconnecting..."),
+        "normal launch splash must not contain 'Reconnecting...' label"
+    );
+    colored::control::unset_override();
+}
+
+#[test]
 fn cli_parses_banner() {
     // Why: `tm banner` must parse and default `--reconnecting` to false.
     // What: parse "banner" and assert the variant and flag are correct.

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -16,8 +16,7 @@ use crate::cli::{
 };
 use crate::formatters::banner::{
     BANNER_ROBOT, colorize_robot_row, fallback_session_name, normalize_workdir,
-    print_launch_banner, print_launch_banner_reconnecting, render_launch_banner,
-    render_robot_splash, terminal_width, wordmark_lines,
+    print_launch_banner, print_launch_banner_reconnecting, terminal_width,
 };
 use crate::formatters::session::short_id;
 
@@ -311,44 +310,64 @@ fn terminal_width_is_positive() {
 }
 
 #[test]
-fn launch_banner_contains_session_fields() {
-    // Why: the banner is the operator's only summary of what was wired up;
-    // the project, session, and prompt fields must all appear, the screen
-    // must be cleared, and the launch action line must be present.
-    let banner = render_launch_banner(
-        "/Users/test/project",
-        "tmpm-quiet-falcon",
-        Some(std::path::Path::new("/tmp/INSTRUCTIONS.md")),
-        None,
-    );
-    assert!(banner.starts_with("\x1B[2J\x1B[1;1H"), "screen not cleared");
-    assert!(banner.contains("/Users/test/project"));
-    assert!(banner.contains("tmpm-quiet-falcon"));
-    assert!(banner.contains("/tmp/INSTRUCTIONS.md"));
-    assert!(banner.contains("Launching claude..."));
-    // Plain-text wordmark: "trusty-mpm" (lowercase) replaces the old block-art.
+fn banner_title_bar_contains_version() {
+    // Why: the single-box banner embeds the crate version in the title bar;
+    // this ensures the version is always visible to the operator at a glance.
+    use crate::formatters::banner::two_panel::{render_two_panel_banner, strip_ansi};
+    use crate::formatters::info_box::{DaemonInfo, WelcomeData};
+    colored::control::set_override(false);
+    let data = WelcomeData {
+        project: "my-project".to_string(),
+        workspace: "/Users/test/project".to_string(),
+        user: "operator".to_string(),
+        reconnecting: false,
+        session_name: "tmpm-my-project".to_string(),
+        daemon: DaemonInfo::default(),
+        recent_commits: vec![],
+        memory_status: "(not detected)".to_string(),
+        search_status: "(not detected)".to_string(),
+        review_status: "(not detected)".to_string(),
+    };
+    let out = render_two_panel_banner(&data, 120, false).expect("wide banner");
+    let first_line = out.lines().next().unwrap_or("");
+    let bare = strip_ansi(first_line);
     assert!(
-        banner.contains("trusty-mpm"),
-        "plain-text wordmark must appear in banner"
+        bare.contains(env!("CARGO_PKG_VERSION")),
+        "title bar must contain CARGO_PKG_VERSION: {bare:?}"
     );
+    assert!(
+        bare.starts_with('╭'),
+        "title bar must start with outer box corner ╭: {bare:?}"
+    );
+    colored::control::unset_override();
 }
 
 #[test]
-fn launch_banner_marks_reconnect() {
-    // Why: a reconnecting launch must not claim it started a new session;
-    // the banner must show a Status row and the "Reconnecting..." action.
-    let banner = render_launch_banner(
-        "/Users/test/project",
-        "tmpm-quiet-falcon",
-        None,
-        Some("tmpm-quiet-falcon"),
-    );
-    assert!(banner.contains("reconnecting to existing session"));
-    assert!(banner.contains("Reconnecting..."));
+fn banner_reconnect_label_in_wide_mode() {
+    // Why: the reconnect label in the wide single-box banner must say
+    // "Reconnecting..." so the operator knows no new session was started.
+    use crate::formatters::banner::two_panel::{render_two_panel_banner, strip_ansi};
+    use crate::formatters::info_box::{DaemonInfo, WelcomeData};
+    colored::control::set_override(false);
+    let data = WelcomeData {
+        project: "my-project".to_string(),
+        workspace: "/Users/test/project".to_string(),
+        user: "operator".to_string(),
+        reconnecting: true,
+        session_name: "tmpm-quiet-falcon".to_string(),
+        daemon: DaemonInfo::default(),
+        recent_commits: vec![],
+        memory_status: "(not detected)".to_string(),
+        search_status: "(not detected)".to_string(),
+        review_status: "(not detected)".to_string(),
+    };
+    let out = render_two_panel_banner(&data, 120, true).expect("wide reconnect banner");
+    let bare = strip_ansi(&out);
     assert!(
-        !banner.contains("Launching claude..."),
-        "reconnect banner must not claim a fresh launch"
+        bare.contains("Reconnecting..."),
+        "wide reconnect banner must contain 'Reconnecting...': {bare:.200}"
     );
+    colored::control::unset_override();
 }
 
 #[test]
@@ -1642,85 +1661,66 @@ fn robot_row_colorize_preserves_text() {
 }
 
 #[test]
-fn robot_splash_contains_robot_and_title() {
-    // Why: `render_robot_splash` is the pure renderer used by the print functions;
-    // it must include both the screen-clear escape and the plain-text wordmark.
-    // What: render the splash (no reconnecting flag), assert key structural markers.
-    // Test: call with reconnecting=false to get the normal launch splash.
+fn narrow_fallback_reconnect_box_includes_reconnecting_text() {
+    // Why: the single-box narrow fallback (< MIN_WIDTH_TWO_PANEL) must include
+    // "Reconnecting..." when reconnecting=true — matching the wide layout's
+    // reconnect indicator. This verifies the fix from commit 54690868 is
+    // preserved under the new single-box design.
+    // What: render via `render_two_panel_banner` with a narrow width and
+    // reconnecting=true; assert the label appears.
+    // Test: pure string assertion via the public compositor.
+    use crate::formatters::banner::two_panel::{render_two_panel_banner, strip_ansi};
+    use crate::formatters::info_box::{DaemonInfo, WelcomeData};
     colored::control::set_override(false);
-    let splash = render_robot_splash(false);
+    let data = WelcomeData {
+        project: "my-project".to_string(),
+        workspace: "/tmp/my-project".to_string(),
+        user: String::new(),
+        reconnecting: true,
+        session_name: "tmpm-my-project".to_string(),
+        daemon: DaemonInfo::default(),
+        recent_commits: vec![],
+        memory_status: "(not detected)".to_string(),
+        search_status: "(not detected)".to_string(),
+        review_status: "(not detected)".to_string(),
+    };
+    // 80-col: narrow stacked box.
+    let out = render_two_panel_banner(&data, 80, true).expect("narrow box");
+    let bare = strip_ansi(&out);
     assert!(
-        splash.starts_with("\x1B[2J\x1B[1;1H"),
-        "splash must start with screen-clear: {splash:?}"
+        bare.contains("Reconnecting..."),
+        "narrow reconnect box must contain 'Reconnecting...' label"
     );
-    // Plain-text "trusty-mpm" label replaces the old block-art BANNER_TITLE.
-    assert!(
-        splash.contains("trusty-mpm"),
-        "plain-text wordmark 'trusty-mpm' must be in splash"
-    );
-    // Version string must follow on the next line.
-    assert!(
-        splash.contains(env!("CARGO_PKG_VERSION")),
-        "version must appear in splash"
-    );
+    // Also verify the outer box is intact.
+    let first = bare.lines().next().unwrap_or("");
+    assert!(first.starts_with('╭'), "must have outer box top border");
     colored::control::unset_override();
 }
 
 #[test]
-fn robot_splash_gradient_rows_present() {
-    // Why: every row of the robot art must appear in the splash output (colorized
-    // or plain); if a row is accidentally skipped the art breaks visually.
-    // What: with color disabled (so no escape-sequence confusion), assert each
-    // BANNER_ROBOT row's trimmed content appears in the splash output.
+fn narrow_fallback_normal_box_does_not_include_reconnecting_text() {
+    // Why: normal launch (reconnecting=false) narrow box must NOT show
+    // "Reconnecting..." — the operator should see the launch context only.
+    use crate::formatters::banner::two_panel::{render_two_panel_banner, strip_ansi};
+    use crate::formatters::info_box::{DaemonInfo, WelcomeData};
     colored::control::set_override(false);
-    let splash = render_robot_splash(false);
-    for (i, row) in BANNER_ROBOT.iter().enumerate() {
-        let trimmed = row.trim();
-        if !trimmed.is_empty() {
-            assert!(
-                splash.contains(trimmed),
-                "robot row {i} trimmed content missing from splash: {trimmed:?}"
-            );
-        }
-    }
-    colored::control::unset_override();
-}
-
-#[test]
-fn narrow_fallback_reconnect_splash_includes_reconnecting_text() {
-    // Why: `print_launch_banner_reconnecting` narrow fallback must pass
-    // `reconnecting=true` to `render_robot_splash` so the "Reconnecting..."
-    // label appears in the robot splash — matching the wide two-panel path
-    // where reconnect state shows in both panels.  Before the fix this branch
-    // incorrectly passed `false`, silently dropping the reconnect label.
-    // What: render the splash with reconnecting=true and assert the label is
-    // present; also confirm screen-clear is still there.
-    // Test: pure string assertion, no I/O side-effects.
-    colored::control::set_override(false);
-    let splash = render_robot_splash(true);
+    let data = WelcomeData {
+        project: "my-project".to_string(),
+        workspace: "/tmp/my-project".to_string(),
+        user: String::new(),
+        reconnecting: false,
+        session_name: String::new(),
+        daemon: DaemonInfo::default(),
+        recent_commits: vec![],
+        memory_status: "(not detected)".to_string(),
+        search_status: "(not detected)".to_string(),
+        review_status: "(not detected)".to_string(),
+    };
+    let out = render_two_panel_banner(&data, 80, false).expect("narrow box");
+    let bare = strip_ansi(&out);
     assert!(
-        splash.starts_with("\x1B[2J\x1B[1;1H"),
-        "narrow reconnect splash must still clear the screen"
-    );
-    assert!(
-        splash.contains("Reconnecting..."),
-        "narrow reconnect splash must contain 'Reconnecting...' label"
-    );
-    colored::control::unset_override();
-}
-
-#[test]
-fn narrow_fallback_launch_splash_does_not_include_reconnecting_text() {
-    // Why: the narrow launch path (non-reconnecting) must NOT show
-    // "Reconnecting..." in the robot splash — only the info panel below it
-    // shows launch context.
-    // What: render with reconnecting=false and confirm the label is absent.
-    // Test: pure string assertion.
-    colored::control::set_override(false);
-    let splash = render_robot_splash(false);
-    assert!(
-        !splash.contains("Reconnecting..."),
-        "normal launch splash must not contain 'Reconnecting...' label"
+        !bare.contains("Reconnecting..."),
+        "normal launch narrow box must not contain 'Reconnecting...' label"
     );
     colored::control::unset_override();
 }
@@ -1761,41 +1761,38 @@ fn cli_parses_banner_reconnecting() {
 
 #[test]
 fn banner_preview_no_clear_escape() {
-    // Why: `render_robot_splash_no_clear` must NOT begin with the full-screen
-    // clear sequence — that would wipe the user's scrollback during a preview.
-    // What: call the no-clear variant and assert the `\x1B[2J\x1B[1;1H` prefix
-    // is absent, while the plain-text wordmark is still present.
-    // Test: direct string assertion.
+    // Why: the `tm banner` preview must NOT begin with the full-screen clear
+    // sequence — that would wipe the user's scrollback.
+    // What: capture whether the print_banner_preview output starts with the
+    // clear escape. Since it writes to stdout, we verify indirectly via the
+    // single-box compositor which is used for the preview path.
+    use crate::formatters::banner::two_panel::{render_two_panel_banner, strip_ansi};
+    use crate::formatters::info_box::{DaemonInfo, WelcomeData};
     colored::control::set_override(false);
-    let splash = crate::formatters::banner::render_robot_splash_no_clear(false);
+    let data = WelcomeData {
+        project: "p".to_string(),
+        workspace: "/tmp/p".to_string(),
+        user: String::new(),
+        reconnecting: false,
+        session_name: String::new(),
+        daemon: DaemonInfo::default(),
+        recent_commits: vec![],
+        memory_status: "(not detected)".to_string(),
+        search_status: "(not detected)".to_string(),
+        review_status: "(not detected)".to_string(),
+    };
+    let out = render_two_panel_banner(&data, 120, false).expect("banner");
+    // The compositor never emits a screen-clear — that is added by the print
+    // wrappers only, and only for the launch (not preview) path.
     assert!(
-        !splash.starts_with("\x1B[2J\x1B[1;1H"),
-        "no-clear variant must not contain the screen-clear escape"
+        !out.starts_with("\x1B[2J"),
+        "compositor output must not start with screen-clear escape"
     );
-    // Plain-text "trusty-mpm" label replaces the old block-art.
+    // Version appears in the title bar.
+    let bare = strip_ansi(&out);
     assert!(
-        splash.contains("trusty-mpm"),
-        "plain-text wordmark 'trusty-mpm' must still appear in no-clear variant"
-    );
-    colored::control::unset_override();
-}
-
-#[test]
-fn wordmark_lines_contain_trusty_and_version() {
-    // Why: `wordmark_lines` is the single source of truth for the banner label
-    // and version; asserting both values here catches accidental regressions.
-    // What: with colour disabled so the output is plain text, verify that line 0
-    // contains "trusty-mpm" and line 1 contains the crate version.
-    // Test: direct function call with colour override off.
-    colored::control::set_override(false);
-    let [label, version] = wordmark_lines();
-    assert!(
-        label.contains("trusty-mpm"),
-        "wordmark label must contain 'trusty-mpm': {label:?}"
-    );
-    assert!(
-        version.contains(env!("CARGO_PKG_VERSION")),
-        "wordmark version line must contain the crate version: {version:?}"
+        bare.contains(env!("CARGO_PKG_VERSION")),
+        "compositor output must contain version in title bar"
     );
     colored::control::unset_override();
 }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -17,7 +17,7 @@ use crate::cli::{
 use crate::formatters::banner::{
     BANNER_ROBOT, colorize_robot_row, fallback_session_name, normalize_workdir,
     print_launch_banner, print_launch_banner_reconnecting, render_launch_banner,
-    render_robot_splash, terminal_width,
+    render_robot_splash, terminal_width, wordmark_lines,
 };
 use crate::formatters::session::short_id;
 
@@ -326,7 +326,11 @@ fn launch_banner_contains_session_fields() {
     assert!(banner.contains("tmpm-quiet-falcon"));
     assert!(banner.contains("/tmp/INSTRUCTIONS.md"));
     assert!(banner.contains("Launching claude..."));
-    assert!(banner.contains("TRUSTY") || banner.contains("M U L T I"));
+    // Plain-text wordmark: "trusty" (lowercase) replaces the old block-art.
+    assert!(
+        banner.contains("trusty"),
+        "plain-text wordmark must appear in banner"
+    );
 }
 
 #[test]
@@ -1640,19 +1644,26 @@ fn robot_row_colorize_preserves_text() {
 #[test]
 fn robot_splash_contains_robot_and_title() {
     // Why: `render_robot_splash` is the pure renderer used by the print functions;
-    // it must include both the screen-clear escape and the TRUSTY wordmark.
+    // it must include both the screen-clear escape and the plain-text wordmark.
     // What: render the splash (no reconnecting flag), assert key structural markers.
     // Test: call with reconnecting=false to get the normal launch splash.
+    colored::control::set_override(false);
     let splash = render_robot_splash(false);
     assert!(
         splash.starts_with("\x1B[2J\x1B[1;1H"),
         "splash must start with screen-clear: {splash:?}"
     );
-    // TRUSTY title block must appear (any row from BANNER_TITLE).
+    // Plain-text "trusty" label replaces the old block-art BANNER_TITLE.
     assert!(
-        splash.contains("M U L T I - A G E N T"),
-        "TRUSTY wordmark must be in splash"
+        splash.contains("trusty"),
+        "plain-text wordmark 'trusty' must be in splash"
     );
+    // Version string must follow on the next line.
+    assert!(
+        splash.contains(env!("CARGO_PKG_VERSION")),
+        "version must appear in splash"
+    );
+    colored::control::unset_override();
 }
 
 #[test]
@@ -1714,7 +1725,7 @@ fn banner_preview_no_clear_escape() {
     // Why: `render_robot_splash_no_clear` must NOT begin with the full-screen
     // clear sequence — that would wipe the user's scrollback during a preview.
     // What: call the no-clear variant and assert the `\x1B[2J\x1B[1;1H` prefix
-    // is absent, while the TRUSTY wordmark is still present.
+    // is absent, while the plain-text wordmark is still present.
     // Test: direct string assertion.
     colored::control::set_override(false);
     let splash = crate::formatters::banner::render_robot_splash_no_clear(false);
@@ -1722,9 +1733,30 @@ fn banner_preview_no_clear_escape() {
         !splash.starts_with("\x1B[2J\x1B[1;1H"),
         "no-clear variant must not contain the screen-clear escape"
     );
+    // Plain-text "trusty" label replaces the old block-art.
     assert!(
-        splash.contains("M U L T I - A G E N T"),
-        "TRUSTY wordmark must still appear in no-clear variant"
+        splash.contains("trusty"),
+        "plain-text wordmark 'trusty' must still appear in no-clear variant"
+    );
+    colored::control::unset_override();
+}
+
+#[test]
+fn wordmark_lines_contain_trusty_and_version() {
+    // Why: `wordmark_lines` is the single source of truth for the banner label
+    // and version; asserting both values here catches accidental regressions.
+    // What: with colour disabled so the output is plain text, verify that line 0
+    // contains "trusty" and line 1 contains the crate version.
+    // Test: direct function call with colour override off.
+    colored::control::set_override(false);
+    let [label, version] = wordmark_lines();
+    assert!(
+        label.contains("trusty"),
+        "wordmark label must contain 'trusty': {label:?}"
+    );
+    assert!(
+        version.contains(env!("CARGO_PKG_VERSION")),
+        "wordmark version line must contain the crate version: {version:?}"
     );
     colored::control::unset_override();
 }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -15,8 +15,8 @@ use crate::cli::{
     TelegramCmd,
 };
 use crate::formatters::banner::{
-    BANNER_ROBOT, colorize_robot_row, fallback_session_name, normalize_workdir,
-    print_launch_banner, print_launch_banner_reconnecting, terminal_width,
+    IMAGE_CLIP_COLS, IMAGE_CLIP_ROWS, clip_and_shade_image, fallback_session_name,
+    normalize_workdir, print_launch_banner, print_launch_banner_reconnecting, terminal_width,
 };
 use crate::formatters::session::short_id;
 
@@ -1588,76 +1588,51 @@ fn cli_parses_login_standalone() {
     assert!(matches!(cli.command.unwrap(), Command::Login { .. }));
 }
 
-// ── Robot-banner color tests ──────────────────────────────────────────────────
+// ── Image-banner color tests ──────────────────────────────────────────────────
 
 #[test]
-fn robot_gradient_has_correct_length() {
-    // Why: ROBOT_GRADIENT is index-accessed by row count; if it shrinks below
-    // BANNER_ROBOT.len() the `.min()` clamp silently applies the wrong color.
-    // The gradient is defined as a fixed 27-element array matching the 27-row
-    // robot art — assert both agree.
-    assert_eq!(
-        crate::formatters::banner::BANNER_ROBOT.len(),
-        27,
-        "BANNER_ROBOT must have 27 rows"
+fn image_clip_has_correct_dimensions() {
+    // Why: IMAGE_CLIP_ROWS/IMAGE_CLIP_COLS are the authoritative dimensions;
+    // if the clip constants drift from the art, the left column will be mis-sized.
+    // What: assert the clipped image matches the expected row and column counts.
+    // Test: direct call to clip_and_shade_image.
+    let lines = clip_and_shade_image();
+    assert_eq!(lines.len(), IMAGE_CLIP_ROWS, "clipped image row count");
+    // Verify the clip width constant is in the expected range for the left column.
+    const { assert!(IMAGE_CLIP_COLS >= 48) };
+    const { assert!(IMAGE_CLIP_COLS <= 56) };
+}
+
+#[test]
+fn art_char_shading_emits_truecolor() {
+    // Why: clip_and_shade_image emits raw ANSI truecolor escapes directly for
+    // non-space art chars so the image always renders with the rust/amber palette
+    // on 24-bit terminals — no color-override needed and no race with parallel tests.
+    // What: call clip_and_shade_image and verify at least one line contains a
+    // truecolor ANSI escape (`\x1B[38;2;`).
+    // Test: no colored::control manipulation; escapes are always emitted.
+    let lines = clip_and_shade_image();
+    let any_colored = lines.iter().any(|l| l.contains("\x1B[38;2;"));
+    assert!(
+        any_colored,
+        "clipped image must always emit truecolor escapes for non-space chars"
     );
 }
 
 #[test]
-fn robot_row_colorize_uses_truecolor_api() {
-    // Why: the rust-gradient colorizer must call the truecolor API so that when
-    // a terminal supports 24-bit color the robot renders with the rust-gradient
-    // palette. We verify the underlying API call produces truecolor escapes by
-    // directly calling colored::Colorize::truecolor with a known color and
-    // confirming the ANSI code format — without relying on global color state.
-    // What: call `colored` directly (force-enabled) with a known truecolor value
-    // and assert the escape sequence encodes R;G;B correctly.
-    // Test: uses `colored::control::SHOULD_COLORIZE` via `force_output_color` to
-    // isolate from environment TTY detection.
-    use colored::Colorize as _;
-    // We call `.truecolor(183, 65, 14)` and check the encoded RGB values appear
-    // in the output under any color mode. The format is `\x1b[38;2;183;65;14m`.
-    // Since we cannot guarantee a TTY in tests, use `colored::control::set_override`
-    // only to read back the color-enabled form, then restore.
-    // Force-enabled by calling set_override and doing the colorize call.
-    colored::control::set_override(true);
-    let colored_text = "test".truecolor(183, 65, 14).to_string();
-    colored::control::unset_override();
-    // Check that the call produces the expected truecolor escape format.
+fn art_shading_spaces_are_uncolored() {
+    // Why: spaces in the art should be transparent (no color escape), so
+    // the terminal background shows through rather than applying a tint.
+    // What: verify that space chars in clipped image lines have no escape prefix.
+    // Test: check that strip_ansi still finds spaces in the output.
+    use crate::formatters::banner::two_panel::strip_ansi;
+    let lines = clip_and_shade_image();
+    // Find a line with at least one space and verify the bare text still has spaces.
+    let has_space = lines.iter().any(|l| strip_ansi(l).contains(' '));
     assert!(
-        colored_text.contains("183"),
-        "truecolor R component 183 must appear in escape: {colored_text:?}"
+        has_space,
+        "clipped image must contain some uncolored spaces"
     );
-    assert!(
-        colored_text.contains("65"),
-        "truecolor G component 65 must appear in escape: {colored_text:?}"
-    );
-    assert!(
-        colored_text.contains("14"),
-        "truecolor B component 14 must appear in escape: {colored_text:?}"
-    );
-}
-
-#[test]
-fn robot_row_colorize_preserves_text() {
-    // Why: the colorize function must not corrupt or drop the robot art text;
-    // operators reading in a no-color terminal must see the full ASCII art.
-    // What: colorize every row (any color state) and verify the trimmed robot
-    // text is present in the result — escapes may or may not appear depending
-    // on the test runner TTY, but the text must always survive.
-    // Test: no color-state mutation; works regardless of parallel test ordering.
-    for (row_idx, line) in BANNER_ROBOT.iter().enumerate() {
-        let result = colorize_robot_row(row_idx, line);
-        // The trimmed robot text (without surrounding spaces) must be present.
-        // For blank rows, trimmed is "", so skip them.
-        let trimmed = line.trim_end();
-        if !trimmed.is_empty() {
-            assert!(
-                result.contains(trimmed),
-                "robot art row {row_idx} text lost in colorize: {result:?}"
-            );
-        }
-    }
 }
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -326,9 +326,9 @@ fn launch_banner_contains_session_fields() {
     assert!(banner.contains("tmpm-quiet-falcon"));
     assert!(banner.contains("/tmp/INSTRUCTIONS.md"));
     assert!(banner.contains("Launching claude..."));
-    // Plain-text wordmark: "trusty" (lowercase) replaces the old block-art.
+    // Plain-text wordmark: "trusty-mpm" (lowercase) replaces the old block-art.
     assert!(
-        banner.contains("trusty"),
+        banner.contains("trusty-mpm"),
         "plain-text wordmark must appear in banner"
     );
 }
@@ -1653,10 +1653,10 @@ fn robot_splash_contains_robot_and_title() {
         splash.starts_with("\x1B[2J\x1B[1;1H"),
         "splash must start with screen-clear: {splash:?}"
     );
-    // Plain-text "trusty" label replaces the old block-art BANNER_TITLE.
+    // Plain-text "trusty-mpm" label replaces the old block-art BANNER_TITLE.
     assert!(
-        splash.contains("trusty"),
-        "plain-text wordmark 'trusty' must be in splash"
+        splash.contains("trusty-mpm"),
+        "plain-text wordmark 'trusty-mpm' must be in splash"
     );
     // Version string must follow on the next line.
     assert!(
@@ -1733,10 +1733,10 @@ fn banner_preview_no_clear_escape() {
         !splash.starts_with("\x1B[2J\x1B[1;1H"),
         "no-clear variant must not contain the screen-clear escape"
     );
-    // Plain-text "trusty" label replaces the old block-art.
+    // Plain-text "trusty-mpm" label replaces the old block-art.
     assert!(
-        splash.contains("trusty"),
-        "plain-text wordmark 'trusty' must still appear in no-clear variant"
+        splash.contains("trusty-mpm"),
+        "plain-text wordmark 'trusty-mpm' must still appear in no-clear variant"
     );
     colored::control::unset_override();
 }
@@ -1746,13 +1746,13 @@ fn wordmark_lines_contain_trusty_and_version() {
     // Why: `wordmark_lines` is the single source of truth for the banner label
     // and version; asserting both values here catches accidental regressions.
     // What: with colour disabled so the output is plain text, verify that line 0
-    // contains "trusty" and line 1 contains the crate version.
+    // contains "trusty-mpm" and line 1 contains the crate version.
     // Test: direct function call with colour override off.
     colored::control::set_override(false);
     let [label, version] = wordmark_lines();
     assert!(
-        label.contains("trusty"),
-        "wordmark label must contain 'trusty': {label:?}"
+        label.contains("trusty-mpm"),
+        "wordmark label must contain 'trusty-mpm': {label:?}"
     );
     assert!(
         version.contains(env!("CARGO_PKG_VERSION")),


### PR DESCRIPTION
## Summary

Follow-up to #1755 — redesigns the `tm launch` / `tm banner` startup banner from a stacked layout to a **two-panel, full-width, natural-height** layout:

- **Full width:** the two panels together span the entire terminal width exactly.
- **Natural height:** banner is only as tall as its content. The taller panel sets the height; the shorter panel's interior is padded with blank rows so both frames close evenly at the same bottom line.
- **LEFT panel** (49 cols incl. frame, ~47 inner): rust-gradient ASCII robot, TRUSTY wordmark, `v{version}` — top-aligned, horizontally centred.
- **RIGHT panel** (remaining width − 1-col gutter): the existing rich welcome info — daemon/service status (memory/search/review ✓/○), session count, recent commits, TM command cheat-sheet, Project/Session/Workspace fields.
- **Border tint:** muted rust `(120, 50, 10)` truecolor; degrades to plain text via `colored`'s NO_COLOR / non-TTY auto-degrade.
- **Graceful narrow fallback:** `COLUMNS < 90` → stacked layout (robot + info box below, unchanged from #1755).
- **Reconnecting state:** shown in both panels simultaneously (left: `↩ reconnecting`; right: session row with `↩ reconnecting (session-name)`).
- **Both entry points updated:** real launch banner (`print_launch_banner` / `print_launch_banner_reconnecting`, with screen-clear) and the `tm banner` preview subcommand (`print_banner_preview`, no clear, no sleep).

## Implementation

- `banner.rs` → `banner/mod.rs` + **new** `banner/two_panel.rs` (301 SLOC)
- `render::build_rows` made `pub(crate)` and re-exported as `info_box::render_info_box_rows` so the two-panel compositor reuses the existing row-building logic without duplication
- All production files well under the 500-SLOC cap (`mod.rs`: 306, `two_panel.rs`: 301)
- Terminal width via existing `terminal_width()` (`libc::TIOCGWINSZ` + `$COLUMNS` fallback); no new dependencies added

## Layout judgment calls

| Decision | Value | Rationale |
|---|---|---|
| Left panel outer width | 49 cols | Robot art is 45 display cols; +2 for frame +2 padding = 49 |
| Gutter | 1 col | Minimal separation; maximises right panel width |
| Narrow fallback threshold | 90 cols | Left panel (49) + gutter (1) + minimum right panel (10) + right frame (2) = 62 min, but 90 gives ~40 cols for right panel which is readable |
| Border tint | `(120, 50, 10)` | Muted dark rust — cohesive with robot gradient but not competing |

## Test plan

- [x] `cargo build -p trusty-mpm` — passes
- [x] `cargo test -p trusty-mpm` — all tests pass (2072+506 tests, 0 failures)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations
- [x] New tests: `two_panel_compose_alignment`, `two_panel_shorter_panel_padded_to_equal_height`, `two_panel_narrow_fallback`, `two_panel_at_threshold_boundary`, `two_panel_version_present`, `two_panel_reconnecting_shows_indicator`, `strip_ansi_removes_color_codes`
- [ ] Visual check: `COLUMNS=120 cargo run -q -p trusty-mpm --bin tm -- banner | cat` (wide, two-panel)
- [ ] Visual check: `COLUMNS=80 cargo run -q -p trusty-mpm --bin tm -- banner | cat` (narrow, stacked fallback)
- [ ] Visual check: `COLUMNS=120 cargo run -q -p trusty-mpm --bin tm -- banner --reconnecting` (reconnecting state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)