### PR TITLE
feat(trusty-mpm): in-place relaunch current session + on-exit hint (#2023 C+D)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -70,6 +70,17 @@ pub(crate) enum PickerDecision {
 /// `guided_non_tty_gate_returns_false_skips_stdin`,
 /// `guided_fallback_never_pollutes_github_git_checkout` (#1724).
 pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> anyhow::Result<()> {
+    // #2023 component C: an in-pane relaunch takes priority over EVERYTHING
+    // below — project detection, the picker, the daemon-unreachable fallback.
+    // `TM_MANAGED_SESSION_ID` (exported by #2023 component B into the pane's
+    // shell) only resolves to a known managed session when bare `tm` is
+    // literally running inside that session's own pane after its runtime
+    // exited; any other case (unset, blank, stale/unknown to the daemon)
+    // falls through to the ordinary guided default below.
+    if let Some(result) = super::guided_inplace::try_inplace_relaunch(client, url).await {
+        return result;
+    }
+
     let cwd = std::env::current_dir().context("cannot resolve current directory")?;
     let workdir = cwd.to_string_lossy().to_string();
     eprintln!("tm: no subcommand — using guided default for {workdir}");

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -14,20 +14,47 @@
 //!
 //! What: [`try_inplace_relaunch`] is the top-level entry point `guided::
 //! run_guided_default` calls FIRST, before any project detection or picker
-//! logic. [`plan_inplace`] is the pure decision (env var present AND resolves
-//! to a known managed-session record → [`super::guided_resume::ResumeAction::
-//! InPlace`]; otherwise `None`, meaning "fall through to the normal guided
-//! flow"). The daemon round-trips ([`fetch_managed_session`],
+//! logic. [`plan_inplace`] is the pure decision (env var present AND the
+//! fetched record's state is `"stopped"` → [`super::guided_resume::
+//! ResumeAction::InPlace`]; otherwise `None`, meaning "fall through to the
+//! normal guided flow"). The daemon round-trips ([`fetch_managed_session`],
 //! [`reactivate_managed_session`]) and the process-replacing exec
-//! ([`exec_claude_in_place`]) are the I/O driver.
+//! ([`exec_claude_in_place`]) are the I/O driver, sequenced by
+//! [`run_inplace_relaunch`] as: resolve the `claude` binary + build the resume
+//! command (pure, local — can fail on a missing binary before anything is
+//! mutated) → reactivate on the daemon (network — a 404/409/unreachable
+//! daemon ABORTS the whole in-place path and falls through to the picker,
+//! never exec'ing against an unconfirmed record) → exec.
 //!
-//! Test: `plan_inplace_*` cover the pure decision; the I/O path (HTTP calls,
-//! `exec`) is not unit-tested here — it requires a live daemon and a real
-//! `claude` binary, mirroring the rest of the guided-resume I/O surface.
+//! Why the ordering matters (safety boundary, code-critic WARN on #2027): a
+//! stale/leaked `TM_MANAGED_SESSION_ID` (e.g. inherited into an unrelated
+//! subshell) must never cause this process to chdir+exec `claude` into the
+//! wrong workspace. Two gates enforce that: (1) [`plan_inplace`] only selects
+//! `InPlace` when the fetched record's state is CONFIRMED `"stopped"` — an
+//! Active/Errored/Decommissioned/unresolved id all fall through to the
+//! ordinary picker; (2) the daemon's own `mark_reactivated` Stopped-only guard
+//! is honored by actually checking the reactivate response — a 404/409/network
+//! failure aborts rather than proceeding to exec regardless.
+//!
+//! Test: `plan_inplace_*` cover the pure decision; `reactivate_managed_session`'s
+//! success/409/404 outcomes are exercised against a local one-shot `TcpListener`
+//! mock (#2027, mirroring `core::sm::providers`' mock convention — no external
+//! mock-server crate); the full exec path is not unit-tested — it requires a
+//! live daemon and a real `claude` binary, mirroring the rest of the
+//! guided-resume I/O surface.
 
 use anyhow::Context as _;
 
 use super::guided_resume::ResumeAction;
+
+/// Per-request timeout for the in-pane reachability probes (GET existence
+/// check + POST reactivate), matching the 2s daemon-reachability convention
+/// used elsewhere in this binary (`pm_guard.rs`, `misc.rs`'s hook relay).
+///
+/// Why: this path runs on EVERY bare `tm` invocation inside a managed pane —
+/// a hung daemon must not add a long stall before falling through to the
+/// ordinary guided default.
+const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Environment variable exported into a managed pane's shell (#2023 B) that
 /// identifies which managed session bare `tm`, run after `claude` exits,
@@ -53,17 +80,27 @@ fn read_env_managed_session_id() -> Option<String> {
 /// relaunch (#2023 component C).
 ///
 /// Why: the actual daemon lookup ("does this id resolve to a known managed
-/// session?") is I/O; separating the DECISION from the lookup makes the
-/// decision itself exhaustively unit-testable.
+/// session, and is it actually `Stopped`?") is I/O; separating the DECISION
+/// from the lookup makes the decision itself exhaustively unit-testable.
+/// Folding the Stopped-state check in HERE (rather than trusting the daemon's
+/// `mark_reactivated` guard alone) closes the hijack window a code-critic WARN
+/// flagged on #2027: a resolved-but-`Active`/`Errored`/`Decommissioned` record
+/// (e.g. from a leaked/stale env var pointing at some OTHER session) must fall
+/// through to the ordinary picker, not attempt an in-place `exec`.
 /// What: `Some(ResumeAction::InPlace)` when `env_session_id` is `Some` AND
-/// `resolves` is `true`; `None` otherwise — covering both "no env var" and
-/// "env var present but stale/unknown to the daemon" (guard case), each of
-/// which must fall through to the ordinary guided picker rather than error.
-/// Test: `plan_inplace_selected_when_env_set_and_resolves`,
+/// `record_state` is `Some("stopped")`; `None` otherwise — covering "no env
+/// var", "env var present but id unknown to the daemon" (`record_state` is
+/// `None`), and "id resolves but is NOT `Stopped`" — every one of which must
+/// fall through to the ordinary guided picker rather than error.
+/// Test: `plan_inplace_selected_when_env_set_and_stopped`,
 /// `plan_inplace_none_when_env_absent`,
-/// `plan_inplace_none_when_env_set_but_unresolved`.
-pub(crate) fn plan_inplace(env_session_id: Option<&str>, resolves: bool) -> Option<ResumeAction> {
-    (env_session_id.is_some() && resolves).then_some(ResumeAction::InPlace)
+/// `plan_inplace_none_when_env_set_but_unresolved`,
+/// `plan_inplace_none_when_resolved_but_not_stopped`.
+pub(crate) fn plan_inplace(
+    env_session_id: Option<&str>,
+    record_state: Option<&str>,
+) -> Option<ResumeAction> {
+    (env_session_id.is_some() && record_state == Some("stopped")).then_some(ResumeAction::InPlace)
 }
 
 /// GET `/api/v1/sessions/managed/{id}` — resolve the env-supplied id to a record.
@@ -82,7 +119,7 @@ async fn fetch_managed_session(
 ) -> Option<trusty_mpm::client::ManagedSessionSummary> {
     let resp = client
         .get(format!("{url}/api/v1/sessions/managed/{id}"))
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(PROBE_TIMEOUT)
         .send()
         .await
         .ok()?;
@@ -95,34 +132,42 @@ async fn fetch_managed_session(
 /// POST `/api/v1/sessions/managed/{id}/reactivate` — flip Stopped -> Active
 /// in place, with no tmux mutation (#2023 C step 3).
 ///
-/// Why: the daemon record must reflect that the session is running again
-/// BEFORE this process execs into `claude` — otherwise `tm session ls` would
-/// keep showing the session as `Stopped` even though it is live.
-/// What: best-effort — a failure here is logged but does NOT block the
-/// relaunch (the operator's priority is getting `claude` back, not a
-/// perfectly synchronized daemon record; a stale `Stopped` record self-heals
-/// on the next reap tick or explicit `tm session info`).
+/// Why: the daemon's `mark_reactivated` is the second half of the
+/// Stopped-only safety guard — [`plan_inplace`] already checked the record
+/// was `Stopped` at fetch time, but that is a TOCTOU-prone read; the daemon
+/// re-validates atomically against its own current state and can legitimately
+/// refuse (404 the id vanished, 409 it is no longer `Stopped`, or the daemon
+/// may simply be unreachable). This result MUST be honored, not logged and
+/// ignored (code-critic WARN on #2027): exec'ing into `claude` after a
+/// refused/failed reactivate would let a hijacked/stale env var drive a
+/// relaunch the daemon never actually confirmed.
+/// What: returns `true` only on an HTTP 2xx response — the daemon record IS
+/// now `Active`. Returns `false` on any other outcome (4xx/5xx or a network
+/// error), each logged with the concrete reason; the caller ABORTS the
+/// in-place path on `false` and falls through to the ordinary guided picker.
 /// Test: I/O path; not unit-tested (requires a live daemon).
-async fn reactivate_managed_session(client: &reqwest::Client, url: &str, id: &str) {
+async fn reactivate_managed_session(client: &reqwest::Client, url: &str, id: &str) -> bool {
     let result = client
         .post(format!("{url}/api/v1/sessions/managed/{id}/reactivate"))
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(PROBE_TIMEOUT)
         .send()
         .await;
     match result {
-        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) if resp.status().is_success() => true,
         Ok(resp) => {
             let status = resp.status();
             eprintln!(
-                "tm: warning: daemon returned {status} reactivating session {id} \
-                 (non-fatal — relaunching anyway)"
+                "tm: daemon refused to reactivate session {id} ({status}) — \
+                 aborting in-place relaunch, falling back to the guided picker"
             );
+            false
         }
         Err(e) => {
             eprintln!(
-                "tm: warning: could not reach daemon to reactivate session {id}: {e} \
-                 (non-fatal — relaunching anyway)"
+                "tm: could not reach daemon to reactivate session {id}: {e} — \
+                 aborting in-place relaunch, falling back to the guided picker"
             );
+            false
         }
     }
 }
@@ -157,41 +202,80 @@ fn exec_claude_in_place(mut cmd: std::process::Command) -> anyhow::Result<()> {
     std::process::exit(status.code().unwrap_or(1));
 }
 
+/// The result of [`run_inplace_relaunch`] — distinguishes a hard failure
+/// (surfaced to the operator, non-zero exit) from a safety-gate abort (must
+/// fall through to the ordinary picker exactly like an unresolved id).
+///
+/// Why: the daemon's reactivate response MUST be honored (#2027 code-critic
+/// WARN) — a refused/failed reactivate is NOT a hard error to report and
+/// exit on, it is "this in-place attempt is not safe to proceed with,"
+/// which is exactly the same outcome as [`plan_inplace`] returning `None`.
+/// Separating the two outcomes lets [`try_inplace_relaunch`] route a
+/// reactivate failure back into the `None`/fall-through path instead of
+/// wrapping it in `Some(Err(..))`.
+enum InPlaceOutcome {
+    /// The exec attempt concluded (never returns on success; carries the
+    /// error when `exec` itself failed, or when command resolution failed
+    /// before any daemon mutation occurred).
+    Result(anyhow::Result<()>),
+    /// The daemon refused/failed to confirm reactivation — abort, fall
+    /// through to the ordinary guided picker (no exec attempted).
+    FallThrough,
+}
+
 /// Drive the full in-place relaunch once [`plan_inplace`] selected it.
 ///
 /// Why: separated from [`try_inplace_relaunch`] so the "should we take this
 /// path at all" decision and the "how do we execute it" mechanics are
 /// distinct, readable steps.
-/// What: (1) prints a one-line notice; (2) best-effort reactivates the record
-/// on the daemon (step 3 of #2023 C — see [`reactivate_managed_session`]);
-/// (3) resolves the workdir (`workspace_path` → `cwd` → the CLI's own current
-/// directory, since the pane's shell is already rooted at the workspace); (4)
-/// builds the resume argv via [`trusty_mpm::runtime::build_inplace_resume_command`]
-/// (the SAME `--resume`-existence-check → `--continue`/fresh-spawn fallback
-/// logic the tmux-pane resume path uses, #2013); (5) execs `claude` in place.
+/// What, IN ORDER (#2027 exec-ordering fix): (1) prints a one-line notice;
+/// (2) resolves the workdir and builds the resume argv via
+/// [`trusty_mpm::runtime::build_inplace_resume_command`] (the SAME
+/// `--resume`-existence-check → `--continue`/fresh-spawn fallback logic the
+/// tmux-pane resume path uses, #2013) — this is PURE/local (resolving the
+/// `claude` binary can fail with `BinaryNotFound`) and runs BEFORE any daemon
+/// mutation, so a missing binary never flips the record to a false `Active`;
+/// (3) reactivates the record on the daemon (step 3 of #2023 C — see
+/// [`reactivate_managed_session`]), immediately before exec — on a
+/// refused/failed reactivate this returns [`InPlaceOutcome::FallThrough`]
+/// rather than proceeding; (4) execs `claude` in place.
 /// Test: I/O path; not unit-tested (requires a live daemon + real `claude`).
 async fn run_inplace_relaunch(
     client: &reqwest::Client,
     url: &str,
     id: &str,
     record: trusty_mpm::client::ManagedSessionSummary,
-) -> anyhow::Result<()> {
+) -> InPlaceOutcome {
     eprintln!("tm: this pane belongs to managed session {id} — relaunching in place…");
 
-    reactivate_managed_session(client, url, id).await;
-
-    let cwd = record
+    let cwd = match record
         .workspace_path
         .or(record.cwd)
         .map(std::path::PathBuf::from)
         .or_else(|| std::env::current_dir().ok())
-        .context("cannot resolve a working directory for the in-place relaunch")?;
+        .context("cannot resolve a working directory for the in-place relaunch")
+    {
+        Ok(cwd) => cwd,
+        Err(e) => return InPlaceOutcome::Result(Err(e)),
+    };
 
-    let resume = trusty_mpm::runtime::build_inplace_resume_command(
+    let resume = match trusty_mpm::runtime::build_inplace_resume_command(
         &cwd,
         record.claude_session_id.as_deref(),
-    )
-    .map_err(|e| anyhow::anyhow!("cannot build in-place relaunch command: {e}"))?;
+    ) {
+        Ok(resume) => resume,
+        Err(e) => {
+            return InPlaceOutcome::Result(Err(anyhow::anyhow!(
+                "cannot build in-place relaunch command: {e}"
+            )));
+        }
+    };
+
+    // Reactivate immediately before exec — and HONOR the result (#2027):
+    // a refused/failed reactivate aborts rather than proceeding to exec.
+    if !reactivate_managed_session(client, url, id).await {
+        return InPlaceOutcome::FallThrough;
+    }
 
     let mut cmd = std::process::Command::new(&resume.claude_bin);
     cmd.args(&resume.args)
@@ -201,7 +285,7 @@ async fn run_inplace_relaunch(
         cmd.env("CLAUDE_CONFIG_DIR", dir);
     }
 
-    exec_claude_in_place(cmd)
+    InPlaceOutcome::Result(exec_claude_in_place(cmd))
 }
 
 /// Top-level entry point: try the in-place relaunch before any other bare-`tm`
@@ -212,13 +296,15 @@ async fn run_inplace_relaunch(
 /// different situation from "operator ran `tm` from a project directory to
 /// pick a session": here the session is already known and already running IN
 /// this exact pane.
-/// What: `None` — [`MANAGED_SESSION_ID_ENV`] is unset, blank, or does not
-/// resolve to a known managed session on the daemon — means "not this path;
-/// fall through to the ordinary guided default." `Some(result)` means this
-/// function took over: on success it never returns (`claude` replaced this
-/// process); on failure it returns `Some(Err(..))` so the caller can surface
-/// the error and exit non-zero rather than silently falling through to a
-/// picker that would confusingly re-offer this very session.
+/// What: `None` — [`MANAGED_SESSION_ID_ENV`] is unset, blank, does not resolve
+/// to a known managed session, resolves to a session NOT currently `Stopped`
+/// (see [`plan_inplace`]), or the daemon refuses/fails to confirm reactivation
+/// (see [`InPlaceOutcome::FallThrough`]) — means "not this path; fall through
+/// to the ordinary guided default." `Some(result)` means this function took
+/// over: on success it never returns (`claude` replaced this process); on
+/// failure it returns `Some(Err(..))` so the caller can surface the error and
+/// exit non-zero rather than silently falling through to a picker that would
+/// confusingly re-offer this very session.
 /// Test: `plan_inplace_*` cover the decision this function delegates to.
 pub(crate) async fn try_inplace_relaunch(
     client: &reqwest::Client,
@@ -226,9 +312,14 @@ pub(crate) async fn try_inplace_relaunch(
 ) -> Option<anyhow::Result<()>> {
     let env_id = read_env_managed_session_id()?;
     let record = fetch_managed_session(client, url, &env_id).await;
-    match plan_inplace(Some(&env_id), record.is_some()) {
+    let record_state = record.as_ref().map(|r| r.state.as_str());
+    match plan_inplace(Some(&env_id), record_state) {
         Some(ResumeAction::InPlace) => {
-            Some(run_inplace_relaunch(client, url, &env_id, record?).await)
+            let record = record.expect("plan_inplace only selects InPlace when record is Some");
+            match run_inplace_relaunch(client, url, &env_id, record).await {
+                InPlaceOutcome::Result(r) => Some(r),
+                InPlaceOutcome::FallThrough => None,
+            }
         }
         _ => None,
     }
@@ -236,29 +327,220 @@ pub(crate) async fn try_inplace_relaunch(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
     use super::*;
 
+    const TEST_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+    /// Spawn a background HTTP mock that replies `status_line` (+ empty JSON
+    /// body) to every connection, counting hits.
+    ///
+    /// Why: `reactivate_managed_session`'s status-code handling (#2027) needs
+    /// a real HTTP round-trip to exercise reqwest's response parsing; this
+    /// mirrors `core::sm::providers::test_support`'s "read the full request
+    /// before replying" mock convention (that helper is `pub(crate)` to the
+    /// `trusty-mpm` LIB crate and unreachable from this `bin/tm` BINARY crate
+    /// — a separate compilation unit — hence the small inline copy in
+    /// [`read_full_request`] below, rather than pulling in an external
+    /// mock-server dependency for one test file).
+    /// What: binds an ephemeral port, loops accepting connections, and for
+    /// each one increments the returned counter, drains the request, then
+    /// replies. Runs until the test's tokio runtime shuts down.
+    /// Test: used by `reactivate_*` and the command-build-ordering test.
+    async fn spawn_mock(status_line: &'static str) -> (String, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_task = hits.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                hits_task.fetch_add(1, Ordering::SeqCst);
+                read_full_request(&mut sock).await;
+                let body = "{}";
+                let resp = format!(
+                    "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        (format!("http://{addr}"), hits)
+    }
+
+    /// Read an entire HTTP/1.1 request (headers + any `Content-Length` body)
+    /// before the caller writes a response — avoids the connection-reset
+    /// flakiness a naive single `read` can cause (mirrors
+    /// `core::sm::providers::test_support::read_full_request`, unreachable
+    /// from this crate; see [`spawn_mock`]'s doc for why it is duplicated
+    /// here rather than shared).
+    async fn read_full_request(sock: &mut TcpStream) {
+        let mut buf: Vec<u8> = Vec::with_capacity(4096);
+        let mut chunk = [0u8; 4096];
+        let header_end = loop {
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+            match sock.read(&mut chunk).await {
+                Ok(0) => return,
+                Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                Err(_) => return,
+            }
+        };
+        let content_len: usize = String::from_utf8_lossy(&buf[..header_end])
+            .split("\r\n")
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.trim()
+                    .eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse().ok())?
+            })
+            .unwrap_or(0);
+        let want_total = header_end + content_len;
+        while buf.len() < want_total {
+            match sock.read(&mut chunk).await {
+                Ok(0) => return,
+                Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                Err(_) => return,
+            }
+        }
+    }
+
     #[test]
-    fn plan_inplace_selected_when_env_set_and_resolves() {
+    fn plan_inplace_selected_when_env_set_and_stopped() {
         assert_eq!(
-            plan_inplace(Some("11111111-2222-3333-4444-555555555555"), true),
+            plan_inplace(Some(TEST_ID), Some("stopped")),
             Some(ResumeAction::InPlace)
         );
     }
 
     #[test]
     fn plan_inplace_none_when_env_absent() {
-        assert_eq!(plan_inplace(None, true), None);
-        assert_eq!(plan_inplace(None, false), None);
+        assert_eq!(plan_inplace(None, Some("stopped")), None);
+        assert_eq!(plan_inplace(None, None), None);
     }
 
     #[test]
     fn plan_inplace_none_when_env_set_but_unresolved() {
         // Guard case (#2023 C item 4): a stale/unknown id must fall through to
         // the ordinary guided picker rather than error.
+        assert_eq!(plan_inplace(Some(TEST_ID), None), None);
+    }
+
+    #[test]
+    fn plan_inplace_none_when_resolved_but_not_stopped() {
+        // Safety-boundary regression guard (#2027 code-critic WARN): a
+        // resolved-but-non-Stopped record (Active/Errored/Decommissioned —
+        // e.g. from a leaked/stale TM_MANAGED_SESSION_ID pointing at some
+        // OTHER, currently-running session) must NOT select the in-place
+        // path; it must fall through to the ordinary guided picker exactly
+        // like an unresolved id.
+        for state in ["active", "errored", "provisioning", "decommissioned"] {
+            assert_eq!(
+                plan_inplace(Some(TEST_ID), Some(state)),
+                None,
+                "state '{state}' must not select InPlace"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn reactivate_confirms_success_on_2xx() {
+        let (url, hits) = spawn_mock("HTTP/1.1 200 OK").await;
+        let client = reqwest::Client::new();
+        let ok = reactivate_managed_session(&client, &url, TEST_ID).await;
+        assert!(ok, "a 2xx response must confirm reactivation");
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn reactivate_aborts_on_409_conflict() {
+        // #2027 HIGH fix: a 409 (session not Stopped on the daemon's own
+        // re-check) must NOT be treated as confirmed — the caller must abort
+        // rather than proceeding to exec.
+        let (url, _hits) = spawn_mock("HTTP/1.1 409 Conflict").await;
+        let client = reqwest::Client::new();
+        let ok = reactivate_managed_session(&client, &url, TEST_ID).await;
+        assert!(!ok, "409 must NOT be treated as a confirmed reactivate");
+    }
+
+    #[tokio::test]
+    async fn reactivate_aborts_on_404_not_found() {
+        let (url, _hits) = spawn_mock("HTTP/1.1 404 Not Found").await;
+        let client = reqwest::Client::new();
+        let ok = reactivate_managed_session(&client, &url, TEST_ID).await;
+        assert!(!ok, "404 must NOT be treated as a confirmed reactivate");
+    }
+
+    #[tokio::test]
+    async fn reactivate_aborts_on_unreachable_daemon() {
+        // Nothing listens on a privileged low port -> immediate connection
+        // refused, exercising the network-error branch without waiting out
+        // the full PROBE_TIMEOUT.
+        let client = reqwest::Client::new();
+        let ok = reactivate_managed_session(&client, "http://127.0.0.1:1", TEST_ID).await;
+        assert!(
+            !ok,
+            "an unreachable daemon must NOT be treated as a confirmed reactivate"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_inplace_relaunch_never_reactivates_when_command_build_fails() {
+        // #2027 MEDIUM fix: command resolution (resolve `claude` + build the
+        // resume argv) must happen BEFORE the daemon is ever asked to
+        // reactivate the record, so a missing-binary failure never flips a
+        // Stopped record to a false Active.
+        //
+        // This ordering guarantee can only be exercised end-to-end on a
+        // machine where `claude` is NOT resolvable — otherwise
+        // build_inplace_resume_command succeeds and this test would be
+        // vacuously true. Probe first; skip (don't fail) when claude IS
+        // present, mirroring the inverse of the "skip when claude absent"
+        // convention used throughout runtime::claude_code's own test suite.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        if trusty_mpm::runtime::build_inplace_resume_command(tmp.path(), None).is_ok() {
+            return;
+        }
+
+        let (url, hits) = spawn_mock("HTTP/1.1 200 OK").await;
+        let record = trusty_mpm::client::ManagedSessionSummary {
+            id: TEST_ID.to_string(),
+            name: "tm-test".to_string(),
+            state: "stopped".to_string(),
+            workspace_path: Some(tmp.path().to_string_lossy().to_string()),
+            repo_url: None,
+            branch: None,
+            created_at: None,
+            last_activity_at: None,
+            pending_decision: None,
+            proposed_default: None,
+            source_id: None,
+            task: None,
+            cwd: None,
+            claude_session_id: None,
+        };
+        let client = reqwest::Client::new();
+
+        let outcome = run_inplace_relaunch(&client, &url, TEST_ID, record).await;
+
+        assert!(
+            matches!(outcome, InPlaceOutcome::Result(Err(_))),
+            "a command-build failure must surface as a hard error, not FallThrough"
+        );
         assert_eq!(
-            plan_inplace(Some("11111111-2222-3333-4444-555555555555"), false),
-            None
+            hits.load(Ordering::SeqCst),
+            0,
+            "reactivate must NEVER be called when command resolution fails first (#2027)"
         );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -1,0 +1,264 @@
+//! Bare-`tm` in-pane relaunch of the CURRENT managed session (#2023 component C).
+//!
+//! Why: components A and B (already landed) leave a managed pane alive as a
+//! bare shell when its `claude` process exits, with `TM_MANAGED_SESSION_ID`
+//! exported into that shell's live environment. If the operator then types
+//! bare `tm` from inside THAT pane, the ordinary guided flow would be wrong on
+//! two counts: (1) it would show a picker/attach flow for a session the
+//! operator is already sitting inside, and (2) if it happened to select
+//! "restart", the daemon's `/resume` route unconditionally kills any surviving
+//! tmux session and creates a fresh one — which would tear down the very pane
+//! the operator is running `tm` from. This module detects that specific
+//! situation and relaunches `claude` directly back into the CURRENT process's
+//! pane via `exec`, bypassing the daemon kill+recreate path entirely.
+//!
+//! What: [`try_inplace_relaunch`] is the top-level entry point `guided::
+//! run_guided_default` calls FIRST, before any project detection or picker
+//! logic. [`plan_inplace`] is the pure decision (env var present AND resolves
+//! to a known managed-session record → [`super::guided_resume::ResumeAction::
+//! InPlace`]; otherwise `None`, meaning "fall through to the normal guided
+//! flow"). The daemon round-trips ([`fetch_managed_session`],
+//! [`reactivate_managed_session`]) and the process-replacing exec
+//! ([`exec_claude_in_place`]) are the I/O driver.
+//!
+//! Test: `plan_inplace_*` cover the pure decision; the I/O path (HTTP calls,
+//! `exec`) is not unit-tested here — it requires a live daemon and a real
+//! `claude` binary, mirroring the rest of the guided-resume I/O surface.
+
+use anyhow::Context as _;
+
+use super::guided_resume::ResumeAction;
+
+/// Environment variable exported into a managed pane's shell (#2023 B) that
+/// identifies which managed session bare `tm`, run after `claude` exits,
+/// belongs to.
+const MANAGED_SESSION_ID_ENV: &str = "TM_MANAGED_SESSION_ID";
+
+/// Read [`MANAGED_SESSION_ID_ENV`] from the environment, treating a blank
+/// value the same as absent.
+///
+/// Why: an exported-but-empty env var (never expected in practice, but cheap
+/// to guard) must not be mistaken for a real session id.
+/// What: `std::env::var` filtered to non-blank (after trim).
+/// Test: exercised indirectly via [`plan_inplace`]'s tests (which take the
+/// already-read `Option<&str>` directly, keeping the env read itself outside
+/// the pure/testable seam).
+fn read_env_managed_session_id() -> Option<String> {
+    std::env::var(MANAGED_SESSION_ID_ENV)
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+}
+
+/// Decide whether bare `tm`'s in-pane environment signals an in-place
+/// relaunch (#2023 component C).
+///
+/// Why: the actual daemon lookup ("does this id resolve to a known managed
+/// session?") is I/O; separating the DECISION from the lookup makes the
+/// decision itself exhaustively unit-testable.
+/// What: `Some(ResumeAction::InPlace)` when `env_session_id` is `Some` AND
+/// `resolves` is `true`; `None` otherwise — covering both "no env var" and
+/// "env var present but stale/unknown to the daemon" (guard case), each of
+/// which must fall through to the ordinary guided picker rather than error.
+/// Test: `plan_inplace_selected_when_env_set_and_resolves`,
+/// `plan_inplace_none_when_env_absent`,
+/// `plan_inplace_none_when_env_set_but_unresolved`.
+pub(crate) fn plan_inplace(env_session_id: Option<&str>, resolves: bool) -> Option<ResumeAction> {
+    (env_session_id.is_some() && resolves).then_some(ResumeAction::InPlace)
+}
+
+/// GET `/api/v1/sessions/managed/{id}` — resolve the env-supplied id to a record.
+///
+/// Why: the in-place path must confirm the daemon still knows this session
+/// (the env var can go stale — e.g. the record was decommissioned after the
+/// pane was left alive) before reactivating/relaunching it.
+/// What: `Some(summary)` on HTTP 2xx, `None` on any failure (network error,
+/// 404, non-2xx, or an undeserializable body) — every failure mode folds into
+/// the same "fall through to the picker" outcome via [`plan_inplace`].
+/// Test: I/O path; not unit-tested (requires a live daemon).
+async fn fetch_managed_session(
+    client: &reqwest::Client,
+    url: &str,
+    id: &str,
+) -> Option<trusty_mpm::client::ManagedSessionSummary> {
+    let resp = client
+        .get(format!("{url}/api/v1/sessions/managed/{id}"))
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    resp.json().await.ok()
+}
+
+/// POST `/api/v1/sessions/managed/{id}/reactivate` — flip Stopped -> Active
+/// in place, with no tmux mutation (#2023 C step 3).
+///
+/// Why: the daemon record must reflect that the session is running again
+/// BEFORE this process execs into `claude` — otherwise `tm session ls` would
+/// keep showing the session as `Stopped` even though it is live.
+/// What: best-effort — a failure here is logged but does NOT block the
+/// relaunch (the operator's priority is getting `claude` back, not a
+/// perfectly synchronized daemon record; a stale `Stopped` record self-heals
+/// on the next reap tick or explicit `tm session info`).
+/// Test: I/O path; not unit-tested (requires a live daemon).
+async fn reactivate_managed_session(client: &reqwest::Client, url: &str, id: &str) {
+    let result = client
+        .post(format!("{url}/api/v1/sessions/managed/{id}/reactivate"))
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await;
+    match result {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => {
+            let status = resp.status();
+            eprintln!(
+                "tm: warning: daemon returned {status} reactivating session {id} \
+                 (non-fatal — relaunching anyway)"
+            );
+        }
+        Err(e) => {
+            eprintln!(
+                "tm: warning: could not reach daemon to reactivate session {id}: {e} \
+                 (non-fatal — relaunching anyway)"
+            );
+        }
+    }
+}
+
+/// Replace the CURRENT process image with `cmd` (Unix `exec`), never returning
+/// on success.
+///
+/// Why: the in-place relaunch must put `claude` directly into THIS process's
+/// controlling terminal/pane — spawning a child and waiting would leave the
+/// `tm` process (and an extra layer of signal/Ctrl-C indirection) sitting
+/// between the pane and `claude`, unlike every other managed-session launch
+/// path where the daemon's tmux pane runs `claude` as the pane's direct child.
+/// What: Unix — `std::os::unix::process::CommandExt::exec` replaces the
+/// process image; a return from `exec` is always a failure (it never returns
+/// on success), so the error is propagated as `Err`. Non-Unix — no `exec`
+/// syscall exists; falls back to spawn+wait and exits this process with the
+/// child's status code, which is observably equivalent from the terminal's
+/// perspective (just one extra, short-lived process in between).
+/// Test: not unit-tested — replacing/exiting the test process is not
+/// observable from within the test itself.
+#[cfg(unix)]
+fn exec_claude_in_place(mut cmd: std::process::Command) -> anyhow::Result<()> {
+    use std::os::unix::process::CommandExt as _;
+    let err = cmd.exec();
+    Err(anyhow::anyhow!("failed to exec claude in place: {err}"))
+}
+
+/// Non-Unix fallback for [`exec_claude_in_place`] (see its doc for rationale).
+#[cfg(not(unix))]
+fn exec_claude_in_place(mut cmd: std::process::Command) -> anyhow::Result<()> {
+    let status = cmd.status().context("failed to run claude")?;
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+/// Drive the full in-place relaunch once [`plan_inplace`] selected it.
+///
+/// Why: separated from [`try_inplace_relaunch`] so the "should we take this
+/// path at all" decision and the "how do we execute it" mechanics are
+/// distinct, readable steps.
+/// What: (1) prints a one-line notice; (2) best-effort reactivates the record
+/// on the daemon (step 3 of #2023 C — see [`reactivate_managed_session`]);
+/// (3) resolves the workdir (`workspace_path` → `cwd` → the CLI's own current
+/// directory, since the pane's shell is already rooted at the workspace); (4)
+/// builds the resume argv via [`trusty_mpm::runtime::build_inplace_resume_command`]
+/// (the SAME `--resume`-existence-check → `--continue`/fresh-spawn fallback
+/// logic the tmux-pane resume path uses, #2013); (5) execs `claude` in place.
+/// Test: I/O path; not unit-tested (requires a live daemon + real `claude`).
+async fn run_inplace_relaunch(
+    client: &reqwest::Client,
+    url: &str,
+    id: &str,
+    record: trusty_mpm::client::ManagedSessionSummary,
+) -> anyhow::Result<()> {
+    eprintln!("tm: this pane belongs to managed session {id} — relaunching in place…");
+
+    reactivate_managed_session(client, url, id).await;
+
+    let cwd = record
+        .workspace_path
+        .or(record.cwd)
+        .map(std::path::PathBuf::from)
+        .or_else(|| std::env::current_dir().ok())
+        .context("cannot resolve a working directory for the in-place relaunch")?;
+
+    let resume = trusty_mpm::runtime::build_inplace_resume_command(
+        &cwd,
+        record.claude_session_id.as_deref(),
+    )
+    .map_err(|e| anyhow::anyhow!("cannot build in-place relaunch command: {e}"))?;
+
+    let mut cmd = std::process::Command::new(&resume.claude_bin);
+    cmd.args(&resume.args)
+        .current_dir(&cwd)
+        .env_remove("ANTHROPIC_API_KEY");
+    if let Some(dir) = &resume.config_dir {
+        cmd.env("CLAUDE_CONFIG_DIR", dir);
+    }
+
+    exec_claude_in_place(cmd)
+}
+
+/// Top-level entry point: try the in-place relaunch before any other bare-`tm`
+/// logic runs (#2023 component C).
+///
+/// Why: `guided::run_guided_default` must check this FIRST — before project
+/// detection, before the picker — because the in-pane case is a completely
+/// different situation from "operator ran `tm` from a project directory to
+/// pick a session": here the session is already known and already running IN
+/// this exact pane.
+/// What: `None` — [`MANAGED_SESSION_ID_ENV`] is unset, blank, or does not
+/// resolve to a known managed session on the daemon — means "not this path;
+/// fall through to the ordinary guided default." `Some(result)` means this
+/// function took over: on success it never returns (`claude` replaced this
+/// process); on failure it returns `Some(Err(..))` so the caller can surface
+/// the error and exit non-zero rather than silently falling through to a
+/// picker that would confusingly re-offer this very session.
+/// Test: `plan_inplace_*` cover the decision this function delegates to.
+pub(crate) async fn try_inplace_relaunch(
+    client: &reqwest::Client,
+    url: &str,
+) -> Option<anyhow::Result<()>> {
+    let env_id = read_env_managed_session_id()?;
+    let record = fetch_managed_session(client, url, &env_id).await;
+    match plan_inplace(Some(&env_id), record.is_some()) {
+        Some(ResumeAction::InPlace) => {
+            Some(run_inplace_relaunch(client, url, &env_id, record?).await)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_inplace_selected_when_env_set_and_resolves() {
+        assert_eq!(
+            plan_inplace(Some("11111111-2222-3333-4444-555555555555"), true),
+            Some(ResumeAction::InPlace)
+        );
+    }
+
+    #[test]
+    fn plan_inplace_none_when_env_absent() {
+        assert_eq!(plan_inplace(None, true), None);
+        assert_eq!(plan_inplace(None, false), None);
+    }
+
+    #[test]
+    fn plan_inplace_none_when_env_set_but_unresolved() {
+        // Guard case (#2023 C item 4): a stale/unknown id must fall through to
+        // the ordinary guided picker rather than error.
+        assert_eq!(
+            plan_inplace(Some("11111111-2222-3333-4444-555555555555"), false),
+            None
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
@@ -58,15 +58,23 @@ pub(crate) fn is_zombie(state: &str, tmux_live: bool) -> bool {
 /// pure function makes the control flow — including the new zombie
 /// auto-reconcile path (#2001) — unit-testable without a daemon, tmux, or HTTP.
 /// The I/O driver simply matches on the returned variant.
-/// What: three variants cover every case the picker can hand a resume:
+/// What: four variants cover every case bare `tm` can hand a resume:
+///   • [`ResumeAction::InPlace`] — bare `tm` is running INSIDE the pane of the
+///     managed session named by `TM_MANAGED_SESSION_ID`, whose runtime already
+///     exited (#2023 A/B); relaunch it in place via direct `exec`, never the
+///     daemon kill+recreate path (#2023 C). Takes priority over everything
+///     below — see [`try_inplace_relaunch`].
 ///   • [`ResumeAction::Attach`] — a live runtime; attach directly.
 ///   • [`ResumeAction::Restart`] — Stopped/Errored; POST `/resume` then attach.
 ///   • [`ResumeAction::ReconcileThenRestart`] — zombie (active/provisioning but
 ///     tmux gone); POST `/runtime-stop` to reset the record to Stopped, THEN
 ///     POST `/resume` then attach.
-/// Test: `guided_resume_plan_*` in `tests_behavior_c_tests.rs`.
+/// Test: `guided_resume_plan_*` in `tests_behavior_c_tests.rs`;
+/// `plan_inplace_*` in this module.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ResumeAction {
+    /// In-pane relaunch (#2023 C): see the variant doc above.
+    InPlace,
     /// Runtime is live — attach directly, no daemon round-trip.
     Attach,
     /// Stopped/Errored — restart via the daemon `/resume` endpoint, then attach.

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod delete;
 pub(crate) mod first_run;
 pub(crate) mod guided;
 pub(crate) mod guided_autostart;
+pub(crate) mod guided_inplace;
 pub(crate) mod guided_launch;
 pub(crate) mod guided_launch_sse;
 pub(crate) mod guided_resume;

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -391,6 +391,7 @@ fn make_session(
         source_id: None,
         task: None,
         cwd: None,
+        claude_session_id: None,
     }
 }
 

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -416,6 +416,13 @@ pub struct ManagedSessionSummary {
     /// Old daemon responses without the field deserialize as `None`.
     #[serde(default)]
     pub cwd: Option<String>,
+    /// Captured Claude Code conversation id, if any (additive; #2023 C).
+    ///
+    /// Why: the bare-`tm` in-pane relaunch path needs this to build the same
+    /// `--resume <id>` command the tmux-pane resume path uses. `None` for
+    /// sessions with no captured conversation id or predating this field.
+    #[serde(default)]
+    pub claude_session_id: Option<String>,
 }
 
 /// Wrapper for `GET /api/v1/sessions/managed` (the list endpoint).

--- a/crates/trusty-mpm/src/client/resolver.rs
+++ b/crates/trusty-mpm/src/client/resolver.rs
@@ -183,6 +183,7 @@ mod tests {
             source_id: None,
             task: None,
             cwd: None,
+            claude_session_id: None,
         };
         let items = vec![summary("m-1", "tmpm-red-owl"), summary("m-2", "api")];
         assert_eq!(

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -120,8 +120,8 @@ use super::managed_routes::{
     adopt_existing_session, answer_session_decision, decommission_ephemeral_route,
     decommission_managed_session, delete_managed_session, fleet_by_project_route, get_attach_cmd,
     get_managed_session, get_session_activity, list_managed_sessions, prune_managed_route,
-    prune_worktrees_route, resume_managed_session, send_to_session, spawn_session,
-    stop_managed_session, stop_managed_session_runtime,
+    prune_worktrees_route, reactivate_managed_session, resume_managed_session, send_to_session,
+    spawn_session, stop_managed_session, stop_managed_session_runtime,
 };
 
 /// Typed HTTP response bodies for every endpoint.
@@ -273,6 +273,13 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .route(
             "/api/v1/sessions/managed/{id}/resume",
             post(resume_managed_session),
+        )
+        // #2023 C: bare-`tm` in-pane relaunch flips Stopped -> Active in place,
+        // with NO tmux mutation — distinct from `/resume` above, which always
+        // kills any surviving tmux session and creates a fresh one.
+        .route(
+            "/api/v1/sessions/managed/{id}/reactivate",
+            post(reactivate_managed_session),
         )
         .route(
             "/api/v1/sessions/managed/{id}/decommission",

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -24,7 +24,6 @@ use tracing::warn;
 
 use crate::daemon::state::DaemonState;
 use crate::runtime::RuntimeKind;
-use crate::session_manager::{ManagedSessionId, SessionRecord};
 
 pub mod activity;
 mod fleet;
@@ -34,6 +33,8 @@ pub mod inproject_hygiene;
 mod lifecycle;
 mod mcp_spawn_gate;
 pub mod prune;
+mod reactivate;
+mod summary;
 pub use activity::{ActivityResponse, get_session_activity};
 pub use fleet::{FleetByProjectResponse, FleetProjectGroup, fleet_by_project_route};
 pub use front_gate::{
@@ -46,6 +47,9 @@ pub use lifecycle::{
 pub use prune::{
     PruneRequest, decommission_ephemeral_route, prune_managed_route, prune_worktrees_route,
 };
+pub use reactivate::reactivate_managed_session;
+pub use summary::record_to_json;
+use summary::{attach_cmd_for, parse_id, record_to_summary};
 
 // ── Request / Response shapes ─────────────────────────────────────────────────
 
@@ -217,6 +221,16 @@ pub struct SessionSummary {
     /// Working directory for the session (additive; absent for legacy records).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+    /// Captured Claude Code conversation id, if any (additive; #2023 C).
+    ///
+    /// Why: the bare-`tm` in-pane relaunch path (#2023 component C) needs the
+    /// SAME `claude_session_id` the tmux-pane resume path uses for its
+    /// `--resume <id>` existence-check-and-fallback logic (#2013) — exposing it
+    /// on the wire lets the CLI build the identical command without a second,
+    /// divergent lookup. `None` for sessions where no `SessionStart` capture has
+    /// landed yet, or for legacy records predating the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_session_id: Option<String>,
 }
 
 /// Response body for POST /api/v1/sessions/managed/{id}/decommission.
@@ -343,93 +357,6 @@ pub struct AnswerResponse {
 pub struct AttachCmdResponse {
     /// tmux attach command string.
     pub attach_cmd: String,
-}
-
-/// Serialize a [`SessionRecord`] to the flat JSON shape the MCP tools return.
-///
-/// Why: the MCP tools return JSON values (not axum responses); reusing the same
-/// field set as [`SpawnResponse`]/[`SessionSummary`] keeps the MCP and HTTP
-/// payloads consistent for the driver skill. `source_id` is included so MCP
-/// callers can filter or reconnect by project identity, matching what the HTTP
-/// `GET /api/v1/sessions/managed` path already exposes (#1733).
-/// What: maps the record to a JSON object including the derived `attach_cmd`
-/// and `source_id` (null when the session has no project identity).
-/// Test: `serializers_include_source_id` unit test in this module; also covered
-/// by `crate::daemon::mcp_session` tests that assert echoed fields.
-pub fn record_to_json(r: &SessionRecord) -> serde_json::Value {
-    serde_json::json!({
-        "id": r.id.to_string(),
-        "name": r.tmux_name,
-        "state": r.state.to_string(),
-        "workspace_path": r.workspace_path.as_ref().map(|p| p.to_string_lossy().to_string()),
-        "cwd": r.cwd.to_string_lossy().to_string(),
-        "task": r.task,
-        "repo_url": r.repo_url,
-        "branch": r.branch,
-        "created_at": r.created_at.to_rfc3339(),
-        "last_activity_at": r.last_activity_at.map(|t| t.to_rfc3339()),
-        "attach_cmd": attach_cmd_for(&r.tmux_name),
-        "runtime": r.runtime.as_str(),
-        "pending_decision": r.pending_decision,
-        "proposed_default": r.proposed_default,
-        "source_id": r.source_id,
-    })
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-/// Convert a [`SessionRecord`] into a wire [`SessionSummary`].
-///
-/// Why: the API exposes a flat, string-typed summary so clients don't depend on
-/// the internal record shape.
-/// What: maps every record field to its serialized form.
-/// Test: covered by the list/get handler tests.
-pub(super) fn record_to_summary(r: &SessionRecord) -> SessionSummary {
-    SessionSummary {
-        id: r.id.to_string(),
-        name: r.tmux_name.clone(),
-        state: r.state.to_string(),
-        workspace_path: r
-            .workspace_path
-            .as_ref()
-            .map(|p| p.to_string_lossy().to_string()),
-        repo_url: r.repo_url.clone(),
-        branch: r.branch.clone(),
-        created_at: r.created_at.to_rfc3339(),
-        last_activity_at: r.last_activity_at.map(|t| t.to_rfc3339()),
-        pending_decision: r.pending_decision.clone(),
-        proposed_default: r.proposed_default.clone(),
-        source_id: r.source_id.clone(),
-        task: Some(r.task.clone()),
-        cwd: Some(r.cwd.to_string_lossy().to_string()),
-    }
-}
-
-/// Build the tmux attach command string for a session.
-///
-/// Why: clients need the exact attach command without hardcoding the convention.
-/// What: returns `tmux attach-session -t <name>`.
-/// Test: attach-cmd handler test.
-fn attach_cmd_for(tmux_name: &str) -> String {
-    format!("tmux attach-session -t {tmux_name}")
-}
-
-/// Parse a UUID path segment into a [`ManagedSessionId`].
-///
-/// Why: handlers receive the id as a string; an invalid UUID must produce a 400
-/// rather than a 404 or panic.
-/// What: parses the string into a UUID, mapping failure to a `400` tuple.
-/// Test: covered by handler tests that pass an invalid id.
-fn parse_id(id_str: &str) -> Result<ManagedSessionId, (StatusCode, String)> {
-    id_str
-        .parse::<uuid::Uuid>()
-        .map(ManagedSessionId::from)
-        .map_err(|_| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("invalid session id: {id_str}"),
-            )
-        })
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────────

--- a/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
@@ -1,0 +1,60 @@
+//! POST /api/v1/sessions/managed/{id}/reactivate route handler (#2023 C).
+//!
+//! Why: `managed_routes/mod.rs` was at the 500-SLOC production cap; this
+//! route (and its doc comment) is extracted here, mirroring how `lifecycle.rs`
+//! and `activity.rs` already keep `mod.rs` under budget.
+//! What: one axum handler, `reactivate_managed_session`, that delegates to
+//! [`crate::session_manager::SessionManager::mark_reactivated`].
+//! Test: `mark_reactivated_flips_stopped_to_active`,
+//! `mark_reactivated_rejects_non_stopped` in `session_manager::reactivate_tests`.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+use crate::daemon::state::DaemonState;
+use crate::session_manager::ManagedError;
+
+use super::{parse_id, record_to_summary};
+
+/// POST /api/v1/sessions/managed/{id}/reactivate — flip Stopped -> Active IN
+/// PLACE, with NO tmux mutation (#2023 component C).
+///
+/// Why: `resume` (in `lifecycle.rs`) always kills any surviving tmux session
+/// and creates a fresh one — correct for the daemon-driven restart path, but
+/// WRONG for the bare-`tm` in-pane relaunch: the operator is running `tm` from
+/// inside the very pane `SessionManager::mark_runtime_exited_stopped` (#2023
+/// A) left alive, and is about to `exec` `claude` directly back into that SAME
+/// pane. This route gives that path a dedicated, non-destructive transition —
+/// [`crate::session_manager::SessionManager::mark_reactivated`] only flips the
+/// record's state.
+/// What: 404 when the id is unknown, 409 when the record is not currently
+/// `Stopped` (mirrors `resume_managed_session`'s typed-error → status
+/// mapping), 200 with the updated summary on success.
+/// Test: `mark_reactivated_flips_stopped_to_active`,
+/// `mark_reactivated_rejects_non_stopped` in `session_manager::reactivate_tests`.
+pub async fn reactivate_managed_session(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(id_str): AxumPath<String>,
+) -> impl IntoResponse {
+    let id = match parse_id(&id_str) {
+        Ok(id) => id,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
+    let mgr = state.session_manager().await;
+    match mgr.mark_reactivated(&id).await {
+        Ok(record) => Json(record_to_summary(&record)).into_response(),
+        Err(ManagedError::SessionNotFound(_)) => {
+            (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
+        }
+        Err(ManagedError::InvalidState(_, reason)) => {
+            (StatusCode::CONFLICT, reason).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -1,0 +1,105 @@
+//! Record → wire-shape conversion helpers shared across the managed-session
+//! route handlers.
+//!
+//! Why: `managed_routes/mod.rs` was at the 500-SLOC production cap; these
+//! conversion helpers are pure and self-contained, so extracting them (rather
+//! than a handler) keeps `mod.rs` focused on request/response shapes and
+//! routing while leaving every call site's import path unchanged (all three
+//! non-JSON helpers are re-exported through `mod.rs` at their original
+//! visibility).
+//! What: [`record_to_json`] (MCP wire shape, crate-public), [`record_to_summary`]
+//! (HTTP wire shape), [`attach_cmd_for`], and [`parse_id`].
+//! Test: `serializers_include_source_id` in `super::tests`; the handler tests
+//! throughout `managed_routes` exercise these indirectly.
+
+use axum::http::StatusCode;
+
+use crate::session_manager::{ManagedSessionId, SessionRecord};
+
+use super::SessionSummary;
+
+/// Serialize a [`SessionRecord`] to the flat JSON shape the MCP tools return.
+///
+/// Why: the MCP tools return JSON values (not axum responses); reusing the same
+/// field set as `SpawnResponse`/[`SessionSummary`] keeps the MCP and HTTP
+/// payloads consistent for the driver skill. `source_id` is included so MCP
+/// callers can filter or reconnect by project identity, matching what the HTTP
+/// `GET /api/v1/sessions/managed` path already exposes (#1733).
+/// What: maps the record to a JSON object including the derived `attach_cmd`
+/// and `source_id` (null when the session has no project identity).
+/// Test: `serializers_include_source_id` unit test in `super::tests`; also
+/// covered by `crate::daemon::mcp_session` tests that assert echoed fields.
+pub fn record_to_json(r: &SessionRecord) -> serde_json::Value {
+    serde_json::json!({
+        "id": r.id.to_string(),
+        "name": r.tmux_name,
+        "state": r.state.to_string(),
+        "workspace_path": r.workspace_path.as_ref().map(|p| p.to_string_lossy().to_string()),
+        "cwd": r.cwd.to_string_lossy().to_string(),
+        "task": r.task,
+        "repo_url": r.repo_url,
+        "branch": r.branch,
+        "created_at": r.created_at.to_rfc3339(),
+        "last_activity_at": r.last_activity_at.map(|t| t.to_rfc3339()),
+        "attach_cmd": attach_cmd_for(&r.tmux_name),
+        "runtime": r.runtime.as_str(),
+        "pending_decision": r.pending_decision,
+        "proposed_default": r.proposed_default,
+        "source_id": r.source_id,
+    })
+}
+
+/// Convert a [`SessionRecord`] into a wire [`SessionSummary`].
+///
+/// Why: the API exposes a flat, string-typed summary so clients don't depend on
+/// the internal record shape.
+/// What: maps every record field to its serialized form.
+/// Test: covered by the list/get handler tests.
+pub(super) fn record_to_summary(r: &SessionRecord) -> SessionSummary {
+    SessionSummary {
+        id: r.id.to_string(),
+        name: r.tmux_name.clone(),
+        state: r.state.to_string(),
+        workspace_path: r
+            .workspace_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string()),
+        repo_url: r.repo_url.clone(),
+        branch: r.branch.clone(),
+        created_at: r.created_at.to_rfc3339(),
+        last_activity_at: r.last_activity_at.map(|t| t.to_rfc3339()),
+        pending_decision: r.pending_decision.clone(),
+        proposed_default: r.proposed_default.clone(),
+        source_id: r.source_id.clone(),
+        task: Some(r.task.clone()),
+        cwd: Some(r.cwd.to_string_lossy().to_string()),
+        claude_session_id: r.claude_session_id.clone(),
+    }
+}
+
+/// Build the tmux attach command string for a session.
+///
+/// Why: clients need the exact attach command without hardcoding the convention.
+/// What: returns `tmux attach-session -t <name>`.
+/// Test: attach-cmd handler test.
+pub(super) fn attach_cmd_for(tmux_name: &str) -> String {
+    format!("tmux attach-session -t {tmux_name}")
+}
+
+/// Parse a UUID path segment into a [`ManagedSessionId`].
+///
+/// Why: handlers receive the id as a string; an invalid UUID must produce a 400
+/// rather than a 404 or panic.
+/// What: parses the string into a UUID, mapping failure to a `400` tuple.
+/// Test: covered by handler tests that pass an invalid id.
+pub(super) fn parse_id(id_str: &str) -> Result<ManagedSessionId, (StatusCode, String)> {
+    id_str
+        .parse::<uuid::Uuid>()
+        .map(ManagedSessionId::from)
+        .map_err(|_| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("invalid session id: {id_str}"),
+            )
+        })
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -120,6 +120,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         source_id: None,
         task: None,
         cwd: None,
+        claude_session_id: None,
     };
     let resp_owned = DecommissionResponse {
         summary: owned_summary,
@@ -149,6 +150,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         source_id: None,
         task: None,
         cwd: None,
+        claude_session_id: None,
     };
     let resp_unowned = DecommissionResponse {
         summary: unowned_summary,

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -63,6 +63,36 @@ fn session_id_export_prefix(session_id: &str) -> String {
     )
 }
 
+/// The one-line hint printed to the pane AFTER `claude` exits (#2023 component D).
+///
+/// Why: component A leaves the pane alive as a bare shell when the runtime
+/// exits, and component C lets a bare `tm` run from inside that pane relaunch
+/// the same session in place — but neither is discoverable unless the pane
+/// itself says so. Backticks are used around the literal command name; they
+/// have no special meaning inside the single-quoted `echo` argument this is
+/// embedded in (see [`on_exit_hint_suffix`]), so no escaping is needed.
+/// What: a short, single-line, non-panicking string.
+/// Test: `spawn_command_prints_relaunch_hint_after_claude_exits`,
+/// `resume_command_prints_relaunch_hint_after_claude_exits`.
+const RELAUNCH_HINT: &str = "tm: run `tm` to relaunch this session";
+
+/// Build the `; echo '<hint>'` suffix appended AFTER every managed
+/// launch/resume command (#2023 component D).
+///
+/// Why: `;` sequences the `echo` to run only once the preceding `claude`
+/// invocation exits (successfully or not) and control returns to the pane's
+/// shell — exactly the moment component A leaves the pane idle at, and
+/// exactly what the in-place relaunch (component C) needs advertised.
+/// What: `; echo '<RELAUNCH_HINT>'`, single-quoted via [`shell_single_quote`]
+/// for the same reason [`env_bin_prefix`] quotes `CLAUDE_CONFIG_DIR` — a
+/// literal constant with no shell metacharacters, but quoting defensively
+/// costs nothing and matches this file's established convention.
+/// Test: `spawn_command_prints_relaunch_hint_after_claude_exits`,
+/// `resume_command_prints_relaunch_hint_after_claude_exits`.
+fn on_exit_hint_suffix() -> String {
+    format!("; echo {}", shell_single_quote(RELAUNCH_HINT))
+}
+
 /// Compose the `env …` prefix + resolved binary that starts every managed
 /// `claude`, wiring in the tm-owned `CLAUDE_CONFIG_DIR` when available (DOC-34).
 ///
@@ -124,24 +154,28 @@ fn env_bin_prefix(claude_bin: &str, config_dir: Option<&Path>) -> String {
 /// / [`crate::core::model_inject::PERMISSION_MODE_FLAG`] constants so this spawn
 /// path and the CLI launch path can never drift.
 /// What: [`session_id_export_prefix`] followed by [`env_bin_prefix`] plus the
-/// two shared flag constants; piped to `tmux send-keys … Enter`. `claude_bin`
-/// is the resolved binary — an absolute path under launchd so the pane (which
-/// inherits the daemon's minimal `PATH`) does not need `claude` on its own
-/// `PATH` (#1298). `session_id` is the managed session's UUID (#2023 component
-/// B), exported so in-pane commands can identify the session after `claude`
-/// exits.
+/// two shared flag constants, followed by [`on_exit_hint_suffix`] (#2023
+/// component D — `; echo '<hint>'`, which only runs once `claude` exits and
+/// control returns to the pane); piped to `tmux send-keys … Enter`.
+/// `claude_bin` is the resolved binary — an absolute path under launchd so the
+/// pane (which inherits the daemon's minimal `PATH`) does not need `claude` on
+/// its own `PATH` (#1298). `session_id` is the managed session's UUID (#2023
+/// component B), exported so in-pane commands can identify the session after
+/// `claude` exits.
 /// Test: `spawn_command_contains_env_scrub`,
 /// `spawn_command_contains_isolation_flags`,
 /// `spawn_command_uses_resolved_binary`,
 /// `spawn_command_sets_claude_config_dir`,
-/// `spawn_command_exports_managed_session_id`.
+/// `spawn_command_exports_managed_session_id`,
+/// `spawn_command_prints_relaunch_hint_after_claude_exits`.
 fn spawn_command(claude_bin: &str, config_dir: Option<&Path>, session_id: &str) -> String {
     format!(
-        "{}{} {} {}",
+        "{}{} {} {}{}",
         session_id_export_prefix(session_id),
         env_bin_prefix(claude_bin, config_dir),
         crate::core::model_inject::SETTING_SOURCES_FLAG,
         crate::core::model_inject::PERMISSION_MODE_FLAG,
+        on_exit_hint_suffix(),
     )
 }
 
@@ -158,12 +192,15 @@ fn spawn_command(claude_bin: &str, config_dir: Option<&Path>, session_id: &str) 
 /// `None, has_prior_conv=false` → plain spawn (no resume flag), so the session
 /// starts a fresh conversation instead of erroring. All three share the same
 /// env prefix (scrub + `CLAUDE_CONFIG_DIR`) and isolation flags as
-/// [`spawn_command`].
+/// [`spawn_command`], and all three get [`on_exit_hint_suffix`] appended
+/// (#2023 component D) so the pane always prints the relaunch hint once
+/// `claude` exits, whichever branch fired.
 /// Test: `resume_command_with_id_uses_resume_flag`,
 /// `resume_command_without_id_with_prior_conv_uses_continue`,
 /// `resume_command_without_id_no_prior_conv_uses_plain_spawn`,
 /// `resume_command_sets_claude_config_dir`,
-/// `resume_command_exports_managed_session_id`.
+/// `resume_command_exports_managed_session_id`,
+/// `resume_command_prints_relaunch_hint_after_claude_exits`.
 fn resume_command(
     claude_bin: &str,
     config_dir: Option<&Path>,
@@ -178,11 +215,12 @@ fn resume_command(
         crate::core::model_inject::SETTING_SOURCES_FLAG,
         crate::core::model_inject::PERMISSION_MODE_FLAG,
     );
-    match claude_session_id {
+    let cmd = match claude_session_id {
         Some(id) => format!("{base} --resume {id}"),
         None if has_prior_conv => format!("{base} --continue"),
         None => base, // No prior conversation: start fresh to avoid "no conversation found".
-    }
+    };
+    format!("{cmd}{}", on_exit_hint_suffix())
 }
 
 /// Encode a workspace path the same way Claude Code names its project dir.
@@ -380,6 +418,112 @@ fn prepare_managed_config(tmux_name: &str, cwd: &Path) -> Option<std::path::Path
     }
 
     Some(config_dir)
+}
+
+/// Owned pieces of an in-place `claude` relaunch command, built for direct
+/// process `exec` rather than a tmux `send_line` (#2023 component C).
+///
+/// Why: [`spawn_command`]/[`resume_command`] build single shell STRINGS meant
+/// for `tmux send-keys` into a pane whose shell does the quoting/splitting.
+/// The bare-`tm` in-pane relaunch instead replaces the CURRENT process image
+/// via `std::os::unix::process::CommandExt::exec` — no shell involved, so
+/// there is no command string to build (or parse back). This struct carries
+/// exactly what the caller (the `tm` CLI binary) needs to construct that
+/// [`std::process::Command`] itself.
+/// What: `claude_bin` (resolved absolute path), `args` (the isolation flags
+/// plus `--resume <id>`/`--continue`/neither, mirroring [`resume_command`]'s
+/// selection — see [`compose_inplace_args`]), and `config_dir` (the tm-owned
+/// `CLAUDE_CONFIG_DIR`, when resolved). The caller is expected to
+/// `env_remove("ANTHROPIC_API_KEY")` and, when `config_dir` is `Some`, set
+/// `CLAUDE_CONFIG_DIR` to it — the same two invariants [`env_bin_prefix`]
+/// encodes into the shell-string commands.
+/// Test: exercised via [`build_inplace_resume_command`]'s tests.
+#[derive(Debug)]
+pub struct InPlaceResumeCommand {
+    /// Resolved `claude` binary (absolute path).
+    pub claude_bin: String,
+    /// Full argv (isolation flags + resume/continue selection), EXCLUDING the
+    /// binary itself.
+    pub args: Vec<String>,
+    /// The tm-owned `CLAUDE_CONFIG_DIR`, when resolved (`None` when home is
+    /// unresolvable — mirrors [`prepare_managed_config`]'s fallback).
+    pub config_dir: Option<std::path::PathBuf>,
+}
+
+/// Pure argv composition shared by [`build_inplace_resume_command`] (#2023 C).
+///
+/// Why: separating the resume/continue/fresh SELECTION from claude-binary
+/// resolution (which needs a real `claude` install to exercise end-to-end)
+/// keeps the decision itself testable in every CI environment — mirroring how
+/// [`resume_command`]'s selection tests pass a fake `claude_bin` string rather
+/// than depending on [`ClaudeCodeAdapter::resolve_claude`].
+/// What: the isolation flags ([`crate::core::model_inject::SETTING_SOURCES_FLAG`]
+/// / [`crate::core::model_inject::PERMISSION_MODE_FLAG`], whitespace-split
+/// into argv tokens since both constants are simple space-separated flags with
+/// no embedded quoting) followed by `--resume <id>` (id exists under
+/// `config_dir`, per [`session_id_exists`]), `--continue` (no usable id but
+/// [`has_prior_conversation`] is true), or neither (fresh start) — the exact
+/// same three-way selection [`resume_command`] makes.
+/// Test: `compose_inplace_args_uses_resume_for_existing_id`,
+/// `compose_inplace_args_falls_back_for_missing_id`,
+/// `compose_inplace_args_uses_continue_when_no_id_but_prior_conv`.
+fn compose_inplace_args(
+    cwd: &Path,
+    config_dir: Option<&Path>,
+    claude_session_id: Option<&str>,
+) -> Vec<String> {
+    let effective_id = claude_session_id.filter(|id| session_id_exists(cwd, config_dir, id));
+
+    let mut args: Vec<String> = crate::core::model_inject::SETTING_SOURCES_FLAG
+        .split_whitespace()
+        .chain(crate::core::model_inject::PERMISSION_MODE_FLAG.split_whitespace())
+        .map(str::to_owned)
+        .collect();
+
+    match effective_id {
+        Some(id) => {
+            args.push("--resume".to_owned());
+            args.push(id.to_owned());
+        }
+        None if has_prior_conversation(cwd) => args.push("--continue".to_owned()),
+        None => {}
+    }
+    args
+}
+
+/// Build an [`InPlaceResumeCommand`] for the bare-`tm` in-pane relaunch path
+/// (#2023 component C).
+///
+/// Why: the in-place relaunch must use the SAME `--resume <id>`
+/// existence-check → `--continue`/fresh-spawn fallback semantics as the
+/// tmux-pane resume path (#2013) — reusing [`session_id_exists`] /
+/// [`has_prior_conversation`] / [`prepare_managed_config`] directly (via
+/// [`compose_inplace_args`]), rather than re-deriving them, means the two
+/// paths can never silently drift.
+/// What: resolves the `claude` binary (`Err(RuntimeError::BinaryNotFound)` if
+/// missing), provisions/trust-seeds the managed `CLAUDE_CONFIG_DIR` via
+/// [`prepare_managed_config`] (logged under the synthetic session name
+/// `"in-place-relaunch"` — there is no tmux session name in this context),
+/// then delegates argv composition to [`compose_inplace_args`].
+/// Test: `build_inplace_resume_command_resolves_claude_binary`.
+pub fn build_inplace_resume_command(
+    cwd: &Path,
+    claude_session_id: Option<&str>,
+) -> Result<InPlaceResumeCommand, RuntimeError> {
+    let claude_bin = ClaudeCodeAdapter::resolve_claude().ok_or_else(|| {
+        RuntimeError::BinaryNotFound(
+            "claude binary not found on PATH or in well-known dirs \
+             (e.g. ~/.local/bin) — install Claude Code first"
+                .into(),
+        )
+    })?;
+    let config_dir = prepare_managed_config("in-place-relaunch", cwd);
+    let args = compose_inplace_args(cwd, config_dir.as_deref(), claude_session_id);
+    Ok(InPlaceResumeCommand {
+        claude_bin,
+        args,
+        config_dir,
+    })
 }
 
 /// Runtime adapter that launches Claude Code CLI inside a tmux session.
@@ -1209,6 +1353,142 @@ mod tests {
             !sends[0].1.contains("--resume"),
             "adapter plain-spawn must NOT use --resume: {}",
             sends[0].1
+        );
+    }
+
+    // ── #2023 component D: on-exit relaunch hint ────────────────────────────
+
+    #[test]
+    fn spawn_command_prints_relaunch_hint_after_claude_exits() {
+        // The hint must appear AFTER the claude invocation, separated by `;` so
+        // it only runs once claude exits and control returns to the pane shell.
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID);
+        assert!(
+            cmd.contains("; echo 'tm: run `tm` to relaunch this session'"),
+            "spawn command must print the relaunch hint after claude exits: {cmd}"
+        );
+        let claude_pos = cmd.find(" claude ").expect("claude invocation present");
+        let hint_pos = cmd.find("; echo").expect("relaunch hint present");
+        assert!(
+            claude_pos < hint_pos,
+            "relaunch hint must come AFTER the claude invocation: {cmd}"
+        );
+    }
+
+    #[test]
+    fn resume_command_prints_relaunch_hint_after_claude_exits() {
+        // Same invariant for the resume path (--resume branch here; the
+        // --continue/plain-spawn branches share the same trailing suffix).
+        let cmd = resume_command("claude", None, Some("abc-123"), false, TEST_SESSION_ID);
+        assert!(
+            cmd.contains("; echo 'tm: run `tm` to relaunch this session'"),
+            "resume command must print the relaunch hint after claude exits: {cmd}"
+        );
+        let resume_pos = cmd.find("--resume").expect("--resume flag present");
+        let hint_pos = cmd.find("; echo").expect("relaunch hint present");
+        assert!(
+            resume_pos < hint_pos,
+            "relaunch hint must come AFTER --resume: {cmd}"
+        );
+    }
+
+    // ── #2023 component C: in-place relaunch command builder ───────────────
+
+    #[test]
+    fn compose_inplace_args_uses_resume_for_existing_id() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cwd = tmp.path().join("workspace");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let config_dir = tmp.path().join("config");
+        let encoded = cwd.to_string_lossy().replace('/', "-");
+        let project_dir = config_dir.join("projects").join(&encoded);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(project_dir.join("existing-id.jsonl"), "{}").unwrap();
+
+        let args = compose_inplace_args(&cwd, Some(&config_dir), Some("existing-id"));
+        assert!(
+            args.windows(2).any(|w| w == ["--resume", "existing-id"]),
+            "must select --resume <id> for an id that exists on disk: {args:?}"
+        );
+        assert!(
+            !args.contains(&"--continue".to_owned()),
+            "must not ALSO pass --continue when --resume is used: {args:?}"
+        );
+    }
+
+    #[test]
+    fn compose_inplace_args_falls_back_for_missing_id() {
+        // #2013 parity: a stale id (no matching .jsonl) with no prior
+        // conversation history falls back to a fresh spawn — neither
+        // --resume nor --continue.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cwd = tmp.path().join("workspace-missing");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let config_dir = tmp.path().join("config");
+
+        let args = compose_inplace_args(&cwd, Some(&config_dir), Some("stale-id"));
+        assert!(
+            !args.contains(&"--resume".to_owned()),
+            "a stale id must not be passed to --resume: {args:?}"
+        );
+        assert!(
+            !args.contains(&"--continue".to_owned()),
+            "no prior conversation history: must not fall back to --continue: {args:?}"
+        );
+        assert!(
+            args.contains(&"--setting-sources".to_owned()),
+            "isolation flags must still be present: {args:?}"
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn compose_inplace_args_uses_continue_when_no_id_but_prior_conv() {
+        // has_prior_conversation (unlike session_id_exists) always looks under
+        // `~/.claude/projects` regardless of `config_dir` — mirroring exactly
+        // what `resume_command`'s own `has_prior_conv` computation does — so
+        // this test redirects $HOME rather than seeding under a config dir.
+        let _home = HomeGuard::set();
+        let home = dirs::home_dir().expect("home resolves under redirected HOME");
+        let cwd = std::path::PathBuf::from("/tmp/inplace-continue-test");
+        // Seed prior conversation history (a .jsonl under the encoded cwd dir)
+        // WITHOUT seeding the specific stale id, so has_prior_conversation is
+        // true but session_id_exists for "stale-id" is false.
+        let encoded = cwd.to_string_lossy().replace('/', "-");
+        let project_dir = home.join(".claude").join("projects").join(&encoded);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(project_dir.join("some-other-session.jsonl"), "{}").unwrap();
+
+        let args = compose_inplace_args(&cwd, None, Some("stale-id"));
+        assert!(
+            !args.contains(&"--resume".to_owned()),
+            "a stale id must not be passed to --resume: {args:?}"
+        );
+        assert!(
+            args.contains(&"--continue".to_owned()),
+            "prior conversation history exists: must fall back to --continue: {args:?}"
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn build_inplace_resume_command_resolves_claude_binary() {
+        // Integration-style check that build_inplace_resume_command wires
+        // resolve_claude + prepare_managed_config + compose_inplace_args
+        // together; the pure selection logic is covered exhaustively above
+        // without needing a real claude binary.
+        let _home = HomeGuard::set();
+        let Some(claude_bin) = ClaudeCodeAdapter::resolve_claude() else {
+            return;
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let result =
+            build_inplace_resume_command(tmp.path(), Some("some-id")).expect("build succeeds");
+        assert_eq!(result.claude_bin, claude_bin);
+        assert!(
+            result.args.contains(&"--setting-sources".to_owned()),
+            "isolation flags must be present: {:?}",
+            result.args
         );
     }
 }

--- a/crates/trusty-mpm/src/runtime/mod.rs
+++ b/crates/trusty-mpm/src/runtime/mod.rs
@@ -5,8 +5,10 @@
 //! without changing its own code. A trait seam here means new adapters slot in
 //! without touching the manager.
 //! What: defines [`RuntimeAdapter`] trait, [`RuntimeError`] error type, the
-//! [`RuntimeKind`] selector + its [`build_adapter`] factory, and re-exports the
-//! two concrete adapters ([`ClaudeCodeAdapter`], [`TcodeAdapter`]).
+//! [`RuntimeKind`] selector + its [`build_adapter`] factory, re-exports the
+//! two concrete adapters ([`ClaudeCodeAdapter`], [`TcodeAdapter`]), and
+//! re-exports [`build_inplace_resume_command`]/[`InPlaceResumeCommand`] — the
+//! `tm` CLI's building block for the bare-`tm` in-pane relaunch path (#2023 C).
 //! Test: each adapter carries its own unit tests; both are testable without a
 //! real tmux binary via a fake tmux driver. `RuntimeKind` parsing/serde is
 //! covered by `runtime_kind_*` tests in this module.
@@ -17,7 +19,7 @@ mod tcode;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 
-pub use claude_code::ClaudeCodeAdapter;
+pub use claude_code::{ClaudeCodeAdapter, InPlaceResumeCommand, build_inplace_resume_command};
 pub use tcode::TcodeAdapter;
 
 use std::path::Path;

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -8,6 +8,8 @@
 //! and provides `create`, `list`, `get`, `send_input`, `stop`,
 //! `mark_runtime_exited_stopped` (non-destructive counterpart to `stop`,
 //! #2023 A), `resume`, `decommission`, and `reconcile_on_boot`.
+//! `mark_reactivated` (the in-place counterpart to `resume`, #2023 C) lives in
+//! the sibling `reactivate.rs` to keep this file under the 500-SLOC cap.
 //! [`ReconcileReport`] describes what the reconciliation pass found.
 //! [`ManagedError`] is the module's error type.
 //! Test: `manager_create_record`, `manager_stop_keeps_workspace`,

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -15,6 +15,7 @@ pub mod driver;
 pub mod hook_sync;
 pub mod manager;
 pub mod prune;
+pub mod reactivate;
 pub mod record;
 pub mod restart_ops;
 pub mod session_guard;
@@ -27,6 +28,9 @@ mod tests;
 
 #[cfg(test)]
 mod restart_tests;
+
+#[cfg(test)]
+mod reactivate_tests;
 
 #[cfg(test)]
 mod backfill_tests;

--- a/crates/trusty-mpm/src/session_manager/reactivate.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate.rs
@@ -1,0 +1,65 @@
+//! In-place session reactivation, with NO tmux mutation (#2023 component C).
+//!
+//! Why: `manager.rs` was at the 500-SLOC production cap; adding this method
+//! there would breach it. Following the same pattern as `hook_sync.rs` /
+//! `adopt.rs` (sibling `impl SessionManager` blocks), this file isolates the
+//! one write-path the bare-`tm` in-pane relaunch needs.
+//! What: one inherent method, `SessionManager::mark_reactivated` — flips a
+//! `Stopped` record back to `Active` with no `create_session`/`kill_session`
+//! call, unlike [`SessionManager::resume`] (which always recreates the tmux
+//! session).
+//! Test: `mark_reactivated_flips_stopped_to_active`,
+//! `mark_reactivated_rejects_non_stopped` in `super::tests`.
+
+use chrono::Utc;
+use tracing::info;
+
+use super::manager::{ManagedError, SessionManager};
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+impl SessionManager {
+    /// Reactivate a Stopped session IN PLACE, with NO tmux mutation (#2023 C).
+    ///
+    /// Why: [`Self::resume`] is the daemon-driven restart path — it always kills
+    /// any surviving tmux session and creates a fresh one, because it assumes
+    /// the caller has no live pane of its own to reuse. The bare-`tm` in-pane
+    /// relaunch (#2023 component C) is the opposite case: the operator is
+    /// running `tm` FROM INSIDE the very pane [`Self::mark_runtime_exited_stopped`]
+    /// (#2023 A) left alive when the runtime exited, and is about to `exec`
+    /// `claude` directly back into that SAME pane. Routing that reactivation
+    /// through `resume` would kill the pane out from under the process that
+    /// is about to relaunch into it. This method gives the in-pane path its own
+    /// non-destructive transition: flip the record back to `Active` and nothing
+    /// else — no `create_session`, no `kill_session`, no pane snapshot.
+    /// What: requires the record be `Stopped` (any other state is an
+    /// [`ManagedError::InvalidState`] — in particular, an `Active` record must
+    /// not be silently re-marked Active by a stray call); sets
+    /// `state = Active` and refreshes `last_activity_at`, then persists.
+    /// Test: `mark_reactivated_flips_stopped_to_active`,
+    /// `mark_reactivated_rejects_non_stopped`.
+    pub async fn mark_reactivated(
+        &self,
+        id: &ManagedSessionId,
+    ) -> Result<SessionRecord, ManagedError> {
+        let mut record = self.get(id).await?;
+        if record.state != ManagedSessionState::Stopped {
+            return Err(ManagedError::InvalidState(
+                id.to_string(),
+                format!(
+                    "cannot reactivate a session in state '{}'; only Stopped sessions can be \
+                     reactivated in place",
+                    record.state
+                ),
+            ));
+        }
+        record.state = ManagedSessionState::Active;
+        record.last_activity_at = Some(Utc::now());
+        self.store.write().await.upsert(record.clone()).await?;
+        info!(
+            id = %id,
+            name = %record.tmux_name,
+            "managed session reactivated in place (#2023 C, no tmux mutation)"
+        );
+        Ok(record)
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/reactivate_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate_tests.rs
@@ -1,0 +1,113 @@
+//! Tests for `SessionManager::mark_reactivated` (#2023 component C).
+//!
+//! Why: `session_manager/tests.rs` is at the 1500-SLOC test cap; this
+//! in-place-reactivation coverage lives here (mirroring `restart_tests.rs`)
+//! so neither file grows past its limit.
+//! What: proves `mark_reactivated` flips `Stopped` -> `Active` WITHOUT ever
+//! calling `create_session`/`kill_session`, and rejects a non-`Stopped`
+//! record.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use tempfile::TempDir;
+
+use super::manager::ManagedError;
+use super::record::ManagedSessionState;
+use super::tests::make_manager;
+
+/// `mark_reactivated` must flip a `Stopped` record back to `Active` WITHOUT
+/// touching tmux at all (#2023 C) — the caller is about to `exec` `claude`
+/// directly back into the SAME pane `mark_runtime_exited_stopped` (#2023 A)
+/// left alive, so no `create_session`/`kill_session` call may occur.
+///
+/// Why: this is the daemon-side half of the bare-`tm` in-pane relaunch path;
+/// unlike `resume` it must never recreate the tmux session.
+/// What: creates a session, stops it (via `stop`, which DOES kill the pane —
+/// irrelevant here, only the record's Stopped state matters), then calls
+/// `mark_reactivated` and asserts the record is `Active` and that no
+/// ADDITIONAL `create_session`/`kill_session` calls were made by
+/// `mark_reactivated` itself.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn mark_reactivated_flips_stopped_to_active() {
+    let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_dir.path().to_owned()),
+            None,
+            Some(workspace_dir.path().to_owned()),
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+
+    mgr.stop(&record.id).await.expect("stop");
+    let kill_calls_before = fake.kill_calls.lock().unwrap().len();
+    let create_calls_before = fake.create_cwd_calls.lock().unwrap().len();
+
+    let reactivated = mgr.mark_reactivated(&record.id).await.expect("reactivate");
+    assert_eq!(
+        reactivated.state,
+        ManagedSessionState::Active,
+        "mark_reactivated must flip Stopped -> Active"
+    );
+
+    assert_eq!(
+        fake.kill_calls.lock().unwrap().len(),
+        kill_calls_before,
+        "mark_reactivated must NEVER call kill_session (#2023 C)"
+    );
+    assert_eq!(
+        fake.create_cwd_calls.lock().unwrap().len(),
+        create_calls_before,
+        "mark_reactivated must NEVER call create_session (#2023 C)"
+    );
+
+    let after = mgr.get(&record.id).await.unwrap();
+    assert_eq!(after.state, ManagedSessionState::Active);
+}
+
+/// `mark_reactivated` must reject any state other than `Stopped` — in
+/// particular it must not silently re-mark an already-`Active` session.
+///
+/// Why: this guards against a stray/duplicate reactivate call (e.g. two
+/// bare-`tm` invocations racing in the same pane) silently succeeding twice.
+/// What: creates and stops a session so it is `Stopped`, reactivates it once
+/// (succeeds), then reactivates it AGAIN and asserts an `InvalidState` error.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn mark_reactivated_rejects_non_stopped() {
+    let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_dir.path().to_owned()),
+            None,
+            Some(workspace_dir.path().to_owned()),
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+
+    mgr.stop(&record.id).await.expect("stop");
+    mgr.mark_reactivated(&record.id)
+        .await
+        .expect("first reactivate");
+
+    let err = mgr
+        .mark_reactivated(&record.id)
+        .await
+        .expect_err("reactivating an already-Active session must fail");
+    assert!(
+        matches!(err, ManagedError::InvalidState(_, _)),
+        "expected InvalidState, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements components C and D of #2023 (final components — A and B are already merged to `main`).

- **Component C — in-place relaunch.** Bare `tm`, run from inside a managed pane whose runtime already exited (component A leaves the pane alive; component B exports `TM_MANAGED_SESSION_ID` into it), now detects it is running in that pane and relaunches `claude` directly back into it via `exec` — never through the daemon's kill+recreate `/resume` path, so the pane the operator is sitting in is never torn down.
  - `guided_inplace.rs` (new): `plan_inplace` (pure decision), `try_inplace_relaunch` (I/O driver: GET the record, POST `/reactivate`, build the resume command, `exec`).
  - `guided_resume.rs`: new `ResumeAction::InPlace` variant.
  - `runtime/claude_code.rs`: new `build_inplace_resume_command`/`compose_inplace_args`/`InPlaceResumeCommand`, reusing the existing `session_id_exists`/`has_prior_conversation`/`prepare_managed_config` (#2013) so the in-place path can never drift from the tmux-pane resume path's `--resume`-existence-check → `--continue`/fresh-spawn fallback semantics.
  - New daemon route `POST /api/v1/sessions/managed/{id}/reactivate` (`session_manager/reactivate.rs` + `daemon/managed_routes/reactivate.rs`) flips `Stopped` → `Active` with **no** tmux mutation (no `create_session`/`kill_session`), distinct from `/resume`.
  - Guard: a stale/unresolved `TM_MANAGED_SESSION_ID` falls through to the ordinary guided picker rather than erroring.
- **Component D — on-exit hint.** The pane command (spawn and resume paths) now appends `; echo 'tm: run `tm` to relaunch this session'`, which only prints once `claude` exits and control returns to the pane's shell.

Also added `claude_session_id` to the managed-session wire types (`SessionSummary`/`ManagedSessionSummary`, additive) so the in-place path can build the identical `--resume <id>` command the daemon-side resume path uses.

Two files were split to stay under the 500-SLOC production cap: `managed_routes/mod.rs` → extracted `summary.rs` (record→wire conversions) and `reactivate.rs` (the new route handler); `session_manager/manager.rs` → extracted `reactivate.rs` (the new `mark_reactivated` method) with its tests in `reactivate_tests.rs`.

Closes #2023

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-mpm` (2334 lib tests + all integration suites pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)