### PR TITLE
fix(trusty-mpm): auto-refresh stale skill source dir, log skill deployment counts

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 
 use crate::cli::SessionAction;
 use crate::commands::project::resolve_dir;
+use crate::formatters::session::deploy_summary_line;
 
 /// `session start` — launch a session, routed through protected-path segregation
 /// for a recognized GitHub-backed git repo (#1916).
@@ -92,7 +93,8 @@ pub(crate) async fn start_session(
 /// into the developer's/CI's real `~/.claude`/`~/.trusty-mpm` — the real CLI
 /// call site in [`start_session`] still passes `FrameworkPaths::default()`, so
 /// production behavior is unchanged.
-/// What: runs `prepare_session` (deploys agents, merges CLAUDE.md, prints the
+/// What: runs `prepare_session` (deploys agents AND skills — printing both
+/// `deploy_summary_line` counts, #1917 — merges CLAUDE.md, prints the
 /// catch-up digest), registers via `POST /sessions`, then creates a detached
 /// tmux session rooted at `path` and starts `claude` in it.
 /// Test: `session_start_in_place_writes_stash_and_hard_fails_on_daemon_unreachable`
@@ -112,10 +114,22 @@ async fn start_session_in_place(
     match trusty_mpm::core::session_launch::prepare_session(fw, path) {
         Ok(report) => {
             println!(
-                "Agents: {} deployed, {} skipped, {} unchanged",
-                report.deploy.deployed.len(),
-                report.deploy.skipped.len(),
-                report.deploy.unchanged.len(),
+                "{}",
+                deploy_summary_line(
+                    "Agents",
+                    report.deploy.deployed.len(),
+                    report.deploy.skipped.len(),
+                    report.deploy.unchanged.len(),
+                )
+            );
+            println!(
+                "{}",
+                deploy_summary_line(
+                    "Skills",
+                    report.skill_deploy.deployed.len(),
+                    report.skill_deploy.skipped.len(),
+                    report.skill_deploy.unchanged.len(),
+                )
             );
             if report.instructions.claude_md_created {
                 println!("  Created CLAUDE.md stub in {}", path.display());

--- a/crates/trusty-mpm/src/bin/tm/formatters/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/session.rs
@@ -3,9 +3,11 @@
 //! Why: session list and event display share compact-output helpers that should
 //! live outside the handler file to keep it below the 500-line cap.
 //! What: `short_id` for UUID truncation, `event_summary` for payload one-liners,
-//! `print_compression_stats` for optimizer feedback.
+//! `print_compression_stats` for optimizer feedback, `deploy_summary_line` for
+//! the agent/skill deploy-count summaries `session start` prints.
 //! Test: `short_id_*` and `event_summary_*` unit tests in `tests.rs`; the
-//! compression stats helper is exercised by `compression_stats_line_*` tests.
+//! compression stats helper is exercised by `compression_stats_line_*` tests;
+//! `deploy_summary_line` by `deploy_summary_line_formats_counts`.
 
 /// Render a `SessionId` newtype JSON value into a short, human id.
 ///
@@ -69,4 +71,22 @@ pub(crate) fn print_compression_stats(body: &serde_json::Value) {
         .checked_div(original)
         .unwrap_or(0);
     println!("\n[summarized: {original} \u{2192} {compressed} bytes ({reduction}% reduction)]");
+}
+
+/// Render a "`<Label>: N deployed, M skipped, K unchanged`" summary line.
+///
+/// Why (#1917): `session start` prints matching three-way deploy summaries
+/// for both agents and skills; a shared formatter keeps the two counts in
+/// lockstep instead of two near-identical `println!` calls drifting apart —
+/// before this fix, only the agent line existed, and `report.skill_deploy`
+/// was silently never surfaced anywhere.
+/// What: formats `"{label}: {deployed} deployed, {skipped} skipped, {unchanged} unchanged"`.
+/// Test: `deploy_summary_line_formats_counts`.
+pub(crate) fn deploy_summary_line(
+    label: &str,
+    deployed: usize,
+    skipped: usize,
+    unchanged: usize,
+) -> String {
+    format!("{label}: {deployed} deployed, {skipped} skipped, {unchanged} unchanged")
 }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -22,7 +22,21 @@ use crate::formatters::banner::{
     fallback_session_name, normalize_workdir, print_launch_banner,
     print_launch_banner_reconnecting, terminal_width,
 };
-use crate::formatters::session::short_id;
+use crate::formatters::session::{deploy_summary_line, short_id};
+
+#[test]
+fn deploy_summary_line_formats_counts() {
+    // #1917: `session start` prints this exact shape for both the Agents and
+    // the (previously missing) Skills deploy summary lines.
+    assert_eq!(
+        deploy_summary_line("Skills", 3, 1, 2),
+        "Skills: 3 deployed, 1 skipped, 2 unchanged"
+    );
+    assert_eq!(
+        deploy_summary_line("Agents", 0, 0, 0),
+        "Agents: 0 deployed, 0 skipped, 0 unchanged"
+    );
+}
 
 #[test]
 fn short_id_extracts_uuid_prefix() {

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -63,6 +63,7 @@ pub mod session_launch;
 pub mod session_store;
 pub mod skill_deployer;
 pub mod skill_manifest;
+pub mod skill_source;
 pub mod sm;
 pub mod stale_skills;
 pub mod standalone;

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -276,6 +276,22 @@ fn prepare_session_inner(
     })
     .map_err(|err| PrepError::Deploy(err.to_string()))?;
 
+    // Self-heal the skill *source* directory before deploying from it
+    // (#1917): `plan.skill_source` falls back to `fw.skill_source_dir()`,
+    // which was previously populated ONLY by a separate, explicit
+    // `tm install` run — a stale or missing directory (e.g. after the
+    // mpm-*→tm-* rename, #1905, or on a machine that never ran `tm install`
+    // under the current binary) made `deploy_skills_filtered` below silently
+    // deploy zero skills, with no error surfaced anywhere. Refreshing here
+    // removes that dependency on a prior manual install; it is a no-op when
+    // the `agents/skills` git submodule is in play (see
+    // `skill_source::ensure_skill_source_fresh`). Non-fatal: a refresh
+    // failure falls back to whatever is already on disk, matching pre-#1917
+    // behaviour rather than blocking the session.
+    if let Err(err) = crate::core::skill_source::ensure_skill_source_fresh(fw) {
+        tracing::warn!("failed to refresh skill source directory: {err}");
+    }
+
     // Deploy skill files — Claude Code reads `~/.claude/skills/` at startup.
     // Skills carry no inheritance, so this is a manifest-tracked content copy;
     // the manifest's skill-set selection restricts WHICH source skills deploy.

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -227,6 +227,56 @@ fn prepare_session_writes_claude_md_and_stash() {
     );
 }
 
+#[test]
+fn prepare_session_self_heals_missing_skill_source() {
+    // #1917: `fw.skills` (the framework skill *source* dir `skill_source_dir()`
+    // falls back to) starts out completely absent here — simulating a machine
+    // that never ran `tm install` under the current binary. Before the fix,
+    // `deploy_skills_filtered` would silently deploy zero skills from an
+    // absent source with no error surfaced anywhere; session prep must now
+    // self-heal it first.
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+    assert!(!fw.skills.exists(), "precondition: no prior tm install ran");
+
+    let report = prepare_session(&fw, project).expect("prep succeeds");
+
+    assert!(
+        !report.skill_deploy.deployed.is_empty(),
+        "session prep must self-heal the missing skill source and deploy at \
+         least one skill; got {:?}",
+        report.skill_deploy
+    );
+    assert!(fw.skills.join("tm-doctor.md").exists());
+}
+
+#[test]
+fn prepare_session_self_heals_renamed_skill_source() {
+    // #1917: a pre-rename `~/.trusty-mpm/framework/skills/` (stale content
+    // left by an old binary, no matching bundle stamp) must be pruned and
+    // refreshed automatically during session prep — not left for a manual
+    // `tm install --force` to notice and fix.
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+    std::fs::create_dir_all(&fw.skills).unwrap();
+    std::fs::write(fw.skills.join("mpm-old-skill.md"), "stale\n").unwrap();
+
+    let report = prepare_session(&fw, project).expect("prep succeeds");
+
+    assert!(
+        !fw.skills.join("mpm-old-skill.md").exists(),
+        "the stale pre-rename file must be pruned during self-heal"
+    );
+    assert!(
+        !report.skill_deploy.deployed.is_empty(),
+        "renamed/stale skill source must self-heal and deploy current skills"
+    );
+}
+
 /// Why (issue #1904 stretch goal): `prepare_session_inner` emits discrete
 /// `provisioning_stage` events (DeployingAgents/DeployingSkills/
 /// BuildingInstructions/ConfiguringMcp) so the daemon's SSE stream can drive

--- a/crates/trusty-mpm/src/core/skill_source.rs
+++ b/crates/trusty-mpm/src/core/skill_source.rs
@@ -1,0 +1,282 @@
+//! Self-healing materialization of the bundled skill *source* directory
+//! (`~/.trusty-mpm/framework/skills/`) — issue #1917.
+//!
+//! Why: [`crate::core::paths::FrameworkPaths::skill_source_dir`] falls back to
+//! `~/.trusty-mpm/framework/skills/` whenever no `agents/skills` git submodule
+//! is checked out — the normal case for every binary-only install. That
+//! directory was previously populated ONLY by the separate, explicit
+//! `tm install` command, which only ever ADDS files: an already-existing one
+//! survives untouched unless the operator passes `--force`
+//! (`install.rs::install_to`). So a skill rename (e.g. the mpm-*→tm-* rename,
+//! #1905) left the OLD file sitting alongside the new one, and a machine that
+//! never ran `tm install` under the current binary at all had an empty or
+//! missing directory. Either way, `deploy_skills_filtered` silently deployed
+//! zero (or stale) skills at session-launch time — no error, no warning,
+//! nothing (#1917). Session preparation must not depend on a prior manual
+//! `tm install` having populated this directory correctly.
+//! What: [`skill_bundle_stamp`] fingerprints the compiled-in `skills/*` slice
+//! of [`bundle::ALL`] via sha256 — `bundle_all.rs` has no existing
+//! version/checksum concept, so this is the marker this module introduces.
+//! [`materialize_skill_artifacts`] writes every bundled skill file into
+//! `paths.skills`, pruning any `.md` file on disk the table no longer lists
+//! (renamed/removed skills). [`ensure_skill_source_fresh`] compares the
+//! current stamp against a marker file written alongside the source
+//! directory and re-materializes it only when they differ (including "never
+//! materialized at all"), so callers can invoke it unconditionally and cheap
+//! on every session-prep run. It deliberately never touches the `agents/skills`
+//! git submodule path — that directory is git-tracked and authoritative on
+//! its own.
+//! Test: `skill_bundle_stamp_is_stable_across_calls`,
+//! `materialize_skill_artifacts_writes_all_skills`,
+//! `materialize_skill_artifacts_prunes_files_not_in_table`,
+//! `ensure_skill_source_fresh_materializes_when_missing`,
+//! `ensure_skill_source_fresh_is_noop_when_current`,
+//! `ensure_skill_source_fresh_prunes_renamed_files`,
+//! `ensure_skill_source_fresh_skips_submodule_source`.
+
+use std::collections::HashSet;
+
+use crate::core::agent_manifest::{atomic_write, checksum};
+use crate::core::bundle;
+use crate::core::error::Result;
+use crate::core::paths::FrameworkPaths;
+
+/// Marker file recording the last-materialized bundle stamp, written
+/// directly under the skill source directory (`paths.skills/.bundle-stamp`).
+const STAMP_FILE_NAME: &str = ".bundle-stamp";
+
+/// Compute a stable sha256 fingerprint over every `skills/*` entry in the
+/// compiled-in [`bundle::ALL`] table.
+///
+/// Why: this fingerprint is how [`ensure_skill_source_fresh`] detects "this
+/// binary embeds different skill content than what is on disk" without
+/// depending on file mtimes, which a plain backup/restore can shuffle.
+/// What: concatenates `<rel_path>\0<contents>\n` for every table entry whose
+/// `rel_path` starts with `"skills/"`, in table order (stable — see
+/// `bundle_tests::bundle_table_is_complete`), and returns the sha256 hex
+/// digest via [`checksum`].
+/// Test: `skill_bundle_stamp_is_stable_across_calls`.
+pub fn skill_bundle_stamp() -> String {
+    let mut buf = String::new();
+    for artifact in bundle::ALL
+        .iter()
+        .filter(|a| a.rel_path.starts_with("skills/"))
+    {
+        buf.push_str(artifact.rel_path);
+        buf.push('\0');
+        buf.push_str(artifact.contents);
+        buf.push('\n');
+    }
+    checksum(&buf)
+}
+
+/// Write every bundled `skills/*` artifact into `paths.skills`, pruning any
+/// top-level `.md` file on disk the current table no longer lists.
+///
+/// Why: `paths.skills` is a framework-owned artifact directory — every entry
+/// in it is written exclusively by trusty-mpm's own installer/self-heal path,
+/// never hand-edited — so it is safe (and necessary, for the renamed-skill
+/// case) to prune files the current binary no longer embeds, not just add new
+/// ones.
+/// What: creates `paths.skills` if absent, atomically (over)writes each
+/// `skills/*` artifact's contents to `<paths.skills>/<basename>` (always,
+/// regardless of prior content — this is the authoritative re-materialization
+/// path, not the user-facing incremental `tm install`), then removes any
+/// existing top-level `*.md` file whose name is not one of the artifacts just
+/// written. Hidden files (leading `.`, e.g. the stamp marker) are never
+/// touched. Returns the basenames written.
+/// Test: `materialize_skill_artifacts_writes_all_skills`,
+/// `materialize_skill_artifacts_prunes_files_not_in_table`.
+pub fn materialize_skill_artifacts(paths: &FrameworkPaths) -> Result<Vec<String>> {
+    std::fs::create_dir_all(&paths.skills)?;
+
+    let mut written = Vec::new();
+    let mut keep: HashSet<String> = HashSet::new();
+    for artifact in bundle::ALL
+        .iter()
+        .filter(|a| a.rel_path.starts_with("skills/"))
+    {
+        let basename = artifact
+            .rel_path
+            .strip_prefix("skills/")
+            .unwrap_or(artifact.rel_path);
+        let dest = paths.skills.join(basename);
+        atomic_write(&dest, artifact.contents)?;
+        keep.insert(basename.to_string());
+        written.push(basename.to_string());
+    }
+
+    for entry in std::fs::read_dir(&paths.skills)? {
+        let entry = entry?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if name.starts_with('.') || !name.ends_with(".md") {
+            continue;
+        }
+        if !keep.contains(&name) {
+            std::fs::remove_file(entry.path())?;
+        }
+    }
+
+    Ok(written)
+}
+
+/// Ensure `paths.skills` reflects the binary's currently-embedded skill
+/// bundle, re-materializing it when missing or stale.
+///
+/// Why: this is the self-healing entry point session preparation calls
+/// before deploying skills (#1917) — it removes the dependency on a prior,
+/// separate `tm install` run having populated (or refreshed) the source
+/// directory.
+/// What: no-ops when [`FrameworkPaths::skill_source_dir`] would resolve to
+/// the `agents/skills` git submodule instead of `paths.skills` (mirrors that
+/// method's own submodule-precedence check) — a populated submodule is
+/// git-tracked and authoritative on its own, so overwriting it here would be
+/// destructive and wrong. Otherwise compares [`skill_bundle_stamp`] against
+/// `<paths.skills>/.bundle-stamp`; when they differ (including "stamp file
+/// absent", which covers a missing or never-materialized directory), calls
+/// [`materialize_skill_artifacts`] and rewrites the stamp file. Returns
+/// `true` when a refresh happened, `false` when the source was already
+/// current or the submodule path is in play.
+/// Test: `ensure_skill_source_fresh_materializes_when_missing`,
+/// `ensure_skill_source_fresh_is_noop_when_current`,
+/// `ensure_skill_source_fresh_prunes_renamed_files`,
+/// `ensure_skill_source_fresh_skips_submodule_source`.
+pub fn ensure_skill_source_fresh(paths: &FrameworkPaths) -> Result<bool> {
+    if paths.skill_source_dir() != paths.skills {
+        return Ok(false);
+    }
+
+    let stamp_path = paths.skills.join(STAMP_FILE_NAME);
+    let current = skill_bundle_stamp();
+    let on_disk = std::fs::read_to_string(&stamp_path).ok();
+    if on_disk.as_deref() == Some(current.as_str()) {
+        return Ok(false);
+    }
+
+    materialize_skill_artifacts(paths)?;
+    atomic_write(&stamp_path, &current)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skill_bundle_stamp_is_stable_across_calls() {
+        // The fingerprint is a pure function of the compiled-in table, so two
+        // calls in the same process must agree.
+        assert_eq!(skill_bundle_stamp(), skill_bundle_stamp());
+    }
+
+    #[test]
+    fn materialize_skill_artifacts_writes_all_skills() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = FrameworkPaths::under(tmp.path());
+
+        let written = materialize_skill_artifacts(&paths).unwrap();
+        let expected: Vec<&str> = bundle::ALL
+            .iter()
+            .filter(|a| a.rel_path.starts_with("skills/"))
+            .map(|a| a.rel_path.strip_prefix("skills/").unwrap())
+            .collect();
+        assert_eq!(written.len(), expected.len());
+        for name in expected {
+            let content = std::fs::read_to_string(paths.skills.join(name))
+                .unwrap_or_else(|e| panic!("missing {name}: {e}"));
+            let artifact = bundle::ALL
+                .iter()
+                .find(|a| a.rel_path == format!("skills/{name}"))
+                .unwrap();
+            assert_eq!(content, artifact.contents);
+        }
+    }
+
+    #[test]
+    fn materialize_skill_artifacts_prunes_files_not_in_table() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = FrameworkPaths::under(tmp.path());
+        std::fs::create_dir_all(&paths.skills).unwrap();
+        // Simulate a leftover pre-rename skill file the current table no
+        // longer lists (e.g. an old `mpm-*.md` under the framework source).
+        std::fs::write(paths.skills.join("mpm-old-skill.md"), "stale\n").unwrap();
+
+        materialize_skill_artifacts(&paths).unwrap();
+
+        assert!(!paths.skills.join("mpm-old-skill.md").exists());
+        assert!(paths.skills.join("tm-doctor.md").exists());
+    }
+
+    #[test]
+    fn ensure_skill_source_fresh_materializes_when_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = FrameworkPaths::under(tmp.path());
+        assert!(!paths.skills.exists());
+
+        let refreshed = ensure_skill_source_fresh(&paths).unwrap();
+
+        assert!(refreshed, "a missing source dir must trigger a refresh");
+        assert!(paths.skills.join("tm-doctor.md").exists());
+        assert!(paths.skills.join(STAMP_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn ensure_skill_source_fresh_is_noop_when_current() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = FrameworkPaths::under(tmp.path());
+        assert!(ensure_skill_source_fresh(&paths).unwrap());
+
+        let marker = paths.skills.join("tm-doctor.md");
+        let before = std::fs::metadata(&marker).unwrap().modified().unwrap();
+
+        let refreshed = ensure_skill_source_fresh(&paths).unwrap();
+
+        assert!(!refreshed, "an already-current source dir must be a no-op");
+        let after = std::fs::metadata(&marker).unwrap().modified().unwrap();
+        assert_eq!(before, after, "a no-op refresh must not rewrite files");
+    }
+
+    #[test]
+    fn ensure_skill_source_fresh_prunes_renamed_files() {
+        // Simulates the exact #1917 symptom: an operator's existing
+        // `~/.trusty-mpm/framework/skills/` predates a skill rename and holds
+        // a stale marker (or none at all) plus a leftover old file.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = FrameworkPaths::under(tmp.path());
+        std::fs::create_dir_all(&paths.skills).unwrap();
+        std::fs::write(paths.skills.join("mpm-old-skill.md"), "stale\n").unwrap();
+        std::fs::write(paths.skills.join(STAMP_FILE_NAME), "stale-stamp").unwrap();
+
+        let refreshed = ensure_skill_source_fresh(&paths).unwrap();
+
+        assert!(refreshed, "a stale stamp must trigger a refresh");
+        assert!(!paths.skills.join("mpm-old-skill.md").exists());
+        assert!(paths.skills.join("tm-doctor.md").exists());
+    }
+
+    #[test]
+    fn ensure_skill_source_fresh_skips_submodule_source() {
+        // When the `agents/skills` git submodule is checked out,
+        // `skill_source_dir()` prefers it over `paths.skills` — the self-heal
+        // path must never materialize into (or even create) `paths.skills`
+        // in that case.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let submodule_root = tempfile::TempDir::new().unwrap();
+        let submodule_skills = submodule_root.path().join("agents").join("skills");
+        std::fs::create_dir_all(&submodule_skills).unwrap();
+
+        let mut paths = FrameworkPaths::under(tmp.path());
+        paths.trusty_mpm_root = Some(submodule_root.path().to_path_buf());
+        assert_eq!(paths.skill_source_dir(), submodule_skills);
+
+        let refreshed = ensure_skill_source_fresh(&paths).unwrap();
+
+        assert!(!refreshed);
+        assert!(
+            !paths.skills.exists(),
+            "must never create paths.skills when a submodule source is in play"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -534,10 +534,12 @@ async fn spawn_managed_inproject(
 /// inlined) so it is unit-testable against a hermetic [`crate::core::paths::FrameworkPaths::under`]
 /// tempdir without touching the operator's real `~/.trusty-mpm`/`~/.claude`.
 /// What: calls `prepare_session_with_repo_url(fw, worktree, Some(repo_url))`.
-/// On success, logs the deployed-agent count. On failure, logs a `tracing::warn!`
-/// and returns — mirroring `WorkspaceProvisioner::provision_in`'s non-fatal
-/// handling of the identical call, so a prep failure never blocks the session
-/// from spawning.
+/// On success, logs the deployed-agent count AND the deployed-skill count
+/// (`report.skill_deploy.deployed.len()` — #1917; previously only the agent
+/// count was logged, so a skill-deploy no-op was invisible here too). On
+/// failure, logs a `tracing::warn!` and returns — mirroring
+/// `WorkspaceProvisioner::provision_in`'s non-fatal handling of the identical
+/// call, so a prep failure never blocks the session from spawning.
 /// Test: `prepare_inproject_session_writes_statusline` in this module's `tests`
 /// submodule.
 fn prepare_inproject_session(
@@ -551,6 +553,7 @@ fn prepare_inproject_session(
             info!(
                 id = %session_id,
                 deployed = report.deploy.deployed.len(),
+                skills_deployed = report.skill_deploy.deployed.len(),
                 worktree = %worktree.display(),
                 "spawn_managed (inproject): session prepared"
             );


### PR DESCRIPTION
## Summary
- Skill deployment was silently no-op-ing whenever the on-disk skill source directory (~/.trusty-mpm/framework/skills/) was stale relative to the running binary's embedded skill bundle (e.g. after the mpm-*→tm-* rename), since it was only ever refreshed by a separate, manual `tm install` step.
- Added a self-healing check: a sha256 fingerprint over the embedded skill bundle, compared against a stamp file on disk, auto-re-materializing (and pruning obsolete files, handling renames) whenever stale — called from session prep, non-fatal on failure.
- Added the previously-missing "Skills: N deployed, N skipped, N unchanged" output alongside the existing "Agents: ..." line, on both the CLI path and the daemon-side in-project spawn logging.
- Rebased onto #1916/PR #1920 (session routing unification) after that merged — session.rs's portion of this change was folded into the new session/start.rs module #1916 introduced; core self-healing logic (skill_source.rs) was unaffected by that merge.

## Test plan
- [x] cargo build -p trusty-mpm
- [x] cargo test -p trusty-mpm (2245+ passing across all binaries, including 7 new skill_source unit tests + 2 self-heal integration tests)
- [x] cargo clippy -p trusty-mpm --all-targets -- -D warnings (clean)
- [x] cargo fmt --check (clean)
- [x] bash scripts/check_line_cap.sh (clean)

Closes #1917

🤖 Generated with Claude Code