### PR TITLE
fix(trusty-mpm): reach trusty-memory over discovered JSON-RPC, never a hardcoded port

### DIFF
--- a/crates/trusty-code/src/catchup.rs
+++ b/crates/trusty-code/src/catchup.rs
@@ -16,17 +16,6 @@ use std::path::Path;
 use tracing::debug;
 use trusty_common::catchup::{CatchupOptions, run_catchup};
 
-/// Environment variable for overriding the trusty-memory daemon base URL.
-///
-/// Why: tests and CI environments may not have the daemon running at the default
-/// port; an env var lets operators point trusty-code at any accessible instance.
-/// What: when set to a non-empty string, this value is used as the `memory_url`
-/// in [`CatchupOptions`]; otherwise the engine default (`http://127.0.0.1:7990`)
-/// is used.
-/// Test: exercised indirectly — tests use an unreachable port to verify
-/// fail-open behaviour without depending on a live daemon.
-const TRUSTY_MEMORY_URL_ENV: &str = "TRUSTY_MEMORY_URL";
-
 /// Build PM-prompt catch-up seed context for the given project directory.
 ///
 /// Why: the PM prompt benefits from a one-time digest of what happened in the
@@ -48,17 +37,15 @@ const TRUSTY_MEMORY_URL_ENV: &str = "TRUSTY_MEMORY_URL";
 /// propagating, so prompt assembly always succeeds even when the daemon is
 /// offline or the project has no git history.
 ///
-/// What: resolves `memory_url` from `TRUSTY_MEMORY_URL` env (falling back to
-/// the engine default), builds `CatchupOptions` with sane limits, calls
-/// `run_catchup` with `advance_watermark = false`, and returns `Some(digest)`
-/// when the result is non-whitespace, else `None`.
+/// What: resolves `memory_url` via
+/// [`trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable`] (env override
+/// `TRUSTY_MEMORY_URL` first, else the daemon's discovered bound address,
+/// else a fail-fast placeholder — issue #2030), builds `CatchupOptions` with
+/// sane limits, calls `run_catchup` with `advance_watermark = false`, and
+/// returns `Some(digest)` when the result is non-whitespace, else `None`.
 /// Test: `catchup::tests::pm_catchup_context_does_not_panic_on_empty_repo`.
 pub async fn pm_catchup_context(project_dir: &Path) -> Option<String> {
-    let memory_url = std::env::var(TRUSTY_MEMORY_URL_ENV)
-        .ok()
-        .filter(|s| !s.trim().is_empty())
-        // fall through to the engine's built-in default
-        .unwrap_or_else(|| CatchupOptions::default().memory_url);
+    let memory_url = trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable();
 
     let opts = CatchupOptions {
         project_dir: project_dir.to_path_buf(),
@@ -130,7 +117,12 @@ mod tests {
 
         // Point memory_url at an unreachable port so palace fetch fails-open.
         // SAFETY: single-threaded test; no concurrent env reads.
-        unsafe { std::env::set_var(TRUSTY_MEMORY_URL_ENV, "http://127.0.0.1:19999") };
+        unsafe {
+            std::env::set_var(
+                trusty_common::mcp::memory_rpc::TRUSTY_MEMORY_URL_ENV,
+                "http://127.0.0.1:19999",
+            )
+        };
 
         let result = pm_catchup_context(tmp.path()).await;
 
@@ -179,7 +171,12 @@ mod tests {
 
         // Point memory_url at an unreachable port.
         // SAFETY: single-threaded test; no concurrent env reads.
-        unsafe { std::env::set_var(TRUSTY_MEMORY_URL_ENV, "http://127.0.0.1:19999") };
+        unsafe {
+            std::env::set_var(
+                trusty_common::mcp::memory_rpc::TRUSTY_MEMORY_URL_ENV,
+                "http://127.0.0.1:19999",
+            )
+        };
 
         // Must not panic — fall through to None or Some(whitespace-only) path.
         let _result = pm_catchup_context(tmp.path()).await;

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -189,8 +189,10 @@ default = []
 # `run_catchup_blocking`, and the per-source submodules (`git`, `palace`,
 # `state`, `session_finder`, `mpm_session`, `mpm_registry`). Pulls in
 # `rusqlite` for the claude-mpm session-registry reader; all other deps are
-# already unconditional in this crate.
-catchup = ["dep:rusqlite"]
+# already unconditional in this crate. Also requires `mcp` (issue #2030):
+# `catchup::palace` reaches trusty-memory via `mcp::memory_rpc`'s discovery +
+# JSON-RPC helper rather than a hardcoded REST URL.
+catchup = ["dep:rusqlite", "mcp"]
 # Enables the `server` module: standard axum middleware stack (CORS, trace,
 # gzip) and a fast-fail reqwest client for daemon-to-daemon calls.
 axum-server = ["dep:axum", "dep:tower-http"]

--- a/crates/trusty-common/src/catchup/mod.rs
+++ b/crates/trusty-common/src/catchup/mod.rs
@@ -58,7 +58,11 @@ impl Default for CatchupOptions {
     fn default() -> Self {
         Self {
             project_dir: PathBuf::from("."),
-            memory_url: "http://127.0.0.1:7990".to_string(),
+            // Discovery-first (issue #2030): resolves TRUSTY_MEMORY_URL when
+            // set, else the daemon's actual discovered bound address, else a
+            // guaranteed-unreachable placeholder that fails fast rather than
+            // guessing a fixed (and likely wrong) port.
+            memory_url: crate::mcp::memory_rpc::resolve_memory_base_url_or_unreachable(),
             include_git: true,
             include_palace: true,
             git_limit: 50,
@@ -191,21 +195,35 @@ pub async fn generate_catchup_context(opts: &CatchupOptions) -> String {
     // ── Section 3: Recent Memory ────────────────────────────────────────────
     if opts.include_palace {
         out.push_str("## Recent Memory\n\n");
-        let drawers =
-            fetch_recent_palace_drawers(&opts.memory_url, &palace_id, opts.drawer_limit, watermark)
-                .await;
-        if drawers.is_empty() {
-            out.push_str("No recent palace activity since last catch-up.\n\n");
-        } else {
-            for d in &drawers {
-                let tags = if d.tags.is_empty() {
-                    String::new()
-                } else {
-                    format!(" [{}]", d.tags.join(", "))
-                };
-                out.push_str(&format!("- {}{}\n", d.title, tags));
+        // `None` means trusty-memory was unreachable; `Some(vec![])` means the
+        // daemon answered but had nothing new. Issue #2030 (item 5): these two
+        // outcomes must render distinct messages rather than the same
+        // "No recent palace activity" line.
+        match fetch_recent_palace_drawers(
+            &opts.memory_url,
+            &palace_id,
+            opts.drawer_limit,
+            watermark,
+        )
+        .await
+        {
+            None => {
+                out.push_str("trusty-memory unreachable — catch-up skipped for this section.\n\n");
             }
-            out.push('\n');
+            Some(drawers) if drawers.is_empty() => {
+                out.push_str("No recent palace activity since last catch-up.\n\n");
+            }
+            Some(drawers) => {
+                for d in &drawers {
+                    let tags = if d.tags.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" [{}]", d.tags.join(", "))
+                    };
+                    out.push_str(&format!("- {}{}\n", d.title, tags));
+                }
+                out.push('\n');
+            }
         }
     }
 
@@ -346,10 +364,12 @@ mod tests {
         );
         // Should contain the commit we made.
         assert!(context.contains("init"), "commit message should appear");
-        // Palace section should gracefully note unavailable (no daemon).
+        // Palace section should gracefully note the daemon is unreachable
+        // (memory_url points at a port nobody listens on) rather than
+        // conflating it with a genuinely empty result (issue #2030, item 5).
         assert!(
-            context.contains("No recent palace activity") || context.contains("## Recent Memory"),
-            "palace section should be present"
+            context.contains("trusty-memory unreachable"),
+            "palace section should distinguish unreachable from empty"
         );
     }
 

--- a/crates/trusty-common/src/catchup/palace.rs
+++ b/crates/trusty-common/src/catchup/palace.rs
@@ -2,26 +2,36 @@
 //!
 //! Why: surfaces recent memory palace activity as one of three catch-up sources
 //! so the operator is reminded of context stored in trusty-memory during the gap.
-//! What: [`fetch_recent_palace_drawers`] calls the trusty-memory HTTP API and
-//! returns parsed [`DrawerSummary`] values. Fail-open: if the daemon is
-//! unreachable or returns non-200, a warning is emitted to stderr and an empty
-//! vec is returned — palace inspection never blocks catch-up.
-//! Test: `drawer_response_parsing`, `drawer_since_filter`, `drawer_empty_array`.
+//! What: [`fetch_recent_palace_drawers`] calls the `memory_list` MCP tool via
+//! [`crate::mcp::memory_rpc::call_memory_tool_at`] (discovery + JSON-RPC,
+//! issue #2030 — `memory_url` is already resolved by the caller, e.g.
+//! `crate::mcp::memory_rpc::resolve_memory_base_url`) and returns parsed
+//! [`DrawerSummary`] values. `memory_list` itself sorts by importance DESC, so
+//! this re-sorts client-side by `created_at` DESC to match the old
+//! `sort=created_desc` REST contract callers depend on. Fail-open: if the
+//! daemon is unreachable or the RPC errors, a warning is emitted to stderr and
+//! `None` is returned so the caller can distinguish "unreachable" from
+//! "reached, but genuinely empty" (`Some(vec![])`) — palace inspection never
+//! blocks catch-up either way.
+//! Test: `drawer_summary_from_raw`, `drawer_since_filter`, `drawer_empty_array`,
+//! `parses_memory_list_result_and_sorts_newest_first`.
 //!
 // CUTOVER BRIDGE — remove post-migration (#1762)
 
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use serde_json::{Value, json};
 
 /// A single memory palace drawer surfaced by the catch-up system.
 ///
 /// Why: callers render this into the "Recent Memory" section of the catch-up
 /// digest so the operator is reminded of stored context.
-/// What: minimal drawer metadata — title, tags, and creation timestamp.
-/// Test: `drawer_response_parsing`.
+/// What: minimal drawer metadata — title (the drawer's content), tags, and
+/// creation timestamp.
+/// Test: `drawer_summary_from_raw`.
 #[derive(Debug, Clone)]
 pub struct DrawerSummary {
-    /// Human-readable title of the drawer.
+    /// Human-readable title of the drawer (the drawer's stored content).
     pub title: String,
     /// Tags associated with the drawer.
     pub tags: Vec<String>,
@@ -29,93 +39,111 @@ pub struct DrawerSummary {
     pub created_at: Option<DateTime<Utc>>,
 }
 
-/// Raw drawer record as returned by the trusty-memory API.
+/// Raw drawer record as returned by the `memory_list` JSON-RPC result.
 ///
-/// Why: isolates JSON deserialization from the public type.
-/// What: maps to the API response object; unknown fields are ignored.
-/// Test: `drawer_response_parsing`.
+/// Why: isolates JSON deserialization from the public [`DrawerSummary`] type.
+/// What: mirrors the payload built by
+/// `trusty_memory::tools::memory_ops::handle_memory_list`; unknown fields are
+/// ignored.
+/// Test: `drawer_summary_from_raw`.
 #[derive(Debug, Deserialize)]
 struct RawDrawer {
     #[serde(default)]
-    title: String,
+    content: String,
     #[serde(default)]
     tags: Vec<String>,
     #[serde(default)]
     created_at: Option<String>,
 }
 
+/// The `result` payload of a `memory_list` JSON-RPC response.
+#[derive(Debug, Default, Deserialize)]
+struct MemoryListResult {
+    #[serde(default)]
+    drawers: Vec<RawDrawer>,
+}
+
 impl From<RawDrawer> for DrawerSummary {
     fn from(r: RawDrawer) -> Self {
-        let created_at = r
-            .created_at
-            .as_deref()
-            .and_then(|s| s.parse::<DateTime<Utc>>().ok());
+        let created_at = r.created_at.as_deref().and_then(|s| s.parse().ok());
         DrawerSummary {
-            title: r.title,
+            title: r.content,
             tags: r.tags,
             created_at,
         }
     }
 }
 
+/// Parse a `memory_list` JSON-RPC `result` payload into drawers sorted
+/// newest-first.
+///
+/// Why: isolated from the HTTP transport so the sort/parse contract is
+/// unit-testable without a live daemon.
+/// What: deserializes `result` into [`MemoryListResult`], projects into
+/// [`DrawerSummary`], and sorts by `created_at` descending (drawers with no
+/// parseable timestamp sort last).
+/// Test: `parses_memory_list_result_and_sorts_newest_first`.
+fn parse_memory_list_result(result: Value) -> anyhow::Result<Vec<DrawerSummary>> {
+    let parsed: MemoryListResult = serde_json::from_value(result)?;
+    let mut drawers: Vec<DrawerSummary> = parsed
+        .drawers
+        .into_iter()
+        .map(DrawerSummary::from)
+        .collect();
+    // memory_list sorts by importance DESC; re-sort client-side by created_at
+    // DESC to match the old `sort=created_desc` REST contract. Timestamp-less
+    // drawers sort last.
+    drawers.sort_by_key(|d| std::cmp::Reverse(d.created_at));
+    Ok(drawers)
+}
+
 /// Fetch recent drawers from a trusty-memory palace, fail-open.
 ///
 /// Why: palace drawers are one of three catch-up activity sources; failure to
-/// reach the daemon must not abort the entire catch-up.
-/// What: issues `GET {memory_url}/api/v1/palaces/{palace_id}/drawers?sort=created_desc&limit={limit}`;
-/// if `since` is Some, filters client-side to drawers created after that timestamp.
-/// On any HTTP error, connection refused, or non-200, logs a warning to stderr
-/// and returns empty vec.
-/// Test: `drawer_response_parsing`, `drawer_since_filter`, `drawer_empty_array`,
+/// reach the daemon must not abort the entire catch-up. Returning `Option`
+/// (rather than always collapsing to an empty `Vec`) lets [`super::generate_catchup_context`]
+/// render a distinct "unreachable" message instead of conflating it with a
+/// genuinely empty result (issue #2030, item 5).
+/// What: calls `memory_list` via
+/// [`crate::mcp::memory_rpc::call_memory_tool_at`] against `memory_url`
+/// (already resolved by the caller). On success, parses + sorts via
+/// [`parse_memory_list_result`] and — when `since` is `Some` — filters
+/// client-side to drawers created after that timestamp. Returns
+/// `Some(drawers)` on success (possibly empty) or `None` on any
+/// transport/HTTP/RPC/parse error (after logging a warning to stderr).
+/// Test: `drawer_since_filter`, `drawer_empty_array`,
 /// `live_drawer_fetch` (ignored; requires running daemon).
 pub async fn fetch_recent_palace_drawers(
     memory_url: &str,
     palace_id: &str,
     limit: usize,
     since: Option<DateTime<Utc>>,
-) -> Vec<DrawerSummary> {
-    let url = format!(
-        "{}/api/v1/palaces/{}/drawers?sort=created_desc&limit={}",
-        memory_url.trim_end_matches('/'),
-        palace_id,
-        limit
-    );
-    let client = match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
+) -> Option<Vec<DrawerSummary>> {
+    let params = json!({ "palace": palace_id, "limit": limit });
+    let result = match crate::mcp::memory_rpc::call_memory_tool_at(
+        memory_url,
+        "memory_list",
+        params,
+    )
+    .await
     {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("catchup: could not build HTTP client: {e}");
-            return vec![];
-        }
-    };
-    let resp = match client.get(&url).send().await {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("catchup: could not reach trusty-memory at {memory_url}: {e}");
-            return vec![];
-        }
-    };
-    if !resp.status().is_success() {
-        eprintln!(
-            "catchup: trusty-memory returned {} for palace drawer query",
-            resp.status()
-        );
-        return vec![];
-    }
-    let raw: Vec<RawDrawer> = match resp.json().await {
         Ok(v) => v,
         Err(e) => {
-            eprintln!("catchup: could not parse palace drawer response: {e}");
-            return vec![];
+            eprintln!("catchup: could not reach trusty-memory at {memory_url}: {e}");
+            return None;
         }
     };
-    let mut drawers: Vec<DrawerSummary> = raw.into_iter().map(DrawerSummary::from).collect();
+    let mut summaries = match parse_memory_list_result(result) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("catchup: could not parse memory_list response: {e}");
+            return None;
+        }
+    };
     if let Some(since_ts) = since {
-        drawers.retain(|d| d.created_at.is_some_and(|ts| ts > since_ts));
+        summaries.retain(|d| d.created_at.is_some_and(|ts| ts > since_ts));
     }
-    drawers
+    Some(summaries)
 }
 
 #[cfg(test)]
@@ -124,14 +152,14 @@ mod tests {
 
     fn make_raw(title: &str, tags: Vec<&str>, created_at: Option<&str>) -> RawDrawer {
         RawDrawer {
-            title: title.to_string(),
+            content: title.to_string(),
             tags: tags.into_iter().map(|s| s.to_string()).collect(),
             created_at: created_at.map(|s| s.to_string()),
         }
     }
 
     #[test]
-    fn drawer_response_parsing() {
+    fn drawer_summary_from_raw() {
         let raw = make_raw(
             "My Drawer",
             vec!["rust", "mpm"],
@@ -173,12 +201,44 @@ mod tests {
         assert!(s.created_at.is_none());
     }
 
+    #[test]
+    fn parses_memory_list_result_and_sorts_newest_first() {
+        let result = json!({
+            "palace": "test-palace",
+            "drawers": [
+                {
+                    "drawer_id": "old",
+                    "content": "Old note",
+                    "importance": 0.9,
+                    "tags": ["a"],
+                    "created_at": "2026-06-25T00:00:00Z",
+                },
+                {
+                    "drawer_id": "new",
+                    "content": "New note",
+                    "importance": 0.1,
+                    "tags": ["b"],
+                    "created_at": "2026-06-27T00:00:00Z",
+                },
+            ],
+        });
+        let drawers = parse_memory_list_result(result).unwrap();
+        assert_eq!(drawers.len(), 2);
+        // Despite "Old note" having higher importance (the tool's native
+        // sort), the newest-first re-sort must put "New note" first.
+        assert_eq!(drawers[0].title, "New note");
+        assert_eq!(drawers[1].title, "Old note");
+    }
+
     /// Live-daemon test: mark #[ignore] so CI doesn't require the daemon running.
+    /// Uses an unreachable port (never bound) rather than any hardcoded daemon
+    /// default — the point of the test is only "does not panic", exercising the
+    /// fail-open `None` path.
     #[tokio::test]
     #[ignore]
     async fn live_drawer_fetch() {
         let drawers =
-            fetch_recent_palace_drawers("http://127.0.0.1:7990", "test-palace", 5, None).await;
+            fetch_recent_palace_drawers("http://127.0.0.1:19999", "test-palace", 5, None).await;
         // Just verify it returns without panicking.
         let _ = drawers;
     }

--- a/crates/trusty-common/src/mcp/memory_rpc.rs
+++ b/crates/trusty-common/src/mcp/memory_rpc.rs
@@ -1,0 +1,307 @@
+//! Discovery-based JSON-RPC access to the trusty-memory daemon (issue #2030).
+//!
+//! Why: several call sites across trusty-mpm and trusty-common used to
+//! hand-roll a `reqwest` GET against a hardcoded fixed port and an ad-hoc
+//! REST path (`/api/v1/palaces/{id}/drawers`). That fixed port was simply
+//! wrong — trusty-memory auto-port-walks from ~7070-7079 — so those call
+//! sites silently reported "could not reach trusty-memory" even when the
+//! daemon was healthy, unless the operator manually exported
+//! `TRUSTY_MEMORY_URL`. This module is the one shared helper: resolve the
+//! daemon's *actual* bound address via discovery, then call its tools over
+//! the same `POST /rpc` JSON-RPC dispatcher the MCP stdio server and UDS
+//! transport share — never a REST path that doesn't exist in the
+//! multi-transport daemon, and never the REST-based `monitor::memory_client`
+//! (gated behind `monitor-tui`, which trusty-mpm does not enable) or the
+//! subprocess-oriented `stdio_mcp_client` / `daemon_bridge` (no generic call
+//! surface).
+//! What: [`resolve_memory_base_url`] resolves the base URL (env override
+//! first, discovery fallback, `Err` when neither is available);
+//! [`resolve_memory_base_url_or_unreachable`] is the fail-open convenience
+//! wrapper callers that must never error use. [`call_memory_tool`] resolves
+//! the address and POSTs a JSON-RPC request for `method`/`params`, returning
+//! the envelope's `result`. [`call_memory_tool_at`] is the same call against
+//! an explicit, already-resolved base URL (used by callers — e.g. catch-up's
+//! `CatchupOptions::memory_url` — that thread their own resolved/overridable
+//! address through, including tests that point at a controlled unreachable
+//! port).
+//! Test: `resolve_memory_base_url_prefers_env_override`,
+//! `resolve_memory_base_url_errs_when_undiscovered`,
+//! `resolve_memory_base_url_or_unreachable_falls_back`,
+//! `call_memory_tool_at_rejects_rpc_error`,
+//! `call_memory_tool_at_unreachable_daemon` (ignored — exercises the fail-open
+//! contract against a dead socket without needing a live daemon).
+
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use serde_json::{Value, json};
+
+/// Environment variable that lets an operator pin trusty-memory's base URL
+/// explicitly, bypassing discovery entirely.
+///
+/// Why: CI/dev environments may run trusty-memory on a non-standard host or
+/// port, or point at a remote daemon; an explicit override must always win
+/// over discovery.
+/// What: the literal env var name `TRUSTY_MEMORY_URL`.
+/// Test: `resolve_memory_base_url_prefers_env_override`.
+pub const TRUSTY_MEMORY_URL_ENV: &str = "TRUSTY_MEMORY_URL";
+
+/// The app name trusty-memory registers its discovery file under (matches
+/// the daemon's own `resolve_data_dir("trusty-memory")` call).
+const MEMORY_APP_NAME: &str = "trusty-memory";
+
+/// A reserved, never-listening loopback address used as a last-resort
+/// fallback so a fail-open caller's own HTTP call fails fast instead of
+/// hanging.
+///
+/// Why: port 1 is a reserved/unassigned port that nothing listens on, so a
+/// connection attempt fails immediately rather than timing out.
+/// What: `http://127.0.0.1:1`.
+/// Test: `resolve_memory_base_url_or_unreachable_falls_back`.
+const UNREACHABLE_PLACEHOLDER: &str = "http://127.0.0.1:1";
+
+/// Resolve the trusty-memory daemon's base URL, discovery-first.
+///
+/// Why: every caller that needs to reach trusty-memory (catch-up, identity
+/// seeding, the TUI health poller) must resolve the *actual* bound address —
+/// trusty-memory auto-port-walks — rather than guessing a fixed port.
+/// Centralising this means a future port-walk range change never requires
+/// touching call sites again.
+/// What: returns `Ok(url)` from [`TRUSTY_MEMORY_URL_ENV`] when set to a
+/// non-empty value (an explicit override always wins over discovery);
+/// otherwise reads `crate::daemon_addr::read_daemon_addr("trusty-memory")`
+/// and formats `http://{addr}`. Returns `Err` when neither source yields an
+/// address (the daemon has never started) or the discovery read fails.
+/// Test: `resolve_memory_base_url_prefers_env_override`,
+/// `resolve_memory_base_url_errs_when_undiscovered`.
+pub fn resolve_memory_base_url() -> Result<String> {
+    if let Ok(url) = std::env::var(TRUSTY_MEMORY_URL_ENV) {
+        let trimmed = url.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+    match crate::daemon_addr::read_daemon_addr(MEMORY_APP_NAME)? {
+        Some(addr) => Ok(format!("http://{addr}")),
+        None => Err(anyhow!(
+            "trusty-memory daemon address not discovered (is the daemon running?)"
+        )),
+    }
+}
+
+/// Fail-open variant of [`resolve_memory_base_url`] for callers that must
+/// never propagate an error.
+///
+/// Why: catch-up, identity-seeding, and the TUI health poller are all
+/// designed to degrade gracefully when trusty-memory is unreachable rather
+/// than aborting their caller. Centralising the "give me *a* URL, even a
+/// dead one" fallback keeps that policy in one place instead of duplicated
+/// `unwrap_or_else` calls at every call site.
+/// What: delegates to [`resolve_memory_base_url`]; on `Err`, logs a warning
+/// to stderr and returns [`UNREACHABLE_PLACEHOLDER`] so the caller's own HTTP
+/// call fails fast rather than hanging or panicking.
+/// Test: `resolve_memory_base_url_or_unreachable_falls_back`.
+pub fn resolve_memory_base_url_or_unreachable() -> String {
+    resolve_memory_base_url().unwrap_or_else(|e| {
+        eprintln!("trusty-memory: {e}");
+        UNREACHABLE_PLACEHOLDER.to_string()
+    })
+}
+
+/// Call a trusty-memory MCP tool over JSON-RPC, resolving the address first.
+///
+/// Why: the common case for a one-off call (no pre-resolved/overridable base
+/// threaded through by the caller) — resolve, then call.
+/// What: resolves the base URL via [`resolve_memory_base_url`], then
+/// delegates to [`call_memory_tool_at`].
+/// Test: covered via `call_memory_tool_at`'s tests (this is a thin wrapper).
+pub async fn call_memory_tool(method: &str, params: Value) -> Result<Value> {
+    let base = resolve_memory_base_url()?;
+    call_memory_tool_at(&base, method, params).await
+}
+
+/// Call a trusty-memory MCP tool over JSON-RPC against an explicit base URL.
+///
+/// Why: some callers (catch-up's `CatchupOptions::memory_url`, which is
+/// resolved once up-front and threaded through for testability) already hold
+/// a resolved or intentionally-overridden base URL and must not re-resolve
+/// discovery on every call.
+/// What: POSTs `{"jsonrpc":"2.0","id":1,"method":method,"params":params}` to
+/// `{base_url}/rpc` — the same dispatcher the MCP stdio server and UDS
+/// transport share (`trusty_memory::transport::rpc::dispatch`). Rejects a
+/// non-2xx HTTP response and an `error` field in the JSON-RPC envelope as
+/// `Err`; otherwise returns the `result` value (`Value::Null` if absent).
+/// Test: `call_memory_tool_at_rejects_rpc_error`,
+/// `call_memory_tool_at_unreachable_daemon` (ignored).
+pub async fn call_memory_tool_at(base_url: &str, method: &str, params: Value) -> Result<Value> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("build reqwest client")?;
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    });
+    let url = format!("{}/rpc", base_url.trim_end_matches('/'));
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    if !resp.status().is_success() {
+        return Err(anyhow!(
+            "trusty-memory returned {} for {method}",
+            resp.status()
+        ));
+    }
+    let envelope: Value = resp
+        .json()
+        .await
+        .with_context(|| format!("parse {method} JSON-RPC response"))?;
+    if let Some(err) = envelope.get("error").filter(|e| !e.is_null()) {
+        return Err(anyhow!("{method} RPC error: {err}"));
+    }
+    Ok(envelope.get("result").cloned().unwrap_or(Value::Null))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Reuse the crate-wide env-mutation lock (`data_dir::ENV_LOCK`) rather than
+    // a module-local one: several test modules mutate `TRUSTY_DATA_DIR_OVERRIDE`,
+    // and cargo runs tests in the same process across files, so a separate
+    // lock would not prevent the race.
+    use crate::data_dir::ENV_LOCK;
+
+    #[test]
+    fn resolve_memory_base_url_prefers_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::set_var(TRUSTY_MEMORY_URL_ENV, "http://example.test:1234");
+        }
+        let resolved = resolve_memory_base_url();
+        unsafe {
+            std::env::remove_var(TRUSTY_MEMORY_URL_ENV);
+        }
+        assert_eq!(resolved.unwrap(), "http://example.test:1234");
+    }
+
+    #[test]
+    fn resolve_memory_base_url_errs_when_undiscovered() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::remove_var(TRUSTY_MEMORY_URL_ENV);
+        }
+        // Point the data-dir override at an empty temp dir so no `http_addr`
+        // file is found, simulating "daemon never started".
+        let tmp = std::env::temp_dir().join(format!(
+            "trusty-common-memory-rpc-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        unsafe {
+            std::env::set_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV, &tmp);
+        }
+        let resolved = resolve_memory_base_url();
+        unsafe {
+            std::env::remove_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV);
+        }
+        assert!(resolved.is_err(), "expected Err when undiscovered");
+    }
+
+    #[test]
+    fn resolve_memory_base_url_or_unreachable_falls_back() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::remove_var(TRUSTY_MEMORY_URL_ENV);
+        }
+        let tmp = std::env::temp_dir().join(format!(
+            "trusty-common-memory-rpc-test-fallback-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        unsafe {
+            std::env::set_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV, &tmp);
+        }
+        let resolved = resolve_memory_base_url_or_unreachable();
+        unsafe {
+            std::env::remove_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV);
+        }
+        assert_eq!(resolved, UNREACHABLE_PLACEHOLDER);
+    }
+
+    /// Spawn a one-shot mock `/rpc` server that always replies with `body`.
+    ///
+    /// Why: `call_memory_tool_at` is a thin, otherwise-untestable HTTP+JSON-RPC
+    /// wrapper; a minimal raw-TCP mock (mirroring the pattern already used by
+    /// `trusty-mpm`'s `spawn_palace_mock`) lets the envelope-error and
+    /// success-result branches be exercised without a live daemon.
+    async fn spawn_rpc_mock(body: &'static str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn call_memory_tool_at_returns_result_on_success() {
+        let base =
+            spawn_rpc_mock(r#"{"jsonrpc":"2.0","id":1,"result":{"palace":"p","drawers":[]}}"#)
+                .await;
+        let result = call_memory_tool_at(&base, "memory_list", json!({"palace": "p"}))
+            .await
+            .unwrap();
+        assert_eq!(result["palace"], "p");
+    }
+
+    #[tokio::test]
+    async fn call_memory_tool_at_rejects_rpc_error() {
+        let base = spawn_rpc_mock(
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"missing 'palace'"}}"#,
+        )
+        .await;
+        let result = call_memory_tool_at(&base, "memory_list", json!({})).await;
+        assert!(result.is_err());
+    }
+
+    /// Live-transport test: mark `#[ignore]` so CI doesn't need a daemon.
+    /// Port 1 is reserved/unassigned, so the connection fails fast — this
+    /// just proves the function returns `Err` rather than hanging or panicking.
+    #[tokio::test]
+    #[ignore]
+    async fn call_memory_tool_at_unreachable_daemon() {
+        let result = call_memory_tool_at(
+            "http://127.0.0.1:1",
+            "memory_list",
+            json!({ "palace": "test-palace", "limit": 5 }),
+        )
+        .await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/trusty-common/src/mcp/mod.rs
+++ b/crates/trusty-common/src/mcp/mod.rs
@@ -12,11 +12,17 @@
 //!
 //! Test: `cargo test -p trusty-mcp-core` covers Response construction +
 //! the stdio loop round-trip behaviour with an in-memory dispatcher.
+//!
+//! `memory_rpc` (issue #2030) additionally provides discovery-based JSON-RPC
+//! *client* access to the trusty-memory daemon — the shared "resolve address
+//! + POST /rpc" helper every trusty-mpm / trusty-common call site now uses
+//! instead of a hardcoded port.
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 pub mod daemon_bridge;
+pub mod memory_rpc;
 pub mod openrpc;
 pub mod service;
 

--- a/crates/trusty-mpm/src/bin/tm/commands/session/catchup.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/catchup.rs
@@ -62,8 +62,9 @@ pub(crate) async fn handle_catchup(all_projects: bool, full: bool) -> anyhow::Re
 
     // Load config for the memory URL (fail-open to default).
     let config = trusty_mpm::core::config::MpmConfig::load_default();
-    let memory_url =
-        std::env::var("TRUSTY_MEMORY_URL").unwrap_or_else(|_| "http://127.0.0.1:7990".to_string());
+    // Discovery-first (issue #2030): resolves TRUSTY_MEMORY_URL when set, else
+    // the daemon's actual discovered bound address, never a hardcoded port.
+    let memory_url = trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable();
 
     for dir in &project_dirs {
         let opts = CatchupOptions {

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -489,8 +489,10 @@ fn prepare_session_inner(
     // repo, runtime error), the session still launches; catchup_context is None.
     // CUTOVER BRIDGE — remove post-migration (#1762)
     let catchup_context = if config.catchup.auto {
-        let memory_url = std::env::var("TRUSTY_MEMORY_URL")
-            .unwrap_or_else(|_| "http://127.0.0.1:7990".to_string());
+        // Discovery-first (issue #2030): resolves TRUSTY_MEMORY_URL when set,
+        // else the daemon's actual discovered bound address, never a
+        // hardcoded port.
+        let memory_url = trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable();
         let opts = crate::core::catchup::CatchupOptions {
             project_dir: project_dir.to_path_buf(),
             memory_url,

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -864,8 +864,11 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
         // it is entirely fail-open: any daemon-unreachable/parse error is
         // logged and swallowed, never propagated here.
         if self.prepare {
-            let memory_url = std::env::var("TRUSTY_MEMORY_URL")
-                .unwrap_or_else(|_| "http://127.0.0.1:7990".to_string());
+            // Discovery-first (issue #2030): resolves TRUSTY_MEMORY_URL when
+            // set, else the daemon's actual discovered bound address, never
+            // a hardcoded port.
+            let memory_url =
+                trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable();
             let override_value = trusty_common::palace_override_from_env();
             match trusty_common::derive_palace_id(
                 &workspace_path,

--- a/crates/trusty-mpm/src/tui/coordinator/banner.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/banner.rs
@@ -21,7 +21,7 @@
 
 use std::time::Duration;
 
-use crate::tui::health::{DEFAULT_MEMORY_URL, DEFAULT_SEARCH_URL};
+use crate::tui::health::DEFAULT_SEARCH_URL;
 
 /// Per-probe HTTP timeout for the startup backplane checks.
 ///
@@ -244,11 +244,20 @@ pub async fn probe_search(base: Option<&str>) -> ProbeOutcome {
 /// create it. Builds a single bounded client and threads it into both helpers.
 /// Returns [`ProbeOutcome::active`] with note `palace: user` when memory is live
 /// and the palace is present/creatable, else [`ProbeOutcome::unreachable`] with a
-/// short reason. `base` defaults to [`DEFAULT_MEMORY_URL`] when `None`.
+/// short reason. `base` defaults to the discovered trusty-memory address
+/// (issue #2030: `TRUSTY_MEMORY_URL` override, else the daemon's actual
+/// discovered bound address — never a hardcoded port) when `None`.
 /// Test: `probe_unreachable_memory_is_inactive` drives the dead-daemon branch;
 /// the live + palace-assertion path is exercised against a running daemon.
 pub async fn probe_memory(base: Option<&str>) -> ProbeOutcome {
-    let base = base.unwrap_or(DEFAULT_MEMORY_URL);
+    let resolved;
+    let base = match base {
+        Some(b) => b,
+        None => {
+            resolved = trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable();
+            resolved.as_str()
+        }
+    };
     let client = probe_client();
     if !health_ok_with(&client, base).await {
         return ProbeOutcome::unreachable(Some("memory daemon down".to_string()));

--- a/crates/trusty-mpm/src/tui/event_loop.rs
+++ b/crates/trusty-mpm/src/tui/event_loop.rs
@@ -39,8 +39,14 @@ pub(super) async fn run_loop<B: ratatui::backend::Backend>(
     // show; otherwise the coordinator chat gets the full width immediately.
     let mut state = DashboardState::default();
     let mut screen = Screen::default();
-    let mut health_screen =
-        HealthScreen::new(health::DEFAULT_SEARCH_URL, health::DEFAULT_MEMORY_URL);
+    // Issue #2030: seed the memory panel from discovery (TRUSTY_MEMORY_URL
+    // override, else the daemon's actual discovered bound address) rather
+    // than a hardcoded port. This resolved value is what the background
+    // poller's `HealthClient` is built with and polls for the TUI's lifetime.
+    let mut health_screen = HealthScreen::new(
+        health::DEFAULT_SEARCH_URL,
+        trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable(),
+    );
 
     // The health pollers run on detached tasks and push updates down a channel
     // the loop drains without blocking.

--- a/crates/trusty-mpm/src/tui/health/mod.rs
+++ b/crates/trusty-mpm/src/tui/health/mod.rs
@@ -44,9 +44,8 @@ pub use screen::{
     palace_index_tab_lines, service_name, tab_bar,
 };
 pub use types::{
-    CollectionRow, DEFAULT_MEMORY_URL, DEFAULT_SEARCH_URL, Daemon, HealthClient, HealthScreen,
-    HealthTab, HealthUpdate, LOG_BUFFER_CAP, LogBuffer, POLL_INTERVAL, PalaceActivity, PanelData,
-    PanelState,
+    CollectionRow, DEFAULT_SEARCH_URL, Daemon, HealthClient, HealthScreen, HealthTab, HealthUpdate,
+    LOG_BUFFER_CAP, LogBuffer, POLL_INTERVAL, PalaceActivity, PanelData, PanelState,
 };
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/tui/health/tests.rs
+++ b/crates/trusty-mpm/src/tui/health/tests.rs
@@ -14,14 +14,20 @@ use super::probes::{
 use super::screen::format_count_suffix;
 use super::types::HealthWire;
 use super::{
-    CollectionRow, DEFAULT_MEMORY_URL, DEFAULT_SEARCH_URL, Daemon, HealthScreen, HealthTab,
-    HealthUpdate, LOG_BUFFER_CAP, LogBuffer, PalaceActivity, PanelData, PanelState, activity_color,
-    ascii_bar, client_for, collections_lines, collections_lines_at_tick, format_bytes,
-    format_count, format_relative_time, format_rss, format_uptime, format_with_commas,
-    header_lines, health_tab_lines, index_tab_lines, memory_panel_lines, palace_activity,
-    palace_index_tab_lines, render, search_panel_lines, service_name, spinner_frame, tab_bar,
+    CollectionRow, DEFAULT_SEARCH_URL, Daemon, HealthScreen, HealthTab, HealthUpdate,
+    LOG_BUFFER_CAP, LogBuffer, PalaceActivity, PanelData, PanelState, activity_color, ascii_bar,
+    client_for, collections_lines, collections_lines_at_tick, format_bytes, format_count,
+    format_relative_time, format_rss, format_uptime, format_with_commas, header_lines,
+    health_tab_lines, index_tab_lines, memory_panel_lines, palace_activity, palace_index_tab_lines,
+    render, search_panel_lines, service_name, spinner_frame, tab_bar,
 };
 use ratatui::{Terminal, backend::TestBackend, style::Color};
+
+/// Test-only stand-in for the trusty-memory daemon address: a port nobody
+/// binds, used wherever a test previously relied on the removed
+/// `DEFAULT_MEMORY_URL` constant (issue #2030 — the real default is now
+/// resolved dynamically via discovery, not a fixed literal).
+const TEST_MEMORY_URL: &str = "http://127.0.0.1:19999";
 
 /// A sample online search payload for rendering tests.
 fn sample_search() -> PanelData {
@@ -55,8 +61,10 @@ fn sample_memory() -> PanelData {
 
 #[test]
 fn default_urls_are_local() {
+    // Only the search daemon has a fixed local convention port; the memory
+    // default is resolved dynamically via discovery (issue #2030), so there
+    // is no `DEFAULT_MEMORY_URL` constant left to assert on.
     assert_eq!(DEFAULT_SEARCH_URL, "http://127.0.0.1:7878");
-    assert_eq!(DEFAULT_MEMORY_URL, "http://127.0.0.1:7990");
 }
 
 #[test]
@@ -152,7 +160,7 @@ fn search_panel_lines_format_fields() {
 fn memory_panel_lines_format_fields() {
     let lines = memory_panel_lines(
         &PanelState::Online(sample_memory()),
-        "http://127.0.0.1:7990",
+        "http://127.0.0.1:7071",
     );
     assert!(lines.iter().any(|l| l.contains("MEMORY [●] v0.1.56")));
     assert!(
@@ -179,7 +187,7 @@ fn panel_lines_render_each_state() {
         &PanelState::Offline {
             last_error: "connection refused".into(),
         },
-        "http://127.0.0.1:7990",
+        "http://127.0.0.1:7071",
     );
     assert!(offline.iter().any(|l| l.contains("OFFLINE")));
     assert!(offline.iter().any(|l| l.contains("connection refused")));
@@ -426,7 +434,7 @@ fn service_name_matches_focus() {
 
 #[test]
 fn header_lines_show_focus_summary() {
-    let mut screen = HealthScreen::new(DEFAULT_SEARCH_URL, DEFAULT_MEMORY_URL);
+    let mut screen = HealthScreen::new(DEFAULT_SEARCH_URL, TEST_MEMORY_URL);
     screen.search = PanelState::Online(sample_search());
     let lines = header_lines(&screen);
     assert!(lines[0].contains("trusty-search"));
@@ -620,7 +628,7 @@ fn ascii_bar_fills_proportionally() {
 
 #[test]
 fn health_tab_lines_show_gauges() {
-    let mut screen = HealthScreen::new(DEFAULT_SEARCH_URL, DEFAULT_MEMORY_URL);
+    let mut screen = HealthScreen::new(DEFAULT_SEARCH_URL, TEST_MEMORY_URL);
     screen.search = PanelState::Online(sample_search());
     let lines = health_tab_lines(&screen);
     assert!(lines.iter().any(|l| l.starts_with("Memory ")));
@@ -1057,7 +1065,7 @@ fn index_tab_lines_routes_to_palace_when_focus_memory() {
 
 #[test]
 fn render_health_smoke() {
-    let mut screen = HealthScreen::new(DEFAULT_SEARCH_URL, DEFAULT_MEMORY_URL);
+    let mut screen = HealthScreen::new(DEFAULT_SEARCH_URL, TEST_MEMORY_URL);
     screen.search = PanelState::Online(sample_search());
     screen.memory = PanelState::Offline {
         last_error: "connection refused".into(),

--- a/crates/trusty-mpm/src/tui/health/types.rs
+++ b/crates/trusty-mpm/src/tui/health/types.rs
@@ -26,14 +26,6 @@ use serde::Deserialize;
 /// Test: `default_urls_are_local`.
 pub const DEFAULT_SEARCH_URL: &str = "http://127.0.0.1:7878";
 
-/// Default trusty-memory daemon address used when no override is supplied.
-///
-/// Why: mirrors [`DEFAULT_SEARCH_URL`]; the memory daemon's health endpoint is
-/// reached at `127.0.0.1:7990` for the monitor surface.
-/// What: the canonical local trusty-memory HTTP base URL.
-/// Test: `default_urls_are_local`.
-pub const DEFAULT_MEMORY_URL: &str = "http://127.0.0.1:7990";
-
 /// Interval between health polls for each panel.
 ///
 /// Why: the ticket mandates a 5-second refresh cadence for both the online and

--- a/crates/trusty-mpm/src/tui/mod.rs
+++ b/crates/trusty-mpm/src/tui/mod.rs
@@ -192,7 +192,11 @@ fn coordinator_session_to_row(s: crate::client::CoordinatorSession) -> client::S
 /// Why: the acceptance criteria require each daemon to be polled independently
 /// every 5 seconds without freezing the input loop. Running each poll on its
 /// own detached tokio task keeps a slow or hung daemon from blocking the other
-/// panel or the keyboard.
+/// panel or the keyboard. `memory_url` is resolved once by the caller before
+/// this is invoked (issue #2030: via discovery — `TRUSTY_MEMORY_URL` override,
+/// else the daemon's actual discovered bound address — never a hardcoded
+/// port); each task then reuses one cached [`health::HealthClient`] for its
+/// whole lifetime.
 /// What: spawns one task per daemon; each task polls its [`health::HealthClient`]
 /// on [`health::POLL_INTERVAL`] and sends every result down `tx` as a
 /// [`HealthUpdate`]. A task exits quietly once the receiver is dropped (the TUI

--- a/crates/trusty-mpm/src/tui/tests.rs
+++ b/crates/trusty-mpm/src/tui/tests.rs
@@ -107,7 +107,10 @@ fn render_screen_draws_both_screens_without_panic() {
     // Rendering each screen against a TestBackend must not panic.
     use ratatui::{Terminal, backend::TestBackend};
     let chat = DashboardState::default();
-    let hp = HealthScreen::new(health::DEFAULT_SEARCH_URL, health::DEFAULT_MEMORY_URL);
+    // `DEFAULT_MEMORY_URL` was removed (issue #2030) — the real default is
+    // resolved dynamically via discovery; an unreachable placeholder is fine
+    // for a render-only smoke test.
+    let hp = HealthScreen::new(health::DEFAULT_SEARCH_URL, "http://127.0.0.1:19999");
     for screen in [Screen::Chat, Screen::Health] {
         let backend = TestBackend::new(120, 24);
         let mut terminal = Terminal::new(backend).expect("test terminal");


### PR DESCRIPTION
## Summary
- `tm` (and trusty-code) reached trusty-memory via a hand-rolled `reqwest` GET against a hardcoded `http://127.0.0.1:7990` and an ad-hoc REST path (`/api/v1/palaces/{id}/drawers`). `7990` is wrong — trusty-memory auto-port-walks from ~7070-7079 — so catch-up silently failed even when the daemon was healthy, unless `TRUSTY_MEMORY_URL` was set.
- Added `trusty_common::mcp::memory_rpc` — one shared helper providing `resolve_memory_base_url` / `resolve_memory_base_url_or_unreachable` (env override first, discovery fallback via `read_daemon_addr("trusty-memory")`, never a hardcoded port) and `call_memory_tool` / `call_memory_tool_at`, which POST a JSON-RPC envelope to `{base}/rpc` — the same dispatcher the MCP stdio server and UDS transport already use.
- `catchup::palace::fetch_recent_palace_drawers` now calls `memory_list` over this JSON-RPC helper instead of the dead REST path, re-sorting client-side by `created_at` DESC (the tool itself sorts by importance) to preserve the old `sort=created_desc` contract. It returns `Option<Vec<DrawerSummary>>` so the catch-up digest can render a distinct "trusty-memory unreachable" message instead of conflating "down" with "genuinely empty".
- All four hardcoded-port call sites (`catchup/palace.rs`, `bin/tm/commands/session/catchup.rs`, `core/session_launch/mod.rs`, `provisioner/workspace.rs`) plus the TUI health screen's startup seed (`event_loop.rs`) and the coordinator banner probe (`banner.rs`) now resolve the address through the shared helper. The TUI's background poller still builds one cached `HealthClient` per daemon for its whole lifetime (unchanged poll cadence/behavior) — only the *initial* address it's given is now resolved via discovery instead of the dropped `DEFAULT_MEMORY_URL` constant.
- `trusty-common`'s `catchup` Cargo feature now also enables `mcp` (the new dependency), so `trusty-mpm` and `trusty-code` (which already enable `catchup`) pick it up transitively with no separate Cargo.toml change needed.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-common --features memory-core,catchup,embedder-test-support` — 494 passed, 0 failed (incl. new `mcp::memory_rpc` and `catchup::palace` tests)
- [x] `cargo test -p trusty-mpm` — 2334 + 722 + … passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations
- [x] `grep -rn "7990" crates/ docs/` — zero matches

Closes #2030

🤖 Generated with [Claude Code](https://claude.com/claude-code)