### PR TITLE
fix(trusty-mpm): call prepare_session in spawn_managed_inproject, add statusline self-heal on resume

### DIFF
--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -140,6 +140,33 @@ pub fn prepare_session_with_repo_url(
     prepare_session_inner(fw, project_dir, None, native, repo_url)
 }
 
+/// Defensively (re)write the `tm statusline` config for an EXISTING session
+/// workspace, without re-running the full preparation pipeline.
+///
+/// Why (issue #1913): sessions spawned via the pre-fix in-project worktree path
+/// never ran [`prepare_session_with_repo_url`] at all, so their on-disk
+/// `.claude/settings.json` may be permanently missing the `statusLine` key, and
+/// nothing else in the launch path ever backfills it. Re-running the FULL prep
+/// pipeline (agent/skill redeploy, CLAUDE.md merge, MCP injection) on every
+/// resume is riskier than necessary here — those steps are not all confirmed
+/// idempotent under a resumed (not freshly-provisioned) workspace — so this
+/// exposes ONLY the one step `write_status_line` itself documents as safe to
+/// call unconditionally (it never clobbers an existing key). The resume path
+/// calls this defensively so a session stuck in the pre-#1913 broken state
+/// self-heals the next time it is resumed, without the broader blast radius of
+/// a full re-prep.
+/// What: thin `pub` wrapper over `settings::write_status_line` (`pub(super)`,
+/// so not directly reachable from `crate::daemon::managed_routes`). Delegates
+/// verbatim — no additional logic.
+/// Test: the underlying idempotency guarantee is covered by
+/// `write_status_line_injects_when_absent` / `write_status_line_skips_when_already_set`
+/// / `write_status_line_preserves_user_config` in this module's test file;
+/// `resume_managed_backfills_missing_status_line` in
+/// `tests/session_manager_mvp.rs` covers the `resume_managed` call site.
+pub fn ensure_status_line(project_dir: &Path) -> Result<(), PrepError> {
+    settings::write_status_line(project_dir)
+}
+
 /// Prepare a session, selecting an explicit output style (HR-4).
 ///
 /// Why: `tm launch --style <id>` lets the operator override the configured

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -328,11 +328,24 @@ pub fn write_task_md(workspace: &std::path::Path, task: &str, session_id: &Manag
 /// sessions for the same project, and sets `workspace_owned = false` (the
 /// worktree is inside the base clone dir, which the operator should manage; the
 /// session does NOT own it for decommission purposes).
-/// What: in order — (1) creates the tmux session rooted at the worktree via
-/// `create_with_id`; (2) writes `TASK.md` into the worktree; (3) sets `source_id`
-/// via `set_source_id`; (4) runs the FRONT gate (fail-open); (5) marks `Active`;
-/// (6) spawns the runtime. A spawn failure marks the record errored (non-fatal).
-/// Test: covered transitively by the in-project spawn integration tests.
+///
+/// #1913: unlike `spawn_managed`'s clone path and `spawn_managed_local`, this
+/// path does not go through `WorkspaceProvisioner::provision_in` (there is no
+/// clone step — the worktree already exists via `try_inproject_spawn`), so it
+/// must call [`crate::core::session_launch::prepare_session_with_repo_url`]
+/// itself. Before this fix it never did, so every in-project session silently
+/// got no statusline, no deployed agents/skills, no injected trusty-memory/
+/// trusty-search MCP config, and no merged CLAUDE.md.
+/// What: in order — (1) writes `TASK.md` into the worktree; (2) runs
+/// [`prepare_inproject_session`] (best-effort, mirrors `provision_in`'s
+/// non-fatal error handling); (3) creates the tmux session rooted at the
+/// worktree via `create_with_id`; (4) sets `source_id` via `set_source_id`;
+/// (5) runs the FRONT gate (fail-open); (6) marks `Active`; (7) spawns the
+/// runtime. A spawn failure marks the record errored (non-fatal).
+/// Test: covered transitively by the in-project spawn integration tests;
+/// `prepare_inproject_session_writes_statusline` in this module's `tests`
+/// submodule exercises the new prep-call in isolation (hermetic — no daemon,
+/// tmux, or git required).
 async fn spawn_managed_inproject(
     state: &std::sync::Arc<crate::daemon::state::DaemonState>,
     session_id: &crate::session_manager::ManagedSessionId,
@@ -377,7 +390,6 @@ async fn spawn_managed_inproject(
 
     write_task_md(&worktree, &params.task, session_id);
 
-    let mgr = state.session_manager().await;
     // Pass a canonical GitHub HTTPS URL as repo_url so the session-manager can
     // derive the project name (`tmpm-<repo>-<8hex>`) for the tmux session name
     // (issue #1789). Using a synthetic HTTPS URL is safe: `parse_github_path`
@@ -385,8 +397,18 @@ async fn spawn_managed_inproject(
     // this URL is the real origin of the base clone (it was derived from the
     // operator's local `remote.origin.url`). The record stores it as `repo_url`
     // which gives `tm sessions ls` useful project context even for in-project
-    // sessions that did not clone a fresh workspace.
+    // sessions that did not clone a fresh workspace. It also doubles as the
+    // `repo_url` threaded into `prepare_inproject_session` below, for the same
+    // trusty-memory palace-pinning reason `provision_in` threads its `repo_url`.
     let synthetic_repo_url = format!("https://github.com/{owner}/{repo}");
+
+    // Prepare the session BEFORE spawning the runtime (#1913). See the
+    // function-level doc for why this call is required here specifically (no
+    // clone step wraps it, unlike the other two spawn paths).
+    let fw = crate::core::paths::FrameworkPaths::default();
+    prepare_inproject_session(&fw, session_id, &worktree, &synthetic_repo_url);
+
+    let mgr = state.session_manager().await;
     let record = mgr
         .create_with_id(
             *session_id,
@@ -447,6 +469,48 @@ async fn spawn_managed_inproject(
     }
 
     Ok(mgr.get(&record.id).await.unwrap_or(record))
+}
+
+/// Run the session-preparation pipeline for an in-project worktree, logging
+/// (never propagating) any failure.
+///
+/// Why (#1913): [`spawn_managed_inproject`] has no clone step to wrap this call
+/// in — unlike `spawn_managed`'s clone branch and `spawn_managed_local`, which
+/// both get preparation "for free" as part of `WorkspaceProvisioner::provision_in`
+/// — so it must invoke [`crate::core::session_launch::prepare_session_with_repo_url`]
+/// directly. Extracted to a named, `fw`-parameterised function (rather than
+/// inlined) so it is unit-testable against a hermetic [`crate::core::paths::FrameworkPaths::under`]
+/// tempdir without touching the operator's real `~/.trusty-mpm`/`~/.claude`.
+/// What: calls `prepare_session_with_repo_url(fw, worktree, Some(repo_url))`.
+/// On success, logs the deployed-agent count. On failure, logs a `tracing::warn!`
+/// and returns — mirroring `WorkspaceProvisioner::provision_in`'s non-fatal
+/// handling of the identical call, so a prep failure never blocks the session
+/// from spawning.
+/// Test: `prepare_inproject_session_writes_statusline` in this module's `tests`
+/// submodule.
+fn prepare_inproject_session(
+    fw: &crate::core::paths::FrameworkPaths,
+    session_id: &ManagedSessionId,
+    worktree: &std::path::Path,
+    repo_url: &str,
+) {
+    match crate::core::session_launch::prepare_session_with_repo_url(fw, worktree, Some(repo_url)) {
+        Ok(report) => {
+            info!(
+                id = %session_id,
+                deployed = report.deploy.deployed.len(),
+                worktree = %worktree.display(),
+                "spawn_managed (inproject): session prepared"
+            );
+        }
+        Err(e) => {
+            warn!(
+                id = %session_id,
+                worktree = %worktree.display(),
+                "spawn_managed (inproject): session prep failed (non-fatal): {e}"
+            );
+        }
+    }
 }
 
 /// Spawn a managed session rooted at a local directory, redirecting to a managed
@@ -793,8 +857,21 @@ impl From<ManagedError> for ResumeManagedError {
 /// [`ResumeManagedError`] (`NotFound`/`InvalidState`/`Other`). It then re-spawns
 /// the SAME runtime backend in the fresh tmux session (no re-clone) and returns
 /// the final record.
+///
+/// #1913 self-heal: sessions spawned via the (now-fixed) in-project worktree
+/// path before this fix landed never ran `prepare_session` at all, so their
+/// workspace may be permanently missing the `statusLine` config key. Every
+/// resume defensively re-applies [`crate::core::session_launch::ensure_status_line`]
+/// — the ONE prep step confirmed idempotent/non-clobbering by its own doc
+/// comment — so such a session self-heals the next time it is resumed. The
+/// broader prep pipeline (agent/skill redeploy, CLAUDE.md merge, MCP injection)
+/// is intentionally NOT re-run here: those steps are not all confirmed safe to
+/// repeat against an already-running workspace, so re-running them on every
+/// resume risks a different class of bug for a narrower payoff.
 /// Test: covered by the HTTP `resume_managed_session` tests and the MCP
-/// `session_resume_unknown_id_errors` test.
+/// `session_resume_unknown_id_errors` test;
+/// `resume_managed_backfills_missing_status_line` in
+/// `tests/session_manager_mvp.rs` covers the self-heal call added here.
 pub async fn resume_managed(
     state: &Arc<DaemonState>,
     id: &ManagedSessionId,
@@ -806,6 +883,15 @@ pub async fn resume_managed(
         .workspace_path
         .clone()
         .unwrap_or_else(|| record.cwd.clone());
+
+    // Defensive self-heal (#1913): best-effort, never blocks the resume.
+    if let Err(e) = crate::core::session_launch::ensure_status_line(&workspace) {
+        warn!(
+            id = %record.id,
+            "resume_managed: statusline self-heal failed (non-fatal): {e}"
+        );
+    }
+
     let tmux_arc = mgr.tmux_driver();
     let adapter = build_adapter(record.runtime, tmux_arc);
     // #1744: prefer --resume <id> when a claude_session_id was captured at
@@ -837,4 +923,60 @@ pub async fn resume_managed(
     }
 
     Ok(mgr.get(id).await.unwrap_or(record))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #1913 regression guard: [`prepare_inproject_session`] — the call this fix
+    /// adds to [`spawn_managed_inproject`] BEFORE `adapter.spawn` — must actually
+    /// run the preparation pipeline and land its most visible symptom (the
+    /// reported bug): the `statusLine` key in `<worktree>/.claude/settings.json`.
+    ///
+    /// Why hermetic: `spawn_managed_inproject` itself needs a live `DaemonState`
+    /// (tmux driver, session store) plus a real git worktree from
+    /// `try_inproject_spawn`, which the crate's existing test suite deliberately
+    /// avoids driving end-to-end (see `handler_spawn_wires_provision_and_spawn`'s
+    /// comment in `tests/session_manager_mvp.rs` — replicating handler steps
+    /// rather than calling the private handler). `prepare_inproject_session` was
+    /// extracted specifically so the ONE new call this fix adds is independently
+    /// testable: point `FrameworkPaths::under` at a tempdir (never the operator's
+    /// real `~/.trusty-mpm`/`~/.claude`) and call it directly against a plain
+    /// temp directory standing in for the worktree — no daemon, tmux, or git
+    /// required, matching how `session_launch::tests` already exercises
+    /// `prepare_session*` hermetically.
+    /// What: calls `prepare_inproject_session` with a hermetic `fw` and a fresh
+    /// temp "worktree" dir, then asserts `<worktree>/.claude/settings.json`
+    /// exists and contains `"statusLine"` — proving the prep pipeline actually
+    /// ran (before this fix, nothing in `spawn_managed_inproject` ever wrote
+    /// this file).
+    /// Test: this function IS the test.
+    #[test]
+    fn prepare_inproject_session_writes_statusline() {
+        let tmp_home = tempfile::TempDir::new().expect("tmp home");
+        let worktree = tempfile::TempDir::new().expect("tmp worktree");
+        let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+        let session_id = ManagedSessionId::new();
+
+        prepare_inproject_session(
+            &fw,
+            &session_id,
+            worktree.path(),
+            "https://github.com/owner/repo",
+        );
+
+        let settings_path = worktree.path().join(".claude").join("settings.json");
+        let content = std::fs::read_to_string(&settings_path).unwrap_or_else(|e| {
+            panic!(
+                "prepare_inproject_session must write {}: {e}",
+                settings_path.display()
+            )
+        });
+        assert!(
+            content.contains("statusLine"),
+            "prepared worktree settings.json must carry the statusLine key \
+             (the #1913 symptom); got: {content}"
+        );
+    }
 }

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -809,6 +809,83 @@ async fn resume_managed_typed_invalid_state_is_conflict() {
     );
 }
 
+/// #1913 self-heal: `resume_managed` must backfill a missing `statusLine` key
+/// in a resumed session's workspace, even though the workspace was never
+/// prepared by `prepare_session*` in the first place.
+///
+/// Why: sessions spawned via the (pre-#1913) broken in-project worktree path
+/// never ran the prep pipeline at all, so their `.claude/settings.json` is
+/// permanently missing `statusLine` — and nothing else in the launch path
+/// would ever add it. `resume_managed` now defensively calls
+/// `ensure_status_line` on every resume so such a session self-heals the next
+/// time an operator resumes it, without re-running the (heavier, not fully
+/// idempotent) full prep pipeline.
+/// What: seeds a session whose `workspace_path` is a real temp directory with
+/// NO `.claude/settings.json` (simulating the pre-fix broken state), stops it
+/// (`Stopped` is resumable), calls `resume_managed`, and asserts
+/// `<workspace>/.claude/settings.json` now exists and contains `"statusLine"`.
+/// The runtime adapter spawn itself is allowed to fail in CI (no real
+/// `tmux`/`claude` binary) — `resume_managed` never propagates that failure —
+/// so this test only asserts on the self-heal side effect, not the spawn
+/// outcome.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn resume_managed_backfills_missing_status_line() {
+    // Hermetic framework root with FakeNoopTmuxDriver — no real tmux sessions
+    // are created, so nothing can escape into the production store (#1790).
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+    let mgr = state.session_manager().await;
+
+    let id = ResumeSessionId::new();
+    let ws = root.path().join(format!("{id}-selfheal-ws"));
+    std::fs::create_dir_all(&ws).expect("create workspace dir");
+
+    // Precondition: no `.claude/settings.json` at all — the exact pre-#1913
+    // broken state (never prepared).
+    let settings_path = ws.join(".claude").join("settings.json");
+    assert!(
+        !settings_path.exists(),
+        "precondition: workspace must start with no settings.json"
+    );
+
+    let _seeded = mgr
+        .create_with_id(
+            id,
+            "regression: statusline self-heal on resume".to_string(),
+            Some(ws.clone()),
+            None,
+            Some(ws.clone()),
+            Some("https://github.com/owner/repo".to_string()),
+            Some("main".to_string()),
+            ResumeRuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session");
+
+    // Stop first — resume is only valid from Stopped/Errored.
+    mgr.stop(&id).await.expect("stop");
+
+    // `resume_managed` never propagates a runtime-adapter spawn failure (CI has
+    // no real tmux/claude binary), so we don't assert on its Ok/Err — only on
+    // the self-heal side effect, which must land regardless of spawn outcome.
+    let _ = resume_managed(&state, &id).await;
+
+    let content = std::fs::read_to_string(&settings_path).unwrap_or_else(|e| {
+        panic!(
+            "resume_managed must backfill {}: {e}",
+            settings_path.display()
+        )
+    });
+    assert!(
+        content.contains("statusLine"),
+        "resumed workspace settings.json must carry the statusLine key \
+         (the #1913 self-heal); got: {content}"
+    );
+}
+
 /// FRONT gate (#1360, AC-15): the withheld spawn launches after human approval.
 ///
 /// Why: a session escalated by the FRONT gate sits in `Provisioning` with no


### PR DESCRIPTION
## Summary
- The in-project worktree spawn path (`spawn_managed_inproject`) never called the session-preparation pipeline before launching the runtime, unlike its sibling clone/local-path spawn functions — so any session spawned that way silently got no statusline config, no deployed agents/skills, and no injected trusty-memory/trusty-search MCP servers.
- Extracted a `prepare_inproject_session` helper (mirroring the non-fatal error handling used elsewhere) and wired it in before the FRONT gate / adapter.spawn call.
- Added a resume-time self-heal: `resume_managed` now defensively backfills a missing `statusLine` config on every resume (scoped narrowly to just this step, since it's the only preparation step confirmed idempotent/non-clobbering) so sessions that started via the pre-fix broken path can recover.
- Investigated (not fixed, flagged as follow-up) a related risk: `tm statusline`'s command hook uses a bare `tm` with no PATH resolution, analogous to an already-fixed issue (#1298) for the `claude` binary under launchd's minimal PATH.

## Test plan
- [x] cargo build -p trusty-mpm
- [x] cargo test -p trusty-mpm (all passing, including new hermetic tests: prepare_inproject_session_writes_statusline, resume_managed_backfills_missing_status_line)
- [x] cargo clippy -p trusty-mpm --all-targets -- -D warnings (clean)
- [x] cargo fmt --check (clean)
- [x] bash scripts/check_line_cap.sh (clean)

Closes #1913

🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)