### PR TITLE
feat(trusty-mpm): unify session start with protected-path routing, rename sessions->session, bare tm shortcut

### DIFF
--- a/crates/trusty-common/src/catchup/mod.rs
+++ b/crates/trusty-common/src/catchup/mod.rs
@@ -214,7 +214,7 @@ pub async fn generate_catchup_context(opts: &CatchupOptions) -> String {
 
 /// Generate the catch-up digest and optionally advance the watermark.
 ///
-/// Why: the CLI `tm sessions catchup` command needs to produce the digest
+/// Why: the CLI `tm session catchup` command needs to produce the digest
 /// without advancing the watermark (manual peek), while the auto-inject on
 /// session start should advance it.
 /// What: calls [`generate_catchup_context`] to produce the context string,

--- a/crates/trusty-mpm/src/assets/instructions/BASE_PM.md
+++ b/crates/trusty-mpm/src/assets/instructions/BASE_PM.md
@@ -45,7 +45,7 @@ Trigger phrases -> act immediately:
 
 After writing: confirm file path, note "takes effect at next session startup."
 Inspect: `ls .trusty-mpm/*.md 2>/dev/null`
-Verify the resolved prompt: `tm sessions instructions` (or read
+Verify the resolved prompt: `tm session instructions` (or read
 `.trusty-mpm/last-instructions.md`).
 
 ## Trusty Tool Priority (Non-Overridable)

--- a/crates/trusty-mpm/src/assets/skills/tm-session-management.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-session-management.md
@@ -74,14 +74,14 @@ Procedure: `git status` + `git log --oneline -10` for context → `mkdir -p
 .trusty-mpm/sessions` → write `session-{timestamp}.md` → update
 `LATEST-SESSION.txt` → report the path to the user.
 
-## Resuming: `tm sessions catchup`
+## Resuming: `tm session catchup`
 
 Resume delegates to the real CLI command rather than manually parsing
 session files:
 
 ```bash
-tm sessions catchup                  # current project only
-tm sessions catchup --all-projects   # also scan machine-wide claude-mpm/trusty-mpm projects
+tm session catchup                  # current project only
+tm session catchup --all-projects   # also scan machine-wide claude-mpm/trusty-mpm projects
 ```
 
 This renders a unified, newest-first digest across both the native
@@ -106,8 +106,8 @@ decommissioned SM sessions. `tm doctor`'s `worktrees` probe flags these; the
 cleanup command is:
 
 ```bash
-tm sessions prune-worktrees          # dry-run by default
-tm sessions prune-worktrees --force  # actually remove
+tm session prune-worktrees          # dry-run by default
+tm session prune-worktrees --force  # actually remove
 ```
 
 Run this as part of session wrap-up when `tm doctor` reports orphaned

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -65,7 +65,7 @@ Never guess what the PM is actually running under. Two equivalent ways to
 check:
 
 ```bash
-tm sessions instructions        # prints the resolved prompt
+tm session instructions        # prints the resolved prompt
 cat .trusty-mpm/last-instructions.md   # the exact stash resolve_pm_prompt wrote
 ```
 

--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -101,16 +101,16 @@ pub(crate) enum Command {
     ///   Managed fleet sessions (provisioned in isolated worktrees):
     ///     new, ls, activity, send, answer, decommission, prune-idle, …
     ///
-    /// Why (#1394, #1841): the invoked name is the plural `sessions` to match the
-    /// `/api/v1/sessions/*` HTTP API surface. The singular `session` spelling is
-    /// accepted as a visible alias (#1841) so both forms work ergonomically. The
-    /// Rust variant stays `Session` (with an explicit `#[command(name = "sessions")]`)
-    /// to keep the `SessionAction` group and every match arm coherent without renaming
-    /// ~80 internal references.
-    /// What: the `tm sessions <action>` command group (`tui`, `ls`, `new`, …).
-    /// Test: `cli_parses_sessions_plural` / `cli_session_alias_accepts_singular` in
-    /// `tests.rs`.
-    #[command(name = "sessions", visible_alias = "session")]
+    /// Why (#1916): the invoked name is the singular `session` — renamed from the
+    /// plural `sessions` (#1394/#1841) now that `tm` has no external users to keep
+    /// a compatibility alias for. `tm session start`/`tm session new` reads more
+    /// naturally as a singular verb group. The Rust variant stays `Session`
+    /// (matching the clap-derived kebab-case default, so no rename of the
+    /// `SessionAction` group or its ~80 internal references was needed).
+    /// What: the `tm session <action>` command group (`tui`, `ls`, `new`, …).
+    /// Test: `cli_parses_session_singular` / `cli_sessions_plural_no_longer_parses`
+    /// in `tests.rs`.
+    #[command(name = "session")]
     Session {
         /// Session action to perform.
         #[command(subcommand)]
@@ -739,7 +739,7 @@ pub(crate) enum SessctlAction {
     },
     /// Stop a session (graceful by default, --force for immediate).
     ///
-    /// Why: mirrors `tm sessions stop` for the SESSCTL surface.
+    /// Why: mirrors `tm session stop` for the SESSCTL surface.
     /// What: POSTs to `POST /api/v1/control/sessions/{id}/stop?force=<bool>`.
     /// Test: `cli_parses_sessctl_stop`.
     Stop {
@@ -1059,7 +1059,7 @@ pub(crate) enum CatalogAction {
 pub(crate) enum RepairAction {
     /// Repair the agent/skill deploy state in `~/.claude/`.
     ///
-    /// Why: a crash during `tm install` or `tm sessions start` may leave stale
+    /// Why: a crash during `tm install` or `tm session start` may leave stale
     /// `.tmp` staging files in `~/.claude/agents/` or `~/.claude/skills/`, or
     /// leave either manifest corrupt. This command removes the orphans and
     /// validates both manifests.
@@ -1204,7 +1204,7 @@ pub(crate) enum SessionAction {
     /// session list (controller bullet + one row per managed session, the active
     /// row in two columns `[id] │ [summary]`). This is a NEW screen, distinct
     /// from the existing `tm tui` dashboard. It lives under the `session` group
-    /// as `tm sessions tui` (#1392): it operates on the same managed-session list
+    /// as `tm session tui` (#1392): it operates on the same managed-session list
     /// the other `session` verbs do, so grouping it there keeps the surface
     /// discoverable without colliding with the `coordinator` SM chat command.
     /// What: polls the daemon's coordinator-context endpoint live on the
@@ -1288,7 +1288,7 @@ pub(crate) enum SessionAction {
     /// Spawn a new managed session from a repo + ref (session-manager MVP).
     ///
     /// Why: the session-manager MVP provisions an isolated workspace from a git
-    /// repo and starts a harness in it; `tm sessions new` is the operator-facing
+    /// repo and starts a harness in it; `tm session new` is the operator-facing
     /// entry point that posts to `POST /api/v1/sessions/managed`.
     /// What: posts repo, ref, task, and an optional name hint to the daemon.
     /// Test: `cli_parses_session_new`.

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -56,7 +56,7 @@ pub(crate) enum PickerDecision {
 /// Bare `tm` guided default — detect project, list sessions, and offer a picker.
 ///
 /// Why: operators who type `tm` from inside a project directory should not
-/// have to remember `tm sessions new`, `tm connect`, or `tm attach <name>` —
+/// have to remember `tm session new`, `tm connect`, or `tm attach <name>` —
 /// the guided default derives the project identity, shows existing sessions,
 /// and lets them resume or launch in one step. The live checkout is NEVER
 /// written to; all managed sessions run in the protected base-clone workspace.
@@ -450,7 +450,7 @@ pub(crate) fn needs_restart(state: &str) -> bool {
 /// provisioning) but its tmux session has disappeared (e.g. after a machine
 /// reboot before the daemon reconcile runs), the daemon's `resume` endpoint
 /// would return 409 (can only resume Stopped/Errored) — leading to a dead end.
-/// The correct recovery is operator-driven: `tm sessions stop <id>` to reset
+/// The correct recovery is operator-driven: `tm session stop <id>` to reset
 /// the daemon state, then `tm` again to restart.
 /// What: returns `true` when `!needs_restart(state)` AND `!tmux_live`.
 /// Test: `guided_resume_is_zombie_*` in `tests_behavior_c_tests.rs`.
@@ -471,7 +471,7 @@ pub(crate) fn is_zombie(state: &str, tmux_live: bool) -> bool {
 /// live, then POSTs `/api/v1/sessions/managed/{id}/resume` with a 30-second
 /// timeout; (4) 404/409/5xx/network errors each print a distinct actionable
 /// message; (5) on HTTP 200, the response body is checked — if `state=errored`
-/// the runtime spawn failed and the operator is directed to `tm sessions info`;
+/// the runtime spawn failed and the operator is directed to `tm session info`;
 /// (6) falls through to `tmux_attach` only when everything is confirmed ready.
 /// Test: `needs_restart` and `is_zombie` are the testable pure seams; the I/O
 /// path is exercised by the e2e suite and manual smoke tests.
@@ -491,7 +491,7 @@ async fn resume_guided_session(
             session.name, session.state
         );
         eprintln!(
-            "tm: run `tm sessions stop {}` then `tm` again to restart it.",
+            "tm: run `tm session stop {}` then `tm` again to restart it.",
             session.id
         );
         anyhow::bail!(
@@ -547,7 +547,7 @@ async fn resume_guided_session(
                     session.name
                 );
                 eprintln!(
-                    "tm: run `tm sessions ls` to see current sessions, \
+                    "tm: run `tm session ls` to see current sessions, \
                      or press [Enter] to launch a new one."
                 );
                 anyhow::bail!("session '{}' not found on daemon", session.name);
@@ -555,7 +555,7 @@ async fn resume_guided_session(
             reqwest::StatusCode::CONFLICT => {
                 let msg = resp.text().await.unwrap_or_default();
                 eprintln!("tm: cannot restart session '{}': {}", session.name, msg);
-                eprintln!("tm: run `tm sessions ls` to see the current state.");
+                eprintln!("tm: run `tm session ls` to see the current state.");
                 anyhow::bail!("cannot restart session '{}': {msg}", session.name);
             }
             // (5) 5xx means the daemon IS running but had an internal error —
@@ -563,7 +563,7 @@ async fn resume_guided_session(
             s if s.is_server_error() => {
                 eprintln!(
                     "tm: daemon returned an internal error ({s}) restarting '{}' — \
-                     try `tm sessions ls`.",
+                     try `tm session ls`.",
                     session.name
                 );
                 anyhow::bail!(
@@ -573,7 +573,7 @@ async fn resume_guided_session(
             }
             s if !s.is_success() => {
                 eprintln!(
-                    "tm: daemon returned {s} restarting '{}' — try `tm sessions ls`.",
+                    "tm: daemon returned {s} restarting '{}' — try `tm session ls`.",
                     session.name
                 );
                 anyhow::bail!("daemon error {s} restarting session '{}'", session.name);
@@ -592,7 +592,7 @@ async fn resume_guided_session(
                         "tm: session '{}' restarted but the runtime failed to start.",
                         session.name
                     );
-                    eprintln!("tm: check `tm sessions info {}` for details.", session.id);
+                    eprintln!("tm: check `tm session info {}` for details.", session.id);
                     anyhow::bail!(
                         "session '{}' restarted but runtime failed to start (state=errored)",
                         session.name

--- a/crates/trusty-mpm/src/bin/tm/commands/install.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install.rs
@@ -61,7 +61,7 @@ pub(crate) fn install(force: bool) -> anyhow::Result<()> {
     // so the source dir is populated before this copy runs — mirroring the
     // agent ordering. Without this step a fresh `tm install` left the skills
     // directory empty and `tm doctor` reported `skills: Fail` (#386); skills
-    // only deployed lazily on `tm sessions start` (see `prepare_session`).
+    // only deployed lazily on `tm session start` (see `prepare_session`).
     println!(
         "Deploying skills into {}",
         paths.claude_skills_dir().display()

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -47,7 +47,7 @@ pub(crate) fn deprecation_notice(old: &str, new: &str) {
 /// Return true when a session state should be shown in the default picker/list view.
 ///
 /// Why: decommissioned tombstones accumulate without bound (#1809); operators
-/// don't want 230+ dead records cluttering the picker and `tm sessions ls`. This
+/// don't want 230+ dead records cluttering the picker and `tm session ls`. This
 /// predicate is the single source of truth for which states are "live" so the
 /// picker and the `sessions list` table use identical logic.
 /// What: returns `false` for `"decommissioned"` (the sole dead/tombstone state);
@@ -61,7 +61,7 @@ pub(crate) fn is_live_session_state(state: &str) -> bool {
 /// Filter a session list to only live sessions for display in the picker (#1809).
 ///
 /// Why: the picker must never show decommissioned tombstones by default; the
-/// `--all` opt-in re-enables them for `tm sessions ls` via this module's path.
+/// `--all` opt-in re-enables them for `tm session ls` via this module's path.
 /// What: retains only sessions whose `state` passes `is_live_session_state`.
 /// Test: `picker_filter_excludes_decommissioned_keeps_active` in
 /// `tests_behavior_c_tests.rs`.
@@ -74,7 +74,7 @@ pub(crate) fn filter_live_sessions(
         .collect()
 }
 
-/// `tm sessions ls` — list managed sessions.
+/// `tm session ls` — list managed sessions.
 ///
 /// Why: operators need a quick view of every managed session and its pending
 /// decision, optionally scoped to a single project so the firehose is tamed.
@@ -202,7 +202,7 @@ fn short_timestamp(s: &str) -> String {
     }
 }
 
-/// `tm sessions activity <id>` — inspect a managed session's activity state.
+/// `tm session activity <id>` — inspect a managed session's activity state.
 ///
 /// Why: inspect what a session is doing without attaching; the raw pane is
 /// always returned for the calling agentic process to reason over. The LLM
@@ -271,7 +271,7 @@ pub(crate) async fn session_activity(
     Ok(())
 }
 
-/// `tm sessions stop <id>` — stop the runtime of a managed session, keep the workspace.
+/// `tm session stop <id>` — stop the runtime of a managed session, keep the workspace.
 ///
 /// Why: a session ENDURES beyond its runtime; `stop` kills only the tmux session
 /// and claude process, preserving the workspace for later `resume`. Renamed from
@@ -297,7 +297,7 @@ pub(crate) async fn session_stop(
     Ok(())
 }
 
-/// `tm sessions resume <id>` — resume a stopped managed session in its existing workspace.
+/// `tm session resume <id>` — resume a stopped managed session in its existing workspace.
 ///
 /// Why: after `stop`, the workspace is still on disk; `resume` re-spawns the
 /// runtime there without re-cloning. Renamed from the verbose `managed-resume`
@@ -328,7 +328,7 @@ pub(crate) async fn session_resume(
     Ok(())
 }
 
-/// `tm sessions decommission <id>` — full teardown (may or may not remove workspace).
+/// `tm session decommission <id>` — full teardown (may or may not remove workspace).
 ///
 /// Why: adopted/local-path sessions were NEVER owned by tm, so the workspace is
 /// NOT removed on their decommission. Previously the CLI printed an incorrect
@@ -387,7 +387,7 @@ pub(crate) async fn session_decommission(
     Ok(())
 }
 
-/// `tm sessions decommission-ephemeral` — bulk-tear-down every ephemeral session (#1508).
+/// `tm session decommission-ephemeral` — bulk-tear-down every ephemeral session (#1508).
 ///
 /// Why: e2e harnesses and operators need a one-shot "clean up all my throwaway
 /// test sessions" verb. REAL sessions default `ephemeral=false` and are
@@ -415,7 +415,7 @@ pub(crate) async fn session_decommission_ephemeral(
     Ok(())
 }
 
-/// `tm sessions prune --state <filter> [--dry-run] [--include-active]` — by-state prune (#1508).
+/// `tm session prune --state <filter> [--dry-run] [--include-active]` — by-state prune (#1508).
 ///
 /// Why: ONE tool to tear down ephemeral/stopped sessions AND compact the store by
 /// dropping decommissioned tombstones, so legacy stale records can be purged with
@@ -482,7 +482,7 @@ pub(crate) async fn session_prune(
     Ok(())
 }
 
-/// `tm sessions prune --worktrees [--dry-run]` — remove orphaned per-session worktrees (#1840).
+/// `tm session prune --worktrees [--dry-run]` — remove orphaned per-session worktrees (#1840).
 ///
 /// Why: sessions decommissioned before Fix 1a (#1840), or where
 /// `git worktree remove` failed, leave stale `.worktrees/<session-id>/`

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
@@ -1,4 +1,4 @@
-//! Route the `tm sessions` managed verbs through the shared chat-core layer.
+//! Route the `tm session` managed verbs through the shared chat-core layer.
 //!
 //! Why: the managed session-manager verbs (`new`/`ls`/`send`/`answer`/`attach`/
 //! `stop`/`resume`/`decommission`) historically built `reqwest` requests by hand
@@ -152,7 +152,7 @@ pub(crate) fn render_cli(result: &CommandResult) -> String {
 /// Resolve a fuzzy id/name against the managed session list (managed-vs-project
 /// routing decision for `stop`/`resume`).
 ///
-/// Why (#1218): the canonical `tm sessions stop`/`resume` verbs are managed-aware
+/// Why (#1218): the canonical `tm session stop`/`resume` verbs are managed-aware
 /// — a managed id/name routes to the managed runtime; anything else falls back to
 /// the project-session path. The matching now goes through the ONE canonical
 /// [`resolve_target`] resolver (Phase 1B collapsed the bespoke
@@ -180,7 +180,7 @@ pub(crate) async fn resolve_managed_match(
 /// Resolve a PROJECT-session id/name to its canonical UUID via the shared
 /// resolver.
 ///
-/// Why: `tm sessions events` needs a UUID for `GET /sessions/{id}/events`, but
+/// Why: `tm session events` needs a UUID for `GET /sessions/{id}/events`, but
 /// operators may pass a friendly `tmpm-*` name. Phase 1B collapsed the bespoke
 /// `resolve_session_id` here so the project-session lookup uses the SAME
 /// [`resolve_target`] precedence (id-exact → name-exact → unambiguous prefix) as

--- a/crates/trusty-mpm/src/bin/tm/commands/prune.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/prune.rs
@@ -1,4 +1,4 @@
-//! `tm sessions prune-idle` — reclaim idle session-manager sessions (issue #1313).
+//! `tm session prune-idle` — reclaim idle session-manager sessions (issue #1313).
 //!
 //! Why: paused orchestration sessions leave behind idle SM tmux sessions that
 //! consume claude Max rate-limit slots and clutter the fleet. This command
@@ -266,7 +266,7 @@ fn short_id(id: &str) -> &str {
     id.split('-').next().unwrap_or(id)
 }
 
-/// `tm sessions prune-idle` — enumerate idle SM sessions and reclaim them.
+/// `tm session prune-idle` — enumerate idle SM sessions and reclaim them.
 ///
 /// Why: the operator-facing (and pause-automated) entry point. It must reuse the
 /// existing managed list/activity/runtime-stop/decommission surface, apply the

--- a/crates/trusty-mpm/src/bin/tm/commands/sessctl.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/sessctl.rs
@@ -156,7 +156,7 @@ async fn sessctl_connect(
 
 /// POST /api/v1/control/sessions/{id}/stop — send a stop command to a session.
 ///
-/// Why: mirrors `tm sessions stop` for the SESSCTL surface.
+/// Why: mirrors `tm session stop` for the SESSCTL surface.
 /// What: POSTs with `?force=<bool>` and prints a confirmation.
 /// Test: `cli_parses_sessctl_stop`; live test requires daemon.
 async fn sessctl_stop(

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -4,17 +4,19 @@
 //! breakers, pause, resume, catchup, run, output, instructions) form a cohesive
 //! group that benefits from a dedicated file.
 //! What: the `session` dispatcher function and its private helpers
-//! `emit_managed_alias_notice`, `compose_session_instructions`. The managed
-//! verbs (`new`/`ls`/`send`/`answer`/`attach`/`stop`/`resume`/`decommission`)
-//! route through the shared chat-core layer (`commands::managed_route`); the
-//! id-or-name resolution for both managed and project sessions goes through the
-//! one canonical `client::resolve_target`. `catchup` is handled by the
-//! DOC-28 cutover bridge in the `catchup` submodule.
+//! `emit_managed_alias_notice`, `compose_session_instructions`. `start` is
+//! handled by the [`start`] submodule (protected-path routing, #1916). The
+//! managed verbs (`new`/`ls`/`send`/`answer`/`attach`/`stop`/`resume`/
+//! `decommission`) route through the shared chat-core layer
+//! (`commands::managed_route`); the id-or-name resolution for both managed and
+//! project sessions goes through the one canonical `client::resolve_target`.
+//! `catchup` is handled by the DOC-28 cutover bridge in the `catchup` submodule.
 //! Test: `cli_parses_session_*`, `cli_parses_session_catchup`,
 //! `compose_session_instructions_*` in `tests.rs`.
 
 // CUTOVER BRIDGE submodule — remove post-migration (#1762)
 pub(crate) mod catchup;
+mod start;
 
 use serde::Deserialize;
 
@@ -27,11 +29,14 @@ use crate::types::{EventRow, SessionRow};
 ///
 /// Why: a session is a Claude Code instance; operators start, stop, list,
 /// reap, and inspect them per project from the shell.
-/// What: `Start` posts `POST /sessions` with the project path; `Stop` and
-/// `Resume` are managed-aware (#1218) — they route to the managed runtime-stop/
-/// resume endpoints when the id/name resolves to a managed session, falling back
-/// to the project-session path otherwise; `Info` resolves a session by id or
-/// friendly name; `List` and `Clean` scope to the project directory.
+/// What: `Start` routes through [`start::start_session`] (protected-path
+/// segregation for a recognized GitHub-backed git repo, in-place
+/// `prepare_session` for everything else — see that function's doc for the
+/// #1916 rationale); `Stop` and `Resume` are managed-aware (#1218) — they
+/// route to the managed runtime-stop/resume endpoints when the id/name
+/// resolves to a managed session, falling back to the project-session path
+/// otherwise; `Info` resolves a session by id or friendly name; `List` and
+/// `Clean` scope to the project directory.
 /// Test: `cli_parses_session_start`, `cli_parses_session_stop`,
 /// `cli_parses_session_list`, `cli_parses_session_clean`,
 /// `cli_parses_session_info`.
@@ -41,102 +46,7 @@ pub(crate) async fn session(
     action: SessionAction,
 ) -> anyhow::Result<()> {
     match action {
-        SessionAction::Start { dir } => {
-            let path = resolve_dir(dir)?;
-            // Prepare the custom instructions Claude Code reads at startup:
-            // deploy composed agents to `~/.claude/agents/` and merge the
-            // project CLAUDE.md. This shared prep is what makes a plain
-            // `claude` process behave as a trusty-mpm session.
-            let fw = trusty_mpm::core::paths::FrameworkPaths::default();
-            match trusty_mpm::core::session_launch::prepare_session(&fw, &path) {
-                Ok(report) => {
-                    println!(
-                        "Agents: {} deployed, {} skipped, {} unchanged",
-                        report.deploy.deployed.len(),
-                        report.deploy.skipped.len(),
-                        report.deploy.unchanged.len(),
-                    );
-                    if report.instructions.claude_md_created {
-                        println!("  Created CLAUDE.md stub in {}", path.display());
-                    }
-                    println!(
-                        "Instructions: {} agents in delegation authority",
-                        report.instructions.agent_count
-                    );
-                    println!(
-                        "  Merged instructions written to {}",
-                        report.stash.display()
-                    );
-                    // DOC-28 cutover bridge: print catch-up digest as seed context.
-                    // CUTOVER BRIDGE — remove post-migration (#1762)
-                    if let Some(ctx) = report.catchup_context {
-                        println!("\n---\n\n## Recent Activity (catch-up)\n\n{ctx}");
-                    }
-                }
-                Err(err) => eprintln!("warning: session preparation failed: {err}"),
-            }
-
-            #[derive(Deserialize)]
-            struct Body {
-                #[serde(default)]
-                name: String,
-            }
-            let body: Body = client
-                .post(format!("{url}/sessions"))
-                .json(&serde_json::json!({
-                    "project": path,
-                    "project_path": path,
-                }))
-                .send()
-                .await?
-                .error_for_status()?
-                .json()
-                .await?;
-
-            // The daemon only registers session state now — it no longer
-            // spawns the tmux host (that caused session proliferation). The
-            // CLI owns the actual launch: create a detached tmux session in
-            // the project directory and start `claude` in it.
-            let workdir = path.to_string_lossy().to_string();
-            let new_session = std::process::Command::new("tmux")
-                .args(["new-session", "-d", "-s", &body.name, "-c", &workdir])
-                .status();
-            match new_session {
-                Ok(status) if status.success() => {
-                    let send = std::process::Command::new("tmux")
-                        .args([
-                            "send-keys",
-                            "-t",
-                            &body.name,
-                            &format!(
-                                "claude {}",
-                                trusty_mpm::core::model_inject::PERMISSION_MODE_FLAG
-                            ),
-                            "Enter",
-                        ])
-                        .status();
-                    match send {
-                        Ok(s) if s.success() => {
-                            println!("started session {} (tmux + claude)", body.name);
-                        }
-                        Ok(_) | Err(_) => {
-                            eprintln!(
-                                "warning: tmux session {} created but failed to start claude",
-                                body.name
-                            );
-                            println!("started session {}", body.name);
-                        }
-                    }
-                }
-                Ok(_) | Err(_) => {
-                    eprintln!(
-                        "warning: failed to create tmux session {}; run `claude` manually in {}",
-                        body.name, workdir
-                    );
-                    println!("started session {}", body.name);
-                }
-            }
-        }
+        SessionAction::Start { dir } => start::start_session(client, url, dir).await?,
         SessionAction::Stop { id_or_name } => {
             // #1218: `stop` is managed-aware. If the argument resolves to a
             // MANAGED session (by id or friendly name) via the canonical
@@ -187,7 +97,7 @@ pub(crate) async fn session(
             url: tui_url,
             interval_ms,
         } => {
-            // #1392: the coordinator TUI is `tm sessions tui` (formerly the
+            // #1392: the coordinator TUI is `tm session tui` (formerly the
             // top-level `tm coordinator-tui`). It polls the daemon live, so its
             // `run` is async and runs on the tokio runtime like `tui::run`.
             // `resolve_daemon_url` honours an explicit `--url`, then the lock
@@ -237,8 +147,8 @@ pub(crate) async fn session(
                     // Fall back: the id/name may belong to a MANAGED session
                     // (SM sessions live in the managed store, not the project-session
                     // store). Fetch the managed list and search there too before
-                    // giving up. This fixes the gap where `tm sessions info <uuid>`
-                    // printed "not found" for sessions visible in `tm sessions ls`.
+                    // giving up. This fixes the gap where `tm session info <uuid>`
+                    // printed "not found" for sessions visible in `tm session ls`.
                     let managed = info_from_managed_store(client, url, &id_or_name).await;
                     match managed {
                         Some(val) => println!("{}", serde_json::to_string_pretty(&val)?),
@@ -555,10 +465,10 @@ fn matches_session(session: &serde_json::Value, id_or_name: &str) -> bool {
 
 /// Fetch the managed session list and find a session matching `id_or_name`.
 ///
-/// Why: `tm sessions info` queries the project-session store first; managed
+/// Why: `tm session info` queries the project-session store first; managed
 /// sessions live in a separate store and return 404 there. This fallback
 /// prevents the confusing "not found" message for sessions that ARE visible in
-/// `tm sessions ls`. Non-404 HTTP errors are logged as warnings so daemon 5xx
+/// `tm session ls`. Non-404 HTTP errors are logged as warnings so daemon 5xx
 /// responses are not silently swallowed as "not found".
 /// What: GETs `/api/v1/sessions/managed`, searches by id-exact then name-exact
 /// via `matches_session`, returns the first match as a `serde_json::Value`.
@@ -601,7 +511,7 @@ async fn info_from_managed_store(
 /// prompt — the text actually delivered to `claude --append-system-prompt-file`.
 /// The old code returned `output.merged` (the legacy pipeline: INSTRUCTIONS.md +
 /// delegation authority + CLAUDE.md) for display, while stashing `resolve_pm_prompt`
-/// separately. That caused `tm sessions instructions` to print content that differed
+/// separately. That caused `tm session instructions` to print content that differed
 /// from what Claude received, which is exactly the divergence issue #382 describes.
 /// The single source of truth for "what claude receives" is `resolve_pm_prompt`;
 /// the display and the stash must both come from it.
@@ -634,7 +544,7 @@ pub(crate) fn compose_session_instructions(
     // The single source of truth for the live PM prompt is
     // `build_system_prompt_for`, NOT the bare `resolve_pm_prompt`. The launcher
     // applies HR-4 output-style version-fallback injection on top of the resolved
-    // prompt (issue #1409), so `tm sessions instructions` must show — and the
+    // prompt (issue #1409), so `tm session instructions` must show — and the
     // stash must hold — that SAME injected text. Writing the pre-injection
     // `resolve_pm_prompt` here made the display/stash diverge from the real launch
     // prompt whenever `claude` was absent/old (injection fires), the same #382

--- a/crates/trusty-mpm/src/bin/tm/commands/session/catchup.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/catchup.rs
@@ -1,4 +1,4 @@
-//! Handler for `tm sessions catchup` (DOC-28 cutover bridge, #1762).
+//! Handler for `tm session catchup` (DOC-28 cutover bridge, #1762).
 //!
 //! Why: during migration from claude-mpm to trusty-mpm, paused sessions may
 //! exist in both the legacy JSON format (`.claude-mpm/sessions/`) and the
@@ -27,9 +27,9 @@ use trusty_mpm::core::{
 
 use crate::commands::project::resolve_dir;
 
-/// Handle `tm sessions catchup [--all-projects] [--full]`.
+/// Handle `tm session catchup [--all-projects] [--full]`.
 ///
-/// Why: provides the catch-up entry-point for `tm sessions catchup`.
+/// Why: provides the catch-up entry-point for `tm session catchup`.
 /// What: collects project directories to scan (cwd always included; registry
 /// projects appended when `all_projects` is set), runs the catch-up runtime
 /// (watermark-aware when `full=false`, full history when `full=true`), and

--- a/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
@@ -1,0 +1,206 @@
+//! `session start` handler — protected-path routing (#1916).
+//!
+//! Why: split out of `session.rs` (issue #610 SLOC cap) — the git-repo-detection
+//! branch and the preserved in-place fallback are a cohesive, independently
+//! testable unit.
+//! What: [`start_session`] is the public entry point the `session` dispatcher
+//! calls for `SessionAction::Start`; [`start_session_in_place`] is the
+//! pre-#1916 in-place deploy-and-start behavior, preserved for directories that
+//! are not a recognized git repo.
+//! Test: `session_start_dispatches_managed_new_for_github_repo`,
+//! `session_start_in_place_writes_stash_and_hard_fails_on_daemon_unreachable`
+//! in `start_tests.rs`.
+
+use serde::Deserialize;
+
+use crate::cli::SessionAction;
+use crate::commands::project::resolve_dir;
+
+/// `session start` — launch a session, routed through protected-path segregation
+/// for a recognized GitHub-backed git repo (#1916).
+///
+/// Why: before this fix, `session start` called `prepare_session` directly on
+/// the given/cwd directory and hand-rolled a `POST /sessions` + raw `tmux
+/// new-session`/`send-keys`, completely bypassing the protected-path/managed-
+/// clone routing `session new` uses (`ManagedNew` → `spawn_managed` →
+/// `spawn_managed_inproject`). That meant running `tm session start` inside an
+/// ordinary, non-tm-managed git checkout with a remote wrote tm session
+/// artifacts (statusline config, deployed agents/skills,
+/// `.trusty-mpm/last-instructions.md`) straight into that live checkout — see
+/// issue #1916. The confirmed design directive (2026-07-02): "An in-place start
+/// should pick up git source info, but it's still running in a protected source
+/// tree" — detect project identity from the directory, but launch inside the
+/// SAME protected worktree `session new` already provides.
+/// What: resolves `dir` (defaulting to cwd) and canonicalizes it. When the
+/// resolved directory IS a recognized GitHub-backed git repository — detected
+/// via [`crate::commands::guided::derive_project`], the SAME detector the bare
+/// `tm` guided default uses (#1916 item 3), so the two surfaces can never
+/// diverge on what counts as "protected" — this builds the IDENTICAL
+/// [`SessionAction::New`] request `session new`/`ManagedNew` would receive
+/// (using the git ROOT as `repo` so a subdirectory invocation still resolves
+/// the right project, and an empty `task` for an interactive session, matching
+/// the guided default's `launch_new_session_and_attach`) and dispatches it
+/// through [`crate::commands::managed_route::run`] — the exact code path
+/// `spawn_managed`/`spawn_managed_inproject` serve. When the directory is NOT a
+/// recognized git repo (no `.git`, or a git repo with no parseable remote)
+/// there is no live source tree to protect: this is the same "just run claude
+/// here, no segregation" case `tm connect`'s doc comment documents as
+/// supported, so the original in-place `prepare_session` + detached-tmux-start
+/// behavior ([`start_session_in_place`]) is preserved unchanged.
+/// Test: `session_start_dispatches_managed_new_for_github_repo`,
+/// `session_start_in_place_writes_stash_and_hard_fails_on_daemon_unreachable`
+/// in `start_tests.rs`.
+pub(crate) async fn start_session(
+    client: &reqwest::Client,
+    url: &str,
+    dir: Option<String>,
+) -> anyhow::Result<()> {
+    let path = resolve_dir(dir)?;
+    let path = path.canonicalize().unwrap_or(path);
+
+    if let Some((_source_id, _workspace, git_root)) = crate::commands::guided::derive_project(&path)
+    {
+        // Protected path: dispatch the IDENTICAL request `session new` builds,
+        // through the IDENTICAL chat-core route (`ManagedNew` → `spawn_managed`
+        // → `spawn_managed_inproject` for this in-project local-dir case).
+        let new_action = SessionAction::New {
+            repo: git_root.to_string_lossy().to_string(),
+            git_ref: "HEAD".to_string(),
+            task: String::new(),
+            name_hint: None,
+            runtime: trusty_mpm::runtime::RuntimeKind::default(),
+        };
+        crate::commands::managed_route::run(client, url, &new_action).await?;
+        return Ok(());
+    }
+
+    // Not a recognized git repo (or no parseable remote): no live source tree
+    // to protect — preserve the original in-place deploy-and-start behavior.
+    let fw = trusty_mpm::core::paths::FrameworkPaths::default();
+    start_session_in_place(client, url, &path, &fw).await
+}
+
+/// The pre-#1916 `session start` behavior: deploy `prepare_session` directly
+/// into `path` and start a detached tmux session there.
+///
+/// Why: extracted verbatim from the original `SessionAction::Start` arm so the
+/// non-git / no-remote "just run claude here" case — [`start_session`]'s doc
+/// explains why it remains supported — keeps its exact prior behavior with zero
+/// regression risk. `fw` is threaded in (rather than resolved internally via
+/// `FrameworkPaths::default()`) so tests can supply a hermetic
+/// `FrameworkPaths::under(tempdir)` and exercise this function without writing
+/// into the developer's/CI's real `~/.claude`/`~/.trusty-mpm` — the real CLI
+/// call site in [`start_session`] still passes `FrameworkPaths::default()`, so
+/// production behavior is unchanged.
+/// What: runs `prepare_session` (deploys agents, merges CLAUDE.md, prints the
+/// catch-up digest), registers via `POST /sessions`, then creates a detached
+/// tmux session rooted at `path` and starts `claude` in it.
+/// Test: `session_start_in_place_writes_stash_and_hard_fails_on_daemon_unreachable`
+/// in `start_tests.rs` covers the routing decision hermetically; the tmux/daemon
+/// I/O is exercised by the pre-existing `tests/session_manager_mvp.rs` coverage
+/// this function inherited unchanged.
+async fn start_session_in_place(
+    client: &reqwest::Client,
+    url: &str,
+    path: &std::path::Path,
+    fw: &trusty_mpm::core::paths::FrameworkPaths,
+) -> anyhow::Result<()> {
+    // Prepare the custom instructions Claude Code reads at startup:
+    // deploy composed agents to `~/.claude/agents/` and merge the
+    // project CLAUDE.md. This shared prep is what makes a plain
+    // `claude` process behave as a trusty-mpm session.
+    match trusty_mpm::core::session_launch::prepare_session(fw, path) {
+        Ok(report) => {
+            println!(
+                "Agents: {} deployed, {} skipped, {} unchanged",
+                report.deploy.deployed.len(),
+                report.deploy.skipped.len(),
+                report.deploy.unchanged.len(),
+            );
+            if report.instructions.claude_md_created {
+                println!("  Created CLAUDE.md stub in {}", path.display());
+            }
+            println!(
+                "Instructions: {} agents in delegation authority",
+                report.instructions.agent_count
+            );
+            println!(
+                "  Merged instructions written to {}",
+                report.stash.display()
+            );
+            // DOC-28 cutover bridge: print catch-up digest as seed context.
+            // CUTOVER BRIDGE — remove post-migration (#1762)
+            if let Some(ctx) = report.catchup_context {
+                println!("\n---\n\n## Recent Activity (catch-up)\n\n{ctx}");
+            }
+        }
+        Err(err) => eprintln!("warning: session preparation failed: {err}"),
+    }
+
+    #[derive(Deserialize)]
+    struct Body {
+        #[serde(default)]
+        name: String,
+    }
+    let body: Body = client
+        .post(format!("{url}/sessions"))
+        .json(&serde_json::json!({
+            "project": path,
+            "project_path": path,
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    // The daemon only registers session state now — it no longer
+    // spawns the tmux host (that caused session proliferation). The
+    // CLI owns the actual launch: create a detached tmux session in
+    // the project directory and start `claude` in it.
+    let workdir = path.to_string_lossy().to_string();
+    let new_session = std::process::Command::new("tmux")
+        .args(["new-session", "-d", "-s", &body.name, "-c", &workdir])
+        .status();
+    match new_session {
+        Ok(status) if status.success() => {
+            let send = std::process::Command::new("tmux")
+                .args([
+                    "send-keys",
+                    "-t",
+                    &body.name,
+                    &format!(
+                        "claude {}",
+                        trusty_mpm::core::model_inject::PERMISSION_MODE_FLAG
+                    ),
+                    "Enter",
+                ])
+                .status();
+            match send {
+                Ok(s) if s.success() => {
+                    println!("started session {} (tmux + claude)", body.name);
+                }
+                Ok(_) | Err(_) => {
+                    eprintln!(
+                        "warning: tmux session {} created but failed to start claude",
+                        body.name
+                    );
+                    println!("started session {}", body.name);
+                }
+            }
+        }
+        Ok(_) | Err(_) => {
+            eprintln!(
+                "warning: failed to create tmux session {}; run `claude` manually in {}",
+                body.name, workdir
+            );
+            println!("started session {}", body.name);
+        }
+    }
+    Ok(())
+}
+
+// Unit tests live in session/start_tests.rs (test-file budget: 1500 SLOC).
+#[cfg(test)]
+#[path = "start_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/session/start_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start_tests.rs
@@ -1,0 +1,288 @@
+//! Unit tests for `session start` protected-path routing (#1916).
+//!
+//! Why: the #1916 fix has three behaviors to prove — (1) a recognized
+//! GitHub-backed git repo routes through the managed-spawn code path and
+//! never touches the source directory; (2) a directory that is NOT a
+//! recognized git repo preserves the pre-#1916 in-place behavior; (3) the
+//! `repo_url`/`ref`/`task` fields `session start` sends match the ones the
+//! bare `tm` guided default's "launch new" sends (item 3 of the issue), so
+//! the two entry points can never silently diverge on WHERE/WHAT gets
+//! spawned. All three must be hermetic (no real daemon, no writes into the
+//! developer's/CI's real `~/.claude`/`~/.trusty-mpm`).
+//! What: `session_start_dispatches_managed_new_for_github_repo` drives
+//! [`super::start_session`] end-to-end against a real temp git repo with a
+//! `github.com` origin remote and an intentionally-unreachable daemon URL,
+//! then asserts no tm artifacts were written into the repo.
+//! `session_start_in_place_writes_stash_and_hard_fails_on_daemon_unreachable`
+//! drives [`super::start_session_in_place`] directly with a hermetic
+//! `FrameworkPaths::under(tempdir)` and asserts the pre-#1916 in-place
+//! behavior (writes the instructions stash, hard-fails when the daemon is
+//! unreachable) is preserved unchanged.
+//! `session_start_posts_the_same_wire_shape_bare_tm_guided_default_sends`
+//! captures the real outgoing `POST /api/v1/sessions/managed` body against a
+//! minimal in-process HTTP server and asserts it matches the literal JSON
+//! shape `commands::guided_launch::launch_new_session_and_attach` sends for
+//! bare `tm`'s "launch new" picker choice.
+//! Test: this file IS the test.
+
+use super::{start_session, start_session_in_place};
+
+/// Run `git <args>` in `dir`, panicking with full context on failure.
+///
+/// Why: every test below needs a real (but disposable) git repo; a tiny
+/// helper keeps the setup boilerplate out of the test bodies.
+/// What: shells out to `git -C <dir> <args>` and panics if the exit status is
+/// non-zero.
+/// Test: exercised by every test in this file (setup step).
+fn git(dir: &std::path::Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to run git {args:?}: {e}"));
+    assert!(status.success(), "git {args:?} failed in {}", dir.display());
+}
+
+/// An address nothing listens on, so any HTTP call fails fast (connection
+/// refused) instead of hanging or hitting a real daemon.
+///
+/// Why: both tests need a daemon-unreachable URL; centralising the constant
+/// avoids typo drift between them.
+/// What: `http://127.0.0.1:1` — port 1 is a reserved/never-listened-on port
+/// on every platform these tests run on.
+const UNREACHABLE_URL: &str = "http://127.0.0.1:1";
+
+/// #1916: `session start` inside a recognized GitHub-backed git repo must
+/// route through the SAME protected-path mechanism `session new` uses, and
+/// must NEVER write tm artifacts (statusline config, `.trusty-mpm/`) into the
+/// source directory itself — the exact regression the issue reported.
+///
+/// Why: this is the acceptance criterion from issue #1916 item (a) — proving
+/// the fix without requiring a live daemon. `managed_route::run` soft-fails
+/// (prints a `CommandResult::Error`, returns `Ok(())`) when the daemon is
+/// unreachable, so `start_session` returning `Ok(())` here confirms the
+/// PROTECTED branch was taken (the in-place fallback hard-fails instead — see
+/// the sibling test below) — and the crucial assertion is that the source
+/// directory was never touched.
+/// What: creates a real temp git repo with a `github.com` origin remote (so
+/// `derive_project` recognizes it), calls `start_session` against it with an
+/// unreachable daemon URL, and asserts `.trusty-mpm/` and
+/// `.claude/settings.json` were never created inside the repo.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn session_start_dispatches_managed_new_for_github_repo() {
+    let tmp = tempfile::TempDir::new().expect("tmp repo");
+    let repo = tmp.path();
+    git(repo, &["init", "-q"]);
+    git(
+        repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example-owner/example-repo.git",
+        ],
+    );
+
+    let client = reqwest::Client::new();
+    let result = start_session(
+        &client,
+        UNREACHABLE_URL,
+        Some(repo.to_string_lossy().to_string()),
+    )
+    .await;
+
+    // The managed path never hard-errors on daemon-unreachable (it renders a
+    // `CommandResult::Error` and returns, matching `session new`'s existing
+    // soft-fail behavior via `managed_route::run`) — so `Ok` here proves the
+    // PROTECTED branch was taken, not the in-place fallback (which hard-fails
+    // — see the sibling test).
+    assert!(
+        result.is_ok(),
+        "expected soft-fail Ok from the managed route, got {result:?}"
+    );
+
+    // The #1916 regression this fix closes: no tm artifacts written into the
+    // live source checkout.
+    assert!(
+        !repo.join(".trusty-mpm").exists(),
+        "session start must not write .trusty-mpm/ into a protected GitHub repo"
+    );
+    assert!(
+        !repo.join(".claude").join("settings.json").exists(),
+        "session start must not write .claude/settings.json into a protected GitHub repo"
+    );
+}
+
+/// #1916: a directory that is NOT a recognized git repo has no live source
+/// tree to protect, so `session start` must preserve its pre-#1916 in-place
+/// behavior exactly — deploy `prepare_session` into the directory, then
+/// hard-fail (propagate `Err`) when the daemon is unreachable, matching the
+/// original `?`-propagating `POST /sessions` call.
+///
+/// Why: proves the "just run claude here, no segregation" case ([`start_session`]'s
+/// doc explains why it remains supported — it mirrors what `tm connect`
+/// already documents) was not silently broken by the #1916 routing change.
+/// Calls [`start_session_in_place`] directly with a hermetic
+/// `FrameworkPaths::under(tempdir)` (never `FrameworkPaths::default()`) so the
+/// test cannot write into the developer's/CI's real `~/.claude`/`~/.trusty-mpm`.
+/// What: creates a plain (non-git) temp directory, calls
+/// `start_session_in_place` with an unreachable daemon URL, and asserts (1) it
+/// returns `Err` (the original hard-fail-on-unreachable-daemon behavior) and
+/// (2) `<dir>/.trusty-mpm/last-instructions.md` was written BEFORE the failed
+/// POST — proving `prepare_session` still ran in place.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn session_start_in_place_writes_stash_and_hard_fails_on_daemon_unreachable() {
+    let tmp_home = tempfile::TempDir::new().expect("tmp home");
+    let target = tempfile::TempDir::new().expect("tmp target dir");
+    let fw = trusty_mpm::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    let client = reqwest::Client::new();
+    let result = start_session_in_place(&client, UNREACHABLE_URL, target.path(), &fw).await;
+
+    // Preserves the original in-place `Start` behavior: a daemon-unreachable
+    // `POST /sessions` propagates as a hard `Err` via `?`.
+    assert!(
+        result.is_err(),
+        "in-place start must hard-fail when the daemon is unreachable (pre-#1916 behavior)"
+    );
+
+    // `prepare_session` ran (and wrote its stash) BEFORE the failed POST,
+    // proving the in-place deploy behavior is preserved.
+    assert!(
+        target
+            .path()
+            .join(".trusty-mpm")
+            .join("last-instructions.md")
+            .exists(),
+        "in-place start must still run prepare_session and stash instructions locally"
+    );
+}
+
+/// Start a minimal in-process HTTP server that captures the JSON body of the
+/// first `POST /api/v1/sessions/managed` it receives, then answers with a
+/// well-formed `ManagedSpawnResponse` so the client-side deserialization in
+/// [`super::start_session`]'s protected branch succeeds.
+///
+/// Why: proving the #1916 item-3 "bare `tm` shortcuts to the same protected
+/// flow" claim needs to compare the ACTUAL bytes `session start` puts on the
+/// wire against the literal JSON `guided_launch::launch_new_session_and_attach`
+/// sends — a real (but tiny, hermetic) HTTP listener is the only way to
+/// capture that without depending on an external mocking crate (none is a
+/// dev-dependency of this crate).
+/// What: binds an ephemeral loopback port, serves one `axum` route via a
+/// background task, and returns `(captured, url)` where `captured` is filled
+/// in by the handler once a request lands.
+/// Test: `session_start_posts_the_same_wire_shape_bare_tm_guided_default_sends`.
+async fn spawn_capturing_managed_spawn_server() -> (
+    std::sync::Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+    String,
+) {
+    use axum::{Json, Router, routing::post};
+
+    let captured: std::sync::Arc<std::sync::Mutex<Option<serde_json::Value>>> =
+        std::sync::Arc::default();
+    let captured_for_handler = std::sync::Arc::clone(&captured);
+
+    let handler = move |Json(body): Json<serde_json::Value>| {
+        let captured = std::sync::Arc::clone(&captured_for_handler);
+        async move {
+            *captured.lock().expect("captured mutex poisoned") = Some(body);
+            Json(serde_json::json!({
+                "id": "11111111-1111-1111-1111-111111111111",
+                "name": "tmpm-test-session",
+                "state": "Active",
+                "runtime": "claude-code",
+                "attach_cmd": "tmux attach -t tmpm-test-session",
+            }))
+        }
+    };
+    let router = Router::new().route("/api/v1/sessions/managed", post(handler));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.ok();
+    });
+
+    (captured, format!("http://{addr}"))
+}
+
+/// #1916 item 3: `session start`'s protected-path branch must POST the SAME
+/// `repo_url`/`ref`/`task` values to `POST /api/v1/sessions/managed` that the
+/// bare `tm` guided default's "launch new" picker choice sends via
+/// `commands::guided_launch::launch_new_session_and_attach` — see that
+/// function's `client.post(...).json(&serde_json::json!({ "repo_url":
+/// repo_url, "ref": "HEAD", "task": "" }))` call, which this test's expected
+/// value mirrors literally for those three fields. Proving matching requests
+/// (rather than just "both eventually call `spawn_managed`") is the strongest
+/// guarantee the two entry points cannot silently diverge in the future.
+///
+/// Why: closes the loop on "bare `tm` in a git repo shortcuts to the
+/// (now-fixed) `session start` flow" — both surfaces already funnel through
+/// `POST /api/v1/sessions/managed`, so this test locks in that they do so
+/// with the same `repo_url`/`ref`/`task`.
+/// What: spins up [`spawn_capturing_managed_spawn_server`], calls
+/// `start_session` against a temp GitHub-remote git repo, then asserts the
+/// captured JSON body's `repo_url`/`ref`/`task` equal `<git root>`/`"HEAD"`/
+/// `""`. `session start` additionally sends an explicit `runtime` key (via
+/// `RuntimeKind::default()`, since [`crate::commands::managed_route::to_command`]
+/// always wraps it `Some(...)`) where the guided default omits the key and
+/// lets the daemon apply its own default — both resolve to `claude-code`, so
+/// this is asserted as part of the expected body too, documented as the one
+/// known (semantically inert) spelling difference between the two callers.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn session_start_posts_the_same_wire_shape_bare_tm_guided_default_sends() {
+    let tmp = tempfile::TempDir::new().expect("tmp repo");
+    let repo = tmp.path().canonicalize().expect("canonicalize tmp repo");
+    git(&repo, &["init", "-q"]);
+    git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example-owner/example-repo.git",
+        ],
+    );
+
+    let (captured, url) = spawn_capturing_managed_spawn_server().await;
+
+    let client = reqwest::Client::new();
+    let result = start_session(&client, &url, Some(repo.to_string_lossy().to_string())).await;
+    assert!(
+        result.is_ok(),
+        "expected Ok from a successful spawn, got {result:?}"
+    );
+
+    let body = captured
+        .lock()
+        .expect("captured mutex poisoned")
+        .clone()
+        .expect("session start must have POSTed to /api/v1/sessions/managed");
+
+    // The three fields that decide WHERE and WHAT gets spawned (`repo_url`,
+    // `ref`, `task`) are byte-for-byte the same values
+    // `launch_new_session_and_attach` sends for the equivalent bare-`tm`
+    // "launch new" choice: repo_url = git root, ref = "HEAD", task = "" for
+    // an interactive session. `session start`'s route additionally sends an
+    // explicit `runtime` key (via `RuntimeKind::default()`) where the guided
+    // default omits it and lets the daemon default — semantically identical
+    // (both resolve to `claude-code`), just spelled differently on the wire,
+    // so it is asserted separately below rather than folded into `expected`.
+    let expected = serde_json::json!({
+        "repo_url": repo.to_string_lossy(),
+        "ref": "HEAD",
+        "task": "",
+        "runtime": "claude-code",
+    });
+    assert_eq!(
+        body, expected,
+        "session start's protected-path request must match bare tm's launch_new_session_and_attach wire shape"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/mod.rs
@@ -221,7 +221,7 @@ pub(crate) async fn ticket(
 /// POST the managed-session spawn request that drives the ticket implementation.
 ///
 /// Why: reuses the exact session-manager spawn path (`POST
-/// /api/v1/sessions/managed`) that `tm sessions new` uses, so `tm ticket` plugs
+/// /api/v1/sessions/managed`) that `tm session new` uses, so `tm ticket` plugs
 /// into the existing isolated-workspace + runtime-adapter machinery rather than
 /// re-implementing it. The provisioner clones the repo and the driver agent
 /// creates `branch` off the base ref per the task instructions.

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/dispatch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/dispatch.rs
@@ -128,7 +128,7 @@ pub(crate) async fn dispatch_issue(
 /// POST the managed-session spawn request that drives the issue implementation.
 ///
 /// Why: reuses the exact session-manager spawn path (`POST
-/// /api/v1/sessions/managed`) that `tm ticket` / `tm sessions new` use, so
+/// /api/v1/sessions/managed`) that `tm ticket` / `tm session new` use, so
 /// `tm watch` plugs into the existing isolated-workspace + runtime-adapter
 /// machinery (the P4 workspace root `~/trusty-mpm-projects/<owner>/<repo>/…`)
 /// rather than re-implementing it. The provisioner clones the repo and the driver

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/render.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/render.rs
@@ -112,7 +112,7 @@ pub(crate) fn build_rows(data: &WelcomeData) -> Vec<String> {
     // ── Commands cheat-sheet ──────────────────────────────────────────────────
     rows.push(String::new());
     rows.push("commands".to_string());
-    rows.push("  tm sessions list      tm sessions resume <id>".to_string());
+    rows.push("  tm session list      tm session resume <id>".to_string());
     rows.push("  tm connect            tm stop".to_string());
     rows.push("  tm status             detach: ^b d".to_string());
 
@@ -397,7 +397,7 @@ mod tests {
     fn welcome_panel_contains_commands_cheatsheet() {
         let out = render_welcome_panel(&base_data());
         assert!(
-            out.contains("tm sessions list"),
+            out.contains("tm session list"),
             "expected sessions list command"
         );
         assert!(out.contains("tm connect"), "expected connect command");

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -44,6 +44,10 @@ mod tests_behavior_b;
 #[path = "tests_behavior_c_tests.rs"]
 mod tests_behavior_c;
 
+#[cfg(test)]
+#[path = "tests_behavior_d_tests.rs"]
+mod tests_behavior_d;
+
 /// Lazy-loaded help configuration for "did you mean?" suggestions (issue #216).
 ///
 /// Why: the YAML help bundle is checked in as a string literal; loading it
@@ -367,7 +371,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    // Top-level exit-code translation: a `tm sessions prune-idle` that found the
+    // Top-level exit-code translation: a `tm session prune-idle` that found the
     // Session Manager unavailable returns `PruneError::SmUnavailable`. That is a
     // graceful no-op, not a failure, so exit with the distinct code 75 (the
     // pause skill branches on it) instead of anyhow's default 1. Any other error

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -3,7 +3,10 @@
 //! Why: tests live in dedicated files so main.rs stays thin. This file
 //! covers short-id / banner / formatter tests and the first half of the
 //! CLI parse round-trips. Install / hook / session / services / compose
-//! tests live in `tests_behavior_a.rs` and `tests_behavior_b_tests.rs`.
+//! tests live in `tests_behavior_a.rs` and `tests_behavior_b_tests.rs`; the
+//! managed session-manager verb surface (`session new`/`ls`/`activity`/
+//! `send`/`answer`/`attach`/lifecycle aliases/`prune*`/`catchup`) lives in
+//! `tests_behavior_d_tests.rs` (split out under the #1916 line-cap rebalance).
 //! What: parse round-trips for short_id, banners, daemon, project, session
 //! subcommands (up through daemon flag parsing).
 //! Test: `cargo test -p trusty-mpm` to run all fast tests.
@@ -402,7 +405,7 @@ fn normalize_workdir_strips_trailing_slash() {
 
 #[test]
 fn cli_parses_session_start() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "start"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "start"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Start { dir },
@@ -413,7 +416,7 @@ fn cli_parses_session_start() {
 
 #[test]
 fn cli_parses_session_start_with_dir() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "start", "--dir", "/work/p"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "start", "--dir", "/work/p"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Start { dir },
@@ -424,7 +427,7 @@ fn cli_parses_session_start_with_dir() {
 
 #[test]
 fn cli_parses_session_stop() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "stop", "tmpm-quiet-falcon"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "stop", "tmpm-quiet-falcon"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Stop { id_or_name },
@@ -436,12 +439,12 @@ fn cli_parses_session_stop() {
 #[test]
 fn cli_session_stop_requires_arg() {
     // `session stop` without an id-or-name is an error.
-    assert!(Cli::try_parse_from(["trusty-mpm", "sessions", "stop"]).is_err());
+    assert!(Cli::try_parse_from(["trusty-mpm", "session", "stop"]).is_err());
 }
 
 #[test]
 fn cli_parses_session_list() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "list"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "list"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::List { dir },
@@ -452,7 +455,7 @@ fn cli_parses_session_list() {
 
 #[test]
 fn cli_parses_session_clean() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "clean"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "clean"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Clean { dir },
@@ -463,7 +466,7 @@ fn cli_parses_session_clean() {
 
 #[test]
 fn cli_parses_session_info() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "info", "abc-123"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "info", "abc-123"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Info { id_or_name },
@@ -474,7 +477,7 @@ fn cli_parses_session_info() {
 
 #[test]
 fn cli_parses_session_instructions() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "instructions"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "instructions"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Instructions { dir },
@@ -486,7 +489,7 @@ fn cli_parses_session_instructions() {
 #[test]
 fn cli_parses_session_instructions_with_dir() {
     let cli =
-        Cli::try_parse_from(["trusty-mpm", "sessions", "instructions", "--dir", "/tmp"]).unwrap();
+        Cli::try_parse_from(["trusty-mpm", "session", "instructions", "--dir", "/tmp"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Instructions { dir },
@@ -546,13 +549,13 @@ fn cli_parses_tui_with_interval() {
 
 #[test]
 fn cli_parses_session_tui() {
-    // #1392: the coordinator TUI is the `tm sessions tui` subcommand (renamed
+    // #1392: the coordinator TUI is the `tm session tui` subcommand (renamed
     // from the former top-level `tm coordinator-tui`). Its `--interval-ms`
     // defaults to 1500. The `url` arg carries `env = "TRUSTY_MPM_URL"`, so an
     // ambient `TRUSTY_MPM_URL` in the test runner would override the (absent)
     // default — assert only the env-independent interval default here, and the
     // url plumbing in `cli_parses_session_tui_with_flags`.
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "tui"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "tui"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Tui { interval_ms, .. },
@@ -567,7 +570,7 @@ fn cli_parses_session_tui() {
 fn cli_parses_session_tui_with_flags() {
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "sessions",
+        "session",
         "tui",
         "--url",
         "http://127.0.0.1:9999",
@@ -587,32 +590,27 @@ fn cli_parses_session_tui_with_flags() {
 }
 
 #[test]
-fn cli_parses_sessions_plural() {
-    // #1394: the command group is invoked as the plural `sessions` (matching
-    // the `/api/v1/sessions/*` HTTP API). Assert a representative subcommand
-    // parses under the plural name.
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "list"]).unwrap();
+fn cli_parses_session_singular() {
+    // #1916: the command group was renamed from the plural `sessions` (#1394)
+    // to the singular `session` — `tm` has no external users, so the rename is
+    // clean (no compatibility alias). Assert a representative subcommand
+    // parses under the canonical singular name.
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "list"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::List { dir },
         } => assert_eq!(dir, None),
-        other => panic!("expected sessions list, got {other:?}"),
+        other => panic!("expected session list, got {other:?}"),
     }
 }
 
 #[test]
-fn cli_session_alias_accepts_singular() {
-    // #1841 Fix 2: `session` (singular) is now a visible_alias for `sessions`.
-    // The plural form was the canonical name (#1394), but operators naturally
-    // type the singular. Both must parse identically.
-    let cli = Cli::try_parse_from(["trusty-mpm", "session", "list"])
-        .expect("singular `session` alias must be accepted (#1841)");
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::List { dir },
-        } => assert_eq!(dir, None, "no --dir flag → dir should be None"),
-        other => panic!("expected Session::List via alias, got {other:?}"),
-    }
+fn cli_sessions_plural_no_longer_parses() {
+    // #1916: the old plural spelling `sessions` was retired (not aliased) as
+    // part of the clean rename to `session`. Parsing it must now fail with an
+    // unrecognized-subcommand error, mirroring `cli_rejects_removed_coordinator_tui`.
+    let err = Cli::try_parse_from(["trusty-mpm", "sessions", "list"]).unwrap_err();
+    assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
 }
 
 #[test]
@@ -862,461 +860,6 @@ fn cli_parses_supervisor_flags() {
     }
 }
 
-// ── Session-manager MVP CLI parse tests ─────────────────────────────────────
-
-#[test]
-fn cli_parses_session_new() {
-    let cli = Cli::try_parse_from([
-        "trusty-mpm",
-        "sessions",
-        "new",
-        "https://github.com/owner/repo",
-        "--git-ref",
-        "feat/x",
-        "--task",
-        "do the thing",
-        "--name-hint",
-        "ticket-1",
-    ])
-    .unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action:
-                SessionAction::New {
-                    repo,
-                    git_ref,
-                    task,
-                    name_hint,
-                    runtime,
-                },
-        } => {
-            assert_eq!(repo, "https://github.com/owner/repo");
-            assert_eq!(git_ref, "feat/x");
-            assert_eq!(task, "do the thing");
-            assert_eq!(name_hint.as_deref(), Some("ticket-1"));
-            // No --runtime flag → default claude-code (now a typed RuntimeKind).
-            assert_eq!(runtime, trusty_mpm::runtime::RuntimeKind::ClaudeCode);
-        }
-        other => panic!("expected session new, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_new_with_tcode_runtime() {
-    // Why: #1203 — operators must be able to select the tcode backend via
-    // `--runtime tcode`; this guards the flag wiring on the New subcommand.
-    let cli = Cli::try_parse_from([
-        "trusty-mpm",
-        "sessions",
-        "new",
-        "https://github.com/owner/repo",
-        "--task",
-        "do the thing",
-        "--runtime",
-        "tcode",
-    ])
-    .unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::New { runtime, .. },
-        } => {
-            assert_eq!(runtime, trusty_mpm::runtime::RuntimeKind::Tcode);
-        }
-        other => panic!("expected session new, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_rejects_unknown_runtime_at_parse_time() {
-    // Why: #1213 — `--runtime` is now a clap `ValueEnum`, so an unsupported
-    // backend must fail during argument parsing (with a "possible values" hint)
-    // rather than being forwarded to the daemon and rejected at the HTTP layer.
-    let err = Cli::try_parse_from([
-        "trusty-mpm",
-        "sessions",
-        "new",
-        "https://github.com/owner/repo",
-        "--task",
-        "do the thing",
-        "--runtime",
-        "gpt",
-    ])
-    .expect_err("unknown runtime must be rejected at parse time");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("claude-code") && msg.contains("tcode"),
-        "error must list the supported runtimes: {msg}"
-    );
-}
-
-#[test]
-fn cli_parses_session_ls() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "ls", "--json"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Ls { json, .. },
-        } => assert!(json),
-        other => panic!("expected session ls, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_ls_source_id() {
-    let cli = Cli::try_parse_from([
-        "trusty-mpm",
-        "sessions",
-        "ls",
-        "--source-id",
-        "myorg/myrepo",
-    ])
-    .unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action:
-                SessionAction::Ls {
-                    source_id,
-                    current,
-                    json,
-                    all,
-                },
-        } => {
-            assert_eq!(source_id, Some("myorg/myrepo".to_string()));
-            assert!(!current);
-            assert!(!json);
-            assert!(!all, "--all must default to false");
-        }
-        other => panic!("expected session ls, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_ls_current() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "ls", "--current"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action:
-                SessionAction::Ls {
-                    current,
-                    source_id,
-                    json,
-                    all,
-                },
-        } => {
-            assert!(current);
-            assert!(source_id.is_none());
-            assert!(!json);
-            assert!(!all, "--all must default to false");
-        }
-        other => panic!("expected session ls, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_session_ls_source_id_and_current_conflict() {
-    // --current conflicts_with --source-id: clap must reject both together.
-    let result = Cli::try_parse_from([
-        "trusty-mpm",
-        "sessions",
-        "ls",
-        "--current",
-        "--source-id",
-        "foo/bar",
-    ]);
-    assert!(
-        result.is_err(),
-        "passing both --current and --source-id must be a parse error"
-    );
-}
-
-#[test]
-fn cli_parses_session_ls_all() {
-    // Why (#1809): `--all` must opt in to showing decommissioned tombstones.
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "ls", "--all"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Ls { all, json, .. },
-        } => {
-            assert!(all, "--all flag must parse to true");
-            assert!(!json);
-        }
-        other => panic!("expected session ls --all, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_activity() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "activity", "abc"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Activity { id },
-        } => assert_eq!(id, "abc"),
-        other => panic!("expected session activity, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_send() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "send", "abc", "hello"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Send { id, text },
-        } => {
-            assert_eq!(id, "abc");
-            assert_eq!(text, "hello");
-        }
-        other => panic!("expected session send, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_answer() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "answer", "abc", "rebase"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Answer { id, answer },
-        } => {
-            assert_eq!(id, "abc");
-            assert_eq!(answer, "rebase");
-        }
-        other => panic!("expected session answer, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_attach() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "attach", "abc"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Attach { id },
-        } => assert_eq!(id, "abc"),
-        other => panic!("expected session attach, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_managed_stop() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "managed-stop", "abc"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::ManagedStop { id },
-        } => assert_eq!(id, "abc"),
-        other => panic!("expected session managed-stop, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_runtime_stop() {
-    // The deprecated `runtime-stop` verb still parses (alias of `stop`, #1205).
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "runtime-stop", "abc"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::RuntimeStop { id },
-        } => assert_eq!(id, "abc"),
-        other => panic!("expected session runtime-stop, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_managed_resume() {
-    // The deprecated `managed-resume` verb still parses (alias of `resume`, #1205).
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "managed-resume", "abc"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::ManagedResume { id },
-        } => assert_eq!(id, "abc"),
-        other => panic!("expected session managed-resume, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_stop_verb() {
-    // The canonical `stop` verb parses to the local-session Stop action (#1205);
-    // it shares the clean name the deprecated managed verbs now point at.
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "stop", "abc"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Stop { id_or_name },
-        } => assert_eq!(id_or_name, "abc"),
-        other => panic!("expected session stop, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_resume_verb() {
-    // The canonical `resume` verb parses to the Resume action (#1205).
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "resume", "abc"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Resume { id_or_name },
-        } => assert_eq!(id_or_name, "abc"),
-        other => panic!("expected session resume, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_decommission() {
-    // `decommission` remains the terminal teardown verb (#1205).
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "decommission", "abc"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Decommission { id },
-        } => assert_eq!(id, "abc"),
-        other => panic!("expected session decommission, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_prune_idle() {
-    // `prune-idle` (#1313) accepts both flags; defaults are false.
-    let cli = Cli::try_parse_from([
-        "trusty-mpm",
-        "sessions",
-        "prune-idle",
-        "--dry-run",
-        "--json",
-    ])
-    .unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::PruneIdle { dry_run, json },
-        } => {
-            assert!(dry_run);
-            assert!(json);
-        }
-        other => panic!("expected session prune-idle, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_prune_idle_defaults() {
-    // With no flags, prune-idle defaults to a live (non-dry-run), text run.
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "prune-idle"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::PruneIdle { dry_run, json },
-        } => {
-            assert!(!dry_run);
-            assert!(!json);
-        }
-        other => panic!("expected session prune-idle, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_decommission_ephemeral() {
-    // #1508: the bulk-teardown verb takes no arguments.
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "decommission-ephemeral"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::DecommissionEphemeral,
-        } => {}
-        other => panic!("expected session decommission-ephemeral, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_prune() {
-    // #1508: `prune` requires `--state` and accepts `--dry-run`/`--include-active`.
-    let cli = Cli::try_parse_from([
-        "trusty-mpm",
-        "sessions",
-        "prune",
-        "--state",
-        "stopped",
-        "--dry-run",
-    ])
-    .unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action:
-                SessionAction::Prune {
-                    state,
-                    dry_run,
-                    include_active,
-                },
-        } => {
-            assert_eq!(state, "stopped");
-            assert!(dry_run);
-            assert!(
-                !include_active,
-                "include_active defaults to the fail-closed false"
-            );
-        }
-        other => panic!("expected session prune, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_session_prune_requires_state() {
-    // #1508: `--state` is mandatory — omitting it must be a parse error (the
-    // fail-closed CLI contract; we never default to a destructive filter).
-    let err = Cli::try_parse_from(["trusty-mpm", "sessions", "prune"]);
-    assert!(err.is_err(), "prune without --state must fail to parse");
-}
-
-#[test]
-fn cli_parses_session_prune_worktrees() {
-    // #1840: `prune-worktrees` with no flags defaults to dry-run (force=false).
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "prune-worktrees"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::PruneWorktrees { force },
-        } => {
-            assert!(!force, "default must be dry-run (force=false)");
-        }
-        other => panic!("expected session prune-worktrees, got {other:?}"),
-    }
-    // With --force, actually deletes.
-    let cli2 =
-        Cli::try_parse_from(["trusty-mpm", "sessions", "prune-worktrees", "--force"]).unwrap();
-    match cli2.command.unwrap() {
-        Command::Session {
-            action: SessionAction::PruneWorktrees { force },
-        } => {
-            assert!(force, "--force must set force=true");
-        }
-        other => panic!("expected session prune-worktrees, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_catchup() {
-    // DOC-28 PR1 (#1762): `tm sessions catchup --all-projects --full` must parse
-    // cleanly and deliver the expected field values.
-    let cli = Cli::try_parse_from([
-        "trusty-mpm",
-        "sessions",
-        "catchup",
-        "--all-projects",
-        "--full",
-    ])
-    .unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Catchup { all_projects, full },
-        } => {
-            assert!(all_projects, "--all-projects should be true");
-            assert!(full, "--full should be true");
-        }
-        other => panic!("expected session catchup, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_parses_session_catchup_defaults() {
-    // DOC-28 PR1 (#1762): bare `tm sessions catchup` defaults to false for both flags.
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "catchup"]).unwrap();
-    match cli.command.unwrap() {
-        Command::Session {
-            action: SessionAction::Catchup { all_projects, full },
-        } => {
-            assert!(!all_projects, "--all-projects should default to false");
-            assert!(!full, "--full should default to false");
-        }
-        other => panic!("expected session catchup, got {other:?}"),
-    }
-}
-
 #[test]
 fn deprecation_notice_format() {
     // The deprecation helper renders a stable, single-line message (#1205).
@@ -1360,7 +903,7 @@ fn resolve_managed_target_matches_by_id() {
 #[test]
 fn resolve_managed_target_matches_by_name_returns_id() {
     // A friendly managed name must resolve to the canonical UUID the managed
-    // endpoints require, so `tm sessions stop <name>` works for managed sessions.
+    // endpoints require, so `tm session stop <name>` works for managed sessions.
     use trusty_mpm::client::{ManagedSessionSummary, resolve_target};
     let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
     let sessions: Vec<ManagedSessionSummary> = serde_json::from_value(serde_json::json!([

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
@@ -351,7 +351,7 @@ fn cli_parses_optimizer_set() {
 
 #[test]
 fn cli_parses_session_events() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "events", "abc-123"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "events", "abc-123"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Events { id_or_name },
@@ -362,7 +362,7 @@ fn cli_parses_session_events() {
 
 #[test]
 fn cli_parses_session_breakers() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "breakers"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "breakers"]).unwrap();
     assert!(matches!(
         cli.command.unwrap(),
         Command::Session {
@@ -373,8 +373,7 @@ fn cli_parses_session_breakers() {
 
 #[test]
 fn cli_parses_session_pause() {
-    let cli =
-        Cli::try_parse_from(["trusty-mpm", "sessions", "pause", "tmpm-quiet-falcon"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "pause", "tmpm-quiet-falcon"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Pause { id_or_name, note },
@@ -390,7 +389,7 @@ fn cli_parses_session_pause() {
 fn cli_parses_session_pause_with_note() {
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "sessions",
+        "session",
         "pause",
         "abc-123",
         "--note",
@@ -410,7 +409,7 @@ fn cli_parses_session_pause_with_note() {
 
 #[test]
 fn cli_parses_session_resume() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "resume", "abc-123"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "resume", "abc-123"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Resume { id_or_name },
@@ -421,7 +420,7 @@ fn cli_parses_session_resume() {
 
 #[test]
 fn cli_parses_session_run() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "run", "abc-123", "help me"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "run", "abc-123", "help me"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action:
@@ -443,7 +442,7 @@ fn cli_parses_session_run() {
 fn cli_parses_session_run_with_summarize() {
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "sessions",
+        "session",
         "run",
         "tmpm-abc",
         "help",
@@ -460,7 +459,7 @@ fn cli_parses_session_run_with_summarize() {
 
 #[test]
 fn cli_parses_session_output_defaults() {
-    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "output", "abc-123"]).unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "output", "abc-123"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action:
@@ -482,7 +481,7 @@ fn cli_parses_session_output_defaults() {
 fn cli_parses_session_output_with_lines() {
     let cli = Cli::try_parse_from([
         "trusty-mpm",
-        "sessions",
+        "session",
         "output",
         "abc-123",
         "--lines",
@@ -499,14 +498,8 @@ fn cli_parses_session_output_with_lines() {
 
 #[test]
 fn cli_parses_session_output_with_summarize() {
-    let cli = Cli::try_parse_from([
-        "trusty-mpm",
-        "sessions",
-        "output",
-        "tmpm-abc",
-        "--summarize",
-    ])
-    .unwrap();
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "output", "tmpm-abc", "--summarize"])
+        .unwrap();
     match cli.command.unwrap() {
         Command::Session {
             action: SessionAction::Output { summarize, .. },
@@ -550,12 +543,12 @@ fn compression_stats_line_printed_when_compressed() {
 
 #[test]
 fn cli_session_pause_requires_arg() {
-    assert!(Cli::try_parse_from(["trusty-mpm", "sessions", "pause"]).is_err());
+    assert!(Cli::try_parse_from(["trusty-mpm", "session", "pause"]).is_err());
 }
 
 #[test]
 fn cli_session_run_requires_command() {
-    assert!(Cli::try_parse_from(["trusty-mpm", "sessions", "run", "abc-123"]).is_err());
+    assert!(Cli::try_parse_from(["trusty-mpm", "session", "run", "abc-123"]).is_err());
 }
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -262,7 +262,7 @@ fn cli_parses_services_restart() {
 
 #[test]
 fn compose_session_instructions_display_matches_stash() {
-    // Why: the #382 bug was that `tm sessions instructions` printed
+    // Why: the #382 bug was that `tm session instructions` printed
     // `output.merged` (old pipeline text) while the stash held the
     // override-resolved PM prompt — a visible divergence. After the fix
     // both come from `resolve_pm_prompt`, so they must be identical.
@@ -282,13 +282,13 @@ fn compose_session_instructions_display_matches_stash() {
 
     assert_eq!(
         display, on_disk,
-        "tm sessions instructions display must equal the stash file (issue #382)"
+        "tm session instructions display must equal the stash file (issue #382)"
     );
 }
 
 #[test]
 fn compose_session_instructions_display_matches_live_prompt() {
-    // Why: `tm sessions instructions` must show exactly what `claude` receives
+    // Why: `tm session instructions` must show exactly what `claude` receives
     // via `--append-system-prompt-file`; the live prompt is produced by
     // `build_system_prompt_for`, which calls `resolve_pm_prompt`. If
     // `compose_session_instructions` ever returns something different from
@@ -308,7 +308,7 @@ fn compose_session_instructions_display_matches_live_prompt() {
 
     assert_eq!(
         display, live_prompt,
-        "tm sessions instructions output must match the live launch prompt (issue #382)"
+        "tm session instructions output must match the live launch prompt (issue #382)"
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -445,7 +445,7 @@ fn guided_resume_no_restart_decommissioned() {
 // A zombie is a session whose daemon state is NOT stopped/errored (i.e., active
 // or provisioning) but whose tmux session has disappeared. The daemon's /resume
 // endpoint would return 409 for these — leading to a permanent dead end. The
-// correct recovery is: `tm sessions stop <id>` then `tm` again.
+// correct recovery is: `tm session stop <id>` then `tm` again.
 
 #[test]
 fn guided_resume_is_zombie_active_no_tmux() {

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -1,0 +1,462 @@
+//! CLI parse tests for `tm session new`/`ls`/`activity`/`send`/`answer`/
+//! `attach`/lifecycle-alias/`prune`/`catchup` — the session-manager MVP verb
+//! surface (extracted from `tests.rs`, issue #610 SLOC cap / #1916 line-cap
+//! rebalance after the `sessions`→`session` rename removed an incidental
+//! `/*`-shaped comment substring that had been masking this file's true SLOC
+//! count from `scripts/check_line_cap.sh`).
+//!
+//! Why: `tests.rs` grew past the 1500-SLOC test-file cap once the #1916
+//! rename fix exposed its true size; this is a natural, self-contained slice
+//! (every managed session-manager CLI-parse test) to split out, following the
+//! existing `tests_behavior_a/b/c` convention.
+//! What: parse round-trips for `SessionAction::New`/`Ls`/`Activity`/`Send`/
+//! `Answer`/`Attach`/the deprecated lifecycle aliases/`Prune*`/`Catchup`.
+//! Test: `cargo test -p trusty-mpm` runs this file as part of the `tm` binary
+//! test suite.
+
+use clap::Parser;
+
+use crate::cli::{Cli, Command, SessionAction};
+
+// ── Session-manager MVP CLI parse tests ─────────────────────────────────────
+
+#[test]
+fn cli_parses_session_new() {
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "new",
+        "https://github.com/owner/repo",
+        "--git-ref",
+        "feat/x",
+        "--task",
+        "do the thing",
+        "--name-hint",
+        "ticket-1",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action:
+                SessionAction::New {
+                    repo,
+                    git_ref,
+                    task,
+                    name_hint,
+                    runtime,
+                },
+        } => {
+            assert_eq!(repo, "https://github.com/owner/repo");
+            assert_eq!(git_ref, "feat/x");
+            assert_eq!(task, "do the thing");
+            assert_eq!(name_hint.as_deref(), Some("ticket-1"));
+            // No --runtime flag → default claude-code (now a typed RuntimeKind).
+            assert_eq!(runtime, trusty_mpm::runtime::RuntimeKind::ClaudeCode);
+        }
+        other => panic!("expected session new, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_new_with_tcode_runtime() {
+    // Why: #1203 — operators must be able to select the tcode backend via
+    // `--runtime tcode`; this guards the flag wiring on the New subcommand.
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "new",
+        "https://github.com/owner/repo",
+        "--task",
+        "do the thing",
+        "--runtime",
+        "tcode",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::New { runtime, .. },
+        } => {
+            assert_eq!(runtime, trusty_mpm::runtime::RuntimeKind::Tcode);
+        }
+        other => panic!("expected session new, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_rejects_unknown_runtime_at_parse_time() {
+    // Why: #1213 — `--runtime` is now a clap `ValueEnum`, so an unsupported
+    // backend must fail during argument parsing (with a "possible values" hint)
+    // rather than being forwarded to the daemon and rejected at the HTTP layer.
+    let err = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "new",
+        "https://github.com/owner/repo",
+        "--task",
+        "do the thing",
+        "--runtime",
+        "gpt",
+    ])
+    .expect_err("unknown runtime must be rejected at parse time");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("claude-code") && msg.contains("tcode"),
+        "error must list the supported runtimes: {msg}"
+    );
+}
+
+#[test]
+fn cli_parses_session_ls() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "ls", "--json"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Ls { json, .. },
+        } => assert!(json),
+        other => panic!("expected session ls, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_ls_source_id() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "ls", "--source-id", "myorg/myrepo"])
+        .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action:
+                SessionAction::Ls {
+                    source_id,
+                    current,
+                    json,
+                    all,
+                },
+        } => {
+            assert_eq!(source_id, Some("myorg/myrepo".to_string()));
+            assert!(!current);
+            assert!(!json);
+            assert!(!all, "--all must default to false");
+        }
+        other => panic!("expected session ls, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_ls_current() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "ls", "--current"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action:
+                SessionAction::Ls {
+                    current,
+                    source_id,
+                    json,
+                    all,
+                },
+        } => {
+            assert!(current);
+            assert!(source_id.is_none());
+            assert!(!json);
+            assert!(!all, "--all must default to false");
+        }
+        other => panic!("expected session ls, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_session_ls_source_id_and_current_conflict() {
+    // --current conflicts_with --source-id: clap must reject both together.
+    let result = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "ls",
+        "--current",
+        "--source-id",
+        "foo/bar",
+    ]);
+    assert!(
+        result.is_err(),
+        "passing both --current and --source-id must be a parse error"
+    );
+}
+
+#[test]
+fn cli_parses_session_ls_all() {
+    // Why (#1809): `--all` must opt in to showing decommissioned tombstones.
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "ls", "--all"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Ls { all, json, .. },
+        } => {
+            assert!(all, "--all flag must parse to true");
+            assert!(!json);
+        }
+        other => panic!("expected session ls --all, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_activity() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "activity", "abc"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Activity { id },
+        } => assert_eq!(id, "abc"),
+        other => panic!("expected session activity, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_send() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "send", "abc", "hello"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Send { id, text },
+        } => {
+            assert_eq!(id, "abc");
+            assert_eq!(text, "hello");
+        }
+        other => panic!("expected session send, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_answer() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "answer", "abc", "rebase"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Answer { id, answer },
+        } => {
+            assert_eq!(id, "abc");
+            assert_eq!(answer, "rebase");
+        }
+        other => panic!("expected session answer, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_attach() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "attach", "abc"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Attach { id },
+        } => assert_eq!(id, "abc"),
+        other => panic!("expected session attach, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_managed_stop() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "managed-stop", "abc"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::ManagedStop { id },
+        } => assert_eq!(id, "abc"),
+        other => panic!("expected session managed-stop, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_runtime_stop() {
+    // The deprecated `runtime-stop` verb still parses (alias of `stop`, #1205).
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "runtime-stop", "abc"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::RuntimeStop { id },
+        } => assert_eq!(id, "abc"),
+        other => panic!("expected session runtime-stop, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_managed_resume() {
+    // The deprecated `managed-resume` verb still parses (alias of `resume`, #1205).
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "managed-resume", "abc"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::ManagedResume { id },
+        } => assert_eq!(id, "abc"),
+        other => panic!("expected session managed-resume, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_stop_verb() {
+    // The canonical `stop` verb parses to the local-session Stop action (#1205);
+    // it shares the clean name the deprecated managed verbs now point at.
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "stop", "abc"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Stop { id_or_name },
+        } => assert_eq!(id_or_name, "abc"),
+        other => panic!("expected session stop, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_resume_verb() {
+    // The canonical `resume` verb parses to the Resume action (#1205).
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "resume", "abc"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Resume { id_or_name },
+        } => assert_eq!(id_or_name, "abc"),
+        other => panic!("expected session resume, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_decommission() {
+    // `decommission` remains the terminal teardown verb (#1205).
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "decommission", "abc"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Decommission { id },
+        } => assert_eq!(id, "abc"),
+        other => panic!("expected session decommission, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_prune_idle() {
+    // `prune-idle` (#1313) accepts both flags; defaults are false.
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "prune-idle", "--dry-run", "--json"])
+        .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::PruneIdle { dry_run, json },
+        } => {
+            assert!(dry_run);
+            assert!(json);
+        }
+        other => panic!("expected session prune-idle, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_prune_idle_defaults() {
+    // With no flags, prune-idle defaults to a live (non-dry-run), text run.
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "prune-idle"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::PruneIdle { dry_run, json },
+        } => {
+            assert!(!dry_run);
+            assert!(!json);
+        }
+        other => panic!("expected session prune-idle, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_decommission_ephemeral() {
+    // #1508: the bulk-teardown verb takes no arguments.
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "decommission-ephemeral"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::DecommissionEphemeral,
+        } => {}
+        other => panic!("expected session decommission-ephemeral, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_prune() {
+    // #1508: `prune` requires `--state` and accepts `--dry-run`/`--include-active`.
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "prune",
+        "--state",
+        "stopped",
+        "--dry-run",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action:
+                SessionAction::Prune {
+                    state,
+                    dry_run,
+                    include_active,
+                },
+        } => {
+            assert_eq!(state, "stopped");
+            assert!(dry_run);
+            assert!(
+                !include_active,
+                "include_active defaults to the fail-closed false"
+            );
+        }
+        other => panic!("expected session prune, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_session_prune_requires_state() {
+    // #1508: `--state` is mandatory — omitting it must be a parse error (the
+    // fail-closed CLI contract; we never default to a destructive filter).
+    let err = Cli::try_parse_from(["trusty-mpm", "session", "prune"]);
+    assert!(err.is_err(), "prune without --state must fail to parse");
+}
+
+#[test]
+fn cli_parses_session_prune_worktrees() {
+    // #1840: `prune-worktrees` with no flags defaults to dry-run (force=false).
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "prune-worktrees"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::PruneWorktrees { force },
+        } => {
+            assert!(!force, "default must be dry-run (force=false)");
+        }
+        other => panic!("expected session prune-worktrees, got {other:?}"),
+    }
+    // With --force, actually deletes.
+    let cli2 =
+        Cli::try_parse_from(["trusty-mpm", "session", "prune-worktrees", "--force"]).unwrap();
+    match cli2.command.unwrap() {
+        Command::Session {
+            action: SessionAction::PruneWorktrees { force },
+        } => {
+            assert!(force, "--force must set force=true");
+        }
+        other => panic!("expected session prune-worktrees, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_catchup() {
+    // DOC-28 PR1 (#1762): `tm session catchup --all-projects --full` must parse
+    // cleanly and deliver the expected field values.
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "catchup",
+        "--all-projects",
+        "--full",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Catchup { all_projects, full },
+        } => {
+            assert!(all_projects, "--all-projects should be true");
+            assert!(full, "--full should be true");
+        }
+        other => panic!("expected session catchup, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_catchup_defaults() {
+    // DOC-28 PR1 (#1762): bare `tm session catchup` defaults to false for both flags.
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "catchup"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Catchup { all_projects, full },
+        } => {
+            assert!(!all_projects, "--all-projects should default to false");
+            assert!(!full, "--full should default to false");
+        }
+        other => panic!("expected session catchup, got {other:?}"),
+    }
+}

--- a/crates/trusty-mpm/src/client/http_client/session_connect.rs
+++ b/crates/trusty-mpm/src/client/http_client/session_connect.rs
@@ -19,7 +19,7 @@ impl DaemonClient {
     ///
     /// Why: the TUI's `/connect <dir>` command is the single entry point for
     /// "connect to or launch a session for a project" — when no session exists
-    /// for a directory it must start one, mirroring `tm sessions start`. A
+    /// for a directory it must start one, mirroring `tm session start`. A
     /// trusty-mpm session is always the `claude` (Claude Code) CLI, never
     /// `claude-mpm`; the trusty-mpm behaviour comes from the custom instructions
     /// (deployed agents + project `CLAUDE.md`) prepared before launch.

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -403,7 +403,7 @@ pub struct ManagedSessionSummary {
     pub source_id: Option<String>,
     /// Task description for the session (additive field; absent for legacy records).
     ///
-    /// Why: the `tm sessions ls` table needs a task column to distinguish sessions
+    /// Why: the `tm session ls` table needs a task column to distinguish sessions
     /// without attaching; this mirrors the `SessionRecord::task` field now surfaced
     /// in `SessionSummary`. Old daemon responses without the field deserialize as
     /// `None`.
@@ -411,7 +411,7 @@ pub struct ManagedSessionSummary {
     pub task: Option<String>,
     /// Working directory for the session (additive; absent for legacy records).
     ///
-    /// Why: `tm sessions info` and the ls table need to show where the session is
+    /// Why: `tm session info` and the ls table need to show where the session is
     /// running; this mirrors `SessionRecord::cwd` now surfaced in `SessionSummary`.
     /// Old daemon responses without the field deserialize as `None`.
     #[serde(default)]

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -151,7 +151,7 @@ fn tm_skills_have_frontmatter() {
             "skill {name} contains an unadapted claude-mpm reference"
         );
         // tm-session-management is the one deliberate exception: it documents
-        // `tm sessions catchup`'s real dual-format cutover bridge (#1762),
+        // `tm session catchup`'s real dual-format cutover bridge (#1762),
         // which genuinely reads the legacy `.claude-mpm/sessions/` path
         // alongside the native one — this is accurate, not an unadapted
         // leftover, and the skill explicitly calls it "legacy".

--- a/crates/trusty-mpm/src/core/bundle_tm_skills.rs
+++ b/crates/trusty-mpm/src/core/bundle_tm_skills.rs
@@ -138,7 +138,7 @@ pub const TM_DELEGATION_PATTERNS: &str = include_str!("../assets/skills/tm-deleg
 ///
 /// Why: consolidates mpm-session-management + mpm-session-pause +
 /// mpm-session-resume into one skill; keeps the 70% auto-pause threshold, the
-/// `.trusty-mpm/sessions/` format, `tm sessions prune-worktrees`, and
+/// `.trusty-mpm/sessions/` format, `tm session prune-worktrees`, and
 /// trusty-memory task_add/task_list/task_complete integration.
 /// What: embedded markdown skill file deployed to `skills/tm-session-management.md`.
 /// Test: `tm_skills_are_in_bundle`.

--- a/crates/trusty-mpm/src/core/config.rs
+++ b/crates/trusty-mpm/src/core/config.rs
@@ -226,8 +226,8 @@ pub struct CatchupConfig {
     /// Whether to automatically inject the catch-up digest on session start.
     ///
     /// `true` → catch-up is generated and appended as seed context when a new
-    /// `tm sessions start` is executed. `false` → only the manual
-    /// `tm sessions catchup` command triggers a digest.
+    /// `tm session start` is executed. `false` → only the manual
+    /// `tm session catchup` command triggers a digest.
     pub auto: bool,
     /// Whether to include git commit history in the digest.
     pub include_git: bool,
@@ -464,7 +464,7 @@ impl MpmConfig {
 /// What: evaluates four sources in descending priority order:
 ///
 /// 1. `explicit` — a model string explicitly specified by the caller (e.g.,
-///    from the `tm sessions start --model` flag). If `Some`, wins immediately.
+///    from the `tm session start --model` flag). If `Some`, wins immediately.
 /// 2. `config.models.agents.<agent_name>` — the per-agent override in
 ///    `~/.trusty-mpm/config.toml`.
 /// 3. `frontmatter_model` — the `model:` field from the agent's frontmatter

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -100,7 +100,7 @@ fn read_override(dir: &Path, name: &str) -> Option<String> {
 ///
 /// Why: this is the single source of truth #381 requires — both the live prompt
 /// delivered to `claude` (`--append-system-prompt-file`) and the inspectable
-/// stash (`tm sessions instructions` / `.trusty-mpm/last-instructions.md`) call
+/// stash (`tm session instructions` / `.trusty-mpm/last-instructions.md`) call
 /// it, so the inspectable copy can never diverge from what the PM actually
 /// received (the #382 concern).
 ///

--- a/crates/trusty-mpm/src/core/model_inject.rs
+++ b/crates/trusty-mpm/src/core/model_inject.rs
@@ -4,7 +4,7 @@
 //! trusty-mpm must instead build the `claude` CLI invocation with an explicit
 //! `--model` flag so the resolved model actually takes effect. This module
 //! centralises the command-string construction so every launch path (CLI
-//! `tm launch`, `tm sessions start`, daemon) emits the same correctly-formed
+//! `tm launch`, `tm session start`, daemon) emits the same correctly-formed
 //! command.
 //! What: [`build_claude_command`] composes the full shell string passed to
 //! `tmux send-keys`; it optionally appends `--model <id>` and
@@ -43,7 +43,7 @@ pub fn write_prompt_file(prompt: &str) -> Option<PathBuf> {
 
 /// Resolve the model for a PM-session launch (no named agent).
 ///
-/// Why: the top-level `tm launch` / `tm sessions start` path spawns Claude
+/// Why: the top-level `tm launch` / `tm session start` path spawns Claude
 /// Code as the PM, not as a named specialist agent. The model resolution still
 /// reads from the config (using the special key `"pm"` or the configured
 /// `models.default`) so operators can pin the PM tier.
@@ -74,7 +74,7 @@ pub const SETTING_SOURCES_FLAG: &str = "--setting-sources project,local";
 /// Why: tm runs Claude Code in unattended orchestration mode; `--dangerously-skip-permissions`
 /// allows the session to operate without any permission prompts, which is required
 /// for fully automated multi-agent orchestration where no human is present to approve
-/// individual tool calls. This is appropriate because tm sessions run in provisioned,
+/// individual tool calls. This is appropriate because tm session run in provisioned,
 /// tm-controlled tmux panes under the operator's explicit supervision.
 /// What: the literal flag string appended to every launch command.
 /// Test: `claude_command_includes_permission_mode`.

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -35,7 +35,7 @@ pub(super) const SPINNER_TIPS: &[&str] = &[
     "Delegate Rust code to rust-engineer — PM never edits .rs files",
     "gh issue create to track work; commits include Closes #N",
     "tmux ls shows all active tmpm-<folder> sessions",
-    "tm sessions list shows daemon-managed sessions",
+    "tm session list shows daemon-managed sessions",
     "/compact at ~50% context to stay focused",
     "Layer new features behind the HTTP API before wiring CLI or TUI",
 ];

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -656,7 +656,7 @@ fn inject_trusty_memory_mcp_preserves_existing() {
 #[test]
 #[serial_test::serial]
 fn inject_trusty_memory_mcp_is_idempotent() {
-    // Why: `/connect` and `tm sessions start` may run repeatedly; a second
+    // Why: `/connect` and `tm session start` may run repeatedly; a second
     // injection must not duplicate or alter the `trusty-memory` entry.
     // `#[serial]` + the guard below are required because `resolve_palace_slug`
     // reads the process-global `TRUSTY_MEMORY_PALACE` env var; a sibling serial
@@ -1467,7 +1467,7 @@ fn prepare_session_reports_skill_deploy() {
 
 #[test]
 fn prepare_session_is_idempotent() {
-    // Why: `/connect` and `tm sessions start` may run repeatedly on the same
+    // Why: `/connect` and `tm session start` may run repeatedly on the same
     // project; a second prep must not fail and must not recreate CLAUDE.md.
     // Use a dedicated tmp_home so parallel tests never race on the shared
     // ~/.claude/agents manifest (each test needs its own claude_agents_dir).

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -64,7 +64,7 @@ pub mod prompt;
 pub mod providers;
 /// Idle-session prune policy (issue #1313).
 ///
-/// Why: the `tm sessions prune-idle` command needs a pure, testable mapping from
+/// Why: the `tm session prune-idle` command needs a pure, testable mapping from
 /// a session's latest activity-monitor verdict to a durability-respecting
 /// teardown action (stop idle, decommission done, skip everything else). Keeping
 /// it in core (not the binary) lets it be unit-tested without a live daemon and

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -93,7 +93,7 @@ pub async fn run_doctor(
 /// that were decommissioned before this fix—or where `git worktree remove`
 /// failed—may leave stale `.worktrees/<session-id>/` directories on disk. This
 /// probe surfaces orphaned dirs so operators know to run
-/// `tm sessions prune --worktrees`. The filesystem walk is delegated to
+/// `tm session prune --worktrees`. The filesystem walk is delegated to
 /// [`crate::session_manager::prune::find_orphaned_worktrees`] inside
 /// `spawn_blocking` so the async executor is not blocked by synchronous I/O.
 /// What: builds a canonicalized active-path set, then spawns a blocking task
@@ -147,7 +147,7 @@ async fn check_worktrees(
             "worktrees",
             CheckStatus::Warn,
             format!(
-                "{} orphaned worktree dir(s) found — run `tm sessions prune --worktrees` to remove",
+                "{} orphaned worktree dir(s) found — run `tm session prune --worktrees` to remove",
                 orphans.len()
             ),
         )
@@ -428,6 +428,6 @@ mod tests {
         let check = check_worktrees(Some(root), &active).await;
         assert_eq!(check.status, CheckStatus::Warn);
         assert!(check.message.contains("1 orphaned"));
-        assert!(check.message.contains("tm sessions prune --worktrees"));
+        assert!(check.message.contains("tm session prune --worktrees"));
     }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -448,7 +448,7 @@ async fn spawn_managed_inproject(
     // normalises both SSH and HTTPS forms to the same `{ owner, repo }` pair, and
     // this URL is the real origin of the base clone (it was derived from the
     // operator's local `remote.origin.url`). The record stores it as `repo_url`
-    // which gives `tm sessions ls` useful project context even for in-project
+    // which gives `tm session ls` useful project context even for in-project
     // sessions that did not clone a fresh workspace. It also doubles as the
     // `repo_url` threaded into `prepare_inproject_session` below, for the same
     // trusty-memory palace-pinning reason `provision_in` threads its `repo_url`.

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -591,7 +591,7 @@ async fn orphan_gc_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::Cance
                 // clone otherwise grows without bound (94 dirs observed for one
                 // project) because decommission-time cleanup (#1806/#1840) only
                 // covers sessions torn down AFTER that fix landed and the manual
-                // `tm sessions prune-worktrees` sweep is rarely run. Only leaf
+                // `tm session prune-worktrees` sweep is rarely run. Only leaf
                 // worktree dirs with NO live record are removed — active worktrees
                 // and the base clone are never touched. Inherits the orphan-GC env
                 // gate (`TRUSTY_MPM_ORPHAN_GC`) since it runs inside this loop.

--- a/crates/trusty-mpm/src/mcp/mod.rs
+++ b/crates/trusty-mpm/src/mcp/mod.rs
@@ -123,7 +123,7 @@ pub trait OrchestratorBackend: Send + Sync {
     ///
     /// Why: the driver skill needs a typed, JSON-native way to create an
     ///      isolated, provisioned workspace and launch a harness in it — without
-    ///      scraping `tm sessions new` CLI text (the #842 defect).
+    ///      scraping `tm session new` CLI text (the #842 defect).
     /// What: provisions a workspace cloned from `repo_url` at `git_ref`, creates
     ///       the tmux host, launches the selected `runtime` (default claude-code)
     ///       with `task`, and returns the new session's id / tmux name /

--- a/crates/trusty-mpm/src/runtime/mod.rs
+++ b/crates/trusty-mpm/src/runtime/mod.rs
@@ -107,7 +107,7 @@ pub trait RuntimeAdapter: Send + Sync {
 
 /// Selector for which runtime backend a managed session uses.
 ///
-/// Why: the spawn endpoint and `tm sessions new` let the operator pick a backend
+/// Why: the spawn endpoint and `tm session new` let the operator pick a backend
 /// (`runtime=tcode` / `--runtime tcode`); the choice must survive on the
 /// persisted [`crate::session_manager::SessionRecord`] so `resume` re-spawns the
 /// SAME backend rather than silently reverting to the default.

--- a/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
@@ -23,7 +23,7 @@ use super::tests::FakeTmuxDriver;
 /// disk AND prunes the git worktree metadata + branch ref from the base clone
 /// (#1806).
 ///
-/// Why: #1806 reported that `tm sessions decommission` tombstones the record
+/// Why: #1806 reported that `tm session decommission` tombstones the record
 /// but leaves the on-disk worktree directory behind, requiring a manual
 /// `git worktree remove`. The `workspace_owned = false` + `.worktrees/`
 /// exception (added for #1840/#1845) is unit-tested for the free function

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -52,7 +52,7 @@ pub enum ManagedError {
     Io(#[from] std::io::Error),
 
     /// A name derived from the cwd hint collided with an existing session.
-    #[error("name already in use: {0} — use `tm sessions ls` to find it")]
+    #[error("name already in use: {0} — use `tm session ls` to find it")]
     NameCollision(String),
 
     /// The operation is not valid for the current session state.
@@ -914,7 +914,7 @@ impl SessionManager {
     /// Mark a session as errored with a message.
     ///
     /// Why: when provisioning or spawning fails the session must not remain in
-    /// `Provisioning`; marking it errored surfaces the failure to `tm sessions ls`.
+    /// `Provisioning`; marking it errored surfaces the failure to `tm session ls`.
     /// What: transitions the record to `ManagedSessionState::Errored` and appends
     /// the error message to the task field for observability, then persists.
     /// Test: covered by handler_spawn_wires_provision_and_spawn error path.
@@ -933,7 +933,7 @@ impl SessionManager {
     /// Update a session's workspace path and transition to a new state.
     ///
     /// Why: after `WorkspaceProvisioner::provision` returns the workspace path
-    /// must be persisted so `tm sessions ls` shows it and `activity` can infer
+    /// must be persisted so `tm session ls` shows it and `activity` can infer
     /// context.
     /// What: looks up the record, sets `workspace_path` and `state`, and persists.
     /// Test: covered by handler_spawn_wires_provision_and_spawn.

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -312,7 +312,7 @@ impl SessionManager {
     /// Why: ONE tool must (a) tear down all ephemeral/stopped sessions and (b)
     /// compact the store by dropping decommissioned tombstones, so the legacy 239
     /// stale records can be purged with the SAME verb that cleans up test sessions.
-    /// It is the engine behind `decommission_all_ephemeral`, the `tm sessions prune`
+    /// It is the engine behind `decommission_all_ephemeral`, the `tm session prune`
     /// CLI verb, the prune HTTP route, and the prune MCP tool.
     ///
     /// SAFETY (the #1508 invariant): a RUNNING record (`Active`/`Provisioning`) is
@@ -570,7 +570,7 @@ impl SessionManager {
     /// record set (#1838).
     ///
     /// Why: [`prune_orphaned_worktrees`](Self::prune_orphaned_worktrees) is only
-    /// invoked manually (the `tm sessions prune-worktrees` CLI / HTTP route), so
+    /// invoked manually (the `tm session prune-worktrees` CLI / HTTP route), so
     /// the managed-clone `.worktrees/<id>` tree still grows without bound — one
     /// project accumulated 94 dead worktree dirs because nothing ran the sweep
     /// automatically. This thin convenience wrapper lets the daemon's orphan-GC

--- a/crates/trusty-mpm/src/tui/coordinator/banner.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/banner.rs
@@ -1,6 +1,6 @@
 //! Claude-Code-style startup banner + backplane probes (STUI-0, DOC-16 §3.1).
 //!
-//! Why: operators launching `tm sessions tui` want the same confidence-building
+//! Why: operators launching `tm session tui` want the same confidence-building
 //! startup Claude Code gives — the tool names itself + its version and confirms
 //! the trusty backplane (memory + search) is live before the interactive view
 //! takes over the terminal. DOC-16 §3.1 (STUI-0) pins that contract: a banner

--- a/crates/trusty-mpm/src/tui/coordinator/mod.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/mod.rs
@@ -11,7 +11,7 @@
 //! immediate-re-poll-after-mutation hook (see [`nav`] and
 //! [`state::CoordinatorState::request_repoll`]).
 //! What: thin façade re-exporting the submodules and exposing [`run`], the
-//! `tm sessions tui` entry point. [`run`] polls the daemon's
+//! `tm session tui` entry point. [`run`] polls the daemon's
 //! coordinator-context endpoint on the `--interval-ms` cadence and maps each
 //! session into the live list (see [`poll`]). The daemon-backed `last_summary`
 //! column and slash-command dispatch are deferred to later children; the summary
@@ -90,7 +90,7 @@ const KEY_POLL: Duration = Duration::from_millis(50);
 
 /// Launch the coordinator TUI against `url`, polling every `interval_ms`.
 ///
-/// Why: the `tm sessions tui` subcommand needs one entry point that owns the
+/// Why: the `tm session tui` subcommand needs one entry point that owns the
 /// terminal lifecycle. Now async (Child #2 added live daemon IO) so it runs on
 /// the same tokio runtime as `tui::run`.
 /// What: builds a [`DaemonClient`] for `url`, enters raw mode + the alternate

--- a/crates/trusty-mpm/src/tui/iterm2.rs
+++ b/crates/trusty-mpm/src/tui/iterm2.rs
@@ -5,7 +5,7 @@
 //! process. AppleScript is the most reliable mechanism — no extra deps, works
 //! on every macOS iTerm2 install.
 //! What: `is_iterm2()` checks env vars at startup; `open_session_tab` runs
-//! an `osascript` one-liner that creates a new tab running `tm sessions attach
+//! an `osascript` one-liner that creates a new tab running `tm session attach
 //! <id>`.
 //! Test: Detection logic is pure and unit-tested below; AppleScript calls are
 //! integration-only (no test without a live iTerm2).
@@ -27,7 +27,7 @@ pub fn is_iterm2() -> bool {
     std::path::Path::new("/Applications/iTerm.app").exists()
 }
 
-/// Open a new iTerm2 tab in the current window running `tm sessions attach <session_id>`.
+/// Open a new iTerm2 tab in the current window running `tm session attach <session_id>`.
 ///
 /// Why: The operator can monitor the session list in the TUI while the new tab
 /// runs the actual Claude Code session — no window-switching required.
@@ -39,7 +39,7 @@ pub fn open_session_tab(session_id: &str) -> Result<(), String> {
     let script = format!(
         r#"tell application "iTerm2"
   tell current window
-    create tab with default profile command "tm sessions attach {session_id}"
+    create tab with default profile command "tm session attach {session_id}"
   end tell
 end tell"#
     );

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -1022,7 +1022,7 @@ fn cli_prune_idle_unreachable_exit_code() {
         .args([
             "--url",
             "http://127.0.0.1:1",
-            "sessions",
+            "session",
             "prune-idle",
             "--json",
         ])


### PR DESCRIPTION
## Summary
- `tm session start` (renamed from `tm sessions start`) now routes git-repo-backed directories through the exact same protected-path mechanism as `tm session new` (spawn_managed/spawn_managed_inproject), instead of writing session artifacts directly into the source checkout.
- Confirmed bare `tm`'s existing guided-launch flow already produces a byte-equivalent managed-spawn request — locked in with a new wire-capture test rather than reimplemented.
- Renamed the `sessions` subcommand group to `session` (singular) throughout the CLI, docs, and tests — no back-compat alias (tm has no external users yet).
- Preserved in-place (non-segregated) behavior only for directories that are NOT a recognized git/GitHub repo, matching the documented supported use case.
- Fixed a latent line-cap-checker blind spot uncovered by the rename (an unterminated block-comment substring was silently undercounting a test file's true SLOC).

## Test plan
- [x] cargo build -p trusty-mpm
- [x] cargo test -p trusty-mpm (all passing across 19 test binaries, including new hermetic tests for protected-branch routing, in-place-branch preservation, and CLI rename regression)
- [x] cargo clippy -p trusty-mpm --all-targets -- -D warnings (clean)
- [x] cargo fmt --check (clean)
- [x] bash scripts/check_line_cap.sh (clean, 0 violations)

Closes #1916

🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)