### PR TITLE
fix(scripts): tolerate aligned-whitespace version fields in bump-version.sh verification

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -182,7 +182,18 @@ main() {
 
   # Verify the rewrite actually landed: a silent awk non-match (e.g. an
   # unexpected manifest layout) must abort here instead of printing "Bumped".
-  if ! grep -qF "version = \"${next}\"" "${manifest}"; then
+  #
+  # Why flexible whitespace: write_package_version()/read_package_version()
+  # already tolerate arbitrary spacing around `=` (`[[:space:]]*`) because some
+  # crate manifests use column-aligned fields, e.g. `version     = "0.6.4"` in
+  # crates/trusty-review/Cargo.toml. This check used to be a literal
+  # `grep -qF "version = \"${next}\""` (single space only), which produced a
+  # false-negative "ERROR: version rewrite failed" on trusty-review's aligned
+  # Cargo.toml during the 0.6.4 patch release even though the awk rewrite above
+  # succeeded — see issue #1888. Match with the same [[:space:]]* tolerance the
+  # rest of this script uses so the verification can't diverge from the write.
+  local next_re="${next//./\\.}"
+  if ! grep -qE "^version[[:space:]]*=[[:space:]]*\"${next_re}\"" "${manifest}"; then
     echo "ERROR: version rewrite failed — ${manifest} still contains ${current}" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
Fixes false-negative in `scripts/bump-version.sh` verification grep. The write path already tolerated flexible whitespace matching (`[[:space:]]*`), but the verification grep only matched single spaces, causing it to reject valid Cargo.toml files with aligned-whitespace version fields.

## Root Cause
- Write path: Used `[[:space:]]*` for flexible whitespace matching
- Verification path: Used single-space literal ` ` only
- Result: Valid aligned-whitespace files failed verification despite being written correctly

**Hit live:** During trusty-review v0.6.4 release this session

## Testing
- Shellcheck: clean
- Manual validation: Both plain-space and aligned-space Cargo.toml files
- Reproduced pre-fix failure to confirm the bug
- Line-cap check: clean

Closes #1888

---
🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)