### PR TITLE
fix(trusty-mpm): graceful CLI session termination + managed-session delegation gating

### DIFF
--- a/crates/trusty-mpm/src/daemon/mcp_backend.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend.rs
@@ -17,6 +17,7 @@ use crate::core::hook::{HookEvent, HookEventRecord};
 use crate::core::memory::MemoryUsage;
 use crate::core::session::SessionId;
 use crate::mcp::OrchestratorBackend;
+use crate::session_manager::record::ManagedSessionId;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use uuid::Uuid;
@@ -90,20 +91,43 @@ impl OrchestratorBackend for StateBackend {
     }
 
     /// Return one session plus its memory snapshot and delegation count.
+    ///
+    /// Resolves BOTH session families (#1976): the legacy in-process
+    /// `DaemonState` registry first, then — on a miss — the managed
+    /// `SessionManager` store. Without the managed fallback, `session_status`
+    /// reported "no such session" for the `tmpm-` sessions trusty-mpm itself
+    /// spawns, even though `session_list` surfaces them. Managed records are
+    /// serialized via the shared `record_to_json` (matching `session_list`) and
+    /// carry no memory snapshot; delegations are keyed by UUID so they resolve
+    /// for either family.
     async fn session_status(&self, session_id: &str) -> Result<Value, String> {
         let id = parse_session_id(session_id)?;
-        let session = self
-            .state
-            .session(id)
-            .ok_or_else(|| format!("no such session: {session_id}"))?;
-        let memory = self.state.memory_for(id);
-        let delegations = self.state.delegations_for(id);
-        Ok(json!({
-            "session": session,
-            "memory": memory,
-            "delegation_count": delegations.len(),
-            "delegations": delegations,
-        }))
+        // Legacy in-process registry first.
+        if let Some(session) = self.state.session(id) {
+            let memory = self.state.memory_for(id);
+            let delegations = self.state.delegations_for(id);
+            return Ok(json!({
+                "session": session,
+                "kind": "legacy",
+                "memory": memory,
+                "delegation_count": delegations.len(),
+                "delegations": delegations,
+            }));
+        }
+        // Managed store fallback (#1976): the `tmpm-` sessions `session_list`
+        // surfaces and `session_stop`/`session_resume` already target by id.
+        let manager = self.state.session_manager().await;
+        if let Ok(record) = manager.get(&ManagedSessionId(id.0)).await {
+            let delegations = self.state.delegations_for(id);
+            return Ok(json!({
+                "session": crate::daemon::managed_routes::record_to_json(&record),
+                "kind": "managed",
+                "memory": Value::Null,
+                "delegation_count": delegations.len(),
+                "delegations": delegations,
+            }));
+        }
+        Err(format!("no such session: {session_id}"))
     }
 
     /// Gate and record a new agent delegation.
@@ -118,7 +142,20 @@ impl OrchestratorBackend for StateBackend {
         tier: Option<&str>,
     ) -> Result<Value, String> {
         let id = parse_session_id(session_id)?;
-        if self.state.session(id).is_none() {
+        // Accept BOTH session families (#1976): the gating registry historically
+        // only knew the legacy in-process registry, so delegations from the
+        // managed (`tmpm-`) sessions trusty-mpm itself spawns were rejected
+        // outright. Fall back to the managed store on a legacy miss. The
+        // delegation is keyed by UUID, so tracking works for either family.
+        let known = self.state.session(id).is_some()
+            || self
+                .state
+                .session_manager()
+                .await
+                .get(&ManagedSessionId(id.0))
+                .await
+                .is_ok();
+        if !known {
             return Err(format!("no such session: {session_id}"));
         }
         let breaker = self.state.breaker(agent);
@@ -614,6 +651,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_status_resolves_managed_session() {
+        // Regression for #1976: session_status previously only consulted the
+        // legacy registry, so a managed (`tmpm-`) session — the primary type
+        // trusty-mpm spawns — reported "no such session". It must now resolve via
+        // the managed store fallback and report `kind: "managed"`.
+        let root = tempfile::TempDir::new().expect("root tempdir");
+        let state =
+            Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+        let record = state
+            .session_manager()
+            .await
+            .create(
+                "fix the bug".to_string(),
+                Some(root.path().to_path_buf()),
+                None,
+                Some(root.path().to_path_buf()),
+                None,
+                None,
+            )
+            .await
+            .expect("managed create");
+
+        let backend = StateBackend::new(state);
+        let status = backend
+            .session_status(&record.id.to_string())
+            .await
+            .expect("managed session must resolve via the #1976 fallback");
+        assert_eq!(status["kind"], "managed");
+        assert_eq!(status["session"]["id"], record.id.to_string());
+    }
+
+    #[tokio::test]
     async fn agent_delegate_records_a_delegation() {
         let (state, id) = state_with_session();
         let backend = StateBackend::new(state.clone());
@@ -638,6 +707,44 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.contains("circuit breaker"));
+    }
+
+    #[tokio::test]
+    async fn agent_delegate_accepts_managed_session() {
+        // Regression for #1976: delegation gating rejected managed (`tmpm-`)
+        // sessions with "no such session" because it only checked the legacy
+        // registry. A delegation from a managed session must now be accepted and
+        // recorded (keyed by UUID).
+        let root = tempfile::TempDir::new().expect("root tempdir");
+        let state =
+            Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+        let record = state
+            .session_manager()
+            .await
+            .create(
+                "implement the fix".to_string(),
+                Some(root.path().to_path_buf()),
+                None,
+                Some(root.path().to_path_buf()),
+                None,
+                None,
+            )
+            .await
+            .expect("managed create");
+
+        let backend = StateBackend::new(state.clone());
+        let result = backend
+            .agent_delegate(
+                &record.id.to_string(),
+                "rust-engineer",
+                "wire it up",
+                Some("sonnet"),
+            )
+            .await
+            .expect("delegation from a managed session must be accepted (#1976)");
+        assert_eq!(result["agent"], "rust-engineer");
+        // The delegation is keyed by the session UUID, shared across both families.
+        assert_eq!(state.delegations_for(SessionId(record.id.0)).len(), 1);
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -310,10 +310,9 @@ impl SessionManager {
         // Gracefully terminate the runtime before removing the workspace (#1975):
         // SIGTERM the claude process and give it a grace window to flush state,
         // then reclaim the pane — instead of an abrupt `kill_session`. Best-effort:
-        // a session whose runtime is already gone still decommissions cleanly.
-        if self.tmux.session_exists(&record.tmux_name) {
-            self.graceful_terminate_runtime(&record.tmux_name).await;
-        }
+        // a session whose runtime is already gone still decommissions cleanly —
+        // the helper self-guards and is a no-op when the pane is already gone.
+        self.graceful_terminate_runtime(&record.tmux_name).await;
 
         // Guard: only remove the workspace directory if the SM provisioned it.
         // Track whether remove_dir_all ACTUALLY RAN (not inferred from filesystem).

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -307,11 +307,12 @@ impl SessionManager {
     ) -> Result<(SessionRecord, bool), ManagedError> {
         let mut record = self.get(id).await?;
 
-        // Kill the runtime (best-effort).
-        if self.tmux.session_exists(&record.tmux_name)
-            && let Err(e) = self.tmux.kill_session(&record.tmux_name)
-        {
-            warn!(name = %record.tmux_name, "decommission: kill_session failed: {e}");
+        // Gracefully terminate the runtime before removing the workspace (#1975):
+        // SIGTERM the claude process and give it a grace window to flush state,
+        // then reclaim the pane — instead of an abrupt `kill_session`. Best-effort:
+        // a session whose runtime is already gone still decommissions cleanly.
+        if self.tmux.session_exists(&record.tmux_name) {
+            self.graceful_terminate_runtime(&record.tmux_name).await;
         }
 
         // Guard: only remove the workspace directory if the SM provisioned it.

--- a/crates/trusty-mpm/src/session_manager/driver.rs
+++ b/crates/trusty-mpm/src/session_manager/driver.rs
@@ -122,23 +122,44 @@ pub trait ManagedTmuxDriver: Send + Sync {
     /// Test: `fake_driver_graceful_stop_with_pid` (pid known, records kill),
     /// `fake_driver_graceful_stop_without_pid` (no pid, falls back to C-c).
     fn graceful_stop(&self, name: &str, claude_pid: Option<u32>) -> Result<(), ManagedError> {
+        self.signal_terminate(name, claude_pid);
+        self.kill_session(name)
+    }
+
+    /// Signal a session's `claude` process to stop WITHOUT killing the pane.
+    ///
+    /// Why: a truly graceful teardown sends the termination signal, waits a grace
+    /// window so `claude` can flush state, and only THEN reclaims the pane. That
+    /// ordering requires the signal and the kill to be separate steps — so this is
+    /// the signal-only half, letting an async caller insert a `tokio::time::sleep`
+    /// grace window between it and `kill_session` (see
+    /// [`SessionManager::graceful_terminate_runtime`] for the CLI stop/decommission
+    /// path). `graceful_stop` composes this with an immediate kill for the
+    /// batched, one-grace-window-for-all shutdown path.
+    /// What: SIGTERMs the known `claude_pid` via `nix::signal::kill` (unix only);
+    /// when the pid is unknown, falls back to a single `send_interrupt` (Ctrl-C).
+    /// Signal errors are logged and swallowed — the process may already be gone —
+    /// so this method is infallible (the fallible reclaim lives in `kill_session`).
+    /// Test: `fake_driver_graceful_stop_with_pid` / `_without_pid` cover the
+    /// composed `graceful_stop`; the CLI drain is covered by
+    /// `graceful_terminate_runtime_signals_then_kills` in `restart_ops`.
+    fn signal_terminate(&self, name: &str, claude_pid: Option<u32>) {
         if let Some(pid) = claude_pid {
             #[cfg(unix)]
             {
                 use nix::sys::signal::{Signal, kill};
                 use nix::unistd::Pid;
                 if let Err(e) = kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
-                    tracing::warn!(pid, name, "graceful_stop: SIGTERM failed: {e}");
+                    tracing::warn!(pid, name, "signal_terminate: SIGTERM failed: {e}");
                 }
             }
             #[cfg(not(unix))]
             {
-                let _ = pid; // SIGTERM not applicable on non-unix; fall through to kill
+                let _ = pid; // SIGTERM not applicable on non-unix
             }
         } else {
             // No pid — best effort interrupt via tmux send-keys.
             let _ = self.send_interrupt(name);
         }
-        self.kill_session(name)
     }
 }

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -579,17 +579,20 @@ impl SessionManager {
     /// tmux session and the `claude` process inside it, but PRESERVES the
     /// workspace directory on disk and the session record so the session can
     /// be resumed later via `resume`.
-    /// What: kills the tmux session (best-effort; logs a warning on failure
-    /// since the session may already be gone), marks the record `Stopped`
-    /// (workspace path untouched), and persists.
+    /// What: captures a pane snapshot, then GRACEFULLY terminates the runtime via
+    /// [`Self::graceful_terminate_runtime`] (SIGTERM the `claude` process, grace
+    /// window, then reclaim the pane — #1975) so the process can flush state
+    /// before it dies, marks the record `Stopped` (workspace path untouched), and
+    /// persists.
     /// Test: `manager_stop_keeps_workspace` — asserts state is `Stopped` and
     /// workspace dir still exists on disk.
     pub async fn stop(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
         let mut record = self.get(id).await?;
         super::snapshot::capture_into(&mut record, &*self.tmux).await;
-        if let Err(e) = self.tmux.kill_session(&record.tmux_name) {
-            warn!(name = %record.tmux_name, "kill_session failed (may already be gone): {e}");
-        }
+        // Graceful teardown (#1975): give the claude process a SIGTERM + grace
+        // window to checkpoint before its tmux pane is reclaimed, instead of an
+        // abrupt `kill_session`. The snapshot above already preserved the pane.
+        self.graceful_terminate_runtime(&record.tmux_name).await;
         record.state = ManagedSessionState::Stopped;
         self.store.write().await.upsert(record.clone()).await?;
         info!(id = %id, name = %record.tmux_name, "managed session stopped (workspace intact)");

--- a/crates/trusty-mpm/src/session_manager/restart_ops.rs
+++ b/crates/trusty-mpm/src/session_manager/restart_ops.rs
@@ -113,4 +113,38 @@ impl SessionManager {
         }
         info!("shutdown: gracefully stopped {stopped} live managed session(s)");
     }
+
+    /// Gracefully terminate ONE session's runtime: signal → grace → kill.
+    ///
+    /// Why: CLI-initiated `stop`/`decommission` tear down a single session at a
+    /// time (unlike [`Self::shutdown`], which batches one grace window across the
+    /// whole fleet) and were previously abrupt — a bare `kill_session` gave the
+    /// inner `claude` process no chance to flush state (memory snapshot, git
+    /// index, session record) before its pane was reclaimed. This drains one
+    /// session the same way `shutdown` drains the fleet, honouring the repo's
+    /// graceful-shutdown convention (SIGTERM drain, not an abrupt kill).
+    /// What: resolves the live `claude` PID via a single
+    /// [`crate::core::process::find_claude_pid_in_tmux`] probe (no retry), calls
+    /// `signal_terminate` (SIGTERM when the PID is known, else one Ctrl-C), awaits
+    /// a [`SIGTERM_GRACE_SECS`] async grace window (0 s in tests) so the process
+    /// can checkpoint, then `kill_session` to reclaim the pane. Every step is
+    /// best-effort: a `kill_session` failure is logged, not returned, because the
+    /// caller still needs to mark the record `Stopped` / decommissioned even when
+    /// the runtime was already gone. Uses `tokio::time::sleep` — never a blocking
+    /// `std::thread::sleep` — so it does not starve the Tokio thread pool.
+    /// Test: `graceful_terminate_runtime_signals_then_kills` in tests.rs (fake
+    /// driver records a Ctrl-C then a kill); exercised end-to-end by
+    /// `manager_stop_keeps_workspace` and `manager_decommission_removes_workspace`.
+    pub(crate) async fn graceful_terminate_runtime(&self, tmux_name: &str) {
+        let pid =
+            crate::core::process::find_claude_pid_in_tmux(tmux_name, 1, Duration::from_millis(0));
+        self.tmux.signal_terminate(tmux_name, pid);
+        tokio::time::sleep(Duration::from_secs(SIGTERM_GRACE_SECS)).await;
+        if let Err(e) = self.tmux.kill_session(tmux_name) {
+            warn!(
+                name = %tmux_name,
+                "graceful_terminate_runtime: kill_session failed (may already be gone): {e}"
+            );
+        }
+    }
 }

--- a/crates/trusty-mpm/src/session_manager/restart_ops.rs
+++ b/crates/trusty-mpm/src/session_manager/restart_ops.rs
@@ -123,9 +123,10 @@ impl SessionManager {
     /// index, session record) before its pane was reclaimed. This drains one
     /// session the same way `shutdown` drains the fleet, honouring the repo's
     /// graceful-shutdown convention (SIGTERM drain, not an abrupt kill).
-    /// What: resolves the live `claude` PID via a single
-    /// [`crate::core::process::find_claude_pid_in_tmux`] probe (no retry), calls
-    /// `signal_terminate` (SIGTERM when the PID is known, else one Ctrl-C), awaits
+    /// What: returns early (no signal, no grace sleep, no kill) when the tmux
+    /// session no longer exists; otherwise resolves the live `claude` PID via a
+    /// single [`crate::core::process::find_claude_pid_in_tmux`] probe (no retry),
+    /// calls `signal_terminate` (SIGTERM when the PID is known, else one Ctrl-C), awaits
     /// a [`SIGTERM_GRACE_SECS`] async grace window (0 s in tests) so the process
     /// can checkpoint, then `kill_session` to reclaim the pane. Every step is
     /// best-effort: a `kill_session` failure is logged, not returned, because the
@@ -136,6 +137,12 @@ impl SessionManager {
     /// driver records a Ctrl-C then a kill); exercised end-to-end by
     /// `manager_stop_keeps_workspace` and `manager_decommission_removes_workspace`.
     pub(crate) async fn graceful_terminate_runtime(&self, tmux_name: &str) {
+        // Fast-path: nothing to drain if the pane is already gone. Skips the grace
+        // sleep entirely so callers looping over dead sessions (e.g. prune-idle) do
+        // not pay SIGTERM_GRACE_SECS per already-terminated session.
+        if !self.tmux.session_exists(tmux_name) {
+            return;
+        }
         let pid =
             crate::core::process::find_claude_pid_in_tmux(tmux_name, 1, Duration::from_millis(0));
         self.tmux.signal_terminate(tmux_name, pid);

--- a/crates/trusty-mpm/src/session_manager/restart_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/restart_tests.rs
@@ -11,7 +11,75 @@
 
 use std::sync::Mutex;
 
-use super::manager::{ManagedError, ManagedTmuxDriver};
+use tempfile::TempDir;
+
+use super::manager::{ManagedError, ManagedTmuxDriver, SessionManager};
+use super::tests::FakeTmuxDriver;
+
+/// `graceful_terminate_runtime` signals the runtime BEFORE reclaiming the pane (#1975).
+///
+/// Why: CLI stop/decommission must give the `claude` process a termination signal
+/// (and a grace window) to flush state, not an abrupt `kill_session`. With no real
+/// tmux the PID probe returns `None`, so `signal_terminate` falls back to a Ctrl-C
+/// interrupt; the grace window is 0 s under `#[cfg(test)]`. Lives here (not in the
+/// at-cap `tests.rs`) alongside the other `restart_ops` graceful-shutdown coverage.
+/// What: seeds the session so the helper's self-guard sees it as live, drives the
+/// helper directly, and asserts BOTH the interrupt fired and the pane was
+/// subsequently killed — the two-phase drain.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn graceful_terminate_runtime_signals_then_kills() {
+    let dir = TempDir::new().unwrap();
+    let fake = FakeTmuxDriver::new();
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    // Seed the session so the helper's self-guard (`session_exists`, which reads
+    // `list_sessions()`) reports it as live; otherwise the helper no-ops.
+    fake.seeded_names
+        .lock()
+        .unwrap()
+        .push("tm-drain-1".to_string());
+
+    mgr.graceful_terminate_runtime("tm-drain-1").await;
+
+    assert_eq!(
+        *fake.interrupt_calls.lock().unwrap(),
+        vec!["tm-drain-1".to_string()],
+        "expected a Ctrl-C interrupt (SIGTERM fallback) before the pane is reclaimed"
+    );
+    assert_eq!(
+        *fake.kill_calls.lock().unwrap(),
+        vec!["tm-drain-1".to_string()],
+        "expected the pane to be reclaimed after the grace window"
+    );
+}
+
+/// `graceful_terminate_runtime` is a no-op when the tmux session no longer exists.
+///
+/// Why: the drain helper now self-guards (fast-path) so callers looping over dead
+/// sessions (e.g. prune-idle) do not pay the SIGTERM grace window per already-gone
+/// session, and a decommission of an already-terminated runtime does no signalling.
+/// What: drives the helper against a name that was never seeded (so `session_exists`
+/// reports false) and asserts neither an interrupt nor a kill was issued.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn graceful_terminate_runtime_noop_when_session_gone() {
+    let dir = TempDir::new().unwrap();
+    let fake = FakeTmuxDriver::new();
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    // Do NOT seed "tm-already-gone" — the session_exists guard must short-circuit.
+    mgr.graceful_terminate_runtime("tm-already-gone").await;
+
+    assert!(
+        fake.interrupt_calls.lock().unwrap().is_empty(),
+        "must not signal a session that no longer exists"
+    );
+    assert!(
+        fake.kill_calls.lock().unwrap().is_empty(),
+        "must not kill a session that no longer exists"
+    );
+}
 
 /// A minimal driver that does NOT override `graceful_stop`, so the DEFAULT trait
 /// impl runs — exercising its real SIGTERM-with-known-PID branch.

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -45,6 +45,13 @@ pub struct FakeTmuxDriver {
     pub create_cwd_calls: Mutex<Vec<(String, String)>>,
     /// Records `(session_name, claude_pid)` for every `graceful_stop` call.
     pub graceful_stop_calls: Mutex<Vec<(String, Option<u32>)>>,
+    /// Records the session name for every `send_interrupt` (Ctrl-C) call.
+    ///
+    /// Why: the CLI graceful-drain path (#1975) signals the runtime via
+    /// `signal_terminate`, which — with no PID known in unit tests — falls back to
+    /// `send_interrupt`. Recording it lets `graceful_terminate_runtime_signals_then_kills`
+    /// assert the signal fired before the pane was reclaimed.
+    pub interrupt_calls: Mutex<Vec<String>>,
 }
 
 impl FakeTmuxDriver {
@@ -57,6 +64,7 @@ impl FakeTmuxDriver {
             seeded_names: Mutex::new(Vec::new()),
             create_cwd_calls: Mutex::new(Vec::new()),
             graceful_stop_calls: Mutex::new(Vec::new()),
+            interrupt_calls: Mutex::new(Vec::new()),
         })
     }
 }
@@ -120,6 +128,17 @@ impl ManagedTmuxDriver for FakeTmuxDriver {
             .unwrap()
             .push((name.to_owned(), claude_pid));
         self.kill_session(name)
+    }
+
+    /// Record Ctrl-C interrupts so the graceful-drain path (#1975) is observable.
+    ///
+    /// Why: the default `send_interrupt` fails loudly (`TmuxUnavailable`) to catch
+    /// drivers that silently drop interrupts; the fake instead records the call and
+    /// succeeds so `graceful_terminate_runtime`'s signal phase can be asserted.
+    /// What: records `name` and returns `Ok`.
+    fn send_interrupt(&self, name: &str) -> Result<(), ManagedError> {
+        self.interrupt_calls.lock().unwrap().push(name.to_owned());
+        Ok(())
     }
 }
 
@@ -326,6 +345,34 @@ async fn manager_name_hint_overrides() {
         .expect("create");
 
     assert_eq!(record.tmux_name, "tm-ticket-1234-01");
+}
+
+/// `graceful_terminate_runtime` signals the runtime BEFORE reclaiming the pane (#1975).
+///
+/// Why: CLI stop/decommission must give the `claude` process a termination signal
+/// (and a grace window) to flush state, not an abrupt `kill_session`. With no real
+/// tmux the PID probe returns `None`, so `signal_terminate` falls back to a Ctrl-C
+/// interrupt; the grace window is 0 s under `#[cfg(test)]`.
+/// What: drives the helper directly and asserts BOTH the interrupt fired and the
+/// pane was subsequently killed — the two-phase drain.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn graceful_terminate_runtime_signals_then_kills() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    mgr.graceful_terminate_runtime("tm-drain-1").await;
+
+    assert_eq!(
+        *fake.interrupt_calls.lock().unwrap(),
+        vec!["tm-drain-1".to_string()],
+        "expected a Ctrl-C interrupt (SIGTERM fallback) before the pane is reclaimed"
+    );
+    assert_eq!(
+        *fake.kill_calls.lock().unwrap(),
+        vec!["tm-drain-1".to_string()],
+        "expected the pane to be reclaimed after the grace window"
+    );
 }
 
 /// `stop` must kill the runtime but KEEP the workspace directory and record,

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -347,34 +347,6 @@ async fn manager_name_hint_overrides() {
     assert_eq!(record.tmux_name, "tm-ticket-1234-01");
 }
 
-/// `graceful_terminate_runtime` signals the runtime BEFORE reclaiming the pane (#1975).
-///
-/// Why: CLI stop/decommission must give the `claude` process a termination signal
-/// (and a grace window) to flush state, not an abrupt `kill_session`. With no real
-/// tmux the PID probe returns `None`, so `signal_terminate` falls back to a Ctrl-C
-/// interrupt; the grace window is 0 s under `#[cfg(test)]`.
-/// What: drives the helper directly and asserts BOTH the interrupt fired and the
-/// pane was subsequently killed — the two-phase drain.
-/// Test: this function IS the test.
-#[tokio::test]
-async fn graceful_terminate_runtime_signals_then_kills() {
-    let dir = TempDir::new().unwrap();
-    let (mgr, fake) = make_manager(&dir).await;
-
-    mgr.graceful_terminate_runtime("tm-drain-1").await;
-
-    assert_eq!(
-        *fake.interrupt_calls.lock().unwrap(),
-        vec!["tm-drain-1".to_string()],
-        "expected a Ctrl-C interrupt (SIGTERM fallback) before the pane is reclaimed"
-    );
-    assert_eq!(
-        *fake.kill_calls.lock().unwrap(),
-        vec!["tm-drain-1".to_string()],
-        "expected the pane to be reclaimed after the grace window"
-    );
-}
-
 /// `stop` must kill the runtime but KEEP the workspace directory and record,
 /// setting state to `Stopped` (not `Dead` or any terminal state).
 ///


### PR DESCRIPTION
Closes #1975. Closes #1976.

Two session-lifecycle correctness fixes in `trusty-mpm`, both found during a live dogfood full-service test.

## #1975 — Graceful CLI session termination
CLI `stop`/`decommission` (`SessionManager::stop()`, `decommission_with_root()`) called a bare `self.tmux.kill_session()` — `tmux kill-session` tears down the pane's process group immediately, giving the inner `claude` process no SIGTERM and no grace window to flush state (memory snapshot, git index, session record). Daemon *shutdown* already drains gracefully; the CLI paths didn't.

- New `SessionManager::graceful_terminate_runtime(tmux_name)` (`restart_ops.rs`): resolve the live claude PID (`find_claude_pid_in_tmux`), `signal_terminate` (SIGTERM; Ctrl-C fallback when the PID is unknown), await `SIGTERM_GRACE_SECS` (0 in test cfg), then `kill_session`.
- Split the `ManagedTmuxDriver::graceful_stop` trait method into `signal_terminate` + `kill_session` (behavior-preserving — `graceful_stop` now composes them) so the async CLI path can insert a real grace window between signal and kill.
- `stop()` (snapshot already captured first) and `decommission_with_root()` now route through the new helper.

## #1976 — Delegation gating resolves managed sessions
`agent_delegate` and `session_status` gated on `state.session(id)` — the legacy in-process `DaemonState` registry only — so managed (`tmpm-`) sessions returned `"no such session"`, even though `session_list` surfaces them. The delegation gating/circuit-breaker layer was therefore unavailable to the primary session type trusty-mpm spawns.

- Both handlers fall back to the managed `SessionManager` store (`state.session_manager().await.get(&ManagedSessionId(id.0))`) on a legacy miss. `session_status` returns the managed record via the shared `record_to_json` tagged `kind: "managed"`; delegations are keyed by UUID so they resolve for either family.

## Tests
`graceful_terminate_runtime_signals_then_kills`, `session_status_resolves_managed_session`, `agent_delegate_accepts_managed_session`. Full gate green: `cargo test -p trusty-mpm` (23 unit + all integration suites), `clippy -D warnings`, `fmt`, and `check_line_cap.sh` (0 violations). Existing regressions (`manager_stop_keeps_workspace`, `manager_decommission_removes_workspace`, `fake_driver_graceful_stop_*`, `session_list_*`, `agent_delegate_*`) stay green.

## Not in this PR
Two related delegation-model defects found in the same dogfood test are filed separately: #1977 (no PreToolUse enforcement hook for PM prohibitions) and #1978 (`rust-engineer.md` deployed as a non-spawnable stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)