### PR TITLE
ci: reclaim more runner disk to stop test-job space exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,18 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Free disk space (issue #2091): kept in sync with the more aggressive
+      # reclamation in the `test` job (see comment there for rationale).
       - name: Free disk space
         run: |
           echo "Before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
             /usr/local/share/boost /usr/local/share/powershell \
-            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" \
+            /usr/local/share/vcpkg /usr/lib/jvm /usr/share/miniconda /opt/az || true
           sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+          sudo rm -rf /var/lib/apt/lists/* || true
           echo "After:"; df -h /
 
       - name: Install stable toolchain with clippy
@@ -177,13 +182,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Free disk space (issue #2091): the baseline removal set below still
+      # left the runner exhausting its disk mid-build on `cargo test --workspace`
+      # (onnxruntime/ort, ~a dozen tree-sitter grammars, aws-sdk-bedrock,
+      # usearch, etc. produce an enormous target/ tree). Extend it with more
+      # well-known unused-SDK/cache purges — vcpkg (~5 GB), preinstalled JVMs
+      # (~2-3 GB, unused by this pure-Rust workspace), miniconda (~2-3 GB),
+      # the Azure CLI (~600 MB), and stale apt package caches/lists — none of
+      # which this workspace's build or test steps touch.
       - name: Free disk space
         run: |
           echo "Before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
             /usr/local/share/boost /usr/local/share/powershell \
-            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" \
+            /usr/local/share/vcpkg /usr/lib/jvm /usr/share/miniconda /opt/az || true
           sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+          sudo rm -rf /var/lib/apt/lists/* || true
           echo "After:"; df -h /
 
       # trusty-agents's git tests (list_branches_includes_current) assert that the
@@ -347,13 +363,18 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Free disk space (issue #2091): kept in sync with the more aggressive
+      # reclamation in the `test` job (see comment there for rationale).
       - name: Free disk space
         run: |
           echo "Before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
             /usr/local/share/boost /usr/local/share/powershell \
-            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" \
+            /usr/local/share/vcpkg /usr/lib/jvm /usr/share/miniconda /opt/az || true
           sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+          sudo rm -rf /var/lib/apt/lists/* || true
           echo "After:"; df -h /
 
       - name: Install Rust 1.91 toolchain
@@ -419,13 +440,18 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Free disk space (issue #2091): kept in sync with the more aggressive
+      # reclamation in the `test` job (see comment there for rationale).
       - name: Free disk space
         run: |
           echo "Before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
             /usr/local/share/boost /usr/local/share/powershell \
-            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+            /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" \
+            /usr/local/share/vcpkg /usr/lib/jvm /usr/share/miniconda /opt/az || true
           sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+          sudo rm -rf /var/lib/apt/lists/* || true
           echo "After:"; df -h /
 
       - name: Install stable toolchain


### PR DESCRIPTION
## Summary

Closes #2091.

The `Test` job's `cargo test --workspace` intermittently crashes with
`No space left on device` / linker SIGBUS during compilation of test
binaries (onnxruntime/`ort`, ~a dozen tree-sitter grammars, aws-sdk-bedrock,
usearch, etc. produce an enormous `target/` tree). The existing "Free disk
space" step (dotnet/ghc/android/boost/powershell/swift/hostedtoolcache +
docker image prune) was confirmed insufficient — the failure recurred on
two independent, unrelated commits.

This PR is **tier (a)** from the issue's candidate-fix list: extend the
existing "Free disk space" reclamation step more aggressively, rather than
splitting the test matrix or dropping test coverage. It adds well-known,
safe-to-delete unused caches/SDKs on the `ubuntu-latest` GitHub-hosted
runner that this pure-Rust workspace never touches:

- `/usr/local/share/vcpkg` (~5 GB)
- `/usr/lib/jvm` (preinstalled JDKs, ~2-3 GB)
- `/usr/share/miniconda` (~2-3 GB)
- `/opt/az` (Azure CLI, ~600 MB)
- `apt-get clean` + `/var/lib/apt/lists/*` (stale package caches/lists)

Applied identically to all four jobs that already carry a "Free disk space"
step (`clippy`, `test`, `msrv`, `search-daemon-smoke`) since they're
literal copies of the same block — the `test` job's copy carries the full
rationale comment; the other three point back to it for detail.

No test coverage is dropped or restructured — `cargo test --workspace
--exclude trusty-mpm-gui` and `cargo test -p trusty-review` run exactly as
before.

## Why tier (a) and not (b)/(c)

Extending the existing reclamation step is the smallest, lowest-risk change
that plausibly fixes the issue (~10 GB+ of additional headroom from
directories that are not used by this build). Trimming debuginfo
(`CARGO_PROFILE_TEST_DEBUG=0`) or splitting `cargo test --workspace` into a
matrix (tier b/c) add more moving parts and are deferred unless this proves
insufficient.

## Verification

**This cannot be verified locally** — the failure is disk-pressure-specific
to GitHub Actions' shared runners and does not reproduce on a local
machine or in a fresh worktree. Validation performed so far:

- `actionlint .github/workflows/ci.yml` → exit 0, no findings.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → parses cleanly.
- Manual structural read of all four modified steps confirms consistent
  indentation and step keys.

**This PR's own CI run is the real validation.** Please watch the `Test`,
`Clippy`, and `MSRV check` job runs on this PR for the
`No space left on device` / linker SIGBUS signature before merging. If it
recurs even with this larger reclamation, the next step is tier (b) — trim
`target/` debuginfo — or tier (c) — split `cargo test --workspace` into a
matrix with a `target/` clean between groups, without dropping any crate
from the test run.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-mpm