### PR TITLE
fix(trusty-mpm): SM context-engine round loss under concurrency + graceful no-memory degradation (closes #1309, #1477)

### DIFF
--- a/crates/trusty-mpm/src/core/sm/agent/chat.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat.rs
@@ -122,11 +122,14 @@ impl SessionManagerAgent {
         let inference = &self.config.inference;
         let rounds = &self.config.rounds;
 
-        // (2) Open (or resume) the rolling-context engine for this conversation.
-        // TODO(#1309): the engine is opened fresh per turn with no per-conv_id
-        // concurrency guard — two concurrent turns with the SAME conv_id can
-        // last-write-wins on save and lose a round. Serialize turns per conv_id
-        // (per-conv_id async lock / actor) before or within the SM-8 loop.
+        // (2a) #1309: serialize turns for the SAME conv_id. The engine is opened
+        // fresh per turn and persists by atomic whole-file replace with NO merge,
+        // so two concurrent turns for one conv_id would last-write-wins on save and
+        // silently lose a round. Hold the per-conv_id lock across the WHOLE turn
+        // (open → record → save); turns for different conv_ids never block.
+        let _turn = self.conv_locks.acquire(&conv_id).await;
+
+        // (2b) Open (or resume) the rolling-context engine for this conversation.
         let mut engine = SmContextEngine::open(&conv_id, &runtime.data_root, inference, rounds)?;
 
         // (3) The SM system prompt (SM-3), with any operator overrides layered in.

--- a/crates/trusty-mpm/src/core/sm/agent/chat_action.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_action.rs
@@ -121,6 +121,12 @@ impl SessionManagerAgent {
         let inference = &self.config().inference;
         let rounds = &self.config().rounds;
 
+        // #1309: serialize turns for the SAME conv_id across the whole turn
+        // (open → record → save) so a concurrent turn cannot last-write-wins on the
+        // context-engine state file and lose this turn's round. Different conv_ids
+        // never block one another.
+        let _turn = self.conv_locks.acquire(&conv_id).await;
+
         let mut engine = SmContextEngine::open(&conv_id, &runtime.data_root, inference, rounds)?;
 
         // System prompt = the SM identity/floor + the inline-action instructions

--- a/crates/trusty-mpm/src/core/sm/agent/chat_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat_tests.rs
@@ -10,10 +10,12 @@
 //! Test: this is the test module.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tempfile::TempDir;
 
-use super::super::mock::{MockChatProvider, MockResolver};
+use super::super::mock::{CompleteGate, MockChatProvider, MockResolver};
+use crate::core::sm::SmContextEngine;
 use crate::core::sm::agent::{SessionManagerAgent, SmAgentError};
 use crate::core::sm::config::SessionManagerConfig;
 
@@ -306,6 +308,119 @@ async fn chat_records_round_when_no_provider_for_compaction() {
         joined.contains("decompose this"),
         "the round must be recorded verbatim even when compaction has no provider, got: {joined}"
     );
+}
+
+/// Why: #1309 (data integrity) — two concurrent chat turns for the SAME conv_id
+/// must NOT lose a round. The context engine opens fresh per turn and persists by
+/// atomic whole-file replace with no merge, so before the per-conv_id serialization
+/// both turns would load the same state, append their round, and save — the second
+/// save clobbering the first (total_rounds == 1, one message lost). This test
+/// reliably reproduces that interleave and asserts BOTH rounds survive post-fix.
+/// What: one shared agent (its conv_locks are shared across the two spawned
+/// clones). A gate parks turn A inside its provider call — so A has OPENED the
+/// engine and is mid-turn — while turn B runs; the paused clock lets B settle
+/// (pre-fix it saves and clobbers; post-fix it blocks on the per-conv lock) before
+/// A is released. After both finish, a fresh engine over the same data root must
+/// show `total_rounds == 2` with BOTH messages persisted.
+/// Test: this is the test (the #1309 regression guard).
+#[tokio::test(start_paused = true)]
+async fn concurrent_turns_same_conv_id_persist_both_rounds() {
+    let tmp = TempDir::new().unwrap();
+    let gate = CompleteGate::new();
+    // One shared provider (gate + request log shared via Arc across clones) so the
+    // FIRST complete() — turn A's orchestration call — parks on the gate.
+    let provider = MockChatProvider::new("reply", 0.0).gated(gate.clone());
+    let resolver = Arc::new(MockResolver::with_provider(provider));
+    let agent = agent_with(enabled_config(), resolver, tmp.path());
+
+    // Two concurrent turns on the SAME conv_id. Clones share the agent's conv_locks
+    // (an Arc), mirroring the daemon's single shared `Arc<SessionManagerAgent>`.
+    let a = {
+        let ag = agent.clone();
+        tokio::spawn(async move { ag.chat("turn A", Some("race")).await })
+    };
+    let b = {
+        let ag = agent.clone();
+        tokio::spawn(async move { ag.chat("turn B", Some("race")).await })
+    };
+
+    // Let both spawned turns run until they settle: A parks at its gated provider
+    // call (having opened the engine), B either finishes (pre-fix, no lock) or
+    // blocks on the per-conv lock (post-fix). With the paused clock, this sleep
+    // returns only once the runtime is otherwise idle, so both have settled.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    // Release A's provider so A records + saves; post-fix, B then proceeds.
+    gate.release();
+
+    let ra = a.await.unwrap().expect("turn A succeeds");
+    let rb = b.await.unwrap().expect("turn B succeeds");
+    assert_eq!(ra.conv_id, "race");
+    assert_eq!(rb.conv_id, "race");
+
+    // Both rounds must be persisted. Pre-fix the second save clobbers the first
+    // (total_rounds == 1, one message lost); post-fix both survive.
+    let cfg = enabled_config();
+    let engine =
+        SmContextEngine::open("race", tmp.path(), &cfg.inference, &cfg.rounds).expect("reopen");
+    let conv = engine.conversation();
+    assert_eq!(
+        conv.total_rounds, 2,
+        "both concurrent same-conv_id turns must persist their round (no loss)"
+    );
+    let users: Vec<&str> = conv.recent_rounds.iter().map(|r| r.user.as_str()).collect();
+    assert!(
+        users.contains(&"turn A") && users.contains(&"turn B"),
+        "both turns' rounds must survive, got {users:?}"
+    );
+}
+
+/// Why: the per-conv_id serialization must NOT over-serialize — turns for
+/// DIFFERENT conv_ids must run concurrently (distinct locks), or the fix would
+/// throttle unrelated conversations to one-at-a-time.
+/// What: gates turn A (conv "x") inside its provider call; turn B (conv "y") must
+/// still complete WITHOUT waiting on A's lock (a different id → a different lock).
+/// After releasing A, both persist their own single round.
+/// Test: this is the test.
+#[tokio::test(start_paused = true)]
+async fn different_conv_ids_do_not_serialize() {
+    let tmp = TempDir::new().unwrap();
+    let gate = CompleteGate::new();
+    let provider = MockChatProvider::new("reply", 0.0).gated(gate.clone());
+    let resolver = Arc::new(MockResolver::with_provider(provider));
+    let agent = agent_with(enabled_config(), resolver, tmp.path());
+
+    let a = {
+        let ag = agent.clone();
+        tokio::spawn(async move { ag.chat("for x", Some("x")).await })
+    };
+    let b = {
+        let ag = agent.clone();
+        tokio::spawn(async move { ag.chat("for y", Some("y")).await })
+    };
+
+    // A parks on the gate (conv "x"); B (conv "y") must finish independently since
+    // it holds a DIFFERENT lock. If the fix over-serialized on a single global
+    // lock, B would block behind A here and this turn would never settle.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let rb = b
+        .await
+        .unwrap()
+        .expect("turn B (conv y) finishes without waiting on A");
+    assert_eq!(rb.conv_id, "y");
+
+    // Now release A and let it finish too.
+    gate.release();
+    let ra = a.await.unwrap().expect("turn A (conv x) succeeds");
+    assert_eq!(ra.conv_id, "x");
+
+    let cfg = enabled_config();
+    for (id, msg) in [("x", "for x"), ("y", "for y")] {
+        let engine =
+            SmContextEngine::open(id, tmp.path(), &cfg.inference, &cfg.rounds).expect("reopen");
+        let conv = engine.conversation();
+        assert_eq!(conv.total_rounds, 1, "conv {id} persists its single round");
+        assert_eq!(conv.recent_rounds.back().unwrap().user, msg);
+    }
 }
 
 /// Why: §7.5 step 3 — when the SM memory palace IS wired (feature build) and

--- a/crates/trusty-mpm/src/core/sm/agent/conv_lock.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/conv_lock.rs
@@ -1,0 +1,100 @@
+//! Per-conversation turn serialization for the SM context engine (#1309).
+//!
+//! Why: the file-based [`SmContextEngine`](crate::core::sm::context::SmContextEngine)
+//! is opened fresh per turn and persists by ATOMIC WHOLE-FILE replace with NO
+//! merge. Two concurrent turns for the SAME `conv_id` each load the state into
+//! their own in-memory conversation, append their round, and save — so the second
+//! save clobbers the first and SILENTLY LOSES a round, even though that round's
+//! reply was already returned to the caller (a data-integrity bug, #1309). This
+//! became reachable once the SM was wired into the async `coordinator/chat`
+//! endpoint, which can drive multiple in-flight turns for one `conv_id`.
+//! Serializing turns per `conv_id` closes the read-modify-write race with the
+//! lightest correct mechanism — a per-`conv_id` async lock held across
+//! open → record → save — mirroring the per-palace `write_mutex` precedent in
+//! `trusty_common::memory_core::retrieval::handle`.
+//! What: [`ConvLocks`] is a small registry of per-`conv_id` [`tokio::sync::Mutex`]es.
+//! [`ConvLocks::acquire`] hands back an owned guard the turn holds for its whole
+//! duration; concurrent turns for the SAME id wait for it, turns for DIFFERENT ids
+//! never block each other. The registry stores [`Weak`] handles and prunes dead
+//! entries on every miss, so it stays bounded by the number of concurrently-active
+//! conversations rather than growing once per `conv_id` seen for the daemon's life.
+//! Test: `chat_tests.rs::concurrent_turns_same_conv_id_persist_both_rounds`
+//! (two concurrent same-id turns both persist — the pre-fix loss is gone) and
+//! `different_conv_ids_do_not_serialize` (distinct ids run without blocking).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, Weak};
+
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+/// A registry of per-`conv_id` async turn locks (#1309).
+///
+/// Why: the SM agent is shared (an `Arc<SessionManagerAgent>` on the daemon
+/// state), so a single registry living on the agent lets every concurrent chat
+/// turn coordinate through the SAME per-`conv_id` lock. Cloning the agent shares
+/// the registry (it is an `Arc` field), so serialization holds across clones too.
+/// What: wraps a [`std::sync::Mutex`] over a map from `conv_id` to a [`Weak`]
+/// handle on that conversation's [`AsyncMutex`]. The std mutex guards ONLY the
+/// tiny map lookup/insert (never held across an await); the async mutex is the one
+/// a turn actually holds across its `open → record → save` critical section.
+/// Test: see the module-level tests.
+pub(super) struct ConvLocks {
+    /// Map of `conv_id` → a weak handle on its turn lock. Weak so a conversation
+    /// with no in-flight turn drops its lock and the entry can be pruned.
+    locks: Mutex<HashMap<String, Weak<AsyncMutex<()>>>>,
+}
+
+impl ConvLocks {
+    /// Build an empty lock registry.
+    ///
+    /// Why: the agent constructs one per instance (shared across clones via the
+    /// `Arc` field); no I/O and no allocation beyond an empty map.
+    /// What: returns a [`ConvLocks`] wrapping an empty map.
+    /// Test: exercised by every `ConvLocks` test via the agent constructors.
+    pub(super) fn new() -> Self {
+        Self {
+            locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Acquire the exclusive turn lock for `conv_id`, awaiting any in-flight turn.
+    ///
+    /// Why: the returned guard MUST be held for the whole turn (open → record →
+    /// save) so no other turn for the same `conv_id` can interleave its
+    /// read-modify-write on the state file. Turns for different ids get distinct
+    /// locks and never block one another.
+    /// What: looks up (or mints) the per-`conv_id` [`AsyncMutex`] and awaits its
+    /// owned lock, returning the [`OwnedMutexGuard`]. The caller drops the guard by
+    /// letting it fall out of scope at the end of the turn.
+    /// Test: `concurrent_turns_same_conv_id_persist_both_rounds`,
+    /// `different_conv_ids_do_not_serialize`.
+    pub(super) async fn acquire(&self, conv_id: &str) -> OwnedMutexGuard<()> {
+        self.lock_for(conv_id).lock_owned().await
+    }
+
+    /// Return the [`AsyncMutex`] for `conv_id`, creating it on a miss and pruning
+    /// any dead entries so the registry stays bounded.
+    ///
+    /// Why: keeping the map keyed by live conversations only (rather than every id
+    /// ever seen) bounds memory on a long-running daemon. The std-mutex critical
+    /// section is a pure map operation with NO await, so it stays negligibly short.
+    /// What: upgrades the existing weak entry if the lock is still live; otherwise
+    /// mints a fresh [`AsyncMutex`], stores a weak handle to it, and drops every
+    /// now-dead weak entry. A poisoned std mutex (only possible after a panic while
+    /// holding it — which never happens in this pure section) is recovered rather
+    /// than propagated so the SM stays panic-free.
+    /// Test: `different_conv_ids_do_not_serialize` (distinct locks per id);
+    /// pruning is covered indirectly (a re-acquired id after release mints anew).
+    fn lock_for(&self, conv_id: &str) -> Arc<AsyncMutex<()>> {
+        let mut map = self.locks.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(existing) = map.get(conv_id).and_then(Weak::upgrade) {
+            return existing;
+        }
+        let fresh = Arc::new(AsyncMutex::new(()));
+        map.insert(conv_id.to_string(), Arc::downgrade(&fresh));
+        // Drop entries whose lock has been released (no strong refs remain). The
+        // freshly inserted entry is still held by `fresh`, so it survives.
+        map.retain(|_, weak| weak.strong_count() > 0);
+        fresh
+    }
+}

--- a/crates/trusty-mpm/src/core/sm/agent/delegate/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/delegate/mod.rs
@@ -25,13 +25,14 @@
 //! sessions and makes repeated goal-store writes. Goal-store mutations are already
 //! ATOMIC and serialized — every mutator goes through the single
 //! `Arc<Mutex<SmGoalStore>>` and SM-6 snapshots+rolls-back on a failed persist —
-//! so the loop introduces NO new last-write-wins race in the goal store. The loop
-//! does NOT touch the per-`conv_id` rolling-context engine (that path stays in
-//! `chat`), so it does not widen the #1309 context-engine race either. TODO(#1309):
-//! if `delegate_goal` ever becomes reachable concurrently for the SAME goal (e.g.
-//! re-driven by two operator turns), add a per-goal serialization seam here; today
-//! each call creates a fresh goal at INTAKE, so concurrent calls operate on
-//! disjoint goals and cannot interleave.
+//! so the loop introduces NO last-write-wins race in the goal store. The loop does
+//! NOT touch the per-`conv_id` rolling-context engine (that path stays in `chat`,
+//! where #1309's per-`conv_id` turn lock now serializes concurrent same-id turns),
+//! so it does not widen the context-engine race either. Remaining follow-up (NOT
+//! #1309): if `delegate_goal` ever becomes reachable concurrently for the SAME
+//! goal (e.g. re-driven by two operator turns), add a per-goal serialization seam
+//! here; today each call creates a fresh goal at INTAKE, so concurrent calls
+//! operate on disjoint goals and cannot interleave.
 //!
 //! What: [`DelegationOutcome`] (the loop result), [`DelegationError`] (typed
 //! failures), and the `impl` block adding

--- a/crates/trusty-mpm/src/core/sm/agent/mock.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/mock.rs
@@ -38,6 +38,28 @@ pub struct MockChatProvider {
     reply: String,
     cost_usd: f64,
     requests: Arc<Mutex<Vec<LlmRequest>>>,
+    /// Optional gate that BLOCKS the first `complete` call until released (#1309).
+    gate: Option<Arc<CompleteGate>>,
+}
+
+/// A one-shot gate that parks the FIRST `complete` call until the test releases it.
+///
+/// Why: the #1309 concurrency test must deterministically force two turns for the
+/// same `conv_id` to overlap — turn A must OPEN the context engine and reach its
+/// provider call while turn B is still in flight, so that (pre-fix) both open the
+/// same on-disk state before either saves and one round is lost. Gating only the
+/// FIRST `complete` (turn A's orchestration call) parks A there while turn B
+/// either races ahead (pre-fix, no lock) or blocks on the per-conv lock (post-fix)
+/// — WITHOUT deadlocking the post-fix path (only A waits on the gate, and B never
+/// needs to reach `complete` for A to be released).
+/// What: `calls` counts `complete` invocations across the shared provider; the
+/// call at index 0 awaits `release`. Later calls pass straight through.
+/// Test: `chat_tests.rs::concurrent_turns_same_conv_id_persist_both_rounds`.
+pub struct CompleteGate {
+    /// Notified by the test to release the parked first `complete` call.
+    release: tokio::sync::Notify,
+    /// Monotonic count of `complete` invocations across all clones.
+    calls: AtomicUsize,
 }
 
 impl MockChatProvider {
@@ -47,7 +69,22 @@ impl MockChatProvider {
             reply: reply.into(),
             cost_usd,
             requests: Arc::new(Mutex::new(Vec::new())),
+            gate: None,
         }
+    }
+
+    /// Gate this provider's FIRST `complete` call on `gate` (#1309 test seam).
+    ///
+    /// Why: lets the concurrency test hold turn A inside its provider call until it
+    /// releases the gate, deterministically forcing the overlap that reproduces the
+    /// round-loss race pre-fix. Clones share the gate (an `Arc`), so the gate spans
+    /// every clone the resolver hands to a `ResolvedCall`.
+    /// What: returns `self` with the gate attached. Call `CompleteGate::release` to
+    /// let the parked first call proceed.
+    /// Test: `chat_tests.rs::concurrent_turns_same_conv_id_persist_both_rounds`.
+    pub fn gated(mut self, gate: Arc<CompleteGate>) -> Self {
+        self.gate = Some(gate);
+        self
     }
 
     /// The most recent request, if any.
@@ -69,6 +106,31 @@ impl MockChatProvider {
     }
 }
 
+impl CompleteGate {
+    /// Build a gate whose first `complete` call will park until released.
+    ///
+    /// Why: the concurrency test creates one gate, shares it with the provider, and
+    /// releases it once both turns have settled.
+    /// What: returns an `Arc<CompleteGate>` (shared with the provider clones).
+    /// Test: `chat_tests.rs::concurrent_turns_same_conv_id_persist_both_rounds`.
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            release: tokio::sync::Notify::new(),
+            calls: AtomicUsize::new(0),
+        })
+    }
+
+    /// Release the parked first `complete` call so turn A can finish.
+    ///
+    /// Why: the test releases the gate after both turns have reached steady state.
+    /// What: notifies the parked waiter (or stores a permit if it has not parked
+    /// yet, so the release can never be lost to a race).
+    /// Test: `chat_tests.rs::concurrent_turns_same_conv_id_persist_both_rounds`.
+    pub fn release(&self) {
+        self.release.notify_one();
+    }
+}
+
 #[async_trait]
 impl LlmProvider for MockChatProvider {
     fn name(&self) -> &str {
@@ -76,6 +138,12 @@ impl LlmProvider for MockChatProvider {
     }
 
     async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, SmLlmError> {
+        // #1309 test seam: park the FIRST complete call until the gate is released.
+        if let Some(gate) = &self.gate
+            && gate.calls.fetch_add(1, Ordering::SeqCst) == 0
+        {
+            gate.release.notified().await;
+        }
         let model = req.model.clone();
         self.requests.lock().expect("mock lock").push(req);
         Ok(LlmResponse {

--- a/crates/trusty-mpm/src/core/sm/agent/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/mod.rs
@@ -26,8 +26,11 @@
 mod chat;
 mod chat_action;
 mod chat_action_protocol;
+mod conv_lock;
 mod delegate;
 mod health;
+
+use conv_lock::ConvLocks;
 
 #[cfg(test)]
 pub mod mock;
@@ -66,6 +69,11 @@ pub struct SessionManagerAgent {
     config: SessionManagerConfig,
     /// Inference + storage runtime; `None` for the inert SM-1 constructor.
     runtime: Option<AgentRuntime>,
+    /// Per-`conv_id` turn locks that serialize concurrent chat turns for the SAME
+    /// conversation so they cannot last-write-wins on the context-engine state file
+    /// and lose a round (#1309). Shared across clones (an `Arc`) so serialization
+    /// holds even though the agent is `Clone`; distinct conversations never block.
+    conv_locks: Arc<ConvLocks>,
 }
 
 impl std::fmt::Debug for SessionManagerAgent {
@@ -125,6 +133,7 @@ impl SessionManagerAgent {
         Self {
             config,
             runtime: None,
+            conv_locks: Arc::new(ConvLocks::new()),
         }
     }
 
@@ -153,6 +162,7 @@ impl SessionManagerAgent {
                 data_root: data_root.into(),
                 memory,
             }),
+            conv_locks: Arc::new(ConvLocks::new()),
         }
     }
 
@@ -175,6 +185,7 @@ impl SessionManagerAgent {
                 resolver,
                 data_root: data_root.into(),
             }),
+            conv_locks: Arc::new(ConvLocks::new()),
         }
     }
 

--- a/crates/trusty-mpm/src/core/sm/goals/memory.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/memory.rs
@@ -64,6 +64,35 @@ pub trait GoalMemory: Send + Sync {
     async fn list_goals(&self, tag: &str) -> Result<Vec<String>, String>;
 }
 
+/// A no-op [`GoalMemory`]: persists nothing, enumerates nothing (#1477).
+///
+/// Why: without the `sm-memory` feature there is no SM palace, but the goal store
+/// (SM-6) is feature-INDEPENDENT and works over any [`GoalMemory`]. Backing it with
+/// this no-op seam lets `sm.goals.*` and the delegation loop DEGRADE GRACEFULLY to
+/// in-memory, non-durable operation on the default build — the headline SM-8
+/// capability functions, it simply does not persist across a restart — instead of
+/// returning "unavailable". This mirrors the recall no-op pattern in `agent::chat`
+/// (memory-dependent work becomes an absent no-op, never a hard failure). Durable
+/// goal persistence remains behind `--features sm-memory`.
+/// What: `remember_goal` succeeds without storing; `list_goals` always returns an
+/// empty set (so a fresh-start store rebuilds to empty). Always compiled.
+/// Test: `store_tests.rs` exercises the store over a mock seam; the wiring that
+/// selects this seam on the default build is covered by `daemon::sm_stdio::tests`
+/// (the no-feature `sm.goals.*` / `sm.delegate` branches).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopGoalMemory;
+
+#[async_trait]
+impl GoalMemory for NoopGoalMemory {
+    async fn remember_goal(&self, _json: String, _tag: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn list_goals(&self, _tag: &str) -> Result<Vec<String>, String> {
+        Ok(Vec::new())
+    }
+}
+
 /// `SmMemory` is the production [`GoalMemory`]: the dedicated SM palace.
 ///
 /// Why: in the daemon the goal store's source of truth is the real SM palace

--- a/crates/trusty-mpm/src/core/sm/goals/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/goals/mod.rs
@@ -27,7 +27,7 @@ pub mod store;
 
 pub use cache::{GOALS_CACHE_FILE, GoalCache};
 pub use error::{SmGoalError, SmGoalResult};
-pub use memory::{GOAL_TAG, GoalMemory};
+pub use memory::{GOAL_TAG, GoalMemory, NoopGoalMemory};
 pub use model::{Goal, GoalStatus, SessionLink, SessionTaskState};
 pub use store::{SessionUpdate, SmGoalStore};
 

--- a/crates/trusty-mpm/src/core/sm/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/mod.rs
@@ -85,8 +85,8 @@ pub use control::{
     LaunchParams, RawObservation, SessionControl, SessionControlError, Submit, Summary,
 };
 pub use goals::{
-    GOAL_TAG, Goal, GoalCache, GoalMemory, GoalStatus, SessionLink, SessionTaskState,
-    SessionUpdate, SmGoalError, SmGoalResult, SmGoalStore,
+    GOAL_TAG, Goal, GoalCache, GoalMemory, GoalStatus, NoopGoalMemory, SessionLink,
+    SessionTaskState, SessionUpdate, SmGoalError, SmGoalResult, SmGoalStore,
 };
 #[cfg(feature = "sm-memory")]
 pub use memory::{SmMemory, SmMemoryError, SmMemoryResult};

--- a/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/methods.rs
@@ -149,11 +149,10 @@ pub async fn sm_chat(d: &SmDispatcher, params: &Value) -> Result<Value, MethodEr
 /// `Abandoned`) so a caller can distinguish in-progress from blocked/failed WITHOUT
 /// a follow-up `sm.goals.list`; `goal_done` is kept additively for back-compat. A
 /// degraded SM (no provider) maps to [`MethodError::Unavailable`]; any other failure
-/// → [`MethodError::Internal`]. Without `sm-memory` (no goal store) it returns a
-/// graceful unavailable error.
+/// → [`MethodError::Internal`]. The goal store is feature-independent, so this runs
+/// in EVERY build (#1477) — goals are non-durable in-memory on the default build.
 /// Test: `tests.rs::delegate_end_to_end_launch_observe_verify_close`,
-/// `delegate_gate_blocks_without_evidence`, `delegate_unavailable_without_feature`.
-#[cfg(feature = "sm-memory")]
+/// `delegate_gate_blocks_without_evidence`.
 pub async fn sm_delegate(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
     let message = req_str(params, "message")?;
     match d.agent.delegate_goal(&message, &d.sessions, &d.goals).await {
@@ -169,20 +168,6 @@ pub async fn sm_delegate(d: &SmDispatcher, params: &Value) -> Result<Value, Meth
         }
         Err(e) => Err(MethodError::Internal(e.to_string())),
     }
-}
-
-/// `sm.delegate` is unavailable without the `sm-memory` feature.
-///
-/// Why: the delegation loop persists goals through the SM-6 store, which is backed
-/// by the SM palace (memory-core); the no-memory build returns a graceful JSON-RPC
-/// error rather than failing to compile.
-/// What: always returns [`MethodError::Unavailable`].
-/// Test: `tests.rs::delegate_unavailable_without_feature`.
-#[cfg(not(feature = "sm-memory"))]
-pub async fn sm_delegate(_d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
-    Err(MethodError::Unavailable(
-        "sm.delegate is not available without the sm-memory feature".to_string(),
-    ))
 }
 
 /// `sm.health {}` → `{ ok, provider, degraded, model_tiers }` (§5.3).
@@ -312,20 +297,20 @@ fn map_control_err(e: SessionControlError) -> MethodError {
     }
 }
 
-// ── sm.context.get (SM-5 context engine — feature-gated) ────────────────────────
+// ── sm.context.get (SM-5 context engine — always available) ─────────────────────
 
-/// `sm.context.get { conv_id? }` → context state (§7.1/§7.5).
+/// `sm.context.get { conv_id }` → context state (§7.1/§7.5).
 ///
 /// Why: surfaces the rolling-context engine's state — the compressed block, the
 /// recent verbatim rounds, the total round count, and the token estimate — so a
-/// driver can inspect what context the SM is carrying for a conversation.
-/// What: under `sm-memory`, opens the per-`conv_id` engine under the SM data root
-/// and returns `{ compressed_context, recent_rounds, total_rounds, token_estimate }`.
-/// Without `sm-memory` (or when no `conv_id` is supplied to identify a stored
-/// conversation), returns the appropriate graceful error.
-/// Test: `tests.rs::context_get_round_trips` (feature),
-/// `context_get_unavailable_without_feature` (no feature).
-#[cfg(feature = "sm-memory")]
+/// driver can inspect what context the SM is carrying for a conversation. The
+/// context engine is compiled in EVERY build (it depends only on serde + the SM
+/// provider trait, not on memory-core), so this method is available regardless of
+/// the `sm-memory` feature (#1477) — it never needed the SM palace.
+/// What: opens the per-`conv_id` engine under the SM data root and returns
+/// `{ compressed_context, recent_rounds, total_rounds, token_estimate }`. A missing
+/// `conv_id` is an invalid-params error; a store failure is an internal error.
+/// Test: `tests.rs::context_get_feature_branches`.
 pub async fn sm_context_get(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
     use crate::core::sm::SmContextEngine;
 
@@ -351,29 +336,16 @@ pub async fn sm_context_get(d: &SmDispatcher, params: &Value) -> Result<Value, M
     }))
 }
 
-/// `sm.context.get` is unavailable without the `sm-memory` feature.
-///
-/// Why: the context engine state lives alongside the SM palace; the no-memory
-/// build returns a graceful JSON-RPC error rather than failing to compile.
-/// What: always returns [`MethodError::Unavailable`].
-/// Test: `tests.rs::context_get_unavailable_without_feature`.
-#[cfg(not(feature = "sm-memory"))]
-pub async fn sm_context_get(_d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
-    Err(MethodError::Unavailable(
-        "sm.context.get is not available without the sm-memory feature".to_string(),
-    ))
-}
-
-// ── sm.goals.* (SmGoalStore — feature-gated) ────────────────────────────────────
+// ── sm.goals.* (SmGoalStore — always available, #1477) ──────────────────────────
 
 /// `sm.goals.list { status? }` → `{ goals: [Goal] }` (SM-6).
 ///
 /// Why: lists tracked operator goals, optionally filtered by status. Maps onto the
-/// SM-6 goal store.
-/// What: under `sm-memory`, reads `store.all()` and (when `status` is supplied)
-/// filters by it; returns `{ goals }`. Without the feature → unavailable error.
-/// Test: `tests.rs::goals_list_round_trips`, `goals_unavailable_without_feature`.
-#[cfg(feature = "sm-memory")]
+/// SM-6 goal store, which is feature-independent (#1477): palace-backed durable
+/// storage under `sm-memory`, non-durable in-memory on the default build.
+/// What: reads `store.all()` and (when `status` is supplied) filters by it; returns
+/// `{ goals }`.
+/// Test: `tests.rs::goals_feature_branches`.
 pub async fn sm_goals_list(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
     let status = opt_str(params, "status");
     let store = d.goals.lock().await;
@@ -390,7 +362,6 @@ pub async fn sm_goals_list(d: &SmDispatcher, params: &Value) -> Result<Value, Me
 }
 
 /// `sm.goals.create { description, acceptance? }` → `{ goal: Goal }` (SM-6).
-#[cfg(feature = "sm-memory")]
 pub async fn sm_goals_create(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
     let description = req_str(params, "description")?;
     let acceptance = params
@@ -421,7 +392,6 @@ pub async fn sm_goals_create(d: &SmDispatcher, params: &Value) -> Result<Value, 
 /// spec's `progress` field is DERIVED by the store from session states (§9.1) and
 /// is not directly settable, so it is accepted-but-ignored with a note.
 /// Test: `tests.rs::goals_update_round_trips`.
-#[cfg(feature = "sm-memory")]
 pub async fn sm_goals_update(d: &SmDispatcher, params: &Value) -> Result<Value, MethodError> {
     let id = req_str(params, "id")?;
     let note = opt_str(params, "note");
@@ -443,7 +413,6 @@ pub async fn sm_goals_update(d: &SmDispatcher, params: &Value) -> Result<Value, 
 }
 
 /// The lowercase wire status string for a goal (matches the camelCase serde).
-#[cfg(feature = "sm-memory")]
 fn goal_status_str(goal: &crate::core::sm::Goal) -> String {
     use crate::core::sm::GoalStatus;
     match goal.status {
@@ -463,7 +432,6 @@ fn goal_status_str(goal: &crate::core::sm::Goal) -> String {
 /// What: case-insensitively matches the five statuses (accepting both
 /// `inprogress` and `in_progress`).
 /// Test: `tests.rs::goals_update_round_trips`.
-#[cfg(feature = "sm-memory")]
 fn parse_goal_status(s: &str) -> Result<crate::core::sm::GoalStatus, MethodError> {
     use crate::core::sm::GoalStatus;
     match s
@@ -491,7 +459,6 @@ fn parse_goal_status(s: &str) -> Result<crate::core::sm::GoalStatus, MethodError
 /// What: `NotFound` → [`MethodError::NotFound`]; everything else (palace/cache/
 /// gate) → [`MethodError::Internal`].
 /// Test: `tests.rs::goals_update_unknown_is_not_found`.
-#[cfg(feature = "sm-memory")]
 fn map_goal_err(e: crate::core::sm::SmGoalError) -> MethodError {
     match e {
         crate::core::sm::SmGoalError::NotFound(msg) => {
@@ -506,9 +473,8 @@ fn map_goal_err(e: crate::core::sm::SmGoalError) -> MethodError {
 /// Why: `sm.sessions.launch` with a `goal_id` must record the goal↔session link;
 /// doing it here keeps the launch handler's two-surface touch minimal. A link
 /// failure (unknown goal / persist error) is reported, never fatal to the launch.
-/// What: under `sm-memory`, calls `store.link`; returns whether it succeeded.
+/// What: calls `store.link`; returns whether it succeeded.
 /// Test: `tests.rs::launch_with_goal_links_session`.
-#[cfg(feature = "sm-memory")]
 async fn link_session_to_goal(d: &SmDispatcher, goal_id: &str, session_id: &str) -> bool {
     use crate::core::sm::SessionLink;
     let mut store = d.goals.lock().await;
@@ -519,46 +485,4 @@ async fn link_session_to_goal(d: &SmDispatcher, goal_id: &str, session_id: &str)
         )
         .await
         .is_ok()
-}
-
-/// No-memory build: there is no goal store, so a launch link is a no-op.
-///
-/// Why: keeps `sm.sessions.launch` compiling without `sm-memory`; the goal link
-/// is simply not recorded (goals are unavailable in that build).
-/// What: always returns `false`.
-/// Test: `tests.rs` (no-feature build) covers launch without a goal.
-#[cfg(not(feature = "sm-memory"))]
-async fn link_session_to_goal(_d: &SmDispatcher, _goal_id: &str, _session_id: &str) -> bool {
-    false
-}
-
-/// `sm.goals.*` are unavailable without the `sm-memory` feature.
-///
-/// Why: the goal store is backed by the SM palace (memory-core); the no-memory
-/// build returns a graceful JSON-RPC error rather than failing to compile.
-/// What: always returns [`MethodError::Unavailable`].
-/// Test: `tests.rs::goals_unavailable_without_feature`.
-#[cfg(not(feature = "sm-memory"))]
-pub async fn sm_goals_list(_d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
-    goals_unavailable()
-}
-
-/// See [`sm_goals_list`] (no-memory build).
-#[cfg(not(feature = "sm-memory"))]
-pub async fn sm_goals_create(_d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
-    goals_unavailable()
-}
-
-/// See [`sm_goals_list`] (no-memory build).
-#[cfg(not(feature = "sm-memory"))]
-pub async fn sm_goals_update(_d: &SmDispatcher, _params: &Value) -> Result<Value, MethodError> {
-    goals_unavailable()
-}
-
-/// The graceful "goals unavailable" error for the no-memory build.
-#[cfg(not(feature = "sm-memory"))]
-fn goals_unavailable() -> Result<Value, MethodError> {
-    Err(MethodError::Unavailable(
-        "sm.goals.* are not available without the sm-memory feature".to_string(),
-    ))
 }

--- a/crates/trusty-mpm/src/daemon/sm_stdio/mod.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/mod.rs
@@ -38,38 +38,23 @@ mod methods;
 
 pub use control::{DaemonSessionControl, LaunchParams, SessionControl, SessionControlError};
 
-#[cfg(feature = "sm-memory")]
-use std::sync::Arc as StdArc;
-#[cfg(feature = "sm-memory")]
 use tokio::sync::Mutex;
 
-#[cfg(feature = "sm-memory")]
-use crate::core::sm::SmGoalStore;
+use crate::core::sm::{NoopGoalMemory, SmGoalStore};
 
-/// The shared goal-store handle `sm.goals.*` operate over (feature-gated type).
+/// The shared goal-store handle `sm.goals.*` and `sm.delegate` operate over (#1477).
 ///
-/// Why: [`SmDispatcher::new`] takes ONE signature across both `sm-memory` and
-/// the default build (a fragile dual-arity API was the prior shape). The goal
-/// store only exists under `sm-memory`, so the constructor accepts this handle
-/// as an `Option` that is simply always `None` in the no-memory build — gating
-/// the TYPE, never the arity. Under `sm-memory` it is the live store behind a
-/// mutex (the `&mut self` goal mutators serialise through it).
-/// What: an `Arc<Mutex<SmGoalStore>>` under the feature; an uninhabited
-/// `std::convert::Infallible` placeholder without it (never constructed —
-/// callers pass `None`).
-/// Test: `tests.rs::dispatcher_with` constructs `Some(..)`/`None` via this alias.
-#[cfg(feature = "sm-memory")]
-pub type SmGoalHandle = StdArc<Mutex<SmGoalStore>>;
-
-/// Placeholder goal-store handle for the no-memory build (never constructed).
-///
-/// Why: lets [`SmDispatcher::new`] keep ONE signature without referencing the
-/// `sm-memory`-only [`SmGoalStore`]. Callers in the default build always pass
-/// `None`, so no value of this type is ever created.
-/// What: a zero-sized uninhabitable-by-convention marker.
-/// Test: compile-only; the no-memory `new` ignores its `Option<SmGoalHandle>`.
-#[cfg(not(feature = "sm-memory"))]
-pub type SmGoalHandle = std::convert::Infallible;
+/// Why: the goal store (SM-6) is feature-INDEPENDENT — it works over the
+/// [`GoalMemory`](crate::core::sm::GoalMemory) seam — so `sm.goals.*` and the
+/// delegation loop can operate in EVERY build. Under `sm-memory` the store is
+/// backed by the durable SM palace; on the default build it is backed by a no-op
+/// seam ([`NoopGoalMemory`]) so goals function in-memory (non-durable) rather than
+/// returning "unavailable" (#1477). Keeping ONE handle type across both builds
+/// keeps [`SmDispatcher::new`] a single signature.
+/// What: an `Arc<Mutex<SmGoalStore>>` (the `&mut self` goal mutators serialise
+/// through the mutex).
+/// Test: `tests.rs::dispatcher_with` constructs it in both builds.
+pub type SmGoalHandle = Arc<Mutex<SmGoalStore>>;
 
 /// The transport-neutral SM dispatcher the stdio adapter drives (§1A.1).
 ///
@@ -80,29 +65,27 @@ pub type SmGoalHandle = std::convert::Infallible;
 /// dispatcher owns one handle per SM surface and does pure translation.
 /// What: the SM [`SessionManagerAgent`] (chat + health), a config snapshot + the
 /// `data_root` for opening the per-`conv_id` context engine (`sm.context.get`),
-/// the [`SessionControl`] seam for `sm.sessions.*`, and — under `sm-memory` — the
-/// shared [`SmGoalStore`] for `sm.goals.*`. Without the feature the goal store is
-/// absent and `sm.goals.*`/`sm.context.get` return a graceful JSON-RPC error.
+/// the [`SessionControl`] seam for `sm.sessions.*`, and the shared [`SmGoalStore`]
+/// for `sm.goals.*` + `sm.delegate`. All four surfaces are present in EVERY build
+/// (#1477): the goal store is palace-backed under `sm-memory` and no-op/in-memory
+/// on the default build, so no `sm.*` method returns "unavailable" purely for lack
+/// of the feature (only a degraded provider makes `sm.chat`/`sm.delegate` degrade).
 /// Test: `tests.rs` builds this over the mock resolver + mock session control.
 pub struct SmDispatcher {
     /// The SM agent (SM-7 chat + SM-2/§5.3 health). Shared, cheap to clone.
     agent: Arc<SessionManagerAgent>,
     /// Config snapshot used to open the context engine for `sm.context.get`
-    /// (inference + rounds) — read-only, never mutated here. Only consulted under
-    /// `sm-memory` (the no-memory build returns the unavailable error before
-    /// touching it).
-    #[cfg_attr(not(feature = "sm-memory"), allow(dead_code))]
+    /// (inference + rounds) — read-only, never mutated here. The context engine is
+    /// compiled in every build (#1477), so this is consulted in every build.
     config: SessionManagerConfig,
     /// Storage root under which per-`conv_id` context-engine state lives (SM-5).
-    /// Only consulted under `sm-memory` (see `config`).
-    #[cfg_attr(not(feature = "sm-memory"), allow(dead_code))]
     data_root: PathBuf,
     /// The managed-session control surface for `sm.sessions.*` (§2.6).
     sessions: Arc<dyn SessionControl>,
-    /// The SM goal store for `sm.goals.*` (SM-6), behind a mutex for the
-    /// `&mut self` mutators. Only present under `sm-memory`.
-    #[cfg(feature = "sm-memory")]
-    goals: StdArc<Mutex<SmGoalStore>>,
+    /// The SM goal store for `sm.goals.*` (SM-6) + the delegation loop, behind a
+    /// mutex for the `&mut self` mutators. Present in EVERY build (#1477): palace-
+    /// backed under `sm-memory`, no-op/in-memory on the default build.
+    goals: Arc<Mutex<SmGoalStore>>,
 }
 
 impl SmDispatcher {
@@ -111,14 +94,12 @@ impl SmDispatcher {
     /// Why: a single constructor across `sm-memory` and the default build keeps
     /// the public API stable for callers and tests — they wire the SAME five
     /// arguments regardless of feature. The goal store is an [`Option`]: `Some`
-    /// under `sm-memory` (the live store), always `None` in the no-memory build
-    /// (where `sm.goals.*`/`sm.context.get` return the graceful unavailable
-    /// error). Only the goal-handle TYPE is feature-gated (via [`SmGoalHandle`]),
-    /// never the arity.
-    /// What: stores agent/config/data_root/sessions; under `sm-memory` also stores
-    /// the unwrapped goal store (defaulting to an empty no-op store if `None`).
-    /// No I/O.
-    /// Test: `tests.rs::dispatcher_with` builds this with `Some`/`None` per build.
+    /// supplies a caller-built store (palace-backed under `sm-memory`, no-op on the
+    /// default build); `None` defaults to an empty no-op store so the dispatcher
+    /// always has a working goal surface (#1477).
+    /// What: stores agent/config/data_root/sessions and the goal store (unwrapping
+    /// the `Option`, defaulting to an empty [`NoopGoalMemory`]-backed store). No I/O.
+    /// Test: `tests.rs::dispatcher_with` builds this with `Some`/`None`.
     pub fn new(
         agent: Arc<SessionManagerAgent>,
         config: SessionManagerConfig,
@@ -127,29 +108,13 @@ impl SmDispatcher {
         goals: Option<SmGoalHandle>,
     ) -> Self {
         let data_root = data_root.into();
-        #[cfg(feature = "sm-memory")]
-        {
-            let goals =
-                goals.unwrap_or_else(|| StdArc::new(Mutex::new(empty_goal_store(&data_root))));
-            Self {
-                agent,
-                config,
-                data_root,
-                sessions,
-                goals,
-            }
-        }
-        #[cfg(not(feature = "sm-memory"))]
-        {
-            // No-memory build: there is no goal store; the handle is never
-            // constructed (callers always pass `None`).
-            let _ = goals;
-            Self {
-                agent,
-                config,
-                data_root,
-                sessions,
-            }
+        let goals = goals.unwrap_or_else(|| Arc::new(Mutex::new(empty_goal_store(&data_root))));
+        Self {
+            agent,
+            config,
+            data_root,
+            sessions,
+            goals,
         }
     }
 
@@ -206,21 +171,14 @@ async fn build_dispatcher(
     let data_root = state.sm_data_root();
     let sessions: Arc<dyn SessionControl> = Arc::new(DaemonSessionControl::new(state.clone()));
 
-    #[cfg(feature = "sm-memory")]
-    {
-        let goals = build_goal_store(&data_root, &config).await;
-        Ok(SmDispatcher::new(
-            agent,
-            config,
-            data_root,
-            sessions,
-            Some(goals),
-        ))
-    }
-    #[cfg(not(feature = "sm-memory"))]
-    {
-        Ok(SmDispatcher::new(agent, config, data_root, sessions, None))
-    }
+    let goals = build_goal_store(&data_root, &config).await;
+    Ok(SmDispatcher::new(
+        agent,
+        config,
+        data_root,
+        sessions,
+        Some(goals),
+    ))
 }
 
 /// Load the SM goal store from the dedicated SM palace (`sm-memory` build).
@@ -237,12 +195,12 @@ async fn build_dispatcher(
 async fn build_goal_store(
     data_root: &std::path::Path,
     config: &SessionManagerConfig,
-) -> StdArc<Mutex<SmGoalStore>> {
+) -> Arc<Mutex<SmGoalStore>> {
     use crate::core::sm::memory::SmMemory;
 
     let store = match SmMemory::open(data_root.join("palace"), &config.memory) {
         Ok(mem) => {
-            let mem: StdArc<dyn crate::core::sm::GoalMemory> = StdArc::new(mem);
+            let mem: Arc<dyn crate::core::sm::GoalMemory> = Arc::new(mem);
             match SmGoalStore::load(mem, data_root.to_path_buf()).await {
                 Ok(store) => store,
                 Err(e) => {
@@ -258,40 +216,35 @@ async fn build_goal_store(
             empty_goal_store(data_root)
         }
     };
-    StdArc::new(Mutex::new(store))
+    Arc::new(Mutex::new(store))
 }
 
-/// Build an empty goal store over a no-op palace seam (degraded fallback).
+/// Build the no-op/in-memory goal store for the default build (#1477).
 ///
-/// Why: when the real palace is unavailable, `sm.goals.*` must still answer
-/// (returning an empty list / accepting creates that simply do not durably
-/// persist) rather than the whole stdio surface failing. A no-op [`GoalMemory`]
-/// gives the store a seam that always succeeds with no entries.
+/// Why: without `sm-memory` there is no palace, but the goal store is
+/// feature-independent, so `sm.goals.*` and the delegation loop DEGRADE GRACEFULLY
+/// to non-durable in-memory operation (backed by [`NoopGoalMemory`]) rather than
+/// returning "unavailable". Durable persistence requires `--features sm-memory`.
+/// What: wraps an empty [`empty_goal_store`] in the shared mutex handle.
+/// Test: `tests.rs` no-feature `sm.goals.*` / `sm.delegate` branches.
+#[cfg(not(feature = "sm-memory"))]
+async fn build_goal_store(
+    data_root: &std::path::Path,
+    _config: &SessionManagerConfig,
+) -> Arc<Mutex<SmGoalStore>> {
+    Arc::new(Mutex::new(empty_goal_store(data_root)))
+}
+
+/// Build an empty goal store over the no-op palace seam ([`NoopGoalMemory`]).
+///
+/// Why: gives the store a seam that always succeeds with no entries — used both as
+/// the default-build backing (#1477) and as the `sm-memory` palace-unavailable
+/// fallback, so `sm.goals.*` answer (empty list / non-durable creates) rather than
+/// failing.
 /// What: constructs an [`SmGoalStore::new`] over a [`NoopGoalMemory`].
-/// Test: runtime fallback; the store behaviour is covered by SM-6 tests.
-#[cfg(feature = "sm-memory")]
+/// Test: covered by SM-6 store tests + the no-feature dispatch tests.
 fn empty_goal_store(data_root: &std::path::Path) -> SmGoalStore {
-    SmGoalStore::new(StdArc::new(NoopGoalMemory), data_root.to_path_buf())
-}
-
-/// A [`GoalMemory`] that persists nothing and lists nothing (degraded seam).
-///
-/// Why: lets the goal store operate (in-memory only) when the real SM palace is
-/// unavailable, so `sm.goals.*` degrade gracefully instead of erroring out.
-/// What: `remember_goal` is a no-op success; `list_goals` returns an empty vec.
-/// Test: runtime fallback only.
-#[cfg(feature = "sm-memory")]
-struct NoopGoalMemory;
-
-#[cfg(feature = "sm-memory")]
-#[async_trait::async_trait]
-impl crate::core::sm::GoalMemory for NoopGoalMemory {
-    async fn remember_goal(&self, _json: String, _tag: &str) -> Result<(), String> {
-        Ok(())
-    }
-    async fn list_goals(&self, _tag: &str) -> Result<Vec<String>, String> {
-        Ok(Vec::new())
-    }
+    SmGoalStore::new(Arc::new(NoopGoalMemory), data_root.to_path_buf())
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/tests.rs
@@ -154,9 +154,9 @@ fn agent_degraded(
 
 /// Build a dispatcher over the given agent + a fresh mock session control.
 ///
-/// Why: the feature-gated goal-store field makes construction differ by build;
-/// this helper hides that so the tests read identically. Under `sm-memory` it
-/// loads an empty goal store over a no-op palace + the tempdir.
+/// Why: the goal store is feature-independent (#1477), so this wires an in-memory
+/// no-op store in EVERY build — the `sm.goals.*` / `sm.delegate` / `sm.context.get`
+/// tests read identically regardless of the `sm-memory` feature.
 fn dispatcher_with(
     agent: Arc<SessionManagerAgent>,
     cfg: SessionManagerConfig,
@@ -164,35 +164,22 @@ fn dispatcher_with(
     control: Arc<MockSessionControl>,
 ) -> SmDispatcher {
     let sessions: Arc<dyn SessionControl> = control;
-    #[cfg(feature = "sm-memory")]
     let goals = Some(test_goal_store(data_root));
-    #[cfg(not(feature = "sm-memory"))]
-    let goals = None;
     SmDispatcher::new(agent, cfg, data_root.to_path_buf(), sessions, goals)
 }
 
-/// Build an in-memory goal store over a no-op palace for `sm.goals.*` tests.
+/// Build an in-memory goal store over the no-op palace seam for the dispatch tests.
 ///
-/// Why: the goal-store methods must round-trip without a real palace (no ONNX);
-/// a no-op [`GoalMemory`] gives the SM-6 store a seam that always succeeds with no
-/// durable entries, so creates/updates are visible in-memory within one test.
-#[cfg(feature = "sm-memory")]
+/// Why: the goal-store methods must round-trip without a real palace (no ONNX) in
+/// both builds; the always-compiled [`NoopGoalMemory`] gives the SM-6 store a seam
+/// that succeeds with no durable entries, so creates/updates are visible in-memory
+/// within one test.
 fn test_goal_store(
     data_root: &std::path::Path,
 ) -> std::sync::Arc<tokio::sync::Mutex<crate::core::sm::SmGoalStore>> {
-    use crate::core::sm::{GoalMemory, SmGoalStore};
+    use crate::core::sm::{NoopGoalMemory, SmGoalStore};
 
-    struct NoopMem;
-    #[async_trait]
-    impl GoalMemory for NoopMem {
-        async fn remember_goal(&self, _json: String, _tag: &str) -> Result<(), String> {
-            Ok(())
-        }
-        async fn list_goals(&self, _tag: &str) -> Result<Vec<String>, String> {
-            Ok(Vec::new())
-        }
-    }
-    let store = SmGoalStore::new(Arc::new(NoopMem), data_root.to_path_buf());
+    let store = SmGoalStore::new(Arc::new(NoopGoalMemory), data_root.to_path_buf());
     std::sync::Arc::new(tokio::sync::Mutex::new(store))
 }
 
@@ -754,8 +741,8 @@ async fn scripted_chat_launch_get_stop_sequence() {
         .await;
     assert_eq!(ok_result(&stop, 43)["ok"], true);
 
-    // 5) goal-update (only meaningful under sm-memory; otherwise it returns the
-    //    graceful unavailable error, which is itself a valid framed response).
+    // 5) goal create + update — works in every build now (#1477; in-memory store
+    //    on the default build, palace-backed under sm-memory).
     let create = d
         .dispatch(req(
             44,
@@ -763,36 +750,29 @@ async fn scripted_chat_launch_get_stop_sequence() {
             json!({ "description": "ship X" }),
         ))
         .await;
-    #[cfg(feature = "sm-memory")]
-    {
-        let goal = ok_result(&create, 44);
-        let goal_id = goal["goal"]["id"].as_str().unwrap().to_string();
-        let upd = d
-            .dispatch(req(
-                45,
-                "sm.goals.update",
-                json!({ "id": goal_id, "note": "kicked off" }),
-            ))
-            .await;
-        assert!(
-            !ok_result(&upd, 45)["goal"]["notes"]
-                .as_array()
-                .unwrap()
-                .is_empty()
-        );
-    }
-    #[cfg(not(feature = "sm-memory"))]
-    {
-        err_code(&create, 44, CODE_UNAVAILABLE);
-    }
+    let goal = ok_result(&create, 44);
+    let goal_id = goal["goal"]["id"].as_str().unwrap().to_string();
+    let upd = d
+        .dispatch(req(
+            45,
+            "sm.goals.update",
+            json!({ "id": goal_id, "note": "kicked off" }),
+        ))
+        .await;
+    assert!(
+        !ok_result(&upd, 45)["goal"]["notes"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
 }
 
-// ── Feature-gated goals / context ───────────────────────────────────────────────
+// ── goals / context (feature-independent since #1477) ───────────────────────────
 
-/// Why: `sm.goals.*` round-trip under `sm-memory` (create then list) and degrade
-/// to a graceful unavailable error without it. This pins both branches.
-/// What: under the feature, creates a goal and lists it; without it, asserts the
-/// unavailable code on `sm.goals.list`.
+/// Why: `sm.goals.*` round-trip in EVERY build (#1477) — create then list — because
+/// the goal store is feature-independent (in-memory on the default build,
+/// palace-backed under `sm-memory`).
+/// What: creates a goal and lists it, asserting the created goal is returned.
 /// Test: this is the test.
 #[tokio::test]
 async fn goals_feature_branches() {
@@ -806,32 +786,25 @@ async fn goals_feature_branches() {
         Arc::new(MockSessionControl::default()),
     );
 
-    #[cfg(feature = "sm-memory")]
-    {
-        let create = d
-            .dispatch(req(
-                50,
-                "sm.goals.create",
-                json!({ "description": "g1", "acceptance": ["pr merged"] }),
-            ))
-            .await;
-        assert_eq!(ok_result(&create, 50)["goal"]["description"], "g1");
+    let create = d
+        .dispatch(req(
+            50,
+            "sm.goals.create",
+            json!({ "description": "g1", "acceptance": ["pr merged"] }),
+        ))
+        .await;
+    assert_eq!(ok_result(&create, 50)["goal"]["description"], "g1");
 
-        let list = d.dispatch(req(51, "sm.goals.list", json!({}))).await;
-        let goals = ok_result(&list, 51)["goals"].as_array().unwrap().clone();
-        assert_eq!(goals.len(), 1, "the created goal is listed");
-    }
-    #[cfg(not(feature = "sm-memory"))]
-    {
-        let list = d.dispatch(req(52, "sm.goals.list", json!({}))).await;
-        err_code(&list, 52, CODE_UNAVAILABLE);
-    }
+    let list = d.dispatch(req(51, "sm.goals.list", json!({}))).await;
+    let goals = ok_result(&list, 51)["goals"].as_array().unwrap().clone();
+    assert_eq!(goals.len(), 1, "the created goal is listed");
 }
 
-/// Why: `sm.context.get` returns the rolling context state under `sm-memory`
-/// (after a chat populates it) and degrades to unavailable without the feature.
-/// What: under the feature, runs a chat then `sm.context.get` for the same
-/// conv_id and asserts the four context fields; without it, asserts unavailable.
+/// Why: `sm.context.get` returns the rolling context state in EVERY build (#1477)
+/// — the context engine never needed the SM palace, it depends only on serde + the
+/// provider trait.
+/// What: runs a chat then `sm.context.get` for the same conv_id and asserts the
+/// four context fields are present with at least one recorded round.
 /// Test: this is the test.
 #[tokio::test]
 async fn context_get_feature_branches() {
@@ -845,32 +818,22 @@ async fn context_get_feature_branches() {
         Arc::new(MockSessionControl::default()),
     );
 
-    #[cfg(feature = "sm-memory")]
-    {
-        // Populate a conversation first so the context engine has a round.
-        let _ = d
-            .dispatch(req(
-                60,
-                "sm.chat",
-                json!({ "message": "hi", "conv_id": "ctx-1" }),
-            ))
-            .await;
-        let ctx = d
-            .dispatch(req(61, "sm.context.get", json!({ "conv_id": "ctx-1" })))
-            .await;
-        let result = ok_result(&ctx, 61);
-        assert!(result["recent_rounds"].is_array());
-        assert!(result["total_rounds"].as_u64().unwrap() >= 1);
-        assert!(result["token_estimate"].is_number());
-        assert!(result.get("compressed_context").is_some());
-    }
-    #[cfg(not(feature = "sm-memory"))]
-    {
-        let ctx = d
-            .dispatch(req(62, "sm.context.get", json!({ "conv_id": "ctx-1" })))
-            .await;
-        err_code(&ctx, 62, CODE_UNAVAILABLE);
-    }
+    // Populate a conversation first so the context engine has a round.
+    let _ = d
+        .dispatch(req(
+            60,
+            "sm.chat",
+            json!({ "message": "hi", "conv_id": "ctx-1" }),
+        ))
+        .await;
+    let ctx = d
+        .dispatch(req(61, "sm.context.get", json!({ "conv_id": "ctx-1" })))
+        .await;
+    let result = ok_result(&ctx, 61);
+    assert!(result["recent_rounds"].is_array());
+    assert!(result["total_rounds"].as_u64().unwrap() >= 1);
+    assert!(result["token_estimate"].is_number());
+    assert!(result.get("compressed_context").is_some());
 }
 
 // ── sm.delegate (SM-8 delegation loop) — §1A.2 step-1 e2e ───────────────────────
@@ -882,7 +845,6 @@ async fn context_get_feature_branches() {
 /// do_work JSON lets the dispatcher test drive any path deterministically.
 /// What: builds an agent (feature-aware) over a [`MockResolver`] returning a
 /// provider that always replies with `decision_json`.
-#[cfg(feature = "sm-memory")]
 fn agent_with_decision(
     cfg: SessionManagerConfig,
     data_root: &std::path::Path,
@@ -904,7 +866,6 @@ fn agent_with_decision(
 /// dispatcher-level e2e exercises the gate passing, not just the agent-level test.
 /// What: `launch` mints an id and records params (so the goal links); `get`
 /// returns the evidence pane; `send` records the delivery.
-#[cfg(feature = "sm-memory")]
 #[derive(Default)]
 struct EvidenceControl {
     evidence: String,
@@ -912,7 +873,6 @@ struct EvidenceControl {
     next: std::sync::atomic::AtomicUsize,
 }
 
-#[cfg(feature = "sm-memory")]
 #[async_trait]
 impl SessionControl for EvidenceControl {
     async fn launch(&self, _params: LaunchParams) -> Result<Value, SessionControlError> {
@@ -978,7 +938,6 @@ impl SessionControl for EvidenceControl {
 }
 
 /// Build a dispatcher over an explicit `Arc<dyn SessionControl>` (e2e helper).
-#[cfg(feature = "sm-memory")]
 fn dispatcher_with_dyn_control(
     agent: Arc<SessionManagerAgent>,
     cfg: SessionManagerConfig,
@@ -995,8 +954,7 @@ fn dispatcher_with_dyn_control(
 /// What: scripts a delegate decision + an evidence-bearing control, dispatches
 /// `sm.delegate`, and asserts the launched session, task delivery (#1299), and
 /// `goal_done == true`; then `sm.goals.list` shows the goal as `done`.
-/// Test: this is the test.
-#[cfg(feature = "sm-memory")]
+/// Test: this is the test (feature-independent since #1477).
 #[tokio::test]
 async fn delegate_end_to_end_launch_observe_verify_close() {
     let tmp = TempDir::new().unwrap();
@@ -1057,8 +1015,7 @@ async fn delegate_end_to_end_launch_observe_verify_close() {
 /// agent unit test.
 /// What: scripts a delegate decision + the default (no-evidence) control;
 /// dispatches `sm.delegate` and asserts a launch happened but `goal_done` is false.
-/// Test: this is the test.
-#[cfg(feature = "sm-memory")]
+/// Test: this is the test (feature-independent since #1477).
 #[tokio::test]
 async fn delegate_gate_blocks_without_evidence_over_wire() {
     let tmp = TempDir::new().unwrap();
@@ -1098,8 +1055,7 @@ async fn delegate_gate_blocks_without_evidence_over_wire() {
 /// and redirected, never executed. Proves SP1–SP5 enforcement reaches the surface.
 /// What: scripts a `do_work` decision; dispatches `sm.delegate`; asserts nothing
 /// launched and the reply redirects to launching a session.
-/// Test: this is the test.
-#[cfg(feature = "sm-memory")]
+/// Test: this is the test (feature-independent since #1477).
 #[tokio::test]
 async fn delegate_refuses_direct_work_over_wire() {
     let tmp = TempDir::new().unwrap();
@@ -1125,8 +1081,8 @@ async fn delegate_refuses_direct_work_over_wire() {
 /// Why: a degraded SM (no provider) must surface `sm.delegate` as a graceful
 /// JSON-RPC unavailable error (the DECOMPOSE reasoning cannot run), never a panic.
 /// What: builds a degraded agent and asserts `sm.delegate` → CODE_UNAVAILABLE.
-/// Test: this is the test.
-#[cfg(feature = "sm-memory")]
+/// Test: this is the test (feature-independent since #1477: the degraded provider,
+/// not the missing goal store, is what makes delegate unavailable).
 #[tokio::test]
 async fn delegate_degraded_is_unavailable() {
     let tmp = TempDir::new().unwrap();
@@ -1142,28 +1098,6 @@ async fn delegate_degraded_is_unavailable() {
         .dispatch(req(74, "sm.delegate", json!({ "message": "anything" })))
         .await;
     err_code(&resp, 74, CODE_UNAVAILABLE);
-}
-
-/// Why: in the no-memory build `sm.delegate` (which persists goals) is gracefully
-/// unavailable, not a compile/runtime failure.
-/// What: dispatches `sm.delegate` and asserts CODE_UNAVAILABLE.
-/// Test: this is the test.
-#[cfg(not(feature = "sm-memory"))]
-#[tokio::test]
-async fn delegate_unavailable_without_feature() {
-    let tmp = TempDir::new().unwrap();
-    let cfg = enabled_config();
-    let agent = agent_with_provider(cfg.clone(), tmp.path());
-    let d = dispatcher_with(
-        agent,
-        cfg,
-        tmp.path(),
-        Arc::new(MockSessionControl::default()),
-    );
-    let resp = d
-        .dispatch(req(75, "sm.delegate", json!({ "message": "anything" })))
-        .await;
-    err_code(&resp, 75, CODE_UNAVAILABLE);
 }
 
 // ── stdout cleanliness guard ────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes two related Session-Manager (SM) hardening issues in one PR (they touch the same subsystem, `crates/trusty-mpm/src/core/sm/`).

## #1309 — Context-engine round loss under concurrent turns (data integrity, P2)

**Root cause:** the file-based `SmContextEngine` is opened fresh per turn and persists by an atomic *whole-file replace with no merge*. Two concurrent chat turns for the **same `conv_id`** each `open()` (loading the same on-disk state into their own in-memory `SmConversation`), append their round, and `save()` — the second save clobbers the first, so the first turn's round is **silently lost even though its reply was already returned to the caller**. This became reachable once the SM was wired into the async `coordinator/chat` endpoint (SM-7), which can drive multiple in-flight turns for one `conv_id`.

**Fix:** a per-`conv_id` async turn lock (`ConvLocks`, new `agent/conv_lock.rs`) held across the **whole** turn (`open → record → save`) in both `chat` and `chat_with_actions`, following the per-palace `write_mutex` precedent in `memory_core/retrieval/handle.rs`. Turns for **different** `conv_id`s never block each other; the registry stores `Weak` handles and prunes dead entries on each miss so it stays bounded by the number of concurrently-active conversations. The lock lives on the shared `Arc<SessionManagerAgent>` (an `Arc` field, so serialization holds across agent clones).

**Regression test:** `concurrent_turns_same_conv_id_persist_both_rounds` deterministically forces the interleave (a gated mock provider parks turn A mid-turn while turn B runs, driven by a `start_paused` clock) and asserts both rounds persist (`total_rounds == 2`). Verified it **fails pre-fix** (`total_rounds == 1`, one round lost) and passes post-fix. A companion `different_conv_ids_do_not_serialize` guards against over-serialization.

## #1477 — Goals / delegation / context degrade gracefully without `--features sm-memory` (P2)

The goal store (`SmGoalStore` over the `GoalMemory` seam) and the rolling-context engine are **already feature-independent** — only semantic recall and the palace-backed `GoalMemory` impl require `sm-memory`. But the `sm_stdio` adapter still returned `SM_UNAVAILABLE` (-32002) for `sm.goals.*`, `sm.delegate`, and `sm.context.get` on the default build (the headline SM-8 capability).

**Fix (mirroring the `recall_block` no-op cfg pattern):**
- Added an always-compiled `NoopGoalMemory` seam in `core/sm/goals/`.
- Back the goal store with it on the default build; un-gated the goals/delegate/context handlers.
- `sm.context.get` is now available in every build (the context engine never needed the palace).

These now **function in every build** — non-durable in-memory goals + full context inspection on the default build, durable palace-backed storage under `sm-memory`. Only a *degraded provider* (not the missing feature) makes `sm.chat`/`sm.delegate` degrade.

## Verification (all green)

- `cargo build --workspace` — ok
- `cargo test --workspace` — ok (trusty-mpm default: `2612 passed; 0 failed`)
- `cargo test -p trusty-mpm --features sm-memory` — ok (`2622 passed; 0 failed`; both concurrency tests pass under the feature too)
- `cargo clippy --workspace --all-targets -- -D warnings` (+ `-p trusty-mpm --features sm-memory`) — ok
- `cargo fmt --check` — ok
- `bash scripts/check_line_cap.sh` — `0 violations — OK`

Closes #1309
Closes #1477

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools