### PR TITLE
fix(trusty-mpm): resolve stable binary for hooks/statusLine + self-heal stale paths (closes #2229)

### DIFF
--- a/crates/trusty-common/src/bin_resolve.rs
+++ b/crates/trusty-common/src/bin_resolve.rs
@@ -174,9 +174,71 @@ fn candidate(dir: &Path, name: &str) -> Option<PathBuf> {
     }
 }
 
+/// Path segments that mark a binary as an ephemeral (non-installed) build.
+///
+/// Why: a `target/debug`/`target/release` binary and any binary living under a
+/// git worktree directory are rebuilt/deleted on the next `cargo` invocation or
+/// worktree cleanup. Baking such a path into a persisted, shared config
+/// (managed hook commands, statusline command) leaves a stale absolute path
+/// that 404s once the build artifact is gone (#2229).
+/// What: the worktree layout markers this workspace uses
+/// (`.claude/worktrees/`, `.base/.worktrees/`) plus the two Cargo build
+/// profiles. Matched as substrings so `deps/`-nested and profile-suffixed
+/// variants are all covered.
+const EPHEMERAL_PATH_SEGMENTS: &[&str] = &[
+    "target/debug",
+    "target/release",
+    ".claude/worktrees/",
+    ".base/.worktrees/",
+];
+
+/// Whether `path` points inside an ephemeral build/worktree location that will
+/// not survive a rebuild or worktree cleanup.
+///
+/// Why: `std::env::current_exe()` returns a `target/debug/deps/...` path when
+/// `tm`/`trusty-mpm` runs from a worktree or a debug build. Persisting that
+/// path into the SHARED global `settings.json` (hook commands, statusline)
+/// breaks every managed session once the artifact is rebuilt away (#2229).
+/// Callers use this to reject `current_exe()` and fall back to a stable,
+/// PATH-resolved installed binary instead.
+/// What: returns `true` when the path's string form contains any of
+/// [`EPHEMERAL_PATH_SEGMENTS`]. Uses a lossy string comparison so non-UTF-8
+/// path components degrade to "not ephemeral" rather than panicking.
+/// Test: `is_ephemeral_build_path_flags_build_and_worktree_paths`,
+/// `is_ephemeral_build_path_accepts_installed_paths`.
+pub fn is_ephemeral_build_path(path: &Path) -> bool {
+    let s = path.to_string_lossy();
+    EPHEMERAL_PATH_SEGMENTS.iter().any(|seg| s.contains(seg))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_ephemeral_build_path_flags_build_and_worktree_paths() {
+        for p in [
+            "/Users/x/trusty-tools/target/debug/deps/trusty_mpm-abc123",
+            "/Users/x/trusty-tools/target/release/tm",
+            "/Users/x/repo/.claude/worktrees/fix-123/target/debug/tm",
+            "/Users/x/repo/.base/.worktrees/abc/crates/trusty-mpm",
+        ] {
+            assert!(
+                is_ephemeral_build_path(Path::new(p)),
+                "{p} must be flagged as an ephemeral build path"
+            );
+        }
+    }
+
+    #[test]
+    fn is_ephemeral_build_path_accepts_installed_paths() {
+        for p in ["/Users/x/.cargo/bin/trusty-mpm", "/usr/local/bin/tm", "tm"] {
+            assert!(
+                !is_ephemeral_build_path(Path::new(p)),
+                "{p} must NOT be flagged as an ephemeral build path"
+            );
+        }
+    }
 
     #[test]
     fn daemon_path_dirs_orders_user_before_system() {

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -47,13 +47,15 @@ use settings::{
 /// seeds `outputStyle`/`statusLine` into the tm-owned `CLAUDE_CONFIG_DIR`
 /// settings.json using these exact same values, rather than duplicating the
 /// default-id constant or the absolute-binary-path resolution logic.
-/// What: re-exports [`settings::OUTPUT_STYLE`] and
-/// [`settings::resolve_statusline_command`] as `session_launch::OUTPUT_STYLE` /
-/// `session_launch::resolve_statusline_command`.
+/// What: re-exports [`settings::OUTPUT_STYLE`],
+/// [`settings::resolve_statusline_command`], and
+/// [`settings::is_stale_statusline_command`] (so `settings_defaults` can
+/// self-heal a stale/ephemeral `statusLine` entry — #2229) under the
+/// `session_launch::` path.
 /// Test: covered indirectly by
 /// `core::standalone::settings_defaults` tests (this is a plain re-export, no
 /// logic of its own).
-pub(crate) use settings::{OUTPUT_STYLE, resolve_statusline_command};
+pub(crate) use settings::{OUTPUT_STYLE, is_stale_statusline_command, resolve_statusline_command};
 
 /// Outcome of the pre-launch preparation for one session.
 ///

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -758,10 +758,12 @@ pub(super) fn clean_global_trusty_memory_hooks(settings_path: &Path) -> Result<(
 /// without ever touching a genuinely user-customized `statusLine.command`.
 /// What: reads the existing `.claude/settings.json` (or `{}` when absent/invalid).
 /// When `statusLine` is absent, inserts it with the resolved absolute command.
-/// When present and it matches [`is_stale_bare_statusline_command`], rewrites
-/// ONLY its `command` field in place. Any other existing `statusLine` value —
-/// a genuine user customization — is left completely untouched. The file is
-/// written back pretty-printed only when a change was actually made.
+/// When present and it matches [`is_stale_statusline_command`] (a bare default,
+/// OR a `"<binary> statusline"` command whose absolute binary is ephemeral or
+/// no longer on disk — #2229), rewrites ONLY its `command` field in place. Any
+/// other existing `statusLine` value — a genuine user customization pointing at
+/// an existing binary — is left completely untouched. The file is written back
+/// pretty-printed only when a change was actually made.
 /// Test: `write_status_line_injects_when_absent`,
 /// `write_status_line_skips_when_already_set`,
 /// `write_status_line_preserves_user_config`,
@@ -796,7 +798,7 @@ pub(super) fn write_status_line(project_dir: &Path) -> Result<(), PrepError> {
             );
             true
         }
-        Some(existing) if is_stale_bare_statusline_command(existing) => {
+        Some(existing) if is_stale_statusline_command(existing) => {
             let resolved = resolve_statusline_command();
             match obj
                 .get_mut("statusLine")
@@ -877,6 +879,50 @@ pub(super) fn is_stale_bare_statusline_command(entry: &serde_json::Value) -> boo
             .is_some_and(|cmd| KNOWN_BARE_STATUSLINE_COMMANDS.contains(&cmd))
 }
 
+/// Whether an existing `statusLine` entry is a broken/stale trusty-mpm default
+/// that [`write_status_line`] / `ensure_settings_defaults` may safely re-resolve
+/// — a strict superset of [`is_stale_bare_statusline_command`].
+///
+/// Why (#2229): the original heal recognised ONLY the exact pre-#1914 bare
+/// literals; every other absolute `statusLine.command` was treated as an
+/// untouchable user customization. But a command baked from an ephemeral
+/// `current_exe()` (`.../target/debug/deps/tm statusline`, or a worktree path)
+/// is NOT a customization — it is our own output pointing at a build artifact
+/// that no longer exists on disk, so the statusline silently breaks and never
+/// self-heals. This predicate additionally flags a `"<binary> statusline"`
+/// command whose absolute binary path is ephemeral or missing on disk, while
+/// still leaving a genuine customization that points at an EXISTING,
+/// non-ephemeral binary completely alone.
+/// What: returns `true` when `entry.type == "command"` and either (a) the
+/// command is one of [`KNOWN_BARE_STATUSLINE_COMMANDS`], or (b) the command has
+/// our managed `"<binary> statusline"` shape AND the binary token is an
+/// absolute path that is either an ephemeral build path
+/// ([`trusty_common::bin_resolve::is_ephemeral_build_path`]) or does not exist.
+/// A command not ending in ` statusline`, or whose absolute binary still exists
+/// and is non-ephemeral, is left untouched.
+/// Test: `is_stale_statusline_command_flags_missing_and_ephemeral`,
+/// `is_stale_statusline_command_respects_existing_custom_binary`.
+pub(crate) fn is_stale_statusline_command(entry: &serde_json::Value) -> bool {
+    // Reuse the strict bare-default fingerprint for the pre-#1914 literals so
+    // that predicate stays the single source of truth for "our own bare
+    // default", then extend it with the ephemeral/missing absolute-path check.
+    if is_stale_bare_statusline_command(entry) {
+        return true;
+    }
+    if entry.get("type").and_then(serde_json::Value::as_str) != Some("command") {
+        return false;
+    }
+    let Some(cmd) = entry.get("command").and_then(serde_json::Value::as_str) else {
+        return false;
+    };
+    let Some(binary) = cmd.strip_suffix(" statusline") else {
+        return false;
+    };
+    let path = Path::new(binary);
+    path.is_absolute()
+        && (trusty_common::bin_resolve::is_ephemeral_build_path(path) || !path.exists())
+}
+
 /// Resolve the absolute `<binary> statusline` command to write into
 /// `statusLine.command`.
 ///
@@ -937,12 +983,15 @@ fn resolve_statusline_binary() -> String {
 /// `has_prior_conversation_in` injected-I/O-root pattern used elsewhere in
 /// this crate (`crate::runtime::claude_code`).
 /// What: returns `current_exe()`'s path as a `String` when it resolves to
-/// valid UTF-8; else the first hit of `path_lookup` over [`STATUSLINE_BIN_NAMES`]
+/// valid UTF-8 AND is not an ephemeral build/worktree path (#2229 — a
+/// `target/debug` or worktree exe would bake a path that 404s after a rebuild);
+/// else the first hit of `path_lookup` over [`STATUSLINE_BIN_NAMES`]
 /// (`"tm"` then `"trusty-mpm"` — #1914 review finding 1: a bare single-name
 /// PATH lookup reproduces the original bug on a `trusty-mpm`-only install);
 /// else the literal `"tm"` so the statusline segment degrades to pre-#1914
 /// behaviour rather than disappearing outright.
 /// Test: `resolve_statusline_binary_with_prefers_current_exe`,
+/// `resolve_statusline_binary_with_rejects_ephemeral_current_exe`,
 /// `resolve_statusline_binary_with_falls_back_to_path_lookup`,
 /// `resolve_statusline_binary_with_falls_back_to_trusty_mpm_name`,
 /// `resolve_statusline_binary_with_falls_back_to_bare_name`.
@@ -951,6 +1000,7 @@ pub(super) fn resolve_statusline_binary_with(
     path_lookup: impl Fn(&str) -> Option<PathBuf>,
 ) -> String {
     if let Ok(exe) = current_exe()
+        && !trusty_common::bin_resolve::is_ephemeral_build_path(&exe)
         && let Some(s) = exe.to_str()
     {
         return s.to_string();

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -3,8 +3,9 @@ use super::search_index::{
 };
 use super::settings::{
     clean_global_trusty_memory_hooks, deploy_output_style, inject_trusty_memory_mcp,
-    is_stale_bare_statusline_command, preseed_workspace_trust, resolve_statusline_binary_with,
-    trusty_memory_mcp_value, write_output_style, write_project_hooks, write_status_line,
+    is_stale_bare_statusline_command, is_stale_statusline_command, preseed_workspace_trust,
+    resolve_statusline_binary_with, trusty_memory_mcp_value, write_output_style,
+    write_project_hooks, write_status_line,
 };
 use super::*;
 use tempfile::tempdir;
@@ -1815,12 +1816,19 @@ fn prepare_session_config_style_overrides_manifest() {
 /// the test binary's path traverses a symlink (e.g. macOS `/tmp` ->
 /// `/private/tmp`).
 fn assert_resolved_statusline_command(cmd: &str) {
-    let exe = std::env::current_exe().expect("current_exe resolvable in test process");
-    let exe = exe.canonicalize().unwrap_or(exe);
-    let expected = format!("{} statusline", exe.to_str().expect("utf8 test exe path"));
-    assert_eq!(
-        cmd, expected,
-        "command must be '<current_exe> statusline', got {cmd}"
+    // #2229: the resolved statusline command must invoke the `statusline`
+    // subcommand and must NOT bake an ephemeral build/worktree path (the test
+    // process's own `current_exe()` is `target/debug/deps/...`, exactly the path
+    // that must be rejected). The binary is either a stable PATH-resolved
+    // install (`~/.cargo/bin/tm`) or the bare `tm`/`trusty-mpm` fallback — never
+    // the transient artifact — so we assert the invariant, not an exact path
+    // (which would depend on whether `tm` is installed in the test env).
+    let binary = cmd
+        .strip_suffix(" statusline")
+        .unwrap_or_else(|| panic!("command must end with ' statusline', got {cmd}"));
+    assert!(
+        !trusty_common::bin_resolve::is_ephemeral_build_path(std::path::Path::new(binary)),
+        "resolved statusline binary must not be an ephemeral build path, got {binary}"
     );
 }
 
@@ -1979,6 +1987,51 @@ fn is_stale_bare_statusline_command_ignores_non_command_type() {
     ));
 }
 
+// ── is_stale_statusline_command tests (#2229) ─────────────────────────────────
+
+#[test]
+fn is_stale_statusline_command_flags_missing_and_ephemeral() {
+    // Bare pre-#1914 defaults are stale (superset of is_stale_bare).
+    assert!(is_stale_statusline_command(
+        &serde_json::json!({"type": "command", "command": "tm statusline"})
+    ));
+    // An ephemeral build path is stale even though it is absolute.
+    assert!(is_stale_statusline_command(&serde_json::json!({
+        "type": "command",
+        "command": "/repo/target/debug/deps/trusty_mpm-abc statusline"
+    })));
+    // A worktree path is stale.
+    assert!(is_stale_statusline_command(&serde_json::json!({
+        "type": "command",
+        "command": "/repo/.claude/worktrees/fix-1/target/release/tm statusline"
+    })));
+    // An absolute path that does not exist on disk is stale.
+    assert!(is_stale_statusline_command(&serde_json::json!({
+        "type": "command",
+        "command": "/no/such/dir/definitely-missing-2229 statusline"
+    })));
+}
+
+#[cfg(unix)]
+#[test]
+fn is_stale_statusline_command_respects_existing_custom_binary() {
+    // An absolute binary that EXISTS and is not ephemeral is a genuine
+    // customization — never flagged. `/bin/sh` exists on every supported unix.
+    assert!(!is_stale_statusline_command(&serde_json::json!({
+        "type": "command",
+        "command": "/bin/sh statusline"
+    })));
+    // A command that is not our "<binary> statusline" shape is never flagged.
+    assert!(!is_stale_statusline_command(
+        &serde_json::json!({"type": "command", "command": "my-custom-line"})
+    ));
+    // Non-command entries are ignored.
+    assert!(!is_stale_statusline_command(&serde_json::json!({
+        "type": "text",
+        "command": "/no/such/dir/x statusline"
+    })));
+}
+
 // ── resolve_statusline_binary_with tests ──────────────────────────────────────
 
 #[test]
@@ -1988,6 +2041,27 @@ fn resolve_statusline_binary_with_prefers_current_exe() {
         |_name| Some(PathBuf::from("/should/not/be/used/tm")),
     );
     assert_eq!(resolved, "/abs/path/to/tm");
+}
+
+#[test]
+fn resolve_statusline_binary_with_rejects_ephemeral_current_exe() {
+    // #2229: when current_exe() is an ephemeral build/worktree path it must be
+    // rejected so the PATH-lookup fallback (a stable installed binary) is used
+    // instead — never the transient artifact.
+    let resolved = resolve_statusline_binary_with(
+        || Ok(PathBuf::from("/repo/target/debug/deps/trusty_mpm-abc123")),
+        |name| {
+            assert_eq!(
+                name, "tm",
+                "path lookup must search for the bare 'tm' name first"
+            );
+            Some(PathBuf::from("/opt/homebrew/bin/tm"))
+        },
+    );
+    assert_eq!(
+        resolved, "/opt/homebrew/bin/tm",
+        "an ephemeral current_exe must be rejected in favour of the PATH-resolved install"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -44,14 +44,39 @@ const BARE_HOOK_COMMAND: &str = "trusty-mpm hook";
 /// lost. Using the absolute path of the running binary eliminates the PATH
 /// dependency entirely and is correct by construction: the binary being
 /// installed is the same binary running `tm install`.
-/// What: calls `std::env::current_exe()`, canonicalizes the path, and
-/// returns `"<abs-path> hook"`. Falls back to `BARE_HOOK_COMMAND` if
-/// resolution or canonicalization fails so the install never panics.
-/// If a caller already knows the exe path (e.g. from `current_exe()` cached
-/// at startup), they can pass it via `exe_override` to skip the syscall.
+/// What: delegates to [`resolve_stable_hook_exe`] and renders `"<abs-path>
+/// hook"`; falls back to `BARE_HOOK_COMMAND` when no stable binary resolves so
+/// the install never panics. If a caller already knows the exe path (e.g. from
+/// `current_exe()` cached at startup), they can pass it via `exe_override` to
+/// skip the syscall.
 /// Test: `test_hook_command_uses_absolute_path`.
 pub fn mpm_hook_command(exe_override: Option<&Path>) -> String {
-    let resolved = exe_override
+    match resolve_stable_hook_exe(exe_override) {
+        Some(p) => format!("{} hook", p.display()),
+        None => BARE_HOOK_COMMAND.to_string(),
+    }
+}
+
+/// Resolve a STABLE, installed absolute binary path for baking into managed
+/// hook commands — never an ephemeral build/worktree path.
+///
+/// Why (#2229): `std::env::current_exe()` returns a
+/// `target/debug/deps/trusty_mpm-<hash>` (or worktree) path when `tm` runs from
+/// a debug build. Persisting that path into the SHARED global `settings.json`
+/// breaks every managed session's hooks once the artifact is rebuilt away. The
+/// hook command must instead point at a stable installed binary (`~/.cargo/bin/tm`)
+/// or degrade to the PATH-resolved bare name — anything but the transient path.
+/// What: prefers `exe_override` (canonicalized), then `current_exe()`
+/// (canonicalized), but only when the result is absolute AND not an ephemeral
+/// build path per [`trusty_common::bin_resolve::is_ephemeral_build_path`]. When
+/// the running binary is ephemeral or unresolved, PATH-resolves the installed
+/// `tm`/`trusty-mpm` binary via [`trusty_common::bin_resolve::resolve_binary`].
+/// Returns `None` only when no stable absolute path can be found (caller then
+/// uses the bare command name).
+/// Test: covered by `test_hook_command_uses_absolute_path`,
+/// `test_hook_command_rejects_ephemeral_exe_override`.
+fn resolve_stable_hook_exe(exe_override: Option<&Path>) -> Option<PathBuf> {
+    let running = exe_override
         .map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()))
         .or_else(|| {
             std::env::current_exe()
@@ -59,10 +84,19 @@ pub fn mpm_hook_command(exe_override: Option<&Path>) -> String {
                 .and_then(|p| p.canonicalize().ok().or(Some(p)))
         });
 
-    match resolved {
-        Some(p) if p.is_absolute() => format!("{} hook", p.display()),
-        _ => BARE_HOOK_COMMAND.to_string(),
+    if let Some(p) = running
+        && p.is_absolute()
+        && !trusty_common::bin_resolve::is_ephemeral_build_path(&p)
+    {
+        return Some(p);
     }
+
+    // Ephemeral or unresolved running path: fall back to a PATH-resolved
+    // installed binary so the hook command survives worktree/debug rebuilds.
+    MPM_BIN_NAMES
+        .iter()
+        .find_map(|name| trusty_common::bin_resolve::resolve_binary(name))
+        .filter(|p| p.is_absolute())
 }
 
 /// Build the MPM lifecycle hook additions JSON block (five events).
@@ -406,11 +440,13 @@ pub fn ensure_managed_hooks(claude_config_dir: &Path) -> anyhow::Result<()> {
 ///
 /// Why: callers that run `tm install` should pin the absolute path once
 /// (at install entry, before any `cd`) and pass it through. This helper
-/// centralises the `current_exe → canonicalize → Option<PathBuf>` dance.
-/// What: returns `Some(canonicalized_path)` or `None` if resolution fails.
-/// Test: covered indirectly by `test_hook_command_uses_absolute_path`.
+/// centralises resolution and, crucially, refuses to pin an ephemeral
+/// build/worktree path (#2229) that would 404 after a rebuild — falling back to
+/// the PATH-resolved installed binary instead.
+/// What: delegates to [`resolve_stable_hook_exe`] with no override, returning a
+/// stable installed absolute path, or `None` when none can be found.
+/// Test: covered indirectly by `test_hook_command_uses_absolute_path`,
+/// `test_hook_command_rejects_ephemeral_exe_override`.
 pub fn resolve_current_exe() -> Option<PathBuf> {
-    std::env::current_exe()
-        .ok()
-        .and_then(|p| p.canonicalize().ok().or(Some(p)))
+    resolve_stable_hook_exe(None)
 }

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -45,6 +45,28 @@ fn test_hook_command_without_override_is_absolute_or_fallback() {
     );
 }
 
+/// Why (#2229): an ephemeral build/worktree `exe_override` (e.g.
+/// `target/debug/deps/...`) must NOT be baked into the hook command — it 404s
+/// once the artifact is rebuilt away. The command must instead resolve a stable
+/// installed binary via PATH, or degrade to the bare fallback — never the
+/// worktree path.
+/// What: passes a `target/debug/deps` path as exe_override and asserts the
+/// resulting command never contains that ephemeral path and still ends with
+/// " hook".
+#[test]
+fn test_hook_command_rejects_ephemeral_exe_override() {
+    let ephemeral = PathBuf::from("/Users/x/trusty-tools/target/debug/deps/trusty_mpm-deadbeef");
+    let cmd = mpm_hook_command(Some(&ephemeral));
+    assert!(
+        !cmd.contains("target/debug/deps"),
+        "ephemeral build path must never be baked into the hook command, got: {cmd:?}"
+    );
+    assert!(
+        cmd.ends_with(" hook"),
+        "hook command must still end with ' hook', got: {cmd:?}"
+    );
+}
+
 #[test]
 fn test_mpm_hook_additions_has_five_events() {
     // #1744: SessionStart/SessionEnd must be present so the daemon receives

--- a/crates/trusty-mpm/src/core/standalone/settings_defaults.rs
+++ b/crates/trusty-mpm/src/core/standalone/settings_defaults.rs
@@ -13,11 +13,13 @@
 //! independent of the project tier.
 //! What: [`ensure_settings_defaults`] reads the tm-owned
 //! `<claude_config_dir>/settings.json` (tolerating absent/malformed content by
-//! starting from `{}`), sets `outputStyle` and `statusLine` ONLY when each key
-//! is not already present — never overwriting a value the client (or a prior
-//! `tm login`) already persisted there — and writes back atomically only when
-//! something actually changed. The values reused are the exact same ones the
-//! project-tier writer computes: [`crate::core::session_launch::OUTPUT_STYLE`]
+//! starting from `{}`), seeds `outputStyle` only when absent, and sets
+//! `statusLine` when absent OR when its existing command is stale — a binary
+//! that is an ephemeral build path or no longer exists on disk (#2229). A
+//! genuinely user-customized value pointing at an existing, non-ephemeral binary
+//! is never overwritten; the file is written back atomically only when something
+//! actually changed. The values reused are the exact same ones the project-tier
+//! writer computes: [`crate::core::session_launch::OUTPUT_STYLE`]
 //! (the default output-style id) and
 //! [`crate::core::session_launch::resolve_statusline_command`] (the resolved
 //! absolute `<tm-binary> statusline` command).
@@ -40,16 +42,23 @@ use trusty_common::claude_config::write_json_atomic;
 /// What: reads the on-disk `settings.json` (or starts from `{}` if
 /// absent/malformed/non-object), inserts `outputStyle` =
 /// [`crate::core::session_launch::OUTPUT_STYLE`] only if the key is not already
-/// present, inserts `statusLine` = `{ "type": "command", "command":
+/// present, and sets `statusLine` = `{ "type": "command", "command":
 /// <resolved absolute path> statusline", "padding": 0 }` (via
-/// [`crate::core::session_launch::resolve_statusline_command`]) only if the key
-/// is not already present, then writes back via
-/// [`trusty_common::claude_config::write_json_atomic`] only when the merged
-/// value actually differs from what was on disk (idempotent — no spurious
+/// [`crate::core::session_launch::resolve_statusline_command`]) when the key is
+/// absent OR when the existing command is stale — a binary that is an ephemeral
+/// build path or no longer exists on disk (#2229), per
+/// [`crate::core::session_launch::is_stale_statusline_command`]. A genuinely
+/// user-customized `statusLine` pointing at an existing, non-ephemeral binary is
+/// left untouched. Managed hook commands self-heal separately via
+/// [`super::hooks::write_project_hooks`]'s replace-by-identity merge. Writes
+/// back via [`trusty_common::claude_config::write_json_atomic`] only when the
+/// merged value actually differs from what was on disk (idempotent — no spurious
 /// rewrite / mtime bump on repeat calls).
 /// Test: `ensure_settings_defaults_seeds_fresh_file`,
 /// `ensure_settings_defaults_preserves_existing_keys`,
 /// `ensure_settings_defaults_does_not_overwrite_customized_values`,
+/// `ensure_settings_defaults_heals_stale_ephemeral_statusline`,
+/// `ensure_settings_defaults_preserves_existing_valid_binary_statusline`,
 /// `ensure_settings_defaults_is_idempotent`.
 pub(crate) fn ensure_settings_defaults(claude_config_dir: &Path) -> anyhow::Result<()> {
     let settings_path = claude_config_dir.join("settings.json");
@@ -69,13 +78,26 @@ pub(crate) fn ensure_settings_defaults(claude_config_dir: &Path) -> anyhow::Resu
     obj.entry("outputStyle").or_insert_with(|| {
         serde_json::Value::String(crate::core::session_launch::OUTPUT_STYLE.to_string())
     });
-    obj.entry("statusLine").or_insert_with(|| {
-        serde_json::json!({
-            "type": "command",
-            "command": crate::core::session_launch::resolve_statusline_command(),
-            "padding": 0
-        })
-    });
+
+    // statusLine: seed when absent, and self-heal when the existing command
+    // points at a binary that is an ephemeral build path or no longer exists on
+    // disk (#2229). A genuinely user-customized command that still points at an
+    // existing, non-ephemeral binary is left untouched by
+    // `is_stale_statusline_command`.
+    let statusline_needs_write = match obj.get("statusLine") {
+        None => true,
+        Some(existing) => crate::core::session_launch::is_stale_statusline_command(existing),
+    };
+    if statusline_needs_write {
+        obj.insert(
+            "statusLine".to_string(),
+            serde_json::json!({
+                "type": "command",
+                "command": crate::core::session_launch::resolve_statusline_command(),
+                "padding": 0
+            }),
+        );
+    }
 
     // Structural comparison (not byte-wise) so formatting differences left by
     // editors or prior writes never trigger a spurious rewrite, matching the
@@ -182,6 +204,76 @@ mod tests {
             "a pre-existing statusLine must never be clobbered"
         );
         assert_eq!(val["statusLine"]["padding"].as_i64(), Some(2));
+    }
+
+    #[test]
+    fn ensure_settings_defaults_heals_stale_ephemeral_statusline() {
+        // #2229: a statusLine.command baked from an ephemeral build path
+        // (target/debug/deps) — the exact defect — must be re-resolved to a
+        // stable command, NOT treated as untouchable customization.
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().to_path_buf();
+        let stale = "/tmp/target/debug/deps/tm-deadbeef statusline";
+        std::fs::write(
+            cfg.join("settings.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "statusLine": { "type": "command", "command": stale, "padding": 0 },
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        ensure_settings_defaults(&cfg).unwrap();
+
+        let text = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let healed = val["statusLine"]["command"].as_str().unwrap();
+        assert_ne!(
+            healed, stale,
+            "a stale ephemeral statusLine must be rewritten"
+        );
+        assert!(
+            !healed.contains("target/debug"),
+            "healed command must not point at an ephemeral build path, got {healed}"
+        );
+        assert!(
+            healed.ends_with(" statusline"),
+            "healed command must still invoke the statusline subcommand, got {healed}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_settings_defaults_preserves_existing_valid_binary_statusline() {
+        // A genuinely custom statusLine.command whose binary EXISTS on disk and
+        // is not an ephemeral build path must be left completely untouched
+        // (#2229 must not over-heal). `/bin/sh` exists on every supported unix.
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().to_path_buf();
+        let custom = "/bin/sh statusline";
+        std::fs::write(
+            cfg.join("settings.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "statusLine": { "type": "command", "command": custom, "padding": 3 },
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        ensure_settings_defaults(&cfg).unwrap();
+
+        let text = std::fs::read_to_string(cfg.join("settings.json")).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            val["statusLine"]["command"].as_str(),
+            Some(custom),
+            "a valid, existing custom binary statusLine must never be clobbered"
+        );
+        assert_eq!(
+            val["statusLine"]["padding"].as_i64(),
+            Some(3),
+            "the rest of a valid custom statusLine must survive untouched"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -731,6 +731,74 @@ use trusty_mpm::daemon::state::DaemonState;
 use trusty_mpm::runtime::RuntimeKind as ResumeRuntimeKind;
 use trusty_mpm::session_manager::ManagedSessionId as ResumeSessionId;
 
+// ── RAII PATH guard (#2229 CI determinism) ─────────────────────────────────
+//
+// Why: `resolve_statusline_binary`'s PATH-lookup fallback (see
+// `core::session_launch::settings::STATUSLINE_BIN_NAMES`) is exercised by
+// `resume_managed_heals_stale_bare_status_line_command` below. `current_exe()`
+// is unconditionally an ephemeral `target/debug/deps/...` path inside a
+// `cargo test` binary, so that test ALWAYS falls through to the PATH-lookup
+// branch — whether it then finds a real `tm`/`trusty-mpm` binary depends
+// entirely on the ambient environment (present on a dev machine with
+// `~/.cargo/bin` on PATH, absent in a stripped-down CI runner). Prepending a
+// temp dir containing a fake, executable `tm` to `PATH` for the duration of
+// the test makes the PATH-lookup hit deterministic in both environments,
+// mirroring the `HomeGuard` pattern in `tests/standalone_isolation.rs`.
+// `std::env::set_var`/`remove_var` are `unsafe` in Rust 2024 (thread-unsafe),
+// so every caller pairs this guard with `#[serial_test::serial]`.
+struct PathGuard(Option<String>);
+
+impl PathGuard {
+    /// Prepend `dir` to `PATH` and return a guard that restores the original
+    /// value on drop.
+    ///
+    /// Why: `trusty_common::bin_resolve::resolve_binary` checks the live
+    /// `PATH` before its well-known-dirs fallback, so prepending here is
+    /// sufficient to make a fake binary the first hit.
+    /// What: saves the current `PATH`, sets `PATH` to `<dir>:<old PATH>`,
+    /// returns a guard.
+    /// Test: exercised by `resume_managed_heals_stale_bare_status_line_command`.
+    fn prepend(dir: &std::path::Path) -> Self {
+        let prev = std::env::var("PATH").ok();
+        let new_path = match &prev {
+            Some(p) => format!("{}:{p}", dir.display()),
+            None => dir.display().to_string(),
+        };
+        // SAFETY: guarded by #[serial_test::serial] on all callers — only one
+        // thread mutates PATH at a time.
+        unsafe { std::env::set_var("PATH", new_path) };
+        PathGuard(prev)
+    }
+}
+
+impl Drop for PathGuard {
+    fn drop(&mut self) {
+        match &self.0 {
+            Some(p) => unsafe { std::env::set_var("PATH", p) },
+            None => unsafe { std::env::remove_var("PATH") },
+        }
+    }
+}
+
+/// Create a fake, executable `tm` binary at `<dir>/tm` so
+/// `trusty_common::bin_resolve::resolve_binary("tm")` resolves it.
+///
+/// Why: `candidate()` (the leaf of `resolve_binary`) requires the file to
+/// exist AND carry an execute bit on Unix — an empty regular file is rejected.
+/// What: writes a trivial shell script and chmods it `0o755`.
+/// Test: exercised by `resume_managed_heals_stale_bare_status_line_command`.
+fn write_fake_tm_binary(dir: &std::path::Path) -> PathBuf {
+    let bin = dir.join("tm");
+    std::fs::write(&bin, "#!/bin/sh\nexit 0\n").expect("write fake tm binary");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake tm binary executable");
+    }
+    bin
+}
+
 /// Resuming a missing session yields the typed `NotFound` variant (→ HTTP 404).
 ///
 /// Why: a session decommissioned (or never created) must produce a 404, and the
@@ -1002,11 +1070,30 @@ async fn resume_managed_launches_despite_incomplete_deployment() {
 /// second hook, so both self-heal concerns land through one code path.
 /// What: seeds a workspace whose `.claude/settings.json` already has the exact
 /// pre-#1914 bare `statusLine.command`, resumes it, and asserts the on-disk
-/// command is no longer the bare literal (it now carries a `/`, i.e. an
-/// absolute path).
+/// command is upgraded to the fake, PATH-resolved `tm` binary this test seeds
+/// (see `PathGuard`/`write_fake_tm_binary`) rather than merely checking for a
+/// `/` — #2229 made `current_exe()` always ineligible inside a `cargo test`
+/// binary (ephemeral `target/debug/deps/...`), so without a seeded PATH hit
+/// the outcome depends on whether the ambient environment happens to have
+/// `tm`/`trusty-mpm` installed, which is exactly what made this test pass
+/// locally and fail in CI.
 /// Test: this function IS the test.
 #[tokio::test]
+#[serial_test::serial]
 async fn resume_managed_heals_stale_bare_status_line_command() {
+    // #2229 CI determinism: `resolve_statusline_binary`'s `current_exe()`
+    // branch is ALWAYS rejected inside a `cargo test` binary (it lives under
+    // `target/debug/deps/...`, an ephemeral build path), so this test always
+    // exercises the PATH-lookup fallback. Whether that fallback finds a real
+    // `tm`/`trusty-mpm` binary is otherwise environment-dependent (present on
+    // a dev machine with `~/.cargo/bin` on PATH, absent in CI, which is
+    // exactly why this test flaked green-locally/red-in-CI) — prepend a fake,
+    // executable `tm` onto `PATH` so the upgrade is deterministic in both
+    // environments. See `PathGuard`/`write_fake_tm_binary` above.
+    let fake_bin_dir = TempDir::new().unwrap();
+    let fake_tm = write_fake_tm_binary(fake_bin_dir.path());
+    let _path_guard = PathGuard::prepend(fake_bin_dir.path());
+
     let root = TempDir::new().unwrap();
     let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
     let mgr = state.session_manager().await;
@@ -1054,17 +1141,15 @@ async fn resume_managed_heals_stale_bare_status_line_command() {
     let command = value["statusLine"]["command"]
         .as_str()
         .expect("statusLine.command is a string");
-    assert_ne!(
-        command, "tm statusline",
-        "the stale bare command must be upgraded, not left as-is; got: {content}"
-    );
-    assert!(
-        command.contains('/'),
-        "the healed command must resolve to an absolute path; got: {command}"
-    );
-    assert!(
-        command.ends_with(" statusline"),
-        "the healed command must still invoke the statusline subcommand; got: {command}"
+    // A single exact-equality assertion subsumes "was upgraded" (differs from
+    // the seeded bare literal), "resolves to an absolute path" (the fake
+    // binary's path is absolute), and "still invokes statusline" — no need for
+    // three separate weaker assertions.
+    let expected = format!("{} statusline", fake_tm.display());
+    assert_eq!(
+        command, expected,
+        "the stale bare command must be upgraded to the PATH-resolved fake `tm` \
+         binary seeded by this test, not left as-is; got: {content}"
     );
 }
 


### PR DESCRIPTION
Resolves two critical issues with binary resolution in hooks and status-line configuration:

- Guards `current_exe()` against ephemeral build paths (`target/debug|release`, worktree paths) at all three resolution sites: hooks `mpm_hook_command`/`resolve_current_exe`, and statusLine `resolve_statusline_binary_with`
- Adds self-heal logic so `ensure_settings_defaults` and `write_status_line` rewrite a statusLine/hook command whose binary no longer exists (was insert-only), while preserving valid custom commands
- Introduces `is_ephemeral_build_path` utility in trusty-common for robust path filtering

Gate run green by implementer. Note: pre-existing unrelated `banner::two_panel::right_col_no_inner_border` test failure is expected.

Closes #2229

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools