### PR TITLE
chore(release): trusty-review v0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11045,7 +11045,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -9,6 +9,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- unify grade computation so outer and embedded grade never diverge (closes #1886) ([#1891](https://github.com/bobmatnyc/trusty-tools/pull/1891)) ([`8f6eab1`](https://github.com/bobmatnyc/trusty-tools/commit/8f6eab15718c9446579b87166bbfd763d72c48da))
+- aggregate token counts across map-reduce for shallow-review heuristic (closes #1885) ([#1890](https://github.com/bobmatnyc/trusty-tools/pull/1890)) ([`7b53d3f`](https://github.com/bobmatnyc/trusty-tools/commit/7b53d3fa2e4baf4578308babccdfc8caa11c86eb))
+## [Unreleased]
+
+### Fixed
+
 - recalibrate RC gate + verifier + Medium floor ([#1876](https://github.com/bobmatnyc/trusty-tools/pull/1876)) ([`2f0169e`](https://github.com/bobmatnyc/trusty-tools/commit/2f0169ed93924e1e35b06770b20663f4d28ee9c2))
 - correct inner_findings_count metric + fail-open smell ([#1877](https://github.com/bobmatnyc/trusty-tools/pull/1877)) ([`b7c1978`](https://github.com/bobmatnyc/trusty-tools/commit/b7c1978863c7b99748cc9380bc7c3d17006987cb))
 - serve-mode diff-fetch loads auth token correctly ([#1880](https://github.com/bobmatnyc/trusty-tools/pull/1880)) ([`f61ce55`](https://github.com/bobmatnyc/trusty-tools/commit/f61ce55d847588470a8b6e7d975a69388374921d))

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.6.3"
+version     = "0.6.4"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
## Summary
- Patch release: v0.6.3 → v0.6.4 (fix-only bump per repo semver convention).
- Covers two fix commits already merged to `main`:
  - fix(trusty-review): aggregate token counts across map-reduce for shallow-review heuristic (closes #1885) (#1890)
  - fix(trusty-review): unify grade computation so outer and embedded grade never diverge (closes #1886) (#1891)
- Bumps `crates/trusty-review/Cargo.toml` version, regenerates `CHANGELOG.md` unreleased section, updates `Cargo.lock`.

## Test plan
- [x] `cargo test -p trusty-review` — 1110 passed, 4 ignored, 0 failed (clean env; one failure was reproduced and confirmed to be caused by ambient `AWS_REGION` env-var leakage into `bedrock_region_resolution`, unrelated to this change — passes with AWS env vars unset)
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p trusty-review` — clean
- [ ] CI green