### PR TITLE
feat(tga): add commit_count_net to weekly reports excluding reverts

### DIFF
--- a/crates/trusty-git-analytics/src/report/aggregator/accumulate.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/accumulate.rs
@@ -387,9 +387,12 @@ pub(super) fn materialize_repositories(repos: HashMap<String, RepoAcc>) -> Vec<R
 /// display names so a single identity reads the same across the report.
 /// What: drains the weekly map into [`WeeklyActivity`] rows, resolving each
 /// row's email to its canonical display name via the `email_to_name` lookup
-/// built from the already-materialised author summaries.
+/// built from the already-materialised author summaries. Also computes
+/// `commit_count_net` (issue #660: `commit_count - revert_count`) so
+/// downstream consumers get the net-new figure without recomputing it.
 /// Test: indirectly via `aggregator_builds_report_data` (two weekly rows
-/// for two authors in different weeks).
+/// for two authors in different weeks); `commit_count_net` specifically via
+/// `weekly_activity_commit_count_net_excludes_reverts`.
 pub(super) fn materialize_weekly_activity(
     weekly: BTreeMap<(String, String, String), WeekAcc>,
     email_to_name: &HashMap<String, String>,
@@ -451,6 +454,10 @@ pub(super) fn materialize_weekly_activity(
                 // Issue #1113: agentic-mode commit counts.
                 agentic_count: w.agentic_count,
                 ide_assisted_count: w.ide_assisted_count,
+                // Issue #660: net-new commits excluding reverts. `commit_count`
+                // is left untouched above so downstream consumers relying on
+                // the gross total keep working unmodified.
+                commit_count_net: w.commits.saturating_sub(w.reverts),
             }
         })
         .collect()

--- a/crates/trusty-git-analytics/src/report/formatters/csv.rs
+++ b/crates/trusty-git-analytics/src/report/formatters/csv.rs
@@ -80,6 +80,9 @@ pub fn write_weekly_csv(data: &ReportData, output_dir: &Path) -> Result<PathBuf>
         // Issue #445 batch B (request #6): mean LLM-assigned complexity for
         // this bucket; empty string when no commit has a complexity score.
         "avg_complexity",
+        // Issue #660: net-new commit count excluding reverts, appended last
+        // so existing column-index consumers are unaffected.
+        "commit_count_net",
     ])?;
     for row in &data.weekly_activity {
         let categories = serialize_categories(&row.categories);
@@ -103,6 +106,7 @@ pub fn write_weekly_csv(data: &ReportData, output_dir: &Path) -> Result<PathBuf>
             &row.abandoned_pr_count.to_string(),
             &row.ai_assisted_count.to_string(),
             avg_complexity_str.as_str(),
+            &row.commit_count_net.to_string(),
         ])?;
     }
     w.flush()?;

--- a/crates/trusty-git-analytics/src/report/models.rs
+++ b/crates/trusty-git-analytics/src/report/models.rs
@@ -113,6 +113,19 @@ pub struct WeeklyActivity {
     /// Counts inline-completion commits (Cursor, GitHub Copilot).
     #[serde(default)]
     pub ide_assisted_count: usize,
+    /// Why: `commit_count` counts revert commits identically to original
+    /// work, so a developer who lands N commits and reverts all N shows 2N
+    /// commits with zero net code change — a 2x+ inflation downstream
+    /// consumers cannot correct without re-deriving it themselves (issue
+    /// #660). `persist_weekly_engineer` already computed this exact formula
+    /// privately for `fact_weekly_engineer.net_commits`; this field exposes
+    /// it on the report row itself.
+    /// What: `commit_count` minus `revert_count` for this (week, author,
+    /// repository) bucket, saturating at zero. Additive field — `commit_count`
+    /// keeps its existing gross-count meaning unchanged for backward compatibility.
+    /// Test: `report::tests::weekly_activity_commit_count_net_excludes_reverts`.
+    #[serde(default)]
+    pub commit_count_net: usize,
 }
 
 /// Per-week aggregated metrics across all developers and repositories.

--- a/crates/trusty-git-analytics/src/report/persist.rs
+++ b/crates/trusty-git-analytics/src/report/persist.rs
@@ -207,12 +207,14 @@ pub fn persist_weekly_engineer(db: &Database, data: &ReportData) -> Result<usize
         .iter()
         .filter_map(|wa| {
             let (iso_year, iso_week) = parse_week_label_to_parts(&wa.week)?;
-            // net_commits = commit_count - revert_count. Merge commits are
+            // net_commits = commit_count - revert_count, i.e.
+            // `wa.commit_count_net` (issue #660). Merge commits are
             // intentionally INCLUDED in this denominator (per #1113 spec) —
             // only reverts are subtracted. Future specs that wish to also
-            // exclude merge commits must update both this formula and the
-            // column description in the DB schema docs.
-            let net = wa.commit_count.saturating_sub(wa.revert_count) as i64;
+            // exclude merge commits must update both the `commit_count_net`
+            // materialisation formula and the column description in the DB
+            // schema docs.
+            let net = wa.commit_count_net as i64;
             // agentic_pct = agentic_count / net * 100 — intentionally
             // EXCLUDES ide_assisted_count (full-agentic only, per #1113 spec).
             // ide_assisted is tracked separately and must NOT inflate the numerator.

--- a/crates/trusty-git-analytics/src/report/tests.rs
+++ b/crates/trusty-git-analytics/src/report/tests.rs
@@ -400,6 +400,33 @@ fn weekly_activity_carries_quality_columns() {
     assert_eq!(wa.quality_tshirt, "4");
 }
 
+/// Why: issue #660 — downstream consumers (e.g. the Duetto CTO weekly org
+/// report) misreported commit volume because the report's gross
+/// `commit_count` counts revert commits identically to original work. This
+/// regression-proves both halves of the additive fix: the new
+/// `commit_count_net` field excludes reverts, AND the existing gross
+/// `commit_count` field is completely unaffected by the change.
+/// What: reuses `seed_quality_db` (4 commits: 2 ticketed features, 1 revert,
+/// 1 bugfix) and asserts `commit_count_net == commit_count - revert_count`.
+/// Test: this test itself.
+#[test]
+fn weekly_activity_commit_count_net_excludes_reverts() {
+    let db = seed_quality_db();
+    let cfg = baseline_config();
+    let data = Aggregator::build(&db, &cfg).expect("aggregate");
+
+    assert_eq!(data.weekly_activity.len(), 1);
+    let wa = &data.weekly_activity[0];
+    // Gross total is unchanged by this fix — still counts the revert.
+    assert_eq!(wa.commit_count, 4, "gross commit_count must stay unchanged");
+    assert_eq!(wa.revert_count, 1);
+    // Net excludes the one revert: 4 - 1 = 3.
+    assert_eq!(
+        wa.commit_count_net, 3,
+        "commit_count_net must equal commit_count - revert_count"
+    );
+}
+
 #[test]
 fn weekly_quality_perfect_when_clean_and_ticketed() {
     // All commits ticketed, no reverts, no bugfixes ⇒ score 1.0, tshirt 5.
@@ -428,6 +455,8 @@ fn weekly_quality_perfect_when_clean_and_ticketed() {
     assert_eq!(wa.bugfix_count, 0);
     assert_eq!(wa.ticketed_count, 3);
     assert_eq!(wa.abandoned_pr_count, 0);
+    // No reverts ⇒ net equals gross (issue #660).
+    assert_eq!(wa.commit_count_net, wa.commit_count);
 }
 
 #[test]
@@ -485,6 +514,8 @@ fn weekly_csv_includes_quality_columns() {
         "quality_score",
         "quality_tshirt",
         "abandoned_pr_count",
+        // Issue #660: net-new commit count excluding reverts.
+        "commit_count_net",
     ] {
         assert!(header.contains(col), "header missing {col}: {header}");
     }
@@ -517,6 +548,10 @@ fn json_report_exposes_weekly_quality_fields() {
     assert_eq!(wa["quality_tshirt"], "4");
     assert!(wa["quality_score"].as_f64().expect("score is f64") > 0.68);
     assert_eq!(wa["abandoned_pr_count"], 0);
+    // Issue #660: net-new commits round-trip through JSON too, and the
+    // gross commit_count is untouched by the additive fix.
+    assert_eq!(wa["commit_count"], 4);
+    assert_eq!(wa["commit_count_net"], 3);
 
     std::fs::remove_dir_all(&dir).ok();
 }


### PR DESCRIPTION
## Summary

TGA's weekly per-(week, author, repository) activity report (`WeeklyActivity`, `weekly_activity.csv`, `report.json`) counted revert commits identically to original work in `commit_count`. A developer who lands N commits and reverts all N showed 2N commits with zero net code change, causing downstream consumers (e.g. the Duetto CTO weekly org report) to misreport commit volume — one case saw a 2.4x apparent inflation (44 reported vs. 18 verified GitHub commits).

This is a purely additive, non-breaking fix per the design decision in #660:

- Added `commit_count_net: usize` to `WeeklyActivity` — `commit_count - revert_count` (saturating), computed at materialisation time in `materialize_weekly_activity` (`crates/trusty-git-analytics/src/report/aggregator/accumulate.rs`).
- The existing `commit_count` field is completely unchanged — same name, same gross-count semantics — so downstream consumers keep working unmodified.
- `WeeklyVelocity` was verified to carry no raw commit-count field (only `commits_per_developer`, a per-active-developer average with no revert tracking upstream), so per the issue's own scoping language only `WeeklyActivity` needed the new field.
- Surfaced the new field through every existing output layer that already shows `commit_count`: `weekly_activity.csv` (new trailing `commit_count_net` column, appended last so existing column-index consumers are unaffected) and `report.json` (automatic via `Serialize` on `WeeklyActivity`). The markdown report and CLI/TUI do not render `weekly_activity` rows at all, so nothing to change there.
- Consolidated a pre-existing duplicate of this exact formula in `persist.rs::persist_weekly_engineer` (which independently computed `net_commits` for `fact_weekly_engineer`) to reuse the new field instead of recomputing it — same values, no behavior change.

Closes #660

## Files changed
- `crates/trusty-git-analytics/src/report/models.rs` — new `commit_count_net` field + Why/What/Test doc comment
- `crates/trusty-git-analytics/src/report/aggregator/accumulate.rs` — compute `commit_count_net` in `materialize_weekly_activity`
- `crates/trusty-git-analytics/src/report/formatters/csv.rs` — new CSV column
- `crates/trusty-git-analytics/src/report/persist.rs` — reuse the new field instead of recomputing the net formula
- `crates/trusty-git-analytics/src/report/tests.rs` — new regression test + assertions in existing CSV/JSON round-trip tests

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test -p tga` — 653 lib tests + 130 bin/integration tests pass, 0 failed
- [x] `cargo clippy -p tga --all-targets -- -D warnings` — 0 lint warnings (only a pre-existing informational MSRV-config note)
- [x] `cargo fmt --check` — no diff
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 14 allowlisted, 0 violations — OK.`
- [x] New test `weekly_activity_commit_count_net_excludes_reverts`: mixed dataset (2 features, 1 revert, 1 bugfix) asserts `commit_count_net == 3` while `commit_count` stays `4` (regression-proof of the non-breaking claim)
- [x] `weekly_quality_perfect_when_clean_and_ticketed` extended to assert `commit_count_net == commit_count` when there are no reverts
- [x] CSV and JSON round-trip tests extended to assert the new column/field

🤖 Generated with [Claude Code](https://claude.com/claude-code)