### PR TITLE
feat: Telegram focused-session free-text routing (TELUI-6, #1440)

### DIFF
--- a/crates/trusty-mpm/src/client/mod.rs
+++ b/crates/trusty-mpm/src/client/mod.rs
@@ -36,8 +36,8 @@ pub use http_client::{
     OverseerSnapshot, PairConfirm, PairRequest, PairStatus, SessionRow, TmuxSessionRow,
 };
 pub use proxy::{
-    FocusOutcome, FocusTarget, FreeTextRoute, InjectOutcome, SessionProxy, SummarizeOutcome,
-    route_free_text,
+    ActivityDigest, FocusOutcome, FocusTarget, FreeTextRoute, InjectOutcome, ManagedBackend,
+    SessionProxy, SummarizeOutcome, route_free_text,
 };
 pub use resolver::{Resolvable, resolve_target};
 pub(crate) use result::fleet_state_glyph;

--- a/crates/trusty-mpm/src/client/mod.rs
+++ b/crates/trusty-mpm/src/client/mod.rs
@@ -18,6 +18,7 @@ pub mod catalog;
 pub mod command;
 pub mod executor;
 pub mod http_client;
+pub mod proxy;
 pub mod resolver;
 pub mod result;
 
@@ -33,6 +34,10 @@ pub use http_client::{
     ManagedAttachCmdResponse, ManagedListResponse, ManagedSendInputRequest,
     ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest, ManagedSpawnResponse,
     OverseerSnapshot, PairConfirm, PairRequest, PairStatus, SessionRow, TmuxSessionRow,
+};
+pub use proxy::{
+    FocusOutcome, FocusTarget, FreeTextRoute, InjectOutcome, SessionProxy, SummarizeOutcome,
+    route_free_text,
 };
 pub use resolver::{Resolvable, resolve_target};
 pub(crate) use result::fleet_state_glyph;

--- a/crates/trusty-mpm/src/client/proxy.rs
+++ b/crates/trusty-mpm/src/client/proxy.rs
@@ -1,31 +1,41 @@
 //! Channel-agnostic session-manager PROXY layer (TELUI-6, #1440).
 //!
 //! Why: this is layer 2 of the three-layer control model — the session-manager
-//! acting as a PROXY between an external channel (Telegram, Slack, MCP) and ONE
-//! managed session. Layer 1 is direct tmux attach; layer 3 (the cross-scope
-//! project manager, #2109) is out of scope here. The proxy is deliberately
-//! SINGLE-SESSION-focused: a conversation "focuses" one session and then talks
-//! to it, in two directions — INJECT (free text routed to the session's
-//! `managed-send`) and SUMMARIZE (the session's recent activity digested back to
-//! the channel). Putting the focus state machine and both directions HERE, in the
-//! shared chat-core over the one [`CommandExecutor`], means Slack and an MCP
-//! surface bind to the same API instead of re-implementing the state machine —
-//! each channel only supplies its conversation key and renders the structured
-//! outcomes in its own markup.
+//! acting as a PROXY between an external channel (Telegram, Slack, a local HTTP
+//! caller) and ONE managed session. Layer 1 is direct tmux attach; layer 3 (the
+//! cross-scope project manager, #2109) is out of scope here. The proxy is
+//! deliberately SINGLE-SESSION-focused: a conversation "focuses" one session and
+//! then talks to it, in two directions — INJECT (free text routed to the
+//! session's `managed-send`) and SUMMARIZE (the session's recent activity
+//! digested back to the channel). Putting the focus state machine and both
+//! directions HERE, behind a [`ManagedBackend`] abstraction, means every surface
+//! — Telegram, Slack, and the daemon's OWN local HTTP proxy routes
+//! (`daemon::managed_routes::proxy`) — share the identical [`SessionProxy`]
+//! state machine and differ only in HOW they reach a managed session: over HTTP
+//! via [`super::executor::CommandExecutor`] (external channels) or in-process via
+//! the daemon's `SessionManager` (the local proxy routes). A caller can therefore
+//! exercise this entire state machine with `curl` against the daemon before ever
+//! wiring up a Telegram bot token.
 //! What: [`SessionProxy`] owns the per-conversation focus map (keyed by an opaque
 //! channel-supplied conversation string — Telegram passes its `chat_id`, Slack a
-//! channel id, MCP a client/session id) and exposes [`SessionProxy::focus`],
-//! [`SessionProxy::unfocus`], [`SessionProxy::current_focus`],
-//! [`SessionProxy::inject`], and [`SessionProxy::summarize`], each returning a
-//! structured, channel-agnostic outcome the binding renders. [`route_free_text`]
-//! is the pure inject-vs-coordinator routing decision. Focus state is in-memory
-//! and VOLATILE across a daemon restart (the channels persist no per-conversation
-//! state); a restart simply drops every conversation back to fleet-wide chat.
+//! channel id, the local HTTP surface a caller-supplied `conversation_key`) and
+//! exposes [`SessionProxy::focus`], [`SessionProxy::unfocus`],
+//! [`SessionProxy::current_focus`], [`SessionProxy::inject`], and
+//! [`SessionProxy::summarize`], each returning a structured, channel-agnostic
+//! outcome the binding renders. [`route_free_text`] is the pure inject-vs-
+//! coordinator routing decision. Focus state is in-memory and VOLATILE across a
+//! daemon restart (no channel persists per-conversation state); a restart simply
+//! drops every conversation back to fleet-wide chat.
 //! Test: `proxy/tests.rs` covers the pure routing, the store round-trip, and the
-//! inject/summarize/dead-session paths against an in-process test daemon.
+//! inject/summarize/dead-session paths against an in-process test daemon (via the
+//! `CommandExecutor` backend); `daemon::managed_routes::proxy` and
+//! `tests/proxy_routes.rs` cover the SAME state machine reached through the
+//! direct in-process backend the daemon's local HTTP surface uses.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use async_trait::async_trait;
 
 use super::executor::CommandExecutor;
 use super::{CommandResult, TrustyCommand};
@@ -36,22 +46,135 @@ use super::{CommandResult, TrustyCommand};
 /// re-resolution and are unambiguous) AND the friendly name (so a channel can
 /// name the session in replies without another daemon round-trip).
 /// What: the canonical managed-session `id` and its human-readable `name`, both
-/// captured at focus time from the authoritative `managed-get` record.
+/// captured at focus time from the authoritative resolution the backend performs.
 /// Test: `set_get_clear_round_trip` in `proxy/tests.rs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FocusTarget {
-    /// Canonical managed-session id (a UUID).
+    /// Canonical managed-session id (a UUID string).
     pub id: String,
     /// Friendly session name shown in replies.
     pub name: String,
 }
 
+/// A lightweight digest of a managed session's current activity.
+///
+/// Why: [`SessionProxy::summarize`] needs just enough to answer "what is my
+/// focused session doing?" without forcing every [`ManagedBackend`] to speak the
+/// full, heavier `ManagedActivity` wire shape (token counts, cache-hit flags,
+/// etc. — those stay on the richer `GET .../activity` endpoint UIs can call
+/// directly when they want the full picture).
+/// What: the session's lifecycle state, a short human-readable summary, and any
+/// pending decision it is blocked on.
+/// Test: exercised via each `ManagedBackend` impl's tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActivityDigest {
+    /// Lifecycle state (e.g. `"active"`, `"stopped"`).
+    pub state: String,
+    /// Short human-readable summary of what the session is doing.
+    pub summary: String,
+    /// A pending decision question, if the session is blocked on one.
+    pub pending_decision: Option<String>,
+}
+
+/// Backend abstraction the proxy resolves/sends/digests through.
+///
+/// Why: this is the seam that lets [`SessionProxy`] be the SAME struct and the
+/// SAME state machine for every surface, while each surface reaches a managed
+/// session differently — an external channel (Telegram, Slack) goes over HTTP
+/// via [`CommandExecutor`]; the daemon's own local proxy routes go in-process
+/// via `SessionManager` directly (see `daemon::managed_routes::proxy`), with no
+/// network hop. Neither implementation duplicates the focus/inject/summarize
+/// decision logic — only the three primitive operations below differ.
+/// What: `resolve` maps a fuzzy target (id, friendly name, or prefix) to its
+/// canonical `(id, name)`; `send` injects text into a resolved session; `activity`
+/// fetches a lightweight digest. All three return `Err(String)` on failure — a
+/// message a resolver-style "not found" error must phrase as containing the
+/// literal substring `"not found"` so [`is_missing_session`] can distinguish a
+/// vanished session from a transient transport failure (see that function's doc).
+/// Test: `ManagedBackend for CommandExecutor` is exercised by `proxy/tests.rs`;
+/// the daemon's direct backend by `daemon::managed_routes::proxy::tests`.
+#[async_trait]
+pub trait ManagedBackend: Send + Sync {
+    /// Resolve a fuzzy target to its canonical `(id, name)`.
+    async fn resolve(&self, target: &str) -> Result<(String, String), String>;
+    /// Inject `text` into the session identified by canonical `id`.
+    async fn send(&self, id: &str, text: &str) -> Result<(), String>;
+    /// Fetch a lightweight activity digest for the session identified by `id`.
+    async fn activity(&self, id: &str) -> Result<ActivityDigest, String>;
+}
+
+/// [`ManagedBackend`] over the shared HTTP [`CommandExecutor`] — the backend
+/// every EXTERNAL channel (Telegram, Slack) uses.
+///
+/// Why: external channels are separate OS processes from the daemon; they can
+/// only reach a managed session over the daemon's existing HTTP API, which is
+/// exactly what [`CommandExecutor`] already does via [`TrustyCommand::ManagedGet`],
+/// [`TrustyCommand::ManagedSend`], and [`TrustyCommand::ManagedActivity`].
+/// What: maps each [`ManagedBackend`] method onto the corresponding
+/// [`TrustyCommand`] and unwraps the resulting [`CommandResult`].
+/// Test: `proxy/tests.rs` (via `SessionProxy` built over this backend against an
+/// in-process test daemon).
+#[async_trait]
+impl ManagedBackend for CommandExecutor {
+    async fn resolve(&self, target: &str) -> Result<(String, String), String> {
+        match self
+            .execute(TrustyCommand::ManagedGet {
+                target: target.to_string(),
+            })
+            .await
+        {
+            CommandResult::ManagedSession(view) => Ok((view.id, view.name)),
+            CommandResult::Error(e) => Err(e),
+            _ => Err("unexpected daemon response".to_string()),
+        }
+    }
+
+    async fn send(&self, id: &str, text: &str) -> Result<(), String> {
+        match self
+            .execute(TrustyCommand::ManagedSend {
+                target: id.to_string(),
+                text: text.to_string(),
+            })
+            .await
+        {
+            CommandResult::ManagedSent { .. } => Ok(()),
+            CommandResult::Error(e) => Err(e),
+            _ => Err("unexpected daemon response".to_string()),
+        }
+    }
+
+    async fn activity(&self, id: &str) -> Result<ActivityDigest, String> {
+        match self
+            .execute(TrustyCommand::ManagedActivity {
+                target: id.to_string(),
+            })
+            .await
+        {
+            CommandResult::ManagedActivity {
+                state,
+                summary,
+                pending_decision,
+                ..
+            } => Ok(ActivityDigest {
+                state,
+                summary,
+                pending_decision,
+            }),
+            CommandResult::Error(e) => Err(e),
+            _ => Err("unexpected daemon response".to_string()),
+        }
+    }
+}
+
 /// The routing decision for one free-text (non-command) message.
 ///
-/// Why: modelling the two outcomes keeps each channel's handler branch trivial
-/// and the decision itself pure and unit-testable, shared across channels.
-/// What: `Inject` routes the text to the focused session's `managed-send`;
-/// `Coordinator` routes it to the action-capable coordinator (the default).
+/// Why: the single seam between "channel received a non-command message" and
+/// "which subsystem handles it"; modelling the two outcomes keeps each channel's
+/// handler branch trivial and the decision itself pure and unit-testable, shared
+/// across channels.
+/// What: `Inject` routes the text to the focused session (proxy INJECT
+/// direction); `Coordinator` routes it to the action-capable coordinator (the
+/// default when nothing is focused).
 /// Test: the `route_free_text_*` tests in `proxy/tests.rs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FreeTextRoute {
@@ -62,6 +185,18 @@ pub enum FreeTextRoute {
 }
 
 /// Outcome of a [`SessionProxy::focus`] request, for the channel to render.
+///
+/// Why: focusing is a validating operation with three genuinely different
+/// results a channel must render differently — successfully focused, a
+/// read-only query of the current focus (empty target), or a target that could
+/// not be resolved. Modelling them as one enum keeps every binding's render
+/// function exhaustive instead of guessing from a boolean + optional error.
+/// What: `Focused` on a successful resolve-and-set; `Current` when the caller
+/// passed an empty target (a read-only "what's focused right now?" query, never
+/// touching the backend); `NotFound` when the backend could not resolve the
+/// target — focus is left unchanged in this case.
+/// Test: `focus_empty_reports_current`, `focus_unknown_is_not_found` in
+/// `proxy/tests.rs`; the render mapping in `telegram::focus::tests`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FocusOutcome {
     /// The session was validated and is now focused for the conversation.
@@ -72,12 +207,27 @@ pub enum FocusOutcome {
     NotFound {
         /// The unresolved target the caller asked to focus.
         target: String,
-        /// The daemon/resolver error explaining why.
+        /// The backend error explaining why.
         error: String,
     },
 }
 
 /// Outcome of a [`SessionProxy::inject`] (free text → session send).
+///
+/// Why: an inject can land in one of four genuinely different states a channel
+/// must handle distinctly — sent, the session having vanished (requiring an
+/// auto-unfocus so the conversation does not fail forever), a transient failure
+/// (which must NOT clear focus, or a network blip would discard the operator's
+/// context), or no focus at all (letting the caller fall back to its own
+/// coordinator instead of receiving an HTTP error). Modelling all four as one
+/// enum keeps that branching explicit and exhaustive at every binding.
+/// What: `Sent` on success; `AutoUnfocused` when the backend's resolve/send
+/// failed with a "not found"-shaped error (see [`is_missing_session`]) — focus
+/// was already cleared by the time this variant is returned; `Failed` on any
+/// other backend error — focus is left untouched; `NoFocus` when the
+/// conversation had nothing focused.
+/// Test: `inject_no_focus`, `inject_auto_unfocuses_dead_session`,
+/// `inject_transient_error_keeps_focus` in `proxy/tests.rs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InjectOutcome {
     /// The text was sent to the focused session.
@@ -106,6 +256,16 @@ pub enum InjectOutcome {
 }
 
 /// Outcome of a [`SessionProxy::summarize`] (session activity → channel).
+///
+/// Why: mirrors [`InjectOutcome`]'s four-way split for exactly the same reason —
+/// a summarize call can succeed, discover the session is gone (auto-unfocus),
+/// hit a transient failure (focus preserved), or have nothing focused to
+/// summarize (letting the caller fall back gracefully).
+/// What: `Summary` carries the [`ActivityDigest`] fields inline; `AutoUnfocused`
+/// and `Failed` mirror [`InjectOutcome`]'s variants of the same name; `NoFocus`
+/// when nothing is focused.
+/// Test: `summarize_no_focus`, `summarize_auto_unfocuses_dead_session` in
+/// `proxy/tests.rs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SummarizeOutcome {
     /// A digest of the focused session's recent activity.
@@ -162,31 +322,55 @@ pub fn route_free_text(text: &str, has_focus: bool) -> FreeTextRoute {
 }
 
 /// Channel-agnostic session-manager proxy: per-conversation focus + inject +
-/// summarize over the shared [`CommandExecutor`].
+/// summarize over a pluggable [`ManagedBackend`].
 ///
-/// Why: one implementation of layer 2 that every channel binds to; the focus
-/// state machine and the two proxy directions live here, not in each adapter.
-/// What: holds an `Arc<CommandExecutor>` (the shared daemon seam) and a
-/// `Mutex`-guarded map of conversation key → [`FocusTarget`]. Construct one per
-/// channel and share it (`Arc`) across that channel's handler tasks.
+/// Why: one implementation of layer 2 that every surface binds to — Telegram,
+/// Slack, and the daemon's own local HTTP proxy routes all construct this SAME
+/// struct, differing only in which [`ManagedBackend`] they pass in. The focus
+/// state machine (validate-then-set, auto-unfocus-on-missing,
+/// preserve-on-transient-error) lives here exactly once.
+/// What: holds an `Arc<dyn ManagedBackend>` (the shared reach-a-session seam) and
+/// a `Mutex`-guarded map of conversation key → [`FocusTarget`]. [`Self::new`]
+/// gives the proxy its own fresh, unshared store (what a long-lived channel
+/// process wants — Telegram/Slack construct exactly one proxy for the process
+/// lifetime); [`Self::with_focus_store`] lets a caller supply an EXTERNAL shared
+/// store instead, which the daemon's local proxy routes use so a fresh
+/// [`SessionProxy`] can be constructed per HTTP request while the focus map
+/// itself persists across requests (owned by `DaemonState`).
 /// Test: `proxy/tests.rs`.
 pub struct SessionProxy {
-    executor: Arc<CommandExecutor>,
-    focus: Mutex<HashMap<String, FocusTarget>>,
+    backend: Arc<dyn ManagedBackend>,
+    focus: Arc<std::sync::Mutex<HashMap<String, FocusTarget>>>,
 }
 
 impl SessionProxy {
-    /// Build a proxy over the shared executor.
+    /// Build a proxy with its OWN fresh, unshared focus store.
     ///
-    /// Why: each channel already holds an `Arc<CommandExecutor>`; the proxy
-    /// borrows the same seam so there is one daemon transport per channel.
-    /// What: wraps the executor and an empty focus map.
-    /// Test: used by every `proxy/tests.rs` test.
-    pub fn new(executor: Arc<CommandExecutor>) -> Self {
+    /// Why: a long-lived channel process (Telegram, Slack) constructs exactly one
+    /// proxy for its whole lifetime, so an internally-owned store is all it needs.
+    /// What: wraps `backend` with a new empty focus map.
+    /// Test: used by every `proxy/tests.rs` test that does not need a shared store.
+    pub fn new(backend: Arc<dyn ManagedBackend>) -> Self {
         Self {
-            executor,
-            focus: Mutex::new(HashMap::new()),
+            backend,
+            focus: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Build a proxy over an EXTERNAL, shared focus store.
+    ///
+    /// Why: the daemon's local HTTP proxy routes construct a fresh
+    /// [`SessionProxy`] per request (see `daemon::managed_routes::proxy`) but the
+    /// focus state must persist ACROSS requests — so the store itself is owned by
+    /// `DaemonState` and shared in here via `Arc::clone`.
+    /// What: wraps `backend` with the caller-supplied shared store.
+    /// Test: `daemon::managed_routes::proxy::tests` (in-crate) and
+    /// `tests/proxy_routes.rs` (HTTP-level) exercise this constructor.
+    pub fn with_focus_store(
+        backend: Arc<dyn ManagedBackend>,
+        focus: Arc<std::sync::Mutex<HashMap<String, FocusTarget>>>,
+    ) -> Self {
+        Self { backend, focus }
     }
 
     /// Read the focused session for `conv`, if any.
@@ -212,13 +396,13 @@ impl SessionProxy {
     /// Focus a session for `conv`, validating it exists first.
     ///
     /// Why: focusing must VALIDATE the target — focusing a typo would silently
-    /// swallow every later inject into a non-existent session. Reusing the shared
-    /// `managed-get` both validates and yields the canonical id + name in one
-    /// call, so no channel re-implements resolution.
+    /// swallow every later inject into a non-existent session. Delegating to the
+    /// backend's `resolve` both validates and yields the canonical id + name in
+    /// one call, so no surface re-implements resolution.
     /// What: with an empty `target`, returns the current focus
-    /// ([`FocusOutcome::Current`]) without touching the daemon. Otherwise runs
-    /// [`TrustyCommand::ManagedGet`]; on success it records the resolved id/name
-    /// and returns [`FocusOutcome::Focused`]; on failure it returns
+    /// ([`FocusOutcome::Current`]) without touching the backend. Otherwise calls
+    /// [`ManagedBackend::resolve`]; on success it records the resolved id/name and
+    /// returns [`FocusOutcome::Focused`]; on failure it returns
     /// [`FocusOutcome::NotFound`] and leaves any existing focus untouched.
     /// Test: `focus_empty_reports_current`, `focus_unknown_is_not_found`.
     pub async fn focus(&self, conv: &str, target: &str) -> FocusOutcome {
@@ -226,28 +410,15 @@ impl SessionProxy {
         if target.is_empty() {
             return FocusOutcome::Current(self.current_focus(conv));
         }
-        match self
-            .executor
-            .execute(TrustyCommand::ManagedGet {
-                target: target.to_string(),
-            })
-            .await
-        {
-            CommandResult::ManagedSession(view) => {
-                let ft = FocusTarget {
-                    id: view.id,
-                    name: view.name,
-                };
+        match self.backend.resolve(target).await {
+            Ok((id, name)) => {
+                let ft = FocusTarget { id, name };
                 self.lock().insert(conv.to_string(), ft.clone());
                 FocusOutcome::Focused(ft)
             }
-            CommandResult::Error(error) => FocusOutcome::NotFound {
+            Err(error) => FocusOutcome::NotFound {
                 target: target.to_string(),
                 error,
-            },
-            _ => FocusOutcome::NotFound {
-                target: target.to_string(),
-                error: "unexpected daemon response".to_string(),
             },
         }
     }
@@ -256,44 +427,33 @@ impl SessionProxy {
     ///
     /// Why: the payoff of focus mode — a plain message becomes a `send` at the
     /// focused session with no per-turn id ceremony. A vanished session (the
-    /// resolver reports "not found") auto-unfocuses so the conversation drops back
-    /// to fleet chat instead of failing forever; a transient error keeps the focus
-    /// so a blip loses no context.
-    /// What: with no focus returns [`InjectOutcome::NoFocus`]; otherwise runs
-    /// [`TrustyCommand::ManagedSend`] at the focused id and maps the result to
-    /// `Sent` / `AutoUnfocused` (missing session, focus cleared) / `Failed`.
+    /// backend reports a "not found"-shaped error) auto-unfocuses so the
+    /// conversation drops back to fleet chat instead of failing forever; a
+    /// transient error keeps the focus so a blip loses no context.
+    /// What: with no focus returns [`InjectOutcome::NoFocus`]; otherwise calls
+    /// [`ManagedBackend::send`] at the focused id and maps the result to `Sent` /
+    /// `AutoUnfocused` (missing session, focus cleared) / `Failed`.
     /// Test: `inject_no_focus`, `inject_auto_unfocuses_dead_session`,
     /// `inject_transient_error_keeps_focus`.
     pub async fn inject(&self, conv: &str, text: &str) -> InjectOutcome {
         let Some(focus) = self.current_focus(conv) else {
             return InjectOutcome::NoFocus;
         };
-        let result = self
-            .executor
-            .execute(TrustyCommand::ManagedSend {
-                target: focus.id.clone(),
-                text: text.to_string(),
-            })
-            .await;
-        match result {
-            CommandResult::ManagedSent { .. } => InjectOutcome::Sent {
+        match self.backend.send(&focus.id, text).await {
+            Ok(()) => InjectOutcome::Sent {
                 target: focus,
                 text: text.to_string(),
             },
-            CommandResult::Error(error) if is_missing_session(&error) => {
+            Err(error) if is_missing_session(&error) => {
                 self.unfocus(conv);
                 InjectOutcome::AutoUnfocused {
                     target: focus,
                     error,
                 }
             }
-            CommandResult::Error(error) => InjectOutcome::Failed {
+            Err(error) => InjectOutcome::Failed {
                 target: focus,
                 error,
-            },
-            _ => InjectOutcome::Failed {
-                target: focus,
-                error: "unexpected daemon response".to_string(),
             },
         }
     }
@@ -301,49 +461,32 @@ impl SessionProxy {
     /// SUMMARIZE: digest the focused session's recent activity back to the channel.
     ///
     /// Why: the second proxy direction — the operator asks "what is my session
-    /// doing?" and the proxy relays a digest without them attaching to tmux. This
-    /// is the minimal digest built on the existing activity surface; a richer
-    /// LLM-summarized digest is follow-up (see the PR "Layering" notes).
-    /// What: with no focus returns [`SummarizeOutcome::NoFocus`]; otherwise runs
-    /// [`TrustyCommand::ManagedActivity`] and maps the result to `Summary` /
+    /// doing?" and the proxy relays a digest without them attaching to tmux.
+    /// What: with no focus returns [`SummarizeOutcome::NoFocus`]; otherwise calls
+    /// [`ManagedBackend::activity`] and maps the result to `Summary` /
     /// `AutoUnfocused` (missing session, focus cleared) / `Failed`.
     /// Test: `summarize_no_focus`, `summarize_auto_unfocuses_dead_session`.
     pub async fn summarize(&self, conv: &str) -> SummarizeOutcome {
         let Some(focus) = self.current_focus(conv) else {
             return SummarizeOutcome::NoFocus;
         };
-        let result = self
-            .executor
-            .execute(TrustyCommand::ManagedActivity {
-                target: focus.id.clone(),
-            })
-            .await;
-        match result {
-            CommandResult::ManagedActivity {
-                state,
-                summary,
-                pending_decision,
-                ..
-            } => SummarizeOutcome::Summary {
+        match self.backend.activity(&focus.id).await {
+            Ok(digest) => SummarizeOutcome::Summary {
                 target: focus,
-                state,
-                summary,
-                pending_decision,
+                state: digest.state,
+                summary: digest.summary,
+                pending_decision: digest.pending_decision,
             },
-            CommandResult::Error(error) if is_missing_session(&error) => {
+            Err(error) if is_missing_session(&error) => {
                 self.unfocus(conv);
                 SummarizeOutcome::AutoUnfocused {
                     target: focus,
                     error,
                 }
             }
-            CommandResult::Error(error) => SummarizeOutcome::Failed {
+            Err(error) => SummarizeOutcome::Failed {
                 target: focus,
                 error,
-            },
-            _ => SummarizeOutcome::Failed {
-                target: focus,
-                error: "unexpected daemon response".to_string(),
             },
         }
     }
@@ -359,10 +502,19 @@ impl SessionProxy {
 ///
 /// Why: the auto-unfocus path must fire ONLY when the session is genuinely gone,
 /// not on a transient transport error — unfocusing on a network blip would throw
-/// away the operator's context. The resolver reports a missing target as
-/// "managed session <target> not found", so that substring is the signal.
+/// away the operator's context. Every [`ManagedBackend`] impl is contractually
+/// required to phrase a resolution failure with the substring `"not found"` (the
+/// [`CommandExecutor`] impl inherits this wording verbatim from the executor's
+/// managed-session resolver's `"managed session {target} not found"`; the
+/// daemon's direct backend mirrors it exactly). This is admittedly substring
+/// matching rather than a typed signal —
+/// `is_missing_session_matches_live_resolver_not_found_format` (in
+/// `proxy/tests.rs`) pins the coupling to the ACTUAL resolver wording so a
+/// message-text drift fails a test instead of silently disabling the
+/// auto-unfocus safety net.
 /// What: returns true when `msg` contains "not found".
-/// Test: `is_missing_session_detects_not_found`.
+/// Test: `is_missing_session_detects_not_found`,
+/// `is_missing_session_matches_live_resolver_not_found_format`.
 fn is_missing_session(msg: &str) -> bool {
     msg.contains("not found")
 }

--- a/crates/trusty-mpm/src/client/proxy.rs
+++ b/crates/trusty-mpm/src/client/proxy.rs
@@ -1,0 +1,371 @@
+//! Channel-agnostic session-manager PROXY layer (TELUI-6, #1440).
+//!
+//! Why: this is layer 2 of the three-layer control model — the session-manager
+//! acting as a PROXY between an external channel (Telegram, Slack, MCP) and ONE
+//! managed session. Layer 1 is direct tmux attach; layer 3 (the cross-scope
+//! project manager, #2109) is out of scope here. The proxy is deliberately
+//! SINGLE-SESSION-focused: a conversation "focuses" one session and then talks
+//! to it, in two directions — INJECT (free text routed to the session's
+//! `managed-send`) and SUMMARIZE (the session's recent activity digested back to
+//! the channel). Putting the focus state machine and both directions HERE, in the
+//! shared chat-core over the one [`CommandExecutor`], means Slack and an MCP
+//! surface bind to the same API instead of re-implementing the state machine —
+//! each channel only supplies its conversation key and renders the structured
+//! outcomes in its own markup.
+//! What: [`SessionProxy`] owns the per-conversation focus map (keyed by an opaque
+//! channel-supplied conversation string — Telegram passes its `chat_id`, Slack a
+//! channel id, MCP a client/session id) and exposes [`SessionProxy::focus`],
+//! [`SessionProxy::unfocus`], [`SessionProxy::current_focus`],
+//! [`SessionProxy::inject`], and [`SessionProxy::summarize`], each returning a
+//! structured, channel-agnostic outcome the binding renders. [`route_free_text`]
+//! is the pure inject-vs-coordinator routing decision. Focus state is in-memory
+//! and VOLATILE across a daemon restart (the channels persist no per-conversation
+//! state); a restart simply drops every conversation back to fleet-wide chat.
+//! Test: `proxy/tests.rs` covers the pure routing, the store round-trip, and the
+//! inject/summarize/dead-session paths against an in-process test daemon.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use super::executor::CommandExecutor;
+use super::{CommandResult, TrustyCommand};
+
+/// A resolved focused session: its canonical id plus a display name.
+///
+/// Why: the proxy keeps the resolved id (so later inject/summarize skip
+/// re-resolution and are unambiguous) AND the friendly name (so a channel can
+/// name the session in replies without another daemon round-trip).
+/// What: the canonical managed-session `id` and its human-readable `name`, both
+/// captured at focus time from the authoritative `managed-get` record.
+/// Test: `set_get_clear_round_trip` in `proxy/tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FocusTarget {
+    /// Canonical managed-session id (a UUID).
+    pub id: String,
+    /// Friendly session name shown in replies.
+    pub name: String,
+}
+
+/// The routing decision for one free-text (non-command) message.
+///
+/// Why: modelling the two outcomes keeps each channel's handler branch trivial
+/// and the decision itself pure and unit-testable, shared across channels.
+/// What: `Inject` routes the text to the focused session's `managed-send`;
+/// `Coordinator` routes it to the action-capable coordinator (the default).
+/// Test: the `route_free_text_*` tests in `proxy/tests.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FreeTextRoute {
+    /// Route the message to the focused session (proxy INJECT direction).
+    Inject,
+    /// Route the message to the action-capable coordinator.
+    Coordinator,
+}
+
+/// Outcome of a [`SessionProxy::focus`] request, for the channel to render.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FocusOutcome {
+    /// The session was validated and is now focused for the conversation.
+    Focused(FocusTarget),
+    /// No target was supplied — reports the current focus (or `None`).
+    Current(Option<FocusTarget>),
+    /// The target could not be resolved; focus is unchanged.
+    NotFound {
+        /// The unresolved target the caller asked to focus.
+        target: String,
+        /// The daemon/resolver error explaining why.
+        error: String,
+    },
+}
+
+/// Outcome of a [`SessionProxy::inject`] (free text → session send).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InjectOutcome {
+    /// The text was sent to the focused session.
+    Sent {
+        /// The focused session it was sent to.
+        target: FocusTarget,
+        /// The text that was injected.
+        text: String,
+    },
+    /// The focused session no longer exists — focus was auto-cleared.
+    AutoUnfocused {
+        /// The session that was focused (now cleared).
+        target: FocusTarget,
+        /// The "not found" error that triggered the auto-unfocus.
+        error: String,
+    },
+    /// A transient failure — focus is preserved so a blip loses no context.
+    Failed {
+        /// The still-focused session.
+        target: FocusTarget,
+        /// The transport/daemon error.
+        error: String,
+    },
+    /// No session was focused for the conversation.
+    NoFocus,
+}
+
+/// Outcome of a [`SessionProxy::summarize`] (session activity → channel).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SummarizeOutcome {
+    /// A digest of the focused session's recent activity.
+    Summary {
+        /// The focused session summarized.
+        target: FocusTarget,
+        /// The session's current lifecycle state.
+        state: String,
+        /// The activity summary text.
+        summary: String,
+        /// Any decision the session is blocked on.
+        pending_decision: Option<String>,
+    },
+    /// The focused session no longer exists — focus was auto-cleared.
+    AutoUnfocused {
+        /// The session that was focused (now cleared).
+        target: FocusTarget,
+        /// The "not found" error that triggered the auto-unfocus.
+        error: String,
+    },
+    /// A transient failure — focus is preserved.
+    Failed {
+        /// The still-focused session.
+        target: FocusTarget,
+        /// The transport/daemon error.
+        error: String,
+    },
+    /// No session was focused for the conversation.
+    NoFocus,
+}
+
+/// Decide where a free-text message routes, given whether a session is focused.
+///
+/// Why: the single seam between "channel received a non-command message" and
+/// "which subsystem handles it"; pure (no store, no daemon) so every branch is
+/// testable and identical across channels. It runs only after a channel has
+/// already failed to parse the text as a known command, so a leading `/` here is
+/// an UNKNOWN command — never hijacked into the focused session (that would send
+/// a mistyped command as a prompt); such lines fall through to the coordinator.
+/// What: a `/`-prefixed line always routes to [`FreeTextRoute::Coordinator`];
+/// otherwise a focused conversation routes to [`FreeTextRoute::Inject`] and an
+/// unfocused one to [`FreeTextRoute::Coordinator`].
+/// Test: `route_free_text_focused_injects`, `route_free_text_unfocused_coordinates`,
+/// `route_free_text_slash_never_injects`.
+pub fn route_free_text(text: &str, has_focus: bool) -> FreeTextRoute {
+    if text.trim_start().starts_with('/') {
+        return FreeTextRoute::Coordinator;
+    }
+    if has_focus {
+        FreeTextRoute::Inject
+    } else {
+        FreeTextRoute::Coordinator
+    }
+}
+
+/// Channel-agnostic session-manager proxy: per-conversation focus + inject +
+/// summarize over the shared [`CommandExecutor`].
+///
+/// Why: one implementation of layer 2 that every channel binds to; the focus
+/// state machine and the two proxy directions live here, not in each adapter.
+/// What: holds an `Arc<CommandExecutor>` (the shared daemon seam) and a
+/// `Mutex`-guarded map of conversation key → [`FocusTarget`]. Construct one per
+/// channel and share it (`Arc`) across that channel's handler tasks.
+/// Test: `proxy/tests.rs`.
+pub struct SessionProxy {
+    executor: Arc<CommandExecutor>,
+    focus: Mutex<HashMap<String, FocusTarget>>,
+}
+
+impl SessionProxy {
+    /// Build a proxy over the shared executor.
+    ///
+    /// Why: each channel already holds an `Arc<CommandExecutor>`; the proxy
+    /// borrows the same seam so there is one daemon transport per channel.
+    /// What: wraps the executor and an empty focus map.
+    /// Test: used by every `proxy/tests.rs` test.
+    pub fn new(executor: Arc<CommandExecutor>) -> Self {
+        Self {
+            executor,
+            focus: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Read the focused session for `conv`, if any.
+    ///
+    /// Why: a channel needs to know whether a conversation is focused (to route
+    /// free text) and to name the focused session in replies.
+    /// What: returns a clone of the [`FocusTarget`] under `conv`, or `None`.
+    /// Test: `set_get_clear_round_trip`.
+    pub fn current_focus(&self, conv: &str) -> Option<FocusTarget> {
+        self.lock().get(conv).cloned()
+    }
+
+    /// Clear the focus for `conv`, returning the session that was focused.
+    ///
+    /// Why: the "back to fleet chat" action (`/unfocus`) and the dead-session
+    /// auto-unfocus both remove the entry and report which session was cleared.
+    /// What: removes and returns the [`FocusTarget`] under `conv`, or `None`.
+    /// Test: `set_get_clear_round_trip`, `inject_auto_unfocuses_dead_session`.
+    pub fn unfocus(&self, conv: &str) -> Option<FocusTarget> {
+        self.lock().remove(conv)
+    }
+
+    /// Focus a session for `conv`, validating it exists first.
+    ///
+    /// Why: focusing must VALIDATE the target — focusing a typo would silently
+    /// swallow every later inject into a non-existent session. Reusing the shared
+    /// `managed-get` both validates and yields the canonical id + name in one
+    /// call, so no channel re-implements resolution.
+    /// What: with an empty `target`, returns the current focus
+    /// ([`FocusOutcome::Current`]) without touching the daemon. Otherwise runs
+    /// [`TrustyCommand::ManagedGet`]; on success it records the resolved id/name
+    /// and returns [`FocusOutcome::Focused`]; on failure it returns
+    /// [`FocusOutcome::NotFound`] and leaves any existing focus untouched.
+    /// Test: `focus_empty_reports_current`, `focus_unknown_is_not_found`.
+    pub async fn focus(&self, conv: &str, target: &str) -> FocusOutcome {
+        let target = target.trim();
+        if target.is_empty() {
+            return FocusOutcome::Current(self.current_focus(conv));
+        }
+        match self
+            .executor
+            .execute(TrustyCommand::ManagedGet {
+                target: target.to_string(),
+            })
+            .await
+        {
+            CommandResult::ManagedSession(view) => {
+                let ft = FocusTarget {
+                    id: view.id,
+                    name: view.name,
+                };
+                self.lock().insert(conv.to_string(), ft.clone());
+                FocusOutcome::Focused(ft)
+            }
+            CommandResult::Error(error) => FocusOutcome::NotFound {
+                target: target.to_string(),
+                error,
+            },
+            _ => FocusOutcome::NotFound {
+                target: target.to_string(),
+                error: "unexpected daemon response".to_string(),
+            },
+        }
+    }
+
+    /// INJECT: route free text to the focused session's `managed-send`.
+    ///
+    /// Why: the payoff of focus mode — a plain message becomes a `send` at the
+    /// focused session with no per-turn id ceremony. A vanished session (the
+    /// resolver reports "not found") auto-unfocuses so the conversation drops back
+    /// to fleet chat instead of failing forever; a transient error keeps the focus
+    /// so a blip loses no context.
+    /// What: with no focus returns [`InjectOutcome::NoFocus`]; otherwise runs
+    /// [`TrustyCommand::ManagedSend`] at the focused id and maps the result to
+    /// `Sent` / `AutoUnfocused` (missing session, focus cleared) / `Failed`.
+    /// Test: `inject_no_focus`, `inject_auto_unfocuses_dead_session`,
+    /// `inject_transient_error_keeps_focus`.
+    pub async fn inject(&self, conv: &str, text: &str) -> InjectOutcome {
+        let Some(focus) = self.current_focus(conv) else {
+            return InjectOutcome::NoFocus;
+        };
+        let result = self
+            .executor
+            .execute(TrustyCommand::ManagedSend {
+                target: focus.id.clone(),
+                text: text.to_string(),
+            })
+            .await;
+        match result {
+            CommandResult::ManagedSent { .. } => InjectOutcome::Sent {
+                target: focus,
+                text: text.to_string(),
+            },
+            CommandResult::Error(error) if is_missing_session(&error) => {
+                self.unfocus(conv);
+                InjectOutcome::AutoUnfocused {
+                    target: focus,
+                    error,
+                }
+            }
+            CommandResult::Error(error) => InjectOutcome::Failed {
+                target: focus,
+                error,
+            },
+            _ => InjectOutcome::Failed {
+                target: focus,
+                error: "unexpected daemon response".to_string(),
+            },
+        }
+    }
+
+    /// SUMMARIZE: digest the focused session's recent activity back to the channel.
+    ///
+    /// Why: the second proxy direction — the operator asks "what is my session
+    /// doing?" and the proxy relays a digest without them attaching to tmux. This
+    /// is the minimal digest built on the existing activity surface; a richer
+    /// LLM-summarized digest is follow-up (see the PR "Layering" notes).
+    /// What: with no focus returns [`SummarizeOutcome::NoFocus`]; otherwise runs
+    /// [`TrustyCommand::ManagedActivity`] and maps the result to `Summary` /
+    /// `AutoUnfocused` (missing session, focus cleared) / `Failed`.
+    /// Test: `summarize_no_focus`, `summarize_auto_unfocuses_dead_session`.
+    pub async fn summarize(&self, conv: &str) -> SummarizeOutcome {
+        let Some(focus) = self.current_focus(conv) else {
+            return SummarizeOutcome::NoFocus;
+        };
+        let result = self
+            .executor
+            .execute(TrustyCommand::ManagedActivity {
+                target: focus.id.clone(),
+            })
+            .await;
+        match result {
+            CommandResult::ManagedActivity {
+                state,
+                summary,
+                pending_decision,
+                ..
+            } => SummarizeOutcome::Summary {
+                target: focus,
+                state,
+                summary,
+                pending_decision,
+            },
+            CommandResult::Error(error) if is_missing_session(&error) => {
+                self.unfocus(conv);
+                SummarizeOutcome::AutoUnfocused {
+                    target: focus,
+                    error,
+                }
+            }
+            CommandResult::Error(error) => SummarizeOutcome::Failed {
+                target: focus,
+                error,
+            },
+            _ => SummarizeOutcome::Failed {
+                target: focus,
+                error: "unexpected daemon response".to_string(),
+            },
+        }
+    }
+
+    /// Lock the focus map, panicking only on a poisoned mutex (a programmer error
+    /// — another thread panicked holding the lock).
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, FocusTarget>> {
+        self.focus.lock().expect("focus map mutex poisoned")
+    }
+}
+
+/// Whether a `managed-*` error means the focused session no longer exists.
+///
+/// Why: the auto-unfocus path must fire ONLY when the session is genuinely gone,
+/// not on a transient transport error — unfocusing on a network blip would throw
+/// away the operator's context. The resolver reports a missing target as
+/// "managed session <target> not found", so that substring is the signal.
+/// What: returns true when `msg` contains "not found".
+/// Test: `is_missing_session_detects_not_found`.
+fn is_missing_session(msg: &str) -> bool {
+    msg.contains("not found")
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/client/proxy/tests.rs
+++ b/crates/trusty-mpm/src/client/proxy/tests.rs
@@ -64,6 +64,28 @@ fn is_missing_session_detects_not_found() {
     assert!(!is_missing_session("send failed: connection refused"));
 }
 
+#[tokio::test]
+async fn is_missing_session_matches_live_resolver_not_found_format() {
+    // Regression pin (adversarial-review finding, PR #2372): `is_missing_session`
+    // is substring matching, not a typed signal, so it is only as reliable as its
+    // coupling to the ACTUAL wording the resolver produces. This drives the REAL
+    // `CommandExecutor::resolve` (the `ManagedBackend` impl every external channel
+    // uses) against a live, empty-fleet test daemon and asserts the resulting
+    // error satisfies the predicate — if the resolver's message ever drifts
+    // (e.g. `executor::managed::resolve_managed`'s wording changes), this test
+    // fails loudly instead of silently disabling the auto-unfocus safety net.
+    let url = spawn_test_daemon().await;
+    let backend = CommandExecutor::new(url);
+    let err = backend
+        .resolve("no-such-session")
+        .await
+        .expect_err("an empty fleet must fail to resolve");
+    assert!(
+        is_missing_session(&err),
+        "resolver's not-found message no longer matches is_missing_session: {err:?}"
+    );
+}
+
 #[test]
 fn set_get_clear_round_trip() {
     let proxy = offline_proxy();

--- a/crates/trusty-mpm/src/client/proxy/tests.rs
+++ b/crates/trusty-mpm/src/client/proxy/tests.rs
@@ -1,0 +1,174 @@
+//! Unit tests for the channel-agnostic session-manager proxy (TELUI-6, #1440).
+//!
+//! Why: this lives in a `proxy/tests.rs` (a recognized test-file path) so the
+//! production `client/proxy.rs` stays under the 500-SLOC production cap while the
+//! suite shares its private items via `use super::*`.
+//! What: covers the pure inject-vs-coordinator routing, the focus store
+//! round-trip, the missing-session predicate, and the focus/inject/summarize
+//! paths (incl. dead-session auto-unfocus) against an in-process test daemon.
+//! Test: this *is* the test module.
+
+use super::*;
+use std::future::IntoFuture;
+
+use crate::client::CommandExecutor;
+
+/// Spawn the daemon's real HTTP API on a random loopback port (empty fleet).
+///
+/// Why: lets the proxy be tested against genuine daemon routes with no live
+/// daemon, tmux, or network. With no managed sessions, every resolve yields the
+/// "not found" error the auto-unfocus path keys on.
+/// What: mirrors the isolated-managed helper in `executor/tests.rs`.
+async fn spawn_test_daemon() -> String {
+    use crate::daemon::{api, state::DaemonState};
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = std::sync::Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let router = api::router(std::sync::Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    format!("http://{addr}")
+}
+
+/// A proxy over an unreachable daemon (for the pure / transient-error tests).
+fn offline_proxy() -> SessionProxy {
+    SessionProxy::new(Arc::new(CommandExecutor::new("http://127.0.0.1:0")))
+}
+
+#[test]
+fn route_free_text_focused_injects() {
+    assert_eq!(route_free_text("build it now", true), FreeTextRoute::Inject);
+}
+
+#[test]
+fn route_free_text_unfocused_coordinates() {
+    assert_eq!(
+        route_free_text("spin up a session", false),
+        FreeTextRoute::Coordinator
+    );
+}
+
+#[test]
+fn route_free_text_slash_never_injects() {
+    // A `/`-prefixed line reaching the router is an UNKNOWN command; never inject.
+    assert_eq!(
+        route_free_text("/typo arg", true),
+        FreeTextRoute::Coordinator
+    );
+    assert_eq!(route_free_text("  /typo", true), FreeTextRoute::Coordinator);
+}
+
+#[test]
+fn is_missing_session_detects_not_found() {
+    assert!(is_missing_session("managed session foo not found"));
+    assert!(!is_missing_session("send failed: connection refused"));
+}
+
+#[test]
+fn set_get_clear_round_trip() {
+    let proxy = offline_proxy();
+    assert!(proxy.current_focus("c1").is_none());
+    proxy.lock().insert(
+        "c1".to_string(),
+        FocusTarget {
+            id: "id-1".into(),
+            name: "api".into(),
+        },
+    );
+    assert_eq!(proxy.current_focus("c1").map(|f| f.id), Some("id-1".into()));
+    // unfocus returns and removes the entry.
+    let removed = proxy.unfocus("c1");
+    assert_eq!(removed.map(|f| f.name), Some("api".to_string()));
+    assert!(proxy.current_focus("c1").is_none());
+    // Unfocusing an empty conversation is a no-op returning None.
+    assert!(proxy.unfocus("c1").is_none());
+}
+
+#[tokio::test]
+async fn focus_empty_reports_current() {
+    // An empty target never touches the daemon; it reports the current focus.
+    let proxy = offline_proxy();
+    assert_eq!(proxy.focus("c1", "   ").await, FocusOutcome::Current(None));
+}
+
+#[tokio::test]
+async fn focus_unknown_is_not_found() {
+    // Focusing a session that does not exist reports NotFound and sets no focus.
+    let url = spawn_test_daemon().await;
+    let proxy = SessionProxy::new(Arc::new(CommandExecutor::new(url)));
+    match proxy.focus("c1", "no-such-session").await {
+        FocusOutcome::NotFound { target, .. } => assert_eq!(target, "no-such-session"),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+    assert!(proxy.current_focus("c1").is_none());
+}
+
+#[tokio::test]
+async fn inject_no_focus() {
+    let proxy = offline_proxy();
+    assert_eq!(proxy.inject("c1", "hi").await, InjectOutcome::NoFocus);
+}
+
+#[tokio::test]
+async fn inject_auto_unfocuses_dead_session() {
+    // A focused session that no longer exists: the send resolves to "not found",
+    // so focus is auto-cleared and the outcome names the vanished session.
+    let url = spawn_test_daemon().await;
+    let proxy = SessionProxy::new(Arc::new(CommandExecutor::new(url)));
+    proxy.lock().insert(
+        "c1".to_string(),
+        FocusTarget {
+            id: "dead-id".into(),
+            name: "ghost".into(),
+        },
+    );
+    match proxy.inject("c1", "are you there?").await {
+        InjectOutcome::AutoUnfocused { target, .. } => assert_eq!(target.name, "ghost"),
+        other => panic!("expected AutoUnfocused, got {other:?}"),
+    }
+    assert!(proxy.current_focus("c1").is_none(), "focus auto-cleared");
+}
+
+#[tokio::test]
+async fn inject_transient_error_keeps_focus() {
+    // An unreachable daemon is a transient failure, not a missing session: focus
+    // must be preserved so a blip does not discard the operator's context.
+    let proxy = offline_proxy();
+    proxy.lock().insert(
+        "c1".to_string(),
+        FocusTarget {
+            id: "id-1".into(),
+            name: "api".into(),
+        },
+    );
+    match proxy.inject("c1", "hello").await {
+        InjectOutcome::Failed { target, .. } => assert_eq!(target.name, "api"),
+        other => panic!("expected Failed, got {other:?}"),
+    }
+    assert!(proxy.current_focus("c1").is_some(), "focus preserved");
+}
+
+#[tokio::test]
+async fn summarize_no_focus() {
+    let proxy = offline_proxy();
+    assert_eq!(proxy.summarize("c1").await, SummarizeOutcome::NoFocus);
+}
+
+#[tokio::test]
+async fn summarize_auto_unfocuses_dead_session() {
+    // Summarizing a vanished focused session auto-clears the focus.
+    let url = spawn_test_daemon().await;
+    let proxy = SessionProxy::new(Arc::new(CommandExecutor::new(url)));
+    proxy.lock().insert(
+        "c1".to_string(),
+        FocusTarget {
+            id: "dead-id".into(),
+            name: "ghost".into(),
+        },
+    );
+    match proxy.summarize("c1").await {
+        SummarizeOutcome::AutoUnfocused { target, .. } => assert_eq!(target.name, "ghost"),
+        other => panic!("expected AutoUnfocused, got {other:?}"),
+    }
+    assert!(proxy.current_focus("c1").is_none(), "focus auto-cleared");
+}

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -119,10 +119,10 @@ pub use rpc::rpc_handler;
 use super::managed_routes::{
     adopt_existing_session, answer_session_decision, decommission_ephemeral_route,
     decommission_managed_session, delete_managed_session, fleet_by_project_route, get_attach_cmd,
-    get_managed_session, get_session_activity, list_managed_sessions, prune_managed_route,
-    prune_worktrees_route, proxy_focus, proxy_get_focus, proxy_message, proxy_summary,
-    proxy_unfocus, reactivate_managed_session, resume_managed_session, send_to_session,
-    spawn_session, stop_managed_session, stop_managed_session_runtime,
+    get_managed_session, get_session_activity, list_managed_sessions, proxy_focus, proxy_get_focus,
+    proxy_message, proxy_summary, proxy_unfocus, prune_managed_route, prune_worktrees_route,
+    reactivate_managed_session, resume_managed_session, send_to_session, spawn_session,
+    stop_managed_session, stop_managed_session_runtime,
 };
 
 /// Typed HTTP response bodies for every endpoint.

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -120,7 +120,8 @@ use super::managed_routes::{
     adopt_existing_session, answer_session_decision, decommission_ephemeral_route,
     decommission_managed_session, delete_managed_session, fleet_by_project_route, get_attach_cmd,
     get_managed_session, get_session_activity, list_managed_sessions, prune_managed_route,
-    prune_worktrees_route, reactivate_managed_session, resume_managed_session, send_to_session,
+    prune_worktrees_route, proxy_focus, proxy_get_focus, proxy_message, proxy_summary,
+    proxy_unfocus, reactivate_managed_session, resume_managed_session, send_to_session,
     spawn_session, stop_managed_session, stop_managed_session_runtime,
 };
 
@@ -290,6 +291,24 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .route(
             "/api/v1/sessions/managed/{id}/delete",
             post(delete_managed_session),
+        )
+        // TELUI-6 (#1440): the local session-manager PROXY surface — the SAME
+        // focus/inject/summarize state machine every channel (Telegram, Slack)
+        // binds to, exposed here as plain HTTP so it is `curl`-testable before
+        // any channel connects. Literal segments (`/focus`, `/unfocus`,
+        // `/message`) are registered as their own routes; the two GET routes
+        // take `conversation_key` as a path param, mirroring the `/{id}`
+        // convention used throughout this managed-session block.
+        .route("/api/v1/sessions/proxy/focus", post(proxy_focus))
+        .route(
+            "/api/v1/sessions/proxy/focus/{conversation_key}",
+            get(proxy_get_focus),
+        )
+        .route("/api/v1/sessions/proxy/unfocus", post(proxy_unfocus))
+        .route("/api/v1/sessions/proxy/message", post(proxy_message))
+        .route(
+            "/api/v1/sessions/proxy/summary/{conversation_key}",
+            get(proxy_summary),
         )
         // #1221: loopback-only JSON-RPC dispatch for the `serve --stdio` bridge.
         // The handler independently enforces the loopback gate via ConnectInfo.

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -33,6 +33,7 @@ pub mod inproject_hygiene;
 mod lifecycle;
 mod mcp_spawn_gate;
 pub mod prune;
+pub mod proxy;
 mod reactivate;
 mod summary;
 pub use activity::{ActivityResponse, get_session_activity};
@@ -46,6 +47,12 @@ pub use lifecycle::{
 };
 pub use prune::{
     PruneRequest, decommission_ephemeral_route, prune_managed_route, prune_worktrees_route,
+};
+pub use proxy::{
+    DirectManagedBackend, ProxyFocusRequest, ProxyFocusResponse, ProxyMessageRequest,
+    ProxyMessageResponse, ProxySummaryResponse, ProxyTargetWire, ProxyUnfocusRequest,
+    ProxyUnfocusResponse, proxy_focus, proxy_get_focus, proxy_message, proxy_summary,
+    proxy_unfocus,
 };
 pub use reactivate::reactivate_managed_session;
 pub use summary::record_to_json;

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -32,8 +32,8 @@ pub mod inproject;
 pub mod inproject_hygiene;
 mod lifecycle;
 mod mcp_spawn_gate;
-pub mod prune;
 pub mod proxy;
+pub mod prune;
 mod reactivate;
 mod summary;
 pub use activity::{ActivityResponse, get_session_activity};
@@ -45,14 +45,14 @@ pub use lifecycle::{
     ResumeManagedError, SpawnParams, is_local_workdir, resume_managed, spawn_managed,
     spawn_runtime_for, write_task_md,
 };
-pub use prune::{
-    PruneRequest, decommission_ephemeral_route, prune_managed_route, prune_worktrees_route,
-};
 pub use proxy::{
     DirectManagedBackend, ProxyFocusRequest, ProxyFocusResponse, ProxyMessageRequest,
     ProxyMessageResponse, ProxySummaryResponse, ProxyTargetWire, ProxyUnfocusRequest,
     ProxyUnfocusResponse, proxy_focus, proxy_get_focus, proxy_message, proxy_summary,
     proxy_unfocus,
+};
+pub use prune::{
+    PruneRequest, decommission_ephemeral_route, prune_managed_route, prune_worktrees_route,
 };
 pub use reactivate::reactivate_managed_session;
 pub use summary::record_to_json;

--- a/crates/trusty-mpm/src/daemon/managed_routes/proxy/backend.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/proxy/backend.rs
@@ -83,7 +83,9 @@ impl ManagedBackend for DirectManagedBackend {
     async fn send(&self, id: &str, text: &str) -> Result<(), String> {
         let parsed = parse_managed_id(id)?;
         let mgr = self.state.session_manager().await;
-        mgr.send_input(&parsed, text).await.map_err(|e| e.to_string())
+        mgr.send_input(&parsed, text)
+            .await
+            .map_err(|e| e.to_string())
     }
 
     /// Build a lightweight digest straight from the session record.

--- a/crates/trusty-mpm/src/daemon/managed_routes/proxy/backend.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/proxy/backend.rs
@@ -1,0 +1,135 @@
+//! In-process [`ManagedBackend`] over this daemon's own `SessionManager`.
+//!
+//! Why: the daemon's local proxy routes must reach a managed session WITHOUT a
+//! network hop back into its own HTTP surface (a self-referential loopback call
+//! would be fragile — an extra failure mode, a needless round trip, and a
+//! bootstrap hazard before the listener is bound). [`DirectManagedBackend`]
+//! reaches the session the same way every OTHER `managed_routes` handler does:
+//! through `state.session_manager()` directly.
+//! What: implements the three [`ManagedBackend`] primitives — `resolve` via the
+//! shared [`resolve_target`] resolver over `SessionManager::list`, `send` via
+//! `SessionManager::send_input`, and `activity` as a lightweight digest built
+//! straight from the [`SessionRecord`] (no tmux capture, no LLM classifier — see
+//! the module doc on `proxy::mod` for why that is a deliberate, documented
+//! divergence from the richer `GET .../activity` endpoint).
+//! Test: `tests.rs` (in-crate) and `tests/proxy_routes.rs` (HTTP-level) exercise
+//! this backend end-to-end through the proxy routes.
+
+use async_trait::async_trait;
+
+use crate::client::proxy::{ActivityDigest, ManagedBackend};
+use crate::client::resolve_target;
+use crate::client::resolver::Resolvable;
+use crate::daemon::state::DaemonState;
+use crate::session_manager::record::{ManagedSessionId, SessionRecord};
+
+impl Resolvable for SessionRecord {
+    /// Why: [`resolve_target`] is the one canonical id/name/prefix resolver every
+    /// surface uses; a managed session's daemon-internal [`SessionRecord`] must
+    /// participate in it exactly like the wire-facing
+    /// [`crate::client::http_client::ManagedSessionSummary`] does, so the local
+    /// proxy backend resolves a fuzzy target with the SAME precedence rules as
+    /// every other surface.
+    /// What: `id_matches` compares the record's UUID (via `Display`) to the
+    /// query; `resolve_name` returns the tmux name.
+    /// Test: `resolve_direct_backend_matches_id_name_prefix` in `tests.rs`.
+    fn id_matches(&self, query: &str) -> bool {
+        self.id.to_string() == query
+    }
+    fn resolve_name(&self) -> &str {
+        &self.tmux_name
+    }
+}
+
+/// [`ManagedBackend`] reaching this daemon's OWN `SessionManager` in-process.
+///
+/// Why: this is the backend the local proxy routes (`daemon::managed_routes::proxy`)
+/// bind [`crate::client::proxy::SessionProxy`] to — see that module's doc for why
+/// this lets the state machine be `curl`-tested before a channel connects.
+/// What: wraps `Arc<DaemonState>` so each method can call
+/// `state.session_manager().await` fresh (matching every other `managed_routes`
+/// handler's pattern; the manager itself is cached behind a `OnceCell`, so this
+/// costs nothing beyond the async yield).
+/// Test: `tests.rs`.
+pub struct DirectManagedBackend {
+    state: std::sync::Arc<DaemonState>,
+}
+
+impl DirectManagedBackend {
+    /// Wrap `state` for in-process managed-session access.
+    pub fn new(state: std::sync::Arc<DaemonState>) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ManagedBackend for DirectManagedBackend {
+    /// Resolve `target` against the live managed-session list.
+    ///
+    /// Why: mirrors [`crate::client::executor::managed`]'s `resolve_managed`
+    /// EXACTLY in wording — the "not found" phrasing must match so
+    /// `is_missing_session` behaves identically regardless of which backend a
+    /// [`crate::client::proxy::SessionProxy`] is built over.
+    async fn resolve(&self, target: &str) -> Result<(String, String), String> {
+        let mgr = self.state.session_manager().await;
+        let records = mgr.list().await;
+        match resolve_target(&records, target) {
+            Some(r) => Ok((r.id.to_string(), r.tmux_name.clone())),
+            None => Err(format!("managed session {target} not found")),
+        }
+    }
+
+    /// Inject `text` into the session identified by `id`.
+    async fn send(&self, id: &str, text: &str) -> Result<(), String> {
+        let parsed = parse_managed_id(id)?;
+        let mgr = self.state.session_manager().await;
+        mgr.send_input(&parsed, text).await.map_err(|e| e.to_string())
+    }
+
+    /// Build a lightweight digest straight from the session record.
+    ///
+    /// Why: deliberately NOT the LLM-classified `GET .../activity` digest — no
+    /// tmux capture, no `OPENROUTER_API_KEY` requirement, so this local surface
+    /// is hermetic and fast to test. A caller wanting the full classified digest
+    /// still calls `GET /api/v1/sessions/managed/{id}/activity` directly.
+    async fn activity(&self, id: &str) -> Result<ActivityDigest, String> {
+        let parsed = parse_managed_id(id)?;
+        let mgr = self.state.session_manager().await;
+        let record = mgr
+            .get(&parsed)
+            .await
+            .map_err(|_| format!("managed session {id} not found"))?;
+        let summary = match &record.pending_decision {
+            Some(d) => format!("blocked on decision: {d}"),
+            None if record.task.trim().is_empty() => {
+                format!("state={}", record.state)
+            }
+            None => format!("state={} task={}", record.state, record.task),
+        };
+        Ok(ActivityDigest {
+            state: record.state.to_string(),
+            summary,
+            pending_decision: record.pending_decision,
+        })
+    }
+}
+
+/// Parse a canonical managed-session id string into a [`ManagedSessionId`].
+///
+/// Why: [`ManagedBackend::send`]/[`ManagedBackend::activity`] receive the
+/// resolved id as a plain `String` (the trait is backend-agnostic); this
+/// backend needs the typed [`ManagedSessionId`] `SessionManager` expects. A
+/// caller always reaches this AFTER `resolve` succeeded, so a parse failure here
+/// would indicate the store returned a non-UUID id — reported as an error rather
+/// than a panic (no `unwrap` on a value that ultimately traces back to a wire
+/// caller in `daemon::managed_routes::proxy`).
+/// What: parses `id` as a `uuid::Uuid` and wraps it; `Err` carries a message
+/// phrased WITHOUT the "not found" substring (an invalid id is a different
+/// failure mode than a missing session, so it must not trip the auto-unfocus
+/// path — see `is_missing_session`'s contract).
+/// Test: `parse_managed_id_rejects_non_uuid` in `tests.rs`.
+pub(super) fn parse_managed_id(id: &str) -> Result<ManagedSessionId, String> {
+    id.parse::<uuid::Uuid>()
+        .map(ManagedSessionId::from)
+        .map_err(|_| format!("invalid managed session id: {id}"))
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/proxy/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/proxy/mod.rs
@@ -1,0 +1,368 @@
+//! Local HTTP surface for the session-manager PROXY (TELUI-6, #1440).
+//!
+//! Why: before this module, the focus/inject/summarize state machine
+//! ([`crate::client::proxy::SessionProxy`]) could only be exercised by
+//! constructing a Telegram (or Slack) bot process and talking to it. That made
+//! the proxy layer un-testable without a live bot token — an operator (or CI)
+//! had no way to drive "focus a session, then send it a message" without
+//! standing up a real channel. This module exposes the SAME
+//! [`crate::client::proxy::SessionProxy`] state machine as a plain daemon HTTP
+//! surface (`/api/v1/sessions/proxy/*`) so it is `curl`-testable locally BEFORE
+//! any channel is connected — and, critically, once Telegram IS connected, its
+//! `focus`/`inject`/`summarize` calls run through this exact same state machine
+//! (just reached over HTTP via [`crate::client::executor::CommandExecutor`]
+//! instead of in-process), so a local API test genuinely exercises what
+//! Telegram will exercise.
+//! What: [`DirectManagedBackend`] implements
+//! [`crate::client::proxy::ManagedBackend`] directly over this daemon's OWN
+//! `SessionManager` (no network hop, no self-referential HTTP call) — resolving
+//! a fuzzy target via the shared [`crate::client::resolve_target`] resolver,
+//! injecting text via `SessionManager::send_input`, and building a lightweight
+//! [`crate::client::ActivityDigest`] straight from the session record (state,
+//! task, pending decision — deliberately NOT the heavier LLM-classified
+//! `GET .../activity` digest, so this surface stays hermetic: no tmux capture,
+//! no LLM key required, safe and fast for local/CI testing). Five handlers wire
+//! this backend to a per-request [`crate::client::SessionProxy`] built with
+//! [`crate::client::SessionProxy::with_focus_store`] over
+//! [`DaemonState::proxy_focus_store`], and render each proxy outcome as a
+//! tagged JSON body — HTTP 200 even for a "no session focused" or "session
+//! vanished" outcome, since those are valid states a caller must branch on, not
+//! transport errors (a caller can therefore fall back to its own coordinator on
+//! a 200 without treating the call as failed).
+//! Test: `tests.rs` (in-crate, mirrors the `proxy/tests.rs` client-side suite)
+//! plus `tests/proxy_routes.rs` (real HTTP, the curl-facing contract).
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path as AxumPath, State};
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+
+use crate::client::proxy::{
+    FocusOutcome, FocusTarget, InjectOutcome, ManagedBackend, SessionProxy, SummarizeOutcome,
+};
+use crate::daemon::state::DaemonState;
+
+mod backend;
+pub use backend::DirectManagedBackend;
+
+/// Build a per-request [`SessionProxy`] over this daemon's direct backend,
+/// sharing `state`'s persistent focus store.
+///
+/// Why: every handler below needs the identical construction; centralising it
+/// keeps each handler a one-line call.
+/// What: wraps a fresh [`DirectManagedBackend`] and the daemon's shared focus
+/// map into a [`SessionProxy`].
+fn local_proxy(state: &Arc<DaemonState>) -> SessionProxy {
+    let backend: Arc<dyn ManagedBackend> = Arc::new(DirectManagedBackend::new(Arc::clone(state)));
+    SessionProxy::with_focus_store(backend, state.proxy_focus_store())
+}
+
+/// Request body for `POST /api/v1/sessions/proxy/focus`.
+#[derive(Debug, Deserialize)]
+pub struct ProxyFocusRequest {
+    /// Opaque caller-supplied conversation key (Telegram's `chat_id`, Slack's
+    /// channel id, or any caller-chosen identifier for local testing).
+    pub conversation_key: String,
+    /// Managed session id, friendly name, or unambiguous prefix to focus.
+    /// Empty (or absent) queries the CURRENT focus instead of setting one.
+    #[serde(default)]
+    pub session_id: String,
+}
+
+/// Request body for `POST /api/v1/sessions/proxy/unfocus`.
+#[derive(Debug, Deserialize)]
+pub struct ProxyUnfocusRequest {
+    /// The conversation whose focus should be cleared.
+    pub conversation_key: String,
+}
+
+/// Request body for `POST /api/v1/sessions/proxy/message`.
+#[derive(Debug, Deserialize)]
+pub struct ProxyMessageRequest {
+    /// The conversation the message arrived on.
+    pub conversation_key: String,
+    /// The free-text message body.
+    pub text: String,
+}
+
+/// A resolved focus target, wire-shaped for the proxy JSON responses.
+#[derive(Debug, Serialize)]
+pub struct ProxyTargetWire {
+    /// Canonical managed-session id.
+    pub session_id: String,
+    /// Friendly session name.
+    pub name: String,
+}
+
+impl From<FocusTarget> for ProxyTargetWire {
+    fn from(f: FocusTarget) -> Self {
+        Self {
+            session_id: f.id,
+            name: f.name,
+        }
+    }
+}
+
+/// Response body for the focus-query/-set endpoints
+/// (`POST /api/v1/sessions/proxy/focus`, `GET .../focus/{conversation_key}`).
+///
+/// Why: a tagged enum lets a caller branch on `outcome` without probing for
+/// `null` fields; every variant is a valid, non-error state (always HTTP 200).
+/// What: `focused` on a successful resolve-and-set; `current` for a read-only
+/// query (target may be `null` when nothing is focused); `not_found` when the
+/// target could not be resolved (focus is left unchanged).
+#[derive(Debug, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ProxyFocusResponse {
+    /// The session was validated and is now focused.
+    Focused(ProxyTargetWire),
+    /// A read-only query of the current focus (may be unset).
+    Current {
+        /// The currently focused session, or `None` if unfocused.
+        target: Option<ProxyTargetWire>,
+    },
+    /// The requested target could not be resolved.
+    NotFound {
+        /// The unresolved target string.
+        target: String,
+        /// Why resolution failed.
+        error: String,
+    },
+}
+
+impl From<FocusOutcome> for ProxyFocusResponse {
+    fn from(o: FocusOutcome) -> Self {
+        match o {
+            FocusOutcome::Focused(t) => Self::Focused(t.into()),
+            FocusOutcome::Current(t) => Self::Current {
+                target: t.map(Into::into),
+            },
+            FocusOutcome::NotFound { target, error } => Self::NotFound { target, error },
+        }
+    }
+}
+
+/// Response body for `POST /api/v1/sessions/proxy/unfocus`.
+#[derive(Debug, Serialize)]
+pub struct ProxyUnfocusResponse {
+    /// The session that WAS focused, now cleared (`None` if nothing was).
+    pub cleared: Option<ProxyTargetWire>,
+}
+
+/// Response body for `POST /api/v1/sessions/proxy/message` — mirrors exactly
+/// how Telegram free text routes: focused → inject outcome; unfocused →
+/// `no_focus` so the caller can fall back to its own coordinator.
+///
+/// Why: this is the acceptance surface for "free text routes exactly like
+/// Telegram" — the SAME [`InjectOutcome`] the Telegram binding renders to HTML
+/// is rendered to JSON here, over the SAME [`SessionProxy::inject`] call.
+/// What: `sent` on success; `auto_unfocused` when the focused session had
+/// vanished (focus is already cleared by the time this is returned); `failed`
+/// on a transient backend error (focus preserved); `no_focus` when nothing was
+/// focused for this conversation.
+#[derive(Debug, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ProxyMessageResponse {
+    /// The text was injected into the focused session.
+    Sent {
+        /// The session it was sent to.
+        target: ProxyTargetWire,
+        /// The text that was injected.
+        text: String,
+    },
+    /// The focused session had vanished; focus was auto-cleared.
+    AutoUnfocused {
+        /// The session that was focused (now cleared).
+        target: ProxyTargetWire,
+        /// The "not found" error that triggered the auto-unfocus.
+        error: String,
+    },
+    /// A transient failure; focus is preserved.
+    Failed {
+        /// The still-focused session.
+        target: ProxyTargetWire,
+        /// The backend error.
+        error: String,
+    },
+    /// Nothing was focused for this conversation — the caller should fall back
+    /// to its own coordinator/default handling.
+    NoFocus,
+}
+
+impl From<InjectOutcome> for ProxyMessageResponse {
+    fn from(o: InjectOutcome) -> Self {
+        match o {
+            InjectOutcome::Sent { target, text } => Self::Sent {
+                target: target.into(),
+                text,
+            },
+            InjectOutcome::AutoUnfocused { target, error } => Self::AutoUnfocused {
+                target: target.into(),
+                error,
+            },
+            InjectOutcome::Failed { target, error } => Self::Failed {
+                target: target.into(),
+                error,
+            },
+            InjectOutcome::NoFocus => Self::NoFocus,
+        }
+    }
+}
+
+/// Response body for `GET /api/v1/sessions/proxy/summary/{conversation_key}`.
+///
+/// Why: mirrors [`ProxyMessageResponse`] for the SUMMARIZE direction — the same
+/// [`SummarizeOutcome`] the Telegram `/summary` command renders is rendered here.
+#[derive(Debug, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ProxySummaryResponse {
+    /// A digest of the focused session's recent activity.
+    Summary {
+        /// The focused session summarized.
+        target: ProxyTargetWire,
+        /// Current lifecycle state.
+        state: String,
+        /// Short activity summary.
+        summary: String,
+        /// Any decision the session is blocked on.
+        pending_decision: Option<String>,
+    },
+    /// The focused session had vanished; focus was auto-cleared.
+    AutoUnfocused {
+        /// The session that was focused (now cleared).
+        target: ProxyTargetWire,
+        /// The "not found" error that triggered the auto-unfocus.
+        error: String,
+    },
+    /// A transient failure; focus is preserved.
+    Failed {
+        /// The still-focused session.
+        target: ProxyTargetWire,
+        /// The backend error.
+        error: String,
+    },
+    /// Nothing was focused for this conversation.
+    NoFocus,
+}
+
+impl From<SummarizeOutcome> for ProxySummaryResponse {
+    fn from(o: SummarizeOutcome) -> Self {
+        match o {
+            SummarizeOutcome::Summary {
+                target,
+                state,
+                summary,
+                pending_decision,
+            } => Self::Summary {
+                target: target.into(),
+                state,
+                summary,
+                pending_decision,
+            },
+            SummarizeOutcome::AutoUnfocused { target, error } => Self::AutoUnfocused {
+                target: target.into(),
+                error,
+            },
+            SummarizeOutcome::Failed { target, error } => Self::Failed {
+                target: target.into(),
+                error,
+            },
+            SummarizeOutcome::NoFocus => Self::NoFocus,
+        }
+    }
+}
+
+/// `POST /api/v1/sessions/proxy/focus` — focus (or query) a session for a
+/// conversation.
+///
+/// Why: the "session click" of TELUI-6 translated to a plain HTTP verb — set
+/// (or, with an empty `session_id`, query) the focused session for
+/// `conversation_key`.
+/// What: builds a per-request [`SessionProxy`] over the shared focus store and
+/// calls [`SessionProxy::focus`]; always 200, the JSON `outcome` tag carries the
+/// result.
+/// Test: `proxy_focus_route_*` in `tests.rs` / `tests/proxy_routes.rs`.
+pub async fn proxy_focus(
+    State(state): State<Arc<DaemonState>>,
+    Json(req): Json<ProxyFocusRequest>,
+) -> impl IntoResponse {
+    let proxy = local_proxy(&state);
+    let outcome = proxy.focus(&req.conversation_key, &req.session_id).await;
+    Json(ProxyFocusResponse::from(outcome)).into_response()
+}
+
+/// `GET /api/v1/sessions/proxy/focus/{conversation_key}` — query the current
+/// focus without setting one.
+///
+/// Why: a read-only companion to `POST .../focus` for a caller that just wants
+/// to know "what's focused right now?" via a plain GET.
+/// What: delegates to [`SessionProxy::focus`] with an empty target, which never
+/// touches the backend and always yields [`FocusOutcome::Current`].
+/// Test: `proxy_get_focus_route_*` in `tests.rs` / `tests/proxy_routes.rs`.
+pub async fn proxy_get_focus(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(conversation_key): AxumPath<String>,
+) -> impl IntoResponse {
+    let proxy = local_proxy(&state);
+    let outcome = proxy.focus(&conversation_key, "").await;
+    Json(ProxyFocusResponse::from(outcome)).into_response()
+}
+
+/// `POST /api/v1/sessions/proxy/unfocus` — clear a conversation's focus.
+///
+/// Why: the "back button" of TELUI-6 as a plain HTTP verb.
+/// What: calls [`SessionProxy::unfocus`] and reports the cleared session (or
+/// `None`) — never an error; unfocusing an already-unfocused conversation is a
+/// harmless no-op.
+/// Test: `proxy_unfocus_route_*` in `tests.rs` / `tests/proxy_routes.rs`.
+pub async fn proxy_unfocus(
+    State(state): State<Arc<DaemonState>>,
+    Json(req): Json<ProxyUnfocusRequest>,
+) -> impl IntoResponse {
+    let proxy = local_proxy(&state);
+    let cleared = proxy.unfocus(&req.conversation_key).map(Into::into);
+    Json(ProxyUnfocusResponse { cleared }).into_response()
+}
+
+/// `POST /api/v1/sessions/proxy/message` — route free text exactly like a
+/// channel's non-command message.
+///
+/// Why: THE acceptance endpoint for "the telegram model should be API testable
+/// locally" — this reproduces the Telegram `on_message` free-text branch
+/// (focused → inject; unfocused → the caller's own fallback) as a single HTTP
+/// call, over the identical [`SessionProxy::inject`] the Telegram binding calls.
+/// What: when `req.conversation_key` has a focus, injects `req.text` into it and
+/// returns the resulting [`InjectOutcome`]; otherwise returns
+/// [`ProxyMessageResponse::NoFocus`] — always HTTP 200, so a caller can branch
+/// on `outcome` to decide whether to fall back to ITS OWN coordinator/default
+/// handling rather than treating the call as failed.
+/// Test: `proxy_message_route_*` in `tests.rs` / `tests/proxy_routes.rs`.
+pub async fn proxy_message(
+    State(state): State<Arc<DaemonState>>,
+    Json(req): Json<ProxyMessageRequest>,
+) -> impl IntoResponse {
+    let proxy = local_proxy(&state);
+    let outcome = proxy.inject(&req.conversation_key, &req.text).await;
+    Json(ProxyMessageResponse::from(outcome)).into_response()
+}
+
+/// `GET /api/v1/sessions/proxy/summary/{conversation_key}` — digest the focused
+/// session's activity.
+///
+/// Why: the SUMMARIZE proxy direction as a plain HTTP GET, over the identical
+/// [`SessionProxy::summarize`] the Telegram `/summary` command calls.
+/// What: returns the [`SummarizeOutcome`] as JSON; always HTTP 200.
+/// Test: `proxy_summary_route_*` in `tests.rs` / `tests/proxy_routes.rs`.
+pub async fn proxy_summary(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(conversation_key): AxumPath<String>,
+) -> impl IntoResponse {
+    let proxy = local_proxy(&state);
+    let outcome = proxy.summarize(&conversation_key).await;
+    Json(ProxySummaryResponse::from(outcome)).into_response()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/managed_routes/proxy/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/proxy/tests.rs
@@ -202,7 +202,12 @@ async fn proxy_summary_route_returns_digest_for_focused_session() {
     assert_eq!(body["outcome"], "summary");
     assert_eq!(body["target"]["name"], name);
     assert!(body["state"].is_string());
-    assert!(body["summary"].as_str().unwrap().contains("proxy test task"));
+    assert!(
+        body["summary"]
+            .as_str()
+            .unwrap()
+            .contains("proxy test task")
+    );
 }
 
 #[tokio::test]

--- a/crates/trusty-mpm/src/daemon/managed_routes/proxy/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/proxy/tests.rs
@@ -1,0 +1,331 @@
+//! In-crate tests for the local session-manager PROXY routes (TELUI-6, #1440).
+//!
+//! Why: mirrors the `client::proxy::tests` suite but drives the handlers
+//! directly with axum's `State`/`Json`/`Path` extractors against a hermetic
+//! `DaemonState::with_root_isolated_managed` — the SAME convention
+//! `tests/session_manager_mvp.rs` uses for `managed_routes` handler tests, kept
+//! in-crate (rather than appended to that already-large integration file) so
+//! this cohesive cluster has its own home. `tests/proxy_routes.rs` covers the
+//! same surface over REAL HTTP (the curl-facing contract).
+//! What: seeds one managed session via `create_with_id` (no real tmux — the
+//! isolated-managed constructor wires a `FakeNoopTmuxDriver`), then drives
+//! focus → message → summary → unfocus, plus the dead-session auto-unfocus and
+//! no-focus paths, asserting on the decoded JSON body.
+//! Test: this *is* the test module.
+
+use super::*;
+use std::sync::Arc;
+
+use crate::daemon::state::DaemonState;
+use crate::runtime::RuntimeKind;
+use crate::session_manager::record::ManagedSessionId;
+
+/// Decode an axum `impl IntoResponse` into its JSON body.
+///
+/// Why: every handler below returns `impl IntoResponse`; a test must read the
+/// body to assert on the tagged `outcome`. Mirrors the identically-named helper
+/// in `tests/session_manager_mvp.rs` (a separate compilation unit, so it cannot
+/// be imported — duplicated here at ~8 lines).
+async fn decode_response(resp: impl axum::response::IntoResponse) -> serde_json::Value {
+    let resp = resp.into_response();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+/// Build a hermetic `DaemonState` with one seeded managed session.
+///
+/// Why: every proxy test needs a resolvable session to focus; centralising the
+/// seed keeps each test focused on the proxy behavior, not setup.
+/// What: returns the state and the seeded session's friendly name (`tmux_name`),
+/// which the tests resolve by name (proving the fuzzy-name path, not just id).
+async fn seeded_state() -> (Arc<DaemonState>, String) {
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let mgr = state.session_manager().await;
+    let record = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "proxy test task".to_string(),
+            None,
+            Some("proxytest".to_string()),
+            None,
+            None,
+            None,
+            RuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session");
+    (state, record.tmux_name)
+}
+
+#[tokio::test]
+async fn proxy_focus_route_resolves_by_name_and_reports_current() {
+    let (state, name) = seeded_state().await;
+
+    // Set the focus by friendly name.
+    let body = decode_response(
+        proxy_focus(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyFocusRequest {
+                conversation_key: "conv-1".into(),
+                session_id: name.clone(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["outcome"], "focused");
+    assert_eq!(body["name"], name);
+
+    // An empty session_id queries the current focus without changing it.
+    let body = decode_response(
+        proxy_focus(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyFocusRequest {
+                conversation_key: "conv-1".into(),
+                session_id: String::new(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["outcome"], "current");
+    assert_eq!(body["target"]["name"], name);
+}
+
+#[tokio::test]
+async fn proxy_get_focus_route_reports_unset() {
+    let (state, _name) = seeded_state().await;
+    let body = decode_response(
+        proxy_get_focus(
+            axum::extract::State(Arc::clone(&state)),
+            axum::extract::Path("conv-never-focused".to_string()),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["outcome"], "current");
+    assert!(body["target"].is_null());
+}
+
+#[tokio::test]
+async fn proxy_focus_route_unknown_target_is_not_found() {
+    let (state, _name) = seeded_state().await;
+    let body = decode_response(
+        proxy_focus(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyFocusRequest {
+                conversation_key: "conv-1".into(),
+                session_id: "no-such-session".into(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["outcome"], "not_found");
+    assert_eq!(body["target"], "no-such-session");
+}
+
+#[tokio::test]
+async fn proxy_message_route_focused_sends_unfocused_no_focus() {
+    let (state, name) = seeded_state().await;
+
+    // Unfocused: the message route reports `no_focus`, never an HTTP error, so
+    // a caller can fall back to its own coordinator.
+    let body = decode_response(
+        proxy_message(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyMessageRequest {
+                conversation_key: "conv-2".into(),
+                text: "hello?".into(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["outcome"], "no_focus");
+
+    // Focus, then the SAME message route sends to the focused session.
+    decode_response(
+        proxy_focus(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyFocusRequest {
+                conversation_key: "conv-2".into(),
+                session_id: name.clone(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    let body = decode_response(
+        proxy_message(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyMessageRequest {
+                conversation_key: "conv-2".into(),
+                text: "run the tests".into(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["outcome"], "sent");
+    assert_eq!(body["target"]["name"], name);
+    assert_eq!(body["text"], "run the tests");
+}
+
+#[tokio::test]
+async fn proxy_summary_route_returns_digest_for_focused_session() {
+    let (state, name) = seeded_state().await;
+    decode_response(
+        proxy_focus(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyFocusRequest {
+                conversation_key: "conv-3".into(),
+                session_id: name.clone(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    let body = decode_response(
+        proxy_summary(
+            axum::extract::State(Arc::clone(&state)),
+            axum::extract::Path("conv-3".to_string()),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["outcome"], "summary");
+    assert_eq!(body["target"]["name"], name);
+    assert!(body["state"].is_string());
+    assert!(body["summary"].as_str().unwrap().contains("proxy test task"));
+}
+
+#[tokio::test]
+async fn proxy_summary_route_no_focus() {
+    let (state, _name) = seeded_state().await;
+    let body = decode_response(
+        proxy_summary(
+            axum::extract::State(Arc::clone(&state)),
+            axum::extract::Path("conv-never".to_string()),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["outcome"], "no_focus");
+}
+
+#[tokio::test]
+async fn proxy_unfocus_route_clears_and_reports_none_when_absent() {
+    let (state, name) = seeded_state().await;
+    decode_response(
+        proxy_focus(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyFocusRequest {
+                conversation_key: "conv-4".into(),
+                session_id: name.clone(),
+            }),
+        )
+        .await,
+    )
+    .await;
+
+    let body = decode_response(
+        proxy_unfocus(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyUnfocusRequest {
+                conversation_key: "conv-4".into(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["cleared"]["name"], name);
+
+    // Unfocusing again reports `cleared: null` — a harmless no-op.
+    let body = decode_response(
+        proxy_unfocus(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyUnfocusRequest {
+                conversation_key: "conv-4".into(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    assert!(body["cleared"].is_null());
+}
+
+#[tokio::test]
+async fn proxy_message_route_auto_unfocuses_when_session_decommissioned() {
+    // Focus a real session, HARD-DELETE its record out from under the focus
+    // (decommission alone leaves a tombstone the resolver still finds — a
+    // deliberately different, non-"not found" failure mode; a hard delete is
+    // what genuinely makes `resolve_target` report "not found"), then confirm
+    // the message route auto-unfocuses (the same guarantee the Telegram
+    // binding relies on) rather than failing forever.
+    let (state, name) = seeded_state().await;
+    decode_response(
+        proxy_focus(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyFocusRequest {
+                conversation_key: "conv-5".into(),
+                session_id: name.clone(),
+            }),
+        )
+        .await,
+    )
+    .await;
+
+    let mgr = state.session_manager().await;
+    let records = mgr.list().await;
+    let id = records
+        .iter()
+        .find(|r| r.tmux_name == name)
+        .expect("seeded session present")
+        .id;
+    mgr.delete_record(&id, true)
+        .await
+        .expect("hard-delete seeded session");
+
+    let body = decode_response(
+        proxy_message(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyMessageRequest {
+                conversation_key: "conv-5".into(),
+                text: "are you still there?".into(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["outcome"], "auto_unfocused");
+
+    // The conversation is now unfocused — a follow-up message reports no_focus.
+    let body = decode_response(
+        proxy_message(
+            axum::extract::State(Arc::clone(&state)),
+            axum::Json(ProxyMessageRequest {
+                conversation_key: "conv-5".into(),
+                text: "hello again".into(),
+            }),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(body["outcome"], "no_focus");
+}
+
+#[test]
+fn parse_managed_id_rejects_non_uuid() {
+    let err = super::backend::parse_managed_id("not-a-uuid").unwrap_err();
+    assert!(err.contains("invalid managed session id"));
+    assert!(
+        !err.contains("not found"),
+        "an invalid id must not trip the auto-unfocus 'not found' predicate: {err}"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -243,6 +243,22 @@ pub struct DaemonState {
     /// `tokio::sync::RwLock`; actors are registered here via `run_session`.
     /// Test: `control_routes` handler tests register sessions and assert list/get.
     pub session_registry: Arc<SessionRegistry>,
+    /// Per-conversation focus state for the local session-manager PROXY surface
+    /// (`/api/v1/sessions/proxy/*`, TELUI-6 #1440).
+    ///
+    /// Why: the proxy routes construct a fresh
+    /// [`crate::client::SessionProxy`] PER REQUEST (mirroring every other
+    /// stateless handler in this file), but which session a conversation has
+    /// focused must persist ACROSS requests — exactly the same durability
+    /// requirement `paired_chat_id`/`pair_code` have, so this follows their
+    /// plain-`Mutex`-field pattern rather than introducing a new subsystem.
+    /// What: an `Arc<Mutex<HashMap<conversation_key, FocusTarget>>>` shared into
+    /// each request's `SessionProxy` via
+    /// [`crate::client::SessionProxy::with_focus_store`]. Volatile — does not
+    /// survive a daemon restart, matching every external channel's focus state.
+    /// Test: `daemon::managed_routes::proxy::tests`, `tests/proxy_routes.rs`.
+    pub(super) proxy_focus:
+        Arc<std::sync::Mutex<HashMap<String, crate::client::proxy::FocusTarget>>>,
 }
 
 impl Default for DaemonState {
@@ -327,6 +343,7 @@ impl DaemonState {
             activity_monitor: std::sync::OnceLock::new(),
             project_registry: tokio::sync::OnceCell::new(),
             session_registry,
+            proxy_focus: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -384,6 +401,7 @@ impl DaemonState {
             activity_monitor: std::sync::OnceLock::new(),
             project_registry: tokio::sync::OnceCell::new(),
             session_registry,
+            proxy_focus: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -399,6 +417,22 @@ impl DaemonState {
     /// `with_root` a tempdir and asserts the handler reads it.
     pub fn framework_root(&self) -> &std::path::Path {
         &self.framework_root
+    }
+
+    /// The shared focus-state store for the local session-manager PROXY routes.
+    ///
+    /// Why: `daemon::managed_routes::proxy` constructs a fresh
+    /// [`crate::client::SessionProxy`] per request (mirroring every other
+    /// stateless handler in this file) via
+    /// [`crate::client::SessionProxy::with_focus_store`], which needs a shared,
+    /// cross-request handle to this daemon's focus map.
+    /// What: clones the `Arc` (cheap) around the `Mutex<HashMap<..>>`; every
+    /// clone guards the SAME underlying map.
+    /// Test: `daemon::managed_routes::proxy::tests`, `tests/proxy_routes.rs`.
+    pub fn proxy_focus_store(
+        &self,
+    ) -> Arc<std::sync::Mutex<HashMap<String, crate::client::proxy::FocusTarget>>> {
+        Arc::clone(&self.proxy_focus)
     }
 
     /// The PID-file registry rooted under this daemon's framework root.

--- a/crates/trusty-mpm/src/telegram/commands.rs
+++ b/crates/trusty-mpm/src/telegram/commands.rs
@@ -114,6 +114,15 @@ pub enum TelegramCommand {
     /// Decommission a managed session — `/decommission <id|name>`.
     #[command(description = "Decommission a managed session (terminal)")]
     Decommission(String),
+    /// Focus a managed session so plain messages route to it — `/focus <id|name>`.
+    #[command(description = "Focus a session so plain messages route to it")]
+    Focus(String),
+    /// Clear the focused session, returning to coordinator chat — `/unfocus`.
+    #[command(description = "Clear the focused session")]
+    Unfocus,
+    /// Digest the focused session's recent activity back to the chat — `/summary`.
+    #[command(description = "Summarize the focused session's activity")]
+    Summary,
     /// Show all commands.
     #[command(description = "Show all commands")]
     Help,
@@ -188,6 +197,15 @@ impl From<TelegramCommand> for TrustyCommand {
             TelegramCommand::Decommission(target) => TrustyCommand::ManagedDecommission {
                 target: target.trim().to_string(),
             },
+            // `/focus`, `/unfocus`, and `/summary` drive the session-manager PROXY
+            // (per-chat focus + INJECT/SUMMARIZE), not the daemon command surface —
+            // they are intercepted in `telegram::on_message` before this conversion
+            // and never reach the executor. These arms only keep the exhaustive
+            // match total; mapping to the harmless `Help` command is a safe,
+            // non-destructive fallback should the interception ever be bypassed.
+            TelegramCommand::Focus(_) | TelegramCommand::Unfocus | TelegramCommand::Summary => {
+                TrustyCommand::Help
+            }
             TelegramCommand::Help => TrustyCommand::Help,
         }
     }
@@ -321,9 +339,10 @@ mod tests {
     #[test]
     fn bot_commands_lists_every_command() {
         // teloxide's generated descriptor must enumerate all commands: the 20
-        // legacy ones plus the 8 managed-fleet verbs added for the drive surface.
+        // legacy ones, the 8 managed-fleet verbs added for the drive surface, and
+        // the 3 proxy verbs (/focus, /unfocus, /summary) added for TELUI-6 (#1440).
         let descriptions = TelegramCommand::bot_commands();
-        assert_eq!(descriptions.len(), 28);
+        assert_eq!(descriptions.len(), 31);
         assert!(descriptions.iter().any(|c| c.command == "/health"));
         assert!(descriptions.iter().any(|c| c.command == "/sessions"));
         assert!(descriptions.iter().any(|c| c.command == "/connect"));
@@ -343,6 +362,31 @@ mod tests {
         assert!(descriptions.iter().any(|c| c.command == "/activity"));
         assert!(descriptions.iter().any(|c| c.command == "/resume"));
         assert!(descriptions.iter().any(|c| c.command == "/decommission"));
+        // The TELUI-6 proxy verbs.
+        assert!(descriptions.iter().any(|c| c.command == "/focus"));
+        assert!(descriptions.iter().any(|c| c.command == "/unfocus"));
+        assert!(descriptions.iter().any(|c| c.command == "/summary"));
+    }
+
+    #[test]
+    fn proxy_verbs_are_adapter_local() {
+        // `/focus`, `/unfocus`, and `/summary` drive the session-manager proxy in
+        // the adapter, not the daemon command surface. The From conversion is
+        // never invoked for them in practice (they are intercepted before
+        // dispatch); this documents the safe Help fallback the exhaustive match
+        // provides.
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Focus("api".into())),
+            TrustyCommand::Help
+        );
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Unfocus),
+            TrustyCommand::Help
+        );
+        assert_eq!(
+            TrustyCommand::from(TelegramCommand::Summary),
+            TrustyCommand::Help
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/telegram/focus.rs
+++ b/crates/trusty-mpm/src/telegram/focus.rs
@@ -1,0 +1,178 @@
+//! Telegram binding for the channel-agnostic session-manager proxy (TELUI-6).
+//!
+//! Why: the focus state machine and both proxy directions (INJECT free text →
+//! session send, SUMMARIZE session activity → channel) are channel-agnostic and
+//! live in [`crate::client::proxy`] so Slack and an MCP surface reuse them. This
+//! module is the THIN Telegram binding: it maps a Telegram `chat_id` to the
+//! proxy's conversation key and renders the proxy's structured outcomes into
+//! Telegram HTML. No focus state or routing logic lives here — only presentation
+//! and the per-chat conversation-key convention.
+//! What: [`handle_focus`]/[`handle_unfocus`]/[`handle_summary`]/[`inject_reply`]
+//! call the shared [`SessionProxy`] and render its outcome as an HTML reply
+//! body. [`conv`] is the Telegram conversation-key convention (`chat_id` as a
+//! string). The routing decision is re-exported from the proxy so `on_message`
+//! uses the one shared function.
+//! Test: `focus/tests.rs` covers the render mapping for each outcome; the state
+//! machine and daemon paths are covered by `client::proxy::tests`.
+
+use crate::client::{FocusOutcome, InjectOutcome, SessionProxy, SummarizeOutcome};
+
+use super::formatter::{html_escape, short_id};
+
+/// The prompt shown when a proxy action needs a focused session but none is set.
+const NO_FOCUS_HINT: &str =
+    "No session is focused — use <code>/focus &lt;session&gt;</code> first.";
+
+/// Map a Telegram `chat_id` to the proxy's conversation key.
+///
+/// Why: the proxy keys focus by an opaque channel-supplied string; Telegram's
+/// per-chat conversation is identified by its `chat_id`, so the binding converts
+/// once here rather than scattering `to_string()` calls through the handlers.
+/// What: returns the `chat_id` rendered as a decimal string.
+/// Test: covered indirectly by every handler test.
+pub fn conv(chat_id: i64) -> String {
+    chat_id.to_string()
+}
+
+/// Handle `/focus [session]` (and the `🎯 Focus` button) for `chat_id`.
+///
+/// Why: focusing routes through the shared proxy (which validates the target and
+/// captures its id/name); this binding only renders the outcome for Telegram.
+/// What: calls [`SessionProxy::focus`] and renders the [`FocusOutcome`] as HTML.
+/// Test: `handle_focus_empty_hints`, `render_focus_*`.
+pub async fn handle_focus(proxy: &SessionProxy, chat_id: i64, arg: &str) -> String {
+    render_focus(&proxy.focus(&conv(chat_id), arg).await)
+}
+
+/// Handle `/unfocus` for `chat_id`.
+///
+/// Why: returns the conversation to fleet-wide chat; the reply names the cleared
+/// session so the state change is unambiguous.
+/// What: clears the proxy focus and renders a confirmation (or a no-op notice).
+/// Test: `handle_unfocus_clears_and_reports`, `handle_unfocus_when_none`.
+pub fn handle_unfocus(proxy: &SessionProxy, chat_id: i64) -> String {
+    match proxy.unfocus(&conv(chat_id)) {
+        Some(f) => format!(
+            "✅ Unfocused <b>{}</b>. Plain messages now go to the coordinator.",
+            html_escape(&f.name),
+        ),
+        None => "No session was focused.".to_string(),
+    }
+}
+
+/// Handle `/summary` for `chat_id` — digest the focused session's activity.
+///
+/// Why: the SUMMARIZE proxy direction on the Telegram surface — read back what
+/// the focused session is doing without attaching to tmux.
+/// What: calls [`SessionProxy::summarize`] and renders the [`SummarizeOutcome`].
+/// Test: `render_summary_*`.
+pub async fn handle_summary(proxy: &SessionProxy, chat_id: i64) -> String {
+    render_summary(&proxy.summarize(&conv(chat_id)).await)
+}
+
+/// Route a free-text message to the focused session (INJECT) and render the ack.
+///
+/// Why: the payoff of focus mode on Telegram — a plain message becomes a send at
+/// the focused session; the proxy handles resolution and dead-session
+/// auto-unfocus, this binding renders the result.
+/// What: calls [`SessionProxy::inject`] and renders the [`InjectOutcome`].
+/// Test: `render_inject_*`.
+pub async fn inject_reply(proxy: &SessionProxy, chat_id: i64, text: &str) -> String {
+    render_inject(&proxy.inject(&conv(chat_id), text).await)
+}
+
+/// Render a [`FocusOutcome`] as a Telegram HTML reply.
+///
+/// Test: `render_focus_focused`, `render_focus_current_none`, `render_focus_not_found`.
+fn render_focus(outcome: &FocusOutcome) -> String {
+    match outcome {
+        FocusOutcome::Focused(f) => format!(
+            "🎯 Focused on <b>{}</b> (<code>{}</code>).\n\
+             Plain messages now route to this session; /unfocus to stop.",
+            html_escape(&f.name),
+            short_id(&f.id),
+        ),
+        FocusOutcome::Current(Some(f)) => format!(
+            "🎯 Focused on <b>{}</b> (<code>{}</code>).\n\
+             Plain messages route here; /unfocus to stop.",
+            html_escape(&f.name),
+            short_id(&f.id),
+        ),
+        FocusOutcome::Current(None) => "Usage: <code>/focus &lt;session&gt;</code> — focus a \
+             managed session so plain messages route straight to it."
+            .to_string(),
+        FocusOutcome::NotFound { target, error } => format!(
+            "❌ Cannot focus <code>{}</code>: {}",
+            html_escape(target),
+            html_escape(error),
+        ),
+    }
+}
+
+/// Render an [`InjectOutcome`] as a Telegram HTML reply.
+///
+/// Test: `render_inject_sent`, `render_inject_auto_unfocused`,
+/// `render_inject_failed`, `render_inject_no_focus`.
+fn render_inject(outcome: &InjectOutcome) -> String {
+    match outcome {
+        InjectOutcome::Sent { target, text } => format!(
+            "📨 → <b>{}</b> (<code>{}</code>)\n<i>{}</i>",
+            html_escape(&target.name),
+            short_id(&target.id),
+            html_escape(text),
+        ),
+        InjectOutcome::AutoUnfocused { target, error } => format!(
+            "⚠️ Focused session <b>{}</b> is gone — focus cleared, back to the \
+             coordinator. ({})",
+            html_escape(&target.name),
+            html_escape(error),
+        ),
+        InjectOutcome::Failed { target, error } => format!(
+            "❌ Send to <b>{}</b> failed: {}\nStill focused; /unfocus to stop.",
+            html_escape(&target.name),
+            html_escape(error),
+        ),
+        InjectOutcome::NoFocus => NO_FOCUS_HINT.to_string(),
+    }
+}
+
+/// Render a [`SummarizeOutcome`] as a Telegram HTML reply.
+///
+/// Test: `render_summary_ok`, `render_summary_no_focus`.
+fn render_summary(outcome: &SummarizeOutcome) -> String {
+    match outcome {
+        SummarizeOutcome::Summary {
+            target,
+            state,
+            summary,
+            pending_decision,
+        } => {
+            let decision = pending_decision
+                .as_deref()
+                .map(|d| format!("\n⚠️ pending: {}", html_escape(d)))
+                .unwrap_or_default();
+            format!(
+                "<b>📋 {}</b> (<code>{}</code>) [{}]\n{}{decision}",
+                html_escape(&target.name),
+                short_id(&target.id),
+                html_escape(state),
+                html_escape(summary),
+            )
+        }
+        SummarizeOutcome::AutoUnfocused { target, error } => format!(
+            "⚠️ Focused session <b>{}</b> is gone — focus cleared, back to the \
+             coordinator. ({})",
+            html_escape(&target.name),
+            html_escape(error),
+        ),
+        SummarizeOutcome::Failed { target, error } => format!(
+            "❌ Summary of <b>{}</b> failed: {}",
+            html_escape(&target.name),
+            html_escape(error),
+        ),
+        SummarizeOutcome::NoFocus => NO_FOCUS_HINT.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-mpm/src/telegram/focus.rs
+++ b/crates/trusty-mpm/src/telegram/focus.rs
@@ -23,6 +23,38 @@ use super::formatter::{html_escape, short_id};
 const NO_FOCUS_HINT: &str =
     "No session is focused — use <code>/focus &lt;session&gt;</code> first.";
 
+/// Safety ceiling (raw, pre-HTML-escape chars) for the activity summary text
+/// embedded in a `/summary` reply.
+///
+/// Why: [`html_escape`] can expand a string up to ~5x (`&` → `&amp;`); an
+/// unbounded activity digest could push a reply over Telegram's hard 4096-char
+/// message-body limit, silently dropping the message. Today's digest contract
+/// (a lightweight [`crate::client::ActivityDigest`]) is always short, so this is
+/// a DEFENSIVE ceiling for a path that should never be hit, not an expected
+/// truncation — but it is enforced, not merely assumed.
+/// What: the raw-text budget before escaping; comfortably below the 4096-char
+/// limit even at worst-case 5x escape expansion plus the surrounding template.
+/// Test: `truncate_summary_leaves_short_text_untouched`,
+/// `truncate_summary_caps_long_text`.
+const MAX_SUMMARY_CHARS: usize = 700;
+
+/// Truncate `s` to at most [`MAX_SUMMARY_CHARS`] characters, marking truncation.
+///
+/// Why: factored out of [`render_summary`] so the truncation rule is
+/// unit-testable independent of the full HTML render.
+/// What: returns `s` unchanged (borrowed, no allocation) when within budget;
+/// otherwise the first [`MAX_SUMMARY_CHARS`] chars (on a char boundary) plus a
+/// `" […truncated]"` marker.
+/// Test: `truncate_summary_leaves_short_text_untouched`,
+/// `truncate_summary_caps_long_text`.
+fn truncate_summary(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.chars().count() <= MAX_SUMMARY_CHARS {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let truncated: String = s.chars().take(MAX_SUMMARY_CHARS).collect();
+    std::borrow::Cow::Owned(format!("{truncated} […truncated]"))
+}
+
 /// Map a Telegram `chat_id` to the proxy's conversation key.
 ///
 /// Why: the proxy keys focus by an opaque channel-supplied string; Telegram's
@@ -156,7 +188,7 @@ fn render_summary(outcome: &SummarizeOutcome) -> String {
                 html_escape(&target.name),
                 short_id(&target.id),
                 html_escape(state),
-                html_escape(summary),
+                html_escape(&truncate_summary(summary)),
             )
         }
         SummarizeOutcome::AutoUnfocused { target, error } => format!(

--- a/crates/trusty-mpm/src/telegram/focus/tests.rs
+++ b/crates/trusty-mpm/src/telegram/focus/tests.rs
@@ -106,6 +106,47 @@ fn render_summary_no_focus_hints() {
     assert!(html.contains("No session is focused"), "{html}");
 }
 
+#[test]
+fn truncate_summary_leaves_short_text_untouched() {
+    let short = "running cargo test, all green";
+    assert_eq!(truncate_summary(short).as_ref(), short);
+}
+
+#[test]
+fn truncate_summary_caps_long_text() {
+    // A digest far longer than the budget is capped and marked, never passed
+    // through verbatim (defensive ceiling against Telegram's 4096-char limit).
+    let long: String = "x".repeat(MAX_SUMMARY_CHARS * 3);
+    let truncated = truncate_summary(&long);
+    assert!(
+        truncated.chars().count() <= MAX_SUMMARY_CHARS + " […truncated]".chars().count(),
+        "truncated length {} exceeds budget",
+        truncated.chars().count()
+    );
+    assert!(truncated.ends_with("[…truncated]"), "{truncated}");
+}
+
+#[test]
+fn render_summary_caps_pathologically_long_digest() {
+    // End-to-end: a session that returned a runaway-long summary still renders
+    // a bounded HTML body, never an unbounded one that could exceed Telegram's
+    // per-message limit.
+    let mut ft = target();
+    ft.name = "tmpm-api".into();
+    let long_summary = "z".repeat(50_000);
+    let html = render_summary(&SummarizeOutcome::Summary {
+        target: ft,
+        state: "active".into(),
+        summary: long_summary,
+        pending_decision: None,
+    });
+    assert!(
+        html.len() < 4096,
+        "rendered summary reply must stay under Telegram's 4096-char body limit, got {}",
+        html.len()
+    );
+}
+
 #[tokio::test]
 async fn handle_unfocus_when_none() {
     let proxy = offline_proxy();

--- a/crates/trusty-mpm/src/telegram/focus/tests.rs
+++ b/crates/trusty-mpm/src/telegram/focus/tests.rs
@@ -1,0 +1,122 @@
+//! Unit tests for the Telegram proxy binding (TELUI-6, #1440).
+//!
+//! Why: this lives in a `focus/tests.rs` (a recognized test-file path) so the
+//! production `telegram/focus.rs` stays under the 500-SLOC production cap while
+//! the suite shares its private render functions via `use super::*`.
+//! What: covers the HTML render mapping for each proxy outcome and the no-focus
+//! handler wiring. The focus state machine and daemon paths are covered by
+//! `client::proxy::tests`.
+//! Test: this *is* the test module.
+
+use super::*;
+use std::sync::Arc;
+
+use crate::client::{
+    CommandExecutor, FocusOutcome, FocusTarget, InjectOutcome, SessionProxy, SummarizeOutcome,
+};
+
+/// A proxy over an unreachable daemon (no focus set).
+fn offline_proxy() -> SessionProxy {
+    SessionProxy::new(Arc::new(CommandExecutor::new("http://127.0.0.1:0")))
+}
+
+fn target() -> FocusTarget {
+    FocusTarget {
+        id: "aaaa1111bbbb2222".into(),
+        name: "tmpm-api".into(),
+    }
+}
+
+#[test]
+fn render_focus_focused_names_session() {
+    let html = render_focus(&FocusOutcome::Focused(target()));
+    assert!(html.contains("Focused on <b>tmpm-api</b>"), "{html}");
+    assert!(html.contains("/unfocus"), "{html}");
+}
+
+#[test]
+fn render_focus_current_none_hints_usage() {
+    let html = render_focus(&FocusOutcome::Current(None));
+    assert!(html.contains("Usage"), "{html}");
+}
+
+#[test]
+fn render_focus_not_found_escapes_and_reports() {
+    let html = render_focus(&FocusOutcome::NotFound {
+        target: "no-such".into(),
+        error: "managed session no-such not found".into(),
+    });
+    assert!(html.contains("Cannot focus"), "{html}");
+    assert!(html.contains("no-such"), "{html}");
+}
+
+#[test]
+fn render_inject_sent_echoes_text() {
+    let html = render_inject(&InjectOutcome::Sent {
+        target: target(),
+        text: "run the tests".into(),
+    });
+    assert!(html.contains("tmpm-api"), "{html}");
+    assert!(html.contains("run the tests"), "{html}");
+}
+
+#[test]
+fn render_inject_auto_unfocused_signals_gone() {
+    let html = render_inject(&InjectOutcome::AutoUnfocused {
+        target: target(),
+        error: "managed session x not found".into(),
+    });
+    assert!(html.contains("gone"), "{html}");
+    assert!(html.contains("tmpm-api"), "{html}");
+}
+
+#[test]
+fn render_inject_failed_keeps_focus_prose() {
+    let html = render_inject(&InjectOutcome::Failed {
+        target: target(),
+        error: "connection refused".into(),
+    });
+    assert!(html.contains("failed"), "{html}");
+    assert!(html.contains("Still focused"), "{html}");
+}
+
+#[test]
+fn render_inject_no_focus_hints() {
+    let html = render_inject(&InjectOutcome::NoFocus);
+    assert!(html.contains("No session is focused"), "{html}");
+}
+
+#[test]
+fn render_summary_ok_shows_state_and_pending() {
+    let html = render_summary(&SummarizeOutcome::Summary {
+        target: target(),
+        state: "active".into(),
+        summary: "running cargo test".into(),
+        pending_decision: Some("apply patch?".into()),
+    });
+    assert!(html.contains("tmpm-api"), "{html}");
+    assert!(html.contains("active"), "{html}");
+    assert!(html.contains("running cargo test"), "{html}");
+    assert!(html.contains("pending: apply patch?"), "{html}");
+}
+
+#[test]
+fn render_summary_no_focus_hints() {
+    let html = render_summary(&SummarizeOutcome::NoFocus);
+    assert!(html.contains("No session is focused"), "{html}");
+}
+
+#[tokio::test]
+async fn handle_unfocus_when_none() {
+    let proxy = offline_proxy();
+    assert!(handle_unfocus(&proxy, 1).contains("No session was focused"));
+}
+
+#[tokio::test]
+async fn handle_focus_empty_hints() {
+    // `/focus` with no argument and no current focus shows the usage hint and
+    // never touches the daemon (offline proxy would otherwise error).
+    let proxy = offline_proxy();
+    let html = handle_focus(&proxy, 1, "   ").await;
+    assert!(html.contains("Usage"), "{html}");
+}

--- a/crates/trusty-mpm/src/telegram/formatter/fleet.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/fleet.rs
@@ -7,9 +7,11 @@
 //! Telegram HTML message body grouped by project.
 //! Test: `format_fleet_by_project_*` tests in `tests.rs`.
 
+use teloxide::types::{InlineKeyboardButton, InlineKeyboardMarkup};
+
 use crate::client::{ProjectFleetView, fleet_state_glyph};
 
-use super::{html_escape, short_id};
+use super::{callback_fits, html_escape, short_id};
 
 /// Render managed sessions grouped by project as a Telegram HTML body.
 ///
@@ -55,4 +57,49 @@ pub fn format_fleet_by_project(fleet: &[ProjectFleetView]) -> String {
         }
     }
     text
+}
+
+/// Build a `🎯 Focus` button row for every session in the fleet (TELUI-6, #1440).
+///
+/// Why: tapping a session in the `/fleet` list is the "session click" from the
+/// TELUI-6 acceptance criteria — it focuses that session so plain messages route
+/// to it. One button per session across all projects gives that click target on
+/// a phone without typing an id.
+/// What: emits one `focus:<id>` button per session (label prefixed with the
+/// session name), skipping any id too long for Telegram's 64-byte callback-data
+/// budget. Returns `None` when the fleet has no sessions (no keyboard warranted).
+/// Test: `focus_keyboard_has_a_button_per_session` in `tests.rs`.
+pub fn focus_keyboard(fleet: &[ProjectFleetView]) -> Option<InlineKeyboardMarkup> {
+    let rows: Vec<Vec<InlineKeyboardButton>> = fleet
+        .iter()
+        .flat_map(|pf| pf.sessions.iter())
+        .filter(|s| callback_fits(&s.id))
+        .map(|s| {
+            vec![InlineKeyboardButton::callback(
+                format!("🎯 Focus — {}", s.name),
+                format!("focus:{}", s.id),
+            )]
+        })
+        .collect();
+    if rows.is_empty() {
+        None
+    } else {
+        Some(InlineKeyboardMarkup::new(rows))
+    }
+}
+
+/// Build a single `🎯 Focus` button for one managed session's detail view.
+///
+/// Why: the `/get` detail card also offers a one-tap focus so the operator can
+/// focus the session they just inspected without retyping its id.
+/// What: returns a one-button keyboard with `focus:<id>` callback data, or `None`
+/// when the id would overflow Telegram's callback-data budget.
+/// Test: `session_focus_keyboard_builds_button` in `tests.rs`.
+pub fn session_focus_keyboard(id: &str, name: &str) -> Option<InlineKeyboardMarkup> {
+    if !callback_fits(id) {
+        return None;
+    }
+    Some(InlineKeyboardMarkup::new(vec![vec![
+        InlineKeyboardButton::callback(format!("🎯 Focus — {name}"), format!("focus:{id}")),
+    ]]))
 }

--- a/crates/trusty-mpm/src/telegram/formatter/mod.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/mod.rs
@@ -371,6 +371,12 @@ impl TelegramFormatter {
                     Some(InlineKeyboardMarkup::new(rows))
                 }
             }
+            // `/fleet` and `/get` decorate each session with a `🎯 Focus` button
+            // so a tap focuses it (the "session click" of TELUI-6, #1440).
+            CommandResult::ManagedFleet(fleet) => fleet::focus_keyboard(fleet),
+            CommandResult::ManagedSession(view) => {
+                fleet::session_focus_keyboard(&view.id, &view.name)
+            }
             _ => None,
         }
     }
@@ -582,7 +588,7 @@ fn project_basename(path: &str) -> &str {
 /// What: returns the first [`SHORT_ID_LEN`] chars plus an ellipsis, or the id
 /// unchanged when already short.
 /// Test: `short_id_truncates_long_ids`.
-fn short_id(id: &str) -> String {
+pub(crate) fn short_id(id: &str) -> String {
     if id.len() > SHORT_ID_LEN {
         format!("{}…", &id[..SHORT_ID_LEN])
     } else {

--- a/crates/trusty-mpm/src/telegram/formatter/tests.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/tests.rs
@@ -587,3 +587,94 @@ fn error_escapes_html_significant_chars() {
         "Error prefix emoji must be preserved: {text}"
     );
 }
+
+#[test]
+fn focus_keyboard_has_a_button_per_session() {
+    // The `/fleet` list decorates every session (across all projects) with a
+    // `🎯 Focus` button whose callback data is `focus:<id>` (TELUI-6, #1440);
+    // empty projects contribute no buttons.
+    let fleet = vec![
+        ProjectFleetView {
+            project_name: "alpha".into(),
+            repo_url: "https://github.com/org/alpha".into(),
+            sessions: vec![
+                ManagedSessionView {
+                    id: "id-1".into(),
+                    name: "tmpm-a1".into(),
+                    state: "active".into(),
+                    workspace_path: None,
+                    repo_url: None,
+                    branch: None,
+                    pending_decision: None,
+                    proposed_default: None,
+                },
+                ManagedSessionView {
+                    id: "id-2".into(),
+                    name: "tmpm-a2".into(),
+                    state: "stopped".into(),
+                    workspace_path: None,
+                    repo_url: None,
+                    branch: None,
+                    pending_decision: None,
+                    proposed_default: None,
+                },
+            ],
+        },
+        ProjectFleetView {
+            project_name: "beta".into(),
+            repo_url: "https://github.com/org/beta".into(),
+            sessions: vec![],
+        },
+    ];
+    let keyboard =
+        TelegramFormatter::keyboard_for(&CommandResult::ManagedFleet(fleet)).expect("keyboard");
+    // One row per session, two sessions total.
+    assert_eq!(keyboard.inline_keyboard.len(), 2);
+    let data: Vec<&str> = keyboard
+        .inline_keyboard
+        .iter()
+        .flat_map(|row| row.iter())
+        .filter_map(|b| match &b.kind {
+            teloxide::types::InlineKeyboardButtonKind::CallbackData(d) => Some(d.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(data.contains(&"focus:id-1"), "callback data: {data:?}");
+    assert!(data.contains(&"focus:id-2"), "callback data: {data:?}");
+}
+
+#[test]
+fn focus_keyboard_empty_fleet_is_none() {
+    // A fleet with no sessions warrants no keyboard.
+    let fleet = vec![ProjectFleetView {
+        project_name: "beta".into(),
+        repo_url: "r".into(),
+        sessions: vec![],
+    }];
+    assert!(TelegramFormatter::keyboard_for(&CommandResult::ManagedFleet(fleet)).is_none());
+}
+
+#[test]
+fn session_detail_has_focus_button() {
+    // The `/get` detail card offers a single `🎯 Focus` button (TELUI-6, #1440).
+    let view = ManagedSessionView {
+        id: "id-9".into(),
+        name: "tmpm-solo".into(),
+        state: "active".into(),
+        workspace_path: None,
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+    };
+    let keyboard =
+        TelegramFormatter::keyboard_for(&CommandResult::ManagedSession(view)).expect("keyboard");
+    assert_eq!(keyboard.inline_keyboard.len(), 1);
+    assert_eq!(keyboard.inline_keyboard[0].len(), 1);
+    match &keyboard.inline_keyboard[0][0].kind {
+        teloxide::types::InlineKeyboardButtonKind::CallbackData(d) => {
+            assert_eq!(d, "focus:id-9")
+        }
+        other => panic!("expected callback data, got {other:?}"),
+    }
+}

--- a/crates/trusty-mpm/src/telegram/mod.rs
+++ b/crates/trusty-mpm/src/telegram/mod.rs
@@ -31,8 +31,8 @@ use teloxide::utils::command::BotCommands;
 use tokio_util::sync::CancellationToken;
 
 use crate::client::{
-    ChatMessage, CommandExecutor, CommandResult, FreeTextRoute, SessionProxy, TrustyCommand,
-    route_free_text,
+    ChatMessage, CommandExecutor, CommandResult, FreeTextRoute, ManagedBackend, SessionProxy,
+    TrustyCommand, route_free_text,
 };
 use alerts::{AlertConfig, LastSeen};
 use commands::TelegramCommand;
@@ -258,7 +258,8 @@ pub async fn run(
     // The channel-agnostic session-manager proxy (TELUI-6, #1440): holds per-chat
     // focus state and drives the INJECT/SUMMARIZE directions over the shared
     // executor. Telegram is one thin binding; Slack/MCP reuse the same proxy.
-    let proxy = Arc::new(SessionProxy::new(Arc::clone(&executor)));
+    let proxy_backend = Arc::clone(&executor) as Arc<dyn ManagedBackend>;
+    let proxy = Arc::new(SessionProxy::new(proxy_backend));
 
     let handler = dptree::entry()
         .branch(Update::filter_message().endpoint(on_message))

--- a/crates/trusty-mpm/src/telegram/mod.rs
+++ b/crates/trusty-mpm/src/telegram/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod alerts;
 pub mod commands;
+pub mod focus;
 pub mod formatter;
 pub mod supervisor;
 
@@ -29,7 +30,10 @@ use teloxide::types::ParseMode;
 use teloxide::utils::command::BotCommands;
 use tokio_util::sync::CancellationToken;
 
-use crate::client::{ChatMessage, CommandExecutor, CommandResult, TrustyCommand};
+use crate::client::{
+    ChatMessage, CommandExecutor, CommandResult, FreeTextRoute, SessionProxy, TrustyCommand,
+    route_free_text,
+};
 use alerts::{AlertConfig, LastSeen};
 use commands::TelegramCommand;
 use formatter::TelegramFormatter;
@@ -251,13 +255,17 @@ pub async fn run(
     let opts = Arc::new(options);
     // Per-chat LLM conversation history for free-text messages.
     let histories: ChatHistories = Arc::new(Mutex::new(HashMap::new()));
+    // The channel-agnostic session-manager proxy (TELUI-6, #1440): holds per-chat
+    // focus state and drives the INJECT/SUMMARIZE directions over the shared
+    // executor. Telegram is one thin binding; Slack/MCP reuse the same proxy.
+    let proxy = Arc::new(SessionProxy::new(Arc::clone(&executor)));
 
     let handler = dptree::entry()
         .branch(Update::filter_message().endpoint(on_message))
         .branch(Update::filter_callback_query().endpoint(on_callback));
 
     Dispatcher::builder(bot, handler)
-        .dependencies(dptree::deps![executor, opts, histories])
+        .dependencies(dptree::deps![executor, opts, histories, proxy])
         .enable_ctrlc_handler()
         .build()
         .dispatch()
@@ -313,18 +321,22 @@ pub async fn run_supervised(
 ///
 /// Why: the dispatcher branch for text messages — kept thin so all command
 /// dispatch stays in the shared [`CommandExecutor`].
-/// What: rejects unauthorized users, parses the text into a [`TelegramCommand`]
-/// via teloxide, dispatches it (the pairing commands need the message's chat id
-/// so they are special-cased), formats the [`CommandResult`], and replies with
-/// the appropriate inline keyboard.
-/// Test: command conversion is covered by `commands` tests; formatting by
-/// `formatter` tests; authorization by `authorization_respects_allowed_user`.
+/// What: rejects unauthorized users, then routes the text. `/focus`/`/unfocus`
+/// are adapter-local focus-state ops (TELUI-6, #1440) handled directly; every
+/// other slash command is dispatched via teloxide + the shared executor (pairing
+/// commands are special-cased for the chat id). A non-command line routes to the
+/// focused session's `managed-send` when the chat is focused, otherwise to the
+/// action-capable coordinator ([`focus::route_free_text`]).
+/// Test: command conversion is covered by `commands` tests; the focus handlers
+/// and routing by `focus::tests`; authorization by
+/// `authorization_respects_allowed_user`.
 async fn on_message(
     bot: Bot,
     msg: Message,
     executor: Arc<CommandExecutor>,
     options: Arc<BotOptions>,
     histories: ChatHistories,
+    proxy: Arc<SessionProxy>,
 ) -> ResponseResult<()> {
     let Some(text) = msg.text() else {
         return Ok(());
@@ -340,31 +352,63 @@ async fn on_message(
         return Ok(());
     }
 
-    let command = match TelegramCommand::parse(text, &bot_username()) {
-        Ok(cmd) => cmd,
-        Err(_) => {
-            // Not a slash command — route the free text to the action-capable
-            // coordinator so natural language can DRIVE the fleet (#1283), unless
-            // the message is empty, in which case there is nothing to ask.
-            if !text.trim().is_empty() {
-                let reply = action_chat_reply(&executor, &histories, msg.chat.id.0, text).await;
-                bot.send_message(msg.chat.id, reply)
-                    .parse_mode(ParseMode::Html)
-                    .await?;
-            }
-            return Ok(());
+    let chat_id = msg.chat.id.0;
+    match TelegramCommand::parse(text, &bot_username()) {
+        // `/focus`/`/unfocus`/`/summary` drive the session-manager PROXY (per-chat
+        // focus + INJECT/SUMMARIZE), not the daemon command surface, so they are
+        // handled here and never converted to a `TrustyCommand`.
+        Ok(TelegramCommand::Focus(arg)) => {
+            let reply = focus::handle_focus(&proxy, chat_id, &arg).await;
+            bot.send_message(msg.chat.id, reply)
+                .parse_mode(ParseMode::Html)
+                .await?;
         }
-    };
-
-    let result = dispatch_command(command, &executor, msg.chat.id.0).await;
-    let body = TelegramFormatter::format(&result);
-    let mut send = bot
-        .send_message(msg.chat.id, body)
-        .parse_mode(ParseMode::Html);
-    if let Some(keyboard) = TelegramFormatter::keyboard_for(&result) {
-        send = send.reply_markup(keyboard);
+        Ok(TelegramCommand::Unfocus) => {
+            let reply = focus::handle_unfocus(&proxy, chat_id);
+            bot.send_message(msg.chat.id, reply)
+                .parse_mode(ParseMode::Html)
+                .await?;
+        }
+        Ok(TelegramCommand::Summary) => {
+            let reply = focus::handle_summary(&proxy, chat_id).await;
+            bot.send_message(msg.chat.id, reply)
+                .parse_mode(ParseMode::Html)
+                .await?;
+        }
+        // Every other recognized slash command dispatches normally — commands
+        // keep working while a session is focused (only free text is captured).
+        Ok(command) => {
+            let result = dispatch_command(command, &executor, chat_id).await;
+            let body = TelegramFormatter::format(&result);
+            let mut send = bot
+                .send_message(msg.chat.id, body)
+                .parse_mode(ParseMode::Html);
+            if let Some(keyboard) = TelegramFormatter::keyboard_for(&result) {
+                send = send.reply_markup(keyboard);
+            }
+            send.await?;
+        }
+        // Not a recognized command — route the free text. An empty message has
+        // nothing to route.
+        Err(_) => {
+            if text.trim().is_empty() {
+                return Ok(());
+            }
+            let has_focus = proxy.current_focus(&focus::conv(chat_id)).is_some();
+            let reply = match route_free_text(text, has_focus) {
+                // A focused chat injects the line straight to that session (#1440).
+                FreeTextRoute::Inject => focus::inject_reply(&proxy, chat_id, text).await,
+                // Otherwise natural language DRIVES the fleet via the coordinator
+                // (#1283).
+                FreeTextRoute::Coordinator => {
+                    action_chat_reply(&executor, &histories, chat_id, text).await
+                }
+            };
+            bot.send_message(msg.chat.id, reply)
+                .parse_mode(ParseMode::Html)
+                .await?;
+        }
     }
-    send.await?;
     Ok(())
 }
 
@@ -512,13 +556,17 @@ fn action_footer(actions: Option<&[String]>) -> Option<String> {
 /// What: parses the `verb:arg` callback data, runs the matching action through
 /// the shared executor (project registration and tmux adoption have their own
 /// executor methods), answers the callback to clear the client spinner, and
-/// posts the reply.
-/// Test: callback dispatch reuses the shared executor, covered by its tests.
+/// posts the reply. The `focus:<id>` button (TELUI-6, #1440) sets the chat's
+/// focused session so a tap in a list is the "session click" that flips the chat
+/// into that session's conversation.
+/// Test: callback dispatch reuses the shared executor, covered by its tests; the
+/// focus handler by `focus::tests`.
 async fn on_callback(
     bot: Bot,
     query: CallbackQuery,
     executor: Arc<CommandExecutor>,
     options: Arc<BotOptions>,
+    proxy: Arc<SessionProxy>,
 ) -> ResponseResult<()> {
     bot.answer_callback_query(query.id.clone()).await?;
 
@@ -534,6 +582,16 @@ async fn on_callback(
     let Some(chat_id) = query.message.as_ref().map(|m| m.chat().id) else {
         return Ok(());
     };
+
+    // `[🎯 Focus]` on a session row is the "session click" that focuses it; it
+    // drives the proxy focus state, so it is handled before the executor dispatch.
+    if let Some(("focus", id)) = data.split_once(':') {
+        let reply = focus::handle_focus(&proxy, chat_id.0, id).await;
+        bot.send_message(chat_id, reply)
+            .parse_mode(ParseMode::Html)
+            .await?;
+        return Ok(());
+    }
 
     let result = match data.split_once(':') {
         Some(("status", id)) => Some(

--- a/crates/trusty-mpm/tests/proxy_routes.rs
+++ b/crates/trusty-mpm/tests/proxy_routes.rs
@@ -1,0 +1,163 @@
+//! HTTP-level integration tests for the local session-manager PROXY surface
+//! (TELUI-6, #1440) — the exact curl-facing contract.
+//!
+//! Why: `daemon::managed_routes::proxy::tests` (in-crate) drives the handlers
+//! directly with axum extractors; this file instead binds a REAL TCP listener
+//! and drives the routes with `reqwest`, so it is the literal proof that the
+//! proxy state machine is exercisable with plain HTTP (curl) BEFORE any
+//! Telegram/Slack bot is wired up. Mirrors the real-network harness already used
+//! by `client/executor/tests.rs` and `client/proxy/tests.rs` (axum::serve on an
+//! ephemeral port + reqwest), applied here to the daemon's OWN proxy routes.
+//! What: seeds one managed session in-process (no HTTP needed for setup — the
+//! session-manager MVP tests seed the same way), serves the real router on a
+//! loopback port, then drives focus → message → summary → unfocus, plus the
+//! no-focus and dead-session auto-unfocus paths, over genuine HTTP requests.
+//! Test: this file IS the test; run with `cargo test -p trusty-mpm --test
+//! proxy_routes`.
+
+use std::future::IntoFuture;
+use std::sync::Arc;
+
+use trusty_mpm::daemon::{api, state::DaemonState};
+use trusty_mpm::runtime::RuntimeKind;
+use trusty_mpm::session_manager::ManagedSessionId;
+
+/// Spawn the real daemon router on a loopback port with one seeded session.
+///
+/// Why: every test below needs a live HTTP endpoint and a resolvable session;
+/// centralising both keeps each test focused on the proxy behavior.
+/// What: builds a hermetic `DaemonState::with_root_isolated_managed` (no real
+/// tmux — `FakeNoopTmuxDriver`), seeds one managed session, serves
+/// `api::router` on an ephemeral `127.0.0.1` port, and returns the base URL plus
+/// the seeded session's friendly name.
+async fn spawn_daemon_with_session() -> (String, String) {
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let mgr = state.session_manager().await;
+    let record = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "curl-recipe demo task".to_string(),
+            None,
+            Some("curltest".to_string()),
+            None,
+            None,
+            None,
+            RuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session");
+
+    let router = api::router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    (format!("http://{addr}"), record.tmux_name)
+}
+
+#[tokio::test]
+async fn http_focus_message_summary_unfocus_round_trip() {
+    let (url, name) = spawn_daemon_with_session().await;
+    let client = reqwest::Client::new();
+
+    // 1. Focus by friendly name over real HTTP.
+    let body: serde_json::Value = client
+        .post(format!("{url}/api/v1/sessions/proxy/focus"))
+        .json(&serde_json::json!({"conversation_key": "curl-1", "session_id": name}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(body["outcome"], "focused");
+    assert_eq!(body["name"], name);
+
+    // 2. GET the current focus back.
+    let body: serde_json::Value = client
+        .get(format!("{url}/api/v1/sessions/proxy/focus/curl-1"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(body["outcome"], "current");
+    assert_eq!(body["target"]["name"], name);
+
+    // 3. Free text routes to the focused session (the Telegram free-text path,
+    // reproduced over plain HTTP).
+    let body: serde_json::Value = client
+        .post(format!("{url}/api/v1/sessions/proxy/message"))
+        .json(&serde_json::json!({"conversation_key": "curl-1", "text": "run the build"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(body["outcome"], "sent");
+    assert_eq!(body["text"], "run the build");
+
+    // 4. Summarize the focused session.
+    let body: serde_json::Value = client
+        .get(format!("{url}/api/v1/sessions/proxy/summary/curl-1"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(body["outcome"], "summary");
+    assert_eq!(body["target"]["name"], name);
+
+    // 5. Unfocus; the response names the session that was cleared.
+    let body: serde_json::Value = client
+        .post(format!("{url}/api/v1/sessions/proxy/unfocus"))
+        .json(&serde_json::json!({"conversation_key": "curl-1"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(body["cleared"]["name"], name);
+}
+
+#[tokio::test]
+async fn http_message_with_no_focus_returns_no_focus_not_an_error() {
+    // The acceptance requirement: an unfocused conversation's message gets a
+    // structured `no_focus` outcome — HTTP 200, not an error — so a caller can
+    // fall back to its own coordinator.
+    let (url, _name) = spawn_daemon_with_session().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{url}/api/v1/sessions/proxy/message"))
+        .json(&serde_json::json!({"conversation_key": "never-focused", "text": "hello?"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["outcome"], "no_focus");
+}
+
+#[tokio::test]
+async fn http_focus_unknown_session_is_not_found() {
+    let (url, _name) = spawn_daemon_with_session().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{url}/api/v1/sessions/proxy/focus"))
+        .json(&serde_json::json!({"conversation_key": "curl-2", "session_id": "no-such"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["outcome"], "not_found");
+    assert_eq!(body["target"], "no-such");
+}


### PR DESCRIPTION
## Summary

Implements **TELUI-6 (#1440)** — focused-session state + free-text routing to managed `send` — as a **channel-agnostic session-manager PROXY**, with Telegram as the first thin surface AND a local, `curl`-testable daemon HTTP surface added per a follow-up requirement: *"the telegram model should be API testable locally before we connect to telegram."* This closes the last real blocker on DOC-22 WI-4 (Telegram control surface for managed sessions).

A conversation "focuses" one managed session; plain (non-command) messages then route straight to that session's `managed-send` instead of the coordinator. `/unfocus` (or the dead-session auto-unfocus) returns to fleet-wide chat. Recognized slash commands keep working while focused. The ENTIRE state machine is now also exposed as plain daemon HTTP routes, so it can be driven end-to-end with `curl` — no bot token, no live Telegram — before any channel connects.

## Layering (three-layer control model)

This PR implements **layer 2** of Bob's model and is deliberately single-session-focused:

1. **DIRECT** — user attaches to tmux (deterministic; not this PR).
2. **SESSION-MANAGER-AS-PROXY** — *this PR*. The SM proxies between an external channel (or a local caller) and ONE session, in two directions: **INJECT** (free text → session send) and **SUMMARIZE** (session activity → channel). Session-aware, single-session-communication focused.
3. **PROJECT MANAGER** (#2109) — cross-scope agent; explicitly out of scope, no cross-session intelligence added.

**Where the logic lives:** the focus state machine + both directions live in the channel-agnostic **`crates/trusty-mpm/src/client/proxy.rs`** (`SessionProxy`), behind a **`ManagedBackend`** trait abstraction added in this revision:

- `ManagedBackend for CommandExecutor` — the backend every EXTERNAL channel (Telegram, Slack) uses, reaching a session over the daemon's existing HTTP API.
- `DirectManagedBackend` (`daemon::managed_routes::proxy::backend`) — a NEW backend reaching this daemon's own `SessionManager` **in-process**, no self-referential HTTP hop. This is what the local `/api/v1/sessions/proxy/*` routes use.

Both backends drive the **exact same `SessionProxy` struct and state machine** (validate-then-focus, auto-unfocus-on-missing-session, preserve-focus-on-transient-error). Telegram's `/focus`/free-text/`/summary` and the local HTTP routes are provably exercising identical logic — differing only in HOW they reach a session (HTTP round-trip vs. in-process call).

- **Slack (#1504):** binds the same `SessionProxy` + `CommandExecutor` backend — no state-machine re-implementation.
- **MCP as a channel:** seam is in place (construct a `SessionProxy` keyed on the MCP client id); tool wiring is deliberate follow-up.

## New daemon HTTP endpoints (`/api/v1/sessions/proxy/*`)

Nested under the existing unified `/api/v1/sessions/*` namespace (matching the #1392 convention) rather than Bob's example top-level `/api/v1/proxy/*` paths — an intentional naming adjustment to fit the existing router convention; the capability is identical.

| Method | Path | Body / Params | Outcome tags |
|---|---|---|---|
| `POST` | `/api/v1/sessions/proxy/focus` | `{conversation_key, session_id}` (empty `session_id` = query) | `focused` / `current` / `not_found` |
| `GET` | `/api/v1/sessions/proxy/focus/{conversation_key}` | — | `current` |
| `POST` | `/api/v1/sessions/proxy/unfocus` | `{conversation_key}` | `{cleared: <target>\|null}` |
| `POST` | `/api/v1/sessions/proxy/message` | `{conversation_key, text}` | `sent` / `auto_unfocused` / `failed` / `no_focus` |
| `GET` | `/api/v1/sessions/proxy/summary/{conversation_key}` | — | `summary` / `auto_unfocused` / `failed` / `no_focus` |

Every response is **HTTP 200** — the tagged `outcome` field carries soft states like `no_focus`/`not_found` so a caller (a future Slack/MCP binding, or a test) branches on state instead of treating them as transport errors. This mirrors exactly how Telegram's free-text handler behaves internally (focused → inject; unfocused → fall back to its own coordinator).

## Curl recipe (acceptance evidence — no Telegram involved)

```bash
# 1. Start the daemon locally (or point at any running one), then spawn/adopt a
#    managed session however you normally would, and grab its name/id.
BASE=http://127.0.0.1:<daemon-port>

# 2. Focus a conversation on that session.
curl -s -X POST "$BASE/api/v1/sessions/proxy/focus" \
  -H 'content-type: application/json' \
  -d '{"conversation_key":"demo-1","session_id":"<session-name-or-id>"}'
# => {"outcome":"focused","session_id":"...","name":"..."}

# 3. Read the current focus back.
curl -s "$BASE/api/v1/sessions/proxy/focus/demo-1"
# => {"outcome":"current","target":{"session_id":"...","name":"..."}}

# 4. Free text — routes to the focused session exactly like a Telegram DM would.
curl -s -X POST "$BASE/api/v1/sessions/proxy/message" \
  -H 'content-type: application/json' \
  -d '{"conversation_key":"demo-1","text":"run the test suite"}'
# => {"outcome":"sent","target":{...},"text":"run the test suite"}

# 5. Ask what the session is doing.
curl -s "$BASE/api/v1/sessions/proxy/summary/demo-1"
# => {"outcome":"summary","target":{...},"state":"active","summary":"...","pending_decision":null}

# 6. Unfocus — back to fleet-wide chat.
curl -s -X POST "$BASE/api/v1/sessions/proxy/unfocus" \
  -H 'content-type: application/json' \
  -d '{"conversation_key":"demo-1"}'
# => {"cleared":{"session_id":"...","name":"..."}}

# Unfocused message: structured fallback signal, NOT an HTTP error.
curl -s -X POST "$BASE/api/v1/sessions/proxy/message" \
  -H 'content-type: application/json' \
  -d '{"conversation_key":"demo-1","text":"hello?"}'
# => {"outcome":"no_focus"}
```

This exact loop (focus → message → summary → unfocus, plus the no-focus and unknown-target paths) is also automated end-to-end over real HTTP in `tests/proxy_routes.rs` — the literal `curl`-facing contract, hermetic (no real tmux, no LLM key).

## What changed by area

**Shared chat-core (channel-agnostic)**
- `client/proxy.rs` — `ManagedBackend` trait (new); `SessionProxy` is now backend-agnostic (`Arc<dyn ManagedBackend>`) with a `with_focus_store` constructor for an externally-shared focus map; `ManagedBackend for CommandExecutor` (the HTTP backend); full Why/What/Test docs on `FocusOutcome`/`InjectOutcome`/`SummarizeOutcome`.
- `client/proxy/tests.rs` — updated for the new backend seam, plus a new regression test pinning `is_missing_session`'s substring match to the REAL resolver error string.

**Local daemon HTTP surface (new)**
- `daemon/managed_routes/proxy/mod.rs` — 5 handlers + tagged JSON response types.
- `daemon/managed_routes/proxy/backend.rs` — `DirectManagedBackend` (in-process `ManagedBackend` impl) + `Resolvable for SessionRecord`.
- `daemon/managed_routes/proxy/tests.rs` — in-crate handler-level tests (mirrors the `managed_routes` convention).
- `daemon/state/core.rs` — `DaemonState::proxy_focus` (persists focus across requests; mirrors the existing `paired_chat_id`/`pair_code` plain-`Mutex`-field pattern) + `proxy_focus_store()` accessor.
- `daemon/api.rs` — routes mounted under `/api/v1/sessions/proxy/*`.
- `tests/proxy_routes.rs` (new) — real `axum::serve` + `reqwest` HTTP integration tests.

**Telegram binding (thin surface)**
- `telegram/focus.rs` — updated for the new `ManagedBackend` seam; added a defensive truncation ceiling (`MAX_SUMMARY_CHARS`) on `/summary` replies, below Telegram's 4096-char message limit.
- `telegram/mod.rs`, `telegram/commands.rs`, `telegram/formatter/{mod,fleet}.rs` — unchanged from the original submission (see below).

## Design decisions

- **Persistence:** focus state is in-memory and **volatile across a daemon restart** for every surface (Telegram, the local HTTP routes) — matching the existing `ChatHistories` seam. Documented in module headers.
- **Dead-session handling:** a vanished focused session **auto-unfocuses** on the next inject/summarize; a *transient* error (daemon unreachable, or a decommissioned-but-not-deleted tombstone) **preserves** focus. Verified in tests to require an actual `delete_record` (hard delete), not merely `decommission` (which leaves a resolvable tombstone) — a real behavioral distinction the test suite now pins.
- **`is_missing_session` is substring matching, not a typed signal** (adversarial-review finding): both `CommandExecutor`'s and `DirectManagedBackend`'s "not found" wording is pinned to the literal resolver string (`"managed session {target} not found"`), and `is_missing_session_matches_live_resolver_not_found_format` drives the REAL `CommandExecutor` against a live test daemon to assert the coupling holds — a wording drift now fails CI instead of silently disabling auto-unfocus.
- **Local backend's summarize is deliberately lightweight** (state + task + pending decision from the record) rather than the full LLM-classified `GET .../activity` digest — no tmux capture, no `OPENROUTER_API_KEY` requirement, keeping the local proxy surface hermetic and fast for CI. A caller wanting the full classified digest still calls the existing `/activity` endpoint directly.
- **Route naming:** `/api/v1/sessions/proxy/*` (nested under the existing unified sessions namespace) rather than the example `/api/v1/proxy/*` — see the endpoints table above.

## Divergences from the issue

The #1440 acceptance criteria are written for a graphical TELUI (session click → chat view, back button, right/left-aligned bubbles). Translated to the Telegram surface: **session click** = the `🎯 Focus` inline button (+ `/focus`); **chat view / conversation persists** = focused-session state routing plain messages to `managed-send`; **back button clears focus** = `/unfocus` (+ auto-unfocus on death). Bubble alignment is N/A on Telegram; the user turn is echoed in the send ack and bot state is surfaced via `/summary`. Per the layering requirement, the routing/state logic lives in the shared proxy so Slack/MCP/local-HTTP all reuse it.

## Quality gate (raw, latest revision after rebase onto origin/main)

```
cargo build --workspace                                  Finished (clean)
cargo test --workspace                                    TOTAL passed=13100 failed=0 ignored=102
cargo test -p trusty-mpm --lib                             test result: ok. 2659 passed; 0 failed; 5 ignored
cargo test -p trusty-mpm --test proxy_routes                test result: ok. 3 passed; 0 failed; 0 ignored
cargo clippy --workspace --all-targets -- -D warnings     CLIPPY_EXIT=0
cargo fmt --check                                         EXIT=0
bash scripts/check_line_cap.sh                            line-cap: 0 allowlisted, 0 violations — OK.
```

One transient flake (`trusty_common::update::tests::cache_fresh_returns_some_when_newer`, an mtime-timing test in a crate untouched by this PR) appeared once during `cargo test --workspace` and passed cleanly on immediate re-run (133/133) and on the full-suite re-run reported above (0 failures) — unrelated to this change.

Branch rebased onto current `origin/main` (was 2 commits behind after the earlier revision; now 0 behind, 2 ahead) so the diff is clean for review.

Closes #1440

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools