### PR TITLE
fix(trusty-mpm): resolve tm statusline to absolute path, heal stale bare entries (closes #1914)

### DIFF
--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -152,17 +152,22 @@ pub fn prepare_session_with_repo_url(
 /// resume is riskier than necessary here — those steps are not all confirmed
 /// idempotent under a resumed (not freshly-provisioned) workspace — so this
 /// exposes ONLY the one step `write_status_line` itself documents as safe to
-/// call unconditionally (it never clobbers an existing key). The resume path
-/// calls this defensively so a session stuck in the pre-#1913 broken state
-/// self-heals the next time it is resumed, without the broader blast radius of
-/// a full re-prep.
+/// call unconditionally (it never clobbers a genuine user customization). The
+/// resume path calls this defensively so a session stuck in the pre-#1913
+/// broken state self-heals the next time it is resumed, without the broader
+/// blast radius of a full re-prep. As of #1914, the same call ALSO upgrades a
+/// stale bare `tm`/`trusty-mpm statusline` command (the pre-#1914 default,
+/// which silently fails to render under a minimal `PATH`) to the resolved
+/// absolute path — the two self-heal concerns share this one entry point
+/// rather than growing a second, duplicate resume hook.
 /// What: thin `pub` wrapper over `settings::write_status_line` (`pub(super)`,
 /// so not directly reachable from `crate::daemon::managed_routes`). Delegates
 /// verbatim — no additional logic.
-/// Test: the underlying idempotency guarantee is covered by
-/// `write_status_line_injects_when_absent` / `write_status_line_skips_when_already_set`
-/// / `write_status_line_preserves_user_config` in this module's test file;
-/// `resume_managed_backfills_missing_status_line` in
+/// Test: the underlying idempotency and path-resolution guarantees are covered
+/// by `write_status_line_injects_when_absent` / `write_status_line_skips_when_already_set`
+/// / `write_status_line_preserves_user_config` / `write_status_line_heals_stale_tm_default`
+/// / `write_status_line_heals_stale_trusty_mpm_default` in this module's test
+/// file; `resume_managed_backfills_missing_status_line` in
 /// `tests/session_manager_mvp.rs` covers the `resume_managed` call site.
 pub fn ensure_status_line(project_dir: &Path) -> Result<(), PrepError> {
     settings::write_status_line(project_dir)

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -682,18 +682,34 @@ pub(super) fn clean_global_trusty_memory_hooks(settings_path: &Path) -> Result<(
     Ok(())
 }
 
-/// Inject `"statusLine": {"type":"command","command":"tm statusline","padding":0}`
-/// into `<project>/.claude/settings.json` when the key is absent.
+/// Inject `"statusLine": {"type":"command","command":"<abs-path> statusline","padding":0}`
+/// into `<project>/.claude/settings.json` when the key is absent, or upgrade a
+/// stale bare `tm`/`trusty-mpm statusline` default already on disk to the
+/// resolved absolute path.
 ///
-/// Why: the `tm statusline` handler renders a compact status bar segment for
-/// every Claude Code render cycle; injecting it at session prep time wires it up
-/// automatically so operators do not have to configure it manually.
-/// What: reads the existing `.claude/settings.json` (or `{}` when absent/invalid),
-/// inserts the `statusLine` key ONLY when it is not already present (never
-/// overwrites the user's existing value), and writes the file back pretty-printed.
+/// Why (#1914, same risk class as #1298's `claude_code.rs::resolve_claude`): a
+/// bare `tm statusline` command relies on the spawning shell's `PATH`
+/// containing wherever `tm` is installed (e.g. `~/.cargo/bin`); under launchd
+/// or Claude Code's minimal environment that PATH omission silently drops the
+/// statusline segment with no error surfaced anywhere. Resolving an absolute
+/// path via [`resolve_statusline_command`] closes that gap the same way
+/// `crate::runtime::claude_code::ClaudeCodeAdapter::resolve_claude` already
+/// does for the `claude` runtime binary. Because every prior version
+/// of this function wrote the exact literal bare string, [`ensure_status_line`]'s
+/// resume self-heal (#1913) can recognise that EXACT fingerprint via
+/// [`is_stale_bare_statusline_command`] and safely upgrade it in place —
+/// without ever touching a genuinely user-customized `statusLine.command`.
+/// What: reads the existing `.claude/settings.json` (or `{}` when absent/invalid).
+/// When `statusLine` is absent, inserts it with the resolved absolute command.
+/// When present and it matches [`is_stale_bare_statusline_command`], rewrites
+/// ONLY its `command` field in place. Any other existing `statusLine` value —
+/// a genuine user customization — is left completely untouched. The file is
+/// written back pretty-printed only when a change was actually made.
 /// Test: `write_status_line_injects_when_absent`,
 /// `write_status_line_skips_when_already_set`,
-/// `write_status_line_preserves_user_config`.
+/// `write_status_line_preserves_user_config`,
+/// `write_status_line_heals_stale_tm_default`,
+/// `write_status_line_heals_stale_trusty_mpm_default`.
 pub(super) fn write_status_line(project_dir: &Path) -> Result<(), PrepError> {
     let claude_dir = project_dir.join(".claude");
     std::fs::create_dir_all(&claude_dir).map_err(|source| PrepError::Io {
@@ -710,14 +726,36 @@ pub(super) fn write_status_line(project_dir: &Path) -> Result<(), PrepError> {
         Some(o) => o,
         None => return Ok(()),
     };
-    // Only inject when absent — never clobber the user's existing statusLine.
-    if obj.contains_key("statusLine") {
+
+    let changed = match obj.get("statusLine") {
+        None => {
+            obj.insert(
+                "statusLine".to_string(),
+                serde_json::json!({
+                    "type": "command",
+                    "command": resolve_statusline_command(),
+                    "padding": 0
+                }),
+            );
+            true
+        }
+        Some(existing) if is_stale_bare_statusline_command(existing) => {
+            let resolved = resolve_statusline_command();
+            obj.get_mut("statusLine")
+                .and_then(serde_json::Value::as_object_mut)
+                .is_some_and(|entry| {
+                    entry.insert("command".to_string(), serde_json::json!(resolved));
+                    true
+                })
+        }
+        // A genuinely user-customized statusLine — never clobber it.
+        Some(_) => false,
+    };
+
+    if !changed {
         return Ok(());
     }
-    obj.insert(
-        "statusLine".to_string(),
-        serde_json::json!({"type": "command", "command": "tm statusline", "padding": 0}),
-    );
+
     let serialized = serde_json::to_string_pretty(&settings)
         .map_err(|err| PrepError::Deploy(err.to_string()))?;
     std::fs::write(&settings_path, serialized).map_err(|source| PrepError::Io {
@@ -725,6 +763,104 @@ pub(super) fn write_status_line(project_dir: &Path) -> Result<(), PrepError> {
         source,
     })?;
     Ok(())
+}
+
+/// The literal `statusLine.command` strings this module has ever auto-injected.
+///
+/// Why: a single source of truth for [`is_stale_bare_statusline_command`] and
+/// its tests keeps the "what counts as our own stale default" fingerprint from
+/// drifting between the two call sites.
+/// What: the bare (no absolute path) commands written before #1914 introduced
+/// path resolution — one per `[[bin]]` name the `trusty-mpm` crate produces.
+pub(super) const KNOWN_BARE_STATUSLINE_COMMANDS: &[&str] =
+    &["tm statusline", "trusty-mpm statusline"];
+
+/// Whether an existing `statusLine` entry is our own previously-injected bare
+/// default, safe for [`write_status_line`] to upgrade in place.
+///
+/// Why (#1914): [`write_status_line`] must never clobber a genuinely
+/// user-customized `statusLine.command`, but a bare `tm statusline` /
+/// `trusty-mpm statusline` written by a pre-#1914 build of this module is not
+/// a user customization — it is stale output of this exact function that
+/// silently breaks under a minimal PATH. Matching the EXACT literal fingerprint
+/// (rather than e.g. "starts with tm") keeps the heuristic conservative: any
+/// command with extra flags, an already-absolute path, or a different binary
+/// name is left alone.
+/// What: returns `true` when `entry.type == "command"` and `entry.command` is
+/// exactly one of [`KNOWN_BARE_STATUSLINE_COMMANDS`] (case-sensitive, no extra
+/// arguments).
+/// Test: `is_stale_bare_statusline_command_matches_known_defaults`,
+/// `is_stale_bare_statusline_command_ignores_custom_command`,
+/// `is_stale_bare_statusline_command_ignores_non_command_type`.
+pub(super) fn is_stale_bare_statusline_command(entry: &serde_json::Value) -> bool {
+    entry.get("type").and_then(serde_json::Value::as_str) == Some("command")
+        && entry
+            .get("command")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|cmd| KNOWN_BARE_STATUSLINE_COMMANDS.contains(&cmd))
+}
+
+/// Resolve the absolute `<binary> statusline` command to write into
+/// `statusLine.command`.
+///
+/// Why (#1914): see [`write_status_line`]'s doc comment for the full
+/// PATH-resolution motivation.
+/// What: appends the `statusline` subcommand to [`resolve_statusline_binary`].
+/// Test: exercised indirectly by `write_status_line_injects_when_absent`
+/// (asserts the written command is an absolute path ending in ` statusline`).
+fn resolve_statusline_command() -> String {
+    format!("{} statusline", resolve_statusline_binary())
+}
+
+/// Resolve the absolute path to the running `tm`/`trusty-mpm` binary.
+///
+/// Why (#1914): [`write_status_line`] always runs INSIDE the `tm`/`trusty-mpm`
+/// process itself — the CLI launch path (`tm session start`) and the daemon
+/// resume path (`ensure_status_line`) are both compiled into that same binary
+/// — so `std::env::current_exe()` is the single most reliable source of truth:
+/// no PATH search needed, the running binary IS the answer. That mirrors, but
+/// is even more direct than, the `bin_resolve::resolve_binary("claude")`
+/// pattern `claude_code.rs` uses for a DIFFERENT binary it does not control.
+/// What: thin wrapper over [`resolve_statusline_binary_with`] using the real
+/// `std::env::current_exe` and [`trusty_common::bin_resolve::resolve_binary`].
+/// Test: exercised indirectly by `write_status_line_injects_when_absent`; the
+/// resolution priority itself is covered by the `resolve_statusline_binary_with_*`
+/// unit tests, which inject fake sources.
+fn resolve_statusline_binary() -> String {
+    resolve_statusline_binary_with(std::env::current_exe, |name| {
+        trusty_common::bin_resolve::resolve_binary(name)
+    })
+}
+
+/// Testable core of [`resolve_statusline_binary`] with its I/O sources injected.
+///
+/// Why: separating the resolution PRIORITY from the actual `current_exe()` /
+/// PATH syscalls lets each branch (current-exe hit, PATH-lookup fallback, bare
+/// last resort) be exercised deterministically, mirroring the
+/// `has_prior_conversation_in` injected-I/O-root pattern used elsewhere in
+/// this crate (`crate::runtime::claude_code`).
+/// What: returns `current_exe()`'s path as a `String` when it resolves to
+/// valid UTF-8; else the first hit of `path_lookup("tm")`; else the literal
+/// `"tm"` so the statusline segment degrades to pre-#1914 behaviour rather
+/// than disappearing outright.
+/// Test: `resolve_statusline_binary_with_prefers_current_exe`,
+/// `resolve_statusline_binary_with_falls_back_to_path_lookup`,
+/// `resolve_statusline_binary_with_falls_back_to_bare_name`.
+pub(super) fn resolve_statusline_binary_with(
+    current_exe: impl Fn() -> std::io::Result<PathBuf>,
+    path_lookup: impl Fn(&str) -> Option<PathBuf>,
+) -> String {
+    if let Ok(exe) = current_exe()
+        && let Some(s) = exe.to_str()
+    {
+        return s.to_string();
+    }
+    if let Some(p) = path_lookup("tm")
+        && let Some(s) = p.to_str()
+    {
+        return s.to_string();
+    }
+    "tm".to_string()
 }
 
 /// Whether a hook handler group is a `trusty-memory` entry.

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -741,12 +741,32 @@ pub(super) fn write_status_line(project_dir: &Path) -> Result<(), PrepError> {
         }
         Some(existing) if is_stale_bare_statusline_command(existing) => {
             let resolved = resolve_statusline_command();
-            obj.get_mut("statusLine")
+            match obj
+                .get_mut("statusLine")
                 .and_then(serde_json::Value::as_object_mut)
-                .is_some_and(|entry| {
+            {
+                Some(entry) => {
                     entry.insert("command".to_string(), serde_json::json!(resolved));
-                    true
-                })
+                }
+                // Defensive (#1914 review finding 2): `is_stale_bare_statusline_command`
+                // only returns `true` for a `serde_json::Value::Object` with matching
+                // `type`/`command` fields, so `as_object_mut` succeeding here is
+                // expected on every real call. If that invariant is ever violated
+                // (e.g. a future refactor of the match guard), replace the entry
+                // wholesale instead of silently leaving the stale/broken value in
+                // place — a silent no-op would defeat the whole point of the heal.
+                None => {
+                    obj.insert(
+                        "statusLine".to_string(),
+                        serde_json::json!({
+                            "type": "command",
+                            "command": resolved,
+                            "padding": 0
+                        }),
+                    );
+                }
+            }
+            true
         }
         // A genuinely user-customized statusLine — never clobber it.
         Some(_) => false,
@@ -812,24 +832,40 @@ fn resolve_statusline_command() -> String {
     format!("{} statusline", resolve_statusline_binary())
 }
 
+/// The `[[bin]]` names this crate's `Cargo.toml` produces, in fallback order.
+///
+/// Why (#1914 review, trusty-review PR #1925 finding 1): a machine that only
+/// has `trusty-mpm` on `PATH` (not the `tm` alias) must still resolve when
+/// `current_exe()` is unavailable — falling back to a single hardcoded "tm"
+/// PATH lookup reproduced the exact bug this module fixes for that installed
+/// name. Both entries are tried, in order, before degrading to the bare
+/// literal.
+const STATUSLINE_BIN_NAMES: &[&str] = &["tm", "trusty-mpm"];
+
 /// Resolve the absolute path to the running `tm`/`trusty-mpm` binary.
 ///
 /// Why (#1914): [`write_status_line`] always runs INSIDE the `tm`/`trusty-mpm`
 /// process itself — the CLI launch path (`tm session start`) and the daemon
 /// resume path (`ensure_status_line`) are both compiled into that same binary
 /// — so `std::env::current_exe()` is the single most reliable source of truth:
-/// no PATH search needed, the running binary IS the answer. That mirrors, but
-/// is even more direct than, the `bin_resolve::resolve_binary("claude")`
-/// pattern `claude_code.rs` uses for a DIFFERENT binary it does not control.
+/// no PATH search needed, the running binary IS the answer. `current_exe()`
+/// does not guarantee a canonical (symlink-free) path, so the result is
+/// canonicalized best-effort — falling back to the raw path when
+/// canonicalization fails (e.g. the exe was deleted/moved since spawn) rather
+/// than losing the resolution entirely. This mirrors, but is even more direct
+/// than, the `bin_resolve::resolve_binary("claude")` pattern `claude_code.rs`
+/// uses for a DIFFERENT binary it does not control.
 /// What: thin wrapper over [`resolve_statusline_binary_with`] using the real
-/// `std::env::current_exe` and [`trusty_common::bin_resolve::resolve_binary`].
+/// `std::env::current_exe` (canonicalized best-effort) and
+/// [`trusty_common::bin_resolve::resolve_binary`].
 /// Test: exercised indirectly by `write_status_line_injects_when_absent`; the
 /// resolution priority itself is covered by the `resolve_statusline_binary_with_*`
 /// unit tests, which inject fake sources.
 fn resolve_statusline_binary() -> String {
-    resolve_statusline_binary_with(std::env::current_exe, |name| {
-        trusty_common::bin_resolve::resolve_binary(name)
-    })
+    resolve_statusline_binary_with(
+        || std::env::current_exe().map(|exe| exe.canonicalize().unwrap_or(exe)),
+        trusty_common::bin_resolve::resolve_binary,
+    )
 }
 
 /// Testable core of [`resolve_statusline_binary`] with its I/O sources injected.
@@ -840,11 +876,14 @@ fn resolve_statusline_binary() -> String {
 /// `has_prior_conversation_in` injected-I/O-root pattern used elsewhere in
 /// this crate (`crate::runtime::claude_code`).
 /// What: returns `current_exe()`'s path as a `String` when it resolves to
-/// valid UTF-8; else the first hit of `path_lookup("tm")`; else the literal
-/// `"tm"` so the statusline segment degrades to pre-#1914 behaviour rather
-/// than disappearing outright.
+/// valid UTF-8; else the first hit of `path_lookup` over [`STATUSLINE_BIN_NAMES`]
+/// (`"tm"` then `"trusty-mpm"` — #1914 review finding 1: a bare single-name
+/// PATH lookup reproduces the original bug on a `trusty-mpm`-only install);
+/// else the literal `"tm"` so the statusline segment degrades to pre-#1914
+/// behaviour rather than disappearing outright.
 /// Test: `resolve_statusline_binary_with_prefers_current_exe`,
 /// `resolve_statusline_binary_with_falls_back_to_path_lookup`,
+/// `resolve_statusline_binary_with_falls_back_to_trusty_mpm_name`,
 /// `resolve_statusline_binary_with_falls_back_to_bare_name`.
 pub(super) fn resolve_statusline_binary_with(
     current_exe: impl Fn() -> std::io::Result<PathBuf>,
@@ -855,7 +894,9 @@ pub(super) fn resolve_statusline_binary_with(
     {
         return s.to_string();
     }
-    if let Some(p) = path_lookup("tm")
+    if let Some(p) = STATUSLINE_BIN_NAMES
+        .iter()
+        .find_map(|name| path_lookup(name))
         && let Some(s) = p.to_str()
     {
         return s.to_string();

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -3,8 +3,8 @@ use super::search_index::{
 };
 use super::settings::{
     clean_global_trusty_memory_hooks, deploy_output_style, inject_trusty_memory_mcp,
-    preseed_workspace_trust, trusty_memory_mcp_value, write_output_style, write_project_hooks,
-    write_status_line,
+    is_stale_bare_statusline_command, preseed_workspace_trust, resolve_statusline_binary_with,
+    trusty_memory_mcp_value, write_output_style, write_project_hooks, write_status_line,
 };
 use super::*;
 use tempfile::tempdir;
@@ -1742,24 +1742,35 @@ fn prepare_session_config_style_overrides_manifest() {
 
 // ── write_status_line tests ───────────────────────────────────────────────────
 
+/// Assert `cmd` is `"<absolute-path> statusline"` where the path is exactly
+/// the current test binary's `current_exe()` (#1914: `write_status_line`
+/// prefers `current_exe()` over a bare command).
+fn assert_resolved_statusline_command(cmd: &str) {
+    let exe = std::env::current_exe().expect("current_exe resolvable in test process");
+    let expected = format!("{} statusline", exe.to_str().expect("utf8 test exe path"));
+    assert_eq!(
+        cmd, expected,
+        "command must be '<current_exe> statusline', got {cmd}"
+    );
+}
+
 #[test]
 fn write_status_line_injects_when_absent() {
-    // When no settings.json exists, write_status_line creates it with statusLine.
+    // When no settings.json exists, write_status_line creates it with statusLine
+    // resolved to the absolute current-exe path (#1914), not a bare command.
     let tmp = tempdir().unwrap();
     write_status_line(tmp.path()).expect("write succeeds");
     let raw = std::fs::read_to_string(tmp.path().join(".claude").join("settings.json")).unwrap();
     let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
     assert_eq!(v["statusLine"]["type"], "command", "type must be command");
-    assert_eq!(
-        v["statusLine"]["command"], "tm statusline",
-        "command must be tm statusline"
-    );
+    assert_resolved_statusline_command(v["statusLine"]["command"].as_str().unwrap());
     assert_eq!(v["statusLine"]["padding"], 0, "padding must be 0");
 }
 
 #[test]
 fn write_status_line_skips_when_already_set() {
-    // When statusLine already exists, write_status_line must not overwrite it.
+    // When statusLine already exists (a genuine user customization), write_status_line
+    // must not overwrite it.
     let tmp = tempdir().unwrap();
     let claude_dir = tmp.path().join(".claude");
     std::fs::create_dir_all(&claude_dir).unwrap();
@@ -1799,8 +1810,120 @@ fn write_status_line_preserves_user_config() {
         "outputStyle must be preserved"
     );
     assert_eq!(v["someKey"], true, "arbitrary keys must be preserved");
+    assert_resolved_statusline_command(v["statusLine"]["command"].as_str().unwrap());
+}
+
+#[test]
+fn write_status_line_heals_stale_tm_default() {
+    // #1914 self-heal: a pre-#1914 bare "tm statusline" default on disk (the
+    // literal fingerprint this module used to write) is upgraded IN PLACE to
+    // the resolved absolute path, so `ensure_status_line`'s resume self-heal
+    // (#1913) also fixes the PATH-resolution risk without a separate hook.
+    let tmp = tempdir().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    std::fs::create_dir_all(&claude_dir).unwrap();
+    let existing = serde_json::json!({"statusLine": {"type": "command", "command": "tm statusline", "padding": 0}});
+    std::fs::write(
+        claude_dir.join("settings.json"),
+        serde_json::to_string_pretty(&existing).unwrap(),
+    )
+    .unwrap();
+    write_status_line(tmp.path()).expect("write succeeds");
+    let raw = std::fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_resolved_statusline_command(v["statusLine"]["command"].as_str().unwrap());
     assert_eq!(
-        v["statusLine"]["command"], "tm statusline",
-        "statusLine must be injected"
+        v["statusLine"]["padding"], 0,
+        "padding must survive the in-place upgrade"
+    );
+}
+
+#[test]
+fn write_status_line_heals_stale_trusty_mpm_default() {
+    // Same self-heal, exercised against the `trusty-mpm` binary-name fingerprint
+    // (the second `[[bin]]` this crate produces).
+    let tmp = tempdir().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    std::fs::create_dir_all(&claude_dir).unwrap();
+    let existing = serde_json::json!({
+        "statusLine": {"type": "command", "command": "trusty-mpm statusline", "padding": 0}
+    });
+    std::fs::write(
+        claude_dir.join("settings.json"),
+        serde_json::to_string_pretty(&existing).unwrap(),
+    )
+    .unwrap();
+    write_status_line(tmp.path()).expect("write succeeds");
+    let raw = std::fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_resolved_statusline_command(v["statusLine"]["command"].as_str().unwrap());
+}
+
+// ── is_stale_bare_statusline_command tests ────────────────────────────────────
+
+#[test]
+fn is_stale_bare_statusline_command_matches_known_defaults() {
+    assert!(is_stale_bare_statusline_command(
+        &serde_json::json!({"type": "command", "command": "tm statusline"})
+    ));
+    assert!(is_stale_bare_statusline_command(
+        &serde_json::json!({"type": "command", "command": "trusty-mpm statusline"})
+    ));
+}
+
+#[test]
+fn is_stale_bare_statusline_command_ignores_custom_command() {
+    // A user's own custom command must never be flagged for in-place upgrade,
+    // even if it happens to invoke `tm` with extra arguments.
+    assert!(!is_stale_bare_statusline_command(
+        &serde_json::json!({"type": "command", "command": "tm statusline --compact"})
+    ));
+    assert!(!is_stale_bare_statusline_command(
+        &serde_json::json!({"type": "command", "command": "my custom cmd"})
+    ));
+    assert!(!is_stale_bare_statusline_command(
+        &serde_json::json!({"type": "command", "command": "/opt/homebrew/bin/tm statusline"})
+    ));
+}
+
+#[test]
+fn is_stale_bare_statusline_command_ignores_non_command_type() {
+    assert!(!is_stale_bare_statusline_command(
+        &serde_json::json!({"type": "text", "command": "tm statusline"})
+    ));
+}
+
+// ── resolve_statusline_binary_with tests ──────────────────────────────────────
+
+#[test]
+fn resolve_statusline_binary_with_prefers_current_exe() {
+    let resolved = resolve_statusline_binary_with(
+        || Ok(PathBuf::from("/abs/path/to/tm")),
+        |_name| Some(PathBuf::from("/should/not/be/used/tm")),
+    );
+    assert_eq!(resolved, "/abs/path/to/tm");
+}
+
+#[test]
+fn resolve_statusline_binary_with_falls_back_to_path_lookup() {
+    let resolved = resolve_statusline_binary_with(
+        || Err(std::io::Error::other("current_exe unavailable")),
+        |name| {
+            assert_eq!(name, "tm", "path lookup must search for the bare 'tm' name");
+            Some(PathBuf::from("/opt/homebrew/bin/tm"))
+        },
+    );
+    assert_eq!(resolved, "/opt/homebrew/bin/tm");
+}
+
+#[test]
+fn resolve_statusline_binary_with_falls_back_to_bare_name() {
+    let resolved = resolve_statusline_binary_with(
+        || Err(std::io::Error::other("current_exe unavailable")),
+        |_name| None,
+    );
+    assert_eq!(
+        resolved, "tm",
+        "must degrade to the bare literal when both sources fail"
     );
 }

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -1745,8 +1745,16 @@ fn prepare_session_config_style_overrides_manifest() {
 /// Assert `cmd` is `"<absolute-path> statusline"` where the path is exactly
 /// the current test binary's `current_exe()` (#1914: `write_status_line`
 /// prefers `current_exe()` over a bare command).
+///
+/// Why the `canonicalize()` call: `resolve_statusline_binary` canonicalizes
+/// `current_exe()` best-effort (symlink resolution, #1914 review finding 1)
+/// before returning it, so the expected value here must apply the identical
+/// transform — otherwise this assertion would be flaky on any platform where
+/// the test binary's path traverses a symlink (e.g. macOS `/tmp` ->
+/// `/private/tmp`).
 fn assert_resolved_statusline_command(cmd: &str) {
     let exe = std::env::current_exe().expect("current_exe resolvable in test process");
+    let exe = exe.canonicalize().unwrap_or(exe);
     let expected = format!("{} statusline", exe.to_str().expect("utf8 test exe path"));
     assert_eq!(
         cmd, expected,
@@ -1792,11 +1800,20 @@ fn write_status_line_skips_when_already_set() {
 
 #[test]
 fn write_status_line_preserves_user_config() {
-    // Existing keys in settings.json must survive the write_status_line call.
+    // #1914 review finding 3: this test must seed a GENUINELY custom
+    // statusLine.command (not one of the bare defaults write_status_line
+    // itself would have written) so it actually exercises "leave user
+    // customizations alone", rather than the absent-key injection path
+    // covered separately by `write_status_line_injects_when_absent` or the
+    // stale-default heal path covered by `write_status_line_heals_stale_*`.
     let tmp = tempdir().unwrap();
     let claude_dir = tmp.path().join(".claude");
     std::fs::create_dir_all(&claude_dir).unwrap();
-    let existing = serde_json::json!({"outputStyle": "trusty-mpm-research", "someKey": true});
+    let existing = serde_json::json!({
+        "outputStyle": "trusty-mpm-research",
+        "someKey": true,
+        "statusLine": {"type": "command", "command": "my-custom-statusline", "padding": 2}
+    });
     std::fs::write(
         claude_dir.join("settings.json"),
         serde_json::to_string_pretty(&existing).unwrap(),
@@ -1810,7 +1827,14 @@ fn write_status_line_preserves_user_config() {
         "outputStyle must be preserved"
     );
     assert_eq!(v["someKey"], true, "arbitrary keys must be preserved");
-    assert_resolved_statusline_command(v["statusLine"]["command"].as_str().unwrap());
+    assert_eq!(
+        v["statusLine"]["command"], "my-custom-statusline",
+        "a genuinely custom statusLine.command must never be overwritten"
+    );
+    assert_eq!(
+        v["statusLine"]["padding"], 2,
+        "the rest of a custom statusLine entry must also survive untouched"
+    );
 }
 
 #[test]
@@ -1914,6 +1938,23 @@ fn resolve_statusline_binary_with_falls_back_to_path_lookup() {
         },
     );
     assert_eq!(resolved, "/opt/homebrew/bin/tm");
+}
+
+#[test]
+fn resolve_statusline_binary_with_falls_back_to_trusty_mpm_name() {
+    // #1914 review finding 1: a machine with ONLY `trusty-mpm` on PATH (not
+    // the `tm` alias) must still resolve when current_exe() is unavailable —
+    // a bare single-name "tm" PATH lookup would silently degrade to the bare
+    // literal here, reproducing the exact bug this module fixes.
+    let resolved = resolve_statusline_binary_with(
+        || Err(std::io::Error::other("current_exe unavailable")),
+        |name| match name {
+            "tm" => None,
+            "trusty-mpm" => Some(PathBuf::from("/opt/homebrew/bin/trusty-mpm")),
+            other => panic!("unexpected binary name looked up: {other}"),
+        },
+    );
+    assert_eq!(resolved, "/opt/homebrew/bin/trusty-mpm");
 }
 
 #[test]

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -886,6 +886,84 @@ async fn resume_managed_backfills_missing_status_line() {
     );
 }
 
+/// #1914 self-heal: `resume_managed` must also upgrade a STALE bare
+/// `tm statusline` command already on disk to an absolute path, not just
+/// backfill a missing key.
+///
+/// Why: a workspace prepared by a pre-#1914 build wrote the literal bare
+/// string `"tm statusline"`, which silently fails to render under a minimal
+/// `PATH` (e.g. launchd, Claude Code's own spawn environment). This extends
+/// the SAME resume self-heal entry point `resume_managed_backfills_missing_status_line`
+/// exercises (`ensure_status_line` → `write_status_line`) rather than adding a
+/// second hook, so both self-heal concerns land through one code path.
+/// What: seeds a workspace whose `.claude/settings.json` already has the exact
+/// pre-#1914 bare `statusLine.command`, resumes it, and asserts the on-disk
+/// command is no longer the bare literal (it now carries a `/`, i.e. an
+/// absolute path).
+/// Test: this function IS the test.
+#[tokio::test]
+async fn resume_managed_heals_stale_bare_status_line_command() {
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+    let mgr = state.session_manager().await;
+
+    let id = ResumeSessionId::new();
+    let ws = root.path().join(format!("{id}-stale-heal-ws"));
+    let claude_dir = ws.join(".claude");
+    std::fs::create_dir_all(&claude_dir).expect("create .claude dir");
+    std::fs::write(
+        claude_dir.join("settings.json"),
+        serde_json::json!({
+            "statusLine": {"type": "command", "command": "tm statusline", "padding": 0}
+        })
+        .to_string(),
+    )
+    .expect("seed pre-#1914 bare statusLine");
+
+    let _seeded = mgr
+        .create_with_id(
+            id,
+            "regression: stale bare statusline self-heal on resume".to_string(),
+            Some(ws.clone()),
+            None,
+            Some(ws.clone()),
+            Some("https://github.com/owner/repo".to_string()),
+            Some("main".to_string()),
+            ResumeRuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session");
+
+    mgr.stop(&id).await.expect("stop");
+    let _ = resume_managed(&state, &id).await;
+
+    let settings_path = claude_dir.join("settings.json");
+    let content = std::fs::read_to_string(&settings_path).unwrap_or_else(|e| {
+        panic!(
+            "resume_managed must rewrite {}: {e}",
+            settings_path.display()
+        )
+    });
+    let value: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
+    let command = value["statusLine"]["command"]
+        .as_str()
+        .expect("statusLine.command is a string");
+    assert_ne!(
+        command, "tm statusline",
+        "the stale bare command must be upgraded, not left as-is; got: {content}"
+    );
+    assert!(
+        command.contains('/'),
+        "the healed command must resolve to an absolute path; got: {command}"
+    );
+    assert!(
+        command.ends_with(" statusline"),
+        "the healed command must still invoke the statusline subcommand; got: {command}"
+    );
+}
+
 /// FRONT gate (#1360, AC-15): the withheld spawn launches after human approval.
 ///
 /// Why: a session escalated by the FRONT gate sits in `Provisioning` with no


### PR DESCRIPTION
## Summary

- `write_status_line` (`crates/trusty-mpm/src/core/session_launch/settings.rs`) previously injected the literal bare string `"tm statusline"` into `.claude/settings.json`'s `statusLine.command`. A bare command relies on the invoking shell's `PATH` containing wherever `tm` is installed (e.g. `~/.cargo/bin`); under launchd or Claude Code's own minimal spawn environment that PATH omission silently drops the statusline segment with no error surfaced anywhere — the same risk class already fixed for the `claude` runtime binary in #1298.
- `write_status_line` now resolves an absolute path via `std::env::current_exe()` first (the process calling this function IS the `tm`/`trusty-mpm` binary itself, both the CLI launch path and the daemon resume path), falls back to `trusty_common::bin_resolve::resolve_binary("tm")` (PATH + well-known-dir lookup, same helper `claude_code.rs` uses for `claude`), and finally degrades to the bare literal `"tm"` as a last resort so the statusline segment never disappears outright.
- Extended the existing #1913/#1915 resume self-heal (`ensure_status_line`, called by `resume_managed` on every resume) so it ALSO upgrades a stale bare `tm statusline` / `trusty-mpm statusline` entry already on disk to the resolved absolute path — recognized via an exact literal fingerprint (`is_stale_bare_statusline_command`) so a genuinely user-customized `statusLine.command` is never touched. Both self-heal concerns (#1913's missing-key backfill and #1914's PATH-resolution upgrade) now share the one `write_status_line` entry point instead of growing a second, duplicate resume hook.

## Root cause

`write_status_line` always wrote the literal string `"tm statusline"` with no path resolution, on the (false) assumption that the spawning shell's `PATH` always contains `tm`. Discovered as a side-finding during #1913, following the established #1298 precedent for the `claude` binary.

## Fix

- New `resolve_statusline_command()` / `resolve_statusline_binary()` / `resolve_statusline_binary_with()` in `settings.rs`, mirroring the injected-I/O-root testability pattern already used elsewhere in this crate (`has_prior_conversation_in`).
- New `is_stale_bare_statusline_command()` fingerprint check so the resume self-heal can safely upgrade ONLY its own previously-injected bare defaults, never a real user customization.
- `write_status_line` now only rewrites the settings file when a change actually happened (insert or in-place upgrade), preserving the prior "never touch a genuine user customization" behavior and avoiding unnecessary file churn on every resume.

## Test plan

- [x] `cargo test -p trusty-mpm` — all tests pass, including 8 new/updated unit tests in `session_launch::tests` (`resolve_statusline_binary_with_*`, `is_stale_bare_statusline_command_*`, `write_status_line_heals_stale_tm_default`, `write_status_line_heals_stale_trusty_mpm_default`) and 2 integration tests in `tests/session_manager_mvp.rs` (`resume_managed_backfills_missing_status_line`, new `resume_managed_heals_stale_bare_status_line_command`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `cargo check` (whole workspace) — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations

Closes #1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)