### PR TITLE
feat(trusty-mpm): refine tm robot banner (clip art, dedupe version, source-id + managed path)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -30,7 +30,9 @@ pub(crate) const BANNER_IMAGE: &str = include_str!("image.txt");
 /// First row to include (0-indexed, inclusive).
 pub(crate) const CLIP_ROW_START: usize = 0;
 /// One-past-the-last row to include (0-indexed, exclusive).
-pub(crate) const CLIP_ROW_END: usize = 34;
+/// Reduced from 34 to 24 to trim the blank footer rows at the bottom of the
+/// robot art and make the rendered banner less tall.
+pub(crate) const CLIP_ROW_END: usize = 24;
 /// First column to include (0-indexed, inclusive).
 pub(crate) const CLIP_COL_START: usize = 9;
 /// One-past-the-last column to include (0-indexed, exclusive).

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
@@ -625,7 +625,7 @@ pub(crate) mod tests {
         colored::control::unset_override();
     }
 
-/// Reconnecting state shows the reconnecting label in the wide layout.
+    /// Reconnecting state shows the reconnecting label in the wide layout.
     #[test]
     fn two_panel_reconnecting_shows_indicator() {
         colored::control::set_override(false);

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
@@ -460,8 +460,8 @@ pub(crate) mod tests {
             lines.len()
         );
         assert!(
-            lines.len() >= 30 && lines.len() <= 36,
-            "clipped rows ({}) must be within 30–36",
+            lines.len() >= 20 && lines.len() <= 28,
+            "clipped rows ({}) must be within 20–28 (CLIP_ROW_END=24)",
             lines.len()
         );
     }
@@ -608,7 +608,24 @@ pub(crate) mod tests {
         colored::control::unset_override();
     }
 
-    /// Reconnecting state shows the reconnecting label in the wide layout.
+    /// The two-panel banner must not repeat the version in the right panel:
+    /// the title bar already shows it.  The full banner has exactly one copy.
+    #[test]
+    fn right_panel_omits_version_line() {
+        colored::control::set_override(false);
+        let data = base_data();
+        let version = env!("CARGO_PKG_VERSION");
+        let out = render_two_panel_banner(&data, 120, false).expect("wide banner");
+        let bare = strip_ansi(&out);
+        let count = bare.matches(version).count();
+        assert_eq!(
+            count, 1,
+            "version string must appear exactly once (title bar only); found {count}"
+        );
+        colored::control::unset_override();
+    }
+
+/// Reconnecting state shows the reconnecting label in the wide layout.
     #[test]
     fn two_panel_reconnecting_shows_indicator() {
         colored::control::set_override(false);

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
@@ -146,20 +146,48 @@ pub(crate) struct CommitLine {
 ///
 /// Why: separating gathering from rendering lets us unit-test the renderer with
 /// hand-crafted `WelcomeData` values.
-/// What: reads `$USER`, probes recent commits (≤150 ms), and detects services
-/// using the banner helpers. All probes are time-bounded — the function never
-/// blocks the launch path.
-/// Test: indirectly by `print_welcome_panel` smoke tests.
+/// What: reads `$USER`, derives the `owner/repo` identity from the git remote
+/// (falls back to the folder name when outside a git repo), resolves the
+/// managed workspace path (`~/trusty-mpm-projects/<owner>/<repo>`), probes
+/// recent commits (≤150 ms), and detects services using the banner helpers.
+/// All probes are time-bounded — the function never blocks the launch path.
+/// Test: indirectly by `print_welcome_panel` smoke tests; the owner/repo and
+/// managed-path derivations are exercised by the underlying helpers in
+/// `trusty_common::github_path` and `trusty_mpm::core::trusty_tools_config`.
 pub(crate) fn gather_welcome_data(
     workdir: &str,
     session_name: &str,
     reconnecting: bool,
     daemon: DaemonInfo,
 ) -> WelcomeData {
-    let project = Path::new(workdir)
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| workdir.to_string());
+    let workdir_path = Path::new(workdir);
+
+    // Derive the GitHub `owner/repo` identity from the git remote.  Falls back
+    // to the folder name when the directory is not a git repo or has no origin.
+    let github_path = trusty_common::github_path::derive_github_path(workdir_path);
+    let project = github_path
+        .as_ref()
+        .map(|gp| gp.rel_path())
+        .unwrap_or_else(|| {
+            workdir_path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| workdir.to_string())
+        });
+
+    // Resolve the managed workspace path (`~/trusty-mpm-projects/<owner>/<repo>`).
+    // This is where trusty-mpm manages a clone of the project independently of
+    // the user's live checkout; the banner should show this path rather than the
+    // live cwd.  Falls back to `workdir` when the GitHub identity cannot be
+    // derived (e.g. no git remote).
+    let workspace = match &github_path {
+        Some(gp) => {
+            let cfg = trusty_mpm::core::trusty_tools_config::TrustyToolsConfig::load();
+            let managed = trusty_mpm::core::trusty_tools_config::workspace_subpath(&cfg, gp);
+            managed.to_string_lossy().into_owned()
+        }
+        None => workdir.to_string(),
+    };
 
     let user = std::env::var("USER")
         .or_else(|_| std::env::var("USERNAME"))
@@ -172,7 +200,7 @@ pub(crate) fn gather_welcome_data(
 
     WelcomeData {
         project,
-        workspace: workdir.to_string(),
+        workspace,
         user,
         reconnecting,
         session_name: session_name.to_string(),
@@ -284,11 +312,24 @@ fn read_lock_addr() -> Option<String> {
 /// Why: the two-panel banner compositor (`banner::two_panel`) needs the raw
 /// row strings to fill the right panel at the compositor-determined width,
 /// without the fixed-width `╭─╮` box that `render_welcome_panel` draws.
-/// What: delegates to `render::build_rows(data)` — the same row builder used
-/// by `render_welcome_panel`, so content is identical in both layouts.
-/// Test: `two_panel_compose_alignment` in `banner::two_panel::tests`.
+/// The first row (`"trusty-mpm vX.Y.Z"`) is omitted here because the
+/// two-panel banner already embeds the version in its title bar border — the
+/// standalone `render_welcome_panel` box (no title bar) keeps it via
+/// `build_rows` directly.
+/// What: calls `render::build_rows(data)`, drops the first element (the
+/// version line), and returns the remainder. Content is otherwise identical
+/// to the standalone panel, so both layouts share the same row-building logic.
+/// Test: `two_panel_compose_alignment` in `banner::two_panel::tests`;
+/// `right_panel_starts_with_welcome` in `banner::two_panel::tests`.
 pub(crate) fn render_info_box_rows(data: &WelcomeData) -> Vec<String> {
-    render::build_rows(data)
+    let mut rows = render::build_rows(data);
+    // Drop the "trusty-mpm vX.Y.Z" header — the two-panel title bar already
+    // shows it. The standalone render_welcome_panel (no title bar) retains it
+    // by calling build_rows directly without going through this function.
+    if !rows.is_empty() {
+        rows.remove(0);
+    }
+    rows
 }
 
 // ── Backward-compat render wrapper ────────────────────────────────────────────

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
@@ -176,10 +176,10 @@ pub(crate) fn gather_welcome_data(
         });
 
     // Resolve the managed workspace path (`~/trusty-mpm-projects/<owner>/<repo>`).
-    // This is where trusty-mpm manages a clone of the project independently of
-    // the user's live checkout; the banner should show this path rather than the
-    // live cwd.  Falls back to `workdir` when the GitHub identity cannot be
-    // derived (e.g. no git remote).
+    // Since #1590, `tm launch` provisions and opens the tmux session inside this
+    // managed clone, so the banner path matches the real session location.
+    // Falls back to `workdir` when the GitHub identity cannot be derived
+    // (e.g. no git remote).
     let workspace = match &github_path {
         Some(gp) => {
             let cfg = trusty_mpm::core::trusty_tools_config::TrustyToolsConfig::load();


### PR DESCRIPTION
## Summary

Four targeted refinements to the `tm` launch banner (the two-panel robot art + info box):

- **Clip robot art**: `CLIP_ROW_END` reduced from 34 to 24, trimming 10 blank footer rows. The banner is now ~27 lines tall instead of ~37.
- **Remove duplicate version line**: The right panel previously started with `trusty-mpm vX.Y.Z` (a duplicate of the version already embedded in the title bar border `╭──── Trusty MPM v0.12.0 ───...───╮`). The right panel now opens directly with `Welcome back {user}!`. The standalone `render_welcome_panel()` box (used without a title bar) keeps the version line via its direct `build_rows()` call.
- **Project field → full owner/repo**: Was showing just the directory name (e.g., `cto`); now shows the full GitHub source identity (e.g., `bobmatnyc/trusty-tools`) derived via `trusty_common::github_path::derive_github_path`. Falls back to folder name when no git remote is present.
- **Workspace field → managed path**: Was showing the user's live cwd (e.g., `~/Duetto/cto`); now shows the trusty-managed workspace path (`~/trusty-mpm-projects/<owner>/<repo>`) via `workspace_subpath(config, gh_path)`. **This is a display-only change** — `tm launch` still creates the tmux session at the user's live cwd; the banner now reflects the canonical managed location.

## Files Changed

- `crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs` — `CLIP_ROW_END` constant: 34 → 24
- `crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs` — updated `image_clip_correct_rows` test bounds; added `right_panel_omits_version_line` test
- `crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs` — `render_info_box_rows()` drops row[0] (version) for two-panel compositor; `gather_welcome_data()` derives `owner/repo` and managed workspace path

## Test plan

- [ ] `cargo test -p trusty-mpm` passes (3,328 tests)
- [ ] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] `bash scripts/check_line_cap.sh` exit 0 (14 allowlisted, 0 violations)
- [ ] `tm banner` renders: shorter art, right pane opens with "Welcome back", project = `owner/repo`, workspace = `~/trusty-mpm-projects/owner/repo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)