### PR TITLE
feat(trusty-mpm): tm mcp test verifies MCP servers via stdio handshake (closes #2311)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -882,6 +882,23 @@ pub(crate) enum McpCmd {
         #[arg(long)]
         root: Option<String>,
     },
+    /// Verify MCP servers by running a real handshake against each.
+    ///
+    /// Bare (`tm mcp test`): sweeps every user-scope server unioned with the
+    /// three framework built-ins. `tm mcp test <name>`: tests just that server.
+    /// stdio servers get a full `initialize` → `tools/list` handshake (reporting
+    /// the tool count); http/sse servers get an HTTP reachability check. Exits
+    /// non-zero if ANY tested server fails, so it is CI-usable.
+    Test {
+        /// Optional server name; omit to sweep all servers + built-ins.
+        name: Option<String>,
+        /// Output as JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+        /// Override the managed root (switches to the standalone config dir).
+        #[arg(long)]
+        root: Option<String>,
+    },
 }
 
 /// Transport choice for `tm mcp add` (clap `ValueEnum` mirror of

--- a/crates/trusty-mpm/src/bin/tm/commands/mcp.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mcp.rs
@@ -11,13 +11,14 @@
 //! Test: `cli_parses_mcp_*` in `tests.rs`; parse helpers unit-tested below;
 //! CRUD in `core::mcp_config`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use serde_json::{Map, Value};
 
 use crate::cli::McpTransportArg;
 use trusty_mpm::core::mcp_config::{self, McpTransport, build_remote_entry, build_stdio_entry};
+use trusty_mpm::core::mcp_test::{self, McpTestResult};
 
 /// Resolve the `.claude.json`-bearing config dir for a `tm mcp` invocation.
 ///
@@ -219,6 +220,73 @@ pub(crate) fn get_cmd(root: Option<&str>, name: &str, json: bool) -> Result<()> 
         println!("  Scope:  User config (available in all managed sessions)");
     }
     Ok(())
+}
+
+/// Handle `tm mcp test [<name>] [--json]`.
+///
+/// Why: registration only proves a server's config is well-formed, not that it
+/// starts and speaks MCP. `test` spawns each server and runs the real handshake
+/// so operators (and CI) get a definitive pass/fail.
+/// What: resolves the config dir, selects targets (one named server, or the
+/// full user-scope + built-in union when `name` is `None`), probes each with a
+/// bounded timeout via [`mcp_test::run_all`], then prints a table (or `--json`).
+/// Exits with status 1 if ANY server failed (so it is usable as a CI gate);
+/// a not-found named server is a hard error. Async because the stdio handshake
+/// and http reachability check are I/O-bound.
+/// Test: `cli_parses_mcp_test` in `tests.rs`; probe/selection logic in
+/// `core::mcp_test`.
+pub(crate) async fn test_cmd(root: Option<&str>, name: Option<&str>, json: bool) -> Result<()> {
+    let config_dir = resolve_config_dir(root)?;
+    let servers = mcp_config::list_servers(&config_dir)?;
+    let targets = mcp_test::select_targets(&servers, name)?;
+    let results = mcp_test::run_all(targets, mcp_test::DEFAULT_PROBE_TIMEOUT).await;
+
+    if json {
+        let arr: Vec<Value> = results.iter().map(McpTestResult::to_json).collect();
+        println!("{}", serde_json::to_string_pretty(&Value::Array(arr))?);
+    } else {
+        print_test_table(&results, &config_dir);
+    }
+
+    // Non-zero exit if any server failed, matching `tm services`' convention so
+    // `tm mcp test` slots straight into CI. Exit here (not a returned Err) to
+    // avoid printing anyhow's error chrome after the report.
+    if mcp_test::any_failed(&results) {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Render the human-readable results table for `tm mcp test`.
+fn print_test_table(results: &[McpTestResult], config_dir: &Path) {
+    if results.is_empty() {
+        println!("No MCP servers to test in {}", config_dir.display());
+        return;
+    }
+    println!(
+        "Testing {} MCP server(s) from {}:",
+        results.len(),
+        config_dir.display()
+    );
+    let name_w = results
+        .iter()
+        .map(|r| r.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    println!("  {:<name_w$}  TRANSPORT  RESULT  DETAIL", "NAME");
+    for r in results {
+        let (label, detail) = r.render();
+        println!(
+            "  {:<name_w$}  {:<9}  {:<6}  {}",
+            r.name,
+            r.transport.as_str(),
+            label,
+            detail
+        );
+    }
+    let passed = results.iter().filter(|r| r.passed()).count();
+    println!("\n{passed}/{} passed", results.len());
 }
 
 /// The `type` discriminant of an entry, defaulting to `stdio` when absent.

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -418,6 +418,9 @@ async fn main() -> anyhow::Result<()> {
             cli::McpCmd::Get { name, json, root } => {
                 commands::mcp::get_cmd(root.as_deref(), &name, json)
             }
+            cli::McpCmd::Test { name, json, root } => {
+                commands::mcp::test_cmd(root.as_deref(), name.as_deref(), json).await
+            }
         },
     };
 

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -191,6 +191,40 @@ fn cli_parses_mcp_remove_list_get() {
 }
 
 #[test]
+fn cli_parses_mcp_test() {
+    // Bare sweep: no name, no flags.
+    let bare = Cli::try_parse_from(["trusty-mpm", "mcp", "test"]).unwrap();
+    let Some(Command::Mcp {
+        cmd: McpCmd::Test { name, json, root },
+    }) = bare.command
+    else {
+        panic!("expected mcp test");
+    };
+    assert!(name.is_none() && !json && root.is_none());
+
+    // Named + --json + --root.
+    let named = Cli::try_parse_from([
+        "trusty-mpm",
+        "mcp",
+        "test",
+        "trusty-memory",
+        "--json",
+        "--root",
+        "/x",
+    ])
+    .unwrap();
+    let Some(Command::Mcp {
+        cmd: McpCmd::Test { name, json, root },
+    }) = named.command
+    else {
+        panic!("expected mcp test named");
+    };
+    assert_eq!(name.as_deref(), Some("trusty-memory"));
+    assert!(json);
+    assert_eq!(root.as_deref(), Some("/x"));
+}
+
+#[test]
 fn cli_parses_start() {
     let cli = Cli::try_parse_from(["trusty-mpm", "start"]).unwrap();
     assert!(matches!(cli.command.unwrap(), Command::Start));

--- a/crates/trusty-mpm/src/core/mcp_config.rs
+++ b/crates/trusty-mpm/src/core/mcp_config.rs
@@ -47,6 +47,32 @@ const CLAUDE_JSON: &str = ".claude.json";
 pub const BUILTIN_MANAGED_MCP_SERVERS: &[&str] =
     &["trusty-memory", "trusty-review", "trusty-search"];
 
+/// The stdio launch entry tm provisions for a built-in framework MCP server.
+///
+/// Why: two call sites need the exact launch definition of the three framework
+/// servers — `standalone::global_config::ensure_mcp_config` (which writes them
+/// into the managed `.mcp.json`) and `core::mcp_test` (which spawns them to run
+/// a real handshake for `tm mcp test`). Keeping the catalog here, next to
+/// [`BUILTIN_MANAGED_MCP_SERVERS`], means the launch command can never drift
+/// between "what a managed session runs" and "what `tm mcp test` probes".
+/// What: returns the canonical `{"type":"stdio","command":<bin>,"args":[…]}`
+/// entry for `trusty-memory` (`serve --stdio`), `trusty-review` (`serve
+/// --stdio`), and `trusty-search` (`serve`); `None` for any other name. The
+/// entries carry no `env` — the managed session and the probe both inherit the
+/// ambient environment (matching the memory/search/review pattern).
+/// Test: `builtin_server_entry_matches_known_servers`; the parity with
+/// `ensure_mcp_config` is enforced by `global_config`'s existing tests.
+pub fn builtin_server_entry(name: &str) -> Option<Value> {
+    let (command, args): (&str, &[&str]) = match name {
+        "trusty-memory" => ("trusty-memory", &["serve", "--stdio"]),
+        "trusty-review" => ("trusty-review", &["serve", "--stdio"]),
+        "trusty-search" => ("trusty-search", &["serve"]),
+        _ => return None,
+    };
+    let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    Some(build_stdio_entry(command, &args, &Map::new()))
+}
+
 /// Transport kind for a user-scope MCP server entry.
 ///
 /// Why: the `add` handler validates transport-specific inputs (`-e` env is
@@ -449,6 +475,28 @@ mod tests {
         let v: Value =
             serde_json::from_str(&std::fs::read_to_string(cfg.join(CLAUDE_JSON)).unwrap()).unwrap();
         assert!(v["mcpServers"]["echo"].is_object());
+    }
+
+    #[test]
+    fn builtin_server_entry_matches_known_servers() {
+        // Every name in the builtin list resolves to a stdio launch entry.
+        for name in BUILTIN_MANAGED_MCP_SERVERS {
+            let e = builtin_server_entry(name).expect("builtin resolves");
+            assert_eq!(e["type"], "stdio");
+            assert_eq!(e["command"], *name, "command matches the binary name");
+            assert!(e["args"].is_array(), "args always present");
+        }
+        // The exact launch args must stay pinned (parity with ensure_mcp_config).
+        assert_eq!(
+            builtin_server_entry("trusty-memory").unwrap()["args"],
+            serde_json::json!(["serve", "--stdio"])
+        );
+        assert_eq!(
+            builtin_server_entry("trusty-search").unwrap()["args"],
+            serde_json::json!(["serve"])
+        );
+        // Unknown names yield None.
+        assert!(builtin_server_entry("not-a-builtin").is_none());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/mcp_test/mod.rs
+++ b/crates/trusty-mpm/src/core/mcp_test/mod.rs
@@ -17,7 +17,11 @@
 //! [`trusty_common::mcp::run_stdio_loop`], the loop each `serve --stdio` server
 //! runs, which reads with `BufReader::lines()` and writes `to_string(resp) +
 //! "\n"`. The `initialize` payload uses `protocolVersion` `"2024-11-05"`,
-//! matching [`trusty_common::mcp::initialize_response`].
+//! matching [`trusty_common::mcp::initialize_response`]. Unlike
+//! `run_stdio_loop`'s plain `BufReader::lines()`, the probe's line reader is
+//! byte-capped (see [`MAX_LINE_BYTES`]) — a misbehaving server that writes
+//! non-newline-terminated noise to stdout cannot grow the read buffer
+//! unbounded within the timeout window.
 //!
 //! Transport scope: `http`/`sse` servers get an HTTP *reachability* check (any
 //! HTTP response — even a 4xx — means the endpoint answered, so it passes); a
@@ -48,6 +52,20 @@ mod tests;
 /// on).
 /// Test: value asserted by `default_timeout_is_bounded`.
 pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Maximum bytes buffered while scanning for one stdio line terminator.
+///
+/// Why: `tokio::io::AsyncBufReadExt::lines()`/`read_until` has no built-in cap —
+/// a server that writes to stdout without a newline (stray `println!` debug
+/// output, a crash dump, …) would otherwise grow the line buffer for the entire
+/// [`DEFAULT_PROBE_TIMEOUT`] window. Capping the scan (via `AsyncReadExt::take`,
+/// see [`read_bounded_line`]) turns that into a bounded, reported
+/// `McpTestOutcome::Protocol("line too long")` instead of unbounded memory
+/// growth.
+/// What: 1 MiB — generous for any legitimate JSON-RPC response, tight enough to
+/// bound worst-case memory.
+/// Test: `read_bounded_line_rejects_oversized_line`.
+pub const MAX_LINE_BYTES: usize = 1024 * 1024;
 
 /// The transport a server entry uses, as understood by the probe.
 ///
@@ -433,17 +451,20 @@ async fn probe_stdio(entry: &Value, timeout: Duration) -> McpTestOutcome {
 /// Drive `initialize` → `initialized` → `tools/list` over the child's stdio.
 ///
 /// Framing: newline-delimited JSON-RPC 2.0 (one compact object per line, `\n`
-/// terminated), matching `trusty_common::mcp::run_stdio_loop`. Returns the tool
+/// terminated), matching `trusty_common::mcp::run_stdio_loop`, with each line
+/// capped at [`MAX_LINE_BYTES`] (see [`read_bounded_line`]). Returns the tool
 /// count on success or an [`McpTestOutcome`] failure. The child is spawned with
-/// `kill_on_drop`, and explicitly killed on the success path, so no orphan
-/// process survives the probe.
+/// `kill_on_drop(true)`, so `child`'s `Drop` (run when this function returns,
+/// on every path — success, error, or the caller's `tokio::time::timeout`
+/// cancelling us mid-await) is what reaps the subprocess; no explicit kill is
+/// needed here.
 async fn stdio_handshake(
     command: &str,
     args: &[String],
     env: &[(String, String)],
 ) -> Result<usize, McpTestOutcome> {
     use std::process::Stdio;
-    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::io::BufReader;
     use tokio::process::Command;
 
     let mut cmd = Command::new(command);
@@ -467,7 +488,7 @@ async fn stdio_handshake(
         .stdout
         .take()
         .ok_or_else(|| McpTestOutcome::Protocol("child stdout unavailable".to_string()))?;
-    let mut reader = BufReader::new(stdout).lines();
+    let mut reader = BufReader::new(stdout);
 
     // initialize → await response → validate.
     write_message(&mut stdin, &initialize_request(1)).await?;
@@ -482,8 +503,8 @@ async fn stdio_handshake(
     let list_resp = read_response(&mut reader, 2).await?;
     let count = parse_tool_count(&list_resp).map_err(McpTestOutcome::Protocol)?;
 
-    // Best-effort clean shutdown (kill_on_drop is the backstop).
-    let _ = child.start_kill();
+    // `child` drops here; `kill_on_drop(true)` (set above) reaps the
+    // subprocess so no orphan survives a successful probe.
     Ok(count)
 }
 
@@ -510,17 +531,15 @@ where
 ///
 /// Skips blank lines and any message whose `id` does not match (server-emitted
 /// notifications or unrelated responses). A non-JSON line is a protocol error; a
-/// closed stream before the wanted id is a protocol error.
-async fn read_response<R>(
-    reader: &mut tokio::io::Lines<R>,
-    want_id: i64,
-) -> Result<Value, McpTestOutcome>
+/// closed stream before the wanted id is a protocol error; a line exceeding
+/// [`MAX_LINE_BYTES`] is a protocol error (see [`read_bounded_line`]).
+async fn read_response<R>(reader: &mut R, want_id: i64) -> Result<Value, McpTestOutcome>
 where
     R: tokio::io::AsyncBufRead + Unpin,
 {
     loop {
-        match reader.next_line().await {
-            Ok(Some(line)) => {
+        match read_bounded_line(reader, MAX_LINE_BYTES).await? {
+            Some(line) => {
                 let trimmed = line.trim();
                 if trimmed.is_empty() {
                     continue;
@@ -533,14 +552,68 @@ where
                     _ => continue, // notification or unrelated response — keep reading
                 }
             }
-            Ok(None) => {
+            None => {
                 return Err(McpTestOutcome::Protocol(
                     "server closed stdout before responding".to_string(),
                 ));
             }
-            Err(e) => return Err(McpTestOutcome::Protocol(format!("read from server: {e}"))),
         }
     }
+}
+
+/// Read one `\n`-terminated line, capping the scan at `max_bytes`.
+///
+/// Why: plain `AsyncBufReadExt::read_until`/`lines()` buffers without limit
+/// while scanning for the delimiter — a server that emits non-newline-
+/// terminated stdout noise would grow that buffer for the whole probe timeout.
+/// Wrapping the reader in [`tokio::io::AsyncReadExt::take`] per call bounds a
+/// single `read_until` to at most `max_bytes`, so a missing terminator within
+/// that budget fails fast instead of growing unbounded.
+/// What: returns `Ok(None)` at true EOF with no bytes read; `Ok(Some(line))`
+/// with the `\n` (and a trailing `\r`, if present) stripped, on either finding
+/// the delimiter or hitting EOF with a non-empty trailing partial line (mirrors
+/// `tokio::io::Lines`' EOF behaviour); `Err(Protocol("line too long"))` when
+/// `max_bytes` is exhausted without finding `\n`.
+/// Test: `read_bounded_line_reads_terminated_line`,
+/// `read_bounded_line_rejects_oversized_line`,
+/// `read_bounded_line_returns_none_at_eof`.
+async fn read_bounded_line<R>(
+    reader: &mut R,
+    max_bytes: usize,
+) -> Result<Option<String>, McpTestOutcome>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+
+    let mut buf: Vec<u8> = Vec::new();
+    let n = {
+        let mut limited = reader.take(max_bytes as u64);
+        limited
+            .read_until(b'\n', &mut buf)
+            .await
+            .map_err(|e| McpTestOutcome::Protocol(format!("read from server: {e}")))?
+    };
+
+    if n == 0 {
+        return Ok(None); // true EOF, nothing buffered
+    }
+    if buf.last() == Some(&b'\n') {
+        buf.pop();
+        if buf.last() == Some(&b'\r') {
+            buf.pop();
+        }
+        return Ok(Some(String::from_utf8_lossy(&buf).into_owned()));
+    }
+    if n >= max_bytes {
+        // Filled the cap without ever finding a terminator — bail rather than
+        // keep scanning an unbounded amount of server output.
+        return Err(McpTestOutcome::Protocol("line too long".to_string()));
+    }
+    // Read fewer bytes than the cap with no terminator: the stream reached
+    // real EOF mid-line. Return the trailing partial line, matching
+    // `tokio::io::Lines`' behaviour for an unterminated final line.
+    Ok(Some(String::from_utf8_lossy(&buf).into_owned()))
 }
 
 /// Reachability-check an http/sse endpoint, timeout-bounded.

--- a/crates/trusty-mpm/src/core/mcp_test/mod.rs
+++ b/crates/trusty-mpm/src/core/mcp_test/mod.rs
@@ -1,0 +1,574 @@
+//! Verify user-scope MCP servers with a real MCP stdio handshake.
+//!
+//! Why: `tm mcp add|list|get` register and inspect servers, but registration
+//! only proves the *config* is well-formed — not that the server actually
+//! starts and speaks MCP. Operators (and CI) need a single command that spawns
+//! each configured server, drives the real `initialize` → `initialized` →
+//! `tools/list` exchange, and reports pass/fail. `tm mcp test` is that command;
+//! this module is its testable core.
+//!
+//! What: splits cleanly into a **pure** layer (result types, transport
+//! classification, target selection, JSON-RPC message build/parse, exit-code
+//! aggregation — all unit-testable with no live server) and an **I/O** layer
+//! (`probe_*`, which spawn a subprocess or open an HTTP connection). The stdio
+//! probe matches the framing every trusty-* MCP server uses:
+//! newline-delimited JSON-RPC 2.0 (one compact JSON object per line, `\n`
+//! terminated), NOT LSP `Content-Length` — confirmed against
+//! [`trusty_common::mcp::run_stdio_loop`], the loop each `serve --stdio` server
+//! runs, which reads with `BufReader::lines()` and writes `to_string(resp) +
+//! "\n"`. The `initialize` payload uses `protocolVersion` `"2024-11-05"`,
+//! matching [`trusty_common::mcp::initialize_response`].
+//!
+//! Transport scope: `http`/`sse` servers get an HTTP *reachability* check (any
+//! HTTP response — even a 4xx — means the endpoint answered, so it passes); a
+//! full SSE/streamable-HTTP MCP handshake is intentionally out of scope. stdio
+//! servers get the full handshake and a real tool count.
+//!
+//! Test: `tests` submodule covers selection, classification, message
+//! (de)serialization against fixtures, and aggregation. The subprocess spawn is
+//! integration-level and is not unit-tested here (the message layer it drives
+//! is fixture-tested instead).
+
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+use crate::core::mcp_config::{builtin_server_entry, managed_mcp_server_names};
+
+#[cfg(test)]
+mod tests;
+
+/// Per-server handshake budget.
+///
+/// Why: one hung or slow server must not stall the whole sweep; a few seconds is
+/// ample for a local subprocess to answer `initialize` + `tools/list` yet short
+/// enough to keep `tm mcp test` snappy.
+/// What: 5 seconds, applied per server (the sweep tests servers sequentially, so
+/// each is independently bounded — a hung server times out and the sweep moves
+/// on).
+/// Test: value asserted by `default_timeout_is_bounded`.
+pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The transport a server entry uses, as understood by the probe.
+///
+/// Why: the probe dispatches to a subprocess handshake (stdio) or an HTTP
+/// reachability check (http/sse); a typed classification keeps that dispatch
+/// total and drives the display column.
+/// What: `Stdio`, `Http`, or `Sse`, derived from an entry's `type` field (or
+/// inferred from the presence of `url`). Derived from
+/// [`crate::core::mcp_config::McpTransport`]'s wire discriminants.
+/// Test: `classify_transport_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestTransport {
+    /// Local subprocess speaking MCP over stdio.
+    Stdio,
+    /// Remote streamable-HTTP endpoint.
+    Http,
+    /// Remote SSE endpoint.
+    Sse,
+}
+
+impl TestTransport {
+    /// The lowercase wire discriminant for display / JSON output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TestTransport::Stdio => "stdio",
+            TestTransport::Http => "http",
+            TestTransport::Sse => "sse",
+        }
+    }
+}
+
+/// Outcome of testing a single server.
+///
+/// Why: the CLI needs to distinguish a pass (and how many tools) from each
+/// distinct failure mode so the table and `--json` output are actionable and
+/// the exit code can aggregate failures.
+/// What: `Ok` carries the stdio tool count (`Some`) or marks an http/sse
+/// endpoint reachable (`None`). Every other variant is a failure with a
+/// human-readable detail where relevant.
+/// Test: `passed_only_true_for_ok`, `render_labels_*`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpTestOutcome {
+    /// Handshake succeeded (`tools = Some(n)` for stdio) or endpoint reachable
+    /// (`tools = None` for http/sse).
+    Ok {
+        /// Tool count from `tools/list` (stdio); `None` for an http/sse
+        /// reachability pass.
+        tools: Option<usize>,
+    },
+    /// Entry present but structurally invalid (missing `command` or `url`).
+    Malformed(String),
+    /// The stdio subprocess could not be spawned (binary missing, no exec bit …).
+    Spawn(String),
+    /// The handshake exceeded [`DEFAULT_PROBE_TIMEOUT`].
+    Timeout,
+    /// A protocol-level failure: non-JSON line, missing fields, a server error
+    /// response, or the server closing stdout before replying.
+    Protocol(String),
+    /// An http/sse endpoint could not be reached (connection refused, timeout …).
+    Unreachable(String),
+}
+
+/// A server chosen for testing: its name, raw config entry, and transport.
+///
+/// Why: selection (which servers to test) is decided up front and separately
+/// from probing so the selection logic is pure and unit-testable.
+/// What: pairs the resolved `entry` with its classified `transport`.
+/// Test: built by [`select_targets`]; see `select_*` tests.
+#[derive(Debug, Clone)]
+pub struct TestTarget {
+    /// The `mcpServers` key.
+    pub name: String,
+    /// The raw entry JSON (stdio command/args/env or http/sse url/headers).
+    pub entry: Value,
+    /// The classified transport.
+    pub transport: TestTransport,
+}
+
+/// The full result of testing one server.
+#[derive(Debug, Clone)]
+pub struct McpTestResult {
+    /// The server name.
+    pub name: String,
+    /// The transport that was probed.
+    pub transport: TestTransport,
+    /// The outcome.
+    pub outcome: McpTestOutcome,
+}
+
+impl McpTestResult {
+    /// Whether this server passed (the only success variant is `Ok`).
+    ///
+    /// Test: `passed_only_true_for_ok`.
+    pub fn passed(&self) -> bool {
+        matches!(self.outcome, McpTestOutcome::Ok { .. })
+    }
+
+    /// A `(result_label, detail)` pair for the human table.
+    ///
+    /// Why: the table's RESULT and DETAIL columns share one source of truth so a
+    /// new outcome variant can't render inconsistently between them.
+    /// What: `("PASS", "12 tools" | "reachable")` on success; `("FAIL", <cause>)`
+    /// otherwise.
+    /// Test: `render_labels_pass_and_fail`.
+    pub fn render(&self) -> (&'static str, String) {
+        match &self.outcome {
+            McpTestOutcome::Ok { tools: Some(n) } => ("PASS", format!("{n} tools")),
+            McpTestOutcome::Ok { tools: None } => ("PASS", "reachable".to_string()),
+            McpTestOutcome::Malformed(m) => ("FAIL", format!("malformed: {m}")),
+            McpTestOutcome::Spawn(m) => ("FAIL", format!("spawn error: {m}")),
+            McpTestOutcome::Timeout => ("FAIL", "timeout".to_string()),
+            McpTestOutcome::Protocol(m) => ("FAIL", format!("protocol error: {m}")),
+            McpTestOutcome::Unreachable(m) => ("FAIL", format!("unreachable: {m}")),
+        }
+    }
+
+    /// A stable machine-readable JSON object for `--json` output.
+    ///
+    /// Why: scripts and CI consume `--json`; explicit field names decouple the
+    /// wire shape from the internal enum layout.
+    /// What: `{name, transport, result, tools, error, passed}` where `result` is
+    /// a short kind string, `tools` is the count (or `null`), and `error` is the
+    /// failure detail (or `null`).
+    /// Test: `to_json_shapes_ok_and_failure`.
+    pub fn to_json(&self) -> Value {
+        let (result, error, tools): (&str, Option<String>, Option<usize>) = match &self.outcome {
+            McpTestOutcome::Ok { tools } => ("ok", None, *tools),
+            McpTestOutcome::Malformed(m) => ("malformed", Some(m.clone()), None),
+            McpTestOutcome::Spawn(m) => ("spawn_error", Some(m.clone()), None),
+            McpTestOutcome::Timeout => ("timeout", None, None),
+            McpTestOutcome::Protocol(m) => ("protocol_error", Some(m.clone()), None),
+            McpTestOutcome::Unreachable(m) => ("unreachable", Some(m.clone()), None),
+        };
+        json!({
+            "name": self.name,
+            "transport": self.transport.as_str(),
+            "result": result,
+            "tools": tools,
+            "error": error,
+            "passed": self.passed(),
+        })
+    }
+}
+
+/// Whether any server in a result set failed (drives the process exit code).
+///
+/// Test: `any_failed_flags_a_single_failure`.
+pub fn any_failed(results: &[McpTestResult]) -> bool {
+    results.iter().any(|r| !r.passed())
+}
+
+/// Classify a server entry's transport.
+///
+/// Why: the probe must route each entry to the right handshake; the default
+/// (no explicit `type`) mirrors `commands::mcp::entry_type` — an entry with a
+/// `url` is remote, otherwise stdio.
+/// What: `type: "http"|"sse"|"stdio"` maps directly; a missing/unknown `type`
+/// infers `Http` when a `url` key is present, else `Stdio`.
+/// Test: `classify_transport_explicit`, `classify_transport_inferred`.
+pub fn classify_transport(entry: &Value) -> TestTransport {
+    match entry.get("type").and_then(Value::as_str) {
+        Some("http") => TestTransport::Http,
+        Some("sse") => TestTransport::Sse,
+        Some("stdio") => TestTransport::Stdio,
+        _ if entry.get("url").is_some() => TestTransport::Http,
+        _ => TestTransport::Stdio,
+    }
+}
+
+/// Select which servers to test.
+///
+/// Why: `tm mcp test` (bare) must sweep every user-scope server unioned with the
+/// three framework built-ins (deduped), while `tm mcp test <name>` targets one
+/// server and errors if it is unknown. Deciding this from the parsed config —
+/// with no I/O — keeps it unit-testable.
+/// What: with `name = None`, unions `servers`' keys with
+/// [`crate::core::mcp_config::BUILTIN_MANAGED_MCP_SERVERS`] via the shared
+/// [`managed_mcp_server_names`] (sorted + deduped) and resolves each name's
+/// entry from `servers`, falling back to [`builtin_server_entry`] for a built-in
+/// not present in the user config. With `name = Some(n)`, returns just that
+/// server (config entry, else built-in fallback), erroring if neither exists.
+/// Test: `select_bare_unions_builtins`, `select_named_uses_config`,
+/// `select_named_falls_back_to_builtin`, `select_named_unknown_errors`.
+pub fn select_targets(
+    servers: &serde_json::Map<String, Value>,
+    name: Option<&str>,
+) -> anyhow::Result<Vec<TestTarget>> {
+    match name {
+        Some(n) => {
+            let entry = servers
+                .get(n)
+                .cloned()
+                .or_else(|| builtin_server_entry(n))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "MCP server '{n}' not found among configured servers or framework built-ins"
+                    )
+                })?;
+            Ok(vec![make_target(n.to_string(), entry)])
+        }
+        None => {
+            // Reuse the exact union semantics `managed_mcp_server_names` applies
+            // when seeding trust, so the sweep and the trust list never diverge.
+            let config = json!({ "mcpServers": Value::Object(servers.clone()) });
+            let names = managed_mcp_server_names(&config);
+            let targets = names
+                .into_iter()
+                .map(|n| {
+                    let entry = servers
+                        .get(&n)
+                        .cloned()
+                        .or_else(|| builtin_server_entry(&n))
+                        .unwrap_or(Value::Null);
+                    make_target(n, entry)
+                })
+                .collect();
+            Ok(targets)
+        }
+    }
+}
+
+/// Build a [`TestTarget`], classifying the transport from the entry.
+fn make_target(name: String, entry: Value) -> TestTarget {
+    let transport = classify_transport(&entry);
+    TestTarget {
+        name,
+        entry,
+        transport,
+    }
+}
+
+// ─── JSON-RPC message layer (pure) ─────────────────────────────────────────
+
+/// Build the MCP `initialize` request.
+///
+/// What: `{jsonrpc, id, method:"initialize", params:{protocolVersion,
+/// capabilities, clientInfo}}` with `protocolVersion` `"2024-11-05"` — the
+/// version [`trusty_common::mcp::initialize_response`] advertises.
+/// Test: `initialize_request_has_protocol_version`.
+pub fn initialize_request(id: i64) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "tm-mcp-test", "version": env!("CARGO_PKG_VERSION") }
+        }
+    })
+}
+
+/// Build the `notifications/initialized` notification (id-less).
+///
+/// Test: `initialized_notification_is_idless`.
+pub fn initialized_notification() -> Value {
+    json!({ "jsonrpc": "2.0", "method": "notifications/initialized" })
+}
+
+/// Build the `tools/list` request.
+///
+/// Test: `tools_list_request_has_method`.
+pub fn tools_list_request(id: i64) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "method": "tools/list", "params": {} })
+}
+
+/// Validate an `initialize` response envelope.
+///
+/// Why: a server that returns an error, or omits `result.protocolVersion`, has
+/// not completed the handshake — that must surface as a protocol failure.
+/// What: `Err` if the envelope carries a JSON-RPC `error` or lacks
+/// `result.protocolVersion`; `Ok(())` otherwise.
+/// Test: `validate_initialize_accepts_valid`, `validate_initialize_rejects_*`.
+pub fn validate_initialize(resp: &Value) -> Result<(), String> {
+    if let Some(err) = resp.get("error") {
+        return Err(rpc_error_message(err));
+    }
+    resp.get("result")
+        .and_then(|r| r.get("protocolVersion"))
+        .ok_or_else(|| "initialize response missing result.protocolVersion".to_string())?;
+    Ok(())
+}
+
+/// Extract the tool count from a `tools/list` response envelope.
+///
+/// What: `Err` if the envelope carries a JSON-RPC `error` or lacks a
+/// `result.tools` array; otherwise `Ok(len)`.
+/// Test: `parse_tool_count_counts_array`, `parse_tool_count_rejects_*`.
+pub fn parse_tool_count(resp: &Value) -> Result<usize, String> {
+    if let Some(err) = resp.get("error") {
+        return Err(rpc_error_message(err));
+    }
+    let tools = resp
+        .get("result")
+        .and_then(|r| r.get("tools"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| "tools/list response missing result.tools array".to_string())?;
+    Ok(tools.len())
+}
+
+/// Render a JSON-RPC `error` object into a one-line message.
+fn rpc_error_message(err: &Value) -> String {
+    let code = err.get("code").and_then(Value::as_i64).unwrap_or(0);
+    let msg = err
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown error");
+    format!("server error {code}: {msg}")
+}
+
+/// Pull the stdio `args` out of an entry as owned strings.
+fn entry_args(entry: &Value) -> Vec<String> {
+    entry
+        .get("args")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Pull the stdio `env` out of an entry as `(key, value)` pairs.
+fn entry_env(entry: &Value) -> Vec<(String, String)> {
+    entry
+        .get("env")
+        .and_then(Value::as_object)
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| v.as_str().map(|vs| (k.clone(), vs.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// ─── probe layer (I/O) ─────────────────────────────────────────────────────
+
+/// Test every selected server sequentially, each bounded by `timeout`.
+///
+/// Why: sequential probing keeps output ordering deterministic and needs no
+/// extra concurrency deps; because each server is independently timeout-bounded,
+/// a single hung server delays but never blocks the sweep.
+/// What: runs [`probe_target`] for each target and collects a [`McpTestResult`].
+/// Test: covered end-to-end by `tm mcp test` (integration); pure inputs are
+/// unit-tested via the message/selection layers.
+pub async fn run_all(targets: Vec<TestTarget>, timeout: Duration) -> Vec<McpTestResult> {
+    let mut results = Vec::with_capacity(targets.len());
+    for target in targets {
+        let outcome = probe_target(&target, timeout).await;
+        results.push(McpTestResult {
+            name: target.name,
+            transport: target.transport,
+            outcome,
+        });
+    }
+    results
+}
+
+/// Probe one target, dispatching on its transport.
+pub async fn probe_target(target: &TestTarget, timeout: Duration) -> McpTestOutcome {
+    match target.transport {
+        TestTransport::Stdio => probe_stdio(&target.entry, timeout).await,
+        TestTransport::Http | TestTransport::Sse => probe_http(&target.entry, timeout).await,
+    }
+}
+
+/// Spawn a stdio server and run the full MCP handshake, timeout-bounded.
+async fn probe_stdio(entry: &Value, timeout: Duration) -> McpTestOutcome {
+    let Some(command) = entry.get("command").and_then(Value::as_str) else {
+        return McpTestOutcome::Malformed("stdio entry missing 'command'".to_string());
+    };
+    let args = entry_args(entry);
+    let env = entry_env(entry);
+    match tokio::time::timeout(timeout, stdio_handshake(command, &args, &env)).await {
+        Ok(Ok(count)) => McpTestOutcome::Ok { tools: Some(count) },
+        Ok(Err(outcome)) => outcome,
+        Err(_) => McpTestOutcome::Timeout,
+    }
+}
+
+/// Drive `initialize` → `initialized` → `tools/list` over the child's stdio.
+///
+/// Framing: newline-delimited JSON-RPC 2.0 (one compact object per line, `\n`
+/// terminated), matching `trusty_common::mcp::run_stdio_loop`. Returns the tool
+/// count on success or an [`McpTestOutcome`] failure. The child is spawned with
+/// `kill_on_drop`, and explicitly killed on the success path, so no orphan
+/// process survives the probe.
+async fn stdio_handshake(
+    command: &str,
+    args: &[String],
+    env: &[(String, String)],
+) -> Result<usize, McpTestOutcome> {
+    use std::process::Stdio;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::process::Command;
+
+    let mut cmd = Command::new(command);
+    cmd.args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| McpTestOutcome::Spawn(format!("{command}: {e}")))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| McpTestOutcome::Protocol("child stdin unavailable".to_string()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| McpTestOutcome::Protocol("child stdout unavailable".to_string()))?;
+    let mut reader = BufReader::new(stdout).lines();
+
+    // initialize → await response → validate.
+    write_message(&mut stdin, &initialize_request(1)).await?;
+    let init_resp = read_response(&mut reader, 1).await?;
+    validate_initialize(&init_resp).map_err(McpTestOutcome::Protocol)?;
+
+    // Per MCP: acknowledge with the `initialized` notification before tool use.
+    write_message(&mut stdin, &initialized_notification()).await?;
+
+    // tools/list → await response → count.
+    write_message(&mut stdin, &tools_list_request(2)).await?;
+    let list_resp = read_response(&mut reader, 2).await?;
+    let count = parse_tool_count(&list_resp).map_err(McpTestOutcome::Protocol)?;
+
+    // Best-effort clean shutdown (kill_on_drop is the backstop).
+    let _ = child.start_kill();
+    Ok(count)
+}
+
+/// Serialize `msg` as one JSON line and write it (flushed) to the child stdin.
+async fn write_message<W>(writer: &mut W, msg: &Value) -> Result<(), McpTestOutcome>
+where
+    W: tokio::io::AsyncWriteExt + Unpin,
+{
+    let mut line = serde_json::to_string(msg)
+        .map_err(|e| McpTestOutcome::Protocol(format!("serialise request: {e}")))?;
+    line.push('\n');
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|e| McpTestOutcome::Protocol(format!("write to server: {e}")))?;
+    writer
+        .flush()
+        .await
+        .map_err(|e| McpTestOutcome::Protocol(format!("flush to server: {e}")))?;
+    Ok(())
+}
+
+/// Read lines until one is a JSON-RPC response with `id == want_id`.
+///
+/// Skips blank lines and any message whose `id` does not match (server-emitted
+/// notifications or unrelated responses). A non-JSON line is a protocol error; a
+/// closed stream before the wanted id is a protocol error.
+async fn read_response<R>(
+    reader: &mut tokio::io::Lines<R>,
+    want_id: i64,
+) -> Result<Value, McpTestOutcome>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    loop {
+        match reader.next_line().await {
+            Ok(Some(line)) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let value: Value = serde_json::from_str(trimmed).map_err(|e| {
+                    McpTestOutcome::Protocol(format!("non-JSON line from server: {e}"))
+                })?;
+                match value.get("id").and_then(Value::as_i64) {
+                    Some(id) if id == want_id => return Ok(value),
+                    _ => continue, // notification or unrelated response — keep reading
+                }
+            }
+            Ok(None) => {
+                return Err(McpTestOutcome::Protocol(
+                    "server closed stdout before responding".to_string(),
+                ));
+            }
+            Err(e) => return Err(McpTestOutcome::Protocol(format!("read from server: {e}"))),
+        }
+    }
+}
+
+/// Reachability-check an http/sse endpoint, timeout-bounded.
+///
+/// Why: a full SSE/streamable-HTTP MCP handshake is out of scope (see the module
+/// docs); confirming the configured URL answers at all is a useful, cheap signal
+/// that mirrors `tm services`' `/health` probing.
+/// What: issues a `GET` (applying any configured headers) and treats ANY HTTP
+/// response — including 4xx/5xx — as reachable (the endpoint answered).
+/// Connection/timeout errors are [`McpTestOutcome::Unreachable`].
+async fn probe_http(entry: &Value, timeout: Duration) -> McpTestOutcome {
+    let Some(url) = entry.get("url").and_then(Value::as_str) else {
+        return McpTestOutcome::Malformed("http/sse entry missing 'url'".to_string());
+    };
+    let client = match reqwest::Client::builder().timeout(timeout).build() {
+        Ok(c) => c,
+        Err(e) => return McpTestOutcome::Unreachable(format!("HTTP client build failed: {e}")),
+    };
+    let mut req = client.get(url);
+    if let Some(headers) = entry.get("headers").and_then(Value::as_object) {
+        for (k, v) in headers {
+            if let Some(vs) = v.as_str() {
+                req = req.header(k, vs);
+            }
+        }
+    }
+    match req.send().await {
+        Ok(_resp) => McpTestOutcome::Ok { tools: None },
+        Err(e) => McpTestOutcome::Unreachable(format!("{e}")),
+    }
+}

--- a/crates/trusty-mpm/src/core/mcp_test/tests.rs
+++ b/crates/trusty-mpm/src/core/mcp_test/tests.rs
@@ -216,6 +216,91 @@ fn parse_tool_count_rejects_error_and_missing() {
     assert!(parse_tool_count(&missing).is_err());
 }
 
+// ─── bounded line reader ──────────────────────────────────────────────────────
+
+#[test]
+fn max_line_bytes_is_one_mebibyte() {
+    assert_eq!(MAX_LINE_BYTES, 1024 * 1024);
+}
+
+#[tokio::test]
+async fn read_bounded_line_reads_terminated_lines() {
+    let data: &[u8] = b"{\"id\":1}\n{\"id\":2}\n";
+    let mut reader = tokio::io::BufReader::new(data);
+    assert_eq!(
+        read_bounded_line(&mut reader, MAX_LINE_BYTES)
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("{\"id\":1}")
+    );
+    assert_eq!(
+        read_bounded_line(&mut reader, MAX_LINE_BYTES)
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("{\"id\":2}")
+    );
+    // True EOF after the last terminated line.
+    assert!(
+        read_bounded_line(&mut reader, MAX_LINE_BYTES)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn read_bounded_line_strips_trailing_cr() {
+    let data: &[u8] = b"hello\r\n";
+    let mut reader = tokio::io::BufReader::new(data);
+    let line = read_bounded_line(&mut reader, MAX_LINE_BYTES)
+        .await
+        .unwrap();
+    assert_eq!(
+        line.as_deref(),
+        Some("hello"),
+        "CRLF terminator strips both bytes"
+    );
+}
+
+#[tokio::test]
+async fn read_bounded_line_returns_none_at_immediate_eof() {
+    let data: &[u8] = b"";
+    let mut reader = tokio::io::BufReader::new(data);
+    assert!(
+        read_bounded_line(&mut reader, MAX_LINE_BYTES)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn read_bounded_line_returns_trailing_partial_line_at_eof() {
+    // No trailing newline: real EOF mid-line still yields the buffered content,
+    // matching `tokio::io::Lines`' behaviour for an unterminated final line.
+    let data: &[u8] = b"no newline here";
+    let mut reader = tokio::io::BufReader::new(data);
+    let line = read_bounded_line(&mut reader, MAX_LINE_BYTES)
+        .await
+        .unwrap();
+    assert_eq!(line.as_deref(), Some("no newline here"));
+}
+
+#[tokio::test]
+async fn read_bounded_line_rejects_oversized_line() {
+    // 100 bytes with no terminator, capped at 16 -- must bail as "line too
+    // long" rather than buffer the rest looking for a `\n` that never comes.
+    let data: Vec<u8> = vec![b'a'; 100];
+    let mut reader = tokio::io::BufReader::new(&data[..]);
+    let err = read_bounded_line(&mut reader, 16).await.unwrap_err();
+    assert!(
+        matches!(&err, McpTestOutcome::Protocol(m) if m.contains("line too long")),
+        "expected a 'line too long' protocol error, got {err:?}"
+    );
+}
+
 // ─── result rendering + aggregation ──────────────────────────────────────────
 
 fn result(name: &str, transport: TestTransport, outcome: McpTestOutcome) -> McpTestResult {
@@ -357,5 +442,59 @@ async fn probe_stdio_missing_binary_reports_spawn_error() {
     assert!(
         matches!(outcome, McpTestOutcome::Spawn(_)),
         "expected a spawn error, got {outcome:?}"
+    );
+}
+
+/// A hung stdio server must time out promptly, and its process must not
+/// survive the probe.
+///
+/// Why: `probe_target` wraps the handshake in `tokio::time::timeout`; when the
+/// bound elapses first, the in-flight `stdio_handshake` future — and the
+/// `Child` it owns — is dropped. `kill_on_drop(true)` is what reaps the
+/// subprocess in that case; this test proves that actually happens, not merely
+/// that the API call returns `Timeout`. No external dependency (`sleep` is a
+/// POSIX coreutil), so this runs in CI, not gated behind `--ignored`.
+/// What: spawns `sleep <marker>` directly with no shell wrapper, so the tokio
+/// `Child`'s pid IS the `sleep` process's pid (nothing to fork/exec away).
+/// `<marker>` is a fractional-second duration derived from this test process's
+/// pid, unique enough that a stray unrelated `sleep` on the same host won't
+/// collide. Confirms `probe_target` returns `Timeout` in well under the 30s
+/// sleep duration, then polls `pgrep -f <marker>` (which self-excludes the
+/// pgrep invocation) until no matching process remains.
+#[cfg(unix)]
+#[tokio::test]
+async fn probe_stdio_timeout_kills_hung_child() {
+    let marker = format!("30.{:06}", std::process::id() % 1_000_000);
+    let entry = json!({ "type": "stdio", "command": "sleep", "args": [marker.clone()] });
+    let target = make_target("hang".to_string(), entry);
+
+    let start = std::time::Instant::now();
+    let outcome = probe_target(&target, Duration::from_millis(300)).await;
+    assert!(
+        matches!(outcome, McpTestOutcome::Timeout),
+        "expected Timeout for a hung server, got {outcome:?}"
+    );
+    assert!(
+        start.elapsed() < Duration::from_secs(2),
+        "must return promptly at the timeout bound, not wait out the 30s sleep"
+    );
+
+    // kill_on_drop reaps asynchronously; poll briefly rather than a single
+    // fixed sleep, to avoid flakiness on a loaded CI runner.
+    let mut still_running = true;
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        still_running = std::process::Command::new("pgrep")
+            .args(["-f", &marker])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !still_running {
+            break;
+        }
+    }
+    assert!(
+        !still_running,
+        "hung child (sleep {marker}) must not survive past the probe timeout"
     );
 }

--- a/crates/trusty-mpm/src/core/mcp_test/tests.rs
+++ b/crates/trusty-mpm/src/core/mcp_test/tests.rs
@@ -1,0 +1,361 @@
+//! Unit tests for the pure layer of `core::mcp_test`.
+//!
+//! Why: selection, transport classification, JSON-RPC message build/parse, and
+//! exit-code aggregation must all be verifiable with no live server. The
+//! subprocess handshake itself is integration-level and exercised end-to-end by
+//! `tm mcp test`; here we drive its message layer against captured fixtures.
+
+use super::*;
+use serde_json::json;
+
+// ─── timeout ────────────────────────────────────────────────────────────────
+
+#[test]
+fn default_timeout_is_bounded() {
+    assert_eq!(DEFAULT_PROBE_TIMEOUT, Duration::from_secs(5));
+}
+
+// ─── transport classification ────────────────────────────────────────────────
+
+#[test]
+fn classify_transport_explicit() {
+    assert_eq!(
+        classify_transport(&json!({"type":"stdio","command":"x","args":[]})),
+        TestTransport::Stdio
+    );
+    assert_eq!(
+        classify_transport(&json!({"type":"http","url":"https://x"})),
+        TestTransport::Http
+    );
+    assert_eq!(
+        classify_transport(&json!({"type":"sse","url":"https://x"})),
+        TestTransport::Sse
+    );
+}
+
+#[test]
+fn classify_transport_inferred() {
+    // No `type`: a url implies http, otherwise stdio (matches entry_type default).
+    assert_eq!(
+        classify_transport(&json!({"url":"https://x"})),
+        TestTransport::Http
+    );
+    assert_eq!(
+        classify_transport(&json!({"command":"x","args":[]})),
+        TestTransport::Stdio
+    );
+    // Unknown `type` with no url falls back to stdio.
+    assert_eq!(
+        classify_transport(&json!({"type":"weird"})),
+        TestTransport::Stdio
+    );
+}
+
+// ─── selection ───────────────────────────────────────────────────────────────
+
+fn map(v: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    v.as_object().cloned().unwrap()
+}
+
+#[test]
+fn select_bare_unions_builtins() {
+    // A single user server plus the three built-ins, deduped + sorted.
+    let servers = map(json!({
+        "aaa-custom": { "type": "stdio", "command": "x", "args": [] }
+    }));
+    let targets = select_targets(&servers, None).unwrap();
+    let names: Vec<&str> = targets.iter().map(|t| t.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "aaa-custom",
+            "trusty-memory",
+            "trusty-review",
+            "trusty-search"
+        ]
+    );
+    // A built-in absent from the user config resolves via builtin_server_entry.
+    let mem = targets.iter().find(|t| t.name == "trusty-memory").unwrap();
+    assert_eq!(mem.entry["command"], "trusty-memory");
+    assert_eq!(mem.transport, TestTransport::Stdio);
+    // The user server keeps its own entry.
+    let custom = targets.iter().find(|t| t.name == "aaa-custom").unwrap();
+    assert_eq!(custom.entry["command"], "x");
+}
+
+#[test]
+fn select_bare_dedups_builtin_configured_by_user() {
+    // trusty-search is both a built-in AND user-configured: appears once, with
+    // the user's entry winning.
+    let servers = map(json!({
+        "trusty-search": { "type": "stdio", "command": "custom-search", "args": [] }
+    }));
+    let targets = select_targets(&servers, None).unwrap();
+    let matches: Vec<_> = targets
+        .iter()
+        .filter(|t| t.name == "trusty-search")
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "no duplicate for a builtin+configured name"
+    );
+    assert_eq!(matches[0].entry["command"], "custom-search");
+}
+
+#[test]
+fn select_named_uses_config() {
+    let servers = map(json!({
+        "echo": { "type": "stdio", "command": "echo", "args": ["hi"] }
+    }));
+    let targets = select_targets(&servers, Some("echo")).unwrap();
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].name, "echo");
+    assert_eq!(targets[0].entry["command"], "echo");
+}
+
+#[test]
+fn select_named_falls_back_to_builtin() {
+    // Empty user config, but a built-in name resolves to its stdio launch entry.
+    let servers = map(json!({}));
+    let targets = select_targets(&servers, Some("trusty-review")).unwrap();
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].entry["command"], "trusty-review");
+    assert_eq!(targets[0].entry["args"], json!(["serve", "--stdio"]));
+}
+
+#[test]
+fn select_named_unknown_errors() {
+    let servers = map(json!({}));
+    let err = select_targets(&servers, Some("nope")).unwrap_err();
+    assert!(
+        err.to_string().contains("not found"),
+        "clear not-found error"
+    );
+}
+
+// ─── message builders ────────────────────────────────────────────────────────
+
+#[test]
+fn initialize_request_has_protocol_version() {
+    let req = initialize_request(1);
+    assert_eq!(req["jsonrpc"], "2.0");
+    assert_eq!(req["id"], 1);
+    assert_eq!(req["method"], "initialize");
+    assert_eq!(req["params"]["protocolVersion"], "2024-11-05");
+    assert_eq!(req["params"]["clientInfo"]["name"], "tm-mcp-test");
+}
+
+#[test]
+fn initialized_notification_is_idless() {
+    let n = initialized_notification();
+    assert_eq!(n["method"], "notifications/initialized");
+    assert!(n.get("id").is_none(), "a notification carries no id");
+}
+
+#[test]
+fn tools_list_request_has_method() {
+    let req = tools_list_request(2);
+    assert_eq!(req["id"], 2);
+    assert_eq!(req["method"], "tools/list");
+}
+
+// ─── response parsers (fixtures) ─────────────────────────────────────────────
+
+#[test]
+fn validate_initialize_accepts_valid() {
+    // Shape mirrors trusty_common::mcp::initialize_response.
+    let resp = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": { "tools": {} },
+            "serverInfo": { "name": "trusty-memory", "version": "0.1.0" }
+        }
+    });
+    assert!(validate_initialize(&resp).is_ok());
+}
+
+#[test]
+fn validate_initialize_rejects_error_envelope() {
+    let resp = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": { "code": -32601, "message": "Method not found" }
+    });
+    let err = validate_initialize(&resp).unwrap_err();
+    assert!(err.contains("-32601"));
+    assert!(err.contains("Method not found"));
+}
+
+#[test]
+fn validate_initialize_rejects_missing_protocol_version() {
+    let resp = json!({ "jsonrpc": "2.0", "id": 1, "result": { "capabilities": {} } });
+    assert!(validate_initialize(&resp).is_err());
+}
+
+#[test]
+fn parse_tool_count_counts_array() {
+    let resp = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": { "tools": [ {"name":"a"}, {"name":"b"}, {"name":"c"} ] }
+    });
+    assert_eq!(parse_tool_count(&resp).unwrap(), 3);
+    // Empty tool list is still a valid (zero-tool) success.
+    let empty = json!({ "jsonrpc":"2.0","id":2,"result":{ "tools": [] } });
+    assert_eq!(parse_tool_count(&empty).unwrap(), 0);
+}
+
+#[test]
+fn parse_tool_count_rejects_error_and_missing() {
+    let err = json!({ "jsonrpc":"2.0","id":2,"error":{"code":-32000,"message":"boom"} });
+    assert!(parse_tool_count(&err).is_err());
+    let missing = json!({ "jsonrpc":"2.0","id":2,"result":{} });
+    assert!(parse_tool_count(&missing).is_err());
+}
+
+// ─── result rendering + aggregation ──────────────────────────────────────────
+
+fn result(name: &str, transport: TestTransport, outcome: McpTestOutcome) -> McpTestResult {
+    McpTestResult {
+        name: name.to_string(),
+        transport,
+        outcome,
+    }
+}
+
+#[test]
+fn passed_only_true_for_ok() {
+    assert!(
+        result(
+            "a",
+            TestTransport::Stdio,
+            McpTestOutcome::Ok { tools: Some(3) }
+        )
+        .passed()
+    );
+    assert!(result("b", TestTransport::Http, McpTestOutcome::Ok { tools: None }).passed());
+    assert!(!result("c", TestTransport::Stdio, McpTestOutcome::Timeout).passed());
+    assert!(
+        !result(
+            "d",
+            TestTransport::Stdio,
+            McpTestOutcome::Spawn("nope".into())
+        )
+        .passed()
+    );
+}
+
+#[test]
+fn render_labels_pass_and_fail() {
+    let (label, detail) = result(
+        "a",
+        TestTransport::Stdio,
+        McpTestOutcome::Ok { tools: Some(12) },
+    )
+    .render();
+    assert_eq!(label, "PASS");
+    assert_eq!(detail, "12 tools");
+
+    let (label, detail) =
+        result("b", TestTransport::Http, McpTestOutcome::Ok { tools: None }).render();
+    assert_eq!(label, "PASS");
+    assert_eq!(detail, "reachable");
+
+    let (label, detail) = result("c", TestTransport::Stdio, McpTestOutcome::Timeout).render();
+    assert_eq!(label, "FAIL");
+    assert_eq!(detail, "timeout");
+}
+
+#[test]
+fn to_json_shapes_ok_and_failure() {
+    let ok = result(
+        "mem",
+        TestTransport::Stdio,
+        McpTestOutcome::Ok { tools: Some(7) },
+    )
+    .to_json();
+    assert_eq!(ok["name"], "mem");
+    assert_eq!(ok["transport"], "stdio");
+    assert_eq!(ok["result"], "ok");
+    assert_eq!(ok["tools"], 7);
+    assert_eq!(ok["error"], serde_json::Value::Null);
+    assert_eq!(ok["passed"], true);
+
+    let fail = result(
+        "sentry",
+        TestTransport::Http,
+        McpTestOutcome::Unreachable("connection refused".into()),
+    )
+    .to_json();
+    assert_eq!(fail["result"], "unreachable");
+    assert_eq!(fail["tools"], serde_json::Value::Null);
+    assert_eq!(fail["error"], "connection refused");
+    assert_eq!(fail["passed"], false);
+}
+
+#[test]
+fn any_failed_flags_a_single_failure() {
+    let all_ok = vec![
+        result(
+            "a",
+            TestTransport::Stdio,
+            McpTestOutcome::Ok { tools: Some(1) },
+        ),
+        result("b", TestTransport::Http, McpTestOutcome::Ok { tools: None }),
+    ];
+    assert!(!any_failed(&all_ok));
+
+    let with_fail = vec![
+        result(
+            "a",
+            TestTransport::Stdio,
+            McpTestOutcome::Ok { tools: Some(1) },
+        ),
+        result("b", TestTransport::Stdio, McpTestOutcome::Timeout),
+    ];
+    assert!(any_failed(&with_fail));
+}
+
+// ─── integration: real stdio handshake against a live server ─────────────────
+
+/// Full spawn + handshake against a real MCP stdio server.
+///
+/// Why: the message layer above is fixture-tested; this proves the framing and
+/// child lifecycle interoperate with an actual trusty server. Ignored by
+/// default (like the ONNX embedder tests) because it needs `trusty-memory` on
+/// PATH and its daemon reachable.
+/// Run: `cargo test -p trusty-mpm probe_stdio_against_trusty_memory -- --ignored`.
+#[tokio::test]
+#[ignore = "requires trusty-memory on PATH + reachable daemon"]
+async fn probe_stdio_against_trusty_memory() {
+    let entry = crate::core::mcp_config::builtin_server_entry("trusty-memory").unwrap();
+    let target = make_target("trusty-memory".to_string(), entry);
+    let outcome = probe_target(&target, DEFAULT_PROBE_TIMEOUT).await;
+    match outcome {
+        McpTestOutcome::Ok { tools: Some(n) } => assert!(n > 0, "expected a non-empty tool list"),
+        other => panic!("expected Ok with tools, got {other:?}"),
+    }
+}
+
+/// A spawn failure (nonexistent binary) is reported, not panicked.
+///
+/// Why: the spawn-error path is cheap to exercise for real and guards the most
+/// common failure mode (a server whose command isn't installed). No external
+/// dependency, so this runs in CI.
+#[tokio::test]
+async fn probe_stdio_missing_binary_reports_spawn_error() {
+    let entry = json!({
+        "type": "stdio",
+        "command": "definitely-not-a-real-binary-xyz-123",
+        "args": []
+    });
+    let target = make_target("ghost".to_string(), entry);
+    let outcome = probe_target(&target, DEFAULT_PROBE_TIMEOUT).await;
+    assert!(
+        matches!(outcome, McpTestOutcome::Spawn(_)),
+        "expected a spawn error, got {outcome:?}"
+    );
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -48,6 +48,7 @@ pub mod llm_overseer;
 pub mod managed_config;
 pub mod manifest;
 pub mod mcp_config;
+pub mod mcp_test;
 pub mod memory;
 pub mod model_inject;
 pub mod names;

--- a/crates/trusty-mpm/src/core/standalone/global_config.rs
+++ b/crates/trusty-mpm/src/core/standalone/global_config.rs
@@ -319,35 +319,17 @@ fn ensure_mcp_config(claude_config_dir: &Path) -> anyhow::Result<()> {
     }
     let servers = servers.as_object_mut().expect("mcpServers is an object");
 
-    let memory_entry = serde_json::json!({
-        "type": "stdio",
-        "command": "trusty-memory",
-        "args": ["serve", "--stdio"]
-    });
-    // WI-8 (refs #1548): trusty-review MCP server, stdio transport.
+    // The three built-in framework servers' launch definitions live in a single
+    // catalog (`core::mcp_config::builtin_server_entry`) so this managed-config
+    // wiring and `tm mcp test`'s probe can never disagree on how a server starts.
     // trusty-review reads its LLM credentials (OPENROUTER_API_KEY, AWS credentials)
     // and TRUSTY_SEARCH_URL from the environment — no secrets are injected here;
     // the managed session inherits the daemon env, matching the memory/search pattern.
-    let review_entry = serde_json::json!({
-        "type": "stdio",
-        "command": "trusty-review",
-        "args": ["serve", "--stdio"]
-    });
-    let search_entry = serde_json::json!({
-        "type": "stdio",
-        "command": "trusty-search",
-        "args": ["serve"]
-    });
-
-    servers
-        .entry("trusty-memory")
-        .or_insert(memory_entry.clone());
-    servers
-        .entry("trusty-review")
-        .or_insert(review_entry.clone());
-    servers
-        .entry("trusty-search")
-        .or_insert(search_entry.clone());
+    for name in crate::core::mcp_config::BUILTIN_MANAGED_MCP_SERVERS {
+        if let Some(entry) = crate::core::mcp_config::builtin_server_entry(name) {
+            servers.entry(*name).or_insert(entry);
+        }
+    }
 
     // Compare structurally (Value == Value) rather than byte-wise so that
     // trailing newlines, editor-inserted whitespace, or any other formatting


### PR DESCRIPTION
## Summary

Adds `tm mcp test [<name>] [--json] [--root <path>]` — verifies user-level MCP servers with a **real MCP handshake**, not just config validation.

- **Bare sweep**: tests every user-scope server unioned with the three framework built-ins (`trusty-memory`, `trusty-review`, `trusty-search`), deduped via the same `managed_mcp_server_names` logic `tm mcp`'s trust-seeding already uses.
- **`tm mcp test <name>`**: tests exactly one server; hard error if it's neither configured nor a built-in.
- **stdio servers**: spawns the configured command+args+env and drives the real `initialize` → `initialized` → `tools/list` exchange, reporting the actual tool count. Framing (newline-delimited JSON-RPC 2.0, `\n`-terminated, `protocolVersion: "2024-11-05"`) is matched byte-for-byte against `trusty_common::mcp::run_stdio_loop` — the loop every `serve --stdio` server in this workspace actually runs.
- **http/sse servers**: an HTTP reachability check (any response, even 4xx, counts as reachable). A full SSE/streamable-HTTP MCP handshake is intentionally out of scope — documented in the module docs.
- Each server is bounded by a 5s timeout so one hung server can't stall the sweep; the process exits non-zero if **any** tested server fails, so it's CI-usable.

**Live verification** against the real installed framework servers (not mocked):
```
Testing 1 MCP server(s) from ~/.trusty-tools/trusty-mpm/claude-config:
  NAME           TRANSPORT  RESULT  DETAIL
  trusty-search  stdio      PASS    21 tools
```
Full sweep results: `trusty-memory` → 37 tools, `trusty-review` → 4 tools, `trusty-search` → 21 tools — all PASS via genuine spawned subprocess handshakes, plus verified FAIL classification for a missing binary (spawn error) and an unreachable http endpoint.

## Consolidation

The three built-in servers' launch definitions (`command`/`args`) previously lived only inline in `standalone::global_config::ensure_mcp_config`. Extracted into `mcp_config::builtin_server_entry()`, now shared by both `ensure_mcp_config` (writing the managed `.mcp.json`) and `tm mcp test` (probing), with a test (`builtin_server_entry_matches_known_servers`) pinning the exact command+args so the managed config and the probe can never disagree on how a server starts.

## Review response (WARN → addressed)

code-critic returned WARN (merge-acceptable) with three hardening items, all addressed in a follow-up commit:

1. **(MEDIUM) Unbounded stdout read** — the stdio response reader now caps each line scan at 1 MiB (`MAX_LINE_BYTES`, via `AsyncReadExt::take`), bailing into `Protocol("line too long")` instead of letting a server that writes non-newline-terminated stdout noise grow the buffer unbounded for the whole timeout window.
2. **(MEDIUM) Missing timeout-path test** — added `probe_stdio_timeout_kills_hung_child` (not `#[ignore]`, runs in CI): spawns `sleep <marker>` directly (no shell), asserts `probe_target` returns `Timeout` well under the 30s sleep, then polls `pgrep -f <marker>` to confirm the hung child is actually killed — not just that the API call returned.
3. **(LOW, cosmetic)** — dropped the redundant explicit `child.start_kill()` on the success path and fixed the comment to correctly attribute the reap to `kill_on_drop(true)` (set at spawn), which covers every return path including timeout-cancellation.

## Test plan

- [x] `cargo build -p trusty-mpm` — clean
- [x] `cargo test -p trusty-mpm` — 2555 lib tests passed, 0 failed (5 ignored, incl. the ONNX-style live-daemon integration test); 777 bin tests passed, 0 failed; all integration suites green
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations`
- [x] Live smoke test of `tm mcp test` (bare sweep, named, `--json`, not-found) against the real installed daemons

Closes #2311. Does not merge itself — CI-gated squash-merge is handled separately.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools