### PR TITLE
feat(trusty-mpm): Deliverable/Milestone data model, central stores, CRUD API + state-machine enforcement (closes #2378, #2380)

### DIFF
--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -109,6 +109,22 @@ pub use origin_guard::origin_allowed;
 pub mod rpc;
 pub use rpc::rpc_handler;
 
+/// The Deliverable/Milestone CRUD routes (`/api/v1/projects/{name}/deliverables`
+/// and `.../milestones`, DOC-35 §10.2/§10.5; #2378 + #2380).
+///
+/// Why: the Deliverable/Milestone ledger is exposed over the same HTTP surface
+/// as every other subsystem so any consumer (CLI #2381, TUI #2383, `tm manager`
+/// #2109) reads and mutates it deterministically. Keeping the handlers in a
+/// sibling module mirrors `coordinator_routes` and keeps `api.rs` focused on
+/// routing. The §10.3 status state machine is enforced inside these handlers
+/// (#2380). The handlers are re-exported so `router` refers to them unqualified.
+/// Test: `deliverable_routes::tests`.
+pub mod deliverable_routes;
+pub use deliverable_routes::{
+    create_deliverable, create_milestone, get_deliverable, get_milestone, list_deliverables,
+    list_milestones, patch_deliverable, patch_milestone,
+};
+
 /// The managed session-manager routes (`/api/v1/sessions/managed/*`).
 ///
 /// Why: the managed-session API is a cohesive cluster (spawn, list, get,
@@ -309,6 +325,28 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .route(
             "/api/v1/sessions/proxy/summary/{conversation_key}",
             get(proxy_summary),
+        )
+        // DOC-35 §10.2/§10.5 (#2378 + #2380): Deliverable/Milestone CRUD, nested
+        // under the projects namespace. The literal `/deliverables` and
+        // `/milestones` segments come before their `/{id}` param routes so a
+        // collection request is never captured as an id (mirroring the managed-
+        // session `/adopt` ordering above). PATCH on `/{id}` is the `set-status`
+        // seam that enforces the §10.3 state machine.
+        .route(
+            "/api/v1/projects/{name}/deliverables",
+            get(list_deliverables).post(create_deliverable),
+        )
+        .route(
+            "/api/v1/projects/{name}/deliverables/{id}",
+            get(get_deliverable).patch(patch_deliverable),
+        )
+        .route(
+            "/api/v1/projects/{name}/milestones",
+            get(list_milestones).post(create_milestone),
+        )
+        .route(
+            "/api/v1/projects/{name}/milestones/{id}",
+            get(get_milestone).patch(patch_milestone),
         )
         // #1221: loopback-only JSON-RPC dispatch for the `serve --stdio` bridge.
         // The handler independently enforces the loopback gate via ConnectInfo.

--- a/crates/trusty-mpm/src/daemon/api/deliverable_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/deliverable_routes.rs
@@ -1,0 +1,490 @@
+//! Deliverable/Milestone CRUD routes (DOC-35 §10.2/§10.5; #2378 + #2380).
+//!
+//! Why: the L3 substrate exposes its Deliverable/Milestone ledger over the SAME
+//! HTTP surface every other subsystem uses, so any consumer (the CLI #2381, the
+//! TUI #2383, `tm manager` #2109) reads and mutates it deterministically. These
+//! handlers are the create/read/update seam nested under the projects namespace
+//! (`/api/v1/projects/{name}/deliverables[/{id}]` and `.../milestones[/{id}]`),
+//! and they are where the §10.3 status state machine is ENFORCED (#2380): an
+//! illegal `set-status` PATCH is rejected with a structured 409 naming the legal
+//! next states. Everything here is a pure function of stored state — no LLM, no
+//! inference, single-project scope (§11).
+//! What: eight handlers (list/create/get/patch for Deliverables and Milestones),
+//! their request/response DTOs, and small store-error → [`DaemonError`] mappers.
+//! Status-transition validation delegates to
+//! [`crate::deliverable::validate_transition`] (unit-tested exhaustively in
+//! `deliverable::status`), so the enforcement rule has ONE source of truth.
+//! Test: `tests` submodule drives every handler in-process, including the full
+//! illegal-transition rejection path.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::{Json, extract::rejection::JsonRejection};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::daemon::error::DaemonError;
+use crate::daemon::state::DaemonState;
+use crate::deliverable::{
+    Deliverable, DeliverableId, DeliverableKind, DeliverableStatus, EstimationTier, Milestone,
+    MilestoneId, MilestoneStatus, StoreError, validate_transition,
+};
+
+#[cfg(test)]
+mod tests;
+
+/// Map a store I/O/serialization error to a 500; `NotFound` never reaches here
+/// on write paths, so it is bucketed as an internal fault.
+///
+/// Why: create/list/save paths have no legitimate `NotFound`; surfacing any
+/// store failure as a 500 keeps those handlers honest about unexpected I/O.
+/// What: renders the error as [`DaemonError::Internal`].
+/// Test: covered indirectly by the happy-path handler tests.
+fn store_internal(e: StoreError) -> DaemonError {
+    DaemonError::Internal(e.to_string())
+}
+
+/// Translate a `NotFound` on a Deliverable lookup into a typed 404.
+///
+/// Why: the GET/PATCH handlers must return a Deliverable-specific 404 (not a
+/// generic session 404) so the error body names the right resource.
+/// What: `NotFound` → [`DaemonError::DeliverableNotFound`]; any other store error
+/// → 500.
+/// Test: `get_unknown_deliverable_is_404`.
+fn deliverable_lookup_err(e: StoreError, id: &str) -> DaemonError {
+    match e {
+        StoreError::NotFound(_) => DaemonError::DeliverableNotFound { id: id.to_string() },
+        other => store_internal(other),
+    }
+}
+
+/// Translate a `NotFound` on a Milestone lookup into a typed 404.
+fn milestone_lookup_err(e: StoreError, id: &str) -> DaemonError {
+    match e {
+        StoreError::NotFound(_) => DaemonError::MilestoneNotFound { id: id.to_string() },
+        other => store_internal(other),
+    }
+}
+
+/// Unwrap a JSON body, mapping a deserialization rejection to a 400.
+///
+/// Why: axum's default `JsonRejection` renders a bare 422 with a plain-text
+/// body; routing it through [`DaemonError::InvalidRequest`] gives a consistent
+/// `{ "error": … }` shape and a 400 for malformed input.
+/// What: returns the parsed body or an `InvalidRequest` error.
+/// Test: exercised by the malformed-body handler test.
+fn body<T>(body: Result<Json<T>, JsonRejection>) -> Result<T, DaemonError> {
+    body.map(|Json(v)| v)
+        .map_err(|e| DaemonError::InvalidRequest(e.body_text()))
+}
+
+// ───────────────────────── Deliverable DTOs ──────────────────────────
+
+/// Request body for `POST /api/v1/projects/{name}/deliverables`.
+///
+/// Why: creation fixes the immutable facts of a Deliverable; `status` is always
+/// `Proposed` at creation (§10.3 forbids starting anywhere else), `id` and
+/// `created_at` are server-assigned, so neither is accepted from the client.
+/// What: the required `name`, `kind`, and `estimated_effort` plus the optional
+/// description and opaque `ticket_ref`/`spec_ref`/`target_date` slots (§13 Q6).
+/// Test: `create_then_get_round_trips`.
+#[derive(Debug, Deserialize)]
+pub struct CreateDeliverable {
+    /// Human-readable name (required, non-empty).
+    pub name: String,
+    /// Free-form description.
+    #[serde(default)]
+    pub description: String,
+    /// The category of work.
+    pub kind: DeliverableKind,
+    /// Coarse effort estimate (S/M/L/XL).
+    pub estimated_effort: EstimationTier,
+    /// Opaque gh-first ticket reference (§13 Q6).
+    #[serde(default)]
+    pub ticket_ref: Option<String>,
+    /// Repo-relative spec path (§10.4).
+    #[serde(default)]
+    pub spec_ref: Option<String>,
+    /// Optional target completion date.
+    #[serde(default)]
+    pub target_date: Option<DateTime<Utc>>,
+}
+
+/// Request body for `PATCH /api/v1/projects/{name}/deliverables/{id}`.
+///
+/// Why: PATCH is a partial, idempotent update; every field is optional and only
+/// the present fields are applied. A present `status` drives the §10.3 state
+/// machine (#2380) — a change to an illegal next state is rejected; setting
+/// `status` to the record's CURRENT value is a no-op (not an error), so echoing
+/// state alongside a field edit never spuriously fails.
+/// What: all Deliverable-mutable fields as `Option`s.
+/// Test: `patch_updates_fields`, `patch_illegal_transition_is_409_with_allowed_next`,
+/// `patch_same_status_is_noop`.
+#[derive(Debug, Default, Deserialize)]
+pub struct PatchDeliverable {
+    /// New name, if changing.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// New description, if changing.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// New kind, if changing.
+    #[serde(default)]
+    pub kind: Option<DeliverableKind>,
+    /// New estimate, if changing.
+    #[serde(default)]
+    pub estimated_effort: Option<EstimationTier>,
+    /// New ticket ref, if changing.
+    #[serde(default)]
+    pub ticket_ref: Option<String>,
+    /// New spec ref, if changing.
+    #[serde(default)]
+    pub spec_ref: Option<String>,
+    /// New status — validated against the §10.3 state machine (#2380).
+    #[serde(default)]
+    pub status: Option<DeliverableStatus>,
+    /// New target date, if changing.
+    #[serde(default)]
+    pub target_date: Option<DateTime<Utc>>,
+}
+
+/// Query parameters for `GET .../deliverables`.
+///
+/// Why: `tm projects deliverables list <project> [--status <s>]` (§10.8) filters
+/// by status; the optional query param mirrors that.
+/// What: an optional [`DeliverableStatus`] filter.
+/// Test: `list_filters_by_status_and_scopes_to_project`.
+#[derive(Debug, Default, Deserialize)]
+pub struct DeliverableListQuery {
+    /// Optional status filter.
+    #[serde(default)]
+    pub status: Option<DeliverableStatus>,
+}
+
+/// Response body for `GET .../deliverables`.
+#[derive(Debug, Serialize)]
+pub struct DeliverablesResponse {
+    /// The project's Deliverables (optionally status-filtered).
+    pub deliverables: Vec<Deliverable>,
+}
+
+// ───────────────────────── Deliverable handlers ──────────────────────
+
+/// `POST /api/v1/projects/{name}/deliverables` — create a Deliverable.
+///
+/// Why: the entry point for tracking a new unit of work against a project.
+/// What: builds a `Deliverable` with a fresh id, `status = Proposed`, and
+/// server-assigned `created_at`; rejects an empty name with 400; persists it and
+/// returns 201 with the created record.
+/// Test: `create_then_get_round_trips`, `create_rejects_empty_name`.
+pub async fn create_deliverable(
+    State(state): State<Arc<DaemonState>>,
+    Path(project): Path<String>,
+    body_in: Result<Json<CreateDeliverable>, JsonRejection>,
+) -> Result<(StatusCode, Json<Deliverable>), DaemonError> {
+    let req = body(body_in)?;
+    if req.name.trim().is_empty() {
+        return Err(DaemonError::InvalidRequest(
+            "deliverable name must not be empty".into(),
+        ));
+    }
+    let deliverable = Deliverable {
+        id: DeliverableId::new(),
+        project_name: project,
+        name: req.name,
+        description: req.description,
+        kind: req.kind,
+        ticket_ref: req.ticket_ref,
+        spec_ref: req.spec_ref,
+        status: DeliverableStatus::Proposed,
+        estimated_effort: req.estimated_effort,
+        created_at: Utc::now(),
+        target_date: req.target_date,
+    };
+    let mgr = state.deliverable_manager().await;
+    mgr.upsert_deliverable(deliverable.clone())
+        .await
+        .map_err(store_internal)?;
+    Ok((StatusCode::CREATED, Json(deliverable)))
+}
+
+/// `GET /api/v1/projects/{name}/deliverables` — list a project's Deliverables.
+///
+/// Why: the project-scoped list view (§10.8), optionally filtered by status.
+/// What: returns every Deliverable whose `project_name` matches, applying the
+/// optional `?status=` filter.
+/// Test: `list_filters_by_status_and_scopes_to_project`.
+pub async fn list_deliverables(
+    State(state): State<Arc<DaemonState>>,
+    Path(project): Path<String>,
+    Query(query): Query<DeliverableListQuery>,
+) -> Result<Json<DeliverablesResponse>, DaemonError> {
+    let mgr = state.deliverable_manager().await;
+    let mut deliverables = mgr
+        .deliverables_by_project(&project)
+        .await
+        .map_err(store_internal)?;
+    if let Some(status) = query.status {
+        deliverables.retain(|d| d.status == status);
+    }
+    Ok(Json(DeliverablesResponse { deliverables }))
+}
+
+/// Fetch a Deliverable and confirm it belongs to `project` (404 otherwise).
+///
+/// Why: a Deliverable id is global, but the route nests it under a project; a
+/// mismatched project must 404 rather than leak another project's record.
+/// What: looks up by id, maps `NotFound` to a typed 404, then enforces the
+/// project scope.
+/// Test: `get_wrong_project_is_404`.
+async fn fetch_scoped(
+    state: &Arc<DaemonState>,
+    project: &str,
+    id: &str,
+) -> Result<Deliverable, DaemonError> {
+    let mgr = state.deliverable_manager().await;
+    let d = mgr
+        .get_deliverable(id)
+        .await
+        .map_err(|e| deliverable_lookup_err(e, id))?;
+    if d.project_name != project {
+        return Err(DaemonError::DeliverableNotFound { id: id.to_string() });
+    }
+    Ok(d)
+}
+
+/// `GET /api/v1/projects/{name}/deliverables/{id}` — fetch one Deliverable.
+///
+/// Why: point lookup without paging the full list.
+/// What: returns the Deliverable if it exists AND belongs to `project`; 404
+/// otherwise.
+/// Test: `create_then_get_round_trips`, `get_unknown_deliverable_is_404`.
+pub async fn get_deliverable(
+    State(state): State<Arc<DaemonState>>,
+    Path((project, id)): Path<(String, String)>,
+) -> Result<Json<Deliverable>, DaemonError> {
+    let d = fetch_scoped(&state, &project, &id).await?;
+    Ok(Json(d))
+}
+
+/// `PATCH /api/v1/projects/{name}/deliverables/{id}` — update a Deliverable.
+///
+/// Why: the single mutation seam — field edits and the `set-status` transition
+/// both flow through here. This is where #2380 is enforced.
+/// What: fetches the (project-scoped) record, applies each present field, and —
+/// when `status` changes — validates the transition against the §10.3 machine
+/// via [`validate_transition`], rejecting an illegal change with a structured 409
+/// naming the legal next states. A `status` equal to the current value is a
+/// no-op. Persists and returns the updated record.
+/// Test: `patch_updates_fields`, `patch_full_legal_lifecycle_succeeds`,
+/// `patch_illegal_transition_is_409_with_allowed_next`, `patch_same_status_is_noop`.
+pub async fn patch_deliverable(
+    State(state): State<Arc<DaemonState>>,
+    Path((project, id)): Path<(String, String)>,
+    body_in: Result<Json<PatchDeliverable>, JsonRejection>,
+) -> Result<Json<Deliverable>, DaemonError> {
+    let patch = body(body_in)?;
+    let mut d = fetch_scoped(&state, &project, &id).await?;
+
+    // #2380: enforce the status state machine BEFORE any mutation, so a rejected
+    // transition leaves the record untouched.
+    if let Some(new_status) = patch.status
+        && new_status != d.status
+    {
+        validate_transition(d.status, new_status).map_err(|te| DaemonError::InvalidTransition {
+            from: te.from.to_string(),
+            to: te.to.to_string(),
+            allowed: te.allowed.iter().map(|s| s.as_str().to_string()).collect(),
+        })?;
+        d.status = new_status;
+    }
+
+    if let Some(name) = patch.name {
+        d.name = name;
+    }
+    if let Some(description) = patch.description {
+        d.description = description;
+    }
+    if let Some(kind) = patch.kind {
+        d.kind = kind;
+    }
+    if let Some(effort) = patch.estimated_effort {
+        d.estimated_effort = effort;
+    }
+    if patch.ticket_ref.is_some() {
+        d.ticket_ref = patch.ticket_ref;
+    }
+    if patch.spec_ref.is_some() {
+        d.spec_ref = patch.spec_ref;
+    }
+    if patch.target_date.is_some() {
+        d.target_date = patch.target_date;
+    }
+
+    let mgr = state.deliverable_manager().await;
+    mgr.upsert_deliverable(d.clone())
+        .await
+        .map_err(store_internal)?;
+    Ok(Json(d))
+}
+
+// ───────────────────────── Milestone DTOs ────────────────────────────
+
+/// Request body for `POST /api/v1/projects/{name}/milestones`.
+///
+/// Why: creation fixes the immutable facts; `id`/`created_at` are server-assigned.
+/// What: required `name` and `target_date`, optional description, member
+/// Deliverable ids, and a rollup `status` (default `Proposed`).
+/// Test: `milestone_create_then_get`.
+#[derive(Debug, Deserialize)]
+pub struct CreateMilestone {
+    /// Human-readable name (required, non-empty).
+    pub name: String,
+    /// Free-form description.
+    #[serde(default)]
+    pub description: String,
+    /// The date this Milestone targets.
+    pub target_date: DateTime<Utc>,
+    /// Member Deliverable ids.
+    #[serde(default)]
+    pub deliverables: Vec<DeliverableId>,
+    /// Rollup status (default `Proposed`, §10.5).
+    #[serde(default)]
+    pub status: MilestoneStatus,
+}
+
+/// Request body for `PATCH /api/v1/projects/{name}/milestones/{id}`.
+///
+/// Why: partial update. Milestone `status` is a rollup field (§10.3/§10.5), NOT
+/// a user-driven state machine, so — unlike Deliverable — it is set directly with
+/// no transition enforcement (the deterministic rollup that overwrites it is
+/// #2382 / the read-only status endpoint's job).
+/// What: all Milestone-mutable fields as `Option`s.
+/// Test: `milestone_patch_updates_fields`.
+#[derive(Debug, Default, Deserialize)]
+pub struct PatchMilestone {
+    /// New name, if changing.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// New description, if changing.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// New target date, if changing.
+    #[serde(default)]
+    pub target_date: Option<DateTime<Utc>>,
+    /// New rollup status, if changing (no transition enforcement — see above).
+    #[serde(default)]
+    pub status: Option<MilestoneStatus>,
+    /// Replacement member Deliverable id list, if changing.
+    #[serde(default)]
+    pub deliverables: Option<Vec<DeliverableId>>,
+}
+
+/// Response body for `GET .../milestones`.
+#[derive(Debug, Serialize)]
+pub struct MilestonesResponse {
+    /// The project's Milestones.
+    pub milestones: Vec<Milestone>,
+}
+
+// ───────────────────────── Milestone handlers ────────────────────────
+
+/// `POST /api/v1/projects/{name}/milestones` — create a Milestone.
+pub async fn create_milestone(
+    State(state): State<Arc<DaemonState>>,
+    Path(project): Path<String>,
+    body_in: Result<Json<CreateMilestone>, JsonRejection>,
+) -> Result<(StatusCode, Json<Milestone>), DaemonError> {
+    let req = body(body_in)?;
+    if req.name.trim().is_empty() {
+        return Err(DaemonError::InvalidRequest(
+            "milestone name must not be empty".into(),
+        ));
+    }
+    let milestone = Milestone {
+        id: MilestoneId::new(),
+        project_name: project,
+        name: req.name,
+        description: req.description,
+        target_date: req.target_date,
+        status: req.status,
+        deliverables: req.deliverables,
+        created_at: Utc::now(),
+    };
+    let mgr = state.deliverable_manager().await;
+    mgr.upsert_milestone(milestone.clone())
+        .await
+        .map_err(store_internal)?;
+    Ok((StatusCode::CREATED, Json(milestone)))
+}
+
+/// `GET /api/v1/projects/{name}/milestones` — list a project's Milestones.
+pub async fn list_milestones(
+    State(state): State<Arc<DaemonState>>,
+    Path(project): Path<String>,
+) -> Result<Json<MilestonesResponse>, DaemonError> {
+    let mgr = state.deliverable_manager().await;
+    let milestones = mgr
+        .milestones_by_project(&project)
+        .await
+        .map_err(store_internal)?;
+    Ok(Json(MilestonesResponse { milestones }))
+}
+
+/// Fetch a Milestone and confirm it belongs to `project` (404 otherwise).
+async fn fetch_scoped_milestone(
+    state: &Arc<DaemonState>,
+    project: &str,
+    id: &str,
+) -> Result<Milestone, DaemonError> {
+    let mgr = state.deliverable_manager().await;
+    let m = mgr
+        .get_milestone(id)
+        .await
+        .map_err(|e| milestone_lookup_err(e, id))?;
+    if m.project_name != project {
+        return Err(DaemonError::MilestoneNotFound { id: id.to_string() });
+    }
+    Ok(m)
+}
+
+/// `GET /api/v1/projects/{name}/milestones/{id}` — fetch one Milestone.
+pub async fn get_milestone(
+    State(state): State<Arc<DaemonState>>,
+    Path((project, id)): Path<(String, String)>,
+) -> Result<Json<Milestone>, DaemonError> {
+    let m = fetch_scoped_milestone(&state, &project, &id).await?;
+    Ok(Json(m))
+}
+
+/// `PATCH /api/v1/projects/{name}/milestones/{id}` — update a Milestone.
+pub async fn patch_milestone(
+    State(state): State<Arc<DaemonState>>,
+    Path((project, id)): Path<(String, String)>,
+    body_in: Result<Json<PatchMilestone>, JsonRejection>,
+) -> Result<Json<Milestone>, DaemonError> {
+    let patch = body(body_in)?;
+    let mut m = fetch_scoped_milestone(&state, &project, &id).await?;
+    if let Some(name) = patch.name {
+        m.name = name;
+    }
+    if let Some(description) = patch.description {
+        m.description = description;
+    }
+    if let Some(target_date) = patch.target_date {
+        m.target_date = target_date;
+    }
+    if let Some(status) = patch.status {
+        m.status = status;
+    }
+    if let Some(deliverables) = patch.deliverables {
+        m.deliverables = deliverables;
+    }
+    let mgr = state.deliverable_manager().await;
+    mgr.upsert_milestone(m.clone())
+        .await
+        .map_err(store_internal)?;
+    Ok(Json(m))
+}

--- a/crates/trusty-mpm/src/daemon/api/deliverable_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/deliverable_routes.rs
@@ -13,9 +13,19 @@
 //! their request/response DTOs, and small store-error → [`DaemonError`] mappers.
 //! Status-transition validation delegates to
 //! [`crate::deliverable::validate_transition`] (unit-tested exhaustively in
-//! `deliverable::status`), so the enforcement rule has ONE source of truth.
+//! `deliverable::status`), so the enforcement rule has ONE source of truth. Per
+//! the #2395 review HIGH, both PATCH handlers run their entire
+//! fetch→validate→mutate→persist sequence inside ONE closure passed to
+//! [`crate::deliverable::DeliverableManager::update_deliverable_with`] /
+//! [`update_milestone_with`](crate::deliverable::DeliverableManager::update_milestone_with) —
+//! a single write-lock guard held for the whole sequence, so two concurrent
+//! PATCHes can never interleave between a separate fetch-lock and a separate
+//! persist-lock (the two-lock shape this replaced).
 //! Test: `tests` submodule drives every handler in-process, including the full
-//! illegal-transition rejection path.
+//! illegal-transition rejection path and the blank-name-on-PATCH rejection. The
+//! concurrency regression itself is proven at the manager layer —
+//! `deliverable::manager::tests::update_deliverable_with_serializes_concurrent_transitions`
+//! and `..::read_then_upsert_pattern_reproduces_lost_update_pre_fix`.
 
 use std::sync::Arc;
 
@@ -27,6 +37,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
+use crate::deliverable::manager::UpdateError;
 use crate::deliverable::{
     Deliverable, DeliverableId, DeliverableKind, DeliverableStatus, EstimationTier, Milestone,
     MilestoneId, MilestoneStatus, StoreError, validate_transition,
@@ -68,6 +79,51 @@ fn milestone_lookup_err(e: StoreError, id: &str) -> DaemonError {
     }
 }
 
+/// Translate an atomic-update [`UpdateError`] into the right [`DaemonError`].
+///
+/// Why: [`crate::deliverable::DeliverableManager::update_deliverable_with`] (the
+/// #2395-review fix for the lost-update hazard) returns one error type covering
+/// both a store failure and a rejected §10.3 transition; the route layer must
+/// still map each to its own HTTP status — 404 for not-found/wrong-project, 409
+/// for an illegal transition — exactly as the pre-fix two-call path did.
+/// What: `UpdateError::Store(NotFound)` → [`DaemonError::DeliverableNotFound`];
+/// any other `Store` variant → 500; `UpdateError::Transition` →
+/// [`DaemonError::InvalidTransition`] carrying the legal next states.
+/// Test: `patch_illegal_transition_is_409_with_allowed_next`,
+/// `get_unknown_deliverable_is_404` (via `get_wrong_project_is_404`'s PATCH twin).
+fn update_err(e: UpdateError, id: &str) -> DaemonError {
+    match e {
+        UpdateError::Store(store_err) => deliverable_lookup_err(store_err, id),
+        UpdateError::Transition(te) => DaemonError::InvalidTransition {
+            from: te.from.to_string(),
+            to: te.to.to_string(),
+            allowed: te.allowed.iter().map(|s| s.as_str().to_string()).collect(),
+        },
+    }
+}
+
+/// Reject a PATCH `name` field that is present but blank after trimming.
+///
+/// Why: `create_deliverable`/`create_milestone` already enforce a non-empty
+/// trimmed name; PATCH left the same field settable to whitespace-only or empty
+/// (#2395 review MEDIUM) — the same rule must apply on both paths so a record
+/// can never end up with a blank name via an update that creation would have
+/// rejected outright.
+/// What: `None` (field absent from the PATCH body) is always fine — the caller
+/// is not touching `name`. `Some(name)` where `name.trim()` is empty is
+/// rejected with a 400; any other `Some` passes.
+/// Test: `patch_deliverable_rejects_blank_name`, `patch_milestone_rejects_blank_name`.
+fn reject_blank_patch_name(name: &Option<String>, resource: &str) -> Result<(), DaemonError> {
+    if let Some(n) = name
+        && n.trim().is_empty()
+    {
+        return Err(DaemonError::InvalidRequest(format!(
+            "{resource} name must not be empty"
+        )));
+    }
+    Ok(())
+}
+
 /// Unwrap a JSON body, mapping a deserialization rejection to a 400.
 ///
 /// Why: axum's default `JsonRejection` renders a bare 422 with a plain-text
@@ -89,6 +145,17 @@ fn body<T>(body: Result<Json<T>, JsonRejection>) -> Result<T, DaemonError> {
 /// `created_at` are server-assigned, so neither is accepted from the client.
 /// What: the required `name`, `kind`, and `estimated_effort` plus the optional
 /// description and opaque `ticket_ref`/`spec_ref`/`target_date` slots (§13 Q6).
+///
+/// **Referential integrity is deferred by design, not a bug:** `project_name`
+/// (taken from the URL path, not the body) is never checked against the
+/// registry-B project store — a Deliverable can be created under a
+/// `project_name` that does not (yet, or ever) exist as a registered `Project`.
+/// This matches §13 Q6's opaque-reference treatment of `ticket_ref`/`spec_ref`
+/// (validation deferred, gh-first / plain-path convention, no cross-store
+/// lookups added here) and keeps this endpoint's boundary strictly deterministic
+/// per §11 (no cross-store reasoning). A future consumer (the #2382 rollup
+/// endpoint, or `tm manager` #2109) can surface a dangling `project_name` as a
+/// read-only signal without this write path needing to enforce it.
 /// Test: `create_then_get_round_trips`.
 #[derive(Debug, Deserialize)]
 pub struct CreateDeliverable {
@@ -118,10 +185,21 @@ pub struct CreateDeliverable {
 /// the present fields are applied. A present `status` drives the §10.3 state
 /// machine (#2380) — a change to an illegal next state is rejected; setting
 /// `status` to the record's CURRENT value is a no-op (not an error), so echoing
-/// state alongside a field edit never spuriously fails.
+/// state alongside a field edit never spuriously fails. `name`, if present, must
+/// be non-blank after trimming (same rule `create_deliverable` enforces).
 /// What: all Deliverable-mutable fields as `Option`s.
+///
+/// **v1 limitation (deferred by design, not a bug):** because every field here
+/// is a single `Option`, there is no way to distinguish "absent from the JSON
+/// body" from "explicitly set to `null`" for `ticket_ref`/`spec_ref`/
+/// `target_date` — both deserialize to `None` and this handler treats `None` as
+/// "leave unchanged" (see `patch_deliverable`'s `if patch.ticket_ref.is_some()`
+/// guards). Clearing an already-set `ticket_ref`/`spec_ref`/`target_date` back to
+/// absent is therefore NOT supported in v1; that would require a double-`Option`
+/// (`Option<Option<String>>`, distinguishing "key omitted" from "key present with
+/// value `null`") which is deliberately deferred until a real caller needs it.
 /// Test: `patch_updates_fields`, `patch_illegal_transition_is_409_with_allowed_next`,
-/// `patch_same_status_is_noop`.
+/// `patch_same_status_is_noop`, `patch_deliverable_rejects_blank_name`.
 #[derive(Debug, Default, Deserialize)]
 pub struct PatchDeliverable {
     /// New name, if changing.
@@ -272,62 +350,72 @@ pub async fn get_deliverable(
 /// `PATCH /api/v1/projects/{name}/deliverables/{id}` — update a Deliverable.
 ///
 /// Why: the single mutation seam — field edits and the `set-status` transition
-/// both flow through here. This is where #2380 is enforced.
-/// What: fetches the (project-scoped) record, applies each present field, and —
-/// when `status` changes — validates the transition against the §10.3 machine
-/// via [`validate_transition`], rejecting an illegal change with a structured 409
-/// naming the legal next states. A `status` equal to the current value is a
-/// no-op. Persists and returns the updated record.
+/// both flow through here. This is where #2380 is enforced. Per the #2395
+/// review HIGH, the fetch, the transition validation, the field mutation, AND
+/// the persist all run inside ONE closure passed to
+/// [`DeliverableManager::update_deliverable_with`](crate::deliverable::DeliverableManager::update_deliverable_with),
+/// which holds a single write-lock guard across the whole sequence — no other
+/// concurrent PATCH can observe or clobber the intermediate state (see that
+/// method's doc for the exact hazard this closes).
+/// What: rejects a present-but-blank `name` before touching the store (MEDIUM
+/// fix — matches `create_deliverable`'s rule). Then atomically: fetches the
+/// project-scoped record, and — when `status` changes — validates the
+/// transition against the §10.3 machine via [`validate_transition`], rejecting
+/// an illegal change with a structured 409 naming the legal next states. A
+/// `status` equal to the current value is a no-op. Applies every other present
+/// field, persists, and returns the updated record — all under the manager's
+/// single lock.
 /// Test: `patch_updates_fields`, `patch_full_legal_lifecycle_succeeds`,
-/// `patch_illegal_transition_is_409_with_allowed_next`, `patch_same_status_is_noop`.
+/// `patch_illegal_transition_is_409_with_allowed_next`, `patch_same_status_is_noop`,
+/// `patch_deliverable_rejects_blank_name`.
 pub async fn patch_deliverable(
     State(state): State<Arc<DaemonState>>,
     Path((project, id)): Path<(String, String)>,
     body_in: Result<Json<PatchDeliverable>, JsonRejection>,
 ) -> Result<Json<Deliverable>, DaemonError> {
     let patch = body(body_in)?;
-    let mut d = fetch_scoped(&state, &project, &id).await?;
-
-    // #2380: enforce the status state machine BEFORE any mutation, so a rejected
-    // transition leaves the record untouched.
-    if let Some(new_status) = patch.status
-        && new_status != d.status
-    {
-        validate_transition(d.status, new_status).map_err(|te| DaemonError::InvalidTransition {
-            from: te.from.to_string(),
-            to: te.to.to_string(),
-            allowed: te.allowed.iter().map(|s| s.as_str().to_string()).collect(),
-        })?;
-        d.status = new_status;
-    }
-
-    if let Some(name) = patch.name {
-        d.name = name;
-    }
-    if let Some(description) = patch.description {
-        d.description = description;
-    }
-    if let Some(kind) = patch.kind {
-        d.kind = kind;
-    }
-    if let Some(effort) = patch.estimated_effort {
-        d.estimated_effort = effort;
-    }
-    if patch.ticket_ref.is_some() {
-        d.ticket_ref = patch.ticket_ref;
-    }
-    if patch.spec_ref.is_some() {
-        d.spec_ref = patch.spec_ref;
-    }
-    if patch.target_date.is_some() {
-        d.target_date = patch.target_date;
-    }
+    reject_blank_patch_name(&patch.name, "deliverable")?;
 
     let mgr = state.deliverable_manager().await;
-    mgr.upsert_deliverable(d.clone())
+    let updated = mgr
+        .update_deliverable_with(&id, &project, move |mut d| {
+            // #2380: enforce the status state machine BEFORE any other mutation,
+            // so a rejected transition leaves the record untouched. Validated
+            // against `d.status`, which was fetched and will be persisted under
+            // the SAME lock this closure runs inside — never a stale read.
+            if let Some(new_status) = patch.status
+                && new_status != d.status
+            {
+                validate_transition(d.status, new_status)?;
+                d.status = new_status;
+            }
+
+            if let Some(name) = patch.name {
+                d.name = name;
+            }
+            if let Some(description) = patch.description {
+                d.description = description;
+            }
+            if let Some(kind) = patch.kind {
+                d.kind = kind;
+            }
+            if let Some(effort) = patch.estimated_effort {
+                d.estimated_effort = effort;
+            }
+            if patch.ticket_ref.is_some() {
+                d.ticket_ref = patch.ticket_ref;
+            }
+            if patch.spec_ref.is_some() {
+                d.spec_ref = patch.spec_ref;
+            }
+            if patch.target_date.is_some() {
+                d.target_date = patch.target_date;
+            }
+            Ok(d)
+        })
         .await
-        .map_err(store_internal)?;
-    Ok(Json(d))
+        .map_err(|e| update_err(e, &id))?;
+    Ok(Json(updated))
 }
 
 // ───────────────────────── Milestone DTOs ────────────────────────────
@@ -337,6 +425,15 @@ pub async fn patch_deliverable(
 /// Why: creation fixes the immutable facts; `id`/`created_at` are server-assigned.
 /// What: required `name` and `target_date`, optional description, member
 /// Deliverable ids, and a rollup `status` (default `Proposed`).
+///
+/// **Referential integrity is deferred by design, not a bug:** neither
+/// `project_name` (URL path, not checked against the registry-B project store —
+/// same deferral as `CreateDeliverable`) nor each entry of `deliverables` (not
+/// checked against the deliverables store — a Milestone can reference a
+/// `DeliverableId` that does not exist, belongs to a different project, or is
+/// later deleted) is validated here. No cross-store lookups are added to this
+/// write path (§11 boundary); a dangling member id is a signal the #2382 rollup
+/// endpoint (or a future `tm manager` #2109 consumer) can surface read-only.
 /// Test: `milestone_create_then_get`.
 #[derive(Debug, Deserialize)]
 pub struct CreateMilestone {
@@ -360,9 +457,10 @@ pub struct CreateMilestone {
 /// Why: partial update. Milestone `status` is a rollup field (§10.3/§10.5), NOT
 /// a user-driven state machine, so — unlike Deliverable — it is set directly with
 /// no transition enforcement (the deterministic rollup that overwrites it is
-/// #2382 / the read-only status endpoint's job).
+/// #2382 / the read-only status endpoint's job). `name`, if present, must be
+/// non-blank after trimming (same rule `create_milestone` enforces).
 /// What: all Milestone-mutable fields as `Option`s.
-/// Test: `milestone_patch_updates_fields`.
+/// Test: `milestone_patch_updates_fields`, `patch_milestone_rejects_blank_name`.
 #[derive(Debug, Default, Deserialize)]
 pub struct PatchMilestone {
     /// New name, if changing.
@@ -460,31 +558,46 @@ pub async fn get_milestone(
 }
 
 /// `PATCH /api/v1/projects/{name}/milestones/{id}` — update a Milestone.
+///
+/// Why: mirrors `patch_deliverable`'s atomicity fix (#2395 review HIGH) even
+/// though Milestone has no state machine to invalidate — a read-then-upsert
+/// PATCH can still silently drop a concurrent field edit. The whole
+/// fetch-mutate-persist sequence runs inside one closure passed to
+/// [`DeliverableManager::update_milestone_with`](crate::deliverable::DeliverableManager::update_milestone_with),
+/// which holds a single write-lock guard across it.
+/// What: rejects a present-but-blank `name` before touching the store (MEDIUM
+/// fix). Then atomically fetches the project-scoped record, applies every
+/// present field, and persists — all under the manager's single lock.
+/// Test: `milestone_patch_updates_fields`, `patch_milestone_rejects_blank_name`.
 pub async fn patch_milestone(
     State(state): State<Arc<DaemonState>>,
     Path((project, id)): Path<(String, String)>,
     body_in: Result<Json<PatchMilestone>, JsonRejection>,
 ) -> Result<Json<Milestone>, DaemonError> {
     let patch = body(body_in)?;
-    let mut m = fetch_scoped_milestone(&state, &project, &id).await?;
-    if let Some(name) = patch.name {
-        m.name = name;
-    }
-    if let Some(description) = patch.description {
-        m.description = description;
-    }
-    if let Some(target_date) = patch.target_date {
-        m.target_date = target_date;
-    }
-    if let Some(status) = patch.status {
-        m.status = status;
-    }
-    if let Some(deliverables) = patch.deliverables {
-        m.deliverables = deliverables;
-    }
+    reject_blank_patch_name(&patch.name, "milestone")?;
+
     let mgr = state.deliverable_manager().await;
-    mgr.upsert_milestone(m.clone())
+    let updated = mgr
+        .update_milestone_with(&id, &project, move |mut m| {
+            if let Some(name) = patch.name {
+                m.name = name;
+            }
+            if let Some(description) = patch.description {
+                m.description = description;
+            }
+            if let Some(target_date) = patch.target_date {
+                m.target_date = target_date;
+            }
+            if let Some(status) = patch.status {
+                m.status = status;
+            }
+            if let Some(deliverables) = patch.deliverables {
+                m.deliverables = deliverables;
+            }
+            m
+        })
         .await
-        .map_err(store_internal)?;
-    Ok(Json(m))
+        .map_err(|e| milestone_lookup_err(e, &id))?;
+    Ok(Json(updated))
 }

--- a/crates/trusty-mpm/src/daemon/api/deliverable_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/api/deliverable_routes/tests.rs
@@ -1,0 +1,322 @@
+//! Handler tests for the Deliverable/Milestone CRUD routes (#2378, #2380).
+//!
+//! Why: these drive every handler in-process against a temp-rooted `DaemonState`
+//! so the CRUD contract and — critically — the #2380 status-transition
+//! enforcement are exercised end-to-end through the exact code the router calls.
+//! What: create/get/list/patch happy paths, 404 scoping, and the full illegal-
+//! transition rejection path (including the structured `allowed_next` body).
+//! Test: this IS the test module.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::response::IntoResponse;
+use axum::{Json, http::StatusCode};
+use chrono::Utc;
+use tempfile::TempDir;
+
+use super::*;
+use crate::daemon::state::DaemonState;
+use crate::deliverable::{DeliverableKind, DeliverableStatus, EstimationTier, MilestoneStatus};
+
+/// Build a temp-rooted daemon state; the deliverable stores live under its root.
+fn state() -> (Arc<DaemonState>, TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let st = Arc::new(DaemonState::with_root(dir.path().to_path_buf()));
+    (st, dir)
+}
+
+fn create_body(name: &str) -> CreateDeliverable {
+    CreateDeliverable {
+        name: name.into(),
+        description: "desc".into(),
+        kind: DeliverableKind::Feature,
+        estimated_effort: EstimationTier::M,
+        ticket_ref: Some("#2117".into()),
+        spec_ref: Some("docs/specs/tm-project-control-plane.md".into()),
+        target_date: None,
+    }
+}
+
+async fn create(st: &Arc<DaemonState>, project: &str, name: &str) -> Deliverable {
+    let (code, Json(d)) = create_deliverable(
+        State(Arc::clone(st)),
+        Path(project.to_string()),
+        Ok(Json(create_body(name))),
+    )
+    .await
+    .expect("create ok");
+    assert_eq!(code, StatusCode::CREATED);
+    d
+}
+
+#[tokio::test]
+async fn create_then_get_round_trips() {
+    let (st, _g) = state();
+    let created = create(&st, "trusty-tools", "OAuth flow").await;
+    assert_eq!(created.status, DeliverableStatus::Proposed);
+    assert_eq!(created.project_name, "trusty-tools");
+
+    let Json(got) = get_deliverable(
+        State(Arc::clone(&st)),
+        Path(("trusty-tools".into(), created.id.to_string())),
+    )
+    .await
+    .expect("get ok");
+    assert_eq!(got, created);
+}
+
+#[tokio::test]
+async fn create_rejects_empty_name() {
+    let (st, _g) = state();
+    let err = create_deliverable(State(st), Path("p".into()), Ok(Json(create_body("   "))))
+        .await
+        .expect_err("empty name rejected");
+    assert!(matches!(err, DaemonError::InvalidRequest(_)));
+}
+
+#[tokio::test]
+async fn list_filters_by_status_and_scopes_to_project() {
+    let (st, _g) = state();
+    let d1 = create(&st, "p1", "a").await;
+    let _d2 = create(&st, "p1", "b").await;
+    let _other = create(&st, "p2", "c").await;
+
+    // Move d1 to in-progress so a status filter can distinguish it.
+    let Json(_moved) = patch_deliverable(
+        State(Arc::clone(&st)),
+        Path(("p1".into(), d1.id.to_string())),
+        Ok(Json(PatchDeliverable {
+            status: Some(DeliverableStatus::InProgress),
+            ..Default::default()
+        })),
+    )
+    .await
+    .expect("patch ok");
+
+    // Project scoping: p1 has two, p2 has one.
+    let Json(all_p1) = list_deliverables(
+        State(Arc::clone(&st)),
+        Path("p1".into()),
+        Query(DeliverableListQuery { status: None }),
+    )
+    .await
+    .expect("list ok");
+    assert_eq!(all_p1.deliverables.len(), 2);
+
+    // Status filter: only the in-progress one.
+    let Json(in_prog) = list_deliverables(
+        State(Arc::clone(&st)),
+        Path("p1".into()),
+        Query(DeliverableListQuery {
+            status: Some(DeliverableStatus::InProgress),
+        }),
+    )
+    .await
+    .expect("list ok");
+    assert_eq!(in_prog.deliverables.len(), 1);
+    assert_eq!(in_prog.deliverables[0].id, d1.id);
+}
+
+#[tokio::test]
+async fn get_unknown_deliverable_is_404() {
+    let (st, _g) = state();
+    let err = get_deliverable(
+        State(st),
+        Path(("p".into(), uuid::Uuid::new_v4().to_string())),
+    )
+    .await
+    .expect_err("unknown 404");
+    assert!(matches!(err, DaemonError::DeliverableNotFound { .. }));
+}
+
+#[tokio::test]
+async fn get_wrong_project_is_404() {
+    let (st, _g) = state();
+    let d = create(&st, "right", "x").await;
+    // Same id, wrong project path → must 404, never leak the record.
+    let err = get_deliverable(
+        State(Arc::clone(&st)),
+        Path(("wrong".into(), d.id.to_string())),
+    )
+    .await
+    .expect_err("wrong project 404");
+    assert!(matches!(err, DaemonError::DeliverableNotFound { .. }));
+}
+
+#[tokio::test]
+async fn patch_updates_fields() {
+    let (st, _g) = state();
+    let d = create(&st, "p", "orig").await;
+    let Json(updated) = patch_deliverable(
+        State(Arc::clone(&st)),
+        Path(("p".into(), d.id.to_string())),
+        Ok(Json(PatchDeliverable {
+            name: Some("renamed".into()),
+            estimated_effort: Some(EstimationTier::Xl),
+            ..Default::default()
+        })),
+    )
+    .await
+    .expect("patch ok");
+    assert_eq!(updated.name, "renamed");
+    assert_eq!(updated.estimated_effort, EstimationTier::Xl);
+    // Status untouched by a field-only patch.
+    assert_eq!(updated.status, DeliverableStatus::Proposed);
+}
+
+#[tokio::test]
+async fn patch_full_legal_lifecycle_succeeds() {
+    let (st, _g) = state();
+    let d = create(&st, "p", "x").await;
+    let id = d.id.to_string();
+    // proposed → in-progress → blocked → in-progress → complete → shipped
+    for step in [
+        DeliverableStatus::InProgress,
+        DeliverableStatus::Blocked,
+        DeliverableStatus::InProgress,
+        DeliverableStatus::Complete,
+        DeliverableStatus::Shipped,
+    ] {
+        let Json(updated) = patch_deliverable(
+            State(Arc::clone(&st)),
+            Path(("p".into(), id.clone())),
+            Ok(Json(PatchDeliverable {
+                status: Some(step),
+                ..Default::default()
+            })),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("legal transition to {step} failed: {e}"));
+        assert_eq!(updated.status, step);
+    }
+}
+
+#[tokio::test]
+async fn patch_illegal_transition_is_409_with_allowed_next() {
+    let (st, _g) = state();
+    let d = create(&st, "p", "x").await;
+    // proposed → complete is the illegal case named in #2380.
+    let err = patch_deliverable(
+        State(Arc::clone(&st)),
+        Path(("p".into(), d.id.to_string())),
+        Ok(Json(PatchDeliverable {
+            status: Some(DeliverableStatus::Complete),
+            ..Default::default()
+        })),
+    )
+    .await
+    .expect_err("illegal transition rejected");
+
+    match &err {
+        DaemonError::InvalidTransition { from, to, allowed } => {
+            assert_eq!(from, "proposed");
+            assert_eq!(to, "complete");
+            assert_eq!(allowed, &vec!["in-progress".to_string()]);
+        }
+        other => panic!("expected InvalidTransition, got {other:?}"),
+    }
+    assert_eq!(err.status(), StatusCode::CONFLICT);
+
+    // The wire body must carry the structured `allowed_next` array (#2380).
+    let resp = err.into_response();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+    assert_eq!(json["from"], "proposed");
+    assert_eq!(json["to"], "complete");
+    assert_eq!(json["allowed_next"][0], "in-progress");
+    assert!(
+        json["error"].as_str().unwrap().contains("in-progress"),
+        "error message names legal next state"
+    );
+
+    // The rejected transition must NOT have mutated the record.
+    let Json(unchanged) =
+        get_deliverable(State(Arc::clone(&st)), Path(("p".into(), d.id.to_string())))
+            .await
+            .expect("get ok");
+    assert_eq!(unchanged.status, DeliverableStatus::Proposed);
+}
+
+#[tokio::test]
+async fn patch_same_status_is_noop() {
+    let (st, _g) = state();
+    let d = create(&st, "p", "x").await;
+    // Echoing the current status (proposed) alongside a field edit must succeed —
+    // a self-"transition" is a no-op, not a rejected transition.
+    let Json(updated) = patch_deliverable(
+        State(Arc::clone(&st)),
+        Path(("p".into(), d.id.to_string())),
+        Ok(Json(PatchDeliverable {
+            name: Some("edited".into()),
+            status: Some(DeliverableStatus::Proposed),
+            ..Default::default()
+        })),
+    )
+    .await
+    .expect("no-op status patch ok");
+    assert_eq!(updated.name, "edited");
+    assert_eq!(updated.status, DeliverableStatus::Proposed);
+}
+
+// ───────────────────────── Milestones ────────────────────────────────
+
+#[tokio::test]
+async fn milestone_create_get_list_patch() {
+    let (st, _g) = state();
+    let (code, Json(m)) = create_milestone(
+        State(Arc::clone(&st)),
+        Path("p".into()),
+        Ok(Json(CreateMilestone {
+            name: "v1.0 Alpha".into(),
+            description: "first".into(),
+            target_date: Utc::now(),
+            deliverables: vec![],
+            status: MilestoneStatus::Proposed,
+        })),
+    )
+    .await
+    .expect("create milestone");
+    assert_eq!(code, StatusCode::CREATED);
+
+    let Json(got) = get_milestone(State(Arc::clone(&st)), Path(("p".into(), m.id.to_string())))
+        .await
+        .expect("get milestone");
+    assert_eq!(got.name, "v1.0 Alpha");
+
+    let Json(list) = list_milestones(State(Arc::clone(&st)), Path("p".into()))
+        .await
+        .expect("list milestones");
+    assert_eq!(list.milestones.len(), 1);
+
+    // Milestone status is a rollup field: it is settable directly with no
+    // transition enforcement (§10.3), unlike Deliverable.
+    let Json(patched) = patch_milestone(
+        State(Arc::clone(&st)),
+        Path(("p".into(), m.id.to_string())),
+        Ok(Json(PatchMilestone {
+            name: Some("v1.0".into()),
+            status: Some(MilestoneStatus::Shipped),
+            ..Default::default()
+        })),
+    )
+    .await
+    .expect("patch milestone");
+    assert_eq!(patched.name, "v1.0");
+    assert_eq!(patched.status, MilestoneStatus::Shipped);
+}
+
+#[tokio::test]
+async fn milestone_unknown_is_404() {
+    let (st, _g) = state();
+    let err = get_milestone(
+        State(st),
+        Path(("p".into(), uuid::Uuid::new_v4().to_string())),
+    )
+    .await
+    .expect_err("unknown milestone 404");
+    assert!(matches!(err, DaemonError::MilestoneNotFound { .. }));
+}

--- a/crates/trusty-mpm/src/daemon/api/deliverable_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/api/deliverable_routes/tests.rs
@@ -262,6 +262,33 @@ async fn patch_same_status_is_noop() {
     assert_eq!(updated.status, DeliverableStatus::Proposed);
 }
 
+#[tokio::test]
+async fn patch_deliverable_rejects_blank_name() {
+    // #2395 review MEDIUM: create enforces non-empty trimmed name; PATCH must
+    // apply the same rule rather than allowing a record to end up blank.
+    let (st, _g) = state();
+    let d = create(&st, "p", "x").await;
+    let err = patch_deliverable(
+        State(Arc::clone(&st)),
+        Path(("p".into(), d.id.to_string())),
+        Ok(Json(PatchDeliverable {
+            name: Some("   ".into()),
+            ..Default::default()
+        })),
+    )
+    .await
+    .expect_err("blank name on PATCH must be rejected");
+    assert!(matches!(err, DaemonError::InvalidRequest(_)));
+
+    // The rejection must happen before touching the store — the record is
+    // untouched.
+    let Json(unchanged) =
+        get_deliverable(State(Arc::clone(&st)), Path(("p".into(), d.id.to_string())))
+            .await
+            .expect("get ok");
+    assert_eq!(unchanged.name, "x");
+}
+
 // ───────────────────────── Milestones ────────────────────────────────
 
 #[tokio::test]
@@ -307,6 +334,43 @@ async fn milestone_create_get_list_patch() {
     .expect("patch milestone");
     assert_eq!(patched.name, "v1.0");
     assert_eq!(patched.status, MilestoneStatus::Shipped);
+}
+
+#[tokio::test]
+async fn patch_milestone_rejects_blank_name() {
+    // #2395 review MEDIUM: same rule as `patch_deliverable_rejects_blank_name`.
+    let (st, _g) = state();
+    let (_code, Json(m)) = create_milestone(
+        State(Arc::clone(&st)),
+        Path("p".into()),
+        Ok(Json(CreateMilestone {
+            name: "v1".into(),
+            description: String::new(),
+            target_date: Utc::now(),
+            deliverables: vec![],
+            status: MilestoneStatus::Proposed,
+        })),
+    )
+    .await
+    .expect("create milestone");
+
+    let err = patch_milestone(
+        State(Arc::clone(&st)),
+        Path(("p".into(), m.id.to_string())),
+        Ok(Json(PatchMilestone {
+            name: Some("".into()),
+            ..Default::default()
+        })),
+    )
+    .await
+    .expect_err("blank name on PATCH must be rejected");
+    assert!(matches!(err, DaemonError::InvalidRequest(_)));
+
+    let Json(unchanged) =
+        get_milestone(State(Arc::clone(&st)), Path(("p".into(), m.id.to_string())))
+            .await
+            .expect("get ok");
+    assert_eq!(unchanged.name, "v1");
 }
 
 #[tokio::test]

--- a/crates/trusty-mpm/src/daemon/error.rs
+++ b/crates/trusty-mpm/src/daemon/error.rs
@@ -65,6 +65,49 @@ pub enum DaemonError {
         id: String,
     },
 
+    /// No Deliverable matched the supplied id (within the named project).
+    ///
+    /// Why: the Deliverable CRUD routes (#2378) need a 404 distinct from the
+    /// session/checkpoint not-founds so the error message names the right
+    /// resource.
+    /// What: carries the id (or malformed id string); maps to HTTP 404.
+    /// Test: `error_status_codes_map`, and the deliverable route tests.
+    #[error("deliverable not found: {id}")]
+    DeliverableNotFound {
+        /// The Deliverable id that failed to resolve.
+        id: String,
+    },
+
+    /// No Milestone matched the supplied id (within the named project).
+    #[error("milestone not found: {id}")]
+    MilestoneNotFound {
+        /// The Milestone id that failed to resolve.
+        id: String,
+    },
+
+    /// A requested Deliverable status change is not a legal transition (#2380).
+    ///
+    /// Why: the §10.3 state machine rejects illegal `set-status` requests (e.g.
+    /// `proposed → complete`). A dedicated variant lets the error body name the
+    /// legal next states so the caller can self-correct, and maps to 409 Conflict
+    /// (the requested change conflicts with the record's current state) — the same
+    /// class as [`SessionNotActive`](Self::SessionNotActive).
+    /// What: carries the `from`/`to` labels and the legal `allowed` next states;
+    /// [`into_response`](Self::into_response) surfaces `allowed` as a JSON array.
+    /// Test: `error_status_codes_map`, `invalid_transition_body_lists_allowed`.
+    #[error(
+        "invalid status transition {from} \u{2192} {to}; legal next states from {from}: [{}]",
+        allowed.join(", ")
+    )]
+    InvalidTransition {
+        /// The Deliverable's current status.
+        from: String,
+        /// The requested (rejected) target status.
+        to: String,
+        /// The states that would have been legal transitions from `from`.
+        allowed: Vec<String>,
+    },
+
     /// A bot pairing code was wrong or had expired.
     #[error("pair code invalid or expired")]
     InvalidPairCode,
@@ -111,8 +154,11 @@ impl DaemonError {
     /// Test: `error_status_codes_map`.
     pub fn status(&self) -> StatusCode {
         match self {
-            Self::SessionNotFound { .. } | Self::CheckpointNotFound { .. } => StatusCode::NOT_FOUND,
-            Self::SessionNotActive { .. } => StatusCode::CONFLICT,
+            Self::SessionNotFound { .. }
+            | Self::CheckpointNotFound { .. }
+            | Self::DeliverableNotFound { .. }
+            | Self::MilestoneNotFound { .. } => StatusCode::NOT_FOUND,
+            Self::SessionNotActive { .. } | Self::InvalidTransition { .. } => StatusCode::CONFLICT,
             Self::OverseerBlocked { .. } | Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::InvalidRequest(_) | Self::InvalidPairCode => StatusCode::BAD_REQUEST,
             Self::TmuxUnavailable(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -132,7 +178,18 @@ impl DaemonError {
 impl IntoResponse for DaemonError {
     fn into_response(self) -> Response {
         let status = self.status();
-        let body = Json(serde_json::json!({ "error": self.to_string() }));
+        // #2380: an invalid transition surfaces the legal next states as a
+        // structured `allowed_next` array so the caller can self-correct without
+        // parsing the message string.
+        let body = match &self {
+            Self::InvalidTransition { from, to, allowed } => Json(serde_json::json!({
+                "error": self.to_string(),
+                "from": from,
+                "to": to,
+                "allowed_next": allowed,
+            })),
+            _ => Json(serde_json::json!({ "error": self.to_string() })),
+        };
         (status, body).into_response()
     }
 }
@@ -198,6 +255,38 @@ mod tests {
             DaemonError::Unprocessable("x".into()).status(),
             StatusCode::UNPROCESSABLE_ENTITY
         );
+        assert_eq!(
+            DaemonError::DeliverableNotFound { id: "x".into() }.status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            DaemonError::MilestoneNotFound { id: "x".into() }.status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            DaemonError::InvalidTransition {
+                from: "proposed".into(),
+                to: "complete".into(),
+                allowed: vec!["in-progress".into()],
+            }
+            .status(),
+            StatusCode::CONFLICT
+        );
+    }
+
+    #[test]
+    fn invalid_transition_message_lists_allowed() {
+        // The Display must name the from-state, to-state, and legal next states
+        // so an operator reading the plain error string can self-correct.
+        let e = DaemonError::InvalidTransition {
+            from: "proposed".into(),
+            to: "complete".into(),
+            allowed: vec!["in-progress".into()],
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("proposed"), "{msg}");
+        assert!(msg.contains("complete"), "{msg}");
+        assert!(msg.contains("in-progress"), "{msg}");
     }
 
     #[test]

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -233,6 +233,20 @@ pub struct DaemonState {
     pub(super) project_registry:
         tokio::sync::OnceCell<std::sync::Arc<crate::project::ProjectRegistry>>,
 
+    /// Lazily-initialized Deliverable/Milestone manager (§10.7, #2378).
+    ///
+    /// Why: [`crate::deliverable::DeliverableManager::load`] is async (it reads
+    /// the two on-disk stores) and cannot run inside the synchronous
+    /// `DaemonState` constructors. A `OnceCell` defers construction to the first
+    /// deliverables/milestones request and caches the shared handle — the same
+    /// pattern as `project_registry` and `managed_sessions`.
+    /// What: holds `None` until [`Self::deliverable_manager`] first runs, then the
+    /// shared `Arc<DeliverableManager>` fronting the central `deliverables.json` /
+    /// `milestones.json` stores.
+    /// Test: the deliverable route tests exercise the accessor via the router.
+    pub(super) deliverable_manager:
+        tokio::sync::OnceCell<std::sync::Arc<crate::deliverable::DeliverableManager>>,
+
     /// SESSCTL control-plane session registry (WI-2, #1593).
     ///
     /// Why: every HTTP handler and CLI command for the SESSCTL surface needs a
@@ -342,6 +356,7 @@ impl DaemonState {
             managed_sessions: tokio::sync::OnceCell::new(),
             activity_monitor: std::sync::OnceLock::new(),
             project_registry: tokio::sync::OnceCell::new(),
+            deliverable_manager: tokio::sync::OnceCell::new(),
             session_registry,
             proxy_focus: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
@@ -400,6 +415,7 @@ impl DaemonState {
             managed_sessions: tokio::sync::OnceCell::new(),
             activity_monitor: std::sync::OnceLock::new(),
             project_registry: tokio::sync::OnceCell::new(),
+            deliverable_manager: tokio::sync::OnceCell::new(),
             session_registry,
             proxy_focus: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
@@ -729,6 +745,47 @@ impl DaemonState {
                     registry.auto_register_from_sessions(&records).await;
                 }
                 std::sync::Arc::new(registry)
+            })
+            .await
+            .clone()
+    }
+
+    /// Return the shared Deliverable/Milestone manager, building it on first
+    /// access (§10.7, #2378).
+    ///
+    /// Why: the Deliverable/Milestone CRUD handlers need one shared manager
+    /// backed by the central `deliverables.json` / `milestones.json` stores.
+    /// Because [`DeliverableManager::load`](crate::deliverable::DeliverableManager::load)
+    /// is async, it is built on first access and cached in a `OnceCell` so every
+    /// subsequent request reuses the same handle — identical to
+    /// [`Self::session_manager`] and [`Self::project_registry`].
+    /// What: on first call loads the two central stores directly under
+    /// `framework_root` (siblings to the registry, §10.7 / §13 Q5); falls back to
+    /// a temp dir if load fails so a transient I/O error never poisons the
+    /// `OnceCell` permanently.
+    /// Test: the deliverable route tests drive this via the router.
+    pub async fn deliverable_manager(
+        &self,
+    ) -> std::sync::Arc<crate::deliverable::DeliverableManager> {
+        self.deliverable_manager
+            .get_or_init(|| async {
+                let data_dir = self.framework_root.clone();
+                match crate::deliverable::DeliverableManager::load(&data_dir).await {
+                    Ok(mgr) => std::sync::Arc::new(mgr),
+                    Err(e) => {
+                        tracing::error!(
+                            "failed to load deliverable stores at {}: {e}; using temp dir",
+                            data_dir.display()
+                        );
+                        let tmp = std::env::temp_dir().join("trusty-mpm-deliverables");
+                        let _ = std::fs::create_dir_all(&tmp);
+                        std::sync::Arc::new(
+                            crate::deliverable::DeliverableManager::load(&tmp)
+                                .await
+                                .expect("temp-dir deliverable stores must load"),
+                        )
+                    }
+                }
             })
             .await
             .clone()

--- a/crates/trusty-mpm/src/deliverable/manager.rs
+++ b/crates/trusty-mpm/src/deliverable/manager.rs
@@ -1,0 +1,228 @@
+//! Shared, async manager over the Deliverable and Milestone stores (§10.7).
+//!
+//! Why: the CRUD routes need a single, `Arc`-shareable handle that owns both the
+//! deliverables and milestones stores behind async locks — the same pattern
+//! [`crate::project::ProjectRegistry`] uses over `ProjectStore`. Centralizing
+//! load + locking here keeps the daemon's `OnceCell` accessor and the route
+//! handlers thin, and gives the future read-only status endpoint (#2382) one
+//! place to read both stores for its rollup histograms.
+//! What: [`DeliverableManager`] wraps a [`DeliverableStore`] and a
+//! [`MilestoneStore`], each in an `Arc<RwLock<…>>`, and exposes create / get /
+//! project-scoped list / replace operations for both. It deliberately does NOT
+//! enforce the status state machine — that gate (#2380) lives in the API layer
+//! (see `daemon::api::deliverable_routes`), calling
+//! [`crate::deliverable::status::validate_transition`] — so the manager stays a
+//! pure persistence facade.
+//! Test: `manager_create_get_deliverable`, `manager_list_by_project`,
+//! `manager_replace_deliverable`, `manager_milestone_round_trip`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use super::milestone::Milestone;
+use super::record::Deliverable;
+use super::store::{DeliverableStore, MilestoneStore, StoreError};
+
+/// The JSON filename for the central deliverables store (§10.7).
+const DELIVERABLES_FILE: &str = "deliverables.json";
+/// The JSON filename for the central milestones store (§10.7).
+const MILESTONES_FILE: &str = "milestones.json";
+
+/// Async manager over the central Deliverable and Milestone stores.
+///
+/// Why: one shared handle, cheaply cloneable (`Arc` inside), for injection into
+/// every CRUD handler — mirroring `ProjectRegistry` and `SessionManager`.
+/// What: holds both stores behind `Arc<RwLock<…>>`; all ops take a write lock
+/// because the underlying store reloads-before-read for cross-process freshness.
+/// Test: see this module's tests.
+#[derive(Debug, Clone)]
+pub struct DeliverableManager {
+    deliverables: Arc<RwLock<DeliverableStore>>,
+    milestones: Arc<RwLock<MilestoneStore>>,
+}
+
+impl DeliverableManager {
+    /// Load (or create) both central stores under `data_dir` (§10.7).
+    ///
+    /// Why: at startup the daemon restores both ledgers; absent files start
+    /// fresh so the daemon boots cleanly.
+    /// What: opens `<data_dir>/deliverables.json` and `<data_dir>/milestones.json`
+    /// and wraps each in an `Arc<RwLock>`.
+    /// Test: `manager_create_get_deliverable`.
+    pub async fn load(data_dir: &Path) -> Result<Self, StoreError> {
+        let deliverables = DeliverableStore::load(data_dir.join(DELIVERABLES_FILE)).await?;
+        let milestones = MilestoneStore::load(data_dir.join(MILESTONES_FILE)).await?;
+        Ok(Self {
+            deliverables: Arc::new(RwLock::new(deliverables)),
+            milestones: Arc::new(RwLock::new(milestones)),
+        })
+    }
+
+    // ----- Deliverables -----
+
+    /// Persist a new (or replacement) Deliverable, keyed by its id.
+    ///
+    /// Why: the create and non-status update paths both upsert a fully-formed
+    /// record; keeping one method avoids a spurious create/update split.
+    /// What: acquires a write lock and upserts.
+    /// Test: `manager_create_get_deliverable`, `manager_replace_deliverable`.
+    pub async fn upsert_deliverable(&self, d: Deliverable) -> Result<(), StoreError> {
+        self.deliverables.write().await.upsert(d).await
+    }
+
+    /// Fetch a Deliverable by its stringified id.
+    ///
+    /// Why: the GET and PATCH handlers both need a point lookup.
+    /// What: reloads-then-reads via the store; `NotFound` when absent.
+    /// Test: `manager_create_get_deliverable`.
+    pub async fn get_deliverable(&self, id: &str) -> Result<Deliverable, StoreError> {
+        self.deliverables.write().await.get(id).await
+    }
+
+    /// List a project's Deliverables.
+    ///
+    /// Why: the list endpoint is project-scoped; filtering lives in the store.
+    /// What: returns every Deliverable whose `project_name` matches.
+    /// Test: `manager_list_by_project`.
+    pub async fn deliverables_by_project(
+        &self,
+        project_name: &str,
+    ) -> Result<Vec<Deliverable>, StoreError> {
+        self.deliverables
+            .write()
+            .await
+            .by_project(project_name)
+            .await
+    }
+
+    /// Return every Deliverable across all projects (for the #2382 rollup).
+    ///
+    /// Why: the read-only status endpoint aggregates status histograms; exposing
+    /// `all` keeps that consumer from reaching into the private store.
+    /// What: reloads-then-clones all values.
+    /// Test: `manager_list_by_project` (asserts total count).
+    pub async fn all_deliverables(&self) -> Result<Vec<Deliverable>, StoreError> {
+        self.deliverables.write().await.all().await
+    }
+
+    // ----- Milestones -----
+
+    /// Persist a new (or replacement) Milestone, keyed by its id.
+    pub async fn upsert_milestone(&self, m: Milestone) -> Result<(), StoreError> {
+        self.milestones.write().await.upsert(m).await
+    }
+
+    /// Fetch a Milestone by its stringified id.
+    pub async fn get_milestone(&self, id: &str) -> Result<Milestone, StoreError> {
+        self.milestones.write().await.get(id).await
+    }
+
+    /// List a project's Milestones.
+    pub async fn milestones_by_project(
+        &self,
+        project_name: &str,
+    ) -> Result<Vec<Milestone>, StoreError> {
+        self.milestones.write().await.by_project(project_name).await
+    }
+
+    /// Return every Milestone across all projects (for the #2382 rollup).
+    pub async fn all_milestones(&self) -> Result<Vec<Milestone>, StoreError> {
+        self.milestones.write().await.all().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deliverable::milestone::{Milestone, MilestoneId, MilestoneStatus};
+    use crate::deliverable::record::{Deliverable, DeliverableId, DeliverableKind, EstimationTier};
+    use crate::deliverable::status::DeliverableStatus;
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn deliverable(project: &str, name: &str) -> Deliverable {
+        Deliverable {
+            id: DeliverableId::new(),
+            project_name: project.into(),
+            name: name.into(),
+            description: String::new(),
+            kind: DeliverableKind::Feature,
+            ticket_ref: None,
+            spec_ref: None,
+            status: DeliverableStatus::Proposed,
+            estimated_effort: EstimationTier::M,
+            created_at: Utc::now(),
+            target_date: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn manager_create_get_deliverable() {
+        let dir = TempDir::new().unwrap();
+        let mgr = DeliverableManager::load(dir.path()).await.unwrap();
+        let d = deliverable("p", "one");
+        let key = d.id.to_string();
+        mgr.upsert_deliverable(d).await.unwrap();
+        assert_eq!(mgr.get_deliverable(&key).await.unwrap().name, "one");
+        // Re-loading the manager sees the persisted record (central store).
+        let mgr2 = DeliverableManager::load(dir.path()).await.unwrap();
+        assert_eq!(mgr2.get_deliverable(&key).await.unwrap().name, "one");
+    }
+
+    #[tokio::test]
+    async fn manager_list_by_project() {
+        let dir = TempDir::new().unwrap();
+        let mgr = DeliverableManager::load(dir.path()).await.unwrap();
+        mgr.upsert_deliverable(deliverable("p1", "a"))
+            .await
+            .unwrap();
+        mgr.upsert_deliverable(deliverable("p1", "b"))
+            .await
+            .unwrap();
+        mgr.upsert_deliverable(deliverable("p2", "c"))
+            .await
+            .unwrap();
+        assert_eq!(mgr.deliverables_by_project("p1").await.unwrap().len(), 2);
+        assert_eq!(mgr.deliverables_by_project("p2").await.unwrap().len(), 1);
+        assert_eq!(mgr.all_deliverables().await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn manager_replace_deliverable() {
+        let dir = TempDir::new().unwrap();
+        let mgr = DeliverableManager::load(dir.path()).await.unwrap();
+        let mut d = deliverable("p", "orig");
+        let key = d.id.to_string();
+        mgr.upsert_deliverable(d.clone()).await.unwrap();
+        d.status = DeliverableStatus::InProgress;
+        d.name = "renamed".into();
+        mgr.upsert_deliverable(d).await.unwrap();
+        let got = mgr.get_deliverable(&key).await.unwrap();
+        assert_eq!(got.name, "renamed");
+        assert_eq!(got.status, DeliverableStatus::InProgress);
+        assert_eq!(mgr.deliverables_by_project("p").await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn manager_milestone_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let mgr = DeliverableManager::load(dir.path()).await.unwrap();
+        let m = Milestone {
+            id: MilestoneId::new(),
+            project_name: "p".into(),
+            name: "v1".into(),
+            description: String::new(),
+            target_date: Utc::now(),
+            status: MilestoneStatus::Proposed,
+            deliverables: vec![],
+            created_at: Utc::now(),
+        };
+        let key = m.id.to_string();
+        mgr.upsert_milestone(m).await.unwrap();
+        assert_eq!(mgr.get_milestone(&key).await.unwrap().name, "v1");
+        assert_eq!(mgr.milestones_by_project("p").await.unwrap().len(), 1);
+        assert_eq!(mgr.all_milestones().await.unwrap().len(), 1);
+    }
+}

--- a/crates/trusty-mpm/src/deliverable/manager.rs
+++ b/crates/trusty-mpm/src/deliverable/manager.rs
@@ -7,23 +7,57 @@
 //! handlers thin, and gives the future read-only status endpoint (#2382) one
 //! place to read both stores for its rollup histograms.
 //! What: [`DeliverableManager`] wraps a [`DeliverableStore`] and a
-//! [`MilestoneStore`], each in an `Arc<RwLock<…>>`, and exposes create / get /
-//! project-scoped list / replace operations for both. It deliberately does NOT
-//! enforce the status state machine — that gate (#2380) lives in the API layer
-//! (see `daemon::api::deliverable_routes`), calling
-//! [`crate::deliverable::status::validate_transition`] — so the manager stays a
-//! pure persistence facade.
+//! [`MilestoneStore`], each in an `Arc<RwLock<…>>`. `upsert_*`/`get_*`/`*_by_project`
+//! are cheap, independently-locked primitives for create/read paths (no race
+//! hazard — creates use a fresh id, reads are eventually-consistent by design).
+//! [`update_deliverable_with`](Self::update_deliverable_with) and
+//! [`update_milestone_with`](Self::update_milestone_with) are the atomic
+//! read-validate-mutate-persist seam PATCH handlers MUST use (#2395 review HIGH):
+//! they hold ONE write-lock guard across the whole sequence so no other task can
+//! observe or clobber the intermediate state. The §10.3 transition CHECK itself
+//! still lives in the caller's closure (calling
+//! [`crate::deliverable::status::validate_transition`]) — the manager does not
+//! hard-code deliverable business rules — but the closure now runs against a
+//! status that was fetched and will be persisted under the SAME lock, closing
+//! the TOCTOU window the two-lock `get_*` + `upsert_*` pattern left open.
 //! Test: `manager_create_get_deliverable`, `manager_list_by_project`,
-//! `manager_replace_deliverable`, `manager_milestone_round_trip`.
+//! `manager_replace_deliverable`, `manager_milestone_round_trip`,
+//! `read_then_upsert_pattern_reproduces_lost_update_pre_fix`,
+//! `update_deliverable_with_serializes_concurrent_transitions`,
+//! `update_deliverable_with_rejects_illegal_transition_without_mutating`,
+//! `update_milestone_with_round_trips`.
 
 use std::path::Path;
 use std::sync::Arc;
 
+use thiserror::Error;
 use tokio::sync::RwLock;
 
 use super::milestone::Milestone;
 use super::record::Deliverable;
+use super::status::TransitionError;
 use super::store::{DeliverableStore, MilestoneStore, StoreError};
+
+/// Error from an atomic [`DeliverableManager::update_deliverable_with`] call.
+///
+/// Why: the atomic update seam must distinguish a store-level failure (I/O,
+/// not-found/wrong-project) from a REJECTED §10.3 transition, so the daemon
+/// error layer (`daemon::api::deliverable_routes`) can map each to its own HTTP
+/// status (404 vs 409) without losing which failure actually occurred.
+/// What: wraps either a [`StoreError`] (lookup/persist failure) or a
+/// [`TransitionError`] (the caller's mutation closure rejected an illegal
+/// transition against the freshly-reloaded status).
+/// Test: `update_deliverable_with_rejects_illegal_transition_without_mutating`,
+/// and the route-level 409 test in `deliverable_routes::tests`.
+#[derive(Debug, Error)]
+pub enum UpdateError {
+    /// The record could not be located, scoped, or persisted.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    /// The mutation closure rejected an illegal status transition.
+    #[error(transparent)]
+    Transition(#[from] TransitionError),
+}
 
 /// The JSON filename for the central deliverables store (§10.7).
 const DELIVERABLES_FILE: &str = "deliverables.json";
@@ -107,6 +141,58 @@ impl DeliverableManager {
         self.deliverables.write().await.all().await
     }
 
+    /// Atomically read-validate-mutate-persist a Deliverable under ONE lock.
+    ///
+    /// Why (fixes the #2395 review HIGH): the original PATCH path called
+    /// [`get_deliverable`](Self::get_deliverable) (one write-lock acquisition),
+    /// released the lock, THEN separately validated the requested transition in
+    /// the route handler and called
+    /// [`upsert_deliverable`](Self::upsert_deliverable) (a SECOND, later
+    /// acquisition). Two concurrent PATCHes could interleave in the gap between
+    /// those two critical sections: both would validate against the SAME stale
+    /// status (both legal from it), then whichever `upsert` ran last would win —
+    /// silently discarding the other's ALREADY-validated, ALREADY-"successful"
+    /// transition with no error ever surfacing to that caller. Worse, the
+    /// persisted end state can be one neither validated call ever actually
+    /// checked (e.g. A validates in-progress→complete, B validates the same
+    /// stale in-progress→blocked; if B's write lands first and A's lands last,
+    /// the final `complete` was validated, but only against a status that, by
+    /// the time it landed, was no longer live — B's committed `blocked` state was
+    /// never itself a validated predecessor of `complete`).
+    /// What: acquires `self.deliverables.write().await` ONCE and holds the guard
+    /// for the ENTIRE read→validate→mutate→persist sequence. Fetches the CURRENT
+    /// on-disk record via the store's own reload-on-read `get` (so the fetch
+    /// reflects any external write), checks project scope, then calls `f` with
+    /// that freshly-reloaded record — so any transition validation the caller's
+    /// closure performs runs against a status that cannot go stale before the
+    /// resulting `upsert` lands, because no other task can acquire the same lock
+    /// in between. Returns [`UpdateError::Transition`] without mutating anything
+    /// if `f` rejects the transition; otherwise persists `f`'s result before
+    /// releasing the lock.
+    /// Test: `update_deliverable_with_serializes_concurrent_transitions` (the
+    /// concurrency regression test — proves exactly one of two racing
+    /// transitions from the same starting status can ever succeed, and the
+    /// final persisted state always matches the winner, never a clobbered or
+    /// unreachable value), `update_deliverable_with_rejects_illegal_transition_without_mutating`.
+    pub async fn update_deliverable_with<F>(
+        &self,
+        id: &str,
+        project: &str,
+        f: F,
+    ) -> Result<Deliverable, UpdateError>
+    where
+        F: FnOnce(Deliverable) -> Result<Deliverable, TransitionError>,
+    {
+        let mut guard = self.deliverables.write().await;
+        let current = guard.get(id).await?;
+        if current.project_name != project {
+            return Err(StoreError::NotFound(id.to_string()).into());
+        }
+        let updated = f(current)?;
+        guard.upsert(updated.clone()).await?;
+        Ok(updated)
+    }
+
     // ----- Milestones -----
 
     /// Persist a new (or replacement) Milestone, keyed by its id.
@@ -130,6 +216,38 @@ impl DeliverableManager {
     /// Return every Milestone across all projects (for the #2382 rollup).
     pub async fn all_milestones(&self) -> Result<Vec<Milestone>, StoreError> {
         self.milestones.write().await.all().await
+    }
+
+    /// Atomically read-mutate-persist a Milestone under ONE lock.
+    ///
+    /// Why: the same lost-update hazard `update_deliverable_with` closes applies
+    /// to Milestone PATCH too — a read-then-upsert pattern can silently drop a
+    /// concurrent field edit (e.g. two PATCHes racing on `deliverables` list
+    /// membership vs `name`) even though Milestone has no status state machine
+    /// to invalidate. Holding one lock across the whole sequence closes that
+    /// window here as well, per the same precedent.
+    /// What: acquires `self.milestones.write().await` ONCE, fetches the current
+    /// record (reload-on-read), checks project scope, applies the mutation
+    /// (infallible — Milestone status is a plain rollup field with no rejectable
+    /// transition, §10.3/§10.5), and persists before releasing the lock.
+    /// Test: `update_milestone_with_round_trips`.
+    pub async fn update_milestone_with<F>(
+        &self,
+        id: &str,
+        project: &str,
+        f: F,
+    ) -> Result<Milestone, StoreError>
+    where
+        F: FnOnce(Milestone) -> Milestone,
+    {
+        let mut guard = self.milestones.write().await;
+        let current = guard.get(id).await?;
+        if current.project_name != project {
+            return Err(StoreError::NotFound(id.to_string()));
+        }
+        let updated = f(current);
+        guard.upsert(updated.clone()).await?;
+        Ok(updated)
     }
 }
 
@@ -224,5 +342,236 @@ mod tests {
         assert_eq!(mgr.get_milestone(&key).await.unwrap().name, "v1");
         assert_eq!(mgr.milestones_by_project("p").await.unwrap().len(), 1);
         assert_eq!(mgr.all_milestones().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn update_deliverable_with_rejects_illegal_transition_without_mutating() {
+        let dir = TempDir::new().unwrap();
+        let mgr = DeliverableManager::load(dir.path()).await.unwrap();
+        let d = deliverable("p", "x");
+        let id = d.id.to_string();
+        mgr.upsert_deliverable(d).await.unwrap();
+
+        let err = mgr
+            .update_deliverable_with(&id, "p", |mut current| {
+                crate::deliverable::status::validate_transition(
+                    current.status,
+                    DeliverableStatus::Complete,
+                )?;
+                current.status = DeliverableStatus::Complete;
+                Ok(current)
+            })
+            .await
+            .expect_err("proposed -> complete must be rejected");
+        assert!(matches!(err, UpdateError::Transition(_)));
+
+        // The rejected closure must not have mutated the persisted record.
+        let unchanged = mgr.get_deliverable(&id).await.unwrap();
+        assert_eq!(unchanged.status, DeliverableStatus::Proposed);
+    }
+
+    /// Reproduces, using the still-available low-level primitives
+    /// (`get_deliverable` + `upsert_deliverable`), the EXACT pre-fix PATCH hazard
+    /// the #2395 review flagged as a HIGH: a `get` under one lock followed LATER
+    /// by a separate `upsert` under a second lock leaves a window in which
+    /// another task's own fetch-validate-upsert sequence can run to completion
+    /// entirely — both tasks validate against the SAME stale status (both are
+    /// independently legal transitions FROM that shared stale read), and
+    /// whichever `upsert` lands last silently discards the other's committed,
+    /// already-"validated-successful" transition. This is the test that "reliably
+    /// fails pre-fix": it exercises exactly the two-call shape the OLD
+    /// `patch_deliverable` handler used (fetch under one lock, then mutate+upsert
+    /// under a later, separate lock) — the same shape this PR's
+    /// `update_deliverable_with` replaces. A `tokio::sync::Notify` gate forces the
+    /// deterministic interleave (B's whole fetch-validate-upsert completes while
+    /// A is parked between its OWN fetch and its OWN upsert), so the outcome never
+    /// depends on scheduler luck.
+    /// Test: this IS the test (the #2395 HIGH regression guard, negative case).
+    #[tokio::test]
+    async fn read_then_upsert_pattern_reproduces_lost_update_pre_fix() {
+        let dir = TempDir::new().unwrap();
+        let mgr = Arc::new(DeliverableManager::load(dir.path()).await.unwrap());
+        let mut d = deliverable("p", "race");
+        d.status = DeliverableStatus::InProgress;
+        let id = d.id.to_string();
+        mgr.upsert_deliverable(d).await.unwrap();
+
+        // Gate: task A fetches, then PARKS here — simulating the exact window the
+        // two-lock pattern leaves open between its `get` and its `upsert` — until
+        // B has fetched, validated, AND upserted its own (different) transition.
+        let gate = Arc::new(tokio::sync::Notify::new());
+
+        let mgr_a = Arc::clone(&mgr);
+        let gate_a = Arc::clone(&gate);
+        let id_a = id.clone();
+        let a = tokio::spawn(async move {
+            // Lock #1 (fetch), released as soon as `get_deliverable` returns —
+            // exactly the OLD `fetch_scoped` call.
+            let current = mgr_a.get_deliverable(&id_a).await.unwrap();
+            // Park until B's own fetch-validate-upsert has fully landed.
+            gate_a.notified().await;
+            let target = DeliverableStatus::Complete;
+            crate::deliverable::status::validate_transition(current.status, target)
+                .expect("A's own validation, against the stale read, succeeds");
+            let mut updated = current;
+            updated.status = target;
+            // Lock #2 (upsert) — a SEPARATE, later acquisition than lock #1.
+            mgr_a.upsert_deliverable(updated).await.unwrap();
+        });
+
+        let mgr_b = Arc::clone(&mgr);
+        let gate_b = Arc::clone(&gate);
+        let id_b = id.clone();
+        let b = tokio::spawn(async move {
+            let current = mgr_b.get_deliverable(&id_b).await.unwrap();
+            let target = DeliverableStatus::Blocked;
+            crate::deliverable::status::validate_transition(current.status, target)
+                .expect("B's own validation, against the SAME stale read, ALSO succeeds");
+            let mut updated = current;
+            updated.status = target;
+            mgr_b.upsert_deliverable(updated).await.unwrap();
+            // B's committed write has landed — release A to clobber it.
+            gate_b.notify_one();
+        });
+
+        b.await.unwrap();
+        a.await.unwrap();
+
+        // The bug: BOTH validations independently succeeded (both are legal FROM
+        // the shared stale in-progress read), yet only A's write survives — B's
+        // committed, validated transition to `blocked` is silently discarded with
+        // NO error ever surfaced to B's caller (B's own call returned Ok).
+        let final_state = mgr.get_deliverable(&id).await.unwrap();
+        assert_eq!(
+            final_state.status,
+            DeliverableStatus::Complete,
+            "demonstrates the pre-fix hazard: B's validated, committed transition \
+             to `blocked` is lost — silently clobbered by A's later upsert against \
+             the same stale read, even though B's own call reported success"
+        );
+    }
+
+    /// Proves the fix: racing two `update_deliverable_with` calls attempting
+    /// DIFFERENT transitions from the SAME starting status can never both
+    /// succeed, and the final persisted status always matches exactly the
+    /// winner's target — no lost update, no state unreachable by a validated
+    /// chain. This assertion is deliberately ORDER-INDEPENDENT (it does not care
+    /// which task's write lands first): from `in-progress`, the legal successors
+    /// are exactly `{blocked, complete}` (§10.3); whichever of the two tasks
+    /// acquires the manager's single write-lock second observes the FIRST task's
+    /// already-persisted target as the current status, and `blocked -> complete`
+    /// / `complete -> blocked` are both illegal (`blocked`'s only successor is
+    /// `in-progress`; `complete`'s successors are `delivered`/`shipped`) — so the
+    /// second task's closure is structurally guaranteed to be rejected, REGARDLESS
+    /// of scheduling order. Pre-fix (the two-lock pattern exercised by
+    /// `read_then_upsert_pattern_reproduces_lost_update_pre_fix` above), this same
+    /// race would have both closures return Ok.
+    /// Test: this IS the test (the #2395 HIGH regression guard, positive case).
+    #[tokio::test]
+    async fn update_deliverable_with_serializes_concurrent_transitions() {
+        let dir = TempDir::new().unwrap();
+        let mgr = Arc::new(DeliverableManager::load(dir.path()).await.unwrap());
+        let mut d = deliverable("p", "race");
+        d.status = DeliverableStatus::InProgress;
+        let id = d.id.to_string();
+        mgr.upsert_deliverable(d).await.unwrap();
+
+        fn transition_to(
+            target: DeliverableStatus,
+        ) -> impl FnOnce(Deliverable) -> Result<Deliverable, crate::deliverable::status::TransitionError>
+        {
+            move |mut current| {
+                crate::deliverable::status::validate_transition(current.status, target)?;
+                current.status = target;
+                Ok(current)
+            }
+        }
+
+        let mgr_a = Arc::clone(&mgr);
+        let id_a = id.clone();
+        let a = tokio::spawn(async move {
+            mgr_a
+                .update_deliverable_with(&id_a, "p", transition_to(DeliverableStatus::Complete))
+                .await
+        });
+
+        let mgr_b = Arc::clone(&mgr);
+        let id_b = id.clone();
+        let b = tokio::spawn(async move {
+            mgr_b
+                .update_deliverable_with(&id_b, "p", transition_to(DeliverableStatus::Blocked))
+                .await
+        });
+
+        let ra = a.await.unwrap();
+        let rb = b.await.unwrap();
+
+        // Capture the outcomes as plain bools BEFORE moving either `Result` —
+        // re-testing `.is_ok()` on a value already moved out of one `if` arm is
+        // a static (not path-sensitive) borrow-check error, so decide once here.
+        let ra_ok = ra.is_ok();
+        let rb_ok = rb.is_ok();
+
+        // Exactly one of the two racing transitions may succeed — never both,
+        // never neither (no lost update either direction).
+        assert_eq!(
+            [ra_ok, rb_ok].iter().filter(|ok| **ok).count(),
+            1,
+            "exactly one racing transition must win: a_ok={ra_ok} b_ok={rb_ok}"
+        );
+
+        // The loser must be rejected via the SAME structured transition error the
+        // route layer surfaces as a 409 — not a store error, not a silent no-op.
+        // The final persisted status is reachable via exactly the winner's
+        // validated transition — never a third, unreachable value.
+        let (loser_err, winner_target) = if ra_ok {
+            (rb.unwrap_err(), DeliverableStatus::Complete)
+        } else {
+            (ra.unwrap_err(), DeliverableStatus::Blocked)
+        };
+        assert!(
+            matches!(loser_err, UpdateError::Transition(_)),
+            "the losing transition must be rejected, not silently dropped: {loser_err:?}"
+        );
+
+        let final_state = mgr.get_deliverable(&id).await.unwrap();
+        assert_eq!(final_state.status, winner_target);
+    }
+
+    #[tokio::test]
+    async fn update_milestone_with_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let mgr = DeliverableManager::load(dir.path()).await.unwrap();
+        let m = Milestone {
+            id: MilestoneId::new(),
+            project_name: "p".into(),
+            name: "v1".into(),
+            description: String::new(),
+            target_date: Utc::now(),
+            status: MilestoneStatus::Proposed,
+            deliverables: vec![],
+            created_at: Utc::now(),
+        };
+        let id = m.id.to_string();
+        mgr.upsert_milestone(m).await.unwrap();
+
+        let updated = mgr
+            .update_milestone_with(&id, "p", |mut current| {
+                current.name = "v1.0".into();
+                current.status = MilestoneStatus::Shipped;
+                current
+            })
+            .await
+            .unwrap();
+        assert_eq!(updated.name, "v1.0");
+        assert_eq!(updated.status, MilestoneStatus::Shipped);
+
+        // Wrong project must be rejected without mutating the record.
+        let err = mgr
+            .update_milestone_with(&id, "wrong-project", |m| m)
+            .await
+            .expect_err("wrong project scope must be rejected");
+        assert!(matches!(err, StoreError::NotFound(_)));
+        assert_eq!(mgr.get_milestone(&id).await.unwrap().name, "v1.0");
     }
 }

--- a/crates/trusty-mpm/src/deliverable/milestone.rs
+++ b/crates/trusty-mpm/src/deliverable/milestone.rs
@@ -1,0 +1,166 @@
+//! The [`Milestone`] record and its value types (DOC-35 §10.5).
+//!
+//! Why: a Milestone groups Deliverables toward a dated target (e.g. `"v1.0
+//! Alpha"`). Like the Deliverable, it is L3-substrate bookkeeping and must
+//! persist across daemon restarts and be exchanged over HTTP.
+//! What: defines [`MilestoneId`] (a UUID newtype), [`MilestoneStatus`], and the
+//! [`Milestone`] struct. Per §10.3 a Milestone's status is a *rollup* of its
+//! contained Deliverables — it is NOT a user-driven state machine, so (unlike
+//! [`DeliverableStatus`](crate::deliverable::DeliverableStatus)) this crate
+//! enforces no transition table on it; computing the rollup is #2382 / the
+//! read-only status endpoint's job (§4.1). Here it is a plain stored field.
+//! Test: `milestone_serde_round_trip`, `milestone_id_round_trip`,
+//! `milestone_status_wire_format`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::record::DeliverableId;
+
+/// A stable, globally-unique identifier for a [`Milestone`].
+///
+/// Why: a newtype prevents mixing Milestone ids with Deliverable/session ids at
+/// the type level, matching the id-newtype convention used elsewhere.
+/// What: wraps `uuid::Uuid`; transparent serde; `Display`/`FromStr` for routing.
+/// Test: `milestone_id_round_trip`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MilestoneId(pub Uuid);
+
+impl MilestoneId {
+    /// Generate a new random Milestone id.
+    ///
+    /// Why: every Milestone created via the API needs a fresh unique id.
+    /// What: wraps `Uuid::new_v4()`.
+    /// Test: `milestone_serde_round_trip`.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for MilestoneId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for MilestoneId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::str::FromStr for MilestoneId {
+    type Err = uuid::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Uuid::parse_str(s)?))
+    }
+}
+
+/// The status of a [`Milestone`] — a rollup of its Deliverables (§10.5).
+///
+/// Why: §10.3/§10.5 define Milestone status as mirroring the rollup of its
+/// contained Deliverables, not an independently user-driven machine; the closed
+/// enum still gives a stable wire vocabulary for the CRUD API and the future
+/// histogram endpoint.
+/// What: the four milestone states from §10.5, serialized kebab-case. No
+/// `Blocked` variant — blocking is a per-Deliverable concept.
+/// Test: `milestone_status_wire_format`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MilestoneStatus {
+    /// No contained Deliverable has started.
+    #[default]
+    Proposed,
+    /// At least one contained Deliverable is in progress.
+    InProgress,
+    /// All contained Deliverables are complete.
+    Complete,
+    /// The Milestone shipped.
+    Shipped,
+}
+
+/// A dated grouping of Deliverables (DOC-35 §10.5).
+///
+/// Why: the persisted record the Milestone CRUD API creates, reads, and mutates.
+/// Keyed by `id` in the store; references its project by `project_name` and its
+/// members by their [`DeliverableId`]s.
+/// What: identity, project linkage, a dated `target_date`, the rollup `status`,
+/// the member Deliverable ids, and a creation timestamp.
+/// Test: `milestone_serde_round_trip`, and the store/route tests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Milestone {
+    /// Store key: a stable UUID assigned at creation.
+    pub id: MilestoneId,
+
+    /// The owning project's registry-B name (`repo_url`-keyed `Project.name`).
+    pub project_name: String,
+
+    /// Human-readable name, e.g. `"v1.0 Alpha"`.
+    pub name: String,
+
+    /// Free-form description.
+    #[serde(default)]
+    pub description: String,
+
+    /// The date the Milestone targets.
+    pub target_date: DateTime<Utc>,
+
+    /// Rollup status (§10.5); a plain stored field here (rollup computation is
+    /// #2382 / the read-only status endpoint).
+    #[serde(default)]
+    pub status: MilestoneStatus,
+
+    /// The Deliverables that make up this Milestone.
+    #[serde(default)]
+    pub deliverables: Vec<DeliverableId>,
+
+    /// When the Milestone record was created.
+    pub created_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Milestone {
+        Milestone {
+            id: MilestoneId::new(),
+            project_name: "trusty-tools".into(),
+            name: "v1.0 Alpha".into(),
+            description: "first alpha".into(),
+            target_date: Utc::now(),
+            status: MilestoneStatus::Proposed,
+            deliverables: vec![DeliverableId::new(), DeliverableId::new()],
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn milestone_serde_round_trip() {
+        let m = sample();
+        let json = serde_json::to_string(&m).unwrap();
+        let back: Milestone = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, back);
+    }
+
+    #[test]
+    fn milestone_id_round_trip() {
+        let id = MilestoneId::new();
+        let parsed: MilestoneId = id.to_string().parse().unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn milestone_status_wire_format() {
+        assert_eq!(
+            serde_json::to_string(&MilestoneStatus::InProgress).unwrap(),
+            "\"in-progress\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MilestoneStatus::Shipped).unwrap(),
+            "\"shipped\""
+        );
+        assert_eq!(MilestoneStatus::default(), MilestoneStatus::Proposed);
+    }
+}

--- a/crates/trusty-mpm/src/deliverable/mod.rs
+++ b/crates/trusty-mpm/src/deliverable/mod.rs
@@ -1,0 +1,28 @@
+//! Deliverable/Milestone data model, central stores, and state machine
+//! (DOC-35 §10, epic #2108; issues #2378 WI-12 + #2380 WI-14).
+//!
+//! Why: the L3 substrate needs a deterministic ledger of *what work exists*, its
+//! tier, its lifecycle state, and which sessions touched it (§10.1) — the same
+//! class of bookkeeping fact as the project and session registries. `tm manager`
+//! (#2109) reasons OVER this ledger but must not own or invent it. Everything
+//! here is a pure function of stored state: no LLM, no inference, single-project
+//! scope (§11 boundary).
+//! What: re-exports the record types ([`Deliverable`], [`Milestone`] and their
+//! value/id types), the [`DeliverableStatus`] state machine (§10.3, #2380), the
+//! generic on-disk [`store`] (central sibling stores to `projects.json`, §10.7,
+//! §13 Q5), and the [`DeliverableManager`] that fronts both stores for the CRUD
+//! routes.
+//! Test: each submodule carries inline unit tests; run with
+//! `cargo test -p trusty-mpm deliverable`.
+
+pub mod manager;
+pub mod milestone;
+pub mod record;
+pub mod status;
+pub mod store;
+
+pub use manager::DeliverableManager;
+pub use milestone::{Milestone, MilestoneId, MilestoneStatus};
+pub use record::{Deliverable, DeliverableId, DeliverableKind, EstimationTier};
+pub use status::{DeliverableStatus, TransitionError, validate_transition};
+pub use store::{DeliverableStore, Keyed, MilestoneStore, StoreError};

--- a/crates/trusty-mpm/src/deliverable/record.rs
+++ b/crates/trusty-mpm/src/deliverable/record.rs
@@ -1,0 +1,248 @@
+//! The [`Deliverable`] record and its value types (DOC-35 §10.2).
+//!
+//! Why: a Deliverable is the L3-substrate unit of work — "does this exist, what
+//! tier is it, what state is it in" (§10.1). It must be serializable to survive
+//! daemon restarts and be exchanged over HTTP without ambiguity, and its shape
+//! must be ready to be referenced by a session (the `SessionRecord.deliverable_id`
+//! link is Wave-2 #2379, NOT added here — but the `id` this file defines is what
+//! that field will point at).
+//! What: defines [`DeliverableId`] (a UUID newtype), [`DeliverableKind`],
+//! [`EstimationTier`] (S/M/L/XL — coarse tiers, no hours, DOC-30 Decision #2),
+//! and the [`Deliverable`] struct. `spec_ref` is a plain repo-relative path
+//! string (§13 Q6: no `SpecRef` abstraction); `ticket_ref` is a loosely-typed
+//! opaque slot (§13 Q6: gh-first, validation deferred).
+//! Test: `deliverable_serde_round_trip`, `deliverable_id_round_trip`,
+//! `estimation_tier_wire_format`, `kind_wire_format`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::status::DeliverableStatus;
+
+/// A stable, globally-unique identifier for a [`Deliverable`].
+///
+/// Why: a newtype over [`Uuid`] prevents accidental confusion with other
+/// UUID-typed identifiers ([`MilestoneId`](crate::deliverable::MilestoneId),
+/// `ManagedSessionId`) at the type level, mirroring the existing id-newtype
+/// convention in `session_manager::record`.
+/// What: wraps `uuid::Uuid`; serializes transparently as the bare UUID string;
+/// implements `Display`/`FromStr` for path-param parsing in the CRUD routes.
+/// Test: `deliverable_id_round_trip`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DeliverableId(pub Uuid);
+
+impl DeliverableId {
+    /// Generate a new random Deliverable id.
+    ///
+    /// Why: every Deliverable created via the API needs a fresh, unique id.
+    /// What: wraps `Uuid::new_v4()`.
+    /// Test: `deliverable_serde_round_trip`.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for DeliverableId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for DeliverableId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::str::FromStr for DeliverableId {
+    type Err = uuid::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Uuid::parse_str(s)?))
+    }
+}
+
+/// The category of work a [`Deliverable`] represents (§10.2).
+///
+/// Why: a small closed vocabulary lets operators filter and group Deliverables
+/// without parsing free-text descriptions.
+/// What: the six kinds from §10.2, serialized lowercase (`feature`, `bugfix`, …).
+/// Test: `kind_wire_format`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeliverableKind {
+    /// A new capability.
+    Feature,
+    /// A defect repair.
+    Bugfix,
+    /// A behavior-preserving restructuring.
+    Refactor,
+    /// Maintenance / housekeeping.
+    Chore,
+    /// Test-only work.
+    Test,
+    /// Documentation-only work.
+    Docs,
+}
+
+/// Coarse-grained effort estimate (DOC-30 Decision #2, unchanged).
+///
+/// Why: tier-based estimation deliberately avoids the false precision of
+/// hour/range estimates. S/M/L/XL is enough signal for planning without inviting
+/// spurious accuracy — and it stays deterministic (no inference, §11).
+/// What: the four tiers, serialized as their uppercase letters (`S`, `M`, `L`,
+/// `XL`) to match the CLI `--estimate` values in §10.8.
+/// Test: `estimation_tier_wire_format`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum EstimationTier {
+    /// Small.
+    S,
+    /// Medium.
+    M,
+    /// Large.
+    L,
+    /// Extra-large.
+    Xl,
+}
+
+/// A discrete unit of work within a project (DOC-35 §10.2).
+///
+/// Why: this is the persisted record the Deliverable CRUD API (#2378) creates,
+/// reads, and mutates. It is keyed by `id` in the store but references its owning
+/// project by `project_name` (registry-B `Project.name`, `repo_url`-keyed — this
+/// epic introduces no second project identity, §10.2). It is intentionally flat
+/// (no recursive sub-tasks, DOC-30 Decision #3).
+/// What: captures identity, project linkage, descriptive metadata, the lifecycle
+/// `status` ([`DeliverableStatus`], §10.3), a coarse `estimated_effort` tier, and
+/// creation/target timestamps. `ticket_ref` is an opaque gh-first slot;
+/// `spec_ref` is a plain `docs/specs/*.md` path (§13 Q6).
+/// Test: `deliverable_serde_round_trip`, and the store/route tests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Deliverable {
+    /// Store key: a stable UUID assigned at creation.
+    pub id: DeliverableId,
+
+    /// The owning project's registry-B name (`repo_url`-keyed `Project.name`).
+    ///
+    /// Why: Deliverables are always scoped to exactly one project; the CRUD
+    /// routes nest under `/api/v1/projects/{name}/deliverables`, and this field
+    /// records that ownership so the central store can be filtered by project.
+    pub project_name: String,
+
+    /// Human-readable name, e.g. `"OAuth2 authentication flow"`.
+    pub name: String,
+
+    /// Free-form description of the work.
+    #[serde(default)]
+    pub description: String,
+
+    /// The category of work.
+    pub kind: DeliverableKind,
+
+    /// Opaque, loosely-typed ticket reference (e.g. `"#2117"`), §13 Q6.
+    ///
+    /// Why: gh-first today; JIRA (#2082) may write through this slot later, so it
+    /// is intentionally unvalidated — a placeholder, not a typed reference.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ticket_ref: Option<String>,
+
+    /// Repo-relative path to the spec this Deliverable implements (§10.4, §13 Q6).
+    ///
+    /// Why: manual linking only (§10.4) — the operator sets it explicitly; no
+    /// auto-scan (that would be inference, out of scope §11). A plain path string,
+    /// not an abstraction (§13 Q6), e.g. `"docs/specs/tm-project-control-plane.md"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spec_ref: Option<String>,
+
+    /// Lifecycle state, mutated only via the §10.3 state machine (#2380).
+    pub status: DeliverableStatus,
+
+    /// Coarse effort estimate.
+    pub estimated_effort: EstimationTier,
+
+    /// When the Deliverable record was created.
+    pub created_at: DateTime<Utc>,
+
+    /// Optional target completion date.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_date: Option<DateTime<Utc>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Deliverable {
+        Deliverable {
+            id: DeliverableId::new(),
+            project_name: "trusty-tools".into(),
+            name: "OAuth2 flow".into(),
+            description: "add oauth".into(),
+            kind: DeliverableKind::Feature,
+            ticket_ref: Some("#2117".into()),
+            spec_ref: Some("docs/specs/tm-project-control-plane.md".into()),
+            status: DeliverableStatus::Proposed,
+            estimated_effort: EstimationTier::L,
+            created_at: Utc::now(),
+            target_date: None,
+        }
+    }
+
+    #[test]
+    fn deliverable_serde_round_trip() {
+        let d = sample();
+        let json = serde_json::to_string(&d).unwrap();
+        let back: Deliverable = serde_json::from_str(&json).unwrap();
+        assert_eq!(d, back);
+    }
+
+    #[test]
+    fn deliverable_id_round_trip() {
+        let id = DeliverableId::new();
+        let s = id.to_string();
+        let parsed: DeliverableId = s.parse().unwrap();
+        assert_eq!(id, parsed);
+        // Transparent serde: the JSON is the bare quoted UUID.
+        assert_eq!(serde_json::to_string(&id).unwrap(), format!("\"{s}\""));
+    }
+
+    #[test]
+    fn estimation_tier_wire_format() {
+        assert_eq!(serde_json::to_string(&EstimationTier::S).unwrap(), "\"S\"");
+        assert_eq!(
+            serde_json::to_string(&EstimationTier::Xl).unwrap(),
+            "\"XL\""
+        );
+        let back: EstimationTier = serde_json::from_str("\"M\"").unwrap();
+        assert_eq!(back, EstimationTier::M);
+    }
+
+    #[test]
+    fn kind_wire_format() {
+        assert_eq!(
+            serde_json::to_string(&DeliverableKind::Feature).unwrap(),
+            "\"feature\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DeliverableKind::Bugfix).unwrap(),
+            "\"bugfix\""
+        );
+        let back: DeliverableKind = serde_json::from_str("\"docs\"").unwrap();
+        assert_eq!(back, DeliverableKind::Docs);
+    }
+
+    #[test]
+    fn optional_fields_omitted_when_absent() {
+        let d = Deliverable {
+            ticket_ref: None,
+            spec_ref: None,
+            target_date: None,
+            ..sample()
+        };
+        let json = serde_json::to_string(&d).unwrap();
+        assert!(!json.contains("ticket_ref"));
+        assert!(!json.contains("spec_ref"));
+        assert!(!json.contains("target_date"));
+    }
+}

--- a/crates/trusty-mpm/src/deliverable/status.rs
+++ b/crates/trusty-mpm/src/deliverable/status.rs
@@ -1,0 +1,316 @@
+//! Deliverable status enum and its transition state machine (DOC-35 §10.3, #2380).
+//!
+//! Why: a Deliverable moves through a small, fixed lifecycle
+//! (`proposed → in-progress → [blocked ↔ in-progress] → complete →
+//! delivered/shipped`). Allowing an arbitrary jump — e.g. `proposed → complete`
+//! — would corrupt the ledger the L3 substrate exists to keep honest (§10.1).
+//! Encoding the legal transitions as a pure, table-driven function keeps the rule
+//! deterministic (§11 boundary: no LLM, no inference) and lets the CRUD API layer
+//! reject illegal `set-status` requests with a structured error that names the
+//! legal next states (#2380).
+//! What: [`DeliverableStatus`] (the six lifecycle states), [`allowed_next`]
+//! ([`DeliverableStatus::allowed_next`]) as the single source of truth for legal
+//! transitions, [`DeliverableStatus::can_transition`], and
+//! [`validate_transition`] which returns a [`TransitionError`] naming the legal
+//! next states on rejection.
+//! Test: `transition_table_covers_every_ordered_pair` exercises all 36 ordered
+//! pairs against an independent legal-set; `rejects_proposed_to_complete` and
+//! `terminal_states_have_no_successors` pin the named cases from #2380;
+//! `status_wire_format_is_kebab_case` pins the serde encoding.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// The lifecycle state of a [`Deliverable`](crate::deliverable::Deliverable).
+///
+/// Why: the state machine in §10.3 is the deterministic backbone of Deliverable
+/// tracking; a closed enum makes every legal state explicit and lets the
+/// transition table be exhaustive at compile time.
+/// What: the six states of `proposed → in-progress → [blocked ↔ in-progress] →
+/// complete → delivered/shipped`. `Delivered` and `Shipped` are both terminal
+/// and both reachable from `Complete` (the `/` in the spec's `delivered/shipped`
+/// — an explicit, manual user choice of terminal label, §10.3). Serialized in
+/// kebab-case so `InProgress` is `"in-progress"` on the wire.
+/// Test: `status_wire_format_is_kebab_case`, and the transition tests below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DeliverableStatus {
+    /// Work is planned but not started.
+    Proposed,
+    /// A session is actively working the Deliverable.
+    InProgress,
+    /// Work is paused on an external blocker (manual, never inferred, §10.3).
+    Blocked,
+    /// The objective gate passed or the user confirmed completion (§10.3).
+    Complete,
+    /// Terminal: the Deliverable was delivered to its consumer.
+    Delivered,
+    /// Terminal: the Deliverable shipped.
+    Shipped,
+}
+
+impl DeliverableStatus {
+    /// Every status variant, for exhaustive iteration in tests and histograms.
+    ///
+    /// Why: the transition-table test and any future status rollup (#2382) need
+    /// to enumerate every state without hand-maintaining a second list that could
+    /// drift from the enum.
+    /// What: the six variants in lifecycle order.
+    /// Test: `all_lists_every_variant`.
+    pub const ALL: [DeliverableStatus; 6] = [
+        DeliverableStatus::Proposed,
+        DeliverableStatus::InProgress,
+        DeliverableStatus::Blocked,
+        DeliverableStatus::Complete,
+        DeliverableStatus::Delivered,
+        DeliverableStatus::Shipped,
+    ];
+
+    /// The stable kebab-case wire label for this status.
+    ///
+    /// Why: the `Display` impl, error messages, and the structured
+    /// `allowed_next` array must all use the exact string serde emits so an
+    /// operator reading a rejection sees the same tokens they would `PATCH`.
+    /// What: maps each variant to its serde `rename_all = "kebab-case"` string.
+    /// Test: `status_wire_format_is_kebab_case`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            DeliverableStatus::Proposed => "proposed",
+            DeliverableStatus::InProgress => "in-progress",
+            DeliverableStatus::Blocked => "blocked",
+            DeliverableStatus::Complete => "complete",
+            DeliverableStatus::Delivered => "delivered",
+            DeliverableStatus::Shipped => "shipped",
+        }
+    }
+
+    /// The set of states this status may legally transition TO (§10.3).
+    ///
+    /// Why: this is the single source of truth for the state machine. Every
+    /// other predicate (`can_transition`, `validate_transition`) and the
+    /// structured rejection error derive from it, so the machine can never
+    /// disagree with itself.
+    /// What: returns a static slice of legal successors. Self-transitions are
+    /// deliberately excluded — `set-status` requires an actual state change.
+    /// `Delivered` and `Shipped` are terminal (empty slice). There is no path
+    /// that skips `Proposed → InProgress` or jumps straight to a terminal.
+    /// Test: `transition_table_covers_every_ordered_pair`,
+    /// `terminal_states_have_no_successors`.
+    pub const fn allowed_next(self) -> &'static [DeliverableStatus] {
+        match self {
+            DeliverableStatus::Proposed => &[DeliverableStatus::InProgress],
+            DeliverableStatus::InProgress => {
+                &[DeliverableStatus::Blocked, DeliverableStatus::Complete]
+            }
+            DeliverableStatus::Blocked => &[DeliverableStatus::InProgress],
+            DeliverableStatus::Complete => {
+                &[DeliverableStatus::Delivered, DeliverableStatus::Shipped]
+            }
+            DeliverableStatus::Delivered => &[],
+            DeliverableStatus::Shipped => &[],
+        }
+    }
+
+    /// Whether `self → to` is a legal transition.
+    ///
+    /// Why: the CRUD `set-status` path needs a cheap boolean gate before it
+    /// mutates and persists a Deliverable.
+    /// What: true iff `to` appears in [`allowed_next`](Self::allowed_next).
+    /// Test: `transition_table_covers_every_ordered_pair`.
+    pub fn can_transition(self, to: DeliverableStatus) -> bool {
+        self.allowed_next().contains(&to)
+    }
+}
+
+impl std::fmt::Display for DeliverableStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A rejected status transition, naming the legal next states (#2380).
+///
+/// Why: rejecting an illegal `set-status` with a bare "invalid" is useless to
+/// the caller. #2380 requires the rejection to name the legal next states so the
+/// operator (or a future policy engine) can self-correct without consulting the
+/// spec.
+/// What: carries the attempted `from`/`to` and the list of states that WOULD
+/// have been legal from `from`. Its `Display` renders a one-line, deterministic
+/// message; the route layer additionally surfaces `allowed` as a JSON array.
+/// Test: `rejects_proposed_to_complete`, `error_message_names_legal_states`.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub struct TransitionError {
+    /// The Deliverable's current status.
+    pub from: DeliverableStatus,
+    /// The requested (rejected) target status.
+    pub to: DeliverableStatus,
+    /// The states that would have been legal transitions from `from`.
+    pub allowed: Vec<DeliverableStatus>,
+}
+
+impl std::fmt::Display for TransitionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let allowed = if self.allowed.is_empty() {
+            "none (terminal state)".to_string()
+        } else {
+            self.allowed
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        write!(
+            f,
+            "invalid status transition {} \u{2192} {}; legal next states from {}: [{}]",
+            self.from, self.to, self.from, allowed
+        )
+    }
+}
+
+/// Validate a `from → to` status transition against the §10.3 state machine.
+///
+/// Why: this is the one deterministic gate the CRUD `set-status` endpoint calls
+/// before persisting a status change (#2380). Keeping it a free function makes it
+/// unit-testable in isolation from any store or HTTP concern.
+/// What: `Ok(())` when the transition is legal; otherwise a [`TransitionError`]
+/// carrying the legal next states. No side effects, no I/O — a pure function of
+/// its two inputs (§11 determinism test).
+/// Test: `transition_table_covers_every_ordered_pair`,
+/// `rejects_proposed_to_complete`, `rejects_self_transition`.
+pub fn validate_transition(
+    from: DeliverableStatus,
+    to: DeliverableStatus,
+) -> Result<(), TransitionError> {
+    if from.can_transition(to) {
+        Ok(())
+    } else {
+        Err(TransitionError {
+            from,
+            to,
+            allowed: from.allowed_next().to_vec(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DeliverableStatus::*;
+    use super::*;
+
+    /// The complete, independently-authored set of LEGAL ordered transition
+    /// pairs from §10.3. Kept separate from `allowed_next` so the table test
+    /// verifies behavior against an independent spec transcription, not a
+    /// tautological echo of the implementation.
+    const LEGAL_PAIRS: [(DeliverableStatus, DeliverableStatus); 6] = [
+        (Proposed, InProgress),
+        (InProgress, Blocked),
+        (InProgress, Complete),
+        (Blocked, InProgress),
+        (Complete, Delivered),
+        (Complete, Shipped),
+    ];
+
+    #[test]
+    fn all_lists_every_variant() {
+        assert_eq!(DeliverableStatus::ALL.len(), 6);
+    }
+
+    /// #2380 core: exercise EVERY ordered pair (6 x 6 = 36) — both legal and
+    /// illegal — against the independent legal-set and confirm `validate_transition`
+    /// agrees with `can_transition`.
+    #[test]
+    fn transition_table_covers_every_ordered_pair() {
+        let legal: std::collections::HashSet<(DeliverableStatus, DeliverableStatus)> =
+            LEGAL_PAIRS.iter().copied().collect();
+        let mut checked = 0usize;
+        for &from in &DeliverableStatus::ALL {
+            for &to in &DeliverableStatus::ALL {
+                let expect_ok = legal.contains(&(from, to));
+                assert_eq!(
+                    from.can_transition(to),
+                    expect_ok,
+                    "can_transition({from} -> {to}) disagreed with the §10.3 legal set"
+                );
+                match validate_transition(from, to) {
+                    Ok(()) => assert!(expect_ok, "validate accepted illegal {from} -> {to}"),
+                    Err(e) => {
+                        assert!(!expect_ok, "validate rejected legal {from} -> {to}");
+                        assert_eq!(e.from, from);
+                        assert_eq!(e.to, to);
+                        assert_eq!(e.allowed, from.allowed_next().to_vec());
+                    }
+                }
+                checked += 1;
+            }
+        }
+        assert_eq!(checked, 36, "must exhaustively check all 36 ordered pairs");
+    }
+
+    #[test]
+    fn rejects_proposed_to_complete() {
+        // The literal example named in issue #2380.
+        let err = validate_transition(Proposed, Complete).expect_err("must reject");
+        assert_eq!(err.from, Proposed);
+        assert_eq!(err.to, Complete);
+        assert_eq!(err.allowed, vec![InProgress]);
+    }
+
+    #[test]
+    fn rejects_self_transition() {
+        // `set-status` requires an actual state change; X -> X is not a
+        // transition in the machine.
+        for &s in &DeliverableStatus::ALL {
+            assert!(
+                validate_transition(s, s).is_err(),
+                "self-transition {s} -> {s} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_states_have_no_successors() {
+        assert!(Delivered.allowed_next().is_empty());
+        assert!(Shipped.allowed_next().is_empty());
+        for &to in &DeliverableStatus::ALL {
+            assert!(validate_transition(Delivered, to).is_err());
+            assert!(validate_transition(Shipped, to).is_err());
+        }
+    }
+
+    #[test]
+    fn blocked_branch_round_trips() {
+        assert!(InProgress.can_transition(Blocked));
+        assert!(Blocked.can_transition(InProgress));
+        // Blocked cannot leap straight to Complete — it must return to
+        // in-progress first (§10.3).
+        assert!(!Blocked.can_transition(Complete));
+    }
+
+    #[test]
+    fn error_message_names_legal_states() {
+        let err = validate_transition(Proposed, Shipped).expect_err("reject");
+        let msg = err.to_string();
+        assert!(msg.contains("proposed"), "message names from-state: {msg}");
+        assert!(msg.contains("shipped"), "message names to-state: {msg}");
+        assert!(
+            msg.contains("in-progress"),
+            "message names the legal next state: {msg}"
+        );
+    }
+
+    #[test]
+    fn status_wire_format_is_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&InProgress).unwrap(),
+            "\"in-progress\""
+        );
+        assert_eq!(serde_json::to_string(&Proposed).unwrap(), "\"proposed\"");
+        let back: DeliverableStatus = serde_json::from_str("\"delivered\"").unwrap();
+        assert_eq!(back, Delivered);
+        // as_str must match the serde encoding exactly.
+        for &s in &DeliverableStatus::ALL {
+            let json = serde_json::to_string(&s).unwrap();
+            assert_eq!(json, format!("\"{}\"", s.as_str()));
+        }
+    }
+}

--- a/crates/trusty-mpm/src/deliverable/store.rs
+++ b/crates/trusty-mpm/src/deliverable/store.rs
@@ -1,0 +1,439 @@
+//! On-disk JSON persistence for Deliverable and Milestone records (§10.7).
+//!
+//! Why: Deliverables and Milestones must survive daemon restarts, and — like the
+//! project registry — be visible regardless of which checkout (if any) is open,
+//! so they live as central, daemon-owned sibling stores next to `projects.json`
+//! (§13 Q5: CENTRAL, not local-checkout). The two record types have identical
+//! persistence needs (UUID-keyed map, atomic temp-file + rename, reload-on-read
+//! freshness), so rather than duplicate the `store.rs` pattern twice (>80%
+//! similar → consolidate) this is ONE generic [`JsonStore<T>`] reused verbatim
+//! for both via the [`Keyed`] trait.
+//! What: [`JsonStore<T>`] loads/saves a `HashMap<String, T>` from/to a JSON file,
+//! using the same atomic-write and `(mtime, len)` freshness fingerprint as
+//! [`crate::project::store::ProjectStore`]. [`DeliverableStore`] and
+//! [`MilestoneStore`] are the two concrete instantiations.
+//! Test: `store_round_trip`, `store_upsert_idempotent`, `store_remove`,
+//! `store_reload_picks_up_external_write`, `store_other_io_error_propagates`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use thiserror::Error;
+use tokio::fs;
+use tracing::debug;
+
+use super::milestone::Milestone;
+use super::record::Deliverable;
+
+/// A record that a [`JsonStore`] can key by a stable string id.
+///
+/// Why: the generic store must know each record's map key without knowing the
+/// concrete type; a tiny trait gives it that without reflection.
+/// What: `store_key` returns the record's stable id as a string (the UUID);
+/// `project_name` scopes the record to its owning project for list filtering.
+/// Test: exercised via `DeliverableStore`/`MilestoneStore` in the store tests.
+pub trait Keyed {
+    /// The record's stable store key (its UUID, stringified).
+    fn store_key(&self) -> String;
+    /// The owning project's registry-B name, for project-scoped listing.
+    fn project_name(&self) -> &str;
+}
+
+impl Keyed for Deliverable {
+    fn store_key(&self) -> String {
+        self.id.to_string()
+    }
+    fn project_name(&self) -> &str {
+        &self.project_name
+    }
+}
+
+impl Keyed for Milestone {
+    fn store_key(&self) -> String {
+        self.id.to_string()
+    }
+    fn project_name(&self) -> &str {
+        &self.project_name
+    }
+}
+
+/// Errors that can arise from Deliverable/Milestone store I/O or serialization.
+///
+/// Why: callers need structured error information to distinguish transient I/O
+/// failures from data-corruption problems and missing records.
+/// What: one variant per failure mode: I/O, serialization, or not-found.
+/// Test: `store_other_io_error_propagates`, `store_get_missing_is_not_found`.
+#[derive(Debug, Error)]
+pub enum StoreError {
+    /// An I/O operation on the backing file failed.
+    #[error("store I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialization or deserialization failed.
+    #[error("store serialization error: {0}")]
+    Serialize(String),
+
+    /// The requested record id was not found in the store.
+    #[error("record not found: {0}")]
+    NotFound(String),
+}
+
+/// A cheap freshness fingerprint for the backing file (mtime + length).
+///
+/// Why: identical rationale to `ProjectStore::FileSig` — an mtime alone is
+/// insufficient on coarse filesystems; pairing it with byte length catches
+/// same-second writes that changed the size.
+/// What: the file's last-modified time and length in bytes.
+/// Test: `store_reload_picks_up_external_write`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct FileSig {
+    mtime: Option<SystemTime>,
+    len: u64,
+}
+
+/// Async, file-backed, UUID-keyed store for any [`Keyed`] record type (§10.7).
+///
+/// Why: both the deliverable and milestone stores need daemon-owned, atomic,
+/// reload-on-read persistence identical to `ProjectStore`; making it generic
+/// avoids duplicating that logic per record type.
+/// What: holds the in-memory `HashMap<String, T>`, the backing file path, and
+/// the last observed file signature. All mutations call `save()` immediately;
+/// reads call `reload_if_changed()` first so out-of-process writes are seen.
+/// Test: `store_round_trip`, `store_upsert_idempotent`, `store_remove`.
+#[derive(Debug)]
+pub struct JsonStore<T> {
+    data: HashMap<String, T>,
+    path: PathBuf,
+    last_sig: Option<FileSig>,
+}
+
+impl<T> JsonStore<T>
+where
+    T: Keyed + Clone + Serialize + DeserializeOwned,
+{
+    /// Load (or create) the store at the given file path.
+    ///
+    /// Why: on startup each store restores state from the previous run; an absent
+    /// file starts fresh so the daemon boots cleanly.
+    /// What: reads and JSON-parses `path` if present; returns an empty store if
+    /// the file is absent; propagates all other I/O errors.
+    /// Test: `store_round_trip`, `store_not_found_starts_fresh`.
+    pub async fn load(path: PathBuf) -> Result<Self, StoreError> {
+        let (data, last_sig) = Self::read_file(&path).await?;
+        Ok(Self {
+            data,
+            path,
+            last_sig,
+        })
+    }
+
+    /// Stat `path` and return its freshness fingerprint, or `None` if absent.
+    async fn sig_of(path: &Path) -> Option<FileSig> {
+        let meta = fs::metadata(path).await.ok()?;
+        Some(FileSig {
+            mtime: meta.modified().ok(),
+            len: meta.len(),
+        })
+    }
+
+    /// Read and parse the backing file, returning the data and its fingerprint.
+    ///
+    /// Why: `load` and `reload_if_changed` share "read or treat absence as
+    /// empty" logic; only `NotFound` is treated as absent so a transient I/O
+    /// error never silently overwrites the store with an empty map on the next
+    /// `save` (the exact data-loss bug `ProjectStore` guards against).
+    /// What: on success returns `(map, Some(sig))`; on `NotFound` returns
+    /// `(empty, None)`; propagates all other I/O errors.
+    /// Test: `store_round_trip`, `store_other_io_error_propagates`.
+    async fn read_file(path: &Path) -> Result<(HashMap<String, T>, Option<FileSig>), StoreError> {
+        match fs::read_to_string(path).await {
+            Ok(raw) => {
+                let data = serde_json::from_str::<HashMap<String, T>>(&raw)
+                    .map_err(|e| StoreError::Serialize(e.to_string()))?;
+                let sig = Self::sig_of(path).await.unwrap_or_default();
+                Ok((data, Some(sig)))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                debug!(path = %path.display(), "no store file found; starting fresh");
+                Ok((HashMap::new(), None))
+            }
+            Err(e) => Err(StoreError::Io(e)),
+        }
+    }
+
+    /// Reload the in-memory map from disk if the backing file changed.
+    ///
+    /// Why: another process (or another store handle) may have written the file;
+    /// reading first reconciles the in-memory view with the authoritative disk
+    /// state (identical semantics to `ProjectStore::reload_if_changed`).
+    /// What: stats the file; if its fingerprint differs from `last_sig`, re-reads
+    /// and replaces `data`/`last_sig`. A matching fingerprint is a fast no-op.
+    /// Test: `store_reload_picks_up_external_write`.
+    pub async fn reload_if_changed(&mut self) -> Result<(), StoreError> {
+        let current = Self::sig_of(&self.path).await;
+        let unchanged = matches!((current, self.last_sig), (Some(a), Some(b)) if a == b);
+        if unchanged {
+            return Ok(());
+        }
+        let (data, sig) = Self::read_file(&self.path).await?;
+        self.data = data;
+        self.last_sig = sig;
+        debug!(path = %self.path.display(), "store reloaded after external change");
+        Ok(())
+    }
+
+    /// Persist the current in-memory state to disk atomically.
+    ///
+    /// Why: every mutation must flush for crash safety; temp-file + rename
+    /// prevents concurrent readers from seeing a torn file.
+    /// What: serializes to pretty JSON, writes a sibling `.tmp`, renames it over
+    /// the real path, and records the resulting signature.
+    /// Test: verified by every mutating store test.
+    pub async fn save(&mut self) -> Result<(), StoreError> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        let json = serde_json::to_string_pretty(&self.data)
+            .map_err(|e| StoreError::Serialize(e.to_string()))?;
+        let tmp = self.path.with_extension("json.tmp");
+        fs::write(&tmp, json).await?;
+        fs::rename(&tmp, &self.path).await?;
+        self.last_sig = Self::sig_of(&self.path).await;
+        debug!(path = %self.path.display(), "store saved");
+        Ok(())
+    }
+
+    /// Insert or update a record, keyed by its [`Keyed::store_key`].
+    ///
+    /// Why: create and update both persist a record; reloading first ensures a
+    /// concurrent write from another handle is not lost.
+    /// What: reloads if changed, inserts/replaces by key, then saves.
+    /// Test: `store_upsert_idempotent`.
+    pub async fn upsert(&mut self, record: T) -> Result<(), StoreError> {
+        self.reload_if_changed().await?;
+        self.data.insert(record.store_key(), record);
+        self.save().await
+    }
+
+    /// Look up a record by its string id, reloading from disk first.
+    ///
+    /// Why: the caller must see out-of-process writes; reloading before answering
+    /// ensures freshness.
+    /// What: reloads if changed, then returns a clone or [`StoreError::NotFound`].
+    /// Test: `store_round_trip`, `store_get_missing_is_not_found`.
+    pub async fn get(&mut self, id: &str) -> Result<T, StoreError> {
+        self.reload_if_changed().await?;
+        self.data
+            .get(id)
+            .cloned()
+            .ok_or_else(|| StoreError::NotFound(id.to_string()))
+    }
+
+    /// Return all stored records, reloading from disk first.
+    ///
+    /// Why: the histogram/status rollup and project-scoped listing both need the
+    /// full set and must reflect any external write.
+    /// What: reloads if changed, then clones and collects all values.
+    /// Test: `store_round_trip`, `store_by_project_filters`.
+    pub async fn all(&mut self) -> Result<Vec<T>, StoreError> {
+        self.reload_if_changed().await?;
+        Ok(self.data.values().cloned().collect())
+    }
+
+    /// Return all records whose owning project matches `project_name`.
+    ///
+    /// Why: the CRUD list endpoints are project-scoped
+    /// (`/api/v1/projects/{name}/deliverables`); filtering in the store keeps the
+    /// handler thin.
+    /// What: reloads if changed, then clones the values whose
+    /// [`Keyed::project_name`] equals `project_name`.
+    /// Test: `store_by_project_filters`.
+    pub async fn by_project(&mut self, project_name: &str) -> Result<Vec<T>, StoreError> {
+        self.reload_if_changed().await?;
+        Ok(self
+            .data
+            .values()
+            .filter(|r| r.project_name() == project_name)
+            .cloned()
+            .collect())
+    }
+
+    /// Remove a record by id, reloading first; errors if absent.
+    ///
+    /// Why: completeness of the CRUD surface; deleting a stale Deliverable/
+    /// Milestone must persist and reconcile against concurrent writes.
+    /// What: reloads if changed, removes by key (NotFound if absent), then saves.
+    /// Test: `store_remove`.
+    pub async fn remove(&mut self, id: &str) -> Result<T, StoreError> {
+        self.reload_if_changed().await?;
+        let removed = self
+            .data
+            .remove(id)
+            .ok_or_else(|| StoreError::NotFound(id.to_string()))?;
+        self.save().await?;
+        Ok(removed)
+    }
+}
+
+/// Central store for [`Deliverable`] records (`<framework_root>/deliverables.json`).
+pub type DeliverableStore = JsonStore<Deliverable>;
+
+/// Central store for [`Milestone`] records (`<framework_root>/milestones.json`).
+pub type MilestoneStore = JsonStore<Milestone>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deliverable::record::{DeliverableId, DeliverableKind, EstimationTier};
+    use crate::deliverable::status::DeliverableStatus;
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn deliverable(project: &str, name: &str) -> Deliverable {
+        Deliverable {
+            id: DeliverableId::new(),
+            project_name: project.into(),
+            name: name.into(),
+            description: String::new(),
+            kind: DeliverableKind::Feature,
+            ticket_ref: None,
+            spec_ref: None,
+            status: DeliverableStatus::Proposed,
+            estimated_effort: EstimationTier::M,
+            created_at: Utc::now(),
+            target_date: None,
+        }
+    }
+
+    fn path(dir: &TempDir) -> PathBuf {
+        dir.path().join("deliverables.json")
+    }
+
+    #[tokio::test]
+    async fn store_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let mut store = DeliverableStore::load(path(&dir)).await.unwrap();
+        assert!(store.all().await.unwrap().is_empty());
+
+        let d = deliverable("alpha", "one");
+        let key = d.store_key();
+        store.upsert(d).await.unwrap();
+
+        let mut store2 = DeliverableStore::load(path(&dir)).await.unwrap();
+        let got = store2.get(&key).await.unwrap();
+        assert_eq!(got.name, "one");
+    }
+
+    #[tokio::test]
+    async fn store_upsert_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let mut store = DeliverableStore::load(path(&dir)).await.unwrap();
+        let mut d = deliverable("beta", "orig");
+        let key = d.store_key();
+        store.upsert(d.clone()).await.unwrap();
+        d.name = "updated".into();
+        store.upsert(d).await.unwrap();
+        let all = store.all().await.unwrap();
+        assert_eq!(all.len(), 1, "upsert on same key must not duplicate");
+        assert_eq!(store.get(&key).await.unwrap().name, "updated");
+    }
+
+    #[tokio::test]
+    async fn store_by_project_filters() {
+        let dir = TempDir::new().unwrap();
+        let mut store = DeliverableStore::load(path(&dir)).await.unwrap();
+        store.upsert(deliverable("p1", "a")).await.unwrap();
+        store.upsert(deliverable("p1", "b")).await.unwrap();
+        store.upsert(deliverable("p2", "c")).await.unwrap();
+        let p1 = store.by_project("p1").await.unwrap();
+        assert_eq!(p1.len(), 2);
+        assert!(p1.iter().all(|d| d.project_name == "p1"));
+        assert_eq!(store.by_project("p2").await.unwrap().len(), 1);
+        assert!(store.by_project("missing").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn store_get_missing_is_not_found() {
+        let dir = TempDir::new().unwrap();
+        let mut store = DeliverableStore::load(path(&dir)).await.unwrap();
+        let err = store.get("nope").await;
+        assert!(matches!(err, Err(StoreError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn store_remove() {
+        let dir = TempDir::new().unwrap();
+        let mut store = DeliverableStore::load(path(&dir)).await.unwrap();
+        let d = deliverable("g", "x");
+        let key = d.store_key();
+        store.upsert(d).await.unwrap();
+        store.remove(&key).await.unwrap();
+        assert!(matches!(
+            store.get(&key).await,
+            Err(StoreError::NotFound(_))
+        ));
+        assert!(matches!(
+            store.remove(&key).await,
+            Err(StoreError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn store_reload_picks_up_external_write() {
+        let dir = TempDir::new().unwrap();
+        let mut a = DeliverableStore::load(path(&dir)).await.unwrap();
+        a.upsert(deliverable("p", "first")).await.unwrap();
+
+        let mut b = DeliverableStore::load(path(&dir)).await.unwrap();
+        let d = deliverable("p", "second");
+        let key = d.store_key();
+        b.upsert(d).await.unwrap();
+
+        // `a` must observe `b`'s write on its next read.
+        let got = a.get(&key).await.unwrap();
+        assert_eq!(got.name, "second");
+    }
+
+    #[tokio::test]
+    async fn store_not_found_starts_fresh() {
+        let dir = TempDir::new().unwrap();
+        let mut store = DeliverableStore::load(path(&dir)).await.unwrap();
+        assert!(store.all().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn store_other_io_error_propagates() {
+        let dir = TempDir::new().unwrap();
+        // Plant a directory where the JSON file would live so read_to_string
+        // returns a non-NotFound OS error.
+        let p = path(&dir);
+        tokio::fs::create_dir_all(&p).await.unwrap();
+        let result = DeliverableStore::load(p).await;
+        assert!(matches!(result, Err(StoreError::Io(_))));
+    }
+
+    #[tokio::test]
+    async fn milestone_store_round_trips() {
+        use crate::deliverable::milestone::{Milestone, MilestoneId, MilestoneStatus};
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("milestones.json");
+        let mut store = MilestoneStore::load(p.clone()).await.unwrap();
+        let m = Milestone {
+            id: MilestoneId::new(),
+            project_name: "trusty-tools".into(),
+            name: "v1".into(),
+            description: String::new(),
+            target_date: Utc::now(),
+            status: MilestoneStatus::Proposed,
+            deliverables: vec![],
+            created_at: Utc::now(),
+        };
+        let key = m.store_key();
+        store.upsert(m).await.unwrap();
+        let mut store2 = MilestoneStore::load(p).await.unwrap();
+        assert_eq!(store2.get(&key).await.unwrap().name, "v1");
+    }
+}

--- a/crates/trusty-mpm/src/lib.rs
+++ b/crates/trusty-mpm/src/lib.rs
@@ -129,6 +129,17 @@ pub mod supervisor;
 /// Test: each submodule carries inline unit tests run by `cargo test -p trusty-mpm`.
 pub mod project;
 
+/// Deliverable/Milestone data model, central stores, and status state machine
+/// (DOC-35 §10, epic #2108; #2378 CRUD API + #2380 transition enforcement).
+///
+/// Why: the L3 substrate needs a deterministic ledger of what work exists, its
+/// tier, and its lifecycle state — bookkeeping `tm manager` (#2109) reasons over
+/// but must not own. Central sibling stores to `projects.json` (§10.7, §13 Q5).
+/// What: re-exports `Deliverable`/`Milestone` records, the `DeliverableStatus`
+/// state machine (§10.3), the on-disk `store`, and the `DeliverableManager`.
+/// Test: each submodule carries inline unit tests run by `cargo test -p trusty-mpm`.
+pub mod deliverable;
+
 /// SESSCTL alpha-1 session control plane (epic #1590, WI-1).
 ///
 /// Why: the daemon's two parallel session paths (project sessions + managed


### PR DESCRIPTION
## Summary

Implements **DOC-35 §10** (epic #2108) end-to-end: the L3-substrate
Deliverable/Milestone ledger — data model, central daemon-owned stores, CRUD
HTTP API, and the §10.3 status state-machine enforcement.

Closes #2378 (WI-12: Deliverable/Milestone CRUD API)
Closes #2380 (WI-14: status state-machine enforcement)

Both issues share the same data-model core, so they land together in one PR (as
directed).

## What landed

**Data model** (`crates/trusty-mpm/src/deliverable/`, §10.2/§10.5)
- `record.rs` — `Deliverable`, `DeliverableId` (UUID newtype), `DeliverableKind`
  (feature/bugfix/refactor/chore/test/docs), `EstimationTier` (S/M/L/XL).
- `milestone.rs` — `Milestone`, `MilestoneId`, `MilestoneStatus`.
- `status.rs` — `DeliverableStatus` + the §10.3 state machine.
- Every public item carries Why/What/Test docs.

**Central stores** (`store.rs` + `manager.rs`, §10.7)
- `deliverables.json` / `milestones.json` as daemon-owned siblings under the
  framework root, reusing `project/store.rs`'s atomic temp-file+rename write and
  `(mtime,len)` reload-on-read freshness discipline verbatim.
- One generic `JsonStore<T: Keyed>` backs both (the two record types are >80%
  identical → consolidated, not duplicated).
- `DeliverableManager` fronts both stores behind `Arc<RwLock<…>>`, mirroring
  `ProjectRegistry`; exposed on `DaemonState` via a `OnceCell` accessor
  (`deliverable_manager()`), same pattern as `session_manager()`.

**CRUD API** (`daemon/api/deliverable_routes.rs`, §10.2/§10.5 route sketch)
- `GET|POST /api/v1/projects/{name}/deliverables`
- `GET|PATCH /api/v1/projects/{name}/deliverables/{id}`
- `GET|POST /api/v1/projects/{name}/milestones`
- `GET|PATCH /api/v1/projects/{name}/milestones/{id}`
- Project-scoped (a mismatched project path 404s rather than leaking a record);
  list supports `?status=` filtering.

**State-machine enforcement** (#2380, §10.3)
- `proposed → in-progress → [blocked ↔ in-progress] → complete →
  delivered/shipped`.
- `PATCH` `set-status` rejects an illegal transition with a **structured 409**
  whose body names the legal next states (`{ error, from, to, allowed_next }`).
- Enforcement is a pure, table-driven `validate_transition` — one source of
  truth — tested over **all 36 ordered transition pairs** plus the named
  `proposed→complete` case, self-transitions, and terminal states.

## Update — adversarial review fixes (HIGH + MEDIUM + LOWs)

An adversarial review returned WARN with one required HIGH plus a required
MEDIUM and four LOWs; all are addressed in a follow-up commit:

- **HIGH (atomicity):** the original `patch_deliverable`/`patch_milestone`
  handlers fetched the record under one write-lock acquisition, then validated
  and persisted under a SEPARATE, later acquisition — a TOCTOU window in which
  two concurrent PATCHes could both validate against the same stale status and
  the later `upsert` would silently clobber the other's committed, validated
  transition (with no error ever surfacing to the clobbered caller). Fixed by
  adding `DeliverableManager::update_deliverable_with` /
  `update_milestone_with`, which hold ONE write-lock guard across the entire
  read→validate→mutate→persist sequence. Both PATCH handlers now run their
  whole mutation inside a closure passed to one of these methods. New
  concurrency tests: `read_then_upsert_pattern_reproduces_lost_update_pre_fix`
  (reproduces the bug via the still-available low-level primitives) and
  `update_deliverable_with_serializes_concurrent_transitions` (proves the fix —
  exactly one of two racing transitions from the same status ever succeeds, the
  loser is rejected with a structured `TransitionError`, and the final
  persisted status always matches exactly the winner).
- **MEDIUM (PATCH name validation):** `PATCH` on both Deliverable and Milestone
  now rejects a present-but-blank (post-trim) `name`, matching the rule
  `create_deliverable`/`create_milestone` already enforced.
- **LOW (option-clearing):** documented in `PatchDeliverable`'s doc comment that
  clearing `ticket_ref`/`spec_ref`/`target_date` back to absent via PATCH is
  unsupported in v1 (would need a double-`Option`; deferred until a real caller
  needs it) — doc only, no behavior change.
- **LOW (referential integrity):** documented on `CreateDeliverable`/
  `CreateMilestone` that project-existence and milestone-member ownership are
  deferred by design (§13 opaque-reference treatment, §11 no-cross-store
  boundary); noted on issue #2378 via a GH comment.
- **LOW (temp-dir fallback logging):** `DaemonState::deliverable_manager()`
  already logs `tracing::error!` on the fallback-to-temp-dir path, identical to
  the `project_registry()` precedent — confirmed consistent, no change needed.
- **LOW (spec discrepancy):** DOC-30's original §old-line-125 text omitted
  `shipped` from the terminal states, but §4.4/Decision-9 text includes it;
  this implementation follows the latter (both `delivered` and `shipped` are
  terminal successors of `complete`), consistent with how the rest of this PR
  reconciles retired-DOC-30 carry-forwards.

## §13 binding-decision compliance

| §13 decision | How this PR complies |
|---|---|
| **Q5 — storage CENTRAL** (siblings to projects.json, keyed by registry-B identity, NOT local `.trusty-mpm/config.toml`) | `deliverables.json`/`milestones.json` are daemon-owned central stores under the framework root; records reference `project_name` (registry-B `Project.name`). |
| **Q6 — `ticket_ref` opaque placeholder** (gh-first, validation deferred) | `ticket_ref: Option<String>`, unvalidated. |
| **Q6 — `spec_ref` NO abstraction** (plain repo path) | `spec_ref: Option<String>` (no `SpecRef` struct — §10.4's struct deliberately not used, per Q6 override). |
| **State machine (#2380)** rejects invalid transitions with a structured error naming legal next states | `DaemonError::InvalidTransition { from, to, allowed }` → 409 with `allowed_next` array. |
| **Q2 — confirm gate stays a deterministic check** (no summarization, no LLM) | `set-status` is a pure deterministic transition check; `in-progress→complete` is an explicit manual transition. No LLM, no CI-poll auto-gate added. |
| **Estimation = S/M/L/XL only** (no hours) | `EstimationTier` enum, no numeric field. |
| **Deliverable ↔ sessions one-to-many; `SessionRecord.deliverable_id` is Wave-2 #2379** | NOT added here; the `Deliverable.id` shape is ready to be referenced. |
| **§11 boundary — no LLM, no inference, single-project scope** | Every handler is a pure function of stored state; lists/rollups are single-project only. |

## Verification (raw)

- `cargo build --workspace` → exit 0.
- `cargo test -p trusty-mpm --lib deliverable` → `test result: ok. 40 passed; 0 failed; 0 ignored`.
- `cargo test -p trusty-mpm` → full crate suite (see PR comments / below).
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0.
- `cargo fmt --check` → clean.
- `bash scripts/check_line_cap.sh` → `0 violations — OK` (all new files under the 500-SLOC prod cap).

## Overlap flags (concurrent siblings feat-2117 / feat-2116)

Shared files this PR touches — coordinate on merge:
- `crates/trusty-mpm/src/daemon/api.rs` — added the 4 route registrations + `pub mod deliverable_routes` (additive; no existing route changed).
- `crates/trusty-mpm/src/daemon/state/core.rs` — added one `OnceCell` field + `deliverable_manager()` accessor (additive).
- `crates/trusty-mpm/src/daemon/error.rs` — added `DeliverableNotFound` / `MilestoneNotFound` / `InvalidTransition` variants (additive).
- `crates/trusty-mpm/src/lib.rs` — added `pub mod deliverable`.

feat-2117 (status endpoint, read-only rollup / #2382) can consume
`DeliverableManager::all_deliverables()` / `all_milestones()` for its histograms;
those accessors are provided here.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
