### PR TITLE
feat(trusty-code): per-model edit-format selection (SEARCH/REPLACE / unified-diff / whole-file) (#2068)

### DIFF
--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -231,11 +231,17 @@ struct ProjectToolFactory {
 
 #[async_trait]
 impl RegistryFactory for ProjectToolFactory {
-    async fn build(&self, _agent: &AgentConfig, _ctx: &RunContext) -> Arc<ToolRegistry> {
+    async fn build(&self, agent: &AgentConfig, ctx: &RunContext) -> Arc<ToolRegistry> {
+        // #2068: resolve the engineer's model slug so `EditTool` can pick its
+        // per-model edit-format fallback order (see `resolve_model`'s own
+        // precedence docs — RunContext override > agent config > default).
+        let model_slug = resolve_model(agent, Some(ctx));
         let mut reg = ToolRegistry::new();
         reg.register(Arc::new(ReadFileTool::new(&self.project)));
         reg.register(Arc::new(WriteFileTool::new(&self.project)));
-        reg.register(Arc::new(EditTool::new(&self.project)));
+        reg.register(Arc::new(
+            EditTool::new(&self.project).with_model_slug(model_slug),
+        ));
         reg.register(Arc::new(BashTool::new(
             Some(self.project.clone()),
             Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -261,11 +261,17 @@ struct ProjectToolFactory {
 
 #[async_trait]
 impl RegistryFactory for ProjectToolFactory {
-    async fn build(&self, _agent: &AgentConfig, _ctx: &RunContext) -> Arc<ToolRegistry> {
+    async fn build(&self, agent: &AgentConfig, ctx: &RunContext) -> Arc<ToolRegistry> {
+        // #2068: resolve the engineer's model slug so `EditTool` can pick its
+        // per-model edit-format fallback order (mirrors
+        // `run_task::ProjectToolFactory::build`, which is private to that module).
+        let model_slug = resolve_model(agent, Some(ctx));
         let mut reg = ToolRegistry::new();
         reg.register(Arc::new(ReadFileTool::new(&self.project)));
         reg.register(Arc::new(WriteFileTool::new(&self.project)));
-        reg.register(Arc::new(EditTool::new(&self.project)));
+        reg.register(Arc::new(
+            EditTool::new(&self.project).with_model_slug(model_slug),
+        ));
         reg.register(Arc::new(BashTool::new(
             Some(self.project.clone()),
             Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),

--- a/crates/trusty-code/src/tools/fs/edit.rs
+++ b/crates/trusty-code/src/tools/fs/edit.rs
@@ -1,62 +1,88 @@
-//! `edit` tool — exact-unique string replacement within a file.
+//! `edit` tool — per-model edit-format selection (#2068).
 //!
 //! Why: Agents that iteratively refine code need a surgical replace-in-place
-//! primitive that is safer than re-writing the whole file from memory. The
-//! "unique match" constraint mirrors the Claude Code `Edit` tool contract:
-//! if `old_string` appears more than once the replacement is ambiguous, so the
-//! agent must provide more context; if it appears zero times the edit would be
-//! a silent no-op.
-//! What: `EditTool` reads the file, counts occurrences of `old_string`, replaces
-//! exactly one occurrence (error on 0 or >1), and writes the modified content
-//! back. All paths are scoped to the working directory.
-//! Test: See `#[cfg(test)]` below — covers unique replace, zero-match error,
-//! multiple-match error, and path traversal.
+//! primitive that is safer than re-writing the whole file from memory. Before
+//! #2068 the only supported wire format was exact-unique SEARCH/REPLACE,
+//! mirroring the Claude Code `Edit` tool contract. Aider's A/B data shows edit
+//! success rate varies by model family and format (see
+//! `tools::fs::edit_format`'s module docs for the matrix): some models
+//! reliably reproduce an exact substring, others do much better with a
+//! unified diff or a full-file rewrite. `EditTool` now accepts any of the
+//! three formats in one call and applies them in the calling model's
+//! preferred order via `edit_format::select_and_apply`.
+//! What: `EditTool` reads the file, builds an `EditPayload` for each format
+//! present in the tool-call arguments (`old_string`+`new_string`, `diff`, or
+//! `content`), and delegates to `edit_format::select_and_apply` to pick and
+//! apply the best-fit format, then writes the result back. All paths are
+//! scoped to the working directory.
+//! Test: See `#[cfg(test)]` below — covers each format, zero/ambiguous
+//! SEARCH/REPLACE errors, malformed-diff errors, and path traversal.
 
 use std::path::PathBuf;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+use crate::tools::fs::edit_format::{EditFormat, EditPayload, select_and_apply};
 use crate::tools::fs::{FsError, scoped_path};
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
-/// `ToolExecutor` that performs an exact-unique string replacement in a file.
+/// `ToolExecutor` that applies an edit using whichever wire format(s) the
+/// caller supplied, in the calling model's preferred order.
 ///
 /// Why: Surgical in-place edits are the primary mutation primitive for coding
-/// agents. The unique-match contract prevents silent partial-writes.
-/// What: Implements `ToolExecutor` with `name = "edit"`. Reads the file, counts
-/// `old_string` occurrences, errors on 0 or >1, replaces the single match,
-/// and writes the result back.
+/// agents. Supporting all three #2068 formats behind one tool keeps the
+/// registry/schema surface simple while letting the caller (or a future
+/// repair loop) hand the model whichever format it is more likely to succeed
+/// with.
+/// What: Implements `ToolExecutor` with `name = "edit"`. Reads the file,
+/// builds the present `EditPayload`s, calls `edit_format::select_and_apply`
+/// with `self.model_slug`, and writes the result back.
 /// Test: `cargo test -p trusty-code -- tools::fs::edit`.
 pub struct EditTool {
     working_dir: PathBuf,
+    model_slug: Option<String>,
 }
 
 impl EditTool {
     /// Construct a new `EditTool` scoped to `working_dir`.
     ///
     /// Why: The working directory is the security boundary set at construction.
-    /// What: Stores `working_dir`.
+    /// What: Stores `working_dir`. `model_slug` defaults to `None`, which
+    /// selects the catch-all format order (see `edit_format::format_order_for`);
+    /// this has no effect on a call that supplies only one format.
     /// Test: `edit_replaces_unique_match`, et al.
     pub fn new(working_dir: impl Into<PathBuf>) -> Self {
         Self {
             working_dir: working_dir.into(),
+            model_slug: None,
         }
     }
 
-    /// Perform the edit: read file, count occurrences, replace, write back.
+    /// Set the model slug used to look up the per-model format fallback order.
     ///
-    /// Why: Centralises the IO + matching logic so `execute` stays clean.
-    /// What: Returns `Ok(())` on success. Returns `FsError::EditNotFound` when
-    /// `old_string` is absent. Returns `FsError::EditAmbiguous` when it appears
-    /// more than once.
+    /// Why: The registry factory resolves the calling agent's model slug
+    /// (`provider::resolve_model`) once per delegation; threading it through
+    /// here lets `edit_format::select_and_apply` pick the best-fit format when
+    /// a tool call supplies more than one representation of the same edit.
+    /// What: Stores `slug` for use in `execute`.
+    /// Test: `edit_falls_back_to_whole_file_when_search_replace_fails`.
+    pub fn with_model_slug(mut self, slug: impl Into<String>) -> Self {
+        self.model_slug = Some(slug.into());
+        self
+    }
+
+    /// Perform the edit: read the file, apply the best-fit payload, write back.
+    ///
+    /// Why: Centralises the IO so `execute` stays focused on argument parsing.
+    /// What: Returns the `EditFormat` that was actually applied. Errors
+    /// propagate from `scoped_path`, file IO, or `edit_format::select_and_apply`.
     /// Test: All `EditTool` unit tests exercise this path.
     fn edit_inner(
         &self,
         path: &std::path::Path,
-        old_string: &str,
-        new_string: &str,
-    ) -> Result<(), FsError> {
+        payloads: &[EditPayload],
+    ) -> Result<EditFormat, FsError> {
         let scoped = scoped_path(&self.working_dir, path)?;
 
         let content = std::fs::read_to_string(&scoped).map_err(|e| {
@@ -67,22 +93,10 @@ impl EditTool {
             }
         })?;
 
-        let count = content.matches(old_string).count();
-
-        match count {
-            0 => return Err(FsError::EditNotFound { path: scoped }),
-            1 => {}
-            n => {
-                return Err(FsError::EditAmbiguous {
-                    path: scoped,
-                    count: n,
-                });
-            }
-        }
-
-        let updated = content.replacen(old_string, new_string, 1);
+        let model_slug = self.model_slug.as_deref().unwrap_or("");
+        let (updated, format) = select_and_apply(model_slug, &content, &scoped, payloads)?;
         std::fs::write(&scoped, updated).map_err(|e| FsError::io(&scoped, e))?;
-        Ok(())
+        Ok(format)
     }
 }
 
@@ -94,15 +108,20 @@ impl ToolExecutor for EditTool {
 
     /// OpenAI function-call schema for `edit`.
     ///
-    /// Why: The LLM uses this schema to construct its tool call.
-    /// What: JSON object with `path`, `old_string`, and `new_string` (all required).
-    /// Test: `schema_has_required_fields`.
+    /// Why: The LLM uses this schema to construct its tool call. `path` is the
+    /// only unconditionally required field (#2068); exactly one edit format's
+    /// fields must also be present, validated at execution time since JSON
+    /// Schema cannot express "one of these three field groups" cleanly here.
+    /// What: JSON object with `path` plus the three optional per-format field
+    /// groups: `old_string`+`new_string` (SEARCH/REPLACE), `diff`
+    /// (unified-diff), `content` (whole-file).
+    /// Test: `schema_requires_only_path`.
     fn schema(&self) -> Value {
         json!({
             "type": "function",
             "function": {
                 "name": "edit",
-                "description": "Replace an exact unique occurrence of old_string with new_string in a file. Fails if old_string appears zero or more than once — provide more context to disambiguate. The path must be inside the working directory.",
+                "description": "Edit a file using one of three formats: (1) SEARCH/REPLACE — provide old_string+new_string; old_string must appear exactly once in the file (cheapest, preferred when you can reproduce it exactly); (2) unified-diff — provide diff as one or more '@@ -l,s +l,s @@' hunks (use when context is easier to express as a diff than an exact substring); (3) whole-file — provide content as the file's complete new contents (most robust, most expensive; use as a last resort). Provide exactly one format's fields. The path must be inside the working directory.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -112,14 +131,22 @@ impl ToolExecutor for EditTool {
                         },
                         "old_string": {
                             "type": "string",
-                            "description": "The exact string to replace. Must appear exactly once in the file."
+                            "description": "SEARCH/REPLACE format: the exact string to replace. Must appear exactly once in the file. Requires new_string."
                         },
                         "new_string": {
                             "type": "string",
-                            "description": "The replacement string."
+                            "description": "SEARCH/REPLACE format: the replacement string. Requires old_string."
+                        },
+                        "diff": {
+                            "type": "string",
+                            "description": "Unified-diff format: one or more '@@ -l,s +l,s @@' hunks to apply against the file's current content."
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Whole-file format: the complete new content of the file."
                         }
                     },
-                    "required": ["path", "old_string", "new_string"],
+                    "required": ["path"],
                     "additionalProperties": false
                 }
             }
@@ -128,23 +155,53 @@ impl ToolExecutor for EditTool {
 
     /// Execute an `edit` tool call.
     ///
-    /// Why: Applies an exact-unique string replacement within the working directory.
-    /// What: Parses `{path, old_string, new_string}` from `args`, calls
-    /// `edit_inner`, and converts the result into a `ToolResult`.
-    /// Test: `edit_replaces_unique_match`, `edit_errors_on_zero_matches`, etc.
+    /// Why: Applies whichever edit format(s) the caller supplied, in the
+    /// model's preferred order.
+    /// What: Builds an `EditPayload` for each format present in `args`
+    /// (`old_string`+`new_string`, `diff`, `content`), errors if none are
+    /// present or `old_string`/`new_string` are only partially supplied, then
+    /// calls `edit_inner` and converts the result into a `ToolResult`.
+    /// Test: `edit_replaces_unique_match`, `edit_errors_on_zero_matches`,
+    /// `edit_applies_unified_diff`, `edit_applies_whole_file`, etc.
     async fn execute(&self, args: Value) -> ToolResult {
         let Some(path_str) = args.get("path").and_then(Value::as_str) else {
             return ToolResult::err("edit: missing required argument 'path'");
         };
-        let Some(old_string) = args.get("old_string").and_then(Value::as_str) else {
-            return ToolResult::err("edit: missing required argument 'old_string'");
-        };
-        let Some(new_string) = args.get("new_string").and_then(Value::as_str) else {
-            return ToolResult::err("edit: missing required argument 'new_string'");
-        };
 
-        match self.edit_inner(std::path::Path::new(path_str), old_string, new_string) {
-            Ok(()) => ToolResult::ok(format!("edited {path_str}")),
+        let mut payloads = Vec::new();
+        match (
+            args.get("old_string").and_then(Value::as_str),
+            args.get("new_string").and_then(Value::as_str),
+        ) {
+            (Some(old_string), Some(new_string)) => payloads.push(EditPayload::SearchReplace {
+                old_string: old_string.to_string(),
+                new_string: new_string.to_string(),
+            }),
+            (None, None) => {}
+            _ => {
+                return ToolResult::err(
+                    "edit: 'old_string' and 'new_string' must be provided together",
+                );
+            }
+        }
+        if let Some(diff) = args.get("diff").and_then(Value::as_str) {
+            payloads.push(EditPayload::UnifiedDiff {
+                diff: diff.to_string(),
+            });
+        }
+        if let Some(content) = args.get("content").and_then(Value::as_str) {
+            payloads.push(EditPayload::WholeFile {
+                content: content.to_string(),
+            });
+        }
+        if payloads.is_empty() {
+            return ToolResult::err(
+                "edit: must provide either 'old_string'+'new_string', 'diff', or 'content'",
+            );
+        }
+
+        match self.edit_inner(std::path::Path::new(path_str), &payloads) {
+            Ok(format) => ToolResult::ok(format!("edited {path_str} ({format})")),
             Err(e) => ToolResult::err(e.to_string()),
         }
     }
@@ -264,13 +321,19 @@ mod tests {
         );
     }
 
-    /// The schema lists `path`, `old_string`, and `new_string` as required.
+    /// The schema requires only `path`; all three edit-format field groups are
+    /// optional at the schema level (validated at execution time instead).
     ///
-    /// Why: The LLM must always provide all three arguments.
-    /// What: Parses `schema()` and checks all three appear in `required`.
+    /// Why: #2068 lets a call supply SEARCH/REPLACE, unified-diff, or
+    /// whole-file fields — JSON Schema cannot cleanly express "exactly one of
+    /// these three field groups", so only the universally-required `path` is
+    /// listed, and every format's properties are documented but optional.
+    /// What: Parses `schema()` and checks `required == ["path"]`, and that all
+    /// five properties (`path`, `old_string`, `new_string`, `diff`, `content`)
+    /// are present.
     /// Test: This test.
     #[test]
-    fn schema_has_required_fields() {
+    fn schema_requires_only_path() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let tool = make_tool(&tmp);
         let schema = tool.schema();
@@ -278,8 +341,121 @@ mod tests {
             .as_array()
             .expect("required array");
         let names: Vec<&str> = required.iter().filter_map(Value::as_str).collect();
-        assert!(names.contains(&"path"), "must require 'path'");
-        assert!(names.contains(&"old_string"), "must require 'old_string'");
-        assert!(names.contains(&"new_string"), "must require 'new_string'");
+        assert_eq!(names, vec!["path"], "only 'path' must be required");
+
+        let properties = schema["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("properties object");
+        for key in ["path", "old_string", "new_string", "diff", "content"] {
+            assert!(properties.contains_key(key), "missing property '{key}'");
+        }
+    }
+
+    /// `edit` applies a unified-diff payload when `diff` is supplied.
+    ///
+    /// Why: Guard the second #2068 format end-to-end through `execute`.
+    /// What: Write a two-line file, execute `edit` with a `diff` argument
+    /// replacing one line, and assert the file was patched.
+    /// Test: This test.
+    #[tokio::test]
+    async fn edit_applies_unified_diff() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("f.py"), "line1\nline2\n").expect("write");
+        let tool = make_tool(&tmp);
+        let result = tool
+            .execute(json!({
+                "path": "f.py",
+                "diff": "@@ -2,1 +2,1 @@\n-line2\n+line2-changed\n"
+            }))
+            .await;
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        assert!(result.content().contains("unified_diff"));
+        let updated = fs::read_to_string(tmp.path().join("f.py")).expect("read");
+        assert_eq!(updated, "line1\nline2-changed\n");
+    }
+
+    /// `edit` applies a whole-file payload when `content` is supplied.
+    ///
+    /// Why: Guard the third #2068 format (last-resort, most-robust) end-to-end.
+    /// What: Write a file, execute `edit` with a `content` argument, and
+    /// assert the file's entire content was replaced.
+    /// Test: This test.
+    #[tokio::test]
+    async fn edit_applies_whole_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("f.py"), "old content\n").expect("write");
+        let tool = make_tool(&tmp);
+        let result = tool
+            .execute(json!({
+                "path": "f.py",
+                "content": "brand new file\n"
+            }))
+            .await;
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        assert!(result.content().contains("whole_file"));
+        let updated = fs::read_to_string(tmp.path().join("f.py")).expect("read");
+        assert_eq!(updated, "brand new file\n");
+    }
+
+    /// `edit` errors when `old_string` is supplied without `new_string`.
+    ///
+    /// Why: A half-supplied SEARCH/REPLACE pair is an unambiguous caller
+    /// mistake and must be rejected before touching the filesystem.
+    /// What: `execute` with only `old_string` set must return a recoverable error.
+    /// Test: This test.
+    #[tokio::test]
+    async fn edit_errors_on_partial_search_replace_pair() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("f.py"), "x = 1\n").expect("write");
+        let tool = make_tool(&tmp);
+        let result = tool
+            .execute(json!({"path": "f.py", "old_string": "x = 1"}))
+            .await;
+        assert!(result.is_error());
+        assert!(result.content().contains("together"));
+    }
+
+    /// `edit` errors when none of the three format field groups are supplied.
+    ///
+    /// Why: Nothing to apply is a caller mistake, not a silent no-op.
+    /// What: `execute` with only `path` must return a recoverable error.
+    /// Test: This test.
+    #[tokio::test]
+    async fn edit_errors_when_no_format_supplied() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("f.py"), "x = 1\n").expect("write");
+        let tool = make_tool(&tmp);
+        let result = tool.execute(json!({"path": "f.py"})).await;
+        assert!(result.is_error());
+        assert!(result.content().contains("must provide"));
+    }
+
+    /// With a model slug set, a failing SEARCH/REPLACE payload falls back to a
+    /// concurrently-supplied whole-file payload within the same call.
+    ///
+    /// Why: This is the #2068 fallback-ordering acceptance criterion exercised
+    /// through the actual `ToolExecutor::execute` entry point, not just the
+    /// underlying `edit_format::select_and_apply` unit tests.
+    /// What: Give a flagship model slug (SEARCH/REPLACE-first order), a
+    /// non-matching `old_string`/`new_string` pair, and a `content` fallback;
+    /// assert the whole-file fallback was applied.
+    /// Test: This test.
+    #[tokio::test]
+    async fn edit_falls_back_to_whole_file_when_search_replace_fails() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("f.py"), "original\n").expect("write");
+        let tool = EditTool::new(tmp.path()).with_model_slug("anthropic/claude-opus-4-5");
+        let result = tool
+            .execute(json!({
+                "path": "f.py",
+                "old_string": "not-present-in-file",
+                "new_string": "x",
+                "content": "fallback content\n"
+            }))
+            .await;
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        assert!(result.content().contains("whole_file"));
+        let updated = fs::read_to_string(tmp.path().join("f.py")).expect("read");
+        assert_eq!(updated, "fallback content\n");
     }
 }

--- a/crates/trusty-code/src/tools/fs/edit_format/diff.rs
+++ b/crates/trusty-code/src/tools/fs/edit_format/diff.rs
@@ -1,0 +1,279 @@
+//! Minimal unified-diff hunk parser + applier for the `unified_diff` edit format.
+//!
+//! Why: #2068's fallback format between SEARCH/REPLACE and whole-file
+//! replacement is a unified diff — the format models most often produce when
+//! prompted for a "diff" (it is ubiquitous in code-training corpora). No
+//! diff-apply crate is already a workspace dependency (see `Cargo.toml`); a
+//! hand-rolled applier is small enough to keep in-tree rather than adding one
+//! for a single call site.
+//! What: [`apply_unified_diff`] parses one or more `@@ -l,s +l,s @@` hunks
+//! (skipping optional `---`/`+++`/`diff --git`/`index` header lines) and
+//! applies them against the file's current content, verifying every context
+//! and removal line matches before committing the hunk.
+//! Test: `tests::*` cover single-hunk, multi-hunk, mismatched-context, and
+//! unparsable-header cases.
+
+use std::path::Path;
+
+use crate::tools::fs::FsError;
+
+/// Apply a unified diff (`diff_text`) against `content`, returning the patched
+/// content.
+///
+/// Why: Central entry point used by `edit_format::apply_payload`.
+/// What: Parses hunks from `diff_text`, applies each in order against
+/// `content`'s lines, and returns the full patched text (preserving whether
+/// the original had a trailing newline). Returns `FsError::DiffHunkHeader` if
+/// no valid hunk header is found, or `FsError::DiffContextMismatch` if a
+/// context/removal line does not match the file at the expected position.
+/// Test: `tests::apply_single_hunk`, `tests::apply_multiple_hunks`,
+/// `tests::apply_context_mismatch_errors`, `tests::apply_no_hunks_errors`.
+pub(crate) fn apply_unified_diff(
+    content: &str,
+    diff_text: &str,
+    path: &Path,
+) -> Result<String, FsError> {
+    let hunks = parse_hunks(diff_text)?;
+    if hunks.is_empty() {
+        return Err(FsError::DiffHunkHeader {
+            reason: "no '@@ -l,s +l,s @@' hunk header found in diff".to_string(),
+        });
+    }
+
+    let had_trailing_newline = content.ends_with('\n');
+    let orig_lines: Vec<&str> = content.lines().collect();
+    let mut out: Vec<String> = Vec::with_capacity(orig_lines.len());
+    let mut cursor = 0usize; // 0-based index into orig_lines already emitted/consumed
+
+    for hunk in &hunks {
+        let start = hunk.old_start.saturating_sub(1); // 0-based
+        if start < cursor || start > orig_lines.len() {
+            return Err(FsError::DiffContextMismatch {
+                path: path.to_path_buf(),
+                line: hunk.old_start,
+                reason: "hunk start is out of order or past end of file".to_string(),
+            });
+        }
+        // Copy unchanged lines up to the hunk's start.
+        out.extend(orig_lines[cursor..start].iter().map(|s| s.to_string()));
+        cursor = start;
+
+        for line in &hunk.lines {
+            match line {
+                HunkLine::Context(text) => {
+                    verify_line(orig_lines.get(cursor), text, hunk.old_start, path)?;
+                    out.push(text.clone());
+                    cursor += 1;
+                }
+                HunkLine::Removal(text) => {
+                    verify_line(orig_lines.get(cursor), text, hunk.old_start, path)?;
+                    cursor += 1;
+                }
+                HunkLine::Addition(text) => {
+                    out.push(text.clone());
+                }
+            }
+        }
+    }
+    out.extend(orig_lines[cursor..].iter().map(|s| s.to_string()));
+
+    let mut result = out.join("\n");
+    if had_trailing_newline {
+        result.push('\n');
+    }
+    Ok(result)
+}
+
+/// Verify that `actual` (the file's current line at `cursor`) equals `expected`.
+fn verify_line(
+    actual: Option<&&str>,
+    expected: &str,
+    hunk_line: usize,
+    path: &Path,
+) -> Result<(), FsError> {
+    match actual {
+        Some(a) if *a == expected => Ok(()),
+        Some(a) => Err(FsError::DiffContextMismatch {
+            path: path.to_path_buf(),
+            line: hunk_line,
+            reason: format!("expected {expected:?}, found {a:?}"),
+        }),
+        None => Err(FsError::DiffContextMismatch {
+            path: path.to_path_buf(),
+            line: hunk_line,
+            reason: format!("expected {expected:?}, found end of file"),
+        }),
+    }
+}
+
+/// One line inside a hunk body, tagged by its unified-diff prefix character.
+#[derive(Debug, Clone, PartialEq)]
+enum HunkLine {
+    Context(String),
+    Removal(String),
+    Addition(String),
+}
+
+/// A single parsed `@@ -old_start,old_len +new_start,new_len @@` hunk.
+#[derive(Debug, Clone, PartialEq)]
+struct Hunk {
+    old_start: usize,
+    lines: Vec<HunkLine>,
+}
+
+/// Parse every hunk out of a unified-diff text, skipping file-header lines.
+fn parse_hunks(diff_text: &str) -> Result<Vec<Hunk>, FsError> {
+    let mut hunks = Vec::new();
+    let mut current: Option<Hunk> = None;
+
+    for raw_line in diff_text.lines() {
+        if let Some(header) = raw_line.strip_prefix("@@ ") {
+            if let Some(hunk) = current.take() {
+                hunks.push(hunk);
+            }
+            let old_start = parse_hunk_header(header)?;
+            current = Some(Hunk {
+                old_start,
+                lines: Vec::new(),
+            });
+            continue;
+        }
+
+        // Skip standard file-header noise that may precede the first hunk.
+        if current.is_none()
+            && (raw_line.starts_with("--- ")
+                || raw_line.starts_with("+++ ")
+                || raw_line.starts_with("diff --git")
+                || raw_line.starts_with("index "))
+        {
+            continue;
+        }
+
+        let Some(hunk) = current.as_mut() else {
+            continue; // Ignore stray text before any hunk header.
+        };
+
+        // Lenient: a truly empty line inside a hunk body is a blank context line.
+        if raw_line.is_empty() {
+            hunk.lines.push(HunkLine::Context(String::new()));
+            continue;
+        }
+        match raw_line.as_bytes()[0] {
+            b' ' => hunk
+                .lines
+                .push(HunkLine::Context(raw_line[1..].to_string())),
+            b'-' => hunk
+                .lines
+                .push(HunkLine::Removal(raw_line[1..].to_string())),
+            b'+' => hunk
+                .lines
+                .push(HunkLine::Addition(raw_line[1..].to_string())),
+            _ => {
+                return Err(FsError::DiffHunkHeader {
+                    reason: format!("unrecognised hunk line prefix: {raw_line:?}"),
+                });
+            }
+        }
+    }
+    if let Some(hunk) = current.take() {
+        hunks.push(hunk);
+    }
+    Ok(hunks)
+}
+
+/// Parse the `-old_start,old_len +new_start,new_len @@` remainder of a hunk
+/// header (the text after the leading `"@@ "` has already been stripped).
+///
+/// Why: Only `old_start` is needed to drive application (removal/context
+/// lines are verified against actual content, so `old_len`/`new_*` are
+/// informational only and are not validated here).
+fn parse_hunk_header(header: &str) -> Result<usize, FsError> {
+    let old_range = header
+        .split_whitespace()
+        .next()
+        .and_then(|tok| tok.strip_prefix('-'))
+        .ok_or_else(|| FsError::DiffHunkHeader {
+            reason: format!("missing '-old_start' range in header: {header:?}"),
+        })?;
+    let old_start_str = old_range.split(',').next().unwrap_or(old_range);
+    old_start_str
+        .parse::<usize>()
+        .map_err(|_| FsError::DiffHunkHeader {
+            reason: format!("non-numeric old_start in header: {header:?}"),
+        })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    /// A single-hunk diff replaces one line and preserves the rest.
+    #[test]
+    fn apply_single_hunk() {
+        let content = "line1\nline2\nline3\n";
+        let diff = "@@ -2,1 +2,1 @@\n-line2\n+line2-changed\n";
+        let updated = apply_unified_diff(content, diff, Path::new("f.py")).expect("must apply");
+        assert_eq!(updated, "line1\nline2-changed\nline3\n");
+    }
+
+    /// Multiple hunks apply independently and in order.
+    #[test]
+    fn apply_multiple_hunks() {
+        let content = "a\nb\nc\nd\ne\n";
+        let diff = "@@ -1,1 +1,1 @@\n-a\n+A\n@@ -4,1 +4,1 @@\n-d\n+D\n";
+        let updated = apply_unified_diff(content, diff, Path::new("f.py")).expect("must apply");
+        assert_eq!(updated, "A\nb\nc\nD\ne\n");
+    }
+
+    /// A hunk with only additions (no removals) inserts without deleting.
+    #[test]
+    fn apply_pure_addition_hunk() {
+        let content = "a\nb\n";
+        let diff = "@@ -1,1 +1,2 @@\n a\n+inserted\n b\n";
+        let updated = apply_unified_diff(content, diff, Path::new("f.py")).expect("must apply");
+        assert_eq!(updated, "a\ninserted\nb\n");
+    }
+
+    /// A mismatched context/removal line surfaces `DiffContextMismatch`, not a panic.
+    #[test]
+    fn apply_context_mismatch_errors() {
+        let content = "line1\nline2\nline3\n";
+        let diff = "@@ -2,1 +2,1 @@\n-not-line2\n+x\n";
+        let err = apply_unified_diff(content, diff, Path::new("f.py")).expect_err("must mismatch");
+        assert!(matches!(err, FsError::DiffContextMismatch { .. }));
+    }
+
+    /// Diff text with no hunk header at all is a clear parse error.
+    #[test]
+    fn apply_no_hunks_errors() {
+        let err = apply_unified_diff("content\n", "not a diff at all", Path::new("f.py"))
+            .expect_err("must error");
+        assert!(matches!(err, FsError::DiffHunkHeader { .. }));
+    }
+
+    /// An unparsable hunk header (non-numeric range) errors cleanly.
+    #[test]
+    fn apply_bad_header_errors() {
+        let err = apply_unified_diff(
+            "content\n",
+            "@@ -x,y +1,1 @@\n-content\n+x\n",
+            Path::new("f.py"),
+        )
+        .expect_err("must error on bad header");
+        assert!(matches!(err, FsError::DiffHunkHeader { .. }));
+    }
+
+    /// Standard `--- a/file` / `+++ b/file` header lines before the first
+    /// hunk are ignored rather than causing a parse error.
+    #[test]
+    fn apply_ignores_file_header_lines() {
+        let content = "a\nb\n";
+        let diff = "--- a/f.py\n+++ b/f.py\n@@ -1,1 +1,1 @@\n-a\n+A\n";
+        let updated = apply_unified_diff(content, diff, Path::new("f.py")).expect("must apply");
+        assert_eq!(updated, "A\nb\n");
+    }
+}

--- a/crates/trusty-code/src/tools/fs/edit_format/mod.rs
+++ b/crates/trusty-code/src/tools/fs/edit_format/mod.rs
@@ -1,0 +1,373 @@
+//! Per-model edit-format selection for the `edit` tool (#2068, P1B-1).
+//!
+//! Why: Aider's A/B data (cited in #2068) shows edit-application success rate
+//! varies a lot by model family for a given wire format: exact-match
+//! SEARCH/REPLACE is the cheapest (fewest tokens) but some models struggle to
+//! reproduce `old_string` byte-for-byte; unified-diff is more forgiving of
+//! minor context drift but costs more tokens to emit; whole-file replacement
+//! is the most robust (no precision needed at all) but the most expensive.
+//! Picking a fixed global order wastes retries on models that reliably fail
+//! their first attempt. [`format_order_for`] centralises a static per-model
+//! preference matrix (Phase 1 — "simple matrix in agent config", full
+//! success-rate learning loop deferred to Phase 2) so the tool can offer
+//! formats in the order most likely to succeed for the calling model,
+//! mirroring the `strategy_order_for` matrix in
+//! `llm::tool_call_extractor` (#1023).
+//! What: [`EditFormat`] names the three supported wire formats; [`EditPayload`]
+//! bundles the format-specific arguments recovered from the LLM's tool call;
+//! [`format_order_for`] returns the per-model fallback order; [`select_and_apply`]
+//! tries the caller-supplied payloads in that order against the current file
+//! content and returns the first one that applies cleanly.
+//!
+//! ## Per-model format matrix
+//!
+//! | Model family (slug substring) | Fallback order |
+//! |---|---|
+//! | `claude-`, `gpt-`, `gemini-` (flagship, native tool-calling) | SEARCH/REPLACE → unified-diff → whole-file |
+//! | `qwen`, `deepseek` | unified-diff → SEARCH/REPLACE → whole-file |
+//! | everything else (`gemma`, small/unknown models) | whole-file → SEARCH/REPLACE → unified-diff |
+//!
+//! Rationale: flagship models reliably reproduce exact substrings, so the
+//! cheapest format leads. Qwen/DeepSeek's published chat templates and code
+//! training corpora lean heavily on diff-formatted code, so diff application
+//! out-performs exact match for that family (per the Aider leaderboard data
+//! referenced in #2068). Weaker/unknown models frequently botch both
+//! precision-dependent formats, so the most forgiving format (whole-file)
+//! leads for the catch-all bucket.
+//! Test: `tests::format_order_*`, `tests::select_and_apply_*`.
+
+mod diff;
+
+use std::path::Path;
+
+use super::FsError;
+
+pub(crate) use diff::apply_unified_diff;
+
+/// The three supported edit wire formats.
+///
+/// Why: Callers (the tool's `execute`, tests, and future telemetry) need a
+/// concrete, comparable value naming which format was attempted/succeeded.
+/// What: Mirrors the three formats in #2068's scope.
+/// Test: `tests::display_matches_wire_name`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditFormat {
+    /// Exact-unique string replacement (the pre-#2068 sole format).
+    SearchReplace,
+    /// A unified-diff hunk (or hunks) applied against the file's current content.
+    UnifiedDiff,
+    /// Full-file content replacement.
+    WholeFile,
+}
+
+impl EditFormat {
+    /// The wire/config name used in the matrix table and tool-result messages.
+    fn as_str(self) -> &'static str {
+        match self {
+            EditFormat::SearchReplace => "search_replace",
+            EditFormat::UnifiedDiff => "unified_diff",
+            EditFormat::WholeFile => "whole_file",
+        }
+    }
+}
+
+impl std::fmt::Display for EditFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One candidate edit, in the shape the LLM actually supplied it.
+///
+/// Why: A single tool call may carry more than one representation of the same
+/// edit (e.g. a model hedges with both `old_string`/`new_string` and a `diff`);
+/// [`select_and_apply`] needs a typed payload per format to try in preference
+/// order.
+/// What: Each variant carries exactly the arguments its format needs.
+/// Test: Constructed directly in `edit.rs::execute` from the parsed tool-call
+/// arguments; exercised via `tests::select_and_apply_*`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EditPayload {
+    /// `old_string` must appear exactly once in the file; replaced with `new_string`.
+    SearchReplace {
+        old_string: String,
+        new_string: String,
+    },
+    /// A unified-diff hunk set to apply against the file's current content.
+    UnifiedDiff { diff: String },
+    /// The complete new content of the file.
+    WholeFile { content: String },
+}
+
+impl EditPayload {
+    /// The [`EditFormat`] this payload represents.
+    fn format(&self) -> EditFormat {
+        match self {
+            EditPayload::SearchReplace { .. } => EditFormat::SearchReplace,
+            EditPayload::UnifiedDiff { .. } => EditFormat::UnifiedDiff,
+            EditPayload::WholeFile { .. } => EditFormat::WholeFile,
+        }
+    }
+}
+
+/// Per-model fallback order for edit-format application, when multiple
+/// candidate payloads are available.
+///
+/// Why: Centralises the matrix documented in the module table above.
+/// What: Returns the three formats in priority order for `model_slug`.
+/// Matching is case-insensitive and substring-based, mirroring
+/// `llm::tool_call_extractor::strategy_order_for`.
+/// Test: `tests::format_order_prefers_search_replace_for_flagship_models`,
+/// `tests::format_order_prefers_unified_diff_for_qwen_and_deepseek`,
+/// `tests::format_order_prefers_whole_file_for_catch_all`.
+pub fn format_order_for(model_slug: &str) -> [EditFormat; 3] {
+    let lower = model_slug.to_ascii_lowercase();
+    if lower.contains("claude-") || lower.contains("gpt-") || lower.contains("gemini-") {
+        [
+            EditFormat::SearchReplace,
+            EditFormat::UnifiedDiff,
+            EditFormat::WholeFile,
+        ]
+    } else if lower.contains("qwen") || lower.contains("deepseek") {
+        [
+            EditFormat::UnifiedDiff,
+            EditFormat::SearchReplace,
+            EditFormat::WholeFile,
+        ]
+    } else {
+        [
+            EditFormat::WholeFile,
+            EditFormat::SearchReplace,
+            EditFormat::UnifiedDiff,
+        ]
+    }
+}
+
+/// Apply an exact-unique string replacement against in-memory `content`.
+///
+/// Why: Shared by [`select_and_apply`]; kept free of file IO so it is testable
+/// without a tempdir.
+/// What: Returns the updated content on success. Errors on 0 or >1 matches,
+/// mirroring the pre-#2068 `EditTool` contract exactly.
+/// Test: `tests::select_and_apply_search_replace_unique_match`,
+/// `tests::select_and_apply_search_replace_zero_and_ambiguous`.
+fn apply_search_replace(
+    content: &str,
+    old_string: &str,
+    new_string: &str,
+    path: &Path,
+) -> Result<String, FsError> {
+    let count = content.matches(old_string).count();
+    match count {
+        0 => Err(FsError::EditNotFound {
+            path: path.to_path_buf(),
+        }),
+        1 => Ok(content.replacen(old_string, new_string, 1)),
+        n => Err(FsError::EditAmbiguous {
+            path: path.to_path_buf(),
+            count: n,
+        }),
+    }
+}
+
+/// Apply one payload against `content`, dispatching on its format.
+fn apply_payload(payload: &EditPayload, content: &str, path: &Path) -> Result<String, FsError> {
+    match payload {
+        EditPayload::SearchReplace {
+            old_string,
+            new_string,
+        } => apply_search_replace(content, old_string, new_string, path),
+        EditPayload::UnifiedDiff { diff } => apply_unified_diff(content, diff, path),
+        EditPayload::WholeFile { content: new } => Ok(new.clone()),
+    }
+}
+
+/// Try `payloads` against `content` in `model_slug`'s preferred format order,
+/// returning the first one that applies cleanly.
+///
+/// Why: This is the fallback-retry loop #2068 asks for: SEARCH/REPLACE first
+/// (for models that prefer it), falling back to unified-diff, then whole-file,
+/// all within a single tool call when the model supplied more than one
+/// representation of the same edit.
+/// What: Iterates [`format_order_for`], and for each preferred format tries
+/// the first payload of that format present in `payloads`; returns
+/// `(updated_content, format_used)` on the first success. If no payload
+/// matches any format (empty `payloads`), or every present payload fails to
+/// apply, returns the last encountered `FsError`.
+/// Test: `tests::select_and_apply_*`.
+pub fn select_and_apply(
+    model_slug: &str,
+    content: &str,
+    path: &Path,
+    payloads: &[EditPayload],
+) -> Result<(String, EditFormat), FsError> {
+    let order = format_order_for(model_slug);
+    let mut last_err: Option<FsError> = None;
+
+    for format in order {
+        let Some(payload) = payloads.iter().find(|p| p.format() == format) else {
+            continue;
+        };
+        match apply_payload(payload, content, path) {
+            Ok(updated) => return Ok((updated, format)),
+            Err(e) => last_err = Some(e),
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| FsError::EditNotFound {
+        path: path.to_path_buf(),
+    }))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    /// `Display` renders the wire-format name used in tool-result messages.
+    #[test]
+    fn display_matches_wire_name() {
+        assert_eq!(EditFormat::SearchReplace.to_string(), "search_replace");
+        assert_eq!(EditFormat::UnifiedDiff.to_string(), "unified_diff");
+        assert_eq!(EditFormat::WholeFile.to_string(), "whole_file");
+    }
+
+    /// Flagship native-tool-calling families prefer SEARCH/REPLACE first.
+    #[test]
+    fn format_order_prefers_search_replace_for_flagship_models() {
+        for slug in [
+            "anthropic/claude-opus-4-5",
+            "openai/gpt-4o",
+            "google/gemini-2.5-pro",
+        ] {
+            assert_eq!(
+                format_order_for(slug),
+                [
+                    EditFormat::SearchReplace,
+                    EditFormat::UnifiedDiff,
+                    EditFormat::WholeFile
+                ],
+                "unexpected order for {slug}"
+            );
+        }
+    }
+
+    /// Qwen/DeepSeek prefer unified-diff first.
+    #[test]
+    fn format_order_prefers_unified_diff_for_qwen_and_deepseek() {
+        for slug in ["qwen/qwen-2.5-72b-instruct", "deepseek/deepseek-chat"] {
+            assert_eq!(
+                format_order_for(slug),
+                [
+                    EditFormat::UnifiedDiff,
+                    EditFormat::SearchReplace,
+                    EditFormat::WholeFile
+                ],
+                "unexpected order for {slug}"
+            );
+        }
+    }
+
+    /// The catch-all bucket (gemma, unknown, empty slug) prefers whole-file first.
+    #[test]
+    fn format_order_prefers_whole_file_for_catch_all() {
+        for slug in ["google/gemma-2-9b-it", "some/unknown-model", ""] {
+            assert_eq!(
+                format_order_for(slug),
+                [
+                    EditFormat::WholeFile,
+                    EditFormat::SearchReplace,
+                    EditFormat::UnifiedDiff
+                ],
+                "unexpected order for {slug}"
+            );
+        }
+    }
+
+    /// A single `SearchReplace` payload applies regardless of model order.
+    #[test]
+    fn select_and_apply_search_replace_unique_match() {
+        let payloads = [EditPayload::SearchReplace {
+            old_string: "foo".into(),
+            new_string: "bar".into(),
+        }];
+        // Even under the whole-file-first catch-all order, the only payload
+        // present (SearchReplace) must still be the one applied.
+        let (updated, format) =
+            select_and_apply("unknown-model", "foo baz", Path::new("f.py"), &payloads)
+                .expect("unique match must apply");
+        assert_eq!(updated, "bar baz");
+        assert_eq!(format, EditFormat::SearchReplace);
+    }
+
+    /// Zero and ambiguous matches surface the same errors as the legacy tool.
+    #[test]
+    fn select_and_apply_search_replace_zero_and_ambiguous() {
+        let zero = [EditPayload::SearchReplace {
+            old_string: "missing".into(),
+            new_string: "x".into(),
+        }];
+        let err = select_and_apply("claude-opus", "content", Path::new("f.py"), &zero)
+            .expect_err("zero matches must error");
+        assert!(matches!(err, FsError::EditNotFound { .. }));
+
+        let ambiguous = [EditPayload::SearchReplace {
+            old_string: "dup".into(),
+            new_string: "x".into(),
+        }];
+        let err = select_and_apply("claude-opus", "dup dup", Path::new("f.py"), &ambiguous)
+            .expect_err("ambiguous matches must error");
+        assert!(matches!(err, FsError::EditAmbiguous { count: 2, .. }));
+    }
+
+    /// A `WholeFile` payload always applies, replacing the entire content.
+    #[test]
+    fn select_and_apply_whole_file_replaces_everything() {
+        let payloads = [EditPayload::WholeFile {
+            content: "brand new content\n".into(),
+        }];
+        let (updated, format) =
+            select_and_apply("claude-opus", "old content\n", Path::new("f.py"), &payloads)
+                .expect("whole-file must always apply");
+        assert_eq!(updated, "brand new content\n");
+        assert_eq!(format, EditFormat::WholeFile);
+    }
+
+    /// When the top-preference payload fails to apply, `select_and_apply`
+    /// falls back to the next preferred format present in `payloads`.
+    #[test]
+    fn select_and_apply_falls_back_on_failure() {
+        // Flagship order is SearchReplace -> UnifiedDiff -> WholeFile. Give a
+        // SearchReplace payload that cannot match, plus a WholeFile payload
+        // that always can; expect the fallback to WholeFile.
+        let payloads = [
+            EditPayload::SearchReplace {
+                old_string: "not-present".into(),
+                new_string: "x".into(),
+            },
+            EditPayload::WholeFile {
+                content: "fallback content\n".into(),
+            },
+        ];
+        let (updated, format) = select_and_apply(
+            "anthropic/claude-opus-4-5",
+            "orig\n",
+            Path::new("f.py"),
+            &payloads,
+        )
+        .expect("must fall back to whole-file");
+        assert_eq!(updated, "fallback content\n");
+        assert_eq!(format, EditFormat::WholeFile);
+    }
+
+    /// Empty `payloads` is a clear error, not a panic.
+    #[test]
+    fn select_and_apply_empty_payloads_errors() {
+        let err = select_and_apply("claude-opus", "content", Path::new("f.py"), &[])
+            .expect_err("no payloads must error");
+        assert!(matches!(err, FsError::EditNotFound { .. }));
+    }
+}

--- a/crates/trusty-code/src/tools/fs/mod.rs
+++ b/crates/trusty-code/src/tools/fs/mod.rs
@@ -7,12 +7,16 @@
 //! impossible.
 //! What: Three `ToolExecutor` impls — `ReadFileTool`, `WriteFileTool`, and
 //! `EditTool` — each with an OpenAI-function-call schema and registration helpers.
+//! `EditTool` (#2068) supports three edit wire formats — SEARCH/REPLACE,
+//! unified-diff, and whole-file — selected per-model via `edit_format`.
 //! Errors use `thiserror` for clean structured error types.
 //! Test: `read.rs`, `write.rs`, and `edit.rs` each carry tempdir-based unit
-//! tests; `registry_tests` verifies all three appear in `schemas()` and dispatch
-//! through `dispatch_gated`.
+//! tests; `edit_format` carries its own matrix/application tests;
+//! `registry_tests` verifies all three tools appear in `schemas()` and
+//! dispatch through `dispatch_gated`.
 
 pub mod edit;
+pub mod edit_format;
 pub mod read;
 pub mod write;
 
@@ -52,6 +56,19 @@ pub enum FsError {
     /// `edit` found more than one occurrence of `old_string`.
     #[error("edit: old_string is ambiguous ({count} matches) in {path}")]
     EditAmbiguous { path: PathBuf, count: usize },
+
+    /// A `unified_diff` edit's hunk header (`@@ -l,s +l,s @@`) could not be parsed.
+    #[error("edit: invalid unified diff: {reason}")]
+    DiffHunkHeader { reason: String },
+
+    /// A `unified_diff` edit's context or removal line did not match the
+    /// file's current content at the expected position.
+    #[error("edit: diff context mismatch in {path} near original line {line}: {reason}")]
+    DiffContextMismatch {
+        path: PathBuf,
+        line: usize,
+        reason: String,
+    },
 
     /// Underlying IO error.
     #[error("io error on {path}: {source}")]


### PR DESCRIPTION
M2 (Tool Calling) P1B-1 — the edit tool gains three edit formats (SEARCH/REPLACE, unified-diff, whole-file) selected per model via a static preference matrix (`format_order_for`, mirroring #1023's `strategy_order_for`). A single `edit` call may carry multiple format payloads; `select_and_apply` tries them in the model's preferred order and falls back on failure with no extra LLM round-trip. Model slug is resolved once at registry-build time via the existing `resolve_model` precedence. Legacy single-format (old_string/new_string) calls are unaffected. Hand-rolled unified-diff applier fails closed (context mismatch / malformed header → recoverable FsError, never silent corruption).

QA: APPROVE (independent worktree at 0b2b44cc) — build 0 warnings, 534 lib + 18 e2e tests pass, clippy clean, fmt clean, line-cap 0 violations (edit_format/mod.rs 260, diff.rs 217 SLOC), trusty-agents unaffected. Diff applier scrutinized: multi-hunk ordering guarded, every context/removal line verified before cursor advance, zero library unwrap(). Backward compat confirmed.

Phase-2 deferred (per issue): success-rate learning loop that adjusts the matrix over time. Minor follow-up (separate ticket): diff parser should skip the git \`\ No newline at end of file\` footer line rather than erroring.

Closes #2068