### PR TITLE
chore: sync workspace dep pins to match released crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.5" }
 trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.1.2" }
 # tga: trusty-git-analytics — developer productivity analytics.
 # Referenced by trusty-review for contributor-profile data pipeline (#558).
-tga = { path = "crates/trusty-git-analytics", version = "2.8.2" }
+tga = { path = "crates/trusty-git-analytics", version = "2.9.0" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -49,7 +49,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.19.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.31.0" }
+trusty-search = { path = "../trusty-search", version = "0.31.1" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- tga: 2.8.2 → 2.9.0 (PR #2219)
- trusty-search in trusty-agents: 0.31.0 → 0.31.1 (PR #2220)

Metadata-only changes to keep workspace dependency pins consistent with released crate versions after the wave of PRs merged to main.

🤖 Generated with Claude Code