### PR TITLE
fix(trusty-mpm): delegation persona reaches resume path + harden tm connect (closes #2230)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -384,18 +384,32 @@ pub(crate) async fn launch(
     Ok(())
 }
 
-/// `connect` subcommand — start or attach to a session without deployment.
+/// `connect` subcommand — start or attach to a session in the live checkout.
 ///
 /// Why: `tm connect` is the lightweight sibling of `tm launch`. Where `launch`
 /// provisions a managed clone, `connect` runs directly in the live checkout without
 /// any cloning. This is the recommended path for repos without a GitHub remote, or
-/// when the operator needs to work with uncommitted local changes.
+/// when the operator needs to work with uncommitted local changes. Issue #2230:
+/// `connect` used to deploy NOTHING and launch a bare
+/// `claude --dangerously-skip-permissions` with no PM persona — the one launch
+/// path that could silently spawn vanilla Claude Code. It now runs the same
+/// [`trusty_mpm::core::session_launch::prepare_session`] seam
+/// `DaemonClient::launch_session` (the TUI's `/connect`) uses, deploying agents,
+/// skills, the project-tier output-style, and the `trusty-memory`/PM-guard
+/// project hooks directly into the live checkout — no clone, no git-remote or
+/// clean-tree requirement, so repos with no GitHub remote or uncommitted
+/// changes (this command's whole reason to exist) still launch.
 /// What: resolves `dir`, reconnects to a live session for the directory when
-/// one exists, otherwise registers the session via
-/// `POST /api/v1/sessions/connect`, creates the tmux host idempotently
-/// (`tmux new-session -A`), starts `claude` only when the session is freshly
-/// created, and `attach`es to it. No agents, skills, instructions, or
-/// system-prompt files are written.
+/// one exists, otherwise runs [`trusty_mpm::core::session_launch::prepare_session`]
+/// (best-effort — logs and continues on any failure, never aborts the
+/// connect), registers the session via `POST /api/v1/sessions/connect`,
+/// builds the PM system prompt via
+/// [`trusty_mpm::core::session_launch::build_system_prompt_for_with_style_and_native`]
+/// and writes it to a temp file, creates the tmux host idempotently
+/// (`tmux new-session -A`), and — only when the session is freshly created —
+/// starts `claude` via [`connect_claude_cmd`] (`--append-system-prompt-file`
+/// plus the shared `--setting-sources project,local` /
+/// `--dangerously-skip-permissions` isolation flags), then `attach`es to it.
 /// Test: `cli_parses_connect`, `cli_parses_connect_with_dir`.
 pub(crate) async fn connect(
     client: &reqwest::Client,
@@ -423,10 +437,46 @@ pub(crate) async fn connect(
         return Ok(());
     }
 
-    // 2. Register the session with the daemon via the connect endpoint. No
-    //    `prepare_session` and no `install_system_prompt` — `connect` skips the
-    //    entire deployment sequence. When the daemon is unreachable we still
-    //    bring the session up under the folder-derived name.
+    // 1c. Deploy the framework directly into the live checkout — agents,
+    //     skills, the project-tier output-style, and the
+    //     `trusty-memory`/PM-guard project hooks (issue #2230). This is the
+    //     SAME `prepare_session` seam `DaemonClient::launch_session` (the
+    //     TUI's `/connect`) uses; unlike `tm launch` it performs no
+    //     git-remote or clean-tree check at all — only filesystem writes
+    //     under `path` — so a repo with no GitHub remote or with uncommitted
+    //     changes still launches. Best-effort: a prep failure is logged and
+    //     never aborts the connect.
+    let fw = trusty_mpm::core::paths::FrameworkPaths::default();
+    match trusty_mpm::core::session_launch::prepare_session(&fw, &path) {
+        Ok(report) => {
+            for err in &report.roster_errors {
+                tracing::error!("roster provisioning gap for {}: {err}", path.display());
+            }
+        }
+        Err(err) => {
+            tracing::warn!(
+                "session prep failed for {} (non-fatal): {err}",
+                path.display()
+            );
+        }
+    }
+
+    // 1d. Build the PM system-prompt text for the live checkout (where 1c just
+    //     deployed the framework) and write it to a temp file for
+    //     `--append-system-prompt-file` (issue #2230). Non-fatal: a write
+    //     failure omits the flag rather than blocking the connect.
+    let native = trusty_mpm::core::output_style::claude_supports_native_output_style();
+    let prompt = trusty_mpm::core::session_launch::build_system_prompt_for_with_style_and_native(
+        &path, None, native,
+    );
+    let prompt_path = trusty_mpm::core::model_inject::write_prompt_file(&prompt);
+    if prompt_path.is_none() {
+        eprintln!("warning: failed to write system prompt file; connecting without prompt");
+    }
+
+    // 2. Register the session with the daemon via the connect endpoint. When
+    //    the daemon is unreachable we still bring the session up under the
+    //    folder-derived name.
     #[derive(Deserialize)]
     struct Body {
         #[serde(default)]
@@ -460,7 +510,7 @@ pub(crate) async fn connect(
     };
 
     // 3. Print the full-screen robot splash + rich info panel before tmux takes over.
-    print_launch_banner(&workdir, &tmux_name, None, None);
+    print_launch_banner(&workdir, &tmux_name, prompt_path.as_deref(), None);
 
     // 4. Create the tmux host idempotently. `new-session -A` attaches to an
     //    existing session and creates a detached one (`-d`) otherwise; the
@@ -481,13 +531,10 @@ pub(crate) async fn connect(
         Some(LaunchSessionGuard::new(&tmux_name))
     };
 
-    // 5. Start `claude` with bypass-permissions inside a freshly-created session.
-    //    `connect` does not compose a `--append-system-prompt` — it does no deployment.
+    // 5. Start `claude` inside a freshly-created session, carrying the PM
+    //    system-prompt injection plus the shared isolation flags (#2230).
     if !already_running {
-        let claude_cmd = format!(
-            "claude {}",
-            trusty_mpm::core::model_inject::PERMISSION_MODE_FLAG
-        );
+        let claude_cmd = connect_claude_cmd(prompt_path.as_deref());
         let send = std::process::Command::new("tmux")
             .args(["send-keys", "-t", &tmux_name, &claude_cmd, "Enter"])
             .status();
@@ -503,6 +550,25 @@ pub(crate) async fn connect(
         g.disarm();
     }
     Ok(())
+}
+
+/// Compose the `claude` invocation `connect` sends to a freshly-created tmux pane.
+///
+/// Why (issue #2230): before this fix, `connect` sent a bare
+/// `claude --dangerously-skip-permissions` with no PM system-prompt injection
+/// and no `--setting-sources` isolation — the one launch path that could
+/// silently spawn vanilla Claude Code. This gives `connect` the same carrier
+/// every other launch path (`spawn`/`resume_command` in the daemon adapter,
+/// `launch`'s own `claude_cmd`) already has.
+/// What: thin wrapper over [`trusty_mpm::core::model_inject::build_claude_command`]
+/// with no `--model` override (`connect` does not resolve a PM model tier);
+/// always carries `SETTING_SOURCES_FLAG` (`--setting-sources project,local`)
+/// and `PERMISSION_MODE_FLAG` (`--dangerously-skip-permissions`), plus
+/// `--append-system-prompt-file <path>` when `prompt_file` is `Some`.
+/// Test: `cli_parses_connect`, `cli_parses_connect_with_dir` (in
+/// `tests_behavior_b_tests.rs`) assert both flags are present in the output.
+pub(crate) fn connect_claude_cmd(prompt_file: Option<&std::path::Path>) -> String {
+    trusty_mpm::core::model_inject::build_claude_command(None, prompt_file)
 }
 
 /// Find the first LIVE session whose `workdir` matches `workdir` (exact) or lies

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -46,13 +46,17 @@ fn cli_attach_requires_target() {
 
 #[test]
 fn cli_parses_connect() {
-    // `tm connect` is the no-deployment session starter; it takes an
+    // `tm connect` is the live-checkout session starter; it takes an
     // optional project directory, exactly like `tm launch`.
     let cli = Cli::try_parse_from(["trusty-mpm", "connect"]).unwrap();
     match cli.command.unwrap() {
         Command::Connect { dir } => assert_eq!(dir, None),
         other => panic!("expected Connect, got {other:?}"),
     }
+    // Issue #2230: `connect` must carry the same PM system-prompt +
+    // isolation-flag carrier every other launch path has — no more bare
+    // `claude --dangerously-skip-permissions` with nothing injected.
+    assert_connect_claude_cmd_carries_persona_flags();
 }
 
 #[test]
@@ -62,6 +66,27 @@ fn cli_parses_connect_with_dir() {
         Command::Connect { dir } => assert_eq!(dir.as_deref(), Some("/work/p")),
         other => panic!("expected Connect, got {other:?}"),
     }
+    assert_connect_claude_cmd_carries_persona_flags();
+}
+
+/// Assert `connect`'s composed `claude` invocation carries both the injected
+/// PM system prompt and the shared session-isolation flag (issue #2230).
+///
+/// Why: `crate::commands::launch::connect_claude_cmd` is the exact function
+/// `connect()` calls to build the command sent to `tmux send-keys`; asserting
+/// on it directly proves the wiring without needing a live daemon/tmux to
+/// drive the full async `connect()` end-to-end.
+fn assert_connect_claude_cmd_carries_persona_flags() {
+    let path = std::path::Path::new("/tmp/trusty-mpm-connect-test-prompt.txt");
+    let cmd = crate::commands::launch::connect_claude_cmd(Some(path));
+    assert!(
+        cmd.contains("--append-system-prompt-file"),
+        "connect claude_cmd must inject the PM system prompt file: {cmd}"
+    );
+    assert!(
+        cmd.contains("--setting-sources project,local"),
+        "connect claude_cmd must carry the session-isolation flag: {cmd}"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -234,8 +234,10 @@ fn spawn_command(
 /// it to a fresh temp file via [`crate::core::model_inject::write_prompt_file`].
 /// Returns `None` (logged) on any write failure so `spawn` still proceeds —
 /// matching the non-fatal pattern every other `prepare_managed_config` step in
-/// this file follows; the CLAUDE.md carrier (#2125 item 1) still applies even
-/// without this flag.
+/// this file follows. There is no CLAUDE.md-carrier fallback: #2173 made
+/// "trusty-mpm must never modify the target project's CLAUDE.md" a hard
+/// constraint, so a write failure here means the session runs without the
+/// injected PM system prompt rather than falling back to a different carrier.
 /// Test: `build_prompt_file_writes_resolved_prompt_for_project`.
 fn build_prompt_file(project_dir: &Path) -> Option<std::path::PathBuf> {
     let native = crate::core::output_style::claude_supports_native_output_style();
@@ -269,24 +271,31 @@ fn build_prompt_file(project_dir: &Path) -> Option<std::path::PathBuf> {
 /// env prefix (scrub + `CLAUDE_CONFIG_DIR`) and isolation flags as
 /// [`spawn_command`], and all three get [`on_exit_hint_suffix`] appended
 /// (#2023 component D) so the pane always prints the relaunch hint once
-/// `claude` exits, whichever branch fired.
+/// `claude` exits, whichever branch fired. `prompt_file` (#2230) carries the
+/// PM system prompt via `--append-system-prompt-file` the same way
+/// [`spawn_command`] does, so resumed/guided-resume/crash-recovery sessions
+/// get the identical carrier a fresh spawn gets instead of falling back to a
+/// vanilla `claude` invocation.
 /// Test: `resume_command_with_id_uses_resume_flag`,
 /// `resume_command_without_id_with_prior_conv_uses_continue`,
 /// `resume_command_without_id_no_prior_conv_uses_plain_spawn`,
 /// `resume_command_sets_claude_config_dir`,
 /// `resume_command_exports_managed_session_id`,
-/// `resume_command_prints_relaunch_hint_after_claude_exits`.
+/// `resume_command_prints_relaunch_hint_after_claude_exits`,
+/// `resume_command_with_prompt_file_contains_flag`.
 fn resume_command(
     claude_bin: &str,
     config_dir: Option<&Path>,
     claude_session_id: Option<&str>,
     has_prior_conv: bool,
     session_id: &str,
+    prompt_file: Option<&Path>,
 ) -> String {
     let base = format!(
-        "{}{} {} {}",
+        "{}{}{} {} {}",
         session_id_export_prefix(session_id),
         env_bin_prefix(claude_bin, config_dir),
+        prompt_file_flag(prompt_file),
         crate::core::model_inject::SETTING_SOURCES_FLAG,
         crate::core::model_inject::PERMISSION_MODE_FLAG,
     );
@@ -726,8 +735,8 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
         let config_dir = prepare_managed_config(tmux_name, cwd);
         // Build and inject the PM system prompt (issue #2125 item 3) so this,
         // the default daemon on-ramp, can no longer silently spawn vanilla
-        // Claude Code. Non-fatal: a write failure omits the flag and falls
-        // back to the CLAUDE.md carrier (item 1).
+        // Claude Code. Non-fatal: a write failure omits the flag (#2173 ruled
+        // out a CLAUDE.md-carrier fallback, so there is no other carrier).
         let prompt_file = build_prompt_file(cwd);
         self.tmux
             .send_line(
@@ -767,9 +776,12 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
     /// `CLAUDE_CONFIG_DIR` via [`prepare_managed_config`], existence-checks
     /// `claude_session_id` against the resolved config dir, falls back when it
     /// is missing, checks for prior conversation when no usable id remains,
+    /// builds the PM system-prompt file via [`build_prompt_file`] (#2230 —
+    /// same carrier `spawn` uses, previously missing from every resume path),
     /// then sends the appropriate [`resume_command`] to the tmux pane.
     /// Test: `spawn_resume_with_id_uses_resume_flag`,
-    /// `spawn_resume_without_id_no_prior_conv_sends_plain_spawn`.
+    /// `spawn_resume_without_id_no_prior_conv_sends_plain_spawn`,
+    /// `spawn_resume_sends_prompt_file_when_binary_available`.
     fn spawn_resume(
         &self,
         tmux_name: &str,
@@ -786,6 +798,11 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             )
         })?;
         let config_dir = prepare_managed_config(tmux_name, cwd);
+        // #2230: build the PM system prompt for the resume path too — before
+        // this fix only spawn() passed --append-system-prompt-file, so every
+        // resumed/guided-resume/crash-recovery session silently ran vanilla
+        // Claude Code. Non-fatal: a write failure omits the flag.
+        let prompt_file = build_prompt_file(cwd);
 
         // #2013: a stored id can go stale — existence-check it before trusting
         // `--resume <id>` so a missing session falls back gracefully instead
@@ -837,6 +854,7 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
                     effective_id,
                     prior,
                     session_id,
+                    prompt_file.as_deref(),
                 ),
             )
             .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))?;
@@ -1026,7 +1044,7 @@ mod tests {
             "config dir must never be interpolated unquoted: {cmd}"
         );
         // Resume path shares env_bin_prefix, so it must quote identically.
-        let resume = resume_command("claude", Some(dir), None, false, TEST_SESSION_ID);
+        let resume = resume_command("claude", Some(dir), None, false, TEST_SESSION_ID, None);
         assert!(
             resume.contains(
                 "CLAUDE_CONFIG_DIR='/Users/John Doe/.trusty-tools/trusty-mpm/claude-config'"
@@ -1240,7 +1258,14 @@ mod tests {
     fn resume_command_with_id_uses_resume_flag() {
         // Why (#1744): --resume <id> restores the exact prior conversation;
         // the test pins the contract so accidental regressions are caught early.
-        let cmd = resume_command("claude", None, Some("abc-123"), false, TEST_SESSION_ID);
+        let cmd = resume_command(
+            "claude",
+            None,
+            Some("abc-123"),
+            false,
+            TEST_SESSION_ID,
+            None,
+        );
         assert!(
             cmd.contains("--resume abc-123"),
             "resume command must include --resume <id>: {cmd}"
@@ -1261,7 +1286,14 @@ mod tests {
         // TM_MANAGED_SESSION_ID before the claude invocation, for the same
         // reason as the spawn path — the pane's shell must retain the id after
         // claude exits, whichever launch path (fresh spawn or resume) started it.
-        let cmd = resume_command("claude", None, Some("abc-123"), false, TEST_SESSION_ID);
+        let cmd = resume_command(
+            "claude",
+            None,
+            Some("abc-123"),
+            false,
+            TEST_SESSION_ID,
+            None,
+        );
         let expected_prefix = format!("export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; ");
         assert!(
             cmd.starts_with(&expected_prefix),
@@ -1282,7 +1314,14 @@ mod tests {
         // DOC-34: the resume path must also carry CLAUDE_CONFIG_DIR so resumed
         // sessions read the same tm-owned roster as fresh spawns.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = resume_command("claude", Some(dir), Some("abc-123"), false, TEST_SESSION_ID);
+        let cmd = resume_command(
+            "claude",
+            Some(dir),
+            Some("abc-123"),
+            false,
+            TEST_SESSION_ID,
+            None,
+        );
         assert!(
             cmd.contains(
                 "env -u ANTHROPIC_API_KEY \
@@ -1301,7 +1340,7 @@ mod tests {
         // Why (#1744 / #1840): when no claude_session_id is stored but prior
         // conversation history exists, --continue resumes the most-recent
         // conversation in the workspace rather than starting fresh.
-        let cmd = resume_command("claude", None, None, true, TEST_SESSION_ID);
+        let cmd = resume_command("claude", None, None, true, TEST_SESSION_ID, None);
         assert!(
             cmd.contains("--continue"),
             "resume command without id + prior conv must use --continue: {cmd}"
@@ -1317,7 +1356,7 @@ mod tests {
         // Why (#1840): when no claude_session_id is stored AND no prior
         // conversation exists, --continue would error with "No conversation
         // found to continue". The plain spawn starts a fresh session instead.
-        let cmd = resume_command("claude", None, None, false, TEST_SESSION_ID);
+        let cmd = resume_command("claude", None, None, false, TEST_SESSION_ID, None);
         assert!(
             !cmd.contains("--continue"),
             "resume command without id + no prior conv must NOT use --continue: {cmd}"
@@ -1420,6 +1459,39 @@ mod tests {
                 && key == "TM_MANAGED_SESSION_ID"
                 && value == TEST_SESSION_ID),
             "spawn_resume must call tmux set-environment with TM_MANAGED_SESSION_ID: {env_sets:?}"
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn spawn_resume_sends_prompt_file_when_binary_available() {
+        // #2230: spawn_resume must inject --append-system-prompt-file just
+        // like spawn() does — before this fix, every resume path (including
+        // guided-resume and crash-recovery, which both funnel through this
+        // adapter method) silently omitted the PM system prompt carrier.
+        // HOME is redirected so build_prompt_file's write lands in a
+        // throwaway dir, not the developer's real ~/.trusty-tools.
+        let _home = HomeGuard::set();
+        let Some(_claude_bin) = ClaudeCodeAdapter::resolve_claude() else {
+            return;
+        };
+        let fake = FakeTmux::new();
+        let adapter = ClaudeCodeAdapter::new(fake.clone());
+        adapter
+            .spawn_resume(
+                "tmpm-test",
+                Path::new("/tmp/does-not-exist-2230"),
+                "task",
+                None,
+                TEST_SESSION_ID,
+            )
+            .expect("spawn_resume");
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1);
+        assert!(
+            sends[0].1.contains("--append-system-prompt-file"),
+            "spawn_resume must inject the PM system prompt file: {}",
+            sends[0].1
         );
     }
 
@@ -1579,7 +1651,7 @@ mod tests {
         // binary so assertions ALWAYS run even when the `claude` binary is absent in CI.
         // The adapter merely calls resume_command() with the same arguments; testing the
         // function directly proves the selection logic without CI depending on claude.
-        let cmd = resume_command("__fake_claude__", None, None, false, TEST_SESSION_ID);
+        let cmd = resume_command("__fake_claude__", None, None, false, TEST_SESSION_ID, None);
         assert!(
             !cmd.contains("--continue"),
             "plain-spawn path must NOT use --continue: {cmd}"
@@ -1648,7 +1720,14 @@ mod tests {
     fn resume_command_prints_relaunch_hint_after_claude_exits() {
         // Same invariant for the resume path (--resume branch here; the
         // --continue/plain-spawn branches share the same trailing suffix).
-        let cmd = resume_command("claude", None, Some("abc-123"), false, TEST_SESSION_ID);
+        let cmd = resume_command(
+            "claude",
+            None,
+            Some("abc-123"),
+            false,
+            TEST_SESSION_ID,
+            None,
+        );
         assert!(
             cmd.contains("; echo 'tm: run `tm` to relaunch this session'"),
             "resume command must print the relaunch hint after claude exits: {cmd}"
@@ -1658,6 +1737,32 @@ mod tests {
         assert!(
             resume_pos < hint_pos,
             "relaunch hint must come AFTER --resume: {cmd}"
+        );
+    }
+
+    #[test]
+    fn resume_command_with_prompt_file_contains_flag() {
+        // #2230: the resume path must carry the same --append-system-prompt-file
+        // carrier as spawn_command — before this fix, resumed / guided-resume /
+        // crash-recovery sessions had no way to inject the PM system prompt at all.
+        let path = Path::new("/tmp/trusty-mpm-system-prompt-resume-test.txt");
+        let cmd = resume_command(
+            "claude",
+            None,
+            Some("abc-123"),
+            false,
+            TEST_SESSION_ID,
+            Some(path),
+        );
+        assert!(
+            cmd.contains(
+                "--append-system-prompt-file '/tmp/trusty-mpm-system-prompt-resume-test.txt'"
+            ),
+            "resume command must pass the prompt file via --append-system-prompt-file: {cmd}"
+        );
+        assert!(
+            cmd.contains("--resume abc-123"),
+            "--resume must still be present alongside the prompt file: {cmd}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Resume path now passes `--append-system-prompt-file` (was fresh-spawn only)
- `tm connect` now runs `prepare_session` (project-tier persona + pm_guard + `--append-system-prompt-file` + `--setting-sources project,local`)
- Best-effort so remote-less/dirty repos still launch
- Removes stale #2125-item-1 CLAUDE.md-carrier doc refs

Closes #2230

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools