### PR TITLE
fix(trusty-common): verify_installed_binary checks ~/.local/bin and $CARGO_HOME

### DIFF
--- a/crates/trusty-common/src/update/tests.rs
+++ b/crates/trusty-common/src/update/tests.rs
@@ -265,6 +265,222 @@ async fn verify_installed_binary_fails_for_missing_binary() {
     );
 }
 
+// ── candidate_bin_dirs (pure path-resolution logic, issue #1771) ──────────
+
+#[test]
+fn candidate_bin_dirs_falls_back_to_dot_cargo() {
+    let home = std::path::Path::new("/home/tester");
+    let dirs = super::upgrade::candidate_bin_dirs(Some(home), None);
+    assert_eq!(dirs[0], home.join(".cargo").join("bin"));
+}
+
+#[test]
+fn candidate_bin_dirs_prefers_cargo_home_override() {
+    let home = std::path::Path::new("/home/tester");
+    let dirs = super::upgrade::candidate_bin_dirs(Some(home), Some("/opt/custom-cargo"));
+    assert_eq!(
+        dirs[0],
+        std::path::PathBuf::from("/opt/custom-cargo").join("bin"),
+        "CARGO_HOME override must take priority over ~/.cargo/bin"
+    );
+}
+
+#[test]
+fn candidate_bin_dirs_ignores_empty_cargo_home() {
+    let home = std::path::Path::new("/home/tester");
+    let dirs = super::upgrade::candidate_bin_dirs(Some(home), Some(""));
+    assert_eq!(
+        dirs[0],
+        home.join(".cargo").join("bin"),
+        "empty CARGO_HOME must fall back to ~/.cargo/bin, not be treated as a path"
+    );
+}
+
+#[test]
+fn candidate_bin_dirs_includes_local_bin() {
+    let home = std::path::Path::new("/home/tester");
+    let dirs = super::upgrade::candidate_bin_dirs(Some(home), None);
+    assert!(
+        dirs.contains(&home.join(".local").join("bin")),
+        "~/.local/bin (the prebuilt installer's default) must be a candidate: {dirs:?}"
+    );
+    // ~/.local/bin must be checked after ~/.cargo/bin, not before.
+    let local_idx = dirs
+        .iter()
+        .position(|d| d == &home.join(".local").join("bin"))
+        .expect("local bin present");
+    let cargo_idx = dirs
+        .iter()
+        .position(|d| d == &home.join(".cargo").join("bin"))
+        .expect("cargo bin present");
+    assert!(cargo_idx < local_idx, "cargo bin must be checked first");
+}
+
+#[test]
+fn candidate_bin_dirs_empty_without_home_or_cargo_home() {
+    let dirs = super::upgrade::candidate_bin_dirs(None, None);
+    assert!(
+        dirs.is_empty(),
+        "no home and no CARGO_HOME override must yield zero candidates"
+    );
+}
+
+// ── verify_installed_binary directory resolution (issue #1771) ────────────
+//
+// These write a tiny executable shell script that exits 0 on `--version` and
+// point HOME at a tempdir so the real filesystem/env are never touched.
+
+/// Write a minimal executable shell script at `path` that responds
+/// successfully to `--version`, standing in for a real installed binary.
+#[cfg(unix)]
+fn write_fake_binary(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::write(path, b"#!/bin/sh\necho fake 1.0.0\nexit 0\n").expect("write fake binary");
+    let mut perms = std::fs::metadata(path)
+        .expect("stat fake binary")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).expect("chmod fake binary");
+}
+
+/// Snapshot of the env vars mutated by the `verify_installed_binary_*`
+/// directory-resolution tests, captured so they can be restored verbatim.
+#[cfg(unix)]
+struct EnvSnapshot {
+    home: Option<String>,
+    cargo_home: Option<String>,
+    path: Option<String>,
+}
+
+/// Set `HOME` (and clear `CARGO_HOME` unless `cargo_home` is given) and
+/// return the prior values so the caller can restore them afterward.
+///
+/// Why: Split into non-async set/restore steps (rather than wrapping an
+/// awaited closure) so the `ENV_LOCK` guard is only ever held across the
+/// synchronous mutation, never across an `.await` point
+/// (`clippy::await_holding_lock`).
+#[cfg(unix)]
+fn set_home_env(home: &std::path::Path, cargo_home: Option<&str>) -> EnvSnapshot {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let snapshot = EnvSnapshot {
+        home: std::env::var("HOME").ok(),
+        cargo_home: std::env::var("CARGO_HOME").ok(),
+        path: std::env::var("PATH").ok(),
+    };
+    unsafe {
+        std::env::set_var("HOME", home);
+        match cargo_home {
+            Some(v) => std::env::set_var("CARGO_HOME", v),
+            None => std::env::remove_var("CARGO_HOME"),
+        }
+    }
+    snapshot
+}
+
+/// Restore env vars captured by [`set_home_env`]. Must be called after the
+/// awaited work under test has completed.
+#[cfg(unix)]
+fn restore_home_env(snapshot: EnvSnapshot) {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    unsafe {
+        match snapshot.home {
+            Some(h) => std::env::set_var("HOME", h),
+            None => std::env::remove_var("HOME"),
+        }
+        match snapshot.cargo_home {
+            Some(h) => std::env::set_var("CARGO_HOME", h),
+            None => std::env::remove_var("CARGO_HOME"),
+        }
+        match snapshot.path {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn verify_installed_binary_finds_binary_in_cargo_bin() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cargo_bin = tmp.path().join(".cargo").join("bin");
+    std::fs::create_dir_all(&cargo_bin).expect("mkdir .cargo/bin");
+    write_fake_binary(&cargo_bin.join("fake_trusty_bin_cargo"));
+
+    let snapshot = set_home_env(tmp.path(), None);
+    let result = super::verify_installed_binary("fake_trusty_bin_cargo").await;
+    restore_home_env(snapshot);
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn verify_installed_binary_finds_binary_in_local_bin() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Deliberately do NOT create ~/.cargo/bin — only ~/.local/bin has the
+    // binary, mirroring a prebuilt-installer-only install (issue #1771/#1992).
+    let local_bin = tmp.path().join(".local").join("bin");
+    std::fs::create_dir_all(&local_bin).expect("mkdir .local/bin");
+    write_fake_binary(&local_bin.join("fake_trusty_bin_local"));
+
+    let snapshot = set_home_env(tmp.path(), None);
+    let result = super::verify_installed_binary("fake_trusty_bin_local").await;
+    restore_home_env(snapshot);
+
+    assert!(
+        result.is_ok(),
+        "expected Ok when binary only exists in ~/.local/bin, got {result:?}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn verify_installed_binary_honours_cargo_home_override() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let custom_cargo_home = tmp.path().join("custom-cargo-home");
+    let custom_bin = custom_cargo_home.join("bin");
+    std::fs::create_dir_all(&custom_bin).expect("mkdir custom cargo bin");
+    write_fake_binary(&custom_bin.join("fake_trusty_bin_cargo_home"));
+
+    let home_dir = tmp.path().join("home");
+    std::fs::create_dir_all(&home_dir).expect("mkdir home");
+
+    let snapshot = set_home_env(
+        &home_dir,
+        Some(custom_cargo_home.to_str().expect("utf8 path")),
+    );
+    let result = super::verify_installed_binary("fake_trusty_bin_cargo_home").await;
+    restore_home_env(snapshot);
+
+    assert!(
+        result.is_ok(),
+        "expected Ok when binary is under $CARGO_HOME/bin, got {result:?}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn verify_installed_binary_finds_binary_via_path() {
+    // HOME points at an empty tempdir with neither ~/.cargo/bin nor
+    // ~/.local/bin containing the binary, forcing the PATH/`which` fallback.
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    let path_tmp = tempfile::tempdir().expect("path tempdir");
+    write_fake_binary(&path_tmp.path().join("fake_trusty_bin_path"));
+
+    let snapshot = set_home_env(home_tmp.path(), None);
+    let prev_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{prev_path}", path_tmp.path().display());
+    unsafe { std::env::set_var("PATH", &new_path) };
+
+    let result = super::verify_installed_binary("fake_trusty_bin_path").await;
+    restore_home_env(snapshot);
+
+    assert!(
+        result.is_ok(),
+        "expected Ok via PATH fallback, got {result:?}"
+    );
+}
+
 /// Verify that `is_launchd_supervised` returns `false` in a normal test env.
 ///
 /// Why: Unit tests run in a developer terminal / CI, neither of which is a

--- a/crates/trusty-common/src/update/upgrade.rs
+++ b/crates/trusty-common/src/update/upgrade.rs
@@ -47,28 +47,82 @@ pub async fn perform_upgrade(crate_name: &str) -> anyhow::Result<()> {
     }
 }
 
+/// Resolve the ordered list of directories a binary might have been
+/// installed into, given an optional home directory and `CARGO_HOME` value.
+///
+/// Why: `cargo install` and the prebuilt-download installer path
+/// (`trusty-installer::download::default_install_dir`, `~/.local/bin`) place
+/// binaries in different directories, and the cargo path honours a
+/// `$CARGO_HOME` override (issue #1771). Extracting the rule into a pure
+/// function over explicit `home` / `cargo_home` inputs — rather than reading
+/// `dirs::home_dir()` / `std::env::var` directly — keeps it testable without
+/// mutating global process state for the common case.
+///
+/// What: Returns, in priority order: `<cargo_home>/bin` when `cargo_home` is
+/// `Some` and non-empty, else `<home>/.cargo/bin`; then `<home>/.local/bin`
+/// (the prebuilt installer's default). Entries that require `home` are
+/// omitted when `home` is `None`.
+///
+/// Test: `candidate_bin_dirs_prefers_cargo_home_override`,
+/// `candidate_bin_dirs_falls_back_to_dot_cargo`,
+/// `candidate_bin_dirs_includes_local_bin`,
+/// `candidate_bin_dirs_empty_without_home_or_cargo_home`.
+pub(crate) fn candidate_bin_dirs(
+    home: Option<&std::path::Path>,
+    cargo_home: Option<&str>,
+) -> Vec<std::path::PathBuf> {
+    let mut dirs = Vec::new();
+
+    match cargo_home {
+        Some(h) if !h.is_empty() => dirs.push(std::path::PathBuf::from(h).join("bin")),
+        _ => {
+            if let Some(home) = home {
+                dirs.push(home.join(".cargo").join("bin"));
+            }
+        }
+    }
+
+    if let Some(home) = home {
+        dirs.push(home.join(".local").join("bin"));
+    }
+
+    dirs
+}
+
 /// Probe the freshly-installed binary with `--version` as a health gate.
 ///
 /// Why: Before the daemon self-exits to trigger launchd's KeepAlive respawn,
 /// we must confirm the new binary is not corrupt or incompatible. If the
 /// health gate fails we keep the old binary running and report the failure
-/// clearly — we never exit into a broken binary.
+/// clearly — we never exit into a broken binary. The binary may have landed
+/// in `~/.cargo/bin` (cargo-install path), `~/.local/bin` (the prebuilt
+/// installer's default — see `trusty-installer::download::default_install_dir`),
+/// or a custom `$CARGO_HOME/bin`; checking only `~/.cargo/bin` produced false
+/// "not installed" reports for prebuilt installs (issue #1771/#1992).
 ///
-/// What: Locates the binary by checking `~/.cargo/bin/<binary_name>` first,
-/// then falling back to PATH via `which`. Spawns `<bin> --version` with a
-/// 10-second timeout; returns `Ok(())` if the process exits 0.
-/// Returns `Err` on failure, timeout, or missing binary.
+/// What: Checks, in order, `$CARGO_HOME/bin/<binary_name>` (or
+/// `~/.cargo/bin/<binary_name>` when `CARGO_HOME` is unset), then
+/// `~/.local/bin/<binary_name>`, then falls back to PATH via `which`. Spawns
+/// `<bin> --version` with a 10-second timeout; returns `Ok(())` if the
+/// process exits 0. Returns `Err` on failure, timeout, or missing binary.
 ///
 /// Test: `verify_installed_binary_passes_for_cargo` (ignore-tagged integration);
-/// `verify_installed_binary_fails_for_missing_binary` tests the failure path.
+/// `verify_installed_binary_fails_for_missing_binary`,
+/// `verify_installed_binary_finds_binary_in_cargo_bin`,
+/// `verify_installed_binary_finds_binary_in_local_bin`,
+/// `verify_installed_binary_finds_binary_via_path`,
+/// `verify_installed_binary_honours_cargo_home_override`.
 pub async fn verify_installed_binary(binary_name: &str) -> anyhow::Result<()> {
-    // Prefer the explicit ~/.cargo/bin/<name> path — that is where
-    // `cargo install` drops the binary, and it may differ from PATH.
-    let cargo_bin = dirs::home_dir().map(|h| h.join(".cargo").join("bin").join(binary_name));
+    let home = dirs::home_dir();
+    let cargo_home = std::env::var("CARGO_HOME").ok();
+    let found = candidate_bin_dirs(home.as_deref(), cargo_home.as_deref())
+        .into_iter()
+        .map(|dir| dir.join(binary_name))
+        .find(|p| p.exists());
 
-    let bin_path = match cargo_bin {
-        Some(p) if p.exists() => p.to_string_lossy().into_owned(),
-        _ => {
+    let bin_path = match found {
+        Some(p) => p.to_string_lossy().into_owned(),
+        None => {
             let which_out = tokio::process::Command::new("which")
                 .arg(binary_name)
                 .output()
@@ -76,7 +130,7 @@ pub async fn verify_installed_binary(binary_name: &str) -> anyhow::Result<()> {
                 .map_err(|e| anyhow::anyhow!("failed to run `which {binary_name}`: {e}"))?;
             if !which_out.status.success() {
                 return Err(anyhow::anyhow!(
-                    "binary `{binary_name}` not found in ~/.cargo/bin or PATH"
+                    "binary `{binary_name}` not found in ~/.cargo/bin, ~/.local/bin, or PATH"
                 ));
             }
             String::from_utf8_lossy(&which_out.stdout).trim().to_owned()


### PR DESCRIPTION
## Summary

`verify_installed_binary` (`crates/trusty-common/src/update/upgrade.rs`) only
checked `~/.cargo/bin/<binary>` before falling back to a PATH `which` lookup.
It never checked `~/.local/bin` — the actual default directory the
installer's prebuilt-download path installs into
(`trusty-installer::download::default_install_dir`, used by
`commands/install.rs`). After a successful prebuilt install into
`~/.local/bin`, the health gate reported the binary as **not installed**,
producing the false "installed 0/N" report from #1992. It also ignored a
`$CARGO_HOME` override, per the issue title.

- Extracts a pure `candidate_bin_dirs(home, cargo_home)` helper that returns,
  in priority order: `$CARGO_HOME/bin` (or `~/.cargo/bin` when unset), then
  `~/.local/bin` (the prebuilt installer's default).
- `verify_installed_binary` now checks all candidate directories before
  falling back to PATH via `which`.
- No `unwrap()`/`expect()` added to non-test code; `anyhow` error handling
  preserved; `Why/What/Test` doc triple kept on both functions.

## Test plan

- [x] `cargo build --workspace` — clean build
- [x] `cargo test -p trusty-common --features update-check,memory-core,embedder-test-support` — 455 lib tests + all integration targets pass (0 failed), including 9 new/updated tests covering found-in-cargo-bin, found-in-local-bin, found-via-PATH, `$CARGO_HOME` override, and not-found
- [x] `cargo test -p trusty-installer` — 311 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (0 violations)

Note: plain `cargo test -p trusty-common` (no extra features) fails to
compile `tests/memory_palace.rs` — a **pre-existing, unrelated** issue: that
integration test unconditionally imports `trusty_common::memory_core`, which
is gated behind the `memory-core` feature, with no `required-features` gate
in `Cargo.toml`. Confirmed pre-existing via `cargo test -p trusty-common
--no-run` (zero features, no relation to this change) hitting the identical
error before any of this PR's edits were exercised.

Closes #1771

🤖 Generated with [Claude Code](https://claude.com/claude-code)