### PR TITLE
fix(trusty-mpm): strip leading -- separator from tm mcp args at write and read (closes #2326)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/mcp.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mcp.rs
@@ -17,7 +17,9 @@ use anyhow::{Context, Result, bail};
 use serde_json::{Map, Value};
 
 use crate::cli::McpTransportArg;
-use trusty_mpm::core::mcp_config::{self, McpTransport, build_remote_entry, build_stdio_entry};
+use trusty_mpm::core::mcp_config::{
+    self, McpTransport, build_remote_entry, build_stdio_entry, strip_arg_separator,
+};
 use trusty_mpm::core::mcp_test::{self, McpTestResult};
 
 /// Resolve the `.claude.json`-bearing config dir for a `tm mcp` invocation.
@@ -92,7 +94,11 @@ pub(crate) fn add_cmd(
 ) -> Result<()> {
     let config_dir = resolve_config_dir(root)?;
     let command_or_url = command_and_args.first().map(String::as_str);
-    let args = command_and_args.get(1..).unwrap_or_default();
+    // Drop a leading `--` separator (clap's `trailing_var_arg` keeps it in the
+    // captured tail after the command positional; persisting it verbatim breaks
+    // every npx/uv-style stdio server). Only the first token is stripped — a
+    // legitimate deeper `--` is preserved. See `mcp_config::strip_arg_separator`.
+    let args = strip_arg_separator(command_and_args.get(1..).unwrap_or_default());
 
     let entry = match transport {
         McpTransportArg::Stdio => {
@@ -300,11 +306,17 @@ fn entry_target(entry: &Value) -> String {
         return url.to_string();
     }
     let cmd = entry.get("command").and_then(Value::as_str).unwrap_or("");
-    let args: Vec<&str> = entry
+    let mut args: Vec<&str> = entry
         .get("args")
         .and_then(Value::as_array)
         .map(|a| a.iter().filter_map(Value::as_str).collect())
         .unwrap_or_default();
+    // Show the EFFECTIVE argv: drop a legacy stored leading `--` separator so
+    // `tm mcp list/get` reflect what actually gets spawned (mirrors the spawn-path
+    // and write-path normalisation in `mcp_config::strip_arg_separator`).
+    if args.first() == Some(&"--") {
+        args.remove(0);
+    }
     if args.is_empty() {
         cmd.to_string()
     } else {
@@ -348,5 +360,89 @@ mod tests {
         assert_eq!(entry_target(&stdio), "echo hi there");
         let http = serde_json::json!({"type":"http","url":"https://x/mcp"});
         assert_eq!(entry_target(&http), "https://x/mcp");
+    }
+
+    #[test]
+    fn entry_target_shows_effective_argv_dropping_legacy_separator() {
+        // A registry entry written before the fix still displays the effective
+        // argv (no leading `--`) in `tm mcp list/get`.
+        let legacy = serde_json::json!({
+            "type":"stdio","command":"npx",
+            "args":["--","-y","@modelcontextprotocol/server-github"]
+        });
+        assert_eq!(
+            entry_target(&legacy),
+            "npx -y @modelcontextprotocol/server-github"
+        );
+    }
+
+    /// The npx shape `tm mcp add github npx -- -y @scope/pkg` must persist WITHOUT
+    /// the `--` sentinel (clap's `trailing_var_arg` captures it as the first tail
+    /// token). `--root` is tier-1 precedence so the write lands in
+    /// `<tempdir>/claude-config`, letting us assert the stored args round-trip.
+    #[test]
+    fn add_strips_leading_separator_before_persisting() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let command_and_args = vec![
+            "npx".to_string(),
+            "--".to_string(),
+            "-y".to_string(),
+            "@modelcontextprotocol/server-github".to_string(),
+        ];
+        add_cmd(
+            Some(root),
+            "github",
+            McpTransportArg::Stdio,
+            &[],
+            &[],
+            &command_and_args,
+        )
+        .unwrap();
+
+        let cfg = std::path::Path::new(root).join("claude-config");
+        let entry = mcp_config::get_server(&cfg, "github")
+            .unwrap()
+            .expect("server persisted");
+        assert_eq!(entry["command"], "npx");
+        assert_eq!(
+            entry["args"],
+            serde_json::json!(["-y", "@modelcontextprotocol/server-github"]),
+            "the `--` sentinel must not be persisted into stored args"
+        );
+    }
+
+    /// Round-trip proof that only the LEADING `--` is stripped: a deeper `--`
+    /// (a real inner separator some CLIs need) survives into the stored args.
+    #[test]
+    fn add_preserves_deeper_separator() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        // `tm mcp add x uv -- run -- tool` → tail = ["uv","--","run","--","tool"].
+        let command_and_args = vec![
+            "uv".to_string(),
+            "--".to_string(),
+            "run".to_string(),
+            "--".to_string(),
+            "tool".to_string(),
+        ];
+        add_cmd(
+            Some(root),
+            "x",
+            McpTransportArg::Stdio,
+            &[],
+            &[],
+            &command_and_args,
+        )
+        .unwrap();
+
+        let cfg = std::path::Path::new(root).join("claude-config");
+        let entry = mcp_config::get_server(&cfg, "x").unwrap().unwrap();
+        assert_eq!(entry["command"], "uv");
+        assert_eq!(
+            entry["args"],
+            serde_json::json!(["run", "--", "tool"]),
+            "leading `--` stripped once; the deeper `--` is preserved"
+        );
     }
 }

--- a/crates/trusty-mpm/src/core/mcp_config.rs
+++ b/crates/trusty-mpm/src/core/mcp_config.rs
@@ -106,6 +106,31 @@ impl McpTransport {
     }
 }
 
+/// Strip a single leading `--` separator token from a stdio args slice.
+///
+/// Why: `tm mcp add <name> <command> -- <args…>` mirrors `claude mcp add`, where
+/// the `--` merely stops flag parsing so hyphen-led args pass through. But clap's
+/// `trailing_var_arg` keeps that `--` in the captured tail once the command
+/// positional has been consumed, so it was being persisted as the FIRST stored
+/// arg (`["--", "-y", "@scope/pkg"]`). Spawned verbatim that breaks every
+/// npx/uv-style server (`npx -- -y …` → npm ETARGET `undefined@-y`; `uv -- run …`
+/// → "unexpected argument 'run' … remove the '--'"). Normalising here — at both
+/// the write path (so new entries are correct at rest) and the spawn/display read
+/// path (so already-broken registries work without manual repair) — keeps the one
+/// stripping rule in a single place.
+/// What: returns `&args[1..]` when the FIRST element is exactly `--`, else `args`
+/// unchanged. Only the leading token is stripped and only once: a legitimate `--`
+/// appearing deeper in the args (some CLIs need their own inner separator) is
+/// preserved.
+/// Test: `strip_arg_separator_removes_only_leading`,
+/// `strip_arg_separator_preserves_deeper_and_absent`.
+pub fn strip_arg_separator(args: &[String]) -> &[String] {
+    match args.first() {
+        Some(first) if first == "--" => &args[1..],
+        _ => args,
+    }
+}
+
 /// Build a stdio MCP server entry.
 ///
 /// Why: hand-built `json!` literals for the entry shape risk drifting in field
@@ -340,6 +365,36 @@ mod tests {
     fn stdio(command: &str, args: &[&str]) -> Value {
         let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
         build_stdio_entry(command, &args, &Map::new())
+    }
+
+    fn strings(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn strip_arg_separator_removes_only_leading() {
+        // The npx shape: a leading `--` is dropped exactly once.
+        let args = strings(&["--", "-y", "@modelcontextprotocol/server-github"]);
+        assert_eq!(
+            strip_arg_separator(&args),
+            &["-y", "@modelcontextprotocol/server-github"]
+        );
+        // Only the FIRST token is stripped — a second leading `--` survives.
+        let doubled = strings(&["--", "--", "-y"]);
+        assert_eq!(strip_arg_separator(&doubled), &["--", "-y"]);
+    }
+
+    #[test]
+    fn strip_arg_separator_preserves_deeper_and_absent() {
+        // A `--` that is not the first token is a real argument — keep it.
+        let deeper = strings(&["run", "--", "tool"]);
+        assert_eq!(strip_arg_separator(&deeper), &["run", "--", "tool"]);
+        // No separator at all → unchanged.
+        let clean = strings(&["-y", "pkg"]);
+        assert_eq!(strip_arg_separator(&clean), &["-y", "pkg"]);
+        // Empty slice → empty (no panic).
+        let empty: Vec<String> = Vec::new();
+        assert!(strip_arg_separator(&empty).is_empty());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/mcp_test/mod.rs
+++ b/crates/trusty-mpm/src/core/mcp_test/mod.rs
@@ -37,7 +37,9 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 
-use crate::core::mcp_config::{builtin_server_entry, managed_mcp_server_names};
+use crate::core::mcp_config::{
+    builtin_server_entry, managed_mcp_server_names, strip_arg_separator,
+};
 
 #[cfg(test)]
 mod tests;
@@ -377,8 +379,18 @@ fn rpc_error_message(err: &Value) -> String {
 }
 
 /// Pull the stdio `args` out of an entry as owned strings.
+///
+/// Why: entries written before the `tm mcp add` fix (or hand-edited) may carry a
+/// stray leading `--` separator as their first arg; spawned verbatim that breaks
+/// npx/uv-style servers. Stripping it here (via
+/// [`crate::core::mcp_config::strip_arg_separator`]) makes the probe exercise the
+/// SAME effective argv a fixed session would, so already-broken registries test
+/// green without manual repair.
+/// What: collects the entry's string `args`, then drops a single leading `--`.
+/// Test: `entry_args_strips_legacy_leading_separator`,
+/// `entry_args_preserves_deeper_separator`.
 fn entry_args(entry: &Value) -> Vec<String> {
-    entry
+    let raw: Vec<String> = entry
         .get("args")
         .and_then(Value::as_array)
         .map(|a| {
@@ -387,7 +399,8 @@ fn entry_args(entry: &Value) -> Vec<String> {
                 .map(str::to_string)
                 .collect()
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    strip_arg_separator(&raw).to_vec()
 }
 
 /// Pull the stdio `env` out of an entry as `(key, value)` pairs.

--- a/crates/trusty-mpm/src/core/mcp_test/tests.rs
+++ b/crates/trusty-mpm/src/core/mcp_test/tests.rs
@@ -134,6 +134,35 @@ fn select_named_unknown_errors() {
     );
 }
 
+// ─── entry arg extraction (legacy `--` separator strip) ──────────────────────
+
+#[test]
+fn entry_args_strips_legacy_leading_separator() {
+    // A registry entry written before the fix stores the sentinel as arg 0.
+    let entry = json!({
+        "type": "stdio",
+        "command": "npx",
+        "args": ["--", "-y", "@modelcontextprotocol/server-github"]
+    });
+    assert_eq!(
+        entry_args(&entry),
+        vec!["-y", "@modelcontextprotocol/server-github"],
+        "the spawn path must drop a legacy leading `--` so npx works"
+    );
+}
+
+#[test]
+fn entry_args_preserves_deeper_separator_and_clean_args() {
+    // A `--` that is a real inner argument is preserved.
+    let deeper = json!({"command": "uv", "args": ["run", "--", "server"]});
+    assert_eq!(entry_args(&deeper), vec!["run", "--", "server"]);
+    // Clean args and missing args are unaffected.
+    let clean = json!({"command": "srv", "args": ["-y", "pkg"]});
+    assert_eq!(entry_args(&clean), vec!["-y", "pkg"]);
+    let none = json!({"command": "srv"});
+    assert!(entry_args(&none).is_empty());
+}
+
 // ─── message builders ────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
clap trailing_var_arg keeps the user-typed `--` as a literal tail token once a positional has begun, so add_cmd persisted it and every consumer (incl. Claude Code) spawned `npx -- -y ...` → npm ETARGET. Fix: shared strip_arg_separator (one leading -- only, deeper -- preserved) applied at write (add_cmd), read/spawn (mcp_test entry_args — self-heals existing registries), display (list/get). 8 targeted tests.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools