### PR TITLE
fix(trusty-installer): arm64 Tier-1 + glibc-aware ORT asset selection (closes #1992)

### DIFF
--- a/crates/trusty-installer/src/download/glibc.rs
+++ b/crates/trusty-installer/src/download/glibc.rs
@@ -1,0 +1,359 @@
+//! Host-glibc probing and glibc-aware asset selection for ONNX-Runtime crates.
+//!
+//! Why: `trusty-search` and `trusty-analyze` bundle ONNX Runtime. Their native
+//! `x86_64-unknown-linux-gnu` release asset is built on the CI `ubuntu-latest`
+//! runner and carries a high glibc floor (`GLIBC_2.39`), so it fails to even
+//! execute on Debian 12, Ubuntu 22.04, RHEL 9, and Amazon Linux 2023 with
+//! `GLIBC_2.39 not found` (issue #1992). The release pipeline (#2037) already
+//! ships a portable `x86_64-linux-al2023` load-dynamic asset for exactly these
+//! hosts, but the installer never selected it — so a low-glibc host silently
+//! downloaded a binary that could not run.
+//!
+//! What: [`host_glibc_version`] probes the running host's glibc via
+//! `ldd --version`. [`select_asset_suffix`] is a pure, hermetic decision:
+//! given a crate, its host target triple, and the (mockable) host glibc, it
+//! returns the release asset suffix to download plus whether that asset is a
+//! load-dynamic ORT build (which requires `ORT_DYLIB_PATH` at runtime).
+//! [`ort_dylib_instructions`] renders the actionable runtime-setup note.
+//!
+//! Test: `tests` covers `parse_glibc_version`, `select_asset_suffix` across the
+//! ORT/non-ORT × low/high/unknown-glibc × x86_64/arm64 matrix, and the
+//! instruction renderer. The live `host_glibc_version` probe is side-effecting
+//! and covered by the integration flow.
+
+use super::platform::{TARGET_LINUX_ARM64, TARGET_LINUX_X86_64};
+
+/// Crates whose native `x86_64-unknown-linux-gnu` asset bundles ONNX Runtime and
+/// therefore carries a high glibc floor.
+///
+/// Why: Only these crates ship a portable `x86_64-linux-al2023` fallback asset;
+/// every other crate's Linux asset is a glibc-2.17-baseline zigbuild (issue
+/// #2037) that runs everywhere, so it needs no glibc-aware routing.
+///
+/// What: The set of crate names that receive AL2023 asset selection.
+///
+/// Test: `tests::select_*` exercise both members and a non-member.
+pub const ORT_CRATES: [&str; 2] = ["trusty-search", "trusty-analyze"];
+
+/// Minimum glibc `(major, minor)` the native x86_64 Linux ORT asset requires.
+///
+/// Why: The native asset is built on `ubuntu-latest` (Ubuntu 24.04 / glibc
+/// 2.39); the bundled static ONNX Runtime additionally needs glibc ≥ 2.38. The
+/// binding constraint is the runner glibc, so 2.39 is the effective floor a host
+/// must meet to run the native asset.
+///
+/// What: `(2, 39)` — hosts below this must use the AL2023 asset instead.
+///
+/// Test: `tests::select_prefers_al2023_below_floor` /
+/// `tests::select_keeps_native_at_floor`.
+pub const NATIVE_LINUX_GLIBC_FLOOR: (u32, u32) = (2, 39);
+
+/// Asset suffix for the portable AL2023 load-dynamic ORT build.
+///
+/// Why: Centralise the literal so the URL builders and the selection logic never
+/// drift from the name the release workflow publishes.
+///
+/// What: `x86_64-linux-al2023` (matches `release.yml`'s `asset_suffix`).
+///
+/// Test: `tests::select_prefers_al2023_below_floor`.
+pub const AL2023_ASSET_SUFFIX: &str = "x86_64-linux-al2023";
+
+/// The chosen release asset for a crate on the running host.
+///
+/// Why: The caller needs both the asset suffix (to build the download URL) and
+/// whether the asset is a load-dynamic ORT build so it can print the
+/// `ORT_DYLIB_PATH` runtime-setup instructions after a successful install.
+///
+/// What: `suffix` is the `<crate>-<version>-<suffix>.tar.gz` infix; `load_dynamic`
+/// is `true` when the asset dlopen()s `libonnxruntime.so` at startup.
+///
+/// Test: `tests::select_*`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssetChoice {
+    /// The asset suffix, e.g. `x86_64-linux-al2023` or `aarch64-apple-darwin`.
+    pub suffix: String,
+    /// `true` when the asset requires `ORT_DYLIB_PATH` at runtime.
+    pub load_dynamic: bool,
+}
+
+/// Probe the running host's glibc version via `ldd --version`.
+///
+/// Why: Only the live host knows its glibc; we need it to decide whether the
+/// native x86_64 ORT asset would even execute here.
+///
+/// What: Runs `ldd --version`, reads stdout, and delegates to the pure
+/// [`parse_glibc_version`]. Returns `None` when `ldd` is absent or its output is
+/// unparseable (e.g. musl hosts) — the caller then conservatively keeps the
+/// native asset.
+///
+/// Test: Side-effecting; the parse half is covered by `tests::parse_*`.
+pub fn host_glibc_version() -> Option<(u32, u32)> {
+    let output = std::process::Command::new("ldd")
+        .arg("--version")
+        .output()
+        .ok()?;
+    // glibc's `ldd --version` prints to stdout; some libcs use stderr — try both.
+    parse_glibc_version(&String::from_utf8_lossy(&output.stdout))
+        .or_else(|| parse_glibc_version(&String::from_utf8_lossy(&output.stderr)))
+}
+
+/// Parse a `(major, minor)` glibc version from `ldd --version` output.
+///
+/// Why: The output format varies by distro — e.g. `ldd (Ubuntu GLIBC
+/// 2.39-0ubuntu8.3) 2.39` or `ldd (GNU libc) 2.31` — so we scan for the trailing
+/// bare `MAJOR.MINOR` token on the first line rather than a fixed column.
+///
+/// What: Takes the first line, finds the last whitespace-delimited token that
+/// parses as `MAJOR.MINOR` (both non-negative integers), and returns it. Returns
+/// `None` when no such token exists (non-glibc loaders like musl's).
+///
+/// Test: `tests::parse_ubuntu`, `tests::parse_gnu_libc`, `tests::parse_musl_none`.
+pub(crate) fn parse_glibc_version(ldd_output: &str) -> Option<(u32, u32)> {
+    let first_line = ldd_output.lines().next()?;
+    // Scan tokens right-to-left: the bare `2.39` version is the last token on
+    // glibc's banner line, after the parenthesised distro string.
+    first_line
+        .split_whitespace()
+        .rev()
+        .find_map(parse_major_minor)
+}
+
+/// Parse a single `MAJOR.MINOR` token into `(u32, u32)`.
+///
+/// Why: Extracted so the token scan in [`parse_glibc_version`] stays a one-liner
+/// and the numeric parsing is unit-testable in isolation.
+///
+/// What: Splits on the first `.`; returns `Some` only when exactly two parts both
+/// parse as `u32`. Trailing patch text (e.g. `2.39-0ubuntu8`) is rejected so the
+/// scan falls through to the bare version token.
+///
+/// Test: Exercised via `tests::parse_*`.
+fn parse_major_minor(token: &str) -> Option<(u32, u32)> {
+    let (major, minor) = token.split_once('.')?;
+    Some((major.parse().ok()?, minor.parse().ok()?))
+}
+
+/// Decide which release asset to download for `crate_name` on `target`.
+///
+/// Why: On a low-glibc x86_64 Linux host, the native ORT asset crashes with
+/// `GLIBC_2.39 not found`; the portable AL2023 asset runs there instead. The ORT
+/// arm64 Linux asset is always a load-dynamic build (issue #2037), so it needs
+/// the `ORT_DYLIB_PATH` note regardless of glibc. This function is pure — the
+/// host glibc is injected — so the whole decision matrix is hermetically testable.
+///
+/// What: For an ORT crate (`ORT_CRATES`):
+/// - on `x86_64-unknown-linux-gnu` with a probed glibc **below**
+///   [`NATIVE_LINUX_GLIBC_FLOOR`], selects [`AL2023_ASSET_SUFFIX`]
+///   (`load_dynamic = true`);
+/// - on `aarch64-unknown-linux-gnu`, keeps the arm64 suffix but flags
+///   `load_dynamic = true` (that asset dlopen()s ONNX Runtime);
+/// - otherwise (macOS, or x86_64 with glibc ≥ floor, or unknown glibc) keeps the
+///   native `target` suffix (`load_dynamic = false`).
+///
+/// For every non-ORT crate it always returns the native `target` suffix.
+/// When the host glibc cannot be probed (`None`) on x86_64, it conservatively
+/// keeps the native asset rather than forcing a load-dynamic path that needs
+/// extra runtime setup.
+///
+/// Test: `tests::select_prefers_al2023_below_floor`,
+/// `tests::select_keeps_native_at_floor`, `tests::select_unknown_glibc_keeps_native`,
+/// `tests::select_arm64_ort_is_load_dynamic`, `tests::select_non_ort_never_switches`.
+pub fn select_asset_suffix(
+    crate_name: &str,
+    target: &str,
+    host_glibc: Option<(u32, u32)>,
+) -> AssetChoice {
+    let native = AssetChoice {
+        suffix: target.to_owned(),
+        load_dynamic: false,
+    };
+
+    if !ORT_CRATES.contains(&crate_name) {
+        return native;
+    }
+
+    match target {
+        TARGET_LINUX_X86_64 => match host_glibc {
+            Some(glibc) if glibc < NATIVE_LINUX_GLIBC_FLOOR => AssetChoice {
+                suffix: AL2023_ASSET_SUFFIX.to_owned(),
+                load_dynamic: true,
+            },
+            _ => native,
+        },
+        // The arm64 Linux ORT asset is a load-dynamic build (issue #2037): it
+        // ships with the native `aarch64-unknown-linux-gnu` suffix but still
+        // dlopen()s ONNX Runtime, so it needs the ORT_DYLIB_PATH note.
+        TARGET_LINUX_ARM64 => AssetChoice {
+            suffix: TARGET_LINUX_ARM64.to_owned(),
+            load_dynamic: true,
+        },
+        _ => native,
+    }
+}
+
+/// Render the actionable `ORT_DYLIB_PATH` runtime-setup note for a load-dynamic
+/// ORT asset on `target`.
+///
+/// Why: The load-dynamic asset does not bundle `libonnxruntime.so`; the binary
+/// dlopen()s it at startup and refuses to run without `ORT_DYLIB_PATH`.
+/// Auto-downloading the ~200 MB ONNX Runtime and mutating the user's shell
+/// profile is out of scope for a clean install step, so we hand the user the
+/// exact commands instead of leaving a binary that silently fails to start.
+///
+/// What: Returns a multi-line string with the ONNX Runtime 1.20.1 download URL
+/// and the `export ORT_DYLIB_PATH=…` line for the host architecture (`aarch64`
+/// for arm64 targets, `x64` otherwise), mirroring the `ORT-RUNTIME-NOTE.txt`
+/// the release workflow packages.
+///
+/// Test: `tests::instructions_mention_dylib_and_arch`.
+pub fn ort_dylib_instructions(target: &str) -> String {
+    let arch = if target.starts_with("aarch64") {
+        "aarch64"
+    } else {
+        "x64"
+    };
+    format!(
+        "This portable ONNX-Runtime build loads libonnxruntime.so at runtime and \
+         will not start until ORT_DYLIB_PATH is set. Install ONNX Runtime 1.20.1 and \
+         export the path:\n  \
+         curl -fsSL https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-linux-{arch}-1.20.1.tgz | tar xz -C /opt\n  \
+         export ORT_DYLIB_PATH=/opt/onnxruntime-linux-{arch}-1.20.1/lib/libonnxruntime.so.1.20.1\n\
+         (add the export line to your shell profile to persist it)."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: Ubuntu's banner embeds the version twice (`2.39-0ubuntu8.3` then a
+    /// bare `2.39`); the bare trailing token is the authoritative version.
+    /// What: Asserts the Ubuntu format parses to `(2, 39)`.
+    /// Test: This is the test.
+    #[test]
+    fn parse_ubuntu() {
+        let out = "ldd (Ubuntu GLIBC 2.39-0ubuntu8.3) 2.39\nCopyright (C) 2024 ...";
+        assert_eq!(parse_glibc_version(out), Some((2, 39)));
+    }
+
+    /// Why: The plain GNU libc banner must parse too.
+    /// What: Asserts `ldd (GNU libc) 2.31` → `(2, 31)`.
+    /// Test: This is the test.
+    #[test]
+    fn parse_gnu_libc() {
+        let out = "ldd (GNU libc) 2.31";
+        assert_eq!(parse_glibc_version(out), Some((2, 31)));
+    }
+
+    /// Why: Debian 12 (glibc 2.36) is a primary #1992 target; it must parse below
+    /// the floor.
+    /// What: Asserts a Debian-style banner parses to `(2, 36)` and is `< floor`.
+    /// Test: This is the test.
+    #[test]
+    fn parse_debian_below_floor() {
+        let out = "ldd (Debian GLIBC 2.36-9+deb12u7) 2.36";
+        let v = parse_glibc_version(out).expect("parses");
+        assert_eq!(v, (2, 36));
+        assert!(v < NATIVE_LINUX_GLIBC_FLOOR);
+    }
+
+    /// Why: A musl loader emits no `MAJOR.MINOR` glibc token; the probe must
+    /// return `None` (→ caller keeps the native asset).
+    /// What: Asserts musl-style output yields `None`.
+    /// Test: This is the test.
+    #[test]
+    fn parse_musl_none() {
+        let out = "musl libc (x86_64)\nVersion 1.2.4";
+        // "1.2.4" is not MAJOR.MINOR (has a patch component) and there is no
+        // bare MAJOR.MINOR token on the first line.
+        assert_eq!(parse_glibc_version(out), None);
+    }
+
+    /// Why: Empty / garbage output must not panic and must return `None`.
+    /// What: Asserts empty input yields `None`.
+    /// Test: This is the test.
+    #[test]
+    fn parse_empty_none() {
+        assert_eq!(parse_glibc_version(""), None);
+    }
+
+    /// Why: The core #1992 fix — an ORT crate on a below-floor x86_64 host must
+    /// select the portable AL2023 asset, not the crashing native one.
+    /// What: trusty-search on x86_64 Linux with glibc 2.35 → AL2023, load-dynamic.
+    /// Test: This is the test.
+    #[test]
+    fn select_prefers_al2023_below_floor() {
+        let choice = select_asset_suffix("trusty-search", TARGET_LINUX_X86_64, Some((2, 35)));
+        assert_eq!(choice.suffix, AL2023_ASSET_SUFFIX);
+        assert!(choice.load_dynamic);
+    }
+
+    /// Why: A host that meets the floor must keep the fast native static asset —
+    /// no needless load-dynamic path.
+    /// What: trusty-analyze on x86_64 Linux with glibc exactly 2.39 → native.
+    /// Test: This is the test.
+    #[test]
+    fn select_keeps_native_at_floor() {
+        let choice = select_asset_suffix("trusty-analyze", TARGET_LINUX_X86_64, Some((2, 39)));
+        assert_eq!(choice.suffix, TARGET_LINUX_X86_64);
+        assert!(!choice.load_dynamic);
+    }
+
+    /// Why: When glibc cannot be probed we must not gamble on load-dynamic setup;
+    /// keeping native preserves prior behaviour.
+    /// What: trusty-search on x86_64 Linux with `None` glibc → native.
+    /// Test: This is the test.
+    #[test]
+    fn select_unknown_glibc_keeps_native() {
+        let choice = select_asset_suffix("trusty-search", TARGET_LINUX_X86_64, None);
+        assert_eq!(choice.suffix, TARGET_LINUX_X86_64);
+        assert!(!choice.load_dynamic);
+    }
+
+    /// Why: The arm64 Linux ORT asset is load-dynamic regardless of glibc, so the
+    /// ORT_DYLIB_PATH note must fire even though the suffix stays native.
+    /// What: trusty-search on aarch64 Linux → native suffix, load_dynamic = true.
+    /// Test: This is the test.
+    #[test]
+    fn select_arm64_ort_is_load_dynamic() {
+        let choice = select_asset_suffix("trusty-search", TARGET_LINUX_ARM64, Some((2, 35)));
+        assert_eq!(choice.suffix, TARGET_LINUX_ARM64);
+        assert!(choice.load_dynamic);
+    }
+
+    /// Why: macOS ORT assets are static; no glibc routing applies there.
+    /// What: trusty-analyze on macOS arm64 → native suffix, not load-dynamic.
+    /// Test: This is the test.
+    #[test]
+    fn select_macos_ort_keeps_native() {
+        let choice = select_asset_suffix("trusty-analyze", "aarch64-apple-darwin", Some((2, 30)));
+        assert_eq!(choice.suffix, "aarch64-apple-darwin");
+        assert!(!choice.load_dynamic);
+    }
+
+    /// Why: Non-ORT crates ship a glibc-2.17 baseline asset that runs everywhere;
+    /// they must never be re-routed to AL2023.
+    /// What: trusty-memory on a below-floor x86_64 host → native suffix.
+    /// Test: This is the test.
+    #[test]
+    fn select_non_ort_never_switches() {
+        let choice = select_asset_suffix("trusty-memory", TARGET_LINUX_X86_64, Some((2, 28)));
+        assert_eq!(choice.suffix, TARGET_LINUX_X86_64);
+        assert!(!choice.load_dynamic);
+    }
+
+    /// Why: The runtime note must be actionable — it must name ORT_DYLIB_PATH and
+    /// the correct arch download.
+    /// What: Asserts the x64 note mentions `ORT_DYLIB_PATH` and `x64`, and the
+    /// arm64 note mentions `aarch64`.
+    /// Test: This is the test.
+    #[test]
+    fn instructions_mention_dylib_and_arch() {
+        let x64 = ort_dylib_instructions(TARGET_LINUX_X86_64);
+        assert!(x64.contains("ORT_DYLIB_PATH"));
+        assert!(x64.contains("onnxruntime-linux-x64-1.20.1"));
+
+        let arm = ort_dylib_instructions(TARGET_LINUX_ARM64);
+        assert!(arm.contains("onnxruntime-linux-aarch64-1.20.1"));
+    }
+}

--- a/crates/trusty-installer/src/download/mod.rs
+++ b/crates/trusty-installer/src/download/mod.rs
@@ -6,9 +6,12 @@
 //! fall back to `cargo install` when the target is unsupported, when no matching
 //! release asset exists, or when any download/verify/extract step fails.
 //!
-//! What: Three focused submodules:
+//! What: Four focused submodules:
 //! - [`platform`] — Tier-1 target detection (`aarch64-apple-darwin`,
-//!   `x86_64-unknown-linux-gnu`).
+//!   `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`).
+//! - [`glibc`] — host-glibc probing and glibc-aware ORT asset selection so
+//!   low-glibc Linux hosts get the portable AL2023 asset instead of a binary
+//!   that fails with `GLIBC_2.39 not found` (issue #1992).
 //! - [`release`] — GitHub Releases API queries and asset-URL construction.
 //! - [`fetch`] — HTTP download, SHA-256 verification, tar.gz extraction, and
 //!   atomic binary placement.
@@ -22,6 +25,7 @@
 //! The orchestrator's fallback decision logic is tested in `tests` below.
 
 pub mod fetch;
+pub mod glibc;
 pub mod platform;
 pub mod release;
 
@@ -104,12 +108,20 @@ pub async fn try_install_prebuilt(crate_name: &str, install_dir: &std::path::Pat
         }
     };
 
-    // Step 3: Build URLs.
-    let archive_name = release::asset_filename(crate_name, &resolved.version, target);
-    let tarball_url = release::asset_url(&resolved.tag, crate_name, &resolved.version, target);
-    let sha_url = release::sha256_url(&resolved.tag, crate_name, &resolved.version, target);
+    // Step 3: Pick the glibc-aware asset suffix. On a low-glibc x86_64 Linux
+    // host the native ORT asset would crash with `GLIBC_2.39 not found`, so an
+    // ORT crate is routed to the portable `x86_64-linux-al2023` load-dynamic
+    // asset instead (issue #1992). Non-ORT crates and adequate hosts keep the
+    // native target suffix.
+    let choice = glibc::select_asset_suffix(crate_name, target, glibc::host_glibc_version());
+    let suffix = choice.suffix.as_str();
 
-    // Step 4: Download into a temp dir, verify, extract, place — atomically.
+    // Step 4: Build URLs from the chosen suffix.
+    let archive_name = release::asset_filename(crate_name, &resolved.version, suffix);
+    let tarball_url = release::asset_url(&resolved.tag, crate_name, &resolved.version, suffix);
+    let sha_url = release::sha256_url(&resolved.tag, crate_name, &resolved.version, suffix);
+
+    // Step 5: Download into a temp dir, verify, extract, place — atomically.
     match install_from_urls(
         &client,
         crate_name,
@@ -121,10 +133,23 @@ pub async fn try_install_prebuilt(crate_name: &str, install_dir: &std::path::Pat
     )
     .await
     {
-        Ok(paths) => Outcome::Installed {
-            paths,
-            version: resolved.version,
-        },
+        Ok(paths) => {
+            // A load-dynamic asset dlopen()s libonnxruntime.so at startup and
+            // will not run until ORT_DYLIB_PATH is set — surface the setup steps
+            // rather than leaving a binary that silently fails to start.
+            if choice.load_dynamic {
+                tracing::warn!(
+                    crate_name,
+                    asset = suffix,
+                    "{}",
+                    glibc::ort_dylib_instructions(target)
+                );
+            }
+            Outcome::Installed {
+                paths,
+                version: resolved.version,
+            }
+        }
         Err(e) => Outcome::Fallback {
             reason: format!("prebuilt download failed ({e}); falling back to cargo install"),
         },
@@ -220,7 +245,7 @@ mod tests {
     fn fallback_on_unsupported_target() {
         // A non-Tier-1 triple must never reach the network.
         assert!(!platform::is_tier1_target("x86_64-apple-darwin"));
-        assert!(!platform::is_tier1_target("aarch64-unknown-linux-gnu"));
+        assert!(!platform::is_tier1_target("aarch64-unknown-linux-musl"));
         assert!(!platform::is_tier1_target("wasm32-unknown-unknown"));
     }
 

--- a/crates/trusty-installer/src/download/platform.rs
+++ b/crates/trusty-installer/src/download/platform.rs
@@ -1,8 +1,9 @@
 //! Platform / architecture detection for prebuilt-binary selection.
 //!
 //! Why: Prebuilt assets are target-triple–specific. Tier-1 targets supported
-//! by the CI release pipeline are `aarch64-apple-darwin` (macOS arm64) and
-//! `x86_64-unknown-linux-gnu` (Linux x86_64). All others fall back to `cargo
+//! by the CI release pipeline are `aarch64-apple-darwin` (macOS arm64),
+//! `x86_64-unknown-linux-gnu` (Linux x86_64), and `aarch64-unknown-linux-gnu`
+//! (Linux arm64, best-effort per issue #2037). All others fall back to `cargo
 //! install` so no supported platform is left without a working install path.
 //!
 //! What: [`current_target`] returns the Rust target triple for the running host
@@ -18,6 +19,15 @@ pub const TARGET_MACOS_ARM64: &str = "aarch64-apple-darwin";
 
 /// The Rust target triple for Linux x86_64.
 pub const TARGET_LINUX_X86_64: &str = "x86_64-unknown-linux-gnu";
+
+/// The Rust target triple for Linux arm64.
+///
+/// Why: Issue #2037 added an `aarch64-unknown-linux-gnu` release leg so Linux
+/// arm64 hosts can install prebuilt binaries instead of always compiling from
+/// source. The leg is `continue-on-error` in CI, so the asset MAY be absent for
+/// a given release — a missing asset degrades cleanly to `cargo install` (a 404
+/// on the download surfaces as `Outcome::Fallback`, verified in `download::mod`).
+pub const TARGET_LINUX_ARM64: &str = "aarch64-unknown-linux-gnu";
 
 /// Returns the Rust target triple for this host if it is a Tier-1 prebuilt target.
 ///
@@ -36,6 +46,7 @@ pub fn current_target() -> Option<&'static str> {
     match (os, arch) {
         ("macos", "aarch64") => Some(TARGET_MACOS_ARM64),
         ("linux", "x86_64") => Some(TARGET_LINUX_X86_64),
+        ("linux", "aarch64") => Some(TARGET_LINUX_ARM64),
         _ => None,
     }
 }
@@ -46,39 +57,40 @@ pub fn current_target() -> Option<&'static str> {
 /// to decide the download path vs. cargo-fallback — useful independently of the
 /// live host probe.
 ///
-/// What: Checks against the two published Tier-1 triples.
+/// What: Checks against the three published Tier-1 triples.
 ///
 /// Test: `tests::tier1_targets_recognised`, `tests::non_tier1_is_false`.
 pub fn is_tier1_target(triple: &str) -> bool {
-    triple == TARGET_MACOS_ARM64 || triple == TARGET_LINUX_X86_64
+    triple == TARGET_MACOS_ARM64 || triple == TARGET_LINUX_X86_64 || triple == TARGET_LINUX_ARM64
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Why: The two Tier-1 triples must be recognised; non-Tier-1 must not be.
+    /// Why: The three Tier-1 triples must be recognised; non-Tier-1 must not be.
     ///
-    /// What: Asserts each Tier-1 constant returns true; Intel macOS, Linux arm64,
-    /// and Windows return false.
+    /// What: Asserts each Tier-1 constant (macOS arm64, Linux x86_64, Linux
+    /// arm64) returns true.
     ///
     /// Test: This is the test.
     #[test]
     fn tier1_targets_recognised() {
         assert!(is_tier1_target(TARGET_MACOS_ARM64));
         assert!(is_tier1_target(TARGET_LINUX_X86_64));
+        assert!(is_tier1_target(TARGET_LINUX_ARM64));
     }
 
     /// Why: The fallback gate must reject non-Tier-1 targets; a stale match arm
     /// would silently enable an unsupported prebuilt path.
     ///
-    /// What: Asserts Intel macOS, Linux arm64, and Windows are not Tier-1.
+    /// What: Asserts Intel macOS, Windows, and a bare string are not Tier-1.
     ///
     /// Test: This is the test.
     #[test]
     fn non_tier1_is_false() {
         assert!(!is_tier1_target("x86_64-apple-darwin"));
-        assert!(!is_tier1_target("aarch64-unknown-linux-gnu"));
+        assert!(!is_tier1_target("aarch64-unknown-linux-musl"));
         assert!(!is_tier1_target("x86_64-pc-windows-msvc"));
         assert!(!is_tier1_target(""));
     }


### PR DESCRIPTION
Closes #1992. Implements the two remaining installer code gaps in `crates/trusty-installer/src/download/` (the rest of #1992 already landed via #2037/#2042/#2038).

## Gap 1 — arm64 Linux Tier-1 recognition (`platform.rs`)
- Added `aarch64-unknown-linux-gnu` (`TARGET_LINUX_ARM64`) to `current_target()` and `is_tier1_target()`, so `tctl install`/`upgrade` attempt the prebuilt path on Linux arm64 (release.yml + install.sh already build/accept these assets via #2038).
- The aarch64-linux CI leg is `continue-on-error`, so the asset may 404 for a given release. Verified the fallback is already clean: a 404 fails `download_and_verify` (`error_for_status`) → `install_from_urls` returns `Err` → `try_install_prebuilt` returns `Outcome::Fallback` → caller runs `cargo install`. No extra work needed.

## Gap 2 — glibc-aware ORT asset selection (new `glibc.rs` + `mod.rs`)
`trusty-search` / `trusty-analyze` bundle ONNX Runtime; their native `x86_64-unknown-linux-gnu` asset carries a `GLIBC_2.39` floor and fails with `GLIBC_2.39 not found` on Debian 12 / Ubuntu 22.04 / RHEL 9 / AL2023. The portable `x86_64-linux-al2023` load-dynamic asset already ships (#2037) but the installer never selected it.

**Implemented option (a)'s core (the real fix):** probe host glibc via `ldd --version` and, for these two ORT crates on a below-floor x86_64 host, select the `x86_64-linux-al2023` asset instead of the crashing native one. The arm64 Linux ORT asset is also load-dynamic (#2037), so it is flagged too.

**Deviation from option (a), stated plainly:** the AL2023/arm64 assets do **not** bundle `libonnxruntime.so` (confirmed in release.yml — they ship an `ORT-RUNTIME-NOTE.txt` instead). Fully *setting* `ORT_DYLIB_PATH` at install time would require downloading the ~200 MB ONNX Runtime and mutating the user's shell profile — too invasive for a clean, well-tested change. So instead of silently downloading a non-executable native binary, the installer now downloads the **correct portable binary** and prints the exact `ORT_DYLIB_PATH` setup commands (`glibc::ort_dylib_instructions`). This is strictly better than pure option (b): the user gets a runnable binary once they set the one env var, rather than a GLIBC crash no matter what. When glibc can't be probed, it conservatively keeps the native asset (prior behaviour).

New logic is covered by hermetic unit tests (mocked glibc input, no network): `ldd --version` parsing across Ubuntu/GNU/Debian/musl/empty, and `select_asset_suffix` across ORT/non-ORT × low/high/unknown-glibc × x86_64/arm64/macOS.

## Verification (raw output in the task report)
- `cargo test -p trusty-installer` → 347 passed; 0 failed; 3 ignored
- `cargo clippy -p trusty-installer --all-targets -- -D warnings` → clean
- `cargo fmt -p trusty-installer --check` → clean
- `cargo build --workspace` → Finished (exit 0)
- `bash scripts/check_line_cap.sh` → 0 violations

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools