### PR TITLE
feat(trusty-mpm): validate managed deployment against canonical manifest with auto-repair (#2158)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -140,6 +140,28 @@ pub(crate) enum Command {
         #[arg(long, hide = true)]
         prune_stale_skills: bool,
     },
+    /// Validate a workspace's deployed `.claude/{agents,skills}` payload and
+    /// `settings.json` against the canonical bundled roster (issue #2158).
+    ///
+    /// Why: `tm doctor` requires a reachable daemon (it round-trips through
+    /// `GET /api/v1/doctor`); this command runs the identical diff engine
+    /// ([`trusty_mpm::core::deploy_validate::validate_workspace`]) directly
+    /// against the local filesystem, so it works standalone (no daemon
+    /// needed) and can gate a script/CI step on a non-zero exit code.
+    /// What: prints every gap found, or a completeness confirmation, and
+    /// exits non-zero when the workspace is incomplete (after an optional
+    /// `--repair` attempt still leaves gaps).
+    /// Test: `cli_parses_validate`, `cli_parses_validate_with_path_and_repair`.
+    Validate {
+        /// Workspace directory to validate. Defaults to the current directory.
+        #[arg(long)]
+        path: Option<std::path::PathBuf>,
+        /// Attempt to auto-repair any gaps found by re-running the deploy
+        /// pipeline ([`trusty_mpm::core::session_launch::prepare_session_with_repo_url`])
+        /// before reporting the final verdict.
+        #[arg(long)]
+        repair: bool,
+    },
     /// Report daemon health: reachability, catalog freshness, and a fleet summary.
     Health,
     /// Launch the ratatui multi-session TUI dashboard.

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -209,6 +209,86 @@ fn prune_stale_skills_locally() {
     }
 }
 
+/// `validate` subcommand — diff a workspace's deployed `.claude/{agents,skills}`
+/// payload against the canonical bundled roster (issue #2158).
+///
+/// Why: unlike `tm doctor` (which round-trips through a reachable daemon),
+/// this runs [`trusty_mpm::core::deploy_validate::validate_workspace`]
+/// directly against the local filesystem, so it works standalone — useful in
+/// CI, in a freshly-provisioned worktree with no daemon yet, or as a
+/// non-interactive gate (`tm validate --path <dir> || exit 1`).
+/// What: resolves `path` (default: the current directory) to a
+/// [`FrameworkPaths`] via [`FrameworkPaths::for_managed_workspace`], runs the
+/// validator, and — when `repair` is set and gaps were found — re-runs
+/// [`trusty_mpm::core::deploy_validate::validate_and_repair`] (which itself
+/// calls `prepare_session_with_repo_url`, the same pipeline `spawn_managed`
+/// uses) before printing the final verdict. Exits the process with status `1`
+/// when the final report is incomplete, `0` otherwise.
+/// Test: `cli_parses_validate`, `cli_parses_validate_with_path_and_repair`
+/// cover parsing; the diff/repair logic itself is covered by
+/// `core::deploy_validate`'s own unit tests.
+pub(crate) async fn validate(path: Option<std::path::PathBuf>, repair: bool) -> anyhow::Result<()> {
+    use trusty_mpm::core::deploy_validate::{validate_and_repair, validate_workspace};
+    use trusty_mpm::core::paths::FrameworkPaths;
+
+    let workspace = match path {
+        Some(p) => p,
+        None => std::env::current_dir()?,
+    };
+    let fw = FrameworkPaths::for_managed_workspace(&workspace);
+
+    println!("tm validate: {}", workspace.display());
+
+    let complete = if repair {
+        let outcome = validate_and_repair(&fw, &workspace, None);
+        if outcome.repaired {
+            println!(
+                "auto-repair ran ({} gap(s) found before repair)",
+                outcome.before.gaps.len()
+            );
+            if let Some(err) = &outcome.repair_error {
+                eprintln!("repair pipeline reported an error (non-fatal): {err}");
+            }
+        }
+        print_gaps(&outcome.after.gaps);
+        outcome.is_complete()
+    } else {
+        let report = validate_workspace(&fw);
+        print_gaps(&report.gaps);
+        report.is_complete()
+    };
+
+    if complete {
+        println!("deployment is complete");
+    } else {
+        eprintln!(
+            "deployment is INCOMPLETE — run `tm validate --path {} --repair` to auto-repair",
+            workspace.display()
+        );
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+/// Print each deployment gap as one `  - <description>` line, or a
+/// "no gaps" line when the slice is empty.
+///
+/// Why: shared by both branches of [`validate`] so the report formatting
+/// cannot drift between the plain and `--repair` paths.
+/// What: thin formatting loop over [`trusty_mpm::core::deploy_validate::DeploymentGap::describe`].
+/// Test: covered indirectly via `validate`'s own behaviour; the gap
+/// descriptions themselves are unit-tested in `core::deploy_validate`.
+fn print_gaps(gaps: &[trusty_mpm::core::deploy_validate::DeploymentGap]) {
+    if gaps.is_empty() {
+        println!("  no gaps found");
+        return;
+    }
+    for gap in gaps {
+        println!("  - {}", gap.describe());
+    }
+}
+
 /// `health` subcommand — report daemon health through chat-core.
 ///
 /// Why: the operator (and scripts) want a quick "is the daemon up, is the catalog

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -20,7 +20,7 @@ use commands::{
     daemon::{restart, run_daemon, start, stop_daemon},
     install::install,
     launch::{connect, launch},
-    misc::{attach_cmd, coordinator, doctor, health, hook, optimizer, overseer, status},
+    misc::{attach_cmd, coordinator, doctor, health, hook, optimizer, overseer, status, validate},
     project::project,
     repair::repair_deploy,
     services::services,
@@ -246,6 +246,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Session { action }) => session(&client, &url, action).await,
         Some(Command::Events) => commands::misc::events(&client, &url).await,
         Some(Command::Doctor { prune_stale_skills }) => doctor(&url, prune_stale_skills).await,
+        Some(Command::Validate { path, repair }) => validate(path, repair).await,
         Some(Command::Health) => health(&url).await,
         Some(Command::Tui {
             url: tui_url,

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -126,6 +126,31 @@ fn cli_parses_doctor_prune_stale_skills() {
 }
 
 #[test]
+fn cli_parses_validate() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "validate"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Validate { path, repair } => {
+            assert_eq!(path, None);
+            assert!(!repair);
+        }
+        other => panic!("expected Command::Validate, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_validate_with_path_and_repair() {
+    let cli =
+        Cli::try_parse_from(["trusty-mpm", "validate", "--path", "/tmp/ws", "--repair"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Validate { path, repair } => {
+            assert_eq!(path, Some(std::path::PathBuf::from("/tmp/ws")));
+            assert!(repair);
+        }
+        other => panic!("expected Command::Validate, got {other:?}"),
+    }
+}
+
+#[test]
 fn cli_parses_health() {
     let cli = Cli::try_parse_from(["trusty-mpm", "health"]).unwrap();
     assert!(matches!(cli.command.unwrap(), Command::Health));

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -190,7 +190,7 @@ async fn register_project_succeeds() {
 
 #[tokio::test]
 async fn execute_doctor_against_test_daemon() {
-    // `/doctor` returns a nine-check report against a live daemon.
+    // `/doctor` returns a ten-check report against a live daemon.
     let (_state, url) = spawn_test_daemon().await;
     let executor = CommandExecutor::new(url);
     match executor.execute(TrustyCommand::Doctor).await {
@@ -198,9 +198,10 @@ async fn execute_doctor_against_test_daemon() {
             // #1840 added the worktrees check (6); DOC-28 R4(a) added the
             // output_style check (7); A2 (tm-skills-portfolio epic) added the
             // skill_source check (8); #gh-account-awareness added the gh_account
-            // check, bringing the total to 9. #1905's stale-skill cleanup is a
-            // one-time migration, not a probe here.
-            assert_eq!(report.checks.len(), 9);
+            // check (9); #2158 added the deployment check, bringing the total to
+            // 10. #1905's stale-skill cleanup is a one-time migration, not a
+            // probe here.
+            assert_eq!(report.checks.len(), 10);
         }
         other => panic!("expected Doctor, got {other:?}"),
     }

--- a/crates/trusty-mpm/src/core/deploy_validate.rs
+++ b/crates/trusty-mpm/src/core/deploy_validate.rs
@@ -1,0 +1,611 @@
+//! Validate a managed workspace's deployed `.claude/{agents,skills}` payload
+//! and `settings.json` against the canonical bundled roster (issue #2158).
+//!
+//! Why: a managed worktree can launch with an INCOMPLETE `.claude/` payload —
+//! missing agents, no deployed skills, a stripped `settings.json` with no
+//! `outputStyle`/hooks, no per-workspace ownership manifest — silently,
+//! because nothing ever diffed the deployed payload against what a complete
+//! deploy must contain. This module is that diff: given a resolved
+//! [`FrameworkPaths`], it enumerates every gap so callers (`tm doctor`, `tm
+//! validate`, and the daemon spawn/resume path) can auto-repair or fail
+//! loudly instead of handing the operator a half-provisioned session.
+//! What: [`validate_workspace`] compares the deployed `.claude/agents/` and
+//! `.claude/skills/` directories (plus their ownership manifests) against the
+//! CANONICAL bundled roster resolved via [`FrameworkPaths::agent_source_dir`]
+//! / [`FrameworkPaths::skill_source_dir`] — the same source
+//! [`crate::core::agent_deployer::deploy_agents`] /
+//! [`crate::core::skill_deployer::deploy_skills`] draw from when called
+//! unfiltered. The default HR-2 manifest selects every bundled agent/skill
+//! (see `session_launch::mod`'s doc comment), so in the common,
+//! no-custom-manifest case the full bundled source set IS the expected
+//! deployed set — a project that opts into a narrower manifest may see
+//! benign `AgentMissing`/`SkillMissing` gaps for deliberately-excluded
+//! entries; callers that need manifest-exact precision should additionally
+//! consult `core::manifest::HarnessPlan` (out of scope here, see #2158 PR
+//! notes). [`validate_workspace`] also checks `.claude/settings.json` (at
+//! [`FrameworkPaths::claude_home_dir`]) for a resolvable `outputStyle` and a
+//! configured `hooks` key. [`validate_and_repair`] re-runs
+//! [`crate::core::session_launch::prepare_session_with_repo_url`] — the exact
+//! deploy pipeline `spawn_managed`/`resume_managed` already use — when the
+//! initial validation finds gaps, then re-validates so callers can tell
+//! whether the repair actually closed them.
+//! Test: `validate_missing_agent_manifest_is_a_gap`,
+//! `validate_missing_agent_is_a_gap`, `validate_missing_skill_manifest_is_a_gap`,
+//! `validate_missing_skill_is_a_gap`, `validate_settings_missing_is_a_gap`,
+//! `validate_missing_output_style_key_is_a_gap`,
+//! `validate_unknown_output_style_id_is_a_gap`,
+//! `validate_output_style_file_missing_is_a_gap`, `validate_missing_hooks_is_a_gap`,
+//! `validate_complete_workspace_has_no_gaps`, `repair_closes_gaps_on_incomplete_workspace`,
+//! `repair_is_a_noop_on_already_complete_workspace`.
+
+use std::path::Path;
+
+use crate::core::agent_manifest::{self, AgentManifest, ManifestLoad};
+use crate::core::bundle::OUTPUT_STYLES;
+use crate::core::paths::FrameworkPaths;
+use crate::core::skill_manifest;
+
+/// One concrete gap between a deployed workspace and the canonical roster.
+///
+/// Why: `tm doctor`/`tm validate` and the spawn/resume auto-repair gate all
+/// need to distinguish WHICH thing is missing, not just "incomplete" — the
+/// doctor/CLI surfaces render `describe()`; the auto-repair gate only cares
+/// whether [`ValidationReport::is_complete`] is `false`.
+/// What: one variant per gap class this module can detect.
+/// Test: one dedicated test per variant, listed on the module doc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeploymentGap {
+    /// `.claude/agents/.trusty-mpm-manifest.json` does not exist.
+    AgentManifestMissing,
+    /// The agent manifest exists but failed to parse.
+    AgentManifestCorrupt(String),
+    /// A canonical bundled agent (`<name>.md`) is not deployed on disk.
+    AgentMissing(String),
+    /// `.claude/skills/.trusty-mpm-skills-manifest.json` does not exist.
+    SkillManifestMissing,
+    /// A canonical bundled skill (`<name>/SKILL.md`) is not deployed on disk.
+    SkillMissing(String),
+    /// `.claude/settings.json` itself does not exist.
+    SettingsMissing,
+    /// `.claude/settings.json` exists but is not valid JSON.
+    SettingsMalformed(String),
+    /// `.claude/settings.json` has no `outputStyle` key set.
+    OutputStyleKeyMissing,
+    /// `outputStyle` names an id unknown to the bundled style catalog.
+    OutputStyleUnknownId(String),
+    /// The resolved style id's file is missing or empty under
+    /// `.claude/output-styles/`.
+    OutputStyleFileMissing(String),
+    /// `.claude/settings.json` has no (non-empty) `hooks` key configured.
+    HooksMissing,
+}
+
+impl DeploymentGap {
+    /// One-line, operator-facing description of the gap.
+    ///
+    /// Why: `tm doctor` and `tm validate` render gaps as plain text; keeping
+    /// the phrasing here means both surfaces stay identical.
+    /// What: a short, human-readable sentence naming what is wrong.
+    /// Test: `describe_is_non_empty_for_every_variant`.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::AgentManifestMissing => format!(
+                "agent ownership manifest ({}) is missing",
+                agent_manifest::MANIFEST_FILE
+            ),
+            Self::AgentManifestCorrupt(detail) => format!("agent manifest is corrupt: {detail}"),
+            Self::AgentMissing(name) => format!("agent `{name}` is not deployed"),
+            Self::SkillManifestMissing => format!(
+                "skill ownership manifest ({}) is missing",
+                skill_manifest::SKILL_MANIFEST_FILE
+            ),
+            Self::SkillMissing(name) => format!("skill `{name}` is not deployed"),
+            Self::SettingsMissing => ".claude/settings.json is missing".to_string(),
+            Self::SettingsMalformed(detail) => {
+                format!(".claude/settings.json is not valid JSON: {detail}")
+            }
+            Self::OutputStyleKeyMissing => {
+                "settings.json has no outputStyle key configured".to_string()
+            }
+            Self::OutputStyleUnknownId(id) => {
+                format!("outputStyle {id:?} is not a known trusty-mpm style")
+            }
+            Self::OutputStyleFileMissing(id) => {
+                format!("outputStyle {id:?} has no deployed style file")
+            }
+            Self::HooksMissing => "settings.json has no hooks configured".to_string(),
+        }
+    }
+}
+
+/// The outcome of [`validate_workspace`].
+///
+/// Why: callers need both the raw gap list (for detailed reporting) and a
+/// single completeness verdict (for the spawn/resume gate).
+/// What: an ordered [`Vec<DeploymentGap>`]; empty means complete.
+/// Test: `validate_complete_workspace_has_no_gaps`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ValidationReport {
+    /// Every gap found, in the order the probes ran.
+    pub gaps: Vec<DeploymentGap>,
+}
+
+impl ValidationReport {
+    /// Whether the deployment is complete (no gaps found).
+    ///
+    /// Why: the spawn/resume gate and `tm validate`'s exit code both reduce
+    /// to this single boolean.
+    /// What: `true` iff `gaps` is empty.
+    /// Test: `validate_complete_workspace_has_no_gaps`.
+    pub fn is_complete(&self) -> bool {
+        self.gaps.is_empty()
+    }
+}
+
+/// Validate `fw`'s deployed `.claude/{agents,skills}` payload and
+/// `settings.json` against the canonical bundled roster.
+///
+/// Why: the single entry point behind `tm doctor`'s manifest-completeness
+/// check, `tm validate`, and the daemon's pre-handoff spawn/resume gate — one
+/// implementation means the three surfaces can never disagree about what
+/// "complete" means.
+/// What: runs the agent, skill, and settings probes in order and folds their
+/// findings into a [`ValidationReport`]. Pure filesystem reads — no writes.
+/// Test: every `validate_*` test in this module's `tests` submodule.
+pub fn validate_workspace(fw: &FrameworkPaths) -> ValidationReport {
+    let mut gaps = Vec::new();
+    validate_agents(fw, &mut gaps);
+    validate_skills(fw, &mut gaps);
+    validate_settings(fw, &mut gaps);
+    ValidationReport { gaps }
+}
+
+/// Probe the deployed agent roster against the canonical bundled source.
+fn validate_agents(fw: &FrameworkPaths, gaps: &mut Vec<DeploymentGap>) {
+    let target = fw.claude_agents_dir();
+    match AgentManifest::load_checked(&target) {
+        ManifestLoad::Corrupt(detail) => gaps.push(DeploymentGap::AgentManifestCorrupt(detail)),
+        ManifestLoad::Ok(_) => {
+            if !target.join(agent_manifest::MANIFEST_FILE).is_file() {
+                gaps.push(DeploymentGap::AgentManifestMissing);
+            }
+        }
+    }
+    for name in canonical_stems(&fw.agent_source_dir()) {
+        if !target.join(format!("{name}.md")).is_file() {
+            gaps.push(DeploymentGap::AgentMissing(name));
+        }
+    }
+}
+
+/// Probe the deployed skill roster against the canonical bundled source.
+fn validate_skills(fw: &FrameworkPaths, gaps: &mut Vec<DeploymentGap>) {
+    let target = fw.claude_skills_dir();
+    if !target.join(skill_manifest::SKILL_MANIFEST_FILE).is_file() {
+        gaps.push(DeploymentGap::SkillManifestMissing);
+    }
+    for name in canonical_stems(&fw.skill_source_dir()) {
+        if !target.join(&name).join("SKILL.md").is_file() {
+            gaps.push(DeploymentGap::SkillMissing(name));
+        }
+    }
+}
+
+/// Probe `.claude/settings.json` for a resolvable `outputStyle` and a
+/// configured `hooks` key.
+fn validate_settings(fw: &FrameworkPaths, gaps: &mut Vec<DeploymentGap>) {
+    let settings_path = fw.claude_home_dir().join(".claude").join("settings.json");
+    let text = match std::fs::read_to_string(&settings_path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            gaps.push(DeploymentGap::SettingsMissing);
+            return;
+        }
+        Err(e) => {
+            gaps.push(DeploymentGap::SettingsMalformed(e.to_string()));
+            return;
+        }
+    };
+    let value: serde_json::Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(e) => {
+            gaps.push(DeploymentGap::SettingsMalformed(e.to_string()));
+            return;
+        }
+    };
+
+    match value.get("outputStyle").and_then(|v| v.as_str()) {
+        None => gaps.push(DeploymentGap::OutputStyleKeyMissing),
+        Some(id) => match OUTPUT_STYLES.iter().find(|s| s.id == id) {
+            None => gaps.push(DeploymentGap::OutputStyleUnknownId(id.to_string())),
+            Some(style) => {
+                let style_path = fw
+                    .claude_home_dir()
+                    .join(".claude")
+                    .join("output-styles")
+                    .join(style.file_name);
+                let deployed = std::fs::metadata(&style_path)
+                    .map(|m| m.len() > 0)
+                    .unwrap_or(false);
+                if !deployed {
+                    gaps.push(DeploymentGap::OutputStyleFileMissing(id.to_string()));
+                }
+            }
+        },
+    }
+
+    let hooks_present = value
+        .get("hooks")
+        .and_then(|h| h.as_object())
+        .is_some_and(|o| !o.is_empty());
+    if !hooks_present {
+        gaps.push(DeploymentGap::HooksMissing);
+    }
+}
+
+/// Canonical `.md` stems (filename without extension) directly under `dir`.
+///
+/// Why: shared by the agent and skill probes — both compare the deployed
+/// target against every `.md` file in a bundled source directory.
+/// What: returns the sorted, deterministic list of `.md` stems; an
+/// unreadable/missing `dir` yields an empty list (no canonical roster to
+/// check against — matches `deploy_agents`/`deploy_skills`'s own "missing
+/// source is an empty no-op" convention).
+/// Test: covered indirectly by every `validate_*` gap test.
+fn canonical_stems(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            let is_md = path
+                .extension()
+                .and_then(|x| x.to_str())
+                .map(|x| x.eq_ignore_ascii_case("md"))
+                .unwrap_or(false);
+            if !is_md {
+                return None;
+            }
+            path.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
+        })
+        .collect();
+    names.sort_unstable();
+    names
+}
+
+/// The outcome of [`validate_and_repair`].
+///
+/// Why: callers (the spawn/resume gate, `tm validate --repair`) need to know
+/// not just the final state but whether a repair was attempted and whether it
+/// actually closed the gaps found before it ran.
+/// What: the pre-repair and post-repair [`ValidationReport`]s, whether a
+/// repair attempt ran at all, and the repair error (if any).
+/// Test: `repair_closes_gaps_on_incomplete_workspace`,
+/// `repair_is_a_noop_on_already_complete_workspace`,
+/// `repair_reports_error_when_prepare_session_fails`.
+#[derive(Debug)]
+pub struct RepairOutcome {
+    /// Validation result before any repair attempt.
+    pub before: ValidationReport,
+    /// Validation result after the repair attempt (equals `before` when no
+    /// repair ran).
+    pub after: ValidationReport,
+    /// Whether a repair attempt actually ran (only when `before` was incomplete).
+    pub repaired: bool,
+    /// The repair pipeline's error, if [`crate::core::session_launch::prepare_session_with_repo_url`]
+    /// returned `Err`. A repair that ran but left gaps (a partial repair) is
+    /// NOT an error here — check `after.is_complete()` for that.
+    pub repair_error: Option<String>,
+}
+
+impl RepairOutcome {
+    /// Whether the workspace is complete after this repair attempt.
+    ///
+    /// Why: the spawn/resume gate's final pass/fail decision reduces to this
+    /// one call.
+    /// What: delegates to `after.is_complete()`.
+    /// Test: covered by every `repair_*` test.
+    pub fn is_complete(&self) -> bool {
+        self.after.is_complete()
+    }
+}
+
+/// Validate `workspace`, and if incomplete, re-run the deploy pipeline and
+/// re-validate.
+///
+/// Why (#2158): a managed session must never be handed to the operator with a
+/// silently-incomplete `.claude/` payload. Auto-repair is preferred over
+/// failing outright — most gaps (a missing agent, a stale output-style file)
+/// are exactly what re-running the deploy step fixes, and the deploy
+/// machinery ([`crate::core::agent_deployer::deploy_agents_filtered`] /
+/// [`crate::core::skill_deployer::deploy_skills_filtered`]) is already safe
+/// to re-run (checksum-based skip of user-modified files, additive `.mcp.json`
+/// merges). This reuses the EXACT pipeline `spawn_managed`/
+/// `spawn_managed_inproject`/`resume_managed` already call for a fresh
+/// session — no parallel repair implementation to drift from it.
+/// What: calls [`validate_workspace`]; if complete, returns immediately with
+/// `repaired: false`. Otherwise calls
+/// [`crate::core::session_launch::prepare_session_with_repo_url`]`(fw,
+/// workspace, repo_url)` (the #2149 roster/output-style/hooks pipeline),
+/// re-validates, and returns both reports plus any repair error.
+/// Test: `repair_closes_gaps_on_incomplete_workspace`,
+/// `repair_is_a_noop_on_already_complete_workspace`.
+pub fn validate_and_repair(
+    fw: &FrameworkPaths,
+    workspace: &Path,
+    repo_url: Option<&str>,
+) -> RepairOutcome {
+    let before = validate_workspace(fw);
+    if before.is_complete() {
+        return RepairOutcome {
+            after: before.clone(),
+            before,
+            repaired: false,
+            repair_error: None,
+        };
+    }
+
+    let repair_error =
+        match crate::core::session_launch::prepare_session_with_repo_url(fw, workspace, repo_url) {
+            Ok(report) if !report.roster_errors.is_empty() => Some(report.roster_errors.join("; ")),
+            Ok(_) => None,
+            Err(e) => Some(e.to_string()),
+        };
+
+    let after = validate_workspace(fw);
+    RepairOutcome {
+        before,
+        after,
+        repaired: true,
+        repair_error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Build a hermetic `FrameworkPaths` whose SOURCE dirs are seeded and
+    /// whose `trusty_mpm_root` is forced to `None`, mirroring the pattern
+    /// `doctor_fs_checks.rs` uses so the resolution never escapes the temp dir
+    /// into the real checkout the test binary happens to run inside.
+    fn hermetic_paths(base: &Path) -> FrameworkPaths {
+        let mut fw = FrameworkPaths::under(base);
+        fw.trusty_mpm_root = None;
+        fw
+    }
+
+    fn seed_agent_source(fw: &FrameworkPaths, names: &[&str]) {
+        std::fs::create_dir_all(&fw.agents).unwrap();
+        for name in names {
+            std::fs::write(
+                fw.agents.join(format!("{name}.md")),
+                format!("---\nname: {name}\ndescription: d\n---\n\nBody.\n"),
+            )
+            .unwrap();
+        }
+    }
+
+    fn seed_skill_source(fw: &FrameworkPaths, names: &[&str]) {
+        std::fs::create_dir_all(&fw.skills).unwrap();
+        for name in names {
+            std::fs::write(fw.skills.join(format!("{name}.md")), "skill body").unwrap();
+        }
+    }
+
+    fn write_settings(fw: &FrameworkPaths, json: &str) {
+        let claude_dir = fw.claude_home_dir().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(claude_dir.join("settings.json"), json).unwrap();
+    }
+
+    fn deploy_style_file(fw: &FrameworkPaths) {
+        let style_dir = fw.claude_home_dir().join(".claude").join("output-styles");
+        std::fs::create_dir_all(&style_dir).unwrap();
+        let default = OUTPUT_STYLES[0];
+        std::fs::write(style_dir.join(default.file_name), default.content).unwrap();
+    }
+
+    /// A fully-provisioned workspace matching everything `prepare_session`
+    /// would have written, used as the positive-path baseline every negative
+    /// test starts from and mutates one field of.
+    fn fully_provisioned(base: &Path) -> FrameworkPaths {
+        let fw = hermetic_paths(base);
+        seed_agent_source(&fw, &["engineer", "BASE-AGENT"]);
+        seed_skill_source(&fw, &["tm-doctor"]);
+
+        let agents_dir = fw.claude_agents_dir();
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(agents_dir.join("engineer.md"), "agent").unwrap();
+        std::fs::write(agents_dir.join("BASE-AGENT.md"), "base").unwrap();
+        AgentManifest::default().save(&agents_dir).unwrap();
+
+        let skills_dir = fw.claude_skills_dir();
+        std::fs::create_dir_all(skills_dir.join("tm-doctor")).unwrap();
+        std::fs::write(skills_dir.join("tm-doctor").join("SKILL.md"), "skill").unwrap();
+        crate::core::skill_manifest::SkillManifest::default()
+            .save(&skills_dir)
+            .unwrap();
+
+        deploy_style_file(&fw);
+        write_settings(
+            &fw,
+            r#"{"outputStyle": "trusty-mpm", "hooks": {"SessionStart": []}}"#,
+        );
+        fw
+    }
+
+    #[test]
+    fn validate_complete_workspace_has_no_gaps() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        let report = validate_workspace(&fw);
+        assert!(
+            report.is_complete(),
+            "expected no gaps, got: {:?}",
+            report.gaps
+        );
+    }
+
+    #[test]
+    fn validate_missing_agent_manifest_is_a_gap() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        std::fs::remove_file(fw.claude_agents_dir().join(agent_manifest::MANIFEST_FILE)).unwrap();
+        let report = validate_workspace(&fw);
+        assert!(report.gaps.contains(&DeploymentGap::AgentManifestMissing));
+    }
+
+    #[test]
+    fn validate_missing_agent_is_a_gap() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        std::fs::remove_file(fw.claude_agents_dir().join("engineer.md")).unwrap();
+        let report = validate_workspace(&fw);
+        assert!(
+            report
+                .gaps
+                .contains(&DeploymentGap::AgentMissing("engineer".to_string()))
+        );
+    }
+
+    #[test]
+    fn validate_missing_skill_manifest_is_a_gap() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        std::fs::remove_file(
+            fw.claude_skills_dir()
+                .join(skill_manifest::SKILL_MANIFEST_FILE),
+        )
+        .unwrap();
+        let report = validate_workspace(&fw);
+        assert!(report.gaps.contains(&DeploymentGap::SkillManifestMissing));
+    }
+
+    #[test]
+    fn validate_missing_skill_is_a_gap() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        std::fs::remove_dir_all(fw.claude_skills_dir().join("tm-doctor")).unwrap();
+        let report = validate_workspace(&fw);
+        assert!(
+            report
+                .gaps
+                .contains(&DeploymentGap::SkillMissing("tm-doctor".to_string()))
+        );
+    }
+
+    #[test]
+    fn validate_settings_missing_is_a_gap() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        std::fs::remove_file(fw.claude_home_dir().join(".claude").join("settings.json")).unwrap();
+        let report = validate_workspace(&fw);
+        assert!(report.gaps.contains(&DeploymentGap::SettingsMissing));
+    }
+
+    #[test]
+    fn validate_missing_output_style_key_is_a_gap() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        write_settings(&fw, r#"{"hooks": {"SessionStart": []}}"#);
+        let report = validate_workspace(&fw);
+        assert!(report.gaps.contains(&DeploymentGap::OutputStyleKeyMissing));
+    }
+
+    #[test]
+    fn validate_unknown_output_style_id_is_a_gap() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        write_settings(
+            &fw,
+            r#"{"outputStyle": "claude_mpm", "hooks": {"SessionStart": []}}"#,
+        );
+        let report = validate_workspace(&fw);
+        assert!(report.gaps.contains(&DeploymentGap::OutputStyleUnknownId(
+            "claude_mpm".to_string()
+        )));
+    }
+
+    #[test]
+    fn validate_output_style_file_missing_is_a_gap() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        let style_dir = fw.claude_home_dir().join(".claude").join("output-styles");
+        std::fs::remove_dir_all(&style_dir).unwrap();
+        let report = validate_workspace(&fw);
+        assert!(report.gaps.contains(&DeploymentGap::OutputStyleFileMissing(
+            "trusty-mpm".to_string()
+        )));
+    }
+
+    #[test]
+    fn validate_missing_hooks_is_a_gap() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        write_settings(&fw, r#"{"outputStyle": "trusty-mpm"}"#);
+        let report = validate_workspace(&fw);
+        assert!(report.gaps.contains(&DeploymentGap::HooksMissing));
+    }
+
+    #[test]
+    fn describe_is_non_empty_for_every_variant() {
+        let gaps = [
+            DeploymentGap::AgentManifestMissing,
+            DeploymentGap::AgentManifestCorrupt("bad".to_string()),
+            DeploymentGap::AgentMissing("engineer".to_string()),
+            DeploymentGap::SkillManifestMissing,
+            DeploymentGap::SkillMissing("tm-doctor".to_string()),
+            DeploymentGap::SettingsMissing,
+            DeploymentGap::SettingsMalformed("bad json".to_string()),
+            DeploymentGap::OutputStyleKeyMissing,
+            DeploymentGap::OutputStyleUnknownId("x".to_string()),
+            DeploymentGap::OutputStyleFileMissing("x".to_string()),
+            DeploymentGap::HooksMissing,
+        ];
+        for gap in gaps {
+            assert!(!gap.describe().is_empty());
+        }
+    }
+
+    #[test]
+    fn repair_is_a_noop_on_already_complete_workspace() {
+        let tmp = TempDir::new().unwrap();
+        let fw = fully_provisioned(tmp.path());
+        let outcome = validate_and_repair(&fw, &fw.claude_home_dir(), None);
+        assert!(!outcome.repaired);
+        assert!(outcome.is_complete());
+        assert_eq!(outcome.before, outcome.after);
+    }
+
+    #[test]
+    fn repair_closes_gaps_on_incomplete_workspace() {
+        // Seed only the framework SOURCE roster (what `prepare_session_inner`
+        // would deploy from) but leave the workspace `.claude/` entirely
+        // unprovisioned — the exact "spawned with an incomplete payload"
+        // scenario #2158 describes. The repair path must deploy everything
+        // and leave the workspace complete.
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        let mut fw = fw;
+        fw.trusty_mpm_root = None;
+        seed_agent_source(&fw, &["engineer"]);
+        seed_skill_source(&fw, &["tm-doctor"]);
+
+        let before = validate_workspace(&fw);
+        assert!(!before.is_complete(), "expected gaps before repair");
+
+        let outcome = validate_and_repair(&fw, &workspace, None);
+        assert!(outcome.repaired);
+        assert!(
+            outcome.is_complete(),
+            "expected repair to close every gap, remaining: {:?}",
+            outcome.after.gaps
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -29,6 +29,7 @@ pub mod compress;
 pub mod config;
 pub mod connect;
 pub mod delegation_authority;
+pub mod deploy_validate;
 pub mod deterministic_overseer;
 pub mod discovery;
 pub mod doctor;

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1059,15 +1059,16 @@ async fn pair_reset_clears_pairing() {
 
 #[tokio::test]
 async fn doctor_endpoint_returns_report() {
-    // `GET /api/v1/doctor` returns a nine-check report (#1840 added the
+    // `GET /api/v1/doctor` returns a ten-check report (#1840 added the
     // worktrees check; DOC-28 R4(a) added the output_style check; A2
     // (tm-skills-portfolio epic) added the skill_source check;
-    // #gh-account-awareness added the gh_account check). #1905's stale-skill
-    // cleanup is a one-time migration, not a `run_doctor` probe, so it does not
-    // appear here; the per-check statuses carry the diagnosis, not the HTTP status.
+    // #gh-account-awareness added the gh_account check; #2158 added the
+    // deployment check). #1905's stale-skill cleanup is a one-time migration,
+    // not a `run_doctor` probe, so it does not appear here; the per-check
+    // statuses carry the diagnosis, not the HTTP status.
     let state = DaemonState::shared();
     let Json(report) = doctor(State(state), Query(DoctorQuery::default())).await;
-    assert_eq!(report.checks.len(), 9);
+    assert_eq!(report.checks.len(), 10);
     let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
     assert_eq!(
         names,
@@ -1077,6 +1078,7 @@ async fn doctor_endpoint_returns_report() {
             "skills",
             "skill_source",
             "output_style",
+            "deployment",
             "memory",
             "search",
             "worktrees",

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -33,6 +33,13 @@ use doctor_output_style::check_output_style;
 mod doctor_fs_checks;
 use doctor_fs_checks::{check_agents, check_instructions, check_skill_source, check_skills};
 
+// Split out to keep this file under the 500-SLOC production cap (issue #2158
+// — the full manifest-completeness diff, layered on top of the narrower
+// check_agents/check_skills/check_output_style probes above).
+#[path = "doctor_deploy_validate.rs"]
+mod doctor_deploy_validate;
+use doctor_deploy_validate::check_deployment_completeness;
+
 /// Per-probe network timeout.
 ///
 /// Why: a sidecar that is down or wedged must not stall the whole diagnostic;
@@ -48,13 +55,16 @@ const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
 /// running all probes here keeps the check set identical across every UI.
 /// What: runs the instruction / agent / skill / output-style filesystem
 /// probes (the output-style probe closes DOC-28 F4 — the "did the
-/// trusty-mpm instructions actually load" gap), then the memory and search
-/// HTTP probes (each bounded by [`PROBE_TIMEOUT`]), a worktree-orphan scan
-/// (Fix 1b, #1840), the `skill_source` probe (A2, tm-skills-portfolio epic), and
-/// the `gh_account` probe (#gh-account-awareness — surfaces the active
-/// github.com identity and warns on the multi-account ambiguity) — folding the
-/// resulting nine [`DoctorCheck`]s into a [`DoctorReport`] whose `overall` status
-/// is the worst of them.
+/// trusty-mpm instructions actually load" gap), the `deployment` probe (issue
+/// #2158 — a full manifest-completeness diff against the canonical bundled
+/// roster, layered on top of the narrower agent/skill/output-style probes),
+/// then the memory and search HTTP probes (each bounded by [`PROBE_TIMEOUT`]),
+/// a worktree-orphan scan (Fix 1b, #1840), the `skill_source` probe (A2,
+/// tm-skills-portfolio epic), and the `gh_account` probe
+/// (#gh-account-awareness — surfaces the active github.com identity and warns
+/// on the multi-account ambiguity) — folding the resulting ten
+/// [`DoctorCheck`]s into a [`DoctorReport`] whose `overall` status is the
+/// worst of them.
 ///
 /// Note (#1905): the mpm-*→tm-* stale-skill cleanup is intentionally NOT a
 /// permanent probe here — it is a one-time migration
@@ -76,7 +86,7 @@ const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
 /// silently missing the exact provisioning gap this issue is about. With no
 /// `project_dir` (the pre-existing CLI/standalone usage) this is unchanged —
 /// [`FrameworkPaths::default`] still probes the home tier.
-/// Test: `run_doctor_produces_nine_checks`,
+/// Test: `run_doctor_produces_ten_checks`,
 /// `check_agents_scoped_to_managed_workspace_fails_on_empty_roster`.
 pub async fn run_doctor(
     project_dir: Option<&Path>,
@@ -98,6 +108,7 @@ pub async fn run_doctor(
         check_skills(skills_root),
         check_skill_source(&paths),
         check_output_style(project_dir, &home),
+        check_deployment_completeness(&paths),
     ];
     checks.push(check_memory(&home).await);
     checks.push(check_search(&home).await);
@@ -505,12 +516,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_doctor_produces_nine_checks() {
-        // #gh-account-awareness: adds the `gh_account` probe, bringing the total
-        // from eight to nine checks. #1905's stale-skill cleanup is deliberately
-        // NOT a `run_doctor` probe — see the `run_doctor` doc comment.
+    async fn run_doctor_produces_ten_checks() {
+        // Issue #2158 adds the `deployment` probe, bringing the total from
+        // nine to ten checks. #1905's stale-skill cleanup is deliberately NOT
+        // a `run_doctor` probe — see the `run_doctor` doc comment.
         let report = run_doctor(None, None, &[]).await;
-        assert_eq!(report.checks.len(), 9);
+        assert_eq!(report.checks.len(), 10);
         let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(
             names,
@@ -520,6 +531,7 @@ mod tests {
                 "skills",
                 "skill_source",
                 "output_style",
+                "deployment",
                 "memory",
                 "search",
                 "worktrees",

--- a/crates/trusty-mpm/src/daemon/doctor_deploy_validate.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_deploy_validate.rs
@@ -1,0 +1,115 @@
+//! `tm doctor` full manifest-completeness check (issue #2158).
+//!
+//! Why: the pre-existing `agents`/`skills`/`output_style` probes each check
+//! ONE facet in isolation (non-empty directory, resolvable style id) but
+//! never diff the deployed payload against the canonical bundled roster as a
+//! whole — a managed workspace could pass all three individually while still
+//! missing several agents, carrying no ownership manifest, or missing the
+//! `hooks` key, none of which the narrower probes catch. This check closes
+//! that gap by delegating to [`crate::core::deploy_validate::validate_workspace`],
+//! the same diff engine `tm validate` and the daemon's spawn/resume
+//! auto-repair gate use, so all three surfaces report identical
+//! completeness verdicts. Split into its own file (mirroring the existing
+//! `doctor_output_style.rs` / `doctor_fs_checks.rs` split) to keep `doctor.rs`
+//! under the 500-SLOC production cap.
+//! What: [`check_deployment_completeness`] takes the already-resolved
+//! [`FrameworkPaths`] `run_doctor` built for `project_dir` (home-relative when
+//! no project is scoped) and folds every [`DeploymentGap`] into one
+//! [`DoctorCheck`] — `Ok` when complete, `Fail` naming every gap otherwise.
+//! Test: `deployment_check_ok_when_complete`, `deployment_check_fail_lists_gaps`.
+
+use crate::core::deploy_validate::validate_workspace;
+use crate::core::doctor::{CheckStatus, DoctorCheck};
+use crate::core::paths::FrameworkPaths;
+
+/// Probe deployment completeness by diffing against the canonical bundled roster.
+///
+/// Why: see the module doc — this is the single check that catches a
+/// partially-provisioned `.claude/` payload as a whole, not just one facet
+/// of it.
+/// What: `Ok` when [`validate_workspace`] finds no gaps; `Fail` naming every
+/// gap (semicolon-joined, capped implicitly by the small roster size so the
+/// message stays readable) plus the actionable hint to run `tm validate
+/// --repair` otherwise.
+/// Test: `deployment_check_ok_when_complete`, `deployment_check_fail_lists_gaps`.
+pub(super) fn check_deployment_completeness(paths: &FrameworkPaths) -> DoctorCheck {
+    let report = validate_workspace(paths);
+    if report.is_complete() {
+        return DoctorCheck::new(
+            "deployment",
+            CheckStatus::Ok,
+            "deployed .claude/{agents,skills} and settings.json match the canonical roster",
+        );
+    }
+    let detail: Vec<String> = report.gaps.iter().map(|g| g.describe()).collect();
+    DoctorCheck::new(
+        "deployment",
+        CheckStatus::Fail,
+        format!(
+            "{} deployment gap(s) found: {} — run `tm validate --repair` to fix",
+            detail.len(),
+            detail.join("; ")
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deployment_check_ok_when_complete() {
+        // An entirely empty temp dir has no canonical source agents/skills to
+        // diff against (both `agent_source_dir()`/`skill_source_dir()` and the
+        // deploy targets are empty), so there is nothing to report missing —
+        // the settings.json probes are the only ones that can still fail, so
+        // seed a minimal complete settings.json plus manifests.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut paths = FrameworkPaths::under(tmp.path());
+        paths.trusty_mpm_root = None;
+
+        let agents_dir = paths.claude_agents_dir();
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        crate::core::agent_manifest::AgentManifest::default()
+            .save(&agents_dir)
+            .unwrap();
+        let skills_dir = paths.claude_skills_dir();
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        crate::core::skill_manifest::SkillManifest::default()
+            .save(&skills_dir)
+            .unwrap();
+
+        let claude_dir = paths.claude_home_dir().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let style_dir = claude_dir.join("output-styles");
+        std::fs::create_dir_all(&style_dir).unwrap();
+        let default_style = crate::core::bundle::OUTPUT_STYLES[0];
+        std::fs::write(
+            style_dir.join(default_style.file_name),
+            default_style.content,
+        )
+        .unwrap();
+        std::fs::write(
+            claude_dir.join("settings.json"),
+            r#"{"outputStyle": "trusty-mpm", "hooks": {"SessionStart": []}}"#,
+        )
+        .unwrap();
+
+        let check = check_deployment_completeness(&paths);
+        assert_eq!(check.status, CheckStatus::Ok, "message: {}", check.message);
+    }
+
+    #[test]
+    fn deployment_check_fail_lists_gaps() {
+        // A totally unprovisioned workspace (no manifests, no settings.json)
+        // must Fail and name the gaps in the message.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut paths = FrameworkPaths::under(tmp.path());
+        paths.trusty_mpm_root = None;
+
+        let check = check_deployment_completeness(&paths);
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.message.contains("agent ownership manifest"));
+        assert!(check.message.contains("tm validate --repair"));
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -410,6 +410,18 @@ async fn spawn_managed_cloned(
         warn!(id = %record.id, "spawn_managed: set_workspace failed: {e}");
     }
 
+    // Deployment-completeness gate (#2158): never hand an incomplete
+    // `.claude/` payload to the operator. Skips the runtime spawn entirely
+    // when auto-repair cannot close every gap.
+    let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&prepared.path);
+    if let Err(reason) =
+        ensure_deployment_complete(&fw, &prepared.path, record.repo_url.as_deref(), &record.id)
+    {
+        warn!(id = %record.id, "spawn_managed: {reason}");
+        let _ = mgr.mark_errored(&record.id, &reason).await;
+        return Ok(mgr.get(&record.id).await.unwrap_or(record));
+    }
+
     // Step 3: spawn the selected runtime in the pane. A spawn failure is recorded
     // (the record is marked errored) but is not fatal — the record exists and the
     // caller still gets it back.
@@ -664,6 +676,17 @@ async fn spawn_managed_inproject(
         warn!(id = %session_id, "spawn_managed (inproject): set_workspace failed: {e}");
     }
 
+    // Deployment-completeness gate (#2158): see `spawn_managed_cloned`'s
+    // identical gate for the full rationale. Reuses the `fw` already resolved
+    // above for `prepare_inproject_session`.
+    if let Err(reason) =
+        ensure_deployment_complete(&fw, &worktree, record.repo_url.as_deref(), session_id)
+    {
+        warn!(id = %session_id, "spawn_managed (inproject): {reason}");
+        let _ = mgr.mark_errored(session_id, &reason).await;
+        return Ok(mgr.get(session_id).await.unwrap_or(record));
+    }
+
     emit(ProvisioningStage::LaunchingRuntime);
     let tmux_arc = mgr.tmux_driver();
     let adapter = crate::runtime::build_adapter(record.runtime, tmux_arc);
@@ -880,6 +903,17 @@ async fn spawn_managed_local(
         .await
     {
         warn!(id = %record.id, "spawn_managed (local→managed): set_workspace failed: {e}");
+    }
+
+    // Deployment-completeness gate (#2158): see `spawn_managed_cloned`'s
+    // identical gate for the full rationale.
+    let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&workspace);
+    if let Err(reason) =
+        ensure_deployment_complete(&fw, &workspace, record.repo_url.as_deref(), &record.id)
+    {
+        warn!(id = %record.id, "spawn_managed (local→managed): {reason}");
+        let _ = mgr.mark_errored(&record.id, &reason).await;
+        return Ok(mgr.get(&record.id).await.unwrap_or(record));
     }
 
     emit(ProvisioningStage::LaunchingRuntime);
@@ -1147,6 +1181,20 @@ pub async fn resume_managed(
         );
     }
 
+    // Deployment-completeness gate (#2158): see `spawn_managed_cloned`'s
+    // identical gate for the full rationale. `ensure_deployment_complete`
+    // itself no-ops for an unresolved (`/unknown`) workspace — an adopted
+    // session with no known cwd is handled separately by the reconcile-on-boot
+    // fix, not here.
+    let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&workspace);
+    if let Err(reason) =
+        ensure_deployment_complete(&fw, &workspace, record.repo_url.as_deref(), &record.id)
+    {
+        warn!(id = %record.id, "resume_managed: {reason}");
+        let _ = mgr.mark_errored(&record.id, &reason).await;
+        return Ok(mgr.get(id).await.unwrap_or(record));
+    }
+
     let tmux_arc = mgr.tmux_driver();
     let adapter = build_adapter(record.runtime, tmux_arc);
     // #1744: prefer --resume <id> when a claude_session_id was captured at
@@ -1179,6 +1227,64 @@ pub async fn resume_managed(
     }
 
     Ok(mgr.get(id).await.unwrap_or(record))
+}
+
+/// Validate a workspace against the canonical bundled roster before handing
+/// the session to the operator, auto-repairing first when gaps are found
+/// (issue #2158).
+///
+/// Why: `prepare_session_inner`'s roster/output-style/hooks steps are already
+/// best-effort/non-fatal (issue #2149) so a session always launches carrying
+/// SOME identity — but "launches" is not the same as "launches complete". A
+/// worktree whose `.claude/` payload came up incomplete (missing agents, a
+/// stripped `settings.json`, no ownership manifest — see #2158) could
+/// otherwise silently reach the operator. This gate closes that hole:
+/// validate, and if incomplete, re-run the deploy pipeline once via
+/// [`crate::core::deploy_validate::validate_and_repair`] (which reuses
+/// [`crate::core::session_launch::prepare_session_with_repo_url`] — the exact
+/// #2149 pipeline, no parallel repair implementation), then re-validate. Every
+/// `spawn_managed_*`/`resume_managed` call site skips the runtime
+/// spawn/respawn and marks the record errored instead of handing over a
+/// silently broken session when this returns `Err`.
+/// What: no-ops (`Ok(())`) when `workspace` is the adopted-session sentinel
+/// `/unknown` or does not exist on disk — an unresolved workspace has nothing
+/// to validate; that case is handled separately by the `reconcile_on_boot`
+/// adopted-session fix, not here. Otherwise delegates to `validate_and_repair`
+/// using the caller-resolved `fw` (production call sites pass
+/// [`crate::core::paths::FrameworkPaths::for_managed_workspace`]`(workspace)`;
+/// tests inject a hermetic [`crate::core::paths::FrameworkPaths::under`]).
+/// `Ok(())` when the workspace is (or becomes) complete; `Err(detail)` naming
+/// every residual gap otherwise.
+/// Test: `ensure_deployment_complete_noops_for_unknown_workspace`,
+/// `ensure_deployment_complete_ok_when_already_complete`,
+/// `ensure_deployment_complete_repairs_and_succeeds`.
+fn ensure_deployment_complete(
+    fw: &crate::core::paths::FrameworkPaths,
+    workspace: &std::path::Path,
+    repo_url: Option<&str>,
+    session_id: &ManagedSessionId,
+) -> Result<(), String> {
+    if workspace == std::path::Path::new("/unknown") || !workspace.is_dir() {
+        return Ok(());
+    }
+    let outcome = crate::core::deploy_validate::validate_and_repair(fw, workspace, repo_url);
+    if outcome.before.is_complete() {
+        return Ok(());
+    }
+    if outcome.is_complete() {
+        info!(
+            id = %session_id,
+            gaps = outcome.before.gaps.len(),
+            "deployment validation: auto-repair closed all gaps before handoff"
+        );
+        return Ok(());
+    }
+    let detail: Vec<String> = outcome.after.gaps.iter().map(|g| g.describe()).collect();
+    Err(format!(
+        "deployment incomplete after auto-repair ({} gap(s) remain): {}",
+        detail.len(),
+        detail.join("; ")
+    ))
 }
 
 #[cfg(test)]
@@ -1529,5 +1635,74 @@ mod tests {
             "the worktree directory must exist on disk, got {}",
             worktree.display()
         );
+    }
+
+    /// Why (#2158): the adopted-session sentinel `/unknown` (and any
+    /// non-existent workspace) must never be handed to `validate_and_repair`
+    /// — there is nothing on disk to diff, and the repair pipeline would
+    /// fail trying to `create_dir_all` under it. The gate must silently no-op
+    /// instead.
+    /// Test: itself.
+    #[test]
+    fn ensure_deployment_complete_noops_for_unknown_workspace() {
+        // `fw`'s fields are never dereferenced on this early-return path, so
+        // a fixed placeholder base (no I/O, no tempdir) is sufficient.
+        let id = ManagedSessionId::new();
+        let fw = crate::core::paths::FrameworkPaths::under("/nonexistent-fw-base-for-test");
+        let result = ensure_deployment_complete(&fw, std::path::Path::new("/unknown"), None, &id);
+        assert!(result.is_ok());
+
+        let missing = std::path::Path::new("/this/path/does/not/exist/anywhere");
+        let result = ensure_deployment_complete(&fw, missing, None, &id);
+        assert!(result.is_ok());
+    }
+
+    /// Why (#2158): a workspace whose `.claude/` payload already matches the
+    /// canonical roster must pass the gate without attempting a repair.
+    /// Test: itself.
+    #[test]
+    fn ensure_deployment_complete_ok_when_already_complete() {
+        use crate::core::agent_manifest::AgentManifest;
+        use crate::core::paths::FrameworkPaths;
+        use crate::core::skill_manifest::SkillManifest;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        // Fully hermetic: `trusty_mpm_root = None` forces the canonical SOURCE
+        // dirs to resolve under the temp `fw.agents`/`fw.skills` (empty here),
+        // never the real daemon-default `~/.trusty-mpm` — so this test's
+        // verdict cannot depend on what happens to be installed on the
+        // machine running it. An empty canonical roster plus a fully
+        // manifested + settings-configured target is "complete" by
+        // definition (nothing to diff against).
+        let mut fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        fw.trusty_mpm_root = None;
+        let agents_dir = fw.claude_agents_dir();
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        AgentManifest::default().save(&agents_dir).unwrap();
+        let skills_dir = fw.claude_skills_dir();
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        SkillManifest::default().save(&skills_dir).unwrap();
+
+        let claude_dir = workspace.join(".claude");
+        std::fs::write(
+            claude_dir.join("settings.json"),
+            r#"{"outputStyle": "trusty-mpm", "hooks": {"SessionStart": []}}"#,
+        )
+        .unwrap();
+        let style_dir = claude_dir.join("output-styles");
+        std::fs::create_dir_all(&style_dir).unwrap();
+        let default_style = crate::core::bundle::OUTPUT_STYLES[0];
+        std::fs::write(
+            style_dir.join(default_style.file_name),
+            default_style.content,
+        )
+        .unwrap();
+
+        let id = ManagedSessionId::new();
+        let result = ensure_deployment_complete(&fw, &workspace, None, &id);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 }

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -630,18 +630,41 @@ impl SessionManager {
             guard.upsert(record).await?;
         }
 
-        // Adopt tmux sessions the store has never seen.
+        // Adopt tmux sessions the store has never seen. Issue #2158: an
+        // adopted session must never be left as a silent half-record with
+        // cwd/workspace_path permanently stubbed to "/unknown" — re-resolve
+        // the pane's real working directory via `get_pane_cwd` (the same
+        // primitive the idle-auto-stop snapshot uses) so it can be validated
+        // and provisioned like any other managed workspace; a pane whose cwd
+        // cannot be resolved is left CLEARLY flagged as unmanaged in `task`
+        // rather than an indistinguishable-from-normal "adopted session".
+        let mut newly_resolved: Vec<(ManagedSessionId, PathBuf)> = Vec::new();
         for name in &live_names {
             if !known_names.contains(name) {
+                let resolved_cwd = self.tmux.get_pane_cwd(name).filter(|p| p.is_dir());
+                let (cwd, workspace_path, task) = match &resolved_cwd {
+                    Some(path) => (
+                        path.clone(),
+                        Some(path.clone()),
+                        "adopted session".to_string(),
+                    ),
+                    None => (
+                        PathBuf::from("/unknown"),
+                        None,
+                        "adopted session (unmanaged — workspace path could not be resolved)"
+                            .to_string(),
+                    ),
+                };
+                let id = ManagedSessionId::new();
                 let external = SessionRecord {
-                    id: ManagedSessionId::new(),
+                    id,
                     tmux_name: name.clone(),
-                    cwd: PathBuf::from("/unknown"),
-                    task: "adopted session".into(),
+                    cwd,
+                    task,
                     state: ManagedSessionState::Active,
                     created_at: Utc::now(),
                     last_activity_at: None,
-                    workspace_path: None,
+                    workspace_path,
                     repo_url: None,
                     branch: None,
                     pending_decision: None,
@@ -663,6 +686,9 @@ impl SessionManager {
                     scrollback_path: None,
                     last_cwd: None,
                 };
+                if let Some(path) = resolved_cwd {
+                    newly_resolved.push((id, path));
+                }
                 guard.upsert(external).await?;
                 report.external_adopted.push(name.clone());
                 info!(name = %name, "reconcile: adopted external managed session");
@@ -671,6 +697,27 @@ impl SessionManager {
 
         // Release write guard before auto-resume (which needs its own locks).
         drop(guard);
+
+        // #2158: best-effort validate + auto-repair the deployed `.claude/`
+        // payload for every adopted session whose workspace was resolved
+        // above. Non-fatal — a repair failure only leaves the workspace as-is;
+        // the operator can run `tm validate --path <dir> --repair` manually.
+        for (id, workspace) in newly_resolved {
+            let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&workspace);
+            let outcome = crate::core::deploy_validate::validate_and_repair(&fw, &workspace, None);
+            if outcome.before.is_complete() {
+                continue;
+            }
+            if outcome.is_complete() {
+                info!(id = %id, "reconcile: auto-repaired adopted session's deployment");
+            } else {
+                warn!(
+                    id = %id,
+                    gaps = outcome.after.gaps.len(),
+                    "reconcile: adopted session's deployment remains incomplete after auto-repair"
+                );
+            }
+        }
 
         if auto_resume && !to_resume.is_empty() {
             info!(

--- a/crates/trusty-mpm/src/session_manager/naming_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/naming_tests.rs
@@ -200,3 +200,103 @@ async fn manager_reconcile_adopts_new_prefix_session() {
         .expect("adopted record present");
     assert_eq!(adopted.state, ManagedSessionState::Active);
 }
+
+/// Minimal `ManagedTmuxDriver` test double whose `get_pane_cwd` is
+/// controllable, mirroring `lifecycle.rs`'s local `StubTmux` pattern rather
+/// than extending the shared `tests::FakeTmuxDriver` (already near its
+/// 1500-SLOC test-file cap).
+///
+/// Why (#2158): the adopted-session cwd-resolution fix needs a driver whose
+/// `get_pane_cwd` returns a controllable value; every other trait method is
+/// unused by these two tests and panics if called, so a wiring mistake fails
+/// loudly instead of silently passing.
+/// What: `list_sessions` returns `alive`; `get_pane_cwd` returns `pane_cwd`
+/// for every session name (both fields set at construction).
+/// Test: used by `reconcile_resolves_adopted_session_cwd_from_pane` and
+/// `reconcile_flags_unresolvable_adopted_session_as_unmanaged` below.
+struct PaneCwdTmux {
+    alive: Vec<String>,
+    pane_cwd: Option<PathBuf>,
+}
+
+impl ManagedTmuxDriver for PaneCwdTmux {
+    fn create_session(
+        &self,
+        _name: &str,
+        _workdir: &str,
+    ) -> Result<(), super::manager::ManagedError> {
+        unimplemented!("not exercised by PaneCwdTmux tests")
+    }
+    fn kill_session(&self, _name: &str) -> Result<(), super::manager::ManagedError> {
+        unimplemented!("not exercised by PaneCwdTmux tests")
+    }
+    fn send_line(&self, _name: &str, _text: &str) -> Result<(), super::manager::ManagedError> {
+        unimplemented!("not exercised by PaneCwdTmux tests")
+    }
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, super::manager::ManagedError> {
+        unimplemented!("not exercised by PaneCwdTmux tests")
+    }
+    fn list_sessions(&self) -> Result<Vec<String>, super::manager::ManagedError> {
+        Ok(self.alive.clone())
+    }
+    fn get_pane_cwd(&self, _name: &str) -> Option<PathBuf> {
+        self.pane_cwd.clone()
+    }
+}
+
+/// Why (#2158): an adopted session whose pane cwd resolves to a real,
+/// existing directory must carry that directory as BOTH `cwd` and
+/// `workspace_path` — never the permanent `/unknown` stub — so it can be
+/// validated/auto-repaired like any other managed workspace.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reconcile_resolves_adopted_session_cwd_from_pane() {
+    let dir = TempDir::new().unwrap();
+    let workspace = TempDir::new().unwrap();
+    let fake = std::sync::Arc::new(PaneCwdTmux {
+        alive: vec!["tm-resolvable-01".into()],
+        pane_cwd: Some(workspace.path().to_path_buf()),
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
+    mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    let listed = mgr.list().await;
+    let adopted = listed
+        .iter()
+        .find(|r| r.tmux_name == "tm-resolvable-01")
+        .expect("adopted record present");
+    assert_eq!(adopted.cwd, workspace.path());
+    assert_eq!(adopted.workspace_path.as_deref(), Some(workspace.path()));
+    assert_eq!(adopted.task, "adopted session");
+}
+
+/// Why (#2158): an adopted session whose pane cwd cannot be resolved (the
+/// driver returns `None`, or resolves to a path that does not exist) must
+/// keep the `/unknown` sentinel AND carry a task string that clearly flags it
+/// as unmanaged — never an indistinguishable-from-normal "adopted session".
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reconcile_flags_unresolvable_adopted_session_as_unmanaged() {
+    let dir = TempDir::new().unwrap();
+    let fake = std::sync::Arc::new(PaneCwdTmux {
+        alive: vec!["tm-unresolvable-01".into()],
+        pane_cwd: None,
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
+    mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    let listed = mgr.list().await;
+    let adopted = listed
+        .iter()
+        .find(|r| r.tmux_name == "tm-unresolvable-01")
+        .expect("adopted record present");
+    assert_eq!(adopted.cwd, PathBuf::from("/unknown"));
+    assert!(adopted.workspace_path.is_none());
+    assert!(
+        adopted.task.contains("unmanaged"),
+        "task must clearly flag the record as unmanaged, got: {}",
+        adopted.task
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `core::deploy_validate` — diffs a managed workspace's deployed `.claude/{agents,skills}` (+ ownership manifests) and `settings.json` (`outputStyle`, `hooks`) against the canonical bundled roster, returning a structured `ValidationReport`. `validate_and_repair` re-runs `session_launch::prepare_session_with_repo_url` (the #2149 deploy pipeline — no parallel implementation) once and re-validates.
- Extends `tm doctor` with a new `deployment` check (`daemon::doctor_deploy_validate`, 10 checks total) that folds the diff into the existing report.
- Adds `tm validate [--path <dir>] [--repair]` — runs the diff standalone (no daemon required), prints every gap, exits non-zero on incompleteness.
- Wires the gate into `spawn_managed_cloned`/`spawn_managed_inproject`/`spawn_managed_local`/`resume_managed` in `daemon::managed_routes::lifecycle`: validate → auto-repair-if-incomplete → re-validate; a still-incomplete result skips the runtime spawn and marks the record errored instead of silently handing over a broken session.
- Fixes the adopted-session bypass in `session_manager::manager::reconcile_on_boot`: an externally-adopted tmux session now resolves its real cwd via `ManagedTmuxDriver::get_pane_cwd` instead of permanently stubbing `cwd = "/unknown"`. A resolved workspace is validated/auto-repaired; an unresolvable one is left with `/unknown` but its `task` field is rewritten to clearly read "unmanaged — workspace path could not be resolved" instead of an indistinguishable-from-normal "adopted session".

## Scope note
`validate_workspace` diffs against the FULL bundled agent/skill source set (`FrameworkPaths::agent_source_dir`/`skill_source_dir`), not a per-project `HarnessPlan`-filtered subset. The default HR-2 manifest selects every bundled agent/skill (see `session_launch::mod`'s doc comment), so this is exact in the common, no-custom-manifest case; a project that opts into a narrower manifest may see benign gaps for deliberately-excluded entries. Flagged as a judgment call — full `HarnessPlan`-aware precision was out of scope for this pass.

`reactivate.rs` (state-flip only, no tmux mutation, no workspace prep) was intentionally left unwired — it performs no provisioning step to gate.

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 14 allowlisted, 0 violations
- [x] `cargo test -p trusty-mpm --no-fail-fast` — 2390 lib tests + 746 bin tests pass; sole failure is the pre-existing flaky `formatters::banner::two_panel::tests::right_col_no_inner_border` (confirmed untouched by this change, unrelated)
- [x] New coverage: gap-class detection (missing agent/skill/manifest, missing/wrong `outputStyle`, missing `hooks`), auto-repair closing gaps, adopted-session cwd resolution + unmanaged flagging

Closes #2158

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools