### PR TITLE
fix(trusty-mpm): never deploy skills whose name contains "mcp" (/mcp collision)

### DIFF
--- a/crates/trusty-mpm/src/assets/agents/mpm-skills-manager.md
+++ b/crates/trusty-mpm/src/assets/agents/mpm-skills-manager.md
@@ -69,6 +69,35 @@ When a project is detected, recommend skills that match its stack:
 - React → `react-patterns`, `webapp-testing`
 - Elixir/Phoenix → `phoenix-api-channels`, `ecto-patterns`
 
+### Naming Convention — Never Collide With a Built-In Slash Command
+
+Claude Code discovers a skill at `<dest>/<name>/SKILL.md` and exposes it as
+the slash command `/<name>` — the filename stem (`.md`-stripped), not the
+frontmatter `name:` field, IS the invocable command. A skill whose stem
+matches or contains a Claude Code built-in command shadows that built-in and
+makes it unreachable for the user.
+
+🔴 **Never name a skill such that its slug contains a Claude Code built-in
+command name (e.g. `mcp`) — it will shadow the built-in.** trusty-mpm's
+deploy guard (`skill_deployer::deploy_skills_filtered`, #2186) refuses to
+deploy any skill whose stem contains `"mcp"` (case-insensitive) as a
+mechanical backstop, but the convention below exists so a colliding name is
+never proposed or authored in the first place.
+
+The reserved set includes at least: `mcp`, `init`, `review`, `clear`,
+`compact`, `config`, `help`.
+
+When naming a topic-area skill (e.g. covering AI/agent protocols, MCP server
+integration, tool-calling conventions), do **not** fold the protocol acronym
+into the slug (e.g. never `toolchains-ai-protocols-mcp`). Prefer a `tm-`
+prefixed or otherwise domain-scoped slug that describes the *capability*,
+not the protocol name — e.g. `tm-agent-protocols` or
+`toolchains-agent-integration` instead of anything containing `mcp`. The
+existing `toolchains-rust-core` naming (language/toolchain-scoped, no
+built-in-command collision) remains the reference pattern for toolchain
+skills — it is not renamed by this rule, only cited as the non-colliding
+baseline new names should follow.
+
 ## Adding a New Skill
 
 1. Create `crates/trusty-mpm/src/assets/skills/<name>.md`

--- a/crates/trusty-mpm/src/core/skill_deployer.rs
+++ b/crates/trusty-mpm/src/core/skill_deployer.rs
@@ -31,7 +31,9 @@ use crate::core::skill_manifest::{SkillManifest, SkillManifestEntry};
 pub struct DeployStats {
     /// Filenames successfully (re)written this run.
     pub deployed: Vec<String>,
-    /// Filenames skipped because the user owns or modified them.
+    /// Filenames skipped because the user owns or modified them, or because
+    /// the name collides with a Claude Code built-in slash command (e.g.
+    /// contains "mcp" — see [`deploy_skills_filtered`]).
     pub skipped: Vec<String>,
     /// Filenames left untouched because their checksum already matched.
     pub unchanged: Vec<String>,
@@ -64,13 +66,16 @@ fn skill_stem(filename: &str) -> &str {
 /// clobbering user-owned or user-modified files.
 ///
 /// Rules:
+///   - Name (stem) contains "mcp" (case-insensitive) → collides with Claude
+///     Code's built-in `/mcp` command → skip, never written (#2186)
 ///   - Not in manifest, file exists → user-owned → skip silently
 ///   - In manifest, checksum matches deployed copy → overwrite when stale
 ///   - In manifest, checksum differs → user-modified → skip
 ///   - New trusty-mpm skill → write + add to manifest
 ///
 /// Test: `deploy_new_skill`, `deploy_skips_user_modified`,
-/// `deploy_unchanged_no_write`, `deploy_user_owned_skipped`.
+/// `deploy_unchanged_no_write`, `deploy_user_owned_skipped`,
+/// `deploy_skips_mcp_named_skill`.
 pub fn deploy_skills(source: &Path, dest: &Path) -> Result<DeployStats, Error> {
     // Default policy: deploy every skill in the source directory.
     deploy_skills_filtered(source, dest, |_name| true)
@@ -146,6 +151,21 @@ pub fn deploy_skills_filtered(
 
     for filename in names {
         let stem = skill_stem(&filename).to_string();
+
+        // Claude Code ships a built-in `/mcp` slash command. A deployed skill
+        // whose invocable name (the stem, i.e. the directory Claude Code
+        // exposes as `/<stem>`) contains "mcp" shadows that built-in and
+        // makes `/mcp` unreachable for the user (#2186). Reject before any
+        // file I/O or manifest write so a bad name never lands on disk.
+        if stem.to_lowercase().contains("mcp") {
+            tracing::warn!(
+                skill = %stem,
+                "refusing to deploy skill whose name contains \"mcp\" — it would shadow Claude Code's built-in /mcp command"
+            );
+            stats.skipped.push(stem);
+            continue;
+        }
+
         let source_path = source.join(&filename);
         let content = std::fs::read_to_string(&source_path)?;
         // Claude Code discovers skills from <dest>/<name>/SKILL.md.
@@ -341,6 +361,66 @@ mod tests {
         assert!(stats.deployed.contains(&"tm-doctor".to_string()));
         let refreshed = fs::read_to_string(tgt.path().join("tm-doctor").join("SKILL.md")).unwrap();
         assert!(refreshed.contains("Doctor v2"));
+    }
+
+    #[test]
+    fn deploy_skips_mcp_named_skill() {
+        // #2186: a skill whose name (stem) contains "mcp" must never be
+        // deployed — Claude Code's built-in `/mcp` command would be shadowed
+        // by `/toolchains-ai-protocols-mcp` (or any other mcp-containing
+        // name). It must be recorded as skipped, not deployed, and must not
+        // block sibling skills in the same batch from deploying normally.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path()); // tm-doctor.md + example-skill.md
+        fs::write(
+            src.path().join("toolchains-ai-protocols-mcp.md"),
+            "---\nname: toolchains-ai-protocols-mcp\n---\n\n# AI Protocols\n\nMCP guidance.\n",
+        )
+        .unwrap();
+
+        let stats = deploy_skills(src.path(), tgt.path()).unwrap();
+
+        assert!(
+            stats
+                .skipped
+                .contains(&"toolchains-ai-protocols-mcp".to_string())
+        );
+        assert!(
+            !stats
+                .deployed
+                .contains(&"toolchains-ai-protocols-mcp".to_string())
+        );
+        assert!(
+            !tgt.path()
+                .join("toolchains-ai-protocols-mcp")
+                .join("SKILL.md")
+                .exists(),
+            "an mcp-named skill must never be written to disk"
+        );
+
+        // Sibling non-mcp skills in the same batch must still deploy.
+        assert!(stats.deployed.contains(&"tm-doctor".to_string()));
+        assert!(stats.deployed.contains(&"example-skill".to_string()));
+    }
+
+    #[test]
+    fn deploy_skips_mcp_named_skill_case_insensitive() {
+        // The guard must match "mcp" regardless of case (e.g. `Foo-MCP.md`).
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path()); // tm-doctor.md + example-skill.md
+        fs::write(
+            src.path().join("Foo-MCP.md"),
+            "---\nname: Foo-MCP\n---\n\n# Foo MCP\n\nSomething.\n",
+        )
+        .unwrap();
+
+        let stats = deploy_skills(src.path(), tgt.path()).unwrap();
+
+        assert!(stats.skipped.contains(&"Foo-MCP".to_string()));
+        assert!(!stats.deployed.contains(&"Foo-MCP".to_string()));
+        assert!(!tgt.path().join("Foo-MCP").exists());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/skill_source.rs
+++ b/crates/trusty-mpm/src/core/skill_source.rs
@@ -84,7 +84,18 @@ pub fn skill_bundle_stamp() -> String {
 /// path, not the user-facing incremental `tm install`), then removes any
 /// existing top-level `*.md` file whose name is not one of the artifacts just
 /// written. Hidden files (leading `.`, e.g. the stamp marker) are never
-/// touched. Returns the basenames written.
+/// touched. An artifact whose basename (stem, `.md`-stripped) contains "mcp"
+/// (case-insensitive) is skipped entirely — never written, and any stale copy
+/// already on disk is pruned by the sweep below (exercised indirectly by
+/// `materialize_skill_artifacts_prunes_files_not_in_table`, which asserts the
+/// prune sweep removes a file absent from `keep`) — as a defense-in-depth
+/// mirror of the `skill_deployer` deploy guard (#2186): such a name would
+/// shadow Claude Code's built-in `/mcp` command once deployed. The compiled-in
+/// `bundle::ALL` table currently contains no such artifact, so this branch has
+/// no dedicated fixture-backed unit test here; coverage lives in
+/// `skill_deployer::tests::deploy_skips_mcp_named_skill`, which exercises the
+/// identical stem-matching rule against an arbitrary source directory. Returns
+/// the basenames written.
 /// Test: `materialize_skill_artifacts_writes_all_skills`,
 /// `materialize_skill_artifacts_prunes_files_not_in_table`.
 pub fn materialize_skill_artifacts(paths: &FrameworkPaths) -> Result<Vec<String>> {
@@ -100,6 +111,21 @@ pub fn materialize_skill_artifacts(paths: &FrameworkPaths) -> Result<Vec<String>
             .rel_path
             .strip_prefix("skills/")
             .unwrap_or(artifact.rel_path);
+
+        // Defense-in-depth mirror of the `skill_deployer::deploy_skills_filtered`
+        // guard (#2186): a bundled skill whose basename (stem, `.md`-stripped)
+        // contains "mcp" would shadow Claude Code's built-in `/mcp` command
+        // once deployed. Refuse to even materialize it into the framework
+        // source dir, so a bad name never reaches the deploy step at all.
+        let stem = basename.strip_suffix(".md").unwrap_or(basename);
+        if stem.to_lowercase().contains("mcp") {
+            tracing::warn!(
+                skill = %stem,
+                "refusing to materialize bundled skill whose name contains \"mcp\" — it would shadow Claude Code's built-in /mcp command"
+            );
+            continue;
+        }
+
         let dest = paths.skills.join(basename);
         atomic_write(&dest, artifact.contents)?;
         keep.insert(basename.to_string());


### PR DESCRIPTION
## Summary
- Claude Code ships a built-in `/mcp` slash command. A deployed skill whose invocable name (the source `.md` file's stem, which becomes `<dest>/<name>/SKILL.md` and thus `/<name>`) contains `"mcp"` shadows that built-in, making `/mcp` unreachable.
- `deploy_skills_filtered` (`crates/trusty-mpm/src/core/skill_deployer.rs`) now skips (case-insensitive `"mcp"` substring match on the stem) and records any such skill in `DeployStats.skipped` **before** any file I/O or manifest write.
- Defense-in-depth: `materialize_skill_artifacts` (`crates/trusty-mpm/src/core/skill_source.rs`) mirrors the identical stem check so a bad name never even reaches `~/.trusty-mpm/framework/skills/`; any stale on-disk copy from before this fix is pruned by the existing prune sweep.
- Updated the skill-naming convention guidance in `crates/trusty-mpm/src/assets/agents/mpm-skills-manager.md` to explicitly forbid names that collide with Claude Code built-ins (`mcp`, `init`, `review`, `clear`, `compact`, `config`, `help`), while leaving the existing non-colliding `toolchains-rust-core` reference untouched.

## Test plan
- [x] Added `skill_deployer::tests::deploy_skips_mcp_named_skill` — an `.md` source named `toolchains-ai-protocols-mcp.md` is skipped, never written to `<dest>/.../SKILL.md`, recorded in `skipped`, and sibling non-mcp skills in the same batch still deploy normally.
- [x] Added `skill_deployer::tests::deploy_skips_mcp_named_skill_case_insensitive` — `Foo-MCP.md` is skipped too.
- [x] `cargo build --workspace` — clean.
- [x] `cargo test -p trusty-mpm` — lib test binary (includes all `skill_deployer`/`skill_source` tests): `2410 passed; 0 failed`. **Note:** the `tm` bin test binary has 1 pre-existing, deterministic failure (`formatters::banner::two_panel::tests::right_col_no_inner_border`) unrelated to this change — confirmed by diffing this branch against `origin/main`, which touches only the 3 files listed above; banner code was never touched here.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0).
- [x] `cargo fmt --check` — clean.
- [x] `bash scripts/check_line_cap.sh` — `14 allowlisted, 0 violations — OK`.

Closes #2186

🤖 Generated with [Claude Code](https://claude.com/claude-code)