### PR TITLE
fix(tm): session attach uses switch-client inside tmux (nested-tmux fix)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -621,21 +621,19 @@ async fn resume_guided_session(
     tmux_attach(&session.name)
 }
 
-/// Invoke `tmux attach-session -t <name>` and await exit.
+/// Attach (or switch) the current terminal into tmux session `name`.
 ///
-/// Why: resuming a session means handing the terminal over to tmux.
-/// What: shells out to `tmux attach-session -t <name>` and waits; returns
-/// `Err` if tmux exits with a non-zero status.
-/// Test: exercised indirectly by the picker flow; mocked in unit tests via
-/// process stubs.
+/// Why: resuming a session means handing the terminal over to tmux; when the
+/// operator is already inside a tmux client, a plain `attach-session` is
+/// refused by tmux (nesting guard), so the actual argv choice is delegated to
+/// the shared [`crate::commands::tmux_attach::tmux_attach`] helper (#1873).
+/// What: thin re-export so existing call sites in this file don't need to
+/// change their import path.
+/// Test: `attach_argv_inside_tmux_uses_switch_client`,
+/// `attach_argv_outside_tmux_uses_attach_session` in `tmux_attach.rs` cover
+/// the argv decision; exercised indirectly here by the picker flow.
 fn tmux_attach(name: &str) -> anyhow::Result<()> {
-    eprintln!("tm: attaching to session '{name}'");
-    let status = std::process::Command::new("tmux")
-        .args(["attach-session", "-t", name])
-        .status()
-        .context("failed to invoke tmux")?;
-    anyhow::ensure!(status.success(), "tmux attach-session exited with failure");
-    Ok(())
+    crate::commands::tmux_attach::tmux_attach(name)
 }
 
 /// POST a new managed session to the daemon and attach to it.

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -139,12 +139,7 @@ pub(crate) async fn launch(
         && !existing.is_empty()
     {
         print_launch_banner_reconnecting(&live_workdir, &existing);
-        let status = std::process::Command::new("tmux")
-            .args(["attach-session", "-t", &existing])
-            .status()?;
-        if !status.success() {
-            anyhow::bail!("tmux attach-session exited with failure");
-        }
+        crate::commands::tmux_attach::tmux_attach(&existing)?;
         return Ok(());
     }
 
@@ -353,12 +348,7 @@ pub(crate) async fn launch(
     }
 
     // 14. Attach to the session — blocks until the user detaches or exits claude.
-    let status = std::process::Command::new("tmux")
-        .args(["attach-session", "-t", &tmux_name])
-        .status()?;
-    if !status.success() {
-        anyhow::bail!("tmux attach-session exited with failure");
-    }
+    crate::commands::tmux_attach::tmux_attach(&tmux_name)?;
     // Attach succeeded: the user detached normally. Disarm the guard so the
     // session persists and can be resumed with `tmux attach -t <name>`.
     session_guard.disarm();
@@ -400,12 +390,7 @@ pub(crate) async fn connect(
     {
         // Full-screen robot splash + rich info panel (reconnect mode).
         print_launch_banner_reconnecting(&workdir, &existing);
-        let status = std::process::Command::new("tmux")
-            .args(["attach-session", "-t", &existing])
-            .status()?;
-        if !status.success() {
-            anyhow::bail!("tmux attach-session exited with failure");
-        }
+        crate::commands::tmux_attach::tmux_attach(&existing)?;
         return Ok(());
     }
 
@@ -483,12 +468,7 @@ pub(crate) async fn connect(
     }
 
     // 6. Attach — takes over the current terminal until the user detaches.
-    let status = std::process::Command::new("tmux")
-        .args(["attach-session", "-t", &tmux_name])
-        .status()?;
-    if !status.success() {
-        anyhow::bail!("tmux attach-session exited with failure");
-    }
+    crate::commands::tmux_attach::tmux_attach(&tmux_name)?;
     // Attach succeeded: disarm the guard so the session persists for re-attachment.
     if let Some(ref mut g) = session_guard {
         g.disarm();

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -36,4 +36,5 @@ pub(crate) mod statusline;
 pub(crate) mod supervisor;
 pub(crate) mod telegram;
 pub(crate) mod ticket;
+pub(crate) mod tmux_attach;
 pub(crate) mod watch;

--- a/crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs
@@ -1,0 +1,118 @@
+//! Nested-tmux-safe attach helper shared by `tm launch`, `tm connect`, and the
+//! guided picker's resume/restart paths.
+//!
+//! Why: tmux refuses `attach-session` when invoked from inside an existing
+//! tmux client (i.e. `$TMUX` is set), to avoid nesting one tmux client inside
+//! another. Every call site that hands the terminal over to a tmux session hit
+//! this failure identically ("sessions should be nested with care, unset
+//! $TMUX to force" / `Error: tmux attach-session exited with failure").
+//! What: [`attach_argv`] is the pure decision function (testable without
+//! spawning tmux) that picks `switch-client` vs `attach-session` argv based on
+//! whether the caller is already inside tmux; [`inside_tmux`] reads `$TMUX`;
+//! [`tmux_attach`] ties them together — it shells out to the resulting tmux
+//! subcommand and translates a `switch-client` failure into an actionable
+//! hint.
+//! Test: `attach_argv_inside_tmux_uses_switch_client`,
+//! `attach_argv_outside_tmux_uses_attach_session` cover the pure decision
+//! logic directly; `tmux_attach` itself is exercised indirectly by the
+//! picker/launch/connect flows (it spawns a real `tmux` process).
+
+use anyhow::Context as _;
+
+/// Build the tmux argv for attaching to `session`, adapting to nesting.
+///
+/// Why: `tmux attach-session` errors out when `$TMUX` is already set (a
+/// nested client), but `switch-client -t <session>` is the documented
+/// nested-safe idiom — it moves the *current* client to the target session
+/// instead of trying to spawn a new client inside the existing one.
+/// What: returns `["switch-client", "-t", session]` when `inside_tmux` is
+/// `true`, else `["attach-session", "-t", session]`.
+/// Test: `attach_argv_inside_tmux_uses_switch_client`,
+/// `attach_argv_outside_tmux_uses_attach_session`.
+pub(crate) fn attach_argv(session: &str, inside_tmux: bool) -> Vec<String> {
+    let verb = if inside_tmux {
+        "switch-client"
+    } else {
+        "attach-session"
+    };
+    vec![verb.to_string(), "-t".to_string(), session.to_string()]
+}
+
+/// Detect whether the current process is already running inside a tmux client.
+///
+/// Why: centralizes the `$TMUX` check so every call site uses identical
+/// semantics — an empty value (which tmux never sets, but a shell script
+/// could export) is treated the same as unset.
+/// What: returns `true` when the `TMUX` environment variable is set to a
+/// non-empty string.
+/// Test: environment-dependent, so it is exercised indirectly; `attach_argv`
+/// takes the resulting bool directly so its tests stay hermetic.
+pub(crate) fn inside_tmux() -> bool {
+    std::env::var("TMUX")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
+/// Attach (or switch) the current terminal into the tmux session `name`.
+///
+/// Why: single choke point for the nested-tmux-safe attach behavior so
+/// `guided.rs` and `launch.rs` don't each re-implement the `$TMUX` branch —
+/// and so a `switch-client` failure gets a more actionable error than a bare
+/// "exited with failure".
+/// What: shells out to `tmux <attach_argv(name, inside_tmux())>` and waits;
+/// returns `Err` if tmux exits with a non-zero status. When the nested-client
+/// `switch-client` path fails, the error mentions that the target session may
+/// live on a different tmux server.
+/// Test: exercised indirectly by the picker/launch/connect flows; the argv
+/// selection itself is unit-tested via `attach_argv`.
+pub(crate) fn tmux_attach(name: &str) -> anyhow::Result<()> {
+    let inside = inside_tmux();
+    let argv = attach_argv(name, inside);
+    let verb = argv[0].clone();
+    eprintln!("tm: attaching to session '{name}'");
+    let status = std::process::Command::new("tmux")
+        .args(&argv)
+        .status()
+        .context("failed to invoke tmux")?;
+    if !status.success() {
+        if inside {
+            anyhow::bail!(
+                "tmux {verb} exited with failure — the target session '{name}' may be \
+                 attached on a different tmux server; try `tmux -L <socket> switch-client -t \
+                 {name}` or detach the other client first"
+            );
+        }
+        anyhow::bail!("tmux {verb} exited with failure");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Inside an existing tmux client, attach must use `switch-client` — this
+    /// is the nested-safe idiom that moves the current client instead of
+    /// spawning a nested one (which tmux refuses).
+    ///
+    /// Test: this function IS the test.
+    #[test]
+    fn attach_argv_inside_tmux_uses_switch_client() {
+        assert_eq!(
+            attach_argv("tmpm-mcp-a-protocol-00f6f5ef", true),
+            vec!["switch-client", "-t", "tmpm-mcp-a-protocol-00f6f5ef"]
+        );
+    }
+
+    /// Outside tmux, attach must keep using `attach-session` — today's
+    /// behavior, unchanged for the non-nested case.
+    ///
+    /// Test: this function IS the test.
+    #[test]
+    fn attach_argv_outside_tmux_uses_attach_session() {
+        assert_eq!(
+            attach_argv("my-session", false),
+            vec!["attach-session", "-t", "my-session"]
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs
@@ -69,7 +69,11 @@ pub(crate) fn tmux_attach(name: &str) -> anyhow::Result<()> {
     let inside = inside_tmux();
     let argv = attach_argv(name, inside);
     let verb = argv[0].clone();
-    eprintln!("tm: attaching to session '{name}'");
+    if inside {
+        eprintln!("tm: switching client to session '{name}'");
+    } else {
+        eprintln!("tm: attaching to session '{name}'");
+    }
     let status = std::process::Command::new("tmux")
         .args(&argv)
         .status()

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -664,6 +664,13 @@ async fn guided_fallback_does_not_refuse_github_ssh_alias_remote() {
     // `fallback_protected`. Asserts the result is NOT the GitHub-remote
     // refusal error. (It may still be an Err from the clone attempt failing
     // due to the daemon being unreachable — that is expected and acceptable.)
+    // Deliberately uses a fixture-only host/owner/repo (NOT the real
+    // `github-duetto` alias from the regression report above) — a developer
+    // machine may have a real, reachable SSH config entry with that exact
+    // name (as this repo's own maintainer's machine does), which would let
+    // `ensure_base_clone` actually succeed and make this test flaky/order-
+    // dependent on local SSH config instead of hermetic (discovered while
+    // fixing the nested-tmux attach bug, #1873).
     // Test: this is the test; annotated `serial` because it may set REPOS_ROOT.
     let dir = tempdir_with_name("trusty_test_github_alias_fallback_1705");
     let ok = std::process::Command::new("git")
@@ -683,7 +690,7 @@ async fn guided_fallback_does_not_refuse_github_ssh_alias_remote() {
             "remote",
             "add",
             "origin",
-            "git@github-duetto:duettoresearch/aria.git",
+            "git@github-test-fixture-alias-nonexistent:acmetest/repo-fixture.git",
         ])
         .current_dir(&dir)
         .status();


### PR DESCRIPTION
## Summary

fixes the nested-tmux attach bug

Attaching/resuming a `tm` session while already inside a tmux client failed with:

```
tm: attaching to session 'tmpm-mcp-a-protocol-00f6f5ef'
sessions should be nested with care, unset $TMUX to force
Error: tmux attach-session exited with failure
```

**Root cause:** every attach code path in the `tm` binary shelled out to `tmux attach-session -t <session>` unconditionally. tmux refuses `attach-session` when `$TMUX` is already set (nested-client guard) — there was no branch for the "operator is already inside tmux" case.

**Fix:** a new shared module, `crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs`, exports:
- `attach_argv(session, inside_tmux) -> Vec<String>` — pure decision function: `["switch-client", "-t", session]` when inside tmux, else `["attach-session", "-t", session]` (unchanged). `switch-client` is the documented nested-safe idiom — it moves the *existing* client to the target session instead of trying to spawn a nested one.
- `inside_tmux() -> bool` — reads `$TMUX` (non-empty = inside tmux).
- `tmux_attach(name) -> anyhow::Result<()>` — spawns `tmux <attach_argv(...)>`, prints an accurate "attaching"/"switching client" status line, and on failure while inside tmux surfaces an actionable hint that the target session may live on a different tmux server rather than a bare "exited with failure".

### Every call site changed (5 total)

- `crates/trusty-mpm/src/bin/tm/commands/guided.rs` — the picker's resume/restart path (`tmux_attach` local fn now delegates to the shared helper).
- `crates/trusty-mpm/src/bin/tm/commands/launch.rs` — 4 inline call sites across `launch()` (reconnect-to-existing + freshly-created session attach) and `connect()` (reconnect-to-existing + freshly-created session attach).

All 5 now route through `crate::commands::tmux_attach::tmux_attach(...)`.

### Test-hygiene fix (discovered during verification)

While running `cargo test -p trusty-mpm` in this sandbox — which turned out to itself be running inside a real tmux session — one pre-existing test, `guided_fallback_does_not_refuse_github_ssh_alias_remote`, started failing. Root-cause trace: the test used the literal SSH remote `git@github-duetto:duettoresearch/aria.git`, assuming the clone would fail (unreachable host). On this maintainer's own machine, `github-duetto` happens to be a real, configured, reachable personal SSH alias, so the clone succeeded for real, and — combined with this fix's new switch-client behavior plus the test process's real inherited `$TMUX` — the subsequent attach also succeeded for real, flipping the test's expected `Err` to `Ok`. Confirmed via `tmux list-sessions` / `git worktree list` that this is long-standing, pre-existing pollution on this box (79+ stray worktrees already existed from prior runs unrelated to this change) — not something newly introduced by this fix. Fixed by swapping only that test's literal fixture data to an unresolvable placeholder host (`git@github-test-fixture-alias-nonexistent:acmetest/repo-fixture.git`) so it's hermetic regardless of local SSH config. The other pure-parsing tests in the same file that reference the original `github-duetto` alias (no live network I/O) were left unchanged since they're the original real-world regression repro data.

## Verification (raw output)

`cargo test -p trusty-mpm`:
```
test commands::tmux_attach::tests::attach_argv_inside_tmux_uses_switch_client ... ok
test commands::tmux_attach::tests::attach_argv_outside_tmux_uses_attach_session ... ok
test result: ok. 2179 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 4.01s
test result: ok. 605 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.08s
test result: ok. 605 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.08s
... (all remaining suites: ok, 0 failed)
```

`cargo clippy -p trusty-mpm --all-targets -- -D warnings`:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.66s
```
(clean — zero warnings for trusty-mpm; unrelated pre-existing MSRV warning from the `tga` crate)

`cargo fmt --check`: clean, no diff.

`bash scripts/check_line_cap.sh`:
```
line-cap: 14 allowlisted, 0 violations — OK.
```

Reviewed by an independent code-critic subagent (APPROVE, one Minor nit fixed: the status message now distinguishes "switching client to" vs "attaching to").

## Test plan

- [x] \`cargo test -p trusty-mpm\` — all green, including new \`attach_argv_inside_tmux_uses_switch_client\` / \`attach_argv_outside_tmux_uses_attach_session\` unit tests
- [x] \`cargo clippy -p trusty-mpm --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`bash scripts/check_line_cap.sh\` — clean
- [x] Manual repro: confirmed via \`$TMUX\` inspection + \`tmux list-sessions\` that the fix correctly triggers \`switch-client\` when already inside tmux

Closes #1874