### PR TITLE
fix(trusty-code): cap engineer re-delegation, stop mislabeling partial work as run_failure

### DIFF
--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -266,6 +266,15 @@ impl AgentLoop {
             self.maybe_compact_transcript(transcript);
 
             let request = self.build_request(transcript, &schemas);
+            // TODO(#2265 follow-up): add in-loop retry-with-backoff for
+            // AgentLoopError::Llm before aborting to re-delegation — a single
+            // retryable Bedrock/transport hiccup here currently propagates
+            // straight out via `?` and aborts this whole engineer turn
+            // immediately, forcing a full re-delegation cycle (now bounded by
+            // `run_task::redelegation::MAX_REDELEGATIONS`, #2265) rather than
+            // a cheap in-loop retry of just this one `chat` call. Deferred
+            // (optional fix #5) to keep #2265's required scope (fixes 1-4)
+            // tightly bounded.
             let response = self.llm.chat(&request).await?;
 
             accrue_usage(perf, &self.config.model, &response);

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -15,6 +15,7 @@
 
 mod diff;
 mod recorder;
+mod redelegation;
 mod report;
 
 #[cfg(test)]
@@ -27,7 +28,7 @@ use std::time::Duration;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::agent_loop::{AgentLoop, AgentLoopConfig};
+use crate::agent_loop::{AgentLoop, AgentLoopConfig, AgentLoopError};
 use crate::agents::AgentConfig;
 use crate::llm::LlmClientTrait;
 use crate::project_context::load_project_context;
@@ -40,6 +41,7 @@ use crate::tools::{
 };
 
 pub use recorder::{RecordingLlmClient, SharedTranscript, TurnRecord};
+pub use redelegation::{MAX_REDELEGATIONS, RedelegationCapSignal};
 pub use report::{ExitCode, RunReport, aggregate_usage_per_role};
 
 /// Default bash timeout for the engineer's tools, in seconds.
@@ -119,6 +121,13 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
     // (`build_engineer_runner`, via `with_timeout_secs`).
     let deadline_secs = resolve_deadline_secs(params.deadline_secs);
 
+    // (#2265) The re-delegation cap signal is shared between the engineer
+    // runner's retry decorator (`RedelegatingRunner`, wired inside
+    // `build_engineer_runner`) and `assemble_report` below, so a cap-hit run
+    // gets a clean terminal report regardless of what the PM's own loop
+    // subsequently does.
+    let redelegation_signal = RedelegationCapSignal::new();
+
     // Build the engineer runner, scoped to the project working dir, sharing the
     // transcript (engineer turns are tagged "python-engineer").
     let engineer_runner = build_engineer_runner(
@@ -127,6 +136,7 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
         project_context.clone(),
         Arc::clone(&transcript),
         deadline_secs,
+        redelegation_signal.clone(),
     );
 
     // The PM's tool registry: the delegate tool (the PM orchestrates; the
@@ -188,9 +198,12 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
         &transcript,
         &pm_model,
         &engineer_model,
-        before,
-        after,
-        pm_result,
+        RunOutcome {
+            before,
+            after,
+            pm_result,
+        },
+        &redelegation_signal,
     )
 }
 
@@ -202,9 +215,19 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
 /// result through the per-run model-override seam (`apply_engineer_model_override`).
 /// `deadline_secs` (#2207) is the SAME resolved wall-clock budget applied to the
 /// delegating PM's own loop, so a raised deadline covers the whole run, not just
-/// the PM's half of it.
+/// the PM's half of it. (#2265) The outermost layer is
+/// `redelegation::RedelegatingRunner`, which internally retries a failed
+/// attempt (reuse-hint-augmented, capped at `redelegation::MAX_REDELEGATIONS`)
+/// entirely within one `AgentRunner::run`/`run_with_context` call — this is
+/// the chosen "decouple retries from PM turns" design for fix #3: every
+/// retry happens inside a SINGLE `delegate_to_agent` tool dispatch, so it
+/// never consumes any of the PM's own `AgentLoopConfig::max_turns` budget
+/// (left at its crate default of 8 — raising it was the alternative design,
+/// rejected here because the cap in fix #1 is a cleaner, purpose-built ceiling
+/// than a bigger, still-somewhat-arbitrary PM turn budget would be).
 /// What: Returns an `Arc<dyn AgentRunner>` the `DelegateToAgentTool` dispatches
 /// to. The engineer's own LLM turns are recorded under the "python-engineer" role.
+/// `redelegation_signal` is shared with `assemble_report` via the caller.
 /// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`.
 fn build_engineer_runner(
     llm: Arc<dyn LlmClientTrait>,
@@ -212,6 +235,7 @@ fn build_engineer_runner(
     project_context: Option<String>,
     transcript: SharedTranscript,
     deadline_secs: u64,
+    redelegation_signal: RedelegationCapSignal,
 ) -> Arc<dyn AgentRunner> {
     let engineer_llm: Arc<dyn LlmClientTrait> = Arc::new(RecordingLlmClient::new(
         llm,
@@ -228,7 +252,12 @@ fn build_engineer_runner(
     if let Some(ctx) = project_context {
         runner = runner.with_project_context(ctx);
     }
-    apply_engineer_model_override(Arc::new(runner), params)
+    let pinned = apply_engineer_model_override(Arc::new(runner), params);
+    Arc::new(redelegation::RedelegatingRunner::new(
+        pinned,
+        redelegation_signal,
+        params.project.clone(),
+    ))
 }
 
 /// Builds the engineer's project-scoped tool registry for each delegation.
@@ -406,6 +435,22 @@ fn config_error_report(
     }
 }
 
+/// The run's raw outcome: before/after working-tree snapshots plus the PM
+/// loop's own `Result`.
+///
+/// Why: These three values are always produced and consumed together; bundling
+/// them keeps `assemble_report`'s argument count under clippy's
+/// `too_many_arguments` limit (#2265 added an 8th argument,
+/// `redelegation_signal`, that pushed the plain-argument version over it)
+/// without losing any of the fields or their names.
+/// What: Plain data holder, no behaviour.
+/// Test: Exercised through every `assemble_report` test.
+struct RunOutcome {
+    before: diff::Snapshot,
+    after: diff::Snapshot,
+    pm_result: Result<AgentOutput, AgentLoopError>,
+}
+
 /// Assemble the final report from the run's outcome.
 ///
 /// Why: Centralises the mapping from (PM loop result, before/after snapshots) to a
@@ -413,45 +458,110 @@ fn config_error_report(
 /// branches never drift.
 /// What: On a PM-loop error → `DeadlineExceeded` when the error is specifically
 /// `AgentLoopError::Timeout` (#2207 — distinct from a genuine failure so a
-/// caller can tell "timed out" from "errored"), else `RunFailure` (with
-/// whatever transcript accrued). On success → compute the diff; empty diff →
-/// `NoChanges`, else `Success`. Usage and cost are aggregated from the
-/// transcript and priced PER ROLE — `pm_model` for `"pm"` turns,
-/// `engineer_model` for the delegated engineer's — per the #1475 bug 1 fix
-/// (`aggregate_usage_per_role`), not blended under one model. #2206: this
-/// aggregation now runs on the error path too, so a `run_failure` or
-/// `deadline_exceeded` report still carries the real usage/cost of every turn
-/// that DID complete before the error/deadline, rather than the zeroed
-/// placeholder the pre-#2206 code returned unconditionally on this branch.
-/// Test: `run_task::tests::*` (success, no-change, failure, and deadline paths).
+/// caller can tell "timed out" from "errored"). (#2265 fix #4) Otherwise, when
+/// the error is `AgentLoopError::TurnCapExceeded` OR `redelegation_signal`
+/// reports the re-delegation cap (fix #1) was hit, the diff is computed
+/// (filesystem-based, independent of which turn/attempt produced it) and — if
+/// it is non-empty, i.e. a deliverable actually exists on disk — the outcome
+/// is `ExitCode::Partial`, NOT `RunFailure`; trusty-code cannot generically
+/// verify correctness, so this gates purely on "work was produced", leaving
+/// the downstream bake-off harness to score correctness itself. Every other
+/// PM-loop error (a hard `Llm`/`Cancelled` failure, or ANY error with an empty
+/// diff — including a cap/turn-cap hit that produced nothing) still maps to
+/// `RunFailure`, preserving that path for genuine no-output failures. On
+/// success → compute the diff; empty diff → `NoChanges`, else `Success`.
+/// Usage and cost are aggregated from the transcript and priced PER ROLE —
+/// `pm_model` for `"pm"` turns, `engineer_model` for the delegated engineer's
+/// — per the #1475 bug 1 fix (`aggregate_usage_per_role`), not blended under
+/// one model. #2206: this aggregation now runs on every error path too, so a
+/// `run_failure`, `partial`, or `deadline_exceeded` report still carries the
+/// real usage/cost of every turn that DID complete, rather than a zeroed
+/// placeholder.
+/// Test: `run_task::tests::*` (success, no-change, failure, deadline, and
+/// #2265 partial/cap-reached paths).
 fn assemble_report(
     params: &RunTaskParams,
     transcript: &SharedTranscript,
     pm_model: &str,
     engineer_model: &str,
-    before: diff::Snapshot,
-    after: diff::Snapshot,
-    pm_result: Result<AgentOutput, crate::agent_loop::AgentLoopError>,
+    outcome: RunOutcome,
+    redelegation_signal: &RedelegationCapSignal,
 ) -> RunReport {
+    let RunOutcome {
+        before,
+        after,
+        pm_result,
+    } = outcome;
     let turns = drain_transcript(transcript);
 
-    // A PM-loop error is a runtime failure (or, #2207, a deadline); the
-    // transcript still reflects whatever turns ran before the error. The PM's
-    // `AgentOutput` content is not needed for the report — the transcript and
-    // diff are the authoritative artifacts. #2206: usage/cost are aggregated
-    // from those completed turns here too, not zeroed.
+    // A PM-loop error is a runtime failure (or, #2207, a deadline; or, #2265,
+    // a turn-cap/re-delegation-cap hit that still produced a deliverable);
+    // the transcript still reflects whatever turns ran before the error. The
+    // PM's `AgentOutput` content is not needed for the report — the
+    // transcript and diff are the authoritative artifacts. #2206: usage/cost
+    // are aggregated from those completed turns here too, not zeroed.
     if let Err(e) = pm_result {
         let (usage, cost) = aggregate_usage_per_role(&turns, pm_model, engineer_model);
-        let is_deadline = matches!(e, crate::agent_loop::AgentLoopError::Timeout { .. });
-        let exit = if is_deadline {
-            ExitCode::DeadlineExceeded
+
+        if matches!(e, AgentLoopError::Timeout { .. }) {
+            return RunReport {
+                agent: params.agent.clone(),
+                task: format!("{} [deadline exceeded: {e}]", params.task),
+                diff: String::new(),
+                transcript: turns,
+                usage,
+                cost_usd: Some(cost),
+                exit: ExitCode::DeadlineExceeded,
+            };
+        }
+
+        // #2265 fix #4: a turn-cap or re-delegation-cap terminal condition
+        // must not be blindly reported as `run_failure` when a deliverable
+        // already exists on disk — the diff is filesystem-based, so it is
+        // authoritative regardless of which attempt produced it.
+        let cap_reached = redelegation_signal.is_cap_reached();
+        let is_turn_cap = matches!(e, AgentLoopError::TurnCapExceeded { .. });
+        let rendered_diff = diff::diff_snapshots(&before, &after);
+        let has_deliverable = !rendered_diff.trim().is_empty();
+
+        if (cap_reached || is_turn_cap) && has_deliverable {
+            let label = if cap_reached {
+                format!(
+                    "partial: re-delegation limit reached after {} attempts; partial work \
+                     preserved at {}",
+                    redelegation_signal.attempts(),
+                    params.project.display()
+                )
+            } else {
+                "partial: PM turn cap exceeded but a deliverable was produced".to_string()
+            };
+            return RunReport {
+                agent: params.agent.clone(),
+                task: format!("{} [{label}: {e}]", params.task),
+                diff: rendered_diff,
+                transcript: turns,
+                usage,
+                cost_usd: Some(cost),
+                exit: ExitCode::Partial,
+            };
+        }
+
+        // Genuine failure: no deliverable exists, or the error is neither a
+        // turn cap nor a re-delegation-cap hit (e.g. a hard `Llm`/`Cancelled`
+        // failure). This path is intentionally left mapped to `RunFailure` —
+        // "Keep genuine no-output failures mapped to RunFailure" per #2265.
+        // When the cap WAS reached but produced nothing reusable, the label
+        // still names that (so an operator/log reader is not left guessing
+        // whether this was an opaque crash or an exhausted, reuse-aware
+        // retry budget), even though the exit code itself is unchanged.
+        let label = if cap_reached {
+            format!(
+                "run failure (re-delegation limit reached after {} attempts, no deliverable \
+                 produced)",
+                redelegation_signal.attempts()
+            )
         } else {
-            ExitCode::RunFailure
-        };
-        let label = if is_deadline {
-            "deadline exceeded"
-        } else {
-            "run failure"
+            "run failure".to_string()
         };
         return RunReport {
             agent: params.agent.clone(),
@@ -460,7 +570,7 @@ fn assemble_report(
             transcript: turns,
             usage,
             cost_usd: Some(cost),
-            exit,
+            exit: ExitCode::RunFailure,
         };
     }
 

--- a/crates/trusty-code/src/run_task/redelegation.rs
+++ b/crates/trusty-code/src/run_task/redelegation.rs
@@ -1,0 +1,495 @@
+//! Re-delegation cap: bounds total engineer delegation attempts per run (#2265).
+//!
+//! Why: (#2265, completes #2233) Before this module, the ONLY ceiling on how
+//! many times the PM could re-delegate a failing engineer task was the PM's
+//! OWN `AgentLoopConfig::default().max_turns` (8) — because #2233 raised the
+//! delegated ENGINEER's turn budget to 40 without raising or decoupling the
+//! PM's, each blind PM-driven retry could burn up to 40 engineer turns while
+//! the PM itself had only 8 total attempts to notice, react, and finish. That
+//! asymmetry produced non-deterministic failure storms (session turn counts
+//! blowing up from ~40 to ~111) that hit the PM's turn cap and were reported
+//! as an opaque `run_failure`, even when a fully working solution already sat
+//! on disk from an earlier attempt. This module makes an explicit,
+//! independent cap ([`MAX_REDELEGATIONS`]) the thing that governs retry
+//! count, and — critically — enforces it INSIDE a single `delegate_to_agent`
+//! tool dispatch via [`RedelegatingRunner`], so retries never consume
+//! additional PM turns at all (the "decouple" design chosen for fix #3: see
+//! `run_task::mod`'s `build_engineer_runner` docs for why this was preferred
+//! over raising the PM's `max_turns`).
+//! What: [`RedelegationCapSignal`] is a small `Arc`-shared attempt
+//! counter/flag, constructed once per `execute_run_task` call and threaded
+//! into both [`RedelegatingRunner`] (which increments it and retries) and
+//! `assemble_report` (which reads `is_cap_reached()` to produce a clean
+//! terminal report instead of riding on a coincidental PM-turn-cap failure).
+//! [`RedelegatingRunner`] wraps the engineer `AgentRunner`: on a failure whose
+//! [`crate::tools::delegate::redelegation_hint`] returns `Some` (partial work
+//! may exist — turn cap, timeout, cancellation, or a retryable LLM/transport
+//! error, per that function's #2265-updated docs), it retries the SAME
+//! engineer agent with the task text augmented by the reuse hint, up to
+//! [`MAX_REDELEGATIONS`] total attempts (shared across every
+//! `delegate_to_agent` call in the run, not reset per call) before giving up
+//! with a clean, quoted "re-delegation limit reached" error. A non-retryable
+//! failure (unknown agent, bad config) propagates immediately without
+//! consuming the cap.
+//! Test: `redelegating_runner_retries_on_llm_error_then_succeeds`,
+//! `redelegating_runner_stops_at_cap_and_marks_signal`,
+//! `redelegating_runner_propagates_non_retryable_errors_immediately`,
+//! `cap_reached_message_names_the_project_path`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::tools::delegate::redelegation_hint;
+use crate::tools::{AgentOutput, AgentRunner, RunContext};
+
+/// Maximum total engineer delegation attempts for a single `execute_run_task`
+/// run, shared across every `delegate_to_agent` call the PM makes (#2265).
+///
+/// Why: This — not the PM's own turn budget — is the ceiling on retry count
+/// going forward. 3 total attempts (1 initial + up to 2 reuse-aware retries)
+/// is deliberately modest: each retry now costs up to 40 engineer turns
+/// (#2233's raised default), so an unbounded or generous cap here would
+/// reintroduce the same runaway-cost failure mode this fix closes.
+/// What: Checked BEFORE every engineer invocation in
+/// [`RedelegatingRunner::run_with_retries`]; once the shared attempt count
+/// exceeds this value, no further engineer invocation happens at all.
+/// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+pub const MAX_REDELEGATIONS: u32 = 3;
+
+/// Shared, run-scoped state behind [`RedelegationCapSignal`].
+///
+/// Why: Kept as a private inner type so the public handle stays a cheap,
+/// `Clone`-able `Arc` wrapper — see [`RedelegationCapSignal`]'s own docs.
+/// What: `attempts` counts every engineer invocation attempted across the
+/// whole run; `cap_reached` latches `true` the first time an attempt would
+/// exceed [`MAX_REDELEGATIONS`].
+/// Test: Exercised indirectly through `RedelegationCapSignal`'s own tests.
+#[derive(Debug, Default)]
+struct RedelegationCapState {
+    attempts: AtomicU32,
+    cap_reached: AtomicBool,
+}
+
+/// Shared signal tracking total re-delegation attempts across one run (#2265).
+///
+/// Why: [`RedelegatingRunner`] and `run_task::assemble_report` are different
+/// call sites that both need to observe the SAME attempt count / cap state —
+/// the runner to enforce the cap, the report assembler to recognise a
+/// cap-triggered terminal state even when the PM's own loop error doesn't
+/// literally say so (e.g. the PM's NEXT turn separately exhausts its own
+/// budget after seeing the cap-reached tool error). An `Arc`-wrapped atomic
+/// pair is the simplest thing that is `Send + Sync` and cheap to clone into
+/// both places.
+/// What: `new()` starts at zero attempts, cap not reached. `is_cap_reached()`
+/// and `attempts()` are read-only accessors for `assemble_report`;
+/// `record_attempt`/`mark_cap_reached` are private, called only by
+/// [`RedelegatingRunner`].
+/// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+#[derive(Debug, Clone, Default)]
+pub struct RedelegationCapSignal(Arc<RedelegationCapState>);
+
+impl RedelegationCapSignal {
+    /// Build a fresh signal with zero recorded attempts.
+    ///
+    /// Why: Each `execute_run_task` call needs its OWN signal — attempts must
+    /// never leak across independent runs.
+    /// What: `Self::default()`.
+    /// Test: `redelegating_runner_retries_on_llm_error_then_succeeds`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record one more attempt and return the new total.
+    ///
+    /// Why: The runner must check the POST-increment total against the cap
+    /// atomically with recording it, so two attempts can never both observe
+    /// "one under the cap" and both proceed.
+    /// What: `fetch_add(1) + 1`.
+    /// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+    fn record_attempt(&self) -> u32 {
+        self.0.attempts.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Latch the cap-reached flag.
+    ///
+    /// Why: Called exactly once, the moment an attempt would exceed
+    /// [`MAX_REDELEGATIONS`] — this is the signal `assemble_report` checks.
+    /// What: Stores `true`.
+    /// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+    fn mark_cap_reached(&self) {
+        self.0.cap_reached.store(true, Ordering::SeqCst);
+    }
+
+    /// Whether the re-delegation cap was hit during this run.
+    ///
+    /// Why: `assemble_report` uses this to distinguish a cap-triggered
+    /// terminal state from an unrelated PM-loop error.
+    /// What: Reads the latched flag.
+    /// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+    pub fn is_cap_reached(&self) -> bool {
+        self.0.cap_reached.load(Ordering::SeqCst)
+    }
+
+    /// Total engineer attempts recorded so far.
+    ///
+    /// Why: Surfaced in the clean terminal report's message so an operator
+    /// knows exactly how many tries were made.
+    /// What: Reads the atomic counter.
+    /// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+    pub fn attempts(&self) -> u32 {
+        self.0.attempts.load(Ordering::SeqCst)
+    }
+}
+
+/// `AgentRunner` decorator that internally retries a failed engineer
+/// delegation, reuse-hint-augmented, up to [`MAX_REDELEGATIONS`] times before
+/// giving up (#2265).
+///
+/// Why: This is the concrete "decouple retries from PM turns" implementation
+/// chosen for fix #3 — every retry this decorator performs happens INSIDE one
+/// `AgentRunner::run`/`run_with_context` call, i.e. inside one
+/// `delegate_to_agent` tool dispatch from the PM's perspective, so the PM's
+/// own `AgentLoopConfig::max_turns` is never consumed by them. Wrapping at the
+/// `AgentRunner` seam (rather than inside `DelegateToAgentTool` itself) keeps
+/// the tool free of retry policy and makes the retry/cap behaviour unit
+/// testable in isolation with a scripted inner runner.
+/// What: Holds the inner (real) engineer runner, a shared
+/// [`RedelegationCapSignal`], and the project path (quoted in the
+/// cap-reached message per the required wording, "…partial work preserved at
+/// <path>"). On each attempt: record it against the shared signal; if the
+/// new total exceeds [`MAX_REDELEGATIONS`], stop WITHOUT invoking the inner
+/// runner, latch the cap, and return a clean, descriptive error. Otherwise
+/// invoke the inner runner; on success, return it; on a failure whose
+/// [`redelegation_hint`] is `Some`, retry with the task text augmented by
+/// that hint; on a failure whose hint is `None` (no partial work to reuse),
+/// propagate immediately without consuming further cap budget.
+/// Test: `redelegating_runner_retries_on_llm_error_then_succeeds`,
+/// `redelegating_runner_stops_at_cap_and_marks_signal`,
+/// `redelegating_runner_propagates_non_retryable_errors_immediately`.
+pub struct RedelegatingRunner {
+    inner: Arc<dyn AgentRunner>,
+    signal: RedelegationCapSignal,
+    project: PathBuf,
+}
+
+impl RedelegatingRunner {
+    /// Construct from the inner engineer runner, a shared cap signal, and the
+    /// project root (used only for the cap-reached message).
+    ///
+    /// Why: Constructor injection keeps this testable with a scripted inner
+    /// runner, exactly like the crate's other `AgentRunner` decorators
+    /// (`ModelPinningRunner`).
+    /// What: Stores all three fields verbatim.
+    /// Test: Every test in this module constructs one directly.
+    pub fn new(
+        inner: Arc<dyn AgentRunner>,
+        signal: RedelegationCapSignal,
+        project: PathBuf,
+    ) -> Self {
+        Self {
+            inner,
+            signal,
+            project,
+        }
+    }
+
+    /// Drive the retry loop for one logical delegation.
+    ///
+    /// Why: Shared by both `AgentRunner` methods so `run` and
+    /// `run_with_context` can never drift on retry policy.
+    /// What: See the type-level docs for the full attempt/retry/cap
+    /// contract. Returns the first successful `AgentOutput`, or — once the
+    /// shared attempt count would exceed [`MAX_REDELEGATIONS`] — a clean
+    /// error naming the attempt count and the project path, or — on a
+    /// non-retryable failure — that failure verbatim.
+    /// Test: `redelegating_runner_retries_on_llm_error_then_succeeds`,
+    /// `redelegating_runner_stops_at_cap_and_marks_signal`,
+    /// `redelegating_runner_propagates_non_retryable_errors_immediately`,
+    /// `cap_reached_message_names_the_project_path`.
+    async fn run_with_retries(
+        &self,
+        agent_name: &str,
+        task: &str,
+        ctx: &RunContext,
+    ) -> Result<AgentOutput> {
+        let mut current_task = task.to_string();
+        loop {
+            let attempt = self.signal.record_attempt();
+            if attempt > MAX_REDELEGATIONS {
+                self.signal.mark_cap_reached();
+                return Err(anyhow::anyhow!(
+                    "re-delegation limit reached after {MAX_REDELEGATIONS} attempts; \
+                     partial work preserved at {}",
+                    self.project.display()
+                ));
+            }
+
+            match self
+                .inner
+                .run_with_context(agent_name, &current_task, ctx)
+                .await
+            {
+                Ok(out) => return Ok(out),
+                Err(e) => {
+                    let Some(hint) = redelegation_hint(&e) else {
+                        // No partial work to reuse — this is a hard failure
+                        // (unknown agent, bad config), not a re-delegation
+                        // candidate. Propagate immediately.
+                        return Err(e);
+                    };
+                    current_task = format!("{task}{hint}");
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl AgentRunner for RedelegatingRunner {
+    /// See [`Self::run_with_retries`]; forwards with a default `RunContext`.
+    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
+        self.run_with_retries(agent_name, task, &RunContext::default())
+            .await
+    }
+
+    /// See [`Self::run_with_retries`]; forwards the caller's `RunContext`
+    /// unchanged to every attempt.
+    async fn run_with_context(
+        &self,
+        agent_name: &str,
+        task: &str,
+        ctx: &RunContext,
+    ) -> Result<AgentOutput> {
+        self.run_with_retries(agent_name, task, ctx).await
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use anyhow::anyhow;
+
+    use super::*;
+    use crate::agent_loop::AgentLoopError;
+    use crate::llm::LlmError;
+    use crate::runner::RunnerError;
+
+    /// Scripted inner runner: replays a fixed queue of `Result`s in order,
+    /// recording the task text it was called with each time.
+    ///
+    /// Why: Deterministic, offline substitute for the real engineer runner so
+    /// these tests exercise ONLY the retry/cap policy in `RedelegatingRunner`.
+    /// What: `outcomes` is drained front-to-back via a `Mutex<VecDeque<..>>`;
+    /// `calls` records every `(agent_name, task)` pair seen.
+    /// Test: Used by every test below.
+    struct ScriptedInner {
+        outcomes: Mutex<std::collections::VecDeque<Result<AgentOutput>>>,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl ScriptedInner {
+        fn new(outcomes: Vec<Result<AgentOutput>>) -> Self {
+            Self {
+                outcomes: Mutex::new(outcomes.into_iter().collect()),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AgentRunner for ScriptedInner {
+        async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .push(task.to_string());
+            self.outcomes
+                .lock()
+                .expect("outcomes lock")
+                .pop_front()
+                .unwrap_or_else(|| Err(anyhow!("ScriptedInner exhausted for {agent_name}")))
+        }
+    }
+
+    fn llm_error() -> anyhow::Error {
+        anyhow::Error::from(RunnerError::Loop {
+            name: "python-engineer".to_string(),
+            source: AgentLoopError::Llm(LlmError::ApiError {
+                status: 500,
+                body: "bedrock hiccup".to_string(),
+            }),
+        })
+    }
+
+    fn unknown_agent_error() -> anyhow::Error {
+        anyhow::Error::from(RunnerError::UnknownAgent {
+            name: "python-engineer".to_string(),
+            dir: PathBuf::from("/agents"),
+        })
+    }
+
+    /// A retryable `AgentLoopError::Llm` failure is retried automatically,
+    /// with the reuse hint appended, and a later success is returned.
+    ///
+    /// Why: This is the core #2265 fix #3 behaviour — retries happen inside
+    /// ONE call, invisible to the PM's own turn budget.
+    /// What: Script [Err(llm), Ok(success)]; call `run`; assert the returned
+    /// output is the success, the inner runner was called twice, and the
+    /// SECOND call's task text carries the reuse hint.
+    /// Test: this test.
+    #[tokio::test]
+    async fn redelegating_runner_retries_on_llm_error_then_succeeds() {
+        let inner = Arc::new(ScriptedInner::new(vec![
+            Err(llm_error()),
+            Ok(AgentOutput::from_content("done")),
+        ]));
+        let signal = RedelegationCapSignal::new();
+        let runner = RedelegatingRunner::new(
+            Arc::clone(&inner) as Arc<dyn AgentRunner>,
+            signal.clone(),
+            PathBuf::from("/tmp/project"),
+        );
+
+        let out = runner
+            .run("python-engineer", "build the package")
+            .await
+            .expect("second attempt must succeed");
+        assert_eq!(out.content, "done");
+
+        let calls = inner.calls.lock().expect("calls lock");
+        assert_eq!(
+            calls.len(),
+            2,
+            "must retry exactly once after the LLM error"
+        );
+        assert_eq!(calls[0], "build the package");
+        assert!(
+            calls[1].contains("READ and CONTINUE"),
+            "the retried task must carry the reuse hint, got: {}",
+            calls[1]
+        );
+        assert!(
+            !signal.is_cap_reached(),
+            "cap must not be reached on a successful retry"
+        );
+        assert_eq!(signal.attempts(), 2);
+    }
+
+    /// Once attempts exceed `MAX_REDELEGATIONS`, the runner stops calling the
+    /// inner runner, marks the cap reached, and returns a clean error naming
+    /// the attempt count.
+    ///
+    /// Why: This is fix #1 — the explicit ceiling that replaces the PM's own
+    /// turn budget as the retry governor.
+    /// What: Script `MAX_REDELEGATIONS` failing `Llm` outcomes (all
+    /// retryable); assert the final error mentions "re-delegation limit
+    /// reached" and the exact attempt count, the inner runner was called
+    /// exactly `MAX_REDELEGATIONS` times (not `MAX_REDELEGATIONS + 1` — the
+    /// cap check happens BEFORE the attempt that would exceed it), and the
+    /// signal reports `is_cap_reached() == true`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn redelegating_runner_stops_at_cap_and_marks_signal() {
+        let outcomes = (0..MAX_REDELEGATIONS).map(|_| Err(llm_error())).collect();
+        let inner = Arc::new(ScriptedInner::new(outcomes));
+        let signal = RedelegationCapSignal::new();
+        let runner = RedelegatingRunner::new(
+            Arc::clone(&inner) as Arc<dyn AgentRunner>,
+            signal.clone(),
+            PathBuf::from("/tmp/project"),
+        );
+
+        let err = runner
+            .run("python-engineer", "build the package")
+            .await
+            .expect_err("must fail once the cap is exceeded");
+
+        assert!(
+            err.to_string().contains("re-delegation limit reached"),
+            "error must name the cap condition, got: {err}"
+        );
+        assert!(
+            err.to_string().contains(&MAX_REDELEGATIONS.to_string()),
+            "error must name the attempt count, got: {err}"
+        );
+
+        let calls = inner.calls.lock().expect("calls lock");
+        assert_eq!(
+            calls.len(),
+            MAX_REDELEGATIONS as usize,
+            "the inner runner must be called exactly MAX_REDELEGATIONS times, not more"
+        );
+        assert!(signal.is_cap_reached(), "signal must latch cap-reached");
+        assert_eq!(signal.attempts(), MAX_REDELEGATIONS + 1);
+    }
+
+    /// A non-retryable failure (no partial work to reuse) propagates
+    /// immediately, without consuming further cap budget on retries that
+    /// would never help.
+    ///
+    /// Why: Guards the negative case — the retry loop must not blindly retry
+    /// EVERY failure, only ones `redelegation_hint` says are worth reusing.
+    /// What: Script a single `UnknownAgent` error; assert it propagates
+    /// verbatim after exactly one attempt, and the cap is NOT marked reached.
+    /// Test: this test.
+    #[tokio::test]
+    async fn redelegating_runner_propagates_non_retryable_errors_immediately() {
+        let inner = Arc::new(ScriptedInner::new(vec![Err(unknown_agent_error())]));
+        let signal = RedelegationCapSignal::new();
+        let runner = RedelegatingRunner::new(
+            Arc::clone(&inner) as Arc<dyn AgentRunner>,
+            signal.clone(),
+            PathBuf::from("/tmp/project"),
+        );
+
+        let err = runner
+            .run("python-engineer", "build the package")
+            .await
+            .expect_err("unknown-agent failures must propagate");
+
+        assert!(err.to_string().contains("unknown agent"));
+        let calls = inner.calls.lock().expect("calls lock");
+        assert_eq!(calls.len(), 1, "must not retry a non-retryable failure");
+        assert!(
+            !signal.is_cap_reached(),
+            "cap must not be marked reached for a non-retryable failure"
+        );
+    }
+
+    /// The cap-reached error message names the exact project path passed to
+    /// the constructor.
+    ///
+    /// Why: The required message shape is "re-delegation limit reached after
+    /// N attempts; partial work preserved at <path>" — pin the `<path>` half.
+    /// What: Force the cap with `MAX_REDELEGATIONS` failures against a
+    /// distinctive project path; assert it appears in the error text.
+    /// Test: this test.
+    #[tokio::test]
+    async fn cap_reached_message_names_the_project_path() {
+        let outcomes = (0..MAX_REDELEGATIONS).map(|_| Err(llm_error())).collect();
+        let inner = Arc::new(ScriptedInner::new(outcomes));
+        let signal = RedelegationCapSignal::new();
+        let runner = RedelegatingRunner::new(
+            Arc::clone(&inner) as Arc<dyn AgentRunner>,
+            signal,
+            PathBuf::from("/very/distinctive/project/path"),
+        );
+
+        let err = runner
+            .run("python-engineer", "build the package")
+            .await
+            .expect_err("must fail once the cap is exceeded");
+
+        assert!(
+            err.to_string().contains("/very/distinctive/project/path"),
+            "error must name the project path, got: {err}"
+        );
+    }
+}

--- a/crates/trusty-code/src/run_task/report.rs
+++ b/crates/trusty-code/src/run_task/report.rs
@@ -22,12 +22,15 @@ use crate::run_task::recorder::TurnRecord;
 /// Why: A caller (CI, the PM smoke-test, a wrapper script) needs to distinguish
 /// outcomes without parsing output. The ladder separates a clean success, a
 /// successful run that changed nothing, a configuration error (bad agent, bad
-/// project), a runtime failure (the loop or LLM errored), and (#2207) the
+/// project), a runtime failure (the loop or LLM errored), (#2207) the
 /// wall-clock deadline firing before the PM reached `finish_task` — a run that
 /// may have made real, useful progress and must not be conflated with a
 /// genuine `RunFailure` (the bug that blocked the M3 bake-off L1 pilot: a
 /// deadline hit at turn 13 on an otherwise fully-passing solution reported the
-/// same `run_failure` a real crash would).
+/// same `run_failure` a real crash would) — and (#2265) a PM turn-cap or
+/// re-delegation-cap hit that STILL produced a deliverable, the same class of
+/// bug as #2207's but triggered by exhausting turns/re-delegation attempts
+/// rather than wall-clock time.
 /// What: `repr(i32)` so the values are stable and documented; `Success = 0`.
 /// Test: `run_task::tests::exit_codes_are_distinct`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -38,7 +41,7 @@ pub enum ExitCode {
     /// Configuration error: missing/invalid agent, bad project path, missing key. `2`.
     ConfigError = 2,
     /// Runtime failure: the agent loop or LLM call errored (excludes the
-    /// deadline — see `DeadlineExceeded`). `3`.
+    /// deadline and partial paths — see `DeadlineExceeded` and `Partial`). `3`.
     RunFailure = 3,
     /// The run completed but changed nothing (empty diff). `4`.
     NoChanges = 4,
@@ -47,6 +50,14 @@ pub enum ExitCode {
     /// the M3 bake-off runner) can tell "timed out, possibly close to done"
     /// from "genuinely errored". `5`.
     DeadlineExceeded = 5,
+    /// The PM's own turn cap, or the (#2265) engineer re-delegation cap, was
+    /// exhausted, but a non-empty diff shows a deliverable was actually
+    /// produced. Distinct from `RunFailure` so a caller does not discard a
+    /// working, on-disk solution as an opaque crash purely because the PM ran
+    /// out of turns/retries absorbing engineer failures — trusty-code cannot
+    /// generically verify correctness, so this status only claims "work was
+    /// produced", leaving scoring to the downstream harness. `6`.
+    Partial = 6,
 }
 
 impl ExitCode {
@@ -184,7 +195,7 @@ impl RunReport {
     ///
     /// Why: Both output forms label the outcome with the same vocabulary.
     /// What: Returns `"success"`, `"no_changes"`, `"config_error"`,
-    /// `"run_failure"`, or (#2207) `"deadline_exceeded"`.
+    /// `"run_failure"`, (#2207) `"deadline_exceeded"`, or (#2265) `"partial"`.
     /// Test: `run_task::tests::report_renders_json`,
     /// `run_task::tests::exit_code_reflects_deadline_exceeded_distinct_from_run_failure`.
     fn status_str(&self) -> &'static str {
@@ -194,6 +205,7 @@ impl RunReport {
             ExitCode::ConfigError => "config_error",
             ExitCode::RunFailure => "run_failure",
             ExitCode::DeadlineExceeded => "deadline_exceeded",
+            ExitCode::Partial => "partial",
         }
     }
 }
@@ -287,7 +299,7 @@ mod tests {
     /// Exit codes are distinct and stable.
     ///
     /// Why: Scripts branch on these; collisions would be silent breakage.
-    /// What: Assert the five codes are 0/2/3/4/5 and pairwise distinct.
+    /// What: Assert the six codes are 0/2/3/4/5/6 and pairwise distinct.
     /// Test: this test.
     #[test]
     fn exit_codes_are_distinct() {
@@ -296,6 +308,24 @@ mod tests {
         assert_eq!(ExitCode::RunFailure.code(), 3);
         assert_eq!(ExitCode::NoChanges.code(), 4);
         assert_eq!(ExitCode::DeadlineExceeded.code(), 5);
+        assert_eq!(ExitCode::Partial.code(), 6);
+    }
+
+    /// The `"partial"` status string renders for `ExitCode::Partial` (#2265).
+    ///
+    /// Why: Downstream callers (the bake-off harness) branch on this exact
+    /// string; it must render distinctly from `"run_failure"`.
+    /// What: Render a report with `exit: ExitCode::Partial`; assert the JSON
+    /// `status` field and the human summary line both say `"partial"`.
+    /// Test: this test.
+    #[test]
+    fn partial_status_renders_distinctly_from_run_failure() {
+        let report = sample_report(ExitCode::Partial, "+++ added: x.py\n");
+        let rendered = report.render_json();
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
+        assert_eq!(parsed["status"], "partial");
+        assert_eq!(parsed["exit_code"], 6);
+        assert!(report.render_human().contains("status=partial"));
     }
 
     /// JSON render carries status, diff, transcript, usage, and cost.

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -12,6 +12,7 @@
 //! dir; tests assert on the returned `RunReport`.
 //! Test: this module is itself the test surface.
 
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -19,8 +20,10 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
-use super::{ExitCode, RunTaskParams, execute_run_task};
+use super::{ExitCode, RedelegationCapSignal, RunTaskParams, execute_run_task};
+use crate::agent_loop::AgentLoopError;
 use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
+use crate::tools::AgentOutput;
 
 // ── Scripted offline LLM ───────────────────────────────────────────────────────
 
@@ -743,4 +746,174 @@ async fn two_runs_route_engineer_to_distinct_slugs() {
             "scripted client must have seen {slug}"
         );
     }
+}
+
+// ── #2265: re-delegation cap, reuse-aware Llm hint, partial status ─────────────
+
+/// Repeated `AgentLoopError::Llm` failures from the engineer trigger the
+/// re-delegation cap (fix #1) — NOT the PM's own turn cap — producing a
+/// report that names the cap explicitly, using only a couple of PM turns
+/// regardless of how many internal engineer retries occurred (fix #3,
+/// decoupled design).
+///
+/// Why: This is the exact regression #2265 closes: before this fix, each
+/// PM-driven retry could burn up to 40 engineer turns (#2233) while the PM
+/// itself had only 8 attempts to notice and react, so a recurring retryable
+/// Bedrock/transport error blew up session turn counts (~40 to ~111) and hit
+/// the PM's OWN turn cap, reported as an opaque `run_failure`. Now the cap in
+/// `run_task::redelegation` governs retry count entirely inside ONE
+/// `delegate_to_agent` dispatch.
+/// What: Script ONLY the PM's initial `delegate_to_agent` call — every
+/// subsequent `chat` call (every engineer retry attempt, and the PM's own
+/// follow-up turn) exhausts the scripted queue and returns
+/// `LlmError::MissingConfig`, i.e. a retryable `AgentLoopError::Llm` per
+/// fix #2. No file is ever written, so the report is a genuine `RunFailure`
+/// (no deliverable) — but assert its `task` text names "re-delegation limit
+/// reached" (the fix #1 label), not a bare/opaque failure, and that at most 2
+/// PM-role transcript turns were recorded — proof the engineer's internal
+/// retries never touched the PM's own turn budget.
+/// Test: this test.
+#[tokio::test]
+async fn repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[delegate_response("do work")]));
+
+    let report = execute_run_task(params(&agents, &project, None), llm).await;
+
+    assert_eq!(
+        report.exit,
+        ExitCode::RunFailure,
+        "no deliverable was ever produced, so this must stay a genuine failure"
+    );
+    assert!(
+        report.task.contains("re-delegation limit reached"),
+        "the report must name the re-delegation cap (fix #1), not an opaque \
+         failure, got: {}",
+        report.task
+    );
+
+    let pm_turns = report.transcript.iter().filter(|t| t.role == "pm").count();
+    assert!(
+        pm_turns <= 2,
+        "the PM must need only a couple of turns regardless of how many internal \
+         engineer retries occurred — decoupling proof (fix #3), got {pm_turns} PM turns"
+    );
+}
+
+/// `assemble_report` maps a PM-loop `TurnCapExceeded` error to the new
+/// `Partial` status (fix #4) — NOT `RunFailure` — when a non-empty diff shows
+/// a deliverable was actually produced.
+///
+/// Why: This is fix #4's core contract: trusty-code cannot generically verify
+/// correctness, so a turn-cap hit must not discard a working, on-disk
+/// solution as an opaque crash purely because the PM ran out of turns.
+/// What: Calls the crate-private `assemble_report` directly with a
+/// `TurnCapExceeded` `pm_result` and a before/after `Snapshot::Files` pair
+/// that differ (one new file). Assert `exit == ExitCode::Partial`, the
+/// rendered diff is non-empty, and the task label mentions the turn cap.
+/// Test: this test.
+#[test]
+fn assemble_report_maps_turn_cap_exceeded_with_deliverable_to_partial() {
+    let params = RunTaskParams {
+        agent: "pm".into(),
+        task: "write hello.py".into(),
+        project: PathBuf::from("/tmp/does-not-matter"),
+        agents_dir: PathBuf::from("/tmp/does-not-matter-agents"),
+        engineer_model: None,
+        deadline_secs: None,
+    };
+    let transcript: super::SharedTranscript = Arc::new(Mutex::new(Vec::new()));
+
+    let before = super::diff::Snapshot::Files(std::collections::BTreeMap::new());
+    let mut after_map = std::collections::BTreeMap::new();
+    after_map.insert("hello.py".to_string(), "print('hi')".to_string());
+    let after = super::diff::Snapshot::Files(after_map);
+
+    let pm_result: Result<AgentOutput, AgentLoopError> = Err(AgentLoopError::TurnCapExceeded {
+        max_turns: 8,
+        partial: Box::new(AgentOutput::from_content("partial pm output")),
+    });
+
+    let signal = RedelegationCapSignal::new();
+    let report = super::assemble_report(
+        &params,
+        &transcript,
+        "openai/gpt-4o-mini",
+        "openai/gpt-4o-mini",
+        super::RunOutcome {
+            before,
+            after,
+            pm_result,
+        },
+        &signal,
+    );
+
+    assert_eq!(
+        report.exit,
+        ExitCode::Partial,
+        "a TurnCapExceeded PM error with a real deliverable must map to Partial, \
+         not RunFailure (fix #4)"
+    );
+    assert!(
+        report.diff.contains("hello.py"),
+        "the deliverable's diff must still be rendered, got: {}",
+        report.diff
+    );
+    assert!(
+        report.task.contains("turn cap"),
+        "the label must explain the turn-cap condition, got: {}",
+        report.task
+    );
+}
+
+/// The mirror negative case: a `TurnCapExceeded` PM error with an EMPTY diff
+/// (no deliverable at all) stays `RunFailure` — the gate is purely "was work
+/// produced", per fix #4's requirement to not weaken the genuine-failure path.
+///
+/// Why: Guards against over-broadly reclassifying every turn-cap hit as
+/// `Partial` regardless of whether anything was actually produced.
+/// What: Same as the positive test, but before == after (no change). Assert
+/// `exit == ExitCode::RunFailure`.
+/// Test: this test.
+#[test]
+fn assemble_report_keeps_turn_cap_exceeded_with_no_deliverable_as_run_failure() {
+    let params = RunTaskParams {
+        agent: "pm".into(),
+        task: "write hello.py".into(),
+        project: PathBuf::from("/tmp/does-not-matter"),
+        agents_dir: PathBuf::from("/tmp/does-not-matter-agents"),
+        engineer_model: None,
+        deadline_secs: None,
+    };
+    let transcript: super::SharedTranscript = Arc::new(Mutex::new(Vec::new()));
+
+    let before = super::diff::Snapshot::Files(std::collections::BTreeMap::new());
+    let after = super::diff::Snapshot::Files(std::collections::BTreeMap::new());
+
+    let pm_result: Result<AgentOutput, AgentLoopError> = Err(AgentLoopError::TurnCapExceeded {
+        max_turns: 8,
+        partial: Box::new(AgentOutput::from_content("partial pm output")),
+    });
+
+    let signal = RedelegationCapSignal::new();
+    let report = super::assemble_report(
+        &params,
+        &transcript,
+        "openai/gpt-4o-mini",
+        "openai/gpt-4o-mini",
+        super::RunOutcome {
+            before,
+            after,
+            pm_result,
+        },
+        &signal,
+    );
+
+    assert_eq!(
+        report.exit,
+        ExitCode::RunFailure,
+        "a TurnCapExceeded PM error with NO deliverable must stay RunFailure (fix #4)"
+    );
 }

--- a/crates/trusty-code/src/tools/delegate.rs
+++ b/crates/trusty-code/src/tools/delegate.rs
@@ -19,6 +19,11 @@
 //! listing available agents. On a runner failure caused by the sub-agent's own
 //! loop aborting with partial work still on disk, the returned `ToolResult`
 //! error appends a fixed reuse/continue directive (`redelegation_hint`).
+//! (#2265) `redelegation_hint` is also `pub(crate)` so
+//! `run_task::redelegation::RedelegatingRunner` can reuse the SAME hint logic
+//! to decide, entirely inside one `delegate_to_agent` dispatch, whether a
+//! failed engineer attempt is worth automatically retrying — see that
+//! module's docs for the retry/cap mechanics.
 //! Test: `unknown_agent_returns_helpful_error` builds a tool pointed at a tempdir
 //! containing `engineer.toml` only, calls `execute({"agent_name":"ghost",...})`,
 //! and asserts the error names the unknown agent and lists `engineer`.
@@ -34,10 +39,10 @@ use crate::agent_loop::AgentLoopError;
 use crate::runner::RunnerError;
 use crate::tools::traits::{AgentRunner, ToolExecutor, ToolResult};
 
-/// Detect whether an `AgentRunner` failure means the sub-agent's OWN loop
-/// aborted with partial work already on disk (turn cap, timeout, or
-/// cancellation), as opposed to a hard failure (unknown agent, bad config,
-/// LLM/transport error) that leaves nothing to reuse.
+/// Detect whether an `AgentRunner` failure means the sub-agent's OWN attempt
+/// may have left partial work already on disk (turn cap, timeout,
+/// cancellation, or a retryable LLM/transport hiccup), as opposed to a hard
+/// failure (unknown agent, bad config) that leaves nothing to reuse.
 ///
 /// Why: (bake-off L1 diagnosis) The PM only sees this failure as opaque error
 /// text; without a structured signal, its free-text re-delegation brief has no
@@ -46,35 +51,45 @@ use crate::tools::traits::{AgentRunner, ToolExecutor, ToolResult};
 /// Surfacing a fixed directive automatically — every time this specific
 /// failure shape occurs — makes "read existing files, then continue" the
 /// default recovery instead of something the PM must remember to ask for.
+/// (#2265) `AgentLoopError::Llm` — a recoverable Bedrock/transport error that
+/// aborts the engineer's sub-loop mid-session — is the DOMINANT failure mode
+/// observed in the bake-off transcripts, yet #2233 left it out of this match,
+/// so the reuse hint never fired for the most common case and every retry
+/// re-read PROBLEM.md from zero. It now gets the same hint: tool calls the
+/// engineer already dispatched before the failing `chat` call (e.g.
+/// `write_file`) already landed on disk even though `AgentLoopError::Llm`
+/// itself carries no `partial: Box<AgentOutput>` (unlike the three
+/// budget-abort variants) — there is real, on-disk work to reuse even though
+/// there is no partial transcript snapshot to point to.
 /// What: Downcasts `err` to [`RunnerError`] and matches `RunnerError::Loop`
-/// whose source is `AgentLoopError::TurnCapExceeded`, `Timeout`, or
-/// `Cancelled` (every abort variant that carries a partial `AgentOutput`,
-/// per that enum's own docs). Returns `None` for `UnknownAgent`, `ConfigLoad`,
-/// and `AgentLoopError::Llm` — those failure modes have no partial work to
-/// reuse.
+/// whose source is `AgentLoopError::TurnCapExceeded`, `Timeout`, `Cancelled`,
+/// or (#2265) `Llm`. Returns `None` only for `UnknownAgent`/`ConfigLoad` —
+/// failures that never reached a sub-agent loop at all, so there is nothing
+/// on disk to reuse.
 /// Test: `redelegation_hint_present_on_turn_cap_exceeded`,
 /// `redelegation_hint_present_on_timeout`,
 /// `redelegation_hint_present_on_cancelled`,
-/// `redelegation_hint_absent_on_unknown_agent`,
-/// `redelegation_hint_absent_on_llm_error`.
-fn redelegation_hint(err: &anyhow::Error) -> Option<&'static str> {
+/// `redelegation_hint_present_on_llm_error`,
+/// `redelegation_hint_absent_on_unknown_agent`.
+pub(crate) fn redelegation_hint(err: &anyhow::Error) -> Option<&'static str> {
     let RunnerError::Loop { source, .. } = err.downcast_ref::<RunnerError>()? else {
         return None;
     };
     match source {
         AgentLoopError::TurnCapExceeded { .. }
         | AgentLoopError::Timeout { .. }
-        | AgentLoopError::Cancelled { .. } => Some(
-            "\n\nNOTE for re-delegation: the sub-agent stopped because it ran out of turns, \
-             time, or was cancelled — NOT because the task failed outright. It has likely \
-             already written real, partial progress to disk. Before delegating this task again: \
+        | AgentLoopError::Cancelled { .. }
+        | AgentLoopError::Llm(_) => Some(
+            "\n\nNOTE for re-delegation: the sub-agent's previous attempt did not reach a \
+             normal finish — it ran out of turns or time, was cancelled, or hit a \
+             transient LLM/transport error — NOT a task failure. It has likely already \
+             written real, partial progress to disk. Before delegating this task again: \
              (1) inspect the project's current files to see what the sub-agent already \
              produced, (2) instruct the next sub-agent to READ and CONTINUE/BUILD ON that \
              existing work rather than rewriting it from scratch, and (3) consider a narrower \
              follow-up task (or a higher turn budget) so it can finish what is already started \
              instead of starting over.",
         ),
-        AgentLoopError::Llm(_) => None,
     }
 }
 
@@ -245,7 +260,7 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::json;
 
-    use super::DelegateToAgentTool;
+    use super::{DelegateToAgentTool, redelegation_hint};
     use crate::agent_loop::AgentLoopError;
     use crate::llm::LlmError;
     use crate::runner::RunnerError;
@@ -615,16 +630,20 @@ mod tests {
         );
     }
 
-    /// A plain LLM/transport failure (no turn/time budget involved) gets NO
-    /// reuse directive.
+    /// A plain LLM/transport failure gets the SAME reuse/continue directive
+    /// (#2265 fix #2: this is the dominant bake-off failure mode, previously
+    /// excluded from the hint).
     ///
-    /// Why: Guards the negative case for the `Loop` variant itself — only the
-    /// three partial-output abort arms should trigger the hint.
+    /// Why: A recoverable Bedrock/transport error aborting the engineer's
+    /// sub-loop is the dominant failure mode observed in the bake-off
+    /// transcripts; the reuse hint must fire here too so re-delegation checks
+    /// for and continues from files already on disk instead of restarting
+    /// exploration from scratch.
     /// What: `FailingRunner` returns `RunnerError::Loop` wrapping
-    /// `AgentLoopError::Llm`.
+    /// `AgentLoopError::Llm`; assert the hint is present.
     /// Test: this test.
     #[tokio::test]
-    async fn redelegation_hint_absent_on_llm_error() {
+    async fn redelegation_hint_present_on_llm_error() {
         let runner = Arc::new(FailingRunner {
             make_err: || {
                 anyhow::Error::from(RunnerError::Loop {
@@ -643,6 +662,35 @@ mod tests {
             .await;
 
         assert!(result.is_error());
-        assert!(!result.content().contains("READ and CONTINUE"));
+        assert!(
+            result.content().contains("READ and CONTINUE"),
+            "an LLM/transport error must ALSO carry the reuse directive (#2265), got: {}",
+            result.content()
+        );
+    }
+
+    /// `redelegation_hint` itself (unit-level, not through the tool) returns
+    /// `Some` for `AgentLoopError::Llm` (#2265 fix #2).
+    ///
+    /// Why: The tool-level test above proves the end-to-end wiring; this test
+    /// pins the specific function contract directly, matching the task's
+    /// required "redelegation_hint(AgentLoopError::Llm) now returns
+    /// Some(<reuse hint>)" assertion.
+    /// What: Builds a `RunnerError::Loop` wrapping `AgentLoopError::Llm`,
+    /// calls `redelegation_hint` directly, asserts `Some`.
+    /// Test: this test.
+    #[test]
+    fn redelegation_hint_fn_returns_some_for_llm_error() {
+        let err = anyhow::Error::from(RunnerError::Loop {
+            name: "engineer".to_string(),
+            source: AgentLoopError::Llm(LlmError::ApiError {
+                status: 503,
+                body: "bedrock throttled".to_string(),
+            }),
+        });
+        assert!(
+            redelegation_hint(&err).is_some(),
+            "redelegation_hint must return Some for AgentLoopError::Llm (#2265)"
+        );
     }
 }


### PR DESCRIPTION
## Root cause (from bake-off transcripts; completes the #2233 partial fix)

- A recurring retryable Bedrock transport error (`AgentLoopError::Llm`) aborts the delegated engineer sub-loop mid-session.
- `crates/trusty-code/src/runner/in_process.rs:121` — #2233 raised the ENGINEER's `max_turns` from 8 to 40.
- `crates/trusty-code/src/agent_loop/mod.rs:121` — the PM's OWN `AgentLoopConfig::default().max_turns` stayed at 8, used unchanged by `run_task/mod.rs`'s PM loop. Each blind retry could burn up to 40 engineer turns while the PM itself only had 8 attempts before its own budget exhausted — this is the asymmetry that produced the failure storms (session turn counts blowing up from ~40 to ~111).
- `crates/trusty-code/src/tools/delegate.rs:77` (pre-fix) — `redelegation_hint()` returned `None` for `AgentLoopError::Llm`, so #2233's "reuse partial work" hint never fired for the dominant failure mode; every retry re-read PROBLEM.md and restarted exploration from zero.
- There was no cap on total re-delegations anywhere; hitting the PM's 8-turn budget produced an opaque `run_failure` (exit code 3) via `assemble_report`, even when a fully working solution already sat on disk from an earlier engineer attempt.

## The four required fixes

**Fix #1 — cap total re-delegations.** New module `crates/trusty-code/src/run_task/redelegation.rs`: `RedelegatingRunner` wraps the engineer `AgentRunner` and internally retries a failed attempt (reuse-hint augmented) up to `MAX_REDELEGATIONS = 3` total attempts, all inside ONE `delegate_to_agent` tool dispatch. A shared `RedelegationCapSignal` (`Arc`-wrapped atomic counter + latch) is threaded into `run_task::assemble_report` so a cap-hit run produces a clean terminal report ("re-delegation limit reached after N attempts; partial work preserved at `<path>`") instead of an opaque PM-turn-cap failure.

**Fix #2 — extend `redelegation_hint()`.** `crates/trusty-code/src/tools/delegate.rs:60-79` (now ~60-90): the match arm now includes `AgentLoopError::Llm(_)` alongside `TurnCapExceeded`/`Timeout`/`Cancelled`, returning the SAME reuse-existing-files hint. This is the dominant bake-off failure mode, and it was previously excluded entirely.

**Fix #3 — turn-budget asymmetry.** **Design chosen: decouple** (not raise `max_turns`). Every re-delegation retry happens inside `RedelegatingRunner::run_with_retries` (`crates/trusty-code/src/run_task/redelegation.rs`), i.e. inside a SINGLE `delegate_to_agent` tool dispatch from the PM's perspective — it never consumes the PM's own `AgentLoopConfig::max_turns` budget, which is left at its crate default of 8. Rejected the "raise PM max_turns" alternative because the cap from fix #1 is a purpose-built, auditable ceiling, whereas a bigger PM turn budget would just be a bigger, still-somewhat-arbitrary number that reintroduces the same class of asymmetry at a different threshold.

**Fix #4 — don't mislabel completed work as failure.** New `ExitCode::Partial` variant (`crates/trusty-code/src/run_task/report.rs`, value `6`, status string `"partial"`). In `assemble_report` (`crates/trusty-code/src/run_task/mod.rs`), when the PM-loop error is `AgentLoopError::TurnCapExceeded` OR `RedelegationCapSignal::is_cap_reached()`, AND the before/after filesystem diff is non-empty, the report now returns `ExitCode::Partial` instead of `ExitCode::RunFailure`. Gated purely on "was a deliverable produced" (non-empty diff) — trusty-code cannot generically run an arbitrary project's test suite, so it leaves correctness scoring to the downstream bake-off harness. Genuine no-output failures (empty diff, or a hard `Llm`/`Cancelled` error unrelated to the cap) still map to `RunFailure` unchanged.

## Fix #5 (optional) — deferred

In-loop retry-with-backoff for `AgentLoopError::Llm` before aborting to a full re-delegation was **deferred** to keep scope bounded. A `TODO(#2265 follow-up)` comment marks the spot: `crates/trusty-code/src/agent_loop/mod.rs`, immediately above the `self.llm.chat(&request).await?` call inside `run_inner`'s turn loop.

## Tests added

- `run_task::tests::repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap` — repeated `AgentLoopError::Llm` failures trigger the re-delegation cap (report names "re-delegation limit reached"), and only ≤2 PM-role transcript turns are ever recorded, proving the engineer's internal retries never touch the PM's own turn budget.
- `run_task::tests::assemble_report_maps_turn_cap_exceeded_with_deliverable_to_partial` — a `TurnCapExceeded` PM error plus a non-empty diff yields `ExitCode::Partial`, not `RunFailure`.
- `run_task::tests::assemble_report_keeps_turn_cap_exceeded_with_no_deliverable_as_run_failure` — the negative case: no diff stays `RunFailure`.
- `tools::delegate::tests::redelegation_hint_present_on_llm_error` and `redelegation_hint_fn_returns_some_for_llm_error` — `redelegation_hint(AgentLoopError::Llm)` now returns `Some(..)`.
- `run_task::redelegation::tests::redelegating_runner_retries_on_llm_error_then_succeeds`, `redelegating_runner_stops_at_cap_and_marks_signal`, `redelegating_runner_propagates_non_retryable_errors_immediately`, `cap_reached_message_names_the_project_path` — unit coverage of the retry/cap decorator in isolation.
- `report::tests::exit_codes_are_distinct` (updated) and `partial_status_renders_distinctly_from_run_failure` (new) — the new exit code/status render correctly.

Existing #2233 tests (turn-budget tests, reuse-aware re-delegation tests) all still pass unchanged.

## Quality gate (all raw, all green)

- `cargo build --workspace` — clean.
- `cargo test -p trusty-code` — 693 passed, 0 failed, 3 ignored (plus all integration-test binaries green).
- `cargo test --workspace` — 123/123 test-result groups green, 0 failures anywhere (including the previously-flagged `trusty-mpm two_panel::tests::right_col_no_inner_border`, which passed cleanly this run).
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0, zero errors.
- `cargo fmt --check` — clean.
- `bash scripts/check_line_cap.sh` — `line-cap: 14 allowlisted, 0 violations — OK.`

Closes #2265
Completes the prior partial fix in #2233