### PR TITLE
fix(trusty-mpm): stop managed-hook duplicate accumulation in shared settings.json

### DIFF
--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -18,6 +18,7 @@
 //! `test_hook_command_uses_absolute_path`,
 //! `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`,
 //! `test_write_project_hooks_targets_project_dir`,
+//! `test_is_mpm_hook_command_recognises_tm_bin_name`,
 //! `test_write_project_hooks_replaces_stale_exe_path_group` in `tests`.
 
 #[cfg(test)]
@@ -145,19 +146,40 @@ pub fn mpm_hook_additions() -> serde_json::Value {
     mpm_hook_additions_with_exe(None)
 }
 
+/// Binary names this crate ships as `[[bin]]` targets (`Cargo.toml`): the
+/// full name and the short everyday alias used by `tm run`/`tm load`/`tm login`.
+const MPM_BIN_NAMES: &[&str] = &["trusty-mpm", "tm"];
+
 /// Check if a command string is one of the trusty-mpm hook command variants.
 ///
-/// Why: when stripping global hooks we need to match both bare and absolute-
-/// path variants so we do not leave stale bare-name entries behind.
-/// What: returns `true` when `cmd` ends with ` hook` and its prefix (the
-/// binary path) either is the literal `"trusty-mpm"` or ends with `/trusty-mpm`.
-/// Test: `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`.
+/// Why (#2015): the crate ships TWO `[[bin]]` targets that share one binary —
+/// `trusty-mpm` and the short alias `tm` (the everyday entry point for `tm
+/// run`/`tm load`/`tm login`). `mpm_hook_command` resolves whichever binary is
+/// currently running via `current_exe()`, so a hook group's command can be
+/// `.../tm hook` on one write and `.../trusty-mpm hook` on the next (or vice
+/// versa) purely from which entry point launched the process — not from any
+/// real difference in ownership. The original predicate only recognised the
+/// `trusty-mpm` name, so a stale `tm`-named group was invisible to the
+/// replace-by-identity strip in [`write_project_hooks`] and survived every
+/// merge: exactly the accumulation bug #2015 reports. Both names must be
+/// recognised as the SAME hook owner.
+/// What: returns `true` when `cmd` ends with ` hook` (scoping the match to an
+/// actual MPM hook invocation, not just any binary that happens to share a
+/// name) AND the remaining prefix's file-name component is one of
+/// [`MPM_BIN_NAMES`] — covering both bare names (`"tm hook"`) and absolute
+/// paths (`"/opt/bin/tm hook"`, `"/opt/bin/trusty-mpm hook"`).
+/// Test: `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`,
+/// `test_is_mpm_hook_command_recognises_tm_bin_name`,
+/// `test_write_project_hooks_replaces_stale_exe_path_group`.
 fn is_mpm_hook_command(cmd: &str) -> bool {
     // The command must end with " hook" (with exactly one trailing sub-command word).
     let Some(binary) = cmd.strip_suffix(" hook") else {
         return false;
     };
-    binary == "trusty-mpm" || binary.ends_with("/trusty-mpm")
+    Path::new(binary)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .is_some_and(|name| MPM_BIN_NAMES.contains(&name))
 }
 
 /// Strip trusty-mpm hook entries from every global Claude settings file.

--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -17,7 +17,11 @@
 //! `test_ensure_managed_hooks_is_idempotent`,
 //! `test_hook_command_uses_absolute_path`,
 //! `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`,
-//! `test_write_project_hooks_targets_project_dir` in this module.
+//! `test_write_project_hooks_targets_project_dir`,
+//! `test_write_project_hooks_replaces_stale_exe_path_group` in `tests`.
+
+#[cfg(test)]
+mod tests;
 
 use std::path::{Path, PathBuf};
 
@@ -206,21 +210,52 @@ pub fn remove_global_trusty_mpm_hooks() -> anyhow::Result<usize> {
 /// Remove every trusty-mpm hook entry from a settings JSON value in-place.
 ///
 /// Why: shared logic between `remove_global_trusty_mpm_hooks` and tests.
-/// What: iterates over every event key under `hooks`, filters out matcher
-/// groups whose `hooks[*].command` matches [`is_mpm_hook_command`], and
-/// removes the entire event key when its array becomes empty after filtering.
-/// Returns `true` if anything was removed.
+/// What: delegates to [`strip_mpm_hook_entries_for_events`] with `events =
+/// None`, which strips MPM-owned groups from every event key present.
 /// Test: `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`.
 fn strip_mpm_hook_entries(val: &mut serde_json::Value) -> bool {
+    strip_mpm_hook_entries_for_events(val, None)
+}
+
+/// Remove MPM-owned hook groups for the given events (or all events) in-place.
+///
+/// Why (#2015): [`trusty_common::claude_config::merge_hook_entries`] dedups a
+/// hook group only by byte-for-byte JSON equality. When the resolved absolute
+/// exe path changes (bin name `tm` vs `trusty-mpm`, worktree rebuilds,
+/// reinstalls) the `command` string differs, so a NEW MPM hook group is
+/// appended beside the stale one on every merge — MPM groups accumulate and
+/// each fires on every lifecycle event. Replacing the existing MPM-owned
+/// group for an event *before* merging enforces replace-by-identity (event
+/// name + "is this an MPM hook"), not full-value equality, so exactly one
+/// MPM group per event survives regardless of exe-path churn.
+/// What: when `events` is `Some(list)`, only those event keys are inspected;
+/// when `None`, every event key under `hooks` is inspected (used by
+/// [`remove_global_trusty_mpm_hooks`] / [`strip_mpm_hook_entries`], which must
+/// clean up all events, not just a fresh-additions subset). Within scope,
+/// filters out matcher groups whose `hooks[*].command` all match
+/// [`is_mpm_hook_command`], removing the event key entirely once its array is
+/// empty. Non-MPM groups and out-of-scope events are left untouched. Returns
+/// `true` if anything was removed.
+/// Test: `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`,
+/// `test_write_project_hooks_replaces_stale_exe_path_group`.
+fn strip_mpm_hook_entries_for_events(
+    val: &mut serde_json::Value,
+    events: Option<&[String]>,
+) -> bool {
     let Some(hooks_map) = val.get_mut("hooks").and_then(|h| h.as_object_mut()) else {
         return false;
+    };
+
+    let scope: Vec<String> = match events {
+        Some(evs) => evs.to_vec(),
+        None => hooks_map.keys().cloned().collect(),
     };
 
     let mut any_changed = false;
     let mut events_to_remove: Vec<String> = Vec::new();
 
-    for (event_key, event_val) in hooks_map.iter_mut() {
-        let Some(arr) = event_val.as_array_mut() else {
+    for event_key in scope {
+        let Some(arr) = hooks_map.get_mut(&event_key).and_then(|v| v.as_array_mut()) else {
             continue;
         };
         let before_len = arr.len();
@@ -239,7 +274,7 @@ fn strip_mpm_hook_entries(val: &mut serde_json::Value) -> bool {
         if arr.len() != before_len {
             any_changed = true;
             if arr.is_empty() {
-                events_to_remove.push(event_key.clone());
+                events_to_remove.push(event_key);
             }
         }
     }
@@ -263,12 +298,23 @@ fn strip_mpm_hook_entries(val: &mut serde_json::Value) -> bool {
 /// Why: global hooks fire in every project and can break unrelated build
 /// environments that have a stripped PATH. Project-scoped hooks only fire
 /// inside the specific project directory, matching trusty-memory's approach.
+/// Before merging, any EXISTING MPM-owned hook group for each event about to
+/// be (re-)added is stripped first (#2015): `merge_hook_entries` dedups only
+/// by byte-for-byte JSON equality, so when the resolved exe path differs from
+/// a previous write (bin name `tm` vs `trusty-mpm`, worktree rebuild,
+/// reinstall) the stale group would otherwise survive alongside the fresh
+/// one, and MPM hook groups accumulate — each one firing on every lifecycle
+/// event. Stripping first enforces replace-by-identity (event name + "is this
+/// an MPM hook") rather than full-value equality.
 /// What: reads `settings_path` (tolerates missing/empty — starts from `{}`),
-/// deep-merges the MPM hook additions, and writes back atomically only when
-/// something actually changed. Returns `true` when the file was updated.
-/// `exe_override` is forwarded to [`mpm_hook_additions_with_exe`] so the
-/// caller can pin the binary path at install time.
-/// Test: `test_write_project_hooks_targets_project_dir`.
+/// strips any MPM-owned hook group for the events present in the fresh
+/// additions via [`strip_mpm_hook_entries_for_events`], deep-merges the MPM
+/// hook additions, and writes back atomically only when something actually
+/// changed. Returns `true` when the file was updated. `exe_override` is
+/// forwarded to [`mpm_hook_additions_with_exe`] so the caller can pin the
+/// binary path at install time.
+/// Test: `test_write_project_hooks_targets_project_dir`,
+/// `test_write_project_hooks_replaces_stale_exe_path_group`.
 pub fn write_project_hooks(
     settings_path: &Path,
     exe_override: Option<&Path>,
@@ -291,7 +337,17 @@ pub fn write_project_hooks(
     };
 
     let additions = mpm_hook_additions_with_exe(exe_override);
-    let merged = merge_hook_entries(&original, &additions);
+
+    // Replace-by-identity: drop any stale MPM-owned group for each event we
+    // are about to add, so the merge below can never leave two MPM groups
+    // (old exe path + new exe path) side-by-side for the same event.
+    let mut base = original.clone();
+    if let Some(events) = additions.get("hooks").and_then(|h| h.as_object()) {
+        let event_keys: Vec<String> = events.keys().cloned().collect();
+        strip_mpm_hook_entries_for_events(&mut base, Some(&event_keys));
+    }
+
+    let merged = merge_hook_entries(&base, &additions);
 
     if merged == original {
         return Ok(false);
@@ -335,323 +391,4 @@ pub fn resolve_current_exe() -> Option<PathBuf> {
     std::env::current_exe()
         .ok()
         .and_then(|p| p.canonicalize().ok().or(Some(p)))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    /// Why: hooks must embed an absolute binary path so they fire even in
-    /// environments where ~/.cargo/bin is not on PATH.
-    /// What: passes a known absolute path as exe_override and asserts the
-    /// returned command starts with that path followed by " hook".
-    #[test]
-    fn test_hook_command_uses_absolute_path() {
-        let fake_exe = PathBuf::from("/usr/local/bin/trusty-mpm");
-        let cmd = mpm_hook_command(Some(&fake_exe));
-        assert!(
-            cmd.starts_with('/'),
-            "hook command must start with '/' (absolute path), got: {cmd:?}"
-        );
-        assert!(
-            cmd.ends_with(" hook"),
-            "hook command must end with ' hook', got: {cmd:?}"
-        );
-        assert_eq!(cmd, "/usr/local/bin/trusty-mpm hook");
-    }
-
-    /// Why: when exe_override is None and current_exe() is available (which
-    /// it always is in cargo test), the command must still start with '/' —
-    /// the test binary itself is an absolute path.
-    #[test]
-    fn test_hook_command_without_override_is_absolute_or_fallback() {
-        let cmd = mpm_hook_command(None);
-        // Either an absolute path (normal) or the bare fallback (edge case
-        // where current_exe() is somehow unavailable / relative).
-        assert!(
-            cmd.ends_with(" hook"),
-            "hook command must end with ' hook', got: {cmd:?}"
-        );
-    }
-
-    #[test]
-    fn test_mpm_hook_additions_has_five_events() {
-        // #1744: SessionStart/SessionEnd must be present so the daemon receives
-        // them for claude_session_id capture and immediate-Stopped marking.
-        let v = mpm_hook_additions();
-        let hooks = v.get("hooks").expect("missing 'hooks' key");
-        assert!(hooks.get("PreToolUse").is_some(), "missing PreToolUse");
-        assert!(hooks.get("PostToolUse").is_some(), "missing PostToolUse");
-        assert!(hooks.get("Stop").is_some(), "missing Stop");
-        assert!(
-            hooks.get("SessionStart").is_some(),
-            "missing SessionStart (#1744)"
-        );
-        assert!(
-            hooks.get("SessionEnd").is_some(),
-            "missing SessionEnd (#1744)"
-        );
-    }
-
-    /// Why: with an absolute exe_override the generated command must start
-    /// with '/' in every event slot.
-    #[test]
-    fn test_mpm_hook_additions_with_exe_embeds_absolute_path() {
-        let fake_exe = PathBuf::from("/home/user/.cargo/bin/trusty-mpm");
-        let v = mpm_hook_additions_with_exe(Some(&fake_exe));
-        let hooks = v.get("hooks").expect("missing 'hooks' key");
-        for event in &[
-            "PreToolUse",
-            "PostToolUse",
-            "Stop",
-            "SessionStart",
-            "SessionEnd",
-        ] {
-            let cmd = hooks[event][0]["hooks"][0]["command"]
-                .as_str()
-                .unwrap_or_default();
-            assert!(
-                cmd.starts_with('/'),
-                "event {event}: command must be absolute, got: {cmd:?}"
-            );
-        }
-    }
-
-    // WI-3 HOOK-CLEAN test: after ensure_managed_hooks, settings.json contains
-    // the full PreToolUse/PostToolUse/Stop trusty-mpm hook entries.
-    #[test]
-    fn test_ensure_managed_hooks_writes_triad() {
-        let tmp = TempDir::new().unwrap();
-        let cfg = tmp.path().to_path_buf();
-
-        // Write a minimal settings.json (simulating the initial seed).
-        std::fs::write(cfg.join("settings.json"), "{}\n").unwrap();
-
-        ensure_managed_hooks(&cfg).unwrap();
-
-        let text = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
-        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
-
-        let hooks = val
-            .get("hooks")
-            .expect("settings.json must contain 'hooks'");
-        assert!(
-            hooks.get("PreToolUse").is_some(),
-            "settings.json must contain hooks.PreToolUse after ensure_managed_hooks"
-        );
-        assert!(
-            hooks.get("PostToolUse").is_some(),
-            "settings.json must contain hooks.PostToolUse after ensure_managed_hooks"
-        );
-        assert!(
-            hooks.get("Stop").is_some(),
-            "settings.json must contain hooks.Stop after ensure_managed_hooks"
-        );
-        assert!(
-            hooks.get("SessionStart").is_some(),
-            "settings.json must contain hooks.SessionStart after ensure_managed_hooks (#1744)"
-        );
-        assert!(
-            hooks.get("SessionEnd").is_some(),
-            "settings.json must contain hooks.SessionEnd after ensure_managed_hooks (#1744)"
-        );
-
-        // Verify the command ends with " hook" (may be absolute or bare fallback).
-        let pre = hooks["PreToolUse"].as_array().unwrap();
-        let cmd = pre[0]["hooks"][0]["command"].as_str().unwrap();
-        assert!(
-            cmd.ends_with(" hook"),
-            "hook command must end with ' hook', got: {cmd:?}"
-        );
-    }
-
-    // WI-3 HOOK-CLEAN idempotency test: calling ensure_managed_hooks twice must
-    // NOT duplicate hook entries.
-    #[test]
-    fn test_ensure_managed_hooks_is_idempotent() {
-        let tmp = TempDir::new().unwrap();
-        let cfg = tmp.path().to_path_buf();
-
-        std::fs::write(cfg.join("settings.json"), "{}\n").unwrap();
-
-        ensure_managed_hooks(&cfg).unwrap();
-        let after_first = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
-
-        ensure_managed_hooks(&cfg).unwrap();
-        let after_second = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
-
-        assert_eq!(
-            after_first, after_second,
-            "ensure_managed_hooks must be idempotent: calling twice must not change settings.json"
-        );
-
-        // Also verify entries are not duplicated.
-        let val: serde_json::Value = serde_json::from_str(&after_second).unwrap();
-        let pre = val["hooks"]["PreToolUse"].as_array().unwrap();
-        let pre_hook_count = pre
-            .iter()
-            .filter(|g| {
-                g.get("hooks")
-                    .and_then(|h| h.as_array())
-                    .is_some_and(|cmds| {
-                        cmds.iter().any(|c| {
-                            c.get("command")
-                                .and_then(|v| v.as_str())
-                                .is_some_and(|s| s.ends_with(" hook"))
-                        })
-                    })
-            })
-            .count();
-        assert_eq!(
-            pre_hook_count, 1,
-            "PreToolUse must have exactly one trusty-mpm hook group after two calls"
-        );
-    }
-
-    // WI-3 HOOK-CLEAN: existing non-hook keys must be preserved after ensure_managed_hooks.
-    #[test]
-    fn test_ensure_managed_hooks_preserves_existing_keys() {
-        let tmp = TempDir::new().unwrap();
-        let cfg = tmp.path().to_path_buf();
-
-        std::fs::write(
-            cfg.join("settings.json"),
-            r#"{"outputStyle":"trusty-mpm","someOtherKey":42}"#,
-        )
-        .unwrap();
-
-        ensure_managed_hooks(&cfg).unwrap();
-
-        let text = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
-        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
-
-        assert_eq!(
-            val.get("outputStyle").and_then(|v| v.as_str()),
-            Some("trusty-mpm"),
-            "outputStyle key must be preserved"
-        );
-        assert_eq!(
-            val.get("someOtherKey").and_then(|v| v.as_i64()),
-            Some(42),
-            "someOtherKey must be preserved"
-        );
-        // Hooks must also be present.
-        assert!(val.get("hooks").is_some(), "hooks must be present");
-    }
-
-    /// Why: `remove_global_trusty_mpm_hooks` must strip only MPM entries and
-    /// leave unrelated hooks (e.g. trusty-memory's) intact.
-    /// What: seeds a settings JSON with both an MPM hook group and a non-MPM
-    /// hook group, calls `strip_mpm_hook_entries`, and asserts only the MPM
-    /// group was removed.
-    #[test]
-    fn test_strip_mpm_hook_entries_removes_only_mpm_entries() {
-        let mut val = serde_json::json!({
-            "hooks": {
-                "PreToolUse": [
-                    {
-                        "matcher": "*",
-                        "hooks": [{ "type": "command", "command": "trusty-mpm hook" }]
-                    },
-                    {
-                        "matcher": "*",
-                        "hooks": [{ "type": "command", "command": "other-tool run" }]
-                    }
-                ],
-                "SessionStart": [
-                    {
-                        "matcher": "*",
-                        "hooks": [{ "type": "command", "command": "trusty-mpm hook" }]
-                    }
-                ]
-            }
-        });
-
-        let changed = strip_mpm_hook_entries(&mut val);
-        assert!(changed, "must report change when MPM entries removed");
-
-        // PreToolUse should still exist with the non-MPM hook.
-        let pre = val["hooks"]["PreToolUse"].as_array().unwrap();
-        assert_eq!(pre.len(), 1, "non-MPM entry must survive");
-        assert_eq!(
-            pre[0]["hooks"][0]["command"].as_str().unwrap(),
-            "other-tool run"
-        );
-
-        // SessionStart must be fully removed (was MPM-only).
-        assert!(
-            val["hooks"].get("SessionStart").is_none(),
-            "empty event key must be removed"
-        );
-    }
-
-    /// Why: absolute-path variants of the MPM hook command must also be
-    /// recognised so stale entries from previous abspath installs are stripped.
-    #[test]
-    fn test_strip_mpm_hook_entries_recognises_abspath_variants() {
-        let mut val = serde_json::json!({
-            "hooks": {
-                "Stop": [
-                    {
-                        "matcher": "*",
-                        "hooks": [{ "type": "command", "command": "/home/user/.cargo/bin/trusty-mpm hook" }]
-                    }
-                ]
-            }
-        });
-
-        let changed = strip_mpm_hook_entries(&mut val);
-        assert!(changed);
-        // hooks key removed entirely when all events are gone.
-        assert!(val.get("hooks").is_none(), "hooks key must be removed");
-    }
-
-    /// Why: `write_project_hooks` must write into the specified project
-    /// settings path, NOT into any global file.
-    /// What: calls `write_project_hooks` with a tempdir-based path, asserts the
-    /// file was created there and contains hook entries.
-    #[test]
-    fn test_write_project_hooks_targets_project_dir() {
-        let tmp = TempDir::new().unwrap();
-        let project_settings = tmp.path().join(".claude").join("settings.json");
-        // File doesn't exist yet — write_project_hooks must create it.
-        let fake_exe = PathBuf::from("/fake/bin/trusty-mpm");
-        let wrote = write_project_hooks(&project_settings, Some(&fake_exe)).unwrap();
-        assert!(wrote, "must report file was written");
-        assert!(
-            project_settings.exists(),
-            "project settings file must exist"
-        );
-
-        let text = std::fs::read_to_string(&project_settings).unwrap();
-        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
-        let hooks = val.get("hooks").expect("hooks key must be present");
-        assert!(hooks.get("PreToolUse").is_some());
-
-        let cmd = hooks["PreToolUse"][0]["hooks"][0]["command"]
-            .as_str()
-            .unwrap();
-        assert!(
-            cmd.starts_with('/'),
-            "command must be absolute, got: {cmd:?}"
-        );
-    }
-
-    /// Why: calling `write_project_hooks` twice must be a no-op (idempotent).
-    #[test]
-    fn test_write_project_hooks_is_idempotent() {
-        let tmp = TempDir::new().unwrap();
-        let settings = tmp.path().join("settings.json");
-        let fake_exe = PathBuf::from("/fake/bin/trusty-mpm");
-
-        write_project_hooks(&settings, Some(&fake_exe)).unwrap();
-        let content_first = std::fs::read_to_string(&settings).unwrap();
-
-        let wrote_second = write_project_hooks(&settings, Some(&fake_exe)).unwrap();
-        assert!(!wrote_second, "second call must be a no-op");
-
-        let content_second = std::fs::read_to_string(&settings).unwrap();
-        assert_eq!(content_first, content_second, "file must not change");
-    }
 }

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -325,16 +325,55 @@ fn test_write_project_hooks_is_idempotent() {
     assert_eq!(content_first, content_second, "file must not change");
 }
 
+/// Why (#2015): the crate ships the SAME binary under two `[[bin]]` names —
+/// `trusty-mpm` and the short `tm` alias used by `tm run`/`tm load`/`tm
+/// login`. `is_mpm_hook_command` must treat both names as the same owner so
+/// [`strip_mpm_hook_entries_for_events`] recognises a stale `tm`-named group
+/// when the next write resolves to `trusty-mpm` (or vice versa).
+/// What: asserts bare `"tm hook"`, absolute `"/opt/bin/tm hook"`, bare
+/// `"trusty-mpm hook"`, and absolute `"/opt/bin/trusty-mpm hook"` are all
+/// recognised, while an unrelated binary that merely shares the `tm` stem
+/// with a *different* trailing subcommand (not literally `hook`) is not.
+#[test]
+fn test_is_mpm_hook_command_recognises_tm_bin_name() {
+    assert!(is_mpm_hook_command("tm hook"), "bare 'tm' must match");
+    assert!(
+        is_mpm_hook_command("/opt/old/bin/tm hook"),
+        "absolute path ending in '/tm' must match"
+    );
+    assert!(
+        is_mpm_hook_command("trusty-mpm hook"),
+        "bare 'trusty-mpm' must still match"
+    );
+    assert!(
+        is_mpm_hook_command("/opt/new/bin/trusty-mpm hook"),
+        "absolute path ending in '/trusty-mpm' must still match"
+    );
+    assert!(
+        !is_mpm_hook_command("tm status"),
+        "must stay scoped to the ' hook' subcommand, not any 'tm' invocation"
+    );
+    assert!(
+        !is_mpm_hook_command("other-tool hook"),
+        "unrelated binaries named neither 'tm' nor 'trusty-mpm' must not match"
+    );
+}
+
 /// Why (#2015): `merge_hook_entries` dedups only by byte-for-byte JSON
-/// equality, so writing with a different resolved exe path (bin rename,
-/// worktree rebuild, reinstall) must REPLACE the stale MPM group rather
-/// than append a second one beside it — otherwise MPM hook groups
-/// accumulate and each fires on every lifecycle event.
-/// What: calls `write_project_hooks` twice with two different
-/// `exe_override` paths against the same settings file, seeding a
-/// pre-existing non-MPM hook group first. Asserts exactly one MPM hook
-/// group per event survives (matching the SECOND call's exe path) and
-/// the non-MPM group is untouched.
+/// equality, so writing with a different resolved exe path (bin rename —
+/// including the `tm` vs `trusty-mpm` [[bin]]-name switch, not just a
+/// directory change — worktree rebuild, reinstall) must REPLACE the stale
+/// MPM group rather than append a second one beside it — otherwise MPM hook
+/// groups accumulate and each fires on every lifecycle event.
+/// What: calls `write_project_hooks` twice — first with the `tm` bin name,
+/// then with the `trusty-mpm` bin name — against the same settings file,
+/// seeding a pre-existing non-MPM hook group first. Deliberately asserts on
+/// the RAW array length and literal command strings (NOT filtered through
+/// `is_mpm_hook_command`, the predicate under test) so a stale group that a
+/// narrow/buggy predicate fails to recognise cannot hide from the
+/// assertion: PreToolUse must have exactly 2 groups (1 preserved non-MPM +
+/// 1 MPM), and no surviving entry anywhere may reference the first (`tm`)
+/// exe path.
 #[test]
 fn test_write_project_hooks_replaces_stale_exe_path_group() {
     let tmp = TempDir::new().unwrap();
@@ -365,48 +404,57 @@ fn test_write_project_hooks_replaces_stale_exe_path_group() {
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
     let hooks = val["hooks"].as_object().expect("hooks must be present");
 
-    for event in &[
-        "PreToolUse",
-        "PostToolUse",
-        "Stop",
-        "SessionStart",
-        "SessionEnd",
-    ] {
+    // PreToolUse: the preserved non-MPM group + exactly one MPM group.
+    // Raw length, independent of `is_mpm_hook_command` — a stale group the
+    // predicate fails to recognise would otherwise inflate this to 3 while
+    // still passing a predicate-filtered assertion.
+    let pre = hooks["PreToolUse"]
+        .as_array()
+        .expect("PreToolUse must be present");
+    assert_eq!(
+        pre.len(),
+        2,
+        "PreToolUse must have exactly 2 groups (1 non-MPM + 1 MPM), found {}: {pre:?}",
+        pre.len()
+    );
+    let pre_commands: Vec<&str> = pre
+        .iter()
+        .filter_map(|g| g["hooks"][0]["command"].as_str())
+        .collect();
+    assert!(
+        pre_commands.contains(&"trusty-memory inbox-check"),
+        "pre-existing non-MPM hook group must be preserved, got: {pre_commands:?}"
+    );
+    assert!(
+        pre_commands
+            .iter()
+            .any(|c| c.contains("/opt/new/bin/trusty-mpm")),
+        "must contain the SECOND call's exe path, got: {pre_commands:?}"
+    );
+    assert!(
+        !pre_commands.iter().any(|c| c.contains("/opt/old/bin/tm")),
+        "must NOT contain the FIRST call's stale exe path, got: {pre_commands:?}"
+    );
+
+    // Every other event started empty, so exactly one (MPM) group must survive.
+    for event in &["PostToolUse", "Stop", "SessionStart", "SessionEnd"] {
         let arr = hooks[*event]
             .as_array()
             .unwrap_or_else(|| panic!("event {event} must be present after two writes"));
-        let mpm_groups: Vec<&serde_json::Value> = arr
-            .iter()
-            .filter(|g| {
-                g.get("hooks")
-                    .and_then(|h| h.as_array())
-                    .is_some_and(|cmds| {
-                        cmds.iter().all(|c| {
-                            c.get("command")
-                                .and_then(|v| v.as_str())
-                                .is_some_and(is_mpm_hook_command)
-                        })
-                    })
-            })
-            .collect();
         assert_eq!(
-            mpm_groups.len(),
+            arr.len(),
             1,
-            "event {event} must have exactly one MPM hook group, found {}",
-            mpm_groups.len()
+            "event {event} must have exactly 1 group, found {}: {arr:?}",
+            arr.len()
         );
-        let cmd = mpm_groups[0]["hooks"][0]["command"].as_str().unwrap();
-        assert_eq!(
-            cmd, "/opt/new/bin/trusty-mpm hook",
-            "event {event} must carry the SECOND call's exe path"
+        let cmd = arr[0]["hooks"][0]["command"].as_str().unwrap();
+        assert!(
+            cmd.contains("/opt/new/bin/trusty-mpm"),
+            "event {event} must carry the SECOND call's exe path, got: {cmd:?}"
+        );
+        assert!(
+            !cmd.contains("/opt/old/bin/tm"),
+            "event {event} must NOT carry the stale FIRST exe path, got: {cmd:?}"
         );
     }
-
-    // The pre-existing non-MPM group must be preserved untouched.
-    let pre = hooks["PreToolUse"].as_array().unwrap();
-    assert!(
-        pre.iter()
-            .any(|g| g["hooks"][0]["command"] == "trusty-memory inbox-check"),
-        "pre-existing non-MPM hook group must be preserved"
-    );
 }

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -1,0 +1,412 @@
+//! Unit tests for [`super`] (managed-session hook definitions and merge logic).
+//!
+//! Why: split out of `mod.rs` to keep the production file under the 500-SLOC
+//! cap (CLAUDE.md) once the #2015 replace-by-identity regression test was
+//! added; mirrors the `core/session_launch/{mod.rs,tests.rs}` split already
+//! used elsewhere in this crate.
+//! What: exercises `mpm_hook_command`, `mpm_hook_additions[_with_exe]`,
+//! `ensure_managed_hooks`, `strip_mpm_hook_entries`, and `write_project_hooks`
+//! (including the #2015 stale-exe-path replacement regression).
+//! Test: this module IS the test suite for `super`.
+
+use super::*;
+use tempfile::TempDir;
+
+/// Why: hooks must embed an absolute binary path so they fire even in
+/// environments where ~/.cargo/bin is not on PATH.
+/// What: passes a known absolute path as exe_override and asserts the
+/// returned command starts with that path followed by " hook".
+#[test]
+fn test_hook_command_uses_absolute_path() {
+    let fake_exe = PathBuf::from("/usr/local/bin/trusty-mpm");
+    let cmd = mpm_hook_command(Some(&fake_exe));
+    assert!(
+        cmd.starts_with('/'),
+        "hook command must start with '/' (absolute path), got: {cmd:?}"
+    );
+    assert!(
+        cmd.ends_with(" hook"),
+        "hook command must end with ' hook', got: {cmd:?}"
+    );
+    assert_eq!(cmd, "/usr/local/bin/trusty-mpm hook");
+}
+
+/// Why: when exe_override is None and current_exe() is available (which
+/// it always is in cargo test), the command must still start with '/' —
+/// the test binary itself is an absolute path.
+#[test]
+fn test_hook_command_without_override_is_absolute_or_fallback() {
+    let cmd = mpm_hook_command(None);
+    // Either an absolute path (normal) or the bare fallback (edge case
+    // where current_exe() is somehow unavailable / relative).
+    assert!(
+        cmd.ends_with(" hook"),
+        "hook command must end with ' hook', got: {cmd:?}"
+    );
+}
+
+#[test]
+fn test_mpm_hook_additions_has_five_events() {
+    // #1744: SessionStart/SessionEnd must be present so the daemon receives
+    // them for claude_session_id capture and immediate-Stopped marking.
+    let v = mpm_hook_additions();
+    let hooks = v.get("hooks").expect("missing 'hooks' key");
+    assert!(hooks.get("PreToolUse").is_some(), "missing PreToolUse");
+    assert!(hooks.get("PostToolUse").is_some(), "missing PostToolUse");
+    assert!(hooks.get("Stop").is_some(), "missing Stop");
+    assert!(
+        hooks.get("SessionStart").is_some(),
+        "missing SessionStart (#1744)"
+    );
+    assert!(
+        hooks.get("SessionEnd").is_some(),
+        "missing SessionEnd (#1744)"
+    );
+}
+
+/// Why: with an absolute exe_override the generated command must start
+/// with '/' in every event slot.
+#[test]
+fn test_mpm_hook_additions_with_exe_embeds_absolute_path() {
+    let fake_exe = PathBuf::from("/home/user/.cargo/bin/trusty-mpm");
+    let v = mpm_hook_additions_with_exe(Some(&fake_exe));
+    let hooks = v.get("hooks").expect("missing 'hooks' key");
+    for event in &[
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+        "SessionStart",
+        "SessionEnd",
+    ] {
+        let cmd = hooks[event][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            cmd.starts_with('/'),
+            "event {event}: command must be absolute, got: {cmd:?}"
+        );
+    }
+}
+
+// WI-3 HOOK-CLEAN test: after ensure_managed_hooks, settings.json contains
+// the full PreToolUse/PostToolUse/Stop trusty-mpm hook entries.
+#[test]
+fn test_ensure_managed_hooks_writes_triad() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = tmp.path().to_path_buf();
+
+    // Write a minimal settings.json (simulating the initial seed).
+    std::fs::write(cfg.join("settings.json"), "{}\n").unwrap();
+
+    ensure_managed_hooks(&cfg).unwrap();
+
+    let text = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+    let hooks = val
+        .get("hooks")
+        .expect("settings.json must contain 'hooks'");
+    assert!(
+        hooks.get("PreToolUse").is_some(),
+        "settings.json must contain hooks.PreToolUse after ensure_managed_hooks"
+    );
+    assert!(
+        hooks.get("PostToolUse").is_some(),
+        "settings.json must contain hooks.PostToolUse after ensure_managed_hooks"
+    );
+    assert!(
+        hooks.get("Stop").is_some(),
+        "settings.json must contain hooks.Stop after ensure_managed_hooks"
+    );
+    assert!(
+        hooks.get("SessionStart").is_some(),
+        "settings.json must contain hooks.SessionStart after ensure_managed_hooks (#1744)"
+    );
+    assert!(
+        hooks.get("SessionEnd").is_some(),
+        "settings.json must contain hooks.SessionEnd after ensure_managed_hooks (#1744)"
+    );
+
+    // Verify the command ends with " hook" (may be absolute or bare fallback).
+    let pre = hooks["PreToolUse"].as_array().unwrap();
+    let cmd = pre[0]["hooks"][0]["command"].as_str().unwrap();
+    assert!(
+        cmd.ends_with(" hook"),
+        "hook command must end with ' hook', got: {cmd:?}"
+    );
+}
+
+// WI-3 HOOK-CLEAN idempotency test: calling ensure_managed_hooks twice must
+// NOT duplicate hook entries.
+#[test]
+fn test_ensure_managed_hooks_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = tmp.path().to_path_buf();
+
+    std::fs::write(cfg.join("settings.json"), "{}\n").unwrap();
+
+    ensure_managed_hooks(&cfg).unwrap();
+    let after_first = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
+
+    ensure_managed_hooks(&cfg).unwrap();
+    let after_second = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
+
+    assert_eq!(
+        after_first, after_second,
+        "ensure_managed_hooks must be idempotent: calling twice must not change settings.json"
+    );
+
+    // Also verify entries are not duplicated.
+    let val: serde_json::Value = serde_json::from_str(&after_second).unwrap();
+    let pre = val["hooks"]["PreToolUse"].as_array().unwrap();
+    let pre_hook_count = pre
+        .iter()
+        .filter(|g| {
+            g.get("hooks")
+                .and_then(|h| h.as_array())
+                .is_some_and(|cmds| {
+                    cmds.iter().any(|c| {
+                        c.get("command")
+                            .and_then(|v| v.as_str())
+                            .is_some_and(|s| s.ends_with(" hook"))
+                    })
+                })
+        })
+        .count();
+    assert_eq!(
+        pre_hook_count, 1,
+        "PreToolUse must have exactly one trusty-mpm hook group after two calls"
+    );
+}
+
+// WI-3 HOOK-CLEAN: existing non-hook keys must be preserved after ensure_managed_hooks.
+#[test]
+fn test_ensure_managed_hooks_preserves_existing_keys() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = tmp.path().to_path_buf();
+
+    std::fs::write(
+        cfg.join("settings.json"),
+        r#"{"outputStyle":"trusty-mpm","someOtherKey":42}"#,
+    )
+    .unwrap();
+
+    ensure_managed_hooks(&cfg).unwrap();
+
+    let text = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+    assert_eq!(
+        val.get("outputStyle").and_then(|v| v.as_str()),
+        Some("trusty-mpm"),
+        "outputStyle key must be preserved"
+    );
+    assert_eq!(
+        val.get("someOtherKey").and_then(|v| v.as_i64()),
+        Some(42),
+        "someOtherKey must be preserved"
+    );
+    // Hooks must also be present.
+    assert!(val.get("hooks").is_some(), "hooks must be present");
+}
+
+/// Why: `remove_global_trusty_mpm_hooks` must strip only MPM entries and
+/// leave unrelated hooks (e.g. trusty-memory's) intact.
+/// What: seeds a settings JSON with both an MPM hook group and a non-MPM
+/// hook group, calls `strip_mpm_hook_entries`, and asserts only the MPM
+/// group was removed.
+#[test]
+fn test_strip_mpm_hook_entries_removes_only_mpm_entries() {
+    let mut val = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "*",
+                    "hooks": [{ "type": "command", "command": "trusty-mpm hook" }]
+                },
+                {
+                    "matcher": "*",
+                    "hooks": [{ "type": "command", "command": "other-tool run" }]
+                }
+            ],
+            "SessionStart": [
+                {
+                    "matcher": "*",
+                    "hooks": [{ "type": "command", "command": "trusty-mpm hook" }]
+                }
+            ]
+        }
+    });
+
+    let changed = strip_mpm_hook_entries(&mut val);
+    assert!(changed, "must report change when MPM entries removed");
+
+    // PreToolUse should still exist with the non-MPM hook.
+    let pre = val["hooks"]["PreToolUse"].as_array().unwrap();
+    assert_eq!(pre.len(), 1, "non-MPM entry must survive");
+    assert_eq!(
+        pre[0]["hooks"][0]["command"].as_str().unwrap(),
+        "other-tool run"
+    );
+
+    // SessionStart must be fully removed (was MPM-only).
+    assert!(
+        val["hooks"].get("SessionStart").is_none(),
+        "empty event key must be removed"
+    );
+}
+
+/// Why: absolute-path variants of the MPM hook command must also be
+/// recognised so stale entries from previous abspath installs are stripped.
+#[test]
+fn test_strip_mpm_hook_entries_recognises_abspath_variants() {
+    let mut val = serde_json::json!({
+        "hooks": {
+            "Stop": [
+                {
+                    "matcher": "*",
+                    "hooks": [{ "type": "command", "command": "/home/user/.cargo/bin/trusty-mpm hook" }]
+                }
+            ]
+        }
+    });
+
+    let changed = strip_mpm_hook_entries(&mut val);
+    assert!(changed);
+    // hooks key removed entirely when all events are gone.
+    assert!(val.get("hooks").is_none(), "hooks key must be removed");
+}
+
+/// Why: `write_project_hooks` must write into the specified project
+/// settings path, NOT into any global file.
+/// What: calls `write_project_hooks` with a tempdir-based path, asserts the
+/// file was created there and contains hook entries.
+#[test]
+fn test_write_project_hooks_targets_project_dir() {
+    let tmp = TempDir::new().unwrap();
+    let project_settings = tmp.path().join(".claude").join("settings.json");
+    // File doesn't exist yet — write_project_hooks must create it.
+    let fake_exe = PathBuf::from("/fake/bin/trusty-mpm");
+    let wrote = write_project_hooks(&project_settings, Some(&fake_exe)).unwrap();
+    assert!(wrote, "must report file was written");
+    assert!(
+        project_settings.exists(),
+        "project settings file must exist"
+    );
+
+    let text = std::fs::read_to_string(&project_settings).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let hooks = val.get("hooks").expect("hooks key must be present");
+    assert!(hooks.get("PreToolUse").is_some());
+
+    let cmd = hooks["PreToolUse"][0]["hooks"][0]["command"]
+        .as_str()
+        .unwrap();
+    assert!(
+        cmd.starts_with('/'),
+        "command must be absolute, got: {cmd:?}"
+    );
+}
+
+/// Why: calling `write_project_hooks` twice must be a no-op (idempotent).
+#[test]
+fn test_write_project_hooks_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let settings = tmp.path().join("settings.json");
+    let fake_exe = PathBuf::from("/fake/bin/trusty-mpm");
+
+    write_project_hooks(&settings, Some(&fake_exe)).unwrap();
+    let content_first = std::fs::read_to_string(&settings).unwrap();
+
+    let wrote_second = write_project_hooks(&settings, Some(&fake_exe)).unwrap();
+    assert!(!wrote_second, "second call must be a no-op");
+
+    let content_second = std::fs::read_to_string(&settings).unwrap();
+    assert_eq!(content_first, content_second, "file must not change");
+}
+
+/// Why (#2015): `merge_hook_entries` dedups only by byte-for-byte JSON
+/// equality, so writing with a different resolved exe path (bin rename,
+/// worktree rebuild, reinstall) must REPLACE the stale MPM group rather
+/// than append a second one beside it — otherwise MPM hook groups
+/// accumulate and each fires on every lifecycle event.
+/// What: calls `write_project_hooks` twice with two different
+/// `exe_override` paths against the same settings file, seeding a
+/// pre-existing non-MPM hook group first. Asserts exactly one MPM hook
+/// group per event survives (matching the SECOND call's exe path) and
+/// the non-MPM group is untouched.
+#[test]
+fn test_write_project_hooks_replaces_stale_exe_path_group() {
+    let tmp = TempDir::new().unwrap();
+    let settings = tmp.path().join("settings.json");
+
+    // Seed a pre-existing non-MPM hook group that must survive untouched.
+    std::fs::write(
+        &settings,
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "*",
+                    "hooks": [{ "type": "command", "command": "trusty-memory inbox-check" }]
+                }]
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let exe_v1 = PathBuf::from("/opt/old/bin/tm");
+    let exe_v2 = PathBuf::from("/opt/new/bin/trusty-mpm");
+
+    write_project_hooks(&settings, Some(&exe_v1)).unwrap();
+    write_project_hooks(&settings, Some(&exe_v2)).unwrap();
+
+    let text = std::fs::read_to_string(&settings).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let hooks = val["hooks"].as_object().expect("hooks must be present");
+
+    for event in &[
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+        "SessionStart",
+        "SessionEnd",
+    ] {
+        let arr = hooks[*event]
+            .as_array()
+            .unwrap_or_else(|| panic!("event {event} must be present after two writes"));
+        let mpm_groups: Vec<&serde_json::Value> = arr
+            .iter()
+            .filter(|g| {
+                g.get("hooks")
+                    .and_then(|h| h.as_array())
+                    .is_some_and(|cmds| {
+                        cmds.iter().all(|c| {
+                            c.get("command")
+                                .and_then(|v| v.as_str())
+                                .is_some_and(is_mpm_hook_command)
+                        })
+                    })
+            })
+            .collect();
+        assert_eq!(
+            mpm_groups.len(),
+            1,
+            "event {event} must have exactly one MPM hook group, found {}",
+            mpm_groups.len()
+        );
+        let cmd = mpm_groups[0]["hooks"][0]["command"].as_str().unwrap();
+        assert_eq!(
+            cmd, "/opt/new/bin/trusty-mpm hook",
+            "event {event} must carry the SECOND call's exe path"
+        );
+    }
+
+    // The pre-existing non-MPM group must be preserved untouched.
+    let pre = hooks["PreToolUse"].as_array().unwrap();
+    assert!(
+        pre.iter()
+            .any(|g| g["hooks"][0]["command"] == "trusty-memory inbox-check"),
+        "pre-existing non-MPM hook group must be preserved"
+    );
+}


### PR DESCRIPTION
## Summary

- `write_project_hooks()` in `crates/trusty-mpm/src/core/standalone/hooks.rs` now strips any existing MPM-owned hook group for each event about to be (re-)added, *before* calling `trusty_common::claude_config::merge_hook_entries`.
- Root cause: `merge_hook_entries` dedups a hook group only by byte-for-byte JSON equality. Since the hook `command` bakes in the resolved absolute exe path (`std::env::current_exe()`), any change in that path (bin name `tm` vs `trusty-mpm`, worktree rebuild, reinstall) produces a *different* JSON group, which the generic merge appends alongside the stale one instead of replacing it. Over repeated `tm run`/`tm load`/`tm login` invocations, MPM hook groups accumulate in the shared `settings.json` and each one fires on every lifecycle event.
- Fix is replace-by-identity: `strip_mpm_hook_entries` was generalized into `strip_mpm_hook_entries_for_events(val, events: Option<&[String]>)` (event-scoped stripping) and is called immediately before the merge, restricted to just the events present in the fresh additions. Non-MPM hook groups (e.g. trusty-memory's) and events outside the current additions are left untouched.
- `trusty_common::merge_hook_entries` itself is **unmodified** — it stays generic/shared with trusty-memory. All logic lives in trusty-mpm's own `hooks.rs`.
- Split `hooks.rs` into a `hooks/` module (`mod.rs` + `tests.rs`) to stay under the 500-SLOC production cap after adding the new regression test — mirrors the existing `core/session_launch/{mod.rs,tests.rs}` pattern in this crate.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-mpm` — all suites pass (2306 lib tests + integration suites, 0 failed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 errors
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] New regression test `test_write_project_hooks_replaces_stale_exe_path_group`: calls `write_project_hooks` twice with two different `exe_override` paths against the same settings file (seeded with a pre-existing non-MPM hook group). Asserts exactly one MPM hook group per event survives, its command matches the SECOND call's exe path, and the non-MPM group is preserved untouched.

Closes #2015

🤖 Generated with [Claude Code](https://claude.com/claude-code)