### PR TITLE
fix(trusty-mpm): PM summarizes orchestration in prose instead of raw pm_summary JSON

### DIFF
--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -184,24 +184,36 @@ exceptions.
 
 ## PM Response Format
 
-At the end of orchestration, provide a structured summary, including an
-`investigation` field that records what research confirmed.
+At the end of orchestration, reply to the user with a concise, human-readable
+**prose** summary — not a raw JSON dump. A wall of JSON is poor UX for a chat
+reply; the user wants to know what was found and fixed, not parse a data
+structure. Lead with the investigation, since that's the differentiator of
+this mode, then cover the rest in short markdown (a few bullets or a small
+table, sized to the work done):
 
-```json
-{
-  "pm_summary": true,
-  "request": "Original user request",
-  "investigation": ["research finding 1 (file:symbol)", "root cause: ..."],
-  "agents_used": {"research": 3, "rust-engineer": 1, "qa": 1},
-  "tasks_completed": ["[research] ...", "[rust-engineer] ...", "[qa] ..."],
-  "files_affected": ["crates/.../src/lib.rs", "crates/.../tests/api.rs"],
-  "quality_gate": "make check: cargo test/clippy/fmt all passed",
-  "layer": "API → CLI surfacing order followed",
-  "blockers_encountered": ["Issue (resolved by agent)"],
-  "next_steps": ["User action 1", "User action 2"],
-  "remember": ["Critical info 1", "Critical info 2"]
-}
-```
+- **What research found** — the confirmed root cause (`file:symbol`) and any
+  ruled-out hypotheses, stated plainly.
+- **What shipped** — PRs/issues opened, merged, or updated; files affected,
+  grouped by crate rather than exhaustively listed.
+- **Quality gate** — the one-line pass/fail result of `make check` plus
+  `cargo build --workspace`.
+- **What's still pending** — follow-up work, open items, or things left undone.
+- **Decisions needed** — anything that requires the user's input, called out
+  clearly so it isn't missed.
+
+Field notes for the Rust context:
+- Name the trusty-mpm agents involved (`research`, `rust-engineer`, `qa`,
+  `local-ops`) only if it adds useful context — don't enumerate every
+  delegation.
+- Reference workspace-relative `.rs`, `Cargo.toml`, or asset paths that
+  changed, grouped by crate.
+- State the raw outcome of `make check` / `cargo build --workspace` plainly —
+  don't soften a failure.
+
+A structured record of the same facts, including the investigation trail, may
+be persisted separately for later recall; that durable-log mechanism is
+independent of this visible reply and is not something the PM implements
+directly.
 
 ## Detailed Workflows (See PM Skills)
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -180,24 +180,33 @@ four must pass — no exceptions.
 
 ## PM Response Format
 
-At the end of orchestration, provide a structured summary. In teaching mode,
-precede it with a short "What you just saw" paragraph recapping the key
-orchestration decisions.
+At the end of orchestration, reply to the user with a concise, human-readable
+**prose** summary — not a raw JSON dump. A wall of JSON defeats the teaching
+purpose; the point is for the user to understand what happened and why. In
+teaching mode, precede it with a short "What you just saw" paragraph recapping
+the key orchestration decisions, then cover the rest in short markdown (a few
+bullets or a small table, sized to the work done):
 
-```json
-{
-  "pm_summary": true,
-  "request": "Original user request",
-  "agents_used": {"research": 2, "rust-engineer": 3, "qa": 1},
-  "tasks_completed": ["[research] ...", "[rust-engineer] ...", "[qa] ..."],
-  "files_affected": ["crates/.../src/lib.rs", "crates/.../tests/api.rs"],
-  "quality_gate": "make check: cargo test/clippy/fmt all passed",
-  "layer": "API → CLI surfacing order followed",
-  "blockers_encountered": ["Issue (resolved by agent)"],
-  "next_steps": ["User action 1", "User action 2"],
-  "remember": ["Critical info 1", "Critical info 2"]
-}
-```
+- **What shipped** — PRs/issues opened, merged, or updated; files affected,
+  grouped by crate rather than exhaustively listed.
+- **Quality gate** — the one-line pass/fail result of `make check` plus
+  `cargo build --workspace`.
+- **What's still pending** — follow-up work, open items, or things left undone.
+- **Decisions needed** — anything that requires the user's input, called out
+  clearly so it isn't missed.
+
+Field notes for the Rust context:
+- Name the trusty-mpm agents involved (`research`, `rust-engineer`, `qa`,
+  `local-ops`) only if it adds useful context — don't enumerate every
+  delegation.
+- Reference workspace-relative `.rs`, `Cargo.toml`, or asset paths that
+  changed, grouped by crate.
+- State the raw outcome of `make check` / `cargo build --workspace` plainly —
+  don't soften a failure.
+
+A structured record of the same facts may be persisted separately for later
+recall; that durable-log mechanism is independent of this visible reply and is
+not something the PM implements directly.
 
 ## Detailed Workflows (See PM Skills)
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -182,29 +182,31 @@ the agent reports back with verified evidence.
 
 ## PM Response Format
 
-At the end of orchestration, provide a structured summary:
+At the end of orchestration, reply to the user with a concise, human-readable
+**prose** summary — not a raw JSON dump. A wall of JSON is poor UX for a chat
+reply; the user wants to know what happened, not parse a data structure. Cover,
+in short markdown (a few bullets or a small table, sized to the work done):
 
-```json
-{
-  "pm_summary": true,
-  "request": "Original user request",
-  "agents_used": {"research": 2, "rust-engineer": 3, "qa": 1},
-  "tasks_completed": ["[research] ...", "[rust-engineer] ...", "[qa] ..."],
-  "files_affected": ["crates/.../src/lib.rs", "crates/.../tests/api.rs"],
-  "quality_gate": "make check: cargo test/clippy/fmt all passed",
-  "layer": "API → CLI surfacing order followed",
-  "blockers_encountered": ["Issue (resolved by agent)"],
-  "next_steps": ["User action 1", "User action 2"],
-  "remember": ["Critical info 1", "Critical info 2"]
-}
-```
+- **What shipped** — PRs/issues opened, merged, or updated; files affected,
+  grouped by crate rather than exhaustively listed.
+- **Quality gate** — the one-line pass/fail result of `make check` plus
+  `cargo build --workspace`.
+- **What's still pending** — follow-up work, open items, or things left undone.
+- **Decisions needed** — anything that requires the user's input, called out
+  clearly so it isn't missed.
 
 Field notes for the Rust context:
-- `agents_used` keys are trusty-mpm agent names (`research`, `rust-engineer`,
-  `qa`, `local-ops`).
-- `files_affected` lists workspace-relative `.rs`, `Cargo.toml`, or asset paths.
-- `quality_gate` records the raw outcome of `make check` plus
-  `cargo build --workspace`.
+- Name the trusty-mpm agents involved (`research`, `rust-engineer`, `qa`,
+  `local-ops`) only if it adds useful context — don't enumerate every
+  delegation.
+- Reference workspace-relative `.rs`, `Cargo.toml`, or asset paths that
+  changed, grouped by crate.
+- State the raw outcome of `make check` / `cargo build --workspace` plainly —
+  don't soften a failure.
+
+A structured record of the same facts may be persisted separately for later
+recall; that durable-log mechanism is independent of this visible reply and is
+not something the PM implements directly.
 
 ## Detailed Workflows (See PM Skills)
 


### PR DESCRIPTION
## Summary
- Part 1 of #2044: stops the trusty-mpm PM from dumping raw `pm_summary` JSON to the user at the end of orchestration.
- Rewrites the "PM Response Format" section in all three bundled output-style assets (`trusty-mpm.md`, `trusty-mpm-research.md`, `trusty-mpm-teacher.md`) so the PM's visible end-of-orchestration reply is a concise, human-readable prose summary — what shipped (PRs/issues), the quality-gate result, what's still pending, and anything needing the user's decision — using short markdown (bullets/small table) instead of a raw ` ```json ` code fence.
- Preserves each variant's character: the research variant still leads with the investigation/root-cause framing, and the teacher variant still opens with a "What you just saw" recap paragraph.
- Adds one sentence noting a structured record of the same facts may be persisted separately for later recall, without instructing the PM to implement that mechanism (durable-log is Part 2 of #2044, a follow-up — not addressed here).

This is an output-style asset change only — no Rust logic touched. The assets are bundled via `include_str!` in `crates/trusty-mpm/src/core/bundle.rs`, so the crate build was rerun to confirm they still bundle correctly.

## Test plan
- [x] `cargo build -p trusty-mpm` — clean build, output styles bundle correctly.
- [x] `cargo build --workspace` — clean build (pre-existing pnpm placeholder-UI warnings only, unrelated to this change).
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 14 allowlisted, 0 violations — OK.`
- [x] Grepped all three edited assets for `pm_summary` and ` ```json ` — no matches remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)