### PR TITLE
fix(trusty-mpm): strip stale-hash mpm hook entries so managed hook-merge is idempotent (closes #2235)

### DIFF
--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -180,31 +180,83 @@ pub fn mpm_hook_additions() -> serde_json::Value {
     mpm_hook_additions_with_exe(None)
 }
 
-/// Binary names this crate ships as `[[bin]]` targets (`Cargo.toml`): the
-/// full name and the short everyday alias used by `tm run`/`tm load`/`tm login`.
+/// Canonical binary names this crate ships as `[[bin]]` targets (`Cargo.toml`):
+/// the full name and the short everyday alias used by `tm run`/`tm load`/`tm login`.
 const MPM_BIN_NAMES: &[&str] = &["trusty-mpm", "tm"];
+
+/// File-name STEMS that identify an mpm-owned binary once any Cargo
+/// build-artifact `-<hash>` suffix is stripped.
+///
+/// Why (#2235): managed hooks resolved from a debug/worktree build embed a
+/// `target/debug/deps/<stem>-<hash>` path whose file name is NOT one of
+/// [`MPM_BIN_NAMES`] — the Cargo dep artifact uses the underscore crate name
+/// (`trusty_mpm`) or the `[[bin]]` alias (`tm`) with a trailing content hash,
+/// and the long-defunct pre-rename binary was `session_manager_mvp`. All of
+/// these must be recognised as the SAME hook owner so stale entries collapse.
+/// What: the canonical stems (dash + underscore spellings) plus the retired MVP
+/// name. Matched by [`is_mpm_binary_filename`] against the hash-stripped stem.
+const MPM_BIN_STEMS: &[&str] = &["trusty-mpm", "trusty_mpm", "tm", "session_manager_mvp"];
+
+/// Recognise an mpm-owned binary by its file-name component, tolerating Cargo
+/// build-artifact hash suffixes and the defunct `session_manager_mvp` name.
+///
+/// Why (#2235): dedup that keyed identity on the exact file name ∈
+/// {`trusty-mpm`,`tm`} could never strip a stale entry whose command carried a
+/// build-artifact path (`.../deps/trusty_mpm-<hash> hook`, `.../tm-<hash> hook`)
+/// or the retired `session_manager_mvp-<hash>` name — those file names are not
+/// in the recognised set, so every managed launch appended a fresh entry beside
+/// the un-strippable stale ones and `settings.json` grew without bound. Matching
+/// the whole binary family (canonical names + hash-suffixed artifacts + the MVP
+/// name) makes the strip remove ALL prior managed variants before the merge, so
+/// exactly one canonical entry per (event, matcher) survives.
+/// What: returns `true` when `name` is a canonical [`MPM_BIN_NAMES`] entry, the
+/// bare defunct `session_manager_mvp` name, OR a Cargo build-artifact of the
+/// form `<stem>-<hexhash>` where `stem ∈ MPM_BIN_STEMS` and `<hexhash>` is an
+/// all-hex-digit suffix of length ≥ 8 (the shape Cargo emits under
+/// `target/*/deps/`). The hex-length guard keeps unrelated binaries that merely
+/// share a stem prefix (e.g. `tm-cli`) from being mis-identified.
+/// Test: `test_is_mpm_hook_command_recognises_tm_bin_name`,
+/// `test_is_mpm_hook_command_recognises_stale_hash_and_mvp_variants`.
+fn is_mpm_binary_filename(name: &str) -> bool {
+    if MPM_BIN_NAMES.contains(&name) || name == "session_manager_mvp" {
+        return true;
+    }
+    // Cargo build-artifact form: `<stem>-<hexhash>` (e.g. `trusty_mpm-1a2b3c4d`).
+    if let Some((stem, hash)) = name.rsplit_once('-')
+        && hash.len() >= 8
+        && hash.bytes().all(|b| b.is_ascii_hexdigit())
+    {
+        return MPM_BIN_STEMS.contains(&stem);
+    }
+    false
+}
 
 /// Check if a command string is one of the trusty-mpm hook command variants.
 ///
-/// Why (#2015): the crate ships TWO `[[bin]]` targets that share one binary —
-/// `trusty-mpm` and the short alias `tm` (the everyday entry point for `tm
-/// run`/`tm load`/`tm login`). `mpm_hook_command` resolves whichever binary is
-/// currently running via `current_exe()`, so a hook group's command can be
+/// Why (#2015, #2235): the crate ships TWO `[[bin]]` targets that share one
+/// binary — `trusty-mpm` and the short alias `tm` (the everyday entry point for
+/// `tm run`/`tm load`/`tm login`). `mpm_hook_command` resolves whichever binary
+/// is currently running via `current_exe()`, so a hook group's command can be
 /// `.../tm hook` on one write and `.../trusty-mpm hook` on the next (or vice
-/// versa) purely from which entry point launched the process — not from any
-/// real difference in ownership. The original predicate only recognised the
-/// `trusty-mpm` name, so a stale `tm`-named group was invisible to the
-/// replace-by-identity strip in [`write_project_hooks`] and survived every
-/// merge: exactly the accumulation bug #2015 reports. Both names must be
-/// recognised as the SAME hook owner.
+/// versa) purely from which entry point launched the process. Worse, a
+/// debug/worktree build resolves to a hash-suffixed artifact
+/// (`.../deps/trusty_mpm-<hash> hook`) and legacy configs still carry the
+/// retired `session_manager_mvp-<hash>` name — none of which the original
+/// file-name-exact predicate recognised, so those stale groups were invisible
+/// to the replace-by-identity strip in [`write_project_hooks`] and survived
+/// every merge: exactly the unbounded-growth bug #2235 reports. The whole
+/// binary family must be recognised as the SAME hook owner.
 /// What: returns `true` when `cmd` ends with ` hook` (scoping the match to an
 /// actual MPM hook invocation, not just any binary that happens to share a
-/// name) AND the remaining prefix's file-name component is one of
-/// [`MPM_BIN_NAMES`] — covering both bare names (`"tm hook"`) and absolute
-/// paths (`"/opt/bin/tm hook"`, `"/opt/bin/trusty-mpm hook"`).
+/// name) AND the remaining prefix's file-name component is recognised by
+/// [`is_mpm_binary_filename`] — covering bare names (`"tm hook"`), absolute
+/// paths (`"/opt/bin/trusty-mpm hook"`), and hash-suffixed build artifacts
+/// (`".../deps/trusty_mpm-<hash> hook"`, `"session_manager_mvp-<hash> hook"`).
 /// Test: `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`,
 /// `test_is_mpm_hook_command_recognises_tm_bin_name`,
-/// `test_write_project_hooks_replaces_stale_exe_path_group`.
+/// `test_is_mpm_hook_command_recognises_stale_hash_and_mvp_variants`,
+/// `test_write_project_hooks_replaces_stale_exe_path_group`,
+/// `test_write_project_hooks_collapses_stale_hash_and_mvp_entries`.
 fn is_mpm_hook_command(cmd: &str) -> bool {
     // The command must end with " hook" (with exactly one trailing sub-command word).
     let Some(binary) = cmd.strip_suffix(" hook") else {
@@ -213,7 +265,7 @@ fn is_mpm_hook_command(cmd: &str) -> bool {
     Path::new(binary)
         .file_name()
         .and_then(|f| f.to_str())
-        .is_some_and(|name| MPM_BIN_NAMES.contains(&name))
+        .is_some_and(is_mpm_binary_filename)
 }
 
 /// Strip trusty-mpm hook entries from every global Claude settings file.

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -381,6 +381,158 @@ fn test_is_mpm_hook_command_recognises_tm_bin_name() {
     );
 }
 
+/// Why (#2235): dedup that keyed identity on the exact file name ∈
+/// {`trusty-mpm`,`tm`} could never strip a stale entry whose command carried a
+/// Cargo build-artifact path (`.../deps/trusty_mpm-<hash> hook`,
+/// `.../tm-<hash> hook`) or the retired `session_manager_mvp-<hash>` name, so
+/// those groups accumulated forever and bloated `settings.json`. The predicate
+/// must recognise the whole binary family so the strip collapses them.
+/// What: asserts hash-suffixed artifacts (underscore + dash spellings, the `tm`
+/// alias) and the defunct MVP name — bare and hash-suffixed — are all
+/// recognised, while look-alikes that merely share a stem prefix (`tm-cli`) or
+/// carry a non-hex suffix are NOT, so unrelated tools are never stripped.
+#[test]
+fn test_is_mpm_hook_command_recognises_stale_hash_and_mvp_variants() {
+    // Cargo build-artifact (deps) forms — the recurring #2235 stale patterns.
+    assert!(
+        is_mpm_hook_command("/x/target/debug/deps/trusty_mpm-1a2b3c4d5e6f7a8b hook"),
+        "underscore dep artifact with hex hash must match"
+    );
+    assert!(
+        is_mpm_hook_command("/x/target/debug/deps/tm-1a2b3c4d5e6f7a8b hook"),
+        "tm alias dep artifact with hex hash must match"
+    );
+    assert!(
+        is_mpm_hook_command("/x/target/debug/deps/trusty-mpm-1a2b3c4d hook"),
+        "dash-spelled artifact with hex hash must match"
+    );
+    // Defunct pre-rename binary — bare and hash-suffixed.
+    assert!(
+        is_mpm_hook_command("session_manager_mvp hook"),
+        "bare defunct MVP name must match"
+    );
+    assert!(
+        is_mpm_hook_command("/x/deps/session_manager_mvp-deadbeef hook"),
+        "hash-suffixed defunct MVP name must match"
+    );
+    // Negative: unrelated binaries sharing a stem prefix must NOT match.
+    assert!(
+        !is_mpm_hook_command("/usr/bin/tm-cli hook"),
+        "look-alike 'tm-cli' (non-hex suffix) must not be mis-identified as mpm"
+    );
+    assert!(
+        !is_mpm_hook_command("/usr/bin/trusty-mpmx hook"),
+        "unrelated 'trusty-mpmx' must not match"
+    );
+}
+
+/// Why (#2235): the durable fix must make provisioning self-compacting — a
+/// config pre-seeded with duplicate managed entries from stale binary paths
+/// (hash-suffixed worktree builds AND the defunct `session_manager_mvp` name)
+/// must collapse to exactly ONE canonical group per event on the next
+/// `write_project_hooks`, instead of the observed unbounded accumulation
+/// (~6900-line settings.json). Also proves N repeated writes stay bounded.
+/// What: seeds an event array with FOUR stale MPM groups (two hash-suffixed
+/// path variants + one `session_manager_mvp` variant + one bare `tm`) plus one
+/// unrelated non-MPM group, then calls `write_project_hooks` and asserts the
+/// event collapses to exactly 2 groups (1 preserved non-MPM + 1 canonical MPM)
+/// with no stale path surviving. Then writes 5 more times and asserts the raw
+/// group count never grows.
+#[test]
+fn test_write_project_hooks_collapses_stale_hash_and_mvp_entries() {
+    let tmp = TempDir::new().unwrap();
+    let settings = tmp.path().join("settings.json");
+
+    // Pre-seed PreToolUse with a pile of stale MPM variants + one non-MPM group.
+    std::fs::write(
+        &settings,
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "matcher": "*", "hooks": [{ "type": "command",
+                        "command": "/a/target/debug/deps/trusty_mpm-1111111111111111 hook" }] },
+                    { "matcher": "*", "hooks": [{ "type": "command",
+                        "command": "/b/target/debug/deps/tm-2222222222222222 hook" }] },
+                    { "matcher": "*", "hooks": [{ "type": "command",
+                        "command": "/c/deps/session_manager_mvp-deadbeef hook" }] },
+                    { "matcher": "*", "hooks": [{ "type": "command",
+                        "command": "tm hook" }] },
+                    { "matcher": "*", "hooks": [{ "type": "command",
+                        "command": "trusty-memory inbox-check" }] }
+                ]
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let exe = PathBuf::from("/home/user/.cargo/bin/trusty-mpm");
+    write_project_hooks(&settings, Some(&exe)).unwrap();
+
+    let text = std::fs::read_to_string(&settings).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let pre = val["hooks"]["PreToolUse"].as_array().unwrap();
+
+    // Raw length (NOT predicate-filtered): 1 preserved non-MPM + 1 canonical MPM.
+    assert_eq!(
+        pre.len(),
+        2,
+        "all stale MPM variants must collapse to one canonical group, found {}: {pre:?}",
+        pre.len()
+    );
+    let cmds: Vec<&str> = pre
+        .iter()
+        .filter_map(|g| g["hooks"][0]["command"].as_str())
+        .collect();
+    assert!(
+        cmds.contains(&"trusty-memory inbox-check"),
+        "non-MPM group must survive, got: {cmds:?}"
+    );
+    for stale in [
+        "trusty_mpm-1111111111111111",
+        "tm-2222222222222222",
+        "session_manager_mvp",
+    ] {
+        assert!(
+            !cmds.iter().any(|c| c.contains(stale)),
+            "stale variant {stale:?} must be stripped, got: {cmds:?}"
+        );
+    }
+    assert!(
+        cmds.iter().any(|c| c.contains("/.cargo/bin/trusty-mpm")),
+        "canonical resolved exe path must be present, got: {cmds:?}"
+    );
+
+    // N-times idempotency: 5 more writes must never grow the group count.
+    for _ in 0..5 {
+        write_project_hooks(&settings, Some(&exe)).unwrap();
+    }
+    let text2 = std::fs::read_to_string(&settings).unwrap();
+    let val2: serde_json::Value = serde_json::from_str(&text2).unwrap();
+    for event in &[
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+        "SessionStart",
+        "SessionEnd",
+    ] {
+        let arr = val2["hooks"][*event].as_array().unwrap();
+        let mpm_groups = arr
+            .iter()
+            .filter(|g| {
+                g["hooks"].as_array().is_some_and(|hs| {
+                    hs.iter()
+                        .any(|h| h["command"].as_str().is_some_and(|c| c.ends_with(" hook")))
+                })
+            })
+            .count();
+        assert_eq!(
+            mpm_groups, 1,
+            "event {event} must have exactly one MPM group after N writes, found {mpm_groups}"
+        );
+    }
+}
+
 /// Why (#2015): `merge_hook_entries` dedups only by byte-for-byte JSON
 /// equality, so writing with a different resolved exe path (bin rename —
 /// including the `tm` vs `trusty-mpm` [[bin]]-name switch, not just a


### PR DESCRIPTION
## Summary

Fixes managed hook-merge accumulation where duplicate hook entries were never stripped.

**Root cause:** Deduplication was keyed on stale binary filenames like `tm-<hash>` and `session_manager_mvp-<hash>`, so older entries never got stripped when the binary was rebuilt with a new hash. Every managed session appended duplicates, and `settings.json` grew unbounded.

**Fix:** 
- Broadened `is_mpm_binary_filename` matching to recognize all filename variants
- Made provisioning self-compacting by stripping all prior variants before merge

**Quality gate:** ✓ 4178 tests passed, clippy/fmt/line-cap clean.

Closes #2235

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools