### PR TITLE
docs: ingrain delivery workflow (source=origin/main:HEAD)

### DIFF
--- a/.claude-mpm/INSTRUCTIONS.md
+++ b/.claude-mpm/INSTRUCTIONS.md
@@ -19,7 +19,12 @@ This is a unified Cargo workspace. Key rules:
 Internal-only crates (never published) resolve via workspace path deps — no `[patch.crates-io]` entry needed. Published sidecar lib crates (e.g. `trusty-embedderd`, `trusty-bm25-daemon`) DO need `[patch.crates-io]` entries in the workspace root `Cargo.toml` so local builds use the in-tree source. See the Single-Install Convention section below.
 
 ### Required Workflow Sequence
-(prompt → ticket) OR (check tickets) → read ticket → implement → test → build → version bump → publish → update consumers → verify CI
+
+**Full delivery chain (spec → issue → worktree branch → PR → trusty-review → squash-merge → release):**
+
+(prompt → ticket) OR (check tickets) → read ticket → **git fetch origin main** → **create worktree off origin/main** → implement → test → build → **commit & push → create PR** → **trusty-review gate** → **squash-merge to main** → version bump → publish → update consumers → verify CI
+
+**Source of truth = `origin/main:HEAD`** — the main checkout is inspection-only. Always `git fetch origin main` and branch worktrees off `origin/main` because local main may be stale. Never commit directly to main; only through PR + trusty-review + squash-merge.
 
 ### Phase 0: Ticket
 No work begins without a ticket reference.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,6 +386,8 @@ When publishing a crate to crates.io:
 
 **CRITICAL RULES FOR CONCURRENT SESSIONS:**
 
+🔴 **SOURCE OF TRUTH = `origin/main:HEAD`.** Local `main` may be stale. **Always `git fetch origin main` and branch worktrees off `origin/main`** (not local main). Stale local main has caused lost commits and missed features. This is not optional.
+
 🔴 **The main checkout is inspection-only.** From the repo root
 (`/path/to/trusty-tools/`), the only allowed operations are read-only: `git status`,
 `git log`, `git diff`, `git show`, file reads. **FORBIDDEN**: edits, `git reset --hard`,
@@ -402,6 +404,8 @@ git worktree add -b <feature-or-fix-branch> \
 cd .claude/worktrees/<dirname>
 # … edit, build, test, commit, push from here …
 ```
+
+**End-to-end delivery chain:** spec → issue → worktree branch → PR (linked to issue) → trusty-review gate → squash-merge → worktree cleanup. See `.claude-mpm/INSTRUCTIONS.md` for the full required sequence.
 
 Each ticket, refactor, or experiment gets its own worktree. Worktrees are
 disposable — delete them with `git worktree remove --force <path>` once the


### PR DESCRIPTION
## Summary

Documentation-only change to firmly embed the trusty-tools delivery workflow and worktree discipline into the two files agents and PM load every session.

**Key changes:**
- `.claude-mpm/INSTRUCTIONS.md`: Replaced vague "workflow sequence" with full delivery chain (spec → issue → worktree → PR → review → merge → release) and added explicit callout that local main can be stale—always fetch and branch off origin/main
- `CLAUDE.md`: Added bold callout in Parallel Worktree Discipline section about stale local main, plus reference to full delivery chain in `.claude-mpm/INSTRUCTIONS.md`

**Why:** Local main can drift; this has caused lost commits and missed features. The canonical rule must be unmistakable: source of truth = origin/main:HEAD. All work happens in worktrees branched off origin/main, never local main.

## Test plan

- [x] Verified both files are git-tracked
- [x] Edits are surgical (no restructuring, preserves all other content)
- [x] Markdown syntax correct (no link breakage)
- [x] Prose consistent between files (same terminology)
- [x] Commit includes Co-Authored-By footer
- [x] Branch created off origin/main (dogfooding worktree discipline)

🤖 Generated with Claude Code