### PR TITLE
feat(trusty-mpm): deterministic project status-aggregation endpoint (closes #2117)

### DIFF
--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -119,10 +119,10 @@ pub use rpc::rpc_handler;
 use super::managed_routes::{
     adopt_existing_session, answer_session_decision, decommission_ephemeral_route,
     decommission_managed_session, delete_managed_session, fleet_by_project_route, get_attach_cmd,
-    get_managed_session, get_session_activity, list_managed_sessions, proxy_focus, proxy_get_focus,
-    proxy_message, proxy_summary, proxy_unfocus, prune_managed_route, prune_worktrees_route,
-    reactivate_managed_session, resume_managed_session, send_to_session, spawn_session,
-    stop_managed_session, stop_managed_session_runtime,
+    get_managed_session, get_session_activity, list_managed_sessions, project_status_route,
+    proxy_focus, proxy_get_focus, proxy_message, proxy_summary, proxy_unfocus, prune_managed_route,
+    prune_worktrees_route, reactivate_managed_session, resume_managed_session, send_to_session,
+    spawn_session, stop_managed_session, stop_managed_session_runtime,
 };
 
 /// Typed HTTP response bodies for every endpoint.
@@ -158,6 +158,11 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .route("/projects", get(list_projects).post(register_project))
         .route("/projects/current", get(current_project))
         .route("/projects/discover", get(discover_projects))
+        // #2117 (DOC-35 §4.1): deterministic project status-aggregation rollup —
+        // session-state histogram + most-recent activity + config-completeness
+        // flags for ONE named project. Pure composition over ProjectRegistry::get
+        // + SessionManager::list; no LLM, no cross-project reasoning (§11).
+        .route("/api/v1/projects/{name}/status", get(project_status_route))
         .route("/events", get(stream_events))
         .route("/events/poll", get(recent_events))
         .route("/hooks", post(ingest_hook))

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -32,6 +32,7 @@ pub mod inproject;
 pub mod inproject_hygiene;
 mod lifecycle;
 mod mcp_spawn_gate;
+mod project_status;
 pub mod proxy;
 pub mod prune;
 mod reactivate;
@@ -44,6 +45,10 @@ pub use front_gate::{
 pub use lifecycle::{
     ResumeManagedError, SpawnParams, is_local_workdir, resume_managed, spawn_managed,
     spawn_runtime_for, write_task_md,
+};
+pub use project_status::{
+    ProjectConfigFlags, ProjectStatusResponse, SessionStateCounts, aggregate_project_status,
+    project_status_route,
 };
 pub use proxy::{
     DirectManagedBackend, ProxyFocusRequest, ProxyFocusResponse, ProxyMessageRequest,

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_status.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_status.rs
@@ -1,0 +1,375 @@
+//! Deterministic project status-aggregation route (#2117, DOC-35 §4.1).
+//!
+//! Why: `tm projects status <name>` (#2115) and the multipane-TUI Projects-pane
+//! aggregate glyph (#2118) need a single-call rollup of a project's session
+//! landscape without every consumer re-implementing the count/max logic. DOC-35
+//! §11 draws a hard boundary: this endpoint is L3-substrate (deterministic
+//! control plane) — it polls and reports already-computed state and MUST NEVER
+//! call an LLM, reason across projects, or infer anything. It is a pure function
+//! of already-materialized state: re-running it with no state change between
+//! calls yields byte-identical output.
+//! What: defines the response shapes ([`SessionStateCounts`],
+//! [`ProjectConfigFlags`], [`ProjectStatusResponse`]), the pure aggregation
+//! function [`aggregate_project_status`], and the axum handler
+//! [`project_status_route`] for `GET /api/v1/projects/{name}/status`.
+//! Test: `aggregate_project_status_*` unit tests in `tests()` below (pure-rollup
+//! contract) and `project_status_route_*` HTTP handler tests in
+//! `tests/session_manager_mvp.rs`.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tracing::warn;
+
+use crate::daemon::state::DaemonState;
+use crate::project::{Project, ProjectStoreError, fleet_by_project};
+use crate::session_manager::{ManagedSessionState, SessionRecord};
+
+/// Histogram of a project's sessions by [`ManagedSessionState`].
+///
+/// Why: the aggregate view needs a per-state count so a consumer can render
+/// "3 active, 1 errored" without walking the raw session list. A typed struct
+/// (one field per variant) keeps the wire shape explicit and self-documenting
+/// rather than a map keyed by stringly-typed states.
+/// What: one `usize` per lifecycle variant plus `total` (the sum of all five —
+/// the number of session records bound to the project, tombstones included).
+/// Every field is a pure count over already-persisted `SessionRecord.state`.
+/// Test: `aggregate_project_status_counts_by_state`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SessionStateCounts {
+    /// Count of sessions in [`ManagedSessionState::Provisioning`].
+    pub provisioning: usize,
+    /// Count of sessions in [`ManagedSessionState::Active`].
+    pub active: usize,
+    /// Count of sessions in [`ManagedSessionState::Stopped`].
+    pub stopped: usize,
+    /// Count of sessions in [`ManagedSessionState::Errored`].
+    pub errored: usize,
+    /// Count of sessions in [`ManagedSessionState::Decommissioned`] (tombstones).
+    pub decommissioned: usize,
+    /// Total session records bound to the project (sum of all five counts).
+    pub total: usize,
+}
+
+/// Boolean config-completeness flags for a project (DOC-35 §4.1).
+///
+/// Why: the aggregate view surfaces at-a-glance whether a project is fully
+/// configured for delegated `gh` operations without the consumer reading the
+/// full [`Project`] record. Every flag is a pure `Option::is_some()` check over
+/// already-persisted config — no validation, no network call, no `gh auth`
+/// probe (that mutating/side-effecting check belongs to the PATCH route, §4).
+/// What: one bool per config field that gates project automation. `jira_config`
+/// is intentionally absent until #2082/#2122 land its persisted field; per §4.1
+/// it will be added here additively as `jira_config_set` at that point.
+/// Test: `aggregate_project_status_config_flags`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectConfigFlags {
+    /// Whether [`Project::gh_user`] is set (preferred `gh` login, #2081).
+    pub gh_user_set: bool,
+    /// Whether [`Project::github`] (per-project `gh` identity binding, #2184) is set.
+    pub github_binding_set: bool,
+}
+
+/// Deterministic rollup of one project's status (`GET .../{name}/status`).
+///
+/// Why: the single response body for #2117 — the pure-rollup contract of
+/// DOC-35 §4.1. It is designed to extend additively: #2382 (Wave 2) adds
+/// `deliverables`/`milestones` histogram fields here once the §10 data model
+/// (#2378) lands, computed the same way over the same kind of already-persisted
+/// state. Adding serde-serialized fields is non-breaking for existing consumers,
+/// so no version bump or shape change is required.
+/// What: the project identity (`project_name`/`repo_url`), the session-state
+/// histogram, the most-recent `last_activity_at` across the project's sessions,
+/// and the config-completeness flags. Every field is a pure function of the
+/// inputs — zero inference, zero LLM, single-project scope.
+/// Test: `aggregate_project_status_counts_by_state`,
+/// `aggregate_project_status_max_activity`, `aggregate_project_status_config_flags`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectStatusResponse {
+    /// Registered project name (the request path key).
+    pub project_name: String,
+    /// Repository URL for the project.
+    pub repo_url: String,
+    /// Per-state session histogram.
+    pub sessions: SessionStateCounts,
+    /// Most recent `last_activity_at` across the project's sessions, if any.
+    ///
+    /// `None` when no bound session has ever recorded activity.
+    pub last_activity_at: Option<DateTime<Utc>>,
+    /// Config-completeness flags.
+    pub config: ProjectConfigFlags,
+}
+
+/// Compute the deterministic status rollup for a project.
+///
+/// Why: the pure core of #2117, extracted from the handler so the rollup logic
+/// is unit-testable with hand-constructed inputs and so its determinism is
+/// self-evident — it takes owned/borrowed state, performs only counting and a
+/// `max`, and does zero I/O, no LLM call, and no cross-project reasoning
+/// (DOC-35 §11 boundary contract). Given the same `project` and `all_sessions`
+/// it returns a byte-identical [`ProjectStatusResponse`] every time.
+/// What: filters `all_sessions` to those bound to `project` (reusing the shared
+/// [`fleet_by_project`] URL-matching so binding stays consistent with the
+/// `/fleet` route), tallies a per-state histogram, takes the maximum
+/// `last_activity_at` across the bound sessions, and reads the two config flags
+/// off the record. Sessions with no `repo_url` (or an unmatched one) are omitted,
+/// exactly as `fleet_by_project` specifies.
+/// Test: `aggregate_project_status_counts_by_state`,
+/// `aggregate_project_status_max_activity`, `aggregate_project_status_config_flags`,
+/// `aggregate_project_status_is_deterministic`.
+pub fn aggregate_project_status(
+    project: &Project,
+    all_sessions: &[SessionRecord],
+) -> ProjectStatusResponse {
+    // Reuse the shared fleet grouping so "which sessions belong to this project"
+    // is answered identically here and by the /fleet route. Passing a
+    // single-project slice yields exactly one ProjectFleet.
+    let bound: Vec<SessionRecord> = fleet_by_project(all_sessions, std::slice::from_ref(project))
+        .into_iter()
+        .next()
+        .map(|fleet| fleet.sessions)
+        .unwrap_or_default();
+
+    let mut counts = SessionStateCounts {
+        provisioning: 0,
+        active: 0,
+        stopped: 0,
+        errored: 0,
+        decommissioned: 0,
+        total: 0,
+    };
+    let mut last_activity_at: Option<DateTime<Utc>> = None;
+
+    for session in &bound {
+        match session.state {
+            ManagedSessionState::Provisioning => counts.provisioning += 1,
+            ManagedSessionState::Active => counts.active += 1,
+            ManagedSessionState::Stopped => counts.stopped += 1,
+            ManagedSessionState::Errored => counts.errored += 1,
+            ManagedSessionState::Decommissioned => counts.decommissioned += 1,
+        }
+        counts.total += 1;
+
+        if let Some(ts) = session.last_activity_at {
+            last_activity_at = Some(match last_activity_at {
+                Some(current) => current.max(ts),
+                None => ts,
+            });
+        }
+    }
+
+    ProjectStatusResponse {
+        project_name: project.name.clone(),
+        repo_url: project.repo_url.clone(),
+        sessions: counts,
+        last_activity_at,
+        config: ProjectConfigFlags {
+            gh_user_set: project.gh_user.is_some(),
+            github_binding_set: project.github.is_some(),
+        },
+    }
+}
+
+/// GET /api/v1/projects/{name}/status — deterministic project status rollup.
+///
+/// Why: exposes [`aggregate_project_status`] over HTTP so the deterministic CLI
+/// (#2115) and TUI (#2118) — and any other consumer, including #2109 per the
+/// §11 "expose data over MCP/HTTP for ANY consumer to read" row — can read the
+/// rollup without an MCP client. The handler is a thin composition over
+/// `ProjectRegistry::get` + `SessionManager::list`; it adds no persistence and
+/// no reasoning.
+/// What: looks up the named project (404 if unregistered), lists all live
+/// session records, and returns `Json(aggregate_project_status(..))`. A project
+/// store read error (other than not-found) degrades to 500 with a logged warning
+/// rather than a panic — the library never `unwrap`s a store result.
+/// Test: `project_status_route_rollup`, `project_status_route_unknown_project`
+/// in `tests/session_manager_mvp.rs`.
+pub async fn project_status_route(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(name): AxumPath<String>,
+) -> impl IntoResponse {
+    let registry = state.project_registry().await;
+    let project = match registry.get(&name).await {
+        Ok(project) => project,
+        Err(ProjectStoreError::NotFound(_)) => {
+            return (StatusCode::NOT_FOUND, format!("project {name} not found")).into_response();
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                project = %name,
+                "project_status_route: project registry read failed"
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "project registry read failed".to_string(),
+            )
+                .into_response();
+        }
+    };
+
+    let mgr = state.session_manager().await;
+    let sessions = mgr.list().await;
+
+    Json(aggregate_project_status(&project, &sessions)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_manager::{ManagedSessionId, SessionRecord};
+    use chrono::TimeZone;
+    use std::path::PathBuf;
+
+    /// Build a minimal [`Project`] fixture with the given name/url and no config.
+    fn project(name: &str, repo_url: &str) -> Project {
+        Project {
+            name: name.to_string(),
+            repo_url: repo_url.to_string(),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        }
+    }
+
+    /// Build a [`SessionRecord`] fixture in `state` bound to `repo_url`, with an
+    /// optional `last_activity_at`.
+    fn session(
+        state: ManagedSessionState,
+        repo_url: Option<&str>,
+        activity: Option<DateTime<Utc>>,
+    ) -> SessionRecord {
+        SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: "tm-test".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            task: "fixture".to_string(),
+            state,
+            created_at: Utc::now(),
+            last_activity_at: activity,
+            workspace_path: None,
+            repo_url: repo_url.map(str::to_string),
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: false,
+            workspace_owned: false,
+            source_id: None,
+            claude_session_id: None,
+            scrollback_path: None,
+            last_cwd: None,
+        }
+    }
+
+    /// The histogram counts each state exactly once and `total` is their sum;
+    /// sessions bound to a DIFFERENT repo (or none) are excluded.
+    #[test]
+    fn aggregate_project_status_counts_by_state() {
+        let url = "https://github.com/acme/widget";
+        let proj = project("widget", url);
+        let sessions = vec![
+            session(ManagedSessionState::Active, Some(url), None),
+            session(ManagedSessionState::Active, Some(url), None),
+            session(ManagedSessionState::Stopped, Some(url), None),
+            session(ManagedSessionState::Errored, Some(url), None),
+            session(ManagedSessionState::Provisioning, Some(url), None),
+            session(ManagedSessionState::Decommissioned, Some(url), None),
+            // Bound to a different project — must be excluded.
+            session(
+                ManagedSessionState::Active,
+                Some("https://github.com/acme/other"),
+                None,
+            ),
+            // No repo_url — must be excluded.
+            session(ManagedSessionState::Active, None, None),
+        ];
+
+        let out = aggregate_project_status(&proj, &sessions);
+
+        assert_eq!(out.sessions.active, 2);
+        assert_eq!(out.sessions.stopped, 1);
+        assert_eq!(out.sessions.errored, 1);
+        assert_eq!(out.sessions.provisioning, 1);
+        assert_eq!(out.sessions.decommissioned, 1);
+        assert_eq!(out.sessions.total, 6, "only the six bound sessions count");
+        assert_eq!(out.project_name, "widget");
+        assert_eq!(out.repo_url, url);
+    }
+
+    /// `last_activity_at` is the maximum across bound sessions; sessions with no
+    /// activity contribute nothing, and an all-`None` set yields `None`.
+    #[test]
+    fn aggregate_project_status_max_activity() {
+        let url = "https://github.com/acme/widget";
+        let proj = project("widget", url);
+        let t_old = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let t_new = Utc.with_ymd_and_hms(2026, 7, 10, 12, 0, 0).unwrap();
+
+        let out = aggregate_project_status(
+            &proj,
+            &[
+                session(ManagedSessionState::Stopped, Some(url), Some(t_old)),
+                session(ManagedSessionState::Active, Some(url), Some(t_new)),
+                session(ManagedSessionState::Active, Some(url), None),
+            ],
+        );
+        assert_eq!(out.last_activity_at, Some(t_new));
+
+        // No activity anywhere → None.
+        let none = aggregate_project_status(
+            &proj,
+            &[session(ManagedSessionState::Provisioning, Some(url), None)],
+        );
+        assert_eq!(none.last_activity_at, None);
+
+        // No bound sessions at all → all zero, None activity.
+        let empty = aggregate_project_status(&proj, &[]);
+        assert_eq!(empty.sessions.total, 0);
+        assert_eq!(empty.last_activity_at, None);
+    }
+
+    /// Config flags are pure `is_some()` reads over the project record.
+    #[test]
+    fn aggregate_project_status_config_flags() {
+        let url = "https://github.com/acme/widget";
+        let mut proj = project("widget", url);
+        let bare = aggregate_project_status(&proj, &[]);
+        assert!(!bare.config.gh_user_set);
+        assert!(!bare.config.github_binding_set);
+
+        proj.gh_user = Some("acme-bot".to_string());
+        let with_user = aggregate_project_status(&proj, &[]);
+        assert!(with_user.config.gh_user_set);
+        assert!(!with_user.config.github_binding_set);
+    }
+
+    /// Re-running the rollup with unchanged inputs yields identical output —
+    /// the DOC-35 §11 determinism test made executable.
+    #[test]
+    fn aggregate_project_status_is_deterministic() {
+        let url = "https://github.com/acme/widget";
+        let proj = project("widget", url);
+        let t = Utc.with_ymd_and_hms(2026, 7, 10, 12, 0, 0).unwrap();
+        let sessions = vec![
+            session(ManagedSessionState::Active, Some(url), Some(t)),
+            session(ManagedSessionState::Errored, Some(url), None),
+        ];
+        let a = aggregate_project_status(&proj, &sessions);
+        let b = aggregate_project_status(&proj, &sessions);
+        assert_eq!(a, b);
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_status.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_status.rs
@@ -13,8 +13,9 @@
 //! function [`aggregate_project_status`], and the axum handler
 //! [`project_status_route`] for `GET /api/v1/projects/{name}/status`.
 //! Test: `aggregate_project_status_*` unit tests in `tests()` below (pure-rollup
-//! contract) and `project_status_route_*` HTTP handler tests in
-//! `tests/session_manager_mvp.rs`.
+//! contract) and `status_route_returns_deterministic_rollup` /
+//! `status_route_unknown_project_is_404` HTTP handler tests in
+//! `tests/project_status_route.rs`.
 
 use std::sync::Arc;
 
@@ -189,8 +190,8 @@ pub fn aggregate_project_status(
 /// session records, and returns `Json(aggregate_project_status(..))`. A project
 /// store read error (other than not-found) degrades to 500 with a logged warning
 /// rather than a panic — the library never `unwrap`s a store result.
-/// Test: `project_status_route_rollup`, `project_status_route_unknown_project`
-/// in `tests/session_manager_mvp.rs`.
+/// Test: `status_route_returns_deterministic_rollup`,
+/// `status_route_unknown_project_is_404` in `tests/project_status_route.rs`.
 pub async fn project_status_route(
     State(state): State<Arc<DaemonState>>,
     AxumPath(name): AxumPath<String>,

--- a/crates/trusty-mpm/tests/project_status_route.rs
+++ b/crates/trusty-mpm/tests/project_status_route.rs
@@ -1,0 +1,147 @@
+//! HTTP-level integration tests for the deterministic project status-aggregation
+//! endpoint `GET /api/v1/projects/{name}/status` (#2117, DOC-35 §4.1).
+//!
+//! Why: the in-crate `daemon::managed_routes::project_status::tests` drive the
+//! pure `aggregate_project_status` rollup directly; this file instead binds the
+//! REAL `api::router` on a loopback port and drives the route with `reqwest`, so
+//! it is the literal proof that the endpoint is reachable over the daemon HTTP
+//! API (the deterministic CLI #2115 and TUI #2118 will call it exactly this way).
+//! Mirrors the real-network harness in `tests/proxy_routes.rs` (axum::serve on an
+//! ephemeral port + reqwest).
+//! What: registers one project, seeds a mixed-state set of managed sessions bound
+//! to it (plus one bound to a DIFFERENT project, which must be excluded), serves
+//! the router, and asserts the JSON rollup body — per-state counts, `total`, and
+//! config-completeness flags — plus the 404 path for an unregistered project.
+//! Test: this file IS the test; run with
+//! `cargo test -p trusty-mpm --test project_status_route`.
+
+use std::future::IntoFuture;
+use std::sync::Arc;
+
+use trusty_mpm::daemon::{api, state::DaemonState};
+use trusty_mpm::project::Project;
+use trusty_mpm::runtime::RuntimeKind;
+use trusty_mpm::session_manager::ManagedSessionId;
+
+/// Register a project fixture on the given daemon state.
+async fn register_project(
+    state: &Arc<DaemonState>,
+    name: &str,
+    repo_url: &str,
+    gh_user: Option<&str>,
+) {
+    state
+        .project_registry()
+        .await
+        .register(Project {
+            name: name.to_string(),
+            repo_url: repo_url.to_string(),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: gh_user.map(str::to_string),
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        })
+        .await
+        .expect("register project");
+}
+
+/// Seed a managed session bound to `repo_url`; returns its id.
+///
+/// `create_with_id` starts the session in `Provisioning`; the caller can then
+/// transition it (e.g. via `mark_errored`) to build a mixed-state fixture with
+/// no real tmux side effects (the isolated state uses `FakeNoopTmuxDriver`).
+async fn seed_session(state: &Arc<DaemonState>, repo_url: &str, task: &str) -> ManagedSessionId {
+    let id = ManagedSessionId::new();
+    state
+        .session_manager()
+        .await
+        .create_with_id(
+            id,
+            task.to_string(),
+            None,
+            None,
+            None,
+            Some(repo_url.to_string()),
+            Some("main".to_string()),
+            RuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session");
+    id
+}
+
+/// The status endpoint returns the deterministic rollup for a named project over
+/// real HTTP: per-state counts, `total`, config flags, and exclusion of sessions
+/// bound to other projects.
+#[tokio::test]
+async fn status_route_returns_deterministic_rollup() {
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+
+    let url = "https://github.com/acme/widget";
+    register_project(&state, "widget", url, Some("acme-bot")).await;
+    register_project(&state, "other", "https://github.com/acme/other", None).await;
+
+    // Two Provisioning + one Errored bound to `widget`.
+    seed_session(&state, url, "prov-a").await;
+    seed_session(&state, url, "prov-b").await;
+    let errored = seed_session(&state, url, "will-error").await;
+    state
+        .session_manager()
+        .await
+        .mark_errored(&errored, "boom")
+        .await
+        .expect("mark errored");
+    // One bound to a DIFFERENT project — must be excluded from widget's rollup.
+    seed_session(&state, "https://github.com/acme/other", "other-proj").await;
+
+    let router = api::router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/api/v1/projects/widget/status"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    assert_eq!(body["project_name"], "widget");
+    assert_eq!(body["repo_url"], url);
+    assert_eq!(body["sessions"]["provisioning"], 2);
+    assert_eq!(body["sessions"]["errored"], 1);
+    assert_eq!(body["sessions"]["active"], 0);
+    assert_eq!(
+        body["sessions"]["total"], 3,
+        "only the three widget-bound sessions count, not the `other` session: {body}"
+    );
+    assert_eq!(body["config"]["gh_user_set"], true);
+    assert_eq!(body["config"]["github_binding_set"], false);
+}
+
+/// An unregistered project name yields 404 (not a 500 or an empty rollup).
+#[tokio::test]
+async fn status_route_unknown_project_is_404() {
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+
+    let router = api::router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/api/v1/projects/nope/status"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

Implements **#2117** (epic #2108, DOC-35 §4.1): a new daemon HTTP endpoint

```
GET /api/v1/projects/{name}/status
```

returning a **pure, deterministic rollup** for one named project:

- per-`ManagedSessionState` histogram — `provisioning` / `active` / `stopped` / `errored` / `decommissioned` + `total`
- `last_activity_at` — the `max` across the project's sessions (`None` if none)
- `config` completeness flags — `gh_user_set`, `github_binding_set` (pure `Option::is_some()` reads)

Thin composition over `ProjectRegistry::get` + `SessionManager::list`, reusing the shared `fleet_by_project` URL-matching so session→project binding is identical to the `/fleet` route. **No new persistence.**

### Response schema

```jsonc
{
  "project_name": "widget",
  "repo_url": "https://github.com/acme/widget",
  "sessions": {
    "provisioning": 2, "active": 0, "stopped": 1,
    "errored": 1, "decommissioned": 0, "total": 4
  },
  "last_activity_at": "2026-07-10T12:00:00Z",   // or null
  "config": { "gh_user_set": true, "github_binding_set": false }
}
```

`404` for an unregistered project; `500` (logged, no panic) on a project-store read error.

## §11 boundary compliance — inference-free by construction

Per DOC-35 §11 (the L3-substrate boundary with `tm manager` #2109), this endpoint is a **pure deterministic rollup**:

- **Zero LLM / inference.** The pure core `aggregate_project_status(&Project, &[SessionRecord])` performs only counting and a `max` over already-materialized fields. No OpenRouter dependency, no classifier, no `gh auth` probe (that mutating check stays on the PATCH route).
- **Single-project scope.** Each call is scoped to one `{name}` — no cross-project synthesis.
- **Reports state, never generates it.** It surfaces already-computed `SessionRecord.state` / `last_activity_at` / config flags as-is; it does not summarize *what* a session is doing (that is `activity.rs`'s field) and makes no state-transition decisions.
- **Determinism is executable:** `aggregate_project_status_is_deterministic` asserts identical inputs → byte-identical output — §11's "which epic does this belong to" test made a unit test.

The `ProjectStatusResponse` struct is designed to **extend additively** for #2382 (Wave 2 Deliverable/Milestone histograms, after #2378 lands) — serde-serialized field additions are non-breaking for existing consumers.

## Scope note

API layer only, per the ticket. The `tm projects status` CLI verb is #2115 (Wave 2); no MCP tool is added because §4/§4.1 specify HTTP only for this ticket (any consumer, incl. #2109, reads it over HTTP per §11).

## File-overlap flags (concurrent siblings feat-2378 / feat-2116)

- `crates/trusty-mpm/src/daemon/api.rs` and `.../managed_routes/mod.rs` — I made **additive-only** edits (one `.route(...)` line + one `mod` decl + one re-export block). **feat-2378** (Deliverable/Milestone CRUD API, #2378) will plausibly add its own routes/exports to these same two files. Any conflict is trivial and mechanical (adjacent additive lines).
- I created **no** deliverable/milestone store and touched **no** CLI arg tree, so there is no overlap with feat-2378's data model or feat-2116's `tm session`→`tm sessions` rename.

## Gate evidence (raw)

- `cargo build --workspace` → `Finished ... in 2m 03s` (exit 0)
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0 (the `tga` MSRV note + multi-target/pnpm notices are pre-existing environmental warnings, none in `trusty-mpm`)
- `cargo fmt --check` → clean
- `bash scripts/check_line_cap.sh` → `0 allowlisted, 0 violations — OK`
- `cargo test -p trusty-mpm` → `test result: ok. 2663 passed; 0 failed; 5 ignored` (lib) incl. the 4 new unit tests + `tests/project_status_route.rs` `2 passed; 0 failed`. **0 failures across all trusty-mpm test binaries.**
- `cargo test --workspace` → one flaky failure: `services::manifest::tests::manifest_expands_tilde`. **Pre-existing, unrelated:** it calls `dirs::home_dir()` and asserts the default `$HOME`; a sibling trusty-mpm test mutates `HOME` and, under parallel scheduling, contaminates it (observed `/var/folders/.../T/.tmp…` vs `/Users/masa`). It **passes in isolation** and **passed in the full `-p trusty-mpm` run that includes my new tests**. My files mutate no env vars and touch no manifest code.

Closes #2117

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools