### PR TITLE
feat(trusty-code): harness mode selection (daily-driver / parity) (#2059)

### DIFF
--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -36,6 +36,7 @@ use std::time::Duration;
 use serde_json::Value;
 
 use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, ToolCall, ToolDefinition};
+use crate::mode::HarnessMode;
 use crate::perf::PerfCollector;
 use crate::tools::{AgentOutput, ToolRegistry, ToolResult};
 
@@ -56,6 +57,10 @@ const PERF_WORKFLOW: &str = "agent_loop";
 /// constructor signature stable as more knobs are added later.
 /// What: `max_turns` bounds LLM round-trips; `timeout_secs` bounds total
 /// wall-clock time; `model` is the OpenRouter slug sent on every request.
+/// `mode` (#2059) is the resolved `HarnessMode` for this run — the branch
+/// point `tool_definitions` uses; defaults to `HarnessMode::default()`
+/// (`DailyDriver`) so every pre-#2059 call site that doesn't set it
+/// unchanged.
 /// Test: `agent_loop::tests::config_defaults_are_sane`.
 #[derive(Debug, Clone)]
 pub struct AgentLoopConfig {
@@ -67,6 +72,10 @@ pub struct AgentLoopConfig {
 
     /// OpenRouter model slug sent on every chat request.
     pub model: String,
+
+    /// The resolved harness mode for this run (#2059). See
+    /// `Self::tool_definitions`' docs for the branch point this feeds.
+    pub mode: HarnessMode,
 }
 
 impl Default for AgentLoopConfig {
@@ -74,13 +83,14 @@ impl Default for AgentLoopConfig {
     ///
     /// Why: Most callers want a bounded but generous loop; defaults avoid
     /// boilerplate at every construction site.
-    /// What: 8 turns, 120s timeout, `openai/gpt-4o-mini`.
+    /// What: 8 turns, 120s timeout, `openai/gpt-4o-mini`, `HarnessMode::default()`.
     /// Test: `config_defaults_are_sane`.
     fn default() -> Self {
         Self {
             max_turns: 8,
             timeout_secs: 120,
             model: "openai/gpt-4o-mini".to_string(),
+            mode: HarnessMode::default(),
         }
     }
 }
@@ -304,17 +314,29 @@ impl AgentLoop {
     ///
     /// Why: The registry emits OpenAI-format `serde_json::Value` schemas, but
     /// `ChatRequest.tools` is typed as `Vec<ToolDefinition>`; this bridges the
-    /// two without forcing every tool to know about the request type.
+    /// two without forcing every tool to know about the request type. The
+    /// `self.config.mode` branch (#2059) is the tool-schema CONSUMPTION POINT
+    /// for P1B's token-efficiency work: `HarnessMode::Parity` must forever
+    /// return the registry's full schema set verbatim (parity-spec D2 requires
+    /// byte-identical schemas across models); `HarnessMode::DailyDriver` is
+    /// where a future deferred/metadata-only schema set will be substituted.
+    /// Both arms are identical in M1 — no such set exists yet.
     /// What: Deserialises each schema value; a schema that fails to parse is
     /// dropped (a malformed schema must not abort the run) but logged with
     /// `tracing::warn!` — including the offending tool's name (best-effort from
     /// the raw schema) and the parse error — so a misconfigured tool that is
     /// never advertised to the model is diagnosable rather than silent.
     /// Test: `agent_loop::tests::two_turn_flow_completes` advertises a real tool
-    /// schema through this path.
+    /// schema through this path; `agent_loop::tests::tool_definitions_identical_across_modes_in_m1`
+    /// pins the #2059 "no behavioural difference yet" contract.
     fn tool_definitions(&self) -> Vec<ToolDefinition> {
-        self.registry
-            .schemas()
+        let schemas = match self.config.mode {
+            HarnessMode::Parity => self.registry.schemas(),
+            // P1B hooks in here: a deferred/metadata-only schema set. Full
+            // schemas until then (#2059 M1 scope).
+            HarnessMode::DailyDriver => self.registry.schemas(),
+        };
+        schemas
             .into_iter()
             .filter_map(
                 |v| match serde_json::from_value::<ToolDefinition>(v.clone()) {

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -254,6 +254,42 @@ fn schema_tool_name_extracts_or_falls_back() {
     assert_eq!(super::schema_tool_name(&non_string_name), "<unknown>");
 }
 
+/// #2059: `tool_definitions`'s `HarnessMode` branch must produce IDENTICAL
+/// tool schemas for both modes in M1 — the branch exists (a real seam for
+/// P1B to hook into) but has no behavioural difference yet.
+///
+/// Why: pins the documented "byte-identical until P1B" contract at the
+/// tool-schema layer, mirroring `prompt::tests::assemble_system_prompt_for_mode_is_identical_in_m1`
+/// for the prompt-assembly layer.
+/// What: constructs two loops over the SAME registry, differing only in
+/// `AgentLoopConfig.mode`, and asserts `tool_definitions()` returns the
+/// exact same `Vec<ToolDefinition>` for both.
+/// Test: this test.
+#[test]
+fn tool_definitions_identical_across_modes_in_m1() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[]));
+    let registry = registry_with_echo(false);
+
+    let parity = make_loop(
+        llm.clone(),
+        registry.clone(),
+        AgentLoopConfig {
+            mode: crate::mode::HarnessMode::Parity,
+            ..AgentLoopConfig::default()
+        },
+    );
+    let daily_driver = make_loop(
+        llm,
+        registry,
+        AgentLoopConfig {
+            mode: crate::mode::HarnessMode::DailyDriver,
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    assert_eq!(parity.tool_definitions(), daily_driver.tool_definitions());
+}
+
 /// A two-turn flow: assistant calls the tool, then stops with final text.
 ///
 /// Why: This is the canonical happy path the loop exists to support.
@@ -463,6 +499,7 @@ async fn agent_loop_live() {
             max_turns: 4,
             timeout_secs: 60,
             model: "openai/gpt-4o-mini".to_string(),
+            mode: crate::mode::HarnessMode::default(),
         },
         Arc::new(client),
         registry,

--- a/crates/trusty-code/src/cli/run_task.rs
+++ b/crates/trusty-code/src/cli/run_task.rs
@@ -17,7 +17,13 @@
 //! and `cli_client::render::exit_code_for_status` for the process exit code.
 //! `--json` suppresses the live per-event lines and prints only the final
 //! `Session` snapshot as pretty JSON, matching the legacy path's `--json`
-//! contract (a single JSON document on stdout).
+//! contract (a single JSON document on stdout). `--mode` (#2059) is passed
+//! straight through as `task.run`'s own `mode` param — this function does
+//! NOT resolve or validate it; the daemon's `crate::mode::resolve_mode`
+//! (highest to lowest: `TRUSTY_CODE_MODE` > this param >
+//! `.claude/settings.json` > default) is the single source of truth, and
+//! the resolved value is printed back (human line and `--json` output both
+//! include `Session.mode`).
 //! Test: `tests/cli_e2e.rs::run_task_streams_live_events_and_reports_final_status`
 //! (the required black-box "replay via thin CLI" case, driven with
 //! `TCODE_MOCK_LLM=echo`).
@@ -38,7 +44,8 @@ use super::tcode_exe;
 /// How often the streaming loop wakes up to re-check for a terminal event.
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
-/// `tcode run-task <AGENT> <TASK> [--project P] [--json] [--engineer-model M]`.
+/// `tcode run-task <AGENT> <TASK> [--project P] [--json] [--engineer-model M]
+/// [--mode daily-driver|parity]`.
 ///
 /// Why/What: see module docs. Returns the process exit code the caller
 /// should use (mirrors the legacy path's `ExitCode` contract via
@@ -49,6 +56,7 @@ pub async fn run(
     task: &str,
     json_output: bool,
     engineer_model: Option<String>,
+    mode: Option<String>,
 ) -> Result<i32> {
     let exe = tcode_exe::resolve()?;
     let mut client = StdioRpcClient::spawn(&exe, project)?;
@@ -57,6 +65,7 @@ pub async fn run(
         "task_description": task,
         "agent_name": agent,
         "model_override": engineer_model,
+        "mode": mode,
     });
     let run_result = client.call("task.run", run_params).await?;
     let session_id = run_result
@@ -113,14 +122,15 @@ pub async fn run(
         );
     } else {
         println!(
-            "run {}: session={} status={}",
+            "run {}: session={} status={} mode={}",
             if session.status == trusty_code::session::SessionStatus::Finished {
                 "finished"
             } else {
                 "did not finish cleanly"
             },
             session.id,
-            session.status.as_str()
+            session.status.as_str(),
+            session.mode.map(|m| m.as_str()).unwrap_or("unknown")
         );
     }
 

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -181,6 +181,7 @@ mod tests {
             project: None,
             status,
             created_at: Utc::now(),
+            mode: None,
         }
     }
 
@@ -244,6 +245,7 @@ mod tests {
             }],
             usage: TokenUsage::new(10, 5, 0, 0),
             cost_usd: Some(0.01),
+            mode: Some(crate::mode::HarnessMode::DailyDriver),
         };
         let out = render_transcript_human(&record);
         assert!(out.contains("pm"));
@@ -259,6 +261,7 @@ mod tests {
             turns: vec![],
             usage: TokenUsage::default(),
             cost_usd: None,
+            mode: None,
         };
         let out = render_transcript_human(&record);
         assert!(out.contains("s-1"));

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -153,6 +153,19 @@ pub mod llm;
 /// Test: `agents::tests::*`.
 pub mod agents;
 
+/// Harness mode selection: `daily-driver` (default, token-efficiency
+/// consumption point) vs `parity` (full-schema benchmark mode) — #2059,
+/// vision spec §5.9.
+///
+/// Why: reconciles the parity spec's byte-identical-schema requirement with
+/// the production harness's future token-efficiency work by making the
+/// choice an explicit, resolvable, queryable mode rather than picking one
+/// behaviour permanently.
+/// What: `HarnessMode`, `resolve_mode` (the three-tier precedence: env var >
+/// `task.run` param > `.claude/settings.json` > default).
+/// Test: `mode::tests::*`.
+pub mod mode;
+
 /// Caller identity hierarchy for memory scoping.
 ///
 /// Why: Memory must be scoped according to who is calling — operator, PM, or

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -133,6 +133,14 @@ enum Command {
         /// thin JSON-RPC client. See this variant's docs for why it is kept.
         #[arg(long)]
         legacy_in_process: bool,
+
+        /// Per-call `HarnessMode` override (#2059, vision spec §5.9):
+        /// `daily-driver` or `parity`. Passed as `task.run`'s `mode` param
+        /// (thin-client path only — ignored under `--legacy-in-process`,
+        /// which has no mode concept). `TRUSTY_CODE_MODE` still overrides
+        /// this per the resolution precedence in `crate::mode`'s docs.
+        #[arg(long, value_name = "MODE")]
+        mode: Option<String>,
     },
 
     /// Execute a named MPM workflow end-to-end.
@@ -238,12 +246,14 @@ async fn main() -> Result<()> {
             json,
             engineer_model,
             legacy_in_process,
+            mode,
         } => {
             if legacy_in_process {
                 run_task(&agent, &task, &project, json, engineer_model).await
             } else {
                 let project = canonicalize_project_or_exit(&project, "run-task");
-                match cli::run_task::run(&project, &agent, &task, json, engineer_model).await {
+                match cli::run_task::run(&project, &agent, &task, json, engineer_model, mode).await
+                {
                     Ok(code) => process::exit(code),
                     Err(e) => {
                         eprintln!("tcode run-task: {e:#}");

--- a/crates/trusty-code/src/mode.rs
+++ b/crates/trusty-code/src/mode.rs
@@ -1,0 +1,315 @@
+//! Harness mode selection: `daily-driver` (token-efficient, default) vs
+//! `parity` (full-schema benchmark mode) — #2059, vision spec §5.9
+//! ("Reconciliation with Parity-Spec Decision D2").
+//!
+//! Why: the parity spec (D2) mandates byte-identical, full tool schemas
+//! across every model for benchmark fairness; the production harness wants
+//! deferred schemas / compaction / per-model optimisation for real coding
+//! work. §5.9's resolved decision is two modes selected by a three-tier
+//! precedence, rather than picking one behaviour permanently. This module
+//! is ONLY the selection mechanism — resolving which mode applies to a
+//! given run and making that resolution queryable. It deliberately does
+//! NOT implement any token-efficiency behaviour (deferred schemas,
+//! compaction, repo-map): that is P1B's job, hooking into the branch
+//! points this module's callers expose (`prompt::assemble_system_prompt_for_mode`,
+//! `agent_loop::AgentLoop`'s `mode`-aware `tool_definitions`). In M1 both
+//! modes are functionally identical.
+//!
+//! **Precedence note:** §5.9 states the three-tier hierarchy, highest to
+//! lowest, as: (1) `TRUSTY_CODE_MODE` env var ("escape hatch... overrides
+//! all"), (2) `task.run`'s `mode` param ("overrides setting"), (3)
+//! `.claude/settings.json`'s `code_harness.mode` (the configured default).
+//! [`resolve_mode`] implements EXACTLY this order. (A paraphrase of this
+//! ticket's delegation put the env var last instead of first; §5.9's own
+//! table and the raw issue #2059 text both independently state env-var-
+//! highest, so this module follows the spec verbatim — flagged explicitly
+//! for the reader rather than silently reconciled.)
+//!
+//! What: [`HarnessMode`] (`DailyDriver` | `Parity`, `Default` =
+//! `DailyDriver`), [`HarnessMode::parse_lenient`] (case/separator-tolerant
+//! string parsing), and [`resolve_mode`] (the three-tier precedence chain,
+//! reading the env var and `.claude/settings.json` directly — no injected
+//! clock/env abstraction, matching this crate's existing
+//! `task::mock_llm::build_llm_client` precedent for a small, direct
+//! `std::env`/`std::fs` read in production code).
+//! Test: `mode::tests::*` (precedence order, lenient parsing, unknown-value
+//! degrade-to-next-tier, settings.json presence/absence/malformed-JSON).
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// Escape-hatch environment variable (§5.9): `TRUSTY_CODE_MODE=parity` or
+/// `daily-driver`. Highest precedence — overrides everything else.
+pub const MODE_ENV_VAR: &str = "TRUSTY_CODE_MODE";
+
+/// The two harness modes §5.9 resolves between.
+///
+/// Why: see module docs. A closed, two-variant enum (not a raw `String`)
+/// so every downstream `match` is exhaustive and a typo can never silently
+/// select an unintended mode.
+/// What: `DailyDriver` (default; where P1B's token-efficiency layers will
+/// apply) and `Parity` (full schemas, parity-spec benchmark mode). Wire
+/// representation is `"daily-driver"` / `"parity"` (kebab-case), matching
+/// §5.9's example JSON verbatim.
+/// Test: `mode::tests::wire_representation_is_kebab_case`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HarnessMode {
+    DailyDriver,
+    Parity,
+}
+
+impl Default for HarnessMode {
+    /// §5.9: "`daily-driver` (DEFAULT)".
+    fn default() -> Self {
+        HarnessMode::DailyDriver
+    }
+}
+
+impl HarnessMode {
+    /// The stable wire string for this mode (matches the serde
+    /// `rename_all = "kebab-case"` representation).
+    ///
+    /// Why: callers building a plain JSON response field (`task.run`'s
+    /// immediate `{"mode": ...}`, the CLI's human-readable summary line)
+    /// want this without round-tripping through `serde_json`.
+    /// Test: `mode::tests::as_str_matches_serde_rename`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HarnessMode::DailyDriver => "daily-driver",
+            HarnessMode::Parity => "parity",
+        }
+    }
+
+    /// Parse a mode string leniently: case-insensitive, `_`/`-`
+    /// interchangeable, surrounding whitespace ignored.
+    ///
+    /// Why: every precedence tier's raw value (an env var, a JSON string
+    /// field, a CLI flag) is human-typed and should not require
+    /// byte-perfect casing to work.
+    /// What: `None` for anything that isn't recognisably `"daily-driver"`
+    /// or `"parity"` — callers treat `None` as "this source does not
+    /// contribute a value", falling through to the next-lower-precedence
+    /// tier (see [`resolve_mode`]'s docs for why this, rather than a hard
+    /// error, was chosen).
+    /// Test: `mode::tests::parse_lenient_accepts_case_and_separator_variants`,
+    /// `mode::tests::parse_lenient_rejects_unknown_values`.
+    pub fn parse_lenient(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().replace('_', "-").as_str() {
+            "daily-driver" | "dailydriver" => Some(HarnessMode::DailyDriver),
+            "parity" => Some(HarnessMode::Parity),
+            _ => None,
+        }
+    }
+}
+
+/// Resolve the effective [`HarnessMode`] for one `task.run` call, per §5.9's
+/// three-tier precedence (highest to lowest): [`MODE_ENV_VAR`] > `task_param`
+/// (the `task.run` request's own `mode` field) > `.claude/settings.json`'s
+/// `code_harness.mode` > [`HarnessMode::default`].
+///
+/// Why: the single place this precedence is implemented, so `task::protocol`
+/// never has to re-derive it.
+/// What: checks each tier in order; a tier whose value is absent OR fails
+/// to parse (see [`HarnessMode::parse_lenient`]'s docs — this is the
+/// "clear error or fall back to default" choice this ticket asks to be
+/// made explicit: an invalid value at ANY tier is treated exactly like an
+/// absent one, falling through to the next tier, rather than hard-erroring
+/// the whole call) is skipped.
+/// Test: `mode::tests::env_var_wins_over_everything`,
+/// `mode::tests::task_param_wins_over_settings_json`,
+/// `mode::tests::settings_json_wins_over_default`,
+/// `mode::tests::default_when_nothing_set`,
+/// `mode::tests::invalid_env_var_falls_through_to_next_tier`.
+pub fn resolve_mode(task_param: Option<&str>, project_root: &Path) -> HarnessMode {
+    if let Some(mode) = std::env::var(MODE_ENV_VAR)
+        .ok()
+        .and_then(|v| HarnessMode::parse_lenient(&v))
+    {
+        return mode;
+    }
+    if let Some(mode) = task_param.and_then(HarnessMode::parse_lenient) {
+        return mode;
+    }
+    if let Some(mode) = read_settings_json_mode(project_root) {
+        return mode;
+    }
+    HarnessMode::default()
+}
+
+/// Read `<project_root>/.claude/settings.json`'s `code_harness.mode` key.
+///
+/// Why: the Claude-Code-compatible, project-scoped config location §5.9's
+/// example JSON uses.
+/// What: `None` when the file is missing, unreadable, not valid JSON, or
+/// the key is absent/unparseable — absence at any step is "this source
+/// does not contribute", never an error (mirrors
+/// `project_context::load_project_context`'s same graceful-degrade
+/// convention for a project-scoped config file).
+/// Test: `mode::tests::settings_json_wins_over_default`,
+/// `mode::tests::missing_settings_json_is_not_an_error`,
+/// `mode::tests::malformed_settings_json_is_not_an_error`.
+fn read_settings_json_mode(project_root: &Path) -> Option<HarnessMode> {
+    let path = project_root.join(".claude").join("settings.json");
+    let raw = std::fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let mode_str = value.get("code_harness")?.get("mode")?.as_str()?;
+    HarnessMode::parse_lenient(mode_str)
+}
+
+/// Serializes every test in this crate that sets/reads the process-wide
+/// [`MODE_ENV_VAR`] — `cargo test` runs tests in parallel within one binary,
+/// and an unguarded `set_var`/`remove_var` pair would race across modules
+/// (both here and in `task::protocol::tests`). `pub(crate)` (not private to
+/// `tests` below) so other test modules needing to mutate the SAME env var
+/// share ONE lock, mirroring `task::mock_llm::MOCK_LLM_ENV_LOCK`'s identical
+/// cross-module rationale. A `tokio::sync::Mutex` (not `std::sync::Mutex`)
+/// because `task::protocol::tests::task_run_resolves_and_reports_mode` holds
+/// the guard across `.await` (spanning several `task_run` calls) — clippy's
+/// `await_holding_lock` correctly flags a std mutex held that way.
+#[cfg(test)]
+pub(crate) static MODE_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn with_env_mode<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _guard = MODE_ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation; serialized by `MODE_ENV_LOCK`.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(MODE_ENV_VAR, v),
+                None => std::env::remove_var(MODE_ENV_VAR),
+            }
+        }
+        let result = f();
+        unsafe {
+            std::env::remove_var(MODE_ENV_VAR);
+        }
+        result
+    }
+
+    fn project_with_settings(json: Option<&str>) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        if let Some(json) = json {
+            let dir = tmp.path().join(".claude");
+            std::fs::create_dir_all(&dir).expect("mkdir");
+            std::fs::write(dir.join("settings.json"), json).expect("write settings.json");
+        }
+        tmp
+    }
+
+    #[test]
+    fn wire_representation_is_kebab_case() {
+        assert_eq!(
+            serde_json::to_value(HarnessMode::DailyDriver).unwrap(),
+            serde_json::json!("daily-driver")
+        );
+        assert_eq!(
+            serde_json::to_value(HarnessMode::Parity).unwrap(),
+            serde_json::json!("parity")
+        );
+    }
+
+    #[test]
+    fn as_str_matches_serde_rename() {
+        for mode in [HarnessMode::DailyDriver, HarnessMode::Parity] {
+            assert_eq!(
+                serde_json::json!(mode.as_str()),
+                serde_json::to_value(mode).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn parse_lenient_accepts_case_and_separator_variants() {
+        for s in ["parity", "PARITY", " Parity "] {
+            assert_eq!(HarnessMode::parse_lenient(s), Some(HarnessMode::Parity));
+        }
+        for s in [
+            "daily-driver",
+            "DAILY-DRIVER",
+            "daily_driver",
+            "dailydriver",
+        ] {
+            assert_eq!(
+                HarnessMode::parse_lenient(s),
+                Some(HarnessMode::DailyDriver)
+            );
+        }
+    }
+
+    #[test]
+    fn parse_lenient_rejects_unknown_values() {
+        assert_eq!(HarnessMode::parse_lenient("bogus"), None);
+        assert_eq!(HarnessMode::parse_lenient(""), None);
+    }
+
+    #[tokio::test]
+    async fn default_when_nothing_set() {
+        let project = project_with_settings(None);
+        with_env_mode(None, || {
+            assert_eq!(resolve_mode(None, project.path()), HarnessMode::DailyDriver);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn settings_json_wins_over_default() {
+        let project = project_with_settings(Some(r#"{"code_harness": {"mode": "parity"}}"#));
+        with_env_mode(None, || {
+            assert_eq!(resolve_mode(None, project.path()), HarnessMode::Parity);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn task_param_wins_over_settings_json() {
+        let project = project_with_settings(Some(r#"{"code_harness": {"mode": "parity"}}"#));
+        with_env_mode(None, || {
+            assert_eq!(
+                resolve_mode(Some("daily-driver"), project.path()),
+                HarnessMode::DailyDriver
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn env_var_wins_over_everything() {
+        let project = project_with_settings(Some(r#"{"code_harness": {"mode": "daily-driver"}}"#));
+        with_env_mode(Some("parity"), || {
+            assert_eq!(
+                resolve_mode(Some("daily-driver"), project.path()),
+                HarnessMode::Parity
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn invalid_env_var_falls_through_to_next_tier() {
+        let project = project_with_settings(None);
+        with_env_mode(Some("not-a-real-mode"), || {
+            assert_eq!(
+                resolve_mode(Some("parity"), project.path()),
+                HarnessMode::Parity
+            );
+        })
+        .await;
+    }
+
+    #[test]
+    fn missing_settings_json_is_not_an_error() {
+        let project = project_with_settings(None);
+        assert_eq!(read_settings_json_mode(project.path()), None);
+    }
+
+    #[test]
+    fn malformed_settings_json_is_not_an_error() {
+        let project = project_with_settings(Some("not valid json"));
+        assert_eq!(read_settings_json_mode(project.path()), None);
+    }
+}

--- a/crates/trusty-code/src/prompt/assembler.rs
+++ b/crates/trusty-code/src/prompt/assembler.rs
@@ -99,6 +99,42 @@ pub fn assemble_system_prompt(
     sections.join(SECTION_SEPARATOR)
 }
 
+/// Mode-aware prompt assembly — the CONSUMPTION POINT #2059 wires up for
+/// P1B's token-efficiency work, without implementing any of it here.
+///
+/// Why: vision spec §5.9 resolves the parity/daily-driver split at the
+/// prompt-assembly and tool-schema layers. This function is where the
+/// prompt-assembly half of that branch lives — real code, both arms
+/// currently identical, so P1B has an obvious, already-wired seam to change
+/// ONE arm without touching every call site (`task::executor`,
+/// `runner::in_process::InProcessAgentRunner::run_pipeline`) that currently
+/// calls [`assemble_system_prompt`] directly.
+/// What: `HarnessMode::Parity` calls [`assemble_system_prompt`] verbatim —
+/// this is contractually permanent, since parity-spec D2 requires
+/// byte-identical schemas/prompts for benchmark fairness and must never
+/// change. `HarnessMode::DailyDriver` ALSO calls it verbatim today (M1: no
+/// token-efficiency built yet — see the crate-level `mode` module docs);
+/// P1B is expected to replace only this arm (progressive-disclosure skill
+/// loading, compaction, etc.), never the `Parity` arm.
+/// Test: `prompt::tests::assemble_system_prompt_for_mode_is_identical_in_m1`.
+pub fn assemble_system_prompt_for_mode(
+    mode: crate::mode::HarnessMode,
+    config: &AgentConfig,
+    project_context: Option<&str>,
+    fallback_guidance: Option<&str>,
+) -> String {
+    match mode {
+        crate::mode::HarnessMode::Parity => {
+            assemble_system_prompt(config, project_context, fallback_guidance)
+        }
+        // P1B hooks in here: deferred/progressive-disclosure prompt assembly.
+        // Byte-identical to `Parity` until then (#2059 M1 scope).
+        crate::mode::HarnessMode::DailyDriver => {
+            assemble_system_prompt(config, project_context, fallback_guidance)
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "tests.rs"]
 mod tests;

--- a/crates/trusty-code/src/prompt/mod.rs
+++ b/crates/trusty-code/src/prompt/mod.rs
@@ -7,13 +7,16 @@
 //! assembler that merges the BASE preamble with the per-agent prompt, project
 //! `CLAUDE.md` context, and the optional per-tier fallback guidance.
 //! What: Re-exports [`BASE_PREAMBLE`], [`BASE_PREAMBLE_VERSION`],
-//! [`PromptAssembler`], and [`assemble_system_prompt`].
+//! [`PromptAssembler`], [`assemble_system_prompt`], and (#2059)
+//! [`assemble_system_prompt_for_mode`] — the `HarnessMode`-branching entry
+//! point `task::executor`/`runner::in_process` call so P1B's daily-driver
+//! token-efficiency work has a real, already-wired seam to land in.
 //! Test: `prompt::tests::*` (via `assembler.rs`'s inline test include).
 
 mod assembler;
 mod preamble;
 mod version;
 
-pub use assembler::{PromptAssembler, assemble_system_prompt};
+pub use assembler::{PromptAssembler, assemble_system_prompt, assemble_system_prompt_for_mode};
 pub use preamble::BASE_PREAMBLE;
 pub use version::BASE_PREAMBLE_VERSION;

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -9,8 +9,10 @@
 //! Test: this file.
 
 use crate::agents::AgentConfig;
+use crate::mode::HarnessMode;
 use crate::prompt::{
     BASE_PREAMBLE, BASE_PREAMBLE_VERSION, PromptAssembler, assemble_system_prompt,
+    assemble_system_prompt_for_mode,
 };
 
 /// Build an `AgentConfig` whose `system_prompt.content` is the given string.
@@ -299,4 +301,30 @@ fn all_sections_present_when_supplied() {
     assert!(out.contains("AGENT"));
     assert!(out.contains("PROJECT"));
     assert!(out.contains("FALLBACK"));
+}
+
+/// #2059's mode-aware branch point must produce IDENTICAL output for both
+/// modes in M1 — no token-efficiency behaviour has been built yet, so the
+/// branch existing (and being exercised by this test) matters more than any
+/// difference in its output today.
+///
+/// Why: pins the documented "byte-identical until P1B" contract so a future
+/// change to ONE arm is a deliberate, visible diff to this test, not a
+/// silent divergence.
+/// What: asserts `assemble_system_prompt_for_mode` returns the exact same
+/// string as `assemble_system_prompt` for both `HarnessMode` variants.
+/// Test: this test.
+#[test]
+fn assemble_system_prompt_for_mode_is_identical_in_m1() {
+    let cfg = config_with_prompt("AGENT");
+    let baseline = assemble_system_prompt(&cfg, Some("PROJECT"), Some("FALLBACK"));
+
+    for mode in [HarnessMode::DailyDriver, HarnessMode::Parity] {
+        let via_mode =
+            assemble_system_prompt_for_mode(mode, &cfg, Some("PROJECT"), Some("FALLBACK"));
+        assert_eq!(
+            via_mode, baseline,
+            "mode {mode:?} must match baseline in M1"
+        );
+    }
 }

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -29,7 +29,8 @@ use async_trait::async_trait;
 use crate::agent_loop::{AgentLoop, AgentLoopConfig, ToolEventSink};
 use crate::agents::AgentConfig;
 use crate::llm::LlmClientTrait;
-use crate::prompt::assemble_system_prompt;
+use crate::mode::HarnessMode;
+use crate::prompt::assemble_system_prompt_for_mode;
 use crate::provider::resolve_model;
 use crate::runner::error::RunnerError;
 use crate::tools::{AgentOutput, AgentRunner, RunContext, ToolRegistry};
@@ -136,6 +137,13 @@ pub struct InProcessAgentRunner {
     /// #2056: propagated to every sub-agent `AgentLoop`, so cancelling the
     /// PM's run also stops any in-flight delegated sub-agent loop.
     cancel: Option<Arc<AtomicBool>>,
+    /// #2059: the resolved `HarnessMode` for the delegating (PM) run,
+    /// propagated to every sub-agent `AgentLoop` this runner drives so a
+    /// delegated sub-agent's prompt/tool-schema assembly uses the SAME mode
+    /// as its delegator. Defaults to `HarnessMode::default()`, matching
+    /// pre-#2059 behaviour exactly (both modes are functionally identical
+    /// in M1 regardless).
+    mode: HarnessMode,
 }
 
 impl InProcessAgentRunner {
@@ -161,6 +169,7 @@ impl InProcessAgentRunner {
             config: InProcessRunnerConfig::default(),
             sink: None,
             cancel: None,
+            mode: HarnessMode::default(),
         }
     }
 
@@ -186,6 +195,19 @@ impl InProcessAgentRunner {
     /// Test: `runner::tests::cancel_flag_reaches_delegated_loop`.
     pub fn with_cancel_flag(mut self, cancel: Arc<AtomicBool>) -> Self {
         self.cancel = Some(cancel);
+        self
+    }
+
+    /// Set the resolved `HarnessMode` every sub-agent `AgentLoop` this runner
+    /// drives will use (#2059).
+    ///
+    /// Why: a delegated sub-agent's prompt/tool-schema assembly must use the
+    /// SAME resolved mode as its delegator — a daily-driver PM run should not
+    /// silently delegate to a parity-mode engineer, or vice versa.
+    /// What: Builder-style setter; returns `self` for chaining.
+    /// Test: `runner::tests::with_mode_completes_a_delegated_run_in_both_modes`.
+    pub fn with_mode(mut self, mode: HarnessMode) -> Self {
+        self.mode = mode;
         self
     }
 
@@ -269,11 +291,18 @@ impl InProcessAgentRunner {
             max_turns,
             timeout_secs: self.config.timeout_secs,
             model,
+            mode: self.mode,
         };
 
-        // Assemble the parity system prompt (BASE + agent prompt + project ctx).
+        // Assemble the mode-branched system prompt (BASE + agent prompt +
+        // project ctx) — see `assemble_system_prompt_for_mode`'s docs (#2059).
         // Fallback guidance (the #1023 per-tier seam) is not wired here yet.
-        let system = assemble_system_prompt(&agent, self.project_context.as_deref(), None);
+        let system = assemble_system_prompt_for_mode(
+            self.mode,
+            &agent,
+            self.project_context.as_deref(),
+            None,
+        );
 
         let mut agent_loop = AgentLoop::new(loop_config, Arc::clone(&self.llm), registry);
         if let Some(sink) = &self.sink {

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -568,6 +568,42 @@ async fn project_context_reaches_prompt() {
     );
 }
 
+/// `with_mode` must be chainable and a delegated run must complete
+/// successfully under EITHER `HarnessMode` (#2059) — both modes are
+/// functionally identical in M1, so this pins "the builder wires through
+/// without breaking the run", not a behavioural difference (there isn't
+/// one yet — see `crate::mode`'s and `agent_loop::tests`'s own docs for
+/// where the real branch point is exercised).
+///
+/// Why: `InProcessAgentRunner` is the seam that propagates the PM's
+/// resolved mode to a delegated sub-agent's own `AgentLoop`; a broken
+/// propagation would most likely surface as the delegated run failing to
+/// construct/complete, which this test would catch.
+/// What: runs the SAME scripted delegation twice, once per mode, asserting
+/// both complete successfully.
+/// Test: this test.
+#[tokio::test]
+async fn with_mode_completes_a_delegated_run_in_both_modes() {
+    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    for mode in [
+        crate::mode::HarnessMode::DailyDriver,
+        crate::mode::HarnessMode::Parity,
+    ] {
+        let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+        let invoked = Arc::new(Mutex::new(Vec::new()));
+        let factory = Arc::new(recording_factory(vec![], invoked));
+        let runner =
+            InProcessAgentRunner::new(llm, factory, tmp.path().to_path_buf()).with_mode(mode);
+
+        runner
+            .run("python-engineer", "task")
+            .await
+            .unwrap_or_else(|e| panic!("run must complete under mode {mode:?}: {e}"));
+    }
+}
+
 // ── #2056: ToolEventSink / cancel-flag propagation into the delegated loop ──────
 
 /// Minimal `ToolEventSink` recording call order (see

--- a/crates/trusty-code/src/session/model.rs
+++ b/crates/trusty-code/src/session/model.rs
@@ -80,7 +80,11 @@ impl SessionStatus {
 /// the caller — `session.create`, `session.list`, `session.status`.
 /// What: `id` is a UUIDv4 string; `agent`/`project` are optional because
 /// `session.create` does not require either in M1 (no real agent-loop
-/// wiring yet); `created_at` is UTC.
+/// wiring yet); `created_at` is UTC. `mode` (#2059) is `None` until
+/// `task.run` resolves and sets it (`SessionRegistry::set_mode`) — a session
+/// that has never run a task has no mode, mirroring the same "`None` means
+/// not yet run" convention `session::transcript::TranscriptRecord` already
+/// uses for `cost_usd`.
 /// Test: `model::tests::session_round_trips_through_json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
@@ -90,6 +94,8 @@ pub struct Session {
     pub project: Option<String>,
     pub status: SessionStatus,
     pub created_at: DateTime<Utc>,
+    #[serde(default)]
+    pub mode: Option<crate::mode::HarnessMode>,
 }
 
 #[cfg(test)]
@@ -159,15 +165,18 @@ mod tests {
             project: None,
             status: SessionStatus::Running,
             created_at: Utc::now(),
+            mode: Some(crate::mode::HarnessMode::DailyDriver),
         };
         let value = serde_json::to_value(&session).unwrap();
         assert_eq!(value["id"], "s-1");
         assert_eq!(value["status"], "running");
         assert_eq!(value["agent"], "engineer");
         assert!(value["project"].is_null());
+        assert_eq!(value["mode"], "daily-driver");
 
         let back: Session = serde_json::from_value(value).unwrap();
         assert_eq!(back.id, session.id);
         assert_eq!(back.status, session.status);
+        assert_eq!(back.mode, session.mode);
     }
 }

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -40,6 +40,7 @@ use uuid::Uuid;
 
 use crate::events::{Event, SessionEventEnvelope};
 use crate::jsonrpc::{NotifySender, RpcError};
+use crate::mode::HarnessMode;
 use crate::perf::TokenUsage;
 use crate::run_task::TurnRecord;
 
@@ -155,6 +156,7 @@ impl SessionRegistry {
             project: project.clone(),
             status: SessionStatus::Created,
             created_at: Utc::now(),
+            mode: None,
         };
         {
             let mut sessions = self.lock();
@@ -574,7 +576,34 @@ impl SessionRegistry {
             turns: entry.transcript.clone(),
             usage: entry.usage,
             cost_usd: entry.cost_usd,
+            mode: entry.session.mode,
         })
+    }
+
+    /// `task.run`: persist the resolved `HarnessMode` onto the session
+    /// (#2059).
+    ///
+    /// Why: `task::protocol::task_run` resolves the mode (env var >
+    /// `task.run` param > `.claude/settings.json` > default) BEFORE spawning
+    /// the execution; storing it here — rather than waiting for
+    /// `set_run_outcome` at the end of the run — makes it queryable via
+    /// `session.status`/`session.list` (`Session.mode`) and
+    /// `session.get_transcript` (`TranscriptRecord.mode`, which reads the
+    /// SAME field) as soon as `task.run` returns, not only after the run
+    /// completes.
+    /// What: `Err(session_not_found)` if `id` is unknown; otherwise sets
+    /// `entry.session.mode = Some(mode)`. No event is published — mode is
+    /// bookkeeping metadata, not a session-lifecycle transition in the
+    /// #2055 event taxonomy.
+    /// Test: `registry_tests::set_mode_stores_on_session`,
+    /// `registry_tests::set_mode_unknown_session_errors`.
+    pub fn set_mode(&self, id: &str, mode: HarnessMode) -> Result<(), RpcError> {
+        let mut sessions = self.lock();
+        let entry = sessions
+            .get_mut(id)
+            .ok_or_else(|| RpcError::session_not_found(id))?;
+        entry.session.mode = Some(mode);
+        Ok(())
     }
 
     /// Cooperatively cancel every in-flight execution and wait, bounded by

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -570,6 +570,7 @@ async fn get_transcript_on_never_run_session_is_empty() {
     assert!(transcript.turns.is_empty());
     assert_eq!(transcript.usage, crate::perf::TokenUsage::default());
     assert_eq!(transcript.cost_usd, None);
+    assert_eq!(transcript.mode, None);
 }
 
 /// `get_transcript` on an unknown session must error `session_not_found`
@@ -578,6 +579,36 @@ async fn get_transcript_on_never_run_session_is_empty() {
 async fn get_transcript_unknown_session_errors() {
     let registry = SessionRegistry::new();
     let err = registry.get_transcript("nope").unwrap_err();
+    assert_eq!(err.code, -32007);
+}
+
+/// `set_mode` must store the mode on the session, queryable both via
+/// `status`/`list` (`Session.mode`) and `get_transcript`
+/// (`TranscriptRecord.mode`, the SAME field) (#2059).
+#[tokio::test]
+async fn set_mode_stores_on_session() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    assert_eq!(session.mode, None, "a fresh session has no mode yet");
+
+    registry
+        .set_mode(&session.id, crate::mode::HarnessMode::Parity)
+        .unwrap();
+
+    let status = registry.status(&session.id).unwrap();
+    assert_eq!(status.mode, Some(crate::mode::HarnessMode::Parity));
+
+    let transcript = registry.get_transcript(&session.id).unwrap();
+    assert_eq!(transcript.mode, Some(crate::mode::HarnessMode::Parity));
+}
+
+/// `set_mode` on an unknown session must error `session_not_found` (#2059).
+#[tokio::test]
+async fn set_mode_unknown_session_errors() {
+    let registry = SessionRegistry::new();
+    let err = registry
+        .set_mode("nope", crate::mode::HarnessMode::DailyDriver)
+        .unwrap_err();
     assert_eq!(err.code, -32007);
 }
 

--- a/crates/trusty-code/src/session/transcript.rs
+++ b/crates/trusty-code/src/session/transcript.rs
@@ -19,11 +19,14 @@
 //! session — the two cases are indistinguishable here by design, matching
 //! `RunReport::cost_usd`'s existing convention). A session that has never
 //! run a task returns `turns: []`, `usage` all-zero, `cost_usd: null` — a
-//! valid, empty transcript, not an error.
+//! valid, empty transcript, not an error. `mode` (#2059) is the resolved
+//! `HarnessMode` `task.run` set via `SessionRegistry::set_mode` — `None` for
+//! the same "never run" case.
 //! Test: `session::registry_tests::get_transcript_*`.
 
 use serde::{Deserialize, Serialize};
 
+use crate::mode::HarnessMode;
 use crate::perf::TokenUsage;
 use crate::run_task::TurnRecord;
 
@@ -37,6 +40,8 @@ use crate::run_task::TurnRecord;
 /// cost, plus the `session_id` for a self-describing response (the wire
 /// method already takes `session_id` as a param, but echoing it back keeps
 /// the result self-contained for a caller inspecting the JSON alone).
+/// `mode` (#2059) mirrors `Session.mode` — the same field, read at
+/// `get_transcript` time.
 /// Test: `session::registry_tests::get_transcript_returns_stored_record`,
 /// `session::registry_tests::get_transcript_on_never_run_session_is_empty`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,4 +50,5 @@ pub struct TranscriptRecord {
     pub turns: Vec<TurnRecord>,
     pub usage: TokenUsage,
     pub cost_usd: Option<f64>,
+    pub mode: Option<HarnessMode>,
 }

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -39,8 +39,9 @@ use crate::agent_loop::{AgentLoop, AgentLoopConfig, ToolEventSink};
 use crate::agents::AgentConfig;
 use crate::jsonrpc::RpcError;
 use crate::llm::LlmClientTrait;
+use crate::mode::HarnessMode;
 use crate::project_context::load_project_context;
-use crate::prompt::assemble_system_prompt;
+use crate::prompt::assemble_system_prompt_for_mode;
 use crate::provider::resolve_model;
 use crate::run_task::{RecordingLlmClient, SharedTranscript, TurnRecord};
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
@@ -71,7 +72,10 @@ pub const ENGINEER_AGENT_NAME: &str = "python-engineer";
 /// (PM) agent, `task` is the free-form request text, `project`/`agents_dir`
 /// mirror `run_task::RunTaskParams`, and `model_override` pins the
 /// DELEGATED ENGINEER's model for this run only (mirrors `run_task`'s
-/// `--engineer-model`).
+/// `--engineer-model`). `mode` (#2059) is the ALREADY-RESOLVED `HarnessMode`
+/// (`task::protocol::task_run` resolves it via `crate::mode::resolve_mode`
+/// before constructing this — resolution is a request-parsing concern, not
+/// an execution one).
 #[derive(Debug, Clone)]
 pub struct TaskRunParams {
     pub session_id: String,
@@ -80,6 +84,7 @@ pub struct TaskRunParams {
     pub project: PathBuf,
     pub agents_dir: PathBuf,
     pub model_override: Option<String>,
+    pub mode: HarnessMode,
 }
 
 /// Reserve the session's execution slot and spawn the background run.
@@ -172,7 +177,8 @@ async fn run_and_record(
     ));
 
     let catchup_ctx = crate::catchup::pm_catchup_context(&params.project).await;
-    let pm_system = assemble_system_prompt(
+    let pm_system = assemble_system_prompt_for_mode(
+        params.mode,
         &pm_config,
         project_context.as_deref(),
         catchup_ctx.as_deref(),
@@ -181,6 +187,7 @@ async fn run_and_record(
     let pm_loop = AgentLoop::new(
         AgentLoopConfig {
             model: pm_model.clone(),
+            mode: params.mode,
             ..AgentLoopConfig::default()
         },
         pm_llm,
@@ -208,8 +215,9 @@ async fn run_and_record(
 }
 
 /// Build the in-process engineer runner with project-scoped fs/bash tools,
-/// the #2056 sink, and the shared cancel flag (mirrors
-/// `run_task::build_engineer_runner`, which is private to that module).
+/// the #2056 sink, the shared cancel flag, and (#2059) the SAME resolved
+/// `HarnessMode` as the delegating PM (mirrors `run_task::build_engineer_runner`,
+/// which is private to that module).
 fn build_engineer_runner(
     llm: Arc<dyn LlmClientTrait>,
     params: &TaskRunParams,
@@ -230,7 +238,8 @@ fn build_engineer_runner(
 
     let mut runner = InProcessAgentRunner::new(engineer_llm, factory, params.agents_dir.clone())
         .with_tool_event_sink(sink)
-        .with_cancel_flag(cancel);
+        .with_cancel_flag(cancel)
+        .with_mode(params.mode);
     if let Some(ctx) = project_context {
         runner = runner.with_project_context(ctx);
     }

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -38,6 +38,7 @@ fn params(agents: &TempDir, project: &TempDir, session_id: &str) -> TaskRunParam
         project: project.path().to_path_buf(),
         agents_dir: agents.path().to_path_buf(),
         model_override: None,
+        mode: crate::mode::HarnessMode::default(),
     }
 }
 
@@ -132,6 +133,7 @@ fn resolve_engineer_model_falls_back_when_config_missing() {
         project: empty_agents.path().to_path_buf(),
         agents_dir: empty_agents.path().to_path_buf(),
         model_override: None,
+        mode: crate::mode::HarnessMode::default(),
     };
     let model = resolve_engineer_model(&p);
     assert_eq!(model, "unknown");

--- a/crates/trusty-code/src/task/protocol.rs
+++ b/crates/trusty-code/src/task/protocol.rs
@@ -75,27 +75,41 @@ struct TaskRunRequestParams {
     /// mode.
     #[serde(default)]
     session_id: Option<String>,
+    /// #2059: per-call `HarnessMode` override (vision spec §5.9's tier-2
+    /// precedence source, above `.claude/settings.json` and below
+    /// `TRUSTY_CODE_MODE`). Leniently parsed by
+    /// `crate::mode::resolve_mode` — an unrecognised string here degrades
+    /// to "this source does not contribute", NOT a request error.
+    #[serde(default)]
+    mode: Option<String>,
 }
 
 /// `task.run(task_description, agent_name?, context?, model_override?,
-/// session_id?) -> { session_id, status }`.
+/// session_id?, mode?) -> { session_id, status, mode }`.
 ///
 /// Why: the single entry point that turns a request into a running
 /// background execution.
 /// What: validates `task_description` is non-empty
 /// (`-32003 invalid_argument`); resolves the target session — an existing
 /// one by `session_id` (propagating `session_not_found` if it doesn't
-/// exist) or a freshly `session.create`d one; builds the shared LLM client
-/// (real or the #2056 offline mock, per `TCODE_MOCK_LLM`); and calls
-/// `spawn_task_run`, which reserves the execution slot synchronously
-/// (rejecting a second overlapping run) before handing off to the
-/// background task. Returns immediately — the caller `session.attach`es to
-/// observe progress, per the ticket's "must not block the request thread on
-/// the whole LLM run" requirement.
+/// exist) or a freshly `session.create`d one; resolves the effective
+/// `HarnessMode` via `crate::mode::resolve_mode` (#2059's three-tier
+/// precedence) and persists it onto the session (`SessionRegistry::set_mode`)
+/// so it is queryable afterward via `session.status`/`session.list`
+/// (`Session.mode`) and `session.get_transcript` (`TranscriptRecord.mode`);
+/// builds the shared LLM client (real or the #2056 offline mock, per
+/// `TCODE_MOCK_LLM`); and calls `spawn_task_run`, which reserves the
+/// execution slot synchronously (rejecting a second overlapping run) before
+/// handing off to the background task. Returns immediately — the caller
+/// `session.attach`es to observe progress, per the ticket's "must not block
+/// the request thread on the whole LLM run" requirement. The response's own
+/// `mode` field is the SAME resolved value, surfaced immediately rather than
+/// requiring a follow-up `session.status` call.
 /// Test: `task::protocol::tests::task_run_rejects_empty_task_description`,
 /// `task::protocol::tests::task_run_creates_session_when_none_given`,
 /// `task::protocol::tests::task_run_sessionful_reuses_existing_session`,
-/// `task::protocol::tests::task_run_unknown_session_id_errors`.
+/// `task::protocol::tests::task_run_unknown_session_id_errors`,
+/// `task::protocol::tests::task_run_resolves_and_reports_mode`.
 async fn task_run(
     registry: Arc<SessionRegistry>,
     params: Value,
@@ -126,6 +140,9 @@ async fn task_run(
         }
     };
 
+    let mode = crate::mode::resolve_mode(p.mode.as_deref(), &project);
+    registry.set_mode(&session_id, mode)?;
+
     let llm = build_llm_client()?;
     let task_params = TaskRunParams {
         session_id: session_id.clone(),
@@ -134,10 +151,11 @@ async fn task_run(
         project,
         agents_dir,
         model_override: p.model_override,
+        mode,
     };
     spawn_task_run(registry, llm, task_params)?;
 
-    Ok(json!({ "session_id": session_id, "status": "running" }))
+    Ok(json!({ "session_id": session_id, "status": "running", "mode": mode.as_str() }))
 }
 
 #[cfg(test)]
@@ -253,6 +271,111 @@ mod tests {
             registry.status(session_id).is_ok(),
             "a new session must have been created"
         );
+    }
+
+    /// `task.run` must resolve `HarnessMode` per §5.9's three-tier
+    /// precedence and report it BOTH in its own immediate response AND on
+    /// the session (queryable via `session.status`/`get_transcript`
+    /// afterward) — #2059.
+    ///
+    /// Why: this is the integration point proving the wiring
+    /// `crate::mode::resolve_mode`'s own unit tests cannot: that
+    /// `task::protocol::task_run` actually reads the `mode` request param,
+    /// the project's `.claude/settings.json`, and `TRUSTY_CODE_MODE`, in
+    /// that precedence, and persists the result via
+    /// `SessionRegistry::set_mode` before spawning the run.
+    /// What: covers default (nothing set), settings.json alone,
+    /// task-param-over-settings.json, and env-var-over-everything.
+    /// Test: this test.
+    #[tokio::test]
+    async fn task_run_resolves_and_reports_mode() {
+        let _mock_guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+        let _mode_guard = crate::mode::MODE_ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation; serialized by both locks above.
+        unsafe {
+            std::env::set_var(
+                super::super::mock_llm::MOCK_LLM_ENV,
+                super::super::mock_llm::MOCK_LLM_ECHO,
+            );
+            std::env::remove_var(crate::mode::MODE_ENV_VAR);
+        }
+        let agents = agents_dir();
+
+        // 1. Nothing set anywhere -> default (daily-driver).
+        let project = tempfile::tempdir().expect("project tempdir");
+        let registry = Arc::new(SessionRegistry::new());
+        let value = task_run(
+            Arc::clone(&registry),
+            json!({"task_description": "say hi"}),
+            project.path().to_path_buf(),
+            agents.path().to_path_buf(),
+        )
+        .await
+        .expect("task.run should succeed");
+        assert_eq!(value["mode"], "daily-driver");
+        let session_id = value["session_id"].as_str().unwrap().to_string();
+        assert_eq!(
+            registry.status(&session_id).unwrap().mode,
+            Some(crate::mode::HarnessMode::DailyDriver)
+        );
+
+        // 2. `.claude/settings.json` alone sets parity.
+        let project2 = tempfile::tempdir().expect("project tempdir");
+        std::fs::create_dir_all(project2.path().join(".claude")).expect("mkdir");
+        std::fs::write(
+            project2.path().join(".claude").join("settings.json"),
+            r#"{"code_harness": {"mode": "parity"}}"#,
+        )
+        .expect("write settings.json");
+        let registry2 = Arc::new(SessionRegistry::new());
+        let value2 = task_run(
+            Arc::clone(&registry2),
+            json!({"task_description": "say hi"}),
+            project2.path().to_path_buf(),
+            agents.path().to_path_buf(),
+        )
+        .await
+        .expect("task.run should succeed");
+        assert_eq!(value2["mode"], "parity");
+
+        // 3. A `mode` request param overrides settings.json (still parity
+        //    from settings.json here, but requesting daily-driver must win).
+        let registry3 = Arc::new(SessionRegistry::new());
+        let value3 = task_run(
+            Arc::clone(&registry3),
+            json!({"task_description": "say hi", "mode": "daily-driver"}),
+            project2.path().to_path_buf(),
+            agents.path().to_path_buf(),
+        )
+        .await
+        .expect("task.run should succeed");
+        assert_eq!(
+            value3["mode"], "daily-driver",
+            "task.run's mode param must override settings.json"
+        );
+
+        // 4. TRUSTY_CODE_MODE overrides EVERYTHING, including a task param.
+        unsafe {
+            std::env::set_var(crate::mode::MODE_ENV_VAR, "parity");
+        }
+        let registry4 = Arc::new(SessionRegistry::new());
+        let value4 = task_run(
+            Arc::clone(&registry4),
+            json!({"task_description": "say hi", "mode": "daily-driver"}),
+            project2.path().to_path_buf(),
+            agents.path().to_path_buf(),
+        )
+        .await
+        .expect("task.run should succeed");
+        assert_eq!(
+            value4["mode"], "parity",
+            "TRUSTY_CODE_MODE must win over a task.run mode param"
+        );
+
+        unsafe {
+            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+            std::env::remove_var(crate::mode::MODE_ENV_VAR);
+        }
     }
 
     /// A `session_id` that does not exist must propagate `session_not_found`.

--- a/crates/trusty-code/tests/cli_e2e.rs
+++ b/crates/trusty-code/tests/cli_e2e.rs
@@ -19,6 +19,9 @@
 //! must print live tool events and a final `status=finished` line, exit 0.
 //! `run_task_json_mode_prints_only_the_final_session` proves `--json`
 //! suppresses the per-event lines and emits one parseable JSON document.
+//! `run_task_mode_precedence_over_the_wire` (#2059) proves the three-tier
+//! `HarnessMode` precedence — env var > `--mode` flag > `.claude/settings.json`
+//! > default — end to end via the REAL CLI binary and its `--json` response.
 //!
 //! `session_list_on_fresh_project_reports_no_sessions`,
 //! `transcript_unknown_session_errors_cleanly`,
@@ -116,6 +119,87 @@ fn run_task_json_mode_prints_only_the_final_session() {
     let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
         .unwrap_or_else(|e| panic!("stdout must be valid JSON: {e}: {stdout}"));
     assert_eq!(parsed["status"], "finished");
+}
+
+/// Run `tcode run-task ... --json`, optionally with `--mode`, a
+/// `.claude/settings.json`, and/or `TRUSTY_CODE_MODE`, returning the
+/// resolved `mode` string from the parsed JSON response.
+fn run_task_resolved_mode(
+    project: &std::path::Path,
+    cli_mode: Option<&str>,
+    env_mode: Option<&str>,
+) -> String {
+    let mut args = vec![
+        "run-task".to_string(),
+        "pm".to_string(),
+        "say hi".to_string(),
+        "--project".to_string(),
+        project.display().to_string(),
+        "--json".to_string(),
+    ];
+    if let Some(m) = cli_mode {
+        args.push("--mode".to_string());
+        args.push(m.to_string());
+    }
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tcode"));
+    cmd.args(&args).env("TCODE_MOCK_LLM", "echo");
+    if let Some(m) = env_mode {
+        cmd.env("TRUSTY_CODE_MODE", m);
+    } else {
+        cmd.env_remove("TRUSTY_CODE_MODE");
+    }
+    let output = cmd.output().expect("spawn tcode run-task");
+    assert!(
+        output.status.success(),
+        "tcode run-task must exit 0: {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be valid JSON: {e}: {stdout}"));
+    parsed["mode"]
+        .as_str()
+        .unwrap_or_else(|| panic!("response must carry a mode string: {parsed}"))
+        .to_string()
+}
+
+/// #2059's three-tier `HarnessMode` precedence, proven over the REAL wire
+/// via the `tcode` CLI (not just `crate::mode::resolve_mode`'s own offline
+/// unit tests, and not just `task::protocol::tests`' direct-handler-call
+/// integration test): `TRUSTY_CODE_MODE` env var > `task.run`'s `mode` param
+/// (here, the CLI's `--mode` flag) > `.claude/settings.json`'s
+/// `code_harness.mode` > default `daily-driver`.
+#[test]
+fn run_task_mode_precedence_over_the_wire() {
+    // 1. Nothing set anywhere -> default.
+    let project = project_with_agents();
+    assert_eq!(
+        run_task_resolved_mode(project.path(), None, None),
+        "daily-driver"
+    );
+
+    // 2. `.claude/settings.json` alone sets parity.
+    std::fs::write(
+        project.path().join(".claude").join("settings.json"),
+        r#"{"code_harness": {"mode": "parity"}}"#,
+    )
+    .expect("write settings.json");
+    assert_eq!(run_task_resolved_mode(project.path(), None, None), "parity");
+
+    // 3. The CLI's `--mode` flag (task.run's `mode` param) overrides
+    //    settings.json.
+    assert_eq!(
+        run_task_resolved_mode(project.path(), Some("daily-driver"), None),
+        "daily-driver"
+    );
+
+    // 4. `TRUSTY_CODE_MODE` overrides EVERYTHING, including `--mode`.
+    assert_eq!(
+        run_task_resolved_mode(project.path(), Some("daily-driver"), Some("parity")),
+        "parity"
+    );
 }
 
 /// `tcode session list` on a project with no prior activity must report no


### PR DESCRIPTION
## Summary
Implements #2059 — HarnessMode{DailyDriver,Parity} with resolution precedence:
1. TRUSTY_CODE_MODE env var (escape hatch per spec §5.9)
2. task.run mode param
3. .claude/settings.json code_harness.mode
4. default daily-driver

Resolved mode is recorded and exposed via task.run response, session.status, and get_transcript. Real prompt/tool-schema branch points wired for future P1B token-efficiency (functionally identical in M1).

## QA Status
Gate verified green:
- 462 lib + 7 cli_e2e + session_e2e + task_e2e tests pass
- clippy/fmt/line-cap clean
- downstream trusty-agents clean
- over-the-wire precedence e2e re-proven (env-highest)
- mode exposure consistent across all 3 surfaces
- stdout clean

Closes #2059
Part of #2052

🤖 Generated with [Claude Code](https://claude.com/claude-code)