### PR TITLE
docs(crates.io): add trusty-mpm package metadata + repoint trusty-search CI badge to monorepo

### DIFF
--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -6,6 +6,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "trusty-mpm: unified multi-agent orchestration platform (core, daemon, CLI, TUI, Telegram)"
+readme = "README.md"
+homepage = "https://github.com/bobmatnyc/trusty-tools"
+keywords = ["orchestration", "multi-agent", "cli", "daemon", "mcp"]
+categories = ["command-line-utilities", "development-tools"]
 exclude = ["/.claude/", "/.trusty-mpm/", "/CLAUDE.md"]
 
 # ── Feature flags ─────────────────────────────────────────────────────────────

--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -1,6 +1,6 @@
 # trusty-search
 
-[![CI](https://github.com/bobmatnyc/trusty-search/actions/workflows/ci.yml/badge.svg)](https://github.com/bobmatnyc/trusty-search/actions/workflows/ci.yml)
+[![CI](https://github.com/bobmatnyc/trusty-tools/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/bobmatnyc/trusty-tools/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/trusty-search.svg)](https://crates.io/crates/trusty-search)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 


### PR DESCRIPTION
## Summary
- Adds missing crates.io publish metadata (`readme`, `homepage`, `keywords`, `categories`) to `crates/trusty-mpm/Cargo.toml` so the published package page renders correctly.
- Repoints the trusty-search README's CI badge from the archived standalone `bobmatnyc/trusty-search` repo (perpetually shows "CI - failing" since Actions no longer run there) to the monorepo `bobmatnyc/trusty-tools` workflow.

## Test plan
- [x] `cargo build -p trusty-mpm` — succeeds
- [x] `cargo metadata --no-deps --format-version 1` confirms the four new TOML fields (`readme`, `homepage`, `keywords`, `categories`) parse and resolve correctly for the `trusty-mpm` package (note: `cargo metadata` in this cargo version does not accept a `-p` flag, so the equivalent whole-workspace `--no-deps` invocation was used and filtered for the `trusty-mpm` package entry)
- [x] `cargo fmt --check` — clean (only nightly-feature warnings, no diffs)
- [x] `bash scripts/check_line_cap.sh` — clean, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)