### PR TITLE
feat(tm-statusline): add context compaction efficiency segment

### DIFF
--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -165,6 +165,8 @@ chrono.workspace = true
 gray_matter.workspace = true
 walkdir.workspace = true
 dirs.workspace = true
+# Used by statusline/compaction.rs for atomic state-file writes (NamedTempFile::persist).
+tempfile.workspace = true
 sha2.workspace = true
 regex.workspace = true
 jsonwebtoken.workspace = true

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/compaction.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/compaction.rs
@@ -5,14 +5,19 @@
 //! `~/.trusty-mpm/statusline/<session_id>.json` so the statusline can show how
 //! much the last auto-compaction shrank the context window.
 //! What: persists a `CompactionState` (running peak + last compaction record)
-//! keyed by `session_id`. Pure helper functions (`humanize_tokens`,
-//! `update_state`) are side-effect-free and unit-testable without I/O.
+//! keyed by `session_id`. All filesystem I/O runs in a detached thread bounded
+//! by a 100 ms wall-clock timeout so it can never stall the render path. Saves
+//! are skipped on no-op ticks. Atomic writes use `NamedTempFile::persist`.
 //! Test: `humanize_tokens_examples`, `compaction_detection_sequence`,
-//! `state_round_trip`, `graceful_on_missing_fields` in the inline test module.
+//! `state_round_trip`, `rejects_path_traversal_session_id` in inline tests.
 
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
 
 // ── Input types (deserialised from Claude Code stdin) ─────────────────────────
 
@@ -21,10 +26,9 @@ use serde::{Deserialize, Serialize};
 /// Why: exposes both raw token counts (for precise compaction delta) and the
 /// pre-computed percentage (as a fallback when size is unknown).
 /// What: all fields default so older Claude Code versions that omit
-/// `context_window` entirely still parse without error. `current_usage` is
-/// `None` while a compaction is in flight and `Some` once the next API call
-/// completes; we store it as an opaque `serde_json::Value` because we only
-/// test for null-vs-non-null.
+/// `context_window` entirely still parse without error. Extra JSON fields
+/// (e.g. `current_usage`, `total_output_tokens`) are silently ignored because
+/// `deny_unknown_fields` is absent.
 /// Test: `render_statusline_with_context_window` in mod.rs tests.
 #[derive(Debug, Default, Clone, Deserialize)]
 pub(crate) struct ContextWindow {
@@ -34,9 +38,6 @@ pub(crate) struct ContextWindow {
     pub context_window_size: u64,
     #[serde(default)]
     pub used_percentage: f64,
-    /// `None` during compaction; `Some(...)` once the next API round-trip completes.
-    #[serde(default)]
-    pub current_usage: Option<serde_json::Value>,
 }
 
 // ── Persisted state ───────────────────────────────────────────────────────────
@@ -47,16 +48,13 @@ pub(crate) struct ContextWindow {
 /// Why: the statusline binary is invoked fresh on every render tick; this state
 /// file bridges invocations so the segment can show a compaction that happened
 /// several ticks ago.
-/// What: tracks the highest `total_input_tokens` seen (`peak_input_tokens`),
-/// whether the previous tick's `current_usage` was null, and the most recent
-/// compaction record.
+/// What: tracks the highest `total_input_tokens` seen (`peak_input_tokens`)
+/// and the most recent compaction record.
 /// Test: `state_round_trip`.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(crate) struct CompactionState {
     #[serde(default)]
     pub peak_input_tokens: u64,
-    #[serde(default)]
-    pub prev_current_usage_was_null: bool,
     #[serde(default)]
     pub last_compaction: Option<CompactionRecord>,
 }
@@ -93,20 +91,21 @@ pub(crate) fn humanize_tokens(n: u64) -> String {
     }
 }
 
-/// Apply one context-window reading to the mutable `CompactionState`.
+/// Apply one context-window reading to `CompactionState`; returns `true` when
+/// the state was modified and a save is warranted.
 ///
 /// Why: keeping detection logic pure (no I/O) allows exhaustive unit testing
-/// of the heuristic without touching the filesystem.
-/// What: when `cur > 0`, detects a compaction if `cur` has dropped below
-/// 60 % of `peak` AND the absolute drop exceeds 10 000 tokens; on detection,
-/// records the event and resets `peak` to `cur`; otherwise advances `peak`.
-/// The `current_usage_is_null` flag is stored for the next call.
-/// Test: `compaction_detection_sequence`.
-pub(crate) fn update_state(state: &mut CompactionState, cur: u64, current_usage_is_null: bool) {
+/// of the heuristic without touching the filesystem. The `bool` return avoids
+/// unnecessary disk writes on every no-op render tick.
+/// What: when `cur == 0` returns `false` immediately. Otherwise detects a
+/// compaction if `cur` has dropped below 60 % of `peak` AND the absolute drop
+/// exceeds 10 000 tokens; on detection records the event and resets `peak` to
+/// `cur` (returns `true`). Advances `peak` when `cur > peak` (returns `true`).
+/// Returns `false` when nothing changed.
+/// Test: `compaction_detection_sequence`, `zero_cur_returns_false`.
+pub(crate) fn update_state(state: &mut CompactionState, cur: u64) -> bool {
     if cur == 0 {
-        // No usable token info this tick; just record the null flag.
-        state.prev_current_usage_was_null = current_usage_is_null;
-        return;
+        return false;
     }
 
     let peak = state.peak_input_tokens;
@@ -123,15 +122,31 @@ pub(crate) fn update_state(state: &mut CompactionState, cur: u64, current_usage_
                 reclaimed_pct,
             });
             state.peak_input_tokens = cur;
-            state.prev_current_usage_was_null = current_usage_is_null;
-            return;
+            return true;
         }
     }
 
     if cur > state.peak_input_tokens {
         state.peak_input_tokens = cur;
+        return true;
     }
-    state.prev_current_usage_was_null = current_usage_is_null;
+
+    false
+}
+
+/// Return `true` when `s` is a safe session identifier: non-empty and composed
+/// entirely of ASCII alphanumeric characters, underscores, or hyphens.
+///
+/// Why: `session_id` is attacker-influenceable (it comes from Claude Code's
+/// stdin JSON); allowing arbitrary strings in `state_file_path` would expose a
+/// path-traversal vulnerability (`../../.bashrc` or `/tmp/evil`).
+/// What: rejects any `s` that contains `/`, `.`, or any other character outside
+/// `[A-Za-z0-9_-]`; also rejects the empty string.
+/// Test: `rejects_path_traversal_session_id`.
+fn is_valid_session_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
 // ── I/O helpers ───────────────────────────────────────────────────────────────
@@ -150,19 +165,29 @@ pub(crate) fn load_state_from(path: &Path) -> CompactionState {
     .unwrap_or_default()
 }
 
-/// Write `state` to `path`, creating parent directories as needed; silently
-/// discards all errors so a filesystem issue never breaks the statusline.
+/// Write `state` to `path` atomically using a temp-file-then-rename strategy,
+/// creating parent directories as needed; silently discards all errors so a
+/// filesystem issue never breaks the statusline.
 ///
-/// Why: the statusline must never fail or block due to transient I/O problems.
-/// What: `create_dir_all` + atomic `write`; every fallible step uses `.ok()`.
-/// Test: `state_round_trip` (nested-dir variant).
+/// Why: a plain `fs::write` is truncate-then-write; an unclean kill between
+/// those two operations leaves a partial/zero-byte file that silently resets
+/// `peak_input_tokens` and clears `last_compaction` on the next render. The
+/// `NamedTempFile::persist` pattern avoids this: the rename(2) syscall is
+/// atomic on POSIX, so readers always see either the old or the new file.
+/// What: creates a `NamedTempFile` in the same directory as `path` (ensuring
+/// same filesystem for `rename`), writes bytes, then renames to `path`. On any
+/// error the temp file is cleaned up by `NamedTempFile`'s `Drop` impl.
+/// Test: `state_round_trip` (verifies correct round-trip after atomic save).
 pub(crate) fn save_state_to(path: &Path, state: &CompactionState) {
     let _ = (|| -> Option<()> {
-        if let Some(dir) = path.parent() {
-            std::fs::create_dir_all(dir).ok()?;
-        }
+        let dir = path.parent()?;
+        std::fs::create_dir_all(dir).ok()?;
         let bytes = serde_json::to_vec(state).ok()?;
-        std::fs::write(path, bytes).ok()
+        let mut tmp = NamedTempFile::new_in(dir).ok()?;
+        tmp.write_all(&bytes).ok()?;
+        // On failure, PersistError::Drop cleans up the temp file.
+        let _ = tmp.persist(path);
+        Some(())
     })();
 }
 
@@ -183,31 +208,45 @@ pub(crate) fn state_file_path(session_id: &str) -> Option<PathBuf> {
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
-/// Run one compaction-tracking cycle and return the displayable segment string.
+/// Run one compaction-tracking cycle inside a bounded thread and return the
+/// displayable segment string, or `None` on timeout / missing inputs.
 ///
-/// Why: wraps the load/update/save cycle so `render_statusline` stays free of
-/// I/O concerns; every error path degrades gracefully to `None`.
-/// What: returns `None` when `session_id` is empty or `context_window` is
-/// absent; otherwise persists state, then returns either
-/// `"⤵ {before}→{after} ({pct}%)"` (post-compaction) or `"ctx {pct}%"` (live fill).
-/// Test: `graceful_on_missing_fields`; integration via `render_statusline`.
+/// Why: `tm statusline` is on Claude Code's hot render path; a stuck NFS
+/// mount, full disk, or slow credential helper in `load_state_from` /
+/// `save_state_to` would stall every render cycle. The bounded-thread +
+/// `recv_timeout(100 ms)` pattern matches `git_branch` in `mod.rs`.
+/// What: validates `session_id` against `[A-Za-z0-9_-]+` (rejects empty /
+/// path-traversal IDs); then spawns a detached thread that loads state,
+/// conditionally updates + saves (skipped when `cur==0` or state unchanged),
+/// and sends back the rendered segment. The caller waits ≤100 ms.
+/// Test: `graceful_on_missing_fields`, `rejects_path_traversal_session_id`.
 pub(crate) fn compaction_segment(
     session_id: &str,
     context_window: Option<&ContextWindow>,
 ) -> Option<String> {
-    if session_id.is_empty() {
+    if !is_valid_session_id(session_id) {
         return None;
     }
     let cw = context_window?;
-    let cur = cw.total_input_tokens;
     let path = state_file_path(session_id)?;
+    let cur = cw.total_input_tokens;
+    // Clone only what crosses the thread boundary.
+    let cw2 = cw.clone();
 
-    let mut state = load_state_from(&path);
-    let usage_is_null = cw.current_usage.is_none();
-    update_state(&mut state, cur, usage_is_null);
-    save_state_to(&path, &state);
+    let (tx, rx) = mpsc::channel::<Option<String>>();
+    std::thread::spawn(move || {
+        let mut state = load_state_from(&path);
+        if cur > 0 {
+            // update_state returns true only when state actually changed.
+            if update_state(&mut state, cur) {
+                save_state_to(&path, &state);
+            }
+        }
+        // cur==0 → skip update+save; still read+render so last_compaction shows.
+        let _ = tx.send(render_compaction_segment(&state, &cw2));
+    });
 
-    render_compaction_segment(&state, cw)
+    rx.recv_timeout(Duration::from_millis(100)).ok().flatten()
 }
 
 /// Render the compaction segment string from persisted state and context window.
@@ -276,25 +315,30 @@ mod tests {
         let mut state = CompactionState::default();
 
         // Rising context: no compaction
-        update_state(&mut state, 50_000, false);
+        assert!(
+            update_state(&mut state, 50_000),
+            "peak advance must return true"
+        );
         assert_eq!(state.peak_input_tokens, 50_000);
         assert!(state.last_compaction.is_none());
 
-        update_state(&mut state, 100_000, false);
+        assert!(update_state(&mut state, 100_000));
         assert_eq!(state.peak_input_tokens, 100_000);
         assert!(state.last_compaction.is_none());
 
-        update_state(&mut state, 182_000, false);
+        assert!(update_state(&mut state, 182_000));
         assert_eq!(state.peak_input_tokens, 182_000);
         assert!(state.last_compaction.is_none());
 
         // Compaction: drop to 58k (< 60% of 182k = 109.2k, drop = 124k > 10k)
-        update_state(&mut state, 58_000, true);
+        assert!(
+            update_state(&mut state, 58_000),
+            "compaction must return true"
+        );
         assert!(state.last_compaction.is_some());
         let rec = state.last_compaction.as_ref().unwrap();
         assert_eq!(rec.before, 182_000);
         assert_eq!(rec.after, 58_000);
-        // reclaimed ≈ 68.13 %
         assert!(
             (rec.reclaimed_pct - 68.13).abs() < 0.1,
             "reclaimed_pct = {}",
@@ -303,7 +347,7 @@ mod tests {
         assert_eq!(state.peak_input_tokens, 58_000);
 
         // Resumes growing: compaction record retained, peak advances
-        update_state(&mut state, 60_000, false);
+        assert!(update_state(&mut state, 60_000));
         assert_eq!(state.peak_input_tokens, 60_000);
         assert!(state.last_compaction.is_some());
     }
@@ -311,29 +355,87 @@ mod tests {
     #[test]
     fn small_drop_not_detected_as_compaction() {
         let mut state = CompactionState::default();
-        update_state(&mut state, 100_000, false);
-        // Drop only 5 k — below 10 k absolute threshold
-        update_state(&mut state, 95_000, false);
+        update_state(&mut state, 100_000);
+        // Drop only 5 k — below 10 k absolute threshold → no change
+        let changed = update_state(&mut state, 95_000);
+        assert!(
+            !changed,
+            "sub-threshold drop must not be detected as compaction"
+        );
         assert!(state.last_compaction.is_none());
     }
 
     #[test]
     fn moderate_drop_ratio_above_threshold_not_detected() {
         let mut state = CompactionState::default();
-        update_state(&mut state, 100_000, false);
+        update_state(&mut state, 100_000);
         // 70 % of peak → ratio 0.7 > 0.6, not detected
-        update_state(&mut state, 70_000, false);
+        let changed = update_state(&mut state, 70_000);
+        assert!(!changed, "above-ratio drop must not be detected");
         assert!(state.last_compaction.is_none());
     }
 
     #[test]
-    fn zero_cur_skips_peak_update() {
+    fn zero_cur_returns_false() {
         let mut state = CompactionState::default();
-        update_state(&mut state, 100_000, false);
-        update_state(&mut state, 0, true); // cur=0 → skip update, record null flag
-        assert_eq!(state.peak_input_tokens, 100_000);
+        update_state(&mut state, 100_000);
+        let changed = update_state(&mut state, 0); // cur=0 → no-op
+        assert!(!changed, "cur=0 must return false (no save needed)");
+        assert_eq!(state.peak_input_tokens, 100_000, "peak must be unchanged");
         assert!(state.last_compaction.is_none());
-        assert!(state.prev_current_usage_was_null);
+    }
+
+    #[test]
+    fn unchanged_state_returns_false() {
+        let mut state = CompactionState::default();
+        update_state(&mut state, 100_000);
+        // Same value as current peak → no change
+        let changed = update_state(&mut state, 100_000);
+        assert!(!changed, "cur == peak must return false");
+        // Slightly below peak but above 60% and below 10k drop → no change
+        let changed2 = update_state(&mut state, 95_000);
+        assert!(!changed2, "small drop must return false");
+    }
+
+    // ── session_id validation ─────────────────────────────────────────────────
+
+    #[test]
+    fn valid_session_id_accepted() {
+        assert!(is_valid_session_id("abc-123_XYZ"));
+        assert!(is_valid_session_id("a"));
+        assert!(is_valid_session_id("session-id-with-dashes"));
+        assert!(is_valid_session_id("ABC0123456789"));
+    }
+
+    #[test]
+    fn rejects_path_traversal_session_id() {
+        // None of these should pass validation; compaction_segment returns None
+        // immediately without any filesystem access.
+        for bad in &[
+            "../../evil",
+            "../evil",
+            "/tmp/evil",
+            "evil/subdir",
+            "evil.json",
+            "",
+            "has space",
+            "has\nnewline",
+        ] {
+            assert!(
+                !is_valid_session_id(bad),
+                "expected validation failure for: {bad:?}"
+            );
+            // Verify no file access: compaction_segment must return None
+            let cw = ContextWindow {
+                total_input_tokens: 100_000,
+                context_window_size: 200_000,
+                ..Default::default()
+            };
+            assert!(
+                compaction_segment(bad, Some(&cw)).is_none(),
+                "compaction_segment must return None for bad id: {bad:?}"
+            );
+        }
     }
 
     // ── State file I/O ────────────────────────────────────────────────────────
@@ -348,10 +450,9 @@ mod tests {
         assert_eq!(loaded.peak_input_tokens, 0);
         assert!(loaded.last_compaction.is_none());
 
-        // Write and read back
+        // Write (atomically) and read back
         let state = CompactionState {
             peak_input_tokens: 182_000,
-            prev_current_usage_was_null: false,
             last_compaction: Some(CompactionRecord {
                 before: 182_000,
                 after: 58_000,
@@ -384,7 +485,6 @@ mod tests {
     fn render_segment_after_compaction() {
         let state = CompactionState {
             peak_input_tokens: 58_000,
-            prev_current_usage_was_null: false,
             last_compaction: Some(CompactionRecord {
                 before: 182_000,
                 after: 58_000,
@@ -395,7 +495,6 @@ mod tests {
             total_input_tokens: 60_000,
             context_window_size: 200_000,
             used_percentage: 30.0,
-            ..Default::default()
         };
         let seg = render_compaction_segment(&state, &cw).unwrap();
         assert!(seg.contains("182k"), "got: {seg}");
@@ -412,7 +511,6 @@ mod tests {
             total_input_tokens: 82_000,
             context_window_size: 200_000,
             used_percentage: 20.0, // ignored when raw counts are available
-            ..Default::default()
         };
         let seg = render_compaction_segment(&state, &cw).unwrap();
         assert_eq!(seg, "ctx 41%", "got: {seg}");
@@ -425,7 +523,6 @@ mod tests {
             total_input_tokens: 0,
             context_window_size: 0,
             used_percentage: 41.0,
-            ..Default::default()
         };
         let seg = render_compaction_segment(&state, &cw).unwrap();
         assert_eq!(seg, "ctx 41%");
@@ -442,9 +539,10 @@ mod tests {
 
     #[test]
     fn graceful_on_missing_fields() {
-        // Empty session_id → None (no filesystem access)
+        // Invalid session_id → None (no filesystem access)
         assert!(compaction_segment("", None).is_none());
-        // No context_window → None (no filesystem access)
-        assert!(compaction_segment("some-session-id", None).is_none());
+        assert!(compaction_segment("../bad", None).is_none());
+        // Valid session_id, no context_window → None (no filesystem access)
+        assert!(compaction_segment("valid-session-id", None).is_none());
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/compaction.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/compaction.rs
@@ -1,0 +1,450 @@
+//! Per-session compaction tracking for `tm statusline`.
+//!
+//! Why: Claude Code fires the `statusLine` hook on every render cycle with no
+//! persistent state; this module maintains a tiny JSON file in
+//! `~/.trusty-mpm/statusline/<session_id>.json` so the statusline can show how
+//! much the last auto-compaction shrank the context window.
+//! What: persists a `CompactionState` (running peak + last compaction record)
+//! keyed by `session_id`. Pure helper functions (`humanize_tokens`,
+//! `update_state`) are side-effect-free and unit-testable without I/O.
+//! Test: `humanize_tokens_examples`, `compaction_detection_sequence`,
+//! `state_round_trip`, `graceful_on_missing_fields` in the inline test module.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+// ── Input types (deserialised from Claude Code stdin) ─────────────────────────
+
+/// Context-window summary provided by Claude Code on every statusLine tick.
+///
+/// Why: exposes both raw token counts (for precise compaction delta) and the
+/// pre-computed percentage (as a fallback when size is unknown).
+/// What: all fields default so older Claude Code versions that omit
+/// `context_window` entirely still parse without error. `current_usage` is
+/// `None` while a compaction is in flight and `Some` once the next API call
+/// completes; we store it as an opaque `serde_json::Value` because we only
+/// test for null-vs-non-null.
+/// Test: `render_statusline_with_context_window` in mod.rs tests.
+#[derive(Debug, Default, Clone, Deserialize)]
+pub(crate) struct ContextWindow {
+    #[serde(default)]
+    pub total_input_tokens: u64,
+    #[serde(default)]
+    pub context_window_size: u64,
+    #[serde(default)]
+    pub used_percentage: f64,
+    /// `None` during compaction; `Some(...)` once the next API round-trip completes.
+    #[serde(default)]
+    pub current_usage: Option<serde_json::Value>,
+}
+
+// ── Persisted state ───────────────────────────────────────────────────────────
+
+/// Session-scoped compaction state serialised to
+/// `~/.trusty-mpm/statusline/<session_id>.json`.
+///
+/// Why: the statusline binary is invoked fresh on every render tick; this state
+/// file bridges invocations so the segment can show a compaction that happened
+/// several ticks ago.
+/// What: tracks the highest `total_input_tokens` seen (`peak_input_tokens`),
+/// whether the previous tick's `current_usage` was null, and the most recent
+/// compaction record.
+/// Test: `state_round_trip`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub(crate) struct CompactionState {
+    #[serde(default)]
+    pub peak_input_tokens: u64,
+    #[serde(default)]
+    pub prev_current_usage_was_null: bool,
+    #[serde(default)]
+    pub last_compaction: Option<CompactionRecord>,
+}
+
+/// Record of a detected context-compaction event.
+///
+/// Why: persisted so the segment keeps showing the compaction delta even after
+/// tokens have risen again above the post-compaction floor.
+/// What: `before`/`after` raw token counts and `reclaimed_pct` at detection time.
+/// Test: `compaction_detection_sequence`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CompactionRecord {
+    pub before: u64,
+    pub after: u64,
+    pub reclaimed_pct: f64,
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+/// Humanize a raw token count to a short display string (e.g. 182 000 → "182k").
+///
+/// Why: raw token counts are too wide for a status bar segment; the humanised
+/// form keeps segments compact and readable at a glance.
+/// What: formats ≥1 M as `{n}m`, ≥1 k as `{n}k`, smaller as `{n}`.
+/// Uses integer floor division (truncation) for consistent compact output.
+/// Test: `humanize_tokens_examples`, `humanize_tokens_boundaries`.
+pub(crate) fn humanize_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{}m", n / 1_000_000)
+    } else if n >= 1_000 {
+        format!("{}k", n / 1_000)
+    } else {
+        format!("{n}")
+    }
+}
+
+/// Apply one context-window reading to the mutable `CompactionState`.
+///
+/// Why: keeping detection logic pure (no I/O) allows exhaustive unit testing
+/// of the heuristic without touching the filesystem.
+/// What: when `cur > 0`, detects a compaction if `cur` has dropped below
+/// 60 % of `peak` AND the absolute drop exceeds 10 000 tokens; on detection,
+/// records the event and resets `peak` to `cur`; otherwise advances `peak`.
+/// The `current_usage_is_null` flag is stored for the next call.
+/// Test: `compaction_detection_sequence`.
+pub(crate) fn update_state(state: &mut CompactionState, cur: u64, current_usage_is_null: bool) {
+    if cur == 0 {
+        // No usable token info this tick; just record the null flag.
+        state.prev_current_usage_was_null = current_usage_is_null;
+        return;
+    }
+
+    let peak = state.peak_input_tokens;
+
+    if peak > 0 {
+        let drop = peak.saturating_sub(cur);
+        let below_ratio = (cur as f64) < (peak as f64) * 0.6;
+
+        if below_ratio && drop > 10_000 {
+            let reclaimed_pct = 100.0 * drop as f64 / peak as f64;
+            state.last_compaction = Some(CompactionRecord {
+                before: peak,
+                after: cur,
+                reclaimed_pct,
+            });
+            state.peak_input_tokens = cur;
+            state.prev_current_usage_was_null = current_usage_is_null;
+            return;
+        }
+    }
+
+    if cur > state.peak_input_tokens {
+        state.peak_input_tokens = cur;
+    }
+    state.prev_current_usage_was_null = current_usage_is_null;
+}
+
+// ── I/O helpers ───────────────────────────────────────────────────────────────
+
+/// Load `CompactionState` from `path`, returning `Default` on any error.
+///
+/// Why: the state file may be absent (first run), malformed, or on a slow
+/// filesystem; all error paths produce a clean default rather than propagating.
+/// What: reads raw bytes, deserialises JSON; any failure → `CompactionState::default()`.
+/// Test: `state_round_trip`.
+pub(crate) fn load_state_from(path: &Path) -> CompactionState {
+    (|| -> Option<CompactionState> {
+        let bytes = std::fs::read(path).ok()?;
+        serde_json::from_slice(&bytes).ok()
+    })()
+    .unwrap_or_default()
+}
+
+/// Write `state` to `path`, creating parent directories as needed; silently
+/// discards all errors so a filesystem issue never breaks the statusline.
+///
+/// Why: the statusline must never fail or block due to transient I/O problems.
+/// What: `create_dir_all` + atomic `write`; every fallible step uses `.ok()`.
+/// Test: `state_round_trip` (nested-dir variant).
+pub(crate) fn save_state_to(path: &Path, state: &CompactionState) {
+    let _ = (|| -> Option<()> {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).ok()?;
+        }
+        let bytes = serde_json::to_vec(state).ok()?;
+        std::fs::write(path, bytes).ok()
+    })();
+}
+
+/// Return the canonical state file path for `session_id`.
+///
+/// Why: centralises the path formula so no caller duplicates it.
+/// What: `~/.trusty-mpm/statusline/<session_id>.json`; `None` when the home
+/// directory cannot be determined.
+/// Test: used transitively by `compaction_segment`.
+pub(crate) fn state_file_path(session_id: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    Some(
+        home.join(".trusty-mpm")
+            .join("statusline")
+            .join(format!("{session_id}.json")),
+    )
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/// Run one compaction-tracking cycle and return the displayable segment string.
+///
+/// Why: wraps the load/update/save cycle so `render_statusline` stays free of
+/// I/O concerns; every error path degrades gracefully to `None`.
+/// What: returns `None` when `session_id` is empty or `context_window` is
+/// absent; otherwise persists state, then returns either
+/// `"⤵ {before}→{after} ({pct}%)"` (post-compaction) or `"ctx {pct}%"` (live fill).
+/// Test: `graceful_on_missing_fields`; integration via `render_statusline`.
+pub(crate) fn compaction_segment(
+    session_id: &str,
+    context_window: Option<&ContextWindow>,
+) -> Option<String> {
+    if session_id.is_empty() {
+        return None;
+    }
+    let cw = context_window?;
+    let cur = cw.total_input_tokens;
+    let path = state_file_path(session_id)?;
+
+    let mut state = load_state_from(&path);
+    let usage_is_null = cw.current_usage.is_none();
+    update_state(&mut state, cur, usage_is_null);
+    save_state_to(&path, &state);
+
+    render_compaction_segment(&state, cw)
+}
+
+/// Render the compaction segment string from persisted state and context window.
+///
+/// Why: separating rendering from I/O enables unit tests that verify output
+/// format without a real state file.
+/// What: returns `"⤵ {before}→{after} ({pct}%)"` when a compaction record
+/// exists; otherwise `"ctx {pct}%"` from token counts or `used_percentage`;
+/// `None` when no displayable information is available.
+/// Test: `render_segment_after_compaction`, `render_segment_live_fill_*`.
+pub(crate) fn render_compaction_segment(
+    state: &CompactionState,
+    cw: &ContextWindow,
+) -> Option<String> {
+    if let Some(ref rec) = state.last_compaction {
+        let before = humanize_tokens(rec.before);
+        let after = humanize_tokens(rec.after);
+        let pct = rec.reclaimed_pct.round() as u64;
+        return Some(format!("\u{2935} {before}\u{2192}{after} ({pct}%)"));
+    }
+
+    if cw.total_input_tokens > 0 && cw.context_window_size > 0 {
+        let pct =
+            (cw.total_input_tokens as f64 / cw.context_window_size as f64 * 100.0).round() as u64;
+        return Some(format!("ctx {pct}%"));
+    }
+    if cw.used_percentage > 0.0 {
+        let pct = cw.used_percentage.round() as u64;
+        return Some(format!("ctx {pct}%"));
+    }
+    None
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── humanize_tokens ───────────────────────────────────────────────────────
+
+    #[test]
+    fn humanize_tokens_examples() {
+        assert_eq!(humanize_tokens(182_000), "182k");
+        assert_eq!(humanize_tokens(58_000), "58k");
+        assert_eq!(humanize_tokens(1_200_000), "1m");
+        assert_eq!(humanize_tokens(999), "999");
+        assert_eq!(humanize_tokens(0), "0");
+    }
+
+    #[test]
+    fn humanize_tokens_boundaries() {
+        assert_eq!(humanize_tokens(1_000), "1k");
+        assert_eq!(humanize_tokens(1_999), "1k"); // floor truncation
+        assert_eq!(humanize_tokens(2_000), "2k");
+        assert_eq!(humanize_tokens(999_999), "999k");
+        assert_eq!(humanize_tokens(1_000_000), "1m");
+        assert_eq!(humanize_tokens(1_500_000), "1m"); // floor truncation
+        assert_eq!(humanize_tokens(2_000_000), "2m");
+    }
+
+    // ── update_state (compaction detection) ───────────────────────────────────
+
+    #[test]
+    fn compaction_detection_sequence() {
+        let mut state = CompactionState::default();
+
+        // Rising context: no compaction
+        update_state(&mut state, 50_000, false);
+        assert_eq!(state.peak_input_tokens, 50_000);
+        assert!(state.last_compaction.is_none());
+
+        update_state(&mut state, 100_000, false);
+        assert_eq!(state.peak_input_tokens, 100_000);
+        assert!(state.last_compaction.is_none());
+
+        update_state(&mut state, 182_000, false);
+        assert_eq!(state.peak_input_tokens, 182_000);
+        assert!(state.last_compaction.is_none());
+
+        // Compaction: drop to 58k (< 60% of 182k = 109.2k, drop = 124k > 10k)
+        update_state(&mut state, 58_000, true);
+        assert!(state.last_compaction.is_some());
+        let rec = state.last_compaction.as_ref().unwrap();
+        assert_eq!(rec.before, 182_000);
+        assert_eq!(rec.after, 58_000);
+        // reclaimed ≈ 68.13 %
+        assert!(
+            (rec.reclaimed_pct - 68.13).abs() < 0.1,
+            "reclaimed_pct = {}",
+            rec.reclaimed_pct
+        );
+        assert_eq!(state.peak_input_tokens, 58_000);
+
+        // Resumes growing: compaction record retained, peak advances
+        update_state(&mut state, 60_000, false);
+        assert_eq!(state.peak_input_tokens, 60_000);
+        assert!(state.last_compaction.is_some());
+    }
+
+    #[test]
+    fn small_drop_not_detected_as_compaction() {
+        let mut state = CompactionState::default();
+        update_state(&mut state, 100_000, false);
+        // Drop only 5 k — below 10 k absolute threshold
+        update_state(&mut state, 95_000, false);
+        assert!(state.last_compaction.is_none());
+    }
+
+    #[test]
+    fn moderate_drop_ratio_above_threshold_not_detected() {
+        let mut state = CompactionState::default();
+        update_state(&mut state, 100_000, false);
+        // 70 % of peak → ratio 0.7 > 0.6, not detected
+        update_state(&mut state, 70_000, false);
+        assert!(state.last_compaction.is_none());
+    }
+
+    #[test]
+    fn zero_cur_skips_peak_update() {
+        let mut state = CompactionState::default();
+        update_state(&mut state, 100_000, false);
+        update_state(&mut state, 0, true); // cur=0 → skip update, record null flag
+        assert_eq!(state.peak_input_tokens, 100_000);
+        assert!(state.last_compaction.is_none());
+        assert!(state.prev_current_usage_was_null);
+    }
+
+    // ── State file I/O ────────────────────────────────────────────────────────
+
+    #[test]
+    fn state_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+
+        // Non-existent file → Default
+        let loaded = load_state_from(&path);
+        assert_eq!(loaded.peak_input_tokens, 0);
+        assert!(loaded.last_compaction.is_none());
+
+        // Write and read back
+        let state = CompactionState {
+            peak_input_tokens: 182_000,
+            prev_current_usage_was_null: false,
+            last_compaction: Some(CompactionRecord {
+                before: 182_000,
+                after: 58_000,
+                reclaimed_pct: 68.13,
+            }),
+        };
+        save_state_to(&path, &state);
+
+        let loaded2 = load_state_from(&path);
+        assert_eq!(loaded2.peak_input_tokens, 182_000);
+        let rec = loaded2.last_compaction.unwrap();
+        assert_eq!(rec.before, 182_000);
+        assert_eq!(rec.after, 58_000);
+        assert!((rec.reclaimed_pct - 68.13).abs() < 0.001);
+
+        // save_state_to creates parent dirs automatically
+        let nested = dir.path().join("a").join("b").join("state.json");
+        let state2 = CompactionState {
+            peak_input_tokens: 42_000,
+            ..Default::default()
+        };
+        save_state_to(&nested, &state2);
+        let loaded3 = load_state_from(&nested);
+        assert_eq!(loaded3.peak_input_tokens, 42_000);
+    }
+
+    // ── render_compaction_segment ─────────────────────────────────────────────
+
+    #[test]
+    fn render_segment_after_compaction() {
+        let state = CompactionState {
+            peak_input_tokens: 58_000,
+            prev_current_usage_was_null: false,
+            last_compaction: Some(CompactionRecord {
+                before: 182_000,
+                after: 58_000,
+                reclaimed_pct: 68.13,
+            }),
+        };
+        let cw = ContextWindow {
+            total_input_tokens: 60_000,
+            context_window_size: 200_000,
+            used_percentage: 30.0,
+            ..Default::default()
+        };
+        let seg = render_compaction_segment(&state, &cw).unwrap();
+        assert!(seg.contains("182k"), "got: {seg}");
+        assert!(seg.contains("58k"), "got: {seg}");
+        assert!(seg.contains("68%"), "got: {seg}");
+        assert!(seg.contains('\u{2935}'), "must contain ⤵: {seg}");
+    }
+
+    #[test]
+    fn render_segment_live_fill_from_tokens() {
+        let state = CompactionState::default();
+        // 82 000 / 200 000 = 41.0 % → "ctx 41%"
+        let cw = ContextWindow {
+            total_input_tokens: 82_000,
+            context_window_size: 200_000,
+            used_percentage: 20.0, // ignored when raw counts are available
+            ..Default::default()
+        };
+        let seg = render_compaction_segment(&state, &cw).unwrap();
+        assert_eq!(seg, "ctx 41%", "got: {seg}");
+    }
+
+    #[test]
+    fn render_segment_live_fill_fallback_to_percentage() {
+        let state = CompactionState::default();
+        let cw = ContextWindow {
+            total_input_tokens: 0,
+            context_window_size: 0,
+            used_percentage: 41.0,
+            ..Default::default()
+        };
+        let seg = render_compaction_segment(&state, &cw).unwrap();
+        assert_eq!(seg, "ctx 41%");
+    }
+
+    #[test]
+    fn render_segment_none_when_no_info() {
+        let state = CompactionState::default();
+        let cw = ContextWindow::default(); // all zeros
+        assert!(render_compaction_segment(&state, &cw).is_none());
+    }
+
+    // ── graceful degradation ──────────────────────────────────────────────────
+
+    #[test]
+    fn graceful_on_missing_fields() {
+        // Empty session_id → None (no filesystem access)
+        assert!(compaction_segment("", None).is_none());
+        // No context_window → None (no filesystem access)
+        assert!(compaction_segment("some-session-id", None).is_none());
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/mod.rs
@@ -368,7 +368,6 @@ mod tests {
             total_input_tokens: 82_000,
             context_window_size: 200_000,
             used_percentage: 41.0,
-            ..Default::default()
         };
         let seg = render_compaction_segment(&state, &cw);
         assert_eq!(seg.as_deref(), Some("ctx 41%"));
@@ -382,7 +381,6 @@ mod tests {
             total_input_tokens: 82_000,
             context_window_size: 200_000,
             used_percentage: 41.0,
-            ..Default::default()
         });
         let out = render_statusline(&input);
         // No compaction/ctx segment because session_id is empty

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/mod.rs
@@ -5,20 +5,26 @@
 //! ` │ `-separated segment string on stdout. All fields degrade gracefully.
 //! What: reads a JSON object from stdin, renders repo+branch/model/daemon/cost
 //! segments, and exits 0. Missing or invalid fields produce empty/omitted segments.
-//! Test: `statusline_renders_minimal`, `statusline_renders_full` in `tests.rs`.
+//! Test: `render_statusline_minimal_input`, `render_statusline_full_payload` in tests.
+
+pub(crate) mod compaction;
 
 use std::io::Read as _;
 
 use crate::formatters::info_box::DaemonInfo;
+use compaction::{ContextWindow, compaction_segment};
 
 /// Claude Code `statusLine` hook input (all fields optional via `#[serde(default)]`).
 ///
 /// Why: Claude Code may add fields in future versions; `deny_unknown_fields` is
 /// intentionally absent so new keys do not cause parse failures.
-/// What: cwd, model metadata, cost summary, and the context-window overflow flag.
-/// Test: `statusline_renders_minimal` (empty input), `statusline_renders_full`.
+/// What: cwd, model metadata, cost summary, context-window data, and the
+/// context-window overflow flag.
+/// Test: `render_statusline_minimal_input` (empty input), `render_statusline_full_payload`.
 #[derive(Debug, Default, serde::Deserialize)]
 pub(crate) struct StatusInput {
+    #[serde(default)]
+    pub(crate) session_id: String,
     #[serde(default)]
     pub(crate) cwd: String,
     #[serde(default)]
@@ -27,6 +33,8 @@ pub(crate) struct StatusInput {
     pub(crate) cost: CostInfo,
     #[serde(default)]
     pub(crate) exceeds_200k_tokens: bool,
+    #[serde(default)]
+    pub(crate) context_window: Option<ContextWindow>,
 }
 
 /// Model metadata from the Claude Code hook input.
@@ -34,7 +42,7 @@ pub(crate) struct StatusInput {
 /// Why: `display_name` carries the human-readable label ("Opus") operators want
 /// in the status bar; `id` is the fallback when `display_name` is absent.
 /// What: both fields are `String` with `#[serde(default)]` so absent keys are "".
-/// Test: `statusline_renders_full`.
+/// Test: `render_statusline_full_payload`.
 #[derive(Debug, Default, serde::Deserialize)]
 pub(crate) struct ModelInfo {
     #[serde(default)]
@@ -47,7 +55,7 @@ pub(crate) struct ModelInfo {
 ///
 /// Why: operators want running cost in the status bar to monitor spend.
 /// What: `total_cost_usd` is the session's accumulated cost; 0.0 when absent.
-/// Test: `statusline_renders_full`.
+/// Test: `render_statusline_full_payload`.
 #[derive(Debug, Default, serde::Deserialize)]
 pub(crate) struct CostInfo {
     #[serde(default)]
@@ -60,7 +68,7 @@ pub(crate) struct CostInfo {
 /// stdin, prints one line to stdout, exits 0"; this is the single entry point.
 /// What: reads all of stdin, parses it as `StatusInput` (empty/invalid → default),
 /// renders segments, and prints exactly one line to stdout.
-/// Test: `statusline_renders_minimal`, `statusline_renders_full`.
+/// Test: `render_statusline_minimal_input`, `render_statusline_full_payload`.
 pub(crate) fn run_statusline() -> anyhow::Result<()> {
     let mut raw = String::new();
     let _ = std::io::stdin().read_to_string(&mut raw);
@@ -71,11 +79,12 @@ pub(crate) fn run_statusline() -> anyhow::Result<()> {
 
 /// Render the compact statusline string from parsed hook input.
 ///
-/// Why: keeping rendering pure (no I/O) makes it unit-testable independently
-/// of the stdin protocol.
-/// What: builds up to six segments — project+branch, model, daemon, session
-/// count, context%, cost — joined with ` │ `, emitting only non-empty segments.
-/// Test: `statusline_renders_minimal`, `statusline_renders_full`.
+/// Why: keeping rendering pure (no mandatory I/O) makes it unit-testable
+/// independently of the stdin protocol.
+/// What: builds up to seven segments — project+branch, model, daemon, session
+/// count, context%, compaction efficiency, cost — joined with ` │ `, emitting
+/// only non-empty segments.
+/// Test: `render_statusline_minimal_input`, `render_statusline_full_payload`.
 pub(crate) fn render_statusline(input: &StatusInput) -> String {
     let mut parts: Vec<String> = Vec::new();
 
@@ -104,6 +113,12 @@ pub(crate) fn render_statusline(input: &StatusInput) -> String {
     if input.exceeds_200k_tokens {
         parts.push("ctx>200k".to_string());
     }
+
+    // Compaction efficiency / live context fill.
+    if let Some(seg) = compaction_segment(&input.session_id, input.context_window.as_ref()) {
+        parts.push(seg);
+    }
+
     if input.cost.total_cost_usd > 0.0 {
         parts.push(cost_segment(input.cost.total_cost_usd));
     }
@@ -119,7 +134,7 @@ pub(crate) fn render_statusline(input: &StatusInput) -> String {
 /// daemon; a subprocess git call is cheap enough for a status-bar refresh.
 /// What: extracts the dirname basename and appends ` ⎇ <branch>` when the
 /// working directory is inside a git repo.
-/// Test: `statusline_renders_minimal` (empty cwd → None).
+/// Test: `render_statusline_minimal_input` (empty cwd → None).
 fn project_segment(cwd: &str) -> Option<String> {
     if cwd.is_empty() {
         return None;
@@ -143,9 +158,9 @@ fn project_segment(cwd: &str) -> Option<String> {
 /// Build the model-label segment.
 ///
 /// Why: operators want to know which model Claude Code is using at a glance.
-/// What: returns `display_name` when non-empty, `id` as fallback, `None` when both
-/// are empty (segment omitted from the status bar).
-/// Test: `statusline_renders_full`.
+/// What: returns `display_name` when non-empty, `id` as fallback, `None` when
+/// both are empty (segment omitted from the status bar).
+/// Test: `render_statusline_full_payload`.
 fn model_segment(model: &ModelInfo) -> Option<String> {
     if !model.display_name.is_empty() {
         Some(model.display_name.clone())
@@ -161,7 +176,7 @@ fn model_segment(model: &ModelInfo) -> Option<String> {
 /// Why: makes the daemon state immediately visible without opening a terminal.
 /// What: extracts the port from `daemon.addr` and returns `"tm ●:<port>"` or
 /// `"tm ○"`.
-/// Test: `statusline_renders_minimal` (offline daemon → `tm ○`).
+/// Test: `render_statusline_minimal_input` (offline daemon → `tm ○`).
 fn daemon_segment(daemon: &DaemonInfo) -> String {
     if daemon.online {
         let port = daemon
@@ -179,7 +194,7 @@ fn daemon_segment(daemon: &DaemonInfo) -> String {
 ///
 /// Why: shows at a glance how many trusty-mpm sessions are active.
 /// What: returns `"⛁{n}"`.
-/// Test: `statusline_renders_full`.
+/// Test: `render_statusline_full_payload`.
 fn count_segment(n: usize) -> String {
     format!("\u{26c1}{n}")
 }
@@ -188,7 +203,7 @@ fn count_segment(n: usize) -> String {
 ///
 /// Why: running cost visibility helps operators monitor API spend.
 /// What: formats `usd` to two decimal places with a `$` prefix.
-/// Test: `statusline_renders_full`.
+/// Test: `render_statusline_full_payload`.
 fn cost_segment(usd: f64) -> String {
     format!("${usd:.2}")
 }
@@ -198,7 +213,7 @@ fn cost_segment(usd: f64) -> String {
 /// Why: the lock file stores `addr = "127.0.0.1:7880"` without the `http://`
 /// scheme; the probe needs a full URL.
 /// What: prepends `http://` when the addr does not already start with it.
-/// Test: covered indirectly by `statusline_renders_minimal`.
+/// Test: covered indirectly by `render_statusline_minimal_input`.
 fn daemon_base_url(daemon: &DaemonInfo) -> String {
     if daemon.addr.starts_with("http") {
         daemon.addr.clone()
@@ -249,9 +264,11 @@ fn git_branch(cwd: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use compaction::ContextWindow;
 
     fn full_input() -> StatusInput {
         StatusInput {
+            session_id: String::new(),
             cwd: "/home/user/my-project".to_string(),
             model: ModelInfo {
                 id: "claude-sonnet-4-6".to_string(),
@@ -261,6 +278,7 @@ mod tests {
                 total_cost_usd: 1.23,
             },
             exceeds_200k_tokens: false,
+            context_window: None,
         }
     }
 
@@ -294,7 +312,6 @@ mod tests {
         let mut input = full_input();
         input.model = ModelInfo::default();
         let out = render_statusline(&input);
-        // Model segment is absent; all other segments still present.
         assert!(!out.contains("claude"), "model segment must be omitted");
         assert!(out.contains("tm "), "daemon segment must still appear");
         assert!(out.contains("$1.23"), "cost must still appear");
@@ -334,9 +351,41 @@ mod tests {
     #[test]
     fn render_statusline_no_empty_separator_pairs() {
         // With every optional field empty, the only segment is the daemon row.
-        // Joining a single-item vec produces no separators at all.
         let out = render_statusline(&StatusInput::default());
         assert!(!out.contains(" \u{2502}  \u{2502} "), "no empty │ │ pairs");
         assert!(!out.contains("│ │"), "no adjacent separators");
+    }
+
+    #[test]
+    fn render_statusline_with_context_window_shows_live_fill() {
+        // When session_id is empty, compaction_segment returns None; ctx% is skipped.
+        // When session_id is present and no state file exists, shows live fill.
+        // We test via render_compaction_segment directly to avoid real file I/O.
+        use compaction::{CompactionState, render_compaction_segment};
+
+        let state = CompactionState::default();
+        let cw = ContextWindow {
+            total_input_tokens: 82_000,
+            context_window_size: 200_000,
+            used_percentage: 41.0,
+            ..Default::default()
+        };
+        let seg = render_compaction_segment(&state, &cw);
+        assert_eq!(seg.as_deref(), Some("ctx 41%"));
+    }
+
+    #[test]
+    fn render_statusline_with_context_window_no_session_id_omits_segment() {
+        // session_id="" → compaction_segment() → None → no compaction segment
+        let mut input = full_input();
+        input.context_window = Some(ContextWindow {
+            total_input_tokens: 82_000,
+            context_window_size: 200_000,
+            used_percentage: 41.0,
+            ..Default::default()
+        });
+        let out = render_statusline(&input);
+        // No compaction/ctx segment because session_id is empty
+        assert!(!out.contains("ctx "), "no ctx segment without session_id");
     }
 }


### PR DESCRIPTION
## Summary

Closes #1773.

Adds a **compaction efficiency segment** to the `tm statusline` bar. After an auto-compaction Claude Code performs, the segment shows how much context was reclaimed (`⤵ 182k→58k (68%)`). Before any compaction it shows live context fill (`ctx 41%`). The segment is absent when `session_id` or `context_window` is not provided (old Claude Code versions, blank session context).

- Extends `StatusInput` with `session_id: String` and `context_window: Option<ContextWindow>`, all `#[serde(default)]` for backward compatibility with older Claude Code versions.
- Per-session compaction state is persisted at `~/.trusty-mpm/statusline/<session_id>.json` (tiny JSON, sync reads — the statusline is called on every render tick so we keep I/O minimal).
- Compaction detection heuristic: `cur < peak * 0.6 AND peak - cur > 10_000`. On detection, records `{ before, after, reclaimed_pct }` and resets the peak to the post-compaction level.
- All I/O errors are discarded silently; the statusline never panics or blocks.
- `statusline.rs` was split into `statusline/{mod.rs, compaction.rs}` to keep both files comfortably under the 500-SLOC production cap.

## Smoke test output (raw)

**Call 1** — context at 182k tokens (91% fill), no compaction yet:
```
tmp │ tm ○ │ ctx 91%
```

**Call 2** — tokens dropped to 58k (compaction detected):
```
tmp │ tm ○ │ ⤵ 182k→58k (68%)
```

## Verification

```
cargo test -p trusty-mpm statusline
# 21 passed; 0 failed

cargo clippy -p trusty-mpm --all-targets -- -D warnings
# zero warnings / errors (trusty-mpm)

cargo fmt --check
# no drift

bash scripts/check_line_cap.sh
# 14 allowlisted, 0 violations — OK
```

## Files changed

| File | Change |
|---|---|
| `crates/trusty-mpm/src/bin/tm/commands/statusline.rs` | Renamed → `statusline/mod.rs`; extended with `session_id`, `context_window` fields and compaction segment call |
| `crates/trusty-mpm/src/bin/tm/commands/statusline/compaction.rs` | New module: `ContextWindow`, `CompactionState`, `CompactionRecord`, `humanize_tokens`, `update_state`, `load/save_state_from`, `compaction_segment`, `render_compaction_segment`, 11 unit tests |

LOC delta: +520 added, −21 removed (net +499 — the new compaction module with full docs and 21 tests accounts for the majority).

## Test plan

- [x] `cargo test -p trusty-mpm` — all 21 new + all existing statusline tests pass
- [x] Smoke-piped two JSON payloads showing the `ctx %` → `⤵` transition
- [x] `bash scripts/check_line_cap.sh` clean
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)