### PR TITLE
feat(trusty-mpm): unify daily tm banner with tm banner + hide decommissioned tombstones (#1808, #1809)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -1273,8 +1273,10 @@ pub(crate) enum SessionAction {
     /// Why: operators need to see every managed session and its pending decision.
     /// What: GETs `/api/v1/sessions/managed` (with optional source_id filter) and
     /// renders a table or JSON. `--current` scopes to sessions for the cwd's repo.
+    /// By default, decommissioned tombstone sessions are hidden (#1809); `--all`
+    /// opts in to seeing every state.
     /// Test: `cli_parses_session_ls`, `cli_parses_session_ls_source_id`,
-    /// `cli_parses_session_ls_current`.
+    /// `cli_parses_session_ls_current`, `cli_parses_session_ls_all`.
     Ls {
         /// Output as JSON instead of a table.
         #[arg(long)]
@@ -1293,6 +1295,13 @@ pub(crate) enum SessionAction {
         /// passing both is a parse error.
         #[arg(long, conflicts_with = "source_id")]
         current: bool,
+        /// Include decommissioned tombstone sessions in the output (#1809).
+        ///
+        /// Why: by default decommissioned sessions are hidden so the list shows only
+        /// live sessions. `--all` opts in to the full unfiltered list for forensics.
+        /// Has no effect on `--json` output (raw daemon response is always complete).
+        #[arg(long)]
+        all: bool,
     },
     /// Show recent activity for a managed session.
     ///

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -25,6 +25,7 @@ use serde::Deserialize;
 
 use super::first_run::needs_first_run_clone;
 pub(crate) use super::guided_autostart::github_host;
+use super::managed::filter_live_sessions;
 use crate::formatters::banner::tmux_has_session;
 
 /// Response shape for `POST /api/v1/sessions/managed` (subset we need).
@@ -145,16 +146,16 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
 
 /// Attempt to list sessions and display the interactive picker for a GitHub project.
 ///
-/// Why: the same "list sessions → tty-gate → info-box → picker" sequence is
-/// needed both on the initial attempt and after a successful auto-start. A shared
-/// helper keeps `run_guided_default` DRY and avoids divergence between the two
-/// call sites.
-/// What: calls `list_project_sessions`; on Err (daemon unreachable) returns
-/// `None` so the caller can try auto-start. On Ok, runs the tty-gate and the
-/// picker, returning `Some(result)`. The `None`/`Some` distinction is the
-/// daemon-reachable signal — it does NOT indicate picker success or failure.
+/// Why: the same "list sessions → two-panel-banner → picker" sequence is needed
+/// both on the initial attempt and after a successful auto-start. A shared helper
+/// keeps `run_guided_default` DRY and avoids divergence between the two call sites.
+/// What: calls `list_project_sessions`, filters out decommissioned tombstones
+/// (#1809), runs the tty-gate, renders the two-panel daily banner (#1808), then
+/// hands off to the picker. Returns `None` when the daemon is unreachable so the
+/// caller can try auto-start; returns `Some(result)` once the daemon responded.
 /// Test: indirectly covered by guided-default e2e tests; the pure sub-functions
-/// (`tty_gate`, `parse_picker_choice`) are unit-tested independently.
+/// (`tty_gate`, `parse_picker_choice`, `is_live_session_state`) are unit-tested
+/// independently.
 async fn try_show_picker(
     client: &reqwest::Client,
     url: &str,
@@ -163,7 +164,8 @@ async fn try_show_picker(
     repo_url: &str,
     cwd: &std::path::Path,
 ) -> Option<anyhow::Result<()>> {
-    let sessions = list_project_sessions(client, url, source_id).await.ok()?;
+    // #1809: exclude decommissioned tombstones from the picker by default.
+    let sessions = filter_live_sessions(list_project_sessions(client, url, source_id).await.ok()?);
     use std::io::IsTerminal as _;
     if !tty_gate(
         std::io::stdin().is_terminal(),
@@ -173,9 +175,11 @@ async fn try_show_picker(
     ) {
         return Some(Ok(()));
     }
+    // #1808: render the same two-panel banner as `tm banner` — version in the
+    // title bar, 24-row clipped art, project/workspace fields — no sleep.
     let daemon =
         crate::formatters::info_box::DaemonInfo::from_lock_file().with_count(sessions.len());
-    crate::formatters::info_box::print_info_box(&cwd.to_string_lossy(), source_id, false, &daemon);
+    crate::formatters::banner::print_daily_banner(&cwd.to_string_lossy(), &daemon);
     Some(run_tty_picker(client, url, repo_url, source_id, sessions).await)
 }
 
@@ -431,9 +435,9 @@ async fn run_tty_picker(
         }
 
         // Detached or session ended — re-fetch the list before redisplaying.
-        sessions = list_project_sessions(client, url, source_id)
-            .await
-            .context("re-fetch")?;
+        // #1809: apply the same tombstone filter on the re-fetched list.
+        let r = list_project_sessions(client, url, source_id).await?;
+        sessions = filter_live_sessions(r);
     }
     Ok(())
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -44,6 +44,36 @@ pub(crate) fn deprecation_notice(old: &str, new: &str) {
     eprintln!("{}", deprecation_message(old, new));
 }
 
+/// Return true when a session state should be shown in the default picker/list view.
+///
+/// Why: decommissioned tombstones accumulate without bound (#1809); operators
+/// don't want 230+ dead records cluttering the picker and `tm sessions ls`. This
+/// predicate is the single source of truth for which states are "live" so the
+/// picker and the `sessions list` table use identical logic.
+/// What: returns `false` for `"decommissioned"` (the sole dead/tombstone state);
+/// returns `true` for every other state (active, provisioning, stopped, errored).
+/// Test: `picker_filter_excludes_decommissioned_keeps_active` in
+/// `tests_behavior_c_tests.rs`.
+pub(crate) fn is_live_session_state(state: &str) -> bool {
+    state != "decommissioned"
+}
+
+/// Filter a session list to only live sessions for display in the picker (#1809).
+///
+/// Why: the picker must never show decommissioned tombstones by default; the
+/// `--all` opt-in re-enables them for `tm sessions ls` via this module's path.
+/// What: retains only sessions whose `state` passes `is_live_session_state`.
+/// Test: `picker_filter_excludes_decommissioned_keeps_active` in
+/// `tests_behavior_c_tests.rs`.
+pub(crate) fn filter_live_sessions(
+    sessions: Vec<ManagedSessionSummary>,
+) -> Vec<ManagedSessionSummary> {
+    sessions
+        .into_iter()
+        .filter(|s| is_live_session_state(&s.state))
+        .collect()
+}
+
 /// `tm sessions ls` — list managed sessions.
 ///
 /// Why: operators need a quick view of every managed session and its pending
@@ -51,15 +81,20 @@ pub(crate) fn deprecation_notice(old: &str, new: &str) {
 /// What: GETs `/api/v1/sessions/managed` (with an optional `?source_id=` filter
 /// that the daemon already supports) and prints a table with id, state, name,
 /// task (truncated to 30 chars), and created_at; or raw JSON with `--json`.
-/// The filter is passed straight through as a query parameter rather than doing
-/// client-side filtering so callers get the daemon's authoritative view.
+/// By default, decommissioned tombstone sessions are hidden from the table (#1809);
+/// `--all` (i.e. `all=true`) opts in to the full unfiltered list. The `--json`
+/// path always returns the raw daemon response unfiltered.
+/// The source_id filter is passed straight through as a query parameter rather
+/// than doing client-side filtering so callers get the daemon's authoritative view.
 /// Test: HTTP path covered by the integration test; filter logic unit-tested by
-/// `ls_source_id_filter_selects_correct_slug`.
+/// `ls_source_id_filter_selects_correct_slug`,
+/// `picker_filter_excludes_decommissioned_keeps_active`.
 pub(crate) async fn session_ls(
     client: &reqwest::Client,
     url: &str,
     json: bool,
     source_id: Option<&str>,
+    all: bool,
 ) -> anyhow::Result<()> {
     // Build the request URL, appending ?source_id= when a filter is active.
     let endpoint = format!("{url}/api/v1/sessions/managed");
@@ -72,10 +107,20 @@ pub(crate) async fn session_ls(
     // the table path deserializes the SAME text rather than issuing a second GET.
     let raw = req.send().await?.error_for_status()?.text().await?;
     if json {
+        // Raw JSON passthrough is always unfiltered — scripts rely on byte-for-byte.
         println!("{raw}");
         return Ok(());
     }
-    let sessions = serde_json::from_str::<trusty_mpm::client::ManagedListResponse>(&raw)?.sessions;
+    let fetched = serde_json::from_str::<trusty_mpm::client::ManagedListResponse>(&raw)?.sessions;
+    // #1809: filter decommissioned tombstones from the default table view.
+    let sessions: Vec<_> = if all {
+        fetched
+    } else {
+        fetched
+            .into_iter()
+            .filter(|s| is_live_session_state(&s.state))
+            .collect()
+    };
     if sessions.is_empty() {
         if let Some(sid) = source_id {
             println!("no managed sessions for {sid}");

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -116,10 +116,7 @@ pub(crate) async fn session_ls(
     let sessions: Vec<_> = if all {
         fetched
     } else {
-        fetched
-            .into_iter()
-            .filter(|s| is_live_session_state(&s.state))
-            .collect()
+        filter_live_sessions(fetched)
     };
     if sessions.is_empty() {
         if let Some(sid) = source_id {

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
@@ -299,7 +299,8 @@ mod tests {
             to_command(&SessionAction::Ls {
                 json: false,
                 source_id: None,
-                current: false
+                current: false,
+                all: false,
             }),
             Some(TrustyCommand::ManagedList)
         ));

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -434,13 +434,14 @@ pub(crate) async fn session(
             json,
             source_id,
             current,
+            all,
         } => {
             let sid: Option<String> = if current {
                 derive_source_id_from_cwd()
             } else {
                 source_id
             };
-            crate::commands::managed::session_ls(client, url, json, sid.as_deref()).await?
+            crate::commands::managed::session_ls(client, url, json, sid.as_deref(), all).await?
         }
         // `activity` stays on the raw path: its CLI output carries confidence,
         // token, cache, and latency detail that `CommandResult::ManagedActivity`

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -203,6 +203,35 @@ pub(crate) fn print_launch_banner_reconnecting(workdir: &str, tmux_name: &str) {
     }
 }
 
+/// Print the two-panel daily banner for the no-subcommand `tm` guided flow (#1808).
+///
+/// Why: the daily `tm` banner should visually match `tm banner` — version in the
+/// title bar (not as a separate content row), 24-row clipped art, and
+/// project/workspace fields — instead of the compact 3-row LOGO via
+/// `render_welcome_panel`. No screen-clear and no sleep since the session picker
+/// follows immediately below. Non-TTY callers are already gated out by `tty_gate`
+/// before this is invoked.
+/// What: builds `WelcomeData` from `workdir` (derives github project + workspace),
+/// renders via `render_two_panel_banner`, and prints to stdout. On very narrow
+/// terminals (<MIN_WIDTH_BOX cols) prints a one-line plain-text fallback.
+/// Test: `daily_banner_two_panel_version_in_title_bar` in `tests.rs`.
+pub(crate) fn print_daily_banner(workdir: &str, daemon: &super::info_box::DaemonInfo) {
+    let w = terminal_width();
+    // Rebuild DaemonInfo by value (no Clone on purpose — same pattern as print_info_box).
+    let d = super::info_box::DaemonInfo {
+        addr: daemon.addr.clone(),
+        online: daemon.online,
+        session_count: daemon.session_count,
+    };
+    let data = super::info_box::gather_welcome_data(workdir, "", false, d, None);
+    if let Some(panel) = two_panel::render_two_panel_banner(&data, w, false) {
+        print!("\n{panel}");
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+    } else {
+        println!("Trusty MPM v{}", env!("CARGO_PKG_VERSION"));
+    }
+}
+
 /// Print the banner to stdout for preview — no screen-clear, no sleep.
 ///
 /// Why: `tm banner` lets the operator eyeball the colored image + welcome panel

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
@@ -4,9 +4,12 @@
 //! service status, and command reminders) before tmux takes over the terminal;
 //! a compact `╭─╮` box conveys that without the old full-screen screen-wipe.
 //! What: `WelcomeData` holds all panel data; `gather_welcome_data` does bounded
-//! probes (≤150 ms each); `render_welcome_panel` builds the box string (pure);
-//! `print_welcome_panel` = gather + render + flush + sleep. `DaemonInfo` reads
-//! the lock file and optionally probes the HTTP API.
+//! probes (≤150 ms each); `render_welcome_panel` builds the box string (pure).
+//! `DaemonInfo` reads the lock file and optionally probes the HTTP API.
+//! The no-subcommand `tm` daily banner uses `banner::print_daily_banner` which
+//! routes through `render_two_panel_banner` instead of the compact LOGO path
+//! (#1808). `print_launch_banner` / `print_launch_banner_reconnecting` in
+//! `banner/mod.rs` handle `tm launch` and `tm connect` banners.
 //! Test: `welcome_panel_renders_*` in `render.rs`; `probe_*` in `probes.rs`;
 //! backward-compat `info_box_renders_*` in the inline tests below.
 
@@ -14,7 +17,6 @@ mod probes;
 pub(crate) mod render;
 
 use std::path::Path;
-use std::time::Duration;
 
 // ── Logo ──────────────────────────────────────────────────────────────────────
 
@@ -23,6 +25,8 @@ use std::time::Duration;
 /// Why: fills the left column of the panel, giving `tm` a visual identity.
 /// What: block-drawing characters space-padded to a uniform 13-column width.
 /// Test: `welcome_panel_renders_online` checks the box renders without panic.
+/// Only consumed by the test-only `render_welcome_panel` box renderer.
+#[cfg(test)]
 pub(crate) const LOGO: [&str; 3] = [
     "▐▛███▜▌      ", // 7 display cols + 6 spaces = 13
     "▝▜█████▛▘    ", // 9 display cols + 4 spaces = 13
@@ -30,6 +34,8 @@ pub(crate) const LOGO: [&str; 3] = [
 ];
 
 /// Display-column width of each logo line.
+/// Only consumed by the test-only `render_welcome_panel` box renderer.
+#[cfg(test)]
 pub(crate) const LOGO_COLS: usize = 13;
 
 // ── DaemonInfo ────────────────────────────────────────────────────────────────
@@ -220,49 +226,6 @@ pub(crate) fn gather_welcome_data(
         search_status,
         review_status,
     }
-}
-
-// ── Print entry points ────────────────────────────────────────────────────────
-
-/// Print the welcome panel to stdout, flush, and pause 1 second.
-///
-/// Why: the panel must be visible before tmux takes over the terminal; the
-/// 1-second pause gives the operator time to read it (#1743).
-/// What: calls `gather_welcome_data`, then `render_welcome_panel`, prints
-/// the result to stdout, flushes, and sleeps 1 s.
-/// Test: `welcome_panel_renders_online` (no panic; sleep not unit-tested).
-pub(crate) fn print_welcome_panel(
-    workdir: &str,
-    session_name: &str,
-    reconnecting: bool,
-    daemon: DaemonInfo,
-) {
-    let data = gather_welcome_data(workdir, session_name, reconnecting, daemon, None);
-    print!("{}", render::render_welcome_panel(&data));
-    let _ = std::io::Write::flush(&mut std::io::stdout());
-    std::thread::sleep(Duration::from_secs(1));
-}
-
-/// Backward-compatible alias — calls `print_welcome_panel`.
-///
-/// Why: existing call sites in `launch.rs` and `guided.rs` use `print_info_box`;
-/// this alias avoids touching those call sites in the same commit.
-/// What: delegates directly to `print_welcome_panel` with identical parameters.
-/// Test: covered by the same paths as `print_welcome_panel`.
-pub(crate) fn print_info_box(
-    workdir: &str,
-    session_name: &str,
-    reconnecting: bool,
-    daemon: &DaemonInfo,
-) {
-    // Rebuild DaemonInfo from its fields (no Clone derive on purpose — keeps the
-    // struct lean; the call sites always have a fresh DaemonInfo).
-    let d = DaemonInfo {
-        addr: daemon.addr.clone(),
-        online: daemon.online,
-        session_count: daemon.session_count,
-    };
-    print_welcome_panel(workdir, session_name, reconnecting, d);
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/render.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/render.rs
@@ -11,7 +11,10 @@
 
 use unicode_width::UnicodeWidthStr as _;
 
-use super::{DaemonInfo, LOGO, LOGO_COLS, WelcomeData};
+use super::{DaemonInfo, WelcomeData};
+// LOGO / LOGO_COLS are only used by render_welcome_panel which is test-only.
+#[cfg(test)]
+use super::{LOGO, LOGO_COLS};
 
 // ── Public render entry point ─────────────────────────────────────────────────
 
@@ -24,6 +27,9 @@ use super::{DaemonInfo, LOGO, LOGO_COLS, WelcomeData};
 /// TM commands cheat-sheet. Width adapts to the longest content line.
 /// Test: `welcome_panel_renders_online`, `welcome_panel_renders_offline`,
 /// `welcome_panel_renders_reconnecting`, `welcome_panel_shows_commits`.
+/// Note: kept for test coverage of `build_rows`; production path uses the
+/// two-panel compositor via `render_info_box_rows` + `banner::two_panel`.
+#[cfg(test)]
 pub(crate) fn render_welcome_panel(data: &WelcomeData) -> String {
     let rows = build_rows(data);
     let right_w = rows.iter().map(|r| display_len(r)).max().unwrap_or(30);
@@ -177,6 +183,8 @@ pub(crate) fn display_len(s: &str) -> usize {
 /// What: appends `(width - display_len(s))` spaces; returns `s` unchanged
 /// when already ≥ `width` columns.
 /// Test: indirectly by render tests.
+/// Note: only called from `render_welcome_panel` which is test-only.
+#[cfg(test)]
 pub(crate) fn pad_to(s: &str, width: usize) -> String {
     let len = display_len(s);
     if len >= width {

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -959,11 +959,13 @@ fn cli_parses_session_ls_source_id() {
                     source_id,
                     current,
                     json,
+                    all,
                 },
         } => {
             assert_eq!(source_id, Some("myorg/myrepo".to_string()));
             assert!(!current);
             assert!(!json);
+            assert!(!all, "--all must default to false");
         }
         other => panic!("expected session ls, got {other:?}"),
     }
@@ -979,11 +981,13 @@ fn cli_parses_session_ls_current() {
                     current,
                     source_id,
                     json,
+                    all,
                 },
         } => {
             assert!(current);
             assert!(source_id.is_none());
             assert!(!json);
+            assert!(!all, "--all must default to false");
         }
         other => panic!("expected session ls, got {other:?}"),
     }
@@ -1004,6 +1008,21 @@ fn cli_session_ls_source_id_and_current_conflict() {
         result.is_err(),
         "passing both --current and --source-id must be a parse error"
     );
+}
+
+#[test]
+fn cli_parses_session_ls_all() {
+    // Why (#1809): `--all` must opt in to showing decommissioned tombstones.
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "ls", "--all"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Ls { all, json, .. },
+        } => {
+            assert!(all, "--all flag must parse to true");
+            assert!(!json);
+        }
+        other => panic!("expected session ls --all, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -30,6 +30,7 @@ use crate::commands::guided::{
     needs_restart, non_github_refusal_message, parse_picker_choice, print_non_tty_hint,
     print_project_context, tty_gate,
 };
+use crate::commands::managed::{filter_live_sessions, is_live_session_state};
 
 // ── parse_picker_choice ───────────────────────────────────────────────────────
 
@@ -923,4 +924,183 @@ fn guided_non_github_refusal_message_reassures_live_checkout_untouched() {
         msg.contains("not touched"),
         "refusal must use the phrase 'not touched': {msg}"
     );
+}
+
+// ── #1809: decommissioned-tombstone filter ────────────────────────────────────
+
+#[test]
+fn picker_filter_live_state_excludes_decommissioned() {
+    // Why (#1809): `is_live_session_state` is the canonical predicate for
+    // "should this session appear in the picker / sessions list by default?".
+    // Test: concrete state → expected bool, not derived from the same expression.
+    assert!(
+        !is_live_session_state("decommissioned"),
+        "decommissioned must be excluded from default view"
+    );
+    // Active sessions must always be visible.
+    assert!(
+        is_live_session_state("active"),
+        "active must be included in default view"
+    );
+    // Stopped/errored sessions can still be resumed — they must show.
+    assert!(
+        is_live_session_state("stopped"),
+        "stopped must be included in default view"
+    );
+    assert!(
+        is_live_session_state("errored"),
+        "errored must be included in default view"
+    );
+    // Provisioning sessions are in-flight — they must show.
+    assert!(
+        is_live_session_state("provisioning"),
+        "provisioning must be included in default view"
+    );
+}
+
+#[test]
+fn picker_filter_excludes_decommissioned_keeps_active() {
+    // Why (#1809): `filter_live_sessions` must drop decommissioned tombstones and
+    // retain all other states. We construct a mixed slice and assert concrete counts
+    // and membership — not the same expression used to compute the filter.
+    let sessions: Vec<trusty_mpm::client::ManagedSessionSummary> =
+        serde_json::from_value(serde_json::json!([
+            { "id": "a1", "name": "sess-active",        "state": "active" },
+            { "id": "b2", "name": "sess-dead-1",        "state": "decommissioned" },
+            { "id": "c3", "name": "sess-stopped",       "state": "stopped" },
+            { "id": "d4", "name": "sess-dead-2",        "state": "decommissioned" },
+            { "id": "e5", "name": "sess-provisioning",  "state": "provisioning" },
+        ]))
+        .expect("test data must deserialize");
+
+    let filtered = filter_live_sessions(sessions);
+
+    // Exactly 3 of the 5 sessions survive the filter.
+    assert_eq!(
+        filtered.len(),
+        3,
+        "filter must keep exactly 3 live sessions (active, stopped, provisioning)"
+    );
+    // Active session must be present.
+    assert!(
+        filtered.iter().any(|s| s.state == "active"),
+        "active session must survive filter"
+    );
+    // Stopped session must be present (can be resumed).
+    assert!(
+        filtered.iter().any(|s| s.state == "stopped"),
+        "stopped session must survive filter"
+    );
+    // Provisioning session must be present (in-flight).
+    assert!(
+        filtered.iter().any(|s| s.state == "provisioning"),
+        "provisioning session must survive filter"
+    );
+    // Neither decommissioned session must appear.
+    assert!(
+        !filtered.iter().any(|s| s.state == "decommissioned"),
+        "decommissioned tombstones must be excluded"
+    );
+}
+
+#[test]
+fn picker_filter_all_live_sessions_unchanged() {
+    // Why: when no sessions are decommissioned, `filter_live_sessions` must
+    // return all sessions unchanged — no unexpected truncation.
+    let sessions: Vec<trusty_mpm::client::ManagedSessionSummary> =
+        serde_json::from_value(serde_json::json!([
+            { "id": "x1", "name": "sess-a", "state": "active" },
+            { "id": "x2", "name": "sess-b", "state": "stopped" },
+            { "id": "x3", "name": "sess-c", "state": "errored" },
+        ]))
+        .expect("test data must deserialize");
+
+    let filtered = filter_live_sessions(sessions);
+    assert_eq!(
+        filtered.len(),
+        3,
+        "all-live input must pass through unchanged (3 sessions)"
+    );
+}
+
+#[test]
+fn picker_filter_all_decommissioned_returns_empty() {
+    // Why: if every session is decommissioned, the picker must show an empty list
+    // (not crash or return some sessions).
+    let sessions: Vec<trusty_mpm::client::ManagedSessionSummary> =
+        serde_json::from_value(serde_json::json!([
+            { "id": "z1", "name": "old-1", "state": "decommissioned" },
+            { "id": "z2", "name": "old-2", "state": "decommissioned" },
+        ]))
+        .expect("test data must deserialize");
+
+    let filtered = filter_live_sessions(sessions);
+    assert!(
+        filtered.is_empty(),
+        "all-decommissioned input must produce empty list"
+    );
+}
+
+// ── #1808: daily banner uses two-panel renderer ───────────────────────────────
+
+#[test]
+fn daily_banner_two_panel_version_in_title_bar_not_content() {
+    // Why (#1808): the daily `tm` banner must use `render_two_panel_banner`
+    // so the version appears in the title bar (first line, starts with ╭) and
+    // NOT as a separate content row. The compact `render_welcome_panel` path
+    // always puts `"trusty-mpm vX.Y.Z"` in the first content row, which is the
+    // old behaviour we are replacing.
+    // What: builds WelcomeData (same shape the daily banner path uses) and checks
+    // the two-panel output for the invariants that distinguish the new path.
+    use crate::formatters::banner::two_panel::{render_two_panel_banner, strip_ansi};
+    use crate::formatters::info_box::{DaemonInfo, WelcomeData};
+
+    colored::control::set_override(false);
+    let data = WelcomeData {
+        project: "owner/repo".to_string(),
+        workspace: "/home/alice/trusty-mpm-projects/owner/repo".to_string(),
+        user: "alice".to_string(),
+        reconnecting: false,
+        session_name: String::new(),
+        daemon: DaemonInfo::default(),
+        recent_commits: vec![],
+        memory_status: "(not detected)".to_string(),
+        search_status: "(not detected)".to_string(),
+        review_status: "(not detected)".to_string(),
+    };
+
+    let version = env!("CARGO_PKG_VERSION");
+    let banner =
+        render_two_panel_banner(&data, 120, false).expect("120-col terminal must produce banner");
+    let bare = strip_ansi(&banner);
+
+    // 1. Version appears exactly once — in the title bar, never in content rows.
+    let count = bare.matches(version).count();
+    assert_eq!(
+        count, 1,
+        "version must appear exactly once (title bar only); found {count}"
+    );
+
+    // 2. First line (title bar) starts with ╭ and contains the version.
+    let first = bare.lines().next().unwrap_or("");
+    assert!(
+        first.starts_with('╭'),
+        "title bar must start with ╭: {first:?}"
+    );
+    assert!(
+        first.contains(version),
+        "title bar must contain the version: {first:?}"
+    );
+
+    // 3. Content rows must NOT contain the version string as a standalone line.
+    // (The title bar is line 0; content rows follow.)
+    for (i, line) in bare.lines().enumerate().skip(1) {
+        // Content lines must not reproduce the version outside the border.
+        let inner = line.trim_start_matches('│').trim_end_matches('│').trim();
+        assert!(
+            !inner.starts_with(&format!("trusty-mpm v{version}")),
+            "content row {i} must not carry the version line: {line:?}"
+        );
+    }
+    colored::control::unset_override();
 }


### PR DESCRIPTION
## Summary

- **#1808 — daily `tm` banner:** The no-subcommand `tm` path now calls `print_daily_banner` which routes through `render_two_panel_banner` (same renderer as `tm banner`). This gives the operator: version in the title bar, 24-row clipped robot art in the left panel, and project/workspace fields in the right panel. The old `print_info_box` (compact 3-row LOGO box, 1-second sleep) is removed. Non-TTY and narrow-terminal (<40 cols) fallback preserved; no sleep; picker appears immediately below the banner.

- **#1809 — hide decommissioned tombstones by default:** `is_live_session_state` / `filter_live_sessions` are the single source of truth (in `managed.rs`). The interactive picker filters before display and on re-fetch. `tm sessions ls` table view excludes decommissioned by default; `--all` opts in to the full list. The `--json` path is always raw/unfiltered for scripts.

## Implementation notes

- `LOGO`, `LOGO_COLS`, `render_welcome_panel`, `pad_to` are now `#[cfg(test)]`-gated — production path never calls the compact box renderer; the test coverage of `build_rows` via `render_welcome_panel` is preserved.
- `render_welcome_panel` was kept (not deleted) because the existing render tests exercise it and provide indirect coverage of `build_rows`. The issue specification says "if unused, remove it" — it is still used from test code.
- `filter_live_sessions` lives in `managed.rs` (not `guided.rs`) to keep `guided.rs` under the 500-SLOC production cap; `guided.rs` imports it via `use super::managed::filter_live_sessions`.

## Tests added / updated

- `cli_parses_session_ls_all` — verifies `--all` flag parses to `true`
- `cli_parses_session_ls_source_id` / `cli_parses_session_ls_current` — updated with `all: bool` field
- `picker_filter_live_state_excludes_decommissioned` — unit-tests the predicate for concrete state values
- `picker_filter_excludes_decommissioned_keeps_active` — 5-session mix (2 decommissioned + 3 live), asserts 3 survive
- `picker_filter_all_live_sessions_unchanged` — all-live input passes through unchanged
- `picker_filter_all_decommissioned_returns_empty` — all-dead input returns empty
- `daily_banner_two_panel_version_in_title_bar_not_content` — verifies version appears exactly once in the title bar, never in content rows

## Quality bar (all passing)

```
cargo clippy -p trusty-mpm --all-targets -- -D warnings  ✓ zero warnings
cargo test -p trusty-mpm                                  ✓ all tests pass
cargo fmt --check -p trusty-mpm                           ✓ no formatting drift
bash scripts/check_line_cap.sh                            ✓ 0 violations
```

Runtime verification of the banner render requires installing the binary (`cargo install --path crates/trusty-mpm --locked`) and running `tm` from a GitHub-backed project directory.

Closes #1808
Closes #1809

🤖 Generated with [Claude Code](https://claude.com/claude-code)