### PR TITLE
fix(trusty-common): auto-fall back to CPU when CoreML embedder init hangs

### DIFF
--- a/crates/trusty-common/src/embedder/fast_embedder.rs
+++ b/crates/trusty-common/src/embedder/fast_embedder.rs
@@ -4,11 +4,15 @@
 //! cap. `FastEmbedder` is the largest single item in the module (init +
 //! embed_batch combined exceed 250 SLOC after comments) so it lives on its own.
 //! What: `FastEmbedder` struct, its `new` / `with_cache_size` constructors,
-//! `init_options` (execution-provider selection), the CUDA provider builder
-//! (behind the `embedder-cuda` feature), and the `Embedder` trait impl.
+//! `init_options` (execution-provider selection), `try_new_bounded` (issue
+//! #2111 — bounds CoreML init so a hang auto-falls-back to CPU instead of
+//! blocking forever, and remembers the hang via `COREML_KNOWN_BAD` so it is
+//! never retried), the CUDA provider builder (behind the `embedder-cuda`
+//! feature), and the `Embedder` trait impl.
 //! Test: `fastembed_returns_correct_dim`, `fastembed_cache_hit_is_idempotent`
-//! (both `#[ignore]` — they download a real ONNX model), plus the env-var
-//! tests in `mod.rs` that call `FastEmbedder::init_options` directly.
+//! (both `#[ignore]` — they download a real ONNX model), the `decide_fallback`
+//! / `coreml_init_timeout` unit tests, plus the env-var tests in `mod.rs`
+//! that call `FastEmbedder::init_options` directly.
 
 use super::types::{
     DEFAULT_CACHE_CAPACITY, EMBED_DIM, ExecutionProvider, OrtThreadingOptions, is_zero_vector,
@@ -20,7 +24,10 @@ use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
 use lru::LruCache;
 use parking_lot::Mutex;
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 
 #[cfg(feature = "embedder-cuda")]
 use super::types::{CudaOptions, resolve_cuda_options};
@@ -117,6 +124,105 @@ fn init_ort_runtime() -> OrtThreadingOptions {
 
         opts
     })
+}
+
+/// Set once a CoreML EP init attempt is observed to hang past
+/// [`coreml_init_timeout`].
+///
+/// Why: issue #2111 — `TextEmbedding::try_new` with the CoreML EP registered
+/// can block the underlying OS thread indefinitely on some Apple Silicon
+/// hosts (0% CPU, no error, no progress — not merely a slow cold-compile).
+/// `ort`/CoreML exposes no cancellation hook, so a hung attempt's OS thread
+/// can never be reclaimed; it is abandoned (leaked) for the rest of the
+/// process. Without this cache, every later `FastEmbedder::new()` (e.g. the
+/// `OnceCell::get_or_try_init` retries in `memory_core::retrieval::embedder`
+/// firing on each ~5-minute dream cycle after an outer timeout) would spawn
+/// *another* doomed thread, leaking one more per retry forever. Once a hang
+/// is observed we remember it for the lifetime of the process and every
+/// subsequent attempt skips CoreML entirely, so at most one thread is ever
+/// leaked.
+/// What: `true` once a `Hung` outcome (see [`InitOutcome`]) has been
+/// observed; `false` otherwise. Never reset — there is no safe way to
+/// "un-observe" a permanently blocked OS thread within a process lifetime.
+/// Test: exercised indirectly by `decide_fallback` unit tests (the boolean
+/// this cache is set from); the cache mutation itself requires a real hang
+/// and is not unit-testable without a live CoreML runtime.
+static COREML_KNOWN_BAD: AtomicBool = AtomicBool::new(false);
+
+/// Default bound (seconds) for a single CoreML EP init attempt before it is
+/// treated as hung and the caller falls back to CPU.
+///
+/// Why: issue #2111 — the ops workaround `TRUSTY_DEVICE=cpu` proves the CPU
+/// EP reaches ready in ~11 s on an affected host, so 60 s leaves generous
+/// headroom above the CPU path while still bounding the worst case far below
+/// the outer `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` (default 180 s, see
+/// `memory_core::timeouts`) — the auto-fallback completes and the embedder
+/// becomes ready before that wrapper would otherwise give up and report a
+/// hard failure. 60 s also comfortably exceeds a legitimately slow (but
+/// working) CoreML cold-compile, which should complete in well under a
+/// minute; hosts that need more can raise
+/// [`TRUSTY_COREML_INIT_TIMEOUT_SECS`](coreml_init_timeout).
+pub(super) const DEFAULT_COREML_INIT_TIMEOUT_SECS: u64 = 60;
+
+/// Resolve the bounded CoreML init timeout from the environment.
+///
+/// Why: operators on a host with a legitimately slow (but eventually
+/// successful) CoreML cold-compile need to be able to raise the bound rather
+/// than have every embedder init permanently fall back to CPU.
+/// What: reads `TRUSTY_COREML_INIT_TIMEOUT_SECS` (positive integer seconds);
+/// falls back to [`DEFAULT_COREML_INIT_TIMEOUT_SECS`] (60) when unset,
+/// non-numeric, or non-positive.
+/// Test: `coreml_init_timeout_default`, `coreml_init_timeout_reads_env` in
+/// `mod.rs`.
+pub(super) fn coreml_init_timeout() -> Duration {
+    let secs = std::env::var("TRUSTY_COREML_INIT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_COREML_INIT_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Outcome of a single execution-provider init attempt, used to decide
+/// whether to fall back to CPU and whether to poison [`COREML_KNOWN_BAD`].
+///
+/// Why: separates the *decision* (fall back? poison the cache?) from the
+/// mechanics of spawning a guard thread and racing it against a timeout, so
+/// the decision is a pure function testable without any real ORT/CoreML
+/// runtime (issue #2111).
+/// What: the three ways a bounded init attempt can resolve.
+/// Test: `decide_fallback` tests in `mod.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InitOutcome {
+    /// The provider initialised successfully within the bound.
+    Success,
+    /// The provider returned an `Err` quickly (pre-existing #763 behaviour).
+    FastError,
+    /// The provider did not return within [`coreml_init_timeout`] — the
+    /// underlying OS thread is presumed permanently blocked.
+    Hung,
+}
+
+/// Decide whether an [`InitOutcome`] should fall back to CPU, and whether
+/// [`COREML_KNOWN_BAD`] should be set as a result.
+///
+/// Why: a fast `Err` (e.g. a transient CoreML registration failure) does not
+/// prove the provider will misbehave on the next attempt, so the pre-existing
+/// #763 behaviour retries CoreML on the next full `FastEmbedder::new()`. A
+/// `Hung` outcome, by contrast, means an OS thread is permanently stuck
+/// inside ORT/CoreML with no cancellation point — retrying would leak one
+/// more blocked thread per attempt, so it must be remembered for the rest of
+/// the process (issue #2111).
+/// What: returns `(fall_back_to_cpu, mark_known_bad)`.
+/// Test: `fallback_decision_success_keeps_provider`,
+/// `fallback_decision_fast_error_falls_back_without_poisoning`,
+/// `fallback_decision_hang_falls_back_and_poisons` in `mod.rs`.
+pub(super) fn decide_fallback(outcome: InitOutcome) -> (bool, bool) {
+    match outcome {
+        InitOutcome::Success => (false, false),
+        InitOutcome::FastError => (true, false),
+        InitOutcome::Hung => (true, true),
+    }
 }
 
 /// Local CPU embedder backed by fastembed-rs (ONNX runtime, all-MiniLM-L6-v2).
@@ -305,6 +411,92 @@ impl FastEmbedder {
         }
     }
 
+    /// Attempt to construct a `TextEmbedding` for `opts`/`provider`, bounding
+    /// CoreML init by [`coreml_init_timeout`] so a hung ORT/CoreML init
+    /// cannot block the caller forever.
+    ///
+    /// Why: `TextEmbedding::try_new` offers no cancellation hook. On some
+    /// Apple Silicon hosts it blocks the calling OS thread indefinitely with
+    /// the CoreML EP registered but never returning (issue #2111). Running
+    /// the attempt on a dedicated `std::thread` and racing it against
+    /// `mpsc::Receiver::recv_timeout` lets the *caller* give up on schedule
+    /// even though the spawned thread itself cannot be cancelled. When the
+    /// bound elapses the spawned thread is abandoned — but this happens at
+    /// most once per process: [`COREML_KNOWN_BAD`] is set on the first
+    /// observed hang, and every later call short-circuits straight to
+    /// `TextEmbedding::try_new` on the current thread without spawning
+    /// another doomed CoreML attempt.
+    /// What: for `provider` other than `CoreML`/`CoreMLAne` (CPU, CUDA), or
+    /// once [`COREML_KNOWN_BAD`] is set, calls `TextEmbedding::try_new`
+    /// directly on the current thread — those paths have never been observed
+    /// to hang, so no bounding is needed. Otherwise spawns a guard thread,
+    /// waits up to `coreml_init_timeout()`, and on timeout marks
+    /// `COREML_KNOWN_BAD` and returns a descriptive `Err` (the caller's
+    /// existing #763 fallback-to-CPU branch then takes over, unchanged).
+    /// Test: the spawn/race mechanics require a real ORT session and are
+    /// exercised only via the `#[ignore]` embedder tests; the *decision*
+    /// logic they depend on (`decide_fallback`) is covered by unit tests in
+    /// `mod.rs` that need no live model.
+    fn try_new_bounded(
+        opts: TextInitOptions,
+        provider: ExecutionProvider,
+    ) -> Result<TextEmbedding> {
+        let accelerated = matches!(
+            provider,
+            ExecutionProvider::CoreML | ExecutionProvider::CoreMLAne
+        );
+        if !accelerated || COREML_KNOWN_BAD.load(Ordering::Relaxed) {
+            return TextEmbedding::try_new(opts);
+        }
+
+        let (tx, rx) = mpsc::channel();
+        std::thread::Builder::new()
+            .name("trusty-embedder-coreml-init".to_string())
+            .spawn(move || {
+                // The receiver may already have given up (timed out) by the
+                // time this send happens — that is expected in the hang
+                // case and the send error is intentionally discarded; there
+                // is nothing left for this (possibly permanently blocked)
+                // thread to do either way.
+                let _ = tx.send(TextEmbedding::try_new(opts));
+            })
+            .context("failed to spawn CoreML init guard thread")?;
+
+        match rx.recv_timeout(coreml_init_timeout()) {
+            Ok(Ok(model)) => {
+                let (fall_back, mark_bad) = decide_fallback(InitOutcome::Success);
+                debug_assert!(
+                    !fall_back && !mark_bad,
+                    "a successful init must never fall back or poison COREML_KNOWN_BAD"
+                );
+                Ok(model)
+            }
+            Ok(Err(e)) => {
+                let (_, mark_bad) = decide_fallback(InitOutcome::FastError);
+                debug_assert!(!mark_bad, "a fast error must never poison COREML_KNOWN_BAD");
+                Err(e)
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                let (_, mark_bad) = decide_fallback(InitOutcome::Hung);
+                if mark_bad {
+                    COREML_KNOWN_BAD.store(true, Ordering::Relaxed);
+                }
+                Err(anyhow::anyhow!(
+                    "{provider} EP init did not complete within {:?} (issue #2111) \
+                     — presumed hung; the stuck OS thread is abandoned and \
+                     {provider} will be skipped for the rest of this process \
+                     (falling back to CPU). Set TRUSTY_COREML_INIT_TIMEOUT_SECS \
+                     to raise the bound if this host's CoreML cold-compile \
+                     legitimately needs more time.",
+                    coreml_init_timeout()
+                ))
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(anyhow::anyhow!(
+                "{provider} EP init guard thread panicked or disconnected unexpectedly"
+            )),
+        }
+    }
+
     /// Construct with an explicit LRU capacity.
     pub async fn with_cache_size(capacity: usize) -> Result<Self> {
         let capacity =
@@ -324,7 +516,7 @@ impl FastEmbedder {
                     .unwrap_or(false);
 
                 let (q_opts, q_provider) = Self::init_options(EmbeddingModel::AllMiniLML6V2Q);
-                let (m, provider) = match TextEmbedding::try_new(q_opts) {
+                let (m, provider) = match Self::try_new_bounded(q_opts, q_provider) {
                     Ok(m) => (m, q_provider),
                     Err(q_err) => {
                         if q_provider != ExecutionProvider::Cpu && !require_gpu {
@@ -332,11 +524,14 @@ impl FastEmbedder {
                                 predicted_provider = %q_provider,
                                 actual_provider = "CPU",
                                 error = %q_err,
-                                "SILENT FALLBACK DETECTED (#763): {p} EP failed to \
-                                 initialise — falling back to CPU. The /health endpoint \
+                                "AUTO CPU FALLBACK (#2111 / #763): {p} EP failed to \
+                                 initialise (or hung past its bounded timeout) — \
+                                 falling back to CPU automatically. The /health endpoint \
                                  will report provider={p} but inference will run on CPU. \
                                  Set TRUSTY_DEVICE=gpu to surface this as a hard failure \
-                                 instead of a silent performance regression.",
+                                 instead of a silent performance regression, or \
+                                 TRUSTY_COREML_INIT_TIMEOUT_SECS to raise the CoreML \
+                                 hang-detection bound.",
                                 p = q_provider
                             );
                             // SAFETY: see TRUSTY_DEVICE comment in

--- a/crates/trusty-common/src/embedder/mod.rs
+++ b/crates/trusty-common/src/embedder/mod.rs
@@ -531,6 +531,96 @@ mod tests {
         }
     }
 
+    /// Why: issue #2111 — the fallback *decision* must be verifiable without a
+    /// real ORT/CoreML runtime. A successful init must never fall back or
+    /// poison the known-bad cache.
+    /// What: asserts `decide_fallback(Success) == (false, false)`.
+    /// Test: this test.
+    #[test]
+    fn fallback_decision_success_keeps_provider() {
+        use crate::embedder::fast_embedder::{InitOutcome, decide_fallback};
+        assert_eq!(decide_fallback(InitOutcome::Success), (false, false));
+    }
+
+    /// Why: a fast `Err` (pre-existing #763 behaviour) is not proof the
+    /// provider will misbehave again, so it must fall back to CPU for this
+    /// attempt WITHOUT poisoning the process-wide known-bad cache — the next
+    /// full `FastEmbedder::new()` should still retry the accelerated
+    /// provider.
+    /// What: asserts `decide_fallback(FastError) == (true, false)`.
+    /// Test: this test.
+    #[test]
+    fn fallback_decision_fast_error_falls_back_without_poisoning() {
+        use crate::embedder::fast_embedder::{InitOutcome, decide_fallback};
+        assert_eq!(decide_fallback(InitOutcome::FastError), (true, false));
+    }
+
+    /// Why: issue #2111 — a `Hung` outcome means an OS thread is permanently
+    /// stuck inside ORT/CoreML with no cancellation point. Falling back
+    /// without poisoning the cache would leak one more blocked thread on
+    /// every subsequent retry (e.g. each ~5-minute dream cycle), so a hang
+    /// MUST poison `COREML_KNOWN_BAD` so it is never attempted again this
+    /// process.
+    /// What: asserts `decide_fallback(Hung) == (true, true)`.
+    /// Test: this test.
+    #[test]
+    fn fallback_decision_hang_falls_back_and_poisons() {
+        use crate::embedder::fast_embedder::{InitOutcome, decide_fallback};
+        assert_eq!(decide_fallback(InitOutcome::Hung), (true, true));
+    }
+
+    /// Why: issue #2111 — the CoreML hang-detection bound must default to a
+    /// documented, sensible value (60 s) so a hang is caught well before the
+    /// outer `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` (default 180 s) gives up.
+    /// What: clears the env override and asserts the default duration.
+    /// Test: this test.
+    #[test]
+    fn coreml_init_timeout_default() {
+        use crate::embedder::fast_embedder::{
+            DEFAULT_COREML_INIT_TIMEOUT_SECS, coreml_init_timeout,
+        };
+        let _g = ENV_LOCK.lock().unwrap();
+        let _t = EnvVarGuard::apply("TRUSTY_COREML_INIT_TIMEOUT_SECS", None);
+        assert_eq!(
+            coreml_init_timeout(),
+            std::time::Duration::from_secs(DEFAULT_COREML_INIT_TIMEOUT_SECS)
+        );
+        assert_eq!(DEFAULT_COREML_INIT_TIMEOUT_SECS, 60);
+    }
+
+    /// Why: operators on a host with a legitimately slow (but working) CoreML
+    /// cold-compile must be able to raise the bound without a code change.
+    /// What: sets an explicit override and asserts it is honoured; also
+    /// checks a malformed value falls back to the default.
+    /// Test: this test.
+    #[test]
+    fn coreml_init_timeout_reads_env() {
+        use crate::embedder::fast_embedder::{
+            DEFAULT_COREML_INIT_TIMEOUT_SECS, coreml_init_timeout,
+        };
+        let _g = ENV_LOCK.lock().unwrap();
+        {
+            let _t = EnvVarGuard::apply("TRUSTY_COREML_INIT_TIMEOUT_SECS", Some("120"));
+            assert_eq!(coreml_init_timeout(), std::time::Duration::from_secs(120));
+        }
+        {
+            let _t = EnvVarGuard::apply("TRUSTY_COREML_INIT_TIMEOUT_SECS", Some("not-a-number"));
+            assert_eq!(
+                coreml_init_timeout(),
+                std::time::Duration::from_secs(DEFAULT_COREML_INIT_TIMEOUT_SECS),
+                "malformed override must fall back to the default"
+            );
+        }
+        {
+            let _t = EnvVarGuard::apply("TRUSTY_COREML_INIT_TIMEOUT_SECS", Some("0"));
+            assert_eq!(
+                coreml_init_timeout(),
+                std::time::Duration::from_secs(DEFAULT_COREML_INIT_TIMEOUT_SECS),
+                "zero override must fall back to the default"
+            );
+        }
+    }
+
     /// Why: zero vectors from a CUDA EP silent fallback would be stored in the
     /// HNSW index and corrupt all similarity searches.
     /// What: asserts `is_zero_vector` fires on an all-zero vector and not on

--- a/crates/trusty-common/src/memory_core/retrieval/embedder.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/embedder.rs
@@ -37,7 +37,23 @@ pub(super) static SHARED_EMBEDDER: OnceCell<Arc<dyn Embedder + Send + Sync>> =
 /// or a CUDA warm-up — without a timeout the first `memory_remember` or
 /// `memory_recall` call blocks indefinitely. Wrapping in
 /// `tokio::time::timeout` turns the hang into an explicit error that the
-/// caller (and the daemon) can surface to the user.
+/// caller (and the daemon) can surface to the user. Issue #2111: on some
+/// Apple Silicon hosts the CoreML EP init inside `FastEmbedder::new()` does
+/// not just run long — it hangs indefinitely with the OS thread blocked and
+/// no cancellation point, so this `tokio::time::timeout` only abandons the
+/// *future*; a naive retry from `get_or_try_init` on every subsequent caller
+/// (e.g. each ~5-minute dream cycle) would otherwise leak one more
+/// permanently blocked blocking-pool thread per retry. The fix lives one
+/// layer down, in `FastEmbedder::try_new_bounded`
+/// (`crate::embedder::fast_embedder`): it bounds the CoreML attempt itself
+/// (default 60 s, well inside this function's 180 s default) and
+/// auto-falls-back to CPU, remembering the hang process-wide via
+/// `COREML_KNOWN_BAD` so CoreML is never attempted again this process. That
+/// means `FastEmbedder::new()` now succeeds (on CPU) well within this
+/// timeout in the common case — `get_or_try_init` here does not need to
+/// retry at all — and even in the pathological case of a misconfigured
+/// (too-short) outer timeout, at most one extra thread can leak before the
+/// inner bound fires and poisons the cache, not an unbounded number.
 /// What: Returns a clone of the shared `Arc<dyn Embedder + Send + Sync>`,
 /// initialising it on first call via `FastEmbedder::new()`. The init is
 /// bounded by `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` (default 180 s). In test
@@ -45,7 +61,9 @@ pub(super) static SHARED_EMBEDDER: OnceCell<Arc<dyn Embedder + Send + Sync>> =
 /// the cell is pre-populated with `MockEmbedder` and no model download is
 /// attempted.
 /// Test: `shared_embedder_is_singleton`; timeout path covered by
-///       `timeout_wrapper_fires_on_embedder_init` in retrieval::tests.
+///       `timeout_wrapper_fires_on_embedder_init` in retrieval::tests; the
+///       CoreML hang auto-recovery decision logic is covered by the
+///       `decide_fallback` unit tests in `embedder::fast_embedder`.
 pub async fn shared_embedder() -> Result<Arc<dyn Embedder + Send + Sync>> {
     let timeout = timeouts::embedder_init_timeout();
     SHARED_EMBEDDER


### PR DESCRIPTION
## Summary

- **Root cause**: On some Apple Silicon hosts, `FastEmbedder::new()`'s CoreML execution-provider init (`TextEmbedding::try_new` in `crates/trusty-common/src/embedder/fast_embedder.rs`) can block the OS thread **indefinitely** (0% CPU, no error, no progress). This is not a slow cold-compile — it's a genuine hang. The existing `#763` silent-fallback-to-CPU logic only fires on a *fast* `Err`, so it never triggers on a hang, and the daemon gets stuck in `warming` forever. The outer `tokio::time::timeout` wrapper in `memory_core/retrieval/embedder.rs` only abandons the *future* — the `spawn_blocking` OS thread stuck inside ORT/CoreML is never cancelled, so every retry (e.g. each ~5-minute dream cycle hitting `OnceCell::get_or_try_init`) leaks another permanently blocked thread.

- **Fix — bounded CoreML init with auto-CPU fallback (`FastEmbedder::try_new_bounded`)**: the CoreML attempt now runs on a dedicated `std::thread`, raced against `mpsc::Receiver::recv_timeout` with a **60 s default bound** (`TRUSTY_COREML_INIT_TIMEOUT_SECS`, configurable). Why 60 s: the existing ops workaround `TRUSTY_DEVICE=cpu` proves CPU init completes in ~11 s on an affected host, so 60 s gives generous headroom above the CPU path and above a legitimately slow (but working) CoreML cold-compile, while staying well under the outer `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` (default 180 s) so the auto-fallback completes and the embedder becomes *ready* before that wrapper would otherwise report a hard failure.

- **Fix — stop the thread leak (`COREML_KNOWN_BAD` cache)**: the first time a hang is observed, a process-wide `AtomicBool` is set. Every subsequent embedder construction (including `OnceCell` retries) skips CoreML entirely and goes straight to CPU without spawning another doomed thread. A fast `Err` (the pre-existing #763 case) does **not** poison this cache — only a genuine hang does — since a transient registration failure isn't proof CoreML will misbehave again. The decision is centralized in a pure function `decide_fallback(InitOutcome) -> (fall_back, mark_known_bad)` so it's unit-testable without a live ORT/CoreML runtime.

- `TRUSTY_DEVICE=cpu` continues to work unchanged as an explicit override.

## Files changed
- `crates/trusty-common/src/embedder/fast_embedder.rs` — `COREML_KNOWN_BAD`, `coreml_init_timeout()`, `InitOutcome`/`decide_fallback`, `FastEmbedder::try_new_bounded`; wired into `with_cache_size`'s existing #763 fallback branch (unchanged control flow, now hang-aware).
- `crates/trusty-common/src/embedder/mod.rs` — unit tests for the decision logic and timeout resolver.
- `crates/trusty-common/src/memory_core/retrieval/embedder.rs` — doc update explaining why the outer `OnceCell` retry no longer needs its own fix (the lower-level bound + cache resolves it).

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-common --features memory-core,embedder-test-support` — 437 passed, 0 failed, 11 ignored (ONNX-backed tests, pre-existing `#[ignore]`); new `fallback_decision_*` and `coreml_init_timeout_*` tests included and passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations

Closes #2111

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)