### PR TITLE
fix(trusty-mpm): make bundled PM skill examples stack-neutral (closes #2005)

### DIFF
--- a/crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md
@@ -111,7 +111,7 @@ or process status — never the PM's own assessment.
 ```
 PM: *delegates to the language-appropriate engineer, which runs the project's
     own test gate (`cargo test` for Cargo, `npm test`/`npm run build` for Node,
-    `pytest`/`ruff` for a pyproject, `go test ./...` for Go, ...)*
+    `pytest` for a pyproject, `go test ./...` for Go, ...)*
 <engineer>: "7 passed; 0 failed" (raw output attached)
 PM: "<engineer> verified: <project test command> → 7 passed, 0 failed"
 ```

--- a/crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md
@@ -44,15 +44,18 @@ Edit target the PM may touch directly.
 
 **Violation:**
 ```
-PM: Edit(crates/trusty-mpm/src/core/paths.rs, ...)   # implementation
+PM: Edit(src/<file>, ...)                             # implementation
 PM: Write(docs/README.md, ...)                        # writing docs directly
 ```
 
 **Correct:**
 ```
 PM: Edit(.git/COMMIT_EDITMSG, ...)                    # ALLOWED
-PM: *delegates to rust-engineer*
-rust-engineer: Edit(crates/trusty-mpm/src/core/paths.rs)
+PM: *delegates to the language-appropriate engineer*  # rust-engineer for a Cargo
+                                                       # project, nextjs-/typescript-
+                                                       # engineer for Node, python-
+                                                       # engineer for a pyproject, ...
+<engineer>: Edit(src/<file>)
 PM: runs git tracking after the agent returns
 ```
 
@@ -75,14 +78,14 @@ files, never for "understanding" the codebase.
 
 **Violation:**
 ```
-PM: Read(crates/trusty-mpm/src/core/paths.rs)
-PM: Read(crates/trusty-mpm/src/core/bundle.rs)        # 2nd Read
-PM: Grep("skill_source_dir", path="crates/")           # investigation
+PM: Read(src/<file-a>)
+PM: Read(src/<file-b>)                                 # 2nd Read
+PM: Grep("<symbol>", path="src/")                      # investigation
 ```
 
 **Correct:**
 ```
-PM: mcp__trusty-search__search(query="skill deploy", index_id="trusty-mpm")
+PM: mcp__trusty-search__search(query="<what to find>", index_id="<project>")
 PM: *delegates to Research if results are insufficient*
 Research: reads/greps as needed, returns findings
 PM: uses findings to write a grounded Engineer delegation
@@ -106,9 +109,11 @@ or process status — never the PM's own assessment.
 
 **Correct:**
 ```
-PM: *delegates to rust-engineer, which runs `cargo test -p trusty-mpm skill_deployer`*
-rust-engineer: "7 passed; 0 failed" (raw output attached)
-PM: "rust-engineer verified: cargo test -p trusty-mpm skill_deployer → 7 passed, 0 failed"
+PM: *delegates to the language-appropriate engineer, which runs the project's
+    own test gate (`cargo test` for Cargo, `npm test`/`npm run build` for Node,
+    `pytest`/`ruff` for a pyproject, `go test ./...` for Go, ...)*
+<engineer>: "7 passed; 0 failed" (raw output attached)
+PM: "<engineer> verified: <project test command> → 7 passed, 0 failed"
 ```
 
 ## CB#4: File Tracking
@@ -240,7 +245,7 @@ file target.
 **Action**: BLOCK — delegate to the Engineer agent, or use Edit/Write
 directly ONLY for the CB#1 exception (commit messages).
 
-**Violation:** `PM: Bash(sed -i 's/old/new/' Cargo.toml)`
+**Violation:** `PM: Bash(sed -i 's/old/new/' <any-file>)`
 
 **Allowed Bash uses (never blocked)**: `git status`, `git add`, `git commit`,
 `git log`, `git diff`, `ls`, `pwd`, `cd` — navigation and git tracking only.

--- a/crates/trusty-mpm/src/assets/skills/tm-git-file-tracking.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-git-file-tracking.md
@@ -79,13 +79,15 @@ the PM tracked them immediately after each agent — not batched at the end.
 ## Example Workflow
 
 ```bash
-# After rust-engineer adds a new doctor probe
+# After the language-appropriate engineer adds a new feature
+# (paths shown are placeholders — substitute the files your engineer actually
+#  touched, e.g. src/handlers/auth.ts, app/services/user.py, src/core/foo.rs)
 git status
-#   modified:   crates/trusty-mpm/src/daemon/doctor.rs
-#   modified:   crates/trusty-mpm/src/core/skill_deployer.rs
+#   modified:   src/<module>/<file-a>
+#   modified:   src/<module>/<file-b>
 
-git add crates/trusty-mpm/src/daemon/doctor.rs crates/trusty-mpm/src/core/skill_deployer.rs
-git commit -m "fix(trusty-mpm): warn instead of silent no-op on empty skill source (A2)
+git add src/<module>/<file-a> src/<module>/<file-b>
+git commit -m "fix(<scope>): warn instead of silent no-op on empty input
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 

--- a/crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md
@@ -29,9 +29,10 @@ behalf without being asked.
 ## Worktree Discipline (Mandatory Before Any Edit)
 
 Per root `CLAUDE.md`: the main checkout is **inspection-only** (read-only
-`git status`/`log`/`diff`/`show`, file reads — no edits, no `cargo
-build`/`test`, no destructive git ops). All write-side work happens in a
-dedicated worktree branched off `origin/main`:
+`git status`/`log`/`diff`/`show`, file reads — no edits, no builds or test
+runs (whatever the project's gate is — `cargo build`/`test`, `npm run
+build`/`test`, `pytest`, ...), no destructive git ops). All write-side work
+happens in a dedicated worktree branched off `origin/main`:
 
 ```bash
 git fetch origin main

--- a/crates/trusty-mpm/src/assets/skills/tm-teaching-templates.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-teaching-templates.md
@@ -91,7 +91,7 @@ at the concrete skill.
 
 Stop teaching-mode elaboration once the user demonstrates fluency: they
 reference agent names unprompted, they ask for a specific agent by name
-("have the typescript-engineer do this"), or they explicitly say "just do it, I know
+("have the <engineer> do this"), or they explicitly say "just do it, I know
 how this works." At that point, Level 1 responses only — re-explaining after
 fluency is signaled reads as condescending, not helpful.
 

--- a/crates/trusty-mpm/src/assets/skills/tm-teaching-templates.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-teaching-templates.md
@@ -91,7 +91,7 @@ at the concrete skill.
 
 Stop teaching-mode elaboration once the user demonstrates fluency: they
 reference agent names unprompted, they ask for a specific agent by name
-("have rust-engineer do this"), or they explicitly say "just do it, I know
+("have the typescript-engineer do this"), or they explicitly say "just do it, I know
 how this works." At that point, Level 1 responses only — re-explaining after
 fluency is signaled reads as condescending, not helpful.
 

--- a/crates/trusty-mpm/src/assets/skills/tm-verification-protocols.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-verification-protocols.md
@@ -48,8 +48,8 @@ evidence]"`.
 **Good evidence** is specific, measurable, attributed, and reproducible:
 - File paths and line numbers; URLs and endpoints tested; HTTP status codes
 - "12 tests passed, 0 failed"; "HTTP 200 OK"; "no console errors found"
-- "web-qa verified via browser navigation"; "rust-engineer ran `cargo test -p
-  trusty-mpm skill_deployer`"
+- "web-qa verified via browser navigation"; "the engineer ran the project's
+  test gate (e.g. `cargo test`, `npm test`, `pytest`, or `go test ./...`)"
 - Reproducible steps: exact command run, exact URL navigated
 
 **Insufficient evidence (violations)**: "works", "looks good", "should be
@@ -84,15 +84,14 @@ console error check, and relevant network request status.
 ## Example Good Report
 
 ```
-Work complete: skill-source doctor probe (A2)
+Work complete: input-validation guard (A2)
 
-Implementation: rust-engineer added check_skill_source in daemon/doctor.rs
-and the tracing::warn! calls in skill_deployer.rs.
-Files: crates/trusty-mpm/src/daemon/doctor.rs (+45),
-crates/trusty-mpm/src/core/skill_deployer.rs (+12).
+Implementation: the engineer added validate_input in src/<module>/<file-a>
+and the warning-log calls in src/<module>/<file-b>.
+Files: src/<module>/<file-a> (+45), src/<module>/<file-b> (+12).
 Commit: a15150fc
 
-Testing: cargo test -p trusty-mpm --lib doctor
+Testing: <the project's test command, e.g. `cargo test`, `npm test`, `pytest`>
   37 passed; 0 failed; 0 ignored
 
 All acceptance criteria met.


### PR DESCRIPTION
## Problem

tm's bundled PM skills carried **Rust-hardwired worked examples** in their otherwise-generic delegation/verification illustrations — `rust-engineer`, `cargo test -p trusty-mpm`, `crates/trusty-mpm/...` paths. A PM running in a **Next.js / Python / Go** project read these as priming and skewed toward `rust-engineer` even when its own stack-detection logic said otherwise (#2005).

## Fix

Genericized the *illustrative* examples across **5 skills** to stack-adaptive placeholders (`<engineer>`, `src/<file>`, "the project's own test gate — `cargo test` / `npm test` / `pytest` / `go test ./...`"):

- `tm-circuit-breaker.md` (worst offender — generic CB examples were Rust-framed)
- `tm-git-file-tracking.md`
- `tm-verification-protocols.md`
- `tm-teaching-templates.md`
- `tm-pr-workflow.md`

**Deliberately preserved** (legitimate, not priming):
- `tm-delegation-patterns.md` stack-**detection** table (`Cargo.toml`→rust-engineer, `tsconfig.json`→typescript-engineer, `pyproject.toml`→python-engineer, `go.mod`→golang-engineer) — this is the logic to keep.
- `tm-agent-architecture.md`'s `cargo build -p trusty-mpm` / `tm install` / `cargo test -p trusty-mpm` commands — these correctly rebuild tm's **own** embedded assets (you can't `npm test` to recompile tm).

Residual `rust-engineer` mentions now appear **only** inside explicit multi-stack lists that reinforce adaptivity.

**Markdown-only; no code paths touched.**

## Gates
- `cargo fmt -p trusty-mpm` → clean
- `cargo test -p trusty-mpm` → 0 failed
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` → clean
- `bash scripts/check_line_cap.sh` → 0 violations

Closes #2005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)