### PR TITLE
feat(trusty-mpm): unify managed clone on shared base + per-session .worktrees/ (#1803)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -190,8 +190,8 @@ async fn try_show_picker(
 /// What: finds the git root, reads `remote.origin.url`, guards that it is a
 /// GitHub URL, parses `owner/repo` via `parse_github_path`, and returns
 /// `(source_id, workspace_path, git_root)` where `source_id = "owner/repo"`,
-/// `workspace_path = <repos_root>/owner/repo`, and `git_root` is the absolute
-/// path of the repository root.
+/// `workspace_path = ~/trusty-mpm-projects/<owner>/<repo>` (the canonical base),
+/// and `git_root` is the absolute path of the repository root.
 /// Test: `guided_derive_project_returns_none_for_non_git_dir`,
 /// `guided_derive_project_rejects_non_github_remote`,
 /// `guided_derive_project_accepts_github_https_remote`,
@@ -825,8 +825,8 @@ pub(crate) async fn fallback_protected(
 ///
 /// Why: when the daemon is unreachable and the current directory is a GitHub-backed
 /// git project, framework files must go into the managed-clone workspace
-/// (`~/trusty-tools/repos/<owner>/<repo>/worktrees/<session-id>/`), never
-/// into the operator's live checkout (#1724).
+/// (`~/trusty-mpm-projects/<owner>/<repo>/.worktrees/<session-id>/`), never
+/// into the operator's live checkout (#1724, #1803).
 /// What: (1) parses `owner/repo` from `origin_url`; (2) ensures the protected
 /// base clone exists (`ensure_base_clone` is idempotent — returns immediately when
 /// the clone already exists); (3) creates a per-session git worktree inside the

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -97,21 +97,54 @@ pub(crate) async fn launch(
         // TODO(follow-up): prepare_session_with_repo_url_and_style
     }
 
-    // 7. Provision the managed workspace: shallow-clone origin + deploy .claude.
-    //    `provision_in` handles the full deploy (agents, skills, palace pin) via
-    //    `prepare_session_with_repo_url` — no separate `prepare_session_with_style`
-    //    call is needed. This step can take 5–30 s for a first clone.
+    // 7. Provision the managed workspace using the shared base-clone + per-session
+    //    worktree mechanism (#1803). This matches what `tm` (guided default) does
+    //    via the daemon's `spawn_managed_inproject` path — both now converge on the
+    //    SAME base clone at `~/trusty-mpm-projects/<owner>/<repo>/` and the SAME
+    //    per-session worktree at `<base>/.worktrees/<session-id>/`.
+    //    Step 7a creates or reuses the shared base clone (idempotent); step 7b adds
+    //    a fresh git worktree for this session; step 7c deploys `.claude` into the
+    //    worktree so the session has the framework available.
     eprintln!("provisioning managed workspace...");
     let session_uuid = trusty_mpm::session_manager::ManagedSessionId::new();
-    let provisioner = trusty_mpm::provisioner::WorkspaceProvisioner::new(
-        trusty_mpm::provisioner::RealGitBackend,
-        std::path::PathBuf::new(),
-    );
-    let prepared = provisioner
-        .provision_in(&project_dir, &session_uuid, &origin_url, "", "")
-        .map_err(|e| anyhow::anyhow!("failed to provision managed workspace: {e}"))?;
 
-    let managed_path = prepared.path;
+    // 7a. Ensure the shared base clone exists. Idempotent: returns immediately when
+    //     `<project_dir>/.git` is already present so a second `tm launch` reuses
+    //     the existing clone rather than re-cloning.
+    trusty_mpm::daemon::managed_routes::inproject::ensure_base_clone(&origin_url, &project_dir)
+        .map_err(|e| anyhow::anyhow!("failed to provision base clone: {e}"))?;
+
+    // 7b. Create a per-session git worktree at `<project_dir>/.worktrees/<session-id>/`.
+    //     Each session gets an isolated branch so concurrent sessions never collide.
+    let managed_path = trusty_mpm::daemon::managed_routes::inproject::create_session_worktree(
+        &project_dir,
+        &session_uuid,
+    )
+    .map_err(|e| anyhow::anyhow!("failed to create session worktree: {e}"))?;
+
+    // 7c. Deploy the `.claude` framework into the worktree (best-effort).
+    //     Non-fatal: a deploy failure never aborts the session — the operator can
+    //     run `tm install` / `tm catalog sync` to populate agents manually.
+    {
+        let fw = trusty_mpm::core::paths::FrameworkPaths::default();
+        if let Err(e) = trusty_mpm::core::session_launch::prepare_session_with_repo_url(
+            &fw,
+            &managed_path,
+            Some(&origin_url),
+        ) {
+            tracing::warn!(
+                "session prep failed for worktree {} (non-fatal): {e}",
+                managed_path.display()
+            );
+        }
+        // Pre-seed workspace trust so claude starts without blocking prompts.
+        if let Err(e) = trusty_mpm::core::home_trust_seed::preseed_home_trust(&managed_path) {
+            tracing::warn!(
+                "home trust pre-seed failed for {} (non-fatal): {e}",
+                managed_path.display()
+            );
+        }
+    }
     let managed_workdir = managed_path.to_string_lossy().to_string();
 
     // 8. Write project-scoped MPM hooks into the managed clone (NOT the live checkout).
@@ -195,8 +228,14 @@ pub(crate) async fn launch(
     );
 
     // 11. Print the full-screen robot splash then the rich info panel.
-    //     The banner shows the MANAGED workdir so the user knows where the session runs.
-    print_launch_banner(&managed_workdir, &tmux_name, prompt_path.as_deref());
+    //     Pass the real managed worktree path so the banner shows the session
+    //     directory (not just the base project dir).
+    print_launch_banner(
+        &live_workdir,
+        &tmux_name,
+        prompt_path.as_deref(),
+        Some(&managed_path),
+    );
     let _ = instructions_path;
 
     // 12. Create a detached tmux session rooted at the MANAGED clone directory.
@@ -333,7 +372,7 @@ pub(crate) async fn connect(
     };
 
     // 3. Print the full-screen robot splash + rich info panel before tmux takes over.
-    print_launch_banner(&workdir, &tmux_name, None);
+    print_launch_banner(&workdir, &tmux_name, None, None);
 
     // 4. Create the tmux host idempotently. `new-session -A` attaches to an
     //    existing session and creates a detached one (`-d`) otherwise; the
@@ -476,9 +515,9 @@ mod tests {
     #[test]
     fn session_matches_workdir_prefix_and_exact() {
         let project_dir = "/home/bob/trusty-mpm-projects/owner/repo";
-        let session_wd = "/home/bob/trusty-mpm-projects/owner/repo/abc-123-uuid";
+        let session_wd = "/home/bob/trusty-mpm-projects/owner/repo/.worktrees/abc-123-uuid";
 
-        // Prefix match: session workdir is under project_dir → match.
+        // Prefix match: session workdir is under project_dir (in .worktrees/) → match.
         assert!(session_matches_workdir(
             session_wd,
             "/other/live/dir",
@@ -534,9 +573,9 @@ mod tests {
             "/other/live",
             Some(project_dir)
         ));
-        // `/owner/repo/<id>` MUST match `/owner/repo`.
+        // `/owner/repo/.worktrees/<id>` MUST match `/owner/repo`.
         assert!(session_matches_workdir(
-            "/projects/owner/repo/some-uuid",
+            "/projects/owner/repo/.worktrees/some-uuid",
             "/other/live",
             Some(project_dir)
         ));

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -159,10 +159,12 @@ pub(crate) fn print_launch_banner(
     workdir: &str,
     tmux_name: &str,
     _prompt_path: Option<&std::path::Path>,
+    managed_path: Option<&std::path::Path>,
 ) {
     let w = terminal_width();
     let daemon = super::info_box::DaemonInfo::from_lock_file();
-    let data = super::info_box::gather_welcome_data(workdir, tmux_name, false, daemon);
+    let data =
+        super::info_box::gather_welcome_data(workdir, tmux_name, false, daemon, managed_path);
 
     if let Some(panel) = two_panel::render_two_panel_banner(&data, w, false) {
         println!("\x1B[2J\x1B[1;1H");
@@ -187,7 +189,7 @@ pub(crate) fn print_launch_banner(
 pub(crate) fn print_launch_banner_reconnecting(workdir: &str, tmux_name: &str) {
     let w = terminal_width();
     let daemon = super::info_box::DaemonInfo::from_lock_file();
-    let data = super::info_box::gather_welcome_data(workdir, tmux_name, true, daemon);
+    let data = super::info_box::gather_welcome_data(workdir, tmux_name, true, daemon, None);
 
     if let Some(panel) = two_panel::render_two_panel_banner(&data, w, true) {
         println!("\x1B[2J\x1B[1;1H");
@@ -217,7 +219,8 @@ pub(crate) fn print_banner_preview(reconnecting: bool) {
         .unwrap_or_else(|_| ".".to_string());
     let session_name = fallback_session_name(std::path::Path::new(&workdir));
     let daemon = super::info_box::DaemonInfo::from_lock_file();
-    let data = super::info_box::gather_welcome_data(&workdir, &session_name, reconnecting, daemon);
+    let data =
+        super::info_box::gather_welcome_data(&workdir, &session_name, reconnecting, daemon, None);
 
     if let Some(panel) = two_panel::render_two_panel_banner(&data, w, reconnecting) {
         print!("\n{panel}");

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
@@ -159,6 +159,7 @@ pub(crate) fn gather_welcome_data(
     session_name: &str,
     reconnecting: bool,
     daemon: DaemonInfo,
+    managed_path: Option<&Path>,
 ) -> WelcomeData {
     let workdir_path = Path::new(workdir);
 
@@ -175,18 +176,27 @@ pub(crate) fn gather_welcome_data(
                 .unwrap_or_else(|| workdir.to_string())
         });
 
-    // Resolve the managed workspace path (`~/trusty-mpm-projects/<owner>/<repo>`).
-    // Since #1590, `tm launch` provisions and opens the tmux session inside this
-    // managed clone, so the banner path matches the real session location.
-    // Falls back to `workdir` when the GitHub identity cannot be derived
-    // (e.g. no git remote).
-    let workspace = match &github_path {
-        Some(gp) => {
-            let cfg = trusty_mpm::core::trusty_tools_config::TrustyToolsConfig::load();
-            let managed = trusty_mpm::core::trusty_tools_config::workspace_subpath(&cfg, gp);
-            managed.to_string_lossy().into_owned()
+    // Resolve the workspace path shown in the panel.
+    //
+    // When `managed_path` is provided (i.e. the caller already provisioned the
+    // session worktree), display it verbatim — this is the real session directory
+    // (`<base>/.worktrees/<session-id>/`) and must NOT be re-derived via
+    // `workspace_subpath` which would strip the session subdir (#1803, #1794).
+    //
+    // When `managed_path` is None (pre-launch picker, reconnect banner, or any
+    // context where no session has been provisioned yet), fall back to deriving
+    // the repo base `~/trusty-mpm-projects/<owner>/<repo>` via `workspace_subpath`.
+    let workspace = if let Some(mp) = managed_path {
+        mp.to_string_lossy().into_owned()
+    } else {
+        match &github_path {
+            Some(gp) => {
+                let cfg = trusty_mpm::core::trusty_tools_config::TrustyToolsConfig::load();
+                let managed = trusty_mpm::core::trusty_tools_config::workspace_subpath(&cfg, gp);
+                managed.to_string_lossy().into_owned()
+            }
+            None => workdir.to_string(),
         }
-        None => workdir.to_string(),
     };
 
     let user = std::env::var("USER")
@@ -227,7 +237,7 @@ pub(crate) fn print_welcome_panel(
     reconnecting: bool,
     daemon: DaemonInfo,
 ) {
-    let data = gather_welcome_data(workdir, session_name, reconnecting, daemon);
+    let data = gather_welcome_data(workdir, session_name, reconnecting, daemon, None);
     print!("{}", render::render_welcome_panel(&data));
     let _ = std::io::Write::flush(&mut std::io::stdout());
     std::thread::sleep(Duration::from_secs(1));

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -287,11 +287,12 @@ fn fallback_session_name_uses_folder() {
 fn launch_banner_does_not_panic() {
     // Why: the banner does width math and probes PATH; exercise it to catch
     // arithmetic underflow or formatting regressions.
-    print_launch_banner("/Users/test/project", "tmpm-quiet-falcon", None);
+    print_launch_banner("/Users/test/project", "tmpm-quiet-falcon", None, None);
     print_launch_banner(
         "/Users/test/project",
         "tmpm-quiet-falcon",
         Some(std::path::Path::new("/tmp/system-prompt.txt")),
+        None,
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -1227,18 +1227,18 @@ async fn guided_fallback_redirect_success_worktree_not_live_checkout() {
     );
     // A per-session worktree must have been created inside the base clone,
     // proving `launch(Some(worktree))` was called, not `launch(None)`.
-    let worktrees_dir = base.join("worktrees");
+    let worktrees_dir = base.join(".worktrees");
     assert!(
         worktrees_dir.exists(),
-        "#1724: worktrees/ dir must exist under base clone after successful redirect"
+        "#1724 #1803: .worktrees/ dir must exist under base clone after successful redirect"
     );
     let sessions: Vec<_> = std::fs::read_dir(&worktrees_dir)
-        .expect("worktrees dir must be listable")
+        .expect(".worktrees dir must be listable")
         .filter_map(|e| e.ok())
         .collect();
     assert!(
         !sessions.is_empty(),
-        "#1724: at least one per-session worktree must be present, proving \
-         launch(Some(worktree)) was invoked rather than launch(None)"
+        "#1724 #1803: at least one per-session worktree must be present under .worktrees/, \
+         proving launch(Some(worktree)) was invoked rather than launch(None)"
     );
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -1,15 +1,18 @@
-//! In-project spawn path: protected base clone + per-session worktree (#1706).
+//! In-project spawn path: shared base clone + per-session worktrees (#1706, #1803).
 //!
 //! Why: operators who run `tm` from inside a git repository should get a managed
 //! session against a git-worktree slice of that repo rather than a full clone.
 //! This module implements the "in-project" path: (a) a durable PROTECTED base
-//! clone under `<repos_root>/<owner>/<repo>/` that is always on the default
-//! branch and owned by the daemon, and (b) a per-session git worktree branched
-//! off that clone so each session works in isolation.
+//! clone under `~/trusty-mpm-projects/<owner>/<repo>/` that is always on the
+//! default branch and owned by the daemon, and (b) a per-session git worktree
+//! at `<base>/.worktrees/<session_id>` branched off that clone so each session
+//! works in isolation.
 //! What: [`repos_root`] resolves the configurable root; [`base_clone_path`]
 //! computes the per-project clone directory; [`ensure_base_clone`] clones if
-//! absent; [`create_session_worktree`] adds a per-session worktree;
-//! [`try_inproject_spawn`] is the main entry point called from the lifecycle layer;
+//! absent; [`create_session_worktree`] adds a per-session worktree at
+//! `<base>/.worktrees/<session_id>`; [`ensure_worktrees_gitignored`] keeps
+//! the worktree directory out of `git status`; [`try_inproject_spawn`] is the
+//! main entry point called from the lifecycle layer;
 //! [`get_origin_url`] reads the remote.origin.url from a git directory.
 //! Test: `try_inproject_spawn_returns_none_for_non_git_path` unit test covers the
 //! non-git early exit; integration coverage via `tests/local_spawn.rs`.
@@ -30,23 +33,27 @@ pub const REPOS_ROOT_ENV: &str = "TRUSTY_MPM_REPOS_ROOT";
 
 /// Default repos root directory name under `$HOME`.
 ///
-/// Why: mirrors the #1220 pattern; a peer directory keeps repos and ephemeral
-/// sessions cleanly separated.
-/// What: `"trusty-tools/repos"`.
-/// Test: `repos_root_default_ends_with_expected_segments`.
-pub const DEFAULT_REPOS_DIR: &str = "trusty-tools/repos";
+/// Why: mirrors the canonical trusty-mpm-projects directory that `workspace_root()`
+/// also resolves to, so both the guided-default path and `tm launch` converge on
+/// the same base clone location (#1803).
+/// What: `"trusty-mpm-projects"`.
+/// Test: `repos_root_default_ends_with_canonical_segment`.
+pub const DEFAULT_REPOS_DIR: &str = "trusty-mpm-projects";
 
 /// Resolve the absolute root for base clones.
 ///
 /// Why: the base-clone path needs ONE answer for "where do managed base clones
-/// live?", with precedence env > built-in default (#1220 pattern).
-/// What: applies **`TRUSTY_MPM_REPOS_ROOT` env > built-in `~/trusty-tools/repos`**,
-/// expanding a leading `~`. Falls back to `/tmp/trusty-tools/repos` only when the
-/// home directory is unresolvable.
-/// Test: covered by the default-shape assertion in unit tests.
+/// live?", with precedence TRUSTY_MPM_REPOS_ROOT env > TRUSTY_MPM_WORKSPACE_ROOT
+/// env > config template > built-in `~/trusty-mpm-projects` (#1803).
+/// What: checks TRUSTY_MPM_REPOS_ROOT first (backward compat), then delegates
+/// to `workspace_root()` from `trusty_tools_config` for the canonical resolution.
+/// Falls back to `/tmp/trusty-mpm-projects` only when the home directory is
+/// unresolvable AND nothing absolute was supplied.
+/// Test: `repos_root_default_ends_with_canonical_segment`.
 pub fn repos_root() -> PathBuf {
     let home = dirs::home_dir();
 
+    // TRUSTY_MPM_REPOS_ROOT env override (backward compat, wins over workspace_root).
     if let Ok(raw) = std::env::var(REPOS_ROOT_ENV) {
         let raw = raw.trim();
         if !raw.is_empty() {
@@ -57,10 +64,10 @@ pub fn repos_root() -> PathBuf {
         }
     }
 
-    match home {
-        Some(h) => h.join(DEFAULT_REPOS_DIR),
-        None => PathBuf::from("/tmp").join(DEFAULT_REPOS_DIR),
-    }
+    // Delegate to the canonical workspace root resolver (TRUSTY_MPM_WORKSPACE_ROOT
+    // > config template > ~/trusty-mpm-projects).
+    let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
+    crate::core::trusty_tools_config::workspace_root(&config)
 }
 
 /// Expand a leading `~` in a path string to `home`.
@@ -84,7 +91,7 @@ fn expand_tilde_repos(template: &str, home: &Path) -> PathBuf {
 /// Why: the base clone directory must be stable and deterministic so multiple
 /// sessions against the same repo all share one protected clone.
 /// What: returns `<repos_root>/<owner>/<repo>`.
-/// Test: `base_clone_path_nests_owner_repo` (unit); wiring via integration tests.
+/// Test: `base_clone_path_resolves_to_canonical_root` (unit); wiring via integration tests.
 pub fn base_clone_path(owner: &str, repo: &str) -> PathBuf {
     repos_root().join(owner).join(repo)
 }
@@ -93,9 +100,11 @@ pub fn base_clone_path(owner: &str, repo: &str) -> PathBuf {
 ///
 /// Why: the first session against a repo triggers a one-time clone; subsequent
 /// sessions reuse the same base directory and only add worktrees.
-/// What: if `base_path/.git` exists, returns `Ok(())` (idempotent). Otherwise
-/// runs `git clone --no-local <origin_url> <base_path>`. A clone failure returns
-/// `Err` with the command's stderr.
+/// What: if `base_path/.git` exists, calls `ensure_worktrees_gitignored` and
+/// returns `Ok(())` (idempotent). Otherwise runs
+/// `git clone --no-local <origin_url> <base_path>` then calls
+/// `ensure_worktrees_gitignored`. A clone failure returns `Err` with the
+/// command's stderr.
 /// Test: idempotent path covered by unit tests; clone path by integration tests.
 pub fn ensure_base_clone(origin_url: &str, base_path: &Path) -> Result<(), String> {
     if base_path.join(".git").exists() {
@@ -103,6 +112,7 @@ pub fn ensure_base_clone(origin_url: &str, base_path: &Path) -> Result<(), Strin
             path = %base_path.display(),
             "inproject: base clone already present, reusing"
         );
+        ensure_worktrees_gitignored(base_path)?;
         return Ok(());
     }
 
@@ -140,6 +150,7 @@ pub fn ensure_base_clone(origin_url: &str, base_path: &Path) -> Result<(), Strin
         ));
     }
     info!(dest = %base_path.display(), "inproject: base clone complete");
+    ensure_worktrees_gitignored(base_path)?;
     Ok(())
 }
 
@@ -148,13 +159,13 @@ pub fn ensure_base_clone(origin_url: &str, base_path: &Path) -> Result<(), Strin
 /// Why: each managed session must work in an isolated branch; git worktrees
 /// achieve this without duplicating the object store of the base clone.
 /// What: runs `git -C <base_path> worktree add -b session/<session_id>
-/// <base_path>/worktrees/<session_id>`. Returns the worktree path on success.
+/// <base_path>/.worktrees/<session_id>`. Returns the worktree path on success.
 /// Test: covered by integration tests against a real temp repo.
 pub fn create_session_worktree(
     base_path: &Path,
     session_id: &ManagedSessionId,
 ) -> Result<PathBuf, String> {
-    let worktree_path = base_path.join("worktrees").join(session_id.to_string());
+    let worktree_path = base_path.join(".worktrees").join(session_id.to_string());
     let branch = format!("session/{session_id}");
 
     info!(
@@ -183,6 +194,57 @@ pub fn create_session_worktree(
 
     info!(worktree = %worktree_path.display(), "inproject: per-session worktree created");
     Ok(worktree_path)
+}
+
+/// Idempotently add `.worktrees/` to the base clone's `.git/info/exclude`.
+///
+/// Why: per-session worktrees live at `<base>/.worktrees/<session-id>/`; without
+/// a gitignore entry `git status` inside the base clone reports the `.worktrees/`
+/// directory as untracked, polluting the output for every harness that runs there.
+/// Adding to `.git/info/exclude` (not `.gitignore`) keeps the entry local to the
+/// clone and does not affect any committed `.gitignore`.
+/// What: creates `<base>/.git/info/` if absent, then appends `.worktrees/` to
+/// `<base>/.git/info/exclude` unless it is already present (idempotent). Returns
+/// `Ok(())` on success or when the entry already exists; propagates I/O errors.
+/// Test: `ensure_worktrees_gitignored_idempotent`.
+pub fn ensure_worktrees_gitignored(base_path: &Path) -> Result<(), String> {
+    let info_dir = base_path.join(".git").join("info");
+    std::fs::create_dir_all(&info_dir).map_err(|e| {
+        format!(
+            "inproject: could not create .git/info/ at {}: {e}",
+            info_dir.display()
+        )
+    })?;
+
+    let exclude_path = info_dir.join("exclude");
+    let existing = std::fs::read_to_string(&exclude_path).unwrap_or_default();
+
+    // Idempotent: skip if the entry is already present.
+    if existing.lines().any(|line| line.trim() == ".worktrees/") {
+        return Ok(());
+    }
+
+    // Append with a leading newline when the file does not already end with one.
+    let entry = if existing.is_empty() || existing.ends_with('\n') {
+        ".worktrees/\n".to_string()
+    } else {
+        "\n.worktrees/\n".to_string()
+    };
+
+    use std::io::Write as _;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&exclude_path)
+        .map_err(|e| format!("inproject: could not open .git/info/exclude: {e}"))?;
+    file.write_all(entry.as_bytes())
+        .map_err(|e| format!("inproject: could not write .git/info/exclude: {e}"))?;
+
+    info!(
+        path = %exclude_path.display(),
+        "inproject: added .worktrees/ to .git/info/exclude"
+    );
+    Ok(())
 }
 
 /// Read the `remote.origin.url` from a git repository at `path`.
@@ -282,10 +344,93 @@ mod tests {
     }
 
     #[test]
-    fn repos_root_default_ends_with_expected_segments() {
-        // Without the env var the default must end with DEFAULT_REPOS_DIR segments.
-        let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
-        let expected = home.join(DEFAULT_REPOS_DIR);
-        assert!(expected.ends_with(DEFAULT_REPOS_DIR));
+    fn repos_root_default_ends_with_canonical_segment() {
+        // Without env overrides, repos_root() must resolve to ~/trusty-mpm-projects
+        // (the canonical base — same root as workspace_root()).
+        // Skip when env is overridden so CI with custom roots doesn't false-fail.
+        if std::env::var(REPOS_ROOT_ENV).is_ok()
+            || std::env::var(crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV).is_ok()
+        {
+            return;
+        }
+        let root = repos_root();
+        assert!(
+            root.ends_with(DEFAULT_REPOS_DIR),
+            "repos_root() default must end with '{DEFAULT_REPOS_DIR}', got {}",
+            root.display()
+        );
+    }
+
+    #[test]
+    fn base_clone_path_resolves_to_canonical_root() {
+        // Without env overrides, base_clone_path must return
+        // ~/trusty-mpm-projects/<owner>/<repo> (#1803).
+        if std::env::var(REPOS_ROOT_ENV).is_ok()
+            || std::env::var(crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV).is_ok()
+        {
+            return;
+        }
+        let base = base_clone_path("myorg", "myrepo");
+        assert!(
+            base.ends_with("trusty-mpm-projects/myorg/myrepo"),
+            "base_clone_path must resolve to …/trusty-mpm-projects/myorg/myrepo, got {}",
+            base.display()
+        );
+    }
+
+    #[test]
+    fn session_worktree_path_uses_dot_prefix() {
+        // create_session_worktree must place the worktree at <base>/.worktrees/<id>
+        // (dot-prefixed) so it is gitignored via .git/info/exclude (#1803).
+        let tmp = tempfile::TempDir::new().expect("tmp dir");
+        let base = tmp.path();
+        let id = ManagedSessionId::new();
+        let expected = base.join(".worktrees").join(id.to_string());
+        // We cannot run git worktree add here (no git repo), but we CAN verify
+        // that the PATH FORMULA is correct by reconstructing it:
+        let actual = base.join(".worktrees").join(id.to_string());
+        assert_eq!(actual, expected, ".worktrees/<id> path must match");
+        // Negative: old path ('worktrees/<id>') must NOT be the formula.
+        let old_path = base.join("worktrees").join(id.to_string());
+        assert_ne!(
+            old_path, expected,
+            "new path must differ from the old non-dot-prefixed formula"
+        );
+    }
+
+    #[test]
+    fn ensure_worktrees_gitignored_idempotent() {
+        // ensure_worktrees_gitignored must write .worktrees/ to .git/info/exclude
+        // exactly ONCE even when called multiple times (idempotent) (#1803).
+        let tmp = tempfile::TempDir::new().expect("tmp dir");
+        let base = tmp.path();
+        // Create a minimal .git dir (not a real git repo, but enough for the function).
+        std::fs::create_dir_all(base.join(".git")).expect("create .git");
+
+        // First call: must write the entry.
+        ensure_worktrees_gitignored(base).expect("first call must succeed");
+
+        let exclude = base.join(".git").join("info").join("exclude");
+        let content1 = std::fs::read_to_string(&exclude).expect("exclude readable");
+        let count1 = content1
+            .lines()
+            .filter(|l| l.trim() == ".worktrees/")
+            .count();
+        assert_eq!(
+            count1, 1,
+            "must contain exactly one .worktrees/ entry after first call"
+        );
+
+        // Second call: must NOT duplicate the entry.
+        ensure_worktrees_gitignored(base).expect("second call must succeed (idempotent)");
+        let content2 = std::fs::read_to_string(&exclude).expect("exclude readable");
+        let count2 = content2
+            .lines()
+            .filter(|l| l.trim() == ".worktrees/")
+            .count();
+        assert_eq!(
+            count2, 1,
+            "second call must not add a duplicate .worktrees/ entry"
+        );
     }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -40,18 +40,28 @@ pub const REPOS_ROOT_ENV: &str = "TRUSTY_MPM_REPOS_ROOT";
 /// Test: `repos_root_default_ends_with_canonical_segment`.
 pub const DEFAULT_REPOS_DIR: &str = "trusty-mpm-projects";
 
-/// Resolve the absolute root for base clones.
+/// Resolve the absolute root for base clones, with an optional direct override.
 ///
-/// Why: the base-clone path needs ONE answer for "where do managed base clones
-/// live?", with precedence TRUSTY_MPM_REPOS_ROOT env > TRUSTY_MPM_WORKSPACE_ROOT
-/// env > config template > built-in `~/trusty-mpm-projects` (#1803).
-/// What: checks TRUSTY_MPM_REPOS_ROOT first (backward compat), then delegates
-/// to `workspace_root()` from `trusty_tools_config` for the canonical resolution.
-/// Falls back to `/tmp/trusty-mpm-projects` only when the home directory is
-/// unresolvable AND nothing absolute was supplied.
-/// Test: `repos_root_default_ends_with_canonical_segment`.
-pub fn repos_root() -> PathBuf {
+/// Why: tests that control the repos root must not mutate process-wide env vars
+/// (which races other threads). Exposing the override as a parameter lets callers
+/// supply the value directly without `set_var` / `remove_var`.
+/// What: `env_override` wins over the `TRUSTY_MPM_REPOS_ROOT` env var, which
+/// wins over `workspace_root()`. Falls back to `/tmp/trusty-mpm-projects` only
+/// when the home directory is unresolvable AND nothing absolute was supplied.
+/// Test: `repos_root_default_ends_with_canonical_segment`; `base_clone_path_respects_repos_root_override` (integration).
+pub fn repos_root_from(env_override: Option<&str>) -> PathBuf {
     let home = dirs::home_dir();
+
+    // Direct in-process override (highest priority — used by tests to avoid env mutation).
+    if let Some(raw) = env_override {
+        let raw = raw.trim();
+        if !raw.is_empty() {
+            return match &home {
+                Some(h) => expand_tilde_repos(raw, h),
+                None => PathBuf::from(raw),
+            };
+        }
+    }
 
     // TRUSTY_MPM_REPOS_ROOT env override (backward compat, wins over workspace_root).
     if let Ok(raw) = std::env::var(REPOS_ROOT_ENV) {
@@ -68,6 +78,20 @@ pub fn repos_root() -> PathBuf {
     // > config template > ~/trusty-mpm-projects).
     let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
     crate::core::trusty_tools_config::workspace_root(&config)
+}
+
+/// Resolve the absolute root for base clones.
+///
+/// Why: the base-clone path needs ONE answer for "where do managed base clones
+/// live?", with precedence TRUSTY_MPM_REPOS_ROOT env > TRUSTY_MPM_WORKSPACE_ROOT
+/// env > config template > built-in `~/trusty-mpm-projects` (#1803).
+/// What: delegates to [`repos_root_from`] with no in-process override, reading
+/// `TRUSTY_MPM_REPOS_ROOT` from the environment as usual.
+/// Falls back to `/tmp/trusty-mpm-projects` only when the home directory is
+/// unresolvable AND nothing absolute was supplied.
+/// Test: `repos_root_default_ends_with_canonical_segment`.
+pub fn repos_root() -> PathBuf {
+    repos_root_from(None)
 }
 
 /// Expand a leading `~` in a path string to `home`.
@@ -196,16 +220,20 @@ pub fn create_session_worktree(
     Ok(worktree_path)
 }
 
-/// Idempotently add `.worktrees/` to the base clone's `.git/info/exclude`.
+/// Best-effort-idempotent: add `.worktrees/` to the base clone's `.git/info/exclude`.
 ///
 /// Why: per-session worktrees live at `<base>/.worktrees/<session-id>/`; without
 /// a gitignore entry `git status` inside the base clone reports the `.worktrees/`
 /// directory as untracked, polluting the output for every harness that runs there.
 /// Adding to `.git/info/exclude` (not `.gitignore`) keeps the entry local to the
 /// clone and does not affect any committed `.gitignore`.
-/// What: creates `<base>/.git/info/` if absent, then appends `.worktrees/` to
-/// `<base>/.git/info/exclude` unless it is already present (idempotent). Returns
-/// `Ok(())` on success or when the entry already exists; propagates I/O errors.
+/// What: creates `<base>/.git/info/` if absent, then reads the current exclude
+/// file and appends `.worktrees/` only when the entry is absent. The read-then-
+/// append window means concurrent callers racing at first launch may each observe
+/// an absent entry and both append — resulting in a duplicate line. Git tolerates
+/// duplicate patterns (same set is matched), so this is safe; single-caller
+/// invocations are strictly idempotent. Returns `Ok(())` on success or when the
+/// entry already exists; propagates I/O errors.
 /// Test: `ensure_worktrees_gitignored_idempotent`.
 pub fn ensure_worktrees_gitignored(base_path: &Path) -> Result<(), String> {
     let info_dir = base_path.join(".git").join("info");
@@ -382,19 +410,82 @@ mod tests {
     fn session_worktree_path_uses_dot_prefix() {
         // create_session_worktree must place the worktree at <base>/.worktrees/<id>
         // (dot-prefixed) so it is gitignored via .git/info/exclude (#1803).
+        // We call the PRODUCTION function against a real temporary git repository
+        // (with an initial commit so `git worktree add` can branch from HEAD) and
+        // assert: (a) path is under <base>/.worktrees/, (b) ends with session id,
+        // (c) the directory actually exists after the call.
+        //
+        // Non-tautology proof: `expected_parent` is hardcoded as `base.join(".worktrees")`
+        // — NOT derived from production code. If `create_session_worktree` changed
+        // to `base_path.join("worktrees").join(...)` the `starts_with` assertion
+        // would fail because `base/worktrees/<id>` does NOT start with `base/.worktrees`.
         let tmp = tempfile::TempDir::new().expect("tmp dir");
         let base = tmp.path();
+
+        // Initialise a real git repo so `git worktree add` can run.
+        let init = std::process::Command::new("git")
+            .args(["init", base.to_str().expect("base is utf8")])
+            .output()
+            .expect("git init");
+        assert!(
+            init.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+
+        // Configure identity (required for `git commit`).
+        for (k, v) in [("user.email", "test@example.com"), ("user.name", "Test")] {
+            let ok = std::process::Command::new("git")
+                .args(["-C", base.to_str().expect("base is utf8"), "config", k, v])
+                .status()
+                .expect("git config");
+            assert!(ok.success(), "git config {k} failed");
+        }
+
+        // Create an initial commit so HEAD exists and `git worktree add -b` works.
+        std::fs::write(base.join("README"), b"init").expect("write README");
+        let add = std::process::Command::new("git")
+            .args(["-C", base.to_str().expect("base is utf8"), "add", "."])
+            .status()
+            .expect("git add");
+        assert!(add.success(), "git add failed");
+        let commit = std::process::Command::new("git")
+            .args([
+                "-C",
+                base.to_str().expect("base is utf8"),
+                "commit",
+                "-m",
+                "init",
+            ])
+            .status()
+            .expect("git commit");
+        assert!(commit.success(), "git commit failed");
+
+        // Call the production function.
         let id = ManagedSessionId::new();
-        let expected = base.join(".worktrees").join(id.to_string());
-        // We cannot run git worktree add here (no git repo), but we CAN verify
-        // that the PATH FORMULA is correct by reconstructing it:
-        let actual = base.join(".worktrees").join(id.to_string());
-        assert_eq!(actual, expected, ".worktrees/<id> path must match");
-        // Negative: old path ('worktrees/<id>') must NOT be the formula.
-        let old_path = base.join("worktrees").join(id.to_string());
-        assert_ne!(
-            old_path, expected,
-            "new path must differ from the old non-dot-prefixed formula"
+        let worktree_path = create_session_worktree(base, &id)
+            .expect("create_session_worktree must succeed on a real git repo");
+
+        // (a) Path must be under <base>/.worktrees/ — hardcoded, not from production.
+        let expected_parent = base.join(".worktrees");
+        assert!(
+            worktree_path.starts_with(&expected_parent),
+            "worktree must be under <base>/.worktrees/, got {}",
+            worktree_path.display()
+        );
+
+        // (b) Path must end with the session id.
+        assert!(
+            worktree_path.ends_with(id.to_string()),
+            "worktree path must end with session id {id}, got {}",
+            worktree_path.display()
+        );
+
+        // (c) The directory must actually exist (git worktree was created on disk).
+        assert!(
+            worktree_path.is_dir(),
+            "worktree directory must exist on disk, got {}",
+            worktree_path.display()
         );
     }
 

--- a/crates/trusty-mpm/tests/local_spawn.rs
+++ b/crates/trusty-mpm/tests/local_spawn.rs
@@ -431,3 +431,33 @@ fn spawn_managed_local_errors_on_no_remote() {
          got: {error_msg}"
     );
 }
+
+/// `base_clone_path` must resolve to `<REPOS_ROOT_ENV>/<owner>/<repo>` when the
+/// env var is set — preserving backward compat with tests that control the root.
+///
+/// Why: tests that mutate TRUSTY_MPM_REPOS_ROOT to a tempdir still work after
+/// the #1803 re-root, because REPOS_ROOT_ENV beats workspace_root().
+/// Test: this function IS the test.
+#[test]
+fn base_clone_path_respects_repos_root_env() {
+    use trusty_mpm::daemon::managed_routes::inproject::{REPOS_ROOT_ENV, base_clone_path};
+
+    let tmp = tempfile::TempDir::new().expect("tmp dir");
+    let prev = std::env::var(REPOS_ROOT_ENV).ok();
+    unsafe { std::env::set_var(REPOS_ROOT_ENV, tmp.path()) };
+
+    let base = base_clone_path("myorg", "myrepo");
+
+    unsafe {
+        match prev {
+            Some(ref v) => std::env::set_var(REPOS_ROOT_ENV, v),
+            None => std::env::remove_var(REPOS_ROOT_ENV),
+        }
+    }
+
+    let expected = tmp.path().join("myorg").join("myrepo");
+    assert_eq!(
+        base, expected,
+        "base_clone_path must respect REPOS_ROOT_ENV override"
+    );
+}

--- a/crates/trusty-mpm/tests/local_spawn.rs
+++ b/crates/trusty-mpm/tests/local_spawn.rs
@@ -432,32 +432,30 @@ fn spawn_managed_local_errors_on_no_remote() {
     );
 }
 
-/// `base_clone_path` must resolve to `<REPOS_ROOT_ENV>/<owner>/<repo>` when the
-/// env var is set — preserving backward compat with tests that control the root.
+/// `repos_root_from` must resolve to the supplied override path, independent of
+/// the environment — preserving backward compat with tests that control the root.
 ///
-/// Why: tests that mutate TRUSTY_MPM_REPOS_ROOT to a tempdir still work after
-/// the #1803 re-root, because REPOS_ROOT_ENV beats workspace_root().
+/// Why: the old test mutated `TRUSTY_MPM_REPOS_ROOT` via `unsafe { set_var }`,
+/// which races other threads reading the same env var. `repos_root_from` accepts
+/// a direct in-process override so the test can pass the value without any env
+/// mutation or `unsafe` block.
+/// What: passes a tempdir path as `env_override` and asserts the returned root
+/// matches; then joins `owner/repo` to confirm the full clone path is correct.
 /// Test: this function IS the test.
 #[test]
-fn base_clone_path_respects_repos_root_env() {
-    use trusty_mpm::daemon::managed_routes::inproject::{REPOS_ROOT_ENV, base_clone_path};
+fn base_clone_path_respects_repos_root_override() {
+    use trusty_mpm::daemon::managed_routes::inproject::repos_root_from;
 
     let tmp = tempfile::TempDir::new().expect("tmp dir");
-    let prev = std::env::var(REPOS_ROOT_ENV).ok();
-    unsafe { std::env::set_var(REPOS_ROOT_ENV, tmp.path()) };
+    let override_str = tmp.path().to_str().expect("tmp path is utf8");
 
-    let base = base_clone_path("myorg", "myrepo");
-
-    unsafe {
-        match prev {
-            Some(ref v) => std::env::set_var(REPOS_ROOT_ENV, v),
-            None => std::env::remove_var(REPOS_ROOT_ENV),
-        }
-    }
+    // No env mutation — pass the override directly to repos_root_from.
+    let root = repos_root_from(Some(override_str));
+    let base = root.join("myorg").join("myrepo");
 
     let expected = tmp.path().join("myorg").join("myrepo");
     assert_eq!(
         base, expected,
-        "base_clone_path must respect REPOS_ROOT_ENV override"
+        "repos_root_from with a direct override must resolve to <override>/<owner>/<repo>"
     );
 }


### PR DESCRIPTION
## Summary

Closes #1803.

`tm` (guided default) and `tm launch` previously used different filesystem roots and different provisioning mechanisms, making session locations inconsistent. This PR unifies both on a single model:

- **ONE shared base clone per repo** at `~/trusty-mpm-projects/<owner>/<repo>/` (the canonical workspace root, same as `workspace_root()` in `trusty_tools_config`)
- **Per-session git worktrees** at `<base>/.worktrees/<session-id>/` — dot-prefixed so the directory is treated as low-noise by tooling
- **`.worktrees/` gitignored** via `<base>/.git/info/exclude` (idempotent, does not touch the repo's committed `.gitignore`)

## Changes

### A. Re-root the base clone (`inproject.rs`)

`repos_root()` now delegates to `workspace_root()` from `trusty_tools_config` (single source of truth). `TRUSTY_MPM_REPOS_ROOT` env var still wins for backward compat. Default is `~/trusty-mpm-projects` — matching the canonical root — rather than the old `~/trusty-tools/repos`.

### B. Dot-prefixed worktrees + gitignore (`inproject.rs`)

- `create_session_worktree` now places worktrees at `<base>/.worktrees/<session-id>` (was `worktrees/<id>`)
- New `ensure_worktrees_gitignored(base_path)` function: idempotently appends `.worktrees/` to `<base>/.git/info/exclude`
- `ensure_base_clone` calls `ensure_worktrees_gitignored` on both the reuse path and after a fresh clone

### C. `tm launch` uses same mechanism (`launch.rs`)

Step 7 previously used `WorkspaceProvisioner::provision_in` which created a **full clone per UUID** at `~/trusty-mpm-projects/<owner>/<repo>/<uuid>/`. Replaced with the same flow as the daemon's `spawn_managed_inproject`:
1. `ensure_base_clone` (idempotent; reuses existing clone)
2. `create_session_worktree` (adds `.worktrees/<id>/` worktree)
3. `prepare_session_with_repo_url` + `preseed_home_trust` (best-effort, non-fatal)

### D. Banner truthfulness (`banner/mod.rs`, `info_box/mod.rs`)

- `print_launch_banner` gains `managed_path: Option<&Path>` (4th arg)
- `gather_welcome_data` uses `managed_path` verbatim when provided, so the panel shows the real session worktree directory (`<base>/.worktrees/<session-id>/`) instead of re-deriving (and stripping) it via `workspace_subpath`
- Reconnect/preview banners pass `None` (unchanged behavior)

### E. Tests

- `tests_behavior_b_tests.rs`: updated `.worktrees/` assertion (was `worktrees/`)
- `tests.rs`: updated `print_launch_banner` calls with new 4th `None` arg
- `inproject.rs` inline tests: 4 new tests — canonical root, dot-prefix formula, gitignore idempotency, env-override backward compat
- `local_spawn.rs`: new `base_clone_path_respects_repos_root_env` test

## Test plan

- [x] `SKIP_UI_BUILD=1 cargo test -p trusty-mpm` — all tests pass (0 failures)
- [x] `SKIP_UI_BUILD=1 cargo clippy -p trusty-mpm --all-targets -- -D warnings` — zero warnings
- [x] `SKIP_UI_BUILD=1 cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] All pre-commit hooks passed

## LOC Delta

- Added: ~303 lines
- Removed: ~75 lines
- Net: +228 lines (bulk is new tests + doc comments for the 4 new `inproject` functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Migration

The default managed-clone root changed from `~/trusty-tools/repos` to `~/trusty-mpm-projects`. Pre-existing base clones at `~/trusty-tools/repos/<owner>/<repo>` are **not auto-migrated** — the daemon will create a fresh base clone at the new location on the next `tm launch`. The old directory is disposable (it is a managed clone, not the live checkout) and can be removed manually:

```bash
rm -rf ~/trusty-tools/repos  # disposable managed clones only; safe to delete
```

No data loss: TASK.md contents, git history, and any committed work that was pushed upstream are unaffected. Uncommitted work in `.worktrees/<session-id>/` inside the OLD root should be pushed or stashed before deletion.