### PR TITLE
fix(trusty-code): enforce toolUse/toolResult pairing across compaction (closes #2278)

### DIFF
--- a/crates/trusty-code/src/agent_loop/transcript.rs
+++ b/crates/trusty-code/src/agent_loop/transcript.rs
@@ -234,30 +234,53 @@ impl Transcript {
     /// Why: (#2070) This is the turn-boundary hook the agent loop calls —
     /// gated by the caller on `HarnessMode::DailyDriver` (Parity must never
     /// compact, per §5.9's D2 reconciliation) — so growth is bounded without
-    /// the loop body needing to know compaction's internals.
+    /// the loop body needing to know compaction's internals. (#2278) A raw
+    /// entry-COUNT cutoff has no tool-call awareness: when it lands between
+    /// an assistant entry carrying `tool_calls` and one of its answering
+    /// `tool`-role entries, the assistant gets folded into the compacted
+    /// summary while the answering entry survives verbatim in the kept
+    /// zone — an orphaned tool result with no tool use, which providers
+    /// with a strict pairing invariant (Bedrock's Converse API) reject
+    /// outright.
     /// What: No-ops (returns `false`) unless the CURRENT model-facing view
     /// (`to_messages()`, not the ever-growing raw history — raw size would
     /// re-trigger every turn even after compaction shrank what's actually
-    /// sent) exceeds `cfg.token_threshold`. Otherwise, marks every entry
-    /// before the trailing `cfg.keep_last_messages` (the active work zone,
-    /// §5.4 item 4) as `compacted = true`, EXCEPT entries already compacted
-    /// (a one-way transform), `pinned` entries (§5.4 item 5's skill-output
-    /// half — see `push_tool_result`), and `system`/`user` role entries
-    /// (§5.4 item 5's "preserve... user requests forever" half). Sets
-    /// `compaction_triggered` and returns `true` only if at least one entry
-    /// was newly marked (an already-fully-compacted or entirely-preserved
-    /// prefix is a no-op, not a spurious trigger).
-    /// Test: `transcript::tests::maybe_compact_marks_middle_span_only`,
-    /// `transcript::tests::maybe_compact_is_noop_below_threshold`,
+    /// sent) exceeds `cfg.token_threshold`. Otherwise computes the naive
+    /// count-based cutoff `keep_from = len - cfg.keep_last_messages`, then
+    /// (#2278) [`turn_group_start`]/[`turn_group_end`] check whether that
+    /// cutoff falls INSIDE a turn group — an assistant entry carrying
+    /// `tool_calls` plus the maximal contiguous run of `tool`-role entries
+    /// immediately following it (naturally covering multi-tool-call turns:
+    /// N `tool_calls` followed by up to N `tool` entries). If so, the whole
+    /// group is pulled FORWARD into the kept zone by moving `keep_from` back
+    /// to the group's start — `cfg.keep_last_messages` becomes a soft floor
+    /// that may slightly enlarge the active zone rather than ever splitting
+    /// a group. Marks every entry before the (possibly adjusted) `keep_from`
+    /// as `compacted = true`, EXCEPT entries already compacted (a one-way
+    /// transform), `pinned` entries (§5.4 item 5's skill-output half — see
+    /// `push_tool_result`), and `system`/`user` role entries (§5.4 item 5's
+    /// "preserve... user requests forever" half). Sets `compaction_triggered`
+    /// and returns `true` only if at least one entry was newly marked (an
+    /// already-fully-compacted or entirely-preserved prefix is a no-op, not
+    /// a spurious trigger).
+    /// Test: `transcript::tests::maybe_compact_is_noop_below_threshold`,
     /// `transcript::tests::maybe_compact_never_touches_system_or_user`,
     /// `transcript::tests::maybe_compact_never_compacts_pinned_skill_output`,
-    /// `transcript::tests::maybe_compact_still_compacts_non_skill_tool_results`.
+    /// `transcript::tests::maybe_compact_still_compacts_non_skill_tool_results`,
+    /// `transcript::tests::maybe_compact_pulls_whole_multi_tool_call_group_forward`.
     pub fn maybe_compact(&mut self, cfg: &CompactionConfig) -> bool {
         if !should_compact(&self.to_messages(), cfg) {
             return false;
         }
 
-        let keep_from = self.entries.len().saturating_sub(cfg.keep_last_messages);
+        let mut keep_from = self.entries.len().saturating_sub(cfg.keep_last_messages);
+        if keep_from > 0
+            && keep_from < self.entries.len()
+            && let Some(group_start) = turn_group_start(&self.entries, keep_from - 1)
+            && turn_group_end(&self.entries, group_start) >= keep_from
+        {
+            keep_from = group_start;
+        }
         let mut newly_compacted = false;
 
         for entry in &mut self.entries[..keep_from] {
@@ -309,6 +332,51 @@ impl Transcript {
         let calls = resp.first_tool_calls().to_vec();
         self.push_assistant(text, &calls);
     }
+}
+
+/// If entry `idx` belongs to a turn group, return the group's assistant
+/// entry index (#2278 Fix A).
+///
+/// Why: `maybe_compact` needs to know whether its naive count-based cutoff
+/// lands inside an atomic assistant-`tool_calls` + answering-`tool`-entries
+/// group, so it can pull the whole group forward rather than splitting it.
+/// What: A turn group is one assistant entry with `tool_calls: Some(_)` plus
+/// the maximal contiguous run of `tool`-role entries immediately following
+/// it. Walks backward from `idx` through any contiguous `tool`-role entries;
+/// the walk stops at the first non-`tool` entry, which is the group's
+/// assistant entry IF it carries `tool_calls` — returns its index in that
+/// case, `None` otherwise (covers `idx` itself already being that assistant
+/// entry, when the backward walk takes zero steps).
+/// Test: `transcript::tests::maybe_compact_pulls_whole_multi_tool_call_group_forward`.
+fn turn_group_start(entries: &[TranscriptEntry], idx: usize) -> Option<usize> {
+    let mut i = idx;
+    while entries[i].message.role == "tool" {
+        if i == 0 {
+            return None;
+        }
+        i -= 1;
+    }
+    (entries[i].message.role == "assistant" && entries[i].message.tool_calls.is_some()).then_some(i)
+}
+
+/// Return the last index of the turn group starting at `group_start`
+/// (#2278 Fix A).
+///
+/// Why: Once [`turn_group_start`] confirms a group exists, `maybe_compact`
+/// must know where it ENDS to tell whether it straddles the naive cutoff —
+/// naturally spanning however many `tool` entries answer a multi-tool-call
+/// turn, not just one.
+/// What: Scans forward from `group_start` while the next entry is `tool`-role;
+/// returns the last such index (or `group_start` itself if no `tool` entry
+/// immediately follows, e.g. a `tool_calls` turn with no results recorded
+/// yet).
+/// Test: `transcript::tests::maybe_compact_pulls_whole_multi_tool_call_group_forward`.
+fn turn_group_end(entries: &[TranscriptEntry], group_start: usize) -> usize {
+    let mut i = group_start;
+    while i + 1 < entries.len() && entries[i + 1].message.role == "tool" {
+        i += 1;
+    }
+    i
 }
 
 /// Flush a pending compacted span into `out` as one summary message, if any.
@@ -487,6 +555,103 @@ mod tests {
         // Non-destructive: every original entry is still present in the raw
         // history even though some are now marked compacted internally.
         assert_eq!(raw.len(), 2 + 20);
+    }
+
+    /// Assert every `tool` entry in a `to_messages()` view has its issuing
+    /// assistant `tool_calls` entry present in the SAME view, and every
+    /// assistant `tool_calls` entry has all its answers present too.
+    ///
+    /// Why: Shared invariant check for the turn-group-atomic compaction
+    /// tests (#2278) — this is exactly the shape that produces Bedrock's
+    /// orphaned-toolResult `ValidationException` if compaction ever splits a
+    /// group across its cutoff.
+    fn assert_view_pairing_intact(view: &[ChatMessage]) {
+        let mut introduced: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut answered: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for msg in view {
+            if let Some(calls) = &msg.tool_calls {
+                for call in calls {
+                    introduced.insert(call.id.clone());
+                }
+            }
+            if msg.role == "tool" {
+                let id = msg.tool_call_id.clone().unwrap_or_default();
+                assert!(
+                    introduced.contains(&id),
+                    "tool entry for {id:?} has no preceding assistant tool_calls entry in this view: {view:?}"
+                );
+                answered.insert(id);
+            }
+        }
+        for id in &introduced {
+            assert!(
+                answered.contains(id),
+                "assistant tool_calls id {id:?} has no answering tool entry in this view: {view:?}"
+            );
+        }
+    }
+
+    /// A naive count-based cutoff that would split a multi-tool-call turn
+    /// group is pulled forward atomically instead (#2278 Fix A).
+    ///
+    /// Why: This is the exact root cause of the Bedrock `ValidationException:
+    /// missing toolResult` bug — a raw entry-count cutoff has no tool-call
+    /// awareness, so it can land between an assistant's `tool_calls` entry
+    /// and one of its answering `tool` entries (here, a two-tool-call turn),
+    /// orphaning whichever half ends up in the compacted summary.
+    /// What: Five ordinary assistant/tool pairs (no tool_calls — plain text
+    /// turns), then ONE assistant entry with TWO `tool_calls` immediately
+    /// followed by their two answering `tool` entries. `keep_last_messages`
+    /// is tuned so the naive `len - keep_last_messages` cutoff lands between
+    /// the multi-call assistant entry and its second answer (i.e. splits the
+    /// group under the old count-only logic). Asserts compaction still
+    /// fires, the five ordinary pairs got compacted (soft floor enlarged,
+    /// not disabled), and — critically — `to_messages()` satisfies
+    /// [`assert_view_pairing_intact`]: the multi-call assistant entry and
+    /// BOTH its answers survive together, uncompacted.
+    /// Test: this test.
+    #[test]
+    fn maybe_compact_pulls_whole_multi_tool_call_group_forward() {
+        let mut t = Transcript::seed("s", "the task");
+        for i in 0..5 {
+            t.push_assistant(Some(format!("turn {i}")), &[]);
+            t.push_tool_result(&format!("c{i}"), "bash", "output");
+        }
+        // entries so far: [system, user, (assistant, tool) x5] = 12 entries,
+        // indices 0..12.
+        t.push_assistant(
+            None,
+            &[
+                sample_call("multi_1", "get_weather"),
+                sample_call("multi_2", "get_time"),
+            ],
+        );
+        t.push_tool_result("multi_1", "get_weather", "72F");
+        t.push_tool_result("multi_2", "get_time", "12:00 UTC");
+        // entries now: 15 total; the multi-call group is at indices 12..15.
+        assert_eq!(t.messages().len(), 15);
+
+        // len(15) - keep_last_messages(2) = 13: falls strictly between the
+        // multi-call assistant entry (12) and its second answer (14) — a
+        // naive cutoff would compact index 12 while keeping 13 and 14.
+        let cfg = CompactionConfig {
+            token_threshold: 1,
+            keep_last_messages: 2,
+        };
+        assert!(t.maybe_compact(&cfg));
+
+        // The five earlier ordinary pairs (indices 2..12, 10 entries) are
+        // still eligible and got compacted — the fix only protects the
+        // straddled group, it doesn't disable compaction entirely.
+        assert_eq!(t.compacted_count(), 10);
+
+        let view = t.to_messages();
+        assert_view_pairing_intact(&view);
+        assert!(
+            view.iter()
+                .any(|m| m.tool_calls.as_ref().is_some_and(|c| c.len() == 2)),
+            "the multi-tool-call assistant entry must survive uncompacted: {view:?}"
+        );
     }
 
     /// A `use_skill` tool result is pinned: it survives compaction even when

--- a/crates/trusty-code/src/llm/bedrock/convert.rs
+++ b/crates/trusty-code/src/llm/bedrock/convert.rs
@@ -27,13 +27,13 @@
 //! module-level SLOC-cap convention already used by
 //! `trusty-review::llm::bedrock`).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use aws_sdk_bedrockruntime::operation::converse::ConverseOutput as ConverseResponse;
 use aws_sdk_bedrockruntime::types::{
     AnyToolChoice, AutoToolChoice, ContentBlock, ConversationRole, Message, SpecificToolChoice,
     SystemContentBlock, Tool, ToolChoice as SdkToolChoice, ToolConfiguration, ToolInputSchema,
-    ToolResultBlock, ToolResultContentBlock, ToolSpecification, ToolUseBlock,
+    ToolResultBlock, ToolResultContentBlock, ToolResultStatus, ToolSpecification, ToolUseBlock,
 };
 use aws_smithy_types::{Document, Number};
 use serde_json::Value;
@@ -60,7 +60,10 @@ use super::cache;
 /// (`user` and `tool` roles) or `Assistant` (`assistant` role); consecutive
 /// messages of the same Converse role are merged into ONE `Message` with
 /// multiple content blocks, which is exactly what happens for a run of
-/// `tool`-role results answering one assistant turn's tool calls.
+/// `tool`-role results answering one assistant turn's tool calls. (#2278)
+/// Before the final return, [`enforce_tool_pairing`] rewrites `messages` so
+/// the emitted request always satisfies Bedrock's ToolUse/ToolResult
+/// pairing invariant, regardless of what produced the input history.
 /// Test: `bedrock::tests::*`.
 pub(super) fn build_converse_messages(
     req: &ChatRequest,
@@ -72,6 +75,16 @@ pub(super) fn build_converse_messages(
 
     for msg in &req.messages {
         if msg.role == "system" {
+            // (#2278) Flush the in-progress same-role batch BEFORE diverting
+            // this entry to the system-prompt array, rather than bare
+            // `continue`. A mid-conversation system-role entry (e.g. a
+            // compaction-summary placeholder, #2070) has no in-conversation
+            // home on Converse either way — the system array has no
+            // per-turn position semantics — but failing to flush here
+            // silently merges content that occurred BEFORE this entry with
+            // content that occurs AFTER it into one artificial message,
+            // corrupting ordering beyond just losing the placeholder text.
+            flush_message(&mut messages, &mut current_role, &mut current_blocks)?;
             if let Some(text) = &msg.content {
                 system_blocks.push(SystemContentBlock::Text(text.clone()));
                 // (#2260) `agent_loop::build_request` marks exactly one
@@ -116,7 +129,158 @@ pub(super) fn build_converse_messages(
     }
 
     flush_message(&mut messages, &mut current_role, &mut current_blocks)?;
+    enforce_tool_pairing(&mut messages)?;
     Ok((system_blocks, messages))
+}
+
+/// Enforce Bedrock's ToolUse/ToolResult pairing invariant on the fully
+/// role-merged Converse message list (#2278 Fix B — the Bedrock-specific
+/// backstop).
+///
+/// Why: `agent_loop::transcript::Transcript::maybe_compact` can (before Fix
+/// A) fold an assistant's `tool_calls` entry into a compaction summary while
+/// one of its answering `tool`-role entries survives verbatim, or vice
+/// versa — a count-based compaction cutoff has no tool-call awareness. Any
+/// unpaired `ToolUse`/`ToolResult` in the request makes Bedrock's Converse
+/// API reject the whole call with `ValidationException: ... toolResult`.
+/// This runs unconditionally on every request as a last-resort guarantee
+/// that the WIRE shape is always valid, independent of whatever produced
+/// the input history — it is not solely a compensating control for the
+/// transcript bug Fix A addresses.
+/// What: Two passes over `messages` (already strictly alternating
+/// `User`/`Assistant` — `build_converse_messages` merges consecutive
+/// same-role turns before this runs, so a `ToolUse`'s only possible
+/// answering window is the immediately-following message). Pass 1 walks
+/// every content block in encounter order, tracking every `tool_use_id`
+/// introduced by a `ToolUse` block; a `ToolResult` whose `tool_use_id` was
+/// never introduced by an earlier (or same, block-order) `ToolUse` is an
+/// orphan and is dropped — there is no call left to attach it to on the
+/// model's side, and Bedrock rejects an orphan just as strictly as a
+/// missing result. Pass 2 walks every `ToolUse` block and, for each whose
+/// `tool_use_id` has no matching `ToolResult` in the immediately-following
+/// message, synthesizes a placeholder `ToolResult` (status `Error`, text
+/// noting the result is unavailable) appended to that following message —
+/// or, if there is no following message at all, a brand-new trailing `User`
+/// message carrying just the placeholders.
+/// Test: `bedrock::tests::enforce_tool_pairing_*`.
+fn enforce_tool_pairing(messages: &mut Vec<Message>) -> Result<(), LlmError> {
+    // Pass 1: drop orphan ToolResult blocks; record every tool_use_id ever
+    // introduced, in block encounter order.
+    let mut introduced: HashSet<String> = HashSet::new();
+    for msg in messages.iter_mut() {
+        let role = msg.role().clone();
+        let mut kept = Vec::with_capacity(msg.content().len());
+        for block in msg.content() {
+            match block {
+                ContentBlock::ToolUse(tu) => {
+                    introduced.insert(tu.tool_use_id().to_string());
+                    kept.push(block.clone());
+                }
+                ContentBlock::ToolResult(tr) if !introduced.contains(tr.tool_use_id()) => {
+                    // Orphan: no ToolUse ever introduced this id. Silently
+                    // drop — the model has nothing to attach it to.
+                }
+                other => kept.push(other.clone()),
+            }
+        }
+        *msg = Message::builder()
+            .role(role)
+            .set_content(Some(kept))
+            .build()
+            .map_err(|e| LlmError::Bedrock(format!("rebuild Message: {e}")))?;
+    }
+
+    // Pass 2: for each ToolUse, compute any missing answers in the
+    // immediately-following message up front (before mutating anything), so
+    // index arithmetic below can't be invalidated by an earlier insertion.
+    let mut missing_by_index: Vec<Vec<String>> = vec![Vec::new(); messages.len()];
+    for (i, msg) in messages.iter().enumerate() {
+        let own_ids: Vec<String> = msg
+            .content()
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolUse(tu) => Some(tu.tool_use_id().to_string()),
+                _ => None,
+            })
+            .collect();
+        if own_ids.is_empty() {
+            continue;
+        }
+        let answered: HashSet<&str> = messages
+            .get(i + 1)
+            .map(|next| {
+                next.content()
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::ToolResult(tr) => Some(tr.tool_use_id()),
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        missing_by_index[i] = own_ids
+            .into_iter()
+            .filter(|id| !answered.contains(id.as_str()))
+            .collect();
+    }
+
+    // Apply back-to-front: inserting a brand-new message at i+1 must never
+    // shift an index this loop still needs to visit (all remaining indices
+    // are < i+1).
+    for i in (0..messages.len()).rev() {
+        if missing_by_index[i].is_empty() {
+            continue;
+        }
+        let placeholders = missing_by_index[i]
+            .iter()
+            .map(|id| placeholder_tool_result(id))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let append_to_next = messages
+            .get(i + 1)
+            .is_some_and(|next| next.role() == &ConversationRole::User);
+        if append_to_next {
+            let mut content = messages[i + 1].content().to_vec();
+            content.extend(placeholders);
+            messages[i + 1] = Message::builder()
+                .role(ConversationRole::User)
+                .set_content(Some(content))
+                .build()
+                .map_err(|e| LlmError::Bedrock(format!("rebuild Message: {e}")))?;
+        } else {
+            let new_msg = Message::builder()
+                .role(ConversationRole::User)
+                .set_content(Some(placeholders))
+                .build()
+                .map_err(|e| LlmError::Bedrock(format!("build placeholder Message: {e}")))?;
+            messages.insert(i + 1, new_msg);
+        }
+    }
+
+    Ok(())
+}
+
+/// Build one synthesized placeholder `ToolResult` block for a `tool_use_id`
+/// that reached the end of its answering window with no real result.
+///
+/// Why: Bedrock requires every `ToolUse` to have a matching `ToolResult`;
+/// when the real result was dropped (compaction splitting a turn group, or
+/// any other history-drift source), the model still needs SOME result to
+/// keep the conversation valid — an explicit "unavailable" marker is honest
+/// about what happened, unlike silently fabricating a fake success.
+/// What: A `ToolResultBlock` keyed by `tool_use_id`, `status: Error`, and a
+/// single text content block saying the result is unavailable.
+/// Test: `bedrock::tests::enforce_tool_pairing_synthesizes_placeholder_for_unanswered_tool_use`.
+fn placeholder_tool_result(tool_use_id: &str) -> Result<ContentBlock, LlmError> {
+    let block = ToolResultBlock::builder()
+        .tool_use_id(tool_use_id)
+        .content(ToolResultContentBlock::Text(
+            "[result unavailable — history was compacted]".to_string(),
+        ))
+        .status(ToolResultStatus::Error)
+        .build()
+        .map_err(|e| LlmError::Bedrock(format!("build placeholder ToolResultBlock: {e}")))?;
+    Ok(ContentBlock::ToolResult(block))
 }
 
 /// Append one `ChatMessage`'s content as Converse `ContentBlock`s onto the

--- a/crates/trusty-code/src/llm/bedrock/tests.rs
+++ b/crates/trusty-code/src/llm/bedrock/tests.rs
@@ -11,6 +11,7 @@ use aws_sdk_bedrockruntime::operation::converse::ConverseOutput as ConverseOutpu
 use aws_sdk_bedrockruntime::types::{
     ContentBlock, ConverseOutput as ConverseOutputKind, Message as SdkMessage, StopReason,
     SystemContentBlock, TokenUsage as SdkTokenUsage, Tool as SdkTool, ToolChoice as SdkToolChoice,
+    ToolResultStatus,
 };
 use serde_json::json;
 
@@ -200,6 +201,194 @@ fn build_converse_messages_maps_tool_use_arguments_to_document() {
             assert_eq!(parsed["query"], "rust");
         }
         other => panic!("expected ToolUse block, got {other:?}"),
+    }
+}
+
+// ─── ToolUse/ToolResult pairing backstop (#2278 Fix B) ─────────────────────
+
+/// Assert `build_converse_messages`'s output always satisfies Bedrock's
+/// pairing invariant: every `ToolResult` has an earlier matching `ToolUse`
+/// (no orphans survive), and every `ToolUse` has a matching `ToolResult`
+/// SOMEWHERE in the output (none left unanswered).
+///
+/// Why: Shared assertion for all three `enforce_tool_pairing_*` tests below
+/// so the invariant itself is defined once, not re-derived per test.
+fn assert_tool_pairing_invariant(messages: &[aws_sdk_bedrockruntime::types::Message]) {
+    let mut introduced: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut answered: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for message in messages {
+        for block in message.content() {
+            match block {
+                ContentBlock::ToolUse(tu) => {
+                    introduced.insert(tu.tool_use_id());
+                }
+                ContentBlock::ToolResult(tr) => {
+                    assert!(
+                        introduced.contains(tr.tool_use_id()),
+                        "orphan ToolResult for {:?} with no preceding ToolUse in {messages:?}",
+                        tr.tool_use_id()
+                    );
+                    answered.insert(tr.tool_use_id());
+                }
+                _ => {}
+            }
+        }
+    }
+    for id in &introduced {
+        assert!(
+            answered.contains(id),
+            "ToolUse {id:?} has no matching ToolResult anywhere in {messages:?}"
+        );
+    }
+}
+
+/// A `tool`-role result whose `tool_call_id` was never introduced by any
+/// preceding assistant `tool_calls` entry is dropped, not passed through as
+/// an orphan `ToolResult`.
+///
+/// Why: This is exactly the corrupted shape a naive count-based compaction
+/// cutoff can produce (#2278): the assistant entry carrying the matching
+/// `tool_calls` got folded into a compacted-span summary while the
+/// answering `tool`-role entry survived verbatim. Bedrock's Converse API
+/// rejects any orphan `ToolResult` with `ValidationException`, so the
+/// backstop must drop it rather than forward it.
+/// What: Build a request with a `tool`-role message whose `tool_call_id` has
+/// no matching prior `ToolUse`; assert the pairing invariant holds and that
+/// no `ToolResult` for that id appears in the output.
+/// Test: this test.
+#[test]
+fn enforce_tool_pairing_drops_orphan_tool_result() {
+    let req = minimal_request(vec![
+        ChatMessage::system("s"),
+        ChatMessage::user("do it"),
+        ChatMessage::tool_result("orphan_call", "bash", "leftover output"),
+    ]);
+    let (_, messages) = build_converse_messages(&req).expect("convert");
+
+    assert_tool_pairing_invariant(&messages);
+    for message in &messages {
+        for block in message.content() {
+            if let ContentBlock::ToolResult(tr) = block {
+                assert_ne!(
+                    tr.tool_use_id(),
+                    "orphan_call",
+                    "orphan ToolResult must be dropped, not passed through: {messages:?}"
+                );
+            }
+        }
+    }
+}
+
+/// An assistant `ToolUse` with NO following `ToolResult` at all gets a
+/// synthesized placeholder `ToolResult` appended immediately after it.
+///
+/// Why: The other half of the #2278 orphan shape — the answering `tool`-role
+/// entry itself was the one folded into a compacted-span summary (or never
+/// recorded at all). Without a synthesized answer, Bedrock rejects the
+/// request outright for a missing `toolResult`.
+/// What: Build a request with an assistant `tool_calls` entry and
+/// deliberately no matching `tool_result` entry; assert the pairing
+/// invariant holds, a placeholder `ToolResult` for that call id exists in
+/// the immediately-following message, and it carries `status: Error`.
+/// Test: this test.
+#[test]
+fn enforce_tool_pairing_synthesizes_placeholder_for_unanswered_tool_use() {
+    let mut req = minimal_request(vec![ChatMessage::system("s"), ChatMessage::user("do it")]);
+    req.messages.push(ChatMessage {
+        role: "assistant".into(),
+        content: None,
+        tool_calls: Some(vec![ToolCall {
+            id: "call_1".into(),
+            kind: "function".into(),
+            function: FunctionCall {
+                name: "bash".into(),
+                arguments: "{}".into(),
+            },
+        }]),
+        tool_call_id: None,
+        name: None,
+        cache_control: None,
+    });
+    // Deliberately no matching tool_result entry.
+
+    let (_, messages) = build_converse_messages(&req).expect("convert");
+
+    assert_tool_pairing_invariant(&messages);
+    let assistant_idx = messages
+        .iter()
+        .position(|m| {
+            m.content()
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolUse(_)))
+        })
+        .expect("assistant ToolUse message must be present");
+    let following = messages
+        .get(assistant_idx + 1)
+        .expect("a following message with the synthesized placeholder must exist");
+    let placeholder = following
+        .content()
+        .iter()
+        .find_map(|b| match b {
+            ContentBlock::ToolResult(tr) if tr.tool_use_id() == "call_1" => Some(tr),
+            _ => None,
+        })
+        .expect("placeholder ToolResult for call_1 must exist");
+    assert!(matches!(
+        placeholder.status(),
+        Some(ToolResultStatus::Error)
+    ));
+}
+
+/// A conversation whose tool calls are already fully paired is left
+/// unchanged by the backstop — no dropped blocks, no synthesized
+/// placeholders.
+///
+/// Why: The fix must be a no-op on the overwhelmingly common valid case;
+/// regression guard against an overzealous implementation mangling healthy
+/// conversations.
+/// What: Build a request with one assistant `tool_calls` entry immediately
+/// answered by its `tool_result`; assert the message shape and the real
+/// result's content are unchanged (no `Error` status stamped onto it).
+/// Test: this test.
+#[test]
+fn enforce_tool_pairing_leaves_valid_conversation_unchanged() {
+    let mut req = minimal_request(vec![ChatMessage::system("s"), ChatMessage::user("go")]);
+    req.messages.push(ChatMessage {
+        role: "assistant".into(),
+        content: None,
+        tool_calls: Some(vec![ToolCall {
+            id: "call_1".into(),
+            kind: "function".into(),
+            function: FunctionCall {
+                name: "bash".into(),
+                arguments: "{}".into(),
+            },
+        }]),
+        tool_call_id: None,
+        name: None,
+        cache_control: None,
+    });
+    req.messages
+        .push(ChatMessage::tool_result("call_1", "bash", "ok"));
+
+    let (_, messages) = build_converse_messages(&req).expect("convert");
+
+    assert_tool_pairing_invariant(&messages);
+    assert_eq!(
+        messages.len(),
+        3,
+        "user(task), assistant(tool use), user(tool result) — no extra synthesized message"
+    );
+    assert_eq!(messages[2].content().len(), 1, "no placeholder appended");
+    match &messages[2].content()[0] {
+        ContentBlock::ToolResult(tr) => {
+            assert_eq!(tr.tool_use_id(), "call_1");
+            assert!(
+                tr.status().is_none(),
+                "a real result must not get the placeholder Error status"
+            );
+        }
+        other => panic!("expected ToolResult, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary

Root-caused in issue #2278: Bedrock sub-agent re-delegation fails with `ValidationException: ... toolResult` because the transcript's compaction cutoff and the Bedrock message-assembly code can each independently produce an orphaned `tool_use`/`tool_result` pair. This PR lands both halves of the fix in one PR, per the issue's requirement that the fix be general (provider-agnostic root cause) plus a Bedrock-specific backstop.

**Fix A — turn-group-atomic compaction (`crates/trusty-code/src/agent_loop/transcript.rs`, provider-agnostic):**
`Transcript::maybe_compact` used a raw entry-COUNT cutoff (`keep_last_messages`) with no tool-call awareness. When the cutoff landed between an assistant entry carrying `tool_calls` and one of its answering `tool`-role entries, the assistant got folded into the compacted summary while the answer survived verbatim — an orphaned tool result with no tool use. `maybe_compact` now treats an assistant entry with `tool_calls` plus the maximal contiguous run of answering `tool` entries as one atomic turn group (naturally covering multi-tool-call turns — N tool_calls answered by N tool entries). New helpers `turn_group_start`/`turn_group_end` detect when the naive cutoff falls inside a group and pull the whole group forward into the kept zone — `keep_last_messages` becomes a soft floor rather than ever splitting a group. All existing invariants (system/user and pinned skill-output entries never compact; turn-boundary-only) are preserved and their tests still pass unchanged.

**Fix B — Bedrock pairing-enforcement backstop (`crates/trusty-code/src/llm/bedrock/convert.rs`, Bedrock-specific):**
`build_converse_messages` now runs a new `enforce_tool_pairing` pass over the fully role-merged Converse message list before returning, so the emitted request ALWAYS satisfies Bedrock's invariant regardless of what produced the input history: any orphan `ToolResult` (no earlier matching `ToolUse`) is dropped; any `ToolUse` left unanswered in its answering window gets a synthesized placeholder `ToolResult` (`status: Error`, "[result unavailable — history was compacted]"). Also fixes a secondary ordering defect: a mid-conversation `system`-role message (e.g. a compaction-summary placeholder) was diverted to the system-prompt array via a bare `continue` without flushing the in-progress same-role batch first, silently corrupting message ordering.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-code` — 750 passed, 0 failed, 0 ignored (`--include-ignored`, including Fix #5 / #2279 gate tests, unaffected)
- [x] `cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 allowlisted, 0 violations
- [x] New tests: `transcript::tests::maybe_compact_pulls_whole_multi_tool_call_group_forward` (reproduces the exact split shape with a 2-tool-call turn and asserts pairing stays intact in `to_messages()`); `bedrock::tests::enforce_tool_pairing_drops_orphan_tool_result`, `bedrock::tests::enforce_tool_pairing_synthesizes_placeholder_for_unanswered_tool_use`, `bedrock::tests::enforce_tool_pairing_leaves_valid_conversation_unchanged`

Closes #2278

🤖 Generated with [Claude Code](https://claude.com/claude-code)