### PR TITLE
feat(trusty-mpm): per-project GitHub identity binding (gh account + commit identity)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -545,7 +545,7 @@ pub(crate) async fn catalog(action: CatalogAction) -> anyhow::Result<()> {
     let framework_root = trusty_mpm::core::paths::FrameworkPaths::default().root;
     let config = trusty_mpm::core::config::MpmConfig::load_default();
     let sync = trusty_mpm::content::CatalogSync::for_framework(
-        trusty_mpm::provisioner::RealGitBackend,
+        trusty_mpm::provisioner::RealGitBackend::default(),
         &framework_root,
         Some(&config.manifest),
     );
@@ -626,7 +626,7 @@ pub(crate) async fn catalog(action: CatalogAction) -> anyhow::Result<()> {
             // HR-3: accept the rebuild offer — sync, redeploy the selected set,
             // optionally prune deselected managed files.
             let report = trusty_mpm::core::update_check::apply_catalog(
-                trusty_mpm::provisioner::RealGitBackend,
+                trusty_mpm::provisioner::RealGitBackend::default(),
                 &trusty_mpm::core::paths::FrameworkPaths::default(),
                 &framework_root,
                 force,

--- a/crates/trusty-mpm/src/bin/tm/gh_identity.rs
+++ b/crates/trusty-mpm/src/bin/tm/gh_identity.rs
@@ -1,247 +1,102 @@
-//! Per-project GitHub identity resolution for every `gh` subprocess `tm` spawns.
+//! CLI-side, project-aware GitHub identity resolution for every `gh`
+//! subprocess `tm` spawns (#1265, project-aware since #2184).
 //!
-//! Why: a host may carry several GitHub identities — a personal account, a work
-//! account, a bot, or a GitHub Enterprise host — yet `tm`'s many `gh` calls
-//! (issue list/view/comment, label/assignee edits, repo view, clone-URL
-//! synthesis, managed spawn) must use the RIGHT one for the active project, not
-//! whichever identity happens to be ambient. #1265 binds that identity per
-//! project via the `github:` config section. This module turns the declarative
-//! [`GithubConfig`] into the concrete set of environment overrides applied to
-//! each `gh` `Command` before spawn, honouring a precedence chain and — for the
-//! `config_dir`/`token_env` strategies — WITHOUT mutating the user's global gh
-//! state.
+//! Why: the precedence engine (`config_dir` > `token_env` > `account`, plus
+//! `GH_HOST`) now lives in the library (`trusty_mpm::core::gh_identity`) so
+//! the daemon's managed-spawn path can share it (#2184). This module is the
+//! remaining CLI-specific glue: it detects the ACTIVE project (by matching
+//! the current directory's git origin remote against `config.projects`),
+//! applies the #2184 project-over-global precedence via
+//! [`trusty_mpm::core::gh_identity::select_github_config`], and folds the
+//! typed [`GhIdentityError`] into `anyhow` (binary code uses `anyhow`, per
+//! this workspace's error-handling convention).
 //!
-//! What: [`GhEnv`] is the resolved, ordered list of `(VAR, value)` overrides;
-//! [`resolve_gh_env`] applies the precedence **`config_dir` > `token_env` >
-//! `account`** for identity selection and ALWAYS applies `host` (as `GH_HOST`)
-//! when set; [`clone_url`] synthesises an HTTPS clone URL honouring the host.
-//! [`GhIdentityError`] is the typed failure (today only the `account`-strategy
-//! refusal). An absent `github:` config resolves to an EMPTY [`GhEnv`], so gh
-//! inherits the ambient identity (no regression).
+//! What: [`load_gh_env`] is the one-line entry point every `tm issue`/`tm
+//! ticket`/`tm watch` call site already uses; it is now project-aware with NO
+//! call-site changes required. [`resolve_project_aware`] is the pure,
+//! directly-testable core (config + a pre-detected origin URL in, `GhEnv`
+//! out) that `load_gh_env` wraps with real cwd/git detection.
 //!
-//! ## Precedence chain (identity)
-//!
-//! 1. `config_dir` → `GH_CONFIG_DIR=<dir>`. Highest precedence and least
-//!    invasive: gh reads its entire auth/config from a private directory, fully
-//!    isolating the identity without touching `~/.config/gh` or global state.
-//! 2. else `token_env` (when the named env var is PRESENT) → `GH_TOKEN=<value>`.
-//!    The config stores only the env-var NAME; the secret is resolved from the
-//!    environment at call time and never persisted. If the named var is absent,
-//!    this strategy is skipped and precedence falls through.
-//! 3. else `account` → see the caveat below.
-//!
-//! `host` is applied independently of the identity strategy whenever set.
-//!
-//! ## `account`-strategy caveat (deliberate decision)
-//!
-//! `gh` has NO universal per-invocation `--user`/`--account` flag, and
-//! `gh auth switch` mutates GLOBAL state (it rewrites the active account in the
-//! shared `~/.config/gh/hosts.yml`). Silently switching the user's global gh
-//! account as a side effect of a `tm` command — and racing every other `gh`
-//! consumer on the box — violates the "do not mutate global state" requirement.
-//! Rather than do that, when `account` is the ONLY identity field set we return
-//! a typed [`GhIdentityError::AccountStrategyUnsupported`] that instructs the
-//! operator to bind via `config_dir` (a per-account gh config home, the gh
-//! convention for multiple accounts) or `token_env` instead. `account` is still
-//! accepted in config (it documents intent and pairs naturally with a
-//! `config_dir`), but on its own it cannot safely select an identity. This keeps
-//! every supported strategy side-effect-free on global gh state.
-//!
-//! Test: `resolve_*`, `precedence_*`, `host_*`, `account_*`, `clone_url_*` in
-//! the inline `tests` module.
+//! Test: `resolve_project_aware_*` in the inline `tests` module exercise the
+//! project-match precedence hermetically (no real `gh`/git needed); the
+//! underlying precedence chain itself is tested in
+//! `trusty_mpm::core::gh_identity`.
 
-use trusty_mpm::core::trusty_tools_config::{DEFAULT_GITHUB_HOST, GithubConfig};
+use trusty_mpm::core::gh_identity::{GhEnv, GhIdentityError, select_github_config};
+use trusty_mpm::core::trusty_tools_config::TrustyToolsConfig;
+use trusty_mpm::project::record::repo_url_matches;
 
-/// `GH_CONFIG_DIR` — points gh at a private config/auth home.
-const ENV_GH_CONFIG_DIR: &str = "GH_CONFIG_DIR";
-/// `GH_TOKEN` — the auth token gh uses for API calls.
-const ENV_GH_TOKEN: &str = "GH_TOKEN";
-/// `GH_HOST` — the default host gh targets.
-const ENV_GH_HOST: &str = "GH_HOST";
+// Re-exported for the existing CLI call sites (`clone_url` is used by
+// `commands::watch`; `effective_host`/`resolve_gh_env` are exercised via the
+// library's own test suite but kept reachable here for any future CLI need).
+pub(crate) use trusty_mpm::core::gh_identity::clone_url;
 
-/// Typed failures from resolving a [`GithubConfig`] into a [`GhEnv`].
+/// Resolve an optional [`trusty_mpm::core::trusty_tools_config::GithubConfig`]
+/// into a [`GhEnv`], surfacing the typed [`GhIdentityError`] as `anyhow` for
+/// binary call sites.
 ///
-/// Why: the `account`-only strategy cannot be honoured without mutating global
-/// gh state (see the module docs); a typed error lets the caller surface an
-/// actionable message and lets tests assert the refusal precisely instead of
-/// string-matching an `anyhow` chain.
-/// What: today the single variant flags the unsupported `account`-only case,
-/// carrying the offending account name for the message.
-/// Test: `account_only_is_refused`.
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
-pub(crate) enum GhIdentityError {
-    /// `account` was the only identity field set; selecting an account alone
-    /// requires mutating global gh state, which is refused.
-    #[error(
-        "github.account = '{0}' cannot select a gh identity on its own without \
-         mutating global gh state (`gh auth switch`). Bind this project's \
-         identity with `github.config_dir` (a per-account gh config home) or \
-         `github.token_env` (the NAME of an env var holding a token) instead."
-    )]
-    AccountStrategyUnsupported(String),
+/// Why: production call sites use `anyhow::Result`; folding the typed error
+/// into `anyhow` here keeps those sites a one-liner.
+/// What: delegates to [`trusty_mpm::core::gh_identity::resolve_gh_env`].
+/// Test: covered transitively by `resolve_project_aware_*` and the library's
+/// own `resolve_*` tests.
+fn resolve_gh_env_anyhow(
+    config: Option<&trusty_mpm::core::trusty_tools_config::GithubConfig>,
+) -> anyhow::Result<GhEnv> {
+    trusty_mpm::core::gh_identity::resolve_gh_env(config)
+        .map_err(|e: GhIdentityError| anyhow::anyhow!(e))
 }
 
-/// The resolved set of environment overrides to apply to a `gh` subprocess.
+/// Resolve the [`GhEnv`] for `origin_url` against a loaded [`TrustyToolsConfig`]
+/// (#2184) — the pure, hermetically-testable core of [`load_gh_env`].
 ///
-/// Why: callers (the `CommandRunner` boundary) need ONE value that lists exactly
-/// which env vars to set on a `gh` `Command`, derived once from the active
-/// project's config, so every `gh` invocation is bound identically and no call
-/// site re-implements the precedence. An EMPTY `GhEnv` means "apply nothing" —
-/// the ambient gh identity is used, preserving pre-#1265 behaviour.
-/// What: an ordered list of `(name, value)` pairs. Order is deterministic
-/// (identity var first when present, then `GH_HOST`) so tests can assert it.
-/// Test: every `resolve_*`/`precedence_*`/`host_*` test inspects `vars()`.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub(crate) struct GhEnv {
-    vars: Vec<(String, String)>,
+/// Why: separating the "which config wins" decision from the real cwd/git
+/// detection lets the project-over-global precedence be asserted without a
+/// real git repo on disk.
+/// What: when `origin_url` is `Some` and matches (via [`repo_url_matches`]) a
+/// `config.projects` entry with its own `github:` binding, that binding wins
+/// outright; otherwise falls back to the global `config.github`; with no
+/// match (or no `origin_url`) resolution is purely global — matching
+/// pre-#2184 behaviour exactly.
+/// Test: `resolve_project_aware_project_binding_wins`,
+/// `resolve_project_aware_falls_back_to_global`,
+/// `resolve_project_aware_no_origin_uses_global`.
+pub(crate) fn resolve_project_aware(
+    config: &TrustyToolsConfig,
+    origin_url: Option<&str>,
+) -> anyhow::Result<GhEnv> {
+    let project_github = origin_url
+        .and_then(|url| {
+            config
+                .projects
+                .iter()
+                .find(|p| repo_url_matches(&p.repo_url, url))
+        })
+        .and_then(|p| p.github.as_ref());
+    let selected = select_github_config(project_github, config.github.as_ref());
+    resolve_gh_env_anyhow(selected)
 }
 
-impl GhEnv {
-    /// Borrow the resolved `(name, value)` overrides.
-    ///
-    /// Why: the `CommandRunner` boundary iterates these to call `Command::env`;
-    /// tests iterate them to assert the resolved set and ordering.
-    /// What: returns the override slice (possibly empty).
-    /// Test: read by every resolution test.
-    pub(crate) fn vars(&self) -> &[(String, String)] {
-        &self.vars
-    }
-
-    /// Whether any override is set (i.e. an identity binding is active).
-    ///
-    /// Why: lets callers cheaply distinguish "bound" from "ambient" without
-    /// allocating; useful for diagnostics.
-    /// What: true when at least one override is present.
-    /// Test: `resolve_absent_config_is_empty` asserts `is_empty()` for None.
-    pub(crate) fn is_empty(&self) -> bool {
-        self.vars.is_empty()
-    }
-}
-
-/// Resolve an optional [`GithubConfig`] into the [`GhEnv`] for `gh` subprocesses.
-///
-/// Why: the single, tested place the #1265 precedence chain is applied so every
-/// `gh` call `tm` makes is bound to the same per-project identity and no call
-/// site diverges. Keeping `token_env` resolution here (via `std::env::var` on
-/// the configured NAME) guarantees the plaintext secret never has to live in the
-/// config or be threaded through the call graph.
-/// What: returns an EMPTY `GhEnv` when `config` is `None`. Otherwise applies
-/// **`config_dir` > `token_env`(present) > `account`** for the identity var and
-/// ALWAYS appends `GH_HOST` when `host` is set. The `account`-only case returns
-/// [`GhIdentityError::AccountStrategyUnsupported`] (see module docs). A
-/// `token_env` whose named var is ABSENT is skipped, falling through to the next
-/// strategy.
-/// Test: `resolve_absent_config_is_empty`, `resolve_config_dir`,
-/// `resolve_token_env_present`, `resolve_token_env_absent_falls_through`,
-/// `precedence_config_dir_beats_token_env`,
-/// `precedence_token_env_beats_account`, `account_only_is_refused`,
-/// `host_always_applied`, `host_applied_with_identity`.
-pub(crate) fn resolve_gh_env(config: Option<&GithubConfig>) -> Result<GhEnv, GhIdentityError> {
-    let Some(cfg) = config else {
-        return Ok(GhEnv::default());
-    };
-
-    let mut vars: Vec<(String, String)> = Vec::new();
-
-    // --- Identity selection (precedence: config_dir > token_env > account) ---
-    if let Some(dir) = cfg
-        .config_dir
-        .as_deref()
-        .map(|p| p.to_string_lossy().trim().to_string())
-        .filter(|s| !s.is_empty())
-    {
-        vars.push((ENV_GH_CONFIG_DIR.to_string(), dir));
-    } else if let Some(token) = resolve_token_env(cfg.token_env.as_deref()) {
-        vars.push((ENV_GH_TOKEN.to_string(), token));
-    } else if let Some(account) = cfg
-        .account
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
-        // `account` alone cannot safely select an identity (see module docs).
-        return Err(GhIdentityError::AccountStrategyUnsupported(
-            account.to_string(),
-        ));
-    }
-
-    // --- Host is applied independently of the identity strategy. ------------
-    if let Some(host) = cfg.host.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-        vars.push((ENV_GH_HOST.to_string(), host.to_string()));
-    }
-
-    Ok(GhEnv { vars })
-}
-
-/// Resolve the token NAMEd by `token_env` from the process environment.
-///
-/// Why: isolates the `std::env::var` lookup so the precedence logic stays
-/// readable and so the "named var absent → skip" rule is a single tested
-/// function. The plaintext token is read here and nowhere else.
-/// What: given `Some(name)`, returns `Some(value)` when the env var `name` is
-/// set to a non-empty value; returns `None` for an unset/empty var or a `None`
-/// name (trimming whitespace around the configured name).
-/// Test: covered via `resolve_token_env_present` /
-/// `resolve_token_env_absent_falls_through`.
-fn resolve_token_env(token_env: Option<&str>) -> Option<String> {
-    let name = token_env.map(str::trim).filter(|s| !s.is_empty())?;
-    let value = std::env::var(name).ok()?;
-    if value.is_empty() { None } else { Some(value) }
-}
-
-/// Resolve the effective gh host, honouring config with a `github.com` default.
-///
-/// Why: both `GH_HOST` and clone-URL synthesis need the same host answer; a
-/// single resolver keeps them aligned and applies the default in one place.
-/// What: returns the trimmed `config.host` when set and non-empty, else
-/// [`DEFAULT_GITHUB_HOST`].
-/// Test: `effective_host_default`, `effective_host_override`.
-pub(crate) fn effective_host(config: Option<&GithubConfig>) -> String {
-    config
-        .and_then(|c| c.host.as_deref())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .unwrap_or(DEFAULT_GITHUB_HOST)
-        .to_string()
-}
-
-/// Synthesise an HTTPS clone URL for `owner/repo`, honouring the configured host.
-///
-/// Why: watch/ticket synthesise a clone URL for a board that may live on GitHub
-/// Enterprise; hard-coding `github.com` breaks GHE (#1261). Routing through the
-/// resolved host fixes that while defaulting to the public host.
-/// What: returns `https://<effective-host>/<repo>` where `repo` is the
-/// `owner/repo` slug and the host comes from [`effective_host`].
-/// Test: `clone_url_default_host`, `clone_url_enterprise_host`.
-pub(crate) fn clone_url(config: Option<&GithubConfig>, repo: &str) -> String {
-    format!("https://{}/{}", effective_host(config), repo)
-}
-
-/// Convenience: resolve the [`GhEnv`] from an optional config, or surface the
-/// typed error as an `anyhow` error for binary call sites.
-///
-/// Why: production call sites use `anyhow::Result`; folding the
-/// [`GhIdentityError`] into `anyhow` here keeps those sites a one-liner while the
-/// typed error stays available for tests.
-/// What: delegates to [`resolve_gh_env`] and maps the error into `anyhow`.
-/// Test: success path covered by the `resolve_*` tests; the error mapping is
-/// thin glue exercised by `account_only_is_refused` on the typed function.
-pub(crate) fn resolve_gh_env_anyhow(config: Option<&GithubConfig>) -> anyhow::Result<GhEnv> {
-    resolve_gh_env(config).map_err(|e| anyhow::anyhow!(e))
-}
-
-/// Convenience wrapper: load trusty-mpm config and resolve the active [`GhEnv`].
+/// Convenience wrapper: load trusty-mpm config, detect the active project from
+/// the current directory's git origin remote, and resolve the active [`GhEnv`].
 ///
 /// Why: every `tm` entry point that spawns `gh` needs the same "load config →
-/// resolve github section → GhEnv" sequence; centralising it keeps the call
-/// sites to one line and the behaviour identical across `ticket`/`watch`/`issue`.
-/// What: loads [`trusty_mpm::core::trusty_tools_config::TrustyToolsConfig`], then
-/// resolves its `github` section into a [`GhEnv`] (empty when absent), surfacing
-/// the `account`-strategy refusal as an `anyhow` error.
-/// Test: the resolution itself is unit-tested; this is thin wiring over `load`.
+/// detect project → resolve `github:` section → GhEnv" sequence; centralising
+/// it keeps the call sites to one line and the behaviour identical across
+/// `ticket`/`watch`/`issue`.
+/// What: loads [`TrustyToolsConfig`], detects the current directory's git
+/// origin remote (best-effort — a non-repo cwd or a read failure simply yields
+/// no project match, never an error), and resolves via
+/// [`resolve_project_aware`], surfacing the `account`-strategy refusal as an
+/// `anyhow` error.
+/// Test: `resolve_project_aware_*` cover the resolution logic; this function
+/// is thin wiring over real cwd/git detection.
 pub(crate) fn load_gh_env() -> anyhow::Result<GhEnv> {
-    let config = trusty_mpm::core::trusty_tools_config::TrustyToolsConfig::load();
-    let env = resolve_gh_env_anyhow(config.github.as_ref())?;
+    let config = TrustyToolsConfig::load();
+    let origin_url = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| trusty_mpm::daemon::managed_routes::inproject::get_origin_url(&cwd));
+    let env = resolve_project_aware(&config, origin_url.as_deref())?;
     if !env.is_empty() {
         // Names only — never the resolved token VALUE (which `vars()` may hold).
         let names: Vec<&str> = env.vars().iter().map(|(k, _)| k.as_str()).collect();
@@ -253,243 +108,97 @@ pub(crate) fn load_gh_env() -> anyhow::Result<GhEnv> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use trusty_mpm::core::trusty_tools_config::{GithubConfig, ProjectConfig};
 
-    /// Serialise env mutation so the token-env tests cannot race each other or
-    /// the workspace-root tests across the shared test process.
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    fn project(repo_url: &str, github: Option<GithubConfig>) -> ProjectConfig {
+        ProjectConfig {
+            name: "p".into(),
+            repo_url: repo_url.into(),
+            default_branch: None,
+            stack_hint: None,
+            tags: None,
+            description: None,
+            gh_user: None,
+            github,
+            commit_name: None,
+            commit_email: None,
+        }
     }
 
-    fn cfg() -> GithubConfig {
-        GithubConfig::default()
+    fn gh(config_dir: &str) -> GithubConfig {
+        GithubConfig {
+            config_dir: Some(config_dir.into()),
+            token_env: None,
+            account: None,
+            host: None,
+        }
     }
 
-    /// Why: an absent `github:` section must yield NO overrides so gh inherits
-    /// the ambient identity — the no-regression guarantee.
+    /// Why: a matched project's own `github:` binding must win over the
+    /// global one — the #2184 precedence this module adds.
     /// Test: itself.
     #[test]
-    fn resolve_absent_config_is_empty() {
-        let env = resolve_gh_env(None).expect("none is ok");
+    fn resolve_project_aware_project_binding_wins() {
+        let config = TrustyToolsConfig {
+            github: Some(gh("/cfg/global")),
+            projects: vec![project(
+                "https://github.com/acme/widget",
+                Some(gh("/cfg/project")),
+            )],
+            ..Default::default()
+        };
+        let env =
+            resolve_project_aware(&config, Some("https://github.com/acme/widget.git")).expect("ok");
+        assert_eq!(
+            env.vars(),
+            &[("GH_CONFIG_DIR".to_string(), "/cfg/project".to_string())]
+        );
+    }
+
+    /// Why: a project match with no `github:` binding of its own must fall
+    /// back to the global tier.
+    /// Test: itself.
+    #[test]
+    fn resolve_project_aware_falls_back_to_global() {
+        let config = TrustyToolsConfig {
+            github: Some(gh("/cfg/global")),
+            projects: vec![project("https://github.com/acme/widget", None)],
+            ..Default::default()
+        };
+        let env =
+            resolve_project_aware(&config, Some("https://github.com/acme/widget")).expect("ok");
+        assert_eq!(
+            env.vars(),
+            &[("GH_CONFIG_DIR".to_string(), "/cfg/global".to_string())]
+        );
+    }
+
+    /// Why: with no detected origin (e.g. `tm` run outside a git repo), and no
+    /// declared project therefore matches — resolution must be purely global,
+    /// matching pre-#2184 behaviour exactly.
+    /// Test: itself.
+    #[test]
+    fn resolve_project_aware_no_origin_uses_global() {
+        let config = TrustyToolsConfig {
+            github: Some(gh("/cfg/global")),
+            ..Default::default()
+        };
+        let env = resolve_project_aware(&config, None).expect("ok");
+        assert_eq!(
+            env.vars(),
+            &[("GH_CONFIG_DIR".to_string(), "/cfg/global".to_string())]
+        );
+    }
+
+    /// Why: a detected origin that matches NO declared project, with no
+    /// global binding either, must resolve to a fully ambient (empty) env —
+    /// the no-regression guarantee for projects with no #2184/#1265 config.
+    /// Test: itself.
+    #[test]
+    fn resolve_project_aware_no_match_no_global_is_ambient() {
+        let config = TrustyToolsConfig::default();
+        let env =
+            resolve_project_aware(&config, Some("https://github.com/someone/else")).expect("ok");
         assert!(env.is_empty());
-        assert_eq!(env.vars(), &[]);
-    }
-
-    /// Why: `config_dir` is the highest-precedence, least-invasive strategy and
-    /// must map to `GH_CONFIG_DIR`.
-    /// Test: itself.
-    #[test]
-    fn resolve_config_dir() {
-        let c = GithubConfig {
-            config_dir: Some(PathBuf::from("/home/bob/.config/gh-work")),
-            ..cfg()
-        };
-        let env = resolve_gh_env(Some(&c)).expect("ok");
-        assert_eq!(
-            env.vars(),
-            &[(
-                ENV_GH_CONFIG_DIR.to_string(),
-                "/home/bob/.config/gh-work".to_string()
-            )]
-        );
-    }
-
-    /// Why: `token_env` resolves the token from the NAMEd env var at call time
-    /// (the secret is never in config) → `GH_TOKEN`.
-    /// Test: itself.
-    #[test]
-    fn resolve_token_env_present() {
-        let _g = env_lock();
-        let name = "TM_TEST_GH_TOKEN_PRESENT";
-        // SAFETY: guarded by env_lock; removed below.
-        unsafe { std::env::set_var(name, "ghp_secret_value") };
-        let c = GithubConfig {
-            token_env: Some(name.to_string()),
-            ..cfg()
-        };
-        let env = resolve_gh_env(Some(&c)).expect("ok");
-        unsafe { std::env::remove_var(name) };
-        assert_eq!(
-            env.vars(),
-            &[(ENV_GH_TOKEN.to_string(), "ghp_secret_value".to_string())]
-        );
-    }
-
-    /// Why: a `token_env` whose named var is ABSENT must be skipped (precedence
-    /// falls through), NOT export an empty `GH_TOKEN`.
-    /// Test: itself.
-    #[test]
-    fn resolve_token_env_absent_falls_through() {
-        let _g = env_lock();
-        let name = "TM_TEST_GH_TOKEN_DEFINITELY_UNSET";
-        // SAFETY: guarded by env_lock.
-        unsafe { std::env::remove_var(name) };
-        let c = GithubConfig {
-            token_env: Some(name.to_string()),
-            ..cfg()
-        };
-        let env = resolve_gh_env(Some(&c)).expect("ok");
-        // No identity var set (and no host configured) → empty.
-        assert!(env.is_empty(), "expected empty, got {:?}", env.vars());
-    }
-
-    /// Why: `config_dir` must win over `token_env` even when the token var IS
-    /// present (precedence ordering).
-    /// Test: itself.
-    #[test]
-    fn precedence_config_dir_beats_token_env() {
-        let _g = env_lock();
-        let name = "TM_TEST_GH_TOKEN_PRECEDENCE";
-        // SAFETY: guarded by env_lock.
-        unsafe { std::env::set_var(name, "tok") };
-        let c = GithubConfig {
-            config_dir: Some(PathBuf::from("/cfg/dir")),
-            token_env: Some(name.to_string()),
-            ..cfg()
-        };
-        let env = resolve_gh_env(Some(&c)).expect("ok");
-        unsafe { std::env::remove_var(name) };
-        assert_eq!(
-            env.vars(),
-            &[(ENV_GH_CONFIG_DIR.to_string(), "/cfg/dir".to_string())]
-        );
-    }
-
-    /// Why: with no `config_dir`, a present `token_env` must win over `account`
-    /// (so the account caveat never triggers when a usable token exists).
-    /// Test: itself.
-    #[test]
-    fn precedence_token_env_beats_account() {
-        let _g = env_lock();
-        let name = "TM_TEST_GH_TOKEN_BEATS_ACCOUNT";
-        // SAFETY: guarded by env_lock.
-        unsafe { std::env::set_var(name, "tok2") };
-        let c = GithubConfig {
-            token_env: Some(name.to_string()),
-            account: Some("bob-work".to_string()),
-            ..cfg()
-        };
-        let env = resolve_gh_env(Some(&c)).expect("ok");
-        unsafe { std::env::remove_var(name) };
-        assert_eq!(
-            env.vars(),
-            &[(ENV_GH_TOKEN.to_string(), "tok2".to_string())]
-        );
-    }
-
-    /// Why: `account` alone cannot safely select an identity; the documented
-    /// decision is to refuse with a typed, actionable error.
-    /// Test: itself.
-    #[test]
-    fn account_only_is_refused() {
-        let c = GithubConfig {
-            account: Some("bob-work".to_string()),
-            ..cfg()
-        };
-        let err = resolve_gh_env(Some(&c)).unwrap_err();
-        assert_eq!(
-            err,
-            GhIdentityError::AccountStrategyUnsupported("bob-work".to_string())
-        );
-        let msg = err.to_string();
-        assert!(msg.contains("config_dir"), "msg: {msg}");
-        assert!(msg.contains("token_env"), "msg: {msg}");
-    }
-
-    /// Why: `account` paired with a usable `config_dir` must NOT error — the
-    /// account documents intent while config_dir does the actual selection.
-    /// Test: itself.
-    #[test]
-    fn account_with_config_dir_is_ok() {
-        let c = GithubConfig {
-            config_dir: Some(PathBuf::from("/cfg/acct")),
-            account: Some("bob-work".to_string()),
-            ..cfg()
-        };
-        let env = resolve_gh_env(Some(&c)).expect("ok");
-        assert_eq!(
-            env.vars(),
-            &[(ENV_GH_CONFIG_DIR.to_string(), "/cfg/acct".to_string())]
-        );
-    }
-
-    /// Why: `host` must always be exported (as `GH_HOST`) when set, even with no
-    /// identity strategy configured.
-    /// Test: itself.
-    #[test]
-    fn host_always_applied() {
-        let c = GithubConfig {
-            host: Some("github.example.com".to_string()),
-            ..cfg()
-        };
-        let env = resolve_gh_env(Some(&c)).expect("ok");
-        assert_eq!(
-            env.vars(),
-            &[(ENV_GH_HOST.to_string(), "github.example.com".to_string())]
-        );
-    }
-
-    /// Why: host applies independently of (and in addition to) the identity var;
-    /// ordering is identity-first then host.
-    /// Test: itself.
-    #[test]
-    fn host_applied_with_identity() {
-        let c = GithubConfig {
-            config_dir: Some(PathBuf::from("/cfg")),
-            host: Some("ghe.corp".to_string()),
-            ..cfg()
-        };
-        let env = resolve_gh_env(Some(&c)).expect("ok");
-        assert_eq!(
-            env.vars(),
-            &[
-                (ENV_GH_CONFIG_DIR.to_string(), "/cfg".to_string()),
-                (ENV_GH_HOST.to_string(), "ghe.corp".to_string()),
-            ]
-        );
-    }
-
-    /// Why: the host resolver must default to `github.com` when unset.
-    /// Test: itself.
-    #[test]
-    fn effective_host_default() {
-        assert_eq!(effective_host(None), "github.com");
-        assert_eq!(effective_host(Some(&cfg())), "github.com");
-    }
-
-    /// Why: a configured host must override the default.
-    /// Test: itself.
-    #[test]
-    fn effective_host_override() {
-        let c = GithubConfig {
-            host: Some("github.example.com".to_string()),
-            ..cfg()
-        };
-        assert_eq!(effective_host(Some(&c)), "github.example.com");
-    }
-
-    /// Why: clone-URL synthesis defaults to the public host (no config).
-    /// Test: itself.
-    #[test]
-    fn clone_url_default_host() {
-        assert_eq!(
-            clone_url(None, "bobmatnyc/trusty-tools"),
-            "https://github.com/bobmatnyc/trusty-tools"
-        );
-    }
-
-    /// Why: clone-URL synthesis must honour a GHE host (closes #1261's GHE part).
-    /// Test: itself.
-    #[test]
-    fn clone_url_enterprise_host() {
-        let c = GithubConfig {
-            host: Some("github.example.com".to_string()),
-            ..cfg()
-        };
-        assert_eq!(
-            clone_url(Some(&c), "acme/widget"),
-            "https://github.example.com/acme/widget"
-        );
     }
 }

--- a/crates/trusty-mpm/src/core/gh_identity.rs
+++ b/crates/trusty-mpm/src/core/gh_identity.rs
@@ -1,0 +1,534 @@
+//! GitHub identity resolution shared by every `gh`/git-auth-aware surface in
+//! `tm` — the CLI's `gh` subprocess sites AND the daemon's managed-session
+//! spawn/provisioner path (#2184).
+//!
+//! Why: #1265 introduced a single GLOBAL `github:` config section and the
+//! `config_dir` > `token_env` > `account` precedence chain that turns it into
+//! concrete env overrides for a `gh` subprocess, but that logic originally
+//! lived only in the `tm` binary (`bin/tm/gh_identity.rs`), unreachable from
+//! library code (the daemon's `spawn_managed`/`WorkspaceProvisioner`). #2184
+//! adds a PER-PROJECT `github:` binding (`ProjectConfig::github` /
+//! `Project::github`) that must resolve identically for both the CLI and the
+//! daemon, so the core precedence engine — everything that does NOT depend on
+//! `anyhow` or a specific caller's project-lookup strategy — now lives here in
+//! the library, with `bin/tm/gh_identity.rs` reduced to a thin,
+//! project-aware, `anyhow`-flavoured wrapper over it.
+//!
+//! What: [`GhEnv`] is the resolved, ordered list of `(VAR, value)` overrides;
+//! [`resolve_gh_env`] applies the precedence **`config_dir` > `token_env` >
+//! `account`** for identity selection and ALWAYS applies `host` (as `GH_HOST`)
+//! when set; [`select_github_config`] applies the #2184 project-over-global
+//! precedence (project binding wins outright when present; otherwise the
+//! global binding is used); [`clone_url`] synthesises an HTTPS clone URL
+//! honouring the host. [`GhIdentityError`] is the typed failure (today only
+//! the `account`-strategy refusal). An absent `github:` config resolves to an
+//! EMPTY [`GhEnv`], so `gh` inherits the ambient identity (no regression).
+//!
+//! ## Precedence chain (identity, within one resolved [`GithubConfig`])
+//!
+//! 1. `config_dir` → `GH_CONFIG_DIR=<dir>`. Highest precedence and least
+//!    invasive: gh reads its entire auth/config from a private directory, fully
+//!    isolating the identity without touching `~/.config/gh` or global state.
+//! 2. else `token_env` (when the named env var is PRESENT) → `GH_TOKEN=<value>`.
+//!    The config stores only the env-var NAME; the secret is resolved from the
+//!    environment at call time and never persisted. If the named var is absent,
+//!    this strategy is skipped and precedence falls through.
+//! 3. else `account` → see the caveat below.
+//!
+//! `host` is applied independently of the identity strategy whenever set.
+//!
+//! ## `account`-strategy caveat (deliberate decision)
+//!
+//! `gh` has NO universal per-invocation `--user`/`--account` flag, and
+//! `gh auth switch` mutates GLOBAL state (it rewrites the active account in the
+//! shared `~/.config/gh/hosts.yml`). Silently switching the user's global gh
+//! account as a side effect of a `tm` command — and racing every other `gh`
+//! consumer on the box — violates the "do not mutate global state" requirement.
+//! Rather than do that, when `account` is the ONLY identity field set we return
+//! a typed [`GhIdentityError::AccountStrategyUnsupported`] that instructs the
+//! operator to bind via `config_dir` (a per-account gh config home, the gh
+//! convention for multiple accounts) or `token_env` instead. `account` is still
+//! accepted in config (it documents intent and pairs naturally with a
+//! `config_dir`), but on its own it cannot safely select an identity. This keeps
+//! every supported strategy side-effect-free on global gh state.
+//!
+//! ## Project-over-global precedence (#2184)
+//!
+//! [`select_github_config`] is the single tested place the new tier is
+//! applied: a project's OWN `github:` binding, when present, is used WHOLESALE
+//! in place of the global binding (no field-level merge between the two tiers
+//! — this matches the existing "a config section is either fully bound or
+//! absent" shape `GithubConfig` already has at the global level). The global
+//! `github:` section remains the fallback for projects with no binding of
+//! their own, and an ambient (unconfigured) identity remains the final
+//! fallback via [`resolve_gh_env`]'s existing `None` handling.
+//!
+//! Test: `resolve_*`, `precedence_*`, `host_*`, `account_*`, `clone_url_*`,
+//! `select_github_config_*` in the inline `tests` module.
+
+use crate::core::trusty_tools_config::{DEFAULT_GITHUB_HOST, GithubConfig};
+
+/// `GH_CONFIG_DIR` — points gh at a private config/auth home.
+const ENV_GH_CONFIG_DIR: &str = "GH_CONFIG_DIR";
+/// `GH_TOKEN` — the auth token gh uses for API calls.
+const ENV_GH_TOKEN: &str = "GH_TOKEN";
+/// `GH_HOST` — the default host gh targets.
+const ENV_GH_HOST: &str = "GH_HOST";
+
+/// Typed failures from resolving a [`GithubConfig`] into a [`GhEnv`].
+///
+/// Why: the `account`-only strategy cannot be honoured without mutating global
+/// gh state (see the module docs); a typed error lets the caller surface an
+/// actionable message and lets tests assert the refusal precisely instead of
+/// string-matching an error chain.
+/// What: today the single variant flags the unsupported `account`-only case,
+/// carrying the offending account name for the message.
+/// Test: `account_only_is_refused`.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum GhIdentityError {
+    /// `account` was the only identity field set; selecting an account alone
+    /// requires mutating global gh state, which is refused.
+    #[error(
+        "github.account = '{0}' cannot select a gh identity on its own without \
+         mutating global gh state (`gh auth switch`). Bind this project's \
+         identity with `github.config_dir` (a per-account gh config home) or \
+         `github.token_env` (the NAME of an env var holding a token) instead."
+    )]
+    AccountStrategyUnsupported(String),
+}
+
+/// The resolved set of environment overrides to apply to a `gh`/git subprocess.
+///
+/// Why: callers need ONE value that lists exactly which env vars to set on a
+/// `Command`, derived once from the active project's config, so every call is
+/// bound identically and no call site re-implements the precedence. An EMPTY
+/// `GhEnv` means "apply nothing" — the ambient identity is used, preserving
+/// pre-#1265 behaviour.
+/// What: an ordered list of `(name, value)` pairs. Order is deterministic
+/// (identity var first when present, then `GH_HOST`) so tests can assert it.
+/// Test: every `resolve_*`/`precedence_*`/`host_*` test inspects `vars()`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GhEnv {
+    vars: Vec<(String, String)>,
+}
+
+impl GhEnv {
+    /// Borrow the resolved `(name, value)` overrides.
+    ///
+    /// Why: callers iterate these to call `Command::env`; tests iterate them
+    /// to assert the resolved set and ordering.
+    /// What: returns the override slice (possibly empty).
+    /// Test: read by every resolution test.
+    pub fn vars(&self) -> &[(String, String)] {
+        &self.vars
+    }
+
+    /// Whether any override is set (i.e. an identity binding is active).
+    ///
+    /// Why: lets callers cheaply distinguish "bound" from "ambient" without
+    /// allocating; useful for diagnostics.
+    /// What: true when at least one override is present.
+    /// Test: `resolve_absent_config_is_empty` asserts `is_empty()` for None.
+    pub fn is_empty(&self) -> bool {
+        self.vars.is_empty()
+    }
+}
+
+/// Apply the #2184 project-over-global precedence for a `github:` binding.
+///
+/// Why: a project's own `github:` section, when present, must win OUTRIGHT
+/// over the global section — not merge field-by-field — matching the existing
+/// "bound or absent" shape of `GithubConfig`. Centralising the `.or(...)` here
+/// (rather than inlining it at each call site) keeps the precedence rule
+/// documented and independently testable.
+/// What: returns `project` when `Some`, else `global`, else `None` (ambient).
+/// Test: `select_github_config_project_wins`,
+/// `select_github_config_falls_back_to_global`,
+/// `select_github_config_none_when_neither_set`.
+pub fn select_github_config<'a>(
+    project: Option<&'a GithubConfig>,
+    global: Option<&'a GithubConfig>,
+) -> Option<&'a GithubConfig> {
+    project.or(global)
+}
+
+/// Resolve an optional [`GithubConfig`] into the [`GhEnv`] for `gh` subprocesses.
+///
+/// Why: the single, tested place the #1265 precedence chain is applied so every
+/// `gh` call `tm` makes is bound to the same identity and no call site diverges.
+/// Keeping `token_env` resolution here (via `std::env::var` on the configured
+/// NAME) guarantees the plaintext secret never has to live in the config or be
+/// threaded through the call graph.
+/// What: returns an EMPTY `GhEnv` when `config` is `None`. Otherwise applies
+/// **`config_dir` > `token_env`(present) > `account`** for the identity var and
+/// ALWAYS appends `GH_HOST` when `host` is set. The `account`-only case returns
+/// [`GhIdentityError::AccountStrategyUnsupported`] (see module docs). A
+/// `token_env` whose named var is ABSENT is skipped, falling through to the next
+/// strategy.
+/// Test: `resolve_absent_config_is_empty`, `resolve_config_dir`,
+/// `resolve_token_env_present`, `resolve_token_env_absent_falls_through`,
+/// `precedence_config_dir_beats_token_env`,
+/// `precedence_token_env_beats_account`, `account_only_is_refused`,
+/// `host_always_applied`, `host_applied_with_identity`.
+pub fn resolve_gh_env(config: Option<&GithubConfig>) -> Result<GhEnv, GhIdentityError> {
+    let Some(cfg) = config else {
+        return Ok(GhEnv::default());
+    };
+
+    let mut vars: Vec<(String, String)> = Vec::new();
+
+    // --- Identity selection (precedence: config_dir > token_env > account) ---
+    if let Some(dir) = cfg
+        .config_dir
+        .as_deref()
+        .map(|p| p.to_string_lossy().trim().to_string())
+        .filter(|s| !s.is_empty())
+    {
+        vars.push((ENV_GH_CONFIG_DIR.to_string(), dir));
+    } else if let Some(token) = resolve_token_env(cfg.token_env.as_deref()) {
+        vars.push((ENV_GH_TOKEN.to_string(), token));
+    } else if let Some(account) = cfg
+        .account
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        // `account` alone cannot safely select an identity (see module docs).
+        return Err(GhIdentityError::AccountStrategyUnsupported(
+            account.to_string(),
+        ));
+    }
+
+    // --- Host is applied independently of the identity strategy. ------------
+    if let Some(host) = cfg.host.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        vars.push((ENV_GH_HOST.to_string(), host.to_string()));
+    }
+
+    Ok(GhEnv { vars })
+}
+
+/// Resolve the token NAMEd by `token_env` from the process environment.
+///
+/// Why: isolates the `std::env::var` lookup so the precedence logic stays
+/// readable and so the "named var absent → skip" rule is a single tested
+/// function. The plaintext token is read here and nowhere else.
+/// What: given `Some(name)`, returns `Some(value)` when the env var `name` is
+/// set to a non-empty value; returns `None` for an unset/empty var or a `None`
+/// name (trimming whitespace around the configured name).
+/// Test: covered via `resolve_token_env_present` /
+/// `resolve_token_env_absent_falls_through`.
+fn resolve_token_env(token_env: Option<&str>) -> Option<String> {
+    let name = token_env.map(str::trim).filter(|s| !s.is_empty())?;
+    let value = std::env::var(name).ok()?;
+    if value.is_empty() { None } else { Some(value) }
+}
+
+/// Resolve the effective gh host, honouring config with a `github.com` default.
+///
+/// Why: both `GH_HOST` and clone-URL synthesis need the same host answer; a
+/// single resolver keeps them aligned and applies the default in one place.
+/// What: returns the trimmed `config.host` when set and non-empty, else
+/// [`DEFAULT_GITHUB_HOST`].
+/// Test: `effective_host_default`, `effective_host_override`.
+pub fn effective_host(config: Option<&GithubConfig>) -> String {
+    config
+        .and_then(|c| c.host.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(DEFAULT_GITHUB_HOST)
+        .to_string()
+}
+
+/// Synthesise an HTTPS clone URL for `owner/repo`, honouring the configured host.
+///
+/// Why: watch/ticket synthesise a clone URL for a board that may live on GitHub
+/// Enterprise; hard-coding `github.com` breaks GHE (#1261). Routing through the
+/// resolved host fixes that while defaulting to the public host.
+/// What: returns `https://<effective-host>/<repo>` where `repo` is the
+/// `owner/repo` slug and the host comes from [`effective_host`].
+/// Test: `clone_url_default_host`, `clone_url_enterprise_host`.
+pub fn clone_url(config: Option<&GithubConfig>, repo: &str) -> String {
+    format!("https://{}/{}", effective_host(config), repo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// Serialise env mutation so the token-env tests cannot race each other
+    /// or the workspace-root tests across the shared test process.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        crate::core::trusty_tools_config::env_test_lock()
+    }
+
+    fn cfg() -> GithubConfig {
+        GithubConfig::default()
+    }
+
+    /// Why: an absent `github:` section must yield NO overrides so gh inherits
+    /// the ambient identity — the no-regression guarantee.
+    /// Test: itself.
+    #[test]
+    fn resolve_absent_config_is_empty() {
+        let env = resolve_gh_env(None).expect("none is ok");
+        assert!(env.is_empty());
+        assert_eq!(env.vars(), &[]);
+    }
+
+    /// Why: `config_dir` is the highest-precedence, least-invasive strategy and
+    /// must map to `GH_CONFIG_DIR`.
+    /// Test: itself.
+    #[test]
+    fn resolve_config_dir() {
+        let c = GithubConfig {
+            config_dir: Some(PathBuf::from("/home/bob/.config/gh-work")),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        assert_eq!(
+            env.vars(),
+            &[(
+                ENV_GH_CONFIG_DIR.to_string(),
+                "/home/bob/.config/gh-work".to_string()
+            )]
+        );
+    }
+
+    /// Why: `token_env` resolves the token from the NAMEd env var at call time
+    /// (the secret is never in config) → `GH_TOKEN`.
+    /// Test: itself.
+    #[test]
+    fn resolve_token_env_present() {
+        let _g = env_lock();
+        let name = "TM_TEST_GH_TOKEN_PRESENT_LIB";
+        // SAFETY: guarded by env_lock; removed below.
+        unsafe { std::env::set_var(name, "ghp_secret_value") };
+        let c = GithubConfig {
+            token_env: Some(name.to_string()),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        unsafe { std::env::remove_var(name) };
+        assert_eq!(
+            env.vars(),
+            &[(ENV_GH_TOKEN.to_string(), "ghp_secret_value".to_string())]
+        );
+    }
+
+    /// Why: a `token_env` whose named var is ABSENT must be skipped (precedence
+    /// falls through), NOT export an empty `GH_TOKEN`.
+    /// Test: itself.
+    #[test]
+    fn resolve_token_env_absent_falls_through() {
+        let _g = env_lock();
+        let name = "TM_TEST_GH_TOKEN_DEFINITELY_UNSET_LIB";
+        // SAFETY: guarded by env_lock.
+        unsafe { std::env::remove_var(name) };
+        let c = GithubConfig {
+            token_env: Some(name.to_string()),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        // No identity var set (and no host configured) → empty.
+        assert!(env.is_empty(), "expected empty, got {:?}", env.vars());
+    }
+
+    /// Why: `config_dir` must win over `token_env` even when the token var IS
+    /// present (precedence ordering).
+    /// Test: itself.
+    #[test]
+    fn precedence_config_dir_beats_token_env() {
+        let _g = env_lock();
+        let name = "TM_TEST_GH_TOKEN_PRECEDENCE_LIB";
+        // SAFETY: guarded by env_lock.
+        unsafe { std::env::set_var(name, "tok") };
+        let c = GithubConfig {
+            config_dir: Some(PathBuf::from("/cfg/dir")),
+            token_env: Some(name.to_string()),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        unsafe { std::env::remove_var(name) };
+        assert_eq!(
+            env.vars(),
+            &[(ENV_GH_CONFIG_DIR.to_string(), "/cfg/dir".to_string())]
+        );
+    }
+
+    /// Why: with no `config_dir`, a present `token_env` must win over `account`
+    /// (so the account caveat never triggers when a usable token exists).
+    /// Test: itself.
+    #[test]
+    fn precedence_token_env_beats_account() {
+        let _g = env_lock();
+        let name = "TM_TEST_GH_TOKEN_BEATS_ACCOUNT_LIB";
+        // SAFETY: guarded by env_lock.
+        unsafe { std::env::set_var(name, "tok2") };
+        let c = GithubConfig {
+            token_env: Some(name.to_string()),
+            account: Some("bob-work".to_string()),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        unsafe { std::env::remove_var(name) };
+        assert_eq!(
+            env.vars(),
+            &[(ENV_GH_TOKEN.to_string(), "tok2".to_string())]
+        );
+    }
+
+    /// Why: `account` alone cannot safely select an identity; the documented
+    /// decision is to refuse with a typed, actionable error.
+    /// Test: itself.
+    #[test]
+    fn account_only_is_refused() {
+        let c = GithubConfig {
+            account: Some("bob-work".to_string()),
+            ..cfg()
+        };
+        let err = resolve_gh_env(Some(&c)).unwrap_err();
+        assert_eq!(
+            err,
+            GhIdentityError::AccountStrategyUnsupported("bob-work".to_string())
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("config_dir"), "msg: {msg}");
+        assert!(msg.contains("token_env"), "msg: {msg}");
+    }
+
+    /// Why: `account` paired with a usable `config_dir` must NOT error — the
+    /// account documents intent while config_dir does the actual selection.
+    /// Test: itself.
+    #[test]
+    fn account_with_config_dir_is_ok() {
+        let c = GithubConfig {
+            config_dir: Some(PathBuf::from("/cfg/acct")),
+            account: Some("bob-work".to_string()),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        assert_eq!(
+            env.vars(),
+            &[(ENV_GH_CONFIG_DIR.to_string(), "/cfg/acct".to_string())]
+        );
+    }
+
+    /// Why: `host` must always be exported (as `GH_HOST`) when set, even with no
+    /// identity strategy configured.
+    /// Test: itself.
+    #[test]
+    fn host_always_applied() {
+        let c = GithubConfig {
+            host: Some("github.example.com".to_string()),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        assert_eq!(
+            env.vars(),
+            &[(ENV_GH_HOST.to_string(), "github.example.com".to_string())]
+        );
+    }
+
+    /// Why: host applies independently of (and in addition to) the identity var;
+    /// ordering is identity-first then host.
+    /// Test: itself.
+    #[test]
+    fn host_applied_with_identity() {
+        let c = GithubConfig {
+            config_dir: Some(PathBuf::from("/cfg")),
+            host: Some("ghe.corp".to_string()),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        assert_eq!(
+            env.vars(),
+            &[
+                (ENV_GH_CONFIG_DIR.to_string(), "/cfg".to_string()),
+                (ENV_GH_HOST.to_string(), "ghe.corp".to_string()),
+            ]
+        );
+    }
+
+    /// Why: the host resolver must default to `github.com` when unset.
+    /// Test: itself.
+    #[test]
+    fn effective_host_default() {
+        assert_eq!(effective_host(None), "github.com");
+        assert_eq!(effective_host(Some(&cfg())), "github.com");
+    }
+
+    /// Why: a configured host must override the default.
+    /// Test: itself.
+    #[test]
+    fn effective_host_override() {
+        let c = GithubConfig {
+            host: Some("github.example.com".to_string()),
+            ..cfg()
+        };
+        assert_eq!(effective_host(Some(&c)), "github.example.com");
+    }
+
+    /// Why: clone-URL synthesis defaults to the public host (no config).
+    /// Test: itself.
+    #[test]
+    fn clone_url_default_host() {
+        assert_eq!(
+            clone_url(None, "bobmatnyc/trusty-tools"),
+            "https://github.com/bobmatnyc/trusty-tools"
+        );
+    }
+
+    /// Why: clone-URL synthesis must honour a GHE host (closes #1261's GHE part).
+    /// Test: itself.
+    #[test]
+    fn clone_url_enterprise_host() {
+        let c = GithubConfig {
+            host: Some("github.example.com".to_string()),
+            ..cfg()
+        };
+        assert_eq!(
+            clone_url(Some(&c), "acme/widget"),
+            "https://github.example.com/acme/widget"
+        );
+    }
+
+    // ── #2184: project-over-global precedence ────────────────────────────────
+
+    /// Why: a project's own `github:` binding must win outright over the
+    /// global one when both are present.
+    /// Test: itself.
+    #[test]
+    fn select_github_config_project_wins() {
+        let project = GithubConfig {
+            account: Some("project-account".into()),
+            ..cfg()
+        };
+        let global = GithubConfig {
+            account: Some("global-account".into()),
+            ..cfg()
+        };
+        let selected = select_github_config(Some(&project), Some(&global));
+        assert_eq!(selected, Some(&project));
+    }
+
+    /// Why: with no project binding, the global one must be used.
+    /// Test: itself.
+    #[test]
+    fn select_github_config_falls_back_to_global() {
+        let global = GithubConfig {
+            account: Some("global-account".into()),
+            ..cfg()
+        };
+        let selected = select_github_config(None, Some(&global));
+        assert_eq!(selected, Some(&global));
+    }
+
+    /// Why: with neither tier set, resolution must fall through to the ambient
+    /// gh identity (represented here by `None`) — no regression.
+    /// Test: itself.
+    #[test]
+    fn select_github_config_none_when_neither_set() {
+        assert_eq!(select_github_config(None, None), None);
+    }
+}

--- a/crates/trusty-mpm/src/core/git_identity.rs
+++ b/crates/trusty-mpm/src/core/git_identity.rs
@@ -1,0 +1,339 @@
+//! Resolved git-operation identity: `gh`-auth env overrides plus an optional
+//! commit-author override, applied to the managed/provisioner git subprocesses
+//! (#2184).
+//!
+//! Why: [`crate::core::gh_identity`] resolves a `GithubConfig` into env
+//! overrides for `gh`/git-credential-helper auth, but the managed spawn path
+//! (`daemon::managed_routes::lifecycle::spawn_managed`) and the workspace
+//! provisioner (`provisioner::workspace::RealGitBackend`) need TWO things
+//! bundled together for every git subprocess they run: those same env
+//! overrides (so `git clone`/`fetch` over HTTPS authenticate as the right
+//! identity when a credential helper consults them) AND an optional commit
+//! author override (`-c user.name=`/`-c user.email=`) that #2184 introduces as
+//! a NET-NEW per-project setting — `tm` previously never set a commit identity
+//! on any git invocation it made. [`GitIdentity`] is that bundle;
+//! [`resolve_git_identity`] builds one from the resolved `GithubConfig` plus
+//! the project's own commit-identity fields; [`resolve_for_config`] is the
+//! convenience entry point that also finds the matching project (by
+//! `repo_url`) in a loaded [`TrustyToolsConfig`].
+//!
+//! What: `GitIdentity::env` are the `(name, value)` pairs to apply via
+//! `Command::envs`; `GitIdentity::commit_config_args` renders the `-c
+//! user.name=…`/`-c user.email=…` args to prepend to a `git` invocation (empty
+//! when neither is set, so an unconfigured project's git commands are
+//! byte-for-byte identical to pre-#2184 behaviour).
+//!
+//! Test: `resolve_git_identity_*`, `resolve_for_config_*`,
+//! `commit_config_args_*` in the inline `tests` module.
+
+use crate::core::gh_identity::{GhIdentityError, resolve_gh_env, select_github_config};
+use crate::core::trusty_tools_config::{GithubConfig, TrustyToolsConfig};
+use crate::project::record::repo_url_matches;
+
+/// A resolved git-operation identity: auth env overrides plus an optional
+/// commit-author override.
+///
+/// Why: bundling both concerns lets `RealGitBackend` apply a SINGLE resolved
+/// value to every git subprocess it runs, rather than threading two separate
+/// values through the `GitBackend` trait.
+/// What: `env` — ordered `(name, value)` overrides (mirrors
+/// [`crate::core::gh_identity::GhEnv::vars`]); `commit_name`/`commit_email` —
+/// optional git commit author overrides. All empty/`None` (the `Default`) is
+/// the pre-#2184 ambient behaviour: no env overrides, no commit identity
+/// applied.
+/// Test: `commit_config_args_empty_when_unset`,
+/// `commit_config_args_both_set`, `commit_config_args_name_only`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GitIdentity {
+    /// Env overrides to apply to the git subprocess (e.g. `GH_CONFIG_DIR`,
+    /// `GH_TOKEN`, `GH_HOST`) so an HTTPS credential helper picks the right
+    /// identity.
+    pub env: Vec<(String, String)>,
+    /// Git commit author name override, applied as `-c user.name=<name>`.
+    pub commit_name: Option<String>,
+    /// Git commit author email override, applied as `-c user.email=<email>`.
+    pub commit_email: Option<String>,
+}
+
+impl GitIdentity {
+    /// Whether this identity carries no overrides at all (fully ambient).
+    ///
+    /// Why: lets callers skip building a command wrapper entirely when there
+    /// is nothing to apply.
+    /// What: true when `env` is empty and both commit fields are `None`.
+    /// Test: covered by `resolve_git_identity_none_when_nothing_configured`.
+    pub fn is_empty(&self) -> bool {
+        self.env.is_empty() && self.commit_name.is_none() && self.commit_email.is_none()
+    }
+
+    /// Render the `-c user.name=…`/`-c user.email=…` args for a `git` command.
+    ///
+    /// Why: git accepts repeated `-c key=value` overrides BEFORE the
+    /// subcommand; centralising the rendering means every git subprocess site
+    /// builds the identical arg shape.
+    /// What: returns `[]` when neither field is set; otherwise one `-c
+    /// user.name=<name>` pair and/or one `-c user.email=<email>` pair, in that
+    /// order, only for the fields that are `Some`.
+    /// Test: `commit_config_args_empty_when_unset`,
+    /// `commit_config_args_both_set`, `commit_config_args_name_only`.
+    pub fn commit_config_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(name) = &self.commit_name {
+            args.push("-c".to_string());
+            args.push(format!("user.name={name}"));
+        }
+        if let Some(email) = &self.commit_email {
+            args.push("-c".to_string());
+            args.push(format!("user.email={email}"));
+        }
+        args
+    }
+}
+
+/// Build a [`GitIdentity`] from already-selected `GithubConfig` tiers plus
+/// commit-identity fields.
+///
+/// Why: the pure combination step — apply [`select_github_config`]'s
+/// project-over-global precedence, resolve it into env overrides via
+/// [`resolve_gh_env`], and attach the (project-scoped-only; #2184 does not
+/// define a global commit identity tier) commit author override — kept
+/// separate from any config/registry lookup so it is unit-testable without a
+/// loaded [`TrustyToolsConfig`].
+/// What: returns `Err` only when [`resolve_gh_env`] refuses an `account`-only
+/// binding (see `core::gh_identity` module docs).
+/// Test: `resolve_git_identity_project_overrides_global`,
+/// `resolve_git_identity_falls_back_to_global`,
+/// `resolve_git_identity_none_when_nothing_configured`,
+/// `resolve_git_identity_commit_identity_independent_of_github`.
+pub fn resolve_git_identity(
+    project_github: Option<&GithubConfig>,
+    global_github: Option<&GithubConfig>,
+    commit_name: Option<&str>,
+    commit_email: Option<&str>,
+) -> Result<GitIdentity, GhIdentityError> {
+    let selected = select_github_config(project_github, global_github);
+    let env = resolve_gh_env(selected)?;
+    Ok(GitIdentity {
+        env: env.vars().to_vec(),
+        commit_name: commit_name.map(str::to_string),
+        commit_email: commit_email.map(str::to_string),
+    })
+}
+
+/// Resolve the [`GitIdentity`] for `repo_url` from a loaded [`TrustyToolsConfig`].
+///
+/// Why: `spawn_managed`'s clone-based and local-redirect provisioning paths
+/// already load `TrustyToolsConfig` once per spawn; this is the one place that
+/// turns that config plus the target `repo_url` into the identity
+/// `RealGitBackend` should use, so the daemon's two call sites cannot diverge.
+/// What: finds the first `config.projects` entry whose `repo_url` matches (via
+/// [`repo_url_matches`], which compares parsed `owner/repo` when possible) and
+/// uses ITS `github`/`commit_name`/`commit_email` fields; falls back to the
+/// global `config.github` tier when no project matches or the matched project
+/// has no `github` binding of its own (commit identity is project-scoped only
+/// — no global fallback tier). No match at all → fully ambient `GitIdentity`
+/// (`is_empty()` — no regression).
+/// Test: `resolve_for_config_matches_project_by_repo_url`,
+/// `resolve_for_config_falls_back_to_global_github`,
+/// `resolve_for_config_ambient_when_no_match`.
+pub fn resolve_for_config(
+    config: &TrustyToolsConfig,
+    repo_url: &str,
+) -> Result<GitIdentity, GhIdentityError> {
+    let matched = config
+        .projects
+        .iter()
+        .find(|p| repo_url_matches(&p.repo_url, repo_url));
+
+    let project_github = matched.and_then(|p| p.github.as_ref());
+    let commit_name = matched.and_then(|p| p.commit_name.as_deref());
+    let commit_email = matched.and_then(|p| p.commit_email.as_deref());
+
+    resolve_git_identity(
+        project_github,
+        config.github.as_ref(),
+        commit_name,
+        commit_email,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gh(account: &str) -> GithubConfig {
+        GithubConfig {
+            account: None,
+            config_dir: Some(std::path::PathBuf::from(format!("/cfg/{account}"))),
+            token_env: None,
+            host: None,
+        }
+    }
+
+    // ── resolve_git_identity ──────────────────────────────────────────────
+
+    /// Why: a project-scoped `github:` binding must win over the global one.
+    /// Test: itself.
+    #[test]
+    fn resolve_git_identity_project_overrides_global() {
+        let project = gh("project");
+        let global = gh("global");
+        let identity = resolve_git_identity(Some(&project), Some(&global), None, None).expect("ok");
+        assert_eq!(
+            identity.env,
+            vec![("GH_CONFIG_DIR".to_string(), "/cfg/project".to_string())]
+        );
+    }
+
+    /// Why: with no project binding, the global tier must be used.
+    /// Test: itself.
+    #[test]
+    fn resolve_git_identity_falls_back_to_global() {
+        let global = gh("global");
+        let identity = resolve_git_identity(None, Some(&global), None, None).expect("ok");
+        assert_eq!(
+            identity.env,
+            vec![("GH_CONFIG_DIR".to_string(), "/cfg/global".to_string())]
+        );
+    }
+
+    /// Why: with nothing configured anywhere, the identity must be fully
+    /// ambient — no regression for projects with no #2184 binding.
+    /// Test: itself.
+    #[test]
+    fn resolve_git_identity_none_when_nothing_configured() {
+        let identity = resolve_git_identity(None, None, None, None).expect("ok");
+        assert!(identity.is_empty());
+    }
+
+    /// Why: commit identity is an independent axis from the `gh` env
+    /// overrides — it must apply even when no `github:` binding exists at
+    /// either tier.
+    /// Test: itself.
+    #[test]
+    fn resolve_git_identity_commit_identity_independent_of_github() {
+        let identity =
+            resolve_git_identity(None, None, Some("Bot"), Some("bot@example.com")).expect("ok");
+        assert!(identity.env.is_empty());
+        assert_eq!(identity.commit_name.as_deref(), Some("Bot"));
+        assert_eq!(identity.commit_email.as_deref(), Some("bot@example.com"));
+    }
+
+    // ── resolve_for_config ────────────────────────────────────────────────
+
+    fn project_config(
+        repo_url: &str,
+        github: Option<GithubConfig>,
+    ) -> crate::core::trusty_tools_config::ProjectConfig {
+        crate::core::trusty_tools_config::ProjectConfig {
+            name: "p".into(),
+            repo_url: repo_url.into(),
+            default_branch: None,
+            stack_hint: None,
+            tags: None,
+            description: None,
+            gh_user: None,
+            github,
+            commit_name: Some("Project Bot".into()),
+            commit_email: Some("bot@project.example.com".into()),
+        }
+    }
+
+    /// Why: `resolve_for_config` must find the project by matching `repo_url`
+    /// (tolerating `.git`/scheme differences via `repo_url_matches`) and use
+    /// its `github`/commit-identity fields.
+    /// Test: itself.
+    #[test]
+    fn resolve_for_config_matches_project_by_repo_url() {
+        let config = TrustyToolsConfig {
+            projects: vec![project_config(
+                "https://github.com/acme/widget.git",
+                Some(gh("project")),
+            )],
+            ..Default::default()
+        };
+        let identity = resolve_for_config(&config, "https://github.com/acme/widget").expect("ok");
+        assert_eq!(
+            identity.env,
+            vec![("GH_CONFIG_DIR".to_string(), "/cfg/project".to_string())]
+        );
+        assert_eq!(identity.commit_name.as_deref(), Some("Project Bot"));
+        assert_eq!(
+            identity.commit_email.as_deref(),
+            Some("bot@project.example.com")
+        );
+    }
+
+    /// Why: a project match with NO `github:` binding of its own must fall
+    /// back to the global tier (project-over-global, not project-only).
+    /// Test: itself.
+    #[test]
+    fn resolve_for_config_falls_back_to_global_github() {
+        let config = TrustyToolsConfig {
+            github: Some(gh("global")),
+            projects: vec![project_config("https://github.com/acme/widget", None)],
+            ..Default::default()
+        };
+        let identity = resolve_for_config(&config, "https://github.com/acme/widget").expect("ok");
+        assert_eq!(
+            identity.env,
+            vec![("GH_CONFIG_DIR".to_string(), "/cfg/global".to_string())]
+        );
+    }
+
+    /// Why: a `repo_url` matching NO declared project must resolve to a fully
+    /// ambient identity — the no-regression guarantee for repos `tm` clones
+    /// that were never declared in `config.projects`.
+    /// Test: itself.
+    #[test]
+    fn resolve_for_config_ambient_when_no_match() {
+        let config = TrustyToolsConfig::default();
+        let identity = resolve_for_config(&config, "https://github.com/someone/else").expect("ok");
+        assert!(identity.is_empty());
+    }
+
+    // ── commit_config_args ────────────────────────────────────────────────
+
+    /// Why: an unconfigured identity must render NO `-c` args, so a git
+    /// invocation for a project with no commit-identity override is
+    /// byte-for-byte identical to pre-#2184 behaviour.
+    /// Test: itself.
+    #[test]
+    fn commit_config_args_empty_when_unset() {
+        assert!(GitIdentity::default().commit_config_args().is_empty());
+    }
+
+    /// Why: both fields set must render both `-c` pairs, name before email.
+    /// Test: itself.
+    #[test]
+    fn commit_config_args_both_set() {
+        let identity = GitIdentity {
+            commit_name: Some("Bot".into()),
+            commit_email: Some("bot@example.com".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            identity.commit_config_args(),
+            vec![
+                "-c".to_string(),
+                "user.name=Bot".to_string(),
+                "-c".to_string(),
+                "user.email=bot@example.com".to_string(),
+            ]
+        );
+    }
+
+    /// Why: only the set field must render — no spurious empty override.
+    /// Test: itself.
+    #[test]
+    fn commit_config_args_name_only() {
+        let identity = GitIdentity {
+            commit_name: Some("Bot".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            identity.commit_config_args(),
+            vec!["-c".to_string(), "user.name=Bot".to_string()]
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -37,6 +37,8 @@ pub mod error;
 pub mod external_session;
 pub mod frontmatter;
 pub mod gh_account;
+pub mod gh_identity;
+pub mod git_identity;
 pub mod home_trust_seed;
 pub mod hook;
 pub mod instruction_overrides;

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -294,6 +294,55 @@ pub struct ProjectConfig {
     /// ([`crate::core::gh_account::resolve_gh_account_env`]).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gh_user: Option<String>,
+
+    /// Per-project `gh`-CLI identity binding (#2184), overriding the global
+    /// `github:` section for this project only.
+    ///
+    /// Why: #1265's `github:` section is a single global binding, but a host
+    /// working on several projects may need a DIFFERENT `gh` identity per
+    /// project (e.g. a personal account for an OSS repo, a work account for a
+    /// client repo). This is a SEPARATE concern from `gh_user` above: `gh_user`
+    /// only documents a preferred login for the non-mutating
+    /// `ensure_gh_account_for_project` enforcement path (#2081), while `github`
+    /// carries the full `config_dir`/`token_env`/`account`/`host` binding that
+    /// [`crate::core::gh_identity::resolve_gh_env`] resolves into concrete env
+    /// overrides for every `gh` subprocess `tm` spawns for this project.
+    /// What: `None` → this project has no override; resolution falls back to
+    /// the global `github:` section, then to the ambient gh identity (no
+    /// regression). `Some(cfg)` → `cfg` is resolved in place of the global
+    /// section for every `gh` call scoped to this project. Mirrored onto the
+    /// seeded [`crate::project::record::Project::github`] by `seed_from_config`.
+    /// Test: `project_config_github_and_commit_identity_yaml_round_trip`;
+    /// resolution precedence in `core::gh_identity`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github: Option<GithubConfig>,
+
+    /// Preferred git commit author name for commits made on behalf of this
+    /// project (#2184).
+    ///
+    /// Why: `tm`'s managed/provisioner git operations previously never set a
+    /// commit identity, inheriting whatever `user.name` happened to be
+    /// globally configured (or none, causing a hard commit failure). A
+    /// per-project override lets an operator pin the right author for
+    /// projects that require a specific bot/service identity, independent of
+    /// the `gh`-CLI identity above (commit authorship and `gh` API auth are
+    /// distinct git/GitHub concerns).
+    /// What: `None` → no override; git uses whatever `user.name` is already
+    /// configured (no regression). `Some(name)` → applied as `-c
+    /// user.name=<name>` on every git invocation the provisioner makes for
+    /// this project. Mirrored onto
+    /// [`crate::project::record::Project::commit_name`] by `seed_from_config`.
+    /// Test: `project_config_github_and_commit_identity_yaml_round_trip`;
+    /// applied via `core::git_identity::GitIdentity::commit_config_args`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_name: Option<String>,
+
+    /// Preferred git commit author email for commits made on behalf of this
+    /// project (#2184). See [`Self::commit_name`] for the full rationale;
+    /// applied as `-c user.email=<email>` alongside it.
+    /// Test: `project_config_github_and_commit_identity_yaml_round_trip`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_email: Option<String>,
 }
 
 impl TrustyToolsConfig {
@@ -590,6 +639,9 @@ mod tests {
                 tags: None,
                 description: None,
                 gh_user: Some("bobmatnyc".into()),
+                github: None,
+                commit_name: None,
+                commit_email: None,
             }],
             ..Default::default()
         };
@@ -608,11 +660,76 @@ mod tests {
                 tags: None,
                 description: None,
                 gh_user: None,
+                github: None,
+                commit_name: None,
+                commit_email: None,
             }],
             ..Default::default()
         };
         let yaml_no_pref = serde_yaml::to_string(&no_pref).expect("serialise");
         assert!(!yaml_no_pref.contains("gh_user"), "yaml: {yaml_no_pref}");
+    }
+
+    /// Why (#2184): a project's per-project `github:` binding and commit
+    /// identity (`commit_name`/`commit_email`) must round-trip through YAML,
+    /// and absent fields must not serialise — matching every other optional
+    /// `ProjectConfig` field so existing configs deserialise unchanged.
+    /// Test: itself.
+    #[test]
+    fn project_config_github_and_commit_identity_yaml_round_trip() {
+        let cfg = TrustyToolsConfig {
+            projects: vec![ProjectConfig {
+                name: "work-repo".into(),
+                repo_url: "https://github.com/acme/work-repo".into(),
+                default_branch: None,
+                stack_hint: None,
+                tags: None,
+                description: None,
+                gh_user: None,
+                github: Some(GithubConfig {
+                    config_dir: Some(PathBuf::from("/home/bob/.config/gh-work")),
+                    token_env: None,
+                    account: Some("bob-work".into()),
+                    host: None,
+                }),
+                commit_name: Some("Bob (work bot)".into()),
+                commit_email: Some("bob@acme.example.com".into()),
+            }],
+            ..Default::default()
+        };
+        let yaml = serde_yaml::to_string(&cfg).expect("serialise");
+        assert!(yaml.contains("github:"), "yaml: {yaml}");
+        assert!(yaml.contains("commit_name"), "yaml: {yaml}");
+        assert!(yaml.contains("commit_email"), "yaml: {yaml}");
+        let back: TrustyToolsConfig = serde_yaml::from_str(&yaml).expect("deserialise");
+        assert_eq!(cfg, back);
+
+        // Absent per-project github/commit fields must not serialise.
+        let minimal = TrustyToolsConfig {
+            projects: vec![ProjectConfig {
+                name: "minimal".into(),
+                repo_url: "https://github.com/o/minimal".into(),
+                default_branch: None,
+                stack_hint: None,
+                tags: None,
+                description: None,
+                gh_user: None,
+                github: None,
+                commit_name: None,
+                commit_email: None,
+            }],
+            ..Default::default()
+        };
+        let yaml_minimal = serde_yaml::to_string(&minimal).expect("serialise");
+        assert!(!yaml_minimal.contains("github:"), "yaml: {yaml_minimal}");
+        assert!(
+            !yaml_minimal.contains("commit_name"),
+            "yaml: {yaml_minimal}"
+        );
+        assert!(
+            !yaml_minimal.contains("commit_email"),
+            "yaml: {yaml_minimal}"
+        );
     }
 
     /// Why: the `daemon:` section (#1836) must round-trip through YAML, and an

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -308,6 +308,19 @@ async fn spawn_managed_cloned(
 ) -> Result<SessionRecord, String> {
     use crate::core::provisioning_stage::{ProvisioningStage, emit};
 
+    // #2184: resolve the per-project gh identity + commit identity ONCE for
+    // this spawn (project `github:`/commit fields in `config.projects` >
+    // global `github:` > fully ambient) and apply it to every git subprocess
+    // the provisioner runs below. A `GhIdentityError` (the `account`-only
+    // refusal — see `core::gh_identity` module docs) is surfaced as a spawn
+    // failure BEFORE any provisioning side effect, mirroring how the MCP
+    // spawn gate above already fails closed before touching disk.
+    let git_identity = crate::core::git_identity::resolve_for_config(&config, &params.repo_url)
+        .map_err(|e| {
+            warn!(id = %session_id, "spawn_managed: git identity resolution failed: {e}");
+            format!("git identity resolution failed: {e}")
+        })?;
+
     // Provision an isolated workspace under the pre-generated `session_id` (the id
     // is generated ONCE in `spawn_managed`, before the local-path/clone branch
     // split, so both branches register the same id).
@@ -330,7 +343,7 @@ async fn spawn_managed_cloned(
             // `provision_in` only appends the session id; pass an empty workspace
             // root because the project dir is already absolute.
             let provisioner = WorkspaceProvisioner::new(
-                crate::provisioner::RealGitBackend,
+                crate::provisioner::RealGitBackend::new(git_identity),
                 std::path::PathBuf::new(),
             );
             provisioner.provision_in(
@@ -343,8 +356,10 @@ async fn spawn_managed_cloned(
         }
         None => {
             let workspace_root = crate::core::trusty_tools_config::workspace_root(&config);
-            let provisioner =
-                WorkspaceProvisioner::new(crate::provisioner::RealGitBackend, workspace_root);
+            let provisioner = WorkspaceProvisioner::new(
+                crate::provisioner::RealGitBackend::new(git_identity),
+                workspace_root,
+            );
             provisioner.provision(&session_id, &params.repo_url, &params.git_ref, &params.task)
         }
     }
@@ -832,8 +847,16 @@ async fn spawn_managed_local(
     let source_id_str = format!("{}/{}", gh.owner, gh.repo);
     let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
     let project_dir = crate::core::trusty_tools_config::workspace_subpath(&config, &gh);
+    // #2184: same per-project identity resolution as the clone-based path
+    // (`spawn_managed_cloned`) — this branch also provisions a managed clone
+    // (of `origin_url`), so it must honour the same binding.
+    let git_identity = crate::core::git_identity::resolve_for_config(&config, &origin_url)
+        .map_err(|e| {
+            warn!(id = %session_id, "spawn_managed (local→managed): git identity resolution failed: {e}");
+            format!("git identity resolution failed: {e}")
+        })?;
     let provisioner = crate::provisioner::WorkspaceProvisioner::new(
-        crate::provisioner::RealGitBackend,
+        crate::provisioner::RealGitBackend::new(git_identity),
         std::path::PathBuf::new(),
     );
     let prepared = provisioner

--- a/crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs
@@ -251,6 +251,9 @@ mod tests {
             tags: vec![],
             description: None,
             gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/mcp_backend.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend.rs
@@ -523,13 +523,32 @@ impl OrchestratorBackend for StateBackend {
         super::mcp_console::config_read()
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn config_write(
         &self,
         workspace_root_template: Option<&str>,
         auto_resume: Option<bool>,
         default_model: Option<&str>,
+        project_name: Option<&str>,
+        github_config_dir: Option<&str>,
+        github_token_env: Option<&str>,
+        github_account: Option<&str>,
+        github_host: Option<&str>,
+        commit_name: Option<&str>,
+        commit_email: Option<&str>,
     ) -> Result<Value, String> {
-        super::mcp_console::config_write(workspace_root_template, auto_resume, default_model)
+        super::mcp_console::config_write(
+            workspace_root_template,
+            auto_resume,
+            default_model,
+            project_name,
+            github_config_dir,
+            github_token_env,
+            github_account,
+            github_host,
+            commit_name,
+            commit_email,
+        )
     }
 
     // ── #1519 WI-2: project-registry tools (delegate to mcp_project) ─────────

--- a/crates/trusty-mpm/src/daemon/mcp_console.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_console.rs
@@ -157,15 +157,22 @@ pub async fn auto_resume_set(enabled: bool) -> Result<Value, String> {
 /// Why: both `config_read` and `config_write` return the same shape — the raw
 /// config fields plus the `workspace_root` the resolver would actually use — so the
 /// UI can show the effective path even when the template field is null. One helper
-/// keeps the two tools in lockstep.
-/// What: returns `{ workspace_root_template, auto_resume, default_model,
-/// workspace_root }` where `workspace_root` is [`trusty_tools_config::workspace_root`].
-/// Test: `config_read_returns_resolved_root`.
+/// keeps the two tools in lockstep. #2184 adds the global `github` binding and the
+/// full `projects` list (each entry now carries its own optional `github`/
+/// `commit_name`/`commit_email` per-project override) so the Config tab can render
+/// and edit them without a separate MCP round-trip or hand-editing the YAML.
+/// What: returns `{ workspace_root_template, auto_resume, default_model, github,
+/// projects, workspace_root }` where `workspace_root` is
+/// [`trusty_tools_config::workspace_root`].
+/// Test: `config_read_returns_resolved_root`,
+/// `config_to_json_includes_github_and_projects`.
 fn config_to_json(config: &TrustyToolsConfig) -> Value {
     json!({
         "workspace_root_template": config.workspace_root_template,
         "auto_resume": config.auto_resume,
         "default_model": config.default_model,
+        "github": config.github,
+        "projects": config.projects,
         "workspace_root": trusty_tools_config::workspace_root(config).to_string_lossy(),
     })
 }
@@ -184,19 +191,96 @@ pub fn config_read() -> Result<Value, String> {
 /// Back the `config_write` tool: merge edits and persist the config file.
 ///
 /// Why: the console Config tab's save action durably records the operator's
-/// workspace-root / auto-resume / default-model choices (#1220) without touching
-/// the legacy `~/.trusty-mpm/config.toml`.
-/// What: loads the current config, overlays only the supplied fields (omitted
-/// fields stay unchanged), writes it back via
-/// [`trusty_common::crate_config::save`], and returns the merged config (with the
-/// resolved root) on success.
-/// Test: `config_write_merges_and_persists`.
+/// workspace-root / auto-resume / default-model choices (#1220), and — since
+/// #2184 — the global GitHub identity binding plus per-project GitHub/commit
+/// identity overrides, all without touching the legacy
+/// `~/.trusty-mpm/config.toml` or requiring the operator to hand-edit YAML.
+/// What: loads the current config, applies [`apply_config_write`] (the
+/// testable merge step), writes it back via
+/// [`trusty_common::crate_config::save`], and returns the merged config (with
+/// the resolved root) on success.
+/// Test: `config_write_merges_and_persists` covers `apply_config_write`
+/// directly (no real filesystem I/O against the operator's real config file —
+/// see that function's own doc for why `config_write` itself is not unit
+/// tested against the real file).
+#[allow(clippy::too_many_arguments)]
 pub fn config_write(
     workspace_root_template: Option<&str>,
     auto_resume: Option<bool>,
     default_model: Option<&str>,
+    project_name: Option<&str>,
+    github_config_dir: Option<&str>,
+    github_token_env: Option<&str>,
+    github_account: Option<&str>,
+    github_host: Option<&str>,
+    commit_name: Option<&str>,
+    commit_email: Option<&str>,
 ) -> Result<Value, String> {
     let mut config = TrustyToolsConfig::load();
+    apply_config_write(
+        &mut config,
+        workspace_root_template,
+        auto_resume,
+        default_model,
+        project_name,
+        github_config_dir,
+        github_token_env,
+        github_account,
+        github_host,
+        commit_name,
+        commit_email,
+    )?;
+
+    trusty_common::crate_config::save(trusty_tools_config::CRATE_NAME, &config)
+        .map_err(|e| format!("persisting trusty-mpm config: {e}"))?;
+
+    Ok(config_to_json(&config))
+}
+
+/// The pure merge step behind `config_write` (#2184).
+///
+/// Why: `config_write` persists to the operator's REAL
+/// `~/.trusty-tools/trusty-mpm/config.yaml` (there is no dependency-injected
+/// base directory in production), so unit-testing `config_write` itself would
+/// mutate the developer's actual config file on every `cargo test` run.
+/// Extracting the merge decision into a pure `&mut TrustyToolsConfig` function
+/// makes the actual field-merge logic — including the #2184 `project_name`
+/// routing — fully unit-testable in memory, with `config_write` reduced to
+/// "load, merge, save".
+/// What: when `workspace_root_template`/`auto_resume`/`default_model` are
+/// `Some`, they overlay the corresponding TOP-LEVEL field (unchanged
+/// behaviour, #1220). When `project_name` is `None`, the `github_*` args
+/// overlay the GLOBAL `config.github` tier (creating it if absent and at
+/// least one `github_*` field is supplied); `commit_*` args with no
+/// `project_name` are rejected (#2184 defines commit identity as
+/// project-scoped only). When `project_name` is `Some(name)`, the `github_*`
+/// AND `commit_*` args overlay the MATCHING entry in `config.projects`
+/// instead — `Err` when no entry with that `name` already exists
+/// (`config_write` deliberately does not fabricate a `ProjectConfig` with an
+/// empty `repo_url`; register the project first via `project_register` or a
+/// static `config.projects` entry). Each `github_*` field only overlays its
+/// own sub-field — omitted sub-fields keep their previous value, matching the
+/// top-level "omitted fields unchanged" contract.
+/// Test: `config_write_merges_top_level_fields`,
+/// `config_write_sets_global_github_binding`,
+/// `config_write_sets_project_github_and_commit_identity`,
+/// `config_write_project_not_found_errors`,
+/// `config_write_preserves_omitted_github_subfields`,
+/// `config_write_global_commit_identity_rejected`.
+#[allow(clippy::too_many_arguments)]
+fn apply_config_write(
+    config: &mut TrustyToolsConfig,
+    workspace_root_template: Option<&str>,
+    auto_resume: Option<bool>,
+    default_model: Option<&str>,
+    project_name: Option<&str>,
+    github_config_dir: Option<&str>,
+    github_token_env: Option<&str>,
+    github_account: Option<&str>,
+    github_host: Option<&str>,
+    commit_name: Option<&str>,
+    commit_email: Option<&str>,
+) -> Result<(), String> {
     if let Some(t) = workspace_root_template {
         config.workspace_root_template = Some(t.to_string());
     }
@@ -207,10 +291,102 @@ pub fn config_write(
         config.default_model = Some(m.to_string());
     }
 
-    trusty_common::crate_config::save(trusty_tools_config::CRATE_NAME, &config)
-        .map_err(|e| format!("persisting trusty-mpm config: {e}"))?;
+    let has_github_edit = github_config_dir.is_some()
+        || github_token_env.is_some()
+        || github_account.is_some()
+        || github_host.is_some();
+    let has_commit_edit = commit_name.is_some() || commit_email.is_some();
+    if !has_github_edit && !has_commit_edit {
+        return Ok(());
+    }
 
-    Ok(config_to_json(&config))
+    match project_name {
+        None => {
+            if has_github_edit {
+                config.github = Some(merge_github_config(
+                    config.github.take(),
+                    github_config_dir,
+                    github_token_env,
+                    github_account,
+                    github_host,
+                ));
+            }
+            // #2184 defines commit identity as PROJECT-scoped only (no global
+            // tier) — a caller supplying commit_name/commit_email with no
+            // project_name has nowhere to persist them.
+            if has_commit_edit {
+                return Err(
+                    "commit_name/commit_email require project_name (commit identity is \
+                     project-scoped; there is no global commit identity tier)"
+                        .to_string(),
+                );
+            }
+        }
+        Some(name) => {
+            let entry = config
+                .projects
+                .iter_mut()
+                .find(|p| p.name == name)
+                .ok_or_else(|| {
+                    format!(
+                        "project '{name}' not found in config.projects; register it first \
+                         (e.g. via `project_register` or a static config.yaml entry) before \
+                         setting its github/commit identity"
+                    )
+                })?;
+            if has_github_edit {
+                entry.github = Some(merge_github_config(
+                    entry.github.take(),
+                    github_config_dir,
+                    github_token_env,
+                    github_account,
+                    github_host,
+                ));
+            }
+            if let Some(n) = commit_name {
+                entry.commit_name = Some(n.to_string());
+            }
+            if let Some(e) = commit_email {
+                entry.commit_email = Some(e.to_string());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Overlay supplied `github_*` sub-fields onto an existing (or absent)
+/// [`trusty_tools_config::GithubConfig`], keeping omitted sub-fields unchanged.
+///
+/// Why: shared by both the global and per-project branches of
+/// [`apply_config_write`] so the "only overlay what was supplied" rule cannot
+/// drift between the two.
+/// What: starts from `existing.unwrap_or_default()`, overlays each `Some`
+/// argument onto the matching field, and returns the result (never
+/// meaningfully empty — the caller only invokes this when at least one
+/// `github_*` field was supplied).
+/// Test: `config_write_preserves_omitted_github_subfields`.
+fn merge_github_config(
+    existing: Option<trusty_tools_config::GithubConfig>,
+    config_dir: Option<&str>,
+    token_env: Option<&str>,
+    account: Option<&str>,
+    host: Option<&str>,
+) -> trusty_tools_config::GithubConfig {
+    let mut cfg = existing.unwrap_or_default();
+    if let Some(d) = config_dir {
+        cfg.config_dir = Some(d.into());
+    }
+    if let Some(t) = token_env {
+        cfg.token_env = Some(t.to_string());
+    }
+    if let Some(a) = account {
+        cfg.account = Some(a.to_string());
+    }
+    if let Some(h) = host {
+        cfg.host = Some(h.to_string());
+    }
+    cfg
 }
 
 #[cfg(test)]
@@ -237,6 +413,276 @@ mod tests {
                 && !got["workspace_root"].as_str().unwrap().is_empty(),
             "workspace_root must be a non-empty resolved path: {got}"
         );
+    }
+
+    /// Why: `config_to_json` must surface the #2184 `github`/`projects` fields
+    /// so the Config tab can render/edit them without a separate round-trip.
+    /// Test: this test.
+    #[test]
+    fn config_to_json_includes_github_and_projects() {
+        let config = TrustyToolsConfig {
+            github: Some(trusty_tools_config::GithubConfig {
+                config_dir: Some("/cfg/global".into()),
+                token_env: None,
+                account: None,
+                host: None,
+            }),
+            projects: vec![trusty_tools_config::ProjectConfig {
+                name: "widget".into(),
+                repo_url: "https://github.com/acme/widget".into(),
+                default_branch: None,
+                stack_hint: None,
+                tags: None,
+                description: None,
+                gh_user: None,
+                github: None,
+                commit_name: Some("Bot".into()),
+                commit_email: None,
+            }],
+            ..Default::default()
+        };
+        let json = config_to_json(&config);
+        assert_eq!(json["github"]["config_dir"], "/cfg/global");
+        assert_eq!(json["projects"][0]["name"], "widget");
+        assert_eq!(json["projects"][0]["commit_name"], "Bot");
+    }
+
+    // ── apply_config_write (#2184) — pure merge logic, no real config file I/O ──
+
+    fn project(name: &str) -> trusty_tools_config::ProjectConfig {
+        trusty_tools_config::ProjectConfig {
+            name: name.to_string(),
+            repo_url: format!("https://github.com/acme/{name}"),
+            default_branch: None,
+            stack_hint: None,
+            tags: None,
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        }
+    }
+
+    /// Why: the pre-#2184 top-level fields must still merge exactly as before
+    /// (no regression from the new params).
+    /// Test: this test.
+    #[test]
+    fn config_write_merges_top_level_fields() {
+        let mut config = TrustyToolsConfig::default();
+        apply_config_write(
+            &mut config,
+            Some("~/custom-projects"),
+            Some(true),
+            Some("opus"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("ok");
+        assert_eq!(
+            config.workspace_root_template.as_deref(),
+            Some("~/custom-projects")
+        );
+        assert_eq!(config.auto_resume, Some(true));
+        assert_eq!(config.default_model.as_deref(), Some("opus"));
+        assert_eq!(config.github, None, "no github edit supplied");
+    }
+
+    /// Why: with no `project_name`, `github_*` fields must set the GLOBAL
+    /// `config.github` tier.
+    /// Test: this test.
+    #[test]
+    fn config_write_sets_global_github_binding() {
+        let mut config = TrustyToolsConfig::default();
+        apply_config_write(
+            &mut config,
+            None,
+            None,
+            None,
+            None,
+            Some("/cfg/global"),
+            None,
+            None,
+            Some("github.example.com"),
+            None,
+            None,
+        )
+        .expect("ok");
+        let gh = config.github.expect("global github set");
+        assert_eq!(
+            gh.config_dir.as_deref(),
+            Some(std::path::Path::new("/cfg/global"))
+        );
+        assert_eq!(gh.host.as_deref(), Some("github.example.com"));
+    }
+
+    /// Why: with `project_name` set, `github_*`/`commit_*` fields must
+    /// overlay the MATCHING `config.projects` entry, not the global tier.
+    /// Test: this test.
+    #[test]
+    fn config_write_sets_project_github_and_commit_identity() {
+        let mut config = TrustyToolsConfig {
+            projects: vec![project("widget")],
+            ..Default::default()
+        };
+        apply_config_write(
+            &mut config,
+            None,
+            None,
+            None,
+            Some("widget"),
+            Some("/cfg/widget"),
+            None,
+            Some("bob-work"),
+            None,
+            Some("Widget Bot"),
+            Some("widget-bot@example.com"),
+        )
+        .expect("ok");
+        assert_eq!(config.github, None, "global tier must be untouched");
+        let entry = &config.projects[0];
+        let gh = entry.github.as_ref().expect("project github set");
+        assert_eq!(
+            gh.config_dir.as_deref(),
+            Some(std::path::Path::new("/cfg/widget"))
+        );
+        assert_eq!(gh.account.as_deref(), Some("bob-work"));
+        assert_eq!(entry.commit_name.as_deref(), Some("Widget Bot"));
+        assert_eq!(
+            entry.commit_email.as_deref(),
+            Some("widget-bot@example.com")
+        );
+    }
+
+    /// Why: setting a project's identity for a `project_name` that is NOT
+    /// already declared in `config.projects` must error, never fabricate a
+    /// `ProjectConfig` with an empty `repo_url`.
+    /// Test: this test.
+    #[test]
+    fn config_write_project_not_found_errors() {
+        let mut config = TrustyToolsConfig::default();
+        let err = apply_config_write(
+            &mut config,
+            None,
+            None,
+            None,
+            Some("does-not-exist"),
+            Some("/cfg/x"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("does-not-exist"), "err: {err}");
+        assert!(err.contains("not found"), "err: {err}");
+    }
+
+    /// Why: `merge_github_config` must overlay only the SUPPLIED sub-fields,
+    /// preserving whatever was already set for the omitted ones — matching
+    /// the top-level "omitted fields unchanged" contract.
+    /// Test: this test.
+    #[test]
+    fn config_write_preserves_omitted_github_subfields() {
+        let mut config = TrustyToolsConfig {
+            github: Some(trusty_tools_config::GithubConfig {
+                config_dir: Some("/cfg/original".into()),
+                token_env: None,
+                account: Some("original-account".into()),
+                host: None,
+            }),
+            ..Default::default()
+        };
+        // Only update `host`; config_dir/account must survive untouched.
+        apply_config_write(
+            &mut config,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("github.example.com"),
+            None,
+            None,
+        )
+        .expect("ok");
+        let gh = config.github.expect("github still set");
+        assert_eq!(
+            gh.config_dir.as_deref(),
+            Some(std::path::Path::new("/cfg/original"))
+        );
+        assert_eq!(gh.account.as_deref(), Some("original-account"));
+        assert_eq!(gh.host.as_deref(), Some("github.example.com"));
+    }
+
+    /// Why: commit identity is project-scoped only (#2184) — supplying
+    /// `commit_name`/`commit_email` with no `project_name` must be rejected
+    /// rather than silently discarded or persisted somewhere unexpected.
+    /// Test: this test.
+    #[test]
+    fn config_write_global_commit_identity_rejected() {
+        let mut config = TrustyToolsConfig::default();
+        let err = apply_config_write(
+            &mut config,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("Global Bot"),
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("project_name"), "err: {err}");
+    }
+
+    /// Why: the doc-referenced round-trip contract — every supplied field
+    /// makes it into the merged config and NOTHING supplied is silently
+    /// dropped. Exercises the full param list together (the shape
+    /// `config_write` itself passes through to `apply_config_write`).
+    /// Test: this test.
+    #[test]
+    fn config_write_merges_and_persists() {
+        let mut config = TrustyToolsConfig {
+            projects: vec![project("widget")],
+            ..Default::default()
+        };
+        apply_config_write(
+            &mut config,
+            Some("~/custom-projects"),
+            Some(false),
+            Some("sonnet"),
+            Some("widget"),
+            Some("/cfg/widget"),
+            Some("WIDGET_GH_TOKEN"),
+            None,
+            Some("github.example.com"),
+            Some("Widget Bot"),
+            Some("widget-bot@example.com"),
+        )
+        .expect("ok");
+        assert_eq!(
+            config.workspace_root_template.as_deref(),
+            Some("~/custom-projects")
+        );
+        assert_eq!(config.auto_resume, Some(false));
+        assert_eq!(config.default_model.as_deref(), Some("sonnet"));
+        let entry = &config.projects[0];
+        let gh = entry.github.as_ref().expect("project github set");
+        assert_eq!(gh.token_env.as_deref(), Some("WIDGET_GH_TOKEN"));
+        assert_eq!(gh.host.as_deref(), Some("github.example.com"));
+        assert_eq!(entry.commit_name.as_deref(), Some("Widget Bot"));
     }
 
     /// Why: the console deserialises the report with `parse_report`; the tool must

--- a/crates/trusty-mpm/src/daemon/mcp_project.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_project.rs
@@ -67,6 +67,13 @@ pub async fn project_register(
     description: Option<&str>,
     gh_user: Option<&str>,
 ) -> Result<Value, String> {
+    let registry = state.project_registry().await;
+    // #2184: `register` REPLACES the whole record and `project_register`'s
+    // params don't carry the github/commit-identity binding (operators set
+    // those via `config_write`'s per-project fields instead) — preserve any
+    // existing binding across a `project_register` call rather than silently
+    // wiping it.
+    let existing = registry.get(name).await.ok();
     let project = Project {
         name: name.to_string(),
         repo_url: repo_url.to_string(),
@@ -75,8 +82,10 @@ pub async fn project_register(
         tags: tags.unwrap_or_default(),
         description: description.map(str::to_string),
         gh_user: gh_user.map(str::to_string),
+        github: existing.as_ref().and_then(|p| p.github.clone()),
+        commit_name: existing.as_ref().and_then(|p| p.commit_name.clone()),
+        commit_email: existing.as_ref().and_then(|p| p.commit_email.clone()),
     };
-    let registry = state.project_registry().await;
     registry
         .register(project.clone())
         .await

--- a/crates/trusty-mpm/src/mcp/mod.rs
+++ b/crates/trusty-mpm/src/mcp/mod.rs
@@ -284,16 +284,31 @@ pub trait OrchestratorBackend: Send + Sync {
     /// Back `config_write`: persist edits to the config-convention file.
     ///
     /// Why: the console Config tab's save action durably records the operator's
-    ///      workspace-root / auto-resume / default-model choices (#1220).
+    ///      workspace-root / auto-resume / default-model choices (#1220), and —
+    ///      since #2184 — the global GitHub identity binding plus per-project
+    ///      GitHub/commit identity overrides, all MCP-settable without
+    ///      hand-editing YAML.
     /// What: merges the supplied fields onto the current config (omitted fields
     ///      unchanged), writes `~/.trusty-tools/trusty-mpm/config.yaml`, and returns
-    ///      the merged config that was persisted.
+    ///      the merged config that was persisted. `project_name` routes the
+    ///      `github_*`/`commit_*` fields to that `config.projects` entry instead of
+    ///      the global `github:` section; omitting it targets the global section
+    ///      (commit identity has no global tier — supplying `commit_name`/
+    ///      `commit_email` with no `project_name` is an error).
     /// Test: `dispatch_config_write_tool` (mock).
+    #[allow(clippy::too_many_arguments)]
     async fn config_write(
         &self,
         workspace_root_template: Option<&str>,
         auto_resume: Option<bool>,
         default_model: Option<&str>,
+        project_name: Option<&str>,
+        github_config_dir: Option<&str>,
+        github_token_env: Option<&str>,
+        github_account: Option<&str>,
+        github_host: Option<&str>,
+        commit_name: Option<&str>,
+        commit_email: Option<&str>,
     ) -> Result<Value, String>;
 
     // ── #1519 WI-2: project-registry tools ───────────────────────────────────
@@ -484,8 +499,26 @@ async fn dispatch_tool_call<B: OrchestratorBackend>(
             let template = args.get("workspace_root_template").and_then(Value::as_str);
             let auto_resume = args.get("auto_resume").and_then(Value::as_bool);
             let default_model = args.get("default_model").and_then(Value::as_str);
+            let project_name = args.get("project_name").and_then(Value::as_str);
+            let github_config_dir = args.get("github_config_dir").and_then(Value::as_str);
+            let github_token_env = args.get("github_token_env").and_then(Value::as_str);
+            let github_account = args.get("github_account").and_then(Value::as_str);
+            let github_host = args.get("github_host").and_then(Value::as_str);
+            let commit_name = args.get("commit_name").and_then(Value::as_str);
+            let commit_email = args.get("commit_email").and_then(Value::as_str);
             backend
-                .config_write(template, auto_resume, default_model)
+                .config_write(
+                    template,
+                    auto_resume,
+                    default_model,
+                    project_name,
+                    github_config_dir,
+                    github_token_env,
+                    github_account,
+                    github_host,
+                    commit_name,
+                    commit_email,
+                )
                 .await
         }
         // #1519 WI-2: the three project-registry tools route through a sibling

--- a/crates/trusty-mpm/src/mcp/tests.rs
+++ b/crates/trusty-mpm/src/mcp/tests.rs
@@ -162,17 +162,28 @@ impl OrchestratorBackend for MockBackend {
             "workspace_root": "/home/test/trusty-mpm-projects",
         }))
     }
+    #[allow(clippy::too_many_arguments)]
     async fn config_write(
         &self,
         workspace_root_template: Option<&str>,
         auto_resume: Option<bool>,
         default_model: Option<&str>,
+        project_name: Option<&str>,
+        github_config_dir: Option<&str>,
+        _github_token_env: Option<&str>,
+        _github_account: Option<&str>,
+        _github_host: Option<&str>,
+        commit_name: Option<&str>,
+        _commit_email: Option<&str>,
     ) -> Result<Value, String> {
         Ok(json!({
             "workspace_root_template": workspace_root_template,
             "auto_resume": auto_resume,
             "default_model": default_model,
             "workspace_root": workspace_root_template.unwrap_or("/home/test/trusty-mpm-projects"),
+            "project_name": project_name,
+            "github_config_dir": github_config_dir,
+            "commit_name": commit_name,
         }))
     }
 

--- a/crates/trusty-mpm/src/mcp/tools/console.rs
+++ b/crates/trusty-mpm/src/mcp/tools/console.rs
@@ -81,8 +81,11 @@ pub(super) fn console_tools() -> Vec<Value> {
             "config_read",
             "Read trusty-mpm's `~/.trusty-tools/trusty-mpm/config.yaml` (the #1220 \
              cross-crate config convention) and return its current settings as JSON: \
-             `workspace_root_template`, `auto_resume`, and `default_model`. An absent \
-             file returns the defaults (all null). Backs the trusty-console Config tab.",
+             `workspace_root_template`, `auto_resume`, `default_model`, the global \
+             `github` GitHub-identity binding, and the full `projects` list (each \
+             entry may carry its own `github`/`commit_name`/`commit_email` \
+             per-project override, #2184). An absent file returns the defaults (all \
+             null/empty). Backs the trusty-console Config tab.",
             json!({
                 "type": "object",
                 "properties": {},
@@ -91,12 +94,21 @@ pub(super) fn console_tools() -> Vec<Value> {
         ),
         tool(
             "config_write",
-            "Write trusty-mpm's `~/.trusty-tools/trusty-mpm/config.yaml` (#1220). \
-             Supplied fields replace the corresponding settings; omitted fields are \
-             left unchanged. `workspace_root_template` sets the managed-session \
-             workspace root (a leading `~` is expanded); `auto_resume` sets the \
-             supervisor default; `default_model` sets the launch model. Returns the \
-             merged config that was persisted.",
+            "Write trusty-mpm's `~/.trusty-tools/trusty-mpm/config.yaml` (#1220, \
+             #2184). Supplied fields replace the corresponding settings; omitted \
+             fields are left unchanged. `workspace_root_template` sets the \
+             managed-session workspace root (a leading `~` is expanded); \
+             `auto_resume` sets the supervisor default; `default_model` sets the \
+             launch model. The `github_*` fields set a GitHub-CLI identity binding \
+             (`config_dir` > `token_env` > `account`, plus `host`) — with no \
+             `project_name` they set the GLOBAL binding; with `project_name` set to \
+             an ALREADY-REGISTERED project (via `project_register` or a static \
+             `config.projects` entry) they set that project's OWN binding instead, \
+             which takes precedence over the global one for that project's `gh` \
+             calls. `commit_name`/`commit_email` set a per-project git commit-author \
+             override applied to managed/provisioner git operations — they REQUIRE \
+             `project_name` (commit identity has no global tier). Returns the merged \
+             config that was persisted.",
             json!({
                 "type": "object",
                 "properties": {
@@ -111,6 +123,34 @@ pub(super) fn console_tools() -> Vec<Value> {
                     "default_model": {
                         "type": "string",
                         "description": "Default model id or tier alias for launched sessions."
+                    },
+                    "project_name": {
+                        "type": "string",
+                        "description": "Route the github_*/commit_* fields to this ALREADY-REGISTERED project's own binding instead of the global one."
+                    },
+                    "github_config_dir": {
+                        "type": "string",
+                        "description": "Private gh config home (GH_CONFIG_DIR) — highest-precedence identity strategy."
+                    },
+                    "github_token_env": {
+                        "type": "string",
+                        "description": "NAME (never the value) of an env var to resolve a gh token from at call time."
+                    },
+                    "github_account": {
+                        "type": "string",
+                        "description": "gh username documenting intent; must be paired with github_config_dir to actually select an identity."
+                    },
+                    "github_host": {
+                        "type": "string",
+                        "description": "gh host (e.g. a GitHub Enterprise host); defaults to github.com."
+                    },
+                    "commit_name": {
+                        "type": "string",
+                        "description": "Git commit author name override for this project (requires project_name)."
+                    },
+                    "commit_email": {
+                        "type": "string",
+                        "description": "Git commit author email override for this project (requires project_name)."
                     }
                 },
                 "additionalProperties": false

--- a/crates/trusty-mpm/src/project/record.rs
+++ b/crates/trusty-mpm/src/project/record.rs
@@ -10,6 +10,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::core::trusty_tools_config::GithubConfig;
+
 /// A project entry in the project registry.
 ///
 /// Why: the registry tracks repositories an operator works with so that session
@@ -80,6 +82,79 @@ pub struct Project {
     /// Test: `project_serde_round_trip`, `project_without_optionals`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gh_user: Option<String>,
+
+    /// Per-project `gh`-CLI identity binding, mirrored from
+    /// [`crate::core::trusty_tools_config::ProjectConfig::github`] (#2184).
+    ///
+    /// Why: `seed_from_config` upserts static `projects:` entries into the
+    /// registry; carrying the binding onto the registry record lets
+    /// `project_get`/`project_list` surface it via MCP without a separate
+    /// config-file read. Resolution (project > global > ambient) is applied by
+    /// [`crate::core::gh_identity::select_github_config`], not here.
+    /// What: `None` → no per-project override (falls back to the global
+    /// `github:` section, then ambient). `Some(cfg)` → the full `gh` identity
+    /// binding for this project.
+    /// Test: `project_serde_round_trip`, `project_without_optionals`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github: Option<GithubConfig>,
+
+    /// Preferred git commit author name for this project, mirrored from
+    /// [`crate::core::trusty_tools_config::ProjectConfig::commit_name`] (#2184).
+    /// `None` → no override; applied via
+    /// [`crate::core::git_identity::GitIdentity::commit_config_args`] when set.
+    /// Test: `project_serde_round_trip`, `project_without_optionals`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_name: Option<String>,
+
+    /// Preferred git commit author email for this project, mirrored from
+    /// [`crate::core::trusty_tools_config::ProjectConfig::commit_email`]
+    /// (#2184). See [`Self::commit_name`].
+    /// Test: `project_serde_round_trip`, `project_without_optionals`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_email: Option<String>,
+}
+
+/// Compare two repository URLs for identity, tolerating scheme/`.git`/
+/// trailing-slash differences (#2184).
+///
+/// Why: `resolve_for_config`'s project lookup must match
+/// `https://github.com/owner/repo`, `https://github.com/owner/repo.git`, and
+/// `git@github.com:owner/repo.git` as the SAME project — operators write
+/// `repo_url` in whichever form is convenient, and the URL `spawn_managed`
+/// receives (or the CLI's detected origin) may use a different form than the
+/// one declared in `config.projects`.
+/// What: parses both sides via [`trusty_common::github_path::parse_github_path`]
+/// and compares the slugified `owner`/`repo` case-insensitively when BOTH
+/// parse; falls back to a normalised (trailing-slash- and `.git`-stripped)
+/// exact string comparison when either side fails to parse (e.g. a bare local
+/// path), so non-GitHub-shaped inputs still get a sensible exact-match result
+/// instead of silently never matching.
+/// Test: `repo_url_matches_https_vs_git_suffix`, `repo_url_matches_ssh_form`,
+/// `repo_url_matches_case_insensitive`, `repo_url_matches_rejects_different_repo`,
+/// `repo_url_matches_falls_back_to_string_compare`.
+pub fn repo_url_matches(a: &str, b: &str) -> bool {
+    match (
+        trusty_common::github_path::parse_github_path(a),
+        trusty_common::github_path::parse_github_path(b),
+    ) {
+        (Some(pa), Some(pb)) => {
+            pa.owner.eq_ignore_ascii_case(&pb.owner) && pa.repo.eq_ignore_ascii_case(&pb.repo)
+        }
+        _ => normalise_repo_url(a) == normalise_repo_url(b),
+    }
+}
+
+/// Normalise a repo URL for the exact-string fallback in [`repo_url_matches`].
+///
+/// Why: isolated so the fallback rule (trim trailing `/`, strip trailing
+/// `.git`, lowercase) is a single tested transform.
+/// What: returns a lowercased copy with a trailing `/` and `.git` suffix
+/// stripped.
+/// Test: covered via `repo_url_matches_falls_back_to_string_compare`.
+fn normalise_repo_url(url: &str) -> String {
+    url.trim_end_matches('/')
+        .trim_end_matches(".git")
+        .to_lowercase()
 }
 
 /// Derive a project name from a repository URL by stripping the `.git` suffix
@@ -129,9 +204,20 @@ mod tests {
             tags: vec!["backend".into(), "oss".into()],
             description: Some("the unified trusty workspace".into()),
             gh_user: Some("bobmatnyc".into()),
+            github: Some(GithubConfig {
+                config_dir: Some("/home/bob/.config/gh-work".into()),
+                token_env: None,
+                account: None,
+                host: None,
+            }),
+            commit_name: Some("Bob".into()),
+            commit_email: Some("bob@example.com".into()),
         };
         let json = serde_json::to_string(&p).expect("serialize");
         assert!(json.contains("gh_user"), "json: {json}");
+        assert!(json.contains("github"), "json: {json}");
+        assert!(json.contains("commit_name"), "json: {json}");
+        assert!(json.contains("commit_email"), "json: {json}");
         let back: Project = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(p, back);
     }
@@ -147,6 +233,9 @@ mod tests {
             tags: vec![],
             description: None,
             gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
         };
         let json = serde_json::to_string(&p).expect("serialize");
         assert!(
@@ -161,9 +250,76 @@ mod tests {
             !json.contains("tags"),
             "empty tags must not serialise: {json}"
         );
+        assert!(
+            // NOTE: `repo_url`'s value legitimately contains the substring
+            // "github" (github.com), so the check must look for the JSON KEY
+            // `"github":`, not the bare substring.
+            !json.contains("\"github\":"),
+            "absent github binding must not serialise: {json}"
+        );
+        assert!(
+            !json.contains("commit_name") && !json.contains("commit_email"),
+            "absent commit identity must not serialise: {json}"
+        );
         let back: Project = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.stack_hint, None);
         assert!(back.tags.is_empty());
+    }
+
+    // ── repo_url_matches (#2184) ─────────────────────────────────────────────
+
+    /// Why: the SAME repo declared with and without a `.git` suffix must match.
+    /// Test: itself.
+    #[test]
+    fn repo_url_matches_https_vs_git_suffix() {
+        assert!(repo_url_matches(
+            "https://github.com/acme/widget",
+            "https://github.com/acme/widget.git"
+        ));
+    }
+
+    /// Why: an SSH-form remote must match its HTTPS equivalent.
+    /// Test: itself.
+    #[test]
+    fn repo_url_matches_ssh_form() {
+        assert!(repo_url_matches(
+            "git@github.com:acme/widget.git",
+            "https://github.com/acme/widget"
+        ));
+    }
+
+    /// Why: owner/repo comparison must be case-insensitive (GitHub logins are).
+    /// Test: itself.
+    #[test]
+    fn repo_url_matches_case_insensitive() {
+        assert!(repo_url_matches(
+            "https://github.com/Acme/Widget",
+            "https://github.com/acme/widget"
+        ));
+    }
+
+    /// Why: a different repo (even same owner) must NOT match.
+    /// Test: itself.
+    #[test]
+    fn repo_url_matches_rejects_different_repo() {
+        assert!(!repo_url_matches(
+            "https://github.com/acme/widget",
+            "https://github.com/acme/gadget"
+        ));
+    }
+
+    /// Why: an input `parse_github_path` cannot derive an identity from (e.g.
+    /// an empty string or a bare host-only URL) must fall back to normalised
+    /// exact-string comparison rather than panicking or always matching.
+    /// Test: itself.
+    #[test]
+    fn repo_url_matches_falls_back_to_string_compare() {
+        assert!(repo_url_matches("", ""));
+        assert!(!repo_url_matches("", "https://github.com/acme/widget"));
+        assert!(!repo_url_matches(
+            "https://github.com/",
+            "https://gitlab.com/"
+        ));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/project/registry.rs
+++ b/crates/trusty-mpm/src/project/registry.rs
@@ -108,6 +108,12 @@ impl ProjectRegistry {
                 tags: entry.tags.clone().unwrap_or_default(),
                 description: entry.description.clone(),
                 gh_user: entry.gh_user.clone(),
+                // #2184: mirror the per-project gh identity + commit identity
+                // onto the registry record so `project_get`/`project_list`
+                // surface it without a separate config-file read.
+                github: entry.github.clone(),
+                commit_name: entry.commit_name.clone(),
+                commit_email: entry.commit_email.clone(),
             };
             let name = project.name.clone();
             if let Err(e) = self.register(project).await {
@@ -164,6 +170,12 @@ impl ProjectRegistry {
                 tags: vec![],
                 description: None,
                 gh_user: None,
+                // No source of a gh/commit identity binding for an implicitly
+                // auto-registered project (#2184) — the operator declares
+                // these explicitly via `config.projects`/`config_write`.
+                github: None,
+                commit_name: None,
+                commit_email: None,
             };
             if let Err(e) = self.register(project).await {
                 warn!(name = %name, "auto_register: failed to register: {e}");
@@ -245,6 +257,9 @@ mod tests {
             tags: vec![],
             description: None,
             gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
         };
         registry.register(p.clone()).await.expect("register once");
         registry
@@ -269,6 +284,9 @@ mod tests {
             tags: vec!["backend".into()],
             description: Some("desc".into()),
             gh_user: Some("bob-work".into()),
+            github: None,
+            commit_name: None,
+            commit_email: None,
         };
         registry.register(p.clone()).await.expect("register");
 
@@ -296,6 +314,9 @@ mod tests {
                 tags: vec![],
                 description: None,
                 gh_user: None,
+                github: None,
+                commit_name: None,
+                commit_email: None,
             };
             registry.register(p).await.expect("register");
         }
@@ -318,6 +339,14 @@ mod tests {
                 tags: Some(vec!["ml".into()]),
                 description: Some("ml project".into()),
                 gh_user: Some("bobmatnyc".into()),
+                github: Some(crate::core::trusty_tools_config::GithubConfig {
+                    config_dir: Some("/home/bob/.config/gh-ml".into()),
+                    token_env: None,
+                    account: None,
+                    host: None,
+                }),
+                commit_name: Some("ML Bot".into()),
+                commit_email: Some("ml-bot@example.com".into()),
             },
             ProjectConfig {
                 name: "from-config-b".into(),
@@ -327,6 +356,9 @@ mod tests {
                 tags: None,
                 description: None,
                 gh_user: None,
+                github: None,
+                commit_name: None,
+                commit_email: None,
             },
         ];
 
@@ -341,12 +373,24 @@ mod tests {
         assert_eq!(a.stack_hint.as_deref(), Some("python"));
         assert_eq!(a.default_branch, "main");
         assert_eq!(a.gh_user.as_deref(), Some("bobmatnyc"));
+        // #2184: the github/commit-identity binding must be mirrored onto the
+        // registry record verbatim.
+        assert_eq!(
+            a.github.as_ref().and_then(|g| g.config_dir.as_deref()),
+            Some(std::path::Path::new("/home/bob/.config/gh-ml"))
+        );
+        assert_eq!(a.commit_name.as_deref(), Some("ML Bot"));
+        assert_eq!(a.commit_email.as_deref(), Some("ml-bot@example.com"));
 
-        // Entry without default_branch must fall back to "main"; gh_user stays
-        // unset (no regression for configs that predate #2081).
+        // Entry without default_branch must fall back to "main"; gh_user and
+        // the #2184 github/commit-identity fields stay unset (no regression
+        // for configs that predate #2081/#2184).
         let b = registry.get("from-config-b").await.expect("get b");
         assert_eq!(b.default_branch, "main");
         assert_eq!(b.gh_user, None);
+        assert_eq!(b.github, None);
+        assert_eq!(b.commit_name, None);
+        assert_eq!(b.commit_email, None);
     }
 
     #[tokio::test]
@@ -395,6 +439,9 @@ mod tests {
             tags: vec![],
             description: Some("manually registered".into()),
             gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
         };
         registry.register(existing).await.expect("pre-register");
 

--- a/crates/trusty-mpm/src/project/resolver/tests.rs
+++ b/crates/trusty-mpm/src/project/resolver/tests.rs
@@ -23,6 +23,9 @@ fn proj(name: &str, repo_url: &str) -> Project {
         tags: vec![],
         description: None,
         gh_user: None,
+        github: None,
+        commit_name: None,
+        commit_email: None,
     }
 }
 
@@ -35,6 +38,9 @@ fn proj_tagged(name: &str, repo_url: &str, tags: &[&str], desc: &str) -> Project
         tags: tags.iter().map(|s| s.to_string()).collect(),
         description: Some(desc.to_string()),
         gh_user: None,
+        github: None,
+        commit_name: None,
+        commit_email: None,
     }
 }
 

--- a/crates/trusty-mpm/src/project/store.rs
+++ b/crates/trusty-mpm/src/project/store.rs
@@ -249,6 +249,9 @@ mod tests {
             tags: vec![],
             description: None,
             gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
         }
     }
 
@@ -360,6 +363,14 @@ mod tests {
             tags: vec!["frontend".into(), "oss".into()],
             description: Some("a fully-populated project".into()),
             gh_user: Some("bobmatnyc".into()),
+            github: Some(crate::core::trusty_tools_config::GithubConfig {
+                config_dir: Some("/home/bob/.config/gh-full".into()),
+                token_env: None,
+                account: None,
+                host: Some("github.example.com".into()),
+            }),
+            commit_name: Some("Full Bot".into()),
+            commit_email: Some("full-bot@example.com".into()),
         };
         store.upsert(full.clone()).await.expect("upsert full");
 

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -184,7 +184,53 @@ pub trait GitBackend: Send + Sync {
 /// Test: used in the `#[ignore]` integration test only; unit tests use
 /// `FakeGitBackend`. The empty-ref contract is locked in by
 /// `blank_git_ref_omits_branch_flag` in `workspace.rs` tests.
-pub struct RealGitBackend;
+#[derive(Debug, Clone, Default)]
+pub struct RealGitBackend {
+    /// Resolved per-project GitHub identity (#2184): env overrides applied to
+    /// every git subprocess plus an optional commit author override. The
+    /// `Default` (empty) identity reproduces pre-#2184 behaviour exactly — no
+    /// env overrides, no `-c user.*` args — so every construction site that
+    /// has no project context (`RealGitBackend::default()`, e.g. the
+    /// framework catalog sync) is unaffected.
+    identity: crate::core::git_identity::GitIdentity,
+}
+
+impl RealGitBackend {
+    /// Construct a backend bound to a resolved per-project [`GitIdentity`]
+    /// (#2184).
+    ///
+    /// Why: the daemon's `spawn_managed` path resolves ONE identity per spawn
+    /// (via `core::git_identity::resolve_for_config`) and must apply it to
+    /// every git subprocess the provisioner runs for that session.
+    /// What: stores `identity`; every `GitBackend` method below applies it via
+    /// [`Self::command`].
+    /// Test: `git_identity_env_applied_to_command`,
+    /// `git_identity_commit_args_applied_to_command`.
+    pub fn new(identity: crate::core::git_identity::GitIdentity) -> Self {
+        Self { identity }
+    }
+
+    /// Build a `git` [`std::process::Command`] with this backend's resolved
+    /// identity applied.
+    ///
+    /// Why: every git subprocess this backend spawns must apply the SAME
+    /// identity (env overrides for auth, `-c user.*` for commit authorship);
+    /// centralising the construction means no call site can diverge or forget
+    /// one half of the identity.
+    /// What: `-c user.name=…`/`-c user.email=…` (when set) are added BEFORE
+    /// any subcommand args (git accepts `-c` overrides only in that
+    /// position); the resolved env overrides are applied via `Command::envs`.
+    /// An empty (`Default`) identity produces a plain `git` command
+    /// byte-for-byte equivalent to the pre-#2184 `Command::new("git")`.
+    /// Test: `git_identity_env_applied_to_command`,
+    /// `git_identity_commit_args_applied_to_command`.
+    fn command(&self) -> std::process::Command {
+        let mut cmd = std::process::Command::new("git");
+        cmd.args(self.identity.commit_config_args());
+        cmd.envs(self.identity.env.iter().cloned());
+        cmd
+    }
+}
 
 // #1935 review findings (PR #1936): bare-checkout detection + the advisory
 // provisioning lock live in the `base_lock` submodule to keep this file under
@@ -202,7 +248,6 @@ impl GitBackend for RealGitBackend {
         git_ref: &str,
         target_dir: &Path,
     ) -> Result<(), ProvisionError> {
-        use std::process::Command;
         // When `git_ref` is blank omit `--branch` entirely so git clones the
         // remote's default branch (HEAD). An empty `--branch ""` arg causes
         // git to fail with "not a valid branch name" rather than falling back.
@@ -217,7 +262,10 @@ impl GitBackend for RealGitBackend {
         // Use the destination's parent as cwd so a deleted inherited cwd cannot
         // cause git to fail with "fatal: Unable to read current working directory".
         let cwd = target_dir.parent().unwrap_or(std::path::Path::new("/"));
-        let out = Command::new("git")
+        // #2184: applies the resolved per-project identity (env overrides +
+        // commit args) to this clone; a `Default` identity is a no-op.
+        let out = self
+            .command()
             .args(&args)
             .current_dir(cwd)
             .output()
@@ -240,9 +288,9 @@ impl GitBackend for RealGitBackend {
     }
 
     fn remote_url(&self, dir: &Path) -> Result<String, ProvisionError> {
-        use std::process::Command;
         let dir_s = dir.to_string_lossy();
-        let out = Command::new("git")
+        let out = self
+            .command()
             .args(["-C", &dir_s, "remote", "get-url", "origin"])
             .output()
             .map_err(|e| ProvisionError::Git(format!("git remote get-url exec failed: {e}")))?;
@@ -257,13 +305,13 @@ impl GitBackend for RealGitBackend {
     }
 
     fn fetch_and_reset(&self, dir: &Path, git_ref: &str) -> Result<(), ProvisionError> {
-        use std::process::Command;
         let dir_s = dir.to_string_lossy();
         // Fetch the specific ref so tags and SHAs work correctly.
         // `git fetch origin <ref>` writes FETCH_HEAD; `git reset --hard FETCH_HEAD`
         // then works for branches, tags, and commit SHAs alike — unlike
         // `origin/<ref>` which only resolves for branches.
-        let fetch = Command::new("git")
+        let fetch = self
+            .command()
             .args(["-C", &dir_s, "fetch", "origin", git_ref])
             .output()
             .map_err(|e| ProvisionError::Git(format!("git fetch exec failed: {e}")))?;
@@ -271,7 +319,8 @@ impl GitBackend for RealGitBackend {
             let stderr = String::from_utf8_lossy(&fetch.stderr);
             return Err(ProvisionError::Git(format!("git fetch failed: {stderr}")));
         }
-        let reset = Command::new("git")
+        let reset = self
+            .command()
             .args(["-C", &dir_s, "reset", "--hard", "FETCH_HEAD"])
             .output()
             .map_err(|e| ProvisionError::Git(format!("git reset exec failed: {e}")))?;
@@ -324,7 +373,6 @@ impl GitBackend for RealGitBackend {
     /// non-bare repo at `base_dir` and asserts a loud error, not silent
     /// reuse), both in `provisioner/workspace/tests.rs`.
     fn ensure_base_checkout(&self, repo_url: &str, base_dir: &Path) -> Result<(), ProvisionError> {
-        use std::process::Command;
         // A bare clone has no working tree of its own, so it can never conflict
         // with a session worktree checking out the same branch (a non-bare
         // clone's own checked-out branch would collide with a worktree trying
@@ -373,7 +421,8 @@ impl GitBackend for RealGitBackend {
         // Use the destination's parent as cwd so a deleted inherited cwd cannot
         // cause git to fail with "fatal: Unable to read current working directory".
         let cwd = base_dir.parent().unwrap_or(std::path::Path::new("/"));
-        let out = Command::new("git")
+        let out = self
+            .command()
             .args(["clone", "--bare", repo_url])
             .arg(base_dir)
             .current_dir(cwd)
@@ -398,7 +447,6 @@ impl GitBackend for RealGitBackend {
         worktree_path: &Path,
         branch_name: &str,
     ) -> Result<(), ProvisionError> {
-        use std::process::Command;
         let base_s = base_dir.to_string_lossy();
         // Blank git_ref means "the remote's default branch" — mirror clone_repo's
         // blank-ref handling by fetching `HEAD` (the remote's default branch
@@ -414,7 +462,8 @@ impl GitBackend for RealGitBackend {
         // other session's `worktree add` observes. The leading `+` allows a
         // non-fast-forward overwrite in case a retry reuses `branch_name`.
         let refspec = format!("+{src_ref}:refs/heads/{branch_name}");
-        let fetch = Command::new("git")
+        let fetch = self
+            .command()
             .args(["-C", &base_s, "fetch", "origin", &refspec])
             .output()
             .map_err(|e| ProvisionError::Git(format!("git fetch exec failed: {e}")))?;
@@ -427,7 +476,8 @@ impl GitBackend for RealGitBackend {
             std::fs::create_dir_all(parent)?;
         }
 
-        let out = Command::new("git")
+        let out = self
+            .command()
             .args(["-C", &base_s, "worktree", "add"])
             .arg(worktree_path)
             .arg(branch_name)

--- a/crates/trusty-mpm/src/provisioner/workspace/tests.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/tests.rs
@@ -384,7 +384,9 @@ fn ensure_base_checkout_recovers_from_concurrent_race() {
         .map(|_| {
             let repo_url = repo_url.clone();
             let base_dir = base_dir.clone();
-            std::thread::spawn(move || RealGitBackend.ensure_base_checkout(&repo_url, &base_dir))
+            std::thread::spawn(move || {
+                RealGitBackend::default().ensure_base_checkout(&repo_url, &base_dir)
+            })
         })
         .collect();
 
@@ -452,7 +454,7 @@ fn ensure_base_checkout_rejects_stale_non_bare_directory() {
         "sanity check: a lone HEAD file with no repo structure must NOT read as bare"
     );
 
-    let result = RealGitBackend.ensure_base_checkout(&repo_url, &base_dir);
+    let result = RealGitBackend::default().ensure_base_checkout(&repo_url, &base_dir);
     assert!(
         result.is_err(),
         "a stale non-repo directory must be rejected loudly, not silently reused: {result:?}"
@@ -588,5 +590,76 @@ fn base_checkout_lock_recovers_stale_lock_marker() {
     assert!(
         !lock_path.exists(),
         "dropping the lock guard must remove the marker file"
+    );
+}
+
+// ── #2184: RealGitBackend applies the resolved GitIdentity to every command ──
+
+/// Why: a `RealGitBackend::default()` (no identity resolved) must build a
+/// PLAIN `git` command — no env overrides, no `-c` args — so every existing
+/// production call site (which constructs `RealGitBackend::default()` when it
+/// has no project context) is byte-for-byte unaffected by #2184.
+/// Test: itself.
+#[test]
+fn default_identity_produces_plain_git_command() {
+    let backend = RealGitBackend::default();
+    let cmd = backend.command();
+    assert_eq!(
+        cmd.get_args().count(),
+        0,
+        "no -c args for an empty identity"
+    );
+    assert_eq!(
+        cmd.get_envs().count(),
+        0,
+        "no env overrides for an empty identity"
+    );
+}
+
+/// Why: the resolved `GitIdentity::env` overrides must be applied to every
+/// command this backend builds, so `git`/its credential helper authenticate
+/// as the right per-project identity.
+/// Test: itself.
+#[test]
+fn git_identity_env_applied_to_command() {
+    let identity = crate::core::git_identity::GitIdentity {
+        env: vec![("GH_CONFIG_DIR".to_string(), "/cfg/project".to_string())],
+        commit_name: None,
+        commit_email: None,
+    };
+    let backend = RealGitBackend::new(identity);
+    let cmd = backend.command();
+    let envs: Vec<_> = cmd.get_envs().collect();
+    assert!(
+        envs.iter().any(|(k, v)| {
+            *k == std::ffi::OsStr::new("GH_CONFIG_DIR")
+                && *v == Some(std::ffi::OsStr::new("/cfg/project"))
+        }),
+        "GH_CONFIG_DIR override must be applied: {envs:?}"
+    );
+}
+
+/// Why: a resolved commit-identity override must render as `-c user.name=…`/
+/// `-c user.email=…` BEFORE any subcommand arg (git only accepts `-c`
+/// overrides in that position).
+/// Test: itself.
+#[test]
+fn git_identity_commit_args_applied_to_command() {
+    let identity = crate::core::git_identity::GitIdentity {
+        env: vec![],
+        commit_name: Some("Bot".to_string()),
+        commit_email: Some("bot@example.com".to_string()),
+    };
+    let backend = RealGitBackend::new(identity);
+    let cmd = backend.command();
+    let args: Vec<&std::ffi::OsStr> = cmd.get_args().collect();
+    assert_eq!(
+        args,
+        vec![
+            std::ffi::OsStr::new("-c"),
+            std::ffi::OsStr::new("user.name=Bot"),
+            std::ffi::OsStr::new("-c"),
+            std::ffi::OsStr::new("user.email=bot@example.com"),
+        ]
     );
 }

--- a/crates/trusty-mpm/tests/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/tests/mcp_spawn_gate.rs
@@ -184,6 +184,9 @@ async fn mcp_initiated_spawn_rejects_repo_name_impersonation() {
             tags: vec![],
             description: None,
             gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
         })
         .await
         .expect("register legitimate project");
@@ -242,6 +245,9 @@ async fn mcp_initiated_spawn_allowed_for_registered_project_reaches_provisioning
             tags: vec![],
             description: None,
             gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
         })
         .await
         .expect("register project");

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -628,7 +628,7 @@ fn live_provision_real_repo() {
     }
 
     let root = TempDir::new().unwrap();
-    let prov = WorkspaceProvisioner::new(RealGitBackend, root.path().to_owned());
+    let prov = WorkspaceProvisioner::new(RealGitBackend::default(), root.path().to_owned());
     let id = ManagedSessionId::new();
     let repo_url = format!("file://{}", bare.display());
     let ws = prov


### PR DESCRIPTION
## Summary

Implements #2184: per-project GitHub identity binding in trusty-mpm, applied to CLI + daemon/provisioner git ops, and MCP-settable.

- **Per-project gh binding**: `ProjectConfig`/`Project` gain an optional `github` field (same shape as the existing global `#1265` `github:` section). Resolution precedence is **project > global > ambient**, centralised in the new `core::gh_identity::select_github_config`.
- **Per-project commit identity** (net-new): `ProjectConfig`/`Project` gain `commit_name`/`commit_email`. Applied as `-c user.name=…`/`-c user.email=…` on every git subprocess `RealGitBackend` runs, via the new `core::git_identity::GitIdentity` bundle.
- **Apply sites**: the 3 existing CLI `gh` call sites (`tm issue`/`tm ticket`/`tm watch`) are now project-aware (matches the cwd's git origin remote against `config.projects`); the daemon's `spawn_managed` clone-based and local-redirect paths resolve identity once per spawn and thread it into `RealGitBackend::new(identity)`.
- **MCP-settable**: `config_write` gains `project_name` + `github_config_dir`/`github_token_env`/`github_account`/`github_host`/`commit_name`/`commit_email` params — omitting `project_name` targets the global binding, supplying it targets that project's own entry in `config.projects` (must already be registered). `config_read`/`config_to_json` now surface `github` and the full `projects` list.

### Architecture

The precedence engine (`GhEnv`, `resolve_gh_env`, `GhIdentityError`, `effective_host`, `clone_url`) moved from the `tm` binary (`bin/tm/gh_identity.rs`) into the library as `core::gh_identity`, so daemon code can share it without duplicating the logic. `bin/tm/gh_identity.rs` is now a thin, project-aware wrapper (`resolve_project_aware` + `load_gh_env`). `core::git_identity` is new: it bundles the resolved `gh` env overrides with the (project-scoped-only) commit identity into `GitIdentity`, and `resolve_for_config` matches a `repo_url` against `config.projects` (via the new `project::record::repo_url_matches`, which tolerates `.git`/scheme/case differences).

`RealGitBackend` changed from a unit struct to `{ identity: GitIdentity }` with `Default` (empty — byte-for-byte prior behaviour) and `::new(identity)`. Every `Command::new("git")` call site inside its `GitBackend` impl now goes through a private `self.command()` builder that applies the identity. All non-project construction sites (framework catalog sync, tests) use `RealGitBackend::default()`.

### Backwards compatibility

No per-project AND no global `github` set → behaviour is byte-for-byte identical to before (empty `GitIdentity`/`GhEnv`, plain `git` commands, ambient `gh` identity). Existing global `config.github` users keep working (global remains the fallback tier).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-mpm` — 2452 lib tests, 744 bin tests (1 pre-existing unrelated failure in `formatters::banner::two_panel` confirmed present on a clean `origin/main` checkout, unrelated to this change), all integration test files under `tests/` pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (no allowlist changes needed)

New tests added: precedence resolution (`core::gh_identity`, `core::git_identity`), `ProjectConfig`⇄`Project` round-trip through `seed_from_config`, `RealGitBackend` command-building (env + `-c user.*` args), `config_write`/`config_read` MCP round-trip (`apply_config_write` merge logic, tested in-memory — `config_write` itself is not unit-tested against the real config file to avoid mutating the developer's actual `~/.trusty-tools/trusty-mpm/config.yaml`).

Closes #2184

🤖 Generated with [Claude Code](https://claude.com/claude-code)