### PR TITLE
feat(trusty-code): infinite-sessions API surface — session.set_goal/get_goals, TranscriptRecord.goals

### DIFF
--- a/crates/trusty-code/src/agent_loop/cadence_tests.rs
+++ b/crates/trusty-code/src/agent_loop/cadence_tests.rs
@@ -111,6 +111,66 @@ async fn resolve_cadence_config_env_wins_over_settings_json() {
     .await;
 }
 
+/// #2350 acceptance criterion: a `.claude/settings.json` `code_harness.*`
+/// override changes cadence BEHAVIOUR end-to-end, not just the resolved
+/// config VALUE — extends `resolve_cadence_config_settings_json_override`
+/// (which only asserts the resolved struct's fields) and
+/// `task::executor::tests::settings_json_cadence_turns_override_reaches_resolver`
+/// (which proves the resolver reads the same `TaskRunParams.project` path a
+/// real `task.run` uses) one step further by actually driving
+/// `maybe_cadence_compress` with the resolved config and observing a
+/// DIFFERENT fire schedule than the built-in default would have produced.
+///
+/// Why: #2346 wired the settings.json -> `CadenceConfig` precedence chain;
+/// this ticket (#2350) is what plugs that resolved config into the session
+/// path's actual turn-boundary behaviour. Proving only that the config VALUE
+/// changes would miss a wiring bug where the resolved config is computed but
+/// never actually passed to `maybe_cadence_compress`.
+/// What: A project's `.claude/settings.json` sets `cadence_turns: 3`. Feed
+/// `resolve_cadence_config(project.path())`'s result into
+/// `maybe_cadence_compress` across 4 turns: with the override, cadence must
+/// have fired once (at turn 3) by turn 4. A second transcript run with the
+/// BUILT-IN DEFAULT (`cadence_turns: 8`) over the same 4 turns must NOT have
+/// fired at all — proving the settings.json override is what changed the
+/// observed behaviour, not some incidental default.
+/// Test: this test.
+#[test]
+fn settings_json_cadence_turns_override_changes_fire_schedule_end_to_end() {
+    let project = project_with_settings(Some(r#"{"code_harness": {"cadence_turns": 3}}"#));
+    let overridden_cfg = resolve_cadence_config(project.path());
+    assert_eq!(overridden_cfg.cadence_turns, 3);
+
+    let context_window = 1_000_000;
+    let mut overridden_transcript = Transcript::seed("s", "task");
+    for turn in 1..=4 {
+        push_sized_turn(&mut overridden_transcript, turn, 10);
+        maybe_cadence_compress(
+            &mut overridden_transcript,
+            &overridden_cfg,
+            1,
+            context_window,
+        );
+    }
+    assert_eq!(
+        overridden_transcript.cadence_fire_count(),
+        1,
+        "cadence_turns=3 from settings.json must have fired once by turn 4"
+    );
+
+    let default_cfg = CadenceConfig::default();
+    let mut default_transcript = Transcript::seed("s", "task");
+    for turn in 1..=4 {
+        push_sized_turn(&mut default_transcript, turn, 10);
+        maybe_cadence_compress(&mut default_transcript, &default_cfg, 1, context_window);
+    }
+    assert_eq!(
+        default_transcript.cadence_fire_count(),
+        0,
+        "the built-in default (cadence_turns=8) must NOT have fired by turn 4 — \
+         proving the settings.json override, not the default, drove the difference"
+    );
+}
+
 /// Cadence fires exactly every N turns (N=3 override) — not on any other
 /// turn.
 #[test]

--- a/crates/trusty-code/src/agent_loop/goals.rs
+++ b/crates/trusty-code/src/agent_loop/goals.rs
@@ -26,6 +26,7 @@
 //! appending.
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// The number of fixed goal slots (#2343 design decision: exactly 5).
@@ -39,23 +40,25 @@ pub const GOAL_SLOT_COUNT: usize = 5;
 /// Who last wrote a given [`GoalSlot`].
 ///
 /// Why: `set_goal` (the `tools::goals::SetGoalTool` the PM's own model
-/// calls) and the future operator-facing `session.set_goal` RPC (#2348)
+/// calls) and the future operator-facing `session.set_goal` RPC (#2350)
 /// both mutate the same [`GoalSlots`]; recording the source lets a future
 /// UI/audit view distinguish "the model decided this" from "an operator
 /// pinned this" without a second parallel data structure.
-/// Test: `goals_tests::set_records_model_source`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Test: `goals_tests::set_records_model_source`,
+/// `goals_tests::goal_source_serialises_snake_case`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum GoalSource {
     /// Written by the PM's own model via the `set_goal` tool call.
     Model,
-    /// Written by a human operator (#2348's `session.set_goal` RPC).
+    /// Written by a human operator (#2350's `session.set_goal` RPC).
     Operator,
 }
 
 /// One occupied goal slot: its text, who wrote it, and when.
 ///
 /// Why: A bare `String` would lose the provenance/recency information a
-/// future operator-facing view (#2348) needs; bundling all three in one
+/// future operator-facing view (#2350) needs; bundling all three in one
 /// struct keeps `GoalSlots`'s storage a simple fixed-size array of
 /// `Option<GoalSlot>` rather than three parallel arrays.
 /// What: `text` is the free-form goal description; `source` is
@@ -63,7 +66,7 @@ pub enum GoalSource {
 /// that wrote this slot (matching the `chrono::Utc` convention already used
 /// by `session::registry`/`session::model` for session timestamps).
 /// Test: `goals_tests::set_then_get_round_trips_all_fields`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GoalSlot {
     /// Free-form goal description.
     pub text: String,
@@ -134,7 +137,7 @@ impl GoalSlots {
     /// Write (or overwrite) a 1-based `slot` with `text` from `source`.
     ///
     /// Why: The model-facing `set_goal` tool and the future operator RPC
-    /// (#2348) both need one shared, validated write path rather than
+    /// (#2350) both need one shared, validated write path rather than
     /// reaching into the array directly.
     /// What: Validates `slot` via [`Self::validate`], then replaces (does
     /// NOT append to) that slot with a fresh `GoalSlot { text, source,
@@ -179,7 +182,7 @@ impl GoalSlots {
     /// Read the current content of a 1-based `slot`, if occupied.
     ///
     /// Why: Test/observability accessor; also lets a future operator view
-    /// (#2348) inspect one slot without re-deriving the whole rendered
+    /// (#2350) inspect one slot without re-deriving the whole rendered
     /// block.
     /// What: Returns `None` for an out-of-range slot OR an empty one — the
     /// two cases are intentionally not distinguished here (callers that
@@ -189,6 +192,26 @@ impl GoalSlots {
     pub fn get(&self, slot: usize) -> Option<&GoalSlot> {
         let idx = slot.checked_sub(1)?;
         self.slots.get(idx)?.as_ref()
+    }
+
+    /// Snapshot every currently-occupied slot as `(1-based slot, GoalSlot)`
+    /// pairs, in slot order (#2350).
+    ///
+    /// Why: `session.get_goals` and `TranscriptRecord.goals`
+    /// (`session::transcript`) both need a serialisable view of every
+    /// occupied slot together with its 1-based index — cloning here (rather
+    /// than returning references) lets the caller build its own DTO without
+    /// holding this `GoalSlots`'s lock any longer than the snapshot itself.
+    /// What: Filters out empty slots, cloning each occupied `GoalSlot` paired
+    /// with its 1-based slot number.
+    /// Test: `goals_tests::occupied_skips_empty_slots_and_preserves_index`,
+    /// `goals_tests::occupied_empty_when_all_slots_empty`.
+    pub fn occupied(&self) -> Vec<(usize, GoalSlot)> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(i, slot)| slot.clone().map(|g| (i + 1, g)))
+            .collect()
     }
 
     /// Render the privileged-goals prompt block, or `None` if every slot is

--- a/crates/trusty-code/src/agent_loop/goals_tests.rs
+++ b/crates/trusty-code/src/agent_loop/goals_tests.rs
@@ -170,6 +170,64 @@ fn render_numbers_by_slot_skipping_empty() {
     assert!(!rendered.contains("2."));
 }
 
+/// `occupied()` returns only occupied slots, paired with their 1-based
+/// index, skipping gaps.
+///
+/// Why: #2350's `session.get_goals`/`TranscriptRecord.goals` both build on
+/// this snapshot; a gap in the middle (slot 2 empty) must not shift slot 3's
+/// reported index down to 2.
+/// What: Occupy slots 1 and 3 only; assert `occupied()` returns exactly
+/// `[(1, ...), (3, ...)]` in that order.
+/// Test: this test.
+#[test]
+fn occupied_skips_empty_slots_and_preserves_index() {
+    let mut goals = GoalSlots::new();
+    goals.set(1, "goal one", GoalSource::Model).expect("ok");
+    goals
+        .set(3, "goal three", GoalSource::Operator)
+        .expect("ok");
+
+    let occupied = goals.occupied();
+    assert_eq!(occupied.len(), 2);
+    assert_eq!(occupied[0].0, 1);
+    assert_eq!(occupied[0].1.text, "goal one");
+    assert_eq!(occupied[1].0, 3);
+    assert_eq!(occupied[1].1.source, GoalSource::Operator);
+}
+
+/// `occupied()` on a fresh `GoalSlots` returns an empty vec, not an error.
+///
+/// Why: `session.get_goals` on a session whose transcript has never had a
+/// goal set must return `[]`, matching `session.get_transcript`'s
+/// never-run-session convention.
+/// What: Fresh `GoalSlots::new()`, assert `occupied()` is empty.
+/// Test: this test.
+#[test]
+fn occupied_empty_when_all_slots_empty() {
+    assert!(GoalSlots::new().occupied().is_empty());
+}
+
+/// `GoalSource` serialises to the stable snake_case wire strings
+/// `session.get_goals`/`TranscriptRecord.goals` expose over JSON-RPC.
+///
+/// Why: #2350 exposes `GoalSource` directly on the wire (unlike #2347, which
+/// only used it in-process); the wire string must be stable and
+/// human-readable independent of Rust variant naming, matching
+/// `SessionStatus`'s `#[serde(rename_all = "snake_case")]` convention.
+/// What: `Model` -> `"model"`, `Operator` -> `"operator"`.
+/// Test: this test.
+#[test]
+fn goal_source_serialises_snake_case() {
+    assert_eq!(
+        serde_json::to_value(GoalSource::Model).unwrap(),
+        serde_json::json!("model")
+    );
+    assert_eq!(
+        serde_json::to_value(GoalSource::Operator).unwrap(),
+        serde_json::json!("operator")
+    );
+}
+
 /// `render()` prefixes the fixed preamble before the numbered slots.
 ///
 /// Why: Guards that the model-facing framing text ("privileged, standing

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -252,6 +252,7 @@ mod tests {
             cost_usd: Some(0.01),
             mode: Some(crate::mode::HarnessMode::DailyDriver),
             compaction_events: 0,
+            goals: vec![],
         };
         let out = render_transcript_human(&record);
         assert!(out.contains("pm"));
@@ -269,6 +270,7 @@ mod tests {
             cost_usd: None,
             mode: None,
             compaction_events: 0,
+            goals: vec![],
         };
         let out = render_transcript_human(&record);
         assert!(out.contains("s-1"));

--- a/crates/trusty-code/src/session/mod.rs
+++ b/crates/trusty-code/src/session/mod.rs
@@ -11,12 +11,15 @@
 //! dispatch through.
 //! What: [`model::Session`]/[`model::SessionStatus`] (the domain type),
 //! [`registry::SessionRegistry`] (storage + ring buffer + attach/detach +,
-//! since #2056, execution tracking), [`transcript::TranscriptRecord`]
-//! (#2058's `session.get_transcript` response DTO), [`memory_sink::TurnMemorySink`]
+//! since #2056, execution tracking, #2350 operator-facing goal slots),
+//! [`transcript::TranscriptRecord`] (#2058's `session.get_transcript`
+//! response DTO, #2350 additive `goals` field) plus its
+//! [`transcript::GoalSlotRecord`] snapshot type, [`memory_sink::TurnMemorySink`]
 //! (#2345's durable per-turn dual-write to trusty-memory, owned per-session
 //! by `registry::SessionRegistry`), and [`protocol::register`] (wires
 //! `session.create`/`list`/`status`/`send`/`attach`/`detach`/`cancel`/
-//! `get_transcript` onto a `Router`).
+//! `get_transcript`/(#2350)`set_goal`/`clear_goal`/`get_goals` onto a
+//! `Router`).
 //! Test: `model::tests::*`, `registry::registry_tests::*`,
 //! `protocol::tests::*`; end-to-end over the real daemon in
 //! `tests/session_e2e.rs` and (#2058) `tests/task_e2e.rs`.
@@ -30,4 +33,4 @@ pub mod transcript;
 pub use memory_sink::TurnMemorySink;
 pub use model::{Session, SessionStatus};
 pub use registry::SessionRegistry;
-pub use transcript::TranscriptRecord;
+pub use transcript::{GoalSlotRecord, TranscriptRecord};

--- a/crates/trusty-code/src/session/protocol.rs
+++ b/crates/trusty-code/src/session/protocol.rs
@@ -5,15 +5,22 @@
 //! CLI (and later TUI/TELGUI/REST) never touch `SessionRegistry` directly.
 //! What: [`register`] wires `session.create`, `session.list`,
 //! `session.status`, `session.send`, `session.attach`, `session.detach`,
-//! `session.cancel`, and (#2058) `session.get_transcript` onto a [`Router`],
-//! all closed over the SAME `Arc<SessionRegistry>` so every method sees a
-//! consistent view. Each handler parses its typed `params`, forwards to the
-//! matching `SessionRegistry` method, and maps the result onto the JSON-RPC
-//! result shape the vision spec's §4.3 examples describe.
-//! Test: `protocol::tests::*` (parameter validation, error mapping); the
-//! full attach/detach streaming behaviour is covered by
-//! `session::registry_tests` (registry-level) and
-//! `tests/session_e2e.rs`/`tests/task_e2e.rs` (API-driven, real daemon).
+//! `session.cancel`, (#2058) `session.get_transcript`, and (#2350)
+//! `session.set_goal`/`session.clear_goal`/`session.get_goals` onto a
+//! [`Router`], all closed over the SAME `Arc<SessionRegistry>` so every
+//! method sees a consistent view. Each handler parses its typed `params`,
+//! forwards to the matching `SessionRegistry` method, and maps the result
+//! onto the JSON-RPC result shape the vision spec's §4.3 examples describe.
+//! The three goal methods' handler bodies live in the sibling
+//! `protocol_goals` module (kept out of this file purely for the 500-SLOC
+//! cap — see that module's docs), but are registered here alongside every
+//! other `session.*` method so this remains the one place listing the full
+//! surface.
+//! Test: `protocol::tests::*` (parameter validation, error mapping);
+//! `protocol_goals::tests::*` (the three goal methods); the full
+//! attach/detach streaming behaviour is covered by `session::registry_tests`
+//! (registry-level) and `tests/session_e2e.rs`/`tests/task_e2e.rs`
+//! (API-driven, real daemon).
 
 use std::sync::Arc;
 
@@ -102,6 +109,33 @@ pub fn register(router: &mut Router, registry: Arc<SessionRegistry>) {
         move |params: Value, ctx: ConnectionContext| {
             let r = r.clone();
             async move { get_transcript(&r, params, ctx).await }
+        },
+    );
+
+    let r = registry.clone();
+    router.register(
+        "session.set_goal",
+        move |params: Value, ctx: ConnectionContext| {
+            let r = r.clone();
+            async move { protocol_goals::set_goal(&r, params, ctx).await }
+        },
+    );
+
+    let r = registry.clone();
+    router.register(
+        "session.clear_goal",
+        move |params: Value, ctx: ConnectionContext| {
+            let r = r.clone();
+            async move { protocol_goals::clear_goal(&r, params, ctx).await }
+        },
+    );
+
+    let r = registry.clone();
+    router.register(
+        "session.get_goals",
+        move |params: Value, ctx: ConnectionContext| {
+            let r = r.clone();
+            async move { protocol_goals::get_goals(&r, params, ctx).await }
         },
     );
 }
@@ -309,6 +343,15 @@ async fn get_transcript(
     Ok(json!(registry.get_transcript(&p.session_id)?))
 }
 
+/// `session.set_goal`/`session.clear_goal`/`session.get_goals` (#2350),
+/// split into their own file purely to keep this production file under the
+/// crate's 500-SLOC cap — a child module of `protocol` (declared via
+/// `#[path = ...] mod protocol_goals;`), so it shares full access to this
+/// module's private `SessionIdParams`/`parse` helpers exactly as if these
+/// handlers were still defined here.
+#[path = "protocol_goals.rs"]
+mod protocol_goals;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -340,6 +383,7 @@ mod tests {
             ("session.attach", json!({"session_id": session.id})),
             ("session.detach", json!({"session_id": session.id})),
             ("session.get_transcript", json!({"session_id": session.id})),
+            ("session.get_goals", json!({"session_id": session.id})),
         ];
         for (method, params) in cases {
             let req = Request {
@@ -369,6 +413,33 @@ mod tests {
             "session.cancel should succeed, got {:?}",
             resp.error
         );
+    }
+
+    /// `session.set_goal`/`session.clear_goal` must be reachable through the
+    /// `Router` (proving the wiring) even though a freshly-created session
+    /// with no `task.run` yet has no transcript to write into — the
+    /// documented #2350 "no transcript yet" error IS the proof the request
+    /// was routed to the real handler rather than `-32601 method not found`.
+    #[tokio::test]
+    async fn register_wires_set_goal_and_clear_goal() {
+        let registry = Arc::new(SessionRegistry::new());
+        let mut router = Router::new();
+        register(&mut router, registry.clone());
+        let session = registry.create("t".to_string(), None, None);
+
+        for method in ["session.set_goal", "session.clear_goal"] {
+            let req = Request {
+                jsonrpc: Some("2.0".to_string()),
+                id: Some(json!(1)),
+                method: method.to_string(),
+                params: Some(json!({"session_id": session.id, "slot": 1, "text": "x"})),
+            };
+            let resp = router.dispatch(req, &test_ctx()).await;
+            let error = resp
+                .error
+                .unwrap_or_else(|| panic!("{method} must error (no transcript yet)"));
+            assert_eq!(error.code, -32003, "{method} wrong error code");
+        }
     }
 
     /// An empty `task` must map to `-32003 invalid_argument`, not silently

--- a/crates/trusty-code/src/session/protocol_goals.rs
+++ b/crates/trusty-code/src/session/protocol_goals.rs
@@ -1,0 +1,253 @@
+//! `session.set_goal`/`session.clear_goal`/`session.get_goals` handlers
+//! (#2350, epic #2343 pillar 3). Split out of `protocol.rs` purely to keep
+//! that production file under the crate's 500-SLOC cap — this is a child
+//! module of `protocol` (declared via `#[path = ...] mod protocol_goals;`),
+//! so it shares full access to `protocol`'s private `SessionIdParams`/`parse`
+//! helpers exactly as if these handlers were still defined in that file.
+//!
+//! Why: `agent_loop::goals::GoalSlots` (#2347) already lets the PM's own
+//! model write goals mid-conversation via the `set_goal`/`clear_goal` tools;
+//! this is the OPERATOR-facing half of the same shared state, reachable over
+//! `session.*` JSON-RPC exactly like every other session operation (vision
+//! spec Axiom 4 — the daemon owns sessions, clients only ever go through the
+//! API).
+//! What: [`set_goal`]/[`clear_goal`] forward to
+//! `SessionRegistry::set_goal`/`clear_goal`, which write with
+//! `GoalSource::Operator` (last-write-wins against a model write to the same
+//! slot — see `SessionRegistry::set_goal`'s docs for the full design
+//! decision on sessions with no transcript yet). [`get_goals`] forwards to
+//! `SessionRegistry::get_goals`, returning `{"goals": [...]}`.
+//! Test: `tests::*` in this module.
+
+use super::*;
+
+/// `params` shape for `session.set_goal`.
+#[derive(Deserialize)]
+struct SetGoalParams {
+    session_id: String,
+    slot: usize,
+    text: String,
+}
+
+/// `params` shape for `session.clear_goal`.
+#[derive(Deserialize)]
+struct ClearGoalParams {
+    session_id: String,
+    slot: usize,
+}
+
+/// `session.set_goal(session_id, slot, text) -> {}` (#2350).
+///
+/// Why: the operator-facing entry point onto the session's 5 fixed goal
+/// slots — see module docs.
+/// What: `-32007 session_not_found` if `session_id` is unknown;
+/// `-32003 invalid_argument` if the session has no transcript yet (see
+/// `SessionRegistry::set_goal`'s docs for this design decision) or `slot` is
+/// out of range (`0` or `> 5`). On success, writes with
+/// `GoalSource::Operator` and returns `{}`.
+/// Test: `tests::set_goal_writes_operator_goal`,
+/// `tests::set_goal_out_of_range_slot_maps_to_invalid_argument`,
+/// `tests::set_goal_unknown_session_maps_to_session_not_found`.
+pub(super) async fn set_goal(
+    registry: &SessionRegistry,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: SetGoalParams = parse(params, "session.set_goal")?;
+    registry.set_goal(&p.session_id, p.slot, &p.text)?;
+    Ok(json!({}))
+}
+
+/// `session.clear_goal(session_id, slot) -> {}` (#2350).
+///
+/// Why: the operator-facing counterpart to `set_goal` — see module docs.
+/// What: same error mapping as [`set_goal`]. Clearing an already-empty slot
+/// is idempotent success (mirrors `GoalSlots::clear`'s own convention).
+/// Test: `tests::clear_goal_clears_operator_goal`,
+/// `tests::clear_goal_out_of_range_slot_maps_to_invalid_argument`.
+pub(super) async fn clear_goal(
+    registry: &SessionRegistry,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: ClearGoalParams = parse(params, "session.clear_goal")?;
+    registry.clear_goal(&p.session_id, p.slot)?;
+    Ok(json!({}))
+}
+
+/// `session.get_goals(session_id) -> { goals: [GoalSlotRecord] }` (#2350).
+///
+/// Why: lets an operator/UI inspect the current goal state (from either
+/// source) without pulling the larger `session.get_transcript` payload.
+/// What: `-32007 session_not_found` if `session_id` is unknown; otherwise
+/// `{"goals": [...]}` — `[]` for a session with no transcript yet, matching
+/// `session.get_transcript`'s never-run convention.
+/// Test: `tests::get_goals_returns_goals_key`,
+/// `tests::get_goals_on_never_run_session_is_empty`,
+/// `tests::get_goals_unknown_session_maps_to_session_not_found`.
+pub(super) async fn get_goals(
+    registry: &SessionRegistry,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: SessionIdParams = parse(params, "session.get_goals")?;
+    Ok(json!({ "goals": registry.get_goals(&p.session_id)? }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    fn test_ctx() -> ConnectionContext {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        ConnectionContext::new(tx)
+    }
+
+    /// Seed `id`'s `pm_transcript` the same way a real `task.run` would, so
+    /// `set_goal`/`clear_goal` get past the "no transcript yet" guard.
+    fn seed_pm_transcript(registry: &SessionRegistry, id: &str) {
+        let transcript = registry
+            .begin_pm_transcript(id, "you are the pm", "first task")
+            .unwrap();
+        registry.store_pm_transcript(id, transcript);
+    }
+
+    /// `set_goal` on a session with a seeded transcript writes the slot,
+    /// visible via `get_goals` with `source: "operator"`.
+    #[tokio::test]
+    async fn set_goal_writes_operator_goal() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, None);
+        seed_pm_transcript(&registry, &session.id);
+
+        let result = set_goal(
+            &registry,
+            json!({"session_id": session.id, "slot": 2, "text": "ship it"}),
+            test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, json!({}));
+
+        let goals = get_goals(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+        assert_eq!(goals["goals"][0]["slot"], 2);
+        assert_eq!(goals["goals"][0]["text"], "ship it");
+        assert_eq!(goals["goals"][0]["source"], "operator");
+    }
+
+    /// `set_goal` with an out-of-range slot must map to `-32003
+    /// invalid_argument`.
+    #[tokio::test]
+    async fn set_goal_out_of_range_slot_maps_to_invalid_argument() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, None);
+        seed_pm_transcript(&registry, &session.id);
+
+        let err = set_goal(
+            &registry,
+            json!({"session_id": session.id, "slot": 6, "text": "x"}),
+            test_ctx(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, -32003);
+    }
+
+    /// `set_goal` on an unknown session must map to `-32007
+    /// session_not_found`.
+    #[tokio::test]
+    async fn set_goal_unknown_session_maps_to_session_not_found() {
+        let registry = SessionRegistry::new();
+        let err = set_goal(
+            &registry,
+            json!({"session_id": "nope", "slot": 1, "text": "x"}),
+            test_ctx(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, -32007);
+    }
+
+    /// `clear_goal` empties a previously `set_goal`-written slot.
+    #[tokio::test]
+    async fn clear_goal_clears_operator_goal() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, None);
+        seed_pm_transcript(&registry, &session.id);
+        set_goal(
+            &registry,
+            json!({"session_id": session.id, "slot": 3, "text": "temp"}),
+            test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        clear_goal(
+            &registry,
+            json!({"session_id": session.id, "slot": 3}),
+            test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        let goals = get_goals(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+        assert_eq!(goals["goals"].as_array().unwrap().len(), 0);
+    }
+
+    /// `clear_goal` with an out-of-range slot must map to `-32003
+    /// invalid_argument`.
+    #[tokio::test]
+    async fn clear_goal_out_of_range_slot_maps_to_invalid_argument() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, None);
+        seed_pm_transcript(&registry, &session.id);
+
+        let err = clear_goal(
+            &registry,
+            json!({"session_id": session.id, "slot": 0}),
+            test_ctx(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, -32003);
+    }
+
+    /// `get_goals` must wrap its result under a `"goals"` key.
+    #[tokio::test]
+    async fn get_goals_returns_goals_key() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, None);
+        let result = get_goals(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+        assert!(result["goals"].is_array());
+    }
+
+    /// `get_goals` on a session that has never run a task returns `[]`, not
+    /// an error.
+    #[tokio::test]
+    async fn get_goals_on_never_run_session_is_empty() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, None);
+        let result = get_goals(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+        assert_eq!(result["goals"].as_array().unwrap().len(), 0);
+    }
+
+    /// `get_goals` on an unknown session must map to `-32007
+    /// session_not_found`.
+    #[tokio::test]
+    async fn get_goals_unknown_session_maps_to_session_not_found() {
+        let registry = SessionRegistry::new();
+        let err = get_goals(&registry, json!({"session_id": "nope"}), test_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, -32007);
+    }
+}

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -709,7 +709,8 @@ impl SessionRegistry {
     /// Test: `registry_tests::get_transcript_returns_stored_record`,
     /// `registry_tests::get_transcript_on_never_run_session_is_empty`,
     /// `registry_tests::get_transcript_unknown_session_errors`,
-    /// `registry_tests::get_transcript_reports_compaction_events`.
+    /// `registry_tests::get_transcript_reports_compaction_events`,
+    /// `registry_tests::get_transcript_round_trips_goal_state`.
     pub fn get_transcript(&self, id: &str) -> Result<TranscriptRecord, RpcError> {
         let sessions = self.lock();
         let entry = sessions
@@ -726,6 +727,7 @@ impl SessionRegistry {
                 .as_ref()
                 .map(Transcript::compaction_events)
                 .unwrap_or(0),
+            goals: goal_ops::goal_records(entry),
         })
     }
 
@@ -911,6 +913,12 @@ mod events;
 /// the same 500-SLOC-cap reason as `events` above.
 #[path = "registry_memory_sink.rs"]
 mod memory_sink_ext;
+
+/// #2350 operator-facing goal-slot plumbing (`session.set_goal`/
+/// `clear_goal`/`get_goals`), split out into its own file for the same
+/// 500-SLOC-cap reason as `events`/`memory_sink_ext` above.
+#[path = "registry_goals.rs"]
+mod goal_ops;
 
 #[cfg(test)]
 #[path = "registry_tests.rs"]

--- a/crates/trusty-code/src/session/registry_goals.rs
+++ b/crates/trusty-code/src/session/registry_goals.rs
@@ -1,0 +1,157 @@
+//! `SessionRegistry`'s #2350 operator-facing goal-slot plumbing:
+//! `session.set_goal`/`session.clear_goal`/`session.get_goals`. Split out of
+//! `registry.rs` for the same 500-SLOC-cap reason as `registry_events.rs`/
+//! `registry_memory_sink.rs` — this is a child module of `registry`
+//! (declared via `#[path = ...] mod goal_ops;`), so it shares full access to
+//! `SessionRegistry`'s private `lock` helper and `SessionEntry`'s fields
+//! exactly as if these methods were still defined in that file.
+//!
+//! Why: `agent_loop::goals::GoalSlots` already lets the PM's own model write
+//! goals via the `set_goal`/`clear_goal` tools (#2347), each tagged
+//! `GoalSource::Model`. An operator (human, or a future TUI/CLI) needs the
+//! SAME shared slots reachable over `session.*` JSON-RPC, tagged
+//! `GoalSource::Operator` — last-write-wins between the two sources is
+//! implicit in `GoalSlots::set` simply overwriting whichever slot is named,
+//! regardless of who wrote it last.
+//! **Design decision (documented per the ticket):** the goal slots live on
+//! `Transcript` (`SessionEntry.pm_transcript`), which is only seeded on a
+//! session's FIRST `task.run` (`SessionRegistry::begin_pm_transcript`). A
+//! session that has never run a task has no `Transcript` and therefore no
+//! goal-slot storage to write into yet. Rather than adding a second,
+//! parallel "pending goals" slot on `SessionEntry` that would need to be
+//! applied at the first `begin_pm_transcript` call (a real design, but more
+//! moving parts than this ticket's scope needs), `set_goal`/`clear_goal`
+//! return a clear `invalid_argument` error naming the limitation. `get_goals`
+//! takes the simpler read-side convention already established by
+//! `get_transcript`: a session with no transcript yet is a valid EMPTY
+//! result, not an error. Upgrading `set_goal` to a pending-goals path that
+//! applies on the first run is documented future work, not needed here.
+//! What: `set_goal`/`clear_goal` resolve `id`'s `pm_transcript`'s
+//! `goals_handle()`, erroring `session_not_found` if the session itself is
+//! unknown or `invalid_argument` if it has no transcript yet or the slot
+//! index is out of range; `get_goals` returns `[]` for a never-run session
+//! rather than erroring. [`goal_records`] is the shared snapshot helper
+//! `registry.rs`'s `get_transcript` also calls, so `TranscriptRecord.goals`
+//! and `session.get_goals` can never independently drift on shape.
+//! Test: `registry_tests::set_goal_*`, `registry_tests::clear_goal_*`,
+//! `registry_tests::get_goals_*`,
+//! `registry_tests::get_transcript_round_trips_goal_state`.
+
+use super::*;
+use crate::agent_loop::{GoalSlots, GoalSource};
+use crate::session::transcript::GoalSlotRecord;
+
+impl SessionRegistry {
+    /// `session.set_goal`: write an operator-provided goal into a 1-based
+    /// slot (#2350).
+    ///
+    /// Why: the operator-facing counterpart to the model-facing `set_goal`
+    /// tool (#2347) — same shared `GoalSlots`, tagged `GoalSource::Operator`
+    /// so a later read can tell the two apart.
+    /// What: `Err(session_not_found)` if `id` is unknown. `Err(invalid_argument)`
+    /// if the session has no `pm_transcript` yet (see module docs' design
+    /// decision) or if `slot` is `0`/greater than `GOAL_SLOT_COUNT`. A
+    /// poisoned goals lock is recovered (mirrors `tools::goals`'s
+    /// convention) rather than propagating a panic.
+    /// Test: `registry_tests::set_goal_writes_operator_source`,
+    /// `registry_tests::set_goal_no_transcript_yet_errors`,
+    /// `registry_tests::set_goal_out_of_range_slot_errors`,
+    /// `registry_tests::set_goal_unknown_session_errors`.
+    pub fn set_goal(&self, id: &str, slot: usize, text: &str) -> Result<(), RpcError> {
+        let handle = self.goals_handle(id)?;
+        let mut guard = handle.lock().unwrap_or_else(|p| p.into_inner());
+        guard
+            .set(slot, text, GoalSource::Operator)
+            .map_err(|e| RpcError::invalid_argument(e.to_string()))
+    }
+
+    /// `session.clear_goal`: clear an operator-named 1-based slot (#2350).
+    ///
+    /// Why: the operator-facing counterpart to the model-facing `clear_goal`
+    /// tool (#2347).
+    /// What: same error shape as [`Self::set_goal`]. Clearing an
+    /// already-empty slot is idempotent success (mirrors
+    /// `GoalSlots::clear`'s own convention).
+    /// Test: `registry_tests::clear_goal_clears_slot`,
+    /// `registry_tests::clear_goal_no_transcript_yet_errors`,
+    /// `registry_tests::clear_goal_out_of_range_slot_errors`.
+    pub fn clear_goal(&self, id: &str, slot: usize) -> Result<(), RpcError> {
+        let handle = self.goals_handle(id)?;
+        let mut guard = handle.lock().unwrap_or_else(|p| p.into_inner());
+        guard
+            .clear(slot)
+            .map_err(|e| RpcError::invalid_argument(e.to_string()))
+    }
+
+    /// `session.get_goals`: snapshot every currently-occupied goal slot
+    /// (#2350).
+    ///
+    /// Why: the operator-facing read path — lets a client inspect the
+    /// current goal state (from either source) without going through
+    /// `session.get_transcript`'s larger payload.
+    /// What: `Err(session_not_found)` if `id` is unknown; otherwise
+    /// [`goal_records`] — `[]` for a session with no `pm_transcript` yet,
+    /// matching `session.get_transcript`'s never-run convention rather than
+    /// `set_goal`/`clear_goal`'s stricter error.
+    /// Test: `registry_tests::get_goals_returns_operator_and_model_sources`,
+    /// `registry_tests::get_goals_on_never_run_session_is_empty`,
+    /// `registry_tests::get_goals_unknown_session_errors`.
+    pub fn get_goals(&self, id: &str) -> Result<Vec<GoalSlotRecord>, RpcError> {
+        let sessions = self.lock();
+        let entry = sessions
+            .get(id)
+            .ok_or_else(|| RpcError::session_not_found(id))?;
+        Ok(goal_records(entry))
+    }
+
+    /// Resolve `id`'s live `GoalSlots` handle, shared by `set_goal`/`clear_goal`.
+    ///
+    /// Why: both mutators need the identical "unknown session" vs.
+    /// "no transcript yet" error mapping — centralising it here means they
+    /// can never independently drift on the design decision documented in
+    /// the module docs.
+    /// What: `Err(session_not_found)` if `id` is unknown; `Err(invalid_argument)`
+    /// naming the "run a task first" limitation if `pm_transcript` is `None`;
+    /// otherwise the cloned `Arc<Mutex<GoalSlots>>` handle.
+    fn goals_handle(&self, id: &str) -> Result<Arc<Mutex<GoalSlots>>, RpcError> {
+        let sessions = self.lock();
+        let entry = sessions
+            .get(id)
+            .ok_or_else(|| RpcError::session_not_found(id))?;
+        entry
+            .pm_transcript
+            .as_ref()
+            .map(Transcript::goals_handle)
+            .ok_or_else(|| {
+                RpcError::invalid_argument(format!(
+                    "session {id} has no transcript yet — run a task first before setting a goal"
+                ))
+            })
+    }
+}
+
+/// Snapshot a `SessionEntry`'s current goal slots as wire-shaped
+/// [`GoalSlotRecord`]s, or `[]` if it has no `pm_transcript` yet.
+///
+/// Why: shared by [`SessionRegistry::get_goals`] and `registry.rs`'s
+/// `SessionRegistry::get_transcript` (`TranscriptRecord.goals`) so the two
+/// read paths can never disagree on shape or on the never-run-session
+/// convention.
+/// What: `None` `pm_transcript` -> `vec![]`; otherwise locks the transcript's
+/// `goals_handle()` (recovering a poisoned lock) and maps every
+/// `GoalSlots::occupied` pair through `GoalSlotRecord::from_slot`.
+pub(super) fn goal_records(entry: &SessionEntry) -> Vec<GoalSlotRecord> {
+    entry
+        .pm_transcript
+        .as_ref()
+        .map(|t| {
+            let handle = t.goals_handle();
+            let guard = handle.lock().unwrap_or_else(|p| p.into_inner());
+            guard
+                .occupied()
+                .into_iter()
+                .map(|(slot, g)| GoalSlotRecord::from_slot(slot, g))
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -957,3 +957,213 @@ async fn finish_unknown_session_errors() {
         .unwrap_err();
     assert_eq!(err.code, -32007);
 }
+
+// ── #2350: operator-facing goal slots ───────────────────────────────────────
+
+/// Seed `id`'s `pm_transcript` the same way a real `task.run` would (via
+/// `begin_pm_transcript` + `store_pm_transcript`), without needing a real
+/// agent-loop execution — the shared setup every goal test in this section
+/// needs to get past the "no transcript yet" guard.
+fn seed_pm_transcript(registry: &SessionRegistry, id: &str) {
+    let transcript = registry
+        .begin_pm_transcript(id, "you are the pm", "first task")
+        .unwrap();
+    registry.store_pm_transcript(id, transcript);
+}
+
+/// `set_goal` on a session with a seeded transcript writes with
+/// `GoalSource::Operator`, visible via both `get_goals` and
+/// `get_transcript`.
+#[tokio::test]
+async fn set_goal_writes_operator_source() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    seed_pm_transcript(&registry, &session.id);
+
+    registry.set_goal(&session.id, 2, "ship it").unwrap();
+
+    let goals = registry.get_goals(&session.id).unwrap();
+    assert_eq!(goals.len(), 1);
+    assert_eq!(goals[0].slot, 2);
+    assert_eq!(goals[0].text, "ship it");
+    assert_eq!(goals[0].source, crate::agent_loop::GoalSource::Operator);
+}
+
+/// `set_goal` on a session that has never run a task (no `pm_transcript`
+/// yet) must return the documented `invalid_argument` "no transcript yet"
+/// error rather than panicking or silently no-op-ing.
+#[tokio::test]
+async fn set_goal_no_transcript_yet_errors() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+
+    let err = registry.set_goal(&session.id, 1, "x").unwrap_err();
+    assert_eq!(err.code, -32003);
+    assert!(err.message.contains("no transcript yet"));
+}
+
+/// `set_goal` with slot `0` or past `GOAL_SLOT_COUNT` must map to a clean
+/// `invalid_argument` error, not a panic.
+#[tokio::test]
+async fn set_goal_out_of_range_slot_errors() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    seed_pm_transcript(&registry, &session.id);
+
+    assert_eq!(
+        registry.set_goal(&session.id, 0, "x").unwrap_err().code,
+        -32003
+    );
+    assert_eq!(
+        registry.set_goal(&session.id, 6, "x").unwrap_err().code,
+        -32003
+    );
+}
+
+/// `set_goal` on an unknown session must map to `session_not_found`.
+#[tokio::test]
+async fn set_goal_unknown_session_errors() {
+    let registry = SessionRegistry::new();
+    assert_eq!(registry.set_goal("nope", 1, "x").unwrap_err().code, -32007);
+}
+
+/// `clear_goal` empties a previously-set slot.
+#[tokio::test]
+async fn clear_goal_clears_slot() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    seed_pm_transcript(&registry, &session.id);
+    registry.set_goal(&session.id, 3, "temp").unwrap();
+
+    registry.clear_goal(&session.id, 3).unwrap();
+
+    assert!(registry.get_goals(&session.id).unwrap().is_empty());
+}
+
+/// `clear_goal` on a session with no transcript yet must error the same way
+/// `set_goal` does.
+#[tokio::test]
+async fn clear_goal_no_transcript_yet_errors() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+
+    let err = registry.clear_goal(&session.id, 1).unwrap_err();
+    assert_eq!(err.code, -32003);
+}
+
+/// `clear_goal` with an out-of-range slot must map to a clean
+/// `invalid_argument` error.
+#[tokio::test]
+async fn clear_goal_out_of_range_slot_errors() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    seed_pm_transcript(&registry, &session.id);
+
+    assert_eq!(
+        registry.clear_goal(&session.id, 0).unwrap_err().code,
+        -32003
+    );
+}
+
+/// `get_goals` reports BOTH an operator-written slot (via `set_goal`) and a
+/// model-written slot (simulating what the `set_goal` tool writes directly
+/// onto the same shared `GoalSlots` handle) — and that a later operator
+/// write to the SAME slot the model wrote wins (last-write-wins).
+#[tokio::test]
+async fn get_goals_returns_operator_and_model_sources() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    seed_pm_transcript(&registry, &session.id);
+
+    registry.set_goal(&session.id, 2, "operator goal").unwrap();
+
+    // Simulate the model's own `set_goal` tool writing slot 1 directly onto
+    // the same shared handle `tools::goals::SetGoalTool` would hold.
+    {
+        let sessions = registry.lock();
+        let handle = sessions
+            .get(&session.id)
+            .unwrap()
+            .pm_transcript
+            .as_ref()
+            .unwrap()
+            .goals_handle();
+        handle
+            .lock()
+            .unwrap()
+            .set(1, "model goal", crate::agent_loop::GoalSource::Model)
+            .unwrap();
+    }
+
+    let goals = registry.get_goals(&session.id).unwrap();
+    assert_eq!(goals.len(), 2);
+    let slot1 = goals.iter().find(|g| g.slot == 1).expect("slot 1 present");
+    assert_eq!(slot1.source, crate::agent_loop::GoalSource::Model);
+    let slot2 = goals.iter().find(|g| g.slot == 2).expect("slot 2 present");
+    assert_eq!(slot2.source, crate::agent_loop::GoalSource::Operator);
+
+    // Last-write-wins: an operator write to the model's slot replaces it.
+    registry
+        .set_goal(&session.id, 1, "operator overwrites model")
+        .unwrap();
+    let goals = registry.get_goals(&session.id).unwrap();
+    let slot1 = goals.iter().find(|g| g.slot == 1).expect("slot 1 present");
+    assert_eq!(slot1.text, "operator overwrites model");
+    assert_eq!(slot1.source, crate::agent_loop::GoalSource::Operator);
+}
+
+/// `get_goals` on a session that has never run a task returns `[]`, not an
+/// error — mirrors `get_transcript`'s never-run convention.
+#[tokio::test]
+async fn get_goals_on_never_run_session_is_empty() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+
+    assert!(registry.get_goals(&session.id).unwrap().is_empty());
+}
+
+/// `get_goals` on an unknown session must map to `session_not_found`.
+#[tokio::test]
+async fn get_goals_unknown_session_errors() {
+    let registry = SessionRegistry::new();
+    assert_eq!(registry.get_goals("nope").unwrap_err().code, -32007);
+}
+
+/// `session.get_transcript` round-trips goal state (#2350 acceptance
+/// criterion): a goal set via `set_goal` is visible on `TranscriptRecord.goals`
+/// with the same slot/text/source it was written with.
+#[tokio::test]
+async fn get_transcript_round_trips_goal_state() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    seed_pm_transcript(&registry, &session.id);
+    registry
+        .set_goal(&session.id, 4, "finish the migration")
+        .unwrap();
+
+    let record = registry.get_transcript(&session.id).unwrap();
+    assert_eq!(record.goals.len(), 1);
+    assert_eq!(record.goals[0].slot, 4);
+    assert_eq!(record.goals[0].text, "finish the migration");
+    assert_eq!(
+        record.goals[0].source,
+        crate::agent_loop::GoalSource::Operator
+    );
+
+    // Round-trip through JSON, exactly as a real client would.
+    let value = serde_json::to_value(&record).unwrap();
+    let back: TranscriptRecord = serde_json::from_value(value).unwrap();
+    assert_eq!(back.goals.len(), 1);
+    assert_eq!(back.goals[0].text, "finish the migration");
+}
+
+/// `session.get_transcript` on a never-run session has an empty `goals`
+/// array, matching the empty `turns`/`usage`/`cost_usd` convention.
+#[tokio::test]
+async fn get_transcript_goals_empty_on_never_run_session() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+
+    let record = registry.get_transcript(&session.id).unwrap();
+    assert!(record.goals.is_empty());
+}

--- a/crates/trusty-code/src/session/transcript.rs
+++ b/crates/trusty-code/src/session/transcript.rs
@@ -21,17 +21,63 @@
 //! run a task returns `turns: []`, `usage` all-zero, `cost_usd: null` — a
 //! valid, empty transcript, not an error. `mode` (#2059) is the resolved
 //! `HarnessMode` `task.run` set via `SessionRegistry::set_mode` — `None` for
+<<<<<<< HEAD
 //! the same "never run" case. `compaction_events` (#2349, epic #2343) is the
 //! session's `pm_transcript`'s cumulative count of #2308 threshold-compactor
 //! fires — `0` for a never-run session, and the field epic #2343's success
-//! metric ("500+ turn session with `compaction_events == 0`") reads.
-//! Test: `session::registry_tests::get_transcript_*`.
+//! metric ("500+ turn session with `compaction_events == 0`") reads. (#2350)
+//! `goals` is a serialisable snapshot of the session's 5 fixed goal slots at
+//! the moment `get_transcript` was called, so a client round-tripping
+//! `session.get_transcript` sees the same goal state `session.get_goals`
+//! reports, with no separate call needed.
+//! Test: `session::registry_tests::get_transcript_*`,
+//! `session::registry_tests::get_transcript_round_trips_goal_state`.
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::agent_loop::{GoalSlot, GoalSource};
 use crate::mode::HarnessMode;
 use crate::perf::TokenUsage;
 use crate::run_task::TurnRecord;
+
+/// A serialisable snapshot of one occupied goal slot, as
+/// `TranscriptRecord.goals` and `session.get_goals` (#2350) expose it.
+///
+/// Why: `agent_loop::goals::GoalSlot` carries the slot's content but not its
+/// own index (it lives at a position in `GoalSlots`'s internal array); the
+/// wire shape needs the 1-based `slot` alongside the content so a client can
+/// refer back to it in a subsequent `session.set_goal`/`session.clear_goal`
+/// call without re-deriving the index.
+/// What: `slot` (1-based), `text`, `source`, `updated_at` — field-for-field
+/// from `GoalSlot` plus the index `GoalSlots::occupied` pairs it with.
+/// Test: `session::registry_tests::get_transcript_round_trips_goal_state`,
+/// `session::registry_tests::get_goals_returns_operator_and_model_sources`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoalSlotRecord {
+    pub slot: usize,
+    pub text: String,
+    pub source: GoalSource,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl GoalSlotRecord {
+    /// Build a `GoalSlotRecord` from an `agent_loop::goals::GoalSlots::occupied`
+    /// pair.
+    ///
+    /// Why: the one place that maps the in-process `GoalSlot` shape onto the
+    /// wire DTO, so `session::registry`'s `get_transcript`/`get_goals` can
+    /// never independently drift on field mapping.
+    /// What: copies `slot`/`text`/`source`/`updated_at` verbatim.
+    pub fn from_slot(slot: usize, goal: GoalSlot) -> Self {
+        Self {
+            slot,
+            text: goal.text,
+            source: goal.source,
+            updated_at: goal.updated_at,
+        }
+    }
+}
 
 /// The full stored run record for one session, as `session.get_transcript`
 /// returns it.
@@ -47,10 +93,13 @@ use crate::run_task::TurnRecord;
 /// `get_transcript` time. `compaction_events` (#2349) mirrors
 /// `agent_loop::Transcript::compaction_events()` on the session's
 /// `pm_transcript` — `0` when that transcript has never fired the #2308
-/// threshold compactor, or the session has never run.
+/// threshold compactor, or the session has never run. (#2350) `goals` mirrors
+/// `session.get_goals` — empty when the session has no `pm_transcript` yet
+/// (never run a task) or simply has no goal set.
 /// Test: `session::registry_tests::get_transcript_returns_stored_record`,
 /// `session::registry_tests::get_transcript_on_never_run_session_is_empty`,
-/// `session::registry_tests::get_transcript_reports_compaction_events`.
+/// `session::registry_tests::get_transcript_reports_compaction_events`,
+/// `session::registry_tests::get_transcript_round_trips_goal_state`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptRecord {
     pub session_id: String,
@@ -59,6 +108,8 @@ pub struct TranscriptRecord {
     pub cost_usd: Option<f64>,
     pub mode: Option<HarnessMode>,
     pub compaction_events: u32,
+    #[serde(default)]
+    pub goals: Vec<GoalSlotRecord>,
 }
 
 #[cfg(test)]
@@ -78,6 +129,7 @@ mod tests {
             cost_usd: None,
             mode: None,
             compaction_events: 7,
+            goals: vec![],
         };
 
         let json = serde_json::to_value(&record).expect("serialize");

--- a/crates/trusty-code/src/tools/goals.rs
+++ b/crates/trusty-code/src/tools/goals.rs
@@ -9,7 +9,7 @@
 //! live session `Transcript` (see `agent_loop::transcript::Transcript::goals_handle`),
 //! rather than an `AgentRunner` or config dir as `delegate_to_agent`
 //! (`tools::delegate`) holds. Both tools write with `GoalSource::Model` — the
-//! future operator-facing `session.set_goal` RPC (#2348) writes the same
+//! future operator-facing `session.set_goal` RPC (#2350) writes the same
 //! `GoalSlots` with `GoalSource::Operator` through a different call path, not
 //! through these tools.
 //! What: [`SetGoalTool`] and [`ClearGoalTool`] each wrap an


### PR DESCRIPTION
## Summary

Ticket 7 (final) of epic #2343 (Infinite Sessions). Adds the operator-facing
JSON-RPC API surface on top of #2347's goal slots and #2346's cadence
compressor:

- `session.set_goal(session_id, slot, text)` / `session.clear_goal(session_id, slot)`
  — operator-facing writes to the session's 5 fixed goal slots
  (`GoalSource::Operator`), living alongside the model-facing `set_goal`/
  `clear_goal` tools from #2347 (`GoalSource::Model`) on the SAME shared
  `GoalSlots` — last-write-wins between the two sources.
- `session.get_goals(session_id)` — read-side snapshot of all occupied slots.
- `TranscriptRecord.goals: Vec<GoalSlotRecord>` (additive field) — so
  `session.get_transcript` round-trips goal state without a second call.
- `GoalSource`/`GoalSlot` gain `Serialize`/`Deserialize` (snake_case wire
  strings for `GoalSource`); `GoalSlots::occupied()` is a new shared snapshot
  accessor used by both new read paths (`get_goals` and
  `TranscriptRecord.goals`).
- Extends #2346's `cadence_turns`/`max_overhead_fraction_pct` config-knob
  test coverage with an integration test proving a `settings.json` override
  changes the actual turn-boundary fire SCHEDULE end-to-end (not just the
  resolved config struct's fields, which #2346 already covered).

**Design decision — sessions with no transcript yet:** goal slots live on
`SessionEntry.pm_transcript`, which is only seeded on a session's FIRST
`task.run`. Rather than adding a second "pending goals" storage path applied
retroactively at the first `begin_pm_transcript` call, `session.set_goal`/
`session.clear_goal` on such a session return a clear
`-32003 invalid_argument` error ("session has no transcript yet — run a task
first"). `session.get_goals` follows `session.get_transcript`'s existing
convention instead: `[]` for a never-run session, not an error. The
pending-goals upgrade is documented as follow-up work in
`session/registry_goals.rs`'s module docs, not implemented here.

`GOAL_SLOT_COUNT` stays a hard `const` (5) per Bob's design decision — this
PR does not make it configurable, only confirms/documents that.

New files `session/protocol_goals.rs` / `session/registry_goals.rs` split the
three new methods' handler/registry bodies out of `protocol.rs`/`registry.rs`
to respect the workspace's 500-SLOC production-file cap (same pattern as the
existing `registry_events.rs`/`registry_memory_sink.rs` split).

Avoided `agent_loop/mod.rs` and `task/executor.rs` entirely — the sibling
#2349 ticket touches those concurrently in `.claude/worktrees/tcode-2349`.

## Base branch note

Stacked on **#2346** (`feat/tcode-cadence-compressor-2346`, PR #2375),
which is still open/unmerged at the time this PR was opened — this PR
targets that branch, not `main`. Rebase onto `main` once #2375 merges.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-code` — 858 passed, 0 failed (lib + all 5
      integration test files: `cli_e2e`, `m1_cutline_e2e`, `session_e2e`,
      `task_e2e`, plus `--lib`)
- [x] `cargo test --workspace` — every crate's `test result: ok`, 0 failed
      across the whole workspace; the known-flaky suites
      (`trusty-console`, `trusty-agents` `telegram_pid_guard`/`api_e2e`)
      all passed clean this run
- [x] `cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations — OK`
- [x] New tests: `session.get_transcript` round-trips goal state; operator
      `set_goal` + simulated model `set_goal` visible together via
      `get_goals` with correct `source`; last-write-wins across sources;
      slot `0`/`6` validation errors map to `-32003`; no-transcript-yet
      behaviour for `set_goal`/`clear_goal` (errors) vs. `get_goals`
      (empty); settings.json cadence override changes the actual fire
      schedule end-to-end

Closes #2350
Part of epic #2343

🤖 Generated with [Claude Code](https://claude.com/claude-code)