### PR TITLE
fix(trusty-memory): stop prompt-context tests hanging on orphaned stdin thread

### DIFF
--- a/crates/trusty-memory/src/commands/prompt_context/mod.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/mod.rs
@@ -235,10 +235,41 @@ pub(super) const EMPTY_PLACEHOLDER: &str = "No prompt facts stored yet.";
 /// `prompt_context_empty_palace_falls_back_to_global`;
 /// `bounded_blocking_times_out_on_slow_closure` and
 /// `handle_prompt_context_fails_open_on_slow_daemon` cover the deadline
-/// fail-open paths added by #2043.
+/// fail-open paths added by #2043. This wrapper itself is intentionally
+/// NOT unit-tested (see [`handle_prompt_context_with_payload`]) — it would
+/// require a real blocking stdin read inside a `#[tokio::test]`, which is
+/// exactly the orphaned-thread hang fixed by issue #2079.
 pub async fn handle_prompt_context() -> Result<()> {
-    let start = Instant::now();
     let trigger_payload = read_stdin_bounded().await;
+    handle_prompt_context_with_payload(trigger_payload).await
+}
+
+/// Core body of [`handle_prompt_context`], parameterised over the stdin
+/// payload (issue #2079).
+///
+/// Why: #2048 bounded the stdin read with `spawn_blocking` + a timeout, but
+/// a blocking OS thread can't be cancelled — on timeout it keeps running,
+/// parked in the real `read_to_string` syscall, until stdin actually closes.
+/// In production that's harmless (`run_prompt_context_and_exit` calls
+/// `std::process::exit(0)` right after, abandoning the thread). But the
+/// `#[tokio::test]` functions that used to call `handle_prompt_context()`
+/// directly returned normally, so their per-test `Runtime::drop()` waited
+/// for that orphaned thread — which never finished when the test binary's
+/// own stdin was a held-open, non-EOF pipe (exactly the shape of GitHub
+/// Actions' runner stdin), wedging `cargo test --workspace` forever.
+/// Splitting the payload out means the tested logic never spawns a real
+/// stdin read, so it can never hang regardless of the test process's stdin.
+/// What: takes the already-resolved stdin payload, builds the injection
+/// body (bounded by [`BODY_DEADLINE`]), prints it, and best-effort emits
+/// the `HookFired` activity event (bounded by [`EMIT_DEADLINE`]). Identical
+/// behaviour to the pre-#2079 `handle_prompt_context` body.
+/// Test: `prompt_context_returns_ok_without_daemon`,
+/// `prompt_context_logs_attempt_without_daemon`,
+/// `handle_prompt_context_fails_open_on_slow_daemon` — all call this
+/// directly with a fixed in-memory payload instead of
+/// `handle_prompt_context()`.
+pub(crate) async fn handle_prompt_context_with_payload(trigger_payload: String) -> Result<()> {
+    let start = Instant::now();
 
     // Fetch + compose, hard-capped at BODY_DEADLINE. On timeout there is
     // nothing safe to print yet, so fail open to an empty body — identical

--- a/crates/trusty-memory/src/commands/prompt_context/tests.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/tests.rs
@@ -231,7 +231,10 @@ fn resolve_palace_for_log_falls_back_to_process_cwd() {
 /// What: redirects `trusty_common::resolve_data_dir` at a fresh tempdir
 /// via `TRUSTY_DATA_DIR_OVERRIDE` so `read_daemon_addr("trusty-memory")`
 /// observes a missing lockfile, then runs the handler and asserts it
-/// returns `Ok(())`.
+/// returns `Ok(())`. Calls `handle_prompt_context_with_payload` directly
+/// (issue #2079) with a fixed empty payload instead of
+/// `handle_prompt_context()` so the test never spawns a real blocking
+/// stdin read that could outlive the test's `Runtime` teardown.
 #[tokio::test]
 async fn prompt_context_returns_ok_without_daemon() {
     let _guard = crate::commands::env_test_lock().lock().await;
@@ -242,7 +245,7 @@ async fn prompt_context_returns_ok_without_daemon() {
     unsafe {
         std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, tmp.path());
     }
-    let res = handle_prompt_context().await;
+    let res = handle_prompt_context_with_payload(String::new()).await;
     unsafe {
         std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
     }
@@ -754,7 +757,9 @@ async fn prompt_context_recall_all_filtered_falls_back_to_global() {
 /// What: pin a tempdir as the data directory, run the handler with no
 /// daemon, and assert exactly one log file landed under `<tmp>/logs/`
 /// with a single JSONL line whose `injection_kind` is the prompt-context
-/// kind.
+/// kind. Calls `handle_prompt_context_with_payload` directly (issue
+/// #2079) with a fixed empty payload so this test never spawns a real
+/// blocking stdin read.
 /// Test: itself.
 #[tokio::test]
 async fn prompt_context_logs_attempt_without_daemon() {
@@ -766,7 +771,7 @@ async fn prompt_context_logs_attempt_without_daemon() {
         std::env::remove_var(crate::prompt_log::ENV_DIR);
         std::env::remove_var(crate::prompt_log::ENV_HASH_PROMPTS);
     }
-    let res = handle_prompt_context().await;
+    let res = handle_prompt_context_with_payload(String::new()).await;
     let logs_dir = trusty_common::resolve_data_dir("trusty-memory")
         .expect("resolve data dir")
         .join("logs");
@@ -856,8 +861,10 @@ async fn bounded_blocking_returns_value_when_fast_enough() {
 /// returns `Ok(())` well inside its own deadline budget.
 /// What: writes the slow listener's address as the discovered daemon addr
 /// (via `write_daemon_addr`, matching what a real running daemon would
-/// have written), runs `handle_prompt_context`, and asserts both the
-/// `Ok(())` contract and a bounded wall-clock time.
+/// have written), runs `handle_prompt_context_with_payload` (issue #2079 —
+/// direct call with a fixed empty payload so this test never spawns a
+/// real blocking stdin read), and asserts both the `Ok(())` contract and
+/// a bounded wall-clock time.
 /// Test: itself.
 /// Note (issue #226): gated on `axum-server` — it needs a real `axum`
 /// listener to simulate the slow daemon.
@@ -889,7 +896,7 @@ async fn handle_prompt_context_fails_open_on_slow_daemon() {
         .expect("write fake daemon addr");
 
     let start = std::time::Instant::now();
-    let res = handle_prompt_context().await;
+    let res = handle_prompt_context_with_payload(String::new()).await;
     let elapsed = start.elapsed();
 
     server.abort();

--- a/crates/trusty-memory/src/web/tests/attribution_tests.rs
+++ b/crates/trusty-memory/src/web/tests/attribution_tests.rs
@@ -310,10 +310,13 @@ async fn drawer_creator_attribution_mcp_default() {
 /// return `Ok(())` so the user's prompt is not blocked. The activity
 /// emit failure is surfaced via a stderr warn-log only.
 /// What: pins a tempdir as the data dir (so `read_daemon_addr`
-/// returns `Ok(None)` — no http_addr file), runs `handle_prompt_context`,
-/// and asserts it returns `Ok(())`. Separately verifies the emit
-/// helper does not panic — covered by `post_hook_event_no_daemon_is_noop`
-/// in `hook_emit::tests`.
+/// returns `Ok(None)` — no http_addr file), runs
+/// `handle_prompt_context_with_payload` directly with a fixed empty
+/// payload (issue #2079 — avoids spawning a real blocking stdin read
+/// that could outlive this test's `Runtime` teardown), and asserts it
+/// returns `Ok(())`. Separately verifies the emit helper does not
+/// panic — covered by `post_hook_event_no_daemon_is_noop` in
+/// `hook_emit::tests`.
 /// Test: itself.
 #[tokio::test]
 async fn hook_emit_failure_isolated() {
@@ -323,7 +326,8 @@ async fn hook_emit_failure_isolated() {
     unsafe {
         std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, tmp.path());
     }
-    let res = crate::commands::prompt_context::handle_prompt_context().await;
+    let res =
+        crate::commands::prompt_context::handle_prompt_context_with_payload(String::new()).await;
     unsafe {
         std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
     }


### PR DESCRIPTION
## Summary

**Fix-forward for red main.** PR #2048 (hook-perf) bounded the `UserPromptSubmit` stdin read with `spawn_blocking` + a `tokio::time::timeout`, but a blocking OS thread cannot be cancelled — on timeout the thread stays parked in the real `read_to_string` syscall indefinitely. Production is fine because `run_prompt_context_and_exit()` calls `std::process::exit(0)` right after, abandoning the thread. But four `#[tokio::test]` functions called `handle_prompt_context()` directly and returned normally, so their per-test `Runtime::drop()` waited for that orphaned thread — which never finishes when the test binary's own stdin is a held-open, non-EOF pipe (the shape of GitHub Actions' runner stdin). That wedges `cargo test --workspace` forever, killing the CI job and turning the `Test` check red.

- Split `handle_prompt_context()` into a thin production wrapper (still does the real bounded stdin read + `process::exit(0)`) and `pub(crate) handle_prompt_context_with_payload(trigger_payload: String)`, which contains all the actual logic and takes the payload as a parameter instead of reading stdin itself.
- Updated the four affected tests (`prompt_context_returns_ok_without_daemon`, `prompt_context_logs_attempt_without_daemon`, `handle_prompt_context_fails_open_on_slow_daemon` in `commands/prompt_context/tests.rs`, and `hook_emit_failure_isolated` in `web/tests/attribution_tests.rs`) to call `handle_prompt_context_with_payload(String::new())` directly — they never touch real stdin now, so they cannot hang regardless of the test process's stdin plumbing.
- Production behavior is unchanged: `run_prompt_context_and_exit()` still bounds the stdin read to `STDIN_READ_DEADLINE` (300 ms) and fails open, then exits immediately.

Regression source: #2048. Tracking issue: #2079.

## Verification

**Reproduced the exact CI condition** (not just `/dev/null`): built the pre-fix test binary (via `git stash` of only the test-file changes, keeping the buggy `handle_prompt_context()` call sites), ran it with stdin bound to a held-open FIFO (`mkfifo` + `exec 3<>fifo`, mirroring a non-EOF CI runner stdin), and confirmed it hung at `handle_prompt_context_fails_open_on_slow_daemon` — `timeout 20` killed it (exit 124). Restored the fix, rebuilt, ran the identical FIFO repro again: all 17 tests in the module completed in 5.47s (exit 0).

- `cargo build --workspace` — clean.
- `cargo test -p trusty-memory --features axum-server prompt_context --lib` under `/dev/null` — 21 passed, 0 failed, ~5s.
- **Non-EOF FIFO repro** (pre-fix): hung, `timeout 20` → exit 124 at `handle_prompt_context_fails_open_on_slow_daemon`.
- **Non-EOF FIFO repro** (post-fix, identical FIFO): 17 passed, 0 failed, finished in 5.47s, exit 0.
- `hook_emit_failure_isolated` under the same non-EOF FIFO: 1 passed, exit 0.
- `cargo test --workspace` (what CI runs) — completed, exit 0, 117 "test result: ok" blocks, zero FAILED/panicked. trusty-memory lib: 404 passed, 0 failed, 4 ignored, 20.73s.
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0.
- `cargo fmt --check` — exit 0 (after `cargo fmt`).
- `bash scripts/check_line_cap.sh` — `line-cap: 14 allowlisted, 0 violations — OK.`

## Test plan
- [x] Build workspace clean
- [x] trusty-memory prompt_context tests pass under `/dev/null`
- [x] Non-EOF FIFO repro confirms hang before fix, no hang after fix
- [x] `cargo test --workspace` completes with 0 failures (mirrors CI)
- [x] clippy / fmt / line-cap gates pass

Closes #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)