### PR TITLE
feat: tm-issues-prune skill organizes, prioritizes, and suggests next tasks

### DIFF
--- a/crates/trusty-mpm/src/assets/skills/tm-issues-prune.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-issues-prune.md
@@ -1,20 +1,28 @@
 ---
 name: tm-issues-prune
-description: Prune and prioritize a project's GitHub issue backlog — natural-language PM delegation pattern (gh-first, JIRA deferred)
+description: Prune, organize, prioritize, and suggest next tasks from a project's GitHub issue backlog — natural-language PM delegation pattern (gh-first, JIRA deferred)
 user-invocable: true
-version: "1.0.0"
+version: "1.1.0"
 category: pm-workflow
-tags: [tickets, github, backlog, pm-required]
+tags: [tickets, github, backlog, pm-required, triage, prioritization]
 effort: medium
 ---
 
-# /tm-issues-prune — Backlog Prune & Prioritize
+# /tm-issues-prune — Backlog Prune, Organize, Prioritize & Suggest Next
 
 A natural-language PM-delegation pattern for keeping a project's GitHub
-issue backlog healthy: closing stale/duplicate/obsolete issues and
-correcting priority labels on the ones that remain open. This skill
-describes a workflow, not a new tool or command — every mechanical `gh`
-operation is delegated, never run by the PM directly.
+issue backlog healthy and actionable: closing stale/duplicate/obsolete
+issues, correcting priority labels on the ones that remain open, grouping
+the survivors into a navigable map, producing a deterministic priority
+ranking, and surfacing a short list of next tasks for the user to choose
+from. This skill describes a workflow, not a new tool or command — every
+mechanical `gh` operation is delegated, never run by the PM directly.
+
+The full sweep runs in four phases, in this order: **Prune → Organize →
+Prioritize → Suggest Next**. Each phase depends on the one before it —
+Organize/Prioritize/Suggest Next operate on the *surviving* open issues
+after any prune-close pass, so stale/duplicate/obsolete noise doesn't
+pollute the ranking or the suggestions.
 
 ## Scope: gh-first, JIRA deferred
 
@@ -58,8 +66,10 @@ PM: [presents the prune/prioritize summary, asks for confirmation before closing
 |---|---|
 | `/tm-issues-prune scan` | Survey the backlog, report prune candidates AND priority gaps without changing anything |
 | `/tm-issues-prune close` | Prune pass — present candidates with reasons, close only after user confirmation |
-| `/tm-issues-prune prioritize` | Prioritize pass — assess open issues, propose label changes, surface top-N |
-| `/tm-issues-prune` (no args) | Run scan, then offer to proceed with close and/or prioritize |
+| `/tm-issues-prune organize` | Organize pass — group surviving open issues by epic/component/theme, flag orphans |
+| `/tm-issues-prune prioritize` | Prioritize pass — assess open issues, propose label changes, surface a ranked list |
+| `/tm-issues-prune suggest-next` | Suggest-next pass — recommend the top 3-7 next tasks as a selectable table |
+| `/tm-issues-prune` (no args) | Run scan, then offer to proceed with close, organize, prioritize, and/or suggest-next, in that order |
 
 ## Prune Workflow
 
@@ -123,6 +133,117 @@ PM: [presents the prune/prioritize summary, asks for confirmation before closing
    ```
 5. **Report** the final label changes and the surfaced top-N list.
 
+## Organize Workflow
+
+Runs after the prune-close pass (if any) so grouping only covers issues
+that actually survive. Ask the `ticketing` agent to pull the surviving
+open-issue set with labels and bodies, then group into a map along three
+axes:
+
+1. **Epic** — group by parent issue where the repo has an epic/parent-issue
+   convention. Detect this from: an `epic` label, a body reference like
+   `Part of #N` / `Epic: #N`, or a parent issue whose body lists child issue
+   numbers. If the repo has no established epic convention, say so rather
+   than inventing one.
+2. **Component/crate** — infer from conventional-commit-style title
+   prefixes (`feat(trusty-mpm): …`, `fix(trusty-search): …`, etc.) and from
+   any `crate:*` / component labels already applied.
+3. **Theme** — when an issue has no inferable epic and no inferable
+   component, cluster it with similar issues by subject matter (e.g.
+   "installer/signing", "session lifecycle") based on title/body content.
+
+**Orphans** — issues with no epic, no labels, and no inferable component or
+theme — must be called out explicitly in their own section, e.g.
+`Orphans (needs labeling): #1234, #1240`. Do not guess a component/theme
+for an orphan just to force it into a bucket; ask the user to label it
+instead.
+
+Present the result as a grouped map (epic → component → theme → orphans),
+one line per issue with its number and title, so the user can see the
+backlog's shape before ranking.
+
+## Prioritize (Ranked List) Workflow
+
+This is a deterministic ranking pass over the organized, surviving open
+issues — distinct from the label-correction "Prioritize Workflow" above,
+which proposes label *changes*. This pass produces an **ordered list**
+using only facts pulled via `gh` (labels, cross-references, dates,
+milestone state) — never subjective judgment alone. Apply these heuristics
+in order, most authoritative first:
+
+1. **Existing priority labels** — P0 > P1 > P2 > P3 > unlabeled.
+2. **Blocks other work** — issues referenced by open PRs or other open
+   issues via `Closes #`, `Blocks #`, `Depends on #`, or cross-references
+   visible in `gh issue view --json` / `gh api` linked-PR data. An issue
+   that blocks active work outranks one that doesn't, within the same
+   priority tier.
+3. **Active epic/milestone membership** — an issue belonging to an open
+   milestone with a due date, or an open parent epic issue that is itself
+   still active, outranks an otherwise-similar issue with no active epic.
+4. **Staleness** — old and untouched (no comments/updates in a long window,
+   default 90 days unless the user specified another window during the
+   prune pass) is a signal to **demote** or flag as a close-candidate for
+   the next prune pass — never a reason to promote.
+5. **Size hints** — if the issue is labeled/estimated for size, use it only
+   as a final tiebreaker between otherwise-equal issues.
+
+**Output format:** an ordered list, one line per issue, ending in a short
+rationale citing which heuristic(s) fired, e.g.:
+
+```
+1. #1234 "Fix daemon restart race" — P0 label; blocks #1240, #1255
+2. #1201 "Add retry backoff to proxy" — P1 label; active epic #1100
+3. #1188 "Refactor config loader" — P2 label; stale 94d — demote candidate
+```
+
+State explicitly which `gh`-observable fact justified each ranking
+decision. If two issues tie on every heuristic, say so rather than
+inventing a tiebreak.
+
+## Suggest Next Workflow
+
+Runs last, over the ranked list, to recommend a short, concrete slate of
+next tasks:
+
+1. **Select 3-7 candidates** from the top of the ranked list, adjusted for
+   dependency sequencing: this repo's layer priority is API/daemon routes
+   before CLI before TUI/GUI — i.e. prefer lower-layer work that unblocks
+   higher-layer work over higher-layer work that has no such leverage, even
+   if the higher-layer item ranks slightly higher in raw priority.
+2. **Size each candidate** S/M/L (rough effort, not a strict estimate).
+3. **Write a one-line why-now rationale** per candidate (why this, why
+   now — cite the ranking heuristic(s) that put it near the top).
+4. **Note what it unblocks** — which other open issues or PRs become easier
+   or possible once this lands (cross-reference the Organize/Prioritize
+   output; don't invent unblocks that aren't visible in the `gh` data).
+5. **Present as a markdown table:**
+
+   | # | Title | Size | Why now | Unblocks |
+   |---|---|---|---|---|
+   | #1234 | Fix daemon restart race | M | P0, blocks 2 other issues | #1240, #1255 |
+
+6. **Do not auto-start any of these tasks.** Present the table to the user
+   and wait for them to explicitly choose one (or more) before delegating
+   any implementation work.
+
+## Output Format (full sweep)
+
+When running the full `/tm-issues-prune` sweep (no args, all phases), report
+back to the user in this sequence, each section clearly labeled:
+
+1. **Prune summary** — candidates presented, confirmations received, final
+   close list with reasons (empty if nothing was closed).
+2. **Organized map** — epic → component → theme → orphans, one line per
+   surviving open issue.
+3. **Ranked list** — the ordered list from the Prioritize (Ranked List)
+   Workflow, each line with its rationale.
+4. **Next-task table** — the Suggest Next markdown table, ending with an
+   explicit prompt for the user to pick a task (or none).
+
+Any phase can also be run standalone via its subcommand (`organize`,
+`prioritize`, `suggest-next`) without running the full sweep, in which case
+only that section is reported.
+
 ## Safety Rules
 
 - **Closing is destructive and requires explicit user confirmation** —
@@ -136,14 +257,18 @@ PM: [presents the prune/prioritize summary, asks for confirmation before closing
 - Never delegate a prune/prioritize sweep against a repo other than the
   one the active project is registered against — confirm the target repo
   first if it is ambiguous.
+- **Organize, ranked-list Prioritize, and Suggest Next are read-only** — they
+  never close issues or edit labels, so they carry no confirmation gate.
+  Suggest Next's only guardrail is behavioral, not destructive: never
+  auto-start a suggested task without the user explicitly picking it.
 
 ## JIRA (Future)
 
 JIRA is not yet supported: `TicketSystemKind::Jira` is stubbed in
 `trusty-agents`, so there is no working JIRA backend today. A JIRA backend
-is a future follow-up — when it lands, the same scan/close/prioritize shape
-applies, with the `ticketing` agent choosing the backend by project
-configuration instead of always shelling `gh`.
+is a future follow-up — when it lands, the same prune/organize/prioritize/
+suggest-next shape applies, with the `ticketing` agent choosing the backend
+by project configuration instead of always shelling `gh`.
 
 ## Related Skills
 

--- a/crates/trusty-mpm/src/core/bundle_tm_skills.rs
+++ b/crates/trusty-mpm/src/core/bundle_tm_skills.rs
@@ -203,15 +203,20 @@ pub const TM_OVERVIEW: &str = include_str!("../assets/skills/tm.md");
 /// Test: `tm_skills_are_in_bundle`, `tm_skills_have_frontmatter`.
 pub const TM_CLI_OPERATIONS: &str = include_str!("../assets/skills/tm-cli-operations.md");
 
-/// `/tm-issues-prune` — GitHub issue backlog prune & prioritize (issue #2185).
+/// `/tm-issues-prune` — GitHub issue backlog prune, organize, prioritize &
+/// suggest-next (issue #2185, extended by #2392).
 ///
-/// Why: backlogs accumulate stale, duplicate, and obsolete issues, and open
-/// issues drift out of accurate priority; this is a natural-language PM
-/// delegation pattern (not a new Rust command) that has the `ticketing`
-/// agent survey the repo via `gh issue list/close/edit`, presents prune
-/// candidates with reasons for confirmation before any close, and proposes
-/// priority-label corrections. gh-first; JIRA is deferred (`TicketSystemKind::Jira`
-/// is stubbed).
+/// Why: backlogs accumulate stale, duplicate, and obsolete issues, open
+/// issues drift out of accurate priority, and surviving issues need to be
+/// grouped and turned into an actionable next-task slate; this is a
+/// natural-language PM delegation pattern (not a new Rust command) that has
+/// the `ticketing` agent survey the repo via `gh issue list/close/edit`,
+/// presents prune candidates with reasons for confirmation before any
+/// close, proposes priority-label corrections, groups surviving issues by
+/// epic/component/theme, produces a deterministic `gh`-fact-justified
+/// ranked list, and recommends a top 3-7 next-task table for the user to
+/// pick from (never auto-started). gh-first; JIRA is deferred
+/// (`TicketSystemKind::Jira` is stubbed).
 /// What: embedded markdown skill file deployed to `skills/tm-issues-prune.md`.
 /// Test: `tm_skills_are_in_bundle`, `tm_skills_have_frontmatter`.
 pub const TM_ISSUES_PRUNE: &str = include_str!("../assets/skills/tm-issues-prune.md");


### PR DESCRIPTION
## Summary

- Extends the bundled `tm-issues-prune` PM skill with three new phases appended after the existing prune flow: **Organize** (group surviving open issues by epic/component/theme, flag orphans for labeling), **Prioritize** (deterministic `gh`-fact-justified ranked list — priority labels, blocks-other-work, active epic membership, staleness, size hints), and **Suggest Next** (top 3-7 next tasks as a markdown table, sized S/M/L, with why-now and unblocks columns — never auto-started).
- Adds a full-sweep "Output Format" section (prune summary → organized map → ranked list → next-task table) and updates the frontmatter `description` so the skill is discoverable for the expanded scope.
- Bumps the skill's frontmatter `version` from `1.0.0` to `1.1.0` per its existing semver field (no prior bump precedent exists across bundled skills, but the field is semver-shaped).
- Updates the `Why/What/Test` doc comment on `TM_ISSUES_PRUNE` in `bundle_tm_skills.rs` to describe the new scope.
- Existing prune flow and its safety rules (explicit confirmation before any close, no bulk/silent closes) are unchanged.

Closes #2392

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-mpm` — all suites pass (2659 passed in bundle/core tests incl. `tm_skills_are_in_bundle`, `tm_skills_have_frontmatter`; 0 failed across all binaries)
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations — OK`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools