### PR TITLE
feat(trusty-mpm): auto-seed R3 identity prompt-fact at provision (DOC-28 Phase 2)

### DIFF
--- a/crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md
+++ b/crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md
@@ -87,12 +87,25 @@ exact wording):
 4. **State the disambiguation explicitly when relevant** — this is
    `trusty-mpm` (binary `tm`), NOT `claude-mpm`.
 
-## Memory seeding (R3 — manual step)
+## Memory seeding (R3)
 
 `get_prompt_context()` surfaces `is_fact` triples from every registered
 trusty-memory palace (see `crates/trusty-memory/src/prompt_facts.rs`), but no
-identity fact exists until one is seeded. Run this once per trusty-memory
-install/upgrade (any palace — the fact is visible cross-palace):
+identity fact exists until one is seeded.
+
+**Automatic (DOC-28 §7 Phase 2, epic #1855):** every time `tm` provisions a
+brand-new managed-session workspace (`WorkspaceProvisioner::provision_in`,
+`crates/trusty-mpm/src/provisioner/workspace.rs`), it attempts this seed once
+against the session's derived palace. The attempt is guarded by a `kg_query`
+idempotency check (skips the assert if the triple already exists) and is
+fail-open: an unreachable trusty-memory daemon, a non-2xx response, or a parse
+error is logged and swallowed, never blocking or failing provisioning. This
+only fires at provision time (a new workspace being created), not on every
+`tm session start`/`connect`/resume of an existing project directory.
+
+**Manual (fallback / any palace):** run this once per trusty-memory
+install/upgrade if you are not going through the managed-session provisioner
+(any palace — the fact is visible cross-palace):
 
 ```
 kg_assert(
@@ -106,9 +119,8 @@ kg_assert(
 
 Via the MCP tool surface this is `mcp__trusty-memory__kg_assert` with the same
 arguments. Re-running it is safe (idempotent in effect — it re-asserts the
-same triple). An automatic, idempotent seed call from `prepare_session` is
-deferred future work (DOC-28 §7 Phase 2) — until it lands, this manual step is
-what makes the fact appear in `get_prompt_context()`'s "### Facts" section.
+same triple), and it uses the identical subject/predicate/object as the
+automatic path, so the two are interchangeable.
 
 ## Verifying the instructions actually loaded
 

--- a/crates/trusty-mpm/src/provisioner/identity_seed.rs
+++ b/crates/trusty-mpm/src/provisioner/identity_seed.rs
@@ -1,0 +1,271 @@
+//! Auto-seed the R3 memory prompt-fact identity pointer at workspace provision
+//! (DOC-28 §5 / §7 Phase 2, epic #1855).
+//!
+//! Why: `get_prompt_context()` (`crates/trusty-memory/src/prompt_facts.rs`)
+//! surfaces `is_fact` triples from every registered trusty-memory palace, but
+//! the identity fact disambiguating `trusty-mpm` (binary `tm`, the Rust
+//! Meta-Harness) from the unrelated Python `claude-mpm` project only appears
+//! once someone runs the manual `kg_assert` step documented in
+//! `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md`'s "Memory seeding" section.
+//! DOC-28 §10 asks whether that seed should run automatically; this module
+//! implements the chosen policy: first-run/provision only, idempotency-guarded,
+//! fail-open. It fires from [`crate::provisioner::workspace::WorkspaceProvisioner::provision_in`]
+//! — the one place a brand-new managed-session workspace is created — rather
+//! than from the general `prepare_session` path that also runs on every
+//! resume/connect, so the seed attempt happens once per provisioned workspace
+//! instead of on every launch.
+//! What: [`seed_identity_prompt_fact_blocking`] is the synchronous entry point
+//! [`WorkspaceProvisioner::provision_in`] calls. It spawns a dedicated OS
+//! thread running a fresh `current_thread` Tokio runtime (mirroring
+//! `trusty_common::catchup::run_catchup_blocking`) so it never conflicts with
+//! whatever async runtime the caller may already be inside, then runs
+//! [`seed_identity_prompt_fact`]: a `kg_query(subject: "trusty-mpm")` call
+//! against the session's palace as an idempotency guard, followed by a
+//! `kg_assert` only when no `is_fact` triple already exists.
+//! Test: `identity_fact_present_detects_existing_fact`,
+//! `identity_fact_present_false_when_absent`, `seed_is_fail_open_on_unreachable_daemon`.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// Subject the identity prompt-fact is asserted against.
+///
+/// Why: must match the literal subject `get_prompt_context()`'s
+/// `gather_hot_triples` surfaces and the one documented in
+/// `WHAT-IS-TRUSTY-MPM.md`'s manual seeding step, so the automatic and manual
+/// seed paths are interchangeable/idempotent with each other.
+const IDENTITY_SUBJECT: &str = "trusty-mpm";
+
+/// Predicate used for the identity prompt-fact.
+///
+/// Why: `is_fact` is already a member of trusty-memory's `HOT_PREDICATES`
+/// (`prompt_facts.rs`), so no trusty-memory code change is required for the
+/// seeded triple to surface in `get_prompt_context()`.
+const IDENTITY_PREDICATE: &str = "is_fact";
+
+/// Object text for the seeded identity prompt-fact (DOC-28 §5 acceptance
+/// criteria: must contain the R1 doc's canonical deployed path and the
+/// disambiguation clause).
+const IDENTITY_OBJECT: &str = "trusty-mpm (binary tm) is the Rust Meta-Harness / control plane, NOT the Python claude-mpm project; see crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md or ~/.trusty-mpm/framework/docs/WHAT-IS-TRUSTY-MPM.md";
+
+/// Provenance tag for the seeded triple, matching the manual step documented
+/// in `WHAT-IS-TRUSTY-MPM.md`.
+const IDENTITY_PROVENANCE: &str = "DOC-28 self-awareness seed";
+
+/// Minimal shape of a triple as returned by `GET /api/v1/palaces/{id}/kg`.
+///
+/// Why: mirrors the fail-open, minimal-deserialization pattern already used by
+/// `trusty_common::catchup::palace::RawDrawer` — only the two fields the
+/// idempotency check needs are read; unknown fields are ignored.
+/// What: `subject`/`predicate` pair; missing fields default to empty string so
+/// a malformed/partial record never panics the parse.
+/// Test: `identity_fact_present_detects_existing_fact`.
+#[derive(Debug, Deserialize)]
+struct RawTriple {
+    #[serde(default)]
+    subject: String,
+    #[serde(default)]
+    predicate: String,
+}
+
+/// True when `triples` already contains the seeded identity `is_fact` triple.
+///
+/// Why: isolates the pure idempotency decision from the HTTP layer so it is
+/// unit-testable without a live trusty-memory daemon.
+/// What: returns true iff any triple has `subject == "trusty-mpm"` and
+/// `predicate == "is_fact"`.
+/// Test: `identity_fact_present_detects_existing_fact`,
+/// `identity_fact_present_false_when_absent`.
+fn identity_fact_present(triples: &[RawTriple]) -> bool {
+    triples
+        .iter()
+        .any(|t| t.subject == IDENTITY_SUBJECT && t.predicate == IDENTITY_PREDICATE)
+}
+
+/// Seed the R3 identity prompt-fact into `palace_id`, fail-open.
+///
+/// Why: the async body of the auto-seed step; kept separate from the blocking
+/// wrapper so the HTTP round-trips can be tested directly with `#[tokio::test]`.
+/// What: builds a short-timeout `reqwest::Client`, issues
+/// `GET {memory_url}/api/v1/palaces/{palace_id}/kg?subject=trusty-mpm` as the
+/// idempotency guard, and — only when [`identity_fact_present`] returns false —
+/// issues `POST {memory_url}/api/v1/palaces/{palace_id}/kg` with the identity
+/// triple. Any client-build failure, connection error, non-2xx response, or
+/// JSON-parse failure at any step is logged to stderr via `tracing::warn!` and
+/// swallowed: this function never returns an error and never panics, so it can
+/// never block or fail workspace provisioning.
+/// Test: `seed_is_fail_open_on_unreachable_daemon`.
+async fn seed_identity_prompt_fact(memory_url: &str, palace_id: &str) {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("identity-seed: could not build HTTP client: {e}");
+            return;
+        }
+    };
+
+    let base = memory_url.trim_end_matches('/');
+    let query_url = format!("{base}/api/v1/palaces/{palace_id}/kg");
+    let resp = match client
+        .get(&query_url)
+        .query(&[("subject", IDENTITY_SUBJECT)])
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("identity-seed: could not reach trusty-memory at {memory_url}: {e}");
+            return;
+        }
+    };
+    if !resp.status().is_success() {
+        tracing::warn!(
+            "identity-seed: trusty-memory returned {} for identity kg_query",
+            resp.status()
+        );
+        return;
+    }
+    let triples: Vec<RawTriple> = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("identity-seed: could not parse kg_query response: {e}");
+            return;
+        }
+    };
+
+    if identity_fact_present(&triples) {
+        tracing::debug!("identity-seed: identity prompt-fact already present, skipping assert");
+        return;
+    }
+
+    let assert_url = format!("{base}/api/v1/palaces/{palace_id}/kg");
+    let body = serde_json::json!({
+        "subject": IDENTITY_SUBJECT,
+        "predicate": IDENTITY_PREDICATE,
+        "object": IDENTITY_OBJECT,
+        "provenance": IDENTITY_PROVENANCE,
+    });
+    match client.post(&assert_url).json(&body).send().await {
+        Ok(r) if r.status().is_success() => {
+            tracing::info!(
+                "identity-seed: seeded trusty-mpm identity prompt-fact into palace {palace_id}"
+            );
+        }
+        Ok(r) => {
+            tracing::warn!(
+                "identity-seed: trusty-memory returned {} for identity kg_assert",
+                r.status()
+            );
+        }
+        Err(e) => {
+            tracing::warn!("identity-seed: could not reach trusty-memory at {memory_url}: {e}");
+        }
+    }
+}
+
+/// Synchronous, fail-open entry point for [`super::workspace::WorkspaceProvisioner::provision_in`].
+///
+/// Why: `provision_in` is a synchronous function that may itself be called
+/// from inside an async handler (`daemon/managed_routes/lifecycle.rs`), so this
+/// cannot simply call `tokio::runtime::Handle::block_on` (that would panic
+/// with "Cannot start a runtime from within a runtime" when already inside
+/// one). Spawning a dedicated OS thread with its own `current_thread` runtime
+/// — the same technique `trusty_common::catchup::run_catchup_blocking` uses —
+/// sidesteps that entirely.
+/// What: spawns a thread, builds a `current_thread` Tokio runtime on it, and
+/// blocks on [`seed_identity_prompt_fact`]. A runtime-build failure or a
+/// panicked/join-failed thread is logged and swallowed — never propagated to
+/// the caller.
+/// Test: `seed_is_fail_open_on_unreachable_daemon` (exercises the async body
+/// directly under `#[tokio::test]`); the thread-spawn wrapper itself has no
+/// independent behaviour to assert beyond "does not panic", which every test
+/// in this module already exercises by construction.
+pub fn seed_identity_prompt_fact_blocking(memory_url: &str, palace_id: &str) {
+    let memory_url = memory_url.to_string();
+    let palace_id = palace_id.to_string();
+    let joined = std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build();
+        match rt {
+            Ok(rt) => rt.block_on(seed_identity_prompt_fact(&memory_url, &palace_id)),
+            Err(e) => {
+                tracing::warn!("identity-seed: could not build tokio runtime: {e}");
+            }
+        }
+    })
+    .join();
+    if joined.is_err() {
+        tracing::warn!("identity-seed: seed thread panicked; skipping");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_triple(subject: &str, predicate: &str) -> RawTriple {
+        RawTriple {
+            subject: subject.to_string(),
+            predicate: predicate.to_string(),
+        }
+    }
+
+    #[test]
+    fn identity_fact_present_detects_existing_fact() {
+        let triples = vec![
+            make_triple("some-other-subject", "is_fact"),
+            make_triple(IDENTITY_SUBJECT, IDENTITY_PREDICATE),
+        ];
+        assert!(identity_fact_present(&triples));
+    }
+
+    #[test]
+    fn identity_fact_present_false_when_absent() {
+        let triples = vec![
+            make_triple(IDENTITY_SUBJECT, "some_other_predicate"),
+            make_triple("unrelated", IDENTITY_PREDICATE),
+        ];
+        assert!(!identity_fact_present(&triples));
+    }
+
+    #[test]
+    fn identity_fact_present_false_for_empty_response() {
+        let triples: Vec<RawTriple> = vec![];
+        assert!(!identity_fact_present(&triples));
+    }
+
+    /// Idempotency guard, exercised without a live daemon: a kg_query response
+    /// that already contains the identity fact must short-circuit before the
+    /// (unreachable) assert step would ever be attempted, mirroring what
+    /// `seed_identity_prompt_fact` does after parsing a successful kg_query.
+    #[test]
+    fn identity_fact_present_skips_when_already_seeded() {
+        let already_seeded = vec![make_triple(IDENTITY_SUBJECT, IDENTITY_PREDICATE)];
+        assert!(
+            identity_fact_present(&already_seeded),
+            "a kg_query response containing the identity triple must be treated as already seeded"
+        );
+    }
+
+    /// Fail-open contract: an unreachable trusty-memory daemon must not panic
+    /// or hang the caller — the async body just logs and returns.
+    #[tokio::test]
+    async fn seed_is_fail_open_on_unreachable_daemon() {
+        // Port 1 is a reserved/unassigned port that nothing listens on, so the
+        // connection fails fast without needing a real daemon or a mock server.
+        seed_identity_prompt_fact("http://127.0.0.1:1", "test-palace").await;
+        // Reaching this line without panicking/hanging proves fail-open.
+    }
+
+    /// Fail-open contract for the synchronous wrapper used by production code:
+    /// must return promptly without panicking even when the daemon is unreachable.
+    #[test]
+    fn seed_blocking_is_fail_open_on_unreachable_daemon() {
+        seed_identity_prompt_fact_blocking("http://127.0.0.1:1", "test-palace");
+    }
+}

--- a/crates/trusty-mpm/src/provisioner/mod.rs
+++ b/crates/trusty-mpm/src/provisioner/mod.rs
@@ -10,6 +10,7 @@
 //! Test: unit tests in workspace.rs use FakeGitBackend; integration test
 //! test_provision_real_repo uses a temp bare repo (marked #[ignore]).
 
+mod identity_seed;
 pub mod workspace;
 
 pub use workspace::{

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -491,6 +491,39 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
             }
         }
 
+        // DOC-28 §5/§7 Phase 2 (R3, epic #1855): auto-seed the trusty-mpm
+        // identity prompt-fact the first time a workspace is provisioned for a
+        // managed session. Gated on `self.prepare` (not a dedicated config
+        // toggle, per the owner's "don't over-engineer" call) so the
+        // lightweight `without_prepare` test provisioner never performs this
+        // network I/O, exactly like the `prepare_session` step above.
+        // Idempotency is enforced inside the helper via a kg_query guard, and
+        // it is entirely fail-open: any daemon-unreachable/parse error is
+        // logged and swallowed, never propagated here.
+        if self.prepare {
+            let memory_url = std::env::var("TRUSTY_MEMORY_URL")
+                .unwrap_or_else(|_| "http://127.0.0.1:7990".to_string());
+            let override_value = trusty_common::palace_override_from_env();
+            match trusty_common::derive_palace_id(
+                &workspace_path,
+                Some(repo_url),
+                override_value.as_deref(),
+            ) {
+                Some(palace_id) => {
+                    super::identity_seed::seed_identity_prompt_fact_blocking(
+                        &memory_url,
+                        &palace_id,
+                    );
+                }
+                None => {
+                    tracing::debug!(
+                        session = %session_id,
+                        "identity-seed: skipping — no palace could be derived for this workspace"
+                    );
+                }
+            }
+        }
+
         Ok(PreparedWorkspace {
             path: workspace_path,
             repo_url: repo_url.to_owned(),


### PR DESCRIPTION
## Summary

Implements DOC-28 Phase 2 "R3 — Memory prompt-fact identity pointer" auto-seed
(spec: `docs/specs/trusty-mpm-self-awareness.md` §5, §7 Phase 2, §10; epic
#1855). Adds a fail-open, idempotency-guarded automatic seed of the trusty-mpm
identity prompt-fact into trusty-memory, so `get_prompt_context()`'s "Facts"
section surfaces the disambiguation (`trusty-mpm` = Rust Meta-Harness, NOT the
Python `claude-mpm` project) without requiring an operator to run the manual
`kg_assert` step from `WHAT-IS-TRUSTY-MPM.md` first.

**Trigger policy: first-run / provision only, idempotent, fail-open.**

- **Trigger:** the seed attempt fires from
  `WorkspaceProvisioner::provision_in` (`crates/trusty-mpm/src/provisioner/workspace.rs`)
  — the one code path that clones a brand-new managed-session workspace
  (`tm session new` / the daemon's managed-spawn lifecycle). It deliberately
  does **not** hook the general `prepare_session` path, because that also runs
  on every `tm session start` / `tm connect` / resume of an *existing* project
  directory — hooking it there would re-attempt the seed on every launch, not
  just first-run/provision, per the owner's explicit choice.
- **Idempotent:** before asserting, the helper issues a `kg_query(subject:
  "trusty-mpm")` against the session's derived palace and only issues the
  `kg_assert` if no `is_fact` triple already exists for that subject/predicate.
  This is the safety net for re-provisioning and for interaction with the
  existing manual seed step (both write the identical
  subject/predicate/object, so they're mutually idempotent).
- **Fail-open:** any HTTP client-build failure, connection error, non-2xx
  response, or JSON-parse error at any step is logged via `tracing::warn!`/`debug!`
  and swallowed. The function never returns an error and never panics, so it
  can never block or fail workspace provisioning — mirrors the existing DOC-28
  catch-up block's error-handling shape
  (`trusty_common::catchup::palace::fetch_recent_palace_drawers`).

**No dedicated config toggle was added.** Per the "don't over-engineer"
guidance in the ticket, the seed is unconditional-but-provision-gated: it's
gated on the existing `WorkspaceProvisioner::prepare` flag (the same flag that
already gates whether `prepare_session` itself runs), rather than introducing
a new `MpmConfig` section that would require threading a fresh config load
through the daemon's managed-session spawn path and two provisioner
constructors. This means the lightweight `WorkspaceProvisioner::without_prepare`
test provisioner skips the seed exactly like it already skips `prepare_session`
— no test performs unwanted network I/O.

## Changes

- `crates/trusty-mpm/src/provisioner/identity_seed.rs` (new): the fail-open
  `seed_identity_prompt_fact_blocking` entry point + async
  `seed_identity_prompt_fact` body + pure `identity_fact_present` idempotency
  decision (unit-testable without a live daemon). Uses the same
  spawn-a-thread-with-a-fresh-`current_thread`-runtime technique as
  `trusty_common::catchup::run_catchup_blocking`, so it's safe to call from
  `provision_in` regardless of whether the caller is already inside an async
  runtime (avoids the "Cannot start a runtime from within a runtime" panic).
- `crates/trusty-mpm/src/provisioner/workspace.rs`: wires the seed call into
  `provision_in`, deriving the target palace via the same
  `trusty_common::derive_palace_id` the existing trusty-memory MCP injection
  uses.
- `crates/trusty-mpm/src/provisioner/mod.rs`: registers the new `identity_seed`
  submodule.
- `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md`: documents the new automatic
  path alongside the existing manual `kg_assert` fallback.

## Test plan

- [x] `cargo test -p trusty-mpm` — 2165 lib tests + all integration suites,
      0 failed (raw output below)
- [x] New unit tests in `identity_seed.rs`:
      `identity_fact_present_detects_existing_fact`,
      `identity_fact_present_false_when_absent`,
      `identity_fact_present_false_for_empty_response`,
      `identity_fact_present_skips_when_already_seeded` (idempotency),
      `seed_is_fail_open_on_unreachable_daemon`,
      `seed_blocking_is_fail_open_on_unreachable_daemon` (fail-open, both the
      async body and the sync wrapper, against an unreachable `127.0.0.1:1`)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (0 violations; new file 151
      SLOC, `workspace.rs` grew to 450 SLOC, both under the 500 cap)

```
$ cargo test -p trusty-mpm --lib identity_seed
running 6 tests
test provisioner::identity_seed::tests::identity_fact_present_false_for_empty_response ... ok
test provisioner::identity_seed::tests::identity_fact_present_detects_existing_fact ... ok
test provisioner::identity_seed::tests::identity_fact_present_skips_when_already_seeded ... ok
test provisioner::identity_seed::tests::identity_fact_present_false_when_absent ... ok
test provisioner::identity_seed::tests::seed_is_fail_open_on_unreachable_daemon ... ok
test provisioner::identity_seed::tests::seed_blocking_is_fail_open_on_unreachable_daemon ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 2162 filtered out; finished in 0.01s
```

```
$ cargo test -p trusty-mpm 2>&1 | grep -E "FAILED|test result"
test result: ok. 2165 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 3.94s
test result: ok. 603 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 16.68s
test result: ok. 603 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 17.26s
... (18 test binaries total, all ok, 0 failed)
```

```
$ bash scripts/check_line_cap.sh
line-cap: 14 allowlisted, 0 violations — OK.
```

Note: this branch was cut from `origin/main` (not from a concurrent PR
touching `session_launch/mod.rs` lines ~411-448) — this PR does not touch
`session_launch/mod.rs` at all, so there should be no overlap with that
concurrent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)