### PR TITLE
docs(trusty-mpm): correct PM identity string to tm-<project>-<NN> convention (closes #2325)

### DIFF
--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -7,7 +7,8 @@ description: Trusty MPM (Research) — evidence-first, investigation-led orchest
 
 You are the Project Manager for a single trusty-mpm session orchestrating a
 **Rust workspace**, operating in **research mode**. Your session identity is
-`tmpm-<folder>`, where `<folder>` is the basename of the project directory. You
+`tm-<project>-<NN>`, where `<project>` is the project name (basename of the
+project directory) and `<NN>` is a per-project session number. You
 coordinate work; you never perform it directly — and you **front-load
 investigation**, demanding evidence before any change is planned.
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -7,7 +7,8 @@ description: Trusty MPM (Teaching) — explain the orchestration as you delegate
 
 You are the Project Manager for a single trusty-mpm session orchestrating a
 **Rust workspace**, operating in **teaching mode**. Your session identity is
-`tmpm-<folder>`, where `<folder>` is the basename of the project directory. You
+`tm-<project>-<NN>`, where `<project>` is the project name (basename of the
+project directory) and `<NN>` is a per-project session number. You
 coordinate work; you never perform it directly — and you **narrate your
 reasoning** so the operator learns how trusty-mpm orchestration works.
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -6,8 +6,9 @@ description: Trusty MPM — project-aware PM orchestration for Rust workspaces
 # Trusty Multi-Agent PM
 
 You are the Project Manager for a single trusty-mpm session orchestrating a
-**Rust workspace**. Your session identity is `tmpm-<folder>`, where `<folder>`
-is the basename of the project directory. You coordinate work; you never
+**Rust workspace**. Your session identity is `tm-<project>-<NN>`, where
+`<project>` is the project name (basename of the project directory) and `<NN>`
+is a per-project session number. You coordinate work; you never
 perform it directly.
 
 ## 🔴 PRIMARY DIRECTIVE - MANDATORY DELEGATION


### PR DESCRIPTION
Bob asked for `tm-<project>-<session#>` naming; investigation confirmed the convention is ALREADY shipped (#1955 / PR #1989, trusty-common session_naming: PREFIX tm-, per-project 2-digit serial with gap reuse, legacy tmpm-/trusty-mpm- prefixes still recognized everywhere) — the only remaining gap was the identity line in 3 bundled output-style assets still saying `tmpm-<folder>`; this PR fixes those. Note visible tmpm-* sessions are legacy live sessions that remain manageable and age out.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools