### PR TITLE
feat(trusty-search): self-managed orphan reaping — stop leaking dead index registrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11087,7 +11087,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.29.2"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -49,7 +49,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.18.1", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.29.0" }
+trusty-search = { path = "../trusty-search", version = "0.30.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -6,6 +6,43 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.30.0] — 2026-07-06
+
+### Added — self-managed orphan reaping (daemon no longer leaks dead registrations)
+
+- **The daemon now removes orphaned index registrations automatically.**
+  Previously, an ephemeral MPM worktree (`.worktrees/<uuid>/`) that was
+  registered and then deleted left a dead entry in `indexes.toml` forever:
+  warm-boot *detected* the missing `root_path`, logged "run
+  `trusty-search prune-orphans`", and skipped it — but nothing ever removed it.
+  Over a long-lived daemon these accumulated without bound (a real machine
+  reached **485 dead registrations over 26 days**), each holding an idle
+  FSEvents watch that pinned macOS `fseventsd` at ~100% CPU / 8 GB RSS.
+  Three complementary mechanisms now keep the registry self-healing:
+  - **Boot self-heal** — `heal_boot_orphans` runs at warm-boot start and drops
+    legacy (non-colocated) registrations whose `root_path` was deleted, so they
+    stop being re-read on every boot. Colocated entries are still left to the
+    relocation scan.
+  - **Runtime reaper ticker** — an hourly background sweep unregisters live
+    indexes whose root vanished mid-run. Cadence is tunable via
+    `TRUSTY_ORPHAN_REAP_SECS` (`0` disables it).
+  - **Ephemeral-dir ignore** — auto-discovery and the colocated rescan now skip
+    the `.worktrees/` component, so throwaway worktrees are never
+    auto-registered (or FSEvents-watched) in the first place. Explicit
+    `trusty-search index <path>` is unaffected.
+
+### Safety
+
+- Orphan reaping only fires when a `root_path` is missing **and its immediate
+  parent still exists** — a deleted worktree leaves `.worktrees/` behind (reap),
+  while an unmounted external volume takes the whole parent chain with it (spared).
+- The automatic reaper **never deletes on-disk index data**, only the
+  registration, so a false-positive detection is always recoverable by
+  re-registering the path. (The interactive `DELETE /indexes/:id` still removes
+  data as before.)
+
+---
+
 ## [0.29.1] — 2026-06-25
 
 ### Fixed (closes #1711)

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.29.2"
+version = "0.30.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/src/commands/discover/mod.rs
+++ b/crates/trusty-search/src/commands/discover/mod.rs
@@ -127,6 +127,15 @@ pub async fn auto_discover_and_index() {
             if !path.is_dir() {
                 continue;
             }
+            // Skip ephemeral session dirs (`.worktrees/`) so throwaway MPM
+            // worktrees are never auto-registered (orphan self-heal).
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(crate::service::constants::is_ephemeral_dir_name)
+            {
+                continue;
+            }
             let marker = detect_project_marker(&path);
             if marker == ProjectMarker::None {
                 continue;

--- a/crates/trusty-search/src/commands/start/restore.rs
+++ b/crates/trusty-search/src/commands/start/restore.rs
@@ -58,8 +58,7 @@ pub(super) async fn restore_indexes(
     // dead entries are re-read, re-warned, and re-skipped on every single boot
     // and never leave `indexes.toml`. Colocated entries are left for the
     // relocation scan; unmounted volumes are spared by `is_reapable_orphan`.
-    let legacy_entries =
-        crate::service::orphan_reaper::heal_boot_orphans(collect_legacy_entries());
+    let legacy_entries = crate::service::orphan_reaper::heal_boot_orphans(collect_legacy_entries());
     let mut seen_ids: HashSet<String> = HashSet::new();
     // Issue #860: track canonicalized root_paths from legacy entries so that
     // colocated scan suppresses entries for the same root.

--- a/crates/trusty-search/src/commands/start/restore.rs
+++ b/crates/trusty-search/src/commands/start/restore.rs
@@ -52,7 +52,14 @@ pub(super) async fn restore_indexes(
     }
 
     // ── Collect: legacy + colocated entries ──────────────────────────────────
-    let legacy_entries = collect_legacy_entries();
+    // Self-heal (orphan self-heal): drop legacy registrations whose root_path
+    // was deleted (e.g. an ephemeral `.worktrees/<uuid>` removed while the
+    // daemon was down) before we try to restore or watch them. Without this the
+    // dead entries are re-read, re-warned, and re-skipped on every single boot
+    // and never leave `indexes.toml`. Colocated entries are left for the
+    // relocation scan; unmounted volumes are spared by `is_reapable_orphan`.
+    let legacy_entries =
+        crate::service::orphan_reaper::heal_boot_orphans(collect_legacy_entries());
     let mut seen_ids: HashSet<String> = HashSet::new();
     // Issue #860: track canonicalized root_paths from legacy entries so that
     // colocated scan suppresses entries for the same root.

--- a/crates/trusty-search/src/service/constants.rs
+++ b/crates/trusty-search/src/service/constants.rs
@@ -16,3 +16,43 @@
 /// unreadable, and the value injected into the embedded UI when
 /// `SearchAppState::daemon_port` is `None`.
 pub const DEFAULT_PORT: u16 = 7878;
+
+/// Directory names that are ephemeral / session-scoped and must never be
+/// *auto*-registered as indexes.
+///
+/// Why: MPM creates a throwaway git worktree per session under
+/// `.worktrees/<uuid>/` and deletes it when the session ends. Auto-discovery
+/// and the colocated rescan would otherwise register (and FSEvents-watch) each
+/// one, and every removed worktree then leaks a dead registration — the churn
+/// that pinned `fseventsd` at 8 GB. Skipping the `.worktrees` component during
+/// *discovery* (component-level, so nested `.base/.worktrees/*` is covered too)
+/// stops the churn at the source. This only gates automatic discovery; the hard
+/// denylist is untouched, so an explicit `trusty-search index <worktree>` still
+/// works when a caller genuinely wants a worktree indexed.
+/// What: the set of path-component names discovery must not descend into or
+/// register, checked via [`is_ephemeral_dir_name`].
+/// Test: `is_ephemeral_dir_name_*` and the discovery skip tests.
+pub const EPHEMERAL_DIR_NAMES: &[&str] = &[".worktrees"];
+
+/// True iff `name` is an ephemeral directory component that auto-discovery must
+/// skip. See [`EPHEMERAL_DIR_NAMES`].
+pub fn is_ephemeral_dir_name(name: &str) -> bool {
+    EPHEMERAL_DIR_NAMES.contains(&name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the discovery skip keys on an exact component match — `.worktrees`
+    /// is ephemeral, but an ordinary project must not be misclassified.
+    /// What: asserts the positive and negative cases.
+    /// Test: this test.
+    #[test]
+    fn is_ephemeral_dir_name_matches_worktrees_only() {
+        assert!(is_ephemeral_dir_name(".worktrees"));
+        assert!(!is_ephemeral_dir_name("worktrees"));
+        assert!(!is_ephemeral_dir_name("my-project"));
+        assert!(!is_ephemeral_dir_name(".git"));
+    }
+}

--- a/crates/trusty-search/src/service/fs_discovery.rs
+++ b/crates/trusty-search/src/service/fs_discovery.rs
@@ -170,7 +170,13 @@ fn scan_dir_recursive(
         let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
         // Prune: do not descend into .trusty-search/ itself, .git/, or any
         // hidden dir other than known project markers — keeps the scan cheap.
-        if name == COLOCATED_DIR_NAME || name == ".git" || name == "node_modules" {
+        // Also skip ephemeral session dirs (`.worktrees/`) so throwaway MPM
+        // worktrees are never rediscovered and re-registered (orphan self-heal).
+        if name == COLOCATED_DIR_NAME
+            || name == ".git"
+            || name == "node_modules"
+            || crate::service::constants::is_ephemeral_dir_name(name)
+        {
             continue;
         }
         // Only scan subdirectories that are children of the original tracked
@@ -256,6 +262,38 @@ mod tests {
             "nested project must be found; got: {root_paths:?}"
         );
         assert_eq!(found.len(), 2, "exactly two indexes must be found");
+    }
+
+    #[test]
+    fn discovery_skips_ephemeral_worktree_dirs() {
+        // Why (orphan self-heal): a colocated index living inside an ephemeral
+        // `.worktrees/<uuid>/` must NOT be rediscovered — rediscovering these is
+        // exactly what leaked hundreds of dead registrations when the worktrees
+        // were later deleted. The top-level project is still found.
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        make_colocated(&root);
+
+        // A worktree with its own colocated index, nested under `.worktrees/`.
+        let worktree = root.join(".worktrees").join("abcd-uuid");
+        fs::create_dir_all(&worktree).unwrap();
+        make_colocated(&worktree);
+
+        let found =
+            scan_roots_for_colocated_indexes(std::slice::from_ref(&root), DEFAULT_SCAN_DEPTH);
+        let canon_root = root.canonicalize().unwrap();
+        let canon_worktree = worktree.canonicalize().unwrap();
+        let root_paths: Vec<_> = found.iter().map(|e| &e.root_path).collect();
+
+        assert!(
+            root_paths.contains(&&canon_root),
+            "top-level project must still be found; got: {root_paths:?}"
+        );
+        assert!(
+            !root_paths.contains(&&canon_worktree),
+            "ephemeral .worktrees/ index must be skipped; got: {root_paths:?}"
+        );
+        assert_eq!(found.len(), 1, "only the top-level index must be found");
     }
 
     #[test]

--- a/crates/trusty-search/src/service/mod.rs
+++ b/crates/trusty-search/src/service/mod.rs
@@ -19,6 +19,7 @@ pub mod lazy_loader;
 pub(crate) mod lazy_restore;
 pub mod mcp_descriptor;
 pub mod metrics;
+pub mod orphan_reaper;
 pub mod persistence;
 pub mod persistence_loader;
 pub mod persistence_timestamps;

--- a/crates/trusty-search/src/service/orphan_reaper.rs
+++ b/crates/trusty-search/src/service/orphan_reaper.rs
@@ -269,7 +269,11 @@ mod tests {
 
         let orphan_ids: Vec<&str> = orphans.iter().map(|e| e.id.as_str()).collect();
         let kept_ids: Vec<&str> = kept.iter().map(|e| e.id.as_str()).collect();
-        assert_eq!(orphan_ids, ["legacy"], "only the dead legacy root is reaped");
+        assert_eq!(
+            orphan_ids,
+            ["legacy"],
+            "only the dead legacy root is reaped"
+        );
         assert!(
             kept_ids.contains(&"colocated"),
             "colocated orphan must be preserved for relocation"

--- a/crates/trusty-search/src/service/orphan_reaper.rs
+++ b/crates/trusty-search/src/service/orphan_reaper.rs
@@ -1,0 +1,292 @@
+//! Automatic self-healing of orphaned index registrations (orphan self-heal).
+//!
+//! Why: MPM spins up an ephemeral git worktree per session under
+//! `.worktrees/<uuid>/` and deletes it when the session ends. Each such root
+//! can get registered as an index (auto-discovery or the colocated rescan);
+//! when the worktree is removed the registration is left behind pointing at a
+//! now-deleted path. Over a long-lived daemon these accumulate without bound —
+//! production saw 485 dead registrations build up over 26 days, each re-read
+//! and re-warned on every warm-boot and, worse, each holding an FSEvents watch
+//! that pinned macOS `fseventsd` at ~100% CPU / 8 GB RSS. Nothing in the daemon
+//! ever removed them; `prune-orphans` / `cleanup` were manual CLI commands
+//! only, so an operator who never ran them accumulated the leak silently.
+//!
+//! What: two entry points share one safety predicate ([`is_reapable_orphan`]):
+//!   * [`heal_boot_orphans`] — called once at warm-boot start; drops legacy
+//!     (non-colocated) registrations whose `root_path` was deleted so they stop
+//!     being re-read on every boot.
+//!   * `server::tickers::spawn_orphan_reaper_ticker` — a periodic task that
+//!     unregisters live indexes whose root vanished while the daemon runs
+//!     (the actual accumulation vector, since the daemon ran continuously).
+//!
+//! Safety: a registration is only reaped when its `root_path` is missing AND
+//! its immediate parent still exists. A deleted worktree leaves `.worktrees/`
+//! behind (→ reap), whereas an unmounted external volume takes the whole parent
+//! chain with it (→ do NOT reap; the data returns when the volume remounts).
+//! Neither path ever deletes on-disk index *data* — only the registration is
+//! removed — so a false-positive detection is always recoverable by
+//! re-registering the path.
+//!
+//! Test: `is_reapable_orphan_*` and `heal_boot_orphans_*` unit tests below.
+
+use std::path::Path;
+
+use crate::service::persistence::{save_index_registry, PersistedIndex};
+
+/// Environment variable overriding the reaper cadence, in seconds. `0` disables
+/// the runtime reaper entirely; any unparseable value falls back to the default.
+pub const REAP_INTERVAL_ENV: &str = "TRUSTY_ORPHAN_REAP_SECS";
+
+/// Default runtime-reaper cadence: hourly.
+///
+/// Why: worktree churn happens on the timescale of minutes-to-hours, and a dead
+/// registration costs an idle FSEvents watch, not correctness, so an hourly
+/// sweep reclaims it promptly without adding meaningful wakeups. The boot-time
+/// [`heal_boot_orphans`] pass covers everything accumulated while the daemon
+/// was down, so the ticker only needs to catch roots deleted mid-run.
+const DEFAULT_REAP_INTERVAL_SECS: u64 = 3600;
+
+/// Resolve the runtime reaper cadence from the environment.
+///
+/// Why: lets an operator retune or disable (`TRUSTY_ORPHAN_REAP_SECS=0`) the
+/// sweep without a rebuild — mirroring the idle-eviction ticker's env knob.
+/// What: returns `None` when the var is exactly `0` (reaper disabled),
+/// `Some(n)` for a positive integer, and `Some(DEFAULT_REAP_INTERVAL_SECS)`
+/// when unset or unparseable.
+/// Test: `reap_interval_secs_*` unit tests below.
+pub fn reap_interval_secs() -> Option<u64> {
+    match std::env::var(REAP_INTERVAL_ENV) {
+        Ok(v) => match v.trim().parse::<u64>() {
+            Ok(0) => None,
+            Ok(n) => Some(n),
+            Err(_) => Some(DEFAULT_REAP_INTERVAL_SECS),
+        },
+        Err(_) => Some(DEFAULT_REAP_INTERVAL_SECS),
+    }
+}
+
+/// True iff `root_path` is a safely-reapable orphan.
+///
+/// Why: distinguishing a genuinely-deleted project directory from a transiently
+/// unavailable one is the whole safety story, and there are two failure modes.
+/// (1) A temporarily-unmounted volume (`/Volumes/Ext/project`) makes the root
+/// vanish along with its parent — keying on "immediate parent still exists"
+/// spares it while still reaping a deleted worktree
+/// (`~/repo/.worktrees/<uuid>`), whose parent `.worktrees/` survives. (2) On
+/// macOS a *mounted-but-TCC-blocked* external volume (issues #723 / #873, the
+/// recurring FDA-loss-after-`cargo install` scenario) can make `exists()`
+/// return `false` — or even hang — for a perfectly live root. So external
+/// mounts under `/Volumes` are excluded outright *before any syscall*: the
+/// reaper's target (MPM worktree churn) always lives under `$HOME`, never on a
+/// removable volume, and manual `prune-orphans` still covers `/Volumes` when a
+/// human confirms.
+/// What: returns `false` for any `/Volumes/…` path (no stat performed) and for
+/// paths that still exist; otherwise returns whether the immediate parent is a
+/// non-empty, present directory.
+/// Test: `is_reapable_orphan_*` unit tests below.
+pub fn is_reapable_orphan(root_path: &Path) -> bool {
+    // Cheap prefix check first — never stat (or risk hanging on) an external
+    // volume that may be mounted-but-TCC-blocked.
+    if root_path.starts_with("/Volumes") {
+        return false;
+    }
+    if root_path.exists() {
+        return false;
+    }
+    match root_path.parent() {
+        Some(parent) => !parent.as_os_str().is_empty() && parent.exists(),
+        None => false,
+    }
+}
+
+/// Remove legacy registrations whose root was deleted, returning the survivors.
+///
+/// Why: warm-boot previously *detected* a missing non-colocated `root_path`,
+/// logged "run `trusty-search prune-orphans`", and skipped it — leaving the
+/// entry in `indexes.toml` to be re-read, re-warned, and re-skipped on every
+/// subsequent boot forever. This converts that detection into action so the
+/// registry self-heals across restarts.
+/// What: partitions `entries` into reapable orphans (`!colocated` AND
+/// [`is_reapable_orphan`]) and survivors. Colocated entries are deliberately
+/// left alone so warm-boot's relocation scan can still recover a *moved* repo.
+/// When any orphan is found, atomically rewrites `indexes.toml` to the
+/// survivors (one write, matching the manual `prune-orphans` path and the
+/// existing last-write-wins persistence contract), best-effort scrubs each
+/// orphan's root from `roots.toml` so the colocated rescan cannot resurrect it,
+/// and returns the survivors. On-disk index *data* is never touched.
+/// Test: `heal_boot_orphans_*` unit tests below (partition logic); the save
+/// path is shared with the `prune-orphans` CLI, whose tests cover it.
+pub fn heal_boot_orphans(entries: Vec<PersistedIndex>) -> Vec<PersistedIndex> {
+    let (orphans, kept) = partition_boot_orphans(entries);
+
+    if orphans.is_empty() {
+        return kept;
+    }
+
+    // `entries` was the full contents of `indexes.toml`, so `kept` is exactly
+    // "everything minus the orphans" — a single atomic rewrite is correct.
+    if let Err(e) = save_index_registry(&kept) {
+        tracing::warn!(
+            "orphan-reaper(boot): could not rewrite indexes.toml ({e}); {} orphaned \
+             registration(s) left on disk (they will be retried next boot)",
+            orphans.len()
+        );
+        // Still return `kept` so this boot does not attempt to restore the dead
+        // entries; only the on-disk cleanup was skipped.
+        return kept;
+    }
+
+    for orphan in &orphans {
+        if let Err(e) = crate::service::roots_registry::remove_root(&orphan.root_path) {
+            tracing::debug!(
+                "orphan-reaper(boot): could not remove root {} from roots.toml: {e}",
+                orphan.root_path.display()
+            );
+        }
+    }
+
+    tracing::info!(
+        "orphan-reaper(boot): removed {} orphaned registration(s) whose root_path was \
+         deleted (self-heal); {} registration(s) remain",
+        orphans.len(),
+        kept.len()
+    );
+
+    kept
+}
+
+/// Pure split of registry entries into reapable orphans and survivors.
+///
+/// Why: extracted from [`heal_boot_orphans`] so the reap decision can be
+/// unit-tested hermetically, without touching the real `indexes.toml`.
+/// What: partitions on `!colocated && is_reapable_orphan(root_path)` — the
+/// first `Vec` is the orphans to drop, the second the survivors to keep.
+/// Test: `heal_boot_orphans_*` unit tests below.
+pub(crate) fn partition_boot_orphans(
+    entries: Vec<PersistedIndex>,
+) -> (Vec<PersistedIndex>, Vec<PersistedIndex>) {
+    entries
+        .into_iter()
+        .partition(|e| !e.colocated && is_reapable_orphan(&e.root_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn entry(id: &str, root: PathBuf, colocated: bool) -> PersistedIndex {
+        PersistedIndex {
+            id: id.to_string(),
+            root_path: root,
+            colocated,
+            ..Default::default()
+        }
+    }
+
+    /// Why: a live directory must never be treated as an orphan.
+    /// What: the tempdir itself exists → not reapable.
+    /// Test: this test.
+    #[test]
+    fn is_reapable_orphan_false_for_live_root() {
+        let tmp = tempdir().unwrap();
+        assert!(!is_reapable_orphan(tmp.path()));
+    }
+
+    /// Why: the core self-heal case — a deleted leaf whose parent survives (the
+    /// vanished-worktree shape) must be reapable.
+    /// What: point at a non-existent child of an existing tempdir.
+    /// Test: this test.
+    #[test]
+    fn is_reapable_orphan_true_for_deleted_leaf_with_live_parent() {
+        let tmp = tempdir().unwrap();
+        let dead = tmp.path().join("worktree-abc123");
+        assert!(!dead.exists());
+        assert!(is_reapable_orphan(&dead));
+    }
+
+    /// Why: the safety guarantee — an unmounted volume (whole parent chain gone)
+    /// must NOT be reaped, or a remount would find its registration destroyed.
+    /// What: a path whose parent also does not exist is not reapable.
+    /// Test: this test.
+    #[test]
+    fn is_reapable_orphan_false_when_parent_also_missing() {
+        let missing = PathBuf::from("/no/such/mount/point/project");
+        assert!(!missing.exists());
+        assert!(!is_reapable_orphan(&missing));
+    }
+
+    /// Why: external `/Volumes/…` mounts are excluded outright — a mounted-but-
+    /// TCC-blocked or unmounted volume must never be auto-reaped (issues
+    /// #723/#873), even when its parent `/Volumes` exists.
+    /// What: a non-existent `/Volumes/Ext/project` is not reapable despite
+    /// `/Volumes` being present.
+    /// Test: this test.
+    #[test]
+    fn is_reapable_orphan_false_for_external_volume() {
+        let vol = PathBuf::from("/Volumes/DefinitelyNotMounted-xyz/project");
+        assert!(!vol.exists());
+        assert!(!is_reapable_orphan(&vol));
+    }
+
+    /// Why: `0` disables the reaper; anything else parses or falls back.
+    /// What: exercises the three branches via a scoped env guard.
+    /// Test: this test.
+    #[test]
+    fn reap_interval_secs_env_branches() {
+        // Serialize on a process-global to avoid cross-test env races.
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(REAP_INTERVAL_ENV, "0");
+        assert_eq!(reap_interval_secs(), None);
+        std::env::set_var(REAP_INTERVAL_ENV, "120");
+        assert_eq!(reap_interval_secs(), Some(120));
+        std::env::set_var(REAP_INTERVAL_ENV, "not-a-number");
+        assert_eq!(reap_interval_secs(), Some(DEFAULT_REAP_INTERVAL_SECS));
+        std::env::remove_var(REAP_INTERVAL_ENV);
+        assert_eq!(reap_interval_secs(), Some(DEFAULT_REAP_INTERVAL_SECS));
+    }
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Why: a colocated orphan must be preserved so warm-boot's relocation scan
+    /// can still recover a moved repo; only non-colocated dead roots are reaped.
+    /// What: two dead-leaf entries (one colocated) plus one live entry → only
+    /// the non-colocated dead one is dropped.
+    /// Test: this test.
+    #[test]
+    fn heal_boot_orphans_reaps_only_non_colocated_dead_roots() {
+        let tmp = tempdir().unwrap();
+        let dead_legacy = tmp.path().join("gone-legacy");
+        let dead_colocated = tmp.path().join("gone-colocated");
+        let live = tmp.path().to_path_buf();
+
+        let (orphans, kept) = partition_boot_orphans(vec![
+            entry("legacy", dead_legacy, false),
+            entry("colocated", dead_colocated, true),
+            entry("live", live, false),
+        ]);
+
+        let orphan_ids: Vec<&str> = orphans.iter().map(|e| e.id.as_str()).collect();
+        let kept_ids: Vec<&str> = kept.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(orphan_ids, ["legacy"], "only the dead legacy root is reaped");
+        assert!(
+            kept_ids.contains(&"colocated"),
+            "colocated orphan must be preserved for relocation"
+        );
+        assert!(kept_ids.contains(&"live"), "live root must be preserved");
+    }
+
+    /// Why: with no orphans the split must return everything as survivors.
+    /// What: all-live input yields zero orphans.
+    /// Test: this test.
+    #[test]
+    fn heal_boot_orphans_noop_when_all_live() {
+        let tmp = tempdir().unwrap();
+        let (orphans, kept) =
+            partition_boot_orphans(vec![entry("a", tmp.path().to_path_buf(), false)]);
+        assert!(orphans.is_empty());
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].id, "a");
+    }
+}

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -88,7 +88,10 @@ use reindex_handlers::{reindex_handler, reindex_stream_handler};
 use routing::search_similar_handler;
 use search::{delete_index_handler, global_search_handler, search_handler};
 use status::{graph_handler, graph_stats_handler, index_status_handler};
-use tickers::{spawn_disk_size_ticker, spawn_idle_chunk_eviction_ticker, spawn_status_ticker};
+use tickers::{
+    spawn_disk_size_ticker, spawn_idle_chunk_eviction_ticker, spawn_orphan_reaper_ticker,
+    spawn_status_ticker,
+};
 
 use files::{call_chain_handler, global_grep_handler, grep_handler};
 use typeahead::typeahead_handler;
@@ -133,6 +136,7 @@ pub fn build_router(state: SearchAppState) -> Router {
     spawn_status_ticker(Arc::clone(&state_arc));
     spawn_disk_size_ticker(Arc::clone(&state_arc));
     spawn_idle_chunk_eviction_ticker(Arc::clone(&state_arc));
+    spawn_orphan_reaper_ticker(Arc::clone(&state_arc));
 
     let limiter = crate::service::concurrency::ConcurrencyLimiter::from_env();
     let query_timeout_cfg = QueryTimeoutConfig::from_env();

--- a/crates/trusty-search/src/service/server/search.rs
+++ b/crates/trusty-search/src/service/server/search.rs
@@ -33,29 +33,48 @@ pub(super) async fn delete_index_handler(
     State(state): State<Arc<SearchAppState>>,
     Path(id): Path<String>,
 ) -> Json<serde_json::Value> {
-    let index_id = IndexId::new(id.clone());
-    // Issue #1090 / #1097 atomicity: capture root_path and unregister in a
-    // single DashMap `remove` so a concurrent PATCH cannot make the captured
-    // root_path stale before the roots.toml cleanup below.
+    // The interactive DELETE also destroys the on-disk footprint (delete_data).
+    let removed = unregister_index(&state, &id, /*delete_data=*/ true).await;
+    Json(serde_json::json!({ "id": id, "removed": removed }))
+}
+
+/// Fully unregister an index from the running daemon.
+///
+/// Why: shared by the interactive `DELETE /indexes/:id` handler and the
+/// automatic orphan-reaper ticker (orphan self-heal). Both must drop the
+/// in-memory registration, stop its filesystem watcher, and rewrite
+/// `indexes.toml` + `roots.toml` so the index cannot resurrect on the next
+/// warm-boot. The two callers differ only in whether the on-disk *data*
+/// directory is destroyed — the reaper passes `delete_data=false` so a
+/// false-positive orphan detection can never delete real index data.
+/// What: atomically removes the handle from the registry (capturing its
+/// `root_path` in the same `remove` so a concurrent PATCH cannot make it stale
+/// — issue #1090/#1097), stops the watcher (issue #1621), deletes the registry
+/// entry (issue #118), optionally removes the data dir (issue #85), scrubs the
+/// root from `roots.toml` so the colocated rescan cannot rediscover it (issue
+/// #1090), emits `IndexRemoved`, and re-syncs the index-count gauge (issue #41).
+/// Returns whether an index was actually removed.
+/// Test: delete-path handler tests; reaper behaviour covered by `orphan_reaper`
+/// unit tests plus the `spawn_orphan_reaper_ticker` wiring.
+pub(super) async fn unregister_index(
+    state: &Arc<SearchAppState>,
+    id: &str,
+    delete_data: bool,
+) -> bool {
+    let index_id = IndexId::new(id.to_string());
     let (removed, removed_handle) = state.registry.remove_and_get(&index_id);
     let root_path_for_cleanup = removed_handle.map(|h| h.root_path.clone());
     state.reindex_progress.remove(&index_id);
-    // Issue #1621: stop the filesystem watcher for this index so it does not
-    // keep firing into a now-dropped indexer after the handle is removed.
     state.watcher_manager.stop_for_index(&index_id).await;
     if removed {
-        // Issue #85: drop the on-disk footprint so the index doesn't come
-        // back on the next daemon restart. Best-effort — log on failure.
-        if let Err(e) = crate::service::persistence::remove_index_registry_entry(&id) {
+        if let Err(e) = crate::service::persistence::remove_index_registry_entry(id) {
             tracing::warn!("could not remove '{id}' from indexes.toml: {e}");
         }
-        if let Err(e) = crate::service::persistence::remove_index_data_dir(&id) {
-            tracing::warn!("could not remove on-disk data for '{id}': {e}");
+        if delete_data {
+            if let Err(e) = crate::service::persistence::remove_index_data_dir(id) {
+                tracing::warn!("could not remove on-disk data for '{id}': {e}");
+            }
         }
-        // Issue #1090: remove the root from roots.toml so the warm-boot
-        // colocated scan does not rediscover this root and resurrect the index.
-        // Without this, roots.toml retains the entry and warm-boot re-registers
-        // the deleted index from the leftover `.trusty-search/` data dir.
         if let Some(ref root) = root_path_for_cleanup {
             if let Err(e) = crate::service::roots_registry::remove_root(root) {
                 tracing::warn!(
@@ -71,11 +90,11 @@ pub(super) async fn delete_index_handler(
             }
         }
         // Push event so connected dashboards drop the row without refresh.
-        state.emit(DaemonEvent::IndexRemoved { id: id.clone() });
-        // Issue #41 Phase 1: keep the index-count gauge in sync.
+        state.emit(DaemonEvent::IndexRemoved { id: id.to_string() });
+        // Keep the index-count gauge in sync.
         crate::service::metrics::set_index_count(state.registry.list().len());
     }
-    Json(serde_json::json!({ "id": id, "removed": removed }))
+    removed
 }
 
 pub(super) async fn search_handler(

--- a/crates/trusty-search/src/service/server/tickers.rs
+++ b/crates/trusty-search/src/service/server/tickers.rs
@@ -140,3 +140,79 @@ pub(super) fn spawn_idle_chunk_eviction_ticker(state: Arc<SearchAppState>) {
         }
     });
 }
+
+/// Spawn a background ticker that unregisters indexes whose `root_path` was
+/// deleted while the daemon runs (orphan self-heal).
+///
+/// Why: MPM deletes ephemeral `.worktrees/<uuid>` roots continuously, so a
+/// long-lived daemon steadily accumulates dead registrations — each one an
+/// idle FSEvents watch that pins `fseventsd` (production: 485 orphans / 8 GB
+/// `fseventsd` over 26 days). The boot-time `heal_boot_orphans` pass only runs
+/// at startup; this ticker reclaims roots that vanish mid-run. It mirrors the
+/// other `spawn_*_ticker` shape: a detached task holding a `Weak` so it stops
+/// when the daemon drops its last `Arc`.
+/// What: every `TRUSTY_ORPHAN_REAP_SECS` seconds (default hourly; `0` disables
+/// and the ticker never spawns), snapshots each index's `(id, root_path)`,
+/// runs the existence checks on `spawn_blocking` (a stat-per-index is blocking
+/// I/O and must not park an async worker), then calls
+/// `unregister_index(.., delete_data=false)` for each reapable orphan —
+/// registration removed, on-disk data preserved. [`is_reapable_orphan`] only
+/// fires when the root is missing AND its parent survives, so an unmounted
+/// external volume is never reaped.
+/// Test: `orphan_reaper` unit tests cover the predicate + interval; this is a
+/// thin scheduling wrapper.
+///
+/// [`is_reapable_orphan`]: crate::service::orphan_reaper::is_reapable_orphan
+pub(super) fn spawn_orphan_reaper_ticker(state: Arc<SearchAppState>) {
+    use crate::service::orphan_reaper::{is_reapable_orphan, reap_interval_secs, REAP_INTERVAL_ENV};
+    let Some(secs) = reap_interval_secs() else {
+        tracing::info!("orphan-reaper: disabled via {REAP_INTERVAL_ENV}=0");
+        return;
+    };
+    let weak = Arc::downgrade(&state);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(secs));
+        // Skip the immediate first tick so a freshly-started daemon (which just
+        // ran the boot heal) isn't sweeping again before it has served anything.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let Some(state) = weak.upgrade() else {
+                break;
+            };
+            // Snapshot (id, root_path) and run existence checks off the async
+            // runtime — a stat-per-index is blocking filesystem I/O.
+            let candidates: Vec<(String, std::path::PathBuf)> = state
+                .registry
+                .list_handles()
+                .into_iter()
+                .map(|h| (h.id.0.clone(), h.root_path.clone()))
+                .collect();
+            let reapable: Vec<String> = tokio::task::spawn_blocking(move || {
+                candidates
+                    .into_iter()
+                    .filter(|(_, root)| is_reapable_orphan(root))
+                    .map(|(id, _)| id)
+                    .collect()
+            })
+            .await
+            .unwrap_or_default();
+
+            let mut reaped = 0usize;
+            for id in reapable {
+                // delete_data=false: never destroy on-disk data automatically —
+                // a false-positive detection stays recoverable by re-registering.
+                if super::search::unregister_index(&state, &id, false).await {
+                    reaped += 1;
+                    tracing::info!(
+                        "orphan-reaper: unregistered index '{id}' — root_path deleted \
+                         (data preserved)"
+                    );
+                }
+            }
+            if reaped > 0 {
+                tracing::info!("orphan-reaper: reaped {reaped} orphaned registration(s) this cycle");
+            }
+        }
+    });
+}

--- a/crates/trusty-search/src/service/server/tickers.rs
+++ b/crates/trusty-search/src/service/server/tickers.rs
@@ -164,7 +164,9 @@ pub(super) fn spawn_idle_chunk_eviction_ticker(state: Arc<SearchAppState>) {
 ///
 /// [`is_reapable_orphan`]: crate::service::orphan_reaper::is_reapable_orphan
 pub(super) fn spawn_orphan_reaper_ticker(state: Arc<SearchAppState>) {
-    use crate::service::orphan_reaper::{is_reapable_orphan, reap_interval_secs, REAP_INTERVAL_ENV};
+    use crate::service::orphan_reaper::{
+        is_reapable_orphan, reap_interval_secs, REAP_INTERVAL_ENV,
+    };
     let Some(secs) = reap_interval_secs() else {
         tracing::info!("orphan-reaper: disabled via {REAP_INTERVAL_ENV}=0");
         return;
@@ -211,7 +213,9 @@ pub(super) fn spawn_orphan_reaper_ticker(state: Arc<SearchAppState>) {
                 }
             }
             if reaped > 0 {
-                tracing::info!("orphan-reaper: reaped {reaped} orphaned registration(s) this cycle");
+                tracing::info!(
+                    "orphan-reaper: reaped {reaped} orphaned registration(s) this cycle"
+                );
             }
         }
     });


### PR DESCRIPTION
## Problem

`trusty-search` never removed orphaned index registrations. An ephemeral MPM worktree (`.worktrees/<uuid>/`) that was registered and then deleted left a dead entry in `indexes.toml` **forever**: warm-boot *detected* the missing `root_path`, logged "run `trusty-search prune-orphans`", and skipped it — but nothing in the daemon ever removed it. `prune-orphans` / `cleanup` were manual CLI commands only.

On a real machine this accumulated to **485 dead registrations over 26 days**, each holding an idle FSEvents watch that pinned macOS `fseventsd` at ~100% CPU / **8 GB RSS**. (Diagnosed from a daemon that had run continuously for 7+ days; the leak grows ~18/day with active MPM session churn.)

## Fix — three complementary mechanisms

1. **Boot self-heal** — `heal_boot_orphans` runs at warm-boot start and drops legacy (non-colocated) registrations whose `root_path` was deleted, so they stop being re-read/re-warned on every boot. Colocated entries are left for the existing relocation scan.
2. **Runtime reaper ticker** — an hourly background sweep unregisters live indexes whose root vanished mid-run (the actual accumulation vector, since the daemon runs continuously). Cadence via `TRUSTY_ORPHAN_REAP_SECS` (`0` disables). Existence checks run on `spawn_blocking` so a stat-per-index never parks an async worker.
3. **Ephemeral-dir ignore** — auto-discovery and the colocated rescan now skip the `.worktrees/` component (component-level, so nested `.base/.worktrees/*` is covered too), so throwaway worktrees are never auto-registered or FSEvents-watched in the first place. The hard denylist is untouched, so explicit `trusty-search index <worktree>` still works.

## Safety

- Reaping fires **only** when a `root_path` is missing **and its immediate parent still exists** — a deleted worktree leaves `.worktrees/` behind (reap); an unmounted volume takes the whole parent chain with it (spared).
- External `/Volumes/…` mounts are **excluded outright, before any syscall** — a mounted-but-TCC-blocked volume (issues #723/#873, the recurring FDA-loss-after-`cargo install` scenario) can make `exists()` return false or hang; the reaper's target (worktree churn) always lives under `$HOME`, never on a removable volume. Manual `prune-orphans` still covers `/Volumes` when a human confirms.
- The automatic reaper **never deletes on-disk index data**, only the registration, so a false positive is always recoverable by re-registering. The interactive `DELETE /indexes/:id` still removes data as before (shared `unregister_index`, `delete_data=true`).

## Tests

- New `orphan_reaper` unit tests: live root, deleted-leaf-with-live-parent, missing-parent, external-volume exclusion, env-var branches, boot-orphan partition (colocated preserved).
- New discovery-skip tests: `.worktrees/` colocated index is not rediscovered; `is_ephemeral_dir_name` component matching.
- Full suite: **963 lib tests pass** + 8 new, `clippy -D warnings` clean, line-cap clean.

## Note (out of scope)

`cargo check -p trusty-agents` surfaces a **pre-existing, unrelated** break in `trusty-memory` (`dream_ops.rs:56` calls `crate::web::…` unconditionally, but `pub mod web` is `#[cfg(feature = "axum-server")]`-gated at `lib.rs:149`). That code is unchanged on `origin/main` and untouched by this PR; it only manifests in the feature combination `trusty-agents` activates. Worth a separate fix.

Bumps `trusty-search` 0.29.2 → 0.30.0 and updates the `trusty-agents` path-dep pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)