### PR TITLE
fix(trusty-mpm): guarantee PM delegation persona loads via fail-closed carriers

### DIFF
--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -109,11 +109,12 @@ pub fn install_system_prompt() -> std::io::Result<std::path::PathBuf> {
 /// The CLAUDE.md stub seeded into a project on first session start.
 ///
 /// Why: the project needs a place for project-specific notes; trusty-mpm
-/// creates it once and then never touches it, so the operator can edit freely.
+/// creates it once and then never touches it (outside the fenced delegation
+/// block below), so the operator can edit freely.
 const CLAUDE_MD_STUB: &str = "# Project Instructions
 
 <!-- trusty-mpm: created by `trusty-mpm session start` — customize for your project -->
-<!-- This file is yours: trusty-mpm will never overwrite it after creation. -->
+<!-- Everything below the delegation directive block is yours: trusty-mpm will never overwrite it after creation. -->
 
 ## Project Context
 
@@ -123,6 +124,140 @@ const CLAUDE_MD_STUB: &str = "# Project Instructions
 
 <!-- Any agent behavior preferences specific to this project. -->
 ";
+
+// ---------------------------------------------------------------------------
+// CLAUDE.md delegation-directive carrier (issue #2125 item 1)
+//
+// Why: the output-style file and `--append-system-prompt-file` carriers can
+// both silently fail to reach a launched session — wrong `--setting-sources`
+// tier, a missing adapter flag, an old Claude Code build. CLAUDE.md is the one
+// instruction surface Claude Code ALWAYS reads at session start regardless of
+// any of those knobs, so it is the fail-closed fallback carrier for the core
+// "PM must not do work directly; delegate" directive.
+// ---------------------------------------------------------------------------
+
+/// Begin marker fencing the framework-owned delegation-directive block that
+/// [`load_or_create_claude_md`] idempotently upserts into the project
+/// `CLAUDE.md`.
+///
+/// Why: the fence lets [`upsert_delegation_block`] find and replace ONLY the
+/// framework-owned span on re-runs, so repeated `prepare_session` calls update
+/// the block in place instead of duplicating it, and every byte outside the
+/// fence — the operator's own notes — is left untouched.
+/// What: an HTML-comment marker, invisible in rendered Markdown and harmless
+/// to Claude Code's raw-text reading.
+/// Test: `upsert_delegation_block_inserts_when_absent`,
+/// `upsert_delegation_block_updates_in_place`,
+/// `upsert_delegation_block_preserves_operator_content`.
+const DELEGATION_BLOCK_BEGIN: &str = "<!-- trusty-mpm:delegation-directive:begin \
+(framework-owned — do not edit; regenerated on every session start, see issue #2125) -->";
+
+/// End marker paired with [`DELEGATION_BLOCK_BEGIN`].
+const DELEGATION_BLOCK_END: &str = "<!-- trusty-mpm:delegation-directive:end -->";
+
+/// Fallback delegation-directive text used only if the bundled `trusty-mpm`
+/// output style's PRIMARY DIRECTIVE section cannot be located.
+///
+/// Why: [`delegation_directive_text`] extracts the live wording from the
+/// bundled output-style asset so this carrier can never drift from what the
+/// output-style / system-prompt carriers state; this fallback is the
+/// fail-closed floor if that extraction ever comes up empty — the CLAUDE.md
+/// carrier must NEVER end up blank. Verbatim excerpt of the same directive.
+/// Test: `delegation_directive_text_falls_back_when_marker_missing`.
+const DELEGATION_DIRECTIVE_FALLBACK: &str = "## PM Delegation Directive (Non-Overridable)
+
+**YOU ARE STRICTLY FORBIDDEN FROM DOING ANY WORK DIRECTLY.**
+
+You are a PROJECT MANAGER whose SOLE PURPOSE is to delegate work to specialized
+agents. You orchestrate; you do not implement.
+
+**THIS IS ABSOLUTE. NO EXCEPTIONS.**";
+
+/// Extract the "PRIMARY DIRECTIVE" heading section from `source`.
+///
+/// Why: item 1 must reuse the SAME wording the output-style / BASE_PM carriers
+/// already state rather than hand-duplicate prose that can drift; separating
+/// the source as a parameter (rather than reading the bundled constant
+/// directly) lets the fallback branch be exercised in tests without editing
+/// the real asset.
+/// What: locates the line containing `PRIMARY DIRECTIVE` and returns
+/// everything from the start of that line up to (excluding) the next
+/// Markdown `##` heading, trimmed. Returns `None` when the marker is absent.
+/// Test: `delegation_directive_text_extracts_primary_directive`,
+/// `delegation_directive_text_falls_back_when_marker_missing`.
+fn extract_primary_directive(source: &'static str) -> Option<&'static str> {
+    let heading_pos = source.find("PRIMARY DIRECTIVE")?;
+    let line_start = source[..heading_pos]
+        .rfind('\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let rest = &source[line_start..];
+    let after_heading_line = rest.find('\n').map(|i| i + 1).unwrap_or(rest.len());
+    let end = rest[after_heading_line..]
+        .find("\n## ")
+        .map(|i| after_heading_line + i)
+        .unwrap_or(rest.len());
+    let section = rest[..end].trim();
+    if section.is_empty() {
+        None
+    } else {
+        Some(section)
+    }
+}
+
+/// Resolve the live delegation-directive text for the CLAUDE.md carrier.
+///
+/// What: [`extract_primary_directive`] applied to the bundled `trusty-mpm`
+/// output style ([`crate::core::bundle::OUTPUT_STYLE`]), falling back to
+/// [`DELEGATION_DIRECTIVE_FALLBACK`] (fail-closed — never an empty directive).
+/// Test: `delegation_directive_text_extracts_primary_directive`.
+fn delegation_directive_text() -> &'static str {
+    extract_primary_directive(crate::core::bundle::OUTPUT_STYLE)
+        .unwrap_or(DELEGATION_DIRECTIVE_FALLBACK)
+}
+
+/// Compose the fenced delegation-directive block written into `CLAUDE.md`.
+///
+/// Test: `upsert_delegation_block_inserts_when_absent`.
+fn delegation_block() -> String {
+    format!(
+        "{DELEGATION_BLOCK_BEGIN}\n\n{}\n\n{DELEGATION_BLOCK_END}",
+        delegation_directive_text()
+    )
+}
+
+/// Idempotently upsert the delegation-directive block into `content`.
+///
+/// Why: [`load_or_create_claude_md`] must guarantee the block is present and
+/// current on every `prepare_session` run without duplicating it on repeated
+/// calls or disturbing the operator's own notes.
+/// What: if both fence markers are present (in order), replaces the span
+/// between them (inclusive) with a freshly-built block; otherwise prepends the
+/// block (followed by a blank line) to `content`, leaving all pre-existing
+/// content intact beneath it.
+/// Test: `upsert_delegation_block_inserts_when_absent`,
+/// `upsert_delegation_block_updates_in_place`,
+/// `upsert_delegation_block_preserves_operator_content`.
+fn upsert_delegation_block(content: &str) -> String {
+    let block = delegation_block();
+    match (
+        content.find(DELEGATION_BLOCK_BEGIN),
+        content.find(DELEGATION_BLOCK_END),
+    ) {
+        (Some(start), Some(end)) if end > start => {
+            let end = end + DELEGATION_BLOCK_END.len();
+            format!("{}{}{}", &content[..start], block, &content[end..])
+        }
+        _ => {
+            let rest = content.trim_start_matches('\n');
+            if rest.is_empty() {
+                format!("{block}\n")
+            } else {
+                format!("{block}\n\n{rest}")
+            }
+        }
+    }
+}
 
 /// Inputs to the instruction merge pipeline.
 ///
@@ -238,15 +373,28 @@ pub fn build_instructions(input: &PipelineInput) -> Result<PipelineOutput, Pipel
     })
 }
 
-/// Load `CLAUDE.md`, seeding the stub (and parents) if it does not exist.
+/// Load `CLAUDE.md`, seeding the stub (and parents) if it does not exist, then
+/// additively + idempotently upsert the fail-closed delegation-directive block
+/// (issue #2125 item 1).
 ///
-/// Why: section 5 is project-owned; trusty-mpm creates it exactly once and
-/// then never overwrites it, so the operator's edits always survive.
-/// What: returns the file's content and whether this call created it.
-/// Test: `pipeline_creates_claude_md`, `pipeline_claude_md_not_overwritten`.
+/// Why: section 5 is otherwise project-owned; trusty-mpm creates the stub
+/// exactly once and never overwrites the operator's own notes, so they always
+/// survive. But the delegation directive must be active on EVERY session
+/// start regardless of which other carriers (output-style, system-prompt file)
+/// happen to load — so this one small, clearly-fenced block IS regenerated on
+/// every call, additively, alongside whatever the operator has written.
+/// What: reads the existing file (creating it from [`CLAUDE_MD_STUB`], plus
+/// parent directories, when absent), upserts the delegation block via
+/// [`upsert_delegation_block`], and writes back only when the content
+/// actually changed (or the file was just created). Returns the final content
+/// and whether this call created the file.
+/// Test: `pipeline_creates_claude_md`, `pipeline_claude_md_not_overwritten`,
+/// `upsert_delegation_block_inserts_when_absent`,
+/// `upsert_delegation_block_updates_in_place`,
+/// `upsert_delegation_block_preserves_operator_content`.
 fn load_or_create_claude_md(path: &PathBuf) -> Result<(String, bool), PipelineError> {
-    match std::fs::read_to_string(path) {
-        Ok(text) => Ok((text, false)),
+    let (existing, created) = match std::fs::read_to_string(path) {
+        Ok(text) => (text, false),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             if let Some(parent) = path.parent()
                 && !parent.as_os_str().is_empty()
@@ -256,17 +404,24 @@ fn load_or_create_claude_md(path: &PathBuf) -> Result<(String, bool), PipelineEr
                     source,
                 })?;
             }
-            std::fs::write(path, CLAUDE_MD_STUB).map_err(|source| PipelineError::Io {
-                path: path.clone(),
-                source,
-            })?;
-            Ok((CLAUDE_MD_STUB.to_string(), true))
+            (CLAUDE_MD_STUB.to_string(), true)
         }
-        Err(err) => Err(PipelineError::Io {
+        Err(err) => {
+            return Err(PipelineError::Io {
+                path: path.clone(),
+                source: err,
+            });
+        }
+    };
+
+    let updated = upsert_delegation_block(&existing);
+    if created || updated != existing {
+        std::fs::write(path, &updated).map_err(|source| PipelineError::Io {
             path: path.clone(),
-            source: err,
-        }),
+            source,
+        })?;
     }
+    Ok((updated, created))
 }
 
 /// Concatenate the three instruction sections in the fixed 3 → 4 → 5 order.
@@ -393,7 +548,10 @@ mod tests {
 
     #[test]
     fn pipeline_claude_md_not_overwritten() {
-        // An existing CLAUDE.md with custom content must be preserved verbatim.
+        // An existing CLAUDE.md with custom content must have that content
+        // preserved; the framework additively upserts its own fenced
+        // delegation-directive block alongside it (issue #2125 item 1) rather
+        // than leaving the file byte-for-byte untouched.
         let tmp = TempDir::new().unwrap();
         let input = input_in(&tmp);
         write_file(&input.framework_instructions_path, "# Framework\n");
@@ -404,8 +562,80 @@ mod tests {
         let out = build_instructions(&input).unwrap();
         assert!(!out.claude_md_created);
         let on_disk = fs::read_to_string(&input.claude_md_path).unwrap();
-        assert_eq!(on_disk, custom, "custom CLAUDE.md must be untouched");
+        assert!(
+            on_disk.contains("CUSTOM HAND-WRITTEN CONTENT"),
+            "custom CLAUDE.md content must be preserved: {on_disk}"
+        );
+        assert!(
+            on_disk.contains(DELEGATION_BLOCK_BEGIN),
+            "delegation-directive block must be additively inserted: {on_disk}"
+        );
         assert!(out.merged.contains("CUSTOM HAND-WRITTEN CONTENT"));
+    }
+
+    #[test]
+    fn upsert_delegation_block_inserts_when_absent() {
+        // Why (#2125 item 1): a CLAUDE.md with no prior fence gets the block
+        // prepended, and the block itself must carry the real directive text.
+        let updated = upsert_delegation_block("# My Project\n\nSome notes.\n");
+        assert!(updated.contains(DELEGATION_BLOCK_BEGIN));
+        assert!(updated.contains(DELEGATION_BLOCK_END));
+        assert!(updated.contains("Some notes."));
+        assert!(
+            updated.contains("DELEGATE") || updated.contains("delegate"),
+            "block must carry the delegation directive: {updated}"
+        );
+    }
+
+    #[test]
+    fn upsert_delegation_block_updates_in_place() {
+        // Why (#2125 item 1): re-running the upsert on content that already
+        // carries the block must replace it IN PLACE — never duplicate it —
+        // and must not disturb content outside the fence.
+        let first = upsert_delegation_block("# My Project\n\nOperator notes.\n");
+        let second = upsert_delegation_block(&first);
+        assert_eq!(
+            second.matches(DELEGATION_BLOCK_BEGIN).count(),
+            1,
+            "a second upsert must not duplicate the begin marker: {second}"
+        );
+        assert_eq!(
+            second.matches(DELEGATION_BLOCK_END).count(),
+            1,
+            "a second upsert must not duplicate the end marker: {second}"
+        );
+        assert!(second.contains("Operator notes."));
+    }
+
+    #[test]
+    fn upsert_delegation_block_preserves_operator_content() {
+        // Why: everything outside the fence is the operator's — it must
+        // survive both the initial insert and a subsequent re-upsert.
+        let operator = "# Custom\n\n## Section\n\nOperator-owned text.\n";
+        let first = upsert_delegation_block(operator);
+        assert!(first.contains("Operator-owned text."));
+        assert!(first.contains("## Section"));
+        let second = upsert_delegation_block(&first);
+        assert!(second.contains("Operator-owned text."));
+        assert!(second.contains("## Section"));
+    }
+
+    #[test]
+    fn delegation_directive_text_extracts_primary_directive() {
+        // Why: the CLAUDE.md carrier must reuse the SAME wording the bundled
+        // output style states, not invented prose.
+        let text = delegation_directive_text();
+        assert!(text.contains("PRIMARY DIRECTIVE"));
+        assert!(text.to_uppercase().contains("DELEGATE"));
+    }
+
+    #[test]
+    fn delegation_directive_text_falls_back_when_marker_missing() {
+        // Why: if the marker is ever absent from the source text, extraction
+        // must fail closed to `None` rather than panicking or returning junk —
+        // `delegation_directive_text` then supplies the fallback text.
+        assert_eq!(extract_primary_directive("# no marker here\n"), None);
+        assert!(!DELEGATION_DIRECTIVE_FALLBACK.is_empty());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -484,6 +484,20 @@ fn prepare_session_inner(
         }
     };
 
+    // Issue #2125 item 2: ALSO deploy the bundled output styles under the
+    // PROJECT tier (`<project_dir>/.claude/output-styles/`). The daemon
+    // managed-spawn path launches `claude --setting-sources project,local`,
+    // which excludes the `user` tier the deploy above lands in — without a
+    // project-tier copy, the `outputStyle` id `write_output_style` writes into
+    // `<project_dir>/.claude/settings.json` cannot resolve under that flag, so
+    // Claude Code silently falls back to its own default (never applying the
+    // PM delegation persona). Non-fatal: a failure here only leaves that one
+    // carrier degraded — the home-tier deploy and the standalone `tm run`
+    // driver (which passes no `--setting-sources` flag) are unaffected.
+    if let Err(err) = deploy_output_style(project_dir) {
+        tracing::warn!("failed to deploy project-tier trusty-mpm output style: {err}");
+    }
+
     // DOC-28 cutover bridge — auto-inject catch-up as seed context (#1762).
     // Fail-open: if catch-up fails for any reason (daemon not running, no git
     // repo, runtime error), the session still launches; catchup_context is None.

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -137,23 +137,31 @@ pub(super) fn trusty_memory_mcp_value(palace_slug: Option<&str>) -> serde_json::
 pub(super) const GLOBAL_TRUSTY_MEMORY_EVENTS: &[&str] =
     &["UserPromptSubmit", "SessionStart", "PostToolUse", "Stop"];
 
-/// Deploy ALL bundled output styles under `<home>/.claude/output-styles/`.
+/// Deploy ALL bundled output styles under `<root>/.claude/output-styles/`.
 ///
 /// Why: [`write_output_style`] sets `"outputStyle": "<active>"` in the project
 /// settings; Claude Code honours that name only when a matching style file
-/// exists in `~/.claude/output-styles/`. HR-4 bundles three styles
+/// exists under a `.claude/output-styles/` directory that is actually loaded
+/// by the running session's `--setting-sources`. HR-4 bundles three styles
 /// (professional / teaching / research) and the operator may select any of
-/// them, so ALL of them must be on disk for the selection to resolve. `home` is
-/// passed in (rather than resolved here) so tests can target a temp directory
-/// instead of the operator's real home.
-/// What: creates `<home>/.claude/output-styles/` if absent, then writes every
+/// them, so ALL of them must be on disk for the selection to resolve. `root`
+/// is passed in (rather than resolved here) so callers can target either the
+/// operator's `$HOME`/`CLAUDE_CONFIG_DIR` (the `user` tier) or, since issue
+/// #2125 item 2, the PROJECT directory itself (the `project` tier) — the
+/// daemon managed-spawn path launches `claude --setting-sources project,local`,
+/// which EXCLUDES the `user` tier, so without a project-tier copy the
+/// `outputStyle` id written into the project's `settings.json` cannot resolve
+/// and Claude Code silently falls back to its own default. `prepare_session`
+/// calls this for BOTH roots; it is a plain additive deploy either way.
+/// What: creates `<root>/.claude/output-styles/` if absent, then writes every
 /// entry in [`crate::core::bundle::OUTPUT_STYLES`] to its `file_name`, always
 /// overwriting so framework upgrades to the styles propagate on the next launch.
 /// Returns the path of the default (professional) style for the [`PrepReport`].
 /// Test: `deploy_output_style_writes_file`, `deploy_output_style_overwrites`,
-/// `deploy_output_style_writes_all_styles`.
-pub(super) fn deploy_output_style(home: &Path) -> Result<PathBuf, PrepError> {
-    let style_dir = home.join(".claude").join("output-styles");
+/// `deploy_output_style_writes_all_styles`,
+/// `deploy_output_style_writes_under_project_root`.
+pub(super) fn deploy_output_style(root: &Path) -> Result<PathBuf, PrepError> {
+    let style_dir = root.join(".claude").join("output-styles");
     std::fs::create_dir_all(&style_dir).map_err(|source| PrepError::Io {
         path: style_dir.clone(),
         source,

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -228,6 +228,27 @@ fn prepare_session_writes_claude_md_and_stash() {
 }
 
 #[test]
+fn prepare_session_deploys_project_tier_output_style() {
+    // Why (#2125 item 2): the daemon managed-spawn path launches `claude`
+    // with `--setting-sources project,local`, excluding the `user` tier the
+    // home-dir deploy lands in. Without a project-tier copy the `outputStyle`
+    // id written into `<project>/.claude/settings.json` cannot resolve.
+    let tmp_home = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    prepare_session(&fw, project).expect("prep succeeds");
+
+    let project_style = project.join(".claude/output-styles/trusty-mpm.md");
+    assert!(
+        project_style.exists(),
+        "project-tier output style file must be deployed: {}",
+        project_style.display()
+    );
+}
+
+#[test]
 fn prepare_session_self_heals_missing_skill_source() {
     // #1917: `fw.skills` (the framework skill *source* dir `skill_source_dir()`
     // falls back to) starts out completely absent here — simulating a machine

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -132,6 +132,28 @@ fn env_bin_prefix(claude_bin: &str, config_dir: Option<&Path>) -> String {
     }
 }
 
+/// Build the `--append-system-prompt-file <path>` flag fragment for a spawn
+/// command, when a prompt file was written (issue #2125 item 3).
+///
+/// Why: the flag must be single-quoted for the same reason
+/// [`env_bin_prefix`] quotes `CLAUDE_CONFIG_DIR` — the prompt file lives under
+/// `std::env::temp_dir()`, which is not attacker-controlled, but quoting
+/// defensively costs nothing and matches this file's established convention.
+/// What: `" --append-system-prompt-file '<path>'"` when `prompt_file` is
+/// `Some`; an empty string when `None` (no prompt was built — e.g. the write
+/// failed — so the flag is simply omitted rather than passing a bad path).
+/// Test: `spawn_command_with_prompt_file_contains_flag`,
+/// `spawn_command_without_prompt_file_omits_flag`.
+fn prompt_file_flag(prompt_file: Option<&Path>) -> String {
+    match prompt_file {
+        Some(p) => format!(
+            " --append-system-prompt-file {}",
+            shell_single_quote(&p.display().to_string())
+        ),
+        None => String::new(),
+    }
+}
+
 /// The shell command sent to the tmux pane to start Claude Code.
 ///
 /// Why: the env prefix (see [`env_bin_prefix`]) strips `ANTHROPIC_API_KEY` and,
@@ -152,31 +174,84 @@ fn env_bin_prefix(claude_bin: &str, config_dir: Option<&Path>) -> String {
 /// unattended orchestration session from blocking on per-tool prompts (#1269).
 /// Both flags reuse the shared [`crate::core::model_inject::SETTING_SOURCES_FLAG`]
 /// / [`crate::core::model_inject::PERMISSION_MODE_FLAG`] constants so this spawn
-/// path and the CLI launch path can never drift.
-/// What: [`session_id_export_prefix`] followed by [`env_bin_prefix`] plus the
-/// two shared flag constants, followed by [`on_exit_hint_suffix`] (#2023
-/// component D — `; echo '<hint>'`, which only runs once `claude` exits and
-/// control returns to the pane); piped to `tmux send-keys … Enter`.
-/// `claude_bin` is the resolved binary — an absolute path under launchd so the
-/// pane (which inherits the daemon's minimal `PATH`) does not need `claude` on
-/// its own `PATH` (#1298). `session_id` is the managed session's UUID (#2023
-/// component B), exported so in-pane commands can identify the session after
-/// `claude` exits.
+/// path and the CLI launch path can never drift. `prompt_file` (issue #2125
+/// item 3) carries the PM system prompt via `--append-system-prompt-file` — the
+/// same mechanism the CLI `tm launch` / client `/connect` paths already use —
+/// so this, previously the one driver missing it, can no longer silently spawn
+/// vanilla Claude Code.
+/// What: [`session_id_export_prefix`] followed by [`env_bin_prefix`], the
+/// optional [`prompt_file_flag`], the two shared flag constants, followed by
+/// [`on_exit_hint_suffix`] (#2023 component D — `; echo '<hint>'`, which only
+/// runs once `claude` exits and control returns to the pane); piped to
+/// `tmux send-keys … Enter`. `claude_bin` is the resolved binary — an absolute
+/// path under launchd so the pane (which inherits the daemon's minimal `PATH`)
+/// does not need `claude` on its own `PATH` (#1298). `session_id` is the
+/// managed session's UUID (#2023 component B), exported so in-pane commands
+/// can identify the session after `claude` exits.
 /// Test: `spawn_command_contains_env_scrub`,
 /// `spawn_command_contains_isolation_flags`,
 /// `spawn_command_uses_resolved_binary`,
 /// `spawn_command_sets_claude_config_dir`,
 /// `spawn_command_exports_managed_session_id`,
-/// `spawn_command_prints_relaunch_hint_after_claude_exits`.
-fn spawn_command(claude_bin: &str, config_dir: Option<&Path>, session_id: &str) -> String {
+/// `spawn_command_prints_relaunch_hint_after_claude_exits`,
+/// `spawn_command_with_prompt_file_contains_flag`,
+/// `spawn_command_without_prompt_file_omits_flag`.
+fn spawn_command(
+    claude_bin: &str,
+    config_dir: Option<&Path>,
+    session_id: &str,
+    prompt_file: Option<&Path>,
+) -> String {
     format!(
-        "{}{} {} {}{}",
+        "{}{}{} {} {}{}",
         session_id_export_prefix(session_id),
         env_bin_prefix(claude_bin, config_dir),
+        prompt_file_flag(prompt_file),
         crate::core::model_inject::SETTING_SOURCES_FLAG,
         crate::core::model_inject::PERMISSION_MODE_FLAG,
         on_exit_hint_suffix(),
     )
+}
+
+/// Build and write the PM system-prompt file for `project_dir`, for injection
+/// into the daemon managed-spawn command via `--append-system-prompt-file`
+/// (issue #2125 item 3 — the daemon-adapter carrier).
+///
+/// Why: this module's own DOC-34 audit trail established that under
+/// `--setting-sources project,local` the framework roster/instructions load
+/// from the PROJECT layer, not the `CLAUDE_CONFIG_DIR` [`prepare_managed_config`]
+/// provisions — but `spawn` never actually passed `--append-system-prompt-file`
+/// at all, so the one thing that turns a bare `claude` process into a
+/// trusty-mpm PM never reached the daemon's default managed-spawn path,
+/// leaving every bare-`tm` session running vanilla Claude Code (#2125). This
+/// reuses the exact same seam
+/// ([`crate::core::session_launch::build_system_prompt_for_with_style_and_native`])
+/// the CLI `tm launch` / client `/connect` paths already use, so all three
+/// drivers build byte-identical prompts for the same project.
+/// What: resolves live native-output-style support (fail-safe to injection via
+/// [`crate::core::output_style::claude_supports_native_output_style`]), builds
+/// the override-resolved + style-injected prompt for `project_dir`, and writes
+/// it to a fresh temp file via [`crate::core::model_inject::write_prompt_file`].
+/// Returns `None` (logged) on any write failure so `spawn` still proceeds —
+/// matching the non-fatal pattern every other `prepare_managed_config` step in
+/// this file follows; the CLAUDE.md carrier (#2125 item 1) still applies even
+/// without this flag.
+/// Test: `build_prompt_file_writes_resolved_prompt_for_project`.
+fn build_prompt_file(project_dir: &Path) -> Option<std::path::PathBuf> {
+    let native = crate::core::output_style::claude_supports_native_output_style();
+    let prompt = crate::core::session_launch::build_system_prompt_for_with_style_and_native(
+        project_dir,
+        None,
+        native,
+    );
+    let file = crate::core::model_inject::write_prompt_file(&prompt);
+    if file.is_none() {
+        tracing::warn!(
+            project = %project_dir.display(),
+            "failed to write PM system-prompt file; spawning without --append-system-prompt-file"
+        );
+    }
+    file
 }
 
 /// Build a resume-aware Claude Code command (#1744, #1840).
@@ -575,11 +650,12 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
     /// What: resolves `claude` to an absolute path (returns `BinaryNotFound`
     /// if it cannot be found on `PATH` or in the well-known daemon dirs),
     /// provisions + trust-seeds the tm-owned `CLAUDE_CONFIG_DIR` via
-    /// [`prepare_managed_config`], then sends [`spawn_command`]
-    /// (`env -u ANTHROPIC_API_KEY CLAUDE_CONFIG_DIR=<dir> <abs-claude>` plus the
-    /// isolation/permission flags) to the pane; the task is logged for
-    /// observability but not passed to the command (Claude Code reads
-    /// instructions from CLAUDE.md or an interactive prompt).
+    /// [`prepare_managed_config`], builds the PM system-prompt file via
+    /// [`build_prompt_file`] (issue #2125 item 3), then sends [`spawn_command`]
+    /// (`env -u ANTHROPIC_API_KEY CLAUDE_CONFIG_DIR=<dir> <abs-claude>
+    /// --append-system-prompt-file <prompt>` plus the isolation/permission
+    /// flags) to the pane; the task is logged for observability but not passed
+    /// to the command.
     /// Test: `spawn_sends_env_scrub_when_binary_available`.
     fn spawn(
         &self,
@@ -608,10 +684,20 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
         // `--setting-sources project,local`, not from this config dir (see
         // `prepare_managed_config`). Non-fatal throughout (closes #1696).
         let config_dir = prepare_managed_config(tmux_name, cwd);
+        // Build and inject the PM system prompt (issue #2125 item 3) so this,
+        // the default daemon on-ramp, can no longer silently spawn vanilla
+        // Claude Code. Non-fatal: a write failure omits the flag and falls
+        // back to the CLAUDE.md carrier (item 1).
+        let prompt_file = build_prompt_file(cwd);
         self.tmux
             .send_line(
                 tmux_name,
-                &spawn_command(&claude_bin, config_dir.as_deref(), session_id),
+                &spawn_command(
+                    &claude_bin,
+                    config_dir.as_deref(),
+                    session_id,
+                    prompt_file.as_deref(),
+                ),
             )
             .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))
     }
@@ -770,7 +856,7 @@ mod tests {
     fn spawn_command_contains_env_scrub() {
         // The spawn command must always strip the API key from the environment
         // so the session falls back to OAuth (keyed by CLAUDE_CONFIG_DIR).
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
         assert!(
             cmd.contains("env -u ANTHROPIC_API_KEY"),
             "spawn command must contain env scrub: {cmd}"
@@ -789,7 +875,7 @@ mod tests {
         // can identify which managed session it belongs to. tmux
         // set-environment alone would NOT reach the pane's already-running
         // shell — the export must be part of the literal command line.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
         let expected_prefix = format!("export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; ");
         assert!(
             cmd.starts_with(&expected_prefix),
@@ -812,7 +898,7 @@ mod tests {
         // home, not the project's committed `.claude/`. It must co-exist with the
         // API-key scrub.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID);
+        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None);
         assert!(
             cmd.contains(
                 "env -u ANTHROPIC_API_KEY \
@@ -837,7 +923,7 @@ mod tests {
         // (`env: -u: No such file or directory`), fatally killing every managed
         // session spawn.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID);
+        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None);
         let u_pos = cmd
             .find("-u ANTHROPIC_API_KEY")
             .expect("cmd must contain -u ANTHROPIC_API_KEY");
@@ -856,7 +942,7 @@ mod tests {
         // When home is unresolvable there is no config dir to point at; the
         // command must fall back to the legacy scrub-only prefix (no bare
         // `CLAUDE_CONFIG_DIR=` token).
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
         assert!(
             !cmd.contains("CLAUDE_CONFIG_DIR"),
             "no config dir → must not reference CLAUDE_CONFIG_DIR: {cmd}"
@@ -869,7 +955,7 @@ mod tests {
         // the pane command. The path must appear single-quoted and INTACT so
         // `env` receives one CLAUDE_CONFIG_DIR value, not two argv tokens.
         let dir = Path::new("/Users/John Doe/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID);
+        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None);
         assert!(
             cmd.contains(
                 "env -u ANTHROPIC_API_KEY \
@@ -909,7 +995,7 @@ mod tests {
         // Why: the session_manager spawn path must isolate from the user's global
         // settings and run fully unattended (bypass all permission prompts) so
         // multi-agent orchestration never stalls on interactive approval dialogs.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
         assert!(
             cmd.contains("--setting-sources project,local"),
             "spawn command must isolate settings: {cmd}"
@@ -930,7 +1016,7 @@ mod tests {
         // Why (#1298): under launchd the pane inherits a minimal PATH, so the
         // spawn command must invoke claude by the resolved (absolute) path
         // rather than a bare `claude` that the pane's PATH cannot find.
-        let cmd = spawn_command("/Users/me/.local/bin/claude", None, TEST_SESSION_ID);
+        let cmd = spawn_command("/Users/me/.local/bin/claude", None, TEST_SESSION_ID, None);
         assert!(
             cmd.contains("env -u ANTHROPIC_API_KEY /Users/me/.local/bin/claude "),
             "spawn command must invoke the resolved absolute claude path: {cmd}"
@@ -954,7 +1040,7 @@ mod tests {
         // HOME is redirected so the spawn's config-dir provisioning + trust seed
         // land in a throwaway dir, not the developer's real ~/.trusty-tools.
         let _home = HomeGuard::set();
-        let Some(claude_bin) = ClaudeCodeAdapter::resolve_claude() else {
+        let Some(_claude_bin) = ClaudeCodeAdapter::resolve_claude() else {
             return;
         };
         let fake = FakeTmux::new();
@@ -965,16 +1051,65 @@ mod tests {
         let sends = fake.sends.lock().unwrap();
         assert_eq!(sends.len(), 1);
         assert_eq!(sends[0].0, "tmpm-test");
-        // The sent command must equal the builder output for whatever config dir
-        // resolves under the redirected HOME (Some in a normal env).
-        let config_dir = crate::core::trusty_tools_config::managed_claude_config_dir();
-        assert_eq!(
-            sends[0].1,
-            spawn_command(&claude_bin, config_dir.as_deref(), TEST_SESSION_ID)
+        let cmd = &sends[0].1;
+        // Must carry the env scrub regardless (the option must precede any
+        // intervening `CLAUDE_CONFIG_DIR=` assignment per POSIX env grammar).
+        assert!(cmd.contains("-u ANTHROPIC_API_KEY"));
+        // Issue #2125 item 3: the spawn command must inject the PM system
+        // prompt via --append-system-prompt-file — the third fail-closed
+        // carrier — so this, the default daemon on-ramp, can no longer
+        // silently spawn vanilla Claude Code. The prompt file path itself is
+        // non-deterministic (fresh UUID per call), so this asserts the flag's
+        // presence rather than an exact command match.
+        assert!(
+            cmd.contains("--append-system-prompt-file"),
+            "spawn command must inject the PM system prompt file: {cmd}"
         );
-        // And it must carry the env scrub regardless (the option must precede
-        // any intervening `CLAUDE_CONFIG_DIR=` assignment per POSIX env grammar).
-        assert!(sends[0].1.contains("-u ANTHROPIC_API_KEY"));
+    }
+
+    #[test]
+    fn spawn_command_with_prompt_file_contains_flag() {
+        // #2125 item 3: when a prompt file is supplied, spawn_command must
+        // inject --append-system-prompt-file pointing at it, alongside the
+        // existing isolation flags — the third fail-closed carrier.
+        let path = Path::new("/tmp/trusty-mpm-system-prompt-test.txt");
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, Some(path));
+        assert!(
+            cmd.contains("--append-system-prompt-file '/tmp/trusty-mpm-system-prompt-test.txt'"),
+            "spawn command must pass the prompt file via --append-system-prompt-file: {cmd}"
+        );
+        assert!(
+            cmd.contains("--setting-sources project,local"),
+            "isolation flags must still be present alongside the prompt file: {cmd}"
+        );
+    }
+
+    #[test]
+    fn spawn_command_without_prompt_file_omits_flag() {
+        // #2125 item 3: no prompt file (e.g. the write failed) → the flag must
+        // be omitted entirely rather than passed with a bad/empty path.
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
+        assert!(
+            !cmd.contains("--append-system-prompt-file"),
+            "no prompt file → flag must be absent: {cmd}"
+        );
+    }
+
+    #[test]
+    fn build_prompt_file_writes_resolved_prompt_for_project() {
+        // #2125 item 3: build_prompt_file must reuse the SAME
+        // build_system_prompt_for_with_style_and_native seam the CLI/client
+        // launch paths use, so the daemon adapter's injected prompt is never a
+        // divergent copy — proven here by asserting the written file carries
+        // the bundled PM_INSTRUCTIONS heading.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = build_prompt_file(tmp.path()).expect("prompt file written");
+        let content = std::fs::read_to_string(&path).expect("prompt file readable");
+        assert!(
+            content.contains("# PM Agent -- Trusty MPM"),
+            "prompt file must contain the resolved PM system prompt: {content}"
+        );
+        std::fs::remove_file(&path).ok();
     }
 
     #[test]
@@ -1362,7 +1497,7 @@ mod tests {
     fn spawn_command_prints_relaunch_hint_after_claude_exits() {
         // The hint must appear AFTER the claude invocation, separated by `;` so
         // it only runs once claude exits and control returns to the pane shell.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
         assert!(
             cmd.contains("; echo 'tm: run `tm` to relaunch this session'"),
             "spawn command must print the relaunch hint after claude exits: {cmd}"

--- a/crates/trusty-mpm/tests/e2e/test_instruction_pipeline.rs
+++ b/crates/trusty-mpm/tests/e2e/test_instruction_pipeline.rs
@@ -65,7 +65,9 @@ fn pipeline_produces_merged_output() {
     assert!(auth < proj, "delegation authority precedes project notes");
 }
 
-/// An existing project `CLAUDE.md` with custom content is preserved verbatim.
+/// An existing project `CLAUDE.md` with custom content has that content
+/// preserved; the framework additively upserts its own fenced
+/// delegation-directive block alongside it (issue #2125 item 1).
 #[test]
 fn pipeline_preserves_claude_md() {
     let tmp = TempDir::new().unwrap();
@@ -80,7 +82,14 @@ fn pipeline_preserves_claude_md() {
     assert!(!out.claude_md_created, "existing CLAUDE.md not recreated");
 
     let on_disk = std::fs::read_to_string(&input.claude_md_path).unwrap();
-    assert_eq!(on_disk, custom, "custom content untouched");
+    assert!(
+        on_disk.contains("CUSTOM HAND-WRITTEN CONTENT"),
+        "custom content preserved: {on_disk}"
+    );
+    assert!(
+        on_disk.contains("trusty-mpm:delegation-directive:begin"),
+        "delegation-directive block additively inserted: {on_disk}"
+    );
     assert!(out.merged.contains("CUSTOM HAND-WRITTEN CONTENT"));
 }
 


### PR DESCRIPTION
## Summary

Closes the P0 in #2125: the PM delegation persona was silently failing to load on the primary launch paths, so daemon-managed sessions ran as vanilla Claude Code. This PR lands the **core (items 1-3)** of the fix — three independent, fail-closed carriers for the delegation directive:

1. **CLAUDE.md carrier (fallback of last resort).** `prepare_session`'s `load_or_create_claude_md` now additively + idempotently upserts a fenced, framework-owned delegation-directive block into `<project>/CLAUDE.md` on every run. The block's wording is extracted programmatically from the bundled `trusty-mpm` output style's "PRIMARY DIRECTIVE" section (falling back to a hardcoded excerpt if that marker is ever missing — fail-closed, never blank). Begin/end HTML-comment markers (`<!-- trusty-mpm:delegation-directive:begin/end -->`) let re-runs update the block in place instead of duplicating it, and everything outside the fence — the operator's own project notes — is left untouched. CLAUDE.md is the one instruction surface Claude Code always reads at session start, independent of `--setting-sources`, `CLAUDE_CONFIG_DIR`, or Claude Code version.
2. **Project-tier output-style deployment.** `prepare_session` now deploys the bundled output styles to `<project>/.claude/output-styles/` in addition to the existing `$HOME`/`CLAUDE_CONFIG_DIR` deployment. The daemon managed-spawn path launches `claude --setting-sources project,local`, which excludes the `user` tier — so the `outputStyle` id already written into the project's `settings.json` could never resolve without a matching file under the project tier. `deploy_output_style` was generalized (parameter renamed `home` → `root`) since it's now called against both roots; no logic change.
3. **`--append-system-prompt-file` wired into the daemon adapter.** `ClaudeCodeAdapter::spawn` (`runtime/claude_code.rs`) now builds the PM system prompt via `build_system_prompt_for_with_style_and_native` (the same seam `tm launch` / `/connect` already use) and passes it via `--append-system-prompt-file`, closing the three-driver divergence for the default `tm` on-ramp.

Items 4-6 from #2125 (`tm connect` wiring, a startup self-check, and `pm_guard` deny-until-confirmed) are explicitly **out of scope** for this PR — tracked as follow-ups.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-mpm` (2366 lib tests + all integration suites, 0 failed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `bash scripts/check_line_cap.sh` (0 violations)
- [x] New unit tests per carrier: CLAUDE.md block inserted when absent / updated in place / preserves operator content; delegation-directive text extraction + fail-closed fallback; project-tier output-style file deployed; adapter command includes `--append-system-prompt-file` (both a pure `spawn_command` test and an integration-style `spawn()` assertion)
- [ ] **Live persona-active verification** (a real `claude` session actually showing the PM persona) requires a post-merge reinstall (`cargo install --path crates/trusty-mpm --locked`) + a fresh managed session — this cannot be proven from an isolated worktree and should be validated after merge.

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)