### PR TITLE
fix(trusty-code): orchestration robustness — higher turn budget, reuse-aware re-delegation, real-test finish-gate (closes #2228)

### DIFF
--- a/crates/trusty-code/src/prompt/preamble.rs
+++ b/crates/trusty-code/src/prompt/preamble.rs
@@ -55,6 +55,19 @@ what the tools expose.
 contents are extracted downstream as the run summary. Keep it concise and \
 factual.
 
+## Verification before finishing
+
+- Before you report the task as complete, if the project already has its own \
+automated test suite (existing unit/integration tests, a documented test \
+command, or a CI configuration), you MUST discover and run it, then report the \
+ACTUAL results you observed.
+- Tests you authored yourself for this task are not a substitute for the \
+project's own pre-existing test suite. Running only your own new tests while \
+an existing suite goes unrun is not verification.
+- Never claim tests passed without having actually executed a test command and \
+observed its output. If you could not run the suite, say so explicitly instead \
+of asserting an unverified result.
+
 ## Finish convention
 
 - You signal that the task is complete by producing an assistant turn that \

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -192,6 +192,35 @@ fn base_preamble_contains_required_blocks() {
     );
 }
 
+/// `BASE_PREAMBLE` requires running the project's OWN test suite before
+/// finishing, not just self-authored tests (bake-off L1 diagnosis: a
+/// delegated engineer's self-reported "my tests pass" previously let a
+/// missing feature ship unnoticed).
+///
+/// Why: This is the default finish-gate strengthening — it must apply to
+/// every agent (PM and delegated sub-agents alike), not just a benchmark
+/// harness, so it belongs in the model-agnostic BASE preamble every prompt
+/// assembles.
+/// What: Asserts the preamble instructs discovering/running the project's
+/// existing suite and explicitly rejects self-authored tests as a substitute.
+/// Test: this test.
+#[test]
+fn base_preamble_requires_running_project_test_suite_before_finishing() {
+    assert!(
+        BASE_PREAMBLE.contains("run it, then report the")
+            || BASE_PREAMBLE.to_lowercase().contains("run it"),
+        "must instruct running the project's own test suite before finishing"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("not a substitute for the"),
+        "must reject self-authored tests as a substitute for the project's own suite"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("Never claim tests passed without"),
+        "must forbid claiming unverified test results"
+    );
+}
+
 /// `BASE_PREAMBLE` carries no host- or model-specific tokens (spec §2a/§3).
 ///
 /// Why: Any model name, provider name, or host path in the BASE preamble would
@@ -229,7 +258,7 @@ fn base_preamble_version_is_semver_shaped() {
 /// Expected FNV-1a-style fold of [`BASE_PREAMBLE`]'s bytes, folded with its
 /// byte length. Regenerate this whenever the preamble legitimately changes
 /// (see [`base_preamble_hash_tripwire`] for the contributor instructions).
-const EXPECTED_PREAMBLE_HASH: u64 = 0x4443_27ac_ff1b_c454;
+const EXPECTED_PREAMBLE_HASH: u64 = 0x9376_d3b2_eb84_3e4e;
 
 /// Test-time guard coupling `BASE_PREAMBLE` *content* to its version constant.
 ///

--- a/crates/trusty-code/src/prompt/version.rs
+++ b/crates/trusty-code/src/prompt/version.rs
@@ -18,4 +18,4 @@
 /// `BASE_PREAMBLE` text so reports referencing an old run remain interpretable.
 /// Test: `prompt::tests::base_preamble_version_is_semver_shaped` asserts the
 /// three-component shape.
-pub const BASE_PREAMBLE_VERSION: &str = "1.0.0";
+pub const BASE_PREAMBLE_VERSION: &str = "1.1.0";

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -96,15 +96,29 @@ pub struct InProcessRunnerConfig {
 }
 
 impl Default for InProcessRunnerConfig {
-    /// Generous-but-bounded defaults matching `AgentLoopConfig`.
+    /// Generous-but-bounded defaults for a delegated sub-agent's own loop.
     ///
-    /// Why: Avoids boilerplate at construction; mirrors the loop's own defaults
-    /// so behaviour is unsurprising.
-    /// What: 8 turns, 120s timeout.
-    /// Test: `runner::tests::config_default_is_sane`.
+    /// Why: (bake-off L1 diagnosis) The former default of 8 turns was tuned for
+    /// a toy/single-file task; a realistic multi-file package build (reading
+    /// several existing files, writing/editing several more, running the
+    /// project's own tests before finishing per the strengthened finish-gate
+    /// convention) routinely needs more than 8 LLM round-trips. Exhausting the
+    /// cap mid-task forces a `TurnCapExceeded` abort, which historically
+    /// triggered a destructive PM re-delegation that discarded correct partial
+    /// work and rebuilt a simpler (sometimes incomplete) solution from scratch
+    /// — see `tools::delegate::redelegation_hint`, the companion fix that makes
+    /// re-delegation reuse-aware regardless of this budget. 40 turns is
+    /// deliberately generous: the tradeoff is a higher worst-case cost/latency
+    /// ceiling per delegation in exchange for comfortably fitting a real
+    /// package-sized task without truncation. Still fully overridable per call
+    /// via `RunContext.max_turns_override` (`run_pipeline`) or per-runner via
+    /// `with_config`/`InProcessRunnerConfig::default().max_turns = N`.
+    /// What: 40 turns, 120s timeout.
+    /// Test: `runner::tests::config_default_is_sane`,
+    /// `runner::tests::default_max_turns_is_generous`.
     fn default() -> Self {
         Self {
-            max_turns: 8,
+            max_turns: 40,
             timeout_secs: 120,
         }
     }
@@ -252,7 +266,7 @@ impl InProcessAgentRunner {
     /// Override the default loop budget (turn cap + timeout).
     ///
     /// Why: Deployments and tests may want a tighter or looser default than the
-    /// built-in 8 turns / 120s.
+    /// built-in 40 turns / 120s.
     /// What: Replaces `self.config`.
     /// Test: `runner::tests::run_context_overrides_max_turns` sets a config then
     /// overrides it per-call.

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -270,6 +270,32 @@ fn config_default_is_sane() {
     assert!(cfg.timeout_secs >= 1);
 }
 
+/// The default turn budget is generous enough for a real multi-file task, not
+/// the old 8-turn default that a package-sized delegation could exhaust
+/// mid-work (bake-off L1 diagnosis).
+///
+/// Why: A regression here would silently reintroduce the destructive
+/// re-delegation failure mode: a delegated engineer running out of turns
+/// before finishing a multi-file package, forcing a `TurnCapExceeded` abort.
+/// What: Asserts the default is comfortably above the old value of 8 and
+/// still overridable (`with_config`/`RunContext.max_turns_override` are
+/// covered by other tests in this module).
+/// Test: this test.
+#[test]
+fn default_max_turns_is_generous() {
+    let cfg = InProcessRunnerConfig::default();
+    assert!(
+        cfg.max_turns > 8,
+        "default max_turns must be raised above the old 8-turn cap, got {}",
+        cfg.max_turns
+    );
+    assert!(
+        cfg.max_turns >= 30,
+        "default max_turns should comfortably fit a multi-file package task, got {}",
+        cfg.max_turns
+    );
+}
+
 /// `agent_config_exists` detects present and absent configs.
 ///
 /// Why: Callers pre-check agent names with the same path rule the runner uses.

--- a/crates/trusty-code/src/tools/delegate.rs
+++ b/crates/trusty-code/src/tools/delegate.rs
@@ -4,14 +4,25 @@
 //! registry can register a single type that owns both. Pre-flight validation of
 //! `agent_name` against the on-disk agent config directory prevents the LLM from
 //! hallucinating sub-agent names and crashing the subprocess runner with a
-//! confusing IO error (#204 equivalent).
+//! confusing IO error (#204 equivalent). (bake-off L1 diagnosis) A delegated
+//! engineer that exhausts its turn/time budget has usually already written
+//! real, partial progress to disk; the PM's recovery historically was a
+//! free-text "re-delegate with a streamlined brief" that never told the next
+//! engineer instance to look at what was already there, so it silently
+//! rebuilt a simpler (sometimes incomplete) solution and orphaned the correct
+//! work. `redelegation_hint` makes the safer instruction automatic: it fires
+//! on every `TurnCapExceeded`/`Timeout`/`Cancelled` abort, regardless of
+//! whether the PM's own free text remembers to ask for it.
 //! What: `DelegateToAgentTool` wraps an `AgentRunner` and (optionally) an agent
 //! config directory. `execute()` parses `{agent_name, task}`, validates the agent
 //! config exists, and hands off to the runner. On miss, returns a helpful error
-//! listing available agents.
+//! listing available agents. On a runner failure caused by the sub-agent's own
+//! loop aborting with partial work still on disk, the returned `ToolResult`
+//! error appends a fixed reuse/continue directive (`redelegation_hint`).
 //! Test: `unknown_agent_returns_helpful_error` builds a tool pointed at a tempdir
 //! containing `engineer.toml` only, calls `execute({"agent_name":"ghost",...})`,
 //! and asserts the error names the unknown agent and lists `engineer`.
+//! `redelegation_hint_*` tests cover the reuse-directive behaviour.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -19,7 +30,53 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+use crate::agent_loop::AgentLoopError;
+use crate::runner::RunnerError;
 use crate::tools::traits::{AgentRunner, ToolExecutor, ToolResult};
+
+/// Detect whether an `AgentRunner` failure means the sub-agent's OWN loop
+/// aborted with partial work already on disk (turn cap, timeout, or
+/// cancellation), as opposed to a hard failure (unknown agent, bad config,
+/// LLM/transport error) that leaves nothing to reuse.
+///
+/// Why: (bake-off L1 diagnosis) The PM only sees this failure as opaque error
+/// text; without a structured signal, its free-text re-delegation brief has no
+/// reliable reason to mention the sub-agent's partial progress, so the next
+/// delegated instance rebuilds from scratch and orphans correct prior work.
+/// Surfacing a fixed directive automatically — every time this specific
+/// failure shape occurs — makes "read existing files, then continue" the
+/// default recovery instead of something the PM must remember to ask for.
+/// What: Downcasts `err` to [`RunnerError`] and matches `RunnerError::Loop`
+/// whose source is `AgentLoopError::TurnCapExceeded`, `Timeout`, or
+/// `Cancelled` (every abort variant that carries a partial `AgentOutput`,
+/// per that enum's own docs). Returns `None` for `UnknownAgent`, `ConfigLoad`,
+/// and `AgentLoopError::Llm` — those failure modes have no partial work to
+/// reuse.
+/// Test: `redelegation_hint_present_on_turn_cap_exceeded`,
+/// `redelegation_hint_present_on_timeout`,
+/// `redelegation_hint_present_on_cancelled`,
+/// `redelegation_hint_absent_on_unknown_agent`,
+/// `redelegation_hint_absent_on_llm_error`.
+fn redelegation_hint(err: &anyhow::Error) -> Option<&'static str> {
+    let RunnerError::Loop { source, .. } = err.downcast_ref::<RunnerError>()? else {
+        return None;
+    };
+    match source {
+        AgentLoopError::TurnCapExceeded { .. }
+        | AgentLoopError::Timeout { .. }
+        | AgentLoopError::Cancelled { .. } => Some(
+            "\n\nNOTE for re-delegation: the sub-agent stopped because it ran out of turns, \
+             time, or was cancelled — NOT because the task failed outright. It has likely \
+             already written real, partial progress to disk. Before delegating this task again: \
+             (1) inspect the project's current files to see what the sub-agent already \
+             produced, (2) instruct the next sub-agent to READ and CONTINUE/BUILD ON that \
+             existing work rather than rewriting it from scratch, and (3) consider a narrower \
+             follow-up task (or a higher turn budget) so it can finish what is already started \
+             instead of starting over.",
+        ),
+        AgentLoopError::Llm(_) => None,
+    }
+}
 
 /// Tool executor that delegates a task to a named sub-agent.
 ///
@@ -170,7 +227,10 @@ impl ToolExecutor for DelegateToAgentTool {
 
         match self.runner.run(agent_name, task).await {
             Ok(out) => ToolResult::ok(out.content),
-            Err(e) => ToolResult::err(format!("sub-agent '{agent_name}' failed: {e:#}")),
+            Err(e) => {
+                let hint = redelegation_hint(&e).unwrap_or("");
+                ToolResult::err(format!("sub-agent '{agent_name}' failed: {e:#}{hint}"))
+            }
         }
     }
 }
@@ -186,6 +246,9 @@ mod tests {
     use serde_json::json;
 
     use super::DelegateToAgentTool;
+    use crate::agent_loop::AgentLoopError;
+    use crate::llm::LlmError;
+    use crate::runner::RunnerError;
     use crate::tools::traits::{AgentOutput, AgentRunner, ToolExecutor};
 
     /// Recording mock runner.
@@ -400,5 +463,186 @@ mod tests {
             4,
             "runner must be called for each valid name"
         );
+    }
+
+    /// Mock runner that always fails with a caller-supplied error.
+    ///
+    /// Why: `redelegation_hint` tests need to control exactly which
+    /// `RunnerError`/`AgentLoopError` shape `execute()` observes, without
+    /// driving a real `AgentLoop`.
+    /// What: `run` always returns `Err` built from the stored `anyhow::Error`
+    /// factory (a `Fn` so each call gets a fresh error, since `anyhow::Error`
+    /// is not `Clone`).
+    /// Test: `redelegation_hint_present_on_turn_cap_exceeded` and siblings.
+    struct FailingRunner<F: Fn() -> anyhow::Error + Send + Sync> {
+        make_err: F,
+    }
+
+    #[async_trait]
+    impl<F: Fn() -> anyhow::Error + Send + Sync> AgentRunner for FailingRunner<F> {
+        async fn run(&self, _agent_name: &str, _task: &str) -> Result<AgentOutput> {
+            Err((self.make_err)())
+        }
+    }
+
+    /// A `TurnCapExceeded` sub-agent failure carries the reuse/continue
+    /// directive in the tool's error text.
+    ///
+    /// Why: This is the core bake-off L1 fix — the PM must see an automatic,
+    /// structured instruction to inspect and reuse partial work instead of
+    /// relying on its own free text remembering to ask for it.
+    /// What: `FailingRunner` returns `RunnerError::Loop` wrapping
+    /// `AgentLoopError::TurnCapExceeded`; assert the rendered error mentions
+    /// both re-delegation and reading/continuing existing work.
+    /// Test: this test.
+    #[tokio::test]
+    async fn redelegation_hint_present_on_turn_cap_exceeded() {
+        let runner = Arc::new(FailingRunner {
+            make_err: || {
+                anyhow::Error::from(RunnerError::Loop {
+                    name: "engineer".to_string(),
+                    source: AgentLoopError::TurnCapExceeded {
+                        max_turns: 8,
+                        partial: Box::new(AgentOutput::from_content("partial work")),
+                    },
+                })
+            },
+        });
+        let tool = DelegateToAgentTool::new(runner);
+
+        let result = tool
+            .execute(json!({"agent_name": "engineer", "task": "build the package"}))
+            .await;
+
+        assert!(result.is_error());
+        let msg = result.content();
+        assert!(
+            msg.contains("READ and CONTINUE"),
+            "must instruct the PM to reuse existing work, got: {msg}"
+        );
+        assert!(
+            msg.contains("already written real, partial progress"),
+            "must explain why re-delegation should not start over, got: {msg}"
+        );
+    }
+
+    /// A `Timeout` sub-agent failure gets the same reuse/continue directive.
+    ///
+    /// Why: A wall-clock timeout carries partial work exactly like a turn-cap
+    /// abort (per `AgentLoopError`'s own docs); the hint must not be
+    /// TurnCapExceeded-specific.
+    /// What: `FailingRunner` returns `RunnerError::Loop` wrapping
+    /// `AgentLoopError::Timeout`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn redelegation_hint_present_on_timeout() {
+        let runner = Arc::new(FailingRunner {
+            make_err: || {
+                anyhow::Error::from(RunnerError::Loop {
+                    name: "engineer".to_string(),
+                    source: AgentLoopError::Timeout {
+                        timeout_secs: 120,
+                        partial: Box::new(AgentOutput::from_content("partial work")),
+                    },
+                })
+            },
+        });
+        let tool = DelegateToAgentTool::new(runner);
+
+        let result = tool
+            .execute(json!({"agent_name": "engineer", "task": "build the package"}))
+            .await;
+
+        assert!(result.is_error());
+        assert!(result.content().contains("READ and CONTINUE"));
+    }
+
+    /// A `Cancelled` sub-agent failure gets the same reuse/continue directive.
+    ///
+    /// What: `FailingRunner` returns `RunnerError::Loop` wrapping
+    /// `AgentLoopError::Cancelled`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn redelegation_hint_present_on_cancelled() {
+        let runner = Arc::new(FailingRunner {
+            make_err: || {
+                anyhow::Error::from(RunnerError::Loop {
+                    name: "engineer".to_string(),
+                    source: AgentLoopError::Cancelled {
+                        partial: Box::new(AgentOutput::from_content("partial work")),
+                    },
+                })
+            },
+        });
+        let tool = DelegateToAgentTool::new(runner);
+
+        let result = tool
+            .execute(json!({"agent_name": "engineer", "task": "build the package"}))
+            .await;
+
+        assert!(result.is_error());
+        assert!(result.content().contains("READ and CONTINUE"));
+    }
+
+    /// An `UnknownAgent` runner failure gets NO reuse directive — there is no
+    /// partial work to reuse when the agent config never resolved.
+    ///
+    /// Why: The hint must not fire indiscriminately on every failure; guard
+    /// the negative case.
+    /// What: `FailingRunner` returns `RunnerError::UnknownAgent`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn redelegation_hint_absent_on_unknown_agent() {
+        let runner = Arc::new(FailingRunner {
+            make_err: || {
+                anyhow::Error::from(RunnerError::UnknownAgent {
+                    name: "ghost".to_string(),
+                    dir: std::path::PathBuf::from("/agents"),
+                })
+            },
+        });
+        let tool = DelegateToAgentTool::new(runner);
+
+        let result = tool
+            .execute(json!({"agent_name": "ghost", "task": "build the package"}))
+            .await;
+
+        assert!(result.is_error());
+        assert!(
+            !result.content().contains("READ and CONTINUE"),
+            "no partial work exists for an unresolved agent config, got: {}",
+            result.content()
+        );
+    }
+
+    /// A plain LLM/transport failure (no turn/time budget involved) gets NO
+    /// reuse directive.
+    ///
+    /// Why: Guards the negative case for the `Loop` variant itself — only the
+    /// three partial-output abort arms should trigger the hint.
+    /// What: `FailingRunner` returns `RunnerError::Loop` wrapping
+    /// `AgentLoopError::Llm`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn redelegation_hint_absent_on_llm_error() {
+        let runner = Arc::new(FailingRunner {
+            make_err: || {
+                anyhow::Error::from(RunnerError::Loop {
+                    name: "engineer".to_string(),
+                    source: AgentLoopError::Llm(LlmError::ApiError {
+                        status: 500,
+                        body: "internal error".to_string(),
+                    }),
+                })
+            },
+        });
+        let tool = DelegateToAgentTool::new(runner);
+
+        let result = tool
+            .execute(json!({"agent_name": "engineer", "task": "build the package"}))
+            .await;
+
+        assert!(result.is_error());
+        assert!(!result.content().contains("READ and CONTINUE"));
     }
 }


### PR DESCRIPTION
The M3 bake-off L1 surfaced a systematic bug where tcode's engineer wrote a correct solution, hit the turn cap, and the PM re-delegated from scratch and shipped a worse one (9/10 vs everyone else's 10/10). Three compounding orchestration defects fixed:

1. **max_turns default 8 → 40** (`runner/in_process.rs`) — a ~9-file package build exhausted the 8-turn engineer budget mid-work. Still fully overridable via RunContext/config.
2. **Reuse-aware re-delegation** (`tools/delegate.rs`) — on a partial-work abort (`TurnCapExceeded`/`Timeout`/`Cancelled`), the PM's tool result now carries a directive to READ and CONTINUE the sub-agent's existing on-disk work instead of rebuilding from scratch. Does NOT fire on real failures (UnknownAgent/ConfigLoad/Llm).
3. **Real-test finish-gate** (`prompt/preamble.rs`, BASE_PREAMBLE 1.0.0→1.1.0) — every agent must discover and run the PROJECT's own existing test suite before finishing, not just self-authored tests. Model-agnostic; applies to PM + all sub-agents.

QA: APPROVE (independent worktree at f0a24d6b) — build 0 warnings, 653 lib + 16 e2e tests pass, clippy/fmt clean, line-cap 0 violations, trusty-agents unaffected. All three fixes verified behaviorally meaningful; no new library unwrap(); #2198/#2210/#2156/#2213 un-regressed.

Follow-up (noted, not in scope): the PM's own AgentLoopConfig::default().max_turns is still 8 — safe (PM only does delegate/finish turns), track separately.

Closes #2228