### PR TITLE
feat(trusty-search): re-view idle promoted HNSW stores back to mmap

### DIFF
--- a/crates/trusty-search/src/core/indexer/idle_evict.rs
+++ b/crates/trusty-search/src/core/indexer/idle_evict.rs
@@ -22,6 +22,12 @@
 //! Test: `bm25_entities_idle_eviction_drops_and_lazily_rehydrates` and
 //! `bm25_entities_idle_eviction_skips_indexers_without_corpus` in
 //! `indexer::tests`.
+//!
+//! Also home to [`CodeIndexer::demote_vector_store_if_idle`] (issue #2164),
+//! which rides the exact same idle sweep to re-view (mmap-demote) an idle,
+//! write-promoted HNSW vector store back to `Index::view` — see that
+//! method's doc comment and `UsearchStore::try_demote_to_view` for the full
+//! design.
 
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -153,6 +159,62 @@ impl CodeIndexer {
                 "index '{index_id}': BM25/entities rehydration task panicked ({e}); \
                  will retry on next access"
             ),
+        }
+    }
+
+    /// Demote this index's HNSW vector store back to mmap-view mode when it
+    /// has been idle longer than `idle_threshold` (issue #2164).
+    ///
+    /// Why: the #709 mmap-view optimization keeps a warm-booted HNSW index
+    /// pageable, but any write promotes it to a full heap copy
+    /// (`UsearchStore::ensure_mutable`) with no path back — so in practice
+    /// almost every index a daemon ever writes to stays heap-resident
+    /// forever, even long after it goes idle. This reclaims that heap the
+    /// same way `evict_chunks_if_idle` / `evict_bm25_entities_if_idle`
+    /// reclaim theirs, riding the same idle window and the same ticker tick
+    /// so there is exactly one idle sweep, not a competing second one.
+    /// What: a no-op when `idle_threshold` is zero, the
+    /// [`crate::core::store_config::hnsw_review_idle_enabled`] env gate is
+    /// off, no vector store is wired (BM25-only mode), or the index was
+    /// recently active. Otherwise delegates to
+    /// [`crate::core::store::VectorStore::demote_to_view`], which is the
+    /// authoritative gate on safety (only demotes a store that is currently
+    /// mutable AND has no unpersisted writes — see
+    /// `UsearchStore::try_demote_to_view`). Logs an `info` on an actual
+    /// demotion, a `warn` on failure (never fatal — demotion is an
+    /// optimization). Returns `true` when a demotion happened.
+    /// Test: `hnsw_idle_demotion_reviews_clean_promoted_store` and
+    /// `hnsw_idle_demotion_skips_when_disabled_via_env` in `indexer::tests`.
+    pub async fn demote_vector_store_if_idle(&self, idle_threshold: Duration) -> bool {
+        if idle_threshold.is_zero() {
+            return false;
+        }
+        if !crate::core::store_config::hnsw_review_idle_enabled() {
+            return false;
+        }
+        let Some(store) = &self.store else {
+            return false;
+        };
+        if self.idle_duration() < idle_threshold {
+            return false;
+        }
+        match store.demote_to_view().await {
+            Ok(true) => {
+                tracing::info!(
+                    "index '{}': demoted HNSW vector store to mmap-view after {}s idle",
+                    self.index_id,
+                    idle_threshold.as_secs(),
+                );
+                true
+            }
+            Ok(false) => false,
+            Err(e) => {
+                tracing::warn!(
+                    "index '{}': HNSW demote-to-view failed ({e}); leaving heap-resident",
+                    self.index_id
+                );
+                false
+            }
         }
     }
 }

--- a/crates/trusty-search/src/core/indexer/tests_idle_evict.rs
+++ b/crates/trusty-search/src/core/indexer/tests_idle_evict.rs
@@ -346,3 +346,150 @@ async fn rebuild_symbol_graph_rehydrates_entities_after_idle_eviction() {
          ensure_bm25_entities_loaded"
     );
 }
+
+/// HNSW idle re-view (issue #2164): a clean, promoted (write-touched)
+/// `UsearchStore` wired into a `CodeIndexer` gets demoted back to mmap-view
+/// mode by the same idle sweep that drives chunk/BM25/entity eviction, and
+/// search returns identical results before and after.
+#[tokio::test]
+async fn hnsw_idle_demotion_reviews_clean_promoted_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("hnsw.usearch");
+    let dim = 32;
+
+    let embedder: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(dim));
+    // Keep a concrete handle alongside the `dyn VectorStore` the indexer
+    // holds so the test can assert `in_view_mode()` directly, mirroring how
+    // production code's `store: Option<Arc<dyn VectorStore>>` and a
+    // `UsearchStore`-typed warm-boot handle are the same underlying object.
+    let usearch = Arc::new(UsearchStore::new(dim).expect("usearch new"));
+    let store: Arc<dyn VectorStore> = usearch.clone();
+    let idx = CodeIndexer::new("hnsw-demote-test", "/tmp/hnsw-demote-test")
+        .with_components(embedder, store);
+
+    idx.add_chunk(raw("a", "src/a.rs", "fn a() {}"))
+        .await
+        .expect("add chunk a");
+    idx.add_chunk(raw("b", "src/b.rs", "fn b() {}"))
+        .await
+        .expect("add chunk b");
+    assert!(
+        !usearch.in_view_mode(),
+        "a freshly built, never-loaded store starts mutable"
+    );
+
+    // Flush to disk — this is what `spawn_incremental_persist` /
+    // `force_incremental_persist` do in production, and (issue #2164) is
+    // also what makes a `new()`-built store demotion-eligible by recording
+    // `hnsw_path` and clearing `dirty`.
+    idx.save_vector_store(&path).await.expect("save hnsw");
+
+    let q = SearchQuery {
+        text: "fn a".to_string(),
+        top_k: 5,
+        expand_graph: false,
+        compact: false,
+        ..Default::default()
+    };
+    let results_before = idx.search(&q).await.expect("search before demotion");
+    assert!(!results_before.is_empty(), "expected at least one hit");
+
+    // `search()` touches activity — sleep past ms resolution (see the BM25
+    // idle tests above) so the near-zero threshold below observes genuine
+    // idleness rather than skipping as "just active".
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    // Zero threshold disables the sweep — no-op.
+    assert!(!idx.demote_vector_store_if_idle(Duration::ZERO).await);
+    assert!(!usearch.in_view_mode());
+
+    // A long threshold means "not idle yet" — no-op.
+    assert!(
+        !idx.demote_vector_store_if_idle(Duration::from_secs(3600))
+            .await
+    );
+    assert!(!usearch.in_view_mode());
+
+    // Near-zero idle window: demotion fires.
+    assert!(
+        idx.demote_vector_store_if_idle(Duration::from_nanos(1))
+            .await,
+        "expected the idle sweep to demote the clean, promoted store"
+    );
+    assert!(
+        usearch.in_view_mode(),
+        "store must be back in mmap-view mode after the idle sweep"
+    );
+
+    // Search after demotion returns identical results — no vectors lost.
+    let results_after = idx.search(&q).await.expect("search after demotion");
+    assert_eq!(
+        results_after.iter().map(|c| &c.id).collect::<Vec<_>>(),
+        results_before.iter().map(|c| &c.id).collect::<Vec<_>>(),
+        "search results must be identical before and after HNSW re-view"
+    );
+
+    // A write after demotion re-promotes (view -> mutable -> view -> mutable
+    // is sound); search still finds the new chunk.
+    idx.add_chunk(raw("c", "src/c.rs", "fn c() {}"))
+        .await
+        .expect("add chunk c after demotion");
+    assert!(
+        !usearch.in_view_mode(),
+        "write after demotion must re-promote to mutable"
+    );
+}
+
+/// The `TRUSTY_HNSW_REVIEW_IDLE=0` escape hatch disables demotion while
+/// leaving the store otherwise untouched (issue #2164).
+#[tokio::test]
+async fn hnsw_idle_demotion_skips_when_disabled_via_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("hnsw.usearch");
+    let dim = 32;
+
+    let embedder: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(dim));
+    let usearch = Arc::new(UsearchStore::new(dim).expect("usearch new"));
+    let store: Arc<dyn VectorStore> = usearch.clone();
+    let idx = CodeIndexer::new(
+        "hnsw-demote-disabled-test",
+        "/tmp/hnsw-demote-disabled-test",
+    )
+    .with_components(embedder, store);
+
+    idx.add_chunk(raw("a", "src/a.rs", "fn a() {}"))
+        .await
+        .expect("add chunk a");
+    idx.save_vector_store(&path).await.expect("save hnsw");
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let prior = std::env::var("TRUSTY_HNSW_REVIEW_IDLE").ok();
+    // SAFETY: this test is the only reader/writer of this env var while it runs.
+    unsafe { std::env::set_var("TRUSTY_HNSW_REVIEW_IDLE", "0") };
+
+    assert!(
+        !idx.demote_vector_store_if_idle(Duration::from_nanos(1))
+            .await,
+        "TRUSTY_HNSW_REVIEW_IDLE=0 must disable demotion"
+    );
+    assert!(
+        !usearch.in_view_mode(),
+        "store must remain mutable while the gate is disabled"
+    );
+
+    // SAFETY: see above.
+    unsafe {
+        match prior {
+            Some(v) => std::env::set_var("TRUSTY_HNSW_REVIEW_IDLE", v),
+            None => std::env::remove_var("TRUSTY_HNSW_REVIEW_IDLE"),
+        }
+    }
+
+    // Re-enabled (default): demotion now proceeds.
+    assert!(
+        idx.demote_vector_store_if_idle(Duration::from_nanos(1))
+            .await,
+        "demotion must proceed once the gate is re-enabled"
+    );
+    assert!(usearch.in_view_mode());
+}

--- a/crates/trusty-search/src/core/store/tests.rs
+++ b/crates/trusty-search/src/core/store/tests.rs
@@ -493,3 +493,137 @@ async fn test_save_populated_index_writes_correctly() {
         "top hit for vec-a direction must be vec-a"
     );
 }
+
+/// Full re-view lifecycle (issue #2164): view → write (promotes to heap) →
+/// save (clean again) → demote (back to view, heap reclaimed) → search
+/// (identical results) → write again (re-promotes) → search (still correct).
+///
+/// Why: this is the exact cycle the idle sweep drives in production —
+/// asserts no vectors are ever lost and `is_view`/`in_view_mode()` flips at
+/// every expected step.
+#[tokio::test]
+async fn test_demote_to_view_full_cycle() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("hnsw.usearch");
+
+    // Seed a snapshot with two vectors and load it back via `view`.
+    let seed = UsearchStore::new(4).unwrap();
+    seed.upsert("alpha", vec![1.0, 0.0, 0.0, 0.0])
+        .await
+        .unwrap();
+    seed.upsert("beta", vec![0.0, 1.0, 0.0, 0.0]).await.unwrap();
+    seed.save(&path).await.expect("seed save");
+    drop(seed);
+
+    let store = UsearchStore::load_from(&path)
+        .await
+        .expect("load ok")
+        .expect("load returned Some");
+    assert!(store.in_view_mode(), "load_from must land in view mode");
+
+    // Not eligible yet: still a view (nothing to demote from mutable).
+    assert!(
+        !store.try_demote_to_view().await.unwrap(),
+        "demoting an already-view store must be a no-op"
+    );
+
+    // Write promotes view -> mutable; the store is now dirty (unsaved).
+    store
+        .upsert("gamma", vec![0.0, 0.0, 1.0, 0.0])
+        .await
+        .expect("upsert promotes");
+    assert!(!store.in_view_mode(), "write must promote to mutable");
+    assert!(
+        !store.try_demote_to_view().await.unwrap(),
+        "demoting a dirty (unsaved) store must be refused — would lose 'gamma'"
+    );
+    assert!(!store.in_view_mode(), "refused demotion must not flip mode");
+
+    // Save flushes the new vector to disk and clears dirty.
+    store.save(&path).await.expect("save after write");
+
+    // Now clean + mutable: demotion must succeed.
+    assert!(
+        store.try_demote_to_view().await.expect("demote"),
+        "clean, mutable, path-backed store must demote"
+    );
+    assert!(store.in_view_mode(), "demote must flip back to view mode");
+
+    // Search after demotion must return identical results — no vectors lost.
+    let hits = store.search(&[1.0, 0.0, 0.0, 0.0], 3).await.unwrap();
+    let ids: std::collections::HashSet<&str> = hits.iter().map(|h| h.chunk_id.as_str()).collect();
+    assert_eq!(
+        ids,
+        ["alpha", "beta", "gamma"].into_iter().collect(),
+        "all 3 vectors must survive the demotion round-trip"
+    );
+    assert_eq!(store.len().await.unwrap(), 3);
+
+    // A demoted (view-mode) store is once again a no-op to demote.
+    assert!(!store.try_demote_to_view().await.unwrap());
+
+    // Re-promote on the next write (view -> mutable -> view -> mutable cycle
+    // must be sound).
+    store
+        .upsert("delta", vec![0.0, 0.0, 0.0, 1.0])
+        .await
+        .expect("upsert after demote must re-promote");
+    assert!(!store.in_view_mode(), "second write must re-promote");
+    let hits = store.search(&[0.0, 0.0, 0.0, 1.0], 1).await.unwrap();
+    assert_eq!(
+        hits[0].chunk_id, "delta",
+        "post-re-promote search must work"
+    );
+    assert_eq!(
+        store.len().await.unwrap(),
+        4,
+        "no vectors lost across the full cycle"
+    );
+}
+
+/// Demotion must refuse a dirty (unsaved) mutable store rather than risk
+/// losing unpersisted vectors (issue #2164 — "when in doubt, skip").
+#[tokio::test]
+async fn test_demote_to_view_skips_when_dirty() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("hnsw.usearch");
+
+    let store = UsearchStore::new(4).unwrap();
+    store.upsert("a", vec![1.0, 0.0, 0.0, 0.0]).await.unwrap();
+    store.save(&path).await.unwrap();
+    assert!(
+        !store.dirty.load(Ordering::Acquire),
+        "clean immediately after save"
+    );
+
+    // Mutate without saving — now dirty.
+    store.upsert("b", vec![0.0, 1.0, 0.0, 0.0]).await.unwrap();
+    assert!(store.dirty.load(Ordering::Acquire), "write must set dirty");
+
+    assert!(
+        !store.try_demote_to_view().await.unwrap(),
+        "a dirty store must never be demoted — would lose 'b' on next promote"
+    );
+    assert!(
+        !store.in_view_mode(),
+        "refused demotion must leave the store mutable"
+    );
+    assert_eq!(
+        store.len().await.unwrap(),
+        2,
+        "both vectors must still be present in the (mutable) index"
+    );
+}
+
+/// A store that was never associated with an on-disk path (e.g. a freshly
+/// constructed `UsearchStore::new()` that has never been saved) has nothing
+/// safe to re-view from and must never attempt it.
+#[tokio::test]
+async fn test_demote_to_view_skips_without_path() {
+    let store = UsearchStore::new(4).unwrap();
+    store.upsert("a", vec![1.0, 0.0, 0.0, 0.0]).await.unwrap();
+    assert!(
+        !store.try_demote_to_view().await.unwrap(),
+        "a store with no known hnsw_path must never demote"
+    );
+}

--- a/crates/trusty-search/src/core/store/types.rs
+++ b/crates/trusty-search/src/core/store/types.rs
@@ -105,4 +105,24 @@ pub trait VectorStore: Send + Sync {
     async fn rewrite_keys_to_relative(&self, _root_path: &Path) -> Result<usize> {
         Ok(0)
     }
+
+    /// Demote a promoted-but-idle store back to mmap-view mode, reclaiming
+    /// its heap-resident copy. Default = no-op (in-memory / mock backends
+    /// have no view-vs-mutable distinction to demote between).
+    ///
+    /// Why (issue #2164): `UsearchStore` promotes its HNSW index to a heap
+    /// copy on the first write (#709's `ensure_mutable`), and until this
+    /// method existed there was no path back — every index ever written even
+    /// once stayed heap-resident for the rest of the process lifetime. This
+    /// is the counterpart demotion path, called from the same idle sweep
+    /// that already evicts chunks/BM25/entities
+    /// (`server::tickers::spawn_idle_chunk_eviction_ticker`).
+    /// What: `UsearchStore` overrides to re-open its HNSW via `Index::view`
+    /// when idle and clean (no unpersisted writes); mock/BM25-only stores
+    /// keep this no-op. Returns `Ok(true)` when an actual demotion happened.
+    /// Test: `UsearchStore` tests — `test_demote_to_view_full_cycle` et al.
+    /// in `store::tests`.
+    async fn demote_to_view(&self) -> Result<bool> {
+        Ok(false)
+    }
 }

--- a/crates/trusty-search/src/core/store/usearch_impl.rs
+++ b/crates/trusty-search/src/core/store/usearch_impl.rs
@@ -58,6 +58,10 @@ impl VectorStore for UsearchStore {
         index
             .add(key, &embedding)
             .map_err(|e| anyhow!("usearch add failed: {e}"))?;
+        // The in-memory graph now differs from the on-disk snapshot (issue
+        // #2164) — the idle-demote sweep must skip this store until the next
+        // `save()` flushes it.
+        self.dirty.store(true, Ordering::Release);
         Ok(())
     }
 
@@ -115,6 +119,8 @@ impl VectorStore for UsearchStore {
             index
                 .remove(key)
                 .map_err(|e| anyhow!("usearch remove failed: {e}"))?;
+            // Graph changed — see the `dirty` note in `upsert` (issue #2164).
+            self.dirty.store(true, Ordering::Release);
         }
         Ok(())
     }
@@ -341,6 +347,12 @@ impl VectorStore for UsearchStore {
                 failed.push((id.clone(), e.to_string()));
             }
         }
+        // The graph was mutated above (removes and/or adds attempted) — mark
+        // dirty so the idle-demote sweep skips this store until the next
+        // `save()` flush (issue #2164). Set while still holding the write
+        // lock so a racing `try_demote_to_view` re-check under the same lock
+        // always observes it.
+        self.dirty.store(true, Ordering::Release);
         // Drop the HNSW write lock before touching the id maps so we don't
         // hold two write locks at once.
         drop(index);
@@ -401,5 +413,11 @@ impl VectorStore for UsearchStore {
             failed.len()
         );
         Ok(())
+    }
+
+    /// See [`VectorStore::demote_to_view`]; delegates to
+    /// [`UsearchStore::try_demote_to_view`] (issue #2164).
+    async fn demote_to_view(&self) -> Result<bool> {
+        self.try_demote_to_view().await
     }
 }

--- a/crates/trusty-search/src/core/store/usearch_store.rs
+++ b/crates/trusty-search/src/core/store/usearch_store.rs
@@ -131,10 +131,30 @@ pub struct UsearchStore {
     /// the index in mutable mode. Stored as `AtomicBool` so the read path needs no
     /// extra lock.
     pub(super) is_view: Arc<AtomicBool>,
-    /// Path the index was loaded from (only set on `load_from`). Required so a
-    /// later mutation can promote a view-mode index to mutable by re-reading the
-    /// same file via `Index::load`.
+    /// Path the index was loaded from (only set on `load_from`, and — as of
+    /// issue #2164 — also on the first successful [`Self::save`]). Required
+    /// so a later mutation can promote a view-mode index to mutable by
+    /// re-reading the same file via `Index::load`, and so an idle, clean
+    /// mutable index can be demoted back to a view via [`Self::try_demote_to_view`].
     pub(super) hnsw_path: Arc<RwLock<Option<PathBuf>>>,
+    /// `true` when the in-memory HNSW graph has additions/removals not yet
+    /// reflected in the on-disk snapshot at `hnsw_path`.
+    ///
+    /// Why (issue #2164): re-viewing (mmap-demoting) a mutable index is only
+    /// safe when the on-disk snapshot is byte-for-byte the current graph —
+    /// otherwise the demotion would silently roll back unsaved vectors the
+    /// next time the index is queried or promoted again. This flag is the
+    /// single source of truth for that guarantee: every graph-mutating path
+    /// (`upsert`, `remove`, `upsert_batch`) sets it `true` before releasing
+    /// the HNSW write lock; [`Self::save`] clears it back to `false` once the
+    /// snapshot is actually flushed; [`Self::promote_view_to_mutable`] clears
+    /// it because a fresh `Index::load` is by definition in sync with disk.
+    /// What: read by [`Self::try_demote_to_view`] (outside the lock as a fast
+    /// pre-check, then again under the write lock as the authoritative
+    /// check) to refuse demotion whenever there is unpersisted state.
+    /// Test: `tests::test_demote_to_view_full_cycle`,
+    /// `tests::test_demote_to_view_skips_when_dirty`.
+    pub(super) dirty: Arc<AtomicBool>,
 }
 
 impl UsearchStore {
@@ -189,6 +209,7 @@ impl UsearchStore {
             // `load_from` flips this to `true`.
             is_view: Arc::new(AtomicBool::new(false)),
             hnsw_path: Arc::new(RwLock::new(None)),
+            dirty: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -319,6 +340,19 @@ impl UsearchStore {
             .map_err(|e| anyhow!("write hnsw key sidecar tmp: {e}"))?;
         std::fs::rename(&sidecar_tmp, &sidecar)
             .map_err(|e| anyhow!("rename hnsw key sidecar: {e}"))?;
+
+        // The on-disk snapshot now matches the in-memory graph exactly: clear
+        // the dirty flag (issue #2164) so the idle sweep can demote this
+        // store back to a view once it goes idle, and remember the path so a
+        // store that was never `load_from`-ed (e.g. a brand-new index built
+        // via `new()`) becomes demotion-eligible after its first save.
+        self.dirty.store(false, Ordering::Release);
+        {
+            let mut path_guard = self.hnsw_path.write().await;
+            if path_guard.as_deref() != Some(hnsw_path) {
+                *path_guard = Some(hnsw_path.to_path_buf());
+            }
+        }
         Ok(())
     }
 
@@ -479,12 +513,106 @@ impl UsearchStore {
                 .map_err(|e| anyhow!("usearch reserve after promote failed: {e}"))?;
         }
         self.is_view.store(false, Ordering::Release);
+        // A fresh `Index::load` is byte-for-byte the on-disk snapshot, so
+        // there is nothing unpersisted yet (issue #2164 dirty tracking).
+        self.dirty.store(false, Ordering::Release);
         tracing::info!(
             "usearch: promoted view → mutable for {} ({} vectors)",
             path.display(),
             size
         );
         Ok(())
+    }
+
+    /// Demote a promoted, currently-idle store back to mmap-view mode,
+    /// releasing the heap-resident HNSW copy (issue #2164).
+    ///
+    /// Why: the #709 mmap-view optimization keeps a freshly warm-booted HNSW
+    /// index pageable (`load_from` calls `Index::view`), but ANY write —
+    /// `index_file`/`reindex`/file-watcher commit — promotes it to a full
+    /// heap copy via [`Self::promote_view_to_mutable`], and until this method
+    /// there was no path back. Live measurement on a 77-index production
+    /// daemon found mmap-resident was only ~80 KB total — i.e. nearly every
+    /// index had been promoted at least once and stayed heap-resident
+    /// forever afterward, even long after going idle. Re-viewing an idle,
+    /// disk-clean index lets it behave like a never-written warm-boot again.
+    /// What: a no-op (`Ok(false)`) unless the store is currently mutable
+    /// (`is_view == false`), has no unpersisted writes (`dirty == false`),
+    /// and has a known source path to re-open (`hnsw_path.is_some()`). Under
+    /// those conditions, takes the HNSW write lock — excluding concurrent
+    /// searches (which take a read lock) and concurrent writers/promoters
+    /// (which take the same write lock) — re-checks the same three
+    /// conditions (a racing writer may have promoted/mutated/demoted between
+    /// the fast pre-check and the lock acquisition), then calls `Index::view`
+    /// on the *same* `Index` handle, mirroring how
+    /// [`Self::promote_view_to_mutable`] calls `Index::load` in place on the
+    /// same handle for the reverse transition. `id_to_key` / `key_to_id` are
+    /// never touched — only the vector graph returns to mmap. Returns
+    /// `Ok(true)` when a demotion actually happened.
+    ///
+    /// CRITICAL correctness (never lose vectors): this only re-views from a
+    /// snapshot that is byte-for-byte the current in-memory graph — the
+    /// `dirty` gate refuses to demote whenever there is a mutation not yet
+    /// flushed by [`Self::save`]. Demotion is an optimization, not a
+    /// correctness requirement, so any doubt (unreadable path, non-UTF8
+    /// path, a racing writer, a `view()` failure) means "skip this cycle",
+    /// never "demote anyway".
+    /// Test: `tests::test_demote_to_view_full_cycle` exercises
+    /// view → promote (write) → demote → search → write (re-promote) →
+    /// search, asserting identical results and `in_view_mode()` at each step.
+    /// `tests::test_demote_to_view_skips_when_dirty` and
+    /// `tests::test_demote_to_view_skips_without_path` cover the guard.
+    pub(super) async fn try_demote_to_view(&self) -> Result<bool> {
+        // Fast pre-check without the write lock: skip the common case
+        // (already a view, dirty, or never associated with a source path)
+        // without contending for the lock that concurrent searches and
+        // writers also need.
+        if self.is_view.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+        if self.dirty.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+        let path = {
+            let guard = self.hnsw_path.read().await;
+            guard.clone()
+        };
+        let Some(path) = path else {
+            return Ok(false);
+        };
+        let Some(path_str) = path.to_str() else {
+            tracing::warn!(
+                "usearch: cannot demote {} to view — non-utf8 path",
+                path.display()
+            );
+            return Ok(false);
+        };
+        let path_str = path_str.to_string();
+
+        let index = self.index.write().await;
+        // Re-check under the write lock: `is_view` and `dirty` are only ever
+        // flipped by a caller holding this same write lock, so the values
+        // observed here are authoritative — a racing promote/mutate/demote
+        // between the fast pre-check and this point is caught here.
+        if self.is_view.load(Ordering::Acquire) || self.dirty.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+
+        if let Err(e) = index.view(&path_str) {
+            tracing::warn!(
+                "usearch: failed to demote {} to view ({e}) — leaving index heap-resident",
+                path.display()
+            );
+            return Ok(false);
+        }
+        let size = index.size();
+        self.is_view.store(true, Ordering::Release);
+        tracing::info!(
+            "usearch: demoted mutable → view for {} ({} vectors, heap reclaimed)",
+            path.display(),
+            size
+        );
+        Ok(true)
     }
 
     /// Ensure the underlying HNSW has room for at least one more vector.

--- a/crates/trusty-search/src/core/store_config.rs
+++ b/crates/trusty-search/src/core/store_config.rs
@@ -26,6 +26,16 @@ pub const HNSW_MMAP_SERVE_ENV: &str = "TRUSTY_HNSW_MMAP_SERVE";
 /// forced reindex (existing snapshots keep the precision they were built with).
 pub const VECTOR_QUANT_ENV: &str = "TRUSTY_VECTOR_QUANT";
 
+/// Environment variable gating the idle-sweep HNSW re-view (demotion) added
+/// by issue #2164. `true` (the default) lets the shared idle sweep
+/// (`server::tickers::spawn_idle_chunk_eviction_ticker`, same window as
+/// `TRUSTY_CHUNKS_IDLE_EVICT_SECS`) demote a promoted-but-clean, idle HNSW
+/// store back to `Index::view` (mmap), reclaiming its heap-resident copy.
+/// `false` disables demotion while leaving chunk/BM25/entity eviction
+/// untouched — an escape hatch in case the view↔load↔view cycle proves
+/// riskier than the memory it reclaims on some deployment.
+pub const HNSW_REVIEW_IDLE_ENV: &str = "TRUSTY_HNSW_REVIEW_IDLE";
+
 /// How a warm-booted (on-disk) HNSW snapshot is served on the read/search path.
 ///
 /// Why (issue #709, quick win #1): the warm-boot memory fix opens snapshots via
@@ -173,6 +183,36 @@ impl VectorQuant {
     }
 }
 
+/// `true` (default) when the idle sweep should demote idle, clean, promoted
+/// HNSW stores back to mmap-view mode; resolved from [`HNSW_REVIEW_IDLE_ENV`]
+/// (issue #2164).
+///
+/// Why: operators who want the memory reclamation but are wary of a new
+/// code path touching a hot HNSW index can turn just this piece off without
+/// losing chunk/BM25/entity idle eviction (issue #2162), which stays on its
+/// own always-on path.
+/// What: unset / `1` / `true` / `yes` / `on` (any case, trimmed) → enabled
+/// (the default); `0` / `false` / `no` / `off` → disabled. Any other value is
+/// treated as enabled with a `tracing::warn!` so a typo never silently
+/// disables the reclamation.
+/// Test: `tests::hnsw_review_idle_enabled_*`.
+pub fn hnsw_review_idle_enabled() -> bool {
+    match std::env::var(HNSW_REVIEW_IDLE_ENV) {
+        Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+            "" | "1" | "true" | "yes" | "on" | "enabled" => true,
+            "0" | "false" | "no" | "off" | "disabled" => false,
+            other => {
+                tracing::warn!(
+                    "{HNSW_REVIEW_IDLE_ENV}={other:?} is not a recognised boolean; \
+                     defaulting to enabled"
+                );
+                true
+            }
+        },
+        Err(_) => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,5 +288,38 @@ mod tests {
         assert_eq!(VectorQuant::None.label(), "f32 (none)");
         assert_eq!(VectorQuant::F16.label(), "f16");
         assert_eq!(VectorQuant::I8.label(), "i8");
+    }
+
+    /// `hnsw_review_idle_enabled` honours unset (default on), explicit
+    /// on/off spellings, and falls back to enabled on garbage (issue #2164).
+    #[test]
+    fn hnsw_review_idle_enabled_default_and_env_override() {
+        let prior = std::env::var(HNSW_REVIEW_IDLE_ENV).ok();
+
+        // SAFETY: this test is the only reader/writer of this env var in the
+        // process while it runs; `cargo test` for this crate runs each test
+        // binary's tests on one thread group but env vars are process-global,
+        // matching the pattern used by the sibling `mmap_serve_mode_*` tests.
+        unsafe { std::env::remove_var(HNSW_REVIEW_IDLE_ENV) };
+        assert!(hnsw_review_idle_enabled());
+
+        unsafe { std::env::set_var(HNSW_REVIEW_IDLE_ENV, "0") };
+        assert!(!hnsw_review_idle_enabled());
+
+        unsafe { std::env::set_var(HNSW_REVIEW_IDLE_ENV, "false") };
+        assert!(!hnsw_review_idle_enabled());
+
+        unsafe { std::env::set_var(HNSW_REVIEW_IDLE_ENV, "1") };
+        assert!(hnsw_review_idle_enabled());
+
+        unsafe { std::env::set_var(HNSW_REVIEW_IDLE_ENV, "banana") };
+        assert!(hnsw_review_idle_enabled());
+
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var(HNSW_REVIEW_IDLE_ENV, v),
+                None => std::env::remove_var(HNSW_REVIEW_IDLE_ENV),
+            }
+        }
     }
 }

--- a/crates/trusty-search/src/service/server/tickers.rs
+++ b/crates/trusty-search/src/service/server/tickers.rs
@@ -90,9 +90,10 @@ pub(super) fn spawn_disk_size_ticker(state: Arc<SearchAppState>) {
 }
 
 /// Spawn a background ticker that evicts each index's in-memory `chunks` map,
-/// BM25 corpus, and per-file entity map after the index has been idle past
-/// the configured window (issue #83 follow-up; BM25/entities added by issue
-/// #2162).
+/// BM25 corpus, and per-file entity map, and demotes its HNSW vector store
+/// back to mmap-view mode, after the index has been idle past the configured
+/// window (issue #83 follow-up; BM25/entities added by issue #2162; HNSW
+/// re-view added by issue #2164).
 ///
 /// Why (idle-memory audit): the durable redb corpus already serves the query
 /// hot path, so an index that hasn't been queried or ingested for a while is
@@ -113,9 +114,10 @@ pub(super) fn spawn_disk_size_ticker(state: Arc<SearchAppState>) {
 /// walk is cheap. Each eviction acquires the relevant read lock only to check
 /// `corpus`/idle state and a brief write lock only when it actually clears
 /// its structure.
-/// Test: `idle_eviction_drops_and_lazily_rehydrates_chunks` and
-/// `bm25_entities_idle_eviction_drops_and_lazily_rehydrates` cover the
-/// per-indexer logic directly; the ticker is a thin scheduling wrapper.
+/// Test: `idle_eviction_drops_and_lazily_rehydrates_chunks`,
+/// `bm25_entities_idle_eviction_drops_and_lazily_rehydrates`, and
+/// `hnsw_idle_demotion_reviews_clean_promoted_store` cover the per-indexer
+/// logic directly; the ticker is a thin scheduling wrapper.
 pub(super) fn spawn_idle_chunk_eviction_ticker(state: Arc<SearchAppState>) {
     let weak = Arc::downgrade(&state);
     tokio::spawn(async move {
@@ -143,6 +145,7 @@ pub(super) fn spawn_idle_chunk_eviction_ticker(state: Arc<SearchAppState>) {
                 let indexer = handle.indexer.read().await;
                 indexer.evict_chunks_if_idle(threshold).await;
                 indexer.evict_bm25_entities_if_idle(threshold).await;
+                indexer.demote_vector_store_if_idle(threshold).await;
             }
         }
     });


### PR DESCRIPTION
## Summary
- Adds `UsearchStore::try_demote_to_view()` — the counterpart to `promote_view_to_mutable()` (#709) — which re-opens a currently-mutable, idle, disk-clean HNSW `Index` via `Index::view` (mmap), releasing its heap-resident copy. `id_to_key`/`key_to_id` stay resident; only the vector graph goes back to mmap.
- Adds a `dirty` flag as the correctness gate: set by every graph-mutating path (`upsert`/`remove`/`upsert_batch`) while still holding the HNSW write lock, cleared by `save()` once the on-disk snapshot is flushed. Demotion refuses whenever `dirty` is true, the store has no known source path, or a concurrent writer raced ahead — "when in doubt, skip" (never lose a vector).
- Wires the demotion into the **existing** idle sweep from #2162 (`spawn_idle_chunk_eviction_ticker` → `CodeIndexer::demote_vector_store_if_idle`) rather than adding a second competing ticker.
- Adds `TRUSTY_HNSW_REVIEW_IDLE` (default **on**) as an independent escape hatch, so operators can disable just the HNSW re-view while keeping chunk/BM25/entity idle eviction on.

Live measurement on a 77-index production daemon found mmap-resident was only ~80 KB total — i.e. essentially every index had been promoted to heap at least once (any write does it) and had no way back. This is the single largest reclaimable chunk of the daemon's ~13 GB footprint.

## Design notes

**Concurrency**: demotion acquires the same `Arc<RwLock<Index>>` write lock used by `search` (read), `ensure_mutable`/`promote_view_to_mutable`, `upsert`, `remove`, and `upsert_batch` (write), so it can never race a concurrent search or promotion. It re-checks `is_view`/`dirty` under the lock (not just in the fast pre-check) so a racing writer that promoted/mutated/demoted between the pre-check and the lock acquisition is always caught.

**No vector loss**: `try_demote_to_view` only proceeds when `dirty == false`, meaning the on-disk snapshot at `hnsw_path` is byte-for-byte the current in-memory graph. `save()` now also records `hnsw_path` on every successful write (previously only `load_from` did), so a freshly-created (`UsearchStore::new()`) index becomes demotion-eligible after its first save, not just warm-booted ones.

**Reactivation**: the next write to a demoted index hits `ensure_mutable()`/`promote_view_to_mutable()` again — the view → mutable → view → mutable cycle is covered end-to-end by `test_demote_to_view_full_cycle`.

## Test plan
- [x] `test_demote_to_view_full_cycle` — view → write (promote) → save (clean) → demote (view) → search (identical results) → write (re-promote) → search (still correct); asserts vector count is stable at every step.
- [x] `test_demote_to_view_skips_when_dirty` — an unsaved write must never be demoted.
- [x] `test_demote_to_view_skips_without_path` — a store never associated with an on-disk snapshot must never demote.
- [x] `hnsw_idle_demotion_reviews_clean_promoted_store` / `hnsw_idle_demotion_skips_when_disabled_via_env` — indexer-level wiring through `CodeIndexer::demote_vector_store_if_idle` and the `TRUSTY_HNSW_REVIEW_IDLE` gate.
- [x] `hnsw_review_idle_enabled_default_and_env_override` — env parsing.
- [x] `cargo build --workspace` — clean.
- [x] `cargo test -p trusty-search` — 993 passed, 0 failed (1 pre-existing test-isolation flake in `patch_persists_to_toml`, unrelated to this change — confirmed to pass in isolation and on a clean rerun).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `bash scripts/check_line_cap.sh` — clean (0 violations).

Closes #2164