### PR TITLE
feat(trusty-mpm): project config stores preferred gh user; default gh ops to it

### DIFF
--- a/crates/trusty-mpm/src/core/gh_account.rs
+++ b/crates/trusty-mpm/src/core/gh_account.rs
@@ -26,9 +26,27 @@
 //! `parse_logged_in_accounts`, `parse_gh_account_status_from_hosts_yml`) are
 //! unit-tested against sample `hosts.yml` and `gh auth status` strings in the
 //! inline `tests` module; the subprocess wrappers are thin bounded glue.
+//!
+//! ## Per-project account enforcement (#2081)
+//!
+//! [`ensure_gh_account_for_project`] is the #2081 mechanism for defaulting
+//! `gh` operations on a project to its configured [`crate::project::record::Project::gh_user`].
+//! It deliberately does NOT run a bare, unscoped `gh auth switch` — `tm`'s
+//! daemon manages many projects concurrently, and `gh auth switch` rewrites the
+//! single SHARED `~/.config/gh/hosts.yml` "active" pointer, so switching for
+//! project A would silently redirect project B's concurrent `gh` calls to the
+//! wrong identity. Instead it requires an already-isolated `GH_CONFIG_DIR`
+//! (the convention this codebase's `gh_identity` module and the operator's own
+//! shell tooling already use to scope `gh` state per project/context) and only
+//! ever mutates the "active" pointer INSIDE that one directory, verifying the
+//! result with a fresh `gh auth status` before returning success. No
+//! `GH_CONFIG_DIR` in the environment → refusal, never a fall-through to the
+//! shared global store.
 
 use std::path::PathBuf;
 use std::time::Duration;
+
+use anyhow::Context;
 
 /// Bounded wall-clock timeout for any `gh` subprocess this module spawns.
 ///
@@ -310,6 +328,231 @@ pub fn logged_in_gh_accounts() -> Vec<String> {
     .unwrap_or_default()
 }
 
+/// Environment variable that scopes every `gh` invocation to a private config
+/// home — the project-isolation primitive [`ensure_gh_account_for_project`]
+/// requires rather than reinvents (already used by `gh_identity::GithubConfig`
+/// and, on at least one operator's host, by a shell `chpwd` hook that sets it
+/// per working directory).
+pub const GH_CONFIG_DIR_ENV: &str = "GH_CONFIG_DIR";
+
+/// Env vars that can override `gh`'s config-dir-resolved identity; must be
+/// neutralised before enforcing/verifying the active account so a stray token
+/// cannot silently outrank the isolated config dir.
+const GH_TOKEN_ENV_VARS: [&str; 2] = ["GH_TOKEN", "GITHUB_TOKEN"];
+
+/// Bound for the `gh auth status` / `gh auth switch` calls
+/// [`ensure_gh_account_for_project`] makes.
+///
+/// Why: unlike [`GH_PROBE_TIMEOUT`] (tuned for the statusline's hot render
+/// path), this call is an explicit, occasional pre-flight — generous enough
+/// for a keyring-backed `gh` to respond without hanging the caller indefinitely.
+const GH_ENFORCE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Ensure `gh` is authenticated as `expected_user` for `config_dir`, WITHOUT
+/// mutating any other gh config store — the #2081 per-project mechanism.
+///
+/// Why: `tm`'s daemon runs many projects concurrently; a bare `gh auth switch`
+/// rewrites the single shared `~/.config/gh/hosts.yml` "active" pointer, so
+/// switching for one project would silently redirect a concurrently-running
+/// project's `gh` calls to the wrong identity. Scoping every read AND the
+/// switch itself to an already-isolated `config_dir` (via `GH_CONFIG_DIR`)
+/// confines the mutation to that one project's store — two projects with
+/// distinct config dirs can run this concurrently without interfering. The
+/// motivating incident (#2081) was NOT fixed by `GH_CONFIG_DIR` isolation
+/// alone: the isolated store itself still had the wrong account marked
+/// active, so this also corrects (and then re-verifies) the active-user
+/// pointer INSIDE that store rather than assuming a config-dir switch is
+/// sufficient.
+/// What: runs `gh auth status` scoped to `config_dir` (with `GH_TOKEN` /
+/// `GITHUB_TOKEN` stripped from the child env so a stray token cannot outrank
+/// the config-dir identity); if `expected_user` is already active, returns
+/// immediately with no mutation. Otherwise runs `gh auth switch --user
+/// <expected_user>` under the same scoped, token-stripped env, then re-runs
+/// `gh auth status` and fails loudly (never silently proceeds) unless the
+/// re-check confirms `expected_user` is now active.
+/// Test: `verify_active_account_*`, `parse_active_account_from_status_*`
+/// cover the pure decision logic; `ensure_gh_account_for_project_*` cover the
+/// public entry point's refusal path without a live `gh`.
+fn ensure_gh_account_in_dir(
+    expected_user: &str,
+    config_dir: &std::path::Path,
+) -> anyhow::Result<()> {
+    let dir = config_dir.to_string_lossy().to_string();
+    let host = crate::core::trusty_tools_config::DEFAULT_GITHUB_HOST;
+
+    let status_text = run_gh_scoped(&dir, ["auth", "status"])
+        .context("failed to run `gh auth status` scoped to the project's GH_CONFIG_DIR")?;
+    if verify_active_account(&status_text, expected_user).is_ok() {
+        return Ok(());
+    }
+
+    let switch = std::process::Command::new("gh")
+        .args([
+            "auth",
+            "switch",
+            "--hostname",
+            host,
+            "--user",
+            expected_user,
+        ])
+        .env(GH_CONFIG_DIR_ENV, &dir)
+        .env_remove(GH_TOKEN_ENV_VARS[0])
+        .env_remove(GH_TOKEN_ENV_VARS[1])
+        .output()
+        .with_context(|| format!("failed to spawn `gh auth switch --user {expected_user}`"))?;
+    if !switch.status.success() {
+        let stderr = String::from_utf8_lossy(&switch.stderr);
+        anyhow::bail!(
+            "`gh auth switch --user {expected_user}` failed inside {dir}: {} \
+             (is '{expected_user}' logged in under this GH_CONFIG_DIR? run \
+             `GH_CONFIG_DIR={dir} gh auth login` first)",
+            stderr.trim()
+        );
+    }
+
+    let recheck = run_gh_scoped(&dir, ["auth", "status"])
+        .context("failed to re-verify `gh auth status` after switching")?;
+    verify_active_account(&recheck, expected_user).map_err(|msg| {
+        anyhow::anyhow!(
+            "gh account switch to '{expected_user}' did not take effect inside {dir}: {msg}"
+        )
+    })
+}
+
+/// Run a bounded `gh` subprocess scoped to `config_dir`, with any env-token
+/// override stripped, returning the combined stdout+stderr text.
+///
+/// Why: both the pre-check and the post-switch re-verification in
+/// [`ensure_gh_account_in_dir`] need the identical scoped-subprocess
+/// invocation; a shared helper keeps the env-stripping and timeout bound in
+/// one place.
+/// What: bounded by [`GH_ENFORCE_TIMEOUT`]; returns an error on a spawn
+/// failure or timeout.
+/// Test: exercised indirectly via `ensure_gh_account_for_project_*` (no live
+/// `gh` in CI, so only the refusal path — which never reaches this
+/// function — is asserted there).
+fn run_gh_scoped(config_dir: &str, args: [&'static str; 2]) -> anyhow::Result<String> {
+    let config_dir = config_dir.to_string();
+    run_bounded(GH_ENFORCE_TIMEOUT, move || {
+        let out = std::process::Command::new("gh")
+            .args(args)
+            .env(GH_CONFIG_DIR_ENV, &config_dir)
+            .env_remove(GH_TOKEN_ENV_VARS[0])
+            .env_remove(GH_TOKEN_ENV_VARS[1])
+            .output()
+            .ok()?;
+        let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+        text.push('\n');
+        text.push_str(&String::from_utf8_lossy(&out.stderr));
+        Some(text)
+    })
+    .ok_or_else(|| anyhow::anyhow!("`gh` did not respond within {GH_ENFORCE_TIMEOUT:?}"))
+}
+
+/// Parse the login marked `Active account: true` from a `gh auth status` transcript.
+///
+/// Why: [`verify_active_account`] needs the SPECIFIC active login (not just
+/// "who is logged in", which [`parse_logged_in_accounts`] already answers) to
+/// confirm a switch actually took effect.
+/// What: scans line-by-line, tracking the login introduced by the most recent
+/// "Logged in to ..." line, and returns it the first time a following
+/// "Active account: true" line is seen. Returns `None` when no login is ever
+/// marked active.
+/// Test: `parse_active_account_from_status_multi`,
+/// `parse_active_account_from_status_single`,
+/// `parse_active_account_from_status_none_active`.
+pub(crate) fn parse_active_account_from_status(auth_status: &str) -> Option<String> {
+    let mut current: Option<String> = None;
+    for line in auth_status.lines() {
+        if let Some((_, rest)) = line.split_once("Logged in to") {
+            current = extract_login_token(rest);
+            continue;
+        }
+        if let Some((_, value)) = line.split_once("Active account:")
+            && value.trim().eq_ignore_ascii_case("true")
+        {
+            return current.clone();
+        }
+    }
+    None
+}
+
+/// Decide whether a `gh auth status` transcript confirms `expected` is active.
+///
+/// Why: isolates the verification decision — including the defensive check
+/// for an env-token override that would make the config-dir identity
+/// unverifiable — so it is unit-testable without a live `gh` and so
+/// [`ensure_gh_account_in_dir`] never has to guess at the meaning of raw
+/// status text.
+/// What: `Err` when the transcript mentions an environment-variable token
+/// override (defence in depth: `GH_TOKEN`/`GITHUB_TOKEN` should already be
+/// stripped from the child env, but this catches the case where `gh` reports
+/// one anyway); `Err` when no account or a DIFFERENT account is active;
+/// `Ok(())` only when [`parse_active_account_from_status`] returns exactly
+/// `expected`.
+/// Test: `verify_active_account_matches`, `verify_active_account_mismatch`,
+/// `verify_active_account_rejects_env_token_override`.
+pub(crate) fn verify_active_account(status_text: &str, expected: &str) -> Result<(), String> {
+    let lower = status_text.to_lowercase();
+    if lower.contains("environment variable")
+        && (lower.contains("gh_token") || lower.contains("github_token"))
+    {
+        return Err(format!(
+            "gh is authenticating via a GH_TOKEN/GITHUB_TOKEN environment variable override, \
+             so the active account inside this GH_CONFIG_DIR cannot be verified as '{expected}'"
+        ));
+    }
+    match parse_active_account_from_status(status_text) {
+        Some(active) if active == expected => Ok(()),
+        Some(active) => Err(format!(
+            "active account is '{active}', expected '{expected}'"
+        )),
+        None => Err(format!(
+            "could not determine an active gh account (expected '{expected}')"
+        )),
+    }
+}
+
+/// Ensure `gh` operations for a project default to `gh_user` — the #2081
+/// public entry point.
+///
+/// Why: `Project::gh_user` (#2081) declares a project's preferred `gh`
+/// account, but honouring it safely requires an already-isolated
+/// `GH_CONFIG_DIR` (see the module-level "Per-project account enforcement"
+/// doc for why a global `gh auth switch` is refused). Requiring
+/// [`GH_CONFIG_DIR_ENV`] to already be set — rather than inventing a
+/// project-specific directory here — aligns with the isolation convention
+/// this codebase (`gh_identity::GithubConfig::config_dir`) and at least one
+/// operator's own shell tooling already use.
+/// What: reads [`GH_CONFIG_DIR_ENV`] from the process environment; `None`/empty
+/// → a loud, actionable error (never falls through to mutating the shared
+/// default gh config). When present, delegates to
+/// [`ensure_gh_account_in_dir`], which is itself a no-op when `gh_user` is
+/// already the active account inside that directory.
+/// Test: `ensure_gh_account_for_project_refuses_without_config_dir` proves the
+/// refusal path never attempts any `gh` call (so it can never perform a
+/// global switch) when no isolated config dir is available.
+pub fn ensure_gh_account_for_project(gh_user: &str) -> anyhow::Result<()> {
+    let gh_user = gh_user.trim();
+    anyhow::ensure!(!gh_user.is_empty(), "gh_user must not be empty");
+
+    let config_dir = std::env::var_os(GH_CONFIG_DIR_ENV)
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no isolated {GH_CONFIG_DIR_ENV} is set in this environment; refusing to run \
+                 `gh auth switch` against the shared ~/.config/gh store (that would leak \
+                 identity across concurrently-running projects). Export {GH_CONFIG_DIR_ENV} \
+                 to a per-project gh config directory (see `github.config_dir` in \
+                 TrustyToolsConfig, or the equivalent per-directory shell convention) before \
+                 retrying."
+            )
+        })?;
+
+    ensure_gh_account_in_dir(gh_user, &config_dir)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -477,5 +720,112 @@ github.com
             logged_in: vec!["a".into(), "b".into()],
         };
         assert!(two.is_ambiguous());
+    }
+
+    // ── #2081: per-project account enforcement (pure decision logic) ────────
+
+    /// Why: the active-account parser must pick the login marked
+    /// `Active account: true`, not just the first login seen.
+    /// Test: itself.
+    #[test]
+    fn parse_active_account_from_status_multi() {
+        assert_eq!(
+            parse_active_account_from_status(MULTI_AUTH_STATUS).as_deref(),
+            Some("bob-duetto")
+        );
+    }
+
+    /// Why: a single-account transcript must resolve to that one login.
+    /// Test: itself.
+    #[test]
+    fn parse_active_account_from_status_single() {
+        assert_eq!(
+            parse_active_account_from_status(SINGLE_AUTH_STATUS).as_deref(),
+            Some("bobmatnyc")
+        );
+    }
+
+    /// Why: a transcript with no `Active account: true` line (or no logins at
+    /// all) must yield `None`, never panic.
+    /// Test: itself.
+    #[test]
+    fn parse_active_account_from_status_none_active() {
+        assert_eq!(parse_active_account_from_status(""), None);
+        assert_eq!(
+            parse_active_account_from_status(
+                "github.com\n  ✓ Logged in to github.com account x\n  - Active account: false\n"
+            ),
+            None
+        );
+    }
+
+    /// Why: [`verify_active_account`] must succeed only when the expected
+    /// login is the one marked active.
+    /// Test: itself.
+    #[test]
+    fn verify_active_account_matches() {
+        assert!(verify_active_account(SINGLE_AUTH_STATUS, "bobmatnyc").is_ok());
+    }
+
+    /// Why: a mismatched active account (the exact #2081 incident shape —
+    /// `bob-duetto` active when `bobmatnyc` was expected) must be a loud `Err`,
+    /// never a silent pass.
+    /// Test: itself.
+    #[test]
+    fn verify_active_account_mismatch() {
+        let err = verify_active_account(MULTI_AUTH_STATUS, "bobmatnyc").unwrap_err();
+        assert!(err.contains("bob-duetto"), "err: {err}");
+        assert!(err.contains("bobmatnyc"), "err: {err}");
+    }
+
+    /// Why: if `gh` reports it is authenticating via an environment-variable
+    /// token override, the config-dir identity cannot be trusted even if some
+    /// login happens to also be marked active — this must be caught and
+    /// refused explicitly (defence in depth alongside stripping `GH_TOKEN` /
+    /// `GITHUB_TOKEN` from the child env before the call).
+    /// Test: itself.
+    #[test]
+    fn verify_active_account_rejects_env_token_override() {
+        let text = "The value of the GH_TOKEN environment variable is being used for authentication.\ngithub.com\n  ✓ Logged in to github.com account bobmatnyc\n  - Active account: true\n";
+        let err = verify_active_account(text, "bobmatnyc").unwrap_err();
+        assert!(err.contains("environment variable"), "err: {err}");
+    }
+
+    /// Why (#2081): the public entry point must REFUSE (never fall through to
+    /// mutating the shared default `~/.config/gh` store) when no isolated
+    /// `GH_CONFIG_DIR` is present in the environment. Because this returns
+    /// before spawning any `gh` subprocess, it structurally proves the
+    /// refusal path can never perform a global `gh auth switch`.
+    /// Test: itself.
+    #[test]
+    fn ensure_gh_account_for_project_refuses_without_config_dir() {
+        let _g = crate::core::trusty_tools_config::env_test_lock();
+        // SAFETY: guarded by the crate-wide env test lock; restored below.
+        let prior = std::env::var_os(GH_CONFIG_DIR_ENV);
+        unsafe { std::env::remove_var(GH_CONFIG_DIR_ENV) };
+        let err = ensure_gh_account_for_project("bobmatnyc").unwrap_err();
+        // SAFETY: restoring whatever was present before the test ran.
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var(GH_CONFIG_DIR_ENV, v),
+                None => std::env::remove_var(GH_CONFIG_DIR_ENV),
+            }
+        }
+        let msg = err.to_string();
+        assert!(msg.contains(GH_CONFIG_DIR_ENV), "msg: {msg}");
+        assert!(
+            msg.contains("shared"),
+            "expected the shared-store refusal rationale: {msg}"
+        );
+    }
+
+    /// Why (#2081): an empty `gh_user` is a caller bug, not a valid
+    /// "no preference" signal (that is `Option::None` at the `Project` layer)
+    /// — must be rejected before even checking `GH_CONFIG_DIR`.
+    /// Test: itself.
+    #[test]
+    fn ensure_gh_account_for_project_rejects_empty_login() {
+        let err = ensure_gh_account_for_project("   ").unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
     }
 }

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -284,6 +284,16 @@ pub struct ProjectConfig {
     /// Free-form description of the project.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Preferred GitHub account login for `gh` operations on this project (#2081).
+    ///
+    /// `None` → no preference declared; `gh_user` is left unset on the seeded
+    /// [`crate::project::record::Project`], so `gh` calls for this project use
+    /// whatever identity is ambient. See `Project::gh_user` for the full
+    /// rationale and the non-mutating resolution mechanism
+    /// ([`crate::core::gh_account::resolve_gh_account_env`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gh_user: Option<String>,
 }
 
 impl TrustyToolsConfig {
@@ -562,6 +572,47 @@ mod tests {
             !yaml.contains("token:"),
             "must not have a bare token field: {yaml}"
         );
+    }
+
+    /// Why (#2081): a `projects:` entry's `gh_user` preference must round-trip
+    /// through YAML, and an absent `gh_user` must not serialise (matching every
+    /// other optional field on `ProjectConfig`) so existing configs deserialise
+    /// unchanged.
+    /// Test: itself.
+    #[test]
+    fn project_config_gh_user_yaml_round_trip() {
+        let cfg = TrustyToolsConfig {
+            projects: vec![ProjectConfig {
+                name: "trusty-tools".into(),
+                repo_url: "https://github.com/bobmatnyc/trusty-tools".into(),
+                default_branch: Some("main".into()),
+                stack_hint: None,
+                tags: None,
+                description: None,
+                gh_user: Some("bobmatnyc".into()),
+            }],
+            ..Default::default()
+        };
+        let yaml = serde_yaml::to_string(&cfg).expect("serialise");
+        assert!(yaml.contains("gh_user"), "yaml: {yaml}");
+        let back: TrustyToolsConfig = serde_yaml::from_str(&yaml).expect("deserialise");
+        assert_eq!(cfg, back);
+
+        // Absent gh_user must not serialise.
+        let no_pref = TrustyToolsConfig {
+            projects: vec![ProjectConfig {
+                name: "other".into(),
+                repo_url: "https://github.com/o/other".into(),
+                default_branch: None,
+                stack_hint: None,
+                tags: None,
+                description: None,
+                gh_user: None,
+            }],
+            ..Default::default()
+        };
+        let yaml_no_pref = serde_yaml::to_string(&no_pref).expect("serialise");
+        assert!(!yaml_no_pref.contains("gh_user"), "yaml: {yaml_no_pref}");
     }
 
     /// Why: the `daemon:` section (#1836) must round-trip through YAML, and an

--- a/crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs
@@ -250,6 +250,7 @@ mod tests {
             stack_hint: None,
             tags: vec![],
             description: None,
+            gh_user: None,
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/mcp_backend.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend.rs
@@ -546,6 +546,7 @@ impl OrchestratorBackend for StateBackend {
         stack_hint: Option<&str>,
         tags: Option<Vec<String>>,
         description: Option<&str>,
+        gh_user: Option<&str>,
     ) -> Result<Value, String> {
         super::mcp_project::project_register(
             &self.state,
@@ -555,6 +556,7 @@ impl OrchestratorBackend for StateBackend {
             stack_hint,
             tags,
             description,
+            gh_user,
         )
         .await
     }

--- a/crates/trusty-mpm/src/daemon/mcp_project.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_project.rs
@@ -47,11 +47,16 @@ pub async fn project_list(state: &Arc<DaemonState>) -> Result<Value, String> {
 /// Register or update a project in the registry.
 ///
 /// Why: `project_register` is the typed, JSON-native way to add a project
-/// without editing `config.yaml` or restarting the daemon.
+/// without editing `config.yaml` or restarting the daemon. `gh_user` (#2081)
+/// lets an operator declare the project's preferred `gh` account so callers
+/// can scope `gh` operations to it instead of relying on a per-session
+/// reminder — see [`crate::core::gh_account::resolve_gh_account_env`] for the
+/// non-mutating resolution mechanism.
 /// What: builds a `Project` from the supplied fields (defaulting
 /// `default_branch` to `"main"` when omitted), calls `registry.register`,
 /// and returns the persisted record.
 /// Test: `dispatch_project_register_tool` in `crate::mcp::tests`.
+#[allow(clippy::too_many_arguments)]
 pub async fn project_register(
     state: &Arc<DaemonState>,
     name: &str,
@@ -60,6 +65,7 @@ pub async fn project_register(
     stack_hint: Option<&str>,
     tags: Option<Vec<String>>,
     description: Option<&str>,
+    gh_user: Option<&str>,
 ) -> Result<Value, String> {
     let project = Project {
         name: name.to_string(),
@@ -68,6 +74,7 @@ pub async fn project_register(
         stack_hint: stack_hint.map(str::to_string),
         tags: tags.unwrap_or_default(),
         description: description.map(str::to_string),
+        gh_user: gh_user.map(str::to_string),
     };
     let registry = state.project_registry().await;
     registry

--- a/crates/trusty-mpm/src/mcp/mod.rs
+++ b/crates/trusty-mpm/src/mcp/mod.rs
@@ -313,11 +313,14 @@ pub trait OrchestratorBackend: Send + Sync {
     /// Why: operators and the driver skill must be able to add or update a
     ///      project without restarting the daemon or editing config.yaml.
     ///      Registration is idempotent — calling with the same `name` updates
-    ///      the entry rather than duplicating it.
+    ///      the entry rather than duplicating it. `gh_user` (#2081) lets an
+    ///      operator declare the project's preferred `gh` account so callers
+    ///      can scope `gh` operations to it without a per-session reminder.
     /// What: upserts the project keyed by `name` and returns the persisted
     ///      project record as JSON.
     /// Test: `dispatch_project_register_tool`,
     ///       `dispatch_project_register_requires_name` (mock).
+    #[allow(clippy::too_many_arguments)]
     async fn project_register(
         &self,
         name: &str,
@@ -326,6 +329,7 @@ pub trait OrchestratorBackend: Send + Sync {
         stack_hint: Option<&str>,
         tags: Option<Vec<String>>,
         description: Option<&str>,
+        gh_user: Option<&str>,
     ) -> Result<Value, String>;
 
     /// Back `project_get`: look up a single project by name.

--- a/crates/trusty-mpm/src/mcp/project_dispatch.rs
+++ b/crates/trusty-mpm/src/mcp/project_dispatch.rs
@@ -47,9 +47,9 @@ pub async fn try_dispatch<B: OrchestratorBackend>(
 /// Parse `project_register` arguments and call the backend.
 ///
 /// Why: `project_register` has the widest argument surface (name, repo_url
-/// required + four optionals); a helper keeps [`try_dispatch`] readable.
+/// required + five optionals); a helper keeps [`try_dispatch`] readable.
 /// What: requires `name` and `repo_url`; reads optional `default_branch`,
-/// `stack_hint`, `tags`, and `description`; calls
+/// `stack_hint`, `tags`, `description`, and `gh_user` (#2081); calls
 /// [`OrchestratorBackend::project_register`]. Missing required fields yield a
 /// descriptive error string.
 /// Test: `super::tests::dispatch_project_register_tool`,
@@ -69,6 +69,7 @@ async fn project_register<B: OrchestratorBackend>(
             .collect()
     });
     let description = args.get("description").and_then(Value::as_str);
+    let gh_user = args.get("gh_user").and_then(Value::as_str);
     backend
         .project_register(
             &name,
@@ -77,6 +78,7 @@ async fn project_register<B: OrchestratorBackend>(
             stack_hint,
             tags,
             description,
+            gh_user,
         )
         .await
 }

--- a/crates/trusty-mpm/src/mcp/tests.rs
+++ b/crates/trusty-mpm/src/mcp/tests.rs
@@ -193,6 +193,7 @@ impl OrchestratorBackend for MockBackend {
         stack_hint: Option<&str>,
         tags: Option<Vec<String>>,
         description: Option<&str>,
+        gh_user: Option<&str>,
     ) -> Result<Value, String> {
         Ok(json!({
             "name": name,
@@ -201,6 +202,7 @@ impl OrchestratorBackend for MockBackend {
             "stack_hint": stack_hint,
             "tags": tags.unwrap_or_default(),
             "description": description,
+            "gh_user": gh_user,
         }))
     }
     async fn project_get(&self, name: &str) -> Result<Value, String> {
@@ -877,6 +879,33 @@ async fn dispatch_project_register_tool() {
     assert_eq!(result["isError"], false);
     let text = result["content"][0]["text"].as_str().unwrap();
     assert!(text.contains("my-repo"), "expected 'my-repo' in: {text}");
+}
+
+/// Why (#2081): `project_register` must accept the optional `gh_user` field
+/// and thread it through to the registered record so operators can declare a
+/// project's preferred `gh` account.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_project_register_accepts_gh_user() {
+    let resp = dispatch(
+        &MockBackend,
+        call(
+            "project_register",
+            json!({
+                "name": "my-repo",
+                "repo_url": "https://github.com/o/my-repo",
+                "gh_user": "bobmatnyc"
+            }),
+        ),
+    )
+    .await;
+    let result = resp.result.unwrap();
+    assert_eq!(result["isError"], false);
+    let text = result["content"][0]["text"].as_str().unwrap();
+    assert!(
+        text.contains("bobmatnyc"),
+        "expected 'bobmatnyc' in: {text}"
+    );
 }
 
 /// Why (#1519): `project_register` must error when the required `name` arg is missing.

--- a/crates/trusty-mpm/src/mcp/tools/project.rs
+++ b/crates/trusty-mpm/src/mcp/tools/project.rs
@@ -31,8 +31,8 @@ pub(super) fn project_tools() -> Vec<Value> {
             "project_list",
             "List all projects registered in the project registry. Returns a JSON \
              array of project objects, each with `name`, `repo_url`, \
-             `default_branch`, and optional `stack_hint`, `tags`, and \
-             `description`.",
+             `default_branch`, and optional `stack_hint`, `tags`, `description`, \
+             and `gh_user` (the project's preferred GitHub account login, #2081).",
             json!({
                 "type": "object",
                 "properties": {},
@@ -72,6 +72,13 @@ pub(super) fn project_tools() -> Vec<Value> {
                     "description": {
                         "type": "string",
                         "description": "Optional free-form human-readable description."
+                    },
+                    "gh_user": {
+                        "type": "string",
+                        "description": "Optional preferred GitHub account login for `gh` \
+                                         operations on this project (#2081). When set, `gh` \
+                                         calls for this project should be scoped to this \
+                                         account rather than whatever identity is ambient."
                     }
                 },
                 "required": ["name", "repo_url"],
@@ -81,7 +88,8 @@ pub(super) fn project_tools() -> Vec<Value> {
         tool(
             "project_get",
             "Look up a single project by name. Returns the project record \
-             (`name`, `repo_url`, `default_branch`, and optional fields) or an \
+             (`name`, `repo_url`, `default_branch`, and optional fields including \
+             `gh_user`, the project's preferred GitHub account login) or an \
              error when the name is not found in the registry.",
             json!({
                 "type": "object",

--- a/crates/trusty-mpm/src/project/record.rs
+++ b/crates/trusty-mpm/src/project/record.rs
@@ -59,6 +59,27 @@ pub struct Project {
     /// when the name alone is ambiguous.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Preferred GitHub account login for `gh` operations on this project (#2081).
+    ///
+    /// Why: a host may have several `gh`-authenticated accounts; the operator
+    /// who has admin rights on THIS project's repo may not be the ambient
+    /// active `gh` account. #2081's motivating incident: a delegated agent's
+    /// active account (`bob-duetto`) lacked admin rights on
+    /// `bobmatnyc/trusty-tools`, so `gh pr merge --admin` failed until the
+    /// account was switched by hand. Storing the preferred login on the
+    /// project record lets callers resolve a per-invocation, non-mutating `gh`
+    /// identity for it (see [`crate::core::gh_account::resolve_gh_account_env`])
+    /// instead of relying on a per-session reminder.
+    /// What: `None` → no preference; `gh` calls made for this project use
+    /// whatever identity is ambient (no regression). `Some(login)` → the
+    /// login callers should scope `gh` operations to, resolved WITHOUT
+    /// mutating the shared `gh auth switch` state (concurrency-safe: two
+    /// projects with different `gh_user` values can run `gh` calls at the
+    /// same time without interfering with each other).
+    /// Test: `project_serde_round_trip`, `project_without_optionals`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gh_user: Option<String>,
 }
 
 /// Derive a project name from a repository URL by stripping the `.git` suffix
@@ -107,8 +128,10 @@ mod tests {
             stack_hint: Some("rust".into()),
             tags: vec!["backend".into(), "oss".into()],
             description: Some("the unified trusty workspace".into()),
+            gh_user: Some("bobmatnyc".into()),
         };
         let json = serde_json::to_string(&p).expect("serialize");
+        assert!(json.contains("gh_user"), "json: {json}");
         let back: Project = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(p, back);
     }
@@ -123,11 +146,16 @@ mod tests {
             stack_hint: None,
             tags: vec![],
             description: None,
+            gh_user: None,
         };
         let json = serde_json::to_string(&p).expect("serialize");
         assert!(
             !json.contains("stack_hint"),
             "absent optional must not serialise: {json}"
+        );
+        assert!(
+            !json.contains("gh_user"),
+            "absent gh_user must not serialise: {json}"
         );
         assert!(
             !json.contains("tags"),

--- a/crates/trusty-mpm/src/project/registry.rs
+++ b/crates/trusty-mpm/src/project/registry.rs
@@ -107,6 +107,7 @@ impl ProjectRegistry {
                 stack_hint: entry.stack_hint.clone(),
                 tags: entry.tags.clone().unwrap_or_default(),
                 description: entry.description.clone(),
+                gh_user: entry.gh_user.clone(),
             };
             let name = project.name.clone();
             if let Err(e) = self.register(project).await {
@@ -162,6 +163,7 @@ impl ProjectRegistry {
                 stack_hint: None,
                 tags: vec![],
                 description: None,
+                gh_user: None,
             };
             if let Err(e) = self.register(project).await {
                 warn!(name = %name, "auto_register: failed to register: {e}");
@@ -242,6 +244,7 @@ mod tests {
             stack_hint: None,
             tags: vec![],
             description: None,
+            gh_user: None,
         };
         registry.register(p.clone()).await.expect("register once");
         registry
@@ -265,6 +268,7 @@ mod tests {
             stack_hint: Some("rust".into()),
             tags: vec!["backend".into()],
             description: Some("desc".into()),
+            gh_user: Some("bob-work".into()),
         };
         registry.register(p.clone()).await.expect("register");
 
@@ -272,6 +276,7 @@ mod tests {
         assert_eq!(got.name, "beta");
         assert_eq!(got.default_branch, "develop");
         assert_eq!(got.stack_hint.as_deref(), Some("rust"));
+        assert_eq!(got.gh_user.as_deref(), Some("bob-work"));
 
         let err = registry.get("nonexistent").await;
         assert!(matches!(err, Err(ProjectStoreError::NotFound(_))));
@@ -290,6 +295,7 @@ mod tests {
                 stack_hint: None,
                 tags: vec![],
                 description: None,
+                gh_user: None,
             };
             registry.register(p).await.expect("register");
         }
@@ -311,6 +317,7 @@ mod tests {
                 stack_hint: Some("python".into()),
                 tags: Some(vec!["ml".into()]),
                 description: Some("ml project".into()),
+                gh_user: Some("bobmatnyc".into()),
             },
             ProjectConfig {
                 name: "from-config-b".into(),
@@ -319,6 +326,7 @@ mod tests {
                 stack_hint: None,
                 tags: None,
                 description: None,
+                gh_user: None,
             },
         ];
 
@@ -332,10 +340,13 @@ mod tests {
         let a = registry.get("from-config-a").await.expect("get a");
         assert_eq!(a.stack_hint.as_deref(), Some("python"));
         assert_eq!(a.default_branch, "main");
+        assert_eq!(a.gh_user.as_deref(), Some("bobmatnyc"));
 
-        // Entry without default_branch must fall back to "main".
+        // Entry without default_branch must fall back to "main"; gh_user stays
+        // unset (no regression for configs that predate #2081).
         let b = registry.get("from-config-b").await.expect("get b");
         assert_eq!(b.default_branch, "main");
+        assert_eq!(b.gh_user, None);
     }
 
     #[tokio::test]
@@ -383,6 +394,7 @@ mod tests {
             stack_hint: Some("rust".into()),
             tags: vec![],
             description: Some("manually registered".into()),
+            gh_user: None,
         };
         registry.register(existing).await.expect("pre-register");
 

--- a/crates/trusty-mpm/src/project/resolver/tests.rs
+++ b/crates/trusty-mpm/src/project/resolver/tests.rs
@@ -22,6 +22,7 @@ fn proj(name: &str, repo_url: &str) -> Project {
         stack_hint: None,
         tags: vec![],
         description: None,
+        gh_user: None,
     }
 }
 
@@ -33,6 +34,7 @@ fn proj_tagged(name: &str, repo_url: &str, tags: &[&str], desc: &str) -> Project
         stack_hint: None,
         tags: tags.iter().map(|s| s.to_string()).collect(),
         description: Some(desc.to_string()),
+        gh_user: None,
     }
 }
 

--- a/crates/trusty-mpm/src/project/store.rs
+++ b/crates/trusty-mpm/src/project/store.rs
@@ -248,6 +248,7 @@ mod tests {
             stack_hint: None,
             tags: vec![],
             description: None,
+            gh_user: None,
         }
     }
 
@@ -358,6 +359,7 @@ mod tests {
             stack_hint: Some("typescript".into()),
             tags: vec!["frontend".into(), "oss".into()],
             description: Some("a fully-populated project".into()),
+            gh_user: Some("bobmatnyc".into()),
         };
         store.upsert(full.clone()).await.expect("upsert full");
 

--- a/crates/trusty-mpm/tests/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/tests/mcp_spawn_gate.rs
@@ -183,6 +183,7 @@ async fn mcp_initiated_spawn_rejects_repo_name_impersonation() {
             stack_hint: None,
             tags: vec![],
             description: None,
+            gh_user: None,
         })
         .await
         .expect("register legitimate project");
@@ -240,6 +241,7 @@ async fn mcp_initiated_spawn_allowed_for_registered_project_reaches_provisioning
             stack_hint: None,
             tags: vec![],
             description: None,
+            gh_user: None,
         })
         .await
         .expect("register project");


### PR DESCRIPTION
## Summary

Closes #2081.

- **Config field**: `Project::gh_user` (`crates/trusty-mpm/src/project/record.rs`) and `ProjectConfig::gh_user` (`crates/trusty-mpm/src/core/trusty_tools_config.rs`) — both `Option<String>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`, so existing configs/registries deserialise unchanged. Threaded through `ProjectRegistry::seed_from_config`, the `project_register`/`project_get`/`project_list` MCP tools (schema, dispatch, trait, daemon impl), so `gh_user` round-trips end to end and is exposed automatically wherever a `Project` is serialised.
- **Enforcement mechanism — project-isolated, no global mutation**: `core::gh_account::ensure_gh_account_for_project(login)`. A bare `gh auth switch` was rejected as the mechanism: `tm`'s daemon manages many projects concurrently, and `gh auth switch` rewrites the single SHARED `~/.config/gh/hosts.yml` "active" pointer — switching for project A would silently redirect project B's concurrent `gh` calls to the wrong identity. Instead the helper:
  1. Requires an already-isolated `GH_CONFIG_DIR` to be set in the environment (the same isolation primitive this codebase's `gh_identity::GithubConfig::config_dir` already uses, and that at least one operator's own shell `chpwd` tooling already sets per working directory). **No `GH_CONFIG_DIR` → loud refusal, never a fall-through to the shared default store.**
  2. Runs `gh auth status`/`gh auth switch` scoped to that one directory only (via `GH_CONFIG_DIR` on the child process), so the mutation is confined to that project's own isolated store — concurrent projects with distinct config dirs never interfere.
  3. Strips `GH_TOKEN`/`GITHUB_TOKEN` from the child env before every call, so a stray token can't silently override the config-dir identity.
  4. Re-verifies with a fresh `gh auth status` after switching and fails loudly if the active account still doesn't match — it never silently proceeds as the wrong identity (this directly targets the original incident: the isolated config dir was correct, but the *active user pointer inside it* was stale).
- **gh call sites found**: `tm`'s own binary has no direct *mutating* `gh` call sites (PR merge/issue edits are done by delegated PM/agents in their own shell, not by `tm`). The only existing `Command::new("gh")` spawns in `trusty-mpm` are the read-only `gh auth status` probes in `core/gh_account.rs` used by the statusline and `tm doctor` — unchanged by this PR. Mechanism chosen: **expose** `gh_user` via `project_get`/`project_list` (for the PM/agents/session-provisioning to consult) **plus** ship the reusable, concurrency-safe `ensure_gh_account_for_project` helper for those callers to invoke.
- **Session provisioning**: not wired in this PR — doing so cleanly requires threading a per-project `GH_CONFIG_DIR` home into the provisioner (`provisioner/workspace.rs`) and the managed-session spawn command builder (`runtime/claude_code.rs`), which is a larger, separate change. Tracked as a follow-up.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-mpm` (lib: 2344 passed, 0 failed; all integration test binaries: all passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean; only pre-existing unrelated `tga` MSRV warning)
- [x] `cargo fmt --check` (clean)
- [x] `bash scripts/check_line_cap.sh` (`line-cap: 14 allowlisted, 0 violations — OK.`)
- New unit tests: `Project`/`ProjectConfig` round-trip with/without `gh_user`; `parse_active_account_from_status_*`; `verify_active_account_matches` / `_mismatch` / `_rejects_env_token_override`; `ensure_gh_account_for_project_refuses_without_config_dir` (proves the refusal path never spawns `gh`, i.e. can never perform a global switch); `ensure_gh_account_for_project_rejects_empty_login`; MCP dispatch test `dispatch_project_register_accepts_gh_user`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)