### PR TITLE
fix(trusty-search): warm-boot health reports degraded when corpus fails to open (closes #1870)

### DIFF
--- a/crates/trusty-search/src/commands/prior_index_count.rs
+++ b/crates/trusty-search/src/commands/prior_index_count.rs
@@ -106,6 +106,10 @@ pub(crate) fn record_warm_boot_result(
             // re-reads from cold_store.failed_len() live so it increases as
             // restore failures are recorded during the daemon's lifetime.
             indexes_failed: 0,
+            // Issue #1870: stored at boot-completion as 0; the health handler
+            // recomputes it live every poll by scanning registry handles for a
+            // failed lane, so its stored value is never read.
+            indexes_corpus_failed: 0,
         };
     }
 

--- a/crates/trusty-search/src/commands/prior_index_count.rs
+++ b/crates/trusty-search/src/commands/prior_index_count.rs
@@ -110,6 +110,10 @@ pub(crate) fn record_warm_boot_result(
             // recomputes it live every poll by scanning registry handles for a
             // failed lane, so its stored value is never read.
             indexes_corpus_failed: 0,
+            // Issue #1870 review follow-up: same rationale — the health
+            // handler recomputes this live every poll; the stored value here
+            // is never read.
+            indexes_health_scan_skipped: 0,
         };
     }
 

--- a/crates/trusty-search/src/core/registry.rs
+++ b/crates/trusty-search/src/core/registry.rs
@@ -150,6 +150,25 @@ impl IndexStages {
         out
     }
 
+    /// Whether any of the three stages is `StageStatus::Failed`.
+    ///
+    /// Why (issue #1870): `/health` must detect a registered index whose
+    /// durable corpus (or any lane) failed to open and report degraded instead
+    /// of a blanket `"ok"`. Such an index warm-boots into the registry with a
+    /// healthy-looking `chunk_count` but all stages marked `Failed` (see
+    /// `derive_warm_boot_stages`' `corpus_open_failed` guard), so free-text /
+    /// BM25 / hybrid queries silently return `[]`. This is the single predicate
+    /// the health handler scans every handle with; it shares the exact
+    /// Failed-dominates rule `lifecycle_status` uses so the two never diverge.
+    /// What: `true` when lexical, semantic, or graph is `Failed`.
+    /// Test: `any_failed_*` in this module + the health-handler regression
+    /// `health_reports_degraded_when_corpus_open_failed` in `tests_health`.
+    pub fn any_failed(&self) -> bool {
+        self.lexical.status == StageStatus::Failed
+            || self.semantic.status == StageStatus::Failed
+            || self.graph.status == StageStatus::Failed
+    }
+
     /// Compute the coarse top-level lifecycle status string used by the
     /// status endpoint's `status` field. Maps to:
     /// `created` → `walking` → `indexed_lexical` → `indexed_vector` → `ready`
@@ -158,10 +177,7 @@ impl IndexStages {
         // Issue #601: ANY failed stage dominates the lifecycle status — a
         // zero-vector embed failure must report `failed`, never `ready`, so
         // `/health` and `GET /indexes/:id` surface the dead lane loudly.
-        if self.lexical.status == StageStatus::Failed
-            || self.semantic.status == StageStatus::Failed
-            || self.graph.status == StageStatus::Failed
-        {
+        if self.any_failed() {
             return "failed";
         }
         match (self.lexical.status, self.semantic.status, self.graph.status) {
@@ -674,6 +690,41 @@ mod tests {
         assert!(!caps.contains(&"kg"));
         // And the top-level status reflects terminal completion.
         assert_eq!(stages.lifecycle_status(), "ready");
+    }
+
+    /// Issue #1870: `any_failed` is the predicate `/health` scans every handle
+    /// with. It must be false for every non-failed combination and true the
+    /// instant any single lane fails — and stay consistent with
+    /// `lifecycle_status`, which reports `"failed"` under the same condition.
+    #[test]
+    fn any_failed_matches_lifecycle_failed() {
+        // No lane failed → any_failed is false across the lifecycle.
+        let mut stages = IndexStages::default();
+        assert!(!stages.any_failed());
+        stages.lexical.status = StageStatus::Ready;
+        stages.semantic.status = StageStatus::Ready;
+        stages.graph.status = StageStatus::Ready;
+        assert!(!stages.any_failed());
+        assert_ne!(stages.lifecycle_status(), "failed");
+
+        // Each lane failing in isolation trips both any_failed and lifecycle.
+        for stages in [
+            IndexStages {
+                lexical: StageState::failed("boom"),
+                ..Default::default()
+            },
+            IndexStages {
+                semantic: StageState::failed("boom"),
+                ..Default::default()
+            },
+            IndexStages {
+                graph: StageState::failed("boom"),
+                ..Default::default()
+            },
+        ] {
+            assert!(stages.any_failed());
+            assert_eq!(stages.lifecycle_status(), "failed");
+        }
     }
 
     /// In-progress lexical → top-level status is `walking`. The search

--- a/crates/trusty-search/src/core/registry.rs
+++ b/crates/trusty-search/src/core/registry.rs
@@ -162,7 +162,8 @@ impl IndexStages {
     /// Failed-dominates rule `lifecycle_status` uses so the two never diverge.
     /// What: `true` when lexical, semantic, or graph is `Failed`.
     /// Test: `any_failed_*` in this module + the health-handler regression
-    /// `health_reports_degraded_when_corpus_open_failed` in `tests_health`.
+    /// `health_reports_degraded_when_corpus_open_failed` in
+    /// `tests_health_degraded`.
     pub fn any_failed(&self) -> bool {
         self.lexical.status == StageStatus::Failed
             || self.semantic.status == StageStatus::Failed

--- a/crates/trusty-search/src/service/server/health.rs
+++ b/crates/trusty-search/src/service/server/health.rs
@@ -229,6 +229,42 @@ pub(super) async fn health_handler(
     warmboot_summary.indexes_lazy = state.cold_store.len();
     warmboot_summary.indexes_failed = state.cold_store.failed_len();
 
+    // Issue #1870: a registered index whose durable redb corpus failed to open
+    // on warm-boot (`DatabaseAlreadyOpen` from an in-process double-open, or an
+    // incompatible/corrupt corpus format) warm-boots into the registry with a
+    // healthy-looking `chunk_count` but every search stage marked `Failed` (see
+    // the `corpus_open_failed` guard in `derive_warm_boot_stages`). Free-text /
+    // BM25 / hybrid queries against it silently return `[]` while `/health` used
+    // to report `"ok"` — a silent, total search outage the daemon self-certified
+    // as healthy. Scan the live registry for any such index and fold the count
+    // into the warm-boot degraded signal so a `status != "ok"` (or
+    // `warm_boot_degraded`) probe detects the outage without tailing logs.
+    //
+    // Issue #1006 (non-blocking health handler): use `try_read()` on each
+    // handle's `stages` lock rather than `.read().await`. The stages lock is
+    // read-mostly and only written by the reindex pipeline, so contention is
+    // rare; on the exceedingly-rare miss we skip that handle (undercount by one
+    // for this poll) — the failure is stable across restarts and every
+    // subsequent 2 s poll re-scans, so it is never lost.
+    let indexes_corpus_failed = state
+        .registry
+        .list_handles()
+        .iter()
+        .filter(|handle| {
+            handle
+                .stages
+                .try_read()
+                .map(|stages| stages.any_failed())
+                .unwrap_or(false)
+        })
+        .count();
+    warmboot_summary.indexes_corpus_failed = indexes_corpus_failed;
+    if indexes_corpus_failed > 0 {
+        // Fold into the single machine-readable warm-boot health flag external
+        // monitors already poll, so #1870 rides the existing degraded channel.
+        warmboot_summary.warm_boot_degraded = true;
+    }
+
     // Issue #1672: read the reconcile summary. Returns None when reconcile has
     // not started yet (disabled via env gate or daemon still in boot). The
     // `skip_serializing_if = "Option::is_none"` on the response field keeps
@@ -255,8 +291,19 @@ pub(super) async fn health_handler(
         })
         .unwrap_or(None);
 
+    // Issue #1870: honest top-level status. `"ok"` used to be unconditional,
+    // so a total silent search outage (all-lanes-Failed corpus) still read as
+    // healthy. Downgrade to `"degraded"` when at least one registered index has
+    // a failed lane so a simple `status != "ok"` gate catches it. The healthy
+    // path is unchanged (`indexes_corpus_failed == 0` → `"ok"`).
+    let overall_status = if warmboot_summary.indexes_corpus_failed > 0 {
+        "degraded"
+    } else {
+        "ok"
+    };
+
     Json(HealthResponse {
-        status: "ok",
+        status: overall_status,
         version: env!("CARGO_PKG_VERSION"),
         indexes: state.registry.list().len(),
         uptime_secs: state.started_at.elapsed().as_secs(),

--- a/crates/trusty-search/src/service/server/health.rs
+++ b/crates/trusty-search/src/service/server/health.rs
@@ -246,19 +246,35 @@ pub(super) async fn health_handler(
     // rare; on the exceedingly-rare miss we skip that handle (undercount by one
     // for this poll) — the failure is stable across restarts and every
     // subsequent 2 s poll re-scans, so it is never lost.
+    //
+    // Issue #1870 review follow-up: failing open on a miss is the correct
+    // trade-off (never block the health handler), but a *persistently*
+    // contended handle would otherwise be silently skipped forever — the one
+    // remaining path that could stay invisibly degraded. Count every miss into
+    // `indexes_health_scan_skipped` and name the skipped index at `debug!` so a
+    // persistent miss is detectable (a healthy poll has this at 0; a handle
+    // stuck under write-lock contention shows up as a repeated non-zero count
+    // for the same id across consecutive polls) without changing the
+    // fail-open behavior itself.
+    let mut indexes_health_scan_skipped = 0usize;
     let indexes_corpus_failed = state
         .registry
         .list_handles()
         .iter()
-        .filter(|handle| {
-            handle
-                .stages
-                .try_read()
-                .map(|stages| stages.any_failed())
-                .unwrap_or(false)
+        .filter(|handle| match handle.stages.try_read() {
+            Ok(stages) => stages.any_failed(),
+            Err(_) => {
+                indexes_health_scan_skipped += 1;
+                tracing::debug!(
+                    index_id = %handle.id,
+                    "health: stages lock contended — skipping this handle for this poll (#1870)"
+                );
+                false
+            }
         })
         .count();
     warmboot_summary.indexes_corpus_failed = indexes_corpus_failed;
+    warmboot_summary.indexes_health_scan_skipped = indexes_health_scan_skipped;
     if indexes_corpus_failed > 0 {
         // Fold into the single machine-readable warm-boot health flag external
         // monitors already poll, so #1870 rides the existing degraded channel.

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -46,6 +46,8 @@ mod tests_grep;
 #[cfg(test)]
 mod tests_health;
 #[cfg(test)]
+mod tests_health_degraded;
+#[cfg(test)]
 mod tests_index;
 #[cfg(test)]
 mod tests_index_config;

--- a/crates/trusty-search/src/service/server/state.rs
+++ b/crates/trusty-search/src/service/server/state.rs
@@ -495,9 +495,30 @@ pub struct WarmBootSummary {
     /// What: computed live on every `GET /health` poll by scanning registry
     /// handles for any `Failed` stage (`IndexStages::any_failed`); not persisted.
     /// `0` is the healthy steady state.
-    /// Test: `health_reports_degraded_when_corpus_open_failed` in `tests_health`.
+    /// Test: `health_reports_degraded_when_corpus_open_failed` in
+    /// `tests_health_degraded`.
     #[serde(default)]
     pub indexes_corpus_failed: usize,
+    /// Number of registered handles whose `stages` lock was contended (a
+    /// `try_read()` miss) during the most recent `/health` scan for
+    /// `indexes_corpus_failed` (issue #1870 review follow-up).
+    ///
+    /// Why: the health handler must never block on a contended lock (issue
+    /// #1006), so a miss fails open (treated as "not failed" for that poll).
+    /// That is the correct trade-off, but it means a *persistently* contended
+    /// handle could in principle stay invisibly excluded from
+    /// `indexes_corpus_failed` forever. This counter makes that failure mode
+    /// observable: `0` on every healthy poll; a handle stuck under sustained
+    /// write-lock contention shows up as a repeated non-zero count here (and
+    /// by index id at `debug!` in the daemon log) across consecutive polls,
+    /// which is the signal an operator needs to notice a persistent miss
+    /// rather than a one-off scheduling blip.
+    /// What: computed live on every `GET /health` poll in `health_handler`;
+    /// not persisted. Does not change the underlying fail-open behavior.
+    /// Test: `health_stays_ok_when_no_corpus_failed` in `tests_health_degraded`
+    /// covers the steady-state `0` case.
+    #[serde(default)]
+    pub indexes_health_scan_skipped: usize,
 }
 
 /// Per-boot reconcile summary surfaced on `GET /health` (issue #1672).

--- a/crates/trusty-search/src/service/server/state.rs
+++ b/crates/trusty-search/src/service/server/state.rs
@@ -446,6 +446,8 @@ pub struct WarmBootSummary {
     /// `true` when any of the following hold:
     /// - `indexes_skipped_tcc > 0` (TCC / FDA denial)
     /// - `indexes_skipped_timeout > 0` (scan timeout — issue #1091)
+    /// - `indexes_corpus_failed > 0` (a registered index's corpus/lane failed
+    ///   to open — issue #1870)
     /// - `indexes_loaded` is less than 80% of the prior-known count
     ///   (suggesting a large fraction of indexes are missing, e.g. after
     ///   FDA was revoked)
@@ -476,6 +478,26 @@ pub struct WarmBootSummary {
     /// `ColdIndexStore::failed_len`. `0` is the normal steady-state value.
     /// Test: `health_failed_index_reported` in server tests.
     pub indexes_failed: usize,
+    /// Number of registered indexes whose durable redb corpus (or any search
+    /// lane) failed to open on warm-boot (issue #1870).
+    ///
+    /// Why: distinct from every other counter here. `indexes_failed` and
+    /// `warmboot_failed_indexes` count entries that never made it into the
+    /// registry (cold-store restore failure / TCC denial). An index hit by
+    /// #1870, by contrast, DOES register — it warm-boots with a healthy-looking
+    /// `chunk_count` but a `DatabaseAlreadyOpen` / incompatible-format corpus
+    /// open failure marks all its stages `Failed` (see the `corpus_open_failed`
+    /// guard in `derive_warm_boot_stages`), so free-text / BM25 / hybrid queries
+    /// silently return `[]` while `/health` previously reported `"ok"`. This
+    /// counter closes that honesty gap: any non-zero value forces
+    /// `warm_boot_degraded = true` and downgrades the top-level `status` to
+    /// `"degraded"` so a `status != "ok"` probe catches the outage.
+    /// What: computed live on every `GET /health` poll by scanning registry
+    /// handles for any `Failed` stage (`IndexStages::any_failed`); not persisted.
+    /// `0` is the healthy steady state.
+    /// Test: `health_reports_degraded_when_corpus_open_failed` in `tests_health`.
+    #[serde(default)]
+    pub indexes_corpus_failed: usize,
 }
 
 /// Per-boot reconcile summary surfaced on `GET /health` (issue #1672).

--- a/crates/trusty-search/src/service/server/tests_health_degraded.rs
+++ b/crates/trusty-search/src/service/server/tests_health_degraded.rs
@@ -1,0 +1,126 @@
+//! Health-honesty regression tests for issue #1870.
+//!
+//! Why: split out of `tests_health.rs` to keep that file under the 500-SLOC
+//! production cap (it is not classified as a test file by the line-cap gate
+//! because its basename does not end in `_test.rs`/`_tests.rs`).
+//! What: covers the `/health` degraded-status path when a registered index's
+//! durable corpus failed to open on warm-boot, plus the healthy-path guard.
+//! Test: these tests.
+use super::*;
+use axum::extract::State;
+use axum::Json;
+
+/// Why (issue #1870): the daemon used to report `status: "ok"` even when a
+/// registered index's durable redb corpus failed to open on warm-boot — a
+/// silent, total search outage (every free-text query returns `[]`) that the
+/// daemon self-certified as healthy. `/health` must instead report `degraded`
+/// and surface a machine-readable count so downstream consumers that gate on
+/// `/health` can detect the degradation.
+/// What: registers an index and drives its stages to the exact state the
+/// warm-boot classifier produces on a corpus-open failure
+/// (`derive_warm_boot_stages` with `corpus_open_failed: true` → all lanes
+/// `Failed`), then asserts `/health` downgrades `status` to `"degraded"`, sets
+/// `warm_boot_degraded = true`, and reports `indexes_corpus_failed == 1`.
+/// Test: this test.
+#[tokio::test]
+async fn health_reports_degraded_when_corpus_open_failed() {
+    use crate::core::{
+        indexer::CodeIndexer,
+        registry::{IndexHandle, IndexId, IndexRegistry},
+    };
+    use crate::service::warm_boot::{derive_warm_boot_stages, WarmBootInputs};
+    use serde_json::Value;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let registry = IndexRegistry::new();
+
+    // A healthy index (all lanes non-failed) so we prove the count is scoped
+    // to the broken one, not "any registered index".
+    registry.register(IndexHandle::bare(
+        IndexId::new("healthy"),
+        Arc::new(RwLock::new(CodeIndexer::new("healthy", "/tmp/healthy"))),
+        "/tmp/healthy".into(),
+    ));
+
+    // The #1870 index: registered, but its redb corpus failed to open on
+    // warm-boot, so the classifier marks every lane Failed.
+    let broken = registry.register(IndexHandle::bare(
+        IndexId::new("apex-green"),
+        Arc::new(RwLock::new(CodeIndexer::new(
+            "apex-green",
+            "/tmp/apex-green",
+        ))),
+        "/tmp/apex-green".into(),
+    ));
+    {
+        let mut stages = broken.stages.write().await;
+        *stages = derive_warm_boot_stages(WarmBootInputs {
+            chunk_count: 47_946,
+            hnsw_snapshot_ready: true,
+            graph_node_count: 1_000,
+            lexical_only: false,
+            skip_kg: false,
+            corpus_open_failed: true,
+        });
+        assert!(
+            stages.any_failed(),
+            "precondition: broken index must have a failed lane"
+        );
+    }
+
+    let state = Arc::new(SearchAppState::new(registry));
+    let Json(resp) = health_handler(State(Arc::clone(&state))).await;
+
+    assert_eq!(
+        resp.status, "degraded",
+        "#1870: /health must NOT report 'ok' when a registered corpus failed to open"
+    );
+
+    let json: Value = serde_json::to_value(&resp).expect("serialize");
+    let summary = &json["warmboot_summary"];
+    assert_eq!(
+        summary["indexes_corpus_failed"].as_u64(),
+        Some(1),
+        "#1870: exactly the one all-lanes-Failed index must be counted; json={json}"
+    );
+    assert_eq!(
+        summary["warm_boot_degraded"].as_bool(),
+        Some(true),
+        "#1870: corpus-open failure must flip the machine-readable degraded flag"
+    );
+}
+
+/// Why: the healthy path must stay `"ok"` — the #1870 downgrade is scoped to
+/// indexes with a failed lane and must not regress the common case that
+/// external probes (open-mpm, `ensure_daemon_running`) depend on.
+/// What: registers a single index left in its default (non-failed) stage state
+/// and asserts `/health` still reports `status: "ok"`, `indexes_corpus_failed:
+/// 0`, and does not spuriously set `warm_boot_degraded`.
+/// Test: this test.
+#[tokio::test]
+async fn health_stays_ok_when_no_corpus_failed() {
+    use crate::core::{
+        indexer::CodeIndexer,
+        registry::{IndexHandle, IndexId, IndexRegistry},
+    };
+    use serde_json::Value;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let registry = IndexRegistry::new();
+    registry.register(IndexHandle::bare(
+        IndexId::new("healthy"),
+        Arc::new(RwLock::new(CodeIndexer::new("healthy", "/tmp/healthy"))),
+        "/tmp/healthy".into(),
+    ));
+
+    let state = Arc::new(SearchAppState::new(registry));
+    let Json(resp) = health_handler(State(state)).await;
+
+    assert_eq!(resp.status, "ok");
+    let json: Value = serde_json::to_value(&resp).expect("serialize");
+    let summary = &json["warmboot_summary"];
+    assert_eq!(summary["indexes_corpus_failed"].as_u64(), Some(0));
+    assert_eq!(summary["warm_boot_degraded"].as_bool(), Some(false));
+}

--- a/crates/trusty-search/src/service/server/tests_health_degraded.rs
+++ b/crates/trusty-search/src/service/server/tests_health_degraded.rs
@@ -1,8 +1,11 @@
 //! Health-honesty regression tests for issue #1870.
 //!
-//! Why: split out of `tests_health.rs` to keep that file under the 500-SLOC
-//! production cap (it is not classified as a test file by the line-cap gate
-//! because its basename does not end in `_test.rs`/`_tests.rs`).
+//! Why: these tests landed in their own module (rather than joining
+//! `tests_health.rs`) to keep that file under the 500-SLOC production cap —
+//! it is not classified as a test file by the line-cap gate because its
+//! basename does not end in `_test.rs`/`_tests.rs`, so adding these cases
+//! there would have pushed it over the limit. Nothing was moved out of
+//! `tests_health.rs`; this module is new.
 //! What: covers the `/health` degraded-status path when a registered index's
 //! durable corpus failed to open on warm-boot, plus the healthy-path guard.
 //! Test: these tests.


### PR DESCRIPTION
## Summary

`/health` used to report `status: "ok"` even when a registered index's durable redb corpus failed to open on warm-boot — a silent, total search outage (every free-text/BM25/hybrid query returns `[]`) that the daemon self-certified as healthy.

An index whose corpus fails to open (`DatabaseAlreadyOpen`, or an incompatible/corrupt format) still registers with a healthy-looking `chunk_count`, but `derive_warm_boot_stages` already marks every search lane `Failed` (#1158/#2203). The gap was that `/health` never scanned for this — it only counted indexes that never registered at all.

**Fix:** `/health` now scans registered handles for any `Failed` search lane (`IndexStages::any_failed`, non-blocking `try_read` per #1006), reports the count as `warmboot_summary.indexes_corpus_failed`, folds it into the existing `warm_boot_degraded` flag, and downgrades the top-level `status` to `"degraded"` — so a `status != "ok"` probe catches the outage. The healthy path (0 failed) is unchanged.

**Root cause of the underlying `DatabaseAlreadyOpen`:** for colocated indexes, `corpus_redb_path_for_entry` resolves to `<root_path>/.trusty-search/index.redb`, so two blue/green slots sharing one `root_path` collide on the same redb file — the first warm-booted handle holds it for the daemon's lifetime, so the second open fails and the existing retry-once can never clear an in-process holder. Fixing that collision (sharing the corpus `Arc` across handles keyed by resolved path, or deduplicating entries by corpus path) is a larger, topology-specific change tracked separately as **#2305**. This PR delivers the health-honesty half per the issue's core ask; #2305 tracks preventing the underlying collision.

**Review follow-ups addressed** (independent review came back WARN — merge-acceptable): added `indexes_health_scan_skipped` observability so a persistently-contended `stages` lock (the one path that could still be invisibly degraded under the fail-open `try_read`) is now detectable via a counter + `debug!` log naming the skipped index, without changing the fail-open behavior; fixed two stale doc-comment references to the test module; corrected the new test module's doc comment to accurately describe why it's separate from `tests_health.rs`.

## Test plan

- [x] `cargo build -p trusty-search`
- [x] `cargo test -p trusty-search` — all targets, 0 failed (new: `any_failed_matches_lifecycle_failed`, `health_reports_degraded_when_corpus_open_failed`, `health_stays_ok_when_no_corpus_failed`)
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations

Closes #1870.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools