### PR TITLE
feat(trusty-mpm): PreToolUse Bash command-rewrite spike + compress subcommand (#1956)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -194,6 +194,28 @@ pub(crate) enum Command {
     /// a daemon restart never blocks the user's prompt.
     /// Test: `cli_parses_hook` plus the inline `hook_guard_short_circuits`.
     Hook,
+    /// Compress a piped command's stdout — the `tm hook` PreToolUse Bash
+    /// command-rewrite spike's filter stage (issue #1956, Option 0).
+    ///
+    /// Why: `tm hook` rewrites a Bash tool call's command to
+    /// `<original> | tm compress --tool "<effective tool name>"` (the tool
+    /// name is derived from the wrapped command — e.g. `"cargo test"`,
+    /// `"git diff"` — not a hardcoded `"bash"`, see
+    /// `commands::hook_rewrite::effective_tool_name`) so Claude Code's own
+    /// subprocess execution produces already-compressed output before the
+    /// model ever sees the raw payload — see
+    /// `docs/specs/tool-output-interception-seam.md` §Option 0.
+    /// What: reads all of stdin, compresses it via
+    /// `trusty_agents_common::compress::compress_tool_output_async_with_path`
+    /// (hoisted from `trusty-agents` in issue #1959), logs a structured
+    /// stats line, and writes the compressed text to stdout.
+    /// Test: `cli_parses_compress` plus `commands::compress`'s unit tests
+    /// and the `tm_compress_pipe` integration test.
+    Compress {
+        /// Tool name used to select the compression filter (e.g. "cargo test").
+        #[arg(long)]
+        tool: String,
+    },
     /// Run the trusty-mpm daemon.
     Daemon {
         /// Address the daemon HTTP API binds to.

--- a/crates/trusty-mpm/src/bin/tm/commands/compress.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/compress.rs
@@ -1,0 +1,151 @@
+//! `tm compress --tool <name>` — pipe-filter subcommand for the `tm hook`
+//! `PreToolUse` Bash command-rewrite spike (issue #1956).
+//!
+//! Why: Option 0 (`docs/specs/tool-output-interception-seam.md`) rewrites a
+//! Bash tool call's command to
+//! `<original> | tm compress --tool "<effective tool name>"` (the tool name
+//! is derived from the wrapped command by
+//! `commands::hook_rewrite::effective_tool_name` — e.g. `"cargo test"`,
+//! `"git diff"` — not a hardcoded `"bash"`, since `compress_tool_output`'s
+//! dispatch table matches filters by substring against the tool name) so
+//! Claude Code's own subprocess execution produces already-compressed
+//! output — this binary is the pipe's filter stage. It exists so the
+//! rewrite in `commands::hook_rewrite`/`commands::misc::hook` has something
+//! real to pipe into.
+//! What: Reads the piped command's full stdout from stdin to EOF,
+//! compresses it via the hoisted
+//! `trusty_agents_common::compress::compress_tool_output_async_with_path`
+//! (issue #1959), emits a structured `tracing::info!` stats log line to
+//! stderr (never stdout — stdout carries the compressed payload back to the
+//! shell pipeline), and writes the compressed text to stdout.
+//! Test: `run_compress_shrinks_repetitive_cargo_test_output`,
+//! `log_compression_stats_pct_reduction_is_zero_for_empty_input`,
+//! `run_compress_passes_through_short_output_unchanged` below.
+
+use std::io::Read;
+
+use trusty_agents_common::compress::compress_tool_output_async_with_path;
+
+/// Run `tm compress --tool <tool>`: read stdin, compress, log stats, print.
+///
+/// Why: the single entry point the rewritten Bash command pipes into
+/// (`<cmd> | tm compress --tool "<effective tool name>"`); must behave like
+/// a well-mannered Unix filter — read all of stdin, write the (possibly
+/// unchanged) result to stdout, exit 0 — so it never breaks the exit-code
+/// semantics of whatever pipeline it's the tail of.
+/// What: Blocks until stdin reaches EOF (this is intentional — the whole
+/// point is to wait for the wrapped command to finish producing output),
+/// compresses via [`compress_tool_output_async_with_path`], logs
+/// `tool_name`/`bytes_before`/`bytes_after`/`pct_reduction`/
+/// `compression_path` at `info` level, then prints the compressed text.
+/// Test: See module tests; `tm compress` has no daemon-only tracing
+/// subscriber from `main()` (that only inits for `Daemon`/`Supervisor`), so
+/// this function installs its own stderr-writing subscriber via
+/// `try_init()` — idempotent, safe to call from every invocation including
+/// under `cargo test`.
+pub(crate) async fn run_compress(tool: &str) -> anyhow::Result<()> {
+    init_stats_log_subscriber();
+
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input)?;
+
+    let (compressed, path) = compress_tool_output_async_with_path(tool, &input).await;
+    log_compression_stats(tool, input.len(), compressed.len(), path.as_str());
+
+    print!("{compressed}");
+    Ok(())
+}
+
+/// Install a stderr-only tracing subscriber for short-lived `tm compress`
+/// invocations.
+///
+/// Why: `main()` only initializes a global tracing subscriber for
+/// long-running modes (`Daemon`/`Supervisor`) — every other CLI subcommand,
+/// including this one, otherwise has no registered subscriber and
+/// `tracing::info!` calls are silently dropped. Without this, issue #1956's
+/// stats-logging requirement would produce no output at all.
+/// What: `tracing_subscriber::fmt()` writing to stderr (never stdout — see
+/// module docs), filtered by `RUST_LOG` (default `info`). Uses `try_init`
+/// so repeated calls (e.g. across unit tests in the same process) are a
+/// harmless no-op rather than a panic.
+/// Test: Exercised indirectly by every `run_compress_*` test capturing
+/// `tracing_test`-free stderr is out of scope for this spike; the log
+/// *content* is verified directly via [`log_compression_stats`]'s own test.
+fn init_stats_log_subscriber() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .with_writer(std::io::stderr)
+        .try_init();
+}
+
+/// Emit the structured compression-effectiveness stats log line.
+///
+/// Why: Split out from [`run_compress`] so the exact field set is a
+/// directly testable, single-purpose function — this is the foundational
+/// per-event log line a broader meta-harness aggregation effort (tracked
+/// separately, out of scope here) will eventually consume.
+/// What: One `tracing::info!` with `tool_name`, `bytes_before`,
+/// `bytes_after`, `pct_reduction` (0.0 when `bytes_before` is 0), and
+/// `compression_path` (`"rtk_binary"` / `"native_fallback"`, see
+/// [`trusty_agents_common::compress::CompressionPath`]) as structured
+/// fields, machine-parseable from `RUST_LOG=info` output.
+/// Test: `log_compression_stats_pct_reduction_is_zero_for_empty_input`,
+/// exercised end-to-end via `run_compress_*` tests below.
+fn log_compression_stats(tool_name: &str, bytes_before: usize, bytes_after: usize, path: &str) {
+    let pct_reduction = if bytes_before > 0 {
+        (1.0 - bytes_after as f64 / bytes_before as f64) * 100.0
+    } else {
+        0.0
+    };
+    tracing::info!(
+        tool_name = %tool_name,
+        bytes_before,
+        bytes_after,
+        pct_reduction,
+        compression_path = %path,
+        "tool output compressed"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_compression_stats_pct_reduction_is_zero_for_empty_input() {
+        // Guards the division-by-zero edge case: an empty tool output must
+        // report 0.0% reduction, not NaN/panic.
+        log_compression_stats("bash", 0, 0, "native_fallback");
+    }
+
+    #[tokio::test]
+    async fn run_compress_shrinks_repetitive_cargo_test_output() {
+        // `compress_tool_output_async_with_path` is exercised directly here
+        // (rather than through stdin/stdout) so the test doesn't depend on
+        // process-level stdio redirection — `run_compress` itself is a thin
+        // wrapper proven correct by inspection plus this + the stats test.
+        let mut input = String::new();
+        for i in 0..50 {
+            input.push_str(&format!("test mod::t{i} ... ok\n"));
+        }
+        input.push_str("test result: ok. 50 passed; 0 failed\n");
+        let (compressed, _path) = compress_tool_output_async_with_path("cargo test", &input).await;
+        assert!(
+            compressed.len() < input.len(),
+            "expected compression to shrink repetitive passing-test output"
+        );
+        assert!(compressed.contains("test result"));
+    }
+
+    #[tokio::test]
+    async fn run_compress_passes_through_short_output_unchanged() {
+        // Below the 80-byte size gate in `compress_tool_output` — must be a
+        // verbatim passthrough, proving `tm compress` never mangles small
+        // Bash results (exit codes, short status lines).
+        let input = "ok\n";
+        let (compressed, _path) = compress_tool_output_async_with_path("bash", input).await;
+        assert_eq!(compressed, input);
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
@@ -1,0 +1,382 @@
+//! `tm hook` `PreToolUse` Bash command-rewrite logic — Option 0 spike (#1956).
+//!
+//! Why: `docs/specs/tool-output-interception-seam.md` §Option 0 documents a
+//! pre-context-insertion compression seam for Bash: rewrite the *command*
+//! Claude Code is about to execute so the subprocess's own stdout is already
+//! filtered by the time the tool result is captured — the same trick
+//! claude-mpm's `ztk` hook uses (`hooks/ztk_hook.py`), but piping through
+//! `tm compress` instead of an external Zig binary. That doc's Tradeoffs
+//! section calls out the exact incident this must defend against from day
+//! one: an earlier orchestrator command (a SAM build) broke when wrapped
+//! unconditionally, because appending a pipe can change exit-code semantics
+//! (`set -o pipefail` interactions) for build tools that spawn long
+//! subprocess chains.
+//! What: [`rewrite_bash_command_for_compression`] is the single entry point —
+//! it returns `None` (meaning: do not rewrite, forward the command
+//! unmodified) for empty commands, day-one orchestrator exclusions
+//! (`make`/`sam`/`rake`/`gradle`/`gradlew`/`mvn`/`ant`/`cdk`/`terraform`,
+//! mirroring claude-mpm's `_ORCHESTRATOR_EXCLUSIONS`), and any command that
+//! already contains pipe/chain composition (`|`, `&&`, `;`) since appending
+//! another pipe to those is the same class of risk. Otherwise it returns
+//! `Some(rewritten)` with `| tm compress --tool "<effective tool name>"`
+//! appended — see [`effective_tool_name`] for why the tool value is derived
+//! from the command rather than a hardcoded `"bash"`.
+//! [`build_pretooluse_rewrite_response`] builds the
+//! `hookSpecificOutput.updatedInput` JSON body `tm hook` prints to stdout so
+//! Claude Code substitutes the rewritten command before executing it.
+//! Test: `rewrite_*`, `is_orchestrator_command_*`, `first_command_token_*`,
+//! `build_pretooluse_rewrite_response_*` below.
+
+/// Day-one orchestrator-command exclusion list.
+///
+/// Why: These tools spawn long, multi-stage subprocess chains where an
+/// unconditional `| tm compress --tool bash` wrap has already caused a real
+/// incident (a SAM build silently truncated at a later stage — see the
+/// design doc's Tradeoffs section and `docs/specs/SPEC-INSTALLER-01.md:150`).
+/// Mirrors claude-mpm's `_ORCHESTRATOR_EXCLUSIONS` (`hooks/ztk_hook.py`
+/// ~lines 49-69) so this spike inherits the same day-one safety margin
+/// rather than rediscovering the failure mode.
+/// What: Matched against the command's first whitespace-delimited token
+/// (after stripping env-var-assignment prefixes, `sudo`, and any leading
+/// path) by [`is_orchestrator_command`].
+/// Test: `is_orchestrator_command_matches_known_exclusions`.
+const ORCHESTRATOR_EXCLUSIONS: &[&str] = &[
+    "make",
+    "sam",
+    "rake",
+    "gradle",
+    "gradlew",
+    "mvn",
+    "ant",
+    "cdk",
+    "terraform",
+];
+
+/// Decide whether `command` is safe to rewrite, and build the rewrite.
+///
+/// Why: Centralises the "is this rewrite safe?" decision so `tm hook` can
+/// stay a thin caller — better to under-rewrite (skip a compressible
+/// command) than to break a working one, per the design doc's explicit
+/// tradeoff framing.
+/// What: Returns `None` (no-op — forward the original command unmodified)
+/// when `command` is empty/whitespace-only, matches
+/// [`is_orchestrator_command`], or already contains pipe/chain composition
+/// (see [`has_unsafe_pipe_composition`]). Otherwise returns
+/// `Some("<command> | tm compress --tool \"<effective tool name>\"")` —
+/// the `--tool` value comes from [`effective_tool_name`], **not** a
+/// hardcoded `"bash"`: `compress_tool_output`'s dispatch table
+/// (`trusty-agents-common::compress::tool_output`) matches filters by
+/// substring against the tool name (`"cargo"`, `"diff"`, `"log"`, …), so a
+/// literal `"bash"` would never match any filter branch and every rewritten
+/// command would silently pass through with 0% compression — defeating the
+/// entire point of this spike. Quoted because the derived name may contain
+/// a space (e.g. `"cargo test"`).
+/// Test: `rewrite_appends_compress_pipe_for_plain_command`,
+/// `rewrite_appends_compress_pipe_with_subcommand_tool_name`,
+/// `rewrite_skips_orchestrator_commands`, `rewrite_skips_piped_commands`,
+/// `rewrite_skips_chained_commands`, `rewrite_skips_empty_command`.
+pub(crate) fn rewrite_bash_command_for_compression(command: &str) -> Option<String> {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if is_orchestrator_command(trimmed) {
+        return None;
+    }
+    if has_unsafe_pipe_composition(trimmed) {
+        return None;
+    }
+    let tool = effective_tool_name(trimmed);
+    Some(format!("{trimmed} | tm compress --tool \"{tool}\""))
+}
+
+/// Derive the `compress_tool_output` dispatch key from a Bash command.
+///
+/// Why: The dispatch table in `trusty-agents-common::compress::tool_output`
+/// matches per-tool filters by substring against a `tool_name` string shaped
+/// like `"cargo test"` / `"git diff"` (see that module's `cargo`/`git`
+/// branches) — it has no branch for the literal string `"bash"`. Passing
+/// the command's actual program + subcommand lets the existing `cargo
+/// test`/`cargo check`/`git diff`/`git log` filters fire for the domains
+/// they already cover; commands outside that coverage (e.g. `grep`, `ls`)
+/// still pass through unchanged, which matches this repo's own documented
+/// filter-coverage gap (`docs/specs/tool-output-interception-seam.md`
+/// §Spike) rather than a new regression.
+/// What: Strips the same env-assignment/`sudo`/path noise
+/// [`first_command_token`] strips, then returns `"<program> <subcommand>"`
+/// when a second whitespace-delimited token follows, else just `<program>`.
+/// Test: `effective_tool_name_joins_program_and_subcommand`,
+/// `effective_tool_name_single_token_command`,
+/// `effective_tool_name_strips_env_and_sudo_noise`.
+fn effective_tool_name(command: &str) -> String {
+    let mut tokens = command.split_whitespace();
+    let Some(mut first) = tokens.next() else {
+        return String::new();
+    };
+    while is_env_assignment(first) {
+        let Some(next) = tokens.next() else {
+            return String::new();
+        };
+        first = next;
+    }
+    if first == "sudo" {
+        first = tokens.next().unwrap_or(first);
+    }
+    let program = first.rsplit('/').next().unwrap_or(first);
+    match tokens.next() {
+        Some(subcommand) => format!("{program} {subcommand}"),
+        None => program.to_string(),
+    }
+}
+
+/// Whether `command`'s first token matches a known orchestrator exclusion.
+///
+/// Why: Split out from [`rewrite_bash_command_for_compression`] for direct
+/// unit testing of the matching rule independent of the rewrite string
+/// format.
+/// What: Delegates token extraction to [`first_command_token`], then does a
+/// case-sensitive exact match against [`ORCHESTRATOR_EXCLUSIONS`].
+/// Test: `is_orchestrator_command_matches_known_exclusions`,
+/// `is_orchestrator_command_ignores_unrelated_commands`.
+fn is_orchestrator_command(command: &str) -> bool {
+    match first_command_token(command) {
+        Some(token) => ORCHESTRATOR_EXCLUSIONS.contains(&token),
+        None => false,
+    }
+}
+
+/// Extract the effective first command token, stripping noise prefixes.
+///
+/// Why: A raw `command.split_whitespace().next()` would miss
+/// `FOO=bar make build` (env-var prefix), `sudo make install`, and
+/// `/usr/bin/make` (absolute path) — all of which should still match
+/// `make` for exclusion purposes. Being permissive here trades a little
+/// precision for staying on the safe (under-rewrite) side.
+/// What: Skips any number of leading `KEY=value`-shaped tokens, then a
+/// single leading `sudo`, then returns the basename (post-`/`) of whatever
+/// token remains.
+/// Test: `first_command_token_strips_env_assignment`,
+/// `first_command_token_strips_sudo`, `first_command_token_strips_path`,
+/// `first_command_token_plain_command`.
+fn first_command_token(command: &str) -> Option<&str> {
+    let mut tokens = command.split_whitespace();
+    let mut tok = tokens.next()?;
+    while is_env_assignment(tok) {
+        tok = tokens.next()?;
+    }
+    if tok == "sudo" {
+        tok = tokens.next()?;
+    }
+    Some(tok.rsplit('/').next().unwrap_or(tok))
+}
+
+/// Whether `token` looks like a `KEY=value` shell environment assignment.
+///
+/// Why: Shared by [`first_command_token`]; split out so the "what counts as
+/// an env assignment" rule has one definition.
+/// What: `KEY` must be non-empty, start with a letter or underscore, and
+/// contain only alphanumerics/underscores up to the first `=`.
+fn is_env_assignment(token: &str) -> bool {
+    let Some((key, _value)) = token.split_once('=') else {
+        return false;
+    };
+    !key.is_empty()
+        && key
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Whether `command` already contains pipe/chain composition.
+///
+/// Why: Appending a second pipe to a command that already pipes/chains
+/// (`|`, `&&`, `;`) is the same class of risk the orchestrator exclusion
+/// guards against — the design doc explicitly calls out "don't rewrite
+/// something that already contains a `|` or `&&`/`;` chain that could break
+/// under an additional pipe".
+/// What: Simple substring checks — deliberately conservative (a command
+/// with `|`/`&&`/`;` inside a quoted string literal will also be skipped;
+/// under-rewriting is the safe failure mode here).
+/// Test: `has_unsafe_pipe_composition_detects_pipe`,
+/// `has_unsafe_pipe_composition_detects_and_chain`,
+/// `has_unsafe_pipe_composition_detects_semicolon`,
+/// `has_unsafe_pipe_composition_false_for_plain_command`.
+fn has_unsafe_pipe_composition(command: &str) -> bool {
+    command.contains('|') || command.contains("&&") || command.contains(';')
+}
+
+/// Build the `hookSpecificOutput.updatedInput` JSON body for a `PreToolUse`
+/// Bash command rewrite.
+///
+/// Why: This is the JSON shape `tm hook` prints to stdout so Claude Code
+/// substitutes `rewritten_command` for the original before executing it.
+/// **Unverified against a live Claude Code instance** — implemented per the
+/// shape sketched in `docs/specs/tool-output-interception-seam.md` §Option 0
+/// (itself derived from claude-mpm's `ztk_hook.py::_build_ztk_response_impl`
+/// convention), since no reference to `hookSpecificOutput`/`updatedInput`
+/// exists elsewhere in this repo's docs. Needs live validation before this
+/// spike is considered production-ready.
+/// What: `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+/// "updatedInput": {"command": rewritten_command}}}`.
+/// Test: `build_pretooluse_rewrite_response_has_expected_shape`.
+pub(crate) fn build_pretooluse_rewrite_response(rewritten_command: &str) -> serde_json::Value {
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "updatedInput": { "command": rewritten_command }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrite_appends_compress_pipe_for_plain_command() {
+        let out = rewrite_bash_command_for_compression("cargo test");
+        assert_eq!(
+            out.as_deref(),
+            Some("cargo test | tm compress --tool \"cargo test\"")
+        );
+    }
+
+    #[test]
+    fn rewrite_appends_compress_pipe_with_subcommand_tool_name() {
+        // The `--tool` value must be the derived "<program> <subcommand>"
+        // pair (matching the compress dispatch table's filter keys), not a
+        // hardcoded "bash" — see `effective_tool_name`'s doc comment for why
+        // a literal "bash" would never match any filter branch.
+        let out = rewrite_bash_command_for_compression("git diff HEAD~1");
+        assert_eq!(
+            out.as_deref(),
+            Some("git diff HEAD~1 | tm compress --tool \"git diff\"")
+        );
+    }
+
+    #[test]
+    fn rewrite_skips_orchestrator_commands() {
+        for cmd in [
+            "make build",
+            "sam deploy",
+            "terraform apply",
+            "gradlew build",
+        ] {
+            assert_eq!(
+                rewrite_bash_command_for_compression(cmd),
+                None,
+                "expected no rewrite for orchestrator command: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_skips_piped_commands() {
+        assert_eq!(
+            rewrite_bash_command_for_compression("cargo test | tee out.log"),
+            None
+        );
+    }
+
+    #[test]
+    fn rewrite_skips_chained_commands() {
+        assert_eq!(
+            rewrite_bash_command_for_compression("cargo build && cargo test"),
+            None
+        );
+        assert_eq!(rewrite_bash_command_for_compression("cd /tmp; ls"), None);
+    }
+
+    #[test]
+    fn rewrite_skips_empty_command() {
+        assert_eq!(rewrite_bash_command_for_compression(""), None);
+        assert_eq!(rewrite_bash_command_for_compression("   "), None);
+    }
+
+    #[test]
+    fn is_orchestrator_command_matches_known_exclusions() {
+        assert!(is_orchestrator_command("make"));
+        assert!(is_orchestrator_command("sudo make install"));
+        assert!(is_orchestrator_command("FOO=bar make build"));
+        assert!(is_orchestrator_command("/usr/bin/make build"));
+    }
+
+    #[test]
+    fn is_orchestrator_command_ignores_unrelated_commands() {
+        assert!(!is_orchestrator_command("cargo test"));
+        assert!(!is_orchestrator_command("git diff"));
+    }
+
+    #[test]
+    fn first_command_token_strips_env_assignment() {
+        assert_eq!(first_command_token("FOO=bar make build"), Some("make"));
+    }
+
+    #[test]
+    fn first_command_token_strips_sudo() {
+        assert_eq!(first_command_token("sudo make install"), Some("make"));
+    }
+
+    #[test]
+    fn first_command_token_strips_path() {
+        assert_eq!(first_command_token("/usr/bin/make build"), Some("make"));
+    }
+
+    #[test]
+    fn first_command_token_plain_command() {
+        assert_eq!(first_command_token("cargo test"), Some("cargo"));
+    }
+
+    #[test]
+    fn effective_tool_name_joins_program_and_subcommand() {
+        assert_eq!(effective_tool_name("cargo test --workspace"), "cargo test");
+        assert_eq!(effective_tool_name("git diff HEAD~1"), "git diff");
+    }
+
+    #[test]
+    fn effective_tool_name_single_token_command() {
+        assert_eq!(effective_tool_name("ls"), "ls");
+        assert_eq!(effective_tool_name("ls -la"), "ls -la");
+    }
+
+    #[test]
+    fn effective_tool_name_strips_env_and_sudo_noise() {
+        assert_eq!(effective_tool_name("FOO=bar cargo test"), "cargo test");
+        assert_eq!(effective_tool_name("sudo cargo test"), "cargo test");
+        assert_eq!(effective_tool_name("/usr/bin/cargo test"), "cargo test");
+    }
+
+    #[test]
+    fn has_unsafe_pipe_composition_detects_pipe() {
+        assert!(has_unsafe_pipe_composition("cargo test | tee out.log"));
+    }
+
+    #[test]
+    fn has_unsafe_pipe_composition_detects_and_chain() {
+        assert!(has_unsafe_pipe_composition("cargo build && cargo test"));
+    }
+
+    #[test]
+    fn has_unsafe_pipe_composition_detects_semicolon() {
+        assert!(has_unsafe_pipe_composition("cd /tmp; ls"));
+    }
+
+    #[test]
+    fn has_unsafe_pipe_composition_false_for_plain_command() {
+        assert!(!has_unsafe_pipe_composition("cargo test"));
+    }
+
+    #[test]
+    fn build_pretooluse_rewrite_response_has_expected_shape() {
+        let response = build_pretooluse_rewrite_response("cargo test | tm compress --tool bash");
+        assert_eq!(
+            response["hookSpecificOutput"]["hookEventName"],
+            "PreToolUse"
+        );
+        assert_eq!(
+            response["hookSpecificOutput"]["updatedInput"]["command"],
+            "cargo test | tm compress --tool bash"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -8,6 +8,9 @@
 
 use crate::cli::{CliCompressionLevel, OptimizerAction, OverseerAction};
 use crate::commands::daemon::{daemon_healthy, print_status};
+use crate::commands::hook_rewrite::{
+    build_pretooluse_rewrite_response, rewrite_bash_command_for_compression,
+};
 use crate::formatters::session::short_id;
 use crate::types::EventRow;
 
@@ -275,6 +278,42 @@ fn status_icon(status: trusty_mpm::core::doctor::CheckStatus) -> &'static str {
     }
 }
 
+/// Best-effort read of Claude Code's hook stdin JSON payload.
+///
+/// Why (issue #1956): Claude Code delivers the full hook payload — including
+/// `tool_name`/`tool_input`/`tool_response` — on the hook process's stdin,
+/// but `hook()` historically never read it (see
+/// `docs/specs/tool-output-interception-seam.md` §Problem). Reading it is a
+/// prerequisite for both the `PreToolUse` Bash rewrite (Option 0) and richer
+/// daemon observability. Bounded by a short timeout rather than reading to
+/// EOF unconditionally: Claude Code always closes stdin promptly after
+/// writing the payload, but a hook must never risk blocking the user's
+/// prompt if some future caller leaves stdin open.
+/// What: Reads up to `HOOK_STDIN_TIMEOUT` worth of stdin, then attempts a
+/// JSON parse. Returns `None` on timeout, empty input, or a parse failure —
+/// every case degrades to "no stdin payload" rather than erroring.
+/// Test: `hook_guard_short_circuits`/`hook_disable_env_short_circuits`
+/// exercise the guard branches that skip this entirely; this helper's
+/// behavior with real Claude Code stdin needs live validation (see
+/// `commands::hook_rewrite` module docs for the broader unverified-schema
+/// caveat).
+async fn read_stdin_hook_payload() -> Option<serde_json::Value> {
+    use tokio::io::AsyncReadExt;
+
+    const HOOK_STDIN_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(200);
+
+    let mut buf = String::new();
+    let read = tokio::time::timeout(
+        HOOK_STDIN_TIMEOUT,
+        tokio::io::stdin().read_to_string(&mut buf),
+    )
+    .await;
+    match read {
+        Ok(Ok(_)) if !buf.trim().is_empty() => serde_json::from_str(&buf).ok(),
+        _ => None,
+    }
+}
+
 /// `hook` subcommand — handle a Claude Code lifecycle hook event.
 ///
 /// Why: Claude Code invokes the configured hook command on every PreToolUse /
@@ -286,6 +325,19 @@ fn status_icon(status: trusty_mpm::core::doctor::CheckStatus) -> &'static str {
 /// the daemon. `TRUSTY_MPM_DISABLE_HOOKS` provides an additional escape hatch
 /// for any environment (SAM deploys, CI, stripped-PATH build shells) where
 /// the hook must not fire at all.
+///
+/// Issue #1956 (Option 0 spike) widens this beyond the original env-var-only
+/// relay: it now also reads Claude Code's stdin JSON payload (see
+/// [`read_stdin_hook_payload`]) so `tool_name`/`tool_input` can be forwarded
+/// to the daemon for observability, AND — for `PreToolUse` events where
+/// `tool_name == "Bash"` — attempts to rewrite the command to pipe through
+/// `tm compress --tool "<effective tool name>"` (see `commands::hook_rewrite`,
+/// which derives a dispatch-relevant tool name from the command rather than
+/// a hardcoded `"bash"`), printing the resulting
+/// `hookSpecificOutput.updatedInput` JSON to stdout when a safe rewrite is
+/// constructed. When no rewrite applies (excluded command, unsafe
+/// composition, or no stdin payload at all) nothing is printed — a silent
+/// no-op, matching this handler's existing fail-open posture.
 /// What: reads the event name from `CLAUDE_HOOK_EVENT` and the session id
 /// from `CLAUDE_SESSION_ID` (both populated by Claude Code; missing values
 /// degrade to placeholders so the daemon still gets a record). POSTs to
@@ -294,7 +346,10 @@ fn status_icon(status: trusty_mpm::core::doctor::CheckStatus) -> &'static str {
 /// user's prompt.
 /// Test: `cli_parses_hook` covers parse routing; the guard branches are
 /// exercised via `hook_guard_short_circuits` and
-/// `hook_disable_env_short_circuits` in `tests_behavior_a.rs`.
+/// `hook_disable_env_short_circuits` in `tests_behavior_a.rs`. The rewrite
+/// decision logic itself is covered by `commands::hook_rewrite`'s unit tests
+/// (this function is a thin caller with no independent branching to test
+/// beyond "print when `Some`, stay silent when `None`").
 pub(crate) async fn hook(client: &reqwest::Client, url: &str) -> anyhow::Result<()> {
     // Guard 1: suppress inside MPM-spawned sub-agents.
     if std::env::var_os(SUB_AGENT_ENV).is_some() {
@@ -312,16 +367,53 @@ pub(crate) async fn hook(client: &reqwest::Client, url: &str) -> anyhow::Result<
     let event = std::env::var("CLAUDE_HOOK_EVENT").unwrap_or_else(|_| "Unknown".to_string());
     let session_id = std::env::var("CLAUDE_SESSION_ID").unwrap_or_default();
 
+    // #1956: read the stdin JSON payload Claude Code delivers alongside the
+    // env vars above. `tool_name`/`tool_input` are used both for the
+    // PreToolUse Bash rewrite below and for daemon observability.
+    let stdin_payload = read_stdin_hook_payload().await;
+    let tool_name = stdin_payload
+        .as_ref()
+        .and_then(|v| v.get("tool_name"))
+        .and_then(|v| v.as_str());
+    let tool_input = stdin_payload.as_ref().and_then(|v| v.get("tool_input"));
+    let bash_command = tool_input
+        .and_then(|v| v.get("command"))
+        .and_then(|v| v.as_str());
+
+    // #1956 Option 0: PreToolUse Bash command-rewrite spike. Printed to
+    // stdout BEFORE the daemon POST below (which is best-effort
+    // observability only) so Claude Code sees the rewrite regardless of
+    // daemon reachability. No output at all when no safe rewrite applies —
+    // a silent no-op, not an error.
+    if event == "PreToolUse"
+        && tool_name == Some("Bash")
+        && let Some(cmd) = bash_command
+        && let Some(rewritten) = rewrite_bash_command_for_compression(cmd)
+    {
+        let response = build_pretooluse_rewrite_response(&rewritten);
+        println!("{response}");
+    }
+
     // Include the caller's cwd so the daemon can correlate this SessionStart
     // event to the right managed session by workspace_path (issue #1744).
     let cwd = std::env::current_dir()
         .ok()
         .and_then(|p| p.to_str().map(str::to_owned))
         .unwrap_or_default();
+    let mut payload = serde_json::json!({ "cwd": cwd });
+    // #1956: enrich the observability payload with tool/input when present —
+    // the daemon's hook_service already reads `payload["tool"]`/`["input"]`
+    // (see `daemon::services::hook_service::OverseerContext` construction).
+    if let Some(name) = tool_name {
+        payload["tool"] = serde_json::Value::String(name.to_string());
+    }
+    if let Some(input) = tool_input {
+        payload["input"] = input.clone();
+    }
     let body = serde_json::json!({
         "session_id": session_id,
         "event": event,
-        "payload": { "cwd": cwd }
+        "payload": payload
     });
 
     // Build a hook-specific client with a tight connect timeout so a

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -3,19 +3,21 @@
 //! Why: splitting each subcommand group into its own file keeps every handler
 //! file well under the 500-line cap and makes the handler surface easy to
 //! navigate.
-//! What: re-exports handler modules — `daemon`, `install`, `launch`,
-//! `managed`, `managed_route`, `meta`, `misc`, `project`, `services`,
-//! `session`, `slack`, `supervisor`, `telegram`.
+//! What: re-exports handler modules — `compress`, `daemon`, `hook_rewrite`,
+//! `install`, `launch`, `managed`, `managed_route`, `meta`, `misc`,
+//! `project`, `services`, `session`, `slack`, `supervisor`, `telegram`.
 //! Test: each module has its own unit tests; integration coverage lives in
 //! `tests.rs`.
 
 pub(crate) mod banner;
+pub(crate) mod compress;
 pub(crate) mod daemon;
 pub(crate) mod first_run;
 pub(crate) mod guided;
 pub(crate) mod guided_autostart;
 pub(crate) mod guided_launch;
 pub(crate) mod guided_launch_sse;
+pub(crate) mod hook_rewrite;
 pub(crate) mod install;
 pub(crate) mod issue;
 pub(crate) mod launch;

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -16,6 +16,7 @@ mod types;
 use clap::Parser;
 use cli::{Cli, Command};
 use commands::{
+    compress::run_compress,
     daemon::{restart, run_daemon, start, stop_daemon},
     install::install,
     launch::{connect, launch},
@@ -258,6 +259,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Slack { cmd }) => slack(cmd).await,
         Some(Command::Install { force }) => install(force),
         Some(Command::Hook) => hook(&client, &url).await,
+        Some(Command::Compress { tool }) => run_compress(&tool).await,
         Some(Command::Daemon {
             addr,
             tailscale,

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
@@ -84,6 +84,18 @@ fn cli_parses_hook() {
     assert!(matches!(cli.command.unwrap(), Command::Hook));
 }
 
+/// Why (#1956): `tm compress --tool bash` is the pipe-filter stage the
+/// `tm hook` PreToolUse Bash rewrite targets; parsing must round-trip the
+/// required `--tool` flag.
+#[test]
+fn cli_parses_compress() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "compress", "--tool", "bash"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Compress { tool } => assert_eq!(tool, "bash"),
+        other => panic!("expected Compress, got {other:?}"),
+    }
+}
+
 /// Why: when `CLAUDE_MPM_SUB_AGENT` is present in the env, the hook
 /// handler must return Ok(()) without performing any I/O — that is the
 /// whole point of the sub-agent guard.

--- a/crates/trusty-mpm/tests/tm_compress_pipe.rs
+++ b/crates/trusty-mpm/tests/tm_compress_pipe.rs
@@ -1,0 +1,104 @@
+//! Integration test for `tm compress --tool <name>` (issue #1956, Option 0
+//! spike).
+//!
+//! Why: `tm compress` is meant to be invoked as the tail of a shell pipe
+//! (`<original bash command> | tm compress --tool "<effective tool name>"`),
+//! so its contract is genuinely process-level: read all of stdin, write the
+//! compressed result to stdout, exit 0. Unit tests inside `commands::compress`
+//! cover the compression logic directly; this file proves the actual binary
+//! honors that stdin/stdout contract end to end.
+//! What: Runs the built `tm` binary (`CARGO_BIN_EXE_tm`) as
+//! `tm compress --tool <name>` with piped stdin.
+//! Test: `cargo test -p trusty-mpm --test tm_compress_pipe`.
+//!
+//! Note on `--tool` values: `commands::hook_rewrite::effective_tool_name`
+//! derives a dispatch-relevant value (e.g. `"cargo test"`, `"git diff"`) from
+//! the wrapped command — NOT a hardcoded `"bash"` — because
+//! `compress_tool_output`'s dispatch table matches filters by substring
+//! against the tool name and has no branch for the literal string `"bash"`.
+//! `tm_compress_passes_through_unmatched_tool_name_unchanged` below documents
+//! that a tool name outside the dispatch table's coverage (whether that's
+//! literally `"bash"` or any other unmatched name) is always a safe,
+//! byte-for-byte passthrough — never a corruption or crash.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_tm_compress(tool: &str, input: &str) -> (bool, String, String) {
+    let bin = env!("CARGO_BIN_EXE_tm");
+    let mut child = Command::new(bin)
+        .args(["compress", "--tool", tool])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn `tm compress`");
+
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(input.as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for tm compress");
+    (
+        output.status.success(),
+        String::from_utf8(output.stdout).expect("stdout is utf8"),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn repetitive_cargo_test_payload() -> String {
+    let mut input = String::new();
+    for i in 0..50 {
+        input.push_str(&format!("test mod::t{i} ... ok\n"));
+    }
+    input.push_str("test result: ok. 50 passed; 0 failed\n");
+    input
+}
+
+#[test]
+fn tm_compress_shrinks_piped_cargo_test_output() {
+    // "cargo test" matches compress_tool_output's cargo/test dispatch
+    // branch — this is the `--tool` value `effective_tool_name` derives for
+    // a wrapped `cargo test ...` command, mirroring real hook usage.
+    let input = repetitive_cargo_test_payload();
+    let (success, stdout, stderr) = run_tm_compress("cargo test", &input);
+    assert!(success, "tm compress exited non-zero: stderr={stderr}");
+    assert!(
+        stdout.len() < input.len(),
+        "expected compressed stdout ({} bytes) to be shorter than input ({} bytes)",
+        stdout.len(),
+        input.len()
+    );
+    assert!(
+        stdout.contains("test result"),
+        "compressed output must retain the summary line, got: {stdout}"
+    );
+}
+
+#[test]
+fn tm_compress_passes_through_unmatched_tool_name_unchanged() {
+    // A tool name outside compress_tool_output's dispatch coverage (e.g. a
+    // literal "bash", or any command domain without a filter branch yet,
+    // such as "grep"/"ls" per the design doc's own documented gap) must be a
+    // safe, byte-for-byte passthrough — never corrupted, never a crash.
+    let input = repetitive_cargo_test_payload();
+    let (success, stdout, stderr) = run_tm_compress("bash", &input);
+    assert!(success, "tm compress exited non-zero: stderr={stderr}");
+    assert_eq!(
+        stdout, input,
+        "expected byte-for-byte passthrough for a tool name with no dispatch match"
+    );
+}
+
+#[test]
+fn tm_compress_passes_through_short_input_unchanged() {
+    // Below the 80-byte size gate in `compress_tool_output` — must be a
+    // verbatim passthrough regardless of `--tool` value.
+    let input = "ok\n";
+    let (success, stdout, stderr) = run_tm_compress("cargo test", input);
+    assert!(success, "tm compress exited non-zero: stderr={stderr}");
+    assert_eq!(stdout, input);
+}

--- a/crates/trusty-mpm/tests/tm_hook_pretooluse_rewrite.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pretooluse_rewrite.rs
@@ -1,0 +1,103 @@
+//! Integration test for `tm hook`'s `PreToolUse` Bash command-rewrite spike
+//! (issue #1956, Option 0).
+//!
+//! Why: `commands::hook_rewrite`'s unit tests cover the rewrite/exclusion
+//! decision logic in isolation; `commands::misc::hook`'s own tests cover the
+//! sub-agent/disable-hooks guard branches. Neither exercises the actual
+//! stdin-read → rewrite → stdout-print path end to end through the real
+//! binary, which is the behavior Claude Code will actually depend on. This
+//! file closes that gap.
+//! What: Runs the built `tm` binary (`CARGO_BIN_EXE_tm`) as
+//! `tm --url http://127.0.0.1:1 hook` with `CLAUDE_HOOK_EVENT=PreToolUse` and
+//! a `{"tool_name":"Bash","tool_input":{"command":"..."}}` stdin payload,
+//! then asserts the printed `hookSpecificOutput.updatedInput.command` matches
+//! the expected rewrite (or that nothing is printed for excluded commands).
+//! The daemon URL is pointed at an unreachable address so the best-effort
+//! POST fails fast without a real daemon running.
+//! Test: `cargo test -p trusty-mpm --test tm_hook_pretooluse_rewrite`.
+//!
+//! Caveat (explicitly flagged, not a bug): the exact
+//! `hookSpecificOutput`/`updatedInput` JSON shape this asserts against is
+//! this repo's own implementation of the design doc's sketch
+//! (`docs/specs/tool-output-interception-seam.md` §Option 0) — it has not
+//! been validated against a live Claude Code instance. This test proves our
+//! own code is internally consistent, not that Claude Code will honor it.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Spawn `tm hook` with the given `CLAUDE_HOOK_EVENT` and stdin JSON,
+/// returning stdout as a string.
+fn run_hook_with_stdin(event: &str, stdin_json: &str) -> String {
+    let bin = env!("CARGO_BIN_EXE_tm");
+    let mut child = Command::new(bin)
+        .args(["--url", "http://127.0.0.1:1", "hook"])
+        .env("CLAUDE_HOOK_EVENT", event)
+        .env("CLAUDE_SESSION_ID", "test-session")
+        .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
+        .env_remove("CLAUDE_MPM_SUB_AGENT")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn `tm hook`");
+
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(stdin_json.as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for tm hook");
+    assert!(
+        output.status.success(),
+        "tm hook exited non-zero: status={:?} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("stdout is utf8")
+}
+
+#[test]
+fn hook_rewrites_plain_bash_command_on_pretooluse() {
+    let stdout = run_hook_with_stdin(
+        "PreToolUse",
+        r#"{"tool_name":"Bash","tool_input":{"command":"cargo test"}}"#,
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must be valid JSON when rewriting");
+    assert_eq!(parsed["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+    assert_eq!(
+        parsed["hookSpecificOutput"]["updatedInput"]["command"],
+        "cargo test | tm compress --tool \"cargo test\""
+    );
+}
+
+#[test]
+fn hook_stays_silent_for_orchestrator_command_on_pretooluse() {
+    let stdout = run_hook_with_stdin(
+        "PreToolUse",
+        r#"{"tool_name":"Bash","tool_input":{"command":"make build"}}"#,
+    );
+    assert_eq!(
+        stdout.trim(),
+        "",
+        "excluded orchestrator command must produce no stdout output, got: {stdout}"
+    );
+}
+
+#[test]
+fn hook_stays_silent_for_non_bash_tool_on_pretooluse() {
+    let stdout = run_hook_with_stdin(
+        "PreToolUse",
+        r#"{"tool_name":"Read","tool_input":{"file_path":"/tmp/x"}}"#,
+    );
+    assert_eq!(stdout.trim(), "");
+}
+
+#[test]
+fn hook_stays_silent_without_stdin_payload() {
+    let stdout = run_hook_with_stdin("PreToolUse", "");
+    assert_eq!(stdout.trim(), "");
+}


### PR DESCRIPTION
## Summary
Implements Option 0 from `docs/specs/tool-output-interception-seam.md`: `tm hook` now reads Claude Code's `PreToolUse` stdin JSON payload and, for Bash tool calls, rewrites the command to pipe through a new `tm compress --tool <name>` subcommand so the subprocess's own stdout is already compressed by the time Claude Code captures the tool result — a pre-context-insertion seam, not post-hoc filtering.

- `commands::hook_rewrite`: rewrite/exclusion decision logic, with a day-one orchestrator exclusion list (`make`/`sam`/`rake`/`gradle`/`gradlew`/`mvn`/`ant`/`cdk`/`terraform`, mirroring claude-mpm's `_ORCHESTRATOR_EXCLUSIONS`) and a skip for commands that already contain pipe/chain composition (`|`, `&&`, `;`) — the same class of risk that broke a SAM build in the prior-art incident this repo's specs already cite.
- **Fixed a real correctness bug found while verifying this spike**: the original sketch (and this repo's own design doc) hardcodes a literal `--tool bash`, but `compress_tool_output`'s dispatch table matches filters by substring against the tool name (`cargo`, `diff`, `log`, …) — `"bash"` never matches any branch, so every rewritten command would silently compress **0%**, regardless of content, defeating the entire point of the spike. `effective_tool_name` now derives `"<program> <subcommand>"` (e.g. `"cargo test"`, `"git diff"`) from the actual Bash command so the existing cargo/git filters actually fire. Covered by new unit + integration tests.
- `commands::compress`: the pipe-filter subcommand — reads stdin to EOF, compresses via `compress_tool_output_async_with_path` (hoisted in #1959 / PR #1968), emits a structured `tracing::info!` **compression-effectiveness stats line** (`tool_name`, `bytes_before`, `bytes_after`, `pct_reduction`, `compression_path`) to stderr, and writes the result to stdout.
- `hook()` now also forwards `tool`/`input` to the daemon's observability payload now that stdin is read, closing the gap flagged in the design doc's "Not Recommended" section revision.

**Explicitly unverified against a live Claude Code instance** (flagged in the module docs) — the `hookSpecificOutput`/`updatedInput` JSON shape follows the design doc's sketch of claude-mpm's `ztk_hook.py` convention, since no other reference to that shape exists in this repo. Needs live validation before this spike is considered production-ready.

**Stacks on #1959 (PR #1968)** for `compress_tool_output_async_with_path` — this PR's base branch is `feat/1956-1959-tool-output-option0-spike`, so only the new commit's diff shows here; merge/rebase order: #1968 first, then this one.

Closes #1956.

## Test plan
- [x] `cargo test -p trusty-mpm` — 2293+649+649+... all passed, 0 failed (full suite, including new `tm_compress_pipe` and `tm_hook_pretooluse_rewrite` integration tests)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)