### PR TITLE
docs: mark DOC-30 superseded by #2108/#2109 split

### DIFF
--- a/docs/specs/DOC-30-project-manager-vision.md
+++ b/docs/specs/DOC-30-project-manager-vision.md
@@ -1,5 +1,7 @@
 # DOC-30 — Project Manager: Vision & Lifecycle Orchestrator
 
+> **SUPERSEDED (2026-07-10):** This vision is superseded by the #2108 (`tm project`, deterministic control plane) + #2109 (`tm manager`, portfolio inference layer) epic split. Retained for historical context; do not implement from this document. See issue #1878 for unique content folded into #2108/#2109.
+
 **Status:** DRAFT — Vision & Design Work Only (0% implemented)
 **Subsystem:** trusty-mpm — project-level orchestration / user-facing surface
 **Owner:** Product / Engineering (trusty-mpm)


### PR DESCRIPTION
## Summary

Add prominent supersession banner at the top of `docs/specs/DOC-30-project-manager-vision.md` noting that this vision is superseded by the #2108 (`tm project`, deterministic control plane) + #2109 (`tm manager`, inference/portfolio layer) epic split per Bob's 2026-07-10 decision.

**Related issues:** Closes #1878 (now closed as "not planned")

## Context

DOC-30 was a comprehensive vision for a Project Manager orchestration layer. The 2026-07-06 split into #2108 and #2109 supersedes this unified vision:
- **#2108 (`tm project`)** covers the deterministic control plane: project registry, session lifecycle, per-session status, CLI + multipane TUI.
- **#2109 (`tm manager`)** covers the inference/agentic layer on top of #2108 for portfolio oversight, external channels, and agent-driven supervision.

Unique content from DOC-30 (Deliverable/Milestone model, estimation tiers, design decision rationales) has been captured in #1878 comment for folding into #2108/#2109 specs.

DOC-30 is retained for historical/decision-record purposes only and marked with the supersession banner.

## Test plan

- [x] Docs-only change (supersession banner added to DOC-30)
- [x] CI passes (no code changes)
- [x] Manual verification: banner is prominent and links to #2108/#2109

🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools