### PR TITLE
feat(trusty-code): tcode serve daemon foundation — dual STDIO + HTTP JSON-RPC transport (#2053)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10734,6 +10734,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "libc",
@@ -10744,6 +10745,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.23",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "trusty-common",

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -54,11 +54,13 @@ reqwest = { workspace = true }
 # Bash tool: process-group kill on Unix (setsid / kill syscalls)
 libc = { workspace = true }
 
-# DOC-28 catch-up digest for PM prompt seed context (#1762 PR2).
-# The `catchup` feature pulls in the incremental session/git/palace engine from
-# trusty-common so trusty-code can inject recent-activity context into the PM
-# prompt at task start without duplicating the engine here.
-trusty-common = { workspace = true, features = ["catchup"] }
+# DOC-28 catch-up digest for PM prompt seed context (#1762 PR2), plus the
+# shared JSON-RPC 2.0 / MCP wire types + STDIO loop (#2053) so `tcode serve
+# --stdio` speaks the exact same JSON-RPC-over-STDIO contract as trusty-memory
+# and trusty-search. `catchup` already pulls in `mcp` transitively
+# (`catchup = ["dep:rusqlite", "mcp"]`); `mcp` is listed explicitly too so the
+# direct dependency is documented rather than relying on the transitive edge.
+trusty-common = { workspace = true, features = ["catchup", "mcp"] }
 
 [dev-dependencies]
 # Async test runtime (events, build_info, perf async tests, tools tests)

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -60,10 +60,23 @@ libc = { workspace = true }
 # and trusty-search. `catchup` already pulls in `mcp` transitively
 # (`catchup = ["dep:rusqlite", "mcp"]`); `mcp` is listed explicitly too so the
 # direct dependency is documented rather than relying on the transitive edge.
-trusty-common = { workspace = true, features = ["catchup", "mcp"] }
+# `axum-server` enables `trusty_common::server::with_standard_middleware`
+# (CORS/trace/gzip) so `tcode serve --http` matches the trusty-memory/
+# trusty-search middleware stack exactly.
+trusty-common = { workspace = true, features = ["catchup", "mcp", "axum-server"] }
+
+# `tcode serve --http`: POST /rpc + GET /health over axum (#2053). Per
+# CLAUDE.md, axum stays feature-gated in *library* crates
+# (`trusty-common`'s `axum-server` flag); trusty-code is a binary crate that
+# actually serves HTTP, so it takes the dependency unconditionally, matching
+# how `trusty-search`/`trusty-memory` depend on it.
+axum = { workspace = true }
 
 [dev-dependencies]
 # Async test runtime (events, build_info, perf async tests, tools tests)
 tokio = { workspace = true }
 # Temp directories for build_info, delegate, and agents tests
 tempfile = { workspace = true }
+# HTTP router test-only helper (`tower::util::ServiceExt::oneshot`) for
+# driving the `tcode serve --http` axum router without a real socket (#2053).
+tower = { workspace = true }

--- a/crates/trusty-code/src/jsonrpc/error.rs
+++ b/crates/trusty-code/src/jsonrpc/error.rs
@@ -1,0 +1,135 @@
+//! Typed JSON-RPC error returned by [`super::router::MethodHandler`] impls.
+//!
+//! Why: handlers need a lightweight, typed way to signal a specific JSON-RPC
+//! error code (invalid params, internal error, …) without the router having
+//! to string-sniff an `anyhow::Error`. Centralising the constructors here
+//! means every handler produces spec-correct codes by construction.
+//! What: `RpcError { code, message, data }` plus constructors for the two
+//! codes a handler is expected to return itself. `-32601 Method not found`
+//! and `-32600 Invalid Request` are produced by [`super::router::Router`]
+//! before a handler is ever invoked, so they are intentionally not exposed
+//! as constructors here — a handler has no legitimate reason to fabricate
+//! either.
+//! Test: this module's unit tests.
+
+use serde_json::Value;
+use trusty_common::mcp::error_codes;
+
+/// A JSON-RPC 2.0 error, as returned by a method handler.
+///
+/// Why: mirrors `trusty_common::mcp::JsonRpcError`'s shape so the router can
+/// convert one into the other with a straight field copy, but stays a
+/// separate type so handler code never has to construct the wire envelope
+/// directly.
+/// What: `code` is a JSON-RPC error code (spec-defined or application
+/// range); `message` is human-readable; `data` is optional structured detail
+/// attached to the wire error.
+/// Test: `rpc_error_invalid_params_sets_code`, `rpc_error_internal_sets_code`.
+#[derive(Debug, Clone)]
+pub struct RpcError {
+    pub code: i32,
+    pub message: String,
+    pub data: Option<Value>,
+}
+
+impl RpcError {
+    /// Construct an `RpcError` with an arbitrary code.
+    ///
+    /// Why: escape hatch for application-defined codes outside the standard
+    /// JSON-RPC range (e.g. a future domain-specific error).
+    /// What: sets `code`/`message`, leaves `data` unset.
+    /// Test: `rpc_error_new_has_no_data_by_default`.
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    /// Attach structured `data` to an existing error.
+    ///
+    /// Why: some failures carry machine-readable detail (e.g. which field
+    /// failed validation) beyond the human-readable `message`.
+    /// What: builder-style setter; returns `self` for chaining.
+    /// Test: `rpc_error_with_data_attaches_payload`.
+    pub fn with_data(mut self, data: Value) -> Self {
+        self.data = Some(data);
+        self
+    }
+
+    /// Build a `-32602 Invalid params` error.
+    ///
+    /// Why: the standard code a handler returns when it cannot parse or
+    /// validate its `params` argument.
+    /// What: `code = error_codes::INVALID_PARAMS`.
+    /// Test: `rpc_error_invalid_params_sets_code`.
+    pub fn invalid_params(message: impl Into<String>) -> Self {
+        Self::new(error_codes::INVALID_PARAMS, message)
+    }
+
+    /// Build a `-32603 Internal error` error.
+    ///
+    /// Why: the standard code for a handler-side failure that isn't the
+    /// caller's fault (I/O failure, downstream panic-free error, etc.).
+    /// What: `code = error_codes::INTERNAL_ERROR`.
+    /// Test: `rpc_error_internal_sets_code`.
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(error_codes::INTERNAL_ERROR, message)
+    }
+}
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JSON-RPC error {}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for RpcError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// `invalid_params` must use the spec's `-32602` code.
+    #[test]
+    fn rpc_error_invalid_params_sets_code() {
+        let e = RpcError::invalid_params("bad shape");
+        assert_eq!(e.code, error_codes::INVALID_PARAMS);
+        assert_eq!(e.message, "bad shape");
+        assert!(e.data.is_none());
+    }
+
+    /// `internal` must use the spec's `-32603` code.
+    #[test]
+    fn rpc_error_internal_sets_code() {
+        let e = RpcError::internal("boom");
+        assert_eq!(e.code, error_codes::INTERNAL_ERROR);
+        assert_eq!(e.message, "boom");
+    }
+
+    /// `new` alone must not attach any `data`.
+    #[test]
+    fn rpc_error_new_has_no_data_by_default() {
+        let e = RpcError::new(-1, "custom");
+        assert_eq!(e.code, -1);
+        assert!(e.data.is_none());
+    }
+
+    /// `with_data` must attach the supplied payload.
+    #[test]
+    fn rpc_error_with_data_attaches_payload() {
+        let e = RpcError::invalid_params("bad field").with_data(json!({"field": "name"}));
+        assert_eq!(e.data, Some(json!({"field": "name"})));
+    }
+
+    /// `Display` must surface both the code and the message for logs.
+    #[test]
+    fn rpc_error_display_contains_code_and_message() {
+        let e = RpcError::internal("db unreachable");
+        let s = e.to_string();
+        assert!(s.contains("-32603"));
+        assert!(s.contains("db unreachable"));
+    }
+}

--- a/crates/trusty-code/src/jsonrpc/mod.rs
+++ b/crates/trusty-code/src/jsonrpc/mod.rs
@@ -1,0 +1,30 @@
+//! JSON-RPC 2.0 core: wire types, error codes, and the method router (#2053).
+//!
+//! Why: `tcode serve` must speak the exact same JSON-RPC-over-STDIO contract
+//! as the rest of the trusty-* family so tooling (CLI clients, MCP bridges,
+//! future TUI/GUI frontends) has one dispatch convention to learn. Re-using
+//! `trusty_common::mcp`'s wire types — rather than hand-rolling a second,
+//! structurally-identical `Request`/`Response`/`JsonRpcError` — is the
+//! ecosystem-consistent choice: `trusty-search` (`mcp::stdio::run`) and
+//! `trusty-memory` (`commands::serve_stdio_bridge::run_stdio_bridge`) both
+//! already build on it, and its own module doc explicitly exists to prevent
+//! "bug-fixed-in-one-not-the-other" drift between servers.
+//!
+//! What tcode adds on top is new: a [`Router`] that maps method names to
+//! async handlers via a registry rather than a single hand-written `match`.
+//! trusty-memory/trusty-search dispatch through one large `match` because
+//! their method surface is fixed; tcode's is not — later tickets register
+//! `session.*` (#2054), `task.*` (#2056), and `harness.describe` (#2066)
+//! methods, and a registry lets each land as an isolated `router.register(...)`
+//! call instead of growing one match arm-by-arm. [`RpcError`] is the typed
+//! error a handler returns; the router converts it into the JSON-RPC error
+//! envelope.
+//!
+//! Test: see `error::tests` and `router::tests`.
+
+pub mod error;
+pub mod router;
+
+pub use error::RpcError;
+pub use router::{MethodHandler, Router};
+pub use trusty_common::mcp::{Request, Response, error_codes};

--- a/crates/trusty-code/src/jsonrpc/router.rs
+++ b/crates/trusty-code/src/jsonrpc/router.rs
@@ -1,0 +1,298 @@
+//! Method-name -> async-handler registry and the JSON-RPC dispatch algorithm.
+//!
+//! Why: the transport loop (`crate::serve::transport`) only knows how to
+//! turn bytes into a `trusty_common::mcp::Request` and a `Response` back
+//! into bytes; it must not know *which* methods exist. The [`Router`] is
+//! the seam in between: handlers register under a method name once, and
+//! every future ticket that adds a method (`session.*` #2054, `task.*`
+//! #2056, `harness.describe` #2066) does so with one `router.register(...)`
+//! call, never touching the transport or the dispatch algorithm.
+//!
+//! What: [`MethodHandler`] is an object-safe async-handler trait, blanket
+//! implemented for any `Fn(Value) -> Future<Output = Result<Value, RpcError>>`
+//! (so plain `async fn(Value) -> Result<Value, RpcError>` items and closures
+//! both register directly, no adapter boilerplate). [`Router::dispatch`]
+//! implements the JSON-RPC 2.0 error model end-to-end for methods it knows
+//! about:
+//!   - `-32600 Invalid Request` — non-`"2.0"` `jsonrpc` version, or an empty
+//!     method name.
+//!   - `-32601 Method not found` — no handler registered under the name.
+//!   - handler-returned [`RpcError`] (typically `-32602`/`-32603`) is copied
+//!     onto the wire error verbatim, `data` included.
+//!   - `-32700 Parse error` is NOT produced here — malformed JSON never
+//!     becomes a `Request` in the first place, so that code is only ever
+//!     emitted by the transport loop before `dispatch` is called.
+//!
+//! Per JSON-RPC 2.0 §4.1, a request with no `id` is a *notification*: the
+//! server must never reply, even with an error, though the handler (if one
+//! matches) still executes for its side effects. `dispatch` computes the
+//! response normally and then swaps in `Response::suppressed()` at the end
+//! when the original request had no `id`.
+//!
+//! Test: see `tests` below — one case per error code, a notification that
+//! still executes its handler but suppresses the reply, and a successful
+//! round trip.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use serde_json::Value;
+use trusty_common::mcp::{Request, Response, error_codes};
+
+use super::error::RpcError;
+
+/// A boxed, pinned future returned by a method handler.
+type HandlerFuture = Pin<Box<dyn Future<Output = Result<Value, RpcError>> + Send>>;
+
+/// Object-safe async handler for one JSON-RPC method.
+///
+/// Why: `Router` stores handlers as trait objects (`Arc<dyn MethodHandler>`)
+/// so methods of different concrete closure/fn types can share one registry.
+/// Async fns are not directly object-safe, hence the `call` -> boxed-future
+/// indirection.
+/// What: implemented for `Self` by the blanket impl below whenever `Self` is
+/// `Fn(Value) -> Fut` with `Fut: Future<Output = Result<Value, RpcError>>` —
+/// callers never need to implement this trait by hand.
+/// Test: exercised indirectly by every `router::tests` case and by
+/// `crate::serve::methods::tests`.
+pub trait MethodHandler: Send + Sync {
+    /// Invoke the handler with the request's `params` (defaulted to `Null`
+    /// when the wire request omitted them).
+    fn call(&self, params: Value) -> HandlerFuture;
+}
+
+impl<F, Fut> MethodHandler for F
+where
+    F: Fn(Value) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<Value, RpcError>> + Send + 'static,
+{
+    fn call(&self, params: Value) -> HandlerFuture {
+        Box::pin(self(params))
+    }
+}
+
+/// Method-name -> handler registry and JSON-RPC 2.0 dispatcher.
+///
+/// Why: the single seam between the STDIO transport and tcode's business
+/// methods. See the module docs for the extensibility rationale.
+/// What: a thin `HashMap<String, Arc<dyn MethodHandler>>` plus `dispatch`.
+/// Test: `router::tests::*`.
+#[derive(Default)]
+pub struct Router {
+    handlers: HashMap<String, Arc<dyn MethodHandler>>,
+}
+
+impl Router {
+    /// Construct an empty router.
+    ///
+    /// Why: callers assemble a router by registering methods immediately
+    /// after construction (see `crate::serve::build_router`).
+    /// What: returns a `Router` with no registered methods.
+    /// Test: `dispatch_unknown_method_returns_method_not_found` uses a
+    /// router with exactly one registered method to prove unregistered
+    /// names are still rejected.
+    pub fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Register a method handler under `method`.
+    ///
+    /// Why: the sole way new JSON-RPC methods enter the dispatcher.
+    /// Re-registering the same name replaces the previous handler (last
+    /// write wins) rather than erroring, since duplicate registration is a
+    /// programmer error caught by tests, not a runtime condition to guard.
+    /// What: inserts `handler` into the registry; returns `&mut Self` so
+    /// call sites can chain multiple `.register(...)` calls.
+    /// Test: `dispatch_registered_method_returns_handler_result`.
+    pub fn register(
+        &mut self,
+        method: impl Into<String>,
+        handler: impl MethodHandler + 'static,
+    ) -> &mut Self {
+        self.handlers.insert(method.into(), Arc::new(handler));
+        self
+    }
+
+    /// Dispatch a parsed JSON-RPC request, returning the response to write
+    /// back on the wire (or a suppressed response for notifications).
+    ///
+    /// Why: the single entry point the transport loop calls per request
+    /// line. See the module docs for the full error-code contract.
+    /// What: validates the envelope, looks up the handler, awaits it, and
+    /// maps the result onto a `Response` — suppressing the reply entirely
+    /// when `req.id` was absent (a notification).
+    /// Test: `router::tests::*` (one case per code path).
+    pub async fn dispatch(&self, req: Request) -> Response {
+        let is_notification = req.id.is_none();
+        let response = self.dispatch_replyable(&req).await;
+        if is_notification {
+            Response::suppressed()
+        } else {
+            response
+        }
+    }
+
+    /// Compute the reply for `req` as if it were not a notification.
+    ///
+    /// Why: split out of `dispatch` so notification suppression is a single
+    /// decision made once, after the (possibly side-effecting) handler has
+    /// already run — matching JSON-RPC 2.0 §4.1's "notifications still
+    /// execute, they just never get a reply" semantics.
+    /// What: envelope validation, method lookup, handler invocation, result
+    /// mapping. Never suppresses.
+    /// Test: covered transitively via `dispatch`'s tests.
+    async fn dispatch_replyable(&self, req: &Request) -> Response {
+        let id = req.id.clone();
+
+        if let Some(version) = &req.jsonrpc
+            && version != "2.0"
+        {
+            return Response::err(
+                id,
+                error_codes::INVALID_REQUEST,
+                format!("unsupported jsonrpc version \"{version}\" (expected \"2.0\")"),
+            );
+        }
+        if req.method.trim().is_empty() {
+            return Response::err(id, error_codes::INVALID_REQUEST, "method must not be empty");
+        }
+
+        let Some(handler) = self.handlers.get(req.method.as_str()) else {
+            return Response::err(
+                id,
+                error_codes::METHOD_NOT_FOUND,
+                format!("method not found: {}", req.method),
+            );
+        };
+
+        let params = req.params.clone().unwrap_or(Value::Null);
+        match handler.call(params).await {
+            Ok(result) => Response::ok(id, result),
+            Err(e) => {
+                let mut resp = Response::err(id, e.code, e.message);
+                if let Some(err) = resp.error.as_mut() {
+                    err.data = e.data;
+                }
+                resp
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn req(id: Option<Value>, method: &str, params: Option<Value>) -> Request {
+        Request {
+            jsonrpc: Some("2.0".to_string()),
+            id,
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    /// A registered method must return its handler's `Ok` result verbatim.
+    #[tokio::test]
+    async fn dispatch_registered_method_returns_handler_result() {
+        let mut router = Router::new();
+        router.register(
+            "ping",
+            |_params: Value| async move { Ok(json!({"pong": true})) },
+        );
+
+        let resp = router.dispatch(req(Some(json!(1)), "ping", None)).await;
+        assert!(resp.error.is_none(), "expected ok, got {:?}", resp.error);
+        assert_eq!(resp.result, Some(json!({"pong": true})));
+        assert_eq!(resp.id, Some(json!(1)));
+        assert!(!resp.suppress);
+    }
+
+    /// Unregistered methods must return `-32601 Method not found`.
+    #[tokio::test]
+    async fn dispatch_unknown_method_returns_method_not_found() {
+        let mut router = Router::new();
+        router.register("ping", |_params: Value| async move { Ok(json!({})) });
+
+        let resp = router
+            .dispatch(req(Some(json!(2)), "definitely_missing", None))
+            .await;
+        let err = resp.error.expect("expected an error response");
+        assert_eq!(err.code, error_codes::METHOD_NOT_FOUND);
+        assert!(err.message.contains("definitely_missing"));
+    }
+
+    /// A non-`"2.0"` `jsonrpc` field must return `-32600 Invalid Request`.
+    #[tokio::test]
+    async fn dispatch_wrong_jsonrpc_version_returns_invalid_request() {
+        let router = Router::new();
+        let mut r = req(Some(json!(3)), "ping", None);
+        r.jsonrpc = Some("1.0".to_string());
+
+        let resp = router.dispatch(r).await;
+        let err = resp.error.expect("expected an error response");
+        assert_eq!(err.code, error_codes::INVALID_REQUEST);
+    }
+
+    /// An empty method name must return `-32600 Invalid Request`.
+    #[tokio::test]
+    async fn dispatch_empty_method_returns_invalid_request() {
+        let router = Router::new();
+        let resp = router.dispatch(req(Some(json!(4)), "", None)).await;
+        let err = resp.error.expect("expected an error response");
+        assert_eq!(err.code, error_codes::INVALID_REQUEST);
+    }
+
+    /// A handler-returned `RpcError` must be copied onto the wire error,
+    /// `data` included.
+    #[tokio::test]
+    async fn dispatch_handler_error_maps_to_response_error() {
+        let mut router = Router::new();
+        router.register("boom", |_params: Value| async move {
+            Err(RpcError::invalid_params("bad field").with_data(json!({"field": "name"})))
+        });
+
+        let resp = router.dispatch(req(Some(json!(5)), "boom", None)).await;
+        let err = resp.error.expect("expected an error response");
+        assert_eq!(err.code, error_codes::INVALID_PARAMS);
+        assert_eq!(err.message, "bad field");
+        assert_eq!(err.data, Some(json!({"field": "name"})));
+    }
+
+    /// A notification (no `id`) must still execute its handler's side
+    /// effect but the reply must be suppressed.
+    #[tokio::test]
+    async fn dispatch_notification_executes_handler_but_suppresses_reply() {
+        static RAN: AtomicBool = AtomicBool::new(false);
+        let mut router = Router::new();
+        router.register("notify_me", |_params: Value| async move {
+            RAN.store(true, Ordering::SeqCst);
+            Ok(json!({}))
+        });
+
+        let resp = router.dispatch(req(None, "notify_me", None)).await;
+        assert!(resp.suppress, "notifications must suppress the reply");
+        assert!(
+            RAN.load(Ordering::SeqCst),
+            "notification handler must still run"
+        );
+    }
+
+    /// `params` must default to `Null` when the wire request omits them.
+    #[tokio::test]
+    async fn dispatch_missing_params_defaults_to_null() {
+        let mut router = Router::new();
+        router.register("echo_params", |params: Value| async move { Ok(params) });
+
+        let resp = router
+            .dispatch(req(Some(json!(6)), "echo_params", None))
+            .await;
+        assert_eq!(resp.result, Some(Value::Null));
+    }
+}

--- a/crates/trusty-code/src/jsonrpc/router.rs
+++ b/crates/trusty-code/src/jsonrpc/router.rs
@@ -19,9 +19,14 @@
 //!   - `-32601 Method not found` — no handler registered under the name.
 //!   - handler-returned [`RpcError`] (typically `-32602`/`-32603`) is copied
 //!     onto the wire error verbatim, `data` included.
-//!   - `-32700 Parse error` is NOT produced here — malformed JSON never
-//!     becomes a `Request` in the first place, so that code is only ever
-//!     emitted by the transport loop before `dispatch` is called.
+//!   - `-32700 Parse error` is produced by [`Router::dispatch_json`], not
+//!     [`Router::dispatch`] — the STDIO transport (`crate::serve::transport`,
+//!     one JSON object per line) and the HTTP transport
+//!     (`crate::serve::http`, one JSON object per `POST /rpc` body) both
+//!     receive raw bytes rather than an already-parsed `Request`, and both
+//!     need the exact same "parse or -32700" behaviour. Centralising it here
+//!     means the error message and code can never drift between the two
+//!     wire formats.
 //!
 //! Per JSON-RPC 2.0 §4.1, a request with no `id` is a *notification*: the
 //! server must never reply, even with an error, though the handler (if one
@@ -181,6 +186,31 @@ impl Router {
             }
         }
     }
+
+    /// Parse `raw` as a single JSON-RPC request and dispatch it, mapping a
+    /// JSON parse failure onto `-32700 Parse error` instead of propagating.
+    ///
+    /// Why: both wire transports (STDIO lines, HTTP request bodies) receive
+    /// raw bytes rather than an already-parsed `Request`; this is the one
+    /// place "parse or -32700" is implemented, so the message/code can never
+    /// drift between them. See the module docs for the full rationale.
+    /// What: `serde_json::from_slice::<Request>(raw)` then [`Self::dispatch`].
+    /// On parse failure, returns `Response::err(None, error_codes::PARSE_ERROR,
+    /// ...)` without ever invoking a handler — the request `id` is
+    /// unrecoverable from malformed JSON, so the response carries a `null`
+    /// id per the JSON-RPC 2.0 spec.
+    /// Test: `dispatch_json_valid_request_dispatches`,
+    /// `dispatch_json_malformed_bytes_return_parse_error`.
+    pub async fn dispatch_json(&self, raw: &[u8]) -> Response {
+        match serde_json::from_slice::<Request>(raw) {
+            Ok(req) => self.dispatch(req).await,
+            Err(e) => Response::err(
+                None,
+                error_codes::PARSE_ERROR,
+                format!("invalid JSON-RPC: {e}"),
+            ),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -294,5 +324,29 @@ mod tests {
             .dispatch(req(Some(json!(6)), "echo_params", None))
             .await;
         assert_eq!(resp.result, Some(Value::Null));
+    }
+
+    /// `dispatch_json` on well-formed bytes must behave exactly like
+    /// `dispatch` on the parsed request.
+    #[tokio::test]
+    async fn dispatch_json_valid_request_dispatches() {
+        let mut router = Router::new();
+        router.register(
+            "ping",
+            |_params: Value| async move { Ok(json!({"pong": true})) },
+        );
+
+        let raw = br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+        let resp = router.dispatch_json(raw).await;
+        assert_eq!(resp.result, Some(json!({"pong": true})));
+    }
+
+    /// Malformed bytes must map to `-32700 Parse error`, not a panic.
+    #[tokio::test]
+    async fn dispatch_json_malformed_bytes_return_parse_error() {
+        let router = Router::new();
+        let resp = router.dispatch_json(b"not json at all").await;
+        let err = resp.error.expect("expected a parse error");
+        assert_eq!(err.code, error_codes::PARSE_ERROR);
     }
 }

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -274,15 +274,18 @@ pub mod prompt;
 /// Test: `jsonrpc::error::tests::*`, `jsonrpc::router::tests::*`.
 pub mod jsonrpc;
 
-/// `tcode serve` daemon: STDIO JSON-RPC transport + proof-of-life methods.
+/// `tcode serve` daemon: STDIO + HTTP JSON-RPC transports + proof-of-life
+/// methods.
 ///
 /// Why: the foundation of the M1 control-plane cut line (#2053) — proves the
 /// transport + router work end-to-end via `ping`/`health` before `session.*`
 /// (#2054), `task.*` (#2056), and `harness.describe` (#2066) land on top.
-/// What: `build_router`, `run_stdio`, and the `methods`/`transport`
-/// submodules.
+/// Both transports dispatch through the same `Router`, so the method
+/// surface can never drift between `--stdio` and `--http`.
+/// What: `build_router`, `run_stdio`, `run_http`, `DEFAULT_HTTP_PORT`, and
+/// the `methods`/`transport`/`http` submodules.
 /// Test: `serve::tests::*`, `serve::methods::tests::*`,
-/// `serve::transport::tests::*`.
+/// `serve::transport::tests::*`, `serve::http::tests::*`.
 pub mod serve;
 
 // ── Package-level re-exports ──

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -260,6 +260,31 @@ pub mod catchup;
 /// Test: `prompt::tests::*`.
 pub mod prompt;
 
+// ── Phase 5 daemon transport layer (#2053, M1 control-plane cut line) ──
+
+/// JSON-RPC 2.0 core: wire types (re-exported from `trusty_common::mcp`) plus
+/// the tcode-specific `Router`/`RpcError` extensibility seam.
+///
+/// Why: `tcode serve` must speak the same JSON-RPC-over-STDIO contract as
+/// the rest of the trusty-* family; the `Router` is the new piece that lets
+/// later tickets register `session.*`/`task.*`/`harness.describe` methods
+/// without touching the transport loop.
+/// What: `Request`, `Response`, `error_codes` (re-exported), `RpcError`,
+/// `MethodHandler`, `Router`.
+/// Test: `jsonrpc::error::tests::*`, `jsonrpc::router::tests::*`.
+pub mod jsonrpc;
+
+/// `tcode serve` daemon: STDIO JSON-RPC transport + proof-of-life methods.
+///
+/// Why: the foundation of the M1 control-plane cut line (#2053) — proves the
+/// transport + router work end-to-end via `ping`/`health` before `session.*`
+/// (#2054), `task.*` (#2056), and `harness.describe` (#2066) land on top.
+/// What: `build_router`, `run_stdio`, and the `methods`/`transport`
+/// submodules.
+/// Test: `serve::tests::*`, `serve::methods::tests::*`,
+/// `serve::transport::tests::*`.
+pub mod serve;
+
 // ── Package-level re-exports ──
 
 /// Version string, re-exported so integration tests can assert it without

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -8,8 +8,9 @@
 //! What: thin clap CLI. `run-task` resolves the agents dir, validates the agent
 //! name + project path, builds the real OpenRouter `LlmClient` from env, and
 //! delegates to `trusty_code::run_task::execute_run_task`, then prints a human or
-//! `--json` report and exits with the report's meaningful exit code. `serve` and
-//! `run-workflow` remain stubs.
+//! `--json` report and exits with the report's meaningful exit code. `serve`
+//! (#2053) delegates to `trusty_code::serve::{run_stdio, run_http}` for its
+//! two transports. `run-workflow` remains a stub.
 //!
 //! Test: `cargo run -p trusty-code -- --version` must exit 0 and print the
 //! crate version. The execution path is covered by `trusty_code::run_task::tests`
@@ -53,7 +54,9 @@ enum Command {
     /// Start the per-project orchestration server.
     ///
     /// Accepts JSON-RPC 2.0 task requests from CLI clients, TUI frontends,
-    /// and MCP callers. One instance per project.
+    /// and MCP callers. One instance per project. Exactly one transport must
+    /// be selected: `--stdio` XOR `--http` (they are independent modes, not
+    /// simultaneous — see `trusty_code::serve` module docs).
     Serve {
         /// Path to the project root (must contain a `.claude/` directory).
         #[arg(long, short, value_name = "PATH")]
@@ -61,11 +64,19 @@ enum Command {
 
         /// Serve JSON-RPC 2.0 over stdio (NDJSON on stdin/stdout), matching
         /// the trusty-memory/trusty-search MCP stdio convention.
-        ///
-        /// This is currently the only supported transport (#2053); an HTTP
-        /// `POST /rpc` transport is tracked as a follow-up.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "http")]
         stdio: bool,
+
+        /// Serve JSON-RPC 2.0 over HTTP: `POST /rpc` + `GET /health`,
+        /// matching the trusty-memory/trusty-search axum daemon convention.
+        #[arg(long, conflicts_with = "stdio")]
+        http: bool,
+
+        /// TCP port for `--http` (ignored otherwise). `0` binds an
+        /// OS-assigned ephemeral port. Defaults to
+        /// `trusty_code::serve::DEFAULT_HTTP_PORT`.
+        #[arg(long, value_name = "PORT", requires = "http")]
+        port: Option<u16>,
     },
 
     /// Delegate a single task to a named agent and run it end-to-end.
@@ -120,7 +131,12 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Serve { project, stdio } => run_serve(project, stdio).await,
+        Command::Serve {
+            project,
+            stdio,
+            http,
+            port,
+        } => run_serve(project, stdio, http, port).await,
 
         Command::RunTask {
             agent,
@@ -140,33 +156,49 @@ async fn main() -> Result<()> {
     }
 }
 
-/// Execute `tcode serve`: currently only the `--stdio` transport is wired.
+/// Execute `tcode serve`: dispatches to whichever transport was selected.
 ///
 /// Why: keeps `main`'s match arm a one-liner, matching the shape of the
 /// `run_task` wrapper below. The binary layer owns only the CLI-shaped
-/// concern (which transport was requested); `trusty_code::serve` owns the
-/// router assembly and the transport loop, both fully unit-tested offline.
-/// What: `--stdio` delegates to `trusty_code::serve::run_stdio`, which runs
-/// until stdin EOF or SIGTERM, logging to stderr only. Without `--stdio`,
-/// prints an actionable error — HTTP `POST /rpc` is listed in the parent
-/// issue (#2053) but deferred to a follow-up ticket — and exits 1.
-/// Test: exercised manually (`tcode serve --project . --stdio`);
-/// `trusty_code::serve::tests` and `serve::transport::tests` cover the
+/// concern (which transport was requested, and the port); `trusty_code::serve`
+/// owns router assembly and both transport loops, all fully unit-tested
+/// offline. clap's `conflicts_with`/`requires` on the `Serve` variant already
+/// reject `--stdio --http` together and `--port` without `--http` before this
+/// function ever runs.
+/// What: `--http` delegates to `trusty_code::serve::run_http` (port defaults
+/// to `serve::DEFAULT_HTTP_PORT` when `--port` is omitted); `--stdio`
+/// delegates to `trusty_code::serve::run_stdio`. Both run until shutdown
+/// (SIGTERM/SIGINT, or stdin EOF for `--stdio`), logging to stderr only.
+/// Neither flag given prints actionable usage and exits 1 rather than
+/// silently doing nothing.
+/// Test: exercised manually (`tcode serve --project . --stdio` /
+/// `--http [--port N]`); `trusty_code::serve::tests`,
+/// `serve::transport::tests`, and `serve::http::tests` cover the
 /// router/transport logic this delegates to.
-async fn run_serve(project: PathBuf, stdio: bool) -> Result<()> {
-    if !stdio {
-        eprintln!(
-            "tcode serve: only --stdio is implemented today (#2053); HTTP POST /rpc is a follow-up [project={}]",
-            project.display()
-        );
-        process::exit(1);
+async fn run_serve(project: PathBuf, stdio: bool, http: bool, port: Option<u16>) -> Result<()> {
+    if http {
+        let port = port.unwrap_or(trusty_code::serve::DEFAULT_HTTP_PORT);
+        if let Err(e) = trusty_code::serve::run_http(project, port).await {
+            eprintln!("tcode serve --http: fatal error: {e:#}");
+            process::exit(1);
+        }
+        return Ok(());
     }
 
-    if let Err(e) = trusty_code::serve::run_stdio(project).await {
-        eprintln!("tcode serve --stdio: fatal error: {e:#}");
-        process::exit(1);
+    if stdio {
+        if let Err(e) = trusty_code::serve::run_stdio(project).await {
+            eprintln!("tcode serve --stdio: fatal error: {e:#}");
+            process::exit(1);
+        }
+        return Ok(());
     }
-    Ok(())
+
+    eprintln!(
+        "tcode serve: pick a transport — `--stdio` (NDJSON on stdin/stdout) or \
+         `--http [--port N]` (POST /rpc + GET /health) [project={}]",
+        project.display()
+    );
+    process::exit(1);
 }
 
 /// Validate that `agent_name` contains only safe filesystem characters.

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -52,12 +52,20 @@ struct Cli {
 enum Command {
     /// Start the per-project orchestration server.
     ///
-    /// Binds an IPC socket and accepts task requests from CLI clients, TUI
-    /// frontends, and MCP callers. One instance per project.
+    /// Accepts JSON-RPC 2.0 task requests from CLI clients, TUI frontends,
+    /// and MCP callers. One instance per project.
     Serve {
         /// Path to the project root (must contain a `.claude/` directory).
         #[arg(long, short, value_name = "PATH")]
         project: PathBuf,
+
+        /// Serve JSON-RPC 2.0 over stdio (NDJSON on stdin/stdout), matching
+        /// the trusty-memory/trusty-search MCP stdio convention.
+        ///
+        /// This is currently the only supported transport (#2053); an HTTP
+        /// `POST /rpc` transport is tracked as a follow-up.
+        #[arg(long)]
+        stdio: bool,
     },
 
     /// Delegate a single task to a named agent and run it end-to-end.
@@ -112,13 +120,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Serve { project } => {
-            eprintln!(
-                "tcode serve: not yet implemented (#587 Phase 5+) [project={}]",
-                project.display()
-            );
-            process::exit(1);
-        }
+        Command::Serve { project, stdio } => run_serve(project, stdio).await,
 
         Command::RunTask {
             agent,
@@ -136,6 +138,35 @@ async fn main() -> Result<()> {
             process::exit(1);
         }
     }
+}
+
+/// Execute `tcode serve`: currently only the `--stdio` transport is wired.
+///
+/// Why: keeps `main`'s match arm a one-liner, matching the shape of the
+/// `run_task` wrapper below. The binary layer owns only the CLI-shaped
+/// concern (which transport was requested); `trusty_code::serve` owns the
+/// router assembly and the transport loop, both fully unit-tested offline.
+/// What: `--stdio` delegates to `trusty_code::serve::run_stdio`, which runs
+/// until stdin EOF or SIGTERM, logging to stderr only. Without `--stdio`,
+/// prints an actionable error — HTTP `POST /rpc` is listed in the parent
+/// issue (#2053) but deferred to a follow-up ticket — and exits 1.
+/// Test: exercised manually (`tcode serve --project . --stdio`);
+/// `trusty_code::serve::tests` and `serve::transport::tests` cover the
+/// router/transport logic this delegates to.
+async fn run_serve(project: PathBuf, stdio: bool) -> Result<()> {
+    if !stdio {
+        eprintln!(
+            "tcode serve: only --stdio is implemented today (#2053); HTTP POST /rpc is a follow-up [project={}]",
+            project.display()
+        );
+        process::exit(1);
+    }
+
+    if let Err(e) = trusty_code::serve::run_stdio(project).await {
+        eprintln!("tcode serve --stdio: fatal error: {e:#}");
+        process::exit(1);
+    }
+    Ok(())
 }
 
 /// Validate that `agent_name` contains only safe filesystem characters.

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -72,10 +72,16 @@ enum Command {
         #[arg(long, conflicts_with = "stdio")]
         http: bool,
 
-        /// TCP port for `--http` (ignored otherwise). `0` binds an
-        /// OS-assigned ephemeral port. Defaults to
-        /// `trusty_code::serve::DEFAULT_HTTP_PORT`.
-        #[arg(long, value_name = "PORT", requires = "http")]
+        /// TCP port for `--http`. `0` binds an OS-assigned ephemeral port.
+        /// Defaults to `trusty_code::serve::DEFAULT_HTTP_PORT`.
+        ///
+        /// Requires `--http` AND conflicts with `--stdio` — both are needed:
+        /// `requires = "http"` alone does not fire when `--stdio` is also
+        /// present, because clap evaluates `--stdio`'s `conflicts_with =
+        /// "http"` first and short-circuits before the requires-graph check,
+        /// so `--stdio --port N` would otherwise be silently accepted with
+        /// the port discarded.
+        #[arg(long, value_name = "PORT", requires = "http", conflicts_with = "stdio")]
         port: Option<u16>,
     },
 

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -1,0 +1,221 @@
+//! HTTP JSON-RPC 2.0 transport for `tcode serve --http` (#2053).
+//!
+//! Why: matches how `trusty-memory` (`web::router` + `run_http_on`) and
+//! `trusty-search` (`service::server::build_router`) stand up their axum
+//! daemons: a pure `axum::Router` builder — testable via `oneshot`, no real
+//! socket — wrapped in `trusty_common::server::with_standard_middleware`
+//! (CORS/trace/gzip), plus a bind+serve entry point that installs the
+//! shared `trusty_common::shutdown_signal()` graceful-shutdown watcher
+//! (SIGTERM + SIGINT), exactly like `trusty-memory`'s `run_http_on`. `POST
+//! /rpc` and `GET /health` dispatch through the SAME [`crate::jsonrpc::Router`]
+//! the STDIO transport (`crate::serve::transport`) uses via
+//! [`Router::dispatch_json`] — there is exactly one implementation of each
+//! method (`ping`, `health`, …), not one per transport.
+//!
+//! What: [`build_axum_router`] (pure, unit-testable) and [`run_http`] (binds
+//! a `TcpListener` — port `0` yields an OS-assigned ephemeral port — logs
+//! the bound address to stderr, never stdout, and serves until graceful
+//! shutdown).
+//!
+//! Deferred: batch JSON-RPC requests (a JSON array body) are not supported —
+//! `POST /rpc` accepts a single request object per call, matching what the
+//! ticket asked for ("single-request is fine for now").
+//!
+//! Test: `http::tests::*` drive [`build_axum_router`] via
+//! `tower::util::ServiceExt::oneshot` (no real socket): `POST /rpc` ping
+//! success, `POST /rpc` malformed JSON -> `-32700`, `GET /health`.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use axum::{
+    Json, Router as AxumRouter,
+    body::Bytes,
+    extract::State,
+    routing::{get, post},
+};
+use tokio::net::TcpListener;
+use tracing::info;
+use trusty_common::mcp::Response;
+
+use crate::jsonrpc::Router;
+use crate::serve::methods::health_payload;
+
+/// Build the pure axum router (no listener bound) exposing `POST /rpc` and
+/// `GET /health`.
+///
+/// Why: kept separate from [`run_http`] so unit tests exercise routing and
+/// dispatch via `tower::util::ServiceExt::oneshot` without opening a real
+/// socket, and so the standard CORS/trace/gzip middleware stack wraps it
+/// identically to trusty-memory/trusty-search.
+/// What: `POST /rpc` dispatches the request body through
+/// `Router::dispatch_json` (shared with the STDIO transport); `GET /health`
+/// returns [`health_payload`] — the exact payload the `health` JSON-RPC
+/// method returns, so HTTP and JSON-RPC callers see the same shape.
+/// Test: `http_rpc_ping_returns_pong`,
+/// `http_rpc_malformed_json_returns_parse_error`,
+/// `http_health_matches_jsonrpc_health_payload`.
+pub fn build_axum_router(router: Arc<Router>) -> AxumRouter {
+    let app = AxumRouter::new()
+        .route("/rpc", post(rpc_handler))
+        .route("/health", get(health_handler))
+        .with_state(router);
+    trusty_common::server::with_standard_middleware(app)
+}
+
+/// `POST /rpc` — JSON-RPC 2.0 dispatch endpoint.
+///
+/// Why: lets browser clients, curl, and any HTTP-only caller reach the same
+/// method surface the STDIO transport exposes, without learning a REST
+/// vocabulary per method.
+/// What: dispatches the raw request body through `Router::dispatch_json`
+/// (single request per call — batch/array bodies are not supported, see
+/// module docs). Always returns HTTP 200; JSON-RPC errors, including
+/// malformed JSON (mapped to `-32700`), are carried in the response
+/// envelope's `error` field rather than the HTTP status.
+/// Test: `http_rpc_ping_returns_pong`, `http_rpc_malformed_json_returns_parse_error`.
+async fn rpc_handler(State(router): State<Arc<Router>>, body: Bytes) -> Json<Response> {
+    Json(router.dispatch_json(&body).await)
+}
+
+/// `GET /health` — liveness probe matching the `health` JSON-RPC method.
+///
+/// Why: the ecosystem convention (trusty-search, trusty-memory) is an
+/// unauthenticated `GET /health`; trusty-console's gateway polls it to
+/// confirm a daemon is alive. Reusing [`health_payload`] — the exact
+/// function the `health` JSON-RPC method calls — keeps the two transports
+/// from drifting into two different health shapes.
+/// What: always returns HTTP 200 with `{"server","version","status"}`.
+/// Test: `http_health_matches_jsonrpc_health_payload`.
+async fn health_handler() -> Json<serde_json::Value> {
+    Json(health_payload())
+}
+
+/// Bind a `TcpListener` and serve `POST /rpc` + `GET /health` until SIGTERM/
+/// SIGINT (graceful) or an internal axum error.
+///
+/// Why: the top-level entry point `crate::serve::run_http` delegates to this
+/// once the router is assembled.
+/// What: binds `127.0.0.1:port` (`port = 0` lets the OS assign an ephemeral
+/// port), logs the real bound address to stderr — mirroring
+/// `trusty-memory`'s `run_http_on`, and never touching stdout — then serves
+/// with `trusty_common::shutdown_signal()` installed via
+/// `with_graceful_shutdown`: SIGTERM/SIGINT stop new connections and drain
+/// in-flight requests before this function returns (issue #534 convention).
+/// Test: not directly unit-tested (would require a real socket + a real
+/// signal); [`build_axum_router`]'s tests cover the routing/dispatch logic
+/// this serves.
+pub async fn run_http(router: Router, port: u16) -> Result<()> {
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let listener = TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("tcode serve --http: bind {addr}"))?;
+    let bound = listener
+        .local_addr()
+        .context("tcode serve --http: read bound local address")?;
+    info!("tcode serve --http: listening on http://{bound}");
+    eprintln!("tcode serve --http: listening on http://{bound}");
+
+    let app = build_axum_router(Arc::new(router));
+    axum::serve(listener, app)
+        .with_graceful_shutdown(trusty_common::shutdown_signal())
+        .await
+        .context("tcode serve --http: axum serve failed")?;
+
+    info!("tcode serve --http: stopped");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::util::ServiceExt;
+
+    fn router_with_methods() -> Arc<Router> {
+        let mut router = Router::new();
+        crate::serve::methods::register(&mut router);
+        Arc::new(router)
+    }
+
+    async fn body_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// `POST /rpc` with a `ping` request must return HTTP 200 and the same
+    /// `{"pong": true}` result the STDIO transport returns.
+    #[tokio::test]
+    async fn http_rpc_ping_returns_pong() {
+        let app = build_axum_router(router_with_methods());
+        let req_body = json!({"jsonrpc": "2.0", "id": 1, "method": "ping"}).to_string();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/rpc")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["result"], json!({"pong": true}));
+        assert_eq!(v["id"], 1);
+    }
+
+    /// `POST /rpc` with a malformed body must still return HTTP 200 with a
+    /// JSON-RPC `-32700 Parse error` envelope, not a bare HTTP 400.
+    #[tokio::test]
+    async fn http_rpc_malformed_json_returns_parse_error() {
+        let app = build_axum_router(router_with_methods());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/rpc")
+                    .header("content-type", "application/json")
+                    .body(Body::from("not json at all"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(
+            v["error"]["code"],
+            trusty_common::mcp::error_codes::PARSE_ERROR
+        );
+    }
+
+    /// `GET /health` must return the exact payload `health_payload()`
+    /// (and thus the `health` JSON-RPC method) returns.
+    #[tokio::test]
+    async fn http_health_matches_jsonrpc_health_payload() {
+        let app = build_axum_router(router_with_methods());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v, health_payload());
+    }
+}

--- a/crates/trusty-code/src/serve/methods.rs
+++ b/crates/trusty-code/src/serve/methods.rs
@@ -1,12 +1,16 @@
-//! Proof-of-life JSON-RPC methods for `tcode serve --stdio` (#2053).
+//! Proof-of-life JSON-RPC methods for `tcode serve` (#2053).
 //!
 //! Why: the transport + router need at least one real method to prove the
 //! whole path works end-to-end without pulling in `session.*`/`task.*`/
 //! `harness.describe` scope (those land in #2054/#2056/#2066). `ping` and
-//! `health` are the minimal, side-effect-free pair for that job.
+//! `health` are the minimal, side-effect-free pair for that job, shared
+//! verbatim across both transports: the STDIO `health` JSON-RPC method and
+//! the HTTP `GET /health` route (`crate::serve::http::health_handler`) both
+//! call [`health_payload`] so the two transports can never drift into
+//! different shapes.
 //! What: `register` wires both methods into a [`Router`]; `ping` returns
-//! `{"pong": true}`; `health` returns the server name, crate version, and a
-//! static `"ok"` status.
+//! `{"pong": true}`; `health` returns [`health_payload`]'s server name,
+//! crate version, and a static `"ok"` status.
 //! Test: `methods::tests::*`.
 
 use serde_json::{Value, json};
@@ -26,8 +30,8 @@ pub fn register(router: &mut Router) {
 
 /// `ping` — returns `{"pong": true}` regardless of `params`.
 ///
-/// Why: the cheapest possible round-trip proof that the STDIO transport and
-/// the router are wired correctly.
+/// Why: the cheapest possible round-trip proof that a transport and the
+/// router are wired correctly.
 /// What: ignores `params`, never fails.
 /// Test: `ping_returns_pong_true`.
 async fn ping(_params: Value) -> Result<Value, RpcError> {
@@ -38,15 +42,29 @@ async fn ping(_params: Value) -> Result<Value, RpcError> {
 ///
 /// Why: a slightly richer proof-of-life than `ping` that a caller can use to
 /// confirm which build of `tcode` it is talking to.
-/// What: ignores `params`, never fails. `version` is `crate::VERSION`
-/// (`CARGO_PKG_VERSION`).
+/// What: ignores `params`, never fails; the payload is [`health_payload`].
 /// Test: `health_returns_server_identity`.
 async fn health(_params: Value) -> Result<Value, RpcError> {
-    Ok(json!({
+    Ok(health_payload())
+}
+
+/// The shared `health` payload: `{"server","version","status"}`.
+///
+/// Why: pulled out of the `health` JSON-RPC handler so
+/// `crate::serve::http::health_handler` (`GET /health`) can return the
+/// identical shape without duplicating the `json!` literal — one source of
+/// truth for what "healthy" means over either transport.
+/// What: `server = "tcode"`, `version = crate::VERSION`
+/// (`CARGO_PKG_VERSION`), `status = "ok"`. Never fails — there is no
+/// fallible state to check yet; a future ticket that adds real readiness
+/// checks (e.g. project root validity) will extend this function.
+/// Test: `health_payload_has_expected_shape`.
+pub(crate) fn health_payload() -> Value {
+    json!({
         "server": "tcode",
         "version": crate::VERSION,
         "status": "ok",
-    }))
+    })
 }
 
 #[cfg(test)]
@@ -67,6 +85,16 @@ mod tests {
         assert_eq!(result["server"], "tcode");
         assert_eq!(result["status"], "ok");
         assert_eq!(result["version"], crate::VERSION);
+    }
+
+    /// `health_payload` (shared with the HTTP `GET /health` route) must
+    /// carry the same three fields.
+    #[test]
+    fn health_payload_has_expected_shape() {
+        let v = health_payload();
+        assert_eq!(v["server"], "tcode");
+        assert_eq!(v["status"], "ok");
+        assert_eq!(v["version"], crate::VERSION);
     }
 
     /// `register` must wire both methods so the router recognises them

--- a/crates/trusty-code/src/serve/methods.rs
+++ b/crates/trusty-code/src/serve/methods.rs
@@ -1,0 +1,96 @@
+//! Proof-of-life JSON-RPC methods for `tcode serve --stdio` (#2053).
+//!
+//! Why: the transport + router need at least one real method to prove the
+//! whole path works end-to-end without pulling in `session.*`/`task.*`/
+//! `harness.describe` scope (those land in #2054/#2056/#2066). `ping` and
+//! `health` are the minimal, side-effect-free pair for that job.
+//! What: `register` wires both methods into a [`Router`]; `ping` returns
+//! `{"pong": true}`; `health` returns the server name, crate version, and a
+//! static `"ok"` status.
+//! Test: `methods::tests::*`.
+
+use serde_json::{Value, json};
+
+use crate::jsonrpc::{Router, RpcError};
+
+/// Register every proof-of-life method onto `router`.
+///
+/// Why: keeps `crate::serve::build_router` a one-line call as more method
+/// groups (session/task/harness) register themselves the same way later.
+/// What: registers `"ping"` and `"health"`.
+/// Test: `methods_register_wires_ping_and_health`.
+pub fn register(router: &mut Router) {
+    router.register("ping", ping);
+    router.register("health", health);
+}
+
+/// `ping` — returns `{"pong": true}` regardless of `params`.
+///
+/// Why: the cheapest possible round-trip proof that the STDIO transport and
+/// the router are wired correctly.
+/// What: ignores `params`, never fails.
+/// Test: `ping_returns_pong_true`.
+async fn ping(_params: Value) -> Result<Value, RpcError> {
+    Ok(json!({"pong": true}))
+}
+
+/// `health` — returns server identity, crate version, and status.
+///
+/// Why: a slightly richer proof-of-life than `ping` that a caller can use to
+/// confirm which build of `tcode` it is talking to.
+/// What: ignores `params`, never fails. `version` is `crate::VERSION`
+/// (`CARGO_PKG_VERSION`).
+/// Test: `health_returns_server_identity`.
+async fn health(_params: Value) -> Result<Value, RpcError> {
+    Ok(json!({
+        "server": "tcode",
+        "version": crate::VERSION,
+        "status": "ok",
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `ping` must return `{"pong": true}` and never fail.
+    #[tokio::test]
+    async fn ping_returns_pong_true() {
+        let result = ping(Value::Null).await.expect("ping must not fail");
+        assert_eq!(result, json!({"pong": true}));
+    }
+
+    /// `health` must report the server name, version, and "ok" status.
+    #[tokio::test]
+    async fn health_returns_server_identity() {
+        let result = health(Value::Null).await.expect("health must not fail");
+        assert_eq!(result["server"], "tcode");
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["version"], crate::VERSION);
+    }
+
+    /// `register` must wire both methods so the router recognises them
+    /// (rather than returning method-not-found).
+    #[tokio::test]
+    async fn methods_register_wires_ping_and_health() {
+        use trusty_common::mcp::Request;
+
+        let mut router = Router::new();
+        register(&mut router);
+
+        for method in ["ping", "health"] {
+            let req = Request {
+                jsonrpc: Some("2.0".to_string()),
+                id: Some(json!(1)),
+                method: method.to_string(),
+                params: None,
+            };
+            let resp = router.dispatch(req).await;
+            assert!(
+                resp.error.is_none(),
+                "{method} should be registered, got {:?}",
+                resp.error
+            );
+        }
+    }
+}

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -1,0 +1,86 @@
+//! `tcode serve` daemon: STDIO JSON-RPC transport + proof-of-life methods
+//! (#2053, M1 control-plane cut line).
+//!
+//! Why: this module is the foundation the `tcode serve` binary subcommand
+//! delegates to. It owns assembling the [`crate::jsonrpc::Router`] and
+//! entering the transport loop; `main.rs` stays a thin clap-to-handler shim,
+//! matching the rest of the crate's CLI wiring.
+//! What: [`build_router`] registers every currently-known method (today:
+//! [`methods::register`]'s `ping`/`health` proof-of-life pair — later
+//! tickets add `session.*` #2054, `task.*` #2056, `harness.describe` #2066
+//! here). [`run_stdio`] builds the router and runs it against
+//! [`transport::run_stdio_loop`] until stdin EOF or SIGTERM.
+//!
+//! Deferred: the parent issue (#2053) also lists an HTTP `POST /rpc`
+//! transport; this ticket implements STDIO only. A future ticket adds an
+//! HTTP listener that shares the same [`crate::jsonrpc::Router`].
+//!
+//! Test: `serve::tests::run_stdio_router_recognises_proof_of_life_methods`.
+
+pub mod methods;
+pub mod transport;
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use tracing::info;
+
+use crate::jsonrpc::Router;
+
+/// Assemble the router with every method this build of `tcode` knows about.
+///
+/// Why: single place that lists which method groups are wired in, so a new
+/// ticket adding `session.*`/`task.*`/`harness.describe` touches exactly one
+/// line here plus its own `register` function.
+/// What: builds an empty `Router` and calls `methods::register` on it.
+/// Test: `run_stdio_router_recognises_proof_of_life_methods`.
+pub fn build_router() -> Router {
+    let mut router = Router::new();
+    methods::register(&mut router);
+    router
+}
+
+/// Run `tcode serve --stdio` to completion.
+///
+/// Why: the top-level entry point `main.rs` calls for the `serve --stdio`
+/// subcommand.
+/// What: builds the router, logs start/stop to stderr, and enters
+/// [`transport::run_stdio_loop`], returning when it returns (stdin EOF or
+/// SIGTERM).
+/// Test: `run_stdio_router_recognises_proof_of_life_methods` covers the
+/// router assembly; the transport loop itself is covered by
+/// `transport::tests`.
+pub async fn run_stdio(project: PathBuf) -> Result<()> {
+    info!(project = %project.display(), "tcode serve --stdio: starting");
+    let router = build_router();
+    transport::run_stdio_loop(router).await?;
+    info!("tcode serve --stdio: stopped");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use trusty_common::mcp::Request;
+
+    /// `build_router` must recognise both proof-of-life methods.
+    #[tokio::test]
+    async fn run_stdio_router_recognises_proof_of_life_methods() {
+        let router = build_router();
+        for method in ["ping", "health"] {
+            let req = Request {
+                jsonrpc: Some("2.0".to_string()),
+                id: Some(json!(1)),
+                method: method.to_string(),
+                params: None,
+            };
+            let resp = router.dispatch(req).await;
+            assert!(
+                resp.error.is_none(),
+                "{method} must be registered, got {:?}",
+                resp.error
+            );
+        }
+    }
+}

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -1,22 +1,27 @@
-//! `tcode serve` daemon: STDIO JSON-RPC transport + proof-of-life methods
-//! (#2053, M1 control-plane cut line).
+//! `tcode serve` daemon: STDIO + HTTP JSON-RPC transports + proof-of-life
+//! methods (#2053, M1 control-plane cut line).
 //!
 //! Why: this module is the foundation the `tcode serve` binary subcommand
 //! delegates to. It owns assembling the [`crate::jsonrpc::Router`] and
-//! entering the transport loop; `main.rs` stays a thin clap-to-handler shim,
-//! matching the rest of the crate's CLI wiring.
+//! entering whichever transport loop was requested; `main.rs` stays a thin
+//! clap-to-handler shim, matching the rest of the crate's CLI wiring.
 //! What: [`build_router`] registers every currently-known method (today:
 //! [`methods::register`]'s `ping`/`health` proof-of-life pair — later
 //! tickets add `session.*` #2054, `task.*` #2056, `harness.describe` #2066
-//! here). [`run_stdio`] builds the router and runs it against
-//! [`transport::run_stdio_loop`] until stdin EOF or SIGTERM.
+//! here — one line in `build_router` plus each group's own `register`).
+//! [`run_stdio`] and [`run_http`] both build a router via `build_router` and
+//! hand it to their respective transport ([`transport::run_stdio_loop`] /
+//! [`http::run_http`]) — `ping`/`health` behave identically over either
+//! transport because both dispatch through the same `Router`.
 //!
-//! Deferred: the parent issue (#2053) also lists an HTTP `POST /rpc`
-//! transport; this ticket implements STDIO only. A future ticket adds an
-//! HTTP listener that shares the same [`crate::jsonrpc::Router`].
+//! What's NOT here yet: the transports are independent modes (`--stdio` xor
+//! `--http`), not simultaneous; running both at once would need a shared
+//! `Arc<Router>` across two concurrently-spawned tasks, which no current
+//! ticket requires.
 //!
-//! Test: `serve::tests::run_stdio_router_recognises_proof_of_life_methods`.
+//! Test: `serve::tests::*`.
 
+pub mod http;
 pub mod methods;
 pub mod transport;
 
@@ -27,11 +32,26 @@ use tracing::info;
 
 use crate::jsonrpc::Router;
 
+/// Default TCP port for `tcode serve --http` when `--port` is omitted.
+///
+/// Why: the trusty-* family reserves a block of fixed local ports so
+/// operators/tooling can find a daemon without a discovery file
+/// (`trusty-memory` 7070, `trusty-search` 7878, `trusty-analyze` 7879,
+/// `trusty-review` 7880). `7881` is the next free port in that sequence.
+/// Pass `--port 0` to bind an OS-assigned ephemeral port instead (e.g. for
+/// tests or running multiple instances side by side); the real bound port
+/// is always logged to stderr regardless of which is used.
+/// What: `7881`.
+/// Test: `default_http_port_is_documented_value`.
+pub const DEFAULT_HTTP_PORT: u16 = 7881;
+
 /// Assemble the router with every method this build of `tcode` knows about.
 ///
 /// Why: single place that lists which method groups are wired in, so a new
 /// ticket adding `session.*`/`task.*`/`harness.describe` touches exactly one
-/// line here plus its own `register` function.
+/// line here plus its own `register` function. Both transports
+/// (`run_stdio`, `run_http`) call this so they can never drift into
+/// different method surfaces.
 /// What: builds an empty `Router` and calls `methods::register` on it.
 /// Test: `run_stdio_router_recognises_proof_of_life_methods`.
 pub fn build_router() -> Router {
@@ -46,7 +66,7 @@ pub fn build_router() -> Router {
 /// subcommand.
 /// What: builds the router, logs start/stop to stderr, and enters
 /// [`transport::run_stdio_loop`], returning when it returns (stdin EOF or
-/// SIGTERM).
+/// SIGTERM/SIGINT).
 /// Test: `run_stdio_router_recognises_proof_of_life_methods` covers the
 /// router assembly; the transport loop itself is covered by
 /// `transport::tests`.
@@ -55,6 +75,23 @@ pub async fn run_stdio(project: PathBuf) -> Result<()> {
     let router = build_router();
     transport::run_stdio_loop(router).await?;
     info!("tcode serve --stdio: stopped");
+    Ok(())
+}
+
+/// Run `tcode serve --http` to completion.
+///
+/// Why: the top-level entry point `main.rs` calls for the `serve --http`
+/// subcommand.
+/// What: builds the router, logs start/stop to stderr, and enters
+/// [`http::run_http`] bound to `port` (`0` = OS-assigned ephemeral port),
+/// returning when it returns (SIGTERM/SIGINT).
+/// Test: `run_stdio_router_recognises_proof_of_life_methods` covers the
+/// shared router assembly; `http::tests` cover the routing/dispatch logic.
+pub async fn run_http(project: PathBuf, port: u16) -> Result<()> {
+    info!(project = %project.display(), port, "tcode serve --http: starting");
+    let router = build_router();
+    http::run_http(router, port).await?;
+    info!("tcode serve --http: stopped");
     Ok(())
 }
 
@@ -82,5 +119,13 @@ mod tests {
                 resp.error
             );
         }
+    }
+
+    /// `DEFAULT_HTTP_PORT` must stay the documented value (7881) so a
+    /// change is a deliberate edit to both the constant and its doc comment,
+    /// not an accidental drift.
+    #[test]
+    fn default_http_port_is_documented_value() {
+        assert_eq!(DEFAULT_HTTP_PORT, 7881);
     }
 }

--- a/crates/trusty-code/src/serve/transport.rs
+++ b/crates/trusty-code/src/serve/transport.rs
@@ -1,0 +1,308 @@
+//! STDIO JSON-RPC transport loop for `tcode serve --stdio` (#2053).
+//!
+//! Why: matches the ecosystem's line-delimited JSON-RPC-over-stdio framing
+//! — the same convention `trusty-search` (`mcp::stdio::run`) and
+//! `trusty-memory` (`commands::serve_stdio_bridge::run_stdio_bridge`) use,
+//! both built on the shared `trusty_common::mcp` primitives — while adding
+//! SIGTERM-aware graceful shutdown per the workspace's connection-safe
+//! daemon-restart convention (issue #534): the loop stops accepting new
+//! input on SIGTERM but always finishes whatever request is already
+//! in-flight before returning, and it never crashes on malformed input —
+//! a `serde_json` parse failure becomes a `-32700 Parse error` JSON-RPC
+//! response instead of propagating and killing the process.
+//!
+//! What: [`run_stdio_loop`] wires the real `tokio::io::stdin()`/`stdout()`
+//! against a [`Router`]. The generic [`run_loop`] underneath accepts any
+//! `AsyncRead`/`AsyncWrite` pair plus a shutdown future so tests can drive
+//! it over an in-memory pipe without touching real stdio or process signals.
+//! Logging goes to stderr only (via `tracing`) — stdout carries only
+//! JSON-RPC response lines, never log output.
+//!
+//! Deferred: the parent issue (#2053) also lists an HTTP `POST /rpc`
+//! transport; this ticket implements STDIO only (see the crate's `serve`
+//! module docs).
+//!
+//! Test: `transport::tests::*` drive `run_loop` over an in-memory duplex
+//! pipe (successful dispatch, malformed JSON, notification suppression,
+//! EOF exit, and shutdown-signal-triggered early exit).
+
+use std::future::Future;
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tracing::{info, warn};
+use trusty_common::mcp::{Response, error_codes};
+
+use crate::jsonrpc::{Request, Router};
+
+/// Read JSON-RPC 2.0 requests line-by-line from stdin, dispatch each through
+/// `router`, and write the response to stdout. Returns on stdin EOF or on
+/// receipt of SIGTERM.
+///
+/// Why: the single entry point `crate::serve::run_stdio` calls once the
+/// router is assembled.
+/// What: thin wrapper over [`run_loop`] binding the real process stdio and
+/// [`shutdown_signal`].
+/// Test: exercised end-to-end (minus real signals/stdio) by `run_loop`'s
+/// tests below.
+pub async fn run_stdio_loop(router: Router) -> Result<()> {
+    let router = Arc::new(router);
+    run_loop(
+        router,
+        tokio::io::stdin(),
+        tokio::io::stdout(),
+        shutdown_signal(),
+    )
+    .await
+}
+
+/// Generic version of [`run_stdio_loop`] parameterised over the reader,
+/// writer, and shutdown future.
+///
+/// Why: lets unit tests substitute an in-memory duplex pipe and a
+/// deterministic shutdown future instead of real stdio/signals.
+/// What: reads newline-delimited JSON one line at a time; blank lines are
+/// skipped; malformed JSON produces a `-32700 Parse error` response;
+/// suppressed responses (notifications) are never written. `select!` is
+/// `biased` so a ready shutdown future always wins over a simultaneously
+/// ready input line, guaranteeing prompt shutdown.
+/// Test: `run_loop_dispatches_and_writes_response`,
+/// `run_loop_malformed_json_returns_parse_error`,
+/// `run_loop_notification_writes_nothing`,
+/// `run_loop_exits_on_eof_when_shutdown_never_fires`,
+/// `run_loop_shutdown_signal_takes_priority_over_pending_input`.
+async fn run_loop<R, W, Sh>(
+    router: Arc<Router>,
+    reader: R,
+    mut writer: W,
+    shutdown: Sh,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    Sh: Future<Output = ()>,
+{
+    tokio::pin!(shutdown);
+    let mut lines = BufReader::new(reader).lines();
+
+    loop {
+        tokio::select! {
+            biased;
+            () = &mut shutdown => {
+                info!("tcode serve: shutdown signal received, stopping");
+                break;
+            }
+            line = lines.next_line() => {
+                let Some(line) = line? else {
+                    info!("tcode serve: stdin EOF, stopping");
+                    break;
+                };
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let response = parse_and_dispatch(&router, trimmed).await;
+                if response.suppress {
+                    continue;
+                }
+                write_response(&mut writer, &response).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Parse one line as a JSON-RPC request and dispatch it, or produce a
+/// `-32700 Parse error` response on malformed JSON.
+///
+/// Why: keeps the parse-error mapping (the one error code the router itself
+/// never produces) next to the one place it can occur.
+/// What: `serde_json::from_str::<Request>` then `router.dispatch`.
+/// Test: `run_loop_malformed_json_returns_parse_error`.
+async fn parse_and_dispatch(router: &Router, line: &str) -> Response {
+    match serde_json::from_str::<Request>(line) {
+        Ok(req) => router.dispatch(req).await,
+        Err(e) => {
+            warn!("tcode serve: malformed JSON-RPC request: {e}");
+            Response::err(
+                None,
+                error_codes::PARSE_ERROR,
+                format!("invalid JSON-RPC: {e}"),
+            )
+        }
+    }
+}
+
+/// Write one JSON-RPC response as a single NDJSON line and flush.
+///
+/// Why: flushing per-line matters for STDIO transports — without it,
+/// responses can sit in a buffer indefinitely when stdout isn't a TTY.
+/// What: serialise, write, `\n`, flush.
+/// Test: covered by every `run_loop_*` test that asserts on written bytes.
+async fn write_response<W: AsyncWrite + Unpin>(writer: &mut W, response: &Response) -> Result<()> {
+    let serialised = serde_json::to_string(response)?;
+    writer.write_all(serialised.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Resolve when the process receives SIGTERM.
+///
+/// Why: the connection-safe daemon-restart convention (issue #534) requires
+/// every trusty-* daemon to drain and exit cleanly on SIGTERM rather than
+/// being SIGKILLed.
+/// What: installs a `SIGTERM` listener and resolves on the first signal. On
+/// non-Unix platforms (or if installing the handler fails) this future never
+/// resolves, leaving stdin EOF as the only shutdown path.
+/// Test: not directly tested (requires a real process); `run_loop`'s
+/// shutdown-priority test substitutes `std::future::ready(())` for this.
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+    match signal(SignalKind::terminate()) {
+        Ok(mut sig) => {
+            sig.recv().await;
+        }
+        Err(e) => {
+            warn!("tcode serve: failed to install SIGTERM handler: {e}");
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+/// Non-Unix fallback: never resolves (EOF remains the only shutdown path).
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    std::future::pending::<()>().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::io::AsyncReadExt;
+
+    fn router_with_ping() -> Arc<Router> {
+        let mut router = Router::new();
+        router.register("ping", |_params: serde_json::Value| async move {
+            Ok(json!({"pong": true}))
+        });
+        Arc::new(router)
+    }
+
+    /// A well-formed request must produce exactly one NDJSON response line
+    /// with the handler's result.
+    #[tokio::test]
+    async fn run_loop_dispatches_and_writes_response() {
+        let router = router_with_ping();
+        let (mut input_tx, input_rx) = tokio::io::duplex(4096);
+        let (output_tx, mut output_rx) = tokio::io::duplex(4096);
+
+        input_tx
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n")
+            .await
+            .unwrap();
+        drop(input_tx); // EOF after the one line
+
+        run_loop(router, input_rx, output_tx, std::future::pending::<()>())
+            .await
+            .expect("loop must return Ok on EOF");
+
+        let mut out = Vec::new();
+        output_rx.read_to_end(&mut out).await.unwrap();
+        let line = String::from_utf8(out).unwrap();
+        let resp: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(resp["result"], json!({"pong": true}));
+        assert_eq!(resp["id"], 1);
+    }
+
+    /// Malformed JSON must produce a `-32700 Parse error` response, not a
+    /// crash.
+    #[tokio::test]
+    async fn run_loop_malformed_json_returns_parse_error() {
+        let router = router_with_ping();
+        let (mut input_tx, input_rx) = tokio::io::duplex(4096);
+        let (output_tx, mut output_rx) = tokio::io::duplex(4096);
+
+        input_tx.write_all(b"not json at all\n").await.unwrap();
+        drop(input_tx);
+
+        run_loop(router, input_rx, output_tx, std::future::pending::<()>())
+            .await
+            .expect("loop must return Ok on EOF even after a parse error");
+
+        let mut out = Vec::new();
+        output_rx.read_to_end(&mut out).await.unwrap();
+        let resp: serde_json::Value =
+            serde_json::from_str(String::from_utf8(out).unwrap().trim()).unwrap();
+        assert_eq!(resp["error"]["code"], error_codes::PARSE_ERROR);
+    }
+
+    /// A notification (no `id`) must produce no output line at all.
+    #[tokio::test]
+    async fn run_loop_notification_writes_nothing() {
+        let router = router_with_ping();
+        let (mut input_tx, input_rx) = tokio::io::duplex(4096);
+        let (output_tx, mut output_rx) = tokio::io::duplex(4096);
+
+        input_tx
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"ping\"}\n")
+            .await
+            .unwrap();
+        drop(input_tx);
+
+        run_loop(router, input_rx, output_tx, std::future::pending::<()>())
+            .await
+            .expect("loop must return Ok on EOF");
+
+        let mut out = Vec::new();
+        output_rx.read_to_end(&mut out).await.unwrap();
+        assert!(
+            out.is_empty(),
+            "a notification must not produce a response line"
+        );
+    }
+
+    /// EOF with a shutdown future that never fires must still return `Ok`.
+    #[tokio::test]
+    async fn run_loop_exits_on_eof_when_shutdown_never_fires() {
+        let router = router_with_ping();
+        let result = run_loop(
+            router,
+            tokio::io::empty(),
+            tokio::io::sink(),
+            std::future::pending::<()>(),
+        )
+        .await;
+        assert!(result.is_ok(), "loop must return Ok on EOF: {result:?}");
+    }
+
+    /// When the shutdown future is already ready, it must take priority
+    /// over a simultaneously-ready input line (biased `select!`), so the
+    /// loop returns promptly instead of draining all remaining input.
+    #[tokio::test]
+    async fn run_loop_shutdown_signal_takes_priority_over_pending_input() {
+        let router = router_with_ping();
+        let (mut input_tx, input_rx) = tokio::io::duplex(4096);
+        let (output_tx, _output_rx) = tokio::io::duplex(4096);
+
+        input_tx
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n")
+            .await
+            .unwrap();
+        drop(input_tx);
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            run_loop(router, input_rx, output_tx, std::future::ready(())),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "loop must return promptly once the shutdown future is ready"
+        );
+        assert!(result.unwrap().is_ok());
+    }
+}

--- a/crates/trusty-code/src/serve/transport.rs
+++ b/crates/trusty-code/src/serve/transport.rs
@@ -4,12 +4,17 @@
 //! — the same convention `trusty-search` (`mcp::stdio::run`) and
 //! `trusty-memory` (`commands::serve_stdio_bridge::run_stdio_bridge`) use,
 //! both built on the shared `trusty_common::mcp` primitives — while adding
-//! SIGTERM-aware graceful shutdown per the workspace's connection-safe
-//! daemon-restart convention (issue #534): the loop stops accepting new
-//! input on SIGTERM but always finishes whatever request is already
-//! in-flight before returning, and it never crashes on malformed input —
-//! a `serde_json` parse failure becomes a `-32700 Parse error` JSON-RPC
-//! response instead of propagating and killing the process.
+//! graceful shutdown per the workspace's connection-safe daemon-restart
+//! convention (issue #534): the loop stops accepting new input on SIGTERM/
+//! SIGINT but always finishes whatever request is already in-flight before
+//! returning, and it never crashes on malformed input — a `serde_json`
+//! parse failure becomes a `-32700 Parse error` JSON-RPC response instead of
+//! propagating and killing the process. Shutdown detection itself is the
+//! shared `trusty_common::shutdown_signal()` helper — the exact function
+//! `trusty-memory`'s `run_http_on` and `trusty-search`'s HTTP daemon install
+//! via `axum::serve(...).with_graceful_shutdown(...)` (see
+//! `crate::serve::http::run_http`) — rather than a second, STDIO-specific
+//! signal handler.
 //!
 //! What: [`run_stdio_loop`] wires the real `tokio::io::stdin()`/`stdout()`
 //! against a [`Router`]. The generic [`run_loop`] underneath accepts any
@@ -17,10 +22,6 @@
 //! it over an in-memory pipe without touching real stdio or process signals.
 //! Logging goes to stderr only (via `tracing`) — stdout carries only
 //! JSON-RPC response lines, never log output.
-//!
-//! Deferred: the parent issue (#2053) also lists an HTTP `POST /rpc`
-//! transport; this ticket implements STDIO only (see the crate's `serve`
-//! module docs).
 //!
 //! Test: `transport::tests::*` drive `run_loop` over an in-memory duplex
 //! pipe (successful dispatch, malformed JSON, notification suppression,
@@ -31,19 +32,19 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
-use tracing::{info, warn};
-use trusty_common::mcp::{Response, error_codes};
+use tracing::info;
+use trusty_common::mcp::Response;
 
-use crate::jsonrpc::{Request, Router};
+use crate::jsonrpc::Router;
 
 /// Read JSON-RPC 2.0 requests line-by-line from stdin, dispatch each through
 /// `router`, and write the response to stdout. Returns on stdin EOF or on
-/// receipt of SIGTERM.
+/// receipt of SIGTERM/SIGINT.
 ///
 /// Why: the single entry point `crate::serve::run_stdio` calls once the
 /// router is assembled.
 /// What: thin wrapper over [`run_loop`] binding the real process stdio and
-/// [`shutdown_signal`].
+/// the shared `trusty_common::shutdown_signal()`.
 /// Test: exercised end-to-end (minus real signals/stdio) by `run_loop`'s
 /// tests below.
 pub async fn run_stdio_loop(router: Router) -> Result<()> {
@@ -52,7 +53,7 @@ pub async fn run_stdio_loop(router: Router) -> Result<()> {
         router,
         tokio::io::stdin(),
         tokio::io::stdout(),
-        shutdown_signal(),
+        trusty_common::shutdown_signal(),
     )
     .await
 }
@@ -102,7 +103,7 @@ where
                 if trimmed.is_empty() {
                     continue;
                 }
-                let response = parse_and_dispatch(&router, trimmed).await;
+                let response = router.dispatch_json(trimmed.as_bytes()).await;
                 if response.suppress {
                     continue;
                 }
@@ -111,27 +112,6 @@ where
         }
     }
     Ok(())
-}
-
-/// Parse one line as a JSON-RPC request and dispatch it, or produce a
-/// `-32700 Parse error` response on malformed JSON.
-///
-/// Why: keeps the parse-error mapping (the one error code the router itself
-/// never produces) next to the one place it can occur.
-/// What: `serde_json::from_str::<Request>` then `router.dispatch`.
-/// Test: `run_loop_malformed_json_returns_parse_error`.
-async fn parse_and_dispatch(router: &Router, line: &str) -> Response {
-    match serde_json::from_str::<Request>(line) {
-        Ok(req) => router.dispatch(req).await,
-        Err(e) => {
-            warn!("tcode serve: malformed JSON-RPC request: {e}");
-            Response::err(
-                None,
-                error_codes::PARSE_ERROR,
-                format!("invalid JSON-RPC: {e}"),
-            )
-        }
-    }
 }
 
 /// Write one JSON-RPC response as a single NDJSON line and flush.
@@ -148,41 +128,12 @@ async fn write_response<W: AsyncWrite + Unpin>(writer: &mut W, response: &Respon
     Ok(())
 }
 
-/// Resolve when the process receives SIGTERM.
-///
-/// Why: the connection-safe daemon-restart convention (issue #534) requires
-/// every trusty-* daemon to drain and exit cleanly on SIGTERM rather than
-/// being SIGKILLed.
-/// What: installs a `SIGTERM` listener and resolves on the first signal. On
-/// non-Unix platforms (or if installing the handler fails) this future never
-/// resolves, leaving stdin EOF as the only shutdown path.
-/// Test: not directly tested (requires a real process); `run_loop`'s
-/// shutdown-priority test substitutes `std::future::ready(())` for this.
-#[cfg(unix)]
-async fn shutdown_signal() {
-    use tokio::signal::unix::{SignalKind, signal};
-    match signal(SignalKind::terminate()) {
-        Ok(mut sig) => {
-            sig.recv().await;
-        }
-        Err(e) => {
-            warn!("tcode serve: failed to install SIGTERM handler: {e}");
-            std::future::pending::<()>().await;
-        }
-    }
-}
-
-/// Non-Unix fallback: never resolves (EOF remains the only shutdown path).
-#[cfg(not(unix))]
-async fn shutdown_signal() {
-    std::future::pending::<()>().await;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
     use tokio::io::AsyncReadExt;
+    use trusty_common::mcp::error_codes;
 
     fn router_with_ping() -> Arc<Router> {
         let mut router = Router::new();


### PR DESCRIPTION
## Summary

Implements #2053 — the first Milestone M1 deliverable and the foundation of the trusty-code Phase 1 control-plane cut line. Replaces the `serve` stub with a real `tcode serve` daemon.

## What's included

- `tcode serve --project <P> (--stdio | --http [--port N])`
- JSON-RPC 2.0 core: request/response/error types + a `Router` method registry designed for `session.*`/`task.*`/`harness.describe` to slot in later
- STDIO line-delimited transport
- HTTP `POST /rpc` + `GET /health` (default port 7881, ephemeral via `--port 0`)
- Reuses `trusty_common::mcp` wire types for ecosystem consistency with trusty-search/trusty-memory
- stderr-only logging
- graceful SIGTERM/SIGINT shutdown
- `ping`/`health` methods over both transports

## QA

Independently verified — full quality gate green:
- cargo build ✓
- 354 tests pass ✓
- clippy `-D warnings` clean ✓
- fmt clean ✓
- line-cap 0 violations ✓
- STDIO + HTTP smoke tests pass ✓
- stdout-cleanliness MCP invariant holds (stdout is 100% JSON-RPC even with RUST_LOG=debug)
- graceful shutdown exits 0 ✓
- CLI transport-flag conflicts enforced ✓

## Deferred

Batch JSON-RPC (array body) is out of scope for this ticket — single request per `POST /rpc`.

Closes #2053. Part of #2052 (epic). Milestone: M1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)