### PR TITLE
fix(trusty-search): dedup warm-boot entries resolving to one colocated redb path (closes #2305)

### DIFF
--- a/crates/trusty-search/src/commands/start/restore.rs
+++ b/crates/trusty-search/src/commands/start/restore.rs
@@ -96,6 +96,17 @@ pub(super) async fn restore_indexes(
         .into_iter()
         .chain(colocated_entries)
         .collect();
+
+    // Issue #2305: collapse entries that resolve to the SAME on-disk redb corpus
+    // (colocated indexes sharing a root_path) down to one handle BEFORE the
+    // eager/cold split. redb is a single-open database; without this, the
+    // sequential restore below opens the file for the first entry, holds the
+    // corpus Arc for the daemon's lifetime, and every later entry sharing that
+    // file fails its open with DatabaseAlreadyOpen on every restart (the 50 ms
+    // retry can never clear an in-process holder). Deduping before the split
+    // also prevents a dropped duplicate from being parked in the cold store and
+    // re-triggering the double-open on first query.
+    let all_entries = crate::service::warm_boot::dedup_entries_by_corpus_path(all_entries);
     let total_discovered = all_entries.len();
 
     let (eager_entries, cold_entries) = select_warmboot_entries(all_entries, max_warmboot);

--- a/crates/trusty-search/src/service/persistence_loader.rs
+++ b/crates/trusty-search/src/service/persistence_loader.rs
@@ -502,4 +502,124 @@ mod tests {
         // Key invariant: no error. Corpus store presence is not asserted here:
         // app-data path may or may not resolve in a test environment.
     }
+
+    // ── Issue #2305 regression: shared-root redb double-open ───────────────────
+
+    /// Why (issue #2305 — the root cause behind #1870): two colocated
+    /// registrations of the SAME `root_path` resolve to one
+    /// `<root>/.trusty-search/index.redb`. redb is a single-open database, so
+    /// warm-booting both opens the file twice and the second fails with
+    /// `DatabaseAlreadyOpen` (surfaced as `corpus_open_failed`) — the 50 ms
+    /// retry can never clear an in-process holder, so it recurs every restart.
+    /// This test proves the hazard is real (a second, concurrently-held open of
+    /// the shared redb fails) and that `dedup_entries_by_corpus_path` collapses
+    /// the pair to exactly one entry so the warm-boot open path opens once.
+    /// What: opens `apex`, then — while that handle is still held — opens `mpm`
+    /// at the same root and asserts `mpm` reports `corpus_open_failed`; then runs
+    /// the pair through the dedup and asserts it collapses to a single survivor.
+    /// Only one *successful* corpus open is performed (the failing second open
+    /// returns immediately) so the test stays cheap. Data-survival across a
+    /// reopen is already covered by
+    /// `colocated_create_handler_path_survives_simulated_reload`, and survivor
+    /// selection by `dedup_by_corpus_path_keeps_most_recent`.
+    /// Test: this IS the test.
+    #[tokio::test]
+    async fn warm_boot_shared_root_double_open_is_prevented_by_dedup() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let embedder = mock_embedder();
+
+        let apex = PersistedIndex {
+            id: "apex".to_string(),
+            root_path: root.clone(),
+            colocated: true,
+            last_indexed_unix: Some(100),
+            ..Default::default()
+        };
+        let mpm = PersistedIndex {
+            id: "trusty-mpm".to_string(),
+            root_path: root.clone(),
+            colocated: true,
+            last_indexed_unix: Some(50),
+            ..Default::default()
+        };
+
+        // Prove the hazard: the first open succeeds and holds the corpus; a
+        // second open of the same redb file — the exact shape of the sequential
+        // warm-boot restore over two shared-root slots — fails with
+        // DatabaseAlreadyOpen (surfaced as corpus_open_failed, the #1870 symptom).
+        let first = build_indexer_from_entry(&apex, &embedder).await.unwrap();
+        let second = build_indexer_from_entry(&mpm, &embedder).await.unwrap();
+        assert!(
+            first.has_corpus_store() && !first.corpus_open_failed,
+            "the first open of the shared redb must succeed"
+        );
+        assert!(
+            second.corpus_open_failed,
+            "#2305: a concurrent second open of the shared redb must fail \
+             (DatabaseAlreadyOpen) — this is the bug the dedup prevents"
+        );
+        drop(first);
+        drop(second);
+
+        // Apply the fix: dedup collapses the two shared-root entries to one, so
+        // the warm-boot restore opens the shared redb exactly once → zero
+        // DatabaseAlreadyOpen. (The survivor is the most recent, `apex`.)
+        let survivors = crate::service::warm_boot::dedup_entries_by_corpus_path(vec![apex, mpm]);
+        assert_eq!(
+            survivors.len(),
+            1,
+            "#2305: two entries sharing one redb corpus must collapse to one"
+        );
+        assert_eq!(
+            survivors[0].id, "apex",
+            "the most-recently-active shared-root entry must be the survivor"
+        );
+    }
+
+    /// Why: the fix must not merge indexes that live in different redb files.
+    /// Two colocated indexes at distinct roots must open independent corpora
+    /// simultaneously with zero `DatabaseAlreadyOpen`, and dedup must keep both.
+    /// What: builds two colocated indexers at distinct roots while both handles
+    /// are held; asserts both are healthy and dedup returns both entries.
+    /// Test: this IS the test.
+    #[tokio::test]
+    async fn distinct_roots_open_independent_corpora() {
+        let a = tempdir().unwrap();
+        let b = tempdir().unwrap();
+        let embedder = mock_embedder();
+
+        let ea = PersistedIndex {
+            id: "a".to_string(),
+            root_path: a.path().to_path_buf(),
+            colocated: true,
+            ..Default::default()
+        };
+        let eb = PersistedIndex {
+            id: "b".to_string(),
+            root_path: b.path().to_path_buf(),
+            colocated: true,
+            ..Default::default()
+        };
+
+        // Both held open at once — distinct redb files, so no double-open.
+        let ia = build_indexer_from_entry(&ea, &embedder).await.unwrap();
+        let ib = build_indexer_from_entry(&eb, &embedder).await.unwrap();
+        assert!(
+            ia.has_corpus_store() && !ia.corpus_open_failed,
+            "distinct-root corpus a must open cleanly"
+        );
+        assert!(
+            ib.has_corpus_store() && !ib.corpus_open_failed,
+            "distinct-root corpus b must open cleanly"
+        );
+
+        // Dedup must leave distinct roots untouched.
+        let kept = crate::service::warm_boot::dedup_entries_by_corpus_path(vec![ea, eb]);
+        assert_eq!(
+            kept.len(),
+            2,
+            "distinct roots resolve to distinct redb files and must both survive dedup"
+        );
+    }
 }

--- a/crates/trusty-search/src/service/warm_boot/mod.rs
+++ b/crates/trusty-search/src/service/warm_boot/mod.rs
@@ -170,6 +170,114 @@ pub fn is_on_inaccessible_volume(
     inaccessible_volumes.contains(&key)
 }
 
+/// Resolve the dedup key for `entry` — the identity of its on-disk redb corpus
+/// file — WITHOUT any filesystem side effect (issue #2305).
+///
+/// Why: `corpus_redb_path_for_entry` routes through `colocated_storage_dir`,
+/// which calls `create_dir_all` and would materialise a ghost `.trusty-search/`
+/// directory for a moved/dead root at collection time (the exact hazard the
+/// #484 relocation guard avoids). Deduplication must therefore key on a pure
+/// path formula. Only colocated entries can collide: their corpus lives at
+/// `<root_path>/.trusty-search/index.redb`, so two entries sharing a
+/// `root_path` share one redb file. Legacy (non-colocated) corpora are keyed by
+/// unique `index_id` in the global data dir and can never collide, so they are
+/// never merged (`None`).
+/// What: for a colocated entry returns `Some(canonicalize_best_effort(root_path))`
+/// (canonicalization resolves symlink / `/var`↔`/private/var` aliases so two
+/// aliased roots map to one key, matching the read-only canonicalization used
+/// for the `seen_root_paths` set in `restore_indexes`); returns `None` for a
+/// non-colocated entry. `canonicalize_best_effort` is read-only — it never
+/// creates directories.
+/// Test: `dedup_by_corpus_path_*` in `warm_boot_tests.rs`.
+fn corpus_dedup_key(entry: &PersistedIndex) -> Option<PathBuf> {
+    if !entry.colocated {
+        // Legacy corpora are id-keyed in the global data dir → never collide.
+        return None;
+    }
+    // Same root ⟺ same `<root>/.trusty-search/index.redb`, so keying on the
+    // canonical root is equivalent to keying on the redb path and avoids the
+    // create_dir_all side effect of resolving the redb path directly.
+    Some(canonicalize_best_effort(&entry.root_path))
+}
+
+/// Collapse warm-boot entries that resolve to the SAME on-disk redb corpus file
+/// down to a single entry, keeping the most-recently-active one (issue #2305).
+///
+/// Why: redb is a single-open database. When two colocated registry entries
+/// share a `root_path` they resolve to the same
+/// `<root_path>/.trusty-search/index.redb`. The sequential warm-boot restore
+/// opens the file for the first entry and holds the corpus `Arc` for the
+/// daemon's lifetime, so every later entry sharing that file fails its open
+/// with `DatabaseAlreadyOpen` — the 50 ms retry in `open_corpus_with_retry`
+/// can never clear an *in-process* holder, so the failure recurs on every
+/// restart (the #1870 root cause). Two live handles serving byte-identical data
+/// from one file is the anomaly, not a feature: trusty-search has no blue/green
+/// layout that needs independent handles to one file, so we collapse the
+/// duplicates to one healthy entry *before* any open is attempted, guaranteeing
+/// zero `DatabaseAlreadyOpen` on warm boot.
+/// What: groups entries by [`corpus_dedup_key`] (colocated only; non-colocated
+/// entries are always kept). Within a colliding group keeps the entry with the
+/// highest `warmboot_sort_key` (most recent query/index activity; ties break by
+/// `id` ascending for determinism) and drops the rest with a `warn` naming both
+/// ids and the shared path. Survivors keep their original input order so the
+/// downstream recency split (`select_warmboot_entries`) and the
+/// legacy/colocated partition are unaffected.
+/// Test: `dedup_by_corpus_path_collapses_same_root`,
+/// `dedup_by_corpus_path_keeps_distinct_roots`,
+/// `dedup_by_corpus_path_keeps_non_colocated`,
+/// `dedup_by_corpus_path_keeps_most_recent` in `warm_boot_tests.rs`.
+pub fn dedup_entries_by_corpus_path(entries: Vec<PersistedIndex>) -> Vec<PersistedIndex> {
+    use crate::service::persistence::warmboot_sort_key;
+    use std::collections::HashMap;
+
+    // First pass: pick the winning entry index per corpus-path key.
+    let mut winner_by_key: HashMap<PathBuf, usize> = HashMap::new();
+    // Entries with no dedup key (non-colocated) are always retained.
+    let mut always_keep: Vec<bool> = vec![false; entries.len()];
+
+    for (i, entry) in entries.iter().enumerate() {
+        let Some(key) = corpus_dedup_key(entry) else {
+            always_keep[i] = true;
+            continue;
+        };
+        match winner_by_key.get(&key).copied() {
+            None => {
+                winner_by_key.insert(key, i);
+            }
+            Some(prev) => {
+                let cur = &entries[i];
+                let old = &entries[prev];
+                let cur_key = warmboot_sort_key(cur);
+                let old_key = warmboot_sort_key(old);
+                // Keep the more-recently-active entry; tie → lower id wins.
+                let cur_wins = cur_key > old_key || (cur_key == old_key && cur.id < old.id);
+                let winner = if cur_wins { i } else { prev };
+                tracing::warn!(
+                    "warm-boot: indexes '{}' and '{}' both resolve to the same redb corpus \
+                     under {} — collapsing to '{}' to avoid an in-process double-open \
+                     (DatabaseAlreadyOpen, issue #2305). The dropped registration is a \
+                     duplicate of the same on-disk index; re-register it at a distinct \
+                     root_path if the two were meant to be separate indexes.",
+                    cur.id,
+                    old.id,
+                    key.display(),
+                    entries[winner].id,
+                );
+                winner_by_key.insert(key, winner);
+            }
+        }
+    }
+
+    // Second pass: rebuild in original order, keeping winners + non-colocated.
+    let kept: std::collections::HashSet<usize> = winner_by_key.values().copied().collect();
+    entries
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| always_keep[*i] || kept.contains(i))
+        .map(|(_, e)| e)
+        .collect()
+}
+
 /// Collect index entries from the durable `indexes.toml` registry only.
 ///
 /// Why (issue #718 Part 2): legacy entries live in `~/Library/Application

--- a/crates/trusty-search/src/service/warm_boot/warm_boot_tests.rs
+++ b/crates/trusty-search/src/service/warm_boot/warm_boot_tests.rs
@@ -320,3 +320,128 @@ async fn colocated_scan_dedup_uses_consistent_canonicalization() {
          dedup fires consistently (canonicalization-symmetry fix, #864); got: {results:?}"
     );
 }
+
+// ── dedup_entries_by_corpus_path (issue #2305) ────────────────────────────
+
+/// Build a minimal colocated `PersistedIndex` for the corpus-path dedup tests.
+fn colocated_entry(id: &str, root: &std::path::Path, last_indexed: Option<u64>) -> PersistedIndex {
+    PersistedIndex {
+        id: id.to_string(),
+        root_path: root.to_path_buf(),
+        colocated: true,
+        last_indexed_unix: last_indexed,
+        ..Default::default()
+    }
+}
+
+/// Why (issue #2305 — the regression): two colocated entries that share a
+/// `root_path` resolve to the SAME `<root>/.trusty-search/index.redb`. redb is a
+/// single-open database, so warm-booting both opens the file twice and the
+/// second fails with `DatabaseAlreadyOpen`. The dedup must collapse them to one
+/// entry before any open is attempted.
+/// What: two colocated entries with one shared root plus one distinct root;
+/// assert the shared pair collapses to exactly one survivor and the distinct
+/// root is untouched (2 entries out for 3 in).
+/// Test: this test.
+#[test]
+fn dedup_by_corpus_path_collapses_same_root() {
+    let shared = tempfile::tempdir().unwrap();
+    let other = tempfile::tempdir().unwrap();
+
+    let entries = vec![
+        colocated_entry("apex", shared.path(), Some(100)),
+        colocated_entry("trusty-mpm", shared.path(), Some(50)),
+        colocated_entry("distinct", other.path(), Some(10)),
+    ];
+
+    let deduped = dedup_entries_by_corpus_path(entries);
+
+    // Shared root collapses to one; distinct root survives → 2 total.
+    assert_eq!(
+        deduped.len(),
+        2,
+        "two entries sharing one redb corpus must collapse to one; got {deduped:?}"
+    );
+    // Exactly one of the shared-root ids survives, and the distinct one is kept.
+    let ids: HashSet<&str> = deduped.iter().map(|e| e.id.as_str()).collect();
+    assert!(
+        ids.contains("distinct"),
+        "the entry with a distinct root must always survive; got {ids:?}"
+    );
+    let shared_survivors = ["apex", "trusty-mpm"]
+        .iter()
+        .filter(|id| ids.contains(**id))
+        .count();
+    assert_eq!(
+        shared_survivors, 1,
+        "exactly one of the shared-root entries must survive; got {ids:?}"
+    );
+}
+
+/// Why: the fix must not merge indexes that genuinely live in different redb
+/// files — distinct roots must keep independent corpora.
+/// What: two colocated entries with distinct roots; assert both survive.
+/// Test: this test.
+#[test]
+fn dedup_by_corpus_path_keeps_distinct_roots() {
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+
+    let entries = vec![
+        colocated_entry("a", a.path(), Some(1)),
+        colocated_entry("b", b.path(), Some(2)),
+    ];
+
+    let deduped = dedup_entries_by_corpus_path(entries);
+    assert_eq!(
+        deduped.len(),
+        2,
+        "entries at distinct roots resolve to distinct redb files and must both survive"
+    );
+}
+
+/// Why: legacy (non-colocated) corpora are keyed by unique `index_id` in the
+/// global data dir and can never collide, so the dedup must never merge them —
+/// even when they happen to share a `root_path`.
+/// What: two non-colocated entries sharing a root_path; assert both survive.
+/// Test: this test.
+#[test]
+fn dedup_by_corpus_path_keeps_non_colocated() {
+    let shared = tempfile::tempdir().unwrap();
+
+    let mut a = colocated_entry("legacy-a", shared.path(), Some(1));
+    a.colocated = false;
+    let mut b = colocated_entry("legacy-b", shared.path(), Some(2));
+    b.colocated = false;
+
+    let deduped = dedup_entries_by_corpus_path(vec![a, b]);
+    assert_eq!(
+        deduped.len(),
+        2,
+        "non-colocated entries are id-keyed and never collide, even sharing a root_path"
+    );
+}
+
+/// Why: when two entries collide, the survivor must be the most-recently-active
+/// one so warm boot keeps the freshest registration (matching the recency key
+/// used by `select_warmboot_entries`).
+/// What: two colocated entries sharing a root with different `last_indexed_unix`;
+/// assert the higher-recency id survives regardless of input order.
+/// Test: this test.
+#[test]
+fn dedup_by_corpus_path_keeps_most_recent() {
+    let shared = tempfile::tempdir().unwrap();
+
+    // Stale entry listed FIRST so we prove recency (not order) selects the winner.
+    let entries = vec![
+        colocated_entry("stale", shared.path(), Some(10)),
+        colocated_entry("fresh", shared.path(), Some(999)),
+    ];
+
+    let deduped = dedup_entries_by_corpus_path(entries);
+    assert_eq!(deduped.len(), 1, "shared root must collapse to one");
+    assert_eq!(
+        deduped[0].id, "fresh",
+        "the most-recently-active entry must be the survivor"
+    );
+}


### PR DESCRIPTION
## Summary
Root cause: two registry entries sharing one root_path result in the same index.redb file. During sequential warm-boot, the first entry holds the corpus Arc for the daemon lifetime, causing the second open to always fail with DatabaseAlreadyOpen.

## Fix
Side-effect-free dedup by canonical root before eager/cold split. Most-recent entry survives; log warnings with normalized names, IDs, and canonical path. Non-destructive—indexes.toml untouched. Auto-heals broken indexes on next restart without requiring --force reindex.

## Verification
Verified against a real DatabaseAlreadyOpen repro test.

## Follow-ups
- Runtime create_index/relocate root-collision guard
- Config-merge on drop
- indexes.toml prune

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools