### PR TITLE
feat(trusty-review): report M2 — opt-in LLM synthesis with fail-closed guardrails

### DIFF
--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -17,8 +17,10 @@ use anyhow::{Context as _, Result};
 use clap::Parser;
 
 use trusty_review::config::ReviewConfig;
+use trusty_review::llm::build_provider;
 use trusty_review::report::{
-    Reporter, TemplateLoader, load_manifest, model::ReportModel, template::DEFAULT_TEMPLATE,
+    Reporter, TemplateLoader, load_manifest, model::ReportModel, synthesize::Synthesis,
+    synthesize::Synthesizer, template::DEFAULT_TEMPLATE,
 };
 
 // ─── Report args ──────────────────────────────────────────────────────────────
@@ -43,6 +45,14 @@ pub struct ReportArgs {
     /// Output directory for the generated report pair (`{slug}.md`/`.json`).
     #[arg(long, value_name = "DIR", default_value = "./reports")]
     pub out: PathBuf,
+
+    /// Opt in to M2 LLM synthesis of the narrative sections (executive summary,
+    /// top-risk rationale, RED/AMBER finding prose).  OFF by default: the report
+    /// is deterministic (M1) unless this flag is set, because synthesis spends
+    /// LLM tokens.  Fails closed — any provider/parse/guardrail failure keeps the
+    /// deterministic output and records a visible `synthesis:` note.
+    #[arg(long)]
+    pub synthesize: bool,
 }
 
 // ─── Command handler ──────────────────────────────────────────────────────────
@@ -56,7 +66,7 @@ pub struct ReportArgs {
 /// the markdown + JSON pair.  Progress → STDERR; written paths → STDOUT.
 /// Test: arg parsing via `tests::report_args_parse_defaults`; full render via
 /// `tests/report_e2e.rs`.
-pub async fn cmd_report(_config: ReviewConfig, args: ReportArgs) -> Result<()> {
+pub async fn cmd_report(config: ReviewConfig, args: ReportArgs) -> Result<()> {
     eprintln!(
         "[trusty-review report] Loading manifest: {}",
         args.manifest.display()
@@ -79,8 +89,25 @@ pub async fn cmd_report(_config: ReviewConfig, args: ReportArgs) -> Result<()> {
         .load(&template_name)
         .with_context(|| format!("failed to load template '{template_name}'"))?;
 
-    let model = ReportModel::build(&manifest, &args.manifest, &template_name)
+    let mut model = ReportModel::build(&manifest, &args.manifest, &template_name)
         .context("failed to assemble report model")?;
+
+    // M2: opt-in LLM synthesis of narrative sections.  Fails closed — on any
+    // provider/parse/guardrail failure the deterministic output stands and the
+    // reason is recorded on the model (surfaced as a `synthesis:` note).
+    if args.synthesize {
+        eprintln!("[trusty-review report] Synthesis enabled — calling LLM provider...");
+        let synthesis = run_synthesis(&config, &model).await;
+        eprintln!(
+            "[trusty-review report] {}",
+            synthesis
+                .status_lines()
+                .first()
+                .cloned()
+                .unwrap_or_default()
+        );
+        model.synthesis = Some(synthesis);
+    }
 
     let reporter = Reporter::new(&args.out);
     let written = reporter
@@ -94,6 +121,28 @@ pub async fn cmd_report(_config: ReviewConfig, args: ReportArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Build the LLM provider and run one synthesis pass, failing closed.
+///
+/// Why: keeps `cmd_report` readable and isolates the provider-build failure path
+/// — a build error (missing API key, bad model id) must NOT abort the report; it
+/// degrades to the deterministic output with an `Unavailable` synthesis, exactly
+/// like the runtime failure paths inside [`Synthesizer::synthesize`].
+/// What: resolves the reviewer role's provider/model (the same construction path
+/// the review pipeline uses), builds the provider, and runs synthesis; a build
+/// error returns `Synthesis::unavailable(reason)`.
+/// Test: build path is network-bound; the fail-closed decisions are covered by
+/// `report::synthesize::tests` with stub providers.
+async fn run_synthesis(config: &ReviewConfig, model: &ReportModel) -> Synthesis {
+    let role = &config.role_models.reviewer;
+    match build_provider(&role.model, &role.provider, &config.openrouter_api_key).await {
+        Ok(provider) => {
+            let synthesizer = Synthesizer::new(provider, role.model.clone());
+            synthesizer.synthesize(model).await
+        }
+        Err(e) => Synthesis::unavailable(format!("provider build failed: {e}")),
+    }
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -20,6 +20,9 @@ pub mod manifest;
 pub mod metrics;
 pub mod model;
 pub mod reporter;
+pub mod synthesize;
+pub mod synthesize_guard;
+pub mod synthesize_prompt;
 pub mod template;
 
 // ── Re-exports for convenience ─────────────────────────────────────────────
@@ -34,4 +37,5 @@ pub use manifest::{
 pub use metrics::{AnalyzeMetrics, MetricFinding, Severity, load_metrics};
 pub use model::{ReportModel, RepositoryReport};
 pub use reporter::Reporter;
+pub use synthesize::{FindingProse, RiskRow, Synthesis, SynthesisStatus, Synthesizer};
 pub use template::{DEFAULT_TEMPLATE, TemplateLoader};

--- a/crates/trusty-review/src/report/model.rs
+++ b/crates/trusty-review/src/report/model.rs
@@ -42,6 +42,14 @@ pub struct ReportModel {
     pub manifest_path: String,
     /// One report per repository, in manifest order.
     pub repositories: Vec<RepositoryReport>,
+    /// Optional M2 LLM synthesis result (present only under `--synthesize`).
+    ///
+    /// Why: recording the synthesis outcome on the model keeps the JSON twin a
+    /// faithful record of what the LLM produced (and what the guardrail
+    /// rejected); the reporter reads this to inject narrative prose and to render
+    /// the visible `synthesis:` status note.  `None` = deterministic M1 output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub synthesis: Option<super::synthesize::Synthesis>,
 }
 
 /// Per-repository resolved data mapped to one `per_application` block.
@@ -99,6 +107,7 @@ impl ReportModel {
             generated_date: today,
             manifest_path: manifest_path.display().to_string(),
             repositories,
+            synthesis: None,
         })
     }
 }

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -50,7 +50,9 @@ impl Reporter {
     /// Test: `reporter_tests.rs::render_contains_expected`.
     pub fn render(&self, model: &ReportModel, template: &str) -> String {
         let scope = build_scope(model);
-        render(template, &scope)
+        let mut out = render(template, &scope);
+        append_synthesis_note(&mut out, model);
+        out
     }
 
     /// Render and write `{slug}.md` + `{slug}.json` atomically to `output_dir`.
@@ -146,7 +148,121 @@ fn build_scope(model: &ReportModel) -> Scope {
         root.push_block("per_application", per_application_scope(repo));
     }
 
+    // M2: inject verified LLM synthesis into the narrative placeholders/blocks.
+    // Absent or unavailable synthesis leaves every narrative field to the M1
+    // honesty marker (deterministic behaviour unchanged).
+    if let Some(syn) = &model.synthesis
+        && syn.is_available()
+    {
+        inject_synthesis(&mut root, model, syn);
+    }
+
     root
+}
+
+/// Inject verified synthesis prose into the narrative placeholders and blocks.
+///
+/// Why: M2 fills exactly the fields M1 leaves as honesty markers — executive
+/// summary, top-risk rows, and RED/AMBER finding elaborations — and only with
+/// prose that already passed the numeric guardrail.  Greens are never touched.
+/// What: sets the executive-summary scalar, the `risk_N_*` scalars, and pushes
+/// `per_application_red` / `per_application_amber` blocks (with nested
+/// `red_finding` / `amber_finding` blocks) for each application that has
+/// verified findings of that band.
+/// Test: `reporter_tests.rs::reporter_injects_synthesis_prose`.
+fn inject_synthesis(root: &mut Scope, model: &ReportModel, syn: &super::synthesize::Synthesis) {
+    if let Some(exec) = &syn.executive_summary {
+        root.set("executive_summary_paragraph", exec.clone());
+    }
+
+    for (i, risk) in syn.top_risks.iter().enumerate() {
+        let n = i + 1;
+        root.set(format!("risk_{n}_description"), risk.description.clone());
+        root.set(format!("risk_{n}_severity"), risk.severity.clone());
+        root.set(format!("risk_{n}_cost"), risk.cost.clone());
+        root.set(format!("risk_{n}_apps"), risk.apps.clone());
+    }
+
+    for repo in &model.repositories {
+        push_band_blocks(
+            root,
+            syn,
+            &repo.name,
+            &repo.slug,
+            "RED",
+            "per_application_red",
+            "red_finding",
+        );
+        push_band_blocks(
+            root,
+            syn,
+            &repo.name,
+            &repo.slug,
+            "AMBER",
+            "per_application_amber",
+            "amber_finding",
+        );
+    }
+}
+
+/// Push one per-application findings block for a single severity band.
+///
+/// Why: the RED and AMBER template sections share an identical shape (an app
+/// header block wrapping a repeated finding block); one helper covers both.
+/// What: collects this repo's verified findings of `band`, and if any exist,
+/// pushes an `app_block` scope carrying `app_name` plus one `finding_block`
+/// child per finding with all elaboration scalars set.
+/// Test: `reporter_tests.rs::reporter_injects_synthesis_prose`.
+fn push_band_blocks(
+    root: &mut Scope,
+    syn: &super::synthesize::Synthesis,
+    app_name: &str,
+    app_slug: &str,
+    band: &str,
+    app_block: &str,
+    finding_block: &str,
+) {
+    let matches: Vec<&super::synthesize::FindingProse> = syn
+        .findings
+        .iter()
+        .filter(|f| f.app_slug == app_slug && f.severity.to_uppercase() == band)
+        .collect();
+    if matches.is_empty() {
+        return;
+    }
+    let mut app_scope = Scope::new();
+    app_scope.set("app_name", app_name.to_string());
+    for f in matches {
+        let mut fs = Scope::new();
+        fs.set("finding_title", f.title.clone());
+        fs.set("finding_description", f.description.clone());
+        fs.set("finding_evidence", f.evidence.clone());
+        fs.set("finding_component", f.component.clone());
+        fs.set("finding_business_impact", f.business_impact.clone());
+        fs.set("finding_remediation", f.remediation.clone());
+        fs.set("finding_cost_effort", f.cost_effort.clone());
+        app_scope.push_block(finding_block, fs);
+    }
+    root.push_block(app_block, app_scope);
+}
+
+/// Append the visible `synthesis:` status note to the rendered markdown.
+///
+/// Why: a reader must never mistake deterministic fallback for synthesized
+/// analysis; the note makes the outcome (available / unavailable-with-reason /
+/// per-field guardrail rejections) explicit at the end of the report.
+/// What: when `model.synthesis` is present, appends a fenced status block whose
+/// lines come from `Synthesis::status_lines`.  Absent synthesis appends nothing
+/// (M1 output is byte-identical).
+/// Test: `reporter_tests.rs::reporter_appends_unavailable_note`.
+fn append_synthesis_note(out: &mut String, model: &ReportModel) {
+    let Some(syn) = &model.synthesis else {
+        return;
+    };
+    out.push_str("\n\n## Synthesis Status\n\n");
+    for line in syn.status_lines() {
+        out.push_str(&format!("- {line}\n"));
+    }
 }
 
 /// Build the per-application child scope for one repository.

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -118,6 +118,71 @@ fn write_emits_both() {
     assert_eq!(parsed["title"], "Acme Due Diligence");
 }
 
+/// Why: available synthesis must inject verified prose into the exec-summary and
+/// RED-finding placeholders and surface the `synthesis: available` note.
+/// What: attaches an available `Synthesis` (exec + one RED finding routed to the
+/// repo slug) to the model and asserts the prose and note appear in the markdown.
+/// Test: this test itself.
+#[test]
+fn reporter_injects_synthesis_prose() {
+    use crate::report::synthesize::{FindingProse, Synthesis, SynthesisStatus};
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model(tmp.path());
+    let slug = model.repositories[0].slug.clone();
+    model.synthesis = Some(Synthesis {
+        status: SynthesisStatus::Available,
+        executive_summary: Some("A grounded acquirer-relevant summary.".to_string()),
+        top_risks: vec![],
+        findings: vec![FindingProse {
+            app_slug: slug,
+            title: "Injection risk".to_string(),
+            severity: "RED".to_string(),
+            description: "Raw query concatenation.".to_string(),
+            evidence: "one path".to_string(),
+            component: "auth".to_string(),
+            business_impact: "data loss".to_string(),
+            remediation: "parameterise".to_string(),
+            cost_effort: "moderate".to_string(),
+        }],
+        notes: vec![],
+    });
+
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("A grounded acquirer-relevant summary."));
+    assert!(md.contains("Injection risk"));
+    assert!(md.contains("Raw query concatenation."));
+    assert!(md.contains("synthesis: available"));
+    assert!(!md.contains("{{"), "no raw placeholder survives");
+}
+
+/// Why: an unavailable synthesis must keep the deterministic output and surface
+/// the fail-closed reason verbatim.
+/// What: attaches `Synthesis::unavailable(..)`; asserts the note is present and
+/// the exec-summary placeholder still falls through to the honesty marker.
+/// Test: this test itself.
+#[test]
+fn reporter_appends_unavailable_note() {
+    use crate::report::synthesize::Synthesis;
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model(tmp.path());
+    model.synthesis = Some(Synthesis::unavailable("provider timeout"));
+
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("synthesis: unavailable (provider timeout)"));
+    // Deterministic fallback: exec summary was never injected.
+    assert!(md.contains(HONESTY_MARKER));
+}
+
 /// Why: output filenames must be date-prefixed and slug-stable.
 /// What: asserts the stem is `{date}-{title-slug}`.
 /// Test: this test itself.

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -1,0 +1,386 @@
+//! Opt-in LLM synthesis of report narrative sections (M2, epic #2312 / #2314).
+//!
+//! Why: M1 fills the report deterministically and leaves the narrative fields
+//! (executive summary, top-risk rationale, RED/AMBER finding prose) as honesty
+//! markers.  M2 lets an LLM write those — and ONLY those — sections, grounded
+//! strictly in the deterministic data.  The posture mirrors the pipeline's
+//! `Verdict::Unknown` convention: any provider error, timeout, truncation, or
+//! unparseable response fails CLOSED to the deterministic M1 output, and a
+//! fabricated figure is rejected field-by-field by a numeric guardrail.  Greens
+//! are excluded structurally (see [`synthesize_prompt`]), never merely by
+//! instruction.
+//! What: [`Synthesizer`] holds an [`LlmProvider`] and calls it once; [`Synthesis`]
+//! is the injected result recorded on the [`ReportModel`] (its JSON twin) and read
+//! by the reporter.  [`SynthesisStatus`] carries the fail-closed reason.
+//! Test: `synthesize_tests.rs` — happy-path injection, malformed-JSON and
+//! provider-error fail-closed, numeric-guardrail rejection, greens-never-sent.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::llm::LlmProvider;
+use crate::report::model::ReportModel;
+use crate::report::synthesize_guard::{allowed_numbers, verify_prose};
+use crate::report::synthesize_prompt::build_synthesis_prompt;
+
+/// Default wall-clock ceiling for one synthesis pass before failing closed.
+const DEFAULT_SYNTHESIS_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// The literal prefix every guardrail-rejection note carries, so the reporter and
+/// tests can assert on it.
+const REJECTED_NOTE: &str = "synthesis: rejected (unverified figure)";
+
+// ─── Injected result types ──────────────────────────────────────────────────
+
+/// Outcome of a synthesis attempt, recorded on the [`ReportModel`].
+///
+/// Why: the reporter injects surviving prose into the narrative placeholders and
+/// renders a visible status note; serialising this onto the model keeps the JSON
+/// twin a faithful record of what synthesis did (and did not) produce.
+/// What: the overall [`SynthesisStatus`], the verified executive summary (absent
+/// when unavailable/rejected), verified top-risk rows, verified per-finding
+/// prose, and human-readable guardrail notes.
+/// Test: `synthesize_tests.rs::synthesize_happy_path_injects`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Synthesis {
+    /// Overall status of the synthesis attempt.
+    pub status: SynthesisStatus,
+    /// Verified executive-summary prose, or `None` when unavailable/rejected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executive_summary: Option<String>,
+    /// Verified top-risk rows (rejected rows are dropped).
+    #[serde(default)]
+    pub top_risks: Vec<RiskRow>,
+    /// Verified per-finding elaboration prose (rejected findings are dropped).
+    #[serde(default)]
+    pub findings: Vec<FindingProse>,
+    /// Human-readable guardrail/routing notes recorded during injection.
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+/// Overall status of a synthesis attempt.
+///
+/// Why: the fail-closed contract needs a single value that says whether the
+/// narrative is trustworthy and, if not, why — surfaced verbatim in the report.
+/// What: `Available` when at least the executive summary or one row/finding
+/// survived; `Unavailable(reason)` for provider/parse/timeout failures.
+/// Test: `synthesize_tests.rs::synthesize_provider_error_fails_closed`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "state", content = "reason", rename_all = "snake_case")]
+pub enum SynthesisStatus {
+    /// Synthesis produced usable, verified prose.
+    Available,
+    /// Synthesis failed closed; the deterministic output stands.  Carries reason.
+    Unavailable(String),
+}
+
+impl Default for SynthesisStatus {
+    fn default() -> Self {
+        SynthesisStatus::Unavailable("not attempted".to_string())
+    }
+}
+
+/// One synthesized top-risk table row (rationale for the Top Risks table).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RiskRow {
+    /// Risk description.
+    pub description: String,
+    /// Severity band (`RED`/`AMBER`).
+    pub severity: String,
+    /// Qualitative cost/effort framing.
+    pub cost: String,
+    /// Affected application(s).
+    pub apps: String,
+}
+
+/// Elaboration prose for one RED/AMBER finding, routed by `app_slug`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FindingProse {
+    /// Application slug this finding belongs to (matches a repository slug).
+    pub app_slug: String,
+    /// Finding title.
+    pub title: String,
+    /// Severity band (`RED`/`AMBER`).
+    pub severity: String,
+    /// One-line finding description.
+    pub description: String,
+    /// Supporting evidence.
+    #[serde(default)]
+    pub evidence: String,
+    /// Affected component/path.
+    #[serde(default)]
+    pub component: String,
+    /// Business-impact framing.
+    #[serde(default)]
+    pub business_impact: String,
+    /// Remediation framing.
+    pub remediation: String,
+    /// Remediation cost/effort framing.
+    #[serde(default)]
+    pub cost_effort: String,
+}
+
+impl Synthesis {
+    /// A fail-closed result carrying a reason and no prose.
+    ///
+    /// Why: every failure path returns the same shape so the reporter treats
+    /// them uniformly (deterministic output + a visible status note).
+    /// What: sets `status = Unavailable(reason)` and leaves all prose empty.
+    /// Test: `synthesize_tests.rs::synthesize_provider_error_fails_closed`.
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Synthesis {
+            status: SynthesisStatus::Unavailable(reason.into()),
+            ..Default::default()
+        }
+    }
+
+    /// True when synthesis produced usable prose.
+    ///
+    /// Why: the reporter injects prose only when the attempt is `Available`.
+    /// What: matches `SynthesisStatus::Available`.
+    /// Test: exercised by `reporter_tests.rs` synthesis cases.
+    pub fn is_available(&self) -> bool {
+        matches!(self.status, SynthesisStatus::Available)
+    }
+
+    /// The visible status note lines for the rendered report.
+    ///
+    /// Why: the report must surface the synthesis outcome — an `available`
+    /// banner, an `unavailable (<reason>)` fail-closed banner, or the
+    /// per-field guardrail rejections — so a reader never mistakes deterministic
+    /// fallback for synthesized analysis.
+    /// What: first line is the overall status; subsequent lines are the notes.
+    /// Test: `reporter_tests.rs::reporter_appends_unavailable_note`.
+    pub fn status_lines(&self) -> Vec<String> {
+        let mut lines = Vec::with_capacity(1 + self.notes.len());
+        match &self.status {
+            SynthesisStatus::Available => lines.push("synthesis: available".to_string()),
+            SynthesisStatus::Unavailable(reason) => {
+                lines.push(format!("synthesis: unavailable ({reason})"));
+            }
+        }
+        lines.extend(self.notes.iter().cloned());
+        lines
+    }
+}
+
+// ─── Synthesizer ────────────────────────────────────────────────────────────
+
+/// Drives one LLM synthesis pass over a deterministic [`ReportModel`].
+///
+/// Why: dependency injection of the provider lets tests supply stub providers
+/// (fake/malformed/error) without any network access, exactly as the pipeline
+/// and profile synthesizer do.
+/// What: holds the provider, the resolved model id, and the fail-closed timeout.
+/// Test: all `synthesize_tests.rs` cases construct one with a stub provider.
+pub struct Synthesizer {
+    llm: Arc<dyn LlmProvider>,
+    model: String,
+    timeout: Duration,
+}
+
+impl Synthesizer {
+    /// Create a synthesizer from an injected provider and model id.
+    ///
+    /// Why: the CLI builds the provider from the reviewer role config; tests
+    /// inject stubs.
+    /// What: stores the provider + model with the default timeout.
+    /// Test: exercised by every synthesize test.
+    pub fn new(llm: Arc<dyn LlmProvider>, model: impl Into<String>) -> Self {
+        Self {
+            llm,
+            model: model.into(),
+            timeout: DEFAULT_SYNTHESIS_TIMEOUT,
+        }
+    }
+
+    /// Override the fail-closed timeout (used by tests).
+    #[cfg(test)]
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Run synthesis, returning a fail-closed [`Synthesis`].
+    ///
+    /// Why: the single entry point the CLI awaits; it NEVER fabricates and NEVER
+    /// partial-trusts a malformed response — on any failure it returns an
+    /// `Unavailable` result and the deterministic output stands.
+    /// What: builds the numeric allow-set from the deterministic model, calls the
+    /// provider under a timeout, rejects truncated/unparseable responses, then
+    /// applies the numeric guardrail field-by-field, dropping any field whose
+    /// prose cites a figure absent from the source.
+    /// Test: `synthesize_tests.rs::{synthesize_happy_path_injects,
+    /// synthesize_malformed_json_fails_closed, synthesize_provider_error_fails_closed,
+    /// synthesize_rejects_unverified_figure}`.
+    pub async fn synthesize(&self, model: &ReportModel) -> Synthesis {
+        // Ground truth for the guardrail comes from the DETERMINISTIC model only.
+        let allowed = match serde_json::to_value(model) {
+            Ok(v) => allowed_numbers(&v),
+            Err(e) => {
+                warn!(error = %e, "synthesis: could not serialise model for guardrail");
+                return Synthesis::unavailable("internal: model not serialisable");
+            }
+        };
+
+        let req = build_synthesis_prompt(model, &self.model);
+        let resp = match tokio::time::timeout(self.timeout, self.llm.complete(req)).await {
+            Err(_) => {
+                warn!("synthesis: provider timed out — failing closed");
+                return Synthesis::unavailable("provider timeout");
+            }
+            Ok(Err(e)) => {
+                warn!(error = %e, "synthesis: provider error — failing closed");
+                return Synthesis::unavailable(format!("provider error: {e}"));
+            }
+            Ok(Ok(r)) => r,
+        };
+
+        // A truncated response is an incomplete response — never partial-trust it.
+        if matches!(
+            resp.finish_reason.as_deref(),
+            Some("length") | Some("max_tokens")
+        ) {
+            warn!("synthesis: response truncated at token ceiling — failing closed");
+            return Synthesis::unavailable("truncated response");
+        }
+
+        let raw = match parse_raw(&resp.text) {
+            Some(r) => r,
+            None => {
+                warn!("synthesis: unparseable response — failing closed");
+                return Synthesis::unavailable("unparseable response");
+            }
+        };
+
+        debug!(
+            input_tokens = resp.input_tokens,
+            output_tokens = resp.output_tokens,
+            "synthesis: provider call complete"
+        );
+
+        apply_guardrail(raw, &allowed)
+    }
+}
+
+// ─── Raw (pre-guardrail) parse types ────────────────────────────────────────
+
+/// The raw JSON contract the provider is asked to emit (pre-verification).
+#[derive(Debug, Deserialize)]
+struct RawSynthesis {
+    #[serde(default)]
+    executive_summary: String,
+    #[serde(default)]
+    top_risks: Vec<RiskRow>,
+    #[serde(default)]
+    findings: Vec<FindingProse>,
+}
+
+/// Parse the provider response into [`RawSynthesis`].
+///
+/// Why: forced structured output returns a bare JSON object, but we still accept
+/// a fenced block (defensive, matching the profile synthesizer) so a provider
+/// that ignores the schema does not silently fail.
+/// What: tries a direct object parse, then a ```json fenced block; `None` when
+/// neither yields a decodable object.
+/// Test: `synthesize_tests.rs::{synthesize_happy_path_injects,
+/// synthesize_malformed_json_fails_closed}`.
+fn parse_raw(text: &str) -> Option<RawSynthesis> {
+    let body = text.trim();
+    if body.starts_with('{')
+        && let Ok(r) = serde_json::from_str::<RawSynthesis>(body)
+    {
+        return Some(r);
+    }
+    let fence_start = body.rfind("```json")?;
+    let after = &body[fence_start + 7..];
+    let fence_end = after.find("```")?;
+    serde_json::from_str::<RawSynthesis>(after[..fence_end].trim()).ok()
+}
+
+/// Apply the numeric guardrail to the raw synthesis, field by field.
+///
+/// Why: this is the fail-closed core — a field whose prose cites a figure not in
+/// the source is dropped (never repaired), so the deterministic honesty marker
+/// stands and a visible rejection note is recorded.
+/// What: verifies the executive summary and every risk row / finding against
+/// `allowed`; keeps only clean fields.  Findings must carry a RED/AMBER severity
+/// (defence-in-depth greens exclusion).  The result is `Available` iff at least
+/// one field survived, else `Unavailable("no verifiable content")`.
+/// Test: `synthesize_tests.rs::{synthesize_rejects_unverified_figure,
+/// synthesize_happy_path_injects}`.
+fn apply_guardrail(raw: RawSynthesis, allowed: &std::collections::HashSet<String>) -> Synthesis {
+    let mut out = Synthesis::default();
+
+    // Executive summary.
+    let exec = raw.executive_summary.trim();
+    if !exec.is_empty() {
+        match verify_prose(exec, allowed) {
+            Ok(()) => out.executive_summary = Some(exec.to_string()),
+            Err(tok) => out
+                .notes
+                .push(format!("{REJECTED_NOTE} in executive summary: {tok}")),
+        }
+    }
+
+    // Top-risk rows.
+    for (i, r) in raw.top_risks.into_iter().enumerate() {
+        match verify_all(&[&r.description, &r.severity, &r.cost, &r.apps], allowed) {
+            Ok(()) => out.top_risks.push(r),
+            Err(tok) => out
+                .notes
+                .push(format!("{REJECTED_NOTE} in top-risk row {}: {tok}", i + 1)),
+        }
+    }
+
+    // RED/AMBER finding elaborations.
+    for f in raw.findings {
+        let sev = f.severity.to_uppercase();
+        if sev != "RED" && sev != "AMBER" {
+            out.notes.push(format!(
+                "synthesis: dropped finding '{}' (non-RED/AMBER severity '{}')",
+                f.title, f.severity
+            ));
+            continue;
+        }
+        match verify_all(
+            &[
+                &f.description,
+                &f.evidence,
+                &f.component,
+                &f.business_impact,
+                &f.remediation,
+                &f.cost_effort,
+            ],
+            allowed,
+        ) {
+            Ok(()) => out.findings.push(f),
+            Err(tok) => out
+                .notes
+                .push(format!("{REJECTED_NOTE} in finding '{}': {tok}", f.title)),
+        }
+    }
+
+    if out.executive_summary.is_some() || !out.top_risks.is_empty() || !out.findings.is_empty() {
+        out.status = SynthesisStatus::Available;
+    } else {
+        out.status = SynthesisStatus::Unavailable("no verifiable content".to_string());
+    }
+    out
+}
+
+/// Verify every field of a group; returns the first offending token on failure.
+fn verify_all(fields: &[&str], allowed: &std::collections::HashSet<String>) -> Result<(), String> {
+    for field in fields {
+        verify_prose(field, allowed)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "synthesize_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/synthesize_guard.rs
+++ b/crates/trusty-review/src/report/synthesize_guard.rs
@@ -1,0 +1,117 @@
+//! Numeric guardrail for LLM-synthesized report prose (M2, #2314).
+//!
+//! Why: synthesis is the one place an LLM touches a due-diligence report, and the
+//! single failure mode that would silently corrupt a deal analysis is a
+//! fabricated figure ("42% of the code is untested") that never appeared in the
+//! source data.  This module is the report-side analogue of the pipeline's
+//! verdict-integrity posture: after the model injects prose, every digit
+//! sequence in that prose MUST trace back to a number already present in the
+//! deterministic [`ReportModel`].  A violation rejects the field (fail-closed) —
+//! it is never partially trusted.
+//! What: [`allowed_numbers`] builds the canonical set of numbers the source model
+//! actually contains (walking the serialized model); [`verify_prose`] checks that
+//! every number token in a candidate string is in that set, tolerating formatting
+//! variants (thousands separators, `$`, `%`, trailing-zero decimals).
+//! Test: `synthesize_tests.rs` covers extraction, canonicalisation, the
+//! formatting-variant equivalences, and the reject path.
+
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde_json::Value;
+
+/// Compiled once: a digit sequence with optional thousands separators and an
+/// optional decimal fraction.  Leading `$` / trailing `%` are intentionally
+/// excluded from the capture so they are stripped for free.
+fn number_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"[0-9][0-9,]*(?:\.[0-9]+)?").expect("valid number regex"))
+}
+
+/// Canonicalise one raw number token to a comparison key.
+///
+/// Why: the same magnitude appears in prose and source in different skins —
+/// `8,200`, `8200`, `8200.0`, `$8200` — and the guardrail must treat them as
+/// equal or it would reject faithful restatements.
+/// What: strips thousands-separator commas, then, for a decimal, trims trailing
+/// zeros and a bare trailing dot (`3.50` → `3.5`, `8200.0` → `8200`).  The
+/// surrounding `$`/`%` are already absent because the capture regex omits them.
+/// Test: `canonicalize_number_variants`.
+fn canonicalize(raw: &str) -> String {
+    let no_commas = raw.replace(',', "");
+    if let Some(dot) = no_commas.find('.') {
+        let (int_part, frac_with_dot) = no_commas.split_at(dot);
+        let frac = frac_with_dot[1..].trim_end_matches('0');
+        if frac.is_empty() {
+            int_part.to_string()
+        } else {
+            format!("{int_part}.{frac}")
+        }
+    } else {
+        no_commas
+    }
+}
+
+/// Extract the canonical number keys present in an arbitrary string.
+///
+/// Why: both the allowed-set construction and the prose check need the same
+/// tokeniser so their notions of "a number" are identical.
+/// What: runs the number regex over `text` and canonicalises each match.
+/// Test: `numbers_in_extracts_and_canonicalises`.
+pub fn numbers_in(text: &str) -> Vec<String> {
+    number_re()
+        .find_iter(text)
+        .map(|m| canonicalize(m.as_str()))
+        .collect()
+}
+
+/// Build the set of numbers the deterministic source model legitimately contains.
+///
+/// Why: the guardrail's ground truth is "what figures does the report's own data
+/// present?" — computed from the machine-readable twin so it captures every
+/// metric, count, LoC total, git SHA digit-run, and date the report is derived
+/// from, with no hand-maintained field list to drift.
+/// What: walks the serialized [`Value`], adding canonical keys for every JSON
+/// number node and every number token found inside every string node.
+/// Test: `allowed_numbers_covers_metrics`.
+pub fn allowed_numbers(model: &Value) -> HashSet<String> {
+    let mut set = HashSet::new();
+    collect(model, &mut set);
+    set
+}
+
+/// Recursively collect canonical number keys from a JSON value tree.
+fn collect(value: &Value, set: &mut HashSet<String>) {
+    match value {
+        Value::Number(n) => {
+            set.insert(canonicalize(&n.to_string()));
+        }
+        Value::String(s) => {
+            for k in numbers_in(s) {
+                set.insert(k);
+            }
+        }
+        Value::Array(items) => items.iter().for_each(|v| collect(v, set)),
+        Value::Object(map) => map.values().for_each(|v| collect(v, set)),
+        Value::Bool(_) | Value::Null => {}
+    }
+}
+
+/// Verify that every number in `prose` traces back to the allowed set.
+///
+/// Why: this is the fail-closed gate — a single unverifiable figure disqualifies
+/// the whole synthesized field, which is then dropped in favour of the
+/// deterministic honesty marker.
+/// What: returns `Ok(())` when every canonical number token in `prose` is a
+/// member of `allowed`; otherwise `Err(first_offending_token)`.  Prose with no
+/// numbers always passes.
+/// Test: `verify_prose_passes_faithful`, `verify_prose_rejects_fabricated`.
+pub fn verify_prose(prose: &str, allowed: &HashSet<String>) -> Result<(), String> {
+    for token in numbers_in(prose) {
+        if !allowed.contains(&token) {
+            return Err(token);
+        }
+    }
+    Ok(())
+}

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -1,0 +1,198 @@
+//! Prompt + JSON contract builder for report synthesis (M2, #2314).
+//!
+//! Why: the synthesizer sends the deterministic report data to the LLM and must
+//! (a) forbid invention of any figure, (b) enforce the no-green-analysis rule
+//! STRUCTURALLY — green findings are never placed in the prompt, so the model
+//! cannot elaborate them even if instructed to — and (c) force a structured JSON
+//! response so parsing never depends on free-text scraping.
+//! What: [`build_synthesis_prompt`] assembles the [`LlmRequest`] (system prompt +
+//! data digest + [`ResponseSchema`]); the digest lists per-application profile
+//! numbers and ONLY the RED/AMBER findings.  The `bedrock/`/`openrouter/` routing
+//! prefix is stripped so the bare id reaches the provider API.
+//! Test: `synthesize_tests.rs` asserts schema shape, that greens are absent from
+//! the digest, and that the prefix is stripped.
+
+use crate::llm::{ChatMessage, LlmRequest, ResponseSchema, strip_provider_prefix};
+use crate::report::metrics::Severity;
+use crate::report::model::ReportModel;
+
+/// Temperature for synthesis — low, to keep the analytic voice grounded.
+pub(super) const SYNTHESIS_TEMPERATURE: f32 = 0.2;
+/// Output-token ceiling for one synthesis pass.
+pub(super) const SYNTHESIS_MAX_TOKENS: u32 = 3072;
+
+/// The JSON Schema the provider forces the model to emit.
+///
+/// Why: forced structured output removes the "did the model wrap it in a fence?"
+/// class of parse failure; the response body IS the JSON object.
+/// What: returns a [`ResponseSchema`] named `report_synthesis` with the exec
+/// summary, a top-risks array, and a RED/AMBER findings array.  Every finding
+/// carries the `app_slug` and `severity` so the reporter can route the prose
+/// back to the correct application section and band.
+/// Test: `synthesize_tests.rs::synthesis_schema_shape`.
+pub(super) fn synthesis_schema() -> ResponseSchema {
+    ResponseSchema {
+        name: "report_synthesis".to_string(),
+        schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "executive_summary": {
+                    "type": "string",
+                    "description": "One deal-relevant paragraph synthesised across all applications. Use ONLY figures present in the provided data; never invent numbers; preserve any \"(approx)\" marker verbatim."
+                },
+                "top_risks": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "description": {"type": "string"},
+                            "severity": {"type": "string", "enum": ["RED", "AMBER"]},
+                            "cost": {"type": "string", "description": "Qualitative effort/cost framing; no invented figures."},
+                            "apps": {"type": "string", "description": "Affected application name(s)."}
+                        },
+                        "required": ["description", "severity", "cost", "apps"]
+                    },
+                    "description": "3-5 top risks, most material first. Drawn ONLY from the RED/AMBER findings provided."
+                },
+                "findings": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "app_slug": {"type": "string", "description": "Must match a provided application slug exactly."},
+                            "title": {"type": "string"},
+                            "severity": {"type": "string", "enum": ["RED", "AMBER"]},
+                            "description": {"type": "string"},
+                            "evidence": {"type": "string"},
+                            "component": {"type": "string"},
+                            "business_impact": {"type": "string"},
+                            "remediation": {"type": "string"},
+                            "cost_effort": {"type": "string"}
+                        },
+                        "required": ["app_slug", "title", "severity", "description", "remediation"]
+                    },
+                    "description": "Elaboration prose for EACH provided RED/AMBER finding. Do NOT add findings not in the provided list."
+                }
+            },
+            "required": ["executive_summary", "top_risks", "findings"]
+        }),
+    }
+}
+
+/// The synthesis system prompt.
+///
+/// Why: the deal-analytic voice + the hard grounding rules (no invented numbers,
+/// preserve approx markers, RED/AMBER only) belong in the system role so they
+/// govern every field.
+/// What: a static instruction block; the no-green rule is stated for defence in
+/// depth even though greens are also excluded structurally from the digest.
+/// Test: covered transitively by the prompt-assembly tests.
+pub(super) fn synthesis_system_prompt() -> &'static str {
+    r#"You are a senior technical due-diligence analyst writing the narrative sections of an acquisition-grade report from pre-computed repository analysis data.
+
+## Absolute rules
+- Use ONLY values present in the provided data. NEVER invent, estimate, or extrapolate a number that is not given.
+- If a provided value carries an "(approx)" marker, preserve that marker verbatim.
+- Write prose for RED and AMBER findings ONLY. Do not mention, elaborate, or infer GREEN/positive findings — none are provided, and none should appear.
+- Be concise, specific, and deal-relevant: what an acquirer must act on.
+
+## Output
+Populate the structured response:
+- `executive_summary`: one paragraph synthesised across all applications (not a restatement of section headers).
+- `top_risks`: the 3-5 most material RED/AMBER risks, each with a severity, a qualitative cost/effort framing, and the affected application(s).
+- `findings`: one elaboration per provided RED/AMBER finding (finding, evidence, affected component, business impact, remediation framing), tagged with its `app_slug` and `severity`."#
+}
+
+/// Build the LLM request for one report-synthesis pass.
+///
+/// Why: single place that turns the deterministic [`ReportModel`] into a grounded
+/// prompt; keeping greens out here is what makes the no-green rule structural
+/// rather than a polite request.
+/// What: assembles the system prompt, a per-application data digest containing
+/// only RED/AMBER findings, and the forced-output schema.  Strips any provider
+/// routing prefix from `llm_model`.
+/// Test: `synthesize_tests.rs::{prompt_excludes_greens, prompt_strips_prefix,
+/// synthesis_schema_shape}`.
+pub(super) fn build_synthesis_prompt(model: &ReportModel, llm_model: &str) -> LlmRequest {
+    LlmRequest {
+        model: strip_provider_prefix(llm_model).to_string(),
+        system: synthesis_system_prompt().to_string(),
+        messages: vec![ChatMessage {
+            role: "user".to_string(),
+            content: build_digest(model),
+        }],
+        temperature: SYNTHESIS_TEMPERATURE,
+        max_tokens: SYNTHESIS_MAX_TOKENS,
+        response_schema: Some(synthesis_schema()),
+    }
+}
+
+/// Build the user-message data digest — RED/AMBER findings only.
+///
+/// Why: the model must see every deterministic figure it may cite and every
+/// RED/AMBER finding it must elaborate, and NOTHING it must not (greens).
+/// What: writes a report header then, per application, its profile numbers and a
+/// bulleted list of its non-green findings; greens are filtered out before the
+/// list is written.
+/// Test: `synthesize_tests.rs::prompt_excludes_greens`.
+fn build_digest(model: &ReportModel) -> String {
+    let mut msg = String::with_capacity(2048);
+    msg.push_str(&format!("# Report: {}\n\n", model.title));
+    msg.push_str(&format!(
+        "Applications assessed: {}\n\n",
+        model
+            .repositories
+            .iter()
+            .map(|r| r.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+
+    for repo in &model.repositories {
+        msg.push_str(&format!("## {} (slug: {})\n", repo.name, repo.slug));
+        if let Some(m) = &repo.metrics {
+            if m.loc.total > 0 {
+                msg.push_str(&format!("- Total LoC: {}\n", m.loc.total));
+            }
+            let langs = m.primary_languages(4);
+            if !langs.is_empty() {
+                msg.push_str(&format!("- Primary languages: {}\n", langs.join(", ")));
+            }
+            msg.push_str(&format!(
+                "- Files: {}; Functions: {}\n",
+                m.counts.files, m.counts.functions
+            ));
+
+            // NO-GREEN RULE (structural): only RED/AMBER findings reach the model.
+            let actionable: Vec<_> = m
+                .findings
+                .iter()
+                .filter(|f| f.severity != Severity::Green)
+                .collect();
+            if actionable.is_empty() {
+                msg.push_str("- Findings (RED/AMBER): none\n");
+            } else {
+                msg.push_str("- Findings (RED/AMBER):\n");
+                for f in actionable {
+                    let sev = match f.severity {
+                        Severity::Red => "RED",
+                        Severity::Amber => "AMBER",
+                        Severity::Green => unreachable!("greens filtered above"),
+                    };
+                    msg.push_str(&format!(
+                        "  - [{sev}] {} (category: {}, component: {})\n",
+                        f.title, f.category, f.component
+                    ));
+                }
+            }
+        } else {
+            msg.push_str("- No metrics available for this application.\n");
+        }
+        msg.push('\n');
+    }
+
+    msg.push_str(
+        "Synthesise the narrative sections from the data above, obeying every rule in the system prompt.\n",
+    );
+    msg
+}

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -1,0 +1,426 @@
+//! Tests for report M2 synthesis (#2314).
+//!
+//! Why: extracted from `synthesize.rs` to keep that file under the 500-line cap.
+//! What: covers the numeric guardrail primitives, the fail-closed paths
+//! (provider error, malformed JSON, timeout, truncation), happy-path injection,
+//! guardrail rejection of a fabricated figure, the structural greens exclusion,
+//! and the forced-output JSON schema shape.  No live LLM calls.
+//! Test: included as `#[cfg(test)] mod tests` from `synthesize.rs`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
+use crate::report::metrics::{
+    AnalyzeMetrics, CountMetrics, LanguageLoc, LocMetrics, MetricFinding, Severity,
+};
+use crate::report::model::{ReportModel, RepositoryReport};
+use crate::report::synthesize_guard::{allowed_numbers, numbers_in, verify_prose};
+use crate::report::synthesize_prompt::{build_synthesis_prompt, synthesis_schema};
+
+use super::{Synthesis, SynthesisStatus, Synthesizer};
+
+// ── Stub providers ──────────────────────────────────────────────────────────
+
+/// Returns a fixed body with an optional `finish_reason`.
+struct FixedLlm {
+    body: String,
+    finish_reason: Option<String>,
+}
+
+#[async_trait]
+impl LlmProvider for FixedLlm {
+    fn name(&self) -> &str {
+        "fixed"
+    }
+    async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        Ok(LlmResponse {
+            text: self.body.clone(),
+            model: "stub".to_string(),
+            input_tokens: 100,
+            output_tokens: 80,
+            latency_ms: 5,
+            cost_usd: 0.0001,
+            finish_reason: self.finish_reason.clone(),
+        })
+    }
+}
+
+struct ErrorLlm;
+
+#[async_trait]
+impl LlmProvider for ErrorLlm {
+    fn name(&self) -> &str {
+        "error"
+    }
+    async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        Err(LlmError::Transport("connection refused".to_string()))
+    }
+}
+
+struct SleepLlm;
+
+#[async_trait]
+impl LlmProvider for SleepLlm {
+    fn name(&self) -> &str {
+        "sleep"
+    }
+    async fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        unreachable!("timeout should fire first")
+    }
+}
+
+// ── Model fixture ───────────────────────────────────────────────────────────
+
+/// Build a one-repo model: 8200 LoC, 120 files, 640 functions, and the given
+/// findings.  Numbers 8200/120/640 are the guardrail's allowed figures.
+fn fixture_model(findings: Vec<MetricFinding>) -> ReportModel {
+    let metrics = AnalyzeMetrics {
+        loc: LocMetrics {
+            total: 8200,
+            by_language: vec![LanguageLoc {
+                language: "Rust".to_string(),
+                loc: 8200,
+            }],
+        },
+        counts: CountMetrics {
+            files: 120,
+            functions: 640,
+        },
+        findings,
+        ..Default::default()
+    };
+    ReportModel {
+        title: "Acme Technical DD".to_string(),
+        template: "report-technical-dd".to_string(),
+        analyst: Some("bobmatnyc".to_string()),
+        report_date: "2026-07-10".to_string(),
+        generated_date: "2026-07-10".to_string(),
+        manifest_path: "manifest.toml".to_string(),
+        repositories: vec![RepositoryReport {
+            name: "Acme Core".to_string(),
+            slug: "acme-core".to_string(),
+            source: "local".to_string(),
+            source_kind: "local_path".to_string(),
+            username: None,
+            git_ref: None,
+            git_info: None,
+            metrics: Some(metrics),
+        }],
+        synthesis: None,
+    }
+}
+
+fn red(title: &str) -> MetricFinding {
+    MetricFinding {
+        title: title.to_string(),
+        severity: Severity::Red,
+        category: "security".to_string(),
+        component: "auth".to_string(),
+    }
+}
+
+fn green(title: &str) -> MetricFinding {
+    MetricFinding {
+        title: title.to_string(),
+        severity: Severity::Green,
+        category: "maintainability".to_string(),
+        component: "core".to_string(),
+    }
+}
+
+// ── Guardrail primitives ────────────────────────────────────────────────────
+
+/// Why: the guardrail must treat formatting variants of the same magnitude as
+/// equal, or it would reject faithful restatements.
+/// What: checks comma, `$`, `%`, and trailing-zero-decimal normalisation.
+/// Test: this test itself.
+#[test]
+fn numbers_in_extracts_and_canonicalises() {
+    assert_eq!(numbers_in("8,200 LoC"), vec!["8200"]);
+    assert_eq!(numbers_in("$1,000 cost"), vec!["1000"]);
+    assert_eq!(numbers_in("50% covered"), vec!["50"]);
+    assert_eq!(numbers_in("value 8200.0 here"), vec!["8200"]);
+    assert_eq!(numbers_in("score 3.50"), vec!["3.5"]);
+    assert!(numbers_in("no digits here").is_empty());
+}
+
+/// Why: the allowed set is the guardrail's ground truth, derived from the
+/// deterministic model.
+/// What: asserts the metric figures are present and a fabricated one is not.
+/// Test: this test itself.
+#[test]
+fn allowed_numbers_covers_metrics() {
+    let model = fixture_model(vec![]);
+    let allowed = allowed_numbers(&serde_json::to_value(&model).unwrap());
+    assert!(allowed.contains("8200"), "LoC total must be allowed");
+    assert!(allowed.contains("120"), "file count must be allowed");
+    assert!(allowed.contains("640"), "function count must be allowed");
+    assert!(
+        !allowed.contains("9999"),
+        "fabricated figure must be absent"
+    );
+}
+
+/// Why: faithful prose passes; fabricated prose is rejected with the offending
+/// token surfaced.
+/// What: verifies a clean string and rejects one citing 9999.
+/// Test: this test itself.
+#[test]
+fn verify_prose_passes_and_rejects() {
+    let model = fixture_model(vec![]);
+    let allowed = allowed_numbers(&serde_json::to_value(&model).unwrap());
+    assert!(verify_prose("The 8,200 LoC codebase has 120 files.", &allowed).is_ok());
+    assert!(verify_prose("No numbers at all.", &allowed).is_ok());
+    assert_eq!(
+        verify_prose("Coverage is 9999 percent.", &allowed),
+        Err("9999".to_string())
+    );
+}
+
+// ── Prompt / schema ─────────────────────────────────────────────────────────
+
+/// Why: the no-green-analysis rule must be STRUCTURAL — greens never reach the
+/// model, so it cannot elaborate them.
+/// What: builds the prompt for a model with a red and a green finding; asserts
+/// the digest contains the red title but not the green one.
+/// Test: this test itself.
+#[test]
+fn prompt_excludes_greens() {
+    let model = fixture_model(vec![red("SQL injection risk"), green("GREEN_SECRET_TOPIC")]);
+    let req = build_synthesis_prompt(&model, "stub/model");
+    let digest = &req.messages[0].content;
+    assert!(
+        digest.contains("SQL injection risk"),
+        "RED finding must be present in the digest"
+    );
+    assert!(
+        !digest.contains("GREEN_SECRET_TOPIC"),
+        "GREEN finding must NEVER reach the model (structural exclusion)"
+    );
+}
+
+/// Why: a routing prefix must be stripped so the bare id reaches the provider.
+/// What: asserts `bedrock/` and `openrouter/` are stripped from `req.model`.
+/// Test: this test itself.
+#[test]
+fn prompt_strips_prefix() {
+    let model = fixture_model(vec![]);
+    let req = build_synthesis_prompt(&model, "bedrock/us.anthropic.claude-sonnet-4-6");
+    assert_eq!(req.model, "us.anthropic.claude-sonnet-4-6");
+    let req2 = build_synthesis_prompt(&model, "openrouter/openai/gpt-5.4-mini");
+    assert_eq!(req2.model, "openai/gpt-5.4-mini");
+}
+
+/// Why: forced structured output requires a well-formed schema.
+/// What: asserts the schema name and the three top-level narrative properties.
+/// Test: this test itself.
+#[test]
+fn synthesis_schema_shape() {
+    let schema = synthesis_schema();
+    assert_eq!(schema.name, "report_synthesis");
+    let props = &schema.schema["properties"];
+    assert!(props["executive_summary"].is_object());
+    assert!(props["top_risks"].is_object());
+    assert!(props["findings"].is_object());
+    let req = build_synthesis_prompt(&fixture_model(vec![]), "stub/model");
+    assert!(
+        req.response_schema.is_some(),
+        "every synthesis request must force structured output"
+    );
+}
+
+// ── Synthesize: happy path + fail-closed paths ──────────────────────────────
+
+fn good_response() -> String {
+    // Every figure (8200, 120, 640) is present in the fixture model.
+    r#"{
+      "executive_summary": "The 8,200 LoC Rust codebase spans 120 files and 640 functions with one critical security gap.",
+      "top_risks": [
+        {"description": "Unauthenticated admin route", "severity": "RED", "cost": "high", "apps": "Acme Core"}
+      ],
+      "findings": [
+        {"app_slug": "acme-core", "title": "SQL injection risk", "severity": "RED",
+         "description": "Raw query concatenation in the auth path.",
+         "evidence": "Observed in the auth handler.", "component": "auth",
+         "business_impact": "Potential data exfiltration.",
+         "remediation": "Parameterise queries.", "cost_effort": "moderate"}
+      ]
+    }"#
+    .to_string()
+}
+
+/// Why: verified prose must be injected and the status marked available.
+/// What: runs synthesize with a clean response; asserts exec/risks/findings and
+/// status Available.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_happy_path_injects() {
+    let model = fixture_model(vec![red("SQL injection risk")]);
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: good_response(),
+        finish_reason: Some("stop".to_string()),
+    });
+    let result = Synthesizer::new(llm, "stub/model").synthesize(&model).await;
+
+    assert_eq!(result.status, SynthesisStatus::Available);
+    assert!(result.executive_summary.is_some());
+    assert_eq!(result.top_risks.len(), 1);
+    assert_eq!(result.findings.len(), 1);
+    assert_eq!(result.findings[0].app_slug, "acme-core");
+    assert!(result.notes.is_empty(), "clean response records no notes");
+}
+
+/// Why: a malformed response must never be partial-trusted.
+/// What: returns non-JSON; asserts Unavailable("unparseable response").
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_malformed_json_fails_closed() {
+    let model = fixture_model(vec![red("x")]);
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: "this is not json at all {{{".to_string(),
+        finish_reason: Some("stop".to_string()),
+    });
+    let result = Synthesizer::new(llm, "stub/model").synthesize(&model).await;
+    assert_eq!(
+        result.status,
+        SynthesisStatus::Unavailable("unparseable response".to_string())
+    );
+    assert!(result.executive_summary.is_none());
+    assert!(result.findings.is_empty());
+}
+
+/// Why: provider errors fail closed to the deterministic output.
+/// What: uses ErrorLlm; asserts Unavailable with a provider-error reason.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_provider_error_fails_closed() {
+    let model = fixture_model(vec![red("x")]);
+    let llm: Arc<dyn LlmProvider> = Arc::new(ErrorLlm);
+    let result = Synthesizer::new(llm, "stub/model").synthesize(&model).await;
+    match result.status {
+        SynthesisStatus::Unavailable(reason) => assert!(reason.contains("provider error")),
+        other => panic!("expected Unavailable, got {other:?}"),
+    }
+}
+
+/// Why: a truncated response is incomplete and must fail closed.
+/// What: returns a valid body but `finish_reason = "length"`; asserts
+/// Unavailable("truncated response").
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_truncation_fails_closed() {
+    let model = fixture_model(vec![red("x")]);
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: good_response(),
+        finish_reason: Some("length".to_string()),
+    });
+    let result = Synthesizer::new(llm, "stub/model").synthesize(&model).await;
+    assert_eq!(
+        result.status,
+        SynthesisStatus::Unavailable("truncated response".to_string())
+    );
+}
+
+/// Why: a timeout must fail closed rather than hang the report.
+/// What: uses a 30s-sleeping provider with a 10ms timeout; asserts
+/// Unavailable("provider timeout").
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_timeout_fails_closed() {
+    let model = fixture_model(vec![red("x")]);
+    let llm: Arc<dyn LlmProvider> = Arc::new(SleepLlm);
+    let result = Synthesizer::new(llm, "stub/model")
+        .with_timeout(Duration::from_millis(10))
+        .synthesize(&model)
+        .await;
+    assert_eq!(
+        result.status,
+        SynthesisStatus::Unavailable("provider timeout".to_string())
+    );
+}
+
+/// Why: the numeric guardrail must drop any field citing a figure not in source.
+/// What: exec summary cites 9999 (rejected); the finding is clean (kept).
+/// Asserts exec is dropped with a `rejected (unverified figure)` note while the
+/// finding survives, and the overall status is still Available.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_rejects_unverified_figure() {
+    let model = fixture_model(vec![red("SQL injection risk")]);
+    let body = r#"{
+      "executive_summary": "Coverage sits at 9999 percent across the estate.",
+      "top_risks": [],
+      "findings": [
+        {"app_slug": "acme-core", "title": "SQL injection risk", "severity": "RED",
+         "description": "Raw query concatenation.", "evidence": "one path",
+         "component": "auth", "business_impact": "data loss",
+         "remediation": "parameterise", "cost_effort": "moderate"}
+      ]
+    }"#;
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: body.to_string(),
+        finish_reason: Some("stop".to_string()),
+    });
+    let result = Synthesizer::new(llm, "stub/model").synthesize(&model).await;
+
+    assert_eq!(result.status, SynthesisStatus::Available);
+    assert!(
+        result.executive_summary.is_none(),
+        "exec summary citing 9999 must be rejected"
+    );
+    assert_eq!(result.findings.len(), 1, "clean finding must survive");
+    assert!(
+        result
+            .notes
+            .iter()
+            .any(|n| n.contains("rejected (unverified figure)") && n.contains("9999")),
+        "a guardrail rejection note must be recorded: {:?}",
+        result.notes
+    );
+}
+
+/// Why: when nothing survives verification the whole attempt is unavailable.
+/// What: every field cites 9999; asserts Unavailable("no verifiable content").
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_all_rejected_is_unavailable() {
+    let model = fixture_model(vec![]);
+    let body = r#"{
+      "executive_summary": "Exactly 9999 issues.",
+      "top_risks": [{"description": "risk 7777", "severity": "RED", "cost": "low", "apps": "Acme Core"}],
+      "findings": []
+    }"#;
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: body.to_string(),
+        finish_reason: None,
+    });
+    let result = Synthesizer::new(llm, "stub/model").synthesize(&model).await;
+    assert_eq!(
+        result.status,
+        SynthesisStatus::Unavailable("no verifiable content".to_string())
+    );
+    assert_eq!(result.notes.len(), 2, "both rejections recorded");
+}
+
+/// Why: the status note must carry the exact `synthesis:` banners the report and
+/// its readers key on.
+/// What: asserts the available and unavailable banner strings.
+/// Test: this test itself.
+#[test]
+fn status_lines_render_banners() {
+    let avail = Synthesis {
+        status: SynthesisStatus::Available,
+        ..Default::default()
+    };
+    assert_eq!(avail.status_lines()[0], "synthesis: available");
+
+    let unavail = Synthesis::unavailable("provider timeout");
+    assert_eq!(
+        unavail.status_lines()[0],
+        "synthesis: unavailable (provider timeout)"
+    );
+}

--- a/docs/trusty-review/spec/report-generation.md
+++ b/docs/trusty-review/spec/report-generation.md
@@ -78,7 +78,7 @@
 | Phase | Deliverable | Effort | Status |
 |---|---|---|---|
 | **M1** | Deterministic, manifest-driven fill (metrics → tables) from trusty-analyze output; no LLM synthesis | Manifest loader + validation; git enrichment; v0 metrics schema; template loader; placeholder fill engine; `report` subcommand | **Landed (#2313)** — `src/report/`, `report` Cargo feature (default-on), `trusty-review report --manifest` |
-| **M2** | LLM synthesis of exec summary + findings prose (RED/AMBER descriptive narratives) | Plug LLM backend (OpenRouter or Bedrock); implement synthesizer; validate output quality | Not started |
+| **M2** | LLM synthesis of exec summary + findings prose (RED/AMBER descriptive narratives) | Plug LLM backend (OpenRouter or Bedrock); implement synthesizer; validate output quality | **Landed (#2314)** — `src/report/synthesize*.rs`, opt-in `--synthesize` flag, fail-closed + numeric guardrail (see [Synthesis (M2)](#synthesis-m2)) |
 | **M3** | Cross-repo benchmarking (percentile ranks, quartile placement like CAST Appmarq) | Maintain corpus of analyzed repos; compute percentile functions; wire into scorecard section | Not started |
 
 ### Explicit Non-Goals
@@ -102,7 +102,7 @@ names the target repositories and their sources; the earlier `--repo` flag is
 replaced by `--manifest`.
 
 ```bash
-trusty-review report --manifest <file> [--template <name>] [--out <dir>]
+trusty-review report --manifest <file> [--template <name>] [--out <dir>] [--synthesize]
   --manifest <file>   Path to the report manifest TOML (required)
   --template <name>   Template override, e.g. report-technical-dd or
                       report-technical-dd-cast. Precedence:
@@ -110,6 +110,10 @@ trusty-review report --manifest <file> [--template <name>] [--out <dir>]
                       (report-technical-dd)
   --out <dir>         Output directory for the generated report pair
                       (default: ./reports)
+  --synthesize        Opt in to M2 LLM synthesis of the narrative sections
+                      (default OFF — deterministic M1 output). Spends LLM
+                      tokens; fails closed to deterministic output on any
+                      provider/parse/guardrail failure. See "Synthesis (M2)".
 ```
 
 Output is always the dual `{date}-{title-slug}.md` + `.json` pair written
@@ -222,6 +226,65 @@ the template needs but the metrics omit falls through to the honesty marker.
 `severity` is one of `red` / `amber` / `green` (unknown/absent → `green`).
 Scoring, health-factor, and benchmark placeholders have no deterministic M1
 source and therefore render as `not stated in source data` until M2/M3 land.
+
+## Synthesis (M2)
+
+M2 layers **opt-in** LLM prose on top of the M1 deterministic fill. It is OFF by
+default: without `--synthesize` the report is byte-for-byte the deterministic M1
+output. Synthesis is opt-in because it spends LLM tokens. It reuses the crate's
+existing provider layer (`src/llm/` — OpenRouter or Bedrock, selected from the
+**reviewer** role config exactly as the review pipeline does); it adds no new LLM
+client or dependency.
+
+### What the LLM writes — and does not
+
+The synthesizer produces **only** the narrative fields M1 leaves as honesty
+markers:
+
+- `{{executive_summary_paragraph}}` — one deal-analytic paragraph.
+- The **Top Risks** table rows (`{{risk_N_description}}` / `_severity` / `_cost`
+  / `_apps`).
+- Per-**RED/AMBER** finding elaboration (`per_application_red` / `_amber` blocks:
+  finding, evidence, affected component, business impact, remediation, cost/effort).
+
+**GREEN findings are never synthesized.** The no-green-analysis rule is enforced
+**structurally**, not by prompt text: the prompt digest (`synthesize_prompt.rs`)
+filters `severity == Green` out before the data ever reaches the model, so the
+LLM cannot elaborate a green even if asked. Greens remain the M1 one-line topic list.
+
+### JSON contract
+
+The provider is forced into structured output via `ResponseSchema`
+(`report_synthesis`): a top-level object with `executive_summary` (string),
+`top_risks` (array of `{description, severity, cost, apps}`), and `findings`
+(array of `{app_slug, title, severity, description, evidence, component,
+business_impact, remediation, cost_effort}`). Each finding carries its `app_slug`
+and `severity` so the reporter routes prose back to the correct application
+section and band. The system prompt mandates: use ONLY provided values, never
+invent numbers, preserve any `(approx)` marker verbatim, RED/AMBER only.
+
+### Fail-closed posture (mirrors `Verdict::Unknown`)
+
+Any failure keeps the deterministic honesty-marker output for the affected fields
+and records a **visible** `synthesis: unavailable (<reason>)` note in the rendered
+report's *Synthesis Status* section (and on the JSON twin's `synthesis` object). A
+malformed or incomplete response is never partial-trusted. Fail-closed reasons:
+`provider timeout` (120 s ceiling), `provider error: …`, `truncated response`
+(`finish_reason = length`), `unparseable response`, and `no verifiable content`.
+
+### Numeric guardrail
+
+After the model returns, a deterministic post-check (`synthesize_guard.rs`)
+verifies that **every number** (digit sequence) appearing in each synthesized
+field exists in the source `ReportModel` data. The allowed set is computed from
+the serialized deterministic model, so it captures every metric, count, LoC
+total, and date the report is derived from. Matching tolerates formatting
+variants — thousands separators (`8,200` = `8200`), `$`, `%`, and trailing-zero
+decimals (`8200.0` = `8200`, `3.50` = `3.5`). Any field citing an unverifiable
+figure is **rejected**: it falls back to the deterministic output and a
+`synthesis: rejected (unverified figure)` note is recorded. This is the
+report-side analogue of the crate's verdict-integrity posture — the guardrail,
+not the prompt, is the last line of defence against a fabricated figure.
 
 ## References & Related Docs
 


### PR DESCRIPTION
## Summary

Layers opt-in `--synthesize` on the deterministic M1 report generation (#2317). LLM (existing reviewer-role provider layer, no new deps) synthesizes exec summary + top-risk rationale + RED/AMBER finding prose via structured output (`report_synthesis` schema). Safety properties: greens structurally excluded before the request is built (never sent to the model); fail-closed on provider error/timeout/truncation/unparseable JSON → deterministic output stands with a visible `synthesis: unavailable (<reason>)` note (mirrors the Verdict::Unknown posture); numeric guardrail rejects any synthesized field citing a figure not present in source data (formatting-variant aware). M1 output is byte-identical when the flag is off.

Gate evidence: cargo build workspace OK; trusty-review tests 1156 passed/0 failed; full workspace tests 0 failed; crate AND workspace clippy clean (exit 0); fmt clean; line-cap 0 violations.

New files: src/report/synthesize{,_prompt,_guard,_tests}.rs; modified: report/mod.rs, model.rs, reporter.rs, reporter_tests.rs, cli_report.rs, spec doc.

Part of #2314

🤖 Generated with [Claude Code](https://claude.com/claude-code)