### PR TITLE
feat(trusty-code): non-destructive context compaction + skill-output pinning (#2070)

### DIFF
--- a/crates/trusty-code/src/agent_loop/compaction.rs
+++ b/crates/trusty-code/src/agent_loop/compaction.rs
@@ -1,0 +1,213 @@
+//! Non-destructive context compaction trigger + summary generation (#2070).
+//!
+//! Why: vision spec §5.4 ("Non-Destructive Compaction + Last-Message Replay")
+//! calls for a token-efficiency middleware in the agent-loop message buffer:
+//! once the running transcript grows past a threshold, older turns should be
+//! collapsed into a short summary rather than sent verbatim on every
+//! subsequent request — while never discarding the original content. This
+//! module holds the two pure, transcript-shape-agnostic pieces of that
+//! mechanism — the trigger decision and the summary text — so
+//! `super::transcript::Transcript` (which owns the actual entries and their
+//! `compacted` flags) can stay focused on state management. Splitting the
+//! policy (when / what to say) from the mechanism (marking entries, replaying
+//! the last user turn) keeps both halves independently testable.
+//! What: [`CompactionConfig`] (the tunable threshold + active-zone size),
+//! [`estimate_tokens`] (a cheap chars/4 heuristic — no tokenizer dependency),
+//! [`should_compact`] (threshold check), and [`summarize_span`] (a
+//! deterministic one-line summary of a compacted message span, built from
+//! role counts and any tool names invoked — never an LLM call, so compaction
+//! never blocks the loop on network I/O).
+//! Test: `compaction::tests::*`.
+
+use crate::llm::ChatMessage;
+
+/// Tuning knobs for non-destructive context compaction (#2070, §5.4).
+///
+/// Why: A caller (production: `AgentLoop`; tests: unit tests exercising
+/// `Transcript` directly) needs to control both "how big is too big" and
+/// "how much of the recent conversation counts as the active work zone" —
+/// bundling them avoids two separate parameters threading through every call
+/// site.
+/// What: `token_threshold` is compared against the transcript's
+/// [`estimate_tokens`] total; `keep_last_messages` is the number of the most
+/// recent messages (the active work zone, §5.4 item 4) that are never
+/// eligible for compaction regardless of size.
+/// Test: `compaction::tests::default_is_sane`.
+#[derive(Debug, Clone, Copy)]
+pub struct CompactionConfig {
+    /// Estimated-token threshold that triggers compaction once exceeded.
+    pub token_threshold: usize,
+    /// Number of most-recent messages kept verbatim (the active work zone).
+    pub keep_last_messages: usize,
+}
+
+impl Default for CompactionConfig {
+    /// §5.4 gives no exact numbers; these defaults keep several full
+    /// tool-call round-trips (a handful of assistant+tool pairs) uncompacted
+    /// while triggering well before a typical model's context window is at
+    /// risk.
+    fn default() -> Self {
+        Self {
+            token_threshold: 6_000,
+            keep_last_messages: 6,
+        }
+    }
+}
+
+/// Estimate the token count of a text span using a cheap chars/4 heuristic.
+///
+/// Why: The agent loop has no tokenizer dependency today and adding one only
+/// to gate a compaction trigger would be disproportionate; the standard
+/// chars-divided-by-four rule of thumb is accurate enough to decide "is this
+/// transcript getting large", which is all the trigger needs.
+/// What: Returns `text.chars().count() / 4`, floor-divided.
+/// Test: `compaction::tests::estimate_tokens_uses_chars_over_four`.
+pub fn estimate_tokens(text: &str) -> usize {
+    text.chars().count() / 4
+}
+
+/// Sum the estimated token count across a span of messages.
+///
+/// Why: The trigger decision operates on the whole transcript's estimated
+/// size, not any single message.
+/// What: Sums `estimate_tokens` over each message's content plus role/name
+/// overhead is intentionally ignored — the heuristic only needs to track
+/// growth trend, not byte-exact accounting.
+/// Test: `compaction::tests::estimate_total_tokens_sums_content`.
+pub fn estimate_total_tokens(messages: &[ChatMessage]) -> usize {
+    messages
+        .iter()
+        .map(|m| estimate_tokens(m.content.as_deref().unwrap_or_default()))
+        .sum()
+}
+
+/// Whether the transcript's estimated size warrants compaction.
+///
+/// Why: Centralises the threshold comparison so `Transcript::maybe_compact`
+/// reads as policy application, not arithmetic.
+/// What: `true` when `estimate_total_tokens(messages) > cfg.token_threshold`.
+/// Test: `compaction::tests::should_compact_respects_threshold`.
+pub fn should_compact(messages: &[ChatMessage], cfg: &CompactionConfig) -> bool {
+    estimate_total_tokens(messages) > cfg.token_threshold
+}
+
+/// Build a deterministic one-line summary of a span of messages being
+/// compacted (§5.4 item 2: "Replace their content with a one-line summary").
+///
+/// Why: A real LLM-generated summary would require a synchronous network
+/// call in the middle of the loop's turn boundary — expensive, and a new
+/// failure mode compaction must not introduce. A deterministic summary built
+/// from role counts and invoked tool names is cheap, always available, and
+/// gives the model (and a human auditor) enough of a pointer to know what was
+/// elided.
+/// What: Counts assistant/tool/other messages in `span` and collects the
+/// distinct tool names named in `tool` role messages (via their `name`
+/// field), rendering `"[compacted N earlier messages: A assistant turn(s),
+/// T tool call(s) (name1, name2, ...)]"`. Returns a fixed placeholder for an
+/// empty span (should not occur in practice, but must not panic).
+/// Test: `compaction::tests::summarize_span_counts_roles_and_tools`,
+/// `compaction::tests::summarize_span_handles_empty_span`.
+pub fn summarize_span(span: &[ChatMessage]) -> String {
+    if span.is_empty() {
+        return "[compacted 0 earlier messages]".to_string();
+    }
+
+    let assistant_count = span.iter().filter(|m| m.role == "assistant").count();
+    let mut tool_names: Vec<&str> = span
+        .iter()
+        .filter(|m| m.role == "tool")
+        .filter_map(|m| m.name.as_deref())
+        .collect();
+    tool_names.sort_unstable();
+    tool_names.dedup();
+
+    let tool_count = span.iter().filter(|m| m.role == "tool").count();
+    let tools_suffix = if tool_names.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", tool_names.join(", "))
+    };
+
+    format!(
+        "[compacted {} earlier message{}: {} assistant turn{}, {} tool call{}{}]",
+        span.len(),
+        plural_suffix(span.len()),
+        assistant_count,
+        plural_suffix(assistant_count),
+        tool_count,
+        plural_suffix(tool_count),
+        tools_suffix,
+    )
+}
+
+/// Return `"s"` unless `n == 1`, for readable pluralisation in the summary.
+fn plural_suffix(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool_msg(name: &str) -> ChatMessage {
+        ChatMessage::tool_result("call_1", name, "result")
+    }
+
+    #[test]
+    fn default_is_sane() {
+        let cfg = CompactionConfig::default();
+        assert!(cfg.token_threshold > 0);
+        assert!(cfg.keep_last_messages > 0);
+    }
+
+    #[test]
+    fn estimate_tokens_uses_chars_over_four() {
+        assert_eq!(estimate_tokens("abcd"), 1);
+        assert_eq!(estimate_tokens("abcdefgh"), 2);
+        assert_eq!(estimate_tokens(""), 0);
+    }
+
+    #[test]
+    fn estimate_total_tokens_sums_content() {
+        let messages = vec![
+            ChatMessage::user("abcd"),
+            ChatMessage::assistant("abcdefgh"),
+        ];
+        assert_eq!(estimate_total_tokens(&messages), 3);
+    }
+
+    #[test]
+    fn should_compact_respects_threshold() {
+        let cfg = CompactionConfig {
+            token_threshold: 2,
+            keep_last_messages: 1,
+        };
+        let small = vec![ChatMessage::user("ab")];
+        let large = vec![ChatMessage::user("abcdefghijkl")];
+        assert!(!should_compact(&small, &cfg));
+        assert!(should_compact(&large, &cfg));
+    }
+
+    #[test]
+    fn summarize_span_counts_roles_and_tools() {
+        let span = vec![
+            ChatMessage::assistant("thinking"),
+            tool_msg("bash"),
+            tool_msg("read_file"),
+            tool_msg("bash"),
+        ];
+        let summary = summarize_span(&span);
+        assert!(summary.contains("4 earlier messages"));
+        assert!(summary.contains("1 assistant turn"));
+        assert!(summary.contains("3 tool calls"));
+        assert!(summary.contains("bash"));
+        assert!(summary.contains("read_file"));
+    }
+
+    #[test]
+    fn summarize_span_handles_empty_span() {
+        assert_eq!(summarize_span(&[]), "[compacted 0 earlier messages]");
+    }
+}

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -25,6 +25,7 @@
 //! tool-error continuation, usage accrual, sink notification order, cancellation,
 //! plus an `#[ignore]`-gated live test.
 
+mod compaction;
 mod error;
 mod sink;
 mod transcript;
@@ -46,6 +47,7 @@ use crate::mode::HarnessMode;
 use crate::perf::PerfCollector;
 use crate::tools::{AgentOutput, FINISH_TASK_TOOL_NAME, FinishTaskArgs, ToolRegistry, ToolResult};
 
+pub use compaction::CompactionConfig;
 pub use error::AgentLoopError;
 pub use sink::ToolEventSink;
 pub use transcript::Transcript;
@@ -82,6 +84,12 @@ pub struct AgentLoopConfig {
     /// The resolved harness mode for this run (#2059). See
     /// `Self::tool_definitions`' docs for the branch point this feeds.
     pub mode: HarnessMode,
+
+    /// Non-destructive context compaction tuning (#2070, §5.4). Only
+    /// consulted when `mode == HarnessMode::DailyDriver` — see
+    /// `Self::maybe_compact_transcript`'s docs for why Parity must never
+    /// compact.
+    pub compaction: CompactionConfig,
 }
 
 impl Default for AgentLoopConfig {
@@ -89,7 +97,8 @@ impl Default for AgentLoopConfig {
     ///
     /// Why: Most callers want a bounded but generous loop; defaults avoid
     /// boilerplate at every construction site.
-    /// What: 8 turns, 120s timeout, `openai/gpt-4o-mini`, `HarnessMode::default()`.
+    /// What: 8 turns, 120s timeout, `openai/gpt-4o-mini`, `HarnessMode::default()`,
+    /// `CompactionConfig::default()`.
     /// Test: `config_defaults_are_sane`.
     fn default() -> Self {
         Self {
@@ -97,6 +106,7 @@ impl Default for AgentLoopConfig {
             timeout_secs: 120,
             model: "openai/gpt-4o-mini".to_string(),
             mode: HarnessMode::default(),
+            compaction: CompactionConfig::default(),
         }
     }
 }
@@ -234,6 +244,10 @@ impl AgentLoop {
                 });
             }
 
+            // #2070: compaction check, same turn boundary as the cancellation
+            // check above — never mid-tool-call.
+            self.maybe_compact_transcript(transcript);
+
             let request = self.build_request(transcript, &schemas);
             let response = self.llm.chat(&request).await?;
 
@@ -369,6 +383,26 @@ impl AgentLoop {
             sink.tool_error(call_id, tool, &message).await;
         }
         transcript.push_tool_result(call_id, tool, &message);
+    }
+
+    /// Apply non-destructive context compaction to `transcript`, gated on mode
+    /// (#2070, §5.4; reconciled with §5.9's D2 the same way `tool_definitions`
+    /// is).
+    ///
+    /// Why: The parity-spec (D2) requires `HarnessMode::Parity` runs to stay
+    /// byte-identical / full-history for cross-model benchmark fairness —
+    /// compacting would silently change what a Parity run sends after enough
+    /// turns, breaking that guarantee. `HarnessMode::DailyDriver` is
+    /// production's token-efficiency mode, so it is the only mode this method
+    /// ever calls `Transcript::maybe_compact` for.
+    /// What: No-op under `HarnessMode::Parity`; under `HarnessMode::DailyDriver`,
+    /// delegates to `transcript.maybe_compact(&self.config.compaction)`.
+    /// Test: `agent_loop::tests::daily_driver_mode_compacts_long_running_loop`,
+    /// `agent_loop::tests::parity_mode_never_compacts_even_past_threshold`.
+    fn maybe_compact_transcript(&self, transcript: &mut Transcript) {
+        if self.config.mode == HarnessMode::DailyDriver {
+            transcript.maybe_compact(&self.config.compaction);
+        }
     }
 
     /// Build a `ChatRequest` from the running transcript and tool schemas.

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
-use super::{AgentLoop, AgentLoopConfig, AgentLoopError, ToolEventSink};
+use super::{AgentLoop, AgentLoopConfig, AgentLoopError, CompactionConfig, ToolEventSink};
 use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
 use crate::tools::{FinishTaskTool, ToolExecutor, ToolRegistry, ToolResult};
 
@@ -35,6 +35,10 @@ use crate::tools::{FinishTaskTool, ToolExecutor, ToolRegistry, ToolResult};
 struct ScriptedLlm {
     responses: Vec<ChatResponse>,
     cursor: AtomicUsize,
+    /// (#2070) Every request's message list, in call order — lets compaction
+    /// tests inspect exactly what the loop sent the model on each turn
+    /// without reaching into `Transcript` internals.
+    requests: Mutex<Vec<Vec<crate::llm::ChatMessage>>>,
 }
 
 impl ScriptedLlm {
@@ -52,6 +56,7 @@ impl ScriptedLlm {
         Self {
             responses,
             cursor: AtomicUsize::new(0),
+            requests: Mutex::new(Vec::new()),
         }
     }
 
@@ -64,11 +69,27 @@ impl ScriptedLlm {
     fn calls(&self) -> usize {
         self.cursor.load(Ordering::SeqCst)
     }
+
+    /// Every request's message list, in call order (#2070).
+    ///
+    /// Why: Compaction tests need to inspect what the loop actually sent the
+    /// model on a given turn — e.g. the last turn's request should carry a
+    /// `[compacted` summary and a replayed last-user message once compaction
+    /// has fired.
+    /// What: Clones the recorded request message lists.
+    /// Test: `agent_loop::tests::daily_driver_mode_compacts_long_running_loop`,
+    /// `agent_loop::tests::parity_mode_never_compacts_even_past_threshold`.
+    fn requests(&self) -> Vec<Vec<crate::llm::ChatMessage>> {
+        self.requests.lock().expect("lock").clone()
+    }
 }
 
 #[async_trait]
 impl LlmClientTrait for ScriptedLlm {
-    async fn chat(&self, _req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        if let Ok(mut guard) = self.requests.lock() {
+            guard.push(req.messages.clone());
+        }
         let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
         match self.responses.get(idx) {
             Some(resp) => Ok(resp.clone()),
@@ -393,6 +414,130 @@ fn tool_definitions_identical_across_modes_in_m1() {
     );
 
     assert_eq!(parity.tool_definitions(), daily_driver.tool_definitions());
+}
+
+/// A low-threshold `CompactionConfig` for a `DailyDriver` run to compact
+/// aggressively and deterministically inside a test.
+fn aggressive_compaction() -> CompactionConfig {
+    CompactionConfig {
+        token_threshold: 1,
+        keep_last_messages: 2,
+    }
+}
+
+/// A long-running `DailyDriver` loop compacts older turns; the request it
+/// finally sends carries a summary and a replayed last user message (#2070).
+///
+/// Why: §5.4's whole mechanism only matters if it is actually wired into the
+/// live turn loop, not just the `Transcript` unit — this is the
+/// loop-level integration proof.
+/// What: Scripts 5 tool-call round-trips then a final stop, with an
+/// aggressive `CompactionConfig` so compaction fires well before the run
+/// ends. Asserts the LAST request the scripted client received contains a
+/// `[compacted` summary message and ends with a replayed `user` message
+/// matching the original task, and that it is far shorter than the raw
+/// message count the run accumulated.
+/// Test: this test.
+#[tokio::test]
+async fn daily_driver_mode_compacts_long_running_loop() {
+    let mut fixtures: Vec<Value> = (0..5)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm.clone(),
+        registry,
+        AgentLoopConfig {
+            max_turns: 10,
+            mode: crate::mode::HarnessMode::DailyDriver,
+            compaction: aggressive_compaction(),
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    agent
+        .run("system prompt", "the original task")
+        .await
+        .expect("run completes");
+
+    let requests = llm.requests();
+    let last_request = requests.last().expect("at least one request");
+
+    let has_summary = last_request
+        .iter()
+        .any(|m| m.content.as_deref().unwrap_or("").contains("[compacted"));
+    assert!(
+        has_summary,
+        "expected a compaction summary in {last_request:?}"
+    );
+
+    let tail = last_request.last().expect("non-empty request");
+    assert_eq!(tail.role, "user");
+    assert_eq!(tail.content.as_deref(), Some("the original task"));
+
+    // Raw history at this point is 2 seed + 5*(assistant+tool) = 12 messages;
+    // the compacted view sent on the last turn must be materially smaller.
+    assert!(
+        last_request.len() < 12,
+        "expected a shrunk request, got {} messages",
+        last_request.len()
+    );
+}
+
+/// `Parity` mode never compacts, even past the same aggressive threshold
+/// that triggers compaction under `DailyDriver` (#2070, §5.9 reconciliation).
+///
+/// Why: The parity-spec (D2) requires byte-identical, full-history requests
+/// for cross-model benchmark fairness; compaction silently changing what a
+/// Parity run sends would break that guarantee.
+/// What: Same script and the SAME aggressive `CompactionConfig` as
+/// `daily_driver_mode_compacts_long_running_loop`, but `mode: Parity`.
+/// Asserts no request ever carries a `[compacted` summary and the last
+/// request's message count equals the full raw history (2 seed + 5 tool
+/// round-trips' worth of turns).
+/// Test: this test.
+#[tokio::test]
+async fn parity_mode_never_compacts_even_past_threshold() {
+    let mut fixtures: Vec<Value> = (0..5)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm.clone(),
+        registry,
+        AgentLoopConfig {
+            max_turns: 10,
+            mode: crate::mode::HarnessMode::Parity,
+            compaction: aggressive_compaction(),
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    agent
+        .run("system prompt", "the original task")
+        .await
+        .expect("run completes");
+
+    let requests = llm.requests();
+    for request in &requests {
+        let has_summary = request
+            .iter()
+            .any(|m| m.content.as_deref().unwrap_or("").contains("[compacted"));
+        assert!(!has_summary, "Parity must never compact, got {request:?}");
+    }
+
+    let last_request = requests.last().expect("at least one request");
+    assert_eq!(
+        last_request.len(),
+        12,
+        "Parity must send the full raw history"
+    );
 }
 
 /// A two-turn flow: assistant calls the tool, then stops with final text.
@@ -769,6 +914,7 @@ async fn agent_loop_live() {
             timeout_secs: 60,
             model: "openai/gpt-4o-mini".to_string(),
             mode: crate::mode::HarnessMode::default(),
+            ..AgentLoopConfig::default()
         },
         Arc::new(client),
         registry,

--- a/crates/trusty-code/src/agent_loop/transcript.rs
+++ b/crates/trusty-code/src/agent_loop/transcript.rs
@@ -10,18 +10,22 @@
 //! being deleted, so the outward, model-facing view can shrink while the
 //! stored history stays fully auditable.
 //! What: `Transcript` owns an ordered `Vec<TranscriptEntry>` (message +
-//! compacted flag); helpers append the seed messages, an assistant turn (text
-//! and/or tool calls), and a `tool` role result message. `assistant_text`
-//! concatenates the assistant text turns for the final `AgentOutput`.
-//! `maybe_compact` (#2070) applies [`super::compaction`]'s threshold policy;
-//! `to_messages` renders the model-facing view — contiguous compacted runs
-//! collapsed to one summary message, followed by a replayed copy of the last
-//! user message once any compaction has occurred (§5.4 items 2-3) — while
-//! `messages` always returns the complete, uncompacted raw history.
+//! compacted flag + pinned flag); helpers append the seed messages, an
+//! assistant turn (text and/or tool calls), and a `tool` role result message.
+//! `assistant_text` concatenates the assistant text turns for the final
+//! `AgentOutput`. `maybe_compact` (#2070) applies [`super::compaction`]'s
+//! threshold policy; `to_messages` renders the model-facing view —
+//! contiguous compacted runs collapsed to one summary message, followed by a
+//! replayed copy of the last user message once any compaction has occurred
+//! (§5.4 items 2-3) — while `messages` always returns the complete,
+//! uncompacted raw history. `push_tool_result` (#2070) pins any
+//! [`crate::tools::USE_SKILL_TOOL_NAME`] result forever — §5.4 item 5's
+//! "preserve skill outputs... forever" — alongside `system`/`user` turns.
 //! Test: `agent_loop::tests` build transcripts indirectly through the loop;
 //! `transcript::tests` cover the helpers and compaction directly.
 
 use crate::llm::{ChatMessage, ChatResponse, ToolCall};
+use crate::tools::USE_SKILL_TOOL_NAME;
 
 use super::compaction::{CompactionConfig, should_compact, summarize_span};
 
@@ -31,22 +35,45 @@ use super::compaction::{CompactionConfig, should_compact, summarize_span};
 /// even after it stops being sent to the model verbatim; a bare flag next to
 /// the message (rather than removing it from the vector) is the simplest
 /// representation that satisfies both "shrink what the model sees" and
-/// "never lose the audit trail".
+/// "never lose the audit trail". `pinned` is a SEPARATE flag from `compacted`
+/// (rather than overloading `compacted`) because a pinned entry must never
+/// transition to `compacted` at all — it is a permanent exemption, not a
+/// one-way state like compaction itself.
 /// What: `message` is the original, untouched `ChatMessage`; `compacted`
 /// starts `false` and is set `true` by `Transcript::maybe_compact` — never
-/// reset, since compaction is a one-way transform for a given entry.
-/// Test: `transcript::tests::maybe_compact_marks_middle_span_only`.
+/// reset, since compaction is a one-way transform for a given entry. `pinned`
+/// starts `false` and is set `true` only at construction time (never later)
+/// for entries `maybe_compact` must always skip — currently: skill outputs
+/// (`push_tool_result` sets it when `name == USE_SKILL_TOOL_NAME`; §5.4 item
+/// 5 also covers `system`/`user` role turns, but those are matched by role
+/// directly in `maybe_compact` rather than via this flag, since they are
+/// identifiable without extra state).
+/// Test: `transcript::tests::maybe_compact_marks_middle_span_only`,
+/// `transcript::tests::maybe_compact_never_compacts_pinned_skill_output`.
 #[derive(Debug, Clone)]
 struct TranscriptEntry {
     message: ChatMessage,
     compacted: bool,
+    pinned: bool,
 }
 
 impl TranscriptEntry {
+    /// An ordinary entry: uncompacted, unpinned.
     fn fresh(message: ChatMessage) -> Self {
         Self {
             message,
             compacted: false,
+            pinned: false,
+        }
+    }
+
+    /// A permanently-exempt entry (#2070): uncompacted and, unlike `fresh`,
+    /// never eligible to become compacted by `Transcript::maybe_compact`.
+    fn pinned(message: ChatMessage) -> Self {
+        Self {
+            message,
+            compacted: false,
+            pinned: true,
         }
     }
 }
@@ -126,16 +153,24 @@ impl Transcript {
     ///
     /// Why: The API requires each tool call to be answered by a `tool` message
     /// referencing its `tool_call_id`, or the next assistant turn errors.
+    /// (#2070) A `use_skill` result is the loaded body of a skill the model
+    /// deliberately chose to invoke — §5.4 item 5 requires it survive
+    /// compaction forever, the same guarantee `system`/`user` turns get.
     /// What: Pushes a `ChatMessage::tool_result` with the call id, function
-    /// name, and textual result.
-    /// Test: `transcript::tests::push_tool_result_sets_call_id`.
+    /// name, and textual result — as a permanently `pinned` entry when
+    /// `name == `[`USE_SKILL_TOOL_NAME`], otherwise as an ordinary compaction-
+    /// eligible entry.
+    /// Test: `transcript::tests::push_tool_result_sets_call_id`,
+    /// `transcript::tests::maybe_compact_never_compacts_pinned_skill_output`,
+    /// `transcript::tests::maybe_compact_still_compacts_non_skill_tool_results`.
     pub fn push_tool_result(&mut self, tool_call_id: &str, name: &str, content: &str) {
-        self.entries
-            .push(TranscriptEntry::fresh(ChatMessage::tool_result(
-                tool_call_id,
-                name,
-                content,
-            )));
+        let message = ChatMessage::tool_result(tool_call_id, name, content);
+        let entry = if name == USE_SKILL_TOOL_NAME {
+            TranscriptEntry::pinned(message)
+        } else {
+            TranscriptEntry::fresh(message)
+        };
+        self.entries.push(entry);
     }
 
     /// Return the complete, uncompacted raw message history.
@@ -205,14 +240,17 @@ impl Transcript {
     /// sent) exceeds `cfg.token_threshold`. Otherwise, marks every entry
     /// before the trailing `cfg.keep_last_messages` (the active work zone,
     /// §5.4 item 4) as `compacted = true`, EXCEPT entries already compacted
-    /// (a one-way transform) and `system`/`user` role entries (§5.4 item 5:
-    /// "preserve... user requests forever"). Sets `compaction_triggered` and
-    /// returns `true` only if at least one entry was newly marked (an
-    /// already-fully-compacted or entirely-preserved prefix is a no-op, not a
-    /// spurious trigger).
+    /// (a one-way transform), `pinned` entries (§5.4 item 5's skill-output
+    /// half — see `push_tool_result`), and `system`/`user` role entries
+    /// (§5.4 item 5's "preserve... user requests forever" half). Sets
+    /// `compaction_triggered` and returns `true` only if at least one entry
+    /// was newly marked (an already-fully-compacted or entirely-preserved
+    /// prefix is a no-op, not a spurious trigger).
     /// Test: `transcript::tests::maybe_compact_marks_middle_span_only`,
     /// `transcript::tests::maybe_compact_is_noop_below_threshold`,
-    /// `transcript::tests::maybe_compact_never_touches_system_or_user`.
+    /// `transcript::tests::maybe_compact_never_touches_system_or_user`,
+    /// `transcript::tests::maybe_compact_never_compacts_pinned_skill_output`,
+    /// `transcript::tests::maybe_compact_still_compacts_non_skill_tool_results`.
     pub fn maybe_compact(&mut self, cfg: &CompactionConfig) -> bool {
         if !should_compact(&self.to_messages(), cfg) {
             return false;
@@ -222,7 +260,7 @@ impl Transcript {
         let mut newly_compacted = false;
 
         for entry in &mut self.entries[..keep_from] {
-            if entry.compacted {
+            if entry.compacted || entry.pinned {
                 continue;
             }
             if entry.message.role == "system" || entry.message.role == "user" {
@@ -448,6 +486,84 @@ mod tests {
         // Non-destructive: every original entry is still present in the raw
         // history even though some are now marked compacted internally.
         assert_eq!(raw.len(), 2 + 20);
+    }
+
+    /// A `use_skill` tool result is pinned: it survives compaction even when
+    /// it falls outside the active zone and the transcript is well past the
+    /// threshold (#2070, §5.4 item 5).
+    ///
+    /// Why: This is the exact gap QA flagged — skill outputs flow through the
+    /// ordinary `push_tool_result` channel and, without pinning, would be
+    /// just as compaction-eligible as any other tool result.
+    /// What: Push a `use_skill` result early, then enough later turns to push
+    /// it well outside a small active zone; force compaction with an
+    /// aggressive config; assert `to_messages()` still contains the skill
+    /// result's ORIGINAL content verbatim (not replaced by a summary), and
+    /// that `messages()` (raw) also still has it — pinned entries are never
+    /// marked `compacted` at all, not merely retrievable via raw history.
+    /// Test: this test.
+    #[test]
+    fn maybe_compact_never_compacts_pinned_skill_output() {
+        let mut t = Transcript::seed("s", "task");
+        t.push_tool_result(
+            "call_skill",
+            USE_SKILL_TOOL_NAME,
+            "full skill body: do the distinctive thing",
+        );
+        for i in 0..10 {
+            t.push_assistant(Some(format!("turn {i}")), &[]);
+            t.push_tool_result(&format!("c{i}"), "bash", "output");
+        }
+        let cfg = CompactionConfig {
+            token_threshold: 1,
+            keep_last_messages: 2,
+        };
+        assert!(t.maybe_compact(&cfg));
+
+        let compacted_view = t.to_messages();
+        assert!(
+            compacted_view
+                .iter()
+                .any(|m| m.content.as_deref() == Some("full skill body: do the distinctive thing")),
+            "pinned skill output must survive verbatim in the compacted view: {compacted_view:?}"
+        );
+    }
+
+    /// Non-skill tool results (e.g. `bash`, `read_file`) remain
+    /// compaction-eligible — pinning must not accidentally exempt everything
+    /// and defeat compaction (#2070).
+    ///
+    /// Why: The fix for the skill-output gap must be narrowly scoped to
+    /// `USE_SKILL_TOOL_NAME`; a broad "pin every tool result" mistake would
+    /// silently disable compaction for ordinary long tool-heavy runs.
+    /// What: Same shape as the skill-pinning test but with only ordinary
+    /// `bash` tool results outside the active zone; assert compaction still
+    /// collapses them into a summary (the compacted view is materially
+    /// smaller than the raw history, and a summary marker is present).
+    /// Test: this test.
+    #[test]
+    fn maybe_compact_still_compacts_non_skill_tool_results() {
+        let mut t = Transcript::seed("s", "task");
+        for i in 0..10 {
+            t.push_assistant(Some(format!("turn {i}")), &[]);
+            t.push_tool_result(&format!("c{i}"), "bash", "output");
+        }
+        let cfg = CompactionConfig {
+            token_threshold: 1,
+            keep_last_messages: 2,
+        };
+        assert!(t.maybe_compact(&cfg));
+
+        let compacted_view = t.to_messages();
+        assert!(compacted_view.len() < t.messages().len());
+        assert!(
+            compacted_view.iter().any(|m| m
+                .content
+                .as_deref()
+                .unwrap_or("")
+                .contains("[compacted")),
+            "expected non-skill tool results to still collapse into a summary: {compacted_view:?}"
+        );
     }
 
     /// A compacted span collapses to exactly one summary message.

--- a/crates/trusty-code/src/agent_loop/transcript.rs
+++ b/crates/trusty-code/src/agent_loop/transcript.rs
@@ -5,27 +5,71 @@
 //! iteration and to render a final answer. Wrapping the `Vec<ChatMessage>` in a
 //! small type gives the loop intent-revealing helpers (`push_assistant`,
 //! `push_tool_result`) and keeps message-construction details out of the loop
-//! body.
-//! What: `Transcript` owns the running `Vec<ChatMessage>`; helpers append the
-//! seed messages, an assistant turn (text and/or tool calls), and a `tool` role
-//! result message. `assistant_text` concatenates the assistant text turns for
-//! the final `AgentOutput`.
+//! body. (#2070) It also owns non-destructive context compaction (vision spec
+//! §5.4): each entry carries a `compacted` flag rather than the message ever
+//! being deleted, so the outward, model-facing view can shrink while the
+//! stored history stays fully auditable.
+//! What: `Transcript` owns an ordered `Vec<TranscriptEntry>` (message +
+//! compacted flag); helpers append the seed messages, an assistant turn (text
+//! and/or tool calls), and a `tool` role result message. `assistant_text`
+//! concatenates the assistant text turns for the final `AgentOutput`.
+//! `maybe_compact` (#2070) applies [`super::compaction`]'s threshold policy;
+//! `to_messages` renders the model-facing view — contiguous compacted runs
+//! collapsed to one summary message, followed by a replayed copy of the last
+//! user message once any compaction has occurred (§5.4 items 2-3) — while
+//! `messages` always returns the complete, uncompacted raw history.
 //! Test: `agent_loop::tests` build transcripts indirectly through the loop;
-//! `transcript::tests` cover the helpers directly.
+//! `transcript::tests` cover the helpers and compaction directly.
 
 use crate::llm::{ChatMessage, ChatResponse, ToolCall};
+
+use super::compaction::{CompactionConfig, should_compact, summarize_span};
+
+/// One stored conversation turn plus its compaction state (#2070).
+///
+/// Why: Non-destructive compaction requires the original message to survive
+/// even after it stops being sent to the model verbatim; a bare flag next to
+/// the message (rather than removing it from the vector) is the simplest
+/// representation that satisfies both "shrink what the model sees" and
+/// "never lose the audit trail".
+/// What: `message` is the original, untouched `ChatMessage`; `compacted`
+/// starts `false` and is set `true` by `Transcript::maybe_compact` — never
+/// reset, since compaction is a one-way transform for a given entry.
+/// Test: `transcript::tests::maybe_compact_marks_middle_span_only`.
+#[derive(Debug, Clone)]
+struct TranscriptEntry {
+    message: ChatMessage,
+    compacted: bool,
+}
+
+impl TranscriptEntry {
+    fn fresh(message: ChatMessage) -> Self {
+        Self {
+            message,
+            compacted: false,
+        }
+    }
+}
 
 /// Running conversation history for one agent-loop run.
 ///
 /// Why: Centralises message accumulation so the loop body stays focused on
-/// control flow rather than `ChatMessage` plumbing.
-/// What: A thin wrapper over `Vec<ChatMessage>` with append helpers and an
-/// assistant-text accessor.
+/// control flow rather than `ChatMessage` plumbing, and (#2070) centralises
+/// the compaction state machine so the loop only has to call
+/// `maybe_compact` at its turn boundary.
+/// What: A thin wrapper over `Vec<TranscriptEntry>` with append helpers, a
+/// raw-history accessor, a compacted model-facing view, and an
+/// assistant-text accessor. `compaction_triggered` records whether ANY
+/// compaction has happened yet in this run — once `true`, `to_messages`
+/// starts appending the last-user-message replay (§5.4 item 3) on every
+/// subsequent call, re-anchoring the model on every following turn, not just
+/// the turn compaction fired on.
 /// Test: `transcript::tests::*`.
 #[derive(Debug, Default, Clone)]
 pub struct Transcript {
-    messages: Vec<ChatMessage>,
+    entries: Vec<TranscriptEntry>,
     assistant_texts: Vec<String>,
+    compaction_triggered: bool,
 }
 
 impl Transcript {
@@ -33,12 +77,19 @@ impl Transcript {
     ///
     /// Why: Every run starts from exactly these two turns; bundling the seed in
     /// a constructor prevents the loop from forgetting either.
-    /// What: Pushes a `system` message then a `user` message.
+    /// What: Pushes a `system` message then a `user` message, both starting
+    /// uncompacted. `maybe_compact` (#2070) never marks `system` or `user`
+    /// role entries — see its docs — so these two seed turns are preserved
+    /// forever regardless of how long the run continues.
     /// Test: `transcript::tests::seed_has_two_messages`.
     pub fn seed(system: &str, task: &str) -> Self {
         Self {
-            messages: vec![ChatMessage::system(system), ChatMessage::user(task)],
+            entries: vec![
+                TranscriptEntry::fresh(ChatMessage::system(system)),
+                TranscriptEntry::fresh(ChatMessage::user(task)),
+            ],
             assistant_texts: Vec::new(),
+            compaction_triggered: false,
         }
     }
 
@@ -62,13 +113,13 @@ impl Transcript {
         } else {
             Some(tool_calls.to_vec())
         };
-        self.messages.push(ChatMessage {
+        self.entries.push(TranscriptEntry::fresh(ChatMessage {
             role: "assistant".into(),
             content: text,
             tool_calls,
             tool_call_id: None,
             name: None,
-        });
+        }));
     }
 
     /// Append a `tool` role result message answering a specific tool call.
@@ -79,28 +130,122 @@ impl Transcript {
     /// name, and textual result.
     /// Test: `transcript::tests::push_tool_result_sets_call_id`.
     pub fn push_tool_result(&mut self, tool_call_id: &str, name: &str, content: &str) {
-        self.messages
-            .push(ChatMessage::tool_result(tool_call_id, name, content));
+        self.entries
+            .push(TranscriptEntry::fresh(ChatMessage::tool_result(
+                tool_call_id,
+                name,
+                content,
+            )));
     }
 
-    /// Borrow the full message history for sending to the model.
+    /// Return the complete, uncompacted raw message history.
     ///
-    /// Why: The loop builds each `ChatRequest` from the current history; it needs
-    /// read access without taking ownership.
-    /// What: Returns a slice over the accumulated messages.
-    /// Test: `transcript::tests::messages_reflects_appends`.
-    pub fn messages(&self) -> &[ChatMessage] {
-        &self.messages
+    /// Why: (#2070) Non-destructive compaction is only meaningful if the full
+    /// history stays retrievable for audit even after `to_messages` starts
+    /// collapsing older turns; this is that escape hatch.
+    /// What: Clones every entry's original `ChatMessage`, in order, regardless
+    /// of its `compacted` flag.
+    /// Test: `transcript::tests::messages_reflects_appends`,
+    /// `transcript::tests::compacted_entries_remain_in_raw_history`.
+    pub fn messages(&self) -> Vec<ChatMessage> {
+        self.entries.iter().map(|e| e.message.clone()).collect()
     }
 
-    /// Clone the message history into an owned `Vec` for a request.
+    /// Render the model-facing view: compacted spans collapsed to a summary,
+    /// plus a replayed last user message once compaction has occurred.
     ///
-    /// Why: `ChatRequest::messages` owns its `Vec`; the loop must hand it a copy
-    /// while keeping the transcript intact for the next iteration.
-    /// What: Clones the internal vector.
-    /// Test: Exercised indirectly via `agent_loop::tests`.
+    /// Why: This is what `ChatRequest.messages` actually sends — it must
+    /// shrink once compaction fires (the whole point of §5.4) while staying
+    /// a valid, coherently-ordered conversation.
+    /// What: Walks entries in order; a run of one-or-more contiguous
+    /// `compacted` entries is replaced by ONE synthetic `system`-role message
+    /// (`super::compaction::summarize_span`'s one-line text) in its place;
+    /// uncompacted entries pass through unchanged. After the walk, if
+    /// `compaction_triggered` is `true` (i.e. compaction has fired at least
+    /// once in this transcript's life), the LAST `user`-role entry's message
+    /// is cloned and appended again at the very end — §5.4 item 3's
+    /// "re-anchor the model" replay. A transcript with no `user` entry (never
+    /// happens via `seed`, but guarded rather than assumed) simply skips the
+    /// replay.
+    /// Test: `transcript::tests::to_messages_collapses_compacted_span`,
+    /// `transcript::tests::to_messages_replays_last_user_message_after_compaction`,
+    /// `transcript::tests::to_messages_is_passthrough_before_compaction`.
     pub fn to_messages(&self) -> Vec<ChatMessage> {
-        self.messages.clone()
+        let mut out = Vec::with_capacity(self.entries.len());
+        let mut compacted_span: Vec<ChatMessage> = Vec::new();
+
+        for entry in &self.entries {
+            if entry.compacted {
+                compacted_span.push(entry.message.clone());
+                continue;
+            }
+            flush_span(&mut out, &mut compacted_span);
+            out.push(entry.message.clone());
+        }
+        flush_span(&mut out, &mut compacted_span);
+
+        if self.compaction_triggered
+            && let Some(last_user) = self.entries.iter().rev().find(|e| e.message.role == "user")
+        {
+            out.push(last_user.message.clone());
+        }
+
+        out
+    }
+
+    /// Apply the compaction policy: mark eligible older entries `compacted`.
+    ///
+    /// Why: (#2070) This is the turn-boundary hook the agent loop calls —
+    /// gated by the caller on `HarnessMode::DailyDriver` (Parity must never
+    /// compact, per §5.9's D2 reconciliation) — so growth is bounded without
+    /// the loop body needing to know compaction's internals.
+    /// What: No-ops (returns `false`) unless the CURRENT model-facing view
+    /// (`to_messages()`, not the ever-growing raw history — raw size would
+    /// re-trigger every turn even after compaction shrank what's actually
+    /// sent) exceeds `cfg.token_threshold`. Otherwise, marks every entry
+    /// before the trailing `cfg.keep_last_messages` (the active work zone,
+    /// §5.4 item 4) as `compacted = true`, EXCEPT entries already compacted
+    /// (a one-way transform) and `system`/`user` role entries (§5.4 item 5:
+    /// "preserve... user requests forever"). Sets `compaction_triggered` and
+    /// returns `true` only if at least one entry was newly marked (an
+    /// already-fully-compacted or entirely-preserved prefix is a no-op, not a
+    /// spurious trigger).
+    /// Test: `transcript::tests::maybe_compact_marks_middle_span_only`,
+    /// `transcript::tests::maybe_compact_is_noop_below_threshold`,
+    /// `transcript::tests::maybe_compact_never_touches_system_or_user`.
+    pub fn maybe_compact(&mut self, cfg: &CompactionConfig) -> bool {
+        if !should_compact(&self.to_messages(), cfg) {
+            return false;
+        }
+
+        let keep_from = self.entries.len().saturating_sub(cfg.keep_last_messages);
+        let mut newly_compacted = false;
+
+        for entry in &mut self.entries[..keep_from] {
+            if entry.compacted {
+                continue;
+            }
+            if entry.message.role == "system" || entry.message.role == "user" {
+                continue;
+            }
+            entry.compacted = true;
+            newly_compacted = true;
+        }
+
+        if newly_compacted {
+            self.compaction_triggered = true;
+        }
+        newly_compacted
+    }
+
+    /// Number of entries currently marked `compacted`.
+    ///
+    /// Why: Test/observability accessor proving compaction happened without
+    /// exposing the private `TranscriptEntry` type.
+    /// What: Counts entries with `compacted == true`.
+    /// Test: `transcript::tests::maybe_compact_marks_middle_span_only`.
+    pub fn compacted_count(&self) -> usize {
+        self.entries.iter().filter(|e| e.compacted).count()
     }
 
     /// Join all recorded assistant text turns into the final answer string.
@@ -125,6 +270,22 @@ impl Transcript {
         let calls = resp.first_tool_calls().to_vec();
         self.push_assistant(text, &calls);
     }
+}
+
+/// Flush a pending compacted span into `out` as one summary message, if any.
+///
+/// Why: `to_messages` needs to collapse a contiguous run of compacted entries
+/// exactly once, whether the run ends because a non-compacted entry follows
+/// or because the entries list ended; sharing this helper avoids duplicating
+/// the "if non-empty, summarise and clear" logic at both call sites.
+/// What: If `span` is non-empty, pushes one `ChatMessage::system` carrying
+/// `summarize_span(span)`'s text, then clears `span`.
+fn flush_span(out: &mut Vec<ChatMessage>, span: &mut Vec<ChatMessage>) {
+    if span.is_empty() {
+        return;
+    }
+    out.push(ChatMessage::system(summarize_span(span)));
+    span.clear();
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -193,7 +354,8 @@ mod tests {
     fn push_tool_result_sets_call_id() {
         let mut t = Transcript::seed("s", "u");
         t.push_tool_result("call_1", "echo", "echoed");
-        let last = t.messages().last().expect("msg");
+        let messages = t.messages();
+        let last = messages.last().expect("msg");
         assert_eq!(last.role, "tool");
         assert_eq!(last.tool_call_id.as_deref(), Some("call_1"));
         assert_eq!(last.name.as_deref(), Some("echo"));
@@ -223,5 +385,181 @@ mod tests {
         t.push_assistant(Some("first".into()), &[]);
         t.push_assistant(Some("second".into()), &[]);
         assert_eq!(t.assistant_text(), "first\n\nsecond");
+    }
+
+    /// `to_messages` is a byte-identical passthrough before compaction fires.
+    ///
+    /// Why: Parity mode (and any DailyDriver run under the threshold) must
+    /// see exactly the raw history — no summary, no replay.
+    /// What: Build a small transcript, assert `to_messages() == messages()`.
+    /// Test: this test.
+    #[test]
+    fn to_messages_is_passthrough_before_compaction() {
+        let mut t = Transcript::seed("s", "u");
+        t.push_assistant(Some("hi".into()), &[]);
+        assert_eq!(t.to_messages(), t.messages());
+    }
+
+    /// `maybe_compact` is a no-op below the threshold.
+    ///
+    /// Why: Compaction must not fire on ordinary, short runs.
+    /// What: A tiny transcript against a generous threshold; assert no
+    /// change and a `false` return.
+    /// Test: this test.
+    #[test]
+    fn maybe_compact_is_noop_below_threshold() {
+        let mut t = Transcript::seed("s", "u");
+        t.push_assistant(Some("hi".into()), &[]);
+        let cfg = CompactionConfig {
+            token_threshold: 10_000,
+            keep_last_messages: 1,
+        };
+        assert!(!t.maybe_compact(&cfg));
+        assert_eq!(t.compacted_count(), 0);
+    }
+
+    /// `maybe_compact` marks only the middle span, never `system`/`user`.
+    ///
+    /// Why: §5.4 item 5 requires user requests (and the system preamble) to
+    /// be preserved forever; only assistant/tool turns outside the active
+    /// zone are compaction-eligible.
+    /// What: Build a transcript with several assistant/tool turns after a
+    /// long user task, set a low threshold and a small active zone, compact,
+    /// and assert the system/user entries stay uncompacted while middle
+    /// entries are marked.
+    /// Test: this test.
+    #[test]
+    fn maybe_compact_never_touches_system_or_user() {
+        let mut t = Transcript::seed("s", &"long task ".repeat(50));
+        for i in 0..10 {
+            t.push_assistant(Some(format!("assistant turn {i}")), &[]);
+            t.push_tool_result(&format!("c{i}"), "bash", "output");
+        }
+        let cfg = CompactionConfig {
+            token_threshold: 1,
+            keep_last_messages: 2,
+        };
+        assert!(t.maybe_compact(&cfg));
+        assert!(t.compacted_count() > 0);
+
+        let raw = t.messages();
+        assert_eq!(raw[0].role, "system");
+        assert_eq!(raw[1].role, "user");
+        // Non-destructive: every original entry is still present in the raw
+        // history even though some are now marked compacted internally.
+        assert_eq!(raw.len(), 2 + 20);
+    }
+
+    /// A compacted span collapses to exactly one summary message.
+    ///
+    /// Why: §5.4 item 2 — replace compacted content with a one-line summary,
+    /// not one summary per original message.
+    /// What: Force compaction, then assert `to_messages()` is shorter than
+    /// the raw history and contains a `[compacted ...]` marker.
+    /// Test: this test.
+    #[test]
+    fn to_messages_collapses_compacted_span() {
+        let mut t = Transcript::seed("s", "task");
+        for i in 0..10 {
+            t.push_assistant(Some(format!("turn {i}")), &[]);
+            t.push_tool_result(&format!("c{i}"), "bash", "output");
+        }
+        let cfg = CompactionConfig {
+            token_threshold: 1,
+            keep_last_messages: 2,
+        };
+        assert!(t.maybe_compact(&cfg));
+
+        let compacted_view = t.to_messages();
+        assert!(compacted_view.len() < t.messages().len());
+        let has_summary = compacted_view
+            .iter()
+            .any(|m| m.content.as_deref().unwrap_or("").contains("[compacted"));
+        assert!(
+            has_summary,
+            "expected a summary message in {compacted_view:?}"
+        );
+    }
+
+    /// After compaction fires, `to_messages` replays the last user message
+    /// at the tail.
+    ///
+    /// Why: §5.4 item 3 — re-anchor the model on the original task after
+    /// older turns are collapsed.
+    /// What: Force compaction, assert the LAST message in `to_messages()` is
+    /// a `user`-role message whose content matches the seeded task.
+    /// Test: this test.
+    #[test]
+    fn to_messages_replays_last_user_message_after_compaction() {
+        let mut t = Transcript::seed("s", "the original task");
+        for i in 0..10 {
+            t.push_assistant(Some(format!("turn {i}")), &[]);
+            t.push_tool_result(&format!("c{i}"), "bash", "output");
+        }
+        let cfg = CompactionConfig {
+            token_threshold: 1,
+            keep_last_messages: 2,
+        };
+        assert!(t.maybe_compact(&cfg));
+
+        let compacted_view = t.to_messages();
+        let last = compacted_view.last().expect("non-empty view");
+        assert_eq!(last.role, "user");
+        assert_eq!(last.content.as_deref(), Some("the original task"));
+    }
+
+    /// `maybe_compact` never panics on a minimal (seed-only) transcript, even
+    /// with a threshold/active-zone combination that would otherwise compact
+    /// everything.
+    ///
+    /// Why: The loop calls `maybe_compact` at every turn boundary, including
+    /// the very first one, when the transcript holds only the seeded
+    /// system+user pair; an off-by-one in the active-zone slice bound must
+    /// not panic on this smallest possible input.
+    /// What: Seed a transcript (2 entries), force a trigger with a
+    /// zero-threshold config and an active zone larger than the transcript,
+    /// call `maybe_compact`, and assert it returns `false` (nothing eligible
+    /// — both entries are `system`/`user`) with no panic.
+    /// Test: this test.
+    #[test]
+    fn maybe_compact_is_noop_on_seed_only_transcript() {
+        let mut t = Transcript::seed("s", "u");
+        let cfg = CompactionConfig {
+            token_threshold: 0,
+            keep_last_messages: 100,
+        };
+        assert!(!t.maybe_compact(&cfg));
+        assert_eq!(t.compacted_count(), 0);
+        assert_eq!(t.to_messages(), t.messages());
+    }
+
+    /// Compacted entries remain retrievable in the raw history (non-destructive).
+    ///
+    /// Why: §5.4's core promise is auditability — a compacted turn must
+    /// still be readable in full, not summarised-and-gone.
+    /// What: Force compaction, assert `messages()` still contains the
+    /// original, uncompacted text of a turn that was marked `compacted`.
+    /// Test: this test.
+    #[test]
+    fn compacted_entries_remain_in_raw_history() {
+        let mut t = Transcript::seed("s", "task");
+        t.push_assistant(Some("distinctive-early-turn-text".into()), &[]);
+        for i in 0..10 {
+            t.push_assistant(Some(format!("turn {i}")), &[]);
+            t.push_tool_result(&format!("c{i}"), "bash", "output");
+        }
+        let cfg = CompactionConfig {
+            token_threshold: 1,
+            keep_last_messages: 2,
+        };
+        assert!(t.maybe_compact(&cfg));
+        assert!(t.compacted_count() > 0);
+
+        let raw = t.messages();
+        assert!(
+            raw.iter()
+                .any(|m| m.content.as_deref() == Some("distinctive-early-turn-text")),
+            "compacted entry's original content must survive in the raw history"
+        );
     }
 }

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -317,6 +317,7 @@ impl InProcessAgentRunner {
             timeout_secs: self.config.timeout_secs,
             model,
             mode: self.mode,
+            compaction: crate::agent_loop::CompactionConfig::default(),
         };
 
         // Assemble the mode-branched system prompt (BASE + agent prompt +

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -7,7 +7,9 @@
 //! `SearchProvider`, `SearchResult`, `SkillResolver`, and `ToolResult` from
 //! `traits`; `ToolRegistry` from `registry`; `DelegateToAgentTool` from
 //! `delegate`; `FinishTaskTool` (#2072) from `finish_task`; and `UseSkillTool`
-//! (#2069's progressive-disclosure on-invoke loader) from `skill`.
+//! plus `USE_SKILL_TOOL_NAME` (#2069's progressive-disclosure on-invoke
+//! loader; the constant lets #2070's compaction pin skill outputs by tool
+//! name) from `skill`.
 //! Test: Unit tests live in each submodule; integration tests use
 //! `DelegateToAgentTool` with a `MockAgentRunner`.
 
@@ -29,7 +31,7 @@ pub use finish_task::{
 };
 pub use fs::{EditTool, ReadFileTool, WriteFileTool};
 pub use registry::ToolRegistry;
-pub use skill::UseSkillTool;
+pub use skill::{USE_SKILL_TOOL_NAME, UseSkillTool};
 pub use traits::{
     AgentOutput, AgentRunner, HistoryMessage, RunContext, SearchProvider, SearchResult,
     ServiceTier, SkillResolver, ToolExecutor, ToolResult,

--- a/crates/trusty-code/src/tools/skill.rs
+++ b/crates/trusty-code/src/tools/skill.rs
@@ -20,6 +20,18 @@ use serde_json::{Value, json};
 
 use crate::tools::traits::{SkillResolver, ToolExecutor, ToolResult};
 
+/// The stable tool name for `UseSkillTool` (matches `name()`/the schema's
+/// `function.name` verbatim).
+///
+/// Why: (#2070) The agent loop must identify a skill-body-load result by tool
+/// name to pin it against compaction (vision spec §5.4 item 5: "preserve
+/// skill outputs... forever"); a shared constant — mirroring
+/// `tools::finish_task::FINISH_TASK_TOOL_NAME`'s identical role for
+/// `finish_task` — means that identification can never drift from the tool's
+/// actual wire name.
+/// Test: `tools::skill::tests::name_matches_constant`.
+pub const USE_SKILL_TOOL_NAME: &str = "use_skill";
+
 /// `ToolExecutor` that lazily fetches a named skill's full Markdown body.
 ///
 /// Why: Keeps the LLM-facing surface (`name()`, `schema()`, `execute()`)
@@ -45,7 +57,7 @@ impl UseSkillTool {
 #[async_trait]
 impl ToolExecutor for UseSkillTool {
     fn name(&self) -> &str {
-        "use_skill"
+        USE_SKILL_TOOL_NAME
     }
 
     /// OpenAI function-call schema for `use_skill`.
@@ -57,7 +69,7 @@ impl ToolExecutor for UseSkillTool {
         json!({
             "type": "function",
             "function": {
-                "name": "use_skill",
+                "name": USE_SKILL_TOOL_NAME,
                 "description": "Load the full instructions for a skill listed in the 'Available skills' catalog. Only call this for a skill you actually intend to use — it returns the skill's complete body.",
                 "parameters": {
                     "type": "object",
@@ -169,6 +181,22 @@ mod tests {
         let result = tool.execute(json!({})).await;
         assert!(result.is_error());
         assert!(result.content().contains("missing required argument"));
+    }
+
+    /// `name()` and the schema's `function.name` both match
+    /// `USE_SKILL_TOOL_NAME` — no drift between the constant and the wire
+    /// name (#2070 depends on this identifying skill outputs for pinning).
+    ///
+    /// Test: this test.
+    #[test]
+    fn name_matches_constant() {
+        let tool = make_tool();
+        assert_eq!(tool.name(), USE_SKILL_TOOL_NAME);
+        assert_eq!(
+            tool.schema()["function"]["name"].as_str(),
+            Some(USE_SKILL_TOOL_NAME)
+        );
+        assert_eq!(USE_SKILL_TOOL_NAME, "use_skill");
     }
 
     /// The schema requires `name`.


### PR DESCRIPTION
M2 (Tool Calling) P1B-3 — non-destructive context compaction with last-message replay. At each turn boundary (DailyDriver mode only; Parity never compacts, stays byte-identical), when the outward token estimate crosses the threshold (default 6000), old non-active-zone messages are marked `compacted` (never deleted — `Transcript::messages()` returns full history for audit; `session.get_transcript` is a separate path so audit is unaffected), collapsed to a deterministic one-line summary (no LLM call), and the last user message is replayed to re-anchor the model. `system`/`user` roles and the last N turns are always preserved. Skill (`use_skill`) tool outputs are permanently pinned against compaction via a `TranscriptEntry.pinned` flag (satisfies the "preserve skill outputs forever" criterion).

QA: APPROVE (two independent passes — full mechanics at 746d8a04, skill-pinning delta at b101e694). Build 0 warnings, 598 lib + 16 e2e tests pass, clippy clean, fmt clean, line-cap 0 violations, trusty-agents unaffected. Non-destructive guarantee traced to a separate audit path (RecordingLlmClient); mode gating byte-identical in Parity; pinning narrowly scoped (verified non-skill tool results still compact); zero library unwrap().

Closes #2070