### PR TITLE
fix(trusty-mpm): non-GitHub remote refusal no longer blames daemon reachability (#1777)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -11,8 +11,10 @@
 //! What: [`run_guided_default`] orchestrates detection, listing, and dispatch.
 //! [`derive_project`] derives the `source_id`, managed workspace, and git root.
 //! [`fallback_protected`] is the three-way dispatch for the daemon-unreachable
-//! path; it is also the target for non-GitHub projects. The TTY picker is
-//! split into a pure `parse_picker_choice` + an I/O driver `run_tty_picker`.
+//! path; it is also the target for non-GitHub projects. [`non_github_refusal_message`]
+//! is the pure helper that produces the accurate refusal text for the
+//! non-GitHub-remote case (see #1777). The TTY picker is split into a pure
+//! `parse_picker_choice` + an I/O driver `run_tty_picker`.
 //!
 //! Test: unit tests for detection and fallback live in `tests_behavior_b_tests.rs`
 //! (#1724 regression suite) and `tests_behavior_c_tests.rs` (#1705 new UX suite);
@@ -667,6 +669,26 @@ async fn launch_new_session_and_attach(
 
 // ── Fallback (daemon-unreachable / non-GitHub) path ─────────────────────────
 
+/// Build the user-facing refusal notice for a non-GitHub-remote refusal.
+///
+/// Why: the non-GitHub-remote branch of [`fallback_protected`] previously
+/// printed "daemon unreachable" wording, which is wrong when the daemon IS
+/// running — the refusal is purely because `tm` only auto-manages GitHub
+/// repositories. Extracting the message into a pure helper makes it
+/// unit-testable without capturing stderr.
+/// What: returns a three-line notice that names the non-GitHub remote as the
+/// reason for refusal and reassures the operator that the live checkout was
+/// not modified. The caller prints via `eprintln!` and then bails.
+/// Test: `guided_non_github_refusal_message_*` in `tests_behavior_c_tests.rs`.
+pub(crate) fn non_github_refusal_message(remote_desc: &str) -> String {
+    format!(
+        "tm: not auto-managing this project — `tm` auto-manages GitHub repositories only.\n\
+         tm: detected non-GitHub remote: {remote_desc}.\n\
+         tm: your live checkout was not touched. \
+         (Use an explicit `tm` subcommand to work here manually.)"
+    )
+}
+
 /// Return true when the remote URL targets GitHub (any transport or SSH alias).
 ///
 /// Why: `parse_github_path` from `trusty-common` accepts *any* git remote URL,
@@ -770,17 +792,15 @@ pub(crate) async fn fallback_protected(
         }
 
         // Non-GitHub remote or no remote: refuse to write to the live tree.
+        // NOTE: the daemon's reachability is irrelevant here — this branch is
+        // reached even when the daemon is UP. The real reason for refusal is
+        // that `tm` only auto-manages GitHub repositories (#1777).
         let remote_desc = origin_url.as_deref().unwrap_or("(no remote configured)");
-        eprintln!(
-            "tm: daemon unreachable — refusing to deploy into live git checkout.\n\
-             tm: Auto-protected managed clones require a GitHub remote \
-             (detected remote: {remote_desc}).\n\
-             tm: Start the daemon with `tm start`, then run `tm` again."
-        );
+        eprintln!("{}", non_github_refusal_message(remote_desc));
         anyhow::bail!(
-            "daemon unreachable: live git checkout at '{}' is protected — \
+            "not auto-managing: live git checkout at '{}' is a non-GitHub repository — \
              auto-managed clones require a GitHub remote; \
-             start the daemon with `tm start` first",
+             use an explicit `tm` subcommand to work here manually",
             git_root.display()
         );
     }

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -13,7 +13,8 @@ use std::path::PathBuf;
 
 use crate::commands::guided::{
     PickerDecision, derive_project, fallback_protected, github_host, is_github_remote, is_zombie,
-    needs_restart, parse_picker_choice, print_non_tty_hint, print_project_context, tty_gate,
+    needs_restart, non_github_refusal_message, parse_picker_choice, print_non_tty_hint,
+    print_project_context, tty_gate,
 };
 
 // ── parse_picker_choice ───────────────────────────────────────────────────────
@@ -707,5 +708,82 @@ async fn guided_fallback_does_not_refuse_github_ssh_alias_remote() {
     assert!(
         !dir.join(".mcp.json").exists(),
         ".mcp.json must NOT appear in the live checkout"
+    );
+}
+
+// ── non_github_refusal_message (#1777) ───────────────────────────────────────
+// These tests verify the message helper introduced to fix the misleading
+// "daemon unreachable" wording shown when the actual reason for refusal is
+// "not a GitHub remote". The helper is pure — no stderr capture needed.
+
+#[test]
+fn guided_non_github_refusal_message_does_not_mention_daemon_or_start() {
+    // Why: the old message wrongly said "daemon unreachable" even when the
+    // daemon is running. The new message must never reference daemon
+    // reachability or the `tm start` command (#1777).
+    // What: call the helper with a GitLab remote and assert forbidden phrases
+    // are absent.
+    // Test: this is the test.
+    let msg = non_github_refusal_message("git@gitlab.com:org/repo.git");
+    assert!(
+        !msg.contains("daemon unreachable"),
+        "refusal message must NOT blame the daemon: {msg}"
+    );
+    assert!(
+        !msg.contains("tm start"),
+        "refusal message must NOT instruct to start the daemon: {msg}"
+    );
+    assert!(
+        !msg.contains("Start the daemon"),
+        "refusal message must NOT mention starting the daemon: {msg}"
+    );
+}
+
+#[test]
+fn guided_non_github_refusal_message_explains_github_only_policy() {
+    // Why: operators need to understand the actual reason — `tm` auto-manages
+    // GitHub repositories only, not Gitea/GitLab/bare-SSH remotes.
+    // What: asserts the message names "GitHub" as the requirement.
+    // Test: this is the test.
+    let msg = non_github_refusal_message("https://gitea.example.com/org/repo.git");
+    assert!(
+        msg.contains("GitHub"),
+        "refusal must name GitHub as the auto-management requirement: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("auto-manag"),
+        "refusal must mention auto-management scope: {msg}"
+    );
+}
+
+#[test]
+fn guided_non_github_refusal_message_includes_detected_remote() {
+    // Why: showing the detected remote URL in the message lets the operator
+    // immediately confirm which remote triggered the refusal — useful when
+    // running `tm` in a repo with multiple or aliased remotes.
+    // What: asserts the passed-in remote string appears verbatim in the output.
+    // Test: this is the test.
+    let remote = "git@gitlab.com:myorg/myrepo.git";
+    let msg = non_github_refusal_message(remote);
+    assert!(
+        msg.contains(remote),
+        "refusal must echo the detected remote ({remote}): {msg}"
+    );
+}
+
+#[test]
+fn guided_non_github_refusal_message_reassures_live_checkout_untouched() {
+    // Why: the operator may be anxious that `tm` modified their working tree.
+    // The message must clearly state the live checkout was not touched.
+    // What: asserts the reassurance phrase appears in the output.
+    // Test: this is the test.
+    let msg = non_github_refusal_message("https://bitbucket.org/org/repo.git");
+    assert!(
+        msg.contains("live checkout"),
+        "refusal must reassure that the live checkout was not touched: {msg}"
+    );
+    assert!(
+        msg.contains("not touched"),
+        "refusal must use the phrase 'not touched': {msg}"
     );
 }


### PR DESCRIPTION
## Problem

Running `tm` inside a GitLab (or any non-GitHub) repository printed:

```
tm: daemon unreachable — refusing to deploy into live git checkout.
tm: Auto-protected managed clones require a GitHub remote (detected remote: git@gitlab.com:org/repo.git).
tm: Start the daemon with `tm start`, then run `tm` again.
```

This message is wrong: the daemon's reachability is **irrelevant** in this branch. The daemon can be up and healthy and the user still sees "daemon unreachable". The actual reason is that `tm` only auto-manages GitHub repositories.

Closes #1777.

## Changes

- **`crates/trusty-mpm/src/bin/tm/commands/guided.rs`**
  - Add `pub(crate) fn non_github_refusal_message(remote_desc: &str) -> String` — a pure helper that returns the accurate refusal text (no daemon wording).
  - Update `fallback_protected`'s non-GitHub branch to use the helper.
  - Update `anyhow::bail!` to remove "daemon unreachable" wording while preserving "live git checkout" and "auto-managed clones require a GitHub remote" so existing `#1724` tests still pass.

- **`crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs`**
  - Import `non_github_refusal_message`.
  - Add four unit tests asserting:
    1. `guided_non_github_refusal_message_does_not_mention_daemon_or_start`
    2. `guided_non_github_refusal_message_explains_github_only_policy`
    3. `guided_non_github_refusal_message_includes_detected_remote`
    4. `guided_non_github_refusal_message_reassures_live_checkout_untouched`

## Before / After

**Before (incorrect):**
```
tm: daemon unreachable — refusing to deploy into live git checkout.
tm: Auto-protected managed clones require a GitHub remote (detected remote: git@gitlab.com:org/repo.git).
tm: Start the daemon with `tm start`, then run `tm` again.
```

**After (accurate):**
```
tm: not auto-managing this project — `tm` auto-manages GitHub repositories only.
tm: detected non-GitHub remote: git@gitlab.com:org/repo.git.
tm: your live checkout was not touched. (Use an explicit `tm` subcommand to work here manually.)
```

## Paths NOT changed

- `redirect_to_managed_clone` (GitHub path, daemon truly down) — still says "daemon unreachable". Correct.
- Auto-start failure path in `run_guided_default` — still says "daemon not running". Correct.
- `resume_guided_session` daemon-POST failure — still says "daemon unreachable". Correct.

## Test results

```
test tests_behavior_c::guided_non_github_refusal_message_does_not_mention_daemon_or_start ... ok
test tests_behavior_c::guided_non_github_refusal_message_explains_github_only_policy ... ok
test tests_behavior_c::guided_non_github_refusal_message_includes_detected_remote ... ok
test tests_behavior_c::guided_non_github_refusal_message_reassures_live_checkout_untouched ... ok
test result: ok. 557 passed; 0 failed; 1 ignored
```

- `cargo check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — clean (488 → 497 SLOC in `guided.rs`, still under 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)