### PR TITLE
feat(trusty-mpm): sync allowlisted untracked/.env files into session worktrees

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/gh_identity.rs
+++ b/crates/trusty-mpm/src/bin/tm/gh_identity.rs
@@ -122,6 +122,7 @@ mod tests {
             github,
             commit_name: None,
             commit_email: None,
+            untracked_sync: None,
         }
     }
 

--- a/crates/trusty-mpm/src/core/git_identity.rs
+++ b/crates/trusty-mpm/src/core/git_identity.rs
@@ -236,6 +236,7 @@ mod tests {
             github,
             commit_name: Some("Project Bot".into()),
             commit_email: Some("bot@project.example.com".into()),
+            untracked_sync: None,
         }
     }
 

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -28,6 +28,15 @@ use serde::{Deserialize, Serialize};
 
 use trusty_common::github_path::GithubPath;
 
+/// Untracked/secret file sync config shape + resolution (#2196), split into
+/// its own module to keep this file under the 500-SLOC production cap. See
+/// that module's doc for the full rationale.
+pub mod untracked_sync;
+pub use untracked_sync::{
+    DEFAULT_UNTRACKED_SYNC_PATTERNS, ResolvedUntrackedSync, UntrackedSyncConfig,
+    resolve_untracked_sync,
+};
+
 /// Crate name used as the `~/.trusty-tools/<crate>/` directory segment.
 ///
 /// Why: the cross-crate convention keys each crate's config dir by its crate name;
@@ -133,6 +142,16 @@ pub struct TrustyToolsConfig {
     /// stays disabled).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daemon: Option<DaemonConfig>,
+
+    /// Global allowlisted untracked/secret file sync settings (the
+    /// `untracked_sync:` YAML section, #2196).
+    ///
+    /// `None` → the built-in default applies: sync is ENABLED with the
+    /// built-in `.env*` pattern set (see [`resolve_untracked_sync`]). A
+    /// per-project `untracked_sync` override (on [`ProjectConfig`]) takes
+    /// precedence over this global section for that project.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub untracked_sync: Option<UntrackedSyncConfig>,
 }
 
 /// The `daemon:` section of `~/.trusty-tools/trusty-mpm/config.yaml` (#1836).
@@ -343,6 +362,16 @@ pub struct ProjectConfig {
     /// Test: `project_config_github_and_commit_identity_yaml_round_trip`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub commit_email: Option<String>,
+
+    /// Per-project untracked/secret file sync override (#2196), overriding
+    /// the global `untracked_sync:` section for this project only.
+    ///
+    /// `None` → no override; resolution falls through to the global section,
+    /// then the built-in default. See [`resolve_untracked_sync`] for the
+    /// full precedence chain.
+    /// Test: `untracked_sync_config_yaml_round_trip`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub untracked_sync: Option<UntrackedSyncConfig>,
 }
 
 impl TrustyToolsConfig {
@@ -642,6 +671,7 @@ mod tests {
                 github: None,
                 commit_name: None,
                 commit_email: None,
+                untracked_sync: None,
             }],
             ..Default::default()
         };
@@ -663,6 +693,7 @@ mod tests {
                 github: None,
                 commit_name: None,
                 commit_email: None,
+                untracked_sync: None,
             }],
             ..Default::default()
         };
@@ -694,6 +725,7 @@ mod tests {
                 }),
                 commit_name: Some("Bob (work bot)".into()),
                 commit_email: Some("bob@acme.example.com".into()),
+                untracked_sync: None,
             }],
             ..Default::default()
         };
@@ -717,6 +749,7 @@ mod tests {
                 github: None,
                 commit_name: None,
                 commit_email: None,
+                untracked_sync: None,
             }],
             ..Default::default()
         };
@@ -775,4 +808,8 @@ mod tests {
             PathBuf::from("/projects/bobmatnyc/trusty-tools")
         );
     }
+
+    // untracked_sync (#2196) resolution + YAML round-trip tests live in
+    // `untracked_sync::tests` (split out to keep this file under the
+    // 500-SLOC cap; see that module's doc).
 }

--- a/crates/trusty-mpm/src/core/trusty_tools_config/untracked_sync.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/untracked_sync.rs
@@ -1,0 +1,129 @@
+//! Untracked/secret file sync config shape + resolution (#2196).
+//!
+//! Why: split out of `trusty_tools_config.rs` so that file stays under the
+//! 500-SLOC production cap (mirrors how `GithubConfig`/`WatchConfig` stay
+//! inline but this section, with its resolver function and tests, pushed the
+//! parent over the limit). Kept as a sibling module rather than a separate
+//! top-level file so `TrustyToolsConfig`/`ProjectConfig` and this section's
+//! types stay conceptually one config surface.
+//! What: [`UntrackedSyncConfig`] is the on-disk shape (global `untracked_sync:`
+//! section or per-project `projects[].untracked_sync` override);
+//! [`DEFAULT_UNTRACKED_SYNC_PATTERNS`] is the built-in `.env*` allowlist;
+//! [`resolve_untracked_sync`] turns the three precedence tiers (per-project >
+//! global > default) into one concrete [`ResolvedUntrackedSync`] per spawn.
+//! Test: `tests` submodule.
+
+use serde::{Deserialize, Serialize};
+
+use super::TrustyToolsConfig;
+
+/// Built-in default allowlist patterns for untracked/secret file sync (#2196).
+///
+/// Why: the dominant real-world need is `.env` files (`.env`, `.env.local`,
+/// per-environment variants like `.env.production`), so an unset config must
+/// still sync them — "operator does nothing" stays the north-star default.
+/// What: `[".env", ".env.local", ".env.*"]`. `.env.*` is a prefix-glob
+/// covering per-environment variants without also matching unrelated names.
+/// Test: `tests::resolve_untracked_sync_defaults_when_unset`.
+pub const DEFAULT_UNTRACKED_SYNC_PATTERNS: &[&str] = &[".env", ".env.local", ".env.*"];
+
+/// The `untracked_sync:` section of `~/.trusty-tools/trusty-mpm/config.yaml`
+/// (global) or a `projects[].untracked_sync` override (per-project), #2196.
+///
+/// Why: operators who use a live checkout with `.env`/secret files expect
+/// those files to be present in the per-session worktree too (managed
+/// sessions never copy uncommitted/untracked files by default). This section
+/// lets an operator declare the sync allowlist and toggle declaratively,
+/// mirroring the `GithubConfig`/`WatchConfig` optional-section convention so
+/// an absent section is fully backward-compatible.
+/// What: `patterns` — an allowlist of filename patterns (see
+/// [`resolve_untracked_sync`] for resolution precedence and the built-in
+/// default); `enabled` — `None`/`Some(true)` syncs, `Some(false)` disables
+/// sync entirely for the scope this section applies to.
+/// Test: `tests::untracked_sync_config_yaml_round_trip`,
+/// `tests::resolve_untracked_sync_project_overrides_global`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UntrackedSyncConfig {
+    /// Allowlist of filename patterns to sync from the source checkout root
+    /// into the session worktree (e.g. `[".env", ".env.local", ".env.*"]`).
+    ///
+    /// `None` → falls through to the next precedence tier (see
+    /// [`resolve_untracked_sync`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub patterns: Option<Vec<String>>,
+
+    /// Whether untracked/secret file sync runs at all for this scope.
+    ///
+    /// `None` → falls through to the next precedence tier; the ultimate
+    /// built-in default is `true` (sync is ON by default, #2196).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+}
+
+/// The resolved untracked-sync allowlist + enabled flag for one spawn (#2196).
+///
+/// Why: [`sync_untracked_files`](crate::daemon::managed_routes::inproject::untracked_sync::sync_untracked_files)
+/// needs a single concrete `(patterns, enabled)` pair per spawn; bundling the
+/// resolution result in one struct keeps the precedence-resolution call site
+/// (`lifecycle::reserve_inproject_worktree`) a one-liner.
+/// What: `patterns` is never empty (falls back to
+/// [`DEFAULT_UNTRACKED_SYNC_PATTERNS`]); `enabled` defaults to `true`.
+/// Test: covered by the `resolve_untracked_sync_*` tests below.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedUntrackedSync {
+    /// The resolved allowlist of filename patterns.
+    pub patterns: Vec<String>,
+    /// Whether sync should run at all.
+    pub enabled: bool,
+}
+
+/// Resolve the untracked-sync allowlist + enabled flag for a project (#2196).
+///
+/// Why: an operator may declare patterns/enabled globally, per-project, or
+/// not at all — this is the single place that turns those three tiers into
+/// one concrete answer, so every call site (currently
+/// `lifecycle::reserve_inproject_worktree`) agrees.
+/// What: precedence is **per-project `patterns`/`enabled` (matched by
+/// `repo_name` against `ProjectConfig::name`) > global
+/// `config.untracked_sync` > built-in default** (`enabled = true`,
+/// `patterns = `[`DEFAULT_UNTRACKED_SYNC_PATTERNS`]). `patterns` and
+/// `enabled` resolve INDEPENDENTLY — e.g. a project may override only
+/// `enabled` while inheriting the global `patterns`. `repo_name = None`
+/// (no repo identity available) skips the per-project tier entirely.
+/// Test: `tests::resolve_untracked_sync_defaults_when_unset`,
+/// `tests::resolve_untracked_sync_global_overrides_default`,
+/// `tests::resolve_untracked_sync_project_overrides_global`,
+/// `tests::resolve_untracked_sync_disabled_by_project`.
+pub fn resolve_untracked_sync(
+    config: &TrustyToolsConfig,
+    repo_name: Option<&str>,
+) -> ResolvedUntrackedSync {
+    let project_cfg = repo_name.and_then(|name| {
+        config
+            .projects
+            .iter()
+            .find(|p| p.name == name)
+            .and_then(|p| p.untracked_sync.as_ref())
+    });
+    let global_cfg = config.untracked_sync.as_ref();
+
+    let patterns = project_cfg
+        .and_then(|c| c.patterns.clone())
+        .or_else(|| global_cfg.and_then(|c| c.patterns.clone()))
+        .unwrap_or_else(|| {
+            DEFAULT_UNTRACKED_SYNC_PATTERNS
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        });
+
+    let enabled = project_cfg
+        .and_then(|c| c.enabled)
+        .or_else(|| global_cfg.and_then(|c| c.enabled))
+        .unwrap_or(true);
+
+    ResolvedUntrackedSync { patterns, enabled }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/core/trusty_tools_config/untracked_sync/tests.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/untracked_sync/tests.rs
@@ -1,0 +1,162 @@
+//! Unit tests for [`super`] (#2196).
+//!
+//! Why: split from `trusty_tools_config.rs`'s own test module when the
+//! `untracked_sync` section moved into its own sibling module, keeping the
+//! parent config file under the 500-SLOC production cap.
+//! What: YAML round-trip for [`super::UntrackedSyncConfig`] (global +
+//! per-project) and the [`super::resolve_untracked_sync`] precedence tests
+//! (default / global-override / project-override / project-disabled).
+//! Test: this IS the test module.
+
+use super::*;
+use crate::core::trusty_tools_config::{ProjectConfig, TrustyToolsConfig};
+
+/// Why: the `untracked_sync:` section (global and per-project) must
+/// round-trip through YAML, and an absent section must not serialise —
+/// matching every other optional section's backward-compat contract.
+/// Test: itself.
+#[test]
+fn untracked_sync_config_yaml_round_trip() {
+    let cfg = TrustyToolsConfig {
+        untracked_sync: Some(UntrackedSyncConfig {
+            patterns: Some(vec![".env".into(), ".env.local".into()]),
+            enabled: Some(true),
+        }),
+        projects: vec![ProjectConfig {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: None,
+            stack_hint: None,
+            tags: None,
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+            untracked_sync: Some(UntrackedSyncConfig {
+                patterns: Some(vec![".env.widget".into()]),
+                enabled: Some(false),
+            }),
+        }],
+        ..Default::default()
+    };
+    let yaml = serde_yaml::to_string(&cfg).expect("serialise");
+    assert!(yaml.contains("untracked_sync"), "yaml: {yaml}");
+    let back: TrustyToolsConfig = serde_yaml::from_str(&yaml).expect("deserialise");
+    assert_eq!(cfg, back);
+
+    // Absent untracked_sync sections must not serialise.
+    let empty = TrustyToolsConfig::default();
+    let yaml_empty = serde_yaml::to_string(&empty).expect("serialise");
+    assert!(!yaml_empty.contains("untracked_sync"), "yaml: {yaml_empty}");
+}
+
+/// Why: with no config at all (fresh install), resolution must fall back
+/// to the built-in default — sync ENABLED with the built-in `.env*`
+/// pattern set (#2196's "operator does nothing" default).
+/// Test: itself.
+#[test]
+fn resolve_untracked_sync_defaults_when_unset() {
+    let config = TrustyToolsConfig::default();
+    let resolved = resolve_untracked_sync(&config, Some("trusty-tools"));
+    assert!(resolved.enabled);
+    assert_eq!(
+        resolved.patterns,
+        DEFAULT_UNTRACKED_SYNC_PATTERNS
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Why: a global `untracked_sync.patterns` override must win over the
+/// built-in default when no per-project override exists.
+/// Test: itself.
+#[test]
+fn resolve_untracked_sync_global_overrides_default() {
+    let config = TrustyToolsConfig {
+        untracked_sync: Some(UntrackedSyncConfig {
+            patterns: Some(vec![".env.global-only".into()]),
+            enabled: None,
+        }),
+        ..Default::default()
+    };
+    let resolved = resolve_untracked_sync(&config, None);
+    assert_eq!(resolved.patterns, vec![".env.global-only".to_string()]);
+    assert!(resolved.enabled, "enabled must default to true");
+}
+
+/// Why: a per-project `untracked_sync.patterns` override must win over
+/// BOTH the global section and the built-in default.
+/// Test: itself.
+#[test]
+fn resolve_untracked_sync_project_overrides_global() {
+    let config = TrustyToolsConfig {
+        untracked_sync: Some(UntrackedSyncConfig {
+            patterns: Some(vec![".env.global".into()]),
+            enabled: Some(true),
+        }),
+        projects: vec![ProjectConfig {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: None,
+            stack_hint: None,
+            tags: None,
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+            untracked_sync: Some(UntrackedSyncConfig {
+                patterns: Some(vec![".env.widget-only".into()]),
+                enabled: None,
+            }),
+        }],
+        ..Default::default()
+    };
+    let resolved = resolve_untracked_sync(&config, Some("widget"));
+    assert_eq!(resolved.patterns, vec![".env.widget-only".to_string()]);
+    // enabled falls through project(None) -> global(Some(true)).
+    assert!(resolved.enabled);
+
+    // A DIFFERENT repo name (no matching project) must fall back to global.
+    let resolved_other = resolve_untracked_sync(&config, Some("other-repo"));
+    assert_eq!(resolved_other.patterns, vec![".env.global".to_string()]);
+}
+
+/// Why: a per-project `enabled: false` must disable sync for that
+/// project even when the global section (or default) is enabled.
+/// Test: itself.
+#[test]
+fn resolve_untracked_sync_disabled_by_project() {
+    let config = TrustyToolsConfig {
+        projects: vec![ProjectConfig {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: None,
+            stack_hint: None,
+            tags: None,
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+            untracked_sync: Some(UntrackedSyncConfig {
+                patterns: None,
+                enabled: Some(false),
+            }),
+        }],
+        ..Default::default()
+    };
+    let resolved = resolve_untracked_sync(&config, Some("widget"));
+    assert!(!resolved.enabled);
+    // patterns still resolve to the default even though sync is disabled
+    // (the caller is expected to check `enabled` before syncing).
+    assert_eq!(
+        resolved.patterns,
+        DEFAULT_UNTRACKED_SYNC_PATTERNS
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -23,13 +23,20 @@
 //! resolution away from an existing worktree dir/branch;
 //! [`ensure_worktrees_gitignored`] keeps the worktree directory out of
 //! `git status`; [`get_origin_url`] reads the remote.origin.url from a git
-//! directory.
+//! directory. The sibling [`untracked_sync`] module (#2196) syncs an
+//! allowlist of untracked/secret files (e.g. `.env*`) from the operator's
+//! live checkout into a freshly-created session worktree; it is called from
+//! `lifecycle::reserve_inproject_worktree`, not from this module directly,
+//! since only that call site holds both the live-checkout source path and
+//! the resolved worktree destination.
 //! Test: `try_inproject_spawn_returns_none_for_non_git_path` unit test covers the
 //! non-git early exit; integration coverage via `tests/local_spawn.rs`.
 
 use std::path::{Path, PathBuf};
 
 use tracing::{info, warn};
+
+pub mod untracked_sync;
 
 /// Environment variable that overrides the managed repos root.
 ///

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject/untracked_sync.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject/untracked_sync.rs
@@ -1,0 +1,350 @@
+//! Allowlisted untracked/secret file sync into session worktrees (#2196).
+//!
+//! Why: an operator's live checkout often carries files git never tracks —
+//! most commonly `.env`/`.env.local` — that a session worktree still needs
+//! (env vars for local tooling, API keys for tests, etc.). Managed sessions
+//! intentionally never copy the operator's uncommitted work into a worktree
+//! (see `tm launch`'s "uncommitted local changes are not carried into the
+//! managed clone" warning), so without an explicit, narrow allowlist those
+//! files are simply absent and every session has to be re-configured by hand.
+//! This module is that narrow allowlist: it copies ONLY files matching
+//! operator-declared patterns (default `.env*`, see
+//! [`crate::core::trusty_tools_config::DEFAULT_UNTRACKED_SYNC_PATTERNS`]) —
+//! never an unrestricted "copy all untracked files" — and never fails the
+//! spawn it runs inside.
+//! What: [`sync_untracked_files`] is the single entry point: for each
+//! pattern, matches files at the SOURCE checkout root (or one explicit
+//! subdirectory when a pattern contains `/`), copies matches into the
+//! destination worktree at the same relative path, and appends each copied
+//! path to the worktree's real `info/exclude` file (resolved via `git
+//! rev-parse --git-path`, which correctly follows a linked worktree's gitlink
+//! back to the shared common git dir) so the secret is gitignore-safe
+//! regardless of the repo's own tracked `.gitignore`. Every step is
+//! best-effort: a missing source root, an unreadable file, an oversized file,
+//! or a failed exclude-append is `warn!`-logged and skipped — this function
+//! NEVER returns an error and NEVER panics, matching the "sync failure must
+//! not fail the spawn" contract from [`try_inproject_spawn`]'s call site.
+//! Test: `tests` submodule — pattern matching, the size cap, the path-escape
+//! guard, the `node_modules/`-is-a-directory-so-never-matches case, and the
+//! `.git/info/exclude` append for a real linked worktree.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tracing::{info, warn};
+
+/// Per-file size ceiling for untracked-sync copies.
+///
+/// Why: the allowlist is meant for small config/secret files; without a cap
+/// a mis-declared pattern (or a `.env.*` matching an unexpectedly large file)
+/// could copy something enormous into every session worktree.
+/// What: 5 MiB. Files larger than this are skipped with a `warn!`.
+/// Test: `tests::oversized_file_is_skipped`.
+pub const MAX_SYNC_FILE_BYTES: u64 = 5 * 1024 * 1024;
+
+/// Sync allowlisted untracked/secret files from `source` into `dest_worktree`.
+///
+/// Why: the single seam that turns a resolved pattern allowlist into actual
+/// copied files, called once per in-project spawn right after the session
+/// worktree is created (`lifecycle::reserve_inproject_worktree`).
+/// What: for each pattern in `patterns`, resolves candidate files via
+/// [`collect_matches`] (top-level of `source`, or one explicit subdirectory
+/// when the pattern contains `/`), skips anything over
+/// [`MAX_SYNC_FILE_BYTES`], copies the rest to
+/// `<dest_worktree>/<relative_path>` (creating parent dirs as needed), and
+/// appends every successfully-copied relative path to the worktree's real
+/// `info/exclude` file via [`append_to_git_exclude`]. Duplicate matches
+/// across overlapping patterns are copied once. Never panics, never returns
+/// an error — every failure is a `warn!` and the loop continues.
+/// Test: `tests::syncs_matching_files_only`, `tests::disabled_copies_nothing`
+/// (caller-side gate — this function itself has no `enabled` concept, the
+/// caller skips calling it entirely when disabled),
+/// `tests::missing_source_file_is_non_fatal`.
+pub fn sync_untracked_files(source: &Path, dest_worktree: &Path, patterns: &[String]) {
+    if patterns.is_empty() {
+        return;
+    }
+
+    // Dedup by relative path so overlapping patterns (e.g. ".env" and
+    // ".env.*" both matching some contrived name) only copy once.
+    let mut candidates: Vec<(PathBuf, String)> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for pattern in patterns {
+        for (abs, rel) in collect_matches(source, pattern) {
+            if seen.insert(rel.clone()) {
+                candidates.push((abs, rel));
+            }
+        }
+    }
+
+    let mut copied: Vec<String> = Vec::new();
+    for (abs_path, rel_path) in candidates {
+        let size = match fs::metadata(&abs_path) {
+            Ok(m) => m.len(),
+            Err(e) => {
+                warn!(
+                    file = %abs_path.display(),
+                    "untracked_sync: could not stat candidate file (non-fatal, skipping): {e}"
+                );
+                continue;
+            }
+        };
+        if size > MAX_SYNC_FILE_BYTES {
+            warn!(
+                file = %abs_path.display(),
+                size,
+                cap = MAX_SYNC_FILE_BYTES,
+                "untracked_sync: file exceeds size cap, skipping"
+            );
+            continue;
+        }
+
+        let dest_path = dest_worktree.join(&rel_path);
+        if let Some(parent) = dest_path.parent()
+            && let Err(e) = fs::create_dir_all(parent)
+        {
+            warn!(
+                dir = %parent.display(),
+                "untracked_sync: could not create parent dir (non-fatal, skipping file): {e}"
+            );
+            continue;
+        }
+
+        match fs::copy(&abs_path, &dest_path) {
+            Ok(_) => {
+                info!(
+                    from = %abs_path.display(),
+                    to = %dest_path.display(),
+                    "untracked_sync: copied allowlisted untracked file into session worktree"
+                );
+                copied.push(rel_path);
+            }
+            Err(e) => {
+                warn!(
+                    from = %abs_path.display(),
+                    to = %dest_path.display(),
+                    "untracked_sync: copy failed (non-fatal, skipping): {e}"
+                );
+            }
+        }
+    }
+
+    if !copied.is_empty()
+        && let Err(e) = append_to_git_exclude(dest_worktree, &copied)
+    {
+        warn!(
+            worktree = %dest_worktree.display(),
+            "untracked_sync: failed to append copied files to git exclude (non-fatal, \
+             copied files may show as untracked in `git status`): {e}"
+        );
+    }
+}
+
+/// Resolve the candidate `(absolute_path, relative_path)` matches for one
+/// allowlist pattern.
+///
+/// Why: a pattern with no `/` matches top-level files only (the `.env*`
+/// case); a pattern containing `/` names an explicit subdirectory, which is
+/// scanned non-recursively at that one level. Splitting the two cases here
+/// keeps [`sync_untracked_files`] a flat copy loop.
+/// What: returns `(source-relative absolute path, relative path string)`
+/// pairs for every regular file directly inside the resolved directory whose
+/// filename matches the leaf pattern via [`glob_match`]. Returns an empty
+/// vec (never an error) when the resolved directory is unreadable/absent, or
+/// when the pattern's directory component escapes `source` (see
+/// [`is_unsafe_dir_component`]).
+/// Test: `tests::top_level_pattern_matches_only_root_files`,
+/// `tests::subdirectory_pattern_matches_one_level`,
+/// `tests::path_escape_pattern_matches_nothing`.
+fn collect_matches(source: &Path, pattern: &str) -> Vec<(PathBuf, String)> {
+    let (dir, dir_prefix, leaf) = match pattern.rsplit_once('/') {
+        Some((dir_part, leaf)) => {
+            if is_unsafe_dir_component(dir_part) {
+                warn!(
+                    pattern,
+                    "untracked_sync: rejecting pattern with an absolute or `..`-escaping \
+                     directory component"
+                );
+                return Vec::new();
+            }
+            (source.join(dir_part), format!("{dir_part}/"), leaf)
+        }
+        None => (source.to_path_buf(), String::new(), pattern),
+    };
+
+    let read_dir = match fs::read_dir(&dir) {
+        Ok(rd) => rd,
+        Err(e) => {
+            // Absent/unreadable source directory is expected (e.g. no `.env`
+            // files at all) and must never be treated as a hard failure.
+            warn!(
+                dir = %dir.display(),
+                "untracked_sync: could not read directory for pattern {pattern:?} (non-fatal): {e}"
+            );
+            return Vec::new();
+        }
+    };
+
+    read_dir
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_file() {
+                return None;
+            }
+            let name = path.file_name()?.to_str()?;
+            if glob_match(leaf, name) {
+                Some((path.clone(), format!("{dir_prefix}{name}")))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Whether a pattern's directory component would escape `source`.
+///
+/// Why: [`collect_matches`] must refuse a pattern like `"../secrets/.env"` or
+/// `"/etc/.env"` BEFORE ever joining it onto `source` and reading a
+/// directory outside the checkout — the allowlist-only / no-escape security
+/// guard (#2196).
+/// What: `true` when `dir_part` is absolute (starts with `/`) or any `/`-
+/// separated segment is `".."` or empty (`"a//b"`, a leading/trailing `/`).
+/// Test: `tests::path_escape_pattern_matches_nothing`.
+fn is_unsafe_dir_component(dir_part: &str) -> bool {
+    dir_part.starts_with('/') || dir_part.split('/').any(|seg| seg == ".." || seg.is_empty())
+}
+
+/// Match `name` against a simple glob `pattern` (literal characters plus `*`
+/// wildcards only — no `?`, no `**`, no character classes).
+///
+/// Why: the allowlist's real-world patterns are exact names (`.env`), simple
+/// prefixes (`.env.*`), or simple suffixes (`*.env`); a hand-rolled matcher
+/// avoids pulling in a glob crate for a handful of trivial shapes while still
+/// handling an arbitrary number/position of `*` correctly.
+/// What: `true` iff `pattern`, with each `*` treated as "zero or more
+/// characters", matches `name` in full. Case-sensitive (filesystem names on
+/// the platforms this runs on are case-sensitive or case-preserving).
+/// Test: `tests::glob_match_exact`, `tests::glob_match_prefix`,
+/// `tests::glob_match_suffix`, `tests::glob_match_no_match`.
+fn glob_match(pattern: &str, name: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let n: Vec<char> = name.chars().collect();
+    glob_match_from(&p, &n)
+}
+
+/// Recursive worker for [`glob_match`].
+///
+/// Why: isolated so the wildcard branch's backtracking search reads as a
+/// one-liner over the two slices.
+/// What: standard `*`-only glob matching: an empty pattern matches only an
+/// empty remainder; a literal char must match the next char exactly; a `*`
+/// tries consuming `0..=n.len()` characters before matching the rest of the
+/// pattern against the rest of the name.
+/// Test: covered transitively via [`glob_match`]'s tests.
+fn glob_match_from(p: &[char], n: &[char]) -> bool {
+    match p.split_first() {
+        None => n.is_empty(),
+        Some((&'*', rest)) => (0..=n.len()).any(|i| glob_match_from(rest, &n[i..])),
+        Some((c, rest)) => match n.split_first() {
+            Some((nc, nrest)) if nc == c => glob_match_from(rest, nrest),
+            _ => false,
+        },
+    }
+}
+
+/// Append copied relative paths to the worktree's real `info/exclude` file.
+///
+/// Why: a linked git worktree's `.git` is a FILE (a gitlink to
+/// `<common-git-dir>/worktrees/<name>`), not a directory — `info/exclude` is
+/// a repo-wide (not per-worktree) file that lives in the SHARED common git
+/// dir. Naively joining `<worktree>/.git/info/exclude` would try to create a
+/// directory inside that gitlink file and fail. `git rev-parse --git-path
+/// info/exclude`, run with the worktree as cwd, is git's own resolver for
+/// this — it returns the correct shared path for both a plain repo and a
+/// linked worktree, mirroring how [`super::ensure_worktrees_gitignored`]
+/// appends to the analogous file for the base clone itself.
+/// What: resolves the real exclude-file path via `git -C <dest_worktree>
+/// rev-parse --git-path info/exclude`, creates its parent dir, and appends
+/// each of `relative_paths` that is not already present (idempotent, mirrors
+/// [`super::ensure_worktrees_gitignored`]'s read-then-append style).
+/// Test: `tests::append_to_git_exclude_resolves_shared_worktree_path`,
+/// `tests::append_to_git_exclude_is_idempotent`.
+fn append_to_git_exclude(dest_worktree: &Path, relative_paths: &[String]) -> Result<(), String> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dest_worktree)
+        .args(["rev-parse", "--git-path", "info/exclude"])
+        .output()
+        .map_err(|e| format!("untracked_sync: git rev-parse failed to spawn: {e}"))?;
+
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(format!(
+            "untracked_sync: git rev-parse --git-path info/exclude failed ({}): {stderr}",
+            out.status
+        ));
+    }
+
+    let raw_path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if raw_path.is_empty() {
+        return Err("untracked_sync: git rev-parse returned an empty path".to_string());
+    }
+    // `--git-path` may return a path relative to the worktree cwd (plain-repo
+    // case) or an absolute path (linked-worktree case, pointing at the
+    // shared common dir) — resolve relative results against dest_worktree.
+    let exclude_path = {
+        let p = PathBuf::from(&raw_path);
+        if p.is_absolute() {
+            p
+        } else {
+            dest_worktree.join(p)
+        }
+    };
+
+    if let Some(parent) = exclude_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("untracked_sync: could not create {}: {e}", parent.display()))?;
+    }
+
+    let existing = fs::read_to_string(&exclude_path).unwrap_or_default();
+    let mut to_append = String::new();
+    for rel in relative_paths {
+        if !existing.lines().any(|line| line.trim() == rel.as_str()) {
+            to_append.push_str(rel);
+            to_append.push('\n');
+        }
+    }
+    if to_append.is_empty() {
+        return Ok(());
+    }
+
+    let entry = if existing.is_empty() || existing.ends_with('\n') {
+        to_append
+    } else {
+        format!("\n{to_append}")
+    };
+
+    use std::io::Write as _;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&exclude_path)
+        .map_err(|e| {
+            format!(
+                "untracked_sync: could not open {}: {e}",
+                exclude_path.display()
+            )
+        })?;
+    file.write_all(entry.as_bytes()).map_err(|e| {
+        format!(
+            "untracked_sync: could not write {}: {e}",
+            exclude_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject/untracked_sync/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject/untracked_sync/tests.rs
@@ -1,0 +1,361 @@
+//! Unit tests for [`super`] (#2196).
+//!
+//! Why: split into a sibling `tests.rs` so the production `untracked_sync.rs`
+//! stays comfortably under the 500-SLOC cap while these get the generous
+//! 1500-SLOC test-file cap (mirrors `inproject/tests.rs`).
+//! What: glob-matcher unit tests, `collect_matches`/`sync_untracked_files`
+//! behaviour against real temp directories, the size cap, the path-escape
+//! guard, and a real-git-worktree round trip proving `.git/info/exclude`
+//! resolution survives the linked-worktree gitlink indirection.
+//! Test: this IS the test module.
+
+use std::path::Path;
+
+use super::*;
+
+// ── glob_match ───────────────────────────────────────────────────────────
+
+#[test]
+fn glob_match_exact() {
+    assert!(glob_match(".env", ".env"));
+    assert!(!glob_match(".env", ".env.local"));
+}
+
+#[test]
+fn glob_match_prefix() {
+    assert!(glob_match(".env.*", ".env.local"));
+    assert!(glob_match(".env.*", ".env.production"));
+    assert!(!glob_match(".env.*", ".envrc"));
+    assert!(
+        !glob_match(".env.*", ".env"),
+        "trailing '*' requires >=0 more chars after the dot"
+    );
+}
+
+#[test]
+fn glob_match_suffix() {
+    assert!(glob_match("*.env", "prod.env"));
+    assert!(glob_match("*.env", ".env"));
+    assert!(!glob_match("*.env", "prod.env.bak"));
+}
+
+#[test]
+fn glob_match_no_match() {
+    assert!(!glob_match(".env", "not-env"));
+    assert!(!glob_match(".env.*", "other-file.txt"));
+}
+
+// ── test fixtures ────────────────────────────────────────────────────────
+
+/// Build a source checkout root with the fixture files the #2196 issue's
+/// test plan names: `.env`, `.env.local`, `.env.local.bak` (must NOT match
+/// `.env.local` exactly, nor `.env.*` since it has no trailing wildcard
+/// continuation issue — `.env.local.bak` DOES start with `.env.` so it is
+/// deliberately given a name that also proves the "only allowlisted
+/// patterns, nothing broader" guarantee: `random.txt` never matches any
+/// default pattern), an oversized file, and a `node_modules/` directory
+/// (which must never be recursed into or copied as a whole).
+fn make_source_fixture() -> tempfile::TempDir {
+    let src = tempfile::TempDir::new().expect("src tmp dir");
+    std::fs::write(src.path().join(".env"), b"SECRET=1").expect("write .env");
+    std::fs::write(src.path().join(".env.local"), b"SECRET=2").expect("write .env.local");
+    std::fs::write(src.path().join("random.txt"), b"not a secret").expect("write random.txt");
+
+    std::fs::create_dir_all(src.path().join("node_modules/some-pkg")).expect("mkdir node_modules");
+    std::fs::write(
+        src.path().join("node_modules/some-pkg/.env"),
+        b"nested, must not be touched by a top-level pattern",
+    )
+    .expect("write nested .env");
+
+    let oversized = vec![0u8; (MAX_SYNC_FILE_BYTES + 1) as usize];
+    std::fs::write(src.path().join(".env.oversized"), &oversized).expect("write oversized file");
+
+    src
+}
+
+/// Default `.env*` allowlist used by most tests here (mirrors
+/// `DEFAULT_UNTRACKED_SYNC_PATTERNS`).
+fn default_patterns() -> Vec<String> {
+    vec![".env".into(), ".env.local".into(), ".env.*".into()]
+}
+
+// ── sync_untracked_files: matching + non-matching + size cap + no-recurse ──
+
+#[test]
+fn syncs_matching_files_only() {
+    let src = make_source_fixture();
+    let dest = tempfile::TempDir::new().expect("dest tmp dir");
+
+    sync_untracked_files(src.path(), dest.path(), &default_patterns());
+
+    assert!(dest.path().join(".env").is_file(), ".env must be copied");
+    assert!(
+        dest.path().join(".env.local").is_file(),
+        ".env.local must be copied"
+    );
+    assert!(
+        !dest.path().join("random.txt").exists(),
+        "non-matching file must NOT be copied"
+    );
+    assert!(
+        !dest.path().join("node_modules").exists(),
+        "node_modules/ must NOT be copied (directories are never matched)"
+    );
+    assert!(
+        !dest.path().join(".env.oversized").exists(),
+        "oversized file must be skipped, not copied"
+    );
+
+    assert_eq!(
+        std::fs::read(dest.path().join(".env")).expect("read copied .env"),
+        b"SECRET=1"
+    );
+}
+
+#[test]
+fn oversized_file_is_skipped() {
+    let src = tempfile::TempDir::new().expect("src tmp dir");
+    let oversized = vec![b'x'; (MAX_SYNC_FILE_BYTES + 1) as usize];
+    std::fs::write(src.path().join(".env"), &oversized).expect("write oversized .env");
+    let dest = tempfile::TempDir::new().expect("dest tmp dir");
+
+    sync_untracked_files(src.path(), dest.path(), &[".env".to_string()]);
+
+    assert!(
+        !dest.path().join(".env").exists(),
+        "a file over MAX_SYNC_FILE_BYTES must never be copied"
+    );
+}
+
+#[test]
+fn empty_patterns_copies_nothing() {
+    let src = make_source_fixture();
+    let dest = tempfile::TempDir::new().expect("dest tmp dir");
+
+    sync_untracked_files(src.path(), dest.path(), &[]);
+
+    assert!(
+        !dest.path().join(".env").exists(),
+        "an empty allowlist must copy nothing (mirrors the caller's enabled=false gate)"
+    );
+}
+
+// ── non-fatal on missing/unreadable source ──────────────────────────────
+
+#[test]
+fn missing_source_root_is_non_fatal() {
+    let dest = tempfile::TempDir::new().expect("dest tmp dir");
+    let missing_source = Path::new("/this/path/does/not/exist/anywhere/2196");
+
+    // Must not panic; must simply copy nothing.
+    sync_untracked_files(missing_source, dest.path(), &default_patterns());
+
+    assert!(
+        std::fs::read_dir(dest.path())
+            .expect("dest still readable")
+            .next()
+            .is_none(),
+        "dest worktree must stay empty when the source root is missing"
+    );
+}
+
+#[test]
+fn missing_source_file_is_non_fatal() {
+    // A pattern that matches nothing existing must not panic or error.
+    let src = tempfile::TempDir::new().expect("src tmp dir");
+    let dest = tempfile::TempDir::new().expect("dest tmp dir");
+
+    sync_untracked_files(src.path(), dest.path(), &[".env.nonexistent".to_string()]);
+
+    assert!(
+        std::fs::read_dir(dest.path())
+            .expect("dest still readable")
+            .next()
+            .is_none(),
+        "no candidate files exist; sync must be a silent no-op"
+    );
+}
+
+// ── path-escape guard ────────────────────────────────────────────────────
+
+#[test]
+fn path_escape_pattern_matches_nothing() {
+    let src = tempfile::TempDir::new().expect("src tmp dir");
+    // A secret OUTSIDE the source root that a malicious/misconfigured
+    // pattern might try to reach via `..`.
+    let outside = tempfile::TempDir::new().expect("outside tmp dir");
+    std::fs::write(outside.path().join(".env"), b"must never be reachable")
+        .expect("write outside .env");
+    let dest = tempfile::TempDir::new().expect("dest tmp dir");
+
+    let escape_pattern = format!(
+        "../{}/.env",
+        outside
+            .path()
+            .file_name()
+            .expect("outside dir has a name")
+            .to_string_lossy()
+    );
+
+    sync_untracked_files(src.path(), dest.path(), &[escape_pattern]);
+
+    assert!(
+        std::fs::read_dir(dest.path())
+            .expect("dest still readable")
+            .next()
+            .is_none(),
+        "a pattern with a `..`-escaping directory component must copy nothing"
+    );
+}
+
+#[test]
+fn absolute_pattern_matches_nothing() {
+    let src = tempfile::TempDir::new().expect("src tmp dir");
+    let dest = tempfile::TempDir::new().expect("dest tmp dir");
+
+    sync_untracked_files(src.path(), dest.path(), &["/etc/.env".to_string()]);
+
+    assert!(
+        std::fs::read_dir(dest.path())
+            .expect("dest still readable")
+            .next()
+            .is_none(),
+        "an absolute pattern must copy nothing"
+    );
+}
+
+// ── subdirectory pattern (explicit path separator) ──────────────────────
+
+#[test]
+fn subdirectory_pattern_matches_one_level_non_recursively() {
+    let src = tempfile::TempDir::new().expect("src tmp dir");
+    std::fs::create_dir_all(src.path().join("config")).expect("mkdir config");
+    std::fs::write(src.path().join("config/.env"), b"nested secret").expect("write config/.env");
+    std::fs::create_dir_all(src.path().join("config/nested")).expect("mkdir config/nested");
+    std::fs::write(src.path().join("config/nested/.env"), b"too deep")
+        .expect("write config/nested/.env");
+    let dest = tempfile::TempDir::new().expect("dest tmp dir");
+
+    sync_untracked_files(src.path(), dest.path(), &["config/.env".to_string()]);
+
+    assert!(
+        dest.path().join("config/.env").is_file(),
+        "an explicit subdirectory pattern must copy that one file"
+    );
+    assert!(
+        !dest.path().join("config/nested").exists(),
+        "a subdirectory pattern must not recurse further than the named directory"
+    );
+}
+
+// ── real linked-worktree .git/info/exclude round trip ───────────────────
+
+/// Init a minimal, committed git repo at `path` (mirrors the setup already
+/// used by `inproject::tests`).
+fn init_base_repo(path: &Path) {
+    let init = std::process::Command::new("git")
+        .args(["init", path.to_str().expect("utf8")])
+        .output()
+        .expect("git init");
+    assert!(init.status.success(), "git init failed");
+    for (k, v) in [("user.email", "t@example.com"), ("user.name", "T")] {
+        let ok = std::process::Command::new("git")
+            .args(["-C", path.to_str().expect("utf8"), "config", k, v])
+            .status()
+            .expect("git config");
+        assert!(ok.success(), "git config {k} failed");
+    }
+    std::fs::write(path.join("README"), b"init").expect("write README");
+    let add = std::process::Command::new("git")
+        .args(["-C", path.to_str().expect("utf8"), "add", "."])
+        .status()
+        .expect("git add");
+    assert!(add.success(), "git add failed");
+    let commit = std::process::Command::new("git")
+        .args(["-C", path.to_str().expect("utf8"), "commit", "-m", "init"])
+        .status()
+        .expect("git commit");
+    assert!(commit.success(), "git commit failed");
+}
+
+#[test]
+fn copied_files_are_added_to_shared_worktree_exclude() {
+    let base_tmp = tempfile::TempDir::new().expect("base tmp dir");
+    let base = base_tmp.path();
+    init_base_repo(base);
+
+    let worktree = super::super::create_session_worktree(base, "untracked-sync-exclude-test")
+        .expect("create_session_worktree must succeed against a real, committed base repo");
+    assert!(
+        worktree.join(".git").is_file(),
+        "sanity: a linked worktree's .git must be a FILE (gitlink), not a directory"
+    );
+
+    let src = make_source_fixture();
+    sync_untracked_files(src.path(), &worktree, &default_patterns());
+
+    assert!(worktree.join(".env").is_file(), ".env must be copied");
+    assert!(worktree.join(".env.local").is_file());
+
+    // The exclude entry must land in the SHARED common dir's info/exclude —
+    // NOT at <worktree>/.git/info/exclude (that path cannot exist: .git is a
+    // gitlink file, not a directory).
+    let exclude_out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&worktree)
+        .args(["rev-parse", "--git-path", "info/exclude"])
+        .output()
+        .expect("git rev-parse");
+    assert!(exclude_out.status.success());
+    let raw = String::from_utf8_lossy(&exclude_out.stdout)
+        .trim()
+        .to_string();
+    let exclude_path = if Path::new(&raw).is_absolute() {
+        std::path::PathBuf::from(raw)
+    } else {
+        worktree.join(raw)
+    };
+    let content = std::fs::read_to_string(&exclude_path).expect("exclude file readable");
+    assert!(
+        content.lines().any(|l| l.trim() == ".env"),
+        "exclude file must list .env: {content}"
+    );
+    assert!(
+        content.lines().any(|l| l.trim() == ".env.local"),
+        "exclude file must list .env.local: {content}"
+    );
+}
+
+#[test]
+fn append_to_git_exclude_is_idempotent() {
+    let base_tmp = tempfile::TempDir::new().expect("base tmp dir");
+    let base = base_tmp.path();
+    init_base_repo(base);
+    let worktree = super::super::create_session_worktree(base, "untracked-sync-idempotent-test")
+        .expect("create_session_worktree must succeed");
+
+    append_to_git_exclude(&worktree, &[".env".to_string()]).expect("first append");
+    append_to_git_exclude(&worktree, &[".env".to_string()]).expect("second append");
+
+    let exclude_out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&worktree)
+        .args(["rev-parse", "--git-path", "info/exclude"])
+        .output()
+        .expect("git rev-parse");
+    let raw = String::from_utf8_lossy(&exclude_out.stdout)
+        .trim()
+        .to_string();
+    let exclude_path = if Path::new(&raw).is_absolute() {
+        std::path::PathBuf::from(raw)
+    } else {
+        worktree.join(raw)
+    };
+    let content = std::fs::read_to_string(&exclude_path).expect("exclude readable");
+    let count = content.lines().filter(|l| l.trim() == ".env").count();
+    assert_eq!(
+        count, 1,
+        "repeated appends must not duplicate the entry: {content}"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -194,6 +194,7 @@ async fn spawn_managed_routed(
                     local_path,
                     &base,
                     &repo,
+                    &config,
                 )
                 .await
                 {
@@ -251,10 +252,21 @@ async fn spawn_managed_routed(
 /// collision predicate (so a name whose `.worktrees/<name>` dir or
 /// `session/<name>` branch already exists is retried with the next serial,
 /// not silently reused); (2) creates the worktree at that name via
-/// `inproject::create_session_worktree`. Returns `(worktree_path,
-/// reserved_name)` so the caller can create the tmux session under the SAME
-/// name without re-deriving it.
-/// Test: exercised transitively by the in-project spawn integration tests.
+/// `inproject::create_session_worktree`; (3) best-effort syncs the
+/// operator's allowlisted untracked/secret files (`.env*` by default, #2196)
+/// from `local_path` (the operator's live checkout) into the new worktree via
+/// [`super::inproject::untracked_sync::sync_untracked_files`] — resolved
+/// per-project-over-global-over-default via
+/// `trusty_tools_config::resolve_untracked_sync(config, Some(repo))`, and
+/// SKIPPED entirely (not even attempted) when resolution says `enabled ==
+/// false`. Step 3 can never fail this function: sync failures are `warn!`-
+/// logged inside `sync_untracked_files` itself and never propagate. Returns
+/// `(worktree_path, reserved_name)` so the caller can create the tmux
+/// session under the SAME name without re-deriving it.
+/// Test: exercised transitively by the in-project spawn integration tests;
+/// the sync step's own behaviour (matching, size cap, path-escape guard,
+/// `.git/info/exclude` append) is unit-tested directly in
+/// `inproject::untracked_sync::tests`.
 async fn reserve_inproject_worktree(
     state: &Arc<DaemonState>,
     session_id: &ManagedSessionId,
@@ -262,6 +274,7 @@ async fn reserve_inproject_worktree(
     local_path: &std::path::Path,
     base: &std::path::Path,
     repo: &str,
+    config: &crate::core::trusty_tools_config::TrustyToolsConfig,
 ) -> Result<(std::path::PathBuf, String), String> {
     let mgr = state.session_manager().await;
     let reserved_name = mgr
@@ -276,6 +289,19 @@ async fn reserve_inproject_worktree(
 
     let worktree = super::inproject::create_session_worktree(base, &reserved_name)
         .map_err(|e| format!("worktree creation failed for session {session_id}: {e}"))?;
+
+    // #2196: best-effort sync of the operator's allowlisted untracked/secret
+    // files (default `.env*`) from the live checkout into the fresh
+    // worktree. Never fails the spawn — see the doc above.
+    let resolved_sync =
+        crate::core::trusty_tools_config::resolve_untracked_sync(config, Some(repo));
+    if resolved_sync.enabled {
+        super::inproject::untracked_sync::sync_untracked_files(
+            local_path,
+            &worktree,
+            &resolved_sync.patterns,
+        );
+    }
 
     Ok((worktree, reserved_name))
 }
@@ -1642,10 +1668,18 @@ mod tests {
             mcp_initiated: false,
         };
 
-        let (worktree, reserved_name) =
-            reserve_inproject_worktree(&state, &session_id, &params, &base, &base, "trusty-tools")
-                .await
-                .expect("reserve_inproject_worktree must succeed against a real git repo");
+        let config = crate::core::trusty_tools_config::TrustyToolsConfig::default();
+        let (worktree, reserved_name) = reserve_inproject_worktree(
+            &state,
+            &session_id,
+            &params,
+            &base,
+            &base,
+            "trusty-tools",
+            &config,
+        )
+        .await
+        .expect("reserve_inproject_worktree must succeed against a real git repo");
 
         assert_eq!(
             reserved_name, "tm-trusty-tools-01",

--- a/crates/trusty-mpm/src/daemon/mcp_backend.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend.rs
@@ -536,6 +536,8 @@ impl OrchestratorBackend for StateBackend {
         github_host: Option<&str>,
         commit_name: Option<&str>,
         commit_email: Option<&str>,
+        untracked_sync_patterns: Option<Vec<String>>,
+        untracked_sync_enabled: Option<bool>,
     ) -> Result<Value, String> {
         super::mcp_console::config_write(
             workspace_root_template,
@@ -548,6 +550,8 @@ impl OrchestratorBackend for StateBackend {
             github_host,
             commit_name,
             commit_email,
+            untracked_sync_patterns,
+            untracked_sync_enabled,
         )
     }
 

--- a/crates/trusty-mpm/src/daemon/mcp_console.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_console.rs
@@ -161,17 +161,22 @@ pub async fn auto_resume_set(enabled: bool) -> Result<Value, String> {
 /// full `projects` list (each entry now carries its own optional `github`/
 /// `commit_name`/`commit_email` per-project override) so the Config tab can render
 /// and edit them without a separate MCP round-trip or hand-editing the YAML.
+/// #2196 adds the global `untracked_sync` allowlist section (each `projects`
+/// entry already carries its own optional `untracked_sync` override via its
+/// own `Serialize` impl, so no separate top-level field is needed for that).
 /// What: returns `{ workspace_root_template, auto_resume, default_model, github,
-/// projects, workspace_root }` where `workspace_root` is
+/// untracked_sync, projects, workspace_root }` where `workspace_root` is
 /// [`trusty_tools_config::workspace_root`].
 /// Test: `config_read_returns_resolved_root`,
-/// `config_to_json_includes_github_and_projects`.
+/// `config_to_json_includes_github_and_projects`,
+/// `config_to_json_includes_untracked_sync`.
 fn config_to_json(config: &TrustyToolsConfig) -> Value {
     json!({
         "workspace_root_template": config.workspace_root_template,
         "auto_resume": config.auto_resume,
         "default_model": config.default_model,
         "github": config.github,
+        "untracked_sync": config.untracked_sync,
         "projects": config.projects,
         "workspace_root": trusty_tools_config::workspace_root(config).to_string_lossy(),
     })
@@ -193,7 +198,8 @@ pub fn config_read() -> Result<Value, String> {
 /// Why: the console Config tab's save action durably records the operator's
 /// workspace-root / auto-resume / default-model choices (#1220), and — since
 /// #2184 — the global GitHub identity binding plus per-project GitHub/commit
-/// identity overrides, all without touching the legacy
+/// identity overrides, and — since #2196 — the global/per-project untracked-
+/// secret-file sync allowlist, all without touching the legacy
 /// `~/.trusty-mpm/config.toml` or requiring the operator to hand-edit YAML.
 /// What: loads the current config, applies [`apply_config_write`] (the
 /// testable merge step), writes it back via
@@ -215,6 +221,8 @@ pub fn config_write(
     github_host: Option<&str>,
     commit_name: Option<&str>,
     commit_email: Option<&str>,
+    untracked_sync_patterns: Option<Vec<String>>,
+    untracked_sync_enabled: Option<bool>,
 ) -> Result<Value, String> {
     let mut config = TrustyToolsConfig::load();
     apply_config_write(
@@ -229,6 +237,8 @@ pub fn config_write(
         github_host,
         commit_name,
         commit_email,
+        untracked_sync_patterns,
+        untracked_sync_enabled,
     )?;
 
     trusty_common::crate_config::save(trusty_tools_config::CRATE_NAME, &config)
@@ -260,13 +270,19 @@ pub fn config_write(
 /// empty `repo_url`; register the project first via `project_register` or a
 /// static `config.projects` entry). Each `github_*` field only overlays its
 /// own sub-field — omitted sub-fields keep their previous value, matching the
-/// top-level "omitted fields unchanged" contract.
+/// top-level "omitted fields unchanged" contract. `untracked_sync_patterns`/
+/// `untracked_sync_enabled` (#2196) follow the SAME `project_name` routing as
+/// `github_*` (global tier when `project_name` is `None`, that project's own
+/// tier when `Some`) — unlike commit identity, untracked-sync HAS a global
+/// tier, so no project_name is required for it.
 /// Test: `config_write_merges_top_level_fields`,
 /// `config_write_sets_global_github_binding`,
 /// `config_write_sets_project_github_and_commit_identity`,
 /// `config_write_project_not_found_errors`,
 /// `config_write_preserves_omitted_github_subfields`,
-/// `config_write_global_commit_identity_rejected`.
+/// `config_write_global_commit_identity_rejected`,
+/// `config_write_sets_global_untracked_sync`,
+/// `config_write_sets_project_untracked_sync`.
 #[allow(clippy::too_many_arguments)]
 fn apply_config_write(
     config: &mut TrustyToolsConfig,
@@ -280,6 +296,8 @@ fn apply_config_write(
     github_host: Option<&str>,
     commit_name: Option<&str>,
     commit_email: Option<&str>,
+    untracked_sync_patterns: Option<Vec<String>>,
+    untracked_sync_enabled: Option<bool>,
 ) -> Result<(), String> {
     if let Some(t) = workspace_root_template {
         config.workspace_root_template = Some(t.to_string());
@@ -296,7 +314,9 @@ fn apply_config_write(
         || github_account.is_some()
         || github_host.is_some();
     let has_commit_edit = commit_name.is_some() || commit_email.is_some();
-    if !has_github_edit && !has_commit_edit {
+    let has_untracked_sync_edit =
+        untracked_sync_patterns.is_some() || untracked_sync_enabled.is_some();
+    if !has_github_edit && !has_commit_edit && !has_untracked_sync_edit {
         return Ok(());
     }
 
@@ -309,6 +329,13 @@ fn apply_config_write(
                     github_token_env,
                     github_account,
                     github_host,
+                ));
+            }
+            if has_untracked_sync_edit {
+                config.untracked_sync = Some(merge_untracked_sync_config(
+                    config.untracked_sync.take(),
+                    untracked_sync_patterns,
+                    untracked_sync_enabled,
                 ));
             }
             // #2184 defines commit identity as PROJECT-scoped only (no global
@@ -341,6 +368,13 @@ fn apply_config_write(
                     github_token_env,
                     github_account,
                     github_host,
+                ));
+            }
+            if has_untracked_sync_edit {
+                entry.untracked_sync = Some(merge_untracked_sync_config(
+                    entry.untracked_sync.take(),
+                    untracked_sync_patterns,
+                    untracked_sync_enabled,
                 ));
             }
             if let Some(n) = commit_name {
@@ -389,350 +423,31 @@ fn merge_github_config(
     cfg
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn state() -> Arc<DaemonState> {
-        DaemonState::shared()
+/// Overlay supplied `untracked_sync_*` fields onto an existing (or absent)
+/// [`trusty_tools_config::UntrackedSyncConfig`] (#2196), keeping an omitted
+/// field unchanged.
+///
+/// Why: mirrors [`merge_github_config`]'s "only overlay what was supplied"
+/// rule so both `apply_config_write` branches (global/per-project) stay in
+/// lockstep.
+/// What: starts from `existing.unwrap_or_default()`, overlays `patterns`/
+/// `enabled` when `Some`, and returns the result.
+/// Test: `config_write_sets_global_untracked_sync`,
+/// `config_write_sets_project_untracked_sync`.
+fn merge_untracked_sync_config(
+    existing: Option<trusty_tools_config::UntrackedSyncConfig>,
+    patterns: Option<Vec<String>>,
+    enabled: Option<bool>,
+) -> trusty_tools_config::UntrackedSyncConfig {
+    let mut cfg = existing.unwrap_or_default();
+    if let Some(p) = patterns {
+        cfg.patterns = Some(p);
     }
-
-    /// Why: `config_read` must always return the four-field shape including the
-    /// resolved absolute `workspace_root`, even on a fresh install (defaults).
-    /// Test: this test (reads the real/default config; asserts SHAPE, not values,
-    /// since the host may have a real config file).
-    #[tokio::test]
-    async fn config_read_returns_resolved_root() {
-        let got = config_read().expect("config_read");
-        assert!(
-            got.get("workspace_root_template").is_some(),
-            "must carry workspace_root_template key: {got}"
-        );
-        assert!(
-            got["workspace_root"].is_string()
-                && !got["workspace_root"].as_str().unwrap().is_empty(),
-            "workspace_root must be a non-empty resolved path: {got}"
-        );
+    if let Some(e) = enabled {
+        cfg.enabled = Some(e);
     }
-
-    /// Why: `config_to_json` must surface the #2184 `github`/`projects` fields
-    /// so the Config tab can render/edit them without a separate round-trip.
-    /// Test: this test.
-    #[test]
-    fn config_to_json_includes_github_and_projects() {
-        let config = TrustyToolsConfig {
-            github: Some(trusty_tools_config::GithubConfig {
-                config_dir: Some("/cfg/global".into()),
-                token_env: None,
-                account: None,
-                host: None,
-            }),
-            projects: vec![trusty_tools_config::ProjectConfig {
-                name: "widget".into(),
-                repo_url: "https://github.com/acme/widget".into(),
-                default_branch: None,
-                stack_hint: None,
-                tags: None,
-                description: None,
-                gh_user: None,
-                github: None,
-                commit_name: Some("Bot".into()),
-                commit_email: None,
-            }],
-            ..Default::default()
-        };
-        let json = config_to_json(&config);
-        assert_eq!(json["github"]["config_dir"], "/cfg/global");
-        assert_eq!(json["projects"][0]["name"], "widget");
-        assert_eq!(json["projects"][0]["commit_name"], "Bot");
-    }
-
-    // ── apply_config_write (#2184) — pure merge logic, no real config file I/O ──
-
-    fn project(name: &str) -> trusty_tools_config::ProjectConfig {
-        trusty_tools_config::ProjectConfig {
-            name: name.to_string(),
-            repo_url: format!("https://github.com/acme/{name}"),
-            default_branch: None,
-            stack_hint: None,
-            tags: None,
-            description: None,
-            gh_user: None,
-            github: None,
-            commit_name: None,
-            commit_email: None,
-        }
-    }
-
-    /// Why: the pre-#2184 top-level fields must still merge exactly as before
-    /// (no regression from the new params).
-    /// Test: this test.
-    #[test]
-    fn config_write_merges_top_level_fields() {
-        let mut config = TrustyToolsConfig::default();
-        apply_config_write(
-            &mut config,
-            Some("~/custom-projects"),
-            Some(true),
-            Some("opus"),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .expect("ok");
-        assert_eq!(
-            config.workspace_root_template.as_deref(),
-            Some("~/custom-projects")
-        );
-        assert_eq!(config.auto_resume, Some(true));
-        assert_eq!(config.default_model.as_deref(), Some("opus"));
-        assert_eq!(config.github, None, "no github edit supplied");
-    }
-
-    /// Why: with no `project_name`, `github_*` fields must set the GLOBAL
-    /// `config.github` tier.
-    /// Test: this test.
-    #[test]
-    fn config_write_sets_global_github_binding() {
-        let mut config = TrustyToolsConfig::default();
-        apply_config_write(
-            &mut config,
-            None,
-            None,
-            None,
-            None,
-            Some("/cfg/global"),
-            None,
-            None,
-            Some("github.example.com"),
-            None,
-            None,
-        )
-        .expect("ok");
-        let gh = config.github.expect("global github set");
-        assert_eq!(
-            gh.config_dir.as_deref(),
-            Some(std::path::Path::new("/cfg/global"))
-        );
-        assert_eq!(gh.host.as_deref(), Some("github.example.com"));
-    }
-
-    /// Why: with `project_name` set, `github_*`/`commit_*` fields must
-    /// overlay the MATCHING `config.projects` entry, not the global tier.
-    /// Test: this test.
-    #[test]
-    fn config_write_sets_project_github_and_commit_identity() {
-        let mut config = TrustyToolsConfig {
-            projects: vec![project("widget")],
-            ..Default::default()
-        };
-        apply_config_write(
-            &mut config,
-            None,
-            None,
-            None,
-            Some("widget"),
-            Some("/cfg/widget"),
-            None,
-            Some("bob-work"),
-            None,
-            Some("Widget Bot"),
-            Some("widget-bot@example.com"),
-        )
-        .expect("ok");
-        assert_eq!(config.github, None, "global tier must be untouched");
-        let entry = &config.projects[0];
-        let gh = entry.github.as_ref().expect("project github set");
-        assert_eq!(
-            gh.config_dir.as_deref(),
-            Some(std::path::Path::new("/cfg/widget"))
-        );
-        assert_eq!(gh.account.as_deref(), Some("bob-work"));
-        assert_eq!(entry.commit_name.as_deref(), Some("Widget Bot"));
-        assert_eq!(
-            entry.commit_email.as_deref(),
-            Some("widget-bot@example.com")
-        );
-    }
-
-    /// Why: setting a project's identity for a `project_name` that is NOT
-    /// already declared in `config.projects` must error, never fabricate a
-    /// `ProjectConfig` with an empty `repo_url`.
-    /// Test: this test.
-    #[test]
-    fn config_write_project_not_found_errors() {
-        let mut config = TrustyToolsConfig::default();
-        let err = apply_config_write(
-            &mut config,
-            None,
-            None,
-            None,
-            Some("does-not-exist"),
-            Some("/cfg/x"),
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .unwrap_err();
-        assert!(err.contains("does-not-exist"), "err: {err}");
-        assert!(err.contains("not found"), "err: {err}");
-    }
-
-    /// Why: `merge_github_config` must overlay only the SUPPLIED sub-fields,
-    /// preserving whatever was already set for the omitted ones — matching
-    /// the top-level "omitted fields unchanged" contract.
-    /// Test: this test.
-    #[test]
-    fn config_write_preserves_omitted_github_subfields() {
-        let mut config = TrustyToolsConfig {
-            github: Some(trusty_tools_config::GithubConfig {
-                config_dir: Some("/cfg/original".into()),
-                token_env: None,
-                account: Some("original-account".into()),
-                host: None,
-            }),
-            ..Default::default()
-        };
-        // Only update `host`; config_dir/account must survive untouched.
-        apply_config_write(
-            &mut config,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some("github.example.com"),
-            None,
-            None,
-        )
-        .expect("ok");
-        let gh = config.github.expect("github still set");
-        assert_eq!(
-            gh.config_dir.as_deref(),
-            Some(std::path::Path::new("/cfg/original"))
-        );
-        assert_eq!(gh.account.as_deref(), Some("original-account"));
-        assert_eq!(gh.host.as_deref(), Some("github.example.com"));
-    }
-
-    /// Why: commit identity is project-scoped only (#2184) — supplying
-    /// `commit_name`/`commit_email` with no `project_name` must be rejected
-    /// rather than silently discarded or persisted somewhere unexpected.
-    /// Test: this test.
-    #[test]
-    fn config_write_global_commit_identity_rejected() {
-        let mut config = TrustyToolsConfig::default();
-        let err = apply_config_write(
-            &mut config,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some("Global Bot"),
-            None,
-        )
-        .unwrap_err();
-        assert!(err.contains("project_name"), "err: {err}");
-    }
-
-    /// Why: the doc-referenced round-trip contract — every supplied field
-    /// makes it into the merged config and NOTHING supplied is silently
-    /// dropped. Exercises the full param list together (the shape
-    /// `config_write` itself passes through to `apply_config_write`).
-    /// Test: this test.
-    #[test]
-    fn config_write_merges_and_persists() {
-        let mut config = TrustyToolsConfig {
-            projects: vec![project("widget")],
-            ..Default::default()
-        };
-        apply_config_write(
-            &mut config,
-            Some("~/custom-projects"),
-            Some(false),
-            Some("sonnet"),
-            Some("widget"),
-            Some("/cfg/widget"),
-            Some("WIDGET_GH_TOKEN"),
-            None,
-            Some("github.example.com"),
-            Some("Widget Bot"),
-            Some("widget-bot@example.com"),
-        )
-        .expect("ok");
-        assert_eq!(
-            config.workspace_root_template.as_deref(),
-            Some("~/custom-projects")
-        );
-        assert_eq!(config.auto_resume, Some(false));
-        assert_eq!(config.default_model.as_deref(), Some("sonnet"));
-        let entry = &config.projects[0];
-        let gh = entry.github.as_ref().expect("project github set");
-        assert_eq!(gh.token_env.as_deref(), Some("WIDGET_GH_TOKEN"));
-        assert_eq!(gh.host.as_deref(), Some("github.example.com"));
-        assert_eq!(entry.commit_name.as_deref(), Some("Widget Bot"));
-    }
-
-    /// Why: the console deserialises the report with `parse_report`; the tool must
-    /// return the exact `ConsoleMetricsReport` shape (service_id, status, and a
-    /// `metrics.fleet` object).
-    /// Test: this test.
-    // NOTE: `DaemonState::shared()` is a PROCESS-WIDE singleton, so other tests in
-    // this binary may have registered managed sessions before these run. The
-    // assertions below therefore check SHAPE and field TYPES, never exact fleet
-    // counts (which are non-deterministic across the shared test process).
-
-    #[tokio::test]
-    async fn console_metrics_report_has_expected_shape() {
-        let report = console_metrics(&state()).await.expect("report");
-        assert_eq!(report["service_id"], "trusty-mpm");
-        assert_eq!(report["display_name"], "Trusty MPM");
-        assert_eq!(report["metrics_schema_version"], METRICS_SCHEMA_VERSION);
-        // Status is one of the coarse ServiceHealth variants.
-        assert!(
-            matches!(report["status"].as_str(), Some("ok") | Some("degraded")),
-            "status must be ok|degraded: {report}"
-        );
-        assert!(
-            report["metrics"]["fleet"].is_object(),
-            "metrics.fleet must be an object: {report}"
-        );
-        assert!(
-            report["metrics"]["fleet"]["total"].is_u64(),
-            "metrics.fleet.total must be an integer: {report}"
-        );
-        assert!(
-            report["metrics"]["auto_resume"].is_object(),
-            "metrics.auto_resume must be an object: {report}"
-        );
-    }
-
-    /// Why: the supervisor widget reads `fleet` counts and the auto-resume control
-    /// state from this object; both must be present and well-typed.
-    /// Test: this test.
-    #[tokio::test]
-    async fn supervisor_status_reports_fleet_and_auto_resume() {
-        let status = supervisor_status(&state()).await.expect("status");
-        // Fleet counts must be present and integer-typed (exact values are
-        // non-deterministic in the shared-singleton test process).
-        assert!(status["fleet"]["active"].is_u64());
-        assert!(status["fleet"]["stopped"].is_u64());
-        assert!(status["fleet"]["total"].is_u64());
-        // Auto-resume control block must carry the three flags.
-        assert!(status["auto_resume"]["desired"].is_boolean());
-        assert!(status["auto_resume"]["env"].is_boolean());
-        assert!(status["auto_resume"]["pending_restart"].is_boolean());
-    }
+    cfg
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/mcp_console/tests.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_console/tests.rs
@@ -1,0 +1,457 @@
+//! Unit tests for [`super`] (the console-facing MCP tool implementations).
+//!
+//! Why: split out of `mcp_console.rs` so the production module stays under
+//! the 500-SLOC cap (mirrors `inproject.rs`/`inproject/tests.rs`); the tests
+//! themselves are unchanged.
+//! What: `config_read`/`config_write`/`apply_config_write` shape and merge
+//! tests (including the #2196 `untracked_sync` cases), plus the
+//! `console_metrics`/`supervisor_status` report-shape tests.
+//! Test: this IS the test module.
+
+use super::*;
+
+fn state() -> Arc<DaemonState> {
+    DaemonState::shared()
+}
+
+/// Why: `config_read` must always return the four-field shape including the
+/// resolved absolute `workspace_root`, even on a fresh install (defaults).
+/// Test: this test (reads the real/default config; asserts SHAPE, not values,
+/// since the host may have a real config file).
+#[tokio::test]
+async fn config_read_returns_resolved_root() {
+    let got = config_read().expect("config_read");
+    assert!(
+        got.get("workspace_root_template").is_some(),
+        "must carry workspace_root_template key: {got}"
+    );
+    assert!(
+        got["workspace_root"].is_string() && !got["workspace_root"].as_str().unwrap().is_empty(),
+        "workspace_root must be a non-empty resolved path: {got}"
+    );
+}
+
+/// Why: `config_to_json` must surface the #2184 `github`/`projects` fields
+/// so the Config tab can render/edit them without a separate round-trip.
+/// Test: this test.
+#[test]
+fn config_to_json_includes_github_and_projects() {
+    let config = TrustyToolsConfig {
+        github: Some(trusty_tools_config::GithubConfig {
+            config_dir: Some("/cfg/global".into()),
+            token_env: None,
+            account: None,
+            host: None,
+        }),
+        projects: vec![trusty_tools_config::ProjectConfig {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: None,
+            stack_hint: None,
+            tags: None,
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: Some("Bot".into()),
+            commit_email: None,
+            untracked_sync: None,
+        }],
+        ..Default::default()
+    };
+    let json = config_to_json(&config);
+    assert_eq!(json["github"]["config_dir"], "/cfg/global");
+    assert_eq!(json["projects"][0]["name"], "widget");
+    assert_eq!(json["projects"][0]["commit_name"], "Bot");
+}
+
+// ── apply_config_write (#2184) — pure merge logic, no real config file I/O ──
+
+fn project(name: &str) -> trusty_tools_config::ProjectConfig {
+    trusty_tools_config::ProjectConfig {
+        name: name.to_string(),
+        repo_url: format!("https://github.com/acme/{name}"),
+        default_branch: None,
+        stack_hint: None,
+        tags: None,
+        description: None,
+        gh_user: None,
+        github: None,
+        commit_name: None,
+        commit_email: None,
+        untracked_sync: None,
+    }
+}
+
+/// Why: the pre-#2184 top-level fields must still merge exactly as before
+/// (no regression from the new params).
+/// Test: this test.
+#[test]
+fn config_write_merges_top_level_fields() {
+    let mut config = TrustyToolsConfig::default();
+    apply_config_write(
+        &mut config,
+        Some("~/custom-projects"),
+        Some(true),
+        Some("opus"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("ok");
+    assert_eq!(
+        config.workspace_root_template.as_deref(),
+        Some("~/custom-projects")
+    );
+    assert_eq!(config.auto_resume, Some(true));
+    assert_eq!(config.default_model.as_deref(), Some("opus"));
+    assert_eq!(config.github, None, "no github edit supplied");
+}
+
+/// Why: with no `project_name`, `github_*` fields must set the GLOBAL
+/// `config.github` tier.
+/// Test: this test.
+#[test]
+fn config_write_sets_global_github_binding() {
+    let mut config = TrustyToolsConfig::default();
+    apply_config_write(
+        &mut config,
+        None,
+        None,
+        None,
+        None,
+        Some("/cfg/global"),
+        None,
+        None,
+        Some("github.example.com"),
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("ok");
+    let gh = config.github.expect("global github set");
+    assert_eq!(
+        gh.config_dir.as_deref(),
+        Some(std::path::Path::new("/cfg/global"))
+    );
+    assert_eq!(gh.host.as_deref(), Some("github.example.com"));
+}
+
+/// Why: with `project_name` set, `github_*`/`commit_*` fields must
+/// overlay the MATCHING `config.projects` entry, not the global tier.
+/// Test: this test.
+#[test]
+fn config_write_sets_project_github_and_commit_identity() {
+    let mut config = TrustyToolsConfig {
+        projects: vec![project("widget")],
+        ..Default::default()
+    };
+    apply_config_write(
+        &mut config,
+        None,
+        None,
+        None,
+        Some("widget"),
+        Some("/cfg/widget"),
+        None,
+        Some("bob-work"),
+        None,
+        Some("Widget Bot"),
+        Some("widget-bot@example.com"),
+        None,
+        None,
+    )
+    .expect("ok");
+    assert_eq!(config.github, None, "global tier must be untouched");
+    let entry = &config.projects[0];
+    let gh = entry.github.as_ref().expect("project github set");
+    assert_eq!(
+        gh.config_dir.as_deref(),
+        Some(std::path::Path::new("/cfg/widget"))
+    );
+    assert_eq!(gh.account.as_deref(), Some("bob-work"));
+    assert_eq!(entry.commit_name.as_deref(), Some("Widget Bot"));
+    assert_eq!(
+        entry.commit_email.as_deref(),
+        Some("widget-bot@example.com")
+    );
+}
+
+/// Why: setting a project's identity for a `project_name` that is NOT
+/// already declared in `config.projects` must error, never fabricate a
+/// `ProjectConfig` with an empty `repo_url`.
+/// Test: this test.
+#[test]
+fn config_write_project_not_found_errors() {
+    let mut config = TrustyToolsConfig::default();
+    let err = apply_config_write(
+        &mut config,
+        None,
+        None,
+        None,
+        Some("does-not-exist"),
+        Some("/cfg/x"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .unwrap_err();
+    assert!(err.contains("does-not-exist"), "err: {err}");
+    assert!(err.contains("not found"), "err: {err}");
+}
+
+/// Why: `merge_github_config` must overlay only the SUPPLIED sub-fields,
+/// preserving whatever was already set for the omitted ones — matching
+/// the top-level "omitted fields unchanged" contract.
+/// Test: this test.
+#[test]
+fn config_write_preserves_omitted_github_subfields() {
+    let mut config = TrustyToolsConfig {
+        github: Some(trusty_tools_config::GithubConfig {
+            config_dir: Some("/cfg/original".into()),
+            token_env: None,
+            account: Some("original-account".into()),
+            host: None,
+        }),
+        ..Default::default()
+    };
+    // Only update `host`; config_dir/account must survive untouched.
+    apply_config_write(
+        &mut config,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some("github.example.com"),
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("ok");
+    let gh = config.github.expect("github still set");
+    assert_eq!(
+        gh.config_dir.as_deref(),
+        Some(std::path::Path::new("/cfg/original"))
+    );
+    assert_eq!(gh.account.as_deref(), Some("original-account"));
+    assert_eq!(gh.host.as_deref(), Some("github.example.com"));
+}
+
+/// Why: commit identity is project-scoped only (#2184) — supplying
+/// `commit_name`/`commit_email` with no `project_name` must be rejected
+/// rather than silently discarded or persisted somewhere unexpected.
+/// Test: this test.
+#[test]
+fn config_write_global_commit_identity_rejected() {
+    let mut config = TrustyToolsConfig::default();
+    let err = apply_config_write(
+        &mut config,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some("Global Bot"),
+        None,
+        None,
+        None,
+    )
+    .unwrap_err();
+    assert!(err.contains("project_name"), "err: {err}");
+}
+
+/// Why: the doc-referenced round-trip contract — every supplied field
+/// makes it into the merged config and NOTHING supplied is silently
+/// dropped. Exercises the full param list together (the shape
+/// `config_write` itself passes through to `apply_config_write`).
+/// Test: this test.
+#[test]
+fn config_write_merges_and_persists() {
+    let mut config = TrustyToolsConfig {
+        projects: vec![project("widget")],
+        ..Default::default()
+    };
+    apply_config_write(
+        &mut config,
+        Some("~/custom-projects"),
+        Some(false),
+        Some("sonnet"),
+        Some("widget"),
+        Some("/cfg/widget"),
+        Some("WIDGET_GH_TOKEN"),
+        None,
+        Some("github.example.com"),
+        Some("Widget Bot"),
+        Some("widget-bot@example.com"),
+        None,
+        None,
+    )
+    .expect("ok");
+    assert_eq!(
+        config.workspace_root_template.as_deref(),
+        Some("~/custom-projects")
+    );
+    assert_eq!(config.auto_resume, Some(false));
+    assert_eq!(config.default_model.as_deref(), Some("sonnet"));
+    let entry = &config.projects[0];
+    let gh = entry.github.as_ref().expect("project github set");
+    assert_eq!(gh.token_env.as_deref(), Some("WIDGET_GH_TOKEN"));
+    assert_eq!(gh.host.as_deref(), Some("github.example.com"));
+    assert_eq!(entry.commit_name.as_deref(), Some("Widget Bot"));
+}
+
+/// Why (#2196): `config_to_json` must surface the global `untracked_sync`
+/// section so the Config tab can render/edit it without a separate
+/// round-trip.
+/// Test: this test.
+#[test]
+fn config_to_json_includes_untracked_sync() {
+    let config = TrustyToolsConfig {
+        untracked_sync: Some(trusty_tools_config::UntrackedSyncConfig {
+            patterns: Some(vec![".env".into(), ".env.*".into()]),
+            enabled: Some(false),
+        }),
+        ..Default::default()
+    };
+    let json = config_to_json(&config);
+    assert_eq!(json["untracked_sync"]["enabled"], false);
+    assert_eq!(json["untracked_sync"]["patterns"][0], ".env");
+}
+
+/// Why (#2196): with no `project_name`, `untracked_sync_*` fields must
+/// set the GLOBAL `config.untracked_sync` tier (mirrors
+/// `config_write_sets_global_github_binding`).
+/// Test: this test.
+#[test]
+fn config_write_sets_global_untracked_sync() {
+    let mut config = TrustyToolsConfig::default();
+    apply_config_write(
+        &mut config,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(vec![".env".to_string(), ".env.local".to_string()]),
+        Some(false),
+    )
+    .expect("ok");
+    let cfg = config.untracked_sync.expect("global untracked_sync set");
+    assert_eq!(
+        cfg.patterns,
+        Some(vec![".env".to_string(), ".env.local".to_string()])
+    );
+    assert_eq!(cfg.enabled, Some(false));
+}
+
+/// Why (#2196): with `project_name` set, `untracked_sync_*` fields must
+/// overlay the MATCHING `config.projects` entry, not the global tier —
+/// and omitted sub-fields (e.g. `enabled` here) must survive untouched.
+/// Test: this test.
+#[test]
+fn config_write_sets_project_untracked_sync() {
+    let mut config = TrustyToolsConfig {
+        projects: vec![project("widget")],
+        ..Default::default()
+    };
+    apply_config_write(
+        &mut config,
+        None,
+        None,
+        None,
+        Some("widget"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(vec![".env.widget-only".to_string()]),
+        None,
+    )
+    .expect("ok");
+    assert_eq!(config.untracked_sync, None, "global tier must be untouched");
+    let entry = &config.projects[0];
+    let cfg = entry
+        .untracked_sync
+        .as_ref()
+        .expect("project untracked_sync set");
+    assert_eq!(cfg.patterns, Some(vec![".env.widget-only".to_string()]));
+    assert_eq!(
+        cfg.enabled, None,
+        "enabled was not supplied; must stay None"
+    );
+}
+
+/// Why: the console deserialises the report with `parse_report`; the tool must
+/// return the exact `ConsoleMetricsReport` shape (service_id, status, and a
+/// `metrics.fleet` object).
+/// Test: this test.
+// NOTE: `DaemonState::shared()` is a PROCESS-WIDE singleton, so other tests in
+// this binary may have registered managed sessions before these run. The
+// assertions below therefore check SHAPE and field TYPES, never exact fleet
+// counts (which are non-deterministic across the shared test process).
+
+#[tokio::test]
+async fn console_metrics_report_has_expected_shape() {
+    let report = console_metrics(&state()).await.expect("report");
+    assert_eq!(report["service_id"], "trusty-mpm");
+    assert_eq!(report["display_name"], "Trusty MPM");
+    assert_eq!(report["metrics_schema_version"], METRICS_SCHEMA_VERSION);
+    // Status is one of the coarse ServiceHealth variants.
+    assert!(
+        matches!(report["status"].as_str(), Some("ok") | Some("degraded")),
+        "status must be ok|degraded: {report}"
+    );
+    assert!(
+        report["metrics"]["fleet"].is_object(),
+        "metrics.fleet must be an object: {report}"
+    );
+    assert!(
+        report["metrics"]["fleet"]["total"].is_u64(),
+        "metrics.fleet.total must be an integer: {report}"
+    );
+    assert!(
+        report["metrics"]["auto_resume"].is_object(),
+        "metrics.auto_resume must be an object: {report}"
+    );
+}
+
+/// Why: the supervisor widget reads `fleet` counts and the auto-resume control
+/// state from this object; both must be present and well-typed.
+/// Test: this test.
+#[tokio::test]
+async fn supervisor_status_reports_fleet_and_auto_resume() {
+    let status = supervisor_status(&state()).await.expect("status");
+    // Fleet counts must be present and integer-typed (exact values are
+    // non-deterministic in the shared-singleton test process).
+    assert!(status["fleet"]["active"].is_u64());
+    assert!(status["fleet"]["stopped"].is_u64());
+    assert!(status["fleet"]["total"].is_u64());
+    // Auto-resume control block must carry the three flags.
+    assert!(status["auto_resume"]["desired"].is_boolean());
+    assert!(status["auto_resume"]["env"].is_boolean());
+    assert!(status["auto_resume"]["pending_restart"].is_boolean());
+}

--- a/crates/trusty-mpm/src/mcp/mod.rs
+++ b/crates/trusty-mpm/src/mcp/mod.rs
@@ -294,7 +294,10 @@ pub trait OrchestratorBackend: Send + Sync {
     ///      `github_*`/`commit_*` fields to that `config.projects` entry instead of
     ///      the global `github:` section; omitting it targets the global section
     ///      (commit identity has no global tier — supplying `commit_name`/
-    ///      `commit_email` with no `project_name` is an error).
+    ///      `commit_email` with no `project_name` is an error). `untracked_sync_*`
+    ///      (#2196) sets the untracked/secret-file sync allowlist and follows the
+    ///      SAME `project_name` routing as `github_*` (it DOES have a global tier,
+    ///      unlike commit identity).
     /// Test: `dispatch_config_write_tool` (mock).
     #[allow(clippy::too_many_arguments)]
     async fn config_write(
@@ -309,6 +312,8 @@ pub trait OrchestratorBackend: Send + Sync {
         github_host: Option<&str>,
         commit_name: Option<&str>,
         commit_email: Option<&str>,
+        untracked_sync_patterns: Option<Vec<String>>,
+        untracked_sync_enabled: Option<bool>,
     ) -> Result<Value, String>;
 
     // ── #1519 WI-2: project-registry tools ───────────────────────────────────
@@ -506,6 +511,15 @@ async fn dispatch_tool_call<B: OrchestratorBackend>(
             let github_host = args.get("github_host").and_then(Value::as_str);
             let commit_name = args.get("commit_name").and_then(Value::as_str);
             let commit_email = args.get("commit_email").and_then(Value::as_str);
+            let untracked_sync_patterns = args.get("untracked_sync_patterns").and_then(|v| {
+                v.as_array().map(|arr| {
+                    arr.iter()
+                        .filter_map(|p| p.as_str().map(str::to_string))
+                        .collect::<Vec<String>>()
+                })
+            });
+            let untracked_sync_enabled =
+                args.get("untracked_sync_enabled").and_then(Value::as_bool);
             backend
                 .config_write(
                     template,
@@ -518,6 +532,8 @@ async fn dispatch_tool_call<B: OrchestratorBackend>(
                     github_host,
                     commit_name,
                     commit_email,
+                    untracked_sync_patterns,
+                    untracked_sync_enabled,
                 )
                 .await
         }

--- a/crates/trusty-mpm/src/mcp/tests.rs
+++ b/crates/trusty-mpm/src/mcp/tests.rs
@@ -175,6 +175,8 @@ impl OrchestratorBackend for MockBackend {
         _github_host: Option<&str>,
         commit_name: Option<&str>,
         _commit_email: Option<&str>,
+        untracked_sync_patterns: Option<Vec<String>>,
+        untracked_sync_enabled: Option<bool>,
     ) -> Result<Value, String> {
         Ok(json!({
             "workspace_root_template": workspace_root_template,
@@ -184,6 +186,8 @@ impl OrchestratorBackend for MockBackend {
             "project_name": project_name,
             "github_config_dir": github_config_dir,
             "commit_name": commit_name,
+            "untracked_sync_patterns": untracked_sync_patterns,
+            "untracked_sync_enabled": untracked_sync_enabled,
         }))
     }
 

--- a/crates/trusty-mpm/src/mcp/tools/console.rs
+++ b/crates/trusty-mpm/src/mcp/tools/console.rs
@@ -82,10 +82,11 @@ pub(super) fn console_tools() -> Vec<Value> {
             "Read trusty-mpm's `~/.trusty-tools/trusty-mpm/config.yaml` (the #1220 \
              cross-crate config convention) and return its current settings as JSON: \
              `workspace_root_template`, `auto_resume`, `default_model`, the global \
-             `github` GitHub-identity binding, and the full `projects` list (each \
-             entry may carry its own `github`/`commit_name`/`commit_email` \
-             per-project override, #2184). An absent file returns the defaults (all \
-             null/empty). Backs the trusty-console Config tab.",
+             `github` GitHub-identity binding, the global `untracked_sync` \
+             untracked/secret-file sync allowlist (#2196), and the full `projects` \
+             list (each entry may carry its own `github`/`commit_name`/`commit_email`/ \
+             `untracked_sync` per-project override). An absent file returns the \
+             defaults (all null/empty). Backs the trusty-console Config tab.",
             json!({
                 "type": "object",
                 "properties": {},
@@ -107,8 +108,13 @@ pub(super) fn console_tools() -> Vec<Value> {
              which takes precedence over the global one for that project's `gh` \
              calls. `commit_name`/`commit_email` set a per-project git commit-author \
              override applied to managed/provisioner git operations — they REQUIRE \
-             `project_name` (commit identity has no global tier). Returns the merged \
-             config that was persisted.",
+             `project_name` (commit identity has no global tier). `untracked_sync_patterns`/ \
+             `untracked_sync_enabled` (#2196) set the allowlist of untracked/secret filename \
+             patterns (default `.env*`) synced from the operator's live checkout into each \
+             session worktree at spawn, and the on/off toggle for that sync; like `github_*` \
+             (and unlike commit identity) these DO have a global tier — omit `project_name` to \
+             set it, or supply an ALREADY-REGISTERED `project_name` to override it for that \
+             project only. Returns the merged config that was persisted.",
             json!({
                 "type": "object",
                 "properties": {
@@ -151,6 +157,15 @@ pub(super) fn console_tools() -> Vec<Value> {
                     "commit_email": {
                         "type": "string",
                         "description": "Git commit author email override for this project (requires project_name)."
+                    },
+                    "untracked_sync_patterns": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Allowlist of untracked/secret filename patterns to sync into session worktrees (e.g. [\".env\", \".env.local\", \".env.*\"]). Global unless project_name is set."
+                    },
+                    "untracked_sync_enabled": {
+                        "type": "boolean",
+                        "description": "Whether untracked/secret file sync runs at all. Global unless project_name is set."
                     }
                 },
                 "additionalProperties": false

--- a/crates/trusty-mpm/src/project/registry.rs
+++ b/crates/trusty-mpm/src/project/registry.rs
@@ -347,6 +347,7 @@ mod tests {
                 }),
                 commit_name: Some("ML Bot".into()),
                 commit_email: Some("ml-bot@example.com".into()),
+                untracked_sync: None,
             },
             ProjectConfig {
                 name: "from-config-b".into(),
@@ -359,6 +360,7 @@ mod tests {
                 github: None,
                 commit_name: None,
                 commit_email: None,
+                untracked_sync: None,
             },
         ];
 


### PR DESCRIPTION
## Summary

- Syncs an allowlist of untracked/secret files (default `.env`, `.env.local`, `.env.*`) from the operator's live checkout into each managed session worktree at spawn time, allowlist-only and gitignore-safe.
- New global `untracked_sync:` config section + per-project `projects[].untracked_sync` override, resolved per-project > global > built-in default (default = **enabled**, `.env*` allowlist).
- Extended `config_read`/`config_write` MCP tools so the allowlist and on/off toggle are settable declaratively, mirroring the #2192 `github:` pattern.

## Details

- **Config** (`core/trusty_tools_config/untracked_sync.rs`, split out of `trusty_tools_config.rs` to respect the 500-SLOC cap): `UntrackedSyncConfig { patterns: Option<Vec<String>>, enabled: Option<bool> }` as `TrustyToolsConfig.untracked_sync` (global) and `ProjectConfig.untracked_sync` (per-project override). `resolve_untracked_sync(config, repo_name)` implements the precedence chain.
- **Sync function** (`daemon/managed_routes/inproject/untracked_sync.rs`, sibling module to keep `inproject.rs` under the cap): `sync_untracked_files(source, dest_worktree, patterns)` — best-effort, non-fatal (`warn!` on any error, never propagates). Four security guards:
  1. **Allowlist-only** — never enumerates all untracked files, only matches declared patterns against top-level (or one explicit subdirectory) entries.
  2. **Size cap** — skips + warns on any file > 5 MiB.
  3. **Path-escape guard** — rejects patterns with `..` segments or absolute paths before ever touching disk.
  4. **Gitignore-safe** — appends every copied file's relative path to the worktree's REAL `info/exclude` (resolved via `git rev-parse --git-path info/exclude`, which correctly follows a linked worktree's gitlink back to the shared common git dir — a naive `<worktree>/.git/info/exclude` join would fail since `.git` in a worktree is a file, not a directory).
- **Wiring**: `lifecycle::reserve_inproject_worktree` (daemon managed-spawn path) calls the sync right after `create_session_worktree` succeeds, resolving the allowlist from the already-loaded `TrustyToolsConfig` + the detected repo name. Gated on `enabled` (default true); a sync failure never fails the spawn.
- **MCP**: `config_read`/`config_write`/`config_to_json` in `daemon/mcp_console.rs` extended with `untracked_sync_patterns`/`untracked_sync_enabled` (global unless `project_name` is set, mirroring `github_*`).

## Test plan

- [x] Config resolution: per-project > global > built-in default; `enabled` gate.
- [x] Sync function: `.env`/`.env.local` copied, `.env.local.bak`-style non-matches skipped, oversized file skipped, `node_modules/` never copied, path-escape guard, missing-source non-fatal.
- [x] Real linked-worktree round trip proving `.git/info/exclude` resolution (gitlink case) and idempotency.
- [x] MCP config_write merge tests (global + per-project untracked_sync tiers).
- [x] `cargo build --workspace` — clean.
- [x] `cargo test -p trusty-mpm` — 2478 lib tests + all integration binaries pass, 0 failed (pre-existing unrelated `formatters::banner::two_panel::tests::right_col_no_inner_border` failure confirmed present on `origin/main` before this branch, untouched by this change).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `bash scripts/check_line_cap.sh` — OK (0 violations; new modules split to respect the 500-SLOC cap).

Closes #2196

🤖 Generated with [Claude Code](https://claude.com/claude-code)