### PR TITLE
fix(trusty-mpm): inject --task into spawned session pane (turnkey execution) (closes #1903, #1299)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -1616,6 +1616,14 @@ pub(crate) enum SessionAction {
         /// with a "possible values" hint, not silently forwarded to the daemon.
         #[arg(long, default_value = "claude-code", value_enum)]
         runtime: trusty_mpm::runtime::RuntimeKind,
+        /// Do NOT auto-inject the task into the session pane (#1903/#1299).
+        ///
+        /// By default the task is turnkey: once the session's runtime is ready
+        /// it is typed into the pane so the session starts working immediately.
+        /// Pass `--no-inject` for the legacy metadata-only behavior, where the
+        /// task is stored but you deliver it yourself with `tm session send`.
+        #[arg(long)]
+        no_inject: bool,
     },
     /// List managed sessions (session-manager MVP).
     ///

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
@@ -55,6 +55,7 @@ pub(crate) fn to_command(action: &SessionAction) -> Option<TrustyCommand> {
             task,
             name_hint,
             runtime,
+            no_inject,
         } => TrustyCommand::ManagedNew {
             repo_url: repo.clone(),
             git_ref: git_ref.clone(),
@@ -63,6 +64,12 @@ pub(crate) fn to_command(action: &SessionAction) -> Option<TrustyCommand> {
             // Send the canonical wire spelling (`claude-code`/`tcode`); the CLI
             // already validated the value via the `RuntimeKind` value-enum.
             runtime: Some(runtime.as_str().to_string()),
+            // Turnkey by default: omit the field (daemon default = inject) and
+            // only send `Some(false)` when `--no-inject` opts into metadata-only
+            // (#1903/#1299). Keeping the default absent means `session start`
+            // (which builds a New action) posts the same minimal wire shape it
+            // always has.
+            inject_task: if *no_inject { Some(false) } else { None },
         },
         SessionAction::Ls { .. } => TrustyCommand::ManagedList,
         SessionAction::Send { id, text } => TrustyCommand::ManagedSend {
@@ -235,6 +242,7 @@ mod tests {
             task: "do it".to_string(),
             name_hint: Some("api".to_string()),
             runtime: trusty_mpm::runtime::RuntimeKind::ClaudeCode,
+            no_inject: false,
         };
         match to_command(&action) {
             Some(TrustyCommand::ManagedNew {
@@ -243,12 +251,35 @@ mod tests {
                 task,
                 name_hint,
                 runtime,
+                inject_task,
             }) => {
                 assert_eq!(repo_url, "https://example/r.git");
                 assert_eq!(git_ref, "main");
                 assert_eq!(task, "do it");
                 assert_eq!(name_hint.as_deref(), Some("api"));
                 assert_eq!(runtime.as_deref(), Some("claude-code"));
+                // Default (no `--no-inject`) → field omitted so the daemon's
+                // turnkey default (inject) applies.
+                assert_eq!(inject_task, None);
+            }
+            other => panic!("expected ManagedNew, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_command_new_no_inject_sets_metadata_only() {
+        // `--no-inject` maps to `inject_task: Some(false)` (metadata-only, #1903).
+        let action = SessionAction::New {
+            repo: "https://example/r.git".to_string(),
+            git_ref: "main".to_string(),
+            task: "do it".to_string(),
+            name_hint: None,
+            runtime: trusty_mpm::runtime::RuntimeKind::ClaudeCode,
+            no_inject: true,
+        };
+        match to_command(&action) {
+            Some(TrustyCommand::ManagedNew { inject_task, .. }) => {
+                assert_eq!(inject_task, Some(false));
             }
             other => panic!("expected ManagedNew, got {other:?}"),
         }

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/launch.rs
@@ -233,19 +233,17 @@ pub(crate) async fn launch_and_wait(
 
     // (4) Deliver the task to the session. `claude` reads the PM prompt from the
     // `--append-system-prompt-file` set by `prepare_session`; the concrete task
-    // is typed into the pane the same way `SessionManager::send_input` does. A
-    // brief settle gives `claude` time to reach its input prompt before we type.
+    // is typed into the pane through the shared readiness-gated injection seam
+    // (`SessionManager::inject_task_when_ready`, #1903/#1299) — which polls for
+    // the runtime to be ready instead of the blind fixed sleep this prototype
+    // used before that seam existed.
     if let Some(task) = task {
-        // TODO(M1 POC hardening follow-up): this fixed 3s settle assumes `claude`
-        // reaches its interactive input prompt within 3s before we type the task.
-        // A readiness check (poll the pane for the prompt) plus a more robust
-        // task-delivery seam is a tracked follow-up; an issue number will be
-        // attached separately.
-        tokio::time::sleep(Duration::from_secs(3)).await;
-        if let Err(e) = mgr.send_input(&record.id, task).await {
-            warn!(tmux = %record.tmux_name, "meta run: failed to inject demo task: {e}");
-        } else {
-            info!(tmux = %record.tmux_name, "meta run: demo task delivered to session");
+        match mgr.inject_task_when_ready(&record.id, task).await {
+            Ok(true) => info!(tmux = %record.tmux_name, "meta run: demo task delivered to session"),
+            Ok(false) => {
+                warn!(tmux = %record.tmux_name, "meta run: runtime never became ready; demo task not delivered")
+            }
+            Err(e) => warn!(tmux = %record.tmux_name, "meta run: failed to inject demo task: {e}"),
         }
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
@@ -70,6 +70,9 @@ pub(crate) async fn start_session(
             task: String::new(),
             name_hint: None,
             runtime: trusty_mpm::runtime::RuntimeKind::default(),
+            // Empty task → injection is a no-op regardless; keep the turnkey
+            // default so `session start` mirrors `session new` semantics (#1903).
+            no_inject: false,
         };
         crate::commands::managed_route::run(client, url, &new_action).await?;
         return Ok(());

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -44,6 +44,7 @@ fn cli_parses_session_new() {
                     task,
                     name_hint,
                     runtime,
+                    no_inject,
                 },
         } => {
             assert_eq!(repo, "https://github.com/owner/repo");
@@ -52,6 +53,31 @@ fn cli_parses_session_new() {
             assert_eq!(name_hint.as_deref(), Some("ticket-1"));
             // No --runtime flag → default claude-code (now a typed RuntimeKind).
             assert_eq!(runtime, trusty_mpm::runtime::RuntimeKind::ClaudeCode);
+            // No --no-inject → turnkey injection is the default (#1903/#1299).
+            assert!(!no_inject);
+        }
+        other => panic!("expected session new, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_new_no_inject() {
+    // Why: #1903/#1299 — `--no-inject` selects the legacy metadata-only spawn.
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "new",
+        "https://github.com/owner/repo",
+        "--task",
+        "do the thing",
+        "--no-inject",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::New { no_inject, .. },
+        } => {
+            assert!(no_inject, "--no-inject must set the flag");
         }
         other => panic!("expected session new, got {other:?}"),
     }

--- a/crates/trusty-mpm/src/client/command.rs
+++ b/crates/trusty-mpm/src/client/command.rs
@@ -168,6 +168,10 @@ pub enum TrustyCommand {
         name_hint: Option<String>,
         /// Optional runtime selector (`claude-code` | `tcode`).
         runtime: Option<String>,
+        /// Turnkey-injection control (#1903/#1299): `Some(false)` → metadata-only
+        /// (`--no-inject`); `None`/`Some(true)` → the daemon auto-injects the
+        /// task once the runtime is ready (the turnkey default).
+        inject_task: Option<bool>,
     },
     /// List every managed session (`sessions.list`).
     ManagedList,
@@ -303,6 +307,7 @@ mod tests {
             task: "do the thing".into(),
             name_hint: Some("api".into()),
             runtime: Some("tcode".into()),
+            inject_task: None,
         };
         assert_eq!(spawn.clone(), spawn);
         let answer = TrustyCommand::ManagedAnswer {

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -52,6 +52,7 @@ impl CommandExecutor {
         task: String,
         name_hint: Option<String>,
         runtime: Option<String>,
+        inject_task: Option<bool>,
     ) -> CommandResult {
         let req = ManagedSpawnRequest {
             repo_url,
@@ -59,6 +60,7 @@ impl CommandExecutor {
             task,
             name_hint,
             runtime,
+            inject_task,
         };
         match self.client().spawn_managed_session(&req).await {
             Ok(resp) => CommandResult::ManagedSpawned {

--- a/crates/trusty-mpm/src/client/executor/mod.rs
+++ b/crates/trusty-mpm/src/client/executor/mod.rs
@@ -133,8 +133,9 @@ impl CommandExecutor {
                 task,
                 name_hint,
                 runtime,
+                inject_task,
             } => {
-                self.managed_new(repo_url, git_ref, task, name_hint, runtime)
+                self.managed_new(repo_url, git_ref, task, name_hint, runtime, inject_task)
                     .await
             }
             TrustyCommand::ManagedList => self.managed_list().await,

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -404,6 +404,7 @@ fn managed_spawn_request_serializes() {
         task: "do the thing".to_string(),
         name_hint: Some("tmpm-custom".to_string()),
         runtime: Some("tcode".to_string()),
+        inject_task: None,
     };
     let v = serde_json::to_value(&req).unwrap();
     assert_eq!(v["ref"], "main");
@@ -418,10 +419,15 @@ fn managed_spawn_request_serializes() {
         task: "t".to_string(),
         name_hint: None,
         runtime: None,
+        inject_task: None,
     };
     let v = serde_json::to_value(&bare).unwrap();
     assert!(v.get("name_hint").is_none(), "None name_hint is omitted");
     assert!(v.get("runtime").is_none(), "None runtime is omitted");
+    assert!(
+        v.get("inject_task").is_none(),
+        "None inject_task is omitted"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -460,6 +460,11 @@ pub struct ManagedSpawnRequest {
     /// Optional runtime selector (`"claude-code"` | `"tcode"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
+    /// Optional turnkey-injection control (#1903/#1299): `Some(false)` requests
+    /// the legacy metadata-only spawn (the daemon otherwise auto-injects the
+    /// task once the runtime is ready). Absent → the daemon default (inject).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inject_task: Option<bool>,
 }
 
 /// Response body for `POST /api/v1/sessions/managed` (spawn).

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -66,6 +66,18 @@ pub struct SpawnParams {
     /// ticket` clients) and the SM-STDIO adapter (`sm.sessions.launch`) — never
     /// gates; those are trusted, explicitly-operator-driven paths.
     pub mcp_initiated: bool,
+    /// Whether to AUTO-INJECT `task` into the spawned pane once the runtime is
+    /// ready (issues #1903 / #1299).
+    ///
+    /// Why: `--task` is meant to be turnkey — the session should start working
+    /// on the task immediately after spawn. `None`/`Some(true)` inject (the
+    /// default, so `tm session new`, `tm ticket`, and MCP/SM callers are all
+    /// turnkey without opting in). `Some(false)` selects the legacy
+    /// metadata-only behavior (`tm session new --no-inject`), for callers that
+    /// deliver the task themselves via `tm session send`. Injection is
+    /// additionally gated by [`crate::session_manager::should_inject_task`]
+    /// (non-empty task, Claude Code runtime, session reached `Active`).
+    pub inject_task: Option<bool>,
 }
 
 /// Spawn a managed session, shared by the HTTP handler and the MCP tool.
@@ -131,11 +143,68 @@ pub async fn spawn_managed(
         params.repo_url.clone(),
         state.event_tx.clone(),
     );
-    crate::core::provisioning_stage::scoped(
+    // Capture the injection opt-out before `params` is moved into the routed
+    // dispatch. `None`/`Some(true)` → turnkey (inject); `Some(false)` →
+    // metadata-only (`--no-inject`).
+    let inject_flag = params.inject_task != Some(false);
+    let record = crate::core::provisioning_stage::scoped(
         emitter,
         spawn_managed_routed(state, session_id, params, runtime, config),
     )
-    .await
+    .await?;
+
+    // Turnkey task injection (#1903 / #1299): once the pane is up and the
+    // runtime is ready, deliver the task through the same seam `tm session send`
+    // uses, so `tm session new --task` / `tm ticket` start working immediately
+    // instead of sitting idle at an empty prompt.
+    spawn_task_injection(state.clone(), record.clone(), inject_flag);
+
+    Ok(record)
+}
+
+/// Kick off turnkey `--task` injection for a freshly-spawned session (#1903 / #1299).
+///
+/// Why: `--task` must be turnkey — after the runtime launches, the task is typed
+/// into the pane so the session starts working immediately. Delivery has to WAIT
+/// for the runtime to be ready (keystrokes sent before `claude` execs are lost),
+/// which can take a few seconds; blocking the spawn response on that would make
+/// every caller wait, so this runs in a detached background task (mirroring
+/// `daemon::services::session_service::spawn_pid_capture`).
+/// What: gates on [`crate::session_manager::should_inject_task`] (opt-out flag,
+/// non-empty task, Claude Code runtime — `tcode` injects the task in its own
+/// launch command — and a session that reached `Active`); when it passes, spawns
+/// a Tokio task that awaits
+/// [`crate::session_manager::SessionManager::inject_task_when_ready`]. A skip or
+/// failure is non-fatal: the task remains on the record as metadata, deliverable
+/// via `tm session send`.
+/// Test: the gate is unit-tested in `session_manager::task_inject`; the delivery
+/// via the fake seam is covered there too. This wiring is side-effect-only
+/// (fire-and-forget) and exercised by the live `#[ignore]` e2e flow.
+fn spawn_task_injection(state: Arc<DaemonState>, record: SessionRecord, inject_flag: bool) {
+    if !crate::session_manager::should_inject_task(
+        inject_flag,
+        &record.task,
+        record.runtime,
+        &record.state,
+    ) {
+        return;
+    }
+    tokio::spawn(async move {
+        let mgr = state.session_manager().await;
+        match mgr.inject_task_when_ready(&record.id, &record.task).await {
+            Ok(true) => {}
+            Ok(false) => warn!(
+                id = %record.id,
+                name = %record.tmux_name,
+                "turnkey task injection skipped (runtime never became ready); task retained as metadata"
+            ),
+            Err(e) => warn!(
+                id = %record.id,
+                name = %record.tmux_name,
+                "turnkey task injection failed: {e}; task retained as metadata"
+            ),
+        }
+    });
 }
 
 /// Route a spawn to the in-project, local-path, or clone-based branch (#1919).
@@ -1757,6 +1826,7 @@ mod tests {
             runtime: None,
             ephemeral: Some(true),
             mcp_initiated: false,
+            inject_task: None,
         };
 
         let config = crate::core::trusty_tools_config::TrustyToolsConfig::default();

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -83,6 +83,12 @@ pub struct SpawnRequest {
     /// → a normal durable session the automatic paths never touch.
     #[serde(default)]
     pub ephemeral: Option<bool>,
+    /// Optional turnkey-injection control (#1903/#1299): absent/null/`true` →
+    /// auto-inject `task` into the pane once the runtime is ready (the default,
+    /// so `tm session new`/`tm ticket` are turnkey); `false` → metadata-only
+    /// (the caller delivers the task via `POST .../{id}/send`).
+    #[serde(default)]
+    pub inject_task: Option<bool>,
 }
 
 /// Response body for POST /api/v1/sessions/managed (spawn, 201 Created).
@@ -405,6 +411,9 @@ pub async fn spawn_session(
         // HTTP route == CLI-origin (`tm launch`/`tm ticket` client calls) —
         // never subject to the MCP spawn gate (#1836/#1837).
         mcp_initiated: false,
+        // Turnkey by default (#1903/#1299); a client sets `inject_task: false`
+        // to opt into the legacy metadata-only behavior (`--no-inject`).
+        inject_task: req.inject_task,
     };
 
     match spawn_managed(&state, params).await {

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -78,6 +78,8 @@ pub async fn session_new(
         // This IS the MCP tool surface (#1836/#1837): every call here is
         // subject to the off-by-default gate + registry allowlist.
         mcp_initiated: true,
+        // Turnkey by default (#1903/#1299): an MCP `session_new` spawns to work.
+        inject_task: None,
     };
     let record = spawn_managed(state, params).await?;
     Ok(record_to_json(&record))

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -140,6 +140,8 @@ impl SessionControl for DaemonSessionControl {
             // subsystem, not the standard MCP tool surface) — never subject to
             // the MCP spawn gate (#1836/#1837), matching `tm launch`/`tm ticket`.
             mcp_initiated: false,
+            // Turnkey by default (#1903/#1299): the SM driver launches to work.
+            inject_task: None,
         };
         let record = spawn_managed(&self.state, spawn)
             .await

--- a/crates/trusty-mpm/src/session_manager/driver.rs
+++ b/crates/trusty-mpm/src/session_manager/driver.rs
@@ -103,6 +103,28 @@ pub trait ManagedTmuxDriver: Send + Sync {
             .unwrap_or(false)
     }
 
+    /// Probe whether the runtime inside `name`'s pane is READY to accept typed
+    /// input (issue #1903 / #1299).
+    ///
+    /// Why: turnkey task injection (`SessionManager::inject_task_when_ready`)
+    /// must not type the task into the pane before the runtime (`claude`) has
+    /// actually launched — keystrokes sent to a pane whose shell is still
+    /// exec-ing the runtime are lost or mangled. This is the readiness signal
+    /// the injection loop polls (with bounded backoff) before delivering the
+    /// task, replacing the blind fixed sleep the meta-launch prototype used.
+    /// What: the default is `session_exists(name)` — sufficient for the test
+    /// doubles (a fake reports its created session as existing) and a safe
+    /// lower bound for any driver that cannot inspect the pane's process tree.
+    /// [`super::real_tmux::RealTmuxDriver`] overrides this to the stronger
+    /// signal: the `claude` child PID has appeared under the pane shell (the
+    /// same probe `daemon::services::session_service::spawn_pid_capture` uses).
+    /// Test: `RealTmuxDriver`'s override is exercised by the `#[ignore]` live
+    /// integration test; the default is exercised via `FakeTmuxDriver` in
+    /// `session_manager::task_inject`'s tests.
+    fn runtime_ready(&self, name: &str) -> bool {
+        self.session_exists(name)
+    }
+
     /// Durably publish `key=value` into the named session's tmux environment
     /// (#2157 item 1) — belt-and-suspenders alongside the pane-shell `export …;`
     /// prefix `runtime::claude_code`/`runtime::tcode` already send.

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -26,6 +26,7 @@ pub mod search_gc;
 pub mod session_guard;
 pub mod snapshot;
 pub mod store;
+pub mod task_inject;
 pub mod workspace_guard;
 
 #[cfg(test)]
@@ -74,6 +75,7 @@ pub use prune::{MAX_EPHEMERAL_AGE_HOURS, PruneAction, PruneFilter, PruneOutcome,
 pub use record::{ManagedSessionId, ManagedSessionState, RecordError, SessionRecord};
 pub use session_guard::TmuxSessionGuard;
 pub use store::{SessionStore, StoreError};
+pub use task_inject::should_inject_task;
 
 #[cfg(feature = "daemon")]
 pub use real_tmux::RealTmuxDriver;

--- a/crates/trusty-mpm/src/session_manager/real_tmux.rs
+++ b/crates/trusty-mpm/src/session_manager/real_tmux.rs
@@ -100,6 +100,24 @@ impl ManagedTmuxDriver for RealTmuxDriver {
         self.driver.pane_current_path(name)
     }
 
+    /// Report the runtime ready when the `claude` child PID has appeared under
+    /// the pane shell (overrides the trait's weaker `session_exists` default;
+    /// issue #1903 / #1299).
+    ///
+    /// Why: the pane exists the instant `create_session` returns, long before
+    /// `claude` has exec'd — typing the task then would lose it. The presence
+    /// of the `claude` child process is the same "runtime is up" signal the
+    /// PID-capture path relies on, so injection waits for it.
+    /// What: a SINGLE-shot probe (`max_attempts = 1`, no delay) of
+    /// [`crate::core::process::find_claude_pid_in_tmux`]; the retry/backoff loop
+    /// lives in [`crate::session_manager::SessionManager::inject_task_when_ready`],
+    /// so this stays a cheap yes/no the loop polls.
+    /// Test: exercised by the `#[ignore]` live integration test (requires a real
+    /// `tmux` + `claude`); the pure retry loop is unit-tested against the fake.
+    fn runtime_ready(&self, name: &str) -> bool {
+        crate::core::process::find_claude_pid_in_tmux(name, 1, std::time::Duration::ZERO).is_some()
+    }
+
     /// Overrides the no-op trait default so the production path actually calls
     /// `tmux set-environment` (#2157 item 1).
     fn set_environment(&self, name: &str, key: &str, value: &str) -> Result<(), ManagedError> {

--- a/crates/trusty-mpm/src/session_manager/task_inject.rs
+++ b/crates/trusty-mpm/src/session_manager/task_inject.rs
@@ -1,0 +1,269 @@
+//! Turnkey task injection: deliver a session's `--task` into its pane once the
+//! runtime is ready (issues #1903 / #1299).
+//!
+//! Why: `tm session new --task "<text>"` (and `tm ticket`, which posts to the
+//! same spawn endpoint) stored the task as metadata but never typed it into the
+//! freshly-launched Claude Code pane — the session sat idle at an empty prompt
+//! and any caller expecting turnkey execution waited forever. The fix reuses the
+//! EXISTING `send_input`/`send_line` seam (`tm session send` /
+//! `POST .../{id}/send`) to deliver the task, but only after the runtime is
+//! ready to accept typed input, replacing the blind fixed sleep the meta-launch
+//! prototype used ([`crate::bin` `meta::launch`]) with a bounded readiness poll.
+//! What: [`should_inject_task`] is the pure gate (opt-out flag, non-empty task,
+//! Claude Code runtime, live session) and [`SessionManager::inject_task_when_ready`]
+//! is the readiness-gated delivery. Only `RuntimeKind::ClaudeCode` is injected —
+//! the `tcode` adapter already delivers the task in its `run-task` launch command,
+//! so injecting there would duplicate it.
+//! Test: `should_inject_*` (pure gate) and `inject_when_ready_*` (delivery via
+//! the `FakeTmuxDriver` seam) in this module's `tests` submodule.
+
+use std::time::Duration;
+
+use tracing::{info, warn};
+
+use crate::runtime::RuntimeKind;
+
+use super::manager::{ManagedError, SessionManager};
+use super::record::{ManagedSessionId, ManagedSessionState};
+
+/// Max readiness-probe attempts before giving up (issue #1903).
+///
+/// Why: injection must be BOUNDED — a runtime that never comes up (spawn failed
+/// silently, `claude` crashed on launch) must not leave a background task
+/// polling forever. With the backoff schedule below this caps the wait at
+/// roughly one minute, comfortably longer than Claude Code's 1–3 s launch while
+/// still terminating.
+const READY_MAX_ATTEMPTS: u32 = 30;
+
+/// Initial delay between readiness probes; doubles up to [`READY_BACKOFF_MAX`].
+const READY_BACKOFF_START: Duration = Duration::from_millis(250);
+
+/// Ceiling for the exponential readiness backoff.
+const READY_BACKOFF_MAX: Duration = Duration::from_secs(2);
+
+/// Pure gate: should the spawned session's task be auto-injected into its pane?
+///
+/// Why: the daemon spawn path must decide — before spending a background task on
+/// readiness polling — whether injection applies at all. Keeping the decision a
+/// pure function of primitives makes every branch unit-testable without a daemon,
+/// a tmux, or a session record.
+/// What: returns `true` only when ALL hold: the caller did not opt out
+/// (`inject_flag`), the task is non-empty after trimming, the runtime is
+/// `ClaudeCode` (the `tcode` adapter already injects the task in its launch
+/// command, so re-injecting would duplicate it), and the session reached
+/// `Active` (a spawn that errored or was withheld by the intent-conformance
+/// front gate stays `Provisioning`/`Errored` — never inject into those).
+/// Test: `should_inject_task_true_for_active_claude_code`,
+/// `should_inject_task_false_when_opted_out`,
+/// `should_inject_task_false_for_empty_task`,
+/// `should_inject_task_false_for_tcode`,
+/// `should_inject_task_false_when_not_active`.
+pub fn should_inject_task(
+    inject_flag: bool,
+    task: &str,
+    runtime: RuntimeKind,
+    state: &ManagedSessionState,
+) -> bool {
+    inject_flag
+        && !task.trim().is_empty()
+        && runtime == RuntimeKind::ClaudeCode
+        && *state == ManagedSessionState::Active
+}
+
+impl SessionManager {
+    /// Deliver `task` into the session's pane once its runtime is ready (#1903).
+    ///
+    /// Why: this is the turnkey half of `--task` — after the pane is up and the
+    /// runtime has launched, the task is typed in through the SAME seam
+    /// `tm session send` uses ([`Self::send_input`] → `send_line` + Enter), so a
+    /// caller that treats `--task` as "start working immediately" gets exactly
+    /// that. Delivery MUST wait for readiness: keystrokes sent before `claude`
+    /// has exec'd are lost, so this polls [`super::driver::ManagedTmuxDriver::runtime_ready`]
+    /// with bounded exponential backoff rather than a blind sleep.
+    /// What: returns `Ok(false)` early for an empty task; otherwise polls
+    /// readiness up to [`READY_MAX_ATTEMPTS`] times (backoff
+    /// [`READY_BACKOFF_START`]→[`READY_BACKOFF_MAX`]), bailing (with a warning,
+    /// `Ok(false)`) if the session transitions to `Stopped`/`Errored`/
+    /// `Decommissioned` while waiting or never becomes ready within the budget.
+    /// On readiness it calls [`Self::send_input`] and returns `Ok(true)`. The
+    /// task is NOT lost when injection is skipped — it remains on the record as
+    /// metadata, exactly as before this fix, so a caller can still deliver it
+    /// manually via `tm session send`.
+    /// Test: `inject_when_ready_sends_task_via_send_seam`,
+    /// `inject_when_ready_skips_empty_task` in this module's `tests`.
+    pub async fn inject_task_when_ready(
+        &self,
+        id: &ManagedSessionId,
+        task: &str,
+    ) -> Result<bool, ManagedError> {
+        if task.trim().is_empty() {
+            return Ok(false);
+        }
+        let name = self.get(id).await?.tmux_name;
+
+        let mut delay = READY_BACKOFF_START;
+        let mut ready = false;
+        for attempt in 0..READY_MAX_ATTEMPTS {
+            if attempt > 0 {
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(READY_BACKOFF_MAX);
+            }
+            // Bail if the session died / was torn down while we waited — typing
+            // into a dead pane is pointless and `send_input` would reject it.
+            let state = self.get(id).await?.state;
+            if matches!(
+                state,
+                ManagedSessionState::Stopped
+                    | ManagedSessionState::Errored
+                    | ManagedSessionState::Decommissioned
+            ) {
+                warn!(
+                    id = %id,
+                    name = %name,
+                    state = %state,
+                    "task injection aborted: session no longer live (task retained as metadata)"
+                );
+                return Ok(false);
+            }
+            if self.tmux.runtime_ready(&name) {
+                ready = true;
+                break;
+            }
+        }
+
+        if !ready {
+            warn!(
+                id = %id,
+                name = %name,
+                "runtime not ready within budget; task NOT injected (retained as metadata — \
+                 deliver it with `tm session send`)"
+            );
+            return Ok(false);
+        }
+
+        self.send_input(id, task).await?;
+        info!(id = %id, name = %name, "injected --task into ready session pane (#1903)");
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::record::ManagedSessionState;
+    use super::super::tests::make_manager;
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn should_inject_task_true_for_active_claude_code() {
+        assert!(should_inject_task(
+            true,
+            "implement OAuth2",
+            RuntimeKind::ClaudeCode,
+            &ManagedSessionState::Active,
+        ));
+    }
+
+    #[test]
+    fn should_inject_task_false_when_opted_out() {
+        // `--no-inject` / metadata-only: never inject even for a live claude session.
+        assert!(!should_inject_task(
+            false,
+            "implement OAuth2",
+            RuntimeKind::ClaudeCode,
+            &ManagedSessionState::Active,
+        ));
+    }
+
+    #[test]
+    fn should_inject_task_false_for_empty_task() {
+        assert!(!should_inject_task(
+            true,
+            "   ",
+            RuntimeKind::ClaudeCode,
+            &ManagedSessionState::Active,
+        ));
+    }
+
+    #[test]
+    fn should_inject_task_false_for_tcode() {
+        // tcode injects the task in its own launch command; re-injecting would duplicate it.
+        assert!(!should_inject_task(
+            true,
+            "implement OAuth2",
+            RuntimeKind::Tcode,
+            &ManagedSessionState::Active,
+        ));
+    }
+
+    #[test]
+    fn should_inject_task_false_when_not_active() {
+        // A spawn that errored or was withheld by the front gate must not be injected.
+        for state in [
+            ManagedSessionState::Provisioning,
+            ManagedSessionState::Errored,
+            ManagedSessionState::Stopped,
+            ManagedSessionState::Decommissioned,
+        ] {
+            assert!(!should_inject_task(
+                true,
+                "implement OAuth2",
+                RuntimeKind::ClaudeCode,
+                &state,
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn inject_when_ready_sends_task_via_send_seam() {
+        // Integration-style: with the FakeTmuxDriver (whose `runtime_ready`
+        // defaults to `session_exists` → true after create), injection delivers
+        // the task through the SAME `send_line` seam `tm session send` uses.
+        let dir = TempDir::new().unwrap();
+        let (mgr, fake) = make_manager(&dir).await;
+        let record = mgr
+            .create("wire up the widget".into(), None, None, None, None, None)
+            .await
+            .expect("create");
+
+        let injected = mgr
+            .inject_task_when_ready(&record.id, "wire up the widget")
+            .await
+            .expect("inject");
+
+        assert!(
+            injected,
+            "task should have been injected into the ready pane"
+        );
+        let sends = fake.send_calls.lock().unwrap();
+        assert_eq!(
+            sends.len(),
+            1,
+            "exactly one send-line should fire: {sends:?}"
+        );
+        assert_eq!(sends[0].0, record.tmux_name);
+        assert_eq!(sends[0].1, "wire up the widget");
+    }
+
+    #[tokio::test]
+    async fn inject_when_ready_skips_empty_task() {
+        // Metadata-vs-inject: an empty task is a no-op — nothing is typed.
+        let dir = TempDir::new().unwrap();
+        let (mgr, fake) = make_manager(&dir).await;
+        let record = mgr
+            .create("   ".into(), None, None, None, None, None)
+            .await
+            .expect("create");
+
+        let injected = mgr
+            .inject_task_when_ready(&record.id, "   ")
+            .await
+            .expect("inject");
+
+        assert!(!injected, "empty task must not be injected");
+        assert!(
+            fake.send_calls.lock().unwrap().is_empty(),
+            "no send-line should fire for an empty task"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/slack/commands.rs
+++ b/crates/trusty-mpm/src/slack/commands.rs
@@ -210,6 +210,7 @@ impl From<SlackCommand> for TrustyCommand {
                     task,
                     name_hint: None,
                     runtime: None,
+                    inject_task: None,
                 }
             }
             SlackCommand::Fleet => TrustyCommand::ManagedList,
@@ -381,6 +382,7 @@ mod tests {
                 task: "build it".into(),
                 name_hint: None,
                 runtime: None,
+                inject_task: None,
             }
         );
     }

--- a/crates/trusty-mpm/src/telegram/commands.rs
+++ b/crates/trusty-mpm/src/telegram/commands.rs
@@ -164,6 +164,7 @@ impl From<TelegramCommand> for TrustyCommand {
                     task,
                     name_hint: None,
                     runtime: None,
+                    inject_task: None,
                 }
             }
             TelegramCommand::Fleet => TrustyCommand::ManagedFleet,
@@ -380,6 +381,7 @@ mod tests {
                 task: "build it".into(),
                 name_hint: None,
                 runtime: None,
+                inject_task: None,
             }
         );
     }

--- a/crates/trusty-mpm/src/tui/coordinator/dispatch.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/dispatch.rs
@@ -216,6 +216,7 @@ fn route_new(args: &str) -> Dispatch {
         task: task.to_string(),
         name_hint: None,
         runtime: None,
+        inject_task: None,
     })
 }
 

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -1312,6 +1312,7 @@ fn route_new_builds_managed_new() {
             task: "do the thing".to_string(),
             name_hint: None,
             runtime: None,
+            inject_task: None,
         })
     );
 }

--- a/crates/trusty-mpm/tests/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/tests/mcp_spawn_gate.rs
@@ -75,6 +75,7 @@ fn base_params(repo_url: &str, mcp_initiated: bool) -> SpawnParams {
         runtime: None,
         ephemeral: Some(true),
         mcp_initiated,
+        inject_task: None,
     }
 }
 


### PR DESCRIPTION
## Summary

`tm session new --task "<text>"` and `tm ticket` (which posts to the same
`POST /api/v1/sessions/managed` endpoint) stored the task as session metadata
but **never typed it into the freshly-launched Claude Code pane** — the session
sat idle at an empty prompt, so a caller expecting turnkey execution polled
`tm session activity` forever. This makes `--task` genuinely turnkey.

Fixes **#1903** (P2) and resolves **#1299** (P3, ticket path) — both funnel
through the daemon `spawn_managed`, so one hook covers both.

## What changed

Injection reuses the **existing** `session_send` seam (`SessionManager::send_input`
→ `send_line`), delivered only once the runtime is ready:

- **`session_manager/task_inject.rs`** (new): `SessionManager::inject_task_when_ready`
  polls a new `ManagedTmuxDriver::runtime_ready` probe with **bounded exponential
  backoff** (250 ms → 2 s, ≤ 30 attempts) instead of a blind sleep, bails if the
  session dies mid-wait, then injects via `send_input`. Pure gate
  `should_inject_task` (opt-out flag · non-empty task · Claude Code runtime ·
  `Active` state).
- **`session_manager/driver.rs`** / **`real_tmux.rs`**: `runtime_ready` trait method
  — default `session_exists` (keeps the fake test seam working); the real driver
  overrides it to "the `claude` child PID has appeared" (same signal `spawn_pid_capture`
  uses).
- **`daemon/managed_routes/lifecycle.rs`**: after a successful `spawn_managed`,
  a **detached** injection task runs so the HTTP spawn response is not blocked on
  readiness. Only `RuntimeKind::ClaudeCode` is injected — the `tcode` adapter
  already delivers the task in its `run-task` launch command, so re-injecting
  would duplicate it.
- **Opt-out**: `tm session new --no-inject` (wire `inject_task: false`) restores
  the legacy metadata-only behavior. Turnkey is the default (field omitted on the
  wire → daemon default). A skipped/failed injection retains the task as metadata,
  deliverable via `tm session send`.
- Replaced the `meta::launch` prototype's fixed 3 s sleep + TODO with the new seam.

Layering: injection logic lives in the session-manager core; the CLI flag and
wire field (`SpawnRequest`/`ManagedSpawnRequest`/`TrustyCommand::ManagedNew`) are
thin surfaces over it.

## #1299 note

#1299 asked whether `tm ticket` should auto-inject or document a manual
`session send`. Per Bob's turnkey intent this fix makes it auto-inject (consistent
with `tm session new`); the SM-STDIO driver still delivers explicitly and is
unaffected (it can pass `inject_task: false`).

## Tests / gates (raw output)

- `cargo build --workspace` → `Finished` (exit 0)
- `cargo test -p trusty-mpm` → `test result: ok. 2614 passed; 0 failed` (+ all bin/integration suites ok)
- `cargo test --workspace` → exit 0, no failures (124 `test result: ok` lines)
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo fmt --check` → clean
- `bash scripts/check_line_cap.sh` → `0 violations — OK`

New tests: `should_inject_*` (gate matrix), `inject_when_ready_*` (delivery/skip
via `FakeTmuxDriver`), `cli_parses_session_new_no_inject`,
`to_command_new_no_inject_sets_metadata_only`.

Closes #1903
Closes #1299

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools