### PR TITLE
feat(trusty-code): finish_task tool + explicit loop termination (#2072)

### DIFF
--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -12,10 +12,13 @@
 //! `LlmClientTrait::chat`, accrue usage into a `PerfCollector`, append the
 //! assistant turn, and — if there are tool calls — dispatch each via
 //! `ToolRegistry::dispatch_gated` (notifying the optional sink around each
-//! dispatch) and append the results. Exits with `AgentOutput` on the first
-//! assistant turn that has NO tool calls (the D3 no-tool-call finish
-//! convention); aborts with a partial output when the turn cap, timeout, or
-//! (#2056) an external cancellation flag fires.
+//! dispatch) and append the results. Exits with `AgentOutput` in either of two
+//! ways: the first assistant turn that has NO tool calls (the D3 no-tool-call
+//! finish convention, preserved unchanged as the fallback), or (#2072) an
+//! explicit, successfully-validated `finish_task` tool call, whose structured
+//! `status`/`summary`/`changes`/test-count fields become the final
+//! `AgentOutput` via `build_finish_output`. Aborts with a partial output when
+//! the turn cap, timeout, or (#2056) an external cancellation flag fires.
 //! What: The whole `chat → dispatch → iterate` body runs inside a single
 //! `tokio::time::timeout` so a stalled model or hung tool cannot block forever.
 //! Test: `agent_loop::tests` — stubbed two-turn flow, turn-cap abort, recoverable
@@ -41,7 +44,7 @@ use crate::llm::{
 };
 use crate::mode::HarnessMode;
 use crate::perf::PerfCollector;
-use crate::tools::{AgentOutput, ToolRegistry, ToolResult};
+use crate::tools::{AgentOutput, FINISH_TASK_TOOL_NAME, FinishTaskArgs, ToolRegistry, ToolResult};
 
 pub use error::AgentLoopError;
 pub use sink::ToolEventSink;
@@ -202,12 +205,16 @@ impl AgentLoop {
     /// What: Iterates up to `max_turns`: check the (#2056) cancellation flag →
     /// build request → chat → accrue usage → append assistant turn → if tool
     /// calls are present, dispatch each (notifying the optional sink) and
-    /// append results, then continue; otherwise (a no-tool-call turn) return
-    /// the assembled output. Per D3, `finish_reason` never gates termination —
-    /// pending tool calls always run first. Exhausting the turn budget returns
-    /// `TurnCapExceeded`; an observed cancellation returns `Cancelled` — both
-    /// with the partial transcript.
-    /// Test: Same tests as `run`, plus `cancel_flag_aborts_before_next_turn`.
+    /// append results, then continue — UNLESS one of those calls was a
+    /// successfully-validated `finish_task` (#2072), in which case the loop
+    /// returns immediately with the structured completion output built by
+    /// `build_finish_output`. Otherwise (a no-tool-call turn) return the
+    /// assembled output — the D3 fallback, unchanged. Per D3, `finish_reason`
+    /// never gates termination — pending tool calls always run first.
+    /// Exhausting the turn budget returns `TurnCapExceeded`; an observed
+    /// cancellation returns `Cancelled` — both with the partial transcript.
+    /// Test: Same tests as `run`, plus `cancel_flag_aborts_before_next_turn`,
+    /// `explicit_finish_task_terminates_loop_with_structured_summary`.
     async fn run_inner(
         &self,
         transcript: &mut Transcript,
@@ -247,7 +254,15 @@ impl AgentLoop {
                 return Ok(build_output(transcript, perf));
             }
 
-            self.dispatch_all(&tool_calls, transcript).await;
+            // #2072: an explicit, successfully-validated `finish_task` call
+            // terminates the loop immediately with the structured completion
+            // report, rather than waiting for a later no-tool-call turn. Every
+            // tool call in this turn is still dispatched and answered first
+            // (the API requires a result for each), so this check happens
+            // AFTER `dispatch_all`, not instead of it.
+            if let Some(finish_args) = self.dispatch_all(&tool_calls, transcript).await {
+                return Ok(build_finish_output(transcript, perf, &finish_args));
+            }
         }
 
         Err(AgentLoopError::TurnCapExceeded {
@@ -269,13 +284,32 @@ impl AgentLoop {
     /// dispatches through `dispatch_gated` with no per-agent allowlist,
     /// notifies `tool_finished` (success) or `tool_error` (a
     /// fatal/non-recoverable `ToolResult::Error`) based on the result, and
-    /// appends the result as a `tool` message.
+    /// appends the result as a `tool` message. EVERY call in `tool_calls` is
+    /// dispatched and answered, regardless of whether an earlier one was
+    /// `finish_task` — the API requires a result for each pending call.
+    /// What (#2072): if any call names [`FINISH_TASK_TOOL_NAME`] and its
+    /// dispatch did not return an error (i.e. its arguments passed both the
+    /// generic schema validation above AND `FinishTaskTool::execute`'s own
+    /// deserialisation), returns `Some(args)` with that call's validated
+    /// argument `Value` — the LAST such call wins if the model (unusually)
+    /// emits more than one in a single turn. A malformed/invalid `finish_task`
+    /// call is reported through the same recoverable-error path as any other
+    /// tool and does NOT terminate the loop, letting the model retry.
     /// Test: `agent_loop::tests::recoverable_tool_error_continues`,
     /// `agent_loop::tests::malformed_tool_arguments_report_recoverable_error_and_loop_continues`,
     /// `sink_receives_started_then_finished_in_order`,
-    /// `sink_receives_tool_error_for_fatal_failures`.
-    async fn dispatch_all(&self, tool_calls: &[ToolCall], transcript: &mut Transcript) {
+    /// `sink_receives_tool_error_for_fatal_failures`,
+    /// `explicit_finish_task_terminates_loop_with_structured_summary`,
+    /// `malformed_finish_task_repairs_then_terminates`,
+    /// `finish_task_missing_required_field_is_recoverable_not_terminal`,
+    /// `finish_task_invalid_enum_value_is_recoverable_not_terminal`.
+    async fn dispatch_all(
+        &self,
+        tool_calls: &[ToolCall],
+        transcript: &mut Transcript,
+    ) -> Option<Value> {
         let extractor = ToolCallExtractor::new(|name| self.registry.schema_for(name));
+        let mut finish_args: Option<Value> = None;
 
         for call in tool_calls {
             let tool = call.function.name.as_str();
@@ -293,14 +327,20 @@ impl AgentLoop {
                 sink.tool_started(&call.id, tool, &args.to_string()).await;
             }
 
-            let result = self.registry.dispatch_gated(tool, args, None).await;
+            let result = self.registry.dispatch_gated(tool, args.clone(), None).await;
 
             if let Some(sink) = &self.sink {
                 notify_result(sink.as_ref(), &call.id, tool, &result).await;
             }
 
             transcript.push_tool_result(&call.id, tool, result.content());
+
+            if tool == FINISH_TASK_TOOL_NAME && !result.is_error() {
+                finish_args = Some(args);
+            }
         }
+
+        finish_args
     }
 
     /// Report an invalid or malformed tool call as a recoverable tool result.
@@ -466,5 +506,34 @@ fn build_output(transcript: &Transcript, perf: &PerfCollector) -> AgentOutput {
         totals.cache_read_tokens,
         totals.cache_creation_tokens,
     );
+    output
+}
+
+/// Assemble the final `AgentOutput` from an explicit `finish_task` call (#2072).
+///
+/// Why: An explicit `finish_task` call carries a deterministic, structured
+/// completion report the model built on purpose — reusing that report as the
+/// loop's final output (rather than falling back to whatever prose the
+/// transcript happens to contain) is the entire point of §5.8's "-20 to -30%
+/// per agent output; deterministic, no prose interpretation" impact claim.
+/// What: Starts from the same usage/content baseline as [`build_output`], then
+/// — if `finish_args` deserialises into a `FinishTaskArgs` (it always should,
+/// since `dispatch_all` only calls this after a successful `finish_task`
+/// dispatch, which itself required a successful deserialisation) — overwrites
+/// `content` with [`crate::tools::render_finish_summary`] and sets `summary` to
+/// the model's own one-line `summary` field. On the (should-be-unreachable)
+/// deserialisation failure, falls back to the transcript-derived content
+/// `build_output` already computed, rather than panicking.
+/// Test: `agent_loop::tests::explicit_finish_task_terminates_loop_with_structured_summary`.
+fn build_finish_output(
+    transcript: &Transcript,
+    perf: &PerfCollector,
+    finish_args: &Value,
+) -> AgentOutput {
+    let mut output = build_output(transcript, perf);
+    if let Ok(parsed) = serde_json::from_value::<FinishTaskArgs>(finish_args.clone()) {
+        output.summary = Some(parsed.summary.clone());
+        output.content = crate::tools::render_finish_summary(&parsed);
+    }
     output
 }

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 
 use super::{AgentLoop, AgentLoopConfig, AgentLoopError, ToolEventSink};
 use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
-use crate::tools::{ToolExecutor, ToolRegistry, ToolResult};
+use crate::tools::{FinishTaskTool, ToolExecutor, ToolRegistry, ToolResult};
 
 // ── Test doubles ───────────────────────────────────────────────────────────────
 
@@ -197,6 +197,37 @@ fn make_loop(
 fn registry_with_echo(fail: bool) -> Arc<ToolRegistry> {
     let mut reg = ToolRegistry::new();
     reg.register(Arc::new(EchoTool { fail }));
+    Arc::new(reg)
+}
+
+/// Build a response fixture in which the assistant calls `finish_task`.
+///
+/// Why: `raw_arguments` is passed through verbatim (not re-serialised) so
+/// tests can construct both well-formed JSON and deliberately malformed
+/// strings for the repair-path tests.
+fn finish_task_call_response(call_id: &str, raw_arguments: &str) -> Value {
+    json!({
+        "id": "gen-finish",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": { "name": "finish_task", "arguments": raw_arguments }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 6, "completion_tokens": 6, "total_tokens": 12 }
+    })
+}
+
+/// A registry containing only `FinishTaskTool` (#2072).
+fn registry_with_finish_task() -> Arc<ToolRegistry> {
+    let mut reg = ToolRegistry::new();
+    reg.register(Arc::new(FinishTaskTool::new()));
     Arc::new(reg)
 }
 
@@ -536,6 +567,170 @@ async fn no_tools_immediate_stop() {
         .expect("completes");
     assert_eq!(out.content, "just text");
     assert_eq!(llm.calls(), 1);
+}
+
+// ── #2072: `finish_task` tool + repair loop ─────────────────────────────────────
+
+/// A valid, explicit `finish_task` call terminates the loop immediately with
+/// the structured completion report, WITHOUT waiting for a later
+/// no-tool-call turn.
+///
+/// Why: This is the core #2072 acceptance criterion — an explicit finish call
+/// is a first-class alternative to the implicit D3 no-tool-call convention.
+/// What: Script a single `finish_task` response with valid `status`/`summary`;
+/// assert the loop returns after exactly ONE chat call (proving it did not
+/// wait for a second turn) with `AgentOutput.summary` and `.content` reflecting
+/// the structured report.
+/// Test: this test.
+#[tokio::test]
+async fn explicit_finish_task_terminates_loop_with_structured_summary() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[finish_task_call_response(
+        "call-finish",
+        r#"{"status": "completed", "summary": "implemented the feature"}"#,
+    )]));
+    let registry = registry_with_finish_task();
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default());
+
+    let out = agent
+        .run("system", "do the task")
+        .await
+        .expect("explicit finish_task should terminate the loop");
+
+    assert_eq!(llm.calls(), 1, "loop must not make a second chat call");
+    assert_eq!(out.summary.as_deref(), Some("implemented the feature"));
+    assert_eq!(
+        out.content, "Task completed: implemented the feature",
+        "content must reflect the structured report, not raw transcript text"
+    );
+}
+
+/// A `finish_task` call with syntactically malformed JSON arguments is
+/// reported as a recoverable error and repaired on the next turn, after which
+/// the corrected call terminates the loop.
+///
+/// Why: This is the #2072 "malformed args → recoverable error → repair →
+/// success" acceptance-criterion scenario, reusing #1023's
+/// `ToolCallExtractor::parse_and_validate` — no bespoke validation exists in
+/// `finish_task.rs` itself.
+/// What: Script [malformed finish_task call, valid finish_task call]; assert
+/// exactly two chat calls and a final structured summary from the SECOND
+/// (corrected) call.
+/// Test: this test.
+#[tokio::test]
+async fn malformed_finish_task_repairs_then_terminates() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        finish_task_call_response("call-bad", "{not valid json"),
+        finish_task_call_response(
+            "call-good",
+            r#"{"status": "completed", "summary": "fixed and done"}"#,
+        ),
+    ]));
+    let registry = registry_with_finish_task();
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default());
+
+    let out = agent
+        .run("system", "do the task")
+        .await
+        .expect("loop should repair and terminate on the corrected call");
+
+    assert_eq!(
+        llm.calls(),
+        2,
+        "one malformed attempt, one repaired attempt"
+    );
+    assert_eq!(out.summary.as_deref(), Some("fixed and done"));
+    assert_eq!(out.content, "Task completed: fixed and done");
+}
+
+/// A `finish_task` call missing the required `summary` field is reported as a
+/// recoverable schema violation and does NOT terminate the loop — the run
+/// continues to whatever comes next (here, a plain no-tool-call finish).
+///
+/// Why: #2072's "missing required field → recoverable error (no panic)"
+/// acceptance criterion. Also guards that an invalid finish_task call is never
+/// mistaken for a successful one (`dispatch_all` only treats a NON-error
+/// dispatch as a finish signal).
+/// What: Script [finish_task missing `summary`, stop response]; assert the run
+/// completes via the D3 fallback, not the finish_task path, after two chat
+/// calls.
+/// Test: this test.
+#[tokio::test]
+async fn finish_task_missing_required_field_is_recoverable_not_terminal() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        finish_task_call_response("call-missing", r#"{"status": "completed"}"#),
+        stop_response("recovered from missing summary"),
+    ]));
+    let registry = registry_with_finish_task();
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default());
+
+    let out = agent
+        .run("system", "do the task")
+        .await
+        .expect("missing required field must not abort the loop");
+
+    assert_eq!(llm.calls(), 2);
+    assert_eq!(out.content, "recovered from missing summary");
+    assert_eq!(
+        out.summary, None,
+        "the D3 fallback path must not set a finish_task summary"
+    );
+}
+
+/// A `finish_task` call with a `status` value outside the declared enum is
+/// reported as a recoverable schema violation, not a panic, and does not
+/// terminate the loop.
+///
+/// Why: #2072's "schema-invalid enum value → recoverable error" acceptance
+/// criterion.
+/// What: Script [finish_task with `status: "in_progress"`, stop response];
+/// assert the run recovers via the D3 fallback after two chat calls.
+/// Test: this test.
+#[tokio::test]
+async fn finish_task_invalid_enum_value_is_recoverable_not_terminal() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        finish_task_call_response(
+            "call-bad-enum",
+            r#"{"status": "in_progress", "summary": "still working"}"#,
+        ),
+        stop_response("recovered from bad enum value"),
+    ]));
+    let registry = registry_with_finish_task();
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default());
+
+    let out = agent
+        .run("system", "do the task")
+        .await
+        .expect("invalid enum value must not abort the loop");
+
+    assert_eq!(llm.calls(), 2);
+    assert_eq!(out.content, "recovered from bad enum value");
+}
+
+/// A `finish_task` call carrying `changes` and test-count fields propagates
+/// all of them into the final rendered content.
+///
+/// Why: Guards the full-shape structured report end to end through the loop,
+/// not just the tool's own unit tests.
+/// What: Script a `finish_task` call with `changes` + `tests_run`/
+/// `tests_passed`; assert the rendered content contains every section.
+/// Test: this test.
+#[tokio::test]
+async fn finish_task_full_shape_propagates_into_output() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[finish_task_call_response(
+        "call-full",
+        r#"{"status": "completed", "summary": "shipped it", "changes": [{"file": "a.rs", "lines_added": 10, "lines_removed": 2}], "tests_run": 4, "tests_passed": 4}"#,
+    )]));
+    let registry = registry_with_finish_task();
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default());
+
+    let out = agent
+        .run("system", "do the task")
+        .await
+        .expect("full-shape finish_task should terminate the loop");
+
+    assert!(out.content.contains("Task completed: shipped it"));
+    assert!(out.content.contains("a.rs (+10/-2)"));
+    assert!(out.content.contains("Tests: 4/4 passed"));
 }
 
 /// Live OpenRouter test: trivial task through the real client + a real tool.

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -35,8 +35,8 @@ use crate::prompt::assemble_system_prompt;
 use crate::provider::resolve_model;
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
 use crate::tools::{
-    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, ReadFileTool, RunContext,
-    ToolRegistry, WriteFileTool,
+    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, FinishTaskTool,
+    ReadFileTool, RunContext, ToolRegistry, WriteFileTool,
 };
 
 pub use recorder::{RecordingLlmClient, SharedTranscript, TurnRecord};
@@ -117,12 +117,16 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
         Arc::clone(&transcript),
     );
 
-    // The PM's tool registry: just the delegate tool (the PM orchestrates; the
-    // engineer does the file work). Pre-flight validation uses the agents dir.
+    // The PM's tool registry: the delegate tool (the PM orchestrates; the
+    // engineer does the file work) plus `finish_task` (#2072) so the PM can
+    // signal completion with a structured report instead of relying solely on
+    // the implicit no-tool-call convention. Pre-flight validation uses the
+    // agents dir.
     let mut pm_registry = ToolRegistry::new();
     pm_registry.register(Arc::new(
         DelegateToAgentTool::new(engineer_runner).with_config_dir(params.agents_dir.clone()),
     ));
+    pm_registry.register(Arc::new(FinishTaskTool::new()));
 
     // The PM's loop uses a transcript-recording client tagged "pm".
     let pm_llm: Arc<dyn LlmClientTrait> = Arc::new(RecordingLlmClient::new(
@@ -211,11 +215,13 @@ fn build_engineer_runner(
 /// Builds the engineer's project-scoped tool registry for each delegation.
 ///
 /// Why: The engineer needs real file and shell tools that cannot escape the
-/// project root. This factory constructs `read_file`, `write_file`, `edit`, and
-/// `bash` all scoped to `self.project` so the engineer operates only inside the
-/// project working tree.
+/// project root, plus (#2072) `finish_task` so it can signal completion with a
+/// structured report. This factory constructs `read_file`, `write_file`,
+/// `edit`, and `bash` all scoped to `self.project`, so the engineer operates
+/// only inside the project working tree; `finish_task` has no filesystem
+/// footprint and needs no scoping.
 /// What: Implements `RegistryFactory::build`, returning an `Arc<ToolRegistry>`
-/// with the four tools; the runner then gates them by the engineer's
+/// with all five tools; the runner then gates them by the engineer's
 /// `tools.allowed`.
 /// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer` (the engineer's
 /// `write_file` actually writes into the project).
@@ -234,6 +240,7 @@ impl RegistryFactory for ProjectToolFactory {
             Some(self.project.clone()),
             Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),
         )));
+        reg.register(Arc::new(FinishTaskTool::new()));
         Arc::new(reg)
     }
 }

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -51,8 +51,8 @@ use crate::run_task::{
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
 use crate::session::{SessionRegistry, SessionStatus};
 use crate::tools::{
-    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, ReadFileTool, RunContext,
-    ToolRegistry, WriteFileTool,
+    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, FinishTaskTool,
+    ReadFileTool, RunContext, ToolRegistry, WriteFileTool,
 };
 
 use super::sink::SessionToolEventSink;
@@ -169,10 +169,13 @@ async fn run_and_record(
         Arc::clone(&cancel),
     );
 
+    // #2072: `finish_task` gives the PM a structured, schema-validated way to
+    // signal completion alongside the delegate tool.
     let mut pm_registry = ToolRegistry::new();
     pm_registry.register(Arc::new(
         DelegateToAgentTool::new(engineer_runner).with_config_dir(params.agents_dir.clone()),
     ));
+    pm_registry.register(Arc::new(FinishTaskTool::new()));
 
     let pm_llm: Arc<dyn LlmClientTrait> = Arc::new(RecordingLlmClient::new(
         Arc::clone(&llm),
@@ -267,6 +270,7 @@ impl RegistryFactory for ProjectToolFactory {
             Some(self.project.clone()),
             Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),
         )));
+        reg.register(Arc::new(FinishTaskTool::new()));
         Arc::new(reg)
     }
 }

--- a/crates/trusty-code/src/tools/finish_task.rs
+++ b/crates/trusty-code/src/tools/finish_task.rs
@@ -1,0 +1,449 @@
+//! `finish_task` tool — structured, schema-validated task completion (#2072, §5.8).
+//!
+//! Why: Before this tool, an `AgentLoop` only recognised completion implicitly —
+//! an assistant turn with NO tool calls (the D3 convention, see
+//! `agent_loop::run_inner`). That works, but it forces the model to convey
+//! "I'm done, here's what happened" as free prose the caller must re-parse.
+//! `finish_task` gives the model an explicit, schema-validated tool call for the
+//! same signal: a `status` enum, a `summary`, and optional structured `changes`/
+//! test-result fields. Malformed arguments (a missing required field, an invalid
+//! `status` enum value, syntactically broken JSON) flow through the EXACT SAME
+//! `llm::tool_call_extractor` plumbing #1023 built for every other tool —
+//! `ToolCallExtractor::parse_and_validate` → `schema::validate_args` — so no new
+//! validation or repair code is needed here; `finish_task` is just another
+//! `ToolExecutor` whose schema happens to describe a completion report.
+//! What: [`FinishTaskTool`] implements `ToolExecutor` with `name()` equal to
+//! [`FINISH_TASK_TOOL_NAME`]. `execute` deserialises the (already
+//! schema-validated) arguments into [`FinishTaskArgs`] and renders them via
+//! [`render_finish_summary`] into the tool's `ToolResult`. `agent_loop::run_inner`
+//! (#2072) recognises a successful `finish_task` dispatch and terminates the loop
+//! immediately, building the final `AgentOutput` from the SAME `FinishTaskArgs` /
+//! `render_finish_summary` this module exposes, instead of waiting for a later
+//! no-tool-call turn.
+//! Test: `finish_task::tests::*` — schema shape, valid execute, execute with
+//! changes/tests fields, and the defensive (should-be-unreachable given upstream
+//! schema validation) malformed-shape branch. `agent_loop::tests::*` covers the
+//! loop-termination integration end to end.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// The tool's registered/advertised name.
+///
+/// Why: Shared literal between the `ToolExecutor` impl and `agent_loop`'s
+/// finish-detection check, so the two can never drift.
+/// Test: `tests::name_matches_constant`.
+pub const FINISH_TASK_TOOL_NAME: &str = "finish_task";
+
+/// Completion status reported by the model.
+///
+/// Why: An enum (rather than a free-form string) lets the shared JSON-Schema
+/// `enum` validator (`llm::tool_call_extractor::schema::validate_args`) catch a
+/// hallucinated status value BEFORE it ever reaches `execute`.
+/// What: Mirrors the three values in the §5.8 schema, serialised/deserialised in
+/// `snake_case` to match the wire strings exactly.
+/// Test: `tests::status_display_and_roundtrip`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishStatus {
+    /// The task was completed successfully.
+    Completed,
+    /// The task could not be completed.
+    Failed,
+    /// The task was abandoned/cancelled before completion.
+    Cancelled,
+}
+
+impl std::fmt::Display for FinishStatus {
+    /// Why: `render_finish_summary` needs the lowercase wire form, not Rust's
+    /// `Debug` casing.
+    /// What: Renders the same lowercase strings the JSON schema's `enum` lists.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            FinishStatus::Completed => "completed",
+            FinishStatus::Failed => "failed",
+            FinishStatus::Cancelled => "cancelled",
+        };
+        write!(f, "{s}")
+    }
+}
+
+/// One entry of the optional `changes` array.
+///
+/// Why: Lets the model report which files it touched without the caller having
+/// to re-parse a diff out of prose. Every field is optional (including `file`)
+/// because the JSON schema does not mark any of them `required` inside the
+/// array item — a partially-populated entry must still deserialise rather than
+/// hard-failing `execute` for something the schema-level validator already let
+/// through.
+/// What: `file`, `lines_added`, `lines_removed` — all `Option`.
+/// Test: `tests::execute_with_changes_and_tests_renders_all_fields`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChangeEntry {
+    /// Path of the changed file, if reported.
+    pub file: Option<String>,
+    /// Lines added, if reported.
+    pub lines_added: Option<i64>,
+    /// Lines removed, if reported.
+    pub lines_removed: Option<i64>,
+}
+
+/// Parsed, validated arguments to a `finish_task` call.
+///
+/// Why: A typed shape is easier for both `execute` and `agent_loop`'s
+/// loop-termination path to work with than a raw `serde_json::Value`.
+/// What: `status` and `summary` are required (matching the schema's `required`
+/// array); `changes` defaults to empty when absent; `tests_run`/`tests_passed`
+/// are optional integers. `tests_run`/`tests_passed` are signed (`i64`) rather
+/// than unsigned so an out-of-range value the JSON-Schema-subset validator does
+/// not itself reject (it declares no `minimum`) still deserialises instead of
+/// hard-failing `execute` for a shape the schema layer already accepted.
+/// Test: `tests::execute_valid_args_renders_summary`,
+/// `tests::execute_with_changes_and_tests_renders_all_fields`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FinishTaskArgs {
+    /// Completion status.
+    pub status: FinishStatus,
+    /// Free-text summary of what was done.
+    pub summary: String,
+    /// Files/changes made, if reported.
+    #[serde(default)]
+    pub changes: Vec<ChangeEntry>,
+    /// Number of tests run, if reported.
+    pub tests_run: Option<i64>,
+    /// Number of tests that passed, if reported.
+    pub tests_passed: Option<i64>,
+}
+
+/// Render a [`FinishTaskArgs`] into human-readable summary text.
+///
+/// Why: Shared by [`FinishTaskTool::execute`] (so the tool's own `ToolResult`
+/// content is meaningful) AND `agent_loop::build_finish_output` (so the final
+/// `AgentOutput.content` on explicit finish reflects the SAME structured
+/// report) — one rendering, no drift between the two call sites.
+/// What: `"Task <status>: <summary>"` followed by an optional `Changes:` list
+/// and an optional `Tests:` line.
+/// Test: `tests::render_includes_status_and_summary`,
+/// `tests::execute_with_changes_and_tests_renders_all_fields`.
+pub fn render_finish_summary(args: &FinishTaskArgs) -> String {
+    let mut out = format!("Task {}: {}", args.status, args.summary);
+
+    if !args.changes.is_empty() {
+        out.push_str("\nChanges:");
+        for change in &args.changes {
+            let file = change.file.as_deref().unwrap_or("<unknown file>");
+            let added = change.lines_added.unwrap_or(0);
+            let removed = change.lines_removed.unwrap_or(0);
+            out.push_str(&format!("\n  - {file} (+{added}/-{removed})"));
+        }
+    }
+
+    match (args.tests_run, args.tests_passed) {
+        (Some(run), Some(passed)) => out.push_str(&format!("\nTests: {passed}/{run} passed")),
+        (Some(run), None) => out.push_str(&format!("\nTests run: {run}")),
+        (None, Some(passed)) => out.push_str(&format!("\nTests passed: {passed}")),
+        (None, None) => {}
+    }
+
+    out
+}
+
+/// `ToolExecutor` for the `finish_task` tool (#2072, §5.8).
+///
+/// Why: Gives the model an explicit, schema-validated way to signal completion
+/// instead of relying solely on the implicit no-tool-call convention.
+/// What: Stateless — `execute` only formats its (already schema-validated)
+/// arguments; it has no side effects on the filesystem, network, or process.
+/// Test: `tests::*`.
+#[derive(Debug, Default)]
+pub struct FinishTaskTool;
+
+impl FinishTaskTool {
+    /// Construct a new `FinishTaskTool`.
+    ///
+    /// Why: Matches the `Tool::new()` constructor convention every other tool in
+    /// this module follows, even though there is no state to inject.
+    /// What: Returns `Self`.
+    /// Test: `tests::execute_valid_args_renders_summary`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for FinishTaskTool {
+    fn name(&self) -> &str {
+        FINISH_TASK_TOOL_NAME
+    }
+
+    /// JSON schema for `finish_task`, matching §5.8 of the vision spec exactly.
+    ///
+    /// Why: This is the schema `ToolRegistry::schema_for` hands to
+    /// `llm::ToolCallExtractor` (#1023), which validates every call's arguments
+    /// against it before `execute` ever runs.
+    /// What: `status` (enum, required), `summary` (string, required), `changes`
+    /// (optional array of `{file, lines_added, lines_removed}`), `tests_run` /
+    /// `tests_passed` (optional integers). `additionalProperties: false` matches
+    /// this crate's convention for every other tool's schema.
+    /// Test: `tests::schema_has_required_fields_and_enum`.
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": FINISH_TASK_TOOL_NAME,
+                "description": "Signal task completion with a structured, machine-readable report. Call this exactly once when the task is finished (successfully, failed, or cancelled) instead of ending your turn with prose.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "status": {
+                            "type": "string",
+                            "enum": ["completed", "failed", "cancelled"],
+                            "description": "Outcome of the task."
+                        },
+                        "summary": {
+                            "type": "string",
+                            "description": "Free-text summary of what was done."
+                        },
+                        "changes": {
+                            "type": "array",
+                            "description": "Files changed, if any.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "file": { "type": "string" },
+                                    "lines_added": { "type": "integer" },
+                                    "lines_removed": { "type": "integer" }
+                                }
+                            }
+                        },
+                        "tests_run": {
+                            "type": "integer",
+                            "description": "Number of tests run, if applicable."
+                        },
+                        "tests_passed": {
+                            "type": "integer",
+                            "description": "Number of tests that passed, if applicable."
+                        }
+                    },
+                    "required": ["status", "summary"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    /// Render the (already schema-validated) arguments into a `ToolResult`.
+    ///
+    /// Why: By the time `execute` runs, `agent_loop::dispatch_all` has already
+    /// validated `args` against [`Self::schema`] via #1023's
+    /// `ToolCallExtractor::parse_and_validate` — a missing required field or an
+    /// invalid `status` enum value never reaches here at all; those are caught
+    /// upstream and fed back through the SAME recoverable-error + repair path
+    /// every other tool uses. The `Err` branch below is therefore a defensive
+    /// fallback (no `unwrap`/`panic`) for a shape the loose JSON-Schema-subset
+    /// validator accepted but strict `serde` deserialisation still rejects —
+    /// exercised directly in `tests::execute_bypassing_schema_validation_is_recoverable`.
+    /// What: `Ok` → `ToolResult::ok(render_finish_summary(&parsed))`. `Err` →
+    /// `ToolResult::err` naming the deserialisation failure so the model can
+    /// retry with a corrected call.
+    /// Test: `tests::execute_valid_args_renders_summary`,
+    /// `tests::execute_with_changes_and_tests_renders_all_fields`,
+    /// `tests::execute_bypassing_schema_validation_is_recoverable`.
+    async fn execute(&self, args: Value) -> ToolResult {
+        match serde_json::from_value::<FinishTaskArgs>(args) {
+            Ok(parsed) => ToolResult::ok(render_finish_summary(&parsed)),
+            Err(e) => ToolResult::err(format!(
+                "finish_task arguments did not match the expected shape ({e}). \
+                 'status' must be one of completed/failed/cancelled and 'summary' must be a string."
+            )),
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `FinishTaskTool::name()` matches the exported constant.
+    ///
+    /// Why: `agent_loop`'s finish-detection check compares against
+    /// `FINISH_TASK_TOOL_NAME`; a drift here would silently break termination.
+    /// What: Trivial equality assertion.
+    /// Test: this test.
+    #[test]
+    fn name_matches_constant() {
+        let tool = FinishTaskTool::new();
+        assert_eq!(tool.name(), FINISH_TASK_TOOL_NAME);
+        assert_eq!(FINISH_TASK_TOOL_NAME, "finish_task");
+    }
+
+    /// The schema declares the exact `required` set and `status` enum from §5.8.
+    ///
+    /// Why: Guards the schema contract the extractor's generic validator relies
+    /// on — a drift here would silently change what's rejected upstream.
+    /// What: Assert `required == ["status", "summary"]` and the enum values.
+    /// Test: this test.
+    #[test]
+    fn schema_has_required_fields_and_enum() {
+        let schema = FinishTaskTool::new().schema();
+        let params = &schema["function"]["parameters"];
+        let required: Vec<&str> = params["required"]
+            .as_array()
+            .expect("required array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(required, vec!["status", "summary"]);
+
+        let enum_values: Vec<&str> = params["properties"]["status"]["enum"]
+            .as_array()
+            .expect("enum array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(enum_values, vec!["completed", "failed", "cancelled"]);
+
+        assert_eq!(params["additionalProperties"], json!(false));
+    }
+
+    /// `FinishStatus` renders its lowercase wire form via `Display`.
+    ///
+    /// Why: `render_finish_summary` depends on this exact casing.
+    /// What: Format each variant, assert the lowercase string.
+    /// Test: this test.
+    #[test]
+    fn status_display_and_roundtrip() {
+        assert_eq!(FinishStatus::Completed.to_string(), "completed");
+        assert_eq!(FinishStatus::Failed.to_string(), "failed");
+        assert_eq!(FinishStatus::Cancelled.to_string(), "cancelled");
+    }
+
+    /// `render_finish_summary` includes the status and summary text.
+    ///
+    /// Why: Guard the minimal happy-path rendering before layering on optional
+    /// fields.
+    /// What: A `FinishTaskArgs` with no changes/tests; assert the rendered text.
+    /// Test: this test.
+    #[test]
+    fn render_includes_status_and_summary() {
+        let args = FinishTaskArgs {
+            status: FinishStatus::Completed,
+            summary: "did the thing".to_string(),
+            changes: vec![],
+            tests_run: None,
+            tests_passed: None,
+        };
+        let rendered = render_finish_summary(&args);
+        assert_eq!(rendered, "Task completed: did the thing");
+    }
+
+    /// A valid, minimal `finish_task` call executes and renders the summary.
+    ///
+    /// Why: The primary happy path — only the two required fields present.
+    /// What: `execute({"status": "completed", "summary": "..."})`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn execute_valid_args_renders_summary() {
+        let tool = FinishTaskTool::new();
+        let result = tool
+            .execute(json!({"status": "completed", "summary": "wrote the feature"}))
+            .await;
+        assert!(!result.is_error());
+        assert_eq!(result.content(), "Task completed: wrote the feature");
+    }
+
+    /// A call with `changes` and both test-count fields renders every section.
+    ///
+    /// Why: Guards the full-shape rendering path, not just the minimal one.
+    /// What: `execute` with two changes entries and matching test counts.
+    /// Test: this test.
+    #[tokio::test]
+    async fn execute_with_changes_and_tests_renders_all_fields() {
+        let tool = FinishTaskTool::new();
+        let result = tool
+            .execute(json!({
+                "status": "completed",
+                "summary": "added the widget",
+                "changes": [
+                    {"file": "src/widget.rs", "lines_added": 42, "lines_removed": 3},
+                    {"file": "src/lib.rs", "lines_added": 1, "lines_removed": 0}
+                ],
+                "tests_run": 12,
+                "tests_passed": 12
+            }))
+            .await;
+        assert!(!result.is_error());
+        let content = result.content();
+        assert!(content.contains("Task completed: added the widget"));
+        assert!(content.contains("src/widget.rs (+42/-3)"));
+        assert!(content.contains("src/lib.rs (+1/-0)"));
+        assert!(content.contains("Tests: 12/12 passed"));
+    }
+
+    /// A `failed` status with only `tests_run` (no `tests_passed`) renders that
+    /// single line, not the combined `x/y passed` form.
+    ///
+    /// Why: Guards the partial-test-info branch of the match in
+    /// `render_finish_summary`.
+    /// What: `execute` with `tests_run` only.
+    /// Test: this test.
+    #[tokio::test]
+    async fn execute_with_only_tests_run_renders_run_count() {
+        let tool = FinishTaskTool::new();
+        let result = tool
+            .execute(json!({
+                "status": "failed",
+                "summary": "tests did not all pass",
+                "tests_run": 5
+            }))
+            .await;
+        assert!(!result.is_error());
+        assert!(result.content().contains("Tests run: 5"));
+        assert!(!result.content().contains("passed\n"));
+    }
+
+    /// Arguments that bypass schema validation (e.g. called directly, as in
+    /// this test) but do not match `FinishTaskArgs`'s shape return a
+    /// recoverable error, never a panic.
+    ///
+    /// Why: `execute` must never `unwrap`/panic on attacker- or model-controlled
+    /// input, even though in the real dispatch path this shape would already
+    /// have been rejected by `schema::validate_args` before reaching here.
+    /// What: `execute({"status": "completed"})` — missing the required
+    /// `summary` field that `FinishTaskArgs` (unlike the schema's own leniency
+    /// elsewhere) requires as non-optional.
+    /// Test: this test.
+    #[tokio::test]
+    async fn execute_bypassing_schema_validation_is_recoverable() {
+        let tool = FinishTaskTool::new();
+        let result = tool.execute(json!({"status": "completed"})).await;
+        assert!(result.is_error());
+        assert!(!result.is_fatal(), "must be recoverable, not fatal");
+        assert!(
+            result
+                .content()
+                .contains("did not match the expected shape")
+        );
+    }
+
+    /// An unrecognised `status` value bypassing schema validation also reports
+    /// a recoverable error rather than panicking.
+    ///
+    /// Why: Guards the enum-deserialisation failure path specifically.
+    /// What: `execute({"status": "in_progress", "summary": "..."})`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn execute_unknown_status_bypassing_schema_validation_is_recoverable() {
+        let tool = FinishTaskTool::new();
+        let result = tool
+            .execute(json!({"status": "in_progress", "summary": "still going"}))
+            .await;
+        assert!(result.is_error());
+        assert!(!result.is_fatal());
+    }
+}

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -5,13 +5,14 @@
 //! touching the core orchestration code. This module is the assembly point.
 //! What: Re-exports `ToolExecutor`, `AgentRunner`, `RunContext`, `AgentOutput`,
 //! `SearchProvider`, `SearchResult`, `SkillResolver`, and `ToolResult` from
-//! `traits`; `ToolRegistry` from `registry`; and `DelegateToAgentTool` from
-//! `delegate`.
+//! `traits`; `ToolRegistry` from `registry`; `DelegateToAgentTool` from
+//! `delegate`; and `FinishTaskTool` (#2072) from `finish_task`.
 //! Test: Unit tests live in each submodule; integration tests use
 //! `DelegateToAgentTool` with a `MockAgentRunner`.
 
 pub mod bash;
 pub mod delegate;
+pub mod finish_task;
 pub mod fs;
 pub mod registry;
 pub mod traits;
@@ -21,6 +22,9 @@ pub mod traits;
 pub use bash::BashTool;
 #[allow(unused_imports)]
 pub use delegate::DelegateToAgentTool;
+pub use finish_task::{
+    FINISH_TASK_TOOL_NAME, FinishTaskArgs, FinishTaskTool, render_finish_summary,
+};
 pub use fs::{EditTool, ReadFileTool, WriteFileTool};
 pub use registry::ToolRegistry;
 pub use traits::{


### PR DESCRIPTION
M2 (Tool Calling) P1B-5 — adds the `finish_task` Tier-1 tool that formalizes task completion as an explicit tool call (previously an implicit no-tool-call signal).

Args: `status` (enum, required), `summary` (required), optional `changes`/`tests_run`/`tests_passed`. Validation reuses #1023's `ToolCallExtractor::parse_and_validate` → `schema::validate_args` (no bespoke validator): malformed JSON / missing required field / invalid enum are all caught as recoverable errors that trigger the corrective-message repair path before `execute` runs. On a successful `finish_task` call the agent loop terminates immediately with a structured `AgentOutput` (summary + rendered changes/test counts). The D3 no-tool-call fallback finish is preserved. Registered in both the PM and engineer (ProjectToolFactory) registries.

QA: APPROVE (independent worktree at e361f880) — build 0 warnings, 527 unit + 16 integration tests pass, clippy clean, fmt clean, line-cap 0 violations (finish_task.rs 449 lines), trusty-agents unaffected. Full test matrix verified (explicit-finish, malformed→repair→terminate, missing-field recoverable, invalid-enum recoverable, full-shape propagation), zero library unwrap().

Deferred (scoped follow-up): `finish_task` is not yet exempt from `tools.allowed` gating (always-available) — gated like any other tool today; revisit per spec if it must bypass the allowlist.

Closes #2072