### PR TITLE
feat(trusty-code): threshold compaction becomes a never-event regression signal

### DIFF
--- a/crates/trusty-code/src/agent_loop/cadence_tests.rs
+++ b/crates/trusty-code/src/agent_loop/cadence_tests.rs
@@ -143,7 +143,10 @@ fn fires_every_n_turns() {
 
 /// The core #2346 acceptance test: a 100-turn run of 5K-token worst-case
 /// turns never triggers the threshold compactor and never exceeds the
-/// overhead cap on any turn.
+/// overhead cap on any turn. (#2349) Also the epic #2343 success-metric
+/// proof: `Transcript::compaction_events()` — the SAME counter
+/// `agent_loop::AgentLoop::maybe_compact_transcript` increments in
+/// production — stays `0` for the whole steady-state run.
 #[test]
 fn stays_under_budget_every_turn_and_threshold_never_fires() {
     let mut t = Transcript::seed("s", "task");
@@ -153,16 +156,16 @@ fn stays_under_budget_every_turn_and_threshold_never_fires() {
     let compaction_cfg = CompactionConfig::for_context_window(context_window);
     let keep_last_messages = compaction_cfg.keep_last_messages;
 
-    let mut compaction_events = 0usize;
     for turn in 1..=100 {
         push_sized_turn(&mut t, turn, 5_000);
         maybe_cadence_compress(&mut t, &cadence_cfg, keep_last_messages, context_window);
 
         // The threshold compactor is the backstop — cadence must keep the
         // transcript under its own (looser, 75%-of-window) trigger point on
-        // every single turn.
+        // every single turn. Mirrors the real call site's
+        // `record_threshold_compaction` on every actual fire.
         if t.maybe_compact(&compaction_cfg) {
-            compaction_events += 1;
+            t.record_threshold_compaction();
         }
 
         let estimate = estimate_total_tokens(&t.to_messages());
@@ -173,7 +176,8 @@ fn stays_under_budget_every_turn_and_threshold_never_fires() {
     }
 
     assert_eq!(
-        compaction_events, 0,
+        t.compaction_events(),
+        0,
         "threshold compaction must never fire under cadence's continuous enforcement"
     );
 }

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -620,14 +620,49 @@ impl AgentLoop {
     /// compacting would silently change what a Parity run sends after enough
     /// turns, breaking that guarantee. `HarnessMode::DailyDriver` is
     /// production's token-efficiency mode, so it is the only mode this method
-    /// ever calls `Transcript::maybe_compact` for.
+    /// ever calls `Transcript::maybe_compact` for. (#2349, epic #2343) Under
+    /// the #2346 cadence system a threshold fire is no longer expected in
+    /// steady state — it means cadence sizing / daemon-availability /
+    /// turn-size assumptions were violated — so this is also where that
+    /// regression signal is raised. Cadence-DISABLED contexts (`run_task`
+    /// one-shot, `Parity`, delegated sub-agent engineer loops — all
+    /// `cadence: None`) still use threshold compaction as their PRIMARY,
+    /// EXPECTED mechanism, so the error-level framing below must never apply
+    /// to them.
     /// What: No-op under `HarnessMode::Parity`; under `HarnessMode::DailyDriver`,
-    /// delegates to `transcript.maybe_compact(&self.config.compaction)`.
+    /// delegates to `transcript.maybe_compact(&self.config.compaction)`. When
+    /// that returns `true` (a fire actually happened), unconditionally calls
+    /// `transcript.record_threshold_compaction()` (#2349's fact counter,
+    /// exposed via `session::TranscriptRecord.compaction_events` —
+    /// increments regardless of cadence), then — ONLY when
+    /// `self.config.cadence.is_some()` — emits `tracing::error!` with the
+    /// current estimated token count, the configured `token_threshold`, and
+    /// `cadence_enabled = true` for context. `cadence: None` keeps today's
+    /// existing behaviour exactly as it was before this ticket: no log at
+    /// this call site at all.
     /// Test: `agent_loop::tests::daily_driver_mode_compacts_long_running_loop`,
-    /// `agent_loop::tests::parity_mode_never_compacts_even_past_threshold`.
+    /// `agent_loop::tests::parity_mode_never_compacts_even_past_threshold`,
+    /// `agent_loop::tests::forced_degradation_increments_counter_and_logs_error`,
+    /// `agent_loop::tests::cadence_none_threshold_fire_does_not_log_error`.
     fn maybe_compact_transcript(&self, transcript: &mut Transcript) {
-        if self.config.mode == HarnessMode::DailyDriver {
-            transcript.maybe_compact(&self.config.compaction);
+        if self.config.mode != HarnessMode::DailyDriver {
+            return;
+        }
+        if !transcript.maybe_compact(&self.config.compaction) {
+            return;
+        }
+        transcript.record_threshold_compaction();
+
+        if self.config.cadence.is_some() {
+            let estimated_tokens = compaction::estimate_total_tokens(&transcript.to_messages());
+            tracing::error!(
+                estimated_tokens,
+                token_threshold = self.config.compaction.token_threshold,
+                cadence_enabled = true,
+                "threshold compaction fired unexpectedly under cadence — this is a regression \
+                 signal: cadence sizing, daemon availability, or turn-size assumptions were \
+                 likely violated (epic #2343 expects compaction_events == 0 in steady state)"
+            );
         }
     }
 

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -812,6 +812,195 @@ async fn cadence_fires_in_daily_driver_when_configured() {
     );
 }
 
+// ── #2349: threshold compaction becomes a never-event regression signal ────
+//
+// Why: no reusable tracing-capture test utility exists elsewhere in this
+// crate — `trusty_common::error_capture::layer::BugCaptureLayer` is the
+// closest prior art (same "tap ERROR events via a `tracing_subscriber::Layer`"
+// shape) but is feature-gated behind `bug-capture` and pulls in a
+// fingerprinting/store stack this test has no use for. A small test-local
+// layer mirroring its shape is simpler than wiring that feature in for one
+// assertion.
+// What: `ErrorCaptureLayer` records every ERROR-level event's `message`
+// field into a shared `Arc<Mutex<Vec<String>>>`; `install_error_capture`
+// installs it as the thread's default subscriber (mirrors
+// `trusty_common::error_capture::layer::tests`'s identical
+// `tracing::subscriber::with_default`/`set_default` pattern) for the
+// duration of the returned guard.
+struct ErrorCaptureLayer {
+    messages: Arc<Mutex<Vec<String>>>,
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for ErrorCaptureLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if *event.metadata().level() != tracing::Level::ERROR {
+            return;
+        }
+        struct MessageVisitor(String);
+        impl tracing::field::Visit for MessageVisitor {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.0 = format!("{value:?}");
+                }
+            }
+        }
+        let mut visitor = MessageVisitor(String::new());
+        event.record(&mut visitor);
+        self.messages.lock().expect("lock").push(visitor.0);
+    }
+}
+
+/// Install an [`ErrorCaptureLayer`] as this thread's default subscriber.
+///
+/// Why: `#[tokio::test]` defaults to the current-thread runtime, so a
+/// `tracing::subscriber::set_default` guard held for the test body's
+/// lifetime (including across `.await` points) captures every ERROR event
+/// the awaited future emits on this thread — no need for `with_default`'s
+/// synchronous-closure shape.
+/// What: Returns the `DefaultGuard` (drop it to restore the prior
+/// subscriber) plus the shared message buffer.
+fn install_error_capture() -> (tracing::subscriber::DefaultGuard, Arc<Mutex<Vec<String>>>) {
+    use tracing_subscriber::layer::SubscriberExt as _;
+    let messages = Arc::new(Mutex::new(Vec::new()));
+    let layer = ErrorCaptureLayer {
+        messages: messages.clone(),
+    };
+    let subscriber = tracing_subscriber::registry().with(layer);
+    (tracing::subscriber::set_default(subscriber), messages)
+}
+
+/// A `CadenceConfig` present (cadence enabled) but sized so it never
+/// actually schedules a fire, forcing the aggressive threshold compactor to
+/// trip anyway — the "cadence sizing assumptions violated" forced-
+/// degradation scenario #2349's acceptance criteria call for.
+fn overwhelmed_cadence() -> CadenceConfig {
+    CadenceConfig {
+        cadence_turns: 1_000_000, // never a scheduled-fire turn in this test
+        max_overhead_fraction_pct: 99,
+    }
+}
+
+/// Forced-degradation acceptance test: cadence is enabled but never actually
+/// schedules a fire (`overwhelmed_cadence`), while `aggressive_compaction`'s
+/// `token_threshold: 1` trips the #2308 threshold compactor on the very
+/// first turn boundary. This must increment
+/// `Transcript::compaction_events()` AND emit an ERROR-level log — the
+/// "cadence sizing / daemon-availability / turn-size assumptions violated"
+/// regression signal.
+///
+/// Why: This is #2349's core acceptance criterion — proving the signal
+/// actually fires end-to-end through `AgentLoop::maybe_compact_transcript`,
+/// not just at the `Transcript` unit level.
+/// What: Runs a 3-tool-call-then-stop script under `mode: DailyDriver` with
+/// both `compaction: aggressive_compaction()` and
+/// `cadence: Some(overwhelmed_cadence())` attached. Asserts
+/// `transcript.compaction_events() > 0` and that the captured ERROR-level
+/// log messages contain the expected "regression signal" text.
+/// Test: this test.
+#[tokio::test]
+async fn forced_degradation_increments_counter_and_logs_error() {
+    let (_guard, captured) = install_error_capture();
+
+    let mut fixtures: Vec<Value> = (0..3)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm,
+        registry,
+        AgentLoopConfig {
+            max_turns: 10,
+            mode: crate::mode::HarnessMode::DailyDriver,
+            compaction: aggressive_compaction(),
+            cadence: Some(overwhelmed_cadence()),
+            ..AgentLoopConfig::default()
+        },
+    );
+    let mut transcript = Transcript::seed("system prompt", "the task");
+    agent
+        .run_with_transcript(&mut transcript, "the task")
+        .await
+        .expect("run completes");
+
+    drop(_guard);
+
+    assert!(
+        transcript.compaction_events() > 0,
+        "threshold compaction should have fired at least once under the tiny token_threshold"
+    );
+    let messages = captured.lock().expect("lock");
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("regression signal") && m.contains("cadence")),
+        "expected an error-level regression-signal log, got: {messages:?}"
+    );
+}
+
+/// The cadence-`None` counterpart: threshold compaction firing is the
+/// PRIMARY, EXPECTED mechanism for `run_task` one-shot / Parity / delegated
+/// sub-agent contexts (all `cadence: None`) — it must NOT emit an
+/// error-level log, and today's existing (no-log) behaviour at this call
+/// site must stay exactly as it was before this ticket.
+///
+/// Why: §3 of the ticket's semantics is explicit that the error-log framing
+/// applies ONLY when `cadence.is_some()` — this is the negative-case guard
+/// against that gate regressing to "always log" or "log regardless of
+/// cadence".
+/// What: Identical script and `aggressive_compaction` to
+/// `forced_degradation_increments_counter_and_logs_error`, but
+/// `cadence: None` (the default). Asserts `compaction_events() > 0` (the
+/// counter itself is NOT cadence-gated) while the captured ERROR log list is
+/// empty.
+/// Test: this test.
+#[tokio::test]
+async fn cadence_none_threshold_fire_does_not_log_error() {
+    let (_guard, captured) = install_error_capture();
+
+    let mut fixtures: Vec<Value> = (0..3)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm,
+        registry,
+        AgentLoopConfig {
+            max_turns: 10,
+            mode: crate::mode::HarnessMode::DailyDriver,
+            compaction: aggressive_compaction(),
+            cadence: None,
+            ..AgentLoopConfig::default()
+        },
+    );
+    let mut transcript = Transcript::seed("system prompt", "the task");
+    agent
+        .run_with_transcript(&mut transcript, "the task")
+        .await
+        .expect("run completes");
+
+    drop(_guard);
+
+    assert!(
+        transcript.compaction_events() > 0,
+        "the counter itself must still increment regardless of cadence"
+    );
+    let messages = captured.lock().expect("lock");
+    assert!(
+        messages.is_empty(),
+        "cadence: None must never emit the error-level regression signal, got: {messages:?}"
+    );
+}
+
 /// The FULL parity conformance check tying the model-routing layer to the
 /// compaction layer (#2073, the "M2 integration" proof §5.9 asks for): two
 /// `HarnessMode::Parity` runs over the identical script, registry, and

--- a/crates/trusty-code/src/agent_loop/transcript.rs
+++ b/crates/trusty-code/src/agent_loop/transcript.rs
@@ -136,6 +136,15 @@ pub struct Transcript {
     /// least one new entry `compacted`) — an observability/test counter,
     /// distinct from `compacted_count` (which counts entries, not events).
     cadence_fire_count: usize,
+    /// (#2349) Number of times the #2308 threshold compactor
+    /// (`Self::maybe_compact`) has actually fired — i.e. returned `true` —
+    /// cumulative for the transcript's entire lifetime, mirroring
+    /// `cadence_fire_count`'s same "events, not entries" accounting. Under
+    /// epic #2343's cadence system this is meant to stay `0` in steady state
+    /// (see [`Self::record_threshold_compaction`]'s docs); exposed
+    /// read-only via [`Self::compaction_events`] and, from there, onto
+    /// `session::TranscriptRecord.compaction_events`.
+    threshold_compaction_events: u32,
 }
 
 impl Transcript {
@@ -160,6 +169,7 @@ impl Transcript {
             cadence_turn_count: 0,
             cadence_last_fire_turn: 0,
             cadence_fire_count: 0,
+            threshold_compaction_events: 0,
         }
     }
 
@@ -479,6 +489,41 @@ impl Transcript {
     /// Test: `cadence::tests::fires_every_n_turns`.
     pub fn cadence_fire_count(&self) -> usize {
         self.cadence_fire_count
+    }
+
+    /// Record that the #2308 threshold compactor (`Self::maybe_compact`)
+    /// actually fired on this call (#2349, epic #2343).
+    ///
+    /// Why: Under the #2346 cadence system, a threshold fire is no longer
+    /// the primary token-efficiency mechanism (cadence is) — it becomes a
+    /// never-event regression signal that cadence sizing, daemon
+    /// availability, or turn-size assumptions were violated. The call site
+    /// (`agent_loop::AgentLoop::maybe_compact_transcript`) increments this
+    /// on EVERY threshold fire regardless of whether cadence is enabled —
+    /// see that method's docs for why the *logging* half of this signal is
+    /// cadence-gated while the counter itself is not. `pub(crate)` (rather
+    /// than `pub(super)`) so `session::registry_tests` can exercise the
+    /// `session.get_transcript` wiring end-to-end without going through a
+    /// full `AgentLoop` run.
+    /// What: Saturating-increments `threshold_compaction_events` by one.
+    /// Test: `agent_loop::tests::forced_degradation_increments_counter_and_logs_error`,
+    /// `agent_loop::tests::cadence_none_threshold_fire_does_not_log_error`,
+    /// `registry_tests::get_transcript_reports_compaction_events`.
+    pub(crate) fn record_threshold_compaction(&mut self) {
+        self.threshold_compaction_events = self.threshold_compaction_events.saturating_add(1);
+    }
+
+    /// Cumulative count of #2308 threshold-compactor fires (#2349).
+    ///
+    /// Why: The epic #2343 success metric is a "500+ turn session with
+    /// `compaction_events == 0`" — this is the field that metric reads,
+    /// exposed onto `session::TranscriptRecord.compaction_events` via
+    /// `SessionRegistry::get_transcript`.
+    /// What: The current `threshold_compaction_events`.
+    /// Test: `agent_loop::tests::forced_degradation_increments_counter_and_logs_error`,
+    /// `cadence_tests::stays_under_budget_every_turn_and_threshold_never_fires`.
+    pub fn compaction_events(&self) -> u32 {
+        self.threshold_compaction_events
     }
 
     /// Number of entries currently marked `compacted`.

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -251,6 +251,7 @@ mod tests {
             usage: TokenUsage::new(10, 5, 0, 0),
             cost_usd: Some(0.01),
             mode: Some(crate::mode::HarnessMode::DailyDriver),
+            compaction_events: 0,
         };
         let out = render_transcript_human(&record);
         assert!(out.contains("pm"));
@@ -267,6 +268,7 @@ mod tests {
             usage: TokenUsage::default(),
             cost_usd: None,
             mode: None,
+            compaction_events: 0,
         };
         let out = render_transcript_human(&record);
         assert!(out.contains("s-1"));

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -703,10 +703,13 @@ impl SessionRegistry {
     /// What: `Err(session_not_found)` if `id` is unknown; otherwise a clone of
     /// whatever is currently stored, wrapped in a self-describing
     /// [`TranscriptRecord`]. Never recomputes cost or usage — exposes exactly
-    /// what [`Self::set_run_outcome`] last stored.
+    /// what [`Self::set_run_outcome`] last stored. `compaction_events` (#2349)
+    /// reads `entry.pm_transcript`'s own cumulative counter — `0` when the
+    /// session has never run (`pm_transcript` still `None`).
     /// Test: `registry_tests::get_transcript_returns_stored_record`,
     /// `registry_tests::get_transcript_on_never_run_session_is_empty`,
-    /// `registry_tests::get_transcript_unknown_session_errors`.
+    /// `registry_tests::get_transcript_unknown_session_errors`,
+    /// `registry_tests::get_transcript_reports_compaction_events`.
     pub fn get_transcript(&self, id: &str) -> Result<TranscriptRecord, RpcError> {
         let sessions = self.lock();
         let entry = sessions
@@ -718,6 +721,11 @@ impl SessionRegistry {
             usage: entry.usage,
             cost_usd: entry.cost_usd,
             mode: entry.session.mode,
+            compaction_events: entry
+                .pm_transcript
+                .as_ref()
+                .map(Transcript::compaction_events)
+                .unwrap_or(0),
         })
     }
 

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -818,6 +818,37 @@ async fn get_transcript_unknown_session_errors() {
     assert_eq!(err.code, -32007);
 }
 
+/// `get_transcript` surfaces `pm_transcript`'s own cumulative
+/// `compaction_events` counter (#2349) — proving the one-line wiring in
+/// `Self::get_transcript` actually reads the stored transcript rather than
+/// always defaulting to `0`.
+///
+/// Why: `Transcript::record_threshold_compaction` is only ever called in
+/// production from `agent_loop::AgentLoop::maybe_compact_transcript`
+/// (exercised end-to-end by `agent_loop::tests::forced_degradation_*`); this
+/// test isolates the SEPARATE registry-level contract — that whatever count
+/// `pm_transcript` carries flows through `get_transcript` unchanged.
+/// What: Seeds a `pm_transcript` via `begin_pm_transcript`, increments its
+/// counter directly (the `pub(crate)` visibility this ticket adds exists
+/// exactly for this), stores it back via `store_pm_transcript`, then asserts
+/// `get_transcript(id).compaction_events` reflects it.
+/// Test: this test.
+#[tokio::test]
+async fn get_transcript_reports_compaction_events() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+
+    let mut transcript = registry
+        .begin_pm_transcript(&session.id, "you are the pm", "first task")
+        .unwrap();
+    transcript.record_threshold_compaction();
+    transcript.record_threshold_compaction();
+    registry.store_pm_transcript(&session.id, transcript);
+
+    let stored = registry.get_transcript(&session.id).unwrap();
+    assert_eq!(stored.compaction_events, 2);
+}
+
 /// `set_mode` must store the mode on the session, queryable both via
 /// `status`/`list` (`Session.mode`) and `get_transcript`
 /// (`TranscriptRecord.mode`, the SAME field) (#2059).

--- a/crates/trusty-code/src/session/transcript.rs
+++ b/crates/trusty-code/src/session/transcript.rs
@@ -21,7 +21,10 @@
 //! run a task returns `turns: []`, `usage` all-zero, `cost_usd: null` — a
 //! valid, empty transcript, not an error. `mode` (#2059) is the resolved
 //! `HarnessMode` `task.run` set via `SessionRegistry::set_mode` — `None` for
-//! the same "never run" case.
+//! the same "never run" case. `compaction_events` (#2349, epic #2343) is the
+//! session's `pm_transcript`'s cumulative count of #2308 threshold-compactor
+//! fires — `0` for a never-run session, and the field epic #2343's success
+//! metric ("500+ turn session with `compaction_events == 0`") reads.
 //! Test: `session::registry_tests::get_transcript_*`.
 
 use serde::{Deserialize, Serialize};
@@ -41,9 +44,13 @@ use crate::run_task::TurnRecord;
 /// method already takes `session_id` as a param, but echoing it back keeps
 /// the result self-contained for a caller inspecting the JSON alone).
 /// `mode` (#2059) mirrors `Session.mode` — the same field, read at
-/// `get_transcript` time.
+/// `get_transcript` time. `compaction_events` (#2349) mirrors
+/// `agent_loop::Transcript::compaction_events()` on the session's
+/// `pm_transcript` — `0` when that transcript has never fired the #2308
+/// threshold compactor, or the session has never run.
 /// Test: `session::registry_tests::get_transcript_returns_stored_record`,
-/// `session::registry_tests::get_transcript_on_never_run_session_is_empty`.
+/// `session::registry_tests::get_transcript_on_never_run_session_is_empty`,
+/// `session::registry_tests::get_transcript_reports_compaction_events`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptRecord {
     pub session_id: String,
@@ -51,4 +58,33 @@ pub struct TranscriptRecord {
     pub usage: TokenUsage,
     pub cost_usd: Option<f64>,
     pub mode: Option<HarnessMode>,
+    pub compaction_events: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// (#2349) `compaction_events` must round-trip through JSON exactly like
+    /// every other field — this is the wire contract every
+    /// `session.get_transcript` caller (the CLI thin client, external RPC
+    /// clients) relies on.
+    #[test]
+    fn compaction_events_round_trips_through_json() {
+        let record = TranscriptRecord {
+            session_id: "s-1".to_string(),
+            turns: vec![],
+            usage: TokenUsage::default(),
+            cost_usd: None,
+            mode: None,
+            compaction_events: 7,
+        };
+
+        let json = serde_json::to_value(&record).expect("serialize");
+        assert_eq!(json["compaction_events"], 7);
+
+        let round_tripped: TranscriptRecord =
+            serde_json::from_value(json).expect("deserialize");
+        assert_eq!(round_tripped.compaction_events, 7);
+    }
 }

--- a/crates/trusty-code/src/session/transcript.rs
+++ b/crates/trusty-code/src/session/transcript.rs
@@ -83,8 +83,7 @@ mod tests {
         let json = serde_json::to_value(&record).expect("serialize");
         assert_eq!(json["compaction_events"], 7);
 
-        let round_tripped: TranscriptRecord =
-            serde_json::from_value(json).expect("deserialize");
+        let round_tripped: TranscriptRecord = serde_json::from_value(json).expect("deserialize");
         assert_eq!(round_tripped.compaction_events, 7);
     }
 }


### PR DESCRIPTION
## Stacked PR — base is NOT main

This PR is **stacked on #2375** (`feat/tcode-cadence-compressor-2346`, the #2346 cadence compressor), which is still OPEN/unmerged at the time this PR was opened. The base branch is deliberately `feat/tcode-cadence-compressor-2346`, not `main`. Rebase onto `main` and retarget once #2375 merges.

## Scope

Ticket 6 of epic #2343 (Infinite Sessions), Size S. Depends on #2346 (cadence compressor).

Wraps the #2308 threshold compactor's call site (`AgentLoop::maybe_compact_transcript` in `crates/trusty-code/src/agent_loop/mod.rs`):

- On every fire (`Transcript::maybe_compact` returns `true`), increments a new cumulative `Transcript::compaction_events` counter (`crates/trusty-code/src/agent_loop/transcript.rs`) — **unconditionally**, regardless of cadence.
- **Only when `self.config.cadence.is_some()`** (cadence enabled but the threshold backstop still fired anyway), emits `tracing::error!` with `estimated_tokens`, `token_threshold`, and `cadence_enabled = true` — framed as a regression signal ("cadence sizing / daemon-availability / turn-size assumptions were likely violated").
- When `cadence` is `None` (the `run_task` one-shot path, `Parity` mode, delegated sub-agent engineer loops — where threshold compaction is the PRIMARY, expected mechanism), the call site's behavior is **unchanged from before this ticket** — there was no log at this call site previously, and there still isn't one. Only the counter increments.

Exposes the counter externally: `TranscriptRecord.compaction_events: u32` (`crates/trusty-code/src/session/transcript.rs`, my ONE additive field per the coordination note with #2350), wired through `SessionRegistry::get_transcript` (`crates/trusty-code/src/session/registry.rs`) from the session's `pm_transcript`.

`perf/mod.rs` was checked for an existing telemetry seam per the ticket's guidance — it's a per-run phase/token-usage collector with no natural home for a session-persistent counter without new plumbing, so (per the ticket's explicit "don't build new telemetry infra for an S ticket" instruction) it was left untouched.

## Cadence-gated error-log semantics

| Context | `cadence` | Threshold fire | Counter | Log |
|---|---|---|---|---|
| `run_task` one-shot / Parity / delegated sub-agent | `None` | Expected, normal | increments | **unchanged** — no log (same as before this ticket) |
| Persistent-session PM loop under cadence | `Some(_)` | Unexpected — regression | increments | `tracing::error!` — regression signal |

## Tests added

- `agent_loop::tests::forced_degradation_increments_counter_and_logs_error` — cadence enabled but sized so it never schedules a fire (`cadence_turns: 1_000_000`) while an aggressive `CompactionConfig` (`token_threshold: 1`) trips the threshold compactor anyway. Asserts the counter increments and an ERROR-level log matching the regression-signal text was emitted, captured via a small test-local `tracing_subscriber::Layer` (no reusable tracing-capture pattern existed elsewhere in the crate; the closest prior art, `trusty_common::error_capture::BugCaptureLayer`, is feature-gated and pulls in a fingerprinting store not needed here — a minimal layer mirroring its shape was simpler than wiring that feature in).
- `agent_loop::tests::cadence_none_threshold_fire_does_not_log_error` — same forced-degradation script but `cadence: None`. Asserts the counter still increments but the captured error-log list is empty.
- `session::transcript::tests::compaction_events_round_trips_through_json` — `TranscriptRecord`-level serde round-trip.
- `registry_tests::get_transcript_reports_compaction_events` — end-to-end registry wiring: seeds a `pm_transcript`, increments its counter, stores it back, asserts `get_transcript` surfaces the count.
- Adapted `cadence::tests::stays_under_budget_every_turn_and_threshold_never_fires` (the existing #2346 100-turn steady-state acceptance test) to assert `Transcript::compaction_events() == 0` throughout, using the SAME counter the real call site increments, rather than a local test-only tally.

## Test evidence

```
cargo test -p trusty-code
...
test result: ok. 818 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 1.15s
... (unit + 5 integration test binaries, all "ok")
```

```
cargo test --workspace
... 124 test-result blocks, all "ok" — zero failures anywhere in the workspace,
including trusty-console and trusty-agents (no pre-existing flakes triggered this run).
```

```
cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 25s   (clean, zero lint errors)
```

```
cargo fmt --check
(exit 0, no diff)
```

```
bash scripts/check_line_cap.sh
line-cap: 0 allowlisted, 0 violations — OK.
```

Closes #2349
Part of epic #2343

🤖 Generated with [Claude Code](https://claude.com/claude-code)