### PR TITLE
chore: release trusty-common 0.22.4 + trusty-memory 0.19.1 + trusty-mpm 0.19.3 (#2273, #2022)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6247,7 +6247,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10760,7 +10760,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10934,7 +10934,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10974,7 +10974,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # publish=false; version 0.0.0 intentionally — pre-release scaffold.
 trusty-code = { path = "crates/trusty-code" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.2.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.22.3" }
+trusty-common = { path = "crates/trusty-common", version = "0.22.4" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.6" }

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- idle-to-disk palace eviction + unpin dream scheduler + configurable max-open ([#2276](https://github.com/bobmatnyc/trusty-tools/pull/2276)) ([`0e8e504`](https://github.com/bobmatnyc/trusty-tools/commit/0e8e50440cea09a8f5eedf2c7bba9613f96cd8a8))
+## [Unreleased]
+
 ### Added
 
 - capture tmux window id at session pause and reattach on resume ([#2269](https://github.com/bobmatnyc/trusty-tools/pull/2269)) ([`1959738`](https://github.com/bobmatnyc/trusty-tools/commit/1959738450d9a1b7adaf707d9d5980d6365fe4a7))

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.22.3"
+version = "0.22.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -9,6 +9,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- idle-to-disk palace eviction + unpin dream scheduler + configurable max-open ([#2276](https://github.com/bobmatnyc/trusty-tools/pull/2276)) ([`0e8e504`](https://github.com/bobmatnyc/trusty-tools/commit/0e8e50440cea09a8f5eedf2c7bba9613f96cd8a8))
+
+### Changed
+
+- release trusty-common 0.22.2 + trusty-mpm 0.19.1 ([#2241](https://github.com/bobmatnyc/trusty-tools/pull/2241)) ([`f7ab5f4`](https://github.com/bobmatnyc/trusty-tools/commit/f7ab5f43c8a5cc41ed4d821e2a53800974e74207))
+## [Unreleased]
+
+### Fixed
+
 - slim build (`--no-default-features`) now compiles: `tools::dream_ops` reached
   the user-config loader through the `axum-server`-gated `crate::web::` re-export,
   breaking any dependent that opts out of `axum-server` (e.g. `trusty-agents`,

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- probe live tmux/process for session liveness, not the stored state field ([#2275](https://github.com/bobmatnyc/trusty-tools/pull/2275)) ([`b5f8b6b`](https://github.com/bobmatnyc/trusty-tools/commit/b5f8b6b7b941b5f8939918f592374e0b4bd76d28))
+## [Unreleased]
+
 ### Added
 
 - capture tmux window id at session pause and reattach on resume ([#2269](https://github.com/bobmatnyc/trusty-tools/pull/2269)) ([`1959738`](https://github.com/bobmatnyc/trusty-tools/commit/1959738450d9a1b7adaf707d9d5980d6365fe4a7))

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Version-bump-only PR preparing a combined release for two already-merged fixes. No tagging or publishing happens here — that's a follow-up step.

New versions:
- `trusty-common` 0.22.3 → **0.22.4**
- `trusty-memory` 0.19.0 → **0.19.1**
- `trusty-mpm` 0.19.2 → **0.19.3**

Ships:
- **#2273** — trusty-memory idle-to-disk palace eviction, unpinned dream scheduler, configurable max-open (merged `0e8e5044`, #2276). Cuts ~6GB RSS.
- **#2022** — trusty-mpm session-liveness probe: probes live tmux/process state instead of the stored state field, so stopped sessions delete without `--force` (merged `b5f8b6b7`, #2275).

The root `Cargo.toml` `[workspace.dependencies]` pin for `trusty-common` is bumped to 0.22.4 (`Cargo.toml:31`) so both `trusty-memory` and `trusty-mpm` resolve the new `trusty-common` from crates.io once published.

## Test plan

- [x] `cargo build --workspace` — clean build, `Finished` dev profile in 2m 23s
- [x] `Cargo.lock` verified to contain `trusty-common 0.22.4`, `trusty-memory 0.19.1`, `trusty-mpm 0.19.3`
- [ ] Note: there is a known-unrelated pre-existing failing test, `two_panel::right_col_no_inner_border`, not touched by this change

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools