### PR TITLE
feat(trusty-mpm): tm ls becomes session connector; alias list moves to tm ls --projects/-p

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -522,18 +522,55 @@ pub(crate) enum Command {
         root: Option<String>,
     },
 
-    /// List registered aliases with loaded status (DOC-24).
+    /// Interactive managed-session connector — list sessions and connect (#2311).
     ///
-    /// Why: operators need a quick overview of their registered fleet and which
-    /// aliases are ready to `run`.
-    /// What: prints a table or JSON array of alias, URL, and loaded status.
-    /// Test: `cli_parses_ls_standalone`.
+    /// Why: bare `tm ls` should do the most useful fleet action for the operator's
+    /// current context. On a real terminal it opens the interactive session picker
+    /// (the same numbered menu as bare `tm`, but scoped to the managed fleet), so
+    /// resuming a session is one keystroke away. Piped, scripted, or `--json`
+    /// invocations degrade to the same static, pipeable list as `tm session ls`,
+    /// never blocking on stdin. The former top-level `tm ls` (the DOC-24 alias /
+    /// project-registry list) now lives behind `--projects`/`-p`.
+    /// What: with `--projects`/`-p`, prints the local-project + managed-fleet alias
+    /// registry (`--json` = combined JSON, `--root` overrides the managed root).
+    /// Without `--projects`, it is the session connector: a TTY with ≥1 session
+    /// opens the picker; `--json`, `--all`, a non-TTY, or 0 sessions print the
+    /// static table. `--source-id`/`--current`/`--all` mirror `tm session ls`.
+    /// Test: `cli_parses_ls_connector_bare`, `cli_parses_ls_projects`,
+    /// `cli_parses_ls_projects_short`, `cli_parses_ls_json`, `cli_parses_ls_current`,
+    /// `cli_ls_source_id_and_current_conflict`.
     #[command(name = "ls")]
-    LsAliases {
-        /// Output as JSON array instead of a table.
+    Ls {
+        /// Show the repo-alias / project registry instead of managed sessions.
+        ///
+        /// Why (#2311): preserves the pre-connector top-level `tm ls` behavior —
+        /// the DOC-24 local-project + managed-fleet alias list — as an explicit,
+        /// discoverable opt-in now that bare `tm ls` is the session connector.
+        /// With `--projects`, `--json` prints the combined alias JSON and `--root`
+        /// selects the managed root; the session flags below are ignored.
+        #[arg(long, short = 'p')]
+        projects: bool,
+        /// Output as JSON. With `--projects`: the combined alias JSON array.
+        /// Without `--projects`: the raw daemon managed-session JSON (byte-for-byte
+        /// passthrough), forcing static output even on a TTY.
         #[arg(long)]
         json: bool,
-        /// Override the managed root (default: `~/.trusty-mpm`).
+        /// Filter sessions to this `owner/repo` slug (session mode only).
+        ///
+        /// Passed to the daemon as `?source_id=`; mirrors `tm session ls`.
+        #[arg(long)]
+        source_id: Option<String>,
+        /// Derive `source_id` from the cwd's git remote (session mode only).
+        ///
+        /// Mutually exclusive with `--source-id`; passing both is a parse error.
+        #[arg(long, conflicts_with = "source_id")]
+        current: bool,
+        /// Include decommissioned tombstone sessions (session mode only).
+        ///
+        /// Forces static output (the full forensic list is not a connect target).
+        #[arg(long)]
+        all: bool,
+        /// Override the managed root (default: `~/.trusty-mpm`). `--projects` only.
         ///
         /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
         /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -24,42 +24,7 @@ use anyhow::Context as _;
 use std::io::IsTerminal as _;
 
 pub(crate) use super::guided_autostart::github_host;
-use super::guided_launch::launch_new_session_and_attach;
-use super::managed::filter_live_sessions;
 use crate::formatters::info_box::DaemonInfo;
-
-/// Decision returned by [`parse_picker_choice`].
-///
-/// Why: extracting the parse-and-decide logic from the I/O driver makes it
-/// unit-testable without stdin/tmux. The driver calls parse, checks the variant,
-/// and shells out only for Resume and LaunchNew.
-/// What: five variants cover every valid and invalid input the picker can
-/// receive. [`Self::ConfirmRestart`] is the #2148 safety default: a bare Enter
-/// that WOULD have silently restarted (destructively recreated the tmux pane
-/// of) a stopped/errored session instead asks for an explicit numeric choice.
-/// Test: `guided_picker_bare_enter_no_sessions_launches_new`,
-/// `guided_picker_bare_enter_live_session_resumes_first`,
-/// `guided_picker_bare_enter_stopped_session_requires_confirm`,
-/// `guided_picker_q_returns_quit`, `guided_picker_numeric_valid_resumes`,
-/// `guided_picker_numeric_launch_new`, `guided_picker_out_of_range_unrecognised`,
-/// `guided_picker_non_numeric_unrecognised`.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum PickerDecision {
-    /// Resume the session at 0-based index into the sessions slice.
-    Resume(usize),
-    /// Launch a brand-new session.
-    LaunchNew,
-    /// User chose to quit without action.
-    Quit,
-    /// Input was not recognised; the caller quits cleanly.
-    Unrecognised,
-    /// Bare Enter was pressed but the 0-based-indexed session at this slot is
-    /// stopped/errored — resuming it would KILL and recreate its tmux pane
-    /// (or, if the pane already happened to be dead, spawn a fresh one). #2148:
-    /// this is no longer an implicit default; the operator must type the
-    /// number explicitly to confirm the restart.
-    ConfirmRestart(usize),
-}
 
 // ── Entry point ──────────────────────────────────────────────────────────────
 
@@ -177,10 +142,12 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
 /// Why: the same "list sessions → two-panel-banner → picker" sequence is needed
 /// both on the initial attempt and after a successful auto-start. A shared helper
 /// keeps `run_guided_default` DRY and avoids divergence between the two call sites.
-/// What: calls `list_project_sessions`, filters out decommissioned tombstones
-/// (#1809), runs the tty-gate, renders the two-panel daily banner (#1808), then
-/// hands off to the picker. Returns `None` when the daemon is unreachable so the
-/// caller can try auto-start; returns `Some(result)` once the daemon responded.
+/// What: fetches the project's live sessions via the shared
+/// [`super::session_picker::fetch_live_sessions`] (decommissioned tombstones
+/// already filtered, #1809), runs the tty-gate, renders the two-panel daily
+/// banner (#1808), then hands off to [`super::session_picker::run_tty_picker`].
+/// Returns `None` when the daemon is unreachable so the caller can try
+/// auto-start; returns `Some(result)` once the daemon responded.
 /// Test: indirectly covered by guided-default e2e tests; the pure sub-functions
 /// (`tty_gate`, `parse_picker_choice`, `is_live_session_state`) are unit-tested
 /// independently.
@@ -192,8 +159,11 @@ async fn try_show_picker(
     repo_url: &str,
     cwd: &std::path::Path,
 ) -> Option<anyhow::Result<()>> {
-    // #1809: exclude decommissioned tombstones from the picker by default.
-    let sessions = filter_live_sessions(list_project_sessions(client, url, source_id).await.ok()?);
+    // #1809: exclude decommissioned tombstones from the picker by default. The
+    // shared fetch path returns the same live-only list the static renderer uses.
+    let sessions = super::session_picker::fetch_live_sessions(client, url, Some(source_id), false)
+        .await
+        .ok()?;
     if !tty_gate(
         std::io::stdin().is_terminal(),
         source_id,
@@ -206,7 +176,8 @@ async fn try_show_picker(
     // title bar, 24-row clipped art, project/workspace fields — no sleep.
     let daemon = DaemonInfo::from_lock_file_with_probe().with_count(sessions.len());
     crate::formatters::banner::print_daily_banner(&cwd.to_string_lossy(), &daemon);
-    Some(run_tty_picker(client, url, repo_url, source_id, sessions).await)
+    let scope = super::session_picker::PickerScope::project(source_id, repo_url);
+    Some(super::session_picker::run_tty_picker(client, url, &scope, sessions).await)
 }
 
 // ── Project derivation ───────────────────────────────────────────────────────
@@ -308,10 +279,10 @@ pub(crate) fn nested_managed_match<'a>(
 /// with no `?source_id=` query.
 ///
 /// Why: [`nested_session_guard`] must find a match even when the record's
-/// `source_id` is missing (#2157 item 5's failure mode), so it cannot reuse
-/// [`list_project_sessions`]'s source_id-filtered query.
-/// What: identical to [`list_project_sessions`] minus the query parameter, with
-/// a 2-second timeout so a hung daemon cannot add a long stall to every bare
+/// `source_id` is missing (#2157 item 5's failure mode), so it cannot reuse the
+/// source_id-filtered picker fetch ([`super::session_picker::fetch_live_sessions`]).
+/// What: GETs the managed-list endpoint with no `?source_id=` query and a
+/// 2-second timeout so a hung daemon cannot add a long stall to every bare
 /// `tm` invocation made from inside tmux.
 /// Test: I/O path; requires a live daemon.
 async fn list_all_managed_sessions(
@@ -321,34 +292,6 @@ async fn list_all_managed_sessions(
     let resp = client
         .get(format!("{url}/api/v1/sessions/managed"))
         .timeout(std::time::Duration::from_secs(2))
-        .send()
-        .await?
-        .error_for_status()?;
-    let body: trusty_mpm::client::ManagedListResponse = resp.json().await?;
-    Ok(body.sessions)
-}
-
-// ── Daemon communication ─────────────────────────────────────────────────────
-
-/// Fetch managed sessions for a project via `GET /api/v1/sessions/managed?source_id`.
-///
-/// Why: the picker only shows sessions that belong to the current project; the
-/// `?source_id=<owner/repo>` filter keeps the response small regardless of how
-/// many total sessions the daemon manages.
-/// What: GETs the managed-list endpoint with the query param and deserializes
-/// the sessions array. Returns `Err` when the daemon is unreachable or the
-/// request fails — the caller uses this as a signal to fall back.
-/// Test: requires a live daemon; covered by the e2e test suite
-/// (`tests/session_manager_mvp.rs`) and integration tests in
-/// requires a live daemon; covered by the e2e test suite.
-async fn list_project_sessions(
-    client: &reqwest::Client,
-    base_url: &str,
-    source_id: &str,
-) -> anyhow::Result<Vec<trusty_mpm::client::ManagedSessionSummary>> {
-    let resp = client
-        .get(format!("{base_url}/api/v1/sessions/managed"))
-        .query(&[("source_id", source_id)])
         .send()
         .await?
         .error_for_status()?;
@@ -366,7 +309,7 @@ async fn list_project_sessions(
 /// thus prevents any attempt to read from stdin (#1705 AC-7 / HIGH-2b).
 /// What: always calls [`print_project_context`]. If `is_tty = false`, also
 /// calls [`print_non_tty_hint`] and returns `false`. If `is_tty = true`,
-/// returns `true` (caller should invoke [`run_tty_picker`]).
+/// returns `true` (caller should invoke [`super::session_picker::run_tty_picker`]).
 /// Test: `guided_non_tty_gate_returns_false_skips_stdin`,
 /// `guided_tty_gate_returns_true_for_tty`.
 pub(crate) fn tty_gate(
@@ -439,172 +382,6 @@ pub(crate) fn print_non_tty_hint(
         eprintln!("tm: to resume: tmux attach-session -t {}", sessions[0].name);
         eprintln!("tm: to launch: run `tm` from an interactive terminal");
     }
-}
-
-// ── TTY picker ───────────────────────────────────────────────────────────────
-
-/// Parse one line of picker input into a [`PickerDecision`].
-///
-/// Why: separating parse-and-decide from the I/O driver makes the dispatch
-/// logic unit-testable without needing a real stdin, tmux, or daemon. Folding
-/// `first_needs_restart` in here (rather than deciding safety in the I/O
-/// driver) keeps the destructive-default guard (#2148) exhaustively
-/// unit-testable alongside every other picker-input case.
-/// What: `session_count` is the number of existing sessions in the menu (the
-/// menu slot `session_count + 1` is always "launch new"); `first_needs_restart`
-/// is true when the session at index 0 is `stopped`/`errored` — i.e. resuming
-/// it goes through the daemon's restart path, which can recreate its tmux pane
-/// (see [`super::guided_resume::needs_restart`]).
-///   • `"q"` / `"Q"` → `Quit`
-///   • empty / whitespace, `session_count == 0` → `LaunchNew`
-///   • empty / whitespace, `session_count > 0`, session 0 is live → `Resume(0)`
-///   • empty / whitespace, `session_count > 0`, session 0 needs a restart →
-///     `ConfirmRestart(0)` (#2148: no longer an implicit destructive default)
-///   • `N` (1..=session_count) → `Resume(N-1)` (0-based index) — an EXPLICIT
-///     numeric choice always restarts/resumes directly, confirm or not
-///   • `session_count + 1` → `LaunchNew`
-///   • anything else → `Unrecognised`
-/// Test: `guided_picker_bare_enter_no_sessions_launches_new`,
-/// `guided_picker_bare_enter_live_session_resumes_first`,
-/// `guided_picker_bare_enter_stopped_session_requires_confirm`,
-/// `guided_picker_q_returns_quit`, `guided_picker_q_uppercase_returns_quit`,
-/// `guided_picker_numeric_valid_resumes`, `guided_picker_numeric_launch_new`,
-/// `guided_picker_out_of_range_unrecognised`,
-/// `guided_picker_non_numeric_unrecognised`.
-pub(crate) fn parse_picker_choice(
-    line: &str,
-    session_count: usize,
-    first_needs_restart: bool,
-) -> PickerDecision {
-    let choice = line.trim();
-    if choice.eq_ignore_ascii_case("q") {
-        return PickerDecision::Quit;
-    }
-    if choice.is_empty() {
-        if session_count == 0 {
-            return PickerDecision::LaunchNew;
-        }
-        return if first_needs_restart {
-            PickerDecision::ConfirmRestart(0)
-        } else {
-            PickerDecision::Resume(0)
-        };
-    }
-    if let Ok(n) = choice.parse::<usize>() {
-        if n >= 1 && n <= session_count {
-            return PickerDecision::Resume(n - 1);
-        }
-        if n == session_count + 1 {
-            return PickerDecision::LaunchNew;
-        }
-    }
-    PickerDecision::Unrecognised
-}
-
-/// Interactive numbered picker (TTY mode only).
-///
-/// Why: a simple numbered menu is the lowest-friction way to resume or launch
-/// without requiring the operator to remember session names or UUIDs. After a
-/// detach, the picker is redisplayed rather than exiting to the shell — the
-/// common "pick → Ctrl-b d → pick again" flow stays in one command.
-/// What: loops: print menu, read one line, dispatch, then re-fetch the session
-/// list so the next iteration shows current state. Exits cleanly on `Quit`,
-/// EOF (Ctrl-D), or unrecognised input; propagates attach/launch errors.
-///   • `Resume(i)` → [`resume_guided_session`] which handles daemon restart
-///     when needed and then calls [`tmux_attach`] internally;
-///   • `LaunchNew` → [`launch_new_session_and_attach`];
-///   • `ConfirmRestart(i)` (#2148) → print a one-line "type the number to
-///     confirm" notice and redisplay the SAME menu — no daemon round-trip;
-///   • `Quit` / EOF / `Unrecognised` → print notice and return `Ok`.
-/// Test: `parse_picker_choice` is the testable seam; I/O path is exercised by
-/// manual smoke tests and the e2e suite.
-async fn run_tty_picker(
-    client: &reqwest::Client,
-    url: &str,
-    repo_url: &str,
-    source_id: &str,
-    mut sessions: Vec<trusty_mpm::client::ManagedSessionSummary>,
-) -> anyhow::Result<()> {
-    loop {
-        eprintln!();
-        let new_idx = sessions.len() + 1;
-        // #2148: bare Enter must not silently restart (kill+recreate the tmux
-        // pane of) a stopped/errored session — only used to pick the menu's
-        // default hint and to gate `parse_picker_choice`'s bare-Enter branch.
-        let first_needs_restart = sessions
-            .first()
-            .map(|s| super::guided_resume::needs_restart(&s.state))
-            .unwrap_or(false);
-        if sessions.is_empty() {
-            eprintln!("tm:   [Enter] launch new session");
-            eprintln!("tm:   [q]     quit");
-        } else {
-            for (i, s) in sessions.iter().enumerate() {
-                // Show "restart" for sessions that are stopped/errored — they have no
-                // live tmux session and will be restarted via the daemon (#1742).
-                let stopped = matches!(s.state.as_str(), "stopped" | "errored");
-                let verb = if stopped { "restart" } else { "resume" };
-                eprintln!("tm:   [{}] {} {} ({})", i + 1, verb, s.name, s.state);
-            }
-            eprintln!("tm:   [{new_idx}] launch new session");
-            eprintln!("tm:   [q] quit");
-            if first_needs_restart {
-                // #2148: no implicit destructive default — an explicit [1] is required.
-                eprintln!("tm: [Enter] does NOT restart — type [1] to confirm the restart");
-            } else {
-                eprintln!("tm: default: [1] resume most recent");
-            }
-        }
-        eprint!("tm: > ");
-
-        let mut line = String::new();
-        let n = std::io::stdin()
-            .read_line(&mut line)
-            .context("failed to read choice from stdin")?;
-        if n == 0 {
-            break;
-        } // EOF (Ctrl-D): exit cleanly.
-
-        match parse_picker_choice(&line, sessions.len(), first_needs_restart) {
-            PickerDecision::Quit => {
-                eprintln!("tm: quit.");
-                break;
-            }
-            // #1742: route through daemon resume when the session is stopped or its
-            // tmux session is absent — never raw-attach a non-live session.
-            PickerDecision::Resume(i) => {
-                super::guided_resume::resume_guided_session(client, url, &sessions[i]).await?
-            }
-            PickerDecision::LaunchNew => {
-                launch_new_session_and_attach(client, url, repo_url).await?
-            }
-            // #2148: bare Enter hit a session that needs a restart — ask for an
-            // explicit choice instead of silently destroying its pane. No daemon
-            // round-trip; redisplay the SAME menu.
-            PickerDecision::ConfirmRestart(i) => {
-                eprintln!(
-                    "tm: '{}' requires a restart (its pane is gone or will be recreated) — \
-                     bare Enter no longer does this automatically.",
-                    sessions[i].name
-                );
-                eprintln!(
-                    "tm: type [{}] to confirm the restart, or [q] to quit.",
-                    i + 1
-                );
-                continue;
-            }
-            PickerDecision::Unrecognised => {
-                eprintln!("tm: unrecognised choice '{}'; quitting.", line.trim());
-                break;
-            }
-        }
-
-        // Detached or session ended — re-fetch the list before redisplaying.
-        // #1809: apply the same tombstone filter on the re-fetched list.
-        let r = list_project_sessions(client, url, source_id).await?;
-        sessions = filter_live_sessions(r);
-    }
-    Ok(())
 }
 
 // ── Guided resume/restart ────────────────────────────────────────────────────

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -96,47 +96,47 @@ pub(crate) async fn session_ls(
     source_id: Option<&str>,
     all: bool,
 ) -> anyhow::Result<()> {
-    // Build the request URL, appending ?source_id= when a filter is active.
-    let endpoint = format!("{url}/api/v1/sessions/managed");
-    let mut req = client.get(&endpoint);
-    if let Some(sid) = source_id {
-        req = req.query(&[("source_id", sid)]);
-    }
-    // Fetch the response body ONCE. `--json` echoes that raw text verbatim
-    // (byte-for-byte — preserving exact field order/whitespace for scripts);
-    // the table path deserializes the SAME text rather than issuing a second GET.
-    let raw = req.send().await?.error_for_status()?.text().await?;
+    // Fetch the response body ONCE via the shared fetch path. `--json` echoes
+    // that raw text verbatim (byte-for-byte — preserving exact field
+    // order/whitespace for scripts); the table path deserializes the SAME text
+    // rather than issuing a second GET.
+    let raw = crate::commands::session_picker::fetch_managed_raw(client, url, source_id).await?;
     if json {
         // Raw JSON passthrough is always unfiltered — scripts rely on byte-for-byte.
         println!("{raw}");
         return Ok(());
     }
-    let fetched = serde_json::from_str::<trusty_mpm::client::ManagedListResponse>(&raw)?.sessions;
-    // #1809: filter decommissioned tombstones from the default table view.
-    // #1841 Fix 4: when --all is requested, sort so active/stopped sessions come
-    // first and decommissioned tombstones come last (stable sort preserves relative
-    // order within each group).
-    let sessions: Vec<_> = if all {
-        let mut s = fetched;
-        s.sort_by_key(|sess| u8::from(sess.state == "decommissioned"));
-        s
-    } else {
-        filter_live_sessions(fetched)
-    };
+    let sessions = crate::commands::session_picker::parse_scoped_sessions(&raw, all)?;
+    render_session_table(&sessions, source_id);
+    Ok(())
+}
+
+/// Render the static `tm session ls` / `tm ls` table for a scoped session list.
+///
+/// Why: both the static list command and the `tm ls` connector's non-picker path
+/// (0 sessions, or a piped/`--json`/`--all` invocation) must print the identical
+/// table, so the row formatting lives in one place rather than being duplicated
+/// across the two entry points.
+/// What: prints a "no managed sessions[ for <slug>]" line when the list is empty;
+/// otherwise prints the header + one row per session (id, state, truncated name,
+/// task/`(interactive)` placeholder, short created-at, and any pending decision).
+/// Test: `ls_source_id_filter_selects_correct_slug` covers the scoping seam; the
+/// table bytes are exercised by `tests/session_manager_mvp.rs`.
+pub(crate) fn render_session_table(sessions: &[ManagedSessionSummary], source_id: Option<&str>) {
     if sessions.is_empty() {
         if let Some(sid) = source_id {
             println!("no managed sessions for {sid}");
         } else {
             println!("no managed sessions");
         }
-        return Ok(());
+        return;
     }
     // Table header
     println!(
         "{:<36}  {:<14}  {:<24}  {:<30}  CREATED",
         "ID", "STATE", "NAME", "TASK"
     );
-    for s in &sessions {
+    for s in sessions {
         // #1841 Fix 3: show a descriptive placeholder for sessions with no task.
         let task = s
             .task
@@ -164,7 +164,6 @@ pub(crate) async fn session_ls(
             pending
         );
     }
-    Ok(())
 }
 
 /// Truncate a string to at most `max` characters, appending `…` when cut.

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod serve_stdio;
 pub(crate) mod services;
 pub(crate) mod sessctl;
 pub(crate) mod session;
+pub(crate) mod session_picker;
 pub(crate) mod slack;
 pub(crate) mod sm_serve;
 pub(crate) mod standalone;

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -452,7 +452,7 @@ fn derive_source_id_from_path(dir: &std::path::Path) -> Option<String> {
 /// Returns `Some("owner/repo")` on success; `None` on any failure (both cases silently
 /// ignored — the caller treats None as "no filter").
 /// Test: `derive_source_id_from_cwd_returns_none_without_git` (unit via path variant).
-fn derive_source_id_from_cwd() -> Option<String> {
+pub(crate) fn derive_source_id_from_cwd() -> Option<String> {
     derive_source_id_from_path(&std::env::current_dir().ok()?)
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
@@ -1,0 +1,430 @@
+//! Shared managed-session picker + fetch helpers.
+//!
+//! Why: two entry points now surface the interactive session picker — bare `tm`
+//! (the project-scoped guided default in `guided.rs`) and the top-level `tm ls`
+//! connector (fleet-wide, optionally scoped). Extracting the numbered-menu loop,
+//! the pure choice-parser, and the fetch-and-filter step into one module keeps
+//! both call sites on a single implementation (no divergence, no duplication) and
+//! keeps `guided.rs` under the 500-SLOC production cap.
+//!
+//! What: [`parse_picker_choice`] is the pure input→decision seam; [`run_tty_picker`]
+//! is the I/O driver that renders the menu, reads stdin, and dispatches to
+//! resume/launch; [`fetch_live_sessions`] is the single GET+filter path shared by
+//! the static `tm session ls` renderer and the picker; [`run_ls_connector`] is the
+//! `tm ls` orchestrator that decides between the interactive picker and static
+//! output based on the TTY/`--json`/`--all`/session-count gate
+//! ([`should_show_picker`]).
+//!
+//! Test: `parse_picker_choice` unit tests live in `tests_behavior_c_tests.rs`
+//! (re-exported through `guided`); the TTY gate is unit-tested by
+//! `ls_connector_should_show_picker_*` in `tests_behavior_d_tests.rs`; the I/O
+//! path is exercised by the e2e suite and manual smoke tests.
+
+use anyhow::Context as _;
+use std::io::IsTerminal as _;
+
+use trusty_mpm::client::{ManagedListResponse, ManagedSessionSummary};
+
+use super::managed::filter_live_sessions;
+
+/// Decision returned by [`parse_picker_choice`].
+///
+/// Why: extracting the parse-and-decide logic from the I/O driver makes it
+/// unit-testable without stdin/tmux. The driver calls parse, checks the variant,
+/// and shells out only for Resume and LaunchNew.
+/// What: five variants cover every valid and invalid input the picker can
+/// receive. [`Self::ConfirmRestart`] is the #2148 safety default: a bare Enter
+/// that WOULD have silently restarted (destructively recreated the tmux pane
+/// of) a stopped/errored session instead asks for an explicit numeric choice.
+/// Test: `guided_picker_bare_enter_no_sessions_launches_new`,
+/// `guided_picker_bare_enter_live_session_resumes_first`,
+/// `guided_picker_bare_enter_stopped_session_requires_confirm`,
+/// `guided_picker_q_returns_quit`, `guided_picker_numeric_valid_resumes`,
+/// `guided_picker_numeric_launch_new`, `guided_picker_out_of_range_unrecognised`,
+/// `guided_picker_non_numeric_unrecognised`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PickerDecision {
+    /// Resume the session at 0-based index into the sessions slice.
+    Resume(usize),
+    /// Launch a brand-new session.
+    LaunchNew,
+    /// User chose to quit without action.
+    Quit,
+    /// Input was not recognised; the caller quits cleanly.
+    Unrecognised,
+    /// Bare Enter was pressed but the 0-based-indexed session at this slot is
+    /// stopped/errored — resuming it would KILL and recreate its tmux pane
+    /// (or, if the pane already happened to be dead, spawn a fresh one). #2148:
+    /// this is no longer an implicit default; the operator must type the
+    /// number explicitly to confirm the restart.
+    ConfirmRestart(usize),
+}
+
+/// Scope describing which sessions the picker operates over and how to launch new.
+///
+/// Why: the picker serves both a single-project context (bare `tm`, where a
+/// `repo_url` is known so "launch new" can spawn into that project) and a
+/// fleet-wide/filtered context (`tm ls`, where sessions may span projects and no
+/// single launch target exists). Threading the scope through one struct keeps
+/// [`run_tty_picker`] agnostic to its caller.
+/// What: `source_id` filters the daemon session list (`None` = every managed
+/// session); `repo_url` is the launch-new target (`None` disables launch-new with
+/// an actionable hint instead of attaching to the wrong project).
+/// Test: constructed by `guided::try_show_picker` and [`run_ls_connector`];
+/// behavior is covered by the picker's e2e path.
+pub(crate) struct PickerScope {
+    /// `owner/repo` slug to filter by, or `None` for every managed session.
+    pub(crate) source_id: Option<String>,
+    /// Git-root path used as the launch-new target, or `None` to disable it.
+    pub(crate) repo_url: Option<String>,
+}
+
+impl PickerScope {
+    /// Build a single-project scope (bare `tm` guided default).
+    ///
+    /// Why: the guided default always knows both the project slug and the git
+    /// root, so both fields are always populated.
+    /// What: returns a scope filtered to `source_id` with `repo_url` as the
+    /// launch target.
+    /// Test: exercised by `guided::try_show_picker`.
+    pub(crate) fn project(source_id: &str, repo_url: &str) -> Self {
+        Self {
+            source_id: Some(source_id.to_string()),
+            repo_url: Some(repo_url.to_string()),
+        }
+    }
+}
+
+/// GET the raw managed-session list body, optionally scoped by `source_id`.
+///
+/// Why: the `--json` passthrough needs the byte-for-byte daemon response while
+/// the table/picker paths need the deserialized form — both must issue exactly
+/// one GET. Returning the raw text lets each caller decide.
+/// What: GETs `/api/v1/sessions/managed`, appending `?source_id=` when a filter
+/// is active, and returns the response body as a `String` after status checks.
+/// Test: HTTP round-trip covered by `tests/session_manager_mvp.rs`.
+pub(crate) async fn fetch_managed_raw(
+    client: &reqwest::Client,
+    url: &str,
+    source_id: Option<&str>,
+) -> anyhow::Result<String> {
+    let endpoint = format!("{url}/api/v1/sessions/managed");
+    let mut req = client.get(&endpoint);
+    if let Some(sid) = source_id {
+        req = req.query(&[("source_id", sid)]);
+    }
+    Ok(req.send().await?.error_for_status()?.text().await?)
+}
+
+/// Parse a raw managed-session list body into a scoped `Vec` for display.
+///
+/// Why: the static table and the picker share one filtering/sorting policy so
+/// the two views never diverge (#1809/#1841).
+/// What: deserializes `ManagedListResponse`; when `all` is false, drops
+/// decommissioned tombstones via [`filter_live_sessions`]; when `all` is true,
+/// keeps every session but stable-sorts tombstones to the end.
+/// Test: `picker_filter_excludes_decommissioned_keeps_active`,
+/// `ls_source_id_filter_selects_correct_slug` in `tests_behavior_c_tests.rs`.
+pub(crate) fn parse_scoped_sessions(
+    raw: &str,
+    all: bool,
+) -> anyhow::Result<Vec<ManagedSessionSummary>> {
+    let fetched = serde_json::from_str::<ManagedListResponse>(raw)?.sessions;
+    let sessions = if all {
+        let mut s = fetched;
+        s.sort_by_key(|sess| u8::from(sess.state == "decommissioned"));
+        s
+    } else {
+        filter_live_sessions(fetched)
+    };
+    Ok(sessions)
+}
+
+/// Fetch and filter managed sessions in one call — the shared picker fetch path.
+///
+/// Why: the interactive picker (both call sites) needs the deserialized, filtered
+/// session list; combining the GET and the parse keeps re-fetch-after-detach a
+/// single call and guarantees identical scoping to the static list.
+/// What: [`fetch_managed_raw`] then [`parse_scoped_sessions`]. The picker always
+/// requests live-only (`all = false`) — a decommissioned tombstone is never a
+/// resume target.
+/// Test: HTTP path in `tests/session_manager_mvp.rs`; the parse/filter seam is
+/// unit-tested via `parse_scoped_sessions`.
+pub(crate) async fn fetch_live_sessions(
+    client: &reqwest::Client,
+    url: &str,
+    source_id: Option<&str>,
+    all: bool,
+) -> anyhow::Result<Vec<ManagedSessionSummary>> {
+    let raw = fetch_managed_raw(client, url, source_id).await?;
+    parse_scoped_sessions(&raw, all)
+}
+
+/// Parse one line of picker input into a [`PickerDecision`].
+///
+/// Why: separating parse-and-decide from the I/O driver makes the dispatch
+/// logic unit-testable without needing a real stdin, tmux, or daemon. Folding
+/// `first_needs_restart` in here (rather than deciding safety in the I/O
+/// driver) keeps the destructive-default guard (#2148) exhaustively
+/// unit-testable alongside every other picker-input case.
+/// What: `session_count` is the number of existing sessions in the menu (the
+/// menu slot `session_count + 1` is always "launch new"); `first_needs_restart`
+/// is true when the session at index 0 is `stopped`/`errored` — i.e. resuming
+/// it goes through the daemon's restart path, which can recreate its tmux pane
+/// (see [`super::guided_resume::needs_restart`]).
+///   • `"q"` / `"Q"` → `Quit`
+///   • empty / whitespace, `session_count == 0` → `LaunchNew`
+///   • empty / whitespace, `session_count > 0`, session 0 is live → `Resume(0)`
+///   • empty / whitespace, `session_count > 0`, session 0 needs a restart →
+///     `ConfirmRestart(0)` (#2148: no longer an implicit destructive default)
+///   • `N` (1..=session_count) → `Resume(N-1)` (0-based index) — an EXPLICIT
+///     numeric choice always restarts/resumes directly, confirm or not
+///   • `session_count + 1` → `LaunchNew`
+///   • anything else → `Unrecognised`
+/// Test: `guided_picker_bare_enter_no_sessions_launches_new`,
+/// `guided_picker_bare_enter_live_session_resumes_first`,
+/// `guided_picker_bare_enter_stopped_session_requires_confirm`,
+/// `guided_picker_q_returns_quit`, `guided_picker_q_uppercase_returns_quit`,
+/// `guided_picker_numeric_valid_resumes`, `guided_picker_numeric_launch_new`,
+/// `guided_picker_out_of_range_unrecognised`,
+/// `guided_picker_non_numeric_unrecognised`.
+pub(crate) fn parse_picker_choice(
+    line: &str,
+    session_count: usize,
+    first_needs_restart: bool,
+) -> PickerDecision {
+    let choice = line.trim();
+    if choice.eq_ignore_ascii_case("q") {
+        return PickerDecision::Quit;
+    }
+    if choice.is_empty() {
+        if session_count == 0 {
+            return PickerDecision::LaunchNew;
+        }
+        return if first_needs_restart {
+            PickerDecision::ConfirmRestart(0)
+        } else {
+            PickerDecision::Resume(0)
+        };
+    }
+    if let Ok(n) = choice.parse::<usize>() {
+        if n >= 1 && n <= session_count {
+            return PickerDecision::Resume(n - 1);
+        }
+        if n == session_count + 1 {
+            return PickerDecision::LaunchNew;
+        }
+    }
+    PickerDecision::Unrecognised
+}
+
+/// Interactive numbered picker (TTY mode only).
+///
+/// Why: a simple numbered menu is the lowest-friction way to resume or launch
+/// without requiring the operator to remember session names or UUIDs. After a
+/// detach, the picker is redisplayed rather than exiting to the shell — the
+/// common "pick → Ctrl-b d → pick again" flow stays in one command.
+/// What: loops: print menu, read one line, dispatch, then re-fetch the session
+/// list (via [`fetch_live_sessions`], honoring the scope) so the next iteration
+/// shows current state. Exits cleanly on `Quit`, EOF (Ctrl-D), or unrecognised
+/// input; propagates attach/launch errors.
+///   • `Resume(i)` → [`super::guided_resume::resume_guided_session`] which
+///     handles daemon restart when needed and then attaches internally;
+///   • `LaunchNew` → [`super::guided_launch::launch_new_session_and_attach`] when
+///     the scope carries a `repo_url`; otherwise prints an actionable hint and
+///     redisplays the menu (fleet-wide `tm ls` has no single launch target);
+///   • `ConfirmRestart(i)` (#2148) → print a one-line "type the number to
+///     confirm" notice and redisplay the SAME menu — no daemon round-trip;
+///   • `Quit` / EOF / `Unrecognised` → print notice and return `Ok`.
+/// Test: `parse_picker_choice` is the testable seam; I/O path is exercised by
+/// manual smoke tests and the e2e suite.
+pub(crate) async fn run_tty_picker(
+    client: &reqwest::Client,
+    url: &str,
+    scope: &PickerScope,
+    mut sessions: Vec<ManagedSessionSummary>,
+) -> anyhow::Result<()> {
+    loop {
+        eprintln!();
+        let new_idx = sessions.len() + 1;
+        // #2148: bare Enter must not silently restart (kill+recreate the tmux
+        // pane of) a stopped/errored session — only used to pick the menu's
+        // default hint and to gate `parse_picker_choice`'s bare-Enter branch.
+        let first_needs_restart = sessions
+            .first()
+            .map(|s| super::guided_resume::needs_restart(&s.state))
+            .unwrap_or(false);
+        if sessions.is_empty() {
+            eprintln!("tm:   [Enter] launch new session");
+            eprintln!("tm:   [q]     quit");
+        } else {
+            for (i, s) in sessions.iter().enumerate() {
+                // Show "restart" for sessions that are stopped/errored — they have no
+                // live tmux session and will be restarted via the daemon (#1742).
+                let stopped = matches!(s.state.as_str(), "stopped" | "errored");
+                let verb = if stopped { "restart" } else { "resume" };
+                eprintln!("tm:   [{}] {} {} ({})", i + 1, verb, s.name, s.state);
+            }
+            eprintln!("tm:   [{new_idx}] launch new session");
+            eprintln!("tm:   [q] quit");
+            if first_needs_restart {
+                // #2148: no implicit destructive default — an explicit [1] is required.
+                eprintln!("tm: [Enter] does NOT restart — type [1] to confirm the restart");
+            } else {
+                eprintln!("tm: default: [1] resume most recent");
+            }
+        }
+        eprint!("tm: > ");
+
+        let mut line = String::new();
+        let n = std::io::stdin()
+            .read_line(&mut line)
+            .context("failed to read choice from stdin")?;
+        if n == 0 {
+            break;
+        } // EOF (Ctrl-D): exit cleanly.
+
+        match parse_picker_choice(&line, sessions.len(), first_needs_restart) {
+            PickerDecision::Quit => {
+                eprintln!("tm: quit.");
+                break;
+            }
+            // #1742: route through daemon resume when the session is stopped or its
+            // tmux session is absent — never raw-attach a non-live session.
+            PickerDecision::Resume(i) => {
+                super::guided_resume::resume_guided_session(client, url, &sessions[i]).await?
+            }
+            PickerDecision::LaunchNew => match scope.repo_url.as_deref() {
+                Some(repo) => {
+                    super::guided_launch::launch_new_session_and_attach(client, url, repo).await?
+                }
+                None => {
+                    // Fleet-wide `tm ls` has no single launch target — steer the
+                    // operator to the project directory or an explicit spawn.
+                    eprintln!(
+                        "tm: launch-new is unavailable from this list view — run `tm` from a \
+                         project directory, or `tm session new <repo-url>`."
+                    );
+                    continue;
+                }
+            },
+            // #2148: bare Enter hit a session that needs a restart — ask for an
+            // explicit choice instead of silently destroying its pane. No daemon
+            // round-trip; redisplay the SAME menu.
+            PickerDecision::ConfirmRestart(i) => {
+                eprintln!(
+                    "tm: '{}' requires a restart (its pane is gone or will be recreated) — \
+                     bare Enter no longer does this automatically.",
+                    sessions[i].name
+                );
+                eprintln!(
+                    "tm: type [{}] to confirm the restart, or [q] to quit.",
+                    i + 1
+                );
+                continue;
+            }
+            PickerDecision::Unrecognised => {
+                eprintln!("tm: unrecognised choice '{}'; quitting.", line.trim());
+                break;
+            }
+        }
+
+        // Detached or session ended — re-fetch the list before redisplaying.
+        // #1809: the shared fetch path applies the same live-only tombstone filter.
+        sessions = fetch_live_sessions(client, url, scope.source_id.as_deref(), false).await?;
+    }
+    Ok(())
+}
+
+/// Decide whether `tm ls` should open the interactive picker or print statically.
+///
+/// Why: a testable seam that folds every gate into one pure decision so the
+/// non-TTY / `--json` / `--all` / empty-list branches are unit-testable without a
+/// live terminal or daemon. Requiring BOTH stdin and stdout to be TTYs is the
+/// anti-hang guarantee: a piped input (would EOF) or a piped output (must stay a
+/// clean pipeable table) both fall through to static output.
+/// What: returns `true` only when stdin AND stdout are TTYs, neither `--json` nor
+/// `--all` was requested, and at least one session exists. `--all` forces static
+/// output because its purpose is the forensic full list (including
+/// decommissioned tombstones), not connecting.
+/// Test: `ls_connector_should_show_picker_*` in `tests_behavior_d_tests.rs`.
+pub(crate) fn should_show_picker(
+    stdin_tty: bool,
+    stdout_tty: bool,
+    json: bool,
+    all: bool,
+    session_count: usize,
+) -> bool {
+    stdin_tty && stdout_tty && !json && !all && session_count > 0
+}
+
+/// `tm ls` — the interactive managed-session connector (top-level).
+///
+/// Why: bare `tm ls` should do the most useful thing for connecting to the
+/// managed fleet: on a real terminal it opens the session picker; piped or
+/// scripted it degrades to the same static, pipeable list as `tm session ls`.
+/// What: resolves the scope (`--current` derives `owner/repo` from the cwd git
+/// remote, mirroring `tm session ls`); routes `--json`, `--all`, or any non-TTY
+/// invocation straight to the static [`super::managed::session_ls`] renderer
+/// (preserving its raw `--json` passthrough byte-for-byte); otherwise fetches the
+/// live sessions once and either renders the static table (0 sessions) or opens
+/// [`run_tty_picker`] (≥1 session). Launch-new inside the picker targets the cwd
+/// project only when it is a GitHub-backed git checkout.
+/// Test: parse tests `cli_parses_ls_*` and the gate tests
+/// `ls_connector_should_show_picker_*` in `tests_behavior_d_tests.rs`.
+pub(crate) async fn run_ls_connector(
+    client: &reqwest::Client,
+    url: &str,
+    json: bool,
+    source_id: Option<String>,
+    current: bool,
+    all: bool,
+) -> anyhow::Result<()> {
+    // `--current` derives the source_id from the cwd git remote, exactly like
+    // `tm session ls --current`. `--source-id` and `--current` are mutually
+    // exclusive at the clap layer, so at most one branch supplies a filter.
+    let sid: Option<String> = if current {
+        super::session::derive_source_id_from_cwd()
+    } else {
+        source_id
+    };
+
+    let stdin_tty = std::io::stdin().is_terminal();
+    let stdout_tty = std::io::stdout().is_terminal();
+
+    // Cheap pre-gate: `--json`, `--all`, or any non-interactive stream never
+    // fetches for the picker — delegate straight to the static renderer, which
+    // owns the raw `--json` passthrough and the `--all` tombstone sort.
+    if json || all || !stdin_tty || !stdout_tty {
+        return super::managed::session_ls(client, url, json, sid.as_deref(), all).await;
+    }
+
+    // Interactive stream: fetch the live sessions once. On any fetch error
+    // (daemon unreachable, HTTP failure) fall back to the static renderer so the
+    // operator sees the same actionable error rather than a bare picker crash.
+    let sessions = match fetch_live_sessions(client, url, sid.as_deref(), false).await {
+        Ok(s) => s,
+        Err(_) => {
+            return super::managed::session_ls(client, url, false, sid.as_deref(), false).await;
+        }
+    };
+
+    if !should_show_picker(stdin_tty, stdout_tty, json, all, sessions.len()) {
+        // 0 sessions on a TTY: print the static "no managed sessions" line rather
+        // than an empty picker.
+        super::managed::render_session_table(&sessions, sid.as_deref());
+        return Ok(());
+    }
+
+    // ≥1 session on a real terminal → the interactive picker. Launch-new targets
+    // the cwd project only when it is a GitHub-backed git checkout.
+    let repo_url = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| super::guided::derive_project(&cwd))
+        .map(|(_sid, _workspace, git_root)| git_root.to_string_lossy().to_string());
+    let scope = PickerScope {
+        source_id: sid,
+        repo_url,
+    };
+    run_tty_picker(client, url, &scope, sessions).await
+}

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -332,9 +332,26 @@ async fn main() -> anyhow::Result<()> {
             let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
             commands::standalone::register_cmd(&paths, &alias, &url, force)
         }
-        Some(Command::LsAliases { json, root }) => {
-            let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
-            commands::standalone::ls_cmd(&paths, json)
+        Some(Command::Ls {
+            projects,
+            json,
+            source_id,
+            current,
+            all,
+            root,
+        }) => {
+            if projects {
+                // #2311: `--projects`/`-p` preserves the DOC-24 alias/project list.
+                let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
+                commands::standalone::ls_cmd(&paths, json)
+            } else {
+                // #2311: bare `tm ls` is the interactive managed-session connector
+                // (TTY-aware; static + pipeable when non-TTY / --json / --all / 0).
+                commands::session_picker::run_ls_connector(
+                    &client, &url, json, source_id, current, all,
+                )
+                .await
+            }
         }
         Some(Command::Load { alias, root }) => {
             let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -26,13 +26,14 @@ use crate::commands::first_run::needs_first_run_clone;
 /// racing `needs_first_run_clone_returns_some_when_no_clone`.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 use crate::commands::guided::{
-    PickerDecision, derive_project, fallback_protected, github_host, is_github_remote,
-    nested_managed_match, non_github_refusal_message, parse_picker_choice, print_non_tty_hint,
-    print_project_context, tty_gate,
+    derive_project, fallback_protected, github_host, is_github_remote, nested_managed_match,
+    non_github_refusal_message, print_non_tty_hint, print_project_context, tty_gate,
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{ResumeAction, is_zombie, needs_restart, plan_resume};
 use crate::commands::managed::{filter_live_sessions, is_live_session_state};
+// The picker decision enum + parser moved to the shared `session_picker` module.
+use crate::commands::session_picker::{PickerDecision, parse_picker_choice};
 
 // ── parse_picker_choice ───────────────────────────────────────────────────────
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -486,3 +486,152 @@ fn cli_parses_session_catchup_defaults() {
         other => panic!("expected session catchup, got {other:?}"),
     }
 }
+
+// ── Top-level `tm ls` connector CLI parse tests (#2311) ─────────────────────
+
+/// Bare `tm ls` parses as the session connector (no `--projects`, all defaults).
+///
+/// Why: the top-level `tm ls` is now the interactive managed-session connector;
+/// this asserts the default field values that route it to the session path.
+/// What: parses `tm ls` and asserts every flag defaults false / `None`.
+/// Test: this test.
+#[test]
+fn cli_parses_ls_connector_bare() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "ls"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Ls {
+            projects,
+            json,
+            source_id,
+            current,
+            all,
+            root,
+        } => {
+            assert!(!projects, "bare `tm ls` must not set --projects");
+            assert!(!json);
+            assert!(source_id.is_none());
+            assert!(!current);
+            assert!(!all);
+            assert!(root.is_none());
+        }
+        other => panic!("expected top-level ls, got {other:?}"),
+    }
+}
+
+/// `tm ls --projects` routes to the legacy alias/project registry list.
+#[test]
+fn cli_parses_ls_projects() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "ls", "--projects"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Ls { projects, .. } => assert!(projects, "--projects must parse to true"),
+        other => panic!("expected top-level ls --projects, got {other:?}"),
+    }
+}
+
+/// `tm ls -p` is the short alias for `--projects`.
+#[test]
+fn cli_parses_ls_projects_short() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "ls", "-p"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Ls { projects, .. } => assert!(projects, "-p must parse to true"),
+        other => panic!("expected top-level ls -p, got {other:?}"),
+    }
+}
+
+/// `tm ls --json` selects JSON output while staying in session (connector) mode.
+#[test]
+fn cli_parses_ls_json() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "ls", "--json"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Ls { json, projects, .. } => {
+            assert!(json, "--json must parse to true");
+            assert!(!projects, "--json alone must not imply --projects");
+        }
+        other => panic!("expected top-level ls --json, got {other:?}"),
+    }
+}
+
+/// `tm ls --current` derives the source_id scope from the cwd (session mode).
+#[test]
+fn cli_parses_ls_current() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "ls", "--current"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Ls {
+            current, source_id, ..
+        } => {
+            assert!(current, "--current must parse to true");
+            assert!(source_id.is_none());
+        }
+        other => panic!("expected top-level ls --current, got {other:?}"),
+    }
+}
+
+/// `tm ls --source-id <slug>` sets the explicit fleet scope filter.
+#[test]
+fn cli_parses_ls_source_id() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "ls", "--source-id", "owner/repo"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Ls {
+            source_id, current, ..
+        } => {
+            assert_eq!(source_id, Some("owner/repo".to_string()));
+            assert!(!current);
+        }
+        other => panic!("expected top-level ls --source-id, got {other:?}"),
+    }
+}
+
+/// `tm ls --current --source-id <slug>` is a parse error (mutually exclusive).
+#[test]
+fn cli_ls_source_id_and_current_conflict() {
+    let result =
+        Cli::try_parse_from(["trusty-mpm", "ls", "--current", "--source-id", "owner/repo"]);
+    assert!(
+        result.is_err(),
+        "passing both --current and --source-id to `tm ls` must be a parse error"
+    );
+}
+
+// ── `tm ls` picker/static gate (#2311) ──────────────────────────────────────
+
+use crate::commands::session_picker::should_show_picker;
+
+/// The picker opens only on a fully-interactive terminal with ≥1 session.
+#[test]
+fn ls_connector_should_show_picker_interactive_with_sessions() {
+    assert!(should_show_picker(true, true, false, false, 1));
+    assert!(should_show_picker(true, true, false, false, 5));
+}
+
+/// A non-TTY stdin OR stdout forces the static (pipeable) list path — never a
+/// blocking picker. Mirrors guided.rs's non-TTY gate.
+#[test]
+fn ls_connector_should_show_picker_non_tty_static() {
+    assert!(
+        !should_show_picker(false, true, false, false, 3),
+        "piped stdin -> static"
+    );
+    assert!(
+        !should_show_picker(true, false, false, false, 3),
+        "piped stdout -> static"
+    );
+    assert!(!should_show_picker(false, false, false, false, 3));
+}
+
+/// `--json` and `--all` force static output even on a TTY, and 0 sessions never
+/// opens an empty picker.
+#[test]
+fn ls_connector_should_show_picker_flags_and_empty_static() {
+    assert!(
+        !should_show_picker(true, true, true, false, 3),
+        "--json -> static"
+    );
+    assert!(
+        !should_show_picker(true, true, false, true, 3),
+        "--all -> static"
+    );
+    assert!(
+        !should_show_picker(true, true, false, false, 0),
+        "0 sessions -> static"
+    );
+}


### PR DESCRIPTION
## Summary

Restructures the top-level `tm ls` command into an interactive managed-session **connector**, moving the DOC-24 repo-alias / project-registry list behind `--projects`/`-p`. Reuses the existing picker + fetch machinery — no new dependencies.

## Command surface

| Invocation | Behavior |
|---|---|
| `tm ls` (TTY, ≥1 session) | Interactive session picker (resume/restart/launch) |
| `tm ls` (non-TTY / 0 sessions) | Static, pipeable session table (never blocks on stdin) |
| `tm ls --json` | Raw daemon managed-session JSON (byte-for-byte passthrough) |
| `tm ls --source-id <slug>` / `--current` / `--all` | Same scoping as `tm session ls` (`--current`⊕`--source-id`; `--all` forces static) |
| `tm ls --projects` / `-p` | The previous top-level `tm ls` alias/project registry list (unchanged; `--json`/`--root`) |
| `tm session ls` | Unchanged |

## Reuse / refactor (no new deps)

- **New `commands/session_picker.rs`**: extracts the picker loop, `parse_picker_choice`/`PickerDecision`, and dispatch from `guided.rs`, parameterized by a `PickerScope` so bare `tm` and `tm ls` share one implementation. Adds `fetch_managed_raw`/`parse_scoped_sessions`/`fetch_live_sessions` (single GET+filter path) and the `should_show_picker` TTY gate + `run_ls_connector` orchestrator.
- **`managed.rs`**: `session_ls` now uses the shared fetch path; static rendering extracted to `render_session_table`.
- **`guided.rs`**: drops 409 → 288 SLOC (picker moved out; protects its budget).
- No changes to `tmux_attach.rs`, `guided_resume.rs`, or daemon routes.

## Decisions flagged for review

1. **Default scope for bare `tm ls`** = all managed sessions (matches `tm session ls` today), decommissioned filtered out.
2. **Picker TTY gate** requires **both** stdin and stdout to be TTYs (spec said "stdout is a TTY"). Requiring both is the strict anti-hang / pipeable-output guarantee; a piped input EOFs cleanly anyway.
3. **`--all` forces static output** even on a TTY (the full forensic list including tombstones is not a connect target).
4. **One vs. many sessions**: always shows the menu (no one-session auto-attach), matching bare `tm`'s existing picker UX.
5. **Launch-new inside `tm ls`**: enabled only when the cwd is a GitHub-backed git checkout (targets that project); otherwise prints a hint (fleet-wide has no single launch target).

## Verification

- `cargo build -p trusty-mpm` — clean
- `cargo test -p trusty-mpm` — **776 passed; 0 failed; 1 ignored** (+10 new tests)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `scripts/check_line_cap.sh` — 0 violations
- Manual: `tm ls --help`, `tm ls --projects`, `tm ls --json`, `tm ls`, `tm ls --current` all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)