### PR TITLE
chore(release): trusty-common v0.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6247,7 +6247,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10752,7 +10752,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Added
+
+- wire trusty-mpm into console reverse proxy ([#1850](https://github.com/bobmatnyc/trusty-tools/pull/1850)) ([`970d297`](https://github.com/bobmatnyc/trusty-tools/commit/970d297bf9448cf74b3117445401524bd17b20e4))
+- detach returns to tm picker + daemon/clone cwd hardening ([#1795](https://github.com/bobmatnyc/trusty-tools/pull/1795)) ([`3b0e723`](https://github.com/bobmatnyc/trusty-tools/commit/3b0e7231e85ca8fbc53dbd55bb4968d4d96e811c))
+
+### Fixed
+
+- warn on skipped malformed claude-mpm session in catchup ([#1762](https://github.com/bobmatnyc/trusty-tools/pull/1762)) ([#1769](https://github.com/bobmatnyc/trusty-tools/pull/1769)) ([`e0b2e7c`](https://github.com/bobmatnyc/trusty-tools/commit/e0b2e7c47cc426d5dd19df37c08d54b53bd436e3))
+
+### Changed
+
+- extract DOC-28 catch-up engine behind catchup feature (PR1, #1762) ([`addfdbb`](https://github.com/bobmatnyc/trusty-tools/commit/addfdbb04ed78028887a0e782afe7cfe83c10b46))
 ## [0.18.0] — 2026-06-25
 
 ### Added

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Bumps `trusty-common` from `0.18.1` to `0.18.2` (patch). The published `0.18.1` on crates.io predates the `catchup` feature (added in commit `addfdbb0`, "extract DOC-28 catch-up engine behind catchup feature", PR #1762), which landed in-tree AFTER `0.18.1` was published without a version bump. `trusty-mpm` v0.13.0 depends on `trusty-common` with the `catchup` feature enabled, so `cargo publish -p trusty-mpm` is currently blocked — publishing `0.18.2` (which already has the feature in-tree) unblocks it.
- Patch bump is correct: the `catchup` feature flag is additive/opt-in (`catchup = ["dep:rusqlite"]`), fully backward-compatible. Existing `^0.18.1` dependents (including trusty-mpm, and the root workspace `Cargo.toml`'s `version = "0.18.1"` requirement) resolve to `0.18.2` automatically — no dependent Cargo.toml edits needed.
- CHANGELOG's `[Unreleased]` section (generated by `scripts/generate-changelog.sh`) already captured all 4 commits touching `crates/trusty-common` since the `trusty-common-v0.18.1` tag: the `catchup` feature extraction (#1762 / `addfdbb0`), the malformed-session warning fix (#1769/#1762), and two trusty-mpm console-proxy related additions (#1850, #1795). Verified against `git log trusty-common-v0.18.1..HEAD --oneline -- crates/trusty-common` — nothing missing.

## Verification

- Confirmed premise: `crates/trusty-common/Cargo.toml` had `version = "0.18.1"` and `catchup = ["dep:rusqlite"]` present in `[features]` before the bump.
- Grepped for hard `=0.18.1` exact-pin dependents: none found. The only `0.18.1` match is the root workspace's `version = "0.18.1"` (implicit `^0.18.1` caret requirement), satisfied by `0.18.2`.
- `SKIP_UI_BUILD=1 cargo build -p trusty-common` — clean build at `v0.18.2`.
- `cargo test -p trusty-common --features memory-core,embedder-test-support` — 437 passed, 0 failed (pre-existing feature-gating: `-p trusty-common` alone with default features fails on `tests/memory_palace.rs`, which requires `memory-core`; confirmed via git-stash comparison that this is unrelated to this bump and pre-exists on `origin/main`).
- `cargo clippy -p trusty-common --all-targets --features memory-core,embedder-test-support -- -D warnings` — clean, 0 warnings.
- `cargo fmt --check` — clean.
- `cargo check -p trusty-mpm` and `cargo test -p trusty-mpm` — clean; 3462 passed, 0 failed across all trusty-mpm test binaries, confirming trusty-mpm builds and tests fine against `trusty-common 0.18.2`.

## Test plan

- [x] Version bumped 0.18.1 → 0.18.2 via `scripts/bump-version.sh`
- [x] CHANGELOG `[Unreleased]` section verified complete against git log
- [x] No dependent Cargo.toml requires editing (no exact pins found)
- [x] `cargo build -p trusty-common` clean
- [x] `cargo test -p trusty-common` (with required features) — 437/437 passed
- [x] `cargo clippy -p trusty-common --all-targets` (with required features) — 0 warnings
- [x] `cargo fmt --check` clean
- [x] `cargo check -p trusty-mpm` clean
- [x] `cargo test -p trusty-mpm` — 3462/3462 passed
- [ ] CI green (watching)
- [ ] Do NOT merge/tag/publish — awaiting human approval per release convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)