### PR TITLE
fix(trusty-mpm): require opt-in before MCP-triggered session spawn for unregistered repos (#1836, #1837)

### DIFF
--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -112,6 +112,40 @@ pub struct TrustyToolsConfig {
     /// in config rather than registering them via MCP on every restart.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub projects: Vec<ProjectConfig>,
+
+    /// Daemon-level safety toggles (the `daemon:` YAML section, #1836).
+    ///
+    /// `None` → every toggle defaults to its safe value (MCP-initiated spawning
+    /// stays disabled).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon: Option<DaemonConfig>,
+}
+
+/// The `daemon:` section of `~/.trusty-tools/trusty-mpm/config.yaml` (#1836).
+///
+/// Why: the ARIA incident showed that an MCP-triggered `session_new` call can
+/// silently provision real infrastructure (clone + worktree + tmux + harness)
+/// for any repo an LLM caller names, with no operator confirmation. The fix is
+/// an explicit, declarative opt-in an operator sets once — rather than a
+/// per-call flag a careless/compromised caller could always supply.
+/// What: currently one toggle, `allow_mcp_spawn`; resolution precedence (env >
+/// config > safe default) lives in
+/// [`crate::daemon::managed_routes::mcp_spawn_gate::mcp_spawn_enabled`], not
+/// here — this is purely the on-disk shape.
+/// Test: `daemon_config_yaml_round_trip`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonConfig {
+    /// Whether MCP-initiated session spawns (`session_new` and friends) are
+    /// permitted to provision new infrastructure.
+    ///
+    /// `None`/`Some(false)` → disabled (the safe default, #1836): an MCP
+    /// caller's `session_new` is refused before any workspace is touched.
+    /// `Some(true)` → opts in to MCP-initiated spawning (still subject to the
+    /// #1837 registry allowlist gate). The `tm` CLI's own spawn path (`tm
+    /// launch`/`tm connect`/`tm ticket`) is NEVER gated by this flag — it
+    /// always spawns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_mcp_spawn: Option<bool>,
 }
 
 /// The `github:` section of `~/.trusty-tools/trusty-mpm/config.yaml` (#1265).
@@ -437,6 +471,29 @@ mod tests {
             !yaml.contains("token:"),
             "must not have a bare token field: {yaml}"
         );
+    }
+
+    /// Why: the `daemon:` section (#1836) must round-trip through YAML, and an
+    /// absent section must not serialise at all (matching every other optional
+    /// top-level section).
+    /// Test: itself.
+    #[test]
+    fn daemon_config_yaml_round_trip() {
+        let cfg = TrustyToolsConfig {
+            daemon: Some(DaemonConfig {
+                allow_mcp_spawn: Some(true),
+            }),
+            ..Default::default()
+        };
+        let yaml = serde_yaml::to_string(&cfg).expect("serialise");
+        let back: TrustyToolsConfig = serde_yaml::from_str(&yaml).expect("deserialise");
+        assert_eq!(cfg, back);
+        assert!(yaml.contains("allow_mcp_spawn"), "yaml: {yaml}");
+
+        // Absent daemon section must not serialise.
+        let empty = TrustyToolsConfig::default();
+        let yaml_empty = serde_yaml::to_string(&empty).expect("serialise");
+        assert!(!yaml_empty.contains("daemon"), "yaml: {yaml_empty}");
     }
 
     /// Why: the project subpath must nest `<owner>/<repo>` under the root in that

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -55,6 +55,17 @@ pub struct SpawnParams {
     /// the session up automatically. `None`/`Some(false)` → a normal, durable
     /// session that the automatic paths never touch.
     pub ephemeral: Option<bool>,
+    /// Whether this spawn originates from the MCP tool surface (#1836, #1837).
+    ///
+    /// Why: an MCP-triggered `session_new` call can mint real infrastructure
+    /// for any repo an LLM caller names, with zero operator confirmation (the
+    /// ARIA incident). `true` subjects the spawn to the two-layer MCP spawn
+    /// gate (off-by-default + registry allowlist,
+    /// [`super::mcp_spawn_gate::ensure_mcp_spawn_allowed`]) BEFORE any
+    /// provisioning begins. `false` — set by the HTTP route (`tm launch`/`tm
+    /// ticket` clients) and the SM-STDIO adapter (`sm.sessions.launch`) — never
+    /// gates; those are trusted, explicitly-operator-driven paths.
+    pub mcp_initiated: bool,
 }
 
 /// Spawn a managed session, shared by the HTTP handler and the MCP tool.
@@ -75,6 +86,11 @@ pub async fn spawn_managed(
     state: &Arc<DaemonState>,
     params: SpawnParams,
 ) -> Result<SessionRecord, String> {
+    // Config is loaded ONCE here and reused below for both the MCP spawn gate
+    // and the workspace-root resolution, so the two cannot read divergent
+    // snapshots of `config.yaml` within a single spawn.
+    let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
+
     // Step 0: resolve the runtime backend (default claude-code). Reject unknown
     // selectors BEFORE any provisioning so a typo never leaves an orphan
     // workspace.
@@ -82,6 +98,17 @@ pub async fn spawn_managed(
         None => RuntimeKind::default(),
         Some(raw) => raw.parse::<RuntimeKind>().map_err(|e| e.to_string())?,
     };
+
+    // Step 0.4 — MCP SPAWN GATE (#1836, #1837): an MCP-triggered spawn (never a
+    // `tm launch`/`tm ticket`/SM-STDIO call — see `SpawnParams::mcp_initiated`)
+    // must be refused BEFORE any side effect when MCP spawning is disabled
+    // (the default) or the target repo is not an already-known project. This
+    // runs before `ManagedSessionId::new()` so a refusal mints nothing.
+    if params.mcp_initiated {
+        let registry = state.project_registry().await;
+        super::mcp_spawn_gate::ensure_mcp_spawn_allowed(&registry, &config, &params.repo_url)
+            .await?;
+    }
 
     let session_id = ManagedSessionId::new();
 
@@ -138,8 +165,8 @@ pub async fn spawn_managed(
     // session nests under the target repo's GitHub `<owner>/<repo>` identity:
     // `<root>/<owner>/<repo>/<session-id>/`. When the repo URL has no parseable
     // GitHub identity we fall back to the legacy single-slug `provision` path so a
-    // bare/non-GitHub URL still provisions cleanly.
-    let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
+    // bare/non-GitHub URL still provisions cleanly. `config` was already loaded
+    // above (before the MCP spawn gate); reused here for the workspace root.
     let prepared = match trusty_common::github_path::parse_github_path(&params.repo_url) {
         Some(gh) => {
             let project_dir = crate::core::trusty_tools_config::workspace_subpath(&config, &gh);

--- a/crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs
@@ -42,10 +42,12 @@ use crate::project::{Project, ProjectRegistry, derive_name_from_url};
 /// `TRUSTY_MPM_WORKSPACE_ROOT` convention — operators (and tests) can flip the
 /// gate without editing `config.yaml`.
 /// What: `"TRUSTY_MPM_ALLOW_MCP_SPAWN"`; a truthy value (`"1"`/`"true"`/`"yes"`,
-/// case-insensitive) enables; anything else (including unset/empty) defers to
-/// config.
+/// case-insensitive) force-enables regardless of config; an explicit falsy
+/// value (`"0"`/`"false"`/`"no"`, case-insensitive) force-disables regardless
+/// of config; unset or empty defers entirely to config.
 /// Test: `tests::env_true_enables_regardless_of_config`,
-/// `tests::env_false_string_defers_to_config`.
+/// `tests::env_false_string_force_disables_regardless_of_config`,
+/// `tests::env_unset_defers_to_config`.
 pub const ALLOW_MCP_SPAWN_ENV: &str = "TRUSTY_MPM_ALLOW_MCP_SPAWN";
 
 /// Resolve whether MCP-initiated session spawning is currently permitted (#1836).
@@ -53,17 +55,26 @@ pub const ALLOW_MCP_SPAWN_ENV: &str = "TRUSTY_MPM_ALLOW_MCP_SPAWN";
 /// Why: the spawn path needs ONE answer, with the same env > config > default
 /// precedence pattern [`crate::core::trusty_tools_config::workspace_root`]
 /// already establishes, so the gate cannot silently diverge between callers.
-/// What: `TRUSTY_MPM_ALLOW_MCP_SPAWN` wins when set to a non-empty value;
-/// otherwise `config.daemon.allow_mcp_spawn`; otherwise the safe default
-/// `false`.
+/// An operator setting `TRUSTY_MPM_ALLOW_MCP_SPAWN=0` expects that to act as a
+/// deliberate, explicit override (force-disable) — not a silent no-op that
+/// falls through to whatever config says.
+/// What: three-state precedence. `TRUSTY_MPM_ALLOW_MCP_SPAWN` set to a truthy
+/// string (`"1"`/`"true"`/`"yes"`) force-enables; set to a falsy string
+/// (`"0"`/`"false"`/`"no"`) force-disables; unset, empty, or any other value
+/// defers to `config.daemon.allow_mcp_spawn`, defaulting to `false` if config
+/// is also silent.
 /// Test: `tests::default_is_disabled`, `tests::config_true_enables`,
-/// `tests::env_true_enables_regardless_of_config`.
+/// `tests::env_true_enables_regardless_of_config`,
+/// `tests::env_false_string_force_disables_regardless_of_config`,
+/// `tests::env_unset_defers_to_config`.
 #[must_use]
 pub fn mcp_spawn_enabled(config: &TrustyToolsConfig) -> bool {
     if let Ok(raw) = std::env::var(ALLOW_MCP_SPAWN_ENV) {
         let raw = raw.trim().to_ascii_lowercase();
-        if !raw.is_empty() {
-            return matches!(raw.as_str(), "1" | "true" | "yes");
+        match raw.as_str() {
+            "1" | "true" | "yes" => return true,
+            "0" | "false" | "no" => return false,
+            _ => {} // empty or unrecognised value: defer to config
         }
     }
     config
@@ -276,10 +287,9 @@ mod tests {
 
     #[test]
     #[serial]
-    fn env_false_string_defers_to_config() {
-        // An explicit non-truthy value must NOT itself disable when config says
-        // true — it simply defers precedence to config (only a recognised truthy
-        // string short-circuits to `true`; anything else falls through).
+    fn env_false_string_force_disables_regardless_of_config() {
+        // An explicit falsy env value is a deliberate override, not a
+        // "no-op" — it must force-disable even when config says `true`.
         let _env = EnvGuard::set("0");
         let cfg = TrustyToolsConfig {
             daemon: Some(DaemonConfig {
@@ -289,8 +299,40 @@ mod tests {
         };
         assert!(
             !mcp_spawn_enabled(&cfg),
-            "an explicit env=0 must NOT enable"
+            "an explicit env=0 must force-disable even when config=true"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn env_unset_defers_to_config() {
+        // With the env var absent entirely, config is authoritative — this is
+        // genuine deferral, distinct from the env=0 force-disable case above.
+        let _env = EnvGuard::unset();
+        let cfg = TrustyToolsConfig {
+            daemon: Some(DaemonConfig {
+                allow_mcp_spawn: Some(true),
+            }),
+            ..Default::default()
+        };
+        assert!(
+            mcp_spawn_enabled(&cfg),
+            "env unset must defer to config=true"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn env_empty_string_defers_to_config() {
+        // An empty (but set) env value is treated the same as unset: defer.
+        let _env = EnvGuard::set("");
+        let cfg = TrustyToolsConfig {
+            daemon: Some(DaemonConfig {
+                allow_mcp_spawn: Some(true),
+            }),
+            ..Default::default()
+        };
+        assert!(mcp_spawn_enabled(&cfg), "env='' must defer to config=true");
     }
 
     // ── looks_like_remote_url classification ────────────────────────────────

--- a/crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs
@@ -1,0 +1,452 @@
+//! MCP-initiated spawn gate: off-by-default + registry allowlist (#1836, #1837).
+//!
+//! Why: the ARIA incident (#1836) showed that an LLM-driven MCP `session_new`
+//! call can mint real infrastructure — a git clone, a tmux session, a running
+//! Claude harness — for ANY `repo_url` the caller supplies, with zero operator
+//! confirmation. A PM agent working in one repo asked for a session against an
+//! entirely unrelated repo and the daemon obliged, creating dozens of orphan
+//! worktrees under `~/trusty-mpm-projects/duettoresearch/aria/.worktrees/`. The
+//! blast radius has two independent dimensions the tickets separate: (1)
+//! MCP-initiated spawning must be OFF by default (#1836) so a careless or
+//! misbehaving LLM call can never provision anything without an explicit
+//! operator opt-in, and (2) even opted in, the target repo must already be a
+//! KNOWN project — registered via `project_register` or `config.yaml`'s
+//! `projects:` list — so a session in repo A cannot spin up infrastructure for
+//! unrelated repo B (#1837). The `tm` CLI's own `tm launch`/`tm connect`/`tm
+//! ticket` paths are NEVER subject to either gate — only the MCP `session_new`
+//! tool (via [`super::lifecycle::spawn_managed`]) calls this.
+//! What: [`mcp_spawn_enabled`] resolves the #1836 toggle (env > config >
+//! default `false`); [`is_known_repo`] is the pure #1837 allowlist predicate —
+//! for a remote-looking `repo_url` it requires a STRICT `(owner, repo)`
+//! identity match (never a bare repo-name match, which would be spoofable by
+//! an attacker-controlled host/owner), falling back to a derived-name match
+//! only for genuine local filesystem paths;
+//! [`ensure_mcp_spawn_allowed`] is the async orchestration `spawn_managed` calls
+//! FIRST — before any session id, workspace, or record is created — so a
+//! refusal has zero side effects. It takes the registry and config as plain
+//! references (not `Arc<DaemonState>`) so it is testable against a bare
+//! `ProjectRegistry` with no daemon state, session manager, or tmux involved.
+//! Test: `tests` covers both gate layers offline (env/config precedence, name
+//! and URL matching, and the composed disposition); the wiring into
+//! `spawn_managed` is covered by `tests/mcp_spawn_gate.rs` (proves a rejected
+//! MCP spawn creates nothing and that CLI-origin spawns are never gated).
+
+use trusty_common::github_path::parse_github_path;
+
+use crate::core::trusty_tools_config::TrustyToolsConfig;
+use crate::project::{Project, ProjectRegistry, derive_name_from_url};
+
+/// Env var that force-enables MCP-initiated spawning, overriding config (#1836).
+///
+/// Why: an explicit, highest-precedence escape hatch mirrors the existing
+/// `TRUSTY_MPM_WORKSPACE_ROOT` convention — operators (and tests) can flip the
+/// gate without editing `config.yaml`.
+/// What: `"TRUSTY_MPM_ALLOW_MCP_SPAWN"`; a truthy value (`"1"`/`"true"`/`"yes"`,
+/// case-insensitive) enables; anything else (including unset/empty) defers to
+/// config.
+/// Test: `tests::env_true_enables_regardless_of_config`,
+/// `tests::env_false_string_defers_to_config`.
+pub const ALLOW_MCP_SPAWN_ENV: &str = "TRUSTY_MPM_ALLOW_MCP_SPAWN";
+
+/// Resolve whether MCP-initiated session spawning is currently permitted (#1836).
+///
+/// Why: the spawn path needs ONE answer, with the same env > config > default
+/// precedence pattern [`crate::core::trusty_tools_config::workspace_root`]
+/// already establishes, so the gate cannot silently diverge between callers.
+/// What: `TRUSTY_MPM_ALLOW_MCP_SPAWN` wins when set to a non-empty value;
+/// otherwise `config.daemon.allow_mcp_spawn`; otherwise the safe default
+/// `false`.
+/// Test: `tests::default_is_disabled`, `tests::config_true_enables`,
+/// `tests::env_true_enables_regardless_of_config`.
+#[must_use]
+pub fn mcp_spawn_enabled(config: &TrustyToolsConfig) -> bool {
+    if let Ok(raw) = std::env::var(ALLOW_MCP_SPAWN_ENV) {
+        let raw = raw.trim().to_ascii_lowercase();
+        if !raw.is_empty() {
+            return matches!(raw.as_str(), "1" | "true" | "yes");
+        }
+    }
+    config
+        .daemon
+        .as_ref()
+        .and_then(|d| d.allow_mcp_spawn)
+        .unwrap_or(false)
+}
+
+/// Whether `s` looks like a remote repo reference (URL or SSH shorthand)
+/// rather than a bare local filesystem path.
+///
+/// Why: [`is_known_repo`] must apply STRICT owner/repo identity matching to
+/// anything that looks like a remote reference — a bare last-path-segment
+/// name match is spoofable (an attacker can name their fork's repo identically
+/// to a legitimate one, e.g. `https://evil.example.com/attacker/trusty-tools`
+/// vs a registered `owner/trusty-tools`). A genuine local filesystem path
+/// (the in-project spawn convenience case, e.g. `/Users/op/checkouts/aria`)
+/// carries no such identity and needs the looser name-based fallback instead.
+/// What: `true` iff `s` contains `://` (any URL scheme) or a bare `:` (the SSH
+/// shorthand `user@host:owner/repo`) — mirrors the exact heuristic
+/// [`crate::project::record::derive_name_from_url`] already uses to detect the
+/// SSH form. A local absolute path never contains `:` on the supported
+/// platforms (macOS/Linux), so this cannot misclassify one.
+/// Test: `tests::looks_like_remote_url_*`.
+fn looks_like_remote_url(s: &str) -> bool {
+    s.contains("://") || s.contains(':')
+}
+
+/// Whether `repo_url` matches an already-registered project (#1837).
+///
+/// Why: the second gate layer — even with MCP spawning enabled, a repo the
+/// operator has never registered must be refused, and the match must NOT be
+/// spoofable by an attacker-controlled URL. When `repo_url` looks like a
+/// remote reference, identity is decided STRICTLY by the parsed
+/// `(owner, repo)` pair (case-insensitive) against each registered project's
+/// OWN `repo_url` parsed the same way — matching only the trailing repo name
+/// (as an earlier revision did) would let `https://evil.example.com/attacker/
+/// trusty-tools` impersonate a registered `owner/trusty-tools`, reproducing
+/// the exact ARIA-incident shape through the allowlist itself. Only when
+/// `repo_url` carries no such identity (a bare local filesystem path) does
+/// this fall back to the looser derived-name match — a URL can never reach
+/// that branch, so it cannot be used to impersonate a local checkout.
+/// What: for a remote-looking `repo_url`, `true` iff some registered project's
+/// `repo_url` is ALSO remote-looking and parses to the same
+/// `(owner, repo)`. For a local-path `repo_url`, `true` iff some registered
+/// project's `name` equals the path's derived basename.
+/// Test: `tests::is_known_repo_matches_by_owner_and_repo_ignoring_git_suffix`,
+/// `tests::is_known_repo_matches_ssh_and_https_forms`,
+/// `tests::is_known_repo_rejects_same_repo_name_different_owner`,
+/// `tests::is_known_repo_matches_by_name`,
+/// `tests::is_known_repo_rejects_unregistered`,
+/// `tests::is_known_repo_remote_target_ignores_local_registered_url`.
+#[must_use]
+pub fn is_known_repo(projects: &[Project], repo_url: &str) -> bool {
+    if looks_like_remote_url(repo_url) {
+        let Some(target) = parse_github_path(repo_url) else {
+            return false;
+        };
+        return projects.iter().any(|p| {
+            looks_like_remote_url(&p.repo_url)
+                && parse_github_path(&p.repo_url).is_some_and(|gh| {
+                    gh.owner.eq_ignore_ascii_case(&target.owner)
+                        && gh.repo.eq_ignore_ascii_case(&target.repo)
+                })
+        });
+    }
+
+    // Bare local filesystem path — match by derived basename only. This arm
+    // is reachable ONLY for inputs `looks_like_remote_url` rejects, so a
+    // crafted URL can never ride this fallback to impersonate a project.
+    let target_name = derive_name_from_url(repo_url);
+    projects
+        .iter()
+        .any(|p| target_name.as_deref() == Some(p.name.as_str()))
+}
+
+/// Enforce the two-layer MCP spawn gate before any provisioning begins
+/// (#1836, #1837).
+///
+/// Why: [`super::lifecycle::spawn_managed`] calls this FIRST — before
+/// `ManagedSessionId::new()` — so a refusal is a pure, side-effect-free `Err`:
+/// no id minted, no workspace touched, no tmux session created. This is the
+/// single seam both tickets share, and taking `&ProjectRegistry` /
+/// `&TrustyToolsConfig` directly (rather than `&Arc<DaemonState>`) keeps it
+/// testable without a daemon.
+/// What: (1) if MCP spawning is disabled (the default), returns an actionable
+/// `Err` naming both the config key and the env var; (2) otherwise consults
+/// the project registry — an unregistered `repo_url` is refused with a message
+/// naming the exact `project_register` call to run. A registered project
+/// passes silently (`Ok(())`).
+/// Test: `tests::ensure_mcp_spawn_allowed_disabled_by_default`,
+/// `tests::ensure_mcp_spawn_allowed_enabled_but_unregistered`,
+/// `tests::ensure_mcp_spawn_allowed_enabled_and_registered`.
+pub async fn ensure_mcp_spawn_allowed(
+    registry: &ProjectRegistry,
+    config: &TrustyToolsConfig,
+    repo_url: &str,
+) -> Result<(), String> {
+    if !mcp_spawn_enabled(config) {
+        return Err(format!(
+            "managed spawning via MCP is disabled; enable it with `allow_mcp_spawn: true` \
+             under `daemon:` in ~/.trusty-tools/trusty-mpm/config.yaml, or set \
+             {ALLOW_MCP_SPAWN_ENV}=1 — or run `tm launch` directly from the CLI, which is \
+             never gated"
+        ));
+    }
+
+    let projects = registry
+        .list()
+        .await
+        .map_err(|e| format!("failed to read project registry: {e}"))?;
+    if !is_known_repo(&projects, repo_url) {
+        let name_hint = derive_name_from_url(repo_url).unwrap_or_else(|| repo_url.to_string());
+        return Err(format!(
+            "refusing MCP-initiated spawn for unregistered repo `{repo_url}`; register it \
+             first with the `project_register` MCP tool (name=\"{name_hint}\", \
+             repo_url=\"{repo_url}\") or add it under `projects:` in \
+             ~/.trusty-tools/trusty-mpm/config.yaml, then retry"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::trusty_tools_config::DaemonConfig;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    /// RAII guard that sets (or removes) [`ALLOW_MCP_SPAWN_ENV`] for the
+    /// duration of a `#[serial]` test, restoring the prior value (or absence)
+    /// on drop — panic-safe, so a failed assertion mid-test cannot leak the
+    /// override into a sibling test (mirrors `session_launch::tests::EnvVarGuard`).
+    struct EnvGuard {
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(value: &str) -> Self {
+            let prev = std::env::var(ALLOW_MCP_SPAWN_ENV).ok();
+            // SAFETY: env-mutating tests using this guard are tagged `#[serial]`.
+            unsafe { std::env::set_var(ALLOW_MCP_SPAWN_ENV, value) };
+            Self { prev }
+        }
+
+        fn unset() -> Self {
+            let prev = std::env::var(ALLOW_MCP_SPAWN_ENV).ok();
+            // SAFETY: env-mutating tests using this guard are tagged `#[serial]`.
+            unsafe { std::env::remove_var(ALLOW_MCP_SPAWN_ENV) };
+            Self { prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: see `set`/`unset` — serialized by `#[serial]`.
+            unsafe {
+                match self.prev.take() {
+                    Some(v) => std::env::set_var(ALLOW_MCP_SPAWN_ENV, v),
+                    None => std::env::remove_var(ALLOW_MCP_SPAWN_ENV),
+                }
+            }
+        }
+    }
+
+    fn make_project(name: &str, repo_url: &str) -> Project {
+        Project {
+            name: name.to_string(),
+            repo_url: repo_url.to_string(),
+            default_branch: "main".into(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+        }
+    }
+
+    // ── mcp_spawn_enabled precedence ───────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn default_is_disabled() {
+        let _env = EnvGuard::unset();
+        assert!(!mcp_spawn_enabled(&TrustyToolsConfig::default()));
+    }
+
+    #[test]
+    #[serial]
+    fn config_true_enables() {
+        let _env = EnvGuard::unset();
+        let cfg = TrustyToolsConfig {
+            daemon: Some(DaemonConfig {
+                allow_mcp_spawn: Some(true),
+            }),
+            ..Default::default()
+        };
+        assert!(mcp_spawn_enabled(&cfg));
+    }
+
+    #[test]
+    #[serial]
+    fn env_true_enables_regardless_of_config() {
+        let _env = EnvGuard::set("1");
+        assert!(
+            mcp_spawn_enabled(&TrustyToolsConfig::default()),
+            "env=1 must enable even with no config set"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn env_false_string_defers_to_config() {
+        // An explicit non-truthy value must NOT itself disable when config says
+        // true — it simply defers precedence to config (only a recognised truthy
+        // string short-circuits to `true`; anything else falls through).
+        let _env = EnvGuard::set("0");
+        let cfg = TrustyToolsConfig {
+            daemon: Some(DaemonConfig {
+                allow_mcp_spawn: Some(true),
+            }),
+            ..Default::default()
+        };
+        assert!(
+            !mcp_spawn_enabled(&cfg),
+            "an explicit env=0 must NOT enable"
+        );
+    }
+
+    // ── looks_like_remote_url classification ────────────────────────────────
+
+    #[test]
+    fn looks_like_remote_url_detects_https_and_ssh() {
+        assert!(looks_like_remote_url("https://github.com/owner/repo"));
+        assert!(looks_like_remote_url("git@github.com:owner/repo.git"));
+    }
+
+    #[test]
+    fn looks_like_remote_url_rejects_local_absolute_path() {
+        assert!(!looks_like_remote_url("/Users/op/checkouts/aria"));
+    }
+
+    // ── is_known_repo matching ──────────────────────────────────────────────
+
+    #[test]
+    fn is_known_repo_matches_by_name() {
+        let projects = vec![make_project("aria", "https://github.com/duettoresearch/x")];
+        // A bare local filesystem path (never a remote URL) matches by
+        // derived basename — e.g. a local worktree path ending in `/aria`.
+        assert!(is_known_repo(&projects, "/Users/op/checkouts/aria"));
+    }
+
+    #[test]
+    fn is_known_repo_matches_by_owner_and_repo_ignoring_git_suffix() {
+        let projects = vec![make_project(
+            "trusty-tools",
+            "https://github.com/bobmatnyc/trusty-tools",
+        )];
+        assert!(is_known_repo(
+            &projects,
+            "https://github.com/bobmatnyc/trusty-tools.git"
+        ));
+    }
+
+    /// SSH and HTTPS forms of the SAME owner/repo must match (a bonus of the
+    /// owner/repo-identity matcher over a raw string comparison).
+    #[test]
+    fn is_known_repo_matches_ssh_and_https_forms() {
+        let projects = vec![make_project(
+            "trusty-tools",
+            "https://github.com/bobmatnyc/trusty-tools",
+        )];
+        assert!(is_known_repo(
+            &projects,
+            "git@github.com:bobmatnyc/trusty-tools.git"
+        ));
+    }
+
+    #[test]
+    fn is_known_repo_rejects_unregistered() {
+        let projects = vec![make_project(
+            "trusty-tools",
+            "https://github.com/bobmatnyc/trusty-tools",
+        )];
+        assert!(!is_known_repo(
+            &projects,
+            "https://github.com/duettoresearch/aria"
+        ));
+    }
+
+    /// CRITICAL regression (found in review): a bare repo-NAME match would let
+    /// an attacker-controlled URL impersonate a registered project merely by
+    /// sharing the last path segment, on a completely different host/owner —
+    /// reproducing the exact ARIA-incident shape (an arbitrary, LLM-supplied
+    /// `repo_url`) through the allowlist itself. Owner+repo identity matching
+    /// must reject this.
+    #[test]
+    fn is_known_repo_rejects_same_repo_name_different_owner() {
+        let projects = vec![make_project(
+            "trusty-tools",
+            "https://github.com/bobmatnyc/trusty-tools",
+        )];
+        assert!(!is_known_repo(
+            &projects,
+            "https://evil.example.com/attacker/trusty-tools"
+        ));
+    }
+
+    /// A registered project whose OWN `repo_url` is (unusually) a local path
+    /// must never be used to satisfy a remote-looking target via the owner/repo
+    /// matcher — the `looks_like_remote_url` guard on the registry side must
+    /// hold.
+    #[test]
+    fn is_known_repo_remote_target_ignores_local_registered_url() {
+        let projects = vec![make_project("weird", "/some/local/path/repo")];
+        assert!(!is_known_repo(&projects, "https://github.com/some/repo"));
+    }
+
+    // ── ensure_mcp_spawn_allowed composed behaviour ─────────────────────────
+
+    #[tokio::test]
+    #[serial]
+    async fn ensure_mcp_spawn_allowed_disabled_by_default() {
+        let _env = EnvGuard::unset();
+        let dir = TempDir::new().expect("tempdir");
+        let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+        let cfg = TrustyToolsConfig::default();
+
+        let err =
+            ensure_mcp_spawn_allowed(&registry, &cfg, "https://github.com/duettoresearch/aria")
+                .await
+                .expect_err("must refuse when MCP spawning is disabled by default");
+        assert!(err.contains("disabled"), "{err}");
+        assert!(err.contains("allow_mcp_spawn"), "{err}");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn ensure_mcp_spawn_allowed_enabled_but_unregistered() {
+        let _env = EnvGuard::unset();
+        let dir = TempDir::new().expect("tempdir");
+        let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+        let cfg = TrustyToolsConfig {
+            daemon: Some(DaemonConfig {
+                allow_mcp_spawn: Some(true),
+            }),
+            ..Default::default()
+        };
+
+        let err =
+            ensure_mcp_spawn_allowed(&registry, &cfg, "https://github.com/duettoresearch/aria")
+                .await
+                .expect_err("must refuse an unregistered repo even when spawning is enabled");
+        assert!(err.contains("unregistered"), "{err}");
+        assert!(err.contains("project_register"), "{err}");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn ensure_mcp_spawn_allowed_enabled_and_registered() {
+        let _env = EnvGuard::unset();
+        let dir = TempDir::new().expect("tempdir");
+        let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+        registry
+            .register(make_project(
+                "trusty-tools",
+                "https://github.com/bobmatnyc/trusty-tools",
+            ))
+            .await
+            .expect("register");
+        let cfg = TrustyToolsConfig {
+            daemon: Some(DaemonConfig {
+                allow_mcp_spawn: Some(true),
+            }),
+            ..Default::default()
+        };
+
+        ensure_mcp_spawn_allowed(
+            &registry,
+            &cfg,
+            "https://github.com/bobmatnyc/trusty-tools.git",
+        )
+        .await
+        .expect("an already-registered project must spawn without extra ceremony");
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -32,6 +32,7 @@ pub mod front_gate;
 pub mod inproject;
 pub mod inproject_hygiene;
 mod lifecycle;
+mod mcp_spawn_gate;
 pub mod prune;
 pub use activity::{ActivityResponse, get_session_activity};
 pub use fleet::{FleetByProjectResponse, FleetProjectGroup, fleet_by_project_route};
@@ -438,6 +439,9 @@ pub async fn spawn_session(
         name_hint: req.name_hint,
         runtime: req.runtime,
         ephemeral: req.ephemeral,
+        // HTTP route == CLI-origin (`tm launch`/`tm ticket` client calls) —
+        // never subject to the MCP spawn gate (#1836/#1837).
+        mcp_initiated: false,
     };
 
     match spawn_managed(&state, params).await {

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -75,6 +75,9 @@ pub async fn session_new(
         name_hint: name_hint.map(str::to_string),
         runtime: runtime.map(str::to_string),
         ephemeral,
+        // This IS the MCP tool surface (#1836/#1837): every call here is
+        // subject to the off-by-default gate + registry allowlist.
+        mcp_initiated: true,
     };
     let record = spawn_managed(state, params).await?;
     Ok(record_to_json(&record))

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -135,6 +135,10 @@ impl SessionControl for DaemonSessionControl {
             name_hint: None,
             runtime: params.model,
             ephemeral: params.ephemeral,
+            // `sm.sessions.launch` is the SM-STDIO adapter (a distinct DOC-14
+            // subsystem, not the standard MCP tool surface) — never subject to
+            // the MCP spawn gate (#1836/#1837), matching `tm launch`/`tm ticket`.
+            mcp_initiated: false,
         };
         let record = spawn_managed(&self.state, spawn)
             .await

--- a/crates/trusty-mpm/tests/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/tests/mcp_spawn_gate.rs
@@ -1,0 +1,291 @@
+//! Integration tests for the MCP-initiated spawn gate (#1836, #1837).
+//!
+//! Why: the ARIA incident showed that an MCP `session_new` call reaches the
+//! SAME [`spawn_managed`] engine the `tm` CLI uses, with no opt-in check —
+//! letting an LLM-driven MCP call mint a real clone + worktree + tmux session
+//! for ANY repo it names. These tests drive the actual daemon-level
+//! `spawn_managed` entry point (not the pure gate logic, which is unit-tested
+//! inline in `daemon::managed_routes::mcp_spawn_gate`) to prove: (1) a rejected
+//! MCP-origin spawn creates NOTHING (no session record, no workspace) and (2)
+//! a CLI/SM-STDIO-origin spawn (`mcp_initiated: false`) is NEVER gated, even
+//! when MCP spawning is globally disabled (the default).
+//!
+//! No network / no real git clone: every case here is engineered to fail (or
+//! succeed) BEFORE the real-clone branch is reached — either the gate itself
+//! short-circuits, or the target is a local non-git directory that fails fast
+//! at "no git origin remote" (`spawn_managed_local`), which is itself a strong
+//! signal the MCP gate was NOT the reason for the failure.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use serial_test::serial;
+use tempfile::TempDir;
+
+use trusty_mpm::daemon::managed_routes::{SpawnParams, spawn_managed};
+use trusty_mpm::daemon::state::DaemonState;
+use trusty_mpm::project::Project;
+
+/// Env var the daemon reads to force-enable MCP spawning (mirrors
+/// `daemon::managed_routes::mcp_spawn_gate::ALLOW_MCP_SPAWN_ENV`, duplicated
+/// here as a literal so this test file has no dependency on that private
+/// module).
+const ALLOW_MCP_SPAWN_ENV: &str = "TRUSTY_MPM_ALLOW_MCP_SPAWN";
+
+/// RAII guard that sets (or removes) `TRUSTY_MPM_ALLOW_MCP_SPAWN` for the
+/// duration of a `#[serial]` test, restoring the prior value (or absence) on
+/// drop — panic-safe, so a failed assertion mid-test cannot leak the override
+/// into a sibling test (mirrors `session_launch::tests::EnvVarGuard`).
+struct EnvGuard {
+    prev: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(value: &str) -> Self {
+        let prev = std::env::var(ALLOW_MCP_SPAWN_ENV).ok();
+        // SAFETY: env-mutating tests using this guard are tagged `#[serial]`.
+        unsafe { std::env::set_var(ALLOW_MCP_SPAWN_ENV, value) };
+        Self { prev }
+    }
+
+    fn unset() -> Self {
+        let prev = std::env::var(ALLOW_MCP_SPAWN_ENV).ok();
+        // SAFETY: env-mutating tests using this guard are tagged `#[serial]`.
+        unsafe { std::env::remove_var(ALLOW_MCP_SPAWN_ENV) };
+        Self { prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: see `set`/`unset` — serialized by `#[serial]`.
+        unsafe {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(ALLOW_MCP_SPAWN_ENV, v),
+                None => std::env::remove_var(ALLOW_MCP_SPAWN_ENV),
+            }
+        }
+    }
+}
+
+fn base_params(repo_url: &str, mcp_initiated: bool) -> SpawnParams {
+    SpawnParams {
+        repo_url: repo_url.to_string(),
+        git_ref: "main".to_string(),
+        task: "test task".to_string(),
+        name_hint: None,
+        runtime: None,
+        ephemeral: Some(true),
+        mcp_initiated,
+    }
+}
+
+/// A rejected MCP-initiated spawn (gate disabled by default) must create
+/// NOTHING — no session record, no id, no workspace (#1836).
+///
+/// Why: the whole point of the off-by-default gate is that a refusal has zero
+/// side effects; if a record were minted before the refusal, an operator would
+/// still see orphan state accumulate even though the harness never launched.
+/// What: calls `spawn_managed` with `mcp_initiated: true` against a fresh,
+/// isolated `DaemonState` with `TRUSTY_MPM_ALLOW_MCP_SPAWN` unset (default
+/// disabled), asserts the call errors mentioning "disabled", and asserts the
+/// session manager's list is still empty afterward.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial]
+async fn mcp_initiated_spawn_rejected_by_default_creates_nothing() {
+    let _env = EnvGuard::unset();
+
+    let root = TempDir::new().expect("root tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+
+    let err = spawn_managed(
+        &state,
+        base_params("https://github.com/duettoresearch/aria", true),
+    )
+    .await
+    .expect_err("MCP-initiated spawn must be refused when spawning is disabled by default");
+    assert!(err.contains("disabled"), "{err}");
+
+    let mgr = state.session_manager().await;
+    assert!(
+        mgr.list().await.is_empty(),
+        "a refused MCP spawn must create zero session records"
+    );
+}
+
+/// An MCP-initiated spawn for an unregistered repo must be refused even when
+/// spawning is explicitly enabled (#1837).
+///
+/// Why: the off-by-default toggle alone is not sufficient — the ARIA incident
+/// happened from a trusty-tools session, so even an operator who enables MCP
+/// spawning globally needs the second layer: the target repo must already be
+/// KNOWN (registered), so a session in repo A cannot silently provision repo B.
+/// What: enables spawning via the env var, leaves the registry empty, and
+/// asserts the call errors mentioning "unregistered" with zero side effects.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial]
+async fn mcp_initiated_spawn_rejected_for_unregistered_repo_when_enabled() {
+    let _env = EnvGuard::set("1");
+
+    let root = TempDir::new().expect("root tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+
+    let err = spawn_managed(
+        &state,
+        base_params("https://github.com/duettoresearch/aria", true),
+    )
+    .await
+    .expect_err("an unregistered repo must be refused even when enabled");
+    assert!(err.contains("unregistered"), "{err}");
+
+    let mgr = state.session_manager().await;
+    assert!(
+        mgr.list().await.is_empty(),
+        "a refused MCP spawn must create zero session records"
+    );
+}
+
+/// CRITICAL regression (found in review): an attacker-controlled `repo_url`
+/// that merely SHARES A REPO NAME with an already-registered project — but on
+/// a different host/owner — must still be refused, even with MCP spawning
+/// enabled (#1837).
+///
+/// Why: an earlier revision of the gate matched by bare derived repo name,
+/// which let `https://evil.example.com/attacker/trusty-tools` impersonate a
+/// registered `bobmatnyc/trusty-tools` project purely because the last path
+/// segment ("trusty-tools") matched — reproducing the exact ARIA-incident
+/// shape (an arbitrary, LLM-supplied `repo_url` gets cloned) through the
+/// allowlist meant to prevent it. `spawn_managed` must reject this end-to-end.
+/// What: registers a legitimate project, enables spawning, then targets an
+/// impersonating URL with the same repo name but a different owner/host;
+/// asserts the call is refused as "unregistered" with zero side effects.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial]
+async fn mcp_initiated_spawn_rejects_repo_name_impersonation() {
+    let _env = EnvGuard::set("1");
+
+    let root = TempDir::new().expect("root tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+
+    let registry = state.project_registry().await;
+    registry
+        .register(Project {
+            name: "trusty-tools".to_string(),
+            repo_url: "https://github.com/bobmatnyc/trusty-tools".to_string(),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+        })
+        .await
+        .expect("register legitimate project");
+
+    let err = spawn_managed(
+        &state,
+        base_params("https://evil.example.com/attacker/trusty-tools", true),
+    )
+    .await
+    .expect_err("a same-repo-name-different-owner URL must be refused, not impersonate");
+    assert!(err.contains("unregistered"), "{err}");
+
+    let mgr = state.session_manager().await;
+    assert!(
+        mgr.list().await.is_empty(),
+        "an impersonation attempt must create zero session records"
+    );
+}
+
+/// An MCP-initiated spawn for an ALREADY-REGISTERED project proceeds past the
+/// gate without extra ceremony (#1836, #1837 — the common case must not break).
+///
+/// Why: the gate must not punish the legitimate case — an operator who has
+/// registered a project (or `tm` has auto-registered it from session history)
+/// gets normal behaviour. This drives the target to a local, non-git temp
+/// directory (never real network/git) so passing the gate is proven by
+/// reaching the DIFFERENT downstream "no git origin remote" error rather than
+/// the gate's own "disabled"/"unregistered" errors.
+/// What: registers a project whose name matches the local dir's basename,
+/// enables spawning, and asserts the resulting error is the local-path
+/// no-origin error, NOT a gate refusal.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial]
+async fn mcp_initiated_spawn_allowed_for_registered_project_reaches_provisioning() {
+    let _env = EnvGuard::set("1");
+
+    let root = TempDir::new().expect("root tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+
+    // A local, non-git directory named "known-project" — `derive_name_from_url`
+    // derives "known-project" from its path, matching the registered project.
+    let target_dir = TempDir::new().expect("target tempdir");
+    let local_path = target_dir.path().join("known-project");
+    std::fs::create_dir(&local_path).expect("create target dir");
+
+    let registry = state.project_registry().await;
+    registry
+        .register(Project {
+            name: "known-project".to_string(),
+            repo_url: "https://github.com/an-owner/known-project".to_string(),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+        })
+        .await
+        .expect("register project");
+
+    let err = spawn_managed(&state, base_params(&local_path.to_string_lossy(), true))
+        .await
+        .expect_err("non-git local dir must fail downstream, not at the gate");
+    assert!(
+        err.contains("no git origin remote"),
+        "expected the gate to pass through to the local-path branch, got: {err}"
+    );
+    assert!(
+        !err.contains("disabled") && !err.contains("unregistered"),
+        "the MCP gate must not be why this failed: {err}"
+    );
+}
+
+/// A CLI/SM-STDIO-origin spawn (`mcp_initiated: false`) is NEVER subject to the
+/// MCP gate, even with MCP spawning left at its disabled default (#1836).
+///
+/// Why: `tm launch`/`tm connect`/`tm ticket` and the SM-STDIO `sm.sessions.launch`
+/// path must keep working exactly as before this change — the gate is scoped
+/// STRICTLY to the MCP tool surface.
+/// What: same local non-git directory trick as above, with `mcp_initiated:
+/// false` and the gate left disabled; asserts the error is the downstream
+/// no-git-origin error, never a gate refusal.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial]
+async fn cli_origin_spawn_bypasses_mcp_gate_even_when_disabled() {
+    let _env = EnvGuard::unset();
+
+    let root = TempDir::new().expect("root tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+
+    let target_dir = TempDir::new().expect("target tempdir");
+    let local_path = target_dir.path().join("unregistered-cli-project");
+    std::fs::create_dir(&local_path).expect("create target dir");
+
+    let err = spawn_managed(&state, base_params(&local_path.to_string_lossy(), false))
+        .await
+        .expect_err("non-git local dir must fail downstream, not at the gate");
+    assert!(
+        err.contains("no git origin remote"),
+        "expected the CLI-origin spawn to bypass the gate entirely, got: {err}"
+    );
+}


### PR DESCRIPTION
## Root cause

Both issues share one root cause: MCP-initiated `session_new` calls reach
`spawn_managed()` — the SAME engine `tm launch`/`tm connect` use — with no
opt-in check and no restriction on the target repo. An LLM-driven MCP call
(from any Claude Code session that happens to have the `trusty-mpm` MCP
server registered, e.g. via a repo's `.mcp.json`) can name an arbitrary
`repo_url` and the daemon will clone it, create a git worktree, start a tmux
session, and launch a Claude harness — with zero operator confirmation. This
is exactly what happened in the ARIA incident (#1836): a trusty-tools session
spawned dozens of `tmpm-aria-*` sessions/worktrees for an unrelated
`duettoresearch/aria` repo the user never asked `tm` to manage.

I audited the second MCP tool named in #1836 (`agent_delegate`) and confirmed
it does **not** reach `spawn_managed` at all — it requires an
already-existing `session_id` and only records an in-memory
circuit-breaker-gated `Delegation`. It needed no change.

## Gate design

Added a two-layer gate, enforced inside `spawn_managed()` **before** any side
effect (before `ManagedSessionId::new()`, before any workspace/tmux/registry
mutation), scoped by a new `SpawnParams::mcp_initiated: bool` flag:

1. **Off by default (#1836).** `mcp_initiated: true` spawns are refused
   unless `[daemon] allow_mcp_spawn: true` is set in
   `~/.trusty-tools/trusty-mpm/config.yaml`, or `TRUSTY_MPM_ALLOW_MCP_SPAWN=1`
   is set (env wins over config). The refusal message names both the config
   key and the env var, and points to `tm launch` as the unaffected path.
2. **Registry allowlist (#1837).** Even when enabled, the target repo must
   already be a *known* project. Matching is **strict `(owner, repo)`
   identity** for anything that looks like a remote reference (URL or SSH
   shorthand) — not a bare repo-name match. A code-review pass caught that a
   bare-name match would let `https://evil.example.com/attacker/trusty-tools`
   impersonate a registered `bobmatnyc/trusty-tools` project purely by
   sharing the last path segment, reproducing the ARIA-incident shape through
   the allowlist itself; this is now closed and pinned by a regression test
   (`is_known_repo_rejects_same_repo_name_different_owner` +
   `mcp_initiated_spawn_rejects_repo_name_impersonation`). A local filesystem
   path (the in-project spawn convenience case) still falls back to a
   derived-basename match, since it carries no owner/repo identity to spoof.

`SpawnParams::mcp_initiated` is `false` at every other construction site —
the HTTP route (`tm launch`/`tm ticket` clients) and the SM-STDIO adapter
(`sm.sessions.launch`, a distinct DOC-14 subsystem) — so those paths are
completely unaffected.

**Scoping note:** `sm.sessions.launch` (`tm sm serve --stdio`) was
deliberately left ungated as CLI/automation-origin, matching `tm launch`. Its
own doc comments note a parent `claude-mpm`/PM process can drive it
headlessly, which is a similar LLM-drivable surface to MCP `session_new` —
but it's a different, separate epic (#1283) not named in either linked
issue. Flagging this here in case a follow-up ticket is warranted; happy to
extend the gate there too if desired.

## Files changed

- `crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs` (new) — the
  gate: `mcp_spawn_enabled`, `is_known_repo`, `ensure_mcp_spawn_allowed`.
- `crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs` —
  `SpawnParams::mcp_initiated` field; gate wired into `spawn_managed`.
- `crates/trusty-mpm/src/daemon/managed_routes/mod.rs` — HTTP route sets
  `mcp_initiated: false`; registers the new module.
- `crates/trusty-mpm/src/daemon/mcp_session.rs` — MCP `session_new` sets
  `mcp_initiated: true`.
- `crates/trusty-mpm/src/daemon/sm_stdio/control.rs` — `sm.sessions.launch`
  sets `mcp_initiated: false`.
- `crates/trusty-mpm/src/core/trusty_tools_config.rs` — new
  `DaemonConfig { allow_mcp_spawn }` + `daemon:` config section.
- `crates/trusty-mpm/tests/mcp_spawn_gate.rs` (new) — end-to-end
  `spawn_managed` integration tests (no network/real git clone).

## Verification (raw output)

`cargo test -p trusty-mpm` (full suite):
```
test result: ok. 2195 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 4.64s
```
(19 test binaries total, all `ok`, 0 failures.)

New gate unit tests (`cargo test -p trusty-mpm --lib mcp_spawn_gate`):
```
running 15 tests
test daemon::managed_routes::mcp_spawn_gate::tests::looks_like_remote_url_detects_https_and_ssh ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::looks_like_remote_url_rejects_local_absolute_path ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::is_known_repo_matches_by_name ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::is_known_repo_remote_target_ignores_local_registered_url ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::is_known_repo_rejects_same_repo_name_different_owner ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::is_known_repo_rejects_unregistered ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::is_known_repo_matches_by_owner_and_repo_ignoring_git_suffix ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::is_known_repo_matches_ssh_and_https_forms ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::ensure_mcp_spawn_allowed_disabled_by_default ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::ensure_mcp_spawn_allowed_enabled_and_registered ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::env_false_string_defers_to_config ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::ensure_mcp_spawn_allowed_enabled_but_unregistered ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::config_true_enables ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::default_is_disabled ... ok
test daemon::managed_routes::mcp_spawn_gate::tests::env_true_enables_regardless_of_config ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 2183 filtered out; finished in 0.00s
```

`spawn_managed` end-to-end integration tests (`cargo test -p trusty-mpm --test mcp_spawn_gate`):
```
running 5 tests
test mcp_initiated_spawn_rejected_for_unregistered_repo_when_enabled ... ok
test mcp_initiated_spawn_rejected_by_default_creates_nothing ... ok
test cli_origin_spawn_bypasses_mcp_gate_even_when_disabled ... ok
test mcp_initiated_spawn_allowed_for_registered_project_reaches_provisioning ... ok
test mcp_initiated_spawn_rejects_repo_name_impersonation ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

`cargo clippy -p trusty-mpm --all-targets -- -D warnings`:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.79s
```
(zero clippy warnings/errors; unrelated pre-existing `tga` warning only)

`cargo fmt --check`: clean (exit 0).

`bash scripts/check_line_cap.sh`:
```
line-cap: 14 allowlisted, 0 violations — OK.
```

## Test plan

- [x] MCP-initiated spawn rejected by default, zero side effects (no session
      record created)
- [x] MCP-initiated spawn rejected for unregistered repo even when enabled
- [x] MCP-initiated spawn allowed for an already-registered project (no
      extra ceremony)
- [x] CLI-origin (`tm launch`/`tm ticket`/SM-STDIO) spawn never gated, even
      with MCP spawning disabled
- [x] Repo-name impersonation (different owner/host, same repo name) rejected
      (regression pinned after independent code review caught this)

Closes #1836
Closes #1837

🤖 Generated with [Claude Code](https://claude.com/claude-code)