### PR TITLE
feat(trusty-mpm): detach returns to tm picker + daemon/clone cwd hardening

### DIFF
--- a/crates/trusty-common/src/mcp/daemon_bridge.rs
+++ b/crates/trusty-common/src/mcp/daemon_bridge.rs
@@ -179,8 +179,11 @@ pub async fn ensure_daemon_up(config: &DaemonBridgeConfig) -> Result<String> {
     eprintln!("\u{25cf} Starting {} daemon\u{2026}", config.service_name);
 
     let exe = std::env::current_exe().map_err(|e| anyhow!("could not resolve current_exe: {e}"))?;
+    // Set a stable cwd so the spawned daemon never inherits a deleted directory.
+    let stable_dir = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/"));
     std::process::Command::new(&exe)
         .args(&config.spawn_args)
+        .current_dir(&stable_dir)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/crates/trusty-mpm/src/bin/tm/commands/daemon.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/daemon.rs
@@ -132,8 +132,11 @@ pub(crate) async fn start(client: &reqwest::Client, url: &str) -> anyhow::Result
     // Remove any stale lock file before spawning so we can detect the new write.
     let _ = std::fs::remove_file(&lock_path);
     let exe = std::env::current_exe()?;
+    // Set a stable cwd so the spawned daemon never inherits a deleted directory.
+    let stable_dir = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/"));
     std::process::Command::new(&exe)
         .arg("daemon")
+        .current_dir(&stable_dir)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::from(stdout))
         .stderr(std::process::Stdio::from(stderr))

--- a/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
@@ -25,6 +25,21 @@ use std::net::SocketAddr;
 pub(crate) async fn run_daemon(addr: SocketAddr, tailscale: bool, mcp: bool) -> anyhow::Result<()> {
     use std::io::ErrorKind;
 
+    // Anchor cwd to a stable directory so that git subprocesses spawned later
+    // never fail with "fatal: Unable to read current working directory" when the
+    // inherited cwd has been deleted (e.g. a /private/tmp session dir cleaned up
+    // by the OS). This is a best-effort set: we ignore the result so a read-only
+    // filesystem cannot prevent the daemon from starting.
+    // Why: daemon cwd is inherited by every subprocess (git clone, git worktree).
+    // What: chdir to home on startup; fall back to "/" if home is unavailable.
+    // Test: side-effect-only; verified via the managed-spawn integration suite
+    //       and the git-clone defensive current_dir() added at each call site.
+    if let Some(home) = dirs::home_dir() {
+        let _ = std::env::set_current_dir(&home);
+    } else {
+        let _ = std::env::set_current_dir("/");
+    }
+
     let state = trusty_mpm::daemon::DaemonState::shared();
     if mcp {
         return trusty_mpm::daemon::run_mcp(state).await;

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -201,10 +201,7 @@ pub(crate) fn derive_project(
 ) -> Option<(String, std::path::PathBuf, std::path::PathBuf)> {
     use trusty_mpm::daemon::managed_routes::inproject;
     let git_root = find_git_root(cwd)?;
-    let origin_url = inproject::get_origin_url(&git_root)?;
-    if !is_github_remote(&origin_url) {
-        return None;
-    }
+    let origin_url = inproject::get_origin_url(&git_root).filter(|u| is_github_remote(u))?;
     let gh = trusty_common::github_path::parse_github_path(&origin_url)?;
     let source_id = format!("{}/{}", gh.owner, gh.repo);
     let workspace = inproject::base_clone_path(&gh.owner, &gh.repo);
@@ -261,10 +258,8 @@ pub(crate) fn tty_gate(
     print_project_context(source_id, workspace, sessions);
     if !is_tty {
         print_non_tty_hint(source_id, sessions);
-        false
-    } else {
-        true
     }
+    is_tty
 }
 
 /// Print the detected project and session list to stderr.
@@ -282,14 +277,22 @@ pub(crate) fn print_project_context(
     sessions: &[trusty_mpm::client::ManagedSessionSummary],
 ) {
     eprintln!("tm: project:   {source_id}");
-    eprintln!("tm: workspace: {} (live checkout is NOT touched)", workspace.display());
+    eprintln!(
+        "tm: workspace: {} (live checkout is NOT touched)",
+        workspace.display()
+    );
     if sessions.is_empty() {
         eprintln!("tm: sessions:  (none)");
     } else {
         eprintln!("tm: sessions:");
         for (i, s) in sessions.iter().enumerate() {
             let activity = s.last_activity_at.as_deref().unwrap_or("—");
-            eprintln!("tm:   [{}] {}  state={}  last={}", i + 1, s.name, s.state, activity);
+            eprintln!(
+                "tm:   [{}] {}  state={}  last={activity}",
+                i + 1,
+                s.name,
+                s.state
+            );
         }
     }
 }
@@ -392,7 +395,8 @@ async fn run_tty_picker(
             for (i, s) in sessions.iter().enumerate() {
                 // Show "restart" for sessions that are stopped/errored — they have no
                 // live tmux session and will be restarted via the daemon (#1742).
-                let verb = if matches!(s.state.as_str(), "stopped" | "errored") { "restart" } else { "resume" };
+                let stopped = matches!(s.state.as_str(), "stopped" | "errored");
+                let verb = if stopped { "restart" } else { "resume" };
                 eprintln!("tm:   [{}] {} {} ({})", i + 1, verb, s.name, s.state);
             }
             eprintln!("tm:   [{new_idx}] launch new session");
@@ -405,7 +409,9 @@ async fn run_tty_picker(
         let n = std::io::stdin()
             .read_line(&mut line)
             .context("failed to read choice from stdin")?;
-        if n == 0 { break; } // EOF (Ctrl-D): exit cleanly.
+        if n == 0 {
+            break;
+        } // EOF (Ctrl-D): exit cleanly.
 
         match parse_picker_choice(&line, sessions.len()) {
             PickerDecision::Quit => {
@@ -415,7 +421,9 @@ async fn run_tty_picker(
             // #1742: route through daemon resume when the session is stopped or its
             // tmux session is absent — never raw-attach a non-live session.
             PickerDecision::Resume(i) => resume_guided_session(client, url, &sessions[i]).await?,
-            PickerDecision::LaunchNew => launch_new_session_and_attach(client, url, repo_url).await?,
+            PickerDecision::LaunchNew => {
+                launch_new_session_and_attach(client, url, repo_url).await?
+            }
             PickerDecision::Unrecognised => {
                 eprintln!("tm: unrecognised choice '{}'; quitting.", line.trim());
                 break;
@@ -423,7 +431,9 @@ async fn run_tty_picker(
         }
 
         // Detached or session ended — re-fetch the list before redisplaying.
-        sessions = list_project_sessions(client, url, source_id).await.context("refresh sessions")?;
+        sessions = list_project_sessions(client, url, source_id)
+            .await
+            .context("re-fetch")?;
     }
     Ok(())
 }
@@ -616,9 +626,7 @@ fn tmux_attach(name: &str) -> anyhow::Result<()> {
         .args(["attach-session", "-t", name])
         .status()
         .context("failed to invoke tmux")?;
-    if !status.success() {
-        anyhow::bail!("tmux attach-session exited with failure");
-    }
+    anyhow::ensure!(status.success(), "tmux attach-session exited with failure");
     Ok(())
 }
 
@@ -665,9 +673,10 @@ async fn launch_new_session_and_attach(
         .json()
         .await
         .context("failed to parse managed spawn response")?;
-    if body.name.is_empty() {
-        anyhow::bail!("daemon returned empty session name from managed spawn");
-    }
+    anyhow::ensure!(
+        !body.name.is_empty(),
+        "daemon returned empty session name from managed spawn"
+    );
     if first_run.is_some() {
         eprintln!("tm: clone complete — workspace ready");
     }
@@ -744,10 +753,8 @@ fn find_git_root(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
         .arg(cwd)
         .args(["rev-parse", "--show-toplevel"])
         .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
+        .ok()
+        .filter(|o| o.status.success())?;
     let root = String::from_utf8_lossy(&out.stdout);
     let root = root.trim();
     (!root.is_empty()).then_some(std::path::PathBuf::from(root))

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -176,7 +176,7 @@ async fn try_show_picker(
     let daemon =
         crate::formatters::info_box::DaemonInfo::from_lock_file().with_count(sessions.len());
     crate::formatters::info_box::print_info_box(&cwd.to_string_lossy(), source_id, false, &daemon);
-    Some(run_tty_picker(client, url, repo_url, &sessions).await)
+    Some(run_tty_picker(client, url, repo_url, source_id, sessions).await)
 }
 
 // ── Project derivation ───────────────────────────────────────────────────────
@@ -282,23 +282,14 @@ pub(crate) fn print_project_context(
     sessions: &[trusty_mpm::client::ManagedSessionSummary],
 ) {
     eprintln!("tm: project:   {source_id}");
-    eprintln!(
-        "tm: workspace: {} (live checkout is NOT touched)",
-        workspace.display()
-    );
+    eprintln!("tm: workspace: {} (live checkout is NOT touched)", workspace.display());
     if sessions.is_empty() {
         eprintln!("tm: sessions:  (none)");
     } else {
         eprintln!("tm: sessions:");
         for (i, s) in sessions.iter().enumerate() {
             let activity = s.last_activity_at.as_deref().unwrap_or("—");
-            eprintln!(
-                "tm:   [{}] {}  state={}  last={}",
-                i + 1,
-                s.name,
-                s.state,
-                activity
-            );
+            eprintln!("tm:   [{}] {}  state={}  last={}", i + 1, s.name, s.state, activity);
         }
     }
 }
@@ -372,63 +363,69 @@ pub(crate) fn parse_picker_choice(line: &str, session_count: usize) -> PickerDec
 /// Interactive numbered picker (TTY mode only).
 ///
 /// Why: a simple numbered menu is the lowest-friction way to resume or launch
-/// without requiring the operator to remember session names or UUIDs.
-/// What: prints the menu, reads one line from stdin, delegates to
-/// [`parse_picker_choice`], and dispatches. Side-effect-free parse logic lives
-/// in `parse_picker_choice` and is unit-tested independently.
+/// without requiring the operator to remember session names or UUIDs. After a
+/// detach, the picker is redisplayed rather than exiting to the shell — the
+/// common "pick → Ctrl-b d → pick again" flow stays in one command.
+/// What: loops: print menu, read one line, dispatch, then re-fetch the session
+/// list so the next iteration shows current state. Exits cleanly on `Quit`,
+/// EOF (Ctrl-D), or unrecognised input; propagates attach/launch errors.
 ///   • `Resume(i)` → [`resume_guided_session`] which handles daemon restart
 ///     when needed and then calls [`tmux_attach`] internally;
 ///   • `LaunchNew` → [`launch_new_session_and_attach`];
-///   • `Quit` / `Unrecognised` → print notice and return `Ok`.
+///   • `Quit` / EOF / `Unrecognised` → print notice and return `Ok`.
 /// Test: `parse_picker_choice` is the testable seam; I/O path is exercised by
 /// manual smoke tests and the e2e suite.
 async fn run_tty_picker(
     client: &reqwest::Client,
     url: &str,
     repo_url: &str,
-    sessions: &[trusty_mpm::client::ManagedSessionSummary],
+    source_id: &str,
+    mut sessions: Vec<trusty_mpm::client::ManagedSessionSummary>,
 ) -> anyhow::Result<()> {
-    eprintln!();
-    let new_idx = sessions.len() + 1;
-    if sessions.is_empty() {
-        eprintln!("tm:   [Enter] launch new session");
-        eprintln!("tm:   [q]     quit");
-    } else {
-        for (i, s) in sessions.iter().enumerate() {
-            // Show "restart" for sessions that are stopped/errored — they have no
-            // live tmux session and will be restarted via the daemon (#1742).
-            let verb = if matches!(s.state.as_str(), "stopped" | "errored") {
-                "restart"
-            } else {
-                "resume"
-            };
-            eprintln!("tm:   [{}] {} {} ({})", i + 1, verb, s.name, s.state);
+    loop {
+        eprintln!();
+        let new_idx = sessions.len() + 1;
+        if sessions.is_empty() {
+            eprintln!("tm:   [Enter] launch new session");
+            eprintln!("tm:   [q]     quit");
+        } else {
+            for (i, s) in sessions.iter().enumerate() {
+                // Show "restart" for sessions that are stopped/errored — they have no
+                // live tmux session and will be restarted via the daemon (#1742).
+                let verb = if matches!(s.state.as_str(), "stopped" | "errored") { "restart" } else { "resume" };
+                eprintln!("tm:   [{}] {} {} ({})", i + 1, verb, s.name, s.state);
+            }
+            eprintln!("tm:   [{new_idx}] launch new session");
+            eprintln!("tm:   [q] quit");
+            eprintln!("tm: default: [1] resume/restart most recent");
         }
-        eprintln!("tm:   [{new_idx}] launch new session");
-        eprintln!("tm:   [q] quit");
-        eprintln!("tm: default: [1] resume/restart most recent");
-    }
-    eprint!("tm: > ");
+        eprint!("tm: > ");
 
-    let mut line = String::new();
-    std::io::stdin()
-        .read_line(&mut line)
-        .context("failed to read choice from stdin")?;
+        let mut line = String::new();
+        let n = std::io::stdin()
+            .read_line(&mut line)
+            .context("failed to read choice from stdin")?;
+        if n == 0 { break; } // EOF (Ctrl-D): exit cleanly.
 
-    match parse_picker_choice(&line, sessions.len()) {
-        PickerDecision::Quit => {
-            eprintln!("tm: quit.");
-            Ok(())
+        match parse_picker_choice(&line, sessions.len()) {
+            PickerDecision::Quit => {
+                eprintln!("tm: quit.");
+                break;
+            }
+            // #1742: route through daemon resume when the session is stopped or its
+            // tmux session is absent — never raw-attach a non-live session.
+            PickerDecision::Resume(i) => resume_guided_session(client, url, &sessions[i]).await?,
+            PickerDecision::LaunchNew => launch_new_session_and_attach(client, url, repo_url).await?,
+            PickerDecision::Unrecognised => {
+                eprintln!("tm: unrecognised choice '{}'; quitting.", line.trim());
+                break;
+            }
         }
-        // #1742: route through daemon resume when the session is stopped or its
-        // tmux session is absent — never raw-attach a non-live session.
-        PickerDecision::Resume(i) => resume_guided_session(client, url, &sessions[i]).await,
-        PickerDecision::LaunchNew => launch_new_session_and_attach(client, url, repo_url).await,
-        PickerDecision::Unrecognised => {
-            eprintln!("tm: unrecognised choice '{}'; quitting.", line.trim());
-            Ok(())
-        }
+
+        // Detached or session ended — re-fetch the list before redisplaying.
+        sessions = list_project_sessions(client, url, source_id).await.context("refresh sessions")?;
     }
+    Ok(())
 }
 
 /// Decide whether a guided resume must restart the session through the daemon.

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -121,9 +121,14 @@ pub fn ensure_base_clone(origin_url: &str, base_path: &Path) -> Result<(), Strin
         })?;
     }
 
+    // Use the parent of base_path (just created above) as cwd so a deleted
+    // inherited cwd cannot cause git to fail at startup with "fatal: Unable to
+    // read current working directory" (exit 128) → HTTP 500 on managed-spawn.
+    let cwd = base_path.parent().unwrap_or(std::path::Path::new("/"));
     let out = std::process::Command::new("git")
         .args(["clone", "--no-local", origin_url])
         .arg(base_path)
+        .current_dir(cwd)
         .output()
         .map_err(|e| format!("inproject: git clone failed to spawn: {e}"))?;
 

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -135,8 +135,12 @@ impl GitBackend for RealGitBackend {
         }
         args.push(repo_url);
         args.push(&dir_str);
+        // Use the destination's parent as cwd so a deleted inherited cwd cannot
+        // cause git to fail with "fatal: Unable to read current working directory".
+        let cwd = target_dir.parent().unwrap_or(std::path::Path::new("/"));
         let out = Command::new("git")
             .args(&args)
+            .current_dir(cwd)
             .output()
             .map_err(|e| ProvisionError::Git(format!("git clone exec failed: {e}")))?;
         if out.status.success() {


### PR DESCRIPTION
## Summary

### Fix 1 — Detach returns to `tm` picker (`guided.rs`)

After attaching to a managed tmux session via the bare `tm` TTY picker and
detaching (Ctrl-b d), the tool now redisplays the picker instead of falling
through to the shell.

Changes in `run_tty_picker`:
- Wrapped the body in `loop {}` so detach-and-pick cycles without re-running `tm`
- Re-fetches the session list on each iteration via `list_project_sessions` so
  the menu shows current state (a session that was restarted since last pick now
  shows its new state)
- Added EOF guard (`n == 0 → break`) so Ctrl-D exits cleanly
- `Resume` and `LaunchNew` arms propagate errors with `?` instead of silently
  discarding them
- `Quit` and `Unrecognised` arms `break` the loop instead of returning — picker
  exits once

### Fix 2 — Daemon/clone working-directory hardening (five sites)

Daemons and subprocesses can inherit a deleted cwd (e.g. a cleaned-up
`/private/tmp` session directory). `git` then fails at startup with
`fatal: Unable to read current working directory` (exit 128), which turns
managed-spawn into HTTP 500.

| File | Change |
|---|---|
| `daemon_run.rs` | `set_current_dir($HOME)` (fallback `/`) at daemon startup |
| `daemon.rs` | `.current_dir(home)` on the `tm start` `Command` spawn |
| `trusty-common/src/mcp/daemon_bridge.rs` | `.current_dir(home)` on MCP stdio autostart spawn |
| `provisioner/workspace.rs` | `.current_dir(parent)` on `git clone` in `RealGitBackend` |
| `daemon/managed_routes/inproject.rs` | `.current_dir(parent)` on `git clone` in `ensure_base_clone` |

Also included: SLOC reductions in `guided.rs` to stay under the 500-SLOC
production cap after `cargo fmt` reformatted Fix 1's additions.

## Test plan

- [ ] All 2088 `trusty-mpm` tests pass (`cargo test -p trusty-mpm`)
- [ ] All 113 `trusty-common` lib tests pass (`cargo test -p trusty-common --lib`)
- [ ] `cargo clippy` zero warnings for both crates
- [ ] `cargo fmt --check` clean for both crates
- [ ] `bash scripts/check_line_cap.sh` exits 0
- [ ] Smoke test: `tm` from inside a GitHub project, attach, Ctrl-b d → picker reappears
- [ ] Smoke test: start daemon, manually `cd /tmp && rmdir /tmp/nonexistent-dir`, verify `tm sessions new` from inside a project succeeds (no git cwd errors in daemon log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)