### PR TITLE
feat(trusty-mpm): add 'kill' alias for 'tm session stop'

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -1244,6 +1244,11 @@ pub(crate) enum SessionAction {
     /// Managed-aware (#1218): if the id/name is a managed session, this stops its
     /// runtime (workspace preserved, resumable); otherwise it stops the local
     /// project session.
+    ///
+    /// `kill` is a visible alias (#2191) for this same non-destructive stop —
+    /// the workspace is preserved and the session remains resumable. For the
+    /// terminal, workspace-removing teardown use `decommission` instead.
+    #[command(visible_alias = "kill")]
     Stop {
         /// Session id or friendly name (e.g. `tm-quiet-falcon`).
         id_or_name: String,

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -482,6 +482,20 @@ fn cli_session_stop_requires_arg() {
 }
 
 #[test]
+fn cli_parses_session_kill() {
+    // `kill` is a visible alias (#2191) for `stop` — it parses to the same
+    // `SessionAction::Stop` variant so it dispatches through the identical
+    // managed-aware handler with zero other changes.
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "kill", "tmpm-quiet-falcon"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::Stop { id_or_name },
+        } => assert_eq!(id_or_name, "tmpm-quiet-falcon"),
+        other => panic!("expected session kill (stop), got {other:?}"),
+    }
+}
+
+#[test]
 fn cli_parses_session_list() {
     let cli = Cli::try_parse_from(["trusty-mpm", "session", "list"]).unwrap();
     match cli.command.unwrap() {


### PR DESCRIPTION
## Summary
- Adds `kill` as a `visible_alias` on `SessionAction::Stop` (clap `#[command(visible_alias = "kill")]`), mirroring the existing `sm`/`session-manager` alias style on `Coordinator`.
- `tm session kill <id|name>` now parses identically to `tm session stop <id|name>` and dispatches through the exact same managed-aware handler (`commands/session.rs:50-73`) — zero handler/dispatch changes, no new daemon route.
- Updated the `Stop` variant's doc comment so `tm session --help` documents the `kill` alias and clarifies that `decommission` remains the separate, terminal (workspace-removing) teardown — `kill` is not aliased onto `decommission`.

## Test plan
- [x] Added `cli_parses_session_kill` in `crates/trusty-mpm/src/bin/tm/tests.rs`, mirroring `cli_parses_session_stop`, asserting `tm session kill <id>` parses to `SessionAction::Stop { id_or_name }`.
- [x] `cargo build --workspace` — clean.
- [x] `cargo test -p trusty-mpm` — 755 passed, 1 pre-existing unrelated failure (`formatters::banner::two_panel::tests::right_col_no_inner_border`, confirmed present on `origin/main` prior to this change), 1 ignored.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `bash scripts/check_line_cap.sh` — 0 violations; `cli.rs` SLOC is 203 (well under the 500 cap), no allowlist entry needed.

Closes #2191

🤖 Generated with [Claude Code](https://claude.com/claude-code)