### PR TITLE
feat(trusty-search): prune subcommand for idle-index cleanup (#1782)

### DIFF
--- a/crates/trusty-search/src/commands/mod.rs
+++ b/crates/trusty-search/src/commands/mod.rs
@@ -71,3 +71,22 @@ pub mod status;
 pub mod stop;
 pub mod upgrade;
 pub mod watch;
+
+/// Shared y/N confirmation prompt used by `prune` and `prune-orphans`.
+///
+/// Why: both prune commands need the same interactive confirmation gate;
+///      extracting here removes duplication and makes the UX consistent.
+/// What: prints `<prompt> [y/N] ` to stdout, reads one line from stdin,
+///       returns `true` when the trimmed reply starts with `y` or `Y`.
+/// Test: bypassed in callers via `interactive=false`; always returns `false`
+///       without consuming stdin when the caller skips it.
+pub(crate) fn confirm(prompt: &str) -> anyhow::Result<bool> {
+    use std::io::{BufRead, Write};
+    print!("{} [y/N] ", prompt);
+    std::io::stdout().flush().ok();
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line)?;
+    let answer = line.trim();
+    Ok(matches!(answer.chars().next(), Some('y') | Some('Y')))
+}

--- a/crates/trusty-search/src/commands/mod.rs
+++ b/crates/trusty-search/src/commands/mod.rs
@@ -56,6 +56,7 @@ pub mod migrate_storage;
 pub mod monitor;
 pub mod port;
 pub(crate) mod prior_index_count;
+pub mod prune;
 pub mod prune_orphans;
 pub mod query;
 pub mod reindex;

--- a/crates/trusty-search/src/commands/prune.rs
+++ b/crates/trusty-search/src/commands/prune.rs
@@ -20,15 +20,17 @@
 //!   `last_indexed_unix = None`) are NOT eligible — they may have been freshly
 //!   created or belong to a pre-tracking installation; deleting them would be
 //!   surprising.
-//! - The `auto_prune.enabled` config flag governs the daemon-side scheduled
-//!   sweep. The manual `prune --apply` command does NOT require `enabled=true`
-//!   — explicit use of `--apply` is sufficient operator intent. Set `enabled`
-//!   to opt in to future daemon-driven automatic deletion.
+//! - The `auto_prune.enabled` config flag governs the future daemon-side
+//!   scheduled sweep. The manual `prune --apply` command does NOT check this
+//!   flag — explicit `--apply` is sufficient operator intent.
 //! - Malformed config (YAML parse error): propagated as an error when `--apply`
 //!   is active so that a corrupt config cannot silently empty `protected_indexes`
 //!   and delete something that should be protected. Dry-runs warn but proceed.
+//! - `--max-idle-days` must be at least 1; 0 would make every tracked index
+//!   eligible and is rejected as a footgun.
 //! - Stop the daemon before `--apply` to avoid a race between the daemon's
 //!   periodic `last_queried_unix` flush and the registry save here.
+//! - Dry-run (no `--apply`) performs NO filesystem mutations of any kind.
 //!
 //! Persistence approach: `last_queried_unix` is already written to
 //! `indexes.toml` by the daemon search handler (rate-limited to at most once
@@ -46,12 +48,13 @@
 
 use anyhow::{Context, Result};
 use colored::Colorize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::config::{AutoPruneConfig, GlobalConfig};
+use crate::service::colocated_storage::COLOCATED_DIR_NAME;
 use crate::service::persistence::{
-    data_dir, indexes_toml_path, load_index_registry_at, remove_index_data_dir,
+    indexes_toml_path, load_index_registry_at, remove_index_data_dir, sanitize_id_for_path,
     save_index_registry_at, PersistedIndex,
 };
 
@@ -147,39 +150,34 @@ pub(crate) fn format_bytes(bytes: u64) -> String {
 
 /// Entry point for `trusty-search prune [--max-idle-days N] [--apply] [--yes]`.
 ///
-/// Why: keep the CLI handler thin; all logic in `handle_prune_at` which is
-///      testable with injected config / path / size_fn / now_unix.
-/// What: loads `GlobalConfig`, applies CLI overrides, delegates to
-///       `handle_prune_at`. When `--apply` is active a malformed config is a
-///       hard error (so corrupt config cannot silence `protected_indexes`).
-///       A dry-run emits a warning and proceeds with defaults.
-/// Test: covered by `handle_prune_at` unit tests in `prune_tests`.
+/// Why: keep the CLI handler thin; delegates to `handle_prune_configured`
+///      with no config-path override (uses the default platform path).
+/// What: calls `handle_prune_configured(None, ...)`.
+/// Test: covered by `handle_prune_configured` unit tests in `prune_tests`.
 pub fn handle_prune(apply: bool, yes: bool, max_idle_days_override: Option<u32>) -> Result<()> {
-    let toml_path = indexes_toml_path()?;
+    handle_prune_configured(None, apply, yes, max_idle_days_override)
+}
 
-    // Load global config for prune settings.
-    let prune_cfg = match GlobalConfig::load() {
-        Ok(cfg) => cfg.auto_prune,
-        Err(e) => {
-            if apply {
-                // CRITICAL: malformed config when --apply is active could
-                // silently clear protected_indexes and delete protected data.
-                return Err(e).context(
-                    "config.yaml is malformed — refusing --apply to protect \
-                     indexes listed in auto_prune.protected_indexes. \
-                     Fix config.yaml or remove the file to reset to defaults.",
-                );
-            }
-            // Dry-run: warn and proceed with defaults (no deletions happen).
-            eprintln!(
-                "{} config.yaml could not be parsed ({}); proceeding with defaults \
-                 for dry-run. Protected indexes may not be highlighted correctly.",
-                "warning:".yellow().bold(),
-                e
-            );
-            AutoPruneConfig::default()
-        }
-    };
+/// Config-path-injectable entry point for `trusty-search prune`.
+///
+/// Why: `handle_prune` reads GlobalConfig from the default platform path,
+///      which is not injectable in unit tests. This variant accepts an explicit
+///      `config_path` so tests can exercise the malformed-config abort guard.
+/// What: loads `GlobalConfig` (from `config_path` when `Some`, otherwise the
+///       default path), aborts if config is malformed and `--apply` is active,
+///       resolves the registry path, and delegates to `handle_prune_at`.
+/// Test: `prune_malformed_config_aborts_apply` in `prune_tests`.
+pub(crate) fn handle_prune_configured(
+    config_path: Option<&Path>,
+    apply: bool,
+    yes: bool,
+    max_idle_days_override: Option<u32>,
+) -> Result<()> {
+    // Load config FIRST so malformed config + --apply aborts before any
+    // registry or filesystem access.
+    let prune_cfg = load_prune_config(config_path, apply)?;
+
+    let toml_path = indexes_toml_path()?;
 
     handle_prune_at(
         &toml_path,
@@ -193,7 +191,44 @@ pub fn handle_prune(apply: bool, yes: bool, max_idle_days_override: Option<u32>)
     )
 }
 
-/// Path-injectable variant of [`handle_prune`].
+/// Load and validate the `auto_prune` section of `GlobalConfig`.
+///
+/// Why: extracted so both `handle_prune_configured` and tests share the same
+///      error propagation / dry-run fallback logic.
+/// What: loads from `config_path` (or default path when `None`). When config
+///       is malformed and `apply=true`, propagates the error so no deletions can
+///       proceed with silenced `protected_indexes`. When `apply=false`, warns and
+///       proceeds with defaults.
+/// Test: `prune_malformed_config_aborts_apply` in `prune_tests`.
+fn load_prune_config(config_path: Option<&Path>, apply: bool) -> Result<AutoPruneConfig> {
+    let result = match config_path {
+        Some(p) => GlobalConfig::load_from(p),
+        None => GlobalConfig::load(),
+    };
+    match result {
+        Ok(cfg) => Ok(cfg.auto_prune),
+        Err(e) => {
+            if apply {
+                Err(e).context(
+                    "config.yaml is malformed — refusing --apply to protect \
+                     indexes listed in auto_prune.protected_indexes. \
+                     Fix config.yaml or remove the file to reset to defaults.",
+                )
+            } else {
+                eprintln!(
+                    "{} config.yaml could not be parsed ({}); proceeding with \
+                     defaults for dry-run. Protected indexes may not be \
+                     highlighted correctly.",
+                    "warning:".yellow().bold(),
+                    e
+                );
+                Ok(AutoPruneConfig::default())
+            }
+        }
+    }
+}
+
+/// Path-injectable variant of the prune logic.
 ///
 /// Why: unit tests need a tempfile registry without touching the user's real
 ///      `indexes.toml`. `interactive=false` skips the stdin confirmation
@@ -201,10 +236,10 @@ pub fn handle_prune(apply: bool, yes: bool, max_idle_days_override: Option<u32>)
 ///      deterministic without real on-disk data or actual time. `prune_cfg`
 ///      is injected so tests can exercise protected_indexes without a real
 ///      GlobalConfig on disk.
-/// What: classifies every registry entry, prints the report, optionally deletes
-///       eligible non-protected entries when `apply=true` and confirmed.
-///       Registry removal is done as a single batched save; on-disk data dirs
-///       are removed after the registry write.
+/// What: validates `max_idle_days >= 1`, classifies every registry entry, prints
+///       the report, optionally deletes eligible non-protected entries when
+///       `apply=true` and confirmed. Registry removal is done as a single
+///       batched save; on-disk data dirs are removed after the registry write.
 /// Test: all `prune_*` unit tests in `prune_tests` call this variant.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_prune_at(
@@ -222,6 +257,12 @@ pub(crate) fn handle_prune_at(
         prune_cfg.max_idle_days = days;
     }
 
+    // Guard: 0 would make every tracked index eligible instantly.
+    anyhow::ensure!(
+        prune_cfg.max_idle_days >= 1,
+        "--max-idle-days must be at least 1 (0 would make every tracked index eligible)"
+    );
+
     let entries = load_index_registry_at(toml_path)?;
 
     if entries.is_empty() {
@@ -230,8 +271,8 @@ pub(crate) fn handle_prune_at(
     }
 
     // Classify every entry.
-    // Use owned PersistedIndex clones in `classifications` so that the borrow
-    // on `entries` can be released before the batch-save move.
+    // Use owned PersistedIndex clones so the borrow on `entries` can be
+    // released before the batch-save move below.
     let classifications: Vec<(PersistedIndex, PruneDecision)> = entries
         .iter()
         .map(|e| {
@@ -254,7 +295,7 @@ pub(crate) fn handle_prune_at(
 
     let total_freeable: u64 = eligible.iter().filter_map(|(_, _, sz)| *sz).sum();
 
-    // Print the report table.
+    // Print the report table (borrows into classifications).
     let class_refs: Vec<(&PersistedIndex, &PruneDecision)> =
         classifications.iter().map(|(e, d)| (e, d)).collect();
     print_report(&class_refs, &prune_cfg);
@@ -323,8 +364,7 @@ pub(crate) fn handle_prune_at(
     let mut deleted = 0usize;
     let mut errors = 0usize;
     for (entry, idle_days, _) in &eligible {
-        let remove_result = remove_data_dir_for_entry(entry);
-        match remove_result {
+        match remove_data_dir_for_entry(entry) {
             Ok(()) => {
                 println!(
                     "  {} deleted {} (idle {} days)",
@@ -371,15 +411,19 @@ pub(crate) fn handle_prune_at(
 ///
 /// Why: colocated indexes store HNSW + redb under `<root_path>/.trusty-search/`,
 ///      not under the global `<data_dir>/indexes/<id>/`. Without this dispatch
-///      a colocated deletion would remove the registry entry and print "deleted"
-///      while leaving the data orphaned on disk.
-/// What: when `entry.colocated`, removes `<root_path>/.trusty-search/` via
-///       `colocated_storage::colocated_storage_dir`; otherwise calls the
-///       existing `remove_index_data_dir` helper.
-/// Test: `prune_colocated_deletion_removes_colocated_dir` in `prune_tests`.
+///      a colocated deletion removes the registry entry but leaves the data on
+///      disk. Crucially, we build the path WITHOUT calling `colocated_storage_dir`
+///      (which unconditionally runs `create_dir_all`) to avoid ghost-dir creation
+///      when the root_path no longer exists.
+/// What: when `entry.colocated`, resolves `<root_path>/.trusty-search/` directly
+///       via `entry.root_path.join(COLOCATED_DIR_NAME)`, guards `dir.exists()`,
+///       then `remove_dir_all`. Otherwise calls `remove_index_data_dir`.
+/// Test: `prune_colocated_deletion_removes_colocated_dir` and
+///       `prune_colocated_absent_root_creates_no_dirs` in `prune_tests`.
 fn remove_data_dir_for_entry(entry: &PersistedIndex) -> Result<()> {
     if entry.colocated {
-        let dir = crate::service::colocated_storage::colocated_storage_dir(&entry.root_path)?;
+        // Build the path directly — no create_dir_all side effect.
+        let dir: PathBuf = entry.root_path.join(COLOCATED_DIR_NAME);
         if dir.exists() {
             std::fs::remove_dir_all(&dir)
                 .with_context(|| format!("remove colocated dir {}", dir.display()))?;
@@ -394,7 +438,9 @@ fn remove_data_dir_for_entry(entry: &PersistedIndex) -> Result<()> {
 ///
 /// Why: extracted so the report logic can be read and verified independently
 ///      of the deletion logic.
-/// What: prints one row per index entry with status, id, idle age, and size.
+/// What: prints one row per index entry with status (pre-padded before
+///       colorization so ANSI escape bytes don't break column alignment),
+///       id, idle age, and size.
 /// Test: covered transitively by `handle_prune_at` tests.
 fn print_report(classifications: &[(&PersistedIndex, &PruneDecision)], cfg: &AutoPruneConfig) {
     let id_width = classifications
@@ -414,25 +460,36 @@ fn print_report(classifications: &[(&PersistedIndex, &PruneDecision)], cfg: &Aut
     );
 
     for (entry, decision) in classifications {
-        let (status_str, idle_str, size_str): (colored::ColoredString, String, String) =
-            match decision {
-                PruneDecision::Eligible {
-                    idle_days,
-                    size_bytes,
-                } => (
-                    "ELIGIBLE".red(),
-                    format!("{} days", idle_days),
-                    size_bytes.map(format_bytes).unwrap_or_else(|| "?".into()),
-                ),
-                PruneDecision::Protected => ("PROTECTED".cyan(), "—".into(), "—".into()),
-                PruneDecision::NotTracked => ("UNTRACKED".yellow(), "unknown".into(), "—".into()),
-                PruneDecision::Recent { idle_days } => {
-                    ("RECENT".green(), format!("{} days", idle_days), "—".into())
-                }
-            };
+        // Pad the raw label BEFORE colorizing so ANSI escape bytes don't
+        // inflate the apparent width and misalign columns.
+        let (status_str, idle_str, size_str): (String, String, String) = match decision {
+            PruneDecision::Eligible {
+                idle_days,
+                size_bytes,
+            } => (
+                format!("{:<9}", "ELIGIBLE").red().to_string(),
+                format!("{} days", idle_days),
+                size_bytes.map(format_bytes).unwrap_or_else(|| "?".into()),
+            ),
+            PruneDecision::Protected => (
+                format!("{:<9}", "PROTECTED").cyan().to_string(),
+                "—".into(),
+                "—".into(),
+            ),
+            PruneDecision::NotTracked => (
+                format!("{:<9}", "UNTRACKED").yellow().to_string(),
+                "unknown".into(),
+                "—".into(),
+            ),
+            PruneDecision::Recent { idle_days } => (
+                format!("{:<9}", "RECENT").green().to_string(),
+                format!("{} days", idle_days),
+                "—".into(),
+            ),
+        };
 
         println!(
-            "  {:<width$}  {:<9}  {:<10}  {}",
+            "  {:<width$}  {}  {:<10}  {}",
             entry.id.bold(),
             status_str,
             idle_str,
@@ -465,27 +522,36 @@ fn current_unix() -> u64 {
         .unwrap_or(0)
 }
 
+/// Compute the base data directory path WITHOUT calling `create_dir_all`.
+///
+/// Why: `data_dir()` in `persistence.rs` calls `create_dir_all` — using it in
+///      `default_size_fn` would mutate the filesystem during a dry-run. This
+///      function derives the same canonical path without any side effects.
+/// What: honours `TRUSTY_DATA_DIR` env-override (absolute path required), then
+///       falls back to `dirs::data_local_dir().join("trusty-search")`. Returns
+///       `None` when neither source yields a path.
+/// Test: side-effect-free; exercised transitively via `default_size_fn`.
+fn data_dir_no_create() -> Option<PathBuf> {
+    if let Ok(override_dir) = std::env::var("TRUSTY_DATA_DIR") {
+        let dir = PathBuf::from(override_dir);
+        if dir.is_absolute() {
+            return Some(dir);
+        }
+    }
+    dirs::data_local_dir().map(|b| b.join("trusty-search"))
+}
+
 /// Default `size_fn`: returns the on-disk byte count for the index data dir.
 ///
 /// Why: production callers need real disk sizes; test callers inject a stub.
-/// What: builds the path as `<data_dir>/indexes/<sanitized_id>` WITHOUT calling
-///       `index_data_dir` (which runs `create_dir_all` and would create empty
-///       dirs during dry-run). Falls back to `None` when the dir does not exist.
+/// What: builds the path as `<data_dir_no_create>/indexes/<sanitized_id>`
+///       without any `create_dir_all` side effect. Falls back to `None` when
+///       the dir does not exist.
 /// Test: covered transitively in production; test callers inject `no_size`.
 fn default_size_fn(id: &str) -> Option<u64> {
-    // Replicate persistence::sanitize_id logic without calling index_data_dir
-    // (which runs create_dir_all and would mutate the filesystem during dry-run).
-    let safe_id: String = id
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let dir = data_dir().ok()?.join("indexes").join(safe_id);
+    let dir = data_dir_no_create()?
+        .join("indexes")
+        .join(sanitize_id_for_path(id));
     if dir.exists() {
         Some(trusty_common::sys_metrics::dir_size_bytes(&dir))
     } else {

--- a/crates/trusty-search/src/commands/prune.rs
+++ b/crates/trusty-search/src/commands/prune.rs
@@ -1,0 +1,698 @@
+//! Handler for `trusty-search prune` (issue #1782).
+//!
+//! Why: trusty-search accumulates indexes for projects that are no longer
+//! actively searched. These stale indexes waste disk (HNSW snapshot + redb
+//! corpus) and slow warm-boot. A dedicated `prune` command lets operators
+//! review and delete indexes that have been idle for longer than a configurable
+//! retention window, without needing the daemon to be running.
+//!
+//! What: reads `indexes.toml` (offline, no daemon required), computes each
+//! index's idle age from `last_queried_unix` (falling back to
+//! `last_indexed_unix`), and classifies each entry as Eligible / Protected /
+//! NotTracked. Default mode is DRY-RUN (print only). `--apply` deletes
+//! eligible, non-protected indexes via the existing
+//! `remove_index_registry_entry` + `remove_index_data_dir` offline path.
+//!
+//! Safety contract:
+//! - Dry-run is the default — `--apply` must be explicit.
+//! - Protected indexes (listed in `auto_prune.protected_indexes` config) are
+//!   NEVER deleted, even with `--apply`.
+//! - Indexes with no timestamp (`last_queried_unix = None` AND
+//!   `last_indexed_unix = None`) are NOT eligible — they may have been freshly
+//!   created or belong to a pre-tracking installation; deleting them would be
+//!   surprising.
+//! - The global `enabled` gate in `auto_prune.enabled` must be `true` OR the
+//!   user must pass `--apply`; the explicit CLI flag is sufficient operator
+//!   intent for the manual command.
+//!
+//! Persistence approach: `last_queried_unix` is already written to
+//! `indexes.toml` by the daemon search handler (rate-limited to at most once
+//! per 60 s). The prune command reads the TOML file directly — it is fully
+//! offline. Timestamp granularity is seconds, with a 60-second write
+//! coarsening inside the daemon; the effective per-index resolution for prune
+//! decisions is therefore "last day searched", which matches the day-scale
+//! `max_idle_days` threshold.
+//!
+//! TODO (issue #1782 follow-up): daemon-side scheduled sweep that runs
+//! periodically when `auto_prune.enabled = true`. The manual command is the
+//! must-have for this PR.
+//!
+//! Test: `prune_dry_run_lists_but_does_not_delete`,
+//! `prune_apply_deletes_only_eligible`,
+//! `prune_apply_skips_protected`,
+//! `prune_not_tracked_is_not_eligible`,
+//! `prune_eligibility_boundary`.
+
+use anyhow::Result;
+use colored::Colorize;
+use std::io::{BufRead, Write};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::config::{AutoPruneConfig, GlobalConfig};
+use crate::service::persistence::{
+    index_data_dir, indexes_toml_path, load_index_registry_at, remove_index_data_dir,
+    remove_index_registry_entry_at, PersistedIndex,
+};
+
+/// Decision for one index entry (computed by [`classify_entry`]).
+///
+/// Why: keeping the classification pure lets unit tests verify eligibility
+///      without touching the filesystem.
+/// What: each variant carries metadata needed for the report / deletion.
+/// Test: covered by eligibility unit tests below.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PruneDecision {
+    /// Index is idle for longer than `max_idle_days` and not protected.
+    Eligible {
+        /// Days since the last query (or last index if never queried).
+        idle_days: u64,
+        /// On-disk footprint in bytes, or `None` when unknown.
+        size_bytes: Option<u64>,
+    },
+    /// Index id is in `protected_indexes` — never delete.
+    Protected,
+    /// Both `last_queried_unix` and `last_indexed_unix` are absent.
+    /// Safety: treated as ineligible to avoid surprising deletes on fresh
+    /// installs or pre-tracking daemon versions.
+    NotTracked,
+    /// Index was queried or indexed more recently than `max_idle_days`.
+    Recent {
+        /// Days since last activity.
+        idle_days: u64,
+    },
+}
+
+/// Compute the idle-age classification for one registry entry.
+///
+/// Why: pure function so unit tests can drive eligibility logic without I/O.
+/// What: picks `last_queried_unix` first, falls back to `last_indexed_unix`.
+///       Returns `NotTracked` when both are absent. Otherwise computes elapsed
+///       days and compares to `max_idle_days`. Protected entries always return
+///       `Protected` regardless of age.
+/// Test: `prune_eligibility_boundary`, `prune_not_tracked_is_not_eligible`.
+pub(crate) fn classify_entry(
+    entry: &PersistedIndex,
+    cfg: &AutoPruneConfig,
+    now_unix: u64,
+    size_fn: impl Fn(&str) -> Option<u64>,
+) -> PruneDecision {
+    // Check protection first — protected indexes are never eligible.
+    if cfg.protected_indexes.iter().any(|p| p == &entry.id) {
+        return PruneDecision::Protected;
+    }
+
+    // Pick the best available timestamp: last query > last index > absent.
+    let last_activity = entry.last_queried_unix.or(entry.last_indexed_unix);
+
+    let Some(ts) = last_activity else {
+        return PruneDecision::NotTracked;
+    };
+
+    let elapsed_secs = now_unix.saturating_sub(ts);
+    let idle_days = elapsed_secs / 86_400;
+
+    if idle_days >= cfg.max_idle_days as u64 {
+        let size_bytes = size_fn(&entry.id);
+        PruneDecision::Eligible {
+            idle_days,
+            size_bytes,
+        }
+    } else {
+        PruneDecision::Recent { idle_days }
+    }
+}
+
+/// Format a byte count as a human-readable string (KB / MB / GB).
+///
+/// Why: raw byte counts are hard to read in a terminal table; operators
+///      care about MB/GB-scale disk reclaim.
+/// What: returns e.g. `"42.3 MB"`, `"1.2 GB"`, `"512 KB"`.
+/// Test: `format_bytes_display_cases`.
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1_024;
+    const MB: u64 = 1_024 * KB;
+    const GB: u64 = 1_024 * MB;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.0} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// Entry point for `trusty-search prune [--max-idle-days N] [--apply] [--yes]`.
+///
+/// Why: keep the CLI handler thin; all logic in `handle_prune_at` which is
+///      testable with path-injectable helpers.
+/// What: resolves config + registry paths, delegates to `handle_prune_at`.
+/// Test: covered by `handle_prune_at` unit tests.
+pub fn handle_prune(apply: bool, yes: bool, max_idle_days_override: Option<u32>) -> Result<()> {
+    let toml_path = indexes_toml_path()?;
+    handle_prune_at(
+        &toml_path,
+        apply,
+        yes,
+        max_idle_days_override,
+        /*interactive=*/ true,
+        /*size_fn=*/ default_size_fn,
+        /*now_unix=*/ current_unix(),
+    )
+}
+
+/// Path-injectable variant of [`handle_prune`].
+///
+/// Why: unit tests need a tempfile registry without touching the user's real
+///      `indexes.toml`. `interactive=false` skips the stdin confirmation
+///      prompt. `size_fn` and `now_unix` are injected to keep tests
+///      deterministic without real on-disk data or actual time.
+/// What: classifies every registry entry, prints the report, optionally deletes
+///       eligible non-protected entries when `apply=true` and confirmed.
+/// Test: all `prune_*` unit tests call this variant.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn handle_prune_at(
+    toml_path: &Path,
+    apply: bool,
+    yes: bool,
+    max_idle_days_override: Option<u32>,
+    interactive: bool,
+    size_fn: impl Fn(&str) -> Option<u64>,
+    now_unix: u64,
+) -> Result<()> {
+    // Load global config for prune settings; fall back to defaults on error.
+    let mut prune_cfg = GlobalConfig::load().unwrap_or_default().auto_prune;
+
+    // CLI override takes precedence over config.
+    if let Some(days) = max_idle_days_override {
+        prune_cfg.max_idle_days = days;
+    }
+
+    let entries = load_index_registry_at(toml_path)?;
+
+    if entries.is_empty() {
+        println!("Registry is empty — nothing to prune.");
+        return Ok(());
+    }
+
+    // Classify every entry.
+    let classifications: Vec<(&PersistedIndex, PruneDecision)> = entries
+        .iter()
+        .map(|e| {
+            let decision = classify_entry(e, &prune_cfg, now_unix, &size_fn);
+            (e, decision)
+        })
+        .collect();
+
+    // Collect eligible entries (those we WOULD delete with --apply).
+    let eligible: Vec<(&PersistedIndex, u64, Option<u64>)> = classifications
+        .iter()
+        .filter_map(|(e, d)| match d {
+            PruneDecision::Eligible {
+                idle_days,
+                size_bytes,
+            } => Some((*e, *idle_days, *size_bytes)),
+            _ => None,
+        })
+        .collect();
+
+    let total_freeable: u64 = eligible.iter().filter_map(|(_, _, sz)| *sz).sum();
+
+    // Print the report table.
+    print_report(&classifications, &prune_cfg);
+
+    if eligible.is_empty() {
+        println!(
+            "{} No indexes eligible for pruning (idle > {} days).",
+            "✓".green(),
+            prune_cfg.max_idle_days
+        );
+        return Ok(());
+    }
+
+    let size_hint = if total_freeable > 0 {
+        format!(" (would free ~{})", format_bytes(total_freeable))
+    } else {
+        String::new()
+    };
+
+    if !apply {
+        println!(
+            "\n{} {} index(es) eligible{}. Re-run with {} to delete.",
+            "ℹ".cyan(),
+            eligible.len(),
+            size_hint,
+            "--apply".bold()
+        );
+        return Ok(());
+    }
+
+    // `--apply` path.
+    println!(
+        "\n{} {} index(es) eligible{}.",
+        "!".yellow(),
+        eligible.len(),
+        size_hint
+    );
+
+    if !yes {
+        if !interactive {
+            println!("Aborted (non-interactive mode).");
+            return Ok(());
+        }
+        if !confirm(&format!(
+            "Permanently delete {} index(es) from the registry and disk?",
+            eligible.len()
+        ))? {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Delete each eligible index from registry + disk.
+    let mut deleted = 0usize;
+    let mut errors = 0usize;
+    for (entry, idle_days, _) in &eligible {
+        let id = &entry.id;
+        if let Err(e) = remove_index_registry_entry_at(toml_path, id) {
+            eprintln!(
+                "{} failed to remove '{}' from registry: {e:#}",
+                "✗".red(),
+                id
+            );
+            errors += 1;
+            continue;
+        }
+        if let Err(e) = remove_index_data_dir(id) {
+            eprintln!(
+                "{} failed to remove on-disk data for '{}': {e:#}",
+                "✗".red(),
+                id
+            );
+            // Registry entry already removed; log but continue.
+        }
+        println!(
+            "  {} deleted {} (idle {} days)",
+            "−".red(),
+            id.bold(),
+            idle_days
+        );
+        deleted += 1;
+    }
+
+    // Summary.
+    let remaining = entries.len() - deleted;
+    if errors == 0 {
+        println!(
+            "\n{} Deleted {} index(es). {} registration(s) remain.",
+            "✓".green(),
+            deleted,
+            remaining
+        );
+    } else {
+        println!(
+            "\n{} Deleted {} index(es), {} failed. {} registration(s) remain.",
+            "⚠".yellow(),
+            deleted,
+            errors,
+            remaining
+        );
+    }
+
+    Ok(())
+}
+
+/// Print the classification table to stdout.
+///
+/// Why: extracted so the report logic can be read and verified independently
+///      of the deletion logic.
+/// What: prints one row per index entry with status, id, idle age, and size.
+/// Test: covered transitively by `handle_prune_at`.
+fn print_report(classifications: &[(&PersistedIndex, PruneDecision)], cfg: &AutoPruneConfig) {
+    let id_width = classifications
+        .iter()
+        .map(|(e, _)| e.id.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+
+    println!(
+        "  {:<width$}  {:<9}  {:<10}  {}",
+        "INDEX".dimmed(),
+        "STATUS".dimmed(),
+        "IDLE DAYS".dimmed(),
+        "DISK".dimmed(),
+        width = id_width
+    );
+
+    for (entry, decision) in classifications {
+        let (status_str, idle_str, size_str): (colored::ColoredString, String, String) =
+            match decision {
+                PruneDecision::Eligible {
+                    idle_days,
+                    size_bytes,
+                } => (
+                    "ELIGIBLE".red(),
+                    format!("{} days", idle_days),
+                    size_bytes.map(format_bytes).unwrap_or_else(|| "?".into()),
+                ),
+                PruneDecision::Protected => ("PROTECTED".cyan(), "—".into(), "—".into()),
+                PruneDecision::NotTracked => ("UNTRACKED".yellow(), "unknown".into(), "—".into()),
+                PruneDecision::Recent { idle_days } => {
+                    ("RECENT".green(), format!("{} days", idle_days), "—".into())
+                }
+            };
+
+        println!(
+            "  {:<width$}  {:<9}  {:<10}  {}",
+            entry.id.bold(),
+            status_str,
+            idle_str,
+            size_str,
+            width = id_width
+        );
+    }
+    println!(
+        "\n  Threshold: {} days ({})",
+        cfg.max_idle_days,
+        if cfg.enabled {
+            "auto-prune enabled".green().to_string()
+        } else {
+            "auto-prune disabled — manual --apply only"
+                .dimmed()
+                .to_string()
+        }
+    );
+}
+
+/// Read the current Unix timestamp.
+///
+/// Why: injecting `now_unix` into `handle_prune_at` makes tests deterministic.
+/// What: `SystemTime::now()` as seconds since UNIX_EPOCH, saturating to 0 on error.
+/// Test: covered transitively.
+fn current_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Default `size_fn`: returns the on-disk byte count for `index_data_dir(id)`.
+///
+/// Why: production callers need real disk sizes; test callers inject a stub.
+/// What: calls `trusty_common::sys_metrics::dir_size_bytes` on the index dir.
+/// Test: covered transitively.
+fn default_size_fn(id: &str) -> Option<u64> {
+    index_data_dir(id)
+        .ok()
+        .filter(|p| p.exists())
+        .map(|p| trusty_common::sys_metrics::dir_size_bytes(&p))
+}
+
+/// Interactive y/N confirmation prompt (matches `prune_orphans` pattern).
+///
+/// Why: safety gate before any deletion — mirrors the pattern in
+///      `commands/prune_orphans.rs` for consistent UX.
+/// What: flushes stdout, reads one line from stdin, returns `true` for `y`/`Y`.
+/// Test: bypassed in tests via `interactive=false`.
+fn confirm(prompt: &str) -> Result<bool> {
+    print!("{} [y/N] ", prompt);
+    std::io::stdout().flush().ok();
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line)?;
+    let answer = line.trim();
+    Ok(matches!(answer.chars().next(), Some('y') | Some('Y')))
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::persistence::{save_index_registry_at, PersistedIndex};
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    /// Seconds per day (86400) exposed for readability in test arithmetic.
+    const DAY: u64 = 86_400;
+
+    fn make_entry(
+        id: &str,
+        last_queried: Option<u64>,
+        last_indexed: Option<u64>,
+    ) -> PersistedIndex {
+        PersistedIndex {
+            id: id.to_string(),
+            root_path: PathBuf::from(format!("/tmp/{id}")),
+            last_queried_unix: last_queried,
+            last_indexed_unix: last_indexed,
+            ..Default::default()
+        }
+    }
+
+    fn default_cfg() -> AutoPruneConfig {
+        AutoPruneConfig {
+            enabled: false,
+            max_idle_days: 30,
+            protected_indexes: vec![],
+        }
+    }
+
+    fn no_size(_id: &str) -> Option<u64> {
+        None
+    }
+
+    // ── classify_entry unit tests ────────────────────────────────────────────
+
+    /// Why: pins the eligibility boundary at exactly `max_idle_days`.
+    /// What: an entry idle for exactly 30 days is eligible; 29 days is not.
+    /// Test: this test.
+    #[test]
+    fn prune_eligibility_boundary() {
+        let cfg = default_cfg();
+        let now: u64 = 1_000 * DAY;
+
+        // Idle for exactly 30 days → eligible.
+        let e30 = make_entry("a", Some(now - 30 * DAY), None);
+        let d30 = classify_entry(&e30, &cfg, now, no_size);
+        assert!(
+            matches!(d30, PruneDecision::Eligible { idle_days: 30, .. }),
+            "30-day idle should be eligible: {d30:?}"
+        );
+
+        // Idle for 29 days → recent.
+        let e29 = make_entry("b", Some(now - 29 * DAY), None);
+        let d29 = classify_entry(&e29, &cfg, now, no_size);
+        assert!(
+            matches!(d29, PruneDecision::Recent { idle_days: 29 }),
+            "29-day idle should be recent: {d29:?}"
+        );
+    }
+
+    /// Why: an index with no timestamps should never be auto-pruned.
+    /// What: entry with both fields None → NotTracked (not Eligible).
+    /// Test: this test.
+    #[test]
+    fn prune_not_tracked_is_not_eligible() {
+        let cfg = default_cfg();
+        let e = make_entry("x", None, None);
+        let d = classify_entry(&e, &cfg, 1_000 * DAY, no_size);
+        assert_eq!(d, PruneDecision::NotTracked);
+    }
+
+    /// Why: when `last_queried_unix` is absent but `last_indexed_unix` is set,
+    ///      the indexed timestamp should be used as the fallback activity anchor.
+    /// What: entry with queried=None, indexed=old → should be Eligible.
+    /// Test: this test.
+    #[test]
+    fn prune_falls_back_to_last_indexed() {
+        let cfg = default_cfg();
+        let now: u64 = 1_000 * DAY;
+        let e = make_entry("y", None, Some(now - 31 * DAY));
+        let d = classify_entry(&e, &cfg, now, no_size);
+        assert!(
+            matches!(d, PruneDecision::Eligible { idle_days: 31, .. }),
+            "should be eligible via indexed fallback: {d:?}"
+        );
+    }
+
+    /// Why: protected indexes must never be classified as Eligible regardless
+    ///      of how old they are.
+    /// What: entry whose id is in `protected_indexes` → Protected.
+    /// Test: this test.
+    #[test]
+    fn prune_protected_is_never_eligible() {
+        let cfg = AutoPruneConfig {
+            protected_indexes: vec!["critical".into()],
+            ..default_cfg()
+        };
+        let now: u64 = 1_000 * DAY;
+        // Even if idle for 1000 days.
+        let e = make_entry("critical", Some(now - 1_000 * DAY), None);
+        let d = classify_entry(&e, &cfg, now, no_size);
+        assert_eq!(d, PruneDecision::Protected);
+    }
+
+    // ── handle_prune_at integration tests ───────────────────────────────────
+
+    fn write_registry(path: &Path, entries: &[PersistedIndex]) {
+        save_index_registry_at(path, entries).unwrap();
+    }
+
+    /// Why: dry-run must NOT modify the registry even when entries are eligible.
+    /// What: write an eligible entry, run without --apply, reload and assert
+    ///       the entry is still present.
+    /// Test: this test.
+    #[test]
+    fn prune_dry_run_lists_but_does_not_delete() {
+        let tmp = tempdir().unwrap();
+        let toml = tmp.path().join("indexes.toml");
+        let now = 1_000 * DAY;
+        let entry = make_entry("old-proj", Some(now - 60 * DAY), None);
+        write_registry(&toml, &[entry]);
+
+        handle_prune_at(
+            &toml,
+            /*apply=*/ false,
+            /*yes=*/ true,
+            /*max_idle_days_override=*/ Some(30),
+            /*interactive=*/ false,
+            no_size,
+            now,
+        )
+        .unwrap();
+
+        let after = load_index_registry_at(&toml).unwrap();
+        assert_eq!(after.len(), 1, "dry-run must leave registry unchanged");
+        assert_eq!(after[0].id, "old-proj");
+    }
+
+    /// Why: --apply must delete only indexes that are both eligible AND not
+    ///      protected; recent and untracked ones must be preserved.
+    /// What: write three entries (old eligible, recent, untracked), run with
+    ///       --apply --yes, reload, assert only the eligible one is removed.
+    /// Test: this test.
+    #[test]
+    fn prune_apply_deletes_only_eligible() {
+        let tmp = tempdir().unwrap();
+        let toml = tmp.path().join("indexes.toml");
+        let now = 1_000 * DAY;
+
+        let old = make_entry("old", Some(now - 60 * DAY), None);
+        let fresh = make_entry("fresh", Some(now - 5 * DAY), None);
+        let untracked = make_entry("untracked", None, None);
+        write_registry(&toml, &[old, fresh, untracked]);
+
+        handle_prune_at(
+            &toml,
+            /*apply=*/ true,
+            /*yes=*/ true,
+            /*max_idle_days_override=*/ Some(30),
+            /*interactive=*/ false,
+            no_size,
+            now,
+        )
+        .unwrap();
+
+        let after = load_index_registry_at(&toml).unwrap();
+        assert_eq!(
+            after.len(),
+            2,
+            "only the eligible old entry must be removed"
+        );
+        let ids: Vec<&str> = after.iter().map(|e| e.id.as_str()).collect();
+        assert!(ids.contains(&"fresh"), "fresh must survive");
+        assert!(ids.contains(&"untracked"), "untracked must survive");
+        assert!(!ids.contains(&"old"), "old must be removed");
+    }
+
+    /// Why: protected entries must survive even when idle beyond the threshold.
+    /// What: write one protected-but-old entry, run --apply, assert it remains.
+    /// Test: this test.
+    #[test]
+    fn prune_apply_skips_protected() {
+        let tmp = tempdir().unwrap();
+        let toml = tmp.path().join("indexes.toml");
+        let now = 1_000 * DAY;
+
+        let e = make_entry("critical", Some(now - 999 * DAY), None);
+        write_registry(&toml, &[e]);
+
+        // cfg with protected_indexes — but we pass that via GlobalConfig.
+        // For this test we use max_idle_days_override and inject a cfg that
+        // has critical as protected. We call the internal classify directly to
+        // verify the protection, then run handle_prune_at with the override to
+        // show the file is untouched.
+        let cfg = AutoPruneConfig {
+            protected_indexes: vec!["critical".into()],
+            ..default_cfg()
+        };
+        let entry_ref = PersistedIndex {
+            id: "critical".into(),
+            root_path: PathBuf::from("/tmp/critical"),
+            last_queried_unix: Some(now - 999 * DAY),
+            ..Default::default()
+        };
+        assert_eq!(
+            classify_entry(&entry_ref, &cfg, now, no_size),
+            PruneDecision::Protected,
+            "classification must be Protected"
+        );
+
+        // handle_prune_at reads GlobalConfig from disk — in tests there is no
+        // real config, so protected_indexes comes from the default (empty).
+        // The entry IS eligible by time; without any protection it WOULD be
+        // deleted. We verify the delete path DOES delete when not protected
+        // (the previous test covers that), and separately verify the classify
+        // result is Protected when the config has the id. End-to-end protection
+        // via GlobalConfig is tested in the config roundtrip test.
+        //
+        // Note: the entry WILL be deleted here because the in-test GlobalConfig
+        // (defaulted) has no protected_indexes. That is intentional — it tests
+        // that the dry-run / apply logic works; the protect test above verifies
+        // the classify function itself.
+        //
+        // Keeping the assertion simple: after --apply the entry is gone.
+        handle_prune_at(
+            &toml,
+            /*apply=*/ true,
+            /*yes=*/ true,
+            /*max_idle_days_override=*/ Some(30),
+            /*interactive=*/ false,
+            no_size,
+            now,
+        )
+        .unwrap();
+        // The entry had no real on-disk dir, so remove_index_data_dir is a
+        // no-op. The registry entry should be gone.
+        let after = load_index_registry_at(&toml).unwrap();
+        assert_eq!(after.len(), 0, "eligible entry must be removed by --apply");
+    }
+
+    /// Why: an empty registry must be handled gracefully.
+    /// What: call handle_prune_at on an empty file, assert it returns Ok.
+    /// Test: this test.
+    #[test]
+    fn prune_empty_registry_is_noop() {
+        let tmp = tempdir().unwrap();
+        let toml = tmp.path().join("indexes.toml");
+        let result = handle_prune_at(&toml, false, true, None, false, no_size, 1_000 * DAY);
+        assert!(result.is_ok(), "empty registry must not error");
+    }
+
+    /// Why: `format_bytes` must produce human-readable output at each scale.
+    /// What: checks the formatting for B, KB, MB, GB boundaries.
+    /// Test: this test.
+    #[test]
+    fn format_bytes_display_cases() {
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(1_024), "1 KB");
+        assert_eq!(format_bytes(1_536), "2 KB");
+        assert_eq!(format_bytes(1_048_576), "1.0 MB");
+        assert_eq!(format_bytes(52_428_800), "50.0 MB");
+        assert_eq!(format_bytes(1_073_741_824), "1.0 GB");
+    }
+}

--- a/crates/trusty-search/src/commands/prune.rs
+++ b/crates/trusty-search/src/commands/prune.rs
@@ -9,9 +9,8 @@
 //! What: reads `indexes.toml` (offline, no daemon required), computes each
 //! index's idle age from `last_queried_unix` (falling back to
 //! `last_indexed_unix`), and classifies each entry as Eligible / Protected /
-//! NotTracked. Default mode is DRY-RUN (print only). `--apply` deletes
-//! eligible, non-protected indexes via the existing
-//! `remove_index_registry_entry` + `remove_index_data_dir` offline path.
+//! NotTracked / Recent. Default mode is DRY-RUN (print only). `--apply`
+//! deletes eligible, non-protected indexes via offline deletion helpers.
 //!
 //! Safety contract:
 //! - Dry-run is the default — `--apply` must be explicit.
@@ -21,9 +20,15 @@
 //!   `last_indexed_unix = None`) are NOT eligible — they may have been freshly
 //!   created or belong to a pre-tracking installation; deleting them would be
 //!   surprising.
-//! - The global `enabled` gate in `auto_prune.enabled` must be `true` OR the
-//!   user must pass `--apply`; the explicit CLI flag is sufficient operator
-//!   intent for the manual command.
+//! - The `auto_prune.enabled` config flag governs the daemon-side scheduled
+//!   sweep. The manual `prune --apply` command does NOT require `enabled=true`
+//!   — explicit use of `--apply` is sufficient operator intent. Set `enabled`
+//!   to opt in to future daemon-driven automatic deletion.
+//! - Malformed config (YAML parse error): propagated as an error when `--apply`
+//!   is active so that a corrupt config cannot silently empty `protected_indexes`
+//!   and delete something that should be protected. Dry-runs warn but proceed.
+//! - Stop the daemon before `--apply` to avoid a race between the daemon's
+//!   periodic `last_queried_unix` flush and the registry save here.
 //!
 //! Persistence approach: `last_queried_unix` is already written to
 //! `indexes.toml` by the daemon search handler (rate-limited to at most once
@@ -37,22 +42,17 @@
 //! periodically when `auto_prune.enabled = true`. The manual command is the
 //! must-have for this PR.
 //!
-//! Test: `prune_dry_run_lists_but_does_not_delete`,
-//! `prune_apply_deletes_only_eligible`,
-//! `prune_apply_skips_protected`,
-//! `prune_not_tracked_is_not_eligible`,
-//! `prune_eligibility_boundary`.
+//! Test: `prune_tests` module (`src/commands/prune_tests.rs`).
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use colored::Colorize;
-use std::io::{BufRead, Write};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::config::{AutoPruneConfig, GlobalConfig};
 use crate::service::persistence::{
-    index_data_dir, indexes_toml_path, load_index_registry_at, remove_index_data_dir,
-    remove_index_registry_entry_at, PersistedIndex,
+    data_dir, indexes_toml_path, load_index_registry_at, remove_index_data_dir,
+    save_index_registry_at, PersistedIndex,
 };
 
 /// Decision for one index entry (computed by [`classify_entry`]).
@@ -60,7 +60,7 @@ use crate::service::persistence::{
 /// Why: keeping the classification pure lets unit tests verify eligibility
 ///      without touching the filesystem.
 /// What: each variant carries metadata needed for the report / deletion.
-/// Test: covered by eligibility unit tests below.
+/// Test: covered by eligibility unit tests in `prune_tests`.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum PruneDecision {
     /// Index is idle for longer than `max_idle_days` and not protected.
@@ -90,7 +90,8 @@ pub(crate) enum PruneDecision {
 ///       Returns `NotTracked` when both are absent. Otherwise computes elapsed
 ///       days and compares to `max_idle_days`. Protected entries always return
 ///       `Protected` regardless of age.
-/// Test: `prune_eligibility_boundary`, `prune_not_tracked_is_not_eligible`.
+/// Test: `prune_eligibility_boundary`, `prune_not_tracked_is_not_eligible` in
+///       `prune_tests`.
 pub(crate) fn classify_entry(
     entry: &PersistedIndex,
     cfg: &AutoPruneConfig,
@@ -128,8 +129,8 @@ pub(crate) fn classify_entry(
 /// Why: raw byte counts are hard to read in a terminal table; operators
 ///      care about MB/GB-scale disk reclaim.
 /// What: returns e.g. `"42.3 MB"`, `"1.2 GB"`, `"512 KB"`.
-/// Test: `format_bytes_display_cases`.
-fn format_bytes(bytes: u64) -> String {
+/// Test: `format_bytes_display_cases` in `prune_tests`.
+pub(crate) fn format_bytes(bytes: u64) -> String {
     const KB: u64 = 1_024;
     const MB: u64 = 1_024 * KB;
     const GB: u64 = 1_024 * MB;
@@ -147,16 +148,45 @@ fn format_bytes(bytes: u64) -> String {
 /// Entry point for `trusty-search prune [--max-idle-days N] [--apply] [--yes]`.
 ///
 /// Why: keep the CLI handler thin; all logic in `handle_prune_at` which is
-///      testable with path-injectable helpers.
-/// What: resolves config + registry paths, delegates to `handle_prune_at`.
-/// Test: covered by `handle_prune_at` unit tests.
+///      testable with injected config / path / size_fn / now_unix.
+/// What: loads `GlobalConfig`, applies CLI overrides, delegates to
+///       `handle_prune_at`. When `--apply` is active a malformed config is a
+///       hard error (so corrupt config cannot silence `protected_indexes`).
+///       A dry-run emits a warning and proceeds with defaults.
+/// Test: covered by `handle_prune_at` unit tests in `prune_tests`.
 pub fn handle_prune(apply: bool, yes: bool, max_idle_days_override: Option<u32>) -> Result<()> {
     let toml_path = indexes_toml_path()?;
+
+    // Load global config for prune settings.
+    let prune_cfg = match GlobalConfig::load() {
+        Ok(cfg) => cfg.auto_prune,
+        Err(e) => {
+            if apply {
+                // CRITICAL: malformed config when --apply is active could
+                // silently clear protected_indexes and delete protected data.
+                return Err(e).context(
+                    "config.yaml is malformed — refusing --apply to protect \
+                     indexes listed in auto_prune.protected_indexes. \
+                     Fix config.yaml or remove the file to reset to defaults.",
+                );
+            }
+            // Dry-run: warn and proceed with defaults (no deletions happen).
+            eprintln!(
+                "{} config.yaml could not be parsed ({}); proceeding with defaults \
+                 for dry-run. Protected indexes may not be highlighted correctly.",
+                "warning:".yellow().bold(),
+                e
+            );
+            AutoPruneConfig::default()
+        }
+    };
+
     handle_prune_at(
         &toml_path,
         apply,
         yes,
         max_idle_days_override,
+        prune_cfg,
         /*interactive=*/ true,
         /*size_fn=*/ default_size_fn,
         /*now_unix=*/ current_unix(),
@@ -168,23 +198,25 @@ pub fn handle_prune(apply: bool, yes: bool, max_idle_days_override: Option<u32>)
 /// Why: unit tests need a tempfile registry without touching the user's real
 ///      `indexes.toml`. `interactive=false` skips the stdin confirmation
 ///      prompt. `size_fn` and `now_unix` are injected to keep tests
-///      deterministic without real on-disk data or actual time.
+///      deterministic without real on-disk data or actual time. `prune_cfg`
+///      is injected so tests can exercise protected_indexes without a real
+///      GlobalConfig on disk.
 /// What: classifies every registry entry, prints the report, optionally deletes
 ///       eligible non-protected entries when `apply=true` and confirmed.
-/// Test: all `prune_*` unit tests call this variant.
+///       Registry removal is done as a single batched save; on-disk data dirs
+///       are removed after the registry write.
+/// Test: all `prune_*` unit tests in `prune_tests` call this variant.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_prune_at(
     toml_path: &Path,
     apply: bool,
     yes: bool,
     max_idle_days_override: Option<u32>,
+    mut prune_cfg: AutoPruneConfig,
     interactive: bool,
     size_fn: impl Fn(&str) -> Option<u64>,
     now_unix: u64,
 ) -> Result<()> {
-    // Load global config for prune settings; fall back to defaults on error.
-    let mut prune_cfg = GlobalConfig::load().unwrap_or_default().auto_prune;
-
     // CLI override takes precedence over config.
     if let Some(days) = max_idle_days_override {
         prune_cfg.max_idle_days = days;
@@ -198,22 +230,24 @@ pub(crate) fn handle_prune_at(
     }
 
     // Classify every entry.
-    let classifications: Vec<(&PersistedIndex, PruneDecision)> = entries
+    // Use owned PersistedIndex clones in `classifications` so that the borrow
+    // on `entries` can be released before the batch-save move.
+    let classifications: Vec<(PersistedIndex, PruneDecision)> = entries
         .iter()
         .map(|e| {
             let decision = classify_entry(e, &prune_cfg, now_unix, &size_fn);
-            (e, decision)
+            (e.clone(), decision)
         })
         .collect();
 
     // Collect eligible entries (those we WOULD delete with --apply).
-    let eligible: Vec<(&PersistedIndex, u64, Option<u64>)> = classifications
+    let eligible: Vec<(PersistedIndex, u64, Option<u64>)> = classifications
         .iter()
         .filter_map(|(e, d)| match d {
             PruneDecision::Eligible {
                 idle_days,
                 size_bytes,
-            } => Some((*e, *idle_days, *size_bytes)),
+            } => Some((e.clone(), *idle_days, *size_bytes)),
             _ => None,
         })
         .collect();
@@ -221,7 +255,9 @@ pub(crate) fn handle_prune_at(
     let total_freeable: u64 = eligible.iter().filter_map(|(_, _, sz)| *sz).sum();
 
     // Print the report table.
-    print_report(&classifications, &prune_cfg);
+    let class_refs: Vec<(&PersistedIndex, &PruneDecision)> =
+        classifications.iter().map(|(e, d)| (e, d)).collect();
+    print_report(&class_refs, &prune_cfg);
 
     if eligible.is_empty() {
         println!(
@@ -262,7 +298,7 @@ pub(crate) fn handle_prune_at(
             println!("Aborted (non-interactive mode).");
             return Ok(());
         }
-        if !confirm(&format!(
+        if !super::confirm(&format!(
             "Permanently delete {} index(es) from the registry and disk?",
             eligible.len()
         ))? {
@@ -271,39 +307,45 @@ pub(crate) fn handle_prune_at(
         }
     }
 
-    // Delete each eligible index from registry + disk.
+    // Batch-remove eligible entries from the registry in one atomic save.
+    // This prevents N separate load-retain-save cycles that race with the
+    // daemon's last_queried_unix flush. (Stop the daemon before --apply for
+    // a fully safe update.)
+    let eligible_ids: Vec<&str> = eligible.iter().map(|(e, _, _)| e.id.as_str()).collect();
+    let survivors: Vec<PersistedIndex> = entries
+        .into_iter()
+        .filter(|e| !eligible_ids.contains(&e.id.as_str()))
+        .collect();
+    let remaining = survivors.len();
+    save_index_registry_at(toml_path, &survivors)?;
+
+    // Delete on-disk data dirs after the registry save.
     let mut deleted = 0usize;
     let mut errors = 0usize;
     for (entry, idle_days, _) in &eligible {
-        let id = &entry.id;
-        if let Err(e) = remove_index_registry_entry_at(toml_path, id) {
-            eprintln!(
-                "{} failed to remove '{}' from registry: {e:#}",
-                "✗".red(),
-                id
-            );
-            errors += 1;
-            continue;
+        let remove_result = remove_data_dir_for_entry(entry);
+        match remove_result {
+            Ok(()) => {
+                println!(
+                    "  {} deleted {} (idle {} days)",
+                    "−".red(),
+                    entry.id.bold(),
+                    idle_days
+                );
+                deleted += 1;
+            }
+            Err(e) => {
+                eprintln!(
+                    "{} failed to remove on-disk data for '{}': {e:#}",
+                    "✗".red(),
+                    entry.id
+                );
+                errors += 1;
+            }
         }
-        if let Err(e) = remove_index_data_dir(id) {
-            eprintln!(
-                "{} failed to remove on-disk data for '{}': {e:#}",
-                "✗".red(),
-                id
-            );
-            // Registry entry already removed; log but continue.
-        }
-        println!(
-            "  {} deleted {} (idle {} days)",
-            "−".red(),
-            id.bold(),
-            idle_days
-        );
-        deleted += 1;
     }
 
     // Summary.
-    let remaining = entries.len() - deleted;
     if errors == 0 {
         println!(
             "\n{} Deleted {} index(es). {} registration(s) remain.",
@@ -313,7 +355,8 @@ pub(crate) fn handle_prune_at(
         );
     } else {
         println!(
-            "\n{} Deleted {} index(es), {} failed. {} registration(s) remain.",
+            "\n{} Deleted {} index(es), {} failed (registry entries already removed). \
+             {} registration(s) remain.",
             "⚠".yellow(),
             deleted,
             errors,
@@ -324,13 +367,36 @@ pub(crate) fn handle_prune_at(
     Ok(())
 }
 
+/// Delete on-disk data for one index, respecting colocated vs. global storage.
+///
+/// Why: colocated indexes store HNSW + redb under `<root_path>/.trusty-search/`,
+///      not under the global `<data_dir>/indexes/<id>/`. Without this dispatch
+///      a colocated deletion would remove the registry entry and print "deleted"
+///      while leaving the data orphaned on disk.
+/// What: when `entry.colocated`, removes `<root_path>/.trusty-search/` via
+///       `colocated_storage::colocated_storage_dir`; otherwise calls the
+///       existing `remove_index_data_dir` helper.
+/// Test: `prune_colocated_deletion_removes_colocated_dir` in `prune_tests`.
+fn remove_data_dir_for_entry(entry: &PersistedIndex) -> Result<()> {
+    if entry.colocated {
+        let dir = crate::service::colocated_storage::colocated_storage_dir(&entry.root_path)?;
+        if dir.exists() {
+            std::fs::remove_dir_all(&dir)
+                .with_context(|| format!("remove colocated dir {}", dir.display()))?;
+        }
+        Ok(())
+    } else {
+        remove_index_data_dir(&entry.id)
+    }
+}
+
 /// Print the classification table to stdout.
 ///
 /// Why: extracted so the report logic can be read and verified independently
 ///      of the deletion logic.
 /// What: prints one row per index entry with status, id, idle age, and size.
-/// Test: covered transitively by `handle_prune_at`.
-fn print_report(classifications: &[(&PersistedIndex, PruneDecision)], cfg: &AutoPruneConfig) {
+/// Test: covered transitively by `handle_prune_at` tests.
+fn print_report(classifications: &[(&PersistedIndex, &PruneDecision)], cfg: &AutoPruneConfig) {
     let id_width = classifications
         .iter()
         .map(|(e, _)| e.id.len())
@@ -378,9 +444,9 @@ fn print_report(classifications: &[(&PersistedIndex, PruneDecision)], cfg: &Auto
         "\n  Threshold: {} days ({})",
         cfg.max_idle_days,
         if cfg.enabled {
-            "auto-prune enabled".green().to_string()
+            "auto-prune sweep enabled".green().to_string()
         } else {
-            "auto-prune disabled — manual --apply only"
+            "auto-prune sweep disabled — use --apply for manual deletion"
                 .dimmed()
                 .to_string()
         }
@@ -399,300 +465,34 @@ fn current_unix() -> u64 {
         .unwrap_or(0)
 }
 
-/// Default `size_fn`: returns the on-disk byte count for `index_data_dir(id)`.
+/// Default `size_fn`: returns the on-disk byte count for the index data dir.
 ///
 /// Why: production callers need real disk sizes; test callers inject a stub.
-/// What: calls `trusty_common::sys_metrics::dir_size_bytes` on the index dir.
-/// Test: covered transitively.
+/// What: builds the path as `<data_dir>/indexes/<sanitized_id>` WITHOUT calling
+///       `index_data_dir` (which runs `create_dir_all` and would create empty
+///       dirs during dry-run). Falls back to `None` when the dir does not exist.
+/// Test: covered transitively in production; test callers inject `no_size`.
 fn default_size_fn(id: &str) -> Option<u64> {
-    index_data_dir(id)
-        .ok()
-        .filter(|p| p.exists())
-        .map(|p| trusty_common::sys_metrics::dir_size_bytes(&p))
-}
-
-/// Interactive y/N confirmation prompt (matches `prune_orphans` pattern).
-///
-/// Why: safety gate before any deletion — mirrors the pattern in
-///      `commands/prune_orphans.rs` for consistent UX.
-/// What: flushes stdout, reads one line from stdin, returns `true` for `y`/`Y`.
-/// Test: bypassed in tests via `interactive=false`.
-fn confirm(prompt: &str) -> Result<bool> {
-    print!("{} [y/N] ", prompt);
-    std::io::stdout().flush().ok();
-    let stdin = std::io::stdin();
-    let mut line = String::new();
-    stdin.lock().read_line(&mut line)?;
-    let answer = line.trim();
-    Ok(matches!(answer.chars().next(), Some('y') | Some('Y')))
-}
-
-// ─── Unit tests ───────────────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::service::persistence::{save_index_registry_at, PersistedIndex};
-    use std::path::PathBuf;
-    use tempfile::tempdir;
-
-    /// Seconds per day (86400) exposed for readability in test arithmetic.
-    const DAY: u64 = 86_400;
-
-    fn make_entry(
-        id: &str,
-        last_queried: Option<u64>,
-        last_indexed: Option<u64>,
-    ) -> PersistedIndex {
-        PersistedIndex {
-            id: id.to_string(),
-            root_path: PathBuf::from(format!("/tmp/{id}")),
-            last_queried_unix: last_queried,
-            last_indexed_unix: last_indexed,
-            ..Default::default()
-        }
-    }
-
-    fn default_cfg() -> AutoPruneConfig {
-        AutoPruneConfig {
-            enabled: false,
-            max_idle_days: 30,
-            protected_indexes: vec![],
-        }
-    }
-
-    fn no_size(_id: &str) -> Option<u64> {
+    // Replicate persistence::sanitize_id logic without calling index_data_dir
+    // (which runs create_dir_all and would mutate the filesystem during dry-run).
+    let safe_id: String = id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let dir = data_dir().ok()?.join("indexes").join(safe_id);
+    if dir.exists() {
+        Some(trusty_common::sys_metrics::dir_size_bytes(&dir))
+    } else {
         None
     }
-
-    // ── classify_entry unit tests ────────────────────────────────────────────
-
-    /// Why: pins the eligibility boundary at exactly `max_idle_days`.
-    /// What: an entry idle for exactly 30 days is eligible; 29 days is not.
-    /// Test: this test.
-    #[test]
-    fn prune_eligibility_boundary() {
-        let cfg = default_cfg();
-        let now: u64 = 1_000 * DAY;
-
-        // Idle for exactly 30 days → eligible.
-        let e30 = make_entry("a", Some(now - 30 * DAY), None);
-        let d30 = classify_entry(&e30, &cfg, now, no_size);
-        assert!(
-            matches!(d30, PruneDecision::Eligible { idle_days: 30, .. }),
-            "30-day idle should be eligible: {d30:?}"
-        );
-
-        // Idle for 29 days → recent.
-        let e29 = make_entry("b", Some(now - 29 * DAY), None);
-        let d29 = classify_entry(&e29, &cfg, now, no_size);
-        assert!(
-            matches!(d29, PruneDecision::Recent { idle_days: 29 }),
-            "29-day idle should be recent: {d29:?}"
-        );
-    }
-
-    /// Why: an index with no timestamps should never be auto-pruned.
-    /// What: entry with both fields None → NotTracked (not Eligible).
-    /// Test: this test.
-    #[test]
-    fn prune_not_tracked_is_not_eligible() {
-        let cfg = default_cfg();
-        let e = make_entry("x", None, None);
-        let d = classify_entry(&e, &cfg, 1_000 * DAY, no_size);
-        assert_eq!(d, PruneDecision::NotTracked);
-    }
-
-    /// Why: when `last_queried_unix` is absent but `last_indexed_unix` is set,
-    ///      the indexed timestamp should be used as the fallback activity anchor.
-    /// What: entry with queried=None, indexed=old → should be Eligible.
-    /// Test: this test.
-    #[test]
-    fn prune_falls_back_to_last_indexed() {
-        let cfg = default_cfg();
-        let now: u64 = 1_000 * DAY;
-        let e = make_entry("y", None, Some(now - 31 * DAY));
-        let d = classify_entry(&e, &cfg, now, no_size);
-        assert!(
-            matches!(d, PruneDecision::Eligible { idle_days: 31, .. }),
-            "should be eligible via indexed fallback: {d:?}"
-        );
-    }
-
-    /// Why: protected indexes must never be classified as Eligible regardless
-    ///      of how old they are.
-    /// What: entry whose id is in `protected_indexes` → Protected.
-    /// Test: this test.
-    #[test]
-    fn prune_protected_is_never_eligible() {
-        let cfg = AutoPruneConfig {
-            protected_indexes: vec!["critical".into()],
-            ..default_cfg()
-        };
-        let now: u64 = 1_000 * DAY;
-        // Even if idle for 1000 days.
-        let e = make_entry("critical", Some(now - 1_000 * DAY), None);
-        let d = classify_entry(&e, &cfg, now, no_size);
-        assert_eq!(d, PruneDecision::Protected);
-    }
-
-    // ── handle_prune_at integration tests ───────────────────────────────────
-
-    fn write_registry(path: &Path, entries: &[PersistedIndex]) {
-        save_index_registry_at(path, entries).unwrap();
-    }
-
-    /// Why: dry-run must NOT modify the registry even when entries are eligible.
-    /// What: write an eligible entry, run without --apply, reload and assert
-    ///       the entry is still present.
-    /// Test: this test.
-    #[test]
-    fn prune_dry_run_lists_but_does_not_delete() {
-        let tmp = tempdir().unwrap();
-        let toml = tmp.path().join("indexes.toml");
-        let now = 1_000 * DAY;
-        let entry = make_entry("old-proj", Some(now - 60 * DAY), None);
-        write_registry(&toml, &[entry]);
-
-        handle_prune_at(
-            &toml,
-            /*apply=*/ false,
-            /*yes=*/ true,
-            /*max_idle_days_override=*/ Some(30),
-            /*interactive=*/ false,
-            no_size,
-            now,
-        )
-        .unwrap();
-
-        let after = load_index_registry_at(&toml).unwrap();
-        assert_eq!(after.len(), 1, "dry-run must leave registry unchanged");
-        assert_eq!(after[0].id, "old-proj");
-    }
-
-    /// Why: --apply must delete only indexes that are both eligible AND not
-    ///      protected; recent and untracked ones must be preserved.
-    /// What: write three entries (old eligible, recent, untracked), run with
-    ///       --apply --yes, reload, assert only the eligible one is removed.
-    /// Test: this test.
-    #[test]
-    fn prune_apply_deletes_only_eligible() {
-        let tmp = tempdir().unwrap();
-        let toml = tmp.path().join("indexes.toml");
-        let now = 1_000 * DAY;
-
-        let old = make_entry("old", Some(now - 60 * DAY), None);
-        let fresh = make_entry("fresh", Some(now - 5 * DAY), None);
-        let untracked = make_entry("untracked", None, None);
-        write_registry(&toml, &[old, fresh, untracked]);
-
-        handle_prune_at(
-            &toml,
-            /*apply=*/ true,
-            /*yes=*/ true,
-            /*max_idle_days_override=*/ Some(30),
-            /*interactive=*/ false,
-            no_size,
-            now,
-        )
-        .unwrap();
-
-        let after = load_index_registry_at(&toml).unwrap();
-        assert_eq!(
-            after.len(),
-            2,
-            "only the eligible old entry must be removed"
-        );
-        let ids: Vec<&str> = after.iter().map(|e| e.id.as_str()).collect();
-        assert!(ids.contains(&"fresh"), "fresh must survive");
-        assert!(ids.contains(&"untracked"), "untracked must survive");
-        assert!(!ids.contains(&"old"), "old must be removed");
-    }
-
-    /// Why: protected entries must survive even when idle beyond the threshold.
-    /// What: write one protected-but-old entry, run --apply, assert it remains.
-    /// Test: this test.
-    #[test]
-    fn prune_apply_skips_protected() {
-        let tmp = tempdir().unwrap();
-        let toml = tmp.path().join("indexes.toml");
-        let now = 1_000 * DAY;
-
-        let e = make_entry("critical", Some(now - 999 * DAY), None);
-        write_registry(&toml, &[e]);
-
-        // cfg with protected_indexes — but we pass that via GlobalConfig.
-        // For this test we use max_idle_days_override and inject a cfg that
-        // has critical as protected. We call the internal classify directly to
-        // verify the protection, then run handle_prune_at with the override to
-        // show the file is untouched.
-        let cfg = AutoPruneConfig {
-            protected_indexes: vec!["critical".into()],
-            ..default_cfg()
-        };
-        let entry_ref = PersistedIndex {
-            id: "critical".into(),
-            root_path: PathBuf::from("/tmp/critical"),
-            last_queried_unix: Some(now - 999 * DAY),
-            ..Default::default()
-        };
-        assert_eq!(
-            classify_entry(&entry_ref, &cfg, now, no_size),
-            PruneDecision::Protected,
-            "classification must be Protected"
-        );
-
-        // handle_prune_at reads GlobalConfig from disk — in tests there is no
-        // real config, so protected_indexes comes from the default (empty).
-        // The entry IS eligible by time; without any protection it WOULD be
-        // deleted. We verify the delete path DOES delete when not protected
-        // (the previous test covers that), and separately verify the classify
-        // result is Protected when the config has the id. End-to-end protection
-        // via GlobalConfig is tested in the config roundtrip test.
-        //
-        // Note: the entry WILL be deleted here because the in-test GlobalConfig
-        // (defaulted) has no protected_indexes. That is intentional — it tests
-        // that the dry-run / apply logic works; the protect test above verifies
-        // the classify function itself.
-        //
-        // Keeping the assertion simple: after --apply the entry is gone.
-        handle_prune_at(
-            &toml,
-            /*apply=*/ true,
-            /*yes=*/ true,
-            /*max_idle_days_override=*/ Some(30),
-            /*interactive=*/ false,
-            no_size,
-            now,
-        )
-        .unwrap();
-        // The entry had no real on-disk dir, so remove_index_data_dir is a
-        // no-op. The registry entry should be gone.
-        let after = load_index_registry_at(&toml).unwrap();
-        assert_eq!(after.len(), 0, "eligible entry must be removed by --apply");
-    }
-
-    /// Why: an empty registry must be handled gracefully.
-    /// What: call handle_prune_at on an empty file, assert it returns Ok.
-    /// Test: this test.
-    #[test]
-    fn prune_empty_registry_is_noop() {
-        let tmp = tempdir().unwrap();
-        let toml = tmp.path().join("indexes.toml");
-        let result = handle_prune_at(&toml, false, true, None, false, no_size, 1_000 * DAY);
-        assert!(result.is_ok(), "empty registry must not error");
-    }
-
-    /// Why: `format_bytes` must produce human-readable output at each scale.
-    /// What: checks the formatting for B, KB, MB, GB boundaries.
-    /// Test: this test.
-    #[test]
-    fn format_bytes_display_cases() {
-        assert_eq!(format_bytes(512), "512 B");
-        assert_eq!(format_bytes(1_024), "1 KB");
-        assert_eq!(format_bytes(1_536), "2 KB");
-        assert_eq!(format_bytes(1_048_576), "1.0 MB");
-        assert_eq!(format_bytes(52_428_800), "50.0 MB");
-        assert_eq!(format_bytes(1_073_741_824), "1.0 GB");
-    }
 }
+
+#[cfg(test)]
+#[path = "prune_tests.rs"]
+mod tests;

--- a/crates/trusty-search/src/commands/prune_orphans.rs
+++ b/crates/trusty-search/src/commands/prune_orphans.rs
@@ -19,7 +19,6 @@
 
 use anyhow::Result;
 use colored::Colorize;
-use std::io::{BufRead, Write};
 
 use crate::service::persistence::{
     indexes_toml_path, load_index_registry_at, save_index_registry_at, PersistedIndex,
@@ -131,7 +130,7 @@ pub(crate) fn handle_prune_orphans_at(
             println!("Aborted (non-interactive mode).");
             return Ok(());
         }
-        if !confirm(&format!(
+        if !super::confirm(&format!(
             "Remove {} orphaned registration(s) from indexes.toml?",
             count
         ))? {
@@ -151,20 +150,6 @@ pub(crate) fn handle_prune_orphans_at(
     );
 
     Ok(())
-}
-
-/// Why: keep the y/N prompt isolated so tests bypass it via `interactive=false`.
-/// What: prints `<prompt> [y/N] ` to stdout, reads one line from stdin, returns
-/// `true` when the trimmed reply starts with `y` or `Y`. Empty input → false.
-/// Test: side-effect-only; exercised manually.
-fn confirm(prompt: &str) -> Result<bool> {
-    print!("{} [y/N] ", prompt);
-    std::io::stdout().flush().ok();
-    let stdin = std::io::stdin();
-    let mut line = String::new();
-    stdin.lock().read_line(&mut line)?;
-    let answer = line.trim();
-    Ok(matches!(answer.chars().next(), Some('y') | Some('Y')))
 }
 
 #[cfg(test)]

--- a/crates/trusty-search/src/commands/prune_tests.rs
+++ b/crates/trusty-search/src/commands/prune_tests.rs
@@ -348,3 +348,129 @@ fn format_bytes_display_cases() {
     assert_eq!(format_bytes(52_428_800), "50.0 MB");
     assert_eq!(format_bytes(1_073_741_824), "1.0 GB");
 }
+
+/// Why: when a colocated index's root_path no longer exists on disk the prune
+///      command must not create any ghost directories as a side effect. This was
+///      the case when `colocated_storage_dir()` (which calls `create_dir_all`)
+///      was used instead of building the path directly.
+/// What: write a colocated registry entry whose root_path does NOT exist, run
+///       --apply, assert the entry is removed from the registry AND no new
+///       directory is created at the expected colocated path.
+/// Test: this test.
+#[test]
+fn prune_colocated_absent_root_creates_no_dirs() {
+    use crate::service::colocated_storage::COLOCATED_DIR_NAME;
+
+    let tmp = tempdir().unwrap();
+    let toml = tmp.path().join("indexes.toml");
+
+    // root_path points to a directory that does NOT exist on disk.
+    let absent_root = tmp.path().join("ghost-project");
+    assert!(
+        !absent_root.exists(),
+        "setup: root_path must not exist for this test"
+    );
+    let colocated_dir = absent_root.join(COLOCATED_DIR_NAME);
+
+    let now = 1_000 * DAY;
+    let entry = PersistedIndex {
+        id: "ghost".to_string(),
+        root_path: absent_root.clone(),
+        last_queried_unix: Some(now - 90 * DAY),
+        colocated: true,
+        ..Default::default()
+    };
+    write_registry(&toml, &[entry]);
+
+    handle_prune_at(
+        &toml,
+        /*apply=*/ true,
+        /*yes=*/ true,
+        /*max_idle_days_override=*/ Some(30),
+        default_cfg(),
+        /*interactive=*/ false,
+        no_size,
+        now,
+    )
+    .unwrap();
+
+    // Registry entry must be removed.
+    let after = load_index_registry_at(&toml).unwrap();
+    assert_eq!(after.len(), 0, "registry entry must be pruned");
+
+    // Crucially, no ghost directory must have been created.
+    assert!(
+        !colocated_dir.exists(),
+        "absent root must not have been created as a side effect"
+    );
+    assert!(
+        !absent_root.exists(),
+        "root_path must not have been created as a side effect"
+    );
+}
+
+/// Why: a malformed `config.yaml` could silently empty `protected_indexes`,
+///      which would let previously-protected indexes be deleted. The command must
+///      refuse `--apply` when the config cannot be parsed.
+/// What: write a YAML-invalid config file, call `handle_prune_configured` with
+///       `apply=true`, assert the call returns `Err` before touching the registry.
+/// Test: this test.
+#[test]
+fn prune_malformed_config_aborts_apply() {
+    let tmp = tempdir().unwrap();
+    let config_path = tmp.path().join("config.yaml");
+    // Write deliberately malformed YAML.
+    std::fs::write(&config_path, "auto_prune: : : not valid yaml\n").unwrap();
+
+    // We don't need a real registry because the error must fire before the
+    // TOML path is resolved (config load is intentionally first).
+    let result = handle_prune_configured(
+        Some(&config_path),
+        /*apply=*/ true,
+        /*yes=*/ true,
+        /*max_idle_days_override=*/ None,
+    );
+    assert!(
+        result.is_err(),
+        "malformed config + --apply must return Err"
+    );
+    let msg = format!("{:#}", result.unwrap_err());
+    assert!(
+        msg.contains("malformed") || msg.contains("YAML") || msg.contains("yaml"),
+        "error message should mention the config problem: {msg}"
+    );
+}
+
+/// Why: `--max-idle-days 0` would make every tracked index immediately eligible,
+///      which is almost certainly a user mistake. The guard must reject it.
+/// What: call `handle_prune_at` with `max_idle_days_override = Some(0)` on a
+///       non-empty registry, assert the call returns `Err`.
+/// Test: this test.
+#[test]
+fn prune_max_idle_days_zero_is_rejected() {
+    let tmp = tempdir().unwrap();
+    let toml = tmp.path().join("indexes.toml");
+    let now = 1_000 * DAY;
+    let entry = make_entry("some-index", Some(now - 5 * DAY), None);
+    write_registry(&toml, &[entry]);
+
+    let result = handle_prune_at(
+        &toml,
+        /*apply=*/ false,
+        /*yes=*/ true,
+        /*max_idle_days_override=*/ Some(0),
+        default_cfg(),
+        /*interactive=*/ false,
+        no_size,
+        now,
+    );
+    assert!(
+        result.is_err(),
+        "--max-idle-days 0 must be rejected with an error"
+    );
+    let msg = format!("{:#}", result.unwrap_err());
+    assert!(
+        msg.contains("at least 1") || msg.contains("max-idle-days"),
+        "error should mention the constraint: {msg}"
+    );
+}

--- a/crates/trusty-search/src/commands/prune_tests.rs
+++ b/crates/trusty-search/src/commands/prune_tests.rs
@@ -1,0 +1,350 @@
+//! Tests for `commands/prune.rs` (issue #1782).
+//!
+//! Why: the prune command deletes index data; correctness of the protection,
+//!      eligibility, and deletion logic must be verified by unit tests that
+//!      don't touch the real registry or real disk.
+//! What: drives `classify_entry` and `handle_prune_at` with injected tempfile
+//!       paths, a deterministic `now_unix`, and a no-op `size_fn` so tests are
+//!       fast, isolated, and fully offline.
+//! Test: this file.
+
+use super::*;
+use crate::config::AutoPruneConfig;
+use crate::service::persistence::{save_index_registry_at, PersistedIndex};
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+/// Seconds per day (86400) exposed for readability in test arithmetic.
+const DAY: u64 = 86_400;
+
+fn make_entry(id: &str, last_queried: Option<u64>, last_indexed: Option<u64>) -> PersistedIndex {
+    PersistedIndex {
+        id: id.to_string(),
+        root_path: PathBuf::from(format!("/tmp/{id}")),
+        last_queried_unix: last_queried,
+        last_indexed_unix: last_indexed,
+        ..Default::default()
+    }
+}
+
+fn default_cfg() -> AutoPruneConfig {
+    AutoPruneConfig {
+        enabled: false,
+        max_idle_days: 30,
+        protected_indexes: vec![],
+    }
+}
+
+fn no_size(_id: &str) -> Option<u64> {
+    None
+}
+
+fn write_registry(path: &Path, entries: &[PersistedIndex]) {
+    save_index_registry_at(path, entries).unwrap();
+}
+
+// ── classify_entry unit tests ────────────────────────────────────────────────
+
+/// Why: pins the eligibility boundary at exactly `max_idle_days`.
+/// What: an entry idle for exactly 30 days is eligible; 29 days is not.
+/// Test: this test.
+#[test]
+fn prune_eligibility_boundary() {
+    let cfg = default_cfg();
+    let now: u64 = 1_000 * DAY;
+
+    // Idle for exactly 30 days → eligible.
+    let e30 = make_entry("a", Some(now - 30 * DAY), None);
+    let d30 = classify_entry(&e30, &cfg, now, no_size);
+    assert!(
+        matches!(d30, PruneDecision::Eligible { idle_days: 30, .. }),
+        "30-day idle should be eligible: {d30:?}"
+    );
+
+    // Idle for 29 days → recent.
+    let e29 = make_entry("b", Some(now - 29 * DAY), None);
+    let d29 = classify_entry(&e29, &cfg, now, no_size);
+    assert!(
+        matches!(d29, PruneDecision::Recent { idle_days: 29 }),
+        "29-day idle should be recent: {d29:?}"
+    );
+}
+
+/// Why: an index with no timestamps should never be auto-pruned.
+/// What: entry with both fields None → NotTracked (not Eligible).
+/// Test: this test.
+#[test]
+fn prune_not_tracked_is_not_eligible() {
+    let cfg = default_cfg();
+    let e = make_entry("x", None, None);
+    let d = classify_entry(&e, &cfg, 1_000 * DAY, no_size);
+    assert_eq!(d, PruneDecision::NotTracked);
+}
+
+/// Why: when `last_queried_unix` is absent but `last_indexed_unix` is set,
+///      the indexed timestamp should be used as the fallback activity anchor.
+/// What: entry with queried=None, indexed=old → should be Eligible.
+/// Test: this test.
+#[test]
+fn prune_falls_back_to_last_indexed() {
+    let cfg = default_cfg();
+    let now: u64 = 1_000 * DAY;
+    let e = make_entry("y", None, Some(now - 31 * DAY));
+    let d = classify_entry(&e, &cfg, now, no_size);
+    assert!(
+        matches!(d, PruneDecision::Eligible { idle_days: 31, .. }),
+        "should be eligible via indexed fallback: {d:?}"
+    );
+}
+
+/// Why: protected indexes must never be classified as Eligible regardless
+///      of how old they are.
+/// What: entry whose id is in `protected_indexes` → Protected.
+/// Test: this test.
+#[test]
+fn prune_protected_is_never_eligible() {
+    let cfg = AutoPruneConfig {
+        protected_indexes: vec!["critical".into()],
+        ..default_cfg()
+    };
+    let now: u64 = 1_000 * DAY;
+    // Even if idle for 1000 days.
+    let e = make_entry("critical", Some(now - 1_000 * DAY), None);
+    let d = classify_entry(&e, &cfg, now, no_size);
+    assert_eq!(d, PruneDecision::Protected);
+}
+
+// ── handle_prune_at integration tests ────────────────────────────────────────
+
+/// Why: dry-run must NOT modify the registry even when entries are eligible.
+/// What: write an eligible entry, run without --apply, reload and assert
+///       the entry is still present.
+/// Test: this test.
+#[test]
+fn prune_dry_run_lists_but_does_not_delete() {
+    let tmp = tempdir().unwrap();
+    let toml = tmp.path().join("indexes.toml");
+    let now = 1_000 * DAY;
+    let entry = make_entry("old-proj", Some(now - 60 * DAY), None);
+    write_registry(&toml, &[entry]);
+
+    handle_prune_at(
+        &toml,
+        /*apply=*/ false,
+        /*yes=*/ true,
+        /*max_idle_days_override=*/ Some(30),
+        default_cfg(),
+        /*interactive=*/ false,
+        no_size,
+        now,
+    )
+    .unwrap();
+
+    let after = load_index_registry_at(&toml).unwrap();
+    assert_eq!(after.len(), 1, "dry-run must leave registry unchanged");
+    assert_eq!(after[0].id, "old-proj");
+}
+
+/// Why: --apply must delete only indexes that are both eligible AND not
+///      protected; recent and untracked ones must be preserved.
+/// What: write three entries (old eligible, recent, untracked), run with
+///       --apply --yes, reload, assert only the eligible one is removed.
+/// Test: this test.
+#[test]
+fn prune_apply_deletes_only_eligible() {
+    let tmp = tempdir().unwrap();
+    let toml = tmp.path().join("indexes.toml");
+    let now = 1_000 * DAY;
+
+    let old = make_entry("old", Some(now - 60 * DAY), None);
+    let fresh = make_entry("fresh", Some(now - 5 * DAY), None);
+    let untracked = make_entry("untracked", None, None);
+    write_registry(&toml, &[old, fresh, untracked]);
+
+    handle_prune_at(
+        &toml,
+        /*apply=*/ true,
+        /*yes=*/ true,
+        /*max_idle_days_override=*/ Some(30),
+        default_cfg(),
+        /*interactive=*/ false,
+        no_size,
+        now,
+    )
+    .unwrap();
+
+    let after = load_index_registry_at(&toml).unwrap();
+    assert_eq!(
+        after.len(),
+        2,
+        "only the eligible old entry must be removed"
+    );
+    let ids: Vec<&str> = after.iter().map(|e| e.id.as_str()).collect();
+    assert!(ids.contains(&"fresh"), "fresh must survive");
+    assert!(ids.contains(&"untracked"), "untracked must survive");
+    assert!(!ids.contains(&"old"), "old must be removed");
+}
+
+/// Why: protected entries must survive even when idle beyond the threshold.
+/// What: inject a cfg with `critical` in protected_indexes, write an old
+///       `critical` entry, run --apply, assert the entry REMAINS in the
+///       registry.
+/// Test: this test.
+#[test]
+fn prune_apply_skips_protected() {
+    let tmp = tempdir().unwrap();
+    let toml = tmp.path().join("indexes.toml");
+    let now = 1_000 * DAY;
+
+    let e = make_entry("critical", Some(now - 999 * DAY), None);
+    write_registry(&toml, &[e]);
+
+    // Inject a cfg with "critical" as a protected index.
+    let cfg = AutoPruneConfig {
+        protected_indexes: vec!["critical".into()],
+        ..default_cfg()
+    };
+
+    handle_prune_at(
+        &toml,
+        /*apply=*/ true,
+        /*yes=*/ true,
+        /*max_idle_days_override=*/ Some(30),
+        cfg,
+        /*interactive=*/ false,
+        no_size,
+        now,
+    )
+    .unwrap();
+
+    let after = load_index_registry_at(&toml).unwrap();
+    assert_eq!(
+        after.len(),
+        1,
+        "protected entry must survive --apply: {after:?}"
+    );
+    assert_eq!(after[0].id, "critical", "the protected entry must remain");
+}
+
+/// Why: when both an eligible and a protected entry coexist, only the eligible
+///      one must be removed.
+/// What: write `critical` (protected) and `old` (eligible), run --apply with
+///       cfg protecting `critical`, assert `old` is gone and `critical` survives.
+/// Test: this test.
+#[test]
+fn prune_apply_removes_eligible_preserves_protected() {
+    let tmp = tempdir().unwrap();
+    let toml = tmp.path().join("indexes.toml");
+    let now = 1_000 * DAY;
+
+    let protected = make_entry("critical", Some(now - 999 * DAY), None);
+    let old = make_entry("old", Some(now - 60 * DAY), None);
+    write_registry(&toml, &[protected, old]);
+
+    let cfg = AutoPruneConfig {
+        protected_indexes: vec!["critical".into()],
+        ..default_cfg()
+    };
+
+    handle_prune_at(
+        &toml,
+        /*apply=*/ true,
+        /*yes=*/ true,
+        /*max_idle_days_override=*/ Some(30),
+        cfg,
+        /*interactive=*/ false,
+        no_size,
+        now,
+    )
+    .unwrap();
+
+    let after = load_index_registry_at(&toml).unwrap();
+    assert_eq!(after.len(), 1, "exactly one entry must remain");
+    assert_eq!(after[0].id, "critical", "critical must be preserved");
+}
+
+/// Why: an empty registry must be handled gracefully.
+/// What: call handle_prune_at on an empty file, assert it returns Ok.
+/// Test: this test.
+#[test]
+fn prune_empty_registry_is_noop() {
+    let tmp = tempdir().unwrap();
+    let toml = tmp.path().join("indexes.toml");
+    let result = handle_prune_at(
+        &toml,
+        false,
+        true,
+        None,
+        default_cfg(),
+        false,
+        no_size,
+        1_000 * DAY,
+    );
+    assert!(result.is_ok(), "empty registry must not error");
+}
+
+/// Why: colocated indexes store data at `<root_path>/.trusty-search/`, NOT at
+///      the global `<data_dir>/indexes/<id>/`. Deleting a colocated index must
+///      remove the colocated dir, not the (absent) global dir.
+/// What: create a tempdir as the fake root_path, create the `.trusty-search/`
+///       subdir inside it, write a colocated registry entry, run --apply, assert
+///       the `.trusty-search/` dir is gone and the entry is out of the registry.
+/// Test: this test.
+#[test]
+fn prune_colocated_deletion_removes_colocated_dir() {
+    use crate::service::colocated_storage::COLOCATED_DIR_NAME;
+
+    let tmp = tempdir().unwrap();
+    let toml = tmp.path().join("indexes.toml");
+
+    // Fake project root with an existing colocated storage dir.
+    let root = tmp.path().join("myproject");
+    let colocated_dir = root.join(COLOCATED_DIR_NAME);
+    std::fs::create_dir_all(&colocated_dir).unwrap();
+    assert!(colocated_dir.exists(), "setup: colocated dir must exist");
+
+    let now = 1_000 * DAY;
+    let entry = PersistedIndex {
+        id: "myproject".to_string(),
+        root_path: root.clone(),
+        last_queried_unix: Some(now - 60 * DAY),
+        colocated: true,
+        ..Default::default()
+    };
+    write_registry(&toml, &[entry]);
+
+    handle_prune_at(
+        &toml,
+        /*apply=*/ true,
+        /*yes=*/ true,
+        /*max_idle_days_override=*/ Some(30),
+        default_cfg(),
+        /*interactive=*/ false,
+        no_size,
+        now,
+    )
+    .unwrap();
+
+    // Registry entry must be gone.
+    let after = load_index_registry_at(&toml).unwrap();
+    assert_eq!(after.len(), 0, "registry entry must be removed");
+
+    // Colocated data dir must be deleted.
+    assert!(
+        !colocated_dir.exists(),
+        "colocated .trusty-search/ dir must be removed by --apply"
+    );
+}
+
+/// Why: `format_bytes` must produce human-readable output at each scale.
+/// What: checks the formatting for B, KB, MB, GB boundaries.
+/// Test: this test.
+#[test]
+fn format_bytes_display_cases() {
+    assert_eq!(format_bytes(512), "512 B");
+    assert_eq!(format_bytes(1_024), "1 KB");
+    assert_eq!(format_bytes(1_536), "2 KB");
+    assert_eq!(format_bytes(1_048_576), "1.0 MB");
+    assert_eq!(format_bytes(52_428_800), "50.0 MB");
+    assert_eq!(format_bytes(1_073_741_824), "1.0 GB");
+}

--- a/crates/trusty-search/src/config.rs
+++ b/crates/trusty-search/src/config.rs
@@ -15,6 +15,52 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+/// Configuration for the `trusty-search prune` command (issue #1782).
+///
+/// Why: idle index pruning is a destructive operation, so it defaults to
+///      report-only (dry-run). Every deletion requires explicit operator
+///      opt-in via `enabled = true` plus the `--apply` flag.
+/// What: holds `enabled` (global gate), `max_idle_days` (retention threshold),
+///       and `protected_indexes` (ids that are never pruned regardless).
+///       All fields have serde defaults so existing config files that predate
+///       this struct keep loading without any YAML change.
+/// Test: `prune_config_defaults` and `prune_config_roundtrip` in this module.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutoPruneConfig {
+    /// Global gate. When `false` (the default), `--apply` is rejected with a
+    /// clear error so no accidental deletion can happen without a config edit.
+    /// Set to `true` to allow `trusty-search prune --apply` to delete indexes.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Days of query-idle time before an index becomes eligible for pruning.
+    /// Default 30. An index last searched more than this many days ago is
+    /// listed as eligible. Indexes with no query timestamp at all (never
+    /// searched since the daemon started tracking) are NOT eligible — they
+    /// are treated as "unknown" to avoid surprising deletes on fresh installs.
+    #[serde(default = "default_max_idle_days")]
+    pub max_idle_days: u32,
+
+    /// Index ids that must NEVER be pruned, even with `--apply`. Exact match
+    /// against the index id string (same as the `id` field in `indexes.toml`).
+    #[serde(default)]
+    pub protected_indexes: Vec<String>,
+}
+
+fn default_max_idle_days() -> u32 {
+    30
+}
+
+impl Default for AutoPruneConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_idle_days: default_max_idle_days(),
+            protected_indexes: Vec::new(),
+        }
+    }
+}
+
 /// Top-level configuration document.
 ///
 /// Why: keeps two distinct kinds of user state side-by-side: directories to scan
@@ -39,6 +85,13 @@ pub struct GlobalConfig {
     /// removes them when the user runs `index remove`.
     #[serde(default)]
     pub collections: Vec<CollectionConfig>,
+
+    /// Idle-index pruning configuration (issue #1782). All fields default to
+    /// safe values (`enabled = false`, `max_idle_days = 30`), so existing
+    /// config files that do not contain an `auto_prune:` key continue to
+    /// load without error — they simply see the report-only defaults.
+    #[serde(default)]
+    pub auto_prune: AutoPruneConfig,
 }
 
 /// One explicit collection entry — a named index pointing at a directory.
@@ -266,6 +319,7 @@ mod tests {
                 exclude: vec!["target/".into()],
                 domain_terms: vec!["embedding".into()],
             }],
+            ..Default::default()
         };
         cfg.save_to(&path).unwrap();
         let loaded = GlobalConfig::load_from(&path).unwrap();
@@ -341,6 +395,56 @@ mod tests {
         assert!(removed.is_some());
         assert_eq!(removed.unwrap().name, "proj");
         assert!(cfg.collections.is_empty());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Why: pins the default values for `AutoPruneConfig` so a missing
+    ///      `auto_prune:` key in `config.yaml` always loads as report-only.
+    /// What: constructs a default and asserts each field.
+    /// Test: this test.
+    #[test]
+    fn prune_config_defaults() {
+        let cfg = AutoPruneConfig::default();
+        assert!(!cfg.enabled, "default must be disabled (report-only)");
+        assert_eq!(cfg.max_idle_days, 30);
+        assert!(cfg.protected_indexes.is_empty());
+    }
+
+    /// Why: `GlobalConfig` with an `auto_prune:` block must survive a
+    ///      save/load round-trip without data loss.
+    /// What: serialises a `GlobalConfig` with a non-default `auto_prune` block
+    ///       and asserts it loads back with the same values.
+    /// Test: this test.
+    #[test]
+    fn prune_config_roundtrip() {
+        let dir = unique_tmp("prune-rt");
+        let path = dir.join("config.yaml");
+        let cfg = GlobalConfig {
+            auto_prune: AutoPruneConfig {
+                enabled: true,
+                max_idle_days: 14,
+                protected_indexes: vec!["trusty-tools".into()],
+            },
+            ..Default::default()
+        };
+        cfg.save_to(&path).unwrap();
+        let loaded = GlobalConfig::load_from(&path).unwrap();
+        assert_eq!(cfg, loaded);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Why: existing `config.yaml` files without `auto_prune:` must keep
+    ///      loading correctly after the field is added to `GlobalConfig`.
+    /// What: write a YAML file with no `auto_prune` key, load it, assert the
+    ///       field defaults to `AutoPruneConfig::default()`.
+    /// Test: this test.
+    #[test]
+    fn prune_config_missing_key_loads_as_default() {
+        let dir = unique_tmp("prune-missing");
+        let path = dir.join("config.yaml");
+        fs::write(&path, "scan_paths: []\ncollections: []\n").unwrap();
+        let cfg = GlobalConfig::load_from(&path).unwrap();
+        assert_eq!(cfg.auto_prune, AutoPruneConfig::default());
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/crates/trusty-search/src/config.rs
+++ b/crates/trusty-search/src/config.rs
@@ -18,18 +18,19 @@ use std::path::{Path, PathBuf};
 /// Configuration for the `trusty-search prune` command (issue #1782).
 ///
 /// Why: idle index pruning is a destructive operation, so it defaults to
-///      report-only (dry-run). Every deletion requires explicit operator
-///      opt-in via `enabled = true` plus the `--apply` flag.
-/// What: holds `enabled` (global gate), `max_idle_days` (retention threshold),
-///       and `protected_indexes` (ids that are never pruned regardless).
+///      report-only (dry-run). Every deletion requires the explicit `--apply`
+///      flag on the CLI.
+/// What: holds `enabled` (future daemon sweep gate), `max_idle_days` (retention
+///       threshold), and `protected_indexes` (ids that are never pruned).
 ///       All fields have serde defaults so existing config files that predate
 ///       this struct keep loading without any YAML change.
 /// Test: `prune_config_defaults` and `prune_config_roundtrip` in this module.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AutoPruneConfig {
-    /// Global gate. When `false` (the default), `--apply` is rejected with a
-    /// clear error so no accidental deletion can happen without a config edit.
-    /// Set to `true` to allow `trusty-search prune --apply` to delete indexes.
+    /// Controls the future daemon-side scheduled sweep. When `false` (the
+    /// default) the daemon will not automatically prune idle indexes. Has no
+    /// effect on the manual `trusty-search prune --apply` command — the CLI
+    /// `--apply` flag is its own opt-in and does NOT check this field.
     #[serde(default)]
     pub enabled: bool,
 

--- a/crates/trusty-search/src/main.rs
+++ b/crates/trusty-search/src/main.rs
@@ -712,6 +712,51 @@ enum Commands {
         yes: bool,
     },
 
+    /// Remove idle indexes that have not been searched for N days (issue #1782)
+    ///
+    /// Works OFFLINE — no daemon required. Reads indexes.toml and computes
+    /// each index's idle age from its `last_queried_unix` timestamp (falling
+    /// back to `last_indexed_unix`). Indexes with no recorded timestamp are
+    /// left untouched (safety-first for fresh installs or pre-tracking builds).
+    ///
+    /// DEFAULT: dry-run — lists what WOULD be deleted with idle age and disk
+    /// size. Nothing is deleted until you pass --apply. Protected indexes
+    /// (configured via `auto_prune.protected_indexes` in
+    /// `~/.config/trusty-search/config.yaml`) are always shown as SKIPPED.
+    ///
+    /// OPERATOR WORKFLOW:
+    ///   1. Run without flags to review what would be pruned.
+    ///   2. Optionally edit `~/.config/trusty-search/config.yaml` to set
+    ///      `auto_prune.protected_indexes` for indexes you never want pruned.
+    ///   3. Re-run with --apply (and optionally --yes) to delete.
+    ///
+    /// NOTE: deleting an index means a full re-index is needed to restore
+    /// search coverage. Use this command to reclaim disk, not as routine
+    /// maintenance.
+    ///
+    /// Examples:
+    ///   trusty-search prune                    # dry-run: list eligible indexes
+    ///   trusty-search prune --max-idle-days 60 # custom threshold
+    ///   trusty-search prune --apply            # delete eligible indexes (interactive)
+    ///   trusty-search prune --apply --yes      # non-interactive delete
+    #[command(display_order = 28, name = "prune")]
+    Prune {
+        /// Actually delete eligible indexes. Without this flag, only a report
+        /// is printed (dry-run). Protecting indexes via the config file's
+        /// `auto_prune.protected_indexes` list takes precedence over --apply.
+        #[arg(long)]
+        apply: bool,
+
+        /// Override the idle-day threshold for this run (default: value from
+        /// `auto_prune.max_idle_days` in config, or 30 if not configured).
+        #[arg(long, value_name = "DAYS")]
+        max_idle_days: Option<u32>,
+
+        /// Skip the interactive confirmation prompt when --apply is given.
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+
     /// Wire trusty-search into Claude Code's settings.json files
     ///
     /// Scans `$HOME` for every `.claude/settings*.json` and idempotently
@@ -1375,6 +1420,14 @@ async fn run() -> Result<()> {
 
         Commands::PruneOrphans { dry_run, yes } => {
             commands::prune_orphans::handle_prune_orphans(dry_run, yes)?;
+        }
+
+        Commands::Prune {
+            apply,
+            max_idle_days,
+            yes,
+        } => {
+            commands::prune::handle_prune(apply, yes, max_idle_days)?;
         }
 
         Commands::Setup => {

--- a/crates/trusty-search/src/service/persistence.rs
+++ b/crates/trusty-search/src/service/persistence.rs
@@ -330,10 +330,17 @@ pub fn index_data_dir(index_id: &str) -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// Crate-internal wrapper exposing [`sanitize_id`] for callers that need to
-/// derive the same on-disk path as [`index_data_dir`] without triggering its
-/// `create_dir_all` side effect.
-pub(crate) fn sanitize_id_for_path(id: &str) -> String {
+/// Public wrapper exposing [`sanitize_id`] for callers — including the binary's
+/// command handlers — that need to derive the same on-disk path as
+/// [`index_data_dir`] without triggering its `create_dir_all` side effect.
+///
+/// Why: the binary's `commands/` modules cannot access `pub(crate)` items from
+///      the library; making this `pub` lets `prune::default_size_fn` compute the
+///      canonical index data-dir path without calling `index_data_dir`.
+/// What: returns `sanitize_id(id)` — the exact same path component used by
+///       `index_data_dir`, `remove_index_data_dir`, and `hnsw_path`.
+/// Test: covered transitively by `prune_tests::prune_*` tests.
+pub fn sanitize_id_for_path(id: &str) -> String {
     sanitize_id(id)
 }
 


### PR DESCRIPTION
## Summary

- Adds `trusty-search prune [--apply] [--max-idle-days N] [-y]` — an offline command (no daemon required) that reports or deletes trusty-search indexes idle beyond a configurable threshold.
- Extends `GlobalConfig` with an `auto_prune:` YAML section (`enabled`, `max_idle_days: 30`, `protected_indexes: []`), fully backward-compatible via `#[serde(default)]`.
- Safe-first defaults: report-only unless `--apply` is passed; protected indexes are never touched; indexes with no timestamp are treated as untracked (ineligible).

## Design decisions

**Timestamp fallback chain:** `last_queried_unix` (added in #993) → `last_indexed_unix` → `NotTracked` (skip, don't prune). This ensures we never delete an index just because it predates the timestamp tracking feature.

**Offline / no-daemon:** Reads `indexes.toml` directly, matching the `prune-orphans` pattern. A daemon-side scheduled sweep is a natural follow-up but out of scope for this PR.

**Pure `classify_entry()` function:** Takes injected `size_fn` and `now_unix` so unit tests don't touch real filesystem or real time. All decision logic is unit-tested independently of I/O.

**CLI overrides config:** `--max-idle-days N` on the command line takes precedence over `GlobalConfig.auto_prune.max_idle_days`.

## Files changed

| File | Change |
|---|---|
| `crates/trusty-search/src/config.rs` | +`AutoPruneConfig` struct; +`auto_prune` field on `GlobalConfig`; +3 config tests |
| `crates/trusty-search/src/commands/prune.rs` | New — `PruneDecision`, `classify_entry`, `handle_prune`, `handle_prune_at`, `print_report`, `format_bytes`, `confirm`, full unit test suite |
| `crates/trusty-search/src/commands/mod.rs` | +`pub mod prune;` |
| `crates/trusty-search/src/main.rs` | +`Commands::Prune` variant + dispatch arm |

## Verification

```
SKIP_UI_BUILD=1 cargo test -p trusty-search        # all pass
SKIP_UI_BUILD=1 cargo clippy -p trusty-search --all-targets -- -D warnings  # clean
SKIP_UI_BUILD=1 cargo clippy --workspace --all-targets -- -D warnings        # clean
cargo fmt --check                                   # clean
bash scripts/check_line_cap.sh                      # 14 allowlisted, 0 violations
```

Closes #1782

## Test plan

- [ ] `trusty-search prune` (report-only) prints a table with ELIGIBLE/PROTECTED/UNTRACKED/RECENT rows and no deletions
- [ ] `trusty-search prune --apply -y` deletes only ELIGIBLE indexes
- [ ] Indexes in `protected_indexes` config list are never deleted even with `--apply`
- [ ] `trusty-search prune --max-idle-days 0 --apply -y` treats all timestamped indexes as eligible
- [ ] Indexes with neither `last_queried_unix` nor `last_indexed_unix` are shown as UNTRACKED and skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)