### PR TITLE
fix(trusty-memory): slim build (default-features=false) — route dream_ops through axum-free config loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10926,7 +10926,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -9,6 +9,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- slim build (`--no-default-features`) now compiles: `tools::dream_ops` reached
+  the user-config loader through the `axum-server`-gated `crate::web::` re-export,
+  breaking any dependent that opts out of `axum-server` (e.g. `trusty-agents`,
+  which uses `default-features = false`). Now routes through the axum-free
+  `crate::service::load_user_config` like `chat_provider()` already does
+  (closes #2049).
 - decouple recall/remember from embedder warm-up (closes #1970) ([#1972](https://github.com/bobmatnyc/trusty-tools/pull/1972)) ([`bb322d4`](https://github.com/bobmatnyc/trusty-tools/commit/bb322d4678f8e167691688e77190b44d9c08627a))
 - palace-level alias resolution for claude-mpm parity (owner-repo -> bare palace) ([#1945](https://github.com/bobmatnyc/trusty-tools/pull/1945)) ([`af7f904`](https://github.com/bobmatnyc/trusty-tools/commit/af7f90499402971ac65aed5b104cde251e182599))
 - stop console_metrics force-opening every palace on poll (closes #1924) ([#1926](https://github.com/bobmatnyc/trusty-tools/pull/1926)) ([`74e9e54`](https://github.com/bobmatnyc/trusty-tools/commit/74e9e54243efc6de3778d7c43d938add2ab7b676))

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true

--- a/crates/trusty-memory/src/tools/dream_ops.rs
+++ b/crates/trusty-memory/src/tools/dream_ops.rs
@@ -53,7 +53,13 @@ pub(crate) async fn handle_dream_consolidate_room(state: &AppState, args: Value)
     // Seed the consolidation config from the daemon's user config so the
     // inference backend (OpenRouter key / local model) matches the idle dream
     // cycle. Everything else uses the dream defaults (semantic enabled).
-    let cfg = crate::web::load_user_config().unwrap_or_default();
+    //
+    // Use `crate::service::load_user_config` (the axum-free home of the loader,
+    // issue #226) rather than the `crate::web::` re-export: this `tools` module
+    // is compiled unconditionally, but `mod web` is `#[cfg(feature =
+    // "axum-server")]`-gated, so the re-export vanishes when a dependent builds
+    // trusty-memory without that feature — which broke the build (E0433).
+    let cfg = crate::service::load_user_config().unwrap_or_default();
     let dream_cfg = DreamConfig {
         openrouter_api_key: cfg.openrouter_api_key,
         local_model_enabled: cfg.local_model.enabled,


### PR DESCRIPTION
Closes #2049.

## Problem

`trusty-memory` failed to compile with `--no-default-features` (the slim library surface from #226), breaking any dependent that opts out of `axum-server` — notably `trusty-agents` (`default-features = false`):

```
error[E0433]: cannot find `web` in `crate`
  --> crates/trusty-memory/src/tools/dream_ops.rs:56
```

`pub mod web` is `#[cfg(feature = "axum-server")]`-gated (`lib.rs:149`), but `tools::dream_ops` is compiled unconditionally and reached the user-config loader through the `crate::web::load_user_config` re-export, which only exists with that feature. The `chat` callers of the same re-export are fine because `mod chat` is itself axum-server-gated; `dream_ops` was simply missed when #226 landed.

## Fix

One line: `dream_ops` now uses `crate::service::load_user_config()` — the axum-free home of the loader — exactly as `chat_provider()` at `lib.rs:1244` already does. Same underlying `helpers::load_user_config`, so behaviour is unchanged.

## Verification

```
cargo check   -p trusty-memory --no-default-features   # was E0433 → now Finished
cargo clippy  -p trusty-memory --no-default-features -- -D warnings   # clean
cargo clippy  -p trusty-memory -- -D warnings           # default combo clean
cargo check   -p trusty-agents                          # original repro → Finished
```

Line-cap clean. Bumps trusty-memory 0.18.1 → 0.18.2 (the `trusty-agents` `^0.18.1` pin still satisfies it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)