### PR TITLE
feat(trusty-code): prompt caching (cache_control) for the static tools+system prefix (closes #2156)

### DIFF
--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -40,8 +40,8 @@ use std::time::Duration;
 use serde_json::Value;
 
 use crate::llm::{
-    ChatRequest, ChatResponse, LlmClientTrait, ToolCall, ToolCallExtractError, ToolCallExtractor,
-    ToolDefinition,
+    CacheControl, ChatMessage, ChatRequest, ChatResponse, LlmClientTrait, ToolCall,
+    ToolCallExtractError, ToolCallExtractor, ToolDefinition,
 };
 use crate::mode::HarnessMode;
 use crate::perf::PerfCollector;
@@ -431,24 +431,65 @@ impl AgentLoop {
     /// any turn (e.g. a real `write_file`) needing more than 1024 tokens.
     /// What: Clones the transcript messages, attaches tools (when any), and sets
     /// `tool_choice = "auto"` so the model may call tools but isn't forced to.
+    /// (#2156) When [`Self::prompt_cache_enabled`] is `true`, marks the LAST
+    /// tool definition and the system-role message with an ephemeral
+    /// prompt-cache breakpoint — the byte-stable prefix this turn resends
+    /// unchanged from the last. When `false` (Parity mode, or a
+    /// provider/model that hasn't verified the passthrough), the request is
+    /// byte-identical to pre-#2156.
     /// Test: Exercised by every loop test; `config_max_tokens_reaches_chat_request`
-    /// pins that a configured cap flows through unchanged.
+    /// pins that a configured cap flows through unchanged;
+    /// `daily_driver_anthropic_model_marks_cache_breakpoints` and
+    /// `parity_mode_never_marks_cache_breakpoints` cover the #2156 gate.
     fn build_request(&self, transcript: &Transcript, schemas: &[ToolDefinition]) -> ChatRequest {
+        let cache_prefix = self.prompt_cache_enabled();
+
         let tools = if schemas.is_empty() {
             None
         } else {
-            Some(schemas.to_vec())
+            let mut schemas = schemas.to_vec();
+            if cache_prefix {
+                mark_cache_breakpoint_on_tools(&mut schemas);
+            }
+            Some(schemas)
         };
         let tool_choice = tools.as_ref().map(|_| Value::String("auto".to_string()));
 
+        let mut messages = transcript.to_messages();
+        if cache_prefix {
+            mark_cache_breakpoint_on_system(&mut messages);
+        }
+
         ChatRequest {
             model: self.config.model.clone(),
-            messages: transcript.to_messages(),
+            messages,
             temperature: Some(0.0),
             max_tokens: Some(self.config.max_tokens),
             tools,
             tool_choice,
         }
+    }
+
+    /// Whether this run should mark the static tools+system prefix with a
+    /// prompt-cache breakpoint (#2156).
+    ///
+    /// Why: Caching changes cost/latency only, never model output, so it is
+    /// safe in principle under any mode — but per the #2156 spec this stays
+    /// scoped to `HarnessMode::DailyDriver` (mirroring
+    /// `Self::maybe_compact_transcript`'s existing mode gate) rather than
+    /// silently changing Parity's wire payload. It is further gated on the
+    /// resolved `Provider::supports_prompt_caching` so a model/backend whose
+    /// `cache_control` passthrough hasn't been verified never receives the
+    /// marker.
+    /// What: `true` only when `self.config.mode == HarnessMode::DailyDriver`
+    /// AND `crate::provider::provider_for(&self.config.model)
+    /// .supports_prompt_caching()` is `true`.
+    /// Test: `agent_loop::tests::daily_driver_anthropic_model_marks_cache_breakpoints`,
+    /// `agent_loop::tests::parity_mode_never_marks_cache_breakpoints`,
+    /// `agent_loop::tests::non_anthropic_model_never_marks_cache_breakpoints`.
+    fn prompt_cache_enabled(&self) -> bool {
+        self.config.mode == HarnessMode::DailyDriver
+            && crate::provider::provider_for(&self.config.model).supports_prompt_caching()
     }
 
     /// Convert the registry's raw JSON schemas into typed `ToolDefinition`s.
@@ -492,6 +533,39 @@ impl AgentLoop {
                 },
             )
             .collect()
+    }
+}
+
+/// Mark the LAST tool definition with an ephemeral prompt-cache breakpoint
+/// (#2156).
+///
+/// Why: Anthropic caches everything up to and including a `cache_control`
+/// breakpoint as one prefix; tools render first on the wire, so marking only
+/// the last tool caches the entire (byte-stable) tools array as a unit —
+/// matching `block/goose`'s verified OpenRouter provider.
+/// What: No-op on an empty slice; otherwise sets
+/// `schemas.last_mut().function.cache_control = Some(CacheControl::ephemeral())`.
+/// Test: `agent_loop::tests::daily_driver_anthropic_model_marks_cache_breakpoints`.
+fn mark_cache_breakpoint_on_tools(schemas: &mut [ToolDefinition]) {
+    if let Some(last) = schemas.last_mut() {
+        last.function.cache_control = Some(CacheControl::ephemeral());
+    }
+}
+
+/// Mark the system-role message with an ephemeral prompt-cache breakpoint
+/// (#2156).
+///
+/// Why: The system prompt is the second (and, combined with the tools
+/// breakpoint, final) segment of the byte-stable prefix `build_request`
+/// resends every turn; marking it caches tools+system together as OpenRouter
+/// renders tools before the system message on the wire.
+/// What: Finds the first `role == "system"` entry (there is always exactly
+/// one, from `Transcript::seed`) and sets its `cache_control`; no-op if none
+/// is found.
+/// Test: `agent_loop::tests::daily_driver_anthropic_model_marks_cache_breakpoints`.
+fn mark_cache_breakpoint_on_system(messages: &mut [ChatMessage]) {
+    if let Some(system) = messages.iter_mut().find(|m| m.role == "system") {
+        system.cache_control = Some(CacheControl::ephemeral());
     }
 }
 

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -43,6 +43,11 @@ struct ScriptedLlm {
     /// `configured_max_tokens_reaches_chat_request` regression test assert the
     /// configured cap (not the old hard-coded 1024) reached the wire request.
     max_tokens_seen: Mutex<Vec<Option<u32>>>,
+    /// (#2156) Every request's `tools` array, in call order — lets the
+    /// prompt-caching gate tests inspect whether the last tool definition
+    /// carries a `cache_control` breakpoint without reaching into
+    /// `AgentLoop` internals.
+    tools_seen: Mutex<Vec<Option<Vec<crate::llm::ToolDefinition>>>>,
 }
 
 impl ScriptedLlm {
@@ -62,6 +67,7 @@ impl ScriptedLlm {
             cursor: AtomicUsize::new(0),
             requests: Mutex::new(Vec::new()),
             max_tokens_seen: Mutex::new(Vec::new()),
+            tools_seen: Mutex::new(Vec::new()),
         }
     }
 
@@ -97,6 +103,19 @@ impl ScriptedLlm {
     fn max_tokens_seen(&self) -> Vec<Option<u32>> {
         self.max_tokens_seen.lock().expect("lock").clone()
     }
+
+    /// Every request's `tools` array, in call order (#2156).
+    ///
+    /// Why: The prompt-caching gate tests need to see exactly what tool
+    /// schemas (and whether they carry a `cache_control` breakpoint) reached
+    /// the wire on a given turn.
+    /// What: Clones the recorded `tools` values.
+    /// Test: `daily_driver_anthropic_model_marks_cache_breakpoints`,
+    /// `parity_mode_never_marks_cache_breakpoints`,
+    /// `non_anthropic_model_never_marks_cache_breakpoints`.
+    fn tools_seen(&self) -> Vec<Option<Vec<crate::llm::ToolDefinition>>> {
+        self.tools_seen.lock().expect("lock").clone()
+    }
 }
 
 #[async_trait]
@@ -107,6 +126,9 @@ impl LlmClientTrait for ScriptedLlm {
         }
         if let Ok(mut guard) = self.max_tokens_seen.lock() {
             guard.push(req.max_tokens);
+        }
+        if let Ok(mut guard) = self.tools_seen.lock() {
+            guard.push(req.tools.clone());
         }
         let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
         match self.responses.get(idx) {
@@ -1304,5 +1326,158 @@ async fn cancel_flag_aborts_before_next_turn() {
         llm.calls(),
         0,
         "cancellation must be observed before any chat call"
+    );
+}
+
+// ── Prompt-caching gate tests (#2156) ────────────────────────────────────────────
+
+/// A `DailyDriver` run against an `anthropic/*` model marks the static
+/// tools+system prefix with an ephemeral prompt-cache breakpoint.
+///
+/// Why: This is the make-or-break cost lever #2156 exists for — the bake-off
+/// L1 pilot showed tcode doing ZERO caching, re-billing the full tools+system
+/// prefix every turn. This test proves the wire request the loop actually
+/// sends carries the breakpoint in both required places: the last tool
+/// definition's `function.cache_control`, and the system message's
+/// `cache_control`.
+/// What: Run a single-turn `DailyDriver` loop with model
+/// `"anthropic/claude-sonnet-4-5"` and the echo tool registered; inspect the
+/// `ScriptedLlm`'s recorded request for both markers.
+/// Test: this test.
+#[tokio::test]
+async fn daily_driver_anthropic_model_marks_cache_breakpoints() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let registry = registry_with_echo(false);
+    let agent = make_loop(
+        llm.clone(),
+        registry,
+        AgentLoopConfig {
+            model: "anthropic/claude-sonnet-4-5".into(),
+            mode: crate::mode::HarnessMode::DailyDriver,
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    agent
+        .run("you are a helpful assistant", "do the thing")
+        .await
+        .expect("single stop turn should complete");
+
+    let requests = llm.requests();
+    let system_msg = requests[0]
+        .iter()
+        .find(|m| m.role == "system")
+        .expect("system message present");
+    assert_eq!(
+        system_msg.cache_control,
+        Some(crate::llm::CacheControl::ephemeral()),
+        "system message must carry the cache breakpoint"
+    );
+
+    let tools = llm.tools_seen()[0]
+        .clone()
+        .expect("tools array present (echo tool registered)");
+    let last_tool = tools.last().expect("at least one tool");
+    assert_eq!(
+        last_tool.function.cache_control,
+        Some(crate::llm::CacheControl::ephemeral()),
+        "last tool definition must carry the cache breakpoint"
+    );
+}
+
+/// `Parity` mode never marks a cache breakpoint, even for an `anthropic/*`
+/// model — the request stays byte-identical to pre-#2156.
+///
+/// Why: #2156's spec scopes caching to `DailyDriver`; Parity's cross-model
+/// benchmark fairness guarantee must not have its wire payload altered.
+/// What: Same setup as the DailyDriver test but with `mode:
+/// HarnessMode::Parity`; assert neither the system message nor the tool
+/// definition carries `cache_control`.
+/// Test: this test.
+#[tokio::test]
+async fn parity_mode_never_marks_cache_breakpoints() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let registry = registry_with_echo(false);
+    let agent = make_loop(
+        llm.clone(),
+        registry,
+        AgentLoopConfig {
+            model: "anthropic/claude-sonnet-4-5".into(),
+            mode: crate::mode::HarnessMode::Parity,
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    agent
+        .run("you are a helpful assistant", "do the thing")
+        .await
+        .expect("single stop turn should complete");
+
+    let requests = llm.requests();
+    let system_msg = requests[0]
+        .iter()
+        .find(|m| m.role == "system")
+        .expect("system message present");
+    assert!(
+        system_msg.cache_control.is_none(),
+        "Parity mode must never carry a cache breakpoint on the system message"
+    );
+
+    let tools = llm.tools_seen()[0]
+        .clone()
+        .expect("tools array present (echo tool registered)");
+    let last_tool = tools.last().expect("at least one tool");
+    assert!(
+        last_tool.function.cache_control.is_none(),
+        "Parity mode must never carry a cache breakpoint on the tools array"
+    );
+}
+
+/// A `DailyDriver` run against a non-Anthropic model never marks a cache
+/// breakpoint — the passthrough is only verified for `anthropic/*` slugs.
+///
+/// Why: Emitting `cache_control` to a family whose OpenRouter passthrough
+/// hasn't been verified risks silently malformed requests; the gate must key
+/// off the resolved `Provider::supports_prompt_caching`, not the mode alone.
+/// What: Same setup as the DailyDriver test but with model
+/// `"openai/gpt-4o-mini"`; assert neither the system message nor the tool
+/// definition carries `cache_control`.
+/// Test: this test.
+#[tokio::test]
+async fn non_anthropic_model_never_marks_cache_breakpoints() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let registry = registry_with_echo(false);
+    let agent = make_loop(
+        llm.clone(),
+        registry,
+        AgentLoopConfig {
+            model: "openai/gpt-4o-mini".into(),
+            mode: crate::mode::HarnessMode::DailyDriver,
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    agent
+        .run("you are a helpful assistant", "do the thing")
+        .await
+        .expect("single stop turn should complete");
+
+    let requests = llm.requests();
+    let system_msg = requests[0]
+        .iter()
+        .find(|m| m.role == "system")
+        .expect("system message present");
+    assert!(
+        system_msg.cache_control.is_none(),
+        "non-Anthropic models must never carry a cache breakpoint on the system message"
+    );
+
+    let tools = llm.tools_seen()[0]
+        .clone()
+        .expect("tools array present (echo tool registered)");
+    let last_tool = tools.last().expect("at least one tool");
+    assert!(
+        last_tool.function.cache_control.is_none(),
+        "non-Anthropic models must never carry a cache breakpoint on the tools array"
     );
 }

--- a/crates/trusty-code/src/agent_loop/transcript.rs
+++ b/crates/trusty-code/src/agent_loop/transcript.rs
@@ -146,6 +146,7 @@ impl Transcript {
             tool_calls,
             tool_call_id: None,
             name: None,
+            cache_control: None,
         }));
     }
 

--- a/crates/trusty-code/src/llm/message.rs
+++ b/crates/trusty-code/src/llm/message.rs
@@ -4,14 +4,17 @@
 //! tool-result injection; isolating it here keeps the request and response
 //! modules free of message construction boilerplate.
 //! What: Defines `ChatMessage` with `role`, `content`, `tool_calls`,
-//! `tool_call_id`, and `name` fields, plus convenience constructors for each
-//! standard role.
+//! `tool_call_id`, `name`, and (#2156) `cache_control` fields, plus convenience
+//! constructors for each standard role.
 //! Test: `chat_message_constructors`, `chat_message_tool_role_round_trip`,
-//! `chat_message_serialises_all_roles`.
+//! `chat_message_serialises_all_roles`,
+//! `chat_message_cache_control_serialises_as_content_block`,
+//! `chat_message_without_cache_control_serialises_plain_string`.
 
-use serde::{Deserialize, Serialize};
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Serialize, Serializer};
 
-use super::request::ToolCall;
+use super::request::{CacheControl, ToolCall};
 
 /// A single message in the chat conversation.
 ///
@@ -21,9 +24,12 @@ use super::request::ToolCall;
 /// What: `role` is one of `"system"`, `"user"`, `"assistant"`, `"tool"`;
 /// `content` is the text or `None` for assistant turns that only emit tool
 /// calls; `tool_calls` carries the outbound calls for assistant turns;
-/// `tool_call_id` and `name` are populated for `tool` role messages.
+/// `tool_call_id` and `name` are populated for `tool` role messages;
+/// `cache_control` (#2156) is a prompt-cache breakpoint applied at
+/// serialisation time — see [`Self::serialize`] for the wire-shape switch it
+/// drives.
 /// Test: `chat_message_serialises_all_roles`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct ChatMessage {
     /// Conversation role: `"system"`, `"user"`, `"assistant"`, or `"tool"`.
     pub role: String,
@@ -43,6 +49,96 @@ pub struct ChatMessage {
     /// For `tool` role messages: the name of the function that was called.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+
+    /// Prompt-cache breakpoint (#2156). Never read back from the wire (this
+    /// type is request-only — see the module doc), so it is dropped on
+    /// deserialise via `#[serde(skip)]` rather than round-tripped.
+    /// `agent_loop::build_request` sets this on the system-role message when
+    /// the run is cache-eligible; see [`Self::serialize`] for how it changes
+    /// `content`'s wire shape.
+    #[serde(skip)]
+    pub cache_control: Option<CacheControl>,
+}
+
+impl Serialize for ChatMessage {
+    /// Serialise `ChatMessage`, converting `content` into a one-element
+    /// cache-annotated content-block array when `cache_control` is set
+    /// (#2156), and a bare string (today's shape) otherwise.
+    ///
+    /// Why: OpenRouter's Claude `cache_control` passthrough only honours the
+    /// breakpoint when `content` is shaped as
+    /// `[{"type":"text","text":...,"cache_control":{"type":"ephemeral"}}]` —
+    /// a plain string `content` value is never inspected for a cache marker
+    /// (verified against OpenRouter's prompt-caching docs and `block/goose`'s
+    /// production OpenRouter provider). Hand-writing this impl — rather than
+    /// deriving — keeps `content: Option<String>` the type every other call
+    /// site (`Transcript`, tests) already depends on; only the wire encoding
+    /// branches on `cache_control`.
+    /// What: `role` always serialises. `content` serialises as the cached
+    /// block array when both `content` and `cache_control` are `Some`, as a
+    /// bare string when only `content` is `Some`, and is omitted entirely
+    /// when `content` is `None` — matching the previous
+    /// `skip_serializing_if = "Option::is_none"` behaviour byte-for-byte when
+    /// `cache_control` is `None`. `tool_calls`, `tool_call_id`, and `name`
+    /// serialise unchanged; `cache_control` itself never appears as its own
+    /// JSON key.
+    /// Test: `chat_message_cache_control_serialises_as_content_block`,
+    /// `chat_message_without_cache_control_serialises_plain_string`,
+    /// `chat_message_serialises_all_roles`.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("ChatMessage", 5)?;
+        state.serialize_field("role", &self.role)?;
+
+        match (&self.content, &self.cache_control) {
+            (Some(text), Some(cache_control)) => {
+                let block = [CachedTextBlock {
+                    kind: "text",
+                    text: text.as_str(),
+                    cache_control,
+                }];
+                state.serialize_field("content", &block)?;
+            }
+            (Some(text), None) => state.serialize_field("content", text)?,
+            (None, _) => state.skip_field("content")?,
+        }
+
+        match &self.tool_calls {
+            Some(calls) => state.serialize_field("tool_calls", calls)?,
+            None => state.skip_field("tool_calls")?,
+        }
+        match &self.tool_call_id {
+            Some(id) => state.serialize_field("tool_call_id", id)?,
+            None => state.skip_field("tool_call_id")?,
+        }
+        match &self.name {
+            Some(name) => state.serialize_field("name", name)?,
+            None => state.skip_field("name")?,
+        }
+
+        state.end()
+    }
+}
+
+/// Wire shape for one Anthropic-ephemeral cached text content block (#2156).
+///
+/// Why: `[{"type":"text","text":...,"cache_control":{"type":"ephemeral"}}]`
+/// is exactly OpenRouter's documented Claude `cache_control` passthrough
+/// shape for message content; this private struct is the single place that
+/// shape is expressed instead of building it ad hoc inside
+/// `ChatMessage::serialize`.
+/// What: `kind` is always `"text"`; `text`/`cache_control` borrow from the
+/// owning `ChatMessage` to avoid a clone during serialisation.
+/// Test: exercised indirectly via
+/// `chat_message_cache_control_serialises_as_content_block`.
+#[derive(Serialize)]
+struct CachedTextBlock<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: &'a str,
+    cache_control: &'a CacheControl,
 }
 
 impl ChatMessage {
@@ -58,6 +154,7 @@ impl ChatMessage {
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            cache_control: None,
         }
     }
 
@@ -73,6 +170,7 @@ impl ChatMessage {
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            cache_control: None,
         }
     }
 
@@ -89,6 +187,7 @@ impl ChatMessage {
             tool_calls: None,
             tool_call_id: None,
             name: None,
+            cache_control: None,
         }
     }
 
@@ -110,6 +209,7 @@ impl ChatMessage {
             tool_calls: None,
             tool_call_id: Some(tool_call_id.into()),
             name: Some(name.into()),
+            cache_control: None,
         }
     }
 }
@@ -168,5 +268,51 @@ mod tests {
                 "role mismatch for expected={expected_role}"
             );
         }
+    }
+
+    /// A message with `cache_control` set serialises `content` as a
+    /// one-element cache-annotated block array (#2156).
+    ///
+    /// Why: This is the exact shape OpenRouter's Claude passthrough requires
+    /// to honour the breakpoint; a plain-string `content` would be silently
+    /// ignored by Anthropic's caching layer.
+    /// What: Build a system message, set `cache_control`, serialise, assert
+    /// `content` is `[{"type":"text","text":...,"cache_control":
+    /// {"type":"ephemeral"}}]`.
+    /// Test: this test.
+    #[test]
+    fn chat_message_cache_control_serialises_as_content_block() {
+        let mut msg = ChatMessage::system("you are helpful");
+        msg.cache_control = Some(CacheControl::ephemeral());
+
+        let v: serde_json::Value = serde_json::to_value(&msg).expect("serialise");
+        assert_eq!(
+            v["content"],
+            serde_json::json!([{
+                "type": "text",
+                "text": "you are helpful",
+                "cache_control": {"type": "ephemeral"}
+            }])
+        );
+        assert_eq!(v["role"], "system");
+    }
+
+    /// A message WITHOUT `cache_control` serialises `content` as a bare
+    /// string — byte-identical to pre-#2156 output (#2156 regression guard).
+    ///
+    /// Why: Every non-caching request (Parity mode, non-Anthropic models)
+    /// must be unaffected by this change; this pins that the default
+    /// (`cache_control: None`) path never emits the block-array shape.
+    /// What: Build a system message via the ordinary constructor (leaving
+    /// `cache_control` at its default `None`), serialise, assert `content`
+    /// is the plain string.
+    /// Test: this test.
+    #[test]
+    fn chat_message_without_cache_control_serialises_plain_string() {
+        let msg = ChatMessage::system("you are helpful");
+        assert!(msg.cache_control.is_none());
+
+        let v: serde_json::Value = serde_json::to_value(&msg).expect("serialise");
+        assert_eq!(v["content"], serde_json::json!("you are helpful"));
     }
 }

--- a/crates/trusty-code/src/llm/mod.rs
+++ b/crates/trusty-code/src/llm/mod.rs
@@ -28,7 +28,9 @@ pub use client::{LlmClient, LlmClientConfig};
 pub use client_trait::LlmClientTrait;
 pub use error::LlmError;
 pub use message::ChatMessage;
-pub use request::{ChatRequest, FunctionCall, FunctionDefinition, ToolCall, ToolDefinition};
+pub use request::{
+    CacheControl, ChatRequest, FunctionCall, FunctionDefinition, ToolCall, ToolDefinition,
+};
 pub use response::{AssistantMessage, ChatChoice, ChatResponse};
 pub use tool_call_extractor::{
     DEFAULT_MAX_REPAIR_ATTEMPTS, ExtractedToolCall, ExtractionStrategy, SchemaViolation,

--- a/crates/trusty-code/src/llm/request.rs
+++ b/crates/trusty-code/src/llm/request.rs
@@ -14,6 +14,41 @@ use serde::{Deserialize, Serialize};
 
 use super::message::ChatMessage;
 
+// ── Prompt-caching types (#2156) ────────────────────────────────────────────────
+
+/// An Anthropic-style ephemeral prompt-cache breakpoint.
+///
+/// Why: Anthropic (and OpenRouter's passthrough for `anthropic/*` slugs) prices
+/// everything up to and including a `cache_control` marker as one cached
+/// prefix — a cache HIT on a later turn bills at roughly 0.1x the normal input
+/// price instead of re-billing the full prefix. `agent_loop::build_request`
+/// places this marker on the byte-stable tools+system-prompt prefix it
+/// resends every turn, which is the make-or-break cost lever for #2156.
+/// What: `kind` is always `"ephemeral"` — the only breakpoint type Anthropic
+/// currently supports. Serialises to `{"type":"ephemeral"}`.
+/// Test: `cache_control_ephemeral_serialises_expected_shape`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CacheControl {
+    /// Always `"ephemeral"`.
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+impl CacheControl {
+    /// Construct the (only) ephemeral cache-breakpoint marker.
+    ///
+    /// Why: Every call site wants the identical `{"type":"ephemeral"}` value;
+    /// naming the constructor after the wire concept avoids a stringly-typed
+    /// literal at each use site.
+    /// What: Returns `CacheControl { kind: "ephemeral".into() }`.
+    /// Test: `cache_control_ephemeral_serialises_expected_shape`.
+    pub fn ephemeral() -> Self {
+        Self {
+            kind: "ephemeral".into(),
+        }
+    }
+}
+
 // ── Tool-calling types ─────────────────────────────────────────────────────────
 
 /// A tool call emitted by the model.
@@ -107,6 +142,17 @@ pub struct FunctionDefinition {
     /// JSON Schema object describing the function's parameter shape.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<serde_json::Value>,
+
+    /// Prompt-cache breakpoint (#2156). When set, serialises as a sibling
+    /// `"cache_control":{"type":"ephemeral"}` field alongside this function's
+    /// schema — the shape `block/goose`'s (verified, production) OpenRouter
+    /// provider uses to cache Claude tool definitions via the OpenAI-compat
+    /// endpoint. `agent_loop::build_request` sets this on the LAST tool
+    /// definition only: Anthropic caches everything up to and including a
+    /// breakpoint, so marking just the last tool caches the entire
+    /// (byte-stable) tools array as a single prefix.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
 }
 
 // ── Request type ───────────────────────────────────────────────────────────────
@@ -193,6 +239,7 @@ mod tests {
                 "properties": { "location": { "type": "string" } },
                 "required": ["location"]
             })),
+            cache_control: None,
         });
         let req = ChatRequest {
             model: "openai/gpt-4o-mini".into(),
@@ -222,10 +269,15 @@ mod tests {
             name: "ping".into(),
             description: None,
             parameters: None,
+            cache_control: None,
         });
         let v: serde_json::Value = serde_json::to_value(&tool).expect("serialise");
         assert_eq!(v["type"], "function");
         assert_eq!(v["function"]["name"], "ping");
+        assert!(
+            v["function"].get("cache_control").is_none(),
+            "cache_control must be omitted when unset"
+        );
     }
 
     /// `FunctionDefinition` round-trips through JSON.
@@ -242,11 +294,54 @@ mod tests {
             name: "my_fn".into(),
             description: Some("does stuff".into()),
             parameters: Some(params.clone()),
+            cache_control: None,
         };
         let serialised = serde_json::to_string(&def).expect("serialise");
         let de: FunctionDefinition = serde_json::from_str(&serialised).expect("deserialise");
         assert_eq!(de.name, "my_fn");
         assert_eq!(de.description.as_deref(), Some("does stuff"));
         assert_eq!(de.parameters.as_ref(), Some(&params));
+        assert!(de.cache_control.is_none());
+    }
+
+    /// `CacheControl::ephemeral` serialises to the exact Anthropic-ephemeral
+    /// shape (#2156).
+    ///
+    /// Why: This is the literal JSON marker OpenRouter's Claude passthrough
+    /// looks for; a typo (wrong key name, wrong value) would silently disable
+    /// caching without any test noticing.
+    /// What: Serialise `CacheControl::ephemeral()`, assert the exact object.
+    /// Test: this test.
+    #[test]
+    fn cache_control_ephemeral_serialises_expected_shape() {
+        let v = serde_json::to_value(CacheControl::ephemeral()).expect("serialise");
+        assert_eq!(v, serde_json::json!({"type": "ephemeral"}));
+    }
+
+    /// A `FunctionDefinition` with `cache_control` set serialises the marker
+    /// nested inside the function object (#2156), matching the shape
+    /// `block/goose`'s verified OpenRouter provider uses.
+    ///
+    /// Why: The breakpoint must land on the tool's `function` object, not on
+    /// the wrapping `ToolDefinition` — placing it at the wrong nesting level
+    /// would mean OpenRouter's OpenAI→Anthropic conversion drops the marker
+    /// entirely and caching silently never activates.
+    /// What: Build a `ToolDefinition` whose `FunctionDefinition.cache_control`
+    /// is `Some`, serialise, assert `tools[0].function.cache_control` matches
+    /// the ephemeral shape.
+    /// Test: this test.
+    #[test]
+    fn function_definition_with_cache_control_serialises_marker() {
+        let tool = ToolDefinition::function(FunctionDefinition {
+            name: "write_file".into(),
+            description: Some("Write a file".into()),
+            parameters: None,
+            cache_control: Some(CacheControl::ephemeral()),
+        });
+        let v: serde_json::Value = serde_json::to_value(&tool).expect("serialise");
+        assert_eq!(
+            v["function"]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
     }
 }

--- a/crates/trusty-code/src/provider/bedrock.rs
+++ b/crates/trusty-code/src/provider/bedrock.rs
@@ -67,6 +67,16 @@ impl Provider for BedrockProvider {
         // strategy matrix (#1023) may refine this per-model later.
         true
     }
+
+    fn supports_prompt_caching(&self) -> bool {
+        // Bedrock's Converse API expresses prompt caching via its own
+        // `cachePoint` block shape, not Anthropic's `cache_control` marker
+        // (#2156) — a different wire format this stub does not implement.
+        // `false` until the real Bedrock integration lands so
+        // `agent_loop::build_request` never emits a marker Bedrock can't
+        // interpret.
+        false
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -93,6 +103,20 @@ mod tests {
     #[test]
     fn bedrock_supports_native_tools() {
         assert!(BedrockProvider::new().supports_native_tools());
+    }
+
+    /// Bedrock does NOT report Anthropic-style prompt-caching support
+    /// (#2156).
+    ///
+    /// Why: Bedrock's Converse API caching uses a different wire shape
+    /// (`cachePoint` blocks); until that integration lands, `build_request`
+    /// must never emit an Anthropic `cache_control` marker for a Bedrock
+    /// route.
+    /// What: Assert `supports_prompt_caching()` is `false`.
+    /// Test: this test.
+    #[test]
+    fn bedrock_does_not_support_prompt_caching() {
+        assert!(!BedrockProvider::new().supports_prompt_caching());
     }
 
     /// `map_tool_choice` panics while stubbed.

--- a/crates/trusty-code/src/provider/openrouter.rs
+++ b/crates/trusty-code/src/provider/openrouter.rs
@@ -56,6 +56,25 @@ fn slug_supports_native_tools(slug: &str) -> bool {
     NATIVE_MARKERS.iter().any(|m| lower.contains(m))
 }
 
+/// Whether a model slug belongs to the Anthropic family, routed via
+/// OpenRouter's OpenAI-compatible endpoint (#2156).
+///
+/// Why: OpenRouter's `cache_control` passthrough for the OpenAI-compat path
+/// is verified (via OpenRouter's prompt-caching docs and `block/goose`'s
+/// production OpenRouter provider, which gates the identical marker on this
+/// exact prefix check) to work for `anthropic/*` slugs. Other families either
+/// don't support Anthropic-style `cache_control` at all or the passthrough
+/// behaviour is unverified; conservative by design, matching
+/// `slug_supports_native_tools`'s posture.
+/// What: Returns `true` when the slug (OpenRouter-namespaced, e.g.
+/// `"anthropic/claude-sonnet-4-5"`) starts with `"anthropic/"`, case
+/// insensitively.
+/// Test: `openrouter::tests::supports_prompt_caching_anthropic_family`,
+/// `openrouter::tests::supports_prompt_caching_non_anthropic_families`.
+fn slug_supports_prompt_caching(slug: &str) -> bool {
+    slug.to_ascii_lowercase().starts_with("anthropic/")
+}
+
 impl Provider for OpenRouterProvider {
     fn name(&self) -> &str {
         "openrouter"
@@ -79,6 +98,10 @@ impl Provider for OpenRouterProvider {
 
     fn supports_native_tools(&self) -> bool {
         slug_supports_native_tools(&self.slug)
+    }
+
+    fn supports_prompt_caching(&self) -> bool {
+        slug_supports_prompt_caching(&self.slug)
     }
 }
 
@@ -187,6 +210,49 @@ mod tests {
             assert!(
                 !OpenRouterProvider::new(slug).supports_native_tools(),
                 "expected NO native-tool support for {slug}"
+            );
+        }
+    }
+
+    /// `anthropic/*` slugs report prompt-caching support (#2156).
+    ///
+    /// Why: This is the gate `agent_loop::build_request` consults before
+    /// marking the tools+system prefix with a cache breakpoint; it must be
+    /// `true` for the exact family the passthrough was verified against.
+    /// What: Construct providers for Anthropic-family slugs (including a
+    /// non-default casing), assert `true`.
+    /// Test: this test.
+    #[test]
+    fn supports_prompt_caching_anthropic_family() {
+        for slug in [
+            "anthropic/claude-sonnet-4-5",
+            "anthropic/claude-haiku-4-5",
+            "Anthropic/Claude-Opus-4",
+        ] {
+            assert!(
+                OpenRouterProvider::new(slug).supports_prompt_caching(),
+                "expected prompt-caching support for {slug}"
+            );
+        }
+    }
+
+    /// Non-Anthropic slugs do NOT report prompt-caching support (#2156).
+    ///
+    /// Why: The OpenRouter passthrough shape has only been verified for
+    /// `anthropic/*`; emitting `cache_control` to other families is
+    /// unverified and must stay off by default.
+    /// What: Construct providers for OpenAI/Gemini/Qwen slugs, assert `false`.
+    /// Test: this test.
+    #[test]
+    fn supports_prompt_caching_non_anthropic_families() {
+        for slug in [
+            "openai/gpt-4o-mini",
+            "google/gemini-2.5-pro",
+            "qwen/qwen-2.5-coder-32b-instruct",
+        ] {
+            assert!(
+                !OpenRouterProvider::new(slug).supports_prompt_caching(),
+                "expected NO prompt-caching support for {slug}"
             );
         }
     }

--- a/crates/trusty-code/src/provider/traits.rs
+++ b/crates/trusty-code/src/provider/traits.rs
@@ -84,4 +84,20 @@ pub trait Provider: Send + Sync {
     /// Test: `openrouter::tests::supports_native_tools_*`,
     /// `bedrock::tests::bedrock_supports_native_tools`.
     fn supports_native_tools(&self) -> bool;
+
+    /// Whether this backend/model honours Anthropic-style `cache_control`
+    /// prompt-cache breakpoints (#2156).
+    ///
+    /// Why: Emitting a `cache_control` marker to a backend/model that ignores
+    /// it is harmless (the field is simply dropped), but gating on this flag
+    /// keeps the wire payload minimal for models that can never benefit and
+    /// documents, in one place, exactly which backends this has been
+    /// verified against — rather than scattering `model.starts_with(...)`
+    /// checks at every call site.
+    /// What: Returns `true` when `agent_loop::build_request` should mark the
+    /// static tools+system-prompt prefix with an ephemeral cache breakpoint;
+    /// `false` otherwise.
+    /// Test: `openrouter::tests::supports_prompt_caching_*`,
+    /// `bedrock::tests::bedrock_does_not_support_prompt_caching`.
+    fn supports_prompt_caching(&self) -> bool;
 }


### PR DESCRIPTION
Adds Anthropic `cache_control: {"type":"ephemeral"}` breakpoints on tcode's stable tools-array + system-prompt prefix, so multi-turn runs read that prefix from cache instead of re-billing it each turn. Surfaced by the M3 bake-off L1 pilot: tcode did ZERO caching (cache=0), re-sending ~316K prompt tokens across 37 turns → $1.49 (vs opencode's $0.91 which caches heavily) — currently the biggest gap in tcode's "comparable quality at lower cost" thesis.

Implementation: `CacheControl` type + `cache_control` on `FunctionDefinition` (nested inside `function`, the shape OpenRouter forwards to Anthropic) and a hand-written `ChatMessage::Serialize` that emits array-of-content-blocks with the marker when set / plain string otherwise (byte-identical when unset — a plain string is silently ignored by Anthropic caching, so the array form is required). `build_request` marks the last tool + the seed system message only when `HarnessMode::DailyDriver && Provider::supports_prompt_caching()` (true only for `anthropic/*` via OpenRouter; Bedrock/non-anthropic return false). Parity mode unaffected (byte-identical).

Wire shape verified against OpenRouter's prompt-caching docs + Block's `goose` OpenRouter provider (not yet a live round-trip — empirical cache-hit validation comes from the bake-off re-run).

QA: APPROVE (independent worktree at 2f1f0558) — build 0 warnings, 635 lib + 16 e2e tests pass, clippy/fmt clean, line-cap 0 violations, trusty-agents unaffected. Serialization shape (array-of-blocks + function-nested tool marker), gating, and cached-prefix contiguity all verified; no new library unwrap(); #2198 + #2210 fixes un-regressed.

Closes #2156