### PR TITLE
feat(trusty-mpm): DOC-28 self-awareness (R1–R4) (#1855)

### DIFF
--- a/crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md
+++ b/crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md
@@ -1,0 +1,122 @@
+# What Is trusty-mpm?
+
+trusty-mpm is a **Rust** crate at `crates/trusty-mpm/`, distributed as a single
+binary — **`tm`** (also installable as `trusty-mpm`) — whose subcommands
+provide the background daemon, the CLI, the TUI dashboard, and the Telegram
+bot surfaces. It is the **Meta-Harness** / control plane described in
+[Three-Harness Architecture](../../../docs/architecture/harnesses.md): it
+manages multi-project Claude Code sessions, relays lifecycle hooks, and
+exposes an MCP server — it does **not** execute coding work itself, it
+delegates all coding tasks to **`trusty-code`** (`tcode`). It is **not** the
+Python `claude-mpm` package: no code relation, different language (Rust vs.
+Python), different maintainers, and a different distribution channel
+(crates.io/Homebrew vs. PyPI).
+
+This document exists because a Claude Code session asked "are you self-aware
+of the framework?" and answered incorrectly — it shell-probed
+(`pip3 show claude-mpm`, `which claude-mpm`) instead of consulting memory or a
+canonical doc, and it conflated this Rust project with the unrelated Python
+one. See [DOC-28 — trusty-mpm Self-Awareness](../../../docs/specs/trusty-mpm-self-awareness.md)
+for the full incident writeup and the behavior contract this doc is part of.
+**This is the single, stable, canonically-pointed-at answer to "what is this
+framework" — consult it (and memory) instead of shell-probing.**
+
+## The one-paragraph answer
+
+If you are a Claude Code session running under trusty-mpm and someone asks
+what framework/tool/system this is: you are working inside a project managed
+by **trusty-mpm** (binary `tm`), a **Rust** Meta-Harness / control-plane
+daemon that launches, observes, and coordinates Claude Code sessions across
+one or more projects. trusty-mpm itself never writes code — every unit of
+real implementation work is delegated to a launched session, which in turn
+runs under **`trusty-code`** (`tcode`), the per-project coding harness. If the
+question could plausibly be about the Python **`claude-mpm`** project: that is
+a *different, unrelated* tool — different repository, different language,
+different maintainers — and this doc, this session, and this repo have
+nothing to do with it.
+
+## What trusty-mpm is (and is not)
+
+| | trusty-mpm (this project) | Python `claude-mpm` |
+|---|---|---|
+| Language | Rust | Python |
+| Binary / package | `tm` / `trusty-mpm` | `claude-mpm` |
+| Distribution | crates.io, Homebrew, GitHub Releases | PyPI |
+| Role | Meta-Harness / control plane (DOC-26) | unrelated Claude Code agent-fleet + output-style layer |
+| Repository | `trusty-tools` (this repo) | a separate, unrelated repository |
+| Relationship to this repo | **is** this repo's `crates/trusty-mpm/` | **none** |
+
+trusty-mpm:
+
+- Manages multi-project sessions (`tm sessions`, `tm run`, `tm load`) and
+  their lifecycle (spawn, observe, decommission).
+- Exposes an MCP server (`mcp__trusty-mpm__*` tools) that Claude Code sessions
+  and other trusty-* tools call into.
+- Assembles and deploys the PM/SM system prompts, agents, skills, and output
+  styles that a launched session runs under.
+- Delegates **all** coding work — edits, builds, tests, research — to a
+  launched session running `trusty-code` (`tcode`); it has no "hands" of its
+  own.
+
+See [Three-Harness Architecture](../../../docs/architecture/harnesses.md) for
+the full three-harness (trusty-code / trusty-mpm / trusty-agents) delegation
+graph, and
+[DOC-26 — trusty-mpm alpha-1 control plane](../../../docs/specs/trusty-mpm-alpha-1-control-plane.md)
+for the control-plane wire protocol and session lifecycle contract. This doc
+deliberately summarizes rather than duplicates those two references — treat
+them as the deeper architectural and protocol sources of truth.
+
+## How to answer an identity question (for a running session)
+
+Per the
+[Identity & Self-Awareness Protocol](../../../docs/specs/trusty-mpm-self-awareness.md#4-r2--identityself-awareness-protocol-in-instruction-assets-specselfaware-02draft)
+(bundled into `BASE_SM.md` and every output style — see that spec for the
+exact wording):
+
+1. **Consult memory first** — call `get_prompt_context()` / `memory_recall`
+   against the active trusty-memory palace before answering.
+2. **Then consult this doc** — read it from
+   `~/.trusty-mpm/framework/docs/WHAT-IS-TRUSTY-MPM.md` (deployed by
+   `tm install`), or, inside the trusty-tools repo itself, from
+   `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md` via `trusty-search` or a
+   direct file read.
+3. **Never shell-probe for identity** — `pip3 show`, `pip show`,
+   `which claude-mpm`, or grepping `site-packages`/`dist-info` interrogate the
+   wrong (Python) ecosystem and cannot see this Rust binary at all. These are
+   forbidden ways to answer an identity question.
+4. **State the disambiguation explicitly when relevant** — this is
+   `trusty-mpm` (binary `tm`), NOT `claude-mpm`.
+
+## Memory seeding (R3 — manual step)
+
+`get_prompt_context()` surfaces `is_fact` triples from every registered
+trusty-memory palace (see `crates/trusty-memory/src/prompt_facts.rs`), but no
+identity fact exists until one is seeded. Run this once per trusty-memory
+install/upgrade (any palace — the fact is visible cross-palace):
+
+```
+kg_assert(
+  palace: "<any palace, e.g. trusty-tools or session-manager>",
+  subject: "trusty-mpm",
+  predicate: "is_fact",
+  object: "trusty-mpm (binary tm) is the Rust Meta-Harness / control plane, NOT the Python claude-mpm project; see crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md or ~/.trusty-mpm/framework/docs/WHAT-IS-TRUSTY-MPM.md",
+  provenance: "DOC-28 self-awareness seed"
+)
+```
+
+Via the MCP tool surface this is `mcp__trusty-memory__kg_assert` with the same
+arguments. Re-running it is safe (idempotent in effect — it re-asserts the
+same triple). An automatic, idempotent seed call from `prepare_session` is
+deferred future work (DOC-28 §7 Phase 2) — until it lands, this manual step is
+what makes the fact appear in `get_prompt_context()`'s "### Facts" section.
+
+## Verifying the instructions actually loaded
+
+`tm doctor` includes an `output_style` check: it reads the effective
+`outputStyle` value (project `.claude/settings.json` if present, else the
+global one) and confirms it resolves to a real, on-disk trusty-mpm style file
+under `~/.claude/output-styles/`. A `Fail` here (unknown/stale style id, e.g.
+a leftover `claude_mpm` value) or a missing file means the session is **not**
+running under trusty-mpm's instructions at all — run `tm run`/`tm load` to
+rewrite the setting correctly, or fix it by hand. See DOC-28 §6 for the full
+detection contract and its limitations.

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -97,6 +97,26 @@ target. Rust code ALWAYS goes to **rust-engineer** — never a generic engineer.
 - **Direct answers** ONLY for PM capabilities/role questions
 - **NEVER Edit, Write, Bash, or implementation tools** without explicit override
 
+<!-- trusty-mpm-instructions-loaded: v1 -->
+## Identity & Self-Awareness Protocol (Non-Overridable)
+
+When asked what this framework/system/tool is, whether it is "self-aware," or to explain its own
+identity:
+
+1. **Consult memory first.** Call `get_prompt_context()` (trusty-memory MCP) and/or
+   `memory_recall` before answering. The active palace carries an `is_fact` triple identifying
+   this framework (see docs/specs/trusty-mpm-self-awareness.md §5).
+2. **Then consult the canonical doc.** Read `~/.trusty-mpm/framework/docs/WHAT-IS-TRUSTY-MPM.md`
+   (or, inside the trusty-tools repo itself, `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md` via
+   `trusty-search`/direct read) for the authoritative description and the claude-mpm
+   disambiguation.
+3. **Never shell-probe for identity.** `pip3 show`, `pip show`, `which claude-mpm`, or grepping
+   `site-packages`/`dist-info` are FORBIDDEN ways to answer an identity question — they interrogate
+   the wrong (Python) ecosystem and cannot see this Rust binary at all.
+4. **State the disambiguation explicitly when relevant.** This is `trusty-mpm` (binary `tm`), a
+   Rust Meta-Harness / control plane. It is NOT `claude-mpm`, the unrelated Python project. If the
+   two could plausibly be confused given the user's phrasing, say so.
+
 ## Communication
 
 - **Tone**: Analytical, precise, evidence-led

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -95,6 +95,26 @@ owns it, and *explain that split* to the operator.
 - **Direct answers** for PM capabilities/role questions AND teaching explanations
 - **NEVER Edit, Write, Bash, or implementation tools** without explicit override
 
+<!-- trusty-mpm-instructions-loaded: v1 -->
+## Identity & Self-Awareness Protocol (Non-Overridable)
+
+When asked what this framework/system/tool is, whether it is "self-aware," or to explain its own
+identity:
+
+1. **Consult memory first.** Call `get_prompt_context()` (trusty-memory MCP) and/or
+   `memory_recall` before answering. The active palace carries an `is_fact` triple identifying
+   this framework (see docs/specs/trusty-mpm-self-awareness.md §5).
+2. **Then consult the canonical doc.** Read `~/.trusty-mpm/framework/docs/WHAT-IS-TRUSTY-MPM.md`
+   (or, inside the trusty-tools repo itself, `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md` via
+   `trusty-search`/direct read) for the authoritative description and the claude-mpm
+   disambiguation.
+3. **Never shell-probe for identity.** `pip3 show`, `pip show`, `which claude-mpm`, or grepping
+   `site-packages`/`dist-info` are FORBIDDEN ways to answer an identity question — they interrogate
+   the wrong (Python) ecosystem and cannot see this Rust binary at all.
+4. **State the disambiguation explicitly when relevant.** This is `trusty-mpm` (binary `tm`), a
+   Rust Meta-Harness / control plane. It is NOT `claude-mpm`, the unrelated Python project. If the
+   two could plausibly be confused given the user's phrasing, say so.
+
 ## Communication
 
 - **Tone**: Patient, instructive, encouraging — but precise

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -75,6 +75,26 @@ agent that owns it.
 - **Direct answers** ONLY for PM capabilities/role questions
 - **NEVER Edit, Write, Bash, or implementation tools** without explicit override
 
+<!-- trusty-mpm-instructions-loaded: v1 -->
+## Identity & Self-Awareness Protocol (Non-Overridable)
+
+When asked what this framework/system/tool is, whether it is "self-aware," or to explain its own
+identity:
+
+1. **Consult memory first.** Call `get_prompt_context()` (trusty-memory MCP) and/or
+   `memory_recall` before answering. The active palace carries an `is_fact` triple identifying
+   this framework (see docs/specs/trusty-mpm-self-awareness.md §5).
+2. **Then consult the canonical doc.** Read `~/.trusty-mpm/framework/docs/WHAT-IS-TRUSTY-MPM.md`
+   (or, inside the trusty-tools repo itself, `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md` via
+   `trusty-search`/direct read) for the authoritative description and the claude-mpm
+   disambiguation.
+3. **Never shell-probe for identity.** `pip3 show`, `pip show`, `which claude-mpm`, or grepping
+   `site-packages`/`dist-info` are FORBIDDEN ways to answer an identity question — they interrogate
+   the wrong (Python) ecosystem and cannot see this Rust binary at all.
+4. **State the disambiguation explicitly when relevant.** This is `trusty-mpm` (binary `tm`), a
+   Rust Meta-Harness / control plane. It is NOT `claude-mpm`, the unrelated Python project. If the
+   two could plausibly be confused given the user's phrasing, say so.
+
 ## Communication
 
 - **Tone**: Professional, neutral

--- a/crates/trusty-mpm/src/assets/sm_instructions/BASE_SM.md
+++ b/crates/trusty-mpm/src/assets/sm_instructions/BASE_SM.md
@@ -37,6 +37,26 @@ The SM itself never shells out for work (SP3). Its only direct actions are the
 Allowlist: talk to the operator, recall/write its own memory, drive the session
 control surface, track goals, summarize, and compact its own context.
 
+<!-- trusty-mpm-instructions-loaded: v1 -->
+## Identity & Self-Awareness Protocol (Non-Overridable)
+
+When asked what this framework/system/tool is, whether it is "self-aware," or to explain its own
+identity:
+
+1. **Consult memory first.** Call `get_prompt_context()` (trusty-memory MCP) and/or
+   `memory_recall` before answering. The active palace carries an `is_fact` triple identifying
+   this framework (see docs/specs/trusty-mpm-self-awareness.md ss5).
+2. **Then consult the canonical doc.** Read `~/.trusty-mpm/framework/docs/WHAT-IS-TRUSTY-MPM.md`
+   (or, inside the trusty-tools repo itself, `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md` via
+   `trusty-search`/direct read) for the authoritative description and the claude-mpm
+   disambiguation.
+3. **Never shell-probe for identity.** `pip3 show`, `pip show`, `which claude-mpm`, or grepping
+   `site-packages`/`dist-info` are FORBIDDEN ways to answer an identity question -- they interrogate
+   the wrong (Python) ecosystem and cannot see this Rust binary at all.
+4. **State the disambiguation explicitly when relevant.** This is `trusty-mpm` (binary `tm`), a
+   Rust Meta-Harness / control plane. It is NOT `claude-mpm`, the unrelated Python project. If the
+   two could plausibly be confused given the user's phrasing, say so.
+
 ## Customizing SM Behavior
 
 Override files live in `~/.trusty-mpm/sm/` and are read when the SM prompt is

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -190,13 +190,14 @@ async fn register_project_succeeds() {
 
 #[tokio::test]
 async fn execute_doctor_against_test_daemon() {
-    // `/doctor` returns a five-check report against a live daemon.
+    // `/doctor` returns a seven-check report against a live daemon.
     let (_state, url) = spawn_test_daemon().await;
     let executor = CommandExecutor::new(url);
     match executor.execute(TrustyCommand::Doctor).await {
         CommandResult::Doctor(report) => {
-            // #1840 added the worktrees check, bringing the total to 6.
-            assert_eq!(report.checks.len(), 6);
+            // #1840 added the worktrees check (6); DOC-28 R4(a) added the
+            // output_style check, bringing the total to 7.
+            assert_eq!(report.checks.len(), 7);
         }
         other => panic!("expected Doctor, got {other:?}"),
     }

--- a/crates/trusty-mpm/src/core/bundle.rs
+++ b/crates/trusty-mpm/src/core/bundle.rs
@@ -161,6 +161,18 @@ pub const MPM_SKILLS_MANAGER_AGENT: &str = include_str!("../assets/agents/mpm-sk
 /// Placeholder skill definition installed to `skills/example-skill.md`.
 pub const EXAMPLE_SKILL: &str = include_str!("../assets/skills/example-skill.md");
 
+/// Canonical self-description doc installed to `docs/WHAT-IS-TRUSTY-MPM.md`
+/// (DOC-28 R1 — `docs/specs/trusty-mpm-self-awareness.md`).
+///
+/// Why: no single, stable, canonically-pointed-at answer to "what is
+/// trusty-mpm" existed anywhere in the bundled assets, which let a launched
+/// session conflate this Rust project with the unrelated Python `claude-mpm`
+/// package (the "self-awareness incident"). Source lives under
+/// `crates/trusty-mpm/docs/` (ordinary, human-reviewable documentation)
+/// rather than `src/assets/` so it reads naturally as a doc while still being
+/// embeddable here, exactly like every other bundled artifact.
+pub const WHAT_IS_TRUSTY_MPM: &str = include_str!("../../docs/WHAT-IS-TRUSTY-MPM.md");
+
 // --- Phase 1 (#770): mpm-* guidance skills — constants in bundle_skills.rs ---
 #[path = "bundle_skills.rs"]
 mod skills_inner;

--- a/crates/trusty-mpm/src/core/bundle_all.rs
+++ b/crates/trusty-mpm/src/core/bundle_all.rs
@@ -335,4 +335,10 @@ pub const ALL: &[BundledArtifact] = &[
         contents: MPM_TOOL_USAGE_GUIDE,
         install: InstallPolicy::Overwrite,
     },
+    // --- DOC-28 R1: canonical self-description doc ---
+    BundledArtifact {
+        rel_path: "docs/WHAT-IS-TRUSTY-MPM.md",
+        contents: WHAT_IS_TRUSTY_MPM,
+        install: InstallPolicy::Overwrite,
+    },
 ];

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -74,6 +74,7 @@ fn constants_are_non_empty() {
     assert!(!MPM_SESSION_PAUSE.trim().is_empty());
     assert!(!MPM_SESSION_RESUME.trim().is_empty());
     assert!(!MPM_TOOL_USAGE_GUIDE.trim().is_empty());
+    assert!(!WHAT_IS_TRUSTY_MPM.trim().is_empty());
 }
 
 #[test]
@@ -110,6 +111,39 @@ fn output_style_registry_ids_match_frontmatter() {
             "{} frontmatter name must match registry id",
             style.id
         );
+    }
+}
+
+#[test]
+fn output_styles_carry_identity_protocol_and_load_marker() {
+    // DOC-28 R2/R4(b): every bundled output style must carry the non-overridable
+    // Identity & Self-Awareness Protocol section, and the marker line
+    // `<!-- trusty-mpm-instructions-loaded: v1 -->` must be the literal first
+    // line of that section (so a stale/degraded style is greppably distinct
+    // from one carrying the current floor).
+    const MARKER: &str = "<!-- trusty-mpm-instructions-loaded: v1 -->";
+    const HEADING: &str = "## Identity & Self-Awareness Protocol (Non-Overridable)";
+    for style in OUTPUT_STYLES {
+        assert!(
+            style.content.contains(HEADING),
+            "{} is missing the Identity & Self-Awareness Protocol section",
+            style.id
+        );
+        let marker_pos = style
+            .content
+            .find(MARKER)
+            .unwrap_or_else(|| panic!("{} is missing the load marker", style.id));
+        let heading_pos = style.content.find(HEADING).expect("heading present");
+        let between = &style.content[marker_pos + MARKER.len()..heading_pos];
+        assert_eq!(
+            between.trim(),
+            "",
+            "{}: marker must be the first line immediately preceding the heading",
+            style.id
+        );
+        // Forbidden shell-probe list must be greppable for regressions.
+        assert!(style.content.contains("pip3 show"));
+        assert!(style.content.contains("which claude-mpm"));
     }
 }
 
@@ -179,11 +213,12 @@ fn bundle_table_is_complete() {
     //   mpm-pr-workflow, mpm-ticketing-integration, mpm-circuit-breaker-enforcement,
     //   mpm-bug-reporting, mpm-session-management, mpm-session-pause,
     //   mpm-session-resume, mpm-tool-usage-guide
-    assert_eq!(ALL.len(), 57);
+    // DOC-28 R1 (1): docs/WHAT-IS-TRUSTY-MPM.md
+    assert_eq!(ALL.len(), 58);
     let mut paths: Vec<&str> = ALL.iter().map(|a| a.rel_path).collect();
     paths.sort_unstable();
     paths.dedup();
-    assert_eq!(paths.len(), 57, "artifact paths must be unique");
+    assert_eq!(paths.len(), 58, "artifact paths must be unique");
     for artifact in ALL {
         assert!(!artifact.rel_path.is_empty());
         assert!(!artifact.contents.trim().is_empty());
@@ -470,4 +505,38 @@ fn phase1_guidance_skills_have_frontmatter() {
             "skill {name} contains unadapted claude-mpm reference"
         );
     }
+}
+
+#[test]
+fn what_is_trusty_mpm_is_in_bundle() {
+    // DOC-28 R1 acceptance: the canonical self-description doc must be a
+    // bundled artifact so `tm install` deploys it to every framework root,
+    // not just the trusty-tools repo's own source tree.
+    let artifact = ALL
+        .iter()
+        .find(|a| a.rel_path == "docs/WHAT-IS-TRUSTY-MPM.md")
+        .expect("WHAT-IS-TRUSTY-MPM.md must be a bundled artifact");
+    assert_eq!(
+        artifact.install,
+        InstallPolicy::Overwrite,
+        "the doc is framework-owned and must track upgrades"
+    );
+    assert_eq!(artifact.contents, WHAT_IS_TRUSTY_MPM);
+}
+
+#[test]
+fn what_is_trusty_mpm_disambiguates_claude_mpm() {
+    // DOC-28 R1 acceptance: the doc must contain the literal substrings that
+    // prove it identifies the project (Rust, tm, tcode) and explicitly
+    // disambiguates it from the unrelated Python claude-mpm package.
+    assert!(WHAT_IS_TRUSTY_MPM.contains("Rust"));
+    assert!(WHAT_IS_TRUSTY_MPM.contains("tm"));
+    assert!(WHAT_IS_TRUSTY_MPM.contains("tcode"));
+    assert!(WHAT_IS_TRUSTY_MPM.contains("claude-mpm"));
+    // The claude-mpm substring must appear inside an explicit disambiguation
+    // sentence, not incidentally — assert it co-occurs with "NOT" nearby.
+    assert!(
+        WHAT_IS_TRUSTY_MPM.contains("NOT") && WHAT_IS_TRUSTY_MPM.contains("claude-mpm"),
+        "doc must explicitly disambiguate from claude-mpm, not mention it incidentally"
+    );
 }

--- a/crates/trusty-mpm/src/core/sm/prompt.rs
+++ b/crates/trusty-mpm/src/core/sm/prompt.rs
@@ -299,6 +299,57 @@ mod tests {
     }
 
     #[test]
+    fn assemble_sm_prompt_contains_identity_protocol() {
+        // DOC-28 R2: the Identity & Self-Awareness Protocol section lives in
+        // the BASE_SM floor, so it must survive into the assembled prompt
+        // verbatim, along with the forbidden shell-probe list a reviewer can
+        // grep for regressions.
+        let prompt = assemble_sm_prompt();
+        assert!(prompt.contains("## Identity & Self-Awareness Protocol (Non-Overridable)"));
+        assert!(prompt.contains("pip3 show"));
+        assert!(prompt.contains("which claude-mpm"));
+    }
+
+    #[test]
+    fn identity_protocol_survives_every_override_branch() {
+        // DOC-28 R2 acceptance: the heading must be present in the resolved
+        // prompt regardless of which project-level overrides are applied —
+        // proving it lives in the non-overridable BASE_SM floor, analogous to
+        // `base_sm_floor_is_never_overridable` above.
+        let tmp = TempDir::new().unwrap();
+        write_override(
+            tmp.path(),
+            FILE_SM_INSTRUCTIONS,
+            "# Custom Identity\n\nCUSTOM_BODY\n",
+        );
+        write_override(tmp.path(), FILE_SM_WORKFLOW, "# Custom Loop\n\nBODY\n");
+        write_override(tmp.path(), FILE_SM_TOOLS, "# Custom Verbs\n\nBODY\n");
+        let prompt = resolve_sm_prompt(tmp.path());
+        assert!(
+            prompt.contains("## Identity & Self-Awareness Protocol (Non-Overridable)"),
+            "identity protocol must survive every override branch"
+        );
+        assert!(prompt.contains("<!-- trusty-mpm-instructions-loaded: v1 -->"));
+    }
+
+    #[test]
+    fn base_sm_carries_the_load_marker_as_first_line_of_its_section() {
+        // DOC-28 R4(b) acceptance: the greppable load marker must be the
+        // literal first line preceding the Identity & Self-Awareness Protocol
+        // heading in the bundled BASE_SM floor.
+        const MARKER: &str = "<!-- trusty-mpm-instructions-loaded: v1 -->";
+        const HEADING: &str = "## Identity & Self-Awareness Protocol (Non-Overridable)";
+        let marker_pos = BASE_SM.find(MARKER).expect("marker present in BASE_SM");
+        let heading_pos = BASE_SM.find(HEADING).expect("heading present in BASE_SM");
+        let between = &BASE_SM[marker_pos + MARKER.len()..heading_pos];
+        assert_eq!(
+            between.trim(),
+            "",
+            "marker must immediately precede the heading with no other content between"
+        );
+    }
+
+    #[test]
     fn assemble_sm_prompt_contains_harness_section() {
         let prompt = assemble_sm_prompt();
         // The harness understanding section contains the Claude Code working glyph

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1059,12 +1059,12 @@ async fn pair_reset_clears_pairing() {
 
 #[tokio::test]
 async fn doctor_endpoint_returns_report() {
-    // `GET /api/v1/doctor` returns a six-check report (#1840 added the
-    // worktrees check); the per-check statuses carry the diagnosis, not the
-    // HTTP status.
+    // `GET /api/v1/doctor` returns a seven-check report (#1840 added the
+    // worktrees check; DOC-28 R4(a) added the output_style check); the
+    // per-check statuses carry the diagnosis, not the HTTP status.
     let state = DaemonState::shared();
     let Json(report) = doctor(State(state), Query(DoctorQuery::default())).await;
-    assert_eq!(report.checks.len(), 6);
+    assert_eq!(report.checks.len(), 7);
     let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
     assert_eq!(
         names,
@@ -1072,6 +1072,7 @@ async fn doctor_endpoint_returns_report() {
             "instructions",
             "agents",
             "skills",
+            "output_style",
             "memory",
             "search",
             "worktrees"

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -4,8 +4,9 @@
 //! launch with no instructions, agents never deploy, memory recall silently
 //! returns nothing. `tm doctor` collapses every "is this wired correctly?"
 //! question into one command so the operator gets a single, actionable verdict.
-//! What: [`run_doctor`] runs five independent probes — the instruction
-//! pipeline, agent deployment, skill deployment, and the trusty-memory /
+//! What: [`run_doctor`] runs independent probes — the instruction pipeline,
+//! agent deployment, skill deployment, the DOC-28 output-style
+//! configuration check (see `doctor_output_style`), and the trusty-memory /
 //! trusty-search sidecars — and folds their outcomes into a
 //! [`DoctorReport`]. Each network probe is bounded by [`PROBE_TIMEOUT`] so an
 //! unreachable service cannot hang the report.
@@ -22,6 +23,11 @@ use crate::core::paths::FrameworkPaths;
 
 use super::discover::{TRUSTY_MEMORY_DEFAULT_ADDR, TRUSTY_SEARCH_DEFAULT_ADDR, discover_addr};
 
+// Split out to keep this file under the 500-SLOC production cap (DOC-28 R4(a)).
+#[path = "doctor_output_style.rs"]
+mod doctor_output_style;
+use doctor_output_style::check_output_style;
+
 /// Per-probe network timeout.
 ///
 /// Why: a sidecar that is down or wedged must not stall the whole diagnostic;
@@ -35,14 +41,17 @@ const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
 ///
 /// Why: the single entry point behind `GET /api/v1/doctor` and `tm doctor` —
 /// running all probes here keeps the check set identical across every UI.
-/// What: runs the instruction / agent / skill filesystem probes, then the
-/// memory and search HTTP probes (each bounded by [`PROBE_TIMEOUT`]), and a
-/// worktree-orphan scan (Fix 1b, #1840), and folds the six [`DoctorCheck`]s
-/// into a [`DoctorReport`] whose `overall` status is the worst of them.
-/// `project_dir` scopes the instruction probe; `repos_root` (when `Some`)
-/// gives the managed workspace root for the worktree scan; `active_workspace_paths`
-/// is the full set of workspace paths currently registered to live sessions.
-/// Test: `run_doctor_produces_six_checks`.
+/// What: runs the instruction / agent / skill / output-style filesystem
+/// probes (the output-style probe closes DOC-28 F4 — the "did the
+/// trusty-mpm instructions actually load" gap), then the memory and search
+/// HTTP probes (each bounded by [`PROBE_TIMEOUT`]), and a worktree-orphan
+/// scan (Fix 1b, #1840), and folds the seven [`DoctorCheck`]s into a
+/// [`DoctorReport`] whose `overall` status is the worst of them.
+/// `project_dir` scopes the instruction and output-style probes; `repos_root`
+/// (when `Some`) gives the managed workspace root for the worktree scan;
+/// `active_workspace_paths` is the full set of workspace paths currently
+/// registered to live sessions.
+/// Test: `run_doctor_produces_seven_checks`.
 pub async fn run_doctor(
     project_dir: Option<&Path>,
     repos_root: Option<&Path>,
@@ -55,6 +64,7 @@ pub async fn run_doctor(
         check_instructions(project_dir),
         check_agents(&paths),
         check_skills(&home),
+        check_output_style(project_dir, &home),
     ];
     checks.push(check_memory(&home).await);
     checks.push(check_search(&home).await);
@@ -553,9 +563,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_doctor_produces_six_checks() {
+    async fn run_doctor_produces_seven_checks() {
+        // DOC-28 R4(a): adds the `output_style` probe, bringing the total
+        // from six to seven checks.
         let report = run_doctor(None, None, &[]).await;
-        assert_eq!(report.checks.len(), 6);
+        assert_eq!(report.checks.len(), 7);
         let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(
             names,
@@ -563,6 +575,7 @@ mod tests {
                 "instructions",
                 "agents",
                 "skills",
+                "output_style",
                 "memory",
                 "search",
                 "worktrees"

--- a/crates/trusty-mpm/src/daemon/doctor_output_style.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_output_style.rs
@@ -1,0 +1,234 @@
+//! `tm doctor` output-style verification probe (DOC-28 R4(a)).
+//!
+//! Why: the self-awareness incident's root failure (F4) was a stale global
+//! `outputStyle` value (`"claude_mpm"`) that resolves to no bundled style
+//! file, so Claude Code silently fell back to its plain default system
+//! prompt — and nothing in the framework detected or reported the gap. This
+//! probe closes that gap deterministically by inspecting the *configuration*
+//! (the effective `outputStyle` string and whether a matching file exists on
+//! disk) rather than asking the model, which is the only way to catch total
+//! instruction-load omission (see `docs/specs/trusty-mpm-self-awareness.md`
+//! §6, §9).
+//! What: [`check_output_style`] resolves the effective `.claude/settings.json`
+//! (project-level if present, else the global one under `home`), reads its
+//! `outputStyle` key, and validates it against [`OUTPUT_STYLES`] and the
+//! deployed style files under `<home>/.claude/output-styles/`.
+//! Test: `output_style_ok_when_style_resolves`,
+//! `output_style_fail_when_id_unknown`, `output_style_warn_when_key_absent`,
+//! `output_style_fail_when_file_missing`, `output_style_fail_on_malformed_json`,
+//! `output_style_prefers_project_over_global`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::bundle::OUTPUT_STYLES;
+use crate::core::doctor::{CheckStatus, DoctorCheck};
+
+/// Probe whether the effective `outputStyle` setting resolves to a real,
+/// on-disk trusty-mpm style file.
+///
+/// Why: this is the deterministic, configuration-level check that catches the
+/// exact incident condition (an `outputStyle` value that does not exist),
+/// which no session-side "please confirm you loaded" instruction can ever
+/// catch, because that instruction itself would be part of what failed to
+/// load.
+/// What: reads [`effective_settings_path`]; `Warn` when the file is absent or
+/// has no `outputStyle` key (Claude Code will use its own default, a valid if
+/// unconfigured state); `Fail` when the file is unreadable/malformed JSON, the
+/// configured id does not match any [`OUTPUT_STYLES`] entry, or the matching
+/// file under `<home>/.claude/output-styles/` is missing/empty; `Ok` when the
+/// id is known and its file exists with content.
+/// Test: `output_style_ok_when_style_resolves`, `output_style_fail_when_id_unknown`,
+/// `output_style_warn_when_key_absent`, `output_style_fail_when_file_missing`.
+pub(crate) fn check_output_style(project_dir: Option<&Path>, home: &Path) -> DoctorCheck {
+    let settings_path = effective_settings_path(project_dir, home);
+
+    let text = match std::fs::read_to_string(&settings_path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return DoctorCheck::new(
+                "output_style",
+                CheckStatus::Warn,
+                format!(
+                    "{} not found — outputStyle unconfigured; Claude Code will use its own default",
+                    settings_path.display()
+                ),
+            );
+        }
+        Err(e) => {
+            return DoctorCheck::new(
+                "output_style",
+                CheckStatus::Fail,
+                format!("{} unreadable: {e}", settings_path.display()),
+            );
+        }
+    };
+
+    let value: serde_json::Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(e) => {
+            return DoctorCheck::new(
+                "output_style",
+                CheckStatus::Fail,
+                format!("{} is not valid JSON: {e}", settings_path.display()),
+            );
+        }
+    };
+
+    let Some(style_id) = value.get("outputStyle").and_then(|v| v.as_str()) else {
+        return DoctorCheck::new(
+            "output_style",
+            CheckStatus::Warn,
+            format!(
+                "{} has no outputStyle key — Claude Code will use its own default",
+                settings_path.display()
+            ),
+        );
+    };
+
+    let known_ids: Vec<&str> = OUTPUT_STYLES.iter().map(|s| s.id).collect();
+    let Some(style) = OUTPUT_STYLES.iter().find(|s| s.id == style_id) else {
+        return DoctorCheck::new(
+            "output_style",
+            CheckStatus::Fail,
+            format!(
+                "outputStyle {style_id:?} is not a known trusty-mpm style (valid: {}) — \
+                 run `tm run`/`tm load` to rewrite it correctly",
+                known_ids.join(", ")
+            ),
+        );
+    };
+
+    let style_path = home
+        .join(".claude")
+        .join("output-styles")
+        .join(style.file_name);
+    match std::fs::metadata(&style_path) {
+        Ok(meta) if meta.len() > 0 => DoctorCheck::new(
+            "output_style",
+            CheckStatus::Ok,
+            format!(
+                "outputStyle {style_id:?} resolves to {}",
+                style_path.display()
+            ),
+        ),
+        _ => DoctorCheck::new(
+            "output_style",
+            CheckStatus::Fail,
+            format!(
+                "outputStyle {style_id:?} is a known id but {} is missing or empty — \
+                 run `tm install` to redeploy styles",
+                style_path.display()
+            ),
+        ),
+    }
+}
+
+/// Resolve the effective `.claude/settings.json` a launched session would see.
+///
+/// Why: `write_output_style` only ever writes the project-local settings file
+/// (`crates/trusty-mpm/src/core/session_launch/settings.rs`); Claude Code
+/// itself falls back to the global `~/.claude/settings.json` when no
+/// project-level file exists, so the probe must mirror that precedence to
+/// inspect the value a session would actually see.
+/// What: returns `<project_dir>/.claude/settings.json` when `project_dir` is
+/// given and that file exists, else `<home>/.claude/settings.json`.
+/// Test: `output_style_prefers_project_over_global`.
+fn effective_settings_path(project_dir: Option<&Path>, home: &Path) -> PathBuf {
+    if let Some(dir) = project_dir {
+        let project_settings = dir.join(".claude").join("settings.json");
+        if project_settings.exists() {
+            return project_settings;
+        }
+    }
+    home.join(".claude").join("settings.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Write `<dir>/.claude/settings.json` with the given raw JSON text.
+    fn write_settings(dir: &Path, json: &str) {
+        let claude_dir = dir.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(claude_dir.join("settings.json"), json).unwrap();
+    }
+
+    /// Deploy the default trusty-mpm style file under `<home>/.claude/output-styles/`.
+    fn deploy_default_style(home: &Path) {
+        let styles_dir = home.join(".claude").join("output-styles");
+        std::fs::create_dir_all(&styles_dir).unwrap();
+        let default = OUTPUT_STYLES[0];
+        std::fs::write(styles_dir.join(default.file_name), default.content).unwrap();
+    }
+
+    #[test]
+    fn output_style_ok_when_style_resolves() {
+        let home = tempfile::tempdir().unwrap();
+        deploy_default_style(home.path());
+        write_settings(home.path(), r#"{"outputStyle": "trusty-mpm"}"#);
+        let check = check_output_style(None, home.path());
+        assert_eq!(check.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn output_style_fail_when_id_unknown() {
+        // This is the exact incident condition: a stale/foreign style id.
+        let home = tempfile::tempdir().unwrap();
+        write_settings(home.path(), r#"{"outputStyle": "claude_mpm"}"#);
+        let check = check_output_style(None, home.path());
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.message.contains("claude_mpm"));
+        assert!(
+            check.message.contains("trusty-mpm"),
+            "valid id list must be present"
+        );
+    }
+
+    #[test]
+    fn output_style_warn_when_key_absent() {
+        let home = tempfile::tempdir().unwrap();
+        write_settings(home.path(), r#"{}"#);
+        let check = check_output_style(None, home.path());
+        assert_eq!(check.status, CheckStatus::Warn);
+    }
+
+    #[test]
+    fn output_style_warn_when_settings_missing() {
+        let home = tempfile::tempdir().unwrap();
+        let check = check_output_style(None, home.path());
+        assert_eq!(check.status, CheckStatus::Warn);
+    }
+
+    #[test]
+    fn output_style_fail_when_file_missing() {
+        // A known id whose deployed file was never written (or was deleted).
+        let home = tempfile::tempdir().unwrap();
+        write_settings(home.path(), r#"{"outputStyle": "trusty-mpm"}"#);
+        let check = check_output_style(None, home.path());
+        assert_eq!(check.status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn output_style_fail_on_malformed_json() {
+        let home = tempfile::tempdir().unwrap();
+        write_settings(home.path(), "{not valid json");
+        let check = check_output_style(None, home.path());
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.message.contains("not valid JSON"));
+    }
+
+    #[test]
+    fn output_style_prefers_project_over_global() {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        deploy_default_style(home.path());
+        // Global settings carry the bad incident value...
+        write_settings(home.path(), r#"{"outputStyle": "claude_mpm"}"#);
+        // ...but the project-local settings (written by `prepare_session`)
+        // carry the correct one and must take precedence.
+        write_settings(project.path(), r#"{"outputStyle": "trusty-mpm"}"#);
+        let check = check_output_style(Some(project.path()), home.path());
+        assert_eq!(check.status, CheckStatus::Ok);
+    }
+}


### PR DESCRIPTION
## Summary

Implements R1–R4 of `docs/specs/trusty-mpm-self-awareness.md` (DOC-28), closing the four gaps from the "self-awareness incident" — a session that shell-probed for its own identity, conflated the Rust `trusty-mpm` with the unrelated Python `claude-mpm`, and had no way to detect that its instructions never loaded.

- **R1 (fully implemented)** — new canonical self-description doc `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md`. Registered as a `BundledArtifact` in `bundle_all.rs`'s `ALL` table with `InstallPolicy::Overwrite`, so `tm install` deploys it to `~/.trusty-mpm/framework/docs/WHAT-IS-TRUSTY-MPM.md`. States trusty-mpm is the Rust Meta-Harness/control plane (binary `tm`), delegates coding to `trusty-code` (`tcode`), and is explicitly NOT the Python `claude-mpm` package. Links out to `docs/architecture/harnesses.md` and DOC-26 rather than duplicating them.
- **R2 (fully implemented)** — added the verbatim "Identity & Self-Awareness Protocol (Non-Overridable)" section to `BASE_SM.md`'s non-overridable floor and to all three bundled output styles (`trusty-mpm.md`, `trusty-mpm-research.md`, `trusty-mpm-teacher.md`). Routes identity questions through `get_prompt_context()`/memory first, then the R1 doc, and forbids shell-probing (`pip3 show`, `which claude-mpm`, grepping `site-packages`/`dist-info`). Proven non-overridable via new tests in `core/sm/prompt.rs` (`identity_protocol_survives_every_override_branch`) and `bundle_tests.rs`.
- **R3 (doc-only, per spec's assigned scope for this phase)** — documented the manual `kg_assert` identity-fact seed step (subject/predicate/object + provenance) in the R1 doc's "Memory seeding" section. Per the spec, automatic idempotent seeding from `prepare_session` is explicitly deferred future work (§7 Phase 2 / §10) and is **not** implemented here — this PR does not touch `trusty-memory` at all.
- **R4 (fully implemented)** — new deterministic `tm doctor` check, `check_output_style` (`crates/trusty-mpm/src/daemon/doctor_output_style.rs`, split out to respect the 500-SLOC production cap): inspects the effective `.claude/settings.json` (project-level if present, else global) and validates the `outputStyle` value resolves to a real, on-disk bundled style file. `Ok`/`Warn`/`Fail` per spec — reproduces the exact incident condition (`outputStyle: "claude_mpm"`) as a `Fail` with the valid-id list in the message. Wired into `run_doctor` (now 7 checks, was 6). Also added the greppable `<!-- trusty-mpm-instructions-loaded: v1 -->` load marker as the first line of each floor section (R4(b), best-effort behavioral signal).

**Does not bump any crate version** — a release is a separate follow-up, noted but not performed here.

## Test plan

- [x] `SKIP_UI_BUILD=1 cargo build --release -p trusty-mpm` — clean build
- [x] `cargo test -p trusty-mpm` — 2159 lib tests + all integration suites pass (one unrelated pre-existing flaky test in `core::standalone::global_config` — mutates the global `HOME` env var without `#[serial]` — passes in isolation and on rerun; untouched by this PR)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] New tests: `what_is_trusty_mpm_is_in_bundle`, `what_is_trusty_mpm_disambiguates_claude_mpm`, `output_styles_carry_identity_protocol_and_load_marker`, `identity_protocol_survives_every_override_branch`, `base_sm_carries_the_load_marker_as_first_line_of_its_section`, `run_doctor_produces_seven_checks`, and the full `doctor_output_style` Ok/Warn/Fail/malformed-JSON/project-vs-global-precedence suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)