### PR TITLE
test(trusty-common): make locate_bm25_daemon_binary env-override test hermetic (closes #2252)

### DIFF
--- a/crates/trusty-common/src/bm25_client.rs
+++ b/crates/trusty-common/src/bm25_client.rs
@@ -462,8 +462,11 @@ mod tests {
     /// env var at it, call the locator, assert it returns that exact path.
     /// (We use the test binary itself as a stand-in for the daemon — we only
     /// care that the path is found, not that it is the real daemon.)
-    /// Test: this test itself.
+    /// Test: this test itself. `#[serial]` serialises it against the other
+    /// `TRUSTY_BM25_DAEMON_BIN`-mutating test so neither one's env restore can
+    /// clear the override mid-flight in the other (issue #2252).
     #[test]
+    #[serial_test::serial]
     fn locate_bm25_daemon_binary_prefers_env_override() {
         // Use the test binary itself as a "daemon" — any existing file works.
         let exe = std::env::current_exe().expect("current_exe");
@@ -484,8 +487,15 @@ mod tests {
 
     /// Why: confirm that an env-var pointing at a non-existent file returns
     /// an error rather than silently falling through to sibling / PATH.
+    /// `#[serial]` is load-bearing (issue #2252): without it this test races
+    /// the sibling env-override test, whose restore can `remove_var` the
+    /// override between this test's `set_var` and its locate call — the locator
+    /// then hits the sibling/PATH fallback and finds a host-installed
+    /// `trusty-bm25-daemon`, so the expected error never occurs and the assert
+    /// fails on machines that have the daemon installed.
     /// Test: this test itself.
     #[test]
+    #[serial_test::serial]
     fn locate_bm25_daemon_binary_env_override_nonexistent_errors() {
         let key = "TRUSTY_BM25_DAEMON_BIN";
         let prev = std::env::var(key).ok();


### PR DESCRIPTION
## Summary

Fixes #2252 — `locate_bm25_daemon_binary_env_override_nonexistent_errors` failed on hosts where `~/.cargo/bin/trusty-bm25-daemon` is installed.

## Root cause

The two `TRUSTY_BM25_DAEMON_BIN`-mutating unit tests in `bm25_client.rs` shared the same **global** env var with no serialization. Under Rust's default parallel test scheduling, the sibling override test's env restore could `remove_var` the override **between** the nonexistent-path test's `set_var` and its `locate_bm25_daemon_binary()` call. With the override cleared, the locator fell through to the sibling/PATH fallback and found a real host-installed daemon, so the expected error never occurred and the assertion failed.

Production `locate_bm25_daemon_binary` already hard-errors on an explicitly-set-but-nonexistent override (no behavior change needed) — this was purely a test-isolation defect.

## Fix

Annotate **both** env-mutating tests with `#[serial_test::serial]`, matching the crate's existing env-mutating-test pattern (`embedder_client/supervisor_tests.rs`, `memory_core/registry_tests.rs`). Neither test can now clear the other's override mid-flight.

## Verification (daemon IS installed on this host — the bug-triggering condition)

```
$ ls ~/.cargo/bin/trusty-bm25-daemon
-rwxr-xr-x  1 masa  staff  3541280  /Users/masa/.cargo/bin/trusty-bm25-daemon

$ cargo test -p trusty-common --features bm25-client --lib bm25_client::tests::locate_bm25
test bm25_client::tests::locate_bm25_daemon_binary_env_override_nonexistent_errors ... ok
test bm25_client::tests::locate_bm25_daemon_binary_prefers_env_override ... ok
test result: ok. 2 passed; 0 failed; 0 ignored
```

Full lib suite run 5× — deterministic (run5 even shows reversed scheduling order, still green):
```
run1..run5: test result: ok. 141 passed; 0 failed; 6 ignored; 0 filtered out
```

Gates: `cargo clippy -p trusty-common --all-targets --features bm25-client,memory-core,embedder-test-support -- -D warnings` → exit 0; `cargo fmt --check` → clean; `bash scripts/check_line_cap.sh` → `14 allowlisted, 0 violations — OK`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools