### PR TITLE
fix(trusty-search): prevent reindex from hijacking to a non-persisted root and pruning the corpus

### DIFF
--- a/crates/trusty-search/src/service/reindex/mod.rs
+++ b/crates/trusty-search/src/service/reindex/mod.rs
@@ -30,6 +30,9 @@
 //! - `staging`     — decide whether to stage the rebuilt corpus.
 //! - `validate`    — `ReindexOutcome`, `canonical_walk_root`, path-relativization.
 //! - `tests`       — integration / unit tests (test-file cap: 1 500 SLOC).
+//! - `root_hijack_tests` — issue #2178 P0 data-risk regression tests (a
+//!   detected root move must be validated against persisted `indexes.toml`
+//!   config before the corpus can be walked/pruned against it).
 //!
 //! Test: see `tests.rs`; the primary coverage is
 //! `reindex_walks_directory_and_emits_events`.
@@ -114,3 +117,7 @@ pub(crate) use tokio::sync::Semaphore;
 // ── test module ──────────────────────────────────────────────────────────────
 #[cfg(test)]
 mod tests;
+// Issue #2178: isolated from `tests.rs` to keep it under the 1500-SLOC
+// test-file cap; see the module doc comment there for the incident writeup.
+#[cfg(test)]
+mod root_hijack_tests;

--- a/crates/trusty-search/src/service/reindex/root_hijack_tests.rs
+++ b/crates/trusty-search/src/service/reindex/root_hijack_tests.rs
@@ -1,0 +1,265 @@
+//! Issue #2178 (P0 data-risk) regression tests.
+//!
+//! Why: isolated from `tests.rs` to keep that file under the 1500-SLOC
+//! test-file cap while giving the incident regression its own focused,
+//! self-contained coverage. A live daemon ran `reindex -i cto`; the #402/
+//! #1073 "colocated root moved" heuristic decided `cto`'s root had moved
+//! from its real, persisted location to an unrelated git worktree that
+//! merely happened to also have colocated `.trusty-search/` storage. The
+//! daemon walked the unrelated worktree (2,506 files) and the post-loop
+//! prune pass then deleted every one of the real corpus's 369,568 chunks
+//! that weren't seen in that walk. See `validate::root_move_is_trusted` for
+//! the full root-cause writeup.
+//!
+//! What: drives `spawn_reindex` end-to-end against a real, durable
+//! `CorpusStore` pre-seeded with chunks, reproducing the exact divergence
+//! that triggered the incident (in-memory `IndexHandle::root_path` disagrees
+//! with both the corpus's own persisted `indexed_root` and the durably
+//! persisted `indexes.toml` entry), and proves the corpus survives. A second
+//! test proves the legitimate #402/#1073 relocation case — where the
+//! candidate root DOES match the persisted `indexes.toml` entry (mirroring
+//! `POST /indexes/:id/relocate`, which persists before swapping the handle)
+//! — still completes normally.
+//!
+//! Test: `reindex_refuses_untrusted_root_move_and_preserves_corpus` (the core
+//! #2178 regression) and `reindex_accepts_root_move_that_matches_persisted_config`
+//! (the surviving legitimate-move case).
+
+use super::*;
+use crate::core::chunker::{ChunkType, RawChunk};
+use crate::core::corpus::CorpusStore;
+use crate::core::indexer::CodeIndexer;
+use crate::core::registry::{IndexHandle, IndexId};
+use crate::service::persistence::PersistedIndex;
+use serial_test::serial;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+/// Minimal `RawChunk` fixture — mirrors the helper duplicated across
+/// `tests.rs` / `prune_tests.rs`.
+fn chunk(file: &str, id: &str) -> RawChunk {
+    RawChunk {
+        id: id.to_string(),
+        file: file.to_string(),
+        start_line: 1,
+        end_line: 1,
+        content: format!("fn {id}() {{}}"),
+        function_name: None,
+        language: Some("rust".to_string()),
+        chunk_type: ChunkType::Code,
+        calls: Vec::new(),
+        inherits_from: Vec::new(),
+        chunk_depth: 0,
+        parent_chunk_id: None,
+        child_chunk_ids: Vec::new(),
+        nlp_keywords: Vec::new(),
+        nlp_code_refs: Vec::new(),
+        virtual_terms: Vec::new(),
+    }
+}
+
+/// Wait up to 5s for `progress` to reach a terminal status.
+async fn wait_for_terminal(progress: &ReindexProgress) {
+    for _ in 0..100 {
+        let status = progress.status.load();
+        if status == ReindexStatus::Failed || status == ReindexStatus::Complete {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+/// THE core #2178 regression: an in-memory handle whose `root_path` diverges
+/// from both the corpus's own persisted `indexed_root` AND the durably
+/// persisted `indexes.toml` `root_path` must NEVER be trusted enough to walk
+/// (or, on the next incremental reindex, prune) the real corpus — even
+/// though the candidate root has its own colocated `.trusty-search/`
+/// storage, exactly as in the live incident.
+///
+/// Why: this is the direct incident reproduction. Before the fix, the old
+/// heuristic accepted the candidate purely because
+/// `has_colocated_storage(candidate)` was `true` — a signal that is
+/// trivially satisfied by ANY colocated project, not just the correct one.
+/// What: seeds a real `CorpusStore` with 50 chunks (standing in for the
+/// incident's 369,568), stamps the corpus's `indexed_root` at the REAL root
+/// (A), persists `indexes.toml`'s `root_path` at A too, then constructs an
+/// `IndexHandle` whose in-memory `root_path` is an UNRELATED root (B) — the
+/// exact shape of the `POST /indexes/:id/reindex` `root_path` override
+/// (issue #63) landing without ever updating `indexes.toml`. Asserts the
+/// reindex is refused (status `Failed`), the walk never ran
+/// (`total_files == 0`), and — the data-safety proof — all 50 original
+/// chunks are still present in the corpus afterward.
+/// Test: this test.
+#[tokio::test]
+#[serial]
+async fn reindex_refuses_untrusted_root_move_and_preserves_corpus() {
+    // Isolate `indexes.toml` so this test's persisted config can't collide
+    // with other tests or the developer's real data dir. `#[serial]` is
+    // required because `TRUSTY_DATA_DIR` is shared process (env) state.
+    let data_dir = tempfile::tempdir().expect("data dir");
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+
+    // root_a: the index's REAL, persisted root (simulates
+    // `/Users/masa/Duetto/cto`).
+    let root_a = tempfile::tempdir().expect("root a");
+    // root_b: an unrelated directory the in-memory handle gets hijacked to
+    // (simulates the unrelated trusty-tools git worktree from the
+    // incident). It even carries its own colocated `.trusty-search/` dir,
+    // exactly like the incident (this very workspace self-indexes) —
+    // proving the old #402 "has colocated storage" signal alone is not
+    // sufficient legitimacy proof.
+    let root_b = tempfile::tempdir().expect("root b");
+    std::fs::create_dir_all(root_b.path().join(".trusty-search")).unwrap();
+
+    let id = IndexId::new("cto-2178-hijack-sim");
+
+    // Seed a real durable corpus with chunks — stands in for the incident's
+    // 369,568-chunk `cto` corpus.
+    let redb_path = data_dir.path().join("cto_corpus.redb");
+    let corpus = Arc::new(CorpusStore::open(&redb_path).expect("open corpus"));
+    let seed_chunks: Vec<RawChunk> = (0..50)
+        .map(|i| chunk("real/file.rs", &format!("real:{i}")))
+        .collect();
+    corpus.upsert_chunks(&seed_chunks).expect("seed chunks");
+    assert_eq!(
+        corpus.load_all_chunks().unwrap().len(),
+        50,
+        "test setup: corpus must start with 50 chunks"
+    );
+
+    let mut indexer = CodeIndexer::new(id.0.clone(), root_b.path().to_path_buf());
+    indexer.set_corpus_store(Arc::clone(&corpus));
+    let handle = Arc::new(IndexHandle::bare(
+        id.clone(),
+        Arc::new(tokio::sync::RwLock::new(indexer)),
+        root_b.path().to_path_buf(), // HIJACKED in-memory root.
+    ));
+
+    // Stamp the corpus's own `indexed_root` = root_a — what a prior,
+    // legitimate reindex against the real root would have written.
+    handle
+        .write_indexed_root(root_a.path())
+        .await
+        .expect("stamp prior indexed_root");
+
+    // Persist `indexes.toml`'s `root_path` = root_a — the durable source of
+    // truth. The in-memory handle above disagrees (root_b): exactly the
+    // #2178 divergence (an unpersisted `root_path` override, or any other
+    // path by which the in-memory handle drifted from disk).
+    crate::service::persistence::upsert_index_registry_entry(PersistedIndex {
+        id: id.0.clone(),
+        root_path: root_a.path().to_path_buf(),
+        ..Default::default()
+    })
+    .expect("persist indexes.toml entry");
+
+    let progress = Arc::new(ReindexProgress::new());
+    spawn_reindex(handle.clone(), progress.clone(), false);
+    wait_for_terminal(&progress).await;
+
+    assert_eq!(
+        progress.status.load(),
+        ReindexStatus::Failed,
+        "an untrusted root move (in-memory root disagrees with the \
+         persisted indexes.toml root_path) must abort the reindex, not \
+         silently walk/prune against the hijacked root"
+    );
+
+    // The gate must fire BEFORE Phase 1 — no walk was performed against the
+    // untrusted candidate root.
+    assert_eq!(
+        progress.total_files.load(Ordering::Acquire),
+        0,
+        "the #2178 gate must fire before the walk starts"
+    );
+
+    // THE core #2178 assertion: the corpus's original chunks must survive
+    // completely untouched — no prune pass ever ran.
+    let surviving = corpus.load_all_chunks().expect("read corpus after abort");
+    assert_eq!(
+        surviving.len(),
+        50,
+        "#2178 regression: the real corpus's chunks must survive a refused \
+         reindex against an untrusted root; found {} (a lower count means \
+         the corpus was wrongly pruned)",
+        surviving.len()
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// The surviving legitimate case: a root move whose candidate root DOES
+/// match the durably persisted `indexes.toml` entry (mirroring `POST
+/// /indexes/:id/relocate`, which persists the new `root_path` BEFORE the
+/// handle is swapped) must still be trusted — the #402/#1073 colocated
+/// relocation behaviour keeps working.
+///
+/// Why: proves the #2178 fix narrows the auto-detected-move convenience
+/// without breaking the one path that is actually safe: an operator-driven,
+/// durably-persisted relocation.
+/// What: same shape as the hijack test, except `indexes.toml`'s
+/// `root_path` is set to the NEW root (matching the in-memory handle), and
+/// the new root has one real file to index. Asserts the reindex completes
+/// normally and the walk ran.
+/// Test: this test.
+#[tokio::test]
+#[serial]
+async fn reindex_accepts_root_move_that_matches_persisted_config() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+
+    let old_root = tempfile::tempdir().expect("old root");
+    let new_root = tempfile::tempdir().expect("new root");
+    std::fs::write(new_root.path().join("keep.rs"), "fn keep() {}\n").unwrap();
+    // Colocated storage marker at the new root (mirrors a genuine `mv` of a
+    // colocated project).
+    std::fs::create_dir_all(new_root.path().join(".trusty-search")).unwrap();
+
+    let id = IndexId::new("legit-move-2178-sim");
+
+    let redb_path = data_dir.path().join("legit_corpus.redb");
+    let corpus = Arc::new(CorpusStore::open(&redb_path).expect("open corpus"));
+
+    let mut indexer = CodeIndexer::new(id.0.clone(), new_root.path().to_path_buf());
+    indexer.set_corpus_store(Arc::clone(&corpus));
+    let handle = Arc::new(IndexHandle::bare(
+        id.clone(),
+        Arc::new(tokio::sync::RwLock::new(indexer)),
+        new_root.path().to_path_buf(),
+    ));
+
+    // The corpus remembers the OLD root — a genuine prior reindex happened
+    // there before the project was relocated.
+    handle
+        .write_indexed_root(old_root.path())
+        .await
+        .expect("stamp prior indexed_root");
+
+    // The relocate flow persists `indexes.toml`'s `root_path` to the NEW
+    // root BEFORE the handle is swapped (mirrors `indexes_relocate.rs`).
+    crate::service::persistence::upsert_index_registry_entry(PersistedIndex {
+        id: id.0.clone(),
+        root_path: new_root.path().to_path_buf(),
+        ..Default::default()
+    })
+    .expect("persist indexes.toml entry");
+
+    let progress = Arc::new(ReindexProgress::new());
+    spawn_reindex(handle.clone(), progress.clone(), false);
+    wait_for_terminal(&progress).await;
+
+    assert_eq!(
+        progress.status.load(),
+        ReindexStatus::Complete,
+        "a root move that matches the persisted indexes.toml root_path must \
+         still be trusted — the #402/#1073 legitimate relocation case must \
+         keep working"
+    );
+    assert_eq!(
+        progress.total_files.load(Ordering::Acquire),
+        1,
+        "the trusted move must proceed to walk the new root normally"
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}

--- a/crates/trusty-search/src/service/reindex/runner.rs
+++ b/crates/trusty-search/src/service/reindex/runner.rs
@@ -89,6 +89,73 @@ pub(super) async fn run_reindex(
     let canonical_root = validate::canonical_walk_root(&root);
     let index_id: IndexId = handle.id.clone();
 
+    // Issue #602/#1073: detect a root move against the corpus's own
+    // persisted `indexed_root` (read from the redb `_meta` table, i.e. the
+    // root the CURRENT corpus's chunk paths are actually relative to).
+    let prior_indexed_root = handle.read_indexed_root().await.unwrap_or(None);
+    let root_moved =
+        validate::needs_path_relativization(prior_indexed_root.as_deref(), &canonical_root);
+
+    // Issue #2178 (P0 data-risk): before trusting ANY detected root move
+    // enough to walk — and, later, prune — the corpus against it, cross-check
+    // the candidate against the durably persisted `indexes.toml` entry for
+    // this index. See `validate::root_move_is_trusted` for the full incident
+    // writeup: the #402/#1073 heuristic below only checked whether the
+    // candidate root merely *had* colocated storage, not whether it was
+    // *this index's* actual registered root, and `POST /indexes/:id/reindex`
+    // can silently repoint the in-memory handle's `root_path` (issue #63)
+    // without ever touching `indexes.toml`. This gate runs BEFORE Phase 1
+    // (the walk) even starts, so an untrusted candidate never touches the
+    // filesystem walk or the finish-phase prune pass — the existing corpus is
+    // left completely untouched.
+    if root_moved {
+        let persisted_root = crate::service::persistence::load_index_registry()
+            .ok()
+            .and_then(|entries| entries.into_iter().find(|e| e.id == index_id.0))
+            .map(|e| e.root_path);
+        if !validate::root_move_is_trusted(persisted_root.as_deref(), &canonical_root) {
+            tracing::warn!(
+                "reindex[{}]: REFUSING untrusted root move — in-memory root is \
+                 {} but the corpus's last-indexed root is {:?} and the persisted \
+                 indexes.toml root_path is {:?}; these disagree, which is exactly \
+                 the #2178 root-hijack signature (an unpersisted root_path \
+                 override or a stale in-memory handle), not a legitimate \
+                 relocation. Aborting before any walk/prune — the existing \
+                 corpus is untouched. Use POST /indexes/:id/relocate for an \
+                 explicit, durable move.",
+                index_id.0,
+                canonical_root.display(),
+                prior_indexed_root,
+                persisted_root,
+            );
+            let reason = format!(
+                "reindex aborted: candidate root {} does not match this index's \
+                 persisted indexes.toml root_path — refusing to walk/prune \
+                 against an unvalidated root to protect the existing corpus \
+                 (issue #2178); use POST /indexes/:id/relocate for an explicit move",
+                canonical_root.display(),
+            );
+            mark_reindex_failed(&handle, &reason).await;
+            progress.status.store(ReindexStatus::Failed);
+            progress
+                .push(serde_json::json!({
+                    "event": "error",
+                    "index_id": index_id.0,
+                    "message": reason,
+                    "fatal": true,
+                }))
+                .await;
+            // term_guard drops here → broadcasts error event via Drop (mirrors
+            // the carryover-copy-failure abort path below).
+            drop(term_guard);
+            schedule_progress_cleanup(cleanup_map, cleanup_id);
+            if let Some(ref q) = quarantine {
+                q.record_failure(&index_id);
+            }
+            return;
+        }
+    }
+
     // Issue #109, Phase 1: reset the staged-pipeline status surface.
     super::stages::reset_stages_for_reindex(&handle).await;
 
@@ -126,17 +193,15 @@ pub(super) async fn run_reindex(
     // Issues #840 / #662: load the persisted hash cache BEFORE emitting
     // the `start` event so `hashes_loaded` is available for the event payload.
     let hashes: FileHashes = hashes_for(&index_id);
-    // Issue #602: detect a root move against the corpus's persisted
-    // `indexed_root` and, for legacy (non-colocated) indexes, clear the
-    // hash cache so every file is re-written relative to the new canonical root.
+    // Issue #602: `root_moved` (computed above, before the walk, and gated by
+    // the #2178 trust check) decides, for legacy (non-colocated) indexes,
+    // whether to clear the hash cache so every file is re-written relative to
+    // the new canonical root.
     //
     // Issue #1073: for colocated indexes the chunk and hash keys are
     // ROOT-RELATIVE (#402), so they are valid at any root location — a pure
     // move changes the root prefix only. Do NOT clear the hash cache on a
     // root move for colocated indexes.
-    let prior_indexed_root = handle.read_indexed_root().await.unwrap_or(None);
-    let root_moved =
-        validate::needs_path_relativization(prior_indexed_root.as_deref(), &canonical_root);
     let is_colocated = crate::service::colocated_storage::has_colocated_storage(&canonical_root);
     let hashes_loaded: usize = if force {
         hashes.clear();

--- a/crates/trusty-search/src/service/reindex/validate.rs
+++ b/crates/trusty-search/src/service/reindex/validate.rs
@@ -10,15 +10,17 @@
 //! counters and paths. Extracting them here makes each decision independently
 //! testable and keeps the monolith from growing.
 //!
-//! What: three pure helpers —
+//! What: four pure helpers —
 //! - [`reindex_outcome`] decides Ready vs. Failed from the vector/file counters
 //!   (the #601 non-empty gate), honouring the lexical-only exception.
 //! - [`canonical_walk_root`] canonicalizes a root exactly as the walker does so
 //!   `strip_prefix` reliably yields root-relative (portable) chunk paths (#602).
 //! - [`needs_path_relativization`] decides whether a root change between reindex
 //!   runs should re-trigger path relativization (#602).
+//! - [`root_move_is_trusted`] decides whether a detected root move is backed by
+//!   durable, persisted config before the caller may walk/prune against it (#2178).
 //!
-//! Test: `super::validate::tests` covers every branch of all three.
+//! Test: `super::validate::tests` covers every branch of all four.
 
 use std::path::{Path, PathBuf};
 
@@ -185,6 +187,45 @@ pub(crate) fn needs_path_relativization(previous_root: Option<&Path>, current_ro
         return false;
     };
     canonical_walk_root(prev) != canonical_walk_root(current_root)
+}
+
+/// Decide whether a detected root move is safe to walk/prune against (#2178).
+///
+/// Why: incident #2178 — a live daemon ran `reindex -i cto`, and the #402/#1073
+/// "colocated root moved" heuristic (see [`needs_path_relativization`]) decided
+/// `cto`'s root had moved from its real, persisted location to an unrelated git
+/// worktree that merely happened to also have colocated `.trusty-search/`
+/// storage (this very workspace self-indexes). The heuristic's only legitimacy
+/// check was `has_colocated_storage(candidate)` — trivially satisfied by ANY
+/// colocated project, not just the right one. The daemon walked the unrelated
+/// worktree (2,506 files) and the post-loop prune pass then deleted every one
+/// of the real corpus's 369,568 chunks that weren't seen in that walk. The
+/// root cause: `POST /indexes/:id/reindex` accepts a caller-supplied
+/// `root_path` override (issue #63) that is swapped into the in-memory
+/// registry entry but is **never** written to `indexes.toml` — so the
+/// in-memory `IndexHandle::root_path` can silently diverge from the durably
+/// persisted source of truth, and the old heuristic trusted the in-memory
+/// value unconditionally.
+///
+/// What: returns `true` iff the candidate root should be trusted enough to
+/// walk and (eventually) prune the corpus against — either there is no
+/// persisted `indexes.toml` entry for this index at all (a fresh or
+/// test-only index has nothing durable to validate against, so the existing
+/// in-memory value is trusted by default), or the candidate's canonical form
+/// matches the persisted entry's canonical `root_path`. Returns `false` when
+/// a persisted entry exists and disagrees — the caller MUST refuse to
+/// walk/prune against the candidate in that case (abort with a clear error
+/// rather than silently reindexing/pruning the wrong tree). This intentionally
+/// narrows the #402/#1073 auto-detected-move convenience: an operator-driven
+/// relocation must go through `POST /indexes/:id/relocate`, which persists the
+/// new `root_path` to `indexes.toml` BEFORE the handle is swapped, so it
+/// always passes this check.
+/// Test: `root_move_is_trusted_*` below.
+pub(crate) fn root_move_is_trusted(persisted_root: Option<&Path>, candidate_root: &Path) -> bool {
+    let Some(persisted) = persisted_root else {
+        return true;
+    };
+    canonical_walk_root(persisted) == canonical_walk_root(candidate_root)
 }
 
 #[cfg(test)]
@@ -404,5 +445,55 @@ mod tests {
         std::os::unix::fs::symlink(&real, &link).unwrap();
         // prev = symlink alias, current = real target → same canonical root.
         assert!(!needs_path_relativization(Some(&link), &real));
+    }
+
+    /// Why: a fresh/test index has no persisted `indexes.toml` entry to check
+    /// against — nothing to validate, so the existing in-memory root is
+    /// trusted by default (must not regress indexes that never persist).
+    /// Test: this test.
+    #[test]
+    fn root_move_is_trusted_no_persisted_entry_is_trusted() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(root_move_is_trusted(None, tmp.path()));
+    }
+
+    /// Why: the legitimate case — the candidate root IS the persisted
+    /// `indexes.toml` root_path (e.g. after `POST /indexes/:id/relocate`,
+    /// which persists before swapping the handle). Must be trusted.
+    /// Test: this test.
+    #[test]
+    fn root_move_is_trusted_matches_persisted_is_trusted() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(root_move_is_trusted(Some(tmp.path()), tmp.path()));
+    }
+
+    /// Why: the #2178 incident — the in-memory candidate root diverges from
+    /// the persisted `indexes.toml` root_path (e.g. an unpersisted `root_path`
+    /// override on `POST /indexes/:id/reindex`, or a CWD-derived accident).
+    /// Must NOT be trusted — this is exactly the corpus-wipe trigger.
+    /// Test: this test.
+    #[test]
+    fn root_move_is_trusted_diverges_from_persisted_is_untrusted() {
+        let real_root = tempfile::tempdir().expect("tempdir a");
+        let hijacked_root = tempfile::tempdir().expect("tempdir b");
+        assert!(!root_move_is_trusted(
+            Some(real_root.path()),
+            hijacked_root.path()
+        ));
+    }
+
+    /// Why: a pure symlink-alias against the persisted root (same real target)
+    /// must not be treated as a divergence — canonicalization collapses both
+    /// sides.
+    /// Test: this test.
+    #[cfg(unix)]
+    #[test]
+    fn root_move_is_trusted_symlink_alias_of_persisted_is_trusted() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real = tmp.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        assert!(root_move_is_trusted(Some(&real), &link));
     }
 }


### PR DESCRIPTION
## Summary

Closes #2178 (P0 data-risk). A live incident: `reindex -i cto` ran while an
unrelated trusty-tools git worktree session was active. The `#402`/`#1073`
"colocated root moved" heuristic in the reindex runner decided `cto`'s root
had moved from its real, persisted location (`/Users/masa/Duetto/cto`) to
that unrelated worktree, walked it (2,506 files), and the post-loop prune
pass then deleted every one of the real corpus's 369,568 chunks that
weren't seen in that walk. The corpus survived only because the atomic
swap happened to fail; data loss was avoided by luck, not by design.

### What triggered the misfire (root cause)

`crates/trusty-search/src/service/reindex/runner.rs`'s root-moved detection
(`validate::needs_path_relativization`) compares the corpus's own
persisted `indexed_root` (from the redb `_meta` table) against the
**in-memory** `IndexHandle.root_path`. The only legitimacy check for
accepting a "move" was `has_colocated_storage(candidate)` — does the
candidate directory merely *have* a `.trusty-search/` dir? That signal is
trivially satisfied by **any** colocated project, not just the correct one
(this very workspace self-indexes, so any worktree of it qualifies).

The in-memory root diverged from durable truth because:
- `POST /indexes/:id/reindex` accepts a caller-supplied `root_path`
  override (issue #63,
  `crates/trusty-search/src/service/server/reindex_handlers.rs`) that is
  swapped into the in-memory registry entry via `registry.register()` —
  which is **purely in-memory** and never writes `indexes.toml`.
- The CLI's bare `reindex` command
  (`crates/trusty-search/src/commands/reindex.rs::handle_reindex`) always
  computes its `root_path` override from `detect_project(cwd)` when no
  explicit `--path` is given — **regardless of which index was targeted by
  `-i`** — and `run_reindex_with` unconditionally sends that as
  `root_path` in the reindex kickoff body
  (`crates/trusty-search/src/commands/reindex_engine/driver.rs`).

So `reindex -i cto` from inside an unrelated worktree silently repoints
`cto`'s in-memory `root_path` at the worktree, and `indexes.toml` never
finds out. This CLI-level chain is documented in the PR/commit for
context but is **not** touched by this fix (deliberately, to stay inside
the assigned scope: `runner.rs` and nearby reindex-module files, not
`registry.rs` / `lazy_loader/` / `tickers.rs`, which a concurrent PR
(#2161) is modifying).

### The invariant enforced (core fix)

`crates/trusty-search/src/service/reindex/validate.rs` gets a new pure
decision function, `root_move_is_trusted(persisted_root, candidate_root)`:
trusts a move iff there is no persisted `indexes.toml` entry to check
against (fresh/test index — nothing durable to validate) or the
candidate's canonical form matches the persisted entry's canonical
`root_path` exactly.

`crates/trusty-search/src/service/reindex/runner.rs::run_reindex` now
computes `root_moved` **before** Phase 1 (the walk) even starts, and — if
`root_moved` is true — loads the current `indexes.toml` registry and
cross-checks the candidate against it via `root_move_is_trusted`. An
untrusted candidate aborts the reindex immediately: `mark_reindex_failed`,
an `error` SSE event, `ReindexStatus::Failed`, and the termination guard
disarmed via `Drop` — mirroring the existing "carryover copy failed" abort
pattern already in this function. **No walk, no prune, no corpus swap** —
the existing corpus is left completely untouched. A clear WARN log points
operators at `POST /indexes/:id/relocate` for an explicit, durable move.

### Legit #402/#1073 behaviour preserved

`POST /indexes/:id/relocate`
(`crates/trusty-search/src/service/server/indexes_relocate.rs`) already
persists the new `root_path` to `indexes.toml` **before** swapping the
handle. Under the new invariant this move is always trusted, so the
genuine "a colocated project relocated on disk" case keeps working exactly
as before — verified by a dedicated regression test.

## Changes

- `crates/trusty-search/src/service/reindex/validate.rs` — new pure
  `root_move_is_trusted` + 4 unit tests.
- `crates/trusty-search/src/service/reindex/runner.rs` — the safety gate:
  moved `prior_indexed_root`/`root_moved` computation before Phase 1,
  added the persisted-config cross-check and abort path.
- `crates/trusty-search/src/service/reindex/mod.rs` — wire in the new test
  module.
- `crates/trusty-search/src/service/reindex/root_hijack_tests.rs` (new) —
  end-to-end regression tests driving `spawn_reindex` against a real,
  durable `CorpusStore`.

## Regression tests

- `reindex_refuses_untrusted_root_move_and_preserves_corpus` — reproduces
  the incident: a 50-chunk durable corpus with persisted `indexes.toml`
  `root_path = A`, an in-memory handle whose `root_path = B` (an unrelated
  directory that also has colocated `.trusty-search/` storage, exactly
  like the incident). Asserts the reindex is refused (`Failed`), the walk
  never ran (`total_files == 0`), and **all 50 chunks survive** in the
  corpus afterward.
- `reindex_accepts_root_move_that_matches_persisted_config` — the
  surviving legitimate case: candidate root matches the persisted
  `indexes.toml` entry (mirrors `relocate`). Asserts the reindex completes
  normally and the walk ran.

## Quality gate (raw output)

```
$ cargo build --workspace
   ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 38s

$ cargo test -p trusty-search --lib root_hijack -- --nocapture
running 2 tests
test service::reindex::root_hijack_tests::reindex_refuses_untrusted_root_move_and_preserves_corpus ... ok
test service::reindex::root_hijack_tests::reindex_accepts_root_move_that_matches_persisted_config ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 998 filtered out; finished in 1.29s

$ cargo test -p trusty-search
test result: ok. 999 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 12.14s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 251 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
... (remaining integration-test binaries: all "ok", 0 failed; ignored tests require --include-ignored / a live daemon)

$ cargo clippy --workspace --all-targets -- -D warnings
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 05s   (exit 0, no clippy errors — only a pre-existing MSRV config warning from `tga`, unrelated to this change)

$ cargo fmt --check
(exit 0, no diff — only pre-existing nightly-feature warnings from rustfmt.toml, unrelated to this change)

$ bash scripts/check_line_cap.sh
line-cap: 14 allowlisted, 0 violations — OK.
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-search` (999 passed, 0 failed, 1 pre-existing ignored)
- [x] New regression tests run by name and pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`
- [ ] QA: verify against a simulated version of the live incident scenario if possible

Branch left intact for QA per instructions — not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)