### PR TITLE
fix(trusty-review): recalibrate RC gate + verifier + Medium floor (#1876)

### DIFF
--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -149,7 +149,13 @@ impl std::fmt::Display for Effort {
 /// "refuted because of error", etc., to compute the correct verdict and emit
 /// the right alarm (spec §07 REV-606, source-analysis §12.1).
 /// What: `ErrorRefuted` carries the error class string so config/lifecycle
-/// failures are distinguishable in logs.
+/// failures are distinguishable in logs.  As of #1876 it also covers transient
+/// verifier errors (rate limit, transport, upstream 5xx) — NOT just
+/// config/lifecycle failures — because both are "unable to verify", a
+/// structurally different outcome from a clean model REFUTED (see
+/// `pipeline::verify::verify_one`).  Only config/lifecycle errors also emit the
+/// `verification_model_error` alarm signal; transient errors are expected
+/// operational noise and do not alarm.
 /// Test: `verify_outcome_serde_roundtrip`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -158,10 +164,16 @@ pub enum VerifyOutcome {
     Confirmed,
     /// Verifier LLM refuted the finding.
     Refuted,
-    /// Verifier call failed with a config/lifecycle error (see spec REV-340).
-    /// The finding is treated as refuted but an alarm is emitted.
+    /// Verifier call failed with a config/lifecycle error (see spec REV-340) or
+    /// a transient error (rate limit / transport / upstream 5xx, #1876). The
+    /// finding is excluded from the verdict floor like a refutation, but
+    /// `rederive_verdict` treats it as "unable to verify" rather than a clean
+    /// model REFUTED — it preserves `primary_verdict` instead of collapsing the
+    /// review to APPROVE. Only config/lifecycle errors also emit the
+    /// `verification_model_error` alarm.
     ErrorRefuted {
-        /// Human-readable error class (e.g. `"ModelNotFound"`, `"AccessDenied"`).
+        /// Human-readable error class (e.g. `"ModelNotFound"`, `"AccessDenied"`,
+        /// `"Transport"`, `"RateLimited"`, `"Upstream"`).
         error_class: String,
     },
     /// Verifier call failed due to truncation / context-length overrun.

--- a/crates/trusty-review/src/pipeline/grade.rs
+++ b/crates/trusty-review/src/pipeline/grade.rs
@@ -27,25 +27,36 @@
 //! 2. SEVERITY FLOOR: take the stricter of (model-proposed, severity-derived).
 //!    As of #1015, Medium findings only count when `confidence > 0.80`
 //!    (`FLOOR_MIN_CONFIDENCE`); advisory-tier Medium findings (0.66–0.80)
-//!    must not force REQUEST_CHANGES on PRs the model judged clean.
+//!    must not force REQUEST_CHANGES on PRs the model judged clean.  As of
+//!    #1876, a SINGLE confident Medium finding is enough to floor to
+//!    REQUEST_CHANGES (previously this required ≥2) — see item 3 below for why
+//!    the count threshold was dropped rather than merely lowered.
 //!
-//! 3. SOURCE-OF-TRUTH RECONCILIATION (#1343): when the model's own verdict is a
-//!    clean `APPROVE`, a *count-based* REQUEST_CHANGES floor (≥2 Medium findings)
-//!    is capped at APPROVE* — it must not contradict the model's own APPROVE
-//!    review_body.  The grade is the model's primary signal; the count heuristic
-//!    may surface an advisory concern but may NOT harden an APPROVE into
-//!    REQUEST_CHANGES (which would loop the PM merge workflow forever).  A
-//!    High-effort (critical) finding is exempt — it still floors to BLOCK, because
-//!    BLOCK is grounded critical evidence, not a Medium-count heuristic.
+//! 3. SOURCE-OF-TRUTH RECONCILIATION (#1343, narrowed by #1876): when the
+//!    model's own verdict is a clean `APPROVE`, a *count-based* REQUEST_CHANGES
+//!    floor used to be capped at APPROVE* — the theory being that "≥2 weakly
+//!    grounded Mediums" was a heuristic weaker than the model's own holistic
+//!    judgment.  A recalibration shadow-eval (#1876, n=473) found this made the
+//!    reviewer dangerously lenient: verdict agreement was only 61.3%, and 89% of
+//!    reference-reviewer REQUEST_CHANGES cases were silently downgraded to
+//!    APPROVE.  `correctness_floor`'s Tier 2 no longer requires a *count* — ONE
+//!    finding that clears `FLOOR_MIN_CONFIDENCE` (0.80) is, by definition,
+//!    well-evidenced, so it now gets the same hard-floor treatment as a
+//!    High-effort finding (Tier 1) and a confident method-conformance divergence
+//!    (`conformance_floor`): it is NEVER capped back down merely because the
+//!    model's own verdict was a clean APPROVE.  There is therefore no longer a
+//!    "weak count heuristic" case for a reconciliation cap to protect, and the
+//!    cap has been removed (see `derive_verdict`'s doc comment for detail).
 //!
 //!   | Finding set                                          | Minimum floor   |
 //!   |------------------------------------------------------|-----------------|
 //!   | Any `High` effort (critical/high sev.)               | BLOCK           |
-//!   | ≥2 `Medium` effort with confidence > 0.80            | REQUEST_CHANGES |
-//!   | Exactly 1 `Medium` effort with confidence > 0.80     | APPROVE*        |
+//!   | ≥1 `Medium` effort with confidence > 0.80             | REQUEST_CHANGES |
 //!   | Only `Low` effort or no floor-counting findings      | APPROVE         |
 //!
-//!   The model can never soften a Critical or High finding below the floor.
+//!   The model can never soften a Critical, High, or confident-Medium finding
+//!   below the floor — none of the three tiers above are subject to the
+//!   APPROVE-review_body reconciliation cap.
 //!
 //! `Verdict::Unknown` is always preserved (pass-through) — the model has
 //! signalled the diff was unassessable and no rule applies.
@@ -73,7 +84,8 @@
 //!
 //! Test: `grade_critical_high_effort_yields_block`,
 //! `grade_two_medium_yields_request_changes`,
-//! `grade_one_medium_yields_approve_star`,
+//! `grade_one_medium_yields_request_changes` (#1876, supersedes the pre-#1876
+//! `..._yields_approve_star` expectation),
 //! `grade_only_low_yields_approve`,
 //! `grade_unknown_is_preserved`,
 //! `grade_floor_overrides_model_approve`,
@@ -87,7 +99,11 @@
 //! `derive_verdict_with_grade_severity_overrides_grade_a`,
 //! `floor_excludes_refuted_and_low_confidence_findings` (#1343),
 //! `approve_b_plus_survives_refuted_and_low_confidence_findings` (#1343),
-//! `approve_b_plus_two_high_conf_medium_caps_at_approve_star` (#1343),
+//! `grade_model_approve_confident_medium_still_escalates_to_request_changes` and
+//! `grade_model_approve_b_plus_confident_medium_escalates_to_request_changes`
+//! (#1876 — supersede the pre-#1876
+//! `..._caps_medium_count_floor_at_approve_star` / `..._two_high_conf_medium_
+//! caps_at_approve_star` expectations),
 //! `model_request_changes_review_body_still_surfaces_request_changes` (#1343),
 //! `high_effort_finding_still_overrides_approve` (#1343),
 //! `low_confidence_high_effort_finding_still_drives_floor` (PR #1350),
@@ -264,10 +280,25 @@ fn floor_count_min_confidence() -> f32 {
 /// 2. SEVERITY FLOOR (minimum): outside the override window, compute a floor from
 ///    the finding severity distribution (see `severity_floor`) and return
 ///    `max(model_proposed, floor)`.  The model can never soften a Critical/High
-///    finding to APPROVE*.
+///    finding — nor, as of #1876, a single confident Medium finding — below the
+///    floor, regardless of the model's own proposed verdict.
 ///
 /// Special case: `Verdict::Unknown` is always returned as-is — the model has
 /// determined the diff was unassessable and no floor or override applies.
+///
+/// ## #1343 reconciliation cap — removed by #1876
+/// A prior version of this function capped a *count-based* (≥2 Medium)
+/// REQUEST_CHANGES floor at APPROVE* whenever `model_proposed == Approve`, on
+/// the theory that a count heuristic was weaker evidence than the model's own
+/// holistic APPROVE.  #1876's shadow-eval showed this made the reviewer
+/// dangerously lenient (61.3% verdict agreement; 89% of reference
+/// REQUEST_CHANGES cases silently downgraded).  `correctness_floor`'s Tier 2 no
+/// longer needs ≥2 findings — ONE finding that clears `FLOOR_MIN_CONFIDENCE`
+/// is, by construction, well-evidenced, so every REQUEST_CHANGES floor this
+/// function can now produce is confidence-grounded, not count-based.  There is
+/// therefore no remaining "weak heuristic" case for a reconciliation cap to
+/// protect, and the cap was removed outright (see `severity_floor` /
+/// `correctness_floor` for the confidence gate that replaces it).
 ///
 /// Test: see module-level test list.
 pub fn derive_verdict(model_proposed: Verdict, findings: &[Finding]) -> Verdict {
@@ -304,43 +335,18 @@ pub fn derive_verdict(model_proposed: Verdict, findings: &[Finding]) -> Verdict 
     }
 
     // Severity floor: take the stricter of model-proposed and severity-derived.
-    let mut floor = severity_floor(&substantive);
-
-    // #1343: source-of-truth reconciliation.  When the model holistically judged
-    // the change APPROVE, a *count-based* REQUEST_CHANGES floor (≥2 Medium findings)
-    // must NOT override that judgment into REQUEST_CHANGES — that is exactly the
-    // calibration bug where APPROVE/B+ drifted to REQUEST_CHANGES/D+.  Cap the
-    // count-based floor at APPROVE* (advisory) in that case.  High-effort findings
-    // are unaffected: a genuine critical (BLOCK floor) still escalates an APPROVE,
-    // because BLOCK is grounded critical evidence, not a count heuristic.
-    //
-    // #1359: a CONFIRMED method-conformance divergence (a conformance finding that
-    // clears FLOOR_MIN_CONFIDENCE = 0.80) is grounded explicit evidence — the diff
-    // contradicts a method the ticket/spec stated — NOT a Medium-count heuristic.
-    // Like the High-effort exemption, it is exempt from this cap so AC-8 holds: a
-    // model APPROVE + a confident conformance divergence still floors to
-    // REQUEST_CHANGES.  (A sub-0.80 conformance finding never reaches the
-    // RequestChanges floor in the first place — see `conformance_floor` — so the
-    // cap correctly still applies to advisory-only conformance, honouring AC-12.)
-    let has_confident_conformance = substantive.iter().any(|f| {
-        f.category == FindingCategory::MethodConformance && f.confidence >= floor_min_confidence()
-    });
-    if model_proposed == Verdict::Approve
-        && floor == Verdict::RequestChanges
-        && !has_confident_conformance
-    {
-        debug!(
-            "source-of-truth reconciliation: model APPROVE + count-based REQUEST_CHANGES floor \
-             → capping floor at APPROVE* (no Medium-count override of an APPROVE review_body)"
-        );
-        floor = Verdict::ApproveWithReservations;
-    }
-    // Traceability (PR #1350): this cap only relaxes the *upward* direction
-    // (an APPROVE review_body must not be hardened to REQUEST_CHANGES by a Medium
-    // count).  The symmetric *downward* direction — a model-proposed BLOCK being
-    // relaxed below the floor — is intentionally NOT handled here; it is covered by
-    // `stricter_of` below, which takes max(model, floor), so a model BLOCK can never
-    // be softened by a weaker floor.  See `grade_model_block_kept_when_no_critical_finding`.
+    // #1876: the pre-existing #1343 "cap a count-based REQUEST_CHANGES floor at
+    // APPROVE* when model_proposed==APPROVE" reconciliation has been removed.
+    // `correctness_floor`'s Tier 2 (below) now floors to REQUEST_CHANGES on a
+    // SINGLE confident (`confidence > FLOOR_MIN_CONFIDENCE`) Medium finding —
+    // the same hard-floor treatment already given to High-effort findings
+    // (Tier 1, BLOCK) and confident method-conformance divergences
+    // (`conformance_floor`, #1359).  Every REQUEST_CHANGES floor this function
+    // can produce is therefore confidence-grounded, not a "weak count
+    // heuristic", so it is never capped back down merely because the model's
+    // own verdict was a clean APPROVE — see the function doc for the shadow-eval
+    // rationale (#1876).
+    let floor = severity_floor(&substantive);
 
     let final_verdict = stricter_of(model_proposed.clone(), floor.clone());
 
@@ -424,22 +430,24 @@ fn is_high_severity(f: &Finding) -> bool {
 /// this function is called; by the time this is reached, the batch has at least
 /// one substantive finding.
 ///
-/// As of #1015, Medium findings only count toward the REQUEST_CHANGES and
-/// APPROVE* floors when their `confidence > FLOOR_MIN_CONFIDENCE` (0.80).
-/// Advisory-tier Medium findings (confidence 0.66–0.80) are speculative; they
-/// must not force REQUEST_CHANGES over-escalation on PRs the model holistically
-/// judged clean.  High-effort behavior is unchanged: any confirmed High finding
-/// still floors to BLOCK regardless of confidence.
+/// As of #1015, Medium findings only count toward the REQUEST_CHANGES floor
+/// when their `confidence > FLOOR_MIN_CONFIDENCE` (0.80).  Advisory-tier Medium
+/// findings (confidence 0.66–0.80) are speculative; they must not force
+/// REQUEST_CHANGES over-escalation on PRs the model holistically judged clean.
+/// High-effort behavior is unchanged: any confirmed High finding still floors
+/// to BLOCK regardless of confidence.  As of #1876, a SINGLE confident Medium
+/// finding is sufficient to floor to REQUEST_CHANGES (previously ≥2 were
+/// required, with exactly 1 capped at the weaker APPROVE*) — see the module doc
+/// for the shadow-eval rationale.
 ///
-/// What: applies the four-tier rule set:
+/// What: applies the three-tier rule set:
 ///
 /// 1. Any `High`-effort finding → BLOCK (Critical/High severity)
-/// 2. ≥2 `Medium`-effort findings with `confidence > 0.80` → REQUEST_CHANGES
-/// 3. Exactly 1 `Medium`-effort finding with `confidence > 0.80` → APPROVE*
-/// 4. Only `Low` / no floor-counting findings → APPROVE
+/// 2. ≥1 `Medium`-effort finding with `confidence > 0.80` → REQUEST_CHANGES
+/// 3. Only `Low` / no floor-counting findings → APPROVE
 ///
 /// Test: `grade_two_medium_yields_request_changes`,
-/// `grade_one_medium_yields_approve_star`,
+/// `grade_one_medium_yields_request_changes` (#1876),
 /// `grade_advisory_medium_below_floor_threshold_does_not_escalate`,
 /// `grade_high_confidence_medium_above_floor_threshold_escalates`.
 ///
@@ -447,7 +455,7 @@ fn is_high_severity(f: &Finding) -> bool {
 /// `is_substantive`, so this function only ever sees substantive findings.
 ///
 /// As of #1359 the floor is split by `FindingCategory`: correctness findings run
-/// the four-tier rule unchanged, while method-conformance findings run a separate,
+/// the three-tier rule above, while method-conformance findings run a separate,
 /// strictly-weaker rule (see [`conformance_floor`]) that caps at `REQUEST_CHANGES`
 /// and never contributes `BLOCK`.  The combined floor is the stricter of the two.
 fn severity_floor(findings: &[&Finding]) -> Verdict {
@@ -468,19 +476,23 @@ fn severity_floor(findings: &[&Finding]) -> Verdict {
     stricter_of(correctness_floor, conformance_floor)
 }
 
-/// The four-tier correctness floor (the pre-#1359 `severity_floor` body).
+/// The three-tier correctness floor (#1876 merged the old Tiers 2/3 — see below).
 ///
 /// Why: separating the correctness rule from the conformance rule (#1359) keeps
 /// each rule readable and lets the conformance rule be strictly weaker (capped at
-/// REQUEST_CHANGES) without touching the proven correctness tiers.
-/// What: applies the unchanged four-tier rule set over correctness findings:
+/// REQUEST_CHANGES) without touching the correctness tiers.  #1876 additionally
+/// collapsed the old count-gated Tier 2/3 split (≥2 Medium → REQUEST_CHANGES,
+/// exactly 1 → APPROVE*) into a single confidence-gated tier: a shadow-eval
+/// showed requiring a SECOND corroborating Medium finding before escalating was
+/// the single largest source of the reviewer under-firing REQUEST_CHANGES.
+/// What: applies the three-tier rule set over correctness findings:
 ///   1. Any `High`-effort finding → BLOCK
-///   2. ≥2 high-confidence Medium-effort findings → REQUEST_CHANGES
-///   3. Exactly 1 high-confidence Medium-effort finding → APPROVE*
-///   4. Only `Low` / no floor-counting findings → APPROVE
+///   2. ≥1 high-confidence (`confidence > FLOOR_MIN_CONFIDENCE`) Medium-effort
+///      finding → REQUEST_CHANGES
+///   3. Only `Low` / no floor-counting findings → APPROVE
 ///
 /// Test: `grade_two_medium_yields_request_changes`,
-///       `grade_one_medium_yields_approve_star`,
+///       `grade_one_medium_yields_request_changes` (#1876),
 ///       `grade_advisory_medium_below_floor_threshold_does_not_escalate`.
 fn correctness_floor(findings: &[&&Finding]) -> Verdict {
     if findings.is_empty() {
@@ -493,27 +505,25 @@ fn correctness_floor(findings: &[&&Finding]) -> Verdict {
     // Only count Medium findings whose confidence clears the floor threshold
     // (#1015: advisory-tier Medium findings must not force REQUEST_CHANGES).
     let medium_floor = floor_min_confidence();
-    let medium_count = findings
+    let has_confident_medium = findings
         .iter()
-        .filter(|f| f.effort == Effort::Medium && f.confidence > medium_floor)
-        .count();
+        .any(|f| f.effort == Effort::Medium && f.confidence > medium_floor);
 
     // Tier 1: any High-effort (critical/high severity) → BLOCK floor.
     if has_high {
         return Verdict::Block;
     }
 
-    // Tier 2: ≥2 high-confidence Medium-effort findings → REQUEST_CHANGES.
-    if medium_count >= 2 {
+    // Tier 2 (#1876): ANY single high-confidence Medium-effort finding →
+    // REQUEST_CHANGES.  A finding that clears FLOOR_MIN_CONFIDENCE (0.80) is,
+    // by definition, well-evidenced — it no longer needs a second corroborating
+    // Medium to escalate, matching the hard-floor treatment already given to
+    // High-effort findings (Tier 1).
+    if has_confident_medium {
         return Verdict::RequestChanges;
     }
 
-    // Tier 3: exactly 1 high-confidence Medium-effort finding → APPROVE*.
-    if medium_count == 1 {
-        return Verdict::ApproveWithReservations;
-    }
-
-    // Tier 4: only Low-effort, no findings, or all-advisory Medium findings.
+    // Tier 3: only Low-effort, no findings, or all-advisory Medium findings.
     Verdict::Approve
 }
 

--- a/crates/trusty-review/src/pipeline/grade_tests.rs
+++ b/crates/trusty-review/src/pipeline/grade_tests.rs
@@ -69,7 +69,7 @@ fn grade_high_effort_beats_request_changes() {
     assert_eq!(verdict, Verdict::Block);
 }
 
-// ── Tier 2: ≥2 Medium ────────────────────────────────────────────────────────
+// ── Tier 2: ≥1 confident Medium (#1876: count gate replaced by confidence gate) ─
 
 /// Two high-confidence Medium findings (confidence > 0.80) must floor to REQUEST_CHANGES.
 ///
@@ -87,8 +87,8 @@ fn grade_two_medium_yields_request_changes() {
 /// → REQUEST_CHANGES.
 ///
 /// Why: when the model's own verdict is APPROVE* (not a clean APPROVE), the
-/// count-based floor is free to escalate to REQUEST_CHANGES — the model already
-/// flagged reservations, so the floor is not contradicting an APPROVE review_body.
+/// floor is free to escalate to REQUEST_CHANGES — the model already flagged
+/// reservations, so the floor is not contradicting an APPROVE review_body.
 /// What: model APPROVE* + three Medium@0.85 → floor REQUEST_CHANGES (stricter wins).
 #[test]
 fn grade_three_medium_yields_request_changes() {
@@ -101,17 +101,20 @@ fn grade_three_medium_yields_request_changes() {
     assert_eq!(verdict, Verdict::RequestChanges);
 }
 
-/// #1343: a clean model APPROVE must NOT be count-overridden to REQUEST_CHANGES by
-/// the Medium-count floor — it caps at APPROVE*.
+/// #1876 (supersedes #1343): a clean model APPROVE is NO LONGER capped down to
+/// APPROVE* when a confidence-grounded Medium floor fires — the reconciliation
+/// cap was removed because every REQUEST_CHANGES floor is now confidence-gated,
+/// not count-gated (see the module doc for the shadow-eval rationale).
 ///
-/// Why: this is the core calibration bug.  The model holistically judged the change
-/// APPROVE; a count-based REQUEST_CHANGES floor (≥2 high-confidence Mediums) must
-/// not contradict the model's own verdict.  The floor still surfaces the concern as
-/// an advisory APPROVE* (not silent APPROVE), but never hardens an APPROVE
-/// review_body to REQUEST_CHANGES.
-/// What: model APPROVE + three Medium@0.85 → APPROVE* (capped, not REQUEST_CHANGES).
+/// Why: #1343 introduced the cap to protect against a *count-based* (≥2 Medium)
+/// heuristic overriding the model's own holistic APPROVE. #1876's shadow-eval
+/// (n=473) showed this made the reviewer too lenient — 89% of reference
+/// REQUEST_CHANGES cases were silently downgraded to APPROVE. Since Tier 2 no
+/// longer needs a *count* (a single confidence > 0.80 finding suffices), there
+/// is no remaining "weak heuristic" for the cap to protect, so it was removed.
+/// What: model APPROVE + three Medium@0.85 → REQUEST_CHANGES (no longer capped).
 #[test]
-fn grade_model_approve_caps_medium_count_floor_at_approve_star() {
+fn grade_model_approve_confident_medium_still_escalates_to_request_changes() {
     let findings = vec![
         finding(Effort::Medium, 0.85),
         finding(Effort::Medium, 0.85),
@@ -120,26 +123,35 @@ fn grade_model_approve_caps_medium_count_floor_at_approve_star() {
     let verdict = derive_verdict(Verdict::Approve, &findings);
     assert_eq!(
         verdict,
-        Verdict::ApproveWithReservations,
-        "model APPROVE must cap the Medium-count floor at APPROVE* (#1343)"
+        Verdict::RequestChanges,
+        "model APPROVE must NOT cap a confidence-grounded Medium floor at \
+         APPROVE* (#1876 removes the #1343 count-based reconciliation cap)"
     );
 }
 
-// ── Tier 3: Exactly 1 Medium ─────────────────────────────────────────────────
-
-/// One high-confidence Medium finding (confidence > 0.80) must floor to APPROVE*.
+/// A SINGLE high-confidence Medium finding (confidence > 0.80) must floor to
+/// REQUEST_CHANGES (#1876 — supersedes the pre-#1876 APPROVE* result).
 ///
-/// Why: a single well-grounded concern should not block the PR but warrants
-/// noting.  Only findings with confidence > FLOOR_MIN_CONFIDENCE (0.80) count
-/// toward the floor (#1015).
+/// Why: the #1876 shadow-eval (n=473) showed requiring a SECOND corroborating
+/// Medium before escalating (the old Tier 2/3 split) was the single largest
+/// source of the reviewer under-firing REQUEST_CHANGES (only 3 emissions
+/// against 119 reference-reviewer REQUEST_CHANGES cases). A finding that clears
+/// FLOOR_MIN_CONFIDENCE (0.80) is, by definition, well-evidenced — it now gets
+/// the same hard-floor treatment as a High-effort finding (Tier 1), matching
+/// the precedent set by `mapreduce::synthesis::apply_synthesis_floor`'s
+/// High-effort hard floor (PR #1674/#1675).
 #[test]
-fn grade_one_medium_yields_approve_star() {
+fn grade_one_medium_yields_request_changes() {
     let findings = vec![finding(Effort::Medium, 0.85)];
     let verdict = derive_verdict(Verdict::Approve, &findings);
-    assert_eq!(verdict, Verdict::ApproveWithReservations);
+    assert_eq!(
+        verdict,
+        Verdict::RequestChanges,
+        "a single high-confidence Medium finding must floor to REQUEST_CHANGES (#1876)"
+    );
 }
 
-// ── Tier 4: Only Low or no findings ─────────────────────────────────────────
+// ── Tier 3: Only Low or no findings ─────────────────────────────────────────
 
 /// No findings → APPROVE.
 #[test]
@@ -260,15 +272,16 @@ fn grade_high_confidence_medium_beats_low_confidence_check() {
 /// Mixed-confidence Medium findings: one above FLOOR_MIN_CONFIDENCE, one below.
 ///
 /// Why: only the finding with confidence > 0.80 counts toward the floor (#1015).
-/// One floor-counting Medium → APPROVE* (not REQUEST_CHANGES).  The old test
-/// (confidence 0.8, 0.5 → REQUEST_CHANGES) encoded the over-aggressive behavior
-/// that caused #1015; confidence 0.8 is NOT > 0.80.
+/// One floor-counting Medium is now (#1876) sufficient on its own →
+/// REQUEST_CHANGES.  The sub-0.80 finding contributes nothing either way;
+/// confidence 0.5 is well below the gate.
 #[test]
 fn grade_mixed_confidence_two_medium_only_one_counts() {
     let findings = vec![finding(Effort::Medium, 0.85), finding(Effort::Medium, 0.5)];
     let verdict = derive_verdict(Verdict::Approve, &findings);
-    // Only the 0.85 finding counts (> 0.80); one floor-counting Medium → APPROVE*.
-    assert_eq!(verdict, Verdict::ApproveWithReservations);
+    // Only the 0.85 finding counts (> 0.80); one floor-counting Medium is
+    // sufficient on its own → REQUEST_CHANGES (#1876).
+    assert_eq!(verdict, Verdict::RequestChanges);
 }
 
 // ── Compile-break BLOCK rule ─────────────────────────────────────────────────
@@ -574,28 +587,32 @@ fn approve_b_plus_survives_refuted_and_low_confidence_findings() {
     );
 }
 
-/// #1343: even high-confidence, non-refuted Medium findings cannot count-override a
-/// clean APPROVE/B+ review_body to REQUEST_CHANGES — they cap at APPROVE* / C+.
+/// #1876 (supersedes #1343): high-confidence, non-refuted Medium findings DO
+/// escalate a clean APPROVE/B+ review_body to REQUEST_CHANGES / D+ — the
+/// #1343 count-based reconciliation cap was removed.
 ///
-/// Why: the source-of-truth reconciliation: a count-based REQUEST_CHANGES floor
-/// must never contradict the model's own APPROVE verdict.  The concern is surfaced
-/// as an advisory APPROVE* (grade clamped to C+, the APPROVE* ceiling), never as a
-/// REQUEST_CHANGES that loops the PM merge workflow forever.
-/// What: model APPROVE, grade B+, two Medium@0.85 → (APPROVE*, C+).
+/// Why: #1343's reconciliation existed to stop a *count-based* (≥2 Medium)
+/// heuristic from contradicting the model's own APPROVE verdict. #1876's
+/// shadow-eval (n=473) found that cap made the reviewer too lenient — a
+/// confidence-grounded concern (confidence > FLOOR_MIN_CONFIDENCE) is no
+/// longer a "weak heuristic"; it now gets the same hard-floor treatment as a
+/// High-effort finding and is never capped back down.
+/// What: model APPROVE, grade B+, two Medium@0.85 → (REQUEST_CHANGES, D+).
 /// Test: this test itself.
 #[test]
-fn approve_b_plus_two_high_conf_medium_caps_at_approve_star() {
+fn grade_model_approve_b_plus_confident_medium_escalates_to_request_changes() {
     let findings = vec![finding(Effort::Medium, 0.85), finding(Effort::Medium, 0.85)];
     let (v, g) = derive_verdict_with_grade(Verdict::Approve, Grade::BPlus, &findings);
     assert_eq!(
         v,
-        Verdict::ApproveWithReservations,
-        "clean APPROVE must cap the Medium-count floor at APPROVE* (#1343)"
+        Verdict::RequestChanges,
+        "clean APPROVE must NOT cap a confidence-grounded Medium floor at \
+         APPROVE* (#1876 removes the #1343 count-based reconciliation cap)"
     );
     assert_eq!(
         g,
-        Some(Grade::CPlus),
-        "grade clamps to C+ (APPROVE* ceiling), never D+ (#1343)"
+        Some(Grade::DPlus),
+        "grade clamps to D+ (REQUEST_CHANGES ceiling) — #1876"
     );
 }
 

--- a/crates/trusty-review/src/pipeline/prompt_templates.rs
+++ b/crates/trusty-review/src/pipeline/prompt_templates.rs
@@ -44,8 +44,13 @@ a grade of "F" must have verdict BLOCK; a grade of "B-" or above must have verdi
 
 - Your default verdict is APPROVE (default grade A-). You bear the burden of proof to escalate.
 - APPROVE* requires at least one Medium finding. Do not emit APPROVE* with only Low findings.
-- REQUEST_CHANGES requires ALL THREE: (a) a specific wrong line cited verbatim,
-  (b) a traceable failure path, (c) a concrete fix proposed.
+- REQUEST_CHANGES requires strong evidence on AT LEAST TWO of these three
+  dimensions: (a) a specific wrong line cited verbatim, (b) a traceable failure
+  path, (c) a concrete fix proposed. Do NOT withhold REQUEST_CHANGES merely
+  because one dimension is thin — e.g. a clear failure path plus a concrete fix
+  is sufficient even when the line citation is only approximate, and a verbatim
+  line plus a concrete fix is sufficient even when the failure path is implicit
+  rather than spelled out step-by-step.
 - Do NOT emit UNKNOWN just because the PR is large; use it only when you
   genuinely cannot tell if the change is correct.
 - **Do not under-rate a clearly blocking issue as advisory.** If it would break
@@ -184,8 +189,13 @@ a grade of "F" must have verdict BLOCK; a grade of "B-" or above must have verdi
 
 - Your default verdict is APPROVE (default grade A-). You bear the burden of proof to escalate.
 - APPROVE* requires at least one Medium finding. Do not emit APPROVE* with only Low findings.
-- REQUEST_CHANGES requires ALL THREE: (a) a specific wrong line cited verbatim,
-  (b) a traceable failure path, (c) a concrete fix proposed.
+- REQUEST_CHANGES requires strong evidence on AT LEAST TWO of these three
+  dimensions: (a) a specific wrong line cited verbatim, (b) a traceable failure
+  path, (c) a concrete fix proposed. Do NOT withhold REQUEST_CHANGES merely
+  because one dimension is thin — e.g. a clear failure path plus a concrete fix
+  is sufficient even when the line citation is only approximate, and a verbatim
+  line plus a concrete fix is sufficient even when the failure path is implicit
+  rather than spelled out step-by-step.
 - Do NOT emit UNKNOWN just because the PR is large; use it only when you
   genuinely cannot tell if the change is correct.
 - **Do not under-rate a clearly blocking issue as advisory.** If it would break

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -23,8 +23,9 @@ fn system_prompt_contains_policy() {
         "system prompt must state APPROVE-default policy"
     );
     assert!(
-        prompt.contains("REQUEST_CHANGES requires ALL THREE"),
-        "system prompt must specify the REQUEST_CHANGES gate"
+        prompt.contains("REQUEST_CHANGES requires strong evidence on AT LEAST TWO"),
+        "system prompt must specify the recalibrated (#1876) REQUEST_CHANGES gate — \
+         evidence on 2-of-3 dimensions, not a conjunctive AND of all three"
     );
     assert!(
         prompt.contains("BLOCK"),

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -988,15 +988,18 @@ async fn run_review_verification_refutes_and_relaxes_verdict() {
     );
 }
 
-/// The verification round, when wired in, CONFIRMS the Medium finding; after #1015
-/// a lone confirmed Medium anchors at APPROVE* (path a2), not REQUEST_CHANGES.
+/// The verification round, when wired in, CONFIRMS the Medium finding; #1876
+/// (superseding #1015) re-escalates a lone confirmed high-confidence Medium
+/// back to REQUEST_CHANGES.
 ///
-/// Why: before #1015 path (a) preserved primary_verdict (REQUEST_CHANGES) on any
-/// confirmed finding.  After #1015, only confirmed High-effort triggers path (a);
-/// confirmed Medium triggers path (a2) which caps the baseline at APPROVE*.
-/// The APPROVE* result is correct — the model judged REQUEST_CHANGES holistically
-/// but the only confirmed evidence is a single Medium finding, which justifies
-/// at most APPROVE*.
+/// Why: path (a2)'s baseline is still capped at APPROVE* for a confirmed
+/// Medium-only finding (#1015 mechanics unchanged) — but `derive_verdict`'s own
+/// severity floor, computed independently from the surviving findings, now
+/// (#1876) floors a SINGLE confidence > 0.80 Medium to REQUEST_CHANGES on its
+/// own merits (see `grade::correctness_floor`). `stricter_of(baseline=APPROVE*,
+/// floor=REQUEST_CHANGES)` therefore lands back on REQUEST_CHANGES — matching
+/// what the model itself originally said, which is the intended #1876 outcome
+/// (a confirmed, well-evidenced finding must not be silently softened).
 #[tokio::test]
 async fn run_review_verification_confirms_and_preserves_verdict() {
     let (source, _tmp) = local_diff_source("+fn bad() {}\n");
@@ -1019,11 +1022,14 @@ async fn run_review_verification_confirms_and_preserves_verdict() {
     );
 
     let result = run_review(&config, input, deps).await;
-    // After #1015: confirmed Medium → path (a2) → APPROVE* (not REQUEST_CHANGES).
+    // #1876: a confirmed high-confidence Medium re-escalates to REQUEST_CHANGES
+    // via derive_verdict's floor, even though the a2 baseline is capped at
+    // APPROVE* (supersedes the #1015-era APPROVE* result).
     assert_eq!(
         result.verdict,
-        Verdict::ApproveWithReservations,
-        "confirmed Medium → APPROVE* (path a2 — #1015); not REQUEST_CHANGES"
+        Verdict::RequestChanges,
+        "confirmed high-confidence Medium → REQUEST_CHANGES (#1876 floor \
+         re-escalation; path a2 baseline cap alone is no longer the last word)"
     );
 }
 

--- a/crates/trusty-review/src/pipeline/verify.rs
+++ b/crates/trusty-review/src/pipeline/verify.rs
@@ -20,8 +20,21 @@
 //! cannot silently auto-refute every finding.  See that module for the full incident
 //! rationale.
 //!
+//! ## Fail-open fix (#1876)
+//! A transient verifier error (rate limit, transport blip, upstream 5xx) is
+//! "unable to verify", not "the model refuted this finding".  Prior to #1876,
+//! `verify_one` mapped transient errors to plain `VerifyOutcome::Refuted` —
+//! structurally identical to a clean model REFUTED — which made
+//! `rederive_verdict` fail OPEN: a network hiccup on the ONLY candidate finding
+//! could collapse the whole review's baseline to APPROVE even though the model
+//! never rendered a judgment.  Transient errors now map to `ErrorRefuted`
+//! (matching the existing #726 treatment of config/lifecycle errors and
+//! truncated responses), so `rederive_verdict` preserves `primary_verdict`
+//! instead of discarding it.  See `verify_one` for the full rationale.
+//!
 //! Test: `verify_tests.rs` — candidate selection, CONFIRMED/REFUTED outcomes,
-//! verdict re-derivation, truncation regression (#726), and liveness-gate logic.
+//! verdict re-derivation, truncation regression (#726), transient-error
+//! fail-open regression (#1876), and liveness-gate logic.
 
 use std::sync::Arc;
 
@@ -205,25 +218,34 @@ pub async fn run_verification_round(
 ///       → keep `primary_verdict` (grounded critical evidence, e.g. BLOCK stays BLOCK)
 ///   a2) confirmed, but only Medium/Low-effort findings confirmed (#1015 + #1343)
 ///       → CAP (ceiling) the baseline at APPROVE*: `min(primary_verdict, APPROVE*)`.
-///         A lone confirmed Medium must not anchor REQUEST_CHANGES from a
-///         floor-driven escalation (#1015) — BUT confirming a non-High finding must
-///         ALSO never *raise* a clean APPROVE baseline to APPROVE* (#1343 runtime
-///         residual).  Using the severity-min of (primary, APPROVE*) is the
-///         source-of-truth reconciliation that mirrors grade.rs::derive_verdict: a
-///         confirmed `praise`/Low-effort finding can neither harden the verdict nor
-///         downgrade the grade when the model itself said APPROVE.
+///         BUT this is a ceiling on the *baseline input*, not on the final result:
+///         `derive_verdict(baseline, survivors)` below independently re-derives the
+///         severity floor from the surviving findings, and as of #1876 a single
+///         confirmed Medium finding with confidence > FLOOR_MIN_CONFIDENCE (0.80)
+///         floors to REQUEST_CHANGES on its own merits (see
+///         `grade::correctness_floor`) — so `stricter_of(baseline, floor)` still
+///         lands on REQUEST_CHANGES even though the *baseline* was capped at
+///         APPROVE*.  The cap's remaining purpose is narrower after #1876: it
+///         still stops a confirmed non-High finding from *raising* a clean model
+///         APPROVE baseline to APPROVE* on its own (#1343 runtime residual), and it
+///         still provides a floor of APPROVE* for a confirmed finding that does
+///         NOT individually clear the severity-floor confidence gate.
 ///   b)  clean model REFUTED, nothing confirmed
 ///       → drop to APPROVE baseline (escalation rested on refuted evidence)
-///   c)  all demotions are infra failures (TruncationRefuted/ErrorRefuted), no confirmed
-///       → preserve `primary_verdict` (do not discard on verifier infra failure, #726)
+///   c)  all demotions are infra / unable-to-verify failures (TruncationRefuted /
+///       ErrorRefuted — the latter now also covers transient errors, #1876), no
+///       confirmed → preserve `primary_verdict` (do not fail-open to APPROVE on
+///       verifier infra failure, #726 + #1876)
 ///
 /// `UNKNOWN` is handled by the caller and never reaches here.
 /// What: filters survivors (non-refuted), selects baseline (path a2 takes the
 /// severity-min of `primary_verdict` and APPROVE*), calls
 /// `derive_verdict(baseline, survivors)`.
 /// Test: `rederive_excludes_refuted_relaxes` (b), `rederive_keeps_confirmed_block` (a),
-/// `rederive_confirmed_medium_caps_at_approve_star` (a2 — #1015),
+/// `rederive_confirmed_medium_still_escalates_to_request_changes` (a2 — #1876,
+/// supersedes the pre-#1876 `..._caps_at_approve_star` expectation),
 /// `rederive_confirmed_praise_keeps_clean_approve` (a2 — #1343 runtime residual),
+/// `rederive_refuted_finding_does_not_clear_standing_medium_finding` (a2 — #1876),
 /// `rederive_error_refuted_preserves_primary_verdict` (c — #726),
 /// `rederive_truncation_refuted_preserves_primary_verdict` (c).
 fn rederive_verdict(
@@ -268,15 +290,18 @@ fn rederive_verdict(
         primary_verdict
     } else if any_confirmed {
         // Path (a2): confirmed evidence, but only Medium/Low tier.  Take the
-        // severity-MIN of the model's own verdict and APPROVE* (the advisory tier):
-        //   - primary=REQUEST_CHANGES/BLOCK → capped down to APPROVE* (#1015), so a
-        //     lone confirmed Medium cannot permanently anchor a floor-driven escalation.
+        // severity-MIN of the model's own verdict and APPROVE* (the advisory tier)
+        // as the BASELINE (not the final answer — see the Why above for #1876):
+        //   - primary=REQUEST_CHANGES/BLOCK → baseline capped down to APPROVE*
+        //     (#1015); `derive_verdict` below still re-escalates to REQUEST_CHANGES
+        //     when the surviving confirmed Medium clears FLOOR_MIN_CONFIDENCE (#1876).
         //   - primary=APPROVE → stays APPROVE (#1343 runtime residual): confirming a
         //     low-effort `praise` finding must NOT harden the verdict to APPROVE* nor
         //     downgrade the grade.  This is the same source-of-truth reconciliation
         //     grade.rs applies — the model's APPROVE review_body is authoritative.
         // `derive_verdict(baseline, survivors)` will still escalate further if the
-        // surviving findings warrant it (e.g. a surviving High → BLOCK).
+        // surviving findings warrant it (e.g. a surviving High → BLOCK, or as of
+        // #1876 a surviving confident Medium → REQUEST_CHANGES).
         verdict_min(primary_verdict, Verdict::ApproveWithReservations)
     } else if any_clean_refuted {
         // Path (b): at least one clean REFUTED from the model — escalation rested
@@ -372,13 +397,31 @@ struct VerifyJudgment {
 /// returned garbage", and preserve the model's escalation in the latter case.
 /// What: calls the verifier, parses the forced JSON judgment, and returns
 /// `Confirmed` / `Refuted` accordingly.  On an alarm-class `LlmError`, emits the
-/// signal and returns `ErrorRefuted`.  On a transient error returns plain `Refuted`
-/// (conservative: unverifiable via transient fault — not a structural problem).
-/// On a successful call that returns unparseable output returns `TruncationRefuted`
+/// signal and returns `ErrorRefuted`.  On a transient error ALSO returns
+/// `ErrorRefuted` (#1876 — see the Why below), never plain `Refuted`, because a
+/// transient fault is "unable to verify", not "the model refuted this".  On a
+/// successful call that returns unparseable output returns `TruncationRefuted`
 /// (structurally distinct from a clean REFUTED judgment).
+///
+/// #1876 fail-open fix: prior to this change, a transient error (rate limit,
+/// transport blip, upstream 5xx) mapped to plain `VerifyOutcome::Refuted` —
+/// structurally identical to a clean model REFUTED judgment. That made
+/// `rederive_verdict` treat "we could not reach the verifier" the same as "the
+/// verifier examined this and found it wrong": both set `any_clean_refuted =
+/// true`, which collapses the review's baseline to APPROVE (path b) when
+/// nothing else was confirmed. A shadow-eval showed this fail-open behavior
+/// contributing to REQUEST_CHANGES being silently downgraded to APPROVE. Mapping
+/// transient errors to `ErrorRefuted` instead routes them through
+/// `rederive_verdict` path (c) — "unable to verify" — which PRESERVES
+/// `primary_verdict` rather than discarding it, matching the existing #726
+/// treatment of config/lifecycle errors and truncated responses. The finding
+/// itself is still excluded from the severity floor either way (an unverified
+/// finding must not drive escalation on its own); only the *fail-open-to-APPROVE*
+/// side effect on the surrounding review is fixed.
 /// Test: `verify_one_confirmed`, `verify_one_refuted`,
 /// `verify_one_model_unavailable_emits_signal`,
-/// `verify_truncated_response_is_truncation_refuted`.
+/// `verify_truncated_response_is_truncation_refuted`,
+/// `verify_transient_error_marks_error_refuted_not_plain_refuted` (#1876).
 async fn verify_one(verifier: &Arc<dyn LlmProvider>, req: crate::llm::LlmRequest) -> VerifyOutcome {
     let model = req.model.clone();
     match verifier.complete(req).await {
@@ -404,11 +447,21 @@ async fn verify_one(verifier: &Arc<dyn LlmProvider>, req: crate::llm::LlmRequest
             VerifyOutcome::ErrorRefuted { error_class }
         }
         Err(e) => {
-            // Transient failure: we could not verify this finding, but the
-            // deployment is not broken.  Conservatively refuse to let an
-            // unverified finding drive a block.
-            warn!("verifier transient error (treating as REFUTED): {e}");
-            VerifyOutcome::Refuted
+            // Transient failure (#1876): we could not verify this finding, but
+            // the deployment is not broken and the model never rendered a
+            // judgment.  Fail toward CAUTION, not toward "this finding is
+            // wrong" — map to ErrorRefuted (not plain Refuted) so
+            // rederive_verdict preserves primary_verdict (path c) instead of
+            // fail-opening the whole review to APPROVE (path b).  This is not
+            // an alarm-worthy incident (no emit_verification_model_error call):
+            // rate limits and transport blips are expected operational noise,
+            // not a broken deployment.
+            let error_class = error_class(&e);
+            warn!(
+                error_class = %error_class,
+                "verifier transient error (treating as unable-to-verify, not refuted): {e}"
+            );
+            VerifyOutcome::ErrorRefuted { error_class }
         }
     }
 }

--- a/crates/trusty-review/src/pipeline/verify_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_tests.rs
@@ -228,16 +228,23 @@ fn rederive_keeps_confirmed_block() {
 }
 
 #[test]
-fn rederive_confirmed_medium_caps_at_approve_star() {
-    // Path (a2) — #1015: confirmed Medium-only caps baseline at APPROVE*; does not
-    // anchor REQUEST_CHANGES from a floor-driven escalation.
+fn rederive_confirmed_medium_still_escalates_to_request_changes() {
+    // Path (a2) — #1876 (supersedes the pre-#1876 #1015 expectation): the
+    // BASELINE is capped at APPROVE*, but `derive_verdict(baseline, survivors)`
+    // independently re-derives the severity floor from the surviving findings.
+    // A single confirmed Medium@0.85 (> FLOOR_MIN_CONFIDENCE) now floors to
+    // REQUEST_CHANGES on its own merits (`correctness_floor` Tier 2, #1876), so
+    // `stricter_of(baseline=APPROVE*, floor=REQUEST_CHANGES)` lands on
+    // REQUEST_CHANGES even though the baseline itself was capped.
     let mut med = finding(Effort::Medium, 0.85);
     apply_outcome(&mut med, VerifyOutcome::Confirmed);
     let verdict = rederive_verdict(Verdict::RequestChanges, true, false, &[med]);
     assert_eq!(
         verdict,
-        Verdict::ApproveWithReservations,
-        "confirmed Medium caps at APPROVE* (path a2 — #1015)"
+        Verdict::RequestChanges,
+        "a single confirmed high-confidence Medium must still escalate to \
+         REQUEST_CHANGES (path a2 + #1876 floor, supersedes the pre-#1876 \
+         APPROVE*-cap expectation)"
     );
 }
 
@@ -289,6 +296,8 @@ fn rederive_confirmed_high_effort_still_escalates_from_approve() {
 #[test]
 fn rederive_mixed_keeps_only_surviving_floor() {
     // Path (a2): High refuted + confirmed Medium@0.85, model said APPROVE*.
+    // #1876: the surviving Medium alone now floors to REQUEST_CHANGES (a single
+    // confident Medium is sufficient, superseding the pre-#1876 APPROVE* result).
     let mut high = finding(Effort::High, 0.95);
     apply_outcome(&mut high, VerifyOutcome::Refuted);
     let mut med = finding(Effort::Medium, 0.85);
@@ -296,8 +305,32 @@ fn rederive_mixed_keeps_only_surviving_floor() {
     let verdict = rederive_verdict(Verdict::ApproveWithReservations, true, true, &[high, med]);
     assert_eq!(
         verdict,
-        Verdict::ApproveWithReservations,
-        "surviving single Medium floors to APPROVE*; refuted High is excluded (path a)"
+        Verdict::RequestChanges,
+        "surviving single confident Medium floors to REQUEST_CHANGES; refuted \
+         High is excluded but does not silently clear the still-standing Medium \
+         (path a2 + #1876 floor)"
+    );
+}
+
+#[test]
+fn rederive_refuted_finding_does_not_clear_standing_medium_finding() {
+    // #1876 regression: a refuted High finding must not silently clear an
+    // unrelated, still-standing confirmed Medium finding down to the weaker
+    // APPROVE*/APPROVE baseline. Two findings originally drove BLOCK; the
+    // verifier refutes the High and confirms the Medium. The Medium alone now
+    // floors to REQUEST_CHANGES (single confident Medium, #1876), so the review
+    // does not silently soften just because one finding among several was
+    // refuted.
+    let mut high = finding(Effort::High, 0.95);
+    apply_outcome(&mut high, VerifyOutcome::Refuted);
+    let mut med = finding(Effort::Medium, 0.85);
+    apply_outcome(&mut med, VerifyOutcome::Confirmed);
+    let verdict = rederive_verdict(Verdict::Block, true, true, &[high, med]);
+    assert_eq!(
+        verdict,
+        Verdict::RequestChanges,
+        "a still-standing confirmed Medium must keep the review at REQUEST_CHANGES \
+         even though a different finding (the High) was refuted (#1876)"
     );
 }
 
@@ -469,6 +502,54 @@ async fn verify_model_unavailable_marks_error_refuted_and_preserves_verdict() {
     );
 }
 
+/// #1876 fail-open regression: a TRANSIENT (non-alarm) verifier error — rate
+/// limiting, a transport blip, an upstream 5xx — must map to `ErrorRefuted`
+/// ("unable to verify"), NOT plain `Refuted` ("the model refuted this").
+///
+/// Why: before this fix, `verify_one`'s transient-error branch returned plain
+/// `VerifyOutcome::Refuted`, structurally identical to a clean model REFUTED
+/// judgment. That set `any_clean_refuted = true` in `run_verification_round`,
+/// which sent `rederive_verdict` down path (b) — dropping the WHOLE review's
+/// baseline to APPROVE — even though the verifier never examined the finding at
+/// all (it just could not be reached). This is the textbook fail-open bug: an
+/// infrastructure hiccup silently downgraded a real BLOCK to APPROVE.
+/// What: a `LlmError::RateLimited` (a non-alarm, transient error per
+/// `LlmError::is_alarm`) on the ONLY candidate finding must record
+/// `ErrorRefuted` and take path (c) — preserve `primary_verdict` — instead of
+/// path (b) — collapse to APPROVE.
+/// Test: this test itself.
+#[tokio::test]
+async fn verify_transient_error_marks_error_refuted_not_plain_refuted() {
+    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
+        make_err: || LlmError::RateLimited,
+    });
+    let mut findings = vec![finding(Effort::High, 0.95)];
+    let verdict = run_verification_round(
+        &verifier,
+        "m",
+        "+ diff",
+        Verdict::Block,
+        &mut findings,
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        matches!(
+            findings[0].verified,
+            Some(VerifyOutcome::ErrorRefuted { .. })
+        ),
+        "a transient verifier error must map to ErrorRefuted, not plain Refuted (#1876)"
+    );
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "a transient-error-only round must preserve primary_verdict (path c), \
+         not fail-open to APPROVE (path b) (#1876)"
+    );
+}
+
 // ── Truncation path (#726 regression) ─────────────────────────────────────────
 
 #[tokio::test]
@@ -516,7 +597,11 @@ async fn verify_truncation_preserves_primary_verdict() {
 }
 
 /// Regression for the dropped-JoinHandle true-positive (PR #720, #726 incident).
-/// Why: (a) CONFIRMED Medium → APPROVE* (path a2, #1015 — pre-#1015 was REQUEST_CHANGES);
+/// Why: (a) CONFIRMED Medium → REQUEST_CHANGES (path a2 baseline capped at
+/// APPROVE*, but the #1876 confidence-gated floor re-escalates a single
+/// confident Medium; pre-#1876 this landed on APPROVE*, and pre-#1015 on
+/// REQUEST_CHANGES via the old count heuristic — #1876 restores the
+/// REQUEST_CHANGES outcome via a confidence gate instead of a count gate);
 /// (b) TruncationRefuted must NOT collapse to APPROVE (path c, #726).
 /// Test: this test itself.
 #[tokio::test]
@@ -534,7 +619,9 @@ async fn verify_join_handle_regression_pr720() {
                 +    tokio::spawn(async move { warm_boot().await });\n\
                 +}\n";
 
-    // Sub-test (a): CONFIRMED Medium → path (a2): baseline=APPROVE*, stays APPROVE*.
+    // Sub-test (a): CONFIRMED Medium@0.85 → path (a2) baseline is capped at
+    // APPROVE*, but `derive_verdict`'s own floor re-escalates to REQUEST_CHANGES
+    // (#1876: a single confident Medium is sufficient — see `correctness_floor`).
     let mut findings_1 = vec![f.clone()];
     let v1 = run_verification_round(
         &confirmed_provider(),
@@ -551,11 +638,14 @@ async fn verify_join_handle_regression_pr720() {
         findings_1[0].verified,
         Some(VerifyOutcome::Confirmed)
     ));
-    // After #1015: a confirmed Medium caps at APPROVE* (path a2), not REQUEST_CHANGES.
+    // #1876: a confirmed high-confidence Medium re-escalates to REQUEST_CHANGES
+    // via derive_verdict's floor, even though the a2 baseline itself is capped
+    // at APPROVE* (supersedes the #1015-era APPROVE* result).
     assert_eq!(
         v1,
-        Verdict::ApproveWithReservations,
-        "CONFIRMED Medium → APPROVE* (path a2 — #1015)"
+        Verdict::RequestChanges,
+        "CONFIRMED Medium → REQUEST_CHANGES (path a2 baseline capped, floor \
+         re-escalates — #1876)"
     );
 
     // Sub-test (b): TruncationRefuted → verdict preserved (path c — #726).


### PR DESCRIPTION
Closes #1876

## Summary

Ships the identified code fix for the three root causes in #1876 (conjunctive RC gate, fail-open verifier, lenient Medium floor). Pre/post verdict-agreement numbers from the issue's shadow-eval (n=473, ≥85% agreement + REQUEST_CHANGES recall parity bar) CANNOT be reproduced in-repo — that eval ran externally against production advisory logs not available in this workspace. Per owner decision, shipping the code fix now with this limitation stated explicitly; trusty-review should remain in advisory/shadow mode (not sole merge-gate authority) until an external re-run of the production shadow-eval confirms the bar is met.

**NEEDS CAREFUL HUMAN REVIEW — this changes reviewer calibration behavior that gates merges; do not rubber-stamp.**

### The three fixes

1. **`prompt_templates.rs`** — the REQUEST_CHANGES rubric required a conjunctive three-part proof (verbatim line AND failure path AND concrete fix) before escalating. Relaxed to "strong evidence on at least two of three dimensions" so a well-evidenced finding thin on only one dimension can still escalate. Applied identically to both the stock and coverage-gating prompt variants.

2. **`verify.rs::verify_one`** — a transient (non-alarm) verifier error (rate limit, transport blip, upstream 5xx) mapped to plain `VerifyOutcome::Refuted`, structurally identical to a clean model REFUTED judgment. This fail-opened: an infrastructure hiccup on the sole candidate finding collapsed the whole review's baseline to APPROVE even though the verifier never rendered a judgment. Transient errors now map to `ErrorRefuted`, matching the existing #726 treatment of config/lifecycle errors and truncated responses, so `rederive_verdict` preserves `primary_verdict` (fails toward caution) instead of discarding it (failing open).

3. **`grade.rs::correctness_floor`** — required ≥2 high-confidence Medium findings to reach REQUEST_CHANGES (a single confident Medium capped at the weaker APPROVE*). Lowered to ≥1: a finding that clears `FLOOR_MIN_CONFIDENCE` (0.80) is well-evidenced on its own and now gets the same hard-floor treatment already given to High-effort findings, matching the precedent set by `apply_synthesis_floor`'s High-effort hard floor (#1674/#1675). The #1343 count-based reconciliation cap (which capped this floor back to APPROVE* whenever the model's own verdict was a clean APPROVE) is removed outright, since every REQUEST_CHANGES floor is now confidence-grounded rather than a "weak count heuristic".

### Calibration direction

Per the explicit constraint carried over from this investigation: the fix makes the reviewer escalate MORE READILY when there is genuine, well-evidenced concern (fewer conjunctive gates, no fail-open on verification errors, lower Medium floor), without touching the separate map-reduce chunking bug (#1873, phantom "file missing from diff" false BLOCKs) or making the reviewer trigger-happy on weak/low-confidence findings — the `FLOOR_MIN_CONFIDENCE` (0.80) confidence gate and the low-confidence override are unchanged.

## Test plan

- [x] `cargo test -p trusty-review --lib` — 1071 passed, 0 failed, 4 ignored (pre-existing, unrelated `#[ignore]` ONNX/network tests). One pre-existing, pre-diff-unrelated failure (`llm::bedrock::tests::bedrock_region_resolution`) reproduces identically on unmodified `origin/main` when `AWS_REGION` is set in the shell environment — not touched by this change; passes cleanly with `AWS_REGION` unset.
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p trusty-review` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (14 allowlisted, 0 violations)
- [x] New/updated tests per fix:
  - (a) `system_prompt_contains_policy` — asserts the relaxed 2-of-3 RC gate text
  - (b) `verify_transient_error_marks_error_refuted_not_plain_refuted` (new) — a transient error maps to `ErrorRefuted`, not `Refuted`; `rederive_refuted_finding_does_not_clear_standing_medium_finding` (new) — a refuted finding no longer silently clears an unrelated, still-standing confirmed Medium finding
  - (c) `grade_one_medium_yields_request_changes` (renamed/updated) and `grade_model_approve_confident_medium_still_escalates_to_request_changes` (new) — a single high-confidence Medium finding floors to REQUEST_CHANGES and is no longer capped back down when the model itself said APPROVE
- [ ] No calibrate corpus fixture exists in-repo (`crates/trusty-review/tests/` checked) — skipped per instructions rather than fabricating one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)