### PR TITLE
feat(trusty-mpm): inject CLAUDE_CODE_OAUTH_TOKEN into managed sessions — fix login loop (closes #2246)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -406,6 +406,32 @@ pub(crate) enum Command {
         action: RepairAction,
     },
 
+    /// Manage the tm-managed `CLAUDE_CODE_OAUTH_TOKEN` store (issue #2246).
+    ///
+    /// Why: managed sessions run `claude` under a relocated `CLAUDE_CONFIG_DIR`
+    /// (`~/.trusty-tools/trusty-mpm/claude-config/`). On macOS, Claude Code's
+    /// primary OAuth login lives in the Keychain under an entry keyed by a
+    /// hash of `CLAUDE_CONFIG_DIR` — so a `/login` run inside a managed
+    /// session diverges from the login stored under the operator's default
+    /// config dir, producing a "login successful" then immediately
+    /// "not logged in" loop. `CLAUDE_CODE_OAUTH_TOKEN` bypasses the Keychain
+    /// entirely; this command manages the tm-owned store the daemon injects
+    /// it from. Get a token via `claude setup-token`, then store it here.
+    /// What: `set-token` stores a token (0600) at
+    /// `~/.trusty-tools/trusty-mpm/claude-code-oauth.token` — read from stdin
+    /// by default, or `--token <val>` (avoid the latter in a shared shell
+    /// history); `clear-token` removes it; `status` reports presence/absence
+    /// of the stored token, the `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY`
+    /// env vars, and a best-effort on-disk credentials check — NEVER the
+    /// token value itself.
+    /// Test: `cli_parses_auth_set_token`, `cli_parses_auth_clear_token`,
+    /// `cli_parses_auth_status`.
+    Auth {
+        /// Auth action to perform.
+        #[command(subcommand)]
+        action: AuthAction,
+    },
+
     /// Sync and inspect the claude-mpm agent/skill catalog.
     ///
     /// Why: the session-manager MVP deploys agents and skills sourced from the
@@ -1280,6 +1306,56 @@ pub(crate) enum RepairAction {
         #[arg(long)]
         force: bool,
     },
+}
+
+/// Actions for the `auth` subcommand (issue #2246).
+///
+/// Why: scoped sub-actions keep the token lifecycle (store/remove/inspect)
+/// under one command group without cluttering the top-level CLI surface.
+/// What: `SetToken`, `ClearToken`, `Status` — see [`Command::Auth`]'s doc
+/// comment for the full rationale.
+/// Test: `cli_parses_auth_set_token`, `cli_parses_auth_set_token_stdin`,
+/// `cli_parses_auth_clear_token`, `cli_parses_auth_status`.
+#[derive(Debug, Subcommand)]
+pub(crate) enum AuthAction {
+    /// Store a `CLAUDE_CODE_OAUTH_TOKEN` for managed sessions to use.
+    ///
+    /// Why: `--token <val>` is convenient for scripting but lands the token in
+    /// shell history; the default (no `--token`) reads it from stdin instead
+    /// (e.g. `claude setup-token | tm auth set-token`), so this is the safer
+    /// path for interactive use.
+    /// What: reads the token from `--token` when given, else from stdin
+    /// (trimmed of surrounding whitespace/newline), and writes it to
+    /// `~/.trusty-tools/trusty-mpm/claude-code-oauth.token` with mode 0600.
+    /// Test: `cli_parses_auth_set_token`, `cli_parses_auth_set_token_stdin`.
+    SetToken {
+        /// The token value. When omitted, read from stdin instead.
+        #[arg(long)]
+        token: Option<String>,
+        /// Explicitly read the token from stdin (the default when `--token`
+        /// is omitted; accepted for clarity in scripts/docs).
+        #[arg(long)]
+        stdin: bool,
+    },
+    /// Remove the stored token, if present.
+    ///
+    /// Why: lets an operator roll back to ambient Keychain/`ANTHROPIC_API_KEY`
+    /// auth, or rotate to a freshly generated token via a subsequent
+    /// `set-token`.
+    /// What: deletes the stored token file; a no-op (not an error) when no
+    /// token is stored.
+    /// Test: `cli_parses_auth_clear_token`.
+    ClearToken,
+    /// Report the current auth configuration without printing any secret.
+    ///
+    /// Why: the fastest way for an operator (or `tm doctor`) to see whether a
+    /// managed session is at risk of the `CLAUDE_CONFIG_DIR` login loop
+    /// (#2246) before it happens.
+    /// What: prints presence/absence of the stored token, the
+    /// `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` env vars, and a
+    /// best-effort on-disk credentials check. NEVER prints the token value.
+    /// Test: `cli_parses_auth_status`.
+    Status,
 }
 
 /// Actions for the `telegram` subcommand.

--- a/crates/trusty-mpm/src/bin/tm/commands/auth.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/auth.rs
@@ -1,0 +1,187 @@
+//! `tm auth` command handlers — manage the tm-managed `CLAUDE_CODE_OAUTH_TOKEN`
+//! store (issue #2246).
+//!
+//! Why: managed sessions run `claude` under a relocated `CLAUDE_CONFIG_DIR`,
+//! whose macOS-Keychain credential entry (keyed by a hash of the dir) diverges
+//! from the operator's default login, causing a `/login` "success then
+//! immediately not-logged-in" loop. Storing a `CLAUDE_CODE_OAUTH_TOKEN` here
+//! and letting the daemon inject it (see `trusty_mpm::runtime::claude_code`)
+//! bypasses the Keychain entirely. This file is thin I/O + printing over
+//! `trusty_mpm::core::oauth_token`, which owns every actual read/write.
+//! What: `set_token`, `clear_token`, `status` — one handler per
+//! [`crate::cli::AuthAction`] variant.
+//! Test: `set_token_reads_from_explicit_arg`, `set_token_reads_from_stdin`,
+//! `status_lines_never_contain_a_token_value`.
+
+use trusty_mpm::core::oauth_token::{self, TokenStatus};
+
+/// Read a token from stdin, trimmed; errors on a blank read.
+///
+/// Why: the default (no `--token`) path for `tm auth set-token` — keeps the
+/// token out of shell history (`claude setup-token | tm auth set-token`).
+/// What: reads all of stdin to EOF and trims surrounding whitespace/newlines.
+/// Test: `read_token_from_reader_trims_and_rejects_blank`.
+fn read_token_from_reader(mut r: impl std::io::Read) -> anyhow::Result<String> {
+    let mut buf = String::new();
+    r.read_to_string(&mut buf)?;
+    let trimmed = buf.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!(
+            "no token provided on stdin — pipe the token (e.g. `claude setup-token | tm auth \
+             set-token`) or pass --token <val>"
+        );
+    }
+    Ok(trimmed.to_string())
+}
+
+/// `tm auth set-token` handler.
+///
+/// Why: the single write path for the store — see [`crate::cli::AuthAction::SetToken`].
+/// What: uses `token` when given, else reads stdin to EOF; writes it via
+/// [`oauth_token::set_token`] (0600) and prints the path (never the value).
+/// Test: exercised via `cli_parses_auth_set_token` (parsing) and
+/// `oauth_token`'s own round-trip tests (the underlying store).
+pub(crate) fn set_token(token: Option<String>, _stdin: bool) -> anyhow::Result<()> {
+    let raw = match token {
+        Some(t) => t,
+        None => read_token_from_reader(std::io::stdin())?,
+    };
+    let path = oauth_token::set_token(&raw)?;
+    println!("tm auth: token stored at {} (mode 0600)", path.display());
+    Ok(())
+}
+
+/// `tm auth clear-token` handler.
+///
+/// Why: lets an operator roll back to ambient auth or rotate tokens.
+/// What: removes the stored token via [`oauth_token::clear_token`]; a missing
+/// file is not an error.
+/// Test: exercised via `oauth_token::clear_token_at`'s tests (underlying I/O);
+/// this wrapper only adds the print.
+pub(crate) fn clear_token() -> anyhow::Result<()> {
+    let path = oauth_token::clear_token()?;
+    println!("tm auth: token cleared ({})", path.display());
+    Ok(())
+}
+
+/// Render a [`TokenStatus`] into printable lines, never including the token
+/// value (the struct has no field capable of carrying it).
+///
+/// Why: separating rendering from I/O makes the "never prints the token"
+/// guarantee directly testable against arbitrary status values.
+/// What: one line per signal, plus an indented path line when a path was
+/// probed (present or not, so the operator knows exactly what was checked).
+/// Test: `status_lines_never_contain_a_token_value`,
+/// `status_lines_report_every_signal`.
+fn format_status_lines(status: &TokenStatus) -> Vec<String> {
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "stored token: {}",
+        if status.stored_token_present {
+            "present"
+        } else {
+            "absent"
+        }
+    ));
+    if let Some(p) = &status.token_path {
+        lines.push(format!("  path: {}", p.display()));
+    }
+    lines.push(format!(
+        "{}: {}",
+        oauth_token::OAUTH_TOKEN_ENV_VAR,
+        if status.env_var_set { "set" } else { "not set" }
+    ));
+    lines.push(format!(
+        "ANTHROPIC_API_KEY: {}",
+        if status.anthropic_api_key_set {
+            "set"
+        } else {
+            "not set"
+        }
+    ));
+    lines.push(format!(
+        "credentials file: {}",
+        if status.credentials_file_present {
+            "present"
+        } else {
+            "absent (this is normal on macOS, which uses the Keychain instead)"
+        }
+    ));
+    if let Some(p) = &status.credentials_path {
+        lines.push(format!("  path: {}", p.display()));
+    }
+    lines
+}
+
+/// `tm auth status` handler.
+///
+/// Why: the fastest way to check whether a managed session risks the #2246
+/// login loop before it happens.
+/// What: computes [`oauth_token::compute_status`] and prints
+/// [`format_status_lines`]. NEVER prints the token value.
+/// Test: `status_lines_never_contain_a_token_value` covers the print
+/// contract; `oauth_token::compute_status` is tested in its own module.
+pub(crate) fn status() -> anyhow::Result<()> {
+    println!("tm auth status");
+    for line in format_status_lines(&oauth_token::compute_status()) {
+        println!("  {line}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn read_token_from_reader_trims_and_rejects_blank() {
+        let token = read_token_from_reader("  sk-ant-oat01-fake-token\n".as_bytes()).unwrap();
+        assert_eq!(token, "sk-ant-oat01-fake-token");
+
+        let err = read_token_from_reader("   \n".as_bytes());
+        assert!(err.is_err(), "blank stdin must be rejected");
+    }
+
+    #[test]
+    fn status_lines_never_contain_a_token_value() {
+        // A status built as if a token WERE present (and stored/env paths
+        // resolved) must never leak the fake token value it stands in for —
+        // structurally guaranteed, since TokenStatus carries no such field.
+        let status = TokenStatus {
+            stored_token_present: true,
+            token_path: Some(PathBuf::from(
+                "/home/bob/.trusty-tools/trusty-mpm/claude-code-oauth.token",
+            )),
+            env_var_set: true,
+            anthropic_api_key_set: false,
+            credentials_file_present: true,
+            credentials_path: Some(PathBuf::from("/home/bob/.claude/.credentials.json")),
+        };
+        let lines = format_status_lines(&status);
+        let rendered = lines.join("\n");
+        assert!(
+            !rendered.contains("sk-ant-oat01-fake-token"),
+            "status output must never contain a token value: {rendered}"
+        );
+        assert!(rendered.contains("present"));
+        assert!(rendered.contains("claude-code-oauth.token"));
+    }
+
+    #[test]
+    fn status_lines_report_every_signal() {
+        let status = TokenStatus {
+            stored_token_present: false,
+            token_path: None,
+            env_var_set: false,
+            anthropic_api_key_set: false,
+            credentials_file_present: false,
+            credentials_path: None,
+        };
+        let rendered = format_status_lines(&status).join("\n");
+        assert!(rendered.contains("stored token: absent"));
+        assert!(rendered.contains("CLAUDE_CODE_OAUTH_TOKEN: not set"));
+        assert!(rendered.contains("ANTHROPIC_API_KEY: not set"));
+        assert!(rendered.contains("credentials file: absent"));
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -412,6 +412,13 @@ async fn run_inplace_relaunch(
     if let Some(dir) = &resume.config_dir {
         cmd.env("CLAUDE_CONFIG_DIR", dir);
     }
+    // Issue #2246: mirror the tmux-pane spawn/resume paths — inject the
+    // resolved CLAUDE_CODE_OAUTH_TOKEN (when available) so an in-place
+    // relaunch does not silently drop back into the CLAUDE_CONFIG_DIR-keyed
+    // Keychain login loop the token exists to bypass.
+    if let Some(token) = &resume.oauth_token {
+        cmd.env(trusty_mpm::core::oauth_token::OAUTH_TOKEN_ENV_VAR, token);
+    }
 
     InPlaceOutcome::Result(exec_claude_in_place(cmd))
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -3,12 +3,13 @@
 //! Why: splitting each subcommand group into its own file keeps every handler
 //! file well under the 500-line cap and makes the handler surface easy to
 //! navigate.
-//! What: re-exports handler modules — `compress`, `daemon`, `hook_rewrite`,
-//! `install`, `launch`, `managed`, `managed_route`, `meta`, `misc`,
-//! `project`, `services`, `session`, `slack`, `supervisor`, `telegram`.
+//! What: re-exports handler modules — `auth`, `compress`, `daemon`,
+//! `hook_rewrite`, `install`, `launch`, `managed`, `managed_route`, `meta`,
+//! `misc`, `project`, `services`, `session`, `slack`, `supervisor`, `telegram`.
 //! Test: each module has its own unit tests; integration coverage lives in
 //! `tests.rs`.
 
+pub(crate) mod auth;
 pub(crate) mod banner;
 pub(crate) mod compress;
 pub(crate) mod daemon;

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -304,6 +304,14 @@ async fn main() -> anyhow::Result<()> {
                 RepairAction::Deploy { force } => repair_deploy(force),
             }
         }
+        Some(Command::Auth { action }) => {
+            use cli::AuthAction;
+            match action {
+                AuthAction::SetToken { token, stdin } => commands::auth::set_token(token, stdin),
+                AuthAction::ClearToken => commands::auth::clear_token(),
+                AuthAction::Status => commands::auth::status(),
+            }
+        }
         Some(Command::Catalog { action }) => commands::managed::catalog(action).await,
         Some(Command::Ticket {
             issue,

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -12,7 +12,7 @@
 
 use clap::Parser;
 
-use crate::cli::{Cli, Command, RepairAction, ServicesAction, SessctlAction};
+use crate::cli::{AuthAction, Cli, Command, RepairAction, ServicesAction, SessctlAction};
 use crate::commands::session::compose_session_instructions;
 
 #[test]
@@ -412,6 +412,60 @@ fn cli_parses_repair_deploy_force() {
         }
         other => panic!("expected Repair {{ Deploy {{ force: true }} }}, got {other:?}"),
     }
+}
+
+// ── issue #2246: `tm auth` CLI parse tests ──────────────────────────────────
+
+#[test]
+fn cli_parses_auth_set_token() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "auth", "set-token", "--token", "abc"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Auth {
+            action: AuthAction::SetToken { token, stdin },
+        } => {
+            assert_eq!(token.as_deref(), Some("abc"));
+            assert!(!stdin, "stdin flag must default to false");
+        }
+        other => panic!("expected Auth {{ SetToken }}, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_auth_set_token_stdin() {
+    // No --token: the handler reads from stdin. --stdin is accepted for
+    // clarity but does not change behaviour (see AuthAction::SetToken docs).
+    let cli = Cli::try_parse_from(["trusty-mpm", "auth", "set-token", "--stdin"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Auth {
+            action: AuthAction::SetToken { token, stdin },
+        } => {
+            assert_eq!(token, None);
+            assert!(stdin);
+        }
+        other => panic!("expected Auth {{ SetToken }}, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_auth_clear_token() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "auth", "clear-token"]).unwrap();
+    assert!(matches!(
+        cli.command.unwrap(),
+        Command::Auth {
+            action: AuthAction::ClearToken
+        }
+    ));
+}
+
+#[test]
+fn cli_parses_auth_status() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "auth", "status"]).unwrap();
+    assert!(matches!(
+        cli.command.unwrap(),
+        Command::Auth {
+            action: AuthAction::Status
+        }
+    ));
 }
 
 // ── standalone rm / update CLI parse tests ──────────────────────────────────

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -190,7 +190,7 @@ async fn register_project_succeeds() {
 
 #[tokio::test]
 async fn execute_doctor_against_test_daemon() {
-    // `/doctor` returns a ten-check report against a live daemon.
+    // `/doctor` returns an eleven-check report against a live daemon.
     let (_state, url) = spawn_test_daemon().await;
     let executor = CommandExecutor::new(url);
     match executor.execute(TrustyCommand::Doctor).await {
@@ -198,10 +198,10 @@ async fn execute_doctor_against_test_daemon() {
             // #1840 added the worktrees check (6); DOC-28 R4(a) added the
             // output_style check (7); A2 (tm-skills-portfolio epic) added the
             // skill_source check (8); #gh-account-awareness added the gh_account
-            // check (9); #2158 added the deployment check, bringing the total to
-            // 10. #1905's stale-skill cleanup is a one-time migration, not a
-            // probe here.
-            assert_eq!(report.checks.len(), 10);
+            // check (9); #2158 added the deployment check (10); #2246 added the
+            // oauth_token check, bringing the total to 11. #1905's stale-skill
+            // cleanup is a one-time migration, not a probe here.
+            assert_eq!(report.checks.len(), 11);
         }
         other => panic!("expected Doctor, got {other:?}"),
     }

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -51,6 +51,7 @@ pub mod mcp_config;
 pub mod memory;
 pub mod model_inject;
 pub mod names;
+pub mod oauth_token;
 // DOC-28 cutover bridge: unified session finder — CUTOVER BRIDGE — remove post-migration (#1762)
 pub mod native_session_finder;
 pub mod output_style;

--- a/crates/trusty-mpm/src/core/oauth_token.rs
+++ b/crates/trusty-mpm/src/core/oauth_token.rs
@@ -1,0 +1,473 @@
+//! tm-managed `CLAUDE_CODE_OAUTH_TOKEN` store (issue #2246).
+//!
+//! Why: managed sessions run `claude` under a relocated `CLAUDE_CONFIG_DIR`
+//! (`~/.trusty-tools/trusty-mpm/claude-config/`, see
+//! [`crate::core::trusty_tools_config::managed_claude_config_dir`]). On macOS,
+//! Claude Code's primary OAuth login lives in the Keychain under a service
+//! name suffixed with a hash of `CLAUDE_CONFIG_DIR` — so a `/login` run inside
+//! a managed session and the login stored under the operator's default
+//! (bare) `CLAUDE_CONFIG_DIR` resolve to two DIFFERENT Keychain entries. The
+//! session reports "Login successful" and then immediately "Not logged in" in
+//! a loop, because the credential it just wrote is never the one it reads back
+//! from under the relocated dir. `CLAUDE_CODE_OAUTH_TOKEN` bypasses the
+//! Keychain entirely — Claude Code reads it directly from the process
+//! environment — so injecting it into every managed spawn/resume sidesteps
+//! the divergence completely, independent of `CLAUDE_CONFIG_DIR`.
+//! What: a durable token store at
+//! `~/.trusty-tools/trusty-mpm/claude-code-oauth.token` (mode 0600, one line,
+//! written via [`set_token_at`]/[`set_token`]) plus [`resolve_oauth_token`],
+//! the single production entry point the daemon's spawn/resume path calls —
+//! it returns an already-set `CLAUDE_CODE_OAUTH_TOKEN` process-env value first
+//! (highest precedence), else the stored file, else `None` (inject nothing —
+//! strictly no regression for operators relying on ambient/Keychain auth).
+//! [`compute_status`] backs `tm auth status`; it reports presence/absence of
+//! each signal only — it NEVER returns the token value itself.
+//! Test: `set_then_load_token_round_trips`, `token_file_is_mode_0600`,
+//! `clear_token_removes_file`, `clear_token_is_noop_when_absent`,
+//! `resolve_oauth_token_prefers_env_over_stored_file`,
+//! `resolve_oauth_token_none_when_neither_present`,
+//! `compute_status_never_carries_the_token_value`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::trusty_tools_config::CRATE_NAME;
+
+/// Filename of the stored token under the crate's `~/.trusty-tools/<crate>` dir.
+///
+/// Why: a single named constant keeps the store and the status/doctor probes
+/// from ever disagreeing on the filename.
+/// What: `"claude-code-oauth.token"`.
+/// Test: `token_file_path_layout`.
+pub const TOKEN_FILE: &str = "claude-code-oauth.token";
+
+/// The environment variable Claude Code reads to authenticate, bypassing the
+/// Keychain/`.credentials.json` entirely.
+///
+/// Why: this is the mechanism the whole module exists to inject — naming it
+/// once avoids the literal drifting between the store, the spawn-command
+/// builder, and `tm auth status`.
+/// What: `"CLAUDE_CODE_OAUTH_TOKEN"`.
+/// Test: `resolve_oauth_token_prefers_env_over_stored_file`.
+pub const OAUTH_TOKEN_ENV_VAR: &str = "CLAUDE_CODE_OAUTH_TOKEN";
+
+/// Resolve the token file path under an explicit base (hermetic).
+///
+/// Why: unit tests must never write into a developer's real
+/// `~/.trusty-tools/trusty-mpm/`; pointing `base` at a `tempfile::TempDir`
+/// keeps every round-trip test hermetic and parallel-safe.
+/// What: `<base>/.trusty-tools/trusty-mpm/claude-code-oauth.token`.
+/// Test: `token_file_path_layout`.
+pub fn token_file_path_at(base: &Path) -> PathBuf {
+    trusty_common::crate_config::crate_config_dir_at(base, CRATE_NAME).join(TOKEN_FILE)
+}
+
+/// Resolve the canonical token file path.
+///
+/// Why: the production accessor every caller (CLI + spawn path) uses so the
+/// location can never drift between them.
+/// What: `~/.trusty-tools/trusty-mpm/claude-code-oauth.token`. `None` only
+/// when the home directory cannot be resolved (a stripped CI environment).
+/// Test: `token_file_path_layout`.
+pub fn token_file_path() -> Option<PathBuf> {
+    trusty_common::crate_config::crate_config_dir(CRATE_NAME).map(|dir| dir.join(TOKEN_FILE))
+}
+
+/// Write `data` to `path` with Unix mode 0600, race-free.
+///
+/// Why: `OpenOptions::mode()` creates the file with the restrictive
+/// permission bits atomically — a write-then-`chmod` sequence has a TOCTOU
+/// window where the token is briefly world-readable. Mirrors
+/// `session_manager::snapshot::secure_write`'s established pattern in this
+/// crate.
+/// What: opens with `O_CREAT | O_TRUNC | O_WRONLY | mode=0o600` and writes
+/// `data` in one call. Falls back to a plain write on non-Unix (no mode bits
+/// available there).
+/// Test: `token_file_is_mode_0600` (Unix only).
+#[cfg(unix)]
+fn secure_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    f.write_all(data)
+}
+
+#[cfg(not(unix))]
+fn secure_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    std::fs::write(path, data)
+}
+
+/// Store `token` at an explicit `path` (hermetic core of [`set_token`]).
+///
+/// Why: separating the I/O root from validation keeps `tm auth set-token`
+/// testable against a temp dir instead of the real home directory.
+/// What: trims `token`, rejects an empty value, creates the parent directory,
+/// and writes it with mode 0600 via [`secure_write`].
+/// Test: `set_then_load_token_round_trips`, `set_token_rejects_empty`.
+pub fn set_token_at(path: &Path, token: &str) -> anyhow::Result<()> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("token must not be empty");
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    secure_write(path, trimmed.as_bytes())
+        .map_err(|e| anyhow::anyhow!("failed to write token file {}: {e}", path.display()))
+}
+
+/// Store `token` at the canonical path.
+///
+/// Why: the production entry point `tm auth set-token` calls.
+/// What: resolves [`token_file_path`] and delegates to [`set_token_at`].
+/// Test: covered via `set_token_at`'s hermetic tests; production path
+/// exercised by the `tm auth` CLI handler.
+pub fn set_token(token: &str) -> anyhow::Result<PathBuf> {
+    let path =
+        token_file_path().ok_or_else(|| anyhow::anyhow!("could not resolve home directory"))?;
+    set_token_at(&path, token)?;
+    Ok(path)
+}
+
+/// Remove the stored token at an explicit `path` (hermetic core of
+/// [`clear_token`]).
+///
+/// Why: `tm auth clear-token` must be idempotent — running it twice, or on a
+/// machine that never had a token stored, must not error.
+/// What: removes the file; a missing file is `Ok(())`, not an error.
+/// Test: `clear_token_removes_file`, `clear_token_is_noop_when_absent`.
+pub fn clear_token_at(path: &Path) -> anyhow::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(anyhow::anyhow!(
+            "failed to remove token file {}: {e}",
+            path.display()
+        )),
+    }
+}
+
+/// Remove the stored token at the canonical path.
+///
+/// Why: the production entry point `tm auth clear-token` calls.
+/// What: resolves [`token_file_path`] and delegates to [`clear_token_at`].
+/// Test: covered via `clear_token_at`'s hermetic tests.
+pub fn clear_token() -> anyhow::Result<PathBuf> {
+    let path =
+        token_file_path().ok_or_else(|| anyhow::anyhow!("could not resolve home directory"))?;
+    clear_token_at(&path)?;
+    Ok(path)
+}
+
+/// Load the stored token from an explicit `path` (hermetic core of
+/// [`load_token`]).
+///
+/// Why: [`resolve_oauth_token`] and `tm auth status` both need a read that
+/// never panics and treats a missing/empty file as "no token", not an error.
+/// What: `None` when the file is absent, unreadable, or contains only
+/// whitespace; otherwise `Some(trimmed contents)`.
+/// Test: `set_then_load_token_round_trips`, `load_token_none_when_absent`,
+/// `load_token_none_when_blank`.
+pub fn load_token_at(path: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Load the stored token from the canonical path.
+///
+/// Why: production entry point mirroring [`token_file_path`]/[`set_token`].
+/// What: resolves [`token_file_path`] and delegates to [`load_token_at`];
+/// `None` when home is unresolved or no token is stored.
+/// Test: covered via `load_token_at`'s hermetic tests.
+pub fn load_token() -> Option<String> {
+    token_file_path().and_then(|p| load_token_at(&p))
+}
+
+/// Resolve the effective OAuth token to inject into a managed spawn/resume,
+/// following the documented precedence.
+///
+/// Why: the daemon's spawn/resume path must never override an operator who
+/// already exports `CLAUDE_CODE_OAUTH_TOKEN` themselves (e.g. a CI runner, or
+/// an operator testing a different token) — that value must always win over
+/// the tm-managed store. When neither is present this returns `None`, and the
+/// caller injects nothing: a strict, zero-regression superset of today's
+/// behaviour (ambient Keychain/`ANTHROPIC_API_KEY` auth continues to work
+/// exactly as before).
+/// What: `Some(process-env CLAUDE_CODE_OAUTH_TOKEN)` when it is set and
+/// non-blank (highest precedence); else `Some(stored file token)` via
+/// [`load_token`]; else `None`.
+/// Test: `resolve_oauth_token_prefers_env_over_stored_file`,
+/// `resolve_oauth_token_falls_back_to_stored_file`,
+/// `resolve_oauth_token_none_when_neither_present`.
+pub fn resolve_oauth_token() -> Option<String> {
+    if let Ok(v) = std::env::var(OAUTH_TOKEN_ENV_VAR) {
+        let trimmed = v.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    load_token()
+}
+
+/// Non-secret snapshot of every auth signal `tm auth status` reports.
+///
+/// Why: keeping this struct free of the token's actual value makes it
+/// structurally impossible for the status command to leak it — the
+/// presentation layer only ever has booleans and paths to print.
+/// What: presence of the stored token file, presence of the
+/// `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` env vars, and a best-effort
+/// check for an on-disk Claude Code credentials file (the Keychain itself is
+/// not introspectable from here without shelling out to `security`, so this
+/// is advisory — it is meaningful on Linux, where credentials live in a
+/// plain file, and absent-but-fine on macOS where the Keychain is used).
+/// Test: `compute_status_never_carries_the_token_value`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenStatus {
+    /// Whether a token is stored on disk.
+    pub stored_token_present: bool,
+    /// Path the stored-token check probed (whether or not it was present).
+    pub token_path: Option<PathBuf>,
+    /// Whether `CLAUDE_CODE_OAUTH_TOKEN` is set in the current process env.
+    pub env_var_set: bool,
+    /// Whether `ANTHROPIC_API_KEY` is set in the current process env.
+    pub anthropic_api_key_set: bool,
+    /// Whether a Claude Code credentials file was found on disk.
+    pub credentials_file_present: bool,
+    /// Path the credentials-file check probed.
+    pub credentials_path: Option<PathBuf>,
+}
+
+/// Build a [`TokenStatus`] against explicit inputs (hermetic core of
+/// [`compute_status`]).
+///
+/// Why: separates the pure assembly from the I/O (file/env reads) so the
+/// struct's invariant — it never carries the token itself — is checkable
+/// without any real home directory or process env.
+/// What: a thin, allocation-free constructor.
+/// Test: `compute_status_never_carries_the_token_value`.
+fn build_status(
+    stored_token_present: bool,
+    token_path: Option<PathBuf>,
+    env_var_set: bool,
+    anthropic_api_key_set: bool,
+    credentials_file_present: bool,
+    credentials_path: Option<PathBuf>,
+) -> TokenStatus {
+    TokenStatus {
+        stored_token_present,
+        token_path,
+        env_var_set,
+        anthropic_api_key_set,
+        credentials_file_present,
+        credentials_path,
+    }
+}
+
+/// Compute the current [`TokenStatus`] against the real environment/home.
+///
+/// Why: the production entry point `tm auth status` calls; also backs the
+/// `tm doctor` login-loop check (issue #2246).
+/// What: checks [`token_file_path`] for a present, non-blank token; the
+/// `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` process env vars; and
+/// `~/.claude/.credentials.json` on disk (a best-effort signal — see
+/// [`TokenStatus`]'s doc comment).
+/// Test: exercised indirectly by the `tm auth status` CLI handler; the pure
+/// assembly is covered by `compute_status_never_carries_the_token_value`
+/// against [`build_status`] directly.
+pub fn compute_status() -> TokenStatus {
+    let token_path = token_file_path();
+    let stored_token_present = token_path.as_deref().and_then(load_token_at).is_some();
+    let env_var_set = std::env::var(OAUTH_TOKEN_ENV_VAR).is_ok_and(|v| !v.trim().is_empty());
+    let anthropic_api_key_set =
+        std::env::var("ANTHROPIC_API_KEY").is_ok_and(|v| !v.trim().is_empty());
+    let credentials_path = dirs::home_dir().map(|h| h.join(".claude").join(".credentials.json"));
+    let credentials_file_present = credentials_path.as_deref().is_some_and(Path::is_file);
+
+    build_status(
+        stored_token_present,
+        token_path,
+        env_var_set,
+        anthropic_api_key_set,
+        credentials_file_present,
+        credentials_path,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RAII guard that redirects `$HOME` to a temp dir and restores it on
+    /// drop (including panic). Mirrors the identical pattern already used in
+    /// `runtime::claude_code`'s tests and `core::standalone`'s — each test
+    /// module keeps its own copy rather than sharing one across crates.
+    struct HomeGuard {
+        prev: Option<String>,
+        _tmp: tempfile::TempDir,
+    }
+    impl HomeGuard {
+        fn set() -> Self {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let prev = std::env::var("HOME").ok();
+            // SAFETY: callers are #[serial], so no other test thread reads
+            // HOME concurrently; Drop restores the prior value even on panic.
+            unsafe { std::env::set_var("HOME", tmp.path()) };
+            Self { prev, _tmp: tmp }
+        }
+    }
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match self.prev {
+                Some(ref p) => unsafe { std::env::set_var("HOME", p) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
+
+    #[test]
+    fn token_file_path_layout() {
+        let p = token_file_path_at(Path::new("/home/bob"));
+        assert_eq!(
+            p,
+            PathBuf::from("/home/bob/.trusty-tools/trusty-mpm/claude-code-oauth.token")
+        );
+    }
+
+    #[test]
+    fn set_then_load_token_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = token_file_path_at(tmp.path());
+        set_token_at(&path, "  sk-ant-oat01-fake-token  ").unwrap();
+        let loaded = load_token_at(&path).expect("token present");
+        assert_eq!(loaded, "sk-ant-oat01-fake-token", "must be trimmed");
+    }
+
+    #[test]
+    fn set_token_rejects_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = token_file_path_at(tmp.path());
+        assert!(set_token_at(&path, "   ").is_err());
+        assert!(!path.exists(), "no file must be written on rejection");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn token_file_is_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = token_file_path_at(tmp.path());
+        set_token_at(&path, "sk-ant-oat01-fake-token").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "token file must be 0600, got {mode:o}");
+    }
+
+    #[test]
+    fn clear_token_removes_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = token_file_path_at(tmp.path());
+        set_token_at(&path, "sk-ant-oat01-fake-token").unwrap();
+        assert!(path.exists());
+        clear_token_at(&path).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn clear_token_is_noop_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = token_file_path_at(tmp.path());
+        assert!(!path.exists());
+        assert!(clear_token_at(&path).is_ok(), "must not error when absent");
+    }
+
+    #[test]
+    fn load_token_none_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = token_file_path_at(tmp.path());
+        assert_eq!(load_token_at(&path), None);
+    }
+
+    #[test]
+    fn load_token_none_when_blank() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = token_file_path_at(tmp.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "   \n").unwrap();
+        assert_eq!(load_token_at(&path), None);
+    }
+
+    #[test]
+    fn compute_status_never_carries_the_token_value() {
+        // Build a status as if a token *were* present and format every field
+        // to a string; the known fake token value must never appear, because
+        // TokenStatus structurally has no field capable of carrying it.
+        let status = build_status(
+            true,
+            Some(PathBuf::from(
+                "/home/bob/.trusty-tools/trusty-mpm/claude-code-oauth.token",
+            )),
+            true,
+            false,
+            true,
+            Some(PathBuf::from("/home/bob/.claude/.credentials.json")),
+        );
+        let rendered = format!("{status:?}");
+        assert!(
+            !rendered.contains("sk-ant-oat01-fake-token"),
+            "status debug output must never contain a token value: {rendered}"
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn resolve_oauth_token_prefers_env_over_stored_file() {
+        let _home = HomeGuard::set();
+        unsafe { std::env::remove_var(OAUTH_TOKEN_ENV_VAR) };
+        set_token("stored-token").expect("store under redirected HOME");
+        assert_eq!(
+            resolve_oauth_token().as_deref(),
+            Some("stored-token"),
+            "with no env var set, the stored file must be used"
+        );
+        unsafe { std::env::set_var(OAUTH_TOKEN_ENV_VAR, "env-token") };
+        let resolved = resolve_oauth_token();
+        unsafe { std::env::remove_var(OAUTH_TOKEN_ENV_VAR) };
+        assert_eq!(
+            resolved.as_deref(),
+            Some("env-token"),
+            "an already-set process env var must win over the stored file"
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn resolve_oauth_token_falls_back_to_stored_file() {
+        let _home = HomeGuard::set();
+        unsafe { std::env::remove_var(OAUTH_TOKEN_ENV_VAR) };
+        assert_eq!(
+            resolve_oauth_token(),
+            None,
+            "no env var, no stored file → None"
+        );
+        set_token("stored-only-token").expect("store under redirected HOME");
+        assert_eq!(resolve_oauth_token().as_deref(), Some("stored-only-token"));
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn resolve_oauth_token_none_when_neither_present() {
+        // A fresh temp HOME with no stored file and no env var must resolve
+        // to None — the strict no-regression fallback (no injection at all).
+        let _home = HomeGuard::set();
+        unsafe { std::env::remove_var(OAUTH_TOKEN_ENV_VAR) };
+        assert_eq!(resolve_oauth_token(), None);
+    }
+}

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1059,16 +1059,17 @@ async fn pair_reset_clears_pairing() {
 
 #[tokio::test]
 async fn doctor_endpoint_returns_report() {
-    // `GET /api/v1/doctor` returns a ten-check report (#1840 added the
+    // `GET /api/v1/doctor` returns an eleven-check report (#1840 added the
     // worktrees check; DOC-28 R4(a) added the output_style check; A2
     // (tm-skills-portfolio epic) added the skill_source check;
     // #gh-account-awareness added the gh_account check; #2158 added the
-    // deployment check). #1905's stale-skill cleanup is a one-time migration,
-    // not a `run_doctor` probe, so it does not appear here; the per-check
-    // statuses carry the diagnosis, not the HTTP status.
+    // deployment check; #2246 added the oauth_token check). #1905's
+    // stale-skill cleanup is a one-time migration, not a `run_doctor` probe,
+    // so it does not appear here; the per-check statuses carry the
+    // diagnosis, not the HTTP status.
     let state = DaemonState::shared();
     let Json(report) = doctor(State(state), Query(DoctorQuery::default())).await;
-    assert_eq!(report.checks.len(), 10);
+    assert_eq!(report.checks.len(), 11);
     let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
     assert_eq!(
         names,
@@ -1082,7 +1083,8 @@ async fn doctor_endpoint_returns_report() {
             "memory",
             "search",
             "worktrees",
-            "gh_account"
+            "gh_account",
+            "oauth_token"
         ]
     );
 }

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -132,46 +132,54 @@ pub async fn run_doctor(
 /// after.
 /// What: `Warn` when the managed config dir resolves (true in virtually every
 /// real environment — see [`crate::core::trusty_tools_config::managed_claude_config_dir`])
-/// AND neither a stored token nor `ANTHROPIC_API_KEY` is configured (via
-/// [`crate::core::oauth_token::compute_status`]); `Ok` otherwise. Never
-/// `Fail` — a first `/login` still frequently succeeds even without a stored
-/// token, so this is advisory, not a hard break.
+/// AND no OAuth token will resolve for a managed spawn — i.e. neither a stored
+/// token file NOR the `CLAUDE_CODE_OAUTH_TOKEN` env var is set (the two sources
+/// [`crate::core::oauth_token::resolve_oauth_token`] consults, via
+/// [`crate::core::oauth_token::compute_status`]); `Ok` otherwise. Ambient
+/// `ANTHROPIC_API_KEY` deliberately does NOT count — every managed spawn strips
+/// it with `env -u ANTHROPIC_API_KEY` (see [`crate::runtime::claude_code`]), so
+/// relying on it still triggers the #2246 login loop while doctor would
+/// otherwise falsely report `Ok`. Never `Fail` — a first `/login` still
+/// frequently succeeds even without a stored token, so this is advisory.
 /// Test: `oauth_token_check_warns_when_relocated_with_no_token_or_key`,
 /// `oauth_token_check_ok_when_token_stored`,
-/// `oauth_token_check_ok_when_api_key_set`.
+/// `oauth_token_check_warns_when_only_api_key_set`.
 fn check_oauth_token_config() -> DoctorCheck {
     let relocated = crate::core::trusty_tools_config::managed_claude_config_dir().is_some();
     let status = crate::core::oauth_token::compute_status();
-    build_oauth_token_check(
-        relocated,
-        status.stored_token_present,
-        status.anthropic_api_key_set,
-    )
+    build_oauth_token_check(relocated, status.stored_token_present, status.env_var_set)
 }
 
 /// Pure verdict for [`check_oauth_token_config`], separated for hermetic
 /// testing without mutating real process env / home state.
 ///
 /// Why: keeping the branch logic pure makes both the warn and ok paths
-/// unit-testable without redirecting `HOME` or `ANTHROPIC_API_KEY`.
-/// What: see [`check_oauth_token_config`]'s doc comment for the exact rule.
+/// unit-testable without redirecting `HOME` or the process env.
+/// What: `token_available = stored_token_present || env_var_set` — exactly the
+/// two sources a managed spawn's [`crate::core::oauth_token::resolve_oauth_token`]
+/// consults. `Warn` when `relocated && !token_available`, else `Ok`. Ambient
+/// `ANTHROPIC_API_KEY` is intentionally NOT an input: managed spawns scrub it,
+/// so it can never satisfy the managed-session auth requirement (#2246 doctor
+/// false-negative fix).
 /// Test: `oauth_token_check_warns_when_relocated_with_no_token_or_key`,
 /// `oauth_token_check_ok_when_token_stored`,
-/// `oauth_token_check_ok_when_api_key_set`,
+/// `oauth_token_check_ok_when_env_var_set`,
+/// `oauth_token_check_warns_when_only_api_key_set`,
 /// `oauth_token_check_ok_when_not_relocated`.
 fn build_oauth_token_check(
     relocated: bool,
     stored_token_present: bool,
-    anthropic_api_key_set: bool,
+    env_var_set: bool,
 ) -> DoctorCheck {
-    if relocated && !stored_token_present && !anthropic_api_key_set {
+    let token_available = stored_token_present || env_var_set;
+    if relocated && !token_available {
         DoctorCheck::new(
             "oauth_token",
             CheckStatus::Warn,
-            "managed sessions relocate CLAUDE_CONFIG_DIR but no CLAUDE_CODE_OAUTH_TOKEN or \
-             ANTHROPIC_API_KEY is configured — a `/login` inside a managed session may loop \
-             between \"successful\" and \"not logged in\" (issue #2246); run \
-             `claude setup-token` then `tm auth set-token`",
+            "managed sessions relocate CLAUDE_CONFIG_DIR but no CLAUDE_CODE_OAUTH_TOKEN is \
+             configured — a `/login` inside a managed session may loop between \"successful\" \
+             and \"not logged in\" (issue #2246). Note an ambient ANTHROPIC_API_KEY does NOT \
+             help: managed spawns strip it. Run `claude setup-token` then `tm auth set-token`",
         )
     } else {
         DoctorCheck::new(
@@ -662,7 +670,7 @@ mod tests {
     fn oauth_token_check_warns_when_relocated_with_no_token_or_key() {
         // Issue #2246: the exact at-risk configuration — CLAUDE_CONFIG_DIR
         // relocated (as every managed spawn does), no stored token, no
-        // ANTHROPIC_API_KEY — must Warn with an actionable hint.
+        // resolvable OAuth env var — must Warn with an actionable hint.
         let check = build_oauth_token_check(true, false, false);
         assert_eq!(check.status, CheckStatus::Warn);
         assert!(check.message.contains("tm auth set-token"));
@@ -671,16 +679,36 @@ mod tests {
 
     #[test]
     fn oauth_token_check_ok_when_token_stored() {
+        // A stored token file resolves for a managed spawn → satisfied.
         let check = build_oauth_token_check(true, true, false);
         assert_eq!(check.status, CheckStatus::Ok);
     }
 
     #[test]
-    fn oauth_token_check_ok_when_api_key_set() {
-        // An operator relying on ANTHROPIC_API_KEY never touches OAuth at
-        // all, so the Keychain divergence this check warns about is moot.
+    fn oauth_token_check_ok_when_env_var_set() {
+        // A CLAUDE_CODE_OAUTH_TOKEN env var is the higher-precedence source
+        // resolve_oauth_token consults → also satisfies the managed-session
+        // auth requirement even without a stored token file.
         let check = build_oauth_token_check(true, false, true);
         assert_eq!(check.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn oauth_token_check_warns_when_only_api_key_set() {
+        // #2246 false-negative fix: ambient ANTHROPIC_API_KEY does NOT satisfy
+        // the managed-session auth requirement — every managed spawn strips it
+        // via `env -u ANTHROPIC_API_KEY`, so relying on it still triggers the
+        // login loop. With only the API key set (no token file, no OAuth env
+        // var), the check MUST still Warn. `build_oauth_token_check` no longer
+        // even takes the API-key flag as an input; this test pins the behaviour
+        // by driving the same relocated/no-token state the api-key-only
+        // environment produces.
+        let check = build_oauth_token_check(true, false, false);
+        assert_eq!(
+            check.status,
+            CheckStatus::Warn,
+            "an ambient ANTHROPIC_API_KEY must NOT count as managed-session auth"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -60,11 +60,12 @@ const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
 /// roster, layered on top of the narrower agent/skill/output-style probes),
 /// then the memory and search HTTP probes (each bounded by [`PROBE_TIMEOUT`]),
 /// a worktree-orphan scan (Fix 1b, #1840), the `skill_source` probe (A2,
-/// tm-skills-portfolio epic), and the `gh_account` probe
+/// tm-skills-portfolio epic), the `gh_account` probe
 /// (#gh-account-awareness — surfaces the active github.com identity and warns
-/// on the multi-account ambiguity) — folding the resulting ten
-/// [`DoctorCheck`]s into a [`DoctorReport`] whose `overall` status is the
-/// worst of them.
+/// on the multi-account ambiguity), and the `oauth_token` probe (issue #2246 —
+/// warns when a managed session risks the `CLAUDE_CONFIG_DIR`-keyed Keychain
+/// login loop) — folding the resulting eleven [`DoctorCheck`]s into a
+/// [`DoctorReport`] whose `overall` status is the worst of them.
 ///
 /// Note (#1905): the mpm-*→tm-* stale-skill cleanup is intentionally NOT a
 /// permanent probe here — it is a one-time migration
@@ -86,7 +87,7 @@ const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
 /// silently missing the exact provisioning gap this issue is about. With no
 /// `project_dir` (the pre-existing CLI/standalone usage) this is unchanged —
 /// [`FrameworkPaths::default`] still probes the home tier.
-/// Test: `run_doctor_produces_ten_checks`,
+/// Test: `run_doctor_produces_eleven_checks`,
 /// `check_agents_scoped_to_managed_workspace_fails_on_empty_roster`.
 pub async fn run_doctor(
     project_dir: Option<&Path>,
@@ -114,8 +115,71 @@ pub async fn run_doctor(
     checks.push(check_search(&home).await);
     checks.push(check_worktrees(repos_root, active_workspace_paths).await);
     checks.push(check_gh_account().await);
+    checks.push(check_oauth_token_config());
 
     DoctorReport::from_checks(checks)
+}
+
+/// Probe for the `CLAUDE_CONFIG_DIR`-keyed OAuth login-loop risk (issue #2246).
+///
+/// Why: every managed spawn relocates `CLAUDE_CONFIG_DIR` to the tm-owned
+/// config home; on macOS the Keychain credential Claude Code reads is keyed by
+/// a hash of that path, so a `/login` run inside a managed session can
+/// diverge from the login stored under the operator's default config dir and
+/// loop between "login successful" and "not logged in". Storing a
+/// `CLAUDE_CODE_OAUTH_TOKEN` (`tm auth set-token`) bypasses the Keychain
+/// entirely — this probe warns BEFORE an operator hits the loop rather than
+/// after.
+/// What: `Warn` when the managed config dir resolves (true in virtually every
+/// real environment — see [`crate::core::trusty_tools_config::managed_claude_config_dir`])
+/// AND neither a stored token nor `ANTHROPIC_API_KEY` is configured (via
+/// [`crate::core::oauth_token::compute_status`]); `Ok` otherwise. Never
+/// `Fail` — a first `/login` still frequently succeeds even without a stored
+/// token, so this is advisory, not a hard break.
+/// Test: `oauth_token_check_warns_when_relocated_with_no_token_or_key`,
+/// `oauth_token_check_ok_when_token_stored`,
+/// `oauth_token_check_ok_when_api_key_set`.
+fn check_oauth_token_config() -> DoctorCheck {
+    let relocated = crate::core::trusty_tools_config::managed_claude_config_dir().is_some();
+    let status = crate::core::oauth_token::compute_status();
+    build_oauth_token_check(
+        relocated,
+        status.stored_token_present,
+        status.anthropic_api_key_set,
+    )
+}
+
+/// Pure verdict for [`check_oauth_token_config`], separated for hermetic
+/// testing without mutating real process env / home state.
+///
+/// Why: keeping the branch logic pure makes both the warn and ok paths
+/// unit-testable without redirecting `HOME` or `ANTHROPIC_API_KEY`.
+/// What: see [`check_oauth_token_config`]'s doc comment for the exact rule.
+/// Test: `oauth_token_check_warns_when_relocated_with_no_token_or_key`,
+/// `oauth_token_check_ok_when_token_stored`,
+/// `oauth_token_check_ok_when_api_key_set`,
+/// `oauth_token_check_ok_when_not_relocated`.
+fn build_oauth_token_check(
+    relocated: bool,
+    stored_token_present: bool,
+    anthropic_api_key_set: bool,
+) -> DoctorCheck {
+    if relocated && !stored_token_present && !anthropic_api_key_set {
+        DoctorCheck::new(
+            "oauth_token",
+            CheckStatus::Warn,
+            "managed sessions relocate CLAUDE_CONFIG_DIR but no CLAUDE_CODE_OAUTH_TOKEN or \
+             ANTHROPIC_API_KEY is configured — a `/login` inside a managed session may loop \
+             between \"successful\" and \"not logged in\" (issue #2246); run \
+             `claude setup-token` then `tm auth set-token`",
+        )
+    } else {
+        DoctorCheck::new(
+            "oauth_token",
+            CheckStatus::Ok,
+            "managed-session auth looks configured",
+        )
+    }
 }
 
 /// Probe the active `gh` github.com account and warn on ambiguity.
@@ -516,12 +580,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_doctor_produces_ten_checks() {
-        // Issue #2158 adds the `deployment` probe, bringing the total from
-        // nine to ten checks. #1905's stale-skill cleanup is deliberately NOT
-        // a `run_doctor` probe — see the `run_doctor` doc comment.
+    async fn run_doctor_produces_eleven_checks() {
+        // Issue #2158 added the `deployment` probe (nine → ten); issue #2246
+        // adds `oauth_token` (ten → eleven). #1905's stale-skill cleanup is
+        // deliberately NOT a `run_doctor` probe — see the `run_doctor` doc comment.
         let report = run_doctor(None, None, &[]).await;
-        assert_eq!(report.checks.len(), 10);
+        assert_eq!(report.checks.len(), 11);
         let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(
             names,
@@ -535,7 +599,8 @@ mod tests {
                 "memory",
                 "search",
                 "worktrees",
-                "gh_account"
+                "gh_account",
+                "oauth_token"
             ]
         );
     }
@@ -591,6 +656,39 @@ mod tests {
                 "gh_account must never Fail"
             );
         }
+    }
+
+    #[test]
+    fn oauth_token_check_warns_when_relocated_with_no_token_or_key() {
+        // Issue #2246: the exact at-risk configuration — CLAUDE_CONFIG_DIR
+        // relocated (as every managed spawn does), no stored token, no
+        // ANTHROPIC_API_KEY — must Warn with an actionable hint.
+        let check = build_oauth_token_check(true, false, false);
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.message.contains("tm auth set-token"));
+        assert!(check.message.contains("claude setup-token"));
+    }
+
+    #[test]
+    fn oauth_token_check_ok_when_token_stored() {
+        let check = build_oauth_token_check(true, true, false);
+        assert_eq!(check.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn oauth_token_check_ok_when_api_key_set() {
+        // An operator relying on ANTHROPIC_API_KEY never touches OAuth at
+        // all, so the Keychain divergence this check warns about is moot.
+        let check = build_oauth_token_check(true, false, true);
+        assert_eq!(check.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn oauth_token_check_ok_when_not_relocated() {
+        // Home unresolved → no managed config dir → the #2246 divergence
+        // cannot occur (there is nothing to relocate).
+        let check = build_oauth_token_check(false, false, false);
+        assert_eq!(check.status, CheckStatus::Ok);
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -24,6 +24,48 @@ use crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR;
 use crate::core::tmux::{TmuxCommand, TmuxTarget, tmux_argv};
 use crate::core::{Error, Result};
 
+/// Find the end (one PAST the true closing `'`, byte offset into `s`) of a
+/// POSIX shell single-quoted value, given `s` is the text immediately AFTER
+/// the opening quote.
+///
+/// Why: [`shell_single_quote`](crate::runtime::claude_code) escapes an
+/// embedded literal `'` as the 4-byte close-escape-reopen sequence `'\''`
+/// (close the current quote, backslash-escape a literal `'`, reopen a new
+/// quote) — POSIX shells have no in-quote escape, so this is the standard
+/// way to embed a quote inside a single-quoted string. A naive scan for the
+/// FIRST `'` after the opener mistakes that sequence's first byte for the
+/// closer, truncating the redaction and leaking every byte of the value AFTER
+/// the embedded quote in cleartext (a real reviewer-caught edge case: a token
+/// containing `'` would leak its tail). This walks the value treating `'\''`
+/// as one escaped-quote unit to skip over, so only a BARE `'` — one not
+/// followed by `\''` — is treated as the true closer.
+/// What: scans byte-by-byte (safe: the only bytes it compares against are `'`
+/// and `\`, both single-byte ASCII, so it can never land mid-codepoint of a
+/// multi-byte UTF-8 sequence in an untouched run of bytes). At each `'`, if
+/// the next three bytes spell `\''` the whole 4-byte run is an escaped
+/// literal quote — skipped, continue scanning; otherwise this `'` is the true
+/// closer and its index + 1 is returned. Falls back to `s.len()` if no closer
+/// is found (malformed input — treat the rest of the string as the value
+/// rather than panic or leak).
+/// Test: `find_quoted_value_end_stops_at_bare_closer`,
+/// `find_quoted_value_end_skips_escaped_embedded_quote`,
+/// `redact_oauth_token_masks_value_with_embedded_single_quote`.
+fn find_quoted_value_end(s: &str) -> usize {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\'' {
+            if bytes[i..].starts_with(b"'\\''") {
+                i += 4; // escaped embedded quote unit — not the closer
+                continue;
+            }
+            return i + 1; // bare closer — include it in the consumed span
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
 /// Mask any `CLAUDE_CODE_OAUTH_TOKEN=<value>` secret in `s` before it reaches a
 /// log or a persisted record.
 ///
@@ -37,12 +79,15 @@ use crate::core::{Error, Result};
 /// paths at once, so no caller has to remember to scrub.
 /// What: replaces the value of each `CLAUDE_CODE_OAUTH_TOKEN=` assignment with
 /// `<redacted>`, handling both the single-quoted form
-/// (`CLAUDE_CODE_OAUTH_TOKEN='…'` → `CLAUDE_CODE_OAUTH_TOKEN='<redacted>'`) and
-/// a bare unquoted form (value ends at the next ASCII whitespace). All other
-/// bytes are copied through unchanged, so a string with no token is returned
+/// (`CLAUDE_CODE_OAUTH_TOKEN='…'` → `CLAUDE_CODE_OAUTH_TOKEN='<redacted>'`,
+/// via [`find_quoted_value_end`] so a value containing an escaped embedded
+/// quote is masked in full, not just up to its first byte) and a bare
+/// unquoted form (value ends at the next ASCII whitespace). All other bytes
+/// are copied through unchanged, so a string with no token is returned
 /// verbatim.
 /// Test: `redact_oauth_token_masks_quoted_value`,
 /// `redact_oauth_token_masks_unquoted_value`,
+/// `redact_oauth_token_masks_value_with_embedded_single_quote`,
 /// `redact_oauth_token_leaves_unrelated_text_untouched`,
 /// `run_style_error_message_does_not_leak_oauth_token`.
 fn redact_oauth_token(s: &str) -> String {
@@ -53,8 +98,9 @@ fn redact_oauth_token(s: &str) -> String {
         out.push_str(&rest[..pos + needle.len()]);
         let after = &rest[pos + needle.len()..];
         if let Some(stripped) = after.strip_prefix('\'') {
-            // Single-quoted value: mask up to and including the closing quote.
-            let end = stripped.find('\'').map(|i| i + 1).unwrap_or(stripped.len());
+            // Single-quoted value: mask up to and including the TRUE closing
+            // quote, correctly skipping any escaped embedded quotes.
+            let end = find_quoted_value_end(stripped);
             out.push_str("'<redacted>'");
             rest = &stripped[end..];
         } else {
@@ -657,6 +703,66 @@ mod tests {
         assert!(
             redacted.contains("CLAUDE_CODE_OAUTH_TOKEN='<redacted>'"),
             "the token env var must be present but redacted: {redacted}"
+        );
+    }
+
+    #[test]
+    fn find_quoted_value_end_stops_at_bare_closer() {
+        // No embedded quote: the end is the first (and only) `'`.
+        assert_eq!(find_quoted_value_end("abcdef' rest"), 7);
+    }
+
+    #[test]
+    fn find_quoted_value_end_skips_escaped_embedded_quote() {
+        // shell_single_quote("abc'def") produces the raw command fragment
+        // 'abc'\''def' — i.e. AFTER the opening quote: abc'\''def' ...
+        // The escaped-quote unit '\'' at index 3 must be skipped so the TRUE
+        // closer (index 10) is found, not the first `'` (index 3).
+        let after_open = "abc'\\''def' trailing";
+        let end = find_quoted_value_end(after_open);
+        assert_eq!(
+            &after_open[..end],
+            "abc'\\''def'",
+            "must consume the full escaped value through the true closer"
+        );
+        assert_eq!(&after_open[end..], " trailing");
+    }
+
+    #[test]
+    fn redact_oauth_token_masks_value_with_embedded_single_quote() {
+        // Reviewer-caught edge case: a token containing a literal `'` is
+        // shell-escaped by `runtime::claude_code::shell_single_quote` as
+        // '\'' (close-escape-reopen — POSIX's standard way to embed a quote
+        // inside a single-quoted string; see that function's doc). A naive
+        // "find the first `'` after the opener" scan mistakes that
+        // sequence's first byte for the closer and lets everything after it
+        // leak in cleartext. Reproduces the exact repro from the review:
+        //   RAW:      CLAUDE_CODE_OAUTH_TOKEN='abc'\''def' claude --resume x
+        //   WRONG:    CLAUDE_CODE_OAUTH_TOKEN='<redacted>'\''def' ...  (leaks "def")
+        //   CORRECT:  CLAUDE_CODE_OAUTH_TOKEN='<redacted>' claude --resume x
+        // The secret's escaped encoding is hardcoded here (rather than calling
+        // `shell_single_quote`, which is private to `runtime::claude_code`)
+        // to keep this test's only dependency the string shape itself.
+        let secret_with_quote = "abc'def";
+        let input = "CLAUDE_CODE_OAUTH_TOKEN='abc'\\''def' claude --resume x";
+        let redacted = redact_oauth_token(input);
+        // No fragment of the secret — including the post-quote tail "def" —
+        // may survive redaction.
+        assert!(
+            !redacted.contains("abc"),
+            "no fragment of the secret must survive: {redacted}"
+        );
+        assert!(
+            !redacted.contains("def"),
+            "the tail after the embedded quote must not leak: {redacted}"
+        );
+        assert!(
+            !redacted.contains(secret_with_quote),
+            "the full secret must not survive redaction: {redacted}"
+        );
+        assert_eq!(
+            redacted, "CLAUDE_CODE_OAUTH_TOKEN='<redacted>' claude --resume x",
+            "the entire escaped quoted value must collapse to one redacted marker: {redacted}"
         );
     }
 

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -20,8 +20,53 @@
 use std::process::Command;
 
 use crate::core::external_session::ExternalSession;
+use crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR;
 use crate::core::tmux::{TmuxCommand, TmuxTarget, tmux_argv};
 use crate::core::{Error, Result};
+
+/// Mask any `CLAUDE_CODE_OAUTH_TOKEN=<value>` secret in `s` before it reaches a
+/// log or a persisted record.
+///
+/// Why: managed-session pane commands interpolate a cleartext
+/// `CLAUDE_CODE_OAUTH_TOKEN='<token>'` (#2246). When [`TmuxDriver::run`] maps a
+/// failed `send-keys` to an error it formats the full argv — which would
+/// otherwise carry that OAuth secret into every downstream `warn!` log in
+/// `daemon::managed_routes::lifecycle` AND into the persisted session `task`
+/// field via `session_manager::manager::mark_errored`, where `tm session ls`
+/// surfaces it. Redacting at this single source closes every one of those
+/// paths at once, so no caller has to remember to scrub.
+/// What: replaces the value of each `CLAUDE_CODE_OAUTH_TOKEN=` assignment with
+/// `<redacted>`, handling both the single-quoted form
+/// (`CLAUDE_CODE_OAUTH_TOKEN='…'` → `CLAUDE_CODE_OAUTH_TOKEN='<redacted>'`) and
+/// a bare unquoted form (value ends at the next ASCII whitespace). All other
+/// bytes are copied through unchanged, so a string with no token is returned
+/// verbatim.
+/// Test: `redact_oauth_token_masks_quoted_value`,
+/// `redact_oauth_token_masks_unquoted_value`,
+/// `redact_oauth_token_leaves_unrelated_text_untouched`,
+/// `run_style_error_message_does_not_leak_oauth_token`.
+fn redact_oauth_token(s: &str) -> String {
+    let needle = format!("{OAUTH_TOKEN_ENV_VAR}=");
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(pos) = rest.find(&needle) {
+        out.push_str(&rest[..pos + needle.len()]);
+        let after = &rest[pos + needle.len()..];
+        if let Some(stripped) = after.strip_prefix('\'') {
+            // Single-quoted value: mask up to and including the closing quote.
+            let end = stripped.find('\'').map(|i| i + 1).unwrap_or(stripped.len());
+            out.push_str("'<redacted>'");
+            rest = &stripped[end..];
+        } else {
+            // Bare value: mask up to the next whitespace (or end of string).
+            let end = after.find(char::is_whitespace).unwrap_or(after.len());
+            out.push_str("<redacted>");
+            rest = &after[end..];
+        }
+    }
+    out.push_str(rest);
+    out
+}
 
 /// A parsed `tmux list-sessions` row.
 ///
@@ -129,7 +174,15 @@ impl TmuxDriver {
             Ok(String::from_utf8_lossy(&output.stdout).into_owned())
         } else {
             let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-            Err(Error::Protocol(format!("tmux {argv:?} failed: {stderr}")))
+            // #2246: the argv can embed a cleartext CLAUDE_CODE_OAUTH_TOKEN
+            // (managed-spawn pane command). Redact at this single source so the
+            // secret can never reach the ~5 warn! sites in
+            // daemon::managed_routes::lifecycle nor the persisted session `task`
+            // field (mark_errored → `tm session ls`). stderr is redacted too in
+            // case tmux echoes the offending keys back.
+            Err(Error::Protocol(redact_oauth_token(&format!(
+                "tmux {argv:?} failed: {stderr}"
+            ))))
         }
     }
 
@@ -527,6 +580,85 @@ pub struct SessionSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── #2246: OAuth-token redaction in error/log strings ───────────────────
+
+    const FAKE_TOKEN: &str = "sk-ant-oat01-super-secret-value";
+
+    #[test]
+    fn redact_oauth_token_masks_quoted_value() {
+        // The exact shape a managed spawn produces: a single-quoted token inside
+        // the `env …` prefix. The value must be gone; the var name must remain.
+        let input = format!(
+            "export TM_MANAGED_SESSION_ID='id'; env -u ANTHROPIC_API_KEY \
+             CLAUDE_CODE_OAUTH_TOKEN='{FAKE_TOKEN}' /usr/bin/claude --resume x"
+        );
+        let out = redact_oauth_token(&input);
+        assert!(
+            !out.contains(FAKE_TOKEN),
+            "token value must not survive redaction: {out}"
+        );
+        assert!(
+            out.contains("CLAUDE_CODE_OAUTH_TOKEN='<redacted>'"),
+            "redacted marker must replace the value: {out}"
+        );
+        // Surrounding, non-secret context must be preserved intact.
+        assert!(out.contains("env -u ANTHROPIC_API_KEY"));
+        assert!(out.contains("/usr/bin/claude --resume x"));
+    }
+
+    #[test]
+    fn redact_oauth_token_masks_unquoted_value() {
+        // Defensive: a bare (unquoted) assignment must also be masked, with the
+        // value ending at the next whitespace.
+        let input = format!("prefix CLAUDE_CODE_OAUTH_TOKEN={FAKE_TOKEN} suffix");
+        let out = redact_oauth_token(&input);
+        assert!(
+            !out.contains(FAKE_TOKEN),
+            "unquoted value must be masked: {out}"
+        );
+        assert_eq!(out, "prefix CLAUDE_CODE_OAUTH_TOKEN=<redacted> suffix");
+    }
+
+    #[test]
+    fn redact_oauth_token_leaves_unrelated_text_untouched() {
+        let input = "tmux [\"send-keys\", \"-t\", \"tmpm-x\", \"-l\", \"echo hi\"] failed: bad";
+        assert_eq!(redact_oauth_token(input), input);
+    }
+
+    #[test]
+    fn run_style_error_message_does_not_leak_oauth_token() {
+        // Reproduce exactly how `run` formats a failed send-keys: build the real
+        // SendKeys argv carrying a token-bearing pane command, format it the same
+        // way, then redact. Proves the error string a failed spawn would surface
+        // (and everything mark_errored persists from it) is token-free.
+        let keys = format!(
+            "export TM_MANAGED_SESSION_ID='abc'; env -u ANTHROPIC_API_KEY \
+             CLAUDE_CODE_OAUTH_TOKEN='{FAKE_TOKEN}' claude --dangerously-skip-permissions"
+        );
+        let argv = tmux_argv(&TmuxCommand::SendKeys {
+            target: TmuxTarget::session("tmpm-test"),
+            keys,
+            literal: true,
+        });
+        let stderr = "can't find pane";
+        let raw = format!("tmux {argv:?} failed: {stderr}");
+        // Sanity: the un-redacted message WOULD leak (guards against the test
+        // silently passing if the token stopped appearing for another reason).
+        assert!(
+            raw.contains(FAKE_TOKEN),
+            "precondition: raw message leaks the token"
+        );
+        let redacted = redact_oauth_token(&raw);
+        assert!(
+            !redacted.contains(FAKE_TOKEN),
+            "the error string for a failed spawn must not contain the token: {redacted}"
+        );
+        assert!(
+            redacted.contains("CLAUDE_CODE_OAUTH_TOKEN='<redacted>'"),
+            "the token env var must be present but redacted: {redacted}"
+        );
+    }
 
     #[test]
     fn parses_session_row() {

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use tracing::debug;
 
+use crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR;
 use crate::session_manager::ManagedTmuxDriver;
 
 use super::RuntimeAdapter;
@@ -93,40 +94,11 @@ fn on_exit_hint_suffix() -> String {
     format!("; echo {}", shell_single_quote(RELAUNCH_HINT))
 }
 
-/// Wrap a managed launch/resume command so it is rooted at `cwd` regardless
-/// of the tmux pane shell's actual starting directory (#2250).
-///
-/// Why: `create_session -c <workdir>` is supposed to root the pane at the
-/// workspace, and `session_manager::resume_workdir::verify_pane_cwd` now
-/// fails loudly when tmux silently falls back to `$HOME` on the fresh-create
-/// resume path — but a RESUMED session that reuses an already-alive pane
-/// (created by a build that predates that verification, or whose cwd drifted
-/// after creation for any other reason) has no such guard. Prepending an
-/// explicit `cd` to the command line itself means the pane ends up in the
-/// right place independent of whatever directory the shell actually started
-/// in, closing that gap for every caller — not just the ones a point-in-time
-/// verification could catch.
-/// What: `cd '<cwd>' && { <body>; }`. `cwd` is single-quoted via
-/// [`shell_single_quote`] for the same reason [`env_bin_prefix`] quotes
-/// `CLAUDE_CONFIG_DIR` — a path with a space would otherwise word-split and
-/// break the pane. The brace GROUP (not a `( … )` subshell) is load-bearing:
-/// `body`'s `export TM_MANAGED_SESSION_ID=…` must land in the SAME shell
-/// process so it survives `claude` exiting and dropping back to the pane's
-/// shell (#2023 component B) — a subshell would discard that export the
-/// instant the group exits, breaking the in-place-relaunch fallback.
-/// Test: `spawn_command_prefixes_cd_to_workdir`,
-/// `resume_command_prefixes_cd_to_workdir`.
-fn cd_and_group(cwd: &Path, body: &str) -> String {
-    format!(
-        "cd {} && {{ {body}; }}",
-        shell_single_quote(&cwd.display().to_string())
-    )
-}
-
 /// Compose the `env …` prefix + resolved binary that starts every managed
-/// `claude`, wiring in the tm-owned `CLAUDE_CONFIG_DIR` when available (DOC-34).
+/// `claude`, wiring in the tm-owned `CLAUDE_CONFIG_DIR` and, when available,
+/// a `CLAUDE_CODE_OAUTH_TOKEN` (DOC-34; issue #2246).
 ///
-/// Why: two invariants must hold on the pane command. (1) `-u ANTHROPIC_API_KEY`
+/// Why: three invariants must hold on the pane command. (1) `-u ANTHROPIC_API_KEY`
 /// strips the API key so Claude Code falls back to OAuth, preventing key leakage
 /// through pane history. (2) When a managed `CLAUDE_CONFIG_DIR` is resolved,
 /// `env -u ANTHROPIC_API_KEY CLAUDE_CONFIG_DIR='<dir>'` points the session at the tm-owned config home
@@ -136,30 +108,47 @@ fn cd_and_group(cwd: &Path, body: &str) -> String {
 /// project layer — but it DOES isolate the session's auth: with the API key
 /// scrubbed, `claude` authenticates via the keychain/`.credentials.json` keyed to
 /// this config-dir path (the tm-managed login), never touching the operator's
-/// `~/.claude`. The path is SINGLE-QUOTED via [`shell_single_quote`] so a home
-/// dir with a space does not word-split and break the pane. Both settings are
-/// applied via a single `env` prefix, consistent with the scrub-only prefix.
-/// What: `env -u ANTHROPIC_API_KEY CLAUDE_CONFIG_DIR='<dir>' <claude_bin>` (path
-/// single-quoted) when `config_dir` is `Some`; the legacy
-/// `env -u ANTHROPIC_API_KEY <claude_bin>` when `None` (home unresolved — no
-/// config dir to point at). The `-u NAME` option MUST precede any `NAME=VALUE`
-/// assignment per POSIX `env` grammar (`env [OPTION]... [NAME=VALUE]...
-/// [COMMAND]...`); putting `CLAUDE_CONFIG_DIR=<dir>` before `-u` makes `env`
-/// stop parsing options at the first `NAME=VALUE` and try to exec `-u` as a
-/// command (`env: -u: No such file or directory`), which fatally kills every
-/// managed session spawn.
+/// `~/.claude`. (3) On macOS the Keychain entry Claude Code reads is keyed by a
+/// hash of `CLAUDE_CONFIG_DIR` — so a `/login` run inside a managed session
+/// diverges from the login stored under the operator's default config dir,
+/// producing a "login successful then immediately not-logged-in" loop
+/// (#2246). `CLAUDE_CODE_OAUTH_TOKEN`, when [`crate::core::oauth_token::resolve_oauth_token`]
+/// resolves one, bypasses the Keychain entirely and sidesteps that divergence.
+/// Every value is SINGLE-QUOTED via [`shell_single_quote`] so a home dir (or a
+/// token, though tokens do not contain shell metacharacters in practice) with a
+/// space does not word-split and break the pane. All settings are applied via a
+/// single `env` prefix, consistent with the scrub-only prefix.
+/// What: `env -u ANTHROPIC_API_KEY [CLAUDE_CONFIG_DIR='<dir>'] [CLAUDE_CODE_OAUTH_TOKEN='<token>'] <claude_bin>`
+/// — each bracketed assignment appears only when its value is `Some`; with
+/// neither, the legacy `env -u ANTHROPIC_API_KEY <claude_bin>` (byte-identical
+/// to the pre-#2246 command). The `-u NAME` option MUST precede any
+/// `NAME=VALUE` assignment per POSIX `env` grammar (`env [OPTION]...
+/// [NAME=VALUE]... [COMMAND]...`); putting an assignment before `-u` makes
+/// `env` stop parsing options at the first `NAME=VALUE` and try to exec `-u`
+/// as a command (`env: -u: No such file or directory`), which fatally kills
+/// every managed session spawn.
 /// Test: `spawn_command_contains_env_scrub`, `spawn_command_sets_claude_config_dir`,
 /// `spawn_command_without_config_dir_omits_it`,
 /// `env_bin_prefix_quotes_config_dir_with_space`,
-/// `env_bin_prefix_orders_unset_flag_before_config_dir_assignment`.
-fn env_bin_prefix(claude_bin: &str, config_dir: Option<&Path>) -> String {
-    match config_dir {
-        Some(dir) => {
-            let quoted = shell_single_quote(&dir.display().to_string());
-            format!("env -u ANTHROPIC_API_KEY CLAUDE_CONFIG_DIR={quoted} {claude_bin}")
-        }
-        None => format!("env -u ANTHROPIC_API_KEY {claude_bin}"),
+/// `env_bin_prefix_orders_unset_flag_before_config_dir_assignment`,
+/// `spawn_command_sets_oauth_token_when_available`,
+/// `spawn_command_omits_oauth_token_when_absent`,
+/// `spawn_command_without_token_is_byte_identical_to_pre_2246`.
+fn env_bin_prefix(
+    claude_bin: &str,
+    config_dir: Option<&Path>,
+    oauth_token: Option<&str>,
+) -> String {
+    let mut assignments = String::new();
+    if let Some(dir) = config_dir {
+        let quoted = shell_single_quote(&dir.display().to_string());
+        assignments.push_str(&format!(" CLAUDE_CONFIG_DIR={quoted}"));
     }
+    if let Some(token) = oauth_token {
+        let quoted = shell_single_quote(token);
+        assignments.push_str(&format!(" {OAUTH_TOKEN_ENV_VAR}={quoted}"));
+    }
+    format!("env -u ANTHROPIC_API_KEY{assignments} {claude_bin}")
 }
 
 /// Build the `--append-system-prompt-file <path>` flag fragment for a spawn
@@ -218,9 +207,6 @@ fn prompt_file_flag(prompt_file: Option<&Path>) -> String {
 /// does not need `claude` on its own `PATH` (#1298). `session_id` is the
 /// managed session's UUID (#2023 component B), exported so in-pane commands
 /// can identify the session after `claude` exits.
-/// `cwd` (#2250) is where the tmux pane is supposed to be rooted; the
-/// entire command is wrapped via [`cd_and_group`] so it is correct
-/// independent of the pane shell's actual starting directory.
 /// Test: `spawn_command_contains_env_scrub`,
 /// `spawn_command_contains_isolation_flags`,
 /// `spawn_command_uses_resolved_binary`,
@@ -229,24 +215,24 @@ fn prompt_file_flag(prompt_file: Option<&Path>) -> String {
 /// `spawn_command_prints_relaunch_hint_after_claude_exits`,
 /// `spawn_command_with_prompt_file_contains_flag`,
 /// `spawn_command_without_prompt_file_omits_flag`,
-/// `spawn_command_prefixes_cd_to_workdir`.
+/// `spawn_command_sets_oauth_token_when_available`,
+/// `spawn_command_omits_oauth_token_when_absent`.
 fn spawn_command(
-    cwd: &Path,
     claude_bin: &str,
     config_dir: Option<&Path>,
     session_id: &str,
     prompt_file: Option<&Path>,
+    oauth_token: Option<&str>,
 ) -> String {
-    let body = format!(
+    format!(
         "{}{}{} {} {}{}",
         session_id_export_prefix(session_id),
-        env_bin_prefix(claude_bin, config_dir),
+        env_bin_prefix(claude_bin, config_dir, oauth_token),
         prompt_file_flag(prompt_file),
         crate::core::model_inject::SETTING_SOURCES_FLAG,
         crate::core::model_inject::PERMISSION_MODE_FLAG,
         on_exit_hint_suffix(),
-    );
-    cd_and_group(cwd, &body)
+    )
 }
 
 /// Build and write the PM system-prompt file for `project_dir`, for injection
@@ -319,25 +305,21 @@ fn build_prompt_file(project_dir: &Path) -> Option<std::path::PathBuf> {
 /// `resume_command_exports_managed_session_id`,
 /// `resume_command_prints_relaunch_hint_after_claude_exits`,
 /// `resume_command_with_prompt_file_contains_flag`,
-/// `resume_command_prefixes_cd_to_workdir`.
-///
-/// `cwd` (#2250) is where the tmux pane is supposed to be rooted; the entire
-/// command is wrapped via [`cd_and_group`] — see its doc for why this must be
-/// a brace GROUP, not a subshell (the exported `TM_MANAGED_SESSION_ID` has to
-/// survive `claude` exiting).
+/// `resume_command_sets_oauth_token_when_available`,
+/// `resume_command_omits_oauth_token_when_absent`.
 fn resume_command(
-    cwd: &Path,
     claude_bin: &str,
     config_dir: Option<&Path>,
     claude_session_id: Option<&str>,
     has_prior_conv: bool,
     session_id: &str,
     prompt_file: Option<&Path>,
+    oauth_token: Option<&str>,
 ) -> String {
     let base = format!(
         "{}{}{} {} {}",
         session_id_export_prefix(session_id),
-        env_bin_prefix(claude_bin, config_dir),
+        env_bin_prefix(claude_bin, config_dir, oauth_token),
         prompt_file_flag(prompt_file),
         crate::core::model_inject::SETTING_SOURCES_FLAG,
         crate::core::model_inject::PERMISSION_MODE_FLAG,
@@ -347,8 +329,7 @@ fn resume_command(
         None if has_prior_conv => format!("{base} --continue"),
         None => base, // No prior conversation: start fresh to avoid "no conversation found".
     };
-    let body = format!("{cmd}{}", on_exit_hint_suffix());
-    cd_and_group(cwd, &body)
+    format!("{cmd}{}", on_exit_hint_suffix())
 }
 
 /// Encode a workspace path the same way Claude Code names its project dir.
@@ -560,10 +541,12 @@ fn prepare_managed_config(tmux_name: &str, cwd: &Path) -> Option<std::path::Path
 /// [`std::process::Command`] itself.
 /// What: `claude_bin` (resolved absolute path), `args` (the isolation flags
 /// plus `--resume <id>`/`--continue`/neither, mirroring [`resume_command`]'s
-/// selection — see [`compose_inplace_args`]), and `config_dir` (the tm-owned
-/// `CLAUDE_CONFIG_DIR`, when resolved). The caller is expected to
-/// `env_remove("ANTHROPIC_API_KEY")` and, when `config_dir` is `Some`, set
-/// `CLAUDE_CONFIG_DIR` to it — the same two invariants [`env_bin_prefix`]
+/// selection — see [`compose_inplace_args`]), `config_dir` (the tm-owned
+/// `CLAUDE_CONFIG_DIR`, when resolved), and `oauth_token` (issue #2246 — the
+/// resolved [`crate::core::oauth_token::resolve_oauth_token`] value, when
+/// available). The caller is expected to `env_remove("ANTHROPIC_API_KEY")`
+/// and, when each field is `Some`, set the matching env var (`CLAUDE_CONFIG_DIR`
+/// / `CLAUDE_CODE_OAUTH_TOKEN`) — the same invariants [`env_bin_prefix`]
 /// encodes into the shell-string commands.
 /// Test: exercised via [`build_inplace_resume_command`]'s tests.
 #[derive(Debug)]
@@ -576,6 +559,9 @@ pub struct InPlaceResumeCommand {
     /// The tm-owned `CLAUDE_CONFIG_DIR`, when resolved (`None` when home is
     /// unresolvable — mirrors [`prepare_managed_config`]'s fallback).
     pub config_dir: Option<std::path::PathBuf>,
+    /// The resolved `CLAUDE_CODE_OAUTH_TOKEN`, when available (issue #2246;
+    /// see [`crate::core::oauth_token::resolve_oauth_token`]'s precedence).
+    pub oauth_token: Option<String>,
 }
 
 /// Pure argv composition shared by [`build_inplace_resume_command`] (#2023 C).
@@ -647,10 +633,12 @@ pub fn build_inplace_resume_command(
     })?;
     let config_dir = prepare_managed_config("in-place-relaunch", cwd);
     let args = compose_inplace_args(cwd, config_dir.as_deref(), claude_session_id);
+    let oauth_token = crate::core::oauth_token::resolve_oauth_token();
     Ok(InPlaceResumeCommand {
         claude_bin,
         args,
         config_dir,
+        oauth_token,
     })
 }
 
@@ -744,11 +732,13 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
     /// if it cannot be found on `PATH` or in the well-known daemon dirs),
     /// provisions + trust-seeds the tm-owned `CLAUDE_CONFIG_DIR` via
     /// [`prepare_managed_config`], builds the PM system-prompt file via
-    /// [`build_prompt_file`] (issue #2125 item 3), then sends [`spawn_command`]
-    /// (`env -u ANTHROPIC_API_KEY CLAUDE_CONFIG_DIR=<dir> <abs-claude>
-    /// --append-system-prompt-file <prompt>` plus the isolation/permission
-    /// flags) to the pane; the task is logged for observability but not passed
-    /// to the command.
+    /// [`build_prompt_file`] (issue #2125 item 3), resolves an optional
+    /// `CLAUDE_CODE_OAUTH_TOKEN` via
+    /// [`crate::core::oauth_token::resolve_oauth_token`] (issue #2246), then
+    /// sends [`spawn_command`] (`env -u ANTHROPIC_API_KEY CLAUDE_CONFIG_DIR=<dir>
+    /// [CLAUDE_CODE_OAUTH_TOKEN=<token>] <abs-claude> --append-system-prompt-file
+    /// <prompt>` plus the isolation/permission flags) to the pane; the task is
+    /// logged for observability but not passed to the command.
     /// Test: `spawn_sends_env_scrub_when_binary_available`.
     fn spawn(
         &self,
@@ -782,15 +772,21 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
         // Claude Code. Non-fatal: a write failure omits the flag (#2173 ruled
         // out a CLAUDE.md-carrier fallback, so there is no other carrier).
         let prompt_file = build_prompt_file(cwd);
+        // Issue #2246: inject CLAUDE_CODE_OAUTH_TOKEN when one is available
+        // (an operator-set env var, else the tm-managed store) to bypass the
+        // CLAUDE_CONFIG_DIR-keyed Keychain divergence that causes the
+        // managed-session login loop. `None` when neither source has a
+        // token — the command is then byte-identical to pre-#2246.
+        let oauth_token = crate::core::oauth_token::resolve_oauth_token();
         self.tmux
             .send_line(
                 tmux_name,
                 &spawn_command(
-                    cwd,
                     &claude_bin,
                     config_dir.as_deref(),
                     session_id,
                     prompt_file.as_deref(),
+                    oauth_token.as_deref(),
                 ),
             )
             .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))?;
@@ -823,10 +819,14 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
     /// is missing, checks for prior conversation when no usable id remains,
     /// builds the PM system-prompt file via [`build_prompt_file`] (#2230 —
     /// same carrier `spawn` uses, previously missing from every resume path),
-    /// then sends the appropriate [`resume_command`] to the tmux pane.
+    /// resolves an optional `CLAUDE_CODE_OAUTH_TOKEN` via
+    /// [`crate::core::oauth_token::resolve_oauth_token`] (#2246 — same carrier
+    /// `spawn` uses), then sends the appropriate [`resume_command`] to the
+    /// tmux pane.
     /// Test: `spawn_resume_with_id_uses_resume_flag`,
     /// `spawn_resume_without_id_no_prior_conv_sends_plain_spawn`,
-    /// `spawn_resume_sends_prompt_file_when_binary_available`.
+    /// `spawn_resume_sends_prompt_file_when_binary_available`,
+    /// `spawn_resume_sends_oauth_token_when_available`.
     fn spawn_resume(
         &self,
         tmux_name: &str,
@@ -848,6 +848,11 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
         // resumed/guided-resume/crash-recovery session silently ran vanilla
         // Claude Code. Non-fatal: a write failure omits the flag.
         let prompt_file = build_prompt_file(cwd);
+        // #2246: the resume path must ALSO carry CLAUDE_CODE_OAUTH_TOKEN —
+        // every resumed/guided-resume/crash-recovery session funnels through
+        // here, so omitting it would leave exactly those sessions exposed to
+        // the login loop spawn() itself was fixed against.
+        let oauth_token = crate::core::oauth_token::resolve_oauth_token();
 
         // #2013: a stored id can go stale — existence-check it before trusting
         // `--resume <id>` so a missing session falls back gracefully instead
@@ -894,13 +899,13 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             .send_line(
                 tmux_name,
                 &resume_command(
-                    cwd,
                     &claude_bin,
                     config_dir.as_deref(),
                     effective_id,
                     prior,
                     session_id,
                     prompt_file.as_deref(),
+                    oauth_token.as_deref(),
                 ),
             )
             .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))?;
@@ -934,11 +939,6 @@ mod tests {
     /// Fixed managed-session UUID string reused across command-builder tests
     /// (#2023 component B) — a representative id, not a real session.
     const TEST_SESSION_ID: &str = "11111111-2222-3333-4444-555555555555";
-
-    /// Fixed workdir reused across command-builder tests (#2250) — a
-    /// representative cwd, not a real workspace (these tests exercise the
-    /// string builders directly, never touching the filesystem).
-    const TEST_CWD: &str = "/tmp/ws";
 
     /// RAII guard that redirects `$HOME` to a temp dir and restores it on drop
     /// (including panic).
@@ -982,7 +982,7 @@ mod tests {
     fn spawn_command_contains_env_scrub() {
         // The spawn command must always strip the API key from the environment
         // so the session falls back to OAuth (keyed by CLAUDE_CONFIG_DIR).
-        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
         assert!(
             cmd.contains("env -u ANTHROPIC_API_KEY"),
             "spawn command must contain env scrub: {cmd}"
@@ -1001,15 +1001,11 @@ mod tests {
         // can identify which managed session it belongs to. tmux
         // set-environment alone would NOT reach the pane's already-running
         // shell — the export must be part of the literal command line.
-        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
         let expected_prefix = format!("export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; ");
-        // #2250: the command now starts with `cd <workdir> && { ...` — the
-        // export is the first statement INSIDE that brace group, not literally
-        // the first bytes of the string.
         assert!(
-            cmd.contains(&format!("{{ {expected_prefix}")),
-            "spawn command must export the session id as the first statement \
-             inside the cd-group: {cmd}"
+            cmd.starts_with(&expected_prefix),
+            "spawn command must start with the session-id export: {cmd}"
         );
         let export_pos = cmd
             .find("export TM_MANAGED_SESSION_ID")
@@ -1028,13 +1024,7 @@ mod tests {
         // home, not the project's committed `.claude/`. It must co-exist with the
         // API-key scrub.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command(
-            Path::new(TEST_CWD),
-            "claude",
-            Some(dir),
-            TEST_SESSION_ID,
-            None,
-        );
+        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None, None);
         assert!(
             cmd.contains(
                 "env -u ANTHROPIC_API_KEY \
@@ -1059,13 +1049,7 @@ mod tests {
         // (`env: -u: No such file or directory`), fatally killing every managed
         // session spawn.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command(
-            Path::new(TEST_CWD),
-            "claude",
-            Some(dir),
-            TEST_SESSION_ID,
-            None,
-        );
+        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None, None);
         let u_pos = cmd
             .find("-u ANTHROPIC_API_KEY")
             .expect("cmd must contain -u ANTHROPIC_API_KEY");
@@ -1084,10 +1068,142 @@ mod tests {
         // When home is unresolvable there is no config dir to point at; the
         // command must fall back to the legacy scrub-only prefix (no bare
         // `CLAUDE_CONFIG_DIR=` token).
-        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
         assert!(
             !cmd.contains("CLAUDE_CONFIG_DIR"),
             "no config dir → must not reference CLAUDE_CONFIG_DIR: {cmd}"
+        );
+    }
+
+    // ── issue #2246: CLAUDE_CODE_OAUTH_TOKEN injection ──────────────────────
+
+    #[test]
+    fn spawn_command_sets_oauth_token_when_available() {
+        let cmd = spawn_command(
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            Some("sk-ant-oat01-fake-token"),
+        );
+        assert!(
+            cmd.contains("CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake-token'"),
+            "spawn command must inject a single-quoted CLAUDE_CODE_OAUTH_TOKEN when \
+             one is available: {cmd}"
+        );
+        assert!(
+            cmd.contains("-u ANTHROPIC_API_KEY"),
+            "the API-key scrub must still be present alongside the token: {cmd}"
+        );
+    }
+
+    #[test]
+    fn spawn_command_omits_oauth_token_when_absent() {
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
+        assert!(
+            !cmd.contains("CLAUDE_CODE_OAUTH_TOKEN"),
+            "no token available → must not reference CLAUDE_CODE_OAUTH_TOKEN: {cmd}"
+        );
+    }
+
+    #[test]
+    fn spawn_command_without_token_is_byte_identical_to_pre_2246() {
+        // Zero-regression guard: a caller with no config dir, no prompt file,
+        // and no token must get EXACTLY the same command string this crate
+        // produced before #2246 introduced the extra parameter.
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
+        let expected = format!(
+            "export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; env -u ANTHROPIC_API_KEY claude \
+             --setting-sources project,local --dangerously-skip-permissions; \
+             echo 'tm: run `tm` to relaunch this session'"
+        );
+        assert_eq!(
+            cmd, expected,
+            "no-token command must be byte-identical to pre-#2246"
+        );
+    }
+
+    #[test]
+    fn spawn_command_sets_both_config_dir_and_oauth_token() {
+        // Both assignments must coexist, config dir first (matching the
+        // established assignment order), each independently single-quoted.
+        let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
+        let cmd = spawn_command(
+            "claude",
+            Some(dir),
+            TEST_SESSION_ID,
+            None,
+            Some("sk-ant-oat01-fake-token"),
+        );
+        assert!(
+            cmd.contains(
+                "env -u ANTHROPIC_API_KEY \
+                 CLAUDE_CONFIG_DIR='/home/bob/.trusty-tools/trusty-mpm/claude-config' \
+                 CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake-token' claude"
+            ),
+            "both assignments must coexist, config dir before the token: {cmd}"
+        );
+    }
+
+    #[test]
+    fn resume_command_sets_oauth_token_when_available() {
+        let cmd = resume_command(
+            "claude",
+            None,
+            Some("abc-123"),
+            false,
+            TEST_SESSION_ID,
+            None,
+            Some("sk-ant-oat01-fake-token"),
+        );
+        assert!(
+            cmd.contains("CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake-token'"),
+            "resume command must inject the token when available: {cmd}"
+        );
+        assert!(
+            cmd.contains("--resume abc-123"),
+            "--resume must still be present alongside the token: {cmd}"
+        );
+    }
+
+    #[test]
+    fn resume_command_omits_oauth_token_when_absent() {
+        let cmd = resume_command(
+            "claude",
+            None,
+            Some("abc-123"),
+            false,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
+        assert!(
+            !cmd.contains("CLAUDE_CODE_OAUTH_TOKEN"),
+            "no token available → must not reference CLAUDE_CODE_OAUTH_TOKEN: {cmd}"
+        );
+    }
+
+    #[test]
+    fn resume_command_without_token_is_byte_identical_to_pre_2246() {
+        // Zero-regression guard, resume-path counterpart to
+        // spawn_command_without_token_is_byte_identical_to_pre_2246.
+        let cmd = resume_command(
+            "claude",
+            None,
+            Some("abc-123"),
+            false,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
+        let expected = format!(
+            "export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; env -u ANTHROPIC_API_KEY claude \
+             --setting-sources project,local --dangerously-skip-permissions --resume abc-123; \
+             echo 'tm: run `tm` to relaunch this session'"
+        );
+        assert_eq!(
+            cmd, expected,
+            "no-token resume command must be byte-identical to pre-#2246"
         );
     }
 
@@ -1097,13 +1213,7 @@ mod tests {
         // the pane command. The path must appear single-quoted and INTACT so
         // `env` receives one CLAUDE_CONFIG_DIR value, not two argv tokens.
         let dir = Path::new("/Users/John Doe/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command(
-            Path::new(TEST_CWD),
-            "claude",
-            Some(dir),
-            TEST_SESSION_ID,
-            None,
-        );
+        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None, None);
         assert!(
             cmd.contains(
                 "env -u ANTHROPIC_API_KEY \
@@ -1118,12 +1228,12 @@ mod tests {
         );
         // Resume path shares env_bin_prefix, so it must quote identically.
         let resume = resume_command(
-            Path::new(TEST_CWD),
             "claude",
             Some(dir),
             None,
             false,
             TEST_SESSION_ID,
+            None,
             None,
         );
         assert!(
@@ -1151,7 +1261,7 @@ mod tests {
         // Why: the session_manager spawn path must isolate from the user's global
         // settings and run fully unattended (bypass all permission prompts) so
         // multi-agent orchestration never stalls on interactive approval dialogs.
-        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
         assert!(
             cmd.contains("--setting-sources project,local"),
             "spawn command must isolate settings: {cmd}"
@@ -1173,10 +1283,10 @@ mod tests {
         // spawn command must invoke claude by the resolved (absolute) path
         // rather than a bare `claude` that the pane's PATH cannot find.
         let cmd = spawn_command(
-            Path::new(TEST_CWD),
             "/Users/me/.local/bin/claude",
             None,
             TEST_SESSION_ID,
+            None,
             None,
         );
         assert!(
@@ -1226,6 +1336,41 @@ mod tests {
         assert!(
             cmd.contains("--append-system-prompt-file"),
             "spawn command must inject the PM system prompt file: {cmd}"
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn spawn_sends_oauth_token_when_available() {
+        // #2246: the fresh-spawn path must inject CLAUDE_CODE_OAUTH_TOKEN when
+        // resolve_oauth_token() finds one (here, via the process env var — the
+        // higher-precedence source). HOME is redirected so the rest of the
+        // provisioning stays hermetic.
+        let _home = HomeGuard::set();
+        let Some(_claude_bin) = ClaudeCodeAdapter::resolve_claude() else {
+            return;
+        };
+        unsafe {
+            std::env::set_var(
+                crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR,
+                "sk-ant-oat01-fake-token",
+            );
+        }
+        let fake = FakeTmux::new();
+        let adapter = ClaudeCodeAdapter::new(fake.clone());
+        let result = adapter.spawn("tmpm-test", Path::new("/tmp"), "some task", TEST_SESSION_ID);
+        unsafe {
+            std::env::remove_var(crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR);
+        }
+        result.expect("spawn");
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1);
+        assert!(
+            sends[0]
+                .1
+                .contains("CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake-token'"),
+            "spawn must inject the resolved oauth token: {}",
+            sends[0].1
         );
     }
 
@@ -1302,13 +1447,7 @@ mod tests {
         // inject --append-system-prompt-file pointing at it, alongside the
         // existing isolation flags — the third fail-closed carrier.
         let path = Path::new("/tmp/trusty-mpm-system-prompt-test.txt");
-        let cmd = spawn_command(
-            Path::new(TEST_CWD),
-            "claude",
-            None,
-            TEST_SESSION_ID,
-            Some(path),
-        );
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, Some(path), None);
         assert!(
             cmd.contains("--append-system-prompt-file '/tmp/trusty-mpm-system-prompt-test.txt'"),
             "spawn command must pass the prompt file via --append-system-prompt-file: {cmd}"
@@ -1323,7 +1462,7 @@ mod tests {
     fn spawn_command_without_prompt_file_omits_flag() {
         // #2125 item 3: no prompt file (e.g. the write failed) → the flag must
         // be omitted entirely rather than passed with a bad/empty path.
-        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
         assert!(
             !cmd.contains("--append-system-prompt-file"),
             "no prompt file → flag must be absent: {cmd}"
@@ -1352,12 +1491,12 @@ mod tests {
         // Why (#1744): --resume <id> restores the exact prior conversation;
         // the test pins the contract so accidental regressions are caught early.
         let cmd = resume_command(
-            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
             false,
             TEST_SESSION_ID,
+            None,
             None,
         );
         assert!(
@@ -1381,22 +1520,18 @@ mod tests {
         // reason as the spawn path — the pane's shell must retain the id after
         // claude exits, whichever launch path (fresh spawn or resume) started it.
         let cmd = resume_command(
-            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
             false,
             TEST_SESSION_ID,
             None,
+            None,
         );
         let expected_prefix = format!("export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; ");
-        // #2250: the command now starts with `cd <workdir> && { ...` — the
-        // export is the first statement INSIDE that brace group, not literally
-        // the first bytes of the string.
         assert!(
-            cmd.contains(&format!("{{ {expected_prefix}")),
-            "resume command must export the session id as the first statement \
-             inside the cd-group: {cmd}"
+            cmd.starts_with(&expected_prefix),
+            "resume command must start with the session-id export: {cmd}"
         );
         let export_pos = cmd
             .find("export TM_MANAGED_SESSION_ID")
@@ -1414,12 +1549,12 @@ mod tests {
         // sessions read the same tm-owned roster as fresh spawns.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
         let cmd = resume_command(
-            Path::new(TEST_CWD),
             "claude",
             Some(dir),
             Some("abc-123"),
             false,
             TEST_SESSION_ID,
+            None,
             None,
         );
         assert!(
@@ -1440,15 +1575,7 @@ mod tests {
         // Why (#1744 / #1840): when no claude_session_id is stored but prior
         // conversation history exists, --continue resumes the most-recent
         // conversation in the workspace rather than starting fresh.
-        let cmd = resume_command(
-            Path::new(TEST_CWD),
-            "claude",
-            None,
-            None,
-            true,
-            TEST_SESSION_ID,
-            None,
-        );
+        let cmd = resume_command("claude", None, None, true, TEST_SESSION_ID, None, None);
         assert!(
             cmd.contains("--continue"),
             "resume command without id + prior conv must use --continue: {cmd}"
@@ -1464,15 +1591,7 @@ mod tests {
         // Why (#1840): when no claude_session_id is stored AND no prior
         // conversation exists, --continue would error with "No conversation
         // found to continue". The plain spawn starts a fresh session instead.
-        let cmd = resume_command(
-            Path::new(TEST_CWD),
-            "claude",
-            None,
-            None,
-            false,
-            TEST_SESSION_ID,
-            None,
-        );
+        let cmd = resume_command("claude", None, None, false, TEST_SESSION_ID, None, None);
         assert!(
             !cmd.contains("--continue"),
             "resume command without id + no prior conv must NOT use --continue: {cmd}"
@@ -1607,6 +1726,49 @@ mod tests {
         assert!(
             sends[0].1.contains("--append-system-prompt-file"),
             "spawn_resume must inject the PM system prompt file: {}",
+            sends[0].1
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn spawn_resume_sends_oauth_token_when_available() {
+        // #2246: spawn_resume must inject CLAUDE_CODE_OAUTH_TOKEN when one is
+        // resolvable, mirroring spawn()'s carrier — every resumed session
+        // funnels through here, so this is the exact path that was silently
+        // exposed to the login loop before this fix. HOME is redirected so
+        // resolve_oauth_token()'s stored-file check is hermetic; the env var
+        // itself is set/cleared around the call.
+        let _home = HomeGuard::set();
+        let Some(_claude_bin) = ClaudeCodeAdapter::resolve_claude() else {
+            return;
+        };
+        unsafe {
+            std::env::set_var(
+                crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR,
+                "sk-ant-oat01-fake-token",
+            );
+        }
+        let fake = FakeTmux::new();
+        let adapter = ClaudeCodeAdapter::new(fake.clone());
+        let result = adapter.spawn_resume(
+            "tmpm-test",
+            Path::new("/tmp/does-not-exist-2246"),
+            "task",
+            None,
+            TEST_SESSION_ID,
+        );
+        unsafe {
+            std::env::remove_var(crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR);
+        }
+        result.expect("spawn_resume");
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1);
+        assert!(
+            sends[0]
+                .1
+                .contains("CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake-token'"),
+            "spawn_resume must inject the resolved oauth token: {}",
             sends[0].1
         );
     }
@@ -1768,12 +1930,12 @@ mod tests {
         // The adapter merely calls resume_command() with the same arguments; testing the
         // function directly proves the selection logic without CI depending on claude.
         let cmd = resume_command(
-            Path::new(TEST_CWD),
             "__fake_claude__",
             None,
             None,
             false,
             TEST_SESSION_ID,
+            None,
             None,
         );
         assert!(
@@ -1821,64 +1983,13 @@ mod tests {
         );
     }
 
-    // ── #2250: cd-prefix belt-and-suspenders ────────────────────────────────
-
-    #[test]
-    fn spawn_command_prefixes_cd_to_workdir() {
-        // #2250: the emitted command must be correct regardless of the pane
-        // shell's actual starting directory — an explicit `cd` must lead the
-        // whole line, and the exported session id / claude invocation must be
-        // wrapped in a brace GROUP (not a subshell) so the env survives.
-        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
-        assert!(
-            cmd.starts_with("cd '/tmp/ws' && { "),
-            "spawn command must start with an explicit cd into the workdir: {cmd}"
-        );
-        assert!(
-            cmd.trim_end().ends_with('}'),
-            "spawn command must close the brace group it opened: {cmd}"
-        );
-    }
-
-    #[test]
-    fn resume_command_prefixes_cd_to_workdir() {
-        // #2250: same cd-prefix guarantee on the resume path — the one most
-        // directly implicated by a stale/removed workspace_path silently
-        // rooting a recreated pane at $HOME.
-        let cmd = resume_command(
-            Path::new(TEST_CWD),
-            "claude",
-            None,
-            Some("abc-123"),
-            false,
-            TEST_SESSION_ID,
-            None,
-        );
-        assert!(
-            cmd.starts_with("cd '/tmp/ws' && { "),
-            "resume command must start with an explicit cd into the workdir: {cmd}"
-        );
-        assert!(
-            cmd.trim_end().ends_with('}'),
-            "resume command must close the brace group it opened: {cmd}"
-        );
-    }
-
-    #[test]
-    fn cd_and_group_quotes_workdir_with_space() {
-        // A workdir with a space must not word-split the pane command — same
-        // invariant env_bin_prefix already enforces for CLAUDE_CONFIG_DIR.
-        let cmd = cd_and_group(Path::new("/Users/John Doe/work"), "echo hi");
-        assert_eq!(cmd, "cd '/Users/John Doe/work' && { echo hi; }");
-    }
-
     // ── #2023 component D: on-exit relaunch hint ────────────────────────────
 
     #[test]
     fn spawn_command_prints_relaunch_hint_after_claude_exits() {
         // The hint must appear AFTER the claude invocation, separated by `;` so
         // it only runs once claude exits and control returns to the pane shell.
-        let cmd = spawn_command(Path::new(TEST_CWD), "claude", None, TEST_SESSION_ID, None);
+        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
         assert!(
             cmd.contains("; echo 'tm: run `tm` to relaunch this session'"),
             "spawn command must print the relaunch hint after claude exits: {cmd}"
@@ -1896,12 +2007,12 @@ mod tests {
         // Same invariant for the resume path (--resume branch here; the
         // --continue/plain-spawn branches share the same trailing suffix).
         let cmd = resume_command(
-            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
             false,
             TEST_SESSION_ID,
+            None,
             None,
         );
         assert!(
@@ -1923,13 +2034,13 @@ mod tests {
         // crash-recovery sessions had no way to inject the PM system prompt at all.
         let path = Path::new("/tmp/trusty-mpm-system-prompt-resume-test.txt");
         let cmd = resume_command(
-            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
             false,
             TEST_SESSION_ID,
             Some(path),
+            None,
         );
         assert!(
             cmd.contains(
@@ -2040,6 +2151,35 @@ mod tests {
             result.args.contains(&"--setting-sources".to_owned()),
             "isolation flags must be present: {:?}",
             result.args
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn build_inplace_resume_command_carries_oauth_token_when_available() {
+        // #2246: the in-place relaunch (bare-`tm` inside a managed pane) must
+        // carry the same resolved oauth token as the tmux-pane spawn/resume
+        // paths, so the caller (guided_inplace.rs) can set the env var on the
+        // relaunched process the same way it already does for CLAUDE_CONFIG_DIR.
+        let _home = HomeGuard::set();
+        if ClaudeCodeAdapter::resolve_claude().is_none() {
+            return;
+        }
+        unsafe {
+            std::env::set_var(
+                crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR,
+                "sk-ant-oat01-fake-token",
+            );
+        }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let result = build_inplace_resume_command(tmp.path(), None);
+        unsafe {
+            std::env::remove_var(crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR);
+        }
+        let result = result.expect("build succeeds");
+        assert_eq!(
+            result.oauth_token.as_deref(),
+            Some("sk-ant-oat01-fake-token")
         );
     }
 }

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -94,6 +94,37 @@ fn on_exit_hint_suffix() -> String {
     format!("; echo {}", shell_single_quote(RELAUNCH_HINT))
 }
 
+/// Wrap a managed launch/resume command so it is rooted at `cwd` regardless
+/// of the tmux pane shell's actual starting directory (#2250).
+///
+/// Why: `create_session -c <workdir>` is supposed to root the pane at the
+/// workspace, and `session_manager::resume_workdir::verify_pane_cwd` now
+/// fails loudly when tmux silently falls back to `$HOME` on the fresh-create
+/// resume path — but a RESUMED session that reuses an already-alive pane
+/// (created by a build that predates that verification, or whose cwd drifted
+/// after creation for any other reason) has no such guard. Prepending an
+/// explicit `cd` to the command line itself means the pane ends up in the
+/// right place independent of whatever directory the shell actually started
+/// in, closing that gap for every caller — not just the ones a point-in-time
+/// verification could catch.
+/// What: `cd '<cwd>' && { <body>; }`. `cwd` is single-quoted via
+/// [`shell_single_quote`] for the same reason [`env_bin_prefix`] quotes
+/// `CLAUDE_CONFIG_DIR` — a path with a space would otherwise word-split and
+/// break the pane. The brace GROUP (not a `( … )` subshell) is load-bearing:
+/// `body`'s `export TM_MANAGED_SESSION_ID=…` must land in the SAME shell
+/// process so it survives `claude` exiting and dropping back to the pane's
+/// shell (#2023 component B) — a subshell would discard that export the
+/// instant the group exits, breaking the in-place-relaunch fallback.
+/// Test: `spawn_command_prefixes_cd_to_workdir`,
+/// `resume_command_prefixes_cd_to_workdir`,
+/// `cd_and_group_quotes_workdir_with_space`.
+fn cd_and_group(cwd: &Path, body: &str) -> String {
+    format!(
+        "cd {} && {{ {body}; }}",
+        shell_single_quote(&cwd.display().to_string())
+    )
+}
+
 /// Compose the `env …` prefix + resolved binary that starts every managed
 /// `claude`, wiring in the tm-owned `CLAUDE_CONFIG_DIR` and, when available,
 /// a `CLAUDE_CODE_OAUTH_TOKEN` (DOC-34; issue #2246).
@@ -207,6 +238,9 @@ fn prompt_file_flag(prompt_file: Option<&Path>) -> String {
 /// does not need `claude` on its own `PATH` (#1298). `session_id` is the
 /// managed session's UUID (#2023 component B), exported so in-pane commands
 /// can identify the session after `claude` exits.
+/// `cwd` (#2250) is where the tmux pane is supposed to be rooted; the
+/// entire command is wrapped via [`cd_and_group`] so it is correct
+/// independent of the pane shell's actual starting directory.
 /// Test: `spawn_command_contains_env_scrub`,
 /// `spawn_command_contains_isolation_flags`,
 /// `spawn_command_uses_resolved_binary`,
@@ -215,16 +249,18 @@ fn prompt_file_flag(prompt_file: Option<&Path>) -> String {
 /// `spawn_command_prints_relaunch_hint_after_claude_exits`,
 /// `spawn_command_with_prompt_file_contains_flag`,
 /// `spawn_command_without_prompt_file_omits_flag`,
+/// `spawn_command_prefixes_cd_to_workdir`,
 /// `spawn_command_sets_oauth_token_when_available`,
 /// `spawn_command_omits_oauth_token_when_absent`.
 fn spawn_command(
+    cwd: &Path,
     claude_bin: &str,
     config_dir: Option<&Path>,
     session_id: &str,
     prompt_file: Option<&Path>,
     oauth_token: Option<&str>,
 ) -> String {
-    format!(
+    let body = format!(
         "{}{}{} {} {}{}",
         session_id_export_prefix(session_id),
         env_bin_prefix(claude_bin, config_dir, oauth_token),
@@ -232,7 +268,8 @@ fn spawn_command(
         crate::core::model_inject::SETTING_SOURCES_FLAG,
         crate::core::model_inject::PERMISSION_MODE_FLAG,
         on_exit_hint_suffix(),
-    )
+    );
+    cd_and_group(cwd, &body)
 }
 
 /// Build and write the PM system-prompt file for `project_dir`, for injection
@@ -305,9 +342,24 @@ fn build_prompt_file(project_dir: &Path) -> Option<std::path::PathBuf> {
 /// `resume_command_exports_managed_session_id`,
 /// `resume_command_prints_relaunch_hint_after_claude_exits`,
 /// `resume_command_with_prompt_file_contains_flag`,
+/// `resume_command_prefixes_cd_to_workdir`,
 /// `resume_command_sets_oauth_token_when_available`,
 /// `resume_command_omits_oauth_token_when_absent`.
+///
+/// `cwd` (#2250) is where the tmux pane is supposed to be rooted; the entire
+/// command is wrapped via [`cd_and_group`] — see its doc for why this must be
+/// a brace GROUP, not a subshell (the exported `TM_MANAGED_SESSION_ID` has to
+/// survive `claude` exiting).
+///
+/// `#[allow(too_many_arguments)]`: each parameter is an independently-tested,
+/// orthogonal command-builder input (cwd/#2250, config_dir/DOC-34, resume
+/// selection/#1744+#1840, session_id/#2023, prompt_file/#2230, oauth_token/
+/// #2246) — bundling them into a struct would only move the field list, not
+/// reduce it, and this is a private, single-call-site builder (mirrors the
+/// established pattern in `session_manager/create.rs`).
+#[allow(clippy::too_many_arguments)]
 fn resume_command(
+    cwd: &Path,
     claude_bin: &str,
     config_dir: Option<&Path>,
     claude_session_id: Option<&str>,
@@ -329,7 +381,8 @@ fn resume_command(
         None if has_prior_conv => format!("{base} --continue"),
         None => base, // No prior conversation: start fresh to avoid "no conversation found".
     };
-    format!("{cmd}{}", on_exit_hint_suffix())
+    let body = format!("{cmd}{}", on_exit_hint_suffix());
+    cd_and_group(cwd, &body)
 }
 
 /// Encode a workspace path the same way Claude Code names its project dir.
@@ -782,6 +835,7 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             .send_line(
                 tmux_name,
                 &spawn_command(
+                    cwd,
                     &claude_bin,
                     config_dir.as_deref(),
                     session_id,
@@ -899,6 +953,7 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             .send_line(
                 tmux_name,
                 &resume_command(
+                    cwd,
                     &claude_bin,
                     config_dir.as_deref(),
                     effective_id,
@@ -939,6 +994,11 @@ mod tests {
     /// Fixed managed-session UUID string reused across command-builder tests
     /// (#2023 component B) — a representative id, not a real session.
     const TEST_SESSION_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+    /// Fixed workdir reused across command-builder tests (#2250) — a
+    /// representative cwd, not a real workspace (these tests exercise the
+    /// string builders directly, never touching the filesystem).
+    const TEST_CWD: &str = "/tmp/ws";
 
     /// RAII guard that redirects `$HOME` to a temp dir and restores it on drop
     /// (including panic).
@@ -982,7 +1042,14 @@ mod tests {
     fn spawn_command_contains_env_scrub() {
         // The spawn command must always strip the API key from the environment
         // so the session falls back to OAuth (keyed by CLAUDE_CONFIG_DIR).
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         assert!(
             cmd.contains("env -u ANTHROPIC_API_KEY"),
             "spawn command must contain env scrub: {cmd}"
@@ -1001,11 +1068,22 @@ mod tests {
         // can identify which managed session it belongs to. tmux
         // set-environment alone would NOT reach the pane's already-running
         // shell — the export must be part of the literal command line.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         let expected_prefix = format!("export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; ");
+        // #2250: the command now starts with `cd <workdir> && { ...` — the
+        // export is the first statement INSIDE that brace group, not literally
+        // the first bytes of the string.
         assert!(
-            cmd.starts_with(&expected_prefix),
-            "spawn command must start with the session-id export: {cmd}"
+            cmd.contains(&format!("{{ {expected_prefix}")),
+            "spawn command must export the session id as the first statement \
+             inside the cd-group: {cmd}"
         );
         let export_pos = cmd
             .find("export TM_MANAGED_SESSION_ID")
@@ -1024,7 +1102,14 @@ mod tests {
         // home, not the project's committed `.claude/`. It must co-exist with the
         // API-key scrub.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            Some(dir),
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         assert!(
             cmd.contains(
                 "env -u ANTHROPIC_API_KEY \
@@ -1049,7 +1134,14 @@ mod tests {
         // (`env: -u: No such file or directory`), fatally killing every managed
         // session spawn.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            Some(dir),
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         let u_pos = cmd
             .find("-u ANTHROPIC_API_KEY")
             .expect("cmd must contain -u ANTHROPIC_API_KEY");
@@ -1068,7 +1160,14 @@ mod tests {
         // When home is unresolvable there is no config dir to point at; the
         // command must fall back to the legacy scrub-only prefix (no bare
         // `CLAUDE_CONFIG_DIR=` token).
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         assert!(
             !cmd.contains("CLAUDE_CONFIG_DIR"),
             "no config dir → must not reference CLAUDE_CONFIG_DIR: {cmd}"
@@ -1080,6 +1179,7 @@ mod tests {
     #[test]
     fn spawn_command_sets_oauth_token_when_available() {
         let cmd = spawn_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             TEST_SESSION_ID,
@@ -1099,7 +1199,14 @@ mod tests {
 
     #[test]
     fn spawn_command_omits_oauth_token_when_absent() {
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         assert!(
             !cmd.contains("CLAUDE_CODE_OAUTH_TOKEN"),
             "no token available → must not reference CLAUDE_CODE_OAUTH_TOKEN: {cmd}"
@@ -1111,11 +1218,19 @@ mod tests {
         // Zero-regression guard: a caller with no config dir, no prompt file,
         // and no token must get EXACTLY the same command string this crate
         // produced before #2246 introduced the extra parameter.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         let expected = format!(
-            "export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; env -u ANTHROPIC_API_KEY claude \
+            "cd '/tmp/ws' && {{ export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; \
+             env -u ANTHROPIC_API_KEY claude \
              --setting-sources project,local --dangerously-skip-permissions; \
-             echo 'tm: run `tm` to relaunch this session'"
+             echo 'tm: run `tm` to relaunch this session'; }}"
         );
         assert_eq!(
             cmd, expected,
@@ -1129,6 +1244,7 @@ mod tests {
         // established assignment order), each independently single-quoted.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
         let cmd = spawn_command(
+            Path::new(TEST_CWD),
             "claude",
             Some(dir),
             TEST_SESSION_ID,
@@ -1148,6 +1264,7 @@ mod tests {
     #[test]
     fn resume_command_sets_oauth_token_when_available() {
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
@@ -1169,6 +1286,7 @@ mod tests {
     #[test]
     fn resume_command_omits_oauth_token_when_absent() {
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
@@ -1188,6 +1306,7 @@ mod tests {
         // Zero-regression guard, resume-path counterpart to
         // spawn_command_without_token_is_byte_identical_to_pre_2246.
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
@@ -1197,9 +1316,10 @@ mod tests {
             None,
         );
         let expected = format!(
-            "export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; env -u ANTHROPIC_API_KEY claude \
+            "cd '/tmp/ws' && {{ export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; \
+             env -u ANTHROPIC_API_KEY claude \
              --setting-sources project,local --dangerously-skip-permissions --resume abc-123; \
-             echo 'tm: run `tm` to relaunch this session'"
+             echo 'tm: run `tm` to relaunch this session'; }}"
         );
         assert_eq!(
             cmd, expected,
@@ -1213,7 +1333,14 @@ mod tests {
         // the pane command. The path must appear single-quoted and INTACT so
         // `env` receives one CLAUDE_CONFIG_DIR value, not two argv tokens.
         let dir = Path::new("/Users/John Doe/.trusty-tools/trusty-mpm/claude-config");
-        let cmd = spawn_command("claude", Some(dir), TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            Some(dir),
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         assert!(
             cmd.contains(
                 "env -u ANTHROPIC_API_KEY \
@@ -1228,6 +1355,7 @@ mod tests {
         );
         // Resume path shares env_bin_prefix, so it must quote identically.
         let resume = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             Some(dir),
             None,
@@ -1261,7 +1389,14 @@ mod tests {
         // Why: the session_manager spawn path must isolate from the user's global
         // settings and run fully unattended (bypass all permission prompts) so
         // multi-agent orchestration never stalls on interactive approval dialogs.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         assert!(
             cmd.contains("--setting-sources project,local"),
             "spawn command must isolate settings: {cmd}"
@@ -1283,6 +1418,7 @@ mod tests {
         // spawn command must invoke claude by the resolved (absolute) path
         // rather than a bare `claude` that the pane's PATH cannot find.
         let cmd = spawn_command(
+            Path::new(TEST_CWD),
             "/Users/me/.local/bin/claude",
             None,
             TEST_SESSION_ID,
@@ -1447,7 +1583,14 @@ mod tests {
         // inject --append-system-prompt-file pointing at it, alongside the
         // existing isolation flags — the third fail-closed carrier.
         let path = Path::new("/tmp/trusty-mpm-system-prompt-test.txt");
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, Some(path), None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            Some(path),
+            None,
+        );
         assert!(
             cmd.contains("--append-system-prompt-file '/tmp/trusty-mpm-system-prompt-test.txt'"),
             "spawn command must pass the prompt file via --append-system-prompt-file: {cmd}"
@@ -1462,7 +1605,14 @@ mod tests {
     fn spawn_command_without_prompt_file_omits_flag() {
         // #2125 item 3: no prompt file (e.g. the write failed) → the flag must
         // be omitted entirely rather than passed with a bad/empty path.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         assert!(
             !cmd.contains("--append-system-prompt-file"),
             "no prompt file → flag must be absent: {cmd}"
@@ -1491,6 +1641,7 @@ mod tests {
         // Why (#1744): --resume <id> restores the exact prior conversation;
         // the test pins the contract so accidental regressions are caught early.
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
@@ -1520,6 +1671,7 @@ mod tests {
         // reason as the spawn path — the pane's shell must retain the id after
         // claude exits, whichever launch path (fresh spawn or resume) started it.
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
@@ -1529,9 +1681,13 @@ mod tests {
             None,
         );
         let expected_prefix = format!("export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; ");
+        // #2250: the command now starts with `cd <workdir> && { ...` — the
+        // export is the first statement INSIDE that brace group, not literally
+        // the first bytes of the string.
         assert!(
-            cmd.starts_with(&expected_prefix),
-            "resume command must start with the session-id export: {cmd}"
+            cmd.contains(&format!("{{ {expected_prefix}")),
+            "resume command must export the session id as the first statement \
+             inside the cd-group: {cmd}"
         );
         let export_pos = cmd
             .find("export TM_MANAGED_SESSION_ID")
@@ -1549,6 +1705,7 @@ mod tests {
         // sessions read the same tm-owned roster as fresh spawns.
         let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             Some(dir),
             Some("abc-123"),
@@ -1575,7 +1732,16 @@ mod tests {
         // Why (#1744 / #1840): when no claude_session_id is stored but prior
         // conversation history exists, --continue resumes the most-recent
         // conversation in the workspace rather than starting fresh.
-        let cmd = resume_command("claude", None, None, true, TEST_SESSION_ID, None, None);
+        let cmd = resume_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            None,
+            true,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         assert!(
             cmd.contains("--continue"),
             "resume command without id + prior conv must use --continue: {cmd}"
@@ -1591,7 +1757,16 @@ mod tests {
         // Why (#1840): when no claude_session_id is stored AND no prior
         // conversation exists, --continue would error with "No conversation
         // found to continue". The plain spawn starts a fresh session instead.
-        let cmd = resume_command("claude", None, None, false, TEST_SESSION_ID, None, None);
+        let cmd = resume_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            None,
+            false,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         assert!(
             !cmd.contains("--continue"),
             "resume command without id + no prior conv must NOT use --continue: {cmd}"
@@ -1930,6 +2105,7 @@ mod tests {
         // The adapter merely calls resume_command() with the same arguments; testing the
         // function directly proves the selection logic without CI depending on claude.
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "__fake_claude__",
             None,
             None,
@@ -1983,13 +2159,79 @@ mod tests {
         );
     }
 
+    // ── #2250: cd-prefix belt-and-suspenders ────────────────────────────────
+
+    #[test]
+    fn spawn_command_prefixes_cd_to_workdir() {
+        // #2250: the emitted command must be correct regardless of the pane
+        // shell's actual starting directory — an explicit `cd` must lead the
+        // whole line, and the exported session id / claude invocation must be
+        // wrapped in a brace GROUP (not a subshell) so the env survives.
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
+        assert!(
+            cmd.starts_with("cd '/tmp/ws' && { "),
+            "spawn command must start with an explicit cd into the workdir: {cmd}"
+        );
+        assert!(
+            cmd.trim_end().ends_with('}'),
+            "spawn command must close the brace group it opened: {cmd}"
+        );
+    }
+
+    #[test]
+    fn resume_command_prefixes_cd_to_workdir() {
+        // #2250: same cd-prefix guarantee on the resume path — the one most
+        // directly implicated by a stale/removed workspace_path silently
+        // rooting a recreated pane at $HOME.
+        let cmd = resume_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            Some("abc-123"),
+            false,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
+        assert!(
+            cmd.starts_with("cd '/tmp/ws' && { "),
+            "resume command must start with an explicit cd into the workdir: {cmd}"
+        );
+        assert!(
+            cmd.trim_end().ends_with('}'),
+            "resume command must close the brace group it opened: {cmd}"
+        );
+    }
+
+    #[test]
+    fn cd_and_group_quotes_workdir_with_space() {
+        // A workdir with a space must not word-split the pane command — same
+        // invariant env_bin_prefix already enforces for CLAUDE_CONFIG_DIR.
+        let cmd = cd_and_group(Path::new("/Users/John Doe/work"), "echo hi");
+        assert_eq!(cmd, "cd '/Users/John Doe/work' && { echo hi; }");
+    }
+
     // ── #2023 component D: on-exit relaunch hint ────────────────────────────
 
     #[test]
     fn spawn_command_prints_relaunch_hint_after_claude_exits() {
         // The hint must appear AFTER the claude invocation, separated by `;` so
         // it only runs once claude exits and control returns to the pane shell.
-        let cmd = spawn_command("claude", None, TEST_SESSION_ID, None, None);
+        let cmd = spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            None,
+        );
         assert!(
             cmd.contains("; echo 'tm: run `tm` to relaunch this session'"),
             "spawn command must print the relaunch hint after claude exits: {cmd}"
@@ -2007,6 +2249,7 @@ mod tests {
         // Same invariant for the resume path (--resume branch here; the
         // --continue/plain-spawn branches share the same trailing suffix).
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),
@@ -2034,6 +2277,7 @@ mod tests {
         // crash-recovery sessions had no way to inject the PM system prompt at all.
         let path = Path::new("/tmp/trusty-mpm-system-prompt-resume-test.txt");
         let cmd = resume_command(
+            Path::new(TEST_CWD),
             "claude",
             None,
             Some("abc-123"),


### PR DESCRIPTION
Managed sessions run under a relocated CLAUDE_CONFIG_DIR whose macOS-Keychain entry (keyed by SHA256(dir)) diverges from the default login → /login "success then not-logged-in" loop; adds tm-managed token store (`tm auth set-token`, 0600) + injects CLAUDE_CODE_OAUTH_TOKEN into spawn+resume env, no-op when unconfigured (byte-identical no-token path). Adds `tm doctor` advisory. QA-APPROVED.

Closes #2246

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools