### PR TITLE
feat(trusty-mpm): route tm CLI through console gateway with direct fallback

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
@@ -52,6 +52,12 @@ pub(crate) async fn run_daemon(addr: SocketAddr, tailscale: bool, mcp: bool) -> 
     // original. `resolve_daemon_url` already validates the recorded PID is
     // alive (and clears stale lock files), so a `None`-ish result here means
     // either no lock exists or the recorded daemon is dead — proceed normally.
+    //
+    // INTENTIONALLY kept on the sync direct-lock resolver (#1849 Phase 2): the
+    // daemon is starting up here; the console gateway isn't relevant — and its
+    // async probe would require bootstrapping a reqwest::Client before the bind
+    // address is even known. Bootstrap circularity means only the lock file
+    // is authoritative at this point.
     let recorded_url = trusty_mpm::core::resolve_daemon_url(None);
     if recorded_url != trusty_mpm::core::DEFAULT_DAEMON_URL
         && trusty_common::probe_health(&recorded_url, "/health").await

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -155,14 +155,18 @@ pub(crate) async fn doctor(url: &str) -> anyhow::Result<()> {
 /// fresh, how big is the fleet?" probe. Routing it through the shared
 /// [`CommandExecutor`] (rather than a bespoke `reqwest` call here) means the CLI
 /// shares the exact `health` dispatch with every other adapter — a single source
-/// of truth per the chat-core nucleus.
+/// of truth per the chat-core nucleus. The `resolved:` line tells operators
+/// whether traffic is flowing via the trusty-console gateway or direct to the
+/// daemon, making the resolution path transparent (#1849 Phase 2).
 /// What: runs [`TrustyCommand::Health`] through the executor and prints a compact,
 /// scriptable summary. A dead daemon prints `daemon: unreachable` and is NOT an
-/// error exit (the probe succeeded in determining the daemon is down).
+/// error exit (the probe succeeded in determining the daemon is down). The
+/// `resolved:` line is printed only on success so unreachable output is unchanged.
 /// Test: `cli_parses_health` covers parsing; the executor's `execute_health_*`
 /// tests cover the live and dead-daemon report paths.
 pub(crate) async fn health(url: &str) -> anyhow::Result<()> {
     use trusty_mpm::client::{CommandExecutor, CommandResult, TrustyCommand};
+    use trusty_mpm::core::GATEWAY_PATH;
 
     let executor = CommandExecutor::new(url.to_string());
     match executor.execute(TrustyCommand::Health).await {
@@ -177,7 +181,15 @@ pub(crate) async fn health(url: &str) -> anyhow::Result<()> {
             } else {
                 "up to date"
             };
+            // Indicate the resolution path so operators can see whether traffic
+            // is flowing via the console gateway or direct to the daemon.
+            let resolved_via = if url.contains(GATEWAY_PATH) {
+                format!("via gateway {url}")
+            } else {
+                format!("direct {url}")
+            };
             println!("daemon: {} ({})", report.status, report.url);
+            println!("resolved: {resolved_via}");
             println!("catalog: {catalog}");
             println!(
                 "fleet: {} session(s), {} awaiting a decision",

--- a/crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs
@@ -70,6 +70,13 @@ fn build_bridge_config() -> DaemonBridgeConfig {
         // arg is passed (matches `tm start`).
         spawn_args: vec!["daemon".to_string()],
         health_path: "/health".to_string(),
+        // INTENTIONALLY kept on the sync direct-lock resolver (#1849 Phase 2):
+        // the stdio bridge calls this closure on every reconnect to track the
+        // daemon's current port. The gateway resolver is async and requires a
+        // reqwest::Client; the `base_url_fn` signature is synchronous. Routing
+        // the MCP bridge through the gateway would also add latency on every
+        // JSON-RPC call and create a dependency on the console being up — an
+        // unacceptable regression for the core MCP path.
         base_url_fn: Box::new(|| trusty_mpm::core::resolve_daemon_url(None)),
         startup_timeout: None, // shared 30s default
         poll_interval: None,   // shared 500ms default

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -191,15 +191,16 @@ async fn main() -> anyhow::Result<()> {
 
     let client = reqwest::Client::new();
     // Resolve the daemon URL once with gateway-first probing:
-    //   1. Explicit --url/TRUSTY_MPM_URL (non-default) → use directly.
+    //   1. Explicit --url/TRUSTY_MPM_URL that is non-empty AND not equal to
+    //      DEFAULT_DAEMON_URL → use directly, bypassing the gateway.
+    //      (A value equal to DEFAULT_DAEMON_URL is treated as "no real override"
+    //      — the clap-injected default — so the gateway probe still runs.)
     //   2. trusty-console gateway (`http://{console}/api/mpm`) if the console is
     //      running and the daemon is reachable through it (#1849 Phase 2).
     //   3. Lock file (daemon may bind to an ephemeral port) → default.
     // The gateway path routes all `tm` traffic through the unified web UI while
     // preserving full direct-fallback behaviour when the console is absent.
-    // Explicit non-default URLs bypass the gateway so `--url http://…:9999`
-    // still works, and stale TRUSTY_MPM_URL values (#1731) are still probed
-    // before falling back.
+    // Stale TRUSTY_MPM_URL values (#1731) are still probed before falling back.
     let url = trusty_mpm::core::resolve_daemon_url_via_gateway(&client, Some(&cli.url)).await;
     // Why: handlers return `anyhow::Result`; we capture the dispatch result here
     // so the top-level boundary can translate the typed `PruneError::SmUnavailable`

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -190,13 +190,17 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let client = reqwest::Client::new();
-    // Resolve the daemon URL once: explicit --url/TRUSTY_MPM_URL wins (but only
-    // when reachable), then lock file (daemon may bind to an ephemeral port),
-    // then default. Using the probing variant prevents a stale TRUSTY_MPM_URL
-    // (e.g. :7881 while the daemon is on :7880) from permanently breaking `tm`
-    // (#1731). Non-default explicit URLs that ARE reachable still win
-    // immediately so `--url http://…:9999` continues to work.
-    let url = trusty_mpm::core::resolve_daemon_url_probing(&client, Some(&cli.url)).await;
+    // Resolve the daemon URL once with gateway-first probing:
+    //   1. Explicit --url/TRUSTY_MPM_URL (non-default) → use directly.
+    //   2. trusty-console gateway (`http://{console}/api/mpm`) if the console is
+    //      running and the daemon is reachable through it (#1849 Phase 2).
+    //   3. Lock file (daemon may bind to an ephemeral port) → default.
+    // The gateway path routes all `tm` traffic through the unified web UI while
+    // preserving full direct-fallback behaviour when the console is absent.
+    // Explicit non-default URLs bypass the gateway so `--url http://…:9999`
+    // still works, and stale TRUSTY_MPM_URL values (#1731) are still probed
+    // before falling back.
+    let url = trusty_mpm::core::resolve_daemon_url_via_gateway(&client, Some(&cli.url)).await;
     // Why: handlers return `anyhow::Result`; we capture the dispatch result here
     // so the top-level boundary can translate the typed `PruneError::SmUnavailable`
     // (issue #1313) into the documented exit code 75. Doing the `process::exit`

--- a/crates/trusty-mpm/src/core/discovery.rs
+++ b/crates/trusty-mpm/src/core/discovery.rs
@@ -234,10 +234,27 @@ async fn resolve_daemon_url_via_gateway_inner(
     }
 
     // b) Gateway probe — build the gateway base URL and probe its /health.
-    //    The console proxies `GET /api/mpm/health` → daemon `GET /health`.
-    //    A 200 means the daemon is reachable through the gateway; use it.
+    //    `probe_url` appends "/health", so the actual request is:
+    //    `GET http://{console}/api/mpm/health`, which the console proxy
+    //    forwards to the daemon's `GET /health`.
+    //
+    //    IMPORTANT: use a **dedicated** short-timeout client for this probe,
+    //    independent of the caller's `client`. The caller's client (from
+    //    `reqwest::Client::new()` in main.rs) carries no timeout by default
+    //    (reqwest's default is effectively unlimited). A slow or unreachable
+    //    console must NEVER stall every `tm` command for up to 30 seconds —
+    //    the gateway probe must fail fast and fall through to the direct path.
+    //    The per-request `.timeout()` in `probe_url` provides a second line of
+    //    defense; the client-level timeout here is the primary guarantee.
+    let probe_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(500))
+        .build()
+        // Client::builder().timeout(...).build() is infallible without custom
+        // TLS or certificate configuration — both are absent here.
+        .expect("gateway probe client is infallible");
+
     let gateway_base = format!("http://{console_addr}{GATEWAY_PATH}");
-    if probe_url(client, &gateway_base).await {
+    if probe_url(&probe_client, &gateway_base).await {
         return gateway_base;
     }
 
@@ -470,29 +487,41 @@ mod tests {
         );
     }
 
-    /// Gateway is used when the console probe returns 200.
+    /// Gateway is used when the console probe returns 200, and the probe
+    /// specifically targets `/api/mpm/health` — not the bare base URL.
     ///
     /// Why: the primary goal of gateway resolution — when the console is
     /// running and the daemon is reachable through it, all `tm` traffic should
-    /// route via `http://{console}/api/mpm`.
-    /// What: binds an ephemeral TCP listener that responds with HTTP 200, uses
-    /// its address as the injected `console_addr`, calls
-    /// `resolve_daemon_url_via_gateway_inner` with no explicit override, and
-    /// asserts the returned URL is the gateway base URL.
+    /// route via `http://{console}/api/mpm`. Confirming the probe path prevents
+    /// a regression where a bare GET /api/mpm (empty suffix) gets routed
+    /// differently from GET /api/mpm/health by the proxy, causing spurious
+    /// fallback to direct even when the gateway is healthy.
+    /// What: binds an ephemeral TCP listener that reads the request line and
+    /// asserts it is `GET /api/mpm/health …` before responding HTTP 200; uses
+    /// its address as the injected `console_addr`; calls
+    /// `resolve_daemon_url_via_gateway_inner` with no explicit override; asserts
+    /// the returned URL is the gateway base URL.
     /// Test: this test.
     #[tokio::test]
     async fn resolve_via_gateway_uses_gateway_when_probe_succeeds() {
-        use tokio::io::AsyncWriteExt as _;
+        use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind listener");
         let addr = listener.local_addr().expect("local_addr");
 
-        // Respond HTTP 200 to any connection (simulates console + daemon healthy).
+        // Capture the request line to confirm the probe targets /api/mpm/health.
+        let (path_tx, path_rx) = tokio::sync::oneshot::channel::<String>();
         tokio::spawn(async move {
-            if let Ok((mut sock, _)) = listener.accept().await {
-                let _ = sock
+            if let Ok((sock, _)) = listener.accept().await {
+                let (reader, mut writer) = sock.into_split();
+                let mut lines = BufReader::new(reader).lines();
+                let req_line = lines.next_line().await.unwrap().unwrap_or_default();
+                let _ = path_tx.send(req_line);
+                // Respond 200 only after capturing the line so the reqwest
+                // future sees the status and probe_url returns true.
+                let _ = writer
                     .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok")
                     .await;
             }
@@ -506,6 +535,13 @@ mod tests {
         assert_eq!(
             result, expected_gateway,
             "gateway URL must be returned when console probe succeeds"
+        );
+
+        // Verify the probe hit /api/mpm/health, not the bare /api/mpm base.
+        let req_line = path_rx.await.expect("request line must be captured");
+        assert!(
+            req_line.starts_with("GET /api/mpm/health "),
+            "gateway probe must target /api/mpm/health; got: {req_line:?}"
         );
     }
 

--- a/crates/trusty-mpm/src/core/discovery.rs
+++ b/crates/trusty-mpm/src/core/discovery.rs
@@ -4,8 +4,11 @@
 //! The lock file records the actual address so clients always find it.
 //! What: `resolve_daemon_url` checks an explicit override first, then
 //! reads `~/.trusty-mpm/daemon.lock`, then falls back to the hard-coded
-//! default.
-//! Test: The unit tests below cover all three resolution paths.
+//! default. `resolve_daemon_url_via_gateway` additionally tries the
+//! trusty-console gateway first so all traffic can flow through the
+//! unified web UI when it is running.
+//! Test: The unit tests below cover all resolution paths, including the
+//! gateway probe, explicit-override bypass, and direct fallback.
 
 use std::path::PathBuf;
 
@@ -36,6 +39,26 @@ pub const DEFAULT_DAEMON_ADDR: &str = "127.0.0.1:7880";
 /// the [`default_url_matches_addr`] test guarantees the two stay in lockstep.
 /// Test: `default_url_matches_addr`.
 pub const DEFAULT_DAEMON_URL: &str = "http://127.0.0.1:7880";
+
+/// Default trusty-console HTTP address (host:port) used when the console's
+/// discovery file is absent or unreadable.
+///
+/// Why: trusty-console defaults to 127.0.0.1:7788; mirroring that here lets
+/// the gateway resolver fall back to the expected address without importing
+/// trusty-console (which would create a circular dependency between crates).
+/// What: the literal `"127.0.0.1:7788"`, matching `trusty_console::DEFAULT_HTTP`.
+/// Test: `resolve_via_gateway_falls_back_to_direct_on_probe_failure`.
+pub const DEFAULT_CONSOLE_ADDR: &str = "127.0.0.1:7788";
+
+/// Path at which the trusty-console proxies the MPM daemon.
+///
+/// Why: a single constant prevents the gateway path `/api/mpm` from being
+/// hard-coded in both the resolver and any caller that needs to detect whether
+/// a resolved URL is routing via the gateway (e.g. `tm health` display).
+/// What: the literal `"/api/mpm"` — appended to the console base URL to form
+/// the gateway base, e.g. `http://127.0.0.1:7788/api/mpm`.
+/// Test: `resolve_via_gateway_uses_gateway_when_probe_succeeds`.
+pub const GATEWAY_PATH: &str = "/api/mpm";
 
 /// Parse [`DEFAULT_DAEMON_ADDR`] into a [`SocketAddr`].
 ///
@@ -148,6 +171,80 @@ pub async fn resolve_daemon_url_probing(
 
     // No real explicit override: delegate to the sync resolver.
     resolve_daemon_url(explicit)
+}
+
+/// Resolve the daemon URL routing through the trusty-console gateway when
+/// possible, with seamless fallback to the direct daemon when the console is
+/// not running.
+///
+/// Why: when the trusty-console is up it proxies `ANY /api/mpm/{path}` to the
+/// MPM daemon, so all `tm` traffic can flow through the unified web UI — with
+/// future benefits like audit logging and auth. Direct fallback (lock file →
+/// default) ensures `tm` still works when the console is not running, with no
+/// operator action required. The gateway-first approach is gated on a live
+/// probe so a stale console discovery file never breaks the CLI.
+///
+/// Precedence:
+///   a) Explicit user override (non-empty, non-default `--url` /
+///      `TRUSTY_MPM_URL`) → use it directly; the operator chose a specific
+///      address, so the gateway is bypassed entirely.
+///   b) Gateway probe: read the console address from its discovery file
+///      (falling back to `DEFAULT_CONSOLE_ADDR`). Construct
+///      `http://{console}/api/mpm` and probe `GET .../health` with a 500 ms
+///      timeout. If it returns 200 → return the gateway base URL.
+///   c) Direct fallback: delegate to `resolve_daemon_url_probing` (lock file →
+///      `DEFAULT_DAEMON_URL`). This path is taken whenever the console is
+///      absent or the gateway probe fails.
+///
+/// Test: `resolve_via_gateway_explicit_override_wins`,
+///       `resolve_via_gateway_uses_gateway_when_probe_succeeds`,
+///       `resolve_via_gateway_falls_back_to_direct_on_probe_failure`.
+pub async fn resolve_daemon_url_via_gateway(
+    client: &reqwest::Client,
+    explicit: Option<&str>,
+) -> String {
+    let console_addr = trusty_common::read_daemon_addr("trusty-console")
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| DEFAULT_CONSOLE_ADDR.to_string());
+    resolve_daemon_url_via_gateway_inner(client, explicit, &console_addr).await
+}
+
+/// Inner implementation of the gateway resolver with an injected console addr.
+///
+/// Why: separates the file-system read (`read_daemon_addr`) from the probe
+/// logic so tests can supply a controlled address without touching disk or
+/// manipulating `$HOME`.
+/// What: implements the three-step precedence (explicit override → gateway
+/// probe → direct fallback) using the caller-supplied `console_addr`.
+/// Test: called directly by the `resolve_via_gateway_*` test cases.
+async fn resolve_daemon_url_via_gateway_inner(
+    client: &reqwest::Client,
+    explicit: Option<&str>,
+    console_addr: &str,
+) -> String {
+    // a) Explicit override — same "clap default is not a real override" rule as
+    //    the other resolvers. A non-default, non-empty explicit URL bypasses the
+    //    gateway entirely so `--url http://…:9999` continues to work.
+    if let Some(url) = explicit
+        && !url.is_empty()
+        && url != DEFAULT_DAEMON_URL
+    {
+        return url.to_string();
+    }
+
+    // b) Gateway probe — build the gateway base URL and probe its /health.
+    //    The console proxies `GET /api/mpm/health` → daemon `GET /health`.
+    //    A 200 means the daemon is reachable through the gateway; use it.
+    let gateway_base = format!("http://{console_addr}{GATEWAY_PATH}");
+    if probe_url(client, &gateway_base).await {
+        return gateway_base;
+    }
+
+    // c) Direct fallback — console absent or gateway probe failed. Delegate to
+    //    the direct-daemon resolver chain (lock file → DEFAULT_DAEMON_URL) so
+    //    `tm` still works when only the daemon is running.
+    resolve_daemon_url_probing(client, explicit).await
 }
 
 /// Probe a URL for reachability with a short timeout.
@@ -348,6 +445,97 @@ mod tests {
         assert_eq!(
             result, url,
             "reachable explicit URL must win over lock file / default"
+        );
+    }
+
+    // ── resolve_daemon_url_via_gateway tests (#1849 Phase 2) ─────────────────
+
+    /// Explicit user-supplied URL bypasses the gateway entirely.
+    ///
+    /// Why: `--url http://…:9999` must still win when the operator deliberately
+    /// overrides the address. The gateway resolver must not intercept it.
+    /// What: calls `resolve_daemon_url_via_gateway_inner` with a non-default,
+    /// non-empty explicit URL and a dummy console addr; asserts the explicit
+    /// URL is returned unchanged.
+    /// Test: this test.
+    #[tokio::test]
+    async fn resolve_via_gateway_explicit_override_wins() {
+        let client = reqwest::Client::new();
+        let explicit = "http://127.0.0.1:9999";
+        let result =
+            resolve_daemon_url_via_gateway_inner(&client, Some(explicit), "127.0.0.1:1").await;
+        assert_eq!(
+            result, explicit,
+            "explicit override must win over gateway probe"
+        );
+    }
+
+    /// Gateway is used when the console probe returns 200.
+    ///
+    /// Why: the primary goal of gateway resolution — when the console is
+    /// running and the daemon is reachable through it, all `tm` traffic should
+    /// route via `http://{console}/api/mpm`.
+    /// What: binds an ephemeral TCP listener that responds with HTTP 200, uses
+    /// its address as the injected `console_addr`, calls
+    /// `resolve_daemon_url_via_gateway_inner` with no explicit override, and
+    /// asserts the returned URL is the gateway base URL.
+    /// Test: this test.
+    #[tokio::test]
+    async fn resolve_via_gateway_uses_gateway_when_probe_succeeds() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("local_addr");
+
+        // Respond HTTP 200 to any connection (simulates console + daemon healthy).
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let _ = sock
+                    .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok")
+                    .await;
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let console_addr = addr.to_string();
+        let result = resolve_daemon_url_via_gateway_inner(&client, None, &console_addr).await;
+
+        let expected_gateway = format!("http://{console_addr}{GATEWAY_PATH}");
+        assert_eq!(
+            result, expected_gateway,
+            "gateway URL must be returned when console probe succeeds"
+        );
+    }
+
+    /// Direct fallback is used when the gateway probe fails.
+    ///
+    /// Why: when the console is not running (port 1 is always refused) the
+    /// resolver must fall through to the direct daemon chain, not return the
+    /// unreachable gateway URL.
+    /// What: calls `resolve_daemon_url_via_gateway_inner` with port 1 as the
+    /// console addr (always refused) and no explicit override; asserts the
+    /// result is a valid HTTP URL and NOT the failed gateway URL.
+    /// Test: this test.
+    #[tokio::test]
+    async fn resolve_via_gateway_falls_back_to_direct_on_probe_failure() {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(200))
+            .build()
+            .expect("build client");
+        // Port 1 is reserved and never listening — probe must fail immediately.
+        let dead_console = "127.0.0.1:1";
+        let result = resolve_daemon_url_via_gateway_inner(&client, None, dead_console).await;
+
+        let gateway_url = format!("http://{dead_console}{GATEWAY_PATH}");
+        assert!(
+            result.starts_with("http"),
+            "fallback must still return an HTTP URL, got: {result}"
+        );
+        assert_ne!(
+            result, gateway_url,
+            "must not return the unreachable gateway URL on probe failure"
         );
     }
 

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -71,7 +71,8 @@ pub mod workspace_scan;
 
 pub use connect::{ResolveResult, SessionSummary, resolve_target};
 pub use discovery::{
-    DEFAULT_DAEMON_ADDR, DEFAULT_DAEMON_URL, default_daemon_addr, lock_file_path,
-    resolve_daemon_url, resolve_daemon_url_probing,
+    DEFAULT_CONSOLE_ADDR, DEFAULT_DAEMON_ADDR, DEFAULT_DAEMON_URL, GATEWAY_PATH,
+    default_daemon_addr, lock_file_path, resolve_daemon_url, resolve_daemon_url_probing,
+    resolve_daemon_url_via_gateway,
 };
 pub use error::{Error, Result};


### PR DESCRIPTION
## Summary

- Adds `resolve_daemon_url_via_gateway` in `core/discovery.rs` implementing gateway-first URL resolution: explicit user override → console gateway probe (`http://{console}/api/mpm`) → direct daemon (lock file → default)
- Wires `main.rs` CLI dispatch to the new resolver so all `tm` subcommands route through the gateway when the console is running, with seamless direct fallback when it is not
- Updates `tm health` to print a `resolved: via gateway …` / `resolved: direct …` line so operators can see which resolution path traffic is taking
- Adds three new unit tests: `resolve_via_gateway_explicit_override_wins`, `resolve_via_gateway_uses_gateway_when_probe_succeeds`, `resolve_via_gateway_falls_back_to_direct_on_probe_failure`
- Adds `DEFAULT_CONSOLE_ADDR` (`127.0.0.1:7788`) and `GATEWAY_PATH` (`/api/mpm`) constants, re-exported from `trusty_mpm::core`

**Intentionally kept on the sync direct-lock resolver to avoid bootstrap circularity:**
- `daemon_run.rs:55` — daemon singleton-guard (daemon is starting; console gateway not available yet; async probe would require bootstrapping a client before bind address is known)
- `serve_stdio.rs` — MCP stdio bridge (`base_url_fn` is a sync closure called on every reconnect; async gateway resolver cannot be used here; routing MCP through the gateway would also add latency and create a console dependency on the critical MCP path)
- `main.rs:234` — TUI path (left on sync resolver as noted)
- Sync attach/TUI session paths in `session.rs`, `misc.rs` (sync context, local liveness indicator)

## Test plan

- [ ] `cargo test -p trusty-mpm` — all pass including 3 new resolver tests
- [ ] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] `bash scripts/check_line_cap.sh` — 0 violations
- [ ] Live: `tm health` with mock gateway → `resolved: via gateway http://…/api/mpm`
- [ ] Live: `tm health` with no console → `resolved: direct http://127.0.0.1:7880`
- [ ] Live: `tm session ls` through proxy gateway → real session data proxied correctly

Part of #1849 (loopback-only/tailscale scoping remains deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)