### PR TITLE
feat(trusty-mpm): capture tmux window id at session pause, reattach on resume

### DIFF
--- a/crates/trusty-common/src/catchup/session_finder.rs
+++ b/crates/trusty-common/src/catchup/session_finder.rs
@@ -38,6 +38,14 @@ pub enum PausedSession {
         in_progress: Option<String>,
         /// Content of the `## Next Steps` section.
         next_steps: Option<String>,
+        /// Why: lets resume re-align to the originating tmux window instead of
+        /// leaving the operator on whatever window they happen to be on.
+        /// What: the `session_name:window_index:window_id` string captured at
+        /// pause time from `tmux display-message` and stored in the
+        /// `## Tmux Window` section; `None` when the snapshot predates the
+        /// feature or was created outside tmux.
+        /// Test: `parse_extracts_tmux_window`, `parse_missing_tmux_window_is_none`.
+        tmux_window: Option<String>,
     },
     /// A session paused by the claude-mpm Python tool (JSON format).
     ///
@@ -144,10 +152,16 @@ fn render_session(out: &mut String, session: &PausedSession) {
             git_context,
             in_progress,
             next_steps,
+            tmux_window,
         } => {
             out.push_str("**Format:** trusty-mpm (native)\n");
             if let Some(ts) = paused_at {
                 out.push_str(&format!("**Paused At:** {ts}\n"));
+            }
+            if let Some(win) = tmux_window
+                && !win.is_empty()
+            {
+                out.push_str(&format!("**Tmux Window:** {win}\n"));
             }
             out.push_str(&format!("**File:** {}\n\n", path.display()));
             if !summary.is_empty() {
@@ -243,6 +257,8 @@ fn parse_trusty_mpm_session(path: &Path) -> anyhow::Result<PausedSession> {
     let git_context = extract_section(&content, "Git Context");
     let in_progress = extract_section(&content, "In Progress");
     let next_steps = extract_section(&content, "Next Steps");
+    // `None` for snapshots without the section keeps older files back-compat.
+    let tmux_window = extract_section(&content, "Tmux Window");
 
     // Try to parse a UTC timestamp from the filename: session-YYYYMMDD-HHMMSS.md
     let paused_at = path
@@ -258,6 +274,7 @@ fn parse_trusty_mpm_session(path: &Path) -> anyhow::Result<PausedSession> {
         git_context,
         in_progress,
         next_steps,
+        tmux_window,
     })
 }
 
@@ -433,6 +450,75 @@ mod tests {
         assert!(
             !output.contains("conversation"),
             "conversation must NOT appear in rendered output"
+        );
+    }
+
+    #[test]
+    fn parse_extracts_tmux_window() {
+        let tmp = TempDir::new().unwrap();
+        let p = write_file(
+            tmp.path(),
+            "session-20260627-100000.md",
+            "## Summary\nWork.\n\n## Tmux Window\nmain:2:@7\n\n## Git Context\nbranch: main",
+        );
+        let session = parse_trusty_mpm_session(&p).unwrap();
+        match session {
+            PausedSession::TrustyMpm { tmux_window, .. } => {
+                assert_eq!(tmux_window.as_deref(), Some("main:2:@7"));
+            }
+            _ => panic!("expected TrustyMpm variant"),
+        }
+    }
+
+    #[test]
+    fn parse_missing_tmux_window_is_none() {
+        let tmp = TempDir::new().unwrap();
+        let p = write_file(
+            tmp.path(),
+            "session-20260627-100000.md",
+            "## Summary\nWork.\n\n## Git Context\nbranch: main",
+        );
+        let session = parse_trusty_mpm_session(&p).unwrap();
+        match session {
+            PausedSession::TrustyMpm { tmux_window, .. } => {
+                assert!(tmux_window.is_none(), "back-compat: absent section => None");
+            }
+            _ => panic!("expected TrustyMpm variant"),
+        }
+    }
+
+    #[test]
+    fn render_tmux_window_present_and_omitted() {
+        // Present → line renders.
+        let with = PausedSession::TrustyMpm {
+            path: PathBuf::from("/tmp/session-20260627-100000.md"),
+            paused_at: None,
+            summary: "Work.".to_string(),
+            git_context: None,
+            in_progress: None,
+            next_steps: None,
+            tmux_window: Some("main:2:@7".to_string()),
+        };
+        let output = render_resume_context(std::slice::from_ref(&with));
+        assert!(
+            output.contains("**Tmux Window:** main:2:@7"),
+            "recorded window should render"
+        );
+
+        // None → line omitted.
+        let without = PausedSession::TrustyMpm {
+            path: PathBuf::from("/tmp/session-20260627-100000.md"),
+            paused_at: None,
+            summary: "Work.".to_string(),
+            git_context: None,
+            in_progress: None,
+            next_steps: None,
+            tmux_window: None,
+        };
+        let output = render_resume_context(std::slice::from_ref(&without));
+        assert!(
+            !output.contains("Tmux Window"),
+            "absent window must not render a line"
         );
     }
 

--- a/crates/trusty-mpm/src/assets/skills/tm-session-management.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-session-management.md
@@ -72,11 +72,20 @@ Snapshot content:
 Branch: {current branch}
 Last commit: {hash and message}
 Uncommitted changes: {git status summary}
+
+## Tmux Window
+{session_name:window_index:window_id, e.g. main:2:@7 — omit this section entirely when not inside tmux}
 ```
 
+The `## Tmux Window` section records the originating tmux window so resume can
+re-align to it. Capture it ONLY when inside tmux (`[ -n "$TMUX" ]`) via
+`tmux display-message -p '#{session_name}:#{window_index}:#{window_id}'`; when
+`$TMUX` is unset, omit the section (resume treats absence as a no-op).
+
 Procedure: `git status` + `git log --oneline -10` for context → `mkdir -p
-.trusty-mpm/sessions` → write `session-{timestamp}.md` → update
-`LATEST-SESSION.txt` → report the path to the user.
+.trusty-mpm/sessions` → when inside tmux, capture the window string (above) →
+write `session-{timestamp}.md` (include `## Tmux Window` only if captured) →
+update `LATEST-SESSION.txt` → report the path to the user.
 
 ## Resuming: `tm session catchup`
 

--- a/crates/trusty-mpm/src/assets/skills/tm-session-pause.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-session-pause.md
@@ -74,7 +74,15 @@ a deliverable. No git commit is created by pausing.
 Branch: {current branch}
 Last commit: {hash and message}
 Uncommitted changes: {git status summary}
+
+## Tmux Window
+{session_name:window_index:window_id, e.g. main:2:@7 — omit this section entirely when not inside tmux}
 ```
+
+The `## Tmux Window` section records the originating tmux window so
+`/tm-session-resume` can re-align you to it with `tmux select-window`. Only
+include the section when the capture step below produced a value; snapshots
+created outside tmux simply omit it (resume treats absence as a no-op).
 
 ## Procedure
 
@@ -82,7 +90,14 @@ Uncommitted changes: {git status summary}
 git status                       # working-tree state for the Git Context block
 git log --oneline -10            # recent commits for context
 mkdir -p .trusty-mpm/sessions    # ensure the store exists
-# write session-{timestamp}.md using the format above, then:
+
+# Capture the current tmux window ONLY when inside tmux; skip the section otherwise.
+if [ -n "$TMUX" ]; then
+  tmux display-message -p '#{session_name}:#{window_index}:#{window_id}'
+fi
+
+# write session-{timestamp}.md using the format above — include a `## Tmux Window`
+# section holding the captured string ONLY if the command above printed one, then:
 # echo "session-{timestamp}.md" > .trusty-mpm/sessions/LATEST-SESSION.txt
 ```
 

--- a/crates/trusty-mpm/src/assets/skills/tm-session-resume.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-session-resume.md
@@ -60,6 +60,29 @@ continuing work.
 > auto-inject-on-session-start. Only the automatic injection path does. This is
 > intentional.
 
+## Re-aligning the Tmux Window
+
+If the catchup digest surfaces a **Tmux Window** line (recorded at pause time as
+`session_name:window_index:window_id`, e.g. `main:2:@7`), realign to the
+originating window so resumed work lands where it left off. Parse the string on
+`:` and use only the `session_name` and `window_index`:
+
+```bash
+# The digest line looks like: **Tmux Window:** main:2:@7
+if [ -n "$TMUX" ]; then
+  # inside tmux → select the recorded window (idempotent no-op if already there)
+  tmux select-window -t 'main:2'   # <session_name>:<window_index> from the digest
+else
+  # not inside tmux → just report it; do not attempt to attach
+  echo "Recorded tmux window: main:2:@7 (start tmux to re-align)"
+fi
+```
+
+This step is a **no-op** when no `Tmux Window` line is present (older snapshots
+or sessions paused outside tmux). `tmux select-window` is safe and idempotent —
+if you are already on that window it does nothing. Never force-create windows or
+attach sessions here; only align within the current tmux client.
+
 ## Session Store Location
 
 ```


### PR DESCRIPTION
## Summary

Three concerns, wired end to end:

- **Pause capture**: `tm-session-pause` now captures the tmux window identity (`#{session_name}:#{window_index}:#{window_id}`) into a new `## Tmux Window` snapshot section alongside todos/git-state.
- **Parse + render**: `crates/trusty-common/src/catchup/session_finder.rs` gains a new optional field for the window identity, parsed from and rendered into the snapshot. Additive `Option<String>` field — old snapshots without the section still parse fine.
- **Resume reattach**: `tm-session-resume` reads the captured window identity and runs `tmux select-window` to reattach the operator to the originating window, falling back gracefully when no window info is present.

Docs updated: `tm-session-pause.md`, `tm-session-management.md`, `tm-session-resume.md`.

## Quality gate

- `cargo build --workspace` ✅
- `cargo test -p trusty-common --features catchup` — 201 passed (incl. 3 new `session_finder` tests) ✅
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings ✅
- `cargo fmt --check` — clean ✅
- `bash scripts/check_line_cap.sh` — green ✅

**Known pre-existing failure (not from this PR)**: `trusty-mpm` test `formatters::banner::two_panel::tests::right_col_no_inner_border` fails on `origin/main` too (byte-identical, username-dependent banner rendering) — unrelated to this change.

Closes #2268

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools