### PR TITLE
fix(clippy): resolve clippy 1.97.0 lint regressions blocking CI

### DIFF
--- a/crates/trusty-agents/src/memory/redb_usearch/mod.rs
+++ b/crates/trusty-agents/src/memory/redb_usearch/mod.rs
@@ -193,7 +193,7 @@ impl RedbUsearchStore {
             let (id_v, label_v) = entry?;
             let id = id_v.value().to_string();
             let label = label_v.value();
-            let key = format!("{}:{}", segment.prefix(), &id);
+            let key = format!("{}:{}", segment.prefix(), id);
             let Some(payload_raw) = payloads.get(key.as_str())? else {
                 continue;
             };

--- a/crates/trusty-agents/src/memory/redb_usearch/store_impl.rs
+++ b/crates/trusty-agents/src/memory/redb_usearch/store_impl.rs
@@ -114,7 +114,7 @@ impl MemoryStore for RedbUsearchStore {
                 continue;
             };
             let id = id_val.value().to_string();
-            let key = format!("{}:{}", segment.prefix(), &id);
+            let key = format!("{}:{}", segment.prefix(), id);
             let Some(payload_raw) = payloads.get(key.as_str())? else {
                 continue;
             };

--- a/crates/trusty-analyze/src/core/tool_impls/csharp/mod.rs
+++ b/crates/trusty-analyze/src/core/tool_impls/csharp/mod.rs
@@ -252,10 +252,7 @@ fn find_csproj(start: &Path) -> Option<PathBuf> {
         if current.join(".git").exists() {
             return None;
         }
-        match current.parent() {
-            Some(p) => current = p,
-            None => return None,
-        }
+        current = current.parent()?;
     }
     None
 }

--- a/crates/trusty-memory/src/commands/serve_stdio_bridge.rs
+++ b/crates/trusty-memory/src/commands/serve_stdio_bridge.rs
@@ -275,10 +275,7 @@ fn inject_default_palace(
 /// Test: `value_to_mcp_response_ok`, `value_to_mcp_response_err`,
 /// `value_to_mcp_response_malformed`.
 pub(crate) fn value_to_mcp_response(v: serde_json::Value) -> mcp::Response {
-    let id = v
-        .get("id")
-        .cloned()
-        .and_then(|id| if id.is_null() { None } else { Some(id) });
+    let id = v.get("id").cloned().filter(|id| !id.is_null());
 
     if let Some(result) = v.get("result").cloned() {
         return mcp::Response::ok(id, result);

--- a/crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs
@@ -116,10 +116,7 @@ fn req_to_value(req: &Request) -> serde_json::Value {
 /// is present, or an internal error when the response is malformed.
 /// Test: `value_to_mcp_response_maps_ok_err_and_malformed`.
 fn value_to_mcp_response(v: serde_json::Value) -> Response {
-    let id = v
-        .get("id")
-        .cloned()
-        .and_then(|id| if id.is_null() { None } else { Some(id) });
+    let id = v.get("id").cloned().filter(|id| !id.is_null());
 
     if let Some(result) = v.get("result").cloned() {
         return Response::ok(id, result);

--- a/crates/trusty-mpm/src/daemon/bug_report/token.rs
+++ b/crates/trusty-mpm/src/daemon/bug_report/token.rs
@@ -115,10 +115,8 @@ impl TokenProvider for EnvFileTokenProvider {
         // 2. Resolve file path (override or default).
         let file_path: PathBuf = if let Ok(override_path) = std::env::var(TOKEN_FILE_ENV_VAR) {
             PathBuf::from(override_path.trim())
-        } else if let Some(home) = dirs::home_dir() {
-            home.join(TOKEN_FILE_RELATIVE)
         } else {
-            return None;
+            dirs::home_dir()?.join(TOKEN_FILE_RELATIVE)
         };
 
         // 3. Read and trim the file.


### PR DESCRIPTION
## CI-unblocking fix

The CI toolchain bump to **clippy 1.97.0** (2026-07-07) newly flags lints on pre-existing `origin/main` code. The required **Clippy** check (`cargo clippy --workspace --all-targets -- -D warnings`) is failing on **every PR** as a result. This restores a zero-warning workspace lint.

## Sites fixed (all behavior-preserving, applying clippy's own suggestions)

**`clippy::manual_filter`** — `.and_then(|id| if id.is_null() { None } else { Some(id) })` → `.filter(|id| !id.is_null())`
- `crates/trusty-memory/src/commands/serve_stdio_bridge.rs:281` (the site named in the CI failure)
- `crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs:122`

**`clippy::question_mark`**
- `crates/trusty-analyze/src/core/tool_impls/csharp/mod.rs:255` — `match current.parent() { Some(p) => current = p, None => return None }` → `current = current.parent()?;`
- `crates/trusty-mpm/src/daemon/bug_report/token.rs:118` — `else if let Some(home) = dirs::home_dir() { … } else { return None }` → `else { dirs::home_dir()?.join(…) }`

**`clippy::useless_borrows_in_formatting`** — redundant `&` in `format!` arg → removed
- `crates/trusty-agents/src/memory/redb_usearch/store_impl.rs:117`
- `crates/trusty-agents/src/memory/redb_usearch/mod.rs:196`

Each rewrite is semantics-identical: `?` returns `None` on exactly the predicate the explicit branch returned `None` on; `filter` equals the `and_then`/predicate; the removed `&` was a no-op format arg. `Why/What/Test` docs on touched items preserved; no SLOC cap impact.

## Verification (RAW output, clippy 1.97.0 toolchain)
- `cargo clippy --workspace --all-targets -- -D warnings` → **0 warnings** (exit 0)
- `cargo build --workspace` → exit 0
- `cargo fmt --check` → clean
- `bash scripts/check_line_cap.sh` → `14 allowlisted, 0 violations — OK`
- `cargo test` (trusty-memory, trusty-analyze, trusty-agents, trusty-mpm) → all `test result: ok`, 0 failed

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools