### PR TITLE
feat: canonical tm sessions namespace with deprecated tm session alias

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -101,16 +101,37 @@ pub(crate) enum Command {
     ///   Managed fleet sessions (provisioned in isolated worktrees):
     ///     new, ls, activity, send, answer, decommission, prune-idle, …
     ///
-    /// Why (#1916): the invoked name is the singular `session` — renamed from the
-    /// plural `sessions` (#1394/#1841) now that `tm` has no external users to keep
-    /// a compatibility alias for. `tm session start`/`tm session new` reads more
-    /// naturally as a singular verb group. The Rust variant stays `Session`
-    /// (matching the clap-derived kebab-case default, so no rename of the
-    /// `SessionAction` group or its ~80 internal references was needed).
-    /// What: the `tm session <action>` command group (`tui`, `ls`, `new`, …).
-    /// Test: `cli_parses_session_singular` / `cli_sessions_plural_no_longer_parses`
-    /// in `tests.rs`.
-    #[command(name = "session")]
+    /// Why (#2116, DOC-35 §2.2/§3.2): session lifecycle verbs are promoted to a
+    /// sibling top-level plural noun — `tm sessions` — matching `tm projects`
+    /// (epic #2108) rather than folding under either. This reverses the earlier
+    /// #1916 rename to the singular `session`: that rename assumed `tm` had no
+    /// external users to keep a compatibility alias for, but the owner has since
+    /// resolved that the plural is the durable spelling and the singular
+    /// (`Command::Session` below) is kept as a hidden deprecated alias instead of
+    /// being retired outright, so scripts/skills/muscle memory keep working.
+    /// What: the `tm sessions <action>` command group (`tui`, `ls`, `new`, …).
+    /// Test: `cli_parses_sessions_*` in `tests.rs` cover the canonical plural;
+    /// `cli_parses_session_*` continue to cover the deprecated singular alias.
+    Sessions {
+        /// Session action to perform.
+        #[command(subcommand)]
+        action: SessionAction,
+    },
+    /// [DEPRECATED] Alias of `sessions` (#2116) — use `tm sessions <verb>`.
+    ///
+    /// Why: `tm session` was the canonical spelling from #1916 until #2116
+    /// promoted `sessions` to a sibling top-level plural alongside `tm projects`.
+    /// This singular form is kept as a hidden alias (mirroring the
+    /// `ManagedStop`/`RuntimeStop`/`ManagedResume` verb-level precedent) so
+    /// existing scripts, skills (`tm-session-management`, `tm-session-pause`,
+    /// `tm-session-resume`), and muscle memory keep working unchanged.
+    /// What: identical dispatch to `Sessions`; `main.rs` prints a one-line
+    /// deprecation notice to stderr exactly once per invocation before routing
+    /// to the same handler — no functional difference in behavior.
+    /// Test: every existing `cli_parses_session_*` test in `tests.rs`;
+    /// `tm_session_singular_prints_deprecation_notice_once` (integration test)
+    /// asserts the notice fires exactly once.
+    #[command(name = "session", hide = true)]
     Session {
         /// Session action to perform.
         #[command(subcommand)]
@@ -554,14 +575,14 @@ pub(crate) enum Command {
     /// current context. On a real terminal it opens the interactive session picker
     /// (the same numbered menu as bare `tm`, but scoped to the managed fleet), so
     /// resuming a session is one keystroke away. Piped, scripted, or `--json`
-    /// invocations degrade to the same static, pipeable list as `tm session ls`,
+    /// invocations degrade to the same static, pipeable list as `tm sessions ls`,
     /// never blocking on stdin. The former top-level `tm ls` (the DOC-24 alias /
     /// project-registry list) now lives behind `--projects`/`-p`.
     /// What: with `--projects`/`-p`, prints the local-project + managed-fleet alias
     /// registry (`--json` = combined JSON, `--root` overrides the managed root).
     /// Without `--projects`, it is the session connector: a TTY with ≥1 session
     /// opens the picker; `--json`, `--all`, a non-TTY, or 0 sessions print the
-    /// static table. `--source-id`/`--current`/`--all` mirror `tm session ls`.
+    /// static table. `--source-id`/`--current`/`--all` mirror `tm sessions ls`.
     /// Test: `cli_parses_ls_connector_bare`, `cli_parses_ls_projects`,
     /// `cli_parses_ls_projects_short`, `cli_parses_ls_json`, `cli_parses_ls_current`,
     /// `cli_ls_source_id_and_current_conflict`.
@@ -583,7 +604,7 @@ pub(crate) enum Command {
         json: bool,
         /// Filter sessions to this `owner/repo` slug (session mode only).
         ///
-        /// Passed to the daemon as `?source_id=`; mirrors `tm session ls`.
+        /// Passed to the daemon as `?source_id=`; mirrors `tm sessions ls`.
         #[arg(long)]
         source_id: Option<String>,
         /// Derive `source_id` from the cwd's git remote (session mode only).
@@ -987,7 +1008,7 @@ pub(crate) enum SessctlAction {
     },
     /// Stop a session (graceful by default, --force for immediate).
     ///
-    /// Why: mirrors `tm session stop` for the SESSCTL surface.
+    /// Why: mirrors `tm sessions stop` for the SESSCTL surface.
     /// What: POSTs to `POST /api/v1/control/sessions/{id}/stop?force=<bool>`.
     /// Test: `cli_parses_sessctl_stop`.
     Stop {
@@ -1307,7 +1328,7 @@ pub(crate) enum CatalogAction {
 pub(crate) enum RepairAction {
     /// Repair the agent/skill deploy state in `~/.claude/`.
     ///
-    /// Why: a crash during `tm install` or `tm session start` may leave stale
+    /// Why: a crash during `tm install` or `tm sessions start` may leave stale
     /// `.tmp` staging files in `~/.claude/agents/` or `~/.claude/skills/`, or
     /// leave either manifest corrupt. This command removes the orphans and
     /// validates both manifests.
@@ -1464,7 +1485,8 @@ pub(crate) enum ProjectAction {
     },
 }
 
-/// Actions for the `session` subcommand.
+/// Actions for the `sessions` subcommand (canonical since #2116; also
+/// reachable via the deprecated hidden `session` alias, see `Command::Session`).
 ///
 /// Two families coexist here (see `sessions --help` for the full description):
 ///   - Local project sessions: start, stop, list, run, output, pause, resume, …
@@ -1507,7 +1529,7 @@ pub(crate) enum SessionAction {
     /// session list (controller bullet + one row per managed session, the active
     /// row in two columns `[id] │ [summary]`). This is a NEW screen, distinct
     /// from the existing `tm tui` dashboard. It lives under the `session` group
-    /// as `tm session tui` (#1392): it operates on the same managed-session list
+    /// as `tm sessions tui` (#1392): it operates on the same managed-session list
     /// the other `session` verbs do, so grouping it there keeps the surface
     /// discoverable without colliding with the `coordinator` SM chat command.
     /// What: polls the daemon's coordinator-context endpoint live on the
@@ -1591,7 +1613,7 @@ pub(crate) enum SessionAction {
     /// Spawn a new managed session from a repo + ref (session-manager MVP).
     ///
     /// Why: the session-manager MVP provisions an isolated workspace from a git
-    /// repo and starts a harness in it; `tm session new` is the operator-facing
+    /// repo and starts a harness in it; `tm sessions new` is the operator-facing
     /// entry point that posts to `POST /api/v1/sessions/managed`.
     /// What: posts repo, ref, task, and an optional name hint to the daemon.
     /// Test: `cli_parses_session_new`.
@@ -1621,7 +1643,7 @@ pub(crate) enum SessionAction {
         /// By default the task is turnkey: once the session's runtime is ready
         /// it is typed into the pane so the session starts working immediately.
         /// Pass `--no-inject` for the legacy metadata-only behavior, where the
-        /// task is stored but you deliver it yourself with `tm session send`.
+        /// task is stored but you deliver it yourself with `tm sessions send`.
         #[arg(long)]
         no_inject: bool,
     },

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -3,15 +3,17 @@
 //! Why: session lifecycle operations (start, stop, list, clean, info, events,
 //! breakers, pause, resume, catchup, run, output, instructions) form a cohesive
 //! group that benefits from a dedicated file.
-//! What: the `session` dispatcher function and its private helpers
-//! `emit_managed_alias_notice`, `compose_session_instructions`. `start` is
-//! handled by the [`start`] submodule (protected-path routing, #1916). The
-//! managed verbs (`new`/`ls`/`send`/`answer`/`attach`/`stop`/`resume`/
-//! `decommission`) route through the shared chat-core layer
+//! What: the `session` dispatcher function (shared by the canonical `tm
+//! sessions` command and its deprecated hidden `tm session` alias, #2116) and
+//! its private helpers `emit_managed_alias_notice`, `compose_session_instructions`,
+//! plus the crate-visible [`emit_top_level_alias_notice`] the alias's `main.rs`
+//! match arm calls. `start` is handled by the [`start`] submodule (protected-path
+//! routing, #1916). The managed verbs (`new`/`ls`/`send`/`answer`/`attach`/
+//! `stop`/`resume`/`decommission`) route through the shared chat-core layer
 //! (`commands::managed_route`); the id-or-name resolution for both managed and
 //! project sessions goes through the one canonical `client::resolve_target`.
 //! `catchup` is handled by the DOC-28 cutover bridge in the `catchup` submodule.
-//! Test: `cli_parses_session_*`, `cli_parses_session_catchup`,
+//! Test: `cli_parses_session_*` / `cli_parses_sessions_*`, `cli_parses_session_catchup`,
 //! `compose_session_instructions_*` in `tests.rs`.
 
 // CUTOVER BRIDGE submodule — remove post-migration (#1762)
@@ -427,6 +429,26 @@ fn emit_managed_alias_notice(action: &SessionAction) {
     if let Some((old, new)) = pair {
         crate::commands::managed::deprecation_notice(old, new);
     }
+}
+
+/// Emit the deprecation notice for the top-level `session` (singular) alias (#2116).
+///
+/// Why: `tm session <verb>` is now a hidden deprecated alias of the canonical
+/// `tm sessions <verb>` (DOC-35 §2.2/§3.2). Unlike [`emit_managed_alias_notice`],
+/// this is a rename of the top-level NOUN, not a specific verb, so it must fire
+/// exactly once per invocation regardless of which verb was invoked. `main.rs`
+/// calls this from the single `Command::Session` match arm — one call site,
+/// executed at most once per process — before dispatching to [`session`], the
+/// same handler the canonical `Command::Sessions` arm calls. No functional
+/// difference in behavior between the two arms beyond this notice.
+/// What: writes `warning: 'session' is deprecated; use 'sessions'` to stderr.
+/// Test: `tm_session_singular_prints_deprecation_notice_once` /
+/// `tm_sessions_plural_prints_no_deprecation_notice` (integration tests,
+/// `tests/tm_sessions_alias_notice.rs`) drive the real binary and assert the
+/// notice appears exactly once for the singular form and not at all for the
+/// plural; `top_level_alias_notice_message` in `tests.rs` asserts the exact text.
+pub(crate) fn emit_top_level_alias_notice() {
+    crate::commands::managed::deprecation_notice("session", "sessions");
 }
 
 /// Derive the `owner/repo` source_id from a git directory for `--current`.

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/render.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/render.rs
@@ -112,7 +112,7 @@ pub(crate) fn build_rows(data: &WelcomeData) -> Vec<String> {
     // ── Commands cheat-sheet ──────────────────────────────────────────────────
     rows.push(String::new());
     rows.push("commands".to_string());
-    rows.push("  tm session list      tm session resume <id>".to_string());
+    rows.push("  tm sessions list     tm sessions resume <id>".to_string());
     rows.push("  tm connect            tm stop".to_string());
     rows.push("  tm status             detach: ^b d".to_string());
 
@@ -397,7 +397,7 @@ mod tests {
     fn welcome_panel_contains_commands_cheatsheet() {
         let out = render_welcome_panel(&base_data());
         assert!(
-            out.contains("tm session list"),
+            out.contains("tm sessions list"),
             "expected sessions list command"
         );
         assert!(out.contains("tm connect"), "expected connect command");

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -49,6 +49,10 @@ mod tests_behavior_c;
 #[path = "tests_behavior_d_tests.rs"]
 mod tests_behavior_d;
 
+#[cfg(test)]
+#[path = "tests_behavior_e_tests.rs"]
+mod tests_behavior_e;
+
 /// Lazy-loaded help configuration for "did you mean?" suggestions (issue #216).
 ///
 /// Why: the YAML help bundle is checked in as a string literal; loading it
@@ -243,7 +247,15 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Stop) => stop_daemon().await,
         Some(Command::Restart) => restart(&client, &url).await,
         Some(Command::Project { action }) => project(&client, &url, action).await,
-        Some(Command::Session { action }) => session(&client, &url, action).await,
+        // #2116: `sessions` (plural) is the canonical top-level command.
+        Some(Command::Sessions { action }) => session(&client, &url, action).await,
+        // #2116: `session` (singular) is a hidden deprecated alias of `sessions`.
+        // The notice fires here — exactly once per invocation, regardless of
+        // which verb was invoked — before dispatching to the identical handler.
+        Some(Command::Session { action }) => {
+            commands::session::emit_top_level_alias_notice();
+            session(&client, &url, action).await
+        }
         Some(Command::Events) => commands::misc::events(&client, &url).await,
         Some(Command::Doctor { prune_stale_skills }) => doctor(&url, prune_stale_skills).await,
         Some(Command::Validate { path, repair }) => validate(path, repair).await,

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -797,10 +797,11 @@ fn cli_parses_session_tui_with_flags() {
 
 #[test]
 fn cli_parses_session_singular() {
-    // #1916: the command group was renamed from the plural `sessions` (#1394)
-    // to the singular `session` — `tm` has no external users, so the rename is
-    // clean (no compatibility alias). Assert a representative subcommand
-    // parses under the canonical singular name.
+    // #1916 made `session` (singular) canonical with no plural alias. #2116
+    // (DOC-35 §2.2/§3.2) reverses that: `sessions` (plural) is now canonical,
+    // sibling to `tm projects`, and `session` is kept as a hidden deprecated
+    // alias rather than retired — so this exact invocation must keep parsing
+    // identically to before, into the same `Command::Session` variant.
     let cli = Cli::try_parse_from(["trusty-mpm", "session", "list"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
@@ -810,14 +811,11 @@ fn cli_parses_session_singular() {
     }
 }
 
-#[test]
-fn cli_sessions_plural_no_longer_parses() {
-    // #1916: the old plural spelling `sessions` was retired (not aliased) as
-    // part of the clean rename to `session`. Parsing it must now fail with an
-    // unrecognized-subcommand error, mirroring `cli_rejects_removed_coordinator_tui`.
-    let err = Cli::try_parse_from(["trusty-mpm", "sessions", "list"]).unwrap_err();
-    assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
-}
+// #2116 note: the mirror-plural parse test, the full-verb-surface parity
+// sweep, and the alias-notice message-text assertion moved to
+// `tests_behavior_e_tests.rs` to keep this file under the 1500-SLOC test cap
+// (`cli_parses_sessions_plural_canonical`, `cli_session_and_sessions_agree_for_every_verb`,
+// `top_level_alias_notice_message`).
 
 #[test]
 fn cli_rejects_removed_coordinator_tui() {

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_e_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_e_tests.rs
@@ -1,0 +1,121 @@
+//! CLI parse tests for the `tm session` -> `tm sessions` top-level rename
+//! (issue #2116, DOC-35 §2.2/§3.2) — extracted from `tests.rs` to keep it
+//! under the 1500-SLOC test-file cap, following the existing
+//! `tests_behavior_a/b/c/d` split convention.
+//!
+//! Why: `cli_parses_session_singular` in `tests.rs` already covers the
+//! deprecated singular alias parsing unchanged; this file adds the mirror
+//! assertions for the new canonical plural (`cli_parses_sessions_plural_canonical`),
+//! the full-verb-surface parity check (`cli_session_and_sessions_agree_for_every_verb`),
+//! and the pure deprecation-message-text assertion
+//! (`top_level_alias_notice_message`) — the process-level "printed exactly
+//! once" property is proven separately by the `tm_sessions_alias_notice`
+//! integration test, which spawns the real binary.
+//! What: parse round-trips for `Command::Sessions` and a full sweep of every
+//! `SessionAction` verb asserting `tm session <verb>` and `tm sessions <verb>`
+//! parse to the identical action.
+//! Test: `cargo test -p trusty-mpm` runs this file as part of the `tm` binary
+//! test suite.
+
+use clap::Parser;
+
+use crate::cli::{Cli, Command, SessionAction};
+
+#[test]
+fn cli_parses_sessions_plural_canonical() {
+    // #2116: `sessions` (plural) is now the canonical top-level spelling —
+    // the mirror image of `cli_parses_session_singular` in `tests.rs`, parsing
+    // into the new `Command::Sessions` variant.
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "list"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Sessions {
+            action: SessionAction::List { dir },
+        } => assert_eq!(dir, None),
+        other => panic!("expected sessions list, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_session_and_sessions_agree_for_every_verb() {
+    // #2116: proves `tm session <verb>` (deprecated alias) and `tm sessions
+    // <verb>` (canonical) resolve to the IDENTICAL `SessionAction` for every
+    // verb the enum carries — zero functional difference between the two
+    // top-level spellings, only the notice in `emit_top_level_alias_notice`
+    // differs. Comparing `{:?}` output sidesteps `SessionAction` not deriving
+    // `PartialEq` (it only derives `Debug` via `#[derive(Debug, Subcommand)]`).
+    let cases: &[&[&str]] = &[
+        &["start"],
+        &["stop", "id-1"],
+        &["kill", "id-1"],
+        &["list"],
+        &["tui"],
+        &["clean"],
+        &["info", "id-1"],
+        &["instructions"],
+        &["events", "id-1"],
+        &["breakers"],
+        &["pause", "id-1"],
+        &["resume", "id-1"],
+        &["run", "id-1", "echo hi"],
+        &["output", "id-1"],
+        &["new", "https://example.com/o/r.git", "--task", "t"],
+        &["ls"],
+        &["activity", "id-1"],
+        &["send", "id-1", "text"],
+        &["answer", "id-1", "yes"],
+        &["attach", "id-1"],
+        &["managed-stop", "id-1"],
+        &["runtime-stop", "id-1"],
+        &["managed-resume", "id-1"],
+        &["decommission", "id-1"],
+        &["delete", "id-1"],
+        &["prune-idle"],
+        &["decommission-ephemeral"],
+        &["catchup"],
+        &["prune", "--state", "all"],
+        &["prune-worktrees"],
+    ];
+    for verb_args in cases {
+        let mut singular_args = vec!["trusty-mpm", "session"];
+        singular_args.extend_from_slice(verb_args);
+        let mut plural_args = vec!["trusty-mpm", "sessions"];
+        plural_args.extend_from_slice(verb_args);
+
+        let singular_action = match Cli::try_parse_from(singular_args)
+            .unwrap_or_else(|e| panic!("`tm session {verb_args:?}` failed to parse: {e}"))
+            .command
+            .unwrap()
+        {
+            Command::Session { action } => action,
+            other => panic!("expected Command::Session for {verb_args:?}, got {other:?}"),
+        };
+        let plural_action = match Cli::try_parse_from(plural_args)
+            .unwrap_or_else(|e| panic!("`tm sessions {verb_args:?}` failed to parse: {e}"))
+            .command
+            .unwrap()
+        {
+            Command::Sessions { action } => action,
+            other => panic!("expected Command::Sessions for {verb_args:?}, got {other:?}"),
+        };
+        assert_eq!(
+            format!("{singular_action:?}"),
+            format!("{plural_action:?}"),
+            "session/sessions parsed to different actions for {verb_args:?}"
+        );
+    }
+}
+
+#[test]
+fn top_level_alias_notice_message() {
+    // #2116: the top-level `session` -> `sessions` alias reuses the shared
+    // `deprecation_message` builder from the #1205 verb-level precedent — pure
+    // message-text assertion, mirroring `deprecation_notice_format` in
+    // `tests.rs`, since the `eprintln!` side effect itself is untestable here
+    // (covered by the `tm_sessions_alias_notice` integration test spawning the
+    // real binary).
+    use crate::commands::managed::deprecation_message;
+    assert_eq!(
+        deprecation_message("session", "sessions"),
+        "warning: 'session' is deprecated; use 'sessions'"
+    );
+}

--- a/crates/trusty-mpm/src/tui/iterm2.rs
+++ b/crates/trusty-mpm/src/tui/iterm2.rs
@@ -5,7 +5,7 @@
 //! process. AppleScript is the most reliable mechanism — no extra deps, works
 //! on every macOS iTerm2 install.
 //! What: `is_iterm2()` checks env vars at startup; `open_session_tab` runs
-//! an `osascript` one-liner that creates a new tab running `tm session attach
+//! an `osascript` one-liner that creates a new tab running `tm sessions attach
 //! <id>`.
 //! Test: Detection logic is pure and unit-tested below; AppleScript calls are
 //! integration-only (no test without a live iTerm2).
@@ -27,10 +27,13 @@ pub fn is_iterm2() -> bool {
     std::path::Path::new("/Applications/iTerm.app").exists()
 }
 
-/// Open a new iTerm2 tab in the current window running `tm session attach <session_id>`.
+/// Open a new iTerm2 tab in the current window running `tm sessions attach <session_id>`.
 ///
 /// Why: The operator can monitor the session list in the TUI while the new tab
-/// runs the actual Claude Code session — no window-switching required.
+/// runs the actual Claude Code session — no window-switching required. Uses
+/// the canonical `tm sessions attach` spelling (#2116/#2394) rather than the
+/// deprecated `tm session attach` alias, so the spawned tab never prints the
+/// deprecation notice.
 /// What: Spawns `osascript` with an inline AppleScript that tells the current
 /// iTerm2 window to create a tab with the default profile and run the attach
 /// command. Returns `Ok(())` if osascript exits 0, `Err(String)` otherwise.
@@ -39,7 +42,7 @@ pub fn open_session_tab(session_id: &str) -> Result<(), String> {
     let script = format!(
         r#"tell application "iTerm2"
   tell current window
-    create tab with default profile command "tm session attach {session_id}"
+    create tab with default profile command "tm sessions attach {session_id}"
   end tell
 end tell"#
     );

--- a/crates/trusty-mpm/tests/tm_sessions_alias_notice.rs
+++ b/crates/trusty-mpm/tests/tm_sessions_alias_notice.rs
@@ -1,0 +1,74 @@
+//! Integration test for the `tm session` -> `tm sessions` top-level rename
+//! (issue #2116, DOC-35 §2.2/§3.2).
+//!
+//! Why: `main.rs`'s dispatch match only fires the deprecation notice for the
+//! `Command::Session` (singular) arm, never for `Command::Sessions` (plural).
+//! That "exactly once per invocation, not per verb" invariant is a real
+//! process-level property (stderr output of the actual binary), so it is
+//! proven here by spawning the compiled `tm` binary — the same technique
+//! `tests/tm_compress_pipe.rs` uses — rather than by unit-testing the pure
+//! message builder alone (that narrower assertion already lives in
+//! `top_level_alias_notice_message` in `src/bin/tm/tests.rs`).
+//! What: runs `tm --url http://127.0.0.1:1 session list` and `tm --url
+//! http://127.0.0.1:1 sessions list`. Port 1 is always refused (see
+//! `core::discovery`'s own tests), so the daemon call fails fast without a
+//! live daemon; the deprecation notice — printed before that network call —
+//! is unaffected by the subsequent failure.
+//! Test: `cargo test -p trusty-mpm --test tm_sessions_alias_notice`.
+
+use std::process::Command;
+
+/// Deterministic never-listening address (reserved port), so the daemon round
+/// trip fails immediately instead of hanging or requiring a live daemon.
+const DEAD_URL: &str = "http://127.0.0.1:1";
+
+fn run_tm(args: &[&str]) -> (String, String) {
+    let bin = env!("CARGO_BIN_EXE_tm");
+    let output = Command::new(bin)
+        .args(args)
+        .output()
+        .expect("failed to spawn `tm`");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Count non-overlapping occurrences of `needle` in `haystack`.
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+#[test]
+fn tm_session_singular_prints_deprecation_notice_once() {
+    let (_, stderr) = run_tm(&["--url", DEAD_URL, "session", "list"]);
+    let notice = "warning: 'session' is deprecated; use 'sessions'";
+    assert_eq!(
+        count_occurrences(&stderr, notice),
+        1,
+        "expected the deprecation notice exactly once, got stderr: {stderr:?}"
+    );
+}
+
+#[test]
+fn tm_sessions_plural_prints_no_deprecation_notice() {
+    let (_, stderr) = run_tm(&["--url", DEAD_URL, "sessions", "list"]);
+    assert!(
+        !stderr.contains("is deprecated"),
+        "canonical `sessions` must never print a deprecation notice, got stderr: {stderr:?}"
+    );
+}
+
+#[test]
+fn tm_session_alias_notice_fires_once_regardless_of_verb() {
+    // Cross-check with a different verb (no positional id required) to prove
+    // the "once per invocation, not once per verb/subcommand-layer" property
+    // is not an artifact of picking `list` specifically.
+    let (_, stderr) = run_tm(&["--url", DEAD_URL, "session", "breakers"]);
+    let notice = "warning: 'session' is deprecated; use 'sessions'";
+    assert_eq!(
+        count_occurrences(&stderr, notice),
+        1,
+        "expected the deprecation notice exactly once for `session breakers`, got stderr: {stderr:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements #2116 (child of epic #2108, DOC-35 §2.2/§3.2/§8 slice 3): promotes `tm session <verb>` to a sibling top-level plural noun, `tm sessions <verb>`, matching `tm projects`. This reverses the earlier #1916 rename to the singular — the owner has resolved that the plural is the durable spelling, with `tm session` kept as a hidden deprecated alias rather than retired, so existing scripts/skills/muscle memory keep working.

## Design / mechanism

- `crates/trusty-mpm/src/bin/tm/cli.rs`:
  - New canonical `Command::Sessions { action: SessionAction }` top-level clap variant.
  - Existing `Command::Session { action: SessionAction }` is retained and now annotated `#[command(name = "session", hide = true)]` — a hidden deprecated alias with **zero functional difference**, mirroring the existing `ManagedStop`/`RuntimeStop`/`ManagedResume` verb-level hidden-alias precedent already in this enum.
  - Doc comments in cli.rs that cross-referenced `tm session <verb>` as illustrative examples (in `ls`, `sessctl`, `install`, etc. help text) are updated to `tm sessions <verb>`.
- `crates/trusty-mpm/src/bin/tm/commands/session.rs`: new `emit_top_level_alias_notice()` helper (reuses the existing `commands::managed::deprecation_notice` builder from the #1205 precedent) — prints `warning: 'session' is deprecated; use 'sessions'` to stderr.
- `crates/trusty-mpm/src/bin/tm/main.rs`: the dispatch match has one arm per top-level variant — `Command::Sessions` calls the shared `session()` handler directly (no notice); `Command::Session` calls `emit_top_level_alias_notice()` once, then the identical `session()` handler. This guarantees the notice fires **exactly once per invocation**, regardless of which verb was invoked (it's a top-level dispatch concern, not a per-verb one).
- No pre-existing partial `tm sessions` aliasing was found in the code (a stray README-adjacent doc mention already used the plural form incidentally but the CLI itself rejected `sessions` prior to this change — confirmed via the now-replaced `cli_sessions_plural_no_longer_parses` test). No second alias mechanism was layered on; this is the only alias mechanism for the top-level noun.

## Test plan

- [x] Existing `cli_parses_session_*` tests continue to pass unchanged (alias path).
- [x] New `cli_parses_sessions_plural_canonical` covers the canonical plural form (`tests_behavior_e_tests.rs`).
- [x] New `cli_session_and_sessions_agree_for_every_verb` sweeps all ~29 `SessionAction` verbs/aliases, asserting `tm session <verb>` and `tm sessions <verb>` parse to the identical action.
- [x] New integration test `tests/tm_sessions_alias_notice.rs` spawns the real `tm` binary and asserts the deprecation notice is printed to stderr exactly once for `tm session <verb>` (across two different verbs) and never for `tm sessions <verb>`.
- [x] `cargo build --workspace`, `cargo test --workspace`, `cargo test -p trusty-mpm`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `bash scripts/check_line_cap.sh` all pass clean.

Closes #2116
Refs #2108

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools