### PR TITLE
feat(trusty-code): CLI thin-client over the JSON-RPC daemon API (#2060)

### DIFF
--- a/crates/trusty-code/src/cli/attach.rs
+++ b/crates/trusty-code/src/cli/attach.rs
@@ -1,0 +1,82 @@
+//! `tcode attach <session-id>` (#2060).
+//!
+//! Why: the standalone streaming subcommand — attach to a session and
+//! narrate its live event stream to the terminal until it reaches a
+//! terminal state or the user presses Ctrl-C. Shares its polling-loop shape
+//! with `cli::run_task::run` (which attaches to the session IT just
+//! created); factored differently because `run_task` also needs to issue
+//! the initial `task.run` call and print a final summary, while this
+//! handler's whole job starts at `session.attach`.
+//! What: `session.attach` for the replay burst, then
+//! `StdioRpcClient::next_notification` in a loop (bounded polling interval,
+//! so Ctrl-C is never more than [`POLL_INTERVAL`] late), printing each via
+//! `cli_client::render::render_event_line`. Same in-memory-per-daemon
+//! caveat as `cli::session`/`cli::cancel`/`cli::transcript` — see their
+//! module docs.
+//! Test: `tests/cli_e2e.rs::attach_unknown_session_errors_cleanly`; the
+//! meaningful "real live events" case is exercised via
+//! `run_task_streams_live_events_and_reports_final_status`, which attaches
+//! to a session created within the SAME invocation.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde_json::json;
+
+use trusty_code::cli_client::StdioRpcClient;
+use trusty_code::cli_client::render::render_event_line;
+use trusty_code::events::Event;
+
+use super::tcode_exe;
+
+/// How often the attach loop wakes up to check for Ctrl-C between
+/// notification polls.
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// `tcode attach <SESSION_ID> [--project P]`.
+///
+/// Why/What: see module docs.
+pub async fn run(project: &Path, session_id: &str) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+
+    let attach_result = client
+        .call("session.attach", json!({"session_id": session_id}))
+        .await?;
+    let replay = attach_result
+        .get("events")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut done = false;
+    for raw in &replay {
+        if let Ok(envelope) =
+            serde_json::from_value::<trusty_code::events::SessionEventEnvelope>(raw.clone())
+        {
+            println!("{}", render_event_line(&envelope));
+            done = done || matches!(envelope.event, Event::SessionDone { .. });
+        }
+    }
+
+    while !done {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                eprintln!("tcode attach: detaching (Ctrl-C)");
+                break;
+            }
+            notification = client.next_notification(POLL_INTERVAL) => {
+                match notification? {
+                    Some(envelope) => {
+                        println!("{}", render_event_line(&envelope));
+                        done = matches!(envelope.event, Event::SessionDone { .. });
+                    }
+                    None => continue,
+                }
+            }
+        }
+    }
+
+    client.shutdown(Duration::from_secs(5)).await?;
+    Ok(())
+}

--- a/crates/trusty-code/src/cli/cancel.rs
+++ b/crates/trusty-code/src/cli/cancel.rs
@@ -1,0 +1,38 @@
+//! `tcode cancel <session-id>` (#2060).
+//!
+//! Why: the thin-client cancellation path — one `session.cancel` call.
+//! What: spawns an ephemeral daemon (same in-memory-per-process caveat as
+//! `cli::session` — see its module docs), calls `session.cancel`, prints the
+//! resulting status. Cooperative-vs-immediate cancellation semantics
+//! (#2056) are entirely the daemon's decision; this handler never inspects
+//! `is_executing` itself.
+//! Test: `tests/cli_e2e.rs::cancel_unknown_session_errors_cleanly`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde_json::json;
+
+use trusty_code::cli_client::StdioRpcClient;
+use trusty_code::session::Session;
+
+use super::tcode_exe;
+
+/// `tcode cancel <SESSION_ID> [--project P]`.
+///
+/// Why/What: see module docs.
+pub async fn run(project: &Path, session_id: &str) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+    let result = client
+        .call("session.cancel", json!({"session_id": session_id}))
+        .await;
+    client.shutdown(Duration::from_secs(5)).await?;
+
+    let result = result?;
+    let session: Session = serde_json::from_value(result)
+        .map_err(|e| anyhow::anyhow!("tcode cancel: malformed daemon response: {e}"))?;
+    println!("{}  {}", session.id, session.status.as_str());
+    Ok(())
+}

--- a/crates/trusty-code/src/cli/mod.rs
+++ b/crates/trusty-code/src/cli/mod.rs
@@ -1,0 +1,29 @@
+//! `tcode` CLI subcommand handlers (#2060) — the binary-side half of the
+//! thin-client architecture whose library half is `trusty_code::cli_client`.
+//!
+//! Why: kept out of `main.rs` (which would otherwise grow past the 500-SLOC
+//! production cap once every subcommand's handler landed) so each
+//! subcommand's wiring — argument-shaped setup, spawning a client, calling
+//! the daemon, printing, picking an exit code — lives in its own small,
+//! focused file. None of these files contain business logic: every decision
+//! (session lifecycle, task execution, transcript contents) is made by the
+//! daemon; these handlers only translate CLI args into JSON-RPC calls and
+//! JSON-RPC results into terminal output, exactly matching the vision
+//! spec's Axiom 3 (API-First) / §4.4 (CLI as Thin Client) requirement.
+//! What: [`tcode_exe::resolve`] (locate the running binary so it can
+//! re-spawn itself as `tcode serve --stdio`), [`session::list`]/
+//! [`session::status`], [`run_task::run`] (create + `task.run` + attach +
+//! stream — the M1 cut-line "replay via thin CLI" verb), [`attach::run`],
+//! [`cancel::run`], [`transcript::run`].
+//! Test: each submodule's own doc comments note its coverage; the full
+//! spawn+wire behaviour is covered end-to-end by `tests/cli_e2e.rs` against
+//! the real `tcode` binary — these handlers are too thin to usefully unit
+//! test in isolation (they are a few lines of glue over
+//! `trusty_code::cli_client`, which carries its own unit tests).
+
+pub mod attach;
+pub mod cancel;
+pub mod run_task;
+pub mod session;
+pub mod tcode_exe;
+pub mod transcript;

--- a/crates/trusty-code/src/cli/run_task.rs
+++ b/crates/trusty-code/src/cli/run_task.rs
@@ -1,0 +1,128 @@
+//! `tcode run-task <agent> <task>` — the M1 cut-line "replay via thin CLI"
+//! verb (#2060, vision spec §13).
+//!
+//! Why: this is the subcommand the cut line names explicitly — a human runs
+//! a task via the CLI and SEES it happen, driven entirely over the daemon's
+//! JSON-RPC surface (create-or-target a session, `task.run`, `session.attach`,
+//! stream events) rather than the legacy in-process `AgentLoop` execution
+//! `main.rs`'s `--legacy-in-process` flag still offers (see its module
+//! docs for why that path was kept, not removed).
+//! What: [`run`] spawns one ephemeral daemon for the whole invocation's
+//! lifetime — `task.run` (mints the session), `session.attach` (replay,
+//! which will be small-to-empty since attach happens immediately after
+//! `task.run` returns), then a poll loop over
+//! `StdioRpcClient::next_notification` printing each event via
+//! `cli_client::render::render_event_line` (human mode) until
+//! `session_done`, a final `session.status` call for the terminal snapshot,
+//! and `cli_client::render::exit_code_for_status` for the process exit code.
+//! `--json` suppresses the live per-event lines and prints only the final
+//! `Session` snapshot as pretty JSON, matching the legacy path's `--json`
+//! contract (a single JSON document on stdout).
+//! Test: `tests/cli_e2e.rs::run_task_streams_live_events_and_reports_final_status`
+//! (the required black-box "replay via thin CLI" case, driven with
+//! `TCODE_MOCK_LLM=echo`).
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde_json::json;
+
+use trusty_code::cli_client::StdioRpcClient;
+use trusty_code::cli_client::render::{exit_code_for_status, render_event_line};
+use trusty_code::events::Event;
+use trusty_code::session::Session;
+
+use super::tcode_exe;
+
+/// How often the streaming loop wakes up to re-check for a terminal event.
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// `tcode run-task <AGENT> <TASK> [--project P] [--json] [--engineer-model M]`.
+///
+/// Why/What: see module docs. Returns the process exit code the caller
+/// should use (mirrors the legacy path's `ExitCode` contract via
+/// `exit_code_for_status`).
+pub async fn run(
+    project: &Path,
+    agent: &str,
+    task: &str,
+    json_output: bool,
+    engineer_model: Option<String>,
+) -> Result<i32> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+
+    let run_params = json!({
+        "task_description": task,
+        "agent_name": agent,
+        "model_override": engineer_model,
+    });
+    let run_result = client.call("task.run", run_params).await?;
+    let session_id = run_result
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("tcode run-task: daemon did not return a session_id"))?
+        .to_string();
+
+    let attach_result = client
+        .call("session.attach", json!({"session_id": session_id}))
+        .await?;
+    let replay = attach_result
+        .get("events")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut done = false;
+    for raw in &replay {
+        if let Ok(envelope) =
+            serde_json::from_value::<trusty_code::events::SessionEventEnvelope>(raw.clone())
+        {
+            if !json_output {
+                println!("{}", render_event_line(&envelope));
+            }
+            done = done || matches!(envelope.event, Event::SessionDone { .. });
+        }
+    }
+
+    while !done {
+        match client.next_notification(POLL_INTERVAL).await? {
+            Some(envelope) => {
+                if !json_output {
+                    println!("{}", render_event_line(&envelope));
+                }
+                done = matches!(envelope.event, Event::SessionDone { .. });
+            }
+            None => continue,
+        }
+    }
+
+    let status_result = client
+        .call("session.status", json!({"session_id": session_id}))
+        .await?;
+    client.shutdown(Duration::from_secs(5)).await?;
+
+    let session: Session = serde_json::from_value(status_result.clone())
+        .map_err(|e| anyhow::anyhow!("tcode run-task: malformed daemon response: {e}"))?;
+
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&status_result)
+                .map_err(|e| anyhow::anyhow!("tcode run-task: failed to render JSON: {e}"))?
+        );
+    } else {
+        println!(
+            "run {}: session={} status={}",
+            if session.status == trusty_code::session::SessionStatus::Finished {
+                "finished"
+            } else {
+                "did not finish cleanly"
+            },
+            session.id,
+            session.status.as_str()
+        );
+    }
+
+    Ok(exit_code_for_status(session.status).code())
+}

--- a/crates/trusty-code/src/cli/session.rs
+++ b/crates/trusty-code/src/cli/session.rs
@@ -1,0 +1,72 @@
+//! `tcode session list` / `tcode session status <id>` (#2060).
+//!
+//! Why: the thin-client demonstration of the simplest `session.*` calls —
+//! no streaming, just spawn, call, print, exit.
+//! What: [`list`] calls `session.list` and prints
+//! `cli_client::render::render_session_table`; [`status`] calls
+//! `session.status` and prints one line. Both spawn a FRESH ephemeral
+//! daemon per invocation (per `cli_client::stdio`'s module docs) — since
+//! M1 sessions are in-memory-only per daemon process (`session::registry`'s
+//! own docs), these commands only ever see sessions created within THIS
+//! same invocation's daemon; they cannot inspect a session created by a
+//! separate `tcode run-task` process. This is a known scope limitation, not
+//! a bug — see this crate's `tests/cli_e2e.rs` module docs for the fuller
+//! rationale.
+//! Test: `tests/cli_e2e.rs::session_list_on_fresh_project_reports_no_sessions`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde_json::json;
+
+use trusty_code::cli_client::StdioRpcClient;
+use trusty_code::cli_client::render::render_session_table;
+use trusty_code::session::Session;
+
+use super::tcode_exe;
+
+/// `tcode session list [--project P]`.
+///
+/// Why/What: see module docs.
+pub async fn list(project: &Path) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+    let result = client.call("session.list", json!({})).await?;
+    client.shutdown(Duration::from_secs(5)).await?;
+
+    let sessions: Vec<Session> = serde_json::from_value(
+        result
+            .get("sessions")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+    )
+    .map_err(|e| anyhow::anyhow!("tcode session list: malformed daemon response: {e}"))?;
+    println!("{}", render_session_table(&sessions));
+    Ok(())
+}
+
+/// `tcode session status <SESSION_ID> [--project P]`.
+///
+/// Why/What: see module docs. Errors (e.g. `session_not_found`) propagate as
+/// a plain `anyhow::Error` — `main.rs` prints it and exits nonzero.
+pub async fn status(project: &Path, session_id: &str) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+    let result = client
+        .call("session.status", json!({"session_id": session_id}))
+        .await;
+    client.shutdown(Duration::from_secs(5)).await?;
+
+    let result = result?;
+    let session: Session = serde_json::from_value(result)
+        .map_err(|e| anyhow::anyhow!("tcode session status: malformed daemon response: {e}"))?;
+    println!(
+        "{}  {}  agent={}  task={}",
+        session.id,
+        session.status.as_str(),
+        session.agent.as_deref().unwrap_or("-"),
+        session.task
+    );
+    Ok(())
+}

--- a/crates/trusty-code/src/cli/tcode_exe.rs
+++ b/crates/trusty-code/src/cli/tcode_exe.rs
@@ -1,0 +1,28 @@
+//! Resolve the path to the running `tcode` binary, for re-spawning itself
+//! as `tcode serve --stdio` (#2060).
+//!
+//! Why: [`trusty_code::cli_client::StdioRpcClient::spawn`] takes an explicit
+//! binary path rather than reading `std::env::current_exe()` itself, so
+//! that library function stays a pure "spawn this path" primitive testable
+//! with any binary. The CLI is the one caller that actually wants "myself"
+//! — this tiny wrapper is where that policy lives, with an actionable error
+//! message instead of a bare `std::io::Error` if resolution fails (a rare
+//! but real possibility per `std::env::current_exe`'s own docs — deleted
+//! binary, unusual sandboxing).
+//! Test: exercised implicitly by every `tests/cli_e2e.rs` case (they all
+//! spawn the real compiled binary, which must resolve itself successfully).
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+/// Resolve the path to the currently-running `tcode` binary.
+///
+/// Why: see module docs.
+/// What: thin wrapper over `std::env::current_exe()` with a CLI-appropriate
+/// error message.
+pub fn resolve() -> Result<PathBuf> {
+    std::env::current_exe().context(
+        "tcode: could not resolve its own executable path (needed to spawn `tcode serve --stdio`)",
+    )
+}

--- a/crates/trusty-code/src/cli/transcript.rs
+++ b/crates/trusty-code/src/cli/transcript.rs
@@ -1,0 +1,53 @@
+//! `tcode transcript <session-id>` (#2060).
+//!
+//! Why: the thin-client read path over #2058's `session.get_transcript` —
+//! one call, human or `--json` output.
+//! What: spawns an ephemeral daemon (same in-memory-per-process caveat as
+//! `cli::session` — see its module docs), calls `session.get_transcript`,
+//! and prints either the pretty-printed raw JSON (`--json`) or
+//! `cli_client::render::render_transcript_human`'s readable view.
+//! Test: `tests/cli_e2e.rs::transcript_unknown_session_errors_cleanly`;
+//! the meaningful "real turns" case is exercised end-to-end via
+//! `run_task::run`, which calls the SAME `session.get_transcript` method
+//! from within one daemon's lifetime (see that module's docs for why a
+//! standalone `transcript` invocation cannot see another process's
+//! session).
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde_json::json;
+
+use trusty_code::cli_client::StdioRpcClient;
+use trusty_code::cli_client::render::render_transcript_human;
+use trusty_code::session::TranscriptRecord;
+
+use super::tcode_exe;
+
+/// `tcode transcript <SESSION_ID> [--project P] [--json]`.
+///
+/// Why/What: see module docs.
+pub async fn run(project: &Path, session_id: &str, json_output: bool) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+    let result = client
+        .call("session.get_transcript", json!({"session_id": session_id}))
+        .await;
+    client.shutdown(Duration::from_secs(5)).await?;
+
+    let result = result?;
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&result)
+                .map_err(|e| anyhow::anyhow!("tcode transcript: failed to render JSON: {e}"))?
+        );
+        return Ok(());
+    }
+
+    let record: TranscriptRecord = serde_json::from_value(result)
+        .map_err(|e| anyhow::anyhow!("tcode transcript: malformed daemon response: {e}"))?;
+    println!("{}", render_transcript_human(&record));
+    Ok(())
+}

--- a/crates/trusty-code/src/cli_client/mod.rs
+++ b/crates/trusty-code/src/cli_client/mod.rs
@@ -1,0 +1,31 @@
+//! Thin JSON-RPC client the `tcode` CLI binary drives against its own
+//! spawned `tcode serve --stdio` child (#2060, vision spec §4.4 "CLI as
+//! Thin Client" / Axiom 3 "API-First").
+//!
+//! Why: prior to this ticket, `tcode run-task` ran the PM->engineer
+//! `AgentLoop` IN-PROCESS inside the CLI binary — the only way to observe
+//! progress was the final printed report. The vision spec's Axiom 3 requires
+//! the CLI to hold NO orchestration logic: every session/task operation goes
+//! through the same JSON-RPC surface `tcode serve` already exposes, so a
+//! human, a script, and a future TUI all see identical behaviour. This
+//! module is the client half of that contract — the daemon (`crate::serve`,
+//! `crate::session`, `crate::task`) already defines the server half.
+//! What: [`stdio::StdioRpcClient`] spawns an EPHEMERAL `tcode serve --stdio`
+//! child per CLI invocation (the "simplest robust M1 approach" the ticket
+//! specifies — no persistent daemon discovery/lifecycle needed yet) and
+//! speaks JSON-RPC 2.0 NDJSON over its stdio pipes, reusing
+//! `trusty_common::mcp::{Request, Response}` for the wire envelope.
+//! [`render`] holds pure, unit-tested formatting functions (session table,
+//! one live-event line, transcript human view) shared by every CLI
+//! subcommand handler in the binary (`src/main.rs`/`src/cli/`), which own
+//! only argument parsing, the client lifecycle, and `process::exit` — never
+//! business logic.
+//! Test: `cli_client::stdio::tests` (line classification, id monotonicity —
+//! offline, no subprocess), `cli_client::render::tests` (formatting).
+//! End-to-end, real-subprocess coverage lives in `tests/cli_e2e.rs`, which
+//! drives the actual `tcode` binary as a black box.
+
+pub mod render;
+pub mod stdio;
+
+pub use stdio::{RpcClientError, StdioRpcClient};

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -1,0 +1,283 @@
+//! Pure, unit-tested formatting for the `tcode` CLI's human-readable output
+//! (#2060).
+//!
+//! Why: every subcommand handler in the binary needs to turn a wire-shaped
+//! `Session`/`SessionEventEnvelope`/`TranscriptRecord` into something a
+//! terminal user can read. Keeping the formatting logic here (rather than
+//! inline `println!`s scattered across the binary's subcommand handlers)
+//! makes it independently unit-testable without spawning a subprocess, and
+//! keeps each handler a thin "call the client, print the result" wrapper.
+//! What: [`render_session_table`] (a fixed-width table for `session list`),
+//! [`render_event_line`] (one line per streamed [`SessionEventEnvelope`],
+//! used by `attach`/`run-task`), [`render_transcript_human`] (a readable
+//! turn-by-turn view for `transcript`), and [`exit_code_for_status`] (maps a
+//! terminal `SessionStatus` onto the SAME `run_task::ExitCode` values the
+//! legacy in-process `run-task` path already used, so scripts checking `$?`
+//! see a consistent contract regardless of which path produced the run).
+//! Test: `render::tests::*`.
+
+use crate::events::{Event, SessionEventEnvelope};
+use crate::run_task::ExitCode;
+use crate::session::{Session, SessionStatus, TranscriptRecord};
+
+/// Render a fixed-width table of sessions for `tcode session list`.
+///
+/// Why: `session.list`'s raw JSON is unreadable at a glance; operators want
+/// id/status/task/agent at one line each.
+/// What: one header line + one row per session, columns
+/// `ID | STATUS | AGENT | TASK` (task truncated to keep rows terminal-width
+/// friendly). An empty list renders a single explanatory line, not an empty
+/// string, so scripts piping through a pager see something.
+/// Test: `tests::render_session_table_lists_every_session`,
+/// `tests::render_session_table_handles_empty_list`.
+pub fn render_session_table(sessions: &[Session]) -> String {
+    if sessions.is_empty() {
+        return "(no sessions)".to_string();
+    }
+    let mut out =
+        String::from("ID                                    STATUS     AGENT           TASK\n");
+    for s in sessions {
+        let agent = s.agent.as_deref().unwrap_or("-");
+        let task_preview = truncate(&s.task, 40);
+        out.push_str(&format!(
+            "{:<38}{:<11}{:<16}{}\n",
+            s.id,
+            s.status.as_str(),
+            truncate(agent, 15),
+            task_preview
+        ));
+    }
+    out.pop(); // drop the trailing newline; callers add their own via println!
+    out
+}
+
+/// Render one line for a single streamed event, for `attach`/`run-task`.
+///
+/// Why: a human watching a live run wants a compact, timestamped narration
+/// — not the raw internally-tagged JSON.
+/// What: matches the handful of variants the M1 cut line actually produces
+/// (session lifecycle, tool lifecycle, generic message/log/progress) with a
+/// readable one-liner; anything else falls back to `[<kind>]` using the
+/// envelope's own `kind` string rather than an exhaustive match on
+/// [`Event`], so a future variant added elsewhere never breaks this
+/// function's compilation.
+/// Test: `tests::render_event_line_covers_key_variants`,
+/// `tests::render_event_line_falls_back_for_unknown_kind`.
+pub fn render_event_line(envelope: &SessionEventEnvelope) -> String {
+    let ts = envelope.at.format("%H:%M:%S");
+    let detail = match &envelope.event {
+        Event::SessionStarted { project, .. } => format!("session started (project: {project})"),
+        Event::SessionStatusChanged { status, .. } => format!("status -> {status}"),
+        Event::SessionDone { status, .. } => format!("done ({status})"),
+        Event::SessionCancelled { .. } => "cancelled".to_string(),
+        Event::ToolStarted {
+            tool, args_preview, ..
+        } => format!("tool_started  {tool}  {args_preview}"),
+        Event::ToolFinished {
+            tool,
+            success,
+            result_preview,
+            ..
+        } => format!(
+            "tool_finished {tool}  {} {result_preview}",
+            if *success { "ok" } else { "error" }
+        ),
+        Event::ToolError { tool, error, .. } => format!("tool_error    {tool}  {error}"),
+        Event::Message { text, .. } => text.clone(),
+        Event::Log { level, message, .. } => format!("[{level}] {message}"),
+        Event::Progress {
+            message, percent, ..
+        } => match percent {
+            Some(p) => format!("{message} ({p:.0}%)"),
+            None => message.clone(),
+        },
+        _ => format!("[{}]", envelope.kind),
+    };
+    format!("[{ts}] {detail}")
+}
+
+/// Render a `TranscriptRecord` as a readable turn-by-turn view for
+/// `tcode transcript` (human mode; `--json` bypasses this entirely and
+/// pretty-prints the raw result).
+///
+/// Why: a bare JSON dump of the transcript is hard to scan; a human wants
+/// "who said what, with which tools" plus the cost/usage summary.
+/// What: one block per turn (`role` header, prose if any, tool calls if
+/// any), then a trailing usage/cost summary line. A never-run session (empty
+/// `turns`) renders a single explanatory line rather than an empty string.
+/// Test: `tests::render_transcript_human_lists_turns_and_totals`,
+/// `tests::render_transcript_human_handles_never_run_session`.
+pub fn render_transcript_human(record: &TranscriptRecord) -> String {
+    if record.turns.is_empty() {
+        return format!(
+            "session {} has not run a task yet (no transcript)",
+            record.session_id
+        );
+    }
+    let mut out = String::new();
+    for turn in &record.turns {
+        out.push_str(&format!("--- {} ({}) ---\n", turn.role, turn.model));
+        if !turn.text.is_empty() {
+            out.push_str(&turn.text);
+            out.push('\n');
+        }
+        if !turn.tool_calls.is_empty() {
+            out.push_str(&format!("tool calls: {}\n", turn.tool_calls.join(", ")));
+        }
+    }
+    out.push_str(&format!(
+        "\ntotal: {} prompt + {} completion tokens, cost: {}\n",
+        record.usage.prompt_tokens,
+        record.usage.completion_tokens,
+        record
+            .cost_usd
+            .map(|c| format!("${c:.4}"))
+            .unwrap_or_else(|| "unknown".to_string())
+    ));
+    out.pop();
+    out
+}
+
+/// Map a terminal `SessionStatus` onto the CLI process exit code.
+///
+/// Why: `run-task` via the thin client and the legacy in-process
+/// `run-task` must agree on what a script checking `$?` sees.
+/// What: `Finished` -> `ExitCode::Success`; `Cancelled`/`Failed` ->
+/// `ExitCode::RunFailure`; `Created`/`Running` (should never be passed here
+/// — the caller only calls this once a run has reached a terminal status)
+/// also map to `RunFailure` defensively rather than panicking.
+/// Test: `tests::exit_code_for_status_maps_terminal_states`.
+pub fn exit_code_for_status(status: SessionStatus) -> ExitCode {
+    match status {
+        SessionStatus::Finished => ExitCode::Success,
+        SessionStatus::Cancelled | SessionStatus::Failed => ExitCode::RunFailure,
+        SessionStatus::Created | SessionStatus::Running => ExitCode::RunFailure,
+    }
+}
+
+/// Truncate `s` to at most `max` chars, appending `…` when it was longer.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::perf::TokenUsage;
+    use crate::run_task::TurnRecord;
+    use chrono::Utc;
+
+    fn session(id: &str, status: SessionStatus) -> Session {
+        Session {
+            id: id.to_string(),
+            task: "do the thing".to_string(),
+            agent: Some("pm".to_string()),
+            project: None,
+            status,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn render_session_table_lists_every_session() {
+        let sessions = vec![
+            session("s-1", SessionStatus::Running),
+            session("s-2", SessionStatus::Finished),
+        ];
+        let table = render_session_table(&sessions);
+        assert!(table.contains("s-1"));
+        assert!(table.contains("running"));
+        assert!(table.contains("s-2"));
+        assert!(table.contains("finished"));
+    }
+
+    #[test]
+    fn render_session_table_handles_empty_list() {
+        assert_eq!(render_session_table(&[]), "(no sessions)");
+    }
+
+    fn envelope(event: Event) -> SessionEventEnvelope {
+        SessionEventEnvelope::new("s-1".to_string(), 1, Utc::now(), event)
+    }
+
+    #[test]
+    fn render_event_line_covers_key_variants() {
+        let line = render_event_line(&envelope(Event::ToolStarted {
+            session_id: "s-1".to_string(),
+            tool: "bash".to_string(),
+            call_id: "c1".to_string(),
+            args_preview: "echo hi".to_string(),
+        }));
+        assert!(line.contains("tool_started"));
+        assert!(line.contains("bash"));
+        assert!(line.contains("echo hi"));
+
+        let line = render_event_line(&envelope(Event::SessionDone {
+            session_id: "s-1".to_string(),
+            status: "finished".to_string(),
+        }));
+        assert!(line.contains("done (finished)"));
+    }
+
+    #[test]
+    fn render_event_line_falls_back_for_unknown_kind() {
+        let line = render_event_line(&envelope(Event::Ping));
+        assert!(line.contains("[ping]"));
+    }
+
+    #[test]
+    fn render_transcript_human_lists_turns_and_totals() {
+        let record = TranscriptRecord {
+            session_id: "s-1".to_string(),
+            turns: vec![TurnRecord {
+                role: "pm".to_string(),
+                model: "openai/gpt-4o-mini".to_string(),
+                text: "done".to_string(),
+                tool_calls: vec!["delegate_to_agent".to_string()],
+                usage: TokenUsage::new(10, 5, 0, 0),
+            }],
+            usage: TokenUsage::new(10, 5, 0, 0),
+            cost_usd: Some(0.01),
+        };
+        let out = render_transcript_human(&record);
+        assert!(out.contains("pm"));
+        assert!(out.contains("done"));
+        assert!(out.contains("delegate_to_agent"));
+        assert!(out.contains("$0.0100"));
+    }
+
+    #[test]
+    fn render_transcript_human_handles_never_run_session() {
+        let record = TranscriptRecord {
+            session_id: "s-1".to_string(),
+            turns: vec![],
+            usage: TokenUsage::default(),
+            cost_usd: None,
+        };
+        let out = render_transcript_human(&record);
+        assert!(out.contains("s-1"));
+        assert!(out.contains("has not run"));
+    }
+
+    #[test]
+    fn exit_code_for_status_maps_terminal_states() {
+        assert_eq!(
+            exit_code_for_status(SessionStatus::Finished).code(),
+            ExitCode::Success.code()
+        );
+        assert_eq!(
+            exit_code_for_status(SessionStatus::Cancelled).code(),
+            ExitCode::RunFailure.code()
+        );
+        assert_eq!(
+            exit_code_for_status(SessionStatus::Failed).code(),
+            ExitCode::RunFailure.code()
+        );
+    }
+}

--- a/crates/trusty-code/src/cli_client/stdio.rs
+++ b/crates/trusty-code/src/cli_client/stdio.rs
@@ -1,0 +1,338 @@
+//! [`StdioRpcClient`]: a JSON-RPC 2.0 client speaking NDJSON over a spawned
+//! `tcode serve --stdio` child's stdio pipes (#2060).
+//!
+//! Why: the CLI needs to drive the daemon's `session.*`/`task.*` methods
+//! without reimplementing any of their logic. Spawning an ephemeral child
+//! per invocation (rather than discovering/reusing a long-lived daemon) is
+//! the simplest robust M1 approach the ticket calls for — no discovery file,
+//! no port, no lifecycle management beyond this one process's lifetime.
+//! What: [`StdioRpcClient::spawn`] launches the child; [`StdioRpcClient::call`]
+//! sends a request and blocks (bounded by [`DEFAULT_CALL_TIMEOUT`]) for its
+//! matching response, buffering any interleaved `session.event` notification
+//! lines rather than dropping them; [`StdioRpcClient::next_notification`]
+//! drains that buffer (or reads fresh lines, bounded by a caller-supplied
+//! wait) for the streaming subcommands (`attach`, `run-task`).
+//! [`classify_notification`]/[`build_request`] are pure helpers, unit tested
+//! here without spawning a real process; the full spawn+wire round trip is
+//! covered by `tests/cli_e2e.rs` against the real `tcode` binary.
+//! Test: `cli_client::stdio::tests::*`.
+
+use std::collections::VecDeque;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+use tokio::time::timeout;
+use trusty_common::mcp::Request;
+
+use crate::events::SessionEventEnvelope;
+
+/// How long [`StdioRpcClient::call`] waits for a matching response before
+/// giving up.
+///
+/// Why: every method this client calls (`session.*`, `task.run`) is a fast,
+/// synchronous handler by design — `task.run` in particular reserves its
+/// execution slot and returns immediately rather than blocking on the LLM
+/// run (see `task::protocol::task_run`'s docs) — so a real hang here means a
+/// genuine daemon-side regression, not a slow-but-legitimate call. Generous
+/// enough for a debug build under load, tight enough to fail fast.
+pub const DEFAULT_CALL_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Errors a CLI subcommand handler surfaces to the user (mapped onto a
+/// nonzero exit code by the caller — this type carries no exit-code opinion
+/// itself).
+#[derive(Debug, thiserror::Error)]
+pub enum RpcClientError {
+    /// The child process could not be spawned at all (binary missing, not
+    /// executable, etc.).
+    #[error("failed to spawn `{0}`: {1}")]
+    Spawn(String, #[source] std::io::Error),
+    /// The child's stdout closed (process exited) before a full response
+    /// arrived.
+    #[error("daemon connection closed unexpectedly")]
+    ConnectionClosed,
+    /// A read/write against the child's stdio pipes failed.
+    #[error("failed to read from daemon: {0}")]
+    Io(#[source] std::io::Error),
+    /// A line on the wire was not valid JSON, or lacked fields a response
+    /// must have.
+    #[error("malformed response from daemon: {0}")]
+    MalformedResponse(String),
+    /// The daemon's JSON-RPC error envelope for this call (verbatim: code +
+    /// message + optional `data`).
+    #[error("daemon returned an error ({code}): {message}")]
+    Rpc {
+        code: i32,
+        message: String,
+        data: Option<Value>,
+    },
+    /// No matching response arrived within [`DEFAULT_CALL_TIMEOUT`].
+    #[error("timed out waiting for the daemon to respond")]
+    Timeout,
+}
+
+/// Build the outgoing JSON-RPC 2.0 request envelope for one call.
+///
+/// Why: split out so `next_id` bookkeeping and wire-envelope construction
+/// are each independently, purely testable — no process I/O involved.
+/// What: `jsonrpc: "2.0"`, `id` as a JSON number, `method`/`params` verbatim.
+/// Test: `tests::build_request_uses_2_0_and_given_id`.
+fn build_request(id: i64, method: &str, params: Value) -> Request {
+    Request {
+        jsonrpc: Some("2.0".to_string()),
+        id: Some(serde_json::json!(id)),
+        method: method.to_string(),
+        params: Some(params),
+    }
+}
+
+/// Classify one already-JSON-parsed wire line as a `session.event`
+/// notification, if it is one.
+///
+/// Why: the daemon interleaves request/response traffic with
+/// server-initiated `session.event` notifications on the SAME connection
+/// (see `session::registry`'s attach-forwarding docs); every line this
+/// client reads must be checked against both shapes.
+/// What: `Some(envelope)` when `value.method == "session.event"` and
+/// `value.params` deserialises as a [`SessionEventEnvelope`]; `None`
+/// otherwise (including a shape that claims to be a notification but fails
+/// to parse — degrade silently rather than error, matching `Event`'s own
+/// "unknown variants are ignored" forward-compatibility stance).
+/// Test: `tests::classify_notification_recognises_session_event`,
+/// `tests::classify_notification_ignores_other_shapes`.
+fn classify_notification(value: &Value) -> Option<SessionEventEnvelope> {
+    if value.get("method").and_then(|m| m.as_str()) != Some("session.event") {
+        return None;
+    }
+    serde_json::from_value(value.get("params")?.clone()).ok()
+}
+
+/// A JSON-RPC 2.0 client over a spawned `tcode serve --stdio` child.
+///
+/// Why: see module docs.
+/// What: owns the child + its stdin/stdout handles and a monotonic request
+/// id counter; buffers notification lines encountered while a `call` is
+/// awaiting its own response so nothing observed on the wire is ever
+/// silently dropped.
+/// Test: `tests::*` for the pure helpers; `tests/cli_e2e.rs` for the real
+/// spawn + wire round trip.
+pub struct StdioRpcClient {
+    child: Child,
+    stdin: ChildStdin,
+    lines: Lines<BufReader<ChildStdout>>,
+    next_id: i64,
+    pending_notifications: VecDeque<SessionEventEnvelope>,
+}
+
+impl StdioRpcClient {
+    /// Spawn `<tcode_exe> serve --project <project> --stdio` and return a
+    /// client wired to its stdio pipes.
+    ///
+    /// Why: `tcode_exe` is normally `std::env::current_exe()` — the CLI
+    /// re-spawns ITSELF in daemon mode, per the ticket's "in-process spawn"
+    /// requirement; passing it explicitly (rather than hardcoding
+    /// `current_exe()` inside this function) keeps this module testable
+    /// with an arbitrary binary path and avoids a hidden `std::env` read
+    /// inside library code.
+    /// What: `kill_on_drop(true)` so a CLI process that exits early (panic,
+    /// early return) never leaks the child; the child's stderr is
+    /// inherited so daemon-side log lines are visible to the operator
+    /// without corrupting the stdout NDJSON framing this client reads.
+    /// Test: `tests/cli_e2e.rs` (spawns the real binary).
+    pub fn spawn(tcode_exe: &Path, project: &Path) -> Result<Self, RpcClientError> {
+        let mut child = tokio::process::Command::new(tcode_exe)
+            .arg("serve")
+            .arg("--project")
+            .arg(project)
+            .arg("--stdio")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| RpcClientError::Spawn(tcode_exe.display().to_string(), e))?;
+        let stdin = child.stdin.take().ok_or(RpcClientError::ConnectionClosed)?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or(RpcClientError::ConnectionClosed)?;
+        Ok(Self {
+            child,
+            stdin,
+            lines: BufReader::new(stdout).lines(),
+            next_id: 1,
+            pending_notifications: VecDeque::new(),
+        })
+    }
+
+    /// Call `method` with `params`, waiting for its matching response.
+    ///
+    /// Why: the request/response half of the protocol every non-streaming
+    /// subcommand (`session.list`/`status`/`cancel`/`get_transcript`,
+    /// `task.run`'s initial call) uses.
+    /// What: writes one NDJSON request line, then reads lines until one
+    /// carries the SAME `id` — any `session.event` notification observed
+    /// along the way is buffered (not dropped) for a later
+    /// [`Self::next_notification`] call. A JSON-RPC error envelope becomes
+    /// `Err(RpcClientError::Rpc)`; the whole call is bounded by
+    /// [`DEFAULT_CALL_TIMEOUT`].
+    /// Test: covered end-to-end by `tests/cli_e2e.rs`.
+    pub async fn call(&mut self, method: &str, params: Value) -> Result<Value, RpcClientError> {
+        timeout(DEFAULT_CALL_TIMEOUT, self.call_inner(method, params))
+            .await
+            .map_err(|_| RpcClientError::Timeout)?
+    }
+
+    async fn call_inner(&mut self, method: &str, params: Value) -> Result<Value, RpcClientError> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let req = build_request(id, method, params);
+        let mut line = serde_json::to_string(&req)
+            .map_err(|e| RpcClientError::MalformedResponse(e.to_string()))?;
+        line.push('\n');
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(RpcClientError::Io)?;
+        self.stdin.flush().await.map_err(RpcClientError::Io)?;
+
+        loop {
+            let raw = self.read_raw_line().await?;
+            let value: Value = serde_json::from_str(&raw)
+                .map_err(|e| RpcClientError::MalformedResponse(format!("{e}: {raw}")))?;
+
+            if value.get("id").and_then(Value::as_i64) == Some(id) {
+                if let Some(err) = value.get("error").filter(|e| !e.is_null()) {
+                    return Err(RpcClientError::Rpc {
+                        code: err.get("code").and_then(Value::as_i64).unwrap_or(0) as i32,
+                        message: err
+                            .get("message")
+                            .and_then(|m| m.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        data: err.get("data").cloned(),
+                    });
+                }
+                return Ok(value.get("result").cloned().unwrap_or(Value::Null));
+            }
+
+            if let Some(envelope) = classify_notification(&value) {
+                self.pending_notifications.push_back(envelope);
+            }
+            // Any other stray line (e.g. a response to an id we no longer
+            // care about) is silently ignored — this client only ever has
+            // one call in flight at a time.
+        }
+    }
+
+    /// Return the next observed `session.event` notification, waiting up to
+    /// `wait` for a fresh one if none is already buffered.
+    ///
+    /// Why: the streaming subcommands (`attach`, `run-task`) poll this in a
+    /// loop, printing each envelope as it arrives, until a terminal event or
+    /// the user interrupts.
+    /// What: drains [`Self::pending_notifications`] first (events observed
+    /// while a previous `call` was still awaiting its own response); only
+    /// reads fresh lines from the child when the buffer is empty.
+    /// `Ok(None)` means "nothing arrived within `wait`" — NOT connection
+    /// loss (that is `Err(ConnectionClosed)`) — callers should keep polling.
+    /// Test: covered end-to-end by `tests/cli_e2e.rs`.
+    pub async fn next_notification(
+        &mut self,
+        wait: Duration,
+    ) -> Result<Option<SessionEventEnvelope>, RpcClientError> {
+        if let Some(envelope) = self.pending_notifications.pop_front() {
+            return Ok(Some(envelope));
+        }
+        match timeout(wait, self.read_raw_line()).await {
+            Ok(Ok(raw)) => {
+                let value: Value = serde_json::from_str(&raw)
+                    .map_err(|e| RpcClientError::MalformedResponse(format!("{e}: {raw}")))?;
+                Ok(classify_notification(&value))
+            }
+            Ok(Err(e)) => Err(e),
+            Err(_) => Ok(None),
+        }
+    }
+
+    async fn read_raw_line(&mut self) -> Result<String, RpcClientError> {
+        self.lines
+            .next_line()
+            .await
+            .map_err(RpcClientError::Io)?
+            .ok_or(RpcClientError::ConnectionClosed)
+    }
+
+    /// Close stdin (EOF) and wait, bounded by `grace`, for the child to
+    /// exit cleanly; force-kills it if it doesn't.
+    ///
+    /// Why: mirrors the daemon's own connection-safe-shutdown convention
+    /// (issue #534) from the client side — the CLI should give its spawned
+    /// child a real chance to drain before the process ends.
+    /// What: dropping `stdin` signals EOF (the same trigger
+    /// `serve::run_stdio` reacts to); force-kill is best-effort, matching
+    /// every other bounded-shutdown path in this crate.
+    /// Test: covered end-to-end by `tests/cli_e2e.rs`.
+    pub async fn shutdown(mut self, grace: Duration) -> Result<(), RpcClientError> {
+        drop(self.stdin);
+        match timeout(grace, self.child.wait()).await {
+            Ok(Ok(_status)) => Ok(()),
+            Ok(Err(e)) => Err(RpcClientError::Io(e)),
+            Err(_) => {
+                let _ = self.child.start_kill();
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// `build_request` must stamp `jsonrpc: "2.0"` and the exact given id.
+    #[test]
+    fn build_request_uses_2_0_and_given_id() {
+        let req = build_request(7, "session.list", json!({}));
+        assert_eq!(req.jsonrpc.as_deref(), Some("2.0"));
+        assert_eq!(req.id, Some(json!(7)));
+        assert_eq!(req.method, "session.list");
+    }
+
+    /// A well-formed `session.event` notification must parse into its
+    /// envelope.
+    #[test]
+    fn classify_notification_recognises_session_event() {
+        let line = json!({
+            "method": "session.event",
+            "params": {
+                "session_id": "s-1",
+                "seq": 1,
+                "at": "2024-01-01T00:00:00Z",
+                "kind": "session_started",
+                "event": {"type": "session_started", "session_id": "s-1", "project": "p"},
+            }
+        });
+        let envelope = classify_notification(&line).expect("must classify as a notification");
+        assert_eq!(envelope.session_id, "s-1");
+        assert_eq!(envelope.kind, "session_started");
+    }
+
+    /// A JSON-RPC response (has an `id`, no `method`) must NOT be classified
+    /// as a notification.
+    #[test]
+    fn classify_notification_ignores_other_shapes() {
+        let response = json!({"jsonrpc": "2.0", "id": 1, "result": {}});
+        assert!(classify_notification(&response).is_none());
+
+        let other_method = json!({"method": "ping", "params": {}});
+        assert!(classify_notification(&other_method).is_none());
+
+        let malformed_params = json!({"method": "session.event", "params": {"not": "an envelope"}});
+        assert!(classify_notification(&malformed_params).is_none());
+    }
+}

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -317,6 +317,21 @@ pub mod session;
 /// coverage in `tests/task_e2e.rs`.
 pub mod task;
 
+/// Thin JSON-RPC client the `tcode` CLI binary drives against its own
+/// spawned `tcode serve --stdio` child (#2060, vision spec §4.4 "CLI as
+/// Thin Client" / Axiom 3 "API-First").
+///
+/// Why: the CLI must hold no orchestration logic of its own — every
+/// session/task operation goes through the SAME JSON-RPC surface `tcode
+/// serve` exposes, so a human, a script, and a future TUI see identical
+/// behaviour.
+/// What: `cli_client::stdio::StdioRpcClient` (spawn + NDJSON request/
+/// response/notification I/O) and `cli_client::render` (pure formatting for
+/// `session list`/`attach`/`run-task`/`transcript`).
+/// Test: `cli_client::stdio::tests::*`, `cli_client::render::tests::*`;
+/// end-to-end coverage in `tests/cli_e2e.rs`.
+pub mod cli_client;
+
 // ── Package-level re-exports ──
 
 /// Version string, re-exported so integration tests can assert it without

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -1,20 +1,26 @@
 //! tcode — entry point for the trusty-code CLI.
 //!
 //! Why: provides the `tcode` binary that operators, agents, and TUI frontends
-//! use to interact with the per-project MPM orchestration harness. Phase 0
-//! defines the CLI surface (subcommands + flags); the `run-task` path is now a
-//! full PM→engineer execution (epic #1039 / #1034).
+//! use to interact with the per-project MPM orchestration harness. As of
+//! #2060 (M1 cut-line "replay via thin CLI"), `run-task`, `session list`/
+//! `status`, `attach`, `cancel`, and `transcript` are all thin JSON-RPC
+//! clients over a `tcode serve --stdio` child this binary spawns itself
+//! (`trusty_code::cli_client` + `crate::cli`) — no orchestration logic lives
+//! in the CLI. The ORIGINAL in-process `run-task` execution (epic #1039 /
+//! #1034, calling `trusty_code::run_task::execute_run_task` directly) is
+//! kept available behind `--legacy-in-process` (see [`Command::RunTask`]'s
+//! docs for why it was kept rather than deleted) — `trusty_code::run_task`'s
+//! own extensive offline test suite (`run_task::tests`) exercises that
+//! library function directly and is unaffected by this CLI-layer change.
 //!
-//! What: thin clap CLI. `run-task` resolves the agents dir, validates the agent
-//! name + project path, builds the real OpenRouter `LlmClient` from env, and
-//! delegates to `trusty_code::run_task::execute_run_task`, then prints a human or
-//! `--json` report and exits with the report's meaningful exit code. `serve`
-//! (#2053) delegates to `trusty_code::serve::{run_stdio, run_http}` for its
-//! two transports. `run-workflow` remains a stub.
+//! What: thin clap CLI. `serve` (#2053) delegates to
+//! `trusty_code::serve::{run_stdio, run_http}` for its two transports.
+//! `run-workflow` remains a stub.
 //!
 //! Test: `cargo run -p trusty-code -- --version` must exit 0 and print the
-//! crate version. The execution path is covered by `trusty_code::run_task::tests`
-//! (offline, mocked LLM); the binary handler is a thin wrapper over that.
+//! crate version. The thin-client subcommands are covered end-to-end by
+//! `tests/cli_e2e.rs` (spawns the real binary); the legacy in-process path
+//! remains covered by `trusty_code::run_task::tests`.
 
 use std::path::{Path, PathBuf};
 use std::process;
@@ -26,6 +32,8 @@ use tracing::info;
 
 use trusty_code::llm::{LlmClient, LlmClientConfig, LlmClientTrait};
 use trusty_code::run_task::{ExitCode, RunTaskParams, execute_run_task};
+
+mod cli;
 
 /// Environment variable that overrides the engineer model for a single run (#1035).
 const ENGINEER_MODEL_ENV: &str = "TCODE_ENGINEER_MODEL";
@@ -85,12 +93,20 @@ enum Command {
         port: Option<u16>,
     },
 
-    /// Delegate a single task to a named agent and run it end-to-end.
+    /// Create (or target) a session, run a task through it via the daemon's
+    /// `task.run`, stream live events to the terminal as they arrive, and
+    /// exit once the run reaches a terminal state (#2060, the M1 cut-line
+    /// "replay via thin CLI" verb).
     ///
-    /// Loads the agent config from `<project>/.claude/agents/<agent>.toml`,
-    /// assembles its system prompt (with project `CLAUDE.md` context), runs the
-    /// PM through the agent loop, lets it delegate to the python-engineer
-    /// in-process, and prints the resulting diff, transcript, and usage.
+    /// This is a THIN CLIENT by default: it spawns an ephemeral
+    /// `tcode serve --stdio` child (`crate::cli::run_task`) and drives it
+    /// entirely over JSON-RPC — no agent-loop logic runs in this process.
+    /// `--legacy-in-process` restores the pre-#2060 behaviour (this binary
+    /// runs the PM->engineer `AgentLoop` directly, printing a diff/
+    /// transcript/usage report at the end) — kept available rather than
+    /// deleted since it is still exercised by `trusty_code::run_task::tests`
+    /// and some callers may depend on its diff-report output, which the
+    /// daemon-driven path does not (yet) compute.
     RunTask {
         /// Agent name as declared in `.claude/agents/<name>.toml` (e.g. `pm`).
         agent: String,
@@ -112,6 +128,11 @@ enum Command {
         /// config's own model.
         #[arg(long, value_name = "SLUG")]
         engineer_model: Option<String>,
+
+        /// Use the ORIGINAL in-process execution path instead of the #2060
+        /// thin JSON-RPC client. See this variant's docs for why it is kept.
+        #[arg(long)]
+        legacy_in_process: bool,
     },
 
     /// Execute a named MPM workflow end-to-end.
@@ -123,6 +144,72 @@ enum Command {
         name: String,
 
         /// Path to the project root.
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+    },
+
+    /// Inspect and manage daemon-owned sessions (#2060).
+    Session {
+        #[command(subcommand)]
+        action: SessionCommand,
+    },
+
+    /// Attach to a live session and stream its events to the terminal until
+    /// it reaches a terminal state or you press Ctrl-C (#2060).
+    ///
+    /// Spawns its OWN ephemeral daemon (see `crate::cli::attach`'s docs) —
+    /// only useful against a session created within THIS same invocation
+    /// today; M1 sessions are in-memory, per daemon process.
+    Attach {
+        /// The session id to attach to.
+        session_id: String,
+
+        /// Path to the project root the daemon should be rooted at.
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+    },
+
+    /// Send a cancellation signal to a session (#2060).
+    Cancel {
+        /// The session id to cancel.
+        session_id: String,
+
+        /// Path to the project root the daemon should be rooted at.
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+    },
+
+    /// Print a session's stored transcript (turns, tool calls, usage, cost)
+    /// via `session.get_transcript` (#2058, #2060).
+    Transcript {
+        /// The session id to inspect.
+        session_id: String,
+
+        /// Path to the project root the daemon should be rooted at.
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+
+        /// Emit the raw JSON result instead of a human-readable rendering.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// `tcode session <action>` subcommands (#2060).
+#[derive(Subcommand)]
+enum SessionCommand {
+    /// List every session the daemon currently knows about.
+    List {
+        /// Path to the project root the daemon should be rooted at.
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+    },
+    /// Show one session's current status.
+    Status {
+        /// The session id to look up.
+        session_id: String,
+
+        /// Path to the project root the daemon should be rooted at.
         #[arg(long, short, value_name = "PATH", default_value = ".")]
         project: PathBuf,
     },
@@ -150,7 +237,21 @@ async fn main() -> Result<()> {
             project,
             json,
             engineer_model,
-        } => run_task(&agent, &task, &project, json, engineer_model).await,
+            legacy_in_process,
+        } => {
+            if legacy_in_process {
+                run_task(&agent, &task, &project, json, engineer_model).await
+            } else {
+                let project = canonicalize_project_or_exit(&project, "run-task");
+                match cli::run_task::run(&project, &agent, &task, json, engineer_model).await {
+                    Ok(code) => process::exit(code),
+                    Err(e) => {
+                        eprintln!("tcode run-task: {e:#}");
+                        process::exit(ExitCode::RunFailure.code());
+                    }
+                }
+            }
+        }
 
         Command::RunWorkflow { name, project } => {
             eprintln!(
@@ -159,7 +260,94 @@ async fn main() -> Result<()> {
             );
             process::exit(1);
         }
+
+        Command::Session { action } => match action {
+            SessionCommand::List { project } => {
+                let project = canonicalize_project_or_exit(&project, "session list");
+                run_thin_client(cli::session::list(&project), "session list").await
+            }
+            SessionCommand::Status {
+                session_id,
+                project,
+            } => {
+                let project = canonicalize_project_or_exit(&project, "session status");
+                run_thin_client(
+                    cli::session::status(&project, &session_id),
+                    "session status",
+                )
+                .await
+            }
+        },
+
+        Command::Attach {
+            session_id,
+            project,
+        } => {
+            let project = canonicalize_project_or_exit(&project, "attach");
+            run_thin_client(cli::attach::run(&project, &session_id), "attach").await
+        }
+
+        Command::Cancel {
+            session_id,
+            project,
+        } => {
+            let project = canonicalize_project_or_exit(&project, "cancel");
+            run_thin_client(cli::cancel::run(&project, &session_id), "cancel").await
+        }
+
+        Command::Transcript {
+            session_id,
+            project,
+            json,
+        } => {
+            let project = canonicalize_project_or_exit(&project, "transcript");
+            run_thin_client(
+                cli::transcript::run(&project, &session_id, json),
+                "transcript",
+            )
+            .await
+        }
     }
+}
+
+/// Canonicalize `project`, printing a `tcode <cmd>:`-prefixed error and
+/// exiting with [`ExitCode::ConfigError`] on failure.
+///
+/// Why: every thin-client subcommand needs the SAME "must be a real,
+/// existing directory" validation `run-task`'s legacy path already applies
+/// — centralised so each one-line match arm above doesn't repeat it.
+/// What: `Path::canonicalize`, exiting on `Err` rather than returning one
+/// (matching this binary's existing `process::exit`-on-config-error style).
+fn canonicalize_project_or_exit(project: &Path, cmd: &str) -> PathBuf {
+    project.canonicalize().unwrap_or_else(|e| {
+        eprintln!(
+            "tcode {cmd}: invalid --project path '{}': {e}",
+            project.display()
+        );
+        process::exit(ExitCode::ConfigError.code());
+    })
+}
+
+/// Run a thin-client subcommand's future, printing a `tcode <cmd>:`-prefixed
+/// error and exiting nonzero on failure; exits 0 on success.
+///
+/// Why: every non-`run-task` thin-client subcommand (`session list`/
+/// `status`, `attach`, `cancel`, `transcript`) shares the exact same
+/// "await, print error verbatim (`RpcClientError`'s `Display` already
+/// includes the daemon's JSON-RPC error message/code where applicable),
+/// exit nonzero" shape — centralised here instead of repeated per arm.
+/// What: `ExitCode::RunFailure`'s numeric value on error (mirrors
+/// `run-task`'s exit-code contract); exits 0 (falls through, returning
+/// `Ok(())`) on success.
+async fn run_thin_client(
+    fut: impl std::future::Future<Output = Result<()>>,
+    cmd: &str,
+) -> Result<()> {
+    if let Err(e) = fut.await {
+        eprintln!("tcode {cmd}: {e:#}");
+        process::exit(ExitCode::RunFailure.code());
+    }
+    Ok(())
 }
 
 /// Execute `tcode serve`: dispatches to whichever transport was selected.

--- a/crates/trusty-code/src/run_task/recorder.rs
+++ b/crates/trusty-code/src/run_task/recorder.rs
@@ -18,7 +18,7 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
 use crate::perf::TokenUsage;
@@ -34,9 +34,11 @@ use crate::perf::TokenUsage;
 /// the invoked tool names in order; `usage` is the token usage the provider
 /// reported for this turn (the per-turn unit the run aggregates over both PM and
 /// engineer turns, since the engineer's usage is otherwise lost when its output
-/// flows back to the PM as a tool-result string).
+/// flows back to the PM as a tool-result string). `Deserialize` (#2060) lets
+/// `tcode`'s CLI thin client parse a `session.get_transcript` JSON-RPC result
+/// straight back into `Vec<TurnRecord>`.
 /// Test: `run_task::tests::transcript_has_pm_and_engineer_turns`.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TurnRecord {
     /// Agent label that produced this turn (e.g. `"pm"`, `"python-engineer"`).
     pub role: String,

--- a/crates/trusty-code/src/session/transcript.rs
+++ b/crates/trusty-code/src/session/transcript.rs
@@ -7,7 +7,11 @@
 //! recomputing anything. Kept as its own small file (rather than growing
 //! `registry.rs`) so the wire shape has one obvious home and stays decoupled
 //! from the registry's storage/locking internals.
-//! What: [`TranscriptRecord`] is a plain, `Serialize`-only DTO: `session_id`,
+//! What: [`TranscriptRecord`] is a plain, `Serialize`+`Deserialize` DTO
+//! (#2060: the `Deserialize` half lets `tcode`'s CLI thin client — see
+//! `crate::cli_client` — parse `session.get_transcript`'s JSON-RPC result
+//! straight back into this type rather than picking fields off a raw
+//! `serde_json::Value`): `session_id`,
 //! the ordered `turns` (each already `role`/`model`/`text`/`tool_calls`/
 //! `usage` — see `crate::run_task::TurnRecord`), the aggregate `usage`, and
 //! `cost_usd` exactly as stored (`None` either because pricing was
@@ -18,7 +22,7 @@
 //! valid, empty transcript, not an error.
 //! Test: `session::registry_tests::get_transcript_*`.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::perf::TokenUsage;
 use crate::run_task::TurnRecord;
@@ -35,7 +39,7 @@ use crate::run_task::TurnRecord;
 /// the result self-contained for a caller inspecting the JSON alone).
 /// Test: `session::registry_tests::get_transcript_returns_stored_record`,
 /// `session::registry_tests::get_transcript_on_never_run_session_is_empty`.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptRecord {
     pub session_id: String,
     pub turns: Vec<TurnRecord>,

--- a/crates/trusty-code/tests/cli_e2e.rs
+++ b/crates/trusty-code/tests/cli_e2e.rs
@@ -1,0 +1,216 @@
+//! Black-box CLI end-to-end test for #2060: the M1 cut-line "replay via
+//! thin CLI" verb.
+//!
+//! Why: #2053-#2058 proved the daemon + JSON-RPC surface works over its own
+//! wire (`tests/session_e2e.rs`, `tests/task_e2e.rs`), driven either
+//! directly against `tcode serve` or via the small test-only `StdioSession`
+//! helper. This ticket's own deliverable — the `tcode` BINARY's subcommands
+//! — needs its OWN black-box proof: spawn the compiled `tcode` binary
+//! (`env!("CARGO_BIN_EXE_tcode")`) exactly as a user's shell would, let it
+//! do whatever it does internally (which, per #2060, is spawn its OWN
+//! nested `tcode serve --stdio` child and speak JSON-RPC to it — this test
+//! never touches that nested layer directly), and assert only on the
+//! OUTER process's stdout/stderr/exit code. `TCODE_MOCK_LLM=echo` keeps
+//! `run-task` deterministic and offline (env propagates from this outer
+//! process to the CLI's own spawned nested daemon child, since it inherits
+//! the environment by default).
+//! What: [`run_task_streams_live_events_and_reports_final_status`] is the
+//! REQUIRED case — `tcode run-task python-engineer "<task>" --project <tmp>`
+//! must print live tool events and a final `status=finished` line, exit 0.
+//! `run_task_json_mode_prints_only_the_final_session` proves `--json`
+//! suppresses the per-event lines and emits one parseable JSON document.
+//!
+//! `session_list_on_fresh_project_reports_no_sessions`,
+//! `transcript_unknown_session_errors_cleanly`,
+//! `attach_unknown_session_errors_cleanly`, and
+//! `cancel_unknown_session_errors_cleanly` prove the remaining subcommands
+//! are wired and that daemon errors surface as clear CLI errors and a
+//! nonzero exit (per the ticket's explicit requirement) — see those
+//! subcommands' own module docs (`crate::cli::session`/`attach`/`cancel`/
+//! `transcript` in `src/cli/`) for why a MEANINGFUL cross-invocation
+//! inspection test (attach to a session a DIFFERENT process created) isn't
+//! possible yet: M1 sessions are in-memory, one per ephemeral spawned
+//! daemon, and this ticket's required path is spawn-stdio, not a shared
+//! long-lived daemon.
+//!
+//! Test: this file IS the test; see `support` for the shared
+//! `project_with_agents` fixture.
+
+mod support;
+
+use std::process::Command;
+
+use support::project_with_agents;
+
+/// `tcode run-task <agent> "<task>" --project <tmp>` (`TCODE_MOCK_LLM=echo`)
+/// must stream the PM's `delegate_to_agent` and the engineer's `bash` tool
+/// events to stdout, then report `status=finished`, exiting 0.
+#[test]
+fn run_task_streams_live_events_and_reports_final_status() {
+    let project = project_with_agents();
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "run-task",
+            "pm",
+            "say hi",
+            "--project",
+            &project.path().display().to_string(),
+        ])
+        .env("TCODE_MOCK_LLM", "echo")
+        .output()
+        .expect("spawn tcode run-task");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "tcode run-task must exit 0, got {:?}\nstdout: {stdout}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("tool_started") && stdout.contains("delegate_to_agent"),
+        "expected the PM's delegate_to_agent dispatch in stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("tool_started") && stdout.contains("bash"),
+        "expected the engineer's bash dispatch in stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("tool_finished"),
+        "expected at least one tool_finished line in stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("status=finished"),
+        "expected the final status line to report finished: {stdout}"
+    );
+}
+
+/// `tcode run-task ... --json` must suppress the live per-event lines and
+/// print exactly one parseable JSON document with `status: "finished"`.
+#[test]
+fn run_task_json_mode_prints_only_the_final_session() {
+    let project = project_with_agents();
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "run-task",
+            "pm",
+            "say hi",
+            "--project",
+            &project.path().display().to_string(),
+            "--json",
+        ])
+        .env("TCODE_MOCK_LLM", "echo")
+        .output()
+        .expect("spawn tcode run-task --json");
+
+    assert!(
+        output.status.success(),
+        "tcode run-task --json must exit 0, got {:?}",
+        output.status.code()
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("tool_started"),
+        "--json must suppress live event lines: {stdout}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be valid JSON: {e}: {stdout}"));
+    assert_eq!(parsed["status"], "finished");
+}
+
+/// `tcode session list` on a project with no prior activity must report no
+/// sessions and exit 0 — proving the `session.list` wiring even though this
+/// ephemeral-spawn CLI invocation's daemon has an empty registry.
+#[test]
+fn session_list_on_fresh_project_reports_no_sessions() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "session",
+            "list",
+            "--project",
+            &project.path().display().to_string(),
+        ])
+        .output()
+        .expect("spawn tcode session list");
+
+    assert!(output.status.success(), "must exit 0: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("no sessions"),
+        "expected an empty-list message: {stdout}"
+    );
+}
+
+/// `tcode transcript <unknown-id>` must surface the daemon's
+/// `session_not_found` error as a clean CLI error on stderr and exit
+/// nonzero.
+#[test]
+fn transcript_unknown_session_errors_cleanly() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "transcript",
+            "nonexistent-id",
+            "--project",
+            &project.path().display().to_string(),
+        ])
+        .output()
+        .expect("spawn tcode transcript");
+
+    assert!(
+        !output.status.success(),
+        "must exit nonzero on session_not_found"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("session not found") || stderr.contains("-32007"),
+        "expected a clear session_not_found error on stderr: {stderr}"
+    );
+}
+
+/// `tcode attach <unknown-id>` must likewise surface a clean error and exit
+/// nonzero rather than hanging.
+#[test]
+fn attach_unknown_session_errors_cleanly() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "attach",
+            "nonexistent-id",
+            "--project",
+            &project.path().display().to_string(),
+        ])
+        .output()
+        .expect("spawn tcode attach");
+
+    assert!(!output.status.success(), "must exit nonzero");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("session not found") || stderr.contains("-32007"),
+        "expected a clear session_not_found error on stderr: {stderr}"
+    );
+}
+
+/// `tcode cancel <unknown-id>` must likewise surface a clean error and exit
+/// nonzero.
+#[test]
+fn cancel_unknown_session_errors_cleanly() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "cancel",
+            "nonexistent-id",
+            "--project",
+            &project.path().display().to_string(),
+        ])
+        .output()
+        .expect("spawn tcode cancel");
+
+    assert!(!output.status.success(), "must exit nonzero");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("session not found") || stderr.contains("-32007"),
+        "expected a clear session_not_found error on stderr: {stderr}"
+    );
+}

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -41,6 +41,29 @@ use tokio::time::timeout;
 /// test in seconds rather than hanging the suite.
 const WIRE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Provision a throwaway project with `.claude/agents/{pm,python-engineer}.toml`.
+///
+/// Why: shared by `tests/task_e2e.rs` (drives the daemon directly) and
+/// (#2060) `tests/cli_e2e.rs` (drives the `tcode` CLI, which spawns its own
+/// nested daemon) — both need the SAME minimal two-agent fixture for
+/// `TCODE_MOCK_LLM=echo`'s scripted PM -> engineer delegation to resolve.
+pub fn project_with_agents() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("project tempdir");
+    let agents = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents).expect("mkdir agents");
+    std::fs::write(
+        agents.join("pm.toml"),
+        "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"You are the PM. Delegate work to python-engineer.\"\n",
+    )
+    .expect("write pm.toml");
+    std::fs::write(
+        agents.join("python-engineer.toml"),
+        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n[system_prompt]\ncontent = \"You are a Python engineer.\"\n",
+    )
+    .expect("write python-engineer.toml");
+    tmp
+}
+
 /// A running `tcode serve --stdio` subprocess with line-buffered stdin/stdout.
 ///
 /// Why: the STDIO half of the API-driven e2e coverage — every call in

--- a/crates/trusty-code/tests/task_e2e.rs
+++ b/crates/trusty-code/tests/task_e2e.rs
@@ -38,25 +38,7 @@
 mod support;
 
 use serde_json::json;
-use support::{StdioSession, find_session_event, run_task_to_completion};
-
-/// Provision a throwaway project with `.claude/agents/{pm,python-engineer}.toml`.
-fn project_with_agents() -> tempfile::TempDir {
-    let tmp = tempfile::tempdir().expect("project tempdir");
-    let agents = tmp.path().join(".claude").join("agents");
-    std::fs::create_dir_all(&agents).expect("mkdir agents");
-    std::fs::write(
-        agents.join("pm.toml"),
-        "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"You are the PM. Delegate work to python-engineer.\"\n",
-    )
-    .expect("write pm.toml");
-    std::fs::write(
-        agents.join("python-engineer.toml"),
-        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n[system_prompt]\ncontent = \"You are a Python engineer.\"\n",
-    )
-    .expect("write python-engineer.toml");
-    tmp
-}
+use support::{StdioSession, find_session_event, project_with_agents, run_task_to_completion};
 
 /// `task.run` -> `session.attach` must observe the FULL PM -> engineer tool
 /// dispatch as live (or, in the replay burst, if the mock run already


### PR DESCRIPTION
Implements #2060 — `tcode` subcommands (session list/status, run-task, attach, cancel, transcript) driving the daemon over JSON-RPC via a spawned `serve --stdio` child; `run-task` streams live tool events to the terminal (the M1 cut-line "replay via thin CLI" verb); legacy in-process path preserved behind `--legacy-in-process`. QA-verified: gate green (445 lib + 6 cli_e2e + session_e2e + task_e2e pass, clippy/fmt/line-cap clean, downstream trusty-agents clean), real-CLI streaming e2e reproduced with no API key, clean nonzero exits on errors, 10/10 no flakes. Follow-ups tracked in #2130 (cross-process HTTP client, daemon diff-capture). 

\`Closes #2060\`. \`Part of #2052\`. Milestone M1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)