### PR TITLE
feat(trusty-memory): fading-memories resurface pass in dream cycle

### DIFF
--- a/crates/trusty-common/src/memory_core/dream/config.rs
+++ b/crates/trusty-common/src/memory_core/dream/config.rs
@@ -7,6 +7,7 @@
 //! Test: `dream::tests::dream_config_defaults` and
 //! `dream::tests::dream_stats_persisted_after_cycle`.
 
+use super::fading::{FadingMemory, FadingParams};
 use crate::memory_core::semantic_consolidation::SemanticConsolidationConfig;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -59,6 +60,16 @@ pub struct DreamConfig {
     /// `recall_benchmark_enabled = false`, the cycle completes and both recall
     /// scores are `None`.
     pub recall_benchmark_enabled: bool,
+
+    /// Tunables for the fading-memories resurface pass (issue #2352).
+    ///
+    /// Why: The resurface thresholds must be configurable per deployment (and,
+    /// through this config, per palace) without recompiling. Embedded here the
+    /// same way `semantic` is, so the dream loop keeps a single config surface.
+    /// What: See [`FadingParams`]. Defaults resurface memories with base
+    /// importance >= 0.7 whose effective importance has fallen below 0.3.
+    /// Test: `dream_config_defaults`.
+    pub fading: FadingParams,
 }
 
 impl Default for DreamConfig {
@@ -78,6 +89,7 @@ impl Default for DreamConfig {
             openrouter_api_key: String::new(),
             local_model_enabled: true,
             recall_benchmark_enabled: true,
+            fading: FadingParams::default(),
         }
     }
 }
@@ -174,6 +186,21 @@ pub struct DreamStats {
     /// Test: `dream_recall_benchmark_returns_score_with_drawers`.
     #[serde(default)]
     pub recall_score_after: Option<f64>,
+
+    /// Fading high-value memories detected this cycle (issue #2352).
+    ///
+    /// Why: Ranked list of originally-important memories whose effective
+    /// importance has decayed below the resurface threshold. The cycle does
+    /// NOT auto-boost them (that would defeat the forgetting curve); it
+    /// surfaces them here so operators/agents can touch (recall re-boosts) or
+    /// `memory_forget`. Persisted into `dream_stats.json` so the list survives
+    /// until the next cycle. `#[serde(default)]` keeps older snapshots readable.
+    /// What: Ranked by base importance desc then age desc, capped at
+    /// `DreamConfig::fading.resurface_top_n`.
+    /// Test: `dream::fading::tests` (detection/ranking) and the
+    /// `palace_dream_response_includes_fading` MCP test in trusty-memory.
+    #[serde(default)]
+    pub fading: Vec<FadingMemory>,
 }
 
 impl DreamStats {

--- a/crates/trusty-common/src/memory_core/dream/dreamer.rs
+++ b/crates/trusty-common/src/memory_core/dream/dreamer.rs
@@ -13,6 +13,7 @@ use super::cycle::{
     compact_pass, content_prune_pass, dedup_pass, prune_pass, refresh_closets,
     semantic_consolidation_pass,
 };
+use super::fading::detect_fading;
 use super::guard::CompactionGuard;
 use super::recall_benchmark::run_benchmark;
 use crate::memory_core::palace::PalaceId;
@@ -254,6 +255,12 @@ impl Dreamer {
         // ── Effectiveness metric: post-cycle snapshot (issue #1530) ───────────
         let drawers_after = handle.drawers.read().len() as u64;
 
+        // ── Fading-memories resurface pass (issue #2352) ──────────────────────
+        // Detect (do NOT boost) high-value memories that have decayed below the
+        // resurface threshold, so operators/agents can touch or forget them.
+        // Runs after consolidation so the list reflects the post-cycle state.
+        let fading = detect_fading(handle, &self.config.fading);
+
         // Recall benchmark after consolidation — skip silently on failure or when disabled.
         let recall_score_after = if self.config.recall_benchmark_enabled {
             run_benchmark(handle).await
@@ -276,6 +283,7 @@ impl Dreamer {
             compression_ratio: 0.0, // populated below
             recall_score_before,
             recall_score_after,
+            fading,
         };
         stats.update_compression_ratio();
 
@@ -340,6 +348,7 @@ fn log_cycle_outcome(palace_id: &PalaceId, outcome: Result<DreamStats>) {
             drawers_before = stats.drawers_before,
             drawers_after = stats.drawers_after,
             compression_ratio = stats.compression_ratio,
+            fading = stats.fading.len(),
             "dream cycle complete"
         ),
         Err(e) => tracing::warn!(palace = %palace_id, "dream cycle failed: {e:#}"),

--- a/crates/trusty-common/src/memory_core/dream/fading.rs
+++ b/crates/trusty-common/src/memory_core/dream/fading.rs
@@ -11,7 +11,9 @@
 //! snapshots a `PalaceHandle` and applies its `DecayConfig`.
 //! Test: `tests` submodule below — flags a high-base aged unaccessed drawer,
 //! rejects fresh / low-base / boosted / protected drawers, verifies ranking +
-//! top-N cap.
+//! top-N cap, pins each comparator's exact boundary value (`boundary_conditions_table`),
+//! and locks the per-palace `DecayConfig` override wiring
+//! (`rank_fading_honours_custom_half_life_override`).
 
 use crate::memory_core::decay::DecayConfig;
 use crate::memory_core::palace::Drawer;
@@ -117,7 +119,8 @@ fn preview(content: &str) -> String {
 /// `resurface_top_n`.
 /// Test: `flags_high_base_aged_unaccessed_drawer`, `rejects_fresh_drawer`,
 /// `rejects_low_base_drawer`, `rejects_recently_boosted_drawer`,
-/// `rejects_protected_task_drawer`, `ranks_and_caps`.
+/// `rejects_protected_task_drawer`, `ranks_and_caps`,
+/// `boundary_conditions_table`, `rank_fading_honours_custom_half_life_override`.
 pub fn rank_fading(
     drawers: &[Drawer],
     decay: &DecayConfig,
@@ -173,15 +176,19 @@ pub fn rank_fading(
 ///
 /// Why: The dream cycle and the `palace_dream` MCP handler both need a
 /// palace-wide fading list computed against that palace's own `DecayConfig`
-/// (per-palace override); this snapshots the drawer table and delegates to the
-/// pure `rank_fading`.
-/// What: Reads `handle.drawers`, applies `handle.decay_config`, and returns the
-/// ranked, capped list. Read-only — never mutates drawers (no auto-boost).
+/// (per-palace override). The naive approach — `handle.drawers.read().clone()`
+/// — deep-clones every drawer's content string on every dream cycle just to
+/// filter most of them out; holding the `parking_lot` read guard for the
+/// duration of the (synchronous, non-blocking) `rank_fading` call avoids that
+/// copy entirely. `rank_fading` never awaits, so there is no
+/// await-while-holding-a-lock hazard.
+/// What: Borrows `handle.drawers` for the read, applies `handle.decay_config`,
+/// and returns the ranked, capped list. Read-only — never mutates drawers (no
+/// auto-boost). The guard drops at the end of the call.
 /// Test: covered via `rank_fading` unit tests (pure core) and the
 /// `palace_dream` MCP response-shape test in trusty-memory.
 pub fn detect_fading(handle: &Arc<PalaceHandle>, params: &FadingParams) -> Vec<FadingMemory> {
-    let snapshot = handle.drawers.read().clone();
-    rank_fading(&snapshot, &handle.decay_config, params)
+    rank_fading(&handle.drawers.read(), &handle.decay_config, params)
 }
 
 #[cfg(test)]
@@ -202,6 +209,7 @@ mod tests {
         let p = FadingParams::default();
         assert_eq!(p.resurface_min_base, 0.7);
         assert_eq!(p.resurface_threshold, 0.3);
+        assert_eq!(p.resurface_boost_epsilon, 0.01);
         assert_eq!(p.resurface_top_n, 10);
     }
 
@@ -299,5 +307,150 @@ mod tests {
         let p = preview(&long);
         assert_eq!(p.chars().count(), PREVIEW_MAX_CHARS + 1, "chars + ellipsis");
         assert!(p.ends_with('…'));
+    }
+
+    /// Table-driven boundary tests pinning the exact threshold semantics used
+    /// by `rank_fading`'s filter chain (review follow-up, issue #2352).
+    ///
+    /// Why: filter comparators are easy to get backwards (`>=` vs `>`, `<` vs
+    /// `<=`) at their exact boundary value; a boundary miss silently changes
+    /// which memories resurface. Each case pins one comparator at the literal
+    /// boundary value so an accidental operator flip fails loudly, plus a
+    /// companion "just past the boundary" case so the direction of the
+    /// comparator (not just its presence) is locked.
+    /// What: `base_importance` uses `>=` (inclusive: exactly
+    /// `resurface_min_base` IS a candidate); `effective_importance` uses `<`
+    /// (exclusive: exactly `resurface_threshold` is NOT fading — engineered
+    /// via a custom `floor` equal to the threshold so the post-decay clamp
+    /// lands the value bit-exactly on the boundary, independent of `powf`
+    /// rounding); `accumulated_boost` uses `<` for "unaccessed" (exclusive:
+    /// exactly `resurface_boost_epsilon` IS treated as accessed, so it is NOT
+    /// fading — engineered via `access_boost` set to the epsilon itself so one
+    /// `record_access()` lands bit-exactly on it, since multiplying by the
+    /// integer access count 1 is an exact IEEE-754 identity operation).
+    /// Test: this IS the test.
+    #[test]
+    fn boundary_conditions_table() {
+        let params = FadingParams::default();
+
+        // ── Case 1: base importance exactly at resurface_min_base (0.7) ──────
+        // `>=` is inclusive: the boundary value itself must be a candidate.
+        // Age is large enough that the other two conditions are unambiguously
+        // satisfied, isolating the base-importance boundary.
+        let decay = DecayConfig::default();
+        let base_boundary = aged_drawer(params.resurface_min_base, 360);
+        let out = rank_fading(&[base_boundary], &decay, &params);
+        assert_eq!(
+            out.len(),
+            1,
+            "base == resurface_min_base must be a candidate (>= is inclusive)"
+        );
+
+        // ── Case 2a: effective importance exactly at resurface_threshold (0.3) ─
+        // A custom floor equal to the threshold forces the post-decay clamp to
+        // land exactly on the threshold bit-for-bit, independent of `powf`
+        // rounding. `<` is exclusive: exactly-at-threshold is NOT fading.
+        let decay_floor_at_threshold = DecayConfig {
+            floor: params.resurface_threshold,
+            ..DecayConfig::default()
+        };
+        let eff_at_boundary = aged_drawer(0.7, 360);
+        let out = rank_fading(&[eff_at_boundary], &decay_floor_at_threshold, &params);
+        assert!(
+            out.is_empty(),
+            "effective == resurface_threshold must NOT be fading (< is exclusive)"
+        );
+
+        // ── Case 2b: companion — just below the threshold IS fading ────────────
+        // Proves the comparator direction isn't inverted: a floor just under
+        // the threshold must clamp to a fading value.
+        let decay_floor_below_threshold = DecayConfig {
+            floor: 0.29,
+            ..DecayConfig::default()
+        };
+        let eff_below_boundary = aged_drawer(0.7, 360);
+        let out = rank_fading(&[eff_below_boundary], &decay_floor_below_threshold, &params);
+        assert_eq!(
+            out.len(),
+            1,
+            "effective just below resurface_threshold must be fading"
+        );
+
+        // ── Case 3a: accumulated_boost exactly at resurface_boost_epsilon (0.01) ─
+        // `<` is exclusive: exactly-at-epsilon is treated as "accessed" (NOT
+        // fading).
+        let decay_boost_at_epsilon = DecayConfig {
+            access_boost: params.resurface_boost_epsilon,
+            ..DecayConfig::default()
+        };
+        let mut boost_at_boundary = aged_drawer(0.7, 360);
+        boost_at_boundary.record_access(); // access_count = 1 -> boost = 1 * 0.01 = 0.01 exactly
+        assert_eq!(
+            boost_at_boundary.accumulated_boost(&decay_boost_at_epsilon),
+            0.01,
+            "sanity: boost lands bit-exactly on the epsilon"
+        );
+        let out = rank_fading(&[boost_at_boundary], &decay_boost_at_epsilon, &params);
+        assert!(
+            out.is_empty(),
+            "accumulated_boost == resurface_boost_epsilon must NOT be fading (< is exclusive)"
+        );
+
+        // ── Case 3b: companion — just below the epsilon IS fading ──────────────
+        let decay_boost_below_epsilon = DecayConfig {
+            access_boost: 0.009,
+            ..DecayConfig::default()
+        };
+        let mut boost_below_boundary = aged_drawer(0.7, 360);
+        boost_below_boundary.record_access();
+        let out = rank_fading(&[boost_below_boundary], &decay_boost_below_epsilon, &params);
+        assert_eq!(
+            out.len(),
+            1,
+            "accumulated_boost just below resurface_boost_epsilon must be fading"
+        );
+    }
+
+    /// Locks that `rank_fading` actually honours a non-default `DecayConfig`
+    /// (per-palace override), rather than silently using crate-wide defaults.
+    ///
+    /// Why: `detect_fading` forwards `handle.decay_config` straight through to
+    /// `rank_fading`, exactly like every other decay consumer, so a per-palace
+    /// override must change the resurface outcome. A much shorter half-life
+    /// (30d vs the crate default 90d) makes the contrast unambiguous at the
+    /// same fixed age.
+    /// What: at 90 days of age, a 30-day half-life has elapsed 3 half-lives
+    /// (`base / 8`) — comfortably under the 0.3 threshold, so it flags. The
+    /// default 90-day half-life has elapsed exactly 1 half-life at the same
+    /// age (`base / 2`) — above 0.3, so it does NOT flag. Same drawer, same
+    /// age, different `DecayConfig` in, different verdict out.
+    /// Test: this IS the test.
+    #[test]
+    fn rank_fading_honours_custom_half_life_override() {
+        let params = FadingParams::default();
+        let short_half_life = DecayConfig {
+            half_life_days: 30.0,
+            ..DecayConfig::default()
+        };
+        let default_decay = DecayConfig::default();
+
+        let d_short = aged_drawer(0.8, 90);
+        let d_default = aged_drawer(0.8, 90);
+
+        // 30-day half-life: 3 half-lives elapsed -> 0.8 / 8 = 0.1, under 0.3.
+        let out_short = rank_fading(&[d_short], &short_half_life, &params);
+        assert_eq!(
+            out_short.len(),
+            1,
+            "shorter half-life override must decay far enough to flag"
+        );
+        assert!(out_short[0].effective_importance < params.resurface_threshold);
+
+        // Default 90-day half-life: 1 half-life elapsed -> 0.8 / 2 = 0.4, above 0.3.
+        let out_default = rank_fading(&[d_default], &default_decay, &params);
+        assert!(
+            out_default.is_empty(),
+            "default half-life must not yet have decayed enough to flag at the same age"
+        );
     }
 }

--- a/crates/trusty-common/src/memory_core/dream/fading.rs
+++ b/crates/trusty-common/src/memory_core/dream/fading.rs
@@ -1,0 +1,303 @@
+//! Fading-memories resurface pass (issue #2352).
+//!
+//! Why: Ebbinghaus decay (`decay.rs`) silently pushes originally-important but
+//! un-recalled memories toward the floor. Auto-boosting them would defeat the
+//! forgetting curve, so instead we make them *visible*: each dream cycle
+//! collects a ranked list of high-value memories whose effective importance has
+//! fallen below a threshold, and surfaces it so a human or agent can decide to
+//! touch (natural recall re-boosts) or `memory_forget` them.
+//! What: `FadingParams` (tunables), `FadingMemory` (one surfaced entry), the
+//! pure `rank_fading` detector over a drawer slice, and `detect_fading` which
+//! snapshots a `PalaceHandle` and applies its `DecayConfig`.
+//! Test: `tests` submodule below — flags a high-base aged unaccessed drawer,
+//! rejects fresh / low-base / boosted / protected drawers, verifies ranking +
+//! top-N cap.
+
+use crate::memory_core::decay::DecayConfig;
+use crate::memory_core::palace::Drawer;
+use crate::memory_core::retrieval::PalaceHandle;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// Max characters of drawer content included in a surfaced `FadingMemory`.
+///
+/// Why: The resurface list is a decision aid, not a full dump — a short preview
+/// is enough for an operator to recognise the memory without bloating the MCP
+/// response or the persisted `dream_stats.json`.
+/// What: Content longer than this is truncated on a char boundary and suffixed
+/// with an ellipsis.
+/// Test: `preview_truncates_long_content`.
+const PREVIEW_MAX_CHARS: usize = 120;
+
+/// Tunables for the fading-memories resurface pass.
+///
+/// Why: The detection thresholds must be configurable per deployment (and,
+/// via `DreamConfig`, per palace) without recompiling. Embedded in `DreamConfig`
+/// exactly like `semantic: SemanticConsolidationConfig` so the dream loop owns a
+/// single config surface.
+/// What: `resurface_min_base` gates on original importance; `resurface_threshold`
+/// gates on decayed effective importance; `resurface_boost_epsilon` approximates
+/// "not accessed recently"; `resurface_top_n` caps the ranked output.
+/// Test: `default_params_match_spec`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FadingParams {
+    /// Only memories whose *base* importance is at least this are candidates.
+    /// Default: 0.7 (we only care about resurfacing originally high-value ones).
+    pub resurface_min_base: f32,
+    /// A candidate is fading when its *effective* importance has fallen below
+    /// this. Default: 0.3.
+    pub resurface_threshold: f32,
+    /// Accumulated access boost below which a drawer is treated as "not accessed
+    /// recently". Access recency is not tracked as an independently-decaying
+    /// signal, so we approximate it via the accumulated boost: a value below
+    /// this epsilon means essentially no recall reinforcement. Default: 0.01.
+    pub resurface_boost_epsilon: f32,
+    /// Cap on the number of ranked entries returned. Default: 10.
+    pub resurface_top_n: usize,
+}
+
+impl Default for FadingParams {
+    fn default() -> Self {
+        Self {
+            resurface_min_base: 0.7,
+            resurface_threshold: 0.3,
+            resurface_boost_epsilon: 0.01,
+            resurface_top_n: 10,
+        }
+    }
+}
+
+/// One high-value memory that has decayed below the resurface threshold.
+///
+/// Why: The dream cycle emits these so operators/agents can decide to touch
+/// (recall re-boosts) or forget them — without the cycle auto-boosting and
+/// defeating the forgetting curve. Serialised into `dream_stats.json` and the
+/// `palace_dream` MCP response.
+/// What: The drawer id, its base and current effective importance, its age in
+/// days, and a short content preview.
+/// Test: `flags_high_base_aged_unaccessed_drawer`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FadingMemory {
+    /// Id of the fading drawer (use with `memory_forget` / recall).
+    pub drawer_id: Uuid,
+    /// Original (undecayed) importance the memory was written with.
+    pub base_importance: f32,
+    /// Current effective importance after decay + boost.
+    pub effective_importance: f32,
+    /// Age of the memory in fractional days.
+    pub age_days: f32,
+    /// Short preview of the drawer content (see `PREVIEW_MAX_CHARS`).
+    pub content_preview: String,
+}
+
+/// Truncate `content` to at most `PREVIEW_MAX_CHARS` characters, char-safe.
+///
+/// Why: Keep previews bounded without panicking on multi-byte boundaries.
+/// What: Returns the content unchanged when short; otherwise the first
+/// `PREVIEW_MAX_CHARS` chars plus an ellipsis.
+/// Test: `preview_truncates_long_content`.
+fn preview(content: &str) -> String {
+    if content.chars().count() <= PREVIEW_MAX_CHARS {
+        return content.to_string();
+    }
+    let truncated: String = content.chars().take(PREVIEW_MAX_CHARS).collect();
+    format!("{truncated}…")
+}
+
+/// Detect fading high-value memories in a drawer slice (pure).
+///
+/// Why: The core detection math is factored out of any handle/IO so it can be
+/// unit-tested exhaustively and reused by both the idle dream cycle and the
+/// on-demand `palace_dream` path.
+/// What: Selects non-protected drawers where `base >= resurface_min_base`,
+/// `effective_importance < resurface_threshold`, and `accumulated_boost <
+/// resurface_boost_epsilon` (the "not accessed recently" approximation), ranks
+/// them by base importance desc then age desc, and truncates to
+/// `resurface_top_n`.
+/// Test: `flags_high_base_aged_unaccessed_drawer`, `rejects_fresh_drawer`,
+/// `rejects_low_base_drawer`, `rejects_recently_boosted_drawer`,
+/// `rejects_protected_task_drawer`, `ranks_and_caps`.
+pub fn rank_fading(
+    drawers: &[Drawer],
+    decay: &DecayConfig,
+    params: &FadingParams,
+) -> Vec<FadingMemory> {
+    if params.resurface_top_n == 0 {
+        return Vec::new();
+    }
+
+    let mut fading: Vec<FadingMemory> = drawers
+        .iter()
+        .filter(|d| !d.drawer_type.is_protected())
+        .filter(|d| d.importance >= params.resurface_min_base)
+        .filter_map(|d| {
+            let age_days = DecayConfig::age_days(d.created_at);
+            let boost = d.accumulated_boost(decay);
+            // "Not accessed recently" is approximated by near-zero accumulated
+            // boost: we only resurface memories that received essentially no
+            // recall reinforcement.
+            if boost >= params.resurface_boost_epsilon {
+                return None;
+            }
+            let effective = decay.effective_importance(d.importance, age_days, boost);
+            if effective >= params.resurface_threshold {
+                return None;
+            }
+            Some(FadingMemory {
+                drawer_id: d.id,
+                base_importance: d.importance,
+                effective_importance: effective,
+                age_days,
+                content_preview: preview(&d.content),
+            })
+        })
+        .collect();
+
+    // Rank: highest base importance first; break ties by oldest (largest age).
+    fading.sort_by(|a, b| {
+        b.base_importance
+            .partial_cmp(&a.base_importance)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(
+                b.age_days
+                    .partial_cmp(&a.age_days)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+    });
+    fading.truncate(params.resurface_top_n);
+    fading
+}
+
+/// Detect fading memories for a live palace handle.
+///
+/// Why: The dream cycle and the `palace_dream` MCP handler both need a
+/// palace-wide fading list computed against that palace's own `DecayConfig`
+/// (per-palace override); this snapshots the drawer table and delegates to the
+/// pure `rank_fading`.
+/// What: Reads `handle.drawers`, applies `handle.decay_config`, and returns the
+/// ranked, capped list. Read-only — never mutates drawers (no auto-boost).
+/// Test: covered via `rank_fading` unit tests (pure core) and the
+/// `palace_dream` MCP response-shape test in trusty-memory.
+pub fn detect_fading(handle: &Arc<PalaceHandle>, params: &FadingParams) -> Vec<FadingMemory> {
+    let snapshot = handle.drawers.read().clone();
+    rank_fading(&snapshot, &handle.decay_config, params)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory_core::palace::DrawerType;
+
+    /// Build a drawer with an explicit importance and created-at age in days.
+    fn aged_drawer(importance: f32, age_days: i64) -> Drawer {
+        let mut d = Drawer::new(Uuid::new_v4(), "an important thing worth remembering");
+        d.importance = importance;
+        d.created_at = chrono::Utc::now() - chrono::Duration::days(age_days);
+        d
+    }
+
+    #[test]
+    fn default_params_match_spec() {
+        let p = FadingParams::default();
+        assert_eq!(p.resurface_min_base, 0.7);
+        assert_eq!(p.resurface_threshold, 0.3);
+        assert_eq!(p.resurface_top_n, 10);
+    }
+
+    #[test]
+    fn flags_high_base_aged_unaccessed_drawer() {
+        let decay = DecayConfig::default();
+        let params = FadingParams::default();
+        // base 0.8, aged 360d: eff = 0.8 * 2^(-360/90) = 0.8 * 0.0625 = 0.05
+        // which is < 0.3 threshold; no access boost.
+        let d = aged_drawer(0.8, 360);
+        let out = rank_fading(&[d], &decay, &params);
+        assert_eq!(out.len(), 1, "high-base aged unaccessed drawer should flag");
+        assert!(out[0].effective_importance < params.resurface_threshold);
+        assert_eq!(out[0].base_importance, 0.8);
+    }
+
+    #[test]
+    fn rejects_fresh_drawer() {
+        let decay = DecayConfig::default();
+        let params = FadingParams::default();
+        // Fresh: eff ~= base 0.8, well above threshold.
+        let d = aged_drawer(0.8, 0);
+        assert!(rank_fading(&[d], &decay, &params).is_empty());
+    }
+
+    #[test]
+    fn rejects_low_base_drawer() {
+        let decay = DecayConfig::default();
+        let params = FadingParams::default();
+        // Low base (0.5 < 0.7 min_base) even though it has decayed.
+        let d = aged_drawer(0.5, 360);
+        assert!(rank_fading(&[d], &decay, &params).is_empty());
+    }
+
+    #[test]
+    fn rejects_recently_boosted_drawer() {
+        let decay = DecayConfig::default();
+        let params = FadingParams::default();
+        let mut d = aged_drawer(0.8, 360);
+        // Simulate recall reinforcement: accumulated_boost >= epsilon.
+        d.record_access();
+        assert!(
+            d.accumulated_boost(&decay) >= params.resurface_boost_epsilon,
+            "one access should exceed the tiny epsilon"
+        );
+        assert!(
+            rank_fading(&[d], &decay, &params).is_empty(),
+            "a reinforced drawer is not fading"
+        );
+    }
+
+    #[test]
+    fn rejects_protected_task_drawer() {
+        let decay = DecayConfig::default();
+        let params = FadingParams::default();
+        let mut d = aged_drawer(0.9, 360);
+        d.drawer_type = DrawerType::Task;
+        assert!(
+            rank_fading(&[d], &decay, &params).is_empty(),
+            "protected Task drawers are never resurfaced"
+        );
+    }
+
+    #[test]
+    fn ranks_and_caps() {
+        let decay = DecayConfig::default();
+        let params = FadingParams {
+            resurface_top_n: 2,
+            ..FadingParams::default()
+        };
+        // Three fading candidates with different base importances.
+        let a = aged_drawer(0.75, 360);
+        let b = aged_drawer(0.95, 360);
+        let c = aged_drawer(0.85, 360);
+        let out = rank_fading(&[a, b, c], &decay, &params);
+        assert_eq!(out.len(), 2, "capped at top_n");
+        assert_eq!(out[0].base_importance, 0.95, "highest base first");
+        assert_eq!(out[1].base_importance, 0.85);
+    }
+
+    #[test]
+    fn top_n_zero_returns_empty() {
+        let decay = DecayConfig::default();
+        let params = FadingParams {
+            resurface_top_n: 0,
+            ..FadingParams::default()
+        };
+        let d = aged_drawer(0.8, 360);
+        assert!(rank_fading(&[d], &decay, &params).is_empty());
+    }
+
+    #[test]
+    fn preview_truncates_long_content() {
+        let long = "x".repeat(PREVIEW_MAX_CHARS + 50);
+        let p = preview(&long);
+        assert_eq!(p.chars().count(), PREVIEW_MAX_CHARS + 1, "chars + ellipsis");
+        assert!(p.ends_with('…'));
+    }
+}

--- a/crates/trusty-common/src/memory_core/dream/mod.rs
+++ b/crates/trusty-common/src/memory_core/dream/mod.rs
@@ -11,6 +11,7 @@
 mod config;
 mod cycle;
 mod dreamer;
+mod fading;
 mod guard;
 mod helpers;
 mod recall_benchmark;
@@ -23,4 +24,5 @@ mod tests;
 pub use config::{DreamConfig, DreamStats, PersistedDreamStats};
 pub use cycle::{RoomConsolidationStats, consolidate_scoped};
 pub use dreamer::Dreamer;
+pub use fading::{FadingMemory, FadingParams, detect_fading, rank_fading};
 pub use helpers::extract_keywords;

--- a/crates/trusty-memory/src/service/types.rs
+++ b/crates/trusty-memory/src/service/types.rs
@@ -59,6 +59,12 @@ pub struct DreamStatusPayload {
     pub compacted: usize,
     pub closets_updated: usize,
     pub duration_ms: u64,
+    /// Fading high-value memories recorded by the last dream cycle (issue
+    /// #2352). Populated from a per-palace snapshot via `From<PersistedDreamStats>`;
+    /// left empty on the cross-palace aggregate endpoint (no single palace to
+    /// attribute). `#[serde(default)]` keeps it omissible for older clients.
+    #[serde(default)]
+    pub fading: Vec<trusty_common::memory_core::dream::FadingMemory>,
 }
 
 impl From<PersistedDreamStats> for DreamStatusPayload {
@@ -70,6 +76,7 @@ impl From<PersistedDreamStats> for DreamStatusPayload {
             compacted: p.stats.compacted,
             closets_updated: p.stats.closets_updated,
             duration_ms: p.stats.duration_ms,
+            fading: p.stats.fading,
         }
     }
 }

--- a/crates/trusty-memory/src/tools/dream_ops.rs
+++ b/crates/trusty-memory/src/tools/dream_ops.rs
@@ -14,9 +14,9 @@
 //! `dream::tests::consolidate_scoped_*` in trusty-common (behaviour).
 
 use crate::AppState;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde_json::{json, Value};
-use trusty_common::memory_core::dream::{consolidate_scoped, DreamConfig};
+use trusty_common::memory_core::dream::{consolidate_scoped, detect_fading, DreamConfig};
 
 use super::helpers::{open_palace_handle, parse_room, resolve_palace};
 
@@ -32,9 +32,13 @@ const DEFAULT_MAX_AGE_DAYS: i64 = 7;
 /// (default 7), builds a `DreamConfig` seeded with the daemon's OpenRouter key
 /// and local-model flag, opens the palace, and runs `consolidate_scoped`. When
 /// no inference backend is configured the helper is a graceful no-op (zero
-/// counts). Returns `{ palace, room, summary_facts_created, facts_evicted }`.
-/// Test: `dream_consolidate_room_returns_shape` (no-op path) in
-/// `tests/dream_room_mcp.rs`.
+/// counts). Also computes the palace-wide fading-memories resurface list (issue
+/// #2352) — high-value memories that have decayed below the resurface threshold,
+/// surfaced (never auto-boosted) so the caller can touch or `memory_forget`
+/// them. Returns
+/// `{ palace, room, summary_facts_created, facts_evicted, fading }`.
+/// Test: `dream_consolidate_room_returns_shape` (no-op path) and
+/// `palace_dream_response_includes_fading` in `tests/dream_room_mcp.rs`.
 pub(crate) async fn handle_dream_consolidate_room(state: &AppState, args: Value) -> Result<Value> {
     let palace = resolve_palace(state, &args, "dream_consolidate_room")?;
     // Absent / null / empty room => all rooms; otherwise scope to that room.
@@ -68,11 +72,18 @@ pub(crate) async fn handle_dream_consolidate_room(state: &AppState, args: Value)
 
     let stats = consolidate_scoped(&handle, &dream_cfg, room, max_age_days, None).await?;
 
+    // Fading-memories resurface pass (issue #2352): palace-wide, read-only.
+    // Surfaced here so the on-demand caller sees the same list the idle dream
+    // cycle records in dream_stats.json.
+    let fading = detect_fading(&handle, &dream_cfg.fading);
+    let fading = serde_json::to_value(&fading).context("serialize fading list")?;
+
     Ok(json!({
         "palace": palace,
         "room": room_arg,
         "summary_facts_created": stats.summary_facts_created,
         "facts_evicted": stats.facts_evicted,
+        "fading": fading,
     }))
 }
 

--- a/crates/trusty-memory/tests/dream_room_mcp.rs
+++ b/crates/trusty-memory/tests/dream_room_mcp.rs
@@ -106,3 +106,39 @@ async fn palace_dream_no_inference_returns_gracefully() {
     assert_eq!(result["summary_facts_created"], 0);
     assert_eq!(result["facts_evicted"], 0);
 }
+
+/// `palace_dream` surfaces the fading-memories resurface list (issue #2352).
+///
+/// Why: the resurface pass must reach the MCP surface so operators/agents can
+/// act on fading high-value memories. This asserts the response carries a
+/// `fading` array. It is empty here (a freshly-created palace has no aged,
+/// decayed drawers — created_at is "now"); the detection/ranking math is
+/// exhaustively covered by `trusty_common::memory_core::dream::fading::tests`.
+/// What: creates an empty palace, calls `palace_dream`, and asserts the
+/// `fading` field is present and is an (empty) array.
+#[tokio::test]
+async fn palace_dream_response_includes_fading() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = ready_state(&tmp);
+    let cwd = tmp.path().to_string_lossy().to_string();
+
+    dispatch_tool(
+        &state,
+        "palace_create",
+        json!({ "name": "fadingapp", "force": true, "cwd": cwd }),
+    )
+    .await
+    .expect("create palace");
+
+    let result = dispatch_tool(&state, "palace_dream", json!({ "palace": "fadingapp" }))
+        .await
+        .expect("palace_dream returns");
+
+    let fading = &result["fading"];
+    assert!(fading.is_array(), "response must carry a `fading` array");
+    assert_eq!(
+        fading.as_array().map(|a| a.len()),
+        Some(0),
+        "a fresh palace has no fading memories"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a **fading-memories resurface pass** to the trusty-memory dream cycle
(Closes #2352). Each dream cycle now detects originally high-value memories whose
Ebbinghaus-decayed effective importance has fallen below a threshold and surfaces
them — **without auto-boosting** (that would defeat the forgetting curve) — so an
operator or agent can decide to *touch* (natural recall re-boosts) or
`memory_forget` them.

## Design

`crates/trusty-common/src/memory_core/decay.rs` computes
`effective_importance = (base * 2^(-age_days/half_life) + access_boost).clamp(floor, 1.0)`
(half-life 90d, floor 0.05). Memories written as important but never recalled
silently decay toward the floor. Instead of touching them, the cycle collects a
ranked, capped list and exposes it.

### Detection criteria (never applies to protected `Task` drawers)
A drawer is **fading** when ALL hold:
- `base importance (drawer.importance) >= resurface_min_base` — default **0.7**
- `effective_importance (per palace DecayConfig) < resurface_threshold` — default **0.3**
- **not accessed recently**: access recency is not tracked as an independently
  decaying signal, so it is approximated as `accumulated_boost <
  resurface_boost_epsilon` (default **0.01**) — i.e. essentially no recall
  reinforcement. This approximation is documented in `fading.rs`.

Ranked by **base importance desc, then age desc** (oldest first on ties), capped
at `resurface_top_n` (default **10**).

### Config
New `FadingParams` sub-config embedded in `DreamConfig` (mirrors the existing
`semantic: SemanticConsolidationConfig` pattern). The decay math uses the
palace's own `handle.decay_config`, so per-palace decay overrides are honoured.

### Surfacing
1. Recorded on `DreamStats.fading` (serde-default, backward compatible) and
   persisted to `dream_stats.json`, so the list survives until the next cycle.
2. Added to the `palace_dream` (and `dream_consolidate_room`) MCP tool response
   as a `fading` array.
3. Added to the per-palace HTTP dream-status payload (`DreamStatusPayload`);
   the cross-palace aggregate leaves it empty (no single palace to attribute).

## Scheduler-state finding

The 2026-06-21 note that the `Dreamer` background scheduler was dormant is
**stale**. `dream_scheduler::spawn_dream_scheduler` /
`spawn_background_maintenance` is now wired into daemon startup
(`crates/trusty-memory/src/main.rs:899`), so idle cycles run on the ~300s timer
(gated by `TRUSTY_DREAM_DISABLED`). The `palace_dream` MCP tool still routes to
`consolidate_scoped` (room-scoped LLM path), so this PR computes the palace-wide
fading list there directly. **No scheduler wiring was changed.**

## Files changed

**trusty-common**
- `memory_core/dream/fading.rs` (new, 187 SLOC) — `FadingParams`, `FadingMemory`,
  pure `rank_fading`, `detect_fading`, + 9 unit tests
- `memory_core/dream/mod.rs` — module + re-exports
- `memory_core/dream/config.rs` — `DreamConfig.fading`, `DreamStats.fading`
- `memory_core/dream/dreamer.rs` — run the pass, record on stats, log count

**trusty-memory**
- `tools/dream_ops.rs` — include `fading` in the `palace_dream` response
- `service/types.rs` — `fading` on `DreamStatusPayload` + `From<PersistedDreamStats>`
- `tests/dream_room_mcp.rs` — MCP response-shape test

## Verification (raw)

- `cargo build --workspace` → `Finished` (clean)
- `cargo test --workspace` → **12964 passed; 0 failed; 102 ignored** (124 suites)
- `cargo test -p trusty-common --features memory-core --lib` → **463 passed; 0 failed; 11 ignored**
  - `dream::fading::tests` → 9 passed (flags aged high-base unaccessed drawer;
    rejects fresh / low-base / boosted / protected; ranking + top-N cap; preview)
- `cargo test -p trusty-memory --test dream_room_mcp` → 3 passed (incl.
  `palace_dream_response_includes_fading`)
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo fmt --check` → clean
- `bash scripts/check_line_cap.sh` → `0 violations — OK`
