### PR TITLE
fix(trusty-mpm): daemon managed-spawn deploys agents/skills to worktree, not real ~/.claude (closes #1931)

### DIFF
--- a/crates/trusty-mpm/src/core/paths.rs
+++ b/crates/trusty-mpm/src/core/paths.rs
@@ -198,6 +198,37 @@ impl FrameworkPaths {
         paths
     }
 
+    /// Resolve the framework layout for a DAEMON-provisioned managed session
+    /// workspace (clone-based or in-project worktree), targeting the
+    /// project-local `.claude/` deploy destination.
+    ///
+    /// Why (issue #1931, follow-up to #1927/#1930): #1930 fixed the
+    /// **standalone** `tm register/load/run` driver (`core::standalone::load`)
+    /// to deploy project-locally via [`for_managed_project`](Self::for_managed_project),
+    /// but the **daemon**'s own managed-spawn code paths — the ones bare `tm`,
+    /// `tm launch`, and `tm session new` actually exercise — were never
+    /// updated and kept calling [`default`](Self::default), which resolves
+    /// `claude_agents`/`claude_skills` under the REAL `$HOME/.claude`. Since
+    /// the harness cwd for a managed session is the provisioned workspace or
+    /// worktree (never the real home), every managed spawn silently deployed
+    /// agents/skills somewhere Claude Code's project-skill discovery would
+    /// never look, so `/tm-*` slash commands were invisible in the spawned
+    /// session. The daemon always resolves its framework root the same way —
+    /// home-relative, with no `--root`/`TRUSTY_MPM_ROOT` override support
+    /// (unlike the standalone driver) — so this constructor hard-codes
+    /// [`default`](Self::default)`().root` as the `managed_root` input to
+    /// [`for_managed_project`](Self::for_managed_project) rather than
+    /// requiring every daemon call site to compute and pass it.
+    /// What: `Self::for_managed_project(Self::default().root, workspace_dir)`
+    /// — framework SOURCE paths still resolve from the shared `~/.trusty-mpm`
+    /// install; only the deploy destination moves to
+    /// `<workspace_dir>/.claude/{agents,skills}`.
+    /// Test: `for_managed_workspace_targets_workspace_local_claude_dirs`,
+    /// `for_managed_workspace_keeps_framework_source_at_default_root`.
+    pub fn for_managed_workspace(workspace_dir: impl AsRef<Path>) -> Self {
+        Self::for_managed_project(Self::default().root, workspace_dir)
+    }
+
     /// Path of the token-optimizer policy file (`hooks/optimizer.toml`).
     ///
     /// Why: the daemon reads this at startup and on file-change to build its
@@ -507,6 +538,52 @@ mod tests {
         // Only the deploy destinations diverge.
         assert_ne!(managed_project.claude_agents, from_root.claude_agents);
         assert_ne!(managed_project.claude_skills, from_root.claude_skills);
+    }
+
+    // Issue #1931: the daemon's managed-spawn deploy destination must be the
+    // provisioned workspace/worktree directory, never the real home — mirrors
+    // `for_managed_project_targets_project_local_claude_dirs` but exercises
+    // the daemon-facing convenience constructor instead of the standalone one.
+    #[test]
+    fn for_managed_workspace_targets_workspace_local_claude_dirs() {
+        let paths = FrameworkPaths::for_managed_workspace("/some/workspace/or/worktree");
+        assert_eq!(
+            paths.claude_agents_dir(),
+            PathBuf::from("/some/workspace/or/worktree/.claude/agents"),
+            "agents must deploy under the workspace dir, not the real home"
+        );
+        assert_eq!(
+            paths.claude_skills_dir(),
+            PathBuf::from("/some/workspace/or/worktree/.claude/skills"),
+            "skills must deploy under the workspace dir, not the real home"
+        );
+        assert_eq!(
+            paths.claude_home_dir(),
+            PathBuf::from("/some/workspace/or/worktree"),
+            "claude_home_dir() must follow the overridden claude_agents base"
+        );
+    }
+
+    // Issue #1931: only the deploy DESTINATION moves workspace-local — the
+    // framework SOURCE paths must keep resolving from `FrameworkPaths::default()`'s
+    // root (the daemon's single home-relative framework install), matching
+    // `for_managed_project_keeps_framework_source_at_managed_root`'s guarantee
+    // for the sibling standalone constructor.
+    #[test]
+    fn for_managed_workspace_keeps_framework_source_at_default_root() {
+        let default_paths = FrameworkPaths::default();
+        let workspace_paths = FrameworkPaths::for_managed_workspace("/some/workspace");
+
+        assert_eq!(workspace_paths.root, default_paths.root);
+        assert_eq!(workspace_paths.agents, default_paths.agents);
+        assert_eq!(workspace_paths.skills, default_paths.skills);
+        assert_eq!(workspace_paths.hooks, default_paths.hooks);
+        assert_eq!(workspace_paths.instructions, default_paths.instructions);
+        assert_eq!(workspace_paths.registry, default_paths.registry);
+
+        // Only the deploy destinations diverge from the real-home default.
+        assert_ne!(workspace_paths.claude_agents, default_paths.claude_agents);
+        assert_ne!(workspace_paths.claude_skills, default_paths.claude_skills);
     }
 
     #[test]

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -400,6 +400,38 @@ pub fn write_task_md(workspace: &std::path::Path, task: &str, session_id: &Manag
     }
 }
 
+/// Find an existing Active managed session for `source_id` whose tmux session
+/// is still live, so [`spawn_managed_inproject`] can reconnect instead of
+/// provisioning a duplicate worktree (#1707).
+///
+/// Why (issue #1931): extracted out of `spawn_managed_inproject` so the
+/// reconnect PREDICATE — the exact rule the operator relies on to avoid
+/// duplicate clones/worktrees for the same project — is unit-testable without
+/// a live `DaemonState`, tmux, or git worktree. `find` (not the async
+/// `SessionManager`/tmux calls themselves) is the only logic that can drift
+/// and cause the "existing clone not detected" symptom, so this is the seam
+/// worth pinning down with a hermetic regression test.
+/// What: returns the first record in `records` whose `source_id` matches
+/// `source_id` exactly, whose `state` is [`ManagedSessionState::Active`], and
+/// whose `tmux_name` reports alive via `tmux.session_exists(...)`. `None` when
+/// no record satisfies all three.
+/// Test: `find_reusable_inproject_session_matches_active_live_session`,
+/// `find_reusable_inproject_session_ignores_stopped_or_dead_or_other_project`.
+fn find_reusable_inproject_session(
+    records: &[SessionRecord],
+    source_id: &str,
+    tmux: &dyn crate::session_manager::ManagedTmuxDriver,
+) -> Option<SessionRecord> {
+    records
+        .iter()
+        .find(|r| {
+            r.source_id.as_deref() == Some(source_id)
+                && r.state == ManagedSessionState::Active
+                && tmux.session_exists(&r.tmux_name)
+        })
+        .cloned()
+}
+
 /// Spawn a managed session rooted at a per-session git worktree (#1706).
 ///
 /// Why: the in-project spawn path gives every managed session its own isolated
@@ -449,17 +481,15 @@ async fn spawn_managed_inproject(
     {
         let mgr = state.session_manager().await;
         let existing = mgr.list().await;
-        if let Some(live) = existing.iter().find(|r| {
-            r.source_id.as_deref() == Some(&candidate_source_id)
-                && r.state == ManagedSessionState::Active
-                && mgr.tmux_driver().session_exists(&r.tmux_name)
-        }) {
+        if let Some(live) =
+            find_reusable_inproject_session(&existing, &candidate_source_id, &*mgr.tmux_driver())
+        {
             info!(
                 id = %live.id,
                 source_id = %candidate_source_id,
                 "spawn_managed (inproject): reconnecting to existing live session"
             );
-            return Ok(live.clone());
+            return Ok(live);
         }
     }
 
@@ -488,7 +518,12 @@ async fn spawn_managed_inproject(
     // Prepare the session BEFORE spawning the runtime (#1913). See the
     // function-level doc for why this call is required here specifically (no
     // clone step wraps it, unlike the other two spawn paths).
-    let fw = crate::core::paths::FrameworkPaths::default();
+    //
+    // #1931: use `for_managed_workspace(&worktree)`, NOT `default()` — the
+    // harness cwd for this session IS `worktree`, so deployed agents/skills
+    // must land in `<worktree>/.claude/{agents,skills}` (where Claude Code's
+    // project-skill discovery looks), not the real `$HOME/.claude`.
+    let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&worktree);
     prepare_inproject_session(&fw, session_id, &worktree, &synthetic_repo_url);
 
     // #1919: mirrors `spawn_managed_cloned`'s placement — announce the tmux
@@ -1027,6 +1062,135 @@ pub async fn resume_managed(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Minimal `ManagedTmuxDriver` test double scoped to this module.
+    ///
+    /// Why (issue #1931): [`find_reusable_inproject_session`] only needs
+    /// `session_exists`, so this fake needs no real tmux process — just a
+    /// settable list of session names considered "alive". The crate's other
+    /// `FakeTmuxDriver` (`session_manager::tests`) is not reachable from here
+    /// (it lives in a private sibling module), so a tiny local double is
+    /// simpler than threading visibility through the module tree.
+    /// What: `session_exists` returns `true` iff `name` is in `alive`; every
+    /// other trait method is unused by this module's tests and panics if
+    /// called, so a wiring mistake fails loudly instead of silently passing.
+    /// Test: used by the `find_reusable_inproject_session_*` tests below.
+    struct StubTmux {
+        alive: Vec<String>,
+    }
+
+    impl crate::session_manager::ManagedTmuxDriver for StubTmux {
+        fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+            unimplemented!("not exercised by find_reusable_inproject_session tests")
+        }
+        fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
+            unimplemented!("not exercised by find_reusable_inproject_session tests")
+        }
+        fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+            unimplemented!("not exercised by find_reusable_inproject_session tests")
+        }
+        fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
+            unimplemented!("not exercised by find_reusable_inproject_session tests")
+        }
+        fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+            Ok(self.alive.clone())
+        }
+    }
+
+    /// Builds a minimal [`SessionRecord`] for [`find_reusable_inproject_session`]
+    /// tests — only `source_id`, `state`, and `tmux_name` affect the predicate;
+    /// every other field is an arbitrary placeholder.
+    fn stub_record(
+        source_id: Option<&str>,
+        state: ManagedSessionState,
+        tmux_name: &str,
+    ) -> SessionRecord {
+        SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: tmux_name.to_owned(),
+            cwd: std::path::PathBuf::from("/tmp/project"),
+            task: "task".into(),
+            state,
+            created_at: chrono::Utc::now(),
+            last_activity_at: None,
+            workspace_path: None,
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: false,
+            workspace_owned: false,
+            source_id: source_id.map(str::to_owned),
+            claude_session_id: None,
+            scrollback_path: None,
+            last_cwd: None,
+        }
+    }
+
+    /// Issue #1931 regression guard (symptom 1 investigation): proves the
+    /// exact predicate `tm` relies on to reconnect to an already-provisioned
+    /// managed project instead of spawning a duplicate clone/worktree — an
+    /// Active record with a matching `source_id` AND a still-live tmux
+    /// session must be returned.
+    #[test]
+    fn find_reusable_inproject_session_matches_active_live_session() {
+        let records = vec![stub_record(
+            Some("bobmatnyc/trusty-tools"),
+            ManagedSessionState::Active,
+            "tmpm-trusty-tools-abc123",
+        )];
+        let tmux = StubTmux {
+            alive: vec!["tmpm-trusty-tools-abc123".to_owned()],
+        };
+
+        let found = find_reusable_inproject_session(&records, "bobmatnyc/trusty-tools", &tmux);
+
+        assert!(
+            found.is_some(),
+            "an Active record with a live tmux session for the same source_id must be reused"
+        );
+        assert_eq!(found.unwrap().tmux_name, "tmpm-trusty-tools-abc123");
+    }
+
+    /// Issue #1931: three ways the predicate must correctly say "no reusable
+    /// session" — a different project's source_id, a non-Active state (e.g.
+    /// `Stopped`, matching the real symptom-1 investigation where prior
+    /// sessions were `state=stopped`), and a record whose tmux session has
+    /// died. Any of these incorrectly matching would either miss a reconnect
+    /// opportunity or, worse, hand back a dead session record.
+    #[test]
+    fn find_reusable_inproject_session_ignores_stopped_or_dead_or_other_project() {
+        let records = vec![
+            stub_record(
+                Some("bobmatnyc/xflux"),
+                ManagedSessionState::Active,
+                "tmpm-xflux-live",
+            ),
+            stub_record(
+                Some("bobmatnyc/trusty-tools"),
+                ManagedSessionState::Stopped,
+                "tmpm-trusty-tools-stopped",
+            ),
+            stub_record(
+                Some("bobmatnyc/trusty-tools"),
+                ManagedSessionState::Active,
+                "tmpm-trusty-tools-dead-tmux",
+            ),
+        ];
+        let tmux = StubTmux {
+            alive: vec!["tmpm-xflux-live".to_owned()],
+        };
+
+        let found = find_reusable_inproject_session(&records, "bobmatnyc/trusty-tools", &tmux);
+
+        assert!(
+            found.is_none(),
+            "must not reuse a different project's session, a Stopped record, \
+             or an Active record whose tmux session is no longer alive; got: {found:?}"
+        );
+    }
 
     /// #1913 regression guard: [`prepare_inproject_session`] — the call this fix
     /// adds to [`spawn_managed_inproject`] BEFORE `adapter.spawn` — must actually

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -334,10 +334,11 @@ pub struct WorkspaceProvisioner<G: GitBackend> {
     workspace_root: PathBuf,
     /// When false, `provision` skips the `prepare_session` deploy step.
     ///
-    /// Why: `prepare_session` deploys agents/skills to the shared `~/.claude/`
-    /// tree; unit tests that only verify path isolation must not perform that
-    /// global side-effect (it races with other tests). Production always sets
-    /// this to true via [`Self::new`].
+    /// Why: `prepare_session` deploys agents/skills into the provisioned
+    /// workspace's `.claude/` tree (issue #1931 — never the shared real
+    /// `~/.claude/`); unit tests that only verify path isolation must not
+    /// perform that filesystem side-effect (it races with other tests).
+    /// Production always sets this to true via [`Self::new`].
     prepare: bool,
 }
 
@@ -470,7 +471,14 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
         // ISOLATED CHECKOUT. If the framework is not installed (or deploy fails
         // for any reason) we log and continue so a session can still start — the
         // operator can run `tm install` / `tm catalog sync` to populate agents.
-        let fw = crate::core::paths::FrameworkPaths::default();
+        //
+        // #1931: use `for_managed_workspace(&workspace_path)`, NOT `default()` —
+        // this workspace IS the harness cwd for the spawned session, so deployed
+        // agents/skills must land in `<workspace_path>/.claude/{agents,skills}`
+        // (where Claude Code's project-skill discovery looks), not the real
+        // `$HOME/.claude`. Mirrors the sibling fix in
+        // `daemon::managed_routes::lifecycle::spawn_managed_inproject`.
+        let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&workspace_path);
         // Thread the cloned-from `repo_url` so the trusty-memory MCP injection
         // pins `env.TRUSTY_MEMORY_PALACE` to the project's `owner-repo` slug
         // (issue #1605). Without it the injector would fall back to deriving the


### PR DESCRIPTION
## Summary

- Fixes issue #1931: two live regressions reported right after the #1927/#1930 isolation-drift fix landed — bare `tm` apparently not detecting an already-cloned managed repo, and spawned Claude Code sessions missing all `tm-*` skills (`/tm-` → "No commands match").
- **Symptom 1 (clone not detected) needed no code fix** — root cause was an operational issue (the daemon process serving port 7880 predated the binary rebuild containing the fix; a graceful restart resolved it). Confirmed via live-state diagnosis that the reconnect logic in `spawn_managed_inproject` was already correct.
- **Symptom 2 (missing `tm-*` skills) is a genuine code regression**, reproduced and fixed here: `#1930` added `FrameworkPaths::for_managed_project` and wired it into the **standalone** driver (`tm register/load/run`), but the **daemon**'s own managed-spawn paths — what bare `tm`/`tm launch`/`tm session new` actually use — still called `FrameworkPaths::default()`, which deploys agents/skills into the real `$HOME/.claude` instead of the harness cwd (the provisioned workspace/worktree).

## Changes

- `core/paths.rs`: adds `FrameworkPaths::for_managed_workspace(workspace_dir)`, a daemon-facing convenience wrapper around `for_managed_project` (hard-codes `default().root` as the managed root, matching how the daemon always resolves its framework install).
- `daemon/managed_routes/lifecycle.rs`: `spawn_managed_inproject` now builds `FrameworkPaths::for_managed_workspace(&worktree)` instead of `FrameworkPaths::default()`. Also extracts the inline "reconnect to existing live session for this source_id" predicate into `find_reusable_inproject_session`, now independently unit-tested.
- `provisioner/workspace.rs`: `WorkspaceProvisioner::provision_in` (used by clone-based and local-redirect managed spawns) now builds `FrameworkPaths::for_managed_workspace(&workspace_path)` instead of `FrameworkPaths::default()`.

## Diagnosis evidence

Reproduced live on the reporting operator's machine for two different projects before the fix:
- `bobmatnyc/trusty-tools` managed worktree: `.claude/skills/` contained only the repo's own checked-in `cargo-publish` skill — zero `tm-*` skills, daemon log recorded `deployed=0 skills_deployed=0`.
- `bobmatnyc/xflux` managed worktree: no `.claude/skills/` directory at all.

Both worktrees' `.claude/agents/` similarly only contained content already checked into each repo, not the framework-deployed catalog.

## Test plan

- [x] `cargo test -p trusty-mpm` — 2266 lib tests + 46 integration tests, all pass
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean
- [x] New regression tests: `for_managed_workspace_targets_workspace_local_claude_dirs`, `for_managed_workspace_keeps_framework_source_at_default_root` (paths.rs); `find_reusable_inproject_session_matches_active_live_session`, `find_reusable_inproject_session_ignores_stopped_or_dead_or_other_project` (lifecycle.rs)
- [ ] End-to-end runtime verification with the installed binary (post-merge, in final report)

Closes #1931.

🤖 Generated with [Claude Code](https://claude.com/claude-code)