### PR TITLE
fix(trusty-review): aggregate token counts across map-reduce for shallow-review heuristic

### DIFF
--- a/crates/trusty-review/src/pipeline/mapreduce/map.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/map.rs
@@ -32,7 +32,7 @@ use crate::{
     voice::VoiceConfig,
 };
 
-use super::outcome::MapOutcome;
+use super::outcome::{MapOutcome, TokenUsage};
 use super::unit::{MapUnit, MapUnitKind};
 
 /// Borrowed inputs shared across every map-stage LLM call.
@@ -221,6 +221,14 @@ async fn run_task(task: MapTask, llm: &Arc<dyn LlmProvider>) -> MapOutcome {
                 file,
                 verdict: parsed.verdict,
                 findings,
+                // Capture this chunk's token/cost telemetry so the reduce stage
+                // can sum it into the aggregate the shallow-review heuristic
+                // reads (#1885) — the unified path gets these off its single call.
+                tokens: TokenUsage {
+                    input_tokens: resp.input_tokens,
+                    output_tokens: resp.output_tokens,
+                    cost_usd: resp.cost_usd,
+                },
             }
         }
         Err(e) => {

--- a/crates/trusty-review/src/pipeline/mapreduce/outcome.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/outcome.rs
@@ -14,6 +14,52 @@
 
 use crate::models::{Finding, Verdict};
 
+// ─── TokenUsage ────────────────────────────────────────────────────────────────
+
+/// Aggregate LLM token / cost telemetry for one or more map-reduce LLM calls.
+///
+/// Why: the shallow-review heuristic (#1877) flags a suspiciously cheap clean
+/// APPROVE by comparing `output_tokens` against a floor proportional to the diff
+/// size.  The unified path reads these fields straight off its single
+/// `LlmResponse`, but the map-reduce path makes MANY calls (one per file, plus an
+/// optional synthesis call).  Without a running total the heuristic sees
+/// `output_tokens == 0` on exactly the largest diffs and never fires (#1885).
+/// This struct is the accumulator that lets each stage add its call's usage so
+/// the runner can apply the SAME heuristic to the aggregate.
+/// What: sums of input/output tokens and USD cost across the calls it covers.
+/// `merged` folds another usage in with saturating integer arithmetic so a
+/// pathological chunk count can never overflow-panic.
+/// Test: `token_usage_add_sums_fields`, `token_usage_add_saturates` (outcome_tests.rs);
+/// aggregation wired end-to-end by `reduce_sums_output_tokens` (reduce_tests.rs).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct TokenUsage {
+    /// Sum of prompt (input) tokens across the covered calls.
+    pub input_tokens: u32,
+    /// Sum of completion (output) tokens across the covered calls.
+    pub output_tokens: u32,
+    /// Sum of estimated USD cost across the covered calls.
+    pub cost_usd: f64,
+}
+
+impl TokenUsage {
+    /// Fold another `TokenUsage` into this one, returning the running total.
+    ///
+    /// Why: the reduce stage accumulates one usage per reviewed chunk and the
+    /// synthesis stage adds its own call; a single associative combinator keeps
+    /// that summation in one tested place.
+    /// What: returns a new `TokenUsage` whose integer fields are saturating sums
+    /// (never overflow-panic) and whose cost is the `f64` sum.
+    /// Test: `token_usage_add_sums_fields`, `token_usage_add_saturates`.
+    #[must_use]
+    pub fn merged(self, other: Self) -> Self {
+        Self {
+            input_tokens: self.input_tokens.saturating_add(other.input_tokens),
+            output_tokens: self.output_tokens.saturating_add(other.output_tokens),
+            cost_usd: self.cost_usd + other.cost_usd,
+        }
+    }
+}
+
 // ─── MapOutcome ────────────────────────────────────────────────────────────────
 
 /// The result of processing a single `MapUnit` in the map stage.
@@ -37,6 +83,9 @@ pub enum MapOutcome {
         verdict: Verdict,
         /// Findings parsed from this chunk's review.
         findings: Vec<Finding>,
+        /// Token / cost telemetry for this chunk's LLM call, summed by the reduce
+        /// stage into the aggregate the shallow-review heuristic reads (#1885).
+        tokens: TokenUsage,
     },
     /// The unit was metadata-only — no LLM call was made (deleted / binary /
     /// rename-only / summary-only / budget-exhausted).
@@ -163,6 +212,17 @@ pub struct ReducedReview {
     /// Synthesis prose summary from the calibration LLM pass, or empty string
     /// when synthesis is disabled or failed.
     pub summary: String,
+    /// Aggregate token / cost telemetry summed across EVERY LLM call this review
+    /// made — all map-stage per-file calls plus the optional synthesis call.
+    ///
+    /// Why: the runner needs a running total to feed the shallow-review heuristic
+    /// (#1877/#1885); without it `output_tokens` stays 0 on map-reduce reviews and
+    /// the heuristic silently never fires on the largest (highest-risk) diffs.
+    /// What: `map-stage sum` set by `reduce`, then `+= synthesis call` by
+    /// `synthesize_review`.  Zero only when no chunk was reviewed.
+    /// Test: `reduce_sums_output_tokens` (reduce_tests.rs); end-to-end coverage in
+    /// `run_review_mapreduce_shallow_clean_flags_low_tokens` (runner_mapreduce_tests.rs).
+    pub tokens: TokenUsage,
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/pipeline/mapreduce/outcome_tests.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/outcome_tests.rs
@@ -19,6 +19,7 @@ fn map_outcome_file_accessor() {
         file: "src/a.rs".to_string(),
         verdict: Verdict::Approve,
         findings: vec![finding("src/a.rs", "x")],
+        tokens: TokenUsage::default(),
     };
     assert_eq!(reviewed.file(), "src/a.rs");
 
@@ -58,4 +59,47 @@ fn stats_partial_on_oversized_hunk() {
         ..Default::default()
     };
     assert!(s.is_partial(), "an over-cap hunk marks coverage partial");
+}
+
+#[test]
+fn token_usage_add_sums_fields() {
+    let a = TokenUsage {
+        input_tokens: 10,
+        output_tokens: 3,
+        cost_usd: 0.01,
+    };
+    let b = TokenUsage {
+        input_tokens: 5,
+        output_tokens: 7,
+        cost_usd: 0.02,
+    };
+    let sum = a.merged(b);
+    assert_eq!(sum.input_tokens, 15);
+    assert_eq!(sum.output_tokens, 10);
+    assert!((sum.cost_usd - 0.03).abs() < 1e-9);
+}
+
+#[test]
+fn token_usage_add_saturates() {
+    let a = TokenUsage {
+        input_tokens: u32::MAX,
+        output_tokens: u32::MAX,
+        cost_usd: 0.0,
+    };
+    let b = TokenUsage {
+        input_tokens: 100,
+        output_tokens: 100,
+        cost_usd: 0.0,
+    };
+    let sum = a.merged(b);
+    assert_eq!(
+        sum.input_tokens,
+        u32::MAX,
+        "must saturate, not overflow-panic"
+    );
+    assert_eq!(
+        sum.output_tokens,
+        u32::MAX,
+        "must saturate, not overflow-panic"
+    );
 }

--- a/crates/trusty-review/src/pipeline/mapreduce/reduce.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/reduce.rs
@@ -28,7 +28,7 @@ use crate::{
     profile::synthesizer::jaccard_similarity,
 };
 
-use super::outcome::{MapOutcome, MapReduceStats, ReducedReview};
+use super::outcome::{MapOutcome, MapReduceStats, ReducedReview, TokenUsage};
 
 /// Reduce a vec of per-chunk `MapOutcome`s into a single `ReducedReview`.
 ///
@@ -39,10 +39,11 @@ use super::outcome::{MapOutcome, MapReduceStats, ReducedReview};
 /// blocking finding.
 /// What: builds `MapReduceStats`, unions + dedups + caps the findings, derives
 /// the verdict from the stricter-of all per-chunk verdicts + the severity floor,
-/// and returns the merged `ReducedReview`.
+/// sums each reviewed chunk's `TokenUsage` into the aggregate the shallow-review
+/// heuristic reads (#1885), and returns the merged `ReducedReview`.
 /// Test: `reduce_unions_findings`, `reduce_chunk_request_changes_propagates`,
 /// `reduce_dedups_identical_findings`, `reduce_all_unknown_collapses`,
-/// `reduce_caps_findings`, `reduce_stats_partial_flag`.
+/// `reduce_caps_findings`, `reduce_stats_partial_flag`, `reduce_sums_output_tokens`.
 pub fn reduce(outcomes: Vec<MapOutcome>, config: &MapReduceConfig) -> ReducedReview {
     let mut stats = MapReduceStats {
         units_total: outcomes.len(),
@@ -52,15 +53,23 @@ pub fn reduce(outcomes: Vec<MapOutcome>, config: &MapReduceConfig) -> ReducedRev
     // Collect the per-chunk verdicts (Reviewed only) and the finding union.
     let mut chunk_verdicts: Vec<Verdict> = Vec::new();
     let mut all_findings: Vec<Finding> = Vec::new();
+    // Running total of token/cost telemetry across every reviewed chunk — this is
+    // the aggregate the shallow-review heuristic reads on the map-reduce path
+    // (#1885). Skipped/failed chunks made no LLM call, so they contribute nothing.
+    let mut tokens = TokenUsage::default();
 
     for outcome in outcomes {
         match outcome {
             MapOutcome::Reviewed {
-                verdict, findings, ..
+                verdict,
+                findings,
+                tokens: chunk_tokens,
+                ..
             } => {
                 stats.files_reviewed += 1;
                 chunk_verdicts.push(verdict);
                 all_findings.extend(findings);
+                tokens = tokens.merged(chunk_tokens);
             }
             MapOutcome::Skipped { .. } => {
                 stats.files_skipped += 1;
@@ -109,6 +118,8 @@ pub fn reduce(outcomes: Vec<MapOutcome>, config: &MapReduceConfig) -> ReducedRev
         grade: None,
         grade_pre_floor: None,
         summary: String::new(),
+        // Map-stage token total; the synthesis pass adds its own call on top.
+        tokens,
     }
 }
 

--- a/crates/trusty-review/src/pipeline/mapreduce/reduce_tests.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/reduce_tests.rs
@@ -10,7 +10,7 @@
 use super::reduce;
 use crate::config::mapreduce::MapReduceConfig;
 use crate::models::{Effort, Finding, Verdict};
-use crate::pipeline::mapreduce::outcome::MapOutcome;
+use crate::pipeline::mapreduce::outcome::{MapOutcome, TokenUsage};
 
 fn cfg() -> MapReduceConfig {
     MapReduceConfig::default()
@@ -21,10 +21,20 @@ fn finding(file: &str, kind: &str, desc: &str, conf: f32, effort: Effort) -> Fin
 }
 
 fn reviewed(file: &str, verdict: Verdict, findings: Vec<Finding>) -> MapOutcome {
+    reviewed_with_tokens(file, verdict, findings, TokenUsage::default())
+}
+
+fn reviewed_with_tokens(
+    file: &str,
+    verdict: Verdict,
+    findings: Vec<Finding>,
+    tokens: TokenUsage,
+) -> MapOutcome {
     MapOutcome::Reviewed {
         file: file.to_string(),
         verdict,
         findings,
+        tokens,
     }
 }
 
@@ -322,4 +332,47 @@ fn reduce_stats_partial_flag() {
     assert_eq!(reduced.stats.files_failed, 1);
     // The clean chunk still yields a usable APPROVE.
     assert_eq!(reduced.verdict, Verdict::Approve);
+}
+
+/// The reduce stage must SUM token/cost telemetry across every reviewed chunk so
+/// the runner can feed the aggregate to the shallow-review heuristic (#1885).
+/// Skipped/failed chunks made no LLM call and must contribute nothing.
+#[test]
+fn reduce_sums_output_tokens() {
+    let outcomes = vec![
+        reviewed_with_tokens(
+            "src/a.rs",
+            Verdict::Approve,
+            vec![],
+            TokenUsage {
+                input_tokens: 100,
+                output_tokens: 7,
+                cost_usd: 0.001,
+            },
+        ),
+        reviewed_with_tokens(
+            "src/b.rs",
+            Verdict::Approve,
+            vec![],
+            TokenUsage {
+                input_tokens: 200,
+                output_tokens: 11,
+                cost_usd: 0.002,
+            },
+        ),
+        // A failed chunk (no LLM usage recorded) must not perturb the totals.
+        MapOutcome::Failed {
+            file: "src/c.rs".to_string(),
+            error: "LLM error".to_string(),
+            hunk_oversized: false,
+        },
+    ];
+    let reduced = reduce(outcomes, &cfg());
+    assert_eq!(reduced.tokens.input_tokens, 300, "input tokens must sum");
+    assert_eq!(reduced.tokens.output_tokens, 18, "output tokens must sum");
+    assert!(
+        (reduced.tokens.cost_usd - 0.003).abs() < 1e-9,
+        "cost must sum, got {}",
+        reduced.tokens.cost_usd
+    );
 }

--- a/crates/trusty-review/src/pipeline/mapreduce/synthesis.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/synthesis.rs
@@ -36,7 +36,7 @@ use crate::{
     pipeline::{letter_grade::Grade, mapreduce::map::MapContext},
 };
 
-use super::outcome::ReducedReview;
+use super::outcome::{ReducedReview, TokenUsage};
 
 // ─── Synthesis LLM request constants ─────────────────────────────────────────
 
@@ -103,7 +103,8 @@ struct SynthesisResponse {
 ///      The count-based Medium floor is deliberately omitted (it is the
 ///      over-strictness source the synthesis pass is calibrating away).
 ///   7. Returns a new `ReducedReview` with synthesis verdict/grade/summary plus
-///      `grade_pre_floor` for observable telemetry (#1665 item 3).
+///      `grade_pre_floor` for observable telemetry (#1665 item 3) and the
+///      map-stage token total plus this synthesis call's usage (#1885).
 ///
 /// Test: `synthesis_tests.rs` — covers `synthesis_softens_minor_nits`,
 /// `synthesis_high_severity_still_floors`, `synthesis_false_returns_unchanged`,
@@ -153,6 +154,17 @@ pub async fn synthesize_review(
             );
             return reduced;
         }
+    };
+
+    // Capture the synthesis call's token/cost usage so it is folded into the
+    // aggregate the shallow-review heuristic reads (#1885). Done unconditionally
+    // here: even if the response fails to parse below we return `reduced`
+    // unchanged (its map-stage total already stands), so we only add this on the
+    // success path where the new `ReducedReview` is built.
+    let synth_tokens = TokenUsage {
+        input_tokens: resp.input_tokens,
+        output_tokens: resp.output_tokens,
+        cost_usd: resp.cost_usd,
     };
 
     // Parse the synthesis response.
@@ -216,6 +228,9 @@ pub async fn synthesize_review(
         "synthesis pass complete"
     );
 
+    // Fold the synthesis call's usage into the map-stage total (#1885).
+    let tokens = reduced.tokens.merged(synth_tokens);
+
     ReducedReview {
         verdict: floored_verdict,
         findings: reduced.findings,
@@ -223,6 +238,7 @@ pub async fn synthesize_review(
         grade: Some(grade_str),
         grade_pre_floor: Some(pre_floor_grade_str),
         summary,
+        tokens,
     }
 }
 

--- a/crates/trusty-review/src/pipeline/mapreduce/synthesis_tests.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/synthesis_tests.rs
@@ -19,7 +19,7 @@ use crate::{
     pipeline::{
         mapreduce::{
             MapContext,
-            outcome::{MapReduceStats, ReducedReview},
+            outcome::{MapReduceStats, ReducedReview, TokenUsage},
             synthesis::{apply_high_severity_floor_only, synthesize_review},
         },
         prompt::{ReviewContext, ReviewPrMeta},
@@ -100,6 +100,14 @@ fn finding(kind: &str, desc: &str, effort: Effort, conf: f32) -> Finding {
     Finding::new("src/a.rs", kind, desc, "", conf, effort)
 }
 
+/// Map-stage token total the helper seeds so the synthesis-fold tests can assert
+/// the synthesis call's usage (#1885) is ADDED to it, not replacing it.
+const BASE_MAP_TOKENS: TokenUsage = TokenUsage {
+    input_tokens: 500,
+    output_tokens: 100,
+    cost_usd: 0.0,
+};
+
 fn reduced_with_findings(verdict: Verdict, findings: Vec<Finding>) -> ReducedReview {
     ReducedReview {
         verdict,
@@ -108,6 +116,7 @@ fn reduced_with_findings(verdict: Verdict, findings: Vec<Finding>) -> ReducedRev
         grade: None,
         grade_pre_floor: None,
         summary: String::new(),
+        tokens: BASE_MAP_TOKENS,
     }
 }
 
@@ -635,5 +644,74 @@ async fn synthesis_embedded_json_ignores_trailing_stray_brace() {
     assert_eq!(
         result.summary, "ok",
         "summary must be extracted from the embedded JSON"
+    );
+}
+
+/// On the synthesis SUCCESS path the new `ReducedReview` must carry the map-stage
+/// token total PLUS the synthesis call's own usage (#1885) — never replace it.
+#[tokio::test]
+async fn synthesis_adds_call_tokens_to_aggregate() {
+    let reduced = reduced_with_findings(Verdict::Approve, vec![]);
+
+    // FixedLlm reports input_tokens: 50, output_tokens: 20 per call.
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm::new(
+        r#"{"verdict":"APPROVE","grade":"A","summary":"ok"}"#,
+    ));
+    let pm = pr_meta();
+    let context = ReviewContext::default();
+    let voice = VoiceConfig::default();
+    let c = ctx(&pm, &context, &voice);
+
+    let result = synthesize_review(reduced, &llm, &c, &cfg()).await;
+
+    assert_eq!(
+        result.tokens.output_tokens,
+        BASE_MAP_TOKENS.output_tokens + 20,
+        "synthesis output tokens must be ADDED to the map-stage total"
+    );
+    assert_eq!(
+        result.tokens.input_tokens,
+        BASE_MAP_TOKENS.input_tokens + 50,
+        "synthesis input tokens must be ADDED to the map-stage total"
+    );
+}
+
+/// When synthesis is disabled the map-stage token total must pass through
+/// unchanged (no synthesis call was made, so nothing is added).
+#[tokio::test]
+async fn synthesis_disabled_preserves_map_tokens() {
+    let reduced = reduced_with_findings(Verdict::Approve, vec![]);
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm::new(
+        r#"{"verdict":"APPROVE","grade":"A","summary":"ok"}"#,
+    ));
+    let pm = pr_meta();
+    let context = ReviewContext::default();
+    let voice = VoiceConfig::default();
+    let c = ctx(&pm, &context, &voice);
+
+    let result = synthesize_review(reduced, &llm, &c, &cfg_synthesis_off()).await;
+
+    assert_eq!(
+        result.tokens, BASE_MAP_TOKENS,
+        "synthesis-off must not alter the map-stage token total"
+    );
+}
+
+/// When the synthesis LLM call fails, the graceful fall-back must preserve the
+/// map-stage token total (the failed call's usage is unknown / not counted).
+#[tokio::test]
+async fn synthesis_llm_error_preserves_map_tokens() {
+    let reduced = reduced_with_findings(Verdict::Approve, vec![]);
+    let llm: Arc<dyn LlmProvider> = Arc::new(FailingLlm);
+    let pm = pr_meta();
+    let context = ReviewContext::default();
+    let voice = VoiceConfig::default();
+    let c = ctx(&pm, &context, &voice);
+
+    let result = synthesize_review(reduced, &llm, &c, &cfg()).await;
+
+    assert_eq!(
+        result.tokens, BASE_MAP_TOKENS,
+        "synthesis fail-safe fall-back must preserve the map-stage token total"
     );
 }

--- a/crates/trusty-review/src/pipeline/runner_mapreduce.rs
+++ b/crates/trusty-review/src/pipeline/runner_mapreduce.rs
@@ -145,8 +145,16 @@ pub(super) async fn run_mapreduce_branch(
         fail_safe_reason: None,
     };
 
-    // Telemetry: surface the map-reduce model.
+    // Telemetry: surface the map-reduce model and the AGGREGATE token/cost usage
+    // summed across every map-stage call plus the synthesis call (#1885). The
+    // unified path reads these straight off its single LlmResponse; on this path
+    // they were never populated, which left `result.output_tokens == 0` and made
+    // the shallow-review heuristic (wired below in `fold_reduced_into_result`)
+    // silently inoperative on exactly the largest, highest-risk diffs.
     result.model = input.reviewer_model.clone();
+    result.input_tokens = reduced.tokens.input_tokens;
+    result.output_tokens = reduced.tokens.output_tokens;
+    result.cost_estimate_usd = reduced.tokens.cost_usd;
 
     // Narrative body: use the synthesis prose summary when available (#1663);
     // fall back to the deterministic stats string when synthesis is disabled.
@@ -330,18 +338,61 @@ async fn fold_reduced_into_result(
     // Inline per-line comments from the RAW diff (#1414 parity).
     attach_inline_comments(result, &run.raw_diff);
 
-    // NOTE (#1877): unlike the unified path (`runner.rs` step 7d-post), this
-    // function does NOT set `result.shallow_clean_review`. The map-reduce path
-    // never aggregates per-chunk `output_tokens`/`input_tokens`/`cost_estimate_usd`
-    // onto `result` (a pre-existing gap, not introduced here — grep confirms no
-    // telemetry-field assignment anywhere in this file), so `result.output_tokens`
-    // stays 0 for every map-reduce review. Wiring `is_shallow_clean_review` in here
-    // today would false-positive on every large map-reduce clean APPROVE (0 tokens
-    // always looks "shallow"). Map-reduce is exactly the path used for the LARGEST
-    // diffs — the population issue #1877's Bug 2 targets — so this is a real
-    // coverage gap, not a deliberate scope exclusion: fix by first threading
-    // aggregate token/cost telemetry from the map/reduce stages onto `result`
-    // (see `mapreduce/reduce.rs`), then wire the same heuristic in here.
+    // Shallow-review flag (#1877 / #1885) — now wired on the map-reduce path.
+    //
+    // Historically this path never populated `result.output_tokens` (it stayed 0),
+    // so the heuristic could not run here without false-positiving on every large
+    // clean review. Issue #1885 closes that gap: the aggregate token total is now
+    // summed across all map + synthesis calls (`reduced.tokens`) and set on
+    // `result` by `run_mapreduce_branch` BEFORE this fold. We therefore apply the
+    // SAME `is_shallow_clean_review` / `cap_shallow_review_grade` logic the unified
+    // path uses (`runner.rs` step 7d-post), so a suspiciously cheap clean APPROVE
+    // on a huge diff is flagged and grade-capped regardless of which path produced
+    // it. `filtered.filtered_byte_size` is the map-reduce analog of the unified
+    // path's rendered `diff.len()` — the char count actually sent to the reviewers,
+    // which the aggregate token spend is proportional to.
+    apply_shallow_review_flag(result, run.filtered.filtered_byte_size);
+}
+
+/// Flag and grade-cap a suspiciously shallow clean review on the map-reduce path.
+///
+/// Why: map-reduce handles the LARGEST diffs, exactly the population the #1877
+/// heuristic targets; leaving it unwired (the #1885 gap) meant a fast/cheap
+/// rubber-stamp APPROVE on a huge diff kept an unearned top grade. Extracting the
+/// wiring into a helper keeps `fold_reduced_into_result` readable and gives the
+/// behaviour a direct unit-test seam.
+/// What: runs `is_shallow_clean_review` against the post-verification verdict,
+/// empty-findings check, the filtered diff length, and the aggregate
+/// `result.output_tokens`; when it fires, sets `result.shallow_clean_review` and
+/// caps `result.grade` at B- via `cap_shallow_review_grade` (leaving the APPROVE
+/// verdict untouched — this is a confidence signal, not a severity judgement).
+/// Test: `run_review_mapreduce_shallow_clean_flags_low_tokens`,
+/// `run_review_mapreduce_substantive_review_not_flagged` (runner_mapreduce_tests.rs).
+fn apply_shallow_review_flag(result: &mut ReviewResult, filtered_byte_size: usize) {
+    result.shallow_clean_review = crate::pipeline::letter_grade::is_shallow_clean_review(
+        &result.verdict,
+        result.findings.is_empty(),
+        filtered_byte_size,
+        result.output_tokens,
+    );
+    if !result.shallow_clean_review {
+        return;
+    }
+    warn!(
+        verdict = %result.verdict,
+        diff_len = filtered_byte_size,
+        output_tokens = result.output_tokens,
+        cost_usd = result.cost_estimate_usd,
+        "flagged shallow clean review on map-reduce path — zero findings with \
+         implausibly low aggregate token spend for this diff size (#1885); grade capped at B-"
+    );
+    if let Some(g) = result
+        .grade
+        .as_deref()
+        .and_then(|s| s.parse::<Grade>().ok())
+    {
+        result.grade = Some(crate::pipeline::letter_grade::cap_shallow_review_grade(g).to_string());
+    }
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/pipeline/runner_mapreduce_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_mapreduce_tests.rs
@@ -596,3 +596,142 @@ async fn run_review_mapreduce_medium_rc_propagates_through_synthesis() {
         "the per-chunk Medium finding must survive into the merged result"
     );
 }
+
+// ── Shallow-review heuristic on the map-reduce path (#1885) ──────────────────
+
+/// A reviewer that APPROVEs every prompt (per-file AND synthesis) with ZERO
+/// findings, reporting a configurable per-call `output_tokens`. The single JSON
+/// body satisfies both the per-file parser (uses verdict/findings) and the
+/// synthesis parser (uses verdict/grade/summary), so one fake drives the whole
+/// pipeline. Used to simulate an implausibly cheap clean review of a huge diff.
+struct LowTokenApprover {
+    output_tokens: u32,
+}
+
+#[async_trait]
+impl LlmProvider for LowTokenApprover {
+    fn name(&self) -> &str {
+        "low-token-approver"
+    }
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        Ok(LlmResponse {
+            // Grade A+ so the pre-cap envelope grade is unambiguously top-band;
+            // the shallow flag must then cap it down to B-.
+            text: r#"{"verdict":"APPROVE","grade":"A+","summary":"ok","findings":[]}"#.to_string(),
+            model: req.model.clone(),
+            input_tokens: 10,
+            output_tokens: self.output_tokens,
+            latency_ms: 1,
+            cost_usd: 0.0,
+            finish_reason: Some("stop".to_string()),
+        })
+    }
+}
+
+/// Build an over-cap multi-file diff whose lines are ALL DISTINCT, so the diff
+/// analyzer's noise/dedup filtering keeps the filtered byte size large (the
+/// shallow heuristic's `diff_len` input). Routes to map-reduce via the size cap.
+fn shallow_oversized_distinct_diff() -> String {
+    use crate::config::constants::MAX_DIFF_CHARS;
+
+    let mut diff = String::new();
+    let mut file_idx = 0;
+    while diff.len() < MAX_DIFF_CHARS + (MAX_DIFF_CHARS / 4) {
+        diff.push_str(&format!(
+            "diff --git a/src/mod{file_idx}.rs b/src/mod{file_idx}.rs\n"
+        ));
+        diff.push_str(&format!(
+            "--- a/src/mod{file_idx}.rs\n+++ b/src/mod{file_idx}.rs\n"
+        ));
+        diff.push_str("@@ -1,1 +1,400 @@\n");
+        for line in 0..400 {
+            // Distinct on both indices so nothing is deduped/collapsed.
+            diff.push_str(&format!(
+                "+    let value_{file_idx}_{line} = compute_{file_idx}({line}, {line} + 1);\n"
+            ));
+        }
+        file_idx += 1;
+    }
+    diff
+}
+
+/// THE #1885 regression test: a huge diff reviewed via MAP-REDUCE that returns a
+/// clean APPROVE (0 findings) with an implausibly low AGGREGATE output-token spend
+/// must be flagged `shallow_clean_review` and have its grade capped at B- — the
+/// SAME treatment the unified path already applies. Before the fix the map-reduce
+/// path never aggregated tokens, so `output_tokens` stayed 0 and the heuristic was
+/// silently inoperative on exactly the largest, highest-risk diffs.
+#[tokio::test]
+async fn run_review_mapreduce_shallow_clean_flags_low_tokens() {
+    let diff = shallow_oversized_distinct_diff();
+    let (source, _tmp) = local_source(&diff);
+
+    // One output token per call → aggregate stays far below the diff-proportional
+    // floor no matter how many chunks the splitter produces.
+    let reviewer = Arc::new(LowTokenApprover { output_tokens: 1 });
+    let llm: Arc<dyn LlmProvider> = reviewer.clone();
+    let config = ReviewConfig::load(None);
+
+    let result = run_review(&config, input(source), deps(llm)).await;
+
+    // Sanity: this really went through the clean-APPROVE map-reduce path.
+    assert_eq!(
+        result.verdict,
+        Verdict::Approve,
+        "all chunks APPROVE with no findings → overall APPROVE"
+    );
+    assert!(
+        result.findings.is_empty(),
+        "the clean review must have zero findings"
+    );
+
+    // Aggregate telemetry must now be populated (was always 0 before the fix).
+    assert!(
+        result.output_tokens > 0,
+        "map-reduce must aggregate output tokens onto the result (was 0 pre-#1885)"
+    );
+
+    // The heuristic must FIRE on the aggregate.
+    assert!(
+        result.shallow_clean_review,
+        "a cheap clean APPROVE on a huge map-reduce diff must be flagged shallow (#1885)"
+    );
+
+    // And the grade must be capped at B- (or lower) — never left at A+.
+    let grade: crate::pipeline::letter_grade::Grade = result
+        .grade
+        .as_deref()
+        .expect("APPROVE verdict must carry a grade")
+        .parse()
+        .expect("grade must parse");
+    assert!(
+        grade >= crate::pipeline::letter_grade::Grade::BMinus,
+        "flagged shallow review grade must be capped at B- or milder, got {:?}",
+        grade
+    );
+}
+
+/// The negative control: the SAME huge map-reduce diff reviewed with a plausible
+/// (high) aggregate output-token spend must NOT be flagged shallow, proving the
+/// heuristic keys on the aggregate token telemetry (not merely on diff size).
+#[tokio::test]
+async fn run_review_mapreduce_substantive_review_not_flagged() {
+    let diff = shallow_oversized_distinct_diff();
+    let (source, _tmp) = local_source(&diff);
+
+    // A high per-call output-token count → aggregate comfortably exceeds the
+    // diff-proportional floor, so the review looks substantive.
+    let reviewer = Arc::new(LowTokenApprover {
+        output_tokens: 100_000,
+    });
+    let llm: Arc<dyn LlmProvider> = reviewer.clone();
+    let config = ReviewConfig::load(None);
+
+    let result = run_review(&config, input(source), deps(llm)).await;
+
+    assert_eq!(result.verdict, Verdict::Approve);
+    assert!(
+        !result.shallow_clean_review,
+        "a review with plausible aggregate token spend must NOT be flagged shallow"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the shallow-review heuristic failing on the map-reduce path by adding token aggregation across map and reduce stages. Previously, per-call token usage was not summed, preventing the heuristic from firing when total tokens crossed the threshold across multiple calls.

## Changes

- Add token aggregation in `outcome.rs`: collect token counts from all map calls
- Update `reduce.rs` to sum tokens across reduce calls
- Wire aggregation through `synthesis.rs` and `runner_mapreduce.rs`
- Add comprehensive tests validating token counting and shallow-review trigger

**Closes #1885**

## Test Plan

✅ All tests passing (engineer verified):
- `cargo test -p trusty-review` — Full test suite passing
- `cargo clippy` — No warnings
- `cargo fmt --check` — Format verified
- Line-cap check — Within limits

CI will re-verify these before merge.