### PR TITLE
chore(trusty-review): v0.8.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11055,7 +11055,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.15.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.7.0" }
+trusty-review = { path = "crates/trusty-review", version = "0.8.0" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [0.8.0] — 2026-07-10
+
+### Added
+
+- **Report wave 2 — analyst instructions + inference-first output** ([#2356](https://github.com/bobmatnyc/trusty-tools/pull/2356)) ([`24d9fb2`](https://github.com/bobmatnyc/trusty-tools/commit/24d9fb2ed2abe967d561cb644e53ebd6904ef1d4)): `--instructions <md>` analyst-brief flag (recorded verbatim + injected as synthesis focus directives); self-derived report metadata (vendor/methodology/dates never honesty-marked); built-in repository scanning (`src/report/scan.rs`) so a bare local-path run produces a measured LoC/file/dependency baseline without an external metrics file; four-kind provenance labels (measured/declared/inferred/not-stated) on every substantive value; omit-empty post-render polish (dropped marker rows, collapsed empty sections, consolidated Gaps list).
+- **Report wave 3 — repo-evidence findings investigation** ([#2371](https://github.com/bobmatnyc/trusty-tools/pull/2371)) ([`088b1e7`](https://github.com/bobmatnyc/trusty-tools/commit/088b1e7a17dd096766736b4378e960f3f3e1c72c)): under `--synthesize`, local-checkout repositories are directly inspected — deterministic relevance-ranked file selection, a batched reviewer-role LLM investigation with a verbatim-evidence guardrail (rejects any RED/AMBER finding whose quote doesn't substring-match the real file), a deterministic dependency inventory (manifest + lockfile parsing, no network), a compact findings digest with a one-shot truncation retry so a large verified-finding count can no longer blank the executive summary, and layered section-instruction overrides (generic default → template `<!-- instruct:<section_id> -->` comment → analyst `--instructions` overlay) for the three synthesized sections.
+- **Report wave 4 — Mermaid charts from dataset markers** ([#2389](https://github.com/bobmatnyc/trusty-tools/pull/2389)) ([`cc61a96`](https://github.com/bobmatnyc/trusty-tools/commit/cc61a9664f6d616516209b9c97075b05e52c517b)): every populated Graph-Ready Data Appendix table now renders a deterministic Mermaid chart beneath it (`bar`/`stacked-bar` → `xychart-beta`, `radar` → `radar-beta`, `heatmap` → table-only fallback); on by default, disable with `--no-mermaid` or manifest `[report] mermaid = false`; also wires dataset population (e.g. `loc_by_technology` from the wave-2 repo scan) for tables that previously had no fill path on a bare scan-only run.
+
+### Changed
+
+- Root workspace `[workspace.dependencies]` pin for `trusty-review` bumped 0.7.0 → 0.8.0 (consumed by `trusty-analyze`'s optional `review` feature).
+
 ## [Unreleased]
 
 ### Added

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.7.0"
+version     = "0.8.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/README.md
+++ b/crates/trusty-review/README.md
@@ -380,6 +380,58 @@ placement tables. A corpus with fewer than 5 peers is never ranked — the
 report discloses `benchmark: corpus too small (n=<peers>)` instead of a
 fabricated placement (the small-n honesty gate).
 
+### `--instructions <md>` (analyst brief)
+
+`--instructions <file>` (precedence over manifest `[report].instructions`)
+hands the generator a free-form markdown brief — focus areas, deal concerns,
+questions. It is always recorded verbatim as an `## Analyst Instructions`
+section; under `--synthesize` it is additionally injected as focus
+directives that steer emphasis in the executive summary and RED/AMBER prose.
+Instructions steer emphasis only — they never authorize invention and never
+relax the numeric guardrail or the no-green rule. A missing file is a hard
+error; an empty file warns and proceeds as absent.
+
+### Inference-first output: repo scanning, provenance, section instructions
+
+Without `--synthesize`, and even without an external trusty-analyze metrics
+file, a local-path repository still gets a substantive report: `src/report/scan.rs`
+computes a **measured** baseline directly from the checkout — tracked file
+list (`git ls-files`, or a filtered walk for non-git paths), total LoC + a
+per-language breakdown, file counts, and top declared dependencies from
+`package.json`/`Cargo.toml`/`pyproject.toml`/`go.mod`. An external metrics
+JSON is treated as enrichment layered on top of the scan — where both provide
+a figure, the declared metrics win; where only the scan has it, the measured
+figure fills the field.
+
+Every substantive value in the rendered report carries a trailing **provenance
+marker** — `⁽ᵐ⁾` measured (from the repo), `⁽ᵈ⁾` declared (manifest/analyst/metrics
+input), or `⁽ⁱ⁾` inferred (LLM judgement grounded in repo evidence); a
+genuinely-unknowable field is dropped rather than shown with a marker. A
+one-line legend renders once near the top of the report.
+
+Templates may override the instruction given to each of the three
+LLM-synthesized sections (`executive_summary`, `top_risks`,
+`finding_elaboration`) with a `<!-- instruct:<section_id> ... -->` comment
+anywhere in the template file; the override replaces the built-in generic
+instruction for that section only and never reaches rendered output (it is
+stripped like any other non-`dataset:` comment). The analyst `--instructions`
+brief still layers on top as an additive emphasis overlay.
+
+Full detail on the scan heuristics, provenance model, and instruction
+layering: [docs/trusty-review/spec/report-generation.md](../../docs/trusty-review/spec/report-generation.md).
+
+### Mermaid charts (`--no-mermaid`)
+
+Every populated Graph-Ready Data Appendix table (tagged with a
+`<!-- dataset: <slug> | chart: <type> | x: … | y: … -->` marker) gets a
+Mermaid chart rendered directly beneath it — `bar`/`stacked-bar` as
+`xychart-beta`, `radar` as `radar-beta` (Mermaid ≥ 11.6), `heatmap` has no
+Mermaid equivalent and falls back to a note. This is on by default, purely
+deterministic (no LLM, no network) — a rendering pass over already-filled
+table rows. Disable it with `--no-mermaid` or the manifest `[report] mermaid
+= false` key (the flag always wins); with it disabled the report is
+byte-identical to the pre-Mermaid output.
+
 ### Templates
 
 Two vendor-neutral, placeholder-only templates ship in


### PR DESCRIPTION
## Summary

Bumps `trusty-review` 0.7.0 → 0.8.0 (MINOR — all bundled changes are `feat:`) and publishes the three report-generation waves that landed since 0.7.0 was cut:

- #2356 — report wave 2: analyst `--instructions` brief, self-derived metadata, built-in repository scanning, provenance labels + omit-empty polish
- #2371 — report wave 3: repo-evidence findings investigation (batched, verifiable-evidence guardrail), deterministic dependency inventory, compact findings digest + truncation retry, layered section-instruction overrides
- #2389 — report wave 4: Mermaid charts rendered from `<!-- dataset: -->` markers, plus dataset population wiring for a bare scan-only run

Also:
- Updates `crates/trusty-review/README.md`'s "Report generation" section to document `--instructions`, built-in repo scanning, provenance markers, section-instruction overrides, and `--no-mermaid`/Mermaid charts (previously covered: `--synthesize`, `--corpus`/`--corpus-add`/`--benchmark`, templates).
- Bumps the root `Cargo.toml` `[workspace.dependencies]` `trusty-review` pin 0.7.0 → 0.8.0 (consumed by `trusty-analyze`'s optional `review` feature — this pin bit the 0.7.0 release when missed).

**Note:** PR #2324 (M2 opt-in LLM synthesis) is deliberately NOT listed as new in this release — it merged *before* the 0.7.0 tag was cut and is already live in the published 0.7.0 crate (verified via `git log trusty-review-v0.6.4..trusty-review-v0.7.0` and the crates.io publish timestamp). The generated changelog correctly excludes it.

Part of #2312

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-review` — 1363 passed, 0 failed
- [x] `cargo check --workspace` — clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)