### PR TITLE
fix(trusty-mpm): address review follow-ups from #1936 (closes #1937)

### DIFF
--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -140,8 +140,10 @@ pub trait GitBackend: Send + Sync {
     /// `RealGitBackend` clones `--bare` (see its impl doc for why); callers
     /// must not assume a working tree exists at `base_dir` itself — only
     /// [`worktree_add`](Self::worktree_add) produces checked-out working trees.
-    /// Test: `FakeGitBackend` records the call and creates a `HEAD` marker so
-    /// a second call is recognised as already-established (no re-clone).
+    /// Test: `FakeGitBackend` records the call and writes fake bare-checkout
+    /// markers (`HEAD` + a `bare = true` `config`) so a second call is
+    /// recognised as already-established (no re-clone), while a stale directory
+    /// carrying only a stray `HEAD` is rejected — matching the real backend.
     fn ensure_base_checkout(&self, repo_url: &str, base_dir: &Path) -> Result<(), ProvisionError>;
 
     /// Fetch `git_ref` fresh from `origin` and add an isolated worktree for it.
@@ -189,7 +191,8 @@ pub struct RealGitBackend;
 // the 500-SLOC production cap — see that module's doc comment for the full
 // rationale behind each item.
 use base_lock::{
-    acquire_base_checkout_lock, base_checkout_lock_path, is_established_bare_checkout,
+    acquire_base_checkout_lock, base_checkout_lock_path, fake_is_established_bare_checkout,
+    is_established_bare_checkout, stale_base_dir_error, write_fake_bare_checkout,
 };
 
 impl GitBackend for RealGitBackend {
@@ -309,7 +312,11 @@ impl GitBackend for RealGitBackend {
     /// `base_dir`, with stale-lock recovery so a crashed process can never
     /// permanently deadlock future provisioning. After acquiring the lock,
     /// re-checks `is_established_bare_checkout` once more (another caller may
-    /// have finished cloning while this one was waiting) before cloning.
+    /// have finished cloning while this one was waiting) before cloning. If the
+    /// path is then found occupied by a non-empty stale/broken (non-bare)
+    /// directory, returns an actionable [`stale_base_dir_error`] naming the
+    /// exact path and the `rm -rf` command to clear it — rather than a cryptic
+    /// clone failure or a destructive auto-delete (issue #1937 item 1).
     /// Test: `ensure_base_checkout_recovers_from_concurrent_race` (spawns
     /// real threads racing on the same `base_dir`, asserts every one returns
     /// `Ok` and exactly one valid bare checkout results),
@@ -350,6 +357,17 @@ impl GitBackend for RealGitBackend {
                 "base checkout completed by a concurrent caller while waiting for the lock; reusing"
             );
             return Ok(());
+        }
+
+        // The path is confirmed NOT a valid bare checkout. If it is a non-empty
+        // stale/broken directory (crashed mid-clone leftover, or a pre-#1935
+        // non-bare clone) a `git clone --bare` here would fail with an opaque
+        // "destination path already exists" message. Surface an actionable
+        // error naming the exact path + the `rm -rf` command instead (issue
+        // #1937 item 1). We do NOT auto-delete: removing operator data is too
+        // destructive for an advisory recovery path.
+        if let Some(err) = stale_base_dir_error(base_dir) {
+            return Err(err);
         }
 
         // Use the destination's parent as cwd so a deleted inherited cwd cannot
@@ -552,15 +570,25 @@ impl GitBackend for FakeGitBackend {
             "ensure_base_checkout".to_owned(),
             base_dir.to_owned(),
         ));
-        // Idempotent: a `HEAD` marker simulates an already-established base so
-        // a second call (e.g. a second session for the same project) does not
-        // re-clone — this is the observable contract
+        // Idempotent reuse, mirroring `RealGitBackend`'s
+        // `rev-parse --is-bare-repository` semantics (issue #1937 item 3):
+        // recognise an already-established base ONLY when it looks like a valid
+        // (fake) bare checkout, not merely when a stray `HEAD` file exists.
+        // This is the observable contract
         // `provision_reuses_base_checkout_across_sessions` pins down.
-        if base_dir.join("HEAD").is_file() {
+        if fake_is_established_bare_checkout(base_dir) {
             return Ok(());
         }
-        std::fs::create_dir_all(base_dir)?;
-        std::fs::write(base_dir.join("HEAD"), "ref: refs/heads/main\n")?;
+        // Mirror `RealGitBackend`: a non-empty directory that is NOT a valid
+        // bare checkout is a stale/broken artifact — reject it loudly (with the
+        // same actionable message) rather than silently reuse or clobber it, so
+        // a fake-backend stale-directory test catches what a real one would.
+        if let Some(err) = stale_base_dir_error(base_dir) {
+            return Err(err);
+        }
+        // Simulate `git clone --bare`: write the structural markers that make
+        // `fake_is_established_bare_checkout` recognise this as a valid base.
+        write_fake_bare_checkout(base_dir)?;
         Ok(())
     }
 

--- a/crates/trusty-mpm/src/provisioner/workspace/base_lock.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/base_lock.rs
@@ -85,12 +85,18 @@ pub(super) fn is_established_bare_checkout(dir: &Path) -> bool {
 /// `fake_ensure_base_checkout_rejects_stale_non_bare_directory` (both assert
 /// the returned message contains the path and the `rm -rf` hint).
 pub(super) fn stale_base_dir_error(base_dir: &Path) -> Option<ProvisionError> {
-    // A missing dir (read_dir errors) or an empty dir (no entries) is fine:
-    // `git clone --bare` clones cleanly into either. Only a NON-empty dir that
-    // is not a valid bare checkout is the stale/broken state worth reporting.
-    let non_empty = std::fs::read_dir(base_dir)
-        .map(|mut entries| entries.next().is_some())
-        .unwrap_or(false);
+    // A missing dir (NotFound) or an empty dir (no entries) is fine: `git clone
+    // --bare` clones cleanly into either. Only a NON-empty dir that is not a
+    // valid bare checkout is the stale/broken state worth reporting. Any OTHER
+    // read_dir error (e.g. permission-denied) must NOT be swallowed as "absent":
+    // treating an unreadable directory as non-empty forces an actionable error
+    // here instead of letting `git clone --bare` fail later with an opaque
+    // message — exactly the failure mode this helper exists to prevent.
+    let non_empty = match std::fs::read_dir(base_dir) {
+        Ok(mut entries) => entries.next().is_some(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => true,
+    };
     if !non_empty {
         return None;
     }

--- a/crates/trusty-mpm/src/provisioner/workspace/base_lock.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/base_lock.rs
@@ -11,9 +11,16 @@
 //! (backed by [`BaseCheckoutLock`], a dependency-free marker-file mutex) plus
 //! [`lock_is_stale`] serialize the check-and-clone window across concurrent
 //! callers to fix the TOCTOU provisioning race (review finding #1).
+//! [`stale_base_dir_error`] turns the "the base path is occupied by a broken,
+//! non-bare directory" state into an actionable operator error (issue #1937
+//! item 1), and is shared by BOTH backends; [`fake_is_established_bare_checkout`]
+//! / [`write_fake_bare_checkout`] let `FakeGitBackend` mirror the real backend's
+//! `rev-parse`-based validity semantics rather than a superficial file-exists
+//! probe (issue #1937 item 3).
 //! Test: `ensure_base_checkout_recovers_from_concurrent_race`,
 //! `ensure_base_checkout_rejects_stale_non_bare_directory`,
-//! `base_checkout_lock_recovers_stale_lock_marker`, all in
+//! `base_checkout_lock_recovers_stale_lock_marker`,
+//! `fake_ensure_base_checkout_rejects_stale_non_bare_directory`, all in
 //! `provisioner/workspace/tests.rs`.
 
 use std::path::{Path, PathBuf};
@@ -54,6 +61,91 @@ pub(super) fn is_established_bare_checkout(dir: &Path) -> bool {
         Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim() == "true",
         _ => false,
     }
+}
+
+/// Build an actionable error for a base-checkout path occupied by a broken,
+/// non-bare directory — or return `None` when the path is safe to clone into.
+///
+/// Why: `ensure_base_checkout` correctly refuses to reuse a `<project_dir>/.base`
+/// that is not a valid bare checkout (a leftover from a crashed mid-clone, or a
+/// stale non-bare directory), but the resulting failure used to be an opaque
+/// `git clone --bare` "destination path already exists" message that gives the
+/// operator no recovery path (issue #1937 item 1). We deliberately do NOT
+/// auto-remediate (delete + re-clone): silently `rm -rf`-ing a directory the
+/// daemon did not create is too destructive for an advisory recovery path.
+/// Instead we surface the exact path and the exact command to clear it, and let
+/// the human decide.
+/// What: returns `None` when `base_dir` is absent or empty (either is safe —
+/// `git clone --bare` accepts a missing or empty target); otherwise returns
+/// `Some(ProvisionError::Git(..))` whose message names the exact path and the
+/// literal `rm -rf <path>` command to run before retrying. Callers MUST invoke
+/// this only AFTER confirming the path is not already a valid bare checkout
+/// (via [`is_established_bare_checkout`]) so a healthy base is never flagged.
+/// Test: `ensure_base_checkout_rejects_stale_non_bare_directory` and
+/// `fake_ensure_base_checkout_rejects_stale_non_bare_directory` (both assert
+/// the returned message contains the path and the `rm -rf` hint).
+pub(super) fn stale_base_dir_error(base_dir: &Path) -> Option<ProvisionError> {
+    // A missing dir (read_dir errors) or an empty dir (no entries) is fine:
+    // `git clone --bare` clones cleanly into either. Only a NON-empty dir that
+    // is not a valid bare checkout is the stale/broken state worth reporting.
+    let non_empty = std::fs::read_dir(base_dir)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false);
+    if !non_empty {
+        return None;
+    }
+    Some(ProvisionError::Git(format!(
+        "base checkout path {path} exists but is not a valid bare git checkout \
+         (likely a leftover from a crashed clone, or a stale non-bare directory). \
+         trusty-mpm will not delete it automatically. To allow re-provisioning, \
+         remove it manually and retry:\n    rm -rf {path}",
+        path = base_dir.display()
+    )))
+}
+
+/// Determine whether `dir` is an already-established (fake) BARE checkout,
+/// mirroring [`is_established_bare_checkout`]'s intent for `FakeGitBackend`.
+///
+/// Why: `FakeGitBackend::ensure_base_checkout` used to treat a lone
+/// `dir.join("HEAD").is_file()` as proof of an established base — the exact
+/// superficial file-existence probe the real backend abandoned in favour of
+/// `git rev-parse --is-bare-repository` (issue #1937 item 3). A future test
+/// author using the fake to simulate a stale `.base` (a stray `HEAD` file with
+/// no repository structure) would have gotten a false-positive "already
+/// established" pass, hiding the very stale-directory bug a real-backend test
+/// would catch. This check restores that fidelity in the filesystem-light fake.
+/// What: returns `true` only when BOTH a root-level `HEAD` file exists AND a
+/// root-level `config` file marked `bare = true` exists — the structural
+/// markers [`write_fake_bare_checkout`] writes to simulate a real bare clone. A
+/// directory containing only a stray `HEAD` (the stale-mid-clone shape) fails
+/// the `config` check and reads as NOT established, matching the real backend.
+/// Test: `fake_ensure_base_checkout_rejects_stale_non_bare_directory`,
+/// `provision_reuses_base_checkout_across_sessions`.
+pub(super) fn fake_is_established_bare_checkout(dir: &Path) -> bool {
+    dir.join("HEAD").is_file()
+        && std::fs::read_to_string(dir.join("config"))
+            .map(|c| c.contains("bare = true"))
+            .unwrap_or(false)
+}
+
+/// Write the minimal structural markers that make a directory read as an
+/// established (fake) bare checkout.
+///
+/// Why: `FakeGitBackend::ensure_base_checkout` must leave behind enough state
+/// that [`fake_is_established_bare_checkout`] recognises it on the next call
+/// (idempotent reuse across sessions) while still being distinguishable from a
+/// stale directory that merely holds a stray `HEAD` file (issue #1937 item 3).
+/// What: creates `dir` (and parents) and writes a `HEAD` ref pointer plus a
+/// `config` file carrying the `bare = true` marker — the two files
+/// [`fake_is_established_bare_checkout`] requires. Returns any I/O error as
+/// [`ProvisionError::Io`].
+/// Test: `provision_reuses_base_checkout_across_sessions` (second provision is a
+/// no-op reuse), `fake_ensure_base_checkout_rejects_stale_non_bare_directory`.
+pub(super) fn write_fake_bare_checkout(dir: &Path) -> Result<(), ProvisionError> {
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(dir.join("HEAD"), "ref: refs/heads/main\n")?;
+    std::fs::write(dir.join("config"), "[core]\n\tbare = true\n")?;
+    Ok(())
 }
 
 /// Maximum time a caller will wait to acquire the base-checkout lock before
@@ -164,6 +256,25 @@ pub(super) fn acquire_base_checkout_lock(
                 });
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // KNOWN, ACCEPTED RACE (issue #1937 item 2): staleness is judged
+                // purely by the marker file's mtime crossing `LOCK_STALE_AFTER`.
+                // On a filesystem with low-resolution timestamps, or under
+                // significant wall-clock skew (e.g. NTP step, VM clock drift),
+                // it is theoretically possible for this caller to compute a
+                // still-live holder's marker as "stale" and force-remove it,
+                // after which BOTH callers could hold the lock at once. We
+                // accept this window deliberately: this is an ADVISORY lock, not
+                // a correctness-critical mutex — the only thing it guards is a
+                // rare first-provision `git clone --bare` collision (finding #1),
+                // and `LOCK_STALE_AFTER` (5 min) is set comfortably longer than
+                // `LOCK_ACQUIRE_TIMEOUT` (60 s) precisely so a live,
+                // slow-but-progressing clone is never mistaken for an abandoned
+                // one under normal conditions. A dependency-free, kernel-tracked
+                // alternative (e.g. `flock`) or a PID-liveness check would close
+                // the window, but the added complexity is not justified for this
+                // low-probability, non-destructive edge case (worst outcome: the
+                // git-clone collision this lock exists to prevent, which was
+                // already tolerable before the lock landed).
                 if lock_is_stale(lock_path) {
                     // Best-effort: if the remove races with the true holder's
                     // own release, the next loop iteration's create_new simply

--- a/crates/trusty-mpm/src/provisioner/workspace/tests.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/tests.rs
@@ -457,6 +457,87 @@ fn ensure_base_checkout_rejects_stale_non_bare_directory() {
         result.is_err(),
         "a stale non-repo directory must be rejected loudly, not silently reused: {result:?}"
     );
+    // #1937 item 1: the error must be ACTIONABLE — name the exact path and the
+    // `rm -rf` command the operator should run to allow re-provisioning.
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains(&base_dir.display().to_string()),
+        "error must name the exact stale base path, got: {msg}"
+    );
+    assert!(
+        msg.contains("rm -rf"),
+        "error must include the `rm -rf` recovery command, got: {msg}"
+    );
+}
+
+/// #1937 item 3: `FakeGitBackend`'s idempotency/stale-detection must match
+/// `RealGitBackend`'s so a fake-backend test catches the same stale-directory
+/// condition a real-backend test would — the fidelity gap flagged in the
+/// PR #1936 review.
+///
+/// Why: before this fix `FakeGitBackend::ensure_base_checkout` reused any
+/// directory containing a stray `HEAD` file (the same superficial probe the
+/// real backend abandoned), so a future author simulating a stale `.base` with
+/// the fake would get a false-positive "already established" pass instead of
+/// the loud rejection the real backend now produces. This test mirrors
+/// `ensure_base_checkout_rejects_stale_non_bare_directory` against the fake.
+/// What: pre-seeds `base_dir` with ONLY a stray `HEAD` file (no `config`
+/// `bare = true` marker — the fake's stand-in for "not a valid bare checkout")
+/// and asserts `FakeGitBackend::ensure_base_checkout` returns an actionable
+/// `Err` naming the path and the `rm -rf` recovery command, exactly like the
+/// real backend — not a silent `Ok` reuse.
+/// Test: this function IS the test.
+#[test]
+fn fake_ensure_base_checkout_rejects_stale_non_bare_directory() {
+    let root = TempDir::new().unwrap();
+    let base_dir = root.path().join("project").join(".base");
+    std::fs::create_dir_all(&base_dir).unwrap();
+    // A lone HEAD file with no `config bare = true` marker is the fake's
+    // stand-in for a stale, non-bare, mid-crash directory.
+    std::fs::write(base_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+    let fake = FakeGitBackend::new();
+    let result = fake.ensure_base_checkout("https://github.com/owner/repo", &base_dir);
+    assert!(
+        result.is_err(),
+        "fake must reject a stale non-bare directory loudly, not silently reuse it: {result:?}"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains(&base_dir.display().to_string()) && msg.contains("rm -rf"),
+        "fake error must be actionable (path + `rm -rf`), got: {msg}"
+    );
+}
+
+/// #1937 item 3 (positive path): a FRESH `FakeGitBackend::ensure_base_checkout`
+/// establishes a valid fake bare checkout, and a SECOND call reuses it
+/// idempotently (no error, no clobber).
+///
+/// Why: locks in that the tightened validity check does not regress the
+/// happy-path reuse contract — the fake must still recognise the base it just
+/// wrote as established on the next call.
+/// What: calls `ensure_base_checkout` twice against an empty base path; asserts
+/// both return `Ok`, the second is recognised via `fake_is_established_bare_checkout`,
+/// and the written markers (`HEAD` + `bare = true` `config`) are present.
+/// Test: this function IS the test.
+#[test]
+fn fake_ensure_base_checkout_is_idempotent_on_valid_base() {
+    let root = TempDir::new().unwrap();
+    let base_dir = root.path().join("project").join(".base");
+    let fake = FakeGitBackend::new();
+
+    fake.ensure_base_checkout("https://github.com/owner/repo", &base_dir)
+        .expect("first ensure must establish the fake base");
+    assert!(
+        super::base_lock::fake_is_established_bare_checkout(&base_dir),
+        "a freshly-established fake base must read as a valid bare checkout"
+    );
+
+    // Second call must be an idempotent no-op reuse, not a stale rejection.
+    fake.ensure_base_checkout("https://github.com/owner/repo", &base_dir)
+        .expect("second ensure must reuse the established fake base");
+    assert!(base_dir.join("HEAD").is_file());
+    assert!(base_dir.join("config").is_file());
 }
 
 /// A lock marker abandoned by a crashed holder must not permanently deadlock


### PR DESCRIPTION
## Summary

Address three low-priority advisory follow-ups from the trusty-review verdict on PR #1936:

1. **Actionable stale-base-checkout error message** — Improved error reporting when the base checkout has drifted, making it easier for users to understand and recover from the issue.

2. **Documented lock-staleness race window** — Added clear documentation explaining the brief window where the advisory lock may become stale due to concurrent operations, and how the system handles this edge case.

3. **FakeGitBackend idempotency alignment** — Aligned the FakeGitBackend's idempotency checks with RealGitBackend behavior, ensuring consistency across the test suite and production code paths. Includes new tests to prevent regression.

All quality gates passed: `cargo check`, `cargo test`, `cargo clippy`, `cargo fmt`, and line-cap verification.

---
🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)