### PR TITLE
fix(trusty-mpm): statusline shows user/repo, drops duplicate session-id branch

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/mod.rs
@@ -128,31 +128,68 @@ pub(crate) fn render_statusline(input: &StatusInput) -> String {
 
 // ── Segment builders ──────────────────────────────────────────────────────────
 
-/// Build the project-name + git-branch segment from `cwd`.
+/// Build the project-identity + git-branch segment from `cwd`.
 ///
-/// Why: shows the project name and current branch without requiring a running
-/// daemon; a subprocess git call is cheap enough for a status-bar refresh.
-/// What: extracts the dirname basename and appends ` ⎇ <branch>` when the
-/// working directory is inside a git repo.
-/// Test: `render_statusline_minimal_input` (empty cwd → None).
+/// Why (#1913-followup): a managed tm session runs in `.worktrees/<uuid>/`, so the
+/// cwd basename is just the session UUID — useless as a project label and a
+/// duplicate of the `session/<uuid>` branch. The leading field should instead be
+/// the GitHub `owner/repo` slug (the codebase's canonical `source_id`), and the
+/// redundant `session/<…>` branch is dropped so the operator can actually tell
+/// which project and branch they are on.
+/// What: derives `owner/repo` from the git remote (reusing
+/// [`trusty_common::github_path::derive_github_path`] — the same parser
+/// `derive_source_id_for_record` uses; handles https and scp-style remotes),
+/// falling back to the cwd basename only when there is no parseable GitHub remote.
+/// Appends ` ⎇ <branch>` for meaningful branches, but omits it for the auto-created
+/// `session/<…>` managed-session branch and for detached `HEAD`.
+/// Test: `project_segment_basename_fallback_non_git`, `git_owner_repo_reads_remote`,
+/// `render_project_segment_*`, `render_statusline_minimal_input` (empty cwd → None).
 fn project_segment(cwd: &str) -> Option<String> {
     if cwd.is_empty() {
         return None;
     }
-    let project = std::path::Path::new(cwd)
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    // Prefer the GitHub owner/repo slug from the git remote; fall back to the cwd
+    // basename only when there is no parseable remote (non-GitHub / non-git dir).
+    let project = git_owner_repo(cwd).unwrap_or_else(|| {
+        std::path::Path::new(cwd)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default()
+    });
+    render_project_segment(project, git_branch(cwd).as_deref())
+}
+
+/// Assemble the project segment string from an already-resolved label and branch.
+///
+/// Why: keeping the label/branch combination pure (no git I/O) makes the
+/// branch-omission logic unit-testable without spawning subprocesses.
+/// What: returns `None` for an empty label; otherwise `"<project>  ⎇ <branch>"`
+/// for a meaningful branch, or just `"<project>"` when the branch is empty,
+/// detached `HEAD`, or a managed `session/<…>` branch (see
+/// [`is_managed_session_branch`]).
+/// Test: `render_project_segment_omits_managed_session_branch`,
+/// `render_project_segment_keeps_real_branch`, `render_project_segment_empty_label`.
+fn render_project_segment(project: String, branch: Option<&str>) -> Option<String> {
     if project.is_empty() {
         return None;
     }
-    let branch = git_branch(cwd);
     Some(match branch {
-        Some(b) if !b.is_empty() && b != "HEAD" => {
+        Some(b) if !b.is_empty() && b != "HEAD" && !is_managed_session_branch(b) => {
             format!("{project}  \u{2387} {b}")
         }
         _ => project,
     })
+}
+
+/// Report whether `branch` is an auto-created managed tm session branch.
+///
+/// Why: tm provisions each managed session on a `session/<uuid>` branch; showing
+/// it in the status bar just repeats the session id and crowds out the real
+/// project identity, so it is elided.
+/// What: matches the literal `session` branch and any `session/<…>` prefix.
+/// Test: `is_managed_session_branch_matches_session_prefix`.
+fn is_managed_session_branch(branch: &str) -> bool {
+    branch == "session" || branch.starts_with("session/")
 }
 
 /// Build the model-label segment.
@@ -261,6 +298,34 @@ fn git_branch(cwd: &str) -> Option<String> {
     rx.recv_timeout(Duration::from_millis(100)).ok().flatten()
 }
 
+/// Derive the GitHub `owner/repo` slug for `cwd` with a 100 ms wall-clock timeout.
+///
+/// Why: the leading status-bar field must identify the project, not the worktree
+/// UUID; the canonical identity is the repo's `owner/repo` (the `source_id`). The
+/// bounded-thread pattern (matching [`git_branch`]) keeps a stuck git config /
+/// filesystem from blocking Claude Code's hot render path.
+/// What: spawns a detached thread that calls the shared parser
+/// [`trusty_common::github_path::derive_github_path`] (which shells to
+/// `git -C <cwd> config --get remote.origin.url` — no network — and parses both
+/// https and scp-style remotes), formats `owner/repo`, and sends it over an mpsc
+/// channel; the caller waits ≤100 ms and returns `None` on timeout, no remote, or
+/// an unparseable / non-GitHub URL.
+/// Test: `git_owner_repo_reads_remote` (temp repo with a github origin);
+/// `git_owner_repo_none_outside_repo` (bare temp dir → None).
+fn git_owner_repo(cwd: &str) -> Option<String> {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let cwd = cwd.to_string();
+    let (tx, rx) = mpsc::channel::<Option<String>>();
+    std::thread::spawn(move || {
+        let result = trusty_common::github_path::derive_github_path(std::path::Path::new(&cwd))
+            .map(|gh| format!("{}/{}", gh.owner, gh.repo));
+        let _ = tx.send(result);
+    });
+    rx.recv_timeout(Duration::from_millis(100)).ok().flatten()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -293,6 +358,7 @@ mod tests {
     #[test]
     fn render_statusline_full_payload() {
         // Full payload shows model name, cost; project segment when cwd is set.
+        // `/home/user/my-project` is not a git repo → basename fallback ("my-project").
         let input = full_input();
         let out = render_statusline(&input);
         assert!(
@@ -304,6 +370,125 @@ mod tests {
             out.contains("my-project"),
             "project name from cwd must appear"
         );
+    }
+
+    /// Why: a managed tm session runs on a `session/<uuid>` branch that just
+    /// repeats the session id; it must be elided while real branches stay.
+    /// Test: itself.
+    #[test]
+    fn is_managed_session_branch_matches_session_prefix() {
+        assert!(is_managed_session_branch("session/2dfb23d1-579f-4168-9d28"));
+        assert!(is_managed_session_branch("session/anything"));
+        assert!(is_managed_session_branch("session"));
+        assert!(!is_managed_session_branch("main"));
+        assert!(!is_managed_session_branch("fix/foo"));
+        // Not the managed prefix (note the trailing `s`).
+        assert!(!is_managed_session_branch("sessions/foo"));
+    }
+
+    /// Why: a managed session must render `owner/repo` with NO branch (and hence
+    /// no duplicated UUID) even though a `session/<uuid>` branch is checked out.
+    /// Test: itself.
+    #[test]
+    fn render_project_segment_omits_managed_session_branch() {
+        let seg = render_project_segment(
+            "bobmatnyc/trusty-tools".to_string(),
+            Some("session/2dfb23d1-579f-4168-9d28"),
+        );
+        assert_eq!(seg.as_deref(), Some("bobmatnyc/trusty-tools"));
+        // No branch marker and no UUID leaked in.
+        let s = seg.unwrap();
+        assert!(!s.contains('\u{2387}'), "managed branch must be omitted");
+        assert!(!s.contains("2dfb23d1"), "session UUID must not appear");
+    }
+
+    /// Why: a normal checkout on a meaningful branch must keep `⎇ <branch>`.
+    /// Test: itself.
+    #[test]
+    fn render_project_segment_keeps_real_branch() {
+        let seg = render_project_segment("bobmatnyc/trusty-tools".to_string(), Some("main"));
+        assert_eq!(
+            seg.as_deref(),
+            Some("bobmatnyc/trusty-tools  \u{2387} main")
+        );
+
+        // Detached HEAD and empty branch collapse to just the label.
+        assert_eq!(
+            render_project_segment("owner/repo".to_string(), Some("HEAD")).as_deref(),
+            Some("owner/repo")
+        );
+        assert_eq!(
+            render_project_segment("owner/repo".to_string(), None).as_deref(),
+            Some("owner/repo")
+        );
+    }
+
+    /// Why: an empty label (basename resolution failed) must omit the segment
+    /// entirely rather than emit a stray `⎇`.
+    /// Test: itself.
+    #[test]
+    fn render_project_segment_empty_label() {
+        assert_eq!(render_project_segment(String::new(), Some("main")), None);
+    }
+
+    /// Why: a bare directory with no git repo must fall back to the cwd basename
+    /// and never panic.
+    /// Test: itself.
+    #[test]
+    fn project_segment_basename_fallback_non_git() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cwd = tmp.path().to_string_lossy().to_string();
+        let seg = project_segment(&cwd).expect("basename segment");
+        let basename = tmp
+            .path()
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        assert_eq!(seg, basename, "non-git cwd → basename, no branch");
+        assert!(!seg.contains('\u{2387}'), "no branch marker for a bare dir");
+    }
+
+    /// Why: the leading field must resolve to the GitHub `owner/repo` slug parsed
+    /// from the git remote (both scp-style and https), matching `source_id`.
+    /// Test: itself (temp git repo; skipped when git is unavailable on the runner).
+    #[test]
+    fn git_owner_repo_reads_remote() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let dir = tmp.path();
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        };
+        if !git(&["init"]) {
+            return; // no git on runner
+        }
+        assert!(git(&[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:bobmatnyc/trusty-tools.git",
+        ]));
+        let cwd = dir.to_string_lossy().to_string();
+        assert_eq!(
+            git_owner_repo(&cwd).as_deref(),
+            Some("bobmatnyc/trusty-tools"),
+            "scp-style remote → owner/repo slug"
+        );
+    }
+
+    /// Why: outside any git repo `git_owner_repo` must yield `None` so callers
+    /// fall back to the basename.
+    /// Test: itself.
+    #[test]
+    fn git_owner_repo_none_outside_repo() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cwd = tmp.path().to_string_lossy().to_string();
+        assert_eq!(git_owner_repo(&cwd), None);
     }
 
     #[test]


### PR DESCRIPTION
The tm statusline used the cwd **basename** as the project label. In a managed session the cwd is `.worktrees/<uuid>/`, so it rendered the session UUID as the leading field **and** again in the `session/<uuid>` branch — duplicated, with no way to tell the project.

**Fix** (`project_segment`, single file):
- First field is now `owner/repo`, derived from the git remote via `trusty_common::github_path::derive_github_path` (the canonical `source_id` parser — handles `https://` and scp-style `git@`), falling back to the cwd basename only when there's no parseable remote.
- Omits the `⎇ <branch>` segment when the branch is a managed-session branch (`session/<…>`) — it was just the session id again. Real branches (`main`, `fix/…`) still show.

Before: `2dfb23d1-…  ⎇ session/2dfb23d1-… │ Opus 4.8 │ …`
After: `bobmatnyc/trusty-tools │ Opus 4.8 │ tm ●:7880 │ ctx 8% │ $1.53`

6 new statusline unit tests; git subprocess uses the existing 100ms bounded-thread fail-soft pattern. `cargo test -p trusty-mpm` green (697 passed); clippy/fmt/line-cap clean. Single file, under the SLOC cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)