### PR TITLE
fix(trusty-code): remove unresolved conflict markers left by #2377 squash

### DIFF
--- a/crates/trusty-code/src/session/transcript.rs
+++ b/crates/trusty-code/src/session/transcript.rs
@@ -21,7 +21,6 @@
 //! run a task returns `turns: []`, `usage` all-zero, `cost_usd: null` — a
 //! valid, empty transcript, not an error. `mode` (#2059) is the resolved
 //! `HarnessMode` `task.run` set via `SessionRegistry::set_mode` — `None` for
-<<<<<<< HEAD
 //! the same "never run" case. `compaction_events` (#2349, epic #2343) is the
 //! session's `pm_transcript`'s cumulative count of #2308 threshold-compactor
 //! fires — `0` for a never-run session, and the field epic #2343's success


### PR DESCRIPTION
## Summary
Fixes broken main at d273eff9.

- PR #2377's squash merge committed a literal, unresolved git conflict marker
  (`<<<<<<< HEAD` with no matching `=======`/`>>>>>>>`) into a module doc
  comment in `crates/trusty-code/src/session/transcript.rs` (~line 24). This
  broke compilation of `trusty-code`, cascading into red Test/MSRV/Format/
  Clippy runs across all of main CI (run 29129503775).
- The surrounding merged content was otherwise correct: both #2376's
  `compaction_events` field/docs and #2377's `goals` field / `GoalSlotRecord`
  DTO / docs were fully present and intact. Only the stray marker line needed
  removal — a one-line fix.
- Swept the entire repo (`git grep` for `<<<<<<<`/`=======`/`>>>>>>>` across
  `*.rs`, `*.toml`, `*.md`, plus a broad repo-wide sweep) for any other
  leftover markers. The only other hits are pre-existing, unrelated content:
  an illustrative "example conflict block" inside a fenced YAML code snippet
  in `crates/trusty-git-analytics/.claude/agents/mpm-agent-manager.md` and
  `crates/trusty-search/.claude/agents/mpm-agent-manager.md` (from the
  original 2026-05-19 monorepo-import commit, confirmed via `git blame`), and
  a decorative `======` divider in `docs/trusty-installer/research/...`. None
  of these are real unresolved conflicts.
- Verified sibling files `crates/trusty-code/src/cli_client/render.rs` and
  `crates/trusty-code/src/session/registry.rs` (also touched by the same
  squash) have no markers and correctly carry both `compaction_events` and
  `goals` in their fixtures / `get_transcript` implementation.

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-code` — 861 passed, 0 failed, 3 ignored (one
      transient parallel-execution flake in `events::tests::
      publish_round_trips_through_subscribe` reproduced as passing both in
      isolation and on a full clean rerun — unrelated to this change)
- [x] Confirmed both feature round-trip tests explicitly pass:
      `session::transcript::tests::compaction_events_round_trips_through_json`,
      `session::registry::registry_tests::get_transcript_reports_compaction_events`,
      `session::registry::registry_tests::get_transcript_goals_empty_on_never_run_session`,
      full `goals` test suite (39 tests)
- [x] `cargo test --workspace` — all green, no failures across any crate
- [x] `cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` — 0 errors
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 allowlisted, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)