### PR TITLE
fix(trusty-review): MCP tools default to local gh auth (App only when creds present)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11046,7 +11046,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -9,6 +9,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- MCP review path is now local-first: `review_pr`/`review_diff` authenticate with
+  the developer's `gh`/PAT login (CLI auth) unless a GitHub App is explicitly
+  configured, instead of always requiring `GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY`
+  (closes #1993)
 - unify grade computation so outer and embedded grade never diverge (closes #1886) ([#1891](https://github.com/bobmatnyc/trusty-tools/pull/1891)) ([`8f6eab1`](https://github.com/bobmatnyc/trusty-tools/commit/8f6eab15718c9446579b87166bbfd763d72c48da))
 - aggregate token counts across map-reduce for shallow-review heuristic (closes #1885) ([#1890](https://github.com/bobmatnyc/trusty-tools/pull/1890)) ([`7b53d3f`](https://github.com/bobmatnyc/trusty-tools/commit/7b53d3fa2e4baf4578308babccdfc8caa11c86eb))
 ## [Unreleased]

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.6.4"
+version     = "0.6.5"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/src/mcp/tools.rs
+++ b/crates/trusty-review/src/mcp/tools.rs
@@ -24,6 +24,7 @@ use tracing::info;
 use trusty_common::console_metrics::CONSOLE_METRICS_METHOD;
 
 use crate::{
+    config::ReviewConfig,
     integrations::github::{AuthStrategy, GithubClient, RunMode},
     mcp::console_metrics,
     models::ReviewResult,
@@ -199,7 +200,7 @@ async fn call_review_pr(args: &Value, state: &AppState) -> Result<Value, ToolErr
     // Resolve GitHub token.
     let client = GithubClient::new()
         .map_err(|e| ToolError::InvalidParams(format!("failed to build HTTP client: {e}")))?;
-    let token = AuthStrategy::select(RunMode::Serve, None)
+    let token = AuthStrategy::select(mcp_run_mode(&state.config), None)
         .resolve_token(&client, &state.config, owner)
         .await
         .map_err(|e| ToolError::InvalidParams(format!("GitHub auth failed: {e}")))?;
@@ -218,7 +219,7 @@ async fn call_review_pr(args: &Value, state: &AppState) -> Result<Value, ToolErr
         write_log: false,
         print_result: false,
         trigger: TriggerDecision::ForceDryRun,
-        run_mode: RunMode::Serve,
+        run_mode: mcp_run_mode(&state.config),
         allow_posting: false,
         caller_context: crate::pipeline::runner::CallerContext::default(),
     };
@@ -270,7 +271,7 @@ async fn call_review_diff(args: &Value, state: &AppState) -> Result<Value, ToolE
         write_log: false,
         print_result: false,
         trigger: TriggerDecision::ForceDryRun,
-        run_mode: RunMode::Serve,
+        run_mode: mcp_run_mode(&state.config),
         allow_posting: false,
         caller_context: crate::pipeline::runner::CallerContext::default(),
     };
@@ -353,6 +354,41 @@ async fn call_review_health(state: &AppState) -> Value {
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Choose the `RunMode` the MCP review path should authenticate under.
+///
+/// Why: MCP review is typically invoked by a developer's harness (Claude Code,
+/// MPM) against *their own* PR, so it should authenticate with their local `gh`
+/// login (CLI auth) — not as a GitHub App.  Hardcoding `RunMode::Serve` here
+/// selected `AuthStrategy::App`, which demands `GITHUB_APP_ID` /
+/// `GITHUB_APP_PRIVATE_KEY`; with no App configured the review failed with
+/// "GitHub App credentials … are required in service mode" and returned no
+/// verdict (issue #1993).  Local-first: only route through the App (`Serve`)
+/// when App credentials are actually present, so hosted-bot deployments (which
+/// DO configure the App) are unaffected while local invocations use `gh` auth.
+/// What: returns `RunMode::Serve` iff BOTH `github_app_id` and
+/// `github_app_private_key` are `Some` and non-empty (after trimming); otherwise
+/// `RunMode::Cli`.  The `TRUSTY_REVIEW_AUTH_MODE` override still wins because
+/// this value is passed to `AuthStrategy::select`, which applies the override
+/// first — this only changes the *default*.
+/// Test: `mcp_run_mode_serve_with_app_creds`, `mcp_run_mode_cli_without_app_creds`,
+/// `mcp_run_mode_cli_with_empty_app_creds`, `mcp_run_mode_resolves_cli_strategy`
+/// (in `tools_tests.rs`).
+fn mcp_run_mode(config: &ReviewConfig) -> RunMode {
+    let has_app_id = config
+        .github_app_id
+        .as_deref()
+        .is_some_and(|v| !v.trim().is_empty());
+    let has_app_key = config
+        .github_app_private_key
+        .as_deref()
+        .is_some_and(|v| !v.trim().is_empty());
+    if has_app_id && has_app_key {
+        RunMode::Serve
+    } else {
+        RunMode::Cli
+    }
+}
 
 /// Build `ReviewDeps` from the shared `AppState`, honouring the provider implied
 /// by a `reviewer_model` override (closes #1233).

--- a/crates/trusty-review/src/mcp/tools_dispatch_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_dispatch_tests.rs
@@ -192,19 +192,30 @@ async fn call_tool_review_diff_returns_non_empty_verdict() {
     );
 }
 
-/// `call_tool("review_pr", ...)` with no `GITHUB_TOKEN` in the environment
-/// returns an error indicating auth / token failure.
+/// `call_tool("review_pr", ...)` with no resolvable token returns an error
+/// indicating auth / token failure.
 ///
 /// Why: exercises the token-resolution failure path in `call_review_pr` —
 /// the tool must not panic and must surface the auth failure clearly
-/// (closes #949).
-/// What: blanks out `github_token` / `github_app_id` in the config so there
+/// (closes #949).  Since #1993 the MCP default is local-first (CLI auth), so a
+/// bare "no App creds" config now falls back to the developer's `gh` login
+/// rather than failing deterministically.  To keep this test network-free and
+/// independent of the host's `gh` state, we force App auth via the
+/// `TRUSTY_REVIEW_AUTH_MODE=app` override (which the local-first default does
+/// NOT bypass) so token resolution fails fast before any HTTP call.
+/// What: sets the auth override to `app` and blanks all App/PAT creds so there
 /// is no token to resolve; calls `call_tool("review_pr", ...)`; asserts the
 /// response is `isError: true` or `ToolError::InvalidParams` mentioning auth.
+/// Serialised (`#[serial]`) because it mutates the `TRUSTY_REVIEW_AUTH_MODE`
+/// env var shared with other auth-selection tests.
 /// Test: this test itself; failure is fast (token resolution fails before
 /// any HTTP call, so no network).
 #[tokio::test]
+#[serial_test::serial]
 async fn call_tool_review_pr_no_token_returns_error() {
+    // SAFETY: test-only env mutation, serialised via #[serial].
+    unsafe { std::env::set_var("TRUSTY_REVIEW_AUTH_MODE", "app") };
+
     let mut config = ReviewConfig::load(None);
     config.github_token = String::new();
     config.github_app_id = None;
@@ -226,6 +237,9 @@ async fn call_tool_review_pr_no_token_returns_error() {
     });
 
     let result = call_tool("review_pr", &args, &state).await;
+
+    // SAFETY: restore env before any assertion can unwind the test.
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_AUTH_MODE") };
 
     match result {
         Ok(envelope) => {

--- a/crates/trusty-review/src/mcp/tools_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_tests.rs
@@ -27,8 +27,10 @@ use crate::{
 };
 
 use super::{
-    ToolError, call_review_health, require_str, tool_descriptors, wrap_result, wrap_tool_error,
+    ToolError, call_review_health, mcp_run_mode, require_str, tool_descriptors, wrap_result,
+    wrap_tool_error,
 };
+use crate::integrations::github::{AuthStrategy, RunMode};
 use crate::models::ReviewResult;
 
 // ── Stub providers ────────────────────────────────────────────────────────────
@@ -351,5 +353,85 @@ fn wrap_result_no_fallback_omits_field() {
     assert!(
         payload.get("reviewer_model_fallback").is_none(),
         "no fallback → payload must NOT carry the marker"
+    );
+}
+
+// ── mcp_run_mode: local-first auth selection (#1993) ──────────────────────────
+
+/// Both App credentials present → `Serve` (hosted-bot deployment).
+///
+/// Why: deployments that actually configure a GitHub App must keep using App
+/// auth; the local-first default must not regress the hosted path.
+/// What: sets both `github_app_id` and `github_app_private_key`; asserts `Serve`.
+/// Test: this test itself.
+#[test]
+fn mcp_run_mode_serve_with_app_creds() {
+    let mut config = ReviewConfig::load(None);
+    config.github_app_id = Some("123456".to_string());
+    config.github_app_private_key = Some("-----BEGIN RSA PRIVATE KEY-----".to_string());
+    assert_eq!(mcp_run_mode(&config), RunMode::Serve);
+}
+
+/// Neither App credential present → `Cli` (local developer invocation).
+///
+/// Why: the common MCP case has no GitHub App configured; it must fall back to
+/// the developer's `gh` login instead of erroring for missing App creds (#1993).
+/// What: clears both App fields; asserts `Cli`.
+/// Test: this test itself.
+#[test]
+fn mcp_run_mode_cli_without_app_creds() {
+    let mut config = ReviewConfig::load(None);
+    config.github_app_id = None;
+    config.github_app_private_key = None;
+    assert_eq!(mcp_run_mode(&config), RunMode::Cli);
+}
+
+/// Partial or empty App credentials → `Cli`.
+///
+/// Why: an App is only usable when BOTH id and key are present and non-empty;
+/// a half-configured or blank-string App must not select the App strategy.
+/// What: exercises id-only, key-only, and both-empty cases; each yields `Cli`.
+/// Test: this test itself.
+#[test]
+fn mcp_run_mode_cli_with_empty_app_creds() {
+    // id only.
+    let mut config = ReviewConfig::load(None);
+    config.github_app_id = Some("123456".to_string());
+    config.github_app_private_key = None;
+    assert_eq!(mcp_run_mode(&config), RunMode::Cli);
+
+    // key only.
+    let mut config = ReviewConfig::load(None);
+    config.github_app_id = None;
+    config.github_app_private_key = Some("-----BEGIN RSA PRIVATE KEY-----".to_string());
+    assert_eq!(mcp_run_mode(&config), RunMode::Cli);
+
+    // both present but whitespace-only.
+    let mut config = ReviewConfig::load(None);
+    config.github_app_id = Some("   ".to_string());
+    config.github_app_private_key = Some("  ".to_string());
+    assert_eq!(mcp_run_mode(&config), RunMode::Cli);
+}
+
+/// With no App creds, MCP auth resolution selects the CLI strategy.
+///
+/// Why: this is the end-to-end contract of #1993 — the MCP path must resolve to
+/// `AuthStrategy::Cli` (developer `gh`/PAT) when no App is configured, rather
+/// than `App` (which would demand `GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY`).
+/// What: feeds `mcp_run_mode` into `AuthStrategy::select` (no override) and
+/// asserts `Cli`.  Clears `TRUSTY_REVIEW_AUTH_MODE` first so the env override
+/// cannot flip the default; serialised to avoid racing other env-reading tests.
+/// Test: this test itself.
+#[test]
+#[serial_test::serial]
+fn mcp_run_mode_resolves_cli_strategy() {
+    // SAFETY: test-only env mutation, serialised via #[serial].
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_AUTH_MODE") };
+    let mut config = ReviewConfig::load(None);
+    config.github_app_id = None;
+    config.github_app_private_key = None;
+    assert_eq!(
+        AuthStrategy::select(mcp_run_mode(&config), None),
+        AuthStrategy::Cli
     );
 }


### PR DESCRIPTION
Closes #1993. The MCP tools hardcoded `RunMode::Serve` → GitHub App auth, so local MCP review (no App configured) errored and the gate fail-opened. New `mcp_run_mode(config)` picks `Serve` only when both App creds are present, else `Cli` (`gh auth token`); `TRUSTY_REVIEW_AUTH_MODE` override still wins; hosted-bot unaffected. v0.6.4→0.6.5. 1111 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)