### PR TITLE
feat(trusty-mpm): include repo name in managed tmux session names (#1789)

### DIFF
--- a/crates/trusty-mpm/src/core/external_session.rs
+++ b/crates/trusty-mpm/src/core/external_session.rs
@@ -18,8 +18,9 @@ use serde::{Deserialize, Serialize};
 /// differently — only external sessions need an explicit "adopt" step before
 /// oversight applies.
 /// What: [`TrustyMpm`](SessionOrigin::TrustyMpm) for `tmpm-*` / `trusty-mpm-*`
-/// names (this covers both the random `tmpm-<adjective>-<noun>` form and the
-/// folder-derived `tmpm-<folder>` form), [`External`](SessionOrigin::External)
+/// names (this covers the random `tmpm-<adjective>-<noun>` form, the
+/// folder-derived `tmpm-<folder>` form, and the project-identifiable
+/// `tmpm-<repo>-<8hex>` form added in #1789), [`External`](SessionOrigin::External)
 /// for everything else.
 /// Test: `classifies_trusty_mpm_prefixes`, `classifies_external`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]

--- a/crates/trusty-mpm/src/core/names.rs
+++ b/crates/trusty-mpm/src/core/names.rs
@@ -84,11 +84,86 @@ pub fn name_from_uuid(uuid: &Uuid) -> String {
 /// the dashboard; truncating the folder keeps `tmpm-<folder>` glanceable.
 const MAX_FOLDER_LEN: usize = 20;
 
+/// Maximum length of the repo-slug portion inside a project-derived session name.
+///
+/// Why: the full name is `tmpm-<slug>-<8hex>` (5 + 1 + slug + 1 + 8 chars).
+/// Capping the slug at 24 keeps the total under 40 chars — well within tmux's
+/// practical limit — while still being uniquely identifiable.
+const MAX_REPO_SLUG_LEN: usize = 24;
+
 /// Fallback session name used when a directory yields an empty folder slug.
 ///
 /// Why: a path like `/` or `///` sanitizes to nothing; a session still needs a
 /// stable, valid tmux name.
 const DIR_FALLBACK: &str = "tmpm-session";
+
+/// Sanitize a repository name to a tmux-safe kebab-case slug.
+///
+/// Why: repo names may contain uppercase letters, dots, underscores, or other
+/// characters that are not valid in tmux session names (which forbit `.` and `:`)
+/// or that make names hard to type. Centralising the sanitization keeps the
+/// `build_managed_session_name` logic pure and testable.
+/// What: lowercases the input, maps runs of non-`[a-z0-9]` characters to a
+/// single `-`, strips leading/trailing dashes, and caps the result at
+/// [`MAX_REPO_SLUG_LEN`] chars (stripping any trailing dash left by the cut).
+/// Returns an empty string when nothing alphanumeric survives.
+/// Test: `slug_project_sanitizes_dots_colons_uppercase`,
+/// `slug_project_collapses_and_trims`, `slug_project_truncates` in the test module.
+fn slug_project(name: &str) -> String {
+    let mut slug = String::with_capacity(name.len());
+    let mut prev_dash = true; // start true → leading dash dropped
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.extend(ch.to_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            slug.push('-');
+            prev_dash = true;
+        }
+    }
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+    if slug.len() > MAX_REPO_SLUG_LEN {
+        slug.truncate(MAX_REPO_SLUG_LEN);
+        while slug.ends_with('-') {
+            slug.pop();
+        }
+    }
+    slug
+}
+
+/// Build a human-identifiable managed session name incorporating the project.
+///
+/// Why: `tmpm-<adjective>-<noun>` names are glanceable but tell the operator
+/// nothing about which project a session belongs to. Operators running `tmux ls`
+/// should be able to tell at a glance which repo each session targets (issue
+/// #1789). The short-id suffix ensures uniqueness even when the same repo spawns
+/// several parallel sessions.
+/// What: returns `tmpm-<slug>-<short-id>` when `project` is `Some` (where
+/// `<slug>` is the sanitized repo name and `<short-id>` is the first 8 hex
+/// characters of `session_id`). When `project` is `None` (no GitHub remote /
+/// not a git repo) returns `tmpm-local-<short-id>` as the fallback.
+///
+/// Design decisions:
+/// - The **repo name only** is used as the slug (not `owner-repo`) because the
+///   repo alone is identifiable in most single-org setups; `owner-repo` would
+///   push the total length up and clutter `tmux ls`.
+/// - The fallback is `tmpm-local-<short-id>` rather than the adjective+noun
+///   scheme so operators can distinguish "I know which project this is"
+///   (`tmpm-trusty-tools-abc12345`) from "this is a local directory session"
+///   (`tmpm-local-abc12345`).
+///
+/// Test: `build_managed_session_name_github_project`,
+/// `build_managed_session_name_none_fallback`,
+/// `build_managed_session_name_sanitized_repo` in the test module.
+pub fn build_managed_session_name(project: Option<&str>, session_id: &uuid::Uuid) -> String {
+    let short_id = &session_id.simple().to_string()[..8];
+    match project.map(slug_project) {
+        Some(slug) if !slug.is_empty() => format!("{PREFIX}{slug}-{short_id}"),
+        _ => format!("{PREFIX}local-{short_id}"),
+    }
+}
 
 /// Derive a session name from a project directory's basename.
 ///
@@ -266,5 +341,102 @@ mod tests {
         assert_eq!(name_from_dir(Path::new("/")), "tmpm-session");
         assert_eq!(name_from_dir(Path::new("/x/----")), "tmpm-session");
         assert_eq!(name_from_dir(Path::new("")), "tmpm-session");
+    }
+
+    // ── build_managed_session_name ───────────────────────────────────────────
+
+    /// Why: the primary use-case is a GitHub-sourced session where the repo name
+    /// is known; the resulting name must be `tmpm-<repo>-<8hex>` and be tmux-safe.
+    /// Test: itself.
+    #[test]
+    fn build_managed_session_name_github_project() {
+        let id = Uuid::parse_str("aad055ec-8014-cd16-f000-000000000000").unwrap();
+        let name = build_managed_session_name(Some("trusty-tools"), &id);
+        assert_eq!(name, "tmpm-trusty-tools-aad055ec");
+    }
+
+    /// Why: when no GitHub project can be determined the name must fall back to
+    /// `tmpm-local-<8hex>` so the session is identifiable as a local session.
+    /// Test: itself.
+    #[test]
+    fn build_managed_session_name_none_fallback() {
+        let id = Uuid::parse_str("aad055ec-8014-cd16-f000-000000000000").unwrap();
+        let name = build_managed_session_name(None, &id);
+        assert_eq!(name, "tmpm-local-aad055ec");
+    }
+
+    /// Why: repo names from GitHub may contain dots (`.`), colons (`:`),
+    /// uppercase letters, or other chars tmux session names cannot contain.
+    /// slug_project must remove them all.
+    /// Test: itself.
+    #[test]
+    fn slug_project_sanitizes_dots_colons_uppercase() {
+        // Dots and colons → dash; uppercase → lowercase.
+        assert_eq!(slug_project("My.Repo:v2"), "my-repo-v2");
+        // All-uppercase.
+        assert_eq!(slug_project("TRUSTY_TOOLS"), "trusty-tools");
+        // Leading/trailing separators stripped.
+        assert_eq!(slug_project("...repo..."), "repo");
+    }
+
+    /// Why: consecutive non-alphanumeric runs must collapse to a single dash
+    /// so the slug stays readable.
+    /// Test: itself.
+    #[test]
+    fn slug_project_collapses_and_trims() {
+        assert_eq!(slug_project("my__repo--v2"), "my-repo-v2");
+        assert_eq!(
+            slug_project("--leading-and-trailing--"),
+            "leading-and-trailing"
+        );
+    }
+
+    /// Why: very long repo names must be truncated so the total session name
+    /// stays under practical tmux limits; no trailing dash after truncation.
+    /// Test: itself.
+    #[test]
+    fn slug_project_truncates() {
+        let long = "this-is-a-very-long-repository-name-that-exceeds-the-cap";
+        let slug = slug_project(long);
+        assert!(
+            slug.len() <= MAX_REPO_SLUG_LEN,
+            "slug must be ≤ {MAX_REPO_SLUG_LEN} chars: {slug}"
+        );
+        assert!(
+            !slug.ends_with('-'),
+            "no trailing dash after truncation: {slug}"
+        );
+    }
+
+    /// Why: a sanitized repo slug derived from an `owner/repo` input (the full
+    /// `source_id`) must produce the REPO portion only — the slash becomes a
+    /// dash, so `bobmatnyc/trusty-tools` → `bobmatnyc-trusty-tools`. Callers
+    /// must pass only the repo name to get `tmpm-trusty-tools-<8hex>`.
+    /// Test: itself.
+    #[test]
+    fn build_managed_session_name_sanitized_repo() {
+        let id = Uuid::parse_str("aad055ec-8014-cd16-f000-000000000000").unwrap();
+        // Uppercase, dots, colons stripped; short-id appended.
+        let name = build_managed_session_name(Some("My.Repo:v2"), &id);
+        assert_eq!(name, "tmpm-my-repo-v2-aad055ec");
+        // An empty-after-sanitize input falls back to local.
+        let name2 = build_managed_session_name(Some("..."), &id);
+        assert_eq!(name2, "tmpm-local-aad055ec");
+    }
+
+    /// Why: collision-freedom guarantee — the short-id suffix must be present
+    /// even when multiple sessions target the same repo.
+    /// Test: itself.
+    #[test]
+    fn build_managed_session_name_short_id_present() {
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        let n1 = build_managed_session_name(Some("trusty-tools"), &id1);
+        let n2 = build_managed_session_name(Some("trusty-tools"), &id2);
+        // Both start with the repo slug.
+        assert!(n1.starts_with("tmpm-trusty-tools-"), "n1={n1}");
+        assert!(n2.starts_with("tmpm-trusty-tools-"), "n2={n2}");
+        // But they differ (with overwhelming probability) because the UUID suffix differs.
+        assert_ne!(n1, n2, "distinct UUIDs should produce distinct names");
     }
 }

--- a/crates/trusty-mpm/src/core/names.rs
+++ b/crates/trusty-mpm/src/core/names.rs
@@ -153,11 +153,22 @@ fn slug_project(name: &str) -> String {
 ///   scheme so operators can distinguish "I know which project this is"
 ///   (`tmpm-trusty-tools-abc12345`) from "this is a local directory session"
 ///   (`tmpm-local-abc12345`).
+/// - `project` should be the repo segment only, NOT `owner/repo`. The caller
+///   is responsible for extracting `GithubPath.repo` before calling here. A
+///   pre-slugified input (e.g. the string already from `slugify_component`) is
+///   safe: `slug_project` is idempotent.
 ///
 /// Test: `build_managed_session_name_github_project`,
 /// `build_managed_session_name_none_fallback`,
 /// `build_managed_session_name_sanitized_repo` in the test module.
 pub fn build_managed_session_name(project: Option<&str>, session_id: &uuid::Uuid) -> String {
+    // Guard against callers passing `owner/repo` instead of just `repo`. The
+    // slash would sanitize to a dash and silently produce `owner-repo-<8hex>`,
+    // making the name unrecognisably long. This fires only in dev/test builds.
+    debug_assert!(
+        project.is_none_or(|p| !p.contains('/')),
+        "build_managed_session_name: pass the repo segment only, not owner/repo — got {project:?}"
+    );
     let short_id = &session_id.simple().to_string()[..8];
     match project.map(slug_project) {
         Some(slug) if !slug.is_empty() => format!("{PREFIX}{slug}-{short_id}"),
@@ -247,6 +258,14 @@ mod tests {
         // Any generated name is, by construction, managed.
         let id = Uuid::parse_str("367c6c51-1025-419c-b6d6-be9a753e8914").unwrap();
         assert!(is_managed_session_name(&name_from_uuid(&id)));
+        // Names produced by build_managed_session_name must also be managed.
+        assert!(is_managed_session_name(&build_managed_session_name(
+            Some("trusty-tools"),
+            &id
+        )));
+        assert!(is_managed_session_name(&build_managed_session_name(
+            None, &id
+        )));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -351,6 +351,15 @@ async fn spawn_managed_inproject(
     write_task_md(&worktree, &params.task, session_id);
 
     let mgr = state.session_manager().await;
+    // Pass a canonical GitHub HTTPS URL as repo_url so the session-manager can
+    // derive the project name (`tmpm-<repo>-<8hex>`) for the tmux session name
+    // (issue #1789). Using a synthetic HTTPS URL is safe: `parse_github_path`
+    // normalises both SSH and HTTPS forms to the same `{ owner, repo }` pair, and
+    // this URL is the real origin of the base clone (it was derived from the
+    // operator's local `remote.origin.url`). The record stores it as `repo_url`
+    // which gives `tm sessions ls` useful project context even for in-project
+    // sessions that did not clone a fresh workspace.
+    let synthetic_repo_url = format!("https://github.com/{owner}/{repo}");
     let record = mgr
         .create_with_id(
             *session_id,
@@ -358,7 +367,7 @@ async fn spawn_managed_inproject(
             Some(worktree.clone()),
             params.name_hint.clone(),
             Some(worktree.clone()),
-            None, // no remote repo_url — the worktree IS the workspace
+            Some(synthetic_repo_url),
             None,
             runtime,
             params.ephemeral.unwrap_or(false),

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
-use crate::core::names::{name_from_dir, name_from_uuid};
+use crate::core::names::{build_managed_session_name, name_from_dir};
 use crate::core::sm::control::Submit;
 
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
@@ -265,8 +265,9 @@ impl SessionManager {
     /// Why: `POST /api/v1/sessions/managed` needs the full create-name-record-spawn
     /// flow in one operation so the HTTP handler stays thin.
     /// What: derives the tmux name from `name_hint` (→ `name_from_dir`) or from
-    /// the generated UUID (→ `name_from_uuid`), creates the tmux session via the
-    /// driver, persists a [`SessionRecord`] in state `Provisioning`, and returns it.
+    /// the `repo_url` GitHub identity (→ `build_managed_session_name`, #1789),
+    /// creates the tmux session via the driver, persists a [`SessionRecord`] in
+    /// state `Provisioning`, and returns it.
     /// The runtime backend defaults to [`crate::runtime::RuntimeKind::ClaudeCode`]
     /// so callers that do not care about the backend keep the pre-#1203 behavior.
     /// Test: `manager_create_record`.
@@ -329,13 +330,29 @@ impl SessionManager {
         owned: bool,
     ) -> Result<SessionRecord, ManagedError> {
         let cwd = cwd.unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp")));
+        // Name selection priority (issue #1789):
+        //   1. Explicit `name_hint` from the user → honor unchanged (→ `tmpm-<hint-slug>`).
+        //   2. GitHub-parseable `repo_url`         → `tmpm-<repo>-<8hex>` (project-identifiable).
+        //   3. No project determined                → `tmpm-local-<8hex>` (fallback).
+        //
+        // The cwd-basename scheme is intentionally removed: for the clone path the
+        // cwd is `<workspace-root>/<owner>/<repo>/<session-id>/` whose BASENAME is
+        // the UUID — not useful. For the in-project path the basename is also the
+        // UUID. For the local-path spawn (no `repo_url`) the new `tmpm-local-<8hex>`
+        // fallback is explicit and avoids the misleading appearance of being a
+        // project-linked session.
         let tmux_name = if let Some(hint) = name_hint {
-            // Treat the hint as a path basename to get the slug convention.
+            // Explicit name hint from the user — treat the hint as a path basename
+            // to match pre-#1789 behaviour (callers may pass a bare "ticket-1234"
+            // or a directory path like "/repos/project").
             name_from_dir(Path::new(&hint))
-        } else if cwd != dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp")) {
-            name_from_dir(&cwd)
         } else {
-            name_from_uuid(id.as_uuid())
+            // Derive project from repo_url if it carries a parseable GitHub identity.
+            let project = repo_url
+                .as_deref()
+                .and_then(trusty_common::github_path::parse_github_path)
+                .map(|gh| gh.repo);
+            build_managed_session_name(project.as_deref(), id.as_uuid())
         };
 
         // Detect collision before creating tmux session.

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -1328,3 +1328,46 @@ async fn list_managed_sessions_source_id_filter() {
         "session B must appear in unfiltered list; ids={ids:?}"
     );
 }
+
+/// A GitHub `repo_url` must produce a project-identifiable session name (#1789).
+///
+/// Why: pins the `parse_github_path → gh.repo → build_managed_session_name`
+/// chain at the manager's call site. If `GithubPath.repo` were ever renamed or
+/// `parse_github_path` changed its extraction contract, the manager would
+/// silently fall back to `tmpm-local-<8hex>` with no compile or existing-test
+/// error. This integration test catches that regression without spawning real tmux.
+/// What: creates a managed session with a real GitHub HTTPS `repo_url` via
+/// `SessionManager::create` (backed by a fake tmux driver) and asserts the
+/// resulting `tmux_name` starts with `tmpm-trusty-tools-` (not `tmpm-local-`).
+/// Test: this function IS the test.
+#[tokio::test]
+async fn session_manager_github_repo_url_produces_project_name() {
+    let dir = TempDir::new().unwrap();
+    let tmux = RecordingTmux::new();
+    let mgr = SessionManager::new(dir.path(), tmux)
+        .await
+        .expect("manager");
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/ws")),
+            None,                                                     // no name_hint
+            None,                                                     // no workspace_path
+            Some("https://github.com/bobmatnyc/trusty-tools".into()), // repo_url
+            None,                                                     // no branch
+        )
+        .await
+        .expect("create");
+
+    assert!(
+        record.tmux_name.starts_with("tmpm-trusty-tools-"),
+        "a GitHub repo_url must produce tmpm-<repo>-<8hex>, got: {}",
+        record.tmux_name
+    );
+    assert!(
+        !record.tmux_name.starts_with("tmpm-local-"),
+        "must not fall through to tmpm-local-<8hex> when repo_url is a GitHub URL: {}",
+        record.tmux_name
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1789.

Managed tmux sessions were named `tmpm-<adjective>-<noun>` (random, unidentifiable) or `tmpm-<cwd-basename>` (where the basename was often a UUID for cloned workspaces). Running `tmux ls` with 10 sessions was unreadable.

New names: `tmpm-<repo>-<8hex>` — immediately identifiable by project, still unique per session.

**Design choices (documented in source):**
- **Repo name only** (not `owner-repo`) as the slug — identifiable in most single-org setups, keeps names short in `tmux ls`
- **Short-id suffix** = first 8 hex chars of the session UUID → uniqueness when same repo has multiple parallel sessions
- **Fallback** for sessions with no GitHub remote: `tmpm-local-<8hex>`
- **Explicit `--name` / `name_hint`** honored unchanged — no behavior change for users who name sessions explicitly
- **Backward compatible**: existing/running sessions keep their current names; only NEW sessions are affected

**Example in `tmux ls`:**
```
# Before
tmpm-brave-otter: 1 windows (created …)
tmpm-calm-ridge: 1 windows (created …)

# After
tmpm-trusty-tools-aad055ec: 1 windows (created …)
tmpm-my-app-3f9b2c17: 1 windows (created …)
```

## Files Changed

- `crates/trusty-mpm/src/core/names.rs`: Added `slug_project(name)` sanitizer and `build_managed_session_name(project, id)` pure function. Sanitizer: lowercase, `[a-z0-9-]` only, collapse non-alnum runs, trim, 24-char cap (safe for long repo names). New function: `tmpm-<slug>-<8hex>` when project known, `tmpm-local-<8hex>` when not.
- `crates/trusty-mpm/src/session_manager/manager.rs`: Replace cwd-basename / adjective+noun fallback logic in `create_with_id` with `build_managed_session_name`, deriving `project` from `parse_github_path(repo_url)`.
- `crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs`: `spawn_managed_inproject` now passes a synthetic `https://github.com/<owner>/<repo>` URL as `repo_url` (previously `None`) so the manager can derive the project slug. This also means in-project sessions now carry the origin URL in their record (useful context for `tm sessions ls`).

## Test Plan

- [x] `cargo check` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero errors
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p trusty-mpm` — 2088+ tests passing, run twice (no flakiness)
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations
- [x] New unit tests in `core::names::tests`:
  - `build_managed_session_name_github_project` — happy path
  - `build_managed_session_name_none_fallback` — no-project fallback  
  - `build_managed_session_name_sanitized_repo` — dots/colons/uppercase removed
  - `build_managed_session_name_short_id_present` — collision-freedom
  - `slug_project_sanitizes_dots_colons_uppercase`
  - `slug_project_collapses_and_trims`
  - `slug_project_truncates`
- [x] No real tmux sessions spawned in tests (pure-function tests only, uses `FakeTmuxDriver` for manager tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)