### PR TITLE
fix(trusty-code): configurable run-task deadline + usage/cost on failure paths (closes #2207, #2206)

### DIFF
--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -770,6 +770,103 @@ async fn turn_cap_returns_partial_transcript() {
     assert_eq!(llm.calls(), 2, "loop must stop calling at the cap");
 }
 
+/// The wall-clock timeout aborts the loop with a partial transcript (#2207).
+///
+/// Why: #2207 raised the default `timeout_secs` and made it configurable, but
+/// the underlying mechanism — `AgentLoop::run` wrapping the whole loop body in
+/// `tokio::time::timeout` — is otherwise unchanged; this pins that it still
+/// fires, returns `AgentLoopError::Timeout` (not `TurnCapExceeded` or a
+/// transport error), carries the configured `timeout_secs`, and preserves
+/// whatever usage accrued before the deadline.
+/// What: Configure a tiny `timeout_secs: 1`; the scripted client sleeps 3s
+/// before responding. Assert the run errors with `Timeout { timeout_secs: 1,
+/// .. }` well before the full 3s delay would have elapsed.
+/// Test: this test.
+#[tokio::test]
+async fn timeout_returns_partial() {
+    struct SleepyLlm {
+        inner: ScriptedLlm,
+        delay: std::time::Duration,
+    }
+
+    #[async_trait]
+    impl LlmClientTrait for SleepyLlm {
+        async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+            tokio::time::sleep(self.delay).await;
+            self.inner.chat(req).await
+        }
+    }
+
+    let llm: Arc<dyn LlmClientTrait> = Arc::new(SleepyLlm {
+        inner: ScriptedLlm::from_json(&[stop_response("too slow")]),
+        delay: std::time::Duration::from_secs(3),
+    });
+    let registry = registry_with_echo(false);
+    let config = AgentLoopConfig {
+        timeout_secs: 1,
+        ..AgentLoopConfig::default()
+    };
+    let agent = AgentLoop::new(config, llm, registry);
+
+    let started = std::time::Instant::now();
+    let err = agent
+        .run("system", "a task that takes too long")
+        .await
+        .expect_err("a 1s deadline against a 3s-delayed response must time out");
+    let elapsed = started.elapsed();
+
+    match err {
+        AgentLoopError::Timeout {
+            timeout_secs,
+            partial,
+        } => {
+            assert_eq!(timeout_secs, 1, "must report the configured deadline");
+            // No turn completed before the deadline (the single chat call
+            // never returned), so usage is legitimately still zero here —
+            // the assertion is on the ERROR VARIANT and its `timeout_secs`,
+            // not on partial usage (that is covered end-to-end by
+            // `run_task::tests::exit_code_reflects_deadline_exceeded_distinct_from_run_failure`,
+            // where an earlier turn DOES complete before the deadline).
+            let _ = partial;
+        }
+        other => panic!("expected Timeout, got {other:?}"),
+    }
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "the 1s deadline must fire well before the mock's 3s delay, elapsed={elapsed:?}"
+    );
+}
+
+/// A generous timeout does NOT prematurely abort a loop that finishes well
+/// within budget (#2207).
+///
+/// Why: The companion regression guard to `timeout_returns_partial` — a
+/// caller raising the deadline (e.g. for the M3 bake-off's L2/L3 multi-hour
+/// tasks) must not have their run cut short by an unrelated bug in the
+/// timeout wiring.
+/// What: Configure a 5s timeout against a normal, instantly-responding
+/// two-turn script; assert the run completes successfully.
+/// Test: this test.
+#[tokio::test]
+async fn generous_timeout_does_not_abort_a_fast_run() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("call_1", "world"),
+        stop_response("done well within budget"),
+    ]));
+    let registry = registry_with_echo(false);
+    let config = AgentLoopConfig {
+        timeout_secs: 5,
+        ..AgentLoopConfig::default()
+    };
+    let agent = make_loop(llm, registry, config);
+
+    let output = agent
+        .run("system", "quick task")
+        .await
+        .expect("a fast run under a generous deadline must not be aborted");
+    assert_eq!(output.content, "done well within budget");
+}
+
 /// A recoverable tool error does not abort the loop; iteration continues.
 ///
 /// Why: Tool failures are usually recoverable — the model should see the error

--- a/crates/trusty-code/src/cli/run_task.rs
+++ b/crates/trusty-code/src/cli/run_task.rs
@@ -45,11 +45,15 @@ use super::tcode_exe;
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 /// `tcode run-task <AGENT> <TASK> [--project P] [--json] [--engineer-model M]
-/// [--mode daily-driver|parity]`.
+/// [--mode daily-driver|parity] [--timeout-seconds N]`.
 ///
 /// Why/What: see module docs. Returns the process exit code the caller
 /// should use (mirrors the legacy path's `ExitCode` contract via
-/// `exit_code_for_status`).
+/// `exit_code_for_status`). `timeout_seconds` (#2207) is passed straight
+/// through as `task.run`'s own `deadline_secs` param — this function does NOT
+/// resolve env/default tiers itself; `task::protocol::task_run` ->
+/// `task::executor` resolve it the same way the legacy path's
+/// `crate::provider::resolve_deadline_secs` does.
 pub async fn run(
     project: &Path,
     agent: &str,
@@ -57,6 +61,7 @@ pub async fn run(
     json_output: bool,
     engineer_model: Option<String>,
     mode: Option<String>,
+    timeout_seconds: Option<u64>,
 ) -> Result<i32> {
     let exe = tcode_exe::resolve()?;
     let mut client = StdioRpcClient::spawn(&exe, project)?;
@@ -66,6 +71,7 @@ pub async fn run(
         "agent_name": agent,
         "model_override": engineer_model,
         "mode": mode,
+        "deadline_secs": timeout_seconds,
     });
     let run_result = client.call("task.run", run_params).await?;
     let session_id = run_result

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -143,14 +143,18 @@ pub fn render_transcript_human(record: &TranscriptRecord) -> String {
 /// Why: `run-task` via the thin client and the legacy in-process
 /// `run-task` must agree on what a script checking `$?` sees.
 /// What: `Finished` -> `ExitCode::Success`; `Cancelled`/`Failed` ->
-/// `ExitCode::RunFailure`; `Created`/`Running` (should never be passed here
-/// — the caller only calls this once a run has reached a terminal status)
-/// also map to `RunFailure` defensively rather than panicking.
+/// `ExitCode::RunFailure`; `DeadlineExceeded` (#2207) -> its own distinct
+/// `ExitCode::DeadlineExceeded`, so a script can tell "timed out" from
+/// "errored" the same way the legacy path's `RunReport::exit` does;
+/// `Created`/`Running` (should never be passed here — the caller only calls
+/// this once a run has reached a terminal status) also map to `RunFailure`
+/// defensively rather than panicking.
 /// Test: `tests::exit_code_for_status_maps_terminal_states`.
 pub fn exit_code_for_status(status: SessionStatus) -> ExitCode {
     match status {
         SessionStatus::Finished => ExitCode::Success,
         SessionStatus::Cancelled | SessionStatus::Failed => ExitCode::RunFailure,
+        SessionStatus::DeadlineExceeded => ExitCode::DeadlineExceeded,
         SessionStatus::Created | SessionStatus::Running => ExitCode::RunFailure,
     }
 }
@@ -281,6 +285,10 @@ mod tests {
         assert_eq!(
             exit_code_for_status(SessionStatus::Failed).code(),
             ExitCode::RunFailure.code()
+        );
+        assert_eq!(
+            exit_code_for_status(SessionStatus::DeadlineExceeded).code(),
+            ExitCode::DeadlineExceeded.code()
         );
     }
 }

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -141,6 +141,17 @@ enum Command {
         /// this per the resolution precedence in `crate::mode`'s docs.
         #[arg(long, value_name = "MODE")]
         mode: Option<String>,
+
+        /// Override the run's wall-clock deadline, in seconds (#2207).
+        /// Applies to BOTH the PM's own loop and the delegated engineer's
+        /// loop, in either execution path (`--legacy-in-process` or the
+        /// default thin-client/daemon path). Falls back to the
+        /// `TCODE_RUN_DEADLINE_SECONDS` env var, then a generous 1800s (30
+        /// minute) default — see `crate::provider::resolve_deadline_secs`'s
+        /// docs for the full precedence. Use a large value (e.g. 7200-10800)
+        /// for multi-hour tasks.
+        #[arg(long, value_name = "SECONDS")]
+        timeout_seconds: Option<u64>,
     },
 
     /// Execute a named MPM workflow end-to-end.
@@ -247,12 +258,30 @@ async fn main() -> Result<()> {
             engineer_model,
             legacy_in_process,
             mode,
+            timeout_seconds,
         } => {
             if legacy_in_process {
-                run_task(&agent, &task, &project, json, engineer_model).await
+                run_task(
+                    &agent,
+                    &task,
+                    &project,
+                    json,
+                    engineer_model,
+                    timeout_seconds,
+                )
+                .await
             } else {
                 let project = canonicalize_project_or_exit(&project, "run-task");
-                match cli::run_task::run(&project, &agent, &task, json, engineer_model, mode).await
+                match cli::run_task::run(
+                    &project,
+                    &agent,
+                    &task,
+                    json,
+                    engineer_model,
+                    mode,
+                    timeout_seconds,
+                )
+                .await
                 {
                     Ok(code) => process::exit(code),
                     Err(e) => {
@@ -442,8 +471,11 @@ fn validate_agent_name(agent_name: &str) -> Result<()> {
 /// What: Validates the agent name and project path (traversal guards), locates the
 /// agents dir, resolves the engineer-model override (CLI flag > `TCODE_ENGINEER_MODEL`
 /// env), builds the real `LlmClient` from `OPENROUTER_API_KEY`, runs
-/// `execute_run_task`, prints the human or JSON report, and exits with the
-/// report's `ExitCode`. A missing API key is a config error (exit 2).
+/// `execute_run_task` (threading `--timeout-seconds` (#2207) through as
+/// `RunTaskParams.deadline_secs` — final flag/env/default resolution happens
+/// inside `execute_run_task` via `resolve_deadline_secs`), prints the human or
+/// JSON report, and exits with the report's `ExitCode`. A missing API key is a
+/// config error (exit 2).
 /// Test: Orchestration (incl. the model swap) is covered by `run_task::tests`; the
 /// wrapper is exercised manually via `tcode run-task pm "<task>" --project <path>`.
 async fn run_task(
@@ -452,6 +484,7 @@ async fn run_task(
     project: &Path,
     json: bool,
     engineer_model_flag: Option<String>,
+    timeout_seconds: Option<u64>,
 ) -> Result<()> {
     if let Err(e) = validate_agent_name(agent_name) {
         eprintln!("tcode run-task: {e}");
@@ -489,6 +522,7 @@ async fn run_task(
         agents_dir = %agents_dir.display(),
         json,
         engineer_model = engineer_model.as_deref().unwrap_or("(agent default)"),
+        timeout_seconds = ?timeout_seconds,
         "tcode run-task: starting"
     );
 
@@ -507,6 +541,7 @@ async fn run_task(
         project: project_root,
         agents_dir,
         engineer_model,
+        deadline_secs: timeout_seconds,
     };
 
     let report = execute_run_task(params, llm).await;

--- a/crates/trusty-code/src/provider/mod.rs
+++ b/crates/trusty-code/src/provider/mod.rs
@@ -8,8 +8,10 @@
 //! What: Re-exports the [`Provider`] trait and [`ToolChoice`] enum, the two
 //! concrete providers ([`OpenRouterProvider`], [`BedrockProvider`]), the
 //! [`provider_for`] factory, the [`resolve_model`] precedence function plus
-//! its [`DEFAULT_MODEL`] constant, and the [`resolve_max_tokens`] precedence
-//! function plus its [`DEFAULT_MAX_TOKENS`] constant.
+//! its [`DEFAULT_MODEL`] constant, the [`resolve_max_tokens`] precedence
+//! function plus its [`DEFAULT_MAX_TOKENS`] constant, and (#2207) the
+//! [`resolve_deadline_secs`] precedence function plus its
+//! [`DEFAULT_RUN_DEADLINE_SECS`] constant and [`RUN_DEADLINE_ENV_VAR`] name.
 //! Test: submodule `tests` in each file; routing/adapter coverage in
 //! `routing.rs` and `adapter.rs`.
 
@@ -22,5 +24,8 @@ mod traits;
 pub use adapter::provider_for;
 pub use bedrock::BedrockProvider;
 pub use openrouter::OpenRouterProvider;
-pub use routing::{DEFAULT_MAX_TOKENS, DEFAULT_MODEL, resolve_max_tokens, resolve_model};
+pub use routing::{
+    DEFAULT_MAX_TOKENS, DEFAULT_MODEL, DEFAULT_RUN_DEADLINE_SECS, RUN_DEADLINE_ENV_VAR,
+    resolve_deadline_secs, resolve_max_tokens, resolve_model,
+};
 pub use traits::{Provider, ToolChoice};

--- a/crates/trusty-code/src/provider/routing.rs
+++ b/crates/trusty-code/src/provider/routing.rs
@@ -32,6 +32,67 @@ pub const DEFAULT_MODEL: &str = "openai/gpt-4o-mini";
 /// Test: `routing::tests::resolve_max_tokens_falls_back_to_default`.
 pub const DEFAULT_MAX_TOKENS: u32 = 8192;
 
+/// Environment variable overriding the `run-task` wall-clock deadline (#2207).
+///
+/// Why: Lets an operator (or the M3 bake-off runner) raise the deadline for a
+/// whole invocation without a CLI flag at every call site — mirrors
+/// `crate::mode::MODE_ENV_VAR`'s "escape hatch" precedent for a small, direct
+/// `std::env` read in production code.
+/// What: Read by [`resolve_deadline_secs`] as the middle precedence tier.
+/// Test: `routing::tests::resolve_deadline_secs_*`.
+pub const RUN_DEADLINE_ENV_VAR: &str = "TCODE_RUN_DEADLINE_SECONDS";
+
+/// Generous default wall-clock deadline for a `run-task` invocation, in
+/// seconds, when neither a CLI override nor [`RUN_DEADLINE_ENV_VAR`] is set.
+///
+/// Why: The AgentLoop's own built-in default (120s, `crate::agent_loop::AgentLoopConfig::default`)
+/// is tuned for a short interactive turn, not a full PM->engineer run-task
+/// invocation — #2207 found that cap cutting off a real, otherwise-successful
+/// task at turn 13 before it reached `finish_task`. 30 minutes is generous
+/// enough for the M3 bake-off's L1 pilot to complete cleanly while L2/L3 (1-3
+/// hour problems) can still raise it further via the flag/env override.
+/// What: The fallback tier of [`resolve_deadline_secs`].
+/// Test: `routing::tests::resolve_deadline_secs_falls_back_to_default`.
+pub const DEFAULT_RUN_DEADLINE_SECS: u64 = 1800;
+
+/// Resolve the wall-clock deadline (in seconds) for a `run-task` invocation.
+///
+/// Why: #2207 — the AgentLoop's built-in 120s timeout is too tight for a real
+/// PM->engineer run-task on anything but a trivial task, cutting off
+/// otherwise-successful runs before they reach `finish_task`. A single
+/// resolver mirrors [`resolve_model`]/[`resolve_max_tokens`]'s precedence-
+/// ladder pattern so every call site (the CLI's legacy in-process path, the
+/// daemon's `task.run`, and the in-process sub-agent runner) agrees.
+/// What: Returns, in priority order, the first of: (1) `cli_override` (the
+/// `run-task --timeout-seconds`/`task.run` `deadline_secs` request param,
+/// threaded in by the caller), (2) [`RUN_DEADLINE_ENV_VAR`] parsed as a `u64`
+/// (an unparseable value is treated as absent, falling through — logged at
+/// `warn` — rather than erroring the whole run), else (3)
+/// [`DEFAULT_RUN_DEADLINE_SECS`].
+/// Test: `routing::tests::resolve_deadline_secs_cli_override_wins`,
+/// `routing::tests::resolve_deadline_secs_env_wins_over_default`,
+/// `routing::tests::resolve_deadline_secs_invalid_env_falls_back_to_default`,
+/// `routing::tests::resolve_deadline_secs_falls_back_to_default`.
+pub fn resolve_deadline_secs(cli_override: Option<u64>) -> u64 {
+    if let Some(secs) = cli_override {
+        return secs;
+    }
+
+    if let Ok(raw) = std::env::var(RUN_DEADLINE_ENV_VAR) {
+        match raw.trim().parse::<u64>() {
+            Ok(secs) => return secs,
+            Err(e) => {
+                tracing::warn!(
+                    "{RUN_DEADLINE_ENV_VAR}={raw:?} is not a valid u64 ({e}); \
+                     falling back to DEFAULT_RUN_DEADLINE_SECS"
+                );
+            }
+        }
+    }
+
+    DEFAULT_RUN_DEADLINE_SECS
+}
+
 /// Resolve the model slug for an invocation.
 ///
 /// Why: Centralises the precedence so per-call overrides, per-agent config, and
@@ -97,6 +158,13 @@ fn non_empty(value: Option<&str>) -> Option<&str> {
         }
     })
 }
+
+/// Serializes every test in this module that sets/reads the process-wide
+/// [`RUN_DEADLINE_ENV_VAR`] — `cargo test` runs tests in parallel within one
+/// binary, and an unguarded `set_var`/`remove_var` pair would race across
+/// tests (mirrors `crate::mode::MODE_ENV_LOCK`'s identical rationale).
+#[cfg(test)]
+pub(crate) static RUN_DEADLINE_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -264,5 +332,83 @@ mod tests {
     fn resolve_max_tokens_falls_back_to_default() {
         let config = AgentConfig::default();
         assert_eq!(resolve_max_tokens(&config), DEFAULT_MAX_TOKENS);
+    }
+
+    // ── #2207: resolve_deadline_secs precedence ─────────────────────────────
+
+    /// Serializes access to [`RUN_DEADLINE_ENV_VAR`] for one test closure,
+    /// restoring the prior (absent) state afterward.
+    async fn with_env_deadline<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _guard = RUN_DEADLINE_ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation; serialized by `RUN_DEADLINE_ENV_LOCK`.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(RUN_DEADLINE_ENV_VAR, v),
+                None => std::env::remove_var(RUN_DEADLINE_ENV_VAR),
+            }
+        }
+        let result = f();
+        unsafe {
+            std::env::remove_var(RUN_DEADLINE_ENV_VAR);
+        }
+        result
+    }
+
+    /// The explicit CLI override wins over both the env var and the default.
+    ///
+    /// Why: `run-task --timeout-seconds` (or `task.run`'s `deadline_secs`
+    /// param) must be the highest-precedence source — an operator setting it
+    /// explicitly for one run must never be silently overridden.
+    /// What: Set the env var to a different value; assert the override wins.
+    /// Test: this test.
+    #[tokio::test]
+    async fn resolve_deadline_secs_cli_override_wins() {
+        with_env_deadline(Some("60"), || {
+            assert_eq!(resolve_deadline_secs(Some(7200)), 7200);
+        })
+        .await;
+    }
+
+    /// The env var wins over the built-in default when no override is given.
+    ///
+    /// Why: `TCODE_RUN_DEADLINE_SECONDS` is the escape-hatch tier for a whole
+    /// invocation without threading a flag through every call site.
+    /// What: No CLI override; env var set; assert the env value is returned.
+    /// Test: this test.
+    #[tokio::test]
+    async fn resolve_deadline_secs_env_wins_over_default() {
+        with_env_deadline(Some("900"), || {
+            assert_eq!(resolve_deadline_secs(None), 900);
+        })
+        .await;
+    }
+
+    /// An unparseable env var falls through to the default rather than
+    /// erroring the whole run.
+    ///
+    /// Why: A misconfigured environment must degrade gracefully, not crash a
+    /// long-running task.
+    /// What: Env var set to a non-numeric string; assert the default wins.
+    /// Test: this test.
+    #[tokio::test]
+    async fn resolve_deadline_secs_invalid_env_falls_back_to_default() {
+        with_env_deadline(Some("not-a-number"), || {
+            assert_eq!(resolve_deadline_secs(None), DEFAULT_RUN_DEADLINE_SECS);
+        })
+        .await;
+    }
+
+    /// Falls back to [`DEFAULT_RUN_DEADLINE_SECS`] when nothing is set.
+    ///
+    /// Why: A run must always resolve to a usable, generous deadline even
+    /// when no override is configured anywhere.
+    /// What: No CLI override, no env var; assert the default.
+    /// Test: this test.
+    #[tokio::test]
+    async fn resolve_deadline_secs_falls_back_to_default() {
+        with_env_deadline(None, || {
+            assert_eq!(resolve_deadline_secs(None), DEFAULT_RUN_DEADLINE_SECS);
+        })
+        .await;
     }
 }

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -32,7 +32,7 @@ use crate::agents::AgentConfig;
 use crate::llm::LlmClientTrait;
 use crate::project_context::load_project_context;
 use crate::prompt::assemble_system_prompt;
-use crate::provider::{resolve_max_tokens, resolve_model};
+use crate::provider::{resolve_deadline_secs, resolve_max_tokens, resolve_model};
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
 use crate::tools::{
     AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, FinishTaskTool,
@@ -74,6 +74,12 @@ pub struct RunTaskParams {
     /// Optional per-run engineer model override (#1035). `None` routes the
     /// engineer via its own config model.
     pub engineer_model: Option<String>,
+    /// Optional per-run wall-clock deadline override, in seconds (#2207).
+    /// `None` falls through to [`crate::provider::resolve_deadline_secs`]'s
+    /// env-var/default tiers — see that function's docs for the full
+    /// precedence. Applied to BOTH the PM's own loop and the delegated
+    /// engineer's loop (`build_engineer_runner`).
+    pub deadline_secs: Option<u64>,
 }
 
 /// Execute a `run-task` end-to-end and return the rendered report.
@@ -108,6 +114,11 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
     // Resolve the PM's own model (no per-call override for the PM).
     let pm_model = resolve_model(&pm_config, None);
 
+    // #2207: resolve the run's wall-clock deadline once, applied to BOTH the
+    // PM's own loop (below) and the delegated engineer's loop
+    // (`build_engineer_runner`, via `with_timeout_secs`).
+    let deadline_secs = resolve_deadline_secs(params.deadline_secs);
+
     // Build the engineer runner, scoped to the project working dir, sharing the
     // transcript (engineer turns are tagged "python-engineer").
     let engineer_runner = build_engineer_runner(
@@ -115,6 +126,7 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
         &params,
         project_context.clone(),
         Arc::clone(&transcript),
+        deadline_secs,
     );
 
     // The PM's tool registry: the delegate tool (the PM orchestrates; the
@@ -150,6 +162,7 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
         AgentLoopConfig {
             model: pm_model.clone(),
             max_tokens: resolve_max_tokens(&pm_config),
+            timeout_secs: deadline_secs,
             ..AgentLoopConfig::default()
         },
         pm_llm,
@@ -187,6 +200,9 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
 /// project context as the PM. This wires a `RegistryFactory` that constructs fs +
 /// bash tools scoped to the project dir plus the project context, then routes the
 /// result through the per-run model-override seam (`apply_engineer_model_override`).
+/// `deadline_secs` (#2207) is the SAME resolved wall-clock budget applied to the
+/// delegating PM's own loop, so a raised deadline covers the whole run, not just
+/// the PM's half of it.
 /// What: Returns an `Arc<dyn AgentRunner>` the `DelegateToAgentTool` dispatches
 /// to. The engineer's own LLM turns are recorded under the "python-engineer" role.
 /// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`.
@@ -195,6 +211,7 @@ fn build_engineer_runner(
     params: &RunTaskParams,
     project_context: Option<String>,
     transcript: SharedTranscript,
+    deadline_secs: u64,
 ) -> Arc<dyn AgentRunner> {
     let engineer_llm: Arc<dyn LlmClientTrait> = Arc::new(RecordingLlmClient::new(
         llm,
@@ -206,7 +223,8 @@ fn build_engineer_runner(
         project: params.project.clone(),
     });
 
-    let mut runner = InProcessAgentRunner::new(engineer_llm, factory, params.agents_dir.clone());
+    let mut runner = InProcessAgentRunner::new(engineer_llm, factory, params.agents_dir.clone())
+        .with_timeout_secs(deadline_secs);
     if let Some(ctx) = project_context {
         runner = runner.with_project_context(ctx);
     }
@@ -393,12 +411,19 @@ fn config_error_report(
 /// Why: Centralises the mapping from (PM loop result, before/after snapshots) to a
 /// `RunReport` with the correct exit code so the success / no-change / failure
 /// branches never drift.
-/// What: On a PM-loop error → `RunFailure` (with whatever transcript accrued). On
-/// success → compute the diff; empty diff → `NoChanges`, else `Success`. Usage and
-/// cost are aggregated from the transcript and priced PER ROLE — `pm_model` for
-/// `"pm"` turns, `engineer_model` for the delegated engineer's — per the #1475
-/// bug 1 fix (`aggregate_usage_per_role`), not blended under one model.
-/// Test: `run_task::tests::*` (success, no-change, and failure paths).
+/// What: On a PM-loop error → `DeadlineExceeded` when the error is specifically
+/// `AgentLoopError::Timeout` (#2207 — distinct from a genuine failure so a
+/// caller can tell "timed out" from "errored"), else `RunFailure` (with
+/// whatever transcript accrued). On success → compute the diff; empty diff →
+/// `NoChanges`, else `Success`. Usage and cost are aggregated from the
+/// transcript and priced PER ROLE — `pm_model` for `"pm"` turns,
+/// `engineer_model` for the delegated engineer's — per the #1475 bug 1 fix
+/// (`aggregate_usage_per_role`), not blended under one model. #2206: this
+/// aggregation now runs on the error path too, so a `run_failure` or
+/// `deadline_exceeded` report still carries the real usage/cost of every turn
+/// that DID complete before the error/deadline, rather than the zeroed
+/// placeholder the pre-#2206 code returned unconditionally on this branch.
+/// Test: `run_task::tests::*` (success, no-change, failure, and deadline paths).
 fn assemble_report(
     params: &RunTaskParams,
     transcript: &SharedTranscript,
@@ -410,18 +435,32 @@ fn assemble_report(
 ) -> RunReport {
     let turns = drain_transcript(transcript);
 
-    // A PM-loop error is a runtime failure; the transcript still reflects whatever
-    // turns ran before the error. The PM's `AgentOutput` content is not needed for
-    // the report — the transcript and diff are the authoritative artifacts.
+    // A PM-loop error is a runtime failure (or, #2207, a deadline); the
+    // transcript still reflects whatever turns ran before the error. The PM's
+    // `AgentOutput` content is not needed for the report — the transcript and
+    // diff are the authoritative artifacts. #2206: usage/cost are aggregated
+    // from those completed turns here too, not zeroed.
     if let Err(e) = pm_result {
+        let (usage, cost) = aggregate_usage_per_role(&turns, pm_model, engineer_model);
+        let is_deadline = matches!(e, crate::agent_loop::AgentLoopError::Timeout { .. });
+        let exit = if is_deadline {
+            ExitCode::DeadlineExceeded
+        } else {
+            ExitCode::RunFailure
+        };
+        let label = if is_deadline {
+            "deadline exceeded"
+        } else {
+            "run failure"
+        };
         return RunReport {
             agent: params.agent.clone(),
-            task: format!("{} [run failure: {e}]", params.task),
+            task: format!("{} [{label}: {e}]", params.task),
             diff: String::new(),
             transcript: turns,
-            usage: crate::perf::TokenUsage::default(),
-            cost_usd: None,
-            exit: ExitCode::RunFailure,
+            usage,
+            cost_usd: Some(cost),
+            exit,
         };
     }
 

--- a/crates/trusty-code/src/run_task/report.rs
+++ b/crates/trusty-code/src/run_task/report.rs
@@ -22,7 +22,12 @@ use crate::run_task::recorder::TurnRecord;
 /// Why: A caller (CI, the PM smoke-test, a wrapper script) needs to distinguish
 /// outcomes without parsing output. The ladder separates a clean success, a
 /// successful run that changed nothing, a configuration error (bad agent, bad
-/// project), and a runtime failure (the loop or LLM errored).
+/// project), a runtime failure (the loop or LLM errored), and (#2207) the
+/// wall-clock deadline firing before the PM reached `finish_task` — a run that
+/// may have made real, useful progress and must not be conflated with a
+/// genuine `RunFailure` (the bug that blocked the M3 bake-off L1 pilot: a
+/// deadline hit at turn 13 on an otherwise fully-passing solution reported the
+/// same `run_failure` a real crash would).
 /// What: `repr(i32)` so the values are stable and documented; `Success = 0`.
 /// Test: `run_task::tests::exit_codes_are_distinct`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -32,10 +37,16 @@ pub enum ExitCode {
     Success = 0,
     /// Configuration error: missing/invalid agent, bad project path, missing key. `2`.
     ConfigError = 2,
-    /// Runtime failure: the agent loop or LLM call errored. `3`.
+    /// Runtime failure: the agent loop or LLM call errored (excludes the
+    /// deadline — see `DeadlineExceeded`). `3`.
     RunFailure = 3,
     /// The run completed but changed nothing (empty diff). `4`.
     NoChanges = 4,
+    /// The configured wall-clock deadline elapsed before the PM loop reached
+    /// a terminal state (#2207). Distinct from `RunFailure` so a caller (e.g.
+    /// the M3 bake-off runner) can tell "timed out, possibly close to done"
+    /// from "genuinely errored". `5`.
+    DeadlineExceeded = 5,
 }
 
 impl ExitCode {
@@ -172,15 +183,17 @@ impl RunReport {
     /// Map the exit outcome to a stable status string.
     ///
     /// Why: Both output forms label the outcome with the same vocabulary.
-    /// What: Returns `"success"`, `"no_changes"`, `"config_error"`, or
-    /// `"run_failure"`.
-    /// Test: `run_task::tests::report_renders_json`.
+    /// What: Returns `"success"`, `"no_changes"`, `"config_error"`,
+    /// `"run_failure"`, or (#2207) `"deadline_exceeded"`.
+    /// Test: `run_task::tests::report_renders_json`,
+    /// `run_task::tests::exit_code_reflects_deadline_exceeded_distinct_from_run_failure`.
     fn status_str(&self) -> &'static str {
         match self.exit {
             ExitCode::Success => "success",
             ExitCode::NoChanges => "no_changes",
             ExitCode::ConfigError => "config_error",
             ExitCode::RunFailure => "run_failure",
+            ExitCode::DeadlineExceeded => "deadline_exceeded",
         }
     }
 }
@@ -267,7 +280,7 @@ mod tests {
     /// Exit codes are distinct and stable.
     ///
     /// Why: Scripts branch on these; collisions would be silent breakage.
-    /// What: Assert the four codes are 0/2/3/4 and pairwise distinct.
+    /// What: Assert the five codes are 0/2/3/4/5 and pairwise distinct.
     /// Test: this test.
     #[test]
     fn exit_codes_are_distinct() {
@@ -275,6 +288,7 @@ mod tests {
         assert_eq!(ExitCode::ConfigError.code(), 2);
         assert_eq!(ExitCode::RunFailure.code(), 3);
         assert_eq!(ExitCode::NoChanges.code(), 4);
+        assert_eq!(ExitCode::DeadlineExceeded.code(), 5);
     }
 
     /// JSON render carries status, diff, transcript, usage, and cost.

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -206,6 +206,7 @@ fn params(agents: &TempDir, project: &TempDir, engineer_model: Option<&str>) -> 
         project: project.path().to_path_buf(),
         agents_dir: agents.path().to_path_buf(),
         engineer_model: engineer_model.map(str::to_string),
+        deadline_secs: None,
     }
 }
 
@@ -429,6 +430,7 @@ async fn missing_pm_config_is_config_error() {
             project: project.path().to_path_buf(),
             agents_dir: empty_agents.path().to_path_buf(),
             engineer_model: None,
+            deadline_secs: None,
         },
         llm,
     )
@@ -465,6 +467,159 @@ async fn exit_code_reflects_run_failure() {
         report.exit,
         ExitCode::RunFailure,
         "an LLM/loop error must map to RunFailure"
+    );
+}
+
+// ── #2207/#2206: configurable deadline + distinct status + telemetry ───────────
+
+/// A response in which the assistant calls `finish_task` with a required
+/// field (`summary`) missing — recoverable per #2072's schema-validation
+/// path, NOT terminal.
+fn malformed_finish_task_response() -> Value {
+    json!({
+        "id": "gen-finish-malformed",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-missing",
+                    "type": "function",
+                    "function": {
+                        "name": "finish_task",
+                        "arguments": json!({"status": "completed"}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 40, "completion_tokens": 10, "total_tokens": 50}
+    })
+}
+
+/// An `LlmClientTrait` that sleeps before its Nth `chat` call, then delegates.
+///
+/// Why: Deterministically drives the PM's own wall-clock deadline past its
+/// configured budget — the FIRST call (index 0) completes instantly and is
+/// recorded with real usage before the deadline fires, then a later call
+/// sleeps well past the remaining budget, so `AgentLoop::run`'s outer
+/// `tokio::time::timeout` aborts mid-flight rather than the loop reaching a
+/// clean or genuinely failed terminal state.
+/// What: Wraps a `ScriptedLlm`; sleeps `stall_for` on the call whose index
+/// equals `stall_at_call`, then delegates to the inner scripted client.
+/// Test: `exit_code_reflects_deadline_exceeded_distinct_from_run_failure`.
+struct DeadlineTriggerLlm {
+    inner: ScriptedLlm,
+    counter: AtomicUsize,
+    stall_at_call: usize,
+    stall_for: std::time::Duration,
+}
+
+#[async_trait]
+impl LlmClientTrait for DeadlineTriggerLlm {
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let idx = self.counter.fetch_add(1, Ordering::SeqCst);
+        if idx == self.stall_at_call {
+            tokio::time::sleep(self.stall_for).await;
+        }
+        self.inner.chat(req).await
+    }
+}
+
+/// A tiny configured deadline yields `DeadlineExceeded` — distinct from
+/// `RunFailure` — AND the report still carries non-zero usage/cost from the
+/// turn(s) that DID complete before the deadline fired (#2207 + #2206).
+///
+/// Why: This is the exact scenario #2207 found blocking the M3 bake-off: a
+/// real, otherwise-productive run cut off mid-flight must be distinguishable
+/// from a genuine crash, and its accrued cost/usage must not be silently
+/// zeroed (#2206) — the bake-off runner needs real telemetry on EVERY
+/// terminal path, not just the clean one.
+/// What: `deadline_secs: Some(1)`. The scenario stays entirely within the
+/// PM's OWN loop (no delegation) to avoid a race against the delegated
+/// engineer's own independently-resolved deadline: turn 0 is a malformed
+/// `finish_task` call (instant, recoverable, recorded with real usage), then
+/// turn 1 sleeps 3s — well past the 1s budget — so the PM's own outer
+/// `tokio::time::timeout` fires before that second turn ever completes.
+/// Assert `exit == DeadlineExceeded` (not `RunFailure`) and `usage`/`cost_usd`
+/// are non-zero/`Some`.
+/// Test: this test.
+#[tokio::test]
+async fn exit_code_reflects_deadline_exceeded_distinct_from_run_failure() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(DeadlineTriggerLlm {
+        inner: ScriptedLlm::from_json(&[
+            malformed_finish_task_response(),
+            stop_response("recovered (never reached in time)"),
+        ]),
+        counter: AtomicUsize::new(0),
+        stall_at_call: 1,
+        stall_for: std::time::Duration::from_secs(3),
+    });
+
+    let mut task_params = params(&agents, &project, None);
+    task_params.deadline_secs = Some(1);
+
+    let started = std::time::Instant::now();
+    let report = execute_run_task(task_params, llm).await;
+    let elapsed = started.elapsed();
+
+    assert_eq!(
+        report.exit,
+        ExitCode::DeadlineExceeded,
+        "a deadline hit must map to DeadlineExceeded, not RunFailure"
+    );
+    assert!(
+        report.usage.prompt_tokens > 0,
+        "the PM's completed first turn must still contribute real usage, got {:?}",
+        report.usage
+    );
+    assert!(
+        report.cost_usd.is_some(),
+        "cost must be populated (not None) on the deadline-exceeded path"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "the 1s deadline must fire well before the mock's 3s delay, elapsed={elapsed:?}"
+    );
+
+    let rendered = report.render_json();
+    let parsed: Value = serde_json::from_str(&rendered).expect("report JSON must parse");
+    assert_eq!(parsed["status"], "deadline_exceeded");
+}
+
+/// A generous configured deadline does NOT prematurely kill a normal run
+/// (#2207).
+///
+/// Why: The companion regression guard — raising the deadline (e.g. for the
+/// M3 bake-off's L2/L3 multi-hour tasks) must not itself break a run that
+/// would otherwise complete quickly.
+/// What: `deadline_secs: Some(5)` against the standard instant PM->engineer
+/// happy path; assert `exit == Success`.
+/// Test: this test.
+#[tokio::test]
+async fn generous_deadline_does_not_abort_a_normal_run() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        delegate_response("create j.py"),
+        write_file_response("j.py", "y=2"),
+        stop_response("engineer done"),
+        stop_response("pm done"),
+    ]));
+
+    let mut task_params = params(&agents, &project, None);
+    task_params.deadline_secs = Some(5);
+
+    let report = execute_run_task(task_params, llm).await;
+
+    assert_eq!(
+        report.exit,
+        ExitCode::Success,
+        "a generous deadline must not abort a run that finishes well within budget"
     );
 }
 

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -261,6 +261,23 @@ impl InProcessAgentRunner {
         self
     }
 
+    /// Override only the wall-clock timeout of the default loop budget (#2207).
+    ///
+    /// Why: `run_task`/`task::executor` resolve a single run-wide deadline
+    /// (`crate::provider::resolve_deadline_secs`) that must apply to the
+    /// delegated engineer's loop as well as the delegating PM's own — but
+    /// they have no reason to touch `max_turns`. A dedicated setter avoids
+    /// forcing every call site to reconstruct a whole `InProcessRunnerConfig`
+    /// (and risk silently resetting `max_turns` to its default) just to
+    /// change one field.
+    /// What: Builder-style setter; returns `self` for chaining. Leaves
+    /// `self.config.max_turns` untouched.
+    /// Test: `runner::tests::with_timeout_secs_overrides_only_timeout`.
+    pub fn with_timeout_secs(mut self, timeout_secs: u64) -> Self {
+        self.config.timeout_secs = timeout_secs;
+        self
+    }
+
     /// Load the agent config for `agent_name` from the config directory.
     ///
     /// Why: Each delegation targets a named agent; its model, prompt, and

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -122,6 +122,27 @@ impl LlmClientTrait for ScriptedLlm {
     }
 }
 
+/// An `LlmClientTrait` that sleeps before every `chat` call, then delegates.
+///
+/// Why: #2207's `with_timeout_secs` override must actually shorten the loop's
+/// wall-clock budget; the only deterministic, offline way to prove that is a
+/// mock whose response arrives later than a short configured deadline.
+/// What: Wraps a `ScriptedLlm`; `chat` sleeps `delay` before returning
+/// whatever the inner scripted client would have returned.
+/// Test: `runner::tests::with_timeout_secs_shortens_the_deadline`.
+struct SleepyLlm {
+    inner: ScriptedLlm,
+    delay: std::time::Duration,
+}
+
+#[async_trait]
+impl LlmClientTrait for SleepyLlm {
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        tokio::time::sleep(self.delay).await;
+        self.inner.chat(req).await
+    }
+}
+
 /// A tool whose invocations are recorded, used to prove gating.
 ///
 /// Why: To assert `tools.allowed` enforcement we need a tool that records
@@ -604,6 +625,96 @@ async fn run_context_overrides_max_turns() {
         llm.calls(),
         1,
         "loop must stop after the single allowed turn"
+    );
+}
+
+/// `with_timeout_secs` actually shortens the loop's wall-clock deadline
+/// (#2207).
+///
+/// Why: This is the direct regression guard for `run_task`/`task::executor`
+/// threading a resolved run-wide deadline onto the delegated engineer's
+/// runner — if `with_timeout_secs` were a no-op, a raised or lowered deadline
+/// on the PM side would never actually reach the engineer's own loop.
+/// What: A response that would otherwise arrive instantly is delayed 3s by
+/// `SleepyLlm`; the runner's timeout is overridden down to 1s. Assert the run
+/// errors with the `Timeout` variant's message (not `TurnCapExceeded` or a
+/// transport error) and that it does so well before the full 3s delay would
+/// have elapsed.
+/// Test: this test.
+#[tokio::test]
+async fn with_timeout_secs_shortens_the_deadline() {
+    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    let llm = Arc::new(SleepyLlm {
+        inner: ScriptedLlm::from_json(&[stop_response("done")]),
+        delay: std::time::Duration::from_secs(3),
+    });
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec![], invoked));
+    let runner =
+        InProcessAgentRunner::new(llm, factory, tmp.path().to_path_buf()).with_timeout_secs(1);
+
+    let started = std::time::Instant::now();
+    let err = runner
+        .run("python-engineer", "task")
+        .await
+        .expect_err("a 1s deadline against a 3s-delayed response must time out");
+    let elapsed = started.elapsed();
+
+    assert!(
+        err.to_string().contains("wall-clock timeout of 1s"),
+        "error must be the Timeout variant, got: {err}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "the 1s override must fire well before the mock's 3s delay, elapsed={elapsed:?}"
+    );
+}
+
+/// `with_timeout_secs` changes ONLY the timeout, leaving a previously
+/// configured `max_turns` untouched (#2207).
+///
+/// Why: `with_timeout_secs` is a targeted setter specifically so callers
+/// don't have to reconstruct a whole `InProcessRunnerConfig` (risking a
+/// silent `max_turns` reset to its default) just to change the deadline.
+/// What: Configure `max_turns: 2` via `with_config`, then call
+/// `with_timeout_secs` with a generous value; script tool calls that never
+/// converge. Assert the run still aborts via `TurnCapExceeded` at exactly 2
+/// calls, proving `max_turns` survived the later `with_timeout_secs` call.
+/// Test: this test.
+#[tokio::test]
+async fn with_timeout_secs_preserves_configured_max_turns() {
+    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let tmp = agents_dir_with(body, "python-engineer");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("c1", "any_tool"),
+        tool_call_response("c2", "any_tool"),
+        tool_call_response("c3", "any_tool"),
+    ]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(vec!["any_tool"], invoked));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf())
+        .with_config(InProcessRunnerConfig {
+            max_turns: 2,
+            timeout_secs: 30,
+        })
+        .with_timeout_secs(300);
+
+    let err = runner
+        .run("python-engineer", "task")
+        .await
+        .expect_err("a 2-turn cap on a non-converging loop must abort");
+
+    assert!(
+        err.to_string().contains("turn cap of 2"),
+        "max_turns=2 from with_config must survive the later with_timeout_secs call, got: {err}"
+    );
+    assert_eq!(
+        llm.calls(),
+        2,
+        "loop must stop after the configured 2 turns"
     );
 }
 

--- a/crates/trusty-code/src/session/model.rs
+++ b/crates/trusty-code/src/session/model.rs
@@ -24,9 +24,14 @@ use serde::{Deserialize, Serialize};
 /// naming).
 /// What: `Created` -> `Running` happens immediately on `session.create` in
 /// M1 (there is no queue to sit in ahead of real task execution, which
-/// lands with `task.*` in #2056). `Cancelled`/`Finished`/`Failed` are the
-/// three terminal states; `session.cancel` is the only one #2054 can drive
-/// today (`Finished`/`Failed` are set by the future task-execution wiring).
+/// lands with `task.*` in #2056). `Cancelled`/`Finished`/`Failed`/
+/// `DeadlineExceeded` are the four terminal states; `session.cancel` is the
+/// only one #2054 can drive directly (`Finished`/`Failed`/`DeadlineExceeded`
+/// are set by `task::executor::run_and_record` when the PM's `AgentLoop`
+/// resolves). `DeadlineExceeded` (#2207) is distinct from `Failed`: it means
+/// the run's configured wall-clock budget elapsed before the PM reached a
+/// terminal state, NOT that the loop or LLM call errored — a run that hit
+/// this status may have made real, useful progress.
 /// Test: `model::tests::session_status_serialises_snake_case`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -36,6 +41,7 @@ pub enum SessionStatus {
     Cancelled,
     Finished,
     Failed,
+    DeadlineExceeded,
 }
 
 impl SessionStatus {
@@ -54,6 +60,7 @@ impl SessionStatus {
             SessionStatus::Cancelled => "cancelled",
             SessionStatus::Finished => "finished",
             SessionStatus::Failed => "failed",
+            SessionStatus::DeadlineExceeded => "deadline_exceeded",
         }
     }
 
@@ -63,12 +70,16 @@ impl SessionStatus {
     /// Why: `session.cancel` and any future completion handler need to
     /// reject transitions out of a terminal state (e.g. cancelling an
     /// already-finished session is a no-op error, not a silent overwrite).
-    /// What: `true` for `Cancelled`/`Finished`/`Failed`; `false` otherwise.
+    /// What: `true` for `Cancelled`/`Finished`/`Failed`/`DeadlineExceeded`;
+    /// `false` otherwise.
     /// Test: `model::tests::is_terminal_covers_terminal_states`.
     pub fn is_terminal(&self) -> bool {
         matches!(
             self,
-            SessionStatus::Cancelled | SessionStatus::Finished | SessionStatus::Failed
+            SessionStatus::Cancelled
+                | SessionStatus::Finished
+                | SessionStatus::Failed
+                | SessionStatus::DeadlineExceeded
         )
     }
 }
@@ -127,6 +138,10 @@ mod tests {
             serde_json::to_value(SessionStatus::Failed).unwrap(),
             json!("failed")
         );
+        assert_eq!(
+            serde_json::to_value(SessionStatus::DeadlineExceeded).unwrap(),
+            json!("deadline_exceeded")
+        );
     }
 
     /// `as_str` must match the serde wire representation exactly.
@@ -138,6 +153,7 @@ mod tests {
             SessionStatus::Cancelled,
             SessionStatus::Finished,
             SessionStatus::Failed,
+            SessionStatus::DeadlineExceeded,
         ] {
             let via_str = status.as_str();
             let via_serde = serde_json::to_value(status).unwrap();
@@ -145,7 +161,7 @@ mod tests {
         }
     }
 
-    /// Only `Cancelled`/`Finished`/`Failed` are terminal.
+    /// Only `Cancelled`/`Finished`/`Failed`/`DeadlineExceeded` are terminal.
     #[test]
     fn is_terminal_covers_terminal_states() {
         assert!(!SessionStatus::Created.is_terminal());
@@ -153,6 +169,7 @@ mod tests {
         assert!(SessionStatus::Cancelled.is_terminal());
         assert!(SessionStatus::Finished.is_terminal());
         assert!(SessionStatus::Failed.is_terminal());
+        assert!(SessionStatus::DeadlineExceeded.is_terminal());
     }
 
     /// A `Session` must round-trip through JSON with the expected shape.

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -44,7 +44,7 @@ use crate::llm::LlmClientTrait;
 use crate::mode::HarnessMode;
 use crate::project_context::load_project_context;
 use crate::prompt::assemble_system_prompt_for_mode;
-use crate::provider::{resolve_max_tokens, resolve_model};
+use crate::provider::{resolve_deadline_secs, resolve_max_tokens, resolve_model};
 use crate::run_task::{
     RecordingLlmClient, SharedTranscript, aggregate_usage_per_role, resolve_agent_model_slug,
 };
@@ -90,6 +90,11 @@ pub struct TaskRunParams {
     pub agents_dir: PathBuf,
     pub model_override: Option<String>,
     pub mode: HarnessMode,
+    /// Per-run wall-clock deadline override, in seconds (#2207). `None`
+    /// falls through to `crate::provider::resolve_deadline_secs`'s env-var
+    /// and default tiers — resolved once in `run_and_record` and applied to
+    /// BOTH the PM's own loop and the delegated engineer's loop.
+    pub deadline_secs: Option<u64>,
 }
 
 /// Reserve the session's execution slot and spawn the background run.
@@ -161,6 +166,11 @@ async fn run_and_record(
     let pm_model = resolve_model(&pm_config, None);
     let engineer_model = resolve_engineer_model(&params);
 
+    // #2207: resolve the run's wall-clock deadline once, applied to BOTH the
+    // PM's own loop (below) and the delegated engineer's loop
+    // (`build_engineer_runner`, via `with_timeout_secs`).
+    let deadline_secs = resolve_deadline_secs(params.deadline_secs);
+
     // #2069: discover the (cheap, metadata-only) skill catalog and, in
     // DailyDriver mode only, register `use_skill` so the PM can lazily fetch
     // a skill's full body on demand. Parity never sees the catalog or the
@@ -208,6 +218,7 @@ async fn run_and_record(
             model: pm_model.clone(),
             max_tokens: resolve_max_tokens(&pm_config),
             mode: params.mode,
+            timeout_secs: deadline_secs,
             ..AgentLoopConfig::default()
         },
         pm_llm,
@@ -218,13 +229,24 @@ async fn run_and_record(
 
     let result = pm_loop.run(&pm_system, &params.task).await;
 
+    // #2206: usage/cost are aggregated from every turn that DID complete
+    // regardless of `result` — this call already ran unconditionally before
+    // the terminal-status match below, so a `Failed`/`DeadlineExceeded`
+    // outcome still persists real telemetry, not zeroed placeholders.
     let turns = transcript.lock().map(|g| g.clone()).unwrap_or_default();
     let (usage, cost) = aggregate_usage_per_role(&turns, &pm_model, &engineer_model);
     registry.set_run_outcome(&session_id, turns, usage, Some(cost));
 
+    // #2207: a wall-clock deadline is distinct from a genuine run failure —
+    // `SessionStatus::DeadlineExceeded` lets a `session.status`/`task.run`
+    // consumer tell "timed out, possibly close to done" from "errored".
     let terminal_status = match result {
         Ok(_output) => SessionStatus::Finished,
         Err(crate::agent_loop::AgentLoopError::Cancelled { .. }) => SessionStatus::Cancelled,
+        Err(e @ crate::agent_loop::AgentLoopError::Timeout { .. }) => {
+            let _ = registry.record_log(&session_id, "error", &format!("run failed: {e}"));
+            SessionStatus::DeadlineExceeded
+        }
         Err(e) => {
             let _ = registry.record_log(&session_id, "error", &format!("run failed: {e}"));
             SessionStatus::Failed
@@ -243,7 +265,13 @@ async fn run_and_record(
 /// prompt gets, threaded through so the delegated engineer's DailyDriver
 /// prompt also sees it. Wiring the `use_skill` *tool* into the engineer's own
 /// per-delegation registry (`ProjectToolFactory::build`) is deferred — see
-/// this crate's #2069 delivery notes.
+/// this crate's #2069 delivery notes. #2207: resolves the SAME wall-clock
+/// budget applied to the delegating PM's own loop via
+/// `crate::provider::resolve_deadline_secs(params.deadline_secs)` — called
+/// again here (rather than threaded in as an extra argument) purely to keep
+/// this function's arity under clippy's `too_many_arguments` gate; the
+/// resolver is pure given the same `params.deadline_secs`/env state, so a
+/// second call is not a correctness risk.
 fn build_engineer_runner(
     llm: Arc<dyn LlmClientTrait>,
     params: &TaskRunParams,
@@ -267,7 +295,8 @@ fn build_engineer_runner(
     let mut runner = InProcessAgentRunner::new(engineer_llm, factory, params.agents_dir.clone())
         .with_tool_event_sink(sink)
         .with_cancel_flag(cancel)
-        .with_mode(params.mode);
+        .with_mode(params.mode)
+        .with_timeout_secs(resolve_deadline_secs(params.deadline_secs));
     if let Some(ctx) = project_context {
         runner = runner.with_project_context(ctx);
     }

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -4,12 +4,15 @@
 //! under the 500-SLOC cap.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
+use async_trait::async_trait;
+use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use super::*;
-use crate::llm::LlmClientTrait;
-use crate::session::SessionRegistry;
+use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
+use crate::session::{SessionRegistry, SessionStatus};
 use crate::task::mock_llm::EchoLlmClient;
 
 /// Agents dir fixture with `pm.toml` + `python-engineer.toml` (mirrors
@@ -38,6 +41,7 @@ fn params(agents: &TempDir, project: &TempDir, session_id: &str) -> TaskRunParam
         agents_dir: agents.path().to_path_buf(),
         model_override: None,
         mode: crate::mode::HarnessMode::default(),
+        deadline_secs: None,
     }
 }
 
@@ -99,6 +103,7 @@ fn resolve_engineer_model_falls_back_when_config_missing() {
         agents_dir: empty_agents.path().to_path_buf(),
         model_override: None,
         mode: crate::mode::HarnessMode::default(),
+        deadline_secs: None,
     };
     let model = resolve_engineer_model(&p);
     assert_eq!(model, "unknown");
@@ -201,4 +206,165 @@ async fn project_tool_factory_threads_parity_mode_into_edit_tool() {
     assert!(result.content().contains("unified_diff"));
     let updated = std::fs::read_to_string(project.path().join("f.py")).expect("read");
     assert_eq!(updated, "line1\nline2-diffed\n");
+}
+
+// ── #2207/#2206: daemon-path deadline wiring + distinct status + telemetry ─────
+
+/// A response in which the assistant calls `finish_task` with a required
+/// field (`summary`) missing — recoverable per #2072's schema-validation
+/// path, NOT terminal (mirrors `run_task::tests::malformed_finish_task_response`).
+fn malformed_finish_task_response() -> Value {
+    json!({
+        "id": "gen-finish-malformed",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-missing",
+                    "type": "function",
+                    "function": {
+                        "name": "finish_task",
+                        "arguments": json!({"status": "completed"}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 40, "completion_tokens": 10, "total_tokens": 50}
+    })
+}
+
+/// A response in which the assistant emits final text and stops.
+fn stop_response(text: &str) -> Value {
+    json!({
+        "id": "gen-stop",
+        "choices": [{
+            "message": { "role": "assistant", "content": text, "tool_calls": [] },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 15, "completion_tokens": 5, "total_tokens": 20 }
+    })
+}
+
+/// An `LlmClientTrait` that sleeps before its Nth `chat` call, then replays a
+/// scripted response (mirrors `run_task::tests::DeadlineTriggerLlm`).
+///
+/// Why: deterministically drives the PM's own wall-clock deadline past its
+/// configured budget, entirely within the PM's own loop (no delegation), so
+/// the daemon path's `run_and_record` observes a genuine
+/// `AgentLoopError::Timeout` rather than racing against the delegated
+/// engineer's own independently-resolved deadline.
+struct DeadlineTriggerLlm {
+    responses: Vec<ChatResponse>,
+    cursor: AtomicUsize,
+    stall_at_call: usize,
+    stall_for: std::time::Duration,
+}
+
+impl DeadlineTriggerLlm {
+    fn new(fixtures: &[Value], stall_at_call: usize, stall_for: std::time::Duration) -> Self {
+        let responses = fixtures
+            .iter()
+            .map(|v| serde_json::from_value(v.clone()).expect("valid ChatResponse fixture"))
+            .collect();
+        Self {
+            responses,
+            cursor: AtomicUsize::new(0),
+            stall_at_call,
+            stall_for,
+        }
+    }
+}
+
+#[async_trait]
+impl LlmClientTrait for DeadlineTriggerLlm {
+    async fn chat(&self, _req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
+        if idx == self.stall_at_call {
+            tokio::time::sleep(self.stall_for).await;
+        }
+        match self.responses.get(idx) {
+            Some(resp) => Ok(resp.clone()),
+            None => Err(LlmError::MissingConfig(format!(
+                "scripted LLM exhausted at call {idx}"
+            ))),
+        }
+    }
+}
+
+/// A tiny `deadline_secs` override on the daemon path yields
+/// `SessionStatus::DeadlineExceeded` (distinct from `Failed`), and the
+/// persisted transcript/usage still reflect the turn that completed before
+/// the deadline fired (#2207 + #2206's daemon-path equivalent of
+/// `run_task::tests::exit_code_reflects_deadline_exceeded_distinct_from_run_failure`).
+///
+/// Why: `task::executor::run_and_record` calls `registry.set_run_outcome`
+/// unconditionally before branching on the loop's `result` (#2206 was
+/// already correct here — this test pins that #2207's new
+/// `SessionStatus::DeadlineExceeded` arm doesn't regress it), and the
+/// deadline must actually reach the PM's `AgentLoopConfig` via
+/// `resolve_deadline_secs(params.deadline_secs)`.
+/// What: `deadline_secs: Some(1)`; turn 0 is a malformed `finish_task` call
+/// (instant, recoverable, recorded with real usage), turn 1 sleeps 3s. Assert
+/// the session ends `DeadlineExceeded` (not `Failed`) and its stored usage is
+/// non-zero.
+/// Test: this test.
+#[tokio::test]
+async fn spawn_task_run_deadline_exceeded_is_distinct_and_preserves_usage() {
+    let registry = Arc::new(SessionRegistry::new());
+    let session = registry.create("t".to_string(), None, None);
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm: Arc<dyn LlmClientTrait> = Arc::new(DeadlineTriggerLlm::new(
+        &[
+            malformed_finish_task_response(),
+            stop_response("recovered (never reached in time)"),
+        ],
+        1,
+        std::time::Duration::from_secs(3),
+    ));
+
+    let mut p = params(&agents, &project, &session.id);
+    p.deadline_secs = Some(1);
+
+    spawn_task_run(Arc::clone(&registry), llm, p).expect("run must start");
+
+    // Poll for the run to reach a terminal state naturally (via its own 1s
+    // deadline), WITHOUT `shutdown_executions` — that flips every tracked
+    // execution's cancel flag immediately, which would race the deadline and
+    // spuriously report `Cancelled` instead of `DeadlineExceeded`.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let status = registry.status(&session.id).expect("session must exist");
+        if status.status.is_terminal() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "run did not reach a terminal state within 5s"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    let status = registry.status(&session.id).expect("session must exist");
+    assert_eq!(
+        status.status,
+        SessionStatus::DeadlineExceeded,
+        "a deadline hit must map to DeadlineExceeded, not Failed"
+    );
+
+    let transcript = registry
+        .get_transcript(&session.id)
+        .expect("transcript must exist");
+    assert!(
+        transcript.usage.prompt_tokens > 0,
+        "the completed first turn must still contribute real usage, got {:?}",
+        transcript.usage
+    );
+    assert!(
+        transcript.cost_usd.is_some(),
+        "cost must be populated (not None) on the deadline-exceeded path"
+    );
 }

--- a/crates/trusty-code/src/task/protocol.rs
+++ b/crates/trusty-code/src/task/protocol.rs
@@ -82,10 +82,16 @@ struct TaskRunRequestParams {
     /// to "this source does not contribute", NOT a request error.
     #[serde(default)]
     mode: Option<String>,
+    /// #2207: per-call wall-clock deadline override, in seconds, applied to
+    /// BOTH the PM's own loop and the delegated engineer's loop. `None`
+    /// falls through to `crate::provider::resolve_deadline_secs`'s env-var
+    /// (`TCODE_RUN_DEADLINE_SECONDS`) and default (1800s) tiers.
+    #[serde(default)]
+    deadline_secs: Option<u64>,
 }
 
 /// `task.run(task_description, agent_name?, context?, model_override?,
-/// session_id?, mode?) -> { session_id, status, mode }`.
+/// session_id?, mode?, deadline_secs?) -> { session_id, status, mode }`.
 ///
 /// Why: the single entry point that turns a request into a running
 /// background execution.
@@ -152,6 +158,7 @@ async fn task_run(
         agents_dir,
         model_override: p.model_override,
         mode,
+        deadline_secs: p.deadline_secs,
     };
     spawn_task_run(registry, llm, task_params)?;
 


### PR DESCRIPTION
Two run-task terminal-path fixes surfaced by the M3 bake-off pilot.

**#2207 — configurable deadline + distinct status.** The ~120s wall-clock deadline is now resolved via `provider::resolve_deadline_secs` (precedence: `--timeout-seconds` flag > `TCODE_RUN_DEADLINE_SECONDS` env > `DEFAULT_RUN_DEADLINE_SECS = 1800`), wired into the PM CLI (`run_task/mod.rs`), PM daemon (`task/executor.rs`), and delegated engineer loop (`runner/in_process.rs` `with_timeout_secs`). Hitting the deadline now yields a distinct `deadline_exceeded` status (ExitCode 5 / SessionStatus::DeadlineExceeded) instead of a generic `run_failure`/`Failed`. Unblocks the bake-off L2/L3 (1–3h problems) via `--timeout-seconds 10800`.

**#2206 — telemetry on failure paths.** `run_task::assemble_report`'s error branch now aggregates real usage/cost from completed turns instead of zeroing them, so `run_failure`/`deadline_exceeded` runs still report accurate token/cost telemetry.

QA: APPROVE (independent worktree at bdedd14b) — build 0 warnings, 625 lib + 18 e2e tests pass, clippy/fmt clean, line-cap 0 violations, trusty-agents unaffected. Verified: default 1800 (not 120), generous deadline does NOT abort normal runs, distinct status in both directions, usage/cost non-zero on failure paths, max_turns preserved, #2198 max-tokens fix un-regressed, no new library unwrap().

Closes #2207
Closes #2206