### PR TITLE
feat(trusty-mpm): seed outputStyle/statusLine into tm-owned config dir (closes #2214)

### DIFF
--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -38,6 +38,23 @@ use settings::{
     remove_global_trusty_memory_hooks, write_output_style, write_project_hooks, write_status_line,
 };
 
+/// Re-export of the project-tier output-style/statusLine resolution primitives
+/// for reuse by `core::standalone::settings_defaults` (issue #2214).
+///
+/// Why: `mod settings` above is private, so a `pub(crate)` item inside it is
+/// still unreachable from outside `session_launch` without a re-export at this
+/// (public) module boundary. `core::standalone::settings_defaults::ensure_settings_defaults`
+/// seeds `outputStyle`/`statusLine` into the tm-owned `CLAUDE_CONFIG_DIR`
+/// settings.json using these exact same values, rather than duplicating the
+/// default-id constant or the absolute-binary-path resolution logic.
+/// What: re-exports [`settings::OUTPUT_STYLE`] and
+/// [`settings::resolve_statusline_command`] as `session_launch::OUTPUT_STYLE` /
+/// `session_launch::resolve_statusline_command`.
+/// Test: covered indirectly by
+/// `core::standalone::settings_defaults` tests (this is a plain re-export, no
+/// logic of its own).
+pub(crate) use settings::{OUTPUT_STYLE, resolve_statusline_command};
+
 /// Outcome of the pre-launch preparation for one session.
 ///
 /// Why: callers (CLI, client) report agent-deploy counts and CLAUDE.md status

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -19,8 +19,11 @@ use super::PrepError;
 /// is configured, launched trusty-mpm sessions advertise the professional
 /// default `trusty-mpm`. HR-4 lets the operator select a different bundled style
 /// (teaching/research); [`write_output_style`] takes the resolved active id and
-/// falls back to this constant when none is supplied.
-pub(super) const OUTPUT_STYLE: &str = crate::core::bundle::DEFAULT_OUTPUT_STYLE_ID;
+/// falls back to this constant when none is supplied. `pub(crate)` (rather than
+/// `pub(super)`) so `core::standalone::settings_defaults::ensure_settings_defaults`
+/// can seed the SAME default id into the tm-owned `CLAUDE_CONFIG_DIR` settings.json
+/// (issue #2214), re-exported via `session_launch::OUTPUT_STYLE`.
+pub(crate) const OUTPUT_STYLE: &str = crate::core::bundle::DEFAULT_OUTPUT_STYLE_ID;
 
 /// trusty-mpm-specific spinner tips shown during Claude Code loading.
 ///
@@ -878,11 +881,15 @@ pub(super) fn is_stale_bare_statusline_command(entry: &serde_json::Value) -> boo
 /// `statusLine.command`.
 ///
 /// Why (#1914): see [`write_status_line`]'s doc comment for the full
-/// PATH-resolution motivation.
+/// PATH-resolution motivation. `pub(crate)` (rather than private) so
+/// `core::standalone::settings_defaults::ensure_settings_defaults` can reuse the
+/// SAME absolute-path resolution when seeding `statusLine` into the tm-owned
+/// `CLAUDE_CONFIG_DIR` settings.json (issue #2214), re-exported via
+/// `session_launch::resolve_statusline_command`.
 /// What: appends the `statusline` subcommand to [`resolve_statusline_binary`].
 /// Test: exercised indirectly by `write_status_line_injects_when_absent`
 /// (asserts the written command is an absolute path ending in ` statusline`).
-fn resolve_statusline_command() -> String {
+pub(crate) fn resolve_statusline_command() -> String {
     format!("{} statusline", resolve_statusline_binary())
 }
 

--- a/crates/trusty-mpm/src/core/standalone/global_config.rs
+++ b/crates/trusty-mpm/src/core/standalone/global_config.rs
@@ -6,13 +6,16 @@
 //! it via the required `CLAUDE_CONFIG_DIR` env var.
 //! This module creates that dir once and never regenerates it per project.
 //! What: [`ensure_global_config_dir`] creates `<managed_root>/claude-config/`,
-//! writes a minimal `settings.json`, seeds `.credentials.json` from
-//! `~/.claude/.credentials.json` if it exists (NOTE: this file holds MCP OAuth
-//! tokens, NOT the primary session auth — see WI-10 for the auth model), writes
-//! a minimal `.mcp.json` with trusty-memory, trusty-review, and trusty-search server stubs, and
-//! (WI-2) deploys bundled agents and skills from
-//! `<managed_root>/framework/{agents,skills}` into the managed config dir so
-//! that every tm-launched session starts with the full agent/skill set.
+//! writes a minimal `settings.json` seeded with the `outputStyle`/`statusLine`
+//! defaults via [`super::settings_defaults::ensure_settings_defaults`] (issue
+//! #2214 defense-in-depth — see that module's doc comment), merges the MPM hook
+//! triad, seeds `.credentials.json` from `~/.claude/.credentials.json` if it
+//! exists (NOTE: this file holds MCP OAuth tokens, NOT the primary session auth
+//! — see WI-10 for the auth model), writes a minimal `.mcp.json` with
+//! trusty-memory, trusty-review, and trusty-search server stubs, and (WI-2)
+//! deploys bundled agents and skills from `<managed_root>/framework/{agents,skills}`
+//! into the managed config dir so that every tm-launched session starts with
+//! the full agent/skill set.
 //!
 //! # WI-10 Auth Model
 //!
@@ -41,26 +44,30 @@ use std::path::{Path, PathBuf};
 /// Why: `tm run` calls this before launching `claude` so the CLAUDE_CONFIG_DIR
 /// always contains a valid `settings.json`, MCP config, and (WI-2) the bundled
 /// agents and skills. Idempotent — safe to call on every launch.
-/// What: creates `<managed_root>/claude-config/`, writes `settings.json` (`{}`
-/// when absent), merges the MPM hook triad into `settings.json` via
-/// [`super::hooks::ensure_managed_hooks`] (WI-3), copies
-/// `~/.claude/.credentials.json` if found (silently skips otherwise), writes
-/// `.mcp.json` with trusty-memory, trusty-review, and trusty-search stubs
-/// (idempotent via the inject pattern; WI-8 adds trusty-review), then deploys
-/// bundled agents and skills via [`deploy_agents_and_skills`].
+/// What: creates `<managed_root>/claude-config/`, seeds `settings.json` with the
+/// `outputStyle`/`statusLine` defaults via
+/// [`super::settings_defaults::ensure_settings_defaults`] (issue #2214;
+/// non-destructive — never overwrites an already-set value), merges the MPM
+/// hook triad into `settings.json` via [`super::hooks::ensure_managed_hooks`]
+/// (WI-3), copies `~/.claude/.credentials.json` if found (silently skips
+/// otherwise), writes `.mcp.json` with trusty-memory, trusty-review, and
+/// trusty-search stubs (idempotent via the inject pattern; WI-8 adds
+/// trusty-review), then deploys bundled agents and skills via
+/// [`deploy_agents_and_skills`].
 /// Test: `test_global_config_dir_ensure_idempotent`,
 /// `test_deploy_agents_and_skills_populates_config_dir`,
-/// `test_deploy_agents_and_skills_missing_source_is_ok`.
+/// `test_deploy_agents_and_skills_missing_source_is_ok`,
+/// `test_global_config_dir_seeds_output_style_and_status_line`.
 pub fn ensure_global_config_dir(
     managed_root: &Path,
     claude_config_dir: &Path,
 ) -> anyhow::Result<PathBuf> {
     std::fs::create_dir_all(claude_config_dir)?;
 
-    let settings_path = claude_config_dir.join("settings.json");
-    if !settings_path.exists() {
-        std::fs::write(&settings_path, "{}\n")?;
-    }
+    // Issue #2214: seed `outputStyle`/`statusLine` defaults directly into the
+    // tm-owned settings.json (defense-in-depth, independent of the project tier
+    // + `--setting-sources`). Non-destructive — see module doc comment.
+    super::settings_defaults::ensure_settings_defaults(claude_config_dir)?;
 
     // WI-3: merge the MPM lifecycle hook triad (PreToolUse/PostToolUse/Stop)
     // into settings.json so managed sessions emit lifecycle events to the daemon.
@@ -375,6 +382,56 @@ mod tests {
         // Second call must not fail (idempotent).
         ensure_global_config_dir(&managed_root, &claude_config).unwrap();
         assert!(claude_config.join("settings.json").exists());
+    }
+
+    // Issue #2214: ensure_global_config_dir must seed outputStyle/statusLine
+    // into a FRESH tm-owned settings.json, and must preserve any pre-existing
+    // unrelated keys (e.g. a client-persisted `theme`) on a second call.
+    #[test]
+    fn test_global_config_dir_seeds_output_style_and_status_line() {
+        let tmp = TempDir::new().unwrap();
+        let managed_root = tmp.path().join("managed");
+        let claude_config = managed_root.join("claude-config");
+
+        ensure_global_config_dir(&managed_root, &claude_config).unwrap();
+
+        let text = std::fs::read_to_string(claude_config.join("settings.json")).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            val["outputStyle"].as_str(),
+            Some(crate::core::session_launch::OUTPUT_STYLE),
+            "fresh tm-owned settings.json must have outputStyle seeded"
+        );
+        assert!(
+            val["statusLine"]["command"]
+                .as_str()
+                .is_some_and(|c| c.ends_with(" statusline")),
+            "fresh tm-owned settings.json must have statusLine seeded"
+        );
+
+        // Simulate a client-persisted key (e.g. self-persisted theme) landing
+        // in the tm-owned settings.json between launches.
+        let mut with_theme = val.clone();
+        with_theme["theme"] = serde_json::json!("dark");
+        std::fs::write(
+            claude_config.join("settings.json"),
+            serde_json::to_string_pretty(&with_theme).unwrap(),
+        )
+        .unwrap();
+
+        // Re-running ensure_global_config_dir must not clobber that key.
+        ensure_global_config_dir(&managed_root, &claude_config).unwrap();
+        let text_after = std::fs::read_to_string(claude_config.join("settings.json")).unwrap();
+        let val_after: serde_json::Value = serde_json::from_str(&text_after).unwrap();
+        assert_eq!(
+            val_after["theme"].as_str(),
+            Some("dark"),
+            "client-persisted keys must survive re-provisioning"
+        );
+        assert_eq!(
+            val_after["outputStyle"].as_str(),
+            Some(crate::core::session_launch::OUTPUT_STYLE)
+        );
     }
 
     // WI-3 + WI-8: ensure_mcp_config must define all three managed MCP servers,

--- a/crates/trusty-mpm/src/core/standalone/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/mod.rs
@@ -6,11 +6,13 @@
 //! operates entirely under `~/.trusty-mpm/` — never touching `~/.claude/` or
 //! `~/.claude.json` — so the driver can replace claude-mpm for daily work
 //! without collision (DOC-24).
-//! What: six submodules — `registry` (alias→URL persistence), `global_config`
+//! What: seven submodules — `registry` (alias→URL persistence), `global_config`
 //! (ensure the one tm-global config dir exists), `hooks` (managed hook triad
-//! definitions and idempotent merge), `load` (clone + prepare a managed
-//! workspace), `run` (launch claude with CLAUDE_CONFIG_DIR isolation), and
-//! `trust_seed` (project trust + MCP-server pre-seeding into managed config dir).
+//! definitions and idempotent merge), `settings_defaults` (seed
+//! `outputStyle`/`statusLine` defense-in-depth, issue #2214), `load` (clone +
+//! prepare a managed workspace), `run` (launch claude with CLAUDE_CONFIG_DIR
+//! isolation), and `trust_seed` (project trust + MCP-server pre-seeding into
+//! managed config dir).
 //! Test: unit tests in each submodule's `#[cfg(test)]` block.
 
 pub mod global_config;
@@ -18,6 +20,7 @@ pub mod hooks;
 pub mod load;
 pub mod registry;
 pub mod run;
+pub mod settings_defaults;
 pub mod trust_seed;
 
 pub use trust_seed::preseed_managed_trust;

--- a/crates/trusty-mpm/src/core/standalone/settings_defaults.rs
+++ b/crates/trusty-mpm/src/core/standalone/settings_defaults.rs
@@ -1,0 +1,203 @@
+//! Seed `outputStyle`/`statusLine` defaults into the tm-owned `CLAUDE_CONFIG_DIR`
+//! `settings.json` (defense-in-depth, issue #2214).
+//!
+//! Why: managed sessions currently rely on the PROJECT-tier `settings.json`
+//! (written by [`crate::core::session_launch::settings::write_output_style`] /
+//! `write_status_line`) plus `claude --setting-sources project,local` to show
+//! the `trusty-mpm` output style and live statusline. That is a single point of
+//! failure: if the project-tier write is ever skipped, races with a resumed
+//! workspace, or the `--setting-sources` flag drifts, the tm-owned config dir
+//! itself carries neither key and the session silently falls back to Claude
+//! Code's own defaults. Seeding the SAME two keys directly into the tm-owned
+//! `CLAUDE_CONFIG_DIR/settings.json` makes that config dir self-sufficient,
+//! independent of the project tier.
+//! What: [`ensure_settings_defaults`] reads the tm-owned
+//! `<claude_config_dir>/settings.json` (tolerating absent/malformed content by
+//! starting from `{}`), sets `outputStyle` and `statusLine` ONLY when each key
+//! is not already present — never overwriting a value the client (or a prior
+//! `tm login`) already persisted there — and writes back atomically only when
+//! something actually changed. The values reused are the exact same ones the
+//! project-tier writer computes: [`crate::core::session_launch::OUTPUT_STYLE`]
+//! (the default output-style id) and
+//! [`crate::core::session_launch::resolve_statusline_command`] (the resolved
+//! absolute `<tm-binary> statusline` command).
+//! Test: `ensure_settings_defaults_seeds_fresh_file`,
+//! `ensure_settings_defaults_preserves_existing_keys`,
+//! `ensure_settings_defaults_does_not_overwrite_customized_values`,
+//! `ensure_settings_defaults_is_idempotent`.
+
+use std::path::Path;
+
+use trusty_common::claude_config::write_json_atomic;
+
+/// Seed `outputStyle` and `statusLine` into `<claude_config_dir>/settings.json`
+/// when either key is absent, preserving every other key untouched.
+///
+/// Why: see the module-level doc comment — this is the defense-in-depth seed
+/// called from [`super::global_config::ensure_global_config_dir`] on every
+/// managed-driver bootstrap, so the tm-owned config dir never depends solely on
+/// the project tier for these two keys.
+/// What: reads the on-disk `settings.json` (or starts from `{}` if
+/// absent/malformed/non-object), inserts `outputStyle` =
+/// [`crate::core::session_launch::OUTPUT_STYLE`] only if the key is not already
+/// present, inserts `statusLine` = `{ "type": "command", "command":
+/// <resolved absolute path> statusline", "padding": 0 }` (via
+/// [`crate::core::session_launch::resolve_statusline_command`]) only if the key
+/// is not already present, then writes back via
+/// [`trusty_common::claude_config::write_json_atomic`] only when the merged
+/// value actually differs from what was on disk (idempotent — no spurious
+/// rewrite / mtime bump on repeat calls).
+/// Test: `ensure_settings_defaults_seeds_fresh_file`,
+/// `ensure_settings_defaults_preserves_existing_keys`,
+/// `ensure_settings_defaults_does_not_overwrite_customized_values`,
+/// `ensure_settings_defaults_is_idempotent`.
+pub(crate) fn ensure_settings_defaults(claude_config_dir: &Path) -> anyhow::Result<()> {
+    let settings_path = claude_config_dir.join("settings.json");
+
+    let existing_value: Option<serde_json::Value> = std::fs::read_to_string(&settings_path)
+        .ok()
+        .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
+        .filter(serde_json::Value::is_object);
+
+    let mut settings = existing_value
+        .clone()
+        .unwrap_or_else(|| serde_json::json!({}));
+    let obj = settings
+        .as_object_mut()
+        .expect("settings was constructed/filtered to be an object");
+
+    obj.entry("outputStyle").or_insert_with(|| {
+        serde_json::Value::String(crate::core::session_launch::OUTPUT_STYLE.to_string())
+    });
+    obj.entry("statusLine").or_insert_with(|| {
+        serde_json::json!({
+            "type": "command",
+            "command": crate::core::session_launch::resolve_statusline_command(),
+            "padding": 0
+        })
+    });
+
+    // Structural comparison (not byte-wise) so formatting differences left by
+    // editors or prior writes never trigger a spurious rewrite, matching the
+    // idempotency pattern used by `global_config::ensure_mcp_config`.
+    let needs_write = existing_value.as_ref() != Some(&settings);
+    if needs_write {
+        write_json_atomic(&settings_path, &settings)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn ensure_settings_defaults_seeds_fresh_file() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().to_path_buf();
+
+        ensure_settings_defaults(&cfg).unwrap();
+
+        let text = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            val["outputStyle"].as_str(),
+            Some(crate::core::session_launch::OUTPUT_STYLE),
+            "outputStyle must be seeded with the tm default id"
+        );
+        let status_line = &val["statusLine"];
+        assert_eq!(status_line["type"].as_str(), Some("command"));
+        assert_eq!(status_line["padding"].as_i64(), Some(0));
+        assert!(
+            status_line["command"]
+                .as_str()
+                .is_some_and(|c| c.ends_with(" statusline")),
+            "statusLine.command must resolve to '<abs path> statusline', got {:?}",
+            status_line["command"]
+        );
+    }
+
+    #[test]
+    fn ensure_settings_defaults_preserves_existing_keys() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().to_path_buf();
+        std::fs::write(
+            cfg.join("settings.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "theme": "dark",
+                "model": "opusplan",
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        ensure_settings_defaults(&cfg).unwrap();
+
+        let text = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            val["theme"].as_str(),
+            Some("dark"),
+            "unrelated key preserved"
+        );
+        assert_eq!(
+            val["model"].as_str(),
+            Some("opusplan"),
+            "unrelated key preserved"
+        );
+        assert_eq!(
+            val["outputStyle"].as_str(),
+            Some(crate::core::session_launch::OUTPUT_STYLE)
+        );
+        assert!(val["statusLine"].is_object());
+    }
+
+    #[test]
+    fn ensure_settings_defaults_does_not_overwrite_customized_values() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().to_path_buf();
+        std::fs::write(
+            cfg.join("settings.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "outputStyle": "teaching",
+                "statusLine": { "type": "command", "command": "my-custom-line", "padding": 2 },
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        ensure_settings_defaults(&cfg).unwrap();
+
+        let text = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            val["outputStyle"].as_str(),
+            Some("teaching"),
+            "a pre-existing outputStyle must never be clobbered"
+        );
+        assert_eq!(
+            val["statusLine"]["command"].as_str(),
+            Some("my-custom-line"),
+            "a pre-existing statusLine must never be clobbered"
+        );
+        assert_eq!(val["statusLine"]["padding"].as_i64(), Some(2));
+    }
+
+    #[test]
+    fn ensure_settings_defaults_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().to_path_buf();
+
+        ensure_settings_defaults(&cfg).unwrap();
+        let bytes_first = std::fs::read(cfg.join("settings.json")).unwrap();
+
+        ensure_settings_defaults(&cfg).unwrap();
+        let bytes_second = std::fs::read(cfg.join("settings.json")).unwrap();
+
+        assert_eq!(
+            bytes_first, bytes_second,
+            "a second call must not rewrite the file when nothing changed"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Makes the tm-owned CLAUDE_CONFIG_DIR settings.json self-sufficient for outputStyle/statusLine as defense-in-depth, independent of the project tier and `--setting-sources project,local`. Non-destructive merge preserves client-persisted keys (theme/tui/etc.).

New module `settings_defaults.rs` with `ensure_settings_defaults`; reuses `OUTPUT_STYLE` and `resolve_statusline_command()` from session_launch.

## Quality Gate Status

- `cargo build --workspace` clean
- `cargo test --workspace` all pass except pre-existing/unrelated `banner::two_panel::right_col_no_inner_border` test
- `cargo clippy --workspace --all-targets -D warnings` exit 0
- `cargo fmt --check` clean
- `check_line_cap.sh` OK

Closes #2214

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools