### PR TITLE
fix(trusty-memory): idle-to-disk palace eviction + unpin dream scheduler + configurable max-open (closes #2273)

### DIFF
--- a/crates/trusty-common/src/memory_core/dream/dreamer.rs
+++ b/crates/trusty-common/src/memory_core/dream/dreamer.rs
@@ -15,6 +15,8 @@ use super::cycle::{
 };
 use super::guard::CompactionGuard;
 use super::recall_benchmark::run_benchmark;
+use crate::memory_core::palace::PalaceId;
+use crate::memory_core::registry::PalaceRegistry;
 use crate::memory_core::retrieval::PalaceHandle;
 use crate::memory_core::semantic_consolidation::SemanticConsolidator;
 use anyhow::{Context, Result};
@@ -90,13 +92,24 @@ impl Dreamer {
     /// Spawn the background dream loop.
     ///
     /// Why: A long-lived daemon needs a per-palace task that wakes periodically,
-    /// checks the idle clock, and runs one cycle when appropriate.
-    /// What: Spawns a tokio task that sleeps `idle_secs`, calls `dream_cycle`
-    /// when `is_idle`, and logs the resulting stats. Runs forever; cancel by
-    /// dropping the daemon.
-    /// Test: Behavioral coverage via direct `dream_cycle` calls; the loop
-    /// itself is just a sleep + dispatch.
-    pub fn start(self: Arc<Self>, handle: Arc<PalaceHandle>) -> tokio::task::JoinHandle<()> {
+    /// checks the idle clock, and runs one cycle when appropriate. It must NOT
+    /// pin the palace handle for the process lifetime: the loop takes the
+    /// `registry` + `palace_id` and re-resolves the handle each cycle via
+    /// `peek` (no MRU promote, no reopen). Between cycles it holds no
+    /// `Arc<PalaceHandle>`, so the LRU and the idle-to-disk sweep can freely
+    /// evict a palace nobody is querying — the previous design captured the
+    /// `Arc` forever and defeated eviction.
+    /// What: Spawns a tokio task that sleeps `idle_secs`, resolves the handle
+    /// (skipping the cycle when the palace has been evicted to disk — dreaming
+    /// must never rehydrate a cold palace), calls `dream_cycle` when `is_idle`,
+    /// and logs the resulting stats. Runs forever; cancel by dropping the task.
+    /// Test: Behavioral coverage via direct `dream_cycle` calls;
+    /// `dream::tests::dream_loop_does_not_pin_palace_handle` covers unpinning.
+    pub fn start(
+        self: Arc<Self>,
+        registry: PalaceRegistry,
+        palace_id: PalaceId,
+    ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let interval = Duration::from_secs(self.config.idle_secs.max(1));
             loop {
@@ -104,24 +117,13 @@ impl Dreamer {
                 if !self.is_idle() {
                     continue;
                 }
-                match self.dream_cycle(&handle).await {
-                    Ok(stats) => tracing::info!(
-                        palace = %handle.id,
-                        merged = stats.merged,
-                        pruned = stats.pruned,
-                        content_pruned = stats.content_pruned,
-                        compacted = stats.compacted,
-                        closets_updated = stats.closets_updated,
-                        semantically_consolidated = stats.semantically_consolidated,
-                        semantic_llm_calls = stats.semantic_llm_calls,
-                        duration_ms = stats.duration_ms,
-                        drawers_before = stats.drawers_before,
-                        drawers_after = stats.drawers_after,
-                        compression_ratio = stats.compression_ratio,
-                        "dream cycle complete"
-                    ),
-                    Err(e) => tracing::warn!(palace = %handle.id, "dream cycle failed: {e:#}"),
-                }
+                // Resolve WITHOUT reopening: a palace idle-evicted to disk is
+                // skipped rather than rehydrated (which would defeat the sweep).
+                let Some(handle) = registry.peek(&palace_id) else {
+                    continue;
+                };
+                log_cycle_outcome(&palace_id, self.dream_cycle(&handle).await);
+                // `handle` drops here — nothing pins the palace between cycles.
             }
         })
     }
@@ -141,7 +143,8 @@ impl Dreamer {
     /// shutdown flag, await the join handle.
     pub fn start_with_shutdown(
         self: Arc<Self>,
-        handle: Arc<PalaceHandle>,
+        registry: PalaceRegistry,
+        palace_id: PalaceId,
         mut shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
@@ -152,36 +155,26 @@ impl Dreamer {
                     res = shutdown.changed() => {
                         // Sender closed (`Err`) or value changed to true: shut down.
                         if res.is_err() || *shutdown.borrow() {
-                            tracing::info!(palace = %handle.id, "dreamer shutting down");
+                            tracing::info!(palace = %palace_id, "dreamer shutting down");
                             return;
                         }
                     }
                 }
                 if *shutdown.borrow() {
-                    tracing::info!(palace = %handle.id, "dreamer shutting down");
+                    tracing::info!(palace = %palace_id, "dreamer shutting down");
                     return;
                 }
                 if !self.is_idle() {
                     continue;
                 }
-                match self.dream_cycle(&handle).await {
-                    Ok(stats) => tracing::info!(
-                        palace = %handle.id,
-                        merged = stats.merged,
-                        pruned = stats.pruned,
-                        content_pruned = stats.content_pruned,
-                        compacted = stats.compacted,
-                        closets_updated = stats.closets_updated,
-                        semantically_consolidated = stats.semantically_consolidated,
-                        semantic_llm_calls = stats.semantic_llm_calls,
-                        duration_ms = stats.duration_ms,
-                        drawers_before = stats.drawers_before,
-                        drawers_after = stats.drawers_after,
-                        compression_ratio = stats.compression_ratio,
-                        "dream cycle complete"
-                    ),
-                    Err(e) => tracing::warn!(palace = %handle.id, "dream cycle failed: {e:#}"),
-                }
+                // Re-resolve without reopening; skip (do NOT rehydrate) a palace
+                // that has been idle-evicted to disk. This also unpins the
+                // handle so the LRU / idle-evict sweep can drop it between
+                // cycles — see `start`.
+                let Some(handle) = registry.peek(&palace_id) else {
+                    continue;
+                };
+                log_cycle_outcome(&palace_id, self.dream_cycle(&handle).await);
             }
         })
     }
@@ -321,5 +314,34 @@ impl Dreamer {
         }
 
         Ok(stats)
+    }
+}
+
+/// Emit the standard per-cycle telemetry for a dream loop.
+///
+/// Why: `start` and `start_with_shutdown` share the identical success/error
+/// logging block; hoisting it into one helper keeps them in lock-step and each
+/// well under the SLOC cap.
+/// What: on `Ok`, logs the full `DreamStats` field set at `info`; on `Err`,
+/// logs a `warn` naming the palace. Pure logging — no return value.
+/// Test: exercised by every dream-loop test that spawns `start_with_shutdown`.
+fn log_cycle_outcome(palace_id: &PalaceId, outcome: Result<DreamStats>) {
+    match outcome {
+        Ok(stats) => tracing::info!(
+            palace = %palace_id,
+            merged = stats.merged,
+            pruned = stats.pruned,
+            content_pruned = stats.content_pruned,
+            compacted = stats.compacted,
+            closets_updated = stats.closets_updated,
+            semantically_consolidated = stats.semantically_consolidated,
+            semantic_llm_calls = stats.semantic_llm_calls,
+            duration_ms = stats.duration_ms,
+            drawers_before = stats.drawers_before,
+            drawers_after = stats.drawers_after,
+            compression_ratio = stats.compression_ratio,
+            "dream cycle complete"
+        ),
+        Err(e) => tracing::warn!(palace = %palace_id, "dream cycle failed: {e:#}"),
     }
 }

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -199,12 +199,16 @@ async fn dream_cycle_prunes_at_floor_importance() {
 #[tokio::test]
 async fn dreamer_shutdown_terminates_loop() {
     let handle = open_test_handle("dream-shutdown").await;
+    // The unpinned dream loop resolves the handle from a registry each cycle.
+    let id = handle.id.clone();
+    let registry = crate::memory_core::PalaceRegistry::new();
+    registry.register_arc(handle);
     let dreamer = Arc::new(Dreamer::new(DreamConfig {
         idle_secs: 10,
         ..DreamConfig::default()
     }));
     let (tx, rx) = tokio::sync::watch::channel(false);
-    let join = dreamer.clone().start_with_shutdown(handle, rx);
+    let join = dreamer.clone().start_with_shutdown(registry, id, rx);
 
     // Yield once so the task is scheduled.
     tokio::task::yield_now().await;
@@ -217,6 +221,49 @@ async fn dreamer_shutdown_terminates_loop() {
         "dream loop did not exit within 2s of shutdown"
     );
     outcome.unwrap().expect("join handle clean exit");
+}
+
+/// Part 1 (unpin): a running dream loop must NOT hold an `Arc<PalaceHandle>`
+/// for the process lifetime — otherwise it defeats LRU / idle-to-disk
+/// eviction (the palace can never be freed while its dream loop lives).
+///
+/// Why: the original design captured `Arc<PalaceHandle>` in the spawned task,
+/// so `registry.remove` (or an idle-evict) could not actually drop the
+/// handle's heavy state. The fix resolves the handle from the registry each
+/// cycle instead.
+/// What: registers a handle, keeps a `Weak` to it, spawns the dream loop with
+/// a long idle interval (so it only sleeps — never resolves the handle during
+/// the test), removes the palace from the registry, and asserts the handle is
+/// fully dropped (`Weak::upgrade` is `None`). Under the old pinning bug the
+/// upgrade would still succeed.
+/// Test: this test itself.
+#[tokio::test]
+async fn dream_loop_does_not_pin_palace_handle() {
+    let handle = open_test_handle("dream-unpin").await;
+    let id = handle.id.clone();
+    let weak = Arc::downgrade(&handle);
+    let registry = crate::memory_core::PalaceRegistry::new();
+    registry.register_arc(handle); // registry now holds the ONLY strong ref
+
+    // Long idle interval: the loop's first action is a `sleep(3600s)`, so it
+    // never peeks the registry during this test and holds no handle Arc.
+    let dreamer = Arc::new(Dreamer::new(DreamConfig {
+        idle_secs: 3600,
+        ..DreamConfig::default()
+    }));
+    let (_tx, rx) = tokio::sync::watch::channel(false);
+    let _join = dreamer.start_with_shutdown(registry.clone(), id.clone(), rx);
+    // Let the task reach its sleep.
+    tokio::task::yield_now().await;
+
+    // Drop the registry's strong reference. If the loop had captured an Arc
+    // (the pinning bug), the handle would survive this.
+    registry.remove(&id);
+    tokio::task::yield_now().await;
+    assert!(
+        weak.upgrade().is_none(),
+        "dream loop must not pin the handle: after registry.remove it must be fully dropped"
+    );
 }
 
 /// Why: When drawer rows disappear without their matching vector being

--- a/crates/trusty-common/src/memory_core/registry.rs
+++ b/crates/trusty-common/src/memory_core/registry.rs
@@ -25,6 +25,37 @@ use parking_lot::Mutex;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
+
+/// Environment variable overriding the LRU open-handle cap
+/// (`PalaceRegistry::with_max_open`).
+///
+/// Why: idle RSS on a busy host is dominated by how many palaces the daemon
+/// keeps resident. Operators close to the fd ceiling (or trying to bound RAM)
+/// need to shrink the cap without recompiling; hosts with a high fd limit may
+/// raise it. An env var read once at registry construction is the lightest
+/// knob.
+/// What: parsed by [`max_open_palaces_from_env`]; consumed by
+/// [`PalaceRegistry::from_env`].
+/// Test: `registry_tests::from_env_respects_max_open_palaces_env`.
+pub const MAX_OPEN_PALACES_ENV: &str = "TRUSTY_MEMORY_MAX_OPEN_PALACES";
+
+/// Resolve the effective open-handle cap from the environment.
+///
+/// Why: centralises the env parse so `from_env` and diagnostics agree on the
+/// value and the fallback.
+/// What: reads [`MAX_OPEN_PALACES_ENV`]; returns its parsed `usize` when set to
+/// a value `>= 1`, otherwise [`DEFAULT_MAX_OPEN_PALACES`]. An unset, empty,
+/// non-numeric, or zero value falls back to the default (a zero cap would be
+/// clamped to 1 anyway and is almost certainly a misconfiguration).
+/// Test: `registry_tests::from_env_respects_max_open_palaces_env`.
+pub fn max_open_palaces_from_env() -> usize {
+    std::env::var(MAX_OPEN_PALACES_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(DEFAULT_MAX_OPEN_PALACES)
+}
 
 /// Default maximum number of palace handles to hold open simultaneously.
 ///
@@ -81,6 +112,23 @@ pub struct PalaceRegistry {
     /// `create_palace`, and the eager `open` hydration path.
     /// Test: `with_writer_intent_sets_writer_open_intent`.
     open_intent: OpenIntent,
+    /// Per-palace mutexes serialising `open_palace` so two concurrent misses
+    /// for the same id never open the redb files twice at once.
+    ///
+    /// Why: idle-to-disk eviction makes cold-palace reopens common. redb takes
+    /// an exclusive `flock(LOCK_EX)`; under `OpenIntent::Writer` a second
+    /// same-process open of an already-open file returns `DatabaseAlreadyOpen`
+    /// and, after the ~1.55 s handoff-retry window, fails loud (see
+    /// `store::concurrent_open`). Without serialisation two racing recalls of a
+    /// just-evicted palace would double-open and the loser would error. A tiny
+    /// per-id sync mutex makes the second racer wait, re-check the cache, and
+    /// share the winner's handle instead.
+    /// What: `DashMap<PalaceId, Arc<parking_lot::Mutex<()>>>`. Held only across
+    /// the (rare) open pipeline — never across an `.await` — so a
+    /// `parking_lot::Mutex` is safe. Entries are lightweight and left in place
+    /// (bounded by palace count) rather than reference-counted out.
+    /// Test: `registry_tests::evict_idle_then_reopen_preserves_recall`.
+    open_locks: Arc<DashMap<PalaceId, Arc<Mutex<()>>>>,
 }
 
 impl Default for PalaceRegistry {
@@ -117,7 +165,21 @@ impl PalaceRegistry {
             // registries keep the issue-#59 snapshot read-fallback. The HTTP
             // daemon overrides this via `with_writer_intent` (issue #1487).
             open_intent: OpenIntent::ReadOnlyClient,
+            open_locks: Arc::new(DashMap::new()),
         }
+    }
+
+    /// Create a registry whose open-handle cap comes from the environment.
+    ///
+    /// Why (idle-to-disk / issue #463): the daemon's resident-palace ceiling is
+    /// the primary lever on idle RSS. `from_env` lets operators tune it via
+    /// [`MAX_OPEN_PALACES_ENV`] without a rebuild while keeping the safe
+    /// [`DEFAULT_MAX_OPEN_PALACES`] default. Callers that want the writer
+    /// contract chain `.with_writer_intent()` as before.
+    /// What: `with_max_open(max_open_palaces_from_env())`.
+    /// Test: `registry_tests::from_env_respects_max_open_palaces_env`.
+    pub fn from_env() -> Self {
+        Self::with_max_open(max_open_palaces_from_env())
     }
 
     /// Mark this registry as the sole writer: open every palace with
@@ -321,6 +383,22 @@ impl PalaceRegistry {
         if let Some(h) = self.get(&effective_id) {
             return Ok(h);
         }
+        // Serialise concurrent opens of the SAME palace so two racing misses
+        // (common once idle-evict starts dropping cold palaces) never
+        // double-open the redb files — under `Writer` intent the loser would
+        // otherwise fail loud after the flock handoff-retry window. The winner
+        // opens + registers; the loser re-checks the cache below and shares it.
+        let open_lock = self
+            .open_locks
+            .entry(effective_id.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        let _open_guard = open_lock.lock();
+        // Re-check under the open lock: another racer may have opened it while
+        // we waited for the lock.
+        if let Some(h) = self.get(&effective_id) {
+            return Ok(h);
+        }
         let palace_dir = data_root.join(effective_id.as_str());
         let palace = PalaceStore::load_palace(&palace_dir)
             .with_context(|| format!("load palace metadata for {palace_id}"))?;
@@ -440,459 +518,62 @@ impl PalaceRegistry {
         }
         Ok(registry)
     }
+
+    /// Drop every idle, unreferenced palace handle — the "idle to disk" sweep.
+    ///
+    /// Why: even under the LRU cap the daemon keeps up to `max_open` palaces
+    /// fully resident (drawer table + HNSW graph + KG adjacency, ~90 MB each)
+    /// regardless of query activity, driving idle RSS to multiple GB. Dropping
+    /// the whole `Arc<PalaceHandle>` for palaces no user has touched in the TTL
+    /// window frees all of that heavy RAM at once; the durable redb store is
+    /// the source of truth and the next access transparently re-opens from disk
+    /// (`open_palace`, already covered by `lru_evicted_handle_reopens`).
+    /// What: under the handles lock, selects ids whose handle (a) has been idle
+    /// `>= threshold` (`PalaceHandle::idle_secs`) AND (b) has `Arc::strong_count
+    /// == 1` — i.e. only the cache references it, so NO in-flight recall /
+    /// remember / dream cycle holds it. That guard is the correctness anchor:
+    /// dropping a strong_count==1 handle cannot race a live operation and its
+    /// redb flocks release synchronously, so a concurrent reopen never
+    /// double-opens the files. Victims are `pop`ed and dropped OUTSIDE the lock
+    /// (fd close / RAM free must not run under it, mirroring `remove`). A zero
+    /// `threshold` disables the sweep. Returns the number of handles evicted.
+    /// Test: `registry_tests::evict_idle_drops_idle_unreferenced_handle`,
+    /// `registry_tests::evict_idle_skips_referenced_handle`,
+    /// `registry_tests::evict_idle_skips_recently_accessed_handle`.
+    pub fn evict_idle(&self, threshold: Duration) -> usize {
+        let threshold_secs = threshold.as_secs();
+        if threshold_secs == 0 {
+            return 0;
+        }
+        let evicted: Vec<Arc<PalaceHandle>> = {
+            let mut cache = self.handles.lock();
+            // Measure strong_count against the cache's OWN reference (never a
+            // clone) so the == 1 guard is accurate; collect ids first because
+            // `iter()` borrows the cache immutably and `pop()` needs it mutably.
+            let victims: Vec<PalaceId> = cache
+                .iter()
+                .filter(|(_, h)| Arc::strong_count(h) == 1 && h.idle_secs() >= threshold_secs)
+                .map(|(id, _)| id.clone())
+                .collect();
+            victims
+                .into_iter()
+                .filter_map(|id| cache.pop(&id))
+                .collect()
+        };
+        let count = evicted.len();
+        // `evicted` drops here, outside the lock: each handle's drawer table,
+        // HNSW store, and KG close now, freeing RAM and releasing redb flocks.
+        if count > 0 {
+            tracing::info!(
+                count,
+                idle_threshold_secs = threshold_secs,
+                "idle-evict: dropped {count} idle palace handle(s); redb remains the source of truth"
+            );
+        }
+        count
+    }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::memory_core::retrieval::seed_shared_embedder_with_mock;
-    use crate::memory_core::store::{kg::KnowledgeGraph, vector::UsearchStore};
-    use tempfile::tempdir;
-
-    fn make_handle(id: &str, dir: &std::path::Path) -> PalaceHandle {
-        let vs = UsearchStore::new(dir.join(format!("{id}.usearch")), 384).unwrap();
-        let kg = KnowledgeGraph::open(&dir.join(format!("{id}.db"))).unwrap();
-        PalaceHandle::new(PalaceId::new(id), format!("Identity for {id}"), vs, kg)
-    }
-
-    #[test]
-    fn register_and_get_roundtrip() {
-        let dir = tempdir().unwrap();
-        let reg = PalaceRegistry::new();
-        reg.register(make_handle("alpha", dir.path()));
-        let h = reg.get(&PalaceId::new("alpha")).expect("registered");
-        assert_eq!(h.id.as_str(), "alpha");
-    }
-
-    /// Why (issue #1487): a default registry must open palaces as a read-only
-    /// client (preserving the snapshot fallback for CLI / stdio / tests),
-    /// while a registry built with `with_writer_intent` must open as a writer
-    /// (fail-loud on a held lock) — this is what the HTTP daemon relies on.
-    /// What: Asserts the default `open_intent()` is `ReadOnlyClient` and that
-    /// `with_writer_intent()` flips it to `Writer`.
-    /// Test: this test.
-    #[test]
-    fn with_writer_intent_sets_writer_open_intent() {
-        let default_reg = PalaceRegistry::new();
-        assert_eq!(
-            default_reg.open_intent(),
-            OpenIntent::ReadOnlyClient,
-            "default registry must open palaces read-only (snapshot fallback)"
-        );
-
-        let writer_reg = PalaceRegistry::new().with_writer_intent();
-        assert_eq!(
-            writer_reg.open_intent(),
-            OpenIntent::Writer,
-            "with_writer_intent() must mark the registry as a writer"
-        );
-    }
-
-    /// Why: Issue #180 — palace deletion must invalidate the in-memory
-    /// `PalaceRegistry` cache so a subsequent `open_palace` doesn't return
-    /// the stale handle for an on-disk-deleted palace.
-    /// What: Register a handle, set a gap entry, call `remove`, and assert
-    /// both the handle and the gap cache entry are gone.
-    /// Test: This test itself.
-    #[test]
-    fn registry_remove_clears_cached_handle() {
-        let dir = tempdir().unwrap();
-        let reg = PalaceRegistry::new();
-        let id = PalaceId::new("doomed");
-        reg.register(make_handle("doomed", dir.path()));
-        reg.set_gaps(id.clone(), Vec::new());
-        assert!(reg.get(&id).is_some());
-        assert!(reg.get_gaps(&id).is_some());
-        reg.remove(&id);
-        assert!(reg.get(&id).is_none());
-        assert!(reg.get_gaps(&id).is_none());
-        // Calling remove again is a no-op.
-        reg.remove(&id);
-    }
-
-    #[test]
-    fn registry_create_and_open() {
-        use crate::memory_core::palace::Palace;
-        use chrono::Utc;
-
-        let dir = tempdir().unwrap();
-        let data_root = dir.path();
-
-        let palace = Palace {
-            id: PalaceId::new("alpha"),
-            name: "Alpha".to_string(),
-            description: Some("test".to_string()),
-            created_at: Utc::now(),
-            data_dir: data_root.join("alpha"),
-        };
-
-        // Create through the registry.
-        {
-            let reg = PalaceRegistry::new();
-            let handle = reg
-                .create_palace(data_root, palace.clone())
-                .expect("create_palace");
-            assert_eq!(handle.id, PalaceId::new("alpha"));
-            // Persist a tiny identity directly (PalaceHandle.identity is set
-            // at open time so we mutate via PalaceStore for the test).
-            crate::memory_core::store::palace_store::PalaceStore::save_identity(
-                &handle.id,
-                "I am Alpha",
-                handle.data_dir.as_ref().expect("data_dir set"),
-            )
-            .expect("save identity");
-        }
-
-        // Drop the registry, reopen from disk.
-        let reg2 = PalaceRegistry::new();
-        let handle2 = reg2
-            .open_palace(data_root, &PalaceId::new("alpha"))
-            .expect("open_palace");
-        assert_eq!(handle2.id, PalaceId::new("alpha"));
-        assert_eq!(handle2.identity, "I am Alpha");
-
-        // list_palaces sees it too.
-        let palaces = PalaceRegistry::list_palaces(data_root).unwrap();
-        assert_eq!(palaces.len(), 1);
-        assert_eq!(palaces[0].name, "Alpha");
-    }
-
-    /// Why: Issue #52 — payloads (drawer content) must survive a process
-    /// restart. Open a registry, write a drawer with a known content string,
-    /// drop everything, reopen via `PalaceRegistry::open(path)`, and assert the
-    /// drawer content is still recoverable from the registered handle.
-    /// What: Uses `PalaceHandle::remember` (the canonical write path) so the
-    /// full persistence chain (kg drawer row + usearch vector + L1 snapshot)
-    /// is exercised, not just metadata.
-    /// Test: This test itself.
-    #[tokio::test]
-    async fn palace_payloads_survive_registry_restart() {
-        // Pre-seed mock embedder so no HuggingFace download is attempted. Issue #850.
-        seed_shared_embedder_with_mock();
-        use crate::memory_core::palace::{Palace, RoomType};
-        use chrono::Utc;
-
-        let dir = tempdir().unwrap();
-        let data_root = dir.path();
-
-        // Phase 1: create palace + write a payload, then drop everything.
-        {
-            let registry = PalaceRegistry::open(data_root).unwrap();
-            let palace = Palace {
-                id: PalaceId::new("restart-test"),
-                name: "Restart".to_string(),
-                description: None,
-                created_at: Utc::now(),
-                data_dir: data_root.join("restart-test"),
-            };
-            let handle = registry.create_palace(data_root, palace).unwrap();
-            handle
-                .remember(
-                    "the quokka is a small marsupial native to Western Australia".to_string(),
-                    RoomType::Research,
-                    vec!["wildlife".to_string()],
-                    0.7,
-                )
-                .await
-                .expect("remember persists the drawer");
-        }
-
-        // Phase 2: reopen from disk, assert the payload is still there.
-        let registry = PalaceRegistry::open(data_root).unwrap();
-        assert_eq!(
-            registry.len(),
-            1,
-            "registry should have hydrated the persisted palace"
-        );
-        let handle = registry
-            .get(&PalaceId::new("restart-test"))
-            .expect("palace should be registered after open()");
-        let drawers = handle.drawers.read().clone();
-        assert!(
-            drawers
-                .iter()
-                .any(|d| d.content.contains("quokka") && d.tags.contains(&"wildlife".to_string())),
-            "persisted drawer content must survive restart; got {drawers:?}"
-        );
-    }
-
-    #[test]
-    fn gaps_cache_round_trip() {
-        use crate::memory_core::community::KnowledgeGap;
-
-        let reg = PalaceRegistry::new();
-        let pid = PalaceId::new("gap-cache");
-
-        // Missing key returns None (not an error).
-        assert!(reg.get_gaps(&pid).is_none());
-
-        let gaps = vec![KnowledgeGap {
-            entities: vec!["alpha".to_string(), "beta".to_string()],
-            internal_density: 0.1,
-            external_bridges: 1,
-            suggested_exploration: "Explore connections between alpha and beta".to_string(),
-        }];
-        reg.set_gaps(pid.clone(), gaps.clone());
-
-        let read = reg.get_gaps(&pid).expect("cached value");
-        assert_eq!(read.len(), 1);
-        assert_eq!(read[0].entities, gaps[0].entities);
-        assert!((read[0].internal_density - 0.1).abs() < 1e-6);
-
-        reg.clear_gaps(&pid);
-        assert!(reg.get_gaps(&pid).is_none());
-    }
-
-    #[test]
-    fn list_contains_all_registered() {
-        let dir = tempdir().unwrap();
-        let reg = PalaceRegistry::new();
-        reg.register(make_handle("a", dir.path()));
-        reg.register(make_handle("b", dir.path()));
-        let ids: Vec<_> = reg.list().into_iter().map(|p| p.0).collect();
-        assert_eq!(ids.len(), 2);
-        assert!(ids.contains(&"a".to_string()));
-        assert!(ids.contains(&"b".to_string()));
-    }
-
-    /// Issue #463 — the LRU registry evicts the least-recently-used handle
-    /// when the capacity ceiling is reached, bounding resident fd usage.
-    ///
-    /// Why: With many palaces the daemon can exhaust file descriptors
-    /// (EMFILE). This test proves that the eviction policy fires correctly:
-    /// inserting a third handle into a capacity-2 registry evicts the LRU,
-    /// and the two remaining entries are the ones accessed most recently.
-    /// What: Creates a capacity-2 registry, registers "a" (LRU) then "b"
-    /// (MRU), then registers "c" — expecting "a" to be evicted. Asserts
-    /// "b" and "c" are present and "a" is gone.
-    /// Test: This test itself (issue #463 regression guard).
-    #[test]
-    fn lru_evicts_least_recently_used() {
-        let dir = tempdir().unwrap();
-        let reg = PalaceRegistry::with_max_open(2);
-
-        // Insert "a" first (will become LRU) then "b".
-        reg.register(make_handle("a", dir.path()));
-        reg.register(make_handle("b", dir.path()));
-        assert_eq!(reg.len(), 2, "two handles registered");
-
-        // "a" was inserted before "b"; inserting "c" must evict "a" (LRU).
-        reg.register(make_handle("c", dir.path()));
-        assert_eq!(reg.len(), 2, "capacity-2 registry must stay at 2");
-        assert!(
-            reg.peek(&PalaceId::new("a")).is_none(),
-            "LRU handle 'a' must have been evicted"
-        );
-        assert!(
-            reg.peek(&PalaceId::new("b")).is_some(),
-            "MRU handle 'b' must survive"
-        );
-        assert!(
-            reg.peek(&PalaceId::new("c")).is_some(),
-            "newly inserted 'c' must be present"
-        );
-    }
-
-    /// Issue #1939 — a palace requested by an aliased name resolves to the
-    /// alias target's on-disk store.
-    ///
-    /// Why: trusty-mpm pins a session to the derived `owner-repo` palace, but the
-    /// real data lives under the bare repo name. Registering the alias must make
-    /// an `open_palace` for the (non-existent) `owner-repo` name transparently
-    /// return the handle for the existing bare palace — the split-brain fix.
-    /// What: creates palace `trusty-tools`, registers alias
-    /// `bobmatnyc-trusty-tools -> trusty-tools`, then opens the alias name and
-    /// asserts the returned handle's canonical id is `trusty-tools` (not the
-    /// alias), proving both names share the one store.
-    /// Test: this test itself (issue #1939 regression guard).
-    #[test]
-    fn open_palace_follows_alias() {
-        use crate::memory_core::palace::Palace;
-        use crate::palace_alias::PalaceAliasStore;
-        use chrono::Utc;
-
-        let dir = tempdir().unwrap();
-        let data_root = dir.path();
-        let reg = PalaceRegistry::new();
-
-        // The real (bare-repo) palace on disk.
-        let bare = Palace {
-            id: PalaceId::new("trusty-tools"),
-            name: "trusty-tools".to_string(),
-            description: None,
-            created_at: Utc::now(),
-            data_dir: data_root.join("trusty-tools"),
-        };
-        reg.create_palace(data_root, bare)
-            .expect("create bare palace");
-
-        // Register the palace-level alias (owner-repo -> bare).
-        PalaceAliasStore::register_alias(data_root, "bobmatnyc-trusty-tools", "trusty-tools")
-            .expect("register alias");
-
-        // Opening the aliased (non-existent) name must resolve to the bare store.
-        let handle = reg
-            .open_palace(data_root, &PalaceId::new("bobmatnyc-trusty-tools"))
-            .expect("alias must resolve to the existing palace");
-        assert_eq!(
-            handle.id,
-            PalaceId::new("trusty-tools"),
-            "aliased open must return the canonical target handle, not the alias id"
-        );
-    }
-
-    /// Issue #1939 — a stale alias whose target does not exist must NOT redirect;
-    /// the original "metadata missing" error stands.
-    ///
-    /// Why: if an alias points at a deleted palace we must fail on the ORIGINAL
-    /// requested id rather than masking it, so operators see the name they asked
-    /// for. Requiring the target to exist on disk enforces this.
-    /// What: registers an alias to a non-existent target, opens the alias name,
-    /// and asserts the open errors (no redirect happened).
-    /// Test: this test itself.
-    #[test]
-    fn open_palace_ignores_alias_when_target_missing() {
-        use crate::palace_alias::PalaceAliasStore;
-
-        let dir = tempdir().unwrap();
-        let data_root = dir.path();
-        let reg = PalaceRegistry::new();
-
-        PalaceAliasStore::register_alias(data_root, "ghost", "does-not-exist")
-            .expect("register alias");
-
-        assert!(
-            reg.open_palace(data_root, &PalaceId::new("ghost")).is_err(),
-            "alias to a missing target must not redirect"
-        );
-    }
-
-    /// Issue #1939 — an alias must never shadow a real palace of the same name.
-    ///
-    /// Why: if both an alias entry AND a real palace exist under the same name,
-    /// the real palace wins (aliases only fill the "missing palace" gap).
-    /// What: creates palace `dup`, registers a (mischievous) alias
-    /// `dup -> other`, and asserts `open_palace("dup")` returns `dup` itself.
-    /// Test: this test itself.
-    #[test]
-    fn open_palace_prefers_real_palace_over_alias() {
-        use crate::memory_core::palace::Palace;
-        use crate::palace_alias::PalaceAliasStore;
-        use chrono::Utc;
-
-        let dir = tempdir().unwrap();
-        let data_root = dir.path();
-        let reg = PalaceRegistry::new();
-
-        for id in ["dup", "other"] {
-            let p = Palace {
-                id: PalaceId::new(id),
-                name: id.to_string(),
-                description: None,
-                created_at: Utc::now(),
-                data_dir: data_root.join(id),
-            };
-            reg.create_palace(data_root, p).expect("create palace");
-        }
-        PalaceAliasStore::register_alias(data_root, "dup", "other").expect("register alias");
-
-        let handle = reg
-            .open_palace(data_root, &PalaceId::new("dup"))
-            .expect("real palace opens");
-        assert_eq!(
-            handle.id,
-            PalaceId::new("dup"),
-            "a real palace must win over an alias of the same name"
-        );
-    }
-
-    /// Issue #463 — a `get` call promotes the accessed handle to MRU,
-    /// protecting it from immediate eviction.
-    ///
-    /// Why: LRU eviction must respect actual access order, not insertion
-    /// order. A handle that was inserted first but subsequently accessed
-    /// should survive longer than one that was inserted more recently but
-    /// never accessed.
-    /// What: Creates a capacity-2 registry, inserts "a" then "b", accesses
-    /// "a" (promoting it to MRU), inserts "c" — expects "b" to be evicted
-    /// instead of "a".
-    /// Test: This test itself (issue #463 regression guard).
-    #[test]
-    fn lru_get_promotes_to_mru() {
-        let dir = tempdir().unwrap();
-        let reg = PalaceRegistry::with_max_open(2);
-
-        reg.register(make_handle("a", dir.path()));
-        reg.register(make_handle("b", dir.path()));
-
-        // Access "a" — promotes it to MRU; "b" is now LRU.
-        let _ = reg.get(&PalaceId::new("a"));
-
-        // Inserting "c" must evict "b" (the new LRU), not "a".
-        reg.register(make_handle("c", dir.path()));
-        assert_eq!(reg.len(), 2);
-        assert!(
-            reg.peek(&PalaceId::new("b")).is_none(),
-            "'b' must be evicted — it was LRU after 'a' was promoted"
-        );
-        assert!(
-            reg.peek(&PalaceId::new("a")).is_some(),
-            "'a' must survive — it was promoted to MRU by get()"
-        );
-        assert!(
-            reg.peek(&PalaceId::new("c")).is_some(),
-            "'c' must be present"
-        );
-    }
-
-    /// Issue #463 — an evicted palace handle is transparently reopened on
-    /// the next `open_palace` call.
-    ///
-    /// Why: Eviction closes fds but must not lose data. The handle is only
-    /// in-memory state; the authoritative store is always on disk. This test
-    /// proves that after an eviction the palace can be reopened from disk
-    /// without error and its metadata is intact.
-    /// What: Creates a capacity-1 registry, creates palace "a", then
-    /// registers "b" (evicting "a"), then calls `open_palace` for "a"
-    /// (must reopen from disk successfully) and asserts the id matches.
-    /// Test: This test itself (issue #463 regression guard).
-    #[test]
-    fn lru_evicted_handle_reopens() {
-        use crate::memory_core::palace::Palace;
-        use chrono::Utc;
-
-        let dir = tempdir().unwrap();
-        let data_root = dir.path();
-        let reg = PalaceRegistry::with_max_open(1);
-
-        // Create and persist "alpha" on disk.
-        let palace_a = Palace {
-            id: PalaceId::new("alpha"),
-            name: "Alpha".to_string(),
-            description: None,
-            created_at: Utc::now(),
-            data_dir: data_root.join("alpha"),
-        };
-        reg.create_palace(data_root, palace_a)
-            .expect("create alpha");
-        assert_eq!(reg.len(), 1, "'alpha' registered");
-
-        // Register "beta" directly — evicts "alpha" from the capacity-1 cache.
-        reg.register(make_handle("beta", data_root));
-        assert_eq!(reg.len(), 1, "capacity-1: only 'beta' remains");
-        assert!(
-            reg.peek(&PalaceId::new("alpha")).is_none(),
-            "'alpha' must have been evicted"
-        );
-
-        // Reopening "alpha" from disk must succeed.
-        let reopened = reg
-            .open_palace(data_root, &PalaceId::new("alpha"))
-            .expect("open_palace after eviction must succeed");
-        assert_eq!(reopened.id, PalaceId::new("alpha"), "reopened id matches");
-        assert!(
-            reg.peek(&PalaceId::new("alpha")).is_some(),
-            "'alpha' must be back in the cache after reopen"
-        );
-    }
-}
+#[path = "registry_tests.rs"]
+mod tests;

--- a/crates/trusty-common/src/memory_core/registry_tests.rs
+++ b/crates/trusty-common/src/memory_core/registry_tests.rs
@@ -1,0 +1,692 @@
+use super::*;
+use crate::memory_core::retrieval::seed_shared_embedder_with_mock;
+use crate::memory_core::store::{kg::KnowledgeGraph, vector::UsearchStore};
+use tempfile::tempdir;
+
+fn make_handle(id: &str, dir: &std::path::Path) -> PalaceHandle {
+    let vs = UsearchStore::new(dir.join(format!("{id}.usearch")), 384).unwrap();
+    let kg = KnowledgeGraph::open(&dir.join(format!("{id}.db"))).unwrap();
+    PalaceHandle::new(PalaceId::new(id), format!("Identity for {id}"), vs, kg)
+}
+
+#[test]
+fn register_and_get_roundtrip() {
+    let dir = tempdir().unwrap();
+    let reg = PalaceRegistry::new();
+    reg.register(make_handle("alpha", dir.path()));
+    let h = reg.get(&PalaceId::new("alpha")).expect("registered");
+    assert_eq!(h.id.as_str(), "alpha");
+}
+
+/// Why (issue #1487): a default registry must open palaces as a read-only
+/// client (preserving the snapshot fallback for CLI / stdio / tests),
+/// while a registry built with `with_writer_intent` must open as a writer
+/// (fail-loud on a held lock) — this is what the HTTP daemon relies on.
+/// What: Asserts the default `open_intent()` is `ReadOnlyClient` and that
+/// `with_writer_intent()` flips it to `Writer`.
+/// Test: this test.
+#[test]
+fn with_writer_intent_sets_writer_open_intent() {
+    let default_reg = PalaceRegistry::new();
+    assert_eq!(
+        default_reg.open_intent(),
+        OpenIntent::ReadOnlyClient,
+        "default registry must open palaces read-only (snapshot fallback)"
+    );
+
+    let writer_reg = PalaceRegistry::new().with_writer_intent();
+    assert_eq!(
+        writer_reg.open_intent(),
+        OpenIntent::Writer,
+        "with_writer_intent() must mark the registry as a writer"
+    );
+}
+
+/// Why: Issue #180 — palace deletion must invalidate the in-memory
+/// `PalaceRegistry` cache so a subsequent `open_palace` doesn't return
+/// the stale handle for an on-disk-deleted palace.
+/// What: Register a handle, set a gap entry, call `remove`, and assert
+/// both the handle and the gap cache entry are gone.
+/// Test: This test itself.
+#[test]
+fn registry_remove_clears_cached_handle() {
+    let dir = tempdir().unwrap();
+    let reg = PalaceRegistry::new();
+    let id = PalaceId::new("doomed");
+    reg.register(make_handle("doomed", dir.path()));
+    reg.set_gaps(id.clone(), Vec::new());
+    assert!(reg.get(&id).is_some());
+    assert!(reg.get_gaps(&id).is_some());
+    reg.remove(&id);
+    assert!(reg.get(&id).is_none());
+    assert!(reg.get_gaps(&id).is_none());
+    // Calling remove again is a no-op.
+    reg.remove(&id);
+}
+
+#[test]
+fn registry_create_and_open() {
+    use crate::memory_core::palace::Palace;
+    use chrono::Utc;
+
+    let dir = tempdir().unwrap();
+    let data_root = dir.path();
+
+    let palace = Palace {
+        id: PalaceId::new("alpha"),
+        name: "Alpha".to_string(),
+        description: Some("test".to_string()),
+        created_at: Utc::now(),
+        data_dir: data_root.join("alpha"),
+    };
+
+    // Create through the registry.
+    {
+        let reg = PalaceRegistry::new();
+        let handle = reg
+            .create_palace(data_root, palace.clone())
+            .expect("create_palace");
+        assert_eq!(handle.id, PalaceId::new("alpha"));
+        // Persist a tiny identity directly (PalaceHandle.identity is set
+        // at open time so we mutate via PalaceStore for the test).
+        crate::memory_core::store::palace_store::PalaceStore::save_identity(
+            &handle.id,
+            "I am Alpha",
+            handle.data_dir.as_ref().expect("data_dir set"),
+        )
+        .expect("save identity");
+    }
+
+    // Drop the registry, reopen from disk.
+    let reg2 = PalaceRegistry::new();
+    let handle2 = reg2
+        .open_palace(data_root, &PalaceId::new("alpha"))
+        .expect("open_palace");
+    assert_eq!(handle2.id, PalaceId::new("alpha"));
+    assert_eq!(handle2.identity, "I am Alpha");
+
+    // list_palaces sees it too.
+    let palaces = PalaceRegistry::list_palaces(data_root).unwrap();
+    assert_eq!(palaces.len(), 1);
+    assert_eq!(palaces[0].name, "Alpha");
+}
+
+/// Why: Issue #52 — payloads (drawer content) must survive a process
+/// restart. Open a registry, write a drawer with a known content string,
+/// drop everything, reopen via `PalaceRegistry::open(path)`, and assert the
+/// drawer content is still recoverable from the registered handle.
+/// What: Uses `PalaceHandle::remember` (the canonical write path) so the
+/// full persistence chain (kg drawer row + usearch vector + L1 snapshot)
+/// is exercised, not just metadata.
+/// Test: This test itself.
+#[tokio::test]
+async fn palace_payloads_survive_registry_restart() {
+    // Pre-seed mock embedder so no HuggingFace download is attempted. Issue #850.
+    seed_shared_embedder_with_mock();
+    use crate::memory_core::palace::{Palace, RoomType};
+    use chrono::Utc;
+
+    let dir = tempdir().unwrap();
+    let data_root = dir.path();
+
+    // Phase 1: create palace + write a payload, then drop everything.
+    {
+        let registry = PalaceRegistry::open(data_root).unwrap();
+        let palace = Palace {
+            id: PalaceId::new("restart-test"),
+            name: "Restart".to_string(),
+            description: None,
+            created_at: Utc::now(),
+            data_dir: data_root.join("restart-test"),
+        };
+        let handle = registry.create_palace(data_root, palace).unwrap();
+        handle
+            .remember(
+                "the quokka is a small marsupial native to Western Australia".to_string(),
+                RoomType::Research,
+                vec!["wildlife".to_string()],
+                0.7,
+            )
+            .await
+            .expect("remember persists the drawer");
+    }
+
+    // Phase 2: reopen from disk, assert the payload is still there.
+    let registry = PalaceRegistry::open(data_root).unwrap();
+    assert_eq!(
+        registry.len(),
+        1,
+        "registry should have hydrated the persisted palace"
+    );
+    let handle = registry
+        .get(&PalaceId::new("restart-test"))
+        .expect("palace should be registered after open()");
+    let drawers = handle.drawers.read().clone();
+    assert!(
+        drawers
+            .iter()
+            .any(|d| d.content.contains("quokka") && d.tags.contains(&"wildlife".to_string())),
+        "persisted drawer content must survive restart; got {drawers:?}"
+    );
+}
+
+#[test]
+fn gaps_cache_round_trip() {
+    use crate::memory_core::community::KnowledgeGap;
+
+    let reg = PalaceRegistry::new();
+    let pid = PalaceId::new("gap-cache");
+
+    // Missing key returns None (not an error).
+    assert!(reg.get_gaps(&pid).is_none());
+
+    let gaps = vec![KnowledgeGap {
+        entities: vec!["alpha".to_string(), "beta".to_string()],
+        internal_density: 0.1,
+        external_bridges: 1,
+        suggested_exploration: "Explore connections between alpha and beta".to_string(),
+    }];
+    reg.set_gaps(pid.clone(), gaps.clone());
+
+    let read = reg.get_gaps(&pid).expect("cached value");
+    assert_eq!(read.len(), 1);
+    assert_eq!(read[0].entities, gaps[0].entities);
+    assert!((read[0].internal_density - 0.1).abs() < 1e-6);
+
+    reg.clear_gaps(&pid);
+    assert!(reg.get_gaps(&pid).is_none());
+}
+
+#[test]
+fn list_contains_all_registered() {
+    let dir = tempdir().unwrap();
+    let reg = PalaceRegistry::new();
+    reg.register(make_handle("a", dir.path()));
+    reg.register(make_handle("b", dir.path()));
+    let ids: Vec<_> = reg.list().into_iter().map(|p| p.0).collect();
+    assert_eq!(ids.len(), 2);
+    assert!(ids.contains(&"a".to_string()));
+    assert!(ids.contains(&"b".to_string()));
+}
+
+/// Issue #463 — the LRU registry evicts the least-recently-used handle
+/// when the capacity ceiling is reached, bounding resident fd usage.
+///
+/// Why: With many palaces the daemon can exhaust file descriptors
+/// (EMFILE). This test proves that the eviction policy fires correctly:
+/// inserting a third handle into a capacity-2 registry evicts the LRU,
+/// and the two remaining entries are the ones accessed most recently.
+/// What: Creates a capacity-2 registry, registers "a" (LRU) then "b"
+/// (MRU), then registers "c" — expecting "a" to be evicted. Asserts
+/// "b" and "c" are present and "a" is gone.
+/// Test: This test itself (issue #463 regression guard).
+#[test]
+fn lru_evicts_least_recently_used() {
+    let dir = tempdir().unwrap();
+    let reg = PalaceRegistry::with_max_open(2);
+
+    // Insert "a" first (will become LRU) then "b".
+    reg.register(make_handle("a", dir.path()));
+    reg.register(make_handle("b", dir.path()));
+    assert_eq!(reg.len(), 2, "two handles registered");
+
+    // "a" was inserted before "b"; inserting "c" must evict "a" (LRU).
+    reg.register(make_handle("c", dir.path()));
+    assert_eq!(reg.len(), 2, "capacity-2 registry must stay at 2");
+    assert!(
+        reg.peek(&PalaceId::new("a")).is_none(),
+        "LRU handle 'a' must have been evicted"
+    );
+    assert!(
+        reg.peek(&PalaceId::new("b")).is_some(),
+        "MRU handle 'b' must survive"
+    );
+    assert!(
+        reg.peek(&PalaceId::new("c")).is_some(),
+        "newly inserted 'c' must be present"
+    );
+}
+
+/// Issue #1939 — a palace requested by an aliased name resolves to the
+/// alias target's on-disk store.
+///
+/// Why: trusty-mpm pins a session to the derived `owner-repo` palace, but the
+/// real data lives under the bare repo name. Registering the alias must make
+/// an `open_palace` for the (non-existent) `owner-repo` name transparently
+/// return the handle for the existing bare palace — the split-brain fix.
+/// What: creates palace `trusty-tools`, registers alias
+/// `bobmatnyc-trusty-tools -> trusty-tools`, then opens the alias name and
+/// asserts the returned handle's canonical id is `trusty-tools` (not the
+/// alias), proving both names share the one store.
+/// Test: this test itself (issue #1939 regression guard).
+#[test]
+fn open_palace_follows_alias() {
+    use crate::memory_core::palace::Palace;
+    use crate::palace_alias::PalaceAliasStore;
+    use chrono::Utc;
+
+    let dir = tempdir().unwrap();
+    let data_root = dir.path();
+    let reg = PalaceRegistry::new();
+
+    // The real (bare-repo) palace on disk.
+    let bare = Palace {
+        id: PalaceId::new("trusty-tools"),
+        name: "trusty-tools".to_string(),
+        description: None,
+        created_at: Utc::now(),
+        data_dir: data_root.join("trusty-tools"),
+    };
+    reg.create_palace(data_root, bare)
+        .expect("create bare palace");
+
+    // Register the palace-level alias (owner-repo -> bare).
+    PalaceAliasStore::register_alias(data_root, "bobmatnyc-trusty-tools", "trusty-tools")
+        .expect("register alias");
+
+    // Opening the aliased (non-existent) name must resolve to the bare store.
+    let handle = reg
+        .open_palace(data_root, &PalaceId::new("bobmatnyc-trusty-tools"))
+        .expect("alias must resolve to the existing palace");
+    assert_eq!(
+        handle.id,
+        PalaceId::new("trusty-tools"),
+        "aliased open must return the canonical target handle, not the alias id"
+    );
+}
+
+/// Issue #1939 — a stale alias whose target does not exist must NOT redirect;
+/// the original "metadata missing" error stands.
+///
+/// Why: if an alias points at a deleted palace we must fail on the ORIGINAL
+/// requested id rather than masking it, so operators see the name they asked
+/// for. Requiring the target to exist on disk enforces this.
+/// What: registers an alias to a non-existent target, opens the alias name,
+/// and asserts the open errors (no redirect happened).
+/// Test: this test itself.
+#[test]
+fn open_palace_ignores_alias_when_target_missing() {
+    use crate::palace_alias::PalaceAliasStore;
+
+    let dir = tempdir().unwrap();
+    let data_root = dir.path();
+    let reg = PalaceRegistry::new();
+
+    PalaceAliasStore::register_alias(data_root, "ghost", "does-not-exist").expect("register alias");
+
+    assert!(
+        reg.open_palace(data_root, &PalaceId::new("ghost")).is_err(),
+        "alias to a missing target must not redirect"
+    );
+}
+
+/// Issue #1939 — an alias must never shadow a real palace of the same name.
+///
+/// Why: if both an alias entry AND a real palace exist under the same name,
+/// the real palace wins (aliases only fill the "missing palace" gap).
+/// What: creates palace `dup`, registers a (mischievous) alias
+/// `dup -> other`, and asserts `open_palace("dup")` returns `dup` itself.
+/// Test: this test itself.
+#[test]
+fn open_palace_prefers_real_palace_over_alias() {
+    use crate::memory_core::palace::Palace;
+    use crate::palace_alias::PalaceAliasStore;
+    use chrono::Utc;
+
+    let dir = tempdir().unwrap();
+    let data_root = dir.path();
+    let reg = PalaceRegistry::new();
+
+    for id in ["dup", "other"] {
+        let p = Palace {
+            id: PalaceId::new(id),
+            name: id.to_string(),
+            description: None,
+            created_at: Utc::now(),
+            data_dir: data_root.join(id),
+        };
+        reg.create_palace(data_root, p).expect("create palace");
+    }
+    PalaceAliasStore::register_alias(data_root, "dup", "other").expect("register alias");
+
+    let handle = reg
+        .open_palace(data_root, &PalaceId::new("dup"))
+        .expect("real palace opens");
+    assert_eq!(
+        handle.id,
+        PalaceId::new("dup"),
+        "a real palace must win over an alias of the same name"
+    );
+}
+
+/// Issue #463 — a `get` call promotes the accessed handle to MRU,
+/// protecting it from immediate eviction.
+///
+/// Why: LRU eviction must respect actual access order, not insertion
+/// order. A handle that was inserted first but subsequently accessed
+/// should survive longer than one that was inserted more recently but
+/// never accessed.
+/// What: Creates a capacity-2 registry, inserts "a" then "b", accesses
+/// "a" (promoting it to MRU), inserts "c" — expects "b" to be evicted
+/// instead of "a".
+/// Test: This test itself (issue #463 regression guard).
+#[test]
+fn lru_get_promotes_to_mru() {
+    let dir = tempdir().unwrap();
+    let reg = PalaceRegistry::with_max_open(2);
+
+    reg.register(make_handle("a", dir.path()));
+    reg.register(make_handle("b", dir.path()));
+
+    // Access "a" — promotes it to MRU; "b" is now LRU.
+    let _ = reg.get(&PalaceId::new("a"));
+
+    // Inserting "c" must evict "b" (the new LRU), not "a".
+    reg.register(make_handle("c", dir.path()));
+    assert_eq!(reg.len(), 2);
+    assert!(
+        reg.peek(&PalaceId::new("b")).is_none(),
+        "'b' must be evicted — it was LRU after 'a' was promoted"
+    );
+    assert!(
+        reg.peek(&PalaceId::new("a")).is_some(),
+        "'a' must survive — it was promoted to MRU by get()"
+    );
+    assert!(
+        reg.peek(&PalaceId::new("c")).is_some(),
+        "'c' must be present"
+    );
+}
+
+/// Issue #463 — an evicted palace handle is transparently reopened on
+/// the next `open_palace` call.
+///
+/// Why: Eviction closes fds but must not lose data. The handle is only
+/// in-memory state; the authoritative store is always on disk. This test
+/// proves that after an eviction the palace can be reopened from disk
+/// without error and its metadata is intact.
+/// What: Creates a capacity-1 registry, creates palace "a", then
+/// registers "b" (evicting "a"), then calls `open_palace` for "a"
+/// (must reopen from disk successfully) and asserts the id matches.
+/// Test: This test itself (issue #463 regression guard).
+#[test]
+fn lru_evicted_handle_reopens() {
+    use crate::memory_core::palace::Palace;
+    use chrono::Utc;
+
+    let dir = tempdir().unwrap();
+    let data_root = dir.path();
+    let reg = PalaceRegistry::with_max_open(1);
+
+    // Create and persist "alpha" on disk.
+    let palace_a = Palace {
+        id: PalaceId::new("alpha"),
+        name: "Alpha".to_string(),
+        description: None,
+        created_at: Utc::now(),
+        data_dir: data_root.join("alpha"),
+    };
+    reg.create_palace(data_root, palace_a)
+        .expect("create alpha");
+    assert_eq!(reg.len(), 1, "'alpha' registered");
+
+    // Register "beta" directly — evicts "alpha" from the capacity-1 cache.
+    reg.register(make_handle("beta", data_root));
+    assert_eq!(reg.len(), 1, "capacity-1: only 'beta' remains");
+    assert!(
+        reg.peek(&PalaceId::new("alpha")).is_none(),
+        "'alpha' must have been evicted"
+    );
+
+    // Reopening "alpha" from disk must succeed.
+    let reopened = reg
+        .open_palace(data_root, &PalaceId::new("alpha"))
+        .expect("open_palace after eviction must succeed");
+    assert_eq!(reopened.id, PalaceId::new("alpha"), "reopened id matches");
+    assert!(
+        reg.peek(&PalaceId::new("alpha")).is_some(),
+        "'alpha' must be back in the cache after reopen"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Idle-to-disk eviction + configurable max-open (idle-evict feature)
+// ---------------------------------------------------------------------------
+
+/// Idle-to-disk config knob (Part 3): the LRU open-handle cap honours
+/// `TRUSTY_MEMORY_MAX_OPEN_PALACES`.
+///
+/// Why: operators tune resident-palace RAM via the env var; `from_env` must
+/// actually apply it.
+/// What: sets the env to 2, builds `from_env()`, registers three handles, and
+/// asserts the cap held the registry at 2 (LRU evicted the oldest). Restores
+/// the env immediately after construction. `#[serial]` guards the env mutation
+/// from parallel tests.
+/// Test: this test.
+#[test]
+#[serial_test::serial]
+fn from_env_respects_max_open_palaces_env() {
+    let dir = tempdir().unwrap();
+    // SAFETY: #[serial] ensures no other thread reads/writes this env var
+    // concurrently; removed immediately after `from_env` reads it.
+    unsafe {
+        std::env::set_var(MAX_OPEN_PALACES_ENV, "2");
+    }
+    let reg = PalaceRegistry::from_env();
+    unsafe {
+        std::env::remove_var(MAX_OPEN_PALACES_ENV);
+    }
+
+    reg.register(make_handle("a", dir.path()));
+    reg.register(make_handle("b", dir.path()));
+    reg.register(make_handle("c", dir.path()));
+    assert_eq!(
+        reg.len(),
+        2,
+        "from_env cap=2 must bound the registry to 2 handles"
+    );
+}
+
+/// Unset / invalid env falls back to the default cap.
+///
+/// Why: a misconfigured or absent env var must not silently drop the cap to an
+/// unusable value.
+/// What: with the env removed, `max_open_palaces_from_env` returns the default.
+/// Test: this test.
+#[test]
+#[serial_test::serial]
+fn max_open_palaces_from_env_defaults_when_unset() {
+    unsafe {
+        std::env::remove_var(MAX_OPEN_PALACES_ENV);
+    }
+    assert_eq!(max_open_palaces_from_env(), DEFAULT_MAX_OPEN_PALACES);
+}
+
+/// Idle-to-disk (Part 2): `evict_idle` drops a handle idle past the threshold
+/// AND referenced only by the cache.
+///
+/// Why: the core "idle to disk" behaviour — reclaim a cold palace's heavy RAM.
+/// What: registers a handle with `last_accessed` forced into the past, evicts
+/// with a 1 s threshold, and asserts it left the cache.
+/// Test: this test.
+#[test]
+fn evict_idle_drops_idle_unreferenced_handle() {
+    let dir = tempdir().unwrap();
+    let reg = PalaceRegistry::new();
+    let h = make_handle("idle", dir.path());
+    h.last_accessed
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+    reg.register(h);
+    assert_eq!(reg.len(), 1);
+
+    let evicted = reg.evict_idle(std::time::Duration::from_secs(1));
+    assert_eq!(evicted, 1, "an idle, unreferenced handle must be evicted");
+    assert!(
+        reg.get(&PalaceId::new("idle")).is_none(),
+        "evicted handle must be gone from the cache"
+    );
+}
+
+/// `evict_idle` must NOT drop a handle a live operation still references
+/// (`strong_count > 1`), even when it is idle.
+///
+/// Why: this is the correctness anchor — dropping an in-use handle could race
+/// the in-flight op and (under Writer intent) break the redb flock. The
+/// strong_count==1 guard prevents it.
+/// What: registers an idle handle, holds a second `Arc` clone (simulating an
+/// in-flight recall), and asserts `evict_idle` skips it.
+/// Test: this test.
+#[test]
+fn evict_idle_skips_referenced_handle() {
+    let dir = tempdir().unwrap();
+    let reg = PalaceRegistry::new();
+    let h = make_handle("busy", dir.path());
+    h.last_accessed
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+    reg.register(h);
+    // Simulate an in-flight operation holding a clone of the handle.
+    let _in_flight = reg.get(&PalaceId::new("busy")).expect("registered");
+    let evicted = reg.evict_idle(std::time::Duration::from_secs(1));
+    assert_eq!(evicted, 0, "a referenced handle must be skipped");
+    assert_eq!(reg.len(), 1);
+}
+
+/// `evict_idle` must skip a handle accessed within the TTL window and treat a
+/// zero threshold as disabled.
+///
+/// Why: only genuinely-idle palaces should be reclaimed; a zero TTL is the
+/// documented "disabled" value.
+/// What: a fresh handle (last_accessed == now) survives a 1 h threshold, and a
+/// zero threshold is a no-op even for an ancient handle.
+/// Test: this test.
+#[test]
+fn evict_idle_skips_recent_and_respects_zero_threshold() {
+    let dir = tempdir().unwrap();
+    let reg = PalaceRegistry::new();
+    reg.register(make_handle("fresh", dir.path()));
+    assert_eq!(
+        reg.evict_idle(std::time::Duration::from_secs(3600)),
+        0,
+        "a recently-accessed handle must not be evicted"
+    );
+
+    let h = make_handle("ancient", dir.path());
+    h.last_accessed
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+    reg.register(h);
+    assert_eq!(
+        reg.evict_idle(std::time::Duration::from_secs(0)),
+        0,
+        "zero threshold disables eviction"
+    );
+    assert_eq!(reg.len(), 2, "no handle should have been evicted");
+}
+
+/// `PalaceHandle::touch` must be a no-op while a dream cycle holds
+/// `is_compacting`.
+///
+/// Why: internal consolidation calls the same remember/forget methods users
+/// do; stamping `last_accessed` there would keep an idle-but-dreaming palace
+/// resident forever, defeating idle-evict.
+/// What: forces the idle clock to 0, sets `is_compacting`, calls `touch`, and
+/// asserts the clock did not advance; then clears the flag and confirms `touch`
+/// advances it.
+/// Test: this test.
+#[test]
+fn touch_suppressed_during_compaction() {
+    use std::sync::atomic::Ordering::Relaxed;
+    let dir = tempdir().unwrap();
+    let h = make_handle("dreaming", dir.path());
+    h.last_accessed.store(0, Relaxed);
+    h.is_compacting.store(true, Relaxed);
+    h.touch();
+    assert_eq!(
+        h.last_accessed.load(Relaxed),
+        0,
+        "touch during compaction must not advance the idle clock"
+    );
+    h.is_compacting.store(false, Relaxed);
+    h.touch();
+    assert!(
+        h.last_accessed.load(Relaxed) > 0,
+        "touch after compaction must advance the idle clock"
+    );
+}
+
+/// Idle-to-disk rehydrate correctness (Part 2): after an idle-evict drops a
+/// palace, the next access transparently re-opens it from redb and recall
+/// returns the same drawer content — no data loss.
+///
+/// Why: eviction reclaims RAM only if reopening is lossless; this is the
+/// end-to-end proof that "idle to disk" round-trips through the durable store.
+/// What: creates a palace, remembers a drawer, snapshots the recall result,
+/// forces the palace idle and drops the handle so `strong_count == 1`, evicts
+/// it, then reopens via `open_palace` and asserts recall returns byte-for-byte
+/// the same drawer contents as before eviction.
+/// Test: this test.
+#[tokio::test]
+async fn evict_idle_then_reopen_preserves_recall() {
+    seed_shared_embedder_with_mock();
+    use crate::memory_core::palace::{Palace, RoomType};
+    use crate::memory_core::retrieval::recall_with_default_embedder;
+    use chrono::Utc;
+
+    let dir = tempdir().unwrap();
+    let data_root = dir.path();
+    let reg = PalaceRegistry::new();
+    let palace = Palace {
+        id: PalaceId::new("evict-reopen"),
+        name: "Evict".to_string(),
+        description: None,
+        created_at: Utc::now(),
+        data_dir: data_root.join("evict-reopen"),
+    };
+    let handle = reg.create_palace(data_root, palace).unwrap();
+    handle
+        .remember(
+            "the quokka is a small marsupial native to Western Australia".to_string(),
+            RoomType::Research,
+            vec!["wildlife".to_string()],
+            0.7,
+        )
+        .await
+        .expect("remember persists the drawer");
+
+    // Snapshot recall BEFORE eviction.
+    let before = recall_with_default_embedder(&handle, "quokka", 5)
+        .await
+        .expect("pre-evict recall");
+    let before_contents: Vec<String> = before.iter().map(|r| r.drawer.content.clone()).collect();
+    assert!(
+        before_contents.iter().any(|c| c.contains("quokka")),
+        "sanity: pre-evict recall must find the drawer"
+    );
+
+    // Make the palace idle and release our reference so strong_count == 1.
+    handle
+        .last_accessed
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+    let id = handle.id.clone();
+    drop(handle);
+
+    // Idle-evict drops the whole handle — heavy fields freed.
+    let evicted = reg.evict_idle(std::time::Duration::from_secs(1));
+    assert_eq!(evicted, 1, "idle palace must be evicted");
+    assert!(
+        reg.get(&id).is_none(),
+        "palace must be cold (absent from the registry) after eviction"
+    );
+
+    // Next access lazily rehydrates from the durable redb store.
+    let reopened = reg
+        .open_palace(data_root, &id)
+        .expect("reopen from disk after idle eviction");
+    let after = recall_with_default_embedder(&reopened, "quokka", 5)
+        .await
+        .expect("post-reopen recall");
+    let after_contents: Vec<String> = after.iter().map(|r| r.drawer.content.clone()).collect();
+    assert_eq!(
+        before_contents, after_contents,
+        "recall after idle-evict + rehydrate must match pre-eviction results"
+    );
+}

--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -25,10 +25,25 @@ use anyhow::{Context, Result};
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use uuid::Uuid;
 
 const RECALL_LOG_FILENAME: &str = "recall.db";
+
+/// Current unix time in whole seconds, saturating to 0 before the epoch.
+///
+/// Why: `last_accessed` idle tracking (issue: idle-to-disk eviction) needs a
+/// cheap, monotonic-enough wall clock to stamp every recall / remember. Whole
+/// seconds are ample granularity for a multi-minute idle TTL and keep the
+/// stamp in a single lock-free `AtomicU64`.
+/// What: reads `SystemTime::now()` as seconds since the unix epoch.
+/// Test: exercised indirectly by `idle_evict` tests via `PalaceHandle::touch`.
+fn now_epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
 
 /// Per-palace handle. Cheap to clone (all heavyweight state lives behind `Arc`).
 ///
@@ -111,6 +126,23 @@ pub struct PalaceHandle {
     /// rather than `parking_lot::Mutex` (which would deadlock the runtime).
     /// Test: `remember_concurrent_does_not_lose_writes` in this module.
     pub write_mutex: Arc<tokio::sync::Mutex<()>>,
+    /// Unix-seconds timestamp of the last genuine user access (recall / remember
+    /// / forget). Drives idle-to-disk eviction.
+    ///
+    /// Why: a long-lived daemon hydrates every palace's drawer table, HNSW
+    /// graph, and KG adjacency into RAM (~90 MB each) and — even with the LRU
+    /// cap — keeps up to `max_open` palaces resident regardless of whether
+    /// anyone is querying them, driving idle RSS to multiple GB. The
+    /// idle-evict ticker reads this stamp to drop the entire handle (freeing
+    /// all heavy fields) for palaces idle past `TRUSTY_MEMORY_IDLE_EVICT_SECS`;
+    /// the durable redb store is the source of truth and the next access
+    /// transparently re-opens from disk (`PalaceRegistry::open_palace`).
+    /// What: `Arc<AtomicU64>` initialised to "now" at open so a freshly-opened
+    /// palace is never immediately evicted. Updated by [`PalaceHandle::touch`]
+    /// on every user recall/remember/forget; suppressed during dream cycles
+    /// (see `touch`) so internal consolidation never resets the idle clock.
+    /// Test: `registry_tests::evict_idle_drops_idle_unreferenced_handle`.
+    pub last_accessed: Arc<AtomicU64>,
 }
 
 impl PalaceHandle {
@@ -182,7 +214,39 @@ impl PalaceHandle {
             closets: Arc::new(RwLock::new(HashMap::new())),
             is_compacting: Arc::new(AtomicBool::new(false)),
             write_mutex: Arc::new(tokio::sync::Mutex::new(())),
+            last_accessed: Arc::new(AtomicU64::new(now_epoch_secs())),
         }
+    }
+
+    /// Record a genuine user access, resetting the idle clock.
+    ///
+    /// Why: idle-to-disk eviction must fire only for palaces no *user* has
+    /// touched in the TTL window. Internal dream-cycle consolidation (dedup /
+    /// prune / semantic passes) calls the same `remember`/`forget` methods, so
+    /// stamping unconditionally there would keep an actively-dreaming-but-idle
+    /// palace resident forever. The dream cycle sets `is_compacting` for its
+    /// whole duration (via `CompactionGuard`), so gating on that flag cleanly
+    /// suppresses maintenance-driven touches without threading a flag through
+    /// every pass.
+    /// What: stores `now` into `last_accessed` unless a dream cycle is in
+    /// flight (`is_compacting`), in which case it is a no-op.
+    /// Test: `registry_tests::touch_suppressed_during_compaction`.
+    pub fn touch(&self) {
+        if self.is_compacting.load(Ordering::Relaxed) {
+            return;
+        }
+        self.last_accessed
+            .store(now_epoch_secs(), Ordering::Relaxed);
+    }
+
+    /// Seconds since the last genuine user access.
+    ///
+    /// Why: the idle-evict ticker compares this against its TTL threshold to
+    /// decide which handles to drop.
+    /// What: `now - last_accessed`, saturating at 0 (clock skew safe).
+    /// Test: `registry_tests::evict_idle_drops_idle_unreferenced_handle`.
+    pub fn idle_secs(&self) -> u64 {
+        now_epoch_secs().saturating_sub(self.last_accessed.load(Ordering::Relaxed))
     }
 
     /// Open a palace from disk, hydrating identity.txt, the L1 snapshot, the
@@ -326,6 +390,7 @@ impl PalaceHandle {
             closets: Arc::new(RwLock::new(HashMap::new())),
             is_compacting: Arc::new(AtomicBool::new(false)),
             write_mutex: Arc::new(tokio::sync::Mutex::new(())),
+            last_accessed: Arc::new(AtomicU64::new(now_epoch_secs())),
         };
         Ok(Arc::new(handle))
     }
@@ -442,6 +507,11 @@ impl PalaceHandle {
         importance: f32,
         opts: RememberOptions,
     ) -> Result<Uuid> {
+        // Idle-to-disk: stamp this as a genuine user access so the idle-evict
+        // ticker does not drop a palace that is actively being written to.
+        // No-op while a dream cycle holds `is_compacting` (see `touch`).
+        self.touch();
+
         // Issue #59: short-circuit before doing any embedding work when the
         // palace is opened read-only. The store layer already rejects the
         // eventual write, but returning here saves the cost of an embed
@@ -683,6 +753,10 @@ impl PalaceHandle {
     /// Test: `cli_forget_removes_drawer` asserts a recalled drawer disappears
     /// after forget.
     pub async fn forget(&self, id: Uuid) -> Result<()> {
+        // Idle-to-disk: a forget is a genuine user access. Suppressed during
+        // dream cycles (which forget merged/pruned drawers) via `touch`.
+        self.touch();
+
         // Issue #59: short-circuit read-only handles so callers get a
         // clean error instead of two best-effort warnings followed by a
         // misleading "ok".

--- a/crates/trusty-common/src/memory_core/retrieval/layers.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/layers.rs
@@ -373,6 +373,9 @@ pub async fn recall(
     query: &str,
     top_k: usize,
 ) -> Result<Vec<RecallResult>> {
+    // Idle-to-disk: a recall is a genuine user access — reset the idle clock
+    // so the idle-evict ticker does not drop an actively-queried palace.
+    handle.touch();
     let expanded = expand_query(query);
     let mut combined = retrieve_l0_l1(handle);
     let l2 = retrieve_l2(handle, embedder, &expanded, None, top_k).await?;
@@ -422,6 +425,8 @@ pub async fn recall_deep(
     query: &str,
     top_k: usize,
 ) -> Result<Vec<RecallResult>> {
+    // Idle-to-disk: deep recall is also a genuine user access.
+    handle.touch();
     let expanded = expand_query(query);
     let mut combined = retrieve_l0_l1(handle);
     let l3 = retrieve_l3(handle, embedder, &expanded, top_k).await?;

--- a/crates/trusty-memory/src/dream_scheduler.rs
+++ b/crates/trusty-memory/src/dream_scheduler.rs
@@ -23,7 +23,7 @@
 use std::sync::Arc;
 
 use tokio::sync::watch;
-use tracing::{info, warn};
+use tracing::info;
 use trusty_common::memory_core::dream::{DreamConfig, Dreamer};
 use trusty_common::memory_core::PalaceRegistry;
 
@@ -75,30 +75,19 @@ pub fn spawn_dream_scheduler(
     }
 
     let palace_ids = registry.list();
-    // Track only successfully-spawned loops; a palace evicted between list()
-    // and get() is silently skipped, so palace_ids.len() can overcount.
     let mut spawned: usize = 0;
 
     for palace_id in palace_ids {
-        let handle = match registry.get(&palace_id) {
-            Some(h) => h,
-            None => {
-                // Palace was evicted from the LRU between list() and get() —
-                // rare but possible under heavy load. Skip; the next startup
-                // hydration will pick it up.
-                warn!(
-                    palace = %palace_id,
-                    "dream_scheduler: handle not in registry after list(); skipping"
-                );
-                continue;
-            }
-        };
-
         let config = DreamConfig::default();
         let idle_secs = config.idle_secs;
         let dreamer = Arc::new(Dreamer::new(config));
-        let rx = shutdown_rx.clone();
-        dreamer.start_with_shutdown(handle, rx);
+        // Unpin (idle-to-disk): the loop takes the registry + id and resolves
+        // the handle each cycle via `peek` (no reopen), so it never captures an
+        // `Arc<PalaceHandle>` for the process lifetime. A palace idle-evicted to
+        // disk is simply skipped until the next access re-opens it — the loop
+        // keeps running and picks it back up. This is what lets the idle-evict
+        // sweep actually free a cold palace's heavy RAM.
+        dreamer.start_with_shutdown(registry.clone(), palace_id.clone(), shutdown_rx.clone());
         spawned += 1;
 
         info!(
@@ -113,6 +102,33 @@ pub fn spawn_dream_scheduler(
         "dream_scheduler: all per-palace loops running"
     );
     spawned
+}
+
+/// Spawn all background maintenance loops (dream scheduler + idle-to-disk
+/// eviction ticker) on the shared shutdown watch, then wire the shutdown bridge.
+///
+/// Why: keeps the startup wiring — and the `#1529` ordering guarantee (spawn the
+/// loops BEFORE the bridge so an early SIGTERM cannot pre-cancel them) — in one
+/// place instead of scattering it across `main::spawn_startup_tasks`. The
+/// idle-evict ticker rides the SAME `watch` receiver as the dream loops so both
+/// stop cleanly on SIGTERM/SIGINT.
+/// What: clones `dream_shutdown_rx` for the idle-evict ticker, spawns the
+/// per-palace dream loops, spawns the idle-evict ticker
+/// (`TRUSTY_MEMORY_IDLE_EVICT_SECS`-gated), then spawns the shutdown bridge on
+/// `dtx`. Returns the number of dream loops spawned (for the caller's log line).
+/// Test: exercised end-to-end by the daemon startup path; the ticker and
+/// scheduler are unit-tested in their own modules.
+pub fn spawn_background_maintenance(
+    registry: &Arc<PalaceRegistry>,
+    dream_shutdown_rx: watch::Receiver<bool>,
+    dtx: watch::Sender<bool>,
+) -> usize {
+    let idle_evict_rx = dream_shutdown_rx.clone();
+    let loops = spawn_dream_scheduler(registry, dream_shutdown_rx);
+    crate::idle_evict::spawn_idle_evict_ticker(registry.clone(), idle_evict_rx);
+    // Bridge is spawned AFTER the loops exist (see #1529 ordering note).
+    spawn_shutdown_bridge(dtx);
+    loops
 }
 
 /// Build the `(Sender, Receiver)` pair for the dream-scheduler shutdown signal.
@@ -271,7 +287,6 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let registry = PalaceRegistry::new();
         let id = register_temp_palace(&registry, tmp.path());
-        let handle = registry.get(&id).expect("handle after create");
 
         let config = DreamConfig {
             idle_secs: 1,
@@ -280,7 +295,7 @@ mod tests {
         let dreamer = Arc::new(Dreamer::new(config));
         let (tx, rx) = make_shutdown_watch();
 
-        let join = dreamer.start_with_shutdown(handle, rx);
+        let join = dreamer.start_with_shutdown(registry, id, rx);
 
         // Signal shutdown.
         tx.send(true).expect("send shutdown");

--- a/crates/trusty-memory/src/idle_evict.rs
+++ b/crates/trusty-memory/src/idle_evict.rs
@@ -1,0 +1,233 @@
+//! Idle-to-disk eviction ticker — periodically drops cold palace handles.
+//!
+//! Why: a long-lived daemon hydrates every palace's drawer table, HNSW graph,
+//! and KG adjacency into RAM (~90 MB each). Even under the LRU open-handle cap
+//! the resident set stays fully loaded regardless of query activity, so a host
+//! with dozens of palaces sits at multiple GB of idle RSS. The durable redb
+//! store is the source of truth, so a palace nobody has queried in a while can
+//! have its whole handle dropped and be lazily re-opened on the next access
+//! (`PalaceRegistry::open_palace`). This module runs the periodic sweep that
+//! calls `PalaceRegistry::evict_idle`, mirroring `dream_scheduler`'s
+//! watch-channel shutdown wiring.
+//!
+//! What: `spawn_idle_evict_ticker` reads `TRUSTY_MEMORY_IDLE_EVICT_SECS`
+//! (default 300; `0` disables) and, when enabled, spawns a background task that
+//! evicts palaces idle past that threshold every `min(threshold, 60)` seconds.
+//!
+//! Test: `tests::idle_evict_secs_from_env_defaults_and_parses`,
+//! `tests::spawn_disabled_returns_none`,
+//! `tests::ticker_evicts_idle_palace`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+use tracing::info;
+use trusty_common::memory_core::PalaceRegistry;
+
+/// Environment variable controlling the idle-to-disk eviction TTL, in seconds.
+///
+/// Why: operators need to trade idle RSS against cold-reopen latency without a
+/// rebuild; a shorter TTL frees RAM sooner at the cost of more reopens.
+/// What: parsed by [`idle_evict_secs_from_env`]. A value of `0` (or an
+/// unset/invalid value that resolves to the default of a positive number)
+/// controls whether the ticker runs — `0` disables it entirely.
+/// Test: `tests::idle_evict_secs_from_env_defaults_and_parses`.
+pub const IDLE_EVICT_ENV: &str = "TRUSTY_MEMORY_IDLE_EVICT_SECS";
+
+/// Default idle-to-disk TTL when the env var is unset or invalid.
+///
+/// Why: 300 s (5 min) matches the dream-scheduler idle window and is long
+/// enough that an interactively-used palace is never evicted mid-session, yet
+/// short enough to reclaim RAM from truly dormant palaces within minutes.
+/// What: a compile-time constant, overridable via [`IDLE_EVICT_ENV`].
+/// Test: `tests::idle_evict_secs_from_env_defaults_and_parses`.
+pub const DEFAULT_IDLE_EVICT_SECS: u64 = 300;
+
+/// Resolve the idle-to-disk TTL (seconds) from the environment.
+///
+/// Why: centralises the env parse so the ticker and diagnostics agree.
+/// What: reads [`IDLE_EVICT_ENV`]. An explicit `0` disables eviction and is
+/// returned verbatim. Any other valid non-negative integer is used as the TTL.
+/// An unset, empty, or non-numeric value falls back to
+/// [`DEFAULT_IDLE_EVICT_SECS`].
+/// Test: `tests::idle_evict_secs_from_env_defaults_and_parses`.
+pub fn idle_evict_secs_from_env() -> u64 {
+    match std::env::var(IDLE_EVICT_ENV) {
+        Ok(v) => v.trim().parse::<u64>().unwrap_or(DEFAULT_IDLE_EVICT_SECS),
+        Err(_) => DEFAULT_IDLE_EVICT_SECS,
+    }
+}
+
+/// Spawn the idle-to-disk eviction ticker using the env-configured TTL.
+///
+/// Why: wires the sweep into daemon startup (see `spawn_startup_tasks`)
+/// alongside `spawn_dream_scheduler`.
+/// What: reads [`idle_evict_secs_from_env`]; if `0`, logs that eviction is
+/// disabled and returns `None` (no task). Otherwise delegates to
+/// [`spawn_idle_evict_ticker_with`] and returns its `JoinHandle`.
+/// Test: `tests::spawn_disabled_returns_none`.
+pub fn spawn_idle_evict_ticker(
+    registry: Arc<PalaceRegistry>,
+    shutdown_rx: watch::Receiver<bool>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    let secs = idle_evict_secs_from_env();
+    if secs == 0 {
+        info!(
+            env = IDLE_EVICT_ENV,
+            "idle-to-disk eviction disabled ({IDLE_EVICT_ENV}=0)"
+        );
+        return None;
+    }
+    Some(spawn_idle_evict_ticker_with(registry, secs, shutdown_rx))
+}
+
+/// Spawn the idle-evict ticker with an explicit TTL (seconds).
+///
+/// Why: separated from the env wrapper so tests can drive a short, deterministic
+/// threshold without mutating process env.
+/// What: spawns a background task that, every `min(threshold_secs, 60)` seconds
+/// (bounded so eviction latency never exceeds ~a minute), calls
+/// [`PalaceRegistry::evict_idle`] with the TTL. The loop races its sleep against
+/// `shutdown_rx`; a `true` value (or a closed sender) exits cleanly. A
+/// `threshold_secs` of `0` is treated as disabled by `evict_idle` itself, so the
+/// task simply no-ops, but callers should prefer `spawn_idle_evict_ticker` which
+/// skips spawning entirely in that case.
+/// Test: `tests::ticker_evicts_idle_palace`.
+pub fn spawn_idle_evict_ticker_with(
+    registry: Arc<PalaceRegistry>,
+    threshold_secs: u64,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    let threshold = Duration::from_secs(threshold_secs);
+    let tick = Duration::from_secs(threshold_secs.clamp(1, 60));
+    info!(
+        threshold_secs,
+        tick_secs = tick.as_secs(),
+        "idle-to-disk eviction ticker started"
+    );
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = tokio::time::sleep(tick) => {}
+                res = shutdown_rx.changed() => {
+                    if res.is_err() || *shutdown_rx.borrow() {
+                        info!("idle-evict ticker shutting down");
+                        return;
+                    }
+                }
+            }
+            if *shutdown_rx.borrow() {
+                info!("idle-evict ticker shutting down");
+                return;
+            }
+            let evicted = registry.evict_idle(threshold);
+            if evicted > 0 {
+                info!(
+                    evicted,
+                    "idle-evict ticker dropped {evicted} idle palace(s)"
+                );
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::sync::atomic::Ordering;
+    use trusty_common::memory_core::palace::{Palace, PalaceId};
+    use trusty_common::memory_core::PalaceRegistry;
+
+    /// Why: the env parse is the single source of truth for the TTL, including
+    /// the `0`-disables contract and the default fallback.
+    /// What: exercises unset (default), explicit `0` (disabled), and a parsed
+    /// value. `#[serial]` guards the env mutation from parallel tests.
+    /// Test: this test.
+    #[test]
+    #[serial]
+    fn idle_evict_secs_from_env_defaults_and_parses() {
+        // SAFETY: #[serial] serialises env mutation across tests in this crate.
+        unsafe {
+            std::env::remove_var(IDLE_EVICT_ENV);
+        }
+        assert_eq!(idle_evict_secs_from_env(), DEFAULT_IDLE_EVICT_SECS);
+
+        unsafe {
+            std::env::set_var(IDLE_EVICT_ENV, "0");
+        }
+        assert_eq!(idle_evict_secs_from_env(), 0, "0 must disable eviction");
+
+        unsafe {
+            std::env::set_var(IDLE_EVICT_ENV, "45");
+        }
+        assert_eq!(idle_evict_secs_from_env(), 45);
+
+        unsafe {
+            std::env::remove_var(IDLE_EVICT_ENV);
+        }
+    }
+
+    /// Why: a `0` TTL must skip spawning the task entirely.
+    /// What: sets the env to `0`, calls `spawn_idle_evict_ticker`, asserts
+    /// `None` is returned (no background task).
+    /// Test: this test.
+    #[tokio::test]
+    #[serial]
+    async fn spawn_disabled_returns_none() {
+        unsafe {
+            std::env::set_var(IDLE_EVICT_ENV, "0");
+        }
+        let registry = Arc::new(PalaceRegistry::new());
+        let (_tx, rx) = watch::channel(false);
+        let handle = spawn_idle_evict_ticker(registry, rx);
+        unsafe {
+            std::env::remove_var(IDLE_EVICT_ENV);
+        }
+        assert!(handle.is_none(), "disabled ticker must not spawn a task");
+    }
+
+    /// Why: end-to-end proof the ticker actually reclaims an idle palace.
+    /// What: registers a palace, forces its idle clock into the past, drops the
+    /// creating reference so only the registry holds it, spawns the ticker with
+    /// a 1 s threshold, and polls until the registry drops it (bounded ~5 s).
+    /// Test: this test.
+    #[tokio::test]
+    async fn ticker_evicts_idle_palace() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let registry = Arc::new(PalaceRegistry::new());
+        let id = PalaceId::new("idle-ticker");
+        let palace = Palace {
+            id: id.clone(),
+            name: "Idle".to_string(),
+            description: None,
+            created_at: chrono::Utc::now(),
+            data_dir: tmp.path().join(id.as_str()),
+        };
+        let handle = registry
+            .create_palace(tmp.path(), palace)
+            .expect("create palace");
+        // Force the idle clock far into the past, then release our reference so
+        // the handle's strong_count is 1 (only the registry) and it is eligible.
+        handle.last_accessed.store(0, Ordering::Relaxed);
+        drop(handle);
+        assert_eq!(registry.len(), 1);
+
+        let (_tx, rx) = watch::channel(false);
+        let _join = spawn_idle_evict_ticker_with(registry.clone(), 1, rx);
+
+        // Poll until the ticker drops the idle palace (bounded to avoid hangs).
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !registry.is_empty() {
+            if std::time::Instant::now() >= deadline {
+                panic!("idle-evict ticker did not drop the idle palace within 5s");
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            registry.get(&id).is_none(),
+            "idle palace must be evicted by the ticker"
+        );
+    }
+}

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -99,6 +99,10 @@ pub mod dream_scheduler;
 /// ceiling and current consumption without needing lsof or shell access.
 /// Test: `fd_metrics::tests::fd_metrics_returns_sane_values`.
 pub mod fd_metrics;
+/// Idle-to-disk eviction ticker: periodically drops cold palace handles to
+/// bound resident RSS. Wired in `spawn_startup_tasks` next to the dream
+/// scheduler; configured via `TRUSTY_MEMORY_IDLE_EVICT_SECS`.
+pub mod idle_evict;
 // Why (issue #226): `chat` and `web` are pure axum HTTP/SSE handler
 //      surfaces. Gating them behind the `axum-server` feature is what lets
 //      library consumers (e.g. `open-mpm` linking only `MemoryMcpService`)
@@ -811,7 +815,9 @@ impl AppState {
         tools::spawn_bm25_index_worker(bm25_index_rx, None, None);
         Self {
             version: env!("CARGO_PKG_VERSION").to_string(),
-            registry: Arc::new(PalaceRegistry::new()),
+            // Idle-to-disk: honour TRUSTY_MEMORY_MAX_OPEN_PALACES (default 64)
+            // so operators can bound resident-palace RAM without a rebuild.
+            registry: Arc::new(PalaceRegistry::from_env()),
             data_root,
             embedder: Arc::new(OnceCell::new()),
             default_palace: None,
@@ -1082,7 +1088,9 @@ impl AppState {
         // shared one (`strong_count > 1`) would silently drop live handles or
         // strand other clones on the stale read-only registry (issue #1487).
         debug_assert!(self.registry.is_empty() && Arc::strong_count(&self.registry) == 1);
-        self.registry = Arc::new(PalaceRegistry::new().with_writer_intent());
+        // Idle-to-disk: preserve the configurable open-handle cap
+        // (TRUSTY_MEMORY_MAX_OPEN_PALACES) while marking the registry a writer.
+        self.registry = Arc::new(PalaceRegistry::from_env().with_writer_intent());
         self
     }
 

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -892,13 +892,16 @@ fn spawn_startup_tasks(state: &AppState) {
         // the loops: loops are created with receivers pointing to a watch that
         // is still `false`, so they will do their first sleep before the bridge
         // could ever flip the value.
-        let n = trusty_memory::dream_scheduler::spawn_dream_scheduler(
+        // Spawn all background maintenance loops (dream scheduler + idle-to-disk
+        // eviction ticker) and the shutdown bridge in one call — see
+        // `spawn_background_maintenance` for the #1529 ordering guarantee and the
+        // idle-to-disk RAM-reclaim rationale.
+        let n = trusty_memory::dream_scheduler::spawn_background_maintenance(
             &bg_state.registry,
             dream_shutdown_rx,
+            dtx,
         );
         tracing::info!(loops = n, "dream_scheduler: {n} loop(s) running (#1529)");
-        // Bridge is spawned AFTER the loops exist — see ordering comment above.
-        trusty_memory::dream_scheduler::spawn_shutdown_bridge(dtx);
 
         // Issue #42: once palaces are live, kick off auto-discovery against
         // cwd targeting the default palace (if configured). Without a default


### PR DESCRIPTION
## Summary

trusty-memory's RSS grew unbounded (up to ~6GB) because the dream scheduler
pinned an `Arc<PalaceHandle>` for the lifetime of the process for every palace
it ever touched — this defeated the registry's LRU/idle-eviction logic since a
pinned handle can never be dropped no matter how idle the palace becomes.

This PR is a 3-part fix across `trusty-common` (memory_core) and `trusty-memory`:

1. **Unpin the dream scheduler** — it now re-resolves palace handles via the
   registry on each cycle instead of holding a long-lived `Arc<PalaceHandle>`,
   so idle palaces become eligible for eviction again.
2. **Idle-TTL eviction at the registry level** — `TRUSTY_MEMORY_IDLE_EVICT_SECS`
   (default `300`s) drops whole idle palace handles once their `Arc` strong
   count reaches 1 (i.e. no other holder is using them). Per-palace open
   operations are serialized so there is always exactly one store instance per
   palace, and eviction races safely with concurrent access. Evicted palaces
   lazily rehydrate from the durable redb store on next access — no data loss.
3. **Configurable max-open cap** — `TRUSTY_MEMORY_MAX_OPEN_PALACES` (default
   `64`) bounds the number of simultaneously open palace handles, proactively
   evicting the least-recently-used idle palace(s) when the cap is exceeded.

### New environment variables

| Variable | Default | Purpose |
|---|---|---|
| `TRUSTY_MEMORY_IDLE_EVICT_SECS` | `300` | Idle seconds before a palace handle becomes eligible for eviction |
| `TRUSTY_MEMORY_MAX_OPEN_PALACES` | `64` | Max simultaneously open palace handles before proactive LRU eviction |

## Quality Gate

- `cargo build --workspace` — clean
- `cargo test -p trusty-common` — 454 passed
- `cargo test -p trusty-memory` — 411 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — green

Closes #2273

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools