### PR TITLE
docs: clarify trusty-mpm is exempt from macOS FDA re-grant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,8 @@ convention (i.e. `tga-v<version>`, matching the abbreviation table) works.
 
 ### macOS Full Disk Access must be re-granted after every `cargo install` (issue #873)
 
+🟢 **Scope: `trusty-search` and external-volume daemons only.** `trusty-mpm` / `tm` does NOT require FDA re-granting because the daemon manages tmux sessions and git worktrees under `$HOME` only — it never reads TCC-protected or external (`/Volumes/…`) paths. FDA caveat applies only to daemons that index external volumes (currently `trusty-search`); `trusty-memory` and `trusty-analyze` read `$HOME` locations only and also do NOT require FDA. No `install-trusty-mpm-signed.sh` script exists because it is not needed.
+
 On macOS, every `cargo install` of a binary writes a NEW file at
 `~/.cargo/bin/<binary>` with a new **cdhash** (code-signing hash). macOS TCC
 keys the **Full Disk Access** grant by cdhash, so the previously-granted FDA no
@@ -355,7 +357,7 @@ binary is a deprecated shim that forwards to `serve --stdio`; update your
 launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/<label>.plist
 cargo install --path crates/<dir> --locked
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/<label>.plist
-# IMPORTANT on macOS: re-grant Full Disk Access after cargo install (see above)
+# NOTE: re-grant Full Disk Access only for trusty-search (and external-volume daemons), not for trusty-mpm (see FDA section above)
 ```
 
 Prefer restarting between Claude Code sessions. See the cargo-publish skill


### PR DESCRIPTION
## Summary

Scope the macOS Full Disk Access (FDA) re-grant caveat to daemons that read TCC-protected or external volumes (currently `trusty-search`). `trusty-mpm` and other daemons that only access `$HOME` do not require FDA re-granting after `cargo install`.

**Rationale:** The `trusty-mpm` daemon manages tmux sessions and git worktrees under `$HOME` only — it never reads protected system paths or external volumes (`/Volumes/…`). Therefore, it does not need the macOS FDA grant that `trusty-search` requires. By contrast, `trusty-search` maintains indexes on external volumes, so it does require FDA and has a signed-install script (`scripts/install-trusty-search-signed.sh`). No `install-trusty-mpm-signed.sh` is needed because `trusty-mpm` has no such requirement.

**Changes:**
- Added a 🟢-scoped clarification at the top of the FDA section explaining that the caveat applies only to external-volume daemons
- Updated the daemon restart comment to clarify which daemons require re-granting

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>