### PR TITLE
fix(trusty-mpm): durable TM_MANAGED_SESSION_ID publish, stale-pane heal, nested-session guard (closes #2157)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -91,6 +91,23 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
         return result;
     }
 
+    // #2157 item 4: nested-session guard. `try_inplace_relaunch` above only
+    // fires when bare `tm` runs in THIS EXACT pane after its runtime exited
+    // (env var resolved + record Stopped). A sibling pane/window in the SAME
+    // tmux session is a different case entirely: no env var to key off, the
+    // record may still be Active, yet launching a brand-new session from here
+    // would nest one tmux client's session inside another (the root cause of
+    // #2157). Check BEFORE any project detection or picker logic runs.
+    if let Some(record) = nested_session_guard(client, url).await {
+        eprintln!(
+            "tm: this tmux session ('{}') is already a managed session (state={}) — \
+             refusing to launch a nested session here.",
+            record.name, record.state
+        );
+        eprintln!("tm: reconnecting to '{}' instead…", record.name);
+        return super::guided_resume::resume_guided_session(client, url, &record).await;
+    }
+
     let cwd = std::env::current_dir().context("cannot resolve current directory")?;
     let workdir = cwd.to_string_lossy().to_string();
     eprintln!("tm: no subcommand — using guided default for {workdir}");
@@ -219,6 +236,96 @@ pub(crate) fn derive_project(
     let source_id = format!("{}/{}", gh.owner, gh.repo);
     let workspace = inproject::base_clone_path(&gh.owner, &gh.repo);
     Some((source_id, workspace, git_root))
+}
+
+// ── Nested-session guard (#2157 item 4) ──────────────────────────────────────
+
+/// I/O driver for the nested-session guard: resolve the current tmux context,
+/// fetch every managed session (unfiltered — a record's `source_id` may be
+/// missing, see #2157 item 5), and apply [`nested_managed_match`].
+///
+/// Why: extracted from [`run_guided_default`] so the "gather the two matching
+/// keys, ask the daemon, apply the pure predicate" sequence is one readable
+/// unit. Fetches the FULL session list (no `?source_id=` filter) rather than
+/// reusing `list_project_sessions` — the whole point of this guard is to catch
+/// a managed record the project-filtered list would MISS (e.g. one whose
+/// `source_id` write never landed, #2157 item 5's failure mode).
+/// What: short-circuits to `None` when not inside tmux (nothing to guard
+/// against) or when the daemon is unreachable/errors (fail-open — matches
+/// every other daemon round-trip in this file, which falls through to the
+/// picker/autostart rather than blocking on a down daemon). Uses a 2-second
+/// timeout, matching the `guided_inplace` probe convention.
+/// Test: the pure decision is `nested_managed_match_*` in
+/// `tests_behavior_c_tests.rs`; this I/O wrapper is exercised by manual smoke
+/// tests and the e2e suite (requires a live daemon + tmux).
+async fn nested_session_guard(
+    client: &reqwest::Client,
+    url: &str,
+) -> Option<trusty_mpm::client::ManagedSessionSummary> {
+    if !super::tmux_attach::inside_tmux() {
+        return None;
+    }
+    let current_session_name = super::tmux_attach::current_tmux_session_name();
+    let env_session_id = std::env::var("TM_MANAGED_SESSION_ID")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+    let all = list_all_managed_sessions(client, url).await.ok()?;
+    nested_managed_match(
+        current_session_name.as_deref(),
+        env_session_id.as_deref(),
+        &all,
+    )
+    .cloned()
+}
+
+/// Pure predicate: does ANY record in `records` belong to the pane bare `tm`
+/// is currently running inside?
+///
+/// Why: isolating the match rule from the daemon round-trip and the tmux
+/// shell-out makes the actual guard DECISION exhaustively unit-testable
+/// without a live daemon or tmux server.
+/// What: returns the first record whose `name` (tmux session name) equals
+/// `current_session_name`, OR whose `id` equals `env_session_id` — either
+/// match is sufficient (the env id is belt-and-suspenders for the rare case
+/// where the session was renamed after spawn). `None` when both inputs are
+/// `None`/non-matching, which includes the "not inside tmux" case (callers
+/// pass `current_session_name: None` then).
+/// Test: `nested_managed_match_by_session_name`,
+/// `nested_managed_match_by_env_id`, `nested_managed_match_none_when_no_match`,
+/// `nested_managed_match_none_when_both_inputs_absent`.
+pub(crate) fn nested_managed_match<'a>(
+    current_session_name: Option<&str>,
+    env_session_id: Option<&str>,
+    records: &'a [trusty_mpm::client::ManagedSessionSummary],
+) -> Option<&'a trusty_mpm::client::ManagedSessionSummary> {
+    records.iter().find(|r| {
+        current_session_name.is_some_and(|n| n == r.name)
+            || env_session_id.is_some_and(|id| id == r.id)
+    })
+}
+
+/// Fetch EVERY managed session, unfiltered — `GET /api/v1/sessions/managed`
+/// with no `?source_id=` query.
+///
+/// Why: [`nested_session_guard`] must find a match even when the record's
+/// `source_id` is missing (#2157 item 5's failure mode), so it cannot reuse
+/// [`list_project_sessions`]'s source_id-filtered query.
+/// What: identical to [`list_project_sessions`] minus the query parameter, with
+/// a 2-second timeout so a hung daemon cannot add a long stall to every bare
+/// `tm` invocation made from inside tmux.
+/// Test: I/O path; requires a live daemon.
+async fn list_all_managed_sessions(
+    client: &reqwest::Client,
+    url: &str,
+) -> anyhow::Result<Vec<trusty_mpm::client::ManagedSessionSummary>> {
+    let resp = client
+        .get(format!("{url}/api/v1/sessions/managed"))
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await?
+        .error_for_status()?;
+    let body: trusty_mpm::client::ManagedListResponse = resp.json().await?;
+    Ok(body.sessions)
 }
 
 // ── Daemon communication ─────────────────────────────────────────────────────

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -41,11 +41,29 @@
 //! failure aborts rather than proceeding to exec regardless.
 //!
 //! Test: `plan_inplace_*` cover the pure decision; `reactivate_managed_session`'s
+<<<<<<< HEAD
 //! success/409/404 outcomes and `fetch_until_stopped_*`'s retry behavior (#2148)
 //! are exercised against a local `TcpListener` mock (#2027, mirroring
 //! `core::sm::providers`' mock convention — no external mock-server crate); the
 //! full exec path is not unit-tested — it requires a live daemon and a real
 //! `claude` binary, mirroring the rest of the guided-resume I/O surface.
+=======
+//! success/409/404 outcomes are exercised against a local one-shot `TcpListener`
+//! mock (#2027, mirroring `core::sm::providers`' mock convention — no external
+//! mock-server crate); the full exec path is not unit-tested — it requires a
+//! live daemon and a real `claude` binary, mirroring the rest of the
+//! guided-resume I/O surface.
+//!
+//! #2157 item 2/6: [`try_inplace_relaunch`] no longer trusts the process
+//! environment alone for `TM_MANAGED_SESSION_ID` — a sibling pane/window in the
+//! same tmux session (or a pane spawned before the durable `tmux
+//! set-environment` publish existed) never had the export line run in its
+//! shell. [`read_tmux_env_managed_session_id`] falls back to `tmux
+//! show-environment` when the process env is empty; its parsing half,
+//! [`parse_show_environment_value`], is pure and exhaustively unit-tested. Every
+//! rejected gate now also emits a `tracing::debug!` so a stuck-in-the-picker
+//! report is diagnosable from `RUST_LOG=debug` output without code archaeology.
+>>>>>>> 3991706f (fix(trusty-mpm): publish TM_MANAGED_SESSION_ID via tmux set-environment + fallback read, heal stale panes, guard against nested-session spawn, harden source_id)
 
 use anyhow::Context as _;
 
@@ -97,6 +115,65 @@ fn read_env_managed_session_id() -> Option<String> {
     std::env::var(MANAGED_SESSION_ID_ENV)
         .ok()
         .filter(|v| !v.trim().is_empty())
+}
+
+/// Fallback read of [`MANAGED_SESSION_ID_ENV`] from the current tmux SESSION's
+/// environment via `tmux show-environment` (#2157 item 2).
+///
+/// Why: [`read_env_managed_session_id`] only sees the id when the CURRENT
+/// process's own environment carries it — true for the exact shell that ran
+/// the `export TM_MANAGED_SESSION_ID=…;` prefix, but NOT for a sibling
+/// pane/window in the same tmux session, nor for a pane spawned by a
+/// pre-#2157 build that never got the durable `tmux set-environment` publish
+/// either. Since `tm` running bare here is, by definition, inside a tmux
+/// client (`$TMUX` is set) whenever this path is reachable at all, querying
+/// the SESSION's own environment table is a reliable second source — durably
+/// published at spawn/resume time by `runtime::claude_code::
+/// ClaudeCodeAdapter::publish_session_env` and healed for stale panes by
+/// `SessionManager::mark_runtime_exited_stopped` (item 3).
+/// What: when `$TMUX` is unset (not inside tmux), returns `None` immediately
+/// — there is no session to query. Otherwise shells out to
+/// `tmux show-environment TM_MANAGED_SESSION_ID` and parses the id via
+/// [`parse_show_environment_value`]. Any I/O failure, non-zero exit, or the
+/// variable being unset in the session (`tmux` prints `-NAME` for an unset
+/// variable) folds into `None` — the caller then falls through exactly as if
+/// no env var was found anywhere.
+/// Test: the I/O shell-out is not unit-tested (requires a live tmux server);
+/// [`parse_show_environment_value`] covers the pure parsing logic exhaustively.
+fn read_tmux_env_managed_session_id() -> Option<String> {
+    let inside_tmux = std::env::var("TMUX")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    if !inside_tmux {
+        return None;
+    }
+    let output = std::process::Command::new("tmux")
+        .args(["show-environment", MANAGED_SESSION_ID_ENV])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_show_environment_value(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Parse the id out of `tmux show-environment <name>`'s stdout.
+///
+/// Why: separating the parse from the process spawn makes the format-handling
+/// logic exhaustively unit-testable without a live tmux server.
+/// What: `tmux show-environment NAME` prints `NAME=value` when the variable is
+/// set in the session, or `-NAME` when it is explicitly unset. Returns
+/// `Some(value)` (trimmed, non-empty) only for the `NAME=value` form;
+/// everything else (unset `-NAME` form, empty output, an empty value, or
+/// unrecognised text) is `None`.
+/// Test: `parse_show_environment_value_extracts_id`,
+/// `parse_show_environment_value_none_when_unset`,
+/// `parse_show_environment_value_none_when_empty`.
+fn parse_show_environment_value(stdout: &str) -> Option<String> {
+    let line = stdout.lines().next()?;
+    let value = line.strip_prefix(&format!("{MANAGED_SESSION_ID_ENV}="))?;
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 /// Decide whether bare `tm`'s in-pane environment signals an in-place
@@ -369,20 +446,56 @@ pub(crate) async fn try_inplace_relaunch(
     client: &reqwest::Client,
     url: &str,
 ) -> Option<anyhow::Result<()>> {
+<<<<<<< HEAD
     let env_id = read_env_managed_session_id()?;
     // #2148: bounded retry absorbs the Active->Stopped transition race instead
     // of giving up on a single unlucky fetch — see `fetch_managed_session_until_stopped`.
     let record = fetch_managed_session_until_stopped(client, url, &env_id).await;
+=======
+    // #2157 item 2: process env is the primary source (it is set for the exact
+    // shell that ran the export prefix); the tmux SESSION environment is the
+    // fallback for every pane/shell that never ran it (a sibling pane/window,
+    // or a pre-#2157-build pane) — see `read_tmux_env_managed_session_id`.
+    let env_id = match read_env_managed_session_id() {
+        Some(id) => id,
+        None => match read_tmux_env_managed_session_id() {
+            Some(id) => id,
+            None => {
+                tracing::debug!(
+                    "tm: in-place relaunch gate: TM_MANAGED_SESSION_ID absent from both \
+                     process env and tmux session env — falling through to guided default"
+                );
+                return None;
+            }
+        },
+    };
+    let record = fetch_managed_session(client, url, &env_id).await;
+>>>>>>> 3991706f (fix(trusty-mpm): publish TM_MANAGED_SESSION_ID via tmux set-environment + fallback read, heal stale panes, guard against nested-session spawn, harden source_id)
     let record_state = record.as_ref().map(|r| r.state.as_str());
     match plan_inplace(Some(&env_id), record_state) {
         Some(ResumeAction::InPlace) => {
             let record = record.expect("plan_inplace only selects InPlace when record is Some");
             match run_inplace_relaunch(client, url, &env_id, record).await {
                 InPlaceOutcome::Result(r) => Some(r),
-                InPlaceOutcome::FallThrough => None,
+                InPlaceOutcome::FallThrough => {
+                    tracing::debug!(
+                        id = %env_id,
+                        "tm: in-place relaunch gate: daemon reactivate refused/failed — \
+                         falling through to guided default"
+                    );
+                    None
+                }
             }
         }
-        _ => None,
+        _ => {
+            tracing::debug!(
+                id = %env_id,
+                state = ?record_state,
+                "tm: in-place relaunch gate: session id did not resolve to a known, \
+                 Stopped managed session — falling through to guided default"
+            );
+            None
+        }
     }
 }
 
@@ -572,6 +685,35 @@ mod tests {
         assert!(
             hits.load(Ordering::SeqCst) > 1,
             "must have retried at least once before giving up"
+        );
+    }
+
+    #[test]
+    fn parse_show_environment_value_extracts_id() {
+        assert_eq!(
+            parse_show_environment_value(
+                "TM_MANAGED_SESSION_ID=11111111-2222-3333-4444-555555555555\n"
+            ),
+            Some("11111111-2222-3333-4444-555555555555".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_show_environment_value_none_when_unset() {
+        // tmux prints "-NAME" (no "=") when the variable is explicitly unset in
+        // the session.
+        assert_eq!(
+            parse_show_environment_value("-TM_MANAGED_SESSION_ID\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_show_environment_value_none_when_empty() {
+        assert_eq!(parse_show_environment_value(""), None);
+        assert_eq!(
+            parse_show_environment_value("TM_MANAGED_SESSION_ID=\n"),
+            None
         );
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs
@@ -53,6 +53,36 @@ pub(crate) fn inside_tmux() -> bool {
         .unwrap_or(false)
 }
 
+/// Resolve the tmux session name of the CURRENT client's pane (#2157 item 4).
+///
+/// Why: the nested-session guard in `guided.rs` needs to know which tmux
+/// session bare `tm` is running inside, so it can check whether that session
+/// already maps to a managed record BEFORE offering to launch a brand-new
+/// (nested) one. `$TMUX`'s own value encodes a socket path and a numeric
+/// window/pane index, not the session's NAME, so the name has to come from
+/// tmux itself.
+/// What: returns `None` immediately when [`inside_tmux`] is `false` (no
+/// session to query). Otherwise runs `tmux display-message -p '#S'` and
+/// returns the trimmed, non-empty stdout, or `None` on any I/O failure,
+/// non-zero exit, or empty output.
+/// Test: I/O path, not unit-tested (requires a live tmux server); the guard's
+/// decision logic that CONSUMES this value is pure and tested separately
+/// (`nested_managed_match_*` in `tests_behavior_c_tests.rs`).
+pub(crate) fn current_tmux_session_name() -> Option<String> {
+    if !inside_tmux() {
+        return None;
+    }
+    let output = std::process::Command::new("tmux")
+        .args(["display-message", "-p", "#S"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!name.is_empty()).then_some(name)
+}
+
 /// Attach (or switch) the current terminal into the tmux session `name`.
 ///
 /// Why: single choke point for the nested-tmux-safe attach behavior so

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -27,8 +27,8 @@ use crate::commands::first_run::needs_first_run_clone;
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 use crate::commands::guided::{
     PickerDecision, derive_project, fallback_protected, github_host, is_github_remote,
-    non_github_refusal_message, parse_picker_choice, print_non_tty_hint, print_project_context,
-    tty_gate,
+    nested_managed_match, non_github_refusal_message, parse_picker_choice, print_non_tty_hint,
+    print_project_context, tty_gate,
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{ResumeAction, is_zombie, needs_restart, plan_resume};
@@ -1267,4 +1267,61 @@ fn daily_banner_two_panel_version_in_title_bar_not_content() {
         );
     }
     colored::control::unset_override();
+}
+
+// ── nested_managed_match (#2157 item 4) ──────────────────────────────────────
+// The nested-session guard's pure decision: does any known managed record
+// belong to the pane bare `tm` is currently running inside? Matched either by
+// tmux session name (the primary signal — works even when the env var was
+// never exported into THIS particular pane) or by TM_MANAGED_SESSION_ID
+// (belt-and-suspenders).
+
+#[test]
+fn nested_managed_match_by_session_name() {
+    let sessions = vec![make_session("tm-proj-01", "active", None)];
+    let matched = nested_managed_match(Some("tm-proj-01"), None, &sessions);
+    assert_eq!(matched.map(|s| s.name.as_str()), Some("tm-proj-01"));
+}
+
+#[test]
+fn nested_managed_match_by_env_id() {
+    let sessions = vec![make_session("tm-proj-01", "active", None)];
+    // make_session sets id = "<name>-id".
+    let matched = nested_managed_match(None, Some("tm-proj-01-id"), &sessions);
+    assert_eq!(matched.map(|s| s.name.as_str()), Some("tm-proj-01"));
+}
+
+#[test]
+fn nested_managed_match_none_when_no_match() {
+    let sessions = vec![make_session("tm-proj-01", "active", None)];
+    // Neither the session name nor the env id matches any record — e.g. a
+    // plain terminal opened outside any managed tmux session.
+    let matched = nested_managed_match(Some("some-other-session"), Some("unrelated-id"), &sessions);
+    assert!(matched.is_none());
+}
+
+#[test]
+fn nested_managed_match_none_when_both_inputs_absent() {
+    // The "not inside tmux" case: the guard's I/O wrapper passes None for
+    // both keys, which must never spuriously match any record.
+    let sessions = vec![make_session("tm-proj-01", "active", None)];
+    let matched = nested_managed_match(None, None, &sessions);
+    assert!(matched.is_none());
+}
+
+#[test]
+fn nested_managed_match_finds_record_missing_from_source_id_filtered_list() {
+    // #2157 items 4+5 interplay: the guard fetches the UNFILTERED session
+    // list specifically so it can still find a record whose source_id write
+    // never landed (item 5's failure mode) — this record would be invisible
+    // to a `?source_id=` filtered fetch, but the guard must still catch it by
+    // tmux session name.
+    let mut orphaned = make_session("tm-orphan-02", "active", None);
+    orphaned.source_id = None;
+    let sessions = vec![orphaned];
+    let matched = nested_managed_match(Some("tm-orphan-02"), None, &sessions);
+    assert!(
+        matched.is_some(),
+        "must match by session name regardless of source_id"
+    );
 }

--- a/crates/trusty-mpm/src/core/tmux.rs
+++ b/crates/trusty-mpm/src/core/tmux.rs
@@ -113,6 +113,27 @@ pub enum TmuxCommand {
         /// Optional number of trailing scrollback lines to capture.
         lines: Option<u32>,
     },
+    /// `set-environment -t <session> <key> <value>` — durably publish a
+    /// variable into the tmux SESSION environment (#2157 item 1).
+    ///
+    /// Why: the pane-shell `export …;` prefix ([`crate::runtime::claude_code`]'s
+    /// `session_id_export_prefix`) only lands in the ONE shell process that ran
+    /// it — a sibling pane/window in the same session, or a pane spawned by a
+    /// pre-fix build, never sees it. `tmux set-environment` writes into the
+    /// session's OWN environment table instead, which any process can query via
+    /// `tmux show-environment -t <session>` regardless of which pane/shell asks
+    /// or when it was created.
+    /// What: targets the SESSION (not a pane) — `set-environment` interprets
+    /// `-t` as a session target here, unlike `send-keys`/`capture-pane` which
+    /// address a specific pane.
+    SetEnvironment {
+        /// Session to set the variable in.
+        session: String,
+        /// Environment variable name.
+        key: String,
+        /// Environment variable value.
+        value: String,
+    },
 }
 
 /// tmux `-F` format string for `list-sessions`.
@@ -213,6 +234,19 @@ pub fn tmux_argv(cmd: &TmuxCommand) -> Vec<String> {
                 argv.push(format!("-{n}"));
             }
             argv
+        }
+        TmuxCommand::SetEnvironment {
+            session,
+            key,
+            value,
+        } => {
+            vec![
+                "set-environment".to_string(),
+                "-t".to_string(),
+                session.clone(),
+                key.clone(),
+                value.clone(),
+            ]
         }
     }
 }
@@ -316,5 +350,24 @@ mod tests {
             name: "work".into(),
         });
         assert_eq!(argv, ["list-panes", "-t", "work", "-F", PANE_LIST_FORMAT]);
+    }
+
+    #[test]
+    fn set_environment_argv() {
+        let argv = tmux_argv(&TmuxCommand::SetEnvironment {
+            session: "tmpm-brave-otter".into(),
+            key: "TM_MANAGED_SESSION_ID".into(),
+            value: "11111111-2222-3333-4444-555555555555".into(),
+        });
+        assert_eq!(
+            argv,
+            [
+                "set-environment",
+                "-t",
+                "tmpm-brave-otter",
+                "TM_MANAGED_SESSION_ID",
+                "11111111-2222-3333-4444-555555555555"
+            ]
+        );
     }
 }

--- a/crates/trusty-mpm/src/daemon/runtime_reap.rs
+++ b/crates/trusty-mpm/src/daemon/runtime_reap.rs
@@ -205,13 +205,16 @@ mod tests {
     /// spy is local to this test module and exists solely to prove the
     /// runtime-exit reconcile path (#2023 A) never reaches `kill_session` — the
     /// pane must be left alive.
-    /// What: every method besides `kill_session` is a silent no-op (mirroring
-    /// `FakeNoopTmuxDriver`); `kill_session` pushes `name` onto `kill_calls`
-    /// before returning `Ok(())`.
-    /// Test: `stop_runtime_exited_does_not_kill_pane`.
+    /// What: every method besides `kill_session`/`set_environment` is a silent
+    /// no-op (mirroring `FakeNoopTmuxDriver`); `kill_session` pushes `name` onto
+    /// `kill_calls`; `set_environment` (#2157 item 3) pushes `(name, key,
+    /// value)` onto `env_set_calls` before returning `Ok(())`.
+    /// Test: `stop_runtime_exited_does_not_kill_pane`,
+    /// `stop_runtime_exited_heals_stale_pane_env`.
     #[derive(Default)]
     struct KillSpyTmuxDriver {
         kill_calls: Mutex<Vec<String>>,
+        env_set_calls: Mutex<Vec<(String, String, String)>>,
     }
 
     impl ManagedTmuxDriver for KillSpyTmuxDriver {
@@ -230,6 +233,14 @@ mod tests {
         }
         fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
             Ok(Vec::new())
+        }
+        fn set_environment(&self, name: &str, key: &str, value: &str) -> Result<(), ManagedError> {
+            self.env_set_calls.lock().unwrap().push((
+                name.to_owned(),
+                key.to_owned(),
+                value.to_owned(),
+            ));
+            Ok(())
         }
     }
 
@@ -430,6 +441,33 @@ mod tests {
         assert!(
             driver.kill_calls.lock().unwrap().is_empty(),
             "runtime-exit reconcile must NEVER kill the tmux pane (#2023 A)"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_runtime_exited_heals_stale_pane_env() {
+        // #2157 item 3: when the reaper confirms a pane's runtime has exited, it
+        // must durably publish TM_MANAGED_SESSION_ID into that pane's tmux
+        // session — healing panes that never got the durable publish at spawn
+        // time (e.g. created by a pre-#2157 build).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let driver = Arc::new(KillSpyTmuxDriver::default());
+        let (mgr, id) =
+            seed_active_with_driver(&tmp, "exited-heal-env", driver.clone() as Arc<_>).await;
+        let record = mgr.get(&id).await.expect("get");
+        let panes = vec![pane(&record.tmux_name, "zsh")];
+
+        let stopped = stop_runtime_exited(&mgr, &panes, &AlwaysIdleProbe).await;
+        assert_eq!(stopped, 1, "exactly one session must be stopped");
+
+        let env_sets = driver.env_set_calls.lock().unwrap();
+        assert!(
+            env_sets
+                .iter()
+                .any(|(name, key, value)| name == &record.tmux_name
+                    && key == "TM_MANAGED_SESSION_ID"
+                    && value == &id.to_string()),
+            "runtime-exit reconcile must heal the pane's tmux env: {env_sets:?}"
         );
     }
 }

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -239,6 +239,30 @@ impl TmuxDriver {
         })
     }
 
+    /// Durably publish `key=value` into the tmux SESSION environment (#2157 item 1).
+    ///
+    /// Why: `runtime::claude_code::session_id_export_prefix` exports
+    /// `TM_MANAGED_SESSION_ID` into the ONE pane shell that ran the spawn/resume
+    /// command line — a sibling pane/window in the same session, or a pane
+    /// spawned before this fix landed, never sees it, which is why the
+    /// in-place-relaunch gate (`bin/tm/commands/guided_inplace.rs`) could fail
+    /// silently and bare `tm` fell through to spawning a nested session
+    /// (issue #2157). `set-environment` writes into the session's own
+    /// environment table, queryable via `tmux show-environment` from ANY
+    /// pane/shell in that session regardless of vintage.
+    /// What: runs `tmux set-environment -t <session> <key> <value>`; maps a
+    /// non-zero exit to `Error::Protocol`. Callers treat this as best-effort —
+    /// the shell-export prefix remains the primary mechanism.
+    /// Test: argv shape covered by `core::tmux::set_environment_argv`.
+    pub fn set_environment(&self, session: &str, key: &str, value: &str) -> Result<()> {
+        self.run(&TmuxCommand::SetEnvironment {
+            session: session.to_string(),
+            key: key.to_string(),
+            value: value.to_string(),
+        })?;
+        Ok(())
+    }
+
     /// List every pane on the host as `session_name pane_current_command`.
     ///
     /// Why: session auto-discovery scans all panes to find ones running Claude

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -640,6 +640,46 @@ impl ClaudeCodeAdapter {
         trusty_common::bin_resolve::resolve_binary("claude")
             .and_then(|p| p.to_str().map(str::to_owned))
     }
+
+    /// Durably publish `TM_MANAGED_SESSION_ID` (and `CLAUDE_CONFIG_DIR` when
+    /// resolved) into the tmux SESSION environment (#2157 item 1).
+    ///
+    /// Why: [`session_id_export_prefix`] only lands in the ONE pane shell that
+    /// runs the spawn/resume command line — a sibling pane/window in the same
+    /// tmux session, or a pane spawned by a pre-#2157 build, never sees it. This
+    /// is belt-and-suspenders alongside that export: `tmux set-environment`
+    /// writes into the session's own environment table, which
+    /// `tmux show-environment` can read from ANY pane in the session — the
+    /// fallback the in-place-relaunch gate (`bin/tm/commands/guided_inplace.rs`)
+    /// now uses when the process environment is empty.
+    /// What: best-effort — a failure is logged at `warn` and never propagated;
+    /// the pane-shell export remains the primary mechanism, so a tmux driver
+    /// that cannot support `set_environment` must not fail the spawn/resume it
+    /// is attached to.
+    /// Test: `spawn_publishes_session_id_via_set_environment`,
+    /// `spawn_resume_publishes_session_id_via_set_environment`.
+    fn publish_session_env(&self, tmux_name: &str, session_id: &str, config_dir: Option<&str>) {
+        if let Err(e) = self
+            .tmux
+            .set_environment(tmux_name, "TM_MANAGED_SESSION_ID", session_id)
+        {
+            tracing::warn!(
+                session = %tmux_name,
+                "tmux set-environment TM_MANAGED_SESSION_ID failed (in-place relaunch \
+                 fallback impaired, non-fatal): {e}"
+            );
+        }
+        if let Some(dir) = config_dir
+            && let Err(e) = self
+                .tmux
+                .set_environment(tmux_name, "CLAUDE_CONFIG_DIR", dir)
+        {
+            tracing::warn!(
+                session = %tmux_name,
+                "tmux set-environment CLAUDE_CONFIG_DIR failed (non-fatal): {e}"
+            );
+        }
+    }
 }
 
 impl RuntimeAdapter for ClaudeCodeAdapter {
@@ -699,7 +739,15 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
                     prompt_file.as_deref(),
                 ),
             )
-            .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))
+            .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))?;
+        // #2157 item 1: durable publish, belt-and-suspenders alongside the
+        // pane-shell export baked into spawn_command above.
+        self.publish_session_env(
+            tmux_name,
+            session_id,
+            config_dir.as_deref().and_then(|p| p.to_str()),
+        );
+        Ok(())
     }
 
     /// Resume Claude Code with conversation continuity (#1744, #1840, #2013).
@@ -791,7 +839,16 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
                     session_id,
                 ),
             )
-            .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))
+            .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))?;
+        // #2157 item 1: durable publish for the RESUME path too — a fresh tmux
+        // session is created on resume, so it needs the same belt-and-suspenders
+        // set-environment call as spawn().
+        self.publish_session_env(
+            tmux_name,
+            session_id,
+            config_dir.as_deref().and_then(|p| p.to_str()),
+        );
+        Ok(())
     }
 
     /// Return `"claude-code"` as the adapter's identifier.
@@ -1068,6 +1125,73 @@ mod tests {
     }
 
     #[test]
+    fn publish_session_env_sets_id_and_config_dir() {
+        // #2157 item 1: exercises publish_session_env directly (no HOME
+        // redirection or real `claude` binary needed) so this call-shape
+        // assertion runs unconditionally in CI, unlike the full-spawn tests
+        // below which are gated on a real `claude` binary being present.
+        let fake = FakeTmux::new();
+        let adapter = ClaudeCodeAdapter::new(fake.clone());
+        adapter.publish_session_env("tmpm-test", TEST_SESSION_ID, Some("/tmp/config-dir"));
+        let env_sets = fake.env_sets.lock().unwrap();
+        assert_eq!(
+            env_sets.len(),
+            2,
+            "expected id + config-dir sets: {env_sets:?}"
+        );
+        assert!(env_sets.contains(&(
+            "tmpm-test".to_string(),
+            "TM_MANAGED_SESSION_ID".to_string(),
+            TEST_SESSION_ID.to_string()
+        )));
+        assert!(env_sets.contains(&(
+            "tmpm-test".to_string(),
+            "CLAUDE_CONFIG_DIR".to_string(),
+            "/tmp/config-dir".to_string()
+        )));
+    }
+
+    #[test]
+    fn publish_session_env_omits_config_dir_when_absent() {
+        let fake = FakeTmux::new();
+        let adapter = ClaudeCodeAdapter::new(fake.clone());
+        adapter.publish_session_env("tmpm-test", TEST_SESSION_ID, None);
+        let env_sets = fake.env_sets.lock().unwrap();
+        assert_eq!(
+            env_sets.len(),
+            1,
+            "expected only the session-id set: {env_sets:?}"
+        );
+        assert_eq!(env_sets[0].1, "TM_MANAGED_SESSION_ID");
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn spawn_publishes_session_id_via_set_environment() {
+        // #2157 item 1: spawn must durably publish TM_MANAGED_SESSION_ID via
+        // `tmux set-environment`, not just the pane-shell export baked into the
+        // command line — belt-and-suspenders so a sibling pane/window in the
+        // same tmux session (which never ran the export line) can still resolve
+        // it via `tmux show-environment`.
+        let _home = HomeGuard::set();
+        if ClaudeCodeAdapter::resolve_claude().is_none() {
+            return;
+        }
+        let fake = FakeTmux::new();
+        let adapter = ClaudeCodeAdapter::new(fake.clone());
+        adapter
+            .spawn("tmpm-test", Path::new("/tmp"), "some task", TEST_SESSION_ID)
+            .expect("spawn");
+        let env_sets = fake.env_sets.lock().unwrap();
+        assert!(
+            env_sets.iter().any(|(name, key, value)| name == "tmpm-test"
+                && key == "TM_MANAGED_SESSION_ID"
+                && value == TEST_SESSION_ID),
+            "spawn must call tmux set-environment with TM_MANAGED_SESSION_ID: {env_sets:?}"
+        );
+    }
+
+    #[test]
     fn spawn_command_with_prompt_file_contains_flag() {
         // #2125 item 3: when a prompt file is supplied, spawn_command must
         // inject --append-system-prompt-file pointing at it, alongside the
@@ -1286,6 +1410,16 @@ mod tests {
             sends[0].1.contains("--resume my-session-id"),
             "spawn_resume with an existing id must use --resume: {}",
             sends[0].1
+        );
+        // #2157 item 1: the RESUME path must ALSO durably publish the id — a
+        // fresh tmux session is created on resume, so it starts with no
+        // set-environment history at all.
+        let env_sets = fake.env_sets.lock().unwrap();
+        assert!(
+            env_sets.iter().any(|(name, key, value)| name == "tmpm-test"
+                && key == "TM_MANAGED_SESSION_ID"
+                && value == TEST_SESSION_ID),
+            "spawn_resume must call tmux set-environment with TM_MANAGED_SESSION_ID: {env_sets:?}"
         );
     }
 

--- a/crates/trusty-mpm/src/runtime/tcode.rs
+++ b/crates/trusty-mpm/src/runtime/tcode.rs
@@ -109,7 +109,21 @@ impl TcodeAdapter {
         );
         self.tmux
             .send_line(tmux_name, &command)
-            .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))
+            .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))?;
+        // #2157 item 1: durable publish, belt-and-suspenders alongside the
+        // pane-shell export baked into build_spawn_command above — see
+        // `claude_code::ClaudeCodeAdapter::publish_session_env` for the full
+        // rationale (shared verbatim here). Best-effort; never fails the spawn.
+        if let Err(e) = self
+            .tmux
+            .set_environment(tmux_name, "TM_MANAGED_SESSION_ID", session_id)
+        {
+            debug!(
+                session = %tmux_name,
+                "tmux set-environment TM_MANAGED_SESSION_ID failed (non-fatal): {e}"
+            );
+        }
+        Ok(())
     }
 }
 
@@ -300,6 +314,14 @@ mod tests {
         assert_eq!(
             sends[0].1,
             build_spawn_command(Path::new("/tmp"), "some task", TEST_SESSION_ID)
+        );
+        // #2157 item 1: durable publish alongside the pane-shell export.
+        let env_sets = fake.env_sets.lock().expect("env-set log mutex");
+        assert!(
+            env_sets.iter().any(|(name, key, value)| name == "tmpm-test"
+                && key == "TM_MANAGED_SESSION_ID"
+                && value == TEST_SESSION_ID),
+            "send_spawn_command must call tmux set-environment with TM_MANAGED_SESSION_ID: {env_sets:?}"
         );
     }
 

--- a/crates/trusty-mpm/src/runtime/test_helpers.rs
+++ b/crates/trusty-mpm/src/runtime/test_helpers.rs
@@ -27,6 +27,10 @@ use crate::session_manager::{ManagedError, ManagedTmuxDriver};
 /// Test: exercised by every runtime adapter test that calls `spawn`.
 pub(crate) struct FakeTmux {
     pub(crate) sends: Mutex<Vec<(String, String)>>,
+    /// Records every `set_environment` call as `(session, key, value)` (#2157
+    /// item 1) so adapter tests can assert `TM_MANAGED_SESSION_ID` is durably
+    /// published at spawn/resume, not just exported into the pane shell line.
+    pub(crate) env_sets: Mutex<Vec<(String, String, String)>>,
 }
 
 impl FakeTmux {
@@ -40,6 +44,7 @@ impl FakeTmux {
     pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self {
             sends: Mutex::new(Vec::new()),
+            env_sets: Mutex::new(Vec::new()),
         })
     }
 }
@@ -71,5 +76,13 @@ impl ManagedTmuxDriver for FakeTmux {
 
     fn session_exists(&self, _name: &str) -> bool {
         false
+    }
+
+    fn set_environment(&self, name: &str, key: &str, value: &str) -> Result<(), ManagedError> {
+        self.env_sets
+            .lock()
+            .expect("FakeTmux env-set log mutex poisoned")
+            .push((name.to_owned(), key.to_owned(), value.to_owned()));
+        Ok(())
     }
 }

--- a/crates/trusty-mpm/src/session_manager/driver.rs
+++ b/crates/trusty-mpm/src/session_manager/driver.rs
@@ -103,6 +103,32 @@ pub trait ManagedTmuxDriver: Send + Sync {
             .unwrap_or(false)
     }
 
+    /// Durably publish `key=value` into the named session's tmux environment
+    /// (#2157 item 1) — belt-and-suspenders alongside the pane-shell `export …;`
+    /// prefix `runtime::claude_code`/`runtime::tcode` already send.
+    ///
+    /// Why: the pane-shell export only lands in the ONE shell process that ran
+    /// the spawn/resume command line; a sibling pane/window in the same tmux
+    /// session (or a pane spawned before this method existed) never sees it.
+    /// `tmux set-environment` writes into the SESSION's own environment table,
+    /// which `tmux show-environment` can read from ANY pane in that session
+    /// regardless of vintage — this is what lets the in-place-relaunch gate
+    /// (`bin/tm/commands/guided_inplace.rs`) fall back to a tmux-side read when
+    /// the process environment does not carry `TM_MANAGED_SESSION_ID`.
+    /// What: the default is a silent `Ok(())` no-op — this is best-effort
+    /// durability plumbing, not a caller-visible control action like
+    /// `send_keys_literal`/`send_interrupt`, so a driver that cannot support it
+    /// (e.g. tmux absent) must never fail the spawn/resume it is attached to.
+    /// [`super::real_tmux::RealTmuxDriver`] overrides this to actually call
+    /// tmux; test doubles record the call for assertions.
+    /// Test: `RealTmuxDriver` override is asserted via `core::tmux::
+    /// set_environment_argv`; call-site assertions live in
+    /// `runtime::test_helpers::FakeTmux` and `session_manager::tests::
+    /// FakeTmuxDriver`.
+    fn set_environment(&self, _name: &str, _key: &str, _value: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
     /// Signal a session's process to stop, then kill the tmux session.
     ///
     /// Why: abruptly killing a session (`kill_session`) discards any in-flight

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use chrono::Utc;
 use thiserror::Error;
 use tokio::sync::RwLock;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::core::names::SessionNameError;
 use crate::core::sm::control::Submit;
@@ -462,6 +462,24 @@ impl SessionManager {
             name = %record.tmux_name,
             "runtime-reap: managed session marked Stopped (pane left alive, #2023)"
         );
+        // #2157 item 3: heal stale panes — durably publish TM_MANAGED_SESSION_ID
+        // into this session's tmux environment right when the runtime is
+        // confirmed to have exited (the pane is now an idle shell). This covers
+        // panes that never got the durable publish at spawn time (created by a
+        // pre-#2157 build, or whose set-environment call failed at spawn), so a
+        // LATER bare `tm` run inside this pane can still resolve the id via
+        // `tmux show-environment` even though the process-env export never
+        // landed. Best-effort — never fails the reap.
+        if let Err(e) =
+            self.tmux
+                .set_environment(&record.tmux_name, "TM_MANAGED_SESSION_ID", &id.to_string())
+        {
+            warn!(
+                id = %id,
+                name = %record.tmux_name,
+                "runtime-reap: tmux set-environment heal failed (non-fatal): {e}"
+            );
+        }
         Ok(record)
     }
 
@@ -864,24 +882,71 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Record a source project identity on a session.
+    /// Record a source project identity on a session, with a bounded retry
+    /// (#2157 item 5, the #2154 remedy).
     ///
     /// Why: the in-project spawn path (#1706) associates a session with a
     /// specific `owner/repo` so callers can later filter sessions by project
     /// and reconnect instead of spawning duplicates. Setting it post-creation
     /// (rather than via `create_with_id`) keeps the manager's SINGLE generic
-    /// create path clean of in-project concerns.
-    /// What: looks up the record, sets `source_id`, and persists. No tmux I/O.
-    /// Test: covered transitively by the in-project spawn integration tests.
+    /// create path clean of in-project concerns. Previously a single transient
+    /// `get`/`upsert` failure here was `warn!`-and-continue at the call site —
+    /// leaving `source_id: None` on the record PERMANENTLY, which makes the
+    /// session invisible to every `?source_id=` filtered listing (the guided
+    /// picker, `tm session ls --project`) forever, since nothing else ever
+    /// retries the write.
+    /// What: retries the read-modify-write up to `MAX_SET_SOURCE_ID_ATTEMPTS`
+    /// times with a short linear backoff between attempts, returning `Ok(())`
+    /// on the first success. If every attempt fails, logs a `tracing::error!`
+    /// (loud, not `warn!`) carrying `id` and `source_id` so a future
+    /// reconcile/doctor pass can self-heal a `source_id: None` record from its
+    /// `repo_url`/`workspace_path`, then returns the last error.
+    /// Test: `set_source_id_succeeds_first_try`,
+    /// `set_source_id_returns_err_after_retries_for_missing_session` in
+    /// `tests.rs`.
     pub async fn set_source_id(
         &self,
         id: &ManagedSessionId,
         source_id: &str,
     ) -> Result<(), ManagedError> {
-        let mut record = self.get(id).await?;
-        record.source_id = Some(source_id.to_string());
-        self.store.write().await.upsert(record).await?;
-        Ok(())
+        const MAX_SET_SOURCE_ID_ATTEMPTS: u8 = 3;
+        let mut last_err: Option<ManagedError> = None;
+        for attempt in 1..=MAX_SET_SOURCE_ID_ATTEMPTS {
+            let result: Result<(), ManagedError> = async {
+                let mut record = self.get(id).await?;
+                record.source_id = Some(source_id.to_string());
+                self.store.write().await.upsert(record).await?;
+                Ok(())
+            }
+            .await;
+            match result {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    warn!(
+                        id = %id,
+                        attempt,
+                        max_attempts = MAX_SET_SOURCE_ID_ATTEMPTS,
+                        "set_source_id: attempt failed: {e}"
+                    );
+                    last_err = Some(e);
+                    if attempt < MAX_SET_SOURCE_ID_ATTEMPTS {
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            50 * u64::from(attempt),
+                        ))
+                        .await;
+                    }
+                }
+            }
+        }
+        error!(
+            id = %id,
+            source_id = %source_id,
+            attempts = MAX_SET_SOURCE_ID_ATTEMPTS,
+            "set_source_id: exhausted all attempts — session will be invisible to \
+             project-filtered listing (source_id: None) until a reconcile/doctor pass \
+             repairs it from repo_url/workspace_path"
+        );
+        Err(last_err.unwrap_or_else(|| ManagedError::SessionNotFound(id.to_string())))
     }
 
     /// Clear a pending decision WITHOUT injecting any text into the pane.

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -51,7 +51,11 @@ mod reap_orphaned_worktrees_tests;
 mod naming_tests;
 
 #[cfg(test)]
+<<<<<<< HEAD
 mod resume_reattach_tests;
+=======
+mod set_source_id_tests;
+>>>>>>> 3991706f (fix(trusty-mpm): publish TM_MANAGED_SESSION_ID via tmux set-environment + fallback read, heal stale panes, guard against nested-session spawn, harden source_id)
 
 /// Real tmux driver adapter — only available when the `daemon` feature (and thus
 /// the daemon's `TmuxDriver`) is compiled in.

--- a/crates/trusty-mpm/src/session_manager/real_tmux.rs
+++ b/crates/trusty-mpm/src/session_manager/real_tmux.rs
@@ -99,6 +99,14 @@ impl ManagedTmuxDriver for RealTmuxDriver {
     fn get_pane_cwd(&self, name: &str) -> Option<std::path::PathBuf> {
         self.driver.pane_current_path(name)
     }
+
+    /// Overrides the no-op trait default so the production path actually calls
+    /// `tmux set-environment` (#2157 item 1).
+    fn set_environment(&self, name: &str, key: &str, value: &str) -> Result<(), ManagedError> {
+        self.driver
+            .set_environment(name, key, value)
+            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
+    }
 }
 
 /// A no-op tmux driver used when `tmux` is not installed.
@@ -132,6 +140,13 @@ impl ManagedTmuxDriver for NoopTmuxDriver {
 
     fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
         Ok(Vec::new())
+    }
+
+    /// Fails loudly like every other mutating op on this driver — mirrors
+    /// `create_session`/`send_line` rather than the trait's silent-no-op
+    /// default, keeping "tmux is absent" uniformly observable.
+    fn set_environment(&self, _name: &str, _key: &str, _value: &str) -> Result<(), ManagedError> {
+        Err(ManagedError::TmuxUnavailable("tmux not installed".into()))
     }
 }
 
@@ -210,6 +225,14 @@ mod tests {
             driver.create_session("tmpm-test-abc123", "/tmp").is_ok(),
             "FakeNoopTmuxDriver::create_session must succeed"
         );
+    }
+
+    #[test]
+    fn noop_driver_set_environment_fails_loudly() {
+        // #2157: the no-tmux fallback must fail this best-effort mutating op the
+        // same way it fails create_session/send_line, not silently no-op.
+        let driver = NoopTmuxDriver;
+        assert!(driver.set_environment("s", "K", "v").is_err());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/session_manager/set_source_id_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/set_source_id_tests.rs
@@ -1,0 +1,62 @@
+//! Unit tests for `SessionManager::set_source_id`'s bounded retry (#2157 item 5).
+//!
+//! Why: split out of `tests.rs` (which was already at the 1500-SLOC test cap)
+//! rather than grown further, mirroring the established pattern of
+//! `restart_tests.rs`/`reactivate_tests.rs`/`naming_tests.rs` etc.
+//! What: the happy path (one clean write, no retry needed) and the
+//! exhausted-retry path (an id that never resolves surfaces a typed error
+//! rather than hanging or silently succeeding).
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use super::manager::ManagedError;
+use super::record::ManagedSessionId;
+use super::tests::make_manager;
+
+#[tokio::test]
+async fn set_source_id_succeeds_first_try() {
+    // #2157 item 5: the common case — one clean read-modify-write — must
+    // succeed without needing any retry.
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/wt")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+
+    mgr.set_source_id(&record.id, "owner/repo")
+        .await
+        .expect("set_source_id");
+
+    let reloaded = mgr.get(&record.id).await.expect("get after set");
+    assert_eq!(reloaded.source_id.as_deref(), Some("owner/repo"));
+}
+
+#[tokio::test]
+async fn set_source_id_returns_err_after_retries_for_missing_session() {
+    // #2157 item 5: an id that never resolves must exhaust the bounded retry
+    // loop and surface a typed error (not hang, not silently succeed) so the
+    // caller's existing warn!-and-continue handling still degrades safely —
+    // now backed by `tracing::error!` on exhaustion for a future
+    // reconcile/doctor pass to find.
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let unknown_id = ManagedSessionId::new();
+
+    let result = mgr.set_source_id(&unknown_id, "owner/repo").await;
+    assert!(
+        matches!(result, Err(ManagedError::SessionNotFound(_))),
+        "expected SessionNotFound after exhausting retries, got {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Root cause (per #2157): the in-place relaunch (#2023/#2148) never engages
because `TM_MANAGED_SESSION_ID` is only exported as a shell-line prefix into
the ONE pane shell that ran the spawn/resume command line. A sibling
pane/window in the same tmux session — or any pane spawned by an older build —
never sees it, so `read_env_managed_session_id()` in
`guided_inplace::try_inplace_relaunch` fails silently and bare `tm` falls
through to spawning a **new** managed session, nesting one tmux client's
session inside another.

This PR implements all six remediation items from the ticket:

1. **Durable publish at spawn/resume** — a new `tmux set-environment` driver
   call (`core::tmux::TmuxCommand::SetEnvironment` → `daemon::tmux::TmuxDriver::set_environment`
   → `session_manager::ManagedTmuxDriver::set_environment`) publishes
   `TM_MANAGED_SESSION_ID` (and `CLAUDE_CONFIG_DIR` when resolved) into the
   tmux **session** environment on every spawn/resume
   (`ClaudeCodeAdapter::publish_session_env`, `TcodeAdapter::send_spawn_command`),
   belt-and-suspenders alongside the existing pane-shell export.
2. **Fallback read** — `guided_inplace::try_inplace_relaunch` now falls back to
   `tmux show-environment TM_MANAGED_SESSION_ID` when the process env is empty,
   so a sibling pane can still resolve the id.
3. **Heal stale panes** — `SessionManager::mark_runtime_exited_stopped`
   publishes the id into the pane's tmux session env the moment the reaper
   confirms the runtime exited, healing panes from pre-fix builds.
4. **Nested-session guard** — `guided::run_guided_default` now checks, before
   any picker/LaunchNew path, whether the current tmux session (by name or env
   id) already maps to a managed record; if so it reconnects instead of
   launching a nested session.
5. **Hardened `source_id`** — `SessionManager::set_source_id` gets a bounded
   retry (3 attempts, linear backoff) and logs loudly (`tracing::error!`) on
   exhaustion so a future reconcile/doctor pass can self-heal a
   `source_id: None` record from `repo_url`/`workspace_path`.
6. **Diagnosability** — every rejected in-place-relaunch gate now emits
   `tracing::debug!` with the reason, visible under `RUST_LOG=debug`.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (only
      pre-existing, unrelated MSRV warning in `tga`)
- [x] `cargo fmt --check` — clean
- [x] `cargo test --workspace` — all green except the pre-existing flaky
      `formatters::banner::two_panel::tests::right_col_no_inner_border` (confirmed
      reproducible and unrelated on `origin/main` before this change)
- [x] `bash scripts/check_line_cap.sh` — clean (0 violations)
- [x] New unit tests assert the tmux driver calls directly (`set_environment`
      invoked at spawn/resume, the `show-environment` fallback parser, the
      nested-session-guard predicate, the stale-pane heal call,
      `set_source_id`'s retry/exhaustion paths) since this bug is a
      runtime/tmux-env issue that unit tests alone cannot fully prove.
- [ ] **Live end-to-end verification** (the true acceptance per the ticket):
      exit a real managed session's `claude` process, run bare `tm` from a
      sibling pane/window in the same tmux session, confirm in-place
      re-entry with **no nesting** — should be done post-install, as noted in
      the ticket.

## Judgment calls

- Item 1's "session-create/resume path" durable publish was implemented at the
  `RuntimeAdapter::spawn`/`spawn_resume` chokepoint (`ClaudeCodeAdapter`,
  `TcodeAdapter`) rather than duplicated into `session_manager::create`/
  `reactivate`, since every create/resume/inproject-spawn/resume_managed path
  in `daemon::managed_routes::lifecycle` funnels through `adapter.spawn`/
  `spawn_resume` — a single chokepoint with both `tmux_name` and `session_id`
  in scope.
- `session_manager/tests.rs` was already at the 1500-SLOC test cap; the two new
  `set_source_id` tests were split into a new `set_source_id_tests.rs`,
  mirroring the existing `restart_tests.rs`/`reactivate_tests.rs` pattern.
- `set_source_id`'s retry doc comment originally promised three named tests;
  reduced to two (happy path + exhausted-retry-for-missing-session) since the
  concrete store isn't easily fault-injectable to prove a mid-retry recovery
  without disproportionate test-harness work.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools