### PR TITLE
fix(tga): store full Bitbucket PR commit SHA list, not abbreviated merge SHA

### DIFF
--- a/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
@@ -8,10 +8,14 @@
 //!   a page counter.
 //! - **Auth** supports either Bearer token (workspace / repo access token)
 //!   or Basic auth (`username` + App Password). Tokens win when both are set.
-//! - **Per-PR commit fetch is skipped** — Bitbucket returns the merge
-//!   commit hash directly in the PR list payload, matching what the GitHub
-//!   client stores today. This keeps `commit_shas` parity without N extra
-//!   round-trips.
+//! - **Per-PR commit fetch** — the PR list payload only carries the (often
+//!   abbreviated) merge commit hash, which cannot be joined against
+//!   `commits.sha` and discards the PR's actual commit composition (#841).
+//!   [`BitbucketClient::fetch_pr_commits`] hits the dedicated per-PR commits
+//!   endpoint, paginating with the same `next`-cursor convention, so
+//!   `commit_shas` carries the full list — one extra round-trip (or more,
+//!   under pagination) per PR, same tradeoff GitHub's equivalent
+//!   `fetch_pr_commits` makes.
 
 use std::time::Duration;
 
@@ -21,7 +25,7 @@ use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use rusqlite::params;
 use tracing::{debug, warn};
 
-use crate::collect::bitbucket::types::{BbPaged, BbPullRequest};
+use crate::collect::bitbucket::types::{BbCommit, BbPaged, BbPullRequest};
 use crate::collect::errors::{CollectError, Result};
 use crate::collect::pr_provider::PrProvider;
 use crate::core::config::BitbucketConfig;
@@ -252,8 +256,62 @@ impl BitbucketClient {
             let page: BbPaged<BbPullRequest> = resp.json().await?;
             let repository = format!("{}/{}", self.workspace, self.repo_slug);
             for pr in page.values {
-                out.push(map_pr(pr, &repository));
+                let pr_number = pr.id;
+                let mut mapped = map_pr(pr, &repository);
+                match self.fetch_pr_commits(pr_number).await {
+                    Ok(shas) => {
+                        mapped.commit_shas = encode_commit_shas(&shas)?;
+                    }
+                    Err(e) => {
+                        // Graceful degradation (mirrors the per-repo partial-success
+                        // precedent in the GitHub client, issue #87): one PR's
+                        // commits endpoint hiccuping must not drop the whole PR,
+                        // nor abort the rest of the batch. `mapped.commit_shas`
+                        // already holds the merge-commit fallback from `map_pr`.
+                        warn!(
+                            pr_number,
+                            error = %e,
+                            "Bitbucket PR commit fetch failed; keeping merge-commit fallback"
+                        );
+                    }
+                }
+                out.push(mapped);
             }
+            next_url = page.next;
+        }
+        Ok(out)
+    }
+
+    /// Fetch every commit SHA attached to a pull request, following `next`
+    /// cursors until exhausted.
+    ///
+    /// Why: the PR list endpoint only carries the merge commit hash (often
+    /// abbreviated), which cannot be joined against `commits.sha` by equality
+    /// and discards the PR's real commit composition (issue #841). This is
+    /// the per-PR enrichment call `fetch_pull_requests` makes for every PR it
+    /// returns.
+    /// What: `GET /2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pr_number}/commits`,
+    /// following `next` cursors exactly like [`Self::fetch_pull_requests`].
+    /// Test: `fetch_pr_commits_follows_next_cursor`,
+    /// `fetch_pull_requests_persists_full_commit_list`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CollectError::Http`] on transport or non-success HTTP
+    /// responses, and [`CollectError::Json`] on payload parse failures.
+    pub async fn fetch_pr_commits(&self, pr_number: u64) -> Result<Vec<String>> {
+        let initial = format!(
+            "{}/repositories/{}/{}/pullrequests/{pr_number}/commits?pagelen={PAGE_SIZE}",
+            self.api_base, self.workspace, self.repo_slug
+        );
+
+        let mut out: Vec<String> = Vec::new();
+        let mut next_url: Option<String> = Some(initial);
+        while let Some(url) = next_url.take() {
+            debug!(url = %url, "GET (bitbucket pr commits)");
+            let resp = self.retry_request(&url).await?.error_for_status()?;
+            let page: BbPaged<BbCommit> = resp.json().await?;
+            out.extend(page.values.into_iter().map(|c| c.hash));
             next_url = page.next;
         }
         Ok(out)
@@ -353,6 +411,11 @@ impl BitbucketClient {
 /// `DECLINED` and `SUPERSEDED` collapse to [`PrState::Closed`] because the
 /// shared schema has no richer variants. The collapse is lossy but documented
 /// in the configuration reference.
+///
+/// `commit_shas` here is seeded from the list payload's (often abbreviated)
+/// `merge_commit` hash only as a fallback; [`BitbucketClient::fetch_pull_requests`]
+/// overwrites it with the full per-PR commit list from
+/// [`BitbucketClient::fetch_pr_commits`] whenever that call succeeds (#841).
 fn map_pr(pr: BbPullRequest, repository: &str) -> PullRequest {
     let state = match pr.state.as_str() {
         "MERGED" => PrState::Merged,
@@ -389,6 +452,21 @@ fn map_pr(pr: BbPullRequest, repository: &str) -> PullRequest {
         merged_at,
         commit_shas,
     }
+}
+
+/// Serialize a full commit SHA list into the JSON-array string stored in
+/// `pull_requests.commit_shas`.
+///
+/// Why: shares the on-disk convention with the GitHub provider's
+/// `commit_shas_for_pull` (a JSON array of SHA strings) so downstream
+/// consumers — e.g. the `commits.sha` join — don't need per-provider
+/// parsing.
+/// What: `serde_json::to_string(shas)`. `Vec<String>` serialization cannot
+/// fail in practice, but the `Result` return keeps the call site symmetric
+/// with the rest of this module's fallible JSON handling.
+/// Test: `fetch_pull_requests_persists_full_commit_list`.
+fn encode_commit_shas(shas: &[String]) -> Result<String> {
+    Ok(serde_json::to_string(shas)?)
 }
 
 /// Parse a Bitbucket ISO8601 timestamp into UTC.

--- a/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
@@ -182,6 +182,182 @@ async fn fetch_pull_requests_follows_next_cursor() {
     assert!(prs[1].commit_shas.contains("abc123"));
 }
 
+/// The per-PR commits endpoint follows its own `next` cursor across two
+/// pages, returning the union of both pages' SHAs in order.
+///
+/// Why: this is the same cursor-pagination contract as the PR list endpoint
+/// (issue #841's fix reuses it for `fetch_pr_commits`); a regression here
+/// would silently truncate large PRs to their first page of commits.
+#[tokio::test]
+async fn fetch_pr_commits_follows_next_cursor() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let base = server.uri();
+
+    let page2_url = format!("{base}/repositories/acme/widgets/pullrequests/9/commits?page=2");
+    let page1 = serde_json::json!({
+        "values": [{"hash": "1111111111111111111111111111111111111a"}],
+        "next": page2_url,
+    });
+    let page2 = serde_json::json!({
+        "values": [{"hash": "2222222222222222222222222222222222222b"}],
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/repositories/acme/widgets/pullrequests/9/commits"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(page1.clone()))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repositories/acme/widgets/pullrequests/9/commits"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(page2.clone()))
+        .mount(&server)
+        .await;
+
+    let client = BitbucketClient::new(&BitbucketConfig {
+        token: Some("dummy".into()),
+        workspace: Some("acme".into()),
+        repo_slug: Some("widgets".into()),
+        fetch_prs: true,
+        api_base_url: Some(base),
+        ..Default::default()
+    })
+    .expect("client builds");
+
+    let shas = client.fetch_pr_commits(9).await.expect("fetch");
+    assert_eq!(
+        shas,
+        vec![
+            "1111111111111111111111111111111111111a".to_string(),
+            "2222222222222222222222222222222222222b".to_string(),
+        ]
+    );
+}
+
+/// `fetch_pull_requests` persists the *full* per-PR commit list (from the
+/// dedicated commits endpoint), not the abbreviated `merge_commit` hash —
+/// the regression this issue (#841) was filed against.
+///
+/// Why: the PR list payload alone yields only a short, often-unjoinable
+/// merge SHA; this proves the enrichment call overwrites it with the real,
+/// fully-qualified, potentially multi-commit list.
+#[tokio::test]
+async fn fetch_pull_requests_persists_full_commit_list() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let base = server.uri();
+
+    let prs_page = serde_json::json!({
+        "values": [{
+            "id": 5,
+            "title": "multi-commit PR",
+            "state": "MERGED",
+            "created_on": "2024-01-01T00:00:00Z",
+            "updated_on": "2024-01-02T00:00:00Z",
+            "merge_commit": {"hash": "36c721d47ff0"}
+        }]
+    });
+    let commits_page = serde_json::json!({
+        "values": [
+            {"hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+            {"hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/repositories/acme/widgets/pullrequests"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(prs_page))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repositories/acme/widgets/pullrequests/5/commits"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(commits_page))
+        .mount(&server)
+        .await;
+
+    let client = BitbucketClient::new(&BitbucketConfig {
+        token: Some("dummy".into()),
+        workspace: Some("acme".into()),
+        repo_slug: Some("widgets".into()),
+        fetch_prs: true,
+        api_base_url: Some(base),
+        ..Default::default()
+    })
+    .expect("client builds");
+
+    let prs = client.fetch_pull_requests().await.expect("fetch");
+    assert_eq!(prs.len(), 1);
+    let shas: Vec<String> =
+        serde_json::from_str(&prs[0].commit_shas).expect("commit_shas is a JSON array");
+    assert_eq!(
+        shas,
+        vec![
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        ]
+    );
+    // The abbreviated merge SHA must NOT be what gets persisted.
+    assert!(!prs[0].commit_shas.contains("36c721d47ff0"));
+}
+
+/// When the per-PR commits endpoint errors (e.g. transient 5xx exhausting
+/// retries), `fetch_pull_requests` degrades gracefully: the PR is still
+/// returned, keeping the merge-commit fallback rather than failing the
+/// whole batch or dropping the PR.
+///
+/// Why: one PR's enrichment call hiccuping must not take down collection
+/// for every other PR in the repository (same partial-success philosophy
+/// as the GitHub per-repo fetch, issue #87).
+#[tokio::test]
+async fn fetch_pull_requests_falls_back_on_commit_fetch_error() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let base = server.uri();
+
+    let prs_page = serde_json::json!({
+        "values": [{
+            "id": 6,
+            "title": "commits endpoint unreachable",
+            "state": "MERGED",
+            "created_on": "2024-01-01T00:00:00Z",
+            "updated_on": "2024-01-02T00:00:00Z",
+            "merge_commit": {"hash": "deadbeefcafe"}
+        }]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/repositories/acme/widgets/pullrequests"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(prs_page))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repositories/acme/widgets/pullrequests/6/commits"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let client = BitbucketClient::new(&BitbucketConfig {
+        token: Some("dummy".into()),
+        workspace: Some("acme".into()),
+        repo_slug: Some("widgets".into()),
+        fetch_prs: true,
+        api_base_url: Some(base),
+        ..Default::default()
+    })
+    .expect("client builds");
+
+    let prs = client.fetch_pull_requests().await.expect("fetch");
+    assert_eq!(prs.len(), 1);
+    assert!(prs[0].commit_shas.contains("deadbeefcafe"));
+}
+
 /// Build a `BitbucketConfig` with workspace/repo set and the given auth
 /// fields, so each auth test only states what it actually cares about.
 fn auth_config(

--- a/crates/trusty-git-analytics/src/collect/bitbucket/types.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/types.rs
@@ -88,3 +88,14 @@ pub struct BbCommitRef {
     /// Full commit hash (Bitbucket Cloud uses git, so 40-char hex).
     pub hash: String,
 }
+
+/// A single commit record as returned by
+/// `GET /2.0/repositories/{workspace}/{repo_slug}/pullrequests/{id}/commits`.
+///
+/// Only `hash` is consumed; the endpoint also returns author/message/date
+/// but the collector only needs the SHA to join against `commits.sha`.
+#[derive(Debug, Deserialize)]
+pub struct BbCommit {
+    /// Full commit hash (40-char hex for Bitbucket Cloud git repos).
+    pub hash: String,
+}


### PR DESCRIPTION
## Summary

The Bitbucket PR collector previously persisted only a single (often 12-char abbreviated) merge-commit SHA per PR into `pull_requests.commit_shas`. This could not be joined against `commits.sha` (40-char full SHAs) by equality, and since ~64% of stored SHAs classify as category `merge`, PR<->commit linkage (PR size in commits, work-type composition) was effectively unavailable.

Closes #841

## Fix

- Added `BitbucketClient::fetch_pr_commits(pr_number)` — calls `GET /2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pr_number}/commits`, following the same cursor-style `next` pagination convention already used by `fetch_pull_requests`.
- `fetch_pull_requests` now calls this per-PR enrichment for every PR it returns, replacing the abbreviated `merge_commit`-based single-SHA fallback with the full commit SHA list, serialized identically to the GitHub provider's convention (a JSON array of SHA strings via `serde_json::to_string`).
- Graceful degradation: if the per-PR commits call fails (transient error, 404, etc.), the PR row keeps the merge-commit fallback rather than aborting the whole collection batch — mirroring the existing per-repo partial-success precedent in the GitHub client (issue #87).
- Added `BbCommit` wire type (`src/collect/bitbucket/types.rs`) for the commits-endpoint payload shape.

## Files changed

**Fix:**
- `crates/trusty-git-analytics/src/collect/bitbucket/client.rs` — new `fetch_pr_commits`, `encode_commit_shas` helper, wiring into `fetch_pull_requests`, updated doc comments.
- `crates/trusty-git-analytics/src/collect/bitbucket/types.rs` — new `BbCommit` type.

**Tests:**
- `crates/trusty-git-analytics/src/collect/bitbucket/tests.rs` — 3 new tests: `fetch_pr_commits_follows_next_cursor` (pagination), `fetch_pull_requests_persists_full_commit_list` (full list replaces abbreviated merge SHA), `fetch_pull_requests_falls_back_on_commit_fetch_error` (graceful degradation on per-PR fetch failure).

## Quality gate evidence (raw output)

**`cargo build --workspace`** (tail):
```
   Compiling trusty-code v0.0.0 (.../crates/trusty-code)
   Compiling trusty-agents v0.38.6 (.../crates/trusty-agents)
   Compiling trusty-mpm-gui v0.2.12 (.../crates/trusty-mpm-gui)
   Compiling trusty-agents-local v0.1.3 (.../crates/trusty-agents-local)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.37s
EXIT:0
```

**`cargo test -p tga`** (tail):
```
test collect::bitbucket::client::tests::fetch_pull_requests_falls_back_on_commit_fetch_error ... ok
test collect::bitbucket::client::tests::fetch_pr_commits_follows_next_cursor ... ok
test collect::bitbucket::client::tests::fetch_pull_requests_persists_full_commit_list ... ok
test collect::bitbucket::client::tests::fetch_pull_requests_follows_next_cursor ... ok
...
test result: ok. 655 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.16s

     Running unittests src/main.rs
test result: ok. 130 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.50s

     Running tests/bitbucket_live.rs
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration_test.rs
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests tga
test result: ok. 5 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 1.13s
```

**`cargo clippy --workspace --all-targets -- -D warnings`**: exit 0 (only a pre-existing `clippy.toml`/`Cargo.toml` MSRV-mismatch config notice, no lint diagnostics on any target).

**`cargo fmt --check`**: exit 0.

**`bash scripts/check_line_cap.sh`**:
```
line-cap: 14 allowlisted, 0 violations — OK.
EXIT:0
```

**Note on `cargo test --workspace`**: one unrelated pre-existing failure was observed — `trusty-common::bm25_client::tests::locate_bm25_daemon_binary_env_override_nonexistent_errors` — caused by `trusty-bm25-daemon` happening to be installed at `~/.cargo/bin/trusty-bm25-daemon` on the dev machine, which the test's PATH fallback finds instead of erroring on the intentionally-nonexistent override path. This file (`crates/trusty-common/src/bm25_client.rs`) is untouched by this PR and unrelated to Bitbucket/tga; it's an environment-coupled pre-existing test bug, out of scope for #841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)