### PR TITLE
feat(trusty-code): progressive-disclosure skill loading (.claude/skills/) (#2069)

### DIFF
--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -116,9 +116,10 @@ pub mod build_info;
 /// plug in without touching orchestration code.
 /// What: `ToolExecutor`, `AgentRunner`, `RunContext`, `AgentOutput`,
 /// `SearchProvider`, `SkillResolver`, `ToolResult`, `ToolRegistry`,
-/// `DelegateToAgentTool`.
+/// `DelegateToAgentTool`, `UseSkillTool` (#2069's progressive-disclosure
+/// on-invoke skill-body loader).
 /// Test: `tools::traits::tests::*`, `tools::registry::tests::*`,
-/// `tools::delegate::tests::*`.
+/// `tools::delegate::tests::*`, `tools::skill::tests::*`.
 pub mod tools;
 
 /// Role-based access control for tool execution.
@@ -154,6 +155,23 @@ pub mod llm;
 /// `RunnerConfig`, `RunnerKind`, `discover_agents`, `load_all_agents`.
 /// Test: `agents::tests::*`.
 pub mod agents;
+
+/// Progressive-disclosure skill discovery for `.claude/skills/` (#2069,
+/// vision spec §5.3, Resolved Decision #7).
+///
+/// Why: A skill catalog's full Markdown bodies cost far more tokens than the
+/// PM/agents need up front — most skills in a session are never invoked.
+/// Splitting discovery into cheap, always-cached metadata (name +
+/// description) and an on-demand-loaded body is the token-efficiency layer
+/// P1B wires into `prompt::assemble_system_prompt_for_mode`'s `DailyDriver`
+/// arm.
+/// What: `SkillMetadata`, `locate_skills_dir` (`.claude/skills`, the
+/// Claude-Code-compatible path), `discover_skill_metadata`,
+/// `load_skill_body` (the lazy on-invoke loader), `format_skill_catalog`
+/// (prompt-injection rendering), and `FsSkillResolver` (the concrete
+/// `tools::SkillResolver` impl the `use_skill` tool is built on).
+/// Test: `skills::tests::*`.
+pub mod skills;
 
 /// Harness mode selection: `daily-driver` (default, token-efficiency
 /// consumption point) vs `parity` (full-schema benchmark mode) — #2059,

--- a/crates/trusty-code/src/prompt/assembler.rs
+++ b/crates/trusty-code/src/prompt/assembler.rs
@@ -99,38 +99,46 @@ pub fn assemble_system_prompt(
     sections.join(SECTION_SEPARATOR)
 }
 
-/// Mode-aware prompt assembly — the CONSUMPTION POINT #2059 wires up for
-/// P1B's token-efficiency work, without implementing any of it here.
+/// Mode-aware prompt assembly — the CONSUMPTION POINT #2059 wired up for
+/// P1B's token-efficiency work; #2069 is the first arm to actually land in
+/// it (progressive-disclosure skill loading).
 ///
 /// Why: vision spec §5.9 resolves the parity/daily-driver split at the
 /// prompt-assembly and tool-schema layers. This function is where the
-/// prompt-assembly half of that branch lives — real code, both arms
-/// currently identical, so P1B has an obvious, already-wired seam to change
-/// ONE arm without touching every call site (`task::executor`,
-/// `runner::in_process::InProcessAgentRunner::run_pipeline`) that currently
-/// calls [`assemble_system_prompt`] directly.
-/// What: `HarnessMode::Parity` calls [`assemble_system_prompt`] verbatim —
-/// this is contractually permanent, since parity-spec D2 requires
-/// byte-identical schemas/prompts for benchmark fairness and must never
-/// change. `HarnessMode::DailyDriver` ALSO calls it verbatim today (M1: no
-/// token-efficiency built yet — see the crate-level `mode` module docs);
-/// P1B is expected to replace only this arm (progressive-disclosure skill
-/// loading, compaction, etc.), never the `Parity` arm.
-/// Test: `prompt::tests::assemble_system_prompt_for_mode_is_identical_in_m1`.
+/// prompt-assembly half of that branch lives — a single seam both call
+/// sites (`task::executor`, `runner::in_process::InProcessAgentRunner::run_pipeline`)
+/// go through, so a token-efficiency change lands in ONE arm without
+/// touching either caller's call shape beyond the one new argument.
+/// What: `HarnessMode::Parity` calls [`assemble_system_prompt`] verbatim and
+/// ignores `skills_catalog` entirely — this is contractually permanent,
+/// since parity-spec D2 requires byte-identical schemas/prompts for
+/// benchmark fairness and must never progressively disclose (#2069's own
+/// scope note: "Parity mode should NOT progressively disclose").
+/// `HarnessMode::DailyDriver` appends `skills_catalog` (the cheap,
+/// always-cached `skills::format_skill_catalog` output — NOT any skill's
+/// full body) as a trailing section when non-empty, via the same
+/// [`SECTION_SEPARATOR`] every other section uses; when `skills_catalog` is
+/// `None` or empty, `DailyDriver` output is still byte-identical to
+/// `Parity`, preserving the pre-#2069 M1 contract for projects with no
+/// `.claude/skills/` catalog.
+/// Test: `prompt::tests::assemble_system_prompt_for_mode_identical_when_no_skills`,
+/// `prompt::tests::daily_driver_appends_skills_catalog`,
+/// `prompt::tests::parity_ignores_skills_catalog`.
 pub fn assemble_system_prompt_for_mode(
     mode: crate::mode::HarnessMode,
     config: &AgentConfig,
     project_context: Option<&str>,
     fallback_guidance: Option<&str>,
+    skills_catalog: Option<&str>,
 ) -> String {
+    let base = assemble_system_prompt(config, project_context, fallback_guidance);
     match mode {
-        crate::mode::HarnessMode::Parity => {
-            assemble_system_prompt(config, project_context, fallback_guidance)
-        }
-        // P1B hooks in here: deferred/progressive-disclosure prompt assembly.
-        // Byte-identical to `Parity` until then (#2059 M1 scope).
+        crate::mode::HarnessMode::Parity => base,
         crate::mode::HarnessMode::DailyDriver => {
-            assemble_system_prompt(config, project_context, fallback_guidance)
+            match skills_catalog.map(str::trim).filter(|s| !s.is_empty()) {
+                Some(catalog) => format!("{base}{SECTION_SEPARATOR}{catalog}"),
+                None => base,
+            }
         }
     }
 }

--- a/crates/trusty-code/src/prompt/mod.rs
+++ b/crates/trusty-code/src/prompt/mod.rs
@@ -9,8 +9,10 @@
 //! What: Re-exports [`BASE_PREAMBLE`], [`BASE_PREAMBLE_VERSION`],
 //! [`PromptAssembler`], [`assemble_system_prompt`], and (#2059)
 //! [`assemble_system_prompt_for_mode`] — the `HarnessMode`-branching entry
-//! point `task::executor`/`runner::in_process` call so P1B's daily-driver
-//! token-efficiency work has a real, already-wired seam to land in.
+//! point `task::executor`/`runner::in_process` call. Its `skills_catalog`
+//! parameter (#2069) is P1B's first token-efficiency layer to actually land:
+//! `DailyDriver` appends the cheap, always-cached skill metadata catalog
+//! (`crate::skills::format_skill_catalog`); `Parity` ignores it.
 //! Test: `prompt::tests::*` (via `assembler.rs`'s inline test include).
 
 mod assembler;

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -303,28 +303,87 @@ fn all_sections_present_when_supplied() {
     assert!(out.contains("FALLBACK"));
 }
 
-/// #2059's mode-aware branch point must produce IDENTICAL output for both
-/// modes in M1 — no token-efficiency behaviour has been built yet, so the
-/// branch existing (and being exercised by this test) matters more than any
-/// difference in its output today.
+/// With no skills catalog, #2059's mode-aware branch point must produce
+/// IDENTICAL output for both modes — this is the pre-#2069 M1 contract,
+/// preserved for any project with no `.claude/skills/` catalog (or when the
+/// catalog happens to be empty).
 ///
-/// Why: pins the documented "byte-identical until P1B" contract so a future
-/// change to ONE arm is a deliberate, visible diff to this test, not a
-/// silent divergence.
-/// What: asserts `assemble_system_prompt_for_mode` returns the exact same
-/// string as `assemble_system_prompt` for both `HarnessMode` variants.
+/// Why: pins the "byte-identical when there is nothing to progressively
+/// disclose" contract so a future change to the `DailyDriver` arm cannot
+/// silently regress projects with no skills.
+/// What: asserts `assemble_system_prompt_for_mode` with `skills_catalog:
+/// None` returns the exact same string as `assemble_system_prompt` for both
+/// `HarnessMode` variants.
 /// Test: this test.
 #[test]
-fn assemble_system_prompt_for_mode_is_identical_in_m1() {
+fn assemble_system_prompt_for_mode_identical_when_no_skills() {
     let cfg = config_with_prompt("AGENT");
     let baseline = assemble_system_prompt(&cfg, Some("PROJECT"), Some("FALLBACK"));
 
     for mode in [HarnessMode::DailyDriver, HarnessMode::Parity] {
         let via_mode =
-            assemble_system_prompt_for_mode(mode, &cfg, Some("PROJECT"), Some("FALLBACK"));
+            assemble_system_prompt_for_mode(mode, &cfg, Some("PROJECT"), Some("FALLBACK"), None);
         assert_eq!(
             via_mode, baseline,
-            "mode {mode:?} must match baseline in M1"
+            "mode {mode:?} must match baseline when there is no skills catalog"
         );
     }
+}
+
+/// `HarnessMode::DailyDriver` appends a non-empty skills catalog as a
+/// trailing section (#2069).
+///
+/// Why: This is the actual token-efficiency payoff — the DailyDriver prompt
+/// gains the cheap metadata-only catalog, never a skill's full body.
+/// What: Asserts the DailyDriver output contains both the baseline (BASE +
+/// agent + project + fallback) and the catalog text, with the catalog
+/// appearing after the baseline.
+/// Test: this test.
+#[test]
+fn daily_driver_appends_skills_catalog() {
+    let cfg = config_with_prompt("AGENT");
+    let catalog = "Available skills:\n- demo-skill: Does demo things";
+
+    let out = assemble_system_prompt_for_mode(
+        HarnessMode::DailyDriver,
+        &cfg,
+        Some("PROJECT"),
+        Some("FALLBACK"),
+        Some(catalog),
+    );
+
+    assert!(out.contains("AGENT"));
+    assert!(out.contains(catalog));
+    assert!(
+        out.find("FALLBACK").unwrap() < out.find(catalog).unwrap(),
+        "the skills catalog must be the trailing section"
+    );
+}
+
+/// `HarnessMode::Parity` ignores `skills_catalog` entirely, even when given
+/// one (#2069's scope note: "Parity mode should NOT progressively
+/// disclose").
+///
+/// Why: The parity spec's byte-identical-schema guarantee (D2) must never
+/// depend on which project's `.claude/skills/` catalog happens to be
+/// present.
+/// What: Asserts `Parity` output with `Some(catalog)` equals the plain
+/// `assemble_system_prompt` baseline and does not contain the catalog text.
+/// Test: this test.
+#[test]
+fn parity_ignores_skills_catalog() {
+    let cfg = config_with_prompt("AGENT");
+    let baseline = assemble_system_prompt(&cfg, Some("PROJECT"), Some("FALLBACK"));
+    let catalog = "Available skills:\n- demo-skill: Does demo things";
+
+    let out = assemble_system_prompt_for_mode(
+        HarnessMode::Parity,
+        &cfg,
+        Some("PROJECT"),
+        Some("FALLBACK"),
+        Some(catalog),
+    );
+
+    assert_eq!(out, baseline);
+    assert!(!out.contains("demo-skill"));
 }

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -144,6 +144,13 @@ pub struct InProcessAgentRunner {
     /// pre-#2059 behaviour exactly (both modes are functionally identical
     /// in M1 regardless).
     mode: HarnessMode,
+    /// #2069: the rendered, metadata-only skill catalog
+    /// (`skills::format_skill_catalog`) threaded into every sub-agent prompt
+    /// this runner assembles, in `HarnessMode::DailyDriver` only (the mode
+    /// arm ignores it entirely in `Parity` — see
+    /// `assemble_system_prompt_for_mode`'s docs). `None` until
+    /// `with_skills_catalog` is called, matching pre-#2069 behaviour exactly.
+    skills_catalog: Option<String>,
 }
 
 impl InProcessAgentRunner {
@@ -170,6 +177,7 @@ impl InProcessAgentRunner {
             sink: None,
             cancel: None,
             mode: HarnessMode::default(),
+            skills_catalog: None,
         }
     }
 
@@ -221,6 +229,23 @@ impl InProcessAgentRunner {
     /// prompt captured by the scripted client).
     pub fn with_project_context(mut self, context: impl Into<String>) -> Self {
         self.project_context = Some(context.into());
+        self
+    }
+
+    /// Attach the rendered skill catalog (#2069) injected into every
+    /// `HarnessMode::DailyDriver` prompt this runner assembles.
+    ///
+    /// Why: A delegated sub-agent should see the same cheap, metadata-only
+    /// skill catalog the delegating PM does, without the runner needing to
+    /// know how the catalog was discovered (the caller renders it via
+    /// `skills::format_skill_catalog` and passes the result straight
+    /// through).
+    /// What: Builder-style setter; returns `self` for chaining. Ignored
+    /// entirely by `HarnessMode::Parity` at prompt-assembly time.
+    /// Test: `runner::tests::skills_catalog_reaches_daily_driver_prompt`,
+    /// `runner::tests::skills_catalog_ignored_in_parity`.
+    pub fn with_skills_catalog(mut self, catalog: impl Into<String>) -> Self {
+        self.skills_catalog = Some(catalog.into());
         self
     }
 
@@ -297,11 +322,13 @@ impl InProcessAgentRunner {
         // Assemble the mode-branched system prompt (BASE + agent prompt +
         // project ctx) — see `assemble_system_prompt_for_mode`'s docs (#2059).
         // Fallback guidance (the #1023 per-tier seam) is not wired here yet.
+        // `skills_catalog` (#2069) is appended only in `HarnessMode::DailyDriver`.
         let system = assemble_system_prompt_for_mode(
             self.mode,
             &agent,
             self.project_context.as_deref(),
             None,
+            self.skills_catalog.as_deref(),
         );
 
         let mut agent_loop = AgentLoop::new(loop_config, Arc::clone(&self.llm), registry);

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -568,6 +568,68 @@ async fn project_context_reaches_prompt() {
     );
 }
 
+/// The skill catalog (#2069) reaches the assembled prompt in
+/// `HarnessMode::DailyDriver`.
+///
+/// Why: A delegated sub-agent must see the same cheap, metadata-only skill
+/// catalog the delegating PM does.
+/// What: Attach a distinctive catalog marker via `with_skills_catalog`,
+/// default mode (`DailyDriver`); assert it appears in the assembled prompt.
+/// Test: this test.
+#[tokio::test]
+async fn skills_catalog_reaches_daily_driver_prompt() {
+    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec![], invoked));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf())
+        .with_skills_catalog("SKILLS-CATALOG-MARKER");
+
+    runner
+        .run("python-engineer", "task")
+        .await
+        .expect("completes");
+
+    let (_, system) = llm.first_request();
+    assert!(
+        system.contains("SKILLS-CATALOG-MARKER"),
+        "assembled DailyDriver prompt must include the skill catalog"
+    );
+}
+
+/// The skill catalog (#2069) is ignored entirely under `HarnessMode::Parity`.
+///
+/// Why: Parity's byte-identical-schema/prompt guarantee (parity-spec D2)
+/// must never depend on a project's skill catalog.
+/// What: Attach a catalog marker AND `with_mode(Parity)`; assert the marker
+/// is absent from the assembled prompt.
+/// Test: this test.
+#[tokio::test]
+async fn skills_catalog_ignored_in_parity() {
+    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec![], invoked));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf())
+        .with_skills_catalog("SKILLS-CATALOG-MARKER")
+        .with_mode(crate::mode::HarnessMode::Parity);
+
+    runner
+        .run("python-engineer", "task")
+        .await
+        .expect("completes");
+
+    let (_, system) = llm.first_request();
+    assert!(
+        !system.contains("SKILLS-CATALOG-MARKER"),
+        "Parity prompt must never include the skill catalog"
+    );
+}
+
 /// `with_mode` must be chainable and a delegated run must complete
 /// successfully under EITHER `HarnessMode` (#2059) — both modes are
 /// functionally identical in M1, so this pins "the builder wires through

--- a/crates/trusty-code/src/skills/frontmatter.rs
+++ b/crates/trusty-code/src/skills/frontmatter.rs
@@ -1,0 +1,186 @@
+//! Minimal `---`-fenced frontmatter parser for `SKILL.md` files.
+//!
+//! Why: `trusty-code` does not depend on `trusty-mpm` (separate products —
+//! see the crate-level docs), so its own lightweight parser is needed rather
+//! than reusing `trusty_mpm::core::frontmatter`. Skill metadata only ever
+//! needs a couple of scalar keys (`name`, `description`), so this is
+//! deliberately a small subset of full YAML: flat `key: value` lines between
+//! two `---` fences, first-colon-only splitting (so URLs/model-ids/timestamps
+//! in a value survive), and a single optional surrounding-quote strip.
+//! What: [`parse_frontmatter`] returns the fenced key/value map;
+//! [`strip_frontmatter`] returns everything after the closing fence.
+//! Test: `frontmatter::tests::*` — happy path, no-fence input, unterminated
+//! fence, quoted values, blank/comment lines inside the fence.
+
+use std::collections::HashMap;
+
+/// Parse the `---`-fenced frontmatter block at the start of `raw` into a
+/// flat key/value map.
+///
+/// Why: Discovery needs `name`/`description` without reading (or caring
+/// about) the Markdown body that follows.
+/// What: Returns an empty map when `raw` does not open with a `---` fence
+/// line, or when no closing fence is found (malformed input degrades to "no
+/// metadata", never a panic). Each line between the fences is parsed by
+/// [`parse_kv_line`]; blank lines and `#` comments are skipped.
+/// Test: `frontmatter::tests::parse_frontmatter_reads_name_and_description`,
+/// `parse_frontmatter_no_opening_fence_is_empty`,
+/// `parse_frontmatter_unterminated_fence_is_empty`.
+pub fn parse_frontmatter(raw: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let mut lines = raw.lines();
+
+    match lines.next() {
+        Some(first) if first.trim() == "---" => {}
+        _ => return map,
+    }
+
+    for line in lines {
+        if line.trim() == "---" {
+            return map;
+        }
+        if let Some((k, v)) = parse_kv_line(line) {
+            map.insert(k, v);
+        }
+    }
+
+    // No closing fence found — treat as if no frontmatter were present.
+    HashMap::new()
+}
+
+/// Return the slice of `raw` after the closing `---` fence, or `raw` itself
+/// when there is no well-formed fence pair.
+///
+/// Why: The lazy body loader wants the Markdown body only, not the
+/// frontmatter block that discovery already consumed.
+/// What: Walks lines tracking whether the opening fence was seen; on the
+/// second `---` line, returns everything after it. Falls back to the whole
+/// input when the fence is absent or unterminated.
+/// Test: `frontmatter::tests::strip_frontmatter_removes_fenced_block`,
+/// `strip_frontmatter_returns_whole_input_when_no_fence`.
+pub fn strip_frontmatter(raw: &str) -> &str {
+    let trimmed = raw.trim_start();
+    if !trimmed.starts_with("---") {
+        return raw;
+    }
+
+    let mut saw_open = false;
+    let mut consumed = 0usize;
+    for line in trimmed.split_inclusive('\n') {
+        consumed += line.len();
+        if line.trim_end_matches('\n').trim() == "---" {
+            if saw_open {
+                return &trimmed[consumed..];
+            }
+            saw_open = true;
+        }
+    }
+
+    // Opening fence with no closing fence — malformed; treat whole input as body.
+    raw
+}
+
+/// Parse one frontmatter line into a `(key, value)` pair.
+///
+/// Why: Values may legitimately contain colons (URLs, timestamps); splitting
+/// on the *first* colon only preserves them.
+/// What: Returns `None` for blank lines and `#` comments. Trims the key,
+/// trims the value, and strips one balanced surrounding `"`/`'` quote pair.
+/// Test: `frontmatter::tests::parse_kv_line_*`.
+fn parse_kv_line(line: &str) -> Option<(String, String)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let (raw_key, raw_value) = trimmed.split_once(':')?;
+    let key = raw_key.trim().to_string();
+    if key.is_empty() {
+        return None;
+    }
+    Some((key, strip_one_quote_pair(raw_value.trim()).to_string()))
+}
+
+/// Strip at most one balanced pair of surrounding `"` or `'` quotes.
+fn strip_one_quote_pair(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &value[1..value.len() - 1];
+        }
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_frontmatter_reads_name_and_description() {
+        let raw = "---\nname: demo\ndescription: A demo skill\n---\nbody\n";
+        let map = parse_frontmatter(raw);
+        assert_eq!(map.get("name").map(String::as_str), Some("demo"));
+        assert_eq!(
+            map.get("description").map(String::as_str),
+            Some("A demo skill")
+        );
+    }
+
+    #[test]
+    fn parse_frontmatter_no_opening_fence_is_empty() {
+        let map = parse_frontmatter("name: demo\nno fence here\n");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn parse_frontmatter_unterminated_fence_is_empty() {
+        let map = parse_frontmatter("---\nname: demo\n(no closing fence)\n");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn parse_frontmatter_skips_blank_and_comment_lines() {
+        let raw = "---\n\n# a comment\nname: demo\n---\n";
+        let map = parse_frontmatter(raw);
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get("name").map(String::as_str), Some("demo"));
+    }
+
+    #[test]
+    fn parse_frontmatter_value_with_colon_survives() {
+        let raw = "---\nwhen_to_use: Use when x: y happens\n---\n";
+        let map = parse_frontmatter(raw);
+        assert_eq!(
+            map.get("when_to_use").map(String::as_str),
+            Some("Use when x: y happens")
+        );
+    }
+
+    #[test]
+    fn parse_frontmatter_strips_quotes() {
+        let raw = "---\nversion: \"1.0.0\"\n---\n";
+        let map = parse_frontmatter(raw);
+        assert_eq!(map.get("version").map(String::as_str), Some("1.0.0"));
+    }
+
+    #[test]
+    fn strip_frontmatter_removes_fenced_block() {
+        let raw = "---\nname: demo\n---\n# Body\ntext\n";
+        let body = strip_frontmatter(raw);
+        assert_eq!(body.trim(), "# Body\ntext");
+    }
+
+    #[test]
+    fn strip_frontmatter_returns_whole_input_when_no_fence() {
+        let raw = "# Just a body\ntext\n";
+        assert_eq!(strip_frontmatter(raw), raw);
+    }
+
+    #[test]
+    fn strip_frontmatter_returns_whole_input_when_unterminated() {
+        let raw = "---\nname: demo\nno closing fence\n";
+        assert_eq!(strip_frontmatter(raw), raw);
+    }
+}

--- a/crates/trusty-code/src/skills/mod.rs
+++ b/crates/trusty-code/src/skills/mod.rs
@@ -1,0 +1,453 @@
+//! Progressive-disclosure skill discovery for `.claude/skills/` (#2069, vision
+//! spec §5.3, Resolved Decision #7).
+//!
+//! Why: A project's `.claude/skills/` catalog can hold dozens of skills, but
+//! any given task only ever invokes a handful of them. Injecting every
+//! skill's full Markdown body into the system prompt up front wastes
+//! 500-1000+ tokens per session for a 20-skill catalog (spec §5.3 impact
+//! estimate) when ~80% of skills are never invoked. Splitting a skill into
+//! cheap, always-cached metadata (name + one-line description, ~100 tokens
+//! per skill) and an on-demand-loaded body lets the PM/agents see the full
+//! catalog for free and pay the body's token cost only for skills they
+//! actually use. This module mirrors `agents::discover_agents`'s directory
+//! scanning pattern, adapted for the Claude-Code skill layout: one
+//! subdirectory per skill, each holding a `SKILL.md` with YAML-ish
+//! frontmatter (`name:`, `description:`, …) followed by the Markdown body.
+//! What: [`SkillMetadata`] (the cached catalog entry), [`locate_skills_dir`]
+//! (resolves `<project_root>/.claude/skills` — the Claude-Code-compatible
+//! path; deliberately NOT `~/.trusty-mpm/skills/`), [`discover_skill_metadata`]
+//! (scans the directory and parses just the frontmatter of every skill),
+//! [`load_skill_body`] (the lazy, on-invoke full-body loader), and
+//! [`format_skill_catalog`] (renders the metadata list for prompt injection).
+//! [`FsSkillResolver`] implements `tools::traits::SkillResolver` over this
+//! discovery layer, giving the tool-registry layer a ready-to-register
+//! concrete resolver.
+//! Test: `skills::tests::*` — discovery over tempdir fixtures (happy path,
+//! missing dir, missing `SKILL.md`, malformed/no-frontmatter file), lazy body
+//! load (found + unknown-name), catalog formatting (empty + populated), and
+//! `FsSkillResolver`'s `SkillResolver` trait conformance.
+
+mod frontmatter;
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+use crate::tools::traits::SkillResolver;
+use frontmatter::{parse_frontmatter, strip_frontmatter};
+
+/// Cheap, always-cached catalog entry for one discovered skill.
+///
+/// Why: The PM/agents need to see what skills exist and when to reach for
+/// them without paying for every skill's full body up front.
+/// What: `name` (frontmatter `name:`, falling back to the skill's directory
+/// name) and `description` (frontmatter `description:`, empty string if
+/// absent).
+/// Test: `discover_skill_metadata_reads_name_and_description`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillMetadata {
+    pub name: String,
+    pub description: String,
+}
+
+/// Errors from lazily loading a skill's full body.
+///
+/// Why: A named error type lets `SkillResolver::resolve` and the `use_skill`
+/// tool distinguish "unknown skill" (an LLM hallucinated a name) from a
+/// genuine IO failure, both without panicking.
+/// What: `Unknown` — the name is not in the discovered catalog; `Io` — the
+/// `SKILL.md` file could not be read even though the name is known.
+/// Test: `load_skill_body_rejects_unknown_name`, `load_skill_body_io_error`.
+#[derive(Debug, Error)]
+pub enum SkillError {
+    #[error("skill '{0}' is not in the discovered catalog")]
+    Unknown(String),
+    #[error("failed to read skill body for '{name}': {source}")]
+    Io {
+        name: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Locate the Claude-Code-compatible skills directory for a project root.
+///
+/// Why: #2069 pins this to `.claude/skills/` exactly — the Claude-Code-native
+/// convention — and explicitly NOT the legacy `~/.trusty-mpm/skills/` path
+/// trusty-mpm uses, so a project's skill catalog resolves identically whether
+/// browsed by a human in Claude Code or discovered by `tcode`.
+/// What: Returns `<project_root>/.claude/skills` (may not exist yet — callers
+/// handle absence via `discover_skill_metadata`'s empty-Vec fallback).
+/// Test: `locate_skills_dir_is_dot_claude_skills`.
+pub fn locate_skills_dir(project_root: &Path) -> PathBuf {
+    project_root.join(".claude").join("skills")
+}
+
+/// Discover skill metadata from every `<dir>/<skill-name>/SKILL.md`.
+///
+/// Why: The catalog must be built once, cheaply, from cheap-to-read
+/// frontmatter only — the whole point of progressive disclosure is to avoid
+/// reading full skill bodies until they are actually invoked.
+/// What: Scans immediate subdirectories of `dir`; a subdirectory without a
+/// readable `SKILL.md` is skipped (not an error — mirrors
+/// `agents::discover_agents`'s graceful-skip convention). Returns entries
+/// sorted by `name`. A missing/unreadable `dir` yields an empty Vec.
+/// Test: `discover_skill_metadata_reads_name_and_description`,
+/// `discover_skill_metadata_skips_dir_without_skill_md`,
+/// `discover_skill_metadata_missing_dir_is_empty`,
+/// `discover_skill_metadata_falls_back_to_dirname`.
+pub fn discover_skill_metadata(dir: &Path) -> Vec<SkillMetadata> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        tracing::debug!("skills dir not found or unreadable: {}", dir.display());
+        return vec![];
+    };
+
+    let mut skills: Vec<SkillMetadata> = entries
+        .flatten()
+        .filter_map(|entry| load_metadata_from_skill_dir(&entry.path()))
+        .collect();
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    skills
+}
+
+/// Load one skill directory's metadata, if it holds a readable `SKILL.md`.
+///
+/// Why: Factored out of `discover_skill_metadata` so each rejection reason
+/// (not a directory, no `SKILL.md`, unreadable) can be logged distinctly.
+/// What: Returns `None` (with a debug log) for anything that is not a skill
+/// directory; otherwise parses frontmatter and falls back to the directory
+/// name when `name:` is absent.
+/// Test: covered via `discover_skill_metadata`'s tests above.
+fn load_metadata_from_skill_dir(path: &Path) -> Option<SkillMetadata> {
+    if !path.is_dir() {
+        return None;
+    }
+    let dirname = path.file_name()?.to_str()?.to_string();
+    let skill_md = path.join("SKILL.md");
+    let raw = match std::fs::read_to_string(&skill_md) {
+        Ok(raw) => raw,
+        Err(e) => {
+            tracing::debug!("skipping skill dir '{dirname}': no readable SKILL.md ({e})");
+            return None;
+        }
+    };
+    let front = parse_frontmatter(&raw);
+    let name = front.get("name").cloned().unwrap_or(dirname);
+    let description = front.get("description").cloned().unwrap_or_default();
+    Some(SkillMetadata { name, description })
+}
+
+/// Lazily load one skill's full Markdown body (the frontmatter stripped off).
+///
+/// Why: This is the "on invoke" half of progressive disclosure — the body is
+/// read from disk only when a caller (the `use_skill` tool, or a resolver's
+/// `resolve`) actually needs it.
+/// What: Rejects any `name` not present in `known` (the cached catalog) up
+/// front — this doubles as the path-traversal guard, since the join'd path is
+/// only ever built from a name the catalog itself already discovered on disk.
+/// Reads `<skills_dir>/<name>/SKILL.md` and returns the body after the
+/// frontmatter fence, trimmed.
+/// Test: `load_skill_body_returns_body_without_frontmatter`,
+/// `load_skill_body_rejects_unknown_name`.
+pub fn load_skill_body(
+    skills_dir: &Path,
+    name: &str,
+    known: &[SkillMetadata],
+) -> Result<String, SkillError> {
+    if !known.iter().any(|m| m.name == name) {
+        return Err(SkillError::Unknown(name.to_string()));
+    }
+    let path = skills_dir.join(name).join("SKILL.md");
+    let raw = std::fs::read_to_string(&path).map_err(|source| SkillError::Io {
+        name: name.to_string(),
+        source,
+    })?;
+    Ok(strip_frontmatter(&raw).trim().to_string())
+}
+
+/// Render the compact, always-injected skill catalog for prompt assembly.
+///
+/// Why: This is the entire token-efficiency payoff — a one-line-per-skill
+/// listing instead of every skill's full body.
+/// What: Returns an empty string when `skills` is empty (callers treat an
+/// empty section as "omit it", matching `assemble_system_prompt`'s
+/// empty-section-skipping convention). Otherwise a header line plus one
+/// `- name: description` line per skill, in the given order (callers pass
+/// already name-sorted `Vec`s from `discover_skill_metadata`).
+/// Test: `format_skill_catalog_empty_is_empty_string`,
+/// `format_skill_catalog_lists_every_skill`.
+pub fn format_skill_catalog(skills: &[SkillMetadata]) -> String {
+    if skills.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from(
+        "Available skills (invoke the `use_skill` tool with the skill name to load its full instructions):\n",
+    );
+    for s in skills {
+        out.push_str(&format!("- {}: {}\n", s.name, s.description));
+    }
+    out.trim_end().to_string()
+}
+
+/// Filesystem-backed [`SkillResolver`] over a `.claude/skills/` directory.
+///
+/// Why: Gives the tool-registry layer (the `use_skill` tool) a ready
+/// concrete resolver: metadata is discovered once at construction (cheap,
+/// cached); `resolve` reads a single skill's body lazily, on demand.
+/// What: Wraps `skills_dir` plus the metadata discovered from it at
+/// construction time. `metadata()`/`list()` return the cached catalog;
+/// `resolve()` calls `load_skill_body` per invocation.
+/// Test: `fs_skill_resolver_resolves_known_skill`,
+/// `fs_skill_resolver_list_matches_metadata_names`,
+/// `fs_skill_resolver_resolve_unknown_returns_none`.
+pub struct FsSkillResolver {
+    skills_dir: PathBuf,
+    metadata: Vec<SkillMetadata>,
+}
+
+impl FsSkillResolver {
+    /// Construct a resolver, eagerly discovering (cheap) metadata.
+    ///
+    /// Why: Metadata discovery is a directory scan plus frontmatter parsing
+    /// only — cheap enough to do once at construction so every later
+    /// `metadata()`/`list()` call is a clone of an in-memory `Vec`.
+    /// What: Calls `discover_skill_metadata(&skills_dir)` and stores both.
+    /// Test: `fs_skill_resolver_resolves_known_skill`.
+    pub fn new(skills_dir: impl Into<PathBuf>) -> Self {
+        let skills_dir = skills_dir.into();
+        let metadata = discover_skill_metadata(&skills_dir);
+        Self {
+            skills_dir,
+            metadata,
+        }
+    }
+}
+
+impl SkillResolver for FsSkillResolver {
+    fn resolve(&self, name: &str) -> Option<String> {
+        load_skill_body(&self.skills_dir, name, &self.metadata).ok()
+    }
+
+    fn list(&self) -> Vec<String> {
+        self.metadata.iter().map(|m| m.name.clone()).collect()
+    }
+
+    fn metadata(&self) -> Vec<SkillMetadata> {
+        self.metadata.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_skill(root: &Path, name: &str, frontmatter: &str, body: &str) {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).expect("mkdir skill dir");
+        std::fs::write(dir.join("SKILL.md"), format!("{frontmatter}{body}")).expect("write");
+    }
+
+    /// `locate_skills_dir` returns `<project_root>/.claude/skills` exactly.
+    ///
+    /// Why: Pins the Claude-Code-compatible path (#2069) so a future edit
+    /// cannot silently drift back to `~/.trusty-mpm/skills/`.
+    /// Test: this test.
+    #[test]
+    fn locate_skills_dir_is_dot_claude_skills() {
+        let root = Path::new("/fake/project");
+        assert_eq!(locate_skills_dir(root), root.join(".claude").join("skills"));
+    }
+
+    /// Discovery reads `name`/`description` from frontmatter for every
+    /// skill directory containing a `SKILL.md`.
+    ///
+    /// Why: This is the core "always cached, cheap" discovery contract.
+    /// What: Two skill dirs; asserts both appear, sorted by name, with the
+    /// exact frontmatter values.
+    /// Test: this test.
+    #[test]
+    fn discover_skill_metadata_reads_name_and_description() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_skill(
+            tmp.path(),
+            "zeta-skill",
+            "---\nname: zeta-skill\ndescription: Does zeta things\n---\n",
+            "# Zeta\nbody\n",
+        );
+        write_skill(
+            tmp.path(),
+            "alpha-skill",
+            "---\nname: alpha-skill\ndescription: Does alpha things\n---\n",
+            "# Alpha\nbody\n",
+        );
+
+        let skills = discover_skill_metadata(tmp.path());
+        assert_eq!(skills.len(), 2);
+        assert_eq!(skills[0].name, "alpha-skill");
+        assert_eq!(skills[0].description, "Does alpha things");
+        assert_eq!(skills[1].name, "zeta-skill");
+        assert_eq!(skills[1].description, "Does zeta things");
+    }
+
+    /// A subdirectory with no `SKILL.md` is skipped, not an error.
+    ///
+    /// Why: `.claude/skills/` may contain scratch or in-progress
+    /// directories; discovery must degrade gracefully (no panic).
+    /// Test: this test.
+    #[test]
+    fn discover_skill_metadata_skips_dir_without_skill_md() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join("not-a-skill")).expect("mkdir");
+        write_skill(
+            tmp.path(),
+            "real-skill",
+            "---\nname: real-skill\ndescription: A real one\n---\n",
+            "body\n",
+        );
+
+        let skills = discover_skill_metadata(tmp.path());
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "real-skill");
+    }
+
+    /// A missing skills directory yields an empty catalog, not an error.
+    ///
+    /// Why: Most projects will not have a `.claude/skills/` dir at all;
+    /// this must never panic or hard-fail discovery.
+    /// Test: this test.
+    #[test]
+    fn discover_skill_metadata_missing_dir_is_empty() {
+        let skills = discover_skill_metadata(Path::new("/nonexistent/skills/dir"));
+        assert!(skills.is_empty());
+    }
+
+    /// A `SKILL.md` with no frontmatter fence falls back to the directory
+    /// name and an empty description, rather than being rejected.
+    ///
+    /// Why: Malformed skill files must degrade gracefully (no panic).
+    /// Test: this test.
+    #[test]
+    fn discover_skill_metadata_falls_back_to_dirname() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_skill(tmp.path(), "no-frontmatter", "", "# Just a body\n");
+
+        let skills = discover_skill_metadata(tmp.path());
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "no-frontmatter");
+        assert_eq!(skills[0].description, "");
+    }
+
+    /// `load_skill_body` returns the body with frontmatter stripped, for a
+    /// name present in the known catalog.
+    ///
+    /// Why: This is the lazy on-invoke load path.
+    /// Test: this test.
+    #[test]
+    fn load_skill_body_returns_body_without_frontmatter() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_skill(
+            tmp.path(),
+            "demo-skill",
+            "---\nname: demo-skill\ndescription: Demo\n---\n",
+            "# Demo Skill\nFull instructions here.\n",
+        );
+        let known = discover_skill_metadata(tmp.path());
+
+        let body = load_skill_body(tmp.path(), "demo-skill", &known).expect("load body");
+        assert!(body.contains("# Demo Skill"));
+        assert!(body.contains("Full instructions here."));
+        assert!(!body.contains("description: Demo"));
+    }
+
+    /// `load_skill_body` rejects a name absent from the known catalog.
+    ///
+    /// Why: This is the safety guard against an LLM hallucinating a skill
+    /// name — no path is ever built from a name outside the discovered set.
+    /// Test: this test.
+    #[test]
+    fn load_skill_body_rejects_unknown_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let known = discover_skill_metadata(tmp.path());
+        let err = load_skill_body(tmp.path(), "ghost-skill", &known);
+        assert!(matches!(err, Err(SkillError::Unknown(_))));
+    }
+
+    /// `format_skill_catalog` returns an empty string for an empty catalog.
+    ///
+    /// Why: An empty section must contribute nothing to the assembled
+    /// prompt, matching `assemble_system_prompt`'s empty-section-skipping.
+    /// Test: this test.
+    #[test]
+    fn format_skill_catalog_empty_is_empty_string() {
+        assert_eq!(format_skill_catalog(&[]), "");
+    }
+
+    /// `format_skill_catalog` lists every skill as a `- name: description`
+    /// line.
+    ///
+    /// Why: This is the token-efficient catalog the prompt actually sees.
+    /// Test: this test.
+    #[test]
+    fn format_skill_catalog_lists_every_skill() {
+        let skills = vec![
+            SkillMetadata {
+                name: "alpha".into(),
+                description: "First".into(),
+            },
+            SkillMetadata {
+                name: "beta".into(),
+                description: "Second".into(),
+            },
+        ];
+        let catalog = format_skill_catalog(&skills);
+        assert!(catalog.contains("- alpha: First"));
+        assert!(catalog.contains("- beta: Second"));
+    }
+
+    /// `FsSkillResolver::resolve` lazily loads a known skill's body.
+    ///
+    /// Why: Verifies the concrete `SkillResolver` impl end-to-end.
+    /// Test: this test.
+    #[test]
+    fn fs_skill_resolver_resolves_known_skill() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_skill(
+            tmp.path(),
+            "demo-skill",
+            "---\nname: demo-skill\ndescription: Demo\n---\n",
+            "Full body content.\n",
+        );
+        let resolver = FsSkillResolver::new(tmp.path());
+        let body = resolver.resolve("demo-skill").expect("resolve");
+        assert!(body.contains("Full body content."));
+    }
+
+    /// `FsSkillResolver::list` returns exactly the discovered metadata names.
+    ///
+    /// Test: this test.
+    #[test]
+    fn fs_skill_resolver_list_matches_metadata_names() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_skill(
+            tmp.path(),
+            "demo-skill",
+            "---\nname: demo-skill\ndescription: Demo\n---\n",
+            "body\n",
+        );
+        let resolver = FsSkillResolver::new(tmp.path());
+        assert_eq!(resolver.list(), vec!["demo-skill".to_string()]);
+        assert_eq!(resolver.metadata().len(), 1);
+    }
+
+    /// `FsSkillResolver::resolve` returns `None` for an unknown skill name.
+    ///
+    /// Why: Guards against a panic or leaked IO error surfacing through the
+    /// trait's `Option`-returning API.
+    /// Test: this test.
+    #[test]
+    fn fs_skill_resolver_resolve_unknown_returns_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let resolver = FsSkillResolver::new(tmp.path());
+        assert!(resolver.resolve("ghost").is_none());
+    }
+}

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -50,9 +50,10 @@ use crate::run_task::{
 };
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
 use crate::session::{SessionRegistry, SessionStatus};
+use crate::skills::{FsSkillResolver, format_skill_catalog, locate_skills_dir};
 use crate::tools::{
     AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, FinishTaskTool,
-    ReadFileTool, RunContext, ToolRegistry, WriteFileTool,
+    ReadFileTool, RunContext, SkillResolver, ToolRegistry, UseSkillTool, WriteFileTool,
 };
 
 use super::sink::SessionToolEventSink;
@@ -160,10 +161,17 @@ async fn run_and_record(
     let pm_model = resolve_model(&pm_config, None);
     let engineer_model = resolve_engineer_model(&params);
 
+    // #2069: discover the (cheap, metadata-only) skill catalog and, in
+    // DailyDriver mode only, register `use_skill` so the PM can lazily fetch
+    // a skill's full body on demand. Parity never sees the catalog or the
+    // tool — see `assemble_system_prompt_for_mode`'s docs.
+    let skills_catalog = daily_driver_skills_catalog(&params);
+
     let engineer_runner = build_engineer_runner(
         Arc::clone(&llm),
         &params,
         project_context.clone(),
+        skills_catalog.as_ref().map(|(catalog, _)| catalog.clone()),
         Arc::clone(&transcript),
         Arc::clone(&sink),
         Arc::clone(&cancel),
@@ -176,6 +184,9 @@ async fn run_and_record(
         DelegateToAgentTool::new(engineer_runner).with_config_dir(params.agents_dir.clone()),
     ));
     pm_registry.register(Arc::new(FinishTaskTool::new()));
+    if let Some((_, resolver)) = &skills_catalog {
+        pm_registry.register(Arc::new(UseSkillTool::new(Arc::clone(resolver))));
+    }
 
     let pm_llm: Arc<dyn LlmClientTrait> = Arc::new(RecordingLlmClient::new(
         Arc::clone(&llm),
@@ -189,6 +200,7 @@ async fn run_and_record(
         &pm_config,
         project_context.as_deref(),
         catchup_ctx.as_deref(),
+        skills_catalog.as_ref().map(|(catalog, _)| catalog.as_str()),
     );
 
     let pm_loop = AgentLoop::new(
@@ -225,10 +237,17 @@ async fn run_and_record(
 /// the #2056 sink, the shared cancel flag, and (#2059) the SAME resolved
 /// `HarnessMode` as the delegating PM (mirrors `run_task::build_engineer_runner`,
 /// which is private to that module).
+///
+/// `skills_catalog` (#2069) is the same rendered metadata catalog the PM's own
+/// prompt gets, threaded through so the delegated engineer's DailyDriver
+/// prompt also sees it. Wiring the `use_skill` *tool* into the engineer's own
+/// per-delegation registry (`ProjectToolFactory::build`) is deferred — see
+/// this crate's #2069 delivery notes.
 fn build_engineer_runner(
     llm: Arc<dyn LlmClientTrait>,
     params: &TaskRunParams,
     project_context: Option<String>,
+    skills_catalog: Option<String>,
     transcript: SharedTranscript,
     sink: Arc<dyn ToolEventSink>,
     cancel: Arc<AtomicBool>,
@@ -250,7 +269,35 @@ fn build_engineer_runner(
     if let Some(ctx) = project_context {
         runner = runner.with_project_context(ctx);
     }
+    if let Some(catalog) = skills_catalog {
+        runner = runner.with_skills_catalog(catalog);
+    }
     apply_engineer_model_override(Arc::new(runner), params)
+}
+
+/// Discover the (cheap, metadata-only) skill catalog for `params.project` and
+/// build a resolver over it — but only in `HarnessMode::DailyDriver`.
+///
+/// Why: #2069's scope note is explicit — "Parity mode should NOT
+/// progressively disclose" — so `Parity` runs must never discover
+/// `.claude/skills/` at all, let alone advertise the `use_skill` tool or
+/// inject the catalog into the prompt.
+/// What: Returns `None` for `HarnessMode::Parity` or when the project has no
+/// (or an empty) skill catalog; otherwise `Some((rendered_catalog,
+/// resolver))` — the resolver backs the `use_skill` tool registration.
+/// Test: `task::executor::tests::daily_driver_skills_catalog_*`.
+fn daily_driver_skills_catalog(params: &TaskRunParams) -> Option<(String, Arc<dyn SkillResolver>)> {
+    if params.mode != HarnessMode::DailyDriver {
+        return None;
+    }
+    let skills_dir = locate_skills_dir(&params.project);
+    let resolver: Arc<dyn SkillResolver> = Arc::new(FsSkillResolver::new(skills_dir));
+    let catalog = format_skill_catalog(&resolver.metadata());
+    if catalog.is_empty() {
+        None
+    } else {
+        Some((catalog, resolver))
+    }
 }
 
 /// Builds the engineer's project-scoped tool registry for each delegation

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -103,3 +103,59 @@ fn resolve_engineer_model_falls_back_when_config_missing() {
     let model = resolve_engineer_model(&p);
     assert_eq!(model, "unknown");
 }
+
+/// `daily_driver_skills_catalog` returns `None` under `HarnessMode::Parity`,
+/// even when the project has a real `.claude/skills/` catalog (#2069's
+/// scope note: "Parity mode should NOT progressively disclose").
+#[test]
+fn daily_driver_skills_catalog_none_in_parity() {
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+    let skills_dir = project.path().join(".claude").join("skills").join("demo");
+    std::fs::create_dir_all(&skills_dir).expect("mkdir skill dir");
+    std::fs::write(
+        skills_dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: Demo skill\n---\nbody\n",
+    )
+    .expect("write SKILL.md");
+
+    let mut p = params(&agents, &project, "s");
+    p.mode = crate::mode::HarnessMode::Parity;
+
+    assert!(daily_driver_skills_catalog(&p).is_none());
+}
+
+/// `daily_driver_skills_catalog` returns `None` when the project has no
+/// `.claude/skills/` directory at all, even in `HarnessMode::DailyDriver`.
+#[test]
+fn daily_driver_skills_catalog_none_when_no_skills_dir() {
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let mut p = params(&agents, &project, "s");
+    p.mode = crate::mode::HarnessMode::DailyDriver;
+
+    assert!(daily_driver_skills_catalog(&p).is_none());
+}
+
+/// `daily_driver_skills_catalog` returns the rendered catalog + a working
+/// resolver under `HarnessMode::DailyDriver` when skills exist.
+#[test]
+fn daily_driver_skills_catalog_some_when_skills_exist() {
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+    let skills_dir = project.path().join(".claude").join("skills").join("demo");
+    std::fs::create_dir_all(&skills_dir).expect("mkdir skill dir");
+    std::fs::write(
+        skills_dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: Demo skill\n---\nfull body\n",
+    )
+    .expect("write SKILL.md");
+
+    let mut p = params(&agents, &project, "s");
+    p.mode = crate::mode::HarnessMode::DailyDriver;
+
+    let (catalog, resolver) = daily_driver_skills_catalog(&p).expect("catalog present");
+    assert!(catalog.contains("demo: Demo skill"));
+    assert_eq!(resolver.resolve("demo").as_deref(), Some("full body"));
+}

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -6,7 +6,8 @@
 //! What: Re-exports `ToolExecutor`, `AgentRunner`, `RunContext`, `AgentOutput`,
 //! `SearchProvider`, `SearchResult`, `SkillResolver`, and `ToolResult` from
 //! `traits`; `ToolRegistry` from `registry`; `DelegateToAgentTool` from
-//! `delegate`; and `FinishTaskTool` (#2072) from `finish_task`.
+//! `delegate`; `FinishTaskTool` (#2072) from `finish_task`; and `UseSkillTool`
+//! (#2069's progressive-disclosure on-invoke loader) from `skill`.
 //! Test: Unit tests live in each submodule; integration tests use
 //! `DelegateToAgentTool` with a `MockAgentRunner`.
 
@@ -15,6 +16,7 @@ pub mod delegate;
 pub mod finish_task;
 pub mod fs;
 pub mod registry;
+pub mod skill;
 pub mod traits;
 
 // Flat re-exports for `crate::tools::*` convenience.
@@ -27,6 +29,7 @@ pub use finish_task::{
 };
 pub use fs::{EditTool, ReadFileTool, WriteFileTool};
 pub use registry::ToolRegistry;
+pub use skill::UseSkillTool;
 pub use traits::{
     AgentOutput, AgentRunner, HistoryMessage, RunContext, SearchProvider, SearchResult,
     ServiceTier, SkillResolver, ToolExecutor, ToolResult,

--- a/crates/trusty-code/src/tools/skill.rs
+++ b/crates/trusty-code/src/tools/skill.rs
@@ -1,0 +1,186 @@
+//! `use_skill` tool — the on-invoke half of progressive-disclosure skill
+//! loading (#2069).
+//!
+//! Why: The prompt only ever injects the cheap skill *metadata* catalog
+//! (`skills::format_skill_catalog`); an agent that decides a listed skill is
+//! relevant needs a way to actually fetch its full body. `UseSkillTool` is
+//! that seam — a thin `ToolExecutor` wrapping any `SkillResolver`, so the
+//! LLM's tool call is the "invoke" moment that triggers the lazy disk read.
+//! What: `UseSkillTool::new(resolver)` takes any `Arc<dyn SkillResolver>`
+//! (production: `skills::FsSkillResolver`); `execute` looks up the
+//! `{"name": ...}` argument via `resolver.resolve()` and returns the body, or
+//! a recoverable error naming the unknown skill.
+//! Test: `tools::skill::tests::*` — resolves a known skill, errors on an
+//! unknown one, errors on a missing `name` argument, schema shape.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::traits::{SkillResolver, ToolExecutor, ToolResult};
+
+/// `ToolExecutor` that lazily fetches a named skill's full Markdown body.
+///
+/// Why: Keeps the LLM-facing surface (`name()`, `schema()`, `execute()`)
+/// independent of which `SkillResolver` implementation backs it.
+/// What: Delegates every call to the wrapped resolver's `resolve()`.
+/// Test: `use_skill_resolves_known_skill`.
+pub struct UseSkillTool {
+    resolver: Arc<dyn SkillResolver>,
+}
+
+impl UseSkillTool {
+    /// Construct a `UseSkillTool` backed by `resolver`.
+    ///
+    /// Why: Constructor injection keeps the tool testable with a stub
+    /// resolver, matching every other `ToolExecutor` in this crate.
+    /// What: Stores the `Arc<dyn SkillResolver>` for use in `execute`.
+    /// Test: `use_skill_resolves_known_skill`.
+    pub fn new(resolver: Arc<dyn SkillResolver>) -> Self {
+        Self { resolver }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for UseSkillTool {
+    fn name(&self) -> &str {
+        "use_skill"
+    }
+
+    /// OpenAI function-call schema for `use_skill`.
+    ///
+    /// Why: The LLM needs the skill `name` field to make the call; the
+    /// description points back at the catalog the prompt already injected.
+    /// Test: `use_skill_schema_has_required_name`.
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "use_skill",
+                "description": "Load the full instructions for a skill listed in the 'Available skills' catalog. Only call this for a skill you actually intend to use — it returns the skill's complete body.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The exact skill name as it appears in the catalog."
+                        }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    /// Execute a `use_skill` tool call.
+    ///
+    /// Why: This is the moment progressive disclosure actually defers to —
+    /// the body is read from disk only now, not at prompt-assembly time.
+    /// What: Parses `{name}` from `args`, calls `resolver.resolve(name)`, and
+    /// converts the result into a `ToolResult`.
+    /// Test: `use_skill_resolves_known_skill`, `use_skill_errors_on_unknown`,
+    /// `use_skill_errors_on_missing_name`.
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(name) = args.get("name").and_then(Value::as_str) else {
+            return ToolResult::err("use_skill: missing required argument 'name'");
+        };
+
+        match self.resolver.resolve(name) {
+            Some(body) => ToolResult::ok(body),
+            None => ToolResult::err(format!("use_skill: unknown skill '{name}'")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::skills::SkillMetadata;
+
+    /// In-memory stub resolver so these tests do not touch the filesystem.
+    struct StubResolver {
+        bodies: Mutex<HashMap<String, String>>,
+    }
+
+    impl SkillResolver for StubResolver {
+        fn resolve(&self, name: &str) -> Option<String> {
+            self.bodies.lock().expect("lock").get(name).cloned()
+        }
+        fn list(&self) -> Vec<String> {
+            self.bodies.lock().expect("lock").keys().cloned().collect()
+        }
+        fn metadata(&self) -> Vec<SkillMetadata> {
+            self.bodies
+                .lock()
+                .expect("lock")
+                .keys()
+                .map(|name| SkillMetadata {
+                    name: name.clone(),
+                    description: String::new(),
+                })
+                .collect()
+        }
+    }
+
+    fn make_tool() -> UseSkillTool {
+        let mut bodies = HashMap::new();
+        bodies.insert("demo-skill".to_string(), "full demo body".to_string());
+        UseSkillTool::new(Arc::new(StubResolver {
+            bodies: Mutex::new(bodies),
+        }))
+    }
+
+    /// `use_skill` returns the resolved body for a known skill name.
+    ///
+    /// Why: Core happy-path contract for the on-invoke load.
+    /// Test: this test.
+    #[tokio::test]
+    async fn use_skill_resolves_known_skill() {
+        let tool = make_tool();
+        let result = tool.execute(json!({"name": "demo-skill"})).await;
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        assert_eq!(result.content(), "full demo body");
+    }
+
+    /// `use_skill` returns a recoverable error for an unknown skill name.
+    ///
+    /// Why: An LLM hallucinating a skill name must get an actionable error,
+    /// not a panic.
+    /// Test: this test.
+    #[tokio::test]
+    async fn use_skill_errors_on_unknown() {
+        let tool = make_tool();
+        let result = tool.execute(json!({"name": "ghost-skill"})).await;
+        assert!(result.is_error());
+        assert!(result.content().contains("unknown skill"));
+    }
+
+    /// `use_skill` errors when the `name` argument is missing.
+    ///
+    /// Test: this test.
+    #[tokio::test]
+    async fn use_skill_errors_on_missing_name() {
+        let tool = make_tool();
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_error());
+        assert!(result.content().contains("missing required argument"));
+    }
+
+    /// The schema requires `name`.
+    ///
+    /// Test: this test.
+    #[test]
+    fn use_skill_schema_has_required_name() {
+        let tool = make_tool();
+        let schema = tool.schema();
+        let required = schema["function"]["parameters"]["required"]
+            .as_array()
+            .expect("required array");
+        assert!(required.iter().any(|v| v.as_str() == Some("name")));
+    }
+}

--- a/crates/trusty-code/src/tools/traits.rs
+++ b/crates/trusty-code/src/tools/traits.rs
@@ -327,16 +327,25 @@ pub trait SearchProvider: Send + Sync {
 /// Resolves named skills to their Markdown content.
 ///
 /// Why: Skill sources vary (project `.claude/`, user `~/.claude/`, bundled
-/// config); callers should not care which.
+/// config); callers should not care which. #2069 splits skills into cheap,
+/// always-cached metadata (name + description) and an on-demand-loaded body
+/// so the PM/agents can see the full catalog without paying every skill's
+/// token cost up front — `metadata()` is the cached catalog, `resolve()` is
+/// the lazy, per-invocation body load.
 /// What: `resolve(name)` returns `Some(content)` if found. `list()` returns
-/// all discoverable names.
-/// Test: A `FsSkillResolver` in tests places a file in a tempdir and asserts
-/// `resolve()` returns its contents.
+/// all discoverable names. `metadata()` returns the full cached
+/// `SkillMetadata` catalog (name + description), the progressive-disclosure
+/// prompt injection uses.
+/// Test: `crate::skills::tests::fs_skill_resolver_*` construct an
+/// `FsSkillResolver` (this trait's concrete filesystem impl) over a tempdir
+/// and assert `resolve()`/`list()`/`metadata()` all agree.
 pub trait SkillResolver: Send + Sync {
     /// Look up a skill by name and return its Markdown content, if found.
     fn resolve(&self, name: &str) -> Option<String>;
     /// List all discoverable skill names.
     fn list(&self) -> Vec<String>;
+    /// Cached metadata (name + description) for every discoverable skill.
+    fn metadata(&self) -> Vec<crate::skills::SkillMetadata>;
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
M2 (Tool Calling) P1B-2 — progressive-disclosure skill loading. Skill metadata (name+description) is parsed once at resolver init from every `.claude/skills/<name>/SKILL.md` frontmatter and cached; the full body is loaded from disk only when the model invokes the new `use_skill` tool. Mode-aware: DailyDriver appends the skills catalog to the system prompt (byte-identical to before when empty), Parity ignores it entirely per spec (no progressive disclosure). `.claude/skills/` path only (Claude-Code-compatible; no ~/.trusty-mpm/skills/).

QA: APPROVE (independent worktree at 21f0db73) — build 0 warnings, 545 lib + 16 e2e tests pass, clippy clean, fmt clean, line-cap 0 violations (skills/mod.rs 244, frontmatter.rs 121, tools/skill.rs 113 SLOC), trusty-agents unaffected. Progressive disclosure confirmed as separate code paths, mode-awareness verified (Parity byte-identical), graceful failure on missing/malformed skill dirs, zero library unwrap().

Deferred fast-follows (filed): #2152 (use_skill not yet in the delegated engineer's own registry — advertised in its prompt but engineer-side call returns a graceful no-tool error). The legacy `run-task` CLI path stays on the pre-mode-seam assembler by design.

Closes #2069