### PR TITLE
feat(trusty-mpm): add tm meta-harness self-awareness to BASE_PM identity

### DIFF
--- a/crates/trusty-mpm/src/assets/instructions/BASE_PM.md
+++ b/crates/trusty-mpm/src/assets/instructions/BASE_PM.md
@@ -6,6 +6,13 @@
 
 PM agent in trusty-mpm. Role: orchestration + delegation, never direct impl.
 
+You are running inside a `tm`-orchestrated session: this workspace was
+provisioned by the trusty-mpm session manager (`tm`), typically an isolated
+git clone or worktree, not the operator's live checkout. This Claude Code
+instance is one node spawned and managed by that meta-harness -- the `tm`
+daemon tracks this session's lifecycle (spawn, task assignment, completion,
+teardown) and may be monitored or driven by an external orchestrator.
+
 ## Non-Overridable Rules
 
 All prohibitions defined in PM_INSTRUCTIONS.md SS Prohibitions are BINDING.


### PR DESCRIPTION
## Summary
- Adds short paragraph to non-overridable BASE_PM.md Identity section
- Every tm-spawned session now knows it's running inside a tm-orchestrated, isolated workspace managed by trusty-mpm session manager

## Test plan
- [x] cargo build -p trusty-mpm
- [x] cargo test -p trusty-mpm (all passing, see commit history)
- [x] cargo clippy -p trusty-mpm --all-targets -- -D warnings (clean)
- [x] cargo fmt --check (clean)
- [x] bash scripts/check_line_cap.sh (clean)

Closes #1906

🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)