### PR TITLE
fix(trusty-search): return doc hits for Unknown-intent queries instead of empty (Closes #2203)

### DIFF
--- a/crates/trusty-search/src/core/indexer/mod.rs
+++ b/crates/trusty-search/src/core/indexer/mod.rs
@@ -57,6 +57,8 @@ mod tests;
 mod tests_cursor;
 #[cfg(test)]
 mod tests_idle_evict;
+#[cfg(test)]
+mod tests_unknown_intent;
 
 // Re-export helpers so sibling modules can use the crate-internal API.
 pub(crate) use helpers::{

--- a/crates/trusty-search/src/core/indexer/search/mod.rs
+++ b/crates/trusty-search/src/core/indexer/search/mod.rs
@@ -147,9 +147,19 @@ impl CodeIndexer {
         // Issue #73: intent-aware effective mode. Conceptual and Definition
         // intents both need docs, so when the caller used the default Code mode,
         // upgrade to All. Explicit Code from the caller still wins.
+        //
+        // Issue #2203: `Unknown` intent (short 1-3 word NL queries — the
+        // `multi_noun_re` classifier requires ≥4 tokens to reach Conceptual)
+        // was NOT in this upgrade set, so it stayed `Code` and BM25's correct
+        // `.md` / `.txt` hits were hard-dropped by `apply_archive_downrank`'s
+        // file-type retain below, silently returning empty/irrelevant results
+        // for exactly the queries the semantic/NL search tool is meant to
+        // serve. Upgrading `Unknown` alongside `Conceptual`/`Definition` lets
+        // those doc hits surface.
         let effective_mode = match (&intent, query.mode) {
             (QueryIntent::Conceptual, super::SearchMode::Code) => super::SearchMode::All,
             (QueryIntent::Definition, super::SearchMode::Code) => super::SearchMode::All,
+            (QueryIntent::Unknown, super::SearchMode::Code) => super::SearchMode::All,
             _ => query.mode,
         };
 
@@ -262,47 +272,66 @@ impl CodeIndexer {
             .await;
 
         // 6) Mode-based hard file-type filter + archive downrank.
-        self.apply_archive_downrank(&mut result, effective_mode, query.exclude_archived);
+        self.apply_archive_downrank(&mut result, &intent, effective_mode, query.exclude_archived);
         Ok(result)
     }
 
-    /// Apply the mode-based hard file-type filter and the archive score
-    /// penalty.
+    /// Apply the mode-based file-type filter and the archive score penalty.
     ///
     /// Why: two distinct concerns share the post-materialisation step: (1) the
-    /// `SearchMode` filter drops chunks outside the allowed file-type set; (2)
-    /// the archive penalty demotes archived/legacy/deprecated code. Combining
-    /// them in one method keeps post-processing logic consolidated.
-    /// What: (1) retains only chunks for which
-    /// `docs_penalty::is_allowed_for_mode` returns `true` (skipped for `All`).
-    /// (2) runs `archive::classify` per chunk, multiplies score by the
-    /// penalty, stamps `archive_reason`. When `exclude_archived` is `true`,
-    /// chunks with strong archive signals are dropped. Re-sorts by score desc.
+    /// `SearchMode` filter drops (or, for `Unknown` intent, down-ranks) chunks
+    /// outside the allowed file-type set; (2) the archive penalty demotes
+    /// archived/legacy/deprecated code. Combining them in one method keeps
+    /// post-processing logic consolidated.
+    /// What: (1) for genuinely code-shaped intents, retains only chunks for
+    /// which `docs_penalty::is_allowed_for_mode` returns `true` (skipped for
+    /// `All`). Issue #2203: for `Unknown` intent specifically, the hard
+    /// retain is replaced by the existing `doc_score_penalty` multiplicative
+    /// down-rank — this is defense-in-depth alongside the `Unknown`→`All`
+    /// upgrade in `search()` so a short NL query can never come back empty
+    /// even if some other caller/path leaves `mode` at `Code`. (2) runs
+    /// `archive::classify` per chunk, multiplies score by the penalty, stamps
+    /// `archive_reason`. When `exclude_archived` is `true`, chunks with
+    /// strong archive signals are dropped. Re-sorts by score desc.
     /// Test: `test_archive_downrank_demotes_deprecated_chunks`,
-    /// `test_exclude_archived_drops_archive_chunks`, `test_mode_filter_*`.
+    /// `test_exclude_archived_drops_archive_chunks`, `test_mode_filter_*`,
+    /// `tests_unknown_intent::test_unknown_intent_downranks_docs_instead_of_dropping_them`.
     fn apply_archive_downrank(
         &self,
         results: &mut Vec<CodeChunk>,
+        intent: &QueryIntent,
         mode: super::SearchMode,
         exclude_archived: bool,
     ) {
         if results.is_empty() {
             return;
         }
+        // Issue #2203: `Unknown` intent never hard-drops non-code files when
+        // `mode` resolves to `Code` — down-rank via `doc_score_penalty`
+        // instead so NL queries can't silently come back empty. Every other
+        // intent keeps the existing hard filter (no regression for real code
+        // queries such as `Usage`/`BugDebt`/explicit `Definition`).
+        let soft_downrank_unknown =
+            matches!(intent, QueryIntent::Unknown) && matches!(mode, super::SearchMode::Code);
         if matches!(mode, super::SearchMode::Code) {
             use crate::core::chunker::ChunkType;
             results.retain(|chunk| !matches!(chunk.chunk_type, ChunkType::Docstring));
         }
-        results.retain(|chunk| docs_penalty::is_allowed_for_mode(&chunk.file, mode));
+        if !soft_downrank_unknown {
+            results.retain(|chunk| docs_penalty::is_allowed_for_mode(&chunk.file, mode));
+        }
 
         let mut markers = MarkerCache::new();
         let mut archived_ids: HashSet<String> = HashSet::new();
         for chunk in results.iter_mut() {
             let (archive_mult, archive_reason_opt) =
                 archive::classify(&self.root_path, &chunk.file, &chunk.content, &mut markers);
-            let (_docs_mult, docs_reason_opt) = docs_penalty::doc_score_penalty(&chunk.file, mode);
+            let (docs_mult, docs_reason_opt) = docs_penalty::doc_score_penalty(&chunk.file, mode);
             if archive_reason_opt.is_some() {
                 chunk.score *= archive_mult;
+            }
+            if soft_downrank_unknown {
+                chunk.score *= docs_mult;
             }
             if let Some(reason) = &archive_reason_opt {
                 if exclude_archived && !reason.starts_with("stale:") {

--- a/crates/trusty-search/src/core/indexer/tests.rs
+++ b/crates/trusty-search/src/core/indexer/tests.rs
@@ -2535,21 +2535,18 @@ async fn seed_mode_filter_corpus(idx: &CodeIndexer) {
 #[tokio::test]
 async fn test_mode_filter_code_returns_only_source() {
     // Why: code mode (the default) must return strictly source-code
-    // extensions. Prose docs, named docs, configs, and data files must
-    // be dropped from results entirely — not merely demoted.
+    // extensions for genuinely code-shaped intents. Prose docs, named
+    // docs, configs, and data files must be dropped from results
+    // entirely — not merely demoted.
     let idx = make_indexer();
     seed_mode_filter_corpus(&idx).await;
-    // Issue #119 update: query is `alpha` (no underscore, no PascalCase, no
-    // acronym) so it classifies as `Unknown` and the intent-aware
-    // effective-mode override in `search()` does not promote Code → All.
-    // The previous query `alpha_qwerty` started classifying as Definition
-    // under the v0.8.3 classifier rules, which (correctly) triggers the
-    // override for docs-only fallback paths and would defeat this test's
-    // explicit Code-mode contract. The corpus chunks all contain
-    // `alpha_qwerty`, which BM25-tokenises into `alpha` + `qwerty`, so the
-    // single-word `alpha` still matches every seeded chunk.
+    // Issue #2203: query is `where is alpha_qwerty`, classified `Usage`
+    // by the `usage_re` pattern (`where is`) — a code-shaped intent NOT
+    // in the Code→All upgrade set, so the hard file-type filter still
+    // applies. (`Unknown`, e.g. bare `alpha`, is now upgraded/down-ranked
+    // instead — see `indexer::tests_unknown_intent`.)
     let q = SearchQuery {
-        text: "alpha".to_string(),
+        text: "where is alpha_qwerty".to_string(),
         top_k: 20,
         expand_graph: false,
         compact: false,

--- a/crates/trusty-search/src/core/indexer/tests_unknown_intent.rs
+++ b/crates/trusty-search/src/core/indexer/tests_unknown_intent.rs
@@ -1,0 +1,177 @@
+//! Regression tests for issue #2203 (P0): `Unknown`-intent (short 1-3 word
+//! natural-language) queries must never silently return empty/irrelevant
+//! results.
+//!
+//! Why: these tests live in their own file (rather than growing `tests.rs`
+//! further) to respect the 1500-SLOC test cap — `tests.rs` is already
+//! grandfathered near its frozen budget (same rationale as `tests_cursor.rs`
+//! / `tests_idle_evict.rs`).
+//! What: pins the fix for the reported bug — a short NL query classifies as
+//! `Unknown` intent (`multi_noun_re` requires >= 4 tokens to reach
+//! `Conceptual`, see `classifier::classify`); `SearchQuery::mode` defaults to
+//! `SearchMode::Code`; before this fix `Unknown` was not in the Code→All
+//! upgrade set in `CodeIndexer::search`, so `effective_mode` stayed `Code`
+//! and `apply_archive_downrank`'s hard file-type `retain` deleted every
+//! non-code chunk post-hoc, silently dropping BM25's correct `.md` hit. Also
+//! pins the companion no-regression contract: intents that are NOT `Unknown`
+//! (e.g. `BugDebt`) still hard-filter to source-only in `Code` mode.
+//! Test: this module.
+
+use std::sync::Arc;
+
+use super::{CodeIndexer, SearchMode, SearchQuery};
+use crate::core::chunker::{ChunkType, RawChunk};
+use crate::core::classifier::{QueryClassifier, QueryIntent};
+use crate::core::embed::{Embedder, MockEmbedder};
+use crate::core::store::{UsearchStore, VectorStore};
+
+const TEST_ROOT: &str = "/tmp/test";
+
+/// Build an absolute file path for a relative path under [`TEST_ROOT`]
+/// (mirrors `tests::abs` — `CodeChunk.file` is resolved to an absolute path
+/// at materialisation time, issue #402).
+fn abs(rel: &str) -> String {
+    std::path::Path::new(TEST_ROOT)
+        .join(rel)
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Minimal in-memory `RawChunk` builder (mirrors `tests::raw`).
+fn raw(id: &str, file: &str, content: &str) -> RawChunk {
+    RawChunk {
+        id: id.to_string(),
+        file: file.to_string(),
+        start_line: 1,
+        end_line: 1 + content.lines().count(),
+        content: content.to_string(),
+        function_name: None,
+        language: Some("rust".to_string()),
+        chunk_type: ChunkType::Code,
+        calls: Vec::new(),
+        inherits_from: Vec::new(),
+        chunk_depth: 0,
+        parent_chunk_id: None,
+        child_chunk_ids: Vec::new(),
+        nlp_keywords: Vec::new(),
+        nlp_code_refs: Vec::new(),
+        virtual_terms: Vec::new(),
+    }
+}
+
+/// Indexer with an embedder + HNSW store but no durable corpus (mirrors
+/// `tests::make_indexer`).
+fn make_indexer() -> CodeIndexer {
+    let dim = 32;
+    let embedder: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(dim));
+    let store: Arc<dyn VectorStore> = Arc::new(UsearchStore::new(dim).expect("usearch new"));
+    CodeIndexer::new("test", TEST_ROOT).with_components(embedder, store)
+}
+
+/// Issue #2203 (P0) acceptance test: a short NL query classifies as
+/// `Unknown`, `mode` is left at its default (`Code`) — mirroring a real
+/// caller that never sets `mode` explicitly — and the matching `.md` doc hit
+/// must survive in a non-empty result set instead of being hard-dropped.
+#[tokio::test]
+async fn test_unknown_intent_downranks_docs_instead_of_dropping_them() {
+    let idx = make_indexer();
+    idx.add_chunk(raw(
+        "doc:pool",
+        "docs/pooling.md",
+        "# connection pooling\nHow the database connection pooling subsystem batches reuse.",
+    ))
+    .await
+    .unwrap();
+    idx.add_chunk(raw(
+        "src:pool",
+        "src/pool.rs",
+        "fn acquire() -> Conn { unimplemented!() }",
+    ))
+    .await
+    .unwrap();
+    idx.add_chunk(raw(
+        "src:other",
+        "src/other.rs",
+        "fn unrelated() -> bool { true }",
+    ))
+    .await
+    .unwrap();
+
+    let query_text = "connection pooling";
+    assert_eq!(
+        QueryClassifier::classify(query_text),
+        QueryIntent::Unknown,
+        "fixture query must classify as Unknown for this to be a valid regression test"
+    );
+
+    let q = SearchQuery {
+        text: query_text.to_string(),
+        top_k: 20,
+        expand_graph: false,
+        compact: false,
+        // Deliberately left at the default (`Code`) — the real-world shape
+        // of the bug: callers of the NL/semantic search tool never set
+        // `mode` explicitly.
+        ..Default::default()
+    };
+    let results = idx.search(&q).await.unwrap();
+    assert!(
+        !results.is_empty(),
+        "Unknown-intent NL query must not return empty results"
+    );
+    let files: Vec<&str> = results.iter().map(|c| c.file.as_str()).collect();
+    assert!(
+        files.iter().any(|f| f.ends_with(".md")),
+        "Unknown-intent NL query must surface the matching doc hit: {files:?}"
+    );
+}
+
+/// Companion no-regression test: an intent that is NOT `Unknown` (here
+/// `BugDebt`) must still hard-filter to source-only in `Code` mode.
+/// `indexer::tests::test_mode_filter_code_returns_only_source` already
+/// covers a `Usage`-intent query end-to-end; this adds an independent
+/// `BugDebt`-intent example.
+#[tokio::test]
+async fn test_bugdebt_intent_still_hard_filters_code_mode() {
+    let idx = make_indexer();
+    idx.add_chunk(raw(
+        "src:1",
+        "src/lib.rs",
+        "fn alpha_qwerty() -> bool { true }",
+    ))
+    .await
+    .unwrap();
+    idx.add_chunk(raw(
+        "doc:1",
+        "docs/intro.md",
+        "# alpha_qwerty\nDocumentation about alpha_qwerty.",
+    ))
+    .await
+    .unwrap();
+
+    let query_text = "bug in alpha_qwerty";
+    assert_eq!(
+        QueryClassifier::classify(query_text),
+        QueryIntent::BugDebt,
+        "fixture query must classify as BugDebt for this to be a valid regression test"
+    );
+
+    let q = SearchQuery {
+        text: query_text.to_string(),
+        top_k: 20,
+        expand_graph: false,
+        compact: false,
+        mode: SearchMode::Code,
+        ..Default::default()
+    };
+    let results = idx.search(&q).await.unwrap();
+    let files: Vec<&str> = results.iter().map(|c| c.file.as_str()).collect();
+    assert!(
+        files.contains(&abs("src/lib.rs").as_str()),
+        "BugDebt intent + code mode must still include source: {files:?}"
+    );
+    assert!(
+        !files.iter().any(|f| f.ends_with(".md")),
+        "BugDebt intent + code mode must still exclude .md: {files:?}"
+    );
+}


### PR DESCRIPTION
Closes #2203

## Summary

Semantic/NL search silently returned empty results for `Unknown`-intent (short 1-3 word natural-language) queries.

**Root cause chain** (diagnosed by repo owner, code-read + live-reproduced on `origin/main`):
- `SearchQuery::mode` defaults to `SearchMode::Code` (`core/indexer/types.rs`).
- `CodeIndexer::search` only upgraded `Code`→`All` for `Conceptual`/`Definition` intents (`core/indexer/search/mod.rs` ~150-153); `Unknown` fell through and stayed `Code`.
- Short NL queries (1-3 words) classify as `Unknown` (`multi_noun_re` requires ≥4 tokens by design, `core/classifier/classify.rs`).
- `apply_archive_downrank` then did a hard `retain` dropping every non-`CODE_EXTENSIONS` file when mode was `Code` — so BM25's correct `.md`/`.txt` hits were deleted post-hoc, silently returning empty/irrelevant results.

## Approach chosen

Two changes, matching the prescribed fix:

1. **`core/indexer/search/mod.rs` ~150-154** — add `Unknown` to the intent set that upgrades `Code`→`All`, alongside `Conceptual`/`Definition`. This is the primary fix: it lets Unknown NL queries surface doc hits.

2. **`core/indexer/search/mod.rs` `apply_archive_downrank` ~283-300** — defense-in-depth: `Unknown` intent no longer hard-drops non-code files even if `mode` somehow still resolves to `Code` (e.g. a future caller path that bypasses the upgrade above). Instead of the hard file-type `retain`, it applies the existing (previously unused — `_docs_mult` was discarded) `docs_penalty::doc_score_penalty` **multiplicative down-rank** to non-code chunks — a soft demotion rather than a deletion.

   Chose the existing multiplicative penalty over a new additive one because: the infrastructure already existed and was unused, it's the simplest change, and it keeps prose/config visible-but-lower-ranked rather than invisible.

   Every other intent (`Usage`, `BugDebt`, and `Conceptual`/`Definition` which already upgrade away from `Code`) keeps the existing hard filter — no regression for real code-shaped queries.

## Regression tests

Added in a new file `crates/trusty-search/src/core/indexer/tests_unknown_intent.rs` (kept separate from `tests.rs`, which is already near its frozen 1500-SLOC test-cap budget — same rationale as the existing `tests_cursor.rs` / `tests_idle_evict.rs` splits):

- `test_unknown_intent_downranks_docs_instead_of_dropping_them` — builds an in-memory corpus with a matching `.md` doc plus `.rs` files, runs a 2-word query (`"connection pooling"`) verified via assertion to classify as `Unknown`, with `mode` left at its default (`Code`) to mirror a real caller that never sets `mode` explicitly. Asserts non-empty results containing the `.md` hit.
- `test_bugdebt_intent_still_hard_filters_code_mode` — companion no-regression test confirming a `BugDebt`-intent query still hard-filters to source-only in `Code` mode.

Also updated `test_mode_filter_code_returns_only_source` in `tests.rs`: its query previously relied on classifying as `Unknown` to exercise the (pre-fix) hard Code-only filter contract. Since `Unknown` is now upgraded/down-ranked per this fix, the query was changed to `"where is alpha_qwerty"` (`Usage` intent — not in the upgrade set) so it continues to validate the genuine hard-filter contract for non-`Unknown` intents.

## Verification (raw output)

**Build:**
```
cargo build -p trusty-search
   Compiling trusty-search v0.32.2 (...)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.42s
```

**Test (full suite):**
```
cargo test -p trusty-search
test result: ok. 1020 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 11.46s   (lib)
test result: ok. 252 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s      (integration_tests)
... (all other integration suites: 0 failed)
```
New tests visible in output:
```
test core::indexer::tests_unknown_intent::test_bugdebt_intent_still_hard_filters_code_mode ... ok
test core::indexer::tests_unknown_intent::test_unknown_intent_downranks_docs_instead_of_dropping_them ... ok
test core::indexer::tests::test_mode_filter_code_returns_only_source ... ok
```

**Clippy:**
```
cargo clippy -p trusty-search --all-targets -- -D warnings
    Checking trusty-search v0.32.2 (...)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.05s
```
(0 warnings; exit 0)

**Fmt:**
```
cargo fmt --check
```
(exit 0, no diffs)

**Line cap:**
```
bash scripts/check_line_cap.sh
line-cap: 14 allowlisted, 0 violations — OK.
```

**Before/after repro (acceptance evidence):** temporarily reverted only `core/indexer/search/mod.rs` to the pre-fix `origin/main` version, then:
```
cargo test -p trusty-search --lib tests_unknown_intent
test core::indexer::tests_unknown_intent::test_bugdebt_intent_still_hard_filters_code_mode ... ok
test core::indexer::tests_unknown_intent::test_unknown_intent_downranks_docs_instead_of_dropping_them ... FAILED

---- core::indexer::tests_unknown_intent::test_unknown_intent_downranks_docs_instead_of_dropping_them stdout ----
thread '...' panicked at crates/trusty-search/src/core/indexer/tests_unknown_intent.rs:123:5:
Unknown-intent NL query must surface the matching doc hit: ["/tmp/test/src/other.rs", "/tmp/test/src/pool.rs"]

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 1019 filtered out; finished in 0.03s
```
Restored the fix, re-ran the same command:
```
cargo test -p trusty-search --lib tests_unknown_intent
test core::indexer::tests_unknown_intent::test_bugdebt_intent_still_hard_filters_code_mode ... ok
test core::indexer::tests_unknown_intent::test_unknown_intent_downranks_docs_instead_of_dropping_them ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1019 filtered out; finished in 0.03s
```

This confirms `test_unknown_intent_downranks_docs_instead_of_dropping_them` is the acceptance test for the fix: it fails pre-fix (only `.rs` files returned, `.md` hit dropped) and passes post-fix (non-empty results including the `.md` doc hit).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools