### PR TITLE
chore: release trusty-common 0.22.3 + trusty-mpm 0.19.2 (window-id #2268)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6247,7 +6247,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10760,7 +10760,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10974,7 +10974,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # publish=false; version 0.0.0 intentionally — pre-release scaffold.
 trusty-code = { path = "crates/trusty-code" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.2.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.22.2" }
+trusty-common = { path = "crates/trusty-common", version = "0.22.3" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.6" }

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -9,6 +9,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- capture tmux window id at session pause and reattach on resume ([#2269](https://github.com/bobmatnyc/trusty-tools/pull/2269)) ([`1959738`](https://github.com/bobmatnyc/trusty-tools/commit/1959738450d9a1b7adaf707d9d5980d6365fe4a7))
+## [Unreleased]
+
+### Added
+
 - `is_ephemeral_build_path` bin-resolve helper, detecting `target/debug|release`
   and worktree binary paths so callers can fall back to a PATH-resolved
   installed binary instead of baking in an ephemeral path (consumed by

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.22.2"
+version = "0.22.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 ## [Unreleased]
+
+### Added
+
+- capture tmux window id at session pause and reattach on resume ([#2269](https://github.com/bobmatnyc/trusty-tools/pull/2269)) ([`1959738`](https://github.com/bobmatnyc/trusty-tools/commit/1959738450d9a1b7adaf707d9d5980d6365fe4a7))
+
+### Fixed
+
+- correct banner two_panel right-column no-inner-border rendering ([#2258](https://github.com/bobmatnyc/trusty-tools/pull/2258)) ([`6b9ae4a`](https://github.com/bobmatnyc/trusty-tools/commit/6b9ae4ab17ce0a07b2f69bfb14d3b477c8db6fbe))
+- keep resumed panes rooted at the workspace, not $HOME ([#2254](https://github.com/bobmatnyc/trusty-tools/pull/2254)) ([`d2c1edf`](https://github.com/bobmatnyc/trusty-tools/commit/d2c1edf4431b0cba3e94f558fc13fc9c40786307))
+## [Unreleased]
 ## [Unreleased]
 
 ### Added

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Version-bumps trusty-common and trusty-mpm to publish the already-merged
tmux window-id session-pause/resume feature (#2268).

- trusty-common: 0.22.2 → 0.22.3
- trusty-mpm: 0.19.1 → 0.19.2

Known unrelated pre-existing test failure: `two_panel::right_col_no_inner_border`
(not touched by this change).

This is the version-bump PR only. Tagging and `cargo publish` happen after
this merges, per the project's release convention (publish only from merged
main).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools