### PR TITLE
fix(trusty-code): plumb agent [llm].max_tokens into AgentLoopConfig (closes #2198)

### DIFF
--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -81,6 +81,18 @@ pub struct AgentLoopConfig {
     /// OpenRouter model slug sent on every chat request.
     pub model: String,
 
+    /// Per-turn completion-token cap sent as `ChatRequest.max_tokens`.
+    ///
+    /// Why: A single hard-coded cap starves any turn that must emit more than
+    /// its value — e.g. `write_file` on a real source file — silently
+    /// truncating output until the loop churns out its turn budget. Callers
+    /// must resolve this from the agent's own `[llm].max_tokens` (via
+    /// `crate::provider::resolve_max_tokens`) rather than relying on the
+    /// default below.
+    /// What: Sent verbatim as `Some(self.max_tokens)` on every `ChatRequest`
+    /// built by `AgentLoop::build_request`.
+    pub max_tokens: u32,
+
     /// The resolved harness mode for this run (#2059). See
     /// `Self::tool_definitions`' docs for the branch point this feeds.
     pub mode: HarnessMode,
@@ -96,15 +108,20 @@ impl Default for AgentLoopConfig {
     /// Sensible defaults for an interactive agent run.
     ///
     /// Why: Most callers want a bounded but generous loop; defaults avoid
-    /// boilerplate at every construction site.
-    /// What: 8 turns, 120s timeout, `openai/gpt-4o-mini`, `HarnessMode::default()`,
-    /// `CompactionConfig::default()`.
+    /// boilerplate at every construction site. `max_tokens` defaults to
+    /// `crate::provider::DEFAULT_MAX_TOKENS` — callers that need the agent's
+    /// configured `[llm].max_tokens` must set this field explicitly via
+    /// `crate::provider::resolve_max_tokens`; this default is only the
+    /// generous fallback for when no agent config is consulted.
+    /// What: 8 turns, 120s timeout, `openai/gpt-4o-mini`,
+    /// `DEFAULT_MAX_TOKENS`, `HarnessMode::default()`, `CompactionConfig::default()`.
     /// Test: `config_defaults_are_sane`.
     fn default() -> Self {
         Self {
             max_turns: 8,
             timeout_secs: 120,
             model: "openai/gpt-4o-mini".to_string(),
+            max_tokens: crate::provider::DEFAULT_MAX_TOKENS,
             mode: HarnessMode::default(),
             compaction: CompactionConfig::default(),
         }
@@ -408,10 +425,14 @@ impl AgentLoop {
     /// Build a `ChatRequest` from the running transcript and tool schemas.
     ///
     /// Why: Each turn re-sends the full history plus the advertised tools so the
-    /// model has complete context.
+    /// model has complete context. The completion-token cap must come from
+    /// `self.config.max_tokens` (the caller-resolved agent `[llm].max_tokens`,
+    /// or `DEFAULT_MAX_TOKENS`) — a hard-coded cap here previously truncated
+    /// any turn (e.g. a real `write_file`) needing more than 1024 tokens.
     /// What: Clones the transcript messages, attaches tools (when any), and sets
     /// `tool_choice = "auto"` so the model may call tools but isn't forced to.
-    /// Test: Exercised by every loop test.
+    /// Test: Exercised by every loop test; `config_max_tokens_reaches_chat_request`
+    /// pins that a configured cap flows through unchanged.
     fn build_request(&self, transcript: &Transcript, schemas: &[ToolDefinition]) -> ChatRequest {
         let tools = if schemas.is_empty() {
             None
@@ -424,7 +445,7 @@ impl AgentLoop {
             model: self.config.model.clone(),
             messages: transcript.to_messages(),
             temperature: Some(0.0),
-            max_tokens: Some(1024),
+            max_tokens: Some(self.config.max_tokens),
             tools,
             tool_choice,
         }

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -39,6 +39,10 @@ struct ScriptedLlm {
     /// tests inspect exactly what the loop sent the model on each turn
     /// without reaching into `Transcript` internals.
     requests: Mutex<Vec<Vec<crate::llm::ChatMessage>>>,
+    /// Every request's `max_tokens`, in call order — lets the
+    /// `configured_max_tokens_reaches_chat_request` regression test assert the
+    /// configured cap (not the old hard-coded 1024) reached the wire request.
+    max_tokens_seen: Mutex<Vec<Option<u32>>>,
 }
 
 impl ScriptedLlm {
@@ -57,6 +61,7 @@ impl ScriptedLlm {
             responses,
             cursor: AtomicUsize::new(0),
             requests: Mutex::new(Vec::new()),
+            max_tokens_seen: Mutex::new(Vec::new()),
         }
     }
 
@@ -82,6 +87,16 @@ impl ScriptedLlm {
     fn requests(&self) -> Vec<Vec<crate::llm::ChatMessage>> {
         self.requests.lock().expect("lock").clone()
     }
+
+    /// Every request's `max_tokens`, in call order.
+    ///
+    /// Why: The regression guard for the max-tokens bug needs to see exactly
+    /// what cap the loop sent per turn, independent of message contents.
+    /// What: Clones the recorded `max_tokens` values.
+    /// Test: `configured_max_tokens_reaches_chat_request`.
+    fn max_tokens_seen(&self) -> Vec<Option<u32>> {
+        self.max_tokens_seen.lock().expect("lock").clone()
+    }
 }
 
 #[async_trait]
@@ -89,6 +104,9 @@ impl LlmClientTrait for ScriptedLlm {
     async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
         if let Ok(mut guard) = self.requests.lock() {
             guard.push(req.messages.clone());
+        }
+        if let Ok(mut guard) = self.max_tokens_seen.lock() {
+            guard.push(req.max_tokens);
         }
         let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
         match self.responses.get(idx) {
@@ -257,7 +275,9 @@ fn registry_with_finish_task() -> Arc<ToolRegistry> {
 /// Config defaults are present and sane.
 ///
 /// Why: Defaults are the most-used construction path; guard them.
-/// What: Assert `max_turns`, `timeout_secs`, and a non-empty model.
+/// What: Assert `max_turns`, `timeout_secs`, a non-empty model, and that
+/// `max_tokens` is generous enough for a real write turn (not the old
+/// hard-coded 1024 that truncated file writes).
 /// Test: this test.
 #[test]
 fn config_defaults_are_sane() {
@@ -265,6 +285,48 @@ fn config_defaults_are_sane() {
     assert!(cfg.max_turns >= 1);
     assert!(cfg.timeout_secs >= 1);
     assert!(!cfg.model.is_empty());
+    assert!(
+        cfg.max_tokens > 1024,
+        "default max_tokens must exceed the old hard-coded 1024 cap"
+    );
+}
+
+/// A configured `max_tokens` reaches the outgoing `ChatRequest` unchanged.
+///
+/// Why: This is the direct regression guard for the bug where `build_request`
+/// hard-coded `max_tokens: Some(1024)` regardless of `AgentLoopConfig` —
+/// truncating any turn (e.g. a real file write) that needed more. Every call
+/// site now resolves the agent's `[llm].max_tokens` into `AgentLoopConfig`
+/// before constructing the loop; this test pins that the loop itself honours
+/// whatever value it is given rather than overriding it.
+/// What: Configure `max_tokens: 8192`, run a single-turn stop, and assert the
+/// `ScriptedLlm` observed `Some(8192)` — never `Some(1024)`.
+/// Test: this test.
+#[tokio::test]
+async fn configured_max_tokens_reaches_chat_request() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let registry = registry_with_echo(false);
+    let agent = make_loop(
+        llm.clone(),
+        registry,
+        AgentLoopConfig {
+            max_tokens: 8192,
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    agent
+        .run("system", "write a file")
+        .await
+        .expect("single stop turn should complete");
+
+    let seen = llm.max_tokens_seen();
+    assert_eq!(seen, vec![Some(8192)]);
+    assert_ne!(
+        seen[0],
+        Some(1024),
+        "configured max_tokens must not be clamped back to the old default"
+    );
 }
 
 /// A tool call with syntactically malformed JSON arguments is reported as a

--- a/crates/trusty-code/src/provider/mod.rs
+++ b/crates/trusty-code/src/provider/mod.rs
@@ -7,8 +7,9 @@
 //! seam (#1021) and the precedence resolver for which slug to use.
 //! What: Re-exports the [`Provider`] trait and [`ToolChoice`] enum, the two
 //! concrete providers ([`OpenRouterProvider`], [`BedrockProvider`]), the
-//! [`provider_for`] factory, and the [`resolve_model`] precedence function plus
-//! its [`DEFAULT_MODEL`] constant.
+//! [`provider_for`] factory, the [`resolve_model`] precedence function plus
+//! its [`DEFAULT_MODEL`] constant, and the [`resolve_max_tokens`] precedence
+//! function plus its [`DEFAULT_MAX_TOKENS`] constant.
 //! Test: submodule `tests` in each file; routing/adapter coverage in
 //! `routing.rs` and `adapter.rs`.
 
@@ -21,5 +22,5 @@ mod traits;
 pub use adapter::provider_for;
 pub use bedrock::BedrockProvider;
 pub use openrouter::OpenRouterProvider;
-pub use routing::{DEFAULT_MODEL, resolve_model};
+pub use routing::{DEFAULT_MAX_TOKENS, DEFAULT_MODEL, resolve_max_tokens, resolve_model};
 pub use traits::{Provider, ToolChoice};

--- a/crates/trusty-code/src/provider/routing.rs
+++ b/crates/trusty-code/src/provider/routing.rs
@@ -20,6 +20,18 @@ use crate::tools::RunContext;
 /// Test: `routing::tests::resolve_model_falls_back_to_default`.
 pub const DEFAULT_MODEL: &str = "openai/gpt-4o-mini";
 
+/// Default per-turn completion token cap when `[llm].max_tokens` is unset.
+///
+/// Why: A turn cap must always resolve to *some* value, and it must be large
+/// enough for a real tool-calling turn (e.g. `write_file` emitting a whole
+/// source file) to complete without truncation — the bug this constant fixes
+/// was every turn silently capped at 1024 regardless of agent config,
+/// truncating real writes. 8192 is generous enough for typical file writes
+/// while still bounding a single turn's cost.
+/// What: The fallback completion-token cap used by [`resolve_max_tokens`].
+/// Test: `routing::tests::resolve_max_tokens_falls_back_to_default`.
+pub const DEFAULT_MAX_TOKENS: u32 = 8192;
+
 /// Resolve the model slug for an invocation.
 ///
 /// Why: Centralises the precedence so per-call overrides, per-agent config, and
@@ -50,6 +62,22 @@ pub fn resolve_model(agent_config: &AgentConfig, run_context: Option<&RunContext
 
     // 4. Built-in default.
     DEFAULT_MODEL.to_string()
+}
+
+/// Resolve the per-turn completion-token cap for an invocation.
+///
+/// Why: `[llm].max_tokens` is how an operator declares that an agent's turns
+/// need a larger completion budget than the default (e.g. an engineer that
+/// writes whole files needs far more than a chat-only PM). Before this fix,
+/// every call site building an `AgentLoopConfig` ignored the agent's
+/// `[llm].max_tokens` entirely and the loop hard-coded a 1024-token cap,
+/// truncating any turn that needed to emit more (#run_task-maxtokens-bug).
+/// What: Returns `agent_config.llm.max_tokens` when set, else
+/// [`DEFAULT_MAX_TOKENS`]. There is no per-call `RunContext` override yet —
+/// the config-file value or the built-in default are the only two tiers.
+/// Test: `routing::tests::resolve_max_tokens_*`.
+pub fn resolve_max_tokens(agent_config: &AgentConfig) -> u32 {
+    agent_config.llm.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS)
 }
 
 /// Treat empty/whitespace-only strings as absent.
@@ -205,5 +233,36 @@ mod tests {
             "deepseek/deepseek-chat",
             "all-whitespace agent.model must fall through to the next tier"
         );
+    }
+
+    /// A configured `[llm].max_tokens` is honoured, not clamped to the default.
+    ///
+    /// Why: This is the regression guard for the bug this function fixes — a
+    /// configured cap higher than the old hard-coded 1024 must reach the
+    /// caller unchanged.
+    /// What: `[llm].max_tokens = 8192` resolves to `8192`.
+    /// Test: this test.
+    #[test]
+    fn resolve_max_tokens_honours_configured_value() {
+        let config = AgentConfig {
+            llm: LlmParams {
+                max_tokens: Some(8192),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(resolve_max_tokens(&config), 8192);
+    }
+
+    /// Falls back to `DEFAULT_MAX_TOKENS` when `[llm].max_tokens` is unset.
+    ///
+    /// Why: A run must always resolve to a usable, generous-enough cap even
+    /// when the agent TOML doesn't specify one.
+    /// What: Empty config resolves to `DEFAULT_MAX_TOKENS`.
+    /// Test: this test.
+    #[test]
+    fn resolve_max_tokens_falls_back_to_default() {
+        let config = AgentConfig::default();
+        assert_eq!(resolve_max_tokens(&config), DEFAULT_MAX_TOKENS);
     }
 }

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -32,7 +32,7 @@ use crate::agents::AgentConfig;
 use crate::llm::LlmClientTrait;
 use crate::project_context::load_project_context;
 use crate::prompt::assemble_system_prompt;
-use crate::provider::resolve_model;
+use crate::provider::{resolve_max_tokens, resolve_model};
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
 use crate::tools::{
     AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, FinishTaskTool,
@@ -149,6 +149,7 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
     let pm_loop = AgentLoop::new(
         AgentLoopConfig {
             model: pm_model.clone(),
+            max_tokens: resolve_max_tokens(&pm_config),
             ..AgentLoopConfig::default()
         },
         pm_llm,

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -37,6 +37,12 @@ struct ScriptedLlm {
     responses: Vec<ChatResponse>,
     cursor: AtomicUsize,
     models: Mutex<Vec<String>>,
+    /// Every request's `max_tokens`, in call order — lets
+    /// `pm_llm_max_tokens_reaches_chat_request` assert the PM's configured
+    /// `[llm].max_tokens` reached the wire request rather than being silently
+    /// dropped in favour of the agent-loop default (the run_task max-tokens
+    /// bug this test guards against).
+    max_tokens: Mutex<Vec<Option<u32>>>,
 }
 
 impl ScriptedLlm {
@@ -49,12 +55,23 @@ impl ScriptedLlm {
             responses,
             cursor: AtomicUsize::new(0),
             models: Mutex::new(Vec::new()),
+            max_tokens: Mutex::new(Vec::new()),
         }
     }
 
     /// Every model slug the client was asked to use, in call order.
     fn models_seen(&self) -> Vec<String> {
         self.models.lock().expect("models lock").clone()
+    }
+
+    /// The `max_tokens` of the first recorded request (the PM's first turn).
+    fn first_max_tokens(&self) -> Option<u32> {
+        self.max_tokens
+            .lock()
+            .expect("max_tokens lock")
+            .first()
+            .copied()
+            .expect("at least one request recorded")
     }
 }
 
@@ -65,6 +82,10 @@ impl LlmClientTrait for ScriptedLlm {
             .lock()
             .expect("models lock")
             .push(req.model.clone());
+        self.max_tokens
+            .lock()
+            .expect("max_tokens lock")
+            .push(req.max_tokens);
         let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
         match self.responses.get(idx) {
             Some(resp) => Ok(resp.clone()),
@@ -243,6 +264,48 @@ async fn end_to_end_pm_delegates_to_engineer() {
     assert!(
         roles.contains(&"python-engineer"),
         "transcript must have an engineer turn: {roles:?}"
+    );
+}
+
+/// The PM's configured `[llm].max_tokens` reaches its `ChatRequest` via
+/// `execute_run_task` — the exact entry point of the run_task max-tokens bug.
+///
+/// Why: `execute_run_task` previously built the PM's `AgentLoopConfig` via
+/// `AgentLoopConfig { model: pm_model, ..AgentLoopConfig::default() }`,
+/// dropping `pm_config.llm.max_tokens` entirely so every PM turn was capped at
+/// the hard-coded default regardless of what `pm.toml` declared. This is the
+/// end-to-end regression guard: a `pm.toml` with `[llm].max_tokens = 8192`
+/// must produce a `ChatRequest.max_tokens` of `8192`, never the old 1024.
+/// What: `pm.toml` declares `[llm].max_tokens = 8192`; script a single PM stop
+/// turn; assert the scripted client observed `Some(8192)`.
+/// Test: this test.
+#[tokio::test]
+async fn pm_llm_max_tokens_reaches_chat_request() {
+    let agents = tempfile::tempdir().expect("agents tempdir");
+    std::fs::write(
+        agents.path().join("pm.toml"),
+        "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n\
+         [llm]\nmax_tokens = 8192\n\
+         [system_prompt]\ncontent = \"You are the PM.\"\n",
+    )
+    .expect("write pm.toml");
+    std::fs::write(
+        agents.path().join("python-engineer.toml"),
+        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n[system_prompt]\ncontent = \"You are a Python engineer.\"\n",
+    )
+    .expect("write python-engineer.toml");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response(
+        "pm: nothing to do",
+    )]));
+
+    let _report = execute_run_task(params(&agents, &project, None), llm.clone()).await;
+
+    assert_eq!(
+        llm.first_max_tokens(),
+        Some(8192),
+        "PM's configured [llm].max_tokens must reach its ChatRequest, not the old 1024 default"
     );
 }
 

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -31,7 +31,7 @@ use crate::agents::AgentConfig;
 use crate::llm::LlmClientTrait;
 use crate::mode::HarnessMode;
 use crate::prompt::assemble_system_prompt_for_mode;
-use crate::provider::resolve_model;
+use crate::provider::{resolve_max_tokens, resolve_model};
 use crate::runner::error::RunnerError;
 use crate::tools::{AgentOutput, AgentRunner, RunContext, ToolRegistry};
 
@@ -311,11 +311,16 @@ impl InProcessAgentRunner {
         // Resolve the model and the per-call turn cap (RunContext wins).
         let model = resolve_model(&agent, Some(ctx));
         let max_turns = ctx.max_turns_override.unwrap_or(self.config.max_turns);
+        // #run_task-maxtokens-bug: the delegated agent's own `[llm].max_tokens`
+        // must reach its loop — previously this was dropped entirely and every
+        // sub-agent turn was silently capped at the agent-loop default.
+        let max_tokens = resolve_max_tokens(&agent);
 
         let loop_config = AgentLoopConfig {
             max_turns,
             timeout_secs: self.config.timeout_secs,
             model,
+            max_tokens,
             mode: self.mode,
             compaction: crate::agent_loop::CompactionConfig::default(),
         };

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -42,6 +42,11 @@ struct ScriptedLlm {
     responses: Vec<ChatResponse>,
     cursor: AtomicUsize,
     seen: Mutex<Vec<(String, String)>>,
+    /// Every request's `max_tokens`, in call order — lets
+    /// `engineer_llm_max_tokens_reaches_chat_request` assert the delegated
+    /// engineer's `[llm].max_tokens` reached the wire request rather than
+    /// being silently dropped in favour of the agent-loop default.
+    max_tokens_seen: Mutex<Vec<Option<u32>>>,
 }
 
 impl ScriptedLlm {
@@ -59,6 +64,7 @@ impl ScriptedLlm {
             responses,
             cursor: AtomicUsize::new(0),
             seen: Mutex::new(Vec::new()),
+            max_tokens_seen: Mutex::new(Vec::new()),
         }
     }
 
@@ -76,6 +82,16 @@ impl ScriptedLlm {
             .cloned()
             .expect("at least one request recorded")
     }
+
+    /// The `max_tokens` of the first recorded request.
+    fn first_max_tokens(&self) -> Option<u32> {
+        self.max_tokens_seen
+            .lock()
+            .expect("max_tokens_seen lock")
+            .first()
+            .copied()
+            .expect("at least one request recorded")
+    }
 }
 
 #[async_trait]
@@ -91,6 +107,10 @@ impl LlmClientTrait for ScriptedLlm {
             .lock()
             .expect("seen lock")
             .push((req.model.clone(), system));
+        self.max_tokens_seen
+            .lock()
+            .expect("max_tokens_seen lock")
+            .push(req.max_tokens);
 
         let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
         match self.responses.get(idx) {
@@ -304,6 +324,59 @@ content = "You are a Python engineer."
         invoked.lock().expect("invoked").as_slice(),
         ["work_tool"],
         "the engineer's tool must have run inside its own loop"
+    );
+}
+
+/// The delegated engineer's own `[llm].max_tokens` reaches its `ChatRequest`.
+///
+/// Why: This is the regression guard for the run_task bug where
+/// `InProcessAgentRunner::run_pipeline` built the engineer's `AgentLoopConfig`
+/// without ever consulting `agent.llm.max_tokens`, silently capping every
+/// engineer turn at the agent-loop default (formerly a hard-coded 1024) and
+/// truncating real file writes. `resolve_max_tokens` must now flow the
+/// configured cap into the loop that actually drives the engineer.
+/// What: Engineer config sets `[llm].max_tokens = 8192`. Script a single stop
+/// turn; assert the `ScriptedLlm` observed `Some(8192)`.
+/// Test: this test.
+#[tokio::test]
+async fn engineer_llm_max_tokens_reaches_chat_request() {
+    let body = r#"
+[agent]
+name = "python-engineer"
+model = "deepseek/deepseek-chat"
+
+[llm]
+max_tokens = 8192
+
+[system_prompt]
+content = "You are a Python engineer."
+"#;
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("engineer done")]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec!["work_tool"], Arc::clone(&invoked)));
+
+    let runner = Arc::new(InProcessAgentRunner::new(
+        llm.clone(),
+        factory,
+        tmp.path().to_path_buf(),
+    ));
+
+    let delegate = DelegateToAgentTool::new(runner).with_config_dir(tmp.path().to_path_buf());
+    let result = delegate
+        .execute(json!({"agent_name": "python-engineer", "task": "write a function"}))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "delegation should succeed: {}",
+        result.content()
+    );
+    assert_eq!(
+        llm.first_max_tokens(),
+        Some(8192),
+        "the engineer's configured [llm].max_tokens must reach its ChatRequest"
     );
 }
 

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -44,7 +44,7 @@ use crate::llm::LlmClientTrait;
 use crate::mode::HarnessMode;
 use crate::project_context::load_project_context;
 use crate::prompt::assemble_system_prompt_for_mode;
-use crate::provider::resolve_model;
+use crate::provider::{resolve_max_tokens, resolve_model};
 use crate::run_task::{
     RecordingLlmClient, SharedTranscript, aggregate_usage_per_role, resolve_agent_model_slug,
 };
@@ -206,6 +206,7 @@ async fn run_and_record(
     let pm_loop = AgentLoop::new(
         AgentLoopConfig {
             model: pm_model.clone(),
+            max_tokens: resolve_max_tokens(&pm_config),
             mode: params.mode,
             ..AgentLoopConfig::default()
         },


### PR DESCRIPTION
`run_task` (and the daemon task path) hardcoded `max_tokens: Some(1024)` in `AgentLoop::build_request` and never plumbed the agent config's `[llm].max_tokens`, so every turn's completion truncated at 1024 tokens — breaking any real task that writes a non-tiny file. Surfaced by the M3 bake-off L1 pilot (tcode scored 1/10 purely from truncated writes).

Fix: add `AgentLoopConfig.max_tokens` (default `DEFAULT_MAX_TOKENS = 8192`); `build_request` now sends `Some(self.config.max_tokens)`; new `provider::routing::resolve_max_tokens(agent_config)` (mirrors `resolve_model`) wired into all three loop-construction sites — PM CLI (`run_task/mod.rs`), PM daemon (`task/executor.rs`), and the delegated engineer loop (`runner/in_process.rs`).

QA: APPROVE (independent worktree at f7fe1dce) — build 0 warnings, 614 lib + 18 e2e tests pass, clippy/fmt clean, line-cap 0 violations, trusty-agents unaffected. 1024 hardcode eliminated on all three paths; three e2e regression tests assert the configured 8192 reaches the outgoing ChatRequest (with an explicit assert_ne! against 1024); no new library unwrap().

Closes #2198