### PR TITLE
feat(trusty-mpm): native gh-account awareness (statusline @login + doctor check)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/mod.rs
@@ -81,14 +81,18 @@ pub(crate) fn run_statusline() -> anyhow::Result<()> {
 ///
 /// Why: keeping rendering pure (no mandatory I/O) makes it unit-testable
 /// independently of the stdin protocol.
-/// What: builds up to seven segments — project+branch, model, daemon, session
-/// count, context%, compaction efficiency, cost — joined with ` │ `, emitting
-/// only non-empty segments.
+/// What: builds up to eight segments — project+branch, active gh account
+/// (`@<login>`, marked `⚠` when multiple accounts are logged in), model, daemon,
+/// session count, context%, compaction efficiency, cost — joined with ` │ `,
+/// emitting only non-empty segments.
 /// Test: `render_statusline_minimal_input`, `render_statusline_full_payload`.
 pub(crate) fn render_statusline(input: &StatusInput) -> String {
     let mut parts: Vec<String> = Vec::new();
 
     if let Some(seg) = project_segment(&input.cwd) {
+        parts.push(seg);
+    }
+    if let Some(seg) = gh_account_segment_probe() {
         parts.push(seg);
     }
     if let Some(seg) = model_segment(&input.model) {
@@ -326,6 +330,58 @@ fn git_owner_repo(cwd: &str) -> Option<String> {
     rx.recv_timeout(Duration::from_millis(100)).ok().flatten()
 }
 
+/// Probe the active `gh` github.com account for the statusline, cheaply and
+/// fail-soft, with a 100 ms wall-clock bound.
+///
+/// Why (#gh-account-awareness): `tm` shells to `gh` constantly (PR merge, issue
+/// edits) but the operator had no visibility into WHICH github.com identity was
+/// active. A non-admin active account silently broke `gh pr merge --admin`.
+/// Surfacing `@<login>` in the status bar — and flagging the multi-account
+/// ambiguity that hides the bug — makes the active identity impossible to miss.
+/// The bounded-thread pattern (matching [`git_branch`]/[`git_owner_repo`]) keeps
+/// a slow config read from ever blocking Claude Code's hot render path.
+/// What: spawns a detached thread that reads `gh`'s `hosts.yml` via the cheap,
+/// subprocess-free [`trusty_mpm::core::gh_account::gh_account_status_local`],
+/// waits ≤100 ms, and renders the segment via [`render_gh_account_segment`].
+/// Returns `None` (segment omitted) when `gh` is unconfigured, the read times
+/// out, or no active account is set — never errors or blocks.
+/// Test: the render is unit-tested via [`render_gh_account_segment`]; the probe
+/// itself is thin bounded glue over the tested local reader.
+fn gh_account_segment_probe() -> Option<String> {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(trusty_mpm::core::gh_account::gh_account_status_local());
+    });
+    let status = rx.recv_timeout(Duration::from_millis(100)).ok().flatten()?;
+    render_gh_account_segment(status.active.as_deref(), status.logged_in.len())
+}
+
+/// Assemble the `@<login>` gh-account segment from a resolved active login.
+///
+/// Why: keeping the render pure (no file/subprocess I/O) makes the
+/// present/absent/multi-account cases unit-testable without touching real `gh`
+/// state, and centralises the ambiguity marker.
+/// What: returns `None` for an absent/blank active login (segment omitted);
+/// `"@<login>"` for a single logged-in account; and `"@<login>⚠"` when more than
+/// one account is logged in (`logged_in_count > 1`) so the operator notices they
+/// may be on the wrong identity.
+/// Test: `render_gh_account_segment_single`, `render_gh_account_segment_multi`,
+/// `render_gh_account_segment_absent`.
+fn render_gh_account_segment(active: Option<&str>, logged_in_count: usize) -> Option<String> {
+    let active = active?.trim();
+    if active.is_empty() {
+        return None;
+    }
+    Some(if logged_in_count > 1 {
+        format!("@{active}\u{26a0}")
+    } else {
+        format!("@{active}")
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -489,6 +545,41 @@ mod tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let cwd = tmp.path().to_string_lossy().to_string();
         assert_eq!(git_owner_repo(&cwd), None);
+    }
+
+    /// Why: a single logged-in account renders `@<login>` with no warning mark.
+    /// Test: itself.
+    #[test]
+    fn render_gh_account_segment_single() {
+        assert_eq!(
+            render_gh_account_segment(Some("bobmatnyc"), 1).as_deref(),
+            Some("@bobmatnyc")
+        );
+        // Zero count is treated the same as one (unambiguous single identity).
+        assert_eq!(
+            render_gh_account_segment(Some("bobmatnyc"), 0).as_deref(),
+            Some("@bobmatnyc")
+        );
+    }
+
+    /// Why: multiple logged-in accounts must append the `⚠` ambiguity marker so
+    /// the operator notices they may be merging as the wrong identity (the bug).
+    /// Test: itself.
+    #[test]
+    fn render_gh_account_segment_multi() {
+        let seg = render_gh_account_segment(Some("bob-duetto"), 2).expect("segment");
+        assert_eq!(seg, "@bob-duetto\u{26a0}");
+        assert!(seg.contains('\u{26a0}'), "multi-account marker must appear");
+    }
+
+    /// Why: an absent/blank active login must omit the segment entirely rather
+    /// than emit a stray `@`.
+    /// Test: itself.
+    #[test]
+    fn render_gh_account_segment_absent() {
+        assert_eq!(render_gh_account_segment(None, 0), None);
+        assert_eq!(render_gh_account_segment(Some("   "), 3), None);
+        assert_eq!(render_gh_account_segment(Some(""), 1), None);
     }
 
     #[test]

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -190,16 +190,17 @@ async fn register_project_succeeds() {
 
 #[tokio::test]
 async fn execute_doctor_against_test_daemon() {
-    // `/doctor` returns an eight-check report against a live daemon.
+    // `/doctor` returns a nine-check report against a live daemon.
     let (_state, url) = spawn_test_daemon().await;
     let executor = CommandExecutor::new(url);
     match executor.execute(TrustyCommand::Doctor).await {
         CommandResult::Doctor(report) => {
             // #1840 added the worktrees check (6); DOC-28 R4(a) added the
             // output_style check (7); A2 (tm-skills-portfolio epic) added the
-            // skill_source check, bringing the total to 8. #1905's
-            // stale-skill cleanup is a one-time migration, not a probe here.
-            assert_eq!(report.checks.len(), 8);
+            // skill_source check (8); #gh-account-awareness added the gh_account
+            // check, bringing the total to 9. #1905's stale-skill cleanup is a
+            // one-time migration, not a probe here.
+            assert_eq!(report.checks.len(), 9);
         }
         other => panic!("expected Doctor, got {other:?}"),
     }

--- a/crates/trusty-mpm/src/core/gh_account.rs
+++ b/crates/trusty-mpm/src/core/gh_account.rs
@@ -1,0 +1,481 @@
+//! Active-`gh`-account awareness for every `tm` surface that shells to GitHub.
+//!
+//! Why: `tm` makes many `gh` calls (PR list/view/merge, issue edits, managed
+//! spawn), but historically had NO awareness of WHICH github.com identity was
+//! active. When a host has several accounts logged in (the common
+//! personal + work + bot setup), `gh` uses whichever one is marked active in its
+//! `hosts.yml` — and that is easy to get wrong. This directly caused a silent
+//! failure: the active account was a non-admin identity (`bob-duetto`) instead
+//! of the repo owner (`bobmatnyc`), so `gh pr merge --admin` kept failing with
+//! "1 approving review required" until the account was switched. This module
+//! makes the active account (and the multi-account ambiguity that hides the bug)
+//! a first-class, always-inspectable fact for the statusline and `tm doctor`.
+//!
+//! What: the CHEAP, subprocess-free path reads `gh`'s own `hosts.yml`
+//! (honouring `GH_CONFIG_DIR` / `XDG_CONFIG_HOME`, else `~/.config/gh/`) and
+//! parses `github.com.user` (the active login) plus the `github.com.users` map
+//! (every logged-in login). [`gh_account_status_local`] returns both from one
+//! file read with no subprocess — safe for the statusline's hot render path.
+//! [`active_gh_account`] falls back to a bounded `gh auth status --active`
+//! subprocess when the local file is absent, and [`logged_in_gh_accounts`]
+//! parses `gh auth status` for the full multi-account list. Every entry point is
+//! fail-soft: a missing `gh`, absent config, or parse error yields `None` /
+//! an empty vec, never an error or panic.
+//!
+//! Test: the pure parsers (`parse_active_account_from_hosts_yml`,
+//! `parse_logged_in_accounts`, `parse_gh_account_status_from_hosts_yml`) are
+//! unit-tested against sample `hosts.yml` and `gh auth status` strings in the
+//! inline `tests` module; the subprocess wrappers are thin bounded glue.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Bounded wall-clock timeout for any `gh` subprocess this module spawns.
+///
+/// Why: both the statusline (hot render path) and `tm doctor` must never block
+/// on a wedged `gh` (stuck credential helper, slow keyring, network). A short
+/// bound turns "hung" into a clean "omit the segment / warn".
+/// What: 250 ms — generous enough for a local `gh auth status` yet short enough
+/// to never stall a render cycle.
+/// Test: covered indirectly (the parsers are the tested surface).
+pub const GH_PROBE_TIMEOUT: Duration = Duration::from_millis(250);
+
+/// A snapshot of the local `gh` github.com account state.
+///
+/// Why: callers (statusline, doctor) need BOTH the active login and the count of
+/// logged-in accounts in one value, so a single cheap `hosts.yml` read answers
+/// "who is active?" and "is there dangerous ambiguity?" together.
+/// What: `active` is `github.com.user` (the login `gh` will actually use);
+/// `logged_in` is every login under `github.com.users` (or just `active` when no
+/// `users` map is present). `logged_in.len() > 1` flags the multi-account
+/// ambiguity that hid the #admin-merge bug.
+/// Test: `parse_gh_account_status_*` construct and assert this.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GhAccountStatus {
+    /// The active github.com login (`hosts.yml` → `github.com.user`), if any.
+    pub active: Option<String>,
+    /// Every github.com login logged in on this host.
+    pub logged_in: Vec<String>,
+}
+
+impl GhAccountStatus {
+    /// Whether more than one github.com account is logged in (the ambiguity).
+    ///
+    /// Why: a single logged-in account is unambiguous; two or more means `gh`
+    /// silently picks the active one and the operator can easily be on the wrong
+    /// identity — the exact condition worth flagging everywhere.
+    /// What: true when `logged_in` holds more than one login.
+    /// Test: `parse_gh_account_status_multi_from_users_map`.
+    pub fn is_ambiguous(&self) -> bool {
+        self.logged_in.len() > 1
+    }
+}
+
+/// Resolve `gh`'s config directory, honouring the same env vars `gh` itself does.
+///
+/// Why: `tm` (and its managed sessions) may set `GH_CONFIG_DIR` to isolate a
+/// per-project identity; reading the DEFAULT path in that case would report the
+/// wrong account. Mirroring `gh`'s own precedence keeps our view identical to
+/// what `gh` will actually use.
+/// What: returns `GH_CONFIG_DIR` when set and non-empty, else
+/// `XDG_CONFIG_HOME/gh`, else `~/.config/gh`.
+/// Test: exercised via `gh_hosts_yml_path` behaviour; env-dependent so not
+/// asserted directly.
+fn gh_config_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("GH_CONFIG_DIR") {
+        let dir = dir.trim();
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        let xdg = xdg.trim();
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg).join("gh"));
+        }
+    }
+    dirs::home_dir().map(|h| h.join(".config").join("gh"))
+}
+
+/// Path to `gh`'s `hosts.yml`, honouring the resolved config dir.
+///
+/// Why: the cheap, subprocess-free account read needs the exact file `gh` writes
+/// its host/auth state to.
+/// What: `<gh-config-dir>/hosts.yml`.
+/// Test: env-dependent; covered indirectly by `gh_account_status_local`.
+fn gh_hosts_yml_path() -> Option<PathBuf> {
+    Some(gh_config_dir()?.join("hosts.yml"))
+}
+
+/// Parse the active github.com login from a `gh` `hosts.yml` document.
+///
+/// Why: the single-value hot-path answer ("who will `gh` act as?") without
+/// spawning a subprocess.
+/// What: reads `github.com.user`, trimmed; returns `None` for a missing key,
+/// empty value, or unparseable YAML.
+/// Test: `parse_active_account_present`, `parse_active_account_absent`.
+pub fn parse_active_account_from_hosts_yml(yaml: &str) -> Option<String> {
+    let doc: serde_yaml::Value = serde_yaml::from_str(yaml).ok()?;
+    let user = doc.get("github.com")?.get("user")?.as_str()?.trim();
+    if user.is_empty() {
+        None
+    } else {
+        Some(user.to_string())
+    }
+}
+
+/// Parse the full account status (active + all logged-in) from a `hosts.yml`.
+///
+/// Why: the statusline and doctor both need to know not just who is active but
+/// whether MULTIPLE accounts are logged in (the ambiguity that hid the bug), and
+/// `hosts.yml` carries both — so one cheap read answers everything.
+/// What: reads `github.com.user` as `active` and every key under
+/// `github.com.users` as `logged_in`; when no `users` map exists it falls back
+/// to `[active]`. Returns `None` only when neither an active user nor any
+/// logged-in account can be found (or the YAML is unparseable).
+/// Test: `parse_gh_account_status_single`,
+/// `parse_gh_account_status_multi_from_users_map`, `parse_gh_account_status_empty`.
+pub fn parse_gh_account_status_from_hosts_yml(yaml: &str) -> Option<GhAccountStatus> {
+    let doc: serde_yaml::Value = serde_yaml::from_str(yaml).ok()?;
+    let host = doc.get("github.com")?;
+
+    let active = host
+        .get("user")
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let mut logged_in: Vec<String> = Vec::new();
+    if let Some(users) = host.get("users").and_then(|v| v.as_mapping()) {
+        for key in users.keys() {
+            if let Some(name) = key.as_str() {
+                let name = name.trim();
+                if !name.is_empty() && !logged_in.iter().any(|e| e == name) {
+                    logged_in.push(name.to_string());
+                }
+            }
+        }
+    }
+    // No `users:` map (older/single-account layout) — the active user is the
+    // only known account.
+    if logged_in.is_empty()
+        && let Some(a) = &active
+    {
+        logged_in.push(a.clone());
+    }
+
+    if active.is_none() && logged_in.is_empty() {
+        return None;
+    }
+    Some(GhAccountStatus { active, logged_in })
+}
+
+/// Parse every logged-in github.com login from `gh auth status` output.
+///
+/// Why: the subprocess path (used when `hosts.yml` is absent, or by the doctor
+/// for a definitive list) needs to enumerate accounts from `gh`'s human-readable
+/// status text, which is the authoritative multi-account source.
+/// What: scans each line for `gh`'s "Logged in to github.com account <login>"
+/// (and the older "as <login>") phrasing and collects the `<login>` tokens,
+/// de-duplicated and order-preserving. Tolerant of leading check-marks and
+/// trailing `(keyring)` / `(...)` annotations.
+/// Test: `parse_logged_in_single`, `parse_logged_in_multiple`,
+/// `parse_logged_in_older_as_phrasing`, `parse_logged_in_empty`.
+pub fn parse_logged_in_accounts(auth_status: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for line in auth_status.lines() {
+        let Some((_, rest)) = line.split_once("Logged in to") else {
+            continue;
+        };
+        if let Some(login) = extract_login_token(rest)
+            && !out.iter().any(|e| e == &login)
+        {
+            out.push(login);
+        }
+    }
+    out
+}
+
+/// Extract the `<login>` following the `account`/`as` keyword in a status line.
+///
+/// Why: isolates the token-scan so [`parse_logged_in_accounts`] stays readable
+/// and the trimming rules are tested in one place.
+/// What: given the remainder after "Logged in to" (e.g.
+/// `" github.com account bobmatnyc (keyring)"`), returns the token after the
+/// `account` (preferred) or `as` keyword, stripped of surrounding punctuation.
+/// Test: covered via `parse_logged_in_*`.
+fn extract_login_token(rest: &str) -> Option<String> {
+    let tokens: Vec<&str> = rest.split_whitespace().collect();
+    for keyword in ["account", "as"] {
+        if let Some(pos) = tokens.iter().position(|t| *t == keyword)
+            && let Some(raw) = tokens.get(pos + 1)
+        {
+            let login = raw.trim_matches(|c: char| !c.is_alphanumeric() && c != '-' && c != '_');
+            if !login.is_empty() {
+                return Some(login.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Cheap, subprocess-free local account status from `gh`'s `hosts.yml`.
+///
+/// Why: the statusline renders on Claude Code's hot path; a subprocess per
+/// render is unacceptable. A single small-file read answers both "who is active"
+/// and "are multiple accounts logged in" for the common case where `gh` has ever
+/// been configured on this host.
+/// What: reads the resolved `hosts.yml` and parses it via
+/// [`parse_gh_account_status_from_hosts_yml`]; returns `None` when the file is
+/// absent/unreadable or carries no github.com account.
+/// Test: env/filesystem-dependent; the parse is covered by
+/// `parse_gh_account_status_*`.
+pub fn gh_account_status_local() -> Option<GhAccountStatus> {
+    let path = gh_hosts_yml_path()?;
+    let contents = std::fs::read_to_string(&path).ok()?;
+    parse_gh_account_status_from_hosts_yml(&contents)
+}
+
+/// Run `f` on a detached thread and return its result within `timeout`.
+///
+/// Why: `gh` subprocesses (or even a slow network-filesystem read) must never
+/// block the statusline or doctor; a bounded thread turns "hung" into "omitted".
+/// The pattern mirrors the statusline's `git_branch` bounded-thread probe.
+/// What: spawns `f` on a new thread, waits up to `timeout` on an mpsc channel,
+/// and returns `None` on timeout (the thread is abandoned, not joined).
+/// Test: side-effect timing; covered by the callers' fail-soft behaviour.
+fn run_bounded<T, F>(timeout: Duration, f: F) -> Option<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Option<T> + Send + 'static,
+{
+    use std::sync::mpsc;
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(f());
+    });
+    rx.recv_timeout(timeout).ok().flatten()
+}
+
+/// Resolve the active github.com login, preferring the cheap local path.
+///
+/// Why: the one call every surface uses to answer "which account is active?".
+/// Reads `hosts.yml` first (no subprocess) and only falls back to a bounded
+/// `gh auth status --active` when the local file cannot answer, so it is fast in
+/// the common case yet still correct when config lives only in the keyring.
+/// What: returns the active login from `hosts.yml`, else the first account
+/// parsed from a bounded `gh auth status --active`; `None` when `gh` is
+/// unconfigured/unauthenticated/absent.
+/// Test: the local parse is covered by `parse_active_account_*`; the subprocess
+/// fallback is thin bounded glue.
+pub fn active_gh_account() -> Option<String> {
+    if let Some(status) = gh_account_status_local()
+        && let Some(active) = status.active
+    {
+        return Some(active);
+    }
+    run_bounded(GH_PROBE_TIMEOUT, || {
+        let out = std::process::Command::new("gh")
+            .args(["auth", "status", "--active"])
+            .output()
+            .ok()?;
+        let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+        text.push('\n');
+        text.push_str(&String::from_utf8_lossy(&out.stderr));
+        parse_logged_in_accounts(&text).into_iter().next()
+    })
+}
+
+/// List every logged-in github.com account via a bounded `gh auth status`.
+///
+/// Why: detecting the MULTIPLE-accounts ambiguity (the condition that caused the
+/// admin-merge bug) is the authoritative signal `tm doctor` warns on. `gh auth
+/// status` is the definitive source across all storage backends (keyring or
+/// file), so the doctor uses it rather than trusting only `hosts.yml`.
+/// What: runs `gh auth status` (bounded by [`GH_PROBE_TIMEOUT`]) and parses its
+/// stdout+stderr via [`parse_logged_in_accounts`]; returns an empty vec on
+/// timeout, a missing `gh`, or when not authenticated.
+/// Test: the parse is covered by `parse_logged_in_*`; this is thin bounded glue.
+pub fn logged_in_gh_accounts() -> Vec<String> {
+    run_bounded(GH_PROBE_TIMEOUT, || {
+        let out = std::process::Command::new("gh")
+            .args(["auth", "status"])
+            .output()
+            .ok()?;
+        let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+        text.push('\n');
+        text.push_str(&String::from_utf8_lossy(&out.stderr));
+        Some(parse_logged_in_accounts(&text))
+    })
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `hosts.yml` with two accounts logged in and `bob-duetto` active — the
+    /// exact shape that produced the admin-merge bug on the dev host.
+    const MULTI_HOSTS_YML: &str = "\
+github.com:
+    git_protocol: https
+    users:
+        bobmatnyc:
+        bob-duetto:
+    user: bob-duetto
+";
+
+    /// A single-account `hosts.yml` (only the active user, no `users` map).
+    const SINGLE_HOSTS_YML: &str = "\
+github.com:
+    git_protocol: https
+    user: bobmatnyc
+";
+
+    /// Real `gh auth status` output with two github.com accounts logged in.
+    const MULTI_AUTH_STATUS: &str = "\
+github.com
+  ✓ Logged in to github.com account bob-duetto (keyring)
+  - Active account: true
+  - Git operations protocol: https
+  - Token: gho_************************************
+  - Token scopes: 'admin:org', 'gist', 'project', 'repo', 'workflow'
+
+  ✓ Logged in to github.com account bobmatnyc (keyring)
+  - Active account: false
+  - Git operations protocol: https
+  - Token: gho_************************************
+  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
+";
+
+    /// Single-account `gh auth status` output.
+    const SINGLE_AUTH_STATUS: &str = "\
+github.com
+  ✓ Logged in to github.com account bobmatnyc (keyring)
+  - Active account: true
+  - Git operations protocol: https
+  - Token: gho_************************************
+";
+
+    /// Why: the active login must be read from `github.com.user`.
+    /// Test: itself.
+    #[test]
+    fn parse_active_account_present() {
+        assert_eq!(
+            parse_active_account_from_hosts_yml(MULTI_HOSTS_YML).as_deref(),
+            Some("bob-duetto")
+        );
+        assert_eq!(
+            parse_active_account_from_hosts_yml(SINGLE_HOSTS_YML).as_deref(),
+            Some("bobmatnyc")
+        );
+    }
+
+    /// Why: absent/blank config must yield `None`, never panic.
+    /// Test: itself.
+    #[test]
+    fn parse_active_account_absent() {
+        assert_eq!(parse_active_account_from_hosts_yml(""), None);
+        assert_eq!(
+            parse_active_account_from_hosts_yml("other.host:\n  user: x"),
+            None
+        );
+        assert_eq!(
+            parse_active_account_from_hosts_yml("github.com:\n  git_protocol: https"),
+            None
+        );
+        // Not YAML at all → None, not a panic.
+        assert_eq!(parse_active_account_from_hosts_yml(": : ["), None);
+    }
+
+    /// Why: a single-account host is unambiguous — active set, one logged-in
+    /// account, `is_ambiguous()` false.
+    /// Test: itself.
+    #[test]
+    fn parse_gh_account_status_single() {
+        let status = parse_gh_account_status_from_hosts_yml(SINGLE_HOSTS_YML).expect("some");
+        assert_eq!(status.active.as_deref(), Some("bobmatnyc"));
+        assert_eq!(status.logged_in, vec!["bobmatnyc".to_string()]);
+        assert!(!status.is_ambiguous());
+    }
+
+    /// Why: multiple accounts under `users:` must populate `logged_in` and flag
+    /// `is_ambiguous()` — the signal that hid the admin-merge bug.
+    /// Test: itself.
+    #[test]
+    fn parse_gh_account_status_multi_from_users_map() {
+        let status = parse_gh_account_status_from_hosts_yml(MULTI_HOSTS_YML).expect("some");
+        assert_eq!(status.active.as_deref(), Some("bob-duetto"));
+        assert!(status.logged_in.contains(&"bobmatnyc".to_string()));
+        assert!(status.logged_in.contains(&"bob-duetto".to_string()));
+        assert_eq!(status.logged_in.len(), 2);
+        assert!(status.is_ambiguous());
+    }
+
+    /// Why: a doc with no github.com host must yield `None`.
+    /// Test: itself.
+    #[test]
+    fn parse_gh_account_status_empty() {
+        assert_eq!(parse_gh_account_status_from_hosts_yml(""), None);
+        assert_eq!(
+            parse_gh_account_status_from_hosts_yml("enterprise.example.com:\n  user: x"),
+            None
+        );
+    }
+
+    /// Why: a single logged-in account parses to exactly one login.
+    /// Test: itself.
+    #[test]
+    fn parse_logged_in_single() {
+        assert_eq!(
+            parse_logged_in_accounts(SINGLE_AUTH_STATUS),
+            vec!["bobmatnyc".to_string()]
+        );
+    }
+
+    /// Why: multiple logged-in accounts must all be parsed, in first-seen order.
+    /// Test: itself.
+    #[test]
+    fn parse_logged_in_multiple() {
+        assert_eq!(
+            parse_logged_in_accounts(MULTI_AUTH_STATUS),
+            vec!["bob-duetto".to_string(), "bobmatnyc".to_string()]
+        );
+    }
+
+    /// Why: older `gh` phrased it "Logged in to github.com as <login>"; the
+    /// parser must still find the login.
+    /// Test: itself.
+    #[test]
+    fn parse_logged_in_older_as_phrasing() {
+        let text = "✓ Logged in to github.com as octocat (oauth_token)";
+        assert_eq!(parse_logged_in_accounts(text), vec!["octocat".to_string()]);
+    }
+
+    /// Why: "not authenticated" output must yield an empty list, never panic.
+    /// Test: itself.
+    #[test]
+    fn parse_logged_in_empty() {
+        assert!(parse_logged_in_accounts("").is_empty());
+        assert!(parse_logged_in_accounts("You are not logged into any GitHub hosts.").is_empty());
+    }
+
+    /// Why: `is_ambiguous` is the load-bearing predicate for the warnings; assert
+    /// its boundary directly.
+    /// Test: itself.
+    #[test]
+    fn is_ambiguous_boundary() {
+        let none = GhAccountStatus::default();
+        assert!(!none.is_ambiguous());
+        let one = GhAccountStatus {
+            active: Some("a".into()),
+            logged_in: vec!["a".into()],
+        };
+        assert!(!one.is_ambiguous());
+        let two = GhAccountStatus {
+            active: Some("a".into()),
+            logged_in: vec!["a".into(), "b".into()],
+        };
+        assert!(two.is_ambiguous());
+    }
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -35,6 +35,7 @@ pub mod doctor;
 pub mod error;
 pub mod external_session;
 pub mod frontmatter;
+pub mod gh_account;
 pub mod home_trust_seed;
 pub mod hook;
 pub mod instruction_overrides;

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1059,15 +1059,15 @@ async fn pair_reset_clears_pairing() {
 
 #[tokio::test]
 async fn doctor_endpoint_returns_report() {
-    // `GET /api/v1/doctor` returns an eight-check report (#1840 added the
+    // `GET /api/v1/doctor` returns a nine-check report (#1840 added the
     // worktrees check; DOC-28 R4(a) added the output_style check; A2
-    // (tm-skills-portfolio epic) added the skill_source check). #1905's
-    // stale-skill cleanup is a one-time migration, not a `run_doctor` probe,
-    // so it does not appear here; the per-check statuses carry the
-    // diagnosis, not the HTTP status.
+    // (tm-skills-portfolio epic) added the skill_source check;
+    // #gh-account-awareness added the gh_account check). #1905's stale-skill
+    // cleanup is a one-time migration, not a `run_doctor` probe, so it does not
+    // appear here; the per-check statuses carry the diagnosis, not the HTTP status.
     let state = DaemonState::shared();
     let Json(report) = doctor(State(state), Query(DoctorQuery::default())).await;
-    assert_eq!(report.checks.len(), 8);
+    assert_eq!(report.checks.len(), 9);
     let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
     assert_eq!(
         names,
@@ -1079,7 +1079,8 @@ async fn doctor_endpoint_returns_report() {
             "output_style",
             "memory",
             "search",
-            "worktrees"
+            "worktrees",
+            "gh_account"
         ]
     );
 }

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -50,9 +50,11 @@ const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
 /// probes (the output-style probe closes DOC-28 F4 — the "did the
 /// trusty-mpm instructions actually load" gap), then the memory and search
 /// HTTP probes (each bounded by [`PROBE_TIMEOUT`]), a worktree-orphan scan
-/// (Fix 1b, #1840), and the `skill_source` probe (A2, tm-skills-portfolio
-/// epic) — folding the resulting eight [`DoctorCheck`]s into a
-/// [`DoctorReport`] whose `overall` status is the worst of them.
+/// (Fix 1b, #1840), the `skill_source` probe (A2, tm-skills-portfolio epic), and
+/// the `gh_account` probe (#gh-account-awareness — surfaces the active
+/// github.com identity and warns on the multi-account ambiguity) — folding the
+/// resulting nine [`DoctorCheck`]s into a [`DoctorReport`] whose `overall` status
+/// is the worst of them.
 ///
 /// Note (#1905): the mpm-*→tm-* stale-skill cleanup is intentionally NOT a
 /// permanent probe here — it is a one-time migration
@@ -64,7 +66,7 @@ const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
 /// (when `Some`) gives the managed workspace root for the worktree scan;
 /// `active_workspace_paths` is the full set of workspace paths currently
 /// registered to live sessions.
-/// Test: `run_doctor_produces_eight_checks`.
+/// Test: `run_doctor_produces_nine_checks`.
 pub async fn run_doctor(
     project_dir: Option<&Path>,
     repos_root: Option<&Path>,
@@ -83,8 +85,86 @@ pub async fn run_doctor(
     checks.push(check_memory(&home).await);
     checks.push(check_search(&home).await);
     checks.push(check_worktrees(repos_root, active_workspace_paths).await);
+    checks.push(check_gh_account().await);
 
     DoctorReport::from_checks(checks)
+}
+
+/// Probe the active `gh` github.com account and warn on ambiguity.
+///
+/// Why (#gh-account-awareness): `tm` shells to `gh` for PR merges, issue edits,
+/// and managed spawn, but had no awareness of WHICH github.com identity was
+/// active. When several accounts are logged in, `gh` uses whichever is active —
+/// and a non-admin active account silently broke `gh pr merge --admin` with
+/// "1 approving review required". This probe makes the active account visible in
+/// `tm doctor` and warns when the dangerous multi-account ambiguity exists.
+/// What: off-loads the two bounded `gh`/`hosts.yml` reads to `spawn_blocking`
+/// (so the async executor is not stalled), then folds the result via
+/// [`build_gh_account_check`]. Advisory only: `Warn` when multiple accounts are
+/// logged in or `gh` is unauthenticated, `Ok` for a single clear account — never
+/// a hard `Fail`, since a missing/other `gh` identity is not a broken stack.
+/// Test: `build_gh_account_check` covers every branch;
+/// `gh_account_check_is_advisory_only` asserts it never returns `Fail`.
+async fn check_gh_account() -> DoctorCheck {
+    let (active, accounts) = tokio::task::spawn_blocking(|| {
+        let active = crate::core::gh_account::active_gh_account();
+        let accounts = crate::core::gh_account::logged_in_gh_accounts();
+        (active, accounts)
+    })
+    .await
+    .unwrap_or((None, Vec::new()));
+    build_gh_account_check(active, accounts)
+}
+
+/// Fold the resolved gh-account state into a [`DoctorCheck`] (pure).
+///
+/// Why: keeping the verdict logic pure makes every branch — single account,
+/// multi-account ambiguity, active-unknown, and unauthenticated — unit-testable
+/// without a live `gh`.
+/// What: returns `Warn` when `accounts` holds more than one login (naming them
+/// and pointing at `gh auth switch`), `Warn` when no account is detected, `Warn`
+/// when accounts exist but none is marked active, and `Ok` for a single clear
+/// active account. Never `Fail` — this is advisory.
+/// Test: `build_gh_account_check_single_ok`, `build_gh_account_check_multi_warn`,
+/// `build_gh_account_check_unauthenticated_warn`,
+/// `gh_account_check_is_advisory_only`.
+fn build_gh_account_check(active: Option<String>, accounts: Vec<String>) -> DoctorCheck {
+    if accounts.len() > 1 {
+        let list = accounts.join(", ");
+        let active_str = active.as_deref().unwrap_or("unknown");
+        return DoctorCheck::new(
+            "gh_account",
+            CheckStatus::Warn,
+            format!(
+                "{} github.com accounts logged in ({list}); active is `{active_str}`. \
+                 `gh` (and `gh pr merge --admin`) uses the ACTIVE account — if merges \
+                 fail on permissions, run `gh auth switch` to the repo owner.",
+                accounts.len()
+            ),
+        );
+    }
+    match active {
+        Some(login) => DoctorCheck::new(
+            "gh_account",
+            CheckStatus::Ok,
+            format!("active gh account: `{login}`"),
+        ),
+        None if accounts.is_empty() => DoctorCheck::new(
+            "gh_account",
+            CheckStatus::Warn,
+            "gh is not authenticated (no github.com account) — `gh` calls will fail; \
+             run `gh auth login`"
+                .to_string(),
+        ),
+        None => DoctorCheck::new(
+            "gh_account",
+            CheckStatus::Warn,
+            format!(
+                "gh authenticated ({}) but no active account is set — run `gh auth switch`",
+                accounts.join(", ")
+            ),
+        ),
+    }
 }
 
 /// Probe for orphaned per-session git worktrees under the managed workspace root.
@@ -351,13 +431,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_doctor_produces_eight_checks() {
-        // A2 (tm-skills-portfolio epic): adds the `skill_source` probe,
-        // bringing the total from seven to eight checks. #1905's stale-skill
-        // cleanup is deliberately NOT a `run_doctor` probe — see the
-        // `run_doctor` doc comment — so this count stays at eight.
+    async fn run_doctor_produces_nine_checks() {
+        // #gh-account-awareness: adds the `gh_account` probe, bringing the total
+        // from eight to nine checks. #1905's stale-skill cleanup is deliberately
+        // NOT a `run_doctor` probe — see the `run_doctor` doc comment.
         let report = run_doctor(None, None, &[]).await;
-        assert_eq!(report.checks.len(), 8);
+        assert_eq!(report.checks.len(), 9);
         let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(
             names,
@@ -369,9 +448,63 @@ mod tests {
                 "output_style",
                 "memory",
                 "search",
-                "worktrees"
+                "worktrees",
+                "gh_account"
             ]
         );
+    }
+
+    #[test]
+    fn build_gh_account_check_single_ok() {
+        // A single clear active account is healthy (Ok), naming the login.
+        let check =
+            build_gh_account_check(Some("bobmatnyc".to_string()), vec!["bobmatnyc".to_string()]);
+        assert_eq!(check.status, CheckStatus::Ok);
+        assert_eq!(check.name, "gh_account");
+        assert!(check.message.contains("bobmatnyc"));
+    }
+
+    #[test]
+    fn build_gh_account_check_multi_warn() {
+        // Multiple logged-in accounts is the ambiguity that hid the admin-merge
+        // bug: Warn, name both accounts, and point at `gh auth switch`.
+        let check = build_gh_account_check(
+            Some("bob-duetto".to_string()),
+            vec!["bob-duetto".to_string(), "bobmatnyc".to_string()],
+        );
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.message.contains("bob-duetto"));
+        assert!(check.message.contains("bobmatnyc"));
+        assert!(check.message.contains("gh auth switch"));
+    }
+
+    #[test]
+    fn build_gh_account_check_unauthenticated_warn() {
+        // No account at all: Warn (advisory), not Fail, pointing at `gh auth login`.
+        let check = build_gh_account_check(None, Vec::new());
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.message.contains("not authenticated"));
+        assert!(check.message.contains("gh auth login"));
+    }
+
+    #[test]
+    fn gh_account_check_is_advisory_only() {
+        // Every branch must be advisory — never a hard Fail.
+        for check in [
+            build_gh_account_check(Some("a".to_string()), vec!["a".to_string()]),
+            build_gh_account_check(
+                Some("a".to_string()),
+                vec!["a".to_string(), "b".to_string()],
+            ),
+            build_gh_account_check(None, Vec::new()),
+            build_gh_account_check(None, vec!["a".to_string()]),
+        ] {
+            assert_ne!(
+                check.status,
+                CheckStatus::Fail,
+                "gh_account must never Fail"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Makes the active `gh` account first-class in tm so the wrong-account trap (non-admin `bob-duetto` active instead of owner `bobmatnyc` → silent merge failures) is always visible.

- `core/gh_account.rs`: subprocess-free read of gh `hosts.yml` (active login + all accounts), bounded fail-soft `gh` fallbacks.
- **Statusline**: `@<login>` segment (`⚠` when >1 account logged in), 100ms bounded local read.
- **Doctor**: advisory check — warns on multi-account (names them + active) or unauthenticated, points at `gh auth switch`.

Example: `bobmatnyc/trusty-tools │ @bobmatnyc⚠ │ Opus │ …`. Pure-function tests; `cargo test -p trusty-mpm` green (700); clippy/fmt/line-cap clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)