### PR TITLE
feat(trusty-search): idle watcher suspension — stop watching inactive projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11087,7 +11087,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -49,7 +49,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.18.1", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.30.0" }
+trusty-search = { path = "../trusty-search", version = "0.31.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -6,6 +6,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.31.0] — 2026-07-06
+
+### Added — idle watcher suspension (stop watching projects nobody is using)
+
+- **A live index's FSEvents watcher is now suspended after it goes idle, and
+  resumes on the next query.** Previously, once an index was warm-booted or
+  registered, its OS filesystem watch ran until the index was *deleted* — so a
+  host tracking hundreds of registered projects kept hundreds of live watches
+  regardless of use, a standing CPU / `fseventsd` cost. Now:
+  - A background ticker releases the watcher of any index whose in-memory
+    `idle_duration()` exceeds `TRUSTY_WATCH_IDLE_SUSPEND_SECS` (default 900 s;
+    `0` disables). This sits above the 300 s chunk-eviction window, so an idle
+    index first sheds memory, then — if still dormant — sheds its watcher.
+  - The query path re-establishes the watcher on the next query to a suspended
+    (or lazily cold-restored) index, then runs a background reconcile
+    (git-diff / mtime catch-up, the same logic used at boot) so any edits made
+    while the watcher was off are picked up. The query itself is served
+    immediately from current in-memory state; suspension is invisible to an
+    active user.
+- **Side fix:** lazily cold-restored indexes (issue #993) previously never
+  started a watcher at all; the wake path now gives them one too.
+
+### Notes
+
+- Memory for idle indexes was already reclaimed by the chunk-eviction ticker
+  (`TRUSTY_CHUNKS_IDLE_EVICT_SECS`); this change adds the CPU/watch half.
+- No behaviour change when `TRUSTY_DISABLE_WATCHER=1` (watchers never spawn) or
+  `TRUSTY_WATCH_IDLE_SUSPEND_SECS=0` (watchers stay hot).
+
+---
+
 ## [0.30.0] — 2026-07-06
 
 ### Added — self-managed orphan reaping (daemon no longer leaks dead registrations)

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/src/commands/start/daemon.rs
+++ b/crates/trusty-search/src/commands/start/daemon.rs
@@ -338,7 +338,7 @@ pub async fn handle_start(
                 // the current git HEAD and reindex only what changed (or fall
                 // back to a full background reindex if the delta is too large).
                 // Gated by TRUSTY_NO_BOOT_RECONCILE=1.
-                super::reconcile::reconcile_stale_indexes(&install_state).await;
+                crate::service::reconcile::reconcile_stale_indexes(&install_state).await;
                 // Schema migration: spawn a per-index background migration task.
                 if std::env::var("TRUSTY_DISABLE_MIGRATIONS").as_deref() != Ok("1") {
                     let registry =

--- a/crates/trusty-search/src/commands/start/mod.rs
+++ b/crates/trusty-search/src/commands/start/mod.rs
@@ -18,7 +18,6 @@
 
 mod daemon;
 mod embedder;
-pub(super) mod reconcile;
 mod restore;
 
 #[cfg(test)]

--- a/crates/trusty-search/src/core/indexer/helpers.rs
+++ b/crates/trusty-search/src/core/indexer/helpers.rs
@@ -76,6 +76,42 @@ pub(crate) fn idle_evict_secs() -> u64 {
     }
 }
 
+/// Default idle window (seconds) after which a live index's FSEvents watcher is
+/// suspended to stop burning CPU / `fseventsd` load on a project nobody is using.
+///
+/// Why: 900s (15 min) sits above the 300s chunk-eviction window
+/// ([`DEFAULT_CHUNKS_IDLE_EVICT_SECS`]) so the escalation is gradual — a briefly
+/// idle index keeps its watcher (cheap incremental indexing on the next save),
+/// and only a genuinely-dormant one drops it. The watcher resumes on the next
+/// query, so suspension is invisible to an active user.
+pub(crate) const DEFAULT_WATCH_IDLE_SUSPEND_SECS: u64 = 900;
+
+/// Resolve the watcher idle-suspend window (in seconds) from the environment,
+/// falling back to [`DEFAULT_WATCH_IDLE_SUSPEND_SECS`].
+///
+/// Why: the FSEvents watch is the CPU/`fseventsd` cost of a registered index;
+/// operators watching hundreds of projects want to release idle watches, while
+/// those on a single active repo may want to disable suspension entirely.
+/// What: reads `TRUSTY_WATCH_IDLE_SUSPEND_SECS` as `u64` seconds. A value of `0`
+/// **disables** suspension (watchers stay hot). Unset / unparseable falls back
+/// to the default.
+/// Test: `watch_idle_suspend_secs_default_and_env_override`.
+pub(crate) fn watch_idle_suspend_secs() -> u64 {
+    match std::env::var("TRUSTY_WATCH_IDLE_SUSPEND_SECS") {
+        Ok(v) if !v.is_empty() => match v.parse::<u64>() {
+            Ok(n) => n,
+            Err(_) => {
+                tracing::warn!(
+                    "indexer: TRUSTY_WATCH_IDLE_SUSPEND_SECS={v:?} is not a valid u64; \
+                     using default ({DEFAULT_WATCH_IDLE_SUSPEND_SECS}s)"
+                );
+                DEFAULT_WATCH_IDLE_SUSPEND_SECS
+            }
+        },
+        _ => DEFAULT_WATCH_IDLE_SUSPEND_SECS,
+    }
+}
+
 /// Default hard cap on chunks per index.
 const DEFAULT_MAX_CHUNKS_PER_INDEX: usize = 200_000;
 
@@ -334,5 +370,47 @@ pub(crate) fn compute_match_reason(in_v: bool, in_b: bool, in_kg: bool) -> &'sta
         (false, true, _) => "bm25",
         (false, false, true) => "hybrid+kg",
         (false, false, false) => "fallback:ripgrep",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Watcher idle-suspend: `watch_idle_suspend_secs` honours the default and
+    /// the `TRUSTY_WATCH_IDLE_SUSPEND_SECS` override, including `0` (disabled)
+    /// and an unparseable value (falls back to default).
+    #[test]
+    fn watch_idle_suspend_secs_default_and_env_override() {
+        let prior = std::env::var("TRUSTY_WATCH_IDLE_SUSPEND_SECS").ok();
+
+        // Unset → default.
+        // SAFETY: this test is the only reader/writer of this env var.
+        unsafe { std::env::remove_var("TRUSTY_WATCH_IDLE_SUSPEND_SECS") };
+        assert_eq!(watch_idle_suspend_secs(), DEFAULT_WATCH_IDLE_SUSPEND_SECS);
+
+        // Valid override wins.
+        // SAFETY: see above.
+        unsafe { std::env::set_var("TRUSTY_WATCH_IDLE_SUSPEND_SECS", "120") };
+        assert_eq!(watch_idle_suspend_secs(), 120);
+
+        // Zero disables (returned verbatim; the ticker treats 0 as "off").
+        // SAFETY: see above.
+        unsafe { std::env::set_var("TRUSTY_WATCH_IDLE_SUSPEND_SECS", "0") };
+        assert_eq!(watch_idle_suspend_secs(), 0);
+
+        // Garbage falls back to default (with a warn).
+        // SAFETY: see above.
+        unsafe { std::env::set_var("TRUSTY_WATCH_IDLE_SUSPEND_SECS", "nope") };
+        assert_eq!(watch_idle_suspend_secs(), DEFAULT_WATCH_IDLE_SUSPEND_SECS);
+
+        // Restore.
+        // SAFETY: see above.
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("TRUSTY_WATCH_IDLE_SUSPEND_SECS", v),
+                None => std::env::remove_var("TRUSTY_WATCH_IDLE_SUSPEND_SECS"),
+            }
+        }
     }
 }

--- a/crates/trusty-search/src/core/indexer/mod.rs
+++ b/crates/trusty-search/src/core/indexer/mod.rs
@@ -60,7 +60,7 @@ pub(crate) use helpers::{
     build_compact_snippet, definition_boost_query_tokens, embed_batch_size, embedding_cache_cap,
     file_type_score_multiplier, hash_query, idle_evict_secs, is_function_definition_chunk_type,
     is_struct_definition_chunk_type, max_chunks_per_index, populate_virtual_terms,
-    raw_to_code_chunk, STRUCT_DEFINITION_BOOST,
+    raw_to_code_chunk, watch_idle_suspend_secs, STRUCT_DEFINITION_BOOST,
 };
 // Exposed for unit tests in `tests.rs`.
 #[cfg(test)]
@@ -245,10 +245,13 @@ impl CodeIndexer {
     /// Milliseconds since the last recorded activity (query/ingest).
     ///
     /// Why: lets the eviction logic compare elapsed idle time against the
-    /// configured window without exposing the raw atomic.
+    /// configured window without exposing the raw atomic. Also read by the
+    /// watcher idle-suspend ticker (`server::tickers`) to decide when to release
+    /// an idle index's FSEvents watch, hence `pub(crate)`.
     /// What: `created_at.elapsed() - last_activity_ms`, floored at 0.
-    /// Test: covered via `evict_chunks_if_idle`'s behaviour tests.
-    fn idle_duration(&self) -> std::time::Duration {
+    /// Test: covered via `evict_chunks_if_idle`'s behaviour tests and the
+    /// watcher idle-suspend ticker.
+    pub(crate) fn idle_duration(&self) -> std::time::Duration {
         let now_ms = self.created_at.elapsed().as_millis().min(u64::MAX as u128) as u64;
         let last = self.last_activity_ms.load(Ordering::Relaxed);
         std::time::Duration::from_millis(now_ms.saturating_sub(last))

--- a/crates/trusty-search/src/service/mod.rs
+++ b/crates/trusty-search/src/service/mod.rs
@@ -24,6 +24,7 @@ pub mod persistence;
 pub mod persistence_loader;
 pub mod persistence_timestamps;
 pub mod query_timeout;
+pub mod reconcile;
 pub mod reindex;
 pub mod roots_registry;
 pub mod server;

--- a/crates/trusty-search/src/service/reconcile.rs
+++ b/crates/trusty-search/src/service/reconcile.rs
@@ -240,7 +240,7 @@ impl Drop for InProgressGuard {
 /// throughout.
 /// Test: `reconcile_disabled_gate`, `reconcile_in_progress_clears_after_tasks_complete`
 /// in reconcile_tests.rs.
-pub(super) async fn reconcile_stale_indexes(state: &SearchAppState) {
+pub async fn reconcile_stale_indexes(state: &SearchAppState) {
     let raw = std::env::var(NO_BOOT_RECONCILE_ENV).ok();
     if reconcile_disabled_for_value(raw.as_deref()) {
         tracing::info!("boot reconcile: disabled via {NO_BOOT_RECONCILE_ENV}=1 — skipping");
@@ -297,12 +297,15 @@ pub(super) async fn reconcile_stale_indexes(state: &SearchAppState) {
 ///
 /// Why: each index is independent; background tasks let the daemon serve
 /// queries while reconciliation proceeds and avoid one slow index blocking others.
+/// Also called on the query-wake path (`server::search`) when an idle-suspended
+/// or lazily-restored index is served without a watcher, to catch edits missed
+/// while the watcher was off — hence `pub(crate)`.
 /// What: reads the stored + current HEAD SHAs (git path), or falls back to the
 /// mtime path for non-git / missing-SHA indexes. Updates `summary` with the
-/// outcome so `GET /health` reports boot-reconcile progress.
+/// outcome so `GET /health` reports reconcile progress.
 /// Test: `reconcile_up_to_date_index_is_noop`, `reconcile_stale_index_stamps_new_sha`
 /// in reconcile_tests.rs.
-async fn reconcile_one_index(
+pub(crate) async fn reconcile_one_index(
     handle: Arc<IndexHandle>,
     summary: Arc<std::sync::Mutex<ReconcileSummary>>,
 ) {

--- a/crates/trusty-search/src/service/reconcile_tests.rs
+++ b/crates/trusty-search/src/service/reconcile_tests.rs
@@ -1,4 +1,4 @@
-//! Tests for `commands::start::reconcile`.
+//! Tests for `service::reconcile`.
 //!
 //! Why: split into a dedicated `*_tests.rs` file so `reconcile.rs` stays
 //! under the 500-SLOC production cap while this file enjoys the 1500-SLOC
@@ -702,7 +702,7 @@ fn mtime_walk_caps_at_threshold_plus_one() {
 
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();
-    let n = crate::commands::start::reconcile::FULL_REINDEX_THRESHOLD + 5;
+    let n = crate::service::reconcile::FULL_REINDEX_THRESHOLD + 5;
     for i in 0..n {
         let p = root.join(format!("file_{i}.rs"));
         std::fs::write(&p, "fn f() {}").expect("write");
@@ -712,7 +712,7 @@ fn mtime_walk_caps_at_threshold_plus_one() {
     let stale = collect_stale_files_by_mtime(root, 0);
     assert_eq!(
         stale.len(),
-        crate::commands::start::reconcile::FULL_REINDEX_THRESHOLD + 1,
+        crate::service::reconcile::FULL_REINDEX_THRESHOLD + 1,
         "result must be capped at FULL_REINDEX_THRESHOLD + 1"
     );
 }

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -90,7 +90,7 @@ use search::{delete_index_handler, global_search_handler, search_handler};
 use status::{graph_handler, graph_stats_handler, index_status_handler};
 use tickers::{
     spawn_disk_size_ticker, spawn_idle_chunk_eviction_ticker, spawn_orphan_reaper_ticker,
-    spawn_status_ticker,
+    spawn_status_ticker, spawn_watcher_idle_suspend_ticker,
 };
 
 use files::{call_chain_handler, global_grep_handler, grep_handler};
@@ -136,6 +136,7 @@ pub fn build_router(state: SearchAppState) -> Router {
     spawn_status_ticker(Arc::clone(&state_arc));
     spawn_disk_size_ticker(Arc::clone(&state_arc));
     spawn_idle_chunk_eviction_ticker(Arc::clone(&state_arc));
+    spawn_watcher_idle_suspend_ticker(Arc::clone(&state_arc));
     spawn_orphan_reaper_ticker(Arc::clone(&state_arc));
 
     let limiter = crate::service::concurrency::ConcurrencyLimiter::from_env();

--- a/crates/trusty-search/src/service/server/search.rs
+++ b/crates/trusty-search/src/service/server/search.rs
@@ -208,6 +208,25 @@ pub(super) async fn search_handler(
             }
         }
     };
+    // Idle-watcher wake: an index served without a live watcher was either
+    // idle-suspended (`server::tickers::spawn_watcher_idle_suspend_ticker`) or
+    // lazily restored from the cold store (which never spawns a watcher). Resume
+    // watching so future saves index incrementally, and — only when we actually
+    // (re)establish a watcher — kick a background reconcile to catch edits made
+    // while it was unwatched. The `is_watching` re-check keeps this a no-op when
+    // `TRUSTY_DISABLE_WATCHER=1` (spawn is a no-op), so we never spin a reconcile
+    // on every query in that mode. The query itself served current in-memory
+    // state; the reconcile converges any missed edits for subsequent queries.
+    if !state.watcher_manager.is_watching(&index_id).await {
+        state.watcher_manager.spawn_for_index(&handle).await;
+        if state.watcher_manager.is_watching(&index_id).await {
+            let woken = Arc::clone(&handle);
+            let summary = Arc::clone(&state.reconcile_summary);
+            tokio::spawn(crate::service::reconcile::reconcile_one_index(
+                woken, summary,
+            ));
+        }
+    }
     // Issue #993: rate-limited write of last_queried_unix (max once per
     // LAST_QUERIED_WRITE_INTERVAL_SECS) so the LRU sort key stays current for
     // future selective warm-boots without hammering indexes.toml on every query.

--- a/crates/trusty-search/src/service/server/tickers.rs
+++ b/crates/trusty-search/src/service/server/tickers.rs
@@ -141,6 +141,73 @@ pub(super) fn spawn_idle_chunk_eviction_ticker(state: Arc<SearchAppState>) {
     });
 }
 
+/// Spawn a background ticker that suspends the FSEvents watcher of any index
+/// that has gone idle, to stop burning CPU / `fseventsd` load on projects
+/// nobody is using.
+///
+/// Why: once `spawn_for_index` fires (warm-boot or `POST /indexes`), an index's
+/// OS watch runs until the index is deleted — so a host tracking hundreds of
+/// registered projects keeps hundreds of live watches even though only a few
+/// are in active use. Releasing an idle index's watch reclaims that cost; the
+/// query path re-establishes it (and reconciles missed edits) on the next
+/// query, so suspension is invisible to an active user. Complements the
+/// idle-chunk-eviction ticker, which reclaims heap but keeps the watcher hot.
+/// What: every 60 s, resolves the idle window via `watch_idle_suspend_secs()`
+/// (env `TRUSTY_WATCH_IDLE_SUSPEND_SECS`, default 900 s; `0` disables and the
+/// ticker idles), then for each *currently-watched* index whose
+/// `CodeIndexer::idle_duration()` meets the threshold, calls
+/// `watcher_manager.stop_for_index`. The per-index idle read takes only the
+/// indexer read lock; unwatched indexes are skipped before any lock.
+/// Test: the idle window helper is covered by
+/// `watch_idle_suspend_secs_default_and_env_override`; `is_watching` transitions
+/// by `is_watching_reflects_spawn_and_stop`; this is a thin scheduling wrapper.
+pub(super) fn spawn_watcher_idle_suspend_ticker(state: Arc<SearchAppState>) {
+    let weak = Arc::downgrade(&state);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        // Skip the immediate first tick so a freshly-started daemon isn't
+        // suspending watchers before it has served anything.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let Some(state) = weak.upgrade() else {
+                break;
+            };
+            let secs = crate::core::indexer::watch_idle_suspend_secs();
+            if secs == 0 {
+                // Suspension disabled by env; keep ticking cheaply so an operator
+                // re-enabling it (next process) is honoured — but do no work.
+                continue;
+            }
+            let threshold = Duration::from_secs(secs);
+            let mut suspended = 0usize;
+            for id in state.registry.list() {
+                // Only watched indexes can be suspended; check before any lock.
+                if !state.watcher_manager.is_watching(&id).await {
+                    continue;
+                }
+                let Some(handle) = state.registry.get(&id) else {
+                    continue;
+                };
+                let idle = handle.indexer.read().await.idle_duration();
+                if idle >= threshold && state.watcher_manager.stop_for_index(&id).await {
+                    suspended += 1;
+                    tracing::info!(
+                        index_id = %id.0,
+                        idle_secs = idle.as_secs(),
+                        "watcher idle-suspended — will resume on next query"
+                    );
+                }
+            }
+            if suspended > 0 {
+                tracing::info!(
+                    "watcher idle-suspend: released {suspended} idle watch(es) this cycle"
+                );
+            }
+        }
+    });
+}
+
 /// Spawn a background ticker that unregisters indexes whose `root_path` was
 /// deleted while the daemon runs (orphan self-heal).
 ///

--- a/crates/trusty-search/src/service/watcher_manager.rs
+++ b/crates/trusty-search/src/service/watcher_manager.rs
@@ -209,6 +209,17 @@ impl WatcherManager {
     pub async fn watched_count(&self) -> usize {
         self.inner.lock().await.len()
     }
+
+    /// Whether a specific index currently has a live watcher.
+    ///
+    /// Why: the query path uses this to detect an index being served without a
+    /// watcher — either idle-suspended (`server::tickers`) or lazily restored
+    /// from the cold store — so it can resume watching and reconcile on wake.
+    /// What: `contains_key` under the lock.
+    /// Test: `is_watching_reflects_spawn_and_stop`.
+    pub async fn is_watching(&self, id: &IndexId) -> bool {
+        self.inner.lock().await.contains_key(id)
+    }
 }
 
 #[cfg(test)]
@@ -271,6 +282,23 @@ mod tests {
             "second spawn for the same index must not add a second watcher"
         );
         mgr.stop_all().await;
+    }
+
+    /// Why: the idle-suspend / wake path keys off `is_watching`, so it must
+    /// track spawn and stop transitions exactly (false → true → false).
+    /// Test: this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn is_watching_reflects_spawn_and_stop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mgr = WatcherManager::new();
+        let handle = handle_for("idx", dir.path());
+        let id = IndexId::new("idx");
+
+        assert!(!mgr.is_watching(&id).await, "not watching before spawn");
+        mgr.spawn_for_index(&handle).await;
+        assert!(mgr.is_watching(&id).await, "watching after spawn");
+        assert!(mgr.stop_for_index(&id).await);
+        assert!(!mgr.is_watching(&id).await, "not watching after stop");
     }
 
     /// Why: `stop_for_index` must remove exactly the targeted watcher and


### PR DESCRIPTION
**Stacked on #2047** (base = `feat/trusty-search-self-prune`). Review/merge that first; this PR's diff is only the incremental idle-suspend change. GitHub will retarget it to `main` when #2047 merges.

## Problem

A live index's FSEvents watcher ran from warm-boot/registration until the index was *deleted* — so a host tracking hundreds of registered projects kept hundreds of live OS watches regardless of use. That standing watch load is the CPU/`fseventsd` cost behind the bloat we diagnosed (orphan reaping in #2047 removes *dead* projects; this handles *live-but-idle* ones).

## What it does (watcher-only suspend)

- **Suspend ticker** — `spawn_watcher_idle_suspend_ticker`: every 60s, releases the watcher of any index whose in-memory `CodeIndexer::idle_duration()` exceeds `TRUSTY_WATCH_IDLE_SUSPEND_SECS` (default **900s**; `0` disables). Sits above the 300s chunk-eviction window, so an idle index sheds heap first, then — if still dormant — its watcher.
- **Wake on query** — `search_handler`: an index served without a live watcher (idle-suspended, *or* lazily cold-restored — which never spawned one) gets its watcher re-established via the idempotent `spawn_for_index`, and — **only when a watcher is actually (re)established** — a background reconcile (git-diff/mtime catch-up, the same logic used at boot) is kicked to pick up edits missed while unwatched. The query serves current in-memory state immediately; the reconcile converges subsequent queries. The `is_watching` re-check makes this a no-op under `TRUSTY_DISABLE_WATCHER=1` (never spins a per-query reconcile).
- **Side fix:** lazily cold-restored indexes (#993) previously never started a watcher at all — the wake path now gives them one.

## Refactor

To call reconcile from the **library** query path, `commands/start/reconcile.rs` (binary-only `commands` tree) moves to `service/reconcile.rs`. It already depended solely on `core`/`service` — zero `commands` deps — so it's a pure relocation. `reconcile_stale_indexes` becomes `pub` (the bin's `daemon.rs` calls it); the boot behaviour is unchanged.

## Safety / knobs

- No behaviour change under `TRUSTY_DISABLE_WATCHER=1` (watchers never spawn) or `TRUSTY_WATCH_IDLE_SUSPEND_SECS=0` (watchers stay hot).
- Memory for idle indexes was already reclaimed by the chunk-eviction ticker; this adds only the CPU/watch half.

## Tests

- `watch_idle_suspend_secs_default_and_env_override` (env knob, incl. `0`/garbage), `is_watching_reflects_spawn_and_stop` (watcher transitions). Full suite: **984 lib tests pass**, `clippy -D warnings` clean, `fmt --check` clean, line-cap clean, all 20 relocated `reconcile` tests pass.

Bumps trusty-search 0.30.0 → 0.31.0; updates the `trusty-agents` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)