### PR TITLE
fix(trusty-mpm): dedup stale duplicate session records per project in reconcile_on_boot (closes #2306)

### DIFF
--- a/crates/trusty-mpm/src/session_manager/dedup.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup.rs
@@ -1,0 +1,158 @@
+//! Stale duplicate-record dedup for `reconcile_on_boot` (#2306).
+//!
+//! Why: a project can accrue two conflicting non-`Decommissioned` records — one
+//! canonical (resolved `workspace_path`) and one adopted record permanently
+//! stuck at `cwd`/`workspace_path = /unknown` (adopted before #2163's
+//! `get_pane_cwd` resolution existed). `reconcile_on_boot` only resolves
+//! `/unknown` when a LIVE pane is discovered; it never revisits a `/unknown`
+//! record once its pane is gone, and nothing collapses N records per project,
+//! so `tm` keeps re-attaching to the wrong/stale one. #2001/#2004 (zombie
+//! reconcile) and #2148 (non-destructive resume) are single-record and do not
+//! cover this.
+//! What: groups non-`Decommissioned` records by `source_id` (fallback: resolved
+//! `workspace_path`); for a group of >1 records in which NO member has a live
+//! tmux session, keeps the best (resolved `workspace_path` beats `/unknown`;
+//! tie-break most-recent `last_activity_at`, then `created_at`) and
+//! decommissions the rest via the existing safe path (adopted `/unknown`
+//! records are `workspace_owned = false`, so no disk removal happens). A group
+//! with ANY live tmux member is left untouched — the live one is authoritative.
+//! Test: `plan_dedup_*` and `reconcile_dedup_*` in `dedup_tests.rs`.
+
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+
+use tracing::{info, warn};
+
+use super::manager::{ManagedError, SessionManager};
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+impl SessionManager {
+    /// Collapse stale duplicate session records per project (#2306).
+    ///
+    /// Why: see the module docs — quiesced projects with a canonical record AND
+    /// a stale `/unknown` adopted record must converge on the canonical one so
+    /// resume/re-attach stops targeting the dead record.
+    /// What: re-derives the live managed-tmux name set, reads all records, plans
+    /// the losers via [`plan_dedup`], removes any planned loser from `to_resume`
+    /// (never auto-resume a record about to be decommissioned), then
+    /// decommissions each loser through the standard `decommission` path (safe:
+    /// `/unknown` losers are `workspace_owned = false` → no disk mutation).
+    /// Decommission failures are logged, not fatal. Returns the ids selected for
+    /// decommission.
+    /// Test: `reconcile_dedup_collapses_stopped_duplicates` and siblings.
+    pub(crate) async fn dedup_stale_duplicates(
+        &self,
+        to_resume: &mut Vec<ManagedSessionId>,
+    ) -> Result<Vec<ManagedSessionId>, ManagedError> {
+        let live_names: HashSet<String> = self
+            .tmux
+            .list_sessions()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|n| crate::core::names::is_managed_session_name(n))
+            .collect();
+        let records = self.store.write().await.all().await?;
+        let losers = plan_dedup(&records, &live_names);
+        if losers.is_empty() {
+            return Ok(losers);
+        }
+        // Never auto-resume a record we are about to decommission.
+        to_resume.retain(|id| !losers.contains(id));
+        for id in &losers {
+            match self.decommission(id).await {
+                Ok((rec, _removed)) => info!(
+                    id = %id,
+                    name = %rec.tmux_name,
+                    "dedup: decommissioned stale duplicate session record (#2306)"
+                ),
+                Err(e) => warn!(id = %id, "dedup: decommission of stale duplicate failed: {e}"),
+            }
+        }
+        Ok(losers)
+    }
+}
+
+/// Grouping key for a record, or `None` if it cannot be grouped.
+///
+/// Why: two records for the SAME project must land in the same group so a
+/// quiesced duplicate can be collapsed; a record with neither a `source_id`
+/// nor a `workspace_path` (a bare `/unknown` with no provenance) is not safely
+/// attributable to any project and is therefore left alone.
+/// What: prefers `source_id`; falls back to the `workspace_path` string. The
+/// key is namespaced (`src:` / `ws:`) so a source id can never collide with a
+/// path.
+/// Test: covered indirectly by `plan_dedup_distinct_source_ids_untouched` and
+/// `plan_dedup_unknown_only_group`.
+fn group_key(record: &SessionRecord) -> Option<String> {
+    if let Some(sid) = &record.source_id {
+        return Some(format!("src:{sid}"));
+    }
+    record
+        .workspace_path
+        .as_ref()
+        .map(|ws| format!("ws:{}", ws.display()))
+}
+
+/// Order two records so the greater one is the preferred survivor.
+///
+/// Why: within a quiesced group the survivor must be the most authoritative
+/// record — a resolved on-disk workspace over a `/unknown` stub, then the most
+/// recently active/created.
+/// What: ranks by `workspace_path.is_some()` (resolved beats `/unknown`), then
+/// `last_activity_at` (`None` sorts earliest), then `created_at`.
+/// Test: `plan_dedup_prefers_resolved_over_unknown`,
+/// `plan_dedup_unknown_only_group`.
+fn survivor_pref(a: &SessionRecord, b: &SessionRecord) -> Ordering {
+    a.workspace_path
+        .is_some()
+        .cmp(&b.workspace_path.is_some())
+        .then(a.last_activity_at.cmp(&b.last_activity_at))
+        .then(a.created_at.cmp(&b.created_at))
+}
+
+/// Plan which records to decommission to dedup stale duplicates (#2306).
+///
+/// Why: the decision must be a pure function of the current record set and the
+/// live-tmux name set so it is trivially unit-testable without a real store or
+/// tmux (the #1790 no-real-tmux guard).
+/// What: groups non-`Decommissioned` records via [`group_key`]; for each group
+/// of size >1 that has NO live-tmux member, selects the best survivor via
+/// [`survivor_pref`] and returns every OTHER member's id as a loser. Groups of
+/// size 1, ungroupable records, and any group with a live-tmux member yield no
+/// losers.
+/// Test: the `plan_dedup_*` tests in `dedup_tests.rs`.
+pub(crate) fn plan_dedup(
+    records: &[SessionRecord],
+    live_names: &HashSet<String>,
+) -> Vec<ManagedSessionId> {
+    let mut groups: HashMap<String, Vec<&SessionRecord>> = HashMap::new();
+    for record in records {
+        if matches!(record.state, ManagedSessionState::Decommissioned) {
+            continue;
+        }
+        if let Some(key) = group_key(record) {
+            groups.entry(key).or_default().push(record);
+        }
+    }
+
+    let mut losers = Vec::new();
+    for members in groups.values() {
+        if members.len() < 2 {
+            continue;
+        }
+        // Live-group guard: if ANY member has a live tmux session, the live one
+        // is authoritative — never touch a group that is not fully quiesced.
+        if members.iter().any(|r| live_names.contains(&r.tmux_name)) {
+            continue;
+        }
+        let Some(survivor) = members.iter().copied().max_by(|a, b| survivor_pref(a, b)) else {
+            continue;
+        };
+        for record in members {
+            if record.id != survivor.id {
+                losers.push(record.id);
+            }
+        }
+    }
+    losers
+}

--- a/crates/trusty-mpm/src/session_manager/dedup.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup.rs
@@ -9,17 +9,46 @@
 //! so `tm` keeps re-attaching to the wrong/stale one. #2001/#2004 (zombie
 //! reconcile) and #2148 (non-destructive resume) are single-record and do not
 //! cover this.
+//!
+//! **Grouping caveat (post-review, #2306):** `source_id` is derived from the
+//! git remote and is per-REPOSITORY
+//! ([`super::adopt::derive_source_id_for_record`]), not per-workspace — every
+//! concurrent worktree session of one repo shares the same `source_id`. A
+//! naive "keep only the newest per group" policy would therefore collapse
+//! *legitimate concurrent sessions*, and worse: an in-project worktree record
+//! is `workspace_owned = false` BY DESIGN, yet `decommission` still runs
+//! `git worktree remove --force` (+ branch delete) for such a path via
+//! [`super::decommission::is_session_worktree`] — so a naive policy would
+//! destroy real, possibly-uncommitted work. See the eligibility rule below,
+//! which is the actual fix for that danger.
+//!
 //! What: groups non-`Decommissioned` records by `source_id` (fallback: resolved
-//! `workspace_path`); for a group of >1 records in which NO member has a live
-//! tmux session, keeps the best (resolved `workspace_path` beats `/unknown`;
-//! tie-break most-recent `last_activity_at`, then `created_at`) and
-//! decommissions the rest via the existing safe path (adopted `/unknown`
-//! records are `workspace_owned = false`, so no disk removal happens). A group
-//! with ANY live tmux member is left untouched — the live one is authoritative.
-//! Test: `plan_dedup_*` and `reconcile_dedup_*` in `dedup_tests.rs`.
+//! `workspace_path`). Within a quiesced group (no member has a live tmux
+//! session — see the live-group guard), a record is only ever a dedup
+//! **loser** when it is unresolved-or-dead: [`is_resolved_existing`] is
+//! `false` for it (no `workspace_path`, the `/unknown` sentinel, or a path
+//! that no longer exists on disk). A record with a resolved, still-existing
+//! `workspace_path` is NEVER a loser — regardless of group size or recency —
+//! because such records are the concurrent-session case the naive policy got
+//! wrong. Consequently:
+//! - a group with 2+ resolved-existing members collapses nothing among them;
+//!   only its unresolved/dead members (if any) are decommissioned, and only
+//!   because a resolved-existing (or live) member supersedes them;
+//! - a group with ZERO resolved-existing members (e.g. `/unknown`-only or
+//!   all-dead) keeps the most-recently-active/created member and
+//!   decommissions the rest — there is nothing on disk to lose in that case.
+//!
+//! An unresolved/dead loser is additionally rechecked against the SAME
+//! [`is_resolved_existing`] predicate immediately before decommission runs
+//! (belt-and-suspenders against a TOCTOU race); a loser that fails the
+//! recheck is skipped with a `warn!`, never decommissioned.
+//!
+//! Test: `plan_dedup_*`, `is_resolved_existing_*`, and `reconcile_dedup_*` in
+//! `dedup_tests.rs`.
 
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 use tracing::{info, warn};
 
@@ -31,14 +60,19 @@ impl SessionManager {
     ///
     /// Why: see the module docs — quiesced projects with a canonical record AND
     /// a stale `/unknown` adopted record must converge on the canonical one so
-    /// resume/re-attach stops targeting the dead record.
-    /// What: re-derives the live managed-tmux name set, reads all records, plans
-    /// the losers via [`plan_dedup`], removes any planned loser from `to_resume`
-    /// (never auto-resume a record about to be decommissioned), then
-    /// decommissions each loser through the standard `decommission` path (safe:
-    /// `/unknown` losers are `workspace_owned = false` → no disk mutation).
-    /// Decommission failures are logged, not fatal. Returns the ids selected for
-    /// decommission.
+    /// resume/re-attach stops targeting the dead record, WITHOUT ever touching
+    /// a resolved, still-existing workspace (the review-fixed danger: naively
+    /// collapsing by `source_id` alone would destroy legitimate concurrent
+    /// worktree sessions of one repo).
+    /// What: re-derives the live managed-tmux name set, reads all records,
+    /// plans the losers via [`plan_dedup`] (which already excludes every
+    /// resolved-existing record categorically), logs the full plan at `info`
+    /// level, removes any planned loser from `to_resume` (never auto-resume a
+    /// record about to be decommissioned), then for each loser: re-fetches it
+    /// and reruns [`is_resolved_existing`] as a belt-and-suspenders recheck
+    /// (skips + `warn!`s if the path has reappeared since planning) before
+    /// decommissioning through the standard `decommission` path. Decommission
+    /// failures are logged, not fatal. Returns the ids actually decommissioned.
     /// Test: `reconcile_dedup_collapses_stopped_duplicates` and siblings.
     pub(crate) async fn dedup_stale_duplicates(
         &self,
@@ -56,19 +90,54 @@ impl SessionManager {
         if losers.is_empty() {
             return Ok(losers);
         }
+
+        info!(
+            count = losers.len(),
+            ids = ?losers.iter().map(ManagedSessionId::to_string).collect::<Vec<_>>(),
+            "dedup: plan computed stale duplicate(s) to decommission (#2306)"
+        );
+
         // Never auto-resume a record we are about to decommission.
         to_resume.retain(|id| !losers.contains(id));
+
+        let mut decommissioned = Vec::new();
         for id in &losers {
-            match self.decommission(id).await {
-                Ok((rec, _removed)) => info!(
+            // Belt-and-suspenders (#2306 review fix): re-fetch and rerun the
+            // EXACT safety predicate used during planning immediately before
+            // acting, guarding a TOCTOU race between the plan snapshot above
+            // and this decommission call. A loser is only ever planned when
+            // unresolved/dead; if its workspace_path now resolves to an
+            // existing directory, refuse to decommission rather than risk
+            // deleting live work.
+            let current = match self.get(id).await {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(id = %id, "dedup: loser vanished before decommission: {e}");
+                    continue;
+                }
+            };
+            if is_resolved_existing(&current) {
+                warn!(
                     id = %id,
-                    name = %rec.tmux_name,
-                    "dedup: decommissioned stale duplicate session record (#2306)"
-                ),
+                    workspace = ?current.workspace_path,
+                    "dedup: belt-and-suspenders skip — loser's workspace_path now \
+                     resolves to an existing directory; refusing to decommission (#2306)"
+                );
+                continue;
+            }
+            match self.decommission(id).await {
+                Ok((rec, _removed)) => {
+                    info!(
+                        id = %id,
+                        name = %rec.tmux_name,
+                        "dedup: decommissioned stale duplicate session record (#2306)"
+                    );
+                    decommissioned.push(*id);
+                }
                 Err(e) => warn!(id = %id, "dedup: decommission of stale duplicate failed: {e}"),
             }
         }
-        Ok(losers)
+        Ok(decommissioned)
     }
 }
 
@@ -77,12 +146,15 @@ impl SessionManager {
 /// Why: two records for the SAME project must land in the same group so a
 /// quiesced duplicate can be collapsed; a record with neither a `source_id`
 /// nor a `workspace_path` (a bare `/unknown` with no provenance) is not safely
-/// attributable to any project and is therefore left alone.
+/// attributable to any project and is therefore left alone. NOTE: `source_id`
+/// is per-repository, not per-workspace (see module docs) — the safety
+/// boundary against over-grouping is [`is_resolved_existing`] at selection
+/// time, not this key.
 /// What: prefers `source_id`; falls back to the `workspace_path` string. The
 /// key is namespaced (`src:` / `ws:`) so a source id can never collide with a
 /// path.
 /// Test: covered indirectly by `plan_dedup_distinct_source_ids_untouched` and
-/// `plan_dedup_unknown_only_group`.
+/// `plan_dedup_unknown_only_group_keeps_most_recent`.
 fn group_key(record: &SessionRecord) -> Option<String> {
     if let Some(sid) = &record.source_id {
         return Some(format!("src:{sid}"));
@@ -93,33 +165,61 @@ fn group_key(record: &SessionRecord) -> Option<String> {
         .map(|ws| format!("ws:{}", ws.display()))
 }
 
-/// Order two records so the greater one is the preferred survivor.
+/// True when `record.workspace_path` is a resolved, real, currently-existing
+/// directory on disk.
 ///
-/// Why: within a quiesced group the survivor must be the most authoritative
-/// record — a resolved on-disk workspace over a `/unknown` stub, then the most
-/// recently active/created.
-/// What: ranks by `workspace_path.is_some()` (resolved beats `/unknown`), then
-/// `last_activity_at` (`None` sorts earliest), then `created_at`.
-/// Test: `plan_dedup_prefers_resolved_over_unknown`,
-/// `plan_dedup_unknown_only_group`.
-fn survivor_pref(a: &SessionRecord, b: &SessionRecord) -> Ordering {
-    a.workspace_path
-        .is_some()
-        .cmp(&b.workspace_path.is_some())
-        .then(a.last_activity_at.cmp(&b.last_activity_at))
+/// Why (#2306 review fix): this is THE safety boundary for dedup. A record
+/// that passes this check represents a legitimate on-disk workspace — which
+/// may be one of several concurrent sessions of the SAME repo, since
+/// `source_id` groups by repository, not by workspace. Such a record must
+/// never be treated as a stale duplicate, no matter the group size or its
+/// recency relative to siblings — an in-project worktree record is
+/// `workspace_owned = false` by design, so the `workspace_owned` flag alone
+/// cannot distinguish "safe to decommission" from "real work that would be
+/// `git worktree remove --force`'d". Only a record that FAILS this check (no
+/// `workspace_path`, the literal `/unknown` sentinel, or a path that no
+/// longer exists — e.g. already removed by other means) is eligible to be a
+/// dedup loser.
+/// What: `true` iff `workspace_path` is `Some(p)`, `p != Path::new("/unknown")`,
+/// and `p.exists()`.
+/// Test: `is_resolved_existing_true_for_real_dir`,
+/// `is_resolved_existing_false_for_missing_dir`,
+/// `is_resolved_existing_false_for_none_and_unknown_sentinel`.
+pub(crate) fn is_resolved_existing(record: &SessionRecord) -> bool {
+    match &record.workspace_path {
+        Some(p) => p.as_path() != Path::new("/unknown") && p.exists(),
+        None => false,
+    }
+}
+
+/// Order two records by recency only (greater = more recently active/created).
+///
+/// Why: used ONLY to break a tie among unresolved/dead candidates in a group
+/// with zero resolved-existing members — there is nothing on disk to lose in
+/// that case, so "most recently touched" is a reasonable survivor heuristic.
+/// What: ranks by `last_activity_at` (`None` sorts earliest), then
+/// `created_at`.
+/// Test: `plan_dedup_unknown_only_group_keeps_most_recent`.
+fn by_recency(a: &SessionRecord, b: &SessionRecord) -> Ordering {
+    a.last_activity_at
+        .cmp(&b.last_activity_at)
         .then(a.created_at.cmp(&b.created_at))
 }
 
 /// Plan which records to decommission to dedup stale duplicates (#2306).
 ///
-/// Why: the decision must be a pure function of the current record set and the
-/// live-tmux name set so it is trivially unit-testable without a real store or
-/// tmux (the #1790 no-real-tmux guard).
-/// What: groups non-`Decommissioned` records via [`group_key`]; for each group
-/// of size >1 that has NO live-tmux member, selects the best survivor via
-/// [`survivor_pref`] and returns every OTHER member's id as a loser. Groups of
-/// size 1, ungroupable records, and any group with a live-tmux member yield no
-/// losers.
+/// Why: the decision must be a pure function of the current record set, disk
+/// state (via [`is_resolved_existing`]'s `exists()` check), and the live-tmux
+/// name set so it is trivially unit-testable without a real store or tmux
+/// driver (the #1790 no-real-tmux guard).
+/// What: groups non-`Decommissioned` records via [`group_key`]; skips any
+/// group of size <2 or with a live-tmux member. For the remaining (quiesced,
+/// size>1) groups, partitions members into resolved-existing vs.
+/// unresolved/dead via [`is_resolved_existing`]. If ANY member is
+/// resolved-existing, every unresolved/dead member is a loser (the
+/// resolved-existing members are NEVER touched, even if there are several).
+/// If NONE are resolved-existing, the most-recent member (by [`by_recency`])
+/// survives and every other member is a loser.
 /// Test: the `plan_dedup_*` tests in `dedup_tests.rs`.
 pub(crate) fn plan_dedup(
     records: &[SessionRecord],
@@ -145,13 +245,32 @@ pub(crate) fn plan_dedup(
         if members.iter().any(|r| live_names.contains(&r.tmux_name)) {
             continue;
         }
-        let Some(survivor) = members.iter().copied().max_by(|a, b| survivor_pref(a, b)) else {
-            continue;
-        };
-        for record in members {
-            if record.id != survivor.id {
-                losers.push(record.id);
+
+        // Safety partition (#2306 review fix): a resolved-existing member can
+        // NEVER be a loser. Only unresolved/dead members are candidates.
+        let (resolved_existing, candidates): (Vec<&SessionRecord>, Vec<&SessionRecord>) = members
+            .iter()
+            .copied()
+            .partition(|r| is_resolved_existing(r));
+
+        if resolved_existing.is_empty() {
+            // Nothing in this group is resolved-existing (an /unknown-only or
+            // all-dead group): nothing on disk to lose. Keep the most
+            // recently active/created candidate, decommission the rest.
+            if let Some(survivor) = candidates.iter().copied().max_by(|a, b| by_recency(a, b)) {
+                losers.extend(
+                    candidates
+                        .iter()
+                        .filter(|r| r.id != survivor.id)
+                        .map(|r| r.id),
+                );
             }
+        } else {
+            // At least one resolved-existing (or live-checked-clean) member
+            // supersedes every unresolved/dead candidate. The
+            // resolved-existing members themselves are left untouched — even
+            // if there are 2+ of them (legitimate concurrent sessions).
+            losers.extend(candidates.iter().map(|r| r.id));
         }
     }
     losers

--- a/crates/trusty-mpm/src/session_manager/dedup_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup_tests.rs
@@ -5,11 +5,18 @@
 //! mirroring the pattern established by `backfill_tests.rs` /
 //! `decommission_worktree_tests.rs`. It reuses the sibling `tests` module's
 //! `FakeTmuxDriver` scaffolding for the reconcile integration tests, and drives
-//! the pure planner [`super::dedup::plan_dedup`] directly for the algorithm
-//! cases (no real tmux — the #1790 guard).
-//! What: unit tests for the grouping/survivor/live-group rules of `plan_dedup`,
-//! plus end-to-end `reconcile_on_boot` tests proving quiesced duplicates
-//! collapse to the resolved survivor while live/distinct groups are untouched.
+//! the pure planner [`super::dedup::plan_dedup`] / predicate
+//! [`super::dedup::is_resolved_existing`] directly for the algorithm cases (no
+//! real tmux — the #1790 guard). Existence checks use real [`TempDir`]s so
+//! `is_resolved_existing`'s `Path::exists()` call observes genuine filesystem
+//! state rather than being mocked.
+//! What: unit tests for the grouping/eligibility/live-group rules of
+//! `plan_dedup` post the #2306 review fix — a resolved, still-existing
+//! `workspace_path` can NEVER be a dedup loser, regardless of group size or
+//! recency, because `source_id` groups by repository and multiple concurrent
+//! worktree sessions of one repo legitimately share a group — plus end-to-end
+//! `reconcile_on_boot` tests proving the same invariant holds through the full
+//! boot path.
 //! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
 
 use std::collections::HashSet;
@@ -18,7 +25,7 @@ use std::path::PathBuf;
 use chrono::{Duration, Utc};
 use tempfile::TempDir;
 
-use super::dedup::plan_dedup;
+use super::dedup::{is_resolved_existing, plan_dedup};
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::tests::FakeTmuxDriver;
 use crate::session_manager::SessionManager;
@@ -27,14 +34,16 @@ use crate::session_manager::SessionManager;
 ///
 /// Why: `plan_dedup` keys off `source_id`, `workspace_path`, `state`,
 /// `tmux_name`, `last_activity_at`, and `created_at`; a compact builder keeps
-/// the 20-field struct literal out of every test.
-/// What: constructs a record; `ws_path = None` models the `/unknown` stub.
+/// the 20-field struct literal out of every test. `ws_path = None` models the
+/// `/unknown` stub (no `workspace_path`); pass a real, existing directory to
+/// model a resolved-existing record, or a path that was never created (or was
+/// removed) to model a resolved-but-dead one.
 /// Test: used by every test in this module.
 #[allow(clippy::too_many_arguments)]
 fn rec(
     tmux_name: &str,
     source_id: Option<&str>,
-    ws_path: Option<&str>,
+    ws_path: Option<&PathBuf>,
     state: ManagedSessionState,
     activity_offset_secs: i64,
 ) -> SessionRecord {
@@ -43,13 +52,13 @@ fn rec(
         id: ManagedSessionId::new(),
         tmux_name: tmux_name.into(),
         cwd: ws_path
-            .map(PathBuf::from)
+            .cloned()
             .unwrap_or_else(|| PathBuf::from("/unknown")),
         task: "t".into(),
         state,
         created_at: created,
         last_activity_at: Some(created + Duration::seconds(activity_offset_secs)),
-        workspace_path: ws_path.map(PathBuf::from),
+        workspace_path: ws_path.cloned(),
         repo_url: None,
         branch: None,
         pending_decision: None,
@@ -65,18 +74,133 @@ fn rec(
     }
 }
 
-/// A quiesced group (same `source_id`, no live tmux) collapses to the resolved
-/// record; the `/unknown` stub is the loser.
+// ---------------------------------------------------------------------
+// `is_resolved_existing` predicate — the #2306 review-fixed safety boundary.
+// ---------------------------------------------------------------------
+
+/// A record whose `workspace_path` points at a real, currently-existing
+/// directory is resolved-existing.
 ///
-/// Why: this is the core #2306 property — re-attach must stop targeting a stale
-/// `/unknown` record when a resolved sibling exists.
+/// Why: this is the exact predicate both `plan_dedup`'s partition and the
+/// belt-and-suspenders recheck at the decommission call site rely on; it must
+/// observe genuine disk state, hence a real `TempDir`.
 /// Test: this function IS the test.
 #[test]
-fn plan_dedup_prefers_resolved_over_unknown() {
+fn is_resolved_existing_true_for_real_dir() {
+    let dir = TempDir::new().unwrap();
+    let r = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        0,
+    );
+    assert!(is_resolved_existing(&r));
+}
+
+/// A record whose `workspace_path` is set but the directory does not (or no
+/// longer) exists on disk is NOT resolved-existing.
+///
+/// Why: this is the "resolved-but-dead" case — e.g. a worktree removed by
+/// other means — which must be dedup-loser-eligible since there is nothing
+/// left on disk to lose.
+/// Test: this function IS the test.
+#[test]
+fn is_resolved_existing_false_for_missing_dir() {
+    let dir = TempDir::new().unwrap();
+    let ghost = dir.path().join("never-existed");
+    let r = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&ghost),
+        ManagedSessionState::Stopped,
+        0,
+    );
+    assert!(!is_resolved_existing(&r));
+}
+
+/// Neither a bare `None` `workspace_path` nor the literal `/unknown` sentinel
+/// path counts as resolved-existing.
+///
+/// Why: both represent "never resolved" records; guards against a stray
+/// literal `/unknown` `PathBuf` ever slipping past the check.
+/// Test: this function IS the test.
+#[test]
+fn is_resolved_existing_false_for_none_and_unknown_sentinel() {
+    let none_ws = rec(
+        "tm-proj-01",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        0,
+    );
+    assert!(!is_resolved_existing(&none_ws));
+
+    let sentinel = PathBuf::from("/unknown");
+    let literal_unknown = rec(
+        "tm-proj-02",
+        Some("proj"),
+        Some(&sentinel),
+        ManagedSessionState::Stopped,
+        0,
+    );
+    assert!(!is_resolved_existing(&literal_unknown));
+}
+
+// ---------------------------------------------------------------------
+// `plan_dedup` — grouping / eligibility / live-group rules.
+// ---------------------------------------------------------------------
+
+/// (i, REWRITE of the pre-review `plan_dedup_three_way_group_one_survivor`):
+/// two DISTINCT resolved-and-existing workspace paths sharing one
+/// `source_id`, both `Stopped`, no live tmux → NEITHER is a loser.
+///
+/// Why: this is the exact scenario the review flagged as a data-loss bug —
+/// `source_id` is per-repository, so two concurrent worktree sessions of one
+/// repo share a group. The old policy collapsed this to "keep the newest,"
+/// which would `git worktree remove --force` real work. The fixed rule must
+/// leave both untouched regardless of recency.
+/// Test: this function IS the test.
+#[test]
+fn plan_dedup_two_resolved_existing_paths_untouched() {
+    let dir_a = TempDir::new().unwrap();
+    let dir_b = TempDir::new().unwrap();
+    let older = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir_a.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    );
+    let newer = rec(
+        "tm-proj-02",
+        Some("proj"),
+        Some(&dir_b.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        99, // more recent — must NOT matter; both are resolved-existing
+    );
+
+    let losers = plan_dedup(&[older, newer], &HashSet::new());
+    assert!(
+        losers.is_empty(),
+        "two resolved-existing distinct-path records must both survive: {losers:?}"
+    );
+}
+
+/// A canonical resolved-existing record + a stale `/unknown` adopted record
+/// sharing one `source_id`, both `Stopped`, no live tmux → the `/unknown`
+/// record is the loser; the canonical one survives.
+///
+/// Why: this IS the #2306 target scenario — the core property the whole
+/// feature exists to fix.
+/// Test: this function IS the test.
+#[test]
+fn plan_dedup_prefers_resolved_existing_over_unknown() {
+    let dir = TempDir::new().unwrap();
     let resolved = rec(
         "tm-proj-01",
         Some("proj"),
-        Some("/tmp/proj"),
+        Some(&dir.path().to_path_buf()),
         ManagedSessionState::Stopped,
         10,
     );
@@ -85,7 +209,7 @@ fn plan_dedup_prefers_resolved_over_unknown() {
         Some("proj"),
         None,
         ManagedSessionState::Stopped,
-        99, // more recent, but must NOT win — resolved beats /unknown
+        99, // more recent, but must NOT win — resolved-existing beats /unknown
     );
     let resolved_id = resolved.id;
     let unknown_id = unknown.id;
@@ -98,21 +222,111 @@ fn plan_dedup_prefers_resolved_over_unknown() {
     );
     assert!(
         !losers.contains(&resolved_id),
-        "the resolved record must survive"
+        "the resolved-existing record must survive"
     );
+}
+
+/// A resolved-but-path-deleted record + a resolved-existing record sharing one
+/// `source_id`, both `Stopped`, no live tmux → the dead-path record is the
+/// loser, regardless of recency.
+///
+/// Why: "resolved" alone (a non-`None` `workspace_path`) is not enough to
+/// protect a record — only a path that still `exists()` does. This proves the
+/// dead-path case is still caught even though it superficially "looks like" a
+/// concurrent-session record (non-`None` `workspace_path`).
+/// Test: this function IS the test.
+#[test]
+fn plan_dedup_dead_path_loses_to_resolved_existing() {
+    let dir = TempDir::new().unwrap();
+    let ghost_dir = TempDir::new().unwrap();
+    let ghost_path = ghost_dir.path().join("removed-worktree");
+    // ghost_path is never created — models a resolved path whose directory
+    // was already removed by other means.
+
+    let existing = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    );
+    let dead = rec(
+        "tm-proj-02",
+        Some("proj"),
+        Some(&ghost_path),
+        ManagedSessionState::Stopped,
+        99, // more recent, but must NOT matter — the path is dead
+    );
+    let existing_id = existing.id;
+    let dead_id = dead.id;
+
+    let losers = plan_dedup(&[existing, dead], &HashSet::new());
+    assert_eq!(
+        losers,
+        vec![dead_id],
+        "the dead-path record must be the loser"
+    );
+    assert!(!losers.contains(&existing_id));
+}
+
+/// A three-way mixed group (resolved-existing + resolved-dead + /unknown)
+/// sharing one `source_id`: the resolved-existing member survives, BOTH
+/// others are losers.
+///
+/// Why: generalises the categorical-exclusion rule beyond two-member groups —
+/// every non-resolved-existing member is superseded once any
+/// resolved-existing member is present, independent of group size.
+/// Test: this function IS the test.
+#[test]
+fn plan_dedup_mixed_three_way_group_existing_survives_others_lose() {
+    let dir = TempDir::new().unwrap();
+    let ghost_dir = TempDir::new().unwrap();
+    let ghost_path = ghost_dir.path().join("removed-worktree");
+
+    let existing = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    );
+    let dead = rec(
+        "tm-proj-02",
+        Some("proj"),
+        Some(&ghost_path),
+        ManagedSessionState::Stopped,
+        50,
+    );
+    let unknown = rec(
+        "tm-proj-03",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        99,
+    );
+    let existing_id = existing.id;
+    let dead_id = dead.id;
+    let unknown_id = unknown.id;
+
+    let losers = plan_dedup(&[existing, dead, unknown], &HashSet::new());
+    let got: HashSet<ManagedSessionId> = losers.iter().copied().collect();
+    let expected: HashSet<ManagedSessionId> = [dead_id, unknown_id].into_iter().collect();
+    assert_eq!(got, expected);
+    assert!(!losers.contains(&existing_id));
 }
 
 /// A group with ANY live-tmux member is left entirely untouched.
 ///
 /// Why: the live pane is authoritative; dedup must only quiesce fully-stopped
-/// groups (issue nuance).
+/// groups (issue nuance) — verified independent of the eligibility rule above.
 /// Test: this function IS the test.
 #[test]
 fn plan_dedup_live_group_untouched() {
+    let dir = TempDir::new().unwrap();
     let live = rec(
         "tm-proj-01",
         Some("proj"),
-        Some("/tmp/proj"),
+        Some(&dir.path().to_path_buf()),
         ManagedSessionState::Active,
         10,
     );
@@ -133,55 +347,17 @@ fn plan_dedup_live_group_untouched() {
     );
 }
 
-/// A three-way quiesced group keeps exactly one survivor (the resolved,
-/// most-recent) and decommissions the other two.
-///
-/// Why: dedup must generalise beyond N=2.
-/// Test: this function IS the test.
-#[test]
-fn plan_dedup_three_way_group_one_survivor() {
-    let old_resolved = rec(
-        "tm-proj-01",
-        Some("proj"),
-        Some("/tmp/proj-old"),
-        ManagedSessionState::Stopped,
-        1,
-    );
-    let new_resolved = rec(
-        "tm-proj-02",
-        Some("proj"),
-        Some("/tmp/proj-new"),
-        ManagedSessionState::Stopped,
-        50, // most recent resolved → survivor
-    );
-    let unknown = rec(
-        "tm-proj-03",
-        Some("proj"),
-        None,
-        ManagedSessionState::Stopped,
-        99,
-    );
-    let survivor_id = new_resolved.id;
-    let old_id = old_resolved.id;
-    let unknown_id = unknown.id;
-
-    let losers = plan_dedup(&[old_resolved, new_resolved, unknown], &HashSet::new());
-    let got: HashSet<ManagedSessionId> = losers.iter().copied().collect();
-    let expected: HashSet<ManagedSessionId> = [old_id, unknown_id].into_iter().collect();
-    assert_eq!(got, expected, "only the most-recent resolved must survive");
-    assert!(!losers.contains(&survivor_id));
-}
-
 /// Records with distinct `source_id`s are distinct projects — never merged.
 ///
 /// Why: dedup must not collapse two legitimately-separate projects.
 /// Test: this function IS the test.
 #[test]
 fn plan_dedup_distinct_source_ids_untouched() {
+    let dir = TempDir::new().unwrap();
     let a = rec(
         "tm-a-01",
         Some("proj-a"),
-        Some("/tmp/a"),
+        Some(&dir.path().to_path_buf()),
         ManagedSessionState::Stopped,
         10,
     );
@@ -199,11 +375,11 @@ fn plan_dedup_distinct_source_ids_untouched() {
     );
 }
 
-/// A `/unknown`-only group (grouped via `workspace_path`... but both lack one)
-/// keyed by `source_id`: the most-recent record survives when none is resolved.
+/// A `/unknown`-only group (zero resolved-existing members): the most-recent
+/// record survives, the rest are losers.
 ///
-/// Why: when there is no resolved record to prefer, the tie-break must fall
-/// through to most-recent `last_activity_at`.
+/// Why: when nothing in the group is resolved-existing, there is nothing on
+/// disk to lose — the tie-break falls through to recency.
 /// Test: this function IS the test.
 #[test]
 fn plan_dedup_unknown_only_group_keeps_most_recent() {
@@ -228,7 +404,7 @@ fn plan_dedup_unknown_only_group_keeps_most_recent() {
     assert_eq!(
         losers,
         vec![older_id],
-        "with no resolved record, the older /unknown loses"
+        "with no resolved-existing record, the older /unknown loses"
     );
     assert!(!losers.contains(&newer_id));
 }
@@ -239,35 +415,42 @@ fn plan_dedup_unknown_only_group_keeps_most_recent() {
 /// Test: this function IS the test.
 #[test]
 fn plan_dedup_singleton_group_untouched() {
+    let dir = TempDir::new().unwrap();
     let only = rec(
         "tm-proj-01",
         Some("proj"),
-        Some("/tmp/proj"),
+        Some(&dir.path().to_path_buf()),
         ManagedSessionState::Stopped,
         10,
     );
     assert!(plan_dedup(&[only], &HashSet::new()).is_empty());
 }
 
+// ---------------------------------------------------------------------
+// `reconcile_on_boot` — end-to-end wiring.
+// ---------------------------------------------------------------------
+
 /// End-to-end: `reconcile_on_boot` collapses a quiesced duplicate pair into the
-/// resolved survivor and decommissions the `/unknown` record.
+/// resolved-existing survivor and decommissions the `/unknown` record.
 ///
 /// Why: proves the pure planner is wired into the boot reconcile and that
 /// decommission runs on the loser via the safe (no-disk) path.
-/// What: seeds two `Stopped` records sharing one `source_id` (one resolved, one
-/// `/unknown`), with NO live tmux, runs reconcile, then asserts the `/unknown`
-/// record is `Decommissioned` and the resolved one is not.
+/// What: seeds two `Stopped` records sharing one `source_id` (one
+/// resolved-existing via a real `TempDir`, one `/unknown`), with NO live
+/// tmux, runs reconcile, then asserts the `/unknown` record is
+/// `Decommissioned` and the resolved one is not.
 /// Test: this function IS the test.
 #[tokio::test]
 async fn reconcile_dedup_collapses_stopped_duplicates() {
     let dir = TempDir::new().unwrap();
+    let ws_dir = TempDir::new().unwrap();
     let fake = FakeTmuxDriver::new();
     let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
 
     let resolved = rec(
         "tm-proj-01",
         Some("proj"),
-        Some("/tmp/proj"),
+        Some(&ws_dir.path().to_path_buf()),
         ManagedSessionState::Stopped,
         10,
     );
@@ -298,8 +481,66 @@ async fn reconcile_dedup_collapses_stopped_duplicates() {
     assert_ne!(
         resolved_after.state,
         ManagedSessionState::Decommissioned,
-        "the resolved survivor must NOT be decommissioned"
+        "the resolved-existing survivor must NOT be decommissioned"
     );
+    assert!(
+        ws_dir.path().exists(),
+        "the resolved survivor's workspace directory must remain on disk"
+    );
+}
+
+/// End-to-end: two resolved-existing concurrent-worktree-style records
+/// sharing one `source_id` are BOTH left untouched by reconcile dedup.
+///
+/// Why: this is the exact review-flagged data-loss scenario driven through the
+/// full boot path, not just the pure planner — proves reconcile_on_boot never
+/// decommissions (and therefore never `git worktree remove --force`s) either
+/// side of a legitimate concurrent-session pair.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reconcile_dedup_leaves_two_resolved_existing_worktrees_untouched() {
+    let dir = TempDir::new().unwrap();
+    let ws_a = TempDir::new().unwrap();
+    let ws_b = TempDir::new().unwrap();
+    let fake = FakeTmuxDriver::new();
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    let a = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&ws_a.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    );
+    let b = rec(
+        "tm-proj-02",
+        Some("proj"),
+        Some(&ws_b.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        99,
+    );
+    let a_id = a.id;
+    let b_id = b.id;
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(a).await.unwrap();
+        store.upsert(b).await.unwrap();
+    }
+
+    mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert_ne!(
+        mgr.get(&a_id).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "first concurrent worktree session must survive"
+    );
+    assert_ne!(
+        mgr.get(&b_id).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "second concurrent worktree session must survive"
+    );
+    assert!(ws_a.path().exists(), "workspace A must remain on disk");
+    assert!(ws_b.path().exists(), "workspace B must remain on disk");
 }
 
 /// End-to-end: a group with a LIVE tmux member is untouched by reconcile dedup.
@@ -313,6 +554,7 @@ async fn reconcile_dedup_collapses_stopped_duplicates() {
 #[tokio::test]
 async fn reconcile_dedup_skips_live_group() {
     let dir = TempDir::new().unwrap();
+    let ws_dir = TempDir::new().unwrap();
     let fake = FakeTmuxDriver::new();
     fake.seeded_names.lock().unwrap().push("tm-proj-01".into());
     let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
@@ -320,7 +562,7 @@ async fn reconcile_dedup_skips_live_group() {
     let live = rec(
         "tm-proj-01",
         Some("proj"),
-        Some("/tmp/proj"),
+        Some(&ws_dir.path().to_path_buf()),
         ManagedSessionState::Active,
         10,
     );

--- a/crates/trusty-mpm/src/session_manager/dedup_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup_tests.rs
@@ -1,0 +1,354 @@
+//! Dedup coverage for stale duplicate session records (#2306).
+//!
+//! Why: `session_manager/tests.rs` is at the 1500-SLOC test cap; this
+//! #2306-specific coverage lives here so neither file grows past its limit,
+//! mirroring the pattern established by `backfill_tests.rs` /
+//! `decommission_worktree_tests.rs`. It reuses the sibling `tests` module's
+//! `FakeTmuxDriver` scaffolding for the reconcile integration tests, and drives
+//! the pure planner [`super::dedup::plan_dedup`] directly for the algorithm
+//! cases (no real tmux — the #1790 guard).
+//! What: unit tests for the grouping/survivor/live-group rules of `plan_dedup`,
+//! plus end-to-end `reconcile_on_boot` tests proving quiesced duplicates
+//! collapse to the resolved survivor while live/distinct groups are untouched.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use chrono::{Duration, Utc};
+use tempfile::TempDir;
+
+use super::dedup::plan_dedup;
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+use super::tests::FakeTmuxDriver;
+use crate::session_manager::SessionManager;
+
+/// Build a `SessionRecord` with only the fields the dedup logic reads varying.
+///
+/// Why: `plan_dedup` keys off `source_id`, `workspace_path`, `state`,
+/// `tmux_name`, `last_activity_at`, and `created_at`; a compact builder keeps
+/// the 20-field struct literal out of every test.
+/// What: constructs a record; `ws_path = None` models the `/unknown` stub.
+/// Test: used by every test in this module.
+#[allow(clippy::too_many_arguments)]
+fn rec(
+    tmux_name: &str,
+    source_id: Option<&str>,
+    ws_path: Option<&str>,
+    state: ManagedSessionState,
+    activity_offset_secs: i64,
+) -> SessionRecord {
+    let created = Utc::now();
+    SessionRecord {
+        id: ManagedSessionId::new(),
+        tmux_name: tmux_name.into(),
+        cwd: ws_path
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/unknown")),
+        task: "t".into(),
+        state,
+        created_at: created,
+        last_activity_at: Some(created + Duration::seconds(activity_offset_secs)),
+        workspace_path: ws_path.map(PathBuf::from),
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral: false,
+        workspace_owned: false,
+        source_id: source_id.map(Into::into),
+        claude_session_id: None,
+        scrollback_path: None,
+        last_cwd: None,
+    }
+}
+
+/// A quiesced group (same `source_id`, no live tmux) collapses to the resolved
+/// record; the `/unknown` stub is the loser.
+///
+/// Why: this is the core #2306 property — re-attach must stop targeting a stale
+/// `/unknown` record when a resolved sibling exists.
+/// Test: this function IS the test.
+#[test]
+fn plan_dedup_prefers_resolved_over_unknown() {
+    let resolved = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some("/tmp/proj"),
+        ManagedSessionState::Stopped,
+        10,
+    );
+    let unknown = rec(
+        "tm-proj-02",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        99, // more recent, but must NOT win — resolved beats /unknown
+    );
+    let resolved_id = resolved.id;
+    let unknown_id = unknown.id;
+
+    let losers = plan_dedup(&[resolved, unknown], &HashSet::new());
+    assert_eq!(
+        losers,
+        vec![unknown_id],
+        "the /unknown stub must be the loser"
+    );
+    assert!(
+        !losers.contains(&resolved_id),
+        "the resolved record must survive"
+    );
+}
+
+/// A group with ANY live-tmux member is left entirely untouched.
+///
+/// Why: the live pane is authoritative; dedup must only quiesce fully-stopped
+/// groups (issue nuance).
+/// Test: this function IS the test.
+#[test]
+fn plan_dedup_live_group_untouched() {
+    let live = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some("/tmp/proj"),
+        ManagedSessionState::Active,
+        10,
+    );
+    let stale = rec(
+        "tm-proj-02",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        5,
+    );
+    let mut live_names = HashSet::new();
+    live_names.insert("tm-proj-01".to_string());
+
+    let losers = plan_dedup(&[live, stale], &live_names);
+    assert!(
+        losers.is_empty(),
+        "a group with a live member must be untouched: {losers:?}"
+    );
+}
+
+/// A three-way quiesced group keeps exactly one survivor (the resolved,
+/// most-recent) and decommissions the other two.
+///
+/// Why: dedup must generalise beyond N=2.
+/// Test: this function IS the test.
+#[test]
+fn plan_dedup_three_way_group_one_survivor() {
+    let old_resolved = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some("/tmp/proj-old"),
+        ManagedSessionState::Stopped,
+        1,
+    );
+    let new_resolved = rec(
+        "tm-proj-02",
+        Some("proj"),
+        Some("/tmp/proj-new"),
+        ManagedSessionState::Stopped,
+        50, // most recent resolved → survivor
+    );
+    let unknown = rec(
+        "tm-proj-03",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        99,
+    );
+    let survivor_id = new_resolved.id;
+    let old_id = old_resolved.id;
+    let unknown_id = unknown.id;
+
+    let losers = plan_dedup(&[old_resolved, new_resolved, unknown], &HashSet::new());
+    let got: HashSet<ManagedSessionId> = losers.iter().copied().collect();
+    let expected: HashSet<ManagedSessionId> = [old_id, unknown_id].into_iter().collect();
+    assert_eq!(got, expected, "only the most-recent resolved must survive");
+    assert!(!losers.contains(&survivor_id));
+}
+
+/// Records with distinct `source_id`s are distinct projects — never merged.
+///
+/// Why: dedup must not collapse two legitimately-separate projects.
+/// Test: this function IS the test.
+#[test]
+fn plan_dedup_distinct_source_ids_untouched() {
+    let a = rec(
+        "tm-a-01",
+        Some("proj-a"),
+        Some("/tmp/a"),
+        ManagedSessionState::Stopped,
+        10,
+    );
+    let b = rec(
+        "tm-b-01",
+        Some("proj-b"),
+        None,
+        ManagedSessionState::Stopped,
+        10,
+    );
+    let losers = plan_dedup(&[a, b], &HashSet::new());
+    assert!(
+        losers.is_empty(),
+        "distinct projects must be untouched: {losers:?}"
+    );
+}
+
+/// A `/unknown`-only group (grouped via `workspace_path`... but both lack one)
+/// keyed by `source_id`: the most-recent record survives when none is resolved.
+///
+/// Why: when there is no resolved record to prefer, the tie-break must fall
+/// through to most-recent `last_activity_at`.
+/// Test: this function IS the test.
+#[test]
+fn plan_dedup_unknown_only_group_keeps_most_recent() {
+    let older = rec(
+        "tm-proj-01",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        5,
+    );
+    let newer = rec(
+        "tm-proj-02",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        50,
+    );
+    let older_id = older.id;
+    let newer_id = newer.id;
+
+    let losers = plan_dedup(&[older, newer], &HashSet::new());
+    assert_eq!(
+        losers,
+        vec![older_id],
+        "with no resolved record, the older /unknown loses"
+    );
+    assert!(!losers.contains(&newer_id));
+}
+
+/// A single record per project is never a duplicate.
+///
+/// Why: guard against decommissioning a lone record.
+/// Test: this function IS the test.
+#[test]
+fn plan_dedup_singleton_group_untouched() {
+    let only = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some("/tmp/proj"),
+        ManagedSessionState::Stopped,
+        10,
+    );
+    assert!(plan_dedup(&[only], &HashSet::new()).is_empty());
+}
+
+/// End-to-end: `reconcile_on_boot` collapses a quiesced duplicate pair into the
+/// resolved survivor and decommissions the `/unknown` record.
+///
+/// Why: proves the pure planner is wired into the boot reconcile and that
+/// decommission runs on the loser via the safe (no-disk) path.
+/// What: seeds two `Stopped` records sharing one `source_id` (one resolved, one
+/// `/unknown`), with NO live tmux, runs reconcile, then asserts the `/unknown`
+/// record is `Decommissioned` and the resolved one is not.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reconcile_dedup_collapses_stopped_duplicates() {
+    let dir = TempDir::new().unwrap();
+    let fake = FakeTmuxDriver::new();
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    let resolved = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some("/tmp/proj"),
+        ManagedSessionState::Stopped,
+        10,
+    );
+    let unknown = rec(
+        "tm-proj-02",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        20,
+    );
+    let resolved_id = resolved.id;
+    let unknown_id = unknown.id;
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(resolved).await.unwrap();
+        store.upsert(unknown).await.unwrap();
+    }
+
+    mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    let unknown_after = mgr.get(&unknown_id).await.unwrap();
+    assert_eq!(
+        unknown_after.state,
+        ManagedSessionState::Decommissioned,
+        "the /unknown duplicate must be decommissioned by dedup"
+    );
+    let resolved_after = mgr.get(&resolved_id).await.unwrap();
+    assert_ne!(
+        resolved_after.state,
+        ManagedSessionState::Decommissioned,
+        "the resolved survivor must NOT be decommissioned"
+    );
+}
+
+/// End-to-end: a group with a LIVE tmux member is untouched by reconcile dedup.
+///
+/// Why: the live/authoritative-record nuance must hold through the full boot
+/// path, not just the pure planner.
+/// What: seeds a live record (its `tmux_name` in `seeded_names`) and a stale
+/// `/unknown` sibling sharing one `source_id`; after reconcile neither is
+/// decommissioned.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reconcile_dedup_skips_live_group() {
+    let dir = TempDir::new().unwrap();
+    let fake = FakeTmuxDriver::new();
+    fake.seeded_names.lock().unwrap().push("tm-proj-01".into());
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    let live = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some("/tmp/proj"),
+        ManagedSessionState::Active,
+        10,
+    );
+    let stale = rec(
+        "tm-proj-02",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        20,
+    );
+    let live_id = live.id;
+    let stale_id = stale.id;
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(live).await.unwrap();
+        store.upsert(stale).await.unwrap();
+    }
+
+    mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert_ne!(
+        mgr.get(&live_id).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "the live record must survive"
+    );
+    assert_ne!(
+        mgr.get(&stale_id).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "a group with a live member must NOT be deduped"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -740,6 +740,12 @@ impl SessionManager {
         // Release write guard before auto-resume (which needs its own locks).
         drop(guard);
 
+        // #2306: collapse stale duplicate records per project. Runs after the
+        // main reconcile persisted states and the write guard was dropped;
+        // decommissions quiesced (no-live-tmux) losers via the safe path and
+        // prunes any of them from the pending auto-resume set. See dedup.rs.
+        self.dedup_stale_duplicates(&mut to_resume).await?;
+
         // #2158: best-effort validate + auto-repair the deployed `.claude/`
         // payload for every adopted session whose workspace was resolved
         // above. Non-fatal — a repair failure only leaves the workspace as-is;

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -11,6 +11,7 @@
 pub mod adopt;
 pub mod create;
 pub mod decommission;
+pub mod dedup;
 pub mod delete;
 pub mod driver;
 pub mod hook_sync;
@@ -59,6 +60,9 @@ mod resume_reattach_tests;
 
 #[cfg(test)]
 mod set_source_id_tests;
+
+#[cfg(test)]
+mod dedup_tests;
 
 /// Real tmux driver adapter — only available when the `daemon` feature (and thus
 /// the daemon's `TmuxDriver`) is compiled in.


### PR DESCRIPTION
## Problem

A project can accumulate duplicate session records in its roster when:
- A canonical record exists (with resolved workspace_path)
- One or more stale records linger (with /unknown or dead workspace_path)

When `tm resume` re-attaches, it may pick up the stale record instead of the canonical one.

## Design

Group session records by `source_id` within each project. Among duplicates:
- **Live-group guard:** retain records with a resolved, still-existing workspace_path
- **Loser eligibility:** ONLY records with `workspace_path = None`, `/unknown`, or nonexistent paths are eligible for decommission
- **Categorical safety:** a record with a resolved, existing path can NEVER be a loser — ensures we never delete legitimate concurrent worktree sessions (data-loss risk)
- **TOCTOU re-check:** verify the loser's workspace_path is still dead immediately before decommission (fail-safe against race conditions)
- **Logging:** info-level plan of the dedup action, warn-level skip when TOCTOU recheck fails

## Review History

- **Initial BLOCK:** Original grouping could collapse legitimate concurrent worktree sessions → data-loss risk
- **Redesign:** Categorical loser-eligibility rule (path must be None/unknown/nonexistent, cannot be resolved-and-existing)
- **Re-review APPROVE:** Adversarial trace of symlink/file/relative-path edge cases — all fail-safe
- **CI gate:** 18 dedup tests passing

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools