### PR TITLE
feat(trusty-code): event taxonomy + streaming envelope (#2055)

### DIFF
--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -1,4 +1,5 @@
-//! Process-wide event bus for real-time UI streaming (#192 Phase B).
+//! Process-wide event bus for real-time UI streaming (#192 Phase B; #2055
+//! formalises the session-attach envelope on top of it).
 //!
 //! Why: The 2-second stderr polling model from #149 is slow, lossy, and only
 //! handles workflow phase transitions. The UI needs immediate feedback on
@@ -7,16 +8,34 @@
 //! A `tokio::sync::broadcast` channel exposed via a process-global `OnceLock`
 //! lets any code path emit events without threading the bus through dozens of
 //! function signatures, while SSE subscribers fan out to all browsers.
-//! What: Defines the `Event` enum (the wire format), a process-global
-//! `EVENT_BUS` initialised lazily from any thread, helpers to publish and
-//! subscribe, and a `__OMPM_EVENT__ <json>\n` stderr-relay protocol so events
-//! emitted by `--workflow` subprocesses can be re-broadcast by the parent
-//! API server.
+//!
+//! #2055 adds [`SessionEventEnvelope`]: every event the `session.attach`
+//! protocol (#2054) cares about is session-scoped, so the bus now carries the
+//! ENVELOPE (`session_id`, a per-session monotonic `seq`, a UTC timestamp,
+//! and the tagged [`Event`] payload) rather than a bare `Event`. This is the
+//! same "envelope wraps a domain-tagged payload" shape as
+//! `trusty-agents-common`'s `HarnessEvent`/`HarnessPayload` convention, with
+//! two deliberate divergences (documented on the struct itself): `seq` is
+//! PER-SESSION here (not process-global) because the session-attach
+//! replay->live continuity this ticket requires is scoped to one session's
+//! stream, and the payload stays a flat `#[serde(tag = "type")]` enum (not a
+//! nested `{domain, event}` wrapper) because #2054 already shipped that wire
+//! shape and rewriting it would break the shipped `session.attach` contract.
+//! `session::registry::SessionRegistry` is the sole assigner of `seq`
+//! (see its `record` method) since it already owns the per-session ring
+//! buffer this must stay consistent with.
+//!
+//! What: Defines the `Event` enum (the tagged payload), `SessionEventEnvelope`
+//! (the wire envelope), a process-global `EVENT_BUS` initialised lazily from
+//! any thread carrying envelopes, helpers to publish and subscribe, and a
+//! `__OMPM_EVENT__ <json>\n` stderr-relay protocol so events emitted by
+//! `--workflow` subprocesses can be re-broadcast by the parent API server.
 //! Test: `events::publish` round-trips through `subscribe()`. The relay
 //! prefix is stable so the parent stderr reader can detect and re-publish.
 
 use std::sync::OnceLock;
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
@@ -96,6 +115,67 @@ pub enum Event {
     SessionInput {
         session_id: String,
         input: String,
+    },
+
+    // -- Tool lifecycle (#2055 taxonomy; emitted by #2056's agent loop) --
+    /// A tool invocation began. Distinct from the older `ToolCalled` (which
+    /// has no started/finished/error distinction or call-correlation id, and
+    /// predates the session-attach protocol) — this is the tcode
+    /// session.attach taxonomy's tool-lifecycle kind.
+    ///
+    /// Why: `call_id` correlates this with the matching `ToolFinished`/
+    /// `ToolError` when a session runs multiple tool calls in sequence or
+    /// concurrently.
+    /// What: `args_preview` is truncated via `preview()` before emission.
+    /// Test: `session::registry::registry_tests::record_tool_started_publishes_event`.
+    ToolStarted {
+        session_id: String,
+        tool: String,
+        call_id: String,
+        args_preview: String,
+    },
+    /// A tool invocation completed (success or failure signalled by `success`,
+    /// not a separate error variant — use `ToolError` for exceptional
+    /// failures the caller wants to narrate distinctly, e.g. a timeout).
+    ToolFinished {
+        session_id: String,
+        tool: String,
+        call_id: String,
+        success: bool,
+        result_preview: String,
+    },
+    /// A tool invocation raised an exceptional error (as opposed to
+    /// completing with `success: false`) — e.g. the tool process crashed or
+    /// timed out rather than returning a normal failure result.
+    ToolError {
+        session_id: String,
+        tool: String,
+        call_id: String,
+        error: String,
+    },
+
+    // -- Diagnostics / progress / generic message (#2055 taxonomy) --
+    /// A structured log line scoped to a session, for operators/UIs that
+    /// want daemon-side diagnostics without parsing stderr.
+    Log {
+        session_id: String,
+        /// `"debug"` | `"info"` | `"warn"` | `"error"`.
+        level: String,
+        message: String,
+    },
+    /// A coarse progress update for a long-running session operation.
+    /// `percent` is `None` when progress isn't quantifiable (e.g. "still
+    /// searching") — the UI falls back to an indeterminate spinner.
+    Progress {
+        session_id: String,
+        message: String,
+        percent: Option<f32>,
+    },
+    /// A generic, freeform session-scoped message that doesn't fit any more
+    /// specific kind — the taxonomy's catch-all, used sparingly.
+    Message {
+        session_id: String,
+        text: String,
     },
 
     // -- PM activity --
@@ -279,6 +359,12 @@ impl Event {
             | Event::SessionCancelled { session_id }
             | Event::SessionStatusChanged { session_id, .. }
             | Event::SessionInput { session_id, .. }
+            | Event::ToolStarted { session_id, .. }
+            | Event::ToolFinished { session_id, .. }
+            | Event::ToolError { session_id, .. }
+            | Event::Log { session_id, .. }
+            | Event::Progress { session_id, .. }
+            | Event::Message { session_id, .. }
             | Event::PmThinking { session_id, .. }
             | Event::PmDelegating { session_id, .. }
             | Event::AgentSpawned { session_id, .. }
@@ -300,19 +386,116 @@ impl Event {
             Event::Ping => None,
         }
     }
+
+    /// The stable `kind` string for this event — identical to the serde
+    /// `"type"` tag `#[serde(tag = "type", rename_all = "snake_case")]`
+    /// produces on the wire.
+    ///
+    /// Why (#2055): `SessionEventEnvelope` carries `kind` as a top-level
+    /// field (vision spec's envelope requirement) so a client can filter/
+    /// route on it without parsing into the nested `event` payload. Hand-
+    /// written rather than derived from serde reflection (no such API exists
+    /// without an extra dependency) — `kind_matches_serde_tag_for_every_variant`
+    /// guards the two from drifting apart.
+    /// What: Returns the exact snake_case tag string for every variant.
+    /// Test: `kind_matches_serde_tag_for_every_variant`.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Event::SessionStarted { .. } => "session_started",
+            Event::SessionDone { .. } => "session_done",
+            Event::SessionCancelled { .. } => "session_cancelled",
+            Event::SessionStatusChanged { .. } => "session_status_changed",
+            Event::SessionInput { .. } => "session_input",
+            Event::ToolStarted { .. } => "tool_started",
+            Event::ToolFinished { .. } => "tool_finished",
+            Event::ToolError { .. } => "tool_error",
+            Event::Log { .. } => "log",
+            Event::Progress { .. } => "progress",
+            Event::Message { .. } => "message",
+            Event::PmThinking { .. } => "pm_thinking",
+            Event::PmDelegating { .. } => "pm_delegating",
+            Event::AgentSpawned { .. } => "agent_spawned",
+            Event::AgentMessage { .. } => "agent_message",
+            Event::AgentDone { .. } => "agent_done",
+            Event::AgentFailed { .. } => "agent_failed",
+            Event::ToolCalled { .. } => "tool_called",
+            Event::ToolResult { .. } => "tool_result",
+            Event::AstOperation { .. } => "ast_operation",
+            Event::PhaseStarted { .. } => "phase_started",
+            Event::PhaseDone { .. } => "phase_done",
+            Event::PhaseSkipped { .. } => "phase_skipped",
+            Event::PersonaDetected { .. } => "persona_detected",
+            Event::LlmRequested { .. } => "llm_requested",
+            Event::LlmResponded { .. } => "llm_responded",
+            Event::AgentStarted { .. } => "agent_started",
+            Event::ReportGenerated { .. } => "report_generated",
+            Event::RecapGenerated { .. } => "recap_generated",
+            Event::Ping => "ping",
+        }
+    }
+}
+
+/// The stable, sequenced wire envelope for one session's event (#2055).
+///
+/// Why: `session.attach`'s ring-buffer replay and every live notification
+/// thereafter (both STDIO `session.event` notifications and the HTTP
+/// `GET /sessions/{id}/events` SSE stream) need the SAME shape so a client
+/// can detect gaps and stitch replay -> live into one ordered stream. See
+/// the module docs for how this aligns with / diverges from
+/// `trusty-agents-common`'s `HarnessEvent` convention.
+/// What: `session_id` (always present — every event this daemon emits is
+/// session-scoped), `seq` (per-session monotonic, assigned by
+/// `session::registry::SessionRegistry::record`, starting at 1), `at` (UTC
+/// emit timestamp), `kind` (== `event.kind()`, duplicated at the top level
+/// for cheap client-side filtering), and `event` (the full tagged payload).
+/// Test: `session_event_envelope_round_trips_through_json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionEventEnvelope {
+    pub session_id: String,
+    pub seq: u64,
+    pub at: DateTime<Utc>,
+    pub kind: String,
+    pub event: Event,
+}
+
+impl SessionEventEnvelope {
+    /// Build an envelope for `event`, computing `kind` from
+    /// [`Event::kind`].
+    ///
+    /// Why: the one place `kind` is derived from `event`, so the two can
+    /// never be constructed out of sync.
+    /// What: `session_id`/`seq`/`at` are supplied by the caller (the
+    /// registry, which owns the per-session sequence counter); `kind` is
+    /// computed here.
+    /// Test: `session_event_envelope_round_trips_through_json`.
+    pub fn new(session_id: String, seq: u64, at: DateTime<Utc>, event: Event) -> Self {
+        let kind = event.kind().to_string();
+        Self {
+            session_id,
+            seq,
+            at,
+            kind,
+            event,
+        }
+    }
 }
 
 /// Process-global event bus, initialised on first access.
 ///
-/// Why: Threading a `broadcast::Sender<Event>` through every code path that
-/// might want to emit telemetry (workflow engine, agent runners, ctrl) would
-/// touch hundreds of function signatures. A `OnceLock` mirrors how `tracing`
-/// solves the same problem — emit-from-anywhere with zero overhead when no
-/// one is listening.
+/// Why: Threading a `broadcast::Sender<SessionEventEnvelope>` through every
+/// code path that might want to emit telemetry (workflow engine, agent
+/// runners, ctrl) would touch hundreds of function signatures. A `OnceLock`
+/// mirrors how `tracing` solves the same problem — emit-from-anywhere with
+/// zero overhead when no one is listening. Carries the full envelope
+/// (#2055), not a bare `Event`, since every current producer
+/// (`session::registry::SessionRegistry`) and every current consumer (the
+/// STDIO forwarder, the HTTP SSE route) is session-scoped and needs `seq`/
+/// `at`/`kind` alongside the payload — see the module docs for the
+/// `HarnessEvent` alignment/divergence rationale.
 /// What: `Sender::send` is non-blocking; when there are no subscribers it
 /// returns an error which we silently drop (events without listeners are
 /// the expected baseline).
-static EVENT_BUS: OnceLock<broadcast::Sender<Event>> = OnceLock::new();
+static EVENT_BUS: OnceLock<broadcast::Sender<SessionEventEnvelope>> = OnceLock::new();
 
 /// Get (or initialise) the process-global event bus sender.
 ///
@@ -322,7 +505,7 @@ static EVENT_BUS: OnceLock<broadcast::Sender<Event>> = OnceLock::new();
 /// What: Returns a clone of the global sender. The receiver half is created
 /// per subscriber via `subscribe()`.
 /// Test: `bus_is_singleton` confirms repeated calls return the same channel.
-pub fn bus() -> broadcast::Sender<Event> {
+pub fn bus() -> broadcast::Sender<SessionEventEnvelope> {
     EVENT_BUS
         .get_or_init(|| broadcast::channel(CHANNEL_CAPACITY).0)
         .clone()
@@ -335,21 +518,24 @@ pub fn bus() -> broadcast::Sender<Event> {
 /// What: Returns a new `Receiver` that begins receiving events emitted after
 /// the call returns. Lagged subscribers receive `RecvError::Lagged(n)` and
 /// can resume.
-pub fn subscribe() -> broadcast::Receiver<Event> {
+pub fn subscribe() -> broadcast::Receiver<SessionEventEnvelope> {
     bus().subscribe()
 }
 
-/// Publish one event to the bus (best-effort, never panics).
+/// Publish one envelope to the bus (best-effort, never panics).
 ///
 /// Why: Most callers don't care whether anyone is listening — events are
-/// telemetry, not control flow. Failures (no subscribers) are normal.
-/// What: Sends the event on the broadcast channel, ignoring `SendError`.
+/// telemetry, not control flow. Failures (no subscribers) are normal. The
+/// envelope (not a bare `Event`) is the unit of publication so `seq`/`at`
+/// travel with the payload to every subscriber, including a client that
+/// only just attached.
+/// What: Sends the envelope on the broadcast channel, ignoring `SendError`.
 /// Test: `publish_round_trips_through_subscribe`.
-pub fn publish(event: Event) {
-    let _ = bus().send(event);
+pub fn publish(envelope: SessionEventEnvelope) {
+    let _ = bus().send(envelope);
 }
 
-/// Publish an event AND emit it on stderr with the `__OMPM_EVENT__` prefix
+/// Publish an envelope AND emit it on stderr with the `__OMPM_EVENT__` prefix
 /// so a parent process can re-broadcast on its own bus.
 ///
 /// Why: Workflow runs spawn as `open-mpm --workflow ...` subprocesses of the
@@ -357,14 +543,14 @@ pub fn publish(event: Event) {
 /// reach the parent's bus only via the existing stderr stream. This helper
 /// does both in one call so emit sites don't have to know whether they're
 /// running as a child.
-/// What: Calls `publish(event.clone())` for in-process subscribers, then
+/// What: Calls `publish(envelope.clone())` for in-process subscribers, then
 /// writes one NDJSON line to stderr prefixed with `__OMPM_EVENT__ `. The
 /// parent's stderr reader (in `api::server::run_task`) detects the prefix
 /// and re-publishes on its own bus.
 /// Test: Indirect — exercised by the workflow integration path.
-pub fn emit(event: Event) {
-    publish(event.clone());
-    if let Ok(line) = serde_json::to_string(&event) {
+pub fn emit(envelope: SessionEventEnvelope) {
+    publish(envelope.clone());
+    if let Ok(line) = serde_json::to_string(&envelope) {
         eprintln!("{EVENT_LINE_PREFIX}{line}");
     }
 }
@@ -427,21 +613,31 @@ mod tests {
         // Two senders to the same channel: a message sent on `a` should be
         // visible to a receiver from `b`.
         let mut rx = b.subscribe();
-        let _ = a.send(Event::Ping);
+        let envelope = SessionEventEnvelope::new("s-bus".into(), 1, Utc::now(), Event::Ping);
+        let _ = a.send(envelope);
         // Drain via try_recv to avoid an async runtime in this sync test.
-        let got = rx.try_recv().expect("expected ping");
-        assert!(matches!(got, Event::Ping));
+        let got = rx.try_recv().expect("expected an envelope");
+        assert!(matches!(got.event, Event::Ping));
     }
 
     #[tokio::test]
     async fn publish_round_trips_through_subscribe() {
         let mut rx = subscribe();
-        publish(Event::SessionStarted {
-            session_id: "t1".into(),
-            project: "demo".into(),
-        });
+        let envelope = SessionEventEnvelope::new(
+            "t1".into(),
+            1,
+            Utc::now(),
+            Event::SessionStarted {
+                session_id: "t1".into(),
+                project: "demo".into(),
+            },
+        );
+        publish(envelope);
         let got = rx.recv().await.unwrap();
-        match got {
+        assert_eq!(got.session_id, "t1");
+        assert_eq!(got.seq, 1);
+        assert_eq!(got.kind, "session_started");
+        match got.event {
             Event::SessionStarted {
                 session_id,
                 project,
@@ -451,6 +647,98 @@ mod tests {
             }
             other => panic!("unexpected event: {other:?}"),
         }
+    }
+
+    /// `kind()` must match the serde `"type"` tag for every variant — the
+    /// guard `SessionEventEnvelope::new`'s doc comment references.
+    #[test]
+    fn kind_matches_serde_tag_for_every_variant() {
+        let samples: Vec<Event> = vec![
+            Event::SessionStarted {
+                session_id: "s".into(),
+                project: "p".into(),
+            },
+            Event::SessionDone {
+                session_id: "s".into(),
+                status: "done".into(),
+            },
+            Event::SessionCancelled {
+                session_id: "s".into(),
+            },
+            Event::SessionStatusChanged {
+                session_id: "s".into(),
+                status: "running".into(),
+            },
+            Event::SessionInput {
+                session_id: "s".into(),
+                input: "hi".into(),
+            },
+            Event::ToolStarted {
+                session_id: "s".into(),
+                tool: "bash".into(),
+                call_id: "c1".into(),
+                args_preview: "ls".into(),
+            },
+            Event::ToolFinished {
+                session_id: "s".into(),
+                tool: "bash".into(),
+                call_id: "c1".into(),
+                success: true,
+                result_preview: "ok".into(),
+            },
+            Event::ToolError {
+                session_id: "s".into(),
+                tool: "bash".into(),
+                call_id: "c1".into(),
+                error: "boom".into(),
+            },
+            Event::Log {
+                session_id: "s".into(),
+                level: "info".into(),
+                message: "m".into(),
+            },
+            Event::Progress {
+                session_id: "s".into(),
+                message: "m".into(),
+                percent: None,
+            },
+            Event::Message {
+                session_id: "s".into(),
+                text: "hi".into(),
+            },
+            Event::Ping,
+        ];
+        for ev in samples {
+            let value = serde_json::to_value(&ev).unwrap();
+            let wire_type = value["type"].as_str().unwrap_or("ping");
+            assert_eq!(
+                ev.kind(),
+                wire_type,
+                "kind() drifted from the serde tag for {ev:?}"
+            );
+        }
+    }
+
+    /// `SessionEventEnvelope` must round-trip through JSON with every field
+    /// present, and `kind` must be derived from `event.kind()`.
+    #[test]
+    fn session_event_envelope_round_trips_through_json() {
+        let event = Event::SessionInput {
+            session_id: "s1".into(),
+            input: "hello".into(),
+        };
+        let envelope = SessionEventEnvelope::new("s1".into(), 7, Utc::now(), event);
+
+        let value = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(value["session_id"], "s1");
+        assert_eq!(value["seq"], 7);
+        assert_eq!(value["kind"], "session_input");
+        assert_eq!(value["event"]["type"], "session_input");
+        assert!(value["at"].is_string());
+
+        let back: SessionEventEnvelope = serde_json::from_value(value).unwrap();
+        assert_eq!(back.session_id, "s1");
+        assert_eq!(back.seq, 7);
     }
 
     #[test]

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -164,15 +164,19 @@ async fn session_events_sse(
         (axum::http::StatusCode::NOT_FOUND, Json(body))
     })?;
 
-    let replay_stream = stream::iter(replay.into_iter().map(|event| Ok(sse_event_for(&event))));
+    let replay_stream = stream::iter(
+        replay
+            .into_iter()
+            .map(|envelope| Ok(sse_event_for(&envelope))),
+    );
 
     let filter_id = session_id.clone();
     let live_stream = BroadcastStream::new(crate::events::subscribe()).filter_map(move |item| {
         let filter_id = filter_id.clone();
         async move {
             match item {
-                Ok(event) if event.session_id() == Some(filter_id.as_str()) => {
-                    Some(Ok(sse_event_for(&event)))
+                Ok(envelope) if envelope.session_id == filter_id => {
+                    Some(Ok(sse_event_for(&envelope)))
                 }
                 _ => None,
             }
@@ -182,17 +186,22 @@ async fn session_events_sse(
     Ok(Sse::new(replay_stream.chain(live_stream)).keep_alive(KeepAlive::default()))
 }
 
-/// Serialise one `crate::events::Event` as an SSE `data:` frame.
+/// Serialise one `crate::events::SessionEventEnvelope` as an SSE `data:`
+/// frame.
 ///
-/// Why: centralises the (practically infallible — `Event` has no untagged
-/// maps or non-string keys) JSON encoding so `session_events_sse` doesn't
-/// repeat the fallback logic at two call sites.
-/// What: `SseEvent::default().json_data(event)`, falling back to an empty
+/// Why: centralises the (practically infallible — the envelope has no
+/// untagged maps or non-string keys) JSON encoding so `session_events_sse`
+/// doesn't repeat the fallback logic at two call sites. Sending the full
+/// envelope (not just the bare `event`) means the HTTP SSE transport carries
+/// exactly the same `session_id`/`seq`/`at`/`kind`/`event` shape the STDIO
+/// `session.event` notification does (#2055 requirement: both transports
+/// carry the full taxonomy with the envelope).
+/// What: `SseEvent::default().json_data(envelope)`, falling back to an empty
 /// JSON object on the (unreachable in practice) serialisation error rather
 /// than `unwrap`ing.
-fn sse_event_for(event: &crate::events::Event) -> SseEvent {
+fn sse_event_for(envelope: &crate::events::SessionEventEnvelope) -> SseEvent {
     SseEvent::default()
-        .json_data(event)
+        .json_data(envelope)
         .unwrap_or_else(|_| SseEvent::default().data("{}"))
 }
 
@@ -396,6 +405,13 @@ mod tests {
         assert!(text.contains("session_started"), "body so far: {text}");
         assert!(
             text.contains("session_status_changed"),
+            "body so far: {text}"
+        );
+        // #2055: the SSE frames must carry the full envelope, not a bare
+        // event — `seq` and the top-level `kind` field must both appear.
+        assert!(text.contains("\"seq\":1"), "body so far: {text}");
+        assert!(
+            text.contains("\"kind\":\"session_started\""),
             "body so far: {text}"
         );
     }

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -1,25 +1,30 @@
-//! Daemon-owned session registry: storage, ring buffer, and attach/detach
-//! bookkeeping (#2054).
+//! Daemon-owned session registry: storage, per-session sequencing, ring
+//! buffer, and attach/detach bookkeeping (#2054, #2055).
 //!
 //! Why: this is the object Axiom 4 describes — sessions live INSIDE the
 //! daemon, not in a CLI-side tmux pane. `SessionRegistry` is the single
-//! owner of every `Session`'s state and its bounded event history, and the
-//! only place that decides who currently gets a session's live events.
-//! Designed so persistence (Phase 2+, out of scope per §12) can be added by
-//! swapping the storage backing this type without touching
+//! owner of every `Session`'s state, its bounded event history, and (#2055)
+//! the per-session sequence counter that makes replay -> live gap detection
+//! possible. Designed so persistence (Phase 2+, out of scope per §12) can be
+//! added by swapping the storage backing this type without touching
 //! `session::protocol`'s handlers or the wire protocol at all.
 //! What: [`SessionRegistry`] holds `HashMap<String, SessionEntry>` behind a
 //! `std::sync::Mutex` (never held across an `.await` — every method here is
 //! synchronous; `attach` uses `tokio::spawn` to hand off, not to block).
-//! Each entry carries the `Session` snapshot, a bounded ring buffer of
-//! recent `crate::events::Event`s (§12.1.5: default 1000, oldest dropped
-//! first), and a map of live attachments (`connection_id` ->
+//! Each entry carries the `Session` snapshot, a monotonic per-session `seq`
+//! counter, a bounded ring buffer of recent
+//! `crate::events::SessionEventEnvelope`s (§12.1.5: default 1000, oldest
+//! dropped first), and a map of live attachments (`connection_id` ->
 //! `oneshot::Sender<()>` used by `detach` to stop that connection's
-//! forwarder task). `attach` replays the ring buffer synchronously, then
-//! spawns a task that subscribes to the existing process-global
-//! `crate::events` bus, filters by `session_id`, and forwards matching
-//! events into the caller's `NotifySender` until detached or the channel
-//! closes (the connection is gone).
+//! forwarder task). [`Self::record`] is the ONE place that assigns `seq`
+//! (under the same lock that pushes the ring buffer entry), so replay and
+//! every subsequent live event share one gap-free, strictly increasing
+//! sequence — see `crate::events`'s module docs for the full envelope
+//! rationale. `attach` replays the ring buffer synchronously, then spawns a
+//! task that subscribes to the existing process-global `crate::events` bus,
+//! filters by `session_id`, and forwards matching envelopes into the
+//! caller's `NotifySender` until detached or the channel closes (the
+//! connection is gone).
 //! Test: see `registry_tests` (sibling file, `#[cfg(test)]`).
 
 use std::collections::{HashMap, VecDeque};
@@ -30,7 +35,7 @@ use serde_json::json;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
-use crate::events::Event;
+use crate::events::{Event, SessionEventEnvelope};
 use crate::jsonrpc::{NotifySender, RpcError};
 
 use super::model::{Session, SessionStatus};
@@ -40,15 +45,18 @@ use super::model::{Session, SessionStatus};
 /// Why: bounds per-session memory use; a freshly-attached client sees
 /// "recent progress but not the full session history" per spec, with full
 /// history reserved for a future `session.get_transcript` (out of scope for
-/// #2054 — not in this issue's method list).
+/// #2054/#2055 — not in either issue's method list).
 /// Test: `registry_tests::ring_buffer_drops_oldest_when_full`.
 pub const DEFAULT_RING_CAPACITY: usize = 1000;
 
-/// One session's storage: the domain snapshot, its ring buffer, and the
-/// live attachments forwarding its events.
+/// One session's storage: the domain snapshot, its sequence counter, ring
+/// buffer, and the live attachments forwarding its events.
 struct SessionEntry {
     session: Session,
-    ring: VecDeque<Event>,
+    /// Last-assigned per-session sequence number; the next event gets
+    /// `seq + 1`. Starts at `0` so the first recorded event is `seq = 1`.
+    seq: u64,
+    ring: VecDeque<SessionEventEnvelope>,
     /// `connection_id` -> the cancel sender for that connection's forwarder
     /// task. Re-attaching the same connection to the same session replaces
     /// (and thus cancels, via `Sender` drop) the previous forwarder.
@@ -96,12 +104,13 @@ impl SessionRegistry {
     /// Why: the sole entry point that mints a session id and puts a
     /// `Session` into the registry.
     /// What: builds a `Session` with a fresh UUIDv4 id and
-    /// `status = Created`, inserts it, publishes `Event::SessionStarted`,
-    /// then immediately transitions to `Running` (M1 has no queue ahead of
-    /// real task execution — see `session::model` docs) which publishes
-    /// `Event::SessionStatusChanged`. Returns the post-transition snapshot
-    /// (so the caller sees `status: "running"`, not the momentary
-    /// `"created"`).
+    /// `status = Created`, inserts it (with a fresh `seq = 0` counter),
+    /// publishes `Event::SessionStarted` (assigned `seq = 1`), then
+    /// immediately transitions to `Running` (M1 has no queue ahead of real
+    /// task execution — see `session::model` docs) which publishes
+    /// `Event::SessionStatusChanged` (`seq = 2`). Returns the
+    /// post-transition snapshot (so the caller sees `status: "running"`,
+    /// not the momentary `"created"`).
     /// Test: `registry_tests::create_publishes_started_and_status_events`.
     pub fn create(&self, task: String, agent: Option<String>, project: Option<String>) -> Session {
         let id = Uuid::new_v4().to_string();
@@ -119,6 +128,7 @@ impl SessionRegistry {
                 id.clone(),
                 SessionEntry {
                     session: session.clone(),
+                    seq: 0,
                     ring: VecDeque::new(),
                     attachments: HashMap::new(),
                 },
@@ -163,8 +173,8 @@ impl SessionRegistry {
     /// `session.send`: deliver input to a session and publish an observable
     /// event proving the daemon received it.
     ///
-    /// Why: #2054 does not wire a real agent loop (that is `task.*`, #2056);
-    /// publishing `Event::SessionInput` is what makes `session.send`
+    /// Why: #2054/#2055 do not wire a real agent loop (that is `task.*`,
+    /// #2056); publishing `Event::SessionInput` is what makes `session.send`
     /// observably reach a `session.attach`ed client NOW, and gives #2056 a
     /// concrete event to build real echo/ack behaviour on top of.
     /// What: errors with `session_not_found` if `id` is unknown; otherwise
@@ -189,17 +199,20 @@ impl SessionRegistry {
     /// terminal.
     ///
     /// Why: vision spec §12 (11.6) Cancellation Semantics — cancellation is
-    /// a status transition + event, not a deletion. #2054 has no in-flight
-    /// agent loop to interrupt yet (that lands with #2056), so this is the
-    /// full implementation available today: it marks the session
-    /// `Cancelled` and publishes the terminal events; #2056 hooks the actual
-    /// agent-loop interrupt onto the same status transition.
+    /// a status transition + event, not a deletion. #2054/#2055 have no
+    /// in-flight agent loop to interrupt yet (that lands with #2056), so
+    /// this is the full implementation available today: it marks the
+    /// session `Cancelled` and publishes the terminal events; #2056 hooks
+    /// the actual agent-loop interrupt onto the same status transition.
     /// What: idempotent — cancelling an already-terminal session is a no-op
     /// that returns the current snapshot rather than erroring (repeated
     /// `session.cancel` calls are safe). Errors with `session_not_found` if
-    /// `id` is unknown. On a live session: sets `status = Cancelled`,
-    /// publishes `Event::SessionStatusChanged` then `Event::SessionDone`
-    /// (`status: "cancelled"`), and returns the updated snapshot.
+    /// `id` is unknown. On a live session: publishes
+    /// `Event::SessionStatusChanged` (`status: "cancelled"`), then the
+    /// dedicated `Event::SessionCancelled` signal, then the generic terminal
+    /// `Event::SessionDone` (`status: "cancelled"`) — matching the vision
+    /// spec's `started/status-changed/input/cancelled/done` taxonomy — and
+    /// returns the updated snapshot.
     /// Test: `registry_tests::cancel_transitions_to_cancelled_and_publishes`,
     /// `registry_tests::cancel_is_idempotent_on_terminal_session`,
     /// `registry_tests::cancel_unknown_session_errors`.
@@ -215,6 +228,12 @@ impl SessionRegistry {
             return self.status(id);
         }
         self.transition(id, SessionStatus::Cancelled);
+        self.record(
+            id,
+            Event::SessionCancelled {
+                session_id: id.to_string(),
+            },
+        );
         self.record(
             id,
             Event::SessionDone {
@@ -236,24 +255,30 @@ impl SessionRegistry {
     /// `crate::jsonrpc::ConnectionContext`'s docs and `crate::serve`'s
     /// transports, not here.
     /// What: errors with `session_not_found` if `id` is unknown. Otherwise
-    /// takes a snapshot of the ring buffer (oldest-first) to return as the
+    /// takes a snapshot of the ring buffer (oldest-first, each entry a full
+    /// [`SessionEventEnvelope`] with its `seq` intact) to return as the
     /// replay, registers `connection_id`'s cancel sender (replacing — and
     /// thus cancelling — any prior forwarder for the same
     /// `(session, connection)` pair), and spawns a task that subscribes to
     /// `crate::events::subscribe()`, filters by `session_id`, and forwards
-    /// each match into `notify` as a JSON-RPC notification
-    /// (`{"jsonrpc":"2.0","method":"session.event","params":{...}}`) until
-    /// `detach` fires the cancel sender or `notify.send` fails (the
-    /// connection is gone).
+    /// each match into `notify` as a JSON-RPC notification whose `params` IS
+    /// the envelope (`{"jsonrpc":"2.0","method":"session.event","params":
+    /// {"session_id":...,"seq":...,"at":...,"kind":...,"event":{...}}}`)
+    /// until `detach` fires the cancel sender or `notify.send` fails (the
+    /// connection is gone). Because every envelope — replayed or live —
+    /// comes from the SAME per-session `seq` counter (`record`), a client
+    /// that concatenates the replay array with the live notifications it
+    /// receives afterward sees one gap-free, strictly increasing sequence.
     /// Test: `registry_tests::attach_returns_ring_buffer_replay`,
     /// `registry_tests::attach_forwards_live_events_until_detach`,
+    /// `registry_tests::attach_replay_then_live_seq_is_contiguous`,
     /// `registry_tests::attach_unknown_session_errors`.
     pub fn attach(
         &self,
         id: &str,
         connection_id: Uuid,
         notify: NotifySender,
-    ) -> Result<Vec<Event>, RpcError> {
+    ) -> Result<Vec<SessionEventEnvelope>, RpcError> {
         let replay = {
             let mut sessions = self.lock();
             let entry = sessions
@@ -298,36 +323,183 @@ impl SessionRegistry {
     /// `Stream` per SSE connection) rather than going through a
     /// `NotifySender` forwarder — so it calls this directly instead of
     /// `attach`.
-    /// What: same replay semantics as `attach`, no side effects (no
-    /// forwarder spawned, no attachment recorded).
+    /// What: same replay semantics as `attach` (full envelopes, `seq`
+    /// intact), no side effects (no forwarder spawned, no attachment
+    /// recorded).
     /// Test: `registry_tests::replay_returns_ring_buffer_without_attaching`.
-    pub fn replay(&self, id: &str) -> Result<Vec<Event>, RpcError> {
+    pub fn replay(&self, id: &str) -> Result<Vec<SessionEventEnvelope>, RpcError> {
         self.lock()
             .get(id)
             .map(|e| e.ring.iter().cloned().collect())
             .ok_or_else(|| RpcError::session_not_found(id))
     }
 
-    /// Record `event` onto `id`'s ring buffer (evicting the oldest entry if
-    /// full) and publish it on the process-global bus.
+    /// Record a tool invocation starting (#2055 emission plumbing for
+    /// #2056's agent loop).
     ///
-    /// Why: every lifecycle event goes through this one function so the
-    /// ring buffer and the live bus can never drift out of sync with each
-    /// other.
-    /// What: a no-op ring push (but still publishes) if `id` is unknown —
-    /// callers that need a hard error check existence first (`send`,
-    /// `cancel`, etc. all do).
-    fn record(&self, id: &str, event: Event) {
-        {
-            let mut sessions = self.lock();
-            if let Some(entry) = sessions.get_mut(id) {
-                if entry.ring.len() >= self.ring_capacity {
-                    entry.ring.pop_front();
-                }
-                entry.ring.push_back(event.clone());
-            }
+    /// Why: gives the future agent loop a stable, already-wired call for
+    /// `ToolStarted` without it needing to touch the ring buffer, sequencing,
+    /// or bus directly.
+    /// What: errors with `session_not_found` if `id` is unknown; `args_preview`
+    /// is truncated via `crate::events::preview` before emission so a large
+    /// argument payload can't blow the ring buffer / wire size.
+    /// Test: `registry_tests::record_tool_started_publishes_event`.
+    pub fn record_tool_started(
+        &self,
+        id: &str,
+        tool: &str,
+        call_id: &str,
+        args: &str,
+    ) -> Result<(), RpcError> {
+        self.ensure_exists(id)?;
+        self.record(
+            id,
+            Event::ToolStarted {
+                session_id: id.to_string(),
+                tool: tool.to_string(),
+                call_id: call_id.to_string(),
+                args_preview: crate::events::preview(args, 500),
+            },
+        );
+        Ok(())
+    }
+
+    /// Record a tool invocation finishing (#2055 emission plumbing for
+    /// #2056's agent loop). See [`Self::record_tool_started`].
+    /// Test: `registry_tests::record_tool_finished_publishes_event`.
+    pub fn record_tool_finished(
+        &self,
+        id: &str,
+        tool: &str,
+        call_id: &str,
+        success: bool,
+        result: &str,
+    ) -> Result<(), RpcError> {
+        self.ensure_exists(id)?;
+        self.record(
+            id,
+            Event::ToolFinished {
+                session_id: id.to_string(),
+                tool: tool.to_string(),
+                call_id: call_id.to_string(),
+                success,
+                result_preview: crate::events::preview(result, 500),
+            },
+        );
+        Ok(())
+    }
+
+    /// Record a tool invocation raising an exceptional error (#2055 emission
+    /// plumbing for #2056's agent loop). See [`Self::record_tool_started`].
+    /// Test: `registry_tests::record_tool_error_publishes_event`.
+    pub fn record_tool_error(
+        &self,
+        id: &str,
+        tool: &str,
+        call_id: &str,
+        error: &str,
+    ) -> Result<(), RpcError> {
+        self.ensure_exists(id)?;
+        self.record(
+            id,
+            Event::ToolError {
+                session_id: id.to_string(),
+                tool: tool.to_string(),
+                call_id: call_id.to_string(),
+                error: error.to_string(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Record a session-scoped diagnostic log line (#2055 emission plumbing).
+    /// Test: `registry_tests::record_log_publishes_event`.
+    pub fn record_log(&self, id: &str, level: &str, message: &str) -> Result<(), RpcError> {
+        self.ensure_exists(id)?;
+        self.record(
+            id,
+            Event::Log {
+                session_id: id.to_string(),
+                level: level.to_string(),
+                message: message.to_string(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Record a coarse progress update (#2055 emission plumbing).
+    /// Test: `registry_tests::record_progress_publishes_event`.
+    pub fn record_progress(
+        &self,
+        id: &str,
+        message: &str,
+        percent: Option<f32>,
+    ) -> Result<(), RpcError> {
+        self.ensure_exists(id)?;
+        self.record(
+            id,
+            Event::Progress {
+                session_id: id.to_string(),
+                message: message.to_string(),
+                percent,
+            },
+        );
+        Ok(())
+    }
+
+    /// Record a generic freeform session message (#2055 emission plumbing).
+    /// Test: `registry_tests::record_message_publishes_event`.
+    pub fn record_message(&self, id: &str, text: &str) -> Result<(), RpcError> {
+        self.ensure_exists(id)?;
+        self.record(
+            id,
+            Event::Message {
+                session_id: id.to_string(),
+                text: text.to_string(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Return `Ok(())` if `id` exists, `Err(session_not_found)` otherwise.
+    ///
+    /// Why: every `record_*` plumbing method needs the same existence guard
+    /// before recording; centralising it keeps each one a two-line body.
+    fn ensure_exists(&self, id: &str) -> Result<(), RpcError> {
+        if self.lock().contains_key(id) {
+            Ok(())
+        } else {
+            Err(RpcError::session_not_found(id))
         }
-        crate::events::publish(event);
+    }
+
+    /// Assign the next per-session `seq`, wrap `event` in a
+    /// [`SessionEventEnvelope`], push it onto `id`'s ring buffer (evicting
+    /// the oldest entry if full), and publish the envelope on the
+    /// process-global bus.
+    ///
+    /// Why: every lifecycle/tool/log/progress/message event goes through
+    /// this ONE function so `seq` assignment, the ring buffer, and the live
+    /// bus can never drift out of sync with each other — the correctness
+    /// property `attach_replay_then_live_seq_is_contiguous` verifies.
+    /// What: a no-op (no envelope built, nothing published) if `id` is
+    /// unknown — callers that need a hard error check existence first
+    /// (`send`, `cancel`, every `record_*` plumbing method all do).
+    fn record(&self, id: &str, event: Event) {
+        let envelope = {
+            let mut sessions = self.lock();
+            let Some(entry) = sessions.get_mut(id) else {
+                return;
+            };
+            entry.seq += 1;
+            let envelope = SessionEventEnvelope::new(id.to_string(), entry.seq, Utc::now(), event);
+            if entry.ring.len() >= self.ring_capacity {
+                entry.ring.pop_front();
+            }
+            entry.ring.push_back(envelope.clone());
+            envelope
+        };
+        crate::events::publish(envelope);
     }
 
     /// Update a session's status in place, then record+publish
@@ -361,8 +533,8 @@ impl SessionRegistry {
     }
 }
 
-/// Spawn the background task that forwards one session's live events to a
-/// connection until cancelled or the connection is gone.
+/// Spawn the background task that forwards one session's live event
+/// envelopes to a connection until cancelled or the connection is gone.
 ///
 /// Why: split out of `attach` for readability; also gives `registry_tests`
 /// a single well-named spawn site to reason about. Subscribing to the bus
@@ -373,11 +545,12 @@ impl SessionRegistry {
 /// and subscribes, and `broadcast::Receiver`s only see events published
 /// after `subscribe()` was called — the event would be silently missed.
 /// What: subscribes to `crate::events::subscribe()` immediately, then
-/// spawns a task that forwards events whose `session_id()` matches
-/// `session_id` as a JSON-RPC notification via `notify`, skips events for
-/// other sessions and lag gaps, and exits on `cancel_rx` firing (either a
-/// real detach or the sender being dropped) or `notify.send` failing
-/// (connection gone).
+/// spawns a task that forwards envelopes whose `session_id` matches
+/// `session_id` as a JSON-RPC notification via `notify` (`params` is the
+/// envelope itself — `seq`/`at`/`kind`/`event` all present), skips
+/// envelopes for other sessions and lag gaps, and exits on `cancel_rx`
+/// firing (either a real detach or the sender being dropped) or
+/// `notify.send` failing (connection gone).
 /// Test: `registry_tests::attach_forwards_live_events_until_detach`.
 fn spawn_forwarder(session_id: String, notify: NotifySender, cancel_rx: oneshot::Receiver<()>) {
     use tokio::sync::broadcast::error::RecvError;
@@ -393,11 +566,11 @@ fn spawn_forwarder(session_id: String, notify: NotifySender, cancel_rx: oneshot:
                 biased;
                 _ = &mut cancel_rx => break,
                 received = events.recv() => match received {
-                    Ok(event) if event.session_id() == Some(session_id.as_str()) => {
+                    Ok(envelope) if envelope.session_id == session_id => {
                         let notification = json!({
                             "jsonrpc": "2.0",
                             "method": "session.event",
-                            "params": { "session_id": session_id, "event": event },
+                            "params": envelope,
                         });
                         if notify.send(notification).is_err() {
                             break;

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -1,6 +1,7 @@
-//! Unit tests for `SessionRegistry` (#2054). Split out of `registry.rs` per
-//! the crate's `_tests.rs` sibling-file convention (see `intent::classifier_tests`
-//! for precedent) to keep the production file under the 500-SLOC cap.
+//! Unit tests for `SessionRegistry` (#2054, #2055). Split out of
+//! `registry.rs` per the crate's `_tests.rs` sibling-file convention (see
+//! `intent::classifier_tests` for precedent) to keep the production file
+//! under the 500-SLOC cap.
 
 use super::*;
 use tokio::sync::broadcast;
@@ -12,23 +13,26 @@ fn notify_channel() -> (NotifySender, mpsc::UnboundedReceiver<serde_json::Value>
     mpsc::unbounded_channel()
 }
 
-/// Read from the process-global event bus until an event matching
+/// Read from the process-global event bus until an envelope matching
 /// `session_id` arrives, ignoring anything else.
 ///
 /// Why: `crate::events::bus()` is a single process-wide singleton shared by
 /// every test in this binary; cargo runs tests concurrently, so a raw
-/// `events.recv().await` can observe another test's unrelated event
+/// `events.recv().await` can observe another test's unrelated envelope
 /// interleaved on the same subscription. Filtering by `session_id` (unique
 /// per test via a fresh UUID) makes these tests robust to that interleaving
-/// instead of assuming "the very next event is mine". Bounded by a 2s
+/// instead of assuming "the very next envelope is mine". Bounded by a 2s
 /// timeout so a genuine bug (event never published) still fails fast
 /// instead of hanging.
-async fn next_event_for(rx: &mut broadcast::Receiver<Event>, session_id: &str) -> Event {
+async fn next_event_for(
+    rx: &mut broadcast::Receiver<SessionEventEnvelope>,
+    session_id: &str,
+) -> SessionEventEnvelope {
     timeout(Duration::from_secs(2), async {
         loop {
-            let ev = rx.recv().await.expect("event bus closed unexpectedly");
-            if ev.session_id() == Some(session_id) {
-                return ev;
+            let envelope = rx.recv().await.expect("event bus closed unexpectedly");
+            if envelope.session_id == session_id {
+                return envelope;
             }
         }
     })
@@ -36,8 +40,9 @@ async fn next_event_for(rx: &mut broadcast::Receiver<Event>, session_id: &str) -
     .expect("timed out waiting for an event on this session")
 }
 
-/// `create` must publish `SessionStarted` then `SessionStatusChanged` (to
-/// `"running"`), and the returned snapshot must already be `Running`.
+/// `create` must publish `SessionStarted` (seq 1) then `SessionStatusChanged`
+/// (seq 2, `status: "running"`), and the returned snapshot must already be
+/// `Running`.
 #[tokio::test]
 async fn create_publishes_started_and_status_events() {
     let registry = SessionRegistry::new();
@@ -47,10 +52,15 @@ async fn create_publishes_started_and_status_events() {
     assert_eq!(session.status, SessionStatus::Running);
 
     let first = next_event_for(&mut events, &session.id).await;
-    assert!(matches!(first, Event::SessionStarted { project, .. } if project == "proj"));
+    assert_eq!(first.seq, 1);
+    assert_eq!(first.kind, "session_started");
+    assert!(matches!(first.event, Event::SessionStarted { project, .. } if project == "proj"));
 
     let second = next_event_for(&mut events, &session.id).await;
-    assert!(matches!(second, Event::SessionStatusChanged { status, .. } if status == "running"));
+    assert_eq!(second.seq, 2);
+    assert!(
+        matches!(second.event, Event::SessionStatusChanged { status, .. } if status == "running")
+    );
 }
 
 /// `list` must return every created session.
@@ -79,8 +89,9 @@ async fn send_publishes_input_event() {
 
     registry.send(&session.id, "hello").unwrap();
 
-    let ev = next_event_for(&mut events, &session.id).await;
-    assert!(matches!(ev, Event::SessionInput { input, .. } if input == "hello"));
+    let envelope = next_event_for(&mut events, &session.id).await;
+    assert_eq!(envelope.seq, 3); // after SessionStarted(1), StatusChanged(2)
+    assert!(matches!(envelope.event, Event::SessionInput { input, .. } if input == "hello"));
 }
 
 /// `send` on an unknown session must error, not panic.
@@ -91,7 +102,9 @@ async fn send_unknown_session_errors() {
     assert_eq!(err.code, -32007);
 }
 
-/// `cancel` must transition to `Cancelled` and publish the terminal events.
+/// `cancel` must transition to `Cancelled` and publish the terminal events
+/// (`status_changed` -> `session_cancelled` -> `session_done`), each with a
+/// strictly increasing `seq`.
 #[tokio::test]
 async fn cancel_transitions_to_cancelled_and_publishes() {
     let registry = SessionRegistry::new();
@@ -103,10 +116,19 @@ async fn cancel_transitions_to_cancelled_and_publishes() {
 
     let status_changed = next_event_for(&mut events, &session.id).await;
     assert!(
-        matches!(status_changed, Event::SessionStatusChanged { status, .. } if status == "cancelled")
+        matches!(status_changed.event, Event::SessionStatusChanged { status, .. } if status == "cancelled")
     );
+
+    let cancelled_event = next_event_for(&mut events, &session.id).await;
+    assert!(matches!(
+        cancelled_event.event,
+        Event::SessionCancelled { .. }
+    ));
+    assert!(cancelled_event.seq > status_changed.seq);
+
     let done = next_event_for(&mut events, &session.id).await;
-    assert!(matches!(done, Event::SessionDone { status, .. } if status == "cancelled"));
+    assert!(matches!(done.event, Event::SessionDone { status, .. } if status == "cancelled"));
+    assert!(done.seq > cancelled_event.seq);
 
     // Idempotent: cancelling again returns the same terminal snapshot,
     // no error, no further events required.
@@ -122,7 +144,8 @@ async fn cancel_unknown_session_errors() {
     assert_eq!(err.code, -32007);
 }
 
-/// `attach` must replay the ring buffer accumulated so far.
+/// `attach` must replay the ring buffer accumulated so far, in order, with
+/// `seq` starting at 1 and increasing by 1 per entry.
 #[tokio::test]
 async fn attach_returns_ring_buffer_replay() {
     let registry = SessionRegistry::new();
@@ -132,13 +155,18 @@ async fn attach_returns_ring_buffer_replay() {
     let (tx, _rx) = notify_channel();
     let replay = registry.attach(&session.id, Uuid::new_v4(), tx).unwrap();
 
-    // SessionStarted, SessionStatusChanged(running), SessionInput(one).
+    // SessionStarted(1), SessionStatusChanged(2, running), SessionInput(3).
     assert_eq!(replay.len(), 3);
-    assert!(matches!(replay.last().unwrap(), Event::SessionInput { input, .. } if input == "one"));
+    let seqs: Vec<u64> = replay.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, vec![1, 2, 3]);
+    assert!(
+        matches!(&replay.last().unwrap().event, Event::SessionInput { input, .. } if input == "one")
+    );
 }
 
 /// After `attach`, a live event published on the session must be forwarded
-/// to the connection's notify channel as a JSON-RPC notification.
+/// to the connection's notify channel as a JSON-RPC notification whose
+/// `params` is the full envelope.
 #[tokio::test]
 async fn attach_forwards_live_events_until_detach() {
     let registry = SessionRegistry::new();
@@ -156,8 +184,11 @@ async fn attach_forwards_live_events_until_detach() {
         .expect("channel must still be open");
     assert_eq!(notification["method"], "session.event");
     assert_eq!(notification["params"]["session_id"], session.id);
+    assert_eq!(notification["params"]["seq"], 3);
+    assert_eq!(notification["params"]["kind"], "session_input");
     assert_eq!(notification["params"]["event"]["type"], "session_input");
     assert_eq!(notification["params"]["event"]["input"], "live");
+    assert!(notification["params"]["at"].is_string());
 
     registry.detach(&session.id, connection_id).unwrap();
     // The forwarder task is cancelled by waking its `select!` on a
@@ -178,6 +209,37 @@ async fn attach_forwards_live_events_until_detach() {
         Err(_) => {}   // timed out waiting: nothing arrived, good.
         Ok(None) => {} // channel closed: nothing arrived, good.
         Ok(Some(v)) => panic!("no event should arrive after detach, got {v:?}"),
+    }
+}
+
+/// Replay and live events must share ONE gap-free, strictly increasing
+/// `seq` — the correctness property the whole envelope design exists for.
+#[tokio::test]
+async fn attach_replay_then_live_seq_is_contiguous() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    registry.send(&session.id, "before-attach").unwrap();
+
+    let (tx, mut rx) = notify_channel();
+    let replay = registry.attach(&session.id, Uuid::new_v4(), tx).unwrap();
+    let last_replay_seq = replay.last().unwrap().seq;
+
+    registry.send(&session.id, "after-attach").unwrap();
+    let notification = timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("forwarder must deliver the live event")
+        .expect("channel must still be open");
+    let live_seq = notification["params"]["seq"].as_u64().unwrap();
+
+    assert_eq!(
+        live_seq,
+        last_replay_seq + 1,
+        "no gap and no duplicate between replay and live"
+    );
+
+    // The whole replay sequence itself must be gap-free from 1.
+    for (i, envelope) in replay.iter().enumerate() {
+        assert_eq!(envelope.seq, (i as u64) + 1);
     }
 }
 
@@ -229,10 +291,162 @@ async fn ring_buffer_drops_oldest_when_full() {
     let replay = registry.replay(&session.id).unwrap();
     assert_eq!(replay.len(), 2);
     assert!(matches!(
-        replay.first().unwrap(),
+        replay.first().unwrap().event,
         Event::SessionStatusChanged { .. }
     ));
     assert!(
-        matches!(replay.last().unwrap(), Event::SessionInput { input, .. } if input == "evicts-started")
+        matches!(&replay.last().unwrap().event, Event::SessionInput { input, .. } if input == "evicts-started")
+    );
+    // Eviction must not reset the seq counter — the surviving entries keep
+    // their original sequence numbers (2, 3), not renumbered to (1, 2).
+    let seqs: Vec<u64> = replay.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, vec![2, 3]);
+}
+
+/// `record_tool_started` must publish a `ToolStarted` event with a
+/// truncated `args_preview`.
+#[tokio::test]
+async fn record_tool_started_publishes_event() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    let mut events = crate::events::subscribe();
+
+    registry
+        .record_tool_started(&session.id, "bash", "call-1", "ls -la")
+        .unwrap();
+
+    let envelope = next_event_for(&mut events, &session.id).await;
+    assert_eq!(envelope.kind, "tool_started");
+    assert!(matches!(
+        envelope.event,
+        Event::ToolStarted { tool, call_id, args_preview, .. }
+            if tool == "bash" && call_id == "call-1" && args_preview == "ls -la"
+    ));
+}
+
+/// `record_tool_finished` must publish a `ToolFinished` event carrying
+/// `success` and a truncated `result_preview`.
+#[tokio::test]
+async fn record_tool_finished_publishes_event() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    let mut events = crate::events::subscribe();
+
+    registry
+        .record_tool_finished(&session.id, "bash", "call-1", true, "done")
+        .unwrap();
+
+    let envelope = next_event_for(&mut events, &session.id).await;
+    assert_eq!(envelope.kind, "tool_finished");
+    assert!(matches!(
+        envelope.event,
+        Event::ToolFinished { success, result_preview, .. } if success && result_preview == "done"
+    ));
+}
+
+/// `record_tool_error` must publish a `ToolError` event.
+#[tokio::test]
+async fn record_tool_error_publishes_event() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    let mut events = crate::events::subscribe();
+
+    registry
+        .record_tool_error(&session.id, "bash", "call-1", "timed out")
+        .unwrap();
+
+    let envelope = next_event_for(&mut events, &session.id).await;
+    assert_eq!(envelope.kind, "tool_error");
+    assert!(matches!(envelope.event, Event::ToolError { error, .. } if error == "timed out"));
+}
+
+/// `record_log` must publish a `Log` event.
+#[tokio::test]
+async fn record_log_publishes_event() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    let mut events = crate::events::subscribe();
+
+    registry
+        .record_log(&session.id, "warn", "disk almost full")
+        .unwrap();
+
+    let envelope = next_event_for(&mut events, &session.id).await;
+    assert_eq!(envelope.kind, "log");
+    assert!(
+        matches!(envelope.event, Event::Log { level, message, .. } if level == "warn" && message == "disk almost full")
+    );
+}
+
+/// `record_progress` must publish a `Progress` event.
+#[tokio::test]
+async fn record_progress_publishes_event() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    let mut events = crate::events::subscribe();
+
+    registry
+        .record_progress(&session.id, "indexing", Some(0.5))
+        .unwrap();
+
+    let envelope = next_event_for(&mut events, &session.id).await;
+    assert_eq!(envelope.kind, "progress");
+    assert!(matches!(envelope.event, Event::Progress { percent: Some(p), .. } if p == 0.5));
+}
+
+/// `record_message` must publish a `Message` event.
+#[tokio::test]
+async fn record_message_publishes_event() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    let mut events = crate::events::subscribe();
+
+    registry.record_message(&session.id, "hello world").unwrap();
+
+    let envelope = next_event_for(&mut events, &session.id).await;
+    assert_eq!(envelope.kind, "message");
+    assert!(matches!(envelope.event, Event::Message { text, .. } if text == "hello world"));
+}
+
+/// Every `record_*` emission-plumbing method must reject an unknown
+/// session id with `session_not_found` rather than panicking.
+#[tokio::test]
+async fn record_plumbing_methods_reject_unknown_session() {
+    let registry = SessionRegistry::new();
+    assert_eq!(
+        registry
+            .record_tool_started("nope", "t", "c", "a")
+            .unwrap_err()
+            .code,
+        -32007
+    );
+    assert_eq!(
+        registry
+            .record_tool_finished("nope", "t", "c", true, "r")
+            .unwrap_err()
+            .code,
+        -32007
+    );
+    assert_eq!(
+        registry
+            .record_tool_error("nope", "t", "c", "e")
+            .unwrap_err()
+            .code,
+        -32007
+    );
+    assert_eq!(
+        registry.record_log("nope", "info", "m").unwrap_err().code,
+        -32007
+    );
+    assert_eq!(
+        registry
+            .record_progress("nope", "m", None)
+            .unwrap_err()
+            .code,
+        -32007
+    );
+    assert_eq!(
+        registry.record_message("nope", "m").unwrap_err().code,
+        -32007
     );
 }

--- a/crates/trusty-code/tests/session_e2e.rs
+++ b/crates/trusty-code/tests/session_e2e.rs
@@ -1,4 +1,6 @@
-//! API-driven end-to-end test for the #2054 session lifecycle.
+//! API-driven end-to-end test for the #2054 session lifecycle, extended by
+//! #2055 to assert on the formalised event taxonomy + envelope over the
+//! real wire.
 //!
 //! Why: the vision spec's Testability requirement (§9, "100% CLI/API
 //! Testable" + "Per-Issue E2E Coverage") mandates that each issue's slice be
@@ -9,10 +11,15 @@
 //! its real stdin/stdout (and, for the HTTP half, real TCP + HTTP).
 //! What: [`session_lifecycle_over_stdio`] drives
 //! create -> attach -> send -> receive a streamed event -> detach -> status
-//! entirely over STDIO NDJSON. [`session_lifecycle_over_http_with_sse`]
-//! drives the same lifecycle over `POST /rpc` plus the
-//! `GET /sessions/{id}/events` SSE stream, proving the HTTP transport
-//! observably streams too (per the ticket's "cover both transports" ask).
+//! -> re-attach -> cancel entirely over STDIO NDJSON, asserting (#2055)
+//! that every envelope carries `session_id`/`seq`/`at`/`kind`/`event`, that
+//! every kind in the lifecycle taxonomy appears, and that `seq` is
+//! gap-free and strictly increasing across the WHOLE session (replay ->
+//! live -> re-attach's replay -> live again). [`session_lifecycle_over_http_with_sse`]
+//! drives the same lifecycle over `POST /rpc` plus a SINGLE
+//! `GET /sessions/{id}/events` SSE connection read in two stages (replay,
+//! then a live event on the SAME connection), proving replay -> live
+//! continuity over HTTP too.
 //! Test: this file IS the test; see `support` for the process/protocol
 //! plumbing shared by both scenarios.
 
@@ -20,13 +27,16 @@ mod support;
 
 use std::time::Duration;
 
-use serde_json::{Value, json};
+use serde_json::json;
 use support::{
-    StdioSession, find_response, find_session_event, http_get_prefix, spawn_http_daemon,
+    StdioSession, assert_envelopes_contiguous, find_response, find_session_event, open_sse,
+    parse_sse_frames, read_sse_until, spawn_http_daemon,
 };
 
-/// create -> attach -> send -> receive a streamed event -> detach -> status,
-/// entirely over `tcode serve --stdio`'s real stdin/stdout.
+/// create -> attach -> send -> receive a streamed event -> detach -> status
+/// -> re-attach -> cancel, entirely over `tcode serve --stdio`'s real
+/// stdin/stdout. Asserts the #2055 envelope + taxonomy + seq-continuity
+/// requirements throughout.
 #[tokio::test]
 async fn session_lifecycle_over_stdio() {
     let mut daemon = StdioSession::spawn();
@@ -45,7 +55,7 @@ async fn session_lifecycle_over_stdio() {
         .to_string();
     assert_eq!(create_resp["result"]["status"], "running");
 
-    // 2. session.attach — replay must include the creation-lifecycle events.
+    // 2. session.attach — replay must be envelope-shaped and gap-free from 1.
     let attach_resp = daemon
         .call(2, "session.attach", json!({"session_id": session_id}))
         .await;
@@ -55,11 +65,13 @@ async fn session_lifecycle_over_stdio() {
     );
     let replay = attach_resp["result"]["events"]
         .as_array()
-        .expect("attach must return a replay events array");
-    assert!(
-        replay.iter().any(|e| e["type"] == "session_started"),
-        "replay must include session_started: {replay:?}"
-    );
+        .expect("attach must return a replay events array")
+        .clone();
+    let (first_seq, last_seq) = assert_envelopes_contiguous(&replay);
+    assert_eq!(first_seq, 1);
+    assert_eq!(last_seq, 2);
+    let kinds: Vec<&str> = replay.iter().map(|e| e["kind"].as_str().unwrap()).collect();
+    assert_eq!(kinds, vec!["session_started", "session_status_changed"]);
     assert_eq!(
         attach_resp["result"]["stream_url"],
         format!("/sessions/{session_id}/events")
@@ -76,29 +88,23 @@ async fn session_lifecycle_over_stdio() {
         .await;
 
     let mut got_ack = false;
-    let mut got_event = false;
-    let lines = daemon.read_lines(2).await;
-    for line in &lines {
-        if let Some(resp) = find_response(line, 3) {
+    let mut input_envelope = None;
+    for line in daemon.read_lines(2).await {
+        if let Some(resp) = find_response(&line, 3) {
             assert!(resp["error"].is_null(), "session.send failed: {resp}");
             assert_eq!(resp["result"]["acknowledged"], true);
             got_ack = true;
         }
-        if let Some(event) = find_session_event(line, &session_id)
-            && event["event"]["type"] == "session_input"
-            && event["event"]["input"] == "hello"
-        {
-            got_event = true;
+        if let Some(envelope) = find_session_event(&line, &session_id) {
+            input_envelope = Some(envelope);
         }
     }
-    assert!(
-        got_ack,
-        "never saw the session.send acknowledgement; lines: {lines:?}"
-    );
-    assert!(
-        got_event,
-        "never saw the streamed session_input event; lines: {lines:?}"
-    );
+    assert!(got_ack, "never saw the session.send acknowledgement");
+    let input_envelope = input_envelope.expect("never saw the streamed session_input event");
+    assert_envelopes_contiguous(std::slice::from_ref(&input_envelope));
+    assert_eq!(input_envelope["seq"], last_seq + 1);
+    assert_eq!(input_envelope["kind"], "session_input");
+    assert_eq!(input_envelope["event"]["input"], "hello");
 
     // 4. session.detach
     let detach_resp = daemon
@@ -120,12 +126,85 @@ async fn session_lifecycle_over_stdio() {
     assert_eq!(status_resp["result"]["status"], "running");
     assert_eq!(status_resp["result"]["id"], session_id);
 
+    // 6. Re-attach (same STDIO connection): its OWN replay burst must be
+    // gap-free from 1 through the input event recorded in step 3 (seq 3).
+    let reattach_resp = daemon
+        .call(6, "session.attach", json!({"session_id": session_id}))
+        .await;
+    assert!(
+        reattach_resp["error"].is_null(),
+        "re-attach failed: {reattach_resp}"
+    );
+    let reattach_replay = reattach_resp["result"]["events"]
+        .as_array()
+        .unwrap()
+        .clone();
+    let (re_first, re_last) = assert_envelopes_contiguous(&reattach_replay);
+    assert_eq!(re_first, 1);
+    assert_eq!(re_last, 3);
+
+    // 7. session.cancel — must publish 3 more events (status_changed,
+    // session_cancelled, session_done), forwarded live via the re-attach.
+    daemon
+        .write_request(7, "session.cancel", json!({"session_id": session_id}))
+        .await;
+    let mut cancel_events = Vec::new();
+    let mut got_cancel_ack = false;
+    for line in daemon.read_lines(4).await {
+        if let Some(resp) = find_response(&line, 7) {
+            assert!(resp["error"].is_null(), "session.cancel failed: {resp}");
+            assert_eq!(resp["result"]["status"], "cancelled");
+            got_cancel_ack = true;
+        }
+        if let Some(envelope) = find_session_event(&line, &session_id) {
+            cancel_events.push(envelope);
+        }
+    }
+    assert!(
+        got_cancel_ack,
+        "never saw the session.cancel acknowledgement"
+    );
+    assert_eq!(
+        cancel_events.len(),
+        3,
+        "expected status_changed + session_cancelled + session_done: {cancel_events:?}"
+    );
+    let (cancel_first, cancel_last) = assert_envelopes_contiguous(&cancel_events);
+    assert_eq!(
+        cancel_first,
+        re_last + 1,
+        "cancel events must continue the seq with no gap after re-attach's replay"
+    );
+    assert_eq!(cancel_last, re_last + 3);
+    let cancel_kinds: Vec<&str> = cancel_events
+        .iter()
+        .map(|e| e["kind"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        cancel_kinds,
+        vec![
+            "session_status_changed",
+            "session_cancelled",
+            "session_done"
+        ]
+    );
+
+    // The FULL session history (replay + input + re-attach replay's tail is
+    // redundant with the first replay, so just check replay ++ input ++
+    // cancel_events) must itself be one gap-free sequence from 1.
+    let mut full_history = replay;
+    full_history.push(input_envelope);
+    full_history.extend(cancel_events);
+    let (full_first, full_last) = assert_envelopes_contiguous(&full_history);
+    assert_eq!(full_first, 1);
+    assert_eq!(full_last, 6);
+
     daemon.shutdown_via_eof_and_assert_clean_exit().await;
 }
 
-/// The same lifecycle, driven over `POST /rpc` + the `GET
-/// /sessions/{id}/events` SSE stream — proves the HTTP transport streams
-/// observably too, not just STDIO.
+/// The same lifecycle, driven over `POST /rpc` + a SINGLE
+/// `GET /sessions/{id}/events` SSE connection read in two stages — proves
+/// replay -> live seq continuity over HTTP too, not just STDIO.
 #[tokio::test]
 async fn session_lifecycle_over_http_with_sse() {
     let daemon = spawn_http_daemon().await;
@@ -133,7 +212,7 @@ async fn session_lifecycle_over_http_with_sse() {
     let rpc_url = format!("{}/rpc", daemon.base_url);
 
     // 1. session.create
-    let create_resp: Value = client
+    let create_resp: serde_json::Value = client
         .post(&rpc_url)
         .json(&json!({"jsonrpc": "2.0", "id": 1, "method": "session.create", "params": {"task": "e2e http task"}}))
         .send()
@@ -148,23 +227,29 @@ async fn session_lifecycle_over_http_with_sse() {
     );
     let session_id = create_resp["result"]["id"].as_str().unwrap().to_string();
 
-    // 2. GET /sessions/{id}/events — read a bounded prefix; the replay burst
-    // must include the creation events.
+    // 2. Open ONE SSE connection and read the replay burst from it.
     let events_url = format!("{}/sessions/{session_id}/events", daemon.base_url);
-    let replay_text = http_get_prefix(
-        &client,
-        &events_url,
+    let mut sse = open_sse(&client, &events_url).await;
+    let mut buffer = Vec::new();
+    read_sse_until(
+        &mut sse,
+        &mut buffer,
         "session_status_changed",
         Duration::from_secs(5),
     )
     .await;
-    assert!(
-        replay_text.contains("session_started"),
-        "replay body: {replay_text}"
-    );
+    let replay_frames = parse_sse_frames(&String::from_utf8_lossy(&buffer));
+    let (first_seq, last_seq) = assert_envelopes_contiguous(&replay_frames);
+    assert_eq!(first_seq, 1);
+    assert_eq!(last_seq, 2);
+    let kinds: Vec<&str> = replay_frames
+        .iter()
+        .map(|e| e["kind"].as_str().unwrap())
+        .collect();
+    assert_eq!(kinds, vec!["session_started", "session_status_changed"]);
 
-    // 3. session.send over POST /rpc.
-    let send_resp: Value = client
+    // 3. session.send over POST /rpc, while the SAME SSE connection is open.
+    let send_resp: serde_json::Value = client
         .post(&rpc_url)
         .json(&json!({"jsonrpc": "2.0", "id": 2, "method": "session.send", "params": {"session_id": session_id, "input": "hello-http"}}))
         .send()
@@ -176,18 +261,21 @@ async fn session_lifecycle_over_http_with_sse() {
     assert!(send_resp["error"].is_null(), "send failed: {send_resp}");
     assert_eq!(send_resp["result"]["acknowledged"], true);
 
-    // 4. Continue reading the SAME SSE endpoint (a fresh GET is fine — every
-    // GET gets its own live subscription, and the ring buffer already holds
-    // the input event by the time this request lands) for the live event.
-    let live_text =
-        http_get_prefix(&client, &events_url, "hello-http", Duration::from_secs(5)).await;
-    assert!(
-        live_text.contains("session_input"),
-        "live body: {live_text}"
+    // 4. Continue reading the SAME SSE connection for the live event —
+    // this is the replay -> live continuity proof over HTTP.
+    read_sse_until(&mut sse, &mut buffer, "hello-http", Duration::from_secs(5)).await;
+    let all_frames = parse_sse_frames(&String::from_utf8_lossy(&buffer));
+    let (full_first, full_last) = assert_envelopes_contiguous(&all_frames);
+    assert_eq!(full_first, 1);
+    assert_eq!(
+        full_last, 3,
+        "the live event must continue the replay's seq with no gap"
     );
+    assert_eq!(all_frames.last().unwrap()["kind"], "session_input");
+    assert_eq!(all_frames.last().unwrap()["event"]["input"], "hello-http");
 
     // 5. session.cancel over POST /rpc.
-    let cancel_resp: Value = client
+    let cancel_resp: serde_json::Value = client
         .post(&rpc_url)
         .json(&json!({"jsonrpc": "2.0", "id": 3, "method": "session.cancel", "params": {"session_id": session_id}}))
         .send()
@@ -202,5 +290,37 @@ async fn session_lifecycle_over_http_with_sse() {
     );
     assert_eq!(cancel_resp["result"]["status"], "cancelled");
 
+    // 6. The SAME SSE connection must observe the cancel-triggered events
+    // too, continuing the seq with no gap.
+    read_sse_until(
+        &mut sse,
+        &mut buffer,
+        "session_done",
+        Duration::from_secs(5),
+    )
+    .await;
+    let final_frames = parse_sse_frames(&String::from_utf8_lossy(&buffer));
+    let (_, cancel_last) = assert_envelopes_contiguous(&final_frames);
+    assert_eq!(cancel_last, 6);
+    let final_kinds: Vec<&str> = final_frames
+        .iter()
+        .map(|e| e["kind"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        final_kinds,
+        vec![
+            "session_started",
+            "session_status_changed",
+            "session_input",
+            "session_status_changed",
+            "session_cancelled",
+            "session_done",
+        ]
+    );
+
+    // Graceful shutdown drains in-flight requests before exiting (issue
+    // #534); an open SSE connection never "completes" on its own, so the
+    // client must close it first or the daemon would wait for it forever.
+    drop(sse);
     daemon.shutdown_via_sigterm_and_assert_clean_exit().await;
 }

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -10,9 +10,12 @@
 //! What: [`StdioSession`] (spawn + NDJSON request/response/notification
 //! I/O over real pipes), [`HttpDaemon`]/[`spawn_http_daemon`] (spawn +
 //! discover the bound HTTP address from stderr), [`find_response`]/
-//! [`find_session_event`] (classify a raw NDJSON line), and
-//! [`http_get_prefix`] (read a bounded prefix of a never-terminating SSE
-//! body).
+//! [`find_session_event`] (classify a raw NDJSON line), [`open_sse`]/
+//! [`read_sse_until`] (read one never-terminating SSE connection in
+//! stages), [`parse_sse_frames`] (split an SSE body into its JSON `data:`
+//! frames), and [`assert_envelopes_contiguous`] (#2055: the shared
+//! seq/field-presence check both the STDIO and HTTP/SSE e2e scenarios run
+//! against the SAME `SessionEventEnvelope` shape).
 
 use std::process::Stdio;
 use std::time::Duration;
@@ -256,34 +259,48 @@ pub fn find_session_event(line: &str, session_id: &str) -> Option<Value> {
     }
 }
 
-/// Read a bounded prefix of a streaming HTTP GET response body until it
-/// contains `until_substr` or `total_timeout` elapses.
+/// Open `url` as a Server-Sent Events GET, asserting a successful status.
 ///
-/// Why: `GET /sessions/{id}/events` never terminates (the live half
-/// subscribes to the event bus forever), so a normal "read the whole body"
-/// helper would hang; this reads chunks via the response's byte stream
-/// until the expected content shows up.
-pub async fn http_get_prefix(
-    client: &reqwest::Client,
-    url: &str,
-    until_substr: &str,
-    total_timeout: Duration,
-) -> String {
-    use futures_util::StreamExt;
-
+/// Why: the #2055 replay->live continuity check needs to read ONE SSE
+/// connection in two stages (first the replay burst, then a live event
+/// published while still connected) — unlike [`http_get_prefix`], which
+/// opens a fresh connection per call and only proves replay content, not
+/// continuity within a single stream.
+/// What: returns the live `reqwest::Response`; pair with
+/// [`read_sse_until`] to pull further chunks from the SAME connection.
+pub async fn open_sse(client: &reqwest::Client, url: &str) -> reqwest::Response {
     let resp = client.get(url).send().await.expect("GET request");
     assert!(
         resp.status().is_success(),
         "GET {url} returned {}",
         resp.status()
     );
+    resp
+}
 
-    let mut stream = resp.bytes_stream();
-    let mut collected = Vec::new();
+/// Read more chunks from `resp` into `buffer` until it contains
+/// `until_substr` or `total_timeout` elapses.
+///
+/// Why: paired with [`open_sse`] so a test can read a SINGLE SSE connection
+/// in stages (replay, then a later live event) instead of opening a fresh
+/// GET per stage — which is what actually proves replay -> live continuity
+/// on one stream, per the #2055 requirement.
+/// What: appends to `buffer` in place (so a second call continues from
+/// where the first left off) via `Response::chunk()` — no `Stream`/`Bytes`
+/// naming needed at the call site.
+pub async fn read_sse_until(
+    resp: &mut reqwest::Response,
+    buffer: &mut Vec<u8>,
+    until_substr: &str,
+    total_timeout: Duration,
+) {
+    if String::from_utf8_lossy(buffer).contains(until_substr) {
+        return;
+    }
     let read = timeout(total_timeout, async {
-        while !String::from_utf8_lossy(&collected).contains(until_substr) {
-            match stream.next().await {
-                Some(Ok(chunk)) => collected.extend_from_slice(&chunk),
+        while !String::from_utf8_lossy(buffer).contains(until_substr) {
+            match resp.chunk().await {
+                Ok(Some(chunk)) => buffer.extend_from_slice(&chunk),
                 _ => break,
             }
         }
@@ -291,8 +308,63 @@ pub async fn http_get_prefix(
     .await;
     assert!(
         read.is_ok(),
-        "timed out waiting for {until_substr:?} in the SSE stream from {url}"
+        "timed out waiting for {until_substr:?} in the SSE stream"
     );
+}
 
-    String::from_utf8(collected).expect("SSE body must be valid UTF-8")
+/// Parse an SSE body (one or more `data: {...}` lines, possibly interleaved
+/// with blank lines or `:`-comment keep-alives) into the JSON objects it
+/// carries.
+///
+/// Why: the #2055 envelope assertions need to inspect individual event
+/// objects (`seq`, `kind`, `session_id`, ...), not just substring-match the
+/// raw SSE text the way [`http_get_prefix`]'s callers otherwise would.
+/// What: for each line starting with `data:`, strips the prefix and parses
+/// the remainder as JSON; lines that aren't `data:` or don't parse are
+/// skipped (SSE comment lines, a partially-read trailing frame at the
+/// prefix's read boundary).
+pub fn parse_sse_frames(text: &str) -> Vec<Value> {
+    text.lines()
+        .filter_map(|line| line.strip_prefix("data:"))
+        .filter_map(|rest| serde_json::from_str::<Value>(rest.trim()).ok())
+        .collect()
+}
+
+/// Assert that `envelopes` (in receipt order) each carry every
+/// `SessionEventEnvelope` field and form ONE gap-free, strictly increasing
+/// `seq` sequence; returns `(first_seq, last_seq)`.
+///
+/// Why: the #2055 correctness property this whole e2e suite exists to
+/// prove — factored out so the STDIO and HTTP/SSE scenarios run the exact
+/// same check against their respective wire representations of the same
+/// envelope shape.
+/// What: panics with the offending envelope on the first missing field or
+/// any `seq` that isn't exactly `previous + 1`. Panics on empty input too —
+/// every call site here always has at least the replay burst to check.
+pub fn assert_envelopes_contiguous(envelopes: &[Value]) -> (u64, u64) {
+    assert!(
+        !envelopes.is_empty(),
+        "expected at least one envelope to check"
+    );
+    let mut previous: Option<u64> = None;
+    for envelope in envelopes {
+        for field in ["session_id", "seq", "at", "kind", "event"] {
+            assert!(
+                envelope.get(field).is_some(),
+                "envelope missing required field {field:?}: {envelope}"
+            );
+        }
+        let seq = envelope["seq"].as_u64().expect("seq must be a u64");
+        if let Some(prev) = previous {
+            assert_eq!(
+                seq,
+                prev + 1,
+                "seq must increase by exactly 1 with no gaps or duplicates: {envelope}"
+            );
+        }
+        previous = Some(seq);
+    }
+    let first = envelopes[0]["seq"].as_u64().unwrap();
+    let last = envelopes[envelopes.len() - 1]["seq"].as_u64().unwrap();
+    (first, last)
 }


### PR DESCRIPTION
## Summary
Implements #2055 — formalizes the Phase-1 event taxonomy + a stable per-session sequenced envelope. Third M1 deliverable. STACKED on #2093 (base `feat/tcode-session-model`); merge after #2088 then #2093.

## Included
- Event kinds `ToolStarted/ToolFinished/ToolError` (call_id correlation) + `Log`/`Progress`/`Message` + session-lifecycle
- `SessionEventEnvelope{session_id, seq (per-session monotonic), at, kind, event}`
- Gap-free ordered delivery + replay→live seq continuity over both stdio notifications and HTTP SSE
- Emission plumbing (`record_tool_*`/`record_log/progress/message`) ready for the #2056 agent loop

## Behavior Note
`session.cancel` now emits 3 events (status_changed → session_cancelled → session_done) to match the spec taxonomy (was 2 in #2054).

## QA
Independently verified — full gate green (build, 399 lib + 2 e2e pass, clippy `-D warnings` clean, fmt clean, line-cap 0 violations); seq integrity reproduced over the wire on both transports (1→6 gap-free across replay/detach/re-attach); stdout-cleanliness holds under `RUST_LOG=debug`; multi-client SSE byte-identical; 10/10 flakiness-stress pass.

## Deferred
→ #2056: no live tool-event producer yet (plumbing only, no agent loop).

Closes #2055. Part of #2052. Milestone M1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)