### PR TITLE
fix(trusty-mpm): CLI ergonomics fixes for tm sessions

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -93,16 +93,24 @@ pub(crate) enum Command {
     },
     /// Define and manage Claude Code sessions within a project.
     ///
-    /// Why (#1394): the invoked name is the plural `sessions` to match the
-    /// `/api/v1/sessions/*` HTTP API surface. The singular `session` spelling
-    /// is intentionally NOT accepted (no alias) so the CLI and API agree on one
-    /// name. The Rust variant stays `Session` (with an explicit
-    /// `#[command(name = "sessions")]`) to keep the `SessionAction` group and
-    /// every match arm coherent without renaming ~80 internal references.
+    /// Two distinct session families live under this command group:
+    ///
+    ///   Local project sessions (bound to the cwd, daemon-backed):
+    ///     start, stop, list, run, output, pause, resume, events, info, …
+    ///
+    ///   Managed fleet sessions (provisioned in isolated worktrees):
+    ///     new, ls, activity, send, answer, decommission, prune-idle, …
+    ///
+    /// Why (#1394, #1841): the invoked name is the plural `sessions` to match the
+    /// `/api/v1/sessions/*` HTTP API surface. The singular `session` spelling is
+    /// accepted as a visible alias (#1841) so both forms work ergonomically. The
+    /// Rust variant stays `Session` (with an explicit `#[command(name = "sessions")]`)
+    /// to keep the `SessionAction` group and every match arm coherent without renaming
+    /// ~80 internal references.
     /// What: the `tm sessions <action>` command group (`tui`, `ls`, `new`, …).
-    /// Test: `cli_parses_sessions_plural` / `cli_rejects_singular_session` in
+    /// Test: `cli_parses_sessions_plural` / `cli_session_alias_accepts_singular` in
     /// `tests.rs`.
-    #[command(name = "sessions")]
+    #[command(name = "sessions", visible_alias = "session")]
     Session {
         /// Session action to perform.
         #[command(subcommand)]
@@ -1139,8 +1147,16 @@ pub(crate) enum ProjectAction {
 }
 
 /// Actions for the `session` subcommand.
+///
+/// Two families coexist here (see `sessions --help` for the full description):
+///   - Local project sessions: start, stop, list, run, output, pause, resume, …
+///   - Managed fleet sessions: new, ls, activity, send, answer, decommission, …
 #[derive(Debug, Subcommand)]
 pub(crate) enum SessionAction {
+    // ── Local project sessions ─────────────────────────────────────────────
+    // These verbs operate on the current project directory and its daemon-backed
+    // session registry. They are NOT valid targets for managed-session IDs.
+    // ──────────────────────────────────────────────────────────────────────
     /// Start a new Claude Code session in the current/specified project.
     Start {
         /// Project directory for the new session (defaults to the cwd).
@@ -1245,6 +1261,10 @@ pub(crate) enum SessionAction {
         #[arg(long)]
         summarize: bool,
     },
+    // ── Managed fleet sessions ─────────────────────────────────────────────
+    // These verbs operate on provisioned worktree sessions in the managed store.
+    // They are NOT valid targets for local project-session IDs.
+    // ──────────────────────────────────────────────────────────────────────
     /// Spawn a new managed session from a repo + ref (session-manager MVP).
     ///
     /// Why: the session-manager MVP provisions an isolated workspace from a git

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -113,8 +113,13 @@ pub(crate) async fn session_ls(
     }
     let fetched = serde_json::from_str::<trusty_mpm::client::ManagedListResponse>(&raw)?.sessions;
     // #1809: filter decommissioned tombstones from the default table view.
+    // #1841 Fix 4: when --all is requested, sort so active/stopped sessions come
+    // first and decommissioned tombstones come last (stable sort preserves relative
+    // order within each group).
     let sessions: Vec<_> = if all {
-        fetched
+        let mut s = fetched;
+        s.sort_by_key(|sess| u8::from(sess.state == "decommissioned"));
+        s
     } else {
         filter_live_sessions(fetched)
     };
@@ -132,11 +137,12 @@ pub(crate) async fn session_ls(
         "ID", "STATE", "NAME", "TASK"
     );
     for s in &sessions {
+        // #1841 Fix 3: show a descriptive placeholder for sessions with no task.
         let task = s
             .task
             .as_deref()
             .map(|t| truncate(t, 30))
-            .unwrap_or_default();
+            .unwrap_or_else(|| "(interactive)".to_string());
         let created = s
             .created_at
             .as_deref()
@@ -148,8 +154,14 @@ pub(crate) async fn session_ls(
             .map(|d| format!(" [pending: {d}]"))
             .unwrap_or_default();
         println!(
+            // #1841 Fix 5: truncate name with ellipsis when it exceeds column width.
             "{:<36}  {:<14}  {:<24}  {:<30}  {}{}",
-            s.id, s.state, s.name, task, created, pending
+            s.id,
+            s.state,
+            truncate(&s.name, 24),
+            task,
+            created,
+            pending
         );
     }
     Ok(())

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -156,10 +156,9 @@ pub(crate) async fn session(
                     .await?;
                 if resp.status() == reqwest::StatusCode::NOT_FOUND {
                     anyhow::bail!("session '{id_or_name}' not found");
-                } else {
-                    resp.error_for_status()?;
-                    println!("stopped {id_or_name}");
                 }
+                resp.error_for_status()?;
+                println!("stopped {id_or_name}");
             }
         }
         SessionAction::List { dir } => {
@@ -338,11 +337,10 @@ pub(crate) async fn session(
                 .await?;
             if resp.status() == reqwest::StatusCode::NOT_FOUND {
                 anyhow::bail!("session '{id_or_name}' not found");
-            } else {
-                let body: serde_json::Value = resp.error_for_status()?.json().await?;
-                let summary = body.get("summary").and_then(|v| v.as_str()).unwrap_or("");
-                println!("paused {id_or_name}: {summary}");
             }
+            let body: serde_json::Value = resp.error_for_status()?.json().await?;
+            let summary = body.get("summary").and_then(|v| v.as_str()).unwrap_or("");
+            println!("paused {id_or_name}: {summary}");
         }
         SessionAction::Resume { id_or_name } => {
             // #1218: `resume` is managed-aware (mirrors `Stop`). A managed
@@ -417,12 +415,11 @@ pub(crate) async fn session(
                 .await?;
             if resp.status() == reqwest::StatusCode::NOT_FOUND {
                 anyhow::bail!("session '{id_or_name}' not found");
-            } else {
-                let body: serde_json::Value = resp.error_for_status()?.json().await?;
-                let output = body.get("output").and_then(|v| v.as_str()).unwrap_or("");
-                print!("{output}");
-                print_compression_stats(&body);
             }
+            let body: serde_json::Value = resp.error_for_status()?.json().await?;
+            let output = body.get("output").and_then(|v| v.as_str()).unwrap_or("");
+            print!("{output}");
+            print_compression_stats(&body);
         }
         // ── Managed session-manager actions ──────────────────────────────────
         // All `ls` variants are routed through the direct HTTP path so the

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -155,7 +155,7 @@ pub(crate) async fn session(
                     .send()
                     .await?;
                 if resp.status() == reqwest::StatusCode::NOT_FOUND {
-                    println!("not found");
+                    anyhow::bail!("session '{id_or_name}' not found");
                 } else {
                     resp.error_for_status()?;
                     println!("stopped {id_or_name}");
@@ -243,7 +243,7 @@ pub(crate) async fn session(
                     let managed = info_from_managed_store(client, url, &id_or_name).await;
                     match managed {
                         Some(val) => println!("{}", serde_json::to_string_pretty(&val)?),
-                        None => println!("session '{id_or_name}' not found"),
+                        None => anyhow::bail!("session '{id_or_name}' not found"),
                     }
                 }
             }
@@ -268,8 +268,7 @@ pub(crate) async fn session(
             {
                 Some(id) => id,
                 None => {
-                    println!("session '{id_or_name}' not found");
-                    return Ok(());
+                    anyhow::bail!("session '{id_or_name}' not found");
                 }
             };
             #[derive(Deserialize)]
@@ -338,7 +337,7 @@ pub(crate) async fn session(
                 .send()
                 .await?;
             if resp.status() == reqwest::StatusCode::NOT_FOUND {
-                println!("session '{id_or_name}' not found");
+                anyhow::bail!("session '{id_or_name}' not found");
             } else {
                 let body: serde_json::Value = resp.error_for_status()?.json().await?;
                 let summary = body.get("summary").and_then(|v| v.as_str()).unwrap_or("");
@@ -362,7 +361,7 @@ pub(crate) async fn session(
                     .await?;
                 match resp.status() {
                     reqwest::StatusCode::NOT_FOUND => {
-                        println!("session '{id_or_name}' not found");
+                        anyhow::bail!("session '{id_or_name}' not found");
                     }
                     reqwest::StatusCode::CONFLICT => {
                         println!("session '{id_or_name}' is not paused");
@@ -389,7 +388,7 @@ pub(crate) async fn session(
                 .await?;
             match resp.status() {
                 reqwest::StatusCode::NOT_FOUND => {
-                    println!("session '{id_or_name}' not found");
+                    anyhow::bail!("session '{id_or_name}' not found");
                 }
                 reqwest::StatusCode::CONFLICT => {
                     println!("session '{id_or_name}' is stopped");
@@ -417,7 +416,7 @@ pub(crate) async fn session(
                 .send()
                 .await?;
             if resp.status() == reqwest::StatusCode::NOT_FOUND {
-                println!("session '{id_or_name}' not found");
+                anyhow::bail!("session '{id_or_name}' not found");
             } else {
                 let body: serde_json::Value = resp.error_for_status()?.json().await?;
                 let output = body.get("output").and_then(|v| v.as_str()).unwrap_or("");

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -585,17 +585,18 @@ fn cli_parses_sessions_plural() {
 }
 
 #[test]
-fn cli_rejects_singular_session() {
-    // #1394: the singular `session` spelling was renamed to `sessions` with NO
-    // alias kept. Parsing the singular name must fail with an
-    // unrecognized-subcommand error so the CLI and the HTTP API agree on one
-    // name. (The separate `session-manager` command is unaffected and remains.)
-    let err = Cli::try_parse_from(["trusty-mpm", "session", "list"]).unwrap_err();
-    assert_eq!(
-        err.kind(),
-        clap::error::ErrorKind::InvalidSubcommand,
-        "singular `session` must be rejected as an unrecognized subcommand"
-    );
+fn cli_session_alias_accepts_singular() {
+    // #1841 Fix 2: `session` (singular) is now a visible_alias for `sessions`.
+    // The plural form was the canonical name (#1394), but operators naturally
+    // type the singular. Both must parse identically.
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "list"])
+        .expect("singular `session` alias must be accepted (#1841)");
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::List { dir },
+        } => assert_eq!(dir, None, "no --dir flag → dir should be None"),
+        other => panic!("expected Session::List via alias, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -247,7 +247,7 @@ mod tests {
             id: ManagedSessionId::new(),
             tmux_name: "tmpm-external".into(),
             cwd: PathBuf::from("/unknown"),
-            task: "externally created".into(),
+            task: "adopted session".into(),
             state: crate::session_manager::ManagedSessionState::Active,
             created_at: Utc::now(),
             last_activity_at: None,

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -788,7 +788,7 @@ impl SessionManager {
                     id: ManagedSessionId::new(),
                     tmux_name: name.clone(),
                     cwd: PathBuf::from("/unknown"),
-                    task: "externally created".into(),
+                    task: "adopted session".into(),
                     state: ManagedSessionState::Active,
                     created_at: Utc::now(),
                     last_activity_at: None,


### PR DESCRIPTION
## Summary

Implements the five CLI ergonomics fixes from #1841 (dogfooding-driven usability improvements for `tm sessions`):

- **Fix 1a (MAJOR)**: `tm sessions --help` now explains both session families (local project sessions and managed fleet sessions) in the command's long about text. clap 4.6 doesn't expose per-subcommand heading annotations for subcommand enums without a full flatten refactor, so the issue's "or about text" qualifier is used.
- **Fix 1b (MAJOR)**: All project-session verbs that find no matching session now exit non-zero (`anyhow::bail!` → stderr + exit 1 instead of `println!` + exit 0). Affected verbs: `output`, `stop` (project path), `run`, `events`, `pause`, `resume` (project path), `info` (managed fallback).
- **Fix 2 (MODERATE)**: `tm session ls` (singular) now works. Added `visible_alias = "session"` to the `sessions` subcommand. Updated the old `cli_rejects_singular_session` test → `cli_session_alias_accepts_singular`.
- **Fix 3 (MODERATE)**: Empty TASK column now shows `(interactive)` instead of blank. The `"externally created"` sentinel for adopted (auto-registered) sessions is replaced by `"adopted session"` in `adopt.rs` and `manager.rs`.
- **Fix 4 (MODERATE)**: `tm sessions ls --all` now sorts active/stopped sessions first, decommissioned tombstones last (stable sort).
- **Fix 5 (MINOR)**: Session names exceeding 24 chars are truncated with `…` in the NAME column (using the existing `truncate()` helper already applied to the TASK column).

## Test plan

- [x] `cargo check -p trusty-mpm` — clean
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p trusty-mpm` — all tests pass (2143 + 603 + ... = all green)
- [x] `cargo fmt --check` — no drift
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations
- [x] `tm sessions --help` — shows both-family description in about text
- [x] `tm session ls` (alias) — resolves to `sessions ls` correctly
- [x] `tm sessions output bogus-nonexistent-session-xyz; echo "exit=$?"` — prints `Error: session '...' not found` to stderr, exits 1

Closes #1841

🤖 Generated with [Claude Code](https://claude.com/claude-code)