### PR TITLE
fix(memory): palace-level alias resolution for claude-mpm parity (owner-repo -> bare palace)

### DIFF
--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -401,8 +401,23 @@ pub use index_id::{derive_index_id, resolve_project_root};
 pub mod palace_id;
 pub use palace_id::{
     PALACE_OVERRIDE_ENV, derive_palace_id, owner_repo_from_git_remote, palace_override_from_env,
-    parent_dir_slug,
+    parent_dir_slug, repo_slug_from_git_remote,
 };
+
+/// Palace-level alias map: redirect one palace name to another (issue #1939).
+///
+/// Why: trusty-mpm pins a managed session to the `owner-repo` palace slug, but
+/// the pre-existing claude-mpm-era palace is the BARE repo name — so the pinned
+/// palace does not exist and memory splits in two. A persisted alias map lets the
+/// non-existent `owner-repo` name resolve to the existing bare palace. This is a
+/// PALACE-level redirect, distinct from the in-palace term/KG entity aliases.
+/// What: exposes [`palace_alias::PalaceAliasStore`] (load/register/resolve) plus
+/// [`palace_alias::default_palace_registry_dir`] and
+/// [`palace_alias::palace_registry_dir_from`] for locating the registry dir. This
+/// module is always compiled (no `memory-core` gate) so trusty-mpm's always-on
+/// session-launch path can register aliases without pulling the storage engine.
+/// Test: `cargo test -p trusty-common -- palace_alias::tests`.
+pub mod palace_alias;
 
 /// Shared GitHub `owner/repo` path derivation (issue #1220).
 ///

--- a/crates/trusty-common/src/memory_core/registry.rs
+++ b/crates/trusty-common/src/memory_core/registry.rs
@@ -17,6 +17,7 @@ use crate::memory_core::palace::{Palace, PalaceId};
 use crate::memory_core::retrieval::PalaceHandle;
 use crate::memory_core::store::concurrent_open::OpenIntent;
 use crate::memory_core::store::palace_store::PalaceStore;
+use crate::palace_alias::PalaceAliasStore;
 use anyhow::{Context, Result};
 use dashmap::DashMap;
 use lru::LruCache;
@@ -303,12 +304,24 @@ impl PalaceRegistry {
     /// `PalaceHandle::open`, and inserts the handle (may evict LRU).
     /// Test: `registry_create_and_open` round-trips create -> drop -> reopen;
     /// `lru_evicted_handle_reopens` verifies evicted handles are transparently
-    /// reopened.
+    /// reopened; `open_palace_follows_alias` covers the alias redirect.
     pub fn open_palace(&self, data_root: &Path, palace_id: &PalaceId) -> Result<Arc<PalaceHandle>> {
+        // Fast path: an already-open handle under the requested id.
         if let Some(h) = self.get(palace_id) {
             return Ok(h);
         }
-        let palace_dir = data_root.join(palace_id.as_str());
+        // Issue #1939: when the requested palace has no on-disk metadata but a
+        // persisted palace-level alias redirects it to an existing palace, open
+        // (and cache under) the alias target so the alias and the canonical name
+        // share ONE handle — never two writers over the same redb files.
+        // `resolve_palace_alias` returns the original id unchanged when there is
+        // no redirect; re-checking the cache under the (possibly redirected) id
+        // shares an already-open canonical handle (a redundant miss otherwise).
+        let effective_id = Self::resolve_palace_alias(data_root, palace_id);
+        if let Some(h) = self.get(&effective_id) {
+            return Ok(h);
+        }
+        let palace_dir = data_root.join(effective_id.as_str());
         let palace = PalaceStore::load_palace(&palace_dir)
             .with_context(|| format!("load palace metadata for {palace_id}"))?;
         // Issue #1487: honour the registry's open intent. On the HTTP daemon
@@ -317,6 +330,36 @@ impl PalaceRegistry {
         let handle = PalaceHandle::open_with_intent(&palace, self.open_intent)?;
         self.register_arc(handle.clone());
         Ok(handle)
+    }
+
+    /// Resolve a palace-level alias, but ONLY when the requested palace is
+    /// missing on disk (issue #1939).
+    ///
+    /// Why: an alias must never shadow a real palace of the same name — a lookup
+    /// for an existing palace always resolves to itself. The redirect fires only
+    /// in the split-brain case: the requested `owner-repo` palace was never
+    /// created, yet an alias points it at an existing bare-repo palace. Requiring
+    /// the target to also exist on disk stops a stale alias from redirecting to a
+    /// deleted palace (which would just fail load anyway, but this keeps the
+    /// error message about the ORIGINAL id).
+    /// What: returns `palace_id` unchanged when `<data_root>/<palace_id>/palace.json`
+    /// exists. Otherwise consults [`PalaceAliasStore::resolve_alias`]; if it maps
+    /// to a `target` whose `<data_root>/<target>/palace.json` exists, returns that
+    /// target id. In every other case returns `palace_id` unchanged so the caller
+    /// surfaces the normal "metadata missing" error. Alias-map read errors are
+    /// swallowed (best-effort redirect) — a broken alias file must not break
+    /// resolution of palaces that DO exist.
+    /// Test: `open_palace_follows_alias`, `open_palace_ignores_alias_when_target_missing`,
+    /// `open_palace_prefers_real_palace_over_alias`.
+    fn resolve_palace_alias(data_root: &Path, palace_id: &PalaceId) -> PalaceId {
+        let exists = |id: &str| data_root.join(id).join("palace.json").exists();
+        if exists(palace_id.as_str()) {
+            return palace_id.clone();
+        }
+        match PalaceAliasStore::resolve_alias(data_root, palace_id.as_str()) {
+            Ok(Some(target)) if exists(&target) => PalaceId::new(target),
+            _ => palace_id.clone(),
+        }
     }
 
     /// Create and persist a new palace, then open it.
@@ -647,6 +690,118 @@ mod tests {
         assert!(
             reg.peek(&PalaceId::new("c")).is_some(),
             "newly inserted 'c' must be present"
+        );
+    }
+
+    /// Issue #1939 — a palace requested by an aliased name resolves to the
+    /// alias target's on-disk store.
+    ///
+    /// Why: trusty-mpm pins a session to the derived `owner-repo` palace, but the
+    /// real data lives under the bare repo name. Registering the alias must make
+    /// an `open_palace` for the (non-existent) `owner-repo` name transparently
+    /// return the handle for the existing bare palace — the split-brain fix.
+    /// What: creates palace `trusty-tools`, registers alias
+    /// `bobmatnyc-trusty-tools -> trusty-tools`, then opens the alias name and
+    /// asserts the returned handle's canonical id is `trusty-tools` (not the
+    /// alias), proving both names share the one store.
+    /// Test: this test itself (issue #1939 regression guard).
+    #[test]
+    fn open_palace_follows_alias() {
+        use crate::memory_core::palace::Palace;
+        use crate::palace_alias::PalaceAliasStore;
+        use chrono::Utc;
+
+        let dir = tempdir().unwrap();
+        let data_root = dir.path();
+        let reg = PalaceRegistry::new();
+
+        // The real (bare-repo) palace on disk.
+        let bare = Palace {
+            id: PalaceId::new("trusty-tools"),
+            name: "trusty-tools".to_string(),
+            description: None,
+            created_at: Utc::now(),
+            data_dir: data_root.join("trusty-tools"),
+        };
+        reg.create_palace(data_root, bare).expect("create bare palace");
+
+        // Register the palace-level alias (owner-repo -> bare).
+        PalaceAliasStore::register_alias(data_root, "bobmatnyc-trusty-tools", "trusty-tools")
+            .expect("register alias");
+
+        // Opening the aliased (non-existent) name must resolve to the bare store.
+        let handle = reg
+            .open_palace(data_root, &PalaceId::new("bobmatnyc-trusty-tools"))
+            .expect("alias must resolve to the existing palace");
+        assert_eq!(
+            handle.id,
+            PalaceId::new("trusty-tools"),
+            "aliased open must return the canonical target handle, not the alias id"
+        );
+    }
+
+    /// Issue #1939 — a stale alias whose target does not exist must NOT redirect;
+    /// the original "metadata missing" error stands.
+    ///
+    /// Why: if an alias points at a deleted palace we must fail on the ORIGINAL
+    /// requested id rather than masking it, so operators see the name they asked
+    /// for. Requiring the target to exist on disk enforces this.
+    /// What: registers an alias to a non-existent target, opens the alias name,
+    /// and asserts the open errors (no redirect happened).
+    /// Test: this test itself.
+    #[test]
+    fn open_palace_ignores_alias_when_target_missing() {
+        use crate::palace_alias::PalaceAliasStore;
+
+        let dir = tempdir().unwrap();
+        let data_root = dir.path();
+        let reg = PalaceRegistry::new();
+
+        PalaceAliasStore::register_alias(data_root, "ghost", "does-not-exist")
+            .expect("register alias");
+
+        assert!(
+            reg.open_palace(data_root, &PalaceId::new("ghost")).is_err(),
+            "alias to a missing target must not redirect"
+        );
+    }
+
+    /// Issue #1939 — an alias must never shadow a real palace of the same name.
+    ///
+    /// Why: if both an alias entry AND a real palace exist under the same name,
+    /// the real palace wins (aliases only fill the "missing palace" gap).
+    /// What: creates palace `dup`, registers a (mischievous) alias
+    /// `dup -> other`, and asserts `open_palace("dup")` returns `dup` itself.
+    /// Test: this test itself.
+    #[test]
+    fn open_palace_prefers_real_palace_over_alias() {
+        use crate::memory_core::palace::Palace;
+        use crate::palace_alias::PalaceAliasStore;
+        use chrono::Utc;
+
+        let dir = tempdir().unwrap();
+        let data_root = dir.path();
+        let reg = PalaceRegistry::new();
+
+        for id in ["dup", "other"] {
+            let p = Palace {
+                id: PalaceId::new(id),
+                name: id.to_string(),
+                description: None,
+                created_at: Utc::now(),
+                data_dir: data_root.join(id),
+            };
+            reg.create_palace(data_root, p).expect("create palace");
+        }
+        PalaceAliasStore::register_alias(data_root, "dup", "other").expect("register alias");
+
+        let handle = reg
+            .open_palace(data_root, &PalaceId::new("dup"))
+            .expect("real palace opens");
+        assert_eq!(
+            handle.id,
+            PalaceId::new("dup"),
+            "a real palace must win over an alias of the same name"
         );
     }
 

--- a/crates/trusty-common/src/memory_core/registry.rs
+++ b/crates/trusty-common/src/memory_core/registry.rs
@@ -723,7 +723,8 @@ mod tests {
             created_at: Utc::now(),
             data_dir: data_root.join("trusty-tools"),
         };
-        reg.create_palace(data_root, bare).expect("create bare palace");
+        reg.create_palace(data_root, bare)
+            .expect("create bare palace");
 
         // Register the palace-level alias (owner-repo -> bare).
         PalaceAliasStore::register_alias(data_root, "bobmatnyc-trusty-tools", "trusty-tools")

--- a/crates/trusty-common/src/palace_alias.rs
+++ b/crates/trusty-common/src/palace_alias.rs
@@ -88,7 +88,8 @@ impl PalaceAliasStore {
             Ok(b) => b,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
             Err(e) => {
-                return Err(e).with_context(|| format!("read palace aliases at {}", path.display()));
+                return Err(e)
+                    .with_context(|| format!("read palace aliases at {}", path.display()));
             }
         };
         if bytes.iter().all(u8::is_ascii_whitespace) {
@@ -127,10 +128,14 @@ impl PalaceAliasStore {
         let alias = alias.trim();
         let target = target.trim();
         if alias.is_empty() || target.is_empty() {
-            anyhow::bail!("palace alias and target must both be non-empty (alias={alias:?}, target={target:?})");
+            anyhow::bail!(
+                "palace alias and target must both be non-empty (alias={alias:?}, target={target:?})"
+            );
         }
         if alias == target {
-            anyhow::bail!("refusing to register a self-referential palace alias {alias:?} -> {target:?}");
+            anyhow::bail!(
+                "refusing to register a self-referential palace alias {alias:?} -> {target:?}"
+            );
         }
 
         std::fs::create_dir_all(registry_dir)
@@ -236,7 +241,10 @@ mod tests {
         );
         // Full-map load reflects it too.
         let all = PalaceAliasStore::load_aliases(tmp.path()).expect("load");
-        assert_eq!(all.get("bobmatnyc-trusty-tools").map(String::as_str), Some("trusty-tools"));
+        assert_eq!(
+            all.get("bobmatnyc-trusty-tools").map(String::as_str),
+            Some("trusty-tools")
+        );
         // File actually exists on disk.
         assert!(tmp.path().join(PALACE_ALIASES_JSON).exists());
     }
@@ -288,7 +296,10 @@ mod tests {
     fn resolve_unknown_is_none() {
         let tmp = tempdir().unwrap();
         PalaceAliasStore::register_alias(tmp.path(), "a", "b").unwrap();
-        assert_eq!(PalaceAliasStore::resolve_alias(tmp.path(), "zzz").unwrap(), None);
+        assert_eq!(
+            PalaceAliasStore::resolve_alias(tmp.path(), "zzz").unwrap(),
+            None
+        );
     }
 
     /// Why: a corrupt alias file must degrade to "no aliases", never panic or
@@ -298,7 +309,8 @@ mod tests {
     fn corrupt_file_degrades_to_empty() {
         let tmp = tempdir().unwrap();
         std::fs::write(tmp.path().join(PALACE_ALIASES_JSON), b"{ not json ]").unwrap();
-        let all = PalaceAliasStore::load_aliases(tmp.path()).expect("load never errors on corruption");
+        let all =
+            PalaceAliasStore::load_aliases(tmp.path()).expect("load never errors on corruption");
         assert!(all.is_empty());
     }
 

--- a/crates/trusty-common/src/palace_alias.rs
+++ b/crates/trusty-common/src/palace_alias.rs
@@ -1,0 +1,327 @@
+//! Palace-level alias map: redirect one palace name to another (issue #1939).
+//!
+//! Why: trusty-mpm pins a managed session's `TRUSTY_MEMORY_PALACE` to the
+//! `owner-repo` slug that [`crate::derive_palace_id`] produces (e.g.
+//! `bobmatnyc-trusty-tools`), but the pre-existing claude-mpm-era palace for a
+//! repo is the BARE repo name (`trusty-tools`). When the `owner-repo` palace has
+//! never been created, every memory tool call fails with "palace metadata
+//! missing" while the real history lives under the bare name — memory is
+//! split-brained. This module persists a small alias map so a lookup for a
+//! non-existent palace can be transparently redirected to an existing target,
+//! letting BOTH names resolve to the one on-disk store.
+//!
+//! What: a JSON file `<registry_dir>/palace_aliases.json` mapping
+//! `alias_name -> target_palace`, with atomic (tmp + rename) writes and a
+//! forgiving read (a missing/empty/corrupt file is treated as "no aliases").
+//! Resolution is consulted by [`crate::memory_core::registry::PalaceRegistry`]
+//! ONLY when the requested palace has no metadata on disk, so aliases never
+//! shadow a real palace of the same name. This is DISTINCT from the term/KG
+//! entity aliases exposed by the `add_alias`/`discover_aliases` MCP tools — those
+//! live INSIDE a palace's knowledge graph; this is a PALACE-level redirect that
+//! lives beside the per-palace subdirectories.
+//!
+//! Test: `crate::palace_alias::tests` covers round-trip register/resolve, the
+//! missing-file default, idempotent re-registration, self-alias rejection, and
+//! the `palace_registry_dir_from` subdir resolution.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Filename for the persisted palace-alias map (beside per-palace subdirs).
+///
+/// Why: the map must live in the SAME directory the daemon uses as its palace
+/// registry root (`AppState::data_root`) so a single lookup finds it. Naming it
+/// with a `.json` suffix (not a directory) means the palace-listing walker —
+/// which only descends into subdirectories containing `palace.json` — skips it
+/// automatically.
+/// What: `"palace_aliases.json"`.
+/// Test: `register_then_resolve_round_trips` writes/reads this path.
+const PALACE_ALIASES_JSON: &str = "palace_aliases.json";
+
+/// On-disk shape of the alias map (versioned for forward compatibility).
+///
+/// Why: wrapping the flat map in a struct with an explicit `version` lets the
+/// schema evolve (e.g. add per-alias metadata) without breaking older readers.
+/// What: `version` (defaulted to 1 for files written before it existed) plus the
+/// `aliases` map. Serialised with `serde_json` pretty output.
+/// Test: `register_then_resolve_round_trips`.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct PalaceAliasesFile {
+    /// Schema version; defaults to 1 when absent so pre-version files still load.
+    #[serde(default = "default_alias_schema_version")]
+    version: u32,
+    /// `alias_name -> target_palace` redirects. `BTreeMap` keeps the on-disk
+    /// order stable so diffs are deterministic.
+    #[serde(default)]
+    aliases: BTreeMap<String, String>,
+}
+
+fn default_alias_schema_version() -> u32 {
+    1
+}
+
+/// Stateless namespace for palace-alias persistence.
+///
+/// Why: like [`crate::memory_core::store::palace_store::PalaceStore`], alias
+/// persistence has no state of its own — every operation is a pure function over
+/// a registry directory. Grouping under a unit struct gives a stable import path.
+/// What: `load_aliases` / `register_alias` / `resolve_alias`.
+/// Test: this module's `tests`.
+pub struct PalaceAliasStore;
+
+impl PalaceAliasStore {
+    /// Load the full alias map for a registry directory.
+    ///
+    /// Why: callers that want the whole map (diagnostics, bulk resolution) get it
+    /// in one read. A missing file is the common case (no aliases registered yet)
+    /// and must NOT be an error, so a fresh install behaves like an empty map.
+    /// What: reads `<registry_dir>/palace_aliases.json`. Returns an empty map when
+    /// the file is absent, empty, or fails to parse (corruption is logged and
+    /// treated as "no aliases" so a bad file can never wedge palace resolution).
+    /// Test: `load_missing_is_empty`, `register_then_resolve_round_trips`.
+    pub fn load_aliases(registry_dir: &Path) -> Result<BTreeMap<String, String>> {
+        let path = registry_dir.join(PALACE_ALIASES_JSON);
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+            Err(e) => {
+                return Err(e).with_context(|| format!("read palace aliases at {}", path.display()));
+            }
+        };
+        if bytes.iter().all(u8::is_ascii_whitespace) {
+            return Ok(BTreeMap::new());
+        }
+        match serde_json::from_slice::<PalaceAliasesFile>(&bytes) {
+            Ok(file) => Ok(file.aliases),
+            Err(e) => {
+                // A corrupt alias file must not break palace resolution — the
+                // authoritative data is the palaces themselves. Log and degrade
+                // to "no aliases".
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "palace alias file is unparseable; ignoring (treating as no aliases)"
+                );
+                Ok(BTreeMap::new())
+            }
+        }
+    }
+
+    /// Register (or overwrite) an alias `alias_name -> target`, persisting it.
+    ///
+    /// Why: trusty-mpm calls this at session launch to bind a derived
+    /// `owner-repo` name to an existing bare-repo palace so the split-brain
+    /// resolves. It must be idempotent — relaunching the same session repeatedly
+    /// must converge on one entry, not error or duplicate.
+    /// What: rejects empty operands and a self-alias (`alias == target`, which
+    /// would be a useless no-op / cycle). Otherwise loads the current map,
+    /// inserts/updates the entry, and atomically writes it back (tmp + rename) so
+    /// a crash mid-write cannot leave a half-written map. Creating an alias that
+    /// already maps to the same target is a cheap no-op write. Returns `Ok(())`.
+    /// Test: `register_then_resolve_round_trips`, `register_is_idempotent`,
+    /// `register_self_alias_is_rejected`, `register_rejects_empty`.
+    pub fn register_alias(registry_dir: &Path, alias: &str, target: &str) -> Result<()> {
+        let alias = alias.trim();
+        let target = target.trim();
+        if alias.is_empty() || target.is_empty() {
+            anyhow::bail!("palace alias and target must both be non-empty (alias={alias:?}, target={target:?})");
+        }
+        if alias == target {
+            anyhow::bail!("refusing to register a self-referential palace alias {alias:?} -> {target:?}");
+        }
+
+        std::fs::create_dir_all(registry_dir)
+            .with_context(|| format!("create registry dir {}", registry_dir.display()))?;
+
+        let mut aliases = Self::load_aliases(registry_dir)?;
+        aliases.insert(alias.to_string(), target.to_string());
+
+        let file = PalaceAliasesFile {
+            version: default_alias_schema_version(),
+            aliases,
+        };
+        let bytes = serde_json::to_vec_pretty(&file).context("serialize palace aliases")?;
+
+        let target_path = registry_dir.join(PALACE_ALIASES_JSON);
+        let tmp_path = registry_dir.join(format!("{PALACE_ALIASES_JSON}.tmp"));
+        std::fs::write(&tmp_path, &bytes)
+            .with_context(|| format!("write palace aliases tmp {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, &target_path)
+            .with_context(|| format!("rename palace aliases into {}", target_path.display()))?;
+        Ok(())
+    }
+
+    /// Resolve a single alias to its target palace name, if one is registered.
+    ///
+    /// Why: the palace registry consults this when a requested palace has no
+    /// on-disk metadata — a hit redirects the open to the target's store.
+    /// What: loads the map and returns `Some(target)` when `alias` is present,
+    /// `None` otherwise. A missing map yields `None`.
+    /// Test: `register_then_resolve_round_trips`, `resolve_unknown_is_none`.
+    pub fn resolve_alias(registry_dir: &Path, alias: &str) -> Result<Option<String>> {
+        Ok(Self::load_aliases(registry_dir)?.get(alias.trim()).cloned())
+    }
+}
+
+/// Resolve the directory that holds the per-palace subdirectories for a data dir.
+///
+/// Why: two on-disk layouts exist in the wild. The current code treats the data
+/// dir itself as the parent of per-palace dirs (`<data_dir>/<id>/palace.json`);
+/// legacy standalone installs nest everything under a `palaces/` subdirectory
+/// (`<data_dir>/palaces/<id>/palace.json`), which is where real installs' data
+/// lives. trusty-mpm (which registers aliases) and trusty-memory (which resolves
+/// them) MUST agree on this directory or the alias file lands somewhere the
+/// daemon never reads. Centralising the choice here keeps the two in lockstep —
+/// trusty-memory's `resolve_palace_registry_dir` delegates to this.
+/// What: returns `<data_dir>/palaces` when that subdirectory exists, else
+/// `<data_dir>` itself.
+/// Test: `palace_registry_dir_prefers_palaces_subdir`,
+/// `palace_registry_dir_falls_back_to_data_dir`.
+pub fn palace_registry_dir_from(data_dir: PathBuf) -> PathBuf {
+    let nested = data_dir.join("palaces");
+    if nested.is_dir() { nested } else { data_dir }
+}
+
+/// Resolve the default trusty-memory palace registry directory for this machine.
+///
+/// Why: trusty-mpm's session-launch alias registration must write the alias file
+/// to the exact directory the trusty-memory daemon uses as its palace registry
+/// root, WITHOUT depending on the `trusty-memory` crate. Reusing
+/// [`crate::resolve_data_dir`] (which honours `TRUSTY_DATA_DIR_OVERRIDE`) keeps
+/// path derivation identical to the daemon's, so tests and production agree.
+/// What: resolves `resolve_data_dir("trusty-memory")` (the app data dir, created
+/// if absent) and applies [`palace_registry_dir_from`] to pick the `palaces/`
+/// subdir when present. Returns the registry directory.
+/// Test: side-effect-bearing (creates the app data dir); the pure subdir choice
+/// it composes is covered by `palace_registry_dir_*`.
+pub fn default_palace_registry_dir() -> Result<PathBuf> {
+    let data_dir = crate::resolve_data_dir("trusty-memory")?;
+    Ok(palace_registry_dir_from(data_dir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Why: a fresh install has no alias file; load must return an empty map,
+    /// never an error, so palace resolution proceeds normally.
+    /// Test: itself.
+    #[test]
+    fn load_missing_is_empty() {
+        let tmp = tempdir().unwrap();
+        let aliases = PalaceAliasStore::load_aliases(tmp.path()).expect("load");
+        assert!(aliases.is_empty());
+    }
+
+    /// Why: the core contract — a registered alias must be readable back both via
+    /// the full map and the single-key resolver, and it must survive as an
+    /// on-disk file (a fresh read from the same dir).
+    /// Test: itself.
+    #[test]
+    fn register_then_resolve_round_trips() {
+        let tmp = tempdir().unwrap();
+        PalaceAliasStore::register_alias(tmp.path(), "bobmatnyc-trusty-tools", "trusty-tools")
+            .expect("register");
+
+        // Single-key resolve.
+        assert_eq!(
+            PalaceAliasStore::resolve_alias(tmp.path(), "bobmatnyc-trusty-tools")
+                .expect("resolve")
+                .as_deref(),
+            Some("trusty-tools")
+        );
+        // Full-map load reflects it too.
+        let all = PalaceAliasStore::load_aliases(tmp.path()).expect("load");
+        assert_eq!(all.get("bobmatnyc-trusty-tools").map(String::as_str), Some("trusty-tools"));
+        // File actually exists on disk.
+        assert!(tmp.path().join(PALACE_ALIASES_JSON).exists());
+    }
+
+    /// Why: relaunching the same managed session repeatedly must not duplicate or
+    /// error — re-registering the same pair converges on one entry, and pointing
+    /// an alias at a new target overwrites in place.
+    /// Test: itself.
+    #[test]
+    fn register_is_idempotent() {
+        let tmp = tempdir().unwrap();
+        PalaceAliasStore::register_alias(tmp.path(), "a", "b").unwrap();
+        PalaceAliasStore::register_alias(tmp.path(), "a", "b").unwrap();
+        let all = PalaceAliasStore::load_aliases(tmp.path()).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all.get("a").map(String::as_str), Some("b"));
+
+        // Overwrite to a new target.
+        PalaceAliasStore::register_alias(tmp.path(), "a", "c").unwrap();
+        let all = PalaceAliasStore::load_aliases(tmp.path()).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all.get("a").map(String::as_str), Some("c"));
+    }
+
+    /// Why: a self-alias is a useless no-op / potential cycle; it must be
+    /// rejected so a mis-derived slug can never point a palace at itself.
+    /// Test: itself.
+    #[test]
+    fn register_self_alias_is_rejected() {
+        let tmp = tempdir().unwrap();
+        assert!(PalaceAliasStore::register_alias(tmp.path(), "same", "same").is_err());
+        assert!(PalaceAliasStore::register_alias(tmp.path(), "same", " same ").is_err());
+    }
+
+    /// Why: empty operands would create a meaningless map entry; guard against
+    /// them so a caller passing a blank slug fails loudly rather than silently.
+    /// Test: itself.
+    #[test]
+    fn register_rejects_empty() {
+        let tmp = tempdir().unwrap();
+        assert!(PalaceAliasStore::register_alias(tmp.path(), "", "b").is_err());
+        assert!(PalaceAliasStore::register_alias(tmp.path(), "a", "  ").is_err());
+    }
+
+    /// Why: an alias that was never registered must resolve to `None` so the
+    /// registry surfaces the normal "metadata missing" error.
+    /// Test: itself.
+    #[test]
+    fn resolve_unknown_is_none() {
+        let tmp = tempdir().unwrap();
+        PalaceAliasStore::register_alias(tmp.path(), "a", "b").unwrap();
+        assert_eq!(PalaceAliasStore::resolve_alias(tmp.path(), "zzz").unwrap(), None);
+    }
+
+    /// Why: a corrupt alias file must degrade to "no aliases", never panic or
+    /// error, so it cannot wedge palace resolution.
+    /// Test: itself.
+    #[test]
+    fn corrupt_file_degrades_to_empty() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(tmp.path().join(PALACE_ALIASES_JSON), b"{ not json ]").unwrap();
+        let all = PalaceAliasStore::load_aliases(tmp.path()).expect("load never errors on corruption");
+        assert!(all.is_empty());
+    }
+
+    /// Why: when a `palaces/` subdir exists (the real-install layout) the
+    /// registry dir must point INTO it so aliases sit beside the palaces.
+    /// Test: itself.
+    #[test]
+    fn palace_registry_dir_prefers_palaces_subdir() {
+        let tmp = tempdir().unwrap();
+        let nested = tmp.path().join("palaces");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert_eq!(palace_registry_dir_from(tmp.path().to_path_buf()), nested);
+    }
+
+    /// Why: absent a `palaces/` subdir the data dir itself is the registry root
+    /// (the monorepo layout), matching trusty-memory's fallback.
+    /// Test: itself.
+    #[test]
+    fn palace_registry_dir_falls_back_to_data_dir() {
+        let tmp = tempdir().unwrap();
+        assert_eq!(
+            palace_registry_dir_from(tmp.path().to_path_buf()),
+            tmp.path().to_path_buf()
+        );
+    }
+}

--- a/crates/trusty-common/src/palace_id.rs
+++ b/crates/trusty-common/src/palace_id.rs
@@ -166,9 +166,7 @@ fn parse_owner_repo_slugs(url: &str) -> Option<(Option<String>, String)> {
         return None;
     }
 
-    let owner_slug = owner
-        .map(slugify_string)
-        .filter(|s| !s.is_empty());
+    let owner_slug = owner.map(slugify_string).filter(|s| !s.is_empty());
     Some((owner_slug, repo_slug))
 }
 

--- a/crates/trusty-common/src/palace_id.rs
+++ b/crates/trusty-common/src/palace_id.rs
@@ -91,6 +91,45 @@ pub fn palace_override_from_env() -> Option<String> {
 /// `git_non_github_host`, `git_trailing_slash`, `git_repo_only`,
 /// `git_empty_returns_none`, `git_self_hosted_with_port`.
 pub fn owner_repo_from_git_remote(url: &str) -> Option<String> {
+    let (owner_slug, repo_slug) = parse_owner_repo_slugs(url)?;
+    match owner_slug {
+        Some(owner) => Some(format!("{owner}-{repo_slug}")),
+        None => Some(repo_slug),
+    }
+}
+
+/// Parse a git remote URL into just the slugified `repo` segment (no owner).
+///
+/// Why: the claude-mpm-era palaces are named by the BARE repo name (e.g.
+/// `trusty-tools`), NOT the `owner-repo` slug that [`owner_repo_from_git_remote`]
+/// produces (`bobmatnyc-trusty-tools`). trusty-mpm's session-launch alias
+/// registration (issue #1939) needs the bare-repo candidate to decide whether a
+/// pre-existing bare palace should be aliased to the derived owner-repo palace.
+/// Deriving it from the same remote (rather than string-splitting the owner-repo
+/// slug on `-`, which is ambiguous because a repo name may itself contain `-`)
+/// keeps the two identities consistent and unambiguous.
+/// What: reuses the same host/path parsing as [`owner_repo_from_git_remote`] but
+/// returns only the slugified final `repo` segment. Returns `None` when nothing
+/// usable can be extracted (empty input, host-only URL).
+/// Test: `repo_slug_ssh_github`, `repo_slug_https_with_owner`,
+/// `repo_slug_repo_only`, `repo_slug_empty_returns_none`.
+pub fn repo_slug_from_git_remote(url: &str) -> Option<String> {
+    parse_owner_repo_slugs(url).map(|(_, repo)| repo)
+}
+
+/// Shared parse: extract the slugified `(owner, repo)` pair from a git remote.
+///
+/// Why: both [`owner_repo_from_git_remote`] (which joins owner+repo) and
+/// [`repo_slug_from_git_remote`] (which keeps only repo) need identical host/path
+/// isolation and slugification; factoring it here guarantees they can never
+/// diverge on how a URL is parsed.
+/// What: strips the scheme and host, trims a trailing `.git`/slashes, takes the
+/// last two path segments as `(owner, repo)`, and slugifies each. Returns
+/// `(Some(owner_slug), repo_slug)` for `owner/repo` URLs, `(None, repo_slug)`
+/// when only a repo segment is present (or the owner slugifies to empty), and
+/// `None` when no non-empty repo slug can be extracted.
+/// Test: covered transitively by the `owner_repo_*` and `repo_slug_*` tests.
+fn parse_owner_repo_slugs(url: &str) -> Option<(Option<String>, String)> {
     let trimmed = url.trim();
     if trimmed.is_empty() {
         return None;
@@ -127,17 +166,10 @@ pub fn owner_repo_from_git_remote(url: &str) -> Option<String> {
         return None;
     }
 
-    match owner {
-        Some(owner) => {
-            let owner_slug = slugify_string(owner);
-            if owner_slug.is_empty() {
-                Some(repo_slug)
-            } else {
-                Some(format!("{owner_slug}-{repo_slug}"))
-            }
-        }
-        None => Some(repo_slug),
-    }
+    let owner_slug = owner
+        .map(slugify_string)
+        .filter(|s| !s.is_empty());
+    Some((owner_slug, repo_slug))
 }
 
 /// Strip a leading URL scheme (`https://`, `ssh://`, `git://`, …) if present.
@@ -406,6 +438,58 @@ mod tests {
         assert_eq!(owner_repo_from_git_remote("   "), None);
         // Host-only (no path segments).
         assert_eq!(owner_repo_from_git_remote("https://github.com/"), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // repo_slug_from_git_remote — bare repo name (no owner)
+    // -----------------------------------------------------------------------
+
+    /// Why: the bare-repo alias candidate must drop the owner entirely so
+    /// `git@github.com:bobmatnyc/trusty-tools.git` yields `trusty-tools`, the
+    /// claude-mpm-era palace name (issue #1939).
+    /// Test: itself.
+    #[test]
+    fn repo_slug_ssh_github() {
+        assert_eq!(
+            repo_slug_from_git_remote("git@github.com:bobmatnyc/trusty-tools.git").as_deref(),
+            Some("trusty-tools")
+        );
+    }
+
+    /// Why: an HTTPS remote with an owner must still reduce to just the repo
+    /// segment, and a repo name containing `-` must survive intact (proving we
+    /// do not string-split the owner-repo slug on `-`).
+    /// Test: itself.
+    #[test]
+    fn repo_slug_https_with_owner() {
+        assert_eq!(
+            repo_slug_from_git_remote("https://github.com/bobmatnyc/trusty-tools").as_deref(),
+            Some("trusty-tools")
+        );
+        assert_eq!(
+            repo_slug_from_git_remote("https://gitlab.com/acme/team/cool-widget.git").as_deref(),
+            Some("cool-widget")
+        );
+    }
+
+    /// Why: an owner-less remote must yield the repo slug (parity with
+    /// `owner_repo_from_git_remote`'s repo-only branch).
+    /// Test: itself.
+    #[test]
+    fn repo_slug_repo_only() {
+        assert_eq!(
+            repo_slug_from_git_remote("git@host:repo.git").as_deref(),
+            Some("repo")
+        );
+    }
+
+    /// Why: unparseable input must return `None` so the caller skips alias
+    /// registration entirely.
+    /// Test: itself.
+    #[test]
+    fn repo_slug_empty_returns_none() {
+        assert_eq!(repo_slug_from_git_remote(""), None);
+        assert_eq!(repo_slug_from_git_remote("https://github.com/"), None);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -206,12 +206,11 @@ pub use tools::MemoryMcpServer;
 /// Test: `tests::resolve_palace_registry_dir_prefers_palaces_subdir` and
 /// `resolve_palace_registry_dir_falls_back_to_data_dir`.
 pub fn resolve_palace_registry_dir(data_dir: PathBuf) -> PathBuf {
-    let nested = data_dir.join("palaces");
-    if nested.is_dir() {
-        nested
-    } else {
-        data_dir
-    }
+    // Issue #1939: the subdir-choice logic is hoisted into trusty-common
+    // (`palace_alias::palace_registry_dir_from`) so trusty-mpm's alias-registration
+    // path and this daemon path can never disagree on WHERE the registry (and the
+    // alias file beside it) lives. This delegates to keep a single implementation.
+    trusty_common::palace_alias::palace_registry_dir_from(data_dir)
 }
 
 /// Hook type — labels the Claude Code hook that triggered a submission.

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -14,6 +14,7 @@
 //! Test: `prepare_session_writes_claude_md_and_stash` and
 //! `prepare_session_is_idempotent` in this module's tests.
 
+mod palace_alias;
 mod search_index;
 mod settings;
 #[cfg(test)]

--- a/crates/trusty-mpm/src/core/session_launch/palace_alias.rs
+++ b/crates/trusty-mpm/src/core/session_launch/palace_alias.rs
@@ -1,0 +1,261 @@
+//! Session-launch palace-alias registration to heal claude-mpm memory parity.
+//!
+//! Why: trusty-mpm pins a managed session to the derived `owner-repo` palace slug
+//! (e.g. `bobmatnyc-trusty-tools`, via [`trusty_common::derive_palace_id`]), but
+//! the pre-existing claude-mpm-era palace for a repo is the BARE repo name
+//! (`trusty-tools`). When the `owner-repo` palace was never created, every memory
+//! tool call in the session fails with "palace metadata missing" while the real
+//! history lives under the bare name — memory is split-brained (issue #1939). The
+//! maintainer's chosen fix is to ALIAS both names, so this module registers a
+//! palace-level alias `owner-repo -> bare-repo` at launch when — and only when —
+//! that split-brain condition holds.
+//!
+//! What: [`maybe_register_palace_alias`] resolves the effective git remote,
+//! derives the owner-repo and bare names, and (guarded on an absent owner-repo
+//! palace plus a present bare palace, and no operator override) persists the
+//! alias via [`trusty_common::palace_alias::PalaceAliasStore`]. It is best-effort
+//! and side-effect-only: every failure is swallowed with at most a `tracing` line
+//! so the launch and palace pinning proceed unchanged.
+//!
+//! Test: `tests` in this module cover the split-brain registration and the two
+//! no-op guards (owner-repo already exists; no bare palace).
+
+use std::path::Path;
+
+use super::settings::git_remote_origin;
+
+/// Register a palace-level alias `owner-repo -> bare-repo` when needed (issue #1939).
+///
+/// Why: heals the claude-mpm memory split-brain (see module docs) by making the
+/// pinned `owner-repo` palace name resolve to the existing bare-repo store,
+/// WITHOUT renaming or recreating either palace. Registering only in the true
+/// split-brain case keeps `owner-repo` canonical whenever it already exists (or
+/// when there is no bare palace to inherit), exactly as before.
+/// What: bails when an operator `TRUSTY_MEMORY_PALACE` override is set (the name
+/// was chosen deliberately). Otherwise resolves the effective remote (explicit
+/// arg, else `git remote get-url origin` under `project_path`), derives the
+/// owner-repo ([`trusty_common::owner_repo_from_git_remote`]) and bare
+/// ([`trusty_common::repo_slug_from_git_remote`]) names, and — when they differ,
+/// the owner-repo palace is missing on disk, and the bare palace exists — calls
+/// [`trusty_common::palace_alias::PalaceAliasStore::register_alias`] in the
+/// trusty-memory registry dir ([`trusty_common::palace_alias::default_palace_registry_dir`]).
+/// Never returns a value or errors; failures are logged and ignored.
+/// Test: `creates_alias_for_split_brain`, `noop_when_owner_repo_exists`,
+/// `noop_when_no_bare_palace`, `noop_when_override_set`.
+pub(super) fn maybe_register_palace_alias(project_path: &Path, git_remote: Option<&str>) {
+    // An explicit operator override means the palace name was chosen
+    // deliberately — do not second-guess it with an alias.
+    if trusty_common::palace_override_from_env().is_some() {
+        return;
+    }
+
+    let probed = match git_remote {
+        Some(_) => None,
+        None => git_remote_origin(project_path),
+    };
+    let Some(remote) = git_remote.map(str::to_string).or(probed) else {
+        return;
+    };
+
+    let Some(owner_repo) = trusty_common::owner_repo_from_git_remote(&remote) else {
+        return;
+    };
+    let Some(bare) = trusty_common::repo_slug_from_git_remote(&remote) else {
+        return;
+    };
+    // No owner segment (owner_repo == bare) — nothing to alias.
+    if owner_repo == bare {
+        return;
+    }
+
+    let registry_dir = match trusty_common::palace_alias::default_palace_registry_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "skipping palace-alias registration: cannot resolve registry dir"
+            );
+            return;
+        }
+    };
+
+    let owner_repo_exists = registry_dir.join(&owner_repo).join("palace.json").exists();
+    let bare_exists = registry_dir.join(&bare).join("palace.json").exists();
+    // Only heal the split-brain: owner-repo missing AND bare present.
+    if owner_repo_exists || !bare_exists {
+        return;
+    }
+
+    match trusty_common::palace_alias::PalaceAliasStore::register_alias(
+        &registry_dir,
+        &owner_repo,
+        &bare,
+    ) {
+        Ok(()) => tracing::info!(
+            alias = %owner_repo,
+            target = %bare,
+            "registered palace-level alias to heal claude-mpm memory parity (#1939)"
+        ),
+        Err(e) => tracing::warn!(
+            alias = %owner_repo,
+            target = %bare,
+            error = %e,
+            "failed to register palace-level alias (#1939); session will pin owner-repo unaliased"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+    use trusty_common::palace_alias::PalaceAliasStore;
+
+    /// A GitHub remote whose derived names are `bobmatnyc-trusty-tools` (owner-repo)
+    /// and `trusty-tools` (bare) — the exact split-brain pair from issue #1939.
+    const REMOTE: &str = "git@github.com:bobmatnyc/trusty-tools.git";
+    const OWNER_REPO: &str = "bobmatnyc-trusty-tools";
+    const BARE: &str = "trusty-tools";
+
+    /// RAII guard that sets/clears an env var for the duration of a `#[serial]`
+    /// test and restores the prior value on drop.
+    ///
+    /// Why: [`maybe_register_palace_alias`] reads the process-global
+    /// `TRUSTY_MEMORY_PALACE` (override) and `TRUSTY_DATA_DIR_OVERRIDE` (registry
+    /// dir) env vars. Tests must set them deterministically and restore them so
+    /// siblings are unaffected; `#[serial]` serialises the mutation.
+    /// What: `set`/`clear` snapshot the prior value; `Drop` restores it.
+    /// Test: exercised by every test in this module.
+    struct EnvGuard {
+        key: &'static str,
+        prior: Option<String>,
+    }
+    impl EnvGuard {
+        fn set(key: &'static str, value: &Path) -> Self {
+            let prior = std::env::var(key).ok();
+            // SAFETY: env-mutating tests here are tagged `#[serial]`.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prior }
+        }
+        fn clear(key: &'static str) -> Self {
+            let prior = std::env::var(key).ok();
+            // SAFETY: serialised by `#[serial]`.
+            unsafe { std::env::remove_var(key) };
+            Self { key, prior }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: serialised by `#[serial]`.
+            match &self.prior {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    /// Create `<registry_dir>/<id>/palace.json` (empty is enough — existence is
+    /// all the alias gate checks).
+    fn make_palace(registry_dir: &Path, id: &str) {
+        let dir = registry_dir.join(id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("palace.json"), b"{}").unwrap();
+    }
+
+    /// The registry dir resolves to `<data_override>/trusty-memory` (no `palaces/`
+    /// subdir created in these tests).
+    fn registry_dir(data_override: &Path) -> PathBuf {
+        data_override.join("trusty-memory")
+    }
+
+    /// Why: the headline #1939 fix — with the bare palace present and the
+    /// owner-repo palace absent, launch must register the alias so the pinned
+    /// owner-repo name resolves to the bare store.
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn creates_alias_for_split_brain() {
+        let data = tempdir().unwrap();
+        let _override = EnvGuard::clear("TRUSTY_MEMORY_PALACE");
+        let _data = EnvGuard::set("TRUSTY_DATA_DIR_OVERRIDE", data.path());
+
+        let reg = registry_dir(data.path());
+        make_palace(&reg, BARE); // bare exists, owner-repo does not.
+
+        maybe_register_palace_alias(Path::new("/unused"), Some(REMOTE));
+
+        assert_eq!(
+            PalaceAliasStore::resolve_alias(&reg, OWNER_REPO).unwrap().as_deref(),
+            Some(BARE),
+            "split-brain must register {OWNER_REPO} -> {BARE}"
+        );
+    }
+
+    /// Why: when the owner-repo palace already exists there is no split-brain —
+    /// registration must be a no-op so owner-repo stays canonical.
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn noop_when_owner_repo_exists() {
+        let data = tempdir().unwrap();
+        let _override = EnvGuard::clear("TRUSTY_MEMORY_PALACE");
+        let _data = EnvGuard::set("TRUSTY_DATA_DIR_OVERRIDE", data.path());
+
+        let reg = registry_dir(data.path());
+        make_palace(&reg, BARE);
+        make_palace(&reg, OWNER_REPO); // owner-repo already present.
+
+        maybe_register_palace_alias(Path::new("/unused"), Some(REMOTE));
+
+        assert_eq!(
+            PalaceAliasStore::resolve_alias(&reg, OWNER_REPO).unwrap(),
+            None,
+            "no alias should be registered when the owner-repo palace exists"
+        );
+    }
+
+    /// Why: with no bare palace to inherit there is nothing to alias to — the
+    /// owner-repo palace is created fresh as today, so registration is a no-op.
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn noop_when_no_bare_palace() {
+        let data = tempdir().unwrap();
+        let _override = EnvGuard::clear("TRUSTY_MEMORY_PALACE");
+        let _data = EnvGuard::set("TRUSTY_DATA_DIR_OVERRIDE", data.path());
+
+        let reg = registry_dir(data.path());
+        std::fs::create_dir_all(&reg).unwrap(); // registry dir exists, no palaces.
+
+        maybe_register_palace_alias(Path::new("/unused"), Some(REMOTE));
+
+        assert_eq!(
+            PalaceAliasStore::resolve_alias(&reg, OWNER_REPO).unwrap(),
+            None,
+            "no alias should be registered when no bare palace exists"
+        );
+    }
+
+    /// Why: an operator `TRUSTY_MEMORY_PALACE` override is a deliberate choice;
+    /// registration must bail even if a split-brain would otherwise be detected.
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn noop_when_override_set() {
+        let data = tempdir().unwrap();
+        let _override = EnvGuard::set("TRUSTY_MEMORY_PALACE", Path::new("operator-choice"));
+        let _data = EnvGuard::set("TRUSTY_DATA_DIR_OVERRIDE", data.path());
+
+        let reg = registry_dir(data.path());
+        make_palace(&reg, BARE); // split-brain present...
+
+        maybe_register_palace_alias(Path::new("/unused"), Some(REMOTE));
+
+        assert_eq!(
+            PalaceAliasStore::resolve_alias(&reg, OWNER_REPO).unwrap(),
+            None,
+            "an operator override must suppress alias registration"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/session_launch/palace_alias.rs
+++ b/crates/trusty-mpm/src/core/session_launch/palace_alias.rs
@@ -186,7 +186,9 @@ mod tests {
         maybe_register_palace_alias(Path::new("/unused"), Some(REMOTE));
 
         assert_eq!(
-            PalaceAliasStore::resolve_alias(&reg, OWNER_REPO).unwrap().as_deref(),
+            PalaceAliasStore::resolve_alias(&reg, OWNER_REPO)
+                .unwrap()
+                .as_deref(),
             Some(BARE),
             "split-brain must register {OWNER_REPO} -> {BARE}"
         );

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -375,6 +375,12 @@ pub(super) fn inject_trusty_memory_mcp(
     git_remote: Option<&str>,
 ) -> Result<(), PrepError> {
     let slug = resolve_palace_slug(project_path, git_remote);
+    // Issue #1939: before pinning, heal the claude-mpm split-brain — if the
+    // derived `owner-repo` palace does not exist but the BARE repo-name palace
+    // does, register a palace-level alias so the pinned `owner-repo` name resolves
+    // to the existing bare store. Best-effort and side-effect-only; never fails
+    // the launch.
+    super::palace_alias::maybe_register_palace_alias(project_path, git_remote);
     inject_mcp_server(
         project_path,
         "trusty-memory",
@@ -426,7 +432,7 @@ fn resolve_palace_slug(project_path: &Path, git_remote: Option<&str>) -> Option<
 /// absent, or `start` is not in a repo. No network.
 /// Test: exercised indirectly via `resolve_palace_slug_falls_back_to_git_remote`
 /// (a temp git repo) and the daemon-less paths in `inject_trusty_memory_mcp_*`.
-fn git_remote_origin(start: &Path) -> Option<String> {
+pub(super) fn git_remote_origin(start: &Path) -> Option<String> {
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(start)


### PR DESCRIPTION
Closes #1939

## Problem

`tm` pins a managed session's `TRUSTY_MEMORY_PALACE` to the `owner-repo` slug from `derive_palace_id` (e.g. `bobmatnyc-trusty-tools`), but the pre-existing claude-mpm-era palace for this repo is the BARE repo name `trusty-tools`. The owner-repo palace never existed, so every MCP memory tool call failed with `palace metadata missing` while the real history lived under `trusty-tools`. Memory was split-brained.

## Fix (ALIAS both names — maintainer decision)

A new **palace-level** alias mechanism (distinct from the in-palace term/KG `add_alias`/`discover_aliases` entity aliases) lets both names resolve to one on-disk store.

### trusty-common
- **`palace_alias`** — new always-compiled module (no `memory-core` gate, so trusty-mpm's always-on launch path can use it). Persists `<registry_dir>/palace_aliases.json` (`{version, aliases}`), with atomic writes and a forgiving read (missing/empty/corrupt → no aliases). API: `load_aliases` / `register_alias` (idempotent; rejects empty + self-alias) / `resolve_alias`, plus `default_palace_registry_dir` and `palace_registry_dir_from`.
- **`PalaceRegistry::open_palace`** now consults the alias map **only** when the requested palace has no on-disk metadata **and** the alias target exists — redirecting to (and caching under) the canonical target so the alias and the real name share **one** handle (never two writers over the same redb files). A real palace always wins over an alias of the same name; a stale alias to a missing target does not redirect.
- **`repo_slug_from_git_remote`** — bare repo name (no owner), factored with `owner_repo_from_git_remote` from a shared `parse_owner_repo_slugs` core (no ambiguous `-` splitting).

### trusty-memory
- `resolve_palace_registry_dir` now delegates to `trusty_common::palace_alias::palace_registry_dir_from` — single source of truth for the registry-dir layout so the writer (mpm) and reader (daemon) can never disagree on where the alias file lives.

### trusty-mpm
- Session launch registers `owner-repo -> bare-repo` when the owner-repo palace is absent but the bare palace exists (best-effort, side-effect-only, never fails the launch; skipped under an operator `TRUSTY_MEMORY_PALACE` override). owner-repo stays canonical when there is no bare palace to inherit. Extracted into `session_launch/palace_alias.rs` (keeps `settings.rs` under the 500 SLOC cap).

## Tests
- trusty-common: `palace_alias::tests` (round-trip, idempotency, self/empty rejection, corruption degrade, subdir resolution); `palace_id` `repo_slug_*`; `registry` `open_palace_follows_alias` / `_ignores_alias_when_target_missing` / `_prefers_real_palace_over_alias`.
- trusty-mpm: `session_launch::palace_alias::tests` (split-brain registration + three no-op guards).
- `cargo test -p trusty-common` (435), `-p trusty-memory` (all), `-p trusty-mpm` (all) green; `cargo clippy --workspace --all-targets -- -D warnings` clean; line-cap clean.

## Real-data verification
A temporary read-only harness (not committed) opened the real palaces dir: `open_palace("bobmatnyc-trusty-tools")` resolved to canonical `trusty-tools` and returned **152** real drawers.

To verify after installing the new binaries: recall in a `tm` session pinned to `bobmatnyc-trusty-tools` returns the `trusty-tools` history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)