### PR TITLE
fix(trusty-review): serve-mode diff-fetch loads auth token correctly (#1880)

### DIFF
--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info, warn};
 use super::runner_coverage::load_coverage_contrib;
 use super::runner_helpers::{
     abort_dry, apply_grade_and_floor, attach_inline_comments, build_author_rationale,
-    fetch_github_pr_meta, finalize_run,
+    fetch_github_pr_meta, finalize_run, resolve_diff_token,
 };
 use crate::{
     config::{DiffStats, MapReduceConfig, ReviewConfig, ReviewPath, select_review_mode},
@@ -237,9 +237,23 @@ pub async fn run_review(
         }
     }
 
+    // ── Step 2c: resolve the GitHub token for the diff fetch (#1880) ──────
+    // `DiffSource::Github` may carry an empty placeholder token (service-path
+    // callers defer resolution here); resolve it now via the run-mode's
+    // `AuthStrategy` rather than letting `load_diff` send an empty bearer
+    // token and surface an opaque 401 from GitHub.
+    let diff_source = match resolve_diff_token(&input.diff_source, config, input.run_mode).await {
+        Ok(source) => source,
+        Err(e) => {
+            warn!("failed to resolve GitHub token for diff fetch: {e}");
+            result.error = Some(format!("GitHub token resolution failed: {e}"));
+            return abort_dry(result, config, &input, &deps);
+        }
+    };
+
     // ── Step 3: load, filter (DiffAnalyzer Stages A+B), and truncate diff ─
     // truncate_diff is the final safety net after noise filtering (REV-209).
-    let raw_diff = match load_diff(&input.diff_source).await {
+    let raw_diff = match load_diff(&diff_source).await {
         Ok(d) => d,
         Err(e) => {
             warn!("failed to load diff: {e}");

--- a/crates/trusty-review/src/pipeline/runner_helpers.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers.rs
@@ -20,6 +20,7 @@ use crate::{
     config::ReviewConfig,
     models::{InlineCommentOut, ReviewResult, Verdict},
     pipeline::{
+        diff::DiffSource,
         grade::derive_verdict_with_grade,
         letter_grade::default_grade_for_verdict,
         output::{print_review_result, write_review_log},
@@ -157,6 +158,62 @@ pub(super) async fn fetch_github_pr_meta(
     ))
 }
 
+/// Resolve the GitHub token for a diff-fetch, replacing an empty placeholder.
+///
+/// Why: service-path callers (`resolve_diff_source` in `service/handlers.rs`,
+/// and the webhook dispatcher in `service/webhook.rs`) intentionally build
+/// `DiffSource::Github` with an empty `token` field, commenting that "the
+/// pipeline will resolve it from config" — but nothing ever did that
+/// resolution, so serve-mode diff fetches sent an empty bearer token straight
+/// to GitHub and got back an opaque `401 Bad credentials` (#1880). This is the
+/// single funnel that closes that gap, mirroring the token resolution already
+/// performed independently for PR-metadata fetch (`fetch_github_pr_meta`
+/// above) and for posting (`pipeline::post::finalize_review`).
+/// What: `LocalFile` sources need no GitHub credentials and pass through
+/// unchanged. `Github` sources with an already-resolved (non-empty) token —
+/// the CLI `run`/`compare`/`calibrate` paths, which resolve up front — also
+/// pass through unchanged so this never triggers a redundant token exchange.
+/// Only a `Github` source with an *empty* token triggers resolution via
+/// `AuthStrategy::select(run_mode, None).resolve_token(...)`, returning a new
+/// `DiffSource::Github` with the resolved token. If no token can be resolved
+/// (no PAT, no `gh` login, no App credentials, or no installation for the
+/// owner) this returns the underlying `GithubError` — whose `Display` already
+/// names the missing env var / config key — so the caller fails CLOSED with an
+/// actionable message instead of silently sending an empty-token request.
+/// Test: `resolve_diff_token_passes_through_local_file`,
+/// `resolve_diff_token_passes_through_already_resolved_token`,
+/// `resolve_diff_token_serve_mode_without_app_creds_errors`,
+/// `resolve_diff_token_cli_mode_resolves_from_config_token`.
+pub(super) async fn resolve_diff_token(
+    source: &DiffSource,
+    config: &ReviewConfig,
+    run_mode: RunMode,
+) -> Result<DiffSource, GithubError> {
+    let DiffSource::Github {
+        owner,
+        repo,
+        pr,
+        token,
+    } = source
+    else {
+        return Ok(source.clone());
+    };
+    if !token.is_empty() {
+        return Ok(source.clone());
+    }
+
+    let client = GithubClient::new()?;
+    let resolved = AuthStrategy::select(run_mode, None)
+        .resolve_token(&client, config, owner)
+        .await?;
+    Ok(DiffSource::Github {
+        owner: owner.clone(),
+        repo: repo.clone(),
+        pr: *pr,
+        token: resolved,
+    })
+}
+
 /// Finalise an *aborted* review as dry-run only, releasing the dedup claim.
 ///
 /// Why: a review that aborts before producing a real verdict (diff-load failure
@@ -266,3 +323,10 @@ pub(super) async fn finalize_run(
     )
     .await
 }
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+// Split into a sibling file to keep this file under the 500-line cap.
+
+#[cfg(test)]
+#[path = "runner_helpers_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/pipeline/runner_helpers_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers_tests.rs
@@ -1,0 +1,124 @@
+//! Unit tests for `pipeline::runner_helpers::resolve_diff_token` (#1880).
+//!
+//! Why: split from `runner_helpers.rs` to keep that file under the 500-line
+//! cap while covering the serve-mode empty-token regression directly at the
+//! function boundary (no network required — App-mode resolution fails fast
+//! on missing credentials/installation before any HTTP call is made).
+//! What: exercises all four branches of `resolve_diff_token`: `LocalFile`
+//! pass-through, already-resolved-token pass-through, Serve-mode failure
+//! without App credentials, and Cli-mode resolution from `config.github_token`.
+//! Test: this is the test module; each function is a self-contained unit test.
+
+use super::*;
+use std::path::PathBuf;
+
+fn config_without_app_creds() -> ReviewConfig {
+    let mut config = ReviewConfig::load(None);
+    config.github_app_id = None;
+    config.github_app_private_key = None;
+    config.github_installations = Vec::new();
+    config
+}
+
+#[tokio::test]
+async fn resolve_diff_token_passes_through_local_file() {
+    // A LocalFile source needs no GitHub credentials at all; it must pass
+    // through unchanged regardless of run mode or config.
+    let config = config_without_app_creds();
+    let source = DiffSource::LocalFile {
+        path: PathBuf::from("/tmp/whatever.diff"),
+    };
+
+    let resolved = resolve_diff_token(&source, &config, RunMode::Serve)
+        .await
+        .expect("LocalFile source must never fail token resolution");
+
+    match resolved {
+        DiffSource::LocalFile { path } => assert_eq!(path, PathBuf::from("/tmp/whatever.diff")),
+        other => panic!("expected LocalFile to pass through unchanged, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_diff_token_passes_through_already_resolved_token() {
+    // A Github source with a non-empty token (the CLI run/compare/calibrate
+    // paths resolve up front) must be returned unchanged — no redundant
+    // resolution attempt. We prove this by using Serve mode with NO App
+    // credentials configured: if resolution were (incorrectly) attempted,
+    // this would error; since the token is already set, it must not be.
+    let config = config_without_app_creds();
+    let source = DiffSource::Github {
+        owner: "acme".to_string(),
+        repo: "widgets".to_string(),
+        pr: 42,
+        token: "already-resolved-token".to_string(),
+    };
+
+    let resolved = resolve_diff_token(&source, &config, RunMode::Serve)
+        .await
+        .expect("a non-empty token must never trigger re-resolution");
+
+    match resolved {
+        DiffSource::Github { token, .. } => assert_eq!(token, "already-resolved-token"),
+        other => panic!("expected Github source to pass through unchanged, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_diff_token_serve_mode_without_app_creds_errors() {
+    // This is the #1880 regression: serve-mode webhook/handler paths build
+    // `DiffSource::Github` with an empty token placeholder. Without App
+    // credentials configured, resolution must fail CLOSED with an actionable
+    // error — never silently return an empty token that would surface as an
+    // opaque 401 from GitHub.
+    let config = config_without_app_creds();
+    let source = DiffSource::Github {
+        owner: "acme".to_string(),
+        repo: "widgets".to_string(),
+        pr: 7,
+        token: String::new(),
+    };
+
+    let err = resolve_diff_token(&source, &config, RunMode::Serve)
+        .await
+        .expect_err("empty token with no App credentials must fail, not silently proceed");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("GITHUB_APP_ID") || message.contains("GITHUB_APP_PRIVATE_KEY"),
+        "error must name the missing config so an operator can act on it: {message}"
+    );
+}
+
+#[tokio::test]
+async fn resolve_diff_token_cli_mode_resolves_from_config_token() {
+    // Cli mode with an empty placeholder token and `config.github_token` set
+    // must resolve synchronously (no network) to that configured token.
+    let mut config = config_without_app_creds();
+    config.github_token = "ghp_configured_pat".to_string(); // pragma: allowlist secret
+    let source = DiffSource::Github {
+        owner: "acme".to_string(),
+        repo: "widgets".to_string(),
+        pr: 99,
+        token: String::new(),
+    };
+
+    let resolved = resolve_diff_token(&source, &config, RunMode::Cli)
+        .await
+        .expect("Cli mode must resolve from config.github_token");
+
+    match resolved {
+        DiffSource::Github {
+            token,
+            owner,
+            repo,
+            pr,
+        } => {
+            assert_eq!(token, "ghp_configured_pat");
+            assert_eq!(owner, "acme");
+            assert_eq!(repo, "widgets");
+            assert_eq!(pr, 99);
+        }
+        other => panic!("expected a resolved Github source, got {other:?}"),
+    }
+}

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -893,6 +893,56 @@ async fn run_review_missing_diff_file_sets_error() {
 }
 
 #[tokio::test]
+async fn run_review_serve_mode_empty_token_fails_closed_with_actionable_error() {
+    // Regression for #1880: serve-mode callers (POST /review, the webhook
+    // dispatcher) build `DiffSource::Github` with an empty placeholder token,
+    // relying on `run_review` to resolve the real one via `resolve_diff_token`
+    // before the diff fetch. With no GitHub App credentials configured, this
+    // must fail CLOSED with an actionable error field — never proceed to
+    // `load_diff` with an empty bearer token (which previously surfaced as an
+    // opaque `401 Bad credentials` from GitHub instead of a clear diagnostic).
+    let mut config = default_config();
+    config.github_app_id = None;
+    config.github_app_private_key = None;
+    config.github_installations = Vec::new();
+
+    let input = ReviewInput {
+        diff_source: DiffSource::Github {
+            owner: "acme".to_string(),
+            repo: "widgets".to_string(),
+            pr: 7,
+            token: String::new(),
+        },
+        reviewer_model: "openai/gpt-5.4-nano-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Serve,
+        allow_posting: true,
+        caller_context: CallerContext::default(),
+    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+
+    let result = run_review(&config, input, deps).await;
+
+    assert!(
+        result.error.is_some(),
+        "empty-token diff fetch without App credentials must set an error"
+    );
+    let error = result.error.expect("checked above");
+    assert!(
+        error.contains("GITHUB_APP_ID") || error.contains("GITHUB_APP_PRIVATE_KEY"),
+        "error must name the missing config so an operator can fix it: {error}"
+    );
+    assert_eq!(
+        result.verdict,
+        Verdict::Unknown,
+        "fail-closed path must never fabricate a verdict"
+    );
+    assert!(!result.posted, "a failed token resolution must never post");
+}
+
+#[tokio::test]
 async fn run_review_local_diff_is_dry_run_and_not_posted() {
     // A local diff can never be posted (no GitHub source); even with the
     // trigger forcing live and posting allowed, the result stays dry-run.

--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -469,8 +469,10 @@ pub async fn handle_review(
 /// Why: centralises request validation so the handler body stays clean.
 /// What: if `local_diff_text` is present, writes it to a tempfile and returns
 /// `DiffSource::LocalFile`; otherwise validates that owner/repo/pr are all
-/// present and returns `DiffSource::Github` with an empty token (the pipeline
-/// will resolve the token from config).
+/// present and returns `DiffSource::Github` with an empty token placeholder.
+/// `pipeline::runner::run_review` resolves the real token from config via
+/// `resolve_diff_token` before fetching the diff (#1880) — this function never
+/// talks to GitHub itself.
 /// Test: covered indirectly by `review_endpoint_*` handler tests.
 fn resolve_diff_source(req: &ReviewRequest) -> Result<DiffSource, String> {
     if let Some(ref diff_text) = req.local_diff_text {
@@ -504,8 +506,10 @@ fn resolve_diff_source(req: &ReviewRequest) -> Result<DiffSource, String> {
         .pr
         .ok_or_else(|| "pr is required (or provide local_diff_text)".to_string())?;
 
-    // Token is empty here; the pipeline will attempt to resolve it from config.
-    // If no token is available the pipeline fails gracefully (fail-safe APPROVE).
+    // Token is empty here; `run_review` resolves it from config via
+    // `resolve_diff_token` before the diff fetch (#1880). If no token can be
+    // resolved the review fails closed (UNKNOWN, `result.error` set) rather
+    // than sending an empty-token request that surfaces as an opaque 401.
     Ok(DiffSource::Github {
         owner,
         repo,

--- a/crates/trusty-review/src/service/webhook.rs
+++ b/crates/trusty-review/src/service/webhook.rs
@@ -278,7 +278,7 @@ pub async fn handle_github_webhook(
                 owner: owner.clone(),
                 repo: repo.clone(),
                 pr: pr_number,
-                token: String::new(), // resolved from config by the pipeline
+                token: String::new(), // resolved by `run_review` via `resolve_diff_token` (#1880)
             },
             reviewer_model,
             write_log: true, // background webhook tasks write the log


### PR DESCRIPTION
Closes #1880

## Root cause

Serve-mode callers of `run_review` construct `DiffSource::Github { token: String::new(), .. }` and defer real token resolution to "the pipeline" via a code comment — but nothing in the pipeline ever performed that resolution:

- `service/handlers.rs::resolve_diff_source` (POST /review) builds an empty-token `DiffSource::Github`.
- `service/webhook.rs` (GitHub webhook dispatch) does the same.
- `pipeline/runner.rs::run_review` calls `load_diff(&input.diff_source)` directly with that empty-token source, which passes straight through to `fetch_pr_diff` — no token resolution anywhere in between.

This only affected the raw-diff fetch. PR-metadata fetch (`fetch_github_pr_meta` in `runner_helpers.rs`) and posting (`pipeline::post::finalize_review`) both already resolve their own token via `AuthStrategy::select(run_mode, None).resolve_token(...)` independently before their GitHub calls — which is why the issue reporter observed those paths working while only the diff fetch 401'd.

All other `DiffSource::Github` construction sites (`mcp/tools.rs`, `commands/run.rs`, `commands/compare.rs`, `commands/calibrate.rs`) already resolve a token up front before constructing the source, so they were unaffected.

## Fix

Added `resolve_diff_token` in `pipeline/runner_helpers.rs`, the same funnel pattern already used for metadata fetch and posting:

- `DiffSource::LocalFile` passes through unchanged (no GitHub credentials needed).
- `DiffSource::Github` with an already non-empty token (the CLI paths) passes through unchanged — no redundant token exchange.
- `DiffSource::Github` with an empty token resolves one via `AuthStrategy::select(run_mode, None).resolve_token(...)` and returns a new `DiffSource::Github` with the resolved token.
- If no token can be resolved, the underlying `GithubError` (which already names the missing env var / config key, e.g. `GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY` or `GITHUB_TOKEN`) is returned so the caller fails CLOSED with an actionable message instead of silently sending an empty-token request.

`run_review` (`pipeline/runner.rs`) now calls `resolve_diff_token` immediately before `load_diff`, converting a resolution failure into `result.error` via the existing `abort_dry` fail-safe path (verdict stays `Unknown`, never posted).

Also corrected two now-inaccurate comments (`service/handlers.rs`, `service/webhook.rs`) that claimed "the pipeline will resolve the token from config" — that claim is true now, and the comments reference the actual mechanism and #1880.

## Tests added

- `pipeline/runner_helpers_tests.rs` (new file, split out to keep `runner_helpers.rs` under the 500-SLOC cap): 4 unit tests exercising all branches of `resolve_diff_token` directly (no network — App-mode resolution fails fast on missing credentials before any HTTP call):
  - `resolve_diff_token_passes_through_local_file`
  - `resolve_diff_token_passes_through_already_resolved_token`
  - `resolve_diff_token_serve_mode_without_app_creds_errors`
  - `resolve_diff_token_cli_mode_resolves_from_config_token`
- `pipeline/runner_tests.rs`: `run_review_serve_mode_empty_token_fails_closed_with_actionable_error`, an end-to-end `run_review` test proving the full pipeline wiring fails closed with an actionable error (naming the missing config) rather than reaching `load_diff` with an empty token.

## Verification (raw output)

`cargo test -p trusty-review` (env-cleaned to avoid an unrelated `AWS_REGION` shell-pollution flake in `bedrock_region_resolution`, confirmed pre-existing and unrelated by reproducing it with/without the fix):
```
running 1078 tests
test result: ok. 1074 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 7.20s
running 35 tests
test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

`cargo clippy -p trusty-review --all-targets -- -D warnings`:
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 28.19s
```
(zero warnings for trusty-review; the only warning printed is an unrelated MSRV-mismatch note from `tga`, a dependency, not from this crate)

`cargo fmt --check` (after `cargo fmt` normalized one multi-field match pattern in the new test file):
```
(no output — clean)
```

`bash scripts/check_line_cap.sh`:
```
line-cap: 14 allowlisted, 0 violations — OK.
```

Also verified downstream consumers still compile: `cargo check -p trusty-analyze --features review` and `cargo check -p trusty-mpm --tests` both succeed (trusty-review is an optional/dev dependency of those crates; no public API surface changed here — `resolve_diff_token` is a private `pub(super)` helper).

## Test plan

- [x] `cargo test -p trusty-review` — all green including 5 new regression tests
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean
- [x] Downstream consumers (`trusty-analyze --features review`, `trusty-mpm --tests`) still compile