### PR TITLE
feat(tga): guard PR upsert against stale-snapshot overwrites via fetched_at

### DIFF
--- a/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
@@ -321,10 +321,20 @@ impl BitbucketClient {
     ///
     /// Why: `ON CONFLICT … DO UPDATE` keeps existing `id` so FK-linked `pr_reviewers`
     /// survive re-collection; `INSERT OR REPLACE` cascade-deleted them (#752).
+    /// A bare `DO UPDATE` still overwrote `state`/`merged_at`/`commit_shas`
+    /// unconditionally on every conflict, so a background job re-ingesting an
+    /// OLDER snapshot could downgrade an already-`merged` PR back to `open`
+    /// (issue #821). The `WHERE excluded.fetched_at > pull_requests.fetched_at`
+    /// guard rejects such stale writes: the conflicting row is left untouched
+    /// and the statement still succeeds with no error.
     /// What: `provider='bitbucket'`; `repository="<workspace>/<repo_slug>"`;
     /// deduplicates on `(provider,repository,pr_number)` (0012/#88); existing rows
-    /// update `title`/`author`/`state`/`merged_at`/`commit_shas`. Test: see
-    /// reviewer_store integration tests for FK-preservation coverage.
+    /// update `title`/`author`/`state`/`merged_at`/`commit_shas`/`fetched_at` only
+    /// when the incoming `fetched_at` is strictly newer. Test: see
+    /// reviewer_store integration tests for FK-preservation coverage;
+    /// `store_pull_requests_stale_write_guard_rejects_older_fetched_at` and
+    /// `store_pull_requests_applies_genuinely_newer_fetched_at` (in `tests.rs`)
+    /// cover the guard itself.
     /// # Errors
     ///
     /// Propagates [`crate::core::TgaError::DbError`] on SQL failures.
@@ -338,11 +348,13 @@ impl BitbucketClient {
         for pr in prs {
             conn.execute(
                 "INSERT INTO pull_requests \
-                 (provider,repository,pr_number,title,author,state,created_at,merged_at,commit_shas) \
-                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9) \
+                 (provider,repository,pr_number,title,author,state,created_at,merged_at,commit_shas,fetched_at) \
+                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10) \
                  ON CONFLICT(provider,repository,pr_number) DO UPDATE SET \
                    title=excluded.title,author=excluded.author,state=excluded.state,\
-                   merged_at=excluded.merged_at,commit_shas=excluded.commit_shas",
+                   merged_at=excluded.merged_at,commit_shas=excluded.commit_shas,\
+                   fetched_at=excluded.fetched_at \
+                 WHERE excluded.fetched_at > pull_requests.fetched_at",
                 params![
                     "bitbucket",
                     pr.repository,
@@ -353,6 +365,7 @@ impl BitbucketClient {
                     pr.created_at.to_rfc3339(),
                     pr.merged_at.map(|t| t.to_rfc3339()),
                     pr.commit_shas,
+                    pr.fetched_at,
                 ],
             )?;
             count += 1;
@@ -451,6 +464,7 @@ fn map_pr(pr: BbPullRequest, repository: &str) -> PullRequest {
         created_at,
         merged_at,
         commit_shas,
+        fetched_at: Utc::now().to_rfc3339(),
     }
 }
 

--- a/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
@@ -538,3 +538,105 @@ fn resolve_auth_app_password_falls_back_to_env_when_config_absent() {
         BbAuth::Bearer(_) => panic!("expected Basic auth, got Bearer"),
     }
 }
+
+/// Build a minimal, fully-populated [`PullRequest`] for upsert-guard tests.
+fn sample_pr(repository: &str, pr_number: u64, state: PrState, fetched_at: &str) -> PullRequest {
+    PullRequest {
+        id: 0,
+        pr_number,
+        repository: repository.to_string(),
+        title: "T".to_string(),
+        author: "ada".to_string(),
+        state,
+        created_at: Utc::now(),
+        merged_at: None,
+        commit_shas: "[]".to_string(),
+        fetched_at: fetched_at.to_string(),
+    }
+}
+
+fn store_test_client() -> BitbucketClient {
+    BitbucketClient::new(&BitbucketConfig {
+        token: Some("dummy".into()),
+        workspace: Some("acme".into()),
+        repo_slug: Some("widgets".into()),
+        ..Default::default()
+    })
+    .expect("client builds")
+}
+
+/// Why: regression guard for issue #821. A background job re-ingesting an
+/// OLDER snapshot must not be able to downgrade a PR already recorded as
+/// `merged` back to `open` — the `fetched_at` guard on `store_pull_requests`
+/// must reject a conflicting write whose `fetched_at` is not strictly newer.
+/// What: upsert a `merged` PR with `fetched_at = "2026-01-02T00:00:00Z"`,
+/// then upsert the same `(provider, repository, pr_number)` with `state =
+/// "open"` and an OLDER `fetched_at = "2026-01-01T00:00:00Z"`. Asserts the
+/// row still reads `state = "merged"` afterwards.
+/// Test: this test.
+#[test]
+fn store_pull_requests_stale_write_guard_rejects_older_fetched_at() {
+    let db = Database::open_in_memory().expect("open db");
+    let client = store_test_client();
+
+    let fresh = sample_pr("acme/widgets", 42, PrState::Merged, "2026-01-02T00:00:00Z");
+    client
+        .store_pull_requests(&db, &[fresh])
+        .expect("initial upsert");
+
+    let stale = sample_pr("acme/widgets", 42, PrState::Open, "2026-01-01T00:00:00Z");
+    client
+        .store_pull_requests(&db, &[stale])
+        .expect("stale upsert must not error, just be rejected by the WHERE guard");
+
+    let state: String = db
+        .connection()
+        .query_row(
+            "SELECT state FROM pull_requests \
+             WHERE provider = 'bitbucket' AND repository = ?1 AND pr_number = 42",
+            params!["acme/widgets"],
+            |r| r.get(0),
+        )
+        .expect("read back state");
+    assert_eq!(
+        state, "merged",
+        "stale write with an older fetched_at must be rejected"
+    );
+}
+
+/// Why: the flip side of the guard — issue #821 requires both branches of
+/// the `WHERE excluded.fetched_at > pull_requests.fetched_at` predicate to
+/// be exercised, not just the rejection path.
+/// What: upsert a `merged` PR, then upsert the same triple with `state =
+/// "open"` and a genuinely NEWER `fetched_at`. Asserts the update DOES
+/// apply this time.
+/// Test: this test.
+#[test]
+fn store_pull_requests_applies_genuinely_newer_fetched_at() {
+    let db = Database::open_in_memory().expect("open db");
+    let client = store_test_client();
+
+    let first = sample_pr("acme/widgets", 77, PrState::Merged, "2026-01-01T00:00:00Z");
+    client
+        .store_pull_requests(&db, &[first])
+        .expect("initial upsert");
+
+    let newer = sample_pr("acme/widgets", 77, PrState::Open, "2026-01-02T00:00:00Z");
+    client
+        .store_pull_requests(&db, &[newer])
+        .expect("newer upsert");
+
+    let state: String = db
+        .connection()
+        .query_row(
+            "SELECT state FROM pull_requests \
+             WHERE provider = 'bitbucket' AND repository = ?1 AND pr_number = 77",
+            params!["acme/widgets"],
+            |r| r.get(0),
+        )
+        .expect("read back state");
+    assert_eq!(
+        state, "open",
+        "a genuinely newer fetched_at must overwrite the previous row"
+    );
+}

--- a/crates/trusty-git-analytics/src/collect/github/client.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client.rs
@@ -1,5 +1,6 @@
 //! Async GitHub REST API v3 client for pull-request and issue metadata.
 
+use chrono::Utc;
 use rusqlite::params;
 use tracing::{debug, warn};
 
@@ -231,6 +232,7 @@ impl GitHubClient {
                     created_at: p.created_at,
                     merged_at: p.merged_at,
                     commit_shas,
+                    fetched_at: Utc::now().to_rfc3339(),
                 });
             }
             if (n as u32) < PAGE_SIZE {
@@ -245,9 +247,20 @@ impl GitHubClient {
     ///
     /// Why: `ON CONFLICT … DO UPDATE` keeps existing `id` so FK-linked
     /// `pr_reviewers` survive re-collection; `INSERT OR REPLACE` wiped them (#752).
-    /// What: new rows insert all columns; existing update `title`/`author`/`state`/
-    /// `merged_at`/`commit_shas`; `id` and `created_at` are never overwritten.
-    /// Test: reviewer_store tests cover FK-preservation.
+    /// A bare `DO UPDATE` still overwrote `state`/`merged_at`/`commit_shas`
+    /// unconditionally on every conflict, so a background job re-ingesting an
+    /// OLDER snapshot could downgrade an already-`merged` PR back to `open`
+    /// (issue #821). The `WHERE excluded.fetched_at > pull_requests.fetched_at`
+    /// guard rejects such stale writes: the conflicting row is left untouched
+    /// and the statement still succeeds with no error.
+    /// What: new rows insert all columns, including `fetched_at`; existing
+    /// rows update `title`/`author`/`state`/`merged_at`/`commit_shas`/`fetched_at`
+    /// only when the incoming `fetched_at` is strictly newer; `id` and
+    /// `created_at` are never overwritten.
+    /// Test: reviewer_store tests cover FK-preservation;
+    /// `store_pull_requests_stale_write_guard_rejects_older_fetched_at` and
+    /// `store_pull_requests_applies_genuinely_newer_fetched_at` (in
+    /// `client_tests.rs`) cover the guard itself.
     ///
     /// # Errors
     ///
@@ -262,11 +275,13 @@ impl GitHubClient {
         for pr in prs {
             conn.execute(
                 "INSERT INTO pull_requests \
-                 (provider,repository,pr_number,title,author,state,created_at,merged_at,commit_shas) \
-                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9) \
+                 (provider,repository,pr_number,title,author,state,created_at,merged_at,commit_shas,fetched_at) \
+                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10) \
                  ON CONFLICT(provider,repository,pr_number) DO UPDATE SET \
                    title=excluded.title,author=excluded.author,state=excluded.state,\
-                   merged_at=excluded.merged_at,commit_shas=excluded.commit_shas",
+                   merged_at=excluded.merged_at,commit_shas=excluded.commit_shas,\
+                   fetched_at=excluded.fetched_at \
+                 WHERE excluded.fetched_at > pull_requests.fetched_at",
                 params![
                     "github",
                     pr.repository,
@@ -277,6 +292,7 @@ impl GitHubClient {
                     pr.created_at.to_rfc3339(),
                     pr.merged_at.map(|t| t.to_rfc3339()),
                     pr.commit_shas,
+                    pr.fetched_at,
                 ],
             )?;
             count += 1;

--- a/crates/trusty-git-analytics/src/collect/github/client_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client_tests.rs
@@ -4,14 +4,35 @@
 
 use std::path::PathBuf;
 
+use chrono::Utc;
+use rusqlite::params;
+
 use crate::collect::errors::CollectError;
 use crate::collect::github::repo_resolver::{
     extract_owner_repo_from_url, parse_slug, resolve_github_repos,
 };
 use crate::collect::github::types::{ApiPull, GitHubIssue, GitHubPrCommit, GitHubReview};
 use crate::core::config::{GithubConfig, RepositoryConfig};
+use crate::core::db::Database;
+use crate::core::models::{PrState, PullRequest};
 
 use super::{commit_shas_for_pull, GitHubClient};
+
+/// Build a minimal, fully-populated [`PullRequest`] for upsert-guard tests.
+fn sample_pr(repository: &str, pr_number: u64, state: PrState, fetched_at: &str) -> PullRequest {
+    PullRequest {
+        id: 0,
+        pr_number,
+        repository: repository.to_string(),
+        title: "T".to_string(),
+        author: "octocat".to_string(),
+        state,
+        created_at: Utc::now(),
+        merged_at: None,
+        commit_shas: "[]".to_string(),
+        fetched_at: fetched_at.to_string(),
+    }
+}
 
 fn gh(repo: Option<&str>, org: Option<&str>) -> GithubConfig {
     GithubConfig {
@@ -443,5 +464,81 @@ fn commit_shas_gated_on_merged_at() {
         commit_shas_for_pull(&p).expect("encodes"),
         "[]",
         "merged PR without a SHA yields the empty array",
+    );
+}
+
+/// Why: regression guard for issue #821. A background job re-ingesting an
+/// OLDER snapshot must not be able to downgrade a PR already recorded as
+/// `merged` back to `open` — the `fetched_at` guard on `store_pull_requests`
+/// must reject a conflicting write whose `fetched_at` is not strictly newer.
+/// What: upsert a `merged` PR with `fetched_at = "2026-01-02T00:00:00Z"`,
+/// then upsert the same `(provider, repository, pr_number)` with `state =
+/// "open"` and an OLDER `fetched_at = "2026-01-01T00:00:00Z"`. Asserts the
+/// row still reads `state = "merged"` afterwards.
+/// Test: this test.
+#[test]
+fn store_pull_requests_stale_write_guard_rejects_older_fetched_at() {
+    let db = Database::open_in_memory().expect("open db");
+    let client = GitHubClient::new(&gh(Some("acme/widget"), None)).expect("client");
+
+    let fresh = sample_pr("acme/widget", 42, PrState::Merged, "2026-01-02T00:00:00Z");
+    client
+        .store_pull_requests(&db, &[fresh])
+        .expect("initial upsert");
+
+    let stale = sample_pr("acme/widget", 42, PrState::Open, "2026-01-01T00:00:00Z");
+    client
+        .store_pull_requests(&db, &[stale])
+        .expect("stale upsert must not error, just be rejected by the WHERE guard");
+
+    let state: String = db
+        .connection()
+        .query_row(
+            "SELECT state FROM pull_requests \
+             WHERE provider = 'github' AND repository = ?1 AND pr_number = 42",
+            params!["acme/widget"],
+            |r| r.get(0),
+        )
+        .expect("read back state");
+    assert_eq!(
+        state, "merged",
+        "stale write with an older fetched_at must be rejected"
+    );
+}
+
+/// Why: the flip side of the guard — issue #821 requires both branches of
+/// the `WHERE excluded.fetched_at > pull_requests.fetched_at` predicate to
+/// be exercised, not just the rejection path.
+/// What: upsert a `merged` PR, then upsert the same triple with `state =
+/// "open"` and a genuinely NEWER `fetched_at`. Asserts the update DOES
+/// apply this time.
+/// Test: this test.
+#[test]
+fn store_pull_requests_applies_genuinely_newer_fetched_at() {
+    let db = Database::open_in_memory().expect("open db");
+    let client = GitHubClient::new(&gh(Some("acme/widget"), None)).expect("client");
+
+    let first = sample_pr("acme/widget", 77, PrState::Merged, "2026-01-01T00:00:00Z");
+    client
+        .store_pull_requests(&db, &[first])
+        .expect("initial upsert");
+
+    let newer = sample_pr("acme/widget", 77, PrState::Open, "2026-01-02T00:00:00Z");
+    client
+        .store_pull_requests(&db, &[newer])
+        .expect("newer upsert");
+
+    let state: String = db
+        .connection()
+        .query_row(
+            "SELECT state FROM pull_requests \
+             WHERE provider = 'github' AND repository = ?1 AND pr_number = 77",
+            params!["acme/widget"],
+            |r| r.get(0),
+        )
+        .expect("read back state");
+    assert_eq!(
+        state, "open",
+        "a genuinely newer fetched_at must overwrite the previous row"
     );
 }

--- a/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
+++ b/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
@@ -139,6 +139,11 @@ pub const MIGRATIONS: &[Migration] = &[
         // Placeholder — execution is routed to v21::apply (with column guard).
         sql: "",
     },
+    Migration {
+        version: 22,
+        name: "pull_requests_fetched_at",
+        sql: include_str!("../sql/0022_pull_requests_fetched_at.sql"),
+    },
 ];
 
 /// Ensure the `schema_migrations` bookkeeping table exists.

--- a/crates/trusty-git-analytics/src/core/db/sql/0022_pull_requests_fetched_at.sql
+++ b/crates/trusty-git-analytics/src/core/db/sql/0022_pull_requests_fetched_at.sql
@@ -1,0 +1,22 @@
+-- Migration v22: add fetched_at column to pull_requests for a stale-write guard.
+--
+-- Issue #821 (advisory follow-up to #752/#808): #808 replaced the
+-- destructive `INSERT OR REPLACE` with `ON CONFLICT … DO UPDATE`, but the
+-- `DO UPDATE SET` clause still overwrites `state`/`merged_at`/`commit_shas`
+-- unconditionally on every conflict. If a background job re-ingests an
+-- OLDER snapshot (e.g. a delayed or retried collection run), a PR already
+-- recorded as `merged` could be silently overwritten back to `open`.
+--
+-- A reviewer originally suggested guarding on `created_at`, but that's the
+-- PR's immutable creation date — identical across re-ingests, so it can
+-- never detect staleness. This migration adds `fetched_at`, a client-set
+-- ingestion/snapshot timestamp (RFC3339, UTC) that changes on every fetch,
+-- so the upsert can guard with
+-- `WHERE excluded.fetched_at > pull_requests.fetched_at` (see
+-- `store_pull_requests` in the GitHub and Bitbucket collectors).
+--
+-- Additive only — no existing columns are modified and no data is removed.
+-- Existing rows default to '' (empty string), which sorts before any real
+-- RFC3339 timestamp string, so the first genuine re-ingest of a
+-- pre-migration row always satisfies the guard and applies normally.
+ALTER TABLE pull_requests ADD COLUMN fetched_at TEXT NOT NULL DEFAULT '';

--- a/crates/trusty-git-analytics/src/core/models/mod.rs
+++ b/crates/trusty-git-analytics/src/core/models/mod.rs
@@ -201,6 +201,24 @@ pub struct PullRequest {
 
     /// JSON-encoded array of commit SHAs in the PR.
     pub commit_shas: String,
+
+    /// Client-set ingestion/snapshot timestamp (RFC3339, UTC).
+    ///
+    /// Why: issue #821, advisory follow-up to #752/#808. The upsert's
+    /// `ON CONFLICT … DO UPDATE` unconditionally overwrote `state` /
+    /// `merged_at` / `commit_shas` on every re-ingest; if a background job
+    /// re-ingests an OLDER snapshot, a PR already recorded as `merged`
+    /// could be overwritten back to `open`. `created_at` is the PR's
+    /// immutable creation date — identical across re-ingests — so it
+    /// cannot detect staleness. `fetched_at` changes on every fetch, so
+    /// `store_pull_requests` guards the update with
+    /// `WHERE excluded.fetched_at > pull_requests.fetched_at`.
+    /// What: set once per fetch (`Utc::now().to_rfc3339()`) by the GitHub
+    /// and Bitbucket collectors when the PR row is constructed; persisted
+    /// via migration v22 (`0022_pull_requests_fetched_at.sql`).
+    /// Test: `store_pull_requests_stale_write_guard_*` in
+    /// `collect::github::client_tests` and `collect::bitbucket::tests`.
+    pub fetched_at: String,
 }
 
 /// Cascade tier that produced a classification.


### PR DESCRIPTION
## Summary

Advisory follow-up to #808 (which replaced destructive `INSERT OR REPLACE` with `ON CONFLICT … DO UPDATE` to stop cascade-deleting `pr_reviewers`). The `DO UPDATE SET` clause still overwrote `state`/`merged_at`/`commit_shas` unconditionally on every conflict — if a background job re-ingested an OLDER snapshot, a PR already recorded as `merged` could be silently overwritten back to `open`. Guarding on `created_at` (as originally suggested) is a no-op since it's the PR's immutable creation date, identical across re-ingests.

**Design (approach b, client-set `fetched_at` guard):**

- **Additive migration** (`0022_pull_requests_fetched_at.sql`, wired into `MIGRATIONS` as v22): `ALTER TABLE pull_requests ADD COLUMN fetched_at TEXT NOT NULL DEFAULT ''`. Existing rows default to `''`, which sorts before any real RFC3339 timestamp, so the first genuine re-ingest of a pre-migration row always passes the guard.
- **`PullRequest` model** gains a `fetched_at: String` field (RFC3339, UTC), set via `Utc::now().to_rfc3339()` at construction time in both the GitHub (`fetch_pull_requests_for_repo`) and Bitbucket (`map_pr`) collectors — matching the existing `created_at`/`merged_at` formatting convention.
- **Upsert guard**: both `store_pull_requests` implementations (GitHub + Bitbucket) now bind `pr.fetched_at`, add it to the `DO UPDATE SET` clause, and append `WHERE excluded.fetched_at > pull_requests.fetched_at`. SQLite evaluates this predicate before applying the update; if false, the conflicting row is left untouched and the statement still succeeds with no error.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p tga` — 100% green, including 4 new regression tests covering both branches of the guard (GitHub + Bitbucket × reject-stale / accept-newer)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings (exit 0; only a pre-existing unrelated MSRV clippy.toml/Cargo.toml informational warning, not a lint failure)
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations

```
test result: ok. 661 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.91s
```

New tests:
- `collect::github::client::tests::store_pull_requests_stale_write_guard_rejects_older_fetched_at`
- `collect::github::client::tests::store_pull_requests_applies_genuinely_newer_fetched_at`
- `collect::bitbucket::client::tests::store_pull_requests_stale_write_guard_rejects_older_fetched_at`
- `collect::bitbucket::client::tests::store_pull_requests_applies_genuinely_newer_fetched_at`

Closes #821