### PR TITLE
fix(trusty-code): parse OpenRouter cache-usage shape + prefer authoritative cost (closes #2213)

### DIFF
--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -40,8 +40,8 @@ use std::time::Duration;
 use serde_json::Value;
 
 use crate::llm::{
-    CacheControl, ChatMessage, ChatRequest, ChatResponse, LlmClientTrait, ToolCall,
-    ToolCallExtractError, ToolCallExtractor, ToolDefinition,
+    CacheControl, ChatMessage, ChatRequest, ChatResponse, LlmClientTrait, RequestUsageConfig,
+    ToolCall, ToolCallExtractError, ToolCallExtractor, ToolDefinition,
 };
 use crate::mode::HarnessMode;
 use crate::perf::PerfCollector;
@@ -436,13 +436,21 @@ impl AgentLoop {
     /// prompt-cache breakpoint — the byte-stable prefix this turn resends
     /// unchanged from the last. When `false` (Parity mode, or a
     /// provider/model that hasn't verified the passthrough), the request is
-    /// byte-identical to pre-#2156.
+    /// byte-identical to pre-#2156. Independently, when the resolved
+    /// provider's `Provider::wants_detailed_usage()` is `true` (currently
+    /// OpenRouter, unconditionally), attaches
+    /// `usage: Some(RequestUsageConfig::detailed())` so the response carries
+    /// OpenRouter's authoritative `cost` and cache-token breakdown (the
+    /// response-side cache-usage fix).
     /// Test: Exercised by every loop test; `config_max_tokens_reaches_chat_request`
     /// pins that a configured cap flows through unchanged;
     /// `daily_driver_anthropic_model_marks_cache_breakpoints` and
-    /// `parity_mode_never_marks_cache_breakpoints` cover the #2156 gate.
+    /// `parity_mode_never_marks_cache_breakpoints` cover the #2156 gate;
+    /// `build_request_sets_detailed_usage_for_openrouter` covers the
+    /// detailed-usage gate.
     fn build_request(&self, transcript: &Transcript, schemas: &[ToolDefinition]) -> ChatRequest {
         let cache_prefix = self.prompt_cache_enabled();
+        let provider = crate::provider::provider_for(&self.config.model);
 
         let tools = if schemas.is_empty() {
             None
@@ -460,6 +468,10 @@ impl AgentLoop {
             mark_cache_breakpoint_on_system(&mut messages);
         }
 
+        let usage = provider
+            .wants_detailed_usage()
+            .then(RequestUsageConfig::detailed);
+
         ChatRequest {
             model: self.config.model.clone(),
             messages,
@@ -467,6 +479,7 @@ impl AgentLoop {
             max_tokens: Some(self.config.max_tokens),
             tools,
             tool_choice,
+            usage,
         }
     }
 

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -48,6 +48,11 @@ struct ScriptedLlm {
     /// carries a `cache_control` breakpoint without reaching into
     /// `AgentLoop` internals.
     tools_seen: Mutex<Vec<Option<Vec<crate::llm::ToolDefinition>>>>,
+    /// Every request's `usage` directive, in call order — lets the
+    /// detailed-usage gate test inspect whether `RequestUsageConfig::detailed`
+    /// reached the wire without reaching into `AgentLoop` internals
+    /// (response-side cache-usage fix).
+    usage_seen: Mutex<Vec<Option<crate::llm::RequestUsageConfig>>>,
 }
 
 impl ScriptedLlm {
@@ -68,6 +73,7 @@ impl ScriptedLlm {
             requests: Mutex::new(Vec::new()),
             max_tokens_seen: Mutex::new(Vec::new()),
             tools_seen: Mutex::new(Vec::new()),
+            usage_seen: Mutex::new(Vec::new()),
         }
     }
 
@@ -116,6 +122,17 @@ impl ScriptedLlm {
     fn tools_seen(&self) -> Vec<Option<Vec<crate::llm::ToolDefinition>>> {
         self.tools_seen.lock().expect("lock").clone()
     }
+
+    /// Every request's `usage` directive, in call order (response-side
+    /// cache-usage fix).
+    ///
+    /// Why: The detailed-usage gate test needs to see exactly what
+    /// `ChatRequest.usage` reached the wire on a given turn.
+    /// What: Clones the recorded `usage` values.
+    /// Test: `build_request_sets_detailed_usage_for_openrouter`.
+    fn usage_seen(&self) -> Vec<Option<crate::llm::RequestUsageConfig>> {
+        self.usage_seen.lock().expect("lock").clone()
+    }
 }
 
 #[async_trait]
@@ -129,6 +146,9 @@ impl LlmClientTrait for ScriptedLlm {
         }
         if let Ok(mut guard) = self.tools_seen.lock() {
             guard.push(req.tools.clone());
+        }
+        if let Ok(mut guard) = self.usage_seen.lock() {
+            guard.push(req.usage.clone());
         }
         let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
         match self.responses.get(idx) {
@@ -1479,5 +1499,61 @@ async fn non_anthropic_model_never_marks_cache_breakpoints() {
     assert!(
         last_tool.function.cache_control.is_none(),
         "non-Anthropic models must never carry a cache breakpoint on the tools array"
+    );
+}
+
+/// `build_request` attaches OpenRouter's detailed-usage directive
+/// (`RequestUsageConfig::detailed`) for an OpenRouter-routed model, but never
+/// for a Bedrock-routed model (response-side cache-usage fix).
+///
+/// Why: This is the request-side half of the fix that makes OpenRouter return
+/// its authoritative `usage.cost` and cache-token breakdown — without it,
+/// only the bare prompt/completion/total counts are guaranteed. It must stay
+/// gated per-provider so the direct/Bedrock path never receives a directive
+/// it doesn't understand.
+/// What: Run the loop once against `"anthropic/claude-sonnet-4-5"` (routes to
+/// OpenRouter) and once against `"bedrock/us.anthropic.claude-sonnet-4-5"`
+/// (routes to Bedrock); assert the recorded `usage` directive is
+/// `Some(RequestUsageConfig::detailed())` for the former and `None` for the
+/// latter.
+/// Test: this test.
+#[tokio::test]
+async fn build_request_sets_detailed_usage_for_openrouter() {
+    let or_llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let or_agent = make_loop(
+        or_llm.clone(),
+        registry_with_echo(false),
+        AgentLoopConfig {
+            model: "anthropic/claude-sonnet-4-5".into(),
+            ..AgentLoopConfig::default()
+        },
+    );
+    or_agent
+        .run("you are a helpful assistant", "do the thing")
+        .await
+        .expect("single stop turn should complete");
+    assert_eq!(
+        or_llm.usage_seen()[0],
+        Some(crate::llm::RequestUsageConfig::detailed()),
+        "OpenRouter-routed requests must carry the detailed-usage directive"
+    );
+
+    let bedrock_llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let bedrock_agent = make_loop(
+        bedrock_llm.clone(),
+        registry_with_echo(false),
+        AgentLoopConfig {
+            model: "bedrock/us.anthropic.claude-sonnet-4-5".into(),
+            ..AgentLoopConfig::default()
+        },
+    );
+    bedrock_agent
+        .run("you are a helpful assistant", "do the thing")
+        .await
+        .expect("single stop turn should complete");
+    assert_eq!(
+        bedrock_llm.usage_seen()[0],
+        None,
+        "Bedrock-routed requests must never carry the OpenRouter-only detailed-usage directive"
     );
 }

--- a/crates/trusty-code/src/ipc/mod.rs
+++ b/crates/trusty-code/src/ipc/mod.rs
@@ -67,7 +67,7 @@ impl HistoryMessage {
 /// Error (sub -> PM failure). All carry a correlation `id`.
 /// Test: Serialize each variant, assert the `"type"` tag matches; parse back
 /// and assert structural equality.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum IpcMessage {
     /// PM -> sub-agent: new task to execute.

--- a/crates/trusty-code/src/llm/client.rs
+++ b/crates/trusty-code/src/llm/client.rs
@@ -299,6 +299,7 @@ mod tests {
             max_tokens: Some(16),
             tools: None,
             tool_choice: None,
+            usage: None,
         };
 
         let resp = client.chat(&req).await.expect("chat call succeeded");

--- a/crates/trusty-code/src/llm/mod.rs
+++ b/crates/trusty-code/src/llm/mod.rs
@@ -29,7 +29,8 @@ pub use client_trait::LlmClientTrait;
 pub use error::LlmError;
 pub use message::ChatMessage;
 pub use request::{
-    CacheControl, ChatRequest, FunctionCall, FunctionDefinition, ToolCall, ToolDefinition,
+    CacheControl, ChatRequest, FunctionCall, FunctionDefinition, RequestUsageConfig, ToolCall,
+    ToolDefinition,
 };
 pub use response::{AssistantMessage, ChatChoice, ChatResponse};
 pub use tool_call_extractor::{

--- a/crates/trusty-code/src/llm/request.rs
+++ b/crates/trusty-code/src/llm/request.rs
@@ -49,6 +49,38 @@ impl CacheControl {
     }
 }
 
+/// OpenRouter's request-side "return detailed usage" directive (response-side
+/// cache-usage fix).
+///
+/// Why: Requesting detailed usage accounting is what makes OpenRouter return
+/// its authoritative, already cache-discount-aware `usage.cost` field (and
+/// the nested `prompt_tokens_details` cache counters) on the response —
+/// without it, only the bare prompt/completion/total counts are guaranteed.
+/// Sent only for the OpenRouter provider (`agent_loop::build_request`); other
+/// providers (direct/Bedrock) never see this field.
+/// What: `include: true` serialises to the wire shape `{"include":true}`
+/// under the request's top-level `usage` key.
+/// Test: `request_usage_config_detailed_serialises_expected_shape`,
+/// `chat_request_with_detailed_usage_serialises`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RequestUsageConfig {
+    /// Whether to request detailed (cost + cache-breakdown) usage accounting.
+    pub include: bool,
+}
+
+impl RequestUsageConfig {
+    /// Construct the "include detailed usage" directive.
+    ///
+    /// Why: Every call site wants the identical `{"include":true}` value;
+    /// naming the constructor after the wire concept avoids a bare `true`
+    /// literal scattered at call sites.
+    /// What: Returns `RequestUsageConfig { include: true }`.
+    /// Test: `request_usage_config_detailed_serialises_expected_shape`.
+    pub fn detailed() -> Self {
+        Self { include: true }
+    }
+}
+
 // ── Tool-calling types ─────────────────────────────────────────────────────────
 
 /// A tool call emitted by the model.
@@ -189,6 +221,13 @@ pub struct ChatRequest {
     /// function selector.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<serde_json::Value>,
+
+    /// Request OpenRouter's detailed usage accounting (response-side
+    /// cache-usage fix). `Some(RequestUsageConfig::detailed())` for the
+    /// OpenRouter provider; `None` (omitted from the wire payload) for every
+    /// other provider/path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<RequestUsageConfig>,
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -213,6 +252,7 @@ mod tests {
             max_tokens: None,
             tools: None,
             tool_choice: None,
+            usage: None,
         };
         let v: serde_json::Value = serde_json::to_value(&req).expect("serialise");
         assert_eq!(v["model"], "anthropic/claude-haiku-4-5");
@@ -220,6 +260,10 @@ mod tests {
         assert_eq!(v["messages"][0]["content"], "hello");
         assert!(v.get("temperature").is_none() || v["temperature"].is_null());
         assert!(v.get("tools").is_none() || v["tools"].is_null());
+        assert!(
+            v.get("usage").is_none() || v["usage"].is_null(),
+            "usage must be omitted when unset"
+        );
     }
 
     /// `ChatRequest` with tools serialises the `tools` and `tool_choice` fields.
@@ -248,6 +292,7 @@ mod tests {
             max_tokens: Some(256),
             tools: Some(vec![tool]),
             tool_choice: Some(serde_json::json!("auto")),
+            usage: None,
         };
         let v: serde_json::Value = serde_json::to_value(&req).expect("serialise");
         assert_eq!(v["tools"][0]["type"], "function");
@@ -255,6 +300,56 @@ mod tests {
         assert_eq!(v["tool_choice"], "auto");
         assert_eq!(v["temperature"], 0.0_f32);
         assert_eq!(v["max_tokens"], 256);
+    }
+
+    /// `RequestUsageConfig::detailed` serialises to the exact
+    /// `{"include":true}` shape OpenRouter expects.
+    ///
+    /// Why: A typo (wrong key, wrong value) would silently disable detailed
+    /// usage accounting without any test noticing — the same failure mode
+    /// `cache_control_ephemeral_serialises_expected_shape` guards against.
+    /// What: Serialise `RequestUsageConfig::detailed()`, assert the exact
+    /// object.
+    /// Test: this test.
+    #[test]
+    fn request_usage_config_detailed_serialises_expected_shape() {
+        let v = serde_json::to_value(RequestUsageConfig::detailed()).expect("serialise");
+        assert_eq!(v, serde_json::json!({"include": true}));
+    }
+
+    /// A `ChatRequest` with `usage` set serialises the top-level `"usage"`
+    /// key; a request with `usage: None` omits it entirely (response-side
+    /// cache-usage fix — gated to the OpenRouter provider only).
+    ///
+    /// Why: `agent_loop::build_request` must only attach this directive for
+    /// OpenRouter; verifying both the present and absent cases in one test
+    /// pins the exact wire contract other providers must never see.
+    /// What: Serialise a request with `usage: Some(...)`, assert the field;
+    /// serialise one with `usage: None`, assert it's absent.
+    /// Test: this test.
+    #[test]
+    fn chat_request_with_detailed_usage_serialises() {
+        let with_usage = ChatRequest {
+            model: "anthropic/claude-sonnet-4-5".into(),
+            messages: vec![ChatMessage::user("hi")],
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            tool_choice: None,
+            usage: Some(RequestUsageConfig::detailed()),
+        };
+        let v: serde_json::Value = serde_json::to_value(&with_usage).expect("serialise");
+        assert_eq!(v["usage"], serde_json::json!({"include": true}));
+
+        let without_usage = ChatRequest {
+            usage: None,
+            ..with_usage
+        };
+        let v: serde_json::Value = serde_json::to_value(&without_usage).expect("serialise");
+        assert!(
+            v.get("usage").is_none() || v["usage"].is_null(),
+            "usage must be omitted when None"
+        );
     }
 
     /// `ToolDefinition::function` sets `kind = "function"`.

--- a/crates/trusty-code/src/llm/usage.rs
+++ b/crates/trusty-code/src/llm/usage.rs
@@ -5,20 +5,59 @@
 //! easy to audit and test in isolation.
 //! What: Defines `UsageBlock` (the wire representation) and its conversion to
 //! the crate's `TokenUsage`.
-//! Test: `usage_block_maps_to_token_usage`, `default_usage_block_is_zero`.
+//! Test: `usage_block_maps_to_token_usage`, `default_usage_block_is_zero`,
+//! `usage_block_maps_openrouter_prompt_tokens_details`,
+//! `usage_block_prefers_authoritative_cost`.
 
 use serde::Deserialize;
 
 use crate::perf::TokenUsage;
+
+/// OpenRouter/OpenAI-shaped nested cache-accounting object (closes the
+/// response-side gap blocking #2156's cost validation).
+///
+/// Why: Anthropic-native responses report cache tokens as flat
+/// `cache_read_input_tokens` / `cache_creation_input_tokens` fields, but
+/// OpenRouter's own usage-accounting normalisation (verified against
+/// OpenRouter's `usage-accounting` docs) nests them instead under
+/// `prompt_tokens_details`, using the OpenAI-style names `cached_tokens` (read)
+/// and `cache_write_tokens` (write). Without parsing this shape, `UsageBlock`'s
+/// `#[serde(default)]` cache fields silently stayed zero on every OpenRouter
+/// call — cache_read/cache_creation always reported 0 and cost never reflected
+/// the cache discount, even though the request-side `cache_control` marker
+/// (#2156) was being honoured upstream.
+/// What: Carries the two cache counters OpenRouter reports; `audio_tokens` is
+/// deliberately not modelled (irrelevant to this crate's text-only usage).
+/// Test: `usage_block_maps_openrouter_prompt_tokens_details`.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PromptTokensDetails {
+    /// Prompt tokens served from the cache (OpenRouter's OpenAI-style name for
+    /// what Anthropic calls `cache_read_input_tokens`).
+    #[serde(default)]
+    pub cached_tokens: u32,
+
+    /// Prompt tokens newly written into the cache this turn (OpenRouter's
+    /// OpenAI-style name for what Anthropic calls
+    /// `cache_creation_input_tokens`).
+    #[serde(default)]
+    pub cache_write_tokens: u32,
+}
 
 /// Token usage block from the API response.
 ///
 /// Why: Mapping the wire `usage` object to our internal `TokenUsage` is easiest
 /// when we first deserialise into this intermediate struct.
 /// What: Carries `prompt_tokens`, `completion_tokens`, and `total_tokens` from
-/// the wire; optional Anthropic-specific cache fields (present on Anthropic
-/// models routed via OpenRouter).
-/// Test: `usage_block_maps_to_token_usage`.
+/// the wire; optional Anthropic-native cache fields (flat
+/// `cache_read_input_tokens` / `cache_creation_input_tokens`, present on the
+/// direct/Bedrock path) AND the OpenRouter-shaped nested
+/// `prompt_tokens_details` object — both are accepted so either provider's
+/// wire shape populates the canonical `TokenUsage` cache fields. `cost` is
+/// OpenRouter's authoritative, already-discounted USD cost for the call (only
+/// present when OpenRouter includes detailed usage accounting).
+/// Test: `usage_block_maps_to_token_usage`,
+/// `usage_block_maps_openrouter_prompt_tokens_details`,
+/// `usage_block_prefers_authoritative_cost`.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct UsageBlock {
     /// Tokens consumed by the prompt (including cached tokens).
@@ -33,31 +72,71 @@ pub struct UsageBlock {
     #[serde(default)]
     pub total_tokens: u32,
 
-    /// Anthropic-only: prompt tokens served from the cache (not re-computed).
+    /// Anthropic-native (direct/Bedrock path): prompt tokens served from the
+    /// cache (not re-computed).
     #[serde(default)]
     pub cache_read_input_tokens: u32,
 
-    /// Anthropic-only: prompt tokens written into the cache this turn.
+    /// Anthropic-native (direct/Bedrock path): prompt tokens written into the
+    /// cache this turn.
     #[serde(default)]
     pub cache_creation_input_tokens: u32,
+
+    /// OpenRouter-shaped nested cache counters (OpenAI wire style). `None`
+    /// when the provider reports the flat Anthropic-native fields instead (or
+    /// omits cache accounting entirely).
+    #[serde(default)]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
+
+    /// OpenRouter's authoritative total USD cost for this call, already
+    /// netting any cache discount. `None` for providers that don't report it
+    /// (direct/Bedrock) or when OpenRouter's detailed-usage accounting wasn't
+    /// returned.
+    #[serde(default)]
+    pub cost: Option<f64>,
 }
 
 impl UsageBlock {
     /// Convert this wire usage block into the crate's `TokenUsage`.
     ///
     /// Why: `PerfCollector` speaks `TokenUsage`; this conversion centralises the
-    /// mapping so callers don't need to know the wire field names.
-    /// What: Maps `prompt_tokens` → `prompt_tokens`, `completion_tokens` →
-    /// `completion_tokens`, `cache_read_input_tokens` → `cache_read_tokens`,
-    /// `cache_creation_input_tokens` → `cache_creation_tokens`.
-    /// Test: `usage_block_maps_to_token_usage`.
+    /// mapping so callers don't need to know the wire field names, and merges
+    /// whichever of the two wire cache shapes (Anthropic-native flat fields vs.
+    /// OpenRouter's nested `prompt_tokens_details`) the provider populated.
+    /// What: `cache_read_tokens` is `cache_read_input_tokens` when non-zero,
+    /// else `prompt_tokens_details.cached_tokens`; `cache_creation_tokens`
+    /// follows the same fallback using `cache_creation_input_tokens` /
+    /// `cache_write_tokens`. `cost_usd` on the resulting `TokenUsage` carries
+    /// `self.cost` verbatim so callers can prefer OpenRouter's authoritative,
+    /// cache-aware price over a static per-token recompute.
+    /// Test: `usage_block_maps_to_token_usage`,
+    /// `usage_block_maps_openrouter_prompt_tokens_details`,
+    /// `usage_block_prefers_authoritative_cost`.
     pub fn into_token_usage(self) -> TokenUsage {
-        TokenUsage::new(
+        let (details_read, details_write) = self
+            .prompt_tokens_details
+            .map(|d| (d.cached_tokens, d.cache_write_tokens))
+            .unwrap_or((0, 0));
+
+        let cache_read = if self.cache_read_input_tokens != 0 {
+            self.cache_read_input_tokens
+        } else {
+            details_read
+        };
+        let cache_creation = if self.cache_creation_input_tokens != 0 {
+            self.cache_creation_input_tokens
+        } else {
+            details_write
+        };
+
+        let mut usage = TokenUsage::new(
             self.prompt_tokens,
             self.completion_tokens,
-            self.cache_read_input_tokens,
-            self.cache_creation_input_tokens,
-        )
+            cache_read,
+            cache_creation,
+        );
+        usage.cost_usd = self.cost;
+        usage
     }
 }
 
@@ -81,12 +160,15 @@ mod tests {
             total_tokens: 150,
             cache_read_input_tokens: 20,
             cache_creation_input_tokens: 10,
+            prompt_tokens_details: None,
+            cost: None,
         };
         let usage = block.into_token_usage();
         assert_eq!(usage.prompt_tokens, 100);
         assert_eq!(usage.completion_tokens, 50);
         assert_eq!(usage.cache_read_tokens, 20);
         assert_eq!(usage.cache_creation_tokens, 10);
+        assert_eq!(usage.cost_usd, None);
     }
 
     /// Default `UsageBlock` produces a zero `TokenUsage`.
@@ -102,5 +184,82 @@ mod tests {
         assert_eq!(usage.completion_tokens, 0);
         assert_eq!(usage.cache_read_tokens, 0);
         assert_eq!(usage.cache_creation_tokens, 0);
+        assert_eq!(usage.cost_usd, None);
+    }
+
+    /// An OpenRouter-shaped `usage` block (nested `prompt_tokens_details`,
+    /// NEITHER flat Anthropic-native cache field present) deserialises into a
+    /// non-zero `cache_read_tokens` / `cache_creation_tokens` — the exact gap
+    /// that made #2156's OpenRouter-path cache accounting always report 0.
+    ///
+    /// Why: This is the empirically observed shape from the bake-off pilot:
+    /// OpenRouter reports cache accounting under
+    /// `prompt_tokens_details: { cached_tokens, cache_write_tokens }`, not the
+    /// Anthropic-native flat fields.
+    /// What: Deserialise the OpenRouter-shaped fixture, assert cache_read /
+    /// cache_creation map from the nested object.
+    /// Test: this test.
+    #[test]
+    fn usage_block_maps_openrouter_prompt_tokens_details() {
+        let fixture = r#"{
+          "prompt_tokens": 1200,
+          "completion_tokens": 80,
+          "total_tokens": 1280,
+          "prompt_tokens_details": {"cached_tokens": 900, "cache_write_tokens": 300}
+        }"#;
+        let block: UsageBlock = serde_json::from_str(fixture).expect("deserialise");
+        let usage = block.into_token_usage();
+        assert_eq!(usage.prompt_tokens, 1200);
+        assert_eq!(usage.completion_tokens, 80);
+        assert_eq!(usage.cache_read_tokens, 900);
+        assert_eq!(usage.cache_creation_tokens, 300);
+    }
+
+    /// The Anthropic-native flat shape still deserialises and maps correctly
+    /// when both wire shapes are theoretically present (flat fields win, since
+    /// they are the shape this crate has verified against the direct/Bedrock
+    /// path).
+    ///
+    /// Why: The fix must not regress the pre-existing direct/Bedrock parsing
+    /// path while adding OpenRouter support.
+    /// What: Deserialise a fixture with only the Anthropic-native flat fields
+    /// set, assert they map through unchanged.
+    /// Test: this test.
+    #[test]
+    fn usage_block_still_maps_anthropic_native_shape() {
+        let fixture = r#"{
+          "prompt_tokens": 500,
+          "completion_tokens": 20,
+          "total_tokens": 520,
+          "cache_read_input_tokens": 400,
+          "cache_creation_input_tokens": 50
+        }"#;
+        let block: UsageBlock = serde_json::from_str(fixture).expect("deserialise");
+        let usage = block.into_token_usage();
+        assert_eq!(usage.cache_read_tokens, 400);
+        assert_eq!(usage.cache_creation_tokens, 50);
+    }
+
+    /// When OpenRouter's authoritative `usage.cost` is present, it is carried
+    /// through onto `TokenUsage::cost_usd` verbatim (issue: cost never
+    /// reflected the cache discount because tcode recomputed from static
+    /// pricing instead of reading this field).
+    ///
+    /// Why: The static per-token pricing table cannot see the cache discount;
+    /// only OpenRouter's own `cost` field nets it correctly.
+    /// What: Deserialise a fixture with `cost` set, assert `cost_usd` matches.
+    /// Test: this test.
+    #[test]
+    fn usage_block_prefers_authoritative_cost() {
+        let fixture = r#"{
+          "prompt_tokens": 1200,
+          "completion_tokens": 80,
+          "total_tokens": 1280,
+          "prompt_tokens_details": {"cached_tokens": 900, "cache_write_tokens": 0},
+          "cost": 0.001234
+        }"#;
+        let block: UsageBlock = serde_json::from_str(fixture).expect("deserialise");
+        let usage = block.into_token_usage();
+        assert_eq!(usage.cost_usd, Some(0.001234));
     }
 }

--- a/crates/trusty-code/src/perf/mod.rs
+++ b/crates/trusty-code/src/perf/mod.rs
@@ -41,34 +41,54 @@ pub use pricing::cost_usd;
 /// and cache_creation_input_tokens alongside the standard prompt/completion
 /// counts. Exposing those as first-class fields lets `PerfCollector` track
 /// cache effectiveness over time. For non-Anthropic models these stay 0.
+/// `cost_usd` (response-side cache-usage fix) carries OpenRouter's
+/// authoritative, already cache-discounted USD cost for this one round-trip
+/// when the provider reported one; `None` means no authoritative cost was
+/// available and callers must fall back to static per-token pricing.
 /// What: Plain struct; additive (`+`-style) accumulation is done inline in
 /// `PerfCollector::totals`.
-/// Test: `token_usage_default_is_zeros`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// Test: `token_usage_default_is_zeros`, `token_usage_accumulates`,
+/// `token_usage_cost_accumulates`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
 pub struct TokenUsage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub cache_read_tokens: u32,
     pub cache_creation_tokens: u32,
+    /// Authoritative per-call USD cost reported by the provider (OpenRouter),
+    /// already netting any cache discount. `None` when unavailable.
+    #[serde(default)]
+    pub cost_usd: Option<f64>,
 }
 
 impl TokenUsage {
     /// Construct a `TokenUsage` from the four individual counts.
+    ///
+    /// Why: Most call sites (tests, static-pricing paths) don't have an
+    /// authoritative provider-reported cost; `cost_usd` starts `None` and
+    /// callers set it explicitly (e.g. `UsageBlock::into_token_usage`) when
+    /// one is available.
     pub fn new(prompt: u32, completion: u32, cache_read: u32, cache_creation: u32) -> Self {
         Self {
             prompt_tokens: prompt,
             completion_tokens: completion,
             cache_read_tokens: cache_read,
             cache_creation_tokens: cache_creation,
+            cost_usd: None,
         }
     }
 
     /// Add another usage record into this one (in place).
     ///
     /// Why: Each phase may comprise multiple LLM turns (tool loop); we sum
-    /// them into a single `PhaseRecord`.
-    /// What: Field-wise saturating add.
-    /// Test: `token_usage_accumulates`.
+    /// them into a single `PhaseRecord`. `cost_usd` sums the two authoritative
+    /// costs when both are present; when only one side carries a cost it is
+    /// preserved rather than discarded, and the sum is `None` only when
+    /// neither side has one — a partial per-turn cost is still meaningful
+    /// signal that must not silently disappear.
+    /// What: Field-wise saturating add for token counts; `Option<f64>` sum for
+    /// cost.
+    /// Test: `token_usage_accumulates`, `token_usage_cost_accumulates`.
     pub fn add(&mut self, other: &TokenUsage) {
         self.prompt_tokens = self.prompt_tokens.saturating_add(other.prompt_tokens);
         self.completion_tokens = self
@@ -80,6 +100,11 @@ impl TokenUsage {
         self.cache_creation_tokens = self
             .cache_creation_tokens
             .saturating_add(other.cache_creation_tokens);
+        self.cost_usd = match (self.cost_usd, other.cost_usd) {
+            (Some(a), Some(b)) => Some(a + b),
+            (Some(a), None) | (None, Some(a)) => Some(a),
+            (None, None) => None,
+        };
     }
 }
 
@@ -311,17 +336,23 @@ impl PerfCollector {
     ///
     /// Why: Engines call this once per phase with the agent model and the
     /// summed `TokenUsage` from all LLM turns in that phase.
-    /// What: Computes `cost_usd` via `cost_usd(model, ...)`, pushes a
+    /// What: Prefers `usage.cost_usd` (OpenRouter's authoritative,
+    /// cache-discount-aware cost) when the provider reported one; otherwise
+    /// falls back to the static per-token recompute via `cost_usd(model, ...)`
+    /// — the static table cannot see the cache discount, so it is a fallback
+    /// only, never a substitute when an authoritative figure exists. Pushes a
     /// `PhaseRecord`.
-    /// Test: `collector_records_phases`.
+    /// Test: `collector_records_phases`, `record_phase_prefers_authoritative_cost`.
     pub fn record_phase(&mut self, name: &str, duration_ms: u64, model: &str, usage: &TokenUsage) {
-        let cost = cost_usd(
-            model,
-            usage.prompt_tokens,
-            usage.completion_tokens,
-            usage.cache_read_tokens,
-            usage.cache_creation_tokens,
-        );
+        let cost = usage.cost_usd.unwrap_or_else(|| {
+            cost_usd(
+                model,
+                usage.prompt_tokens,
+                usage.completion_tokens,
+                usage.cache_read_tokens,
+                usage.cache_creation_tokens,
+            )
+        });
         self.phases.push(PhaseRecord {
             name: name.to_string(),
             duration_ms,

--- a/crates/trusty-code/src/perf/tests.rs
+++ b/crates/trusty-code/src/perf/tests.rs
@@ -24,6 +24,35 @@ fn token_usage_accumulates() {
     assert_eq!(a, TokenUsage::new(13, 12, 2, 5));
 }
 
+/// `TokenUsage::add` sums `cost_usd` when both sides have an authoritative
+/// cost, preserves the one present side when only one does, and stays `None`
+/// only when neither side has one.
+///
+/// Why: The response-side cache-usage fix threads OpenRouter's authoritative
+/// per-call `cost` through `TokenUsage`; accumulation across turns must not
+/// silently drop it.
+/// What: Exercise all three `(Some, Some)` / `(Some, None)` / `(None, None)`
+/// cases.
+/// Test: this test.
+#[test]
+fn token_usage_cost_accumulates() {
+    let mut both = TokenUsage::new(10, 5, 2, 1);
+    both.cost_usd = Some(0.01);
+    let mut other = TokenUsage::new(3, 7, 0, 4);
+    other.cost_usd = Some(0.02);
+    both.add(&other);
+    assert_eq!(both.cost_usd, Some(0.03));
+
+    let mut one_sided = TokenUsage::new(10, 5, 2, 1);
+    one_sided.cost_usd = Some(0.01);
+    one_sided.add(&TokenUsage::new(3, 7, 0, 4));
+    assert_eq!(one_sided.cost_usd, Some(0.01));
+
+    let mut neither = TokenUsage::new(10, 5, 2, 1);
+    neither.add(&TokenUsage::new(3, 7, 0, 4));
+    assert_eq!(neither.cost_usd, None);
+}
+
 #[test]
 fn cost_usd_known_sonnet() {
     // 1M prompt tokens of sonnet = $3.00
@@ -117,6 +146,26 @@ fn collector_records_phases() {
     assert!(r.totals.cost_usd > 0.0);
     assert_eq!(r.build, 7);
     assert_eq!(r.workflow, "prescriptive");
+}
+
+/// `record_phase` uses `usage.cost_usd` verbatim when the provider reported
+/// an authoritative cost, instead of recomputing from the static pricing
+/// table (which cannot see the cache discount).
+///
+/// Why: This is the exact behaviour the response-side cache-usage fix
+/// depends on to make OpenRouter's cache discount visible in the perf record.
+/// What: Record a phase with a `TokenUsage` carrying a deliberately
+/// implausible static-vs-authoritative mismatch cost, assert the phase's
+/// `cost_usd` is the authoritative value, not the static recompute.
+/// Test: this test.
+#[test]
+fn record_phase_prefers_authoritative_cost() {
+    let mut c = PerfCollector::new(1, "wf", "task");
+    let mut usage = TokenUsage::new(1_000_000, 0, 0, 0);
+    usage.cost_usd = Some(0.000001); // far below the static per-token price
+    c.record_phase("turn", 10, "anthropic/claude-sonnet-4-5", &usage);
+    let r = c.build_record();
+    assert_eq!(r.phases[0].cost_usd, 0.000001);
 }
 
 #[test]

--- a/crates/trusty-code/src/provider/bedrock.rs
+++ b/crates/trusty-code/src/provider/bedrock.rs
@@ -77,6 +77,14 @@ impl Provider for BedrockProvider {
         // interpret.
         false
     }
+
+    fn wants_detailed_usage(&self) -> bool {
+        // `RequestUsageConfig`/`usage: {"include": true}` is an
+        // OpenRouter-specific OpenAI-compat wire directive; Bedrock's
+        // Converse API reports usage in its own response envelope entirely,
+        // so this must stay `false` until the real Bedrock integration lands.
+        false
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -117,6 +125,19 @@ mod tests {
     #[test]
     fn bedrock_does_not_support_prompt_caching() {
         assert!(!BedrockProvider::new().supports_prompt_caching());
+    }
+
+    /// Bedrock does NOT request OpenRouter-style detailed usage accounting
+    /// (response-side cache-usage fix).
+    ///
+    /// Why: `usage: {"include": true}` is an OpenRouter-only OpenAI-compat
+    /// directive; sending it to Bedrock (once implemented) would be a
+    /// meaningless no-op at best.
+    /// What: Assert `wants_detailed_usage()` is `false`.
+    /// Test: this test.
+    #[test]
+    fn bedrock_does_not_want_detailed_usage() {
+        assert!(!BedrockProvider::new().wants_detailed_usage());
     }
 
     /// `map_tool_choice` panics while stubbed.

--- a/crates/trusty-code/src/provider/openrouter.rs
+++ b/crates/trusty-code/src/provider/openrouter.rs
@@ -103,6 +103,16 @@ impl Provider for OpenRouterProvider {
     fn supports_prompt_caching(&self) -> bool {
         slug_supports_prompt_caching(&self.slug)
     }
+
+    fn wants_detailed_usage(&self) -> bool {
+        // Unconditional for every OpenRouter-routed model (unlike prompt
+        // caching, which is verified only for `anthropic/*` slugs): detailed
+        // usage accounting is a wire-format directive OpenRouter honours
+        // uniformly across model families, and the response-side parsing in
+        // `UsageBlock` degrades gracefully (falls back to static pricing)
+        // when a particular upstream model/route doesn't populate `cost`.
+        true
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -253,6 +263,30 @@ mod tests {
             assert!(
                 !OpenRouterProvider::new(slug).supports_prompt_caching(),
                 "expected NO prompt-caching support for {slug}"
+            );
+        }
+    }
+
+    /// Every OpenRouter-routed slug requests detailed usage accounting
+    /// (response-side cache-usage fix).
+    ///
+    /// Why: Unlike prompt caching, detailed usage accounting isn't gated to
+    /// a specific model family — it must be requested for every OpenRouter
+    /// call so `usage.cost` and cache counters are available whenever the
+    /// upstream route supports them.
+    /// What: Construct providers for a representative spread of families,
+    /// assert `wants_detailed_usage() == true` for all of them.
+    /// Test: this test.
+    #[test]
+    fn wants_detailed_usage_is_true() {
+        for slug in [
+            "anthropic/claude-sonnet-4-5",
+            "openai/gpt-4o-mini",
+            "qwen/qwen-2.5-coder-32b-instruct",
+        ] {
+            assert!(
+                OpenRouterProvider::new(slug).wants_detailed_usage(),
+                "expected detailed-usage request for {slug}"
             );
         }
     }

--- a/crates/trusty-code/src/provider/traits.rs
+++ b/crates/trusty-code/src/provider/traits.rs
@@ -100,4 +100,22 @@ pub trait Provider: Send + Sync {
     /// Test: `openrouter::tests::supports_prompt_caching_*`,
     /// `bedrock::tests::bedrock_does_not_support_prompt_caching`.
     fn supports_prompt_caching(&self) -> bool;
+
+    /// Whether this backend should be asked for detailed usage accounting
+    /// (response-side cache-usage fix).
+    ///
+    /// Why: OpenRouter's detailed-usage directive
+    /// (`RequestUsageConfig::detailed`, `usage: {"include": true}`) is what
+    /// makes OpenRouter return its authoritative, cache-discount-aware
+    /// `usage.cost` and the nested `prompt_tokens_details` cache counters —
+    /// without it only the bare prompt/completion/total counts are
+    /// guaranteed. This is an OpenRouter-specific wire directive with no
+    /// equivalent on the direct/Bedrock path, so it must stay gated per
+    /// backend rather than sent unconditionally.
+    /// What: Returns `true` when `agent_loop::build_request` should attach
+    /// `ChatRequest.usage = Some(RequestUsageConfig::detailed())`; `false`
+    /// otherwise.
+    /// Test: `openrouter::tests::wants_detailed_usage_is_true`,
+    /// `bedrock::tests::bedrock_does_not_want_detailed_usage`.
+    fn wants_detailed_usage(&self) -> bool;
 }

--- a/crates/trusty-code/src/run_task/recorder.rs
+++ b/crates/trusty-code/src/run_task/recorder.rs
@@ -38,7 +38,7 @@ use crate::perf::TokenUsage;
 /// `tcode`'s CLI thin client parse a `session.get_transcript` JSON-RPC result
 /// straight back into `Vec<TurnRecord>`.
 /// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TurnRecord {
     /// Agent label that produced this turn (e.g. `"pm"`, `"python-engineer"`).
     pub role: String,

--- a/crates/trusty-code/src/run_task/report.rs
+++ b/crates/trusty-code/src/run_task/report.rs
@@ -214,11 +214,16 @@ impl RunReport {
 /// applied for the daemon path (#2056); this is now the ONE shared
 /// implementation both paths call, so they can never independently drift.
 /// What: Field-wise sums each turn's `usage` into a single `TokenUsage`
-/// (unchanged), but computes cost PER TURN using `pm_model` for
-/// `role == "pm"` and `engineer_model` otherwise, then sums the per-turn
-/// costs. Returns `(total_usage, cost)`.
+/// (unchanged). Per turn, PREFERS the turn's own `usage.cost_usd` —
+/// OpenRouter's authoritative, already cache-discount-aware cost
+/// (response-side cache-usage fix) — when present; only falls back to the
+/// static per-token recompute (priced per role: `pm_model` for
+/// `role == "pm"`, `engineer_model` otherwise) when the turn carries no
+/// authoritative cost. Sums the per-turn costs. Returns `(total_usage,
+/// cost)`.
 /// Test: `run_task::tests::usage_and_cost_aggregate_end_to_end`,
-/// `report::tests::aggregate_usage_per_role_prices_each_role_separately`.
+/// `report::tests::aggregate_usage_per_role_prices_each_role_separately`,
+/// `report::tests::aggregate_usage_per_role_prefers_authoritative_cost`.
 pub fn aggregate_usage_per_role(
     turns: &[TurnRecord],
     pm_model: &str,
@@ -228,18 +233,20 @@ pub fn aggregate_usage_per_role(
     let mut cost = 0.0;
     for turn in turns {
         total.add(&turn.usage);
-        let model = if turn.role == "pm" {
-            pm_model
-        } else {
-            engineer_model
-        };
-        cost += crate::perf::cost_usd(
-            model,
-            turn.usage.prompt_tokens,
-            turn.usage.completion_tokens,
-            turn.usage.cache_read_tokens,
-            turn.usage.cache_creation_tokens,
-        );
+        cost += turn.usage.cost_usd.unwrap_or_else(|| {
+            let model = if turn.role == "pm" {
+                pm_model
+            } else {
+                engineer_model
+            };
+            crate::perf::cost_usd(
+                model,
+                turn.usage.prompt_tokens,
+                turn.usage.completion_tokens,
+                turn.usage.cache_read_tokens,
+                turn.usage.cache_creation_tokens,
+            )
+        });
     }
     (total, cost)
 }
@@ -416,6 +423,51 @@ mod tests {
         assert_ne!(
             per_role_cost, blended_cost,
             "per-role pricing must differ from blending everything under the PM model"
+        );
+    }
+
+    /// `aggregate_usage_per_role` prefers a turn's own authoritative
+    /// `usage.cost_usd` over the static per-token recompute (response-side
+    /// cache-usage fix).
+    ///
+    /// Why: The static pricing table cannot see OpenRouter's cache discount;
+    /// only the provider-reported `cost` reflects it. This is the exact gap
+    /// that made #2156's cost thesis unverifiable end-to-end.
+    /// What: One turn carries an authoritative cost that is deliberately far
+    /// below what static pricing would compute for its token counts; one turn
+    /// carries no authoritative cost (static fallback). Assert the total cost
+    /// is exactly the authoritative value plus the static fallback for the
+    /// second turn — i.e. the first turn's static price is NOT used.
+    /// Test: this test.
+    #[test]
+    fn aggregate_usage_per_role_prefers_authoritative_cost() {
+        let mut authoritative_usage = TokenUsage::new(1_000_000, 0, 900_000, 100_000);
+        authoritative_usage.cost_usd = Some(0.0005); // far below static per-token price
+        let turns = vec![
+            TurnRecord {
+                role: "pm".into(),
+                model: "anthropic/claude-sonnet-4-5".into(),
+                text: String::new(),
+                tool_calls: vec![],
+                usage: authoritative_usage,
+            },
+            TurnRecord {
+                role: "python-engineer".into(),
+                model: "anthropic/claude-sonnet-4-5".into(),
+                text: "done".into(),
+                tool_calls: vec![],
+                usage: TokenUsage::new(100, 50, 0, 0),
+            },
+        ];
+        let (_, cost) = aggregate_usage_per_role(
+            &turns,
+            "anthropic/claude-sonnet-4-5",
+            "anthropic/claude-sonnet-4-5",
+        );
+        let expected_fallback = crate::perf::cost_usd("anthropic/claude-sonnet-4-5", 100, 50, 0, 0);
+        assert!(
+            (cost - (0.0005 + expected_fallback)).abs() < 1e-12,
+            "expected authoritative cost + static fallback, got {cost}"
         );
     }
 }

--- a/crates/trusty-code/src/task/mock_llm.rs
+++ b/crates/trusty-code/src/task/mock_llm.rs
@@ -201,6 +201,7 @@ mod tests {
             max_tokens: None,
             tools: None,
             tool_choice: None,
+            usage: None,
         };
 
         let turn1 = client.chat(&req).await.expect("turn 1");


### PR DESCRIPTION
Follow-up to #2156 (PR #2212): the request-side cache_control breakpoints were correct and Anthropic honors them over OpenRouter, but tcode couldn't READ the cache back — so cache_read/cache_creation were always 0 and cost never reflected the discount (M3 bake-off L1: cache=0 across all 42 turns).

Fix: `UsageBlock` now parses OpenRouter's nested `prompt_tokens_details.{cached_tokens→cache_read, cache_write_tokens→cache_creation}` alongside the Anthropic-native flat fields, plus `cost`. `TokenUsage` gained `cost_usd`; `record_phase`/`aggregate_usage_per_role` prefer OpenRouter's authoritative response cost (already cache-discounted) over static per-token pricing, with static as fallback. `ChatRequest` sends `usage:{include:true}` gated to OpenRouter (`Provider::wants_detailed_usage`) — harmless if OpenRouter treats it as a documented no-op.

QA: APPROVE (independent worktree at 025f0bfe) — build 0 warnings, 646 lib + 16 e2e tests pass, clippy/fmt clean, line-cap 0 violations, trusty-agents unaffected. OpenRouter+Anthropic usage shapes both parse correctly (no double-count/silent-zero), authoritative-cost preference with intact static fallback, Eq→PartialEq drop safe, no new library unwrap(); #2156/#2198/#2210 un-regressed. Empirical cache-hit validation follows via the bake-off L1 re-run.

Closes #2213