### PR TITLE
fix(tga): prevent identity collisions + Tier-3 cross-identity misattribution (closes #2244, #2253)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9705,7 +9705,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+All notable changes are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+## [Unreleased]
+
+### Added
+
+- add commit_count_net to weekly reports excluding reverts ([#2248](https://github.com/bobmatnyc/trusty-tools/pull/2248)) ([`68d3872`](https://github.com/bobmatnyc/trusty-tools/commit/68d38724c66bcd945574b7031ff243298ea836ab))
+
+### Fixed
+
+- seed primary email + local-part Tier-3 fuzzy to prevent identity collisions/misattribution ([`b8f5291`](https://github.com/bobmatnyc/trusty-tools/commit/b8f52914e4c8f33b196029fc4e6b6d5d20d40431))
+- store full Bitbucket PR commit SHA list, not abbreviated merge SHA ([#2251](https://github.com/bobmatnyc/trusty-tools/pull/2251)) ([`e57a036`](https://github.com/bobmatnyc/trusty-tools/commit/e57a036bcbf1cb149dd428191c0ca87051a4c2b0))
+- seed primary_email as alias for non-aliased team members to avoid empty canonical_email collisions ([#2249](https://github.com/bobmatnyc/trusty-tools/pull/2249)) ([`4f9cef3`](https://github.com/bobmatnyc/trusty-tools/commit/4f9cef3e7141c31288c31257266a3fe145732897))
+# Changelog
+
 All notable changes to trusty-git-analytics will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.9.0"
+version = "2.9.1"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.91) per #254. Required for

--- a/crates/trusty-git-analytics/src/collect/identity/resolver.rs
+++ b/crates/trusty-git-analytics/src/collect/identity/resolver.rs
@@ -51,6 +51,21 @@ fn email_local_part(email: &str) -> String {
     }
 }
 
+/// Extract the domain-part (after the last `@`) of an email address,
+/// lowercased. Returns an empty string when no `@` is present.
+///
+/// Why: Tier-3 fuzzy matching (issue #2253) must gate email similarity on
+/// domain equality, and it needs the two domains to compare. `email_local_part`
+/// covers the complementary half; this pairs with it.
+/// What: splits on the last `@` and lowercases the remainder.
+/// Test: see `resolver_tests::email_domain_basic`.
+fn email_domain(email: &str) -> String {
+    match email.rfind('@') {
+        Some(i) => email[i + 1..].to_lowercase(),
+        None => String::new(),
+    }
+}
+
 /// Why: `IdentityResolver::upsert_author` and the suggester both need to ask
 /// "does this email live under the configured canonical_domain?". Centralising
 /// the check avoids subtle case- or `@`-prefix bugs at the two call sites.
@@ -244,11 +259,26 @@ impl IdentityResolver {
             }
         }
 
-        // 3. Fuzzy match against member names/emails (raw Jaro-Winkler).
+        // 3. Fuzzy match against member names/emails (Jaro-Winkler).
+        //    Name similarity uses the raw names. Email similarity compares
+        //    LOCAL-PARTS only, and only when both addresses share the same
+        //    domain (issue #2253). Comparing full email strings let a long
+        //    shared domain suffix alone clear the 0.85 threshold — e.g.
+        //    jaro_winkler("ops+snyk@duettoresearch.com",
+        //    "jenkins@duettoresearch.com") = 0.857 — merging unrelated bots.
+        //    Gating on domain equality + local-part comparison removes that
+        //    false-positive class while keeping genuine same-domain,
+        //    near-identical-local-part matches.
+        let inbound_domain = email_domain(email);
         let mut best: Option<(f64, &(String, String))> = None;
         for m in &self.members {
             let s_name = jaro_winkler(&name_lc, &m.0.to_lowercase());
-            let s_email = jaro_winkler(&email_lc, &m.1.to_lowercase());
+            let member_domain = email_domain(&m.1);
+            let s_email = if !inbound_domain.is_empty() && inbound_domain == member_domain {
+                jaro_winkler(&email_local_part(email), &email_local_part(&m.1))
+            } else {
+                0.0
+            };
             let score = s_name.max(s_email);
             if score >= self.threshold && best.map(|(b, _)| score > b).unwrap_or(true) {
                 best = Some((score, m));

--- a/crates/trusty-git-analytics/src/collect/identity/resolver_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/identity/resolver_tests.rs
@@ -391,6 +391,79 @@ fn canonical_domain_absent_falls_back_to_first_seen_email() {
 }
 
 #[test]
+fn email_domain_basic() {
+    // Why: regression guard for the helper backing the Tier-3 domain gate
+    // (#2253).
+    assert_eq!(email_domain("ops+snyk@Duetto.COM"), "duetto.com");
+    assert_eq!(email_domain("no-at-symbol"), "");
+    // Only the last `@` delimits the domain.
+    assert_eq!(email_domain("weird@name@example.org"), "example.org");
+}
+
+/// Issue #2253: two unrelated bots sharing a long common domain suffix must
+/// NOT collapse into one identity via the Tier-3 fuzzy pass.
+///
+/// Before the fix, Tier 3 scored Jaro-Winkler on the FULL email string, so
+/// `jaro_winkler("ops+snyk@duettoresearch.com", "jenkins@duettoresearch.com")`
+/// = 0.857 ≥ 0.85 (the shared 18-char domain suffix alone cleared the bar),
+/// misattributing every Snyk-bot commit to "Jenkins CI". Comparing
+/// local-parts under a domain-equality gate keeps them distinct.
+#[test]
+fn tier3_does_not_merge_bots_sharing_domain_suffix() {
+    let team = TeamConfig {
+        members: vec![TeamMember {
+            name: "Jenkins CI".into(),
+            email: "jenkins@duettoresearch.com".into(),
+            aliases: vec![],
+        }],
+        aliases: HashMap::new(),
+        canonical_domain: None,
+    };
+    let r = IdentityResolver::new(Some(&team));
+
+    // Sanity: the pre-fix root cause really did clear the threshold on the
+    // full-string comparison, so this test is guarding a real regression.
+    assert!(
+        jaro_winkler("ops+snyk@duettoresearch.com", "jenkins@duettoresearch.com")
+            >= DEFAULT_SIMILARITY_THRESHOLD,
+        "precondition: full-string similarity should exceed the threshold"
+    );
+
+    let (name, email) = r.resolve("Snyk Bot", "ops+snyk@duettoresearch.com");
+    assert_ne!(
+        name, "Jenkins CI",
+        "Snyk bot must not be misattributed to Jenkins CI (#2253)"
+    );
+    // The unrelated bot falls through unchanged.
+    assert_eq!(name, "Snyk Bot");
+    assert_eq!(email, "ops+snyk@duettoresearch.com");
+}
+
+/// The #2253 fix must not over-tighten: a genuine same-person match — same
+/// domain, near-identical local-parts — must STILL resolve via Tier 3 even
+/// when the display name is too different to carry the match on its own.
+#[test]
+fn tier3_still_matches_same_domain_near_identical_local_parts() {
+    let team = TeamConfig {
+        members: vec![TeamMember {
+            name: "Alice Cooper".into(),
+            email: "alice.cooper@acme.com".into(),
+            aliases: vec![],
+        }],
+        aliases: HashMap::new(),
+        canonical_domain: None,
+    };
+    let r = IdentityResolver::new(Some(&team));
+
+    // Display name "acoopr" is far from "Alice Cooper"; the match rides on
+    // the email local-part `alice.coopr` ~= `alice.cooper` under the shared
+    // `acme.com` domain.
+    let (name, email) = r.resolve("acoopr", "alice.coopr@acme.com");
+    assert_eq!(name, "Alice Cooper");
+    assert_eq!(email, "alice.cooper@acme.com");
+}
+
+#[test]
 fn canonical_domain_read_from_config() {
     // Why: confirms YAML deserialization wires the new key end-to-end.
     let yaml = r#"


### PR DESCRIPTION
## Summary

Two coupled identity-resolution bugs in `trusty-git-analytics` (`tga`), fixed together and released as `tga` v2.9.1:

- **#2244** — primary-email seeding for non-aliased `team.members` entries. This half already landed on `origin/main` via #2249; its regression guard (`resolved_aliases_seeds_primary_email_for_non_aliased_members`) is re-verified as part of this branch.
- **#2253** — `IdentityResolver::resolve()` Tier 3 computed Jaro-Winkler similarity on the **full email string**, so identities sharing a long domain suffix (e.g. `@duettoresearch.com`) cleared the 0.85 threshold from the shared suffix alone — `jaro_winkler("ops+snyk@duettoresearch.com", "jenkins@duettoresearch.com") = 0.857` — misattributing Snyk-bot commits to "Jenkins CI".

The two bugs are coupled: #2244 was already merged, but #2253 needed the same identity-resolution code path fixed to complete the pair before a clean `tga` release could ship.

## What changed

- `IdentityResolver::resolve()` Tier 3 now compares email **local-parts**, gated on domain equality (new `email_domain` helper), instead of the full email string — removing the shared-domain-suffix false-positive class while preserving genuine same-domain, near-identical-local-part matches.
- Name-similarity matching is unchanged; genuine cross-domain same-person cases still resolve via the existing Tier-4 normalized pass.
- Regression tests added: bots sharing a domain suffix stay distinct; genuine same-domain fuzzy matches still succeed; `email_domain` helper coverage.
- Version bump: `tga` 2.9.0 → 2.9.1 (patch), with staged `CHANGELOG.md` unreleased section.

## Quality gate

- `cargo test -p tga`: 130 passed, 0 failed (identity resolver test binary); 660 passed, 0 failed, 1 ignored (lib tests overall)
- `cargo clippy -p tga --all-targets -- -D warnings`: clean (exit 0)
- `cargo fmt --check -p tga`: clean (exit 0)
- `bash scripts/check_line_cap.sh`: 14 allowlisted, 0 violations

Closes #2244
Closes #2253

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools