### PR TITLE
feat(trusty-mpm): manage trusty-search index lifecycle for session worktrees

### DIFF
--- a/crates/trusty-common/src/daemon_addr.rs
+++ b/crates/trusty-common/src/daemon_addr.rs
@@ -118,6 +118,38 @@ pub async fn check_already_running(addr_file: &Path, health_path: &str) -> Optio
     }
 }
 
+/// Resolve a running daemon's discovered HTTP base URL (issue #2033).
+///
+/// Why: several trusty-mpm call sites (session-launch index registration,
+/// decommission-time index removal, the orphan-index sweep) each need "if the
+/// named daemon recorded a bound address, give me its `http://`-prefixed base
+/// URL, else `None`" — and must NEVER fall back to a hardcoded/guessed port
+/// (the #2030 discovery-first rule: a wrong guessed port produces worse
+/// failures than a clean skip). Centralising the `read_daemon_addr` +
+/// scheme-prefix dance here, instead of repeating it at each call site, keeps
+/// every caller in sync and removes the duplication.
+/// What: reads `{app_name}`'s recorded address via [`read_daemon_addr`]; when
+/// present and non-blank, returns it prefixed with `http://` unless it
+/// already carries a `http://`/`https://` scheme. Returns `None` when the
+/// daemon has never started (no address file), the file is empty, or is
+/// unreadable — callers treat `None` as "skip, daemon not discoverable"
+/// rather than guessing a default port.
+/// Test: `resolve_daemon_base_url_adds_scheme`,
+/// `resolve_daemon_base_url_preserves_existing_scheme`,
+/// `resolve_daemon_base_url_none_when_undiscoverable`.
+pub fn resolve_daemon_base_url(app_name: &str) -> Option<String> {
+    match read_daemon_addr(app_name) {
+        Ok(Some(addr)) if !addr.trim().is_empty() => Some(
+            if addr.starts_with("http://") || addr.starts_with("https://") {
+                addr
+            } else {
+                format!("http://{addr}")
+            },
+        ),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -292,5 +324,82 @@ mod tests {
             std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
         }
         assert!(result.is_ok(), "removing non-existent addr must succeed");
+    }
+
+    /// Why (#2033): a bare `host:port` recorded on disk must come back with an
+    /// `http://` scheme prefixed so callers can hand it straight to `reqwest`.
+    /// Test: this test.
+    #[test]
+    fn resolve_daemon_base_url_adds_scheme() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile_like_dir();
+        unsafe {
+            std::env::set_var(DATA_DIR_OVERRIDE_ENV, &tmp);
+        }
+        let app = format!(
+            "trusty-test-daemon-base-url-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        write_daemon_addr(&app, "127.0.0.1:54321").unwrap();
+        let got = resolve_daemon_base_url(&app);
+        unsafe {
+            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
+        }
+        assert_eq!(got.as_deref(), Some("http://127.0.0.1:54321"));
+    }
+
+    /// Why (#2033): an address that already carries a scheme (rare, but the
+    /// contract must be idempotent) must not be double-prefixed.
+    /// Test: this test.
+    #[test]
+    fn resolve_daemon_base_url_preserves_existing_scheme() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile_like_dir();
+        unsafe {
+            std::env::set_var(DATA_DIR_OVERRIDE_ENV, &tmp);
+        }
+        let app = format!(
+            "trusty-test-daemon-base-url-scheme-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        write_daemon_addr(&app, "https://127.0.0.1:54321").unwrap();
+        let got = resolve_daemon_base_url(&app);
+        unsafe {
+            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
+        }
+        assert_eq!(got.as_deref(), Some("https://127.0.0.1:54321"));
+    }
+
+    /// Why (#2033): the discovery-first rule — an undiscoverable daemon must
+    /// resolve to `None`, never a guessed default port.
+    /// Test: this test.
+    #[test]
+    fn resolve_daemon_base_url_none_when_undiscoverable() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile_like_dir();
+        unsafe {
+            std::env::set_var(DATA_DIR_OVERRIDE_ENV, &tmp);
+        }
+        let app = format!(
+            "trusty-test-daemon-base-url-missing-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        let got = resolve_daemon_base_url(&app);
+        unsafe {
+            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
+        }
+        assert!(got.is_none(), "undiscoverable daemon must resolve to None");
     }
 }

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -473,7 +473,9 @@ pub mod daemon_guard;
 /// Why: Both trusty-search and trusty-memory persist their bound `host:port`
 /// to disk for discovery by CLI and MCP clients. Centralising keeps them in sync.
 /// What: Exposes [`daemon_addr::write_daemon_addr`], [`daemon_addr::read_daemon_addr`],
-/// and [`daemon_addr::check_already_running`].
+/// [`daemon_addr::check_already_running`], and
+/// [`daemon_addr::resolve_daemon_base_url`] (discovery-first `http://` base
+/// URL resolution, issue #2033).
 /// Test: `cargo test -p trusty-common -- daemon_addr::tests`.
 pub mod daemon_addr;
 
@@ -537,7 +539,8 @@ pub use data_dir::{DATA_DIR_OVERRIDE_ENV, is_dir, resolve_data_dir, sanitize_dat
 
 // Daemon address
 pub use daemon_addr::{
-    check_already_running, read_daemon_addr, remove_daemon_addr, write_daemon_addr,
+    check_already_running, read_daemon_addr, remove_daemon_addr, resolve_daemon_base_url,
+    write_daemon_addr,
 };
 
 // Health probe

--- a/crates/trusty-mpm/src/core/session_launch/search_index.rs
+++ b/crates/trusty-mpm/src/core/session_launch/search_index.rs
@@ -118,20 +118,17 @@ pub(super) fn register_project_index(project_root: &Path) -> Option<String> {
         return None;
     }
 
-    // Discover the running daemon's address. Absent / unreadable file ⇒ daemon
-    // not started: skip registration (best-effort) but still return the id so
-    // the stub is pinned — the daemon will create the index on first reindex.
-    match trusty_common::read_daemon_addr("trusty-search") {
-        Ok(Some(addr)) if !addr.trim().is_empty() => {
-            let base = if addr.starts_with("http://") || addr.starts_with("https://") {
-                addr
-            } else {
-                format!("http://{addr}")
-            };
+    // Discover the running daemon's address (issue #2033: via the shared
+    // `trusty_common::resolve_daemon_base_url` helper — never a hardcoded
+    // port). Absent / unreadable file ⇒ daemon not started: skip registration
+    // (best-effort) but still return the id so the stub is pinned — the
+    // daemon will create the index on first reindex.
+    match trusty_common::resolve_daemon_base_url("trusty-search") {
+        Some(base) => {
             best_effort_create_index(&base, &index_id, &root);
             best_effort_trigger_reindex(&base, &index_id);
         }
-        _ => {
+        None => {
             tracing::warn!(
                 "trusty-search daemon address not found; pinning index '{index_id}' \
                  without pre-registering it (it will be created on first reindex)"

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -620,6 +620,22 @@ async fn orphan_gc_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::Cance
                     Ok(_) => {}
                     Err(e) => tracing::warn!("orphan-GC worktree sweep failed: {e}"),
                 }
+
+                // #2033: sweep orphaned / 0-chunk trusty-search indexes left
+                // behind by managed worktrees — sessions decommissioned before
+                // the decommission-time index-removal fix, or whose worktree
+                // was never populated before teardown. Best-effort: a
+                // discoverable-but-erroring daemon logs and is retried next tick.
+                match mgr.reap_orphaned_search_indexes().await {
+                    Ok(removed) if !removed.is_empty() => {
+                        info!(
+                            "orphan-GC removed {} orphaned trusty-search index(es)",
+                            removed.len()
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => tracing::warn!("orphan-GC search-index sweep failed: {e}"),
+                }
             }
         }
     }

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -20,6 +20,7 @@ use crate::core::trusty_tools_config::{TrustyToolsConfig, workspace_root};
 
 use super::manager::{ManagedError, SessionManager};
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+use super::search_gc;
 use super::workspace_guard::is_safe_to_remove;
 
 /// Sentinel file written by [`create_session_worktree`] into every SM-created
@@ -79,7 +80,12 @@ pub(crate) const GIT_WORKTREE_REMOVE_TIMEOUT: std::time::Duration =
 /// only the immediate parent (not any ancestor) prevents false positives for
 /// paths like `<base>/.worktrees/deep/nested` where `.worktrees` is a grandparent.
 /// Test: `is_session_worktree_detects_dot_worktrees_component`.
-fn is_session_worktree(path: &Path) -> bool {
+///
+/// Visibility (#2033): `pub(super)` — reused by `session_manager::search_gc`
+/// so the "is this path a disposable in-project worktree?" rule lives in
+/// exactly one place and the search-index lifecycle (delete-on-decommission,
+/// orphan sweep) can never diverge from the filesystem-removal safety gate.
+pub(super) fn is_session_worktree(path: &Path) -> bool {
     path.parent()
         .and_then(|p| p.file_name())
         .map(|n| n == WORKTREES_DIRNAME)
@@ -327,6 +333,23 @@ impl SessionManager {
     ) -> Result<(SessionRecord, bool), ManagedError> {
         let mut record = self.get(id).await?;
 
+        // #2033: derive the trusty-search index id for a disposable workspace
+        // (SM-owned clone or in-project worktree — see
+        // `search_gc::disposable_workspace_index_id`) BEFORE any removal
+        // happens below. This must run first because
+        // `trusty_common::resolve_project_root` walks UP from the workspace
+        // path looking for a `.git` marker — if the directory is already gone
+        // by the time we derive the id, the walk would find the wrong (e.g.
+        // shared base clone's) ancestor `.git` and target the WRONG index for
+        // deletion. Local-path/adopted sessions (`workspace_owned == false`
+        // and not an in-project worktree) return `None` here — their real,
+        // long-lived directory keeps its search index, exactly mirroring the
+        // filesystem-removal guard below.
+        let search_index_id = search_gc::disposable_workspace_index_id(
+            record.workspace_path.as_deref(),
+            record.workspace_owned,
+        );
+
         // Gracefully terminate the runtime before removing the workspace (#1975):
         // SIGTERM the claude process and give it a grace window to flush state,
         // then reclaim the pane — instead of an abrupt `kill_session`. Best-effort:
@@ -424,6 +447,15 @@ impl SessionManager {
                     }
                 }
             }
+        }
+
+        // #2033: best-effort remove the trusty-search index for a disposed
+        // workspace, alongside the worktree/clone directory. Fail-soft: an
+        // unreachable/erroring search daemon must never block or fail session
+        // teardown — `delete_search_index_best_effort` logs and swallows every
+        // failure mode itself.
+        if let Some(index_id) = search_index_id {
+            search_gc::delete_search_index_best_effort(&index_id).await;
         }
 
         // Tombstone: clear workspace_path, mark Decommissioned, persist.

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -20,6 +20,7 @@ pub mod prune;
 pub mod reactivate;
 pub mod record;
 pub mod restart_ops;
+pub mod search_gc;
 pub mod session_guard;
 pub mod snapshot;
 pub mod store;

--- a/crates/trusty-mpm/src/session_manager/search_gc.rs
+++ b/crates/trusty-mpm/src/session_manager/search_gc.rs
@@ -1,0 +1,478 @@
+//! Trusty-search index lifecycle for managed-session teardown + orphan sweep (#2033).
+//!
+//! Why: `core::session_launch::search_index::register_project_index` already
+//! find-or-creates (and starts a persistent file watcher for) a trusty-search
+//! index at session launch — but nothing ever removed that index again. Every
+//! decommissioned managed-worktree session left a permanently-orphaned,
+//! never-queried index registered in the daemon, and worktrees created/torn
+//! down before population left behind 0-chunk stub indexes. This module is
+//! the missing teardown half of the lifecycle: [`disposable_workspace_index_id`]
+//! together with [`delete_search_index_best_effort`] remove a single
+//! session's index at decommission time (used by
+//! `decommission::decommission_with_root`), and
+//! [`SessionManager::sweep_orphaned_search_indexes`] periodically GCs any
+//! worktree-scoped index left behind with no matching live session.
+//! What: split out of `decommission.rs`/`prune.rs` (both near/at the 500-SLOC
+//! production cap) rather than growing either file — this module's `impl
+//! SessionManager` block is additive, exactly like `adopt.rs`/`prune.rs`.
+//! Test: `disposable_index_id_*`, `is_orphan_index_*` in `tests` below (pure,
+//! no live daemon required); the live-HTTP paths are best-effort/fail-soft by
+//! design and are exercised the same way `search_index::best_effort_create_index`'s
+//! daemon-down path is (integration-only).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Deserialize;
+use tracing::{debug, info, warn};
+
+use super::decommission::is_session_worktree;
+use super::manager::SessionManager;
+
+/// Per-request timeout for trusty-search index-lifecycle HTTP calls.
+///
+/// Why: these calls run off the interactive request path (decommission,
+/// periodic GC) but must still never hang the daemon indefinitely if
+/// trusty-search is wedged.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+/// Connect timeout, tighter than the overall request timeout so an
+/// unreachable host fails fast.
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(750);
+
+/// Whether — and under which id — a session's workspace should lose its
+/// trusty-search index on decommission (#2033).
+///
+/// Why: pure predicate so the safety rule is unit-testable without a live
+/// daemon or a real git checkout. The rule intentionally mirrors
+/// `decommission_with_root`'s FILESYSTEM-removal guard exactly: only a
+/// disposable workspace (one the SM provisioned by clone, or an in-project
+/// `.worktrees/<leaf>` worktree) ever loses its index. A local-path/adopted
+/// session's real, long-lived directory is untouched on disk, so its index
+/// must be untouched too.
+/// What: returns `None` when `workspace_path` is `None`, or when the session
+/// is neither `workspace_owned` nor [`is_session_worktree`]. Otherwise
+/// resolves the git-root of `workspace_path` via
+/// `trusty_common::resolve_project_root` (a worktree's OWN `.git` file makes
+/// it its own root — a no-op walk in the common case) and derives the id via
+/// `trusty_common::derive_index_id`, returning `None` if that yields an empty
+/// string. CRITICAL (caller contract): must be invoked BEFORE the workspace
+/// directory is removed from disk — once the directory is gone,
+/// `resolve_project_root`'s upward walk could resolve to an ancestor's (e.g.
+/// the shared base clone's) `.git` and derive the WRONG id.
+/// Test: `disposable_index_id_none_when_no_workspace`,
+/// `disposable_index_id_none_for_unowned_non_worktree`,
+/// `disposable_index_id_derives_from_worktree_path`,
+/// `disposable_index_id_derives_from_owned_clone_path`.
+pub(super) fn disposable_workspace_index_id(
+    workspace_path: Option<&Path>,
+    workspace_owned: bool,
+) -> Option<String> {
+    let ws = workspace_path?;
+    if !(workspace_owned || is_session_worktree(ws)) {
+        return None;
+    }
+    let root = trusty_common::resolve_project_root(ws);
+    let id = trusty_common::derive_index_id(&root);
+    if id.trim().is_empty() { None } else { Some(id) }
+}
+
+/// Best-effort `DELETE {base}/indexes/{index_id}` against the discovered
+/// trusty-search daemon (#2033).
+///
+/// Why: decommissioning a disposable managed-session workspace removes its
+/// directory from disk; leaving its trusty-search index registered is exactly
+/// the orphan-index problem this issue reports. Fail-soft by design: an
+/// unreachable or erroring search daemon must NEVER block or fail session
+/// teardown, so every outcome is logged and swallowed here — the caller
+/// (`decommission_with_root`) invokes this unconditionally.
+/// What: resolves the daemon's base URL via
+/// `trusty_common::resolve_daemon_base_url`; when discoverable, issues a
+/// short-timeout `DELETE` and logs the outcome (removed / non-2xx / transport
+/// error) at info/warn. A `None` base (daemon never started) is a debug-logged
+/// no-op.
+/// Test: exercised via the live-daemon decommission integration path; the
+/// daemon-unreachable branch mirrors `search_index::best_effort_create_index`'s
+/// (both skip cleanly on a missing address file).
+pub(super) async fn delete_search_index_best_effort(index_id: &str) {
+    let Some(base) = trusty_common::resolve_daemon_base_url("trusty-search") else {
+        debug!(
+            index_id,
+            "trusty-search daemon not discoverable; skipping index removal on decommission (#2033)"
+        );
+        return;
+    };
+    let client = match build_client() {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("trusty-search index-delete client build failed: {e}");
+            return;
+        }
+    };
+    let url = format!("{base}/indexes/{index_id}");
+    match client.delete(&url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            info!(
+                index_id,
+                "decommission: removed trusty-search index (#2033)"
+            );
+        }
+        Ok(resp) => {
+            warn!(
+                index_id,
+                status = %resp.status(),
+                "decommission: trusty-search index delete returned non-2xx"
+            );
+        }
+        Err(e) => {
+            warn!(
+                index_id,
+                "decommission: trusty-search index delete failed: {e}"
+            );
+        }
+    }
+}
+
+/// Build the short-timeout `reqwest::Client` shared by every search-index
+/// lifecycle call in this module.
+fn build_client() -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .build()
+}
+
+/// Wire shape of one row of `GET /indexes?details=true`.
+#[derive(Debug, Deserialize)]
+struct IndexDetailRow {
+    id: String,
+    root_path: Option<String>,
+}
+
+/// Wire shape of `GET /indexes?details=true`.
+#[derive(Debug, Deserialize, Default)]
+struct IndexDetailsResponse {
+    #[serde(default)]
+    indexes: Vec<IndexDetailRow>,
+}
+
+/// Wire shape of the fields we need from `GET /indexes/:id/status`.
+#[derive(Debug, Deserialize, Default)]
+struct IndexStatusRow {
+    #[serde(default)]
+    chunk_count: u64,
+}
+
+/// A minimal snapshot of one registered trusty-search index, enough to decide
+/// orphan-candidacy (#2033).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct IndexSnapshot {
+    pub id: String,
+    pub root_path: PathBuf,
+    pub chunk_count: u64,
+}
+
+/// Pure predicate: is `entry` an orphaned managed-worktree trusty-search index
+/// (#2033)?
+///
+/// Why: isolates the sweep's safety rule from the live HTTP fetch loop so it
+/// is exercisable with fabricated data — no daemon, no real worktree.
+/// What: `false` unless (a) `entry.root_path`'s immediate parent directory is
+/// named `.worktrees` (mirrors [`is_session_worktree`] — the sweep NEVER
+/// touches a manually-registered, persistent, non-session project index),
+/// (b) neither `entry.root_path` nor its canonicalized form appears in
+/// `active_workspace_paths` (a live session still claims this root), and (c)
+/// `entry.chunk_count == 0` OR `entry.root_path` no longer exists on disk.
+/// Test: `is_orphan_index_false_for_non_worktree_root`,
+/// `is_orphan_index_false_when_claimed_by_active_session`,
+/// `is_orphan_index_true_for_zero_chunk_unclaimed_worktree`,
+/// `is_orphan_index_true_for_deleted_root_path`,
+/// `is_orphan_index_false_for_populated_unclaimed_worktree_that_still_exists`.
+pub(super) fn is_orphan_index(
+    entry: &IndexSnapshot,
+    active_workspace_paths: &HashSet<PathBuf>,
+) -> bool {
+    if !is_session_worktree(&entry.root_path) {
+        return false;
+    }
+    if active_workspace_paths.contains(&entry.root_path) {
+        return false;
+    }
+    let canonical =
+        std::fs::canonicalize(&entry.root_path).unwrap_or_else(|_| entry.root_path.clone());
+    if active_workspace_paths.contains(&canonical) {
+        return false;
+    }
+    entry.chunk_count == 0 || !entry.root_path.exists()
+}
+
+/// Fetch `(id, root_path)` for every index registered with the daemon.
+async fn fetch_index_details(
+    client: &reqwest::Client,
+    base: &str,
+) -> anyhow::Result<Vec<(String, PathBuf)>> {
+    let url = format!("{base}/indexes?details=true");
+    let body: IndexDetailsResponse = client.get(&url).send().await?.json().await?;
+    Ok(body
+        .indexes
+        .into_iter()
+        .filter_map(|row| row.root_path.map(|rp| (row.id, PathBuf::from(rp))))
+        .collect())
+}
+
+/// Fetch `chunk_count` for one index. A non-2xx or transport error is treated
+/// as `0` (fail-open toward "looks empty, worth reconsidering") since the
+/// caller's [`is_orphan_index`] check ALSO requires the index to be
+/// `.worktrees`-scoped and unclaimed by any live session before this value
+/// can result in deletion — a genuinely populated, still-claimed index is
+/// never at risk from a flaky status probe.
+async fn fetch_chunk_count(client: &reqwest::Client, base: &str, id: &str) -> u64 {
+    let url = format!("{base}/indexes/{id}/status");
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => resp
+            .json::<IndexStatusRow>()
+            .await
+            .map(|s| s.chunk_count)
+            .unwrap_or(0),
+        _ => 0,
+    }
+}
+
+impl SessionManager {
+    /// Snapshot every live managed session's workspace path, canonicalized
+    /// (with a raw-path fallback for symlink-canonicalize failures — mirrors
+    /// `prune::prune_orphaned_worktrees`'s `fresh_active` construction).
+    async fn active_workspace_path_set(&self) -> HashSet<PathBuf> {
+        let mut set = HashSet::new();
+        for p in self
+            .list()
+            .await
+            .into_iter()
+            .filter_map(|r| r.workspace_path)
+        {
+            if let Ok(canonical) = std::fs::canonicalize(&p) {
+                set.insert(canonical);
+            }
+            set.insert(p);
+        }
+        set
+    }
+
+    /// Sweep orphaned / 0-chunk trusty-search indexes for managed worktrees (#2033).
+    ///
+    /// Why: `decommission_with_root` removes a session's OWN index, but
+    /// sessions decommissioned before this fix (or torn down by a crashed
+    /// daemon) leave `.worktrees/`-rooted indexes registered forever, and
+    /// worktrees created/deleted before ever being populated leave 0-chunk
+    /// stub indexes — both accumulate unboundedly (`trusty-search doctor`
+    /// flagged hundreds of these). This is the periodic backstop, mirroring
+    /// `prune::prune_orphaned_worktrees`'s "orphan == not claimed by any live
+    /// session" shape.
+    /// What: lists every registered index (`GET /indexes?details=true`),
+    /// keeps only `.worktrees`-scoped candidates ([`is_session_worktree`]) not
+    /// claimed by [`active_workspace_path_set`], fetches each candidate's
+    /// `chunk_count`, and applies [`is_orphan_index`]. Under `dry_run` the
+    /// matching ids are logged and returned without deleting anything
+    /// (mirrors `PruneWorktreesRequest`'s dry-run-by-default convention);
+    /// otherwise each is removed via `DELETE /indexes/:id`, logged
+    /// individually (no silent truncation), and returned. Returns `Ok(vec![])`
+    /// without error when the daemon is undiscoverable — the sweep is
+    /// best-effort, like the rest of the orphan-GC loop.
+    /// Test: `is_orphan_index_*` cover the pure decision; this async
+    /// orchestration is exercised via the daemon-unreachable no-op path in
+    /// `sweep_orphaned_search_indexes_noop_when_daemon_unreachable`.
+    pub async fn sweep_orphaned_search_indexes(
+        &self,
+        dry_run: bool,
+    ) -> anyhow::Result<Vec<String>> {
+        let Some(base) = trusty_common::resolve_daemon_base_url("trusty-search") else {
+            debug!("trusty-search daemon not discoverable; skipping index orphan sweep (#2033)");
+            return Ok(Vec::new());
+        };
+        let client = build_client()?;
+
+        let details = fetch_index_details(&client, &base).await?;
+        let active_workspace_paths = self.active_workspace_path_set().await;
+
+        let mut candidates = Vec::new();
+        for (id, root_path) in details {
+            // Cheap scope filter before paying for a status round-trip: never
+            // even consider a non-worktree (persistent project) index.
+            if !is_session_worktree(&root_path) {
+                continue;
+            }
+            let chunk_count = fetch_chunk_count(&client, &base, &id).await;
+            let snapshot = IndexSnapshot {
+                id: id.clone(),
+                root_path,
+                chunk_count,
+            };
+            if is_orphan_index(&snapshot, &active_workspace_paths) {
+                candidates.push(id);
+            }
+        }
+
+        if dry_run {
+            for id in &candidates {
+                info!(index_id = %id, "search-index-gc (dry-run): would remove orphaned/0-chunk index");
+            }
+            return Ok(candidates);
+        }
+
+        let mut removed = Vec::new();
+        for id in candidates {
+            let url = format!("{base}/indexes/{id}");
+            match client.delete(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    info!(index_id = %id, "search-index-gc: removed orphaned/0-chunk index");
+                    removed.push(id);
+                }
+                Ok(resp) => {
+                    warn!(
+                        index_id = %id,
+                        status = %resp.status(),
+                        "search-index-gc: delete returned non-2xx"
+                    );
+                }
+                Err(e) => {
+                    warn!(index_id = %id, "search-index-gc: delete failed: {e}");
+                }
+            }
+        }
+        Ok(removed)
+    }
+
+    /// Auto-reap convenience wrapper for the periodic orphan-GC loop (#2033).
+    ///
+    /// Why: mirrors [`prune::reap_orphaned_worktrees`](super::prune) — the
+    /// daemon's `orphan_gc_loop` calls one no-args method per sweep kind
+    /// rather than assembling `dry_run`/path arguments itself.
+    /// What: delegates to [`sweep_orphaned_search_indexes`](Self::sweep_orphaned_search_indexes)
+    /// with `dry_run = false`.
+    /// Test: covered transitively by the `sweep_orphaned_search_indexes` tests.
+    pub async fn reap_orphaned_search_indexes(&self) -> anyhow::Result<Vec<String>> {
+        self.sweep_orphaned_search_indexes(false).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn worktree_path(root: &Path, leaf: &str) -> PathBuf {
+        root.join("owner")
+            .join("repo")
+            .join(".worktrees")
+            .join(leaf)
+    }
+
+    // ---- disposable_workspace_index_id -----------------------------------
+
+    #[test]
+    fn disposable_index_id_none_when_no_workspace() {
+        assert_eq!(disposable_workspace_index_id(None, true), None);
+        assert_eq!(disposable_workspace_index_id(None, false), None);
+    }
+
+    #[test]
+    fn disposable_index_id_none_for_unowned_non_worktree() {
+        // Local-path spawn / adopted session: not owned, not a `.worktrees/`
+        // leaf — the real user directory must never lose its index.
+        let path = Path::new("/Users/dev/my-real-project");
+        assert_eq!(disposable_workspace_index_id(Some(path), false), None);
+    }
+
+    #[test]
+    fn disposable_index_id_derives_from_worktree_path() {
+        // In-project worktree (workspace_owned = false, but IS a `.worktrees/`
+        // leaf) — must derive the id from the worktree leaf's OWN basename,
+        // proving derivation is from the path, never session_id/tmux_name.
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = worktree_path(tmp.path(), "my-feature-worktree");
+        std::fs::create_dir_all(&wt).unwrap();
+        // A git worktree has a `.git` FILE (not dir) at its own root.
+        std::fs::write(wt.join(".git"), "gitdir: /somewhere/else").unwrap();
+
+        let id = disposable_workspace_index_id(Some(&wt), false);
+        assert_eq!(id.as_deref(), Some("my-feature-worktree"));
+    }
+
+    #[test]
+    fn disposable_index_id_derives_from_owned_clone_path() {
+        // SM-owned clone (workspace_owned = true), not under `.worktrees/`.
+        let tmp = tempfile::tempdir().unwrap();
+        let clone_root = tmp.path().join("owner").join("cloned-repo");
+        std::fs::create_dir_all(clone_root.join(".git")).unwrap();
+
+        let id = disposable_workspace_index_id(Some(&clone_root), true);
+        assert_eq!(id.as_deref(), Some("cloned-repo"));
+    }
+
+    // ---- is_orphan_index ---------------------------------------------------
+
+    #[test]
+    fn is_orphan_index_false_for_non_worktree_root() {
+        let entry = IndexSnapshot {
+            id: "persistent-project".into(),
+            root_path: PathBuf::from("/Users/dev/persistent-project"),
+            chunk_count: 0,
+        };
+        assert!(!is_orphan_index(&entry, &HashSet::new()));
+    }
+
+    #[test]
+    fn is_orphan_index_false_when_claimed_by_active_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = worktree_path(tmp.path(), "live-session");
+        std::fs::create_dir_all(&wt).unwrap();
+        let entry = IndexSnapshot {
+            id: "live-session".into(),
+            root_path: wt.clone(),
+            chunk_count: 0,
+        };
+        let active: HashSet<PathBuf> = [wt].into_iter().collect();
+        assert!(!is_orphan_index(&entry, &active));
+    }
+
+    #[test]
+    fn is_orphan_index_true_for_zero_chunk_unclaimed_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = worktree_path(tmp.path(), "stub-session");
+        std::fs::create_dir_all(&wt).unwrap();
+        let entry = IndexSnapshot {
+            id: "stub-session".into(),
+            root_path: wt,
+            chunk_count: 0,
+        };
+        assert!(is_orphan_index(&entry, &HashSet::new()));
+    }
+
+    #[test]
+    fn is_orphan_index_true_for_deleted_root_path() {
+        // Never existed on disk at all (worktree already removed) — even with
+        // a non-zero chunk_count still cached in the daemon's registry, an
+        // unclaimed index whose root is gone is a clear orphan.
+        let entry = IndexSnapshot {
+            id: "gone-session".into(),
+            root_path: PathBuf::from("/nonexistent/owner/repo/.worktrees/gone-session"),
+            chunk_count: 500,
+        };
+        assert!(is_orphan_index(&entry, &HashSet::new()));
+    }
+
+    #[test]
+    fn is_orphan_index_false_for_populated_unclaimed_worktree_that_still_exists() {
+        // Conservative: an unclaimed worktree index that STILL has chunks AND
+        // whose root still exists on disk is left alone — it might be a
+        // session the tracker briefly missed, not a genuine orphan.
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = worktree_path(tmp.path(), "maybe-orphaned");
+        std::fs::create_dir_all(&wt).unwrap();
+        let entry = IndexSnapshot {
+            id: "maybe-orphaned".into(),
+            root_path: wt,
+            chunk_count: 42,
+        };
+        assert!(!is_orphan_index(&entry, &HashSet::new()));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2033. Two-part fix so managed-session worktrees stay search-indexed while alive and stop leaking search-daemon state once they're gone.

- **Create-side auto-update: already working, no fix needed.** Verified that `register_project_index` (`crates/trusty-mpm/src/core/session_launch/search_index.rs`) already POSTs to `/indexes`, which (per `crates/trusty-search/src/service/server/indexes.rs::create_index_handler`) registers the handle **and** calls `state.watcher_manager.spawn_for_index(&registered)` — this starts a persistent FSEvents/inotify watcher (issue #1621/#1635, hardened in #1644, idle-suspend/auto-resume added in #2077) that incrementally reindexes on every save. The watcher idle-suspends after inactivity and auto-resumes (with a reconcile pass) on the next query, so a session's own worktree index never goes stale while the session is in use. This machinery already existed on `main` at HEAD; the issue's live observation ("no watch process") most likely predates the #1621/#1635/#1644/#2077 chain landing on the deployed daemon. No changes were needed here — I did refactor `register_project_index`'s inline daemon-address-discovery block into a new shared helper (`trusty_common::resolve_daemon_base_url`, see below) since I needed the identical logic for the new decommission/sweep code, and duplicating it a third time would violate the "search before implement" / dedup rule.

- **Decommission-time index removal (the main new piece).** `SessionManager::decommission_with_root` (`crates/trusty-mpm/src/session_manager/decommission.rs`) now derives the trusty-search index id from `record.workspace_path` **fresh, at call time, before any removal happens** — never from `session_id`/`tmux_name` — via the new `search_gc::disposable_workspace_index_id`. This matters because #2076 changed worktree naming from UUID to semantic tmux-name; deriving from the path (not the id) means both pre- and post-#2076 sessions resolve correctly, and deriving *before* the directory is deleted avoids `resolve_project_root`'s upward `.git`-search walk from drifting to an ancestor (e.g. the shared base clone) once the worktree is gone. Only disposable workspaces (SM-owned clones or in-project `.worktrees/` worktrees) ever lose their index — local-path/adopted sessions keep both their real directory and its index, exactly mirroring the existing filesystem-removal guard. The actual `DELETE /indexes/{id}` call (`search_gc::delete_search_index_best_effort`) is fail-soft: an unreachable/erroring search daemon is logged and swallowed, never blocking teardown.

- **Orphan / 0-chunk index sweep.** `SessionManager::sweep_orphaned_search_indexes` (new `crates/trusty-mpm/src/session_manager/search_gc.rs`, kept out of `prune.rs` since that file was already at 486/500 SLOC) lists every registered index via `GET /indexes?details=true`, restricts candidates to `.worktrees/`-scoped roots (never touching a persistent, non-session project index), cross-references against every live managed session's workspace path, and removes any unclaimed index that is either 0-chunk or whose root no longer exists on disk. Wired into the existing `orphan_gc_loop` in `crates/trusty-mpm/src/daemon/mod.rs` right after the worktree-orphan reaper, so it runs on the same automatic cadence — no new HTTP endpoint needed for this pass. Every removal (and every eligible-but-dry-run candidate) is logged individually, matching the "no silent truncation" requirement.

- **Discovery, never a hardcoded port.** Added `trusty_common::resolve_daemon_base_url` (`crates/trusty-common/src/daemon_addr.rs`) — a small, unconditional (no feature-gate) helper that wraps `read_daemon_addr` + `http://` scheme-prefixing, mirroring the #2030 discovery-first philosophy (a wrong guessed port is worse than a clean skip). All three call sites (session-launch registration, decommission removal, orphan sweep) now share this one implementation.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-mpm` (2347 lib tests + all integration binaries — 0 failed)
- [x] `cargo test -p trusty-search` (984 lib tests + all integration binaries — 0 failed, unchanged since trusty-search itself wasn't modified)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `bash scripts/check_line_cap.sh` (14 allowlisted, 0 violations)
- [x] New unit tests: `disposable_workspace_index_id` derives from workspace_path (not session_id), scoped to disposable workspaces only; `is_orphan_index` covers non-worktree-root exclusion, active-session-claim exclusion, 0-chunk-unclaimed removal, deleted-root removal, and the conservative "still has chunks + still exists" non-removal case; `resolve_daemon_base_url` scheme-prefixing and undiscoverable-daemon fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)