### PR TITLE
feat(trusty-code): cadence compressor — continuous N-turn history compression under context budget

### DIFF
--- a/crates/trusty-code/src/agent_loop/cadence.rs
+++ b/crates/trusty-code/src/agent_loop/cadence.rs
@@ -1,0 +1,334 @@
+//! Cadence compressor (#2346, epic #2343 "Infinite Sessions" ticket 3):
+//! continuous every-N-turn history compression that keeps the model-facing
+//! transcript under a fixed fraction of the model's context window at ALL
+//! times, so [`super::compaction`]'s threshold compactor becomes a backstop
+//! that should never fire in steady state, rather than the primary
+//! token-efficiency mechanism.
+//!
+//! Why: The pre-#2346 design only compacts REACTIVELY, once
+//! `estimate_total_tokens` crosses ~75% of the window
+//! (`CompactionConfig::for_context_window`) — by the time that fires, the
+//! transcript has already grown close to the limit, and every fire triggers
+//! a "re-anchor thrash" (the last-user-message replay). The epic's hard
+//! constraint is working context >= 60% of the window AT ALL TIMES and ZERO
+//! threshold-compaction events in a steady long-running session. A
+//! proactive, turn-count-driven cadence — compress every `cadence_turns`
+//! turns, THEN continuously enforce the budget every turn regardless of
+//! cadence — achieves both: routine cadence firing keeps growth bounded in
+//! the common case, and the continuous-enforcement loop is the safety net
+//! for a single pathological oversized turn that would otherwise blow the
+//! budget between cadence fires.
+//! What: [`CadenceConfig`] (`cadence_turns` + `max_overhead_fraction_pct`,
+//! resolved from `.claude/settings.json`'s `code_harness.*` keys and two
+//! escape-hatch env vars via [`resolve_cadence_config`], mirroring
+//! `crate::mode`'s precedence convention); [`maybe_cadence_compress`] (the
+//! turn-boundary entry point `agent_loop::AgentLoop` calls) which (1) ticks
+//! the transcript's turn counter and, on a cadence-fire turn, unconditionally
+//! compacts the span older than the active zone via
+//! `Transcript::compact_span_tagged` (#2278 group-safety and #2070 pinned/
+//! system/user exemptions reused verbatim, never reimplemented here), then
+//! (2) ALWAYS runs [`enforce_budget`] — a small, hard-bounded loop that keeps
+//! shrinking the active zone and re-compacting until
+//! `estimate_total_tokens(to_messages())` is back under the
+//! `max_overhead_fraction_pct` cap or nothing compactable remains (logging a
+//! warning, never panicking or looping forever, on that documented floor).
+//! Summarisation itself stays the existing deterministic
+//! `super::compaction::summarize_span` — see this module's doc note on the
+//! LLM-summary follow-up below.
+//!
+//! **LLM vs. deterministic summary (design decision, ticket-sanctioned):**
+//! the epic's prose says "LLM auto-compresses history", but wiring a
+//! synchronous `LlmClientTrait::chat` call into this turn boundary would
+//! make cadence's own summarisation step a new network-dependent failure
+//! mode for a mechanism whose entire point is to keep the loop robust and
+//! fast — and every turn already pays for one real model round-trip. Per
+//! the ticket's own explicit guidance ("do NOT block the epic on perfect
+//! summarization"), this ships the deterministic `summarize_span` fallback
+//! now, with the summary text pointing at the durable per-turn memory record
+//! (#2345's `chat_turn_append`/`memory_remember` dual-write) via a
+//! "turns N-M — use recall_session" pointer (see [`super::transcript::flush_span`]).
+//! An LLM-generated abstractive summary (bounded to ~500 tokens, prompted to
+//! preserve decisions/open-questions/artifact names) is the natural
+//! follow-up once `agent_loop::AgentLoop` exposes a clean async hook at this
+//! boundary — tracked for #2349/#2350 rather than blocking this ticket.
+//! Test: `cadence::tests::*`.
+
+use std::path::Path;
+
+use super::Transcript;
+use super::compaction::estimate_total_tokens;
+
+/// Turn-count cadence at which history compression fires by default (epic
+/// #2343: "N=8 default, config knob").
+pub const DEFAULT_CADENCE_TURNS: usize = 8;
+
+/// Fraction (as a whole-number percentage) of the model's context window the
+/// working transcript may occupy before continuous enforcement kicks in
+/// (epic #2343: "max_overhead_fraction=0.40 knob").
+pub const DEFAULT_MAX_OVERHEAD_FRACTION_PCT: usize = 40;
+
+/// Escape-hatch env var overriding [`CadenceConfig::cadence_turns`] for one
+/// process, mirroring `crate::mode::MODE_ENV_VAR`'s precedent.
+pub const CADENCE_TURNS_ENV_VAR: &str = "TCODE_CADENCE_TURNS";
+
+/// Escape-hatch env var overriding
+/// [`CadenceConfig::max_overhead_fraction_pct`] for one process.
+pub const CADENCE_OVERHEAD_FRACTION_ENV_VAR: &str = "TCODE_CADENCE_MAX_OVERHEAD_FRACTION_PCT";
+
+/// Tuning knobs for the #2346 cadence compressor.
+///
+/// Why: A caller needs to control both "how often" (turn-count cadence) and
+/// "how much of the window is overhead" (the budget the cadence + continuous
+/// enforcement together must respect) — bundling them mirrors
+/// `CompactionConfig`'s own two-knob shape.
+/// What: `cadence_turns` is the turn-count period `maybe_cadence_compress`
+/// fires the unconditional compaction pass on (0 disables cadence firing
+/// entirely, though continuous enforcement still applies — see
+/// `Transcript::tick_cadence_turn`'s docs); `max_overhead_fraction_pct` is
+/// the whole-number percentage of the model's real context window
+/// [`CadenceConfig::overhead_cap_tokens`] resolves the absolute cap from.
+/// Test: `cadence::tests::default_is_sane`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CadenceConfig {
+    /// Compress every this-many completed turns.
+    pub cadence_turns: usize,
+    /// Whole-number percentage of the context window the working transcript
+    /// may occupy.
+    pub max_overhead_fraction_pct: usize,
+}
+
+impl Default for CadenceConfig {
+    /// The epic's stated defaults: `cadence_turns: 8`,
+    /// `max_overhead_fraction_pct: 40`.
+    /// Test: `cadence::tests::default_is_sane`.
+    fn default() -> Self {
+        Self {
+            cadence_turns: DEFAULT_CADENCE_TURNS,
+            max_overhead_fraction_pct: DEFAULT_MAX_OVERHEAD_FRACTION_PCT,
+        }
+    }
+}
+
+impl CadenceConfig {
+    /// Resolve the absolute overhead-token cap for a given context window.
+    ///
+    /// Why: The budget arithmetic (epic #2343: on a 200K window, 40% ->
+    /// 80K overhead cap, 120K working floor) needs the model's REAL context
+    /// window — a property of the model, resolved separately via
+    /// `crate::provider::resolve_context_window` — combined with this
+    /// config's fraction.
+    /// What: `context_window * max_overhead_fraction_pct / 100`.
+    /// Test: `cadence::tests::overhead_cap_matches_epic_arithmetic`.
+    pub fn overhead_cap_tokens(&self, context_window: usize) -> usize {
+        context_window * self.max_overhead_fraction_pct / 100
+    }
+}
+
+/// Resolve a project's [`CadenceConfig`] via the `code_harness.*`
+/// `.claude/settings.json` precedence chain `crate::mode::resolve_mode`
+/// establishes, adapted to this config's two knobs.
+///
+/// Why: An operator needs to tune cadence per-project (`settings.json`) or
+/// per-process (the escape-hatch env vars) without a code change, matching
+/// every other `code_harness.*` knob in this crate. Unlike `resolve_mode`,
+/// there is no `task.run`-request tier — this ticket does not add a
+/// per-call cadence override to the wire protocol, so the chain is simply
+/// env var (highest) > `settings.json` > built-in default.
+/// What: Starts from `.claude/settings.json`'s `code_harness.cadence_turns`/
+/// `code_harness.max_overhead_fraction_pct` (via
+/// [`read_settings_json_cadence`], falling back to [`CadenceConfig::default`]
+/// when the file/keys are absent or malformed — never an error, matching
+/// `crate::mode::read_settings_json_mode`'s graceful-degrade convention),
+/// then overrides either field from [`CADENCE_TURNS_ENV_VAR`]/
+/// [`CADENCE_OVERHEAD_FRACTION_ENV_VAR`] when set to a valid `usize` (an
+/// unparseable value is logged via `tracing::warn!` and the prior tier's
+/// value is kept, rather than erroring the whole run).
+/// Test: `cadence::tests::resolve_cadence_config_settings_json_override`,
+/// `cadence::tests::resolve_cadence_config_env_wins_over_settings_json`.
+pub fn resolve_cadence_config(project_root: &Path) -> CadenceConfig {
+    let mut cfg = read_settings_json_cadence(project_root).unwrap_or_default();
+
+    if let Ok(raw) = std::env::var(CADENCE_TURNS_ENV_VAR) {
+        match raw.trim().parse::<usize>() {
+            Ok(v) => cfg.cadence_turns = v,
+            Err(e) => tracing::warn!(
+                "{CADENCE_TURNS_ENV_VAR}={raw:?} is not a valid usize ({e}); keeping {}",
+                cfg.cadence_turns
+            ),
+        }
+    }
+    if let Ok(raw) = std::env::var(CADENCE_OVERHEAD_FRACTION_ENV_VAR) {
+        match raw.trim().parse::<usize>() {
+            Ok(v) => cfg.max_overhead_fraction_pct = v,
+            Err(e) => tracing::warn!(
+                "{CADENCE_OVERHEAD_FRACTION_ENV_VAR}={raw:?} is not a valid usize ({e}); keeping {}",
+                cfg.max_overhead_fraction_pct
+            ),
+        }
+    }
+    cfg
+}
+
+/// Read `<project_root>/.claude/settings.json`'s `code_harness.cadence_turns`
+/// / `code_harness.max_overhead_fraction_pct` keys.
+///
+/// Why: mirrors `crate::mode::read_settings_json_mode`'s graceful-degrade
+/// convention for the same project-scoped config file.
+/// What: `None` when the file is missing, unreadable, not valid JSON, or has
+/// no `code_harness` object at all; otherwise `Some(CadenceConfig)` starting
+/// from [`CadenceConfig::default`] with either field overridden by whichever
+/// of the two keys is present and a valid non-negative integer (a present
+/// but wrong-typed key is silently skipped for that field, not an error for
+/// the whole read).
+/// Test: `cadence::tests::resolve_cadence_config_settings_json_override`,
+/// `cadence::tests::read_settings_json_cadence_missing_file_is_not_an_error`.
+fn read_settings_json_cadence(project_root: &Path) -> Option<CadenceConfig> {
+    let path = project_root.join(".claude").join("settings.json");
+    let raw = std::fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let harness = value.get("code_harness")?;
+
+    let mut cfg = CadenceConfig::default();
+    if let Some(turns) = harness
+        .get("cadence_turns")
+        .and_then(serde_json::Value::as_u64)
+    {
+        cfg.cadence_turns = turns as usize;
+    }
+    if let Some(pct) = harness
+        .get("max_overhead_fraction_pct")
+        .and_then(serde_json::Value::as_u64)
+    {
+        cfg.max_overhead_fraction_pct = pct as usize;
+    }
+    Some(cfg)
+}
+
+/// Outcome of one [`maybe_cadence_compress`] call, for observability/tests.
+///
+/// Why: `agent_loop::AgentLoop`'s turn boundary and unit tests both need to
+/// know what happened without re-deriving it from `Transcript`'s counters.
+/// What: `fired` — whether the scheduled cadence compaction ran THIS turn;
+/// `rounds` — total compaction rounds this call performed (the cadence round,
+/// if any, plus every continuous-enforcement round); `within_budget` —
+/// whether the transcript ended at/under the overhead cap (`false` only on
+/// the documented floor: the active zone alone, after full compaction,
+/// still exceeds the cap).
+/// Test: `cadence::tests::*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CadenceOutcome {
+    pub fired: bool,
+    pub rounds: usize,
+    pub within_budget: bool,
+}
+
+/// The turn-boundary entry point: tick the cadence counter, compress on
+/// schedule, then continuously enforce the overhead budget every turn.
+///
+/// Why: This is what makes the epic's "ZERO threshold-compaction events in
+/// steady state" metric achievable — see the module doc's overview. Called
+/// BEFORE `Transcript::maybe_compact` at the same turn boundary
+/// (`AgentLoop::run_inner`), so the threshold compactor only ever sees a
+/// transcript this function already kept under budget.
+/// What: `transcript.tick_cadence_turn(cfg.cadence_turns)` advances the
+/// counter and reports whether this is a scheduled fire; if so,
+/// `transcript.compact_span_tagged` unconditionally compacts everything
+/// older than `keep_last_messages` (the active zone — reused from the
+/// caller's own `CompactionConfig::keep_last_messages`, not a new knob).
+/// Regardless of whether cadence fired this turn, [`enforce_budget`] then
+/// runs: it re-checks `estimate_total_tokens(transcript.to_messages())`
+/// against `cfg.overhead_cap_tokens(context_window)` and, if still over,
+/// keeps shrinking the active zone and re-compacting (still via the SAME
+/// group-safe `compact_span_tagged`) until under budget or the active zone
+/// hits zero with nothing left to compact — at which point it warns (via
+/// `tracing::warn!`) and returns rather than looping forever.
+/// Test: `cadence::tests::fires_every_n_turns`,
+/// `cadence::tests::stays_under_budget_every_turn`,
+/// `cadence::tests::single_oversized_turn_still_ends_under_budget`,
+/// `cadence::tests::floor_exceeded_warns_not_panics`.
+pub fn maybe_cadence_compress(
+    transcript: &mut Transcript,
+    cfg: &CadenceConfig,
+    keep_last_messages: usize,
+    context_window: usize,
+) -> CadenceOutcome {
+    let fired = transcript.tick_cadence_turn(cfg.cadence_turns);
+    let mut rounds = 0;
+    if fired {
+        let range = transcript.begin_cadence_range();
+        if transcript.compact_span_tagged(keep_last_messages, range) {
+            transcript.advance_cadence_fire_marker();
+        }
+        rounds += 1;
+    }
+
+    let cap = cfg.overhead_cap_tokens(context_window);
+    let (enforcement_rounds, within_budget) = enforce_budget(transcript, cap, keep_last_messages);
+
+    CadenceOutcome {
+        fired,
+        rounds: rounds + enforcement_rounds,
+        within_budget,
+    }
+}
+
+/// Continuously compact until `transcript`'s model-facing view is at/under
+/// `cap_tokens`, or nothing compactable remains.
+///
+/// Why: A single pathological turn (e.g. a 60K-token `write_file` argument)
+/// can blow the overhead cap even immediately after a cadence fire, since
+/// cadence only ever protects the last `active_zone` messages, never
+/// compacts them. Requirement 3 of #2346 ("continuous budget enforcement")
+/// is this loop: shrink the protected active zone one message at a time and
+/// re-compact (group-safely) until the budget is satisfied.
+/// What: Starting at `keep_last = active_zone`, loop: if already under
+/// `cap_tokens`, return `(rounds, true)`. Otherwise compact tagged with the
+/// transcript's current cadence range, then either shrink `keep_last` by one
+/// (more rounds to go) or, once `keep_last == 0`, either loop back (that
+/// round newly compacted something — recheck the budget) or return
+/// `(rounds, false)` with a `tracing::warn!` (nothing left to compact and
+/// still over budget — the documented floor: pinned/system/user content
+/// alone exceeds the cap). Bounded by `active_zone + 2` iterations — never an
+/// unbounded loop.
+/// Test: `cadence::tests::stays_under_budget_every_turn`,
+/// `cadence::tests::single_oversized_turn_still_ends_under_budget`,
+/// `cadence::tests::floor_exceeded_warns_not_panics`.
+fn enforce_budget(
+    transcript: &mut Transcript,
+    cap_tokens: usize,
+    active_zone: usize,
+) -> (usize, bool) {
+    let mut keep_last = active_zone;
+    let mut rounds = 0;
+
+    loop {
+        if estimate_total_tokens(&transcript.to_messages()) <= cap_tokens {
+            return (rounds, true);
+        }
+
+        let range = transcript.begin_cadence_range();
+        let compacted = transcript.compact_span_tagged(keep_last, range);
+        rounds += 1;
+        if compacted {
+            transcript.advance_cadence_fire_marker();
+        }
+
+        if keep_last == 0 {
+            if !compacted {
+                tracing::warn!(
+                    cap_tokens,
+                    "cadence: overhead cap still exceeded after compacting every eligible \
+                     entry — the active zone (pinned + system/user turns) alone exceeds \
+                     budget; this is a documented floor, not an error"
+                );
+                return (rounds, false);
+            }
+            continue;
+        }
+        keep_last -= 1;
+    }
+}
+
+#[cfg(test)]
+#[path = "cadence_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/agent_loop/cadence_tests.rs
+++ b/crates/trusty-code/src/agent_loop/cadence_tests.rs
@@ -1,0 +1,343 @@
+//! Unit tests for the #2346 cadence compressor. Split out of `cadence.rs`
+//! per the crate's `_tests.rs` sibling-file convention (see
+//! `transcript_tests.rs` precedent) to keep the production file under the
+//! 500-SLOC cap.
+
+use super::super::CompactionConfig;
+use super::*;
+use crate::llm::{ChatMessage, FunctionCall, ToolCall};
+
+/// Serializes tests that mutate the process-wide cadence env vars, mirroring
+/// `crate::mode::MODE_ENV_LOCK`'s identical rationale.
+static CADENCE_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn with_cadence_env<T>(turns: Option<&str>, pct: Option<&str>, f: impl FnOnce() -> T) -> T {
+    let _guard = CADENCE_ENV_LOCK.lock().await;
+    // SAFETY: test-only env mutation, serialized by `CADENCE_ENV_LOCK`.
+    unsafe {
+        match turns {
+            Some(v) => std::env::set_var(CADENCE_TURNS_ENV_VAR, v),
+            None => std::env::remove_var(CADENCE_TURNS_ENV_VAR),
+        }
+        match pct {
+            Some(v) => std::env::set_var(CADENCE_OVERHEAD_FRACTION_ENV_VAR, v),
+            None => std::env::remove_var(CADENCE_OVERHEAD_FRACTION_ENV_VAR),
+        }
+    }
+    let result = f();
+    unsafe {
+        std::env::remove_var(CADENCE_TURNS_ENV_VAR);
+        std::env::remove_var(CADENCE_OVERHEAD_FRACTION_ENV_VAR);
+    }
+    result
+}
+
+fn project_with_settings(json: Option<&str>) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    if let Some(json) = json {
+        let dir = tmp.path().join(".claude");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(dir.join("settings.json"), json).expect("write settings.json");
+    }
+    tmp
+}
+
+/// Append one turn (an assistant tool-call + its tool result) whose
+/// estimated token size is `~token_size` (via `estimate_tokens`'s chars/4
+/// heuristic applied to the tool-call argument body — mirrors #2261's
+/// tool-call-argument accounting).
+fn push_sized_turn(t: &mut Transcript, idx: usize, token_size: usize) {
+    let arguments = format!(r#"{{"content":"{}"}}"#, "x".repeat(token_size * 4));
+    t.push_assistant(
+        None,
+        &[ToolCall {
+            id: format!("call_{idx}"),
+            kind: "function".into(),
+            function: FunctionCall {
+                name: "write_file".into(),
+                arguments,
+            },
+        }],
+    );
+    t.push_tool_result(&format!("call_{idx}"), "write_file", "ok");
+}
+
+#[test]
+fn default_is_sane() {
+    let cfg = CadenceConfig::default();
+    assert_eq!(cfg.cadence_turns, DEFAULT_CADENCE_TURNS);
+    assert_eq!(
+        cfg.max_overhead_fraction_pct,
+        DEFAULT_MAX_OVERHEAD_FRACTION_PCT
+    );
+}
+
+/// The epic's stated arithmetic: a 200K window at 40% overhead -> an 80K cap.
+#[test]
+fn overhead_cap_matches_epic_arithmetic() {
+    let cfg = CadenceConfig::default();
+    assert_eq!(cfg.overhead_cap_tokens(200_000), 80_000);
+}
+
+#[test]
+fn read_settings_json_cadence_missing_file_is_not_an_error() {
+    let project = project_with_settings(None);
+    assert_eq!(read_settings_json_cadence(project.path()), None);
+}
+
+#[tokio::test]
+async fn resolve_cadence_config_settings_json_override() {
+    let project = project_with_settings(Some(
+        r#"{"code_harness": {"cadence_turns": 3, "max_overhead_fraction_pct": 25}}"#,
+    ));
+    with_cadence_env(None, None, || {
+        let cfg = resolve_cadence_config(project.path());
+        assert_eq!(cfg.cadence_turns, 3);
+        assert_eq!(cfg.max_overhead_fraction_pct, 25);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn resolve_cadence_config_env_wins_over_settings_json() {
+    let project = project_with_settings(Some(
+        r#"{"code_harness": {"cadence_turns": 3, "max_overhead_fraction_pct": 25}}"#,
+    ));
+    with_cadence_env(Some("5"), Some("50"), || {
+        let cfg = resolve_cadence_config(project.path());
+        assert_eq!(cfg.cadence_turns, 5);
+        assert_eq!(cfg.max_overhead_fraction_pct, 50);
+    })
+    .await;
+}
+
+/// Cadence fires exactly every N turns (N=3 override) — not on any other
+/// turn.
+#[test]
+fn fires_every_n_turns() {
+    let mut t = Transcript::seed("s", "task");
+    // A generous cap so only the SCHEDULED cadence fire (never the
+    // continuous-enforcement loop) drives `cadence_fire_count` in this test.
+    let cfg = CadenceConfig {
+        cadence_turns: 3,
+        max_overhead_fraction_pct: 99,
+    };
+    let context_window = 1_000_000;
+
+    // keep_last_messages=1: small enough that every scheduled fire always
+    // has fresh, not-yet-compacted entries to act on (each turn adds 2
+    // entries), so the schedule (`outcome.fired`) and the "did work happen"
+    // counter (`cadence_fire_count`) agree in this test. A larger active
+    // zone can leave a scheduled fire with nothing new to compact yet (e.g.
+    // right when the transcript has grown to exactly fill the zone) — a
+    // real, correct distinction between "scheduled" and "did work", not a
+    // bug; this test isolates the schedule itself.
+    for turn in 1..=9 {
+        push_sized_turn(&mut t, turn, 10);
+        let outcome = maybe_cadence_compress(&mut t, &cfg, 1, context_window);
+        assert_eq!(outcome.fired, turn % 3 == 0, "turn {turn} fired mismatch");
+    }
+    assert_eq!(t.cadence_fire_count(), 3);
+    assert_eq!(t.cadence_turn_count(), 9);
+}
+
+/// The core #2346 acceptance test: a 100-turn run of 5K-token worst-case
+/// turns never triggers the threshold compactor and never exceeds the
+/// overhead cap on any turn.
+#[test]
+fn stays_under_budget_every_turn_and_threshold_never_fires() {
+    let mut t = Transcript::seed("s", "task");
+    let cadence_cfg = CadenceConfig::default(); // 8 turns, 40%
+    let context_window = 200_000;
+    let cap = cadence_cfg.overhead_cap_tokens(context_window);
+    let compaction_cfg = CompactionConfig::for_context_window(context_window);
+    let keep_last_messages = compaction_cfg.keep_last_messages;
+
+    let mut compaction_events = 0usize;
+    for turn in 1..=100 {
+        push_sized_turn(&mut t, turn, 5_000);
+        maybe_cadence_compress(&mut t, &cadence_cfg, keep_last_messages, context_window);
+
+        // The threshold compactor is the backstop — cadence must keep the
+        // transcript under its own (looser, 75%-of-window) trigger point on
+        // every single turn.
+        if t.maybe_compact(&compaction_cfg) {
+            compaction_events += 1;
+        }
+
+        let estimate = estimate_total_tokens(&t.to_messages());
+        assert!(
+            estimate <= cap,
+            "turn {turn}: estimate {estimate} exceeded overhead cap {cap}"
+        );
+    }
+
+    assert_eq!(
+        compaction_events, 0,
+        "threshold compaction must never fire under cadence's continuous enforcement"
+    );
+}
+
+/// A single pathologically large (60K-token) turn still ends under the
+/// overhead cap once continuous enforcement runs, even though it falls
+/// inside the protected active zone.
+#[test]
+fn single_oversized_turn_still_ends_under_budget() {
+    let mut t = Transcript::seed("s", "task");
+    for turn in 1..=5 {
+        push_sized_turn(&mut t, turn, 500);
+    }
+    push_sized_turn(&mut t, 6, 60_000);
+
+    let cfg = CadenceConfig {
+        cadence_turns: 8, // not a scheduled-fire turn; enforcement alone must do the work
+        max_overhead_fraction_pct: 40,
+    };
+    let context_window = 200_000;
+    let cap = cfg.overhead_cap_tokens(context_window);
+
+    let outcome = maybe_cadence_compress(&mut t, &cfg, 6, context_window);
+    assert!(
+        outcome.within_budget,
+        "enforcement must bring a single oversized turn back under budget"
+    );
+    assert!(estimate_total_tokens(&t.to_messages()) <= cap);
+}
+
+/// When even full compaction of everything compactable cannot bring the
+/// transcript under budget (the system/user preamble alone is oversized),
+/// enforcement returns `within_budget: false` rather than panicking or
+/// looping forever.
+#[test]
+fn floor_exceeded_warns_not_panics() {
+    // A huge seeded user task: system/user entries are NEVER compacted, so
+    // this alone exceeds a deliberately tiny cap.
+    let mut t = Transcript::seed("s", &"x".repeat(40_000));
+    let cfg = CadenceConfig {
+        cadence_turns: 1,
+        max_overhead_fraction_pct: 1,
+    };
+    let context_window = 1_000; // cap = 10 tokens — trivially exceeded by the seed alone.
+
+    let outcome = maybe_cadence_compress(&mut t, &cfg, 6, context_window);
+    assert!(!outcome.within_budget);
+}
+
+/// The synthesized summary for a cadence-compacted span references the
+/// durable memory turn range.
+#[test]
+fn summary_references_turn_range() {
+    let mut t = Transcript::seed("s", "task");
+    for turn in 1..=10 {
+        push_sized_turn(&mut t, turn, 100);
+    }
+    let cfg = CadenceConfig {
+        cadence_turns: 1,
+        max_overhead_fraction_pct: 99,
+    };
+    let outcome = maybe_cadence_compress(&mut t, &cfg, 2, 1_000_000);
+    assert!(outcome.fired);
+
+    let view = t.to_messages();
+    let summary = view
+        .iter()
+        .find(|m| m.content.as_deref().unwrap_or("").contains("[compacted"))
+        .expect("a compacted summary message");
+    let text = summary.content.as_deref().unwrap_or_default();
+    assert!(
+        text.contains("session memory"),
+        "summary must reference session memory: {text}"
+    );
+    assert!(
+        text.contains("recall_session"),
+        "summary must reference recall_session: {text}"
+    );
+    assert!(
+        text.contains("turns 1-1"),
+        "summary must reference the turn range: {text}"
+    );
+}
+
+/// Adversarial case: a cadence-triggered cutoff landing mid multi-tool-call
+/// group is pulled forward atomically instead of splitting it (#2278,
+/// reused verbatim by the cadence path via `Transcript::compact_span_tagged`).
+#[test]
+fn cadence_boundary_never_splits_a_tool_call_group() {
+    let mut t = Transcript::seed("s", "task");
+    for i in 0..5 {
+        t.push_assistant(Some(format!("turn {i}")), &[]);
+        t.push_tool_result(&format!("c{i}"), "bash", "output");
+    }
+    t.push_assistant(
+        None,
+        &[
+            ToolCall {
+                id: "multi_1".into(),
+                kind: "function".into(),
+                function: FunctionCall {
+                    name: "get_weather".into(),
+                    arguments: "{}".into(),
+                },
+            },
+            ToolCall {
+                id: "multi_2".into(),
+                kind: "function".into(),
+                function: FunctionCall {
+                    name: "get_time".into(),
+                    arguments: "{}".into(),
+                },
+            },
+        ],
+    );
+    t.push_tool_result("multi_1", "get_weather", "72F");
+    t.push_tool_result("multi_2", "get_time", "12:00 UTC");
+    assert_eq!(t.messages().len(), 15);
+
+    // keep_last_messages=2 lands the naive cutoff strictly between the
+    // multi-call assistant entry (index 12) and its second answer (14) —
+    // see `transcript::tests::maybe_compact_pulls_whole_multi_tool_call_group_forward`
+    // for the exact index arithmetic this mirrors.
+    let cfg = CadenceConfig {
+        cadence_turns: 1,
+        max_overhead_fraction_pct: 99,
+    };
+    let outcome = maybe_cadence_compress(&mut t, &cfg, 2, 1_000_000);
+    assert!(outcome.fired);
+
+    let view = t.to_messages();
+    assert_view_pairing_intact(&view);
+    assert!(
+        view.iter()
+            .any(|m| m.tool_calls.as_ref().is_some_and(|c| c.len() == 2)),
+        "the multi-tool-call assistant entry must survive uncompacted: {view:?}"
+    );
+}
+
+/// Same pairing-intact invariant `transcript_tests.rs` checks for the
+/// threshold path — every `tool` entry's issuing assistant entry (and vice
+/// versa) must be present in the same rendered view.
+fn assert_view_pairing_intact(view: &[ChatMessage]) {
+    let mut introduced: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut answered: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for msg in view {
+        if let Some(calls) = &msg.tool_calls {
+            for call in calls {
+                introduced.insert(call.id.clone());
+            }
+        }
+        if msg.role == "tool" {
+            let id = msg.tool_call_id.clone().unwrap_or_default();
+            assert!(
+                introduced.contains(&id),
+                "orphaned tool entry {id:?}: {view:?}"
+            );
+            answered.insert(id);
+        }
+    }
+    for id in &introduced {
+        assert!(
+            answered.contains(id),
+            "unanswered tool_calls id {id:?}: {view:?}"
+        );
+    }
+}

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -34,6 +34,7 @@
 //! tool-error continuation, usage accrual, sink notification order, cancellation,
 //! plus an `#[ignore]`-gated live test.
 
+mod cadence;
 mod compaction;
 mod error;
 mod goals;
@@ -57,6 +58,7 @@ use crate::mode::HarnessMode;
 use crate::perf::PerfCollector;
 use crate::tools::{AgentOutput, FINISH_TASK_TOOL_NAME, FinishTaskArgs, ToolRegistry, ToolResult};
 
+pub use cadence::{CadenceConfig, resolve_cadence_config};
 pub use compaction::CompactionConfig;
 // (#2260) Crate-internal re-export so `llm::bedrock::cache` can reuse the
 // same chars/4 token-estimate heuristic for its cachePoint min-size guard
@@ -140,6 +142,15 @@ pub struct AgentLoopConfig {
     /// `Self::maybe_compact_transcript`'s docs for why Parity must never
     /// compact.
     pub compaction: CompactionConfig,
+
+    /// Cadence-compressor tuning (#2346, epic #2343). `None` (the default)
+    /// disables cadence entirely — the delegated engineer's own loop and
+    /// `run_task`'s legacy one-shot/bake-off path both rely on this default
+    /// to stay byte-identical to pre-#2346 behaviour; only
+    /// `task::executor::run_and_record`'s persistent-session PM loop sets
+    /// `Some(_)`. Consulted only under `HarnessMode::DailyDriver` — see
+    /// `Self::maybe_cadence_compress`'s docs.
+    pub cadence: Option<CadenceConfig>,
 }
 
 impl Default for AgentLoopConfig {
@@ -152,7 +163,8 @@ impl Default for AgentLoopConfig {
     /// `crate::provider::resolve_max_tokens`; this default is only the
     /// generous fallback for when no agent config is consulted.
     /// What: 8 turns, 120s timeout, `openai/gpt-4o-mini`,
-    /// `DEFAULT_MAX_TOKENS`, `HarnessMode::default()`, `CompactionConfig::default()`.
+    /// `DEFAULT_MAX_TOKENS`, `HarnessMode::default()`, `CompactionConfig::default()`,
+    /// `cadence: None` (#2346 — disabled unless a caller opts in).
     /// Test: `config_defaults_are_sane`.
     fn default() -> Self {
         Self {
@@ -162,6 +174,7 @@ impl Default for AgentLoopConfig {
             max_tokens: crate::provider::DEFAULT_MAX_TOKENS,
             mode: HarnessMode::default(),
             compaction: CompactionConfig::default(),
+            cadence: None,
         }
     }
 }
@@ -417,8 +430,16 @@ impl AgentLoop {
                 });
             }
 
+            // #2346: cadence compression runs FIRST, same turn boundary as
+            // the checks above — the continuous, turn-count-driven mechanism
+            // that keeps working context under budget so #2070's threshold
+            // compactor below becomes a backstop rather than the primary
+            // token-efficiency path.
+            self.maybe_cadence_compress(transcript);
+
             // #2070: compaction check, same turn boundary as the cancellation
-            // check above — never mid-tool-call.
+            // check above — never mid-tool-call. Runs AFTER cadence so it
+            // only ever sees a transcript cadence already kept under budget.
             self.maybe_compact_transcript(transcript);
 
             let request = self.build_request(transcript, &schemas);
@@ -608,6 +629,44 @@ impl AgentLoop {
         if self.config.mode == HarnessMode::DailyDriver {
             transcript.maybe_compact(&self.config.compaction);
         }
+    }
+
+    /// Apply the #2346 cadence compressor to `transcript`, gated on mode the
+    /// SAME way [`Self::maybe_compact_transcript`] is, plus an explicit
+    /// per-run opt-in.
+    ///
+    /// Why: Cadence must respect the identical `HarnessMode::Parity` carve-out
+    /// as threshold compaction (byte-identical benchmark runs), AND must stay
+    /// off by default (`self.config.cadence == None`) so every call site that
+    /// doesn't explicitly opt in — the delegated engineer's own loop,
+    /// `run_task`'s legacy one-shot/bake-off path — sees zero behavioural
+    /// change from before this ticket. Only
+    /// `task::executor::run_and_record`'s persistent-session PM loop sets
+    /// `AgentLoopConfig.cadence = Some(_)`.
+    /// What: No-op unless `mode == HarnessMode::DailyDriver` AND
+    /// `self.config.cadence` is `Some`; otherwise resolves the model's real
+    /// context window (`crate::provider::resolve_context_window`, mirroring
+    /// `Self::maybe_compact_transcript`'s own model-aware sibling) and
+    /// delegates to `cadence::maybe_cadence_compress`, reusing
+    /// `self.config.compaction.keep_last_messages` as the shared active-zone
+    /// size rather than introducing a second, possibly-inconsistent knob.
+    /// Test: `agent_loop::tests::cadence_disabled_by_default`,
+    /// `agent_loop::tests::cadence_never_fires_in_parity_mode`,
+    /// `agent_loop::tests::cadence_fires_in_daily_driver_when_configured`.
+    fn maybe_cadence_compress(&self, transcript: &mut Transcript) {
+        if self.config.mode != HarnessMode::DailyDriver {
+            return;
+        }
+        let Some(cadence_cfg) = &self.config.cadence else {
+            return;
+        };
+        let context_window = crate::provider::resolve_context_window(&self.config.model);
+        cadence::maybe_cadence_compress(
+            transcript,
+            cadence_cfg,
+            self.config.compaction.keep_last_messages,
+            context_window,
+        );
     }
 
     /// Build a `ChatRequest` from the running transcript and tool schemas.

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -19,7 +19,8 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use super::{
-    AgentLoop, AgentLoopConfig, AgentLoopError, CompactionConfig, ToolEventSink, Transcript,
+    AgentLoop, AgentLoopConfig, AgentLoopError, CadenceConfig, CompactionConfig, ToolEventSink,
+    Transcript,
 };
 use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
 use crate::tools::{FinishTaskTool, ToolExecutor, ToolRegistry, ToolResult};
@@ -680,6 +681,134 @@ async fn parity_mode_never_compacts_even_past_threshold() {
         last_request.len(),
         12,
         "Parity must send the full raw history"
+    );
+}
+
+// ── #2346: cadence-compressor turn-boundary wiring ──────────────────────────
+
+/// Cadence stays off by default (#2346): `AgentLoopConfig::default().cadence`
+/// is `None`, and the loop never ticks the transcript's cadence counter when
+/// it is `None` — the exact "zero behaviour change for run_task/delegated
+/// engineer" contract this ticket requires.
+///
+/// Why: Every pre-#2346 call site (`run_task`, the delegated engineer's own
+/// loop) constructs `AgentLoopConfig` via `..AgentLoopConfig::default()`;
+/// this is the direct regression guard that doing so keeps cadence off.
+/// What: Run a several-turn script under `mode: DailyDriver` (the default)
+/// with `cadence: None` (the default) via `run_with_transcript` against an
+/// externally-owned `Transcript`, then assert `cadence_turn_count() == 0`.
+/// Test: this test.
+#[tokio::test]
+async fn cadence_disabled_by_default() {
+    let mut fixtures: Vec<Value> = (0..3)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(llm, registry, AgentLoopConfig::default());
+    let mut transcript = Transcript::seed("system prompt", "the task");
+    agent
+        .run_with_transcript(&mut transcript, "the task")
+        .await
+        .expect("run completes");
+
+    assert_eq!(transcript.cadence_turn_count(), 0);
+}
+
+/// `Parity` never ticks cadence even when a `CadenceConfig` is explicitly
+/// attached (#2346, mirrors `parity_mode_never_compacts_even_past_threshold`'s
+/// mode gate for the threshold compactor).
+///
+/// Why: The parity-spec (D2) byte-identical guarantee must hold for cadence
+/// exactly as it does for threshold compaction — an operator accidentally
+/// wiring `cadence: Some(_)` onto a Parity run must not silently break
+/// benchmark fairness.
+/// What: Same script shape as `cadence_disabled_by_default`, but
+/// `mode: Parity` with an aggressive `cadence: Some(CadenceConfig { cadence_turns: 1, .. })`
+/// attached; assert `cadence_turn_count() == 0` regardless.
+/// Test: this test.
+#[tokio::test]
+async fn cadence_never_fires_in_parity_mode() {
+    let mut fixtures: Vec<Value> = (0..3)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm,
+        registry,
+        AgentLoopConfig {
+            mode: crate::mode::HarnessMode::Parity,
+            cadence: Some(CadenceConfig {
+                cadence_turns: 1,
+                max_overhead_fraction_pct: 40,
+            }),
+            ..AgentLoopConfig::default()
+        },
+    );
+    let mut transcript = Transcript::seed("system prompt", "the task");
+    agent
+        .run_with_transcript(&mut transcript, "the task")
+        .await
+        .expect("run completes");
+
+    assert_eq!(transcript.cadence_turn_count(), 0);
+}
+
+/// `DailyDriver` mode with an explicit `CadenceConfig` attached ticks and
+/// fires cadence compression at the turn boundary (#2346).
+///
+/// Why: The positive case completing the mode-gate matrix — cadence must
+/// actually engage when both preconditions (`DailyDriver` + `Some(cadence)`)
+/// hold, not just correctly stay inert in the negative cases above.
+/// What: Scripts 6 tool-call round-trips then a stop (7 loop turns) under
+/// `mode: DailyDriver` with `cadence_turns: 1` (fires every turn) and an
+/// aggressive `compaction.keep_last_messages: 1` (small active zone, so
+/// cadence has fresh entries to compact on nearly every turn). Asserts both
+/// `cadence_turn_count() == 7` (one tick per loop turn) and
+/// `cadence_fire_count() > 0` (at least one turn actually compacted
+/// something).
+/// Test: this test.
+#[tokio::test]
+async fn cadence_fires_in_daily_driver_when_configured() {
+    let mut fixtures: Vec<Value> = (0..6)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm,
+        registry,
+        AgentLoopConfig {
+            max_turns: 10,
+            mode: crate::mode::HarnessMode::DailyDriver,
+            compaction: CompactionConfig {
+                token_threshold: 1_000_000, // keep the THRESHOLD backstop inert for this test
+                keep_last_messages: 1,
+            },
+            cadence: Some(CadenceConfig {
+                cadence_turns: 1,
+                max_overhead_fraction_pct: 99,
+            }),
+            ..AgentLoopConfig::default()
+        },
+    );
+    let mut transcript = Transcript::seed("system prompt", "the task");
+    agent
+        .run_with_transcript(&mut transcript, "the task")
+        .await
+        .expect("run completes");
+
+    assert_eq!(transcript.cadence_turn_count(), 7);
+    assert!(
+        transcript.cadence_fire_count() > 0,
+        "expected at least one cadence fire to actually compact something"
     );
 }
 

--- a/crates/trusty-code/src/agent_loop/transcript.rs
+++ b/crates/trusty-code/src/agent_loop/transcript.rs
@@ -58,6 +58,15 @@ struct TranscriptEntry {
     message: ChatMessage,
     compacted: bool,
     pinned: bool,
+    /// The cadence-turn range `(start, end)` active when this entry was
+    /// marked `compacted` by the #2346 cadence compressor — `None` for an
+    /// uncompacted entry OR one compacted by the threshold path
+    /// (`Transcript::maybe_compact`), which has no turn-range concept.
+    /// `to_messages`'s `flush_span` reads this to append a
+    /// "full detail in session memory (turns N-M)" pointer onto the
+    /// synthetic summary message, but only for spans the cadence
+    /// compressor produced.
+    cadence_turn_range: Option<(usize, usize)>,
 }
 
 impl TranscriptEntry {
@@ -67,6 +76,7 @@ impl TranscriptEntry {
             message,
             compacted: false,
             pinned: false,
+            cadence_turn_range: None,
         }
     }
 
@@ -77,6 +87,7 @@ impl TranscriptEntry {
             message,
             compacted: false,
             pinned: true,
+            cadence_turn_range: None,
         }
     }
 }
@@ -110,6 +121,21 @@ pub struct Transcript {
     assistant_texts: Vec<String>,
     last_compaction_len: Option<usize>,
     goals: Arc<Mutex<GoalSlots>>,
+    /// (#2346) Count of agent-loop turn boundaries this transcript has
+    /// observed via `tick_cadence_turn`, cumulative for the transcript's
+    /// entire lifetime — including across repeated `task.run` calls on the
+    /// same persistent session transcript, since this field lives on
+    /// `Transcript` (the session-persistent piece) rather than on
+    /// `AgentLoop` (reconstructed fresh per call).
+    cadence_turn_count: usize,
+    /// (#2346) The `cadence_turn_count` value as of the last time the
+    /// cadence compressor actually marked new entries `compacted` — the
+    /// start of the NEXT reported turn range is always one past this.
+    cadence_last_fire_turn: usize,
+    /// (#2346) Number of times the cadence compressor has fired (marked at
+    /// least one new entry `compacted`) — an observability/test counter,
+    /// distinct from `compacted_count` (which counts entries, not events).
+    cadence_fire_count: usize,
 }
 
 impl Transcript {
@@ -131,6 +157,9 @@ impl Transcript {
             assistant_texts: Vec::new(),
             last_compaction_len: None,
             goals: Arc::new(Mutex::new(GoalSlots::new())),
+            cadence_turn_count: 0,
+            cadence_last_fire_turn: 0,
+            cadence_fire_count: 0,
         }
     }
 
@@ -215,25 +244,27 @@ impl Transcript {
     /// ClearGoalTool}` most recently wrote via the same `Arc<Mutex<_>>`).
     /// What: Walks entries in order; a run of one-or-more contiguous
     /// `compacted` entries is replaced by ONE synthetic `system`-role message
-    /// (`super::compaction::summarize_span`'s one-line text) in its place;
-    /// uncompacted entries pass through unchanged. (#2347) If
-    /// `self.goals.render()` returns `Some`, a synthetic `system`-role
-    /// message carrying that text is inserted at index `1` (immediately
-    /// after the real system message, which `Transcript::seed` always
-    /// places at index `0` and `maybe_compact` never touches) — or appended
-    /// if `out` is empty, a defensive case that never occurs via `seed`. A
-    /// poisoned goals lock degrades to "no goals block" rather than
-    /// panicking (mirrors `run_task::recorder`'s poisoned-lock convention).
-    /// After that insertion, if `last_compaction_len` equals the CURRENT
-    /// entry count (i.e. this call is happening on the very turn
-    /// `maybe_compact` last fired on — the loop calls `maybe_compact` then
-    /// `to_messages` back-to-back before any further entries are appended),
-    /// the LAST `user`-role entry's message is cloned and appended again at
-    /// the very end — §5.4 item 3's "re-anchor the model" replay. On every
-    /// later call the entry count has grown past `last_compaction_len`, so
-    /// the replay does not repeat until compaction fires again. A
-    /// transcript with no `user` entry (never happens via `seed`, but
-    /// guarded rather than assumed) simply skips the replay.
+    /// (`super::compaction::summarize_span`'s one-line text, plus (#2346) a
+    /// "full detail in session memory (turns N-M)" pointer appended when any
+    /// entry in the span carries a `cadence_turn_range` — see
+    /// [`flush_span`]'s docs) in its place; uncompacted entries pass through
+    /// unchanged. (#2347) If `self.goals.render()` returns `Some`, a
+    /// synthetic `system`-role message carrying that text is inserted at
+    /// index `1` (immediately after the real system message, which
+    /// `Transcript::seed` always places at index `0` and `maybe_compact`
+    /// never touches) — or appended if `out` is empty, a defensive case that
+    /// never occurs via `seed`. A poisoned goals lock degrades to "no goals
+    /// block" rather than panicking (mirrors `run_task::recorder`'s
+    /// poisoned-lock convention). After that insertion, if
+    /// `last_compaction_len` equals the CURRENT entry count (i.e. this call
+    /// is happening on the very turn `maybe_compact` last fired on — the
+    /// loop calls `maybe_compact` then `to_messages` back-to-back before any
+    /// further entries are appended), the LAST `user`-role entry's message is
+    /// cloned and appended again at the very end — §5.4 item 3's "re-anchor
+    /// the model" replay. On every later call the entry count has grown past
+    /// `last_compaction_len`, so the replay does not repeat until compaction
+    /// fires again. A transcript with no `user` entry (never happens via
+    /// `seed`, but guarded rather than assumed) simply skips the replay.
     /// Test: `transcript::tests::to_messages_collapses_compacted_span`,
     /// `transcript::tests::to_messages_replays_last_user_message_after_compaction`,
     /// `transcript::tests::to_messages_does_not_replay_on_every_subsequent_turn`,
@@ -242,12 +273,14 @@ impl Transcript {
     /// `transcript::tests::to_messages_omits_goals_message_when_all_empty`,
     /// `transcript::tests::to_messages_goals_survive_aggressive_compaction`.
     pub fn to_messages(&self) -> Vec<ChatMessage> {
+        // #2347: `+ 1` accounts for the goals-injection message inserted
+        // below, so the common case never reallocates.
         let mut out = Vec::with_capacity(self.entries.len() + 1);
-        let mut compacted_span: Vec<ChatMessage> = Vec::new();
+        let mut compacted_span: Vec<(ChatMessage, Option<(usize, usize)>)> = Vec::new();
 
         for entry in &self.entries {
             if entry.compacted {
-                compacted_span.push(entry.message.clone());
+                compacted_span.push((entry.message.clone(), entry.cadence_turn_range));
                 continue;
             }
             flush_span(&mut out, &mut compacted_span);
@@ -315,17 +348,29 @@ impl Transcript {
         if !should_compact(&self.to_messages(), cfg) {
             return false;
         }
+        let keep_from = resolve_keep_from(&self.entries, cfg.keep_last_messages);
+        self.mark_compacted(keep_from, None)
+    }
 
-        let mut keep_from = self.entries.len().saturating_sub(cfg.keep_last_messages);
-        if keep_from > 0
-            && keep_from < self.entries.len()
-            && let Some(group_start) = turn_group_start(&self.entries, keep_from - 1)
-            && turn_group_end(&self.entries, group_start) >= keep_from
-        {
-            keep_from = group_start;
-        }
+    /// Mark every eligible entry before `keep_from` as `compacted`, tagging
+    /// each newly-marked entry with `cadence_range` (#2346).
+    ///
+    /// Why: [`Self::maybe_compact`] (threshold-triggered, no turn-range
+    /// concept) and the #2346 cadence compressor's
+    /// [`Self::compact_span_tagged`] both need to apply the EXACT same
+    /// pinned/`system`/`user`/already-compacted exemptions — this is the one
+    /// place that logic lives, so the two callers can never independently
+    /// drift.
+    /// What: For every entry in `self.entries[..keep_from]` that is not
+    /// already `compacted`, not `pinned`, and not `system`/`user` role, sets
+    /// `compacted = true` and `cadence_turn_range = cadence_range`. Records
+    /// `last_compaction_len` and returns whether anything was newly marked,
+    /// exactly as `maybe_compact` did before this extraction.
+    /// Test: `transcript::tests::maybe_compact_marks_middle_span_only` (via
+    /// `maybe_compact`); `transcript::tests::compact_span_tagged_*` (via the
+    /// cadence path).
+    fn mark_compacted(&mut self, keep_from: usize, cadence_range: Option<(usize, usize)>) -> bool {
         let mut newly_compacted = false;
-
         for entry in &mut self.entries[..keep_from] {
             if entry.compacted || entry.pinned {
                 continue;
@@ -334,13 +379,106 @@ impl Transcript {
                 continue;
             }
             entry.compacted = true;
+            entry.cadence_turn_range = cadence_range;
             newly_compacted = true;
         }
-
         if newly_compacted {
             self.last_compaction_len = Some(self.entries.len());
         }
         newly_compacted
+    }
+
+    /// Advance the cadence turn counter and report whether THIS turn is a
+    /// cadence-fire turn (#2346).
+    ///
+    /// Why: `agent_loop::cadence::maybe_cadence_compress` needs a
+    /// session-persistent counter (see [`Self::cadence_turn_count`]'s field
+    /// doc for why it lives on `Transcript`, not `AgentLoop`) it can advance
+    /// exactly once per turn boundary and compare against the configured
+    /// cadence.
+    /// What: Increments `cadence_turn_count`, then returns `true` when
+    /// `cadence_turns > 0` and the new count is an exact multiple of it —
+    /// `cadence_turns == 0` never fires (guards the modulo and treats "0" as
+    /// "cadence disabled" rather than firing every turn).
+    /// Test: `cadence::tests::fires_every_n_turns`.
+    pub(super) fn tick_cadence_turn(&mut self, cadence_turns: usize) -> bool {
+        self.cadence_turn_count += 1;
+        cadence_turns > 0 && self.cadence_turn_count.is_multiple_of(cadence_turns)
+    }
+
+    /// The turn range `(start, end)` a cadence compression happening RIGHT
+    /// NOW should be tagged with (#2346).
+    ///
+    /// Why: A span's "turns N-M" label (surfaced in the summary text via
+    /// [`flush_span`]) must cover every turn since the LAST fire, not just
+    /// the current one — otherwise a gap between fires would be
+    /// unaccounted-for in the durable-memory pointer.
+    /// What: `(cadence_last_fire_turn + 1, cadence_turn_count)`.
+    /// Test: `cadence::tests::summary_references_turn_range`.
+    pub(super) fn begin_cadence_range(&self) -> (usize, usize) {
+        (self.cadence_last_fire_turn + 1, self.cadence_turn_count)
+    }
+
+    /// Record that a cadence fire just happened (#2346).
+    ///
+    /// Why: [`Self::begin_cadence_range`]'s next call must start the range
+    /// right after this fire's end, and `cadence_fire_count` is the
+    /// "cadence fires exactly every N turns" test's observability hook.
+    /// What: Sets `cadence_last_fire_turn = cadence_turn_count` and
+    /// increments `cadence_fire_count`.
+    /// Test: `cadence::tests::fires_every_n_turns`.
+    pub(super) fn advance_cadence_fire_marker(&mut self) {
+        self.cadence_last_fire_turn = self.cadence_turn_count;
+        self.cadence_fire_count += 1;
+    }
+
+    /// Unconditionally compact the span older than `keep_last_messages`,
+    /// tagged with `cadence_range` — the #2346 cadence compressor's
+    /// entry point into the shared group-safe marking machinery.
+    ///
+    /// Why: Unlike [`Self::maybe_compact`], this is NEVER gated on a token
+    /// threshold — cadence fires on a turn-count schedule regardless of
+    /// current size, and the continuous-budget-enforcement loop
+    /// (`agent_loop::cadence::enforce_budget`) calls this repeatedly with a
+    /// shrinking `keep_last_messages` until the transcript is back under
+    /// budget. Reuses [`resolve_keep_from`] (#2278 group-safety) so a
+    /// cadence-triggered cutoff can never split a tool-call/tool-result pair
+    /// any more than the threshold path can.
+    /// What: Delegates to [`resolve_keep_from`] then [`Self::mark_compacted`]
+    /// with `Some(cadence_range)`.
+    /// Test: `cadence::tests::*`.
+    pub(super) fn compact_span_tagged(
+        &mut self,
+        keep_last_messages: usize,
+        cadence_range: (usize, usize),
+    ) -> bool {
+        let keep_from = resolve_keep_from(&self.entries, keep_last_messages);
+        self.mark_compacted(keep_from, Some(cadence_range))
+    }
+
+    /// Cumulative count of agent-loop turn boundaries observed (#2346).
+    ///
+    /// Why: Lives on `Transcript` (not `AgentLoop`, which is reconstructed
+    /// fresh on every `task.run` call — see `task::executor::run_and_record`)
+    /// so cadence counts turns CUMULATIVELY across a session's whole
+    /// lifetime, matching the epic's "500+ turn interactive session" framing
+    /// rather than resetting every call.
+    /// What: The current `cadence_turn_count`.
+    /// Test: `cadence::tests::fires_every_n_turns`.
+    pub fn cadence_turn_count(&self) -> usize {
+        self.cadence_turn_count
+    }
+
+    /// Number of times the cadence compressor has fired (#2346).
+    ///
+    /// Why: The turn-count test ("cadence fires exactly every N turns") and
+    /// the "compaction_events == 0" acceptance test both need an
+    /// observability counter distinct from `compacted_count` (entries, not
+    /// events).
+    /// What: The current `cadence_fire_count`.
+    /// Test: `cadence::tests::fires_every_n_turns`.
+    pub fn cadence_fire_count(&self) -> usize {
+        self.cadence_fire_count
     }
 
     /// Number of entries currently marked `compacted`.
@@ -434,6 +572,31 @@ impl Transcript {
     }
 }
 
+/// Compute the group-safe cutoff index for a naive `keep_last_messages`
+/// active-zone size (#2278 Fix A; extracted for #2346 so the cadence
+/// compressor shares this EXACT logic with [`Transcript::maybe_compact`]).
+///
+/// Why: A raw entry-count cutoff (`entries.len() - keep_last_messages`) has
+/// no tool-call awareness — see [`Transcript::maybe_compact`]'s docs for the
+/// Bedrock `ValidationException` this fixes. Both compaction callers
+/// (threshold and cadence) need the identical adjustment, so it is pulled out
+/// once rather than risking the two independently drifting.
+/// What: Computes the naive cutoff, then — if it falls strictly inside a
+/// [`turn_group_start`]/[`turn_group_end`] group — pulls it forward to the
+/// group's start. Returns the (possibly adjusted) cutoff.
+/// Test: `transcript::tests::maybe_compact_pulls_whole_multi_tool_call_group_forward`.
+fn resolve_keep_from(entries: &[TranscriptEntry], keep_last_messages: usize) -> usize {
+    let mut keep_from = entries.len().saturating_sub(keep_last_messages);
+    if keep_from > 0
+        && keep_from < entries.len()
+        && let Some(group_start) = turn_group_start(entries, keep_from - 1)
+        && turn_group_end(entries, group_start) >= keep_from
+    {
+        keep_from = group_start;
+    }
+    keep_from
+}
+
 /// If entry `idx` belongs to a turn group, return the group's assistant
 /// entry index (#2278 Fix A).
 ///
@@ -484,14 +647,41 @@ fn turn_group_end(entries: &[TranscriptEntry], group_start: usize) -> usize {
 /// Why: `to_messages` needs to collapse a contiguous run of compacted entries
 /// exactly once, whether the run ends because a non-compacted entry follows
 /// or because the entries list ended; sharing this helper avoids duplicating
-/// the "if non-empty, summarise and clear" logic at both call sites.
+/// the "if non-empty, summarise and clear" logic at both call sites. (#2346)
+/// A span produced by the cadence compressor carries a `cadence_turn_range`
+/// on each of its entries; appending a durable-memory pointer to the summary
+/// text (rather than inventing a second, cadence-specific summary format)
+/// keeps the deterministic `summarize_span` base identical for both
+/// compaction paths.
 /// What: If `span` is non-empty, pushes one `ChatMessage::system` carrying
-/// `summarize_span(span)`'s text, then clears `span`.
-fn flush_span(out: &mut Vec<ChatMessage>, span: &mut Vec<ChatMessage>) {
+/// `summarize_span`'s text over the span's messages, then — if any entry in
+/// the span carries a `cadence_turn_range` — appends
+/// `" — full detail preserved in session memory (turns {min}-{max}); use
+/// recall_session to retrieve"` using the min start / max end across all
+/// tagged entries in the span (a span can, in principle, straddle more than
+/// one cadence fire once the continuous-budget-enforcement loop has run more
+/// than once on the same turn). A span with no tagged entries (the threshold
+/// path, or #2070 pre-#2346 behaviour) gets no pointer appended — byte-
+/// identical to before this ticket. Clears `span` either way.
+/// Test: `transcript::tests::to_messages_collapses_compacted_span` (no
+/// pointer, threshold path unchanged); `cadence::tests::summary_references_turn_range`.
+fn flush_span(out: &mut Vec<ChatMessage>, span: &mut Vec<(ChatMessage, Option<(usize, usize)>)>) {
     if span.is_empty() {
         return;
     }
-    out.push(ChatMessage::system(summarize_span(span)));
+    let messages: Vec<ChatMessage> = span.iter().map(|(m, _)| m.clone()).collect();
+    let mut text = summarize_span(&messages);
+
+    let start = span.iter().filter_map(|(_, r)| r.map(|(s, _)| s)).min();
+    let end = span.iter().filter_map(|(_, r)| r.map(|(_, e)| e)).max();
+    if let (Some(start), Some(end)) = (start, end) {
+        text.push_str(&format!(
+            " — full detail preserved in session memory (turns {start}-{end}); \
+             use recall_session to retrieve"
+        ));
+    }
+
+    out.push(ChatMessage::system(text));
     span.clear();
 }
 

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -207,6 +207,13 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
             // struct-update `..AgentLoopConfig::default()` below must not be
             // allowed to silently supply the flat, model-blind default here.
             compaction: CompactionConfig::for_context_window(resolve_context_window(&pm_model)),
+            // #2346: `cadence` stays the `..AgentLoopConfig::default()` value
+            // (`None`) here, deliberately — the legacy one-shot/bake-off
+            // `run-task` CLI path is explicitly out of scope for the cadence
+            // compressor (epic #2343 scopes it to the daemon-driven,
+            // persistent-session path in `task::executor::run_and_record`
+            // only), so this run sees zero behaviour change from before
+            // #2346.
             ..AgentLoopConfig::default()
         },
         pm_llm,

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -364,6 +364,11 @@ impl InProcessAgentRunner {
             max_tokens,
             mode: self.mode,
             compaction,
+            // #2346: cadence stays disabled for the delegated sub-agent's own
+            // loop — the epic scopes cadence to the PM transcript only
+            // (`task::executor::run_and_record`'s persistent-session path);
+            // delegated engineer loops stay bounded/ephemeral per-delegation.
+            cadence: None,
         };
 
         // Assemble the mode-branched system prompt (BASE + agent prompt +

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -37,7 +37,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
-use crate::agent_loop::{AgentLoop, AgentLoopConfig, CompactionConfig, ToolEventSink};
+use crate::agent_loop::{
+    AgentLoop, AgentLoopConfig, CompactionConfig, ToolEventSink, resolve_cadence_config,
+};
 use crate::agents::AgentConfig;
 use crate::jsonrpc::RpcError;
 use crate::llm::{DebugCaptureSink, LlmClientTrait, wrap_with_debug_capture};
@@ -304,6 +306,15 @@ async fn run_and_record(
             // struct-update `..AgentLoopConfig::default()` below must not be
             // allowed to silently supply the flat, model-blind default here.
             compaction: CompactionConfig::for_context_window(resolve_context_window(&pm_model)),
+            // #2346: the cadence compressor is opt-in per `AgentLoopConfig`
+            // (defaults to `None`) — this daemon-driven, persistent-session
+            // PM loop is the ONE call site that enables it, resolved from
+            // this project's `.claude/settings.json`/env-var precedence
+            // chain (`resolve_cadence_config`). The delegated engineer's own
+            // loop (`build_engineer_runner` below) and `run_task`'s legacy
+            // one-shot/bake-off path both keep the default `None` — zero
+            // behaviour change there, per #2346's explicit scope.
+            cadence: Some(resolve_cadence_config(&params.project)),
             ..AgentLoopConfig::default()
         },
         pm_llm,

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -143,6 +143,42 @@ fn daily_driver_skills_catalog_none_when_no_skills_dir() {
     assert!(daily_driver_skills_catalog(&p).is_none());
 }
 
+/// A project's `.claude/settings.json` `code_harness.cadence_turns` override
+/// reaches `resolve_cadence_config` exactly the way `run_and_record` calls it
+/// (#2346) — the same `params.project` path a real `spawn_task_run` would use.
+///
+/// Why: #2346's acceptance criteria explicitly call for an integration-style
+/// proof that the settings.json precedence chain changes `cadence_turns`, not
+/// just a unit test isolated to `agent_loop::cadence`'s own module (see
+/// `cadence::tests::resolve_cadence_config_settings_json_override` for that
+/// unit-level coverage) — this test exercises the SAME `TaskRunParams.project`
+/// shape `run_and_record`'s `cadence: Some(resolve_cadence_config(&params.project))`
+/// wiring consumes.
+/// What: Build a project `TempDir` (via the same `params` helper every other
+/// executor test uses) with a `.claude/settings.json` overriding
+/// `cadence_turns` to `3`; assert `crate::agent_loop::resolve_cadence_config`
+/// against `p.project` returns `3`, not the built-in default of `8`.
+/// Test: this test.
+#[test]
+fn settings_json_cadence_turns_override_reaches_resolver() {
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+    std::fs::create_dir_all(project.path().join(".claude")).expect("mkdir .claude");
+    std::fs::write(
+        project.path().join(".claude").join("settings.json"),
+        r#"{"code_harness": {"cadence_turns": 3}}"#,
+    )
+    .expect("write settings.json");
+
+    let p = params(&agents, &project, "s");
+    let cfg = crate::agent_loop::resolve_cadence_config(&p.project);
+    assert_eq!(cfg.cadence_turns, 3);
+    assert_ne!(
+        cfg.cadence_turns,
+        crate::agent_loop::CadenceConfig::default().cadence_turns
+    );
+}
+
 /// `daily_driver_skills_catalog` returns the rendered catalog + a working
 /// resolver under `HarnessMode::DailyDriver` when skills exist.
 #[test]


### PR DESCRIPTION
## Summary

Implements #2346 (ticket 3 of epic #2343 "Infinite Sessions"): a proactive, turn-count-driven compressor that keeps the PM's working context under a fixed overhead budget at all times, so the existing threshold compactor (#2308) becomes a backstop rather than the primary token-efficiency mechanism.

**Budget arithmetic:** `overhead_cap = context_window * max_overhead_fraction_pct / 100`. On a 200K-token window at the default 40%, that's an 80K overhead cap / 120K working floor. Defaults: `cadence_turns = 8`, `max_overhead_fraction_pct = 40` (both epic-specified).

**Design:**
- New `agent_loop::cadence` module: `CadenceConfig` + `resolve_cadence_config` (env var > `.claude/settings.json` `code_harness.cadence_turns`/`code_harness.max_overhead_fraction_pct` > built-in default — mirrors `mode.rs`'s precedence convention, minus a task-param tier since this ticket doesn't add one to the wire protocol).
- `Transcript` gains a session-persistent cadence turn counter (lives on `Transcript`, not `AgentLoop`, so it counts cumulatively across repeated `task.run` calls on the same session). The existing #2278 group-safe / pinned / `system`/`user`-exempt marking logic was extracted into shared `resolve_keep_from`/`mark_compacted` primitives and reused verbatim by both the threshold and cadence paths — no reimplementation of group safety.
- **Continuous budget enforcement**: every turn boundary, after any scheduled cadence fire, a small hard-bounded loop keeps shrinking the protected active zone and re-compacting until `estimate_total_tokens(to_messages())` is back under the cap or nothing compactable remains (logs a warning and returns, never panics or loops forever, on that documented floor — e.g. an oversized `system`/`user` seed alone).
- Cadence-compacted summaries append a durable-memory pointer ("full detail preserved in session memory (turns N-M); use recall_session to retrieve") reusing #2345's per-turn dual-write; threshold-only summaries are byte-unchanged.
- Wired at the same turn boundary as `maybe_compact_transcript`, cadence FIRST, threshold backstop after — gated on `HarnessMode::DailyDriver` AND an explicit per-run opt-in (`AgentLoopConfig.cadence: Option<CadenceConfig>`, default `None`). Only `task::executor::run_and_record`'s persistent-session PM loop opts in via `resolve_cadence_config(&params.project)`; the delegated engineer's own loop (`runner/in_process.rs`) and `run_task`'s legacy one-shot/bake-off path explicitly stay `None` — zero behaviour change there.

**LLM vs. deterministic summary (explicit design decision):** the epic's prose says "LLM auto-compresses history", but wiring a synchronous `LlmClientTrait::chat` call into this turn boundary would make cadence's own summarisation step a new network-dependent failure mode, for a mechanism whose entire point is robustness. Per the ticket's own guidance ("do NOT block the epic on perfect summarization"), this ships the deterministic `summarize_span` fallback now, with the summary pointing at the durable memory record. An LLM-generated abstractive summary is the natural follow-up once `AgentLoop` exposes a clean async hook at this boundary — flagged for #2349/#2350.

**Mid-work rebase:** PR #2367 (#2347 goal slots) merged to main while this was in flight. Rebased onto `origin/main` (`4b95ccc4`); the only conflict was in `transcript.rs` — both changes added new `Transcript` fields/doc text in the same spots (goals's `Arc<Mutex<GoalSlots>>` + this ticket's three cadence counters), resolved by keeping both additively. The goals injection renders fresh into `to_messages()` at position `[1]` and is never a stored `TranscriptEntry`, so this ticket's raw-entry-based compression (`self.entries`, `messages()`) never touches it by construction — confirmed by the full post-rebase test run below (`to_messages_injects_goals_at_position_one` et al. still pass unchanged).

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-code` — 814 lib tests + all integration suites pass
- [x] `cargo test --workspace` — every crate reports 0 failed (no isolate-verify needed; the flagged flaky suites — trusty-console, trusty-agents `telegram_pid_guard` — passed in this run)
- [x] `cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations`
- [x] Scripted 100-turn / 5K-token-worst-case-turn acceptance test: `compaction_events == 0` AND `estimate_total_tokens(to_messages()) <= overhead_cap` on every turn (`cadence::tests::stays_under_budget_every_turn_and_threshold_never_fires`)
- [x] Cadence fires exactly every N turns, N=3 override (`cadence::tests::fires_every_n_turns`)
- [x] Adversarial cadence-boundary-mid-tool-call-group case (`cadence::tests::cadence_boundary_never_splits_a_tool_call_group`)
- [x] Single 60K-token turn still ends under budget after enforcement (`cadence::tests::single_oversized_turn_still_ends_under_budget`)
- [x] Documented floor warns, doesn't panic/loop forever (`cadence::tests::floor_exceeded_warns_not_panics`)
- [x] Summary text references the durable memory turn range (`cadence::tests::summary_references_turn_range`)
- [x] Parity + run_task path zero behaviour change (`agent_loop::tests::cadence_never_fires_in_parity_mode`, `cadence_disabled_by_default`; `run_task`'s existing suite unaffected)
- [x] settings.json override reaches `cadence_turns` (`cadence::tests::resolve_cadence_config_settings_json_override`, `task::executor::tests::settings_json_cadence_turns_override_reaches_resolver`)

Closes #2346
Part of epic #2343

🤖 Generated with [Claude Code](https://claude.com/claude-code)