### PR TITLE
improve(trusty-code): verify visible tests before finish_task + testability guidance (closes #2279)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10743,6 +10743,7 @@ dependencies = [
  "clap",
  "futures-util",
  "libc",
+ "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -56,6 +56,10 @@ reqwest = { workspace = true }
 # Bash tool: process-group kill on Unix (setsid / kill syscalls)
 libc = { workspace = true }
 
+# verify_gate (#2279): matches a `bash` tool call's command against the
+# finalized test-invocation patterns (`pytest\s+\S+`, `cargo test`, …).
+regex = { workspace = true }
+
 # DOC-28 catch-up digest for PM prompt seed context (#1762 PR2), plus the
 # shared JSON-RPC 2.0 / MCP wire types + STDIO loop (#2053) so `tcode serve
 # --stdio` speaks the exact same JSON-RPC-over-STDIO contract as trusty-memory

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -17,9 +17,11 @@
 //! finish convention, preserved unchanged as the fallback), or (#2072) an
 //! explicit, successfully-validated `finish_task` tool call, whose structured
 //! `status`/`summary`/`changes`/test-count fields become the final
-//! `AgentOutput` via `build_finish_output`. Aborts with a partial output when
-//! the turn cap, timeout, (#2056) an external cancellation flag, or (#2265
-//! fix #5) an external stop signal fires.
+//! `AgentOutput` via `build_finish_output` — UNLESS (#2279) an attached
+//! `FinishGate` rejects it first, downgrading it to a recoverable retry so
+//! the model gets another turn instead of finishing prematurely. Aborts with
+//! a partial output when the turn cap, timeout, (#2056) an external
+//! cancellation flag, or (#2265 fix #5) an external stop signal fires.
 //! What: The whole `chat → dispatch → iterate` body runs inside a single
 //! `tokio::time::timeout` so a stalled model or hung tool cannot block forever.
 //! Test: `agent_loop::tests` — stubbed two-turn flow, turn-cap abort, recoverable
@@ -56,6 +58,29 @@ pub(crate) use compaction::estimate_tokens;
 pub use error::AgentLoopError;
 pub use sink::ToolEventSink;
 pub use transcript::Transcript;
+
+/// Verify-before-finish gate hook (#2279): inspects the run's own
+/// `Transcript` at the exact moment a successful `finish_task` call would
+/// otherwise terminate the loop, and may reject it with a human-readable
+/// reason instead.
+///
+/// Why: A closure (rather than a trait) lets two very different verification
+/// strategies share one turn-boundary hook without `agent_loop` knowing
+/// about either concrete strategy: a delegated engineer's own loop needs
+/// only its own `Transcript` (its `bash` calls land there directly — see
+/// `crate::verify_gate::default_finish_gate`); the delegating PM's loop
+/// never calls `bash` itself, so its gate closure instead captures an
+/// external `run_task::SharedTranscript` and consults that instead (see
+/// `crate::verify_gate::pm_finish_gate`). This is the SAME decoupling
+/// `Self::stop_signal` (#2265 fix #5) already established for "some external
+/// condition the loop must consult at a turn boundary" — reused here rather
+/// than adding a bespoke third turn-boundary check.
+/// What: Returns `None` when the gate is satisfied (or inert — nothing
+/// requires verification for this run); `Some(reason)` when it trips,
+/// carrying the message fed back to the model as the rejected `finish_task`
+/// call's recoverable tool result.
+/// Test: `agent_loop::tests::finish_gate_*`.
+pub type FinishGate = Arc<dyn Fn(&Transcript) -> Option<String> + Send + Sync>;
 
 /// Phase name used when accruing token usage into the `PerfCollector`.
 const PERF_PHASE: &str = "agent_loop";
@@ -145,7 +170,9 @@ impl Default for AgentLoopConfig {
 /// dispatch, (#2056) a `cancel` flag checked once per turn boundary, and
 /// (#2265 fix #5) a `stop_signal` closure checked at that SAME turn boundary.
 /// All three default to `None`, so every existing call site (`run_task`,
-/// `runner::in_process`) is unaffected.
+/// `runner::in_process`) is unaffected. A fourth optional collaborator,
+/// (#2279) `finish_gate`, is set via [`Self::with_finish_gate`] — see
+/// [`FinishGate`]'s docs.
 /// Test: `agent_loop::tests::*`.
 pub struct AgentLoop {
     config: AgentLoopConfig,
@@ -154,6 +181,7 @@ pub struct AgentLoop {
     sink: Option<Arc<dyn ToolEventSink>>,
     cancel: Option<Arc<AtomicBool>>,
     stop_signal: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+    finish_gate: Option<FinishGate>,
 }
 
 impl AgentLoop {
@@ -182,6 +210,7 @@ impl AgentLoop {
             sink: None,
             cancel: None,
             stop_signal: None,
+            finish_gate: None,
         }
     }
 
@@ -233,6 +262,22 @@ impl AgentLoop {
     /// Test: `agent_loop::tests::stop_signal_aborts_before_next_turn`.
     pub fn with_stop_signal(mut self, signal: Arc<dyn Fn() -> bool + Send + Sync>) -> Self {
         self.stop_signal = Some(signal);
+        self
+    }
+
+    /// Attach a [`FinishGate`] consulted the moment a successful
+    /// `finish_task` call would otherwise terminate the loop (#2279).
+    ///
+    /// Why: Gives a caller a hook to reject a premature `finish_task` with a
+    /// recoverable retry instead of letting the loop terminate — see
+    /// [`FinishGate`]'s docs for how the delegated-engineer and delegating-PM
+    /// cases differ. `None` (the default) is a pure no-op; every existing
+    /// call site that never attaches a gate is unaffected.
+    /// What: Builder-style setter; returns `self` for chaining.
+    /// Test: `agent_loop::tests::finish_gate_trips_and_recovers`,
+    /// `agent_loop::tests::finish_gate_inert_without_named_test_command`.
+    pub fn with_finish_gate(mut self, gate: FinishGate) -> Self {
+        self.finish_gate = Some(gate);
         self
     }
 
@@ -389,6 +434,14 @@ impl AgentLoop {
     /// emits more than one in a single turn. A malformed/invalid `finish_task`
     /// call is reported through the same recoverable-error path as any other
     /// tool and does NOT terminate the loop, letting the model retry.
+    /// (#2279) A `finish_task` call that DID succeed is still subject to the
+    /// optional [`Self::finish_gate`] — see [`FinishGate`]'s docs. When
+    /// attached and it trips, the result is downgraded in place to
+    /// `ToolResult::err(reason)` — the SAME recoverable-error shape used
+    /// throughout this method — BEFORE the sink notification and transcript
+    /// push below, so both see the rejection, not the original success; this
+    /// also means the `finish_args` assignment below never fires for a
+    /// gate-rejected call, so the loop simply continues to the next turn.
     /// Test: `agent_loop::tests::recoverable_tool_error_continues`,
     /// `agent_loop::tests::malformed_tool_arguments_report_recoverable_error_and_loop_continues`,
     /// `sink_receives_started_then_finished_in_order`,
@@ -396,7 +449,9 @@ impl AgentLoop {
     /// `explicit_finish_task_terminates_loop_with_structured_summary`,
     /// `malformed_finish_task_repairs_then_terminates`,
     /// `finish_task_missing_required_field_is_recoverable_not_terminal`,
-    /// `finish_task_invalid_enum_value_is_recoverable_not_terminal`.
+    /// `finish_task_invalid_enum_value_is_recoverable_not_terminal`,
+    /// `finish_gate_trips_and_recovers`,
+    /// `finish_gate_inert_without_named_test_command`.
     async fn dispatch_all(
         &self,
         tool_calls: &[ToolCall],
@@ -421,7 +476,20 @@ impl AgentLoop {
                 sink.tool_started(&call.id, tool, &args.to_string()).await;
             }
 
-            let result = self.registry.dispatch_gated(tool, args.clone(), None).await;
+            let mut result = self.registry.dispatch_gated(tool, args.clone(), None).await;
+
+            // #2279: a `finish_task` call that otherwise SUCCEEDED is still
+            // subject to the verify-before-finish gate, if one is attached.
+            // Tripping it downgrades the result to the same recoverable-error
+            // shape every other tool failure uses, so the model sees WHY
+            // finish was rejected and gets another turn to fix it, rather
+            // than the loop silently declining to terminate.
+            if tool == FINISH_TASK_TOOL_NAME
+                && !result.is_error()
+                && let Some(reason) = self.finish_gate.as_ref().and_then(|gate| gate(transcript))
+            {
+                result = ToolResult::err(reason);
+            }
 
             if let Some(sink) = &self.sink {
                 notify_result(sink.as_ref(), &call.id, tool, &result).await;

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -312,6 +312,43 @@ fn registry_with_finish_task() -> Arc<ToolRegistry> {
     Arc::new(reg)
 }
 
+/// A registry containing `FinishTaskTool` AND `BashTool` (#2279).
+///
+/// Why: The verify-before-finish gate tests need a real `bash` tool so a
+/// scripted `bash` call actually dispatches (its dispatch outcome does not
+/// matter to the gate — only that the call landed in the transcript — but a
+/// registered tool keeps the scenario representative of production wiring).
+fn registry_with_finish_task_and_bash() -> Arc<ToolRegistry> {
+    let mut reg = ToolRegistry::new();
+    reg.register(Arc::new(FinishTaskTool::new()));
+    reg.register(Arc::new(crate::tools::BashTool::default_config()));
+    Arc::new(reg)
+}
+
+/// Build a response fixture in which the assistant calls `bash` with the
+/// given `command` (#2279).
+fn bash_call_response(call_id: &str, command: &str) -> Value {
+    json!({
+        "id": "gen-bash",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "arguments": json!({"command": command}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 8, "completion_tokens": 6, "total_tokens": 14 }
+    })
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────────
 
 /// Config defaults are present and sane.
@@ -1145,6 +1182,89 @@ async fn finish_task_full_shape_propagates_into_output() {
     assert!(out.content.contains("Task completed: shipped it"));
     assert!(out.content.contains("a.rs (+10/-2)"));
     assert!(out.content.contains("Tests: 4/4 passed"));
+}
+
+// ── #2279: verify-before-finish gate ────────────────────────────────────────────
+
+/// An attached [`crate::verify_gate::default_finish_gate`] rejects a
+/// premature `finish_task` with a RECOVERABLE retry (not a terminal error)
+/// when the task names a runnable test command that was never invoked, and
+/// the loop recovers once the named tests actually run.
+///
+/// Why: This is #2279's core acceptance criterion — a `finish_task` call
+/// that would otherwise have terminated the loop after turn 1 must instead
+/// give the model another turn to run the named tests, then succeed on a
+/// LATER `finish_task` call once the gate is satisfied.
+/// What: Script [finish_task (premature), bash("pytest tests/ -v"),
+/// finish_task (now valid)]; attach the default gate; assert the run
+/// completes only after all THREE chat calls (proving turn 1's finish was
+/// rejected and turn 3's succeeded), with the final structured summary from
+/// the second `finish_task` call.
+/// Test: this test.
+#[tokio::test]
+async fn finish_gate_trips_and_recovers() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        finish_task_call_response(
+            "call-premature",
+            r#"{"status": "completed", "summary": "done (premature)"}"#,
+        ),
+        bash_call_response("call-bash", "pytest tests/ -v"),
+        finish_task_call_response(
+            "call-verified",
+            r#"{"status": "completed", "summary": "done (verified)"}"#,
+        ),
+    ]));
+    let registry = registry_with_finish_task_and_bash();
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default())
+        .with_finish_gate(crate::verify_gate::default_finish_gate());
+
+    let out = agent
+        .run(
+            "system prompt",
+            "implement the parser; run `pytest tests/ -v` before finishing",
+        )
+        .await
+        .expect("loop should recover and terminate on the verified finish call");
+
+    assert_eq!(
+        llm.calls(),
+        3,
+        "turn 1's premature finish must be rejected, turn 2 runs the named \
+         tests, turn 3's finish must succeed"
+    );
+    assert_eq!(out.summary.as_deref(), Some("done (verified)"));
+    assert_eq!(out.content, "Task completed: done (verified)");
+}
+
+/// An attached [`crate::verify_gate::default_finish_gate`] is INERT — the
+/// success path is unchanged — when the task never names a runnable test
+/// command.
+///
+/// Why: #2279 explicitly defers general polyglot test-suite discovery; the
+/// gate must not invent a requirement nothing ever stated, and existing
+/// tasks with no test command must behave exactly as before this change.
+/// What: Script a single valid `finish_task` call for a task that names no
+/// test command; attach the default gate; assert it still terminates after
+/// exactly ONE chat call, identically to
+/// `explicit_finish_task_terminates_loop_with_structured_summary`.
+/// Test: this test.
+#[tokio::test]
+async fn finish_gate_inert_without_named_test_command() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[finish_task_call_response(
+        "call-finish",
+        r#"{"status": "completed", "summary": "implemented the widget"}"#,
+    )]));
+    let registry = registry_with_finish_task_and_bash();
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default())
+        .with_finish_gate(crate::verify_gate::default_finish_gate());
+
+    let out = agent
+        .run("system prompt", "implement a widget")
+        .await
+        .expect("gate must stay inert when no test command is named");
+
+    assert_eq!(llm.calls(), 1, "gate must not force an extra turn");
+    assert_eq!(out.summary.as_deref(), Some("implemented the widget"));
 }
 
 /// Live OpenRouter test: trivial task through the real client + a real tool.

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -245,6 +245,7 @@ mod tests {
                 model: "openai/gpt-4o-mini".to_string(),
                 text: "done".to_string(),
                 tool_calls: vec!["delegate_to_agent".to_string()],
+                ran_test_command: false,
                 usage: TokenUsage::new(10, 5, 0, 0),
             }],
             usage: TokenUsage::new(10, 5, 0, 0),

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -267,6 +267,20 @@ pub mod runner;
 /// Test: `run_task::tests::*` (all offline, mocked LLM).
 pub mod run_task;
 
+/// Verify-before-finish gate (#2279): rejects a premature `finish_task` with
+/// a recoverable retry when a named test command was never run.
+///
+/// Why: (bake-off L2 diagnosis) An engineer that never runs the visible,
+/// prompt-named test suite can still call `finish_task` successfully today;
+/// this module gives both the delegated engineer's loop and the delegating
+/// PM's loop a turn-boundary hook to reject that specific case.
+/// What: [`agent_loop::FinishGate`] constructors `default_finish_gate` (own
+/// transcript) and `pm_finish_gate` (externally shared engineer transcript),
+/// plus the pure `names_test_command`/`is_test_command` regex predicates
+/// they share.
+/// Test: `verify_gate::tests::*`.
+pub mod verify_gate;
+
 /// DOC-28 catch-up context injection for the PM prompt (#1762, PR2).
 ///
 /// Why: The PM agent needs recent project-activity context (paused sessions,

--- a/crates/trusty-code/src/prompt/preamble.rs
+++ b/crates/trusty-code/src/prompt/preamble.rs
@@ -68,6 +68,13 @@ an existing suite goes unrun is not verification.
 observed its output. If you could not run the suite, say so explicitly instead \
 of asserting an unverified result.
 
+## Testable design
+
+- Prefer pure, unit-testable core functions: parsing and business logic should \
+accept plain data as input and return plain data as output.
+- Keep I/O (subprocess invocation, network calls, filesystem access) in thin \
+wrapper functions, separate from the core logic they feed.
+
 ## Finish convention
 
 - You signal that the task is complete by producing an assistant turn that \

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -221,6 +221,30 @@ fn base_preamble_requires_running_project_test_suite_before_finishing() {
     );
 }
 
+/// `BASE_PREAMBLE` nudges toward pure, unit-testable core functions with I/O
+/// kept in thin wrappers (#2279 improvement 2, bake-off L2 diagnosis: tcode
+/// fused `git` invocation directly into `parse_git_log`, making it untestable
+/// against the visible text-fixture suite the challenge instructed it to
+/// run).
+///
+/// Why: This is a general product-quality nudge, not a benchmark-specific
+/// patch — it must apply to every agent's assembled prompt, so it belongs in
+/// the model-agnostic BASE preamble like the neighbouring verification block.
+/// What: Asserts the preamble names both halves of the principle: pure core
+/// functions, and I/O kept separate in thin wrappers.
+/// Test: this test.
+#[test]
+fn base_preamble_nudges_testable_design() {
+    assert!(
+        BASE_PREAMBLE.contains("pure, unit-testable core functions"),
+        "must nudge toward pure, unit-testable core functions"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("thin wrapper functions"),
+        "must instruct keeping I/O in thin wrapper functions separate from core logic"
+    );
+}
+
 /// `BASE_PREAMBLE` carries no host- or model-specific tokens (spec §2a/§3).
 ///
 /// Why: Any model name, provider name, or host path in the BASE preamble would
@@ -258,7 +282,7 @@ fn base_preamble_version_is_semver_shaped() {
 /// Expected FNV-1a-style fold of [`BASE_PREAMBLE`]'s bytes, folded with its
 /// byte length. Regenerate this whenever the preamble legitimately changes
 /// (see [`base_preamble_hash_tripwire`] for the contributor instructions).
-const EXPECTED_PREAMBLE_HASH: u64 = 0x9376_d3b2_eb84_3e4e;
+const EXPECTED_PREAMBLE_HASH: u64 = 0xcdfb_41b6_3f06_2396;
 
 /// Test-time guard coupling `BASE_PREAMBLE` *content* to its version constant.
 ///

--- a/crates/trusty-code/src/prompt/version.rs
+++ b/crates/trusty-code/src/prompt/version.rs
@@ -18,4 +18,4 @@
 /// `BASE_PREAMBLE` text so reports referencing an old run remain interpretable.
 /// Test: `prompt::tests::base_preamble_version_is_semver_shaped` asserts the
 /// three-component shape.
-pub const BASE_PREAMBLE_VERSION: &str = "1.1.0";
+pub const BASE_PREAMBLE_VERSION: &str = "1.2.0";

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -205,7 +205,14 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
         pm_llm,
         Arc::new(pm_registry),
     )
-    .with_stop_signal(Arc::new(move || stop_signal.is_cap_reached()));
+    .with_stop_signal(Arc::new(move || stop_signal.is_cap_reached()))
+    // #2279: the PM never calls `bash` itself (its registry above is
+    // `delegate_to_agent` + `finish_task` only), so its verify-before-finish
+    // gate must scan the delegated engineer's transcript instead of its
+    // own — `verify_gate::pm_finish_gate` does exactly that against the
+    // SAME shared `transcript` the engineer's `RecordingLlmClient` records
+    // into (see `build_engineer_runner` above).
+    .with_finish_gate(crate::verify_gate::pm_finish_gate(Arc::clone(&transcript)));
 
     // Snapshot before, run the PM, snapshot after.
     let before = diff::capture_snapshot(&params.project);

--- a/crates/trusty-code/src/run_task/recorder.rs
+++ b/crates/trusty-code/src/run_task/recorder.rs
@@ -31,13 +31,19 @@ use crate::perf::TokenUsage;
 /// the full raw message history.
 /// What: `role` is the agent label; `model` is the resolved slug for that turn;
 /// `text` is the assistant prose (empty for tool-only turns); `tool_calls` lists
-/// the invoked tool names in order; `usage` is the token usage the provider
-/// reported for this turn (the per-turn unit the run aggregates over both PM and
-/// engineer turns, since the engineer's usage is otherwise lost when its output
-/// flows back to the PM as a tool-result string). `Deserialize` (#2060) lets
-/// `tcode`'s CLI thin client parse a `session.get_transcript` JSON-RPC result
-/// straight back into `Vec<TurnRecord>`.
-/// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`.
+/// the invoked tool names in order; `ran_test_command` (#2279) is a summarized
+/// signal — `true` iff this turn's tool calls included a `bash` invocation
+/// matching `crate::verify_gate::is_test_command` — the delegating PM's own
+/// `verify_gate::pm_finish_gate` consults this instead of the engineer's full
+/// transcript, since the PM never calls `bash` itself; `usage` is the token
+/// usage the provider reported for this turn (the per-turn unit the run
+/// aggregates over both PM and engineer turns, since the engineer's usage is
+/// otherwise lost when its output flows back to the PM as a tool-result
+/// string). `Deserialize` (#2060) lets `tcode`'s CLI thin client parse a
+/// `session.get_transcript` JSON-RPC result straight back into
+/// `Vec<TurnRecord>`.
+/// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`,
+/// `verify_gate::tests::pm_gate_satisfied_when_engineer_ran_tests`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TurnRecord {
     /// Agent label that produced this turn (e.g. `"pm"`, `"python-engineer"`).
@@ -48,6 +54,11 @@ pub struct TurnRecord {
     pub text: String,
     /// Names of tools the assistant called this turn, in order.
     pub tool_calls: Vec<String>,
+    /// Whether this turn ran a `bash` command matching #2279's verify-before-
+    /// finish test-command pattern. `#[serde(default)]` keeps a pre-#2279
+    /// persisted transcript deserialising cleanly with this flag `false`.
+    #[serde(default)]
+    pub ran_test_command: bool,
     /// Token usage the provider reported for this turn.
     pub usage: TokenUsage,
 }
@@ -107,23 +118,30 @@ impl LlmClientTrait for RecordingLlmClient {
     /// RESOLVED model slug (#1475 bug 2 — `resp.resolved_model(&req.model)`,
     /// which prefers the provider-reported model and falls back to the
     /// requested slug when the response omits one), the response's first
-    /// text, and its tool-call names; returns the response unchanged. Errors
-    /// propagate untouched (and are not recorded).
+    /// text, its tool-call names, and (#2279) whether any of those calls was
+    /// a matching `bash` test invocation (`ran_test_command`, computed via
+    /// `crate::verify_gate::bash_command_from_call` +
+    /// `crate::verify_gate::is_test_command` — the SAME predicate the
+    /// engineer's own in-transcript gate uses); returns the response
+    /// unchanged. Errors propagate untouched (and are not recorded).
     /// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`,
-    /// `run_task::tests::transcript_records_resolved_model_not_requested_slug`.
+    /// `run_task::tests::transcript_records_resolved_model_not_requested_slug`,
+    /// `run_task::tests::recorder_flags_ran_test_command_on_matching_bash_call`.
     async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
         let resp = self.inner.chat(req).await?;
 
-        let tool_calls = resp
-            .first_tool_calls()
+        let calls = resp.first_tool_calls();
+        let ran_test_command = calls
             .iter()
-            .map(|c| c.function.name.clone())
-            .collect();
+            .filter_map(crate::verify_gate::bash_command_from_call)
+            .any(|cmd| crate::verify_gate::is_test_command(&cmd));
+        let tool_calls = calls.iter().map(|c| c.function.name.clone()).collect();
         let record = TurnRecord {
             role: self.role.clone(),
             model: resp.resolved_model(&req.model).to_string(),
             text: resp.first_text().unwrap_or_default(),
             tool_calls,
+            ran_test_command,
             usage: resp.clone().token_usage(),
         };
 

--- a/crates/trusty-code/src/run_task/report.rs
+++ b/crates/trusty-code/src/run_task/report.rs
@@ -280,6 +280,7 @@ mod tests {
                     model: "openai/gpt-4o-mini".into(),
                     text: String::new(),
                     tool_calls: vec!["delegate_to_agent".into()],
+                    ran_test_command: false,
                     usage: TokenUsage::new(60, 20, 0, 0),
                 },
                 TurnRecord {
@@ -287,6 +288,7 @@ mod tests {
                     model: "deepseek/deepseek-chat".into(),
                     text: "wrote the file".into(),
                     tool_calls: vec!["write_file".into()],
+                    ran_test_command: false,
                     usage: TokenUsage::new(40, 20, 0, 0),
                 },
             ],
@@ -396,6 +398,7 @@ mod tests {
                 model: "openai/gpt-4o-mini".into(),
                 text: String::new(),
                 tool_calls: vec![],
+                ran_test_command: false,
                 usage: TokenUsage::new(10, 5, 0, 0),
             },
             TurnRecord {
@@ -403,6 +406,7 @@ mod tests {
                 model: "openai/gpt-4o-mini".into(),
                 text: "done".into(),
                 tool_calls: vec![],
+                ran_test_command: false,
                 usage: TokenUsage::new(20, 8, 0, 0),
             },
         ];
@@ -431,6 +435,7 @@ mod tests {
                 model: "anthropic/claude-haiku-4".into(),
                 text: String::new(),
                 tool_calls: vec!["delegate_to_agent".into()],
+                ran_test_command: false,
                 usage: TokenUsage::new(1000, 500, 0, 0),
             },
             TurnRecord {
@@ -438,6 +443,7 @@ mod tests {
                 model: "anthropic/claude-sonnet-4-5".into(),
                 text: "done".into(),
                 tool_calls: vec![],
+                ran_test_command: false,
                 usage: TokenUsage::new(2000, 1000, 0, 0),
             },
         ];
@@ -479,6 +485,7 @@ mod tests {
                 model: "anthropic/claude-sonnet-4-5".into(),
                 text: String::new(),
                 tool_calls: vec![],
+                ran_test_command: false,
                 usage: authoritative_usage,
             },
             TurnRecord {
@@ -486,6 +493,7 @@ mod tests {
                 model: "anthropic/claude-sonnet-4-5".into(),
                 text: "done".into(),
                 tool_calls: vec![],
+                ran_test_command: false,
                 usage: TokenUsage::new(100, 50, 0, 0),
             },
         ];

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -147,6 +147,53 @@ fn write_file_response(path: &str, content: &str) -> Value {
     })
 }
 
+/// A response where the assistant calls `bash(command)` (#2279).
+fn bash_response(command: &str) -> Value {
+    json!({
+        "id": "gen-bash",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-bash",
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "arguments": json!({"command": command}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}
+    })
+}
+
+/// A response where the assistant calls `finish_task(status, summary)`
+/// (#2279).
+fn finish_task_response(status: &str, summary: &str) -> Value {
+    json!({
+        "id": "gen-finish",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-finish",
+                    "type": "function",
+                    "function": {
+                        "name": "finish_task",
+                        "arguments": json!({"status": status, "summary": summary}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 15, "completion_tokens": 8, "total_tokens": 23}
+    })
+}
+
 /// A response where the assistant emits final text and stops.
 fn stop_response(text: &str) -> Value {
     json!({
@@ -1048,5 +1095,108 @@ async fn pm_stops_redelegating_once_cap_latched_ends_partial_promptly() {
         "the PM must not have issued any further delegate_to_agent calls \
          after the cap latched (bounded, not spinning to the ~12 calls an \
          unfixed 8-turn PM loop would need), got {total_calls} total chat calls"
+    );
+}
+
+// ── #2279: PM-side verify-before-finish gate (symmetric with the engineer's) ────
+
+/// (#2279) The PM's verify-before-finish gate is SATISFIED — its
+/// `finish_task` call succeeds on the FIRST attempt — when the delegated
+/// engineer's OWN transcript shows a matching `bash` test invocation, even
+/// though the PM never calls `bash` itself.
+///
+/// Why: This is #2279's PM-symmetric acceptance criterion proven end to end
+/// (not just at the `verify_gate::pm_finish_gate` unit level): the real
+/// wiring in `execute_run_task` — the shared `SharedTranscript` both the PM's
+/// and the engineer's `RecordingLlmClient` record into — must actually carry
+/// the engineer's `ran_test_command` signal through to the PM's gate.
+/// What: The task names `pytest tests/ -v`. Script [PM delegates, engineer
+/// runs `pytest tests/ -v` via `bash`, engineer stops (D3), PM finish_task];
+/// assert the scripted client saw EXACTLY four calls — proving the PM's
+/// single `finish_task` attempt was accepted, not rejected into a fifth
+/// retry turn — and the run did not surface as a failure.
+/// Test: this test.
+#[tokio::test]
+async fn pm_finish_gate_satisfied_when_engineer_ran_named_tests() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        delegate_response("implement the parser; then run `pytest tests/ -v`"),
+        bash_response("pytest tests/ -v"),
+        stop_response("engineer: ran the suite"),
+        finish_task_response("completed", "verified via the named test suite"),
+    ]));
+
+    let mut task_params = params(&agents, &project, None);
+    task_params.task = "implement the parser; run `pytest tests/ -v` before finishing".into();
+
+    let report = execute_run_task(task_params, llm.clone()).await;
+
+    assert_eq!(
+        llm.models_seen().len(),
+        4,
+        "the PM's single finish_task attempt must be accepted, not rejected \
+         into a fifth retry turn; task: {}",
+        report.task
+    );
+    assert_ne!(
+        report.exit,
+        ExitCode::RunFailure,
+        "an accepted finish must not surface as a run failure; task: {}",
+        report.task
+    );
+}
+
+/// (#2279) The PM's verify-before-finish gate TRIPS — its `finish_task` call
+/// is rejected as a RECOVERABLE retry, not a run failure — when the task
+/// names a runnable test command but the delegated engineer's transcript
+/// shows no matching invocation, and the PM's run still recovers/completes
+/// via its OWN next turn.
+///
+/// Why: The negative half of the PM-symmetric acceptance criterion, proving
+/// (a) the gate actually rejects a premature finish sourced from the
+/// engineer's silence, and (b) that rejection is recoverable — the PM gets
+/// exactly one more turn, not a hung loop or a hard failure.
+/// What: The task names `pytest tests/ -v`. Script [PM delegates, engineer
+/// writes a file WITHOUT running `bash` at all, engineer stops (D3), PM's
+/// FIRST finish_task attempt (must be rejected), PM's SECOND turn (a plain
+/// D3 stop — unaffected by the gate, proving recovery)]; assert the scripted
+/// client saw exactly FIVE calls — one more than the satisfied-gate test's
+/// four, precisely the one recoverable retry turn the gate forced — and the
+/// run did not surface as a failure.
+/// Test: this test.
+#[tokio::test]
+async fn pm_finish_gate_trips_when_engineer_never_ran_named_tests() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        delegate_response("implement the parser; then run `pytest tests/ -v`"),
+        write_file_response("parser.py", "def parse():\n    pass\n"),
+        stop_response("engineer: wrote the parser (did not run tests)"),
+        finish_task_response("completed", "premature — tests never ran"),
+        stop_response("pm: recovered after the rejected finish_task"),
+    ]));
+
+    let mut task_params = params(&agents, &project, None);
+    task_params.task = "implement the parser; run `pytest tests/ -v` before finishing".into();
+
+    let report = execute_run_task(task_params, llm.clone()).await;
+
+    assert_eq!(
+        llm.models_seen().len(),
+        5,
+        "the PM's premature finish_task must be rejected into exactly one \
+         recoverable retry turn, not accepted outright and not looped \
+         indefinitely; task: {}",
+        report.task
+    );
+    assert_ne!(
+        report.exit,
+        ExitCode::RunFailure,
+        "a gate rejection must be a recoverable retry, not a run failure; \
+         task: {}",
+        report.task
     );
 }

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -325,7 +325,9 @@ impl InProcessAgentRunner {
     /// `tools.allowed`), resolves the model (`RunContext` > agent > default) and
     /// turn cap (`RunContext.max_turns_override` > runner default), assembles the
     /// system prompt (BASE + agent prompt + project context), runs the
-    /// `AgentLoop`, and maps any loop error to `RunnerError::Loop`.
+    /// `AgentLoop` — attaching (#2279) `verify_gate::default_finish_gate` so a
+    /// premature `finish_task` gets a recoverable retry rather than
+    /// terminating the loop — and maps any loop error to `RunnerError::Loop`.
     /// Test: `runner::tests::*`.
     async fn run_pipeline(
         &self,
@@ -368,7 +370,15 @@ impl InProcessAgentRunner {
             self.skills_catalog.as_deref(),
         );
 
-        let mut agent_loop = AgentLoop::new(loop_config, Arc::clone(&self.llm), registry);
+        let mut agent_loop = AgentLoop::new(loop_config, Arc::clone(&self.llm), registry)
+            // #2279: every sub-agent this runner drives gets the default
+            // verify-before-finish gate — its own `bash` calls land in its
+            // own `Transcript`, so no external state is needed. This is the
+            // ONE production construction site for every delegated
+            // sub-agent loop (both `run_task` and `task::executor` delegate
+            // through this runner), so wiring it here covers both entry
+            // points without duplicating the attachment at each call site.
+            .with_finish_gate(crate::verify_gate::default_finish_gate());
         if let Some(sink) = &self.sink {
             agent_loop = agent_loop.with_tool_event_sink(Arc::clone(sink));
         }

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -540,6 +540,7 @@ async fn set_run_outcome_stores_transcript_and_usage() {
         model: "openai/gpt-4o-mini".to_string(),
         text: "done".to_string(),
         tool_calls: vec![],
+        ran_test_command: false,
         usage: crate::perf::TokenUsage::new(10, 5, 0, 0),
     }];
     registry.set_run_outcome(

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -231,7 +231,13 @@ async fn run_and_record(
         Arc::new(pm_registry),
     )
     .with_tool_event_sink(Arc::clone(&sink))
-    .with_cancel_flag(Arc::clone(&cancel));
+    .with_cancel_flag(Arc::clone(&cancel))
+    // #2279: mirrors `run_task::execute_run_task`'s own wiring — the PM
+    // never calls `bash` itself, so its verify-before-finish gate scans the
+    // delegated engineer's turns via the SAME shared `transcript` the
+    // engineer's `RecordingLlmClient` records into (`build_engineer_runner`
+    // above), rather than the PM's own (bash-less) transcript.
+    .with_finish_gate(crate::verify_gate::pm_finish_gate(Arc::clone(&transcript)));
 
     let result = pm_loop.run(&pm_system, &params.task).await;
 

--- a/crates/trusty-code/src/tools/bash/mod.rs
+++ b/crates/trusty-code/src/tools/bash/mod.rs
@@ -33,6 +33,14 @@ pub(crate) const MAX_OUTPUT_BYTES: usize = 100 * 1024; // 100 KB
 /// Default command timeout in seconds.
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
 
+/// The tool's registered/advertised name.
+///
+/// Why: Shared literal between the `ToolExecutor` impl and
+/// `crate::verify_gate`'s bash-call scan (#2279), so the two can never drift
+/// — mirrors `finish_task::FINISH_TASK_TOOL_NAME`'s existing convention.
+/// Test: `bash::tests::name_matches_constant`.
+pub const BASH_TOOL_NAME: &str = "bash";
+
 /// Executes arbitrary shell commands on behalf of the coder agent loop.
 ///
 /// Why: Lets the LLM run test suites (pytest, cargo test, etc.), build steps,
@@ -80,7 +88,7 @@ impl BashTool {
 #[async_trait]
 impl ToolExecutor for BashTool {
     fn name(&self) -> &str {
-        "bash"
+        BASH_TOOL_NAME
     }
 
     /// OpenAI-function schema for the bash tool.

--- a/crates/trusty-code/src/tools/bash/tests.rs
+++ b/crates/trusty-code/src/tools/bash/tests.rs
@@ -11,9 +11,22 @@ use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
 
-use super::BashTool;
+use super::{BASH_TOOL_NAME, BashTool};
 use crate::tools::registry::ToolRegistry;
 use crate::tools::traits::ToolExecutor;
+
+/// `BashTool::name()` matches the exported [`BASH_TOOL_NAME`] constant.
+///
+/// Why: `crate::verify_gate`'s bash-call scan (#2279) matches tool calls by
+/// this literal; a drift here would silently break that gate.
+/// What: Trivial equality assertion.
+/// Test: this test.
+#[test]
+fn name_matches_constant() {
+    let tool = BashTool::default_config();
+    assert_eq!(tool.name(), BASH_TOOL_NAME);
+    assert_eq!(BASH_TOOL_NAME, "bash");
+}
 
 /// A fast command (echo) returns captured stdout and exit 0.
 ///

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -6,10 +6,11 @@
 //! What: Re-exports `ToolExecutor`, `AgentRunner`, `RunContext`, `AgentOutput`,
 //! `SearchProvider`, `SearchResult`, `SkillResolver`, and `ToolResult` from
 //! `traits`; `ToolRegistry` from `registry`; `DelegateToAgentTool` from
-//! `delegate`; `FinishTaskTool` (#2072) from `finish_task`; and `UseSkillTool`
+//! `delegate`; `FinishTaskTool` (#2072) from `finish_task`; `UseSkillTool`
 //! plus `USE_SKILL_TOOL_NAME` (#2069's progressive-disclosure on-invoke
 //! loader; the constant lets #2070's compaction pin skill outputs by tool
-//! name) from `skill`.
+//! name) from `skill`; and `BASH_TOOL_NAME` (#2279's verify-before-finish
+//! gate matches bash tool calls by this literal) from `bash`.
 //! Test: Unit tests live in each submodule; integration tests use
 //! `DelegateToAgentTool` with a `MockAgentRunner`.
 
@@ -23,7 +24,7 @@ pub mod traits;
 
 // Flat re-exports for `crate::tools::*` convenience.
 #[allow(unused_imports)]
-pub use bash::BashTool;
+pub use bash::{BASH_TOOL_NAME, BashTool};
 #[allow(unused_imports)]
 pub use delegate::DelegateToAgentTool;
 pub use finish_task::{

--- a/crates/trusty-code/src/verify_gate.rs
+++ b/crates/trusty-code/src/verify_gate.rs
@@ -1,0 +1,520 @@
+//! Verify-before-finish gate (#2279): a recoverable retry, not a hard block,
+//! that keeps a coding agent from calling `finish_task` before it has run a
+//! test suite it was explicitly told about.
+//!
+//! Why: (bake-off L2 diagnosis) tcode's delegated engineer authored 81 tests
+//! validating the wrong contract and never ran the visible, prompt-named
+//! test suite the L2 challenge instructed it to run before submitting. The
+//! task prompt and `challenges/README.md` (folded into project context)
+//! named a runnable test command (`pytest challenges/level-2-git-analyzer/
+//! test_suite/ -v`); the transcript never shows it being invoked. This
+//! module is the structural fix: at the `finish_task` turn boundary
+//! (`agent_loop::AgentLoop::dispatch_all`), if the task/project-context text
+//! names a runnable test command AND no matching `bash` invocation appears
+//! in the relevant transcript, `finish_task` is rejected with a recoverable
+//! error — the SAME `ToolResult::err` retry path every other tool failure
+//! uses — instead of terminating the loop. If no test command is named at
+//! all, the gate is INERT: #2279 explicitly defers general polyglot
+//! test-suite discovery (the "(b2)" follow-up) rather than inventing one
+//! here.
+//! What: [`names_test_command`] and [`is_test_command`] are pure,
+//! independently unit-testable regex predicates — Improvement 2's own
+//! testability principle applied to its sibling Improvement 1. Two
+//! `agent_loop::FinishGate` constructors build on them: [`default_finish_gate`]
+//! scans a single loop's OWN `Transcript` — what a delegated engineer's
+//! sub-agent loop attaches (`runner::in_process::InProcessAgentRunner`),
+//! since its own `bash` calls land directly in that transcript.
+//! [`pm_finish_gate`] is for the delegating PM's loop, which never calls
+//! `bash` itself — it scans the externally shared `run_task::SharedTranscript`
+//! of `TurnRecord`s the delegated engineer's turns are recorded into
+//! instead, via each record's `ran_test_command` flag (set by
+//! `run_task::recorder::RecordingLlmClient` using the SAME [`is_test_command`]
+//! predicate this module owns, so the two paths can never independently
+//! drift on what counts as a matching invocation).
+//! Test: `verify_gate::tests::*`.
+
+use std::sync::Arc;
+
+use regex::Regex;
+use serde_json::Value;
+
+use crate::agent_loop::{FinishGate, Transcript};
+use crate::llm::{ChatMessage, ToolCall};
+use crate::run_task::SharedTranscript;
+use crate::tools::BASH_TOOL_NAME;
+
+/// Recoverable-retry message fed back to a delegated engineer's own loop
+/// when its `finish_task` call is rejected.
+const GATE_REASON_ENGINEER: &str = "finish_task rejected: the task prompt or project context \
+names a runnable test command (a pytest/cargo/npm/pnpm/go test invocation), but no matching \
+command has been run yet in this session. Run the named test suite via the bash tool, \
+reconcile any failures, and only then call finish_task again.";
+
+/// Recoverable-retry message fed back to the delegating PM's own loop when
+/// its `finish_task` call is rejected because the delegated engineer never
+/// ran the named tests.
+const GATE_REASON_PM: &str = "finish_task rejected: the task prompt or project context names a \
+runnable test command (a pytest/cargo/npm/pnpm/go test invocation), but the delegated \
+engineer's transcript shows no matching invocation yet. Delegate a follow-up task instructing \
+the engineer to run the named test suite and reconcile any failures before finishing.";
+
+/// Build the regex alternation matching the six test-invocation shapes named
+/// in #2279's finalized trigger heuristic.
+///
+/// Why: A single compiled pattern, rather than six separate `Regex`es, keeps
+/// [`names_test_command`] and [`is_test_command`] identical in shape — "does
+/// this text contain a recognizable test-command invocation" — the only
+/// difference between the two call sites is WHICH text they scan. Compiled
+/// fresh per call rather than cached in a `once_cell`/`lazy_static` global
+/// (project convention reserves those for the tracing subscriber only); this
+/// is not a hot path — at most once per `finish_task` dispatch attempt, or
+/// once per recorded turn — so the recompilation cost is immaterial next to
+/// the LLM round-trip it sits beside.
+/// What: `pytest\s+\S+` (a pytest invocation naming a path/module),
+/// `cargo test`, `npm test`, `pnpm test`, `go test`, `python -m pytest` —
+/// exactly the six patterns #2279's finalized decision comment named.
+/// Test: covered indirectly by every `tests::*` case below.
+fn test_command_pattern() -> Regex {
+    Regex::new(
+        r"(?:pytest\s+\S+)|(?:cargo\s+test)|(?:npm\s+test)|(?:pnpm\s+test)|(?:go\s+test)|(?:python\s+-m\s+pytest)",
+    )
+    .expect("test_command_pattern: hardcoded regex literal must compile")
+}
+
+/// Whether `text` textually names a runnable test command (the gate's
+/// TRIGGER half).
+///
+/// Why: The gate must stay inert when nothing in the task/project context
+/// ever asked for a specific test command.
+/// What: `true` iff [`test_command_pattern`] finds a match anywhere in
+/// `text`.
+/// Test: `tests::names_test_command_detects_each_pattern`,
+/// `tests::names_test_command_false_on_unrelated_text`.
+pub fn names_test_command(text: &str) -> bool {
+    test_command_pattern().is_match(text)
+}
+
+/// Whether `command` (a `bash` tool call's shell command) IS a matching test
+/// invocation (the gate's VERIFY half).
+///
+/// Why: Reused by both [`default_finish_gate`]'s own-transcript scan and
+/// `run_task::recorder`'s per-turn `ran_test_command` signal, so the two
+/// gate sites can never independently drift on what counts as "the named
+/// tests actually ran".
+/// What: Same predicate as [`names_test_command`], applied to a single
+/// command string rather than free-form prose.
+/// Test: `tests::is_test_command_matches_each_pattern`,
+/// `tests::is_test_command_false_on_unrelated_command`.
+pub fn is_test_command(command: &str) -> bool {
+    test_command_pattern().is_match(command)
+}
+
+/// Extract the shell command from a `bash` tool call's arguments, if `call`
+/// names the `bash` tool at all.
+///
+/// Why: Shared by [`default_finish_gate`]'s own-transcript scan and
+/// `run_task::recorder::RecordingLlmClient`'s per-turn signal, so the two
+/// gate sites parse the SAME wire shape (`{"command": "..."}`) identically.
+/// What: `None` when `call.function.name != BASH_TOOL_NAME` or the
+/// arguments do not parse as a JSON object with a string `command` field.
+/// Test: `tests::bash_command_from_call_extracts_command`,
+/// `tests::bash_command_from_call_ignores_other_tools`.
+pub fn bash_command_from_call(call: &ToolCall) -> Option<String> {
+    if call.function.name != BASH_TOOL_NAME {
+        return None;
+    }
+    let parsed: Value = serde_json::from_str(&call.function.arguments).ok()?;
+    parsed.get("command")?.as_str().map(str::to_string)
+}
+
+/// Whether any `bash` call in `messages` invoked a matching test command.
+///
+/// Why: The core predicate [`default_finish_gate`] applies to a delegated
+/// engineer's own `Transcript` — factored out as a free function so it is
+/// independently unit-testable against a plain `&[ChatMessage]` without
+/// constructing a full `Transcript`.
+/// What: Flattens every assistant turn's `tool_calls`, extracts each `bash`
+/// call's command via [`bash_command_from_call`], and checks
+/// [`is_test_command`].
+/// Test: `tests::transcript_ran_test_command_detects_match`,
+/// `tests::transcript_ran_test_command_false_without_bash`.
+fn transcript_ran_test_command(messages: &[ChatMessage]) -> bool {
+    messages
+        .iter()
+        .filter_map(|m| m.tool_calls.as_ref())
+        .flatten()
+        .filter_map(bash_command_from_call)
+        .any(|cmd| is_test_command(&cmd))
+}
+
+/// Join the seeded `system` + `user` message text into one haystack for
+/// [`names_test_command`].
+///
+/// Why: `Transcript::seed` is the ONLY place raw history ever gets a
+/// `system`- or `user`-role entry, and it seeds exactly one of each — the
+/// assembled system prompt (BASE + agent prompt + project `CLAUDE.md`
+/// context) and the task text. Scanning by role (not position) stays
+/// correct even if `Transcript`'s internal layout ever changes.
+/// What: Concatenates the `content` of every `system`/`user` entry with
+/// newlines.
+/// Test: `tests::seed_text_joins_system_and_user`.
+fn seed_text(messages: &[ChatMessage]) -> String {
+    messages
+        .iter()
+        .filter(|m| m.role == "system" || m.role == "user")
+        .filter_map(|m| m.content.as_deref())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Build the default verify-before-finish gate: scans the SAME loop's own
+/// transcript for both the trigger and the verification.
+///
+/// Why: This is the shape a delegated engineer's sub-agent loop needs — its
+/// own `bash` calls land directly in its own `Transcript`, so no external
+/// state is required.
+/// What: Returns a [`FinishGate`] closure that is inert unless
+/// [`seed_text`] of the transcript [`names_test_command`]; when it does,
+/// trips (returning [`GATE_REASON_ENGINEER`]) unless
+/// [`transcript_ran_test_command`] finds a match.
+/// Test: `tests::default_gate_trips_when_named_and_unrun`,
+/// `tests::default_gate_inert_when_not_named`,
+/// `tests::default_gate_satisfied_when_run`,
+/// `agent_loop::tests::finish_gate_trips_and_recovers`.
+pub fn default_finish_gate() -> FinishGate {
+    Arc::new(|transcript: &Transcript| {
+        let messages = transcript.messages();
+        if !names_test_command(&seed_text(&messages)) {
+            return None;
+        }
+        if transcript_ran_test_command(&messages) {
+            return None;
+        }
+        Some(GATE_REASON_ENGINEER.to_string())
+    })
+}
+
+/// Build the delegating PM's verify-before-finish gate: the trigger comes
+/// from the PM's own transcript, but the verification scans the externally
+/// shared engineer transcript instead.
+///
+/// Why: The PM's own tool registry never includes `bash` (`run_task::
+/// execute_run_task` registers only `delegate_to_agent` and `finish_task`),
+/// so scanning the PM's own `Transcript` for a `bash` call would ALWAYS
+/// report "not run" — wrongly tripping the gate even when the delegated
+/// engineer ran the named tests correctly. `shared` is the SAME
+/// `run_task::SharedTranscript` the engineer's `RecordingLlmClient` records
+/// into, so this closure sees the engineer's turns too.
+/// What: Returns a [`FinishGate`] closure inert unless the PM transcript's
+/// [`seed_text`] [`names_test_command`]; when it does, trips (returning
+/// [`GATE_REASON_PM`]) unless any `TurnRecord` in `shared` has
+/// `ran_test_command == true`. A poisoned lock is treated as "not run" —
+/// fail toward asking the model to verify, not toward silently finishing.
+/// Test: `tests::pm_gate_trips_when_engineer_never_ran_tests`,
+/// `tests::pm_gate_satisfied_when_engineer_ran_tests`,
+/// `tests::pm_gate_inert_when_not_named`.
+pub fn pm_finish_gate(shared: SharedTranscript) -> FinishGate {
+    Arc::new(move |transcript: &Transcript| {
+        let messages = transcript.messages();
+        if !names_test_command(&seed_text(&messages)) {
+            return None;
+        }
+        let ran = shared
+            .lock()
+            .map(|turns| turns.iter().any(|t| t.ran_test_command))
+            .unwrap_or(false);
+        if ran {
+            return None;
+        }
+        Some(GATE_REASON_PM.to_string())
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::llm::FunctionCall;
+    use crate::run_task::TurnRecord;
+
+    fn bash_call(id: &str, command: &str) -> ToolCall {
+        ToolCall {
+            id: id.into(),
+            kind: "function".into(),
+            function: FunctionCall {
+                name: BASH_TOOL_NAME.into(),
+                arguments: serde_json::json!({"command": command}).to_string(),
+            },
+        }
+    }
+
+    fn assistant_with_tool_calls(calls: Vec<ToolCall>) -> ChatMessage {
+        ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            tool_calls: Some(calls),
+            tool_call_id: None,
+            name: None,
+            cache_control: None,
+        }
+    }
+
+    /// [`names_test_command`] detects each of the six finalized patterns.
+    ///
+    /// Why: Guards the exact pattern set #2279's decision comment named.
+    /// What: One assertion per pattern, embedded in surrounding prose.
+    /// Test: this test.
+    #[test]
+    fn names_test_command_detects_each_pattern() {
+        for text in [
+            "please run pytest tests/test_basic.py -v before submitting",
+            "then run cargo test",
+            "run npm test after building",
+            "use pnpm test to check",
+            "run go test ./... first",
+            "invoke python -m pytest as the final step",
+        ] {
+            assert!(names_test_command(text), "expected a match in {text:?}");
+        }
+    }
+
+    /// [`names_test_command`] is `false` on prose naming no test command.
+    ///
+    /// Why: The gate must stay inert for ordinary tasks that never mention a
+    /// runnable test suite.
+    /// What: Free-form task text with no recognizable pattern.
+    /// Test: this test.
+    #[test]
+    fn names_test_command_false_on_unrelated_text() {
+        assert!(!names_test_command(
+            "implement a git log parser and make sure it builds cleanly"
+        ));
+    }
+
+    /// [`is_test_command`] matches each pattern as a standalone command
+    /// string (not embedded in prose).
+    ///
+    /// Why: This is the shape a `bash` tool call's `command` argument
+    /// actually takes.
+    /// What: One assertion per pattern.
+    /// Test: this test.
+    #[test]
+    fn is_test_command_matches_each_pattern() {
+        for cmd in [
+            "pytest challenges/level-2-git-analyzer/test_suite/ -v",
+            "cargo test -p trusty-code",
+            "npm test",
+            "pnpm test --run",
+            "go test ./...",
+            "python -m pytest -x",
+        ] {
+            assert!(is_test_command(cmd), "expected a match in {cmd:?}");
+        }
+    }
+
+    /// [`is_test_command`] is `false` on an unrelated shell command.
+    ///
+    /// Why: Ordinary bash calls (`ls`, `git status`, a build command) must
+    /// not be mistaken for a test invocation.
+    /// What: A handful of common non-test commands.
+    /// Test: this test.
+    #[test]
+    fn is_test_command_false_on_unrelated_command() {
+        for cmd in ["ls -la", "git status", "cargo build --release", "echo ok"] {
+            assert!(!is_test_command(cmd), "unexpected match in {cmd:?}");
+        }
+    }
+
+    /// [`bash_command_from_call`] extracts the command from a real `bash`
+    /// call's JSON arguments.
+    ///
+    /// Why: This is the exact wire shape `BashTool::schema` declares.
+    /// What: Build a `bash` call, assert the extracted command.
+    /// Test: this test.
+    #[test]
+    fn bash_command_from_call_extracts_command() {
+        let call = bash_call("c1", "cargo test -p trusty-code");
+        assert_eq!(
+            bash_command_from_call(&call).as_deref(),
+            Some("cargo test -p trusty-code")
+        );
+    }
+
+    /// [`bash_command_from_call`] returns `None` for a non-`bash` tool call.
+    ///
+    /// Why: The gate must only ever consider `bash` calls a test invocation
+    /// — a `write_file` or `delegate_to_agent` call must never match.
+    /// What: A `write_file`-named call with an unrelated argument shape.
+    /// Test: this test.
+    #[test]
+    fn bash_command_from_call_ignores_other_tools() {
+        let call = ToolCall {
+            id: "c1".into(),
+            kind: "function".into(),
+            function: FunctionCall {
+                name: "write_file".into(),
+                arguments: serde_json::json!({"path": "x", "content": "y"}).to_string(),
+            },
+        };
+        assert_eq!(bash_command_from_call(&call), None);
+    }
+
+    /// [`seed_text`] joins the `system` and `user` entries, skipping any
+    /// `assistant`/`tool` entries in between.
+    ///
+    /// Why: The trigger check must only ever consider the ORIGINAL task
+    /// prompt/project context, never text that later shows up in tool
+    /// output.
+    /// What: Build a small message list; assert the join.
+    /// Test: this test.
+    #[test]
+    fn seed_text_joins_system_and_user() {
+        let messages = vec![
+            ChatMessage::system("SYSTEM_TEXT"),
+            ChatMessage::user("USER_TEXT"),
+            ChatMessage {
+                role: "assistant".into(),
+                content: Some("mentions cargo test in passing".into()),
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
+                cache_control: None,
+            },
+        ];
+        let joined = seed_text(&messages);
+        assert!(joined.contains("SYSTEM_TEXT"));
+        assert!(joined.contains("USER_TEXT"));
+        assert!(!joined.contains("mentions cargo test"));
+    }
+
+    /// [`transcript_ran_test_command`] finds a match inside an assistant
+    /// turn's `bash` tool calls.
+    ///
+    /// Why: This is the exact shape the engineer's own transcript takes
+    /// after it runs the named suite.
+    /// What: An assistant turn with one matching `bash` call.
+    /// Test: this test.
+    #[test]
+    fn transcript_ran_test_command_detects_match() {
+        let messages = vec![assistant_with_tool_calls(vec![bash_call(
+            "c1",
+            "pytest tests/ -v",
+        )])];
+        assert!(transcript_ran_test_command(&messages));
+    }
+
+    /// [`transcript_ran_test_command`] is `false` when no `bash` call is
+    /// present at all.
+    ///
+    /// Why: Guards the common "nothing ran yet" case.
+    /// What: An empty message list.
+    /// Test: this test.
+    #[test]
+    fn transcript_ran_test_command_false_without_bash() {
+        assert!(!transcript_ran_test_command(&[]));
+    }
+
+    /// [`default_finish_gate`] trips when the task names a test command and
+    /// no matching `bash` call appears in the transcript.
+    ///
+    /// Why: This is the core acceptance behaviour — a `finish_task` call
+    /// must be rejected with a recoverable reason under exactly this
+    /// condition.
+    /// What: Seed a transcript whose task names `pytest`, with no tool
+    /// calls at all; assert the gate returns `Some`.
+    /// Test: this test.
+    #[test]
+    fn default_gate_trips_when_named_and_unrun() {
+        let transcript = Transcript::seed("system prompt", "run pytest tests/ -v before finishing");
+        let gate = default_finish_gate();
+        assert!(gate(&transcript).is_some());
+    }
+
+    /// [`default_finish_gate`] is inert when the task never names a test
+    /// command.
+    ///
+    /// Why: #2279 explicitly defers general polyglot test-suite discovery —
+    /// the gate must not invent a requirement that was never stated.
+    /// What: Seed a transcript with an unrelated task; assert `None`.
+    /// Test: this test.
+    #[test]
+    fn default_gate_inert_when_not_named() {
+        let transcript = Transcript::seed("system prompt", "implement a widget");
+        let gate = default_finish_gate();
+        assert!(gate(&transcript).is_none());
+    }
+
+    /// [`default_finish_gate`] is satisfied once a matching `bash` call has
+    /// been pushed onto the transcript.
+    ///
+    /// Why: Proves the "recover" half of the recoverable-retry contract —
+    /// after the agent runs the named tests, a second gate check must pass.
+    /// What: Seed, push an assistant turn with a matching `bash` call;
+    /// assert `None`.
+    /// Test: this test.
+    #[test]
+    fn default_gate_satisfied_when_run() {
+        let mut transcript = Transcript::seed("system prompt", "run cargo test before finishing");
+        transcript.push_assistant(None, &[bash_call("c1", "cargo test -p trusty-code")]);
+        let gate = default_finish_gate();
+        assert!(gate(&transcript).is_none());
+    }
+
+    /// [`pm_finish_gate`] trips when the PM's task names a test command but
+    /// the shared (engineer) transcript never records a matching invocation.
+    ///
+    /// Why: This is the PM-symmetric half of the acceptance criterion — the
+    /// PM must not be able to `finish_task` while its delegated engineer's
+    /// transcript shows no verification either.
+    /// What: An empty `SharedTranscript`; assert the gate trips.
+    /// Test: this test.
+    #[test]
+    fn pm_gate_trips_when_engineer_never_ran_tests() {
+        let shared: SharedTranscript = Arc::new(Mutex::new(Vec::new()));
+        let transcript = Transcript::seed("pm system prompt", "run pytest tests/ -v");
+        let gate = pm_finish_gate(shared);
+        assert!(gate(&transcript).is_some());
+    }
+
+    /// [`pm_finish_gate`] is satisfied when a `TurnRecord` in the shared
+    /// transcript (recorded from the delegated engineer's own turns) has
+    /// `ran_test_command == true`.
+    ///
+    /// Why: Proves the PM-side gate correctly consults EXTERNAL state
+    /// (the engineer's recorded turns) rather than its own (bash-less)
+    /// transcript.
+    /// What: Seed the shared transcript with one `python-engineer` turn
+    /// carrying `ran_test_command: true`; assert `None`.
+    /// Test: this test.
+    #[test]
+    fn pm_gate_satisfied_when_engineer_ran_tests() {
+        let shared: SharedTranscript = Arc::new(Mutex::new(vec![TurnRecord {
+            role: "python-engineer".into(),
+            model: "test-model".into(),
+            text: String::new(),
+            tool_calls: vec!["bash".into()],
+            ran_test_command: true,
+            usage: crate::perf::TokenUsage::default(),
+        }]));
+        let transcript = Transcript::seed("pm system prompt", "run pytest tests/ -v");
+        let gate = pm_finish_gate(shared);
+        assert!(gate(&transcript).is_none());
+    }
+
+    /// [`pm_finish_gate`] is inert when the PM's own task never names a test
+    /// command, regardless of the shared transcript's contents.
+    ///
+    /// Why: Mirrors [`default_gate_inert_when_not_named`] for the PM path.
+    /// What: An unrelated PM task with an empty shared transcript.
+    /// Test: this test.
+    #[test]
+    fn pm_gate_inert_when_not_named() {
+        let shared: SharedTranscript = Arc::new(Mutex::new(Vec::new()));
+        let transcript = Transcript::seed("pm system prompt", "coordinate the widget build");
+        let gate = pm_finish_gate(shared);
+        assert!(gate(&transcript).is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- **Improvement 2** — `BASE_PREAMBLE` gains a "Testable design" block nudging agents toward pure, unit-testable core functions with I/O kept in thin wrappers. `BASE_PREAMBLE_VERSION` bumped to 1.2.0 (preamble hash tripwire refreshed).
- **Improvement 1** — verify-before-finish gate: a RECOVERABLE RETRY (not a terminal block, not a soft warning) at the `finish_task` turn boundary. If the task prompt or injected project context names a runnable test command (`pytest`, `cargo test`, `npm test`, `pnpm test`, `go test`, `python -m pytest`) and no matching `bash` invocation appears in the relevant transcript, `finish_task` is downgraded to `ToolResult::err(reason)` instead of terminating the loop, giving the agent another turn to run the named tests. Inert when no test command is named (general polyglot discovery stays deferred per #2279's decision comment).
  - Symmetric: the delegated engineer's own loop (`verify_gate::default_finish_gate`, wired once in `InProcessAgentRunner` — covers both the `run_task` CLI path and the `task::executor` daemon path) scans its own `Transcript`; the delegating PM's loop (`verify_gate::pm_finish_gate`, wired in both `run_task::execute_run_task` and `task::executor::run_and_record`) never calls `bash` itself, so it scans the shared `run_task::SharedTranscript` via a new `TurnRecord.ran_test_command` summarized signal.
  - Reuses PR #2274's `with_stop_signal` turn-boundary pattern (`AgentLoop::with_finish_gate`) rather than a bespoke third check. Does not alter `ExitCode` terminal semantics or Fix #5's stop-on-cap logic/tests.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-code` — 743 lib tests + all e2e suites pass (0 failed, 3 pre-existing live-API-gated ignores)
- [x] `cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] New tests: gate trips → recoverable retry → agent recovers/finishes (`agent_loop::tests::finish_gate_trips_and_recovers`); gate inert when no test command named (`agent_loop::tests::finish_gate_inert_without_named_test_command`, plus `verify_gate::tests::*_inert_*`); PM-side symmetric check sees the delegated sub-agent's transcript, both satisfied and tripped (`run_task::tests::pm_finish_gate_satisfied_when_engineer_ran_named_tests`, `run_task::tests::pm_finish_gate_trips_when_engineer_never_ran_named_tests`)

Closes #2279

🤖 Generated with [Claude Code](https://claude.com/claude-code)