### PR TITLE
P0 HOTFIX: resolve conflict markers committed to main (trusty-code transcript.rs) — unblocks all CI

### DIFF
--- a/crates/trusty-code/src/session/transcript.rs
+++ b/crates/trusty-code/src/session/transcript.rs
@@ -21,7 +21,6 @@
 //! run a task returns `turns: []`, `usage` all-zero, `cost_usd: null` — a
 //! valid, empty transcript, not an error. `mode` (#2059) is the resolved
 //! `HarnessMode` `task.run` set via `SessionRegistry::set_mode` — `None` for
-<<<<<<< HEAD
 //! the same "never run" case. `compaction_events` (#2349, epic #2343) is the
 //! session's `pm_transcript`'s cumulative count of #2308 threshold-compactor
 //! fires — `0` for a never-run session, and the field epic #2343's success


### PR DESCRIPTION
## P0 — main is broken repo-wide

`origin/main` (`d273eff9`, landed via #2377's admin-squash) committed an **unresolved conflict marker** into `crates/trusty-code/src/session/transcript.rs:24` — a lone `<<<<<<< HEAD` inside the module doc comment. This fails Rust parse, so `cargo build`/`cargo test`/`clippy` fail across the whole workspace and **no PR can merge repo-wide** (blocks queued docs PR #2385 and everything else).

## What the conflict actually was

A doc-comment-only collision in the `TranscriptRecord` module docs. Both sides' prose was already correctly merged during #2377's resolution — the `mode` (#2059), `compaction_events` (#2349), and `goals` (#2350) descriptions are all present and coherent — but the opening `<<<<<<< HEAD` marker was left behind (no matching `=======`/`>>>>>>>` existed). Reading across it, line 23 ends "…`None` for" and line 25 continues "the same "never run" case." — continuous, correct prose.

## Resolution

Delete the stray marker line only (1 line removed). No semantic change: both features' behavior is fully preserved (struct fields at lines 109-112 unchanged; all `get_transcript_*` tests, the goal round-trip test, and the compaction_events test pass).

## Verification (raw)

- `cargo build --workspace` — Finished, clean
- `cargo test -p trusty-code` — 861 + 3 + 7 + 4 + 2 + 3 passed; **0 failed** (incl. `get_transcript_round_trips_goal_state`, `get_transcript_reports_compaction_events`)
- `cargo clippy -p trusty-code --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — exit 0
- `bash scripts/check_line_cap.sh` — 0 violations
- Repo-wide `.rs` marker sweep — clean after this change

## Note (separate, out of scope)

Two pre-existing markdown conflict blocks exist in bundled agent-catalog files (`crates/trusty-git-analytics/.claude/agents/mpm-agent-manager.md`, `crates/trusty-search/.claude/agents/mpm-agent-manager.md`), present since the day-one monorepo commit `13f9fa2c` and **not** touched by #2377. They are markdown (don't break cargo CI) and resolving them requires an agent-catalog semantic decision — filed for separate cleanup, deliberately excluded from this P0.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools