### PR TITLE
chore(trusty-mpm): bump 0.16.0 -> 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10970,7 +10970,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- statusline renders context >50% in red ([#2099](https://github.com/bobmatnyc/trusty-tools/pull/2099)) ([`a821b9d`](https://github.com/bobmatnyc/trusty-tools/commit/a821b9da89d7c076dfb4557094f632859b53642e))
+- manage trusty-search index lifecycle for session worktrees ([#2094](https://github.com/bobmatnyc/trusty-tools/pull/2094)) ([`299e993`](https://github.com/bobmatnyc/trusty-tools/commit/299e9931edd2b7faf9236bd5ccc3b6ddb038329d))
+- project config stores preferred gh user; default gh ops to it ([#2087](https://github.com/bobmatnyc/trusty-tools/pull/2087)) ([`d49e385`](https://github.com/bobmatnyc/trusty-tools/commit/d49e385826c0befb0d4cece01a032c71e67e1aa3))
+- name managed-session worktrees by tmux session name, not UUID ([#2076](https://github.com/bobmatnyc/trusty-tools/pull/2076)) ([`39abd2e`](https://github.com/bobmatnyc/trusty-tools/commit/39abd2e02b47e5b4e739ad30de57c33cfdf4dc54))
+
+### Fixed
+
+- guarantee PM delegation persona loads (CLAUDE.md carrier + project-tier output-style + daemon-adapter system-prompt injection) ([#2129](https://github.com/bobmatnyc/trusty-tools/pull/2129)) ([`3a071a0`](https://github.com/bobmatnyc/trusty-tools/commit/3a071a0a2897911279433522d2564cb532f310be))
+- pm_guard exempts native delegated sub-agent edits; retire global UNRESTRICTED bypass ([#2107](https://github.com/bobmatnyc/trusty-tools/pull/2107)) ([`0f413d0`](https://github.com/bobmatnyc/trusty-tools/commit/0f413d0c5d611178dbd5344475ae61ba5fa21213))
+- PM summarizes orchestration in prose instead of raw pm_summary JSON ([#2045](https://github.com/bobmatnyc/trusty-tools/pull/2045)) ([`53731f4`](https://github.com/bobmatnyc/trusty-tools/commit/53731f4849436607cdef55237680a230c798d94f))
+- statusline shows tmux session name instead of worktree UUID branch ([#2035](https://github.com/bobmatnyc/trusty-tools/pull/2035)) ([`bbafad1`](https://github.com/bobmatnyc/trusty-tools/commit/bbafad11063accc2631be4fd97cb610c13152faa))
+- reach trusty-memory over discovered JSON-RPC, never a hardcoded port ([#2040](https://github.com/bobmatnyc/trusty-tools/pull/2040)) ([`e0f41c5`](https://github.com/bobmatnyc/trusty-tools/commit/e0f41c51f1baa7ddf0e427cb5c7e86cbe9bba5fa))
+
+### Documentation
+
+- bundled architecture doc for memory-MCP, session/worktree, search-index ([#2096](https://github.com/bobmatnyc/trusty-tools/pull/2096)) ([`d82e15a`](https://github.com/bobmatnyc/trusty-tools/commit/d82e15ae9367a4c17cdd8fb714e053eb6da9cab7))
+## [Unreleased]
+
+### Added
+
 - in-place relaunch current session + on-exit hint (#2023 C+D) ([#2027](https://github.com/bobmatnyc/trusty-tools/pull/2027)) ([`dba2195`](https://github.com/bobmatnyc/trusty-tools/commit/dba21950daedb48e909ffa2aefd9c12b0d47537a))
 - export TM_MANAGED_SESSION_ID into managed pane shell ([#2025](https://github.com/bobmatnyc/trusty-tools/pull/2025)) ([`879343b`](https://github.com/bobmatnyc/trusty-tools/commit/879343b93c720c69b6c706535de7d2d8e0db8021))
 - non-destructive stop for runtime-exited sessions (#2023 A) ([#2024](https://github.com/bobmatnyc/trusty-tools/pull/2024)) ([`bca3685`](https://github.com/bobmatnyc/trusty-tools/commit/bca3685d665e67bcc0e1ba2f862410521b22c6fd))

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Bumps `crates/trusty-mpm` from `0.16.0` to `0.16.1` (patch) so the installed `tm --version` is legible again — the last batch of functional changes (notably the #2129 PM-delegation-persona-carrier fix) landed without a version bump.
- Generated the unreleased CHANGELOG section via `scripts/bump-version.sh trusty-mpm patch`, which pulls the actual merged PRs touching `crates/trusty-mpm` since the last tag: #2129, #2107, #2094, #2087, #2096, #2099, #2076, #2045, #2040, #2035.
  - Note: #2100, #2113, #2127 (docs / trusty-common CoreML fallback) don't touch `crates/trusty-mpm` and correctly do not appear in this crate's changelog.
- `Cargo.lock` updated to reflect the new `trusty-mpm` version (no other dependency changes).

Checked: no crate in the workspace declares `trusty-mpm = { workspace = true }` as an actual dependency, so nothing else needs a matching bump. (The root `Cargo.toml`'s `[workspace.dependencies]` entry `trusty-mpm = { path = "crates/trusty-mpm", version = "0.15.0" }` is unreferenced by any crate and already stale relative to 0.16.0 — pre-existing, out of scope for this PR.)

## Test plan

- [x] `cargo build -p trusty-mpm` — clean build
- [x] `cargo test -p trusty-mpm` — all suites pass (2366 + 730×2 + others, 0 failed)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

This is a version-only change (plus CHANGELOG), no tag is created and nothing is published — that remains a separate human-gated step.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools