### PR TITLE
fix(trusty-code): stop PM re-delegating once cap latched (closes #2265 follow-up)

### DIFF
--- a/crates/trusty-code/src/agent_loop/error.rs
+++ b/crates/trusty-code/src/agent_loop/error.rs
@@ -1,18 +1,22 @@
 //! Error type for the multi-turn agent loop.
 //!
-//! Why: The loop has four distinct failure modes that callers handle
+//! Why: The loop has five distinct failure modes that callers handle
 //! differently — an LLM transport/API failure (usually fatal), exhausting the
 //! turn budget (recoverable: a partial transcript is still useful), the
-//! wall-clock timeout firing (also carries partial work), and (#2056)
+//! wall-clock timeout firing (also carries partial work), (#2056)
 //! cooperative cancellation via `AgentLoop::with_cancel_flag` (a
-//! `session.cancel` on an in-flight daemon-driven run). A structured enum lets
-//! callers branch without string-matching, and every abort variant carries the
-//! partial `AgentOutput` so no work is lost.
-//! What: Defines `AgentLoopError` with `Llm`, `TurnCapExceeded`, `Timeout`, and
-//! `Cancelled` variants, deriving `thiserror::Error`.
+//! `session.cancel` on an in-flight daemon-driven run), and (#2265 fix #5)
+//! an external stop signal firing via `AgentLoop::with_stop_signal` (e.g. the
+//! `run_task` PM loop refusing to issue another `delegate_to_agent` call once
+//! `run_task::redelegation::RedelegationCapSignal` has latched). A structured
+//! enum lets callers branch without string-matching, and every abort variant
+//! carries the partial `AgentOutput` so no work is lost.
+//! What: Defines `AgentLoopError` with `Llm`, `TurnCapExceeded`, `Timeout`,
+//! `Cancelled`, and `StoppedBySignal` variants, deriving `thiserror::Error`.
 //! Test: `agent_loop::tests::turn_cap_returns_partial_transcript` asserts the
 //! `TurnCapExceeded` variant carries the accumulated transcript;
-//! `cancel_flag_aborts_before_next_turn` covers `Cancelled`.
+//! `cancel_flag_aborts_before_next_turn` covers `Cancelled`;
+//! `stop_signal_aborts_before_next_turn` covers `StoppedBySignal`.
 
 use thiserror::Error;
 
@@ -99,6 +103,32 @@ pub enum AgentLoopError {
     #[error("cancelled; returning partial transcript")]
     Cancelled {
         /// Partial output accumulated before cancellation was observed.
+        ///
+        /// Inspection/diagnostics only — see the variant note on the other
+        /// abort arms. Do NOT replay or resume from it.
+        partial: Box<AgentOutput>,
+    },
+
+    /// The loop's `with_stop_signal` external stop condition was observed
+    /// `true` at a turn boundary (#2265 fix #5).
+    ///
+    /// Why: A caller may know, independently of this loop's own turn/timeout
+    /// budget, that continuing is pointless — e.g. `run_task`'s PM loop shares
+    /// a `RedelegationCapSignal` with the engineer-delegation retry decorator;
+    /// once that cap latches, every further `delegate_to_agent` call is a
+    /// guaranteed dead end, so burning the PM's remaining turns issuing them
+    /// (previously bounded only by `AgentLoopConfig::max_turns`) wasted up to
+    /// 7 turns per run in the bake-off L1 evidence for zero additional
+    /// engineer work. Checking the signal at the SAME turn boundary as the
+    /// (#2056) cancellation flag — before the next `chat` call, never
+    /// mid-tool-call — stops the loop the turn AFTER the condition becomes
+    /// true, without dropping any in-flight tool dispatch.
+    /// What: Carries the partial `AgentOutput` assembled before the signal
+    /// was observed, for the same inspection-only purpose as the other abort
+    /// variants.
+    #[error("external stop signal observed; returning partial transcript")]
+    StoppedBySignal {
+        /// Partial output accumulated before the stop signal was observed.
         ///
         /// Inspection/diagnostics only — see the variant note on the other
         /// abort arms. Do NOT replay or resume from it.

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -18,7 +18,8 @@
 //! explicit, successfully-validated `finish_task` tool call, whose structured
 //! `status`/`summary`/`changes`/test-count fields become the final
 //! `AgentOutput` via `build_finish_output`. Aborts with a partial output when
-//! the turn cap, timeout, or (#2056) an external cancellation flag fires.
+//! the turn cap, timeout, (#2056) an external cancellation flag, or (#2265
+//! fix #5) an external stop signal fires.
 //! What: The whole `chat → dispatch → iterate` body runs inside a single
 //! `tokio::time::timeout` so a stalled model or hung tool cannot block forever.
 //! Test: `agent_loop::tests` — stubbed two-turn flow, turn-cap abort, recoverable
@@ -139,10 +140,12 @@ impl Default for AgentLoopConfig {
 /// sites express intent ("run this task") not mechanics.
 /// What: Holds the config, an `Arc<dyn LlmClientTrait>` (mockable in tests), an
 /// `Arc<ToolRegistry>` whose schemas are advertised and whose `dispatch_gated`
-/// executes tool calls, and (#2056) two OPTIONAL collaborators set via builder
-/// methods after construction: a `sink` notified around every tool dispatch,
-/// and a `cancel` flag checked once per turn boundary. Both default to `None`,
-/// so every existing call site (`run_task`, `runner::in_process`) is unaffected.
+/// executes tool calls, and three OPTIONAL collaborators set via builder
+/// methods after construction: (#2056) a `sink` notified around every tool
+/// dispatch, (#2056) a `cancel` flag checked once per turn boundary, and
+/// (#2265 fix #5) a `stop_signal` closure checked at that SAME turn boundary.
+/// All three default to `None`, so every existing call site (`run_task`,
+/// `runner::in_process`) is unaffected.
 /// Test: `agent_loop::tests::*`.
 pub struct AgentLoop {
     config: AgentLoopConfig,
@@ -150,6 +153,7 @@ pub struct AgentLoop {
     registry: Arc<ToolRegistry>,
     sink: Option<Arc<dyn ToolEventSink>>,
     cancel: Option<Arc<AtomicBool>>,
+    stop_signal: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
 }
 
 impl AgentLoop {
@@ -158,10 +162,13 @@ impl AgentLoop {
     /// Why: Constructor injection keeps the loop testable — production passes a
     /// real `LlmClient`, tests pass a scripted mock, both as
     /// `Arc<dyn LlmClientTrait>`.
-    /// What: Stores the config, LLM client, and tool registry; `sink`/`cancel`
-    /// start `None` — attach them via [`Self::with_tool_event_sink`]/
-    /// [`Self::with_cancel_flag`] when the caller needs them (#2056's
-    /// daemon-driven task execution does; `run_task`'s CLI path does not).
+    /// What: Stores the config, LLM client, and tool registry; `sink`/`cancel`/
+    /// `stop_signal` start `None` — attach them via
+    /// [`Self::with_tool_event_sink`]/[`Self::with_cancel_flag`]/
+    /// [`Self::with_stop_signal`] when the caller needs them (#2056's
+    /// daemon-driven task execution attaches the first two; `run_task`'s PM
+    /// loop attaches `stop_signal` (#2265 fix #5); the delegated engineer's
+    /// own loop attaches none of them).
     /// Test: `agent_loop::tests::two_turn_flow_completes`.
     pub fn new(
         config: AgentLoopConfig,
@@ -174,6 +181,7 @@ impl AgentLoop {
             registry,
             sink: None,
             cancel: None,
+            stop_signal: None,
         }
     }
 
@@ -200,6 +208,31 @@ impl AgentLoop {
     /// Test: `agent_loop::tests::cancel_flag_aborts_before_next_turn`.
     pub fn with_cancel_flag(mut self, cancel: Arc<AtomicBool>) -> Self {
         self.cancel = Some(cancel);
+        self
+    }
+
+    /// Attach an external stop condition checked once per turn boundary
+    /// (#2265 fix #5).
+    ///
+    /// Why: Some callers know, independently of this loop's own turn/timeout
+    /// budget, that a shared external condition has made further turns
+    /// pointless — `run_task`'s PM loop is the motivating case: once its
+    /// shared `redelegation::RedelegationCapSignal` latches (the engineer
+    /// delegation retry decorator has exhausted `MAX_REDELEGATIONS`), every
+    /// subsequent `delegate_to_agent` call is a guaranteed dead end, so the
+    /// PM must stop issuing them rather than silently burning its remaining
+    /// `max_turns` one doomed tool call at a time (the exact bake-off L1
+    /// regression this fix closes). Modelled as a boolean-returning closure,
+    /// not a narrower `RedelegationCapSignal`-specific hook, so `agent_loop`
+    /// stays generic and does not need to depend on `run_task`.
+    /// What: Builder-style setter; returns `self` for chaining. Checked with
+    /// the SAME turn-boundary placement as [`Self::with_cancel_flag`] — once
+    /// per iteration, before the next `chat` call, never mid-tool-call — so a
+    /// tool dispatch already in flight always completes and is answered
+    /// first.
+    /// Test: `agent_loop::tests::stop_signal_aborts_before_next_turn`.
+    pub fn with_stop_signal(mut self, signal: Arc<dyn Fn() -> bool + Send + Sync>) -> Self {
+        self.stop_signal = Some(signal);
         self
     }
 
@@ -243,8 +276,11 @@ impl AgentLoop {
     /// assembled output — the D3 fallback, unchanged. Per D3, `finish_reason`
     /// never gates termination — pending tool calls always run first.
     /// Exhausting the turn budget returns `TurnCapExceeded`; an observed
-    /// cancellation returns `Cancelled` — both with the partial transcript.
+    /// cancellation returns `Cancelled`; an observed (#2265 fix #5) external
+    /// stop signal returns `StoppedBySignal` — all three with the partial
+    /// transcript.
     /// Test: Same tests as `run`, plus `cancel_flag_aborts_before_next_turn`,
+    /// `stop_signal_aborts_before_next_turn`,
     /// `explicit_finish_task_terminates_loop_with_structured_summary`.
     async fn run_inner(
         &self,
@@ -261,6 +297,20 @@ impl AgentLoop {
                 && cancel.load(Ordering::Relaxed)
             {
                 return Err(AgentLoopError::Cancelled {
+                    partial: Box::new(build_output(transcript, perf)),
+                });
+            }
+
+            // #2265 fix #5: the external stop-signal check, same turn
+            // boundary as the cancellation check above — never mid-tool-call.
+            // This is what stops `run_task`'s PM loop from issuing further
+            // `delegate_to_agent` calls once the shared re-delegation cap has
+            // latched, instead of silently spinning through the remaining
+            // `max_turns` on doomed retries.
+            if let Some(stop) = &self.stop_signal
+                && stop()
+            {
+                return Err(AgentLoopError::StoppedBySignal {
                     partial: Box::new(build_output(transcript, perf)),
                 });
             }

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -1349,6 +1349,44 @@ async fn cancel_flag_aborts_before_next_turn() {
     );
 }
 
+/// An external stop signal (#2265 fix #5) that reports `true` must abort the
+/// loop with `AgentLoopError::StoppedBySignal` before the next turn's LLM
+/// call — never mid-tool-call. Mirrors `cancel_flag_aborts_before_next_turn`
+/// exactly, proving `with_stop_signal` shares the same turn-boundary contract
+/// as `with_cancel_flag`.
+///
+/// Why: This is the generic mechanism `run_task`'s PM loop relies on to stop
+/// issuing `delegate_to_agent` calls the turn after the shared re-delegation
+/// cap latches (see `run_task::mod`'s `execute_run_task` wiring and
+/// `run_task::tests::pm_stops_redelegating_once_cap_latched_ends_partial_promptly`
+/// for the production end-to-end proof); this test isolates the loop
+/// mechanism itself from any `run_task`-specific signal.
+/// What: A closure pre-set to always return `true` before the loop even
+/// starts must abort on the very first turn boundary, making zero `chat`
+/// calls.
+/// Test: this test.
+#[tokio::test]
+async fn stop_signal_aborts_before_next_turn() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response(
+        "should never be reached",
+    )]));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default())
+        .with_stop_signal(Arc::new(|| true));
+
+    let err = agent
+        .run("sys", "task")
+        .await
+        .expect_err("must abort as stopped-by-signal");
+    assert!(matches!(err, AgentLoopError::StoppedBySignal { .. }));
+    assert_eq!(
+        llm.calls(),
+        0,
+        "the stop signal must be observed before any chat call"
+    );
+}
+
 // ── Prompt-caching gate tests (#2156) ────────────────────────────────────────────
 
 /// A `DailyDriver` run against an `anthropic/*` model marks the static

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -93,13 +93,18 @@ pub struct RunTaskParams {
 /// What: Loads the PM config, assembles its prompt (BASE + PM prompt + project
 /// `CLAUDE.md`), builds the engineer runner (fs/bash scoped to the project, with
 /// the optional per-run model override), wraps it in the PM's
-/// `DelegateToAgentTool`, snapshots the working tree, runs the PM `AgentLoop`,
+/// `DelegateToAgentTool`, snapshots the working tree, runs the PM `AgentLoop`
+/// (#2265 fix #5: wired with `with_stop_signal` against the SAME
+/// `redelegation_signal` the engineer runner shares, so the PM stops issuing
+/// `delegate_to_agent` calls the turn after the re-delegation cap latches
+/// instead of spinning through its remaining turns on doomed retries),
 /// snapshots again, and assembles a `RunReport` (diff + transcript + usage/cost +
 /// exit code). A PM-config or loop error yields a `ConfigError`/`RunFailure`
 /// report rather than a panic.
 /// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`,
 /// `diff_reflects_engineer_file_change`, `usage_and_cost_aggregate_end_to_end`,
-/// `exit_code_reflects_run_failure`.
+/// `exit_code_reflects_run_failure`,
+/// `pm_stops_redelegating_once_cap_latched_ends_partial_promptly`.
 pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait>) -> RunReport {
     let transcript: SharedTranscript = Arc::new(Mutex::new(Vec::new()));
 
@@ -177,6 +182,19 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
         project_context.as_deref(),
         catchup_ctx.as_deref(),
     );
+    // (#2265 fix #5) Once the shared re-delegation cap latches, every further
+    // `delegate_to_agent` call the PM might issue is a guaranteed dead end —
+    // `RedelegatingRunner` will reject it immediately without even invoking
+    // the engineer. Wiring the SAME signal into the PM's own loop as a stop
+    // condition (checked at the existing turn-boundary, alongside the #2056
+    // cancellation flag) stops the PM from spending its remaining
+    // `max_turns` issuing those doomed calls one per turn — the bake-off L1
+    // regression this fix closes (see `redelegation` module docs for the
+    // full before/after). `assemble_report` already maps a cap-latched,
+    // deliverable-bearing run to `ExitCode::Partial` regardless of which
+    // `AgentLoopError` variant the PM's loop returns, so this purely trims
+    // wasted turns — it does not change the reported outcome.
+    let stop_signal = redelegation_signal.clone();
     let pm_loop = AgentLoop::new(
         AgentLoopConfig {
             model: pm_model.clone(),
@@ -186,7 +204,8 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
         },
         pm_llm,
         Arc::new(pm_registry),
-    );
+    )
+    .with_stop_signal(Arc::new(move || stop_signal.is_cap_reached()));
 
     // Snapshot before, run the PM, snapshot after.
     let before = diff::capture_snapshot(&params.project);

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -916,4 +916,137 @@ fn assemble_report_keeps_turn_cap_exceeded_with_no_deliverable_as_run_failure() 
         ExitCode::RunFailure,
         "a TurnCapExceeded PM error with NO deliverable must stay RunFailure (fix #4)"
     );
+    let _ = &report;
+}
+
+// ── #2265 fix #5: PM stops re-delegating once the cap latches ──────────────────
+
+/// An `LlmClientTrait` that forces a retryable `LlmError` at specific GLOBAL
+/// call indices (shared across the PM's and the engineer's chat calls) and
+/// otherwise forwards to an inner `ScriptedLlm`, whose own fixture cursor
+/// only advances on forwarded (non-forced-error) calls.
+///
+/// Why: `repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap` proves
+/// the cap latches within one `delegate_to_agent` dispatch, but its mock
+/// exhausts entirely at that point — a bare-exhaustion error also aborts the
+/// PM's OWN next `chat` call, so that test cannot distinguish "the PM's loop
+/// stopped itself before calling chat again" (this fix) from "the PM's chat
+/// call happened and failed anyway" (the pre-fix behaviour would produce the
+/// same shape of error there). This wrapper keeps VALID `delegate_to_agent`
+/// fixtures queued up behind the forced-error window, standing in for a real
+/// model that keeps deciding to re-delegate because it does not understand
+/// the cap-reached tool error — the exact bake-off L1 failure mode. If the
+/// PM's loop does NOT stop itself, those fixtures get consumed and recorded;
+/// if it does, the global call counter never reaches them.
+/// What: `error_at` global call indices return `LlmError::ApiError` (a
+/// retryable `AgentLoopError::Llm` per `redelegation_hint`) without touching
+/// `inner`; every other index forwards to `inner.chat`, so `inner`'s fixture
+/// list is consumed strictly in the order its calls are actually forwarded.
+/// Test: `pm_stops_redelegating_once_cap_latched_ends_partial_promptly`.
+struct FlakyThenRepeatLlm {
+    inner: ScriptedLlm,
+    counter: AtomicUsize,
+    error_at: Vec<usize>,
+}
+
+#[async_trait]
+impl LlmClientTrait for FlakyThenRepeatLlm {
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let idx = self.counter.fetch_add(1, Ordering::SeqCst);
+        if self.error_at.contains(&idx) {
+            return Err(LlmError::ApiError {
+                status: 500,
+                body: "synthetic retryable transport failure".to_string(),
+            });
+        }
+        self.inner.chat(req).await
+    }
+}
+
+/// Once the shared re-delegation cap latches, the PM must stop issuing
+/// `delegate_to_agent` calls immediately (bounded total chat calls, well
+/// under the PM's `max_turns` of 8) and the run must still end `Partial`
+/// with the deliverable the engineer already wrote preserved in the diff.
+///
+/// Why: This is the exact #2265 follow-up regression closed by fix #5: before
+/// this fix, `AgentLoop::run_inner` had no way to learn the cap had latched,
+/// so the PM's own LLM — seeing only an opaque tool error, with nothing
+/// telling it re-delegating again is pointless — could keep calling
+/// `delegate_to_agent` every remaining turn, each one an instant, guaranteed
+/// dead end (bake-off L1 evidence: "re-delegation limit reached after 10
+/// attempts … turn cap of 8 exceeded", 3 productive attempts + 7 wasted PM
+/// turns). The exit code must NOT change — `assemble_report` already maps a
+/// cap-latched, deliverable-bearing run to `Partial` regardless of which
+/// `AgentLoopError` variant fired; this test proves the fix trims the wasted
+/// turns without touching that mapping.
+/// What: Script [PM delegate, engineer write_file (the deliverable), then 3
+/// forced retryable `Llm` errors — engineer's own second turn plus its two
+/// internal reuse-hint retries — landing the shared cap at
+/// `MAX_REDELEGATIONS` attempts entirely inside that ONE PM dispatch]. Queue
+/// SIX MORE valid `delegate_to_agent` fixtures behind that window (as if a
+/// real model kept trying) — enough to fill the PM's remaining `max_turns`
+/// budget if the fix did not stop it. Assert: `exit == Partial`, the diff
+/// still names `hello.py`, the PM's own turn count is exactly 1 (it never
+/// reached a second turn), and the total number of chat calls made across
+/// the whole run stayed small (well below the ~12 calls an unfixed run would
+/// need to hit its own `TurnCapExceeded`) — direct proof the trailing
+/// `delegate_response` fixtures were never consumed.
+/// Test: this test.
+#[tokio::test]
+async fn pm_stops_redelegating_once_cap_latched_ends_partial_promptly() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let inner = ScriptedLlm::from_json(&[
+        delegate_response("do work"),
+        write_file_response("hello.py", "print(1)"),
+        // Trailing fixtures a real, cap-unaware model might trigger by
+        // calling delegate_to_agent again on turns 2..8 — must NEVER be
+        // consumed once the fix is in place.
+        delegate_response("task-2"),
+        delegate_response("task-3"),
+        delegate_response("task-4"),
+        delegate_response("task-5"),
+        delegate_response("task-6"),
+        delegate_response("task-7"),
+    ]);
+    let llm = Arc::new(FlakyThenRepeatLlm {
+        inner,
+        counter: AtomicUsize::new(0),
+        // Global calls: 0=PM delegate, 1=engineer write_file, then 2,3,4 are
+        // the engineer's own failing turn plus its two internal reuse-hint
+        // retries — landing attempt 4 (> MAX_REDELEGATIONS=3) and latching
+        // the cap without a 5th call.
+        error_at: vec![2, 3, 4],
+    });
+
+    let report = execute_run_task(params(&agents, &project, None), llm.clone()).await;
+
+    assert_eq!(
+        report.exit,
+        ExitCode::Partial,
+        "the cap latched but the engineer's write_file already produced a \
+         deliverable, so this must be Partial, not RunFailure; got task: {}",
+        report.task
+    );
+    assert!(
+        report.diff.contains("hello.py"),
+        "the deliverable diff must be preserved, got: {}",
+        report.diff
+    );
+
+    let pm_turns = report.transcript.iter().filter(|t| t.role == "pm").count();
+    assert_eq!(
+        pm_turns, 1,
+        "the PM must stop after its single delegating turn — it must never \
+         reach a second turn once the cap has latched"
+    );
+
+    let total_calls = llm.counter.load(Ordering::SeqCst);
+    assert!(
+        total_calls <= 5,
+        "the PM must not have issued any further delegate_to_agent calls \
+         after the cap latched (bounded, not spinning to the ~12 calls an \
+         unfixed 8-turn PM loop would need), got {total_calls} total chat calls"
+    );
 }

--- a/crates/trusty-code/src/tools/delegate.rs
+++ b/crates/trusty-code/src/tools/delegate.rs
@@ -63,9 +63,14 @@ use crate::tools::traits::{AgentRunner, ToolExecutor, ToolResult};
 /// there is no partial transcript snapshot to point to.
 /// What: Downcasts `err` to [`RunnerError`] and matches `RunnerError::Loop`
 /// whose source is `AgentLoopError::TurnCapExceeded`, `Timeout`, `Cancelled`,
-/// or (#2265) `Llm`. Returns `None` only for `UnknownAgent`/`ConfigLoad` —
-/// failures that never reached a sub-agent loop at all, so there is nothing
-/// on disk to reuse.
+/// (#2265) `Llm`, or (#2265 fix #5) `StoppedBySignal`. Returns `None` only
+/// for `UnknownAgent`/`ConfigLoad` — failures that never reached a sub-agent
+/// loop at all, so there is nothing on disk to reuse.
+/// Note: a delegated engineer's own sub-loop never actually attaches a stop
+/// signal today (only `run_task`'s PM loop does, via
+/// `AgentLoop::with_stop_signal`), so `StoppedBySignal` is unreachable from
+/// this call site in practice; it is included for exhaustiveness and to stay
+/// correct if that ever changes.
 /// Test: `redelegation_hint_present_on_turn_cap_exceeded`,
 /// `redelegation_hint_present_on_timeout`,
 /// `redelegation_hint_present_on_cancelled`,
@@ -79,6 +84,7 @@ pub(crate) fn redelegation_hint(err: &anyhow::Error) -> Option<&'static str> {
         AgentLoopError::TurnCapExceeded { .. }
         | AgentLoopError::Timeout { .. }
         | AgentLoopError::Cancelled { .. }
+        | AgentLoopError::StoppedBySignal { .. }
         | AgentLoopError::Llm(_) => Some(
             "\n\nNOTE for re-delegation: the sub-agent's previous attempt did not reach a \
              normal finish — it ran out of turns or time, was cancelled, or hit a \


### PR DESCRIPTION
## Summary

- Once the shared re-delegation cap (`run_task::redelegation::RedelegationCapSignal`, `MAX_REDELEGATIONS = 3`) latches, the PM's own `AgentLoop` had no way to learn about it — its underlying LLM kept issuing doomed `delegate_to_agent` calls every remaining turn until it exhausted its own `max_turns = 8` budget. Bake-off L1 evidence: "re-delegation limit reached after 10 attempts … turn cap of 8 exceeded" — 3 productive attempts + 7 wasted PM turns.
- Adds a generic `AgentLoop::with_stop_signal(Arc<dyn Fn() -> bool + Send + Sync>)` builder, checked at the same turn boundary as the existing `#2056` cancellation flag (before the next `chat` call, never mid-tool-call), plus a new `AgentLoopError::StoppedBySignal` variant carrying the partial output.
- Wires `run_task`'s PM loop with a closure over the shared `RedelegationCapSignal`, so the PM stops issuing `delegate_to_agent` calls the turn after the cap latches.
- `assemble_report` already mapped a cap-latched, deliverable-bearing run to `ExitCode::Partial` regardless of which `AgentLoopError` variant fired, so the reported outcome (`Partial`, deliverable diff preserved) is unchanged — this change purely eliminates the wasted turns.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-code` — 722 passed, 0 failed, 3 ignored (pre-existing ONNX-gated tests)
- [x] New unit test `agent_loop::tests::stop_signal_aborts_before_next_turn` — proves the generic `with_stop_signal` mechanism aborts before any `chat` call when the signal is already true, mirroring the existing `cancel_flag_aborts_before_next_turn` test.
- [x] New integration test `run_task::tests::pm_stops_redelegating_once_cap_latched_ends_partial_promptly` — scripts an engineer write (deliverable) followed by 3 forced retryable `Llm` errors that latch the cap, then queues 6 more valid `delegate_to_agent` fixtures behind that window (standing in for a real model that keeps trying). Asserts: `exit == Partial`, diff still contains the deliverable, the PM's own turn count is exactly 1, and total chat calls stay bounded (`<= 5`) instead of spinning to the ~12 calls an unfixed 8-turn PM loop would need. Verified this test fails (`left: 7, right: 1`) when the `with_stop_signal` wiring is temporarily removed, confirming it actually exercises the fix.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (only a pre-existing, unrelated MSRV-mismatch info note in the `tga` crate)
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `14 allowlisted, 0 violations — OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)