### PR TITLE
feat(trusty-mpm): opt-in deny-by-default pm_guard + warn-only carrier self-check (closes #2231)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -31,6 +31,7 @@ pub(crate) mod meta;
 pub(crate) mod misc;
 pub(crate) mod pm_guard;
 pub(crate) mod pm_guard_bash;
+pub(crate) mod pm_guard_deny_by_default;
 pub(crate) mod project;
 pub(crate) mod prune;
 pub(crate) mod repair;

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -27,17 +27,28 @@
 //! a static default-ALLOW + explicit deny-list: [`evaluate_tool`] denies the
 //! file-edit tools and forbidden Bash verbs and allows everything else. Every
 //! error path (malformed stdin, missing fields) fails **open** — ALLOW — so a
-//! broken hook never wedges the PM.
+//! broken hook never wedges the PM. **Opt-in deny-by-default (issue #2231):**
+//! the sub-agent exemption is narrowed, ONLY when
+//! [`pm_guard_deny_by_default::deny_by_default_enabled`] is truthy, so a
+//! delegated dispatch of an [`evaluate_tool`]-guarded tool is denied when
+//! [`pm_guard_deny_by_default::persona_status`] resolves to
+//! `PersonaStatus::ExplicitlyFailed` (a positively-recorded managed-session
+//! persona-deployment failure). This is the ONE place default behavior can
+//! change, and only when the operator explicitly opts in — see that module's
+//! doc comment for the full #2172-lesson rationale. Unset (the default),
+//! Guard 4 is byte-for-byte identical to the pre-#2231 unconditional exemption.
 //! Test: `evaluate_tool_*`, `payload_is_subagent_dispatch_*`, and
 //! `build_pretooluse_deny_response_*` below cover the tool policy, sub-agent
 //! exemption, and JSON shape; the Bash-command classifier (composition and
 //! substitution handling) lives in the sibling [`super::pm_guard_bash`] module
-//! with its own tests; `tests/tm_hook_pm_guard.rs` exercises the
-//! stdin→decision→stdout path (and the env bypasses / sub-agent exemption /
-//! fail-open) end to end through the real binary.
+//! with its own tests; the opt-in persona gate's policy lives in
+//! [`super::pm_guard_deny_by_default`] with its own tests; `tests/tm_hook_pm_guard.rs`
+//! exercises the stdin→decision→stdout path (and the env bypasses / sub-agent
+//! exemption / fail-open) end to end through the real binary.
 
 use crate::commands::misc::{DISABLE_HOOKS_ENV, SUB_AGENT_ENV, read_stdin_hook_payload};
 use crate::commands::pm_guard_bash::evaluate_bash_command;
+use crate::commands::pm_guard_deny_by_default::{self, PERSONA_DENY_REASON};
 
 /// Escape-hatch env var: `TRUSTY_MPM_PM_UNRESTRICTED=1` disables all PM
 /// enforcement for the invocation.
@@ -114,11 +125,32 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
         return Ok(());
     };
     let tool_input = payload.get("tool_input");
+    let session_id = payload
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
 
     // Guard 4: native Claude Code sub-agent dispatch (issue #2014). A
     // Task/Agent-dispatched sub-agent is doing exactly the delegated work the
-    // PM is steered toward, so its Edit/Write calls are exempt, not denied.
+    // PM is steered toward, so its Edit/Write calls are exempt, not denied —
+    // UNLESS the opt-in deny-by-default persona gate (issue #2231) is enabled
+    // AND this tool is one `evaluate_tool` would itself guard AND the
+    // session's persona is positively confirmed failed. `deny_by_default_enabled`
+    // short-circuits the `&&` below to `false` in the (default) unset case, so
+    // `evaluate_tool` is never even called on that path — this branch is
+    // byte-for-byte identical to the pre-#2231 unconditional exemption when
+    // the env var is unset.
     if payload_is_subagent_dispatch(&payload) {
+        if pm_guard_deny_by_default::deny_by_default_enabled()
+            && evaluate_tool(tool_name, tool_input).is_some()
+        {
+            let status = pm_guard_deny_by_default::persona_status(url).await;
+            if status.should_deny() {
+                audit_denied_tool(url, session_id, tool_name, PERSONA_DENY_REASON).await;
+                println!("{}", build_pretooluse_deny_response(PERSONA_DENY_REASON));
+                return Ok(());
+            }
+        }
         tracing::debug!(
             tool_name,
             "pm_guard: allow — native sub-agent dispatch (agent_id present in PreToolUse payload)"
@@ -135,10 +167,6 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
     // emit the block. The audit POST is intentionally the *only* daemon call
     // and fires solely on the rare deny path, so the common ALLOW path adds
     // zero latency to every tool invocation.
-    let session_id = payload
-        .get("session_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default();
     audit_denied_tool(url, session_id, tool_name, reason).await;
     println!("{}", build_pretooluse_deny_response(reason));
     Ok(())

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_deny_by_default.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_deny_by_default.rs
@@ -1,0 +1,396 @@
+//! Opt-in deny-by-default persona-confirmation gate for delegated (sub-agent)
+//! edit-tool dispatches under `tm hook --pm-guard` (issue #2231).
+//!
+//! Why: `pm_guard`'s Guard 4 (see `super::pm_guard::pm_guard`) unconditionally
+//! exempts a native Task/Agent-tool sub-agent dispatch from every deny rule —
+//! correct by default (issue #2014: the PM legitimately delegates edits to
+//! rust-engineer and friends), but it means a managed session whose persona
+//! deployment *positively, provably* failed would still let a delegated
+//! Edit/Write through unchallenged. Some operators want a stricter posture:
+//! refuse delegated edits too until the session's persona is confirmed. That
+//! must be strictly OPT-IN — issue #2172 is the standing lesson here: a
+//! fail-closed persona/spawn gate previously aborted real managed-session
+//! launches because it could not positively confirm success, even for
+//! perfectly healthy ad-hoc/`tm connect`/vanilla sessions that were never
+//! managed in the first place. This module repeats none of that: the new
+//! check is (a) OFF unless [`DENY_BY_DEFAULT_ENV`] is explicitly truthy, and
+//! (b) even when on, it only ever denies on POSITIVE evidence of failure
+//! (`state == "errored"`, the daemon's own definitive terminal-failure
+//! record); every ambiguous or unmanaged case allows, exactly like the
+//! pre-#2231 default.
+//! What: [`deny_by_default_enabled`] reads the opt-in env var (default:
+//! off — see [`is_truthy`] for the accepted spellings, shared with this
+//! crate's other boolean env-var parsers). [`persona_status`] resolves a
+//! [`PersonaStatus`] for the CURRENT pane by reading the `TM_MANAGED_SESSION_ID`
+//! pane env var (exported by `runtime::claude_code::session_id_export_prefix`
+//! into every managed session's shell — absent for ad-hoc/`tm connect`/vanilla
+//! sessions) and, only when present, querying the daemon's
+//! `GET /api/v1/sessions/managed/{id}` endpoint (via [`trusty_mpm::client::DaemonClient`],
+//! the same typed call `guided.rs`'s `nested_session_guard` already uses) with a
+//! tight connect+total timeout so an unreachable/slow daemon degrades to
+//! `Ambiguous` (allow) rather than hanging the hook. [`classify_persona_status`]
+//! is the pure decision core: no session id at all is [`PersonaStatus::NotManaged`];
+//! a resolved `state == "errored"` is [`PersonaStatus::ExplicitlyFailed`]; any
+//! other resolved state is [`PersonaStatus::Confirmed`]; a lookup that could not
+//! be resolved (daemon unreachable, id unknown, malformed id) is
+//! [`PersonaStatus::Ambiguous`]. [`PersonaStatus::should_deny`] is the ONLY
+//! place that maps a status to a gating decision — `true` solely for
+//! `ExplicitlyFailed`, so every other branch (including every error path)
+//! resolves to allow.
+//! Test: `is_truthy_*`, `classify_persona_status_*`,
+//! `persona_status_for_session_not_managed_when_session_id_absent`,
+//! `persona_status_for_session_ambiguous_when_daemon_unreachable`,
+//! `persona_status_should_deny_only_for_explicitly_failed`.
+
+use trusty_mpm::client::DaemonClient;
+
+/// Opt-in env var (issue #2231): when truthy (see [`is_truthy`]), a native
+/// sub-agent dispatch of an otherwise-guarded tool (Edit/Write/MultiEdit/
+/// NotebookEdit, or a guarded Bash verb — i.e. anything
+/// `super::pm_guard::evaluate_tool` would deny for the top-level PM) is
+/// DENIED unless [`persona_status`] resolves to [`PersonaStatus::Confirmed`],
+/// [`PersonaStatus::NotManaged`], or [`PersonaStatus::Ambiguous`]. Unset (the
+/// default) leaves Guard 4's unconditional sub-agent exemption completely
+/// unchanged.
+pub(crate) const DENY_BY_DEFAULT_ENV: &str = "TRUSTY_MPM_PM_DENY_BY_DEFAULT";
+
+/// The pane env var a managed session's launcher exports (see
+/// `runtime::claude_code::session_id_export_prefix`), naming the managed
+/// session this pane belongs to. Absent for ad-hoc/`tm connect`/vanilla
+/// `claude` invocations — there was never a launcher to export it.
+const MANAGED_SESSION_ID_ENV: &str = "TM_MANAGED_SESSION_ID";
+
+/// Deny reason surfaced when the persona gate denies a delegated dispatch.
+pub(crate) const PERSONA_DENY_REASON: &str = "PM session persona deployment explicitly failed \
+     (TRUSTY_MPM_PM_DENY_BY_DEFAULT strict mode). Delegated edit blocked until the managed \
+     session's persona is repaired (see `tm doctor`) or the session is restarted.";
+
+/// Parse a truthy token, shared spelling with this crate's other boolean env
+/// parsers (`core::auto_resume::parse_truthy`, `supervisor::config::env_bool`).
+///
+/// Why: one accepted-spellings list keeps every opt-in boolean flag in this
+/// crate consistent instead of each guard inventing its own.
+/// What: case-insensitive match against `1`/`true`/`yes`/`on`; `None` or any
+/// other value is not truthy.
+/// Test: `is_truthy_accepts_known_tokens`, `is_truthy_rejects_unknown_or_absent`.
+pub(crate) fn is_truthy(raw: Option<&str>) -> bool {
+    raw.is_some_and(|v| {
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+/// Whether the [`DENY_BY_DEFAULT_ENV`] opt-in is active for this process.
+///
+/// Why: split out so every call site shares one definition of "on".
+/// What: `true` iff [`DENY_BY_DEFAULT_ENV`] is set to a truthy token.
+/// Test: covered via `is_truthy_*` (this is a one-line env wrapper around it).
+pub(crate) fn deny_by_default_enabled() -> bool {
+    is_truthy(std::env::var(DENY_BY_DEFAULT_ENV).ok().as_deref())
+}
+
+/// Resolved persona-confirmation status for the current pane (issue #2231).
+///
+/// Why: the deny-by-default gate must distinguish "nothing to confirm" (not a
+/// managed session), "confirmed good", "positively confirmed bad", and
+/// "cannot tell" — collapsing the first three into "allow" and the fourth
+/// bucket into "allow" too is the entire #2172-lesson safeguard; see
+/// [`Self::should_deny`].
+/// What: one variant per resolvable state; see [`classify_persona_status`] for
+/// the pure mapping from raw inputs to this type.
+/// Test: `classify_persona_status_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PersonaStatus {
+    /// No `TM_MANAGED_SESSION_ID` at all — an ad-hoc/`tm connect`/vanilla
+    /// session with no launcher, hence nothing to have failed.
+    NotManaged,
+    /// A managed session whose daemon-reported state is anything other than
+    /// `errored` (e.g. `active`, `provisioning`, `stopped`).
+    Confirmed,
+    /// A managed session whose daemon-reported state is `errored` — a
+    /// concrete, positive record of failure, not merely absent evidence.
+    ExplicitlyFailed,
+    /// A managed session id is present but its state could not be resolved
+    /// (daemon unreachable/slow, id unknown to the daemon, malformed id).
+    /// This is deliberately NOT treated the same as `ExplicitlyFailed` — the
+    /// #2172 lesson is that absence of confirmation must never be treated as
+    /// confirmation of failure.
+    Ambiguous,
+}
+
+impl PersonaStatus {
+    /// Maximally-permissive mapping to a gating decision (the #2172 lesson,
+    /// applied here): only positive, unambiguous evidence of failure denies.
+    ///
+    /// Why: this is the ONE place a [`PersonaStatus`] becomes an ALLOW/DENY
+    /// verdict, so the permissive default is enforced in exactly one spot.
+    /// What: `true` only for [`Self::ExplicitlyFailed`]; every other variant
+    /// (including `Ambiguous`) is `false` (allow).
+    /// Test: `persona_status_should_deny_only_for_explicitly_failed`.
+    pub(crate) fn should_deny(self) -> bool {
+        matches!(self, Self::ExplicitlyFailed)
+    }
+}
+
+/// Pure decision core: map (session-id presence, resolved daemon state) to a
+/// [`PersonaStatus`].
+///
+/// Why: isolating the decision from the env-read and the HTTP call makes the
+/// actual policy exhaustively unit-testable without a daemon or process env
+/// mutation — the same "pure predicate, thin I/O wrapper" split already used
+/// by `guided::nested_managed_match` / `nested_session_guard` in this crate.
+/// What: no session id at all is [`PersonaStatus::NotManaged`]; a resolved
+/// state string equal to `"errored"` (the exact `ManagedSessionState::Errored`
+/// `Display` spelling — see `daemon::managed_routes::mod::` `SessionSummary`
+/// construction, `state: record.state.to_string()`) is
+/// [`PersonaStatus::ExplicitlyFailed`]; any other resolved state is
+/// [`PersonaStatus::Confirmed`]; `None` (lookup failed/unresolved) with a
+/// session id present is [`PersonaStatus::Ambiguous`].
+/// Test: `classify_persona_status_not_managed_without_session_id`,
+/// `classify_persona_status_confirmed_for_non_errored_state`,
+/// `classify_persona_status_explicitly_failed_for_errored_state`,
+/// `classify_persona_status_ambiguous_when_state_unresolved`.
+fn classify_persona_status(session_id_present: bool, state: Option<&str>) -> PersonaStatus {
+    if !session_id_present {
+        return PersonaStatus::NotManaged;
+    }
+    match state {
+        Some("errored") => PersonaStatus::ExplicitlyFailed,
+        Some(_) => PersonaStatus::Confirmed,
+        None => PersonaStatus::Ambiguous,
+    }
+}
+
+/// Best-effort daemon lookup of a managed session's lifecycle-state word.
+///
+/// Why: the daemon's `sessions.json`-backed `SessionRecord::state` is the
+/// only place a genuine `Errored` verdict is recorded; this hook process must
+/// not read that file directly (it may not share the daemon's resolved
+/// framework root) nor block on a slow/down daemon, so it reuses the same
+/// typed HTTP call `guided.rs`'s `nested_session_guard` already makes,
+/// with its own short-lived, tightly-timed client (mirrors
+/// `pm_guard::audit_denied_tool`'s connect/total timeout budget).
+/// What: `Some(state)` (e.g. `"active"`, `"errored"`) on a successful
+/// `GET /api/v1/sessions/managed/{id}`; `None` on ANY failure — client-build
+/// error, connect/timeout, non-2xx, or malformed body — so a down daemon
+/// degrades to [`PersonaStatus::Ambiguous`], never a hang or a deny.
+/// Test: exercised end to end (unreachable daemon → `None`) via
+/// `persona_status_for_session_ambiguous_when_daemon_unreachable`.
+async fn lookup_session_state(url: &str, session_id: &str) -> Option<String> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_millis(500))
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+        .ok()?;
+    let daemon = DaemonClient::with_client(client, url);
+    daemon
+        .get_managed_session(session_id)
+        .await
+        .ok()
+        .map(|s| s.state)
+}
+
+/// Resolve [`PersonaStatus`] given an explicit (test-injectable) session id.
+///
+/// Why: separating the session-id SOURCE from the resolution logic lets tests
+/// drive every branch (present/absent, reachable/unreachable daemon) without
+/// mutating process-global env state.
+/// What: `None`/empty `raw_session_id` short-circuits to
+/// [`classify_persona_status`]`(false, None)` (= `NotManaged`) with no network
+/// call at all; otherwise awaits [`lookup_session_state`] and classifies the
+/// result.
+/// Test: `persona_status_for_session_not_managed_when_session_id_absent`,
+/// `persona_status_for_session_ambiguous_when_daemon_unreachable`.
+pub(crate) async fn persona_status_for_session(
+    raw_session_id: Option<&str>,
+    url: &str,
+) -> PersonaStatus {
+    let Some(session_id) = raw_session_id.map(str::trim).filter(|s| !s.is_empty()) else {
+        return classify_persona_status(false, None);
+    };
+    let state = lookup_session_state(url, session_id).await;
+    classify_persona_status(true, state.as_deref())
+}
+
+/// Resolve [`PersonaStatus`] for the CURRENT pane by reading
+/// [`MANAGED_SESSION_ID_ENV`] from the process environment.
+///
+/// Why: this is the production entry point `pm_guard`'s Guard 4 calls; the
+/// pane-env read is the ONLY place this module touches `std::env` for the
+/// session id, keeping [`persona_status_for_session`] fully test-injectable.
+/// What: thin wrapper delegating to [`persona_status_for_session`].
+/// Test: covered by the `persona_status_for_session_*` tests (this adds only
+/// the env read, which mirrors the well-established `TM_MANAGED_SESSION_ID`
+/// read in `guided.rs::nested_session_guard`).
+pub(crate) async fn persona_status(url: &str) -> PersonaStatus {
+    let raw = std::env::var(MANAGED_SESSION_ID_ENV).ok();
+    persona_status_for_session(raw.as_deref(), url).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_truthy_accepts_known_tokens() {
+        for t in ["1", "true", "TRUE", "Yes", "on", " on "] {
+            assert!(is_truthy(Some(t)), "{t:?} should be truthy");
+        }
+    }
+
+    #[test]
+    fn is_truthy_rejects_unknown_or_absent() {
+        for f in [
+            None,
+            Some("0"),
+            Some("false"),
+            Some("no"),
+            Some("off"),
+            Some(""),
+        ] {
+            assert!(!is_truthy(f), "{f:?} should not be truthy");
+        }
+    }
+
+    #[test]
+    fn classify_persona_status_not_managed_without_session_id() {
+        // Case: no launcher ever ran (ad-hoc / `tm connect` / vanilla claude).
+        assert_eq!(
+            classify_persona_status(false, None),
+            PersonaStatus::NotManaged
+        );
+    }
+
+    #[test]
+    fn classify_persona_status_confirmed_for_non_errored_state() {
+        // Case (ii): managed session, deployment succeeded.
+        for state in ["active", "provisioning", "stopped"] {
+            assert_eq!(
+                classify_persona_status(true, Some(state)),
+                PersonaStatus::Confirmed,
+                "state {state:?} must classify as Confirmed"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_persona_status_explicitly_failed_for_errored_state() {
+        // Case (iii): managed session with a positive, recorded failure.
+        assert_eq!(
+            classify_persona_status(true, Some("errored")),
+            PersonaStatus::ExplicitlyFailed
+        );
+    }
+
+    #[test]
+    fn classify_persona_status_ambiguous_when_state_unresolved() {
+        // Case (iv, managed-but-inconclusive branch): a session id is present
+        // but its state could not be resolved — must NOT be treated as failure.
+        assert_eq!(
+            classify_persona_status(true, None),
+            PersonaStatus::Ambiguous
+        );
+    }
+
+    #[test]
+    fn persona_status_should_deny_only_for_explicitly_failed() {
+        assert!(PersonaStatus::ExplicitlyFailed.should_deny());
+        for allowed in [
+            PersonaStatus::NotManaged,
+            PersonaStatus::Confirmed,
+            PersonaStatus::Ambiguous,
+        ] {
+            assert!(
+                !allowed.should_deny(),
+                "{allowed:?} must never deny (the #2172 permissive default)"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn persona_status_for_session_not_managed_when_session_id_absent() {
+        // Case (iv, unmanaged branch): no id at all — allowed, and no network
+        // call is even attempted (a bogus unroutable URL would otherwise hang).
+        let status = persona_status_for_session(None, "http://127.0.0.1:1").await;
+        assert_eq!(status, PersonaStatus::NotManaged);
+    }
+
+    #[tokio::test]
+    async fn persona_status_for_session_ambiguous_when_daemon_unreachable() {
+        // Fail-open on internal error: an unroutable daemon URL must resolve
+        // to Ambiguous (allow), never hang and never deny.
+        let status = persona_status_for_session(
+            Some("11111111-1111-1111-1111-111111111111"),
+            "http://127.0.0.1:1",
+        )
+        .await;
+        assert_eq!(status, PersonaStatus::Ambiguous);
+    }
+
+    /// Spawn a one-shot HTTP mock daemon that replies to the
+    /// `GET /api/v1/sessions/managed/{id}` request with a canned
+    /// [`trusty_mpm::client::ManagedSessionSummary`]-shaped JSON body (issue
+    /// #2231, live-round-trip coverage for cases ii/iii).
+    ///
+    /// Why: the unreachable-daemon test above only covers the fail-open
+    /// branch; `persona_status_for_session`'s daemon-REACHABLE branch (state
+    /// `"active"` vs `"errored"`) needs a real HTTP round trip through
+    /// [`trusty_mpm::client::DaemonClient::get_managed_session`] to be
+    /// genuinely exercised, not merely asserted via the pure
+    /// `classify_persona_status` mapping. A raw one-shot [`TcpListener`] (no
+    /// axum router) is the lightest dependency-free mock, mirroring the same
+    /// technique `core::sm::providers::openrouter_tests::spawn_mock` uses in
+    /// the library crate.
+    /// What: binds an ephemeral port, accepts ONE connection, drains the
+    /// request (a bare GET has no body, so one read suffices), writes a fixed
+    /// 200 JSON response carrying `state`, and shuts down. Returns the bound
+    /// `http://127.0.0.1:PORT` base URL.
+    /// Test: used by `persona_status_for_session_confirmed_for_active_state`,
+    /// `persona_status_for_session_explicitly_failed_for_errored_state`.
+    async fn spawn_mock_daemon(state: &str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let body = format!(
+            r#"{{"id":"11111111-1111-1111-1111-111111111111","name":"tmpm-test","state":"{state}"}}"#
+        );
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.expect("accept");
+            let mut buf = [0u8; 1024];
+            let _ = sock.read(&mut buf).await;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.shutdown().await;
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn persona_status_for_session_confirmed_for_active_state() {
+        // Case (ii): managed session, deployment succeeded — a live daemon
+        // reporting `state: "active"` must resolve to Confirmed (allow).
+        let url = spawn_mock_daemon("active").await;
+        let status =
+            persona_status_for_session(Some("11111111-1111-1111-1111-111111111111"), &url).await;
+        assert_eq!(status, PersonaStatus::Confirmed);
+    }
+
+    #[tokio::test]
+    async fn persona_status_for_session_explicitly_failed_for_errored_state() {
+        // Case (iii): managed session with a positive, recorded failure — a
+        // live daemon reporting `state: "errored"` must resolve to
+        // ExplicitlyFailed (deny).
+        let url = spawn_mock_daemon("errored").await;
+        let status =
+            persona_status_for_session(Some("11111111-1111-1111-1111-111111111111"), &url).await;
+        assert_eq!(status, PersonaStatus::ExplicitlyFailed);
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -1325,6 +1325,10 @@ fn ensure_deployment_complete(
         return Ok(());
     }
     let outcome = crate::core::deploy_validate::validate_and_repair(fw, workspace, repo_url);
+    // Warn-only carrier-reachability self-check (issue #2231) — see its own
+    // doc comment. Runs regardless of the completeness verdict below and can
+    // NEVER turn this `Ok` branch into an `Err`; it only logs.
+    warn_if_no_persona_carrier(&outcome.after.gaps, workspace, session_id);
     if outcome.before.is_complete() {
         return Ok(());
     }
@@ -1342,6 +1346,93 @@ fn ensure_deployment_complete(
         detail.len(),
         detail.join("; ")
     ))
+}
+
+/// Warn-only self-check: is at least one delegation-persona CARRIER reachable
+/// under the daemon path's `--setting-sources project,local` posture (issue
+/// #2231)?
+///
+/// Why: `--setting-sources project,local` (see
+/// `core::model_inject::SETTING_SOURCES_FLAG`) restricts the launched
+/// `claude` to the project+local tiers and EXCLUDES the `user` tier that
+/// `CLAUDE_CONFIG_DIR` relocates to (see `core::managed_config`'s module doc,
+/// "WHICH LAYER ACTUALLY LOADS THE ROSTER") — so the PM's identity survives
+/// ONLY if a project-tier carrier is reachable: either the deployed
+/// `trusty-mpm` output-style file (`settings.json`'s `outputStyle` resolving
+/// to a real file under `.claude/output-styles/`), or the per-workspace
+/// instructions stash (`<workspace>/.trusty-mpm/last-instructions.md`,
+/// written by `session_launch::prepare_session_inner` and injected via
+/// `--append-system-prompt-file`). This is a DIAGNOSTIC ONLY, mirroring the
+/// #2172/98b994c3 lesson this very function already embodies
+/// (`ensure_deployment_complete` was softened from a hard gate to a
+/// non-blocking warn by #2172, commit 98b994c3) — over-reporting "no carrier
+/// reachable" must NEVER abort a real launch, so this only logs; it cannot
+/// fail this function or any caller, and it never returns a value.
+/// What: logs `tracing::warn!` with an actionable message (naming the missing
+/// carriers and how they are normally wired) when [`carrier_reachable`]
+/// returns `false`; a no-op otherwise.
+/// Test: `carrier_reachable_*` cover the pure predicate directly;
+/// `ensure_deployment_complete_does_not_abort_when_no_carrier_reachable`
+/// asserts this self-check never turns the caller's `Ok` into an `Err`.
+fn warn_if_no_persona_carrier(
+    gaps: &[crate::core::deploy_validate::DeploymentGap],
+    workspace: &std::path::Path,
+    session_id: &ManagedSessionId,
+) {
+    if carrier_reachable(gaps, workspace) {
+        return;
+    }
+    warn!(
+        id = %session_id,
+        workspace = %workspace.display(),
+        "deployment self-check: no delegation-persona carrier reachable under \
+         --setting-sources project,local (no project-tier output-style file \
+         resolved from settings.json's outputStyle, and no \
+         .trusty-mpm/last-instructions.md prompt stash) — the launched PM may \
+         be missing its identity/instructions carrier; this is diagnostic only \
+         and does not block the launch (issue #2231). Re-run `tm doctor` or \
+         `tm repair` against this workspace to re-provision the .claude/ payload."
+    );
+}
+
+/// Pure predicate: is at least one delegation-persona carrier reachable?
+///
+/// Why: isolated from the logging side effect in
+/// [`warn_if_no_persona_carrier`] so the decision itself is directly
+/// unit-testable — see that function's doc for the full carrier-reachability
+/// rationale.
+/// What: `true` when `gaps` contains NONE of the output-style-related
+/// [`crate::core::deploy_validate::DeploymentGap`] variants
+/// (`OutputStyleKeyMissing`, `OutputStyleUnknownId`, `OutputStyleFileMissing`)
+/// — the output-style carrier is intact — OR
+/// `<workspace>/.trusty-mpm/last-instructions.md` exists and is non-empty (the
+/// prompt-file carrier). `false` only when NEITHER carrier is reachable.
+/// Test: `carrier_reachable_true_when_no_output_style_gap`,
+/// `carrier_reachable_true_when_prompt_file_present_despite_style_gap`,
+/// `carrier_reachable_false_when_neither_carrier_present`.
+fn carrier_reachable(
+    gaps: &[crate::core::deploy_validate::DeploymentGap],
+    workspace: &std::path::Path,
+) -> bool {
+    use crate::core::deploy_validate::DeploymentGap;
+
+    let output_style_ok = !gaps.iter().any(|g| {
+        matches!(
+            g,
+            DeploymentGap::OutputStyleKeyMissing
+                | DeploymentGap::OutputStyleUnknownId(_)
+                | DeploymentGap::OutputStyleFileMissing(_)
+        )
+    });
+    if output_style_ok {
+        return true;
+    }
+    workspace
+        .join(".trusty-mpm")
+        .join("last-instructions.md")
+        .metadata()
+        .map(|m| m.is_file() && m.len() > 0)
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -1769,5 +1860,140 @@ mod tests {
         let id = ManagedSessionId::new();
         let result = ensure_deployment_complete(&fw, &workspace, None, &id);
         assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    /// Why (#2231): when neither carrier is present (no output-style gap
+    /// resolved AND no prompt-file stash), an empty `gaps` slice trivially
+    /// satisfies the output-style branch — this proves that specific
+    /// short-circuit.
+    /// Test: itself.
+    #[test]
+    fn carrier_reachable_true_when_no_output_style_gap() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(
+            carrier_reachable(&[], tmp.path()),
+            "no output-style gap at all must be treated as carrier-reachable"
+        );
+    }
+
+    /// Why (#2231): the prompt-file carrier is an ALTERNATIVE to the
+    /// output-style carrier — a workspace with an output-style gap but a
+    /// present, non-empty `.trusty-mpm/last-instructions.md` must still be
+    /// reachable.
+    /// Test: itself.
+    #[test]
+    fn carrier_reachable_true_when_prompt_file_present_despite_style_gap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stash_dir = tmp.path().join(".trusty-mpm");
+        std::fs::create_dir_all(&stash_dir).unwrap();
+        std::fs::write(stash_dir.join("last-instructions.md"), "you are the PM").unwrap();
+
+        let gaps = vec![crate::core::deploy_validate::DeploymentGap::OutputStyleKeyMissing];
+        assert!(
+            carrier_reachable(&gaps, tmp.path()),
+            "a present, non-empty prompt-file stash must satisfy the carrier check \
+             even when the output-style carrier has a gap"
+        );
+    }
+
+    /// Why (#2231): the false case — an output-style gap AND no prompt-file
+    /// stash at all — must resolve to "no carrier reachable" so the warn-only
+    /// diagnostic fires.
+    /// Test: itself.
+    #[test]
+    fn carrier_reachable_false_when_neither_carrier_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gaps = vec![
+            crate::core::deploy_validate::DeploymentGap::OutputStyleFileMissing(
+                "trusty-mpm".to_string(),
+            ),
+        ];
+        assert!(
+            !carrier_reachable(&gaps, tmp.path()),
+            "an output-style gap with no prompt-file stash must be unreachable"
+        );
+    }
+
+    /// Why (#2231): an EMPTY (zero-byte) prompt-file stash must not count as
+    /// "wired" — a truncated/placeholder file is not a real carrier.
+    /// Test: itself.
+    #[test]
+    fn carrier_reachable_false_when_prompt_file_present_but_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stash_dir = tmp.path().join(".trusty-mpm");
+        std::fs::create_dir_all(&stash_dir).unwrap();
+        std::fs::write(stash_dir.join("last-instructions.md"), "").unwrap();
+
+        let gaps = vec![
+            crate::core::deploy_validate::DeploymentGap::OutputStyleUnknownId("bogus".to_string()),
+        ];
+        assert!(!carrier_reachable(&gaps, tmp.path()));
+    }
+
+    /// Why (#2231): [`warn_if_no_persona_carrier`] returns `()` and is the
+    /// ONLY thing `ensure_deployment_complete` calls for this self-check — its
+    /// signature already makes it structurally impossible to turn the
+    /// caller's `Ok` into an `Err`. This proves it also never PANICS when
+    /// neither carrier is reachable (the exact condition that makes it log).
+    /// Test: itself — reaching the end of this test without panicking IS the
+    /// assertion.
+    #[test]
+    fn warn_if_no_persona_carrier_does_not_panic_when_neither_carrier_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gaps = vec![crate::core::deploy_validate::DeploymentGap::OutputStyleKeyMissing];
+        let id = ManagedSessionId::new();
+        warn_if_no_persona_carrier(&gaps, tmp.path(), &id);
+    }
+
+    /// Why (#2231): full-pipeline regression guard — even when auto-repair
+    /// cannot write anything at all (workspace directory made read-only, so
+    /// NEITHER the output-style file nor the `.trusty-mpm/last-instructions.md`
+    /// stash can be created), `ensure_deployment_complete` must still RETURN
+    /// (not panic/hang) — the carrier self-check is purely additive logging
+    /// and can never abort this call. The pre-existing (unrelated, #2172)
+    /// contract — an unrepairable gap surfaces as `Err` for the caller to log
+    /// non-blockingly — is asserted too, proving this diagnostic didn't change
+    /// it. Skipped when running as root: a read-only directory does not block
+    /// root's writes, so the "nothing got written" precondition cannot be
+    /// established.
+    /// Test: itself. Unix-only (permission bits).
+    #[cfg(unix)]
+    #[test]
+    fn ensure_deployment_complete_does_not_abort_when_no_carrier_reachable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::set_permissions(&workspace, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        // Confirm the read-only precondition actually holds before relying on
+        // it — running as root would silently defeat it.
+        let probe = workspace.join(".probe");
+        if std::fs::write(&probe, "x").is_ok() {
+            let _ = std::fs::remove_file(&probe);
+            let _ = std::fs::set_permissions(&workspace, std::fs::Permissions::from_mode(0o755));
+            eprintln!(
+                "skipping ensure_deployment_complete_does_not_abort_when_no_carrier_reachable: \
+                 read-only directory did not block a write (likely running as root)"
+            );
+            return;
+        }
+
+        let mut fw =
+            crate::core::paths::FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+        fw.trusty_mpm_root = None;
+        let id = ManagedSessionId::new();
+
+        let result = ensure_deployment_complete(&fw, &workspace, None, &id);
+
+        // Restore write permission so the TempDir can clean itself up.
+        let _ = std::fs::set_permissions(&workspace, std::fs::Permissions::from_mode(0o755));
+
+        assert!(
+            result.is_err(),
+            "expected the pre-existing incomplete-after-repair contract to still hold \
+             (unrelated to the new carrier self-check); got {result:?}"
+        );
     }
 }

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -1,5 +1,6 @@
 //! Integration test for `tm hook --pm-guard` — PM PreToolUse enforcement
-//! (issue #1977; native sub-agent exemption issue #2014).
+//! (issue #1977; native sub-agent exemption issue #2014; opt-in deny-by-default
+//! persona gate issue #2231).
 //!
 //! Why: `commands::pm_guard`'s unit tests cover the pure policy (which tools /
 //! Bash verbs deny) in isolation, but none exercises the actual
@@ -35,6 +36,8 @@ fn run_pm_guard(stdin_json: &str, extra_env: &[(&str, &str)]) -> String {
         .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
         .env_remove("CLAUDE_MPM_SUB_AGENT")
         .env_remove("TRUSTY_MPM_PM_UNRESTRICTED")
+        .env_remove("TRUSTY_MPM_PM_DENY_BY_DEFAULT")
+        .env_remove("TM_MANAGED_SESSION_ID")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -207,6 +210,61 @@ fn pm_guard_native_subagent_dispatch_allows_bash() {
         stdout.trim(),
         "",
         "a native sub-agent's Bash call must be allowed"
+    );
+}
+
+#[test]
+fn pm_guard_deny_by_default_unset_allows_subagent_edit_unchanged() {
+    // Issue #2231, case (i): TRUSTY_MPM_PM_DENY_BY_DEFAULT unset (default) — a
+    // native sub-agent's Edit call must be allowed exactly as before, with no
+    // TM_MANAGED_SESSION_ID at all (not a managed session).
+    let stdout = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","agent_id":"agent-abc123","tool_name":"Edit","tool_input":{"file_path":"/x/a.rs","old_string":"a","new_string":"b"}}"#,
+        &[],
+    );
+    assert_eq!(
+        stdout.trim(),
+        "",
+        "deny-by-default unset must leave the sub-agent exemption unchanged"
+    );
+}
+
+#[test]
+fn pm_guard_deny_by_default_allows_subagent_edit_when_not_managed() {
+    // Issue #2231, case (iv, unmanaged branch): TRUSTY_MPM_PM_DENY_BY_DEFAULT=1
+    // but no TM_MANAGED_SESSION_ID (ad-hoc/`tm connect`/vanilla session) — the
+    // permissive #2172-lesson default must still allow.
+    let stdout = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","agent_id":"agent-abc123","tool_name":"Edit","tool_input":{"file_path":"/x/a.rs","old_string":"a","new_string":"b"}}"#,
+        &[("TRUSTY_MPM_PM_DENY_BY_DEFAULT", "1")],
+    );
+    assert_eq!(
+        stdout.trim(),
+        "",
+        "an unmanaged session must be allowed even in strict mode"
+    );
+}
+
+#[test]
+fn pm_guard_deny_by_default_allows_subagent_edit_when_daemon_unreachable() {
+    // Issue #2231, case (iv, ambiguous branch): TRUSTY_MPM_PM_DENY_BY_DEFAULT=1
+    // AND a managed-session id set, but the daemon (fixed at an unreachable
+    // address by `run_pm_guard`) cannot confirm the session's state — ambiguous
+    // must allow, never hang and never deny.
+    let stdout = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","agent_id":"agent-abc123","tool_name":"Edit","tool_input":{"file_path":"/x/a.rs","old_string":"a","new_string":"b"}}"#,
+        &[
+            ("TRUSTY_MPM_PM_DENY_BY_DEFAULT", "1"),
+            (
+                "TM_MANAGED_SESSION_ID",
+                "11111111-1111-1111-1111-111111111111",
+            ),
+        ],
+    );
+    assert_eq!(
+        stdout.trim(),
+        "",
+        "an unresolvable (ambiguous) persona status must allow, not deny"
     );
 }
 


### PR DESCRIPTION
TRUSTY_MPM_PM_DENY_BY_DEFAULT=1 opt-in inverts pm_guard to deny-unless-persona-confirmed (default behavior byte-identical — short-circuited off when unset; denies only on positively-confirmed failed deployment, errs toward allow per the #2172 lesson); `ensure_deployment_complete` gains a warn-only carrier-reachability diagnostic that never aborts a launch. Gate green by implementer (only the pre-existing `banner::two_panel::right_col_no_inner_border` fails). Ref #2125.

Closes #2231

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools