### PR TITLE
fix(trusty-memory): decouple recall/remember from embedder warm-up

### DIFF
--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -512,30 +512,42 @@ impl PalaceHandle {
         // spin up a fresh ONNX session per call (issue #57). The
         // OnceCell-backed `shared_embedder` guarantees at most one model load
         // for the lifetime of the process.
-        // Issue #906: both `shared_embedder()` (cold init path) and
-        // `embed_batch` carry their own bounded timeouts — if the embedder
-        // hangs mid-batch the remember call returns an error instead of
-        // blocking the write-lock indefinitely.
-        let embedder = shared_embedder()
-            .await
-            .context("acquire shared embedder for remember")?;
-        let embed_timeout = timeouts::embed_batch_timeout();
-        let vecs = tokio::time::timeout(embed_timeout, embedder.embed_batch(&[content]))
-            .await
-            .map_err(|_| {
-                anyhow::anyhow!(
-                    "embed_batch timed out after {:?} on remember path (issue #906); \
-                     increase TRUSTY_EMBED_BATCH_TIMEOUT_SECS if batches legitimately \
-                     take longer on this host",
-                    embed_timeout
-                )
-            })?
-            .context("embed drawer content")?;
-        if let Some(v) = vecs.into_iter().next() {
-            self.vector_store
-                .upsert(id, v)
+        //
+        // Issue #1970: a caller whose daemon is still warming up (embedder
+        // cold-init in progress) sets `opts.defer_embedding` so this write
+        // returns as soon as the KG/redb portion below completes instead of
+        // blocking behind a 30-120s ONNX/CoreML compile — the vector is
+        // backfilled by a background task once the embedder resolves. Text
+        // and KG indexing never depend on the embedder either way; this
+        // branch only changes *when* the drawer becomes vector-searchable.
+        if opts.defer_embedding {
+            self.spawn_deferred_embed(id, content.clone());
+        } else {
+            // Issue #906: both `shared_embedder()` (cold init path) and
+            // `embed_batch` carry their own bounded timeouts — if the embedder
+            // hangs mid-batch the remember call returns an error instead of
+            // blocking the write-lock indefinitely.
+            let embedder = shared_embedder()
                 .await
-                .context("upsert drawer vector")?;
+                .context("acquire shared embedder for remember")?;
+            let embed_timeout = timeouts::embed_batch_timeout();
+            let vecs = tokio::time::timeout(embed_timeout, embedder.embed_batch(&[content]))
+                .await
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "embed_batch timed out after {:?} on remember path (issue #906); \
+                         increase TRUSTY_EMBED_BATCH_TIMEOUT_SECS if batches legitimately \
+                         take longer on this host",
+                        embed_timeout
+                    )
+                })?
+                .context("embed drawer content")?;
+            if let Some(v) = vecs.into_iter().next() {
+                self.vector_store
+                    .upsert(id, v)
+                    .await
+                    .context("upsert drawer vector")?;
+            }
         }
 
         // Persist drawer metadata BEFORE the in-memory push so a crash mid-op
@@ -561,6 +573,85 @@ impl PalaceHandle {
         self.rebuild_closets();
 
         Ok(id)
+    }
+
+    /// Fire-and-forget background embed + vector-store backfill for a
+    /// drawer written while the shared embedder was cold (issue #1970).
+    ///
+    /// Why: `memory_remember` / `memory_note` / `task_add` must not block
+    /// the caller behind a 30-120s CoreML/CUDA cold compile just to persist
+    /// a memory — the KG/redb write already completed synchronously by the
+    /// time this is called. This task's only job is to make the drawer's
+    /// vector show up in `retrieve_l2` / `retrieve_l3` once the shared
+    /// embedder resolves.
+    /// What: clones the `Arc<UsearchStore>` handle and spawns a detached
+    /// task that awaits `shared_embedder()` (retrying the cold init if
+    /// necessary), embeds `content` under the same bounded timeout the
+    /// synchronous path uses, and upserts the resulting vector under `id`.
+    /// Every failure mode (embedder init failure, embed timeout, upsert
+    /// error) is logged at `warn!` and dropped — the drawer is already
+    /// durable via KG/redb regardless of whether the vector backfill
+    /// succeeds.
+    /// Known limitation: if the drawer is forgotten before this task
+    /// completes, the backfilled vector becomes an orphaned entry in the
+    /// vector store. Acceptable for a best-effort background lane (mirrors
+    /// the existing best-effort tone of BM25 indexing and auto-KG
+    /// extraction elsewhere in this pipeline); tighten with an
+    /// existence check against `self.drawers` if this proves to matter in
+    /// practice.
+    /// Test: `deferred_embed_backfills_vector_once_embedder_ready` in
+    /// `retrieval::tests`.
+    fn spawn_deferred_embed(&self, id: Uuid, content: String) {
+        let vector_store = self.vector_store.clone();
+        let palace_id = self.id.clone();
+        tokio::spawn(async move {
+            let embedder = match shared_embedder().await {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!(
+                        palace = %palace_id,
+                        drawer = %id,
+                        "deferred embed: shared embedder init failed (vector left unindexed): {e:#}"
+                    );
+                    return;
+                }
+            };
+            let embed_timeout = timeouts::embed_batch_timeout();
+            let vecs =
+                match tokio::time::timeout(embed_timeout, embedder.embed_batch(&[content])).await {
+                    Ok(Ok(v)) => v,
+                    Ok(Err(e)) => {
+                        tracing::warn!(
+                            palace = %palace_id,
+                            drawer = %id,
+                            "deferred embed: embed_batch failed: {e:#}"
+                        );
+                        return;
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            palace = %palace_id,
+                            drawer = %id,
+                            "deferred embed: embed_batch timed out after {embed_timeout:?}"
+                        );
+                        return;
+                    }
+                };
+            if let Some(v) = vecs.into_iter().next() {
+                match vector_store.upsert(id, v).await {
+                    Ok(()) => tracing::info!(
+                        palace = %palace_id,
+                        drawer = %id,
+                        "deferred embed: vector backfill complete"
+                    ),
+                    Err(e) => tracing::warn!(
+                        palace = %palace_id,
+                        drawer = %id,
+                        "deferred embed: vector upsert failed: {e:#}"
+                    ),
+                }
+            }
+        });
     }
 
     /// Rebuild the closet keyword index from the current in-memory drawer table.

--- a/crates/trusty-common/src/memory_core/retrieval/types.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/types.rs
@@ -51,14 +51,21 @@ pub(super) const L1_CAP: usize = 15;
 /// What: `filter` defaults to `FilterConfig::default()`; `force` skips the
 /// gate entirely; `enforce_min_tokens` lets `memory_note` keep noise rejects
 /// while accepting short content; `classify_as` pins the resulting
-/// `DrawerType` (used by `memory_note` to force `UserFact`).
-/// Test: See `remember_force_bypasses_filter` and friends in this file.
+/// `DrawerType` (used by `memory_note` to force `UserFact`);
+/// `defer_embedding` (issue #1970) tells `remember_with_options` to skip the
+/// synchronous embed + vector-store upsert and instead background it, so a
+/// caller whose embedder is still cold-initialising is not blocked behind a
+/// 30-120s ONNX/CoreML compile just to persist a drawer.
+/// Test: See `remember_force_bypasses_filter` and friends in this file;
+/// `deferred_embed_backfills_vector_once_embedder_ready` covers
+/// `defer_embedding`.
 #[derive(Debug, Clone)]
 pub struct RememberOptions {
     pub filter: FilterConfig,
     pub force: bool,
     pub enforce_min_tokens: bool,
     pub classify_as: Option<DrawerType>,
+    pub defer_embedding: bool,
 }
 
 impl Default for RememberOptions {
@@ -68,6 +75,7 @@ impl Default for RememberOptions {
             force: false,
             enforce_min_tokens: true,
             classify_as: None,
+            defer_embedding: false,
         }
     }
 }
@@ -89,6 +97,7 @@ impl RememberOptions {
             force: false,
             enforce_min_tokens: false,
             classify_as: Some(DrawerType::UserFact),
+            defer_embedding: false,
         }
     }
 

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -36,20 +36,24 @@ use trusty_common::ChatProvider;
 #[cfg(feature = "axum-server")]
 use tracing::info;
 
-/// Two-phase daemon readiness state (issues #910/#911).
+/// Two-phase daemon readiness state (issues #910/#911, revised by #1970).
 ///
-/// Why: The embedder cold-init (CoreML compile, 30-120 s) blocks the first
-/// real `memory_remember`/`memory_recall` call if it arrives before warm-up
-/// completes.  Advertising the state lets handlers return an explicit, fast
-/// error ("daemon is warming up, retry shortly") instead of blocking for
-/// minutes.
+/// Why: The embedder cold-init (CoreML compile, 30-120 s) must never block
+/// the fast text/KG/BM25 paths that don't need it. Originally (#910/#911)
+/// this state gated a hard-error preflight that rejected every
+/// `memory_remember`/`memory_recall` call outright while `Warming` — mirrored
+/// from trusty-search's staged pipeline, #1970 replaced that with graceful
+/// degradation: writes persist immediately and defer embedding to a
+/// background task, reads return BM25 + L0/L1 results and simply omit the
+/// vector lane, all keyed off this same state.
 /// What: Two stable values stored atomically.  `Warming` (0) is the initial
 /// state; `Ready` (1) is set once the embedder has been successfully
 /// initialised by `spawn_startup_tasks`.  The transition is one-way and
 /// lock-free: a single `AtomicU8` compare-and-swap.
 /// Test: `daemon_readiness_transitions_warming_to_ready` in this module;
-///       end-to-end warming-error path covered by
-///       `tools::tests::remember_returns_warming_error_while_state_is_warming`.
+///       degraded-path coverage in `tools::tests`
+///       (`remember_succeeds_and_defers_embedding_while_state_is_warming`,
+///       `recall_falls_back_to_bm25_and_l0_l1_while_warming`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DaemonReadiness {
     /// Embedder cold-init (and/or pin scan) still in progress.
@@ -1321,25 +1325,6 @@ impl AppState {
             .store(DaemonReadiness::Ready as u8, Ordering::Release);
     }
 
-    /// Return `Ok(())` when `Ready`, or an explicit `Err` with the warming
-    /// message when still `Warming`.
-    ///
-    /// Why: the preflight in every bounded handler calls this and returns the
-    /// error immediately so no embedding / redb I/O is attempted while the
-    /// daemon is still initialising (tracks #911 internally).
-    /// What: cheaply reads `daemon_readiness`; returns the fast error string
-    /// on `Warming`.  Zero allocation on the happy path.
-    /// Test: covered by `tools::tests::remember_returns_warming_error_while_state_is_warming`.
-    pub fn readiness_check(&self) -> Result<()> {
-        if self.readiness() == DaemonReadiness::Warming {
-            return Err(anyhow::anyhow!(
-                "trusty-memory is warming up (embedder initialising); \
-                 please retry in a few seconds"
-            ));
-        }
-        Ok(())
-    }
-
     /// Obtain the shared `FastEmbedder` instance, initialising it on first call.
     ///
     /// Why: centralises lazy embedder access so every tool handler goes through
@@ -1348,30 +1333,23 @@ impl AppState {
     /// CoreML/CUDA first-compile cannot block a handler indefinitely.  On
     /// timeout the `OnceCell` is left unresolved and the next caller retries.
     ///
-    /// **Callers on the request path MUST call `readiness_check()` before
-    /// this method.**  The four guarded handlers (`memory_remember`,
-    /// `memory_recall`, `memory_recall_deep`, `memory_note`) do so; any new
-    /// handler that calls `embedder()` must follow the same pattern.
-    /// Reaching this method while still `Warming` is not a bug — the warm-up
-    /// task itself calls `embedder()` while in `Warming` state — but request
-    /// handlers should have short-circuited before here via `readiness_check()`.
+    /// **Callers on the request path SHOULD check `readiness()` before this
+    /// method** (issue #1970) — every recall handler now checks
+    /// `readiness() == Ready` first and only calls `embedder()` on that
+    /// branch, falling back to a BM25/L0/L1-only path while `Warming` instead
+    /// of paying this method's cold-init cost. Reaching this method while
+    /// still `Warming` is not a bug (the warm-up task itself calls
+    /// `embedder()` while in `Warming` state), just unusual on the request
+    /// path.
     ///
-    /// The `readiness_check()` preflight is the PRIMARY guard (fast rejection
-    /// with no I/O).  This timeout is the last-resort backstop in case a
-    /// handler bypasses the preflight or the warm-up task itself hits a
-    /// pathological init delay.  If this timeout fires the `OnceCell` is left
-    /// in the unresolved state and the next call retries from scratch.
+    /// This timeout is a backstop against a pathological init delay (e.g. the
+    /// warm-up task's own call, or a handler that skips the `readiness()`
+    /// check). If this timeout fires the `OnceCell` is left in the unresolved
+    /// state and the next call retries from scratch.
     pub async fn embedder(&self) -> Result<Arc<FastEmbedder>> {
         use trusty_common::memory_core::timeouts;
         let cell = self.embedder.clone();
         let timeout = timeouts::embedder_init_timeout();
-        // `readiness_check()` is the PRIMARY guard — handlers return a fast
-        // warming error before reaching here.  This timeout is the last-resort
-        // backstop: if the embedder init races past the preflight (e.g. in the
-        // warm-up task itself, which calls embedder() while still Warming) or
-        // the CoreML/CUDA compile stalls, we fail fast rather than blocking
-        // indefinitely.  On timeout the OnceCell stays unresolved; the next
-        // caller will retry the init from scratch.
         let embedder = tokio::time::timeout(
             timeout,
             cell.get_or_try_init(|| async {

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -33,8 +33,7 @@ fn test_state() -> (AppState, tempfile::TempDir) {
 
 /// Why: DaemonReadiness tests need a state that starts in Warming; this
 /// variant skips `set_ready()` so the transition can be tested explicitly.
-/// Test: `daemon_readiness_transitions_warming_to_ready`,
-///       `readiness_check_ok_when_ready_err_when_warming`.
+/// Test: `daemon_readiness_transitions_warming_to_ready`.
 fn test_state_warming() -> (AppState, tempfile::TempDir) {
     // Use OnceLock so the env var is written exactly once across all
     // parallel test threads — avoids the unsynchronised set_var race while
@@ -1072,30 +1071,6 @@ async fn daemon_readiness_transitions_warming_to_ready() {
         DaemonReadiness::Ready,
         "daemon must be Ready after set_ready()"
     );
-}
-
-/// Why (issue #911): `readiness_check` must return `Ok(())` when Ready and
-/// an explicit `Err` when Warming, so tool handlers can use `?` to short-
-/// circuit without blocking.
-/// What: verify both states.
-/// Test: this test.
-#[tokio::test]
-async fn readiness_check_ok_when_ready_err_when_warming() {
-    let (state, _tmp) = test_state_warming();
-    // Warming → should error.
-    let err = state
-        .readiness_check()
-        .expect_err("readiness_check must fail when Warming");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("warming up"),
-        "error must mention 'warming up'; got: {msg}"
-    );
-    // Ready → should succeed.
-    state.set_ready();
-    state
-        .readiness_check()
-        .expect("readiness_check must succeed when Ready");
 }
 
 /// Why (issue #911): `DaemonReadiness::from_u8` must map 0 → Warming and

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -834,13 +834,17 @@ fn spawn_startup_tasks(state: &AppState) {
     // is likely ready by the time the first `memory_remember` / `memory_recall`
     // arrives.
     //
-    // On SUCCESS flip `daemon_readiness` to `Ready` so the preflight guards in
-    // `tools.rs` (issue #911) allow requests through.  Until then they return
-    // a fast "warming up" error instead of blocking behind the OnceCell init.
+    // On SUCCESS flip `daemon_readiness` to `Ready` so the recall handlers in
+    // `tools/memory_ops.rs` switch from the BM25/L0/L1-only fallback to full
+    // vector-backed recall (issue #1970; formerly issue #911's hard-error
+    // preflight, which blocked writes/reads outright while Warming — replaced
+    // by graceful degradation that mirrors trusty-search's staged pipeline).
     //
     // On FAILURE: log at ERROR, leave state as `Warming`.  The lazy-init path
     // in `shared_embedder()` will retry on the first real request (and the
-    // bounded timeout there means it will fail fast, not hang).
+    // bounded timeout there means it will fail fast, not hang). Writes still
+    // succeed while Warming — they defer embedding to a background task
+    // (see `PalaceHandle::remember_with_options` / `defer_embedding`).
     let warmup_state = state.clone();
     tokio::spawn(async move {
         let ws = std::time::Instant::now();

--- a/crates/trusty-memory/src/tools/bm25.rs
+++ b/crates/trusty-memory/src/tools/bm25.rs
@@ -298,6 +298,42 @@ pub(crate) fn fuse_bm25_into_recall(
     results.truncate(top_k);
 }
 
+/// Hydrate BM25 hits directly into `RecallResult`s from a palace's
+/// in-memory drawer table (issue #1970 embedder-warming fallback).
+///
+/// Why: `fuse_bm25_into_recall` only *boosts* vector hits already present in
+/// `results` — it never appends BM25-only matches because (per its own
+/// comment) it has no drawer payload to hydrate them with. During embedder
+/// warm-up there are no vector hits at all, so that boost-only behaviour
+/// would silently drop every BM25 match. `PalaceHandle::drawers` already
+/// holds every drawer's metadata in memory (no disk I/O needed), so each
+/// BM25 `doc_id` (a stringified drawer UUID) can be resolved into a full
+/// `RecallResult` directly.
+/// What: parses each hit's `doc_id` as a `Uuid`, looks it up in
+/// `handle.drawers`, and emits a `RecallResult` carrying the BM25 score and
+/// `layer: 4` (the same lexical-lane marker `fuse_bm25_into_recall` uses).
+/// Hits whose `doc_id` doesn't parse or no longer resolves to a drawer
+/// (e.g. forgotten since the BM25 snapshot was built) are skipped.
+/// Test: `bm25_hits_hydrate_from_handle_during_warmup`.
+pub(crate) fn bm25_hits_to_recall_results(
+    handle: &trusty_common::memory_core::retrieval::PalaceHandle,
+    bm25_hits: &[trusty_common::bm25_client::BM25Hit],
+) -> Vec<trusty_common::memory_core::retrieval::RecallResult> {
+    let drawers = handle.drawers.read();
+    bm25_hits
+        .iter()
+        .filter_map(|hit| {
+            let drawer_id = uuid::Uuid::parse_str(&hit.doc_id).ok()?;
+            let drawer = drawers.iter().find(|d| d.id == drawer_id)?.clone();
+            Some(trusty_common::memory_core::retrieval::RecallResult {
+                drawer,
+                score: hit.score,
+                layer: 4,
+            })
+        })
+        .collect()
+}
+
 /// Serialize `recall` results into a JSON shape the MCP client can render.
 pub(crate) fn serialize_recall(
     palace: &str,

--- a/crates/trusty-memory/src/tools/helpers.rs
+++ b/crates/trusty-memory/src/tools/helpers.rs
@@ -214,9 +214,14 @@ pub(crate) fn dedup_gate(handle: &trusty_common::memory_core::PalaceHandle, cont
 /// Why: Issue #61 — the MCP boundary is where auto-capture hooks deposit
 /// raw tool/commit/prompt data; we want the 8-token threshold there even
 /// though the library default is more permissive for direct callers.
+/// Issue #1970: `defer_embedding` is threaded through separately so callers
+/// can key it off the live `AppState::readiness()` at dispatch time rather
+/// than baking a stale snapshot into this helper.
 /// What: Clones the default filter and bumps `min_tokens` to `MCP_MIN_TOKENS`.
-/// Test: `dispatch_remember_rejects_short_content`.
-pub(crate) fn mcp_remember_opts(force: bool) -> RememberOptions {
+/// Test: `dispatch_remember_rejects_short_content`;
+/// `remember_succeeds_and_defers_embedding_while_state_is_warming` covers
+/// `defer_embedding`.
+pub(crate) fn mcp_remember_opts(force: bool, defer_embedding: bool) -> RememberOptions {
     let filter = FilterConfig {
         min_tokens: MCP_MIN_TOKENS,
         ..FilterConfig::default()
@@ -224,6 +229,7 @@ pub(crate) fn mcp_remember_opts(force: bool) -> RememberOptions {
     RememberOptions {
         filter,
         force,
+        defer_embedding,
         ..RememberOptions::default()
     }
 }

--- a/crates/trusty-memory/src/tools/memory_ops.rs
+++ b/crates/trusty-memory/src/tools/memory_ops.rs
@@ -10,7 +10,7 @@
 //! `dispatch_memory_list_*`, `dispatch_memory_recall_all_*` in `tools::tests`.
 
 use crate::attribution::{CreatorInfo, CreatorSource, MCP_CLIENT_NAME};
-use crate::{ActivitySource, AppState, DaemonEvent};
+use crate::{ActivitySource, AppState, DaemonEvent, DaemonReadiness};
 use anyhow::{anyhow, Context, Result};
 use serde_json::{json, Value};
 use trusty_common::memory_core::palace::RoomType;
@@ -20,7 +20,9 @@ use trusty_common::memory_core::retrieval::{
 use trusty_common::memory_core::timeouts;
 use uuid::Uuid;
 
-use super::bm25::{bm25_search_optional, fuse_bm25_into_recall, serialize_recall};
+use super::bm25::{
+    bm25_hits_to_recall_results, bm25_search_optional, fuse_bm25_into_recall, serialize_recall,
+};
 use super::helpers::{
     attach_mcp_attribution, blocklist_gate, content_gate, dedup_gate, mcp_remember_opts,
     open_palace_handle, parse_room, parse_tags, resolve_palace, room_label, skipped_envelope,
@@ -28,10 +30,13 @@ use super::helpers::{
 };
 
 pub(crate) async fn handle_memory_remember(state: &AppState, args: Value) -> Result<Value> {
-    // Issue #911: fast readiness preflight — return an explicit bounded error
-    // immediately if the daemon is still warming up (embedder not yet
-    // initialised) so the caller is never parked behind an open-ended init.
-    state.readiness_check()?;
+    // Issue #1970: writes no longer hard-block on embedder readiness. The
+    // text/KG/BM25 path below never touches the embedder; when the daemon
+    // is still `Warming`, `defer_embedding` tells `write_drawer` to
+    // background the embed + vector-store upsert instead of blocking this
+    // call behind a 30-120s ONNX/CoreML cold compile (mirrors trusty-search's
+    // lexical-first, vector-later staged pipeline).
+    let defer_embedding = state.readiness() == DaemonReadiness::Warming;
     let palace = resolve_palace(state, &args, "memory_remember")?;
     let palace = palace.as_str();
     let raw_text = args
@@ -119,7 +124,7 @@ pub(crate) async fn handle_memory_remember(state: &AppState, args: Value) -> Res
             tags,
             room,
             importance: 0.5,
-            opts: mcp_remember_opts(force),
+            opts: mcp_remember_opts(force, defer_embedding),
             room_label_for_kg,
         },
     )
@@ -132,8 +137,9 @@ pub(crate) async fn handle_memory_remember(state: &AppState, args: Value) -> Res
 }
 
 pub(crate) async fn handle_memory_note(state: &AppState, args: Value) -> Result<Value> {
-    // Issue #911: fast readiness preflight — same guard as memory_remember.
-    state.readiness_check()?;
+    // Issue #1970: same non-blocking write posture as memory_remember — see
+    // that handler's comment for the rationale.
+    let defer_embedding = state.readiness() == DaemonReadiness::Warming;
     // Issue #61: curated short-fact shortcut. Bypasses the token
     // threshold (so "User prefers snake_case" is accepted) but still
     // applies noise-pattern rejects so the tool can't be used to
@@ -216,7 +222,10 @@ pub(crate) async fn handle_memory_note(state: &AppState, args: Value) -> Result<
             tags,
             room: RoomType::General,
             importance: 1.0,
-            opts: RememberOptions::note(),
+            opts: RememberOptions {
+                defer_embedding,
+                ..RememberOptions::note()
+            },
             // memory_note is pinned to the General room; mirror that for
             // the KG extractor so the auto-extracted triples carry the
             // same room label as the drawer.
@@ -233,9 +242,45 @@ pub(crate) async fn handle_memory_note(state: &AppState, args: Value) -> Result<
     }))
 }
 
+/// Degraded-embedder recall fallback (issue #1970): L0/L1 + BM25 only.
+///
+/// Why: mirrors trusty-search's staged-pipeline degradation — rather than
+/// blocking/erroring while the shared embedder cold-inits, every recall
+/// variant should return identity + essential drawers plus whatever the
+/// BM25 lexical lane can resolve, with the semantic (vector) layer simply
+/// omitted until the embedder warms up.
+/// What: seeds the result set with `retrieve_l0_l1`, joins the optional BM25
+/// lane (query runs regardless of embedder state — BM25 has no embedder
+/// dependency), hydrates any BM25-only hits via `bm25_hits_to_recall_results`,
+/// merges without duplicating drawers already present, re-sorts by score
+/// descending, and truncates to `top_k`.
+/// Test: `recall_falls_back_to_bm25_and_l0_l1_while_warming`,
+/// `recall_deep_falls_back_to_bm25_and_l0_l1_while_warming`.
+async fn recall_without_embedder(
+    state: &AppState,
+    handle: &trusty_common::memory_core::retrieval::PalaceHandle,
+    palace: &str,
+    query: &str,
+    top_k: usize,
+) -> Vec<trusty_common::memory_core::retrieval::RecallResult> {
+    let mut results = trusty_common::memory_core::retrieval::retrieve_l0_l1(handle);
+    if let Some(bm25_hits) = bm25_search_optional(state, palace, query, top_k).await {
+        for hydrated in bm25_hits_to_recall_results(handle, &bm25_hits) {
+            if !results.iter().any(|r| r.drawer.id == hydrated.drawer.id) {
+                results.push(hydrated);
+            }
+        }
+    }
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    results.truncate(top_k);
+    results
+}
+
 pub(crate) async fn handle_memory_recall(state: &AppState, args: Value) -> Result<Value> {
-    // Issue #911: fast readiness preflight.
-    state.readiness_check()?;
     let palace = resolve_palace(state, &args, "memory_recall")?;
     let query = args
         .get("query")
@@ -244,6 +289,15 @@ pub(crate) async fn handle_memory_recall(state: &AppState, args: Value) -> Resul
     let top_k = args.get("top_k").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
 
     let handle = open_palace_handle(state, &palace)?;
+
+    // Issue #1970: while the embedder is still warming up, return BM25 +
+    // L0/L1 results immediately instead of blocking/erroring on embedder
+    // state.
+    if state.readiness() == DaemonReadiness::Warming {
+        let results = recall_without_embedder(state, &handle, &palace, query, top_k).await;
+        return Ok(serialize_recall(&palace, query, results));
+    }
+
     let embedder = state.embedder().await?;
     // Issue #156: when the BM25 lane is enabled, run it in parallel
     // with the vector recall and RRF-fuse the two ranked lists.
@@ -261,8 +315,6 @@ pub(crate) async fn handle_memory_recall(state: &AppState, args: Value) -> Resul
 }
 
 pub(crate) async fn handle_memory_recall_deep(state: &AppState, args: Value) -> Result<Value> {
-    // Issue #911: fast readiness preflight.
-    state.readiness_check()?;
     let palace = resolve_palace(state, &args, "memory_recall_deep")?;
     let query = args
         .get("query")
@@ -271,6 +323,13 @@ pub(crate) async fn handle_memory_recall_deep(state: &AppState, args: Value) -> 
     let top_k = args.get("top_k").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
 
     let handle = open_palace_handle(state, &palace)?;
+
+    // Issue #1970: same warming-fallback posture as memory_recall.
+    if state.readiness() == DaemonReadiness::Warming {
+        let results = recall_without_embedder(state, &handle, &palace, query, top_k).await;
+        return Ok(serialize_recall(&palace, query, results));
+    }
+
     let embedder = state.embedder().await?;
     let results = recall_deep(&handle, embedder.as_ref(), query, top_k)
         .await
@@ -330,12 +389,43 @@ pub(crate) async fn handle_memory_forget(state: &AppState, args: Value) -> Resul
     Ok(json!({ "status": "deleted", "drawer_id": drawer_id_str, "palace": palace }))
 }
 
+/// Cross-palace counterpart of `recall_without_embedder` (issue #1970).
+///
+/// Why: `memory_recall_all` must degrade the same way the single-palace
+/// recall handlers do — BM25 + L0/L1 per palace, no vector lane — while the
+/// embedder is warming up.
+/// What: runs `recall_without_embedder` against every handle, tags each hit
+/// with its source palace id, then merges/re-sorts/truncates exactly like
+/// `recall_across_palaces` does for the vector-backed path.
+/// Test: `recall_all_falls_back_to_bm25_and_l0_l1_while_warming`.
+async fn recall_all_without_embedder(
+    state: &AppState,
+    handles: &[std::sync::Arc<trusty_common::memory_core::retrieval::PalaceHandle>],
+    query: &str,
+    top_k: usize,
+) -> Vec<trusty_common::memory_core::retrieval::CrossPalaceResult> {
+    let mut merged = Vec::new();
+    for handle in handles {
+        let palace_id = handle.id.as_str().to_string();
+        let hits = recall_without_embedder(state, handle, &palace_id, query, top_k).await;
+        merged.extend(hits.into_iter().map(|result| {
+            trusty_common::memory_core::retrieval::CrossPalaceResult {
+                palace_id: palace_id.clone(),
+                result,
+            }
+        }));
+    }
+    merged.sort_by(|a, b| {
+        b.result
+            .score
+            .partial_cmp(&a.result.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    merged.truncate(top_k);
+    merged
+}
+
 pub(crate) async fn handle_memory_recall_all(state: &AppState, args: Value) -> Result<Value> {
-    // Issue #914 (Part A): fast readiness preflight — mirror the guard on
-    // every other embedder-touching handler. Without this, a `memory_recall_all`
-    // call while the daemon is still Warming blocks behind the OnceCell init
-    // (up to 180 s) instead of returning the fast bounded error.
-    state.readiness_check()?;
     let query = args
         .get("q")
         .and_then(|v| v.as_str())
@@ -363,12 +453,17 @@ pub(crate) async fn handle_memory_recall_all(state: &AppState, args: Value) -> R
         }
     }
 
-    let embedder = state.embedder().await?;
-    let erased: std::sync::Arc<dyn trusty_common::memory_core::embed::Embedder + Send + Sync> =
-        embedder;
-    let results = recall_across_palaces(&handles, &erased, query, top_k, deep)
-        .await
-        .context("recall_across_palaces")?;
+    // Issue #1970: BM25 + L0/L1 fallback across every palace while warming.
+    let results = if state.readiness() == DaemonReadiness::Warming {
+        recall_all_without_embedder(state, &handles, query, top_k).await
+    } else {
+        let embedder = state.embedder().await?;
+        let erased: std::sync::Arc<dyn trusty_common::memory_core::embed::Embedder + Send + Sync> =
+            embedder;
+        recall_across_palaces(&handles, &erased, query, top_k, deep)
+            .await
+            .context("recall_across_palaces")?
+    };
 
     let payload: Vec<Value> = results
         .iter()

--- a/crates/trusty-memory/src/tools/mod.rs
+++ b/crates/trusty-memory/src/tools/mod.rs
@@ -39,7 +39,7 @@ pub(crate) use helpers::{auto_extract_and_assert, room_label};
 
 // Re-exports used only by the in-crate test module (`super::*`).
 #[cfg(test)]
-pub(crate) use bm25::bm25_index_enqueue;
+pub(crate) use bm25::{bm25_hits_to_recall_results, bm25_index_enqueue};
 #[cfg(test)]
 pub(crate) use helpers::{blocklist_gate, content_gate, dedup_gate, open_palace_handle};
 

--- a/crates/trusty-memory/src/tools/task_ops.rs
+++ b/crates/trusty-memory/src/tools/task_ops.rs
@@ -8,7 +8,7 @@
 //! create/query/complete Task drawers via the standard palace storage pipeline.
 //! Test: `crates/trusty-memory/tests/task_mcp.rs`.
 
-use crate::AppState;
+use crate::{AppState, DaemonReadiness};
 use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
 use serde_json::{json, Value};
@@ -36,7 +36,10 @@ use super::helpers::{
 /// Returns `{ drawer_id, palace, status: "stored", drawer_type: "Task" }`.
 /// Test: `task_add_and_list_via_mcp` in `tests/task_mcp.rs`.
 pub(crate) async fn handle_task_add(state: &AppState, args: Value) -> Result<Value> {
-    state.readiness_check()?;
+    // Issue #1970: same non-blocking write posture as memory_remember — the
+    // KG/redb write below never touches the embedder, so a warming daemon
+    // defers vector embedding to a background task instead of erroring.
+    let defer_embedding = state.readiness() == DaemonReadiness::Warming;
     let palace = resolve_palace(state, &args, "task_add")?;
     let palace = palace.as_str();
     let content = args
@@ -69,6 +72,7 @@ pub(crate) async fn handle_task_add(state: &AppState, args: Value) -> Result<Val
                 force: true, // bypass token/noise filters
                 enforce_min_tokens: false,
                 classify_as: Some(DrawerType::Task),
+                defer_embedding,
                 ..RememberOptions::default()
             },
             room_label_for_kg,

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -1458,90 +1458,123 @@ async fn bm25_index_queue_drops_when_full() {
 }
 
 // -------------------------------------------------------------------------
-// Issues #910 / #911 — readiness preflight in remember / recall handlers
+// Issue #1970 — graceful degradation while the embedder is Warming
+// (supersedes the former issues #910/#911/#914 hard-error preflight, which
+// blocked writes AND reads outright until the embedder finished cold-init;
+// trusty-memory now mirrors trusty-search's staged-pipeline degradation:
+// BM25/KG/text paths never wait on the embedder).
 // -------------------------------------------------------------------------
 
-/// Why (issue #911): while the daemon is still `Warming`, `memory_remember`
-/// must return an explicit error immediately — never block or queue behind
-/// the embedder init.
-/// What: construct a state that remains in Warming state (no `set_ready`),
-/// dispatch `memory_remember`, assert the error message mentions "warming".
+/// Why (issue #1970): `memory_remember` must succeed immediately while the
+/// daemon is still `Warming` — the KG/redb write never depends on the
+/// embedder, and vector embedding is deferred to a background task rather
+/// than blocking the caller behind a 30-120s cold compile.
+/// What: dispatch `memory_remember` against a state that stays `Warming`,
+/// assert the call succeeds (`status: "stored"`), assert the drawer is
+/// immediately visible via `memory_list` (proves the synchronous KG/redb
+/// portion completed), then poll (bounded, condition-based — no blind
+/// sleep) until the real shared embedder backfills the vector so
+/// `handle.vector_store` returns a hit for the drawer id. This proves the
+/// deferred embed job is not just fired but actually completes.
+///
+/// Deliberately does NOT seed a mock embedder: this unit-test binary also
+/// runs `dispatch_remember_then_recall` against the real, process-wide
+/// `shared_embedder()` singleton, and seeding a mock here would race with
+/// (and potentially poison) that test depending on execution order.
 /// Test: this test.
 #[tokio::test]
-async fn remember_returns_warming_error_while_state_is_warming() {
-    // Use test_state_warming() so the daemon stays in Warming state.
-    // The readiness preflight fires BEFORE the embedder is accessed, so
-    // no mock embedder is needed.
+async fn remember_succeeds_and_defers_embedding_while_state_is_warming() {
+    use trusty_common::memory_core::store::VectorStore;
+
     let (state, _tmp) = test_state_warming();
-    // Create the palace so the handler doesn't fail on "palace not found".
     let _ = dispatch_tool(
         &state,
         "palace_create",
         serde_json::json!({"name": "warmtest"}),
     )
-    .await;
+    .await
+    .expect("palace_create");
 
-    let result = dispatch_tool(
+    let content = "Quokkas are famously photogenic marsupials found in Western Australia";
+    let remembered = dispatch_tool(
         &state,
         "memory_remember",
         serde_json::json!({
             "palace": "warmtest",
-            "text": "test memory that should be rejected while warming up"
+            "text": content,
         }),
     )
-    .await;
-    let err = result.expect_err("memory_remember must fail while Warming");
-    let msg = err.to_string();
+    .await
+    .expect("memory_remember must succeed while Warming (issue #1970)");
+    assert_eq!(remembered["status"], "stored");
+    let drawer_id_str = remembered["drawer_id"]
+        .as_str()
+        .expect("drawer_id present")
+        .to_string();
+    let drawer_id = Uuid::parse_str(&drawer_id_str).expect("valid uuid");
+
+    // The text/KG portion is synchronous — no need to wait for it.
+    let listed = dispatch_tool(
+        &state,
+        "memory_list",
+        serde_json::json!({"palace": "warmtest"}),
+    )
+    .await
+    .expect("memory_list");
+    let drawers = listed["drawers"].as_array().expect("drawers array");
     assert!(
-        msg.contains("warming up"),
-        "error must mention 'warming up'; got: {msg}"
+        drawers.iter().any(|d| d["drawer_id"] == drawer_id_str),
+        "drawer must be listed immediately even though the embedder is warming"
+    );
+
+    // Poll (bounded) until the background embed task backfills the vector.
+    let handle = open_palace_handle(&state, "warmtest").expect("open palace");
+    let embedder = trusty_common::memory_core::retrieval::shared_embedder()
+        .await
+        .expect("shared embedder must initialise");
+    // Generous bound: a cold ONNX/CoreML compile can take up to ~120s per
+    // CLAUDE.md; a warm model cache (the common case once any other test in
+    // this binary has touched the embedder) resolves in well under a second.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(120);
+    let mut backfilled = false;
+    while std::time::Instant::now() < deadline {
+        let vecs = embedder
+            .embed_batch(&[content.to_string()])
+            .await
+            .expect("embed query");
+        let hits = handle
+            .vector_store
+            .search(&vecs[0], 5)
+            .await
+            .expect("vector search");
+        if hits
+            .iter()
+            .any(|h| h.drawer_id.as_bytes()[..8] == drawer_id.as_bytes()[..8])
+        {
+            backfilled = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    assert!(
+        backfilled,
+        "background embed task must backfill the vector index once the embedder is ready"
     );
 }
 
-/// Why (issue #911): while the daemon is still `Warming`, `memory_recall`
-/// must return an explicit error immediately.
-/// What: construct a Warming state, dispatch `memory_recall`, assert the
-/// error message mentions "warming".
+/// Why (issue #1970): `memory_note` shares `write_drawer`'s deferred-embed
+/// posture; confirm it also succeeds (rather than erroring) while Warming.
 /// Test: this test.
 #[tokio::test]
-async fn recall_returns_warming_error_while_state_is_warming() {
-    let (state, _tmp) = test_state_warming();
-    let _ = dispatch_tool(
-        &state,
-        "palace_create",
-        serde_json::json!({"name": "warmtest-recall"}),
-    )
-    .await;
-
-    let result = dispatch_tool(
-        &state,
-        "memory_recall",
-        serde_json::json!({
-            "palace": "warmtest-recall",
-            "query": "test query"
-        }),
-    )
-    .await;
-    let err = result.expect_err("memory_recall must fail while Warming");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("warming up"),
-        "error must mention 'warming up'; got: {msg}"
-    );
-}
-
-/// Why (issue #911): `memory_note` must also return the warming error while
-/// the daemon is `Warming` (it shares the same preflight guard).
-/// Test: this test.
-#[tokio::test]
-async fn note_returns_warming_error_while_state_is_warming() {
+async fn note_succeeds_while_state_is_warming() {
     let (state, _tmp) = test_state_warming();
     let _ = dispatch_tool(
         &state,
         "palace_create",
         serde_json::json!({"name": "warmtest-note"}),
     )
-    .await;
+    .await
+    .expect("palace_create");
 
     let result = dispatch_tool(
         &state,
@@ -1551,38 +1584,144 @@ async fn note_returns_warming_error_while_state_is_warming() {
             "content": "short note content here"
         }),
     )
-    .await;
-    let err = result.expect_err("memory_note must fail while Warming");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("warming up"),
-        "error must mention 'warming up'; got: {msg}"
-    );
+    .await
+    .expect("memory_note must succeed while Warming (issue #1970)");
+    assert_eq!(result["status"], "stored");
 }
 
-/// Why (issue #914 Part A): `memory_recall_all` was the only
-/// embedder-touching handler without the readiness preflight from #912.
-/// It must return the fast "warming up" error immediately — not block
-/// behind an open-ended OnceCell init — while the daemon is `Warming`.
-/// What: construct a state that stays `Warming` (no `set_ready`), dispatch
-/// `memory_recall_all`, assert the error message mentions "warming".
-/// Test: this test (regression guard for the gap fixed in #914 Part A).
+/// Why (issue #1970): `memory_recall` must never block/error on embedder
+/// state — it should degrade to the BM25/L0/L1 fallback and return
+/// normally while the daemon is `Warming`.
+/// What: dispatch `memory_recall` against a Warming state and assert the
+/// call succeeds with a well-formed (possibly empty, since BM25 isn't
+/// wired up in this unit test and L1 isn't live-refreshed mid-process)
+/// results array — the key assertion is the absence of a "warming up"
+/// error, not the result content (see
+/// `bm25_hits_hydrate_from_handle_during_warmup` for content-level
+/// coverage of the fallback's BM25 hydration path).
+/// Test: this test.
 #[tokio::test]
-async fn recall_all_returns_warming_error_while_state_is_warming() {
+async fn recall_does_not_error_while_state_is_warming() {
+    let (state, _tmp) = test_state_warming();
+    let _ = dispatch_tool(
+        &state,
+        "palace_create",
+        serde_json::json!({"name": "warmtest-recall"}),
+    )
+    .await
+    .expect("palace_create");
+
+    let result = dispatch_tool(
+        &state,
+        "memory_recall",
+        serde_json::json!({
+            "palace": "warmtest-recall",
+            "query": "test query"
+        }),
+    )
+    .await
+    .expect("memory_recall must not error while Warming (issue #1970)");
+    assert!(result["results"].is_array());
+}
+
+/// Why (issue #1970): `memory_recall_deep` mirrors `memory_recall`'s
+/// warming-fallback posture.
+/// Test: this test.
+#[tokio::test]
+async fn recall_deep_does_not_error_while_state_is_warming() {
+    let (state, _tmp) = test_state_warming();
+    let _ = dispatch_tool(
+        &state,
+        "palace_create",
+        serde_json::json!({"name": "warmtest-recall-deep"}),
+    )
+    .await
+    .expect("palace_create");
+
+    let result = dispatch_tool(
+        &state,
+        "memory_recall_deep",
+        serde_json::json!({
+            "palace": "warmtest-recall-deep",
+            "query": "test query"
+        }),
+    )
+    .await
+    .expect("memory_recall_deep must not error while Warming (issue #1970)");
+    assert!(result["results"].is_array());
+}
+
+/// Why (issue #1970, was #914 Part A): `memory_recall_all` must not error
+/// while `Warming` either — it fans the same BM25/L0/L1 fallback out across
+/// every palace.
+/// Test: this test (regression guard for the gap originally fixed in #914
+/// Part A, now re-targeted at graceful degradation instead of a hard error).
+#[tokio::test]
+async fn recall_all_does_not_error_while_state_is_warming() {
     let (state, _tmp) = test_state_warming();
 
     let result = dispatch_tool(
         &state,
         "memory_recall_all",
         serde_json::json!({
-            "q": "test query that should be rejected while warming up"
+            "q": "test query issued while warming up"
         }),
     )
-    .await;
-    let err = result.expect_err("memory_recall_all must fail while Warming");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("warming up"),
-        "error must mention 'warming up'; got: {msg}"
+    .await
+    .expect("memory_recall_all must not error while Warming (issue #1970)");
+    assert!(result["results"].is_array());
+}
+
+/// Why (issue #1970): `bm25_hits_to_recall_results` is the piece that makes
+/// the warming-fallback recall path actually useful — without it, BM25
+/// hits would be silently dropped whenever there's no vector lane to boost
+/// (exactly the situation while the embedder is cold). This test exercises
+/// it directly against a handle's in-memory drawer table, with no BM25
+/// daemon or embedder involved.
+/// What: adds two drawers to a fresh handle, fabricates `BM25Hit`s
+/// referencing one real drawer id and one unknown id, calls
+/// `bm25_hits_to_recall_results`, and asserts the known drawer is hydrated
+/// with the BM25 score and `layer: 4` while the unknown hit is skipped.
+/// Test: this test.
+#[test]
+fn bm25_hits_hydrate_from_handle_during_warmup() {
+    use trusty_common::bm25_client::BM25Hit;
+    use trusty_common::memory_core::palace::Drawer;
+    use trusty_common::memory_core::store::kg::KnowledgeGraph;
+    use trusty_common::memory_core::store::vector::UsearchStore;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let vs = UsearchStore::new(dir.path().join("idx.usearch"), 384).expect("vector store");
+    let kg = KnowledgeGraph::open(&dir.path().join("kg.db")).expect("kg");
+    let handle = trusty_common::memory_core::retrieval::PalaceHandle::new(
+        PalaceId::new("bm25hydrate"),
+        String::new(),
+        vs,
+        kg,
     );
+
+    let drawer = Drawer::new(Uuid::new_v4(), "Rustc is a compiler for the Rust language");
+    let known_id = drawer.id;
+    handle.add_drawer(drawer);
+
+    let hits = vec![
+        BM25Hit {
+            doc_id: known_id.to_string(),
+            score: 4.2,
+        },
+        BM25Hit {
+            doc_id: Uuid::new_v4().to_string(),
+            score: 1.0,
+        },
+    ];
+
+    let results = bm25_hits_to_recall_results(&handle, &hits);
+    assert_eq!(
+        results.len(),
+        1,
+        "unknown drawer id must be skipped, not fabricated"
+    );
+    assert_eq!(results[0].drawer.id, known_id);
+    assert_eq!(results[0].score, 4.2);
+    assert_eq!(results[0].layer, 4, "BM25-hydrated hits use layer 4");
 }

--- a/crates/trusty-memory/tests/serve_stdio_e2e.rs
+++ b/crates/trusty-memory/tests/serve_stdio_e2e.rs
@@ -308,9 +308,12 @@ async fn stdio_serve_tools_list_bounded() {
 /// Why: proves that `memory_remember` and `memory_recall` work end-to-end
 /// through the bridge server and that both complete within the deadline.
 /// The daemon starts in `Warming` state (no background embedder warm-up
-/// completes before the test sends requests), so these calls may return the
-/// fast "warming up" error OR succeed if the embedder completes quickly.
-/// Either response counts as a pass — the invariant is "never hang".
+/// completes before the test sends requests). Since issue #1970, both calls
+/// are expected to *succeed* even while Warming (writes defer embedding to a
+/// background task; reads fall back to BM25/L0/L1) rather than error — the
+/// assertions below accept either shape defensively (a bounded explicit
+/// error would also be an acceptable non-hang outcome), but the invariant
+/// under test is "never hang".
 /// Test: `cargo test -p trusty-memory --test serve_stdio_e2e -- stdio_serve_remember_and_recall_bounded`.
 #[tokio::test]
 async fn stdio_serve_remember_and_recall_bounded() {
@@ -348,7 +351,8 @@ async fn stdio_serve_remember_and_recall_bounded() {
     // either is fine.  We only assert the response arrived within the deadline.
     assert_eq!(create_resp["id"], 2, "palace_create response id must match");
 
-    // memory_remember — may return success or warming error; must not hang.
+    // memory_remember — expected to succeed even while Warming (issue #1970);
+    // must not hang regardless.
     child
         .send(&json!({
             "jsonrpc": "2.0",
@@ -368,14 +372,16 @@ async fn stdio_serve_remember_and_recall_bounded() {
         remember_resp["id"], 3,
         "memory_remember response id must match"
     );
-    // Either success or an explicit error (e.g., warming up) — never absent.
+    // Accept either shape defensively — the hard invariant is "responded at
+    // all" (never absent / never a hang); success is now the expected shape.
     let is_ok_or_error = !remember_resp["result"].is_null() || !remember_resp["error"].is_null();
     assert!(
         is_ok_or_error,
         "memory_remember must return a result or error; got: {remember_resp}"
     );
 
-    // memory_recall — may return success or warming error; must not hang.
+    // memory_recall — expected to succeed even while Warming (BM25/L0/L1
+    // fallback, issue #1970); must not hang regardless.
     child
         .send(&json!({
             "jsonrpc": "2.0",
@@ -401,10 +407,11 @@ async fn stdio_serve_remember_and_recall_bounded() {
     child.close().await;
 }
 
-/// Why: `memory_recall_all` was the specific handler that lacked the
-/// readiness preflight (issue #914 Part A fix).  This test proves that even
-/// before the embedder is warm, `memory_recall_all` returns a bounded explicit
-/// response — not a hang.
+/// Why: `memory_recall_all` was originally the one handler that lacked the
+/// readiness preflight (issue #914 Part A fix); since #1970 the preflight
+/// itself is gone (graceful BM25/L0/L1 degradation replaced the hard error).
+/// This test proves that even before the embedder is warm, `memory_recall_all`
+/// returns a bounded response — not a hang.
 /// What: provisions daemon + bridge, sends `memory_recall_all` immediately
 /// after `initialize` (before any embedder warm-up could complete) and asserts
 /// the response arrives within `RESPONSE_DEADLINE`.
@@ -429,8 +436,9 @@ async fn stdio_serve_recall_all_bounded() {
     );
 
     // memory_recall_all — send immediately, before any warm-up can complete.
-    // Must return the fast "warming up" error (or succeed on very fast machines)
-    // within the deadline.
+    // Expected to succeed (BM25/L0/L1 fallback, issue #1970) within the
+    // deadline; a bounded error would also satisfy "never hangs" if it ever
+    // occurred (e.g. no palaces registered yet).
     child
         .send(&json!({
             "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary

Closes #1970.

**Root cause:** `memory_recall` / `memory_recall_deep` / `memory_recall_all` / `memory_remember` / `memory_note` / `task_add` all called `AppState::readiness_check()` as a hard preflight (issues #910/#911/#914) that returned MCP error `-32603` (`"trusty-memory is warming up (embedder initialising); please retry in a few seconds"`) whenever the shared embedder was still cold-initialising (30-120s CoreML/CUDA compile). trusty-search's staged pipeline, by contrast, treats the lexical (BM25) lane as fully independent of the semantic (vector) lane and never blocks reads/writes on embedder readiness — it just omits vector results until the embedder warms up.

**Fix:** remove the hard-error preflight and make trusty-memory behave the same way architecturally.

- **Reads** (`memory_recall`, `memory_recall_deep`, `memory_recall_all`): while `AppState::readiness()` is `Warming`, skip the vector lane entirely and return `retrieve_l0_l1()` + BM25 results instead of erroring. Since `fuse_bm25_into_recall()` only *boosts* existing vector hits (it has no drawer payload to hydrate BM25-only matches with), a new `bm25_hits_to_recall_results()` helper hydrates BM25 hits directly from the palace's in-memory drawer table (already resident, no disk I/O) so the degraded path returns real content instead of silently dropping lexical-only matches. Once `Ready`, behavior is unchanged (full vector + BM25 fusion).

- **Writes** (`memory_remember`, `memory_note`, `task_add`): a new `RememberOptions::defer_embedding` flag lets `PalaceHandle::remember_with_options()` skip the synchronous embed + vector-store upsert and instead spawn a background task (`spawn_deferred_embed`) that awaits the shared embedder and backfills the vector once it resolves. KG/redb/BM25 indexing stays fully synchronous, so writes are durable and BM25/KG-searchable immediately; only the vector lane trails behind. `defer_embedding` defaults to `false`, so every other caller of `RememberOptions` (CLI, trusty-mpm, direct trusty-common callers) is unaffected — this is opt-in, keyed off the live `AppState::readiness()` at the trusty-memory MCP boundary only.

`AppState::readiness_check()` is removed as dead code now that no handler hard-blocks on embedder state (confirmed no external crate called it).

## Test plan

- [x] `cargo test -p trusty-memory` — 401 lib tests + all integration test binaries pass (see raw output below)
- [x] `cargo test -p trusty-common --features memory-core,embedder-test-support` — 429 lib tests + all integration/doc tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (0 violations)
- [x] Replaced the four "must return warming-up error" tests with tests asserting graceful degradation (writes succeed + defer embedding; reads return without erroring)
- [x] Added `remember_succeeds_and_defers_embedding_while_state_is_warming`, which writes while `Warming`, confirms the drawer is immediately visible via `memory_list` (proves the synchronous KG/redb path), then polls (bounded, condition-based) `handle.vector_store` until the deferred embed backfills the vector — proving the background job actually runs and completes, not just fires-and-forgets into the void
- [x] Added a focused unit test for the new `bm25_hits_to_recall_results` hydration helper
- [ ] Live smoke test against a real running daemon — **not performed**. This machine has a live `trusty-memory` daemon other sessions may depend on (per repo convention, `trusty-memory` doesn't require FDA re-grant, but restarting it mid-session would still disrupt concurrent MCP clients); simulating a genuinely cold embedder safely would require stopping that daemon. Relied on the unit/integration test simulation (`test_state_warming()`, which constructs an isolated `AppState` that never calls `set_ready()`) instead, per the task's guidance to fall back to test simulation when a live test isn't safely feasible.

## Notable side-detail found during investigation

`AppState::embedder()` (used only by the read handlers) and `shared_embedder()` (used by the write path in `trusty-common`) are two independent process-wide `FastEmbedder` singletons — `AppState.daemon_readiness` is driven by `shared_embedder()`'s warm-up (see `spawn_startup_tasks` in `main.rs`), but `AppState::embedder()` has never been pre-warmed by anything, so historically the very first `memory_recall` after `daemon_readiness` flips to `Ready` could still eat a redundant cold compile. Out of scope for this fix (not the reported symptom, and unifying the two singletons is a larger refactor), but worth a follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)