### PR TITLE
chore(trusty-review): v0.7.0 release — docs, changelog, version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11055,7 +11055,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.6.5"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.15.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.6.1" }
+trusty-review = { path = "crates/trusty-review", version = "0.7.0" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **Technical-DD report generation** (`trusty-review report --manifest <toml>`) — new manifest-driven report subcommand generating CAST-style technical due-diligence reports (markdown + JSON) from repository inspection:
+  - **M1** — deterministic manifest-driven fill: `[report]`/`[[repositories]]` manifest schema (path or remote + username/ref/metrics), git enrichment, v0 trusty-analyze metrics schema, bundled `report-technical-dd` + `report-technical-dd-cast` templates, XDG template override dir ([#2317](https://github.com/bobmatnyc/trusty-tools/pull/2317)) ([`2b916d8`](https://github.com/bobmatnyc/trusty-tools/commit/2b916d8d0cc1e162b8bddcc48d370057d59dc5c6))
+  - **M2** — opt-in `--synthesize` LLM narrative synthesis (executive summary, Top Risks, RED/AMBER findings), fail-closed on any provider/parse/guardrail failure, plus a deterministic numeric guardrail rejecting unverifiable figures; GREEN findings never synthesized ([#2324](https://github.com/bobmatnyc/trusty-tools/pull/2324)) ([`f6cbb1b`](https://github.com/bobmatnyc/trusty-tools/commit/f6cbb1bded79d37406ddac37bd28d6feda67b1ff))
+  - **M3** — opt-in `--corpus`/`--corpus-add`/`--benchmark` local benchmark corpus: privacy-redacted per-repository snapshots, deterministic percentile/quartile placement, small-n honesty gate (< 5 peers never ranked), plus live-QA fixes ([#2334](https://github.com/bobmatnyc/trusty-tools/pull/2334)) ([`3c457e2`](https://github.com/bobmatnyc/trusty-tools/commit/3c457e22fb598310e9858af43aa702138a7df8fc))
+
+### Fixed
+
+- MCP tools default to local (gh) auth, App only when creds present (closes #1993) ([#1995](https://github.com/bobmatnyc/trusty-tools/pull/1995)) ([`e11a5de`](https://github.com/bobmatnyc/trusty-tools/commit/e11a5de4e2d49c19894e4f47ec694bdf414de5b0))
+## [Unreleased]
+
 ### Fixed
 
 - MCP review path is now local-first: `review_pr`/`review_diff` authenticate with

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.6.5"
+version     = "0.7.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/README.md
+++ b/crates/trusty-review/README.md
@@ -315,6 +315,89 @@ Provider prefix convention:
 - `openrouter/<id>` — OpenRouter (requires `OPENROUTER_API_KEY`)
 - Bare id — uses the configured default provider
 
+## Report generation
+
+`trusty-review report` generates a CAST-style technical due-diligence report
+from repository inspection — a structured markdown + JSON pair with executive
+summary, per-application scorecards, findings by severity, risk registers, and
+graph-ready datasets. Full design detail:
+[docs/trusty-review/spec/report-generation.md](../../docs/trusty-review/spec/report-generation.md).
+
+```bash
+trusty-review report --manifest dd/acme.toml \
+  --template report-technical-dd-cast --out /tmp/dd-reports
+```
+
+### Manifest
+
+A single TOML file drives the run: a `[report]` section (title, optional
+`template`/`analyst`/`corpus`) plus one or more `[[repositories]]` entries.
+Each repository declares **exactly one** of `path` (local checkout) or
+`remote` (`owner/repo`, with optional `username` for attribution), plus an
+optional `ref` and a pre-produced trusty-analyze `metrics` JSON file:
+
+```toml
+[report]
+title = "Acme Technical DD"
+
+[[repositories]]
+name    = "Acme Web"
+path    = "/path/to/local/checkout"   # OR remote = "owner/repo"
+ref     = "main"
+metrics = "acme-metrics.json"
+```
+
+Local `path` entries get deterministic git enrichment (branch, short SHA,
+origin, dirty flag); missing deterministic data renders as an explicit honesty
+marker (e.g. `not stated in source data`) rather than being invented — a
+convention enforced throughout the deterministic fill (M1).
+
+### `--synthesize` (M2, opt-in LLM synthesis)
+
+Off by default — without it, output is the byte-for-byte deterministic M1
+fill. `--synthesize` layers LLM-written prose onto the executive summary, Top
+Risks table, and RED/AMBER finding narratives only; **GREEN findings are
+never synthesized** (filtered out before the prompt is built, so it's a
+structural guarantee, not a prompt instruction). It reuses the crate's
+existing reviewer LLM provider (no new client/dependency). Any provider,
+parse, or guardrail failure **fails closed** to the deterministic output with
+a visible `synthesis: unavailable (<reason>)` note — never a partial-trusted
+result. A deterministic numeric guardrail additionally rejects any
+synthesized field that cites a figure not present in the underlying report
+data.
+
+### `--corpus` / `--corpus-add` / `--benchmark` (M3, benchmark corpus)
+
+Opt-in, fully deterministic cross-repo percentile/quartile placement against
+a local corpus of accumulated per-repository metrics snapshots (the
+trusty-review analogue of CAST's Appmarq peer benchmark). Snapshots are
+privacy-redacted — the source path/URL is stored as a basename only, never
+the full path or remote URL. `--corpus <dir>` resolves the corpus location
+(falling back to the manifest's `[report].corpus` key, then a per-user XDG
+data directory); `--corpus-add` appends a snapshot per analyzed repository
+after a successful run; `--benchmark` computes and fills percentile/quartile
+placement tables. A corpus with fewer than 5 peers is never ranked — the
+report discloses `benchmark: corpus too small (n=<peers>)` instead of a
+fabricated placement (the small-n honesty gate).
+
+### Templates
+
+Two vendor-neutral, placeholder-only templates ship in
+`crates/trusty-review/templates/`: `report-technical-dd` (generic) and
+`report-technical-dd-cast` (CAST-specific health factors, ISO-5055 domains,
+Appmarq-style benchmarks). Override either by dropping a same-named file in
+the XDG template override directory (`~/.trusty-review/templates/`, checked
+before the bundled `include_str!()` default — same pattern as the reviewer's
+`VoiceLoader`).
+
+### No-green-analysis convention
+
+Across the whole report-generation feature, GREEN (healthy) findings are
+rendered as a one-line topic list only — no elaboration, root-cause prose, or
+recommendation ever attaches to a GREEN item, whether from deterministic fill
+or LLM synthesis. This keeps every report focused on what's actually
+actionable.
+
 ## Cargo features
 
 | Feature | Default | Description |


### PR DESCRIPTION
## Summary

- Bumps `trusty-review` 0.6.5 → 0.7.0 (MINOR — `feat` commits since last release) for the report-generation feature (M1-M3) merged today via #2317, #2324, #2334.
- Updates `crates/trusty-review/Cargo.toml` version and the workspace `trusty-review` path-dependency version pin in root `Cargo.toml` (was pinned to `0.6.1`, needed for `trusty-analyze`'s optional `review` feature to resolve).
- Adds a "Report generation" section to `crates/trusty-review/README.md` covering the `report` subcommand, manifest schema, `--synthesize` (opt-in LLM synthesis, fail-closed, numeric guardrail), `--corpus`/`--corpus-add`/`--benchmark` (benchmark corpus, privacy-redacted snapshots, small-n honesty gate), bundled templates, XDG template override dir, and the no-green-analysis convention — pointing to `docs/trusty-review/spec/report-generation.md` for full detail.
- Expands the generated CHANGELOG.md unreleased section with explicit M1/M2/M3 labels and PR references (#2317/#2324/#2334).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-review` — 1183 + 37 + 2 passed, 0 failed
- [x] `cargo check --workspace` — clean

Part of #2312

🤖 Generated with [Claude Code](https://claude.com/claude-code)