### PR TITLE
fix(trusty-embedderd): bound ONNX model-init so a provider hang fails loud (#1633)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6247,7 +6247,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10868,7 +10868,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-embedderd"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.2.0"
 trusty-common = { path = "crates/trusty-common", version = "0.22.0" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
-trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.4" }
+trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.5" }
 # trusty-bm25-daemon: per-palace BM25 lexical-index daemon — referenced by
 # trusty-memory so `cargo install trusty-memory` produces both binaries from
 # one command (mirrors the trusty-embedderd / trusty-search pattern, PR #190).

--- a/crates/trusty-embedderd/CHANGELOG.md
+++ b/crates/trusty-embedderd/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog — trusty-embedderd
 
+## [0.3.5] — 2026-07-07
+
+### Fixed (mitigation for #1633; toolchain root cause deferred to infra decision)
+
+- **Bounded model-init — fail loud instead of hanging forever.** The published
+  binary's `FastEmbedder::new()` model-load call had no timeout at all. On
+  Amazon Linux 2023 / glibc 2.34 hosts, ONNX Runtime CPU(no-arena)
+  execution-provider init deadlocks in `futex_wait_queue` indefinitely (0% CPU,
+  no error, no further log output) — the daemon would sit hung for hours with
+  no HTTP/stdio/UDS listener ever bound, silently degrading semantic search to
+  lexical-only with no signal to the operator. `run_with_args` now races the
+  model load against a bounded timeout (`readiness::run_bounded`, default
+  180 s, overridable via `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS`); on expiry the
+  process exits nonzero with a stderr message naming issue #1633 and the
+  remediation (raise the timeout, or reinstall with
+  `--features embedder-load-dynamic` + `ORT_DYLIB_PATH` on AL2023/older-glibc
+  hosts). Because every transport listener is only bound after model load
+  succeeds, the daemon already could not report readiness while init was
+  outstanding — this change makes the failure observable (bounded, loud exit)
+  instead of an unbounded silent hang.
+- Suspected toolchain root cause (see issue #1633 for full writeup, deferred to
+  an infra/release-workflow decision): the crates.io-published default feature
+  set (`embedder-bundled-ort`) links a statically-bundled ONNX Runtime built
+  assuming glibc >= 2.38; AL2023 ships glibc 2.34. `cargo install` always
+  builds with default features regardless of host glibc, so AL2023 users who
+  `cargo install` never get the already-existing `embedder-load-dynamic` /
+  AL2023 release-asset variant that the GitHub Releases build matrix produces.
+
 ## [0.3.4] — 2026-06-16
 
 ### Changed (BREAKING for the binary; closes part of #1318)

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-embedderd"
-version = "0.3.4"
+version = "0.3.5"
 publish = true
 edition = "2021"
 license.workspace = true

--- a/crates/trusty-embedderd/src/lib.rs
+++ b/crates/trusty-embedderd/src/lib.rs
@@ -13,14 +13,35 @@
 //! selected transport. Returns `Ok(())` on clean shutdown; propagates any
 //! startup error.
 //!
+//! Issue #1633: the ONNX model load is bounded by `readiness::run_bounded`
+//! (default 180 s, `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS`). A provider-init
+//! deadlock (observed on AL2023/glibc 2.34 — the CPU(no-arena) execution
+//! provider blocks in `futex_wait_queue` indefinitely) now fails loudly with
+//! a nonzero exit and an actionable stderr message instead of hanging the
+//! process forever with no HTTP/stdio/UDS listener ever bound. Because every
+//! transport listener is only started *after* this call returns `Ok`, the
+//! daemon structurally cannot report readiness (`/health`, a stdio response,
+//! a UDS accept) while init is still outstanding — there is no code path that
+//! answers anything until model load has actually succeeded.
+//!
 //! Test: `cargo test -p trusty-embedderd` (unit + integration).
 //! The `run()` path is exercised indirectly by `embedder_supervisor_e2e`
-//! integration tests in `trusty-search` (which spawn the binary).
+//! integration tests in `trusty-search` (which spawn the binary). The bounded
+//! model-init mechanics are unit-tested in `readiness` against synthetic
+//! futures (no ONNX runtime required).
 
 pub mod batch_queue;
 pub mod protocol;
 pub mod stdio_server;
 pub mod uds_server;
+
+// Why (issue #1633): bounds the model-init call below so an ORT
+// provider-init deadlock (observed on AL2023/glibc 2.34) fails loudly within
+// a fixed ceiling instead of hanging the process forever. Private — no
+// public API surface change, gated behind `http-server` since that is the
+// only place `FastEmbedder::new()` is called from this crate.
+#[cfg(feature = "http-server")]
+mod readiness;
 
 // Why (issue #250): the daemon's HTTP startup sequence (`run`, `run_with_args`,
 // `AppState`, `health_handler`, `embed_handler`, and the `Args` clap struct
@@ -229,11 +250,17 @@ pub async fn run_with_args(args: Args) -> Result<()> {
         );
     }
 
-    // Load the ONNX model (expensive one-time init).
+    // Load the ONNX model (expensive one-time init), bounded so a
+    // provider-init deadlock (issue #1633 — AL2023/glibc 2.34) fails loudly
+    // instead of hanging forever with no listener ever bound.
     info!("loading AllMiniLML6V2Q model...");
-    let embedder = FastEmbedder::new()
-        .await
-        .context("failed to load AllMiniLML6V2Q model")?;
+    let init_timeout = readiness::model_init_timeout();
+    let embedder = readiness::run_bounded(
+        "FastEmbedder::new (AllMiniLML6V2Q model load)",
+        init_timeout,
+        FastEmbedder::new(),
+    )
+    .await?;
     let dim = embedder.dimension();
     info!("model loaded: dim={dim}");
 

--- a/crates/trusty-embedderd/src/readiness.rs
+++ b/crates/trusty-embedderd/src/readiness.rs
@@ -1,0 +1,240 @@
+//! Bounded model-init guard — fail loud instead of hanging (issue #1633).
+//!
+//! Why: the published `trusty-embedderd` binary calls `FastEmbedder::new()`
+//! with no bound at all. On Amazon Linux 2023 / glibc 2.34 hosts the ORT
+//! CPU(no-arena) execution-provider init deadlocks in `futex_wait_queue`
+//! *indefinitely* (observed 12+ consecutive spawns over several hours, 0% CPU,
+//! no error, no log line past "registering CPU(no-arena) execution
+//! provider"). The likely trigger is a toolchain/glibc mismatch: the default
+//! `embedder-bundled-ort` feature links a statically-bundled ONNX Runtime
+//! built assuming glibc >= 2.38 (see `trusty-common/Cargo.toml`), while AL2023
+//! ships glibc 2.34. Because `run_with_args` awaits the model load *before*
+//! binding any HTTP/stdio/UDS listener, a hang here means the process never
+//! answers anything — indistinguishable from a slow-but-working cold start
+//! until an operator notices no embeddings are ever produced (silent
+//! semantic-search degradation to lexical-only).
+//!
+//! What: `model_init_timeout()` resolves a bounded ceiling from
+//! `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` (default 180 s — the same env var name
+//! and default already established by
+//! `trusty_common::memory_core::timeouts::embedder_init_timeout` for the
+//! memory-core embedder singleton, so operators only need to learn one knob).
+//! `run_bounded` races an arbitrary init future against that timeout via
+//! `tokio::time::timeout`; on expiry it returns a descriptive `anyhow::Error`
+//! (issue #1633 + remediation steps) instead of hanging forever, so the
+//! caller can `bail!` out of `run_with_args` and the process exits loudly
+//! with a nonzero code and an actionable stderr message. A fast `Err` from
+//! the wrapped future is propagated unchanged (never mistaken for a timeout).
+//!
+//! Note: on timeout the still-blocked OS thread inside `spawn_blocking`
+//! (`FastEmbedder::with_cache_size` runs the ORT init on a blocking-pool
+//! thread) is abandoned, exactly like the existing CoreML-hang bound in
+//! `trusty_common::embedder::fast_embedder::try_new_bounded` (issue #2111).
+//! This is acceptable here because the *process itself* exits immediately
+//! after — there is no long-lived caller left to leak threads under repeated
+//! retries.
+//!
+//! Test: `model_init_timeout_default`, `model_init_timeout_reads_env`,
+//! `model_init_timeout_ignores_malformed`, `run_bounded_returns_ok_when_fast`,
+//! `run_bounded_propagates_fast_error`, `run_bounded_times_out_when_slow` (all
+//! below) — exercise the timeout resolver and the race mechanics against
+//! synthetic futures (`tokio::time::sleep`), with no ONNX/ORT runtime
+//! involved. The real `FastEmbedder::new()` call site is covered indirectly
+//! by the `embedder_supervisor_e2e` integration tests in `trusty-search`.
+
+use std::future::Future;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+/// Default ceiling (seconds) for the one-shot model-init call in
+/// `run_with_args` before it is treated as hung.
+///
+/// Why: mirrors `trusty_common::memory_core::timeouts::embedder_init_timeout`
+/// (180 s) — cold ONNX model downloads plus a legitimately slow (but
+/// eventually successful) CoreML/CPU cold-compile can take up to a couple of
+/// minutes; 180 s gives generous headroom without risking an indefinite hang
+/// on the AL2023 futex deadlock (issue #1633).
+pub(crate) const DEFAULT_MODEL_INIT_TIMEOUT_SECS: u64 = 180;
+
+/// Resolve the bounded model-init timeout from the environment.
+///
+/// Why: operators on a host with a legitimately slow cold start (large model
+/// download over a slow link, busy CI runner) need to be able to raise the
+/// bound; operators who want faster failure detection can lower it.
+/// What: reads `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` (positive integer
+/// seconds); falls back to [`DEFAULT_MODEL_INIT_TIMEOUT_SECS`] (180) when
+/// unset, non-numeric, or non-positive.
+/// Test: `model_init_timeout_default`, `model_init_timeout_reads_env`,
+/// `model_init_timeout_ignores_malformed`.
+pub(crate) fn model_init_timeout() -> Duration {
+    let secs = std::env::var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_MODEL_INIT_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Race `fut` against `timeout`, turning an unbounded hang into a loud,
+/// actionable error instead of blocking the caller forever.
+///
+/// Why: `TextEmbedding::try_new` (inside `FastEmbedder::new()`) offers no
+/// cancellation hook and can deadlock the underlying OS thread indefinitely
+/// on AL2023/glibc-2.34 hosts (issue #1633). Without a bound, `run_with_args`
+/// would await it forever, reporting nothing to logs or `/health` — a silent
+/// false-negative that looks identical to "still starting up."
+/// What: on success returns `Ok(value)`. A fast `Err` from `fut` is
+/// propagated unchanged (annotated with `op_name` context) — that is a real
+/// failure, not a hang, and must not be reworded as a timeout. On timeout
+/// returns a descriptive `anyhow::Error` naming issue #1633, the known
+/// AL2023/glibc trigger, and two remediations: raise
+/// `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` if the host is just slow, or rebuild
+/// with `--features embedder-load-dynamic` + `ORT_DYLIB_PATH` if the host is
+/// on AL2023 / glibc < 2.38.
+/// Test: `run_bounded_returns_ok_when_fast`,
+/// `run_bounded_propagates_fast_error`, `run_bounded_times_out_when_slow`.
+pub(crate) async fn run_bounded<F, T>(op_name: &str, timeout: Duration, fut: F) -> Result<T>
+where
+    F: Future<Output = Result<T>>,
+{
+    match tokio::time::timeout(timeout, fut).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(e)) => Err(e).with_context(|| format!("{op_name} failed")),
+        Err(_) => Err(anyhow::anyhow!(
+            "{op_name} did not complete within {timeout:?} (issue #1633) — presumed hung. \
+             Known trigger: ONNX Runtime CPU(no-arena) execution-provider init deadlocks on \
+             Amazon Linux 2023 / glibc 2.34 hosts because the default `embedder-bundled-ort` \
+             feature links a statically-bundled ONNX Runtime built assuming glibc >= 2.38. \
+             Remediation: (1) if this host legitimately needs more time, raise \
+             TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS above {timeout:?}; (2) on AL2023 / older-glibc \
+             hosts, reinstall with `--no-default-features --features \
+             http-server,embedder-load-dynamic` and set ORT_DYLIB_PATH to a host-compatible \
+             libonnxruntime.so (e.g. an Ubuntu 20.04 / glibc 2.31 build) instead of the \
+             bundled static ORT — or use the prebuilt `x86_64-linux-al2023` release asset, \
+             which already ships that configuration.",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Process-global lock guarding every test that mutates
+    /// `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` — env vars are process-global and
+    /// tests run in parallel by default.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static ENV_MUTEX: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        ENV_MUTEX
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .expect("env_lock mutex poisoned")
+    }
+
+    /// Why: guard that the default is 180 s when the env var is absent.
+    /// What: clears the var, asserts the default is returned.
+    /// Test: itself.
+    #[test]
+    fn model_init_timeout_default() {
+        let _guard = env_lock();
+        // SAFETY: serialised under `env_lock()`; no other thread mutates
+        // this var while the guard is held.
+        unsafe { std::env::remove_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS") };
+        assert_eq!(
+            model_init_timeout(),
+            Duration::from_secs(DEFAULT_MODEL_INIT_TIMEOUT_SECS)
+        );
+        assert_eq!(DEFAULT_MODEL_INIT_TIMEOUT_SECS, 180);
+    }
+
+    /// Why: operators must be able to raise or lower the bound without a
+    /// code change.
+    /// What: sets an explicit value, asserts it is honoured.
+    /// Test: itself.
+    #[test]
+    fn model_init_timeout_reads_env() {
+        let _guard = env_lock();
+        // SAFETY: serialised under `env_lock()`.
+        unsafe { std::env::set_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS", "45") };
+        assert_eq!(model_init_timeout(), Duration::from_secs(45));
+        // SAFETY: serialised under `env_lock()`.
+        unsafe { std::env::remove_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS") };
+    }
+
+    /// Why: a malformed or zero override must never panic or silently
+    /// disable the bound (which would reintroduce the unbounded hang).
+    /// What: feeds non-numeric and zero values, asserts the default wins.
+    /// Test: itself.
+    #[test]
+    fn model_init_timeout_ignores_malformed() {
+        let _guard = env_lock();
+        for bad in ["not-a-number", "0", ""] {
+            // SAFETY: serialised under `env_lock()`.
+            unsafe { std::env::set_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS", bad) };
+            assert_eq!(
+                model_init_timeout(),
+                Duration::from_secs(DEFAULT_MODEL_INIT_TIMEOUT_SECS),
+                "malformed value {bad:?} must fall back to the default"
+            );
+        }
+        // SAFETY: serialised under `env_lock()`.
+        unsafe { std::env::remove_var("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS") };
+    }
+
+    /// Why: the common case (init completes well inside the bound) must
+    /// succeed and return the wrapped value unchanged.
+    /// What: races a near-instant future against a generous timeout.
+    /// Test: itself.
+    #[tokio::test]
+    async fn run_bounded_returns_ok_when_fast() {
+        let result = run_bounded("test-op", Duration::from_secs(5), async {
+            Ok::<_, anyhow::Error>(42)
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    /// Why: a fast, real failure (e.g. a malformed model file) must be
+    /// propagated as-is — it must never be reworded as a timeout, which
+    /// would mislead an operator into raising a timeout knob that cannot
+    /// fix the actual problem.
+    /// What: races a future that resolves immediately to `Err`.
+    /// Test: itself.
+    #[tokio::test]
+    async fn run_bounded_propagates_fast_error() {
+        let result = run_bounded("test-op", Duration::from_secs(5), async {
+            Err::<i32, _>(anyhow::anyhow!("boom"))
+        })
+        .await;
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("test-op failed"));
+        assert!(format!("{err:#}").contains("boom"));
+    }
+
+    /// Why: the core fix for issue #1633 — a hung future must fail loudly
+    /// within the bound instead of hanging forever, and the error must name
+    /// the issue and remediation so an operator isn't left guessing.
+    /// What: races a future that never resolves within the test's lifetime
+    /// (a long sleep) against a short timeout; asserts the timeout fires and
+    /// the message is actionable.
+    /// Test: itself.
+    #[tokio::test]
+    async fn run_bounded_times_out_when_slow() {
+        let result = run_bounded("test-op", Duration::from_millis(50), async {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            Ok::<_, anyhow::Error>(())
+        })
+        .await;
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("1633"),
+            "error must reference issue #1633: {msg}"
+        );
+        assert!(
+            msg.contains("TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS"),
+            "error must name the override knob: {msg}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Mitigation + investigation for #1633: the published `trusty-embedderd` binary hangs forever in `futex_wait_queue` during ONNX Runtime CPU(no-arena) execution-provider init on Amazon Linux 2023 / glibc 2.34, silently reporting nothing while search degrades to lexical-only.

### Piece 1 — shippable mitigation (this PR's code change)

- `run_with_args`'s `FastEmbedder::new()` model-load call had **no timeout at all**. Added `crates/trusty-embedderd/src/readiness.rs`: `run_bounded()` races the model load against `tokio::time::timeout`, bounded by `model_init_timeout()` (default **180s**, overridable via `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` — the same env var name/default already established by `trusty_common::memory_core::timeouts::embedder_init_timeout`, so operators only need to learn one knob).
- On timeout: the process exits nonzero with an actionable stderr message naming issue #1633, the suspected AL2023/glibc trigger, and two remediations (raise the timeout if just slow; reinstall with `--features embedder-load-dynamic` + `ORT_DYLIB_PATH` if on AL2023/older glibc).
- A **fast** `Err` from the wrapped future (a real failure) is propagated unchanged — never reworded as a timeout, so operators aren't misled into raising a timeout knob that can't fix a real error.
- **Readiness ordering was already correct** and required no change: every HTTP/stdio/UDS listener in `run_with_args` only binds *after* `FastEmbedder::new()` returns `Ok`, so the daemon structurally cannot report `ready` (or answer anything) while init is outstanding — the gap was purely "hangs unboundedly," not "lies about readiness." Documented this invariant explicitly in the module doc.
- Tests (`readiness.rs`, no ONNX runtime needed — mirrors the existing `#[ignore]`-for-ONNX convention): timeout-resolver defaults/overrides/malformed-input handling, `run_bounded` success/fast-error/timeout paths using synthetic `tokio::time::sleep` futures. All 6 new tests pass; full existing suite (18 unit + 5 integration) unaffected.

### Piece 2 — toolchain root-cause investigation

Found the likely root cause in `crates/trusty-common/Cargo.toml`: the `embedder-bundled-ort` feature (part of `trusty-embedderd`'s **default** feature set) links a statically-bundled ONNX Runtime via `fastembed/ort-download-binaries-native-tls`, documented in that same Cargo.toml as **"right choice for macOS and modern Linux (glibc >= 2.38)"**. AL2023 ships glibc 2.34 — below that floor. This lines up precisely with the reported symptom (futex deadlock during CPU provider init) and the reported workaround (gcc14 + glibc-2.34 compat shim rebuild "fixes" it — i.e., rebuilding forces a compatible link).

Crucially, **this is already a solved problem for the GitHub Releases distribution channel**: `.github/workflows/release.yml` builds a dedicated `x86_64-linux-al2023` variant inside an `amazonlinux:2023` container using `--no-default-features --features load-dynamic` (or `http-server,load-dynamic`), downloading ONNX Runtime 1.20.1 (built on Ubuntu 20.04 / glibc 2.31, confirmed compatible) and setting `ORT_DYLIB_PATH` at runtime. **But `cargo install trusty-search` (crates.io) never uses this variant** — `cargo install` always builds with the crate's declared *default* features, and there is no way for `cargo install` to auto-detect the host's glibc version and select `embedder-load-dynamic` instead. Any AL2023 (or other glibc<2.38) user who installs via `cargo install` rather than downloading the GitHub Release tarball will hit this hang, unconditionally, every time.

**Recommendation (needs a PM/product decision, not made in this PR):**
1. Document loudly (README + crates.io description + a startup-time glibc sanity check?) that AL2023/older-glibc hosts must use the `x86_64-linux-al2023` GitHub Release asset, not `cargo install`.
2. Longer term: consider whether `trusty-search`/`trusty-embedderd`'s crates.io default features should change (e.g., default to `load-dynamic` + require an explicit `ORT_DYLIB_PATH`), which would be a **breaking change** for the current zero-config `cargo install` experience on macOS/modern-Linux — not something to change silently.
3. Alternative: a runtime glibc-version probe at daemon startup that logs an explicit warning/refusal before even attempting ORT init on a host below the bundled-ORT's glibc floor, so the failure mode becomes an instant, clear log line instead of relying purely on the new 180s timeout.

I did not change the release workflow or crates.io default features in this PR — that's the infra/product decision called out above.

### Coordinated-bump flag

`trusty-search` bundles `trusty-embedderd` as a second binary (`trusty-embedderd = { workspace = true }`, produced via `crates/trusty-search/src/bin/trusty-embedderd.rs`, which just calls `trusty_embedderd::run()`). **A `trusty-embedderd` version bump alone does not ship this fix to users** — `trusty-search` needs its own coordinated release (new crates.io publish + `cargo install trusty-search`) to pick up the updated `trusty-embedderd` library code, since the bundled binary is compiled from `trusty-search`'s own Cargo.lock resolution. I did **not** touch `trusty-search` in this PR (per instructions — a separate engineer owns it); please sequence a `trusty-search` bump right after this merges.

### Version

`trusty-embedderd` 0.3.4 → **0.3.5** (patch — behavior-only change, no public API surface added; `readiness` module is private). Root `Cargo.toml`'s pinned path-dep version updated to match.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-embedderd` — 18 unit + 5 integration pass (6 new in `readiness::tests`); ONNX-backed test stays `#[ignore]`d (no local model)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (pre-existing unrelated `tga` MSRV warning only, not from this change)
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `14 allowlisted, 0 violations — OK`

Refs #1633 (mitigation lands here; toolchain/distribution root cause needs a follow-up infra decision — see Piece 2 above — so not marked `Closes`)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>