### PR TITLE
fix(trusty-mpm): keep resumed panes rooted at the workspace, not $HOME (closes #2250)

### DIFF
--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -93,6 +93,36 @@ fn on_exit_hint_suffix() -> String {
     format!("; echo {}", shell_single_quote(RELAUNCH_HINT))
 }
 
+/// Wrap a managed launch/resume command so it is rooted at `cwd` regardless
+/// of the tmux pane shell's actual starting directory (#2250).
+///
+/// Why: `create_session -c <workdir>` is supposed to root the pane at the
+/// workspace, and `session_manager::resume_workdir::verify_pane_cwd` now
+/// fails loudly when tmux silently falls back to `$HOME` on the fresh-create
+/// resume path — but a RESUMED session that reuses an already-alive pane
+/// (created by a build that predates that verification, or whose cwd drifted
+/// after creation for any other reason) has no such guard. Prepending an
+/// explicit `cd` to the command line itself means the pane ends up in the
+/// right place independent of whatever directory the shell actually started
+/// in, closing that gap for every caller — not just the ones a point-in-time
+/// verification could catch.
+/// What: `cd '<cwd>' && { <body>; }`. `cwd` is single-quoted via
+/// [`shell_single_quote`] for the same reason [`env_bin_prefix`] quotes
+/// `CLAUDE_CONFIG_DIR` — a path with a space would otherwise word-split and
+/// break the pane. The brace GROUP (not a `( … )` subshell) is load-bearing:
+/// `body`'s `export TM_MANAGED_SESSION_ID=…` must land in the SAME shell
+/// process so it survives `claude` exiting and dropping back to the pane's
+/// shell (#2023 component B) — a subshell would discard that export the
+/// instant the group exits, breaking the in-place-relaunch fallback.
+/// Test: `spawn_command_prefixes_cd_to_workdir`,
+/// `resume_command_prefixes_cd_to_workdir`.
+fn cd_and_group(cwd: &Path, body: &str) -> String {
+    format!(
+        "cd {} && {{ {body}; }}",
+        shell_single_quote(&cwd.display().to_string())
+    )
+}
+
 /// Compose the `env …` prefix + resolved binary that starts every managed
 /// `claude`, wiring in the tm-owned `CLAUDE_CONFIG_DIR` when available (DOC-34).
 ///
@@ -188,6 +218,9 @@ fn prompt_file_flag(prompt_file: Option<&Path>) -> String {
 /// does not need `claude` on its own `PATH` (#1298). `session_id` is the
 /// managed session's UUID (#2023 component B), exported so in-pane commands
 /// can identify the session after `claude` exits.
+/// `cwd` (#2250) is where the tmux pane is supposed to be rooted; the
+/// entire command is wrapped via [`cd_and_group`] so it is correct
+/// independent of the pane shell's actual starting directory.
 /// Test: `spawn_command_contains_env_scrub`,
 /// `spawn_command_contains_isolation_flags`,
 /// `spawn_command_uses_resolved_binary`,
@@ -195,14 +228,16 @@ fn prompt_file_flag(prompt_file: Option<&Path>) -> String {
 /// `spawn_command_exports_managed_session_id`,
 /// `spawn_command_prints_relaunch_hint_after_claude_exits`,
 /// `spawn_command_with_prompt_file_contains_flag`,
-/// `spawn_command_without_prompt_file_omits_flag`.
+/// `spawn_command_without_prompt_file_omits_flag`,
+/// `spawn_command_prefixes_cd_to_workdir`.
 fn spawn_command(
+    cwd: &Path,
     claude_bin: &str,
     config_dir: Option<&Path>,
     session_id: &str,
     prompt_file: Option<&Path>,
 ) -> String {
-    format!(
+    let body = format!(
         "{}{}{} {} {}{}",
         session_id_export_prefix(session_id),
         env_bin_prefix(claude_bin, config_dir),
@@ -210,7 +245,8 @@ fn spawn_command(
         crate::core::model_inject::SETTING_SOURCES_FLAG,
         crate::core::model_inject::PERMISSION_MODE_FLAG,
         on_exit_hint_suffix(),
-    )
+    );
+    cd_and_group(cwd, &body)
 }
 
 /// Build and write the PM system-prompt file for `project_dir`, for injection
@@ -282,8 +318,15 @@ fn build_prompt_file(project_dir: &Path) -> Option<std::path::PathBuf> {
 /// `resume_command_sets_claude_config_dir`,
 /// `resume_command_exports_managed_session_id`,
 /// `resume_command_prints_relaunch_hint_after_claude_exits`,
-/// `resume_command_with_prompt_file_contains_flag`.
+/// `resume_command_with_prompt_file_contains_flag`,
+/// `resume_command_prefixes_cd_to_workdir`.
+///
+/// `cwd` (#2250) is where the tmux pane is supposed to be rooted; the entire
+/// command is wrapped via [`cd_and_group`] — see its doc for why this must be
+/// a brace GROUP, not a subshell (the exported `TM_MANAGED_SESSION_ID` has to
+/// survive `claude` exiting).
 fn resume_command(
+    cwd: &Path,
     claude_bin: &str,
     config_dir: Option<&Path>,
     claude_session_id: Option<&str>,
@@ -304,7 +347,8 @@ fn resume_command(
         None if has_prior_conv => format!("{base} --continue"),
         None => base, // No prior conversation: start fresh to avoid "no conversation found".
     };
-    format!("{cmd}{}", on_exit_hint_suffix())
+    let body = format!("{cmd}{}", on_exit_hint_suffix());
+    cd_and_group(cwd, &body)
 }
 
 /// Encode a workspace path the same way Claude Code names its project dir.
@@ -742,6 +786,7 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             .send_line(
                 tmux_name,
                 &spawn_command(
+                    cwd,
                     &claude_bin,
                     config_dir.as_deref(),
                     session_id,
@@ -849,6 +894,7 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             .send_line(
                 tmux_name,
                 &resume_command(
+                    cwd,
                     &claude_bin,
                     config_dir.as_deref(),
                     effective_id,
@@ -888,6 +934,11 @@ mod tests {
     /// Fixed managed-session UUID string reused across command-builder tests
     /// (#2023 component B) — a representative id, not a real session.
     const TEST_SESSION_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+    /// Fixed workdir reused across command-builder tests (#2250) — a
+    /// representative cwd, not a real workspace (these tests exercise the
+    /// string builders directly, never touching the filesystem).
+    const TEST_CWD: &str = "/tmp/ws";
 
     /// RAII guard that redirects `$HOME` to a temp dir and restores it on drop
     /// (including panic).
@@ -931,7 +982,7 @@ mod tests {
     fn spawn_command_contains_env_scrub() {
         // The spawn command must always strip the API key from the environment
         // so the session falls back to OAuth (keyed by CLAUDE_CONFIG_DIR).
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
         assert!(
             cmd.contains("env -u ANTHROPIC_API_KEY"),
             "spawn command must contain env scrub: {cmd}"
@@ -950,11 +1001,15 @@ mod tests {
         // can identify which managed session it belongs to. tmux
         // set-environment alone would NOT reach the pane's already-running
         // shell — the export must be part of the literal command line.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
         let expected_prefix = format!("export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; ");
+        // #2250: the command now starts with `cd <workdir> && { ...` — the
+        // export is the first statement INSIDE that brace group, not literally
+        // the first bytes of the string.
         assert!(
-            cmd.starts_with(&expected_prefix),
-            "spawn command must start with the session-id export: {cmd}"
+            cmd.contains(&format!("{{ {expected_prefix}")),
+            "spawn command must export the session id as the first statement \
+             inside the cd-group: {cmd}"
         );
         let export_pos = cmd
             .find("export TM_MANAGED_SESSION_ID")
@@ -973,7 +1028,13 @@ mod tests {
         // home, not the project's committed `.claude/`. It must co-exist with the
         // API-key scrub.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            Some(dir),
+            TEST_SESSION_ID,
+            None,
+        );
         assert!(
             cmd.contains(
                 "env -u ANTHROPIC_API_KEY \
@@ -998,7 +1059,13 @@ mod tests {
         // (`env: -u: No such file or directory`), fatally killing every managed
         // session spawn.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            Some(dir),
+            TEST_SESSION_ID,
+            None,
+        );
         let u_pos = cmd
             .find("-u ANTHROPIC_API_KEY")
             .expect("cmd must contain -u ANTHROPIC_API_KEY");
@@ -1017,7 +1084,7 @@ mod tests {
         // When home is unresolvable there is no config dir to point at; the
         // command must fall back to the legacy scrub-only prefix (no bare
         // `CLAUDE_CONFIG_DIR=` token).
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
         assert!(
             !cmd.contains("CLAUDE_CONFIG_DIR"),
             "no config dir → must not reference CLAUDE_CONFIG_DIR: {cmd}"
@@ -1030,7 +1097,13 @@ mod tests {
         // the pane command. The path must appear single-quoted and INTACT so
         // `env` receives one CLAUDE_CONFIG_DIR value, not two argv tokens.
         let dir = Path::new("/Users/John Doe/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            Some(dir),
+            TEST_SESSION_ID,
+            None,
+        );
         assert!(
             cmd.contains(
                 "env -u ANTHROPIC_API_KEY \
@@ -1044,7 +1117,15 @@ mod tests {
             "config dir must never be interpolated unquoted: {cmd}"
         );
         // Resume path shares env_bin_prefix, so it must quote identically.
-        let resume = resume_command("claude", Some(dir), None, false, TEST_SESSION_ID, None);
+        let resume = resume_command(
+            Path::new(TEST_CWD),
+            "claude",
+            Some(dir),
+            None,
+            false,
+            TEST_SESSION_ID,
+            None,
+        );
         assert!(
             resume.contains(
                 "CLAUDE_CONFIG_DIR='/Users/John Doe/.trusty-tools/trusty-mpm/claude-config'"
@@ -1070,7 +1151,7 @@ mod tests {
         // Why: the session_manager spawn path must isolate from the user's global
         // settings and run fully unattended (bypass all permission prompts) so
         // multi-agent orchestration never stalls on interactive approval dialogs.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
         assert!(
             cmd.contains("--setting-sources project,local"),
             "spawn command must isolate settings: {cmd}"
@@ -1091,7 +1172,13 @@ mod tests {
         // Why (#1298): under launchd the pane inherits a minimal PATH, so the
         // spawn command must invoke claude by the resolved (absolute) path
         // rather than a bare `claude` that the pane's PATH cannot find.
-        let cmd = spawn_command("/Users/me/.local/bin/claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "/Users/me/.local/bin/claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+        );
         assert!(
             cmd.contains("env -u ANTHROPIC_API_KEY /Users/me/.local/bin/claude "),
             "spawn command must invoke the resolved absolute claude path: {cmd}"
@@ -1215,7 +1302,13 @@ mod tests {
         // inject --append-system-prompt-file pointing at it, alongside the
         // existing isolation flags — the third fail-closed carrier.
         let path = Path::new("/tmp/trusty-mpm-system-prompt-test.txt");
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, Some(path));
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            Some(path),
+        );
         assert!(
             cmd.contains("--append-system-prompt-file '/tmp/trusty-mpm-system-prompt-test.txt'"),
             "spawn command must pass the prompt file via --append-system-prompt-file: {cmd}"
@@ -1230,7 +1323,7 @@ mod tests {
     fn spawn_command_without_prompt_file_omits_flag() {
         // #2125 item 3: no prompt file (e.g. the write failed) → the flag must
         // be omitted entirely rather than passed with a bad/empty path.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
         assert!(
             !cmd.contains("--append-system-prompt-file"),
             "no prompt file → flag must be absent: {cmd}"
@@ -1259,6 +1352,7 @@ mod tests {
         // Why (#1744): --resume <id> restores the exact prior conversation;
         // the test pins the contract so accidental regressions are caught early.
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
@@ -1287,6 +1381,7 @@ mod tests {
         // reason as the spawn path — the pane's shell must retain the id after
         // claude exits, whichever launch path (fresh spawn or resume) started it.
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
@@ -1295,9 +1390,13 @@ mod tests {
             None,
         );
         let expected_prefix = format!("export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; ");
+        // #2250: the command now starts with `cd <workdir> && { ...` — the
+        // export is the first statement INSIDE that brace group, not literally
+        // the first bytes of the string.
         assert!(
-            cmd.starts_with(&expected_prefix),
-            "resume command must start with the session-id export: {cmd}"
+            cmd.contains(&format!("{{ {expected_prefix}")),
+            "resume command must export the session id as the first statement \
+             inside the cd-group: {cmd}"
         );
         let export_pos = cmd
             .find("export TM_MANAGED_SESSION_ID")
@@ -1315,6 +1414,7 @@ mod tests {
         // sessions read the same tm-owned roster as fresh spawns.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             Some(dir),
             Some("abc-123"),
@@ -1340,7 +1440,15 @@ mod tests {
         // Why (#1744 / #1840): when no claude_session_id is stored but prior
         // conversation history exists, --continue resumes the most-recent
         // conversation in the workspace rather than starting fresh.
-        let cmd = resume_command("claude", None, None, true, TEST_SESSION_ID, None);
+        let cmd = resume_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            None,
+            true,
+            TEST_SESSION_ID,
+            None,
+        );
         assert!(
             cmd.contains("--continue"),
             "resume command without id + prior conv must use --continue: {cmd}"
@@ -1356,7 +1464,15 @@ mod tests {
         // Why (#1840): when no claude_session_id is stored AND no prior
         // conversation exists, --continue would error with "No conversation
         // found to continue". The plain spawn starts a fresh session instead.
-        let cmd = resume_command("claude", None, None, false, TEST_SESSION_ID, None);
+        let cmd = resume_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            None,
+            false,
+            TEST_SESSION_ID,
+            None,
+        );
         assert!(
             !cmd.contains("--continue"),
             "resume command without id + no prior conv must NOT use --continue: {cmd}"
@@ -1651,7 +1767,15 @@ mod tests {
         // binary so assertions ALWAYS run even when the `claude` binary is absent in CI.
         // The adapter merely calls resume_command() with the same arguments; testing the
         // function directly proves the selection logic without CI depending on claude.
-        let cmd = resume_command("__fake_claude__", None, None, false, TEST_SESSION_ID, None);
+        let cmd = resume_command(
+            Path::new(TEST_CWD),
+            "__fake_claude__",
+            None,
+            None,
+            false,
+            TEST_SESSION_ID,
+            None,
+        );
         assert!(
             !cmd.contains("--continue"),
             "plain-spawn path must NOT use --continue: {cmd}"
@@ -1697,13 +1821,64 @@ mod tests {
         );
     }
 
+    // ── #2250: cd-prefix belt-and-suspenders ────────────────────────────────
+
+    #[test]
+    fn spawn_command_prefixes_cd_to_workdir() {
+        // #2250: the emitted command must be correct regardless of the pane
+        // shell's actual starting directory — an explicit `cd` must lead the
+        // whole line, and the exported session id / claude invocation must be
+        // wrapped in a brace GROUP (not a subshell) so the env survives.
+        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
+        assert!(
+            cmd.starts_with("cd '/tmp/ws' && { "),
+            "spawn command must start with an explicit cd into the workdir: {cmd}"
+        );
+        assert!(
+            cmd.trim_end().ends_with('}'),
+            "spawn command must close the brace group it opened: {cmd}"
+        );
+    }
+
+    #[test]
+    fn resume_command_prefixes_cd_to_workdir() {
+        // #2250: same cd-prefix guarantee on the resume path — the one most
+        // directly implicated by a stale/removed workspace_path silently
+        // rooting a recreated pane at $HOME.
+        let cmd = resume_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            Some("abc-123"),
+            false,
+            TEST_SESSION_ID,
+            None,
+        );
+        assert!(
+            cmd.starts_with("cd '/tmp/ws' && { "),
+            "resume command must start with an explicit cd into the workdir: {cmd}"
+        );
+        assert!(
+            cmd.trim_end().ends_with('}'),
+            "resume command must close the brace group it opened: {cmd}"
+        );
+    }
+
+    #[test]
+    fn cd_and_group_quotes_workdir_with_space() {
+        // A workdir with a space must not word-split the pane command — same
+        // invariant env_bin_prefix already enforces for CLAUDE_CONFIG_DIR.
+        let cmd = cd_and_group(Path::new("/Users/John Doe/work"), "echo hi");
+        assert_eq!(cmd, "cd '/Users/John Doe/work' && { echo hi; }");
+    }
+
     // ── #2023 component D: on-exit relaunch hint ────────────────────────────
 
     #[test]
     fn spawn_command_prints_relaunch_hint_after_claude_exits() {
         // The hint must appear AFTER the claude invocation, separated by `;` so
         // it only runs once claude exits and control returns to the pane shell.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
         assert!(
             cmd.contains("; echo 'tm: run `tm` to relaunch this session'"),
             "spawn command must print the relaunch hint after claude exits: {cmd}"
@@ -1721,6 +1896,7 @@ mod tests {
         // Same invariant for the resume path (--resume branch here; the
         // --continue/plain-spawn branches share the same trailing suffix).
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
@@ -1747,6 +1923,7 @@ mod tests {
         // crash-recovery sessions had no way to inject the PM system prompt at all.
         let path = Path::new("/tmp/trusty-mpm-system-prompt-resume-test.txt");
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -28,6 +28,7 @@ use crate::core::names::SessionNameError;
 use crate::core::sm::control::Submit;
 
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+use super::resume_workdir;
 use super::store::{SessionStore, StoreError};
 
 /// Errors produced by the session manager.
@@ -96,6 +97,25 @@ pub enum ManagedError {
     /// variant.
     #[error("session name error: {0}")]
     SessionName(#[from] SessionNameError),
+
+    /// No fallback candidate for a session's workdir exists on disk during
+    /// `resume` (#2250).
+    ///
+    /// Why: prior to #2250, `resume()`'s recreate branch handed
+    /// `workspace_path` straight to tmux with no existence check — a
+    /// removed/stale worktree silently rooted the recreated pane at `$HOME`,
+    /// discarding the project-tier `.claude/` skills/persona/MCP config that
+    /// lives only under the real workspace. All three fallback candidates
+    /// (`last_cwd`, `workspace_path`, `cwd`) are now existence-checked by
+    /// [`super::resume_workdir::resolve_existing_workdir`]; when NONE exist,
+    /// failing loudly here beats silently spawning a pane at `$HOME`.
+    /// What: `(session_id, path)` — `path` is the most-informative candidate
+    /// considered (`workspace_path` if set, else `cwd`), surfaced in the error
+    /// message so the operator knows exactly which directory vanished.
+    #[error(
+        "workspace directory {1} no longer exists; cannot resume session {0} — the worktree may have been removed"
+    )]
+    WorkspaceMissing(String, String),
 }
 
 // [`ManagedTmuxDriver`] lives in `driver.rs` (issue #1955 SLOC split — the
@@ -495,22 +515,31 @@ impl SessionManager {
     /// (CLI restart, HTTP `/resume`, MCP `sessions.resume`, the auto-resume
     /// supervisor) inherited that destructiveness, dropping the operator into a
     /// freshly recreated pane instead of the one they were already looking at.
-    /// What: validates the session is `Stopped` or `Errored`, then branches on
+    /// What: validates the session is `Stopped` or `Errored`, resolves the
+    /// workdir via [`resume_workdir::resolve_existing_workdir`] (#2250 —
+    /// existence-checks `last_cwd` → `workspace_path` → `cwd` in order,
+    /// erroring with [`ManagedError::WorkspaceMissing`] rather than handing a
+    /// stale/removed path to tmux when none remain), then branches on
     /// [`ManagedTmuxDriver::session_exists`]: if the tmux pane is STILL alive, it
     /// is reused as-is — no `kill_session`, no `create_session` — because the
     /// caller (e.g. `resume_managed`) re-spawns the runtime via
     /// `RuntimeAdapter::spawn_resume`, which types the resume command straight
     /// into that same pane (already rooted at the right cwd from its original
-    /// creation). If the pane is gone, behavior is unchanged from before: a
-    /// best-effort `kill_session` guard followed by a fresh `create_session` with
-    /// `cwd = workspace_path` (falls back to `cwd` when `workspace_path` is
-    /// absent). Either way the record is marked `Active` and persisted.
+    /// creation). If the pane is gone: a best-effort `kill_session` guard
+    /// followed by [`resume_workdir::create_and_verify_pane`], which creates the
+    /// fresh session AND verifies (#2250) the pane actually landed at the
+    /// resolved workdir — tmux `-c <dir>` can exit 0 while silently falling back
+    /// to `$HOME`, which this catches and fails loudly on rather than typing the
+    /// resume command into a mis-rooted pane. Either way the record is marked
+    /// `Active` and persisted.
     /// Test: `manager_resume_respawns_in_existing_workspace` (`tests.rs`) —
     /// asserts a new `create_session` call is issued when no pane survives (the
     /// `stop()` path, which kills the pane); `resume_reattach_tests.rs`'s
     /// `manager_resume_reuses_live_pane_without_recreate` — asserts NEITHER
     /// `kill_session` NOR `create_session` fires when the pane survives (the
-    /// `mark_runtime_exited_stopped` path, #2148).
+    /// `mark_runtime_exited_stopped` path, #2148); `resume_reattach_tests.rs`'s
+    /// `manager_resume_errors_when_recreated_pane_cwd_mismatches` — asserts a
+    /// pane-cwd mismatch on the recreate path fails loudly (#2250).
     pub async fn resume(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
         let mut record = self.get(id).await?;
         match record.state {
@@ -525,20 +554,12 @@ impl SessionManager {
             }
         }
 
-        // Prefer last_cwd (if it still exists on disk) → workspace_path → cwd (#1816).
-        // The existence check guards against the case where last_cwd was deleted
-        // between the stop and the resume (e.g. ephemeral workspace cleaned up).
-        // Use tokio::fs::try_exists to avoid blocking the async executor.
-        let cwd_ok = match record.last_cwd.as_deref() {
-            Some(p) => tokio::fs::try_exists(p).await.unwrap_or(false),
-            None => false,
-        };
-        let workdir = record
-            .last_cwd
-            .as_deref()
-            .filter(|_| cwd_ok)
-            .or(record.workspace_path.as_deref())
-            .unwrap_or(record.cwd.as_path())
+        // Prefer last_cwd → workspace_path → cwd (#1816), each existence-checked
+        // on disk (#2250 — workspace_path and cwd previously were NOT, so a
+        // stale/removed worktree silently rooted the recreated pane at $HOME).
+        // Errors loudly via WorkspaceMissing when none of the three remain.
+        let workdir = resume_workdir::resolve_existing_workdir(id, &record)
+            .await?
             .to_string_lossy()
             .to_string();
 
@@ -559,11 +580,14 @@ impl SessionManager {
                 warn!(name = %record.tmux_name, "resume: kill stale session failed: {e}");
             }
 
-            // Create a fresh tmux session rooted at the EXISTING workspace.
-            // No re-clone — workspace_path is reused as-is.
-            self.tmux
-                .create_session(&record.tmux_name, &workdir)
-                .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
+            // Create a fresh tmux session rooted at the EXISTING workspace, then
+            // verify tmux didn't silently fall back to $HOME (#2250). No
+            // re-clone — workspace_path is reused as-is.
+            resume_workdir::create_and_verify_pane(
+                self.tmux.as_ref(),
+                &record.tmux_name,
+                &workdir,
+            )?;
             info!(
                 id = %id,
                 name = %record.tmux_name,

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -20,6 +20,7 @@ pub mod prune;
 pub mod reactivate;
 pub mod record;
 pub mod restart_ops;
+mod resume_workdir;
 pub mod search_gc;
 pub mod session_guard;
 pub mod snapshot;

--- a/crates/trusty-mpm/src/session_manager/resume_reattach_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_reattach_tests.rs
@@ -1,15 +1,20 @@
-//! Tests for `SessionManager::resume`'s non-destructive re-attach branch (#2148).
+//! Tests for `SessionManager::resume`'s non-destructive re-attach branch (#2148)
+//! and its post-create pane-cwd verification (#2250).
 //!
 //! Why: `session_manager/tests.rs` is at the 1500-SLOC test cap; this
 //! regression coverage lives here (mirroring `reactivate_tests.rs` /
 //! `restart_tests.rs`) so neither file grows past its limit.
 //! What: proves `resume` reuses a tmux pane that survived the runtime exit
 //! (via `mark_runtime_exited_stopped`, #2023 A) instead of killing and
-//! recreating it — the destructive default #2148 fixes.
+//! recreating it — the destructive default #2148 fixes; also proves the
+//! RECREATE branch fails loudly when the driver reports the fresh pane landed
+//! somewhere other than the requested workspace (tmux silently falling back
+//! to `$HOME`, #2250).
 //! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
 
 use tempfile::TempDir;
 
+use super::manager::ManagedError;
 use super::record::ManagedSessionState;
 use super::tests::make_manager;
 
@@ -67,5 +72,64 @@ async fn manager_resume_reuses_live_pane_without_recreate() {
         fake.create_cwd_calls.lock().unwrap().len(),
         creates_before,
         "resume must NOT recreate a tmux pane that is still alive (#2148)"
+    );
+}
+
+/// #2250: `resume`'s RECREATE branch must fail loudly when the driver reports
+/// the fresh pane landed somewhere other than the requested workspace — the
+/// tmux-silently-fell-back-to-$HOME case that the exit-status check alone can
+/// never catch.
+///
+/// Why: `tmux new-session -c <dir>` can exit 0 while actually rooting the pane
+/// at `$HOME`. Without a post-create verification, `resume` would proceed to
+/// type the resume command into that mis-rooted pane, silently discarding the
+/// project-tier `.claude/` skills/persona/MCP config.
+/// What: creates + stops a session (killing the pane so `resume` takes the
+/// recreate branch), configures the fake driver's `get_pane_cwd` to report a
+/// DIFFERENT directory than the workspace, resumes, and asserts the call
+/// fails with `ManagedError::TmuxUnavailable` rather than transitioning the
+/// record to `Active`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_resume_errors_when_recreated_pane_cwd_mismatches() {
+    let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
+    let wrong_dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    let workspace_path = workspace_dir.path().to_owned();
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_path.clone()),
+            Some("cwd-mismatch-session".into()),
+            Some(workspace_path),
+            Some("https://github.com/owner/repo".into()),
+            Some("main".into()),
+        )
+        .await
+        .expect("create");
+
+    // stop() kills the pane, so the next resume() takes the recreate branch.
+    mgr.stop(&record.id).await.expect("stop");
+
+    // Simulate tmux silently landing the fresh pane somewhere else entirely.
+    *fake.pane_cwd_override.lock().unwrap() = Some(wrong_dir.path().to_owned());
+
+    let err = mgr
+        .resume(&record.id)
+        .await
+        .expect_err("mismatched pane cwd must fail the resume, not silently proceed");
+    assert!(
+        matches!(err, ManagedError::TmuxUnavailable(_)),
+        "expected TmuxUnavailable on pane-cwd mismatch, got: {err:?}"
+    );
+
+    // The record must NOT have been flipped to Active by the failed resume.
+    let after = mgr.get(&record.id).await.expect("get after failed resume");
+    assert_eq!(
+        after.state,
+        ManagedSessionState::Stopped,
+        "a failed resume must leave the record Stopped, not Active"
     );
 }

--- a/crates/trusty-mpm/src/session_manager/resume_workdir.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_workdir.rs
@@ -1,0 +1,312 @@
+//! Workdir resolution + pane-cwd verification for `SessionManager::resume` (#2250).
+//!
+//! Why: `manager.rs` sits at the 500-SLOC production cap (same constraint that
+//! forced `reactivate.rs`/`hook_sync.rs`/`create.rs` out into sibling files),
+//! so the two new guards `resume()` needs land here instead of growing that
+//! file further. Prior to #2250, `resume()`'s recreate branch picked
+//! `workspace_path` as a fallback WITHOUT an existence check (unlike
+//! `last_cwd`, which already had one), and a `create_session` success was
+//! trusted blindly. `tmux new-session -c <missing-dir>` exits 0 but silently
+//! roots the pane at `$HOME` — the project-tier `.claude/` skills/persona/MCP
+//! config that only exists under the real workspace is silently lost the
+//! instant that happens, because `claude --setting-sources project,local`
+//! only reads `<cwd>/.claude`.
+//! What: [`resolve_existing_workdir`] picks the first of
+//! (`last_cwd`, `workspace_path`, `cwd`) that exists on disk, returning a typed
+//! [`ManagedError::WorkspaceMissing`] when none do (never a silent `$HOME`
+//! fallback); [`verify_pane_cwd`] compares the driver-reported pane cwd against
+//! the expected workdir right after a fresh `create_session`, failing loudly on
+//! a mismatch (tmux silently fell back) rather than proceeding to type the
+//! resume command into a mis-rooted pane. A driver that cannot report the pane
+//! cwd (`get_pane_cwd` returns `None` — the trait default, and every test
+//! double unless it opts in) is treated as "cannot verify", not a mismatch.
+//! Test: `resolve_existing_workdir_prefers_first_existing`,
+//! `resolve_existing_workdir_falls_back_through_candidates`,
+//! `resolve_existing_workdir_errors_when_all_missing`,
+//! `verify_pane_cwd_ok_on_match`, `verify_pane_cwd_ok_when_unknown`,
+//! `verify_pane_cwd_errors_on_mismatch` (this file's `#[cfg(test)]` module);
+//! end-to-end coverage of the recreate branch lives in
+//! `resume_reattach_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+use super::ManagedTmuxDriver;
+use super::manager::ManagedError;
+use super::record::{ManagedSessionId, SessionRecord};
+
+/// Pick the first candidate workdir that exists on disk, in priority order.
+///
+/// Why: see module doc — `resume()` must never hand a stale/removed path to
+/// tmux; all three fallback candidates need the same existence guard
+/// `last_cwd` already had before #2250 (`workspace_path` and `cwd` did not).
+/// Takes `&SessionRecord` (rather than three separate `Option<&Path>`
+/// parameters) purely to keep the call site in `manager.rs` — already at its
+/// 500-SLOC cap — a single short line.
+/// What: checks `record.last_cwd`, then `record.workspace_path`, then
+/// `record.cwd` in order via `tokio::fs::try_exists` (non-blocking); returns
+/// the first that exists. When none do, returns
+/// [`ManagedError::WorkspaceMissing`] carrying `id` and the most-informative
+/// candidate (`workspace_path` if set, else `cwd`) so the operator knows
+/// exactly which directory vanished.
+/// Test: `resolve_existing_workdir_prefers_first_existing`,
+/// `resolve_existing_workdir_falls_back_through_candidates`,
+/// `resolve_existing_workdir_errors_when_all_missing`.
+pub(super) async fn resolve_existing_workdir(
+    id: &ManagedSessionId,
+    record: &SessionRecord,
+) -> Result<PathBuf, ManagedError> {
+    let (last_cwd, workspace_path, cwd) = (
+        record.last_cwd.as_deref(),
+        record.workspace_path.as_deref(),
+        record.cwd.as_path(),
+    );
+    for candidate in [last_cwd, workspace_path, Some(cwd)].into_iter().flatten() {
+        if tokio::fs::try_exists(candidate).await.unwrap_or(false) {
+            return Ok(candidate.to_path_buf());
+        }
+    }
+    let missing = workspace_path.unwrap_or(cwd);
+    Err(ManagedError::WorkspaceMissing(
+        id.to_string(),
+        missing.display().to_string(),
+    ))
+}
+
+/// Verify a freshly created tmux pane actually landed at `expected`.
+///
+/// Why: `tmux new-session -c <missing-dir>` exits 0 but silently roots the
+/// pane at `$HOME` — exit status alone can never detect this (#2250); this is
+/// the only point where the ACTUAL pane cwd can be cross-checked before the
+/// resume command is typed into it.
+/// What: reads `driver.get_pane_cwd(name)`; `None` (driver doesn't support the
+/// probe — the trait default, and every test double unless it opts in) is
+/// treated as "cannot verify", not a failure, so drivers/tests that never
+/// implement it don't spuriously break. `Some(actual)` is compared against
+/// `expected`, canonicalizing both when possible (falls back to the raw path
+/// when canonicalization fails, e.g. a path that doesn't exist from this
+/// process's perspective) so a symlinked tmp dir does not spuriously
+/// mismatch; a real mismatch returns [`ManagedError::TmuxUnavailable`] with an
+/// actionable message instead of silently proceeding.
+/// Test: `verify_pane_cwd_ok_on_match`, `verify_pane_cwd_ok_when_unknown`,
+/// `verify_pane_cwd_errors_on_mismatch`.
+pub(super) fn verify_pane_cwd(
+    driver: &dyn ManagedTmuxDriver,
+    name: &str,
+    expected: &Path,
+) -> Result<(), ManagedError> {
+    let Some(actual) = driver.get_pane_cwd(name) else {
+        return Ok(());
+    };
+    let expected_c = expected
+        .canonicalize()
+        .unwrap_or_else(|_| expected.to_path_buf());
+    let actual_c = actual.canonicalize().unwrap_or_else(|_| actual.clone());
+    if expected_c == actual_c {
+        Ok(())
+    } else {
+        Err(ManagedError::TmuxUnavailable(format!(
+            "tmux session '{name}' pane landed at '{}' instead of the requested workspace \
+             '{}' — tmux silently fell back (likely $HOME) because the target directory was \
+             unusable; refusing to type the resume command into a mis-rooted pane",
+            actual.display(),
+            expected.display()
+        )))
+    }
+}
+
+/// Create a fresh tmux session at `workdir`, then verify it actually landed
+/// there (#2250).
+///
+/// Why: `manager.rs::resume`'s recreate branch needs both steps back-to-back
+/// every time it creates a session — folding them into one call keeps that
+/// call site a single line instead of growing `manager.rs` (already at its
+/// 500-SLOC cap) by the width of both.
+/// What: `driver.create_session(name, workdir)` (mapped to
+/// [`ManagedError::TmuxUnavailable`] on failure), then
+/// [`verify_pane_cwd`] against the same `workdir`.
+/// Test: covered end-to-end via `SessionManager::resume` in
+/// `resume_reattach_tests.rs` (`manager_resume_respawns_in_existing_workspace`,
+/// `manager_resume_errors_when_recreated_pane_cwd_mismatches`).
+pub(super) fn create_and_verify_pane(
+    driver: &dyn ManagedTmuxDriver,
+    name: &str,
+    workdir: &str,
+) -> Result<(), ManagedError> {
+    driver
+        .create_session(name, workdir)
+        .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
+    verify_pane_cwd(driver, name, Path::new(workdir))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    use super::super::record::ManagedSessionState;
+    use super::*;
+
+    /// Minimal `SessionRecord` builder for `resolve_existing_workdir` tests —
+    /// only `cwd`/`workspace_path`/`last_cwd` vary between cases.
+    fn make_record(
+        cwd: PathBuf,
+        workspace_path: Option<PathBuf>,
+        last_cwd: Option<PathBuf>,
+    ) -> SessionRecord {
+        SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: "tmpm-resume-workdir-test".into(),
+            cwd,
+            task: "test".into(),
+            state: ManagedSessionState::Stopped,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path,
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: false,
+            workspace_owned: false,
+            source_id: None,
+            claude_session_id: None,
+            scrollback_path: None,
+            last_cwd,
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_existing_workdir_prefers_first_existing() {
+        let last = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+        let id = ManagedSessionId::new();
+        let record = make_record(
+            last.path().to_owned(),
+            Some(workspace.path().to_owned()),
+            Some(last.path().to_owned()),
+        );
+        let resolved = resolve_existing_workdir(&id, &record)
+            .await
+            .expect("last_cwd exists, must be chosen first");
+        assert_eq!(resolved, last.path());
+    }
+
+    #[tokio::test]
+    async fn resolve_existing_workdir_falls_back_through_candidates() {
+        let workspace = TempDir::new().unwrap();
+        let cwd = TempDir::new().unwrap();
+        let id = ManagedSessionId::new();
+        let missing_last = PathBuf::from("/nonexistent/last-cwd-2250");
+
+        // last_cwd missing -> falls back to workspace_path.
+        let record = make_record(
+            cwd.path().to_owned(),
+            Some(workspace.path().to_owned()),
+            Some(missing_last.clone()),
+        );
+        let resolved = resolve_existing_workdir(&id, &record)
+            .await
+            .expect("workspace_path exists, must be chosen over missing last_cwd");
+        assert_eq!(resolved, workspace.path());
+
+        // last_cwd AND workspace_path missing -> falls back to cwd.
+        let missing_workspace = PathBuf::from("/nonexistent/workspace-2250");
+        let record = make_record(
+            cwd.path().to_owned(),
+            Some(missing_workspace),
+            Some(missing_last),
+        );
+        let resolved = resolve_existing_workdir(&id, &record)
+            .await
+            .expect("cwd exists, must be the final fallback");
+        assert_eq!(resolved, cwd.path());
+    }
+
+    #[tokio::test]
+    async fn resolve_existing_workdir_errors_when_all_missing() {
+        let id = ManagedSessionId::new();
+        let missing_workspace = PathBuf::from("/nonexistent/workspace-2250");
+        let record = make_record(
+            PathBuf::from("/nonexistent/cwd-2250"),
+            Some(missing_workspace.clone()),
+            Some(PathBuf::from("/nonexistent/last-cwd-2250")),
+        );
+
+        let err = resolve_existing_workdir(&id, &record).await.expect_err(
+            "no candidate exists on disk — must error, not silently fall back to $HOME",
+        );
+
+        match err {
+            ManagedError::WorkspaceMissing(err_id, path) => {
+                assert_eq!(err_id, id.to_string());
+                assert_eq!(path, missing_workspace.display().to_string());
+            }
+            other => panic!("expected WorkspaceMissing, got {other:?}"),
+        }
+    }
+
+    /// Minimal `ManagedTmuxDriver` test double whose `get_pane_cwd` is
+    /// controllable, so `verify_pane_cwd` can be exercised without pulling in
+    /// the full `FakeTmuxDriver` from `tests.rs`.
+    struct StubDriver {
+        pane_cwd: Mutex<Option<PathBuf>>,
+    }
+
+    impl ManagedTmuxDriver for StubDriver {
+        fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
+            Ok(String::new())
+        }
+        fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+            Ok(Vec::new())
+        }
+        fn get_pane_cwd(&self, _name: &str) -> Option<PathBuf> {
+            self.pane_cwd.lock().unwrap().clone()
+        }
+    }
+
+    #[test]
+    fn verify_pane_cwd_ok_on_match() {
+        let dir = TempDir::new().unwrap();
+        let driver = StubDriver {
+            pane_cwd: Mutex::new(Some(dir.path().to_path_buf())),
+        };
+        assert!(verify_pane_cwd(&driver, "s", dir.path()).is_ok());
+    }
+
+    #[test]
+    fn verify_pane_cwd_ok_when_unknown() {
+        // Driver reports no pane cwd (the trait default) — "cannot verify" is
+        // NOT the same as a mismatch, so this must succeed.
+        let dir = TempDir::new().unwrap();
+        let driver = StubDriver {
+            pane_cwd: Mutex::new(None),
+        };
+        assert!(verify_pane_cwd(&driver, "s", dir.path()).is_ok());
+    }
+
+    #[test]
+    fn verify_pane_cwd_errors_on_mismatch() {
+        let expected = TempDir::new().unwrap();
+        let actual = TempDir::new().unwrap();
+        let driver = StubDriver {
+            pane_cwd: Mutex::new(Some(actual.path().to_path_buf())),
+        };
+        let err = verify_pane_cwd(&driver, "s", expected.path())
+            .expect_err("pane cwd disagrees with the requested workdir — must fail loudly");
+        assert!(matches!(err, ManagedError::TmuxUnavailable(_)));
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -52,6 +52,11 @@ pub struct FakeTmuxDriver {
     /// `send_interrupt`. Recording it lets `graceful_terminate_runtime_signals_then_kills`
     /// assert the signal fired before the pane was reclaimed.
     pub interrupt_calls: Mutex<Vec<String>>,
+    /// Controllable `get_pane_cwd` response (#2250) — `None` by default,
+    /// matching the trait's "cannot verify" default; set to `Some(path)` to
+    /// simulate a real driver reporting the pane's actual cwd, including a
+    /// deliberate mismatch against the requested workdir.
+    pub pane_cwd_override: Mutex<Option<PathBuf>>,
 }
 
 impl FakeTmuxDriver {
@@ -65,6 +70,7 @@ impl FakeTmuxDriver {
             create_cwd_calls: Mutex::new(Vec::new()),
             graceful_stop_calls: Mutex::new(Vec::new()),
             interrupt_calls: Mutex::new(Vec::new()),
+            pane_cwd_override: Mutex::new(None),
         })
     }
 }
@@ -139,6 +145,13 @@ impl ManagedTmuxDriver for FakeTmuxDriver {
     fn send_interrupt(&self, name: &str) -> Result<(), ManagedError> {
         self.interrupt_calls.lock().unwrap().push(name.to_owned());
         Ok(())
+    }
+
+    /// Report the controllable `pane_cwd_override` (#2250) instead of the
+    /// trait's silent `None` default, so tests can simulate a real driver
+    /// confirming (or disagreeing with) the pane's actual cwd.
+    fn get_pane_cwd(&self, _name: &str) -> Option<PathBuf> {
+        self.pane_cwd_override.lock().unwrap().clone()
     }
 }
 
@@ -1022,6 +1035,12 @@ async fn manager_create_persists_runtime() {
 #[tokio::test]
 async fn manager_get_reflects_out_of_process_write() {
     let dir = TempDir::new().unwrap();
+    // #2250: resume() now existence-checks cwd/workspace_path before handing
+    // either to tmux, so the workspace must be a REAL directory (a fake
+    // "/tmp/wt-shared" placeholder made `mgr_b.resume` below fail loudly with
+    // `WorkspaceMissing` — correct new behavior, but orthogonal to what this
+    // test actually verifies: cross-manager reload-on-read).
+    let workspace_dir = TempDir::new().unwrap();
 
     // Manager A = the daemon's view; Manager B = the supervisor's view.
     // Both point at the same data dir / sessions.json.
@@ -1032,7 +1051,7 @@ async fn manager_get_reflects_out_of_process_write() {
     let record = mgr_a
         .create(
             "shared-state task".into(),
-            Some(PathBuf::from("/tmp/wt-shared")),
+            Some(workspace_dir.path().to_owned()),
             None,
             None,
             None,


### PR DESCRIPTION
Existence-check workspace_path before handing to tmux; verify pane cwd after create_session and fail loudly (WorkspaceMissing) if tmux fell back to $HOME; prepend explicit `cd '<cwd>' &&` to the emitted relaunch one-liner — prevents a resumed session silently losing project-tier skills/persona/MCP. QA-APPROVED.

Closes #2250

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools