### PR TITLE
fix(trusty-mpm): session worktrees get working git pull without push-to-main

### DIFF
--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -420,6 +420,11 @@ pub fn create_session_worktree(base_path: &Path, worktree_name: &str) -> Result<
         ));
     }
 
+    // #2189: give the new worktree a working `git pull` (upstream tracking the
+    // default branch) WITHOUT letting `git push` target that branch. Best-effort
+    // and non-fatal — see `configure_session_branch_tracking`.
+    configure_session_branch_tracking(base_path, &worktree_path);
+
     // Item 5 (#1845): write the SM ownership sentinel so remove_session_worktree
     // can confirm this directory was TM-created and not a user-owned path that
     // happens to sit under a `.worktrees/` parent. The sentinel is best-effort:
@@ -436,6 +441,127 @@ pub fn create_session_worktree(base_path: &Path, worktree_name: &str) -> Result<
 
     info!(worktree = %worktree_path.display(), "inproject: per-session worktree created");
     Ok(worktree_path)
+}
+
+/// Give a freshly-created session worktree a working `git pull` from the
+/// default branch, WITHOUT making `git push` target that branch (#2189).
+///
+/// Why: [`create_session_worktree`] leaves the new `session/<name>` branch
+/// with no upstream at all, so a bare `git pull` inside the worktree fails
+/// with "There is no tracking information for the current branch." Setting
+/// the upstream to `origin/<default>` fixes `pull`/`fetch`-with-merge, but
+/// naively doing so ALSO makes a bare `git push` try to push the session
+/// branch's commits onto the shared default branch — which is exactly what a
+/// per-session isolated branch must never do. Scoping `push.default =
+/// current` to this one worktree (via `extensions.worktreeConfig` +
+/// `--worktree` config) keeps push targeting `origin/session/<name>` while
+/// pull still tracks the default branch.
+/// What: (1) resolves the default branch via
+/// [`super::inproject_hygiene::get_default_branch`], falling back to `"main"`
+/// when it cannot be determined; (2) runs `git -C <worktree_path> branch
+/// --set-upstream-to=origin/<default>` so `git pull` works; (3) runs `git -C
+/// <base_path> config extensions.worktreeConfig true` to enable per-worktree
+/// config on the shared base repo (idempotent — safe to set on every call);
+/// (4) runs `git -C <worktree_path> config --worktree push.default current`
+/// so `git push` always targets the current (session) branch, never the
+/// default branch. Every step is best-effort: a failure is logged via `warn!`
+/// and does NOT fail worktree creation — the worktree itself was already
+/// created successfully by the time this runs, and an operator can always set
+/// tracking manually as a fallback.
+/// Test: `create_session_worktree_sets_pull_upstream_and_worktree_scoped_push`
+/// (integration, real temp git repos with a bare `origin` remote).
+fn configure_session_branch_tracking(base_path: &Path, worktree_path: &Path) {
+    let default_branch = super::inproject_hygiene::get_default_branch(base_path)
+        .unwrap_or_else(|| "main".to_string());
+
+    // Step 1: set upstream so `git pull` (and `git fetch` + merge) works.
+    let upstream = format!("origin/{default_branch}");
+    let set_upstream = std::process::Command::new("git")
+        .arg("-C")
+        .arg(worktree_path)
+        .args(["branch", &format!("--set-upstream-to={upstream}")])
+        .output();
+    match set_upstream {
+        Ok(out) if out.status.success() => {
+            info!(
+                worktree = %worktree_path.display(),
+                upstream = %upstream,
+                "inproject: session worktree branch upstream set (git pull now works)"
+            );
+        }
+        Ok(out) => {
+            warn!(
+                worktree = %worktree_path.display(),
+                upstream = %upstream,
+                "inproject: failed to set branch upstream (non-fatal; `git pull` will \
+                 require manual tracking setup) ({}): {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Err(e) => {
+            warn!(
+                worktree = %worktree_path.display(),
+                "inproject: git branch --set-upstream-to failed to spawn (non-fatal): {e}"
+            );
+        }
+    }
+
+    // Step 2: enable per-worktree config on the shared base repo (idempotent).
+    let enable_worktree_config = std::process::Command::new("git")
+        .arg("-C")
+        .arg(base_path)
+        .args(["config", "extensions.worktreeConfig", "true"])
+        .output();
+    match enable_worktree_config {
+        Ok(out) if out.status.success() => {
+            info!(base = %base_path.display(), "inproject: extensions.worktreeConfig enabled on base clone");
+        }
+        Ok(out) => {
+            warn!(
+                base = %base_path.display(),
+                "inproject: git config extensions.worktreeConfig failed (non-fatal) ({}): {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Err(e) => {
+            warn!(
+                base = %base_path.display(),
+                "inproject: failed to spawn git config extensions.worktreeConfig (non-fatal): {e}"
+            );
+        }
+    }
+
+    // Step 3: scope push.default=current to THIS worktree only, so `git push`
+    // always targets `origin/session/<name>` and never the default branch.
+    let set_push_default = std::process::Command::new("git")
+        .arg("-C")
+        .arg(worktree_path)
+        .args(["config", "--worktree", "push.default", "current"])
+        .output();
+    match set_push_default {
+        Ok(out) if out.status.success() => {
+            info!(
+                worktree = %worktree_path.display(),
+                "inproject: worktree-scoped push.default=current set (git push cannot target the default branch)"
+            );
+        }
+        Ok(out) => {
+            warn!(
+                worktree = %worktree_path.display(),
+                "inproject: failed to set worktree-scoped push.default (non-fatal) ({}): {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Err(e) => {
+            warn!(
+                worktree = %worktree_path.display(),
+                "inproject: git config --worktree push.default failed to spawn (non-fatal): {e}"
+            );
+        }
+    }
 }
 
 /// Best-effort-idempotent: add `.worktrees/` to the base clone's `.git/info/exclude`.

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
@@ -610,3 +610,184 @@ async fn ensure_base_clone_emits_cloning_repo_only_on_fresh_clone() {
         "reusing an existing base clone must NOT re-emit CloningRepo, got: {stages2:?}"
     );
 }
+
+/// #2189: [`create_session_worktree`] must leave the new session branch with a
+/// working `git pull` (upstream tracking `origin/<default>`) WITHOUT letting a
+/// bare `git push` target the default branch.
+///
+/// Why: before this fix the new `session/<name>` branch had no upstream at
+/// all, so `git pull` inside a session worktree failed with "There is no
+/// tracking information for the current branch." Naively setting the
+/// upstream to `origin/<default>` would fix `pull` but ALSO make a bare `git
+/// push` try to push session commits onto the shared default branch — this
+/// test proves both halves: pull-tracking works AND push is scoped to the
+/// worktree's own branch.
+/// What: builds a real bare `origin` remote with one commit on `main`, clones
+/// it into `base` (mirroring what `ensure_base_clone` produces in
+/// production — `origin` wired up, `refs/remotes/origin/HEAD` set), then
+/// calls the production `create_session_worktree` and asserts: (a) `git -C
+/// <worktree> rev-parse --abbrev-ref --symbolic-full-name @{u}` resolves to
+/// `origin/main`; (b) `git -C <worktree> config --worktree push.default` ==
+/// `"current"`; (c) `git -C <base> config extensions.worktreeConfig` ==
+/// `"true"`.
+/// Test: this function IS the test.
+#[test]
+fn create_session_worktree_sets_pull_upstream_and_worktree_scoped_push() {
+    // 1. A real bare `origin` remote, explicitly on `main` so the assertions
+    //    below are not at the mercy of the host's `init.defaultBranch`.
+    let origin_dir = tempfile::TempDir::new().expect("origin tmp dir");
+    let origin_path = origin_dir.path();
+    let init = std::process::Command::new("git")
+        .args([
+            "init",
+            "--bare",
+            "-b",
+            "main",
+            origin_path.to_str().expect("origin utf8"),
+        ])
+        .output()
+        .expect("git init --bare origin");
+    assert!(
+        init.status.success(),
+        "git init --bare origin failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // 2. Seed the bare origin with one commit via a scratch clone (a bare repo
+    //    has no working tree to commit into directly).
+    let seed = tempfile::TempDir::new().expect("seed tmp dir");
+    let seed_path = seed.path();
+    let clone_seed = std::process::Command::new("git")
+        .args([
+            "clone",
+            origin_path.to_str().expect("origin utf8"),
+            seed_path.to_str().expect("seed utf8"),
+        ])
+        .output()
+        .expect("git clone seed");
+    assert!(
+        clone_seed.status.success(),
+        "git clone seed failed: {}",
+        String::from_utf8_lossy(&clone_seed.stderr)
+    );
+    for (k, v) in [("user.email", "t@example.com"), ("user.name", "T")] {
+        let ok = std::process::Command::new("git")
+            .args(["-C", seed_path.to_str().expect("seed utf8"), "config", k, v])
+            .status()
+            .expect("git config");
+        assert!(ok.success(), "git config {k} failed");
+    }
+    std::fs::write(seed_path.join("README"), b"seed").expect("write README");
+    let add = std::process::Command::new("git")
+        .args(["-C", seed_path.to_str().expect("seed utf8"), "add", "."])
+        .status()
+        .expect("git add");
+    assert!(add.success(), "git add failed");
+    let commit = std::process::Command::new("git")
+        .args([
+            "-C",
+            seed_path.to_str().expect("seed utf8"),
+            "commit",
+            "-m",
+            "init",
+        ])
+        .status()
+        .expect("git commit");
+    assert!(commit.success(), "git commit failed");
+    let push_seed = std::process::Command::new("git")
+        .args([
+            "-C",
+            seed_path.to_str().expect("seed utf8"),
+            "push",
+            "origin",
+            "main",
+        ])
+        .status()
+        .expect("git push seed");
+    assert!(push_seed.success(), "git push seed failed");
+
+    // 3. Clone the now-non-empty bare origin into `base` — this mirrors what
+    //    `ensure_base_clone` produces in production: `origin` remote wired up
+    //    and `refs/remotes/origin/HEAD` set by the clone itself.
+    let base_parent = tempfile::TempDir::new().expect("base parent tmp dir");
+    let base = base_parent.path().join("base");
+    let clone_base = std::process::Command::new("git")
+        .args([
+            "clone",
+            origin_path.to_str().expect("origin utf8"),
+            base.to_str().expect("base utf8"),
+        ])
+        .output()
+        .expect("git clone base");
+    assert!(
+        clone_base.status.success(),
+        "git clone base failed: {}",
+        String::from_utf8_lossy(&clone_base.stderr)
+    );
+    for (k, v) in [("user.email", "t@example.com"), ("user.name", "T")] {
+        let ok = std::process::Command::new("git")
+            .args(["-C", base.to_str().expect("base utf8"), "config", k, v])
+            .status()
+            .expect("git config");
+        assert!(ok.success(), "git config {k} failed");
+    }
+
+    // 4. Call the production function under test.
+    let worktree_path =
+        create_session_worktree(&base, "tm-pull-01").expect("create_session_worktree must succeed");
+
+    // (a) `git pull` must work: @{u} resolves to origin/main.
+    let upstream = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&worktree_path)
+        .args(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
+        .output()
+        .expect("git rev-parse @{u}");
+    assert!(
+        upstream.status.success(),
+        "worktree branch must have an upstream set (git pull must work): {}",
+        String::from_utf8_lossy(&upstream.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&upstream.stdout).trim(),
+        "origin/main",
+        "worktree branch upstream must track origin/main"
+    );
+
+    // (b) push.default=current must be scoped to THIS worktree only, so a
+    // bare `git push` targets `origin/session/tm-pull-01`, never `main`.
+    let push_default = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&worktree_path)
+        .args(["config", "--worktree", "push.default"])
+        .output()
+        .expect("git config --worktree push.default");
+    assert!(
+        push_default.status.success(),
+        "worktree-scoped push.default must be set: {}",
+        String::from_utf8_lossy(&push_default.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&push_default.stdout).trim(),
+        "current",
+        "push.default must be worktree-scoped to 'current' so push never targets main"
+    );
+
+    // (c) extensions.worktreeConfig must be enabled on the base clone —
+    // required for the worktree-scoped config in (b) to take effect at all.
+    let ext = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&base)
+        .args(["config", "extensions.worktreeConfig"])
+        .output()
+        .expect("git config extensions.worktreeConfig");
+    assert!(
+        ext.status.success(),
+        "extensions.worktreeConfig must be set on the base clone"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&ext.stdout).trim(),
+        "true",
+        "extensions.worktreeConfig must be true"
+    );
+}


### PR DESCRIPTION
## Summary
- `create_session_worktree` (`crates/trusty-mpm/src/daemon/managed_routes/inproject.rs`) previously left the new `session/<name>` branch with no upstream, so a bare `git pull` inside a managed session worktree failed with "There is no tracking information for the current branch."
- After a successful `git worktree add`, a new best-effort/non-fatal helper `configure_session_branch_tracking` now:
  1. Resolves the default branch via `inproject_hygiene::get_default_branch` (fallback `"main"`).
  2. Runs `git branch --set-upstream-to=origin/<default>` in the new worktree so `git pull` works.
  3. Enables `extensions.worktreeConfig` on the shared base clone.
  4. Sets `push.default=current` **scoped to the worktree only** (`git config --worktree`), so a bare `git push` always targets `origin/session/<name>` and can never push onto the shared default branch.
- Every step warns and continues on failure — it never fails worktree creation.

## Test plan
- [x] Added `create_session_worktree_sets_pull_upstream_and_worktree_scoped_push` (real bare `origin` remote + clone, mirrors `ensure_base_clone`'s production shape) asserting: `@{u}` resolves to `origin/main`, worktree-scoped `push.default` is `current`, and `extensions.worktreeConfig` is `true` on the base.
- [x] `cargo build --workspace` — clean.
- [x] `cargo test -p trusty-mpm` — 2409 passed / 0 failed in the lib target; new test passes by name. One pre-existing, unrelated failure (`formatters::banner::two_panel::tests::right_col_no_inner_border`) remains in a file this PR does not touch (confirmed via `git diff --stat origin/main`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `bash scripts/check_line_cap.sh` — 0 violations.

Closes #2189

🤖 Generated with [Claude Code](https://claude.com/claude-code)