### PR TITLE
fix(trusty-mpm): make SessionManager::resume non-destructive for live panes (#2148)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -33,9 +33,13 @@ use crate::formatters::info_box::DaemonInfo;
 /// Why: extracting the parse-and-decide logic from the I/O driver makes it
 /// unit-testable without stdin/tmux. The driver calls parse, checks the variant,
 /// and shells out only for Resume and LaunchNew.
-/// What: four variants cover every valid and invalid input the picker can receive.
+/// What: five variants cover every valid and invalid input the picker can
+/// receive. [`Self::ConfirmRestart`] is the #2148 safety default: a bare Enter
+/// that WOULD have silently restarted (destructively recreated the tmux pane
+/// of) a stopped/errored session instead asks for an explicit numeric choice.
 /// Test: `guided_picker_bare_enter_no_sessions_launches_new`,
-/// `guided_picker_bare_enter_with_sessions_resumes_first`,
+/// `guided_picker_bare_enter_live_session_resumes_first`,
+/// `guided_picker_bare_enter_stopped_session_requires_confirm`,
 /// `guided_picker_q_returns_quit`, `guided_picker_numeric_valid_resumes`,
 /// `guided_picker_numeric_launch_new`, `guided_picker_out_of_range_unrecognised`,
 /// `guided_picker_non_numeric_unrecognised`.
@@ -49,6 +53,12 @@ pub(crate) enum PickerDecision {
     Quit,
     /// Input was not recognised; the caller quits cleanly.
     Unrecognised,
+    /// Bare Enter was pressed but the 0-based-indexed session at this slot is
+    /// stopped/errored — resuming it would KILL and recreate its tmux pane
+    /// (or, if the pane already happened to be dead, spawn a fresh one). #2148:
+    /// this is no longer an implicit default; the operator must type the
+    /// number explicitly to confirm the restart.
+    ConfirmRestart(usize),
 }
 
 // ── Entry point ──────────────────────────────────────────────────────────────
@@ -329,30 +339,48 @@ pub(crate) fn print_non_tty_hint(
 /// Parse one line of picker input into a [`PickerDecision`].
 ///
 /// Why: separating parse-and-decide from the I/O driver makes the dispatch
-/// logic unit-testable without needing a real stdin, tmux, or daemon.
+/// logic unit-testable without needing a real stdin, tmux, or daemon. Folding
+/// `first_needs_restart` in here (rather than deciding safety in the I/O
+/// driver) keeps the destructive-default guard (#2148) exhaustively
+/// unit-testable alongside every other picker-input case.
 /// What: `session_count` is the number of existing sessions in the menu (the
-/// menu slot `session_count + 1` is always "launch new").
+/// menu slot `session_count + 1` is always "launch new"); `first_needs_restart`
+/// is true when the session at index 0 is `stopped`/`errored` — i.e. resuming
+/// it goes through the daemon's restart path, which can recreate its tmux pane
+/// (see [`super::guided_resume::needs_restart`]).
 ///   • `"q"` / `"Q"` → `Quit`
-///   • empty / whitespace → `Resume(0)` when `session_count > 0`, else `LaunchNew`
-///   • `N` (1..=session_count) → `Resume(N-1)` (0-based index)
+///   • empty / whitespace, `session_count == 0` → `LaunchNew`
+///   • empty / whitespace, `session_count > 0`, session 0 is live → `Resume(0)`
+///   • empty / whitespace, `session_count > 0`, session 0 needs a restart →
+///     `ConfirmRestart(0)` (#2148: no longer an implicit destructive default)
+///   • `N` (1..=session_count) → `Resume(N-1)` (0-based index) — an EXPLICIT
+///     numeric choice always restarts/resumes directly, confirm or not
 ///   • `session_count + 1` → `LaunchNew`
 ///   • anything else → `Unrecognised`
 /// Test: `guided_picker_bare_enter_no_sessions_launches_new`,
-/// `guided_picker_bare_enter_with_sessions_resumes_first`,
+/// `guided_picker_bare_enter_live_session_resumes_first`,
+/// `guided_picker_bare_enter_stopped_session_requires_confirm`,
 /// `guided_picker_q_returns_quit`, `guided_picker_q_uppercase_returns_quit`,
 /// `guided_picker_numeric_valid_resumes`, `guided_picker_numeric_launch_new`,
 /// `guided_picker_out_of_range_unrecognised`,
 /// `guided_picker_non_numeric_unrecognised`.
-pub(crate) fn parse_picker_choice(line: &str, session_count: usize) -> PickerDecision {
+pub(crate) fn parse_picker_choice(
+    line: &str,
+    session_count: usize,
+    first_needs_restart: bool,
+) -> PickerDecision {
     let choice = line.trim();
     if choice.eq_ignore_ascii_case("q") {
         return PickerDecision::Quit;
     }
     if choice.is_empty() {
-        return if session_count > 0 {
-            PickerDecision::Resume(0)
+        if session_count == 0 {
+            return PickerDecision::LaunchNew;
+        }
+        return if first_needs_restart {
+            PickerDecision::ConfirmRestart(0)
         } else {
-            PickerDecision::LaunchNew
+            PickerDecision::Resume(0)
         };
     }
     if let Ok(n) = choice.parse::<usize>() {
@@ -378,6 +406,8 @@ pub(crate) fn parse_picker_choice(line: &str, session_count: usize) -> PickerDec
 ///   • `Resume(i)` → [`resume_guided_session`] which handles daemon restart
 ///     when needed and then calls [`tmux_attach`] internally;
 ///   • `LaunchNew` → [`launch_new_session_and_attach`];
+///   • `ConfirmRestart(i)` (#2148) → print a one-line "type the number to
+///     confirm" notice and redisplay the SAME menu — no daemon round-trip;
 ///   • `Quit` / EOF / `Unrecognised` → print notice and return `Ok`.
 /// Test: `parse_picker_choice` is the testable seam; I/O path is exercised by
 /// manual smoke tests and the e2e suite.
@@ -391,6 +421,13 @@ async fn run_tty_picker(
     loop {
         eprintln!();
         let new_idx = sessions.len() + 1;
+        // #2148: bare Enter must not silently restart (kill+recreate the tmux
+        // pane of) a stopped/errored session — only used to pick the menu's
+        // default hint and to gate `parse_picker_choice`'s bare-Enter branch.
+        let first_needs_restart = sessions
+            .first()
+            .map(|s| super::guided_resume::needs_restart(&s.state))
+            .unwrap_or(false);
         if sessions.is_empty() {
             eprintln!("tm:   [Enter] launch new session");
             eprintln!("tm:   [q]     quit");
@@ -404,7 +441,12 @@ async fn run_tty_picker(
             }
             eprintln!("tm:   [{new_idx}] launch new session");
             eprintln!("tm:   [q] quit");
-            eprintln!("tm: default: [1] resume/restart most recent");
+            if first_needs_restart {
+                // #2148: no implicit destructive default — an explicit [1] is required.
+                eprintln!("tm: [Enter] does NOT restart — type [1] to confirm the restart");
+            } else {
+                eprintln!("tm: default: [1] resume most recent");
+            }
         }
         eprint!("tm: > ");
 
@@ -416,7 +458,7 @@ async fn run_tty_picker(
             break;
         } // EOF (Ctrl-D): exit cleanly.
 
-        match parse_picker_choice(&line, sessions.len()) {
+        match parse_picker_choice(&line, sessions.len(), first_needs_restart) {
             PickerDecision::Quit => {
                 eprintln!("tm: quit.");
                 break;
@@ -428,6 +470,21 @@ async fn run_tty_picker(
             }
             PickerDecision::LaunchNew => {
                 launch_new_session_and_attach(client, url, repo_url).await?
+            }
+            // #2148: bare Enter hit a session that needs a restart — ask for an
+            // explicit choice instead of silently destroying its pane. No daemon
+            // round-trip; redisplay the SAME menu.
+            PickerDecision::ConfirmRestart(i) => {
+                eprintln!(
+                    "tm: '{}' requires a restart (its pane is gone or will be recreated) — \
+                     bare Enter no longer does this automatically.",
+                    sessions[i].name
+                );
+                eprintln!(
+                    "tm: type [{}] to confirm the restart, or [q] to quit.",
+                    i + 1
+                );
+                continue;
             }
             PickerDecision::Unrecognised => {
                 eprintln!("tm: unrecognised choice '{}'; quitting.", line.trim());

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -17,9 +17,13 @@
 //! logic. [`plan_inplace`] is the pure decision (env var present AND the
 //! fetched record's state is `"stopped"` → [`super::guided_resume::
 //! ResumeAction::InPlace`]; otherwise `None`, meaning "fall through to the
-//! normal guided flow"). The daemon round-trips ([`fetch_managed_session`],
-//! [`reactivate_managed_session`]) and the process-replacing exec
-//! ([`exec_claude_in_place`]) are the I/O driver, sequenced by
+//! normal guided flow"). The record is fetched via
+//! [`fetch_managed_session_until_stopped`] (#2148), which retries
+//! [`fetch_managed_session`] over a short bounded budget so a record that is
+//! still transitioning `Active` -> `Stopped` (the `SessionEnd` stop racing this
+//! exact invocation) is not mistaken for "not stopped" on a single unlucky
+//! read. [`reactivate_managed_session`] and the process-replacing exec
+//! ([`exec_claude_in_place`]) are the rest of the I/O driver, sequenced by
 //! [`run_inplace_relaunch`] as: resolve the `claude` binary + build the resume
 //! command (pure, local — can fail on a missing binary before anything is
 //! mutated) → reactivate on the daemon (network — a 404/409/unreachable
@@ -37,11 +41,11 @@
 //! failure aborts rather than proceeding to exec regardless.
 //!
 //! Test: `plan_inplace_*` cover the pure decision; `reactivate_managed_session`'s
-//! success/409/404 outcomes are exercised against a local one-shot `TcpListener`
-//! mock (#2027, mirroring `core::sm::providers`' mock convention — no external
-//! mock-server crate); the full exec path is not unit-tested — it requires a
-//! live daemon and a real `claude` binary, mirroring the rest of the
-//! guided-resume I/O surface.
+//! success/409/404 outcomes and `fetch_until_stopped_*`'s retry behavior (#2148)
+//! are exercised against a local `TcpListener` mock (#2027, mirroring
+//! `core::sm::providers`' mock convention — no external mock-server crate); the
+//! full exec path is not unit-tested — it requires a live daemon and a real
+//! `claude` binary, mirroring the rest of the guided-resume I/O surface.
 
 use anyhow::Context as _;
 
@@ -60,6 +64,25 @@ const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 /// identifies which managed session bare `tm`, run after `claude` exits,
 /// belongs to.
 const MANAGED_SESSION_ID_ENV: &str = "TM_MANAGED_SESSION_ID";
+
+/// Total time budget for polling the managed-session fetch while the record is
+/// transitioning `Active` -> `Stopped` (#2148 race hardening).
+///
+/// Why: `SessionEnd` marks the record `Stopped` asynchronously (via
+/// `mark_runtime_exited_stopped`) at roughly the same moment bare `tm` runs in
+/// the just-vacated pane. A single unlucky fetch can observe the record still
+/// `"active"`, causing [`plan_inplace`] to reject the in-place path and fall
+/// through to the destructive guided-picker `/resume` — exactly the pane loss
+/// #2148 is about. A short, bounded poll absorbs that race without adding a
+/// human-perceptible delay to every bare-`tm` invocation.
+const FETCH_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// Delay between polls within [`FETCH_RETRY_BUDGET`].
+///
+/// Why: a handful of short polls (400ms / 80ms ≈ up to 5 attempts) is enough
+/// to ride out the `SessionEnd` race without noticeably slowing the common
+/// case, where the very first fetch already sees `"stopped"`.
+const FETCH_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(80);
 
 /// Read [`MANAGED_SESSION_ID_ENV`] from the environment, treating a blank
 /// value the same as absent.
@@ -127,6 +150,42 @@ async fn fetch_managed_session(
         return None;
     }
     resp.json().await.ok()
+}
+
+/// Poll [`fetch_managed_session`] until the record reads `"stopped"` or the
+/// [`FETCH_RETRY_BUDGET`] is exhausted (#2148 race hardening).
+///
+/// Why: [`plan_inplace`] requires the FIRST fetch to already show `"stopped"`;
+/// a record that is transitioning `Active` -> `Stopped` (the `SessionEnd` stop
+/// racing this exact bare-`tm` invocation) would otherwise be seen as
+/// unresolved/non-stopped and fall through to the destructive guided-picker
+/// `/resume` path — the very pane loss #2148 fixes. Retrying a few times over
+/// a small, bounded budget lets the transition land before giving up.
+/// What: fetches once immediately; returns as soon as `state == "stopped"`.
+/// Otherwise sleeps [`FETCH_RETRY_INTERVAL`] and retries, stopping the moment
+/// the elapsed time reaches [`FETCH_RETRY_BUDGET`] — returning whatever the
+/// LAST attempt produced (`Some` non-stopped record, or `None` if the fetch
+/// itself kept failing). Never blocks longer than the budget, so a genuinely
+/// unresolved/unknown id still falls through promptly.
+/// Test: `fetch_until_stopped_returns_immediately_when_already_stopped`,
+/// `fetch_until_stopped_gives_up_after_budget_when_never_stopped` (both use a
+/// local one-shot/counting mock, mirroring [`spawn_mock`]'s convention).
+async fn fetch_managed_session_until_stopped(
+    client: &reqwest::Client,
+    url: &str,
+    id: &str,
+) -> Option<trusty_mpm::client::ManagedSessionSummary> {
+    let start = std::time::Instant::now();
+    loop {
+        let record = fetch_managed_session(client, url, id).await;
+        if record.as_ref().map(|r| r.state.as_str()) == Some("stopped") {
+            return record;
+        }
+        if start.elapsed() >= FETCH_RETRY_BUDGET {
+            return record;
+        }
+        tokio::time::sleep(FETCH_RETRY_INTERVAL).await;
+    }
 }
 
 /// POST `/api/v1/sessions/managed/{id}/reactivate` — flip Stopped -> Active
@@ -311,7 +370,9 @@ pub(crate) async fn try_inplace_relaunch(
     url: &str,
 ) -> Option<anyhow::Result<()>> {
     let env_id = read_env_managed_session_id()?;
-    let record = fetch_managed_session(client, url, &env_id).await;
+    // #2148: bounded retry absorbs the Active->Stopped transition race instead
+    // of giving up on a single unlucky fetch — see `fetch_managed_session_until_stopped`.
+    let record = fetch_managed_session_until_stopped(client, url, &env_id).await;
     let record_state = record.as_ref().map(|r| r.state.as_str());
     match plan_inplace(Some(&env_id), record_state) {
         Some(ResumeAction::InPlace) => {
@@ -413,6 +474,105 @@ mod tests {
                 Err(_) => return,
             }
         }
+    }
+
+    /// Spawn a background HTTP mock that replies 200 OK with `{"state": ..}`,
+    /// walking through `states` one entry per connection (clamping to the last
+    /// entry once exhausted) — used to simulate a record transitioning
+    /// `Active` -> `Stopped` across retries (#2148).
+    ///
+    /// Why: [`fetch_managed_session_until_stopped`]'s retry behavior needs a
+    /// mock whose response changes across calls, unlike [`spawn_mock`]'s fixed
+    /// status line; this mirrors the same "read the full request before
+    /// replying" convention.
+    /// What: binds an ephemeral port, loops accepting connections, and for the
+    /// Nth connection replies with `states[min(N, states.len() - 1)]` as the
+    /// summary's `state` field. Runs until the test's tokio runtime shuts down.
+    /// Test: `fetch_until_stopped_*` below.
+    async fn spawn_state_mock(states: Vec<&'static str>) -> (String, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_task = hits.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                let n = hits_task.fetch_add(1, Ordering::SeqCst);
+                read_full_request(&mut sock).await;
+                let idx = n.min(states.len().saturating_sub(1));
+                let state = states.get(idx).copied().unwrap_or("active");
+                let body = format!(r#"{{"id":"{TEST_ID}","name":"tm-test","state":"{state}"}}"#);
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        (format!("http://{addr}"), hits)
+    }
+
+    #[tokio::test]
+    async fn fetch_until_stopped_returns_immediately_when_already_stopped() {
+        // #2148: the common case — no race — must not pay any retry delay.
+        let (url, hits) = spawn_state_mock(vec!["stopped"]).await;
+        let client = reqwest::Client::new();
+        let start = std::time::Instant::now();
+        let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
+        assert_eq!(record.map(|r| r.state), Some("stopped".to_string()));
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "must not retry once the first fetch already reads stopped"
+        );
+        assert!(
+            start.elapsed() < FETCH_RETRY_BUDGET,
+            "must return promptly, not wait out the whole retry budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_until_stopped_retries_past_transitioning_state() {
+        // #2148: the race this hardens against — the record briefly reads
+        // "active" while the SessionEnd stop is still in flight, then settles
+        // on "stopped" a couple of polls later.
+        let (url, hits) = spawn_state_mock(vec!["active", "active", "stopped"]).await;
+        let client = reqwest::Client::new();
+        let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
+        assert_eq!(record.map(|r| r.state), Some("stopped".to_string()));
+        assert!(
+            hits.load(Ordering::SeqCst) >= 3,
+            "must retry past the transitioning reads before accepting stopped"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_until_stopped_gives_up_after_budget_when_never_stopped() {
+        // A genuinely non-stopped record (e.g. still active, or the id belongs
+        // to some other running session) must not retry forever — it gives up
+        // once the bounded budget elapses so the caller falls through promptly.
+        let (url, hits) = spawn_state_mock(vec!["active"]).await;
+        let client = reqwest::Client::new();
+        let start = std::time::Instant::now();
+        let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
+        let elapsed = start.elapsed();
+        assert_eq!(record.map(|r| r.state), Some("active".to_string()));
+        assert!(
+            elapsed >= FETCH_RETRY_BUDGET,
+            "must not give up before the retry budget elapses"
+        );
+        assert!(
+            elapsed < FETCH_RETRY_BUDGET + FETCH_RETRY_INTERVAL * 3,
+            "must not overrun the budget by more than a poll or two"
+        );
+        assert!(
+            hits.load(Ordering::SeqCst) > 1,
+            "must have retried at least once before giving up"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -39,65 +39,121 @@ use crate::commands::managed::{filter_live_sessions, is_live_session_state};
 #[test]
 fn guided_picker_bare_enter_no_sessions_launches_new() {
     // Why: bare Enter with no sessions must launch a new session, not hang.
-    assert_eq!(parse_picker_choice("", 0), PickerDecision::LaunchNew);
-    assert_eq!(parse_picker_choice("  \t", 0), PickerDecision::LaunchNew);
+    assert_eq!(parse_picker_choice("", 0, false), PickerDecision::LaunchNew);
+    assert_eq!(
+        parse_picker_choice("  \t", 0, false),
+        PickerDecision::LaunchNew
+    );
 }
 
 #[test]
-fn guided_picker_bare_enter_with_sessions_resumes_first() {
-    // Why: bare Enter when sessions exist must resume the most-recent session
-    // (index 0) — the documented default for sessions-present mode.
-    assert_eq!(parse_picker_choice("", 1), PickerDecision::Resume(0));
-    assert_eq!(parse_picker_choice("  ", 3), PickerDecision::Resume(0));
+fn guided_picker_bare_enter_live_session_resumes_first() {
+    // Why: bare Enter when the most-recent session is LIVE (not needing a
+    // restart) must resume it directly — attaching to a live pane is safe,
+    // it never destroys anything (#2148).
+    assert_eq!(parse_picker_choice("", 1, false), PickerDecision::Resume(0));
+    assert_eq!(
+        parse_picker_choice("  ", 3, false),
+        PickerDecision::Resume(0)
+    );
+}
+
+#[test]
+fn guided_picker_bare_enter_stopped_session_requires_confirm() {
+    // #2148: bare Enter must NOT silently restart (kill+recreate the tmux pane
+    // of) a stopped/errored session — the operator must type the number.
+    assert_eq!(
+        parse_picker_choice("", 1, true),
+        PickerDecision::ConfirmRestart(0)
+    );
+    assert_eq!(
+        parse_picker_choice("  ", 3, true),
+        PickerDecision::ConfirmRestart(0)
+    );
 }
 
 #[test]
 fn guided_picker_q_returns_quit() {
     // Why: "q" must quit cleanly without touching tmux or the daemon.
-    assert_eq!(parse_picker_choice("q", 0), PickerDecision::Quit);
-    assert_eq!(parse_picker_choice("q", 3), PickerDecision::Quit);
+    assert_eq!(parse_picker_choice("q", 0, false), PickerDecision::Quit);
+    assert_eq!(parse_picker_choice("q", 3, true), PickerDecision::Quit);
 }
 
 #[test]
 fn guided_picker_q_uppercase_returns_quit() {
     // Why: "Q" must be treated identically to "q" (case-insensitive).
-    assert_eq!(parse_picker_choice("Q", 2), PickerDecision::Quit);
-    assert_eq!(parse_picker_choice("Q\n", 0), PickerDecision::Quit);
+    assert_eq!(parse_picker_choice("Q", 2, false), PickerDecision::Quit);
+    assert_eq!(parse_picker_choice("Q\n", 0, false), PickerDecision::Quit);
 }
 
 #[test]
 fn guided_picker_numeric_valid_resumes() {
-    // Why: "[N]" where 1 <= N <= session_count must resume the Nth session (0-based).
-    assert_eq!(parse_picker_choice("1", 1), PickerDecision::Resume(0));
-    assert_eq!(parse_picker_choice("1", 3), PickerDecision::Resume(0));
-    assert_eq!(parse_picker_choice("2", 3), PickerDecision::Resume(1));
-    assert_eq!(parse_picker_choice("3", 3), PickerDecision::Resume(2));
+    // Why: "[N]" where 1 <= N <= session_count must resume the Nth session
+    // (0-based) — an EXPLICIT numeric choice always dispatches directly,
+    // regardless of `first_needs_restart` (that flag only gates bare Enter).
+    assert_eq!(parse_picker_choice("1", 1, true), PickerDecision::Resume(0));
+    assert_eq!(parse_picker_choice("1", 3, true), PickerDecision::Resume(0));
+    assert_eq!(
+        parse_picker_choice("2", 3, false),
+        PickerDecision::Resume(1)
+    );
+    assert_eq!(
+        parse_picker_choice("3", 3, false),
+        PickerDecision::Resume(2)
+    );
     // With newline (as stdin read_line returns)
-    assert_eq!(parse_picker_choice("2\n", 3), PickerDecision::Resume(1));
+    assert_eq!(
+        parse_picker_choice("2\n", 3, false),
+        PickerDecision::Resume(1)
+    );
 }
 
 #[test]
 fn guided_picker_numeric_launch_new() {
     // Why: "[session_count+1]" must always launch a new session.
-    assert_eq!(parse_picker_choice("1", 0), PickerDecision::LaunchNew);
-    assert_eq!(parse_picker_choice("4", 3), PickerDecision::LaunchNew);
+    assert_eq!(
+        parse_picker_choice("1", 0, false),
+        PickerDecision::LaunchNew
+    );
+    assert_eq!(
+        parse_picker_choice("4", 3, false),
+        PickerDecision::LaunchNew
+    );
 }
 
 #[test]
 fn guided_picker_out_of_range_unrecognised() {
     // Why: a number out of range (>session_count+1) must not silently
     // resume or launch — it must be rejected cleanly.
-    assert_eq!(parse_picker_choice("5", 3), PickerDecision::Unrecognised);
-    assert_eq!(parse_picker_choice("100", 1), PickerDecision::Unrecognised);
-    assert_eq!(parse_picker_choice("0", 3), PickerDecision::Unrecognised);
+    assert_eq!(
+        parse_picker_choice("5", 3, false),
+        PickerDecision::Unrecognised
+    );
+    assert_eq!(
+        parse_picker_choice("100", 1, false),
+        PickerDecision::Unrecognised
+    );
+    assert_eq!(
+        parse_picker_choice("0", 3, false),
+        PickerDecision::Unrecognised
+    );
 }
 
 #[test]
 fn guided_picker_non_numeric_unrecognised() {
     // Why: arbitrary text input must be rejected without panicking.
-    assert_eq!(parse_picker_choice("abc", 2), PickerDecision::Unrecognised);
-    assert_eq!(parse_picker_choice("exit", 0), PickerDecision::Unrecognised);
-    assert_eq!(parse_picker_choice("1a", 3), PickerDecision::Unrecognised);
+    assert_eq!(
+        parse_picker_choice("abc", 2, false),
+        PickerDecision::Unrecognised
+    );
+    assert_eq!(
+        parse_picker_choice("exit", 0, false),
+        PickerDecision::Unrecognised
+    );
+    assert_eq!(
+        parse_picker_choice("1a", 3, false),
+        PickerDecision::Unrecognised
+    );
 }
 
 // ── tty_gate ──────────────────────────────────────────────────────────────────

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -465,20 +465,34 @@ impl SessionManager {
         Ok(record)
     }
 
-    /// Resume a stopped session by re-spawning the runtime in its existing workspace.
+    /// Resume a stopped session, reusing its tmux pane when one already survives.
     ///
     /// Why: a session ENDURES until decommissioned; after `stop` the workspace
     /// directory is still on disk and `resume` brings the runtime back without
-    /// re-cloning. A new tmux session is created with `cwd = workspace_path` and
-    /// the caller is responsible for spawning claude inside it (via
-    /// `ClaudeCodeAdapter::spawn`) so the runtime restarts cleanly.
-    /// What: validates the session is `Stopped` or `Errored`, creates a fresh
-    /// tmux session with `cwd = workspace_path` (falls back to `cwd` when
-    /// `workspace_path` is absent), marks the record `Active`, and persists.
-    /// Returns the updated record; the HTTP handler then calls
-    /// `ClaudeCodeAdapter::spawn` on the new tmux session.
-    /// Test: `manager_resume_respawns` — asserts a new `create_session` call is
-    /// issued with cwd = existing workspace_path, no re-clone occurs.
+    /// re-cloning. Prior to #2148 this UNCONDITIONALLY killed any surviving tmux
+    /// session and created a brand-new one, even when the pane was left alive on
+    /// purpose (e.g. [`Self::mark_runtime_exited_stopped`], #2023 A, which marks a
+    /// session `Stopped` WITHOUT touching its pane so the operator can glance at
+    /// trailing output or keep a live `tmux attach`). Every caller of `resume`
+    /// (CLI restart, HTTP `/resume`, MCP `sessions.resume`, the auto-resume
+    /// supervisor) inherited that destructiveness, dropping the operator into a
+    /// freshly recreated pane instead of the one they were already looking at.
+    /// What: validates the session is `Stopped` or `Errored`, then branches on
+    /// [`ManagedTmuxDriver::session_exists`]: if the tmux pane is STILL alive, it
+    /// is reused as-is — no `kill_session`, no `create_session` — because the
+    /// caller (e.g. `resume_managed`) re-spawns the runtime via
+    /// `RuntimeAdapter::spawn_resume`, which types the resume command straight
+    /// into that same pane (already rooted at the right cwd from its original
+    /// creation). If the pane is gone, behavior is unchanged from before: a
+    /// best-effort `kill_session` guard followed by a fresh `create_session` with
+    /// `cwd = workspace_path` (falls back to `cwd` when `workspace_path` is
+    /// absent). Either way the record is marked `Active` and persisted.
+    /// Test: `manager_resume_respawns_in_existing_workspace` (`tests.rs`) —
+    /// asserts a new `create_session` call is issued when no pane survives (the
+    /// `stop()` path, which kills the pane); `resume_reattach_tests.rs`'s
+    /// `manager_resume_reuses_live_pane_without_recreate` — asserts NEITHER
+    /// `kill_session` NOR `create_session` fires when the pane survives (the
+    /// `mark_runtime_exited_stopped` path, #2148).
     pub async fn resume(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
         let mut record = self.get(id).await?;
         match record.state {
@@ -510,23 +524,39 @@ impl SessionManager {
             .to_string_lossy()
             .to_string();
 
-        // Kill the old tmux session if still somehow alive (best-effort).
-        if self.tmux.session_exists(&record.tmux_name)
-            && let Err(e) = self.tmux.kill_session(&record.tmux_name)
-        {
-            warn!(name = %record.tmux_name, "resume: kill stale session failed: {e}");
-        }
+        // #2148: a pane that survived the runtime exit (e.g.
+        // `mark_runtime_exited_stopped`, #2023 A) must be REUSED, not destroyed.
+        // Only recreate the tmux session when no live pane remains.
+        if self.tmux.session_exists(&record.tmux_name) {
+            info!(
+                id = %id,
+                name = %record.tmux_name,
+                workdir = %workdir,
+                "managed session resumed: re-attached to live pane (#2148, no recreate)"
+            );
+        } else {
+            // Best-effort guard: clear any stale entry the driver may still report
+            // before creating the replacement session.
+            if let Err(e) = self.tmux.kill_session(&record.tmux_name) {
+                warn!(name = %record.tmux_name, "resume: kill stale session failed: {e}");
+            }
 
-        // Create a fresh tmux session rooted at the EXISTING workspace.
-        // No re-clone — workspace_path is reused as-is.
-        self.tmux
-            .create_session(&record.tmux_name, &workdir)
-            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
+            // Create a fresh tmux session rooted at the EXISTING workspace.
+            // No re-clone — workspace_path is reused as-is.
+            self.tmux
+                .create_session(&record.tmux_name, &workdir)
+                .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
+            info!(
+                id = %id,
+                name = %record.tmux_name,
+                workdir = %workdir,
+                "managed session resumed: recreated pane"
+            );
+        }
 
         record.state = ManagedSessionState::Active;
         record.last_activity_at = Some(Utc::now());
         self.store.write().await.upsert(record.clone()).await?;
-        info!(id = %id, name = %record.tmux_name, workdir = %workdir, "managed session resumed");
         Ok(record)
     }
 

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -50,6 +50,9 @@ mod reap_orphaned_worktrees_tests;
 #[cfg(test)]
 mod naming_tests;
 
+#[cfg(test)]
+mod resume_reattach_tests;
+
 /// Real tmux driver adapter — only available when the `daemon` feature (and thus
 /// the daemon's `TmuxDriver`) is compiled in.
 #[cfg(feature = "daemon")]

--- a/crates/trusty-mpm/src/session_manager/resume_reattach_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_reattach_tests.rs
@@ -1,0 +1,71 @@
+//! Tests for `SessionManager::resume`'s non-destructive re-attach branch (#2148).
+//!
+//! Why: `session_manager/tests.rs` is at the 1500-SLOC test cap; this
+//! regression coverage lives here (mirroring `reactivate_tests.rs` /
+//! `restart_tests.rs`) so neither file grows past its limit.
+//! What: proves `resume` reuses a tmux pane that survived the runtime exit
+//! (via `mark_runtime_exited_stopped`, #2023 A) instead of killing and
+//! recreating it — the destructive default #2148 fixes.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use tempfile::TempDir;
+
+use super::record::ManagedSessionState;
+use super::tests::make_manager;
+
+/// #2148: `resume` must NOT kill/recreate a tmux pane that survived the
+/// runtime exit (e.g. `mark_runtime_exited_stopped`, #2023 A).
+///
+/// Why: prior to this fix, `resume` unconditionally killed any surviving tmux
+/// session and created a fresh one, tearing down a pane the operator might
+/// still be looking at purely because the record was marked `Stopped` via the
+/// non-destructive reaper path. This regression guard asserts neither
+/// `kill_session` nor `create_session` fires when the pane is still alive.
+/// What: creates a session (one `create_session` call), marks it Stopped via
+/// `mark_runtime_exited_stopped` (which never touches tmux), then resumes it
+/// and asserts: (a) state becomes `Active`, (b) `kill_calls` stays empty, (c)
+/// no additional `create_cwd_calls` entry was recorded.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_resume_reuses_live_pane_without_recreate() {
+    let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    let workspace_path = workspace_dir.path().to_owned();
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_path.clone()),
+            Some("my-live-session".into()),
+            Some(workspace_path.clone()),
+            Some("https://github.com/owner/repo".into()),
+            Some("main".into()),
+        )
+        .await
+        .expect("create");
+
+    // Runtime-exit reaper path (#2023 A): marks Stopped WITHOUT killing the pane.
+    mgr.mark_runtime_exited_stopped(&record.id)
+        .await
+        .expect("mark_runtime_exited_stopped");
+
+    let kills_before = fake.kill_calls.lock().unwrap().len();
+    let creates_before = fake.create_cwd_calls.lock().unwrap().len();
+
+    // Resume the session — the pane is still alive in the fake driver.
+    let resumed = mgr.resume(&record.id).await.expect("resume");
+
+    assert_eq!(resumed.state, ManagedSessionState::Active);
+    assert_eq!(
+        fake.kill_calls.lock().unwrap().len(),
+        kills_before,
+        "resume must NOT kill a tmux pane that is still alive (#2148)"
+    );
+    assert_eq!(
+        fake.create_cwd_calls.lock().unwrap().len(),
+        creates_before,
+        "resume must NOT recreate a tmux pane that is still alive (#2148)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2148 — managed-session relaunch-on-exit was dropping operators into a NEW tmux pane (or the picker) instead of re-entering their live session. Three interacting defects, all fixed:

1. **`SessionManager::resume` was unconditionally destructive** (`crates/trusty-mpm/src/session_manager/manager.rs`). It always `kill_session`'d then `create_session`'d, even when the pane was left alive on purpose by `mark_runtime_exited_stopped` (#2023 A — the runtime-exit reaper, which marks a session `Stopped` WITHOUT killing its pane). Every caller of `resume` (CLI restart, HTTP `/resume`, MCP `sessions.resume`, the auto-resume supervisor) inherited that destructiveness.
   - Fix: `resume` now checks `ManagedTmuxDriver::session_exists` first. If the pane is still alive, it skips `kill_session`/`create_session` entirely and reuses the pane in place (the caller's `RuntimeAdapter::spawn_resume` types the resume command straight into that same pane). The kill+recreate path is preserved, unchanged, when no pane survives.

2. **In-place relaunch gate race** (`crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs`). `plan_inplace` required the FIRST fetch of the managed-session record to already read `"stopped"`; a record still transitioning `Active -> Stopped` (racing the in-flight `SessionEnd` stop) would be seen as "not stopped" and fall through to the destructive guided-picker `/resume` path.
   - Fix: added `fetch_managed_session_until_stopped`, a bounded retry (~400ms budget, 80ms polls) around the fetch, so a transitioning record is very likely to settle before the gate gives up.

3. **Picker default was destructive** (`crates/trusty-mpm/src/bin/tm/commands/guided.rs`). Bare Enter on the picker always mapped to `Resume(0)`, which restarts (kills + recreates the pane of) a stopped/errored session with no confirmation.
   - Fix: `parse_picker_choice` now takes `first_needs_restart`; bare Enter on a live session still resumes it directly (safe — no pane is destroyed), but bare Enter on a session that needs a restart now returns a new `PickerDecision::ConfirmRestart` variant instead, requiring an explicit numeric choice.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-mpm` — 744 passed, 1 failed (pre-existing/verified-unrelated, see below), 1 ignored
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 14 allowlisted, 0 violations — OK.`
- [x] New regression tests: `manager_resume_reuses_live_pane_without_recreate` (new `resume_reattach_tests.rs`), `fetch_until_stopped_returns_immediately_when_already_stopped` / `fetch_until_stopped_retries_past_transitioning_state` / `fetch_until_stopped_gives_up_after_budget_when_never_stopped` (`guided_inplace.rs`), `guided_picker_bare_enter_live_session_resumes_first` / `guided_picker_bare_enter_stopped_session_requires_confirm` (`tests_behavior_c_tests.rs`) — all pass
- [x] Verified `formatters::banner::two_panel::tests::right_col_no_inner_border` fails identically on unmodified `origin/main` (via `git stash` before/after) — pre-existing, unrelated to this change
- [x] Verified `trusty-console`'s `test_connect_retry_recovers_on_second_attempt` is a pre-existing TCP-timing flake (passes on isolated rerun; `trusty-console` untouched by this diff)

Tmux-existence API used for the re-attach branch: `ManagedTmuxDriver::session_exists` (`crates/trusty-mpm/src/session_manager/driver.rs:100`), an existing trait method already used elsewhere in `manager.rs`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools