### PR TITLE
chore: re-cut trusty-search 0.32.1 to supersede 0.32.0 with P0 fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11091,7 +11091,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.31.1"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -49,7 +49,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.19.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.31.1" }
+trusty-search = { path = "../trusty-search", version = "0.32.1" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -6,6 +6,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.32.1] — 2026-07-07
+
+### Fixed — re-cut with P0 corpus-identity fixes (supersedes 0.32.0)
+
+- **0.32.1 = 0.32.0 versioning + 0.31.1's P0 fixes.** Version 0.32.0 was
+  published out-of-band (PR #2209) without corpus-identity hardening. This
+  re-cut applies the essential P0 fixes from 0.31.1 to the 0.32.0 version
+  line, becoming the latest published version. Consume 0.32.1 instead of 0.32.0.
+  
+  P0 fixes included (from 0.31.1):
+  - **Issues #2203, #1870 (corpus open failure):** failed durable-corpus open no
+    longer leaves `semantic`/`graph` falsely reporting `"ready"` (#2203).
+  - **Issue #2211 (`defer_embed` premature ready):** `stages.semantic.status`
+    no longer flips to `"ready"` prematurely during deferred embedding.
+  - **Issue #2179 (HNSW key-migration):** `rewrite_keys_to_relative` (M003
+    one-time migration) now genuinely promotes a view-mode store to mutable.
+
+---
+
 ## [0.31.1] — 2026-07-07
 
 ### Fixed — corpus/status desync bug cluster (issues #2203, #1870, #2211, #2179)

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.31.1"
+version = "0.32.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Version 0.32.0 was published out-of-band (PR #2209) without the corpus-identity hardening fixes. This re-cut applies the essential P0 fixes from 0.31.1 to the 0.32.0 version line, making 0.32.1 the latest published version.

**Expected dependency state after merge:**
- trusty-search 0.32.1 (re-cut, ready to publish)
- trusty-agents pin updated to 0.32.1
- trusty-memory 0.19.0 (not yet published)
- tga 2.9.0 (not yet published)
- All upstream dependencies already live (trusty-common 0.22.0, trusty-embedderd 0.3.5, trusty-bm25-daemon 0.1.3)

## Verification

- [x] cargo build --workspace (exit 0)
- [x] cargo test -p trusty-search (all pass)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --check
- [x] bash scripts/check_line_cap.sh (14 allowlisted, 0 violations)
- [x] No trusty-search source code dropped from 0.32.0 (only P0 fixes added)

## Test plan

- Squash-merge after trusty-review gate
- Post-merge: verify `cargo build --workspace` and grep confirm 0.32.1
- Ready for authorized publish step (trusty-search 0.32.1, trusty-memory 0.19.0, tga 2.9.0)