### PR TITLE
feat(trusty-code): session.get_transcript inspection API (#2058)

### DIFF
--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -1,6 +1,6 @@
 //! `tcode serve` daemon: STDIO + HTTP JSON-RPC transports + proof-of-life,
-//! `session.*`, and `task.*` methods (#2053, #2054, #2056, M1 control-plane
-//! cut line).
+//! `session.*`, and `task.*` methods (#2053, #2054, #2056, #2058,
+//! M1 control-plane cut line).
 //!
 //! Why: this module is the foundation the `tcode serve` binary subcommand
 //! delegates to. It owns assembling the [`crate::jsonrpc::Router`] (and,
@@ -10,8 +10,9 @@
 //! of the crate's CLI wiring.
 //! What: [`build_router`] registers every currently-known method group
 //! (today: [`methods::register`]'s `ping`/`health` proof-of-life pair,
-//! `crate::session::protocol::register`'s seven `session.*` methods, and
-//! (#2056) `crate::task::protocol::register`'s `task.run` — later tickets add
+//! `crate::session::protocol::register`'s eight `session.*` methods
+//! (including #2058's read-only `session.get_transcript`), and (#2056)
+//! `crate::task::protocol::register`'s `task.run` — later tickets add
 //! `harness.describe` #2066 here, one line each). [`run_stdio`] and
 //! [`run_http`] both build a router + registry via `build_router` and hand
 //! them to their respective transport ([`transport::run_stdio_loop`] /

--- a/crates/trusty-code/src/session/mod.rs
+++ b/crates/trusty-code/src/session/mod.rs
@@ -10,16 +10,20 @@
 //! (`crate::serve`), reusing the SAME method surface both transports
 //! dispatch through.
 //! What: [`model::Session`]/[`model::SessionStatus`] (the domain type),
-//! [`registry::SessionRegistry`] (storage + ring buffer + attach/detach),
-//! and [`protocol::register`] (wires `session.create`/`list`/`status`/
-//! `send`/`attach`/`detach`/`cancel` onto a `Router`).
+//! [`registry::SessionRegistry`] (storage + ring buffer + attach/detach +,
+//! since #2056, execution tracking), [`transcript::TranscriptRecord`]
+//! (#2058's `session.get_transcript` response DTO), and [`protocol::register`]
+//! (wires `session.create`/`list`/`status`/`send`/`attach`/`detach`/`cancel`/
+//! `get_transcript` onto a `Router`).
 //! Test: `model::tests::*`, `registry::registry_tests::*`,
 //! `protocol::tests::*`; end-to-end over the real daemon in
-//! `tests/session_e2e.rs`.
+//! `tests/session_e2e.rs` and (#2058) `tests/task_e2e.rs`.
 
 pub mod model;
 pub mod protocol;
 pub mod registry;
+pub mod transcript;
 
 pub use model::{Session, SessionStatus};
 pub use registry::SessionRegistry;
+pub use transcript::TranscriptRecord;

--- a/crates/trusty-code/src/session/protocol.rs
+++ b/crates/trusty-code/src/session/protocol.rs
@@ -4,16 +4,16 @@
 //! goes through JSON-RPC, reachable identically over STDIO and HTTP, so the
 //! CLI (and later TUI/TELGUI/REST) never touch `SessionRegistry` directly.
 //! What: [`register`] wires `session.create`, `session.list`,
-//! `session.status`, `session.send`, `session.attach`, `session.detach`, and
-//! `session.cancel` onto a [`Router`], all closed over the SAME
-//! `Arc<SessionRegistry>` so every method sees a consistent view. Each
-//! handler parses its typed `params`, forwards to the matching
-//! `SessionRegistry` method, and maps the result onto the JSON-RPC result
-//! shape the vision spec's §4.3 examples describe.
+//! `session.status`, `session.send`, `session.attach`, `session.detach`,
+//! `session.cancel`, and (#2058) `session.get_transcript` onto a [`Router`],
+//! all closed over the SAME `Arc<SessionRegistry>` so every method sees a
+//! consistent view. Each handler parses its typed `params`, forwards to the
+//! matching `SessionRegistry` method, and maps the result onto the JSON-RPC
+//! result shape the vision spec's §4.3 examples describe.
 //! Test: `protocol::tests::*` (parameter validation, error mapping); the
 //! full attach/detach streaming behaviour is covered by
 //! `session::registry_tests` (registry-level) and
-//! `tests/session_e2e.rs` (API-driven, real daemon).
+//! `tests/session_e2e.rs`/`tests/task_e2e.rs` (API-driven, real daemon).
 
 use std::sync::Arc;
 
@@ -93,6 +93,15 @@ pub fn register(router: &mut Router, registry: Arc<SessionRegistry>) {
         move |params: Value, ctx: ConnectionContext| {
             let r = r.clone();
             async move { cancel(&r, params, ctx).await }
+        },
+    );
+
+    let r = registry.clone();
+    router.register(
+        "session.get_transcript",
+        move |params: Value, ctx: ConnectionContext| {
+            let r = r.clone();
+            async move { get_transcript(&r, params, ctx).await }
         },
     );
 }
@@ -278,6 +287,28 @@ async fn cancel(
     }
 }
 
+/// `session.get_transcript(session_id) -> TranscriptRecord` (#2058, vision
+/// spec §11.1 Transcript Persistence / §4.3 API Surface).
+///
+/// Why: completes the M1 cut-line's "inspect transcript" verb — read-only
+/// access to the run record `task.run` (#2056) persists via
+/// `SessionRegistry::set_run_outcome`.
+/// What: `-32007 session_not_found` if `session_id` is unknown; otherwise
+/// `SessionRegistry::get_transcript`'s `TranscriptRecord` verbatim — turns,
+/// aggregate usage, and stored cost, never recomputed here. A session that
+/// has never run a task returns a `TranscriptRecord` with an empty `turns`
+/// array rather than an error (see `SessionRegistry::get_transcript`'s docs).
+/// Test: `protocol::tests::get_transcript_unknown_session_maps_to_session_not_found`,
+/// `protocol::tests::get_transcript_on_never_run_session_is_empty`.
+async fn get_transcript(
+    registry: &SessionRegistry,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: SessionIdParams = parse(params, "session.get_transcript")?;
+    Ok(json!(registry.get_transcript(&p.session_id)?))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -308,6 +339,7 @@ mod tests {
             ),
             ("session.attach", json!({"session_id": session.id})),
             ("session.detach", json!({"session_id": session.id})),
+            ("session.get_transcript", json!({"session_id": session.id})),
         ];
         for (method, params) in cases {
             let req = Request {
@@ -378,6 +410,31 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.code, -32007);
+    }
+
+    /// `session.get_transcript` on an unknown id must map to
+    /// `session_not_found` (#2058).
+    #[tokio::test]
+    async fn get_transcript_unknown_session_maps_to_session_not_found() {
+        let registry = SessionRegistry::new();
+        let err = get_transcript(&registry, json!({"session_id": "nope"}), test_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, -32007);
+    }
+
+    /// `session.get_transcript` on a session that has never run a task
+    /// returns an empty transcript, not an error (#2058).
+    #[tokio::test]
+    async fn get_transcript_on_never_run_session_is_empty() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, None);
+        let result = get_transcript(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+        assert_eq!(result["session_id"], session.id);
+        assert_eq!(result["turns"].as_array().unwrap().len(), 0);
+        assert_eq!(result["cost_usd"], Value::Null);
     }
 
     /// `session.send` on an unknown id must map to `session_not_found`.

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -44,13 +44,14 @@ use crate::perf::TokenUsage;
 use crate::run_task::TurnRecord;
 
 use super::model::{Session, SessionStatus};
+use super::transcript::TranscriptRecord;
 
 /// Default ring-buffer capacity per session (vision spec §12, 11.5).
 ///
 /// Why: bounds per-session memory use; a freshly-attached client sees
-/// "recent progress but not the full session history" per spec, with full
-/// history reserved for a future `session.get_transcript` (out of scope for
-/// #2054/#2055 — not in either issue's method list).
+/// "recent progress but not the full session history" per spec — the ring
+/// buffer is the LIVE-event window, distinct from the full run transcript
+/// `session.get_transcript` (#2058) exposes via `Self::get_transcript`.
 /// Test: `registry_tests::ring_buffer_drops_oldest_when_full`.
 pub const DEFAULT_RING_CAPACITY: usize = 1000;
 
@@ -70,9 +71,9 @@ struct SessionEntry {
     /// #2056: set while a background task-execution is in flight; `None`
     /// when idle (never started, or already finished).
     execution: Option<Execution>,
-    /// #2056: the run transcript populated once an execution finishes —
-    /// ready for a future `session.get_transcript` (#2058) to expose. Empty
-    /// until then.
+    /// #2056: the run transcript populated once an execution finishes;
+    /// exposed read-only via `session.get_transcript` (#2058,
+    /// `Self::get_transcript`). Empty until the first execution completes.
     transcript: Vec<TurnRecord>,
     /// #2056: aggregated token usage from the last completed execution.
     usage: TokenUsage,
@@ -526,9 +527,8 @@ impl SessionRegistry {
     /// Persist a finished execution's transcript/usage/cost into the session
     /// (#2056).
     ///
-    /// Why: populates the storage a future `session.get_transcript` (#2058)
-    /// will expose — #2056's scope is populating it, not adding a new
-    /// retrieval method.
+    /// Why: populates the storage `Self::get_transcript` (#2058) reads back
+    /// over the wire.
     /// What: best-effort — a no-op if `id` is already gone (e.g. the daemon
     /// is shutting down mid-run).
     /// Test: `registry_tests::set_run_outcome_stores_transcript_and_usage`.
@@ -545,6 +545,36 @@ impl SessionRegistry {
             entry.usage = usage;
             entry.cost_usd = cost_usd;
         }
+    }
+
+    /// `session.get_transcript`: fetch the stored run record for a session
+    /// (#2058).
+    ///
+    /// Why: [`Self::set_run_outcome`] populates the storage; this is its read
+    /// counterpart — the M1 cut-line's "inspect transcript" verb. A never-run
+    /// session is a valid, empty transcript, not an error: `SessionEntry`'s
+    /// `transcript`/`usage`/`cost_usd` fields already default to
+    /// empty/zero/`None` at `create` time, so returning them unconditionally
+    /// (once the session itself is confirmed to exist) is correct with no
+    /// extra branching.
+    /// What: `Err(session_not_found)` if `id` is unknown; otherwise a clone of
+    /// whatever is currently stored, wrapped in a self-describing
+    /// [`TranscriptRecord`]. Never recomputes cost or usage — exposes exactly
+    /// what [`Self::set_run_outcome`] last stored.
+    /// Test: `registry_tests::get_transcript_returns_stored_record`,
+    /// `registry_tests::get_transcript_on_never_run_session_is_empty`,
+    /// `registry_tests::get_transcript_unknown_session_errors`.
+    pub fn get_transcript(&self, id: &str) -> Result<TranscriptRecord, RpcError> {
+        let sessions = self.lock();
+        let entry = sessions
+            .get(id)
+            .ok_or_else(|| RpcError::session_not_found(id))?;
+        Ok(TranscriptRecord {
+            session_id: id.to_string(),
+            turns: entry.transcript.clone(),
+            usage: entry.usage,
+            cost_usd: entry.cost_usd,
+        })
     }
 
     /// Cooperatively cancel every in-flight execution and wait, bounded by

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -549,10 +549,36 @@ async fn set_run_outcome_stores_transcript_and_usage() {
         Some(0.01),
     );
 
-    // No public getter exists yet (session.get_transcript is #2058); this
-    // test proves the call is infallible and side-effect-free on a missing
-    // session, which is the only externally-observable contract for now.
+    let stored = registry.get_transcript(&session.id).unwrap();
+    assert_eq!(stored.turns, turns);
+    assert_eq!(stored.usage, crate::perf::TokenUsage::new(10, 5, 0, 0));
+    assert_eq!(stored.cost_usd, Some(0.01));
+
+    // A no-op on a missing session, not a panic.
     registry.set_run_outcome("nope", turns, crate::perf::TokenUsage::default(), None);
+}
+
+/// `get_transcript` on a session that has never run a task must return an
+/// empty, valid `TranscriptRecord` — not an error (#2058).
+#[tokio::test]
+async fn get_transcript_on_never_run_session_is_empty() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+
+    let transcript = registry.get_transcript(&session.id).unwrap();
+    assert_eq!(transcript.session_id, session.id);
+    assert!(transcript.turns.is_empty());
+    assert_eq!(transcript.usage, crate::perf::TokenUsage::default());
+    assert_eq!(transcript.cost_usd, None);
+}
+
+/// `get_transcript` on an unknown session must error `session_not_found`
+/// (#2058).
+#[tokio::test]
+async fn get_transcript_unknown_session_errors() {
+    let registry = SessionRegistry::new();
+    let err = registry.get_transcript("nope").unwrap_err();
+    assert_eq!(err.code, -32007);
 }
 
 /// `shutdown_executions` must flip every tracked execution's cancel flag and

--- a/crates/trusty-code/src/session/transcript.rs
+++ b/crates/trusty-code/src/session/transcript.rs
@@ -1,0 +1,44 @@
+//! `session.get_transcript`'s response shape (#2058).
+//!
+//! Why: `SessionRegistry::set_run_outcome` (#2056) already persists a
+//! finished execution's turn-by-turn transcript, aggregate token usage, and
+//! priced cost onto the `SessionEntry` — this is the M1 cut-line's "inspect
+//! transcript" verb, exposing that stored record over the wire without
+//! recomputing anything. Kept as its own small file (rather than growing
+//! `registry.rs`) so the wire shape has one obvious home and stays decoupled
+//! from the registry's storage/locking internals.
+//! What: [`TranscriptRecord`] is a plain, `Serialize`-only DTO: `session_id`,
+//! the ordered `turns` (each already `role`/`model`/`text`/`tool_calls`/
+//! `usage` — see `crate::run_task::TurnRecord`), the aggregate `usage`, and
+//! `cost_usd` exactly as stored (`None` either because pricing was
+//! unavailable for the run, or because no run has ever completed on this
+//! session — the two cases are indistinguishable here by design, matching
+//! `RunReport::cost_usd`'s existing convention). A session that has never
+//! run a task returns `turns: []`, `usage` all-zero, `cost_usd: null` — a
+//! valid, empty transcript, not an error.
+//! Test: `session::registry_tests::get_transcript_*`.
+
+use serde::Serialize;
+
+use crate::perf::TokenUsage;
+use crate::run_task::TurnRecord;
+
+/// The full stored run record for one session, as `session.get_transcript`
+/// returns it.
+///
+/// Why: see module docs — this is the read-only DTO wrapping whatever
+/// `SessionRegistry::set_run_outcome` last stored (or the all-empty default
+/// for a session that has never run a task).
+/// What: field-for-field passthrough of `SessionEntry`'s transcript/usage/
+/// cost, plus the `session_id` for a self-describing response (the wire
+/// method already takes `session_id` as a param, but echoing it back keeps
+/// the result self-contained for a caller inspecting the JSON alone).
+/// Test: `session::registry_tests::get_transcript_returns_stored_record`,
+/// `session::registry_tests::get_transcript_on_never_run_session_is_empty`.
+#[derive(Debug, Clone, Serialize)]
+pub struct TranscriptRecord {
+    pub session_id: String,
+    pub turns: Vec<TurnRecord>,
+    pub usage: TokenUsage,
+    pub cost_usd: Option<f64>,
+}

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -293,6 +293,79 @@ pub fn find_session_event(line: &str, session_id: &str) -> Option<Value> {
     }
 }
 
+/// Drive `task.run` -> `session.attach` -> read-until-`session_done` over an
+/// already-spawned [`StdioSession`], returning the session id once the run
+/// has reached a terminal state.
+///
+/// Why: (#2058) both `tests/task_e2e.rs`'s live-tool-event assertions and its
+/// `session.get_transcript` assertions need "run a task to completion" as a
+/// precondition — `get_transcript` in particular must not be called before
+/// `task::executor::run_and_record` has stored the outcome via
+/// `SessionRegistry::set_run_outcome`, or the transcript would still be
+/// empty. Factored out so both call sites share the exact same
+/// read-until-terminal logic rather than copy-pasting the polling loop.
+/// What: calls `task.run` (id 1) and `session.attach` (id 2) — these two ids
+/// are reserved by this helper, so callers must start their OWN subsequent
+/// request ids at 3 — then reads NDJSON lines, classifying each as a
+/// `session.event` for this session, until `session_done` is observed (or
+/// panics after 20 read rounds, mirroring the bounded wait every other e2e
+/// polling loop in this crate uses). Returns the session id.
+pub async fn run_task_to_completion(daemon: &mut StdioSession, task_description: &str) -> String {
+    let run_resp = daemon
+        .call(1, "task.run", json!({"task_description": task_description}))
+        .await;
+    assert!(run_resp["error"].is_null(), "task.run failed: {run_resp}");
+    let session_id = run_resp["result"]["session_id"]
+        .as_str()
+        .expect("task.run must return a session_id")
+        .to_string();
+
+    let attach_resp = daemon
+        .call(2, "session.attach", json!({"session_id": session_id}))
+        .await;
+    assert!(
+        attach_resp["error"].is_null(),
+        "attach failed: {attach_resp}"
+    );
+    let mut kinds: Vec<String> = attach_resp["result"]["events"]
+        .as_array()
+        .expect("attach must return a replay events array")
+        .iter()
+        .map(|e| {
+            e["kind"]
+                .as_str()
+                .expect("kind must be a string")
+                .to_string()
+        })
+        .collect();
+
+    let mut iterations = 0;
+    while !kinds.iter().any(|k| k == "session_done") {
+        iterations += 1;
+        assert!(
+            iterations < 20,
+            "gave up waiting for session_done after {iterations} read rounds; kinds so far: {kinds:?}"
+        );
+        let lines = daemon.read_lines(20).await;
+        assert!(
+            !lines.is_empty(),
+            "timed out waiting for more events; kinds so far: {kinds:?}"
+        );
+        for line in &lines {
+            if let Some(envelope) = find_session_event(line, &session_id) {
+                kinds.push(
+                    envelope["kind"]
+                        .as_str()
+                        .expect("kind must be a string")
+                        .to_string(),
+                );
+            }
+        }
+    }
+
+    session_id
+}
+
 /// Open `url` as a Server-Sent Events GET, asserting a successful status.
 ///
 /// Why: the #2055 replay->live continuity check needs to read ONE SSE

--- a/crates/trusty-code/tests/task_e2e.rs
+++ b/crates/trusty-code/tests/task_e2e.rs
@@ -1,9 +1,11 @@
-//! API-driven end-to-end test for #2056's `task.run` — the M1
-//! control-plane cut line: a task actually EXECUTES through the daemon and
-//! produces LIVE tool events via the #2055 emission plumbing.
+//! API-driven end-to-end test for #2056's `task.run` and #2058's
+//! `session.get_transcript` — the M1 control-plane cut line: a task actually
+//! EXECUTES through the daemon, produces LIVE tool events via the #2055
+//! emission plumbing, and its transcript/usage/cost can be inspected
+//! afterward over the wire.
 //!
 //! Why: the vision spec's Testability requirement (§9, "100% CLI/API
-//! Testable") mandates that #2056's slice be validated by spawning the REAL
+//! Testable") mandates that each slice be validated by spawning the REAL
 //! `tcode serve` daemon and driving it over the actual wire protocol — never
 //! by calling into `trusty_code`'s Rust API directly (see
 //! `tests/session_e2e.rs`'s module docs for the same rationale, applied
@@ -24,13 +26,19 @@
 //! [`task_run_rejects_a_second_overlapping_run`] proves the "no overlapping
 //! runs per session" guarantee over the real wire, not just at the
 //! `SessionRegistry` unit level.
+//! [`task_run_then_get_transcript_exposes_turns_usage_and_cost`] (#2058) runs
+//! a task to completion, then calls `session.get_transcript` and asserts the
+//! returned turns cover both the `pm` and `python-engineer` roles with their
+//! `delegate_to_agent`/`bash` tool calls, and that aggregate usage/cost are
+//! non-zero — proving the stored run record is readable over the real wire,
+//! not just at the `SessionRegistry` unit level.
 //! Test: this file IS the test; see `support` for the process/protocol
 //! plumbing shared with `session_e2e.rs`.
 
 mod support;
 
 use serde_json::json;
-use support::{StdioSession, find_session_event};
+use support::{StdioSession, find_session_event, run_task_to_completion};
 
 /// Provision a throwaway project with `.claude/agents/{pm,python-engineer}.toml`.
 fn project_with_agents() -> tempfile::TempDir {
@@ -198,6 +206,82 @@ async fn task_run_rejects_a_second_overlapping_run() {
         "a second overlapping task.run must be rejected: {second}"
     );
     assert_eq!(second["error"]["code"], -32003);
+
+    daemon.shutdown_via_eof_and_assert_clean_exit().await;
+}
+
+/// `task.run` -> (wait for completion) -> `session.get_transcript` must
+/// expose the stored run record over the real wire: turns for BOTH the `pm`
+/// and `python-engineer` roles, their `delegate_to_agent`/`bash` tool calls,
+/// and non-zero aggregate usage + a priced cost (#2058).
+#[tokio::test]
+async fn task_run_then_get_transcript_exposes_turns_usage_and_cost() {
+    let project = project_with_agents();
+    let mut daemon = StdioSession::spawn_with_mock_llm(project.path());
+
+    // `run_task_to_completion` reserves request ids 1 (task.run) and 2
+    // (session.attach); this test's own next id is 3.
+    let session_id = run_task_to_completion(&mut daemon, "say hi").await;
+
+    let transcript_resp = daemon
+        .call(
+            3,
+            "session.get_transcript",
+            json!({"session_id": session_id}),
+        )
+        .await;
+    assert!(
+        transcript_resp["error"].is_null(),
+        "get_transcript failed: {transcript_resp}"
+    );
+    let result = &transcript_resp["result"];
+    assert_eq!(result["session_id"], session_id);
+
+    let turns = result["turns"].as_array().expect("turns must be an array");
+    assert!(
+        !turns.is_empty(),
+        "a completed run must have recorded turns"
+    );
+
+    let roles: Vec<&str> = turns.iter().map(|t| t["role"].as_str().unwrap()).collect();
+    assert!(roles.contains(&"pm"), "expected a pm turn: {roles:?}");
+    assert!(
+        roles.contains(&"python-engineer"),
+        "expected a python-engineer turn: {roles:?}"
+    );
+
+    let all_tool_calls: Vec<&str> = turns
+        .iter()
+        .flat_map(|t| t["tool_calls"].as_array().unwrap())
+        .map(|c| c.as_str().unwrap())
+        .collect();
+    assert!(
+        all_tool_calls.contains(&"delegate_to_agent"),
+        "expected the pm's delegate_to_agent call in the transcript: {all_tool_calls:?}"
+    );
+    assert!(
+        all_tool_calls.contains(&"bash"),
+        "expected the engineer's bash call in the transcript: {all_tool_calls:?}"
+    );
+
+    // Aggregate usage/cost must be non-zero (the mock script's fixtures
+    // carry non-zero token counts on every turn) — and must NOT be
+    // recomputed here, only read back exactly as `task::executor` stored it.
+    assert!(
+        result["usage"]["prompt_tokens"].as_u64().unwrap() > 0,
+        "expected non-zero aggregate prompt_tokens: {}",
+        result["usage"]
+    );
+    assert!(
+        result["usage"]["completion_tokens"].as_u64().unwrap() > 0,
+        "expected non-zero aggregate completion_tokens: {}",
+        result["usage"]
+    );
+    assert!(
+        result["cost_usd"].as_f64().unwrap() > 0.0,
+        "expected a priced, non-zero cost_usd: {}",
+        result["cost_usd"]
+    );
 
     daemon.shutdown_via_eof_and_assert_clean_exit().await;
 }


### PR DESCRIPTION
Implements #2058 — `session.get_transcript(session_id)` returns the stored run record (turns, tool calls, usage, cost) persisted by `task.run`, over both transports; unknown session → -32007; never-run session → empty (no error); cost never recomputed. Completes the M1 cut-line "inspect transcript" verb. 

QA-verified: gate green (435 lib + session_e2e + task_e2e pass, clippy/fmt/line-cap clean, downstream trusty-agents clean), offline transcript e2e reproduced over the wire (no API key), stdout-cleanliness holds.

Closes #2058
Part of #2052
Milestone M1

🤖 Generated with [Claude Code](https://claude.com/claude-code)