### PR TITLE
fix(scripts): signed-install log helpers write to stderr so identity capture stays clean (closes #2322)

### DIFF
--- a/scripts/install-trusty-search-signed.sh
+++ b/scripts/install-trusty-search-signed.sh
@@ -70,10 +70,17 @@ TRUSTY_CODESIGN_DRY_RUN="${TRUSTY_CODESIGN_DRY_RUN:-0}"
 # Helpers
 # ---------------------------------------------------------------------------
 
-info()    { printf '\033[0;32m[install-signed] %s\033[0m\n' "$*"; }
+# All log helpers write to stderr (issue #2322). This is not cosmetic: several
+# functions below (detect_identity, detect_repo_root) are called via command
+# substitution (`identity="$(detect_identity)"`), and anything these helpers
+# print to stdout gets silently concatenated into the captured value. That
+# previously corrupted the --sign identity string with log text, so codesign
+# failed with "no identity found" even though a valid Developer ID cert was
+# present.
+info()    { printf '\033[0;32m[install-signed] %s\033[0m\n' "$*" >&2; }
 warn()    { printf '\033[0;33m[install-signed] WARNING: %s\033[0m\n' "$*" >&2; }
 error()   { printf '\033[0;31m[install-signed] ERROR: %s\033[0m\n' "$*" >&2; }
-section() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+section() { printf '\n\033[1;34m==> %s\033[0m\n' "$*" >&2; }
 
 # Detect repo root (script may be called from anywhere)
 # Why: cargo install --path needs an absolute path to the workspace root.
@@ -155,7 +162,13 @@ detect_identity() {
 
 # Sign a single binary with the Developer ID identity.
 # Why: Encapsulates codesign flags so they are applied identically to both binaries.
-# What: Runs codesign --force --options runtime --timestamp --identifier <id> --sign <identity>.
+# What: Runs codesign --force --options runtime --timestamp --identifier <id> --sign <identity>,
+# then immediately verifies the resulting signature (issue #2322) so a corrupted
+# --sign identity (e.g. from a stdout-capture bug) can never pass silently —
+# `set -e` means codesign itself already aborts on an outright invalid identity,
+# but this extra, explicit check fails loudly and immediately after each binary
+# is signed rather than deferring all verification to the later Step 4, and
+# guards against subtler corruption that codesign alone might not catch.
 # The --options runtime flag enables the Hardened Runtime, required for notarization.
 # The fixed --identifier keeps the DR stable across rebuilds.
 sign_binary() {
@@ -174,6 +187,16 @@ sign_binary() {
         --identifier "$identifier" \
         --sign "$identity" \
         "$binary"
+
+    local verify_output
+    if ! verify_output="$(codesign --verify --deep --strict "$binary" 2>&1)"; then
+        error "Post-sign verification FAILED for $binary"
+        error "codesign --verify --deep --strict output:"
+        printf '%s\n' "$verify_output" >&2
+        error "The signature is invalid or corrupted — refusing to continue."
+        exit 1
+    fi
+    info "Post-sign verification passed for $binary"
 }
 
 # Verify the signature on a binary and print the Authority/TeamIdentifier/Identifier.


### PR DESCRIPTION
## Root cause

In `scripts/install-trusty-search-signed.sh`, the `info()` and `section()` log helpers wrote to **stdout** instead of stderr (`warn()`/`error()` already used `>&2`). `detect_identity()` calls `info()` for status messages while also using `echo "$identity"` to return its actual result, and `run_identity_detection()` captures that result via command substitution:

```bash
identity="$(detect_identity)"
```

Because `info()`'s log lines landed on the same stdout stream as the echoed identity, the captured `identity` variable was corrupted with log text (multiple lines mixed with the real identity string). That corrupted value was then passed straight into:

```bash
codesign --force --options runtime --timestamp --identifier "$identifier" --sign "$identity" "$binary"
```

`codesign` failed with "no identity found" even though a valid `Developer ID Application` certificate was present in the login keychain — despite the preceding `cargo install` having already succeeded, so the binaries were left installed but **unsigned**, silently reintroducing the FDA-loss-on-reinstall problem (#873) this script exists to prevent.

Reproduced live during an actual signed install on 2026-07-10. The field workaround was to manually run the intended `codesign --force --options runtime --timestamp --identifier <fixed-id> --sign <identity>` for both `trusty-search` and `trusty-embedderd`, which then verified correctly under the Developer ID.

## Fix

1. **Route all log helpers to stderr.** `info()` and `section()` now append `>&2` to their `printf`, matching `warn()`/`error()`, which already did.
2. **Audited every function invoked via command substitution** (`$(...)`) in the file: `detect_identity()` (the one named in the issue) and `detect_repo_root()`. With `info`/`section` now stderr-only, `detect_identity()`'s stdout carries exactly one line — the identity string — and nothing else. `detect_repo_root()` never logged in the first place.
3. **Added a post-sign verification step.** `sign_binary()` now runs `codesign --verify --deep --strict "$binary"` immediately after `codesign --sign`, and exits non-zero with a clear stderr message (printing the verify output) if it fails — so a corrupted or invalid signature can never pass silently before the next binary is signed. This is in addition to the existing detailed `verify_binary()` step (Step 4) that already ran after both binaries were signed; the new check catches problems immediately, per-binary, rather than only at the end.
4. **Checked sibling scripts** under `scripts/` for the same copy-pasted `info()`/`warn()`/`error()` helper pattern and for any other `find-identity`/`codesign` usage. `install-trusty-search-signed.sh` is the only script with this pattern — no other script needed the same fix.

## Verification

No signing cert is required to reproduce/verify this — a bash harness stubs `security find-identity` and sources the **real, unmodified** helper + `detect_identity()` function bodies out of the script under test, then asserts the value captured via `identity="$(detect_identity)"` is exactly the identity string with no log-prefix contamination.

**Harness run against the FIXED script (this PR) — PASS:**

```
=== Captured stdout from detect_identity via $(...) ===
Developer ID Application: Acme Corp (TEAM1234)
=== End captured stdout ===

PASS: captured output is exactly 1 line
PASS: captured value exactly matches expected identity string
PASS: captured value does not contain log marker [[install-signed]]
PASS: captured value does not contain log marker [Auto-detecting]
PASS: captured value does not contain log marker [Found identity]
PASS: captured value does not contain log marker [Using TRUSTY_SIGN_IDENTITY]

=== OVERALL: PASS — detect_identity() stdout capture is clean ===
```
(Exit code: 0. Note: the `[install-signed] Auto-detecting...` / `Found identity...` lines from `info()` DID print to the terminal during this run — because they now go to the real stderr, which the harness's `$(...)` capture does not include. That's the fix working as intended.)

**Same harness run against the PRE-FIX script (`origin/main`'s copy) for comparison — confirms the harness reproduces the exact bug:**

```
=== Captured stdout from detect_identity via $(...) ===
[0;32m[install-signed] Auto-detecting Developer ID Application identity...[0m
[0;32m[install-signed] Found identity: Developer ID Application: Acme Corp (TEAM1234)[0m
Developer ID Application: Acme Corp (TEAM1234)
=== End captured stdout ===

FAIL: expected exactly 1 line of captured output, got 3
FAIL: captured value does not exactly match expected identity string
  expected: [Developer ID Application: Acme Corp (TEAM1234)]
  actual:   [[0;32m[install-signed] Auto-detecting Developer ID Application identity...[0m
[0;32m[install-signed] Found identity: Developer ID Application: Acme Corp (TEAM1234)[0m
Developer ID Application: Acme Corp (TEAM1234)]
FAIL: captured value contains log-prefix contamination: [[install-signed]]
FAIL: captured value contains log-prefix contamination: [Auto-detecting]
FAIL: captured value contains log-prefix contamination: [Found identity]
PASS: captured value does not contain log marker [Using TRUSTY_SIGN_IDENTITY]

=== OVERALL: FAIL — detect_identity() stdout capture is corrupted ===
```
(Exit code: 1 — exactly the corruption pattern described in the issue: the 3-line capture with embedded ANSI-colored log text.)

**Other checks (all run inside `.claude/worktrees/fix-2322`, from `origin/main`):**

- `bash -n scripts/install-trusty-search-signed.sh` → syntax OK, no output, exit 0.
- `shellcheck scripts/install-trusty-search-signed.sh` → clean, exit 0, no findings (shellcheck 0.11.0 is installed on this machine).
- `cargo fmt --check` → exit 0 (only pre-existing nightly-feature warnings unrelated to this change; no formatting diffs).
- `bash scripts/check_line_cap.sh` → `line-cap: 0 allowlisted, 0 violations — OK.`

**This is a shell-only change** — `git diff --name-only origin/main..HEAD` shows only `scripts/install-trusty-search-signed.sh`, zero `.rs` files touched — so `cargo test` / `cargo clippy` were intentionally skipped per repo convention (no Rust code changed, nothing to compile-test).

## Files changed

- `scripts/install-trusty-search-signed.sh`

Closes #2322