### PR TITLE
feat(trusty-code): turn recorder — durable per-turn dual-write to trusty-memory

### DIFF
--- a/crates/trusty-code/src/session/memory_sink.rs
+++ b/crates/trusty-code/src/session/memory_sink.rs
@@ -1,0 +1,220 @@
+//! Turn recorder (#2345): durable per-turn dual-write to trusty-memory.
+//!
+//! Why: epic #2343 (Infinite Sessions) requires every PM prompt/response
+//! turn to be durably recorded in trusty-memory, independent of the
+//! in-process `Transcript` (#2344), which only lives as long as the daemon
+//! process. Without this, a daemon restart or crash loses the entire
+//! conversation; #2348's future `recall_session` tool also needs a semantic
+//! recall surface over session history that a bare `chat_turn_append` record
+//! alone would not give it (it stores the exact turn but is not
+//! embedded/indexed for recall the way `memory_remember` is).
+//! What: [`TurnMemorySink`] owns a bounded `tokio::sync::mpsc` queue and a
+//! background drain task. [`TurnMemorySink::enqueue`] is the non-blocking
+//! producer side, called from `task::executor::run_and_record` at each turn
+//! boundary. The drain task calls BOTH `chat_turn_append` (the exact
+//! chronological record) and `memory_remember` (tagged
+//! `["session:<id>", "turn"]` — the semantic recall surface for #2348) via
+//! `trusty_common::mcp::memory_rpc::call_memory_tool_at`, against a base URL
+//! resolved ONCE at construction — never blocking or failing the calling
+//! turn: any RPC failure is logged via `tracing::warn!` and dropped.
+//! [`derive_palace_id_for_project`] mirrors
+//! `trusty_common::catchup`'s (private) palace-derivation convention so a
+//! session's turns land in the same palace its PM catch-up digest reads
+//! from.
+//! Test: `memory_sink::tests::*`.
+
+use std::path::Path;
+
+use serde_json::json;
+use tokio::sync::mpsc;
+use tracing::warn;
+use trusty_common::mcp::memory_rpc::call_memory_tool_at;
+
+/// Bounded mpsc queue capacity (#2345 scope: "~50").
+///
+/// Why: bounds memory use when trusty-memory is slow or unreachable for a
+/// long stretch; a session realistically produces at most one turn per LLM
+/// round trip, so 50 in-flight turns is generous slack before the overflow
+/// policy below kicks in.
+/// Test: `memory_sink::tests::enqueue_drops_newest_when_queue_full`.
+pub const QUEUE_CAPACITY: usize = 50;
+
+/// One user-prompt/assistant-response turn queued for durable dual-write.
+#[derive(Debug, Clone)]
+struct QueuedTurn {
+    session_id: String,
+    prompt: String,
+    response: String,
+}
+
+/// Async, fire-and-forget durable-write sink for one session's turns (#2345).
+///
+/// Why: see module docs.
+/// What: `enqueue` never blocks the calling turn and never fails visibly —
+/// see its docs for the overflow policy. The background drain task owns the
+/// only receiver, so it keeps running for exactly as long as this sink (and
+/// therefore the channel's sender half) stays alive — the session's
+/// `SessionEntry` holds the constructed `Arc<TurnMemorySink>` for the
+/// session's lifetime (built once, lazily, on the session's first
+/// `task.run` — see `SessionRegistry::memory_sink_for`), so the drain task
+/// naturally survives across every run on that session, not just one.
+pub struct TurnMemorySink {
+    tx: mpsc::Sender<QueuedTurn>,
+}
+
+impl TurnMemorySink {
+    /// Construct a sink writing to `palace` at the given (already-resolved)
+    /// `base_url`, and spawn its background drain task with the default
+    /// [`QUEUE_CAPACITY`].
+    /// Test: `memory_sink::tests::enqueue_drain_happy_path`.
+    pub fn new(base_url: String, palace: String) -> Self {
+        Self::with_capacity(base_url, palace, QUEUE_CAPACITY)
+    }
+
+    /// Same as [`Self::new`] with an explicit queue capacity — tests use a
+    /// tiny capacity to exercise the overflow policy cheaply.
+    ///
+    /// Why: `base_url` is resolved ONCE by the caller (mirroring
+    /// `catchup::pm_catchup_context`'s own
+    /// `resolve_memory_base_url_or_unreachable()` call) rather than
+    /// re-resolved on every enqueued turn — the daemon's bound address does
+    /// not change mid-session, and re-resolving on every turn would add
+    /// discovery-file I/O to the hot drain path for no benefit. Tests inject
+    /// a mock server's URL directly here instead of mutating the
+    /// process-global `TRUSTY_MEMORY_URL` env var (unsafe across parallel
+    /// tests).
+    /// What: spawns [`drain`] as a detached `tokio::spawn`ed task owning the
+    /// receiver half of a `capacity`-bounded channel; returns the sink
+    /// holding only the sender half.
+    /// Test: `memory_sink::tests::enqueue_drops_newest_when_queue_full`.
+    pub fn with_capacity(base_url: String, palace: String, capacity: usize) -> Self {
+        let (tx, rx) = mpsc::channel(capacity);
+        tokio::spawn(drain(base_url, palace, rx));
+        Self { tx }
+    }
+
+    /// Enqueue one turn for durable dual-write, never blocking the caller.
+    ///
+    /// Why: turn recording must NEVER stall or fail a running turn (#2345
+    /// acceptance criteria) — a slow or wedged drain task must not back up
+    /// into the agent loop.
+    /// What: `try_send`s onto the bounded channel. Overflow policy: DROP THE
+    /// NEWEST turn (this call's turn) rather than evicting an
+    /// already-queued older one — the simplest policy `mpsc::Sender::
+    /// try_send` supports directly (no peek/pop-front on the sender side
+    /// without a different channel type), logged via `tracing::warn!` so an
+    /// operator can see it happened. A closed receiver (the drain task
+    /// panicked or was dropped) degrades the same way: logged, dropped, no
+    /// error surfaced to the caller.
+    /// Test: `memory_sink::tests::enqueue_drops_newest_when_queue_full`.
+    pub fn enqueue(
+        &self,
+        session_id: impl Into<String>,
+        prompt: impl Into<String>,
+        response: impl Into<String>,
+    ) {
+        let turn = QueuedTurn {
+            session_id: session_id.into(),
+            prompt: prompt.into(),
+            response: response.into(),
+        };
+        match self.tx.try_send(turn) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                warn!("turn_recorder: queue full (capacity reached) — dropping newest turn");
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                warn!("turn_recorder: drain task gone — dropping turn");
+            }
+        }
+    }
+}
+
+/// Background drain loop: pop turns off the channel and dual-write each one,
+/// fail-open (see [`write_turn`]).
+async fn drain(base_url: String, palace: String, mut rx: mpsc::Receiver<QueuedTurn>) {
+    while let Some(turn) = rx.recv().await {
+        write_turn(&base_url, &palace, &turn).await;
+    }
+}
+
+/// Dual-write one turn: `chat_turn_append` (the exact chronological record)
+/// THEN `memory_remember` (the semantic recall surface, #2348).
+///
+/// Why: the exact and semantic representations are independent trusty-memory
+/// endpoints; a mid-outage failure of one must not block the other, so each
+/// call's error is handled separately rather than short-circuiting on the
+/// first failure.
+/// What: never propagates an error — every failure is logged via
+/// `tracing::warn!` and swallowed, matching
+/// `resolve_memory_base_url_or_unreachable`'s fail-open contract (mirrored
+/// here, not reused directly, since `base_url` is already resolved by the
+/// caller of [`TurnMemorySink::new`]).
+/// Test: `memory_sink::tests::enqueue_drain_happy_path`,
+/// `memory_sink::tests::write_turn_is_fail_open_on_unreachable_daemon`.
+async fn write_turn(base_url: &str, palace: &str, turn: &QueuedTurn) {
+    let append_params = json!({
+        "palace": palace,
+        "session_id": turn.session_id,
+        "prompt": turn.prompt,
+        "response": turn.response,
+    });
+    if let Err(e) = call_memory_tool_at(base_url, "chat_turn_append", append_params).await {
+        warn!(
+            session_id = %turn.session_id,
+            error = %e,
+            "turn_recorder: chat_turn_append failed (fail-open)"
+        );
+    }
+
+    let remember_params = json!({
+        "palace": palace,
+        "text": format!("User: {}\n\nAssistant: {}", turn.prompt, turn.response),
+        "tags": [format!("session:{}", turn.session_id), "turn"],
+    });
+    if let Err(e) = call_memory_tool_at(base_url, "memory_remember", remember_params).await {
+        warn!(
+            session_id = %turn.session_id,
+            error = %e,
+            "turn_recorder: memory_remember failed (fail-open)"
+        );
+    }
+}
+
+/// Derive the palace id for a project directory (#2345).
+///
+/// Why: mirrors `trusty_common::catchup`'s own (private-to-that-module)
+/// `derive_palace_id_for` convention exactly, so a session's turns land in
+/// the SAME palace `catchup::pm_catchup_context` reads its digest from — the
+/// PM's own catch-up section and the turn recorder's writes must agree on
+/// "which palace is this project."
+/// What: probes `git config --get remote.origin.url` from `project_dir`,
+/// then calls `trusty_common::derive_palace_id` (explicit override env ->
+/// git owner/repo slug -> parent/dir slug), falling back to the directory's
+/// basename (or `"unknown-project"`) when all three yield `None`.
+/// Test: `memory_sink::tests::derive_palace_id_for_project_falls_back_to_dirname`.
+pub fn derive_palace_id_for_project(project_dir: &Path) -> String {
+    let remote = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_dir)
+        .args(["config", "--get", "remote.origin.url"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let override_val = trusty_common::palace_override_from_env();
+    trusty_common::derive_palace_id(project_dir, remote.as_deref(), override_val.as_deref())
+        .unwrap_or_else(|| {
+            project_dir
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown-project")
+                .to_string()
+        })
+}
+
+#[cfg(test)]
+#[path = "memory_sink_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/session/memory_sink_tests.rs
+++ b/crates/trusty-code/src/session/memory_sink_tests.rs
@@ -1,0 +1,176 @@
+//! Unit tests for [`super::TurnMemorySink`] and
+//! [`super::derive_palace_id_for_project`] (#2345).
+//!
+//! Why: the turn recorder must never block/fail a running turn even when
+//! trusty-memory is unreachable, must dual-write both `chat_turn_append` and
+//! `memory_remember` with the documented params/tags against a live mock
+//! daemon, and must apply its documented "drop newest" overflow policy —
+//! none of that is exercised anywhere else.
+//! What: `enqueue_drain_happy_path` spins up a tiny in-process axum mock
+//! `/rpc` server (mirrors `trusty_common::mcp::memory_rpc`'s own test
+//! pattern) and asserts both calls land with the right shape;
+//! `enqueue_drops_newest_when_queue_full` exercises the overflow policy
+//! directly against the raw channel (no networking, fully deterministic);
+//! `write_turn_is_fail_open_on_unreachable_daemon` proves an unreachable
+//! `base_url` never panics or hangs; `derive_palace_id_for_project_*` cover
+//! the palace-derivation fallback chain.
+//! Test: this file.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+
+use super::*;
+
+/// One captured `/rpc` call: the JSON-RPC `method` and its `params`.
+type Captured = Arc<Mutex<Vec<(String, Value)>>>;
+
+/// Spin up a tiny in-process `/rpc` mock that captures every request and
+/// always replies with a successful JSON-RPC envelope.
+///
+/// Why: `TurnMemorySink`'s drain task must be observed making REAL HTTP
+/// calls with the correct method/params shape — a mock server is the only
+/// way to assert that without a live trusty-memory daemon.
+/// What: binds an ephemeral port, spawns `axum::serve` detached (the test
+/// process exits with it), and returns the base URL plus the shared capture
+/// buffer.
+async fn spawn_capturing_mock() -> (String, Captured) {
+    let captured: Captured = Arc::new(Mutex::new(Vec::new()));
+    let store = Arc::clone(&captured);
+
+    async fn handle(State(store): State<Captured>, Json(body): Json<Value>) -> Json<Value> {
+        let method = body["method"].as_str().unwrap_or_default().to_string();
+        let params = body["params"].clone();
+        store
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push((method, params));
+        Json(json!({"jsonrpc": "2.0", "id": 1, "result": {"ok": true}}))
+    }
+
+    let app = Router::new().route("/rpc", post(handle)).with_state(store);
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), captured)
+}
+
+/// Poll `captured` until it holds at least `n` entries or `timeout` elapses.
+async fn wait_for_captures(captured: &Captured, n: usize, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if captured.lock().unwrap_or_else(|e| e.into_inner()).len() >= n
+            || tokio::time::Instant::now() >= deadline
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Enqueuing one turn against a live mock daemon must land BOTH
+/// `chat_turn_append` (exact record) and `memory_remember` (semantic recall
+/// surface, tagged `session:<id>` + `turn`) with the documented params.
+#[tokio::test]
+async fn enqueue_drain_happy_path() {
+    let (base_url, captured) = spawn_capturing_mock().await;
+    let sink = TurnMemorySink::new(base_url, "test-palace".to_string());
+
+    sink.enqueue("sess-1", "what is 2+2?", "4");
+    wait_for_captures(&captured, 2, Duration::from_secs(2)).await;
+
+    let calls = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    assert_eq!(calls.len(), 2, "expected both dual-write calls to land");
+
+    let append = calls
+        .iter()
+        .find(|(m, _)| m == "chat_turn_append")
+        .expect("chat_turn_append call");
+    assert_eq!(append.1["palace"], "test-palace");
+    assert_eq!(append.1["session_id"], "sess-1");
+    assert_eq!(append.1["prompt"], "what is 2+2?");
+    assert_eq!(append.1["response"], "4");
+
+    let remember = calls
+        .iter()
+        .find(|(m, _)| m == "memory_remember")
+        .expect("memory_remember call");
+    assert_eq!(remember.1["palace"], "test-palace");
+    let tags: Vec<String> = remember.1["tags"]
+        .as_array()
+        .expect("tags array")
+        .iter()
+        .map(|t| t.as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(tags.contains(&"session:sess-1".to_string()));
+    assert!(tags.contains(&"turn".to_string()));
+    assert!(
+        remember.1["text"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("what is 2+2?")
+    );
+}
+
+/// An unreachable `base_url` must never panic or hang the drain task — the
+/// core fail-open contract (#2345 acceptance criteria).
+#[tokio::test]
+async fn write_turn_is_fail_open_on_unreachable_daemon() {
+    let sink = TurnMemorySink::new("http://127.0.0.1:1".to_string(), "p".to_string());
+    sink.enqueue("sess-2", "prompt", "response");
+    // Give the drain task a moment to attempt (and fail) the calls; the test
+    // passing at all (no panic, no hang) is the assertion.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+/// `enqueue` must drop the NEWEST turn (not block) once the bounded channel
+/// is full, per its documented overflow policy.
+///
+/// Why: exercised directly against the raw channel (constructing
+/// `TurnMemorySink` from a sender with no drain task consuming it) so the
+/// overflow behaviour is deterministic — no networking, no timing races
+/// against a live consumer.
+#[test]
+fn enqueue_drops_newest_when_queue_full() {
+    let (tx, mut rx) = mpsc::channel(1);
+    let sink = TurnMemorySink { tx };
+
+    sink.enqueue("s1", "p1", "r1");
+    sink.enqueue("s1", "p2", "r2"); // queue is full; this one must be dropped
+
+    let first = rx.try_recv().expect("first turn should have been queued");
+    assert_eq!(first.prompt, "p1");
+    assert!(
+        rx.try_recv().is_err(),
+        "second turn must have been dropped, not queued"
+    );
+}
+
+/// No git remote, no override -> falls back to a non-empty, stable slug
+/// derived from the directory (never panics, never empty).
+///
+/// Why: this is a plain (non-git) temp dir, so `derive_palace_id_for_project`
+/// must exercise its final fallback branch rather than the git-remote or
+/// override branches; the exact slug shape is `derive_palace_id`'s concern
+/// (already unit-tested in `trusty-common`), so this only asserts the
+/// contract this function adds: non-empty and deterministic.
+#[test]
+fn derive_palace_id_for_project_falls_back_to_dirname() {
+    let tmp = TempDir::new().expect("tempdir");
+    let first = derive_palace_id_for_project(tmp.path());
+    let second = derive_palace_id_for_project(tmp.path());
+    assert!(!first.is_empty(), "expected a non-empty fallback palace id");
+    assert_eq!(
+        first, second,
+        "derivation must be deterministic for the same path"
+    );
+}

--- a/crates/trusty-code/src/session/mod.rs
+++ b/crates/trusty-code/src/session/mod.rs
@@ -12,18 +12,22 @@
 //! What: [`model::Session`]/[`model::SessionStatus`] (the domain type),
 //! [`registry::SessionRegistry`] (storage + ring buffer + attach/detach +,
 //! since #2056, execution tracking), [`transcript::TranscriptRecord`]
-//! (#2058's `session.get_transcript` response DTO), and [`protocol::register`]
-//! (wires `session.create`/`list`/`status`/`send`/`attach`/`detach`/`cancel`/
+//! (#2058's `session.get_transcript` response DTO), [`memory_sink::TurnMemorySink`]
+//! (#2345's durable per-turn dual-write to trusty-memory, owned per-session
+//! by `registry::SessionRegistry`), and [`protocol::register`] (wires
+//! `session.create`/`list`/`status`/`send`/`attach`/`detach`/`cancel`/
 //! `get_transcript` onto a `Router`).
 //! Test: `model::tests::*`, `registry::registry_tests::*`,
 //! `protocol::tests::*`; end-to-end over the real daemon in
 //! `tests/session_e2e.rs` and (#2058) `tests/task_e2e.rs`.
 
+pub mod memory_sink;
 pub mod model;
 pub mod protocol;
 pub mod registry;
 pub mod transcript;
 
+pub use memory_sink::TurnMemorySink;
 pub use model::{Session, SessionStatus};
 pub use registry::SessionRegistry;
 pub use transcript::TranscriptRecord;

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -98,6 +98,13 @@ struct SessionEntry {
     /// ends, regardless of outcome, so the NEXT run continues from exactly
     /// where this one left off.
     pm_transcript: Option<Transcript>,
+    /// (#2345) The session's durable turn-recorder sink — `None` until the
+    /// session's first `task.run` lazily constructs it via
+    /// [`SessionRegistry::memory_sink_for`] (the project directory, needed to
+    /// derive the palace id, is only known once a run starts). Built once and
+    /// reused for the life of the session (see `memory_sink` module docs for
+    /// why its background drain task must outlive any single run).
+    memory_sink: Option<Arc<super::memory_sink::TurnMemorySink>>,
 }
 
 /// #2056: bookkeeping for one in-flight background task execution.
@@ -189,6 +196,7 @@ impl SessionRegistry {
                     usage: TokenUsage::default(),
                     cost_usd: None,
                     pm_transcript: None,
+                    memory_sink: None,
                 },
             );
         }
@@ -890,6 +898,11 @@ fn spawn_forwarder(session_id: String, notify: NotifySender, cancel_rx: oneshot:
 /// exactly the same way as if they lived here.
 #[path = "registry_events.rs"]
 mod events;
+
+/// #2345 turn-recorder sink lazy-init/lookup, split out into its own file for
+/// the same 500-SLOC-cap reason as `events` above.
+#[path = "registry_memory_sink.rs"]
+mod memory_sink_ext;
 
 #[cfg(test)]
 #[path = "registry_tests.rs"]

--- a/crates/trusty-code/src/session/registry_memory_sink.rs
+++ b/crates/trusty-code/src/session/registry_memory_sink.rs
@@ -1,0 +1,63 @@
+//! `SessionRegistry`'s #2345 turn-recorder sink lazy-init/lookup. Split out
+//! of `registry.rs` for the same 500-SLOC-cap reason `registry_events.rs`
+//! was split out (#2344) — a child module of `registry` (declared via
+//! `#[path = ...] mod memory_sink_ext;`), so it shares full access to
+//! `SessionRegistry`'s private `lock` helper and `SessionEntry`'s private
+//! `memory_sink` field exactly as if this method were still defined in
+//! `registry.rs`.
+//!
+//! Why: the turn recorder's sink (and its background drain task) must be
+//! constructed exactly ONCE per session — see the `memory_sink` module's own
+//! docs — not once per `task.run`; this is the single lazy-init/lookup entry
+//! point `task::executor::run_and_record` calls at each run's turn boundary.
+//! What: [`SessionRegistry::memory_sink_for`].
+//! Test: `registry_tests::memory_sink_for_reuses_the_same_sink_across_calls`,
+//! `registry_tests::memory_sink_for_unknown_session_returns_none`.
+
+use std::path::Path;
+
+use crate::session::memory_sink::{TurnMemorySink, derive_palace_id_for_project};
+
+use super::*;
+
+impl SessionRegistry {
+    /// Lazily construct (on first call) or return (on every later call) this
+    /// session's durable turn-recorder sink.
+    ///
+    /// Why: `task::executor::run_and_record` needs the SAME
+    /// `Arc<TurnMemorySink>` — and therefore the same background drain task
+    /// and bounded queue — across every `task.run` on one session, not a
+    /// fresh one per run (a fresh sink per run would spawn a new drain task
+    /// each time, multiplying in-flight writers with no bound). Constructing
+    /// it here, inside the session-map lock, means two calls can never build
+    /// two different sinks for the same session even under a hypothetical
+    /// race (in practice `Self::begin_execution`'s single-in-flight-run guard
+    /// already prevents concurrent calls per session).
+    /// What: `None` if `id` is unknown (best-effort — mirrors
+    /// `Self::set_run_outcome`'s framing; the caller has already validated
+    /// the session's existence earlier in the same run via
+    /// `begin_execution`/`begin_pm_transcript`). On the FIRST call for a
+    /// session, derives the palace id from `project_dir` via
+    /// [`derive_palace_id_for_project`], resolves trusty-memory's base URL
+    /// via `trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable`
+    /// (fail-open — the sink is built regardless of whether the daemon is
+    /// currently reachable; every write attempt after that is independently
+    /// fail-open, see `memory_sink::write_turn`), and stores the constructed
+    /// `Arc`. On every SUBSEQUENT call, `project_dir` is ignored and the
+    /// already-built sink is returned unchanged — a session's palace/base-url
+    /// binding is fixed for its lifetime, mirroring
+    /// `Self::begin_pm_transcript`'s analogous "the system prompt is fixed
+    /// after the first call" rule.
+    /// Test: `registry_tests::memory_sink_for_reuses_the_same_sink_across_calls`,
+    /// `registry_tests::memory_sink_for_unknown_session_returns_none`.
+    pub fn memory_sink_for(&self, id: &str, project_dir: &Path) -> Option<Arc<TurnMemorySink>> {
+        let mut sessions = self.lock();
+        let entry = sessions.get_mut(id)?;
+        if entry.memory_sink.is_none() {
+            let palace = derive_palace_id_for_project(project_dir);
+            let base_url = trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable();
+            entry.memory_sink = Some(Arc::new(TurnMemorySink::new(base_url, palace)));
+        }
+        entry.memory_sink.clone()
+    }
+}

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -670,6 +670,42 @@ async fn begin_pm_transcript_unknown_session_errors() {
     assert_eq!(err.code, -32007);
 }
 
+/// `memory_sink_for` (#2345) must construct exactly ONE sink for a session
+/// and return the SAME `Arc` on every subsequent call — proving the sink (and
+/// therefore its background drain task) survives across repeated
+/// `task.run`s on one session rather than being rebuilt per run.
+#[tokio::test]
+async fn memory_sink_for_reuses_the_same_sink_across_calls() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    let project_dir = tempfile::TempDir::new().unwrap();
+
+    let first = registry
+        .memory_sink_for(&session.id, project_dir.path())
+        .expect("first call constructs a sink");
+    let second = registry
+        .memory_sink_for(&session.id, project_dir.path())
+        .expect("second call reuses the sink");
+
+    assert!(
+        Arc::ptr_eq(&first, &second),
+        "memory_sink_for must return the SAME Arc across calls on one session"
+    );
+}
+
+/// `memory_sink_for` on an unknown session must return `None`, not panic
+/// (best-effort, mirrors `set_run_outcome`'s framing).
+#[tokio::test]
+async fn memory_sink_for_unknown_session_returns_none() {
+    let registry = SessionRegistry::new();
+    let project_dir = tempfile::TempDir::new().unwrap();
+    assert!(
+        registry
+            .memory_sink_for("nope", project_dir.path())
+            .is_none()
+    );
+}
+
 /// `set_run_outcome` must store the transcript/usage/cost verbatim, and must
 /// not panic when the session no longer exists.
 #[tokio::test]

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -150,7 +150,14 @@ pub fn spawn_task_run(
 /// clearing the execution slot. (#2344) `Finished` is no longer a dead end —
 /// `SessionRegistry::begin_execution` resumes a `Finished` session back to
 /// `Running` on its next `task.run`, which is what makes this whole
-/// persistence chain observable across repeated calls.
+/// persistence chain observable across repeated calls. (#2345) after this
+/// run's turn (prompt + whatever response text it produced, even on
+/// failure/cancellation/timeout) is captured, it is durably enqueued onto the
+/// session's lazily-constructed `session::TurnMemorySink` — fire-and-forget,
+/// never able to block or fail this run — for the ONE-time-per-session dual
+/// write to trusty-memory (`chat_turn_append` + `memory_remember`); see
+/// `session::memory_sink` module docs for the fail-open contract and the
+/// per-run (not yet per-turn) enqueue granularity this ticket settles for.
 async fn run_and_record(
     registry: Arc<SessionRegistry>,
     llm: Arc<dyn LlmClientTrait>,
@@ -273,15 +280,44 @@ async fn run_and_record(
             }
         };
 
+    // #2345: mark "how much assistant text exists before this run" so the
+    // turn recorder can later scope its durable dual-write to just THIS
+    // run's new response text via `Transcript::assistant_text_since`, even
+    // though `pm_transcript` is the session's whole cumulative (#2344)
+    // conversation. Fetching the sink here (rather than after the run) is
+    // just convenience — `SessionRegistry::memory_sink_for` is idempotent
+    // and cheap on every call after the first.
+    let turn_mark = pm_transcript.assistant_text_mark();
+    let memory_sink = registry.memory_sink_for(&session_id, &params.project);
+
     let result = pm_loop
         .run_with_transcript(&mut pm_transcript, &params.task)
         .await;
+
+    // #2345: capture this run's new assistant text BEFORE `pm_transcript` is
+    // moved into `store_pm_transcript` below. Per-turn (not per-run) enqueue
+    // is the ideal granularity (#2346 upgrade path — the loop currently has
+    // no per-turn callback/event seam to hook synchronously); a per-RUN batch
+    // of "this run's prompt -> this run's aggregated response text" is the
+    // documented, acceptable fallback for this ticket.
+    let turn_response = pm_transcript.assistant_text_since(turn_mark);
 
     // #2344: persist the (possibly partial) conversation back onto the
     // session UNCONDITIONALLY — success, failure, cancellation, or
     // timeout — so the NEXT `task.run` on this session continues from
     // exactly where this one left off, rather than silently re-seeding.
     registry.store_pm_transcript(&session_id, pm_transcript);
+
+    // #2345: durably record this run's turn (fire-and-forget, never blocks
+    // or fails this run — see `session::memory_sink` module docs). Recorded
+    // regardless of `result` (success/failure/cancellation/timeout all still
+    // produce a real prompt and whatever response text WAS generated before
+    // interruption) so the durable record matches `pm_transcript`'s own
+    // "persist unconditionally" contract above. `memory_sink` is `None` only
+    // if the session vanished between `begin_execution` and here.
+    if let Some(sink) = memory_sink {
+        sink.enqueue(session_id.clone(), params.task.clone(), turn_response);
+    }
 
     // #2206: usage/cost are aggregated from every turn that DID complete
     // regardless of `result` — this call already ran unconditionally before


### PR DESCRIPTION
## Summary

- Adds `session::TurnMemorySink` (`crates/trusty-code/src/session/memory_sink.rs`): an async, fire-and-forget durable-write sink with a bounded (~50) `tokio::sync::mpsc` queue drained by a background task. Each queued turn is dual-written to trusty-memory via `chat_turn_append` (exact chronological record) and `memory_remember` (tagged `session:<id>` + `turn` — the semantic recall surface #2348's future `recall_session` tool will read from), calling `trusty_common::mcp::memory_rpc::call_memory_tool_at` against a base URL resolved once at construction.
- Wires it into `task::executor::run_and_record` (the daemon-session `task.run` path only — `run_task`/one-shot/bake-off untouched): after `store_pm_transcript`, this run's prompt (`params.task`) and its aggregated new response text (`Transcript::assistant_text_since`, scoped via a mark taken before the run) are enqueued.
- The sink is constructed lazily, ONCE per session, via `SessionRegistry::memory_sink_for` (new field on `SessionEntry` + a sibling `registry_memory_sink.rs` module to stay under the 500-SLOC cap) — so its drain task and queue persist across every `task.run` on that session rather than being rebuilt per run.
- `derive_palace_id_for_project` mirrors `trusty_common::catchup`'s (private) palace-derivation convention exactly, so a session's turns land in the same palace its PM catch-up digest reads from.
- Fail-open throughout: any RPC failure (daemon unreachable, RPC error) is logged via `tracing::warn!` and dropped — never blocks or fails a turn. Queue-full policy: drop the newest turn (documented in `TurnMemorySink::enqueue`'s doc comment) — the simplest policy `mpsc::Sender::try_send` supports directly.

## Design choices

- **Per-run (not per-turn) enqueue granularity**: the PM `AgentLoop` has no per-turn callback/event seam to hook synchronously today, so this ticket settles for one enqueue per `task.run` call (prompt = the run's task text, response = all assistant text produced during that run). This is the ticket's explicitly documented acceptable fallback; #2346 is the noted upgrade path to true per-turn granularity.
- **Queue-overflow policy — drop newest**: `try_send`'s `Full` variant is the only overflow signal a plain bounded `mpsc` gives without switching channel types; dropping the newest (this call's) turn rather than attempting to evict an already-queued older one is simplest to implement correctly and is logged so it's observable.
- **Base URL resolved once per session** (not per enqueued turn): mirrors `catchup::pm_catchup_context`'s own one-shot `resolve_memory_base_url_or_unreachable()` call — the daemon's bound address does not change mid-session, and per-turn re-resolution would add discovery-file I/O to the hot drain path for no benefit. Also makes tests inject a mock server's URL directly rather than mutating the process-global `TRUSTY_MEMORY_URL` env var (unsafe across parallel tests).

## Test plan

- [x] `enqueue_drain_happy_path` — spins up a tiny in-process axum `/rpc` mock, asserts BOTH `chat_turn_append` and `memory_remember` land with correct `palace`/`session_id`/`prompt`/`response`/`tags` params.
- [x] `write_turn_is_fail_open_on_unreachable_daemon` — an unreachable `base_url` never panics or hangs.
- [x] `enqueue_drops_newest_when_queue_full` — deterministic overflow-policy test against the raw channel (no networking/timing).
- [x] `derive_palace_id_for_project_falls_back_to_dirname` — non-git-remote fallback is non-empty and deterministic.
- [x] `memory_sink_for_reuses_the_same_sink_across_calls` / `memory_sink_for_unknown_session_returns_none` — registry-level lazy-init/lookup contract (sink survives across two runs on one session).

```
cargo build --workspace                         -> clean
cargo test -p trusty-code                        -> 776 passed; 0 failed; 3 ignored (incl. 6 new tests)
cargo test --workspace                           -> 1782 passed; 1 failed (isolated pre-existing flake:
                                                     trusty-agents telegram_pid_guard_live_conflict_is_rejected,
                                                     passes in isolation — unrelated crate, not touched by this PR)
cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings  -> clean
cargo fmt --check                                -> clean
bash scripts/check_line_cap.sh                   -> line-cap: 0 allowlisted, 0 violations — OK.
```

Closes #2345
Part of epic #2343

🤖 Generated with [Claude Code](https://claude.com/claude-code)