### PR TITLE
fix(trusty-search): stop status/corpus desync causing silently-empty search results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11091,7 +11091,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -6,6 +6,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.31.1] — 2026-07-07
+
+### Fixed — corpus/status desync bug cluster (issues #2203, #1870, #2211, #2179)
+
+- **#2203 / #1870 (joint root cause): a failed durable-corpus open no longer
+  leaves `semantic`/`graph` falsely reporting `"ready"`.** `derive_warm_boot_stages`
+  previously threaded `corpus_open_failed` into the `lexical` stage only;
+  `semantic` and `graph` were classified purely from `hnsw_snapshot_ready` /
+  `graph_node_count` — signals entirely independent of the redb corpus. A
+  restored HNSW mmap snapshot (or symbol graph) can load successfully even
+  when the redb corpus failed to open (`DatabaseAlreadyOpen` or any other
+  open error, #1870), so `/health` and `GET /indexes/:id/status` kept
+  reporting `semantic.status: "ready"` while the query hot path's
+  `fetch_chunks_for_ids` could never resolve any HNSW hit against the
+  unwired corpus — every result was silently dropped at materialisation
+  (`search/materialize.rs`), producing HTTP 200 + `results: []` for
+  essentially every query (#2203). A corpus-open failure now fails all three
+  stages together, and `search_capabilities` correctly advertises no lanes.
+- **#2211: `stages.semantic.status` no longer flips to `"ready"` prematurely
+  when `defer_embed` is active.** `finish_reindex` called
+  `mark_semantic_ready_graph_in_progress` unconditionally right after the
+  fast pass, before the deferred background embed pass had even started —
+  reporting `"ready"` for the entire duration of the real embedding job.
+  Semantic now stays `InProgress` until the deferred pass actually
+  completes and marks it `Ready`.
+- **#2179 (tech debt): `rewrite_keys_to_relative` (M003's one-time HNSW
+  key-migration path) now genuinely promotes a view-mode store to mutable
+  instead of just flipping the `is_view` flag**, keeping the flag truthful
+  relative to the underlying `usearch::Index` mode.
+
+---
+
 ## [0.31.0] — 2026-07-06
 
 ### Added — idle watcher suspension (stop watching projects nobody is using)

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/src/commands/start/tests.rs
+++ b/crates/trusty-search/src/commands/start/tests.rs
@@ -108,6 +108,64 @@ fn warm_boot_respects_lexical_only_flag() {
     assert!(!caps.contains(&"kg"));
 }
 
+/// Issues #1870 / #2203 (joint root cause): a failed durable-corpus open
+/// must fail EVERY stage — lexical, semantic, AND graph — even when the
+/// HNSW snapshot and symbol graph independently loaded fine from disk.
+///
+/// Why: before this fix, `corpus_open_failed` only forced `lexical` to
+/// `Failed`; `semantic` and `graph` were still classified purely from
+/// `hnsw_snapshot_ready` / `graph_node_count`, which are on-disk signals
+/// completely independent of the redb corpus. That let `/health` and
+/// `GET /indexes/:id/status` report `semantic.status: "ready"` (and
+/// `"vector"` in `search_capabilities`) while the query hot path's
+/// `fetch_chunks_for_ids` could never resolve any HNSW hit against the
+/// (unwired) corpus — every result was silently dropped at materialisation,
+/// producing HTTP 200 + `results: []` for essentially every query (#2203)
+/// while the status endpoint kept lying about health (#1870).
+/// What: constructs `WarmBootInputs` with `corpus_open_failed: true` AND
+/// healthy-looking `hnsw_snapshot_ready` / `graph_node_count` values, then
+/// asserts all three stages are `Failed`, `lifecycle_status() == "failed"`,
+/// and `search_capabilities()` is empty (no lane is falsely advertised).
+/// Test: this test.
+#[test]
+fn warm_boot_corpus_open_failure_fails_every_stage() {
+    let stages = derive_warm_boot_stages(WarmBootInputs {
+        chunk_count: 48_742,
+        hnsw_snapshot_ready: true,
+        graph_node_count: 7_402,
+        lexical_only: false,
+        skip_kg: false,
+        corpus_open_failed: true,
+    });
+    assert_eq!(
+        stages.lexical.status,
+        StageStatus::Failed,
+        "corpus open failure must fail lexical"
+    );
+    assert_eq!(
+        stages.semantic.status,
+        StageStatus::Failed,
+        "corpus open failure must fail semantic even though the HNSW snapshot loaded fine \
+         — without the corpus, no HNSW hit can ever resolve to chunk text (issues #1870, #2203)"
+    );
+    assert_eq!(
+        stages.graph.status,
+        StageStatus::Failed,
+        "corpus open failure must fail graph even though the symbol graph loaded fine"
+    );
+    assert_eq!(stages.lifecycle_status(), "failed");
+    assert!(
+        stages.search_capabilities().is_empty(),
+        "no lane may be advertised as queryable when the durable corpus is unavailable; got: {:?}",
+        stages.search_capabilities()
+    );
+    // Every failed stage must carry the actionable reason (issue #1158's
+    // original contract, now extended to semantic + graph).
+    assert!(stages.lexical.failure.is_some());
+    assert!(stages.semantic.failure.is_some());
+    assert!(stages.graph.failure.is_some());
+}
+
 /// Mid-reindex recovery: the registry has the entry but the redb corpus is
 /// empty. Lexical must come back as `InProgress` — not `Pending` — so the
 /// lifecycle status surfaces "walking".

--- a/crates/trusty-search/src/core/store/tests.rs
+++ b/crates/trusty-search/src/core/store/tests.rs
@@ -256,6 +256,74 @@ async fn test_load_corrupt_sidecar_returns_none() {
     assert!(loaded.is_none(), "corrupt sidecar must fall back to None");
 }
 
+/// Issue #2179 regression: `rewrite_keys_to_relative` (the M003 one-time
+/// key-migration path) must leave `is_view` truthful relative to the
+/// underlying `usearch::Index` mode — not just flip the flag to `false`
+/// while the Index handle is still literally an mmap view.
+///
+/// Why: before the fix, `rewrite_keys_to_relative` set `is_view.store(false,
+/// ...)` directly instead of calling `ensure_mutable()` / `Index::load()`.
+/// When applied against a store that was warm-booted via `load_from` (view
+/// mode), that left a latent invariant violation: `in_view_mode()` reported
+/// `false` (claiming a mutable heap-resident copy) while the Index was still
+/// a read-only mmap — the exact mismatch `#2164`'s demote/dirty logic
+/// assumes can never happen. A subsequent write (`upsert`/`remove`) would
+/// then see `is_view == false`, skip `ensure_mutable`'s promotion, and
+/// mutate the view directly (usearch documents this as erroring or UB for
+/// a genuine view).
+/// What: builds a store with one absolute-keyed vector, saves it, reloads it
+/// via `load_from` (asserts `in_view_mode() == true`), calls
+/// `rewrite_keys_to_relative`, and asserts `in_view_mode() == false`
+/// afterward — AND that a subsequent `upsert` (which would UB/error against
+/// a real, un-promoted view) succeeds and is searchable, proving the
+/// underlying Index was genuinely promoted, not just flagged.
+/// Test: this test.
+#[tokio::test]
+async fn test_rewrite_keys_to_relative_promotes_view_to_mutable() {
+    let dir = tempfile::tempdir().unwrap();
+    let hnsw_path = dir.path().join("hnsw.usearch");
+    let root = dir.path().join("proj");
+    let abs_id = format!("{}/src/lib.rs:1:10", root.display());
+
+    // Build + save a store with one absolute-keyed vector.
+    {
+        let store = UsearchStore::new(4).unwrap();
+        store
+            .upsert(&abs_id, vec![1.0, 0.0, 0.0, 0.0])
+            .await
+            .unwrap();
+        store.save(&hnsw_path).await.unwrap();
+    }
+
+    // Reload — this lands in view (mmap) mode.
+    let store = UsearchStore::load_from(&hnsw_path)
+        .await
+        .unwrap()
+        .expect("load returned Some");
+    assert!(store.in_view_mode(), "load_from must land in view mode");
+
+    // Apply the M003 key rewrite (one absolute key → relative).
+    let count = store.rewrite_keys_to_relative(&root).await.unwrap();
+    assert_eq!(count, 1, "must rewrite the one absolute key");
+
+    // The flag must now be false, AND the underlying Index must genuinely
+    // be promoted — not just the flag flipped.
+    assert!(
+        !store.in_view_mode(),
+        "rewrite must leave is_view truthfully false"
+    );
+
+    // Prove genuine promotion happened: a write against a real (un-promoted)
+    // view would error/UB per usearch's contract. If this upsert succeeds
+    // and is searchable, the Index was actually reloaded mutable.
+    store
+        .upsert("src/other.rs:1:5", vec![0.0, 1.0, 0.0, 0.0])
+        .await
+        .expect("upsert after rewrite must succeed against a genuinely promoted store");
+    let hits = store.search(&[0.0, 1.0, 0.0, 0.0], 1).await.unwrap();
+    assert_eq!(hits[0].chunk_id, "src/other.rs:1:5");
+}
+
 #[tokio::test]
 async fn test_view_promotes_to_mutable_on_write() {
     // Why: warm-boot opens the snapshot via `Index::view` (mmap) to keep

--- a/crates/trusty-search/src/core/store/usearch_impl.rs
+++ b/crates/trusty-search/src/core/store/usearch_impl.rs
@@ -143,7 +143,14 @@ impl VectorStore for UsearchStore {
     /// as a prefix, strips the prefix (mirrors M002's `strip_prefix` logic),
     /// replaces the entry in both maps. Idempotent: already-relative IDs are
     /// skipped. Outside-root absolute IDs are left unchanged and logged at warn.
-    /// Test: `tests::test_rewrite_keys_to_relative`.
+    /// Issue #2179: when any rewrite happened, promotes the store view →
+    /// mutable via [`Self::ensure_mutable`] (rather than flipping the
+    /// `is_view` flag directly) so the flag never claims "mutable" while the
+    /// underlying `usearch::Index` is still literally an mmap view — see
+    /// [`Self::ensure_mutable`]'s doc comment for why that mismatch is unsafe
+    /// (a subsequent write path would skip promotion and mutate the view).
+    /// Test: `tests::test_rewrite_keys_to_relative`,
+    /// `tests::test_rewrite_keys_to_relative_promotes_view_to_mutable`.
     async fn rewrite_keys_to_relative(&self, root_path: &Path) -> Result<usize> {
         let mut id_map = self.id_to_key.write().await;
         let mut key_map = self.key_to_id.write().await;
@@ -193,13 +200,27 @@ impl VectorStore for UsearchStore {
             id_map.insert(new_id.clone(), key);
             key_map.insert(key, new_id);
         }
+        // Release the id-map locks before touching the HNSW index lock inside
+        // `ensure_mutable` below — the two lock pairs are never held together
+        // elsewhere in this store, and doing so here would be a new (and
+        // unnecessary) lock-ordering dependency.
+        drop(id_map);
+        drop(key_map);
 
-        // The in-memory maps now differ from the on-disk sidecar: clear the
-        // view flag so `save()` does not treat the snapshot as clean and skip
-        // the flush. We use `Release` ordering to pair with the `Acquire` load
-        // in `save()` — the updated map state must be visible before save reads it.
+        // Issue #2179: the in-memory maps now differ from the on-disk
+        // sidecar, so `save()` must not treat the snapshot as clean and skip
+        // the flush. Previously this set `is_view = false` directly, which
+        // left the flag claiming "mutable" while the underlying
+        // `usearch::Index` handle was still literally an mmap view whenever
+        // this ran against a warm-booted (view-mode) store — a later write
+        // path (`upsert`/`remove`/`upsert_batch`) would then see `is_view ==
+        // false`, skip `ensure_mutable`'s promotion, and mutate the view
+        // directly, which usearch documents as erroring or UB. Routing
+        // through `ensure_mutable()` instead performs the real `Index::load`
+        // promotion when the store was a view (no-op when it was already
+        // mutable), keeping `is_view` truthful in both cases.
         if count > 0 {
-            self.is_view.store(false, Ordering::Release);
+            self.ensure_mutable().await?;
         }
 
         Ok(count)

--- a/crates/trusty-search/src/service/reindex/finish.rs
+++ b/crates/trusty-search/src/service/reindex/finish.rs
@@ -258,13 +258,24 @@ pub(super) async fn finish_reindex(ctx: FinishCtx, totals: BatchTotals) {
         return;
     }
 
-    // Issue #109, Phase 1: flip the semantic stage to `Ready`.
-    mark_semantic_ready_graph_in_progress(
-        &handle,
-        total_vector_count,
-        progress.total_chunks.load(AtomicOrdering::Acquire),
-    )
-    .await;
+    // Issue #109, Phase 1 / #2211: flip the semantic stage to `Ready` — but
+    // ONLY when embedding actually ran to completion as part of this pass.
+    // When `defer_embed` is active with an embedder wired, the real
+    // embedding happens in the background pass spawned below (after this
+    // function returns); marking semantic Ready here reported a false
+    // "ready" signal for the entire duration of that background pass — see
+    // `validate::semantic_ready_now` for the full rationale. In that case
+    // semantic stays `InProgress` (already set by
+    // `mark_lexical_ready_semantic_in_progress` above) until
+    // `spawn_deferred_embed_pass` itself marks it `Ready`.
+    if validate::semantic_ready_now(defer_embed, embedder_present) {
+        mark_semantic_ready_graph_in_progress(
+            &handle,
+            total_vector_count,
+            progress.total_chunks.load(AtomicOrdering::Acquire),
+        )
+        .await;
+    }
 
     // Phase 3: rebuild the symbol graph.
     let kg = rebuild_kg(

--- a/crates/trusty-search/src/service/reindex/tests.rs
+++ b/crates/trusty-search/src/service/reindex/tests.rs
@@ -618,6 +618,122 @@ async fn reindex_marks_failed_on_zero_vectors_and_preserves_corpus() {
     );
 }
 
+/// Issue #2211 regression: with `defer_embed=true` (the default) and a real
+/// embedder wired, the semantic stage must NOT report `Ready` the instant
+/// the fast pass (C1: walk → chunk → BM25 → KG) completes — the actual
+/// embedding runs in a background pass that has not finished yet. Before the
+/// fix, `finish_reindex` called `mark_semantic_ready_graph_in_progress`
+/// unconditionally right after the batch loop, flipping `semantic.status`
+/// to `Ready` regardless of `defer_embed`; the deferred background pass
+/// never reset it back to `InProgress`, so operators polling
+/// `/indexes/:id/status` (or health-check callers like apex-companion) saw
+/// a false "ready" signal for the entire embedding window.
+///
+/// Why: uses a `SlowEmbedder` that sleeps briefly per call so the background
+/// pass takes long enough to reliably observe the intermediate (non-Ready)
+/// state between the fast-pass `Complete` event and the deferred pass
+/// actually finishing.
+/// What: runs a full `spawn_reindex` with `defer_embed` defaulted `true`
+/// (via `IndexHandle::bare`) and a real (slow) embedder + HNSW store; polls
+/// for `ReindexStatus::Complete` (fast pass done), then immediately asserts
+/// `semantic.status != Ready`; then polls further and asserts it eventually
+/// does become `Ready` once the deferred pass finishes.
+/// Test: this test.
+#[tokio::test]
+async fn defer_embed_semantic_stage_not_ready_before_background_pass_completes() {
+    use crate::core::embed::Embedder;
+    use crate::core::store::{UsearchStore, VectorStore};
+    use std::sync::atomic::AtomicUsize;
+
+    /// Embedder that sleeps briefly per call so the deferred background pass
+    /// takes long enough to observe an intermediate (non-Ready) semantic
+    /// stage state before it completes.
+    struct SlowEmbedder {
+        calls: Arc<AtomicUsize>,
+    }
+    #[async_trait::async_trait]
+    impl Embedder for SlowEmbedder {
+        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+            self.calls.fetch_add(1, Ordering::AcqRel);
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            Ok(vec![0.1; 32])
+        }
+        async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+            self.calls.fetch_add(1, Ordering::AcqRel);
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            Ok(texts.iter().map(|_| vec![0.1; 32]).collect())
+        }
+        fn dimension(&self) -> usize {
+            32
+        }
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    fs::write(root.join("lib.rs"), "pub fn alpha() {}\n").unwrap();
+
+    let dim = 32;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let embedder: Arc<dyn Embedder> = Arc::new(SlowEmbedder {
+        calls: calls.clone(),
+    });
+    let store: Arc<dyn VectorStore> = Arc::new(UsearchStore::new(dim).expect("usearch new"));
+    let indexer = CodeIndexer::new("defer-2211", root.clone()).with_components(embedder, store);
+
+    // `defer_embed` defaults to `true` via `IndexHandle::bare`.
+    let handle = Arc::new(IndexHandle::bare(
+        IndexId::new("defer-2211"),
+        Arc::new(tokio::sync::RwLock::new(indexer)),
+        root.clone(),
+    ));
+    assert!(
+        handle.defer_embed,
+        "precondition: defer_embed must default true"
+    );
+    let progress = Arc::new(ReindexProgress::new());
+    spawn_reindex(handle.clone(), progress.clone(), false);
+
+    // Wait for the fast pass to complete (lexical/BM25/KG done, embedding deferred).
+    for _ in 0..200 {
+        if progress.status.load() == ReindexStatus::Complete {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(progress.status.load(), ReindexStatus::Complete);
+
+    // Issue #2211: right after the fast pass, the background embed pass has
+    // NOT finished yet (SlowEmbedder blocks 300ms per call) — the semantic
+    // stage must not report Ready. Before the fix this was already Ready
+    // here, because `finish_reindex` marked it Ready unconditionally.
+    let semantic_status = handle.stages.read().await.semantic.status;
+    assert_ne!(
+        semantic_status,
+        StageStatus::Ready,
+        "semantic stage must not be Ready while the deferred embed pass is still running \
+         (issue #2211 — false-ready before embedding actually completes)"
+    );
+
+    // Eventually the deferred pass finishes and semantic really does flip Ready.
+    let mut final_status = semantic_status;
+    for _ in 0..100 {
+        final_status = handle.stages.read().await.semantic.status;
+        if final_status == StageStatus::Ready {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        final_status,
+        StageStatus::Ready,
+        "semantic stage must eventually become Ready once the deferred pass completes"
+    );
+    assert!(
+        calls.load(Ordering::Acquire) > 0,
+        "the (slow) embedder must have been invoked by the deferred pass"
+    );
+}
+
 /// Issue #112: when no recognised metadata files exist, the context
 /// embedding stays `None` so the router falls back to a neutral 1.0
 /// weight for this index.

--- a/crates/trusty-search/src/service/reindex/validate.rs
+++ b/crates/trusty-search/src/service/reindex/validate.rs
@@ -142,6 +142,38 @@ pub(crate) fn reindex_outcome(
     ReindexOutcome::Ready
 }
 
+/// Issue #2211: decide whether the semantic stage may be marked `Ready`
+/// immediately after the C1 fast pass completes, or must wait for a
+/// deferred-embed background pass to actually finish first.
+///
+/// Why: `defer_embed` (issue #923) intentionally embeds nothing synchronously
+/// during the fast pass — the real embedding runs in the background job
+/// spawned by `spawn_deferred_embed_pass` right after `finish_reindex`
+/// returns. Before this gate, `finish_reindex` called
+/// `mark_semantic_ready_graph_in_progress` unconditionally after the batch
+/// loop, which flipped `stages.semantic.status` to `Ready` — carrying
+/// whatever tiny `total_vector_count` happened to be embedded synchronously
+/// before deferral kicked in (observed in production: `embedded: 512` out of
+/// `total: 48742`) — regardless of `defer_embed`. The deferred background
+/// pass (`defer_embed.rs`) never resets the status back to `InProgress`, so
+/// `semantic.status` stayed `"ready"` for the ENTIRE duration of the real
+/// background embed — a false-green signal that callers treating `status`
+/// as authoritative (health checks) trusted immediately after a reindex was
+/// triggered.
+/// What: returns `true` (safe to mark Ready now) whenever embedding actually
+/// ran to completion as part of THIS pass — i.e. not deferred, or no
+/// embedder is wired at all (in which case `defer_embed` is a no-op and
+/// `total_vector_count` is definitionally final). Returns `false` only when
+/// a real deferred background pass is about to be spawned; in that case the
+/// semantic stage is left `InProgress` (already set earlier by
+/// `mark_lexical_ready_semantic_in_progress`) until
+/// `spawn_deferred_embed_pass` itself flips it to `Ready` once embedding
+/// truly completes.
+/// Test: `semantic_ready_now_*` below.
+pub(crate) fn semantic_ready_now(defer_embed: bool, embedder_present: bool) -> bool {
+    !(defer_embed && embedder_present)
+}
+
 /// Canonicalize `root` exactly as the walker does (#602).
 ///
 /// Why: `walk_source_files_with_options` canonicalizes its root via
@@ -366,6 +398,42 @@ mod tests {
             "defer_embed fast pass must be Ready despite zero vectors"
         );
         assert_eq!(outcome.failure_reason(), None);
+    }
+
+    /// Issue #2211 regression: when `defer_embed` is active AND an embedder
+    /// is wired, the semantic stage must NOT be marked Ready right after the
+    /// fast pass — the real embedding happens in a background pass that
+    /// hasn't started yet.
+    /// Test: this test.
+    #[test]
+    fn semantic_ready_now_false_when_deferring_with_embedder() {
+        assert!(
+            !semantic_ready_now(true, true),
+            "must NOT mark semantic Ready synchronously when a real deferred embed pass \
+             is about to be spawned"
+        );
+    }
+
+    /// Issue #2211: without `defer_embed`, embedding always ran synchronously
+    /// as part of this pass, so semantic Ready reflects the true, final state.
+    /// Test: this test.
+    #[test]
+    fn semantic_ready_now_true_when_not_deferring() {
+        assert!(semantic_ready_now(false, true));
+        assert!(semantic_ready_now(false, false));
+    }
+
+    /// Issue #2211: `defer_embed=true` with NO embedder wired is a no-op —
+    /// there is no background pass to wait for (BM25-only / test indexer),
+    /// so it is safe to mark semantic Ready immediately (it stays vacuously
+    /// "ready" with nothing to embed).
+    /// Test: this test.
+    #[test]
+    fn semantic_ready_now_true_when_deferring_without_embedder() {
+        assert!(
+            semantic_ready_now(true, false),
+            "defer_embed without an embedder has no background pass to wait for"
+        );
     }
 
     /// Why: confirms the strip-prefix root resolves a real symlinked directory

--- a/crates/trusty-search/src/service/warm_boot/stages.rs
+++ b/crates/trusty-search/src/service/warm_boot/stages.rs
@@ -55,7 +55,9 @@ pub struct WarmBootInputs {
 ///
 /// Why (issue #135): see [`WarmBootInputs`].
 /// What: applies rules in order:
-///   1. `corpus_open_failed == true` → lexical is `Failed` (issue #1158).
+///   1. `corpus_open_failed == true` → lexical, semantic, AND graph are all
+///      `Failed` (issues #1158, #1870, #2203 — see the inline rationale
+///      below).
 ///   2. `chunk_count > 0` → lexical is `Ready`.
 ///   3. `chunk_count == 0` → lexical is `InProgress`.
 ///   4. `lexical_only == true` → semantic + graph are `Skipped`.
@@ -64,17 +66,38 @@ pub struct WarmBootInputs {
 ///
 /// Test: `warm_boot_*` tests in `commands/start.rs`.
 pub fn derive_warm_boot_stages(inputs: WarmBootInputs) -> IndexStages {
+    // Issues #1870 / #2203 (joint root cause): a failed durable-corpus open
+    // must fail EVERY stage, not just lexical. Before this guard, `semantic`
+    // and `graph` were classified purely from `hnsw_snapshot_ready` /
+    // `graph_node_count` — signals that are entirely independent of the
+    // corpus. A restored HNSW mmap snapshot (or symbol graph) can load
+    // successfully even when the redb corpus failed to open (e.g.
+    // `DatabaseAlreadyOpen`, #1870), so `semantic` kept reporting `Ready`
+    // while the query hot path's `fetch_chunks_for_ids` could never resolve
+    // any chunk id against the (unwired) corpus — every HNSW hit was
+    // silently dropped at materialisation (`search/materialize.rs`'s "fused
+    // id not in corpus" trace), producing HTTP 200 + `results: []` for
+    // essentially every query while `/health` / `GET /indexes/:id/status`
+    // kept reporting `semantic.status: "ready"` (#2203). Both lanes depend
+    // on the same durable corpus for chunk text, so both must fail together
+    // with it — this is the `search_capabilities`/corpus-resolvability
+    // consistency guard.
+    if inputs.corpus_open_failed {
+        let reason = "redb corpus could not be opened (incompatible or corrupted format); \
+             run `trusty-search index <path> --force` to rebuild from source \
+             (issues #1158, #1870, #2203)";
+        return IndexStages {
+            lexical: StageState::failed(reason),
+            semantic: StageState::failed(reason),
+            graph: StageState::failed(reason),
+        };
+    }
+
     // Issue #1158: corpus open failure must surface as Failed, not InProgress.
     // Before this guard, `chunk_count == 0` (corpus store absent) was treated
     // identically to a freshly-created, never-indexed handle — silently
     // appearing healthy while the durable store was unreadable.
-    let lexical = if inputs.corpus_open_failed {
-        StageState::failed(
-            "redb corpus could not be opened (incompatible or corrupted format); \
-             run `trusty-search index <path> --force` to rebuild from source \
-             (issue #1158)",
-        )
-    } else if inputs.chunk_count > 0 {
+    let lexical = if inputs.chunk_count > 0 {
         StageState {
             status: StageStatus::Ready,
             ..Default::default()


### PR DESCRIPTION
## Summary

Fixes a P0 production-outage bug cluster in `trusty-search` where the redb-backed corpus/index desyncs from what `/health` and `/status` report, causing silent empty search results.

- **#2203 / #1870 (joint root cause)**: `derive_warm_boot_stages` (shared by both the eager warm-boot path in `commands/start_restore.rs` and the lazy cold-load path in `service/lazy_restore.rs`) threaded `corpus_open_failed` into the `lexical` stage classification only. `semantic` and `graph` were classified purely from `hnsw_snapshot_ready` / `graph_node_count` — signals entirely independent of the redb corpus. A restored HNSW mmap snapshot (or symbol graph) can load successfully even when the redb corpus failed to open (`DatabaseAlreadyOpen`, #1870), so `/health` / `GET /indexes/:id/status` kept reporting `semantic.status: "ready"` while the query hot path's `fetch_chunks_for_ids` (`search/lanes.rs`) could never resolve any HNSW hit id against the unwired corpus — every hit was silently dropped at materialisation (`search/materialize.rs`'s "fused id not in corpus" trace), producing HTTP 200 + `results: []` for essentially every natural-language query (#2203), while status reporting kept lying about health (#1870). **Fix**: a corpus-open failure now fails `lexical`, `semantic`, AND `graph` together (`crates/trusty-search/src/service/warm_boot/stages.rs`) — this is the "corpus-key resolvability" consistency guard called for in the ticket.
- **#2211**: `finish_reindex` called `mark_semantic_ready_graph_in_progress` unconditionally right after the C1 fast-pass batch loop, regardless of `defer_embed` — flipping `stages.semantic.status` to `Ready` before the deferred background embed pass had even started. The background pass (`defer_embed.rs`) never reset it back to `InProgress`, so `semantic.status` reported `"ready"` for the entire duration of real embedding (production observation: `embedded: 512 / total: 48742, reported ready`). **Fix**: a new pure decision helper `validate::semantic_ready_now(defer_embed, embedder_present)` gates the call in `finish.rs` — semantic now stays `InProgress` until the deferred pass genuinely completes.
- **#2179** (tech debt): `rewrite_keys_to_relative` (M003's one-time HNSW key-migration path) set `is_view = false` directly instead of calling `ensure_mutable()` / `Index::load()`, leaving the flag claiming "mutable" while the underlying `usearch::Index` handle was still a genuine read-only mmap view whenever this ran against a warm-booted (view-mode) store. **Fix**: routes through `ensure_mutable()` so the flag stays truthful relative to the actual Index mode.

`#2203` and `#1870` share ONE root cause (the incomplete `corpus_open_failed` propagation in the stage classifier); `#2211` and `#2179` are separate, independently-verified defects.

Version bump: `0.31.0` → `0.31.1` (behavior-changing bugfix — status semantics change in a new failure scenario — no public API break).

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-search` — 1018 lib + 252 bin + integration suites, 0 failed (includes 4 new regression tests, one per issue, each verified to exercise the actual fixed code path)
- [x] `cargo test --workspace` — clean except two **pre-existing, unrelated** flaky tests (`trusty-agents::mistake_log::tests::mistake_log_records_nonzero_exit`, `trusty-console::proxy::routes::tests::test_connect_retry_recovers_on_second_attempt`) — both pass in isolation, `git status` confirms zero changes to either crate in this branch
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `14 allowlisted, 0 violations — OK`

Closes #2203, #1870, #2211, #2179