### PR TITLE
fix: correct trusty-search rss_mb to true physical footprint

### DIFF
--- a/crates/trusty-common/src/sys_metrics.rs
+++ b/crates/trusty-common/src/sys_metrics.rs
@@ -16,6 +16,59 @@
 
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
 
+/// True physical memory footprint of a process, in megabytes (macOS only).
+///
+/// Why (issue #2165): `sysinfo::Process::memory()` on macOS reads
+/// `PROC_PIDTASKINFO.pti_resident_size`, which is the same "resident set"
+/// figure `getrusage()`/`ru_maxrss` report. That figure does NOT count pages
+/// the macOS memory compressor has swept into compressed (still in-RAM, still
+/// counted against the process by the kernel's Jetsam/OOM logic) storage. On
+/// long-running daemons with large ONNX/HNSW arenas, the compressor can hold
+/// many GB that `pti_resident_size` simply omits — so a self-reported
+/// `rss_mb` can read as a few dozen MB while `vmmap`/`footprint`/Activity
+/// Monitor (and the kernel's own memory-pressure accounting) see many GB.
+/// A `TRUSTY_MEMORY_LIMIT_MB` guardrail keyed off the under-counted figure
+/// can never trip. The `phys_footprint` counter — surfaced by `libproc`'s
+/// `proc_pid_rusage(RUSAGE_INFO_V0)` as `ri_phys_footprint` — is exactly the
+/// figure `vmmap`/`footprint` report, so using it makes the guardrail
+/// meaningful again.
+/// What: calls `proc_pid_rusage(pid, RUSAGE_INFO_V0, ...)` (from `libc`,
+/// already a workspace dependency — no new crate needed) and reads
+/// `ri_phys_footprint`, converting bytes to whole megabytes. Returns `None`
+/// on any failure (invalid pid, cross-user permission denial) rather than
+/// panicking or returning a garbage value — callers fall back to the
+/// `sysinfo`-derived RSS in that case.
+/// Test: `tests::self_physical_footprint_is_plausible` (macOS-only) asserts
+/// this returns `Some` for the test process's own PID with a plausible
+/// value. Asserting it *exceeds* the getrusage-style RSS deterministically
+/// is not testable in CI — that gap only manifests under the memory
+/// compressor, which requires sustained real memory pressure to trigger and
+/// cannot be reliably induced in a unit test.
+#[cfg(target_os = "macos")]
+pub fn physical_footprint_mb(pid: u32) -> Option<u64> {
+    // SAFETY: `info` is a zero-initialised, `#[repr(C)]` struct matching the
+    // kernel ABI for `RUSAGE_INFO_V0`. The C API's `buffer` parameter is
+    // typed `rusage_info_t *` (`rusage_info_t` itself being `void *`), and
+    // the canonical call pattern — mirrored here — passes the struct's own
+    // address reinterpreted as that opaque pointer type, e.g. Apple's
+    // `libproc.h` usage `(rusage_info_t *)&rusage`: the kernel writes
+    // directly into `info`'s bytes, there is no extra pointer indirection.
+    // `proc_pid_rusage` returns a negative value on failure without writing
+    // to `info`, so `info` is only read once the call has reported success.
+    let mut info: libc::rusage_info_v0 = unsafe { std::mem::zeroed() };
+    let ret = unsafe {
+        libc::proc_pid_rusage(
+            pid as libc::c_int,
+            libc::RUSAGE_INFO_V0,
+            std::ptr::addr_of_mut!(info).cast(),
+        )
+    };
+    if ret != 0 {
+        return None;
+    }
+    Some(info.ri_phys_footprint / (1024 * 1024))
+}
+
 /// Per-process RSS + CPU sampler bound to the current process.
 ///
 /// Why: holding the `System` between calls is required for CPU measurement —
@@ -62,13 +115,22 @@ impl SysMetrics {
     /// Why: the `/health` handler calls this once per request. Polling more
     ///      often than ~once per 500 ms yields noisy CPU readings because the
     ///      delta window shrinks; `/health` is typically polled every 2 s so
-    ///      this is not a concern in practice.
+    ///      this is not a concern in practice. On macOS the reported RSS is
+    ///      the true physical footprint (issue #2165) — see
+    ///      [`physical_footprint_mb`] — rather than the getrusage-style
+    ///      resident size, which undercounts memory the compressor is
+    ///      currently holding for this process.
     /// What: refreshes this process's memory + CPU stats. Returns RSS in
-    ///      whole megabytes (`bytes / 1_048_576`) and CPU as a percentage
-    ///      where `100.0` means one fully-saturated core (sysinfo's
-    ///      convention — a process on 4 cores can exceed 100). If the process
-    ///      cannot be resolved (extremely rare; only in containers with
-    ///      `/proc` hidden), returns `(0, 0.0)`.
+    ///      whole megabytes and CPU as a percentage where `100.0` means one
+    ///      fully-saturated core (sysinfo's convention — a process on 4 cores
+    ///      can exceed 100). RSS: macOS uses [`physical_footprint_mb`],
+    ///      falling back to `sysinfo`'s `bytes / 1_048_576` reading if the
+    ///      `libproc` call fails; all other platforms use the `sysinfo`
+    ///      reading directly (Linux's `/proc/self/status` `VmRSS` — which
+    ///      `sysinfo::Process::memory()` already surfaces — has no analogous
+    ///      compressor-accounting gap). If the process cannot be resolved
+    ///      (extremely rare; only in containers with `/proc` hidden), returns
+    ///      `(0, 0.0)`.
     /// Test: `sample_does_not_panic`, `rss_is_plausible`.
     pub fn sample(&mut self) -> (u64, f32) {
         self.sys.refresh_processes_specifics(
@@ -76,10 +138,16 @@ impl SysMetrics {
             true,
             ProcessRefreshKind::nothing().with_memory().with_cpu(),
         );
-        match self.sys.process(self.pid) {
-            Some(proc) => (proc.memory() / (1024 * 1024), proc.cpu_usage()),
-            None => (0, 0.0),
-        }
+        let Some(proc) = self.sys.process(self.pid) else {
+            return (0, 0.0);
+        };
+        let sysinfo_rss_mb = proc.memory() / (1024 * 1024);
+        let cpu_pct = proc.cpu_usage();
+        #[cfg(target_os = "macos")]
+        let rss_mb = physical_footprint_mb(self.pid.as_u32()).unwrap_or(sysinfo_rss_mb);
+        #[cfg(not(target_os = "macos"))]
+        let rss_mb = sysinfo_rss_mb;
+        (rss_mb, cpu_pct)
     }
 }
 
@@ -171,5 +239,74 @@ mod tests {
     fn dir_size_missing_dir_is_zero() {
         let missing = std::path::Path::new("/nonexistent/trusty/path/xyz");
         assert_eq!(dir_size_bytes(missing), 0);
+    }
+
+    /// `physical_footprint_mb(self_pid)` must return a plausible non-zero
+    /// value for the test process on macOS.
+    ///
+    /// Why: regression coverage for issue #2165 — asserts the `libproc`
+    /// `RUSAGE_INFO_V0` path actually resolves rather than silently always
+    /// falling back to the sysinfo reading. Deterministically asserting it
+    /// *exceeds* the getrusage-style RSS is not testable here: that gap only
+    /// opens up under real memory-compressor pressure, which a unit test
+    /// cannot reliably induce.
+    /// What: calls with `std::process::id()`, asserts `Some` with a plausible
+    /// (non-zero, sub-terabyte) MB value.
+    /// Test: this test.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn self_physical_footprint_is_plausible() {
+        let pid = std::process::id();
+        let mb = physical_footprint_mb(pid).expect("proc_pid_rusage must resolve our own pid");
+        assert!(mb > 0, "physical footprint should be > 0 MB, got {mb}");
+        assert!(
+            mb < 1024 * 1024,
+            "physical footprint implausibly large ({mb} MB) — unit must be MB"
+        );
+    }
+
+    /// `physical_footprint_mb` must return `None` (not panic) for a bogus pid.
+    ///
+    /// Why: `proc_pid_rusage` fails for a nonexistent pid; the function must
+    /// map that failure to `None` rather than reading uninitialised memory.
+    /// What: pass `u32::MAX`, assert `None`.
+    /// Test: this test.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn physical_footprint_bogus_pid_returns_none() {
+        assert_eq!(physical_footprint_mb(u32::MAX), None);
+    }
+
+    /// `physical_footprint_mb` must track real memory growth.
+    ///
+    /// Why: the strongest test available without inducing actual memory-
+    /// compressor pressure (untestable deterministically in CI). Allocating
+    /// and touching 200 MB must move the reading up by a comparable amount —
+    /// this catches regressions like the double-pointer-indirection bug this
+    /// function shipped with initially (which always read back zeroed
+    /// kernel-untouched memory instead of `ri_phys_footprint`).
+    /// What: sample before, allocate + touch every page of a 200 MB `Vec`
+    /// (touching is required — an untouched allocation may not be backed by
+    /// real pages yet), sample after, assert the delta is positive and at
+    /// least 100 MB (leaves headroom for measurement noise well below the
+    /// full 200 MB).
+    /// Test: this test.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn physical_footprint_tracks_real_allocation_growth() {
+        let pid = std::process::id();
+        let before = physical_footprint_mb(pid).expect("must resolve our own pid");
+        let mut touched: Vec<u8> = vec![0u8; 200 * 1024 * 1024];
+        for byte in touched.iter_mut().step_by(4096) {
+            *byte = 1;
+        }
+        let after = physical_footprint_mb(pid).expect("must resolve our own pid");
+        assert!(
+            after >= before + 100,
+            "expected footprint to grow by >= 100 MB after touching a 200 MB \
+             allocation; before={before} after={after}"
+        );
+        // Keep `touched` alive through the measurement above.
+        drop(touched);
     }
 }

--- a/crates/trusty-search/src/core/memguard.rs
+++ b/crates/trusty-search/src/core/memguard.rs
@@ -265,40 +265,51 @@ pub fn over_index_memory_limit() -> bool {
 /// Current process Resident Set Size in megabytes. Returns `None` if sysinfo
 /// could not resolve the current process (extremely unlikely; only seen in
 /// containerised environments with /proc hidden).
+///
+/// Why (issue #2165): this backs [`over_memory_limit`] / [`over_index_memory_limit`],
+/// the guardrails that bail a reindex or warn an operator before the kernel
+/// OOM-kills the daemon. Delegates to [`current_rss_mb_for_pid`] with our own
+/// pid so both the self-sample and arbitrary-pid paths (used for the
+/// embedderd sidecar) share one true-physical-footprint implementation on
+/// macOS instead of two copies of the same sysinfo-only logic silently
+/// under-reporting compressed memory.
 pub fn current_rss_mb() -> Option<u64> {
-    let pid = Pid::from_u32(std::process::id());
-    let mut sys = System::new_with_specifics(
-        RefreshKind::nothing().with_processes(ProcessRefreshKind::everything()),
-    );
-    sys.refresh_processes_specifics(
-        sysinfo::ProcessesToUpdate::Some(&[pid]),
-        true,
-        ProcessRefreshKind::nothing().with_memory(),
-    );
-    // `Process::memory()` returns bytes on every supported platform as of
-    // sysinfo 0.30+. Convert to MB with a saturating divide.
-    sys.process(pid).map(|p| p.memory() / (1024 * 1024))
+    current_rss_mb_for_pid(std::process::id())
 }
 
-/// Resident Set Size in megabytes for an arbitrary child process (by OS PID).
+/// Resident Set Size in megabytes for an arbitrary process (by OS PID),
+/// including the current process itself.
 ///
 /// Why: the embedderd sidecar runs in a separate process. Its RSS is not
-/// captured by `current_rss_mb()` (which reads only the daemon's own RSS).
-/// This helper uses the same platform-agnostic `sysinfo` approach to sample
-/// any process by its OS PID — the same path used for the daemon-parent RSS
-/// but parameterised on an external PID.
+/// captured by a self-only sampler. This helper also backs
+/// [`current_rss_mb`] for the daemon's own pid so there is exactly one RSS
+/// implementation to keep correct.
 ///
-/// What: asks `sysinfo` to refresh exactly the named PID (minimal overhead).
-/// Returns `None` if the PID is 0 (sentinel for "no sidecar running"), if
-/// sysinfo cannot locate the process (exited between spawn and sample), or if
-/// the platform `procfs`/`task_info` call fails.
+/// Why the macOS-first path (issue #2165): `sysinfo::Process::memory()` on
+/// macOS reads `PROC_PIDTASKINFO.pti_resident_size`, a getrusage-style
+/// figure that excludes pages the memory compressor currently holds. A daemon
+/// with several GB compressed can read as tens of MB, so `TRUSTY_MEMORY_LIMIT_MB`
+/// never trips. On macOS this now tries
+/// [`trusty_common::sys_metrics::physical_footprint_mb`] (the `ri_phys_footprint`
+/// counter `vmmap`/`footprint`/Activity Monitor report) first, falling back to
+/// the `sysinfo` reading if the `libproc` call fails (e.g. cross-user
+/// permission denial sampling a foreign pid).
+///
+/// What: returns `None` if the PID is 0 (sentinel for "no sidecar running"),
+/// if neither sampling path can locate the process (exited between spawn and
+/// sample), or if the platform call fails.
 ///
 /// Test: `tests::test_rss_for_self_pid` calls this with `std::process::id()`
-/// and asserts the result matches `current_rss_mb()` within 10 MB. Negative
-/// cases (pid=0, bogus pid) assert `None`.
+/// and asserts the result matches `current_rss_mb()` within 10 MB (trivially
+/// true now that both delegate to this function). Negative cases (pid=0,
+/// bogus pid) assert `None`.
 pub fn current_rss_mb_for_pid(pid: u32) -> Option<u64> {
     if pid == 0 {
         return None;
+    }
+    #[cfg(target_os = "macos")]
+    if let Some(mb) = trusty_common::sys_metrics::physical_footprint_mb(pid) {
+        return Some(mb);
     }
     let sysinfo_pid = Pid::from_u32(pid);
     let mut sys = System::new_with_specifics(


### PR DESCRIPTION
## Summary
- On macOS, `sysinfo::Process::memory()` reads `PROC_PIDTASKINFO.pti_resident_size` — a getrusage-style RSS figure that does **not** count pages the memory compressor currently holds. A live daemon with ~12 GB compressed could self-report `rss_mb: 66` on `/health` while `vmmap`/`footprint` showed **13 GB** physical footprint, so the `rss_limit_mb: 32768` guardrail could never trip.
- Adds `trusty_common::sys_metrics::physical_footprint_mb(pid)`, which reads `libproc`'s `proc_pid_rusage(RUSAGE_INFO_V0).ri_phys_footprint` — the exact counter `vmmap`/`footprint`/Activity Monitor report — via `libc` (already a workspace dependency; no new crate added).
- Wires it into `SysMetrics::sample()` (feeds `/health`'s `rss_mb`) and `trusty-search`'s `memguard::current_rss_mb`/`current_rss_mb_for_pid` (feeds the reindex-pipeline `over_memory_limit`/`over_index_memory_limit` guardrails), falling back to the existing `sysinfo` reading on non-macOS platforms or whenever the `libproc` call fails.
- Consolidates `memguard::current_rss_mb()` to delegate to `current_rss_mb_for_pid()` instead of duplicating the same sysinfo-sampling logic.
- Preserves the `/health` JSON response shape — only the `rss_mb` value's accuracy changes.

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-search` — 251 lib tests pass (plus integration suites; ignored tests unaffected)
- [x] `cargo test -p trusty-common --features memory-core,embedder-test-support` — 440+ tests pass, including new `sys_metrics` coverage (a pre-existing gap means `-p trusty-common` alone fails to compile an unrelated integration test without these features — confirmed present on `origin/main` before this change too)
- [x] New test `sys_metrics::tests::physical_footprint_tracks_real_allocation_growth` allocates + touches 200 MB and asserts the footprint reading grows by >= 100 MB, catching a pointer-indirection bug caught during development
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations

Closes #2165

🤖 Generated with [Claude Code](https://claude.com/claude-code)