### PR TITLE
fix(agents): make rust-engineer subagent spawnable (add description + valid model)

### DIFF
--- a/.claude/agents/rust-engineer.md
+++ b/.claude/agents/rust-engineer.md
@@ -1,11 +1,13 @@
 ---
 name: rust-engineer
-model: claude-opus-4-6
+description: Rust implementation specialist for the trusty-tools Cargo workspace. Use for all Rust code changes — new crates, features, refactors, bug fixes. Writes memory-safe code (no unwrap in libraries, thiserror for libs / anyhow for binaries, Why/What/Test docs on public items), respects the 500-SLOC production cap and per-crate edition rules, and runs the cargo test/clippy/fmt gate before returning.
+model: opus
+agent_type: engineer
 ---
 
 # Rust Engineer — trusty-tools Monorepo
 
-You are a Rust engineer working in the trusty-tools unified workspace at `/Users/masa/Projects/trusty-tools/`.
+You are a Rust engineer working in the trusty-tools unified Cargo workspace.
 
 ## Workspace structure
 All crates live under `crates/`. Internal deps use path references — no `[patch.crates-io]` needed.


### PR DESCRIPTION
Closes #1978.

## Root cause (corrected from the issue)
The committed `.claude/agents/rust-engineer.md` (added in `aa771c8b`) is a trusty-tools-local, hand-written agent with a custom monorepo body — but its frontmatter is missing the `description` field the harness requires to register an agent as a **spawnable subagent type**. Result: `Agent(subagent_type="rust-engineer")` fails with *"Agent type 'rust-engineer' not found"*, so the PM cannot delegate Rust work to the agent `AGENT_DELEGATION.md` routes it to (it's the only project agent without a `description`).

This is **not** a tm agent-deploy-template bug — the tm asset (`crates/trusty-mpm/src/assets/agents/rust-engineer.md`) is well-formed, and `agent_deployer.rs` correctly skips user-owned files, so it never overwrote this local stub.

## Fix
- Add a `description` (registers the subagent).
- Replace stale `model: claude-opus-4-6` with `model: opus` (matches `AGENT_DELEGATION.md`'s "rust-engineer (opus)").
- Add `agent_type: engineer` for parity with the other deployed agents.
- Drop the stale `/Users/masa/Projects/trusty-tools/` absolute path from the body.
- Custom monorepo guidance (MSRV, editions, conventions, gate) preserved verbatim.

## Verification
Frontmatter parses as valid YAML with a non-empty `description`. Note: Claude Code resolves subagent types at **session start**, so spawnability takes effect on the next session — cannot be exercised in the current running session. Config/docs-only change; no Rust touched.

Found via dogfood test 2026-07-03. Part of the delegation-model trio (#1976 tracking ✅ shipped, #1977 enforcement ⏳).

🤖 Generated with [Claude Code](https://claude.com/claude-code)