### PR TITLE
docs(mpm): fix DOC-29 BHV-05 test citation + add backlinks

### DIFF
--- a/docs/architecture/harnesses.md
+++ b/docs/architecture/harnesses.md
@@ -25,6 +25,12 @@ and delegation edges. **Out of scope:** internal implementation details of any
 single harness, tool lists, model routing specifics, and per-crate release
 procedures (those live in the crate-level README and `docs/<crate>/`).
 
+> **Conformance tracking:** For testable conformance verification of the primary
+> trusty-mpm harness behaviors enumerated herein, refer to
+> [DOC-29 — Primary trusty-mpm Harness Behaviors — Conformance Matrix](../specs/mpm-behavior-conformance.md).
+> DOC-29 is the canonical source for per-behavior test citations and current
+> implementation status.
+
 ---
 
 ## Table of Contents

--- a/docs/specs/harness-runner-vision.md
+++ b/docs/specs/harness-runner-vision.md
@@ -27,6 +27,12 @@ surface, DOC-16).
 > the metaharness runner-core epic (#1045) and the interactive-TUI epic (#1272 /
 > DOC-16): #1045 builds the runner, #1272 builds the operator surface, and this
 > spec frames why the runner must be *autonomous*.
+>
+> **Conformance tracking:** DOC-29 (`docs/specs/mpm-behavior-conformance.md`) is
+> the canonical, testable source of truth for the primary trusty-mpm harness
+> behaviors (instruction assembly, self-awareness, memory integration, agent/skill
+> bundling, autonomous provisioning, content freshness) defined herein. Refer to
+> DOC-29 for conformance status and per-behavior test citations.
 
 ---
 
@@ -247,6 +253,13 @@ are explicitly post-MVP (§5).
 | Coordinator TUI | yes | **done** | — |
 
 ### 4.2 Partial
+
+> **Note:** This table is a historical compliance audit snapshot (2026-06-17).
+> For the canonical, up-to-date conformance status of the primary trusty-mpm
+> harness behaviors (HR-1, HR-2, HR-3, HR-4), refer to
+> [DOC-29 — Primary trusty-mpm Harness Behaviors — Conformance Matrix](./mpm-behavior-conformance.md).
+> DOC-29 consolidates these behaviors, adds test citations, and reflects current
+> implementation status as of the most recent pass.
 
 | Feature | claude-mpm has it | t-mpm status | Effort |
 |---|---|---|---|

--- a/docs/specs/mpm-behavior-conformance.md
+++ b/docs/specs/mpm-behavior-conformance.md
@@ -261,11 +261,13 @@ tests are the direct confirmation that HR-2's precedence order is implemented,
 §3 HR-2 was written as pending near-term work; as of this pass it is wired
 into `prepare_session_inner` and unit-verified).
 
-**What was NOT run this pass:** a live end-to-end smoke test — a real
-`tm sessions new --repo <url> --ref main --task "…"` against a real tmux
-binary and a real git remote (`SESSION_MANAGER_MVP.md §13`, acceptance
-criteria 2/3/5/6/11/12; the crate's own `#[ignore]`-tagged
-`test_live_session_e2e`). Everything above is unit/fake-backend level.
+**What was NOT run this pass:** a full live end-to-end smoke test — the
+complete tmux spawn/observe/resume/decommission workflow. The crate includes
+a live-provisioning smoke test (`#[ignore]`-tagged `live_provision_real_repo`
+at `crates/trusty-mpm/tests/session_manager_mvp.rs:580`), which exercises
+workspace isolation and git/repo provisioning, but does not run the complete
+session lifecycle (that is, BHV-05's full spec is aspirational and not yet
+exercised end-to-end). Everything above is unit/fake-backend level.
 
 **Status:** PARTIALLY-IMPLEMENTED — unit-verified with fake backends (workspace
 isolation, naming, reconciliation, manifest precedence all pass); the

--- a/docs/trusty-mpm/spec/SESSION_MANAGER_MVP.md
+++ b/docs/trusty-mpm/spec/SESSION_MANAGER_MVP.md
@@ -251,6 +251,12 @@ workflow, agents, skills, and memory. Instruction/prompt assembly stays in MPM;
 each harness implementation only **PROJECTS** that canonical context into the
 runtime's native format and deployment model.
 
+> **Conformance tracking:** [DOC-29 — Primary trusty-mpm Harness Behaviors](../../specs/mpm-behavior-conformance.md)
+> is the single canonical source of truth for testing and conformance verification of
+> these principles. It consolidates the testable behaviors (instruction assembly, agent
+> bundling, memory integration, etc.) scattered across this and other spec documents
+> into one conformance matrix with per-behavior test citations.
+
 - MPM assembles the canonical instruction bundle once (agents, skills, system
   prompt, `.mcp.json`, `.claude/settings.json`, memory palace links, hooks).
 - The `RuntimeAdapter` trait receives this bundle as input.


### PR DESCRIPTION
## Summary

Documentation-only cleanup for DOC-29 behavior-conformance matrix:

- **Task 1:** Fix DOC-29's broken BHV-05 test citation — replaced non-existent `test_live_session_e2e` with actual live-provisioning test `live_provision_real_repo` (crates/trusty-mpm/tests/session_manager_mvp.rs:580), and updated prose to be honest that it covers provisioning only, not full session lifecycle
- **Task 2:** Add backlinks from three source docs to DOC-29 as the canonical conformance matrix:
  - `docs/specs/harness-runner-vision.md` (DOC-17): Added conformance-tracking note in scope section + clarifying note at §4.2
  - `docs/trusty-mpm/spec/SESSION_MANAGER_MVP.md`: Added conformance-tracking note after Canonical-Context Preservation Principle
  - `docs/architecture/harnesses.md`: Added conformance-tracking note in Purpose & Scope section

All relative links verified and cross-referenced. No code changes. Markdown edits only.

## Related
Epic #1855: DOC-29 behavior-conformance hygiene + backlink setup

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>