### PR TITLE
feat(trusty-mpm): tm guided-default auto-start daemon + github-* SSH alias support (#1775)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -21,6 +21,7 @@
 use anyhow::Context as _;
 use serde::Deserialize;
 
+pub(crate) use super::guided_autostart::github_host;
 use crate::formatters::banner::tmux_has_session;
 
 /// Response shape for `POST /api/v1/sessions/managed` (subset we need).
@@ -84,38 +85,51 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
     let workdir = cwd.to_string_lossy().to_string();
     eprintln!("tm: no subcommand — using guided default for {workdir}");
 
+    // Use a mutable URL so that a successful auto-start can update it to the
+    // actual bound address discovered via the lock file.
+    let mut effective_url = url.to_string();
+
     // Try the rich UX when CWD is a GitHub-backed git project.
     if let Some((source_id, workspace, git_root)) = derive_project(&cwd) {
         // Pass the git root as repo_url so daemon detects .git at root even
         // when tm is invoked from a subdirectory (#1705 LOW fix).
         let repo_url = git_root.to_string_lossy().to_string();
-        match list_project_sessions(client, url, &source_id).await {
-            Ok(sessions) => {
-                use std::io::IsTerminal as _;
-                // tty_gate prints project context; returns true when stdin is a
-                // TTY and the picker should run, false for non-TTY exit.
-                if !tty_gate(
-                    std::io::stdin().is_terminal(),
+
+        // First attempt: daemon may already be up.
+        if let Some(r) = try_show_picker(
+            client,
+            &effective_url,
+            &source_id,
+            &workspace,
+            &repo_url,
+            &cwd,
+        )
+        .await
+        {
+            return r;
+        }
+
+        // Daemon unreachable — try to auto-start it transparently.
+        eprintln!("tm: daemon not running — starting it…");
+        match super::guided_autostart::ensure_daemon_started(client, &effective_url).await {
+            Ok(new_url) => {
+                effective_url = new_url;
+                // Retry the full picker flow with the freshly-started daemon.
+                if let Some(r) = try_show_picker(
+                    client,
+                    &effective_url,
                     &source_id,
                     &workspace,
-                    &sessions,
-                ) {
-                    return Ok(());
+                    &repo_url,
+                    &cwd,
+                )
+                .await
+                {
+                    return r;
                 }
-                // Show the compact info box before the TTY picker.
-                let daemon = crate::formatters::info_box::DaemonInfo::from_lock_file()
-                    .with_count(sessions.len());
-                crate::formatters::info_box::print_info_box(
-                    &cwd.to_string_lossy(),
-                    &source_id,
-                    false,
-                    &daemon,
-                );
-                return run_tty_picker(client, url, &repo_url, &sessions).await;
+                eprintln!("tm: daemon started but sessions still unreachable; falling back");
             }
-            Err(e) => {
-                eprintln!("tm: daemon unreachable ({e}); falling back");
-            }
+            Err(e) => eprintln!("tm: auto-start failed ({e}); falling back to offline mode"),
         }
     }
 
@@ -123,7 +137,43 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
     // For GitHub projects this redirects to the managed-clone workspace.
     // For non-GitHub git projects it refuses (live-checkout guard).
     // For non-git directories it falls through to the classic `tm launch` path.
-    fallback_protected(client, url, &cwd).await
+    fallback_protected(client, &effective_url, &cwd).await
+}
+
+/// Attempt to list sessions and display the interactive picker for a GitHub project.
+///
+/// Why: the same "list sessions → tty-gate → info-box → picker" sequence is
+/// needed both on the initial attempt and after a successful auto-start. A shared
+/// helper keeps `run_guided_default` DRY and avoids divergence between the two
+/// call sites.
+/// What: calls `list_project_sessions`; on Err (daemon unreachable) returns
+/// `None` so the caller can try auto-start. On Ok, runs the tty-gate and the
+/// picker, returning `Some(result)`. The `None`/`Some` distinction is the
+/// daemon-reachable signal — it does NOT indicate picker success or failure.
+/// Test: indirectly covered by guided-default e2e tests; the pure sub-functions
+/// (`tty_gate`, `parse_picker_choice`) are unit-tested independently.
+async fn try_show_picker(
+    client: &reqwest::Client,
+    url: &str,
+    source_id: &str,
+    workspace: &std::path::Path,
+    repo_url: &str,
+    cwd: &std::path::Path,
+) -> Option<anyhow::Result<()>> {
+    let sessions = list_project_sessions(client, url, source_id).await.ok()?;
+    use std::io::IsTerminal as _;
+    if !tty_gate(
+        std::io::stdin().is_terminal(),
+        source_id,
+        workspace,
+        &sessions,
+    ) {
+        return Some(Ok(()));
+    }
+    let daemon =
+        crate::formatters::info_box::DaemonInfo::from_lock_file().with_count(sessions.len());
+    crate::formatters::info_box::print_info_box(&cwd.to_string_lossy(), source_id, false, &daemon);
+    Some(run_tty_picker(client, url, repo_url, &sessions).await)
 }
 
 // ── Project derivation ───────────────────────────────────────────────────────
@@ -617,24 +667,32 @@ async fn launch_new_session_and_attach(
 
 // ── Fallback (daemon-unreachable / non-GitHub) path ─────────────────────────
 
-/// Return true when the remote URL targets github.com (any transport).
+/// Return true when the remote URL targets GitHub (any transport or SSH alias).
 ///
 /// Why: `parse_github_path` from `trusty-common` accepts *any* git remote URL,
 /// not just GitHub ones. We need a host-specific guard so that non-GitHub git
 /// projects (Gitea, GitLab, bare SSH, etc.) are refused rather than having a
-/// clone attempt made against an unrecognised host (#1724 residual gap).
-/// What: case-insensitive substring match for `"github.com"` in the raw URL —
-/// catches both HTTPS (`https://github.com/…`) and SSH (`git@github.com:…`)
-/// forms without adding a URL-parsing dependency.
-/// Known limitation: a hostname such as `github.mycompany.com` does NOT match
-/// since `"github.mycompany.com".contains("github.com")` is false. URLs like
-/// `https://notgithub.com/a/b.git` also do not match. Both cases fall through
-/// to the non-GitHub refusal path — safe but not redirected.
-/// Test: `guided_fallback_blocks_non_github_git_checkout` verifies a Gitea URL
-/// is NOT treated as GitHub; `guided_fallback_never_pollutes_github_git_checkout`
-/// verifies a real GitHub URL is recognised.
-fn is_github_remote(url: &str) -> bool {
-    url.to_ascii_lowercase().contains("github.com")
+/// clone attempt made against an unrecognised host (#1724 residual gap). We
+/// also need to recognise GitHub repos accessed via multi-account SSH host
+/// aliases (e.g. `git@github-duetto:owner/repo.git` via `~/.ssh/config`).
+/// What: extracts the host via [`github_host`], then accepts it when:
+///   (a) host == `"github.com"` (the canonical GitHub host), OR
+///   (b) host starts with `"github-"` or `"github_"` (SSH alias convention —
+///       e.g. `github-duetto`, `github-work`, `github_personal`).
+/// Decision — GitHub Enterprise (`github.mycompany.com`): NOT matched. GHE
+/// uses a dot separator after `github`, and the broader managed-clone
+/// infrastructure is not tested against GHE; erring on the side of safety
+/// avoids an unexpected redirect for GHE users.
+/// Does NOT match: `githubusercontent.com` (the `u` after `github` is
+/// alphanumeric, so neither rule fires), `gitlab.com`, `bitbucket.org`, or
+/// any other host.
+/// Test: `is_github_remote_*` unit tests in `tests_behavior_c_tests.rs`;
+/// `guided_fallback_never_pollutes_github_git_checkout` (real `github.com` URL);
+/// `guided_fallback_blocks_non_github_git_checkout` (Gitea URL must be blocked).
+pub(crate) fn is_github_remote(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    let host = github_host(&lower);
+    host == "github.com" || host.starts_with("github-") || host.starts_with("github_")
 }
 
 /// Detect the git working-tree root at any depth by shelling to git.

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_autostart.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_autostart.rs
@@ -3,8 +3,8 @@
 //! Why: bare `tm` should bring the trusty-mpm daemon up automatically when
 //! it is unreachable, so the operator gets the full picker UX without having
 //! to run `tm start` first.
-//! What: [`ensure_daemon_started`] checks for a launchd supervisor plist
-//! (preferred: reboot-durable) and falls back to a detached direct spawn.
+//! What: [`ensure_daemon_started`] checks for a launchd supervisor plist on
+//! macOS (preferred: reboot-durable) and falls back to a detached direct spawn.
 //! Both paths poll `/health` via lock-file URL resolution for up to 5 s and
 //! return the resolved daemon URL on success.
 //! Test: [`supervisor_plist_path_has_expected_components`] verifies the path
@@ -37,7 +37,7 @@ pub(crate) fn supervisor_plist_path() -> std::path::PathBuf {
         .join(format!("{SUPERVISOR_PLIST_LABEL}.plist"))
 }
 
-/// Outcome of a `launchctl bootstrap` attempt.
+/// Outcome of a `launchctl bootstrap` attempt (macOS only).
 ///
 /// Why: distinguishes "already running" (EALREADY) from "truly unavailable" so
 /// `ensure_daemon_started` can skip the lock-delete+spawn step when launchd
@@ -45,9 +45,8 @@ pub(crate) fn supervisor_plist_path() -> std::path::PathBuf {
 /// What: three variants — `Launched` (exit 0), `AlreadyLoaded` (exit 37 /
 /// EALREADY or matching stderr), `Unavailable` (plist absent, `id -u` failed,
 /// or unknown non-zero exit).
-/// Test: covered indirectly by the launchd e2e smoke test; `Unavailable` path
-/// is exercised by the detached-spawn unit path.
-#[derive(Debug, PartialEq)]
+/// Test: covered indirectly by the launchd e2e smoke test.
+#[cfg(target_os = "macos")]
 enum LaunchctlOutcome {
     /// launchd accepted the bootstrap command — daemon is now (re)starting.
     Launched,
@@ -67,46 +66,54 @@ enum LaunchctlOutcome {
 /// What: (1) on macOS, if the supervisor plist exists, issues
 /// `launchctl bootstrap gui/<uid> <plist>` for reboot-durable startup and
 /// skips the spawn step when the service is already loaded (EALREADY);
-/// (2) when launchd is unavailable or the plist is absent, removes any stale
-/// lock file and spawns the current executable with the `daemon` subcommand in
-/// a detached process; (3) polls `/health` every 500 ms for up to 5 s via
-/// lock-file URL resolution; (4) returns the resolved daemon URL on success or
-/// `Err` on timeout. The `_url` parameter is intentionally unused: after
-/// auto-start the lock file records the actual bound address.
+/// (2) when launchd is unavailable, the plist is absent, or on non-macOS,
+/// removes any stale lock file and spawns the current executable with the
+/// `daemon` subcommand in a detached process; (3) polls `/health` every 500 ms
+/// for up to 5 s via lock-file URL resolution; (4) returns the resolved daemon
+/// URL on success or `Err` on timeout. The `_url` parameter is intentionally
+/// unused: after auto-start the lock file records the actual bound address.
 /// Test: launchd path requires a macOS launchd environment; detached-spawn and
 /// polling paths are covered by the guided-default e2e smoke test.
 pub(crate) async fn ensure_daemon_started(
     client: &reqwest::Client,
     _url: &str,
 ) -> anyhow::Result<String> {
-    let plist_path = supervisor_plist_path();
-    match try_launchctl_start(&plist_path) {
-        LaunchctlOutcome::Launched | LaunchctlOutcome::AlreadyLoaded => {
-            // launchd owns the service — no second spawn needed.
-        }
-        LaunchctlOutcome::Unavailable => {
-            // launchd not available or plist absent — fall back to detached
-            // spawn, the same approach used by `commands::daemon::start`.
-            let lock_path = trusty_mpm::core::lock_file_path();
-            let _ = std::fs::remove_file(&lock_path);
-            let root = trusty_mpm::core::paths::FrameworkPaths::default().root;
-            std::fs::create_dir_all(&root).context("create framework dir for daemon log")?;
-            let log_path = root.join("daemon.log");
-            let log_file = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&log_path)
-                .context("open daemon log file")?;
-            let log_copy = log_file.try_clone().context("clone log file handle")?;
-            let exe = std::env::current_exe().context("resolve current executable path")?;
-            std::process::Command::new(&exe)
-                .arg("daemon")
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::from(log_file))
-                .stderr(std::process::Stdio::from(log_copy))
-                .spawn()
-                .context("spawn daemon process")?;
-        }
+    // Determine whether we need to spawn a new daemon process.
+    // On macOS: prefer launchctl; spawn only when launchd cannot help.
+    // On all other platforms: always spawn directly.
+    #[cfg(target_os = "macos")]
+    let needs_spawn = {
+        let plist_path = supervisor_plist_path();
+        matches!(
+            try_launchctl_start(&plist_path),
+            LaunchctlOutcome::Unavailable
+        )
+    };
+    #[cfg(not(target_os = "macos"))]
+    let needs_spawn = true;
+
+    if needs_spawn {
+        // launchd not available or plist absent — fall back to detached spawn,
+        // the same approach used by `commands::daemon::start`.
+        let lock_path = trusty_mpm::core::lock_file_path();
+        let _ = std::fs::remove_file(&lock_path);
+        let root = trusty_mpm::core::paths::FrameworkPaths::default().root;
+        std::fs::create_dir_all(&root).context("create framework dir for daemon log")?;
+        let log_path = root.join("daemon.log");
+        let log_file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .context("open daemon log file")?;
+        let log_copy = log_file.try_clone().context("clone log file handle")?;
+        let exe = std::env::current_exe().context("resolve current executable path")?;
+        std::process::Command::new(&exe)
+            .arg("daemon")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::from(log_file))
+            .stderr(std::process::Stdio::from(log_copy))
+            .spawn()
+            .context("spawn daemon process")?;
     }
 
     // Poll until healthy or timeout (5 s). Re-resolve from the lock file each
@@ -127,11 +134,11 @@ pub(crate) async fn ensure_daemon_started(
 /// Why: `launchctl bootstrap` is preferred over a bare process spawn because
 /// launchd registers the unit for reboot-durability and respawn-on-crash. The
 /// detached-spawn fallback is session-only (no reboot durability).
-/// What: on macOS, if `plist_path` exists, resolves the current user UID via
-/// `id -u`, then runs `launchctl bootstrap gui/<uid> <plist>`. Returns
-/// `Launched` on exit 0, `AlreadyLoaded` on exit 37 (EALREADY) or when stderr
-/// contains "already bootstrapped"/"service already loaded", and `Unavailable`
-/// in all other cases (plist absent, `id -u` failure, unknown launchctl error).
+/// What: if `plist_path` exists, resolves the current user UID via `id -u`,
+/// then runs `launchctl bootstrap gui/<uid> <plist>`. Returns `Launched` on
+/// exit 0, `AlreadyLoaded` on exit 37 (EALREADY) or when stderr contains
+/// "already bootstrapped"/"service already loaded", and `Unavailable` in all
+/// other cases (plist absent, `id -u` failure, unknown launchctl error).
 /// Test: requires a real macOS launchd environment; covered by e2e smoke test.
 #[cfg(target_os = "macos")]
 fn try_launchctl_start(plist_path: &std::path::Path) -> LaunchctlOutcome {
@@ -171,11 +178,6 @@ fn try_launchctl_start(plist_path: &std::path::Path) -> LaunchctlOutcome {
     {
         return LaunchctlOutcome::AlreadyLoaded;
     }
-    LaunchctlOutcome::Unavailable
-}
-
-#[cfg(not(target_os = "macos"))]
-fn try_launchctl_start(_plist_path: &std::path::Path) -> LaunchctlOutcome {
     LaunchctlOutcome::Unavailable
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_autostart.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_autostart.rs
@@ -1,0 +1,202 @@
+//! Daemon auto-start helper for the guided-default flow.
+//!
+//! Why: bare `tm` should bring the trusty-mpm daemon up automatically when
+//! it is unreachable, so the operator gets the full picker UX without having
+//! to run `tm start` first.
+//! What: [`ensure_daemon_started`] checks for a launchd supervisor plist
+//! (preferred: reboot-durable) and falls back to a detached direct spawn.
+//! Both paths poll `/health` via lock-file URL resolution for up to 5 s and
+//! return the resolved daemon URL on success.
+//! Test: [`supervisor_plist_path_has_expected_components`] verifies the path
+//! derivation; integration coverage lives in the guided-default e2e suite.
+
+use anyhow::Context as _;
+
+/// The launchd label for the trusty-mpm supervisor plist.
+///
+/// Why: the identical string appears as `PLIST_LABEL` in `trusty-installer`;
+/// defining it here avoids importing that crate (which would create a circular
+/// dependency). It MUST match the installer's constant exactly so that
+/// `try_launchctl_start` and the installer target the same plist.
+/// What: `"com.trusty.mpm.supervisor"`.
+/// Test: `supervisor_plist_path_has_expected_components` derives the filename
+/// from this constant and asserts it matches the expected plist basename.
+pub(crate) const SUPERVISOR_PLIST_LABEL: &str = "com.trusty.mpm.supervisor";
+
+/// Resolve the expected macOS LaunchAgents path for the supervisor plist.
+///
+/// Why: factored out so `ensure_daemon_started` can check whether a supervisor
+/// plist is installed before deciding between launchd-start and detached-spawn.
+/// What: returns `~/Library/LaunchAgents/com.trusty.mpm.supervisor.plist`.
+/// Test: `supervisor_plist_path_has_expected_components`.
+pub(crate) fn supervisor_plist_path() -> std::path::PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("Library")
+        .join("LaunchAgents")
+        .join(format!("{SUPERVISOR_PLIST_LABEL}.plist"))
+}
+
+/// Ensure the trusty-mpm daemon is running, starting it if unreachable.
+///
+/// Why: bare `tm` in the guided-default flow should not require the operator
+/// to run `tm start` manually first. This helper transparently starts the
+/// daemon so the picker UX appears on every invocation.
+/// What: (1) on macOS, if the supervisor plist exists at
+/// `~/Library/LaunchAgents/com.trusty.mpm.supervisor.plist`, issues
+/// `launchctl bootstrap gui/<uid> <plist>` for reboot-durable startup;
+/// (2) otherwise removes any stale lock file and spawns the current executable
+/// with the `daemon` subcommand in a detached process (same logic as
+/// `commands::daemon::start`); (3) polls `/health` every 500 ms for up to 5 s
+/// via lock-file URL resolution; (4) returns the resolved daemon URL on success
+/// or `Err` on timeout. The `_url` parameter is intentionally unused: after
+/// auto-start the lock file records the actual bound address, which may differ
+/// from the stale or default URL the caller held.
+/// Test: launchd path requires a macOS launchd environment; detached-spawn and
+/// polling paths are covered by the guided-default e2e smoke test.
+pub(crate) async fn ensure_daemon_started(
+    client: &reqwest::Client,
+    _url: &str,
+) -> anyhow::Result<String> {
+    let plist_path = supervisor_plist_path();
+    if !try_launchctl_start(&plist_path) {
+        // launchd not available or plist absent — fall back to detached spawn,
+        // the same approach used by `commands::daemon::start`.
+        let lock_path = trusty_mpm::core::lock_file_path();
+        let _ = std::fs::remove_file(&lock_path);
+        let root = trusty_mpm::core::paths::FrameworkPaths::default().root;
+        std::fs::create_dir_all(&root).context("create framework dir for daemon log")?;
+        let log_path = root.join("daemon.log");
+        let log_file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .context("open daemon log file")?;
+        let log_copy = log_file.try_clone().context("clone log file handle")?;
+        let exe = std::env::current_exe().context("resolve current executable path")?;
+        std::process::Command::new(&exe)
+            .arg("daemon")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::from(log_file))
+            .stderr(std::process::Stdio::from(log_copy))
+            .spawn()
+            .context("spawn daemon process")?;
+    }
+
+    // Poll until healthy or timeout (5 s). Re-resolve from the lock file each
+    // iteration so we pick up the actual bound address written by the daemon.
+    for _ in 0..10 {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let resolved = trusty_mpm::core::resolve_daemon_url(None);
+        if super::daemon::daemon_healthy(client, &resolved).await {
+            eprintln!("tm: daemon ready");
+            return Ok(resolved);
+        }
+    }
+    anyhow::bail!("daemon did not become healthy within 5 s after auto-start")
+}
+
+/// Attempt to start the daemon via launchd `bootstrap` (macOS only).
+///
+/// Why: `launchctl bootstrap` is preferred over a bare process spawn because
+/// launchd registers the unit for reboot-durability and respawn-on-crash. The
+/// detached-spawn fallback is session-only (no reboot durability).
+/// What: on macOS, if `plist_path` exists, resolves the current user UID via
+/// `id -u`, then runs `launchctl bootstrap gui/<uid> <plist>`. Returns `true`
+/// when the command exits 0. Returns `false` on non-macOS, when the plist is
+/// absent, when `id -u` fails, or when `launchctl` exits non-zero (e.g. already
+/// loaded — the caller falls through to the polling wait either way).
+/// Test: requires a real macOS launchd environment; covered by e2e smoke test.
+#[cfg(target_os = "macos")]
+fn try_launchctl_start(plist_path: &std::path::Path) -> bool {
+    if !plist_path.exists() {
+        return false;
+    }
+    let uid = std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+    if uid.is_empty() {
+        return false;
+    }
+    let domain = format!("gui/{uid}");
+    let plist_str = match plist_path.to_str() {
+        Some(s) => s,
+        None => return false,
+    };
+    std::process::Command::new("launchctl")
+        .args(["bootstrap", &domain, plist_str])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn try_launchctl_start(_plist_path: &std::path::Path) -> bool {
+    false
+}
+
+/// Extract the host token from a git remote URL (lowercased input expected).
+///
+/// Why: `is_github_remote` needs to compare the host portion of the URL, not
+/// the whole string, so that `github-duetto` SSH aliases are matched without
+/// also matching unrelated hosts that happen to contain `"github"`.
+/// What: handles scp-style (`git@HOST:path` → `HOST`), `https://[user@]HOST/…`,
+/// and `ssh://[user@]HOST/…`. Returns the full input when no host can be
+/// extracted — the caller's equality checks will then simply fail safely.
+/// Test: `is_github_remote_*` tests in `tests_behavior_c_tests.rs` exercise
+/// this indirectly; `github_host_*` tests verify extraction directly.
+pub(crate) fn github_host(lower_url: &str) -> &str {
+    // scp-style: git@HOST:path  — HOST is between '@' and ':'
+    if let Some(at) = lower_url.find('@') {
+        let after = &lower_url[at + 1..];
+        if let Some(col) = after.find(':') {
+            return &after[..col];
+        }
+    }
+    // scheme-URL: [scheme://][user@]HOST[/path]
+    let without_scheme = lower_url
+        .find("://")
+        .map(|i| &lower_url[i + 3..])
+        .unwrap_or(lower_url);
+    let after_userinfo = without_scheme
+        .find('@')
+        .map(|i| &without_scheme[i + 1..])
+        .unwrap_or(without_scheme);
+    after_userinfo.split('/').next().unwrap_or(after_userinfo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify the supervisor plist path is derived correctly from the label constant.
+    ///
+    /// Why: the path must match what `launchctl bootstrap` and the installer
+    /// both expect so they all refer to the same file.
+    /// What: asserts the filename is `<LABEL>.plist` and the parent dir is
+    /// `LaunchAgents`.
+    /// Test: this test.
+    #[test]
+    fn supervisor_plist_path_has_expected_components() {
+        let path = supervisor_plist_path();
+        let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        assert_eq!(
+            filename,
+            format!("{SUPERVISOR_PLIST_LABEL}.plist"),
+            "plist filename must be <LABEL>.plist"
+        );
+        let parent = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+        assert_eq!(
+            parent, "LaunchAgents",
+            "plist must live in ~/Library/LaunchAgents/"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_autostart.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_autostart.rs
@@ -12,7 +12,7 @@
 
 use anyhow::Context as _;
 
-/// The launchd label for the trusty-mpm supervisor plist.
+/// The launchd label for the trusty-mpm supervisor plist (macOS only).
 ///
 /// Why: the identical string appears as `PLIST_LABEL` in `trusty-installer`;
 /// defining it here avoids importing that crate (which would create a circular
@@ -21,6 +21,7 @@ use anyhow::Context as _;
 /// What: `"com.trusty.mpm.supervisor"`.
 /// Test: `supervisor_plist_path_has_expected_components` derives the filename
 /// from this constant and asserts it matches the expected plist basename.
+#[cfg(target_os = "macos")]
 pub(crate) const SUPERVISOR_PLIST_LABEL: &str = "com.trusty.mpm.supervisor";
 
 /// Resolve the expected macOS LaunchAgents path for the supervisor plist.
@@ -29,6 +30,7 @@ pub(crate) const SUPERVISOR_PLIST_LABEL: &str = "com.trusty.mpm.supervisor";
 /// plist is installed before deciding between launchd-start and detached-spawn.
 /// What: returns `~/Library/LaunchAgents/com.trusty.mpm.supervisor.plist`.
 /// Test: `supervisor_plist_path_has_expected_components`.
+#[cfg(target_os = "macos")]
 pub(crate) fn supervisor_plist_path() -> std::path::PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
@@ -233,6 +235,7 @@ mod tests {
     /// What: asserts the filename is `<LABEL>.plist` and the parent dir is
     /// `LaunchAgents`.
     /// Test: this test.
+    #[cfg(target_os = "macos")]
     #[test]
     fn supervisor_plist_path_has_expected_components() {
         let path = supervisor_plist_path();

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_autostart.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_autostart.rs
@@ -37,21 +37,42 @@ pub(crate) fn supervisor_plist_path() -> std::path::PathBuf {
         .join(format!("{SUPERVISOR_PLIST_LABEL}.plist"))
 }
 
+/// Outcome of a `launchctl bootstrap` attempt.
+///
+/// Why: distinguishes "already running" (EALREADY) from "truly unavailable" so
+/// `ensure_daemon_started` can skip the lock-delete+spawn step when launchd
+/// already owns the service, preventing a double-start race.
+/// What: three variants — `Launched` (exit 0), `AlreadyLoaded` (exit 37 /
+/// EALREADY or matching stderr), `Unavailable` (plist absent, `id -u` failed,
+/// or unknown non-zero exit).
+/// Test: covered indirectly by the launchd e2e smoke test; `Unavailable` path
+/// is exercised by the detached-spawn unit path.
+#[derive(Debug, PartialEq)]
+enum LaunchctlOutcome {
+    /// launchd accepted the bootstrap command — daemon is now (re)starting.
+    Launched,
+    /// launchd reports the service is already bootstrapped (exit 37 / EALREADY).
+    /// No second spawn is needed — proceed straight to the health-poll loop.
+    AlreadyLoaded,
+    /// launchctl is not available, the plist is absent, or bootstrap failed for
+    /// an unknown reason. Fall back to a detached direct spawn.
+    Unavailable,
+}
+
 /// Ensure the trusty-mpm daemon is running, starting it if unreachable.
 ///
 /// Why: bare `tm` in the guided-default flow should not require the operator
 /// to run `tm start` manually first. This helper transparently starts the
 /// daemon so the picker UX appears on every invocation.
-/// What: (1) on macOS, if the supervisor plist exists at
-/// `~/Library/LaunchAgents/com.trusty.mpm.supervisor.plist`, issues
-/// `launchctl bootstrap gui/<uid> <plist>` for reboot-durable startup;
-/// (2) otherwise removes any stale lock file and spawns the current executable
-/// with the `daemon` subcommand in a detached process (same logic as
-/// `commands::daemon::start`); (3) polls `/health` every 500 ms for up to 5 s
-/// via lock-file URL resolution; (4) returns the resolved daemon URL on success
-/// or `Err` on timeout. The `_url` parameter is intentionally unused: after
-/// auto-start the lock file records the actual bound address, which may differ
-/// from the stale or default URL the caller held.
+/// What: (1) on macOS, if the supervisor plist exists, issues
+/// `launchctl bootstrap gui/<uid> <plist>` for reboot-durable startup and
+/// skips the spawn step when the service is already loaded (EALREADY);
+/// (2) when launchd is unavailable or the plist is absent, removes any stale
+/// lock file and spawns the current executable with the `daemon` subcommand in
+/// a detached process; (3) polls `/health` every 500 ms for up to 5 s via
+/// lock-file URL resolution; (4) returns the resolved daemon URL on success or
+/// `Err` on timeout. The `_url` parameter is intentionally unused: after
+/// auto-start the lock file records the actual bound address.
 /// Test: launchd path requires a macOS launchd environment; detached-spawn and
 /// polling paths are covered by the guided-default e2e smoke test.
 pub(crate) async fn ensure_daemon_started(
@@ -59,28 +80,33 @@ pub(crate) async fn ensure_daemon_started(
     _url: &str,
 ) -> anyhow::Result<String> {
     let plist_path = supervisor_plist_path();
-    if !try_launchctl_start(&plist_path) {
-        // launchd not available or plist absent — fall back to detached spawn,
-        // the same approach used by `commands::daemon::start`.
-        let lock_path = trusty_mpm::core::lock_file_path();
-        let _ = std::fs::remove_file(&lock_path);
-        let root = trusty_mpm::core::paths::FrameworkPaths::default().root;
-        std::fs::create_dir_all(&root).context("create framework dir for daemon log")?;
-        let log_path = root.join("daemon.log");
-        let log_file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&log_path)
-            .context("open daemon log file")?;
-        let log_copy = log_file.try_clone().context("clone log file handle")?;
-        let exe = std::env::current_exe().context("resolve current executable path")?;
-        std::process::Command::new(&exe)
-            .arg("daemon")
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::from(log_file))
-            .stderr(std::process::Stdio::from(log_copy))
-            .spawn()
-            .context("spawn daemon process")?;
+    match try_launchctl_start(&plist_path) {
+        LaunchctlOutcome::Launched | LaunchctlOutcome::AlreadyLoaded => {
+            // launchd owns the service — no second spawn needed.
+        }
+        LaunchctlOutcome::Unavailable => {
+            // launchd not available or plist absent — fall back to detached
+            // spawn, the same approach used by `commands::daemon::start`.
+            let lock_path = trusty_mpm::core::lock_file_path();
+            let _ = std::fs::remove_file(&lock_path);
+            let root = trusty_mpm::core::paths::FrameworkPaths::default().root;
+            std::fs::create_dir_all(&root).context("create framework dir for daemon log")?;
+            let log_path = root.join("daemon.log");
+            let log_file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_path)
+                .context("open daemon log file")?;
+            let log_copy = log_file.try_clone().context("clone log file handle")?;
+            let exe = std::env::current_exe().context("resolve current executable path")?;
+            std::process::Command::new(&exe)
+                .arg("daemon")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::from(log_file))
+                .stderr(std::process::Stdio::from(log_copy))
+                .spawn()
+                .context("spawn daemon process")?;
+        }
     }
 
     // Poll until healthy or timeout (5 s). Re-resolve from the lock file each
@@ -102,15 +128,15 @@ pub(crate) async fn ensure_daemon_started(
 /// launchd registers the unit for reboot-durability and respawn-on-crash. The
 /// detached-spawn fallback is session-only (no reboot durability).
 /// What: on macOS, if `plist_path` exists, resolves the current user UID via
-/// `id -u`, then runs `launchctl bootstrap gui/<uid> <plist>`. Returns `true`
-/// when the command exits 0. Returns `false` on non-macOS, when the plist is
-/// absent, when `id -u` fails, or when `launchctl` exits non-zero (e.g. already
-/// loaded — the caller falls through to the polling wait either way).
+/// `id -u`, then runs `launchctl bootstrap gui/<uid> <plist>`. Returns
+/// `Launched` on exit 0, `AlreadyLoaded` on exit 37 (EALREADY) or when stderr
+/// contains "already bootstrapped"/"service already loaded", and `Unavailable`
+/// in all other cases (plist absent, `id -u` failure, unknown launchctl error).
 /// Test: requires a real macOS launchd environment; covered by e2e smoke test.
 #[cfg(target_os = "macos")]
-fn try_launchctl_start(plist_path: &std::path::Path) -> bool {
+fn try_launchctl_start(plist_path: &std::path::Path) -> LaunchctlOutcome {
     if !plist_path.exists() {
-        return false;
+        return LaunchctlOutcome::Unavailable;
     }
     let uid = std::process::Command::new("id")
         .arg("-u")
@@ -120,23 +146,37 @@ fn try_launchctl_start(plist_path: &std::path::Path) -> bool {
         .map(|s| s.trim().to_string())
         .unwrap_or_default();
     if uid.is_empty() {
-        return false;
+        return LaunchctlOutcome::Unavailable;
     }
     let domain = format!("gui/{uid}");
     let plist_str = match plist_path.to_str() {
         Some(s) => s,
-        None => return false,
+        None => return LaunchctlOutcome::Unavailable,
     };
-    std::process::Command::new("launchctl")
+    let output = match std::process::Command::new("launchctl")
         .args(["bootstrap", &domain, plist_str])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return LaunchctlOutcome::Unavailable,
+    };
+    if output.status.success() {
+        return LaunchctlOutcome::Launched;
+    }
+    // exit 37 = EALREADY; some launchctl versions surface this in stderr instead.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if output.status.code() == Some(37)
+        || stderr.contains("already bootstrapped")
+        || stderr.contains("service already loaded")
+    {
+        return LaunchctlOutcome::AlreadyLoaded;
+    }
+    LaunchctlOutcome::Unavailable
 }
 
 #[cfg(not(target_os = "macos"))]
-fn try_launchctl_start(_plist_path: &std::path::Path) -> bool {
-    false
+fn try_launchctl_start(_plist_path: &std::path::Path) -> LaunchctlOutcome {
+    LaunchctlOutcome::Unavailable
 }
 
 /// Extract the host token from a git remote URL (lowercased input expected).
@@ -145,19 +185,21 @@ fn try_launchctl_start(_plist_path: &std::path::Path) -> bool {
 /// the whole string, so that `github-duetto` SSH aliases are matched without
 /// also matching unrelated hosts that happen to contain `"github"`.
 /// What: handles scp-style (`git@HOST:path` → `HOST`), `https://[user@]HOST/…`,
-/// and `ssh://[user@]HOST/…`. Returns the full input when no host can be
-/// extracted — the caller's equality checks will then simply fail safely.
+/// and `ssh://[user@]HOST/…`. Strips any trailing `:<port>` from scheme-style
+/// URLs so `github.com:443` → `github.com`. Returns the full input when no
+/// host can be extracted — the caller's equality checks will then simply fail.
 /// Test: `is_github_remote_*` tests in `tests_behavior_c_tests.rs` exercise
 /// this indirectly; `github_host_*` tests verify extraction directly.
 pub(crate) fn github_host(lower_url: &str) -> &str {
-    // scp-style: git@HOST:path  — HOST is between '@' and ':'
+    // scp-style: git@HOST:path  — HOST is between '@' and first ':'
+    // (no port in scp-style; the ':' separates host from path)
     if let Some(at) = lower_url.find('@') {
         let after = &lower_url[at + 1..];
         if let Some(col) = after.find(':') {
             return &after[..col];
         }
     }
-    // scheme-URL: [scheme://][user@]HOST[/path]
+    // scheme-URL: [scheme://][user@]HOST[:port][/path]
     let without_scheme = lower_url
         .find("://")
         .map(|i| &lower_url[i + 3..])
@@ -166,7 +208,16 @@ pub(crate) fn github_host(lower_url: &str) -> &str {
         .find('@')
         .map(|i| &without_scheme[i + 1..])
         .unwrap_or(without_scheme);
-    after_userinfo.split('/').next().unwrap_or(after_userinfo)
+    let host_with_port = after_userinfo.split('/').next().unwrap_or(after_userinfo);
+    // Strip optional :<port> suffix (e.g. "github.com:443" → "github.com").
+    // Only strip when the suffix is all ASCII digits to avoid mangling IPv6.
+    if let Some(colon) = host_with_port.rfind(':') {
+        let port_str = &host_with_port[colon + 1..];
+        if !port_str.is_empty() && port_str.chars().all(|c| c.is_ascii_digit()) {
+            return &host_with_port[..colon];
+        }
+    }
+    host_with_port
 }
 
 #[cfg(test)]
@@ -197,6 +248,33 @@ mod tests {
         assert_eq!(
             parent, "LaunchAgents",
             "plist must live in ~/Library/LaunchAgents/"
+        );
+    }
+
+    /// Verify github_host strips a port suffix from scheme-style URLs.
+    ///
+    /// Why: `https://github.com:443/o/r.git` is a valid remote URL but the
+    /// old code returned `"github.com:443"`, causing `is_github_remote` to
+    /// return false — a regression vs the previous substring-match approach.
+    /// What: asserts `github_host` strips `":443"` so `is_github_remote` fires.
+    /// Test: this test; regression guard for the port-stripping fix.
+    #[test]
+    fn github_host_strips_port_from_https_url() {
+        assert_eq!(
+            github_host("https://github.com:443/owner/repo.git"),
+            "github.com",
+            "port suffix must be stripped from https:// URLs"
+        );
+        assert_eq!(
+            github_host("ssh://git@github-work:2222/o/r.git"),
+            "github-work",
+            "port suffix must be stripped from ssh:// URLs with userinfo"
+        );
+        // scp-style has no port — unchanged
+        assert_eq!(
+            github_host("git@github.com:owner/repo.git"),
+            "github.com",
+            "scp-style host must be unaffected"
         );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -12,6 +12,7 @@
 pub(crate) mod banner;
 pub(crate) mod daemon;
 pub(crate) mod guided;
+pub(crate) mod guided_autostart;
 pub(crate) mod install;
 pub(crate) mod issue;
 pub(crate) mod launch;

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -558,6 +558,18 @@ fn is_github_remote_rejects_githubusercontent() {
 }
 
 #[test]
+fn is_github_remote_accepts_github_com_https_with_port() {
+    // Why: `https://github.com:443/o/r.git` is a valid remote URL (explicit
+    // port). The old substring-match handled this; the host-based approach
+    // regressed on it because `split('/').next()` returned `"github.com:443"`.
+    // This is the regression guard for the port-stripping fix.
+    assert!(
+        is_github_remote("https://github.com:443/o/r.git"),
+        "https://github.com:443/… must be recognised as GitHub (port stripped)"
+    );
+}
+
+#[test]
 fn is_github_remote_rejects_gitea_with_github_in_path() {
     // Why: a self-hosted Gitea whose URL happens to mention "github" in the
     // path (e.g. a mirror) must not be treated as GitHub.

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -12,8 +12,8 @@
 use std::path::PathBuf;
 
 use crate::commands::guided::{
-    PickerDecision, derive_project, fallback_protected, is_zombie, needs_restart,
-    parse_picker_choice, print_non_tty_hint, print_project_context, tty_gate,
+    PickerDecision, derive_project, fallback_protected, github_host, is_github_remote, is_zombie,
+    needs_restart, parse_picker_choice, print_non_tty_hint, print_project_context, tty_gate,
 };
 
 // ── parse_picker_choice ───────────────────────────────────────────────────────
@@ -473,5 +473,227 @@ fn guided_resume_not_zombie_active_with_tmux() {
     assert!(
         !is_zombie("active", true),
         "active + live tmux is the normal attach path, not a zombie"
+    );
+}
+
+// ── is_github_remote (Change 2: SSH alias support) ───────────────────────────
+
+#[test]
+fn is_github_remote_accepts_github_com_ssh() {
+    // Why: `git@github.com:o/r.git` is the canonical SSH GitHub URL.
+    assert!(
+        is_github_remote("git@github.com:o/r.git"),
+        "github.com SSH must be recognised as GitHub"
+    );
+}
+
+#[test]
+fn is_github_remote_accepts_github_com_https() {
+    // Why: `https://github.com/o/r.git` is the canonical HTTPS GitHub URL.
+    assert!(
+        is_github_remote("https://github.com/o/r.git"),
+        "github.com HTTPS must be recognised as GitHub"
+    );
+}
+
+#[test]
+fn is_github_remote_accepts_github_hyphen_alias() {
+    // Why: `git@github-duetto:duettoresearch/aria.git` is the real-world repro
+    // case from the issue. Multi-account SSH aliases use `github-<name>`.
+    assert!(
+        is_github_remote("git@github-duetto:duettoresearch/aria.git"),
+        "github-<alias> SSH remote must be recognised as GitHub"
+    );
+}
+
+#[test]
+fn is_github_remote_accepts_github_alias_ssh_url_style() {
+    // Why: `ssh://git@github-work/o/r` uses scheme-URL form with an alias host.
+    assert!(
+        is_github_remote("ssh://git@github-work/o/r"),
+        "ssh:// github-<alias> must be recognised as GitHub"
+    );
+}
+
+#[test]
+fn is_github_remote_accepts_github_underscore_alias() {
+    // Why: some operators use underscores in their SSH config host aliases
+    // (e.g. `github_personal`). The rule covers `-` and `_` separators.
+    assert!(
+        is_github_remote("git@github_personal:user/repo.git"),
+        "github_<alias> SSH remote must be recognised as GitHub"
+    );
+}
+
+#[test]
+fn is_github_remote_rejects_gitlab() {
+    // Why: GitLab URLs must NEVER be treated as GitHub to avoid an unexpected
+    // managed-clone redirect for non-GitHub projects.
+    assert!(
+        !is_github_remote("git@gitlab.com:o/r.git"),
+        "gitlab.com must NOT be recognised as GitHub"
+    );
+}
+
+#[test]
+fn is_github_remote_rejects_bitbucket() {
+    // Why: Bitbucket is not GitHub; the guard must block it.
+    assert!(
+        !is_github_remote("https://bitbucket.org/o/r"),
+        "bitbucket.org must NOT be recognised as GitHub"
+    );
+}
+
+#[test]
+fn is_github_remote_rejects_githubusercontent() {
+    // Why: `raw.githubusercontent.com` contains `github` but is a content
+    // delivery host, not a clone remote. The host does NOT start with
+    // `github-` or `github_`, and it is not `github.com`, so it must be
+    // blocked. (Cloning from this host would fail anyway, but blocking it
+    // prevents a misleading redirect attempt.)
+    assert!(
+        !is_github_remote("https://raw.githubusercontent.com/o/r/file"),
+        "githubusercontent.com must NOT be recognised as GitHub"
+    );
+}
+
+#[test]
+fn is_github_remote_rejects_gitea_with_github_in_path() {
+    // Why: a self-hosted Gitea whose URL happens to mention "github" in the
+    // path (e.g. a mirror) must not be treated as GitHub.
+    assert!(
+        !is_github_remote("https://gitea.example.com/mirrors/github-fork.git"),
+        "gitea host with github in path must NOT match"
+    );
+}
+
+// ── github_host extraction ────────────────────────────────────────────────────
+
+#[test]
+fn github_host_extracts_scp_style() {
+    // Why: the most common GitHub remote form is scp-style `git@HOST:path`.
+    assert_eq!(
+        github_host("git@github-duetto:duettoresearch/aria.git"),
+        "github-duetto"
+    );
+    assert_eq!(github_host("git@github.com:owner/repo.git"), "github.com");
+}
+
+#[test]
+fn github_host_extracts_https() {
+    // Why: HTTPS remotes use scheme-URL form `https://HOST/path`.
+    assert_eq!(
+        github_host("https://github.com/owner/repo.git"),
+        "github.com"
+    );
+    assert_eq!(github_host("https://gitlab.com/o/r"), "gitlab.com");
+}
+
+#[test]
+fn github_host_extracts_ssh_url_with_user() {
+    // Why: `ssh://git@HOST/path` is the RFC-compliant SSH URL form.
+    assert_eq!(github_host("ssh://git@github-work/o/r"), "github-work");
+}
+
+// ── derive_project accepts SSH alias remote ──────────────────────────────────
+
+#[test]
+fn guided_derive_project_accepts_github_ssh_alias() {
+    // Why: `derive_project` uses `is_github_remote` internally. With the
+    // SSH-alias fix, a repo whose origin is `git@github-duetto:owner/repo.git`
+    // must return Some with the correct source_id.
+    let tmp = tempdir_with_name("trusty_test_github_alias_derive_1705");
+    let ok = git_init_with_commit(&tmp);
+    if !ok {
+        return;
+    }
+    git_remote_add(&tmp, "git@github-duetto:duettoresearch/aria.git");
+    let result = derive_project(&tmp);
+    match result {
+        Some((source_id, _workspace, _git_root)) => {
+            assert_eq!(
+                source_id, "duettoresearch/aria",
+                "source_id must be parsed correctly from alias remote"
+            );
+        }
+        None => panic!("expected Some for GitHub SSH alias remote, got None"),
+    }
+}
+
+// ── fallback_protected with SSH alias does not hit GitHub-remote refusal ─────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn guided_fallback_does_not_refuse_github_ssh_alias_remote() {
+    // Why: before this fix, `git@github-duetto:duettoresearch/aria.git`
+    // triggered the "Auto-protected managed clones require a GitHub remote"
+    // error because `is_github_remote` only matched `github.com`. The SSH alias
+    // host `github-duetto` was not recognised, so `fallback_protected` fell
+    // into the non-GitHub refusal path. This test locks in the fix.
+    // What: creates a real git repo, sets the SSH-alias remote, and calls
+    // `fallback_protected`. Asserts the result is NOT the GitHub-remote
+    // refusal error. (It may still be an Err from the clone attempt failing
+    // due to the daemon being unreachable — that is expected and acceptable.)
+    // Test: this is the test; annotated `serial` because it may set REPOS_ROOT.
+    let dir = tempdir_with_name("trusty_test_github_alias_fallback_1705");
+    let ok = std::process::Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !ok {
+        eprintln!(
+            "guided_fallback_does_not_refuse_github_ssh_alias_remote: git unavailable, skipping"
+        );
+        return;
+    }
+    let _ = std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "git@github-duetto:duettoresearch/aria.git",
+        ])
+        .current_dir(&dir)
+        .status();
+
+    // Point REPOS_ROOT at a tempdir so we don't pollute the real repos root
+    // and to make `ensure_base_clone` fail fast (base/.git absent → clone
+    // attempt → network failure → Err, which is what we want to assert on).
+    let repos_root = tempfile::tempdir().unwrap();
+    let repos_root_key = trusty_mpm::daemon::managed_routes::inproject::REPOS_ROOT_ENV;
+    let prev = std::env::var(repos_root_key).ok();
+    unsafe { std::env::set_var(repos_root_key, repos_root.path()) };
+
+    let client = reqwest::Client::new();
+    let result = fallback_protected(&client, "http://127.0.0.1:1", &dir).await;
+
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var(repos_root_key, v),
+            None => std::env::remove_var(repos_root_key),
+        }
+    }
+
+    // The call must fail (daemon unreachable + clone fails), but NOT with the
+    // "requires a GitHub remote" refusal message.
+    assert!(
+        result.is_err(),
+        "fallback must Err (daemon unreachable / clone fails)"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        !err_msg.contains("auto-managed clones require a GitHub remote"),
+        "SSH alias remote must NOT trigger GitHub-remote refusal; got: {err_msg}"
+    );
+    // Also confirm no framework files landed in the live checkout.
+    assert!(
+        !dir.join("CLAUDE.md").exists(),
+        "CLAUDE.md must NOT appear in the live checkout"
+    );
+    assert!(
+        !dir.join(".mcp.json").exists(),
+        ".mcp.json must NOT appear in the live checkout"
     );
 }


### PR DESCRIPTION
Closes #1775

## Summary

- **Auto-start daemon**: bare `tm` now transparently starts the daemon when unreachable (launchctl supervisor plist preferred, detached spawn fallback), retries the picker, and falls back gracefully — no more manual `tm start` prerequisite.
- **GitHub SSH alias recognition**: `is_github_remote` now matches `github-*` and `github_*` host aliases (e.g. `git@github-duetto:…`) in addition to `github.com`, enabling the managed-clone picker UX for multi-account SSH setups.
- **SLOC cap maintained**: both helpers extracted into a new `commands::guided_autostart` module, keeping `guided.rs` under the 500-SLOC production cap.

## Changes

| File | Description |
|------|-------------|
| `commands/guided_autostart.rs` (new) | `github_host` extractor, `ensure_daemon_started`, `supervisor_plist_path`, `SUPERVISOR_PLIST_LABEL` |
| `commands/mod.rs` | Register `pub(crate) mod guided_autostart` |
| `commands/guided.rs` | Re-export `github_host`; new `is_github_remote` host-based matching; `run_guided_default` auto-start loop; `try_show_picker` DRY helper |
| `tests_behavior_c_tests.rs` | 13 new unit tests: `is_github_remote_*`, `github_host_*`, `guided_derive_project_accepts_github_ssh_alias`, `guided_fallback_does_not_refuse_github_ssh_alias_remote` |

## Test plan

- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt -p trusty-mpm --check` — no drift
- [x] `bash scripts/check_line_cap.sh` — 0 violations (guided.rs ~490 SLOC, guided_autostart.rs ~140 SLOC)
- [x] `cargo test -p trusty-mpm --bin tm -- is_github_remote github_host guided_derive guided_fallback supervisor_plist` — 26 tests pass
- [x] Full `cargo test -p trusty-mpm` — 2073 pass, 1 pre-existing unrelated failure (`global_config::test_mcp_config_review_no_home_write`), 3 ignored

## Invariants preserved

The live-checkout protection is unchanged. Auto-start only removes the `tm start` prerequisite; `fallback_protected` continues to gate all deployment paths as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
