### PR TITLE
feat(trusty-code): Bedrock cachePoint prompt-caching + tool_calls-aware compaction

### DIFF
--- a/crates/trusty-code/src/agent_loop/compaction.rs
+++ b/crates/trusty-code/src/agent_loop/compaction.rs
@@ -69,15 +69,34 @@ pub fn estimate_tokens(text: &str) -> usize {
 /// Sum the estimated token count across a span of messages.
 ///
 /// Why: The trigger decision operates on the whole transcript's estimated
-/// size, not any single message.
-/// What: Sums `estimate_tokens` over each message's content plus role/name
-/// overhead is intentionally ignored — the heuristic only needs to track
-/// growth trend, not byte-exact accounting.
-/// Test: `compaction::tests::estimate_total_tokens_sums_content`.
+/// size, not any single message. (#2261) `content` alone systematically
+/// undercounts coding sessions: `write_file`/`edit` tool calls carry their
+/// argument bodies (the actual file contents being written) in
+/// `ChatMessage.tool_calls[].function.arguments`, not `content` — an
+/// assistant turn that only calls a tool has `content: None` entirely. A
+/// real segment measured at 23,541 tokens (by this same heuristic applied to
+/// the full request body) never compacted under the old content-only sum
+/// because the default `token_threshold: 6_000` was never crossed.
+/// What: Sums `estimate_tokens` over each message's `content` PLUS, for
+/// every entry in `tool_calls`, `estimate_tokens` over that call's
+/// `function.arguments` JSON string. Role/name overhead is still
+/// intentionally ignored — the heuristic only needs to track growth trend,
+/// not byte-exact accounting.
+/// Test: `compaction::tests::estimate_total_tokens_sums_content`,
+/// `compaction::tests::estimate_total_tokens_sums_tool_call_arguments`.
 pub fn estimate_total_tokens(messages: &[ChatMessage]) -> usize {
     messages
         .iter()
-        .map(|m| estimate_tokens(m.content.as_deref().unwrap_or_default()))
+        .map(|m| {
+            let content_tokens = estimate_tokens(m.content.as_deref().unwrap_or_default());
+            let tool_call_tokens: usize = m
+                .tool_calls
+                .iter()
+                .flatten()
+                .map(|call| estimate_tokens(&call.function.arguments))
+                .sum();
+            content_tokens + tool_call_tokens
+        })
         .sum()
 }
 
@@ -176,6 +195,92 @@ mod tests {
             ChatMessage::assistant("abcdefgh"),
         ];
         assert_eq!(estimate_total_tokens(&messages), 3);
+    }
+
+    /// A tool-call-only assistant turn (`content: None`, arguments carrying
+    /// the actual payload — e.g. a `write_file` body) contributes its
+    /// argument-string tokens to the total, not zero (#2261).
+    ///
+    /// Why: This is the exact bug #2261 reports: `estimate_total_tokens`
+    /// previously summed only `content`, so a transcript whose size lives
+    /// entirely in `write_file`/`edit` tool-call arguments was invisible to
+    /// the compaction trigger — `should_compact` never fired regardless of
+    /// how large those arguments grew.
+    /// What: Build an assistant message with `content: None` and one
+    /// `tool_calls` entry whose `function.arguments` is a known-length JSON
+    /// string; assert the total equals `estimate_tokens` of that arguments
+    /// string (content contributes 0 since it's `None`).
+    /// Test: this test.
+    #[test]
+    fn estimate_total_tokens_sums_tool_call_arguments() {
+        use crate::llm::{FunctionCall, ToolCall};
+
+        let arguments = r#"{"path":"src/main.rs","content":"fn main() {}"}"#;
+        let messages = vec![ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".into(),
+                kind: "function".into(),
+                function: FunctionCall {
+                    name: "write_file".into(),
+                    arguments: arguments.into(),
+                },
+            }]),
+            tool_call_id: None,
+            name: None,
+            cache_control: None,
+        }];
+
+        assert_eq!(estimate_total_tokens(&messages), estimate_tokens(arguments));
+    }
+
+    /// A transcript whose size comes entirely from `write_file`/`edit`
+    /// tool-call arguments now crosses `should_compact`'s threshold, even
+    /// though every message's `content` is empty or trivial (#2261).
+    ///
+    /// Why: Reproduces the reported real-world case — a segment measured at
+    /// 23,541 real tokens that compacted zero times because the default
+    /// `token_threshold: 6_000` was gated on `content` alone.
+    /// What: Build a small transcript whose only assistant turn carries a
+    /// large `write_file` argument body (well over the default threshold)
+    /// and a matching `tool` result; assert `should_compact` now returns
+    /// `true` against `CompactionConfig::default()`.
+    /// Test: this test.
+    #[test]
+    fn should_compact_triggers_on_large_tool_call_arguments() {
+        use crate::llm::{FunctionCall, ToolCall};
+
+        // ~9,000 chars -> ~2,250 estimated tokens per call; three calls sum
+        // to ~6,750 tokens, comfortably clearing the 6,000-token default
+        // threshold via tool_calls alone, with every `content` field left
+        // `None`/trivial.
+        let big_content = "x".repeat(9_000);
+        let mut messages = vec![ChatMessage::system("s"), ChatMessage::user("do the thing")];
+        for i in 0..3 {
+            messages.push(ChatMessage {
+                role: "assistant".into(),
+                content: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: format!("call_{i}"),
+                    kind: "function".into(),
+                    function: FunctionCall {
+                        name: "write_file".into(),
+                        arguments: format!(r#"{{"content":"{big_content}"}}"#),
+                    },
+                }]),
+                tool_call_id: None,
+                name: None,
+                cache_control: None,
+            });
+            messages.push(ChatMessage::tool_result(
+                format!("call_{i}"),
+                "write_file",
+                "ok",
+            ));
+        }
+
+        assert!(should_compact(&messages, &CompactionConfig::default()));
     }
 
     #[test]

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -48,6 +48,10 @@ use crate::perf::PerfCollector;
 use crate::tools::{AgentOutput, FINISH_TASK_TOOL_NAME, FinishTaskArgs, ToolRegistry, ToolResult};
 
 pub use compaction::CompactionConfig;
+// (#2260) Crate-internal re-export so `llm::bedrock::cache` can reuse the
+// same chars/4 token-estimate heuristic for its cachePoint min-size guard
+// instead of duplicating it.
+pub(crate) use compaction::estimate_tokens;
 pub use error::AgentLoopError;
 pub use sink::ToolEventSink;
 pub use transcript::Transcript;
@@ -445,7 +449,12 @@ impl AgentLoop {
     /// prompt-cache breakpoint — the byte-stable prefix this turn resends
     /// unchanged from the last. When `false` (Parity mode, or a
     /// provider/model that hasn't verified the passthrough), the request is
-    /// byte-identical to pre-#2156. Independently, when the resolved
+    /// byte-identical to pre-#2156. This marker is provider-neutral: each
+    /// transport interprets it in its own wire shape — OpenRouter's
+    /// `anthropic/*` passthrough serialises it as Anthropic's `cache_control`
+    /// content-block field (`llm::message::ChatMessage::serialize`); Bedrock's
+    /// Converse transport (#2260) translates it into a native `cachePoint`
+    /// content block (`llm::bedrock::cache`). Independently, when the resolved
     /// provider's `Provider::wants_detailed_usage()` is `true` (currently
     /// OpenRouter, unconditionally), attaches
     /// `usage: Some(RequestUsageConfig::detailed())` so the response carries
@@ -453,8 +462,9 @@ impl AgentLoop {
     /// response-side cache-usage fix).
     /// Test: Exercised by every loop test; `config_max_tokens_reaches_chat_request`
     /// pins that a configured cap flows through unchanged;
-    /// `daily_driver_anthropic_model_marks_cache_breakpoints` and
-    /// `parity_mode_never_marks_cache_breakpoints` cover the #2156 gate;
+    /// `daily_driver_anthropic_model_marks_cache_breakpoints`,
+    /// `daily_driver_bedrock_model_marks_cache_breakpoints`, and
+    /// `parity_mode_never_marks_cache_breakpoints` cover the #2156/#2260 gate;
     /// `build_request_sets_detailed_usage_for_openrouter` covers the
     /// detailed-usage gate.
     fn build_request(&self, transcript: &Transcript, schemas: &[ToolDefinition]) -> ChatRequest {
@@ -507,6 +517,7 @@ impl AgentLoop {
     /// AND `crate::provider::provider_for(&self.config.model)
     /// .supports_prompt_caching()` is `true`.
     /// Test: `agent_loop::tests::daily_driver_anthropic_model_marks_cache_breakpoints`,
+    /// `agent_loop::tests::daily_driver_bedrock_model_marks_cache_breakpoints`,
     /// `agent_loop::tests::parity_mode_never_marks_cache_breakpoints`,
     /// `agent_loop::tests::non_anthropic_model_never_marks_cache_breakpoints`.
     fn prompt_cache_enabled(&self) -> bool {

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -447,7 +447,11 @@ impl AgentLoop {
     /// (#2156) When [`Self::prompt_cache_enabled`] is `true`, marks the LAST
     /// tool definition and the system-role message with an ephemeral
     /// prompt-cache breakpoint — the byte-stable prefix this turn resends
-    /// unchanged from the last. When `false` (Parity mode, or a
+    /// unchanged from the last — AND (rolling-history follow-up to #2260)
+    /// marks the last two non-system messages via
+    /// [`mark_cache_breakpoint_on_history`], rolling the cached prefix
+    /// forward to cover the growing transcript, the dominant token cost.
+    /// When `false` (Parity mode, or a
     /// provider/model that hasn't verified the passthrough), the request is
     /// byte-identical to pre-#2156. This marker is provider-neutral: each
     /// transport interprets it in its own wire shape — OpenRouter's
@@ -485,6 +489,7 @@ impl AgentLoop {
         let mut messages = transcript.to_messages();
         if cache_prefix {
             mark_cache_breakpoint_on_system(&mut messages);
+            mark_cache_breakpoint_on_history(&mut messages);
         }
 
         let usage = provider
@@ -599,6 +604,47 @@ fn mark_cache_breakpoint_on_tools(schemas: &mut [ToolDefinition]) {
 fn mark_cache_breakpoint_on_system(messages: &mut [ChatMessage]) {
     if let Some(system) = messages.iter_mut().find(|m| m.role == "system") {
         system.cache_control = Some(CacheControl::ephemeral());
+    }
+}
+
+/// Mark the last two non-system messages with an ephemeral prompt-cache
+/// breakpoint, rolling the cached prefix forward each turn (Bedrock
+/// history-cache follow-up to #2260).
+///
+/// Why: The tools+system prefix `mark_cache_breakpoint_on_tools`/
+/// `mark_cache_breakpoint_on_system` mark is small and static — the growing
+/// transcript is the dominant token cost. A live cost-proof of #2260
+/// as-merged showed cache_read staying 0 and ~452K fresh tokens/run on L1
+/// because nothing ever marked the history: every turn re-sent the full
+/// conversation as fresh input. Marking the LAST TWO non-system messages
+/// (rather than just the last one) mirrors opencode's verified
+/// `final.slice(-2)` pattern and guards against a single turn appending more
+/// content blocks than Bedrock's ~20-block cache lookback window covers — if
+/// only the very last message were marked and it alone exceeded that window,
+/// the previous turn's cache write would fall outside it and never hit.
+/// Uses breakpoint slots 3+4 of Bedrock's 4-per-request cachePoint budget
+/// (slots 1+2 are tools + system).
+/// Caveat: the OpenRouter/Anthropic-passthrough serializer
+/// (`llm::message::ChatMessage::serialize`) drops `cache_control` when a
+/// message has `content: None` (e.g. an assistant turn that is only
+/// `tool_calls`). Marking the last two messages already mitigates this in
+/// practice (at least one of the two usually carries text content); the
+/// Bedrock Converse path (`llm::bedrock::convert`) does not go through that
+/// serializer and is unaffected.
+/// What: Collects the indices of all non-system messages, then sets
+/// `cache_control` on the last (up to) two of them, in original order.
+/// No-op when there are zero or one non-system messages (the loop still
+/// marks whatever is present).
+/// Test: `agent_loop::tests::daily_driver_bedrock_model_marks_cache_breakpoints`.
+fn mark_cache_breakpoint_on_history(messages: &mut [ChatMessage]) {
+    let idxs: Vec<usize> = messages
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| m.role != "system")
+        .map(|(i, _)| i)
+        .collect();
+    for &i in idxs.iter().rev().take(2) {
+        messages[i].cache_control = Some(CacheControl::ephemeral());
     }
 }
 

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -1405,6 +1405,61 @@ async fn daily_driver_anthropic_model_marks_cache_breakpoints() {
     );
 }
 
+/// A `DailyDriver` run against a `bedrock/*` model ALSO marks the static
+/// tools+system prefix with an ephemeral prompt-cache breakpoint (#2260).
+///
+/// Why: `BedrockProvider::supports_prompt_caching` now returns `true`, so
+/// `AgentLoop::prompt_cache_enabled` must treat a Bedrock route the same as
+/// an `anthropic/*` OpenRouter slug — this is the `agent_loop`-level half of
+/// #2260 (the Converse-transport half, translating this marker into a
+/// native `cachePoint` block, is covered by
+/// `llm::bedrock::tests::build_converse_messages_emits_cache_point_after_large_cached_system`
+/// and its tool-config sibling).
+/// What: Same setup as `daily_driver_anthropic_model_marks_cache_breakpoints`
+/// but with model `"bedrock/us.anthropic.claude-sonnet-4-5"`; assert both
+/// markers are present on the `ChatRequest` the loop builds.
+/// Test: this test.
+#[tokio::test]
+async fn daily_driver_bedrock_model_marks_cache_breakpoints() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let registry = registry_with_echo(false);
+    let agent = make_loop(
+        llm.clone(),
+        registry,
+        AgentLoopConfig {
+            model: "bedrock/us.anthropic.claude-sonnet-4-5".into(),
+            mode: crate::mode::HarnessMode::DailyDriver,
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    agent
+        .run("you are a helpful assistant", "do the thing")
+        .await
+        .expect("single stop turn should complete");
+
+    let requests = llm.requests();
+    let system_msg = requests[0]
+        .iter()
+        .find(|m| m.role == "system")
+        .expect("system message present");
+    assert_eq!(
+        system_msg.cache_control,
+        Some(crate::llm::CacheControl::ephemeral()),
+        "system message must carry the cache breakpoint for a Bedrock route"
+    );
+
+    let tools = llm.tools_seen()[0]
+        .clone()
+        .expect("tools array present (echo tool registered)");
+    let last_tool = tools.last().expect("at least one tool");
+    assert_eq!(
+        last_tool.function.cache_control,
+        Some(crate::llm::CacheControl::ephemeral()),
+        "last tool definition must carry the cache breakpoint for a Bedrock route"
+    );
+}
+
 /// `Parity` mode never marks a cache breakpoint, even for an `anthropic/*`
 /// model — the request stays byte-identical to pre-#2156.
 ///

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -1405,8 +1405,10 @@ async fn daily_driver_anthropic_model_marks_cache_breakpoints() {
     );
 }
 
-/// A `DailyDriver` run against a `bedrock/*` model ALSO marks the static
-/// tools+system prefix with an ephemeral prompt-cache breakpoint (#2260).
+/// A `DailyDriver` run against a `bedrock/*` model marks the static
+/// tools+system prefix AND the rolling history (last two non-system
+/// messages) with an ephemeral prompt-cache breakpoint (#2260 +
+/// rolling-history follow-up).
 ///
 /// Why: `BedrockProvider::supports_prompt_caching` now returns `true`, so
 /// `AgentLoop::prompt_cache_enabled` must treat a Bedrock route the same as
@@ -1414,14 +1416,24 @@ async fn daily_driver_anthropic_model_marks_cache_breakpoints() {
 /// #2260 (the Converse-transport half, translating this marker into a
 /// native `cachePoint` block, is covered by
 /// `llm::bedrock::tests::build_converse_messages_emits_cache_point_after_large_cached_system`
-/// and its tool-config sibling).
-/// What: Same setup as `daily_driver_anthropic_model_marks_cache_breakpoints`
-/// but with model `"bedrock/us.anthropic.claude-sonnet-4-5"`; assert both
-/// markers are present on the `ChatRequest` the loop builds.
+/// and its tool-config sibling). A live cost-proof of #2260 as-merged-so-far
+/// showed cache_read staying 0 because nothing ever marked the growing
+/// transcript — this test pins that the last two non-system messages of a
+/// multi-turn request now carry the breakpoint too, while an OLDER
+/// non-system message (outside the rolling window) does not.
+/// What: Scripts a two-turn flow (tool call, then stop) so the second
+/// `ChatRequest` carries four messages: system, user, assistant(tool_calls),
+/// tool(result). Assert the system message and the last tool definition
+/// carry the breakpoint (unchanged #2260 coverage), AND that the assistant
+/// and tool messages (the last two non-system entries) carry it, AND that
+/// the user message (now outside the rolling window) does not.
 /// Test: this test.
 #[tokio::test]
 async fn daily_driver_bedrock_model_marks_cache_breakpoints() {
-    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("call_1", "world"),
+        stop_response("done"),
+    ]));
     let registry = registry_with_echo(false);
     let agent = make_loop(
         llm.clone(),
@@ -1436,7 +1448,7 @@ async fn daily_driver_bedrock_model_marks_cache_breakpoints() {
     agent
         .run("you are a helpful assistant", "do the thing")
         .await
-        .expect("single stop turn should complete");
+        .expect("two-turn flow should complete");
 
     let requests = llm.requests();
     let system_msg = requests[0]
@@ -1457,6 +1469,33 @@ async fn daily_driver_bedrock_model_marks_cache_breakpoints() {
         last_tool.function.cache_control,
         Some(crate::llm::CacheControl::ephemeral()),
         "last tool definition must carry the cache breakpoint for a Bedrock route"
+    );
+
+    // Second request: system, user, assistant(tool_calls), tool(result).
+    let second_request = &requests[1];
+    let non_system: Vec<&crate::llm::ChatMessage> = second_request
+        .iter()
+        .filter(|m| m.role != "system")
+        .collect();
+    assert_eq!(
+        non_system.len(),
+        3,
+        "expected user, assistant, and tool messages on the second turn"
+    );
+    assert!(
+        non_system[0].cache_control.is_none(),
+        "the oldest non-system message must NOT carry the breakpoint once it \
+         rolls outside the last-two window"
+    );
+    assert_eq!(
+        non_system[1].cache_control,
+        Some(crate::llm::CacheControl::ephemeral()),
+        "the assistant message (second-to-last) must carry the rolling history breakpoint"
+    );
+    assert_eq!(
+        non_system[2].cache_control,
+        Some(crate::llm::CacheControl::ephemeral()),
+        "the tool-result message (last) must carry the rolling history breakpoint"
     );
 }
 

--- a/crates/trusty-code/src/llm/bedrock/cache.rs
+++ b/crates/trusty-code/src/llm/bedrock/cache.rs
@@ -1,0 +1,130 @@
+//! Bedrock Converse `cachePoint` prompt-caching helpers (#2260).
+//!
+//! Why: `agent_loop::build_request` already marks the byte-stable
+//! tools+system-prompt prefix with `cache_control` (#2156) — a marker every
+//! provider's transport is free to interpret however its wire format
+//! requires. OpenRouter's `anthropic/*` passthrough serialises that marker
+//! as Anthropic's `cache_control` content-block field
+//! (`llm::message::ChatMessage::serialize`); Bedrock's Converse API has NO
+//! such field — it expresses the identical concept as a distinct
+//! `cachePoint` content block interleaved into the `system`/`tools`/
+//! `messages` arrays (`ContentBlock::CachePoint` / `SystemContentBlock::
+//! CachePoint` / `Tool::CachePoint`, all wrapping the same `CachePointBlock`
+//! struct). This module is the translation: it reads the SAME `build_request`
+//! markers `super::convert` already receives on the `ChatRequest` and emits
+//! the Bedrock-native block shape instead.
+//! What: [`cache_point_block`] builds the one `CachePointBlock` shape tcode
+//! ever sends (`type: default`, no explicit TTL). [`system_cacheable`] and
+//! [`tools_cacheable`] are the minimum-size guards: Anthropic models on
+//! Bedrock only cache a prefix at or above ~1024 tokens (the Sonnet/Opus
+//! floor; Haiku's is 2048, but tcode does not yet track per-model minimums,
+//! so the conservative Sonnet floor is applied universally) — marking a
+//! smaller prefix is not an error, but it wastes a checkpoint slot (Bedrock
+//! allows at most 4 per request) for zero benefit, so `super::convert` skips
+//! emission below the floor rather than relying on Bedrock to silently
+//! no-op it.
+//! Test: `bedrock::tests::*`.
+
+use aws_sdk_bedrockruntime::types::{CachePointBlock, CachePointType};
+
+use crate::agent_loop::estimate_tokens;
+use crate::llm::ToolDefinition;
+
+/// Minimum estimated-token size of a prefix worth a Bedrock cachePoint
+/// breakpoint (the Claude Sonnet/Opus floor; see module doc).
+pub(super) const MIN_CACHEABLE_TOKENS: usize = 1024;
+
+/// Build the one `CachePointBlock` shape tcode ever sends.
+///
+/// Why: Every breakpoint tcode emits is the same "cache everything up to
+/// here, ephemeral" marker — there is no per-call variation (no custom TTL)
+/// today, so a single constructor keeps `super::convert`'s call sites a
+/// one-liner instead of repeating the builder chain.
+/// What: Returns `CachePointBlock { r#type: Default, ttl: None }`. The
+/// builder can only fail if `r#type` is left unset, which never happens
+/// here — `expect` documents that as a genuine invariant, not a call for
+/// `?` plumbing a caller could ever meaningfully recover from.
+/// Test: `bedrock::tests::cache_point_block_is_default_type`.
+pub(super) fn cache_point_block() -> CachePointBlock {
+    CachePointBlock::builder()
+        .r#type(CachePointType::Default)
+        .build()
+        .expect("CachePointBlock::builder always sets the only required field, `r#type`")
+}
+
+/// Whether a system-prompt text is large enough to justify a cachePoint
+/// breakpoint.
+///
+/// Why: Guards [`super::convert::build_converse_messages`] against spending
+/// one of Bedrock's 4-per-request checkpoint slots on a system prompt too
+/// small for Anthropic's minimum-cacheable-prefix floor to ever produce a
+/// cache hit.
+/// What: `true` when `estimate_tokens(text) >= MIN_CACHEABLE_TOKENS`.
+/// Test: `bedrock::tests::system_cacheable_respects_floor`.
+pub(super) fn system_cacheable(text: &str) -> bool {
+    estimate_tokens(text) >= MIN_CACHEABLE_TOKENS
+}
+
+/// Whether a set of tool definitions is large enough (their combined
+/// JSON-Schema bodies) to justify a cachePoint breakpoint.
+///
+/// Why: Same floor as [`system_cacheable`], applied to the tools array —
+/// guards [`super::convert::build_tool_config`] against a wasted checkpoint
+/// on a small tool set (e.g. a single-tool test fixture).
+/// What: Serialises each `ToolDefinition.function` (name + description +
+/// parameters — the JSON Schema actually sent on the wire) to a JSON string,
+/// sums `estimate_tokens` over those strings, and compares against
+/// `MIN_CACHEABLE_TOKENS`. A serialisation failure (should be unreachable —
+/// `FunctionDefinition` is always representable as JSON) contributes zero
+/// rather than aborting the guard.
+/// Test: `bedrock::tests::tools_cacheable_respects_floor`.
+pub(super) fn tools_cacheable(tools: &[ToolDefinition]) -> bool {
+    let total: usize = tools
+        .iter()
+        .map(|t| {
+            let json = serde_json::to_string(&t.function).unwrap_or_default();
+            estimate_tokens(&json)
+        })
+        .sum();
+    total >= MIN_CACHEABLE_TOKENS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::FunctionDefinition;
+
+    #[test]
+    fn cache_point_block_is_default_type() {
+        let block = cache_point_block();
+        assert_eq!(block.r#type(), &CachePointType::Default);
+        assert!(block.ttl().is_none());
+    }
+
+    #[test]
+    fn system_cacheable_respects_floor() {
+        let small = "short prompt";
+        let large = "x".repeat(MIN_CACHEABLE_TOKENS * 4 + 100);
+        assert!(!system_cacheable(small));
+        assert!(system_cacheable(&large));
+    }
+
+    #[test]
+    fn tools_cacheable_respects_floor() {
+        let tiny_tool = ToolDefinition::function(FunctionDefinition {
+            name: "ping".into(),
+            description: None,
+            parameters: None,
+            cache_control: None,
+        });
+        assert!(!tools_cacheable(&[tiny_tool]));
+
+        let big_tool = ToolDefinition::function(FunctionDefinition {
+            name: "write_file".into(),
+            description: Some("x".repeat(MIN_CACHEABLE_TOKENS * 4 + 100)),
+            parameters: None,
+            cache_control: None,
+        });
+        assert!(tools_cacheable(&[big_tool]));
+    }
+}

--- a/crates/trusty-code/src/llm/bedrock/convert.rs
+++ b/crates/trusty-code/src/llm/bedrock/convert.rs
@@ -19,6 +19,10 @@
 //! `BedrockProvider::map_tool_choice` produces) so either input flows
 //! correctly. [`converse_output_to_chat_response`] maps the Converse
 //! response's content blocks and token usage back into `ChatResponse`.
+//! (#2260) Both [`build_converse_messages`] and [`build_tool_config`] also
+//! translate `build_request`'s `cache_control` markers into Bedrock-native
+//! `cachePoint` blocks via `super::cache` — see that module's doc for the
+//! wire-shape translation and minimum-size guard.
 //! Test: `bedrock::tests::*` (this module has no inline tests — see the
 //! module-level SLOC-cap convention already used by
 //! `trusty-review::llm::bedrock`).
@@ -38,6 +42,7 @@ use super::super::{
     AssistantMessage, ChatChoice, ChatMessage, ChatRequest, ChatResponse, FunctionCall, LlmError,
     ToolCall, ToolDefinition, UsageBlock,
 };
+use super::cache;
 
 /// Split `req.messages` into Converse's system-prompt array and the
 /// alternating user/assistant message list.
@@ -69,6 +74,15 @@ pub(super) fn build_converse_messages(
         if msg.role == "system" {
             if let Some(text) = &msg.content {
                 system_blocks.push(SystemContentBlock::Text(text.clone()));
+                // (#2260) `agent_loop::build_request` marks exactly one
+                // system-role entry (the seed system prompt) with
+                // `cache_control` when the run is cache-eligible; translate
+                // that marker into a Bedrock-native cachePoint immediately
+                // after its Text block, guarded by the minimum-size floor so
+                // a too-small prompt never wastes a checkpoint slot.
+                if msg.cache_control.is_some() && cache::system_cacheable(text) {
+                    system_blocks.push(SystemContentBlock::CachePoint(cache::cache_point_block()));
+                }
             }
             continue;
         }
@@ -299,6 +313,20 @@ pub(super) fn build_tool_config(
             .build()
             .map_err(|e| LlmError::Bedrock(format!("build ToolSpecification: {e}")))?;
         builder = builder.tools(Tool::ToolSpec(spec));
+    }
+
+    // (#2260) `agent_loop::build_request` marks the LAST tool definition's
+    // `function.cache_control` when the run is cache-eligible; translate
+    // that marker into a Bedrock-native cachePoint appended after all
+    // `ToolSpec` entries, so the entire (byte-stable) tools array caches as
+    // one unit — mirroring `mark_cache_breakpoint_on_tools`'s OpenRouter
+    // placement. Guarded by the minimum-size floor.
+    if tools
+        .last()
+        .is_some_and(|def| def.function.cache_control.is_some())
+        && cache::tools_cacheable(tools)
+    {
+        builder = builder.tools(Tool::CachePoint(cache::cache_point_block()));
     }
 
     let sdk_choice = match decision {

--- a/crates/trusty-code/src/llm/bedrock/convert.rs
+++ b/crates/trusty-code/src/llm/bedrock/convert.rs
@@ -99,6 +99,20 @@ pub(super) fn build_converse_messages(
         }
 
         append_content_blocks(msg, &mut current_blocks)?;
+
+        // (rolling-history follow-up to #2260) `agent_loop::build_request`
+        // marks the last two non-system messages with `cache_control` when
+        // the run is cache-eligible (`mark_cache_breakpoint_on_history`);
+        // translate that marker into a trailing Bedrock-native cachePoint
+        // content block for THIS message, appended after its own content so
+        // it lands inside the right (possibly same-role-merged) `Message`
+        // once `flush_message` runs. Unlike the system/tools breakpoints,
+        // no minimum-size floor is applied here — the history segments this
+        // marks are, by construction, the dominant token cost, never a
+        // too-small fixture.
+        if msg.cache_control.is_some() {
+            current_blocks.push(ContentBlock::CachePoint(cache::cache_point_block()));
+        }
     }
 
     flush_message(&mut messages, &mut current_role, &mut current_blocks)?;

--- a/crates/trusty-code/src/llm/bedrock/mod.rs
+++ b/crates/trusty-code/src/llm/bedrock/mod.rs
@@ -16,13 +16,16 @@
 //! [`convert::converse_output_to_chat_response`]. Region resolves
 //! `TRUSTY_AWS_REGION` > `AWS_REGION` > `us-east-1`; credentials come from the
 //! standard AWS credential chain (env vars, `~/.aws/credentials`, IMDS, SSO —
-//! so `AWS_PROFILE=cto` works with zero code changes). cachePoint prompt
-//! caching is DEFERRED to a follow-up (see `provider::BedrockProvider`'s
-//! module doc).
+//! so `AWS_PROFILE=cto` works with zero code changes). (#2260) When
+//! `req`'s messages/tools carry `build_request`'s cache markers,
+//! [`convert::build_converse_messages`]/[`convert::build_tool_config`] also
+//! emit Bedrock-native `cachePoint` breakpoints via `cache` — see that
+//! module's doc for the wire-shape translation and minimum-size guard.
 //! Test: `bedrock::tests::*` (region resolution, message/tool-choice/response
 //! conversion — all unit-level, no real AWS calls) plus an `#[ignore]`-gated
 //! live Converse call.
 
+mod cache;
 mod convert;
 
 use aws_config::BehaviorVersion;

--- a/crates/trusty-code/src/llm/bedrock/tests.rs
+++ b/crates/trusty-code/src/llm/bedrock/tests.rs
@@ -10,17 +10,19 @@
 use aws_sdk_bedrockruntime::operation::converse::ConverseOutput as ConverseOutputResponse;
 use aws_sdk_bedrockruntime::types::{
     ContentBlock, ConverseOutput as ConverseOutputKind, Message as SdkMessage, StopReason,
-    TokenUsage as SdkTokenUsage, ToolChoice as SdkToolChoice,
+    SystemContentBlock, TokenUsage as SdkTokenUsage, Tool as SdkTool, ToolChoice as SdkToolChoice,
 };
 use serde_json::json;
 
+use super::cache::MIN_CACHEABLE_TOKENS;
 use super::convert::{
     build_converse_messages, build_tool_config, converse_output_to_chat_response,
     document_to_json_string, json_to_document,
 };
 use super::{bedrock_model_id, resolve_bedrock_region};
 use crate::llm::{
-    ChatMessage, ChatRequest, FunctionCall, FunctionDefinition, ToolCall, ToolDefinition,
+    CacheControl, ChatMessage, ChatRequest, FunctionCall, FunctionDefinition, ToolCall,
+    ToolDefinition,
 };
 
 /// Serializes every test that mutates the process-wide region env vars —
@@ -199,6 +201,163 @@ fn build_converse_messages_maps_tool_use_arguments_to_document() {
         }
         other => panic!("expected ToolUse block, got {other:?}"),
     }
+}
+
+// ─── cachePoint (#2260) ─────────────────────────────────────────────────────
+
+/// Build a system message carrying `build_request`'s cache-eligibility
+/// marker (`cache_control: Some(...)`), exactly as
+/// `agent_loop::mark_cache_breakpoint_on_system` produces it.
+fn cached_system_message(text: &str) -> ChatMessage {
+    let mut msg = ChatMessage::system(text);
+    msg.cache_control = Some(CacheControl::ephemeral());
+    msg
+}
+
+/// A large-enough system prompt, marked cache-eligible, gets a Bedrock
+/// `cachePoint` block immediately after its `Text` block.
+///
+/// Why: This is the core #2260 wire-shape translation — without it,
+/// `supports_prompt_caching() == true` would be a lie: `agent_loop` would
+/// mark the request as cache-eligible but the Converse transport would never
+/// emit the native breakpoint that actually makes Bedrock cache it.
+/// What: Convert a request whose system message is marked and exceeds
+/// `MIN_CACHEABLE_TOKENS`; assert `system` has exactly two entries — the
+/// original `Text` followed by a `CachePoint`.
+/// Test: this test.
+#[test]
+fn build_converse_messages_emits_cache_point_after_large_cached_system() {
+    let large_system = "x".repeat(MIN_CACHEABLE_TOKENS * 4 + 100);
+    let req = minimal_request(vec![
+        cached_system_message(&large_system),
+        ChatMessage::user("hi"),
+    ]);
+    let (system, _) = build_converse_messages(&req).expect("convert");
+
+    assert_eq!(system.len(), 2, "expected Text + CachePoint");
+    assert!(matches!(system[0], SystemContentBlock::Text(_)));
+    assert!(matches!(system[1], SystemContentBlock::CachePoint(_)));
+}
+
+/// A system prompt marked cache-eligible but BELOW the minimum-cacheable
+/// size never gets a `cachePoint` (the size guard).
+///
+/// Why: Anthropic's minimum-cacheable-prefix floor means a checkpoint below
+/// it can never produce a cache hit — emitting one would waste one of
+/// Bedrock's 4-per-request checkpoint slots for zero benefit.
+/// What: Convert a request whose (short) system message is marked; assert
+/// `system` has exactly one entry (just the `Text` block).
+/// Test: this test.
+#[test]
+fn build_converse_messages_omits_cache_point_for_small_cached_system() {
+    let req = minimal_request(vec![
+        cached_system_message("short prompt"),
+        ChatMessage::user("hi"),
+    ]);
+    let (system, _) = build_converse_messages(&req).expect("convert");
+
+    assert_eq!(
+        system.len(),
+        1,
+        "a too-small cached prefix must not get a cachePoint"
+    );
+}
+
+/// A system prompt NOT marked cache-eligible never gets a `cachePoint`,
+/// regardless of size — the #2156 regression guard applied to Bedrock.
+///
+/// Why: Parity mode / a non-cache-eligible run must produce byte-identical
+/// Converse requests to pre-#2260 behaviour.
+/// What: Convert a request with a large but UNMARKED system message; assert
+/// `system` has exactly one entry.
+/// Test: this test.
+#[test]
+fn build_converse_messages_omits_cache_point_when_not_marked() {
+    let large_system = "x".repeat(MIN_CACHEABLE_TOKENS * 4 + 100);
+    let req = minimal_request(vec![
+        ChatMessage::system(large_system),
+        ChatMessage::user("hi"),
+    ]);
+    let (system, _) = build_converse_messages(&req).expect("convert");
+
+    assert_eq!(
+        system.len(),
+        1,
+        "unmarked system must never get a cachePoint"
+    );
+}
+
+/// A large-enough LAST tool definition, marked cache-eligible, gets a
+/// Bedrock `cachePoint` appended after all `ToolSpec` entries.
+///
+/// Why: Mirrors `mark_cache_breakpoint_on_tools`'s OpenRouter placement —
+/// marking only the last tool caches the entire (byte-stable) tools array
+/// as one prefix.
+/// What: Build tool config from one large tool definition with
+/// `function.cache_control` set; assert `config.tools()` has two entries —
+/// the `ToolSpec` followed by a `CachePoint`.
+/// Test: this test.
+#[test]
+fn build_tool_config_emits_cache_point_for_large_cached_last_tool() {
+    let tool = ToolDefinition::function(FunctionDefinition {
+        name: "write_file".into(),
+        description: Some("x".repeat(MIN_CACHEABLE_TOKENS * 4 + 100)),
+        parameters: None,
+        cache_control: Some(CacheControl::ephemeral()),
+    });
+    let config = build_tool_config(&[tool], None)
+        .expect("no error")
+        .expect("config present");
+
+    assert_eq!(config.tools().len(), 2, "expected ToolSpec + CachePoint");
+    assert!(matches!(
+        config.tools().last(),
+        Some(SdkTool::CachePoint(_))
+    ));
+}
+
+/// A LAST tool marked cache-eligible but whose combined schema is BELOW the
+/// minimum-cacheable size never gets a `cachePoint` (the size guard).
+///
+/// Why: Same rationale as the system-prompt guard — a checkpoint below the
+/// floor wastes a slot.
+/// What: Build tool config from one small marked tool; assert
+/// `config.tools()` has exactly one entry.
+/// Test: this test.
+#[test]
+fn build_tool_config_omits_cache_point_for_small_cached_tool() {
+    let tool = ToolDefinition::function(FunctionDefinition {
+        name: "ping".into(),
+        description: None,
+        parameters: None,
+        cache_control: Some(CacheControl::ephemeral()),
+    });
+    let config = build_tool_config(&[tool], None)
+        .expect("no error")
+        .expect("config present");
+
+    assert_eq!(
+        config.tools().len(),
+        1,
+        "a too-small cached tool set must not get a cachePoint"
+    );
+}
+
+/// Tools NOT marked cache-eligible never get a `cachePoint` — the #2156
+/// regression guard applied to Bedrock's tool config.
+///
+/// Why: `sample_tool()` (used throughout this file's existing tool-choice
+/// tests) has `cache_control: None`; this pins that the new cachePoint logic
+/// never fires for it, so every pre-#2260 assertion in this file
+/// (`config.tools().len() == 1`) stays correct.
+/// What: Build tool config from `sample_tool()`; assert one entry.
+/// Test: this test.
+#[test]
+fn build_tool_config_omits_cache_point_when_not_marked() {
+    let config = build_tool_config(&[sample_tool()], None)
+        .expect("no error")
+        .expect("config present");
+    assert_eq!(config.tools().len(), 1);
 }
 
 // ─── Tool-choice / tool-config ──────────────────────────────────────────────

--- a/crates/trusty-code/src/llm/bedrock/tests.rs
+++ b/crates/trusty-code/src/llm/bedrock/tests.rs
@@ -287,6 +287,83 @@ fn build_converse_messages_omits_cache_point_when_not_marked() {
     );
 }
 
+/// A non-system message marked cache-eligible (`cache_control: Some(...)`,
+/// exactly as `agent_loop::mark_cache_breakpoint_on_history` produces it)
+/// gets a trailing Bedrock `cachePoint` content block appended after its own
+/// content, inside the SAME `Message` — the rolling-history follow-up to
+/// #2260.
+///
+/// Why: Without this, `agent_loop`'s rolling-history marker would be a lie
+/// on the Bedrock transport: the growing transcript (the dominant token
+/// cost) would never actually get a native `cachePoint`, so cache_read would
+/// stay 0 regardless of what `build_request` marks.
+/// What: Convert a request with an unmarked user message followed by a
+/// marked assistant message; assert the assistant `Message`'s content ends
+/// with a `CachePoint` block immediately after its `Text` block, and the
+/// user `Message` (unmarked) has no such block.
+/// Test: this test.
+#[test]
+fn build_converse_messages_emits_cache_point_after_marked_history_message() {
+    let mut assistant_msg = ChatMessage::assistant("on it");
+    assistant_msg.cache_control = Some(CacheControl::ephemeral());
+    let req = minimal_request(vec![
+        ChatMessage::system("s"),
+        ChatMessage::user("do the thing"),
+        assistant_msg,
+    ]);
+    let (_, messages) = build_converse_messages(&req).expect("convert");
+
+    // user(unmarked), assistant(marked) — different roles, not merged.
+    assert_eq!(messages.len(), 2);
+    assert_eq!(
+        messages[0].content().len(),
+        1,
+        "unmarked user message must not get a cachePoint"
+    );
+    assert!(matches!(&messages[0].content()[0], ContentBlock::Text(_)));
+
+    assert_eq!(
+        messages[1].content().len(),
+        2,
+        "expected Text + CachePoint on the marked assistant message"
+    );
+    assert!(matches!(&messages[1].content()[0], ContentBlock::Text(_)));
+    assert!(matches!(
+        &messages[1].content()[1],
+        ContentBlock::CachePoint(_)
+    ));
+}
+
+/// A non-system message WITHOUT `cache_control` set never gets a
+/// `cachePoint`, regardless of role or content — the regression guard for
+/// the rolling-history follow-up to #2260.
+///
+/// Why: A run outside the cache-eligible gate (Parity mode, or a
+/// provider/model that hasn't verified the passthrough) must produce
+/// byte-identical Converse requests to pre-rolling-history behaviour.
+/// What: Convert a request with ordinary (unmarked) user/assistant/tool
+/// messages; assert none of the resulting Converse messages contain a
+/// `CachePoint` block.
+/// Test: this test.
+#[test]
+fn build_converse_messages_omits_cache_point_for_unmarked_history_messages() {
+    let req = minimal_request(vec![
+        ChatMessage::system("s"),
+        ChatMessage::user("do two things"),
+        ChatMessage::assistant("on it"),
+    ]);
+    let (_, messages) = build_converse_messages(&req).expect("convert");
+
+    for message in &messages {
+        for block in message.content() {
+            assert!(
+                !matches!(block, ContentBlock::CachePoint(_)),
+                "no message should carry a cachePoint when unmarked"
+            );
+        }
+    }
+}
+
 /// A large-enough LAST tool definition, marked cache-eligible, gets a
 /// Bedrock `cachePoint` appended after all `ToolSpec` entries.
 ///

--- a/crates/trusty-code/src/provider/bedrock.rs
+++ b/crates/trusty-code/src/provider/bedrock.rs
@@ -21,8 +21,13 @@
 //! and `extract_usage`'s delegation; `crate::llm::bedrock::tests` covers the
 //! actual Converse wire conversion this provider's mapping feeds.
 //!
-//! DEFERRED to a follow-up: cachePoint prompt-caching
-//! (`supports_prompt_caching` stays `false` — see its doc below).
+//! (#2260) `supports_prompt_caching` now returns `true`: the Converse
+//! transport (`crate::llm::bedrock::cache`) translates the SAME
+//! `agent_loop::build_request` cache markers (`ChatMessage.cache_control`,
+//! `FunctionDefinition.cache_control`) that OpenRouter's `cache_control`
+//! passthrough consumes into Bedrock's native `cachePoint` content blocks —
+//! see that module's doc for the wire-shape translation and the minimum-size
+//! guard.
 
 use serde_json::{Value, json};
 
@@ -107,15 +112,13 @@ impl Provider for BedrockProvider {
     }
 
     fn supports_prompt_caching(&self) -> bool {
-        // DEFERRED to a follow-up (#1021 phase 2): Bedrock's Converse API
-        // expresses prompt caching via its own `cachePoint` block shape, not
-        // Anthropic's `cache_control` marker (#2156) — a different wire
-        // format this phase does not implement. `false` until that follow-up
-        // lands so `agent_loop::build_request` never emits a marker Bedrock
-        // can't interpret (harmless if it did — the field would just be
-        // ignored — but sending a marker for an unimplemented feature is
-        // misleading).
-        false
+        // (#2260) Bedrock's Converse API supports prompt caching via its own
+        // `cachePoint` block shape (not Anthropic's `cache_control` marker
+        // used by the OpenRouter passthrough, #2156) — `crate::llm::bedrock`
+        // now implements that translation, so a Bedrock route is eligible
+        // for `agent_loop::build_request`'s cache markers exactly like an
+        // `anthropic/*` OpenRouter slug is.
+        true
     }
 
     fn wants_detailed_usage(&self) -> bool {
@@ -153,18 +156,17 @@ mod tests {
         assert!(BedrockProvider::new().supports_native_tools());
     }
 
-    /// Bedrock does NOT report Anthropic-style prompt-caching support yet
-    /// (#2156, deferred to a follow-up).
+    /// Bedrock reports prompt-caching support (#2260).
     ///
-    /// Why: Bedrock's Converse API caching uses a different wire shape
-    /// (`cachePoint` blocks); until that follow-up lands, `build_request`
-    /// must never emit an Anthropic `cache_control` marker for a Bedrock
-    /// route.
-    /// What: Assert `supports_prompt_caching()` is `false`.
+    /// Why: `crate::llm::bedrock::cache` translates `build_request`'s cache
+    /// markers into Bedrock's native `cachePoint` blocks, so
+    /// `agent_loop::prompt_cache_enabled` must now treat a Bedrock route the
+    /// same as an `anthropic/*` OpenRouter slug.
+    /// What: Assert `supports_prompt_caching()` is `true`.
     /// Test: this test.
     #[test]
-    fn bedrock_does_not_support_prompt_caching() {
-        assert!(!BedrockProvider::new().supports_prompt_caching());
+    fn bedrock_supports_prompt_caching() {
+        assert!(BedrockProvider::new().supports_prompt_caching());
     }
 
     /// Bedrock does NOT request OpenRouter-style detailed usage accounting.


### PR DESCRIPTION
## Summary

Two highest-leverage cost fixes for trusty-code (tcode), discovered via an evidence-based Bedrock bake-off teardown. Landed in one PR because they compound.

### Lever 1 (#2260, highest) — Bedrock Converse `cachePoint` prompt-caching

**Measured problem:** the Bedrock path emitted no prompt-cache breakpoints and re-sent full history as fresh input every turn. L1 bake-off: tcode 452,901 fresh input tokens / $1.67 vs claude-code $0.72 / opencode $0.75 (both read ~847K-1.11M tokens from cache instead of re-billing fresh). Counterfactual with caching → ~$0.68 (~2.5x cut).

**Fix:**
- `provider::BedrockProvider::supports_prompt_caching()` now returns `true` (was `false`, deferred from #1021).
- New `llm::bedrock::cache` module translates the **same** `agent_loop::build_request` cache markers (`ChatMessage.cache_control`, `FunctionDefinition.cache_control`) that OpenRouter's `anthropic/*` `cache_control` passthrough (#2156/#2212) already sets — instead of adding a second marker channel — into Bedrock's native `cachePoint` content blocks.
- `llm::bedrock::convert::build_converse_messages` appends a `SystemContentBlock::CachePoint` right after the (marked) system prompt's `Text` block; `build_tool_config` appends a `Tool::CachePoint` after all `ToolSpec` entries when the last tool is marked — mirroring exactly where the OpenRouter path places its two breakpoints (tools, then system).
- Both are guarded by a 1024-estimated-token minimum-cacheable-prefix floor (the Claude Sonnet/Opus minimum) so a too-small prefix never wastes one of Bedrock's 4-per-request checkpoint slots.
- No change to the full-history-resend behavior itself — only the cache breakpoints were added, so the resent prefix now bills as `cache_read` instead of fresh input.

### Lever 2 (#2261) — compaction estimator now counts `tool_calls`

**Problem:** `agent_loop::compaction::estimate_total_tokens` summed only `ChatMessage.content`, ignoring `tool_calls[].function.arguments` — where `write_file`/`edit` argument bodies (the actual file contents) live. A tool-call-only assistant turn has `content: None` entirely, so a real segment measured at 23,541 tokens never crossed the default 6,000-token `token_threshold` and compacted zero times.

**Fix:** `estimate_total_tokens` now also sums `estimate_tokens` over each tool call's `function.arguments` JSON string, using the same chars/4 heuristic already used for `content`.

## Files changed

- `crates/trusty-code/src/provider/bedrock.rs` — `supports_prompt_caching() → true`
- `crates/trusty-code/src/llm/bedrock/cache.rs` (new) — cachePoint construction + minimum-size guards
- `crates/trusty-code/src/llm/bedrock/convert.rs` — emits `cachePoint` blocks in system/tools
- `crates/trusty-code/src/llm/bedrock/mod.rs` — registers the new submodule, doc update
- `crates/trusty-code/src/llm/bedrock/tests.rs` — cachePoint emission/guard tests
- `crates/trusty-code/src/agent_loop/mod.rs` — re-exports `estimate_tokens` for reuse by `llm::bedrock::cache`; doc updates
- `crates/trusty-code/src/agent_loop/tests.rs` — Bedrock-route cache-marker test (agent_loop level)
- `crates/trusty-code/src/agent_loop/compaction.rs` — tool_calls-aware `estimate_total_tokens` + tests

Closes #2260
Closes #2261

References #2242, #2212 (the OpenRouter `cache_control` pattern this mirrors).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-code` → 696 passed, 0 failed, 3 ignored — includes new tests: `build_converse_messages_emits_cache_point_after_large_cached_system`, `build_converse_messages_omits_cache_point_for_small_cached_system`, `build_converse_messages_omits_cache_point_when_not_marked`, `build_tool_config_emits_cache_point_for_large_cached_last_tool`, `build_tool_config_omits_cache_point_for_small_cached_tool`, `build_tool_config_omits_cache_point_when_not_marked`, `daily_driver_bedrock_model_marks_cache_breakpoints`, `estimate_total_tokens_sums_tool_call_arguments`, `should_compact_triggers_on_large_tool_call_arguments`
- [x] `cargo test --workspace` → all green except the pre-existing, known-unrelated `trusty-mpm` TUI failure (`formatters::banner::two_panel::tests::right_col_no_inner_border`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → zero warnings
- [x] `cargo fmt --check` → clean
- [x] `bash scripts/check_line_cap.sh` → 0 violations
- [ ] Live Bedrock smoke test to confirm the measured cost drop (follow-up, not part of this PR — no live AWS calls were made here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)