### PR TITLE
feat(trusty-code): mode-aware prompt assembly + parity conformance (strict diff-only Parity) (#2073)

### DIFF
--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -540,6 +540,74 @@ async fn parity_mode_never_compacts_even_past_threshold() {
     );
 }
 
+/// The FULL parity conformance check tying the model-routing layer to the
+/// compaction layer (#2073, the "M2 integration" proof §5.9 asks for): two
+/// `HarnessMode::Parity` runs over the identical script, registry, and
+/// aggressive `CompactionConfig`, differing ONLY in `AgentLoopConfig.model`,
+/// must send the model IDENTICAL message sequences turn-by-turn — proving
+/// Parity's assembled requests are deterministic and model-independent, not
+/// merely "does not compact" (`parity_mode_never_compacts_even_past_threshold`)
+/// or "same schema in M1" (`tool_definitions_identical_across_modes_in_m1`)
+/// in isolation.
+///
+/// Why: Each P1B layer (#2059 mode, #2068 edit-format, #2069 skills, #2070
+/// compaction) already has its own per-layer unit test proving IT respects
+/// the mode branch; #2073's job is proving the layers hold TOGETHER — that
+/// swapping the model under Parity changes nothing about what the loop sends
+/// except the `model` field itself (which `ChatRequest.messages` never
+/// carries, so comparing `ScriptedLlm::requests()` — the recorded message
+/// lists — directly proves this).
+/// What: Runs the SAME 5-tool-call-then-stop script against two configs that
+/// differ only in `model`, both `mode: Parity` with the SAME aggressive
+/// `CompactionConfig` used by the two single-mode tests above. Asserts the
+/// two runs' full `requests()` vectors are byte-for-byte equal.
+/// Test: this test.
+#[tokio::test]
+async fn parity_mode_message_sequences_are_model_independent() {
+    fn script() -> Vec<Value> {
+        let mut fixtures: Vec<Value> = (0..5)
+            .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+            .collect();
+        fixtures.push(stop_response("all done"));
+        fixtures
+    }
+
+    fn run_with_model(model: &str) -> (AgentLoop, Arc<ScriptedLlm>) {
+        let llm = Arc::new(ScriptedLlm::from_json(&script()));
+        let registry = registry_with_echo(false);
+        let agent = make_loop(
+            llm.clone(),
+            registry,
+            AgentLoopConfig {
+                max_turns: 10,
+                model: model.to_string(),
+                mode: crate::mode::HarnessMode::Parity,
+                compaction: aggressive_compaction(),
+                ..AgentLoopConfig::default()
+            },
+        );
+        (agent, llm)
+    }
+
+    let (agent_a, llm_a) = run_with_model("openai/gpt-4o-mini");
+    let (agent_b, llm_b) = run_with_model("anthropic/claude-opus-4-5");
+
+    agent_a
+        .run("system prompt", "the original task")
+        .await
+        .expect("run a completes");
+    agent_b
+        .run("system prompt", "the original task")
+        .await
+        .expect("run b completes");
+
+    assert_eq!(
+        llm_a.requests(),
+        llm_b.requests(),
+        "Parity's assembled message sequences must be identical across models"
+    );
+}
+
 /// A two-turn flow: assistant calls the tool, then stops with final text.
 ///
 /// Why: This is the canonical happy path the loop exists to support.

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -260,6 +260,7 @@ fn build_engineer_runner(
 
     let factory: Arc<dyn RegistryFactory> = Arc::new(ProjectToolFactory {
         project: params.project.clone(),
+        mode: params.mode,
     });
 
     let mut runner = InProcessAgentRunner::new(engineer_llm, factory, params.agents_dir.clone())
@@ -304,6 +305,14 @@ fn daily_driver_skills_catalog(params: &TaskRunParams) -> Option<(String, Arc<dy
 /// (mirrors `run_task::ProjectToolFactory`, which is private to that module).
 struct ProjectToolFactory {
     project: PathBuf,
+    /// #2073: the delegating run's resolved `HarnessMode`, threaded onto the
+    /// engineer's `EditTool` so `HarnessMode::Parity` selects edit-format
+    /// order the same way regardless of which model is delegated to (§5.9's
+    /// edit-format reconciliation). `run_task::ProjectToolFactory` (the
+    /// legacy CLI path, which never resolves a `HarnessMode`) intentionally
+    /// does not carry this field — its `EditTool` stays on the pre-#2073
+    /// plain per-model order, unchanged.
+    mode: HarnessMode,
 }
 
 #[async_trait]
@@ -317,7 +326,9 @@ impl RegistryFactory for ProjectToolFactory {
         reg.register(Arc::new(ReadFileTool::new(&self.project)));
         reg.register(Arc::new(WriteFileTool::new(&self.project)));
         reg.register(Arc::new(
-            EditTool::new(&self.project).with_model_slug(model_slug),
+            EditTool::new(&self.project)
+                .with_model_slug(model_slug)
+                .with_mode(self.mode),
         ));
         reg.register(Arc::new(BashTool::new(
             Some(self.project.clone()),

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -159,3 +159,46 @@ fn daily_driver_skills_catalog_some_when_skills_exist() {
     assert!(catalog.contains("demo: Demo skill"));
     assert_eq!(resolver.resolve("demo").as_deref(), Some("full body"));
 }
+
+/// `ProjectToolFactory::build` threads the run's resolved `HarnessMode` onto
+/// the engineer's `EditTool` (#2073) — under `HarnessMode::Parity`, the
+/// dispatched `edit` call must prefer a supplied unified-diff payload even
+/// when the calling model slug would prefer SEARCH/REPLACE under the plain
+/// per-model matrix, proving the daemon path actually wires `with_mode`
+/// through, not just that `EditTool` supports it in isolation
+/// (`tools::fs::edit::tests::edit_under_parity_mode_prefers_unified_diff_even_for_flagship_model_slug`
+/// covers the tool itself).
+#[tokio::test]
+async fn project_tool_factory_threads_parity_mode_into_edit_tool() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    std::fs::write(project.path().join("f.py"), "line1\nline2\n").expect("seed file");
+
+    let factory = ProjectToolFactory {
+        project: project.path().to_path_buf(),
+        mode: crate::mode::HarnessMode::Parity,
+    };
+    let agent = crate::agents::AgentConfig::default();
+    let ctx = crate::tools::RunContext {
+        model: Some("anthropic/claude-opus-4-5".to_string()),
+        ..Default::default()
+    };
+    let registry = factory.build(&agent, &ctx).await;
+
+    let result = registry
+        .dispatch_gated(
+            "edit",
+            serde_json::json!({
+                "path": "f.py",
+                "old_string": "not-present",
+                "new_string": "x",
+                "diff": "@@ -2,1 +2,1 @@\n-line2\n+line2-diffed\n"
+            }),
+            None,
+        )
+        .await;
+
+    assert!(!result.is_error(), "unexpected error: {}", result.content());
+    assert!(result.content().contains("unified_diff"));
+    let updated = std::fs::read_to_string(project.path().join("f.py")).expect("read");
+    assert_eq!(updated, "line1\nline2-diffed\n");
+}

--- a/crates/trusty-code/src/tools/fs/edit.rs
+++ b/crates/trusty-code/src/tools/fs/edit.rs
@@ -50,7 +50,9 @@ pub struct EditTool {
     /// pre-#2073 behaviour: always the plain per-model order via
     /// `edit_format::select_and_apply`. `Some(mode)` routes through
     /// `edit_format::select_and_apply_for_mode`, whose `HarnessMode::Parity`
-    /// arm ignores `model_slug` (§5.9's edit-format reconciliation).
+    /// arm requires a `diff` payload and does NOT fall back to SEARCH/REPLACE
+    /// or whole-file (owner-tightened 2026-07-07, §5.9's edit-format
+    /// reconciliation read literally for benchmark fairness).
     mode: Option<HarnessMode>,
 }
 
@@ -85,13 +87,16 @@ impl EditTool {
 
     /// Set the resolved `HarnessMode` this tool's owning run uses (#2073).
     ///
-    /// Why: `HarnessMode::Parity` must select edit-format order the same way
-    /// regardless of the calling model (§5.9's reconciliation table); without
-    /// this the tool always used the plain per-model matrix even in Parity.
-    /// Every call site that does not opt in (`mode` stays `None`) keeps the
-    /// exact pre-#2073 behaviour.
+    /// Why: `HarnessMode::Parity` must score a model's raw diff-editing
+    /// ability, unforgivingly — without this the tool always used the
+    /// per-model fallback matrix even in Parity, letting a model "pass" an
+    /// edit via SEARCH/REPLACE or whole-file without ever demonstrating a
+    /// valid diff (owner decision, 2026-07-07: this would defeat M3's model
+    /// bake-off). Every call site that does not opt in (`mode` stays `None`)
+    /// keeps the exact pre-#2073 behaviour.
     /// What: Stores `mode` for use in `execute`/`edit_inner`.
-    /// Test: `edit_under_parity_mode_prefers_unified_diff_even_for_flagship_model_slug`,
+    /// Test: `edit_under_parity_mode_applies_a_valid_diff`,
+    /// `edit_under_parity_mode_errors_without_a_diff_payload`,
     /// `edit_under_daily_driver_mode_matches_legacy_model_based_order`.
     pub fn with_mode(mut self, mode: HarnessMode) -> Self {
         self.mode = Some(mode);
@@ -106,8 +111,11 @@ impl EditTool {
     /// `edit_format::select_and_apply`/`select_and_apply_for_mode` call.
     /// `self.mode` (#2073) picks which of the two: `None` (unset) preserves
     /// the exact pre-#2073 plain per-model selection; `Some(mode)` routes
-    /// through the mode-aware variant, whose `Parity` arm ignores the model
-    /// slug entirely.
+    /// through the mode-aware variant, whose `Parity` arm accepts ONLY a
+    /// `diff` payload and returns a recoverable
+    /// `FsError::ParityDiffRequired` (never a panic) when none was supplied
+    /// or the diff fails to apply — no fallback to SEARCH/REPLACE or
+    /// whole-file, even then.
     /// Test: All `EditTool` unit tests exercise this path.
     fn edit_inner(
         &self,
@@ -495,10 +503,12 @@ mod tests {
 
     /// Under `HarnessMode::Parity`, a flagship model slug (which would prefer
     /// SEARCH/REPLACE first under the plain per-model matrix) still applies
-    /// the unified-diff payload when both are supplied (#2073, §5.9's
-    /// edit-format reconciliation: Parity's selection must not vary by model).
+    /// ONLY the unified-diff payload when both are supplied — the
+    /// SEARCH/REPLACE payload is never even attempted (#2073, tightened
+    /// 2026-07-07: Parity's edit-format is strict unified-diff only, not
+    /// merely model-independent).
     #[tokio::test]
-    async fn edit_under_parity_mode_prefers_unified_diff_even_for_flagship_model_slug() {
+    async fn edit_under_parity_mode_applies_a_valid_diff() {
         let tmp = tempfile::tempdir().expect("tempdir");
         fs::write(tmp.path().join("f.py"), "line1\nline2\n").expect("write");
         let tool = EditTool::new(tmp.path())
@@ -509,7 +519,8 @@ mod tests {
             .execute(json!({
                 "path": "f.py",
                 // Deliberately non-matching, so a SEARCH/REPLACE-first order
-                // would fail; only the diff below can actually apply.
+                // would fail; only the diff below can actually apply. Under
+                // strict Parity this payload is never even attempted.
                 "old_string": "not-present",
                 "new_string": "x",
                 "diff": "@@ -2,1 +2,1 @@\n-line2\n+line2-diffed\n"
@@ -520,6 +531,48 @@ mod tests {
         assert!(result.content().contains("unified_diff"));
         let updated = fs::read_to_string(tmp.path().join("f.py")).expect("read");
         assert_eq!(updated, "line1\nline2-diffed\n");
+    }
+
+    /// Under `HarnessMode::Parity`, an `edit` call that supplies only
+    /// SEARCH/REPLACE (no `diff`) must return a RECOVERABLE tool error — the
+    /// same `ToolResult::err` mechanism every other edit failure uses, never
+    /// a panic — whose message makes clear Parity requires a unified-diff
+    /// edit, and must NOT silently succeed via the fallback matrix (#2073,
+    /// tightened 2026-07-07: the model is scored as failing the edit, per
+    /// the owner's benchmark-fairness decision).
+    #[tokio::test]
+    async fn edit_under_parity_mode_errors_without_a_diff_payload() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("f.py"), "line1\nline2\n").expect("write");
+        let tool = EditTool::new(tmp.path())
+            .with_model_slug("anthropic/claude-opus-4-5")
+            .with_mode(crate::mode::HarnessMode::Parity);
+
+        // A payload that WOULD succeed under DailyDriver's fallback matrix
+        // (unique old_string match) — under Parity it must never be tried.
+        let result = tool
+            .execute(json!({
+                "path": "f.py",
+                "old_string": "line2",
+                "new_string": "line2-replaced"
+            }))
+            .await;
+
+        assert!(
+            result.is_error(),
+            "Parity must reject an edit with no diff payload, got: {}",
+            result.content()
+        );
+        assert!(
+            result.content().contains("unified-diff"),
+            "error must make the Parity requirement clear: {}",
+            result.content()
+        );
+        let unchanged = fs::read_to_string(tmp.path().join("f.py")).expect("read");
+        assert_eq!(
+            unchanged, "line1\nline2\n",
+            "the file must be untouched when Parity rejects the edit"
+        );
     }
 
     /// Under `HarnessMode::DailyDriver`, `with_mode` must produce the exact

--- a/crates/trusty-code/src/tools/fs/edit.rs
+++ b/crates/trusty-code/src/tools/fs/edit.rs
@@ -23,7 +23,10 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
-use crate::tools::fs::edit_format::{EditFormat, EditPayload, select_and_apply};
+use crate::mode::HarnessMode;
+use crate::tools::fs::edit_format::{
+    EditFormat, EditPayload, select_and_apply, select_and_apply_for_mode,
+};
 use crate::tools::fs::{FsError, scoped_path};
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
@@ -42,6 +45,13 @@ use crate::tools::traits::{ToolExecutor, ToolResult};
 pub struct EditTool {
     working_dir: PathBuf,
     model_slug: Option<String>,
+    /// The resolved `HarnessMode` for this tool's owning run (#2073). `None`
+    /// (the default, and every pre-#2073 call site) preserves the exact
+    /// pre-#2073 behaviour: always the plain per-model order via
+    /// `edit_format::select_and_apply`. `Some(mode)` routes through
+    /// `edit_format::select_and_apply_for_mode`, whose `HarnessMode::Parity`
+    /// arm ignores `model_slug` (§5.9's edit-format reconciliation).
+    mode: Option<HarnessMode>,
 }
 
 impl EditTool {
@@ -56,6 +66,7 @@ impl EditTool {
         Self {
             working_dir: working_dir.into(),
             model_slug: None,
+            mode: None,
         }
     }
 
@@ -72,11 +83,31 @@ impl EditTool {
         self
     }
 
+    /// Set the resolved `HarnessMode` this tool's owning run uses (#2073).
+    ///
+    /// Why: `HarnessMode::Parity` must select edit-format order the same way
+    /// regardless of the calling model (§5.9's reconciliation table); without
+    /// this the tool always used the plain per-model matrix even in Parity.
+    /// Every call site that does not opt in (`mode` stays `None`) keeps the
+    /// exact pre-#2073 behaviour.
+    /// What: Stores `mode` for use in `execute`/`edit_inner`.
+    /// Test: `edit_under_parity_mode_prefers_unified_diff_even_for_flagship_model_slug`,
+    /// `edit_under_daily_driver_mode_matches_legacy_model_based_order`.
+    pub fn with_mode(mut self, mode: HarnessMode) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
     /// Perform the edit: read the file, apply the best-fit payload, write back.
     ///
     /// Why: Centralises the IO so `execute` stays focused on argument parsing.
     /// What: Returns the `EditFormat` that was actually applied. Errors
-    /// propagate from `scoped_path`, file IO, or `edit_format::select_and_apply`.
+    /// propagate from `scoped_path`, file IO, or the underlying
+    /// `edit_format::select_and_apply`/`select_and_apply_for_mode` call.
+    /// `self.mode` (#2073) picks which of the two: `None` (unset) preserves
+    /// the exact pre-#2073 plain per-model selection; `Some(mode)` routes
+    /// through the mode-aware variant, whose `Parity` arm ignores the model
+    /// slug entirely.
     /// Test: All `EditTool` unit tests exercise this path.
     fn edit_inner(
         &self,
@@ -94,7 +125,10 @@ impl EditTool {
         })?;
 
         let model_slug = self.model_slug.as_deref().unwrap_or("");
-        let (updated, format) = select_and_apply(model_slug, &content, &scoped, payloads)?;
+        let (updated, format) = match self.mode {
+            Some(mode) => select_and_apply_for_mode(mode, model_slug, &content, &scoped, payloads)?,
+            None => select_and_apply(model_slug, &content, &scoped, payloads)?,
+        };
         std::fs::write(&scoped, updated).map_err(|e| FsError::io(&scoped, e))?;
         Ok(format)
     }
@@ -453,6 +487,62 @@ mod tests {
                 "content": "fallback content\n"
             }))
             .await;
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        assert!(result.content().contains("whole_file"));
+        let updated = fs::read_to_string(tmp.path().join("f.py")).expect("read");
+        assert_eq!(updated, "fallback content\n");
+    }
+
+    /// Under `HarnessMode::Parity`, a flagship model slug (which would prefer
+    /// SEARCH/REPLACE first under the plain per-model matrix) still applies
+    /// the unified-diff payload when both are supplied (#2073, §5.9's
+    /// edit-format reconciliation: Parity's selection must not vary by model).
+    #[tokio::test]
+    async fn edit_under_parity_mode_prefers_unified_diff_even_for_flagship_model_slug() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("f.py"), "line1\nline2\n").expect("write");
+        let tool = EditTool::new(tmp.path())
+            .with_model_slug("anthropic/claude-opus-4-5")
+            .with_mode(crate::mode::HarnessMode::Parity);
+
+        let result = tool
+            .execute(json!({
+                "path": "f.py",
+                // Deliberately non-matching, so a SEARCH/REPLACE-first order
+                // would fail; only the diff below can actually apply.
+                "old_string": "not-present",
+                "new_string": "x",
+                "diff": "@@ -2,1 +2,1 @@\n-line2\n+line2-diffed\n"
+            }))
+            .await;
+
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        assert!(result.content().contains("unified_diff"));
+        let updated = fs::read_to_string(tmp.path().join("f.py")).expect("read");
+        assert_eq!(updated, "line1\nline2-diffed\n");
+    }
+
+    /// Under `HarnessMode::DailyDriver`, `with_mode` must produce the exact
+    /// same outcome as the pre-#2073 default (no `with_mode` call at all) —
+    /// the mode-aware path is a no-op wrapper around the legacy per-model
+    /// matrix for this mode.
+    #[tokio::test]
+    async fn edit_under_daily_driver_mode_matches_legacy_model_based_order() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("f.py"), "original\n").expect("write");
+        let tool = EditTool::new(tmp.path())
+            .with_model_slug("anthropic/claude-opus-4-5")
+            .with_mode(crate::mode::HarnessMode::DailyDriver);
+
+        let result = tool
+            .execute(json!({
+                "path": "f.py",
+                "old_string": "not-present-in-file",
+                "new_string": "x",
+                "content": "fallback content\n"
+            }))
+            .await;
+
         assert!(!result.is_error(), "unexpected error: {}", result.content());
         assert!(result.content().contains("whole_file"));
         let updated = fs::read_to_string(tmp.path().join("f.py")).expect("read");

--- a/crates/trusty-code/src/tools/fs/edit_format/mod.rs
+++ b/crates/trusty-code/src/tools/fs/edit_format/mod.rs
@@ -17,10 +17,14 @@
 //! bundles the format-specific arguments recovered from the LLM's tool call;
 //! [`format_order_for`] returns the per-model fallback order; [`select_and_apply`]
 //! tries the caller-supplied payloads in that order against the current file
-//! content and returns the first one that applies cleanly. [`format_order_for_mode`]
-//! and [`select_and_apply_for_mode`] (#2073) are the `HarnessMode`-aware
-//! variants that reconcile this per-model matrix with vision spec §5.9's
-//! Parity/DailyDriver split (see their own docs).
+//! content and returns the first one that applies cleanly. [`select_and_apply_for_mode`]
+//! (#2073) is the `HarnessMode`-aware entry point that reconciles this
+//! per-model matrix with vision spec §5.9's Parity/DailyDriver split:
+//! `HarnessMode::DailyDriver` keeps this per-model matrix with full
+//! fallback, unchanged; `HarnessMode::Parity` is STRICT unified-diff only,
+//! with NO fallback to SEARCH/REPLACE or whole-file (owner decision,
+//! 2026-07-07 — see [`apply_parity_diff_only`]'s docs for the
+//! benchmark-fairness rationale).
 //!
 //! ## Per-model format matrix
 //!
@@ -38,7 +42,9 @@
 //! precision-dependent formats, so the most forgiving format (whole-file)
 //! leads for the catch-all bucket. This table is the `HarnessMode::DailyDriver`
 //! behaviour (#2073, §5.9): production, per-model-optimised edit-format
-//! selection. `HarnessMode::Parity` overrides it — see [`format_order_for_mode`].
+//! selection with full fallback. `HarnessMode::Parity` does NOT use this
+//! table at all — see [`apply_parity_diff_only`] for its strict,
+//! no-fallback unified-diff-only behaviour.
 //! Test: `tests::format_order_*`, `tests::select_and_apply_*`.
 
 mod diff;
@@ -213,43 +219,52 @@ pub fn select_and_apply(
 /// `HarnessMode`-aware fallback order for edit-format application (#2073,
 /// §5.9's reconciliation table).
 ///
-/// Why: The parity spec's benchmark-fairness goal (D2) extends to the edit
-/// layer: §5.9's table lists Parity's edit-format column as "unified-diff
-/// only", in contrast to DailyDriver's "per-model optimized". The literal
-/// reading ("reject every other format outright") would strand a Parity run
-/// against any model that cannot reliably emit a diff, which defeats
-/// "benchmark fairness" more than it serves it — so this applies the
-/// spec's INTENT (edit-format choice must not vary by model in Parity) by
-/// returning a FIXED, model-independent order with unified-diff leading,
-/// rather than hard-rejecting the other two formats. A caller wanting the
-/// stricter literal reading can inspect the returned `EditFormat` and treat
-/// anything but `UnifiedDiff` as a policy violation; `select_and_apply_for_mode`
-/// itself still falls back so a Parity run can always complete an edit.
-/// What: `HarnessMode::Parity` ignores `model_slug` and always returns
-/// `[UnifiedDiff, SearchReplace, WholeFile]`. `HarnessMode::DailyDriver`
+/// Why: §5.9's table lists Parity's edit-format column as "unified-diff
+/// only", in contrast to DailyDriver's "per-model optimized". An earlier
+/// revision of this function returned a fixed-but-still-falling-back order
+/// (`[UnifiedDiff, SearchReplace, WholeFile]`) for Parity; the owner
+/// tightened that decision (2026-07-07): Parity/Benchmark mode exists to
+/// measure MODELS unforgivingly, and silently rescuing a model that fails
+/// at diff-editing via a SearchReplace/WholeFile fallback defeats that
+/// purpose (M3's model bake-off depends on the stricter reading). Parity is
+/// therefore STRICT unified-diff only — see [`select_and_apply_for_mode`],
+/// which is what actually enforces this (NOT this function — see below).
+/// What: Kept for API-shape parity with [`format_order_for`] and existing
+/// callers that introspect "what would be preferred", but for
+/// `HarnessMode::Parity` this returns `[UnifiedDiff, UnifiedDiff,
+/// UnifiedDiff]` — not a real preference order, since Parity has none —
+/// purely to keep the fixed 3-element return type; `model_slug` is ignored.
+/// `select_and_apply_for_mode`'s `Parity` arm does NOT consult this
+/// function's return value at all; it dispatches through the dedicated,
+/// no-fallback [`apply_parity_diff_only`] instead, so there is exactly ONE
+/// place Parity's strictness is enforced. `HarnessMode::DailyDriver`
 /// delegates to [`format_order_for`] unchanged (the existing per-model
-/// matrix, #2068).
-/// Test: `tests::format_order_for_mode_parity_is_model_independent`,
+/// matrix, #2068) and IS still consulted by `select_and_apply_for_mode`.
+/// Test: `tests::format_order_for_mode_parity_is_unified_diff_only`,
 /// `tests::format_order_for_mode_daily_driver_matches_legacy_order`.
 pub fn format_order_for_mode(mode: HarnessMode, model_slug: &str) -> [EditFormat; 3] {
     match mode {
-        HarnessMode::Parity => [
-            EditFormat::UnifiedDiff,
-            EditFormat::SearchReplace,
-            EditFormat::WholeFile,
-        ],
+        HarnessMode::Parity => [EditFormat::UnifiedDiff; 3],
         HarnessMode::DailyDriver => format_order_for(model_slug),
     }
 }
 
-/// `HarnessMode`-aware [`select_and_apply`] (#2073).
+/// `HarnessMode`-aware edit-format dispatch (#2073).
 ///
 /// Why: The single call site (`EditTool::edit_inner`) that needs to pick
-/// between the plain per-model order and the Parity-fixed order without
-/// duplicating the apply loop.
-/// What: Computes the order via [`format_order_for_mode`], then applies it
-/// exactly as [`select_and_apply`] does.
-/// Test: `tests::select_and_apply_for_mode_parity_prefers_unified_diff_regardless_of_model`.
+/// between DailyDriver's per-model fallback chain and Parity's strict,
+/// no-fallback unified-diff requirement.
+/// What: `HarnessMode::DailyDriver` applies [`format_order_for`] (ignoring
+/// `format_order_for_mode`'s Parity-shaped return entirely for this arm —
+/// it calls the per-model matrix directly) via the shared [`apply_in_order`]
+/// loop, unchanged from pre-#2073 behaviour. `HarnessMode::Parity` ignores
+/// `model_slug` and delegates to [`apply_parity_diff_only`], which accepts
+/// ONLY a supplied `diff` payload — a present `old_string`/`new_string` or
+/// `content` payload is never attempted, even if the diff fails to apply.
+/// Test: `tests::select_and_apply_for_mode_parity_applies_a_valid_diff`,
+/// `tests::select_and_apply_for_mode_parity_errors_without_a_diff_payload`,
+/// `tests::select_and_apply_for_mode_parity_does_not_fall_back_on_diff_failure`,
+/// `tests::select_and_apply_for_mode_daily_driver_still_falls_back_per_model`.
 pub fn select_and_apply_for_mode(
     mode: HarnessMode,
     model_slug: &str,
@@ -257,12 +272,52 @@ pub fn select_and_apply_for_mode(
     path: &Path,
     payloads: &[EditPayload],
 ) -> Result<(String, EditFormat), FsError> {
-    apply_in_order(
-        format_order_for_mode(mode, model_slug),
-        content,
-        path,
-        payloads,
-    )
+    match mode {
+        HarnessMode::Parity => apply_parity_diff_only(content, path, payloads),
+        HarnessMode::DailyDriver => {
+            apply_in_order(format_order_for(model_slug), content, path, payloads)
+        }
+    }
+}
+
+/// Strict, no-fallback unified-diff application for `HarnessMode::Parity`
+/// (#2073, owner-tightened 2026-07-07 per vision spec §5.9's literal
+/// "unified-diff only" reading and the benchmark-fairness rationale).
+///
+/// Why: Parity/Benchmark mode exists to measure MODELS, unforgivingly — a
+/// model that cannot produce a valid unified diff must be scored as FAILING
+/// at the edit, not silently rescued by falling back to SEARCH/REPLACE or
+/// whole-file replacement. M3's model bake-off depends on this: a fallback
+/// would let a model "pass" an edit it did not actually demonstrate
+/// diff-editing competence at.
+/// What: Requires a present `EditPayload::UnifiedDiff` in `payloads`; any
+/// other payload present (`SearchReplace`, `WholeFile`) is ignored entirely
+/// and never attempted. Returns [`FsError::ParityDiffRequired`] when no diff
+/// payload was supplied at all. When a diff payload IS present, propagates
+/// `apply_unified_diff`'s own error verbatim on failure (bad hunk header,
+/// context mismatch, …) — NO fallback to another format is attempted even
+/// then. Both outcomes are ordinary recoverable `FsError`s (never a panic),
+/// so the model sees a clear message and can retry with a corrected diff,
+/// scored as a failed attempt in the interim.
+/// Test: `tests::select_and_apply_for_mode_parity_applies_a_valid_diff`,
+/// `tests::select_and_apply_for_mode_parity_errors_without_a_diff_payload`,
+/// `tests::select_and_apply_for_mode_parity_does_not_fall_back_on_diff_failure`.
+fn apply_parity_diff_only(
+    content: &str,
+    path: &Path,
+    payloads: &[EditPayload],
+) -> Result<(String, EditFormat), FsError> {
+    let diff_payload = payloads
+        .iter()
+        .find(|p| p.format() == EditFormat::UnifiedDiff);
+
+    let Some(EditPayload::UnifiedDiff { diff }) = diff_payload else {
+        return Err(FsError::ParityDiffRequired {
+            path: path.to_path_buf(),
+        });
+    };
+
+    apply_unified_diff(content, diff, path).map(|updated| (updated, EditFormat::UnifiedDiff))
 }
 
 /// Shared apply loop behind both [`select_and_apply`] and
@@ -449,16 +504,16 @@ mod tests {
         assert!(matches!(err, FsError::EditNotFound { .. }));
     }
 
-    /// `HarnessMode::Parity` returns the SAME fixed order regardless of
-    /// `model_slug` (#2073) — proves edit-format selection is model-independent
-    /// under Parity, matching every other reconciled layer (prompt assembly,
-    /// tool schemas, compaction).
+    /// `HarnessMode::Parity` returns `[UnifiedDiff, UnifiedDiff, UnifiedDiff]`
+    /// regardless of `model_slug` (#2073, tightened 2026-07-07) — reflects
+    /// that Parity has no real fallback order at all; `model_slug` is
+    /// ignored entirely.
     #[test]
-    fn format_order_for_mode_parity_is_model_independent() {
+    fn format_order_for_mode_parity_is_unified_diff_only() {
         let expected = [
             EditFormat::UnifiedDiff,
-            EditFormat::SearchReplace,
-            EditFormat::WholeFile,
+            EditFormat::UnifiedDiff,
+            EditFormat::UnifiedDiff,
         ];
         for slug in [
             "anthropic/claude-opus-4-5",
@@ -469,7 +524,7 @@ mod tests {
             assert_eq!(
                 format_order_for_mode(HarnessMode::Parity, slug),
                 expected,
-                "Parity order must not vary for {slug}"
+                "Parity must report unified-diff-only for {slug}"
             );
         }
     }
@@ -492,11 +547,12 @@ mod tests {
         }
     }
 
-    /// A flagship model slug (SEARCH/REPLACE-first under DailyDriver) must
-    /// still prefer unified-diff under Parity when both payloads are present
-    /// and the diff applies cleanly (#2073).
+    /// A valid `diff` payload applies cleanly under Parity, even alongside a
+    /// SEARCH/REPLACE payload that would otherwise win under a flagship
+    /// model's DailyDriver order — Parity must use ONLY the diff, never even
+    /// consider the other payload (#2073, tightened 2026-07-07).
     #[test]
-    fn select_and_apply_for_mode_parity_prefers_unified_diff_regardless_of_model() {
+    fn select_and_apply_for_mode_parity_applies_a_valid_diff() {
         let payloads = [
             EditPayload::SearchReplace {
                 old_string: "line2".into(),
@@ -518,23 +574,92 @@ mod tests {
         assert_eq!(updated, "line1\nline2-diffed\n");
     }
 
-    /// Parity still falls back to a present, applicable format when no
-    /// unified-diff payload was supplied at all — Parity must never strand a
-    /// run that only emitted SEARCH/REPLACE or whole-file.
+    /// Parity with NO diff payload supplied — only SEARCH/REPLACE or
+    /// whole-file — must return a recoverable `FsError::ParityDiffRequired`,
+    /// NOT silently fall back and succeed (#2073, tightened 2026-07-07: the
+    /// owner's benchmark-fairness decision — a model that never emitted a
+    /// diff must be scored as failing the edit).
     #[test]
-    fn select_and_apply_for_mode_parity_falls_back_without_a_diff_payload() {
+    fn select_and_apply_for_mode_parity_errors_without_a_diff_payload() {
         let payloads = [EditPayload::WholeFile {
             content: "brand new\n".into(),
         }];
-        let (updated, format) = select_and_apply_for_mode(
+        let err = select_and_apply_for_mode(
             HarnessMode::Parity,
             "anthropic/claude-opus-4-5",
             "old\n",
             Path::new("f.py"),
             &payloads,
         )
-        .expect("whole-file fallback must apply");
+        .expect_err("Parity must reject a run with no diff payload");
+        assert!(
+            matches!(err, FsError::ParityDiffRequired { .. }),
+            "expected ParityDiffRequired, got {err:?}"
+        );
+        assert!(
+            err.to_string()
+                .contains("Parity mode requires a unified-diff edit"),
+            "error message must make the Parity requirement clear: {err}"
+        );
+    }
+
+    /// Parity with a PRESENT but inapplicable diff (bad hunk/context
+    /// mismatch), plus a whole-file payload that WOULD otherwise succeed,
+    /// must still fail — no fallback to the whole-file payload is attempted
+    /// even when the diff itself is the one that failed (#2073, tightened
+    /// 2026-07-07).
+    #[test]
+    fn select_and_apply_for_mode_parity_does_not_fall_back_on_diff_failure() {
+        let payloads = [
+            EditPayload::UnifiedDiff {
+                diff: "@@ -99,1 +99,1 @@\n-nonexistent-line\n+replacement\n".into(),
+            },
+            EditPayload::WholeFile {
+                content: "would-have-worked\n".into(),
+            },
+        ];
+        let err = select_and_apply_for_mode(
+            HarnessMode::Parity,
+            "anthropic/claude-opus-4-5",
+            "line1\nline2\n",
+            Path::new("f.py"),
+            &payloads,
+        )
+        .expect_err("an inapplicable diff must error, not fall back to whole-file");
+        assert!(
+            matches!(
+                err,
+                FsError::DiffContextMismatch { .. } | FsError::DiffHunkHeader { .. }
+            ),
+            "expected a diff-application error (not a fallback success), got {err:?}"
+        );
+    }
+
+    /// `HarnessMode::DailyDriver` still falls back per-model exactly as
+    /// before #2073 tightened Parity — guards against accidentally
+    /// tightening the wrong mode.
+    #[test]
+    fn select_and_apply_for_mode_daily_driver_still_falls_back_per_model() {
+        let payloads = [
+            EditPayload::SearchReplace {
+                old_string: "not-present".into(),
+                new_string: "x".into(),
+            },
+            EditPayload::WholeFile {
+                content: "fallback content\n".into(),
+            },
+        ];
+        // Flagship order is SearchReplace -> UnifiedDiff -> WholeFile; the
+        // non-matching SearchReplace payload must fall through to WholeFile.
+        let (updated, format) = select_and_apply_for_mode(
+            HarnessMode::DailyDriver,
+            "anthropic/claude-opus-4-5",
+            "orig\n",
+            Path::new("f.py"),
+            &payloads,
+        )
+        .expect("DailyDriver must still fall back to whole-file");
         assert_eq!(format, EditFormat::WholeFile);
-        assert_eq!(updated, "brand new\n");
+        assert_eq!(updated, "fallback content\n");
     }
 }

--- a/crates/trusty-code/src/tools/fs/edit_format/mod.rs
+++ b/crates/trusty-code/src/tools/fs/edit_format/mod.rs
@@ -17,7 +17,10 @@
 //! bundles the format-specific arguments recovered from the LLM's tool call;
 //! [`format_order_for`] returns the per-model fallback order; [`select_and_apply`]
 //! tries the caller-supplied payloads in that order against the current file
-//! content and returns the first one that applies cleanly.
+//! content and returns the first one that applies cleanly. [`format_order_for_mode`]
+//! and [`select_and_apply_for_mode`] (#2073) are the `HarnessMode`-aware
+//! variants that reconcile this per-model matrix with vision spec §5.9's
+//! Parity/DailyDriver split (see their own docs).
 //!
 //! ## Per-model format matrix
 //!
@@ -33,7 +36,9 @@
 //! out-performs exact match for that family (per the Aider leaderboard data
 //! referenced in #2068). Weaker/unknown models frequently botch both
 //! precision-dependent formats, so the most forgiving format (whole-file)
-//! leads for the catch-all bucket.
+//! leads for the catch-all bucket. This table is the `HarnessMode::DailyDriver`
+//! behaviour (#2073, §5.9): production, per-model-optimised edit-format
+//! selection. `HarnessMode::Parity` overrides it — see [`format_order_for_mode`].
 //! Test: `tests::format_order_*`, `tests::select_and_apply_*`.
 
 mod diff;
@@ -41,6 +46,7 @@ mod diff;
 use std::path::Path;
 
 use super::FsError;
+use crate::mode::HarnessMode;
 
 pub(crate) use diff::apply_unified_diff;
 
@@ -201,7 +207,79 @@ pub fn select_and_apply(
     path: &Path,
     payloads: &[EditPayload],
 ) -> Result<(String, EditFormat), FsError> {
-    let order = format_order_for(model_slug);
+    apply_in_order(format_order_for(model_slug), content, path, payloads)
+}
+
+/// `HarnessMode`-aware fallback order for edit-format application (#2073,
+/// §5.9's reconciliation table).
+///
+/// Why: The parity spec's benchmark-fairness goal (D2) extends to the edit
+/// layer: §5.9's table lists Parity's edit-format column as "unified-diff
+/// only", in contrast to DailyDriver's "per-model optimized". The literal
+/// reading ("reject every other format outright") would strand a Parity run
+/// against any model that cannot reliably emit a diff, which defeats
+/// "benchmark fairness" more than it serves it — so this applies the
+/// spec's INTENT (edit-format choice must not vary by model in Parity) by
+/// returning a FIXED, model-independent order with unified-diff leading,
+/// rather than hard-rejecting the other two formats. A caller wanting the
+/// stricter literal reading can inspect the returned `EditFormat` and treat
+/// anything but `UnifiedDiff` as a policy violation; `select_and_apply_for_mode`
+/// itself still falls back so a Parity run can always complete an edit.
+/// What: `HarnessMode::Parity` ignores `model_slug` and always returns
+/// `[UnifiedDiff, SearchReplace, WholeFile]`. `HarnessMode::DailyDriver`
+/// delegates to [`format_order_for`] unchanged (the existing per-model
+/// matrix, #2068).
+/// Test: `tests::format_order_for_mode_parity_is_model_independent`,
+/// `tests::format_order_for_mode_daily_driver_matches_legacy_order`.
+pub fn format_order_for_mode(mode: HarnessMode, model_slug: &str) -> [EditFormat; 3] {
+    match mode {
+        HarnessMode::Parity => [
+            EditFormat::UnifiedDiff,
+            EditFormat::SearchReplace,
+            EditFormat::WholeFile,
+        ],
+        HarnessMode::DailyDriver => format_order_for(model_slug),
+    }
+}
+
+/// `HarnessMode`-aware [`select_and_apply`] (#2073).
+///
+/// Why: The single call site (`EditTool::edit_inner`) that needs to pick
+/// between the plain per-model order and the Parity-fixed order without
+/// duplicating the apply loop.
+/// What: Computes the order via [`format_order_for_mode`], then applies it
+/// exactly as [`select_and_apply`] does.
+/// Test: `tests::select_and_apply_for_mode_parity_prefers_unified_diff_regardless_of_model`.
+pub fn select_and_apply_for_mode(
+    mode: HarnessMode,
+    model_slug: &str,
+    content: &str,
+    path: &Path,
+    payloads: &[EditPayload],
+) -> Result<(String, EditFormat), FsError> {
+    apply_in_order(
+        format_order_for_mode(mode, model_slug),
+        content,
+        path,
+        payloads,
+    )
+}
+
+/// Shared apply loop behind both [`select_and_apply`] and
+/// [`select_and_apply_for_mode`].
+///
+/// Why: Both public entry points differ only in how they compute the
+/// preference order; centralising the loop keeps that the ONLY difference.
+/// What: Tries each format in `order`, applying the first present payload
+/// that succeeds; returns the last error if none apply, or `EditNotFound` if
+/// `payloads` never contained any of `order`'s formats.
+/// Test: Exercised transitively by every `select_and_apply*` test.
+fn apply_in_order(
+    order: [EditFormat; 3],
+    content: &str,
+    path: &Path,
+    payloads: &[EditPayload],
+) -> Result<(String, EditFormat), FsError> {
     let mut last_err: Option<FsError> = None;
 
     for format in order {
@@ -369,5 +447,94 @@ mod tests {
         let err = select_and_apply("claude-opus", "content", Path::new("f.py"), &[])
             .expect_err("no payloads must error");
         assert!(matches!(err, FsError::EditNotFound { .. }));
+    }
+
+    /// `HarnessMode::Parity` returns the SAME fixed order regardless of
+    /// `model_slug` (#2073) — proves edit-format selection is model-independent
+    /// under Parity, matching every other reconciled layer (prompt assembly,
+    /// tool schemas, compaction).
+    #[test]
+    fn format_order_for_mode_parity_is_model_independent() {
+        let expected = [
+            EditFormat::UnifiedDiff,
+            EditFormat::SearchReplace,
+            EditFormat::WholeFile,
+        ];
+        for slug in [
+            "anthropic/claude-opus-4-5",
+            "qwen/qwen-2.5-72b-instruct",
+            "google/gemma-2-9b-it",
+            "",
+        ] {
+            assert_eq!(
+                format_order_for_mode(HarnessMode::Parity, slug),
+                expected,
+                "Parity order must not vary for {slug}"
+            );
+        }
+    }
+
+    /// `HarnessMode::DailyDriver` delegates verbatim to the pre-#2073
+    /// per-model matrix (#2068) — no behavioural change for the production
+    /// default.
+    #[test]
+    fn format_order_for_mode_daily_driver_matches_legacy_order() {
+        for slug in [
+            "anthropic/claude-opus-4-5",
+            "qwen/qwen-2.5-72b-instruct",
+            "google/gemma-2-9b-it",
+        ] {
+            assert_eq!(
+                format_order_for_mode(HarnessMode::DailyDriver, slug),
+                format_order_for(slug),
+                "DailyDriver order must match the legacy per-model matrix for {slug}"
+            );
+        }
+    }
+
+    /// A flagship model slug (SEARCH/REPLACE-first under DailyDriver) must
+    /// still prefer unified-diff under Parity when both payloads are present
+    /// and the diff applies cleanly (#2073).
+    #[test]
+    fn select_and_apply_for_mode_parity_prefers_unified_diff_regardless_of_model() {
+        let payloads = [
+            EditPayload::SearchReplace {
+                old_string: "line2".into(),
+                new_string: "replaced".into(),
+            },
+            EditPayload::UnifiedDiff {
+                diff: "@@ -2,1 +2,1 @@\n-line2\n+line2-diffed\n".into(),
+            },
+        ];
+        let (updated, format) = select_and_apply_for_mode(
+            HarnessMode::Parity,
+            "anthropic/claude-opus-4-5",
+            "line1\nline2\n",
+            Path::new("f.py"),
+            &payloads,
+        )
+        .expect("unified diff must apply");
+        assert_eq!(format, EditFormat::UnifiedDiff);
+        assert_eq!(updated, "line1\nline2-diffed\n");
+    }
+
+    /// Parity still falls back to a present, applicable format when no
+    /// unified-diff payload was supplied at all — Parity must never strand a
+    /// run that only emitted SEARCH/REPLACE or whole-file.
+    #[test]
+    fn select_and_apply_for_mode_parity_falls_back_without_a_diff_payload() {
+        let payloads = [EditPayload::WholeFile {
+            content: "brand new\n".into(),
+        }];
+        let (updated, format) = select_and_apply_for_mode(
+            HarnessMode::Parity,
+            "anthropic/claude-opus-4-5",
+            "old\n",
+            Path::new("f.py"),
+            &payloads,
+        )
+        .expect("whole-file fallback must apply");
+        assert_eq!(format, EditFormat::WholeFile);
+        assert_eq!(updated, "brand new\n");
     }
 }

--- a/crates/trusty-code/src/tools/fs/mod.rs
+++ b/crates/trusty-code/src/tools/fs/mod.rs
@@ -57,6 +57,15 @@ pub enum FsError {
     #[error("edit: old_string is ambiguous ({count} matches) in {path}")]
     EditAmbiguous { path: PathBuf, count: usize },
 
+    /// `HarnessMode::Parity` (#2073) requires a `diff` payload and none was
+    /// supplied — SEARCH/REPLACE and whole-file payloads are ignored under
+    /// Parity, never used as a fallback.
+    #[error(
+        "edit: Parity mode requires a unified-diff edit (provide 'diff'); \
+         SEARCH/REPLACE and whole-file are not accepted under Parity for {path}"
+    )]
+    ParityDiffRequired { path: PathBuf },
+
     /// A `unified_diff` edit's hunk header (`@@ -l,s +l,s @@`) could not be parsed.
     #[error("edit: invalid unified diff: {reason}")]
     DiffHunkHeader { reason: String },


### PR DESCRIPTION
M2 (Tool Calling) P1B-6 — the integration ticket that makes the P1B efficiency layers coherent under the HarnessMode seam and validates parity. DailyDriver enables all token-efficiency layers (progressive skill disclosure #2069, context compaction #2070, per-model edit-format selection #2068); Parity/Benchmark mode disables them for model-independent, byte-identical assembly.

Closes the two real gaps: (1) edit-format now branches on mode — Parity is STRICT unified-diff-only (per spec §5.9): a missing/failed diff returns the recoverable `FsError::ParityDiffRequired` and does NOT fall back to SEARCH/REPLACE or whole-file even when such a payload would succeed (so a model that can't diff-edit is scored as failing, preserving benchmark integrity for M3); DailyDriver keeps the per-model matrix with full fallback. (2) An integration-level parity conformance test (`parity_mode_message_sequences_are_model_independent`) runs two full AgentLoop executions differing only in model and asserts byte-identical request sequences.

QA: APPROVE (two independent passes — mode-assembly at 2e996e01, strict-diff-only tightening at 7913c3a2). Build 0 warnings, 609 lib + 18 e2e tests pass, clippy clean, fmt clean, line-cap 0 violations, trusty-agents unaffected. No-fallback-even-with-valid-alternative confirmed by test; recoverable error path (no panic/unwrap); DailyDriver untouched.

Note: the strict diff-only Parity edit-format is an explicit owner decision matching vision-spec §5.9 "unified-diff only".

Closes #2073