### PR TITLE
feat(trusty-installer): encode crate dependency graph and install transitively

### DIFF
--- a/crates/trusty-installer/src/commands/dependency_graph.rs
+++ b/crates/trusty-installer/src/commands/dependency_graph.rs
@@ -1,0 +1,473 @@
+//! Runtime "requires" dependency graph among [`super::stable_set`] members (#2036).
+//!
+//! Why: `tctl install trusty-mpm` used to install ONLY trusty-mpm, silently
+//! skipping the runtime daemons it actually needs (trusty-memory for the
+//! memory-palace MCP server, trusty-search for hybrid code search) — the
+//! operator ended up with a partially-functional stack and no warning.
+//! Encoding the "requires" edges as data lets [`super::stable_set::select_members_transitive`]
+//! compute the closure once, in one place, instead of every call site
+//! re-deriving it.
+//!
+//! What: A static edge table (`DEPENDENCY_EDGES`) plus pure graph functions:
+//! [`direct_requires`] (one hop), [`transitive_closure`] (all hops, BFS), and
+//! [`added_members`] (which crates were pulled in and by what). The edge table
+//! is intentionally conservative — an edge is only added when a member spawns,
+//! connects to, or otherwise requires another member's binary at runtime (not
+//! merely a `Cargo.toml` library dependency, which cargo already resolves).
+//! Two runtime edges are confirmed as of #2036:
+//! - `trusty-mpm` → `trusty-memory` + `trusty-search`: both MCP servers are
+//!   injected into every managed session by default
+//!   (`crates/trusty-mpm/src/core/manifest/default.rs`), and their addresses
+//!   are resolved via `crates/trusty-mpm/src/daemon/discover.rs`.
+//! - `trusty-review` → `trusty-search` + `trusty-analyze`: the
+//!   required-context preflight gate (#590,
+//!   `crates/trusty-review/src/pipeline/context_gate.rs`) SKIPS the review
+//!   entirely — "a review produced WITHOUT that context is actively harmful"
+//!   — when either dependency is unreachable, unless the operator explicitly
+//!   opts into a degraded run. This is a hard runtime requirement, not a soft
+//!   nicety (contrast `trusty-review`'s separate, genuinely best-effort JIRA/
+//!   Confluence/GitHub-Issues enrichment sources, which fail open and are NOT
+//!   encoded here).
+//!
+//! No other stable-set member has a confirmed runtime process dependency on
+//! another as of #2036. In particular: `trusty-console`'s `detect/*` connectors
+//! probe search/memory/analyze/review/mpm and proxy to whichever are already
+//! running, but console starts and serves fine with all of them absent (each
+//! reports `Absent` gracefully) — that is service discovery, not a runtime
+//! requirement, so no edge is encoded for it. `trusty-analyze` embeds
+//! `trusty-review`'s pipeline as an in-process library
+//! (`crates/trusty-analyze/src/mcp/review.rs`) rather than calling out to a
+//! separate `trusty-review` process, so that is a `Cargo.toml`/library
+//! relationship, not a process-level one — also not encoded. `tga` has no
+//! references to any other stable-set member's runtime surface.
+//!
+//! Test: `tests` covers closure computation (multi-hop, no-op for a leaf,
+//! idempotence when a dependency is named explicitly), the `added_members`
+//! grouping, and an invariant test that every edge target appears strictly
+//! earlier in [`super::stable_set::stable_set`] order than its dependent (so
+//! filtering the master list by closure membership yields a valid topological
+//! order without needing a separate sort).
+
+use std::collections::BTreeSet;
+
+/// Static "requires" edges: `(crate_name, [direct runtime dependencies])`.
+///
+/// Why: See module docs — kept conservative and evidence-based rather than
+/// mirroring `Cargo.toml`.
+///
+/// What: `trusty-mpm` requires `trusty-memory` + `trusty-search` (both MCP
+/// servers are injected into every session by default). `trusty-review`
+/// requires `trusty-search` + `trusty-analyze` (the #590 required-context gate
+/// skips the review when either is unreachable, absent an explicit
+/// degraded-mode opt-in).
+///
+/// Test: `tests::mpm_requires_memory_and_search`,
+/// `tests::review_requires_search_and_analyze`,
+/// `tests::edges_precede_dependent_in_stable_set_order`.
+const DEPENDENCY_EDGES: &[(&str, &[&str])] = &[
+    ("trusty-mpm", &["trusty-memory", "trusty-search"]),
+    ("trusty-review", &["trusty-search", "trusty-analyze"]),
+];
+
+/// One member added to a selection because an explicitly-requested member
+/// (transitively) requires it.
+///
+/// Why: The CLI and picker need to tell the operator *why* extra members
+/// appeared in the install set, not just silently expand it.
+///
+/// What: `crate_name` is the added member; `required_by` lists the
+/// explicitly-requested crate names whose transitive dependency chain
+/// includes it (sorted, deduplicated).
+///
+/// Test: `tests::added_members_reports_requester`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AddedMember {
+    /// The crate name that was pulled in.
+    pub crate_name: String,
+    /// Explicitly-requested crate names that (transitively) require it.
+    pub required_by: Vec<String>,
+}
+
+/// The direct (one-hop) runtime dependencies of `crate_name`.
+///
+/// Why: The single lookup point into [`DEPENDENCY_EDGES`] so callers never
+/// pattern-match the table directly.
+///
+/// What: Returns the declared dependency slice, or `&[]` when `crate_name` has
+/// no entry (leaf or unknown crate).
+///
+/// Test: `tests::leaf_has_no_direct_requires`, `tests::mpm_requires_memory_and_search`.
+pub fn direct_requires(crate_name: &str) -> &'static [&'static str] {
+    DEPENDENCY_EDGES
+        .iter()
+        .find(|(c, _)| *c == crate_name)
+        .map_or(&[], |(_, deps)| *deps)
+}
+
+/// Compute the transitive closure of `explicit` crate names over the graph.
+///
+/// Why: `select_members_transitive` needs the full set of crates to install —
+/// everything explicitly requested plus everything they (transitively) require
+/// — before it can filter the master ordered list.
+///
+/// What: BFS from every name in `explicit`, following [`direct_requires`] edges,
+/// returning the union (including the explicit names themselves) as a
+/// `BTreeSet` for stable, deduplicated iteration.
+///
+/// Test: `tests::transitive_closure_expands_mpm`,
+/// `tests::transitive_closure_noop_for_leaf`,
+/// `tests::transitive_closure_idempotent_when_dep_named_explicitly`.
+pub fn transitive_closure(explicit: &[String]) -> BTreeSet<String> {
+    let mut closure: BTreeSet<String> = explicit.iter().cloned().collect();
+    let mut stack: Vec<String> = explicit.to_vec();
+    while let Some(current) = stack.pop() {
+        for dep in direct_requires(&current) {
+            let dep = (*dep).to_owned();
+            if closure.insert(dep.clone()) {
+                stack.push(dep);
+            }
+        }
+    }
+    closure
+}
+
+/// Whether `from` transitively requires `to` (used to build `required_by`).
+///
+/// Why: `added_members` needs to know, for each pulled-in crate, which
+/// explicitly-requested crates are responsible for pulling it in.
+///
+/// What: DFS from `from` over [`direct_requires`] edges; returns `true` if
+/// `to` is reachable (including zero hops, i.e. `from == to`).
+///
+/// Test: Exercised indirectly via `tests::added_members_reports_requester`.
+fn reaches(from: &str, to: &str) -> bool {
+    let mut seen = BTreeSet::new();
+    let mut stack = vec![from.to_owned()];
+    while let Some(current) = stack.pop() {
+        if current == to {
+            return true;
+        }
+        if !seen.insert(current.clone()) {
+            continue;
+        }
+        for dep in direct_requires(&current) {
+            stack.push((*dep).to_owned());
+        }
+    }
+    false
+}
+
+/// Describe which members of `closure` were added because of an explicit
+/// request, and by whom.
+///
+/// Why: Powers the "adding trusty-memory, trusty-search (required by
+/// trusty-mpm)" surfacing in the CLI and picker.
+///
+/// What: For every crate in `closure` that is NOT itself in `explicit`, finds
+/// every explicitly-requested crate that transitively requires it and records
+/// an [`AddedMember`]. Order follows `closure`'s (alphabetical) iteration.
+///
+/// Test: `tests::added_members_reports_requester`,
+/// `tests::added_members_empty_when_nothing_added`.
+pub fn added_members(explicit: &[String], closure: &BTreeSet<String>) -> Vec<AddedMember> {
+    let mut added = Vec::new();
+    for crate_name in closure {
+        if explicit.iter().any(|e| e == crate_name) {
+            continue;
+        }
+        let mut required_by: Vec<String> = explicit
+            .iter()
+            .filter(|e| reaches(e, crate_name))
+            .cloned()
+            .collect();
+        required_by.sort();
+        required_by.dedup();
+        added.push(AddedMember {
+            crate_name: crate_name.clone(),
+            required_by,
+        });
+    }
+    added
+}
+
+/// Render `added` as human-readable lines, grouped by identical requester sets.
+///
+/// Why: One line per distinct requester group reads better than one line per
+/// added crate ("adding trusty-memory, trusty-search (required by
+/// trusty-mpm)" instead of two separate lines).
+///
+/// What: Groups `added` by `required_by`, joins each group's crate names with
+/// `", "`, and formats `"adding {crates} (required by {requesters})"` per
+/// group. Groups are ordered by their sorted requester key for determinism.
+///
+/// Test: `tests::describe_added_groups_by_requester`,
+/// `tests::describe_added_empty_is_empty`.
+pub fn describe_added(added: &[AddedMember]) -> Vec<String> {
+    use std::collections::BTreeMap;
+
+    let mut groups: BTreeMap<Vec<String>, Vec<String>> = BTreeMap::new();
+    for a in added {
+        groups
+            .entry(a.required_by.clone())
+            .or_default()
+            .push(a.crate_name.clone());
+    }
+    groups
+        .into_iter()
+        .map(|(required_by, crates)| {
+            format!(
+                "adding {} (required by {})",
+                crates.join(", "),
+                required_by.join(", ")
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::stable_set::stable_set;
+
+    /// Why: Pins the one confirmed runtime edge so a future accidental table
+    /// edit is caught.
+    /// What: Asserts `direct_requires("trusty-mpm")` is exactly
+    /// `[trusty-memory, trusty-search]`.
+    /// Test: This is the test.
+    #[test]
+    fn mpm_requires_memory_and_search() {
+        assert_eq!(
+            direct_requires("trusty-mpm"),
+            &["trusty-memory", "trusty-search"]
+        );
+    }
+
+    /// Why: A crate with no table entry (leaf or unknown) must not panic or
+    /// synthesize an edge.
+    /// What: Asserts `direct_requires` returns `&[]` for a leaf and an unknown name.
+    /// Test: This is the test.
+    #[test]
+    fn leaf_has_no_direct_requires() {
+        assert!(direct_requires("trusty-search").is_empty());
+        assert!(direct_requires("not-a-real-crate").is_empty());
+    }
+
+    /// Why: trusty-review's #590 required-context gate is a hard runtime
+    /// dependency on search + analyze (it SKIPS the review outright when
+    /// either is unreachable); pin the edge.
+    /// What: Asserts `direct_requires("trusty-review")` is exactly
+    /// `[trusty-search, trusty-analyze]`.
+    /// Test: This is the test.
+    #[test]
+    fn review_requires_search_and_analyze() {
+        assert_eq!(
+            direct_requires("trusty-review"),
+            &["trusty-search", "trusty-analyze"]
+        );
+    }
+
+    /// Why: trusty-console's service-discovery probes (detect/*) are
+    /// deliberately NOT a hard requires edge — console runs fine with every
+    /// daemon absent — so this must stay a leaf even though it has detectors
+    /// for every other member.
+    /// What: Asserts `direct_requires("trusty-console")` is empty.
+    /// Test: This is the test.
+    #[test]
+    fn console_service_discovery_is_not_a_requires_edge() {
+        assert!(direct_requires("trusty-console").is_empty());
+    }
+
+    /// Why: The core transitive-expansion contract for #2036 — installing
+    /// trusty-mpm must pull in its runtime deps.
+    /// What: `transitive_closure(["trusty-mpm"])` includes trusty-mpm,
+    /// trusty-memory, and trusty-search (and nothing else).
+    /// Test: This is the test.
+    #[test]
+    fn transitive_closure_expands_mpm() {
+        let closure = transitive_closure(&["trusty-mpm".to_owned()]);
+        assert_eq!(
+            closure,
+            BTreeSet::from([
+                "trusty-mpm".to_owned(),
+                "trusty-memory".to_owned(),
+                "trusty-search".to_owned(),
+            ])
+        );
+    }
+
+    /// Why: A leaf crate (no dependents) must expand to exactly itself.
+    /// What: `transitive_closure(["tga"])` is `{"tga"}`.
+    /// Test: This is the test.
+    #[test]
+    fn transitive_closure_noop_for_leaf() {
+        let closure = transitive_closure(&["tga".to_owned()]);
+        assert_eq!(closure, BTreeSet::from(["tga".to_owned()]));
+    }
+
+    /// Why: The #590 gate scenario — installing trusty-review alone must pull
+    /// in both trusty-search and trusty-analyze.
+    /// What: `transitive_closure(["trusty-review"])` includes all three
+    /// crate_names (and nothing else).
+    /// Test: This is the test.
+    #[test]
+    fn transitive_closure_expands_review() {
+        let closure = transitive_closure(&["trusty-review".to_owned()]);
+        assert_eq!(
+            closure,
+            BTreeSet::from([
+                "trusty-review".to_owned(),
+                "trusty-search".to_owned(),
+                "trusty-analyze".to_owned(),
+            ])
+        );
+    }
+
+    /// Why: Requesting two dependents that share a dependency (trusty-mpm and
+    /// trusty-review both require trusty-search) must union correctly rather
+    /// than duplicating or dropping the shared dependency.
+    /// What: `transitive_closure(["trusty-mpm", "trusty-review"])` is exactly
+    /// the five-member union.
+    /// Test: This is the test.
+    #[test]
+    fn transitive_closure_unions_shared_dependency() {
+        let closure = transitive_closure(&["trusty-mpm".to_owned(), "trusty-review".to_owned()]);
+        assert_eq!(
+            closure,
+            BTreeSet::from([
+                "trusty-mpm".to_owned(),
+                "trusty-memory".to_owned(),
+                "trusty-search".to_owned(),
+                "trusty-review".to_owned(),
+                "trusty-analyze".to_owned(),
+            ])
+        );
+    }
+
+    /// Why: Naming a dependency explicitly alongside its dependent must not
+    /// duplicate it or change the closure.
+    /// What: `transitive_closure(["trusty-mpm", "trusty-memory"])` is still
+    /// exactly `{trusty-mpm, trusty-memory, trusty-search}`.
+    /// Test: This is the test.
+    #[test]
+    fn transitive_closure_idempotent_when_dep_named_explicitly() {
+        let closure = transitive_closure(&["trusty-mpm".to_owned(), "trusty-memory".to_owned()]);
+        assert_eq!(
+            closure,
+            BTreeSet::from([
+                "trusty-mpm".to_owned(),
+                "trusty-memory".to_owned(),
+                "trusty-search".to_owned(),
+            ])
+        );
+    }
+
+    /// Why: `added_members` must attribute a pulled-in crate to the explicit
+    /// request that caused it, not list every explicit crate blindly.
+    /// What: Requesting only trusty-mpm reports trusty-memory and
+    /// trusty-search as added, each `required_by: ["trusty-mpm"]`.
+    /// Test: This is the test.
+    #[test]
+    fn added_members_reports_requester() {
+        let explicit = vec!["trusty-mpm".to_owned()];
+        let closure = transitive_closure(&explicit);
+        let mut added = added_members(&explicit, &closure);
+        added.sort_by(|a, b| a.crate_name.cmp(&b.crate_name));
+        assert_eq!(
+            added,
+            vec![
+                AddedMember {
+                    crate_name: "trusty-memory".to_owned(),
+                    required_by: vec!["trusty-mpm".to_owned()],
+                },
+                AddedMember {
+                    crate_name: "trusty-search".to_owned(),
+                    required_by: vec!["trusty-mpm".to_owned()],
+                },
+            ]
+        );
+    }
+
+    /// Why: When nothing was pulled in (e.g. a leaf, or all deps named
+    /// explicitly), `added_members` must be empty — no spurious announcements.
+    /// What: Asserts an empty result for a leaf-only request.
+    /// Test: This is the test.
+    #[test]
+    fn added_members_empty_when_nothing_added() {
+        let explicit = vec!["tga".to_owned()];
+        let closure = transitive_closure(&explicit);
+        assert!(added_members(&explicit, &closure).is_empty());
+    }
+
+    /// Why: When two explicitly-requested members share a dependency (mpm and
+    /// review both require trusty-search), the shared dependency's
+    /// `required_by` must list BOTH requesters, not just the first one found.
+    /// What: Requesting `["trusty-mpm", "trusty-review"]`; asserts
+    /// trusty-search's `required_by` is `["trusty-mpm", "trusty-review"]`.
+    /// Test: This is the test.
+    #[test]
+    fn added_members_reports_all_requesters_for_shared_dependency() {
+        let explicit = vec!["trusty-mpm".to_owned(), "trusty-review".to_owned()];
+        let closure = transitive_closure(&explicit);
+        let added = added_members(&explicit, &closure);
+        let search = added
+            .iter()
+            .find(|a| a.crate_name == "trusty-search")
+            .expect("trusty-search reported as added");
+        assert_eq!(
+            search.required_by,
+            vec!["trusty-mpm".to_owned(), "trusty-review".to_owned()]
+        );
+    }
+
+    /// Why: The CLI/picker message format is a load-bearing contract (#2036
+    /// acceptance criteria); pin its exact shape.
+    /// What: Asserts the grouped message text for the mpm case.
+    /// Test: This is the test.
+    #[test]
+    fn describe_added_groups_by_requester() {
+        let explicit = vec!["trusty-mpm".to_owned()];
+        let closure = transitive_closure(&explicit);
+        let added = added_members(&explicit, &closure);
+        let lines = describe_added(&added);
+        assert_eq!(
+            lines,
+            vec!["adding trusty-memory, trusty-search (required by trusty-mpm)".to_owned()]
+        );
+    }
+
+    /// Why: No added members must produce no message lines.
+    /// What: Asserts `describe_added(&[])` is empty.
+    /// Test: This is the test.
+    #[test]
+    fn describe_added_empty_is_empty() {
+        assert!(describe_added(&[]).is_empty());
+    }
+
+    /// Why: `select_members_transitive` relies on filtering the master
+    /// `stable_set()` order to already be a valid topological order; that only
+    /// holds if every edge target appears strictly earlier in the list than
+    /// its dependent. This test guards the invariant so a future edge addition
+    /// that violates it fails loudly instead of silently mis-ordering installs.
+    /// What: For every `(dependent, deps)` in `DEPENDENCY_EDGES`, asserts each
+    /// dep's index in `stable_set()` is less than the dependent's index.
+    /// Test: This is the test.
+    #[test]
+    fn edges_precede_dependent_in_stable_set_order() {
+        let order: Vec<String> = stable_set().into_iter().map(|m| m.crate_name).collect();
+        let index_of = |name: &str| {
+            order
+                .iter()
+                .position(|n| n == name)
+                .unwrap_or_else(|| panic!("{name} not in stable_set()"))
+        };
+        for (dependent, deps) in DEPENDENCY_EDGES {
+            let dependent_idx = index_of(dependent);
+            for dep in *deps {
+                assert!(
+                    index_of(dep) < dependent_idx,
+                    "{dep} must precede {dependent} in stable_set() order"
+                );
+            }
+        }
+    }
+}

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -24,9 +24,10 @@
 use serde::Serialize;
 use trusty_progress::{Component, ComponentTracker};
 
+use super::dependency_graph::describe_added;
 use super::progress_ui::{narrator, prompt_yes_no};
 use super::runtime::block_on;
-use super::stable_set::{select_members, StableMember};
+use super::stable_set::{select_members_transitive, StableMember};
 use crate::output::render_json;
 
 /// One member's install outcome for the `--json` report.
@@ -129,7 +130,8 @@ pub fn run(members: &[String], yes: bool, json: bool) -> i32 {
         members
     };
 
-    let (selected, unknown) = select_members(members);
+    let resolved = select_members_transitive(members);
+    let (selected, unknown) = (resolved.members, resolved.unknown);
 
     if !unknown.is_empty() {
         let msg = format!("unknown member(s): {}", unknown.join(", "));
@@ -147,6 +149,16 @@ pub fn run(members: &[String], yes: bool, json: bool) -> i32 {
             eprintln!("tctl install: {msg}");
         }
         return 3;
+    }
+
+    // #2036: surface members pulled in transitively by a runtime dependency
+    // (e.g. "adding trusty-memory, trusty-search (required by trusty-mpm)")
+    // before the blast-radius confirmation, so the operator knows why the set
+    // grew beyond what they typed.
+    if !json {
+        for line in describe_added(&resolved.added) {
+            eprintln!("tctl install: {line}");
+        }
     }
 
     // Phase 6: detect and optionally install external prerequisites.

--- a/crates/trusty-installer/src/commands/mod.rs
+++ b/crates/trusty-installer/src/commands/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod auto_update;
 pub mod config;
+pub mod dependency_graph;
 pub mod doctor;
 pub mod ensure;
 pub mod install;

--- a/crates/trusty-installer/src/commands/picker.rs
+++ b/crates/trusty-installer/src/commands/picker.rs
@@ -16,7 +16,8 @@
 //! interactive I/O surface (`prompt_picker`) is side-effect-only and validated
 //! manually.
 
-use crate::commands::stable_set::StableMember;
+use crate::commands::dependency_graph::describe_added;
+use crate::commands::stable_set::{select_members_transitive, StableMember};
 
 /// A short human-readable description for each stable-set member.
 ///
@@ -103,18 +104,23 @@ pub fn parse_selection(input: &str, n: usize) -> Result<Vec<usize>, String> {
 /// What: Prints a numbered list of `components` (index, crate name, description)
 /// and a selection prompt. Accepts `all`, `none`/empty, or comma/space-separated
 /// 1-based indices. On invalid input: re-prompts once with an error note, then
-/// returns an error if the second attempt also fails. On success returns the
-/// selected [`StableMember`] slice in stable-set order.
+/// returns an error if the second attempt also fails. On success, expands the
+/// chosen components over the runtime dependency graph (#2036) — auto-selecting
+/// (and announcing to stderr) any member required by a chosen one that the
+/// operator didn't pick themselves — and returns the resulting
+/// [`StableMember`] list in stable-set order. An empty choice (`none`/empty
+/// input) is returned as-is (never expanded to "everything").
 ///
-/// Test: Side-effect-only (stderr + stdin); `parse_selection` is unit-tested.
+/// Test: Side-effect-only (stderr + stdin); `parse_selection` and the
+/// dependency expansion (`dependency_graph::tests`) are unit-tested.
 pub fn prompt_picker(components: &[StableMember]) -> anyhow::Result<Vec<StableMember>> {
     use std::io::Write;
 
     print_menu(components);
 
     let first = read_line()?;
-    match parse_selection(&first, components.len()) {
-        Ok(indices) => Ok(indices.into_iter().map(|i| components[i].clone()).collect()),
+    let chosen = match parse_selection(&first, components.len()) {
+        Ok(indices) => indices.into_iter().map(|i| components[i].clone()).collect(),
         Err(e) => {
             // Re-prompt once with the error note.
             eprintln!("  (invalid: {e} — try again or type 'all'/'none')");
@@ -124,9 +130,39 @@ pub fn prompt_picker(components: &[StableMember]) -> anyhow::Result<Vec<StableMe
             let indices = parse_selection(&second, components.len()).map_err(|e2| {
                 anyhow::anyhow!("invalid selection: {e2} (aborting — re-run tctl install)")
             })?;
-            Ok(indices.into_iter().map(|i| components[i].clone()).collect())
+            indices.into_iter().map(|i| components[i].clone()).collect()
         }
+    };
+    Ok(expand_with_dependencies(chosen))
+}
+
+/// Expand a picker choice to include its runtime dependencies (#2036).
+///
+/// Why: A picker that lets the operator select `trusty-mpm` alone but not its
+/// runtime deps would recreate the exact gap #2036 fixes for the non-picker
+/// (`tctl install <names>`) path. Separated from `prompt_picker` so the
+/// dependency-expansion logic is reachable without stdin/stderr in tests.
+///
+/// What: An empty `chosen` is returned unchanged (no picker selection means
+/// "install nothing", not "install everything"). Otherwise resolves `chosen`'s
+/// crate names through [`select_members_transitive`] (against the full
+/// [`crate::commands::stable_set::stable_set`], independent of what subset
+/// `components` showed), prints one "adding …" line per distinct requester
+/// group via [`describe_added`], and returns the expanded, topologically
+/// ordered member list.
+///
+/// Test: `tests::expand_with_dependencies_pulls_in_mpm_deps`,
+/// `tests::expand_with_dependencies_noop_for_empty`.
+fn expand_with_dependencies(chosen: Vec<StableMember>) -> Vec<StableMember> {
+    if chosen.is_empty() {
+        return chosen;
     }
+    let names: Vec<String> = chosen.iter().map(|m| m.crate_name.clone()).collect();
+    let resolved = select_members_transitive(&names);
+    for line in describe_added(&resolved.added) {
+        eprintln!("  {line}");
+    }
+    resolved.members
 }
 
 /// Print the numbered component menu to stderr.
@@ -307,5 +343,47 @@ mod tests {
             member_description("nonexistent-crate"),
             "trusty-* component"
         );
+    }
+
+    // ── expand_with_dependencies (#2036) ─────────────────────────────────────
+
+    /// Why: Picking trusty-mpm alone in the picker must pull in its runtime
+    /// deps, same as the non-interactive `tctl install trusty-mpm` path.
+    /// What: Chooses only the trusty-mpm `StableMember`; asserts the expanded
+    /// result also contains trusty-memory and trusty-search, in stable-set order.
+    /// Test: This is the test.
+    #[test]
+    fn expand_with_dependencies_pulls_in_mpm_deps() {
+        let mpm = stable_set()
+            .into_iter()
+            .find(|m| m.crate_name == "trusty-mpm")
+            .expect("trusty-mpm in stable set");
+        let expanded = expand_with_dependencies(vec![mpm]);
+        let names: Vec<String> = expanded.into_iter().map(|m| m.crate_name).collect();
+        assert_eq!(names, vec!["trusty-search", "trusty-memory", "trusty-mpm"]);
+    }
+
+    /// Why: An empty picker choice ("none"/empty input) means "install
+    /// nothing" and must NOT be expanded to the whole stable set (which is
+    /// what `select_members_transitive(&[])` would otherwise return).
+    /// What: Passes an empty `Vec`; asserts the result is still empty.
+    /// Test: This is the test.
+    #[test]
+    fn expand_with_dependencies_noop_for_empty() {
+        assert!(expand_with_dependencies(Vec::new()).is_empty());
+    }
+
+    /// Why: A leaf choice (no dependents) must pass through unchanged.
+    /// What: Chooses only tga; asserts the expanded result is still `[tga]`.
+    /// Test: This is the test.
+    #[test]
+    fn expand_with_dependencies_noop_for_leaf() {
+        let tga = stable_set()
+            .into_iter()
+            .find(|m| m.crate_name == "tga")
+            .expect("tga in stable set");
+        let expanded = expand_with_dependencies(vec![tga]);
+        let names: Vec<String> = expanded.into_iter().map(|m| m.crate_name).collect();
+        assert_eq!(names, vec!["tga"]);
     }
 }

--- a/crates/trusty-installer/src/commands/stable_set.rs
+++ b/crates/trusty-installer/src/commands/stable_set.rs
@@ -163,6 +163,105 @@ pub fn select_members(names: &[String]) -> (Vec<StableMember>, Vec<String>) {
     (selected, unknown)
 }
 
+/// Result of resolving a caller-named subset AND expanding it over the
+/// [`super::dependency_graph`] runtime "requires" edges (#2036).
+///
+/// Why: Install needs three things from one resolution pass: the full,
+/// topologically-ordered set to actually install; the unresolved names to
+/// error out on; and which members were pulled in by dependency (so the CLI
+/// and picker can tell the operator why).
+///
+/// What: `members` is the transitive closure of the resolved explicit names,
+/// filtered from [`stable_set`] (so it is already in topological — dependency
+/// before dependent — order); `unknown` mirrors [`select_members`]'s unknown
+/// list; `added` describes members present in `members` that were not named
+/// explicitly.
+///
+/// Test: `tests::select_transitive_expands_mpm`,
+/// `tests::select_transitive_noop_for_leaf`,
+/// `tests::select_transitive_idempotent_when_dep_named_explicitly`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransitiveSelection {
+    /// The resolved set, transitively closed, in topological install order.
+    pub members: Vec<StableMember>,
+    /// Names from the caller's request that matched no stable-set member.
+    pub unknown: Vec<String>,
+    /// Members pulled in because something explicitly requested requires them.
+    pub added: Vec<super::dependency_graph::AddedMember>,
+}
+
+/// Resolve a caller-named subset AND expand it to the transitive closure of
+/// its runtime dependencies (#2036).
+///
+/// Why: `tctl install trusty-mpm` must also bring up trusty-memory and
+/// trusty-search — the daemons trusty-mpm actually needs at runtime — rather
+/// than leaving the operator with a silently-incomplete stack. Scoped to
+/// install/picker only (not `upgrade`/`config`/`lifecycle`, which use
+/// [`select_members`] unchanged): those commands target already-installed,
+/// independently-running daemons where auto-expanding the blast radius (e.g.
+/// `tctl stop trusty-mpm` also stopping the shared trusty-search daemon) would
+/// surprise the operator rather than help them.
+///
+/// What: Resolves `names` against [`stable_set`] exactly like [`select_members`]
+/// (empty = all, matched by crate name or binary), then runs
+/// [`super::dependency_graph::transitive_closure`] over the resolved crate
+/// names and filters the master ordered list down to that closure — which is
+/// already a valid topological order because every dependency edge points to a
+/// crate earlier in [`stable_set`]'s list (see
+/// `dependency_graph::tests::edges_precede_dependent_in_stable_set_order`).
+/// `unknown` short-circuits: when any name is unrecognised, `members`/`added`
+/// are left empty (mirrors [`select_members`]'s existing "unknown wins"
+/// caller contract used by `install.rs`).
+///
+/// Test: `tests::select_transitive_expands_mpm`,
+/// `tests::select_transitive_reports_unknown`,
+/// `tests::select_transitive_preserves_order_with_explicit_deps`.
+pub fn select_members_transitive(names: &[String]) -> TransitiveSelection {
+    let all = stable_set();
+    if names.is_empty() {
+        return TransitiveSelection {
+            members: all,
+            unknown: Vec::new(),
+            added: Vec::new(),
+        };
+    }
+
+    let mut explicit: Vec<String> = Vec::new();
+    for n in names {
+        if let Some(m) = all.iter().find(|m| n == &m.crate_name || n == &m.binary) {
+            if !explicit.contains(&m.crate_name) {
+                explicit.push(m.crate_name.clone());
+            }
+        }
+    }
+    let unknown: Vec<String> = names
+        .iter()
+        .filter(|n| !all.iter().any(|m| *n == &m.crate_name || *n == &m.binary))
+        .cloned()
+        .collect();
+
+    if !unknown.is_empty() {
+        return TransitiveSelection {
+            members: Vec::new(),
+            unknown,
+            added: Vec::new(),
+        };
+    }
+
+    let closure = super::dependency_graph::transitive_closure(&explicit);
+    let members: Vec<StableMember> = all
+        .into_iter()
+        .filter(|m| closure.contains(&m.crate_name))
+        .collect();
+    let added = super::dependency_graph::added_members(&explicit, &closure);
+
+    TransitiveSelection {
+        members,
+        unknown: Vec::new(),
+        added,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,5 +401,101 @@ mod tests {
         let (sel, unknown) = select_members(&["not-a-tool".to_owned()]);
         assert!(sel.is_empty());
         assert_eq!(unknown, vec!["not-a-tool".to_owned()]);
+    }
+
+    // ── select_members_transitive (#2036) ────────────────────────────────────
+
+    /// Why: The core #2036 contract — installing trusty-mpm must transitively
+    /// pull in trusty-memory and trusty-search, in topological (deps-first) order.
+    /// What: Requests only trusty-mpm; asserts the resolved set is exactly
+    /// [trusty-search, trusty-memory, trusty-mpm] (stable-set order) and both
+    /// pulled-in members are reported in `added`.
+    /// Test: This is the test.
+    #[test]
+    fn select_transitive_expands_mpm() {
+        let sel = select_members_transitive(&["trusty-mpm".to_owned()]);
+        let names: Vec<String> = sel.members.iter().map(|m| m.crate_name.clone()).collect();
+        assert_eq!(names, vec!["trusty-search", "trusty-memory", "trusty-mpm"]);
+        assert!(sel.unknown.is_empty());
+        let mut added_names: Vec<String> = sel.added.iter().map(|a| a.crate_name.clone()).collect();
+        added_names.sort();
+        assert_eq!(added_names, vec!["trusty-memory", "trusty-search"]);
+        for a in &sel.added {
+            assert_eq!(a.required_by, vec!["trusty-mpm".to_owned()]);
+        }
+    }
+
+    /// Why: The other #2036-confirmed edge — installing trusty-review alone
+    /// must transitively pull in trusty-search and trusty-analyze (the #590
+    /// required-context gate), in topological order.
+    /// What: Requests only trusty-review; asserts the resolved set is exactly
+    /// [trusty-search, trusty-analyze, trusty-review] and both pulled-in
+    /// members are reported in `added`.
+    /// Test: This is the test.
+    #[test]
+    fn select_transitive_expands_review() {
+        let sel = select_members_transitive(&["trusty-review".to_owned()]);
+        let names: Vec<String> = sel.members.iter().map(|m| m.crate_name.clone()).collect();
+        assert_eq!(
+            names,
+            vec!["trusty-search", "trusty-analyze", "trusty-review"]
+        );
+        let mut added_names: Vec<String> = sel.added.iter().map(|a| a.crate_name.clone()).collect();
+        added_names.sort();
+        assert_eq!(added_names, vec!["trusty-analyze", "trusty-search"]);
+    }
+
+    /// Why: A leaf crate (no dependents) must not pull in anything extra.
+    /// What: Requests only tga; asserts the resolved set is exactly `[tga]` with
+    /// no `added` entries.
+    /// Test: This is the test.
+    #[test]
+    fn select_transitive_noop_for_leaf() {
+        let sel = select_members_transitive(&["tga".to_owned()]);
+        let names: Vec<String> = sel.members.iter().map(|m| m.crate_name.clone()).collect();
+        assert_eq!(names, vec!["tga"]);
+        assert!(sel.added.is_empty());
+    }
+
+    /// Why: Naming a dependency explicitly alongside its dependent must be
+    /// idempotent — no duplicate, no spurious `added` entry for the
+    /// explicitly-named dependency, and order is still preserved.
+    /// What: Requests `["trusty-mpm", "trusty-memory"]`; asserts the resolved
+    /// set is still exactly [trusty-search, trusty-memory, trusty-mpm] and only
+    /// trusty-search shows up in `added`.
+    /// Test: This is the test.
+    #[test]
+    fn select_transitive_preserves_order_with_explicit_deps() {
+        let sel = select_members_transitive(&["trusty-mpm".to_owned(), "trusty-memory".to_owned()]);
+        let names: Vec<String> = sel.members.iter().map(|m| m.crate_name.clone()).collect();
+        assert_eq!(names, vec!["trusty-search", "trusty-memory", "trusty-mpm"]);
+        let added_names: Vec<String> = sel.added.iter().map(|a| a.crate_name.clone()).collect();
+        assert_eq!(added_names, vec!["trusty-search"]);
+    }
+
+    /// Why: Unknown names must still be surfaced (not silently dropped) even
+    /// though this function does dependency expansion.
+    /// What: Requests a bogus name; asserts `members`/`added` are empty and the
+    /// bogus name lands in `unknown`.
+    /// Test: This is the test.
+    #[test]
+    fn select_transitive_reports_unknown() {
+        let sel = select_members_transitive(&["not-a-tool".to_owned()]);
+        assert!(sel.members.is_empty());
+        assert!(sel.added.is_empty());
+        assert_eq!(sel.unknown, vec!["not-a-tool".to_owned()]);
+    }
+
+    /// Why: An empty selection means "the whole platform" — same contract as
+    /// `select_members`.
+    /// What: Asserts `select_members_transitive(&[])` returns the full set, no
+    /// unknowns, no added.
+    /// Test: This is the test.
+    #[test]
+    fn select_transitive_empty_returns_all() {
+        let sel = select_members_transitive(&[]);
+        assert_eq!(sel.members.len(), stable_set().len());
+        assert!(sel.unknown.is_empty());
+        assert!(sel.added.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Encodes a runtime "requires" dependency graph among the stable-set trusty-* crates in a new `crates/trusty-installer/src/commands/dependency_graph.rs` module, and makes `tctl install <members>` / the interactive picker compute the transitive closure of the requested members instead of installing only the named binary.
- Two runtime edges are encoded, each backed by concrete code evidence (not guessed):
  - `trusty-mpm` → `trusty-memory` + `trusty-search`: both MCP servers are injected into every managed session by default (`crates/trusty-mpm/src/core/manifest/default.rs`), and their addresses are resolved via `crates/trusty-mpm/src/daemon/discover.rs`.
  - `trusty-review` → `trusty-search` + `trusty-analyze`: the required-context preflight gate (#590, `crates/trusty-review/src/pipeline/context_gate.rs`) explicitly SKIPS the review when either dependency is unreachable, unless the operator opts into a degraded run — a hard runtime requirement, not a soft nicety.
- Deliberately conservative on what is NOT encoded: `trusty-console`'s `detect/*` connectors probe every other daemon (search/memory/analyze/review/mpm) for its proxy/overview UI, but console starts and serves fine with all of them absent — that's service discovery, not a runtime requirement, so no edge is added for it. `trusty-analyze` embeds `trusty-review`'s pipeline as an in-process library (not a separate process), so that's a `Cargo.toml` relationship, not encoded either. `tga` has no cross-references to any other member.
- `select_members` (used by `upgrade`/`config`/lifecycle commands) is left unchanged; a new `select_members_transitive` (returning a `TransitiveSelection` with `members`, `unknown`, and `added`) is used only by `install`/`picker`, since auto-expanding the blast radius of `stop`/`upgrade` on an already-running daemon would surprise an operator rather than help them.
- `tctl install trusty-mpm` and the interactive picker now print `adding trusty-memory, trusty-search (required by trusty-mpm)` before the install confirmation, so the operator knows why the set grew.
- Order is computed by filtering the master `stable_set()` list down to the closure, which is already a valid topological (deps-before-dependent) order because every encoded edge points to a crate earlier in `stable_set()`'s list — an invariant test (`edges_precede_dependent_in_stable_set_order`) guards this so a future edge that violates it fails loudly.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-installer` (335 passed, 0 failed, 3 ignored — live-network tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)