### PR TITLE
docs(crates.io): add missing package metadata to 7 crates

### DIFF
--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -7,6 +7,10 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Stable agent-plugin surface (ToolExecutor, AgentPlugin, ToolResult) shared by trusty-agents and external agent crates."
+readme = "README.md"
+homepage = "https://github.com/bobmatnyc/trusty-tools"
+keywords = ["agent", "orchestration", "plugin", "rpc", "traits"]
+categories = ["development-tools", "asynchronous"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -9,6 +9,10 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Per-project Claude-Code-compatible MPM orchestration harness (bin: tcode) — an original coding harness, tracked under epic #2052."
+readme = "README.md"
+homepage = "https://github.com/bobmatnyc/trusty-tools"
+keywords = ["cli", "mcp", "orchestration", "agents", "harness"]
+categories = ["command-line-utilities", "development-tools"]
 publish = false
 
 [[bin]]

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -9,7 +9,7 @@ description = "Unified ONNX embedding daemon with HTTP + UDS transports and Batc
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"
 keywords = ["onnx", "embeddings", "daemon", "ml", "nlp"]
-categories = ["science::ml", "network-programming"]
+categories = ["artificial-intelligence", "network-programming"]
 
 [lib]
 name = "trusty_embedderd"

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/bobmatnyc/trusty-tools"
 description = "Unified ONNX embedding daemon with HTTP + UDS transports and BatchQueue (issue #164)."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"
+keywords = ["onnx", "embeddings", "daemon", "ml", "nlp"]
+categories = ["science::ml", "network-programming"]
 
 [lib]
 name = "trusty_embedderd"

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -11,6 +11,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 license.workspace = true
 repository = "https://github.com/bobmatnyc/trusty-tools"
 description = "Developer productivity analytics — git commit collection, classification, and reporting"
+homepage = "https://github.com/bobmatnyc/trusty-tools"
 keywords = ["git", "analytics", "productivity", "developer-metrics"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "README.md"

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.3.0"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"
+homepage = "https://github.com/bobmatnyc/trusty-tools"
+keywords = ["install", "upgrade", "control-plane", "cli", "orchestration"]
+categories = ["command-line-utilities", "development-tools"]
 # Workspace default: MIT (see root Cargo.toml [workspace.package] license = "MIT",
 # #898 relicense, and sibling crates). Use license.workspace = true so the
 # authoritative value propagates from one place.

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -6,6 +6,9 @@ description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true
 repository.workspace = true
 readme = "README.md"
+homepage = "https://github.com/bobmatnyc/trusty-tools"
+keywords = ["mcp", "memory", "vector-search", "knowledge-graph", "embeddings"]
+categories = ["command-line-utilities", "development-tools"]
 
 exclude = [".fastembed_cache/", "ui/node_modules/**"]
 

--- a/crates/trusty-progress/Cargo.toml
+++ b/crates/trusty-progress/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "trusty-progress"
 description = "Shared rustup/cargo-style progress + status display for the trusty-* tooling ecosystem"
+homepage = "https://github.com/bobmatnyc/trusty-tools"
+keywords = ["progress", "spinner", "cli", "terminal", "status"]
+categories = ["command-line-interface", "development-tools"]
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true


### PR DESCRIPTION
## Summary
- Manifest-only change adding missing crates.io `[package]` metadata (`keywords`, `categories`, `homepage`, `readme`) to bring 7 crates to parity with trusty-search's crates.io page.
- No `version`, `publish`, `license`, `repository`, `authors`, `edition`, or `rust-version` fields were touched in any manifest.

### Crates updated
| Crate | Fields added |
|---|---|
| `trusty-embedderd` | `keywords`, `categories` |
| `tga` (trusty-git-analytics) | `homepage` |
| `trusty-memory` | `homepage`, `keywords`, `categories` |
| `trusty-progress` | `homepage`, `keywords`, `categories` (no README present — `readme` skipped) |
| `trusty-agents-common` | `readme`, `homepage`, `keywords`, `categories` |
| `trusty-installer` | `homepage`, `keywords`, `categories` |
| `trusty-code` | `readme`, `homepage`, `keywords`, `categories` (`publish = false` / `version = "0.0.0"` left untouched) |

## Test plan
- [x] `cargo metadata --no-deps --format-version 1` exits 0
- [x] `cargo build -p trusty-embedderd -p tga -p trusty-memory -p trusty-progress -p trusty-agents-common -p trusty-installer -p trusty-code` — clean build
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations