### PR TITLE
fix(trusty-mpm): validate deployment against the per-project filtered plan/manifest

### DIFF
--- a/crates/trusty-mpm/src/core/deploy_validate/expected_set.rs
+++ b/crates/trusty-mpm/src/core/deploy_validate/expected_set.rs
@@ -1,0 +1,325 @@
+//! Resolve the expected agent/skill roster for a workspace validation pass.
+//!
+//! Why (issue #2171): pre-#2171, [`super::validate_workspace`] diffed the
+//! deployed payload against the UNCONDITIONAL full bundled roster returned by
+//! [`FrameworkPaths::agent_source_dir`]/[`FrameworkPaths::skill_source_dir`] —
+//! the same source `deploy_agents`/`deploy_skills` read from when called
+//! unfiltered. A workspace legitimately provisioned from a FILTERED roster
+//! (e.g. a Rust-only project whose #1941 language-scoped manifest excludes
+//! every foreign-language `*-engineer` and the generic `engineer` catch-all)
+//! was then falsely reported incomplete for every deliberately-excluded
+//! entry. This module resolves the roster a workspace SHOULD carry, preferring
+//! — in order — (a) the per-project [`HarnessPlan`] the SAME
+//! `prepare_session_inner` pipeline would compute for this workspace, (b) the
+//! workspace's own deployed ownership manifest (an internal-consistency
+//! check: every entry the manifest claims to manage must exist on disk), and
+//! only when both resolve to nothing (c) the full canonical bundled roster —
+//! the pre-#2171 behaviour, preserved as the last-resort floor so a totally
+//! unprovisioned workspace still reports every bundled entry as missing.
+//! What: [`expected_agent_stems`] and [`expected_skill_stems`] each
+//! reconstruct the manifest-resolved [`HarnessPlan`] via
+//! [`crate::core::manifest::resolve_manifest`] /
+//! [`crate::core::manifest::HarnessPlan::from_manifest`] rooted at
+//! `fw.claude_home_dir()` — verified (see `paths.rs`'s
+//! `for_managed_workspace`/`for_managed_project` tests) to equal the
+//! workspace/project directory at every `validate_workspace` call site, so no
+//! new parameter is needed on the public API. When the plan's source
+//! directory yields no `.md` stems (missing/unreadable/genuinely empty), the
+//! caller-supplied deployed manifest's managed keys are used instead; when
+//! that is also empty (or absent), [`canonical_stems`] falls back to the
+//! full bundled source directory.
+//! Test: `plan_filters_expected_agents`, `plan_selection_excludes_generic_engineer`,
+//! `empty_plan_source_falls_back_to_manifest`,
+//! `manifest_and_plan_both_empty_falls_back_to_canonical_roster`,
+//! `expected_skill_stems_mirrors_agent_fallback_order`.
+
+use std::path::Path;
+
+use crate::core::agent_manifest::AgentManifest;
+use crate::core::manifest::{HarnessPlan, ManifestSources, resolve_manifest};
+use crate::core::paths::FrameworkPaths;
+use crate::core::skill_manifest::SkillManifest;
+
+/// Build the [`HarnessPlan`] `prepare_session_inner` would compute for `fw`'s
+/// workspace.
+///
+/// Why: shared by [`expected_agent_stems`] and [`expected_skill_stems`] so the
+/// two never reconstruct diverging plans.
+/// What: resolves the manifest layers rooted at `fw.claude_home_dir()` and the
+/// framework/catalog roots, then materializes the plan. Infallible: every
+/// step tolerates a missing/malformed layer (`resolve_manifest`'s own
+/// contract), so this always returns SOME plan — even one pointing at an
+/// empty or nonexistent source directory.
+/// Test: `plan_filters_expected_agents`.
+fn reconstruct_plan(fw: &FrameworkPaths) -> HarnessPlan {
+    let project_dir = fw.claude_home_dir();
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    let sources = ManifestSources::resolve(&project_dir, &fw.root, &catalog_root);
+    let manifest = resolve_manifest(&sources);
+    HarnessPlan::from_manifest(&manifest, fw, &catalog_root)
+}
+
+/// Canonical `.md` stems (filename without extension) directly under `dir`.
+///
+/// Why: shared by every tier of the (a)/(b)/(c) fallback below — the plan
+/// tier reads the plan's resolved source dir, the last-resort tier reads the
+/// unconditional bundled source dir.
+/// What: returns the sorted, deterministic list of `.md` stems; an
+/// unreadable/missing `dir` yields an empty list (no roster to check
+/// against — matches `deploy_agents`/`deploy_skills`'s own "missing source is
+/// an empty no-op" convention).
+/// Test: covered indirectly by every test in this module.
+fn canonical_stems(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            let is_md = path
+                .extension()
+                .and_then(|x| x.to_str())
+                .map(|x| x.eq_ignore_ascii_case("md"))
+                .unwrap_or(false);
+            if !is_md {
+                return None;
+            }
+            path.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
+        })
+        .collect();
+    names.sort_unstable();
+    names
+}
+
+/// Resolve the expected AGENT stems for `fw`'s workspace (issue #2171).
+///
+/// Why/What: see the module doc — tier (a) the reconstructed plan, tier (b)
+/// `manifest`'s managed keys (the caller already loaded it while checking
+/// [`super::DeploymentGap::AgentManifestMissing`]/`AgentManifestCorrupt`, so
+/// it is passed in rather than re-read), tier (c) the unconditional bundled
+/// source directory.
+/// Test: `plan_filters_expected_agents`, `plan_selection_excludes_generic_engineer`,
+/// `empty_plan_source_falls_back_to_manifest`,
+/// `manifest_and_plan_both_empty_falls_back_to_canonical_roster`.
+pub(super) fn expected_agent_stems(
+    fw: &FrameworkPaths,
+    manifest: Option<&AgentManifest>,
+) -> Vec<String> {
+    let plan = reconstruct_plan(fw);
+    let plan_stems: Vec<String> = canonical_stems(&plan.agent_source)
+        .into_iter()
+        .filter(|name| plan.agent_selected(name))
+        .collect();
+    if !plan_stems.is_empty() {
+        return plan_stems;
+    }
+
+    if let Some(m) = manifest {
+        let manifest_stems: Vec<String> = m
+            .managed
+            .keys()
+            .filter_map(|f| f.strip_suffix(".md").map(str::to_owned))
+            .collect();
+        if !manifest_stems.is_empty() {
+            return manifest_stems;
+        }
+    }
+
+    canonical_stems(&fw.agent_source_dir())
+}
+
+/// Resolve the expected SKILL stems for `fw`'s workspace (issue #2171).
+///
+/// Why/What: mirrors [`expected_agent_stems`] exactly, for the skill roster —
+/// tier (a) the reconstructed plan's skill source, tier (b) the deployed
+/// [`SkillManifest`]'s managed keys, tier (c) the unconditional bundled skill
+/// source directory.
+/// Test: `expected_skill_stems_mirrors_agent_fallback_order`.
+pub(super) fn expected_skill_stems(
+    fw: &FrameworkPaths,
+    manifest: Option<&SkillManifest>,
+) -> Vec<String> {
+    let plan = reconstruct_plan(fw);
+    let plan_stems: Vec<String> = canonical_stems(&plan.skill_source)
+        .into_iter()
+        .filter(|name| plan.skill_selected(name))
+        .collect();
+    if !plan_stems.is_empty() {
+        return plan_stems;
+    }
+
+    if let Some(m) = manifest {
+        let manifest_stems: Vec<String> = m.managed.keys().cloned().collect();
+        if !manifest_stems.is_empty() {
+            return manifest_stems;
+        }
+    }
+
+    canonical_stems(&fw.skill_source_dir())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn seed_agent_source(fw: &FrameworkPaths, names: &[&str]) {
+        std::fs::create_dir_all(&fw.agents).unwrap();
+        for name in names {
+            std::fs::write(
+                fw.agents.join(format!("{name}.md")),
+                format!("---\nname: {name}\ndescription: d\n---\n\nBody.\n"),
+            )
+            .unwrap();
+        }
+    }
+
+    fn write_project_manifest(fw: &FrameworkPaths, project_dir: &Path, toml: &str) {
+        let dir = project_dir.join(".trusty-mpm");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("manifest.toml"), toml).unwrap();
+        // `for_managed_workspace`-style paths already point `claude_home_dir()`
+        // at `project_dir`; nothing else to wire up here.
+        let _ = fw;
+    }
+
+    #[test]
+    fn plan_filters_expected_agents() {
+        // No manifest.toml override present: the plan selects every bundled
+        // agent (today's zero-regression default), so the expected set equals
+        // the full seeded roster.
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        let mut fw = fw;
+        fw.trusty_mpm_root = None;
+        seed_agent_source(&fw, &["engineer", "rust-engineer"]);
+
+        let mut expected = expected_agent_stems(&fw, None);
+        expected.sort();
+        assert_eq!(
+            expected,
+            vec!["engineer".to_string(), "rust-engineer".to_string()]
+        );
+    }
+
+    #[test]
+    fn plan_selection_excludes_generic_engineer() {
+        // A project manifest excluding the generic `engineer` catch-all must
+        // yield an expected set WITHOUT it, even though the bundled source
+        // directory still carries the file (issue #2171's exact scenario).
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let mut fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        fw.trusty_mpm_root = None;
+        seed_agent_source(&fw, &["engineer", "rust-engineer", "python-engineer"]);
+        write_project_manifest(&fw, &workspace, "[agents]\nexclude = [\"engineer\"]\n");
+
+        let mut expected = expected_agent_stems(&fw, None);
+        expected.sort();
+        assert_eq!(
+            expected,
+            vec!["python-engineer".to_string(), "rust-engineer".to_string()],
+            "excluded generic engineer must not be in the expected set"
+        );
+    }
+
+    #[test]
+    fn user_level_manifest_exclude_is_honored() {
+        // The exact real-world scenario reported against a live launch: an
+        // operator's USER-level `~/.trusty-mpm/manifest.toml` (not a
+        // per-project `.trusty-mpm/manifest.toml` override) excludes the
+        // generic `engineer` catch-all. `ManifestSources::resolve` reads this
+        // layer from `fw.root.join("manifest.toml")` — `fw.root` is the real
+        // global framework root (`~/.trusty-mpm` in production) for EVERY
+        // workspace on the machine, not something scoped per-project — so the
+        // expected set must reflect it exactly as `prepare_session_inner`
+        // would when deploying.
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let mut fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        fw.trusty_mpm_root = None;
+        seed_agent_source(&fw, &["engineer", "rust-engineer", "python-engineer"]);
+
+        // Write directly to `fw.root/manifest.toml` — the USER layer, no
+        // project-level `.trusty-mpm/manifest.toml` involved at all.
+        std::fs::create_dir_all(&fw.root).unwrap();
+        std::fs::write(
+            fw.root.join("manifest.toml"),
+            "[agents]\nexclude = [\"engineer\"]\n",
+        )
+        .unwrap();
+
+        let mut expected = expected_agent_stems(&fw, None);
+        expected.sort();
+        assert_eq!(
+            expected,
+            vec!["python-engineer".to_string(), "rust-engineer".to_string()],
+            "a user-level (~/.trusty-mpm/manifest.toml) exclude must be honored, not just a project-level override"
+        );
+    }
+
+    #[test]
+    fn empty_plan_source_falls_back_to_manifest() {
+        // The plan's source directory is entirely empty/unreadable (a
+        // binary-only install with no framework/agents populated yet) — the
+        // deployed manifest's managed keys must be used instead of an empty
+        // expected set.
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let mut fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        fw.trusty_mpm_root = None;
+        // No seed_agent_source call: `fw.agents` stays nonexistent.
+
+        let mut manifest = AgentManifest::default();
+        manifest.managed.insert(
+            "engineer.md".to_string(),
+            crate::core::agent_manifest::ManifestEntry {
+                source_chain: vec!["engineer".to_string()],
+                checksum: "abc".to_string(),
+                deployed_at: "2026-01-01T00:00:00Z".to_string(),
+                origin: crate::core::agent_manifest::Origin::Bundled,
+            },
+        );
+
+        let expected = expected_agent_stems(&fw, Some(&manifest));
+        assert_eq!(expected, vec!["engineer".to_string()]);
+    }
+
+    #[test]
+    fn manifest_and_plan_both_empty_falls_back_to_canonical_roster() {
+        // Neither the plan's source nor the manifest yields anything — this is
+        // the totally-fresh/unprovisioned-workspace floor: fall back to the
+        // unconditional bundled canonical roster (pre-#2171 behaviour).
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let mut fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        fw.trusty_mpm_root = None;
+        seed_agent_source(&fw, &["engineer"]);
+        // Plan source == fw.agent_source_dir() here (no catalog override), so
+        // this also exercises the "plan == bundled" common case end-to-end.
+
+        let expected = expected_agent_stems(&fw, None);
+        assert_eq!(expected, vec!["engineer".to_string()]);
+    }
+
+    #[test]
+    fn expected_skill_stems_mirrors_agent_fallback_order() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let mut fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        fw.trusty_mpm_root = None;
+        std::fs::create_dir_all(&fw.skills).unwrap();
+        std::fs::write(fw.skills.join("tm-doctor.md"), "skill body").unwrap();
+
+        let expected = expected_skill_stems(&fw, None);
+        assert_eq!(expected, vec!["tm-doctor".to_string()]);
+    }
+}

--- a/crates/trusty-mpm/src/core/deploy_validate/mod.rs
+++ b/crates/trusty-mpm/src/core/deploy_validate/mod.rs
@@ -1,5 +1,6 @@
 //! Validate a managed workspace's deployed `.claude/{agents,skills}` payload
-//! and `settings.json` against the canonical bundled roster (issue #2158).
+//! and `settings.json` against the expected per-project roster (issue #2158,
+//! refined by #2171).
 //!
 //! Why: a managed worktree can launch with an INCOMPLETE `.claude/` payload —
 //! missing agents, no deployed skills, a stripped `settings.json` with no
@@ -11,20 +12,26 @@
 //! loudly instead of handing the operator a half-provisioned session.
 //! What: [`validate_workspace`] compares the deployed `.claude/agents/` and
 //! `.claude/skills/` directories (plus their ownership manifests) against the
-//! CANONICAL bundled roster resolved via [`FrameworkPaths::agent_source_dir`]
-//! / [`FrameworkPaths::skill_source_dir`] — the same source
-//! [`crate::core::agent_deployer::deploy_agents`] /
-//! [`crate::core::skill_deployer::deploy_skills`] draw from when called
-//! unfiltered. The default HR-2 manifest selects every bundled agent/skill
-//! (see `session_launch::mod`'s doc comment), so in the common,
-//! no-custom-manifest case the full bundled source set IS the expected
-//! deployed set — a project that opts into a narrower manifest may see
-//! benign `AgentMissing`/`SkillMissing` gaps for deliberately-excluded
-//! entries; callers that need manifest-exact precision should additionally
-//! consult `core::manifest::HarnessPlan` (out of scope here, see #2158 PR
-//! notes). [`validate_workspace`] also checks `.claude/settings.json` (at
-//! [`FrameworkPaths::claude_home_dir`]) for a resolvable `outputStyle` and a
-//! configured `hooks` key. [`validate_and_repair`] re-runs
+//! EXPECTED set [`expected_set::expected_agent_stems`] /
+//! [`expected_set::expected_skill_stems`] resolve for this workspace — the
+//! SAME per-project [`crate::core::manifest::HarnessPlan`]
+//! `prepare_session_inner` computes before calling
+//! [`crate::core::agent_deployer::deploy_agents_filtered`] /
+//! [`crate::core::skill_deployer::deploy_skills_filtered`], not the
+//! unconditional full bundled roster (issue #2171 — a workspace legitimately
+//! provisioned from a FILTERED roster, e.g. every specialist `*-engineer`
+//! present but the generic `engineer` catch-all deliberately excluded, was
+//! previously reported incomplete for every excluded entry). When the plan
+//! cannot be usefully reconstructed (its resolved source directory is empty
+//! or missing), `expected_set` falls back to the workspace's OWN deployed
+//! ownership manifest (validating internal consistency: every entry the
+//! manifest claims to manage must exist on disk), and only when neither
+//! yields anything falls back further to the unconditional full canonical
+//! bundled roster (the pre-#2171 behavior) — see `expected_set`'s module doc
+//! for the full fallback contract. [`validate_workspace`] also checks
+//! `.claude/settings.json` (at [`FrameworkPaths::claude_home_dir`]) for a
+//! resolvable `outputStyle` and a configured `hooks` key.
+//! [`validate_and_repair`] re-runs
 //! [`crate::core::session_launch::prepare_session_with_repo_url`] — the exact
 //! deploy pipeline `spawn_managed`/`resume_managed` already use — when the
 //! initial validation finds gaps, then re-validates so callers can tell
@@ -35,8 +42,12 @@
 //! `validate_missing_output_style_key_is_a_gap`,
 //! `validate_unknown_output_style_id_is_a_gap`,
 //! `validate_output_style_file_missing_is_a_gap`, `validate_missing_hooks_is_a_gap`,
-//! `validate_complete_workspace_has_no_gaps`, `repair_closes_gaps_on_incomplete_workspace`,
-//! `repair_is_a_noop_on_already_complete_workspace`.
+//! `validate_complete_workspace_has_no_gaps`,
+//! `validate_filtered_but_manifest_matching_workspace_has_no_gaps`,
+//! `validate_entry_missing_on_disk_but_in_manifest_is_still_a_gap`,
+//! `repair_closes_gaps_on_incomplete_workspace`,
+//! `repair_is_a_noop_on_already_complete_workspace`; the expected-set
+//! resolution itself is covered by `expected_set`'s own test module.
 
 use std::path::Path;
 
@@ -44,6 +55,9 @@ use crate::core::agent_manifest::{self, AgentManifest, ManifestLoad};
 use crate::core::bundle::OUTPUT_STYLES;
 use crate::core::paths::FrameworkPaths;
 use crate::core::skill_manifest;
+
+mod expected_set;
+use expected_set::{expected_agent_stems, expected_skill_stems};
 
 /// One concrete gap between a deployed workspace and the canonical roster.
 ///
@@ -160,31 +174,39 @@ pub fn validate_workspace(fw: &FrameworkPaths) -> ValidationReport {
     ValidationReport { gaps }
 }
 
-/// Probe the deployed agent roster against the canonical bundled source.
+/// Probe the deployed agent roster against the EXPECTED per-project set
+/// (issue #2171 — see [`expected_set::expected_agent_stems`]).
 fn validate_agents(fw: &FrameworkPaths, gaps: &mut Vec<DeploymentGap>) {
     let target = fw.claude_agents_dir();
-    match AgentManifest::load_checked(&target) {
-        ManifestLoad::Corrupt(detail) => gaps.push(DeploymentGap::AgentManifestCorrupt(detail)),
-        ManifestLoad::Ok(_) => {
+    let manifest = match AgentManifest::load_checked(&target) {
+        ManifestLoad::Corrupt(detail) => {
+            gaps.push(DeploymentGap::AgentManifestCorrupt(detail));
+            None
+        }
+        ManifestLoad::Ok(m) => {
             if !target.join(agent_manifest::MANIFEST_FILE).is_file() {
                 gaps.push(DeploymentGap::AgentManifestMissing);
             }
+            Some(m)
         }
-    }
-    for name in canonical_stems(&fw.agent_source_dir()) {
+    };
+    for name in expected_agent_stems(fw, manifest.as_ref()) {
         if !target.join(format!("{name}.md")).is_file() {
             gaps.push(DeploymentGap::AgentMissing(name));
         }
     }
 }
 
-/// Probe the deployed skill roster against the canonical bundled source.
+/// Probe the deployed skill roster against the EXPECTED per-project set
+/// (issue #2171 — see [`expected_set::expected_skill_stems`]).
 fn validate_skills(fw: &FrameworkPaths, gaps: &mut Vec<DeploymentGap>) {
     let target = fw.claude_skills_dir();
-    if !target.join(skill_manifest::SKILL_MANIFEST_FILE).is_file() {
+    let manifest_present = target.join(skill_manifest::SKILL_MANIFEST_FILE).is_file();
+    if !manifest_present {
         gaps.push(DeploymentGap::SkillManifestMissing);
     }
-    for name in canonical_stems(&fw.skill_source_dir()) {
+    let manifest = manifest_present.then(|| skill_manifest::SkillManifest::load(&target));
+    for name in expected_skill_stems(fw, manifest.as_ref()) {
         if !target.join(&name).join("SKILL.md").is_file() {
             gaps.push(DeploymentGap::SkillMissing(name));
         }
@@ -241,38 +263,6 @@ fn validate_settings(fw: &FrameworkPaths, gaps: &mut Vec<DeploymentGap>) {
     if !hooks_present {
         gaps.push(DeploymentGap::HooksMissing);
     }
-}
-
-/// Canonical `.md` stems (filename without extension) directly under `dir`.
-///
-/// Why: shared by the agent and skill probes — both compare the deployed
-/// target against every `.md` file in a bundled source directory.
-/// What: returns the sorted, deterministic list of `.md` stems; an
-/// unreadable/missing `dir` yields an empty list (no canonical roster to
-/// check against — matches `deploy_agents`/`deploy_skills`'s own "missing
-/// source is an empty no-op" convention).
-/// Test: covered indirectly by every `validate_*` gap test.
-fn canonical_stems(dir: &Path) -> Vec<String> {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return Vec::new();
-    };
-    let mut names: Vec<String> = entries
-        .flatten()
-        .filter_map(|entry| {
-            let path = entry.path();
-            let is_md = path
-                .extension()
-                .and_then(|x| x.to_str())
-                .map(|x| x.eq_ignore_ascii_case("md"))
-                .unwrap_or(false);
-            if !is_md {
-                return None;
-            }
-            path.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
-        })
-        .collect();
-    names.sort_unstable();
-    names
 }
 
 /// The outcome of [`validate_and_repair`].
@@ -409,6 +399,17 @@ mod tests {
         std::fs::write(style_dir.join(default.file_name), default.content).unwrap();
     }
 
+    /// A minimal, deterministic agent-manifest entry for the entries the
+    /// #2171 fallback tests record directly (no real deploy pipeline run).
+    fn sample_agent_entry(source_name: &str) -> crate::core::agent_manifest::ManifestEntry {
+        crate::core::agent_manifest::ManifestEntry {
+            source_chain: vec![source_name.to_string()],
+            checksum: agent_manifest::checksum("agent"),
+            deployed_at: "2026-01-01T00:00:00Z".to_string(),
+            origin: crate::core::agent_manifest::Origin::Bundled,
+        }
+    }
+
     /// A fully-provisioned workspace matching everything `prepare_session`
     /// would have written, used as the positive-path baseline every negative
     /// test starts from and mutates one field of.
@@ -446,6 +447,110 @@ mod tests {
         assert!(
             report.is_complete(),
             "expected no gaps, got: {:?}",
+            report.gaps
+        );
+    }
+
+    #[test]
+    fn validate_filtered_but_manifest_matching_workspace_has_no_gaps() {
+        // #2171: a workspace provisioned from a FILTERED per-project roster
+        // (a project manifest override excludes the generic `engineer`
+        // catch-all; only `rust-engineer` is deployed, matching its own
+        // ownership manifest exactly) must validate COMPLETE. The pre-fix
+        // validator diffed against the unconditional full bundled roster and
+        // falsely reported `engineer` missing even though it was never
+        // supposed to be deployed here.
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let mut fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        fw.trusty_mpm_root = None;
+
+        seed_agent_source(&fw, &["engineer", "rust-engineer"]);
+        seed_skill_source(&fw, &["tm-doctor"]);
+
+        let manifest_dir = workspace.join(".trusty-mpm");
+        std::fs::create_dir_all(&manifest_dir).unwrap();
+        std::fs::write(
+            manifest_dir.join("manifest.toml"),
+            "[agents]\nexclude = [\"engineer\"]\n",
+        )
+        .unwrap();
+
+        let agents_dir = fw.claude_agents_dir();
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(agents_dir.join("rust-engineer.md"), "agent").unwrap();
+        let mut agent_manifest = AgentManifest::default();
+        agent_manifest.managed.insert(
+            "rust-engineer.md".to_string(),
+            sample_agent_entry("rust-engineer"),
+        );
+        agent_manifest.save(&agents_dir).unwrap();
+
+        let skills_dir = fw.claude_skills_dir();
+        std::fs::create_dir_all(skills_dir.join("tm-doctor")).unwrap();
+        std::fs::write(skills_dir.join("tm-doctor").join("SKILL.md"), "skill").unwrap();
+        crate::core::skill_manifest::SkillManifest::default()
+            .save(&skills_dir)
+            .unwrap();
+
+        deploy_style_file(&fw);
+        write_settings(
+            &fw,
+            r#"{"outputStyle": "trusty-mpm", "hooks": {"SessionStart": []}}"#,
+        );
+
+        let report = validate_workspace(&fw);
+        assert!(
+            report.is_complete(),
+            "filtered-but-complete workspace must validate as complete, got: {:?}",
+            report.gaps
+        );
+    }
+
+    #[test]
+    fn validate_entry_missing_on_disk_but_in_manifest_is_still_a_gap() {
+        // The plan's bundled source directory is unpopulated (a binary-only
+        // install with no `framework/agents` yet), so expected-set resolution
+        // falls through to tier (b): the workspace's own deployed manifest.
+        // An entry the manifest claims to manage but which is NOT actually
+        // present on disk must still be reported — the fallback must never
+        // suppress a genuine gap, and an entry that IS on disk must not be
+        // falsely flagged.
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let mut fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        fw.trusty_mpm_root = None;
+        // No seed_agent_source call — the plan's bundled source stays empty.
+
+        let agents_dir = fw.claude_agents_dir();
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(agents_dir.join("rust-engineer.md"), "agent").unwrap();
+        let mut agent_manifest = AgentManifest::default();
+        agent_manifest.managed.insert(
+            "rust-engineer.md".to_string(),
+            sample_agent_entry("rust-engineer"),
+        );
+        agent_manifest.managed.insert(
+            "python-engineer.md".to_string(),
+            sample_agent_entry("python-engineer"),
+        );
+        agent_manifest.save(&agents_dir).unwrap();
+
+        let report = validate_workspace(&fw);
+        assert!(
+            report
+                .gaps
+                .contains(&DeploymentGap::AgentMissing("python-engineer".to_string())),
+            "manifest-recorded entry missing on disk must still be reported, got: {:?}",
+            report.gaps
+        );
+        assert!(
+            !report
+                .gaps
+                .contains(&DeploymentGap::AgentMissing("rust-engineer".to_string())),
+            "the entry that IS on disk must not be falsely reported missing, got: {:?}",
             report.gaps
         );
     }


### PR DESCRIPTION
## Summary
- `tm validate` / the deployment-completeness check (`core::deploy_validate`) previously diffed a workspace's deployed `.claude/{agents,skills}` payload against the FULL bundled roster unconditionally — a workspace legitimately provisioned from a FILTERED roster (a project- or user-level `manifest.toml` `[agents] exclude = [...]`, or #1941 language auto-scoping) was falsely reported incomplete for every deliberately-excluded entry (exit 1 / spawn-gate false failure).
- New `core::deploy_validate::expected_set` module reconstructs the same `HarnessPlan` `prepare_session_inner` computes for the workspace (project override > user config > catalog > compiled-in default) and diffs the deployed payload against THAT filtered set.
- Fallback ordering when the plan yields nothing usable (empty/unreadable source dir): (a) the reconstructed plan → (b) the workspace's own deployed ownership manifest (`.trusty-mpm-manifest.json` / `.trusty-mpm-skills-manifest.json`, an internal-consistency check: every entry the manifest claims to manage must exist on disk) → (c) only when both are empty, the full canonical bundled roster (pre-#2171 behavior), so a totally unprovisioned workspace still reports every gap.
- True gaps are still caught: an entry present in the plan/manifest but missing on disk, or a wrong/missing `outputStyle`/`hooks`, are still reported.

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --no-fail-fast` — all green except the pre-existing, unrelated flaky banner test `formatters::banner::two_panel::tests::right_col_no_inner_border` (randomized content generation; re-running the identical scenario passes cleanly, confirming it's not caused by this change)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (14 allowlisted, 0 violations)
- [x] New tests: `validate_filtered_but_manifest_matching_workspace_has_no_gaps`, `validate_entry_missing_on_disk_but_in_manifest_is_still_a_gap`, `plan_selection_excludes_generic_engineer`, `user_level_manifest_exclude_is_honored` (covers the real-world `~/.trusty-mpm/manifest.toml` exclude case specifically, not just a per-project override), `empty_plan_source_falls_back_to_manifest`, `manifest_and_plan_both_empty_falls_back_to_canonical_roster`

Closes #2171

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools