### PR TITLE
feat(trusty-mpm): auto-register git project alias on tm launch + tm ls shows local paths

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -92,7 +92,7 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
     // Auto-register the git project root as a local path alias (non-fatal, silent).
     // Why: every `tm` invocation from a git directory populates `tm ls` with
     // the project's canonical name so operators can quickly find their projects.
-    trusty_mpm::core::project_aliases::try_register_project_alias(&cwd);
+    super::managed_root::try_register_alias(&cwd);
 
     // Use a mutable URL so that a successful auto-start can update it to the
     // actual bound address discovered via the lock file.

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -89,6 +89,11 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
     let workdir = cwd.to_string_lossy().to_string();
     eprintln!("tm: no subcommand — using guided default for {workdir}");
 
+    // Auto-register the git project root as a local path alias (non-fatal, silent).
+    // Why: every `tm` invocation from a git directory populates `tm ls` with
+    // the project's canonical name so operators can quickly find their projects.
+    trusty_mpm::core::project_aliases::try_register_project_alias(&cwd);
+
     // Use a mutable URL so that a successful auto-start can update it to the
     // actual bound address discovered via the lock file.
     let mut effective_url = url.to_string();

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -100,7 +100,7 @@ pub(crate) async fn launch(
     let live_path = live_path.canonicalize().unwrap_or(live_path);
 
     // Auto-register the git project root as a local path alias (non-fatal, silent).
-    trusty_mpm::core::project_aliases::try_register_project_alias(&live_path);
+    super::managed_root::try_register_alias(&live_path);
     let live_workdir = live_path.to_string_lossy().to_string();
 
     // 2. Derive the GitHub identity from the origin remote.
@@ -389,7 +389,7 @@ pub(crate) async fn connect(
     let workdir = path.to_string_lossy().to_string();
 
     // Auto-register the git project root as a local path alias (non-fatal, silent).
-    trusty_mpm::core::project_aliases::try_register_project_alias(&path);
+    super::managed_root::try_register_alias(&path);
 
     // 1b. Reconnect to an existing LIVE session for this directory if one
     //     exists — `connect` is idempotent by design. No project_dir prefix-match

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -98,6 +98,9 @@ pub(crate) async fn launch(
     // 1. Resolve the live source directory (absolute, so the banner is unambiguous).
     let live_path = resolve_dir(dir)?;
     let live_path = live_path.canonicalize().unwrap_or(live_path);
+
+    // Auto-register the git project root as a local path alias (non-fatal, silent).
+    trusty_mpm::core::project_aliases::try_register_project_alias(&live_path);
     let live_workdir = live_path.to_string_lossy().to_string();
 
     // 2. Derive the GitHub identity from the origin remote.
@@ -384,6 +387,9 @@ pub(crate) async fn connect(
     let path = resolve_dir(dir)?;
     let path = path.canonicalize().unwrap_or(path);
     let workdir = path.to_string_lossy().to_string();
+
+    // Auto-register the git project root as a local path alias (non-fatal, silent).
+    trusty_mpm::core::project_aliases::try_register_project_alias(&path);
 
     // 1b. Reconnect to an existing LIVE session for this directory if one
     //     exists — `connect` is idempotent by design. No project_dir prefix-match

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_root.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_root.rs
@@ -93,6 +93,23 @@ struct XdgConfigFile {
 // Resolver
 // ──────────────────────────────────────────────────────────────────────────────
 
+/// Resolve the managed store root and auto-register `cwd` as a project alias.
+///
+/// Why: thin wrapper used by `run_guided_default`, `launch`, and `connect`
+/// so each call site stays at one SLOC while still using the same resolved
+/// root (via the four-level precedence chain) that `tm ls` reads from.
+/// What: resolves the managed paths with `cli_root = None` (honours
+/// `TRUSTY_MPM_ROOT` and config file), then calls
+/// `try_register_project_alias` non-fatally. Silently does nothing when
+/// root resolution fails.
+/// Test: the underlying pieces are exercised by `try_register_and_load_round_trip_same_root`
+/// in `core::project_aliases::tests` and by `test_resolve_default` here.
+pub(crate) fn try_register_alias(cwd: &std::path::Path) {
+    if let Ok(managed) = resolve_managed_paths(None) {
+        trusty_mpm::core::project_aliases::try_register_project_alias(cwd, &managed.root);
+    }
+}
+
 /// Resolve `ManagedPaths` using the four-level precedence.
 ///
 /// Why: centralises root resolution so every standalone command uses the same

--- a/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/standalone.rs
@@ -42,19 +42,39 @@ pub(crate) fn register_cmd(
 
 /// Handle `tm ls [--json]`.
 ///
-/// Why: operators need a quick overview of their registered aliases and which
-/// ones are ready to `run` (loaded vs. unloaded).
-/// What: lists all registry entries with loaded status; prints a human-readable
-/// table by default or a JSON array with `--json`.
+/// Why: operators need a quick overview of (a) local git project paths that
+/// `tm` has visited and auto-registered, and (b) the managed fleet aliases
+/// registered via `tm register`.
+/// What: prints two sections — "Local project aliases" (auto-populated from
+/// git roots visited by `tm`) and "Managed fleet aliases" (DOC-24 GitHub-URL
+/// entries). Empty sections are omitted. `--json` outputs a combined JSON
+/// object with both arrays for scripted consumers.
 /// Test: `cli_parses_ls` in tests.rs.
 pub(crate) fn ls_cmd(paths: &ManagedPaths, json: bool) -> anyhow::Result<()> {
     let root = &paths.root;
+
+    // Load the local project-path alias store (non-fatal if absent).
+    let local_entries = trusty_mpm::core::project_aliases::ProjectAliasStore::load(root)
+        .unwrap_or_default()
+        .list();
+
+    // Load the standalone managed-fleet registry.
     let registry = trusty_mpm::core::standalone::registry::ManagedRegistry::load(root)
         .with_context(|| format!("failed to load registry from {}", root.display()))?;
-    let entries = registry.list();
+    let fleet_entries = registry.list();
 
     if json {
-        let rows: Vec<serde_json::Value> = entries
+        // JSON output: combined object with two top-level keys.
+        let local_rows: Vec<serde_json::Value> = local_entries
+            .iter()
+            .map(|e| {
+                serde_json::json!({
+                    "alias": e.alias,
+                    "path": e.path,
+                })
+            })
+            .collect();
+        let fleet_rows: Vec<serde_json::Value> = fleet_entries
             .iter()
             .map(|e| {
                 serde_json::json!({
@@ -66,21 +86,70 @@ pub(crate) fn ls_cmd(paths: &ManagedPaths, json: bool) -> anyhow::Result<()> {
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&rows)?);
-    } else if entries.is_empty() {
-        println!("No aliases registered. Use `tm register <alias> <url>` to add one.");
-    } else {
-        println!("{:<20} {:<10} URL", "ALIAS", "LOADED");
-        println!("{}", "-".repeat(60));
-        for e in &entries {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "local_projects": local_rows,
+                "managed_fleet": fleet_rows,
+            }))?
+        );
+        return Ok(());
+    }
+
+    // Human-readable output.
+    if local_entries.is_empty() && fleet_entries.is_empty() {
+        println!("No aliases registered.");
+        println!("  Run `tm` from a git project to auto-register a local alias.");
+        println!("  Run `tm register <alias> <url>` to add a managed fleet alias.");
+        return Ok(());
+    }
+
+    // ── Section 1: Local project aliases ──────────────────────────────────
+    if !local_entries.is_empty() {
+        println!("Local project aliases ({}):", local_entries.len());
+        // Compute column widths for alignment.
+        let alias_w = local_entries
+            .iter()
+            .map(|e| e.alias.len())
+            .max()
+            .unwrap_or(5)
+            .max(5);
+        println!("  {:<alias_w$}  PATH", "ALIAS");
+        println!("  {}  {}", "─".repeat(alias_w), "─".repeat(40));
+        for e in &local_entries {
+            println!("  {:<alias_w$}  {}", e.alias, e.path.display());
+        }
+    }
+
+    // ── Section 2: Managed fleet aliases ──────────────────────────────────
+    if !fleet_entries.is_empty() {
+        if !local_entries.is_empty() {
+            println!();
+        }
+        println!("Managed fleet aliases ({}):", fleet_entries.len());
+        let alias_w = fleet_entries
+            .iter()
+            .map(|e| e.alias.len())
+            .max()
+            .unwrap_or(5)
+            .max(5);
+        println!("  {:<alias_w$}  {:<10}  URL", "ALIAS", "LOADED");
+        println!(
+            "  {}  {}  {}",
+            "─".repeat(alias_w),
+            "─".repeat(10),
+            "─".repeat(30)
+        );
+        for e in &fleet_entries {
             let loaded = if registry.is_loaded(&e.alias, root) {
                 "yes"
             } else {
                 "no"
             };
-            println!("{:<20} {:<10} {}", e.alias, loaded, e.url);
+            println!("  {:<alias_w$}  {:<10}  {}", e.alias, loaded, e.url);
         }
     }
+
     Ok(())
 }
 

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -55,6 +55,7 @@ pub mod paths;
 pub mod pid_registry;
 pub mod process;
 pub mod project;
+pub mod project_aliases;
 pub mod project_discovery;
 pub mod session;
 pub mod session_launch;

--- a/crates/trusty-mpm/src/core/project_aliases.rs
+++ b/crates/trusty-mpm/src/core/project_aliases.rs
@@ -173,14 +173,16 @@ pub fn alias_from_path(path: &Path) -> String {
 /// Why: `tm` should silently accumulate a map of visited git project roots so
 /// `tm ls` gives a quick overview without operator effort. The operation is
 /// fire-and-forget — it must never block or fail the calling command.
-/// What: resolves the git root via `git -C <cwd> rev-parse --show-toplevel`;
+/// What: resolves the git root by walking ancestors looking for a `.git` entry;
 /// if cwd is not inside a git repo, silently returns. Otherwise derives the
-/// alias from the basename, loads the store from `~/.trusty-mpm/`, calls
-/// `try_register`, and saves only when a new entry was added.
-/// Test: `try_register_project_alias_noop_outside_git` (integration-style;
-/// requires a tmpdir with no .git ancestor).
-pub fn try_register_project_alias(cwd: &Path) {
-    if let Err(e) = try_register_project_alias_inner(cwd) {
+/// alias from the basename, loads the store from `store_root` (the same root
+/// that `tm ls` reads from — callers resolve it once via `resolve_managed_paths`
+/// so write and read always agree), calls `try_register`, and saves only when a
+/// new entry was added.
+/// Test: `try_register_and_load_round_trip_same_root` proves the write-then-read
+/// path through the same configurable root.
+pub fn try_register_project_alias(cwd: &Path, store_root: &Path) {
+    if let Err(e) = try_register_project_alias_inner(cwd, store_root) {
         warn!("project-alias: auto-registration failed (non-fatal): {e}");
     }
 }
@@ -189,10 +191,11 @@ pub fn try_register_project_alias(cwd: &Path) {
 ///
 /// Why: wrapping the fallible logic lets `try_register_project_alias` present
 /// a non-fatal interface while keeping the inner code idiomatic with `?`.
-/// What: runs git, derives alias, loads store, registers, saves if needed.
+/// What: walks ancestors to find git root, derives alias, loads store from
+/// `store_root`, registers, saves if needed.
 /// Test: exercised via `try_register_project_alias` wrapper tests.
-fn try_register_project_alias_inner(cwd: &Path) -> anyhow::Result<()> {
-    // Resolve git root. Not a git repo → skip silently.
+fn try_register_project_alias_inner(cwd: &Path, store_root: &Path) -> anyhow::Result<()> {
+    // Resolve git root via ancestor walk. Not a git repo → skip silently.
     let Some(git_root) = find_git_root(cwd) else {
         debug!("project-alias: cwd is not inside a git repo; skipping");
         return Ok(());
@@ -201,13 +204,8 @@ fn try_register_project_alias_inner(cwd: &Path) -> anyhow::Result<()> {
     // Derive alias from the basename.
     let alias = alias_from_path(&git_root);
 
-    // Load the store from the default root (~/.trusty-mpm/).
-    let Some(home) = dirs::home_dir() else {
-        warn!("project-alias: cannot resolve home directory; skipping");
-        return Ok(());
-    };
-    let store_root = home.join(".trusty-mpm");
-    let mut store = ProjectAliasStore::load(&store_root)
+    // Load the store from the caller-provided root (same root that ls_cmd reads).
+    let mut store = ProjectAliasStore::load(store_root)
         .map_err(|e| anyhow::anyhow!("load project-paths: {e}"))?;
 
     // Register; save only when a new entry was added.
@@ -220,27 +218,23 @@ fn try_register_project_alias_inner(cwd: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Run `git -C <cwd> rev-parse --show-toplevel` and return the root path.
+/// Walk ancestors of `cwd` looking for a `.git` entry (file or directory).
 ///
-/// Why: this is the canonical way to detect a git repository from any
-/// subdirectory without implementing a manual `.git` search.
-/// What: returns `None` when cwd is not inside a git working tree (non-git
-/// directory, bare repo, or git not on PATH).
-/// Test: `find_git_root_returns_none_outside_repo`.
+/// Why: replaces a `git -C <cwd> rev-parse --show-toplevel` subprocess,
+/// removing a fork+exec on every `tm` invocation and working without `git` on
+/// PATH. The `.git` entry is a directory for normal repos and a file for git
+/// worktrees and submodules — `Path::exists()` handles both.
+/// What: returns the first ancestor directory that contains a `.git` entry.
+/// Returns `None` when no such ancestor exists (non-git directory or bare repo).
+/// Test: `find_git_root_returns_none_outside_repo`,
+/// `find_git_root_returns_some_in_this_repo`.
 fn find_git_root(cwd: &Path) -> Option<PathBuf> {
-    let out = std::process::Command::new("git")
-        .arg("-C")
-        .arg(cwd)
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())?;
-    let root = String::from_utf8_lossy(&out.stdout);
-    let root = root.trim();
-    if root.is_empty() {
-        return None;
+    for ancestor in cwd.ancestors() {
+        if ancestor.join(".git").exists() {
+            return Some(ancestor.to_path_buf());
+        }
     }
-    Some(PathBuf::from(root))
+    None
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -360,8 +354,10 @@ mod tests {
 
     #[test]
     fn find_git_root_returns_none_outside_repo() {
-        // /tmp is guaranteed to not be a git repo on CI.
-        let result = find_git_root(Path::new("/tmp"));
+        // Use a fresh TempDir guaranteed to not be inside any git repo
+        // (system temp directories sit outside all project trees).
+        let dir = TempDir::new().expect("tmpdir");
+        let result = find_git_root(dir.path());
         assert!(
             result.is_none(),
             "expected None for non-git dir, got {result:?}"
@@ -370,17 +366,51 @@ mod tests {
 
     #[test]
     fn find_git_root_returns_some_in_this_repo() {
-        // The worktree itself is a git repo, so this should succeed.
-        // We use the current file's directory as cwd.
+        // The worktree itself is a git repo (has a .git file at the worktree
+        // root). We use CARGO_MANIFEST_DIR (crates/trusty-mpm/) as cwd.
         let cwd = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
         let result = find_git_root(cwd);
         assert!(result.is_some(), "expected Some for cwd inside a git repo");
         let root = result.unwrap();
+        // The returned dir must contain a .git entry (file for worktrees, dir
+        // for normal repos; Path::exists covers both).
         assert!(
-            root.join(".git").exists() || root.join("../.git").exists() || {
-                // worktrees have a .git FILE, not a dir
-                root.join(".git").is_file()
-            }
+            root.join(".git").exists(),
+            ".git must exist at {}",
+            root.display()
+        );
+    }
+
+    #[test]
+    fn try_register_and_load_round_trip_same_root() {
+        // Why: proves that try_register_project_alias and ProjectAliasStore::load
+        // both target the same store_root when callers thread it through, so
+        // writes from auto-registration are visible to `tm ls`.
+        // What: registers via the public entry point, reads back via
+        // ProjectAliasStore::load with the same root, asserts the entry appears.
+        // Test: this function IS the test.
+        let store_root = TempDir::new().expect("tmpdir");
+        let cwd = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+
+        // Determine expected alias from the git root (may skip if not a git repo,
+        // though in practice CARGO_MANIFEST_DIR is always inside the worktree).
+        let Some(git_root) = find_git_root(cwd) else {
+            return; // not inside a git repo — skip
+        };
+        let expected_alias = alias_from_path(&git_root);
+
+        // Register using the same store_root as the read path.
+        try_register_project_alias(cwd, store_root.path());
+
+        // Read back — same code path as ls_cmd (ProjectAliasStore::load(root)).
+        let store = ProjectAliasStore::load(store_root.path()).expect("load");
+        let entries = store.list();
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.alias == expected_alias && e.path == git_root),
+            "expected entry alias={expected_alias} path={} in {entries:?}",
+            git_root.display()
         );
     }
 }

--- a/crates/trusty-mpm/src/core/project_aliases.rs
+++ b/crates/trusty-mpm/src/core/project_aliases.rs
@@ -1,0 +1,386 @@
+//! Local project-path alias store — lightweight `alias → path` registry.
+//!
+//! Why: operators run `tm` across many git projects; recording where `tm` has
+//! been run lets `tm ls` give a quick overview of known local project paths
+//! without requiring a running daemon. The store is independent of the DOC-24
+//! standalone fleet registry (which maps alias → GitHub URL) and the daemon's
+//! project HTTP API.
+//! What: [`ProjectAliasStore`] persists a `Vec<ProjectAliasEntry>` to
+//! `<root>/project-paths.json`. [`try_register_project_alias`] is the single
+//! non-fatal entry point for auto-registration on `tm` launch.
+//! Test: `project_alias_store_new_is_empty`, `try_register_idempotent`,
+//! `try_register_collision_keeps_existing`, `alias_from_path_basename`,
+//! `alias_from_path_no_component`.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+// ── Record type ──────────────────────────────────────────────────────────────
+
+/// One entry in the local project-path alias store.
+///
+/// Why: a flat struct is the simplest representation; separate alias and path
+/// fields map cleanly to the `tm ls` two-column display.
+/// What: alias (basename-derived, stable key) plus the absolute git root path.
+/// Test: round-tripped by `project_alias_store_new_is_empty`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectAliasEntry {
+    /// Short human-readable alias derived from the git root directory basename.
+    pub alias: String,
+    /// Absolute path to the git repository root.
+    pub path: PathBuf,
+}
+
+// ── Store ────────────────────────────────────────────────────────────────────
+
+/// In-memory + on-disk registry of local project-path aliases.
+///
+/// Why: all auto-registration and listing goes through one struct so persistence
+/// never drifts from the in-memory view.
+/// What: a thin wrapper around `Vec<ProjectAliasEntry>` with a `file_path`
+/// pointing to `<root>/project-paths.json`. Mutations are committed by explicit
+/// `save()` calls so callers control the write order.
+/// Test: `try_register_idempotent`, `try_register_collision_keeps_existing`.
+#[derive(Debug, Default)]
+pub struct ProjectAliasStore {
+    entries: Vec<ProjectAliasEntry>,
+    file_path: PathBuf,
+}
+
+impl ProjectAliasStore {
+    /// Load (or create) the alias store at `<root>/project-paths.json`.
+    ///
+    /// Why: a missing file is treated as an empty store so first-run
+    /// auto-registration succeeds without an explicit init step.
+    /// What: reads and deserializes the JSON file when present; returns an
+    /// empty store with the correct path when the file is absent.
+    /// Test: `project_alias_store_new_is_empty`.
+    pub fn load(root: &Path) -> anyhow::Result<Self> {
+        let file_path = root.join("project-paths.json");
+        if !file_path.exists() {
+            return Ok(Self {
+                entries: Vec::new(),
+                file_path,
+            });
+        }
+        let raw = std::fs::read_to_string(&file_path)
+            .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", file_path.display()))?;
+        let entries: Vec<ProjectAliasEntry> = serde_json::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("failed to parse {}: {e}", file_path.display()))?;
+        Ok(Self { entries, file_path })
+    }
+
+    /// Persist the store to disk.
+    ///
+    /// Why: write only when there is a change so most `tm` invocations skip
+    /// the write entirely.
+    /// What: creates parent directories if absent, serialises to pretty JSON, and
+    /// writes atomically via a rename.
+    /// Test: `try_register_idempotent` (write+reload cycle).
+    pub fn save(&self) -> anyhow::Result<()> {
+        if let Some(parent) = self.file_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| anyhow::anyhow!("failed to create {}: {e}", parent.display()))?;
+        }
+        let json = serde_json::to_string_pretty(&self.entries)
+            .map_err(|e| anyhow::anyhow!("failed to serialize project-paths: {e}"))?;
+        // Atomic write: write to .tmp then rename.
+        let tmp_path = self.file_path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, &json)
+            .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, &self.file_path).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to rename {} → {}: {e}",
+                tmp_path.display(),
+                self.file_path.display()
+            )
+        })?;
+        Ok(())
+    }
+
+    /// Attempt to register `alias → path`.
+    ///
+    /// Why: idempotency and collision safety must be centralised so every call
+    /// site gets the same semantics without duplicating the logic.
+    /// What: three outcomes:
+    ///   • Identical entry already exists → no-op, returns `false`.
+    ///   • Alias exists with a *different* path → keep existing, log debug,
+    ///     returns `false` (the caller should NOT save).
+    ///   • Alias is new → insert, returns `true` (caller should save).
+    /// Collision rule: keep existing. This is conservative — the first project
+    /// with a given basename wins. A future `--force` flag could override.
+    /// Test: `try_register_idempotent`, `try_register_collision_keeps_existing`.
+    pub fn try_register(&mut self, alias: &str, path: &Path) -> bool {
+        for entry in &self.entries {
+            if entry.alias == alias {
+                if entry.path == path {
+                    debug!(
+                        alias,
+                        "project-alias: already registered (same path); no-op"
+                    );
+                } else {
+                    debug!(
+                        alias,
+                        existing = %entry.path.display(),
+                        incoming = %path.display(),
+                        "project-alias: collision — keeping existing entry"
+                    );
+                }
+                return false;
+            }
+        }
+        self.entries.push(ProjectAliasEntry {
+            alias: alias.to_string(),
+            path: path.to_path_buf(),
+        });
+        true
+    }
+
+    /// Return all entries sorted by alias name.
+    ///
+    /// Why: stable ordering makes `tm ls` output deterministic across runs.
+    /// What: clones and sorts by alias (lexicographic).
+    /// Test: `project_alias_store_list_is_sorted`.
+    pub fn list(&self) -> Vec<ProjectAliasEntry> {
+        let mut out = self.entries.clone();
+        out.sort_by(|a, b| a.alias.cmp(&b.alias));
+        out
+    }
+}
+
+// ── Alias derivation ─────────────────────────────────────────────────────────
+
+/// Derive a local-alias from a directory path.
+///
+/// Why: the auto-registration convention uses the basename as the alias so that
+/// `~/Projects/trusty-tools` becomes `trusty-tools` without operator input.
+/// What: returns the final path component as a UTF-8 string, falling back to
+/// `"project"` for a path with no usable component (e.g. `/`).
+/// Test: `alias_from_path_basename`, `alias_from_path_no_component`.
+pub fn alias_from_path(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "project".to_string())
+}
+
+// ── Non-fatal public entry point ─────────────────────────────────────────────
+
+/// Auto-register the git project root found from `cwd` into the alias store.
+///
+/// Why: `tm` should silently accumulate a map of visited git project roots so
+/// `tm ls` gives a quick overview without operator effort. The operation is
+/// fire-and-forget — it must never block or fail the calling command.
+/// What: resolves the git root via `git -C <cwd> rev-parse --show-toplevel`;
+/// if cwd is not inside a git repo, silently returns. Otherwise derives the
+/// alias from the basename, loads the store from `~/.trusty-mpm/`, calls
+/// `try_register`, and saves only when a new entry was added.
+/// Test: `try_register_project_alias_noop_outside_git` (integration-style;
+/// requires a tmpdir with no .git ancestor).
+pub fn try_register_project_alias(cwd: &Path) {
+    if let Err(e) = try_register_project_alias_inner(cwd) {
+        warn!("project-alias: auto-registration failed (non-fatal): {e}");
+    }
+}
+
+/// Internal implementation that can return `Err`.
+///
+/// Why: wrapping the fallible logic lets `try_register_project_alias` present
+/// a non-fatal interface while keeping the inner code idiomatic with `?`.
+/// What: runs git, derives alias, loads store, registers, saves if needed.
+/// Test: exercised via `try_register_project_alias` wrapper tests.
+fn try_register_project_alias_inner(cwd: &Path) -> anyhow::Result<()> {
+    // Resolve git root. Not a git repo → skip silently.
+    let Some(git_root) = find_git_root(cwd) else {
+        debug!("project-alias: cwd is not inside a git repo; skipping");
+        return Ok(());
+    };
+
+    // Derive alias from the basename.
+    let alias = alias_from_path(&git_root);
+
+    // Load the store from the default root (~/.trusty-mpm/).
+    let Some(home) = dirs::home_dir() else {
+        warn!("project-alias: cannot resolve home directory; skipping");
+        return Ok(());
+    };
+    let store_root = home.join(".trusty-mpm");
+    let mut store = ProjectAliasStore::load(&store_root)
+        .map_err(|e| anyhow::anyhow!("load project-paths: {e}"))?;
+
+    // Register; save only when a new entry was added.
+    if store.try_register(&alias, &git_root) {
+        store
+            .save()
+            .map_err(|e| anyhow::anyhow!("save project-paths: {e}"))?;
+        debug!(alias, path = %git_root.display(), "project-alias: registered");
+    }
+    Ok(())
+}
+
+/// Run `git -C <cwd> rev-parse --show-toplevel` and return the root path.
+///
+/// Why: this is the canonical way to detect a git repository from any
+/// subdirectory without implementing a manual `.git` search.
+/// What: returns `None` when cwd is not inside a git working tree (non-git
+/// directory, bare repo, or git not on PATH).
+/// Test: `find_git_root_returns_none_outside_repo`.
+fn find_git_root(cwd: &Path) -> Option<PathBuf> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let root = String::from_utf8_lossy(&out.stdout);
+    let root = root.trim();
+    if root.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(root))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn make_store(dir: &TempDir) -> ProjectAliasStore {
+        ProjectAliasStore::load(dir.path()).expect("load")
+    }
+
+    #[test]
+    fn project_alias_store_new_is_empty() {
+        let dir = TempDir::new().expect("tmpdir");
+        let store = make_store(&dir);
+        assert!(store.list().is_empty());
+    }
+
+    #[test]
+    fn try_register_inserts_new_entry() {
+        let dir = TempDir::new().expect("tmpdir");
+        let mut store = make_store(&dir);
+        let path = PathBuf::from("/home/user/Projects/my-project");
+
+        let changed = store.try_register("my-project", &path);
+        assert!(changed, "new entry should return true");
+        let list = store.list();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].alias, "my-project");
+        assert_eq!(list[0].path, path);
+    }
+
+    #[test]
+    fn try_register_idempotent() {
+        let dir = TempDir::new().expect("tmpdir");
+        let mut store = make_store(&dir);
+        let path = PathBuf::from("/home/user/Projects/my-project");
+
+        // First registration: inserts.
+        assert!(store.try_register("my-project", &path));
+        // Second identical registration: no-op.
+        let changed = store.try_register("my-project", &path);
+        assert!(!changed, "re-register same alias+path must be no-op");
+        assert_eq!(store.list().len(), 1, "no duplicate entries");
+    }
+
+    #[test]
+    fn try_register_collision_keeps_existing() {
+        let dir = TempDir::new().expect("tmpdir");
+        let mut store = make_store(&dir);
+        let path_a = PathBuf::from("/home/user/Projects-A/my-project");
+        let path_b = PathBuf::from("/home/user/Projects-B/my-project");
+
+        // Register first path.
+        assert!(store.try_register("my-project", &path_a));
+        // Attempt registration of same alias with different path: keep existing.
+        let changed = store.try_register("my-project", &path_b);
+        assert!(!changed, "collision must not mutate the store");
+
+        let list = store.list();
+        assert_eq!(list.len(), 1, "collision must not add a second entry");
+        assert_eq!(list[0].path, path_a, "existing path must be preserved");
+    }
+
+    #[test]
+    fn project_alias_store_list_is_sorted() {
+        let dir = TempDir::new().expect("tmpdir");
+        let mut store = make_store(&dir);
+
+        store.try_register("zebra", &PathBuf::from("/z"));
+        store.try_register("apple", &PathBuf::from("/a"));
+        store.try_register("mango", &PathBuf::from("/m"));
+
+        let list = store.list();
+        let names: Vec<&str> = list.iter().map(|e| e.alias.as_str()).collect();
+        assert_eq!(names, ["apple", "mango", "zebra"]);
+    }
+
+    #[test]
+    fn save_and_reload_round_trip() {
+        let dir = TempDir::new().expect("tmpdir");
+        {
+            let mut store = make_store(&dir);
+            store.try_register("alpha", &PathBuf::from("/home/user/alpha"));
+            store.try_register("beta", &PathBuf::from("/home/user/beta"));
+            store.save().expect("save");
+        }
+        {
+            let store2 = make_store(&dir);
+            let list = store2.list();
+            assert_eq!(list.len(), 2);
+            let names: Vec<&str> = list.iter().map(|e| e.alias.as_str()).collect();
+            assert!(names.contains(&"alpha"), "{names:?}");
+            assert!(names.contains(&"beta"), "{names:?}");
+        }
+    }
+
+    #[test]
+    fn alias_from_path_basename() {
+        assert_eq!(
+            alias_from_path(Path::new("/home/user/Projects/trusty-tools")),
+            "trusty-tools"
+        );
+        assert_eq!(
+            alias_from_path(Path::new("/home/user/Projects/trusty-tools/")),
+            "trusty-tools"
+        );
+    }
+
+    #[test]
+    fn alias_from_path_no_component() {
+        assert_eq!(alias_from_path(Path::new("/")), "project");
+    }
+
+    #[test]
+    fn find_git_root_returns_none_outside_repo() {
+        // /tmp is guaranteed to not be a git repo on CI.
+        let result = find_git_root(Path::new("/tmp"));
+        assert!(
+            result.is_none(),
+            "expected None for non-git dir, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn find_git_root_returns_some_in_this_repo() {
+        // The worktree itself is a git repo, so this should succeed.
+        // We use the current file's directory as cwd.
+        let cwd = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let result = find_git_root(cwd);
+        assert!(result.is_some(), "expected Some for cwd inside a git repo");
+        let root = result.unwrap();
+        assert!(
+            root.join(".git").exists() || root.join("../.git").exists() || {
+                // worktrees have a .git FILE, not a dir
+                root.join(".git").is_file()
+            }
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/project_aliases.rs
+++ b/crates/trusty-mpm/src/core/project_aliases.rs
@@ -90,13 +90,16 @@ impl ProjectAliasStore {
         let tmp_path = self.file_path.with_extension("json.tmp");
         std::fs::write(&tmp_path, &json)
             .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", tmp_path.display()))?;
-        std::fs::rename(&tmp_path, &self.file_path).map_err(|e| {
-            anyhow::anyhow!(
+        if let Err(e) = std::fs::rename(&tmp_path, &self.file_path) {
+            // Best-effort cleanup: remove the leftover .json.tmp so it does not
+            // accumulate across repeated rename failures.
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(anyhow::anyhow!(
                 "failed to rename {} → {}: {e}",
                 tmp_path.display(),
                 self.file_path.display()
-            )
-        })?;
+            ));
+        }
         Ok(())
     }
 
@@ -106,7 +109,8 @@ impl ProjectAliasStore {
     /// site gets the same semantics without duplicating the logic.
     /// What: three outcomes:
     ///   • Identical entry already exists → no-op, returns `false`.
-    ///   • Alias exists with a *different* path → keep existing, log debug,
+    ///   • Alias exists with a *different* path → keep existing, log warn
+    ///     (visible at default log level so operator knows about the skip),
     ///     returns `false` (the caller should NOT save).
     ///   • Alias is new → insert, returns `true` (caller should save).
     /// Collision rule: keep existing. This is conservative — the first project
@@ -121,11 +125,12 @@ impl ProjectAliasStore {
                         "project-alias: already registered (same path); no-op"
                     );
                 } else {
-                    debug!(
+                    warn!(
                         alias,
                         existing = %entry.path.display(),
                         incoming = %path.display(),
-                        "project-alias: collision — keeping existing entry"
+                        "project-alias: collision — '{}' already points to a different path; use `tm register` to override",
+                        alias
                     );
                 }
                 return false;


### PR DESCRIPTION
## Summary

Closes #1817

- **Feature A — Auto-register on launch:** When `tm`, `tm launch`, or `tm connect` is run from inside a git working tree, the git repository root basename is silently registered as an alias → local-path entry in `~/.trusty-mpm/project-paths.json`. The call is non-fatal; any I/O or git error is swallowed so it never blocks the launch flow.

- **Feature B — `tm ls` shows local aliases:** The existing `tm ls` command (which already listed managed-fleet GitHub-URL aliases) now renders a second section for local project aliases. Both sections display aligned `ALIAS / PATH` columns. `--json` output gains a `local_projects` key alongside the existing `managed_fleet` key.

## Implementation notes

| Decision | Choice | Rationale |
|---|---|---|
| Storage | `~/.trusty-mpm/project-paths.json` (new flat file) | Independent of the daemon so registration works before `tm` is daemonized |
| Collision rule | First-project-wins (keep existing) | Conservative; avoids silently clobbering a hand-crafted alias |
| `tm ls` extension | Two sections in the same command | Avoids adding a new top-level subcommand; backward-compatible |
| Error handling | `try_register_project_alias` is a `fn(cwd) -> ()` fire-and-forget wrapper | Guarantees no launch regression on any filesystem/permission error |

## Test plan

- [x] `cargo test -p trusty-mpm` — 10 new `project_alias` unit tests; 2103 total passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations

**Example `tm ls` output after one invocation from a git directory:**

```
Local project aliases (1):
  ALIAS          PATH
  ─────────────  ────────────────────────────────────────
  trusty-tools   /Users/masa/Projects/trusty-tools

Managed fleet aliases (0):
  (none — run `tm register <alias> <github-url>` to add a project)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)