### PR TITLE
chore: release workspace crates 2026-07-07

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10652,7 +10652,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10715,7 +10715,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-bm25-daemon"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -10756,7 +10756,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10829,7 +10829,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-console"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -10868,7 +10868,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-embedderd"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -10905,7 +10905,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -10930,7 +10930,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10970,7 +10970,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11091,7 +11091,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,21 +28,21 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # publish=false; version 0.0.0 intentionally — pre-release scaffold.
 trusty-code = { path = "crates/trusty-code" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.2.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.21.0" }
+trusty-common = { path = "crates/trusty-common", version = "0.22.0" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
-trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.4" }
+trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.5" }
 # trusty-bm25-daemon: per-palace BM25 lexical-index daemon — referenced by
 # trusty-memory so `cargo install trusty-memory` produces both binaries from
 # one command (mirrors the trusty-embedderd / trusty-search pattern, PR #190).
-trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.1.2" }
+trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.1.3" }
 # tga: trusty-git-analytics — developer productivity analytics.
 # Referenced by trusty-review for contributor-profile data pipeline (#558).
 tga = { path = "crates/trusty-git-analytics", version = "2.8.2" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.
-trusty-mpm = { path = "crates/trusty-mpm", version = "0.15.0" }
+trusty-mpm = { path = "crates/trusty-mpm", version = "0.17.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
@@ -52,7 +52,7 @@ trusty-review = { path = "crates/trusty-review", version = "0.6.1" }
 # (de-bundled from the host crates for single-owner-per-binary). It is still a
 # published library crate; the path entry remains so any local lib consumers
 # resolve in-tree.
-trusty-console = { path = "crates/trusty-console", version = "0.3.1" }
+trusty-console = { path = "crates/trusty-console", version = "0.4.0" }
 # trusty-progress: shared rustup/cargo-style progress + status display (#1315).
 # Consumed by trusty-installer for install/upgrade component rows; published library crate.
 trusty-progress = { path = "crates/trusty-progress", version = "0.1.0" }

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -48,8 +48,8 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      `default-features = false` drops the `axum-server` feature so we don't
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
-trusty-memory = { path = "../trusty-memory", version = "0.18.1", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.31.0" }
+trusty-memory = { path = "../trusty-memory", version = "0.18.3", default-features = false }
+trusty-search = { path = "../trusty-search", version = "0.32.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.7.2"
+version     = "0.7.3"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true

--- a/crates/trusty-bm25-daemon/Cargo.toml
+++ b/crates/trusty-bm25-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-bm25-daemon"
-version = "0.1.2"
+version = "0.1.3"
 publish = true
 edition = "2021"
 rust-version = "1.91"

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-console"
-version     = "0.3.1"
+version     = "0.4.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-embedderd"
-version = "0.3.4"
+version = "0.3.5"
 publish = true
 edition = "2021"
 license.workspace = true

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -14,7 +14,7 @@ name = "gworkspace-mcp"
 path = "src/bin/gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.21.0", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.22.0", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-installer"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.18.2"
+version = "0.18.3"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true
@@ -80,7 +80,7 @@ path = "src/bin/mcp_bridge.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.21.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics"] }
+trusty-common = { path = "../trusty-common", version = "0.22.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside
@@ -163,7 +163,7 @@ serial_test = { workspace = true }
 # which is gated behind `embedder-test-support`. Re-declaring trusty-common here
 # with the feature activates it for all integration tests without enabling it in
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
-trusty-common = { path = "../trusty-common", version = "0.21.0", default-features = false, features = ["memory-core", "embedder-test-support"] }
+trusty-common = { path = "../trusty-common", version = "0.22.0", default-features = false, features = ["memory-core", "embedder-test-support"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.16.2"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -54,7 +54,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.21.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
+trusty-common = { version = "0.22.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics"] }  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
 
 # ── Bundled sidecars ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue


### PR DESCRIPTION
Version bumps for the 10-crate crates.io release.

Crates published to crates.io:
- trusty-common 0.22.0
- trusty-embedderd 0.3.5
- trusty-bm25-daemon 0.1.3
- trusty-installer 0.4.0
- trusty-analyze 0.7.3
- trusty-search 0.32.0
- trusty-memory 0.18.3
- trusty-console 0.4.0
- trusty-mpm 0.17.0
- trusty-progress 0.1.0 (pre-published)