### PR TITLE
fix(trusty-code): derive compaction threshold from model context window (closes #2308)

### DIFF
--- a/crates/trusty-code/src/agent_loop/compaction.rs
+++ b/crates/trusty-code/src/agent_loop/compaction.rs
@@ -11,7 +11,9 @@
 //! `compacted` flags) can stay focused on state management. Splitting the
 //! policy (when / what to say) from the mechanism (marking entries, replaying
 //! the last user turn) keeps both halves independently testable.
-//! What: [`CompactionConfig`] (the tunable threshold + active-zone size),
+//! What: [`CompactionConfig`] (the tunable threshold + active-zone size —
+//! production code builds one via [`CompactionConfig::for_context_window`],
+//! #2308, rather than the legacy flat [`Default`] impl),
 //! [`estimate_tokens`] (a cheap chars/4 heuristic — no tokenizer dependency),
 //! [`should_compact`] (threshold check), and [`summarize_span`] (a
 //! deterministic one-line summary of a compacted message span, built from
@@ -41,11 +43,65 @@ pub struct CompactionConfig {
     pub keep_last_messages: usize,
 }
 
+/// Percentage of a model's context window at which compaction fires (#2308).
+///
+/// Why: A flat `token_threshold` (the old `6_000` constant) is model-blind —
+/// for a 200K-token Bedrock Claude Sonnet window that is ~3% utilisation,
+/// meaning ordinary coding turns (post-#2261 tool-call-arg counting) blow
+/// through it every couple of turns, destroying working context via
+/// "re-anchor thrash". Scaling the threshold to a fraction of the ACTUAL
+/// resolved context window (see [`crate::provider::resolve_context_window`])
+/// fixes this at the root: compaction now fires only once the transcript is
+/// genuinely close to exhausting the model's real budget. 75% leaves a
+/// generous headroom margin for the completion tokens of the turn that
+/// crosses the threshold, plus the summary/replay overhead compaction itself
+/// introduces.
+/// What: Used by [`CompactionConfig::for_context_window`] as
+/// `context_window * COMPACTION_THRESHOLD_FRACTION_PCT / 100`.
+/// Test: `compaction::tests::for_context_window_scales_threshold_proportionally`.
+pub const COMPACTION_THRESHOLD_FRACTION_PCT: usize = 75;
+
+impl CompactionConfig {
+    /// Derive a `CompactionConfig` proportional to a model's real context
+    /// window (#2308).
+    ///
+    /// Why: This is the production constructor — the flat, model-blind
+    /// `Default` threshold (see that impl's doc) is the root cause of #2308's
+    /// pathological re-compaction. Every production call site that knows its
+    /// model slug must resolve the model's real context window (via
+    /// [`crate::provider::resolve_context_window`]) and build its
+    /// `CompactionConfig` through this constructor instead.
+    /// What: `token_threshold` is `context_window * `
+    /// [`COMPACTION_THRESHOLD_FRACTION_PCT`]` / 100`; `keep_last_messages` is
+    /// unchanged from the previous default (6).
+    /// Test: `compaction::tests::for_context_window_scales_threshold_proportionally`,
+    /// `compaction::tests::should_compact_does_not_trigger_at_10k_tokens_against_200k_window`,
+    /// `compaction::tests::should_compact_triggers_near_75pct_of_200k_window`.
+    pub fn for_context_window(context_window: usize) -> Self {
+        Self {
+            token_threshold: context_window * COMPACTION_THRESHOLD_FRACTION_PCT / 100,
+            keep_last_messages: 6,
+        }
+    }
+}
+
 impl Default for CompactionConfig {
-    /// §5.4 gives no exact numbers; these defaults keep several full
+    /// LEGACY/TEST-ONLY default — a flat, model-blind `6_000`-token threshold.
+    ///
+    /// Why: This was the pre-#2308 production default; the root cause of
+    /// #2308's pathological re-compaction (roughly every 2 turns at
+    /// 4-13K estimated tokens) is exactly this hard-coded constant, which is
+    /// only ~3% of a real Bedrock Claude Sonnet 200K-token context window.
+    /// Kept for back-compat (tests that want a small, deterministic
+    /// threshold without wiring a model slug) but production code must call
+    /// [`CompactionConfig::for_context_window`] instead so the threshold
+    /// scales with the model actually in use.
+    /// What: §5.4 gives no exact numbers; these defaults keep several full
     /// tool-call round-trips (a handful of assistant+tool pairs) uncompacted
     /// while triggering well before a typical model's context window is at
-    /// risk.
+    /// risk — but ONLY for a small/unknown context window; see
+    /// [`CompactionConfig::for_context_window`] for the model-aware
+    /// production path.
     fn default() -> Self {
         Self {
             token_threshold: 6_000,
@@ -293,6 +349,122 @@ mod tests {
         let large = vec![ChatMessage::user("abcdefghijkl")];
         assert!(!should_compact(&small, &cfg));
         assert!(should_compact(&large, &cfg));
+    }
+
+    // ── #2308: model-aware compaction threshold ─────────────────────────────
+
+    /// `for_context_window` scales the threshold proportionally to the
+    /// window size, for both a large (Bedrock-sized) and a small window.
+    ///
+    /// Why: This is the direct regression guard for the fix itself — the
+    /// threshold must track [`COMPACTION_THRESHOLD_FRACTION_PCT`] of
+    /// whatever window is passed in, not a flat constant.
+    /// What: 200,000 -> threshold within the 70-80% band (140,000-160,000);
+    /// 8,000 -> threshold scales down proportionally (5,600-6,400) rather
+    /// than staying pinned at a large absolute number.
+    /// Test: this test.
+    #[test]
+    fn for_context_window_scales_threshold_proportionally() {
+        let large = CompactionConfig::for_context_window(200_000);
+        assert!(
+            (140_000..=160_000).contains(&large.token_threshold),
+            "expected ~75% of 200_000, got {}",
+            large.token_threshold
+        );
+
+        let small = CompactionConfig::for_context_window(8_000);
+        assert!(
+            (5_600..=6_400).contains(&small.token_threshold),
+            "expected ~75% of 8_000, got {}",
+            small.token_threshold
+        );
+    }
+
+    /// The exact #2308 failure case: a ~10K-estimated-token transcript must
+    /// NOT trigger compaction against a 200K-window model's config.
+    ///
+    /// Why: Under the old flat `token_threshold: 6_000` default, a transcript
+    /// this size compacted almost immediately even though it's only ~5% of a
+    /// real 200K-token Bedrock Claude Sonnet window — the exact
+    /// "re-anchor thrash" this issue reports.
+    /// What: Build a transcript whose `estimate_total_tokens` is ~10,000
+    /// (via a single large user message, well within chars/4 rounding) and
+    /// assert `should_compact` is `false` against
+    /// `CompactionConfig::for_context_window(200_000)`.
+    /// Test: this test.
+    #[test]
+    fn should_compact_does_not_trigger_at_10k_tokens_against_200k_window() {
+        // 40_000 chars / 4 == 10_000 estimated tokens.
+        let messages = vec![ChatMessage::user("x".repeat(40_000))];
+        assert_eq!(estimate_total_tokens(&messages), 10_000);
+
+        let cfg = CompactionConfig::for_context_window(200_000);
+        assert!(
+            !should_compact(&messages, &cfg),
+            "a 10K-token transcript must not compact against a 200K-window model"
+        );
+    }
+
+    /// Compaction still fires once a transcript crosses ~75% of a 200K
+    /// window — the fix must not disable compaction outright.
+    ///
+    /// Why: The fix scales the threshold; it must not remove it. A
+    /// transcript genuinely approaching the model's real context limit must
+    /// still trigger compaction.
+    /// What: Build a transcript just over 150,000 estimated tokens and assert
+    /// `should_compact` is `true` against
+    /// `CompactionConfig::for_context_window(200_000)`.
+    /// Test: this test.
+    #[test]
+    fn should_compact_triggers_near_75pct_of_200k_window() {
+        // 601_000 chars / 4 == 150_250 estimated tokens, just over the
+        // 150_000 (75% of 200_000) threshold.
+        let messages = vec![ChatMessage::user("x".repeat(601_000))];
+        let cfg = CompactionConfig::for_context_window(200_000);
+        assert!(
+            should_compact(&messages, &cfg),
+            "a transcript just over 75% of the window must trigger compaction"
+        );
+    }
+
+    /// `estimate_total_tokens` applies the SAME units to content and to
+    /// tool-call arguments — no hidden scaling bug between the two.
+    ///
+    /// Why: Directly guards the "units" invariant the research for #2308
+    /// verified but which this fix must not regress: a content-only message
+    /// and a tool-call-only message of identical string length must produce
+    /// identical estimates.
+    /// What: Build one message with `content: Some(s)` and one with
+    /// `content: None` plus a single tool call whose `arguments` is the same
+    /// string `s`; assert both totals are equal.
+    /// Test: this test.
+    #[test]
+    fn estimate_total_tokens_units_match_between_content_and_tool_args() {
+        use crate::llm::{FunctionCall, ToolCall};
+
+        let s = "y".repeat(1000);
+
+        let content_only = vec![ChatMessage::assistant(s.clone())];
+        let tool_call_only = vec![ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".into(),
+                kind: "function".into(),
+                function: FunctionCall {
+                    name: "write_file".into(),
+                    arguments: s.clone(),
+                },
+            }]),
+            tool_call_id: None,
+            name: None,
+            cache_control: None,
+        }];
+
+        assert_eq!(
+            estimate_total_tokens(&content_only),
+            estimate_total_tokens(&tool_call_only)
+        );
     }
 
     #[test]

--- a/crates/trusty-code/src/agent_loop/transcript.rs
+++ b/crates/trusty-code/src/agent_loop/transcript.rs
@@ -563,6 +563,45 @@ mod tests {
         assert_eq!(raw.len(), 2 + 20);
     }
 
+    /// Once `maybe_compact` fires, `estimate_total_tokens` over the
+    /// resulting `to_messages()` view is strictly smaller than the pre-fire
+    /// estimate (#2308).
+    ///
+    /// Why: Research for #2308 verified this reset bookkeeping is NOT the
+    /// bug (no feedback-loop regression) — this test locks that invariant in
+    /// as a regression guard alongside the model-aware threshold fix, so a
+    /// future change can't silently reintroduce a "compaction never actually
+    /// shrinks the estimate" bug.
+    /// What: Build a transcript with several sizeable assistant/tool turns,
+    /// force one compaction with a low threshold, and assert the post-fire
+    /// `estimate_total_tokens(&t.to_messages())` is strictly less than the
+    /// pre-fire estimate over the same view.
+    /// Test: this test.
+    #[test]
+    fn maybe_compact_estimate_drops_after_compaction_fires() {
+        use super::super::compaction::estimate_total_tokens;
+
+        let mut t = Transcript::seed("s", "task");
+        for i in 0..10 {
+            t.push_assistant(Some(format!("assistant turn {i}: {}", "x".repeat(200))), &[]);
+            t.push_tool_result(&format!("c{i}"), "bash", &"output ".repeat(50));
+        }
+
+        let cfg = CompactionConfig {
+            token_threshold: 1,
+            keep_last_messages: 2,
+        };
+
+        let pre_fire_estimate = estimate_total_tokens(&t.to_messages());
+        assert!(t.maybe_compact(&cfg));
+        let post_fire_estimate = estimate_total_tokens(&t.to_messages());
+
+        assert!(
+            post_fire_estimate < pre_fire_estimate,
+            "expected estimate to drop after compaction: pre={pre_fire_estimate} post={post_fire_estimate}"
+        );
+    }
+
     /// Assert every `tool` entry in a `to_messages()` view has its issuing
     /// assistant `tool_calls` entry present in the SAME view, and every
     /// assistant `tool_calls` entry has all its answers present too.

--- a/crates/trusty-code/src/agent_loop/transcript.rs
+++ b/crates/trusty-code/src/agent_loop/transcript.rs
@@ -583,7 +583,10 @@ mod tests {
 
         let mut t = Transcript::seed("s", "task");
         for i in 0..10 {
-            t.push_assistant(Some(format!("assistant turn {i}: {}", "x".repeat(200))), &[]);
+            t.push_assistant(
+                Some(format!("assistant turn {i}: {}", "x".repeat(200))),
+                &[],
+            );
             t.push_tool_result(&format!("c{i}"), "bash", &"output ".repeat(50));
         }
 

--- a/crates/trusty-code/src/provider/mod.rs
+++ b/crates/trusty-code/src/provider/mod.rs
@@ -11,7 +11,9 @@
 //! its [`DEFAULT_MODEL`] constant, the [`resolve_max_tokens`] precedence
 //! function plus its [`DEFAULT_MAX_TOKENS`] constant, and (#2207) the
 //! [`resolve_deadline_secs`] precedence function plus its
-//! [`DEFAULT_RUN_DEADLINE_SECS`] constant and [`RUN_DEADLINE_ENV_VAR`] name.
+//! [`DEFAULT_RUN_DEADLINE_SECS`] constant and [`RUN_DEADLINE_ENV_VAR`] name,
+//! and (#2308) the [`resolve_context_window`] precedence function plus its
+//! [`DEFAULT_CONTEXT_WINDOW`] constant.
 //! Test: submodule `tests` in each file; routing/adapter coverage in
 //! `routing.rs` and `adapter.rs`.
 
@@ -25,7 +27,8 @@ pub use adapter::provider_for;
 pub use bedrock::BedrockProvider;
 pub use openrouter::OpenRouterProvider;
 pub use routing::{
-    DEFAULT_MAX_TOKENS, DEFAULT_MODEL, DEFAULT_RUN_DEADLINE_SECS, RUN_DEADLINE_ENV_VAR,
-    resolve_deadline_secs, resolve_max_tokens, resolve_model,
+    DEFAULT_CONTEXT_WINDOW, DEFAULT_MAX_TOKENS, DEFAULT_MODEL, DEFAULT_RUN_DEADLINE_SECS,
+    RUN_DEADLINE_ENV_VAR, resolve_context_window, resolve_deadline_secs, resolve_max_tokens,
+    resolve_model,
 };
 pub use traits::{Provider, ToolChoice};

--- a/crates/trusty-code/src/provider/routing.rs
+++ b/crates/trusty-code/src/provider/routing.rs
@@ -125,6 +125,49 @@ pub fn resolve_model(agent_config: &AgentConfig, run_context: Option<&RunContext
     DEFAULT_MODEL.to_string()
 }
 
+/// Fallback context-window size (in tokens) for a model slug this resolver
+/// does not recognise.
+///
+/// Why: [`resolve_context_window`] must always return a usable number even
+/// for an unlisted/unknown slug (a new provider, a typo'd override, etc.) —
+/// 128,000 is a conservative, widely-supported floor shared by several
+/// mainstream hosted models (e.g. `gpt-4o`), so an unknown model is treated
+/// no more generously than that.
+/// What: The fallback tier of [`resolve_context_window`].
+/// Test: `routing::tests::resolve_context_window_falls_back_to_default_for_unknown_model`.
+pub const DEFAULT_CONTEXT_WINDOW: usize = 128_000;
+
+/// Resolve the real context-window size (in tokens) for a model slug.
+///
+/// Why: #2308 — `CompactionConfig::default()`'s flat `token_threshold: 6_000`
+/// is model-blind: ~3% of Bedrock Claude Sonnet's real 200K-token window, so
+/// ordinary coding turns (post-#2261 tool-call-arg counting) blow through it
+/// constantly and trigger pathological re-compaction. Compaction must instead
+/// scale with the model actually in use, which means a resolver is needed
+/// alongside [`resolve_model`] to turn a slug into a window size before
+/// [`crate::agent_loop::CompactionConfig::for_context_window`] can compute a
+/// proportional threshold.
+/// What: A minimal substring/format table, checked in order: (1) any slug
+/// containing `claude-sonnet` or `claude-opus` (covers both the bare
+/// Anthropic slug and the Bedrock-routed
+/// `bedrock/us.anthropic.claude-sonnet-4-6` / `-opus-*` inference-profile
+/// format, see `crate::llm::bedrock::bedrock_model_id`) -> 200,000; (2) any
+/// slug containing `gpt-4o` -> 128,000; else (3) [`DEFAULT_CONTEXT_WINDOW`].
+/// Deliberately NOT a config file or per-agent override — the window size is
+/// a property of the model itself, not something an operator should need to
+/// tune per project.
+/// Test: `routing::tests::resolve_context_window_maps_bedrock_sonnet_to_200k`,
+/// `routing::tests::resolve_context_window_falls_back_to_default_for_unknown_model`.
+pub fn resolve_context_window(model: &str) -> usize {
+    if model.contains("claude-sonnet") || model.contains("claude-opus") {
+        200_000
+    } else if model.contains("gpt-4o") {
+        128_000
+    } else {
+        DEFAULT_CONTEXT_WINDOW
+    }
+}
+
 /// Resolve the per-turn completion-token cap for an invocation.
 ///
 /// Why: `[llm].max_tokens` is how an operator declares that an agent's turns
@@ -332,6 +375,45 @@ mod tests {
     fn resolve_max_tokens_falls_back_to_default() {
         let config = AgentConfig::default();
         assert_eq!(resolve_max_tokens(&config), DEFAULT_MAX_TOKENS);
+    }
+
+    // ── #2308: resolve_context_window ───────────────────────────────────────
+
+    /// The real Bedrock-routed Claude Sonnet slug maps to a 200K window.
+    ///
+    /// Why: This is the exact model whose flat 6,000-token compaction
+    /// threshold (#2308) was ~3% of its real context window; the resolver
+    /// must recognise the SAME slug format `resolve_model`/the Bedrock
+    /// dispatch layer actually produce
+    /// (`bedrock/us.anthropic.claude-sonnet-4-6`, see
+    /// `crate::llm::bedrock::bedrock_model_id`'s doctests), not just a bare
+    /// `claude-sonnet-*` slug.
+    /// What: Assert the real Bedrock dispatch slug resolves to 200,000.
+    /// Test: this test.
+    #[test]
+    fn resolve_context_window_maps_bedrock_sonnet_to_200k() {
+        assert_eq!(
+            resolve_context_window("bedrock/us.anthropic.claude-sonnet-4-6"),
+            200_000
+        );
+        assert_eq!(
+            resolve_context_window("bedrock/us.anthropic.claude-opus-4-6"),
+            200_000
+        );
+    }
+
+    /// An unrecognised model slug falls back to [`DEFAULT_CONTEXT_WINDOW`].
+    ///
+    /// Why: A resolver that panics or silently returns 0 on an unknown slug
+    /// would break every downstream compaction-threshold calculation.
+    /// What: Assert an arbitrary/unknown slug resolves to the default.
+    /// Test: this test.
+    #[test]
+    fn resolve_context_window_falls_back_to_default_for_unknown_model() {
+        assert_eq!(
+            resolve_context_window("some-vendor/unheard-of-model-v1"),
+            DEFAULT_CONTEXT_WINDOW
+        );
     }
 
     // ── #2207: resolve_deadline_secs precedence ─────────────────────────────

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -28,12 +28,14 @@ use std::time::Duration;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::agent_loop::{AgentLoop, AgentLoopConfig, AgentLoopError};
+use crate::agent_loop::{AgentLoop, AgentLoopConfig, AgentLoopError, CompactionConfig};
 use crate::agents::AgentConfig;
 use crate::llm::{DebugCaptureSink, LlmClientTrait, wrap_with_debug_capture};
 use crate::project_context::load_project_context;
 use crate::prompt::assemble_system_prompt;
-use crate::provider::{resolve_deadline_secs, resolve_max_tokens, resolve_model};
+use crate::provider::{
+    resolve_context_window, resolve_deadline_secs, resolve_max_tokens, resolve_model,
+};
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
 use crate::tools::{
     AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, FinishTaskTool,
@@ -200,6 +202,11 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
             model: pm_model.clone(),
             max_tokens: resolve_max_tokens(&pm_config),
             timeout_secs: deadline_secs,
+            // #2308: model-aware compaction threshold — see
+            // `CompactionConfig::for_context_window`'s doc for why the
+            // struct-update `..AgentLoopConfig::default()` below must not be
+            // allowed to silently supply the flat, model-blind default here.
+            compaction: CompactionConfig::for_context_window(resolve_context_window(&pm_model)),
             ..AgentLoopConfig::default()
         },
         pm_llm,

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -31,7 +31,7 @@ use crate::agents::AgentConfig;
 use crate::llm::LlmClientTrait;
 use crate::mode::HarnessMode;
 use crate::prompt::assemble_system_prompt_for_mode;
-use crate::provider::{resolve_max_tokens, resolve_model};
+use crate::provider::{resolve_context_window, resolve_max_tokens, resolve_model};
 use crate::runner::error::RunnerError;
 use crate::tools::{AgentOutput, AgentRunner, RunContext, ToolRegistry};
 
@@ -349,13 +349,21 @@ impl InProcessAgentRunner {
         // sub-agent turn was silently capped at the agent-loop default.
         let max_tokens = resolve_max_tokens(&agent);
 
+        // #2308: derive the compaction threshold from this agent's ACTUAL
+        // resolved context window rather than the flat, model-blind
+        // `CompactionConfig::default()` — see that impl's doc for the root
+        // cause (a 6_000-token threshold is ~3% of a real 200K-token Bedrock
+        // Claude Sonnet window).
+        let compaction =
+            crate::agent_loop::CompactionConfig::for_context_window(resolve_context_window(&model));
+
         let loop_config = AgentLoopConfig {
             max_turns,
             timeout_secs: self.config.timeout_secs,
             model,
             max_tokens,
             mode: self.mode,
-            compaction: crate::agent_loop::CompactionConfig::default(),
+            compaction,
         };
 
         // Assemble the mode-branched system prompt (BASE + agent prompt +

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -37,14 +37,16 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
-use crate::agent_loop::{AgentLoop, AgentLoopConfig, ToolEventSink};
+use crate::agent_loop::{AgentLoop, AgentLoopConfig, CompactionConfig, ToolEventSink};
 use crate::agents::AgentConfig;
 use crate::jsonrpc::RpcError;
 use crate::llm::{DebugCaptureSink, LlmClientTrait, wrap_with_debug_capture};
 use crate::mode::HarnessMode;
 use crate::project_context::load_project_context;
 use crate::prompt::assemble_system_prompt_for_mode;
-use crate::provider::{resolve_deadline_secs, resolve_max_tokens, resolve_model};
+use crate::provider::{
+    resolve_context_window, resolve_deadline_secs, resolve_max_tokens, resolve_model,
+};
 use crate::run_task::{
     RecordingLlmClient, SharedTranscript, aggregate_usage_per_role, resolve_agent_model_slug,
 };
@@ -225,6 +227,11 @@ async fn run_and_record(
             max_tokens: resolve_max_tokens(&pm_config),
             mode: params.mode,
             timeout_secs: deadline_secs,
+            // #2308: model-aware compaction threshold — see
+            // `CompactionConfig::for_context_window`'s doc for why the
+            // struct-update `..AgentLoopConfig::default()` below must not be
+            // allowed to silently supply the flat, model-blind default here.
+            compaction: CompactionConfig::for_context_window(resolve_context_window(&pm_model)),
             ..AgentLoopConfig::default()
         },
         pm_llm,


### PR DESCRIPTION
## Root cause

`CompactionConfig::default()` hardcoded `token_threshold: 6_000` — a flat, model-blind constant that is only ~3% of Bedrock Claude Sonnet's real 200K-token context window. Post-#2263 tool-call-arg counting (which correctly sums `content` PLUS tool-call `arguments`) means ordinary coding turns blow through that flat 6,000-token threshold constantly (~every 2 turns at 4-13K estimated tokens), triggering pathological, destructive re-compaction ("re-anchor thrash").

Prior research verified these are NOT the bug and were left untouched:
- `estimate_tokens` / `estimate_total_tokens` (`crates/trusty-code/src/agent_loop/compaction.rs`) — the chars/4 heuristic is applied uniformly to content and tool-call args; no units bug.
- `maybe_compact` / `should_compact` / `to_messages` reset bookkeeping (`crates/trusty-code/src/agent_loop/transcript.rs`) — the estimate correctly shrinks after compaction fires; no feedback loop.

## Fix

- **`resolve_context_window(model: &str) -> usize`** (`crates/trusty-code/src/provider/routing.rs`) — a minimal substring table alongside the existing `resolve_model`/`resolve_max_tokens` precedence resolvers: `claude-sonnet`/`claude-opus` (covers the real `bedrock/us.anthropic.claude-sonnet-4-6` dispatch-slug format) -> 200,000; `gpt-4o` -> 128,000; else `DEFAULT_CONTEXT_WINDOW = 128,000`.
- **`CompactionConfig::for_context_window(context_window: usize) -> Self`** (`crates/trusty-code/src/agent_loop/compaction.rs`) — `token_threshold = context_window * COMPACTION_THRESHOLD_FRACTION_PCT / 100` with `COMPACTION_THRESHOLD_FRACTION_PCT = 75`; `keep_last_messages` unchanged at 6. The old `Default` impl is kept (tests/back-compat only) with its doc updated to flag it as the pre-#2308 flat default, not for production use.
- Wired every production call site that resolves a model to build its `CompactionConfig` via `for_context_window` instead of silently inheriting the flat default through `AgentLoopConfig::default()`'s struct-update syntax:
  - `crates/trusty-code/src/runner/in_process.rs`
  - `crates/trusty-code/src/run_task/mod.rs`
  - `crates/trusty-code/src/task/executor.rs`

## Test evidence

New regression tests (all passing):
- `compaction::tests::should_compact_does_not_trigger_at_10k_tokens_against_200k_window` — the exact #2308 failure case.
- `compaction::tests::should_compact_triggers_near_75pct_of_200k_window` — compaction still fires near the real threshold.
- `compaction::tests::for_context_window_scales_threshold_proportionally` — 200K and 8K windows both scale ~75%.
- `compaction::tests::estimate_total_tokens_units_match_between_content_and_tool_args` — units invariant.
- `transcript::tests::maybe_compact_estimate_drops_after_compaction_fires` — post-fire estimate strictly smaller than pre-fire.
- `routing::tests::resolve_context_window_maps_bedrock_sonnet_to_200k` / `resolve_context_window_falls_back_to_default_for_unknown_model`.

```
cargo test -p trusty-code
test result: ok. 755 passed; 0 failed; 3 ignored (lib) + all integration test binaries green

cargo test --workspace
exit code 0, 0 failures across every crate

cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings
exit code 0 (pre-existing, unrelated warnings only: MSRV config mismatch, tga duplicate-binary-target, pnpm placeholder-UI build-script warnings)

cargo fmt --check
exit code 0

bash scripts/check_line_cap.sh
line-cap: 0 allowlisted, 0 violations — OK.
```

Closes #2308

🤖 Generated with [Claude Code](https://claude.com/claude-code)