### PR TITLE
fix(trusty-mpm): output-style resolution + test-isolation hygiene

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -105,25 +105,25 @@ pub(crate) fn shade_bucket(c: char) -> (u8, u8, u8) {
 /// Why: auto-computing the display width from the actual art means an
 /// arbitrarily-sized user-edited file renders correctly without recompiling;
 /// all previous hard-coded CLIP_* constants are replaced by this measurement.
+/// Taking `use_color` as an explicit parameter (issue #1858) rather than
+/// probing the process-global `colored::control` override internally makes
+/// this function pure and deterministic: tests can exercise both the
+/// color-on and color-off paths directly, with no shared mutable state to
+/// race against other tests running in parallel threads.
 /// What: iterates every line of `art`, colourises non-space chars via
-/// `shade_bucket`, pads each row to `max_display_cols` with spaces. Returns
-/// `(rows, max_display_cols)`. Spaces are transparent (no colour escape).
-/// Rows wider than `max_display_cols` are clipped gracefully (no panic).
-/// Test: `image_autosize_uses_art_dimensions`, `image_clip_correct_cols`
-/// in `two_panel::tests`.
-pub(crate) fn shade_image(art: &str) -> (Vec<String>, usize) {
+/// `shade_bucket` when `use_color` is `true`, pads each row to
+/// `max_display_cols` with spaces. Returns `(rows, max_display_cols)`. Spaces
+/// are transparent (no colour escape) regardless of `use_color`. Rows wider
+/// than `max_display_cols` are clipped gracefully (no panic).
+/// Test: `image_autosize_uses_art_dimensions`, `image_clip_correct_cols`,
+/// `image_shading_emits_truecolor` in `two_panel::tests`.
+pub(crate) fn shade_image(art: &str, use_color: bool) -> (Vec<String>, usize) {
     let raw_lines: Vec<&str> = art.lines().collect();
     let max_cols = raw_lines.iter().map(|l| l.width()).max().unwrap_or(0);
 
     if max_cols == 0 || raw_lines.is_empty() {
         return (Vec::new(), 0);
     }
-
-    // Probe colored's current control state so our raw truecolor escapes respect
-    // the same set_override(false) call that banner callers use for non-TTY mode.
-    // When set_override(false) is active, truecolor() returns bare text and the
-    // probe string has no ANSI escape — emitting raw escapes would bypass that.
-    let use_color = "a".truecolor(0, 0, 0).to_string().contains('\x1B');
 
     let rows = raw_lines
         .iter()
@@ -160,13 +160,24 @@ pub(crate) fn shade_image(art: &str) -> (Vec<String>, usize) {
 /// Load the banner art from disk (or embedded default) and shade it.
 ///
 /// Why: decouples the renderer (`two_panel`) from the I/O of discovering and
-/// reading the user-editable banner file.
-/// What: calls `source::load_banner_art()` then `shade_image()`, returning
-/// `(coloured_rows, max_display_cols)`.
+/// reading the user-editable banner file. This is the one legitimate
+/// production read of `colored`'s global override: a real launch must follow
+/// whatever `NoColorGuard`/TTY detection has configured for the process, so
+/// the probe happens here, once, and is threaded into the now-pure
+/// `shade_image` rather than that function reading the global itself.
+/// What: calls `source::load_banner_art()`, probes `colored`'s current
+/// override via a throwaway `truecolor()` call, then calls
+/// `shade_image(&art, use_color)`, returning `(coloured_rows,
+/// max_display_cols)`.
 /// Test: `image_autosize_uses_art_dimensions` in `two_panel::tests`.
 pub(crate) fn load_and_shade_banner() -> (Vec<String>, usize) {
     let art = source::load_banner_art();
-    shade_image(&art)
+    // Probe colored's current control state so our raw truecolor escapes respect
+    // the same set_override(false) call that banner callers use for non-TTY mode.
+    // When set_override(false) is active, truecolor() returns bare text and the
+    // probe string has no ANSI escape — emitting raw escapes would bypass that.
+    let use_color = "a".truecolor(0, 0, 0).to_string().contains('\x1B');
+    shade_image(&art, use_color)
 }
 
 /// Query the terminal width in columns, falling back to 80 when unknown.

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/two_panel.rs
@@ -450,7 +450,8 @@ pub(crate) mod tests {
     /// Shaded art rows match the actual line count of the embedded default.
     #[test]
     fn image_clip_correct_rows() {
-        let (lines, _cols) = super::super::shade_image(super::super::source::DEFAULT_BANNER_ART);
+        let (lines, _cols) =
+            super::super::shade_image(super::super::source::DEFAULT_BANNER_ART, false);
         let raw_count = super::super::source::DEFAULT_BANNER_ART.lines().count();
         assert_eq!(
             lines.len(),
@@ -464,9 +465,8 @@ pub(crate) mod tests {
     /// Each shaded row has the same display width (auto-sized to art max width).
     #[test]
     fn image_clip_correct_cols() {
-        colored::control::set_override(false);
         let (lines, expected_cols) =
-            super::super::shade_image(super::super::source::DEFAULT_BANNER_ART);
+            super::super::shade_image(super::super::source::DEFAULT_BANNER_ART, false);
         assert!(expected_cols > 0, "auto-sized cols must be > 0");
         for (i, line) in lines.iter().enumerate() {
             let bare = strip_ansi(line);
@@ -476,31 +476,30 @@ pub(crate) mod tests {
                 "row {i} display width ({width}) must equal auto-sized cols ({expected_cols})"
             );
         }
-        colored::control::unset_override();
     }
 
     /// Non-space art characters emit truecolor escapes when color is enabled.
     #[test]
     fn image_shading_emits_truecolor() {
-        // shade_image now respects the colored global state (set_override) so
-        // that non-TTY callers can suppress escapes (#1839 Fix 3). Force color
-        // on here so the assertion holds regardless of CI environment settings.
-        colored::control::set_override(true);
-        let (lines, _) = super::super::shade_image(super::super::source::DEFAULT_BANNER_ART);
+        // Issue #1858: `shade_image` used to read the process-global
+        // `colored::control` override internally, so this test raced every
+        // sibling test in this file that flips the same global via
+        // `set_override(false)`. Now that `use_color` is an explicit
+        // parameter, this test needs no global mutation at all — it is fully
+        // deterministic and immune to parallel-test interleaving.
+        let (lines, _) = super::super::shade_image(super::super::source::DEFAULT_BANNER_ART, true);
         let any_colored = lines.iter().any(|l| l.contains("\x1B[38;2;"));
         assert!(
             any_colored,
             "shaded art must emit truecolor escapes when color is enabled"
         );
-        colored::control::unset_override();
     }
 
     /// Auto-sizing picks up dimensions from a custom art string.
     #[test]
     fn image_autosize_uses_art_dimensions() {
-        colored::control::set_override(false);
         let custom_art = "ABC\nDE\nFGHI\n";
-        let (lines, cols) = super::super::shade_image(custom_art);
+        let (lines, cols) = super::super::shade_image(custom_art, false);
         // "FGHI" is the widest line: 4 chars.
         assert_eq!(cols, 4, "max width of 'FGHI' is 4");
         assert_eq!(lines.len(), 3, "three non-empty lines");
@@ -509,7 +508,6 @@ pub(crate) mod tests {
             let bare = strip_ansi(line);
             assert_eq!(bare.width(), 4, "row {i} must be padded to 4 display cols");
         }
-        colored::control::unset_override();
     }
 
     /// The right-column content has no inner-box border chars (╭╮╰╯).

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1739,9 +1739,13 @@ fn cli_parses_login_standalone() {
 
 // ── Image-banner color tests ──────────────────────────────────────────────────
 
-// Serialize all tests that mutate `colored`'s global override so they do not
-// race each other (cargo test runs threads concurrently within the binary).
-static COLOR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+// Issue #1858: `shade_image` used to probe the process-global
+// `colored::control` override internally, so these tests had to serialize on
+// COLOR_LOCK and mutate/restore that global to exercise the color-on and
+// color-off paths — and the sibling test in `two_panel.rs` that did the same
+// without the lock was the actual flaky test. `shade_image` now takes
+// `use_color` as an explicit parameter, so every test below passes it
+// directly; no global mutation or lock is needed anywhere in this file.
 
 #[test]
 fn image_clip_has_correct_dimensions() {
@@ -1751,7 +1755,7 @@ fn image_clip_has_correct_dimensions() {
     // consistency.
     // Test: direct call to shade_image with DEFAULT_BANNER_ART.
     use crate::formatters::banner::{shade_image, source::DEFAULT_BANNER_ART};
-    let (lines, cols) = shade_image(DEFAULT_BANNER_ART);
+    let (lines, cols) = shade_image(DEFAULT_BANNER_ART, false);
     let raw_count = DEFAULT_BANNER_ART.lines().count();
     assert_eq!(
         lines.len(),
@@ -1764,42 +1768,35 @@ fn image_clip_has_correct_dimensions() {
 
 #[test]
 fn art_char_shading_emits_truecolor() {
-    // Why: shade_image now respects the colored global state so non-TTY banner
-    // callers can suppress ANSI escapes (#1839 Fix 3). Force color on so the
-    // assertion holds in CI regardless of environment settings.
-    // What: call shade_image with color enabled and verify at least one line
-    // contains a truecolor ANSI escape (`\x1B[38;2;`).
-    // Test: holds COLOR_LOCK to prevent concurrent color-state tests from racing.
-    let _guard = COLOR_LOCK.lock().unwrap();
-    colored::control::set_override(true);
+    // Why: shade_image must emit truecolor escapes when the caller asks for
+    // color (#1839 Fix 3), independent of any process-global state.
+    // What: call shade_image with `use_color = true` and verify at least one
+    // line contains a truecolor ANSI escape (`\x1B[38;2;`).
+    // Test: pure function call, no shared state to race.
     use crate::formatters::banner::{shade_image, source::DEFAULT_BANNER_ART};
-    let (lines, _) = shade_image(DEFAULT_BANNER_ART);
+    let (lines, _) = shade_image(DEFAULT_BANNER_ART, true);
     let any_colored = lines.iter().any(|l| l.contains("\x1B[38;2;"));
     assert!(
         any_colored,
         "shaded art must emit truecolor escapes when color is enabled"
     );
-    colored::control::unset_override();
 }
 
 #[test]
 fn art_shading_no_ansi_when_color_disabled() {
     // Why: shade_image must suppress ANSI escapes when color is disabled so that
     // banner output piped to a file or CI log is clean plain text (#1839 Fix 3).
-    // What: disable color via set_override(false), shade the default art, then
-    // assert no line contains an ANSI escape byte.
-    // Test: holds COLOR_LOCK to prevent concurrent color-state tests from racing.
-    let _guard = COLOR_LOCK.lock().unwrap();
-    colored::control::set_override(false);
+    // What: call shade_image with `use_color = false` and assert no line
+    // contains an ANSI escape byte.
+    // Test: pure function call, no shared state to race.
     use crate::formatters::banner::{shade_image, source::DEFAULT_BANNER_ART};
-    let (lines, _) = shade_image(DEFAULT_BANNER_ART);
+    let (lines, _) = shade_image(DEFAULT_BANNER_ART, false);
     for line in &lines {
         assert!(
             !line.contains('\x1B'),
             "shade_image must not emit ANSI escapes when color is disabled: {line:?}"
         );
     }
-    colored::control::unset_override();
 }
 
 #[test]
@@ -1811,7 +1808,7 @@ fn art_shading_spaces_are_uncolored() {
     use crate::formatters::banner::{
         shade_image, source::DEFAULT_BANNER_ART, two_panel::strip_ansi,
     };
-    let (lines, _) = shade_image(DEFAULT_BANNER_ART);
+    let (lines, _) = shade_image(DEFAULT_BANNER_ART, true);
     let has_space = lines.iter().any(|l| strip_ansi(l).contains(' '));
     assert!(has_space, "shaded art must contain some uncolored spaces");
 }

--- a/crates/trusty-mpm/src/core/paths.rs
+++ b/crates/trusty-mpm/src/core/paths.rs
@@ -268,6 +268,29 @@ impl FrameworkPaths {
     pub fn claude_skills_dir(&self) -> PathBuf {
         self.claude_skills.clone()
     }
+
+    /// The base directory `.claude/{agents,skills}` nest under — the real home
+    /// for [`default`](Self::default), the temp dir for [`under`](Self::under).
+    ///
+    /// Why (issue #1860): settings-file operations that need `~/.claude`
+    /// directly (e.g. deploying the bundled output-style definition) must
+    /// honor the same base this `FrameworkPaths` was resolved against. Calling
+    /// `dirs::home_dir()` directly at those call sites ignores test isolation:
+    /// `FrameworkPaths::under(tempdir)` is supposed to confine ALL filesystem
+    /// writes to the temp dir, but a stray `dirs::home_dir()` call re-escapes
+    /// to the real `$HOME` and leaks state between test runs.
+    /// What: derives the base by walking up two levels from `claude_agents`
+    /// (`<base>/.claude/agents` -> `<base>/.claude` -> `<base>`). Falls back to
+    /// `claude_agents` itself in the practically-unreachable case where it has
+    /// no grandparent (e.g. a root-relative path).
+    /// Test: `claude_home_dir_matches_under_base`, `claude_home_dir_matches_default_home`.
+    pub fn claude_home_dir(&self) -> PathBuf {
+        self.claude_agents
+            .parent()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| self.claude_agents.clone())
+    }
 }
 
 #[cfg(test)]
@@ -398,6 +421,25 @@ mod tests {
             paths.claude_skills_dir(),
             PathBuf::from("/base/.claude/skills")
         );
+    }
+
+    #[test]
+    fn claude_home_dir_matches_under_base() {
+        // Issue #1860: `claude_home_dir()` must recover the exact `base` passed
+        // to `under()`, not some hardcoded or re-resolved home directory — this
+        // is what lets output-style deploy honor test isolation.
+        let paths = FrameworkPaths::under("/base");
+        assert_eq!(paths.claude_home_dir(), PathBuf::from("/base"));
+    }
+
+    #[test]
+    fn claude_home_dir_matches_default_home() {
+        // The home-relative resolver's `claude_home_dir()` must equal the real
+        // home directory `dirs::home_dir()` reports (falling back to "." like
+        // `default()` does), keeping the two resolution paths consistent.
+        let paths = FrameworkPaths::default();
+        let expected = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+        assert_eq!(paths.claude_home_dir(), expected);
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -49,9 +49,8 @@ pub struct PrepReport {
     pub stash: PathBuf,
     /// Path the `trusty-mpm` output style was deployed to, if it succeeded.
     ///
-    /// `None` when deployment was skipped (no home directory) or failed; the
-    /// session still launches in that case, just with the operator's default
-    /// style.
+    /// `None` when the deploy write failed; the session still launches in
+    /// that case, just with the operator's default style.
     pub output_style: Option<PathBuf>,
     /// Whether the `trusty-memory` hook block was written to the project's
     /// `.claude/settings.json`.
@@ -408,17 +407,14 @@ fn prepare_session_inner(
 
     // Deploy the bundled output-style definition so Claude Code can resolve the
     // `trusty-mpm` name written into `.claude/settings.json` above. Non-fatal:
-    // a missing style file just falls back to the operator's default.
-    let output_style = match dirs::home_dir() {
-        Some(home) => match deploy_output_style(&home) {
-            Ok(path) => Some(path),
-            Err(err) => {
-                tracing::warn!("failed to deploy trusty-mpm output style file: {err}");
-                None
-            }
-        },
-        None => {
-            tracing::warn!("skipping output style deploy: home directory unresolved");
+    // a missing style file just falls back to the operator's default. Uses
+    // `fw.claude_home_dir()` (issue #1860) rather than `dirs::home_dir()`
+    // directly so isolated `FrameworkPaths::under(tempdir)` callers (tests)
+    // stay confined to the temp dir instead of leaking into the real `$HOME`.
+    let output_style = match deploy_output_style(&fw.claude_home_dir()) {
+        Ok(path) => Some(path),
+        Err(err) => {
+            tracing::warn!("failed to deploy trusty-mpm output style file: {err}");
             None
         }
     };

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -1331,6 +1331,13 @@ fn prepare_session_reports_output_style() {
         .expect("output style deployed when home is resolvable");
     assert!(style.ends_with("trusty-mpm.md"));
     assert!(style.exists());
+    // Issue #1860: the deploy must target the scoped `tmp_home`, never the
+    // real `$HOME` — this is the regression the leaking test exposed.
+    assert!(
+        style.starts_with(tmp_home.path()),
+        "output style must deploy under the injected FrameworkPaths base, got {}",
+        style.display()
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/daemon/doctor_output_style.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_output_style.rs
@@ -9,90 +9,155 @@
 //! disk) rather than asking the model, which is the only way to catch total
 //! instruction-load omission (see `docs/specs/trusty-mpm-self-awareness.md`
 //! §6, §9).
-//! What: [`check_output_style`] resolves the effective `.claude/settings.json`
-//! (project-level if present, else the global one under `home`), reads its
-//! `outputStyle` key, and validates it against [`OUTPUT_STYLES`] and the
-//! deployed style files under `<home>/.claude/output-styles/`.
+//! What: [`check_output_style`] resolves Claude Code's EFFECTIVE `outputStyle`
+//! — the project-level `.claude/settings.json` value when that file exists
+//! AND carries the key, otherwise the global `~/.claude/settings.json` value
+//! (issue #1863: a project settings file that exists but is silent on
+//! `outputStyle` must NOT shadow a bad global value, since project settings
+//! only override keys they actually set) — and validates it against
+//! [`OUTPUT_STYLES`] and the deployed style files under
+//! `<home>/.claude/output-styles/`. The report names which scope
+//! ("project"/"global") the resolved value came from.
 //! Test: `output_style_ok_when_style_resolves`,
 //! `output_style_fail_when_id_unknown`, `output_style_warn_when_key_absent`,
 //! `output_style_fail_when_file_missing`, `output_style_fail_on_malformed_json`,
-//! `output_style_prefers_project_over_global`.
+//! `output_style_prefers_project_over_global`,
+//! `output_style_falls_back_to_global_when_project_silent`,
+//! `output_style_falls_back_to_global_when_project_missing`.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::core::bundle::OUTPUT_STYLES;
 use crate::core::doctor::{CheckStatus, DoctorCheck};
 
-/// Probe whether the effective `outputStyle` setting resolves to a real,
+/// Result of reading the `outputStyle` key out of one settings file.
+///
+/// Why: a settings file can be "silent" on `outputStyle` in two equivalent
+/// ways — the file does not exist, or it exists but has no such key — and
+/// both must fall through to the next scope in the resolution chain the same
+/// way. Splitting this from a malformed/unreadable file (which must stop
+/// resolution and `Fail` immediately) needs its own type rather than
+/// overloading `Option`.
+/// What: `Present` carries the configured id; `Silent` means "keep looking".
+/// Test: exercised indirectly by every `check_output_style` test below.
+enum StyleKey {
+    Present(String),
+    Silent,
+}
+
+/// Read the `outputStyle` key from `path`, distinguishing "absent" (fall
+/// through) from "malformed" (stop and report).
+///
+/// Why: shared by both the project and global read attempts in
+/// [`check_output_style`] so the two scopes apply identical parsing and
+/// error-reporting rules.
+/// What: `Ok(StyleKey::Silent)` when the file is missing or has no
+/// `outputStyle` key; `Ok(StyleKey::Present(id))` when it does;
+/// `Err(DoctorCheck)` (a ready-to-return `Fail`) when the file exists but is
+/// unreadable or not valid JSON.
+/// Test: `output_style_fail_on_malformed_json`, `output_style_warn_when_key_absent`.
+fn read_style_key(path: &Path) -> Result<StyleKey, DoctorCheck> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(StyleKey::Silent),
+        Err(e) => {
+            return Err(DoctorCheck::new(
+                "output_style",
+                CheckStatus::Fail,
+                format!("{} unreadable: {e}", path.display()),
+            ));
+        }
+    };
+
+    let value: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+        DoctorCheck::new(
+            "output_style",
+            CheckStatus::Fail,
+            format!("{} is not valid JSON: {e}", path.display()),
+        )
+    })?;
+
+    match value.get("outputStyle").and_then(|v| v.as_str()) {
+        Some(id) => Ok(StyleKey::Present(id.to_string())),
+        None => Ok(StyleKey::Silent),
+    }
+}
+
+/// Probe whether the EFFECTIVE `outputStyle` setting resolves to a real,
 /// on-disk trusty-mpm style file.
 ///
 /// Why: this is the deterministic, configuration-level check that catches the
 /// exact incident condition (an `outputStyle` value that does not exist),
 /// which no session-side "please confirm you loaded" instruction can ever
 /// catch, because that instruction itself would be part of what failed to
-/// load.
-/// What: reads [`effective_settings_path`]; `Warn` when the file is absent or
-/// has no `outputStyle` key (Claude Code will use its own default, a valid if
-/// unconfigured state); `Fail` when the file is unreadable/malformed JSON, the
-/// configured id does not match any [`OUTPUT_STYLES`] entry, or the matching
-/// file under `<home>/.claude/output-styles/` is missing/empty; `Ok` when the
-/// id is known and its file exists with content.
+/// load. It must inspect the value Claude Code will ACTUALLY resolve — the
+/// project settings when they set the key, else the global settings — so a
+/// bad global value is never masked by a project file that is silent on it
+/// (issue #1863).
+/// What: tries `<project_dir>/.claude/settings.json` first (when
+/// `project_dir` is given); if that file is missing or has no `outputStyle`
+/// key, falls back to `<home>/.claude/settings.json`. `Fail`s immediately on
+/// an unreadable/malformed settings file at whichever scope it was found in.
+/// `Warn` when neither scope configures a value (Claude Code will use its own
+/// default, a valid if unconfigured state). Otherwise validates the resolved
+/// id against [`OUTPUT_STYLES`] and the deployed file under
+/// `<home>/.claude/output-styles/`, reporting `Fail`/`Ok` with the resolved
+/// scope ("project"/"global") named in the message.
 /// Test: `output_style_ok_when_style_resolves`, `output_style_fail_when_id_unknown`,
-/// `output_style_warn_when_key_absent`, `output_style_fail_when_file_missing`.
+/// `output_style_warn_when_key_absent`, `output_style_fail_when_file_missing`,
+/// `output_style_falls_back_to_global_when_project_silent`.
 pub(crate) fn check_output_style(project_dir: Option<&Path>, home: &Path) -> DoctorCheck {
-    let settings_path = effective_settings_path(project_dir, home);
+    let global_path = home.join(".claude").join("settings.json");
 
-    let text = match std::fs::read_to_string(&settings_path) {
-        Ok(text) => text,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return DoctorCheck::new(
-                "output_style",
-                CheckStatus::Warn,
-                format!(
-                    "{} not found — outputStyle unconfigured; Claude Code will use its own default",
-                    settings_path.display()
-                ),
-            );
+    if let Some(dir) = project_dir {
+        let project_path = dir.join(".claude").join("settings.json");
+        match read_style_key(&project_path) {
+            Ok(StyleKey::Present(style_id)) => {
+                return evaluate_style(&style_id, home, &project_path, "project");
+            }
+            Ok(StyleKey::Silent) => { /* fall through to global scope below */ }
+            Err(check) => return check,
         }
-        Err(e) => {
-            return DoctorCheck::new(
-                "output_style",
-                CheckStatus::Fail,
-                format!("{} unreadable: {e}", settings_path.display()),
-            );
-        }
-    };
+    }
 
-    let value: serde_json::Value = match serde_json::from_str(&text) {
-        Ok(v) => v,
-        Err(e) => {
-            return DoctorCheck::new(
-                "output_style",
-                CheckStatus::Fail,
-                format!("{} is not valid JSON: {e}", settings_path.display()),
-            );
-        }
-    };
-
-    let Some(style_id) = value.get("outputStyle").and_then(|v| v.as_str()) else {
-        return DoctorCheck::new(
+    match read_style_key(&global_path) {
+        Ok(StyleKey::Present(style_id)) => evaluate_style(&style_id, home, &global_path, "global"),
+        Ok(StyleKey::Silent) => DoctorCheck::new(
             "output_style",
             CheckStatus::Warn,
             format!(
-                "{} has no outputStyle key — Claude Code will use its own default",
-                settings_path.display()
+                "no outputStyle configured (checked project and {}) — \
+                 Claude Code will use its own default",
+                global_path.display()
             ),
-        );
-    };
+        ),
+        Err(check) => check,
+    }
+}
 
+/// Validate a resolved `outputStyle` id against the known styles and the
+/// deployed style files, naming which scope it was resolved from.
+///
+/// Why: shared by both the project-scope and global-scope resolution
+/// branches in [`check_output_style`] so an unknown id or a missing deployed
+/// file is reported identically regardless of which settings file supplied
+/// it — only the reported scope/path differs.
+/// What: `Fail` when `style_id` matches no [`OUTPUT_STYLES`] entry or its
+/// deployed file under `<home>/.claude/output-styles/` is missing/empty;
+/// `Ok` otherwise. `source` and `source_path` are folded into the message so
+/// the operator knows which file the effective value came from.
+/// Test: `output_style_ok_when_style_resolves`, `output_style_fail_when_id_unknown`,
+/// `output_style_fail_when_file_missing`.
+fn evaluate_style(style_id: &str, home: &Path, source_path: &Path, source: &str) -> DoctorCheck {
     let known_ids: Vec<&str> = OUTPUT_STYLES.iter().map(|s| s.id).collect();
     let Some(style) = OUTPUT_STYLES.iter().find(|s| s.id == style_id) else {
         return DoctorCheck::new(
             "output_style",
             CheckStatus::Fail,
             format!(
-                "outputStyle {style_id:?} is not a known trusty-mpm style (valid: {}) — \
-                 run `tm run`/`tm load` to rewrite it correctly",
+                "{source} outputStyle {style_id:?} ({}) is not a known trusty-mpm style \
+                 (valid: {}) — run `tm run`/`tm load` to rewrite it correctly",
+                source_path.display(),
                 known_ids.join(", ")
             ),
         );
@@ -107,7 +172,8 @@ pub(crate) fn check_output_style(project_dir: Option<&Path>, home: &Path) -> Doc
             "output_style",
             CheckStatus::Ok,
             format!(
-                "outputStyle {style_id:?} resolves to {}",
+                "{source} outputStyle {style_id:?} ({}) resolves to {}",
+                source_path.display(),
                 style_path.display()
             ),
         ),
@@ -115,32 +181,13 @@ pub(crate) fn check_output_style(project_dir: Option<&Path>, home: &Path) -> Doc
             "output_style",
             CheckStatus::Fail,
             format!(
-                "outputStyle {style_id:?} is a known id but {} is missing or empty — \
-                 run `tm install` to redeploy styles",
+                "{source} outputStyle {style_id:?} ({}) is a known id but {} is missing or \
+                 empty — run `tm install` to redeploy styles",
+                source_path.display(),
                 style_path.display()
             ),
         ),
     }
-}
-
-/// Resolve the effective `.claude/settings.json` a launched session would see.
-///
-/// Why: `write_output_style` only ever writes the project-local settings file
-/// (`crates/trusty-mpm/src/core/session_launch/settings.rs`); Claude Code
-/// itself falls back to the global `~/.claude/settings.json` when no
-/// project-level file exists, so the probe must mirror that precedence to
-/// inspect the value a session would actually see.
-/// What: returns `<project_dir>/.claude/settings.json` when `project_dir` is
-/// given and that file exists, else `<home>/.claude/settings.json`.
-/// Test: `output_style_prefers_project_over_global`.
-fn effective_settings_path(project_dir: Option<&Path>, home: &Path) -> PathBuf {
-    if let Some(dir) = project_dir {
-        let project_settings = dir.join(".claude").join("settings.json");
-        if project_settings.exists() {
-            return project_settings;
-        }
-    }
-    home.join(".claude").join("settings.json")
 }
 
 #[cfg(test)]
@@ -230,5 +277,57 @@ mod tests {
         write_settings(project.path(), r#"{"outputStyle": "trusty-mpm"}"#);
         let check = check_output_style(Some(project.path()), home.path());
         assert_eq!(check.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn output_style_falls_back_to_global_when_project_silent() {
+        // Issue #1863: the exact incident condition. A project settings file
+        // EXISTS (so the old `effective_settings_path` would stop looking
+        // there) but does not set `outputStyle` — Claude Code itself falls
+        // back to the global value in that case, and so must this check. The
+        // global value here is the bad incident id, so this must Fail, not
+        // silently report Warn/Ok from the project scope.
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        write_settings(home.path(), r#"{"outputStyle": "claude_mpm"}"#);
+        write_settings(project.path(), r#"{"theme": "dark"}"#);
+        let check = check_output_style(Some(project.path()), home.path());
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.message.contains("claude_mpm"));
+        assert!(
+            check.message.contains("global"),
+            "message must name the resolved scope: {}",
+            check.message
+        );
+    }
+
+    #[test]
+    fn output_style_falls_back_to_global_when_project_missing() {
+        // No project settings file at all (e.g. `tm doctor` run before the
+        // project has ever launched a session) must still catch a bad global
+        // value.
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        write_settings(home.path(), r#"{"outputStyle": "claude_mpm"}"#);
+        let check = check_output_style(Some(project.path()), home.path());
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.message.contains("claude_mpm"));
+    }
+
+    #[test]
+    fn output_style_reports_project_scope_on_success() {
+        // The `Ok` message must name which scope ("project") supplied the
+        // resolved value, so operators can tell the two apart.
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        deploy_default_style(home.path());
+        write_settings(project.path(), r#"{"outputStyle": "trusty-mpm"}"#);
+        let check = check_output_style(Some(project.path()), home.path());
+        assert_eq!(check.status, CheckStatus::Ok);
+        assert!(
+            check.message.contains("project"),
+            "message must name the resolved scope: {}",
+            check.message
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three small, independent test-hygiene / output-style bugs in trusty-mpm, all filed under epic #1855:

- **#1860** — `prepare_session`'s output-style deploy step called `dirs::home_dir()` directly instead of honoring the injected `FrameworkPaths` base, so tests using `FrameworkPaths::under(tempdir)` silently leaked writes into the real `~/.claude/output-styles/trusty-mpm.md`. Added `FrameworkPaths::claude_home_dir()` (recovers the exact base a `FrameworkPaths` was resolved against) and routed the deploy through it.
- **#1863** — `check_output_style` stopped looking at the project settings file as soon as it existed, even when that file had no `outputStyle` key — so a project settings file silent on the key masked a bad *global* value, missing the exact DOC-28 R4 incident condition. Rewrote resolution to fall through to the global settings file when the project scope is silent (missing file OR missing key), and the report now names which scope ("project"/"global") supplied the resolved value.
- **#1858** — `image_shading_emits_truecolor` raced every sibling test in `two_panel.rs` because `shade_image()` read the process-global `colored::control` override internally while ~13 tests in that file flip the same global with no synchronization. Made `shade_image(art, use_color)` take the color decision as an explicit parameter (dependency injection) instead of probing the global; the one legitimate production call site (`load_and_shade_banner`) still probes the global once and threads the result down.

## Test plan

- [x] `cargo test -p trusty-mpm` — all green (2164 + 603×2 + … across lib/bin/integration tests, 0 failed)
- [x] `image_shading_emits_truecolor` run 10x back-to-back (isolated and alongside its ~48 banner siblings under default parallel threading) — 10/10 passing
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (14 allowlisted, 0 violations)
- [x] Verified `~/.claude/output-styles/trusty-mpm.md` mtime is unchanged after a full test run (confirms #1860 fix)

Closes #1860, #1863, #1858.