### PR TITLE
feat(trusty-review): render Mermaid charts from graph-ready dataset markers

### DIFF
--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -95,6 +95,14 @@ pub struct ReportArgs {
     /// corpus with fewer than five peers is disclosed, never silently ranked.
     #[arg(long)]
     pub benchmark: bool,
+
+    /// Disable Mermaid chart rendering under the Graph-Ready Data Appendix tables
+    /// (#2366).  Charts are ON by default; this flag OR the manifest key
+    /// `[report] mermaid = false` disables them, yielding byte-identical
+    /// pre-wave-4 output.  Precedence: this flag forces off regardless of the
+    /// manifest key.
+    #[arg(long)]
+    pub no_mermaid: bool,
 }
 
 // ─── Command handler ──────────────────────────────────────────────────────────
@@ -219,7 +227,10 @@ pub async fn cmd_report(config: ReviewConfig, args: ReportArgs) -> Result<()> {
         model.benchmark = Some(report);
     }
 
-    let reporter = Reporter::new(&args.out);
+    // #2366: Mermaid charts on by default; disabled by --no-mermaid OR the
+    // manifest `[report] mermaid = false`.  The flag forces off unconditionally.
+    let mermaid = manifest.report.mermaid.unwrap_or(true) && !args.no_mermaid;
+    let reporter = Reporter::new(&args.out).with_mermaid(mermaid);
     let written = reporter
         .write(&model, &template)
         .context("failed to write report output")?;

--- a/crates/trusty-review/src/report/manifest.rs
+++ b/crates/trusty-review/src/report/manifest.rs
@@ -83,6 +83,13 @@ pub struct ReportSection {
     /// precedence; when neither is set the built-in default applies.
     #[serde(default)]
     pub investigate_max_bytes: Option<usize>,
+    /// Optional toggle for Mermaid chart rendering under dataset tables (#2366).
+    ///
+    /// Why: charts are on by default; a manifest may opt out with `mermaid =
+    /// false` (the `--no-mermaid` CLI flag also forces off).  When disabled the
+    /// report is byte-identical to the pre-wave-4 output.
+    #[serde(default)]
+    pub mermaid: Option<bool>,
 }
 
 /// One validated repository entry mapping to a single per-application block.

--- a/crates/trusty-review/src/report/mermaid.rs
+++ b/crates/trusty-review/src/report/mermaid.rs
@@ -1,0 +1,639 @@
+//! Mermaid chart rendering from Graph-Ready Data Appendix markers (wave 4, #2366).
+//!
+//! Why: §7's `<!-- dataset: <slug> | chart: <type> | x: <field> | y: <field>[,
+//! group: <field>] -->` markers already declare a chart intent per populated
+//! table, but the marker was opaque to the renderer — a reader saw only the
+//! machine-readable pipe table.  This pass turns each POPULATED dataset table into
+//! a human-viewable Mermaid chart emitted directly under it, deterministically
+//! (pure rendering from the table rows — no LLM, no network).  The pipe table
+//! stays the authoritative source of truth; the chart is a derived view.
+//! What: [`inject`] scans filled+polished markdown, and for each dataset marker
+//! whose following table is populated appends a fenced ```mermaid block per the
+//! chart-type mapping (bar/stacked-bar → `xychart-beta`, radar → `radar-beta`,
+//! heatmap → a note-only fallback).  Empty datasets (table dropped by omit-empty)
+//! get no chart.  Numeric parsing strips provenance markers / separators; labels
+//! are Mermaid-escaped and capped.
+//! Test: `mermaid_tests.rs` covers per-chart-type syntax, numeric parsing, label
+//! escaping + caps, the heatmap fallback, empty datasets, and end-to-end
+//! injection under populated tables.
+
+use tracing::debug;
+
+/// Max distinct x-categories rendered before the remainder is folded into a note.
+///
+/// Why: a chart with dozens of categories is illegible; the pipe table above the
+/// chart remains authoritative for the full set, so the chart is capped for
+/// readability and the overflow is disclosed.
+const MAX_CATEGORIES: usize = 12;
+
+/// Max distinct series/curves (group values) rendered before an overflow note.
+const MAX_SERIES: usize = 8;
+
+/// The note emitted in place of a Mermaid block for a `heatmap` dataset.
+///
+/// Why: Mermaid has no native heatmap; rather than a misleading approximation the
+/// pipe table stays the authoritative artifact and a one-line note explains why
+/// no chart is drawn.
+const HEATMAP_NOTE: &str = "_(heatmap: no Mermaid rendering; see table above)_";
+
+/// Inject a ```mermaid block under every populated dataset table.
+///
+/// Why: the single entry point the reporter calls (when mermaid is enabled) after
+/// the polish pass, so charts render into the final §7 appendix without the
+/// reporter knowing the chart grammar.
+/// What: walks `markdown` line by line tracking fenced regions (opaque — never
+/// interpreted); on a `<!-- dataset: … -->` marker it copies the marker, the
+/// following table, then appends the rendered block (or a note) derived from the
+/// table rows.  A dataset whose table was dropped (omit-empty) gets no block.
+/// The original trailing-newline state is preserved so a disabled run stays
+/// byte-identical (this fn is simply not called when disabled).
+/// Test: `mermaid_tests.rs::{injects_bar_after_table, empty_dataset_no_chart}`.
+pub fn inject(markdown: &str) -> String {
+    let lines: Vec<&str> = markdown.lines().collect();
+    let mut out = String::with_capacity(markdown.len() + 512);
+    let mut i = 0usize;
+    let mut in_fence = false;
+
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim();
+
+        // Fenced regions (evidence quotes, and any ```mermaid we may have already
+        // emitted) are opaque — never interpret a marker inside one.
+        if trimmed.starts_with("```") {
+            in_fence = !in_fence;
+            push_line(&mut out, line);
+            i += 1;
+            continue;
+        }
+        if in_fence {
+            push_line(&mut out, line);
+            i += 1;
+            continue;
+        }
+
+        if let Some(marker) = parse_marker(trimmed) {
+            push_line(&mut out, line);
+            i += 1;
+            // Skip/copy blank lines between the marker and its table.
+            while i < lines.len() && lines[i].trim().is_empty() {
+                push_line(&mut out, lines[i]);
+                i += 1;
+            }
+            // Copy the contiguous table (if any), then append the chart.
+            if i < lines.len() && is_table_line(lines[i].trim()) {
+                let start = i;
+                while i < lines.len() && is_table_line(lines[i].trim()) {
+                    push_line(&mut out, lines[i]);
+                    i += 1;
+                }
+                if let Some(table) = parse_table(&lines[start..i])
+                    && let Some(block) = render_block(&marker, &table)
+                {
+                    out.push('\n');
+                    out.push_str(&block);
+                }
+            }
+            continue;
+        }
+
+        push_line(&mut out, line);
+        i += 1;
+    }
+
+    // `lines()` drops the trailing newline; restore the original state.
+    if !markdown.ends_with('\n') {
+        while out.ends_with('\n') {
+            out.pop();
+        }
+    }
+    out
+}
+
+/// Push a line plus a trailing newline.
+fn push_line(out: &mut String, line: &str) {
+    out.push_str(line);
+    out.push('\n');
+}
+
+// ─── Marker parsing ─────────────────────────────────────────────────────────
+
+/// The chart intent declared by a dataset marker.
+///
+/// Why: the `chart:` field is a closed vocabulary; an explicit enum makes the
+/// per-type mapping exhaustive and keeps an unknown value from panicking.
+/// What: the four documented types plus `Unknown` for any unrecognized/absent
+/// value (rendered as no block + a debug log).
+/// Test: `mermaid_tests.rs::parses_chart_types`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChartType {
+    /// Single-series bars (`xychart-beta`); a declared `group:` is aggregated away.
+    Bar,
+    /// One bar series per group value (`xychart-beta`); layered, NOT truly stacked.
+    StackedBar,
+    /// One curve per group value (`radar-beta`, Mermaid ≥ 11.6).
+    Radar,
+    /// No native Mermaid support — note-only fallback, table stays authoritative.
+    Heatmap,
+    /// Unrecognized or absent chart type — no block emitted.
+    Unknown,
+}
+
+/// A parsed dataset marker: chart intent plus the field names naming its columns.
+struct Marker {
+    /// Dataset slug — used as the chart title (humanized).
+    slug: String,
+    /// The declared chart type.
+    chart: ChartType,
+    /// The x-axis (category) field name.
+    x: String,
+    /// The y-axis (numeric value) field name.
+    y: String,
+    /// Optional grouping (series/curve) field name.
+    group: Option<String>,
+}
+
+/// Parse a `<!-- dataset: … -->` marker line into a [`Marker`].
+///
+/// Why: the marker declares every field the chart needs; parsing it up front
+/// keeps the per-type renderers free of grammar concerns.
+/// What: strips the comment delimiters, splits on `|` AND `,` into `key: value`
+/// pairs (the `group:` field lives comma-appended inside the `y:` segment), and
+/// collects `dataset`/`chart`/`x`/`y`/`group`.  Returns `None` for any non-dataset
+/// comment or one missing the required `dataset`/`x`/`y` fields.
+/// Test: `mermaid_tests.rs::{parses_full_marker, ignores_non_dataset_comment}`.
+fn parse_marker(trimmed: &str) -> Option<Marker> {
+    let inner = trimmed.strip_prefix("<!--")?.strip_suffix("-->")?.trim();
+    if !inner.starts_with("dataset:") {
+        return None;
+    }
+    let mut slug = None;
+    let mut chart = ChartType::Unknown;
+    let mut x = None;
+    let mut y = None;
+    let mut group = None;
+    for token in inner.replace('|', ",").split(',') {
+        let Some((key, val)) = token.split_once(':') else {
+            continue;
+        };
+        let val = val.trim().to_string();
+        match key.trim() {
+            "dataset" => slug = Some(val),
+            "chart" => chart = parse_chart(&val),
+            "x" => x = Some(val),
+            "y" => y = Some(val),
+            "group" => group = Some(val),
+            _ => {}
+        }
+    }
+    Some(Marker {
+        slug: slug?,
+        chart,
+        x: x?,
+        y: y?,
+        group: group.filter(|g| !g.is_empty()),
+    })
+}
+
+/// Map the `chart:` field value to a [`ChartType`].
+fn parse_chart(s: &str) -> ChartType {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "bar" => ChartType::Bar,
+        "stacked-bar" | "stacked_bar" | "stacked" => ChartType::StackedBar,
+        "radar" => ChartType::Radar,
+        "heatmap" => ChartType::Heatmap,
+        _ => ChartType::Unknown,
+    }
+}
+
+// ─── Table parsing ──────────────────────────────────────────────────────────
+
+/// A parsed pipe table: header cells plus body rows (separator row dropped).
+struct Table {
+    /// Column headers (trimmed, outer pipes removed).
+    header: Vec<String>,
+    /// Body rows, each a vector of trimmed cell strings.
+    rows: Vec<Vec<String>>,
+}
+
+/// Parse a contiguous run of `|`-lines into a [`Table`].
+///
+/// Why: the chart renderers work off resolved columns; parsing once yields the
+/// header (for column resolution) and the body rows (for values).
+/// What: first line is the header, the `|---|` separator is skipped, remaining
+/// non-separator lines are body rows.  Returns `None` when there is no body.
+/// Test: `mermaid_tests.rs::parses_table_rows`.
+fn parse_table(lines: &[&str]) -> Option<Table> {
+    let mut iter = lines.iter().map(|l| l.trim());
+    let header = cells_of(iter.next()?);
+    let rows: Vec<Vec<String>> = iter
+        .filter(|l| !is_separator_row(l))
+        .map(cells_of)
+        .collect();
+    if rows.is_empty() {
+        return None;
+    }
+    Some(Table { header, rows })
+}
+
+/// True when a trimmed line belongs to a markdown pipe table.
+fn is_table_line(trimmed: &str) -> bool {
+    trimmed.starts_with('|')
+}
+
+/// True when a table line is the `|---|---|` separator row.
+fn is_separator_row(trimmed: &str) -> bool {
+    let inner = trimmed.trim_matches('|');
+    !inner.is_empty()
+        && inner
+            .chars()
+            .all(|c| matches!(c, '-' | ':' | '|' | ' ' | '\t'))
+}
+
+/// Split a table row into trimmed cell strings (outer pipes dropped).
+fn cells_of(trimmed: &str) -> Vec<String> {
+    trimmed
+        .trim_matches('|')
+        .split('|')
+        .map(|c| c.trim().to_string())
+        .collect()
+}
+
+// ─── Chart rendering ────────────────────────────────────────────────────────
+
+/// Render the Mermaid block (or note) for one marker + its table, if any.
+///
+/// Why: the single dispatch over chart type keeps [`inject`] agnostic of the
+/// grammar and centralizes the "no block" cases (heatmap note, unknown, no data).
+/// What: resolves the x/y/group columns by name, then delegates to the per-type
+/// builder.  `Heatmap` → the fallback note; `Unknown` → `None` + a debug log;
+/// bar/stacked-bar/radar → a ```mermaid block, or `None` when no row yields a
+/// numeric y (chart would be empty).
+/// Test: `mermaid_tests.rs::{renders_bar, heatmap_fallback, unknown_no_block}`.
+fn render_block(marker: &Marker, table: &Table) -> Option<String> {
+    if marker.chart == ChartType::Heatmap {
+        return Some(format!("{HEATMAP_NOTE}\n"));
+    }
+    if marker.chart == ChartType::Unknown {
+        debug!(slug = %marker.slug, "unknown/absent chart type — no mermaid block");
+        return None;
+    }
+
+    let x_col = resolve_column(&table.header, &marker.x).unwrap_or(0);
+    let y_col = resolve_column(&table.header, &marker.y)?;
+    let group_col = marker
+        .group
+        .as_ref()
+        .and_then(|g| resolve_column(&table.header, g));
+
+    match marker.chart {
+        ChartType::Bar => render_bar(marker, table, x_col, y_col),
+        ChartType::StackedBar => render_stacked(marker, table, x_col, y_col, group_col),
+        ChartType::Radar => render_radar(marker, table, x_col, y_col, group_col),
+        _ => None,
+    }
+}
+
+/// Aggregated chart data: categories (x) × series (group) numeric sums.
+struct Aggregated {
+    /// Distinct x-values in first-seen order (capped at [`MAX_CATEGORIES`]).
+    categories: Vec<String>,
+    /// Count of x-values dropped by the category cap.
+    cat_overflow: usize,
+    /// One series per group value, each aligned to `categories`.
+    series: Vec<Series>,
+    /// Count of group values dropped by the series cap.
+    series_overflow: usize,
+}
+
+/// A single chart series: a group label plus one value per category.
+struct Series {
+    /// The group value (empty for the no-group single-series case).
+    label: String,
+    /// Numeric value per category (summed over matching rows; 0 when absent).
+    values: Vec<f64>,
+}
+
+/// Aggregate table rows into categories × series by summing numeric y-values.
+///
+/// Why: bar/stacked/radar all reduce to "sum y per (x, group)"; sharing the
+/// aggregation keeps the numeric-parse, dedup, and cap rules in one place.
+/// What: for each row parses y (non-numeric rows skipped), keys the sum on the
+/// distinct x value and — when `group_col` is set — the distinct group value.
+/// Applies the category/series caps, recording the dropped counts.  Returns
+/// `None` when no row yielded a numeric y (the chart would be empty).
+/// Test: `mermaid_tests.rs::{skips_non_numeric_rows, caps_categories}`.
+fn aggregate(
+    table: &Table,
+    x_col: usize,
+    y_col: usize,
+    group_col: Option<usize>,
+) -> Option<Aggregated> {
+    let mut categories: Vec<String> = Vec::new();
+    let mut groups: Vec<String> = Vec::new();
+    let mut sums: std::collections::HashMap<(usize, usize), f64> = std::collections::HashMap::new();
+    let mut any = false;
+
+    for row in &table.rows {
+        let Some(yv) = row.get(y_col).and_then(|c| parse_num(c)) else {
+            continue;
+        };
+        any = true;
+        let x = row
+            .get(x_col)
+            .map(|s| s.trim())
+            .unwrap_or_default()
+            .to_string();
+        let g = match group_col {
+            Some(c) => row.get(c).map(|s| s.trim()).unwrap_or_default().to_string(),
+            None => String::new(),
+        };
+        let ci = index_or_push(&mut categories, &x);
+        let gi = index_or_push(&mut groups, &g);
+        *sums.entry((ci, gi)).or_insert(0.0) += yv;
+    }
+    if !any {
+        return None;
+    }
+
+    let cat_overflow = categories.len().saturating_sub(MAX_CATEGORIES);
+    categories.truncate(MAX_CATEGORIES);
+    let series_overflow = groups.len().saturating_sub(MAX_SERIES);
+    groups.truncate(MAX_SERIES);
+
+    let series = groups
+        .iter()
+        .enumerate()
+        .map(|(gi, label)| Series {
+            label: label.clone(),
+            values: (0..categories.len())
+                .map(|ci| *sums.get(&(ci, gi)).unwrap_or(&0.0))
+                .collect(),
+        })
+        .collect();
+
+    Some(Aggregated {
+        categories,
+        cat_overflow,
+        series,
+        series_overflow,
+    })
+}
+
+/// Return the index of `value` in `vec`, appending it (first-seen order) if new.
+fn index_or_push(vec: &mut Vec<String>, value: &str) -> usize {
+    if let Some(i) = vec.iter().position(|v| v == value) {
+        i
+    } else {
+        vec.push(value.to_string());
+        vec.len() - 1
+    }
+}
+
+/// Build a `bar` chart: single `xychart-beta` bar series over the x categories.
+///
+/// Why: the documented mapping — `bar` is always one series; a declared `group:`
+/// is aggregated away (summed per x) so the bars total across groups.
+/// What: aggregates with no group column, emits the `xychart-beta` header, the
+/// quoted x-axis categories, a y-axis label, and one `bar [ … ]` line.
+/// Test: `mermaid_tests.rs::renders_bar`.
+fn render_bar(marker: &Marker, table: &Table, x_col: usize, y_col: usize) -> Option<String> {
+    let agg = aggregate(table, x_col, y_col, None)?;
+    let mut b = String::new();
+    b.push_str("```mermaid\n");
+    b.push_str("xychart-beta\n");
+    b.push_str(&format!("    title \"{}\"\n", humanize(&marker.slug)));
+    b.push_str(&format!("    x-axis [{}]\n", axis_list(&agg.categories)));
+    b.push_str(&format!("    y-axis \"{}\"\n", humanize(&marker.y)));
+    b.push_str(&format!("    bar [{}]\n", num_list(&agg.series[0].values)));
+    b.push_str("```\n");
+    b.push_str(&overflow_notes(agg.cat_overflow, 0));
+    Some(b)
+}
+
+/// Build a `stacked-bar` chart: one bar series per group, layered (overlaid).
+///
+/// Why: Mermaid `xychart-beta` has NO true stacking — multiple `bar` series are
+/// drawn overlaid, not stacked.  This is an intentional approximation: the
+/// layering preserves per-group magnitude comparison, and the note + `%%` comment
+/// disclose that the bars are not summed on top of one another.
+/// What: aggregates by group column (falling back to a single series when the
+/// group does not resolve), emits one `bar [ … ]` per series plus a legend note
+/// naming the series order (xychart has no built-in legend).
+/// Test: `mermaid_tests.rs::renders_stacked_bar`.
+fn render_stacked(
+    marker: &Marker,
+    table: &Table,
+    x_col: usize,
+    y_col: usize,
+    group_col: Option<usize>,
+) -> Option<String> {
+    let agg = aggregate(table, x_col, y_col, group_col)?;
+    let mut b = String::new();
+    b.push_str("```mermaid\n");
+    b.push_str(
+        "%% stacked-bar approximated as layered (overlaid) bars — Mermaid has no native stacking\n",
+    );
+    b.push_str("xychart-beta\n");
+    b.push_str(&format!("    title \"{}\"\n", humanize(&marker.slug)));
+    b.push_str(&format!("    x-axis [{}]\n", axis_list(&agg.categories)));
+    b.push_str(&format!("    y-axis \"{}\"\n", humanize(&marker.y)));
+    for s in &agg.series {
+        b.push_str(&format!("    bar [{}]\n", num_list(&s.values)));
+    }
+    b.push_str("```\n");
+    let labels: Vec<&str> = agg.series.iter().map(|s| s.label.as_str()).collect();
+    if group_col.is_some() && !labels.iter().all(|l| l.is_empty()) {
+        b.push_str(&format!(
+            "_Layered series (front-to-back): {}._\n",
+            labels.join(", ")
+        ));
+    }
+    b.push_str(&overflow_notes(agg.cat_overflow, agg.series_overflow));
+    Some(b)
+}
+
+/// Build a `radar` chart (`radar-beta`, Mermaid ≥ 11.6): one curve per group.
+///
+/// Why: a radar compares many factors across a few entities — axes are the x
+/// factors, curves are the group entities.  `radar-beta` is gated on Mermaid
+/// 11.6; the `%%` comment records the version floor in the emitted block.
+/// What: aggregates by group column (single curve labeled after the y field when
+/// no group resolves), emits the `axis` line and one `curve …{ … }` per series.
+/// Test: `mermaid_tests.rs::renders_radar`.
+fn render_radar(
+    marker: &Marker,
+    table: &Table,
+    x_col: usize,
+    y_col: usize,
+    group_col: Option<usize>,
+) -> Option<String> {
+    let agg = aggregate(table, x_col, y_col, group_col)?;
+    let mut b = String::new();
+    b.push_str("```mermaid\n");
+    b.push_str("%% radar-beta requires Mermaid >= 11.6\n");
+    b.push_str("radar-beta\n");
+    b.push_str(&format!("    title \"{}\"\n", humanize(&marker.slug)));
+    let axes: Vec<String> = agg
+        .categories
+        .iter()
+        .enumerate()
+        .map(|(i, c)| format!("a{i}{}", bracket_label(c)))
+        .collect();
+    b.push_str(&format!("    axis {}\n", axes.join(", ")));
+    for (i, s) in agg.series.iter().enumerate() {
+        let label = if s.label.is_empty() {
+            humanize(&marker.y)
+        } else {
+            s.label.clone()
+        };
+        b.push_str(&format!(
+            "    curve c{i}{}{{{}}}\n",
+            bracket_label(&label),
+            num_list(&s.values)
+        ));
+    }
+    b.push_str("```\n");
+    b.push_str(&overflow_notes(agg.cat_overflow, agg.series_overflow));
+    Some(b)
+}
+
+/// The overflow disclosure note(s) for dropped categories/series.
+fn overflow_notes(cat_overflow: usize, series_overflow: usize) -> String {
+    let mut s = String::new();
+    if cat_overflow > 0 {
+        s.push_str(&format!(
+            "_… and {cat_overflow} more categories omitted from the chart; see table above._\n"
+        ));
+    }
+    if series_overflow > 0 {
+        s.push_str(&format!(
+            "_… and {series_overflow} more series omitted from the chart; see table above._\n"
+        ));
+    }
+    s
+}
+
+// ─── Column resolution + value helpers ──────────────────────────────────────
+
+/// Resolve a marker field name to a table column index by fuzzy name matching.
+///
+/// Why: marker field names (`factor`, `tqi_rank`) are semantic hints, not exact
+/// header text (`Factor`, `Rank`); a tiered normalized match maps them robustly
+/// without the marker author having to echo the exact column header.
+/// What: normalizes both sides to lowercase alphanumerics and tries, in priority
+/// order over the full field then its last `_`/space token: exact equality,
+/// header-starts-with, header-contains.  Returns the first matching column.
+/// Test: `mermaid_tests.rs::{resolves_exact_column, resolves_by_last_token}`.
+fn resolve_column(header: &[String], field: &str) -> Option<usize> {
+    let full = normalize(field);
+    let last_raw = field.rsplit(['_', ' ']).next().unwrap_or(field);
+    let last = normalize(last_raw);
+    let norms: Vec<String> = header.iter().map(|h| normalize(h)).collect();
+    let targets = [&full, &last];
+
+    for t in targets {
+        if !t.is_empty()
+            && let Some(i) = norms.iter().position(|h| h == t)
+        {
+            return Some(i);
+        }
+    }
+    for t in targets {
+        if !t.is_empty()
+            && let Some(i) = norms.iter().position(|h| h.starts_with(t.as_str()))
+        {
+            return Some(i);
+        }
+    }
+    for t in targets {
+        if !t.is_empty()
+            && let Some(i) = norms.iter().position(|h| h.contains(t.as_str()))
+        {
+            return Some(i);
+        }
+    }
+    None
+}
+
+/// Lowercase a string down to its ASCII alphanumerics (drop spaces/punctuation).
+fn normalize(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+/// Parse a numeric y-value cell, tolerant of provenance markers and separators.
+///
+/// Why: rendered value cells carry provenance superscripts (` ⁽ᵐ⁾`), thousands
+/// separators, `$`/`%`, and stray whitespace; the chart needs the bare number.
+/// What: strips the provenance superscript codepoints and `$ % , ` whitespace,
+/// then parses the remainder as `f64`.  A non-numeric remainder yields `None`
+/// (the caller skips that row).
+/// Test: `mermaid_tests.rs::parse_num_strips_markers`.
+fn parse_num(cell: &str) -> Option<f64> {
+    let cleaned: String = cell
+        .chars()
+        .filter(|c| {
+            !matches!(
+                c,
+                '$' | '%' | ',' | ' ' | '\t' | '⁽' | '⁾' | 'ᵐ' | 'ᵈ' | 'ⁱ'
+            )
+        })
+        .collect();
+    let cleaned = cleaned.trim();
+    if cleaned.is_empty() {
+        None
+    } else {
+        cleaned.parse::<f64>().ok()
+    }
+}
+
+/// Format an `f64` compactly: integers without a decimal, else trimmed decimals.
+fn fmt_num(v: f64) -> String {
+    if v.fract() == 0.0 && v.abs() < 1e15 {
+        format!("{}", v as i64)
+    } else {
+        let s = format!("{v:.4}");
+        s.trim_end_matches('0').trim_end_matches('.').to_string()
+    }
+}
+
+/// Join numeric values as a comma-separated Mermaid list.
+fn num_list(values: &[f64]) -> String {
+    values
+        .iter()
+        .map(|v| fmt_num(*v))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Join category labels as a comma-separated list of quoted Mermaid strings.
+fn axis_list(cats: &[String]) -> String {
+    cats.iter().map(|c| quote(c)).collect::<Vec<_>>().join(", ")
+}
+
+/// A Mermaid double-quoted label with internal quotes sanitized.
+fn quote(label: &str) -> String {
+    let clean = label.trim().replace('"', "'");
+    if clean.is_empty() {
+        "\"?\"".to_string()
+    } else {
+        format!("\"{clean}\"")
+    }
+}
+
+/// A `radar-beta` bracketed, quoted label: `["Label"]`.
+fn bracket_label(label: &str) -> String {
+    format!("[{}]", quote(label))
+}
+
+/// Humanize a slug/field for a chart title: underscores → spaces, trimmed.
+fn humanize(s: &str) -> String {
+    s.replace('_', " ").trim().to_string()
+}
+
+#[cfg(test)]
+#[path = "mermaid_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/mermaid_tests.rs
+++ b/crates/trusty-review/src/report/mermaid_tests.rs
@@ -1,0 +1,286 @@
+//! Unit tests for the Mermaid chart renderer (#2366 wave-4).
+//!
+//! Why: the chart output is deterministic and syntax-sensitive (Mermaid parses
+//! `xychart-beta`/`radar-beta` strictly); these tests pin the block header +
+//! structure per chart type, the numeric-parse tolerance, label escaping/caps,
+//! the heatmap fallback, empty-dataset omission, and end-to-end injection.
+//! What: exercises [`inject`] end-to-end plus the internal helpers via the
+//! module's private surface (same-crate `mod tests`).
+//! Test: this file IS the test.
+
+use super::*;
+
+/// A dataset marker + its populated table, as it appears post-polish.
+fn radar_input() -> &'static str {
+    "<!-- dataset: health_factors_by_app | chart: radar | x: factor | y: score, group: application -->\n\
+     | Application | Factor | Score (native 1-4) | Normalized (0-100) |\n\
+     |---|---|---|---|\n\
+     | App One | Reliability | 3 ⁽ᵐ⁾ | 75 ⁽ᵐ⁾ |\n\
+     | App One | Security | 2 ⁽ᵐ⁾ | 50 ⁽ᵐ⁾ |\n\
+     | App Two | Reliability | 4 ⁽ᵐ⁾ | 100 ⁽ᵐ⁾ |\n\
+     | App Two | Security | 1 ⁽ᵐ⁾ | 25 ⁽ᵐ⁾ |\n"
+}
+
+/// Why: a `bar` marker must emit a valid `xychart-beta` bar block under its table.
+/// What: asserts the fence, chart header, quoted x-axis, y-axis, and bar series.
+/// Test: this test.
+#[test]
+fn injects_bar_after_table() {
+    let input = "<!-- dataset: tqi_benchmark_position | chart: bar | x: application | y: tqi_rank -->\n\
+                 | Application | Peer set | Compliance % | Quartile | Rank | Rank total |\n\
+                 |---|---|---|---|---|---|\n\
+                 | App One | SaaS | 62% ⁽ᵈ⁾ | Q2 | 2 ⁽ᵈ⁾ | 8 |\n\
+                 | App Two | SaaS | 40% ⁽ᵈ⁾ | Q3 | 5 ⁽ᵈ⁾ | 8 |\n";
+    let out = inject(input);
+    assert!(out.contains("```mermaid"), "block emitted:\n{out}");
+    assert!(out.contains("xychart-beta"));
+    assert!(out.contains("x-axis [\"App One\", \"App Two\"]"), "{out}");
+    assert!(out.contains("bar [2, 5]"), "rank y-values resolved:\n{out}");
+    // Block appears AFTER the table (the last table row precedes the fence).
+    let table_pos = out.find("| App Two |").unwrap();
+    let block_pos = out.find("```mermaid").unwrap();
+    assert!(table_pos < block_pos);
+}
+
+/// Why: `radar` → `radar-beta` with a curve per group and the version-floor note.
+/// What: asserts the `radar-beta` header, the version comment, axes, and curves.
+/// Test: this test.
+#[test]
+fn renders_radar() {
+    let out = inject(radar_input());
+    assert!(out.contains("radar-beta"), "{out}");
+    assert!(out.contains("%% radar-beta requires Mermaid >= 11.6"));
+    // Axes = distinct x (factor) values; curves = distinct group (application).
+    assert!(
+        out.contains("axis a0[\"Reliability\"], a1[\"Security\"]"),
+        "{out}"
+    );
+    assert!(out.contains("curve c0[\"App One\"]{3, 2}"), "{out}");
+    assert!(out.contains("curve c1[\"App Two\"]{4, 1}"), "{out}");
+}
+
+/// Why: `stacked-bar` → layered `xychart-beta` with one bar series per group and
+/// the documented no-native-stacking disclosure.
+/// What: asserts the approximation comment, one bar line per group, and the
+/// front-to-back legend note.
+/// Test: this test.
+#[test]
+fn renders_stacked_bar() {
+    let input = "<!-- dataset: violations_by_domain | chart: stacked-bar | x: application | y: violation_count, group: domain -->\n\
+                 | Application | Domain | Violation count | Compliance % |\n\
+                 |---|---|---|---|\n\
+                 | App One | Security | 10 ⁽ᵐ⁾ | 80% |\n\
+                 | App One | Reliability | 5 ⁽ᵐ⁾ | 90% |\n\
+                 | App Two | Security | 3 ⁽ᵐ⁾ | 95% |\n";
+    let out = inject(input);
+    assert!(
+        out.contains("%% stacked-bar approximated as layered"),
+        "{out}"
+    );
+    assert!(out.contains("xychart-beta"));
+    // Two group values (Security, Reliability) → two layered bar series.
+    let bars = out.matches("    bar [").count();
+    assert_eq!(bars, 2, "one bar per group:\n{out}");
+    assert!(
+        out.contains("_Layered series (front-to-back): Security, Reliability._"),
+        "{out}"
+    );
+}
+
+/// Why: `heatmap` has no Mermaid support — the fallback is a note, not a block.
+/// What: asserts NO ```mermaid fence and the presence of the note.
+/// Test: this test.
+#[test]
+fn heatmap_fallback_note_only() {
+    let input = "<!-- dataset: cve_by_component_severity | chart: heatmap | x: component | y: severity -->\n\
+                 | Application | Component | Severity | CVE ids / Count |\n\
+                 |---|---|---|---|\n\
+                 | App One | openssl | high | CVE-1 |\n";
+    let out = inject(input);
+    assert!(!out.contains("```mermaid"), "no block for heatmap:\n{out}");
+    assert!(out.contains("_(heatmap: no Mermaid rendering; see table above)_"));
+}
+
+/// Why: an unknown/absent chart type must never panic and emit no block.
+/// What: a marker with an unrecognized chart yields the table unchanged.
+/// Test: this test.
+#[test]
+fn unknown_chart_no_block() {
+    let input = "<!-- dataset: mystery | chart: bubble | x: a | y: b -->\n\
+                 | A | B |\n|---|---|\n| x | 1 |\n";
+    let out = inject(input);
+    assert!(!out.contains("```mermaid"), "{out}");
+}
+
+/// Why: an empty dataset (table dropped by omit-empty) gets no chart.
+/// What: a marker with no following table passes through untouched.
+/// Test: this test.
+#[test]
+fn empty_dataset_no_chart() {
+    let input = "<!-- dataset: loc_by_technology | chart: bar | x: application | y: loc -->\n\
+                 \n## Next section\n";
+    let out = inject(input);
+    assert!(!out.contains("```mermaid"), "{out}");
+    assert!(out.contains("## Next section"));
+}
+
+/// Why: numeric parsing must strip provenance markers, `$`, `%`, and thousands
+/// separators before charting.
+/// What: pins the cleaned parse across representative cell shapes.
+/// Test: this test.
+#[test]
+fn parse_num_strips_markers() {
+    assert_eq!(parse_num("8200 ⁽ᵐ⁾"), Some(8200.0));
+    assert_eq!(parse_num("$1,200,000 ⁽ᵈ⁾"), Some(1_200_000.0));
+    assert_eq!(parse_num("45% ⁽ⁱ⁾"), Some(45.0));
+    assert_eq!(parse_num("3.5"), Some(3.5));
+    assert_eq!(parse_num("n/a"), None);
+    assert_eq!(parse_num(""), None);
+}
+
+/// Why: a non-numeric y skips only that row; a chart still renders from the rest.
+/// What: one bad row is dropped, the good rows still chart.
+/// Test: this test.
+#[test]
+fn skips_non_numeric_rows() {
+    let input = "<!-- dataset: d | chart: bar | x: name | y: count -->\n\
+                 | Name | Count |\n|---|---|\n| a | 5 |\n| b | n/a |\n| c | 7 |\n";
+    let out = inject(input);
+    assert!(
+        out.contains("x-axis [\"a\", \"c\"]"),
+        "bad row dropped:\n{out}"
+    );
+    assert!(out.contains("bar [5, 7]"));
+}
+
+/// Why: all-non-numeric y → no chart at all (nothing to plot).
+/// What: a table whose y column never parses emits no block.
+/// Test: this test.
+#[test]
+fn all_non_numeric_no_chart() {
+    let input = "<!-- dataset: d | chart: bar | x: name | y: count -->\n\
+                 | Name | Count |\n|---|---|\n| a | n/a |\n| b | tbd |\n";
+    assert!(!inject(input).contains("```mermaid"));
+}
+
+/// Why: labels with spaces/quotes must be Mermaid-escaped (quoted; `\"` sanitized).
+/// What: a category containing a double-quote renders with it replaced by `'`.
+/// Test: this test.
+#[test]
+fn escapes_labels() {
+    let input = "<!-- dataset: d | chart: bar | x: name | y: count -->\n\
+                 | Name | Count |\n|---|---|\n| a \"b\" c | 5 |\n";
+    let out = inject(input);
+    assert!(out.contains("x-axis [\"a 'b' c\"]"), "{out}");
+}
+
+/// Why: categories are capped at [`MAX_CATEGORIES`] with an "and N more" note.
+/// What: 15 categories → 12 charted + a "3 more categories" note.
+/// Test: this test.
+#[test]
+fn caps_categories() {
+    let mut input = String::from(
+        "<!-- dataset: d | chart: bar | x: name | y: count -->\n| Name | Count |\n|---|---|\n",
+    );
+    for i in 0..15 {
+        input.push_str(&format!("| cat{i} | {i} |\n"));
+    }
+    let out = inject(&input);
+    assert!(out.contains("_… and 3 more categories omitted"), "{out}");
+    // Only the first 12 categories appear in the axis list.
+    assert!(out.contains("\"cat11\""));
+    assert!(!out.contains("\"cat12\""));
+}
+
+/// Why: series (group values) are capped at [`MAX_SERIES`] with an overflow note.
+/// What: 10 groups → 8 charted + a "2 more series" note.
+/// Test: this test.
+#[test]
+fn caps_series() {
+    let mut input = String::from(
+        "<!-- dataset: d | chart: stacked-bar | x: cat | y: v, group: g -->\n| Cat | V | G |\n|---|---|---|\n",
+    );
+    for i in 0..10 {
+        input.push_str(&format!("| c | {i} | grp{i} |\n"));
+    }
+    let out = inject(&input);
+    assert!(out.contains("_… and 2 more series omitted"), "{out}");
+}
+
+/// Why: a marker with a group on a `bar` chart aggregates the group away (single
+/// series summed per x), per the documented mapping.
+/// What: two rows sharing an x with different groups sum into one bar.
+/// Test: this test.
+#[test]
+fn bar_aggregates_group_away() {
+    let input = "<!-- dataset: d | chart: bar | x: bucket | y: count, group: app -->\n\
+                 | Bucket | Count | App |\n|---|---|---|\n\
+                 | low | 3 | A |\n| low | 2 | B |\n| high | 4 | A |\n";
+    let out = inject(input);
+    assert!(out.contains("bar [5, 4]"), "low=3+2, high=4:\n{out}");
+}
+
+/// Why: content inside a fenced block must never be interpreted as a marker.
+/// What: a dataset marker written inside a ``` fence is passed through verbatim,
+/// no chart injected.
+/// Test: this test.
+#[test]
+fn fenced_marker_is_opaque() {
+    let input = "```\n<!-- dataset: d | chart: bar | x: a | y: b -->\n| A | B |\n|---|---|\n| x | 1 |\n```\n";
+    let out = inject(input);
+    assert!(
+        !out.contains("xychart-beta"),
+        "fenced marker not charted:\n{out}"
+    );
+}
+
+/// Why: chart-type parsing is the closed vocabulary the mapping keys off.
+/// What: pins each recognized value and the unknown fallback.
+/// Test: this test.
+#[test]
+fn parses_chart_types() {
+    assert_eq!(parse_chart("bar"), ChartType::Bar);
+    assert_eq!(parse_chart("stacked-bar"), ChartType::StackedBar);
+    assert_eq!(parse_chart("radar"), ChartType::Radar);
+    assert_eq!(parse_chart("heatmap"), ChartType::Heatmap);
+    assert_eq!(parse_chart("pie"), ChartType::Unknown);
+}
+
+/// Why: column resolution maps semantic field names to real headers.
+/// What: exact match, last-token match, and a miss.
+/// Test: this test.
+#[test]
+fn resolves_columns() {
+    let header: Vec<String> = ["Application", "Factor", "Score (native 1-4)"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(resolve_column(&header, "factor"), Some(1));
+    assert_eq!(resolve_column(&header, "score"), Some(2));
+    assert_eq!(resolve_column(&header, "application"), Some(0));
+    assert_eq!(resolve_column(&header, "nonesuch"), None);
+
+    let ranks: Vec<String> = ["Application", "Rank", "Rank total"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(resolve_column(&ranks, "tqi_rank"), Some(1));
+}
+
+/// Why: a full end-to-end report with ≥2 populated datasets must emit a valid
+/// mermaid block after EACH table (integration of the injection loop).
+/// What: a bar dataset followed by a radar dataset both get their blocks.
+/// Test: this test.
+#[test]
+fn two_datasets_both_charted() {
+    let input = format!(
+        "## 7. Graph-Ready Data Appendix\n\n\
+         <!-- dataset: loc | chart: bar | x: tech | y: loc -->\n\
+         | Tech | LoC |\n|---|---|\n| Rust | 8200 ⁽ᵐ⁾ |\n| Python | 3100 ⁽ᵐ⁾ |\n\n{}",
+        radar_input()
+    );
+    let out = inject(&input);
+    assert_eq!(out.matches("```mermaid").count(), 2, "two blocks:\n{out}");
+    assert!(out.contains("xychart-beta"));
+    assert!(out.contains("radar-beta"));
+}

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -20,6 +20,7 @@ pub mod git_info;
 pub mod instructions;
 pub mod investigate;
 pub mod manifest;
+pub mod mermaid;
 pub mod metrics;
 pub mod model;
 pub mod polish;
@@ -51,6 +52,7 @@ pub use manifest::{
     Manifest, ReportSection, RepositoryEntry, RepositorySource, load_manifest, parse_manifest,
     slugify,
 };
+pub use mermaid::inject as inject_mermaid;
 pub use metrics::{AnalyzeMetrics, MetricFinding, Severity, load_metrics};
 pub use model::{ReportModel, RepositoryReport};
 pub use polish::{polish, strip_template_comments};

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -27,6 +27,7 @@ pub mod polish;
 pub mod provenance;
 pub mod reporter;
 pub mod reporter_fill;
+pub mod reporter_graph_datasets;
 pub mod scan;
 pub mod section_instructions;
 pub mod synthesize;

--- a/crates/trusty-review/src/report/polish_tests.rs
+++ b/crates/trusty-review/src/report/polish_tests.rs
@@ -117,6 +117,36 @@ fn fenced_code_resembling_markers_is_untouched() {
     assert!(out.contains("| a | b |"));
 }
 
+/// Why: a ```mermaid fenced block (#2366) must be OPAQUE to `polish` exactly like
+/// an evidence fence — a `title`/`bar`-looking line, a `%%` comment, or a bare
+/// heading-looking token inside it must never be interpreted as a marker, table
+/// row, or heading and never trigger a spliced collapse line.
+/// What: a section whose body is a mermaid block (with an inner blank line and a
+/// `#`-looking comment) survives `polish()` verbatim with no gap splice.
+/// Test: this test itself.
+#[test]
+fn mermaid_fence_is_opaque_to_polish() {
+    let input = "## 7. Appendix\n\n\
+        <!-- dataset: d | chart: bar | x: a | y: b -->\n\
+        | A | B |\n|---|---|\n| x | 1 |\n\n\
+        ```mermaid\n\
+        xychart-beta\n\
+        %% a comment\n\
+        \n\
+        x-axis [\"x\"]\n\
+        bar [1]\n\
+        ```\n";
+    let out = polish(input);
+    assert!(
+        out.contains("```mermaid\nxychart-beta\n%% a comment\n\nx-axis [\"x\"]\nbar [1]\n```"),
+        "mermaid fence survives polish verbatim: {out}"
+    );
+    assert!(
+        !out.contains("No data available"),
+        "no splice around mermaid: {out}"
+    );
+}
+
 /// Why: a metadata row whose value is only the honesty marker is empty
 /// scaffolding — it must be dropped and the field recorded under Data gaps, while
 /// rows with real values survive.

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -23,6 +23,9 @@ use super::model::{ReportModel, RepositoryReport};
 use super::polish::polish;
 use super::provenance::{self, Provenance, tag};
 use super::reporter_fill::{crate_version, fill_profile, instructions_block, set_scoring_model};
+use super::reporter_graph_datasets::{
+    inject_complexity_distribution_dataset, inject_loc_by_technology_dataset,
+};
 
 /// Renders a [`ReportModel`] to markdown + JSON and writes them atomically.
 ///
@@ -240,6 +243,12 @@ fn build_scope(model: &ReportModel) -> Scope {
     if let Some(bench) = &model.benchmark {
         inject_benchmark_dataset(&mut root, model, bench);
     }
+
+    // #2366 follow-up (live-QA): the §7 graph appendix must produce REAL charts
+    // on a bare run, not empty scaffolding — these two datasets are wired to data
+    // the model already computes (scan/metrics), never fabricated.
+    inject_loc_by_technology_dataset(&mut root, model);
+    inject_complexity_distribution_dataset(&mut root, model);
 
     // Live-QA defect #2314: RED/AMBER finding blocks are deterministic, not
     // synthesis-gated — title/category/component come verbatim from

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -32,10 +32,16 @@ use super::reporter_fill::{crate_version, fill_profile, instructions_block, set_
 /// Test: `reporter_tests.rs::{render_contains_expected, write_emits_both}`.
 pub struct Reporter {
     output_dir: PathBuf,
+    /// Whether to render Mermaid charts under populated dataset tables (#2366).
+    ///
+    /// Why: charts are on by default but disabled via `--no-mermaid` / manifest
+    /// `[report] mermaid = false`; when off the output is byte-identical to the
+    /// pre-wave-4 report (the injection pass is simply skipped).
+    mermaid: bool,
 }
 
 impl Reporter {
-    /// Create a reporter writing to `output_dir`.
+    /// Create a reporter writing to `output_dir` (Mermaid charts on by default).
     ///
     /// Why: callers choose the output directory (`--out`, default `./reports`).
     /// What: stores the directory; it is created on `write` if absent.
@@ -43,7 +49,20 @@ impl Reporter {
     pub fn new(output_dir: impl Into<PathBuf>) -> Self {
         Self {
             output_dir: output_dir.into(),
+            mermaid: true,
         }
+    }
+
+    /// Set whether Mermaid charts are rendered (#2366).
+    ///
+    /// Why: the CLI resolves the on/off decision (flag OR manifest key) and threads
+    /// it in without changing `render`'s signature.
+    /// What: consumes and returns `self` with the flag set; `false` disables the
+    /// post-polish injection pass, keeping output byte-identical to pre-wave-4.
+    /// Test: `reporter_tests.rs::no_mermaid_byte_identical`.
+    pub fn with_mermaid(mut self, mermaid: bool) -> Self {
+        self.mermaid = mermaid;
+        self
     }
 
     /// Render the model into markdown using the supplied template source.
@@ -67,6 +86,13 @@ impl Reporter {
         // never mistaken for real placeholders by the fill engine.
         let filled = render(strip_leading_comment(template), &scope);
         let mut out = polish(&filled);
+        // #2366 wave-4: render a ```mermaid chart under every populated dataset
+        // table.  Runs AFTER polish (so it sees the omit-empty'd tables and never
+        // charts a dropped/empty dataset) and BEFORE the appended status notes.
+        // When disabled the pass is skipped entirely — output stays byte-identical.
+        if self.mermaid {
+            out = super::mermaid::inject(&out);
+        }
         // Status notes are appended AFTER polish so their bullets are not subject
         // to omit-empty (they are always meaningful provenance, never markers).
         append_synthesis_note(&mut out, model);

--- a/crates/trusty-review/src/report/reporter_fill.rs
+++ b/crates/trusty-review/src/report/reporter_fill.rs
@@ -184,7 +184,12 @@ pub(super) fn format_language_breakdown(langs: &[super::metrics::LanguageLoc], n
 }
 
 /// Format a `u64` with comma thousands separators (e.g. `19568` → `"19,568"`).
-fn format_thousands(n: u64) -> String {
+///
+/// `pub(super)` (not private): the §7 graph-appendix `loc_by_technology` dataset
+/// fill (`reporter.rs::inject_loc_by_technology_dataset`, #2366 follow-up) reuses
+/// this exact formatting for its per-language LoC cells, so the appendix number
+/// matches the Profile section's tech-stack summary byte-for-byte.
+pub(super) fn format_thousands(n: u64) -> String {
     let digits = n.to_string();
     let mut out = String::with_capacity(digits.len() + digits.len() / 3);
     for (i, ch) in digits.chars().rev().enumerate() {

--- a/crates/trusty-review/src/report/reporter_graph_datasets.rs
+++ b/crates/trusty-review/src/report/reporter_graph_datasets.rs
@@ -1,0 +1,126 @@
+//! §7 Graph-Ready Data Appendix dataset fill: repo-derivable datasets (#2366
+//! follow-up).
+//!
+//! Why: live-QA on a real bare `report` run (no `--synthesize`, no external
+//! trusty-analyze metrics JSON) found the §7 appendix entirely empty — every
+//! dataset table collapsed under omit-empty and the wave-4 Mermaid renderer had
+//! nothing to chart.  Root cause: `loc_by_technology`'s data (per-language LoC)
+//! is exactly what the built-in scan (#2342.3) already computes, but the
+//! dataset had no fill path at all.  Factoring these injectors into their own
+//! module (rather than growing `reporter.rs` further) keeps the reporter under
+//! the SLOC cap and gives this dataset-population concern one home, mirroring
+//! `reporter_fill.rs`'s per-application profile fill.
+//! What: [`inject_loc_by_technology_dataset`] and
+//! [`inject_complexity_distribution_dataset`] — both `pub(super)` so
+//! `reporter.rs::build_scope` calls them while they stay crate-internal. Every
+//! other §7 dataset (violations, CVEs, license tiers, remediation economics,
+//! …) has no deterministic source anywhere in the model yet and correctly stays
+//! empty by design — see the spec's "Dataset population" table for the full
+//! per-dataset status.
+//! Test: `reporter_tests.rs::{bare_scan_populates_loc_by_technology,
+//! declared_metrics_win_for_loc_by_technology,
+//! complexity_distribution_fills_from_metrics,
+//! complexity_distribution_empty_without_metrics}`; end-to-end via
+//! `tests/report_e2e.rs::end_to_end_bare_scan_emits_mermaid_chart`.
+
+use super::fill::Scope;
+use super::metrics::LanguageLoc;
+use super::model::ReportModel;
+use super::provenance::{Provenance, tag};
+use super::reporter_fill::format_thousands;
+
+/// Fill the graph-appendix `loc_by_technology` dataset — one row per
+/// (application, language) pair, from data the model ALREADY computes.
+///
+/// Why: this dataset's data (per-language LoC) is exactly what already fills
+/// the Profile section's "Technology stack" line (`fill_profile` /
+/// `format_language_breakdown`) — this is the SAME data, just exploded into one
+/// row per language instead of joined into one summary string, so a bare
+/// scan-only run emits a real stacked-bar chart instead of empty scaffolding.
+/// What: for each repository, prefers declared metrics (`repo.metrics.loc.
+/// by_language`) over the measured scan (`repo.scan.by_language`) — same
+/// precedence as `fill_profile` — and pushes one `loc_by_tech_row` child per
+/// language, largest first, with `tech_pct` computed against the breakdown's
+/// own total (so the column always sums to 100% regardless of source). A
+/// repository with no language data from either source contributes nothing
+/// (omit-empty applies as usual).
+/// Test: `reporter_tests.rs::{bare_scan_populates_loc_by_technology,
+/// declared_metrics_win_for_loc_by_technology}`.
+pub(super) fn inject_loc_by_technology_dataset(root: &mut Scope, model: &ReportModel) {
+    for repo in &model.repositories {
+        let source: Option<(&[LanguageLoc], Provenance)> = repo
+            .metrics
+            .as_ref()
+            .map(|m| m.loc.by_language.as_slice())
+            .filter(|langs| !langs.is_empty())
+            .map(|langs| (langs, Provenance::Declared))
+            .or_else(|| {
+                repo.scan
+                    .as_ref()
+                    .map(|s| s.by_language.as_slice())
+                    .filter(|langs| !langs.is_empty())
+                    .map(|langs| (langs, Provenance::Measured))
+            });
+        let Some((langs, prov)) = source else {
+            continue;
+        };
+        let total: u64 = langs.iter().map(|l| l.loc).sum();
+        if total == 0 {
+            continue;
+        }
+        let mut sorted: Vec<&LanguageLoc> = langs.iter().collect();
+        sorted.sort_by(|a, b| b.loc.cmp(&a.loc).then_with(|| a.language.cmp(&b.language)));
+        for lang in sorted {
+            let pct = (lang.loc as f64 / total as f64) * 100.0;
+            let mut row = Scope::new();
+            row.set("app_name", repo.name.clone());
+            row.set("tech_name", lang.language.clone());
+            row.set("tech_loc", tag(format_thousands(lang.loc), prov));
+            row.set("tech_pct", tag(format!("{pct:.0}%"), prov));
+            root.push_block("loc_by_tech_row", row);
+        }
+    }
+}
+
+/// Fill the graph-appendix `complexity_distribution` dataset — one row per
+/// (application, complexity bucket).
+///
+/// Why: unlike LoC-by-language, cyclomatic-complexity buckets are NOT
+/// computable by the built-in scan (`RepoScan` has no complexity analysis) —
+/// they exist only in an externally supplied trusty-analyze metrics JSON
+/// (`AnalyzeMetrics::complexity`). Per the honesty rule, a bare scan-only run
+/// correctly leaves this dataset empty (omit-empty collapses the table, no
+/// chart) rather than fabricating buckets from nothing; this is a genuine data
+/// gap, not a bug (see `docs/trusty-review/spec/report-generation.md`).
+/// What: for each repository with a non-empty declared `metrics.complexity.
+/// buckets`, pushes one `complexity_bucket_row` child per bucket (declared
+/// order preserved) with `complexity_pct` computed against the bucket total.
+/// Test: `reporter_tests.rs::{complexity_distribution_fills_from_metrics,
+/// complexity_distribution_empty_without_metrics}`.
+pub(super) fn inject_complexity_distribution_dataset(root: &mut Scope, model: &ReportModel) {
+    for repo in &model.repositories {
+        let Some(metrics) = &repo.metrics else {
+            continue;
+        };
+        let buckets = &metrics.complexity.buckets;
+        let total: u64 = buckets.iter().map(|b| b.count).sum();
+        if total == 0 {
+            continue;
+        }
+        for bucket in buckets {
+            let pct = (bucket.count as f64 / total as f64) * 100.0;
+            let mut row = Scope::new();
+            row.set("app_name", repo.name.clone());
+            row.set("complexity_bucket", bucket.label.clone());
+            row.set(
+                "complexity_count",
+                tag(bucket.count.to_string(), Provenance::Declared),
+            );
+            row.set(
+                "complexity_pct",
+                tag(format!("{pct:.0}%"), Provenance::Declared),
+            );
+            root.push_block("complexity_bucket_row", row);
+        }
+    }
+}

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -1290,6 +1290,204 @@ fn no_mermaid_byte_identical() {
     assert!(off.contains("| Rust | 8200 |"), "table itself untouched");
 }
 
+// ─── §7 graph-appendix repo-derivable dataset fill (#2366 follow-up) ───────
+
+/// Initialise a tiny git repo at `dir` with Rust + TypeScript sources so
+/// `scan_repo` computes a real, non-empty per-language LoC breakdown (mirrors
+/// `scan_tests.rs::git_init_add`).
+fn git_repo_with_languages(dir: &Path) {
+    std::fs::write(
+        dir.join("main.rs"),
+        "fn main() {\n    work();\n    work();\n}\n",
+    )
+    .expect("write rs");
+    std::fs::write(
+        dir.join("app.ts"),
+        "const x = 1;\nexport {};\nconst y = 2;\n",
+    )
+    .expect("write ts");
+    let _ = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .arg("init")
+        .output();
+    let _ = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["add", "-A"])
+        .output();
+}
+
+/// Why: live-QA on a real bare run (no `--synthesize`, no external metrics JSON)
+/// found the §7 `loc_by_technology` dataset table NEVER populated — it had no
+/// fill path, so it collapsed under omit-empty and the Mermaid injector had
+/// nothing to chart. This dataset's data (per-language LoC) is exactly what the
+/// built-in scan already computes.
+/// What: builds a model from a manifest pointing at a REAL scanned checkout (no
+/// `metrics` key) using the bundled `report-technical-dd` template, and asserts
+/// the dataset table renders with the scanned languages under `measured`
+/// provenance, and a real `xychart-beta` chart follows it.
+/// Test: this test itself.
+#[test]
+fn bare_scan_populates_loc_by_technology() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo_dir = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo_dir).expect("mkdir");
+    git_repo_with_languages(&repo_dir);
+
+    let manifest_toml = format!(
+        "[report]\ntitle = \"Bare Scan DD\"\n\n[[repositories]]\nname = \"Acme\"\npath = \"{}\"\n",
+        repo_dir.display()
+    );
+    let manifest_path = tmp.path().join("manifest.toml");
+    let manifest = parse_manifest(&manifest_toml, &manifest_path).expect("manifest parse");
+    let model = ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("model builds");
+    // Sanity: the scan actually ran and found languages (else this test proves nothing).
+    let scan = model.repositories[0].scan.as_ref().expect("scan present");
+    assert!(!scan.by_language.is_empty(), "scan found languages");
+
+    let template = TemplateLoader::new()
+        .load("report-technical-dd")
+        .expect("template loads");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("Rust"), "loc_by_technology row for Rust:\n{md}");
+    assert!(
+        md.contains("TypeScript"),
+        "loc_by_technology row for TS:\n{md}"
+    );
+    // Measured provenance: no metrics JSON was supplied, only the scan.
+    assert!(
+        md.contains('⁽'),
+        "measured/declared provenance tag present:\n{md}"
+    );
+    // A real mermaid chart renders under the now-populated dataset.
+    assert!(
+        md.contains("```mermaid"),
+        "chart emitted for scan-only run:\n{md}"
+    );
+    assert!(md.contains("xychart-beta"));
+}
+
+/// Why: an external trusty-analyze metrics JSON is ENRICHMENT that must win over
+/// the measured scan (mirrors `fill_profile`'s existing precedence) — a stale or
+/// differing scan number must never leak into the dataset table when a more
+/// authoritative declared figure exists.
+/// What: a repo with BOTH a real scanned checkout AND a metrics JSON declaring a
+/// different LoC for the same language; asserts the DECLARED number renders
+/// (under its provenance tag), not the scanned one.
+/// Test: this test itself.
+#[test]
+fn declared_metrics_win_for_loc_by_technology() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo_dir = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo_dir).expect("mkdir");
+    git_repo_with_languages(&repo_dir); // scan would find a handful of Rust lines
+
+    std::fs::write(
+        tmp.path().join("acme.json"),
+        r#"{ "loc": { "total": 9000, "by_language": [
+          { "language": "Rust", "loc": 9000 }
+        ]}}"#,
+    )
+    .expect("write metrics");
+
+    let manifest_toml = format!(
+        "[report]\ntitle = \"Declared Wins\"\n\n[[repositories]]\nname = \"Acme\"\npath = \"{}\"\nmetrics = \"acme.json\"\n",
+        repo_dir.display()
+    );
+    let manifest_path = tmp.path().join("manifest.toml");
+    let manifest = parse_manifest(&manifest_toml, &manifest_path).expect("manifest parse");
+    let model = ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("model builds");
+
+    let template = TemplateLoader::new()
+        .load("report-technical-dd")
+        .expect("template loads");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("9,000"), "declared LoC wins over scan:\n{md}");
+    assert!(
+        md.contains(&format!("9,000{}", crate::report::provenance::DECLARED_TAG)),
+        "declared provenance tag on the declared value:\n{md}"
+    );
+}
+
+/// Why: cyclomatic-complexity buckets are NOT computable by the built-in scan
+/// (`RepoScan` has no complexity analysis) — they exist only in an externally
+/// supplied trusty-analyze metrics JSON. When that data IS present, wiring must
+/// fill the dataset from it (never fabricate).
+/// What: a repo whose metrics declare two complexity buckets; asserts both
+/// bucket labels/percentages render and a `xychart-beta` bar chart follows.
+/// Test: this test itself.
+#[test]
+fn complexity_distribution_fills_from_metrics() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("acme.json"),
+        r#"{ "complexity": { "buckets": [
+          { "label": "low (1-5)", "count": 80 },
+          { "label": "high (>20)", "count": 20 }
+        ]}}"#,
+    )
+    .expect("write metrics");
+    let manifest_toml = "[report]\ntitle = \"Complexity\"\n\n[[repositories]]\nname = \"Acme\"\npath = \"/nonexistent/acme\"\nmetrics = \"acme.json\"\n";
+    let manifest_path = tmp.path().join("manifest.toml");
+    let manifest = parse_manifest(manifest_toml, &manifest_path).expect("manifest parse");
+    let model = ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("model builds");
+    let template = TemplateLoader::new()
+        .load("report-technical-dd")
+        .expect("template loads");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("low (1-5)"), "{md}");
+    assert!(md.contains("high (>20)"), "{md}");
+    assert!(md.contains("80%"), "80/100 buckets:\n{md}");
+    assert!(md.contains("20%"), "20/100 buckets:\n{md}");
+    assert!(
+        md.contains("```mermaid"),
+        "chart emitted for complexity dataset:\n{md}"
+    );
+}
+
+/// Why: a bare scan-only run has NO complexity data — the dataset must stay
+/// empty (omit-empty) rather than fabricating buckets from nothing, and no
+/// chart should render for it, even while a SIBLING repo-derivable dataset
+/// (`loc_by_technology`) in the same §7 section DOES populate and chart.
+/// What: a repo with a real scanned checkout but no `metrics` key; asserts no
+/// complexity bucket data leaks in and exactly one `xychart-beta` chart renders
+/// (the loc_by_technology one) — proving complexity contributed no chart.
+/// Test: this test itself.
+#[test]
+fn complexity_distribution_empty_without_metrics() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo_dir = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo_dir).expect("mkdir");
+    git_repo_with_languages(&repo_dir);
+
+    let manifest_toml = format!(
+        "[report]\ntitle = \"No Complexity\"\n\n[[repositories]]\nname = \"Acme\"\npath = \"{}\"\n",
+        repo_dir.display()
+    );
+    let manifest_path = tmp.path().join("manifest.toml");
+    let manifest = parse_manifest(&manifest_toml, &manifest_path).expect("manifest parse");
+    let model = ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("model builds");
+    let template = TemplateLoader::new()
+        .load("report-technical-dd")
+        .expect("template loads");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(!md.contains("low ("), "no fabricated bucket label:\n{md}");
+    assert_eq!(
+        md.matches("xychart-beta").count(),
+        1,
+        "only the sibling loc_by_technology chart renders:\n{md}"
+    );
+}
+
 /// Why: output filenames must be date-prefixed and slug-stable.
 /// What: asserts the stem is `{date}-{title-slug}`.
 /// Test: this test itself.

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -1239,6 +1239,57 @@ fn reporter_renders_language_breakdown_with_counts() {
     )));
 }
 
+/// A minimal template carrying one POPULATED dataset table (literal values, so
+/// it survives fill + omit-empty) to exercise the wave-4 mermaid injection.
+const MERMAID_TEMPLATE: &str = "# Report\n\n\
+    ## 7. Graph-Ready Data Appendix\n\n\
+    <!-- dataset: loc_by_tech | chart: bar | x: tech | y: loc -->\n\
+    | Tech | LoC |\n|---|---|\n| Rust | 8200 |\n| Python | 3100 |\n";
+
+/// Why: when mermaid is enabled (the default) the reporter must emit a ```mermaid
+/// block directly under a populated §7 dataset table (#2366).
+/// What: renders a template with one literal-value dataset table and asserts the
+/// `xychart-beta` block appears AFTER the table.
+/// Test: this test itself.
+#[test]
+fn render_injects_mermaid_under_populated_dataset() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = fixture_model(tmp.path());
+    let md = Reporter::new(tmp.path()).render(&model, MERMAID_TEMPLATE);
+    assert!(md.contains("```mermaid"), "block emitted:\n{md}");
+    assert!(md.contains("xychart-beta"));
+    assert!(md.contains("x-axis [\"Rust\", \"Python\"]"), "{md}");
+    assert!(md.contains("bar [8200, 3100]"), "{md}");
+    let table_pos = md.find("| Python |").unwrap();
+    let block_pos = md.find("```mermaid").unwrap();
+    assert!(table_pos < block_pos, "chart follows table");
+}
+
+/// Why: `--no-mermaid` / `[report] mermaid = false` must disable charts entirely,
+/// leaving output byte-identical to the pre-wave-4 report (#2366).
+/// What: renders the same model+template with `with_mermaid(false)`; asserts no
+/// mermaid artifacts appear and the pipe table is untouched.
+/// Test: this test itself.
+#[test]
+fn no_mermaid_byte_identical() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = fixture_model(tmp.path());
+    let off = Reporter::new(tmp.path())
+        .with_mermaid(false)
+        .render(&model, MERMAID_TEMPLATE);
+    let on = Reporter::new(tmp.path()).render(&model, MERMAID_TEMPLATE);
+    assert!(
+        !off.contains("```mermaid"),
+        "no chart when disabled:\n{off}"
+    );
+    assert!(!off.contains("xychart-beta"));
+    assert!(on.contains("```mermaid"), "chart when enabled");
+    // Disabling is purely additive-off: the `on` output is the `off` output with
+    // the chart block inserted, so removing every mermaid fence region recovers it.
+    assert!(on.len() > off.len());
+    assert!(off.contains("| Rust | 8200 |"), "table itself untouched");
+}
+
 /// Why: output filenames must be date-prefixed and slug-stable.
 /// What: asserts the stem is `{date}-{title-slug}`.
 /// Test: this test itself.

--- a/crates/trusty-review/templates/report-technical-dd-cast.md
+++ b/crates/trusty-review/templates/report-technical-dd-cast.md
@@ -299,13 +299,13 @@ Summary: {{total_components}} components detected; {{critical_cve_components}} w
 
 <!-- dataset: loc_by_technology | chart: stacked-bar | x: application | y: loc, group: technology -->
 | Application | Technology | LoC | % of total |
-|---|---|---|---|
-| {{app_name}} | {{tech_name}} | {{tech_loc}} | {{tech_pct}} |
+|---|---|---|---|<!-- BEGIN loc_by_tech_row -->
+| {{app_name}} | {{tech_name}} | {{tech_loc}} | {{tech_pct}} |<!-- END loc_by_tech_row -->
 
 <!-- dataset: complexity_distribution | chart: bar | x: complexity_bucket | y: count, group: application -->
 | Application | Complexity bucket | Count | % of total complexity |
-|---|---|---|---|
-| {{app_name}} | {{complexity_bucket}} | {{complexity_count}} | {{complexity_pct}} |
+|---|---|---|---|<!-- BEGIN complexity_bucket_row -->
+| {{app_name}} | {{complexity_bucket}} | {{complexity_count}} | {{complexity_pct}} |<!-- END complexity_bucket_row -->
 
 <!-- dataset: green_deficiencies_top10 | chart: bar | x: deficiency | y: occurrences, group: application -->
 | Application | Deficiency | Technology | Occurrences | Effort (days) |

--- a/crates/trusty-review/templates/report-technical-dd.md
+++ b/crates/trusty-review/templates/report-technical-dd.md
@@ -272,13 +272,13 @@ report against others normalized through this same template.
 
 <!-- dataset: loc_by_technology | chart: stacked-bar | x: application | y: loc, group: technology -->
 | Application | Technology | LoC | % of total |
-|---|---|---|---|
-| {{app_name}} | {{tech_name}} | {{tech_loc}} | {{tech_pct}} |
+|---|---|---|---|<!-- BEGIN loc_by_tech_row -->
+| {{app_name}} | {{tech_name}} | {{tech_loc}} | {{tech_pct}} |<!-- END loc_by_tech_row -->
 
 <!-- dataset: complexity_distribution | chart: bar | x: complexity_bucket | y: count, group: application -->
 | Application | Complexity bucket | Count | % of total complexity |
-|---|---|---|---|
-| {{app_name}} | {{complexity_bucket}} | {{complexity_count}} | {{complexity_pct}} |
+|---|---|---|---|<!-- BEGIN complexity_bucket_row -->
+| {{app_name}} | {{complexity_bucket}} | {{complexity_count}} | {{complexity_pct}} |<!-- END complexity_bucket_row -->
 
 <!-- Add further `<!-- dataset: ... -->` blocks for any other chart the
      source report presents (size distributions, green-impact deficiencies,

--- a/crates/trusty-review/tests/report_e2e.rs
+++ b/crates/trusty-review/tests/report_e2e.rs
@@ -217,3 +217,145 @@ fn end_to_end_corpus_benchmark() {
         "ranked"
     );
 }
+
+/// Initialise a tiny git repo at `dir` with a real, deterministic per-language
+/// LoC split — 3 non-blank Rust lines, 2 non-blank TypeScript lines — so
+/// `scan_repo` (and, downstream, the §7 `loc_by_technology` dataset fill) has
+/// real `measured` data to work with, with no external metrics JSON at all.
+fn git_repo_with_known_loc(dir: &std::path::Path) {
+    std::fs::write(dir.join("main.rs"), "fn main() {\n\n    work();\n}\n").expect("write rs");
+    std::fs::write(dir.join("app.ts"), "const x = 1;\nexport {};\n").expect("write ts");
+    let _ = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .arg("init")
+        .output();
+    let _ = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["add", "-A"])
+        .output();
+}
+
+/// Why: live-QA on a real bare `report` run (no `--synthesize`, no external
+/// trusty-analyze metrics JSON) found the §7 Graph-Ready Data Appendix entirely
+/// empty — every dataset table collapsed under omit-empty and the wave-4
+/// Mermaid renderer had nothing to chart. The root cause: `loc_by_technology`
+/// had no fill path at all, even though its data (per-language LoC) is exactly
+/// what the built-in scan already computes. This test proves the fix
+/// end-to-end: a bare scan-only run now emits a REAL populated dataset table
+/// AND a real `xychart-beta` Mermaid block whose numbers match the scan.
+/// What: builds a two-language fixture repo (no metrics), renders the bundled
+/// `report-technical-dd` template, and asserts (a) the dataset table carries
+/// the scanned LoC figures, (b) a mermaid chart follows it with matching
+/// numbers, (c) a dataset with genuinely no available data (complexity
+/// buckets, which only ever come from an external metrics JSON) stays empty
+/// and chartless, and (d) `--no-mermaid` (`with_mermaid(false)`) suppresses
+/// only the chart, leaving the populated table intact.
+/// Test: this test itself.
+#[test]
+fn end_to_end_bare_scan_emits_mermaid_chart() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let dir = tmp.path();
+    let repo_dir = dir.join("repo");
+    std::fs::create_dir_all(&repo_dir).expect("mkdir repo");
+    git_repo_with_known_loc(&repo_dir);
+
+    let manifest_toml = format!(
+        "[report]\ntitle = \"Bare Scan Report\"\n\n[[repositories]]\nname = \"Acme\"\npath = \"{}\"\n",
+        repo_dir.display()
+    );
+    let manifest_path = dir.join("manifest.toml");
+    std::fs::write(&manifest_path, &manifest_toml).expect("write manifest");
+
+    let manifest = load_manifest(&manifest_path).expect("manifest loads");
+    let template = TemplateLoader::new()
+        .load("report-technical-dd")
+        .expect("template loads");
+    let model = ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("model builds — no --synthesize, no metrics, scan-only");
+
+    // Sanity: prove the scan itself found the expected LoC split before
+    // asserting on the rendered report (isolates a scanner regression from a
+    // fill-wiring regression).
+    let scan = model.repositories[0].scan.as_ref().expect("scan present");
+    let rust_loc = scan
+        .by_language
+        .iter()
+        .find(|l| l.language == "Rust")
+        .map(|l| l.loc)
+        .expect("rust language present");
+    let ts_loc = scan
+        .by_language
+        .iter()
+        .find(|l| l.language == "TypeScript")
+        .map(|l| l.loc)
+        .expect("typescript language present");
+    assert_eq!(rust_loc, 3, "3 non-blank Rust lines");
+    assert_eq!(ts_loc, 2, "2 non-blank TypeScript lines");
+
+    // (a) + (b): mermaid ON (default) — populated table + matching chart.
+    let on = Reporter::new(dir.join("reports")).render(&model, &template);
+    assert!(on.contains("Rust"), "loc_by_technology row for Rust:\n{on}");
+    assert!(
+        on.contains("TypeScript"),
+        "loc_by_technology row for TypeScript:\n{on}"
+    );
+    assert!(on.contains("```mermaid"), "chart emitted:\n{on}");
+    assert!(on.contains("xychart-beta"));
+    // `loc_by_technology` is `stacked-bar` with `x: application, group:
+    // technology` — the fixture repo has only ONE application ("Acme"), so the
+    // x-axis has a single category and the two languages become two layered
+    // bar series (Rust=3, TypeScript=2), each the raw scanned LoC value.
+    assert!(
+        on.contains("x-axis [\"Acme\"]"),
+        "x-axis is the single application:\n{on}"
+    );
+    assert!(on.contains("bar [3]"), "Rust series = scanned LoC 3:\n{on}");
+    assert!(
+        on.contains("bar [2]"),
+        "TypeScript series = scanned LoC 2:\n{on}"
+    );
+    let table_pos = on
+        .find("| Acme | TypeScript |")
+        .unwrap_or_else(|| panic!("expected a filled loc_by_technology row in:\n{on}"));
+    let chart_pos = on.find("```mermaid").expect("chart present");
+    assert!(table_pos < chart_pos, "chart follows the table");
+
+    // (c) complexity_distribution has no data source on a bare scan (no
+    // metrics JSON, and the scan itself never computes complexity buckets) —
+    // it must stay empty and contribute no chart, while the sibling
+    // loc_by_technology chart above still renders. Its header row (distinct
+    // from the always-present `<!-- dataset: complexity_distribution -->`
+    // marker text, which legitimately contains the substring
+    // "complexity_bucket") must be gone; exactly one `xychart-beta` block
+    // exists (proves complexity added no chart of its own).
+    assert!(
+        !on.contains("Complexity bucket |"),
+        "no fabricated complexity table header — genuinely no data:\n{on}"
+    );
+    assert_eq!(
+        on.matches("xychart-beta").count(),
+        1,
+        "only loc_by_technology charts on a bare scan-only run:\n{on}"
+    );
+
+    // (d) --no-mermaid suppresses only the chart; the table itself must be
+    // byte-for-byte present in both renders (mermaid is purely additive).
+    let off = Reporter::new(dir.join("reports"))
+        .with_mermaid(false)
+        .render(&model, &template);
+    assert!(
+        !off.contains("```mermaid"),
+        "no chart when disabled:\n{off}"
+    );
+    assert!(!off.contains("xychart-beta"));
+    assert!(
+        off.contains("Rust"),
+        "table survives with mermaid off:\n{off}"
+    );
+    assert!(
+        off.contains("TypeScript"),
+        "table survives with mermaid off:\n{off}"
+    );
+}

--- a/docs/trusty-review/spec/report-generation.md
+++ b/docs/trusty-review/spec/report-generation.md
@@ -760,6 +760,67 @@ trusty-analyze daemon integration (deterministic findings) remains the future
 complement per the epic architecture; the findings schema already accepts both
 sources (a `MetricFinding` is source-agnostic).
 
+## Mermaid charts from dataset markers (wave 4, #2366)
+
+**Problem.** The Graph-Ready Data Appendix (§7) already tags each pipe table with
+a `<!-- dataset: <slug> | chart: <type> | x: <field> | y: <field>[, group:
+<field>] -->` marker, but that marker was opaque to the renderer — a human reader
+saw only the machine-readable table. Wave 4 turns each POPULATED dataset table
+into a human-viewable Mermaid chart, emitted directly under it. Implementation
+lives in `src/report/mermaid.rs`.
+
+**When it runs.** Always on by default, as a post-`polish` pass in
+`Reporter::render` (after omit-empty, before the appended status notes). It is
+deterministic — pure rendering from the already-filled table rows, **no LLM, no
+network**. Disable it with the `--no-mermaid` CLI flag OR the manifest
+`[report] mermaid = false` key (the flag forces off regardless of the manifest).
+When disabled the pass is skipped entirely and the report is **byte-identical** to
+the pre-wave-4 output. Running after `polish` guarantees a chart is only ever
+drawn under a table that survived omit-empty — an empty/dropped dataset gets no
+chart, consistent with the omit-empty rule. The `<!-- dataset: … -->` marker
+itself is preserved (it is semantic; downstream tooling still lifts tables by it).
+
+### Chart-type mapping
+
+| `chart:` | Mermaid | Rendering |
+|---|---|---|
+| `bar` | `xychart-beta` | Single bar series. Categories = distinct `x` values; each bar = the **sum** of numeric `y` over rows sharing that `x`. A declared `group:` is aggregated away (bars total across groups). |
+| `stacked-bar` | `xychart-beta` | One bar series **per `group:` value**, layered/overlaid. **Mermaid has no native stacking** — this is a documented approximation (bars are drawn over one another, not summed on top); a `%%` comment in the block and a front-to-back legend note disclose it. Falls back to a single series when the group column does not resolve. |
+| `radar` | `radar-beta` | Axes = distinct `x` values; one `curve` per `group:` value (single curve named after the `y` field when there is no group). **Requires Mermaid ≥ 11.6** — a `%% radar-beta requires Mermaid >= 11.6` comment records the version floor in every emitted block. |
+| `heatmap` | *(none)* | **No native Mermaid support.** Fallback: emit NO block and a one-line note `_(heatmap: no Mermaid rendering; see table above)_` — the pipe table remains the authoritative artifact. |
+| unknown / absent | *(none)* | No block; a `debug!` log records the skip. Never panics. |
+
+### Column resolution & numeric parsing
+
+The marker's `x`/`y`/`group` field names are semantic hints, not exact header
+text (`x: factor` → the `Factor` column; `y: tqi_rank` → `Rank`). Resolution
+normalizes both sides to lowercase alphanumerics and matches in priority order —
+exact, then header-starts-with, then header-contains — over the full field name
+then its last `_`/space token. An unresolvable `y` column yields no chart; an
+unresolvable `x` falls back to the first column.
+
+`y`-value cells are parsed tolerant of the report's rendered decoration: the
+provenance superscripts (`⁽ᵐ⁾`/`⁽ᵈ⁾`/`⁽ⁱ⁾`), thousands separators, `$`, `%`, and
+whitespace are stripped before `f64` parsing. A row whose `y` is non-numeric is
+**skipped** (not charted); if **every** row is unparseable, no chart is emitted.
+
+### Escaping & caps
+
+All category / axis / series labels are Mermaid-escaped: emitted double-quoted,
+with any interior `"` replaced by `'` (empty labels become `"?"`). To keep charts
+legible the renderer caps **12 categories** and **8 series/curves**; the remainder
+is dropped with an `_… and N more categories/series omitted from the chart; see
+table above._` note (the full set stays in the table).
+
+### Polish interaction
+
+The emitted ` ```mermaid ` block is a fenced region, so `polish`'s fence-state
+tracking (any ` ``` ` at line-start opens a fence) already treats it as opaque —
+no marker/heading/table interpretation inside it, exactly like an evidence fence.
+Because injection runs *after* `polish`, the polish pass never sees the block in
+the normal flow; a regression test (`polish_tests::mermaid_fence_is_opaque_to_polish`)
+pins the opacity defensively.
+
 ## References & Related Docs
 
 - **[crates/trusty-review/templates/](../../../crates/trusty-review/templates/)** — Template instances (generic + CAST-specific)

--- a/docs/trusty-review/spec/report-generation.md
+++ b/docs/trusty-review/spec/report-generation.md
@@ -790,6 +790,35 @@ itself is preserved (it is semantic; downstream tooling still lifts tables by it
 | `heatmap` | *(none)* | **No native Mermaid support.** Fallback: emit NO block and a one-line note `_(heatmap: no Mermaid rendering; see table above)_` — the pipe table remains the authoritative artifact. |
 | unknown / absent | *(none)* | No block; a `debug!` log records the skip. Never panics. |
 
+### Dataset population: which §7 tables fill on a bare run (#2366 follow-up)
+
+**Problem.** Live-QA on a real bare `report` run (no `--synthesize`, no external
+metrics JSON) found EVERY §7 dataset table empty — nothing but bare `<!--
+dataset: … -->` markers, so nothing charted. Root cause: the mandated §7
+appendix names ten datasets, but only `tqi_benchmark_position` (gated on
+`--benchmark`) had a fill path; the rest — including `loc_by_technology`, whose
+data (per-language LoC) the built-in scan (#2342.3) ALREADY computes — had no
+wiring at all. A chart feature that never fires on the common case (a bare
+scan) is empty scaffolding, which the honesty rule exists to prevent. The fix is
+to wire every dataset whose data is already present in the model, and leave the
+rest empty **by design** — never fabricate data a bare run cannot produce.
+
+Per-dataset status:
+
+| Dataset | Populates from | On a bare scan-only run |
+|---|---|---|
+| `loc_by_technology` | `RepositoryReport::scan.by_language` (measured), or `metrics.loc.by_language` (declared) when an external metrics JSON is supplied — declared wins, same precedence as the Profile "Technology stack" line (`fill_profile`) | **Populates** — one row per (application, language), `tech_pct` computed against the breakdown's own total; a real `stacked-bar` chart renders |
+| `tqi_benchmark_position` | `ReportModel::benchmark` (only set under `--benchmark`) | Empty — correctly gated on `--benchmark`, not a bare-scan input |
+| `complexity_distribution` | `metrics.complexity.buckets` — **metrics-only**; `RepoScan` has no complexity analysis, so the bare scan can never supply this | Empty (omit-empty) — **requires an external trusty-analyze metrics JSON**; never fabricated |
+| `health_factors_by_app`, `violations_by_iso_domain` / `violations_by_domain`, `cve_by_component_severity`, `license_risk_tiers`, `cloud_maturity_by_tech`, `violations_by_horizon`, `remediation_cost_by_tier`, `green_deficiencies_top10` | Deal-specific DD findings (violations, CVEs, license tiers, remediation economics) that no deterministic scan or metrics schema currently captures | Empty (omit-empty) by design — populating these requires a future structured-findings source (see the Alternative/future source note above); NOT wired by #2366, and must not be force-populated from unrelated data |
+
+The same precedence rule applies throughout: an external metrics JSON is
+**enrichment**, not a prerequisite — where both the scan and metrics provide a
+figure, metrics (declared) wins; where only the scan has it, the measured figure
+still renders (and still charts). A dataset with genuinely no available
+deterministic source stays empty and chartless — that is the honest outcome, not
+a bug.
+
 ### Column resolution & numeric parsing
 
 The marker's `x`/`y`/`group` field names are semantic hints, not exact header


### PR DESCRIPTION
implements #2366. Deterministic Mermaid renderer emits a ```mermaid block under each POPULATED §7 dataset table: bar/stacked-bar→xychart-beta (layered approximation, no native stacking), radar→radar-beta (Mermaid ≥11.6), heatmap→table-authoritative fallback note, unknown→no block. Numeric parsing strips provenance markers/commas/$/%; labels escaped; categories/series capped. Second commit wires the repo-derivable datasets so bare runs actually emit charts: loc_by_technology now populates from repo-scan by_language data (root cause: its template rows were never in a repeatable BEGIN/END block, so the table never filled and there was nothing to chart); complexity_distribution and metrics-only datasets correctly stay empty/chartless without a trusty-analyze metrics JSON. On by default; `[report] mermaid=false` / `--no-mermaid` disable (byte-identical off). Polish pass treats ```mermaid fences as opaque. Live-verified on a real repo: loc_by_technology renders TypeScript 19,568/SQL 184/CSS 43/JS 20 as a valid xychart-beta with bare numbers matching the table, zero fence artifacts, --no-mermaid strips only the chart. Gates: trusty-review 1319 tests 0 failed; workspace 0 failed; crate+workspace clippy exit 0; fmt clean; line-cap 0 violations.

Closes #2366
Part of #2312

🤖 Generated with [Claude Code](https://claude.com/claude-code)