### PR TITLE
feat(trusty-mpm): name managed-session worktrees by tmux session name, not UUID

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -642,7 +642,13 @@ async fn redirect_to_managed_clone(
 
     // Create a per-session worktree branched from the base clone.
     let session_id = ManagedSessionId::new();
-    let worktree = match inproject::create_session_worktree(&base, &session_id) {
+    // NOTE (#2032): this daemon-unreachable fallback path is NOT the managed
+    // SessionManager spawn flow — it has no session manager to resolve a
+    // semantic tmux name from, so it deliberately keeps the pre-#2032
+    // UUID-named worktree here. Only the daemon's `spawn_managed_inproject`
+    // path (`daemon::managed_routes::lifecycle`) uses the new semantic-name
+    // worktree layout.
+    let worktree = match inproject::create_session_worktree(&base, &session_id.to_string()) {
         Ok(p) => p,
         Err(e) => {
             eprintln!(

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -183,9 +183,17 @@ pub(crate) async fn launch(
 
     // 7b. Create a per-session git worktree at `<project_dir>/.worktrees/<session-id>/`.
     //     Each session gets an isolated branch so concurrent sessions never collide.
+    //     NOTE (#2032): `tm launch` is a standalone CLI flow, not the daemon's
+    //     managed `SessionManager` spawn path — the tmux name here is derived
+    //     from the live folder AFTER the worktree already exists (see
+    //     `folder_name`/`fallback_session_name` below), so there is no
+    //     resolved semantic name available yet at worktree-creation time.
+    //     This keeps the pre-#2032 UUID-named worktree; only
+    //     `spawn_managed_inproject` (the daemon's HTTP/MCP spawn path) uses
+    //     the new semantic-name layout.
     let managed_path = trusty_mpm::daemon::managed_routes::inproject::create_session_worktree(
         &project_dir,
-        &session_uuid,
+        &session_uuid.to_string(),
     )
     .map_err(|e| anyhow::anyhow!("failed to create session worktree: {e}"))?;
 

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -73,6 +73,7 @@ pub mod tmux;
 pub mod trusty_tools_config;
 pub mod update_check;
 pub mod workspace_scan;
+pub mod worktree_naming;
 
 pub use connect::{ResolveResult, SessionSummary, resolve_target};
 pub use discovery::{

--- a/crates/trusty-mpm/src/core/worktree_naming.rs
+++ b/crates/trusty-mpm/src/core/worktree_naming.rs
@@ -1,0 +1,48 @@
+//! Shared per-session git-worktree branch naming convention (issue #2032).
+//!
+//! Why: both `daemon::managed_routes::inproject` (feature = `"daemon"`;
+//! creates per-session worktrees/branches) and `session_manager::decommission`
+//! (unconditional — compiled with or without the `daemon` feature; removes
+//! them) must agree on EXACTLY the same `session/<name>` branch convention.
+//! Placing the convention here, in `core` (always compiled, no feature gate),
+//! lets the unconditional `session_manager` module depend on it WITHOUT
+//! pulling in the feature-gated `daemon` module — the reverse dependency
+//! direction is what caused the bug this module fixes: `decommission.rs`
+//! previously hardcoded `git branch -D <leaf>` (missing the `session/` prefix
+//! `create_session_worktree` actually uses), so the branch-delete step always
+//! targeted a nonexistent ref and silently no-opped — every session's branch
+//! leaked forever.
+//! What: [`worktree_branch_for`] builds the `session/<name>` branch name for a
+//! given worktree leaf/session name.
+//! Test: `worktree_branch_for_adds_session_prefix`.
+
+/// Compute the per-session branch name for a worktree leaf/session name.
+///
+/// Why: single source of truth for the `session/<name>` convention, shared by
+/// `daemon::managed_routes::inproject::create_session_worktree` (which
+/// creates the branch) and `session_manager::decommission::remove_session_worktree`
+/// (which must delete the SAME branch — see the #2032 branch-prefix fix in
+/// that module's doc comment).
+/// What: `format!("session/{name}")`.
+/// Test: `worktree_branch_for_adds_session_prefix`.
+pub fn worktree_branch_for(name: &str) -> String {
+    format!("session/{name}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The branch convention must always be `session/<name>`, for both
+    /// pre-#2032 raw-UUID leaves and the new semantic-tmux-name leaves — the
+    /// convention is name-format-agnostic.
+    /// Test: this function IS the test.
+    #[test]
+    fn worktree_branch_for_adds_session_prefix() {
+        assert_eq!(worktree_branch_for("tm-foo-01"), "session/tm-foo-01");
+        assert_eq!(
+            worktree_branch_for("00000000-old-session-uuid"),
+            "session/00000000-old-session-uuid"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -1,27 +1,35 @@
-//! In-project spawn path: shared base clone + per-session worktrees (#1706, #1803).
+//! In-project spawn path: shared base clone + per-session worktrees (#1706, #1803, #2032).
 //!
 //! Why: operators who run `tm` from inside a git repository should get a managed
 //! session against a git-worktree slice of that repo rather than a full clone.
 //! This module implements the "in-project" path: (a) a durable PROTECTED base
 //! clone under `~/trusty-mpm-projects/<owner>/<repo>/` that is always on the
 //! default branch and owned by the daemon, and (b) a per-session git worktree
-//! at `<base>/.worktrees/<session_id>` branched off that clone so each session
-//! works in isolation.
+//! at `<base>/.worktrees/<worktree_name>` branched off that clone so each
+//! session works in isolation. Since #2032 `worktree_name` is the SEMANTIC
+//! tmux session name (e.g. `tm-trusty-tools-01`), not the raw session UUID —
+//! resolving that name requires the async `SessionManager`, which this module
+//! deliberately does not depend on, so worktree CREATION is split from
+//! DETECTION (see [`try_inproject_spawn`] vs [`create_session_worktree`]).
+//! Existing UUID-named worktrees are left as-is; only NEW sessions get the
+//! semantic name.
 //! What: [`repos_root`] resolves the configurable root; [`base_clone_path`]
 //! computes the per-project clone directory; [`ensure_base_clone`] clones if
-//! absent; [`create_session_worktree`] adds a per-session worktree at
-//! `<base>/.worktrees/<session_id>`; [`ensure_worktrees_gitignored`] keeps
-//! the worktree directory out of `git status`; [`try_inproject_spawn`] is the
-//! main entry point called from the lifecycle layer;
-//! [`get_origin_url`] reads the remote.origin.url from a git directory.
+//! absent; [`try_inproject_spawn`] is the main entry point called from the
+//! lifecycle layer — it detects the GitHub identity and ensures the base
+//! clone, returning `(base_path, owner, repo)`; [`create_session_worktree`]
+//! adds a per-session worktree at `<base>/.worktrees/<worktree_name>` given a
+//! CALLER-RESOLVED name; [`worktree_name_collides`] lets the caller steer name
+//! resolution away from an existing worktree dir/branch;
+//! [`ensure_worktrees_gitignored`] keeps the worktree directory out of
+//! `git status`; [`get_origin_url`] reads the remote.origin.url from a git
+//! directory.
 //! Test: `try_inproject_spawn_returns_none_for_non_git_path` unit test covers the
 //! non-git early exit; integration coverage via `tests/local_spawn.rs`.
 
 use std::path::{Path, PathBuf};
 
 use tracing::{info, warn};
-
-use crate::session_manager::ManagedSessionId;
 
 /// Environment variable that overrides the managed repos root.
 ///
@@ -292,19 +300,101 @@ pub fn ensure_base_clone(origin_url: &str, base_path: &Path) -> Result<(), Strin
     Ok(())
 }
 
+/// Compute the per-session worktree directory for `worktree_name` under `base_path`.
+///
+/// Why: both [`create_session_worktree`] and the caller-side collision check
+/// ([`worktree_name_collides`], used by the in-project spawn routing layer to
+/// steer `SessionManager::resolve_session_name` away from a name whose
+/// worktree already exists on disk, #2032) must agree on exactly where a
+/// worktree for a given name would live.
+/// What: `<base_path>/.worktrees/<worktree_name>` (dot-prefixed so
+/// `ensure_worktrees_gitignored` hides it from `git status`).
+/// Test: `session_worktree_path_uses_dot_prefix`.
+pub fn worktree_path_for(base_path: &Path, worktree_name: &str) -> PathBuf {
+    base_path.join(".worktrees").join(worktree_name)
+}
+
+/// Compute the per-session branch name for `worktree_name`.
+///
+/// Why: re-exported here (rather than defined here) so existing callers in
+/// this module keep the short `worktree_branch_for(...)` spelling. The single
+/// source of truth lives in [`crate::core::worktree_naming`] — an
+/// unconditionally-compiled module — specifically so
+/// `session_manager::decommission` (which is NOT gated behind the `daemon`
+/// feature) can depend on the SAME convention without pulling in this
+/// feature-gated `daemon` module (#2032; see that module's doc for why the
+/// dependency direction matters).
+/// What: `format!("session/{worktree_name}")`.
+/// Test: `crate::core::worktree_naming::tests::worktree_branch_for_adds_session_prefix`.
+pub use crate::core::worktree_naming::worktree_branch_for;
+
+/// Check whether a worktree directory or branch already exists for `worktree_name`.
+///
+/// Why (#2032): `tmux_name` collisions were already guarded by
+/// `SessionManager::resolve_session_name`'s live-tmux-session check, but that
+/// check knows nothing about git worktrees or branches — a DIFFERENT
+/// collision surface. Without this, two names could theoretically differ in
+/// tmux-liveness (one dead, one live) yet share the same worktree directory
+/// once #2032 makes the worktree leaf equal to the tmux name, silently
+/// clobbering (or failing to clobber, but confusingly erroring on) a stale
+/// worktree left behind by a hand-deleted-but-not-decommissioned session.
+/// This predicate is threaded into `resolve_session_name` as its
+/// `extra_collision` callback so a colliding candidate is retried with the
+/// next free serial BEFORE `create_session_worktree` ever runs, rather than
+/// discovered as a raw `git worktree add`/`git branch` failure.
+/// What: `true` if `<base_path>/.worktrees/<worktree_name>` exists on disk OR
+/// `refs/heads/session/<worktree_name>` already exists in `base_path`'s repo.
+/// Test: `worktree_name_collides_detects_existing_dir_and_branch`.
+pub fn worktree_name_collides(base_path: &Path, worktree_name: &str) -> bool {
+    if worktree_path_for(base_path, worktree_name).exists() {
+        return true;
+    }
+    let branch_ref = format!("refs/heads/{}", worktree_branch_for(worktree_name));
+    std::process::Command::new("git")
+        .arg("-C")
+        .arg(base_path)
+        .args(["rev-parse", "--verify", "--quiet"])
+        .arg(&branch_ref)
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
 /// Create a per-session git worktree branched off the base clone.
 ///
 /// Why: each managed session must work in an isolated branch; git worktrees
-/// achieve this without duplicating the object store of the base clone.
-/// What: runs `git -C <base_path> worktree add -b session/<session_id>
-/// <base_path>/.worktrees/<session_id>`. Returns the worktree path on success.
-/// Test: covered by integration tests against a real temp repo.
-pub fn create_session_worktree(
-    base_path: &Path,
-    session_id: &ManagedSessionId,
-) -> Result<PathBuf, String> {
-    let worktree_path = base_path.join(".worktrees").join(session_id.to_string());
-    let branch = format!("session/{session_id}");
+/// achieve this without duplicating the object store of the base clone. Since
+/// #2032 the caller supplies the ALREADY-RESOLVED semantic tmux name (e.g.
+/// `tm-trusty-tools-01`) rather than the raw session UUID, so the worktree
+/// directory and branch are human-readable and match the tmux session the
+/// operator actually sees in `tm session ls`.
+///
+/// NOTE for #2033 (trusty-search index-id derivation): the worktree LEAF NAME
+/// computed here (`worktree_name`) is significant beyond this function — the
+/// trusty-search index id for a managed session is derived from the worktree
+/// path, so #2033 must read the ACTUAL path this function returns (or the
+/// record's `workspace_path`, which `spawn_managed_inproject` sets to this
+/// same path) rather than re-deriving a path from the session id.
+/// What: runs `git -C <base_path> worktree add -b session/<worktree_name>
+/// <base_path>/.worktrees/<worktree_name>`. Returns the worktree path on
+/// success. Fails loudly (rather than silently clobbering) if the target
+/// worktree directory already exists — callers are expected to have already
+/// steered `SessionManager::resolve_session_name` away from a colliding name
+/// via [`worktree_name_collides`], so hitting this guard indicates a TOCTOU
+/// race or a caller that skipped the collision check.
+/// Test: covered by integration tests against a real temp repo;
+/// `create_session_worktree_rejects_existing_worktree_dir`.
+pub fn create_session_worktree(base_path: &Path, worktree_name: &str) -> Result<PathBuf, String> {
+    let worktree_path = worktree_path_for(base_path, worktree_name);
+    let branch = worktree_branch_for(worktree_name);
+
+    if worktree_path.exists() {
+        return Err(format!(
+            "inproject: worktree path already exists: {} — refusing to clobber \
+             (this should have been caught by the pre-reservation collision check)",
+            worktree_path.display()
+        ));
+    }
 
     info!(
         base = %base_path.display(),
@@ -425,22 +515,26 @@ pub fn get_origin_url(path: &Path) -> Option<String> {
     if url.is_empty() { None } else { Some(url) }
 }
 
-/// Main entry point for the in-project spawn path (#1706).
+/// Main entry point for the in-project spawn path's DETECTION phase (#1706, #2032).
 ///
 /// Why: the lifecycle layer needs a single call that encapsulates in-project
-/// detection and setup: is the given path inside a git repo with a GitHub remote?
-/// If so, ensure the base clone exists and create a per-session worktree.
+/// detection: is the given path inside a git repo with a GitHub remote? If so,
+/// ensure the base clone exists. Since #2032 this function STOPS SHORT of
+/// creating the per-session worktree: the worktree directory/branch must be
+/// named after the semantic tmux name (resolved via
+/// `SessionManager::resolve_session_name`), which requires the session
+/// manager's async store/tmux state that this synchronous, decoupled module
+/// deliberately has no access to. The caller
+/// (`daemon::managed_routes::lifecycle::spawn_managed_routed`) resolves the
+/// name and calls [`create_session_worktree`] itself.
 /// What: (1) checks that `path` is an existing directory with a `.git` entry;
 /// (2) reads the `remote.origin.url` — returns `Ok(None)` if absent;
 /// (3) parses the URL via `trusty_common::github_path::parse_github_path` —
-/// returns `Ok(None)` if unparseable; (4) calls [`ensure_base_clone`] and
-/// [`create_session_worktree`]; (5) returns `Ok(Some((worktree_path, owner, repo)))`.
-/// Steps 4–5 errors propagate as `Err`.
+/// returns `Ok(None)` if unparseable; (4) calls [`ensure_base_clone`];
+/// (5) returns `Ok(Some((base_clone_path, owner, repo)))` — NOT a worktree
+/// path (that was the pre-#2032 contract). Step 4 errors propagate as `Err`.
 /// Test: `try_inproject_spawn_returns_none_for_non_git_path` (unit).
-pub fn try_inproject_spawn(
-    path: &Path,
-    session_id: &ManagedSessionId,
-) -> Result<Option<(PathBuf, String, String)>, String> {
+pub fn try_inproject_spawn(path: &Path) -> Result<Option<(PathBuf, String, String)>, String> {
     if !path.is_dir() || !path.join(".git").exists() {
         return Ok(None);
     }
@@ -463,17 +557,15 @@ pub fn try_inproject_spawn(
 
     let base = base_clone_path(&gh.owner, &gh.repo);
     ensure_base_clone(&origin_url, &base)?;
-    let worktree = create_session_worktree(&base, session_id)?;
 
     info!(
         owner = %gh.owner,
         repo = %gh.repo,
-        worktree = %worktree.display(),
-        session = %session_id,
-        "inproject: per-session worktree ready"
+        base = %base.display(),
+        "inproject: base clone ready for per-session worktree"
     );
 
-    Ok(Some((worktree, gh.owner, gh.repo)))
+    Ok(Some((base, gh.owner, gh.repo)))
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
@@ -205,8 +205,7 @@ fn migrate_old_layout_aside_ignores_empty_and_git_dirs() {
 fn try_inproject_spawn_returns_none_for_non_git_path() {
     // A directory that is not a git repo must return Ok(None), not an error.
     let tmp = std::env::temp_dir();
-    let id = ManagedSessionId::new();
-    let result = try_inproject_spawn(&tmp, &id);
+    let result = try_inproject_spawn(&tmp);
     assert!(
         matches!(result, Ok(None)),
         "non-git path should yield Ok(None), got {result:?}"
@@ -257,17 +256,19 @@ fn base_clone_path_resolves_to_canonical_root() {
 
 #[test]
 fn session_worktree_path_uses_dot_prefix() {
-    // create_session_worktree must place the worktree at <base>/.worktrees/<id>
-    // (dot-prefixed) so it is gitignored via .git/info/exclude (#1803).
+    // create_session_worktree must place the worktree at
+    // <base>/.worktrees/<worktree_name> (dot-prefixed) so it is gitignored via
+    // .git/info/exclude (#1803). Since #2032 `worktree_name` is the resolved
+    // SEMANTIC tmux name (e.g. `tm-trusty-tools-01`), not a raw session UUID.
     // We call the PRODUCTION function against a real temporary git repository
     // (with an initial commit so `git worktree add` can branch from HEAD) and
-    // assert: (a) path is under <base>/.worktrees/, (b) ends with session id,
+    // assert: (a) path is under <base>/.worktrees/, (b) ends with the name,
     // (c) the directory actually exists after the call.
     //
     // Non-tautology proof: `expected_parent` is hardcoded as `base.join(".worktrees")`
     // — NOT derived from production code. If `create_session_worktree` changed
     // to `base_path.join("worktrees").join(...)` the `starts_with` assertion
-    // would fail because `base/worktrees/<id>` does NOT start with `base/.worktrees`.
+    // would fail because `base/worktrees/<name>` does NOT start with `base/.worktrees`.
     let tmp = tempfile::TempDir::new().expect("tmp dir");
     let base = tmp.path();
 
@@ -311,8 +312,8 @@ fn session_worktree_path_uses_dot_prefix() {
     assert!(commit.success(), "git commit failed");
 
     // Call the production function.
-    let id = ManagedSessionId::new();
-    let worktree_path = create_session_worktree(base, &id)
+    let name = "tm-test-repo-01";
+    let worktree_path = create_session_worktree(base, name)
         .expect("create_session_worktree must succeed on a real git repo");
 
     // (a) Path must be under <base>/.worktrees/ — hardcoded, not from production.
@@ -323,10 +324,10 @@ fn session_worktree_path_uses_dot_prefix() {
         worktree_path.display()
     );
 
-    // (b) Path must end with the session id.
+    // (b) Path must end with the semantic worktree name.
     assert!(
-        worktree_path.ends_with(id.to_string()),
-        "worktree path must end with session id {id}, got {}",
+        worktree_path.ends_with(name),
+        "worktree path must end with worktree name {name}, got {}",
         worktree_path.display()
     );
 
@@ -335,6 +336,142 @@ fn session_worktree_path_uses_dot_prefix() {
         worktree_path.is_dir(),
         "worktree directory must exist on disk, got {}",
         worktree_path.display()
+    );
+}
+
+/// Issue #2032: a worktree directory OR branch that already exists for a
+/// candidate name must be detected by [`worktree_name_collides`] so
+/// `SessionManager::resolve_session_name`'s extra-collision predicate steers
+/// away from it instead of `create_session_worktree` silently clobbering (or
+/// confusingly erroring on) it.
+///
+/// Why: the tmux-liveness check alone cannot see git worktrees/branches — a
+/// stale worktree left behind by a hand-deleted-but-not-decommissioned
+/// session must still be treated as a collision.
+/// What: (a) an absent name must not collide; (b) after creating a worktree
+/// for a name, THAT SAME name must collide (both the dir and the branch
+/// exist); (c) a name whose branch exists but whose worktree dir was manually
+/// removed must still collide (branch-only check).
+/// Test: this function IS the test.
+#[test]
+fn worktree_name_collides_detects_existing_dir_and_branch() {
+    let tmp = tempfile::TempDir::new().expect("tmp dir");
+    let base = tmp.path();
+
+    let init = std::process::Command::new("git")
+        .args(["init", base.to_str().expect("base is utf8")])
+        .output()
+        .expect("git init");
+    assert!(init.status.success(), "git init failed");
+    for (k, v) in [("user.email", "test@example.com"), ("user.name", "Test")] {
+        let ok = std::process::Command::new("git")
+            .args(["-C", base.to_str().expect("utf8"), "config", k, v])
+            .status()
+            .expect("git config");
+        assert!(ok.success(), "git config {k} failed");
+    }
+    std::fs::write(base.join("README"), b"init").expect("write README");
+    let add = std::process::Command::new("git")
+        .args(["-C", base.to_str().expect("utf8"), "add", "."])
+        .status()
+        .expect("git add");
+    assert!(add.success(), "git add failed");
+    let commit = std::process::Command::new("git")
+        .args(["-C", base.to_str().expect("utf8"), "commit", "-m", "init"])
+        .status()
+        .expect("git commit");
+    assert!(commit.success(), "git commit failed");
+
+    // (a) No collision before anything exists.
+    assert!(
+        !worktree_name_collides(base, "tm-fresh-01"),
+        "an unused name must not collide"
+    );
+
+    // (b) After creating the worktree, the SAME name must collide.
+    create_session_worktree(base, "tm-fresh-01").expect("create_session_worktree");
+    assert!(
+        worktree_name_collides(base, "tm-fresh-01"),
+        "an in-use name (dir + branch both exist) must collide"
+    );
+
+    // (c) Remove the worktree directory (but not the branch) via `git worktree
+    // remove`, which deletes the dir but leaves the branch ref intact — the
+    // branch-only check must still report a collision.
+    let remove = std::process::Command::new("git")
+        .arg("-C")
+        .arg(base)
+        .args(["worktree", "remove", "--force"])
+        .arg(base.join(".worktrees").join("tm-fresh-01"))
+        .output()
+        .expect("git worktree remove");
+    assert!(
+        remove.status.success(),
+        "git worktree remove failed: {}",
+        String::from_utf8_lossy(&remove.stderr)
+    );
+    assert!(
+        !base.join(".worktrees").join("tm-fresh-01").exists(),
+        "worktree dir must be gone after `git worktree remove`"
+    );
+    assert!(
+        worktree_name_collides(base, "tm-fresh-01"),
+        "a name whose branch still exists must still collide even after the \
+         worktree dir was removed"
+    );
+}
+
+/// Issue #2032: [`create_session_worktree`] must refuse to clobber an
+/// existing worktree directory rather than silently overwriting it.
+///
+/// Why: `worktree_name_collides` is the PROACTIVE guard used by name
+/// resolution; this is the DEFENSIVE guard inside `create_session_worktree`
+/// itself, covering a caller that skips the collision check (or a TOCTOU
+/// race).
+/// What: creates a worktree for a name, then calls `create_session_worktree`
+/// again for the SAME name and asserts it returns `Err` (not a panic, not a
+/// silent overwrite) and that the original worktree directory is untouched.
+/// Test: this function IS the test.
+#[test]
+fn create_session_worktree_rejects_existing_worktree_dir() {
+    let tmp = tempfile::TempDir::new().expect("tmp dir");
+    let base = tmp.path();
+
+    let init = std::process::Command::new("git")
+        .args(["init", base.to_str().expect("base is utf8")])
+        .output()
+        .expect("git init");
+    assert!(init.status.success(), "git init failed");
+    for (k, v) in [("user.email", "test@example.com"), ("user.name", "Test")] {
+        let ok = std::process::Command::new("git")
+            .args(["-C", base.to_str().expect("utf8"), "config", k, v])
+            .status()
+            .expect("git config");
+        assert!(ok.success(), "git config {k} failed");
+    }
+    std::fs::write(base.join("README"), b"init").expect("write README");
+    let add = std::process::Command::new("git")
+        .args(["-C", base.to_str().expect("utf8"), "add", "."])
+        .status()
+        .expect("git add");
+    assert!(add.success(), "git add failed");
+    let commit = std::process::Command::new("git")
+        .args(["-C", base.to_str().expect("utf8"), "commit", "-m", "init"])
+        .status()
+        .expect("git commit");
+    assert!(commit.success(), "git commit failed");
+
+    let first = create_session_worktree(base, "tm-dup-01").expect("first create must succeed");
+    assert!(first.is_dir(), "first worktree must exist");
+
+    let second = create_session_worktree(base, "tm-dup-01");
+    assert!(
+        second.is_err(),
+        "creating a worktree for an already-existing name must error, not clobber"
+    );
+    assert!(
+        first.is_dir(),
+        "the original worktree must remain untouched after the rejected re-create"
     );
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -145,10 +145,22 @@ pub async fn spawn_managed(
 /// function is exactly the routing logic `spawn_managed` used to run inline
 /// after `is_local_workdir` detection, before #1919 moved the scope to cover it.
 /// What: local-path fast path (#1433) — if `repo_url` is an existing local
-/// absolute directory, tries in-project detection (#1706, via
-/// `try_inproject_spawn`) first and dispatches to `spawn_managed_inproject` on
-/// a match, else falls through to `spawn_managed_local`. A remote repo URL
-/// (the common case) falls straight through to `spawn_managed_cloned`.
+/// absolute directory, tries in-project DETECTION (#1706, via
+/// `try_inproject_spawn`, which since #2032 only ensures the base clone and
+/// returns `(base_path, owner, repo)` — it no longer creates the worktree
+/// itself). On a match, this function resolves the SEMANTIC tmux name here —
+/// BEFORE the per-session worktree exists — via
+/// `SessionManager::resolve_session_name`, folding in
+/// `inproject::worktree_name_collides` as the extra collision predicate so a
+/// name whose worktree dir/branch already exists is retried with the next
+/// free serial instead of silently colliding. It then creates the worktree at
+/// that resolved name (`inproject::create_session_worktree`) and dispatches to
+/// `spawn_managed_inproject`, threading the resolved name through so
+/// `create_with_id` never re-derives it (issue #2032 — a session's tmux name
+/// is derived in exactly ONE place). Any failure in detection, name
+/// resolution, or worktree creation falls through to `spawn_managed_local`. A
+/// remote repo URL (the common case) falls straight through to
+/// `spawn_managed_cloned`.
 /// Test: exercised transitively by the same tests that covered the inline
 /// version before extraction (HTTP spawn tests, MCP session tests); the
 /// stage-emission behaviour added by #1919 is covered by
@@ -173,18 +185,38 @@ async fn spawn_managed_routed(
         // with a GitHub remote (no `.git`, no remote origin, non-GitHub URL), fall
         // through to the existing local-path spawn.
         let local_path = std::path::Path::new(&params.repo_url);
-        match try_inproject_spawn(local_path, &session_id) {
-            Ok(Some((worktree, owner, repo))) => {
-                return spawn_managed_inproject(
+        match try_inproject_spawn(local_path) {
+            Ok(Some((base, owner, repo))) => {
+                match reserve_inproject_worktree(
                     state,
                     &session_id,
                     &params,
-                    runtime,
-                    worktree,
-                    owner,
-                    repo,
+                    local_path,
+                    &base,
+                    &repo,
                 )
-                .await;
+                .await
+                {
+                    Ok((worktree, reserved_name)) => {
+                        return spawn_managed_inproject(
+                            state,
+                            &session_id,
+                            &params,
+                            runtime,
+                            worktree,
+                            owner,
+                            repo,
+                            reserved_name,
+                        )
+                        .await;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            id = %session_id,
+                            "in-project spawn: {e}; falling back to local-path spawn"
+                        );
+                    }
+                }
             }
             Ok(None) => {
                 // Not a git repo with a GitHub remote — use local-path fast path.
@@ -200,6 +232,52 @@ async fn spawn_managed_routed(
     }
 
     spawn_managed_cloned(state, session_id, params, runtime, config).await
+}
+
+/// Resolve the semantic tmux name and create the per-session worktree for the
+/// in-project spawn path (issue #2032).
+///
+/// Why: split out of [`spawn_managed_routed`] so the name-resolution-then-
+/// worktree-creation sequence — the actual #2032 hoist — reads as one clear
+/// step, and so its two fallible sub-steps (name resolution, worktree
+/// creation) share one error-formatting path back to the caller's
+/// fall-through-to-local-path handling.
+/// What: (1) resolves a collision-free tmux name via
+/// `SessionManager::resolve_session_name`, using `params.name_hint`, the
+/// detected repo name as the GitHub-project fallback (`cwd` is passed only as
+/// the third-priority basename fallback — it is never actually reached here
+/// since the repo name is always `Some`), and
+/// `inproject::worktree_name_collides(base, candidate)` as the extra
+/// collision predicate (so a name whose `.worktrees/<name>` dir or
+/// `session/<name>` branch already exists is retried with the next serial,
+/// not silently reused); (2) creates the worktree at that name via
+/// `inproject::create_session_worktree`. Returns `(worktree_path,
+/// reserved_name)` so the caller can create the tmux session under the SAME
+/// name without re-deriving it.
+/// Test: exercised transitively by the in-project spawn integration tests.
+async fn reserve_inproject_worktree(
+    state: &Arc<DaemonState>,
+    session_id: &ManagedSessionId,
+    params: &SpawnParams,
+    local_path: &std::path::Path,
+    base: &std::path::Path,
+    repo: &str,
+) -> Result<(std::path::PathBuf, String), String> {
+    let mgr = state.session_manager().await;
+    let reserved_name = mgr
+        .resolve_session_name(
+            params.name_hint.as_deref(),
+            Some(repo),
+            local_path,
+            |candidate| super::inproject::worktree_name_collides(base, candidate),
+        )
+        .await
+        .map_err(|e| format!("name resolution failed for session {session_id}: {e}"))?;
+
+    let worktree = super::inproject::create_session_worktree(base, &reserved_name)
+        .map_err(|e| format!("worktree creation failed for session {session_id}: {e}"))?;
+
+    Ok((worktree, reserved_name))
 }
 
 /// The clone-based provisioning tail of [`spawn_managed_routed`] (issue #1904).
@@ -455,21 +533,26 @@ fn find_reusable_inproject_session(
 ///
 /// #1913: unlike `spawn_managed`'s clone path and `spawn_managed_local`, this
 /// path does not go through `WorkspaceProvisioner::provision_in` (there is no
-/// clone step — the worktree already exists via `try_inproject_spawn`), so it
-/// must call [`crate::core::session_launch::prepare_session_with_repo_url`]
-/// itself. Before this fix it never did, so every in-project session silently
-/// got no statusline, no deployed agents/skills, no injected trusty-memory/
+/// clone step — the worktree already exists via `try_inproject_spawn` +
+/// `reserve_inproject_worktree`), so it must call
+/// [`crate::core::session_launch::prepare_session_with_repo_url`] itself.
+/// Before this fix it never did, so every in-project session silently got no
+/// statusline, no deployed agents/skills, no injected trusty-memory/
 /// trusty-search MCP config, and no merged CLAUDE.md.
 /// What: in order — (1) writes `TASK.md` into the worktree; (2) runs
 /// [`prepare_inproject_session`] (best-effort, mirrors `provision_in`'s
 /// non-fatal error handling); (3) creates the tmux session rooted at the
-/// worktree via `create_with_id`; (4) sets `source_id` via `set_source_id`;
-/// (5) runs the FRONT gate (fail-open); (6) marks `Active`; (7) spawns the
-/// runtime. A spawn failure marks the record errored (non-fatal).
+/// worktree via `create_with_reserved_name` (issue #2032 — `reserved_name` was
+/// already resolved by `reserve_inproject_worktree` and used to name the
+/// worktree/branch, so this step reuses it verbatim instead of re-deriving);
+/// (4) sets `source_id` via `set_source_id`; (5) runs the FRONT gate
+/// (fail-open); (6) marks `Active`; (7) spawns the runtime. A spawn failure
+/// marks the record errored (non-fatal).
 /// Test: covered transitively by the in-project spawn integration tests;
 /// `prepare_inproject_session_writes_statusline` in this module's `tests`
 /// submodule exercises the new prep-call in isolation (hermetic — no daemon,
 /// tmux, or git required).
+#[allow(clippy::too_many_arguments)]
 async fn spawn_managed_inproject(
     state: &std::sync::Arc<crate::daemon::state::DaemonState>,
     session_id: &crate::session_manager::ManagedSessionId,
@@ -478,6 +561,7 @@ async fn spawn_managed_inproject(
     worktree: std::path::PathBuf,
     owner: String,
     repo: String,
+    reserved_name: String,
 ) -> Result<crate::session_manager::SessionRecord, String> {
     use crate::core::provisioning_stage::{ProvisioningStage, emit};
     use crate::session_manager::ManagedSessionState;
@@ -542,11 +626,11 @@ async fn spawn_managed_inproject(
     emit(ProvisioningStage::CreatingTmuxSession);
     let mgr = state.session_manager().await;
     let record = mgr
-        .create_with_id(
+        .create_with_reserved_name(
             *session_id,
+            reserved_name,
             params.task.clone(),
             Some(worktree.clone()),
-            params.name_hint.clone(),
             Some(worktree.clone()),
             Some(synthetic_repo_url),
             None,
@@ -1337,6 +1421,102 @@ mod tests {
             ],
             "prepare_inproject_session's call tree must emit exactly these \
              four stages, in order, when a StageEmitter scope is active"
+        );
+    }
+
+    /// Issue #2032: [`reserve_inproject_worktree`] must name the per-session
+    /// worktree/branch after the SEMANTIC tmux name (`tm-<repo>-NN`), not the
+    /// raw session UUID — and the returned name must be the exact name used
+    /// for both the worktree directory and (via `create_session_worktree`)
+    /// the `session/<name>` branch.
+    ///
+    /// Why hermetic: `DaemonState::with_root_isolated_managed` (the same
+    /// helper `tests/session_manager_mvp.rs` uses) gives this test a real
+    /// `SessionManager` backed by `FakeNoopTmuxDriver` — no real tmux, no
+    /// production store — while a real temp git repo stands in for the base
+    /// clone so `create_session_worktree`'s `git worktree add` actually runs.
+    /// What: builds a real git repo (init + one commit) as `base`, calls
+    /// `reserve_inproject_worktree` with `repo = "trusty-tools"`, and asserts
+    /// (a) the resolved name matches `tm-trusty-tools-01` (NOT a UUID); (b)
+    /// the returned worktree path ends with that exact name; (c) the
+    /// worktree directory actually exists on disk.
+    /// Test: this function IS the test.
+    #[tokio::test]
+    async fn reserve_inproject_worktree_uses_semantic_name_not_uuid() {
+        let data_root = tempfile::TempDir::new().expect("tmp data root");
+        let state = std::sync::Arc::new(
+            crate::daemon::state::DaemonState::with_root_isolated_managed(
+                data_root.path().to_path_buf(),
+            )
+            .await,
+        );
+
+        let base_dir = tempfile::TempDir::new().expect("tmp base dir");
+        let base = base_dir.path().to_path_buf();
+        assert!(
+            std::process::Command::new("git")
+                .arg("init")
+                .current_dir(&base)
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false),
+            "git init must succeed in this test fixture"
+        );
+        for (k, v) in [("user.email", "t@example.com"), ("user.name", "T")] {
+            let _ = std::process::Command::new("git")
+                .args(["-C", base.to_str().unwrap(), "config", k, v])
+                .status();
+        }
+        assert!(
+            std::process::Command::new("git")
+                .args([
+                    "-C",
+                    base.to_str().unwrap(),
+                    "commit",
+                    "--allow-empty",
+                    "-m",
+                    "init",
+                ])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false),
+            "git commit must succeed in this test fixture"
+        );
+
+        let session_id = ManagedSessionId::new();
+        let params = SpawnParams {
+            repo_url: base.to_string_lossy().into_owned(),
+            git_ref: "main".into(),
+            task: "task".into(),
+            name_hint: None,
+            runtime: None,
+            ephemeral: Some(true),
+            mcp_initiated: false,
+        };
+
+        let (worktree, reserved_name) =
+            reserve_inproject_worktree(&state, &session_id, &params, &base, &base, "trusty-tools")
+                .await
+                .expect("reserve_inproject_worktree must succeed against a real git repo");
+
+        assert_eq!(
+            reserved_name, "tm-trusty-tools-01",
+            "the resolved name must be the SEMANTIC tm-<repo>-NN form, not the raw session UUID"
+        );
+        assert!(
+            worktree.ends_with(&reserved_name),
+            "the worktree path must end with the resolved semantic name, got {}",
+            worktree.display()
+        );
+        assert!(
+            !worktree.to_string_lossy().contains(&session_id.to_string()),
+            "the worktree path must NOT contain the raw session UUID (issue #2032), got {}",
+            worktree.display()
+        );
+        assert!(
+            worktree.is_dir(),
+            "the worktree directory must exist on disk, got {}",
+            worktree.display()
         );
     }
 }

--- a/crates/trusty-mpm/src/session_manager/create.rs
+++ b/crates/trusty-mpm/src/session_manager/create.rs
@@ -1,0 +1,253 @@
+//! Session creation: derive/accept a tmux name, create the host, persist the
+//! record (issue #2032; extracted from `manager.rs` to keep it under its
+//! 500-SLOC production cap — same pattern as `reactivate.rs`/`hook_sync.rs`).
+//!
+//! Why: issue #2032 needs a THIRD create path — alongside the existing
+//! derive-the-name [`SessionManager::create`]/[`SessionManager::create_with_id`]
+//! — for the in-project spawn routing layer, which must resolve the semantic
+//! tmux name BEFORE the per-session git worktree exists (the worktree is now
+//! named after the tmux name, not the raw session UUID) and therefore cannot
+//! let `create_with_id` re-derive a (possibly different) name afterwards.
+//! [`SessionManager::create_with_reserved_name`] accepts that pre-reserved
+//! name directly. All three converge on one private tail,
+//! [`SessionManager::create_with_resolved_name`], so the
+//! tmux-guard/correlation/persist dance is written exactly once.
+//! What: `create_with_id` (derives via [`super::naming`]'s
+//! `resolve_session_name`, then delegates), `create_with_reserved_name`
+//! (skips derivation, trusts the caller), `create_with_resolved_name` (shared
+//! tail: create tmux session, arm the orphan-reaping guard, build and persist
+//! the [`SessionRecord`]).
+//! Test: `manager_create_record`, `manager_create_persists_runtime`,
+//! `manager_create_persists_ephemeral_flag` in `tests.rs`; the in-project
+//! spawn integration tests exercise `create_with_reserved_name` transitively.
+
+use std::path::PathBuf;
+
+use chrono::Utc;
+use tracing::{info, warn};
+
+use super::manager::{ManagedError, SessionManager};
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+impl SessionManager {
+    /// Create a new managed session with a caller-supplied session id.
+    ///
+    /// Why: the `spawn_session` handler must provision the workspace BEFORE
+    /// creating the tmux session so that the tmux pane is rooted in the
+    /// provisioned directory (not `$HOME`). Provisioning requires the session id
+    /// upfront (it is embedded in the workspace path). This method lets the
+    /// handler pre-generate the id, provision, and then call here with `cwd =
+    /// Some(workspace_path)` so `tmux new-session -c <workspace>` is issued.
+    /// What: identical to [`SessionManager::create`] except the id and runtime
+    /// backend are supplied by the caller. Derives the tmux name (issue #1955
+    /// priority: `name_hint` > GitHub-parseable `repo_url` > `cwd` basename)
+    /// via [`SessionManager::resolve_session_name`] (`naming.rs`, shared
+    /// verbatim with the in-project spawn path's pre-worktree name
+    /// reservation — see [`Self::create_with_reserved_name`]), then delegates
+    /// to [`Self::create_with_resolved_name`] for the actual tmux-create +
+    /// persist steps. The `ephemeral` flag (#1508) tags test/throwaway
+    /// sessions so the bulk-teardown and age-based reap paths may
+    /// decommission them automatically; real callers pass `false`. The
+    /// `owned` flag (#1511) must be `true` ONLY when the SM provisioned the
+    /// workspace via git clone; local-path spawn, adopt, and reconcile all
+    /// pass `false` (safe default — never delete).
+    /// Test: `spawn_session_tmux_cwd_is_workspace` in session_manager/tests.rs;
+    /// `handler_spawn_creates_tmux_at_workspace_cwd` in session_manager_mvp.rs;
+    /// `manager_create_persists_runtime` in session_manager/tests.rs;
+    /// `manager_create_persists_ephemeral_flag` in session_manager/tests.rs.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_with_id(
+        &self,
+        id: ManagedSessionId,
+        task: String,
+        cwd: Option<PathBuf>,
+        name_hint: Option<String>,
+        workspace_path: Option<PathBuf>,
+        repo_url: Option<String>,
+        branch: Option<String>,
+        runtime: crate::runtime::RuntimeKind,
+        ephemeral: bool,
+        owned: bool,
+    ) -> Result<SessionRecord, ManagedError> {
+        let cwd = cwd.unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp")));
+        let github_project = repo_url
+            .as_deref()
+            .and_then(trusty_common::github_path::parse_github_path)
+            .map(|gh| gh.repo);
+        let tmux_name = self
+            .resolve_session_name(
+                name_hint.as_deref(),
+                github_project.as_deref(),
+                &cwd,
+                |_| false,
+            )
+            .await?;
+        self.create_with_resolved_name(
+            id,
+            tmux_name,
+            task,
+            cwd,
+            workspace_path,
+            repo_url,
+            branch,
+            runtime,
+            ephemeral,
+            owned,
+        )
+        .await
+    }
+
+    /// Create a new managed session using a PRE-RESOLVED, pre-reserved tmux
+    /// session name (issue #2032).
+    ///
+    /// Why: the in-project spawn path (`daemon::managed_routes::inproject`)
+    /// must name the per-session git worktree/branch after the SEMANTIC tmux
+    /// name rather than the raw session UUID, and the worktree has to exist
+    /// BEFORE the tmux session does. That forces name resolution to happen
+    /// earlier than [`Self::create_with_id`] normally would derive it (via
+    /// [`SessionManager::resolve_session_name`], with the worktree-dir/branch
+    /// check folded in as an extra collision predicate). This method accepts
+    /// that already-reserved name directly instead of re-deriving it, so a
+    /// single session is never named twice.
+    /// What: identical to [`Self::create_with_id`] except `reserved_name` is
+    /// used verbatim as the tmux session name — no `name_hint`/`repo_url`/`cwd`
+    /// derivation runs here at all.
+    /// Test: exercised transitively by the in-project spawn integration tests;
+    /// `manager_create_with_reserved_name_skips_derivation` in `tests.rs`.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn create_with_reserved_name(
+        &self,
+        id: ManagedSessionId,
+        reserved_name: String,
+        task: String,
+        cwd: Option<PathBuf>,
+        workspace_path: Option<PathBuf>,
+        repo_url: Option<String>,
+        branch: Option<String>,
+        runtime: crate::runtime::RuntimeKind,
+        ephemeral: bool,
+        owned: bool,
+    ) -> Result<SessionRecord, ManagedError> {
+        let cwd = cwd.unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp")));
+        self.create_with_resolved_name(
+            id,
+            reserved_name,
+            task,
+            cwd,
+            workspace_path,
+            repo_url,
+            branch,
+            runtime,
+            ephemeral,
+            owned,
+        )
+        .await
+    }
+
+    /// Shared tail of [`Self::create_with_id`] / [`Self::create_with_reserved_name`]:
+    /// create the tmux host at an ALREADY-RESOLVED name and persist the record.
+    ///
+    /// Why: extracting this (#2032) means the name-derivation callers and the
+    /// pre-reserved-name caller share one create+persist implementation instead
+    /// of two near-duplicate copies of the tmux-guard/correlation/upsert dance.
+    /// What: creates the tmux session at `cwd` via the driver, arms a
+    /// [`super::session_guard::TmuxSessionGuard`] so a failed persist reaps the
+    /// orphaned session (#1452/#1453), builds the [`SessionRecord`] in state
+    /// `Provisioning`, and persists it.
+    /// Test: covered transitively by every `create_with_id`/
+    /// `create_with_reserved_name` test.
+    #[allow(clippy::too_many_arguments)]
+    async fn create_with_resolved_name(
+        &self,
+        id: ManagedSessionId,
+        tmux_name: String,
+        task: String,
+        cwd: PathBuf,
+        workspace_path: Option<PathBuf>,
+        repo_url: Option<String>,
+        branch: Option<String>,
+        runtime: crate::runtime::RuntimeKind,
+        ephemeral: bool,
+        owned: bool,
+    ) -> Result<SessionRecord, ManagedError> {
+        let workdir = cwd.to_string_lossy().to_string();
+        self.tmux
+            .create_session(&tmux_name, &workdir)
+            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
+
+        // OWN the freshly-created tmux session immediately (#1453). From here
+        // until the record is durably persisted, this guard is the session's
+        // sole owner: any early return (e.g. a failing `store.upsert`) drops the
+        // guard and reaps the otherwise-orphaned tmux session. Ownership is
+        // transferred to the persistent store via `disarm` only AFTER upsert
+        // succeeds — closing the window that let 159 orphans accumulate (#1452).
+        let mut tmux_guard =
+            super::session_guard::TmuxSessionGuard::new(tmux_name.clone(), self.tmux.clone());
+
+        // Seed the session↔artifact correlation from what we know at creation
+        // time (worktree path + branch). PR / issue ids accrue later as the
+        // driver pushes work and opens a PR.
+        let mut correlation = crate::driver::SessionCorrelation::new();
+        if let Some(ref ws) = workspace_path {
+            correlation = correlation.with_worktree(ws.clone());
+        }
+        if let Some(ref b) = branch {
+            correlation = correlation.with_branch(b.clone());
+        }
+
+        let record = SessionRecord {
+            id,
+            tmux_name: tmux_name.clone(),
+            cwd,
+            task,
+            state: ManagedSessionState::Provisioning,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path,
+            repo_url,
+            branch,
+            pending_decision: None,
+            proposed_default: None,
+            correlation,
+            runtime,
+            ephemeral,
+            // Ownership is set atomically at creation: `true` ONLY when the SM
+            // provisioned the workspace via git clone; local-path spawn (#1502),
+            // adopt (#1433), and reconcile all pass `false` (safe default —
+            // prefer NOT deleting over accidental deletion).
+            workspace_owned: owned,
+            // source_id is set post-creation by the in-project spawn path
+            // (via SessionManager::set_source_id); this constructor never
+            // knows the source project — it is set by the caller.
+            source_id: None,
+            claude_session_id: None,
+            scrollback_path: None,
+            last_cwd: None,
+        };
+
+        // Persist the record. On failure the freshly-created tmux session has
+        // NO registry owner — the armed `tmux_guard` above reaps it on the early
+        // return below, preventing the orphan (#1457). The reap itself happens
+        // silently in the guard's `Drop`; log here first so the rollback is
+        // visible in the daemon's stderr logs alongside the other lifecycle
+        // events (never stdout — that carries MCP JSON-RPC framing).
+        if let Err(e) = self.store.write().await.upsert(record.clone()).await {
+            warn!(
+                id = %id,
+                name = %tmux_name,
+                "registry upsert failed; rolling back (reaping) the orphaned tmux session: {e}"
+            );
+            // Returning here drops the still-armed `tmux_guard`, which kills the
+            // session. The original store error propagates unchanged.
+            return Err(ManagedError::from(e));
+        }
+
+        // The record is durably persisted; the store/registry now owns the
+        // session's lifetime. Disarm so the guard's drop is a no-op and the
+        // tracked session is NOT reaped at the end of this request scope (#1453).
+        tmux_guard.disarm();
+
+        info!(id = %id, name = %tmux_name, runtime = %runtime.as_str(), "managed session created");
+        Ok(record)
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -95,11 +95,18 @@ fn is_session_worktree(path: &Path) -> bool {
 /// What: runs `git -C <repo-root> worktree remove --force <path>` where
 /// `<repo-root>` is the grandparent of the worktree directory
 /// (`path` → `.worktrees` → `<repo-root>`). Also runs
-/// `git -C <repo-root> worktree prune` and `git -C <repo-root> branch -D <session>`
-/// on success to clear stale git refs and the session branch. `<session>` is
-/// the last component of `path` (the worktree dir name). Branch deletion is
-/// best-effort — "not found" is silently ignored since older sessions may not
-/// have a branch. OsStr-safe path args avoid lossy UTF-8 coercion (#1840).
+/// `git -C <repo-root> worktree prune` and
+/// `git -C <repo-root> branch -D session/<leaf>` on success to clear stale git
+/// refs and the session branch, where `<leaf>` is the last component of `path`
+/// (the worktree dir name) and the `session/` prefix matches EXACTLY what
+/// `inproject::create_session_worktree` creates (issue #2032 fix — before
+/// this, the missing prefix meant the branch delete always targeted a
+/// nonexistent ref and silently no-opped, leaking every session's branch).
+/// Works identically for both pre-#2032 UUID-named leaves and the new
+/// semantic-tmux-name leaves, since both share the `session/<leaf>`
+/// convention. Branch deletion is best-effort — "not found" is silently
+/// ignored since older sessions may not have a branch. OsStr-safe path args
+/// avoid lossy UTF-8 coercion (#1840).
 /// Idempotent: if `path` is already absent, returns `true` (already removed).
 /// On git failure, best-effort falls back to `remove_dir_all` and logs WARN.
 /// Returns `true` when the workspace was removed (either via git or fallback)
@@ -205,22 +212,35 @@ pub(super) fn remove_session_worktree(path: &Path) -> bool {
             warn!(root = %repo_root.display(), "decommission: git worktree prune failed: {e}");
         }
 
-        // Step 3: delete the session branch ref (if any). The branch name matches
-        // the worktree dir name. Ignore "not found" — the branch may not exist for
-        // older sessions that never created one (#1840).
-        if let Some(session_name) = path.file_name() {
+        // Step 3: delete the session branch ref (if any). #2032 FIX: the branch
+        // `create_session_worktree` actually creates is `session/<worktree-leaf>`
+        // (see `crate::core::worktree_naming::worktree_branch_for` — the SAME
+        // convention `daemon::managed_routes::inproject::create_session_worktree`
+        // uses), NOT the bare leaf name. Before this fix the missing `session/`
+        // prefix meant `git branch -D <leaf>` always targeted a nonexistent
+        // branch and silently fell into the "not found" debug-log path below —
+        // session branches were NEVER actually cleaned up. This works
+        // identically for both OLD (raw-UUID-named, pre-#2032) and NEW
+        // (semantic-tmux-name) worktree leaves, since both used/use the same
+        // `session/<leaf>` convention for the branch name. Ignore "not found"
+        // — the branch may not exist for older sessions that never created one
+        // (#1840). Uses `core::worktree_naming` (unconditionally compiled),
+        // NOT `daemon::managed_routes::inproject` (feature = "daemon"), so
+        // this module keeps compiling with the `daemon` feature disabled.
+        if let Some(session_name) = path.file_name().and_then(|n| n.to_str()) {
+            let branch = crate::core::worktree_naming::worktree_branch_for(session_name);
             let branch_out = std::process::Command::new("git")
                 .arg("-C")
                 .arg(repo_root)
                 .args(["branch", "-D"])
-                .arg(session_name)
+                .arg(&branch)
                 .output();
             match branch_out {
                 Ok(o) if o.status.success() => {
                     info!(
                         path = %path.display(),
                         "decommission: git branch -D {:?} (session ref cleaned)",
-                        session_name
+                        branch
                     );
                 }
                 Ok(o) => {
@@ -228,7 +248,7 @@ pub(super) fn remove_session_worktree(path: &Path) -> bool {
                     tracing::debug!(
                         path = %path.display(),
                         "decommission: git branch -D {:?} not needed: {}",
-                        session_name,
+                        branch,
                         String::from_utf8_lossy(&o.stderr).trim()
                     );
                 }

--- a/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
@@ -90,7 +90,14 @@ async fn manager_decommission_removes_real_git_worktree() {
     }
 
     // ── Real `git worktree add` under <base>/.worktrees/<session-name> ───────
+    // Branch is `session/<session_name>` (issue #2032 fix) — this MUST mirror
+    // the exact convention `create_session_worktree`/`worktree_branch_for`
+    // use in production, or this fixture would silently re-encode the very
+    // bug #2032 fixed (a pre-#2032 version of this fixture used the bare,
+    // unprefixed name here, which happened to match `decommission.rs`'s
+    // then-buggy `git branch -D <leaf>` and masked the missing-prefix bug).
     let session_name = "test-session-1806";
+    let branch_name = crate::core::worktree_naming::worktree_branch_for(session_name);
     let worktrees_dir = base.join(".worktrees");
     std::fs::create_dir_all(&worktrees_dir).unwrap();
     let worktree_path = worktrees_dir.join(session_name);
@@ -101,7 +108,7 @@ async fn manager_decommission_removes_real_git_worktree() {
             "worktree",
             "add",
             "-b",
-            session_name,
+            &branch_name,
         ])
         .arg(&worktree_path)
         .status()
@@ -158,14 +165,14 @@ async fn manager_decommission_removes_real_git_worktree() {
         "git worktree list must not reference the removed worktree; got: {list_stdout}"
     );
 
-    // The session branch ref must have been deleted.
+    // The session branch ref (`session/<name>`, #2032) must have been deleted.
     let branch_out = std::process::Command::new("git")
         .args([
             "-C",
             base.to_str().unwrap(),
             "branch",
             "--list",
-            session_name,
+            &branch_name,
         ])
         .output()
         .expect("git branch --list");

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
-use crate::core::names::{SessionNameError, build_managed_session_name, leaf_slug_from_dir};
+use crate::core::names::SessionNameError;
 use crate::core::sm::control::Submit;
 
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
@@ -176,7 +176,7 @@ impl SessionManager {
     ///
     /// Why: `POST /api/v1/sessions/managed` needs the full create-name-record-spawn
     /// flow in one operation so the HTTP handler stays thin.
-    /// What: derives the tmux name via [`build_managed_session_name`]
+    /// What: derives the tmux name via [`Self::resolve_session_name`]
     /// (`tm-<project-leaf>-NN`, #1955), creates the tmux session via the driver,
     /// persists a [`SessionRecord`] in state `Provisioning`, and returns it.
     /// The runtime backend defaults to [`crate::runtime::RuntimeKind::ClaudeCode`]
@@ -204,205 +204,6 @@ impl SessionManager {
             false,
         )
         .await
-    }
-
-    /// Create a new managed session with a caller-supplied session id.
-    ///
-    /// Why: the `spawn_session` handler must provision the workspace BEFORE
-    /// creating the tmux session so that the tmux pane is rooted in the
-    /// provisioned directory (not `$HOME`). Provisioning requires the session id
-    /// upfront (it is embedded in the workspace path). This method lets the
-    /// handler pre-generate the id, provision, and then call here with `cwd =
-    /// Some(workspace_path)` so `tmux new-session -c <workspace>` is issued.
-    /// What: identical to [`create`] except the id and runtime backend are
-    /// supplied by the caller. Creates the tmux session at `cwd` via the driver,
-    /// persists a [`SessionRecord`] in state `Provisioning` carrying `runtime`,
-    /// and returns it. The `ephemeral` flag (#1508) tags test/throwaway sessions
-    /// so the bulk-teardown and age-based reap paths may decommission them
-    /// automatically; real callers pass `false`. The `owned` flag (#1511) must be
-    /// `true` ONLY when the SM provisioned the workspace via git clone; local-path
-    /// spawn, adopt, and reconcile all pass `false` (safe default — never delete).
-    /// Test: `spawn_session_tmux_cwd_is_workspace` in session_manager/tests.rs;
-    /// `handler_spawn_creates_tmux_at_workspace_cwd` in session_manager_mvp.rs;
-    /// `manager_create_persists_runtime` in session_manager/tests.rs;
-    /// `manager_create_persists_ephemeral_flag` in session_manager/tests.rs.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn create_with_id(
-        &self,
-        id: ManagedSessionId,
-        task: String,
-        cwd: Option<PathBuf>,
-        name_hint: Option<String>,
-        workspace_path: Option<PathBuf>,
-        repo_url: Option<String>,
-        branch: Option<String>,
-        runtime: crate::runtime::RuntimeKind,
-        ephemeral: bool,
-        owned: bool,
-    ) -> Result<SessionRecord, ManagedError> {
-        let cwd = cwd.unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp")));
-        // Name selection priority (issue #1955, supersedes the #1789/#1791
-        // `tmpm-<repo-slug>-<8hex>` scheme):
-        //   1. Explicit `name_hint` from the user → leaf = sanitized hint
-        //      (treated as a directory-like basename, matching pre-#1955
-        //      behaviour for the hint itself) → `tm-<hint-slug>-NN`.
-        //   2. GitHub-parseable `repo_url`         → leaf = repo name →
-        //      `tm-<repo>-NN` (project-identifiable; preferred over the cwd
-        //      basename because for the clone path `cwd` is
-        //      `<workspace-root>/<owner>/<repo>/<session-id>/`, whose BASENAME
-        //      is the session UUID — not useful).
-        //   3. Otherwise                            → leaf = basename(cwd), or
-        //      the literal `"local"` if that sanitizes to empty (e.g. cwd is
-        //      `/` or unset and fell back to `$HOME`'s unusable basename).
-        // Every branch now allocates a per-project serial (issue #1955) so
-        // concurrent sessions for the SAME leaf get distinguishable `-01`,
-        // `-02`, `-03` names instead of relying solely on the raw tmux
-        // `NameCollision` error — the hint path previously had NO uniqueness
-        // suffix at all.
-        let mut existing_names = self.names_for_serial_allocation().await?;
-        let leaf_hint = name_hint
-            .as_deref()
-            .map(|h| leaf_slug_from_dir(Path::new(h)));
-        let github_project = repo_url
-            .as_deref()
-            .and_then(trusty_common::github_path::parse_github_path)
-            .map(|gh| gh.repo);
-
-        // Allocate a name, then check for a live tmux collision (belt-and-
-        // suspenders: the serial allocation above should already guarantee
-        // freedom from collision, but a concurrent create for the same leaf
-        // between the allocation read and this check is possible under load).
-        // Why a bounded retry loop (#1966 review follow-up) rather than a
-        // single check-and-fail: a lost race is recoverable — feeding the
-        // just-collided name back into `existing_names` makes the next
-        // allocation pick the following free serial, so a concurrent create
-        // only costs an extra loop iteration instead of a hard user-visible
-        // failure. `NameCollision` is still returned if every attempt in the
-        // bounded window collides (e.g. sustained, pathological contention),
-        // so this can never loop forever.
-        //
-        // Residual race window (KNOWN, not closed by this loop): there is
-        // still a gap between THIS `session_exists` check and the
-        // `create_session` call a few lines below. Note this does NOT
-        // surface as a `TmuxUnavailable` error the way a naive analysis might
-        // suggest — `create_session` shells out to `tmux new-session -A -d`
-        // (see `crate::core::tmux::tmux_argv`), and `-A` makes tmux ATTACH to
-        // an existing session of the same name instead of failing. So if two
-        // concurrent creates lose this exact race, both succeed, but the
-        // second one silently attaches to the first one's pane — an aliasing
-        // risk (two `SessionRecord`s could end up pointing at one tmux
-        // session), not a crash. Closing this fully would require a
-        // distributed lock across the external `tmux` process (e.g. a
-        // per-name lock file) — out of scope for this naming-scheme ticket;
-        // tracked as a follow-up if it proves to matter in practice.
-        const MAX_NAME_ALLOCATION_ATTEMPTS: u8 = 5;
-        let mut tmux_name = None;
-        for _ in 0..MAX_NAME_ALLOCATION_ATTEMPTS {
-            let candidate = if let Some(ref leaf) = leaf_hint {
-                // Explicit name hint from the user — treat the hint as a path
-                // basename (callers may pass a bare "ticket-1234" or a
-                // directory path like "/repos/project"), then allocate a
-                // serial for it same as every other leaf.
-                crate::core::names::build_session_name(leaf, &existing_names)?
-            } else {
-                // Derive project from repo_url if it carries a parseable
-                // GitHub identity; otherwise `build_managed_session_name`
-                // falls back to the basename of `cwd`, then to `"local"`.
-                build_managed_session_name(github_project.as_deref(), &cwd, &existing_names)?
-            };
-            if self.tmux.session_exists(&candidate) {
-                existing_names.push(candidate);
-                continue;
-            }
-            tmux_name = Some(candidate);
-            break;
-        }
-        let Some(tmux_name) = tmux_name else {
-            return Err(ManagedError::NameCollision(format!(
-                "no free `tm-<leaf>-NN` name after {MAX_NAME_ALLOCATION_ATTEMPTS} attempts \
-                 (sustained concurrent creates for the same project)"
-            )));
-        };
-
-        let workdir = cwd.to_string_lossy().to_string();
-        self.tmux
-            .create_session(&tmux_name, &workdir)
-            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
-
-        // OWN the freshly-created tmux session immediately (#1453). From here
-        // until the record is durably persisted, this guard is the session's
-        // sole owner: any early return (e.g. a failing `store.upsert`) drops the
-        // guard and reaps the otherwise-orphaned tmux session. Ownership is
-        // transferred to the persistent store via `disarm` only AFTER upsert
-        // succeeds — closing the window that let 159 orphans accumulate (#1452).
-        let mut tmux_guard =
-            super::session_guard::TmuxSessionGuard::new(tmux_name.clone(), self.tmux.clone());
-
-        // Seed the session↔artifact correlation from what we know at creation
-        // time (worktree path + branch). PR / issue ids accrue later as the
-        // driver pushes work and opens a PR.
-        let mut correlation = crate::driver::SessionCorrelation::new();
-        if let Some(ref ws) = workspace_path {
-            correlation = correlation.with_worktree(ws.clone());
-        }
-        if let Some(ref b) = branch {
-            correlation = correlation.with_branch(b.clone());
-        }
-
-        let record = SessionRecord {
-            id,
-            tmux_name: tmux_name.clone(),
-            cwd,
-            task,
-            state: ManagedSessionState::Provisioning,
-            created_at: Utc::now(),
-            last_activity_at: None,
-            workspace_path,
-            repo_url,
-            branch,
-            pending_decision: None,
-            proposed_default: None,
-            correlation,
-            runtime,
-            ephemeral,
-            // Ownership is set atomically at creation: `true` ONLY when the SM
-            // provisioned the workspace via git clone; local-path spawn (#1502),
-            // adopt (#1433), and reconcile all pass `false` (safe default —
-            // prefer NOT deleting over accidental deletion).
-            workspace_owned: owned,
-            // source_id is set post-creation by the in-project spawn path
-            // (via SessionManager::set_source_id); `create_with_id` itself
-            // never knows the source project — it is set by the caller.
-            source_id: None,
-            claude_session_id: None,
-            scrollback_path: None,
-            last_cwd: None,
-        };
-
-        // Persist the record. On failure the freshly-created tmux session has
-        // NO registry owner — the armed `tmux_guard` above reaps it on the early
-        // return below, preventing the orphan (#1457). The reap itself happens
-        // silently in the guard's `Drop`; log here first so the rollback is
-        // visible in the daemon's stderr logs alongside the other lifecycle
-        // events (never stdout — that carries MCP JSON-RPC framing).
-        if let Err(e) = self.store.write().await.upsert(record.clone()).await {
-            warn!(
-                id = %id,
-                name = %tmux_name,
-                "registry upsert failed; rolling back (reaping) the orphaned tmux session: {e}"
-            );
-            // Returning here drops the still-armed `tmux_guard`, which kills the
-            // session. The original store error propagates unchanged.
-            return Err(ManagedError::from(e));
-        }
-
-        // The record is durably persisted; the store/registry now owns the
-        // session's lifetime. Disarm so the guard's drop is a no-op and the
-        // tracked session is NOT reaped at the end of this request scope (#1453).
-        tmux_guard.disarm();
-
-        info!(id = %id, name = %tmux_name, runtime = %runtime.as_str(), "managed session created");
-        Ok(record)
     }
 
     /// Inject an answer to the session's pending decision.
@@ -923,7 +724,7 @@ impl SessionManager {
     /// so a read-only guard would not compile and the read-only
     /// `cached_all()` alternative would risk a stale serial set.
     /// Test: `manager_serial_reuses_decommissioned_gap` in tests.rs.
-    async fn names_for_serial_allocation(&self) -> Result<Vec<String>, ManagedError> {
+    pub(crate) async fn names_for_serial_allocation(&self) -> Result<Vec<String>, ManagedError> {
         let mut names: Vec<String> = self
             .tmux
             .list_sessions()

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -9,11 +9,13 @@
 //! tested in `manager::tests`.
 
 pub mod adopt;
+pub mod create;
 pub mod decommission;
 pub mod delete;
 pub mod driver;
 pub mod hook_sync;
 pub mod manager;
+pub mod naming;
 pub mod prune;
 pub mod reactivate;
 pub mod record;

--- a/crates/trusty-mpm/src/session_manager/naming.rs
+++ b/crates/trusty-mpm/src/session_manager/naming.rs
@@ -1,0 +1,98 @@
+//! Tmux session-name resolution, extracted from `manager.rs` (issue #2032).
+//!
+//! Why: `manager.rs` was at the 500-SLOC production cap (same constraint
+//! documented in `reactivate.rs`/`hook_sync.rs`), and issue #2032 needs the
+//! semantic tmux name resolved BEFORE the in-project per-session git worktree
+//! is created — the worktree directory and branch are now named after the
+//! tmux name instead of the raw session UUID, so the name has to exist first.
+//! Splitting the derivation/serial-allocation/collision-retry loop out of
+//! `create_with_id` (moved here verbatim, then generalised) lets BOTH
+//! `create_with_id` (post-hoc derivation, for the cloned/local spawn paths)
+//! and the in-project spawn routing layer (pre-hoc reservation, via
+//! `SessionManager::create_with_reserved_name`) share the exact same logic —
+//! a session's tmux name is derived in exactly ONE place, never twice.
+//! What: `SessionManager::resolve_session_name` runs the existing
+//! priority-ordered derivation (`name_hint` > GitHub-parseable `repo_url`-
+//! derived project > `cwd` basename), the per-project serial allocation
+//! (issue #1955), and the bounded collision-retry loop (#1966 review
+//! follow-up). The `extra_collision` predicate lets a caller reject a
+//! candidate for reasons `resolve_session_name` cannot see itself — the
+//! in-project spawn path uses it to also refuse names whose
+//! `.worktrees/<name>` directory or `session/<name>` branch already exists on
+//! disk (a collision surface the plain tmux-name check knows nothing about;
+//! see `daemon::managed_routes::inproject::create_session_worktree`).
+//! Test: `naming_tests.rs`.
+
+use std::path::Path;
+
+use super::manager::{ManagedError, SessionManager};
+
+impl SessionManager {
+    /// Resolve a fresh, collision-free tmux session name (issues #1955, #2032).
+    ///
+    /// Why: both [`Self::create_with_id`] (deriving the name itself) and the
+    /// in-project spawn path (reserving the name BEFORE the worktree that will
+    /// be named after it) need identical priority/serial/collision-retry
+    /// semantics. Centralising it here means neither caller can silently drift
+    /// from the other's naming behaviour.
+    /// What: name selection priority —
+    ///   1. Explicit `name_hint` → leaf = sanitized hint (treated as a
+    ///      directory-like basename) → `tm-<hint-slug>-NN`.
+    ///   2. GitHub-parseable `github_project` (a bare repo name, already
+    ///      extracted by the caller from `repo_url`) → `tm-<repo>-NN`.
+    ///   3. Otherwise → leaf = basename(`cwd`), or `"local"` if that sanitizes
+    ///      to empty.
+    ///
+    /// Every branch allocates a per-project serial so concurrent sessions for
+    /// the same leaf get distinguishable `-01`, `-02`, `-03` names. A candidate
+    /// is rejected (and retried with the next free serial) when it collides
+    /// with a live tmux session OR when `extra_collision(candidate)` returns
+    /// `true` — the latter lets the in-project path fold in its
+    /// worktree-dir/branch existence check without this function needing to
+    /// know anything about git worktrees. Returns [`ManagedError::NameCollision`]
+    /// if every attempt in the bounded window (`MAX_NAME_ALLOCATION_ATTEMPTS`)
+    /// collides.
+    ///
+    /// Residual race window (KNOWN, not closed by this loop, unchanged from the
+    /// pre-#2032 behaviour): there is still a gap between THIS check and the
+    /// caller's actual `create_session`/`git worktree add` a few lines later.
+    /// `create_session` shells out to `tmux new-session -A -d`, and `-A` makes
+    /// tmux ATTACH to an existing session of the same name instead of failing,
+    /// so a lost race is an aliasing risk, not a crash. Closing this fully
+    /// would require a distributed lock across the external `tmux`/`git`
+    /// processes — out of scope; tracked as a follow-up if it proves to matter.
+    /// Test: `manager_serial_reuses_decommissioned_gap`,
+    /// `resolve_session_name_rejects_extra_collision` in `naming_tests.rs`.
+    pub(crate) async fn resolve_session_name(
+        &self,
+        name_hint: Option<&str>,
+        github_project: Option<&str>,
+        cwd: &Path,
+        extra_collision: impl Fn(&str) -> bool,
+    ) -> Result<String, ManagedError> {
+        let mut existing_names = self.names_for_serial_allocation().await?;
+        let leaf_hint = name_hint.map(|h| crate::core::names::leaf_slug_from_dir(Path::new(h)));
+
+        const MAX_NAME_ALLOCATION_ATTEMPTS: u8 = 5;
+        for _ in 0..MAX_NAME_ALLOCATION_ATTEMPTS {
+            let candidate = if let Some(ref leaf) = leaf_hint {
+                crate::core::names::build_session_name(leaf, &existing_names)?
+            } else {
+                crate::core::names::build_managed_session_name(
+                    github_project,
+                    cwd,
+                    &existing_names,
+                )?
+            };
+            if self.tmux.session_exists(&candidate) || extra_collision(&candidate) {
+                existing_names.push(candidate);
+                continue;
+            }
+            return Ok(candidate);
+        }
+        Err(ManagedError::NameCollision(format!(
+            "no free `tm-<leaf>-NN` name after {MAX_NAME_ALLOCATION_ATTEMPTS} attempts \
+             (sustained concurrent creates for the same project)"
+        )))
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2032. New managed-session worktrees created by the in-project spawn
path (`daemon::managed_routes::inproject` / `lifecycle::spawn_managed_inproject`)
are now named after the **semantic tmux session name** (e.g. `tm-trusty-tools-01`)
instead of the raw session UUID. **Existing worktrees are untouched — no migration.**

## Approach: single chokepoint

- `SessionManager::resolve_session_name` (extracted from `create_with_id` into
  a new `session_manager/naming.rs`, following the `reactivate.rs`/`hook_sync.rs`
  sibling-file pattern used to stay under the 500-SLOC production cap) is now the
  ONE place a session's tmux name is derived — the existing name-hint /
  GitHub-repo / cwd-basename priority + per-project serial allocation +
  bounded collision-retry loop, unchanged in behavior.
- The in-project spawn routing layer (`lifecycle::spawn_managed_routed` →
  new `reserve_inproject_worktree`) now calls `resolve_session_name` **before**
  creating the per-session git worktree, then creates the worktree at that
  resolved name (`inproject::create_session_worktree`, whose second parameter
  changed from `&ManagedSessionId` to `&str`).
- A new `SessionManager::create_with_reserved_name` (in a new
  `session_manager/create.rs`, alongside the refactored `create_with_id`, both
  sharing a private `create_with_resolved_name` tail) accepts that
  pre-reserved name directly so it is never re-derived — a session's tmux name
  is computed in exactly one place per spawn.

`create_with_id`'s public signature is unchanged, so the ~20 existing call
sites (tests, `tm launch`, MCP tools, `mcp_session.rs`) needed no changes.

## Collision handling

`worktree_name_collides(base, candidate)` (in `inproject.rs`) checks BOTH the
`.worktrees/<name>` directory and the `session/<name>` branch ref, and is
threaded into `resolve_session_name` as an extra collision predicate — a
candidate whose worktree/branch already exists on disk is retried with the
next free serial via the SAME bounded retry loop that already handles live
tmux-name collisions, rather than failing with a raw git error. This is a
**different** failure surface than the existing tmux-name collision (dead
tmux session + stale worktree from a hand-deleted-but-not-decommissioned
session), so it needed its own check. `create_session_worktree` also gained a
defensive pre-flight guard that refuses to clobber an existing worktree
directory (belt-and-suspenders against a TOCTOU race or a caller that skips
the proactive check).

## Free adjacent bug fix

While touching this code: `decommission.rs`'s branch cleanup ran
`git branch -D <leaf>` but the branch `create_session_worktree` actually
creates is `session/<leaf>` — the missing prefix meant `git branch -D` always
targeted a nonexistent ref and silently no-opped into the "not found" log
path, so **session branches were never actually deleted on decommission**
(for either old UUID-named or new semantic-named worktrees). Fixed to use the
`session/<leaf>` convention, now centralized in a new, always-compiled
`core::worktree_naming` module (rather than referencing the `daemon`-feature-
gated `inproject` module from the unconditionally-compiled `session_manager`).
A pre-existing integration test (`decommission_worktree_tests.rs`) had
inadvertently encoded the same bug in its fixture (creating the branch without
the `session/` prefix) — fixed to mirror the real convention, which is what
surfaced the bug during verification.

## Not migrated / out of scope

- `tm launch` (`bin/tm/commands/launch.rs`) and the daemon-unreachable guided
  fallback (`bin/tm/commands/guided.rs`) also call `create_session_worktree`
  directly, but are separate CLI flows that don't go through
  `SessionManager`/`resolve_session_name` — they keep their pre-#2032
  UUID-named worktrees unchanged (documented inline with a NOTE).
- Issue #2033 (trusty-search index-id derivation from the worktree path) is
  NOT addressed here; a code comment near `create_session_worktree` flags that
  the worktree leaf name is significant for that follow-up, and confirms
  `record.workspace_path` (read at call time) will carry the correct new path.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-mpm` — 2338 passed, 0 failed (lib) + all integration suites green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations
- [x] New unit tests: `worktree_name_collides_detects_existing_dir_and_branch`,
      `create_session_worktree_rejects_existing_worktree_dir`,
      `reserve_inproject_worktree_uses_semantic_name_not_uuid` (end-to-end,
      real git repo, asserts the resolved name is `tm-trusty-tools-01` and the
      worktree path does NOT contain the raw UUID)
- [x] Confirmed `is_session_worktree`/decommission continue to work for BOTH
      old UUID-named and new semantic-named worktrees (leaf-name-agnostic
      detection, verified by `manager_decommission_removes_real_git_worktree`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)