### PR TITLE
chore(release): trusty-mpm v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10966,7 +10966,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [0.14.0] — 2026-07-01
+
+### Added
+
+DOC-28 self-awareness (R1-R4 of `docs/specs/trusty-mpm-self-awareness.md`), closing the
+gaps behind the "self-awareness incident" where a session conflated this Rust
+`trusty-mpm` with the unrelated Python `claude-mpm`, and no mechanism detected
+that its instructions never loaded ([#1855](https://github.com/bobmatnyc/trusty-tools/pull/1855)) ([#1859](https://github.com/bobmatnyc/trusty-tools/pull/1859)) ([`5708d95`](https://github.com/bobmatnyc/trusty-tools/commit/5708d95310dd02c903502d812990c8c6d9d743e8)):
+
+- **R1 — canonical self-description doc**: new bundled
+  `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md`, deployed via
+  `bundle_all.rs::ALL` with `InstallPolicy::Overwrite` so `tm install` installs
+  it to `~/.trusty-mpm/framework/docs/`.
+- **R2 — identity protocol in instructions**: "Identity & Self-Awareness
+  Protocol (Non-Overridable)" section added verbatim to `BASE_SM.md`'s
+  non-overridable floor and to all three bundled output styles
+  (`trusty-mpm.md`, `trusty-mpm-teacher.md`, `trusty-mpm-research.md`),
+  routing identity questions through memory + the R1 doc and forbidding
+  shell-probing (`pip3 show`, `which claude-mpm`).
+- **R3 — manual identity-fact seeding**: documents the `kg_assert` identity-fact
+  seed step in the R1 doc (automatic seeding from `prepare_session` is deferred
+  future work per spec §7 Phase 2/§10).
+- **R4 — `tm doctor` output-style check + load marker**: new
+  `daemon/doctor_output_style.rs` probe validates that the effective
+  `outputStyle` setting resolves to a real bundled style file (Ok/Warn/Fail per
+  spec, reproducing the exact incident condition as a Fail), plus the
+  greppable `<!-- trusty-mpm-instructions-loaded: v1 -->` load marker at the
+  top of each floor section.
+
 ## [0.13.0] — 2026-06-30
 
 ### Added

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Prepares a **minor** version bump for `trusty-mpm`: `0.13.0` → `0.14.0`.

The DOC-28 self-awareness work merged in 5708d953 (#1855/#1859) added
additive, user-facing features since the last publish — this warrants a
MINOR bump, not a patch:

- **R1** — new bundled `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md`
  canonical self-description doc, deployed to `~/.trusty-mpm/framework/docs/`
  via `tm install`.
- **R2** — "Identity & Self-Awareness Protocol (Non-Overridable)" section
  added to `BASE_SM.md`'s non-overridable floor and to all three bundled
  output styles (`trusty-mpm.md`, `trusty-mpm-teacher.md`,
  `trusty-mpm-research.md`).
- **R3** — documents the manual `kg_assert` identity-fact seeding step
  (automatic seeding is deferred future work).
- **R4** — new `tm doctor` output-style check (`doctor_output_style.rs`) plus
  the greppable `<!-- trusty-mpm-instructions-loaded: v1 -->` load marker.

`trusty-common 0.18.2` (with the `catchup` feature) is already published to
crates.io, so the previous publish blocker is resolved.

This PR only bumps the version and updates the changelog — no functional
code changes. **Publish is a separate follow-up after merge** (not included
in this PR).

## Test plan

- [x] `SKIP_UI_BUILD=1 cargo build --release -p trusty-mpm` — clean build
- [x] `cargo test -p trusty-mpm` — 2159+603+4+3+3+34+13+0+6+3+0+10+21+1+11+1+0 = all passed, 0 failed (including both known-flaky global-state tests `image_shading_emits_truecolor` and `test_mcp_config_review_no_home_write`, which passed cleanly on this run)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)