### PR TITLE
feat(trusty-code): cross-provider ToolCallExtractor + validate-repair loop (#1023)

### DIFF
--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -35,7 +35,10 @@ use std::time::Duration;
 
 use serde_json::Value;
 
-use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, ToolCall, ToolDefinition};
+use crate::llm::{
+    ChatRequest, ChatResponse, LlmClientTrait, ToolCall, ToolCallExtractError, ToolCallExtractor,
+    ToolDefinition,
+};
 use crate::mode::HarnessMode;
 use crate::perf::PerfCollector;
 use crate::tools::{AgentOutput, ToolRegistry, ToolResult};
@@ -257,19 +260,34 @@ impl AgentLoop {
     ///
     /// Why: A single assistant turn may request several tools; all must run and
     /// be answered before the next chat call, or the API rejects the follow-up.
-    /// What: For each call, parse its JSON arguments (a parse failure becomes a
-    /// recoverable error string rather than aborting the loop), notify the
-    /// optional (#2056) sink's `tool_started`, dispatch through `dispatch_gated`
-    /// with no per-agent allowlist, notify `tool_finished` (success) or
-    /// `tool_error` (a fatal/non-recoverable `ToolResult::Error`) based on the
-    /// result, and append the result as a `tool` message.
+    /// What: For each call, parse and schema-validate its JSON arguments via
+    /// [`crate::llm::ToolCallExtractor::parse_and_validate`] (#1023) — a parse
+    /// or validation failure is reported through [`Self::report_invalid_arguments`]
+    /// as a recoverable tool result rather than aborting the loop OR (the
+    /// pre-#1023 behaviour) silently dispatching with `{}`. On valid
+    /// arguments, notifies the optional (#2056) sink's `tool_started`,
+    /// dispatches through `dispatch_gated` with no per-agent allowlist,
+    /// notifies `tool_finished` (success) or `tool_error` (a
+    /// fatal/non-recoverable `ToolResult::Error`) based on the result, and
+    /// appends the result as a `tool` message.
     /// Test: `agent_loop::tests::recoverable_tool_error_continues`,
+    /// `agent_loop::tests::malformed_tool_arguments_report_recoverable_error_and_loop_continues`,
     /// `sink_receives_started_then_finished_in_order`,
     /// `sink_receives_tool_error_for_fatal_failures`.
     async fn dispatch_all(&self, tool_calls: &[ToolCall], transcript: &mut Transcript) {
+        let extractor = ToolCallExtractor::new(|name| self.registry.schema_for(name));
+
         for call in tool_calls {
-            let args = parse_args(&call.function.arguments);
             let tool = call.function.name.as_str();
+
+            let args = match extractor.parse_and_validate(tool, &call.function.arguments) {
+                Ok(args) => args,
+                Err(error) => {
+                    self.report_invalid_arguments(&call.id, tool, &error, transcript)
+                        .await;
+                    continue;
+                }
+            };
 
             if let Some(sink) = &self.sink {
                 sink.tool_started(&call.id, tool, &args.to_string()).await;
@@ -283,6 +301,34 @@ impl AgentLoop {
 
             transcript.push_tool_result(&call.id, tool, result.content());
         }
+    }
+
+    /// Report an invalid or malformed tool call as a recoverable tool result.
+    ///
+    /// Why: #1023 replaces the prior silent `{}` degrade with the extractor's
+    /// precise validation failure. Feeding it back through the SAME
+    /// tool-result channel used for a real execution error lets the model
+    /// see exactly what was wrong and self-correct on its next turn — bounded
+    /// by the loop's existing `max_turns`, with no separate network
+    /// round-trip required for this same-turn dispatch path.
+    /// What: Notifies the optional sink (`tool_started` with a placeholder
+    /// arguments string, then `tool_error` with `error`'s `Display` text),
+    /// then appends a `tool` message carrying that same text.
+    /// Test: `agent_loop::tests::malformed_tool_arguments_report_recoverable_error_and_loop_continues`.
+    async fn report_invalid_arguments(
+        &self,
+        call_id: &str,
+        tool: &str,
+        error: &ToolCallExtractError,
+        transcript: &mut Transcript,
+    ) {
+        let message = error.to_string();
+        if let Some(sink) = &self.sink {
+            sink.tool_started(call_id, tool, "<invalid-arguments>")
+                .await;
+            sink.tool_error(call_id, tool, &message).await;
+        }
+        transcript.push_tool_result(call_id, tool, &message);
     }
 
     /// Build a `ChatRequest` from the running transcript and tool schemas.
@@ -388,20 +434,6 @@ async fn notify_result(sink: &dyn ToolEventSink, call_id: &str, tool: &str, resu
         sink.tool_finished(call_id, tool, !result.is_error(), result.content())
             .await;
     }
-}
-
-/// Parse a tool call's JSON argument string into a `Value`.
-///
-/// Why: Models occasionally emit malformed or empty argument strings; the loop
-/// must not panic on them. An unparseable string degrades to an empty object so
-/// the tool can surface its own validation error.
-/// What: Parses `raw`; on error or empty input returns `{}`.
-/// Test: `agent_loop::tests::parse_args_handles_malformed`.
-fn parse_args(raw: &str) -> Value {
-    if raw.trim().is_empty() {
-        return Value::Object(Default::default());
-    }
-    serde_json::from_str(raw).unwrap_or_else(|_| Value::Object(Default::default()))
 }
 
 /// Accrue one response's token usage into the collector as a phase record.

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -215,23 +215,97 @@ fn config_defaults_are_sane() {
     assert!(!cfg.model.is_empty());
 }
 
-/// Malformed / empty tool argument strings degrade to an empty object.
+/// A tool call with syntactically malformed JSON arguments is reported as a
+/// recoverable tool result, and the loop continues to completion.
 ///
-/// Why: Models sometimes emit blank or invalid argument JSON; the loop must not
-/// panic. This guards the private `parse_args` helper via a tool dispatch.
-/// What: Script a tool call whose arguments are intentionally exercised through
-/// the echo tool with a valid arg, then via a second fixture with empty args.
+/// Why: #1023 replaces the pre-#1023 silent `{}` degrade (the old private
+/// `parse_args` helper) with `llm::ToolCallExtractor::parse_and_validate`.
+/// The model must see the real parse failure — not have its malformed call
+/// silently dispatched with empty arguments — and the loop must still
+/// recover exactly like any other recoverable tool error.
+/// What: Script [malformed tool_call, stop]; assert the run completes with
+/// the stop text and made exactly two LLM calls (proving it continued past
+/// the malformed call rather than aborting).
 /// Test: this test.
-#[test]
-fn parse_args_handles_malformed() {
-    // Directly exercise the helper through the public surface by routing an
-    // empty-argument call: the echo tool sees `{}` and returns "<none>".
-    let parsed = super::parse_args("");
-    assert!(parsed.is_object());
-    let parsed_bad = super::parse_args("not json");
-    assert!(parsed_bad.is_object());
-    let parsed_ok = super::parse_args(r#"{"text":"hi"}"#);
-    assert_eq!(parsed_ok["text"], "hi");
+#[tokio::test]
+async fn malformed_tool_arguments_report_recoverable_error_and_loop_continues() {
+    let malformed_call = json!({
+        "id": "gen-tool-malformed",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_bad",
+                    "type": "function",
+                    "function": { "name": "echo", "arguments": "{not valid json" }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10 }
+    });
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        malformed_call,
+        stop_response("Recovered from malformed arguments"),
+    ]));
+    let registry = registry_with_echo(false);
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default());
+
+    let out = agent
+        .run("system", "call echo with bad json")
+        .await
+        .expect("loop should continue past malformed tool arguments");
+
+    assert_eq!(out.content, "Recovered from malformed arguments");
+    assert_eq!(
+        llm.calls(),
+        2,
+        "loop should make two calls despite the malformed call"
+    );
+}
+
+/// An unknown tool name (not registered) is also reported as a recoverable
+/// tool result rather than panicking or dispatching against a missing tool.
+///
+/// Why: `ToolCallExtractor::parse_and_validate` returns `UnknownTool` when the
+/// schema lookup misses; `dispatch_all` must route that through the same
+/// recoverable path as a malformed-JSON failure.
+/// What: Script a tool call naming an unregistered tool, then a stop; assert
+/// the run still completes.
+/// Test: this test.
+#[tokio::test]
+async fn unknown_tool_call_reports_recoverable_error_and_loop_continues() {
+    let unknown_call = json!({
+        "id": "gen-tool-unknown",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_unknown",
+                    "type": "function",
+                    "function": { "name": "does_not_exist", "arguments": "{}" }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10 }
+    });
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        unknown_call,
+        stop_response("Recovered from unknown tool"),
+    ]));
+    let registry = registry_with_echo(false);
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default());
+
+    let out = agent
+        .run("system", "call a nonexistent tool")
+        .await
+        .expect("loop should continue past an unknown tool call");
+
+    assert_eq!(out.content, "Recovered from unknown tool");
+    assert_eq!(llm.calls(), 2);
 }
 
 /// `schema_tool_name` extracts `function.name` and degrades gracefully.

--- a/crates/trusty-code/src/llm/mod.rs
+++ b/crates/trusty-code/src/llm/mod.rs
@@ -19,6 +19,7 @@ mod error;
 mod message;
 mod request;
 mod response;
+mod tool_call_extractor;
 mod usage;
 
 // ── Public API re-exports ─────────────────────────────────────────────────────
@@ -29,4 +30,8 @@ pub use error::LlmError;
 pub use message::ChatMessage;
 pub use request::{ChatRequest, FunctionCall, FunctionDefinition, ToolCall, ToolDefinition};
 pub use response::{AssistantMessage, ChatChoice, ChatResponse};
+pub use tool_call_extractor::{
+    DEFAULT_MAX_REPAIR_ATTEMPTS, ExtractedToolCall, ExtractionStrategy, SchemaViolation,
+    ToolCallExtractError, ToolCallExtractor, extract_with_repair, strategy_order_for,
+};
 pub use usage::UsageBlock;

--- a/crates/trusty-code/src/llm/tool_call_extractor/error.rs
+++ b/crates/trusty-code/src/llm/tool_call_extractor/error.rs
@@ -1,0 +1,171 @@
+//! Error type for [`super::ToolCallExtractor`] (#1023).
+//!
+//! Why: Extraction and validation can fail in several distinct, actionable
+//! ways (nothing found, malformed JSON, schema mismatch, unknown tool) plus
+//! one terminal way (the bounded repair loop in `super::repair` ran out of
+//! attempts). Callers — the agent loop's dispatch path today, and any future
+//! caller — need to branch on which happened without string-matching, and the
+//! repair loop needs a structured value to build its corrective message from.
+//! What: Defines `ToolCallExtractError` deriving `thiserror::Error`. No
+//! variant panics or unwraps on construction; this is purely a data carrier.
+//! Test: `error::tests::*` — display strings for each variant.
+
+use thiserror::Error;
+
+use super::ExtractionStrategy;
+use super::schema::SchemaViolation;
+use crate::llm::LlmError;
+
+/// Failure modes of tool-call extraction and validation.
+///
+/// Why: Distinguishes "no candidate call found at all" from "found a call but
+/// its arguments are broken" from "found valid JSON but it fails the tool's
+/// schema" — each warrants a different corrective message from
+/// `repair::build_corrective_message`. `Unrepairable` is the terminal variant
+/// the bounded repair loop returns once `max_attempts` is exhausted.
+/// Test: Constructed and matched throughout `mod.rs`, `repair.rs` tests.
+#[derive(Debug, Error)]
+pub enum ToolCallExtractError {
+    /// No strategy in the configured order recovered a tool call.
+    ///
+    /// Why: The model may have answered in plain prose with no embedded call
+    /// at all, or used a convention none of the four strategies recognise.
+    /// What: Carries the strategies that were attempted, in order, for
+    /// diagnostics and for the corrective message.
+    #[error("no tool call found in response (tried strategies: {tried:?})")]
+    NoCallFound {
+        /// Strategies attempted, in the order they were tried.
+        tried: Vec<ExtractionStrategy>,
+    },
+
+    /// A candidate call's argument text failed to parse as JSON.
+    ///
+    /// Why: The native wire format carries `arguments` as a JSON-encoded
+    /// string (see `llm::FunctionCall::arguments`); a model can emit
+    /// syntactically broken JSON there even when the surrounding envelope is
+    /// well-formed.
+    /// What: Carries the tool `name` (best-effort — the name itself parses
+    /// independently of the arguments) and the underlying `serde_json` error.
+    #[error("tool call '{name}' arguments are not valid JSON: {source}")]
+    MalformedArguments {
+        /// The tool name the (unparseable) arguments were destined for.
+        name: String,
+        /// The underlying JSON parse error.
+        source: serde_json::Error,
+    },
+
+    /// The extracted call names a tool with no registered schema.
+    ///
+    /// Why: Validation needs a schema to check against; a hallucinated tool
+    /// name has none. This is distinct from `SchemaInvalid` because there is
+    /// nothing to validate the arguments AGAINST, not merely a mismatch.
+    /// What: Carries the unrecognised tool name.
+    #[error("no schema registered for tool '{name}'")]
+    UnknownTool {
+        /// The hallucinated or misspelled tool name.
+        name: String,
+    },
+
+    /// The extracted call's arguments failed schema validation.
+    ///
+    /// Why: The most common repairable failure — the model called a real
+    /// tool but got the argument shape wrong (missing required field, wrong
+    /// type, disallowed extra key).
+    /// What: Carries the tool `name` and every [`SchemaViolation`] found (not
+    /// just the first) so a single corrective message can address them all.
+    #[error("tool call '{name}' failed schema validation: {violations:?}")]
+    SchemaInvalid {
+        /// The tool the arguments were destined for.
+        name: String,
+        /// All violations found; see `schema::validate_args`.
+        violations: Vec<SchemaViolation>,
+    },
+
+    /// The retry callback's chat call failed (transport/API error).
+    ///
+    /// Why: `repair::extract_with_repair`'s retry closure typically wraps a
+    /// real `LlmClientTrait::chat` call; that call can fail independently of
+    /// extraction. Wrapping it here lets the repair loop propagate it with
+    /// `?` instead of requiring every caller to define its own error type.
+    /// What: Wraps the underlying `LlmError`.
+    #[error("retry chat call failed: {0}")]
+    Retry(#[from] LlmError),
+
+    /// The bounded repair loop exhausted its attempts without success.
+    ///
+    /// Why: The terminal, structured (never-panicking) error the repair loop
+    /// returns once `max_attempts` corrective round-trips have all failed —
+    /// this is the "Unrepairable → structured error" acceptance criterion.
+    /// What: Carries how many attempts were made and the last failure seen.
+    #[error("unrepairable after {attempts} attempt(s): {last_error}")]
+    Unrepairable {
+        /// Number of repair attempts made (corrective round-trips), not
+        /// counting the initial extraction attempt.
+        attempts: u32,
+        /// The failure from the final attempt.
+        last_error: Box<ToolCallExtractError>,
+    },
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `NoCallFound` lists the attempted strategies in its display string.
+    ///
+    /// Why: Diagnostics/logs should show what was tried without needing to
+    /// inspect the struct fields.
+    /// What: Construct with two strategies, assert both appear.
+    /// Test: this test.
+    #[test]
+    fn no_call_found_display_lists_strategies() {
+        let err = ToolCallExtractError::NoCallFound {
+            tried: vec![
+                ExtractionStrategy::FencedJson,
+                ExtractionStrategy::AngleBracket,
+            ],
+        };
+        let s = err.to_string();
+        assert!(s.contains("FencedJson"));
+        assert!(s.contains("AngleBracket"));
+    }
+
+    /// `SchemaInvalid` display includes the tool name.
+    ///
+    /// Why: Operators scanning logs need the tool name without expanding the
+    /// full violation list.
+    /// What: Construct with a name and one violation; assert name appears.
+    /// Test: this test.
+    #[test]
+    fn schema_invalid_display_includes_name() {
+        let err = ToolCallExtractError::SchemaInvalid {
+            name: "bash".into(),
+            violations: vec![SchemaViolation {
+                path: "$.command".into(),
+                message: "missing required property 'command'".into(),
+            }],
+        };
+        assert!(err.to_string().contains("bash"));
+    }
+
+    /// `Unrepairable` display includes the attempt count and nests the source.
+    ///
+    /// Why: This is the terminal error surfaced to callers; both pieces of
+    /// information must be visible without downcasting.
+    /// What: Wrap an `UnknownTool` inside `Unrepairable`; assert both appear.
+    /// Test: this test.
+    #[test]
+    fn unrepairable_display_includes_attempts_and_source() {
+        let err = ToolCallExtractError::Unrepairable {
+            attempts: 2,
+            last_error: Box::new(ToolCallExtractError::UnknownTool {
+                name: "frobnicate".into(),
+            }),
+        };
+        let s = err.to_string();
+        assert!(s.contains('2'));
+        assert!(s.contains("frobnicate"));
+    }
+}

--- a/crates/trusty-code/src/llm/tool_call_extractor/mod.rs
+++ b/crates/trusty-code/src/llm/tool_call_extractor/mod.rs
@@ -1,0 +1,575 @@
+//! Cross-provider tool-call extraction, validation, and bounded repair (#1023).
+//!
+//! Why: `ChatResponse::first_tool_calls` (see `llm::response`) only recovers a
+//! tool call when the provider populated the native
+//! `choices[0].message.tool_calls` wire field. Several model families routed
+//! through OpenRouter (Qwen, DeepSeek, Gemma, and any future non-native
+//! family — see `provider::traits::Provider::supports_native_tools`) instead
+//! emit their intended call as text inside `content`, using one of a few
+//! conventions. Before #1023 there was no fallback: `agent_loop::parse_args`
+//! silently degraded any unparseable native `arguments` string to `{}`,
+//! discarding the model's intent and dispatching the tool with no arguments
+//! at all. This module recovers the call across all four representations,
+//! validates its arguments against the tool's real schema (the same
+//! validation for every provider — `schema::validate_args`), and drives a
+//! bounded corrective-retry loop (`repair::extract_with_repair`) when the
+//! first attempt fails.
+//! What: Re-exports [`ExtractedToolCall`], [`ExtractionStrategy`],
+//! [`ToolCallExtractError`], [`ToolCallExtractor`], and the `repair` module's
+//! [`repair::extract_with_repair`] / [`repair::DEFAULT_MAX_REPAIR_ATTEMPTS`].
+//! [`ToolCallExtractor::extract`] is the single-attempt entry point: try
+//! native first, then the fallback strategies in [`strategy_order_for`]'s
+//! per-model order, then validate whatever was found against the schema
+//! looked up for that tool's name.
+//!
+//! ## Per-model strategy matrix
+//!
+//! | Model family (slug substring) | Native tools? | Fallback order (when native absent) |
+//! |---|---|---|
+//! | `claude-`, `gpt-`, `gemini-` (native families, see `provider::openrouter`) | yes | n/a — native `tool_calls` is authoritative |
+//! | `qwen`, `deepseek` | no | `<tool_call>` tag → fenced ```json → tolerant scan |
+//! | `gemma`, everything else | no | fenced ```json → `<tool_call>` tag → tolerant scan |
+//!
+//! Rationale: Qwen's and DeepSeek's published chat templates natively teach
+//! the `<tool_call>{...}</tool_call>` convention, so it is tried first for
+//! those slugs. Gemma has no standard function-calling convention; a fenced
+//! JSON block is the most common prompt-guided pattern across
+//! OpenRouter-hosted community fine-tunes, so it leads for the catch-all
+//! branch. The tolerant balanced-JSON scan is always last — it is the most
+//! expensive and least precise, only used when both structured conventions
+//! fail.
+//! Test: `tool_call_extractor::tests::*`, `strategies::tests::*`,
+//! `schema::tests::*`, `repair::tests::*`.
+
+mod error;
+mod repair;
+mod schema;
+mod strategies;
+
+pub use error::ToolCallExtractError;
+pub use repair::{DEFAULT_MAX_REPAIR_ATTEMPTS, extract_with_repair};
+pub use schema::SchemaViolation;
+
+use serde_json::Value;
+
+use crate::llm::ChatResponse;
+
+/// Synthetic call ID assigned to a tool call recovered via a text fallback
+/// strategy, since none of those conventions carry a wire-level call ID.
+const FALLBACK_CALL_ID: &str = "fallback-call-0";
+
+/// Schema-lookup callback type: tool name -> its raw OpenAI-function schema.
+///
+/// Why: `clippy::type_complexity` flags the inline `Box<dyn Fn(...) -> ...>`
+/// form; naming it here also documents the expected shape at the point
+/// `ToolCallExtractor` is defined.
+/// What: See [`ToolCallExtractor::new`] for the expected schema shape.
+type SchemaLookup<'a> = Box<dyn Fn(&str) -> Option<Value> + Send + Sync + 'a>;
+
+/// Which extraction convention recovered a tool call.
+///
+/// Why: Callers (repair-message building, logging, the per-model ordering
+/// table) need to know which strategy succeeded or was attempted.
+/// What: `Native` is the OpenAI-wire `tool_calls` field; the other three are
+/// the text-based fallbacks in `strategies`.
+/// Test: `tests::extract_native_success`, `tests::extract_fenced_json_success`,
+/// `tests::extract_angle_bracket_success`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtractionStrategy {
+    /// Recovered from `choices[0].message.tool_calls`.
+    Native,
+    /// Recovered from a ```` ```json ``` ```` fenced code block.
+    FencedJson,
+    /// Recovered from an `<tool_call>{...}</tool_call>` tag.
+    AngleBracket,
+    /// Recovered via the tolerant balanced-`{}`-scan last resort.
+    BalancedJsonScan,
+}
+
+/// A tool call recovered by [`ToolCallExtractor::extract`], normalised across
+/// every extraction strategy and already schema-validated.
+///
+/// Why: Downstream dispatch (`tools::ToolRegistry::dispatch_gated`) wants a
+/// single shape regardless of which strategy produced the call.
+/// What: `id` is the wire call ID for `Native`, or [`FALLBACK_CALL_ID`] for
+/// any text-based strategy (documented there — those conventions carry no
+/// ID). `arguments` is already a parsed, schema-valid `Value`.
+/// Test: `tests::extract_native_success` and friends assert every field.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExtractedToolCall {
+    /// Call ID to echo back in the subsequent `tool` result message.
+    pub id: String,
+    /// The tool's registered name.
+    pub name: String,
+    /// Parsed, schema-validated argument object.
+    pub arguments: Value,
+    /// Which strategy recovered this call.
+    pub strategy: ExtractionStrategy,
+}
+
+/// Per-model fallback strategy order, tried when no native tool call is present.
+///
+/// Why: Centralising the per-family order here (rather than scattering
+/// `if slug.contains(...)` checks through `extract`) keeps the matrix
+/// documented in exactly one place — see the module-level table above.
+/// What: Returns the three text-based strategies in priority order for
+/// `model_slug`. Matching is case-insensitive and substring-based, mirroring
+/// `provider::openrouter::slug_supports_native_tools`.
+/// Test: `tests::strategy_order_prefers_angle_bracket_for_qwen_and_deepseek`,
+/// `tests::strategy_order_prefers_fenced_json_for_others`.
+pub fn strategy_order_for(model_slug: &str) -> [ExtractionStrategy; 3] {
+    let lower = model_slug.to_ascii_lowercase();
+    if lower.contains("qwen") || lower.contains("deepseek") {
+        [
+            ExtractionStrategy::AngleBracket,
+            ExtractionStrategy::FencedJson,
+            ExtractionStrategy::BalancedJsonScan,
+        ]
+    } else {
+        [
+            ExtractionStrategy::FencedJson,
+            ExtractionStrategy::AngleBracket,
+            ExtractionStrategy::BalancedJsonScan,
+        ]
+    }
+}
+
+/// Recovers and validates tool calls across every supported provider convention.
+///
+/// Why: Bundles the schema-lookup callback so a single instance can be reused
+/// across every attempt of a [`repair::extract_with_repair`] loop without
+/// re-threading the tool registry through each call.
+/// What: Holds a boxed closure from tool name to that tool's raw
+/// OpenAI-function schema `Value` (see `tools::traits::ToolExecutor::schema`;
+/// callers typically pass a closure over `ToolRegistry::schemas()` results
+/// keyed by name). [`Self::extract`] is the single-attempt entry point.
+/// Test: `tests::*`.
+pub struct ToolCallExtractor<'a> {
+    schema_lookup: SchemaLookup<'a>,
+}
+
+impl<'a> ToolCallExtractor<'a> {
+    /// Build an extractor bound to a schema-lookup callback.
+    ///
+    /// Why: Decouples this module from `tools::ToolRegistry` directly, so it
+    /// can be unit-tested with a plain closure/`HashMap` lookup.
+    /// What: Stores `schema_lookup`; each tool's schema is expected to be the
+    /// full `{"type":"function","function":{"name","parameters",...}}`
+    /// envelope — [`Self::extract`] reads `.function.parameters` out of it.
+    /// Test: `tests::*` all construct via this constructor.
+    pub fn new(schema_lookup: impl Fn(&str) -> Option<Value> + Send + Sync + 'a) -> Self {
+        Self {
+            schema_lookup: Box::new(schema_lookup),
+        }
+    }
+
+    /// Attempt one extraction across native + fallback strategies, then validate.
+    ///
+    /// Why: This is the "single attempt" the bounded repair loop iterates:
+    /// try native first (authoritative when present), else each fallback
+    /// strategy for `model_slug` in order, then validate whatever candidate
+    /// was found against its tool's schema.
+    /// What: If `response.first_tool_calls()` is non-empty, parses and
+    /// validates each as [`ExtractionStrategy::Native`], returning the first
+    /// failure encountered (or all calls on full success). Otherwise scans
+    /// `response.first_text()` via [`strategy_order_for`]'s fallback order,
+    /// stopping at the first strategy that recovers a candidate — even if
+    /// that candidate then fails validation, later strategies are NOT tried
+    /// (the model committed to a shape; the repair loop, not a different
+    /// parse strategy, is the correct next step).
+    /// Test: `tests::extract_native_success`, `tests::extract_fenced_json_success`,
+    /// `tests::extract_angle_bracket_success`, `tests::extract_no_call_found`,
+    /// `tests::extract_native_malformed_arguments`,
+    /// `tests::extract_schema_invalid_arguments`, `tests::extract_unknown_tool`.
+    pub fn extract(
+        &self,
+        response: &ChatResponse,
+        model_slug: &str,
+    ) -> Result<Vec<ExtractedToolCall>, ToolCallExtractError> {
+        let native = response.first_tool_calls();
+        if !native.is_empty() {
+            let mut out = Vec::with_capacity(native.len());
+            for call in native {
+                let args =
+                    self.parse_and_validate(&call.function.name, &call.function.arguments)?;
+                out.push(ExtractedToolCall {
+                    id: call.id.clone(),
+                    name: call.function.name.clone(),
+                    arguments: args,
+                    strategy: ExtractionStrategy::Native,
+                });
+            }
+            return Ok(out);
+        }
+
+        let text = response.first_text().unwrap_or_default();
+        let order = strategy_order_for(model_slug);
+        for strategy in order {
+            let candidate = match strategy {
+                ExtractionStrategy::FencedJson => strategies::extract_fenced_json(&text),
+                ExtractionStrategy::AngleBracket => strategies::extract_angle_bracket(&text),
+                ExtractionStrategy::BalancedJsonScan => {
+                    strategies::extract_balanced_json_scan(&text)
+                }
+                ExtractionStrategy::Native => {
+                    unreachable!("strategy_order_for never returns Native")
+                }
+            };
+            if let Some((name, args)) = candidate {
+                let validated = self.validate(&name, args, strategy)?;
+                return Ok(vec![ExtractedToolCall {
+                    id: FALLBACK_CALL_ID.to_string(),
+                    ..validated
+                }]);
+            }
+        }
+
+        Err(ToolCallExtractError::NoCallFound {
+            tried: order.to_vec(),
+        })
+    }
+
+    /// Parse a raw JSON arguments string and validate it against `name`'s schema.
+    ///
+    /// Why: This is the exact per-call operation `Self::extract`'s native
+    /// branch needs, factored out so a caller that already has a single known
+    /// `(name, raw_arguments)` pair — notably `agent_loop::dispatch_all`,
+    /// which dispatches native `ToolCall`s one at a time — can validate
+    /// without constructing a `ChatResponse`. This is the #1023 replacement
+    /// for the pre-#1023 `agent_loop::parse_args`, which silently degraded
+    /// any unparseable `arguments` string to `{}`; a genuine JSON syntax
+    /// error now surfaces as a structured, actionable
+    /// [`ToolCallExtractError::MalformedArguments`] instead.
+    /// What: An empty or all-whitespace `raw_arguments` is treated as `{}`
+    /// (many providers send an empty string for a zero-argument call — this
+    /// preserves that legacy leniency) and still runs through schema
+    /// validation, so a tool with required arguments correctly reports
+    /// `SchemaInvalid` rather than silently succeeding. A non-empty string
+    /// that fails to parse reports `MalformedArguments`. Returns the
+    /// validated `arguments` value on success.
+    /// Test: `tests::parse_and_validate_success`,
+    /// `tests::parse_and_validate_empty_string_becomes_empty_object`,
+    /// `tests::parse_and_validate_malformed_json`.
+    pub fn parse_and_validate(
+        &self,
+        name: &str,
+        raw_arguments: &str,
+    ) -> Result<Value, ToolCallExtractError> {
+        let trimmed = raw_arguments.trim();
+        let args: Value = if trimmed.is_empty() {
+            Value::Object(Default::default())
+        } else {
+            serde_json::from_str(trimmed).map_err(|source| {
+                ToolCallExtractError::MalformedArguments {
+                    name: name.to_string(),
+                    source,
+                }
+            })?
+        };
+        self.validate(name, args, ExtractionStrategy::Native)
+            .map(|c| c.arguments)
+    }
+
+    /// Validate one candidate `(name, args)` pair against its tool's schema.
+    ///
+    /// Why: Shared by both the native and fallback branches of [`Self::extract`]
+    /// so every strategy funnels through the exact same validation (#1023:
+    /// "all providers share same validation plumbing").
+    /// What: Looks up `name` via `schema_lookup`; `None` → `UnknownTool`.
+    /// Reads `schema["function"]["parameters"]` (defaulting to an empty
+    /// object schema `{}` when absent, which validates everything) and runs
+    /// `schema::validate_args`. Returns a placeholder-ID `ExtractedToolCall`
+    /// on success — callers overwrite `id` with the real value.
+    /// Test: `tests::extract_unknown_tool`, `tests::extract_schema_invalid_arguments`.
+    fn validate(
+        &self,
+        name: &str,
+        args: Value,
+        strategy: ExtractionStrategy,
+    ) -> Result<ExtractedToolCall, ToolCallExtractError> {
+        let schema =
+            (self.schema_lookup)(name).ok_or_else(|| ToolCallExtractError::UnknownTool {
+                name: name.to_string(),
+            })?;
+        let parameters = schema
+            .get("function")
+            .and_then(|f| f.get("parameters"))
+            .cloned()
+            .unwrap_or_else(|| Value::Object(Default::default()));
+
+        schema::validate_args(&parameters, &args).map_err(|violations| {
+            ToolCallExtractError::SchemaInvalid {
+                name: name.to_string(),
+                violations,
+            }
+        })?;
+
+        Ok(ExtractedToolCall {
+            id: String::new(),
+            name: name.to_string(),
+            arguments: args,
+            strategy,
+        })
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn bash_schema_entry() -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "parameters": {
+                    "type": "object",
+                    "properties": { "command": { "type": "string" } },
+                    "required": ["command"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    fn extractor_with_bash() -> ToolCallExtractor<'static> {
+        ToolCallExtractor::new(|name| match name {
+            "bash" => Some(bash_schema_entry()),
+            _ => None,
+        })
+    }
+
+    fn response_with_native_call(name: &str, arguments: &str) -> ChatResponse {
+        let fixture = format!(
+            r#"{{
+              "id": "gen-1",
+              "choices": [{{
+                "message": {{
+                  "role": "assistant",
+                  "content": null,
+                  "tool_calls": [{{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {{"name": "{name}", "arguments": {arguments:?}}}
+                  }}]
+                }},
+                "finish_reason": "tool_calls"
+              }}],
+              "usage": {{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}}
+            }}"#
+        );
+        serde_json::from_str(&fixture).expect("fixture deserialises")
+    }
+
+    fn response_with_text(text: &str) -> ChatResponse {
+        let fixture = json!({
+            "id": "gen-2",
+            "choices": [{
+                "message": { "role": "assistant", "content": text, "tool_calls": [] },
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        });
+        serde_json::from_str(&fixture.to_string()).expect("fixture deserialises")
+    }
+
+    /// Native `tool_calls` with valid arguments extracts and validates cleanly.
+    ///
+    /// Why: The primary, cheapest path — most requests never need a fallback.
+    /// What: A response with a valid native call; assert strategy + fields.
+    /// Test: this test.
+    #[test]
+    fn extract_native_success() {
+        let resp = response_with_native_call("bash", r#"{"command": "ls"}"#);
+        let extractor = extractor_with_bash();
+        let calls = extractor
+            .extract(&resp, "anthropic/claude-sonnet-4-5")
+            .expect("extract");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_1");
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].arguments, json!({"command": "ls"}));
+        assert_eq!(calls[0].strategy, ExtractionStrategy::Native);
+    }
+
+    /// A fenced ```json block is recovered when no native call is present.
+    ///
+    /// Why: Required acceptance-criterion scenario for #1023.
+    /// What: A text-only response containing a fenced tool call.
+    /// Test: this test.
+    #[test]
+    fn extract_fenced_json_success() {
+        let text = "```json\n{\"name\": \"bash\", \"arguments\": {\"command\": \"pwd\"}}\n```";
+        let resp = response_with_text(text);
+        let extractor = extractor_with_bash();
+        let calls = extractor
+            .extract(&resp, "google/gemma-2-27b-it")
+            .expect("extract");
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].strategy, ExtractionStrategy::FencedJson);
+        assert_eq!(calls[0].id, FALLBACK_CALL_ID);
+    }
+
+    /// An `<tool_call>` tag is recovered when no native call is present.
+    ///
+    /// Why: Required acceptance-criterion scenario for #1023.
+    /// What: A text-only response using the tag convention, for a Qwen slug
+    /// (which prioritises this strategy per `strategy_order_for`).
+    /// Test: this test.
+    #[test]
+    fn extract_angle_bracket_success() {
+        let text = "<tool_call>{\"name\": \"bash\", \"arguments\": {\"command\": \"echo hi\"}}</tool_call>";
+        let resp = response_with_text(text);
+        let extractor = extractor_with_bash();
+        let calls = extractor
+            .extract(&resp, "qwen/qwen-2.5-coder-32b-instruct")
+            .expect("extract");
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].strategy, ExtractionStrategy::AngleBracket);
+    }
+
+    /// `parse_and_validate` succeeds for well-formed, schema-valid arguments.
+    ///
+    /// Why: Guards the direct per-call entry point used by
+    /// `agent_loop::dispatch_all` (the pre-#1023 `parse_args` replacement).
+    /// What: Valid JSON for `bash`; assert the parsed value.
+    /// Test: this test.
+    #[test]
+    fn parse_and_validate_success() {
+        let extractor = extractor_with_bash();
+        let args = extractor
+            .parse_and_validate("bash", r#"{"command": "ls"}"#)
+            .expect("valid");
+        assert_eq!(args, json!({"command": "ls"}));
+    }
+
+    /// An empty (or whitespace-only) arguments string is treated as `{}`.
+    ///
+    /// Why: Some providers send an empty string for a zero-argument call;
+    /// preserving this leniency avoids regressing existing behaviour. It
+    /// must still be validated — a required-field violation surfaces rather
+    /// than silently succeeding.
+    /// What: Empty string against `bash` (which requires `command`) reports
+    /// `SchemaInvalid`, not a parse error.
+    /// Test: this test.
+    #[test]
+    fn parse_and_validate_empty_string_becomes_empty_object() {
+        let extractor = extractor_with_bash();
+        let err = extractor
+            .parse_and_validate("bash", "")
+            .expect_err("missing required field");
+        assert!(matches!(err, ToolCallExtractError::SchemaInvalid { .. }));
+    }
+
+    /// A genuinely malformed (non-empty) arguments string reports `MalformedArguments`.
+    ///
+    /// Why: This is the exact #1023 regression target — previously silently
+    /// degraded to `{}` and dispatched anyway.
+    /// What: `"not json"` against `bash`.
+    /// Test: this test.
+    #[test]
+    fn parse_and_validate_malformed_json() {
+        let extractor = extractor_with_bash();
+        let err = extractor
+            .parse_and_validate("bash", "not json")
+            .expect_err("malformed");
+        assert!(
+            matches!(err, ToolCallExtractError::MalformedArguments { name, .. } if name == "bash")
+        );
+    }
+
+    /// No recognisable call anywhere yields a structured `NoCallFound`, not a panic.
+    ///
+    /// Why: The model may just answer in prose; extraction must fail cleanly.
+    /// What: Plain prose text, no native calls.
+    /// Test: this test.
+    #[test]
+    fn extract_no_call_found() {
+        let resp = response_with_text("Sure, here's the answer: 42.");
+        let extractor = extractor_with_bash();
+        let err = extractor
+            .extract(&resp, "google/gemma-2-27b-it")
+            .expect_err("should fail");
+        assert!(matches!(err, ToolCallExtractError::NoCallFound { .. }));
+    }
+
+    /// A native call with unparseable JSON arguments reports `MalformedArguments`.
+    ///
+    /// Why: This is the exact case `agent_loop::parse_args` used to silently
+    /// degrade to `{}`; #1023 requires it surface as a structured error instead.
+    /// What: Native call whose `arguments` string is invalid JSON.
+    /// Test: this test.
+    #[test]
+    fn extract_native_malformed_arguments() {
+        let resp = response_with_native_call("bash", "{not valid json");
+        let extractor = extractor_with_bash();
+        let err = extractor
+            .extract(&resp, "anthropic/claude-sonnet-4-5")
+            .expect_err("should fail");
+        assert!(
+            matches!(err, ToolCallExtractError::MalformedArguments { name, .. } if name == "bash")
+        );
+    }
+
+    /// A native call to an unregistered tool name reports `UnknownTool`.
+    ///
+    /// Why: A hallucinated tool name has no schema to validate against.
+    /// What: Call a tool absent from the extractor's schema lookup.
+    /// Test: this test.
+    #[test]
+    fn extract_unknown_tool() {
+        let resp = response_with_native_call("frobnicate", "{}");
+        let extractor = extractor_with_bash();
+        let err = extractor
+            .extract(&resp, "anthropic/claude-sonnet-4-5")
+            .expect_err("should fail");
+        assert!(matches!(err, ToolCallExtractError::UnknownTool { name } if name == "frobnicate"));
+    }
+
+    /// A native call with valid JSON but schema-invalid arguments reports `SchemaInvalid`.
+    ///
+    /// Why: Valid JSON that doesn't satisfy the tool's schema (missing
+    /// required field) is a distinct, repairable failure mode.
+    /// What: Call `bash` with no `command` field.
+    /// Test: this test.
+    #[test]
+    fn extract_schema_invalid_arguments() {
+        let resp = response_with_native_call("bash", "{}");
+        let extractor = extractor_with_bash();
+        let err = extractor
+            .extract(&resp, "anthropic/claude-sonnet-4-5")
+            .expect_err("should fail");
+        assert!(matches!(err, ToolCallExtractError::SchemaInvalid { name, .. } if name == "bash"));
+    }
+
+    /// Qwen and DeepSeek slugs prioritise the angle-bracket strategy.
+    ///
+    /// Why: Guards the documented per-model matrix stays correct as the table
+    /// evolves.
+    /// What: Assert the first element of the order for representative slugs.
+    /// Test: this test.
+    #[test]
+    fn strategy_order_prefers_angle_bracket_for_qwen_and_deepseek() {
+        for slug in ["qwen/qwen-2.5-coder-32b-instruct", "deepseek/deepseek-chat"] {
+            assert_eq!(
+                strategy_order_for(slug)[0],
+                ExtractionStrategy::AngleBracket
+            );
+        }
+    }
+
+    /// Gemma and any other non-native family prioritise fenced-JSON.
+    ///
+    /// Why: Guards the catch-all branch of the matrix.
+    /// What: Assert the first element for Gemma and an arbitrary other slug.
+    /// Test: this test.
+    #[test]
+    fn strategy_order_prefers_fenced_json_for_others() {
+        for slug in ["google/gemma-2-27b-it", "mistralai/mixtral-8x7b"] {
+            assert_eq!(strategy_order_for(slug)[0], ExtractionStrategy::FencedJson);
+        }
+    }
+}

--- a/crates/trusty-code/src/llm/tool_call_extractor/repair.rs
+++ b/crates/trusty-code/src/llm/tool_call_extractor/repair.rs
@@ -1,0 +1,370 @@
+//! Bounded corrective-retry loop for tool-call extraction (#1023).
+//!
+//! Why: A single extraction attempt (`ToolCallExtractor::extract`) can fail
+//! for reasons a model can often fix if told exactly what was wrong — broken
+//! JSON, a missing required field, an unknown tool name. Silently giving up
+//! (or worse, silently substituting `{}` as `agent_loop::parse_args` did
+//! pre-#1023) discards a recoverable turn. This loop re-attempts extraction
+//! after sending the model a precise corrective message, bounded by
+//! `max_attempts` so a persistently broken model cannot loop forever.
+//! What: [`extract_with_repair`] drives the loop; [`build_corrective_message`]
+//! renders a [`ToolCallExtractError`] into the text sent back to the model.
+//! The loop is generic over how a "retry" is performed (`retry: F`) — callers
+//! typically close over an `Arc<dyn LlmClientTrait>` and the running
+//! transcript, but tests can supply a canned sequence of responses with no
+//! network dependency at all.
+//! Test: `repair::tests::*` — covers "malformed → one repair → success" and
+//! "unrepairable → structured error (no panic)", the two repair-loop
+//! acceptance-criterion scenarios from #1023.
+
+use std::future::Future;
+
+use super::error::ToolCallExtractError;
+use super::{ExtractedToolCall, ToolCallExtractor};
+use crate::llm::ChatResponse;
+
+/// Default cap on corrective round-trips before giving up.
+///
+/// Why: A concrete default lets call sites opt in to the bounded loop without
+/// having to pick a number themselves; 2 retries (3 total attempts) matches
+/// this crate's general "bounded but generous" philosophy (compare
+/// `AgentLoopConfig::default`'s turn cap) while keeping a persistently broken
+/// model from burning the whole run's turn budget on one tool call.
+/// Test: `repair::tests::default_is_two`.
+pub const DEFAULT_MAX_REPAIR_ATTEMPTS: u32 = 2;
+
+/// Render one extraction failure into a corrective message for the model.
+///
+/// Why: A repair round-trip only helps if the model is told EXACTLY what was
+/// wrong and how to fix it; a generic "that didn't work" message wastes the
+/// retry.
+/// What: Matches every non-terminal [`ToolCallExtractError`] variant and
+/// produces an actionable instruction naming the tool and the precise
+/// violation(s). `Unrepairable` has no sensible corrective text (it is the
+/// loop's own terminal output, never fed back in) — it renders a generic
+/// fallback that should never actually be reached in practice.
+/// Test: `repair::tests::corrective_message_names_missing_field`,
+/// `repair::tests::corrective_message_for_malformed_json`.
+pub fn build_corrective_message(error: &ToolCallExtractError) -> String {
+    match error {
+        ToolCallExtractError::NoCallFound { tried } => format!(
+            "Your previous response did not contain a recognisable tool call. \
+             Please emit exactly one tool call using either the native function-call \
+             mechanism, a ```json fenced block shaped like {{\"name\": \"<tool>\", \"arguments\": {{...}}}}, \
+             or a <tool_call>{{...}}</tool_call> tag. (Already checked and found nothing: {tried:?}.)"
+        ),
+        ToolCallExtractError::MalformedArguments { name, source } => format!(
+            "Your call to '{name}' had arguments that are not valid JSON ({source}). \
+             Please re-emit the call to '{name}' with syntactically valid JSON arguments."
+        ),
+        ToolCallExtractError::UnknownTool { name } => format!(
+            "'{name}' is not a recognised tool in this conversation. \
+             Please re-emit your call using one of the tools already provided to you."
+        ),
+        ToolCallExtractError::SchemaInvalid { name, violations } => {
+            let details = violations
+                .iter()
+                .map(|v| format!("- {v}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!(
+                "Your call to '{name}' had invalid arguments:\n{details}\n\
+                 Please re-emit the call to '{name}' with corrected arguments that satisfy every point above."
+            )
+        }
+        ToolCallExtractError::Retry(source) => format!(
+            "A transient error occurred while requesting a repair ({source}). Please try again."
+        ),
+        ToolCallExtractError::Unrepairable { .. } => {
+            "the previous tool call could not be repaired".to_string()
+        }
+    }
+}
+
+/// Drive the bounded extract → (on failure) corrective-retry loop.
+///
+/// Why: Centralises the "try, and if it fails, tell the model precisely what
+/// to fix and try again, up to N times" control flow so every caller (today:
+/// none directly — `agent_loop` uses the same-turn tool-result-feedback path
+/// for its native-argument repairs; future: any caller that wants an
+/// explicit, immediate corrective round-trip rather than waiting for the next
+/// natural turn) gets identical, tested bounding behaviour.
+/// What: Calls `extractor.extract(&response, model_slug)`. On success,
+/// returns the calls immediately. On failure, if `attempts` has already
+/// reached `max_attempts`, returns `Unrepairable { attempts, last_error }` —
+/// a structured error, never a panic. Otherwise builds a corrective message
+/// via [`build_corrective_message`], invokes `retry(corrective)` to obtain
+/// the next `ChatResponse`, increments `attempts`, and loops.
+/// Test: `repair::tests::malformed_then_one_repair_succeeds`,
+/// `repair::tests::unrepairable_after_max_attempts_returns_structured_error`,
+/// `repair::tests::succeeds_immediately_without_calling_retry`.
+pub async fn extract_with_repair<F, Fut>(
+    extractor: &ToolCallExtractor<'_>,
+    mut response: ChatResponse,
+    model_slug: &str,
+    max_attempts: u32,
+    mut retry: F,
+) -> Result<Vec<ExtractedToolCall>, ToolCallExtractError>
+where
+    F: FnMut(String) -> Fut,
+    Fut: Future<Output = Result<ChatResponse, ToolCallExtractError>>,
+{
+    let mut attempts = 0u32;
+    loop {
+        match extractor.extract(&response, model_slug) {
+            Ok(calls) => return Ok(calls),
+            Err(err) => {
+                if attempts >= max_attempts {
+                    return Err(ToolCallExtractError::Unrepairable {
+                        attempts,
+                        last_error: Box::new(err),
+                    });
+                }
+                let corrective = build_corrective_message(&err);
+                attempts += 1;
+                response = retry(corrective).await?;
+            }
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use serde_json::json;
+
+    use super::*;
+
+    fn bash_schema_entry() -> serde_json::Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "parameters": {
+                    "type": "object",
+                    "properties": { "command": { "type": "string" } },
+                    "required": ["command"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    fn extractor_with_bash() -> ToolCallExtractor<'static> {
+        ToolCallExtractor::new(|name| match name {
+            "bash" => Some(bash_schema_entry()),
+            _ => None,
+        })
+    }
+
+    fn response_with_native_call(arguments: &str) -> ChatResponse {
+        let fixture = format!(
+            r#"{{
+              "id": "gen-1",
+              "choices": [{{
+                "message": {{
+                  "role": "assistant",
+                  "content": null,
+                  "tool_calls": [{{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {{"name": "bash", "arguments": {arguments:?}}}
+                  }}]
+                }},
+                "finish_reason": "tool_calls"
+              }}],
+              "usage": {{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}}
+            }}"#
+        );
+        serde_json::from_str(&fixture).expect("fixture deserialises")
+    }
+
+    /// The repair loop's default cap is 2 (3 total attempts).
+    ///
+    /// Why: Guards the documented default against accidental drift.
+    /// What: Trivial constant assertion.
+    /// Test: this test.
+    #[test]
+    fn default_is_two() {
+        assert_eq!(DEFAULT_MAX_REPAIR_ATTEMPTS, 2);
+    }
+
+    /// A corrective message for a missing required field names the field.
+    ///
+    /// Why: The whole point of the message is to be actionable.
+    /// What: Build a `SchemaInvalid` error and check the rendered text.
+    /// Test: this test.
+    #[test]
+    fn corrective_message_names_missing_field() {
+        let err = ToolCallExtractError::SchemaInvalid {
+            name: "bash".into(),
+            violations: vec![super::super::SchemaViolation {
+                path: "$".into(),
+                message: "missing required property 'command'".into(),
+            }],
+        };
+        let msg = build_corrective_message(&err);
+        assert!(msg.contains("bash"));
+        assert!(msg.contains("command"));
+    }
+
+    /// A corrective message for malformed JSON names the tool and the parse error.
+    ///
+    /// Why: Distinct failure mode from schema mismatch; message must differ.
+    /// What: Build a `MalformedArguments` error from a real parse failure.
+    /// Test: this test.
+    #[test]
+    fn corrective_message_for_malformed_json() {
+        let parse_err = serde_json::from_str::<serde_json::Value>("{not json").unwrap_err();
+        let err = ToolCallExtractError::MalformedArguments {
+            name: "bash".into(),
+            source: parse_err,
+        };
+        let msg = build_corrective_message(&err);
+        assert!(msg.contains("bash"));
+        assert!(msg.contains("valid JSON"));
+    }
+
+    /// Extraction that succeeds on the first attempt never calls `retry`.
+    ///
+    /// Why: The loop must not waste a round-trip when nothing is wrong.
+    /// What: A valid native call; `retry` panics if invoked.
+    /// Test: this test.
+    #[tokio::test]
+    async fn succeeds_immediately_without_calling_retry() {
+        let extractor = extractor_with_bash();
+        let response = response_with_native_call(r#"{"command": "ls"}"#);
+        let result = extract_with_repair(
+            &extractor,
+            response,
+            "anthropic/claude-sonnet-4-5",
+            DEFAULT_MAX_REPAIR_ATTEMPTS,
+            |_corrective| async { panic!("retry must not be called on first-attempt success") },
+        )
+        .await
+        .expect("should succeed without repair");
+        assert_eq!(result[0].name, "bash");
+    }
+
+    /// A malformed first attempt, corrected on the first retry, succeeds.
+    ///
+    /// Why: This is the #1023 acceptance-criterion scenario "malformed → one
+    /// repair → success".
+    /// What: First response has invalid args (missing `command`); the retry
+    /// closure returns a corrected response with valid args; assert success
+    /// with `attempts` reflected via a call counter of exactly 1.
+    /// Test: this test.
+    #[tokio::test]
+    async fn malformed_then_one_repair_succeeds() {
+        let extractor = extractor_with_bash();
+        let first = response_with_native_call("{}"); // missing required `command`
+        let call_count = AtomicU32::new(0);
+
+        let result = extract_with_repair(
+            &extractor,
+            first,
+            "anthropic/claude-sonnet-4-5",
+            DEFAULT_MAX_REPAIR_ATTEMPTS,
+            |corrective| {
+                call_count.fetch_add(1, Ordering::SeqCst);
+                assert!(
+                    corrective.contains("command"),
+                    "corrective message: {corrective}"
+                );
+                async { Ok(response_with_native_call(r#"{"command": "ls"}"#)) }
+            },
+        )
+        .await
+        .expect("should succeed after one repair");
+
+        assert_eq!(result[0].name, "bash");
+        assert_eq!(result[0].arguments, json!({"command": "ls"}));
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "exactly one repair round-trip"
+        );
+    }
+
+    /// A persistently invalid response exhausts the attempt budget and
+    /// returns a structured `Unrepairable` error — never a panic.
+    ///
+    /// Why: This is the #1023 acceptance-criterion scenario "unrepairable →
+    /// structured error (no panic)".
+    /// What: `retry` always returns the same invalid response; assert the
+    /// loop terminates with `Unrepairable { attempts: max_attempts, .. }`
+    /// after exactly `max_attempts` retry calls (not more, not fewer).
+    /// Test: this test.
+    #[tokio::test]
+    async fn unrepairable_after_max_attempts_returns_structured_error() {
+        let extractor = extractor_with_bash();
+        let call_count = AtomicU32::new(0);
+        let max_attempts = 2;
+
+        let err = extract_with_repair(
+            &extractor,
+            response_with_native_call("{}"),
+            "anthropic/claude-sonnet-4-5",
+            max_attempts,
+            |_corrective| {
+                call_count.fetch_add(1, Ordering::SeqCst);
+                let resp = response_with_native_call("{}");
+                async move { Ok(resp) }
+            },
+        )
+        .await
+        .expect_err("should be unrepairable");
+
+        match err {
+            ToolCallExtractError::Unrepairable {
+                attempts,
+                last_error,
+            } => {
+                assert_eq!(attempts, max_attempts);
+                assert!(matches!(
+                    *last_error,
+                    ToolCallExtractError::SchemaInvalid { .. }
+                ));
+            }
+            other => panic!("expected Unrepairable, got {other:?}"),
+        }
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            max_attempts,
+            "retry must be called exactly max_attempts times"
+        );
+    }
+
+    /// A `Retry` failure (the retry closure's own chat call failing) propagates
+    /// immediately rather than being retried again.
+    ///
+    /// Why: A transport/API failure during the repair round-trip itself is not
+    /// something another repair attempt can fix; it must surface, not loop.
+    /// What: `retry` returns `Err(ToolCallExtractError::Retry(..))`; assert it
+    /// propagates unchanged via `?`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn retry_failure_propagates_immediately() {
+        let extractor = extractor_with_bash();
+        let first = response_with_native_call("{}");
+
+        let err = extract_with_repair(
+            &extractor,
+            first,
+            "anthropic/claude-sonnet-4-5",
+            DEFAULT_MAX_REPAIR_ATTEMPTS,
+            |_corrective| async {
+                Err(ToolCallExtractError::UnknownTool {
+                    name: "irrelevant".into(),
+                })
+            },
+        )
+        .await
+        .expect_err("should propagate the retry error");
+
+        assert!(matches!(err, ToolCallExtractError::UnknownTool { .. }));
+    }
+}

--- a/crates/trusty-code/src/llm/tool_call_extractor/schema.rs
+++ b/crates/trusty-code/src/llm/tool_call_extractor/schema.rs
@@ -1,0 +1,366 @@
+//! JSON-Schema-subset validator for tool-call arguments.
+//!
+//! Why: Every tool's `schema()` (see `tools::traits::ToolExecutor`) emits an
+//! OpenAI-function-style JSON Schema for its `parameters` object. Before a
+//! model-produced tool call is dispatched, its arguments must be checked
+//! against that schema so malformed calls are caught and reported precisely
+//! (#1023) — feeding the bounded repair loop in `super::repair` — instead of
+//! silently degrading to `{}` (the pre-#1023 behaviour in `agent_loop::parse_args`).
+//! What: [`validate_args`] walks `args` against a `parameters` JSON Schema
+//! object, supporting the subset every tool in this crate actually emits:
+//! `type` (object/string/integer/number/boolean/array/null), `properties`,
+//! `required`, `additionalProperties` (bool), `enum`, `minimum`/`maximum`, and
+//! a single `items` schema for arrays. Collects every violation rather than
+//! stopping at the first, so a repair message can address them all at once.
+//! Test: `schema::tests::*`.
+
+use serde_json::Value;
+
+/// One schema-validation failure, with a JSON-pointer-like `path` for context.
+///
+/// Why: A repair message that says "arguments are invalid" is useless to a
+/// model; naming the exact field and what was wrong lets the corrective
+/// message be actionable.
+/// What: `path` is a dotted/bracketed pointer from the argument root (`$`);
+/// `message` is a human-readable description of the mismatch.
+/// Test: `schema::tests::missing_required_property_reports_path`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaViolation {
+    /// Location of the offending value, rooted at `$` (the whole arguments object).
+    pub path: String,
+    /// Human-readable description of the violation.
+    pub message: String,
+}
+
+impl SchemaViolation {
+    fn new(path: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for SchemaViolation {
+    /// Why: `repair::build_corrective_message` renders violations into the
+    /// text sent back to the model; a stable `Display` keeps that formatting
+    /// in one place.
+    /// What: Renders as `"<path>: <message>"`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.path, self.message)
+    }
+}
+
+/// Validate `args` against a tool's `parameters` JSON Schema object.
+///
+/// Why: This is the single validation entry point shared by every extraction
+/// strategy and every provider (#1023 acceptance criterion: "all providers
+/// share same validation plumbing") — native, fenced-JSON, angle-bracket, and
+/// balanced-scan results all funnel through here before dispatch.
+/// What: Returns `Ok(())` when `args` satisfies `schema`; otherwise `Err` with
+/// every violation found (never just the first).
+/// Test: `schema::tests::*`.
+pub fn validate_args(schema: &Value, args: &Value) -> Result<(), Vec<SchemaViolation>> {
+    let mut violations = Vec::new();
+    validate_value(schema, args, "$", &mut violations);
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(violations)
+    }
+}
+
+/// Recursive worker behind [`validate_args`].
+///
+/// Why: Separating the recursive walk from the public entry point keeps the
+/// `path` threading (for precise violation messages) out of the public API.
+/// What: Checks `type` and `enum` at this node, then recurses into
+/// `properties`/`required`/`additionalProperties` for objects, `items` for
+/// arrays, and `minimum`/`maximum` for numbers. A `type` mismatch stops
+/// descent (there is nothing meaningful left to check underneath).
+/// Test: Exercised via `validate_args` in every test below.
+fn validate_value(schema: &Value, value: &Value, path: &str, out: &mut Vec<SchemaViolation>) {
+    if let Some(expected) = schema.get("type").and_then(Value::as_str)
+        && !type_matches(expected, value)
+    {
+        out.push(SchemaViolation::new(
+            path,
+            format!(
+                "expected type '{expected}', got '{}'",
+                value_type_name(value)
+            ),
+        ));
+        return;
+    }
+
+    if let Some(allowed) = schema.get("enum").and_then(Value::as_array)
+        && !allowed.contains(value)
+    {
+        out.push(SchemaViolation::new(
+            path,
+            format!("value {value} is not one of the allowed enum values {allowed:?}"),
+        ));
+    }
+
+    match value {
+        Value::Object(map) => {
+            let props = schema.get("properties").and_then(Value::as_object);
+            if let Some(props) = props {
+                for (key, subschema) in props {
+                    if let Some(v) = map.get(key) {
+                        validate_value(subschema, v, &format!("{path}.{key}"), out);
+                    }
+                }
+            }
+            if let Some(required) = schema.get("required").and_then(Value::as_array) {
+                for req in required {
+                    if let Some(name) = req.as_str()
+                        && !map.contains_key(name)
+                    {
+                        out.push(SchemaViolation::new(
+                            path,
+                            format!("missing required property '{name}'"),
+                        ));
+                    }
+                }
+            }
+            if schema.get("additionalProperties") == Some(&Value::Bool(false)) {
+                let allowed_keys = props;
+                for key in map.keys() {
+                    let known = allowed_keys.is_some_and(|p| p.contains_key(key));
+                    if !known {
+                        out.push(SchemaViolation::new(
+                            path,
+                            format!("unexpected property '{key}' (additionalProperties: false)"),
+                        ));
+                    }
+                }
+            }
+        }
+        Value::Array(items) => {
+            if let Some(item_schema) = schema.get("items") {
+                for (i, item) in items.iter().enumerate() {
+                    validate_value(item_schema, item, &format!("{path}[{i}]"), out);
+                }
+            }
+        }
+        Value::Number(n) => {
+            if let Some(min) = schema.get("minimum").and_then(Value::as_f64)
+                && n.as_f64().is_some_and(|v| v < min)
+            {
+                out.push(SchemaViolation::new(
+                    path,
+                    format!("value {n} is below minimum {min}"),
+                ));
+            }
+            if let Some(max) = schema.get("maximum").and_then(Value::as_f64)
+                && n.as_f64().is_some_and(|v| v > max)
+            {
+                out.push(SchemaViolation::new(
+                    path,
+                    format!("value {n} exceeds maximum {max}"),
+                ));
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Whether `value`'s runtime JSON type matches a JSON-Schema `type` keyword.
+///
+/// Why: JSON Schema's `"integer"` has no direct `serde_json::Value` variant —
+/// it is a `Number` with no fractional part — so this needs its own check
+/// rather than a straight enum match.
+/// What: Returns `true` for a matching type; an unrecognised `expected`
+/// string is treated permissively (`true`) rather than rejecting every value,
+/// matching JSON Schema's general laxness toward unknown keywords.
+/// Test: `schema::tests::type_mismatch_is_reported`, `integer_type_rejects_float`.
+fn type_matches(expected: &str, value: &Value) -> bool {
+    match expected {
+        "object" => value.is_object(),
+        "string" => value.is_string(),
+        "integer" => value.is_i64() || value.is_u64(),
+        "number" => value.is_number(),
+        "boolean" => value.is_boolean(),
+        "array" => value.is_array(),
+        "null" => value.is_null(),
+        _ => true,
+    }
+}
+
+/// Human-readable JSON type name for a value, used in violation messages.
+///
+/// Why: Error messages should say "got 'string'" not "got 'Value::String(..)'".
+/// What: Maps each `Value` variant to its JSON Schema type name, distinguishing
+/// `integer` from `number` the same way [`type_matches`] does.
+/// Test: Exercised via violation message assertions in `schema::tests::*`.
+fn value_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(n) if n.is_i64() || n.is_u64() => "integer",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn bash_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "command": { "type": "string" },
+                "timeout_secs": { "type": "integer", "minimum": 1 }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        })
+    }
+
+    /// A fully valid argument object passes with no violations.
+    ///
+    /// Why: Guard the happy path before testing failure modes.
+    /// What: Valid `{command, timeout_secs}` against `bash_schema()`.
+    /// Test: this test.
+    #[test]
+    fn valid_args_pass() {
+        let args = json!({"command": "ls", "timeout_secs": 30});
+        assert_eq!(validate_args(&bash_schema(), &args), Ok(()));
+    }
+
+    /// A missing required property is reported with its name and root path.
+    ///
+    /// Why: The repair message must name the exact missing field.
+    /// What: Omit `command`; assert the violation names it.
+    /// Test: this test.
+    #[test]
+    fn missing_required_property_reports_path() {
+        let args = json!({"timeout_secs": 30});
+        let err = validate_args(&bash_schema(), &args).unwrap_err();
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].path, "$");
+        assert!(err[0].message.contains("command"));
+    }
+
+    /// A type mismatch on a property is reported with the property's path.
+    ///
+    /// Why: Nested-path reporting lets a repair message point at the exact field.
+    /// What: `command` as a number instead of a string.
+    /// Test: this test.
+    #[test]
+    fn type_mismatch_is_reported() {
+        let args = json!({"command": 123});
+        let err = validate_args(&bash_schema(), &args).unwrap_err();
+        assert!(err.iter().any(|v| v.path == "$.command"));
+        assert!(err.iter().any(|v| v.message.contains("string")));
+    }
+
+    /// JSON Schema's `"integer"` rejects a fractional number.
+    ///
+    /// Why: `serde_json::Value::Number` conflates ints and floats; the
+    /// validator must still distinguish them per JSON Schema semantics.
+    /// What: `timeout_secs: 30.5` against an `"integer"` schema.
+    /// Test: this test.
+    #[test]
+    fn integer_type_rejects_float() {
+        let args = json!({"command": "ls", "timeout_secs": 30.5});
+        let err = validate_args(&bash_schema(), &args).unwrap_err();
+        assert!(err.iter().any(|v| v.path == "$.timeout_secs"));
+    }
+
+    /// A value below `minimum` is reported.
+    ///
+    /// Why: Range constraints must actually be enforced, not just parsed.
+    /// What: `timeout_secs: 0` against `minimum: 1`.
+    /// Test: this test.
+    #[test]
+    fn below_minimum_is_reported() {
+        let args = json!({"command": "ls", "timeout_secs": 0});
+        let err = validate_args(&bash_schema(), &args).unwrap_err();
+        assert!(err.iter().any(|v| v.message.contains("minimum")));
+    }
+
+    /// An unexpected property is reported when `additionalProperties: false`.
+    ///
+    /// Why: Tools declare a closed argument shape; extra hallucinated keys
+    /// should be caught rather than silently ignored.
+    /// What: Add an unknown `foo` key.
+    /// Test: this test.
+    #[test]
+    fn unexpected_property_is_reported() {
+        let args = json!({"command": "ls", "foo": "bar"});
+        let err = validate_args(&bash_schema(), &args).unwrap_err();
+        assert!(err.iter().any(|v| v.message.contains("foo")));
+    }
+
+    /// All violations are collected, not just the first.
+    ///
+    /// Why: A single repair round-trip should let the model fix everything at
+    /// once rather than playing whack-a-mole one violation per turn.
+    /// What: Two independent violations in one payload; both are reported.
+    /// Test: this test.
+    #[test]
+    fn collects_multiple_violations() {
+        let args = json!({"timeout_secs": "not-a-number"});
+        let err = validate_args(&bash_schema(), &args).unwrap_err();
+        // missing `command` AND wrong type for `timeout_secs`.
+        assert!(
+            err.len() >= 2,
+            "expected at least 2 violations, got {err:?}"
+        );
+    }
+
+    /// `enum` restricts a string property to its declared values.
+    ///
+    /// Why: Some future tool schemas may restrict a field to a fixed set;
+    /// validate that path even though no current tool schema uses it yet.
+    /// What: A schema with an `enum` property; an out-of-set value fails.
+    /// Test: this test.
+    #[test]
+    fn enum_violation_is_reported() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "mode": { "type": "string", "enum": ["fast", "slow"] } },
+            "required": ["mode"]
+        });
+        let err = validate_args(&schema, &json!({"mode": "medium"})).unwrap_err();
+        assert!(err.iter().any(|v| v.message.contains("enum")));
+    }
+
+    /// `items` validates each element of an array property.
+    ///
+    /// Why: Guard the array-recursion path even though no current tool uses it.
+    /// What: An array property with a `string` item schema; a numeric element fails.
+    /// Test: this test.
+    #[test]
+    fn array_items_are_validated() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "tags": { "type": "array", "items": { "type": "string" } } }
+        });
+        let err = validate_args(&schema, &json!({"tags": ["a", 1]})).unwrap_err();
+        assert!(err.iter().any(|v| v.path == "$.tags[1]"));
+    }
+
+    /// `SchemaViolation`'s `Display` renders `"path: message"`.
+    ///
+    /// Why: `repair::build_corrective_message` depends on this exact shape.
+    /// What: Format a violation, assert the rendered string.
+    /// Test: this test.
+    #[test]
+    fn violation_display_format() {
+        let v = SchemaViolation::new("$.command", "missing required property 'command'");
+        assert_eq!(
+            v.to_string(),
+            "$.command: missing required property 'command'"
+        );
+    }
+}

--- a/crates/trusty-code/src/llm/tool_call_extractor/strategies.rs
+++ b/crates/trusty-code/src/llm/tool_call_extractor/strategies.rs
@@ -1,0 +1,271 @@
+//! Text-based tool-call extraction fallbacks (#1023).
+//!
+//! Why: Only well-known model families reliably populate the OpenAI-native
+//! `choices[0].message.tool_calls` wire field (see
+//! `provider::traits::Provider::supports_native_tools`). Others (Qwen,
+//! DeepSeek, Gemma, and any future family) emit their intended tool call as
+//! text inside `content` instead, using one of a few conventions. Each
+//! convention gets its own free function here so [`super::ToolCallExtractor`]
+//! can try them in a per-model order (see `super::strategy_order_for`).
+//! What: [`extract_fenced_json`] handles a ```` ```json ``` ```` code block;
+//! [`extract_angle_bracket`] handles `<tool_call>{...}</tool_call>`;
+//! [`extract_balanced_json_scan`] is the tolerant last resort — it scans the
+//! whole text for the first balanced `{...}` object (respecting quoted
+//! strings) that parses as JSON and has a `name` field. All three return the
+//! same `(name, arguments)` shape via the shared [`parse_call_object`] helper,
+//! so `{"name": ..., "arguments": {...}}` and the `"parameters"` alias are
+//! accepted uniformly.
+//! Test: `strategies::tests::*`.
+
+use serde_json::Value;
+
+/// Parse a JSON object body into a `(name, arguments)` tool-call candidate.
+///
+/// Why: All three text-based strategies converge on the same expected JSON
+/// shape once they've located the candidate substring; centralising the
+/// parse avoids three copies of the same `name`/`arguments` extraction.
+/// What: Parses `body` as JSON; requires a string `"name"` field; accepts
+/// either `"arguments"` or `"parameters"` (alias) as the argument object,
+/// defaulting to an empty object when neither is present. Returns `None` on
+/// any parse failure or a missing/non-string `name`.
+/// Test: `strategies::tests::parse_call_object_accepts_parameters_alias`.
+fn parse_call_object(body: &str) -> Option<(String, Value)> {
+    let value: Value = serde_json::from_str(body).ok()?;
+    let name = value.get("name")?.as_str()?.to_string();
+    let args = value
+        .get("arguments")
+        .or_else(|| value.get("parameters"))
+        .cloned()
+        .unwrap_or_else(|| Value::Object(Default::default()));
+    Some((name, args))
+}
+
+/// Extract a tool call from a fenced ```` ```json ``` ```` code block.
+///
+/// Why: Prompt-guided models (told "respond with a ```json tool call") commonly
+/// follow that instruction literally rather than using native function-calling.
+/// What: Finds the first ```` ```json ```` fence, takes everything up to the
+/// next ```` ``` ````, and parses it via [`parse_call_object`]. Returns `None`
+/// when no such fence exists or the body doesn't parse to the expected shape.
+/// Test: `strategies::tests::fenced_json_extracts_call`.
+pub(super) fn extract_fenced_json(text: &str) -> Option<(String, Value)> {
+    const FENCE_OPEN: &str = "```json";
+    const FENCE_CLOSE: &str = "```";
+    let start = text.find(FENCE_OPEN)? + FENCE_OPEN.len();
+    let rest = &text[start..];
+    let end = rest.find(FENCE_CLOSE)?;
+    parse_call_object(rest[..end].trim())
+}
+
+/// Extract a tool call from an `<tool_call>{...}</tool_call>` span.
+///
+/// Why: Some model families (notably Qwen/DeepSeek-style chat templates) are
+/// trained on this exact tag convention for function-calling.
+/// What: Finds the first `<tool_call>`/`</tool_call>` pair and parses the
+/// enclosed body via [`parse_call_object`].
+/// Test: `strategies::tests::angle_bracket_extracts_call`.
+pub(super) fn extract_angle_bracket(text: &str) -> Option<(String, Value)> {
+    const OPEN: &str = "<tool_call>";
+    const CLOSE: &str = "</tool_call>";
+    let start = text.find(OPEN)? + OPEN.len();
+    let rest = &text[start..];
+    let end = rest.find(CLOSE)?;
+    parse_call_object(rest[..end].trim())
+}
+
+/// Tolerant last-resort scan: find any balanced `{...}` object in noisy text.
+///
+/// Why: A model may wrap its tool call in prose, partial markdown, or a
+/// malformed fence — this is the catch-all before giving up entirely.
+/// What: Scans left-to-right for `{`, finds its matching (quote-aware)
+/// closing `}` via [`find_balanced_end`], and attempts [`parse_call_object`]
+/// on each balanced span in turn until one succeeds. Returns `None` when no
+/// balanced span parses to the expected shape.
+/// Test: `strategies::tests::balanced_scan_recovers_call_from_noisy_text`.
+pub(super) fn extract_balanced_json_scan(text: &str) -> Option<(String, Value)> {
+    let mut search_from = 0usize;
+    while let Some(rel_start) = text[search_from..].find('{') {
+        let start = search_from + rel_start;
+        let Some(end) = find_balanced_end(text, start) else {
+            break;
+        };
+        if let Some(call) = parse_call_object(&text[start..=end]) {
+            return Some(call);
+        }
+        search_from = start + 1;
+    }
+    None
+}
+
+/// Find the index of the `}` that balances the `{` at `start`, quote-aware.
+///
+/// Why: A naive "next `}`" search breaks on any tool argument string that
+/// itself contains braces (e.g. a `content` argument with JSON inside it);
+/// tracking string state and depth is required for a correct scan.
+/// What: Walks characters from `start`, toggling `in_string` on unescaped `"`
+/// and adjusting brace `depth` outside strings. Returns the byte index of the
+/// `}` where `depth` first returns to zero, or `None` if the text ends first.
+/// Test: Exercised via `extract_balanced_json_scan` tests (nested-object case).
+fn find_balanced_end(text: &str, start: usize) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut escape = false;
+    for (idx, ch) in text.char_indices() {
+        if idx < start {
+            continue;
+        }
+        if in_string {
+            if escape {
+                escape = false;
+            } else if ch == '\\' {
+                escape = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A fenced ```json block extracts the call's name and arguments.
+    ///
+    /// Why: The primary fallback path for prompt-guided tool calling.
+    /// What: A response with a fenced block; assert name + args.
+    /// Test: this test.
+    #[test]
+    fn fenced_json_extracts_call() {
+        let text = "Sure, I'll do that.\n```json\n{\"name\": \"bash\", \"arguments\": {\"command\": \"ls\"}}\n```\nDone.";
+        let (name, args) = extract_fenced_json(text).expect("fenced call");
+        assert_eq!(name, "bash");
+        assert_eq!(args, json!({"command": "ls"}));
+    }
+
+    /// Missing fence returns `None` rather than panicking.
+    ///
+    /// Why: Must not treat arbitrary text as a hit.
+    /// What: Plain text with no fence.
+    /// Test: this test.
+    #[test]
+    fn fenced_json_none_without_fence() {
+        assert!(extract_fenced_json("just some prose").is_none());
+    }
+
+    /// An `<tool_call>` tag extracts the call's name and arguments.
+    ///
+    /// Why: Qwen/DeepSeek-style tag convention.
+    /// What: A response wrapping the JSON body in `<tool_call>` tags.
+    /// Test: this test.
+    #[test]
+    fn angle_bracket_extracts_call() {
+        let text =
+            "<tool_call>{\"name\": \"read_file\", \"arguments\": {\"path\": \"a.rs\"}}</tool_call>";
+        let (name, args) = extract_angle_bracket(text).expect("angle-bracket call");
+        assert_eq!(name, "read_file");
+        assert_eq!(args, json!({"path": "a.rs"}));
+    }
+
+    /// Missing tags return `None`.
+    ///
+    /// Why: Guard against false positives.
+    /// What: Plain text with no tags.
+    /// Test: this test.
+    #[test]
+    fn angle_bracket_none_without_tags() {
+        assert!(extract_angle_bracket("no tags here").is_none());
+    }
+
+    /// The balanced scan recovers a call embedded in noisy surrounding prose.
+    ///
+    /// Why: This is the last-resort fallback for a model that ignores both
+    /// conventions but still emits a raw JSON object somewhere in its answer.
+    /// What: Prose before and after a bare JSON object.
+    /// Test: this test.
+    #[test]
+    fn balanced_scan_recovers_call_from_noisy_text() {
+        let text = "Let me call the tool: {\"name\": \"bash\", \"arguments\": {\"command\": \"echo hi\"}} — running now.";
+        let (name, args) = extract_balanced_json_scan(text).expect("scanned call");
+        assert_eq!(name, "bash");
+        assert_eq!(args, json!({"command": "echo hi"}));
+    }
+
+    /// The balanced scan is brace-depth-aware around nested objects.
+    ///
+    /// Why: A naive "find first `}`" would truncate the arguments object;
+    /// verify nested braces inside `arguments` are handled correctly.
+    /// What: `arguments` itself contains a nested object.
+    /// Test: this test.
+    #[test]
+    fn balanced_scan_handles_nested_braces() {
+        let text = r#"{"name": "write_file", "arguments": {"path": "a.json", "content": "{\"nested\": true}"}}"#;
+        let (name, args) = extract_balanced_json_scan(text).expect("scanned call");
+        assert_eq!(name, "write_file");
+        assert_eq!(args["path"], "a.json");
+    }
+
+    /// The scan skips a non-matching brace span and finds a later valid one.
+    ///
+    /// Why: Noisy text may contain an unrelated `{...}` (e.g. an example) before
+    /// the real tool call; the scan must not give up on the first failure.
+    /// What: A non-tool-call object followed by a real one.
+    /// Test: this test.
+    #[test]
+    fn balanced_scan_skips_non_matching_object_then_finds_real_call() {
+        let text = r#"Example: {"foo": "bar"} then the real call {"name": "bash", "arguments": {"command": "pwd"}}"#;
+        let (name, _) = extract_balanced_json_scan(text).expect("scanned call");
+        assert_eq!(name, "bash");
+    }
+
+    /// No JSON object anywhere in the text returns `None`.
+    ///
+    /// Why: The extractor must be able to report "nothing found" cleanly.
+    /// What: Plain prose with no braces at all.
+    /// Test: this test.
+    #[test]
+    fn balanced_scan_none_when_no_object_present() {
+        assert!(extract_balanced_json_scan("no json here at all").is_none());
+    }
+
+    /// `parse_call_object` accepts `"parameters"` as an alias for `"arguments"`.
+    ///
+    /// Why: Some model templates use `parameters` instead of `arguments`; the
+    /// extractor should not reject an otherwise well-formed call over naming.
+    /// What: A call object using `parameters` instead of `arguments`.
+    /// Test: this test.
+    #[test]
+    fn parse_call_object_accepts_parameters_alias() {
+        let (name, args) =
+            parse_call_object(r#"{"name": "bash", "parameters": {"command": "ls"}}"#)
+                .expect("parsed call");
+        assert_eq!(name, "bash");
+        assert_eq!(args, json!({"command": "ls"}));
+    }
+
+    /// A call object missing `name` is rejected.
+    ///
+    /// Why: `name` is the one field with no reasonable default.
+    /// What: A JSON object with only `arguments`.
+    /// Test: this test.
+    #[test]
+    fn parse_call_object_rejects_missing_name() {
+        assert!(parse_call_object(r#"{"arguments": {}}"#).is_none());
+    }
+}

--- a/crates/trusty-code/src/tools/registry.rs
+++ b/crates/trusty-code/src/tools/registry.rs
@@ -165,6 +165,18 @@ impl ToolRegistry {
         self.tools.values().map(|t| t.schema()).collect()
     }
 
+    /// Return the raw schema for a single registered tool by name.
+    ///
+    /// Why: `llm::ToolCallExtractor` (#1023) validates one tool call's
+    /// arguments at a time; looking up exactly one schema is cheaper and
+    /// simpler than enumerating and filtering the full `schemas()` vector on
+    /// every dispatch.
+    /// What: Returns `Some(tool.schema())` for a registered `name`, else `None`.
+    /// Test: `schema_for_returns_registered_tool_schema`, `schema_for_none_when_missing`.
+    pub fn schema_for(&self, name: &str) -> Option<Value> {
+        self.tools.get(name).map(|t| t.schema())
+    }
+
     /// Return the subset of registered tools that `user` may invoke.
     ///
     /// Why: Schema emission for the LLM request must reflect what the user can
@@ -294,6 +306,30 @@ mod tests {
         reg.register(Arc::new(MockTool::new("tool_a")));
         reg.register(Arc::new(MockTool::new("tool_b")));
         assert_eq!(reg.schemas().len(), 2);
+    }
+
+    /// `schema_for` returns the registered tool's schema.
+    ///
+    /// Why: Guard the direct single-tool lookup used by `ToolCallExtractor`.
+    /// What: Register "mock", fetch its schema by name, assert its shape.
+    /// Test: this test.
+    #[test]
+    fn schema_for_returns_registered_tool_schema() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(MockTool::new("mock")));
+        let schema = reg.schema_for("mock").expect("schema present");
+        assert_eq!(schema["function"]["name"], "mock");
+    }
+
+    /// `schema_for` returns `None` for an unregistered name.
+    ///
+    /// Why: Guard the miss path — no panic, no default schema fabricated.
+    /// What: Query a name that was never registered.
+    /// Test: this test.
+    #[test]
+    fn schema_for_none_when_missing() {
+        let reg = ToolRegistry::new();
+        assert!(reg.schema_for("does_not_exist").is_none());
     }
 
     /// `dispatch_gated` rejects a tool not in the allowlist.


### PR DESCRIPTION
M2 (Tool Calling) foundation — the cross-provider tool-call extraction surface.

Adds `ToolCallExtractor` with four strategies (native `tool_calls`, fenced-```json, `<tool_call>` angle-bracket, tolerant balanced-JSON scan), auto-selected per model via `strategy_order_for` but sharing one JSON-schema validation path. Adds a bounded repair loop (`DEFAULT_MAX_REPAIR_ATTEMPTS = 2`) that builds a corrective message on validation/parse failure and retries, returning a structured `Unrepairable` error (never a panic) when exhausted. `agent_loop::dispatch_all` now validates tool args via `parse_and_validate` instead of silently degrading malformed JSON to `{}`; the old `parse_args` helper is removed.

Submodules (all under the 500-SLOC cap): `tool_call_extractor/{mod,strategies,schema,error,repair}.rs`.

QA: APPROVE (independent worktree at 6ea65079) — build 0 warnings, 513 unit + 16 integration tests pass, clippy clean, fmt clean, line-cap 0 violations, trusty-agents downstream unaffected. Full #1023 test matrix verified (native/fenced/angle-bracket success, malformed→repair→success, unrepairable→structured error), zero library unwrap(), Why/What/Test docs present.

Deferred (scoped follow-up): per-provider strategy order is slug-based (`strategy_order_for`) rather than routed through the `Provider` trait — sufficient for current providers; revisit if a future provider needs richer selection.

Closes #1023