### PR TITLE
feat(trusty-console): rename proxy /proxy/* → /api/{service}/* + URL hardening

### DIFF
--- a/crates/trusty-console/src/detect/helpers.rs
+++ b/crates/trusty-console/src/detect/helpers.rs
@@ -108,21 +108,23 @@ pub(super) fn fetch_health_version(addr: &str) -> Option<String> {
 
 // ─── orchestrator ─────────────────────────────────────────────────────────────
 
-/// Strip any leading `http://` or `https://` scheme from a bare address string.
+/// Strip all leading `http://` or `https://` scheme prefixes from a bare
+/// address string.
 ///
 /// Why: Discovery addr files should contain bare `host:port` (e.g.
-/// `127.0.0.1:7788`), but a malformed or misconfigured file might include a
-/// scheme prefix.  Building `format!("http://{addr}")` with a scheme-prefixed
-/// addr produces a double-scheme URL (`http://http://127.0.0.1:7788`) that
-/// reqwest fails to parse.  Stripping exactly one leading scheme before
-/// composing guarantees a single well-formed `http://host:port` URL.
-/// What: Strips one leading `http://` or `https://` prefix if present; returns
-/// the original string slice otherwise (no allocation on the hot path).
-/// Test: `test_normalize_addr_*` below.
+/// `127.0.0.1:7788`), but a malformed or misconfigured file might include one
+/// or more scheme prefixes.  Building `format!("http://{addr}")` with a
+/// scheme-prefixed addr produces a double-scheme URL
+/// (`http://http://127.0.0.1:7788`) that reqwest fails to parse.
+/// Stripping all leading schemes before composing guarantees exactly one
+/// well-formed `http://host:port` URL.
+/// What: Delegates to `crate::url_util::strip_schemes` — the single shared
+/// implementation backing both this function and `proxy::routes::normalize_base_url`
+/// so the loop logic cannot drift between the two sites.  Returns a slice of
+/// `addr`, allocation-free on the hot path.
+/// Test: `test_normalize_addr_*` below; `url_util::tests` cover the core loop.
 fn normalize_addr(addr: &str) -> &str {
-    addr.strip_prefix("http://")
-        .or_else(|| addr.strip_prefix("https://"))
-        .unwrap_or(addr)
+    crate::url_util::strip_schemes(addr)
 }
 
 /// Run the standard P0 detection sequence for a service.

--- a/crates/trusty-console/src/detect/helpers.rs
+++ b/crates/trusty-console/src/detect/helpers.rs
@@ -108,6 +108,23 @@ pub(super) fn fetch_health_version(addr: &str) -> Option<String> {
 
 // ─── orchestrator ─────────────────────────────────────────────────────────────
 
+/// Strip any leading `http://` or `https://` scheme from a bare address string.
+///
+/// Why: Discovery addr files should contain bare `host:port` (e.g.
+/// `127.0.0.1:7788`), but a malformed or misconfigured file might include a
+/// scheme prefix.  Building `format!("http://{addr}")` with a scheme-prefixed
+/// addr produces a double-scheme URL (`http://http://127.0.0.1:7788`) that
+/// reqwest fails to parse.  Stripping exactly one leading scheme before
+/// composing guarantees a single well-formed `http://host:port` URL.
+/// What: Strips one leading `http://` or `https://` prefix if present; returns
+/// the original string slice otherwise (no allocation on the hot path).
+/// Test: `test_normalize_addr_*` below.
+fn normalize_addr(addr: &str) -> &str {
+    addr.strip_prefix("http://")
+        .or_else(|| addr.strip_prefix("https://"))
+        .unwrap_or(addr)
+}
+
 /// Run the standard P0 detection sequence for a service.
 ///
 /// Why: All three connectors use the same three-step sequence; extracting it
@@ -138,7 +155,11 @@ pub(super) fn detect_service(
     if let Some(addr) = read_addr_file(&addr_file)
         && tcp_probe(&addr)
     {
-        let base_url = format!("http://{addr}");
+        // Normalize the addr to strip any accidental scheme prefix before
+        // building the base URL — prevents a double-scheme like
+        // `http://http://127.0.0.1:7788` if the addr file was written with
+        // the scheme included (#1849 Phase 2 hardening).
+        let base_url = format!("http://{}", normalize_addr(&addr));
         let version = fetch_health_version(&addr);
         return ServiceInfo {
             id: id.to_string(),
@@ -238,5 +259,34 @@ mod tests {
     #[test]
     fn test_tcp_probe_malformed_addr() {
         assert!(!tcp_probe("not-an-addr"));
+    }
+
+    // ── normalize_addr ──────────────────────────────────────────────────────
+
+    /// Why: a bare `host:port` must pass through unchanged.
+    /// What: calls normalize_addr with `127.0.0.1:7788`; asserts no change.
+    /// Test: this test itself.
+    #[test]
+    fn test_normalize_addr_bare_unchanged() {
+        assert_eq!(normalize_addr("127.0.0.1:7788"), "127.0.0.1:7788");
+    }
+
+    /// Why: an addr file that was erroneously written with an `http://` scheme
+    /// (e.g. `http://127.0.0.1:7788`) must have the scheme stripped so that
+    /// `format!("http://{}", normalize_addr(...))` produces exactly one scheme.
+    /// What: calls normalize_addr with `http://127.0.0.1:7788`; asserts scheme
+    /// is stripped, returning `127.0.0.1:7788`.
+    /// Test: this test itself (double-scheme regression guard for #1849 Phase 2).
+    #[test]
+    fn test_normalize_addr_strips_http_scheme() {
+        assert_eq!(normalize_addr("http://127.0.0.1:7788"), "127.0.0.1:7788");
+    }
+
+    /// Why: an https-prefixed addr must also have the scheme stripped.
+    /// What: calls normalize_addr with `https://127.0.0.1:7788`; asserts `127.0.0.1:7788`.
+    /// Test: this test itself.
+    #[test]
+    fn test_normalize_addr_strips_https_scheme() {
+        assert_eq!(normalize_addr("https://127.0.0.1:7788"), "127.0.0.1:7788");
     }
 }

--- a/crates/trusty-console/src/detect/mpm.rs
+++ b/crates/trusty-console/src/detect/mpm.rs
@@ -1,7 +1,7 @@
 //! `ServiceConnector` implementation for `trusty-mpm` (#1222, #1849).
 //!
 //! Why: the console's Overview must show trusty-mpm alongside the other services,
-//! and the `/proxy/mpm/*` reverse-proxy route (#1849 Phase 1) requires a live URL
+//! and the `/api/mpm/*` reverse-proxy route (#1849 Phase 2) requires a live URL
 //! from the connector so the proxy handler can resolve the upstream daemon.
 //! What: `MpmConnector` implements `ServiceConnector::detect()` using the standard
 //! `trusty-common` http_addr discovery file written by the daemon after bind
@@ -23,7 +23,7 @@ use super::helpers::{binary_on_path, detect_service, tcp_probe};
 /// ServiceConnector for `trusty-mpm`.
 ///
 /// Why: surfaces the running trusty-mpm daemon in the console Overview and
-/// enables the `/proxy/mpm/*` route by providing the daemon's live base URL
+/// enables the `/api/mpm/*` route by providing the daemon's live base URL
 /// via the standard `http_addr` discovery file (#1849 Phase 1). A backward-compat
 /// fallback reads the TOML lock file for daemons that pre-date the http_addr write.
 /// What: implements `detect()` using the standard `trusty-common` data-dir

--- a/crates/trusty-console/src/lib.rs
+++ b/crates/trusty-console/src/lib.rs
@@ -48,6 +48,7 @@ pub mod poller;
 pub mod proxy;
 pub mod routes;
 pub mod server;
+pub(crate) mod url_util;
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 

--- a/crates/trusty-console/src/proxy/mod.rs
+++ b/crates/trusty-console/src/proxy/mod.rs
@@ -1,15 +1,17 @@
-//! Reverse-proxy module for trusty-console P1.
+//! Reverse-proxy module for trusty-console (#1849 Phase 2).
 //!
 //! Why: Operators want to reach each daemon's UI and API through the console's
 //! single URL (`http://127.0.0.1:7788`) rather than remembering per-daemon
-//! ports.  This module implements the `/proxy/{daemon}/{*path}` route that
-//! forwards requests to the live daemon base URL resolved from the background
-//! health-poll cache.
-//! What: Two sub-modules — `routes` contains the axum extractor types and the
-//! forwarding handler; this `mod.rs` re-exports the public surface and houses
-//! the `KNOWN_DAEMONS` constant.
-//! Test: Unit tests for URL construction live in `routes.rs`.
+//! ports.  This module implements the primary `/api/{service}/{*path}` route
+//! (Phase 2) and the deprecated `/proxy/{daemon}/{*path}` alias (backward
+//! compatibility) that both forward requests to the live daemon base URL
+//! resolved from the background health-poll cache.
+//! What: `routes` contains the axum extractor types and the forwarding handlers.
+//! This `mod.rs` re-exports the public surface (`proxy_handler`,
+//! `deprecated_proxy_handler`).
+//! Test: Unit tests for URL construction and normalization live in `routes.rs`.
 
 pub mod routes;
 
+pub use routes::deprecated_proxy_handler;
 pub use routes::proxy_handler;

--- a/crates/trusty-console/src/proxy/routes.rs
+++ b/crates/trusty-console/src/proxy/routes.rs
@@ -86,21 +86,21 @@ fn is_local_upstream(url: &str) -> bool {
 /// Stripping all leading scheme prefixes and re-adding exactly one `http://`
 /// ensures a single well-formed `http://host:port` URL regardless of how many
 /// schemes were stacked.  Idempotent on a correctly-formed URL.
-/// What: Loops stripping `http://` or `https://` prefixes until neither is
-/// present, then prepends `http://`.
+/// What: Delegates to `crate::url_util::strip_schemes` (the single shared
+/// implementation) so the loop logic cannot drift between this site and the
+/// connector layer.  Emits a `warn!` when `https://` is present — that
+/// indicates a misconfigured discovery file (all upstream connections are
+/// loopback HTTP only).
 /// Test: `test_normalize_base_url_*` below.
 pub fn normalize_base_url(url: &str) -> String {
-    let mut rest = url;
-    loop {
-        if let Some(s) = rest.strip_prefix("http://") {
-            rest = s;
-        } else if let Some(s) = rest.strip_prefix("https://") {
-            rest = s;
-        } else {
-            break;
-        }
+    if url.contains("https://") {
+        warn!(
+            "proxy: upstream base URL contains https:// — stripping to http:// \
+             (loopback upstream connections are HTTP only). \
+             Check the service's http_addr discovery file."
+        );
     }
-    format!("http://{rest}")
+    format!("http://{}", crate::url_util::strip_schemes(url))
 }
 
 /// Build the upstream URL from a base URL, sub-path, and optional query string.
@@ -168,6 +168,17 @@ pub async fn proxy_handler(
     Path((service_key, subpath)): Path<(String, String)>,
     req: Request,
 ) -> Response {
+    // Defensive guard: "console" is a reserved service key that routes to the
+    // console's own /api/console/* namespace.  Reject it explicitly here as a
+    // routing-independent second layer so the proxy can never target itself,
+    // even if axum's literal-segment priority were somehow bypassed.
+    if service_key.as_str() == "console" {
+        warn!(
+            "proxy: service_key 'console' is reserved and cannot be proxied (routing invariant violated)"
+        );
+        return error_response(StatusCode::BAD_REQUEST, "reserved service key");
+    }
+
     // Map short key → full id via the exhaustive match in full_id(), which is
     // the single source of truth for the proxy allowlist.
     let Some(full_service_id) = full_id(&service_key) else {
@@ -442,6 +453,36 @@ mod tests {
         // #1849 Phase 1: mpm must be in the allowlist.
         assert_eq!(full_id("mpm"), Some("trusty-mpm"));
         assert_eq!(full_id("unknown"), None);
+    }
+
+    /// Why: a double-scheme URL like `http://http://127.0.0.1:7878` must NOT
+    /// pass the SSRF guard — it starts with `http://http://`, not `http://127.`,
+    /// `http://[::1]`, or `http://localhost`.  This locks in the ordering
+    /// safety: normalize_base_url must run before is_local_upstream so the
+    /// guard only ever sees a clean single-scheme URL.
+    /// What: asserts is_local_upstream("http://http://127.0.0.1:7878") is false.
+    /// Test: this test itself (#1849 Phase 2 double-scheme SSRF regression guard).
+    #[test]
+    fn test_is_local_upstream_rejects_double_scheme() {
+        assert!(
+            !is_local_upstream("http://http://127.0.0.1:7878"),
+            "double-scheme URL must not pass the loopback guard"
+        );
+    }
+
+    /// Why: the "console" service key is reserved; full_id returns None for it
+    /// so it would be caught by the unknown-key guard — but the explicit
+    /// console check must fire first (defensive depth).
+    /// What: asserts full_id("console") is None (the allowlist does not list it).
+    /// Test: this test itself (unit-level guard; HTTP-level guard tested in
+    /// server.rs::test_api_proxy_console_key_returns_400).
+    #[test]
+    fn test_console_key_not_in_allowlist() {
+        assert_eq!(
+            full_id("console"),
+            None,
+            "console must never appear in the proxy allowlist"
+        );
     }
 
     /// Why: hop-by-hop headers must be stripped; safe headers must pass through.

--- a/crates/trusty-console/src/proxy/routes.rs
+++ b/crates/trusty-console/src/proxy/routes.rs
@@ -1,14 +1,17 @@
-//! Reverse-proxy handler for `/proxy/{daemon}/{*path}`.
+//! Reverse-proxy handlers for `/api/{service}/{*path}` (primary) and the
+//! deprecated `/proxy/{daemon}/{*path}` alias (#1849 Phase 2).
 //!
 //! Why: Provides a single handler that forwards every HTTP method to the live
 //! upstream daemon URL resolved from the background health-poll cache, enabling
-//! all daemon APIs and UIs to be reached through the console port.
-//! What: `proxy_handler` strips the `/proxy/{daemon}/` prefix, resolves the
-//! daemon's base URL from the cached snapshot, forwards the request (method,
-//! allowed headers, body) via `reqwest`, and streams the response (status,
-//! allowed response headers, body) back to the caller.  Returns 400 for unknown
-//! daemon IDs and 502 when the daemon is not reachable.
-//! Test: `tests::test_build_upstream_url_*` below exercise URL construction.
+//! all daemon APIs and UIs to be reached through the console port without knowing
+//! per-daemon port numbers.
+//! What: `proxy_handler` resolves the service key, normalises the upstream base
+//! URL (double-scheme guard), forwards the request (method, allowed headers,
+//! body) via `reqwest`, and streams the response back.  Returns 400 for unknown
+//! service keys and 503/502 when the daemon cache is cold or unreachable.
+//! `deprecated_proxy_handler` wraps `proxy_handler` with a debug deprecation
+//! note to nudge callers toward the new `/api/{service}/…` prefix.
+//! Test: `tests::test_build_upstream_url_*` and `test_normalize_base_url_*` below.
 
 use axum::{
     body::{Body, Bytes},
@@ -17,7 +20,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use reqwest::Method;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use crate::server::AppState;
 
@@ -36,18 +39,18 @@ static HOP_BY_HOP: &[&str] = &[
     "host",
 ];
 
-/// Map a short daemon key (as it appears in the URL) to the full service ID
+/// Map a short service key (as it appears in the URL) to the full service ID
 /// stored in `CachedSnapshot.services`.
 ///
 /// Why: The URL uses short names (`search`, `memory`, …) while `ServiceInfo.id`
 /// uses the full `trusty-*` prefix.  This function is the single source of
 /// truth for the proxy allowlist: `None` means the key is not permitted.
-/// `mpm` is added here in #1849 Phase 1 so `/proxy/mpm/*path` forwards to
+/// `mpm` is in the allowlist (#1849 Phase 1) so `/api/mpm/*path` forwards to
 /// the live trusty-mpm daemon URL resolved from the connector's `ServiceInfo`.
 /// What: Returns the full service ID, or `None` for unknown/disallowed keys.
-/// Test: `test_daemon_key_mapping` below.
-fn full_id(daemon_key: &str) -> Option<&'static str> {
-    match daemon_key {
+/// Test: `test_service_key_mapping` below.
+fn full_id(service_key: &str) -> Option<&'static str> {
+    match service_key {
         "search" => Some("trusty-search"),
         "memory" => Some("trusty-memory"),
         "analyze" => Some("trusty-analyze"),
@@ -73,6 +76,31 @@ fn is_local_upstream(url: &str) -> bool {
     url.starts_with("http://127.")
         || url.starts_with("http://[::1]")
         || url.starts_with("http://localhost")
+}
+
+/// Normalize a service base URL to strip any accidental double-scheme prefix.
+///
+/// Why: Defense in depth against a misconfigured discovery file that already
+/// contains a scheme (`http://127.0.0.1:7788`).  The connector prepends
+/// `http://` via `detect_service`, which would produce `http://http://127.0.0.1:7788`.
+/// Stripping all leading scheme prefixes and re-adding exactly one `http://`
+/// ensures a single well-formed `http://host:port` URL regardless of how many
+/// schemes were stacked.  Idempotent on a correctly-formed URL.
+/// What: Loops stripping `http://` or `https://` prefixes until neither is
+/// present, then prepends `http://`.
+/// Test: `test_normalize_base_url_*` below.
+pub fn normalize_base_url(url: &str) -> String {
+    let mut rest = url;
+    loop {
+        if let Some(s) = rest.strip_prefix("http://") {
+            rest = s;
+        } else if let Some(s) = rest.strip_prefix("https://") {
+            rest = s;
+        } else {
+            break;
+        }
+    }
+    format!("http://{rest}")
 }
 
 /// Build the upstream URL from a base URL, sub-path, and optional query string.
@@ -125,25 +153,25 @@ fn error_response(status: StatusCode, body: &'static str) -> Response {
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }
 
-/// `ANY /proxy/{daemon}/{*path}` — reverse-proxy to the daemon's live URL.
+/// `ANY /api/{service}/{*path}` — reverse-proxy to the service's live URL.
 ///
 /// Why: Lets operators and the console SPA reach every daemon API through the
 /// console port without knowing per-daemon port numbers.
-/// What: Resolves the daemon's base URL from the background health-poll cache,
-/// forwards the request (method, safe headers, body) via reqwest, and streams
-/// the upstream response back.  Unknown daemon IDs → 400; daemon not reachable
-/// → 502.
+/// What: Resolves the service's base URL from the background health-poll cache,
+/// normalises the URL (double-scheme guard), forwards the request (method, safe
+/// headers, body) via reqwest, and streams the upstream response back.
+/// Unknown service keys → 400; daemon not reachable → 502.
 /// Test: URL construction is unit-tested in `tests` below.  End-to-end proxy
 /// behaviour requires a live daemon and is not tested in CI.
 pub async fn proxy_handler(
     State(state): State<AppState>,
-    Path((daemon_key, subpath)): Path<(String, String)>,
+    Path((service_key, subpath)): Path<(String, String)>,
     req: Request,
 ) -> Response {
     // Map short key → full id via the exhaustive match in full_id(), which is
     // the single source of truth for the proxy allowlist.
-    let Some(full_daemon_id) = full_id(&daemon_key) else {
-        warn!("proxy: unknown daemon key '{daemon_key}'");
+    let Some(full_service_id) = full_id(&service_key) else {
+        warn!("proxy: unknown service key '{service_key}'");
         return error_response(StatusCode::BAD_REQUEST, "unknown daemon");
     };
 
@@ -151,21 +179,25 @@ pub async fn proxy_handler(
         let snap = state.poller_cache().snapshot().await;
         match snap {
             None => {
-                warn!("proxy: cache not yet populated for '{daemon_key}'");
+                warn!("proxy: cache not yet populated for '{service_key}'");
                 return error_response(StatusCode::SERVICE_UNAVAILABLE, "cache not ready");
             }
             Some(s) => {
                 let map = s.url_map();
-                match map.get(full_daemon_id).cloned() {
+                match map.get(full_service_id).cloned() {
                     Some(url) => url,
                     None => {
-                        warn!("proxy: daemon '{daemon_key}' is not running");
+                        warn!("proxy: service '{service_key}' is not running");
                         return error_response(StatusCode::BAD_GATEWAY, "daemon not running");
                     }
                 }
             }
         }
     };
+
+    // Normalize base URL — strips any accidental double-scheme prefix produced
+    // by a malformed discovery file (#1849 Phase 2 hardening).
+    let base_url = normalize_base_url(&base_url);
 
     // SSRF guard: the console is a local-only tool; reject any upstream that is
     // not a loopback address.  A non-local URL in the cache would be a bug or
@@ -181,7 +213,7 @@ pub async fn proxy_handler(
     // Build the upstream URL.
     let query = parts.uri.query();
     let upstream_url = build_upstream_url(&base_url, &subpath, query);
-    debug!("proxy: {daemon_key} → {upstream_url}");
+    debug!("proxy: {service_key} → {upstream_url}");
 
     // Convert axum Method to reqwest Method.
     let method = match Method::from_bytes(parts.method.as_str().as_bytes()) {
@@ -218,7 +250,7 @@ pub async fn proxy_handler(
     let upstream_resp = match upstream_req.send().await {
         Ok(r) => r,
         Err(e) => {
-            warn!("proxy: upstream request failed for '{daemon_key}': {e}");
+            warn!("proxy: upstream request failed for '{service_key}': {e}");
             return error_response(StatusCode::BAD_GATEWAY, "upstream request failed");
         }
     };
@@ -251,6 +283,23 @@ pub async fn proxy_handler(
     resp_builder
         .body(resp_body)
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+/// `ANY /proxy/{daemon}/{*path}` — deprecated alias for `proxy_handler`.
+///
+/// Why: The `/proxy/` prefix was renamed to `/api/` in #1849 Phase 2 to align
+/// with the console's `/api/console/…` namespace.  This alias keeps old callers
+/// working without a hard break while nudging them toward the new path.
+/// What: Logs a debug-level deprecation note then delegates to `proxy_handler`
+/// with the same extracted path components.
+/// Test: `test_deprecated_proxy_alias_*` in `server.rs`.
+pub async fn deprecated_proxy_handler(
+    State(state): State<AppState>,
+    Path((service_key, subpath)): Path<(String, String)>,
+    req: Request,
+) -> Response {
+    trace!("proxy: DEPRECATED /proxy/{service_key}/… — use /api/{service_key}/… instead (#1849)");
+    proxy_handler(State(state), Path((service_key, subpath)), req).await
 }
 
 // ─── tests ───────────────────────────────────────────────────────────────────
@@ -319,6 +368,42 @@ mod tests {
         );
     }
 
+    /// Why: normalize_base_url must be idempotent on a correctly-formed URL.
+    /// What: passes `http://127.0.0.1:7878`; asserts it is returned unchanged.
+    /// Test: this test itself.
+    #[test]
+    fn test_normalize_base_url_idempotent_on_correct_url() {
+        assert_eq!(
+            normalize_base_url("http://127.0.0.1:7878"),
+            "http://127.0.0.1:7878"
+        );
+    }
+
+    /// Why: a double-scheme URL (produced when a discovery file already contains
+    /// `http://` and detect_service prepends another) must be collapsed to one
+    /// scheme (#1849 Phase 2 double-scheme hardening).
+    /// What: passes `http://http://127.0.0.1:7878`; asserts `http://127.0.0.1:7878`.
+    /// Test: this test itself.
+    #[test]
+    fn test_normalize_base_url_collapses_double_http_scheme() {
+        assert_eq!(
+            normalize_base_url("http://http://127.0.0.1:7878"),
+            "http://127.0.0.1:7878"
+        );
+    }
+
+    /// Why: an https-prefixed discovery URL must also be normalised to http://
+    /// (all upstream connections are loopback HTTP only).
+    /// What: passes `https://127.0.0.1:7878`; asserts `http://127.0.0.1:7878`.
+    /// Test: this test itself.
+    #[test]
+    fn test_normalize_base_url_replaces_https_with_http() {
+        assert_eq!(
+            normalize_base_url("https://127.0.0.1:7878"),
+            "http://127.0.0.1:7878"
+        );
+    }
+
     /// Why: the SSRF guard must accept loopback IPv4, IPv6, and localhost but
     /// reject any other URL including external hosts and non-loopback RFC-1918.
     /// What: calls is_local_upstream with accepted and rejected URLs.
@@ -345,11 +430,11 @@ mod tests {
         assert!(!is_local_upstream("http://0.0.0.0:7878"));
     }
 
-    /// Why: full_id must map all known short keys to their trusty-* IDs.
+    /// Why: full_id must map all known short service keys to their trusty-* IDs.
     /// What: calls full_id for each known key and the unknown key.
     /// Test: this test itself.
     #[test]
-    fn test_daemon_key_mapping() {
+    fn test_service_key_mapping() {
         assert_eq!(full_id("search"), Some("trusty-search"));
         assert_eq!(full_id("memory"), Some("trusty-memory"));
         assert_eq!(full_id("analyze"), Some("trusty-analyze"));

--- a/crates/trusty-console/src/server.rs
+++ b/crates/trusty-console/src/server.rs
@@ -11,8 +11,10 @@
 //!   - `GET /api/console/metrics/analyze/visualize?index=<id>` — graph+entities+clusters.
 //!   - `…/api/console/sessions/*` — the single HTTP front door for the trusty-mpm
 //!     session manager (#1222); handlers live in `crate::routes::sessions`.
-//!   - `ANY /proxy/{daemon}/{*path}` — reverse-proxy to live daemon (mpm is NOT
-//!     in the proxy allowlist — operators use `/api/console/sessions/*` instead).
+//!   - `ANY /api/{service}/{*path}` — reverse-proxy to live daemon via clean path
+//!     (#1849 Phase 2); `{service}` ∈ {search, memory, analyze, review, mpm}.
+//!   - `ANY /proxy/{daemon}/{*path}` — DEPRECATED alias; routes to the same
+//!     handler with a trace-level deprecation note.
 //!   - `GET /` and `GET /ui/*path` — serve the embedded Svelte SPA.
 //!
 //! All logs go to stderr; stdout is clean.
@@ -351,8 +353,16 @@ pub fn build_router(state: AppState) -> Router {
             "/api/console/metrics/analyze/visualize",
             get(analyze_visualize_handler),
         )
-        // Reverse-proxy: /proxy/{daemon}/{*path}
-        .route("/proxy/{daemon}/{*path}", any(crate::proxy::proxy_handler))
+        // Primary reverse-proxy: /api/{service}/{*path} (#1849 Phase 2).
+        // {service} ∈ {search, memory, analyze, review, mpm}.
+        // No collision with /api/console/* — "console" is not a valid service key.
+        .route("/api/{service}/{*path}", any(crate::proxy::proxy_handler))
+        // Deprecated alias: /proxy/{daemon}/{*path} → same handler with a trace log.
+        // Kept for backward compatibility; callers should migrate to /api/{service}/*.
+        .route(
+            "/proxy/{daemon}/{*path}",
+            any(crate::proxy::deprecated_proxy_handler),
+        )
         .route("/", get(spa_index_handler))
         .route("/ui", get(spa_index_handler))
         .route("/ui/", get(spa_index_handler))
@@ -1028,11 +1038,88 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
-    /// Why: the proxy route for an unknown daemon key must return 400.
+    /// Why: the `/api/{service}/*` proxy route for an unknown service key must
+    /// return 400 (not a 404 route-miss, since the route pattern matches but the
+    /// handler rejects the key).
+    /// What: issues GET /api/unknown/health on the new primary path, asserts 400.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn test_api_proxy_unknown_service_returns_400() {
+        let router = build_router(make_test_state());
+
+        let req = Request::builder()
+            .uri("/api/unknown/health")
+            .body(Body::empty())
+            .expect("request");
+        let resp = router.oneshot(req).await.expect("response");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// Why: the `/api/{service}/*` route for a known service that is not running
+    /// must return 503 (cache cold) — proves the route reaches the proxy handler.
+    /// What: issues GET /api/search/health on a fresh state (no poll),
+    /// asserts 503 SERVICE_UNAVAILABLE.
+    /// Test: this test itself (#1849 Phase 2 primary path).
+    #[tokio::test]
+    async fn test_api_proxy_known_service_cold_cache_returns_503() {
+        let router = build_router(make_test_state());
+
+        let req = Request::builder()
+            .uri("/api/search/health")
+            .body(Body::empty())
+            .expect("request");
+        let resp = router.oneshot(req).await.expect("response");
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// Why: `mpm` must be reachable via the new `/api/mpm/*` path and must NOT
+    /// return 400 (key absent from allowlist).
+    /// What: issues GET /api/mpm/health on a fresh state (no poll),
+    /// asserts 503 SERVICE_UNAVAILABLE (not 400 BAD_REQUEST).
+    /// Test: this test itself (#1849 Phase 2).
+    #[tokio::test]
+    async fn test_api_proxy_mpm_is_in_allowlist_cold_cache_returns_503() {
+        let router = build_router(make_test_state());
+
+        let req = Request::builder()
+            .uri("/api/mpm/health")
+            .body(Body::empty())
+            .expect("request");
+        let resp = router.oneshot(req).await.expect("response");
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "/api/mpm/health must return 503 (mpm in allowlist, cache cold), not 400"
+        );
+    }
+
+    /// Why: the deprecated `/proxy/{daemon}/*` alias must still route to the
+    /// proxy handler; removing it would break external callers mid-migration.
+    /// What: issues GET /proxy/search/health on the deprecated path, asserts 503
+    /// (cache cold, not 404 route-miss or 400 key-rejected).
+    /// Test: this test itself (backward-compat guard for #1849 Phase 2).
+    #[tokio::test]
+    async fn test_deprecated_proxy_alias_still_routes() {
+        let router = build_router(make_test_state());
+
+        let req = Request::builder()
+            .uri("/proxy/search/health")
+            .body(Body::empty())
+            .expect("request");
+        let resp = router.oneshot(req).await.expect("response");
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "/proxy/search/health must return 503 via deprecated alias, not 404"
+        );
+    }
+
+    /// Why: the deprecated `/proxy/*` alias must also reject unknown service keys
+    /// with 400, not a silent 404 — proves the handler still validates the key.
     /// What: issues GET /proxy/unknown/health, asserts 400.
     /// Test: this test itself.
     #[tokio::test]
-    async fn test_proxy_unknown_daemon_returns_400() {
+    async fn test_deprecated_proxy_alias_unknown_key_returns_400() {
         let router = build_router(make_test_state());
 
         let req = Request::builder()
@@ -1041,23 +1128,6 @@ mod tests {
             .expect("request");
         let resp = router.oneshot(req).await.expect("response");
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    }
-
-    /// Why: the proxy route for a known daemon that is not running must return
-    /// 503 (cache not populated) when no poll has occurred yet.
-    /// What: issues GET /proxy/search/health on a fresh state (no poll),
-    /// asserts 503 SERVICE_UNAVAILABLE.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_proxy_known_daemon_cold_cache_returns_503() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/proxy/search/health")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     /// Why: #1849 Phase 1 adds `mpm` to the proxy allowlist. A request to

--- a/crates/trusty-console/src/server.rs
+++ b/crates/trusty-console/src/server.rs
@@ -355,7 +355,10 @@ pub fn build_router(state: AppState) -> Router {
         )
         // Primary reverse-proxy: /api/{service}/{*path} (#1849 Phase 2).
         // {service} ∈ {search, memory, analyze, review, mpm}.
-        // No collision with /api/console/* — "console" is not a valid service key.
+        // No collision with /api/console/*: axum (matchit 0.8) routes literal
+        // segments before wildcard captures, so /api/console/* always wins.
+        // The proxy handler also rejects service_key == "console" explicitly as // pragma: allowlist secret
+        // a routing-independent second layer of defence.
         .route("/api/{service}/{*path}", any(crate::proxy::proxy_handler))
         // Deprecated alias: /proxy/{daemon}/{*path} → same handler with a trace log.
         // Kept for backward compatibility; callers should migrate to /api/{service}/*.
@@ -1149,6 +1152,28 @@ mod tests {
             resp.status(),
             StatusCode::SERVICE_UNAVAILABLE,
             "/proxy/mpm/health must return 503 (mpm in allowlist, cache cold), not 400"
+        );
+    }
+
+    /// Why: the "console" service key is reserved for the console's own
+    /// /api/console/* namespace.  Issuing a request like /api/console/hijack
+    /// must never reach the reverse-proxy and be forwarded to an upstream; the
+    /// explicit guard in proxy_handler must return 400 before full_id is called.
+    /// What: issues GET /api/console/hijack on a fresh state, asserts 400.
+    /// Test: this test itself (#1849 Phase 2 console-key reservation guard).
+    #[tokio::test]
+    async fn test_api_proxy_console_key_returns_400() {
+        let router = build_router(make_test_state());
+
+        let req = Request::builder()
+            .uri("/api/console/hijack")
+            .body(Body::empty())
+            .expect("request");
+        let resp = router.oneshot(req).await.expect("response");
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "/api/console/<unregistered-path> must return 400 from the console guard, not 404"
         );
     }
 

--- a/crates/trusty-console/src/url_util.rs
+++ b/crates/trusty-console/src/url_util.rs
@@ -1,0 +1,92 @@
+//! URL scheme-stripping utilities shared across the console crate.
+//!
+//! Why: Both the service-connector layer (`detect/helpers.rs`) and the
+//! reverse-proxy layer (`proxy/routes.rs`) need to strip leading `http://` /
+//! `https://` scheme prefixes from discovered service addresses.  Centralising
+//! the core loop in one place prevents the logic from drifting between the two
+//! sites.
+//! What: `strip_schemes` is the single implementation; callers wrap it with
+//! their domain-specific formatting or normalization.
+//! Test: `test_strip_schemes_*` below; callers add domain-specific tests on
+//! top.
+
+/// Strip all leading `http://` and `https://` scheme prefixes from a string.
+///
+/// Why: Discovery addr files should contain bare `host:port` (e.g.
+/// `127.0.0.1:7788`), but a misconfigured or round-tripped value may include
+/// one or more scheme prefixes.  Removing all prefixes before composing a URL
+/// guarantees exactly one scheme at the call site and prevents double-scheme
+/// URLs like `http://http://127.0.0.1:7788`.
+/// What: Loops stripping `http://` or `https://` from the front of `s` until
+/// neither prefix is present; returns the remaining string slice (borrowed from
+/// `s`).  Allocation-free and idempotent.
+/// Test: `test_strip_schemes_*` below.
+pub(crate) fn strip_schemes(s: &str) -> &str {
+    let mut rest = s;
+    loop {
+        if let Some(t) = rest.strip_prefix("http://") {
+            rest = t;
+        } else if let Some(t) = rest.strip_prefix("https://") {
+            rest = t;
+        } else {
+            break;
+        }
+    }
+    rest
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: a bare addr must pass through unchanged — no allocations, no
+    /// modification.
+    /// What: calls strip_schemes("127.0.0.1:7788"); asserts identity.
+    /// Test: this test itself.
+    #[test]
+    fn test_strip_schemes_bare_unchanged() {
+        assert_eq!(strip_schemes("127.0.0.1:7788"), "127.0.0.1:7788");
+    }
+
+    /// Why: a single http:// prefix must be stripped.
+    /// What: calls strip_schemes("http://127.0.0.1:7788"); asserts bare addr.
+    /// Test: this test itself.
+    #[test]
+    fn test_strip_schemes_strips_http() {
+        assert_eq!(strip_schemes("http://127.0.0.1:7788"), "127.0.0.1:7788");
+    }
+
+    /// Why: a single https:// prefix must be stripped.
+    /// What: calls strip_schemes("https://127.0.0.1:7788"); asserts bare addr.
+    /// Test: this test itself.
+    #[test]
+    fn test_strip_schemes_strips_https() {
+        assert_eq!(strip_schemes("https://127.0.0.1:7788"), "127.0.0.1:7788");
+    }
+
+    /// Why: a double http:// (produced when detect_service prepends http:// to
+    /// an addr file that already contains http://) must be fully stripped.
+    /// What: calls strip_schemes("http://http://127.0.0.1:7788"); asserts bare addr.
+    /// Test: this test itself (double-scheme regression guard for #1849 Phase 2).
+    #[test]
+    fn test_strip_schemes_strips_double_http() {
+        assert_eq!(
+            strip_schemes("http://http://127.0.0.1:7788"),
+            "127.0.0.1:7788"
+        );
+    }
+
+    /// Why: a mixed https+http stack (e.g. https:// over http://) must be fully
+    /// stripped.
+    /// What: calls strip_schemes("https://http://127.0.0.1:7788"); asserts bare addr.
+    /// Test: this test itself.
+    #[test]
+    fn test_strip_schemes_strips_mixed_https_http() {
+        assert_eq!(
+            strip_schemes("https://http://127.0.0.1:7788"),
+            "127.0.0.1:7788"
+        );
+    }
+}

--- a/crates/trusty-console/ui/src/AnalyzeTab.svelte
+++ b/crates/trusty-console/ui/src/AnalyzeTab.svelte
@@ -130,7 +130,7 @@
     clusters = [];
     try {
       // Use the console's own API route — the console calls trusty-analyze over
-      // stdio MCP internally. No /proxy/analyze usage from the browser (#1104).
+      // stdio MCP internally. No /api/analyze/* usage from the browser (#1104).
       const resp = await fetch(
         `/api/console/metrics/analyze/visualize?index=${encodeURIComponent(indexId)}`
       );


### PR DESCRIPTION
Part of #1849

## Summary

- **Route rename**: Add primary `/api/{service}/{*path}` reverse-proxy route alongside a deprecated `/proxy/{daemon}/{*path}` alias. The alias logs a `trace`-level deprecation note and delegates to the same handler, so existing callers keep working without a hard break.
- **No collision**: Console's own `/api/console/*` routes are unaffected — `"console"` is not a valid service key in the allowlist.
- **URL hardening** (#1850 review finding): Two independent layers prevent double-scheme URLs (`http://http://...`):
  - `normalize_addr()` in `detect_service` (connector layer) strips any scheme from the discovery file addr before composing `http://{addr}`.
  - `normalize_base_url()` in `proxy_handler` (proxy layer) loops stripping all scheme prefixes and re-adds exactly one `http://`.

## Final scheme

| Path | Status |
|---|---|
| `ANY /api/{service}/{*path}` | **Primary** (new, #1849 Phase 2) |
| `ANY /proxy/{daemon}/{*path}` | **Deprecated alias** (kept for backward compat, traces a deprecation note) |

`{service}` ∈ `search`, `memory`, `analyze`, `review`, `mpm` — same allowlist as before.

## Consumers updated

- `src/proxy/routes.rs` — new route handler, `normalize_base_url`, renamed `daemon_key` → `service_key`, `deprecated_proxy_handler`
- `src/proxy/mod.rs` — updated exports and doc
- `src/server.rs` — wired both routes; updated + 5 new tests
- `src/detect/helpers.rs` — `normalize_addr` + use in `detect_service` + 3 tests
- `src/detect/mpm.rs` — doc comment path update
- `ui/src/AnalyzeTab.svelte` — doc comment path update (comment only, no fetch calls)
- **ui-dist**: No rebuild needed — SPA never calls `/proxy/` directly (confirmed by grep)

## Test plan

- [ ] `cargo fmt --check -p trusty-console` — clean (no output = pass)
- [ ] `cargo clippy -p trusty-console --all-targets -- -D warnings` — clean
- [ ] `cargo test -p trusty-console` — 131 passed, 0 failed
- [ ] `bash scripts/check_line_cap.sh` — `14 allowlisted, 0 violations — OK`
- [ ] Live verification: console on :18989 + stub daemon on :64962 → `GET /api/mpm/health` → 200 (proxied JSON), `GET /proxy/mpm/health` → 200 (deprecated alias works), `GET /api/unknown/health` → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)