### PR TITLE
feat(trusty-mpm): common tmux entry point + generous scrollback

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -69,9 +69,12 @@ impl Drop for LaunchSessionGuard {
         if !self.armed {
             return;
         }
-        let _ = std::process::Command::new("tmux")
-            .args(["kill-session", "-t", &self.name])
-            .output();
+        // #2398 architecture consolidation: route through the crate's single
+        // tmux entry point instead of shelling out independently.
+        let _ =
+            trusty_mpm::core::tmux::run_tmux(&trusty_mpm::core::tmux::TmuxCommand::KillSession {
+                name: self.name.clone(),
+            });
     }
 }
 
@@ -326,16 +329,14 @@ pub(crate) async fn launch(
     let _ = instructions_path;
 
     // 12. Create a detached tmux session rooted at the MANAGED clone directory.
-    let new_session = std::process::Command::new("tmux")
-        .args([
-            "new-session",
-            "-d",
-            "-s",
-            &tmux_name,
-            "-c",
-            &managed_workdir,
-        ])
-        .status();
+    //     #2398: routes through `core::tmux::create_managed_session`, the
+    //     crate's single session-creation choke point — this is what applies
+    //     the configured scrollback/mouse ergonomics BEFORE the pane exists
+    //     (a bare `tmux new-session` here would silently bypass them, the
+    //     exact QA-caught regression this consolidation closes).
+    let new_session =
+        trusty_mpm::core::tmux::create_managed_session(None, &tmux_name, Some(&managed_workdir))
+            .map(|output| output.status);
     if !matches!(new_session, Ok(s) if s.success()) {
         anyhow::bail!("failed to create tmux session {tmux_name} in {managed_workdir}");
     }
@@ -346,9 +347,12 @@ pub(crate) async fn launch(
     let mut session_guard = LaunchSessionGuard::new(&tmux_name);
 
     // 13. Start `claude` inside the tmux session.
-    let send = std::process::Command::new("tmux")
-        .args(["send-keys", "-t", &tmux_name, &claude_cmd, "Enter"])
-        .status();
+    let send = trusty_mpm::core::tmux::send_line(
+        None,
+        &trusty_mpm::core::tmux::TmuxTarget::session(&tmux_name),
+        &claude_cmd,
+    )
+    .map(|output| output.status);
     if !matches!(send, Ok(s) if s.success()) {
         anyhow::bail!("tmux session {tmux_name} created but failed to start claude");
     }
@@ -515,11 +519,14 @@ pub(crate) async fn connect(
     // 4. Create the tmux host idempotently. `new-session -A` attaches to an
     //    existing session and creates a detached one (`-d`) otherwise; the
     //    `has-session` probe tells us which happened so `claude` is started
-    //    only for a freshly-created session.
+    //    only for a freshly-created session. #2398: routes through
+    //    `core::tmux::create_managed_session`, the crate's single session-
+    //    creation choke point, so the configured scrollback/mouse ergonomics
+    //    are applied before the pane exists.
     let already_running = tmux_has_session(&tmux_name);
-    let new_session = std::process::Command::new("tmux")
-        .args(["new-session", "-A", "-d", "-s", &tmux_name, "-c", &workdir])
-        .status();
+    let new_session =
+        trusty_mpm::core::tmux::create_managed_session(None, &tmux_name, Some(&workdir))
+            .map(|output| output.status);
     if !matches!(new_session, Ok(s) if s.success()) {
         anyhow::bail!("failed to create tmux session {tmux_name} in {workdir}");
     }
@@ -535,9 +542,12 @@ pub(crate) async fn connect(
     //    system-prompt injection plus the shared isolation flags (#2230).
     if !already_running {
         let claude_cmd = connect_claude_cmd(prompt_path.as_deref());
-        let send = std::process::Command::new("tmux")
-            .args(["send-keys", "-t", &tmux_name, &claude_cmd, "Enter"])
-            .status();
+        let send = trusty_mpm::core::tmux::send_line(
+            None,
+            &trusty_mpm::core::tmux::TmuxTarget::session(&tmux_name),
+            &claude_cmd,
+        )
+        .map(|output| output.status);
         if !matches!(send, Ok(s) if s.success()) {
             anyhow::bail!("tmux session {tmux_name} created but failed to start claude");
         }

--- a/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
@@ -181,25 +181,25 @@ async fn start_session_in_place(
     // The daemon only registers session state now — it no longer
     // spawns the tmux host (that caused session proliferation). The
     // CLI owns the actual launch: create a detached tmux session in
-    // the project directory and start `claude` in it.
+    // the project directory and start `claude` in it. #2398: routes through
+    // `core::tmux::create_managed_session`, the crate's single session-
+    // creation choke point, so the configured scrollback/mouse ergonomics
+    // are applied before the pane exists.
     let workdir = path.to_string_lossy().to_string();
-    let new_session = std::process::Command::new("tmux")
-        .args(["new-session", "-d", "-s", &body.name, "-c", &workdir])
-        .status();
+    let new_session =
+        trusty_mpm::core::tmux::create_managed_session(None, &body.name, Some(&workdir))
+            .map(|output| output.status);
     match new_session {
         Ok(status) if status.success() => {
-            let send = std::process::Command::new("tmux")
-                .args([
-                    "send-keys",
-                    "-t",
-                    &body.name,
-                    &format!(
-                        "claude {}",
-                        trusty_mpm::core::model_inject::PERMISSION_MODE_FLAG
-                    ),
-                    "Enter",
-                ])
-                .status();
+            let send = trusty_mpm::core::tmux::send_line(
+                None,
+                &trusty_mpm::core::tmux::TmuxTarget::session(&body.name),
+                &format!(
+                    "claude {}",
+                    trusty_mpm::core::model_inject::PERMISSION_MODE_FLAG
+                ),
+            )
+            .map(|output| output.status);
             match send {
                 Ok(s) if s.success() => {
                     println!("started session {} (tmux + claude)", body.name);

--- a/crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs
@@ -104,7 +104,15 @@ pub(crate) fn tmux_attach(name: &str) -> anyhow::Result<()> {
     } else {
         eprintln!("tm: attaching to session '{name}'");
     }
-    let status = std::process::Command::new("tmux")
+    // #2398: resolves the binary through the crate's shared resolver rather
+    // than a bare "tmux" lookup — this is the "attach path" migration (the
+    // interactive attach-session/switch-client spawn itself inherits this
+    // process's stdio via `.status()`, which does not fit
+    // `core::tmux::run_tmux`'s output-capturing `.output()` shape, so only
+    // binary resolution is unified here; see `core::tmux`'s module doc for
+    // the full scope note).
+    let tmux_bin = trusty_mpm::core::tmux::resolve_tmux_binary_or_bare();
+    let status = std::process::Command::new(&tmux_bin)
         .args(&argv)
         .status()
         .context("failed to invoke tmux")?;

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs
@@ -441,10 +441,12 @@ pub(crate) fn normalize_workdir(workdir: &str) -> String {
 /// What: runs `tmux has-session -t <name>` and returns true on exit code 0.
 /// Test: covered indirectly by the launch reconnect integration path.
 pub(crate) fn tmux_has_session(name: &str) -> bool {
+    // #2398 architecture consolidation: routes through the crate's single
+    // tmux entry point instead of shelling out independently.
     matches!(
-        std::process::Command::new("tmux")
-            .args(["has-session", "-t", name])
-            .status(),
-        Ok(status) if status.success()
+        trusty_mpm::core::tmux::run_tmux(&trusty_mpm::core::tmux::TmuxCommand::HasSession {
+            name: name.to_string(),
+        }),
+        Ok(output) if output.status.success()
     )
 }

--- a/crates/trusty-mpm/src/client/http_client/session_connect.rs
+++ b/crates/trusty-mpm/src/client/http_client/session_connect.rs
@@ -94,14 +94,22 @@ impl DaemonClient {
             }
         };
 
-        let new_session = std::process::Command::new("tmux")
-            .args(["new-session", "-d", "-s", &body.name, "-c", workdir])
-            .status();
+        // #2398: routes through `core::tmux::create_managed_session`, the
+        // crate's single session-creation choke point, so the configured
+        // scrollback/mouse ergonomics are applied before the pane exists (a
+        // bare `tmux new-session` here would silently bypass them — the
+        // exact QA-caught regression this consolidation closes).
+        let new_session =
+            crate::core::tmux::create_managed_session(None, &body.name, Some(workdir))
+                .map(|output| output.status);
         match new_session {
             Ok(status) if status.success() => {
-                let send = std::process::Command::new("tmux")
-                    .args(["send-keys", "-t", &body.name, &claude_cmd, "Enter"])
-                    .status();
+                let send = crate::core::tmux::send_line(
+                    None,
+                    &crate::core::tmux::TmuxTarget::session(&body.name),
+                    &claude_cmd,
+                )
+                .map(|output| output.status);
                 if !matches!(send, Ok(s) if s.success()) {
                     return Err(anyhow::anyhow!(
                         "tmux session {} created but failed to start claude",
@@ -184,21 +192,29 @@ impl DaemonClient {
         // it already exists and creates it (detached, `-d`) otherwise. The
         // `has-session` probe distinguishes the two so `claude` is started only
         // for a freshly-created session — an already-running one is left alone.
-        let already_running = std::process::Command::new("tmux")
-            .args(["has-session", "-t", &body.name])
-            .status()
-            .map(|s| s.success())
+        // #2398: routes through the crate's single tmux entry point.
+        let already_running =
+            crate::core::tmux::run_tmux(&crate::core::tmux::TmuxCommand::HasSession {
+                name: body.name.clone(),
+            })
+            .map(|output| output.status.success())
             .unwrap_or(false);
 
-        let new_session = std::process::Command::new("tmux")
-            .args(["new-session", "-A", "-d", "-s", &body.name, "-c", workdir])
-            .status();
+        // #2398: routes through `core::tmux::create_managed_session`, the
+        // crate's single session-creation choke point, so the configured
+        // scrollback/mouse ergonomics are applied before the pane exists.
+        let new_session =
+            crate::core::tmux::create_managed_session(None, &body.name, Some(workdir))
+                .map(|output| output.status);
         match new_session {
             Ok(status) if status.success() => {
                 if !already_running {
-                    let send = std::process::Command::new("tmux")
-                        .args(["send-keys", "-t", &body.name, &claude_cmd, "Enter"])
-                        .status();
+                    let send = crate::core::tmux::send_line(
+                        None,
+                        &crate::core::tmux::TmuxTarget::session(&body.name),
+                        &claude_cmd,
+                    )
+                    .map(|output| output.status);
                     if !matches!(send, Ok(s) if s.success()) {
                         return Err(anyhow::anyhow!(
                             "tmux session {} created but failed to start claude",

--- a/crates/trusty-mpm/src/control/backend/tmux.rs
+++ b/crates/trusty-mpm/src/control/backend/tmux.rs
@@ -17,13 +17,12 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::Utc;
-use std::process::Command;
 use tokio::time::Duration;
 use tracing::{debug, warn};
 
 use crate::control::event::SessionEvent;
 use crate::control::id::ControlSessionId;
-use crate::core::tmux::{TmuxCommand, TmuxTarget, tmux_argv};
+use crate::core::tmux::TmuxTarget;
 use crate::daemon::tmux::TmuxDriver;
 
 use super::{SessionBackend, SessionInput};
@@ -135,28 +134,6 @@ impl TmuxBackend {
             last_pane_content: String::new(),
         })
     }
-
-    /// Run a raw tmux command and return its stdout as a `String`.
-    ///
-    /// Why: the `TmuxDriver` wraps synchronous `std::process::Command` calls;
-    /// calling them from async context is acceptable here because they are
-    /// short-lived (< 1s) shell invocations. For Phase 1 this avoids
-    /// introducing `tokio::task::spawn_blocking` complexity.
-    /// What: invokes `tmux <argv>` via `std::process::Command::output()`,
-    /// returns stdout or an error.
-    /// Test: covered transitively by `recv()` unit tests.
-    fn run_tmux_cmd(&self, cmd: &TmuxCommand) -> Result<String> {
-        let argv = tmux_argv(cmd);
-        let out = Command::new("tmux")
-            .args(&argv)
-            .output()
-            .with_context(|| format!("failed to run tmux {}", argv.first().map_or("", |s| s)))?;
-        if !out.status.success() {
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            anyhow::bail!("tmux command failed: {stderr}");
-        }
-        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
-    }
 }
 
 #[async_trait]
@@ -181,19 +158,25 @@ impl SessionBackend for TmuxBackend {
     /// Why: the actor polls `recv()` to pick up new pane output and broadcast
     /// it to observers. Without a park point the actor's `select!` loop would
     /// call `capture-pane` in a tight spin at ~100% CPU when the pane is idle.
-    /// What: runs `capture-pane -p -S -<lines>`. If the pane is empty OR its
-    /// content is unchanged since the last call, parks for `TMUX_POLL_INTERVAL_MS`
+    /// What: runs `capture-pane -p -S -<lines>` via `TmuxDriver::capture`
+    /// (#2398 architecture consolidation — this used to shell out to a bare
+    /// `tmux` independently via a private `run_tmux_cmd` helper; reusing
+    /// `TmuxDriver`'s own public `capture` method, which already routes
+    /// through the crate's shared tmux entry point, removed that duplicate
+    /// implementation entirely). If the pane is empty OR its content is
+    /// unchanged since the last call, parks for `TMUX_POLL_INTERVAL_MS`
     /// before returning an empty batch — giving the executor a chance to service
     /// other tasks. Only emits an `Output` event when the pane content has
     /// actually changed (diff vs `last_pane_content`). Returns `None` when the
     /// tmux session no longer exists (treating it as a clean exit).
     /// Test: `tmux_recv_parks_when_idle`.
     async fn recv(&mut self) -> Option<Result<Vec<SessionEvent>>> {
-        let cmd = TmuxCommand::CapturePane {
-            target: TmuxTarget::session(&self.tmux_name),
-            lines: Some(self.capture_lines),
-        };
-        match self.run_tmux_cmd(&cmd) {
+        let target = TmuxTarget::session(&self.tmux_name);
+        match self
+            .driver
+            .capture(&target, Some(self.capture_lines))
+            .with_context(|| format!("capture-pane for tmux session {} failed", self.tmux_name))
+        {
             Ok(output) => {
                 let is_empty = output.trim().is_empty();
                 let is_unchanged = !is_empty && output == self.last_pane_content;

--- a/crates/trusty-mpm/src/core/tmux.rs
+++ b/crates/trusty-mpm/src/core/tmux.rs
@@ -1,16 +1,58 @@
-//! tmux session-control primitives.
+//! tmux session-control primitives AND the crate's single tmux-spawning
+//! entry point (#2398 architecture consolidation).
 //!
 //! Why: trusty-mpm hosts each Claude Code session inside a named tmux session
 //! (the primary control model — see `docs/research/session-control-models.md`).
 //! The patterns here are distilled from `ai-commander`'s `commander-tmux` crate
 //! and `open-mpm`'s `tm` module: create named detached sessions, send keystrokes
-//! with `send-keys`, and capture pane output. Keeping the command-builder logic
-//! in `core` (pure, no process spawning) makes it unit-testable; the daemon
-//! owns the actual `std::process::Command` execution.
-//! What: `TmuxTarget` (session\[:pane\] addressing), `TmuxCommand` (a typed tmux
-//! sub-command), and `tmux_argv` (renders a command to an argv vector).
+//! with `send-keys`, and capture pane output. `TmuxTarget`/`TmuxCommand`/
+//! `tmux_argv` stay PURE (no process spawning) so argv construction is
+//! unit-testable without a live tmux server.
+//!
+//! Originally this module was argv-construction only, with each of the
+//! daemon (`daemon::tmux::TmuxDriver`), the CLI (`bin/tm`'s launch/connect/
+//! session-start commands), the TUI client (`client::http_client`), and the
+//! control-plane backend (`control::backend::tmux`) independently spawning
+//! `std::process::Command::new("tmux")`. That let FIVE call sites bypass the
+//! #2398 scrollback/mouse ergonomics entirely (a QA-caught regression) simply
+//! by not knowing about `daemon::tmux::TmuxDriver::create_session`. Per Bob's
+//! architecture directive, this module now ALSO owns the actual process
+//! spawning for output-capturing tmux commands
+//! ([`run_tmux_with_bin`]/[`run_tmux`]) and the single choke point for
+//! creating a session with ergonomics applied first
+//! ([`create_managed_session`]) — every session-creating call site in the
+//! crate routes through it, so nothing can bypass the scrollback/mouse
+//! options again. [`daemon::tmux::TmuxDriver`](crate::daemon::tmux::TmuxDriver)
+//! wraps [`run_tmux_with_bin`] rather than spawning independently.
+//!
+//! Scope note (#2398 follow-up filed for stragglers): a handful of read-only
+//! probes — `tmux display-message -p '#S'` (current-session-name lookups in
+//! `bin/tm/commands/tmux_attach.rs` and `bin/tm/commands/statusline/
+//! branch.rs`), `tmux show-environment` (`bin/tm/commands/guided_inplace.rs`),
+//! and `tmux display-message -t <s> -p '#{pane_pid}'`
+//! (`core::process::tmux_pane_pid`) — still shell out directly. They are
+//! read-only queries against an EXISTING session, not session-creation, so
+//! they cannot bypass the scrollback/mouse ergonomics; migrating them was
+//! judged out of scope for this PR (no `TmuxCommand` variant models
+//! `display-message`/`show-environment` yet) to keep the diff reviewable.
+//! `bin/tm/commands/tmux_attach.rs::tmux_attach` (the actual `attach-session`/
+//! `switch-client` spawn) DOES route its binary resolution through
+//! [`resolve_tmux_binary_or_bare`] even though its interactive,
+//! stdio-inheriting `.status()` call shape does not fit [`run_tmux`]'s
+//! output-capturing signature.
+//! What: `TmuxTarget` (session\[:pane\] addressing), `TmuxCommand` (a typed
+//! tmux sub-command), `tmux_argv` (renders a command to an argv vector),
+//! [`resolve_tmux_binary`]/[`resolve_tmux_binary_or_bare`] (binary
+//! resolution), [`run_tmux_with_bin`]/[`run_tmux`] (the shared spawn
+//! primitive), and [`create_managed_session`] (the session-creation choke
+//! point with ergonomics baked in).
 //! Test: `cargo test -p trusty-mpm-core` asserts the rendered argv for each
-//! command shape, including literal vs. key-name `send-keys`.
+//! command shape, including literal vs. key-name `send-keys`; the spawning
+//! functions are exercised transitively by every call site (a live `tmux`
+//! binary is needed to observe real output, so those paths are covered by
+//! `#[ignore]` integration tests plus this module's own no-panic smoke test).
+
+use tracing::warn;
 
 use serde::{Deserialize, Serialize};
 
@@ -185,6 +227,205 @@ pub fn scrollback_option_commands(history_limit: u32, mouse: bool) -> Vec<TmuxCo
             value: if mouse { "on" } else { "off" }.to_string(),
         },
     ]
+}
+
+/// Resolve the `tmux` binary, preferring live `PATH` and falling back to
+/// well-known daemon dirs (Homebrew, user bins) via `trusty_common::bin_resolve`
+/// (#2398 architecture consolidation).
+///
+/// Why: a daemon process under launchd inherits a minimal `PATH` (#1298);
+/// resolving through the SAME helper for every caller (daemon, CLI, TUI
+/// client) — rather than a bare `"tmux"` PATH lookup for some callers and a
+/// well-known-dirs-aware lookup for others — means resolution behavior is
+/// identical everywhere, and there is exactly one place to fix if it ever
+/// needs to change.
+/// What: delegates to `trusty_common::bin_resolve::resolve_binary("tmux")`.
+/// Test: `resolve_tmux_binary_does_not_panic`.
+pub fn resolve_tmux_binary() -> Option<std::path::PathBuf> {
+    trusty_common::bin_resolve::resolve_binary("tmux")
+}
+
+/// [`resolve_tmux_binary`], falling back to the literal `"tmux"` (a plain
+/// `PATH` lookup at spawn time) when resolution itself comes up empty.
+///
+/// Why: callers that do not need [`daemon::tmux::TmuxDriver::discover`]'s
+/// (crate::daemon::tmux) fail-fast-if-truly-absent contract — the CLI and TUI
+/// client, which already surface their own "tmux command failed" error on the
+/// subsequent spawn — just want a best-effort binary name to run. Falling
+/// back to the bare string preserves their pre-#2398 behavior (trust the
+/// interactive shell's own `PATH`) as the worst case.
+/// What: returns the resolved absolute path as a `String` when found, else
+/// `"tmux"`.
+/// Test: `resolve_tmux_binary_or_bare_never_empty`.
+pub fn resolve_tmux_binary_or_bare() -> String {
+    resolve_tmux_binary()
+        .and_then(|p| p.to_str().map(str::to_string))
+        .unwrap_or_else(|| "tmux".to_string())
+}
+
+/// Run a typed tmux command against an EXPLICITLY resolved binary path,
+/// returning the raw process `Output` (#2398 architecture consolidation).
+///
+/// Why: this is the ONE place in the crate that actually spawns an
+/// output-capturing `tmux` child process — every caller
+/// ([`daemon::tmux::TmuxDriver`](crate::daemon::tmux::TmuxDriver), `bin/tm`'s
+/// CLI commands, `client::http_client`'s TUI-driving methods, and
+/// `control::backend::tmux::TmuxBackend`) routes through here so argv
+/// construction and process-spawning can never drift or be re-implemented ad
+/// hoc at a call site — the exact drift that let 5 CLI/client call sites
+/// bypass the scrollback/mouse ergonomics entirely (the QA finding this
+/// consolidation closes). Takes an explicit `tmux_bin` (rather than
+/// re-resolving on every call) so callers that already cache a resolved path
+/// — like `TmuxDriver`, which resolves once in `discover()` for its
+/// fail-fast-if-absent contract — do not pay repeated resolution cost.
+/// What: renders `cmd` via [`tmux_argv`] and runs
+/// `Command::new(tmux_bin).args(argv).output()`. Callers own interpreting the
+/// exit status / stderr — this function does not classify failures.
+/// Test: exercised transitively by every call site; a live `tmux` binary is
+/// required to observe real output, so this is covered by the `#[ignore]`
+/// integration tests rather than a hermetic unit test.
+pub fn run_tmux_with_bin(
+    tmux_bin: &str,
+    cmd: &TmuxCommand,
+) -> std::io::Result<std::process::Output> {
+    std::process::Command::new(tmux_bin)
+        .args(tmux_argv(cmd))
+        .output()
+}
+
+/// [`run_tmux_with_bin`], resolving the tmux binary via
+/// [`resolve_tmux_binary_or_bare`] first.
+///
+/// Why: the common-case convenience for callers (CLI, TUI client) that do not
+/// already hold a cached, resolved tmux path.
+/// What: resolves then delegates to [`run_tmux_with_bin`].
+/// Test: exercised transitively; see [`run_tmux_with_bin`].
+pub fn run_tmux(cmd: &TmuxCommand) -> std::io::Result<std::process::Output> {
+    run_tmux_with_bin(&resolve_tmux_binary_or_bare(), cmd)
+}
+
+/// Create a tmux session with the configured scrollback + mouse ergonomics
+/// applied FIRST — THE single choke point for "create a managed session"
+/// used by every session-creating call site in the crate (#2398 architecture
+/// consolidation).
+///
+/// Why: `history-limit` is captured into a pane's ring buffer AT CREATION
+/// TIME, so the scrollback/mouse `set-option -g` calls MUST run before
+/// `new-session` — see [`scrollback_option_commands`]. Baking both steps into
+/// one function (rather than asking every caller to remember "apply options,
+/// then create") is what makes it structurally impossible for a future call
+/// site to bypass the ergonomics again, which is exactly how the #2398 QA
+/// finding happened the first time (5 call sites independently shelled out to
+/// `tmux new-session`, none aware the daemon-side ergonomics existed).
+/// What: resolves the tmux binary (`tmux_bin` if given, else
+/// [`resolve_tmux_binary_or_bare`]), loads
+/// [`crate::core::trusty_tools_config::TrustyToolsConfig`] and resolves the
+/// `tmux:` section, best-effort applies each
+/// [`scrollback_option_commands`] entry via [`run_tmux_with_bin`] (a failure
+/// here is logged and does NOT block session creation — `set-option -g` is
+/// idempotent and virtually never fails on a tmux new enough to run
+/// trusty-mpm at all), then issues `new-session` and returns its raw
+/// `Output`. Callers classify success/failure from the returned `Output`
+/// exactly as they did before this consolidation (`output.status.success()`).
+/// Test: argv construction is covered by `scrollback_option_commands_*` and
+/// `new_session_argv`; config resolution by `core::trusty_tools_config`'s
+/// `tmux_options_*` tests. The live-process call itself needs a real `tmux`
+/// binary, so it is exercised transitively by every migrated call site
+/// (daemon `#[ignore]` integration tests; CLI/TUI paths are exercised
+/// end-to-end by the existing `tm launch`/`tm connect` integration coverage).
+pub fn create_managed_session(
+    tmux_bin: Option<&str>,
+    name: &str,
+    workdir: Option<&str>,
+) -> std::io::Result<std::process::Output> {
+    let owned_bin;
+    let bin = match tmux_bin {
+        Some(b) => b,
+        None => {
+            owned_bin = resolve_tmux_binary_or_bare();
+            &owned_bin
+        }
+    };
+
+    let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
+    let opts = crate::core::trusty_tools_config::resolve_tmux_options(&config);
+    for cmd in scrollback_option_commands(opts.history_limit, opts.mouse) {
+        match run_tmux_with_bin(bin, &cmd) {
+            Ok(output) if !output.status.success() => {
+                warn!(
+                    "tmux {cmd:?} exited non-zero (non-fatal, session creation continues): {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            Err(e) => {
+                warn!("failed to run tmux {cmd:?} (non-fatal, session creation continues): {e}");
+            }
+            Ok(_) => {}
+        }
+    }
+
+    run_tmux_with_bin(
+        bin,
+        &TmuxCommand::NewSession {
+            name: name.to_string(),
+            workdir: workdir.map(str::to_string),
+        },
+    )
+}
+
+/// Type `text` into a tmux pane, then press Enter (#2398 consolidation).
+///
+/// Why: every call site that starts `claude` in a freshly-created pane needs
+/// this exact idiom — mirrors
+/// [`daemon::tmux::TmuxDriver::send_line`](crate::daemon::tmux::TmuxDriver::send_line)'s
+/// literal-then-Enter pattern (two `send-keys` invocations: `-l` literal text,
+/// then the `Enter` key name), now shared so CLI/TUI callers do not
+/// re-implement it as a single bare `send-keys <text> Enter` invocation
+/// (functionally equivalent for a non-key-name string, but a second,
+/// independently-typed-out version of the same idiom is exactly the kind of
+/// drift #2398 closes).
+/// What: runs the literal `send-keys -l <text>` via [`run_tmux_with_bin`]
+/// (`tmux_bin` if given, else resolved via [`resolve_tmux_binary_or_bare`]);
+/// if that invocation itself fails to spawn, the error is returned
+/// immediately WITHOUT sending `Enter`. Otherwise sends `Enter` and returns
+/// ITS `Output` — callers check `output.status.success()` exactly as they
+/// did with the single-invocation form.
+/// Test: argv shapes covered by `core::tmux`'s `send_keys_literal_argv`/
+/// `send_keys_keyname_argv`; the live-process call needs a real `tmux`
+/// binary, exercised transitively by every migrated call site.
+pub fn send_line(
+    tmux_bin: Option<&str>,
+    target: &TmuxTarget,
+    text: &str,
+) -> std::io::Result<std::process::Output> {
+    let owned_bin;
+    let bin = match tmux_bin {
+        Some(b) => b,
+        None => {
+            owned_bin = resolve_tmux_binary_or_bare();
+            &owned_bin
+        }
+    };
+    let literal_output = run_tmux_with_bin(
+        bin,
+        &TmuxCommand::SendKeys {
+            target: target.clone(),
+            keys: text.to_string(),
+            literal: true,
+        },
+    )?;
+    if !literal_output.status.success() {
+        // Don't send Enter after a failed literal send — nothing to submit.
+        return Ok(literal_output);
+    }
+    run_tmux_with_bin(
+        bin,
+        &TmuxCommand::SendKeys {
+            target: target.clone(),
+            keys: "Enter".to_string(),
+            literal: false,
+        },
+    )
 }
 
 /// tmux `-F` format string for `list-sessions`.
@@ -457,5 +698,43 @@ mod tests {
     fn scrollback_option_commands_mouse_off() {
         let cmds = scrollback_option_commands(100_000, false);
         assert_eq!(tmux_argv(&cmds[1]), ["set-option", "-g", "mouse", "off"]);
+    }
+
+    // ── #2398 architecture consolidation: shared tmux entry point ──────────
+
+    #[test]
+    fn resolve_tmux_binary_does_not_panic() {
+        // Works whether or not tmux is installed on the test host.
+        let _ = resolve_tmux_binary();
+    }
+
+    #[test]
+    fn resolve_tmux_binary_or_bare_never_empty() {
+        // Even when resolution fails entirely, the bare "tmux" fallback keeps
+        // this non-empty — callers always get a spawnable binary name.
+        assert!(!resolve_tmux_binary_or_bare().is_empty());
+    }
+
+    #[test]
+    fn run_tmux_with_bin_does_not_panic_on_missing_binary() {
+        // A deliberately bogus binary name must surface as an Err, never panic.
+        let result = run_tmux_with_bin(
+            "definitely-not-a-real-tmux-binary-2398",
+            &TmuxCommand::ListSessions,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn create_managed_session_does_not_panic_on_missing_binary() {
+        // Same smoke guarantee for the session-creation choke point: a bogus
+        // binary must degrade to an Err (from the final new-session spawn),
+        // never panic — including through the best-effort scrollback loop.
+        let result = create_managed_session(
+            Some("definitely-not-a-real-tmux-binary-2398"),
+            "tmpm-test-2398-no-bin",
+            None,
+        );
+        assert!(result.is_err());
     }
 }

--- a/crates/trusty-mpm/src/core/tmux.rs
+++ b/crates/trusty-mpm/src/core/tmux.rs
@@ -134,6 +134,57 @@ pub enum TmuxCommand {
         /// Environment variable value.
         value: String,
     },
+    /// `set-option -g <name> <value>` — set a server-wide (global) tmux
+    /// option (#2398).
+    ///
+    /// Why: managed sessions need a generous scrollback (`history-limit`) and
+    /// mouse-wheel scrolling (`mouse`) applied to the SERVER before any pane
+    /// is created — `history-limit` is captured into a pane's ring buffer AT
+    /// CREATION TIME, so a per-session `set-option` issued after a pane
+    /// already exists would not retroactively grow it. trusty-mpm runs every
+    /// managed session on the ONE default tmux server (no dedicated `-S`
+    /// socket), so a single `-g` (global) `set-option` benefits every session
+    /// subsequently created on that server.
+    /// What: renders `set-option -g <name> <value>`.
+    SetGlobalOption {
+        /// tmux option name (e.g. `history-limit`, `mouse`).
+        name: String,
+        /// Option value (e.g. `"100000"`, `"on"`).
+        value: String,
+    },
+}
+
+/// tmux global option name for scrollback lines retained per pane (#2398).
+pub const HISTORY_LIMIT_OPTION: &str = "history-limit";
+
+/// tmux global option name for mouse-wheel scrolling / copy-mode (#2398).
+pub const MOUSE_OPTION: &str = "mouse";
+
+/// Build the `set-option -g` command sequence that applies the scrollback +
+/// mouse-scroll ergonomics to the tmux server (#2398).
+///
+/// Why: [`crate::daemon::tmux::TmuxDriver::apply_scrollback_options`] needs a
+/// pure, unit-testable builder for the exact commands it issues (and their
+/// order) — the resolved values come from
+/// `core::trusty_tools_config::resolve_tmux_options`, not from here, so this
+/// function stays free of any config/file-system dependency and is testable
+/// with plain arguments.
+/// What: two [`TmuxCommand::SetGlobalOption`] entries, `history-limit` then
+/// `mouse` (rendered `"on"`/`"off"`), in the order the caller must run them —
+/// both must land before the caller's subsequent `new-session`.
+/// Test: `scrollback_option_commands_uses_configured_values`,
+/// `scrollback_option_commands_mouse_off`.
+pub fn scrollback_option_commands(history_limit: u32, mouse: bool) -> Vec<TmuxCommand> {
+    vec![
+        TmuxCommand::SetGlobalOption {
+            name: HISTORY_LIMIT_OPTION.to_string(),
+            value: history_limit.to_string(),
+        },
+        TmuxCommand::SetGlobalOption {
+            name: MOUSE_OPTION.to_string(),
+            value: if mouse { "on" } else { "off" }.to_string(),
+        },
+    ]
 }
 
 /// tmux `-F` format string for `list-sessions`.
@@ -245,6 +296,14 @@ pub fn tmux_argv(cmd: &TmuxCommand) -> Vec<String> {
                 "-t".to_string(),
                 session.clone(),
                 key.clone(),
+                value.clone(),
+            ]
+        }
+        TmuxCommand::SetGlobalOption { name, value } => {
+            vec![
+                "set-option".to_string(),
+                "-g".to_string(),
+                name.clone(),
                 value.clone(),
             ]
         }
@@ -369,5 +428,34 @@ mod tests {
                 "11111111-2222-3333-4444-555555555555"
             ]
         );
+    }
+
+    #[test]
+    fn set_global_option_argv() {
+        let argv = tmux_argv(&TmuxCommand::SetGlobalOption {
+            name: "history-limit".into(),
+            value: "100000".into(),
+        });
+        assert_eq!(argv, ["set-option", "-g", "history-limit", "100000"]);
+    }
+
+    #[test]
+    fn scrollback_option_commands_uses_configured_values() {
+        // Order matters: history-limit must precede mouse (both must land
+        // before the caller's subsequent new-session, but the internal order
+        // between the two is asserted here so it stays stable).
+        let cmds = scrollback_option_commands(50_000, true);
+        assert_eq!(cmds.len(), 2);
+        assert_eq!(
+            tmux_argv(&cmds[0]),
+            ["set-option", "-g", "history-limit", "50000"]
+        );
+        assert_eq!(tmux_argv(&cmds[1]), ["set-option", "-g", "mouse", "on"]);
+    }
+
+    #[test]
+    fn scrollback_option_commands_mouse_off() {
+        let cmds = scrollback_option_commands(100_000, false);
+        assert_eq!(tmux_argv(&cmds[1]), ["set-option", "-g", "mouse", "off"]);
     }
 }

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -152,6 +152,15 @@ pub struct TrustyToolsConfig {
     /// precedence over this global section for that project.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub untracked_sync: Option<UntrackedSyncConfig>,
+
+    /// Managed-tmux scrollback + mouse ergonomics (the `tmux:` YAML section,
+    /// #2398).
+    ///
+    /// `None` → the built-in defaults apply: a 100,000-line `history-limit`
+    /// and `mouse on`. See [`resolve_tmux_options`] for the full precedence
+    /// and [`TmuxConfig`] for the field-level docs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tmux: Option<TmuxConfig>,
 }
 
 /// The `daemon:` section of `~/.trusty-tools/trusty-mpm/config.yaml` (#1836).
@@ -179,6 +188,93 @@ pub struct DaemonConfig {
     /// always spawns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_mcp_spawn: Option<bool>,
+}
+
+/// Built-in default tmux `history-limit` (scrollback lines) applied to every
+/// managed session (#2398).
+///
+/// Why: tmux's own default is 2000 lines, which a long-running PM session
+/// exhausts almost immediately. 100,000 lines comfortably covers a full
+/// working session without materially growing tmux's per-pane memory
+/// footprint (each line is only retained while it exists in the pane).
+/// What: `100_000`.
+/// Test: `tmux_options_default_when_no_config`.
+pub const DEFAULT_TMUX_HISTORY_LIMIT: u32 = 100_000;
+
+/// Built-in default for whether mouse-wheel scrolling (and click-to-select
+/// copy mode) is enabled on the tmux server (#2398).
+///
+/// Why: a large `history-limit` is only reachable in practice if the operator
+/// has an easy way to scroll into it; tmux's `mouse on` option maps the wheel
+/// to scrolling the pane / entering copy-mode, which is the actual "scroll"
+/// gesture operators expect.
+/// What: `true`.
+/// Test: `tmux_options_default_when_no_config`.
+pub const DEFAULT_TMUX_MOUSE: bool = true;
+
+/// The `tmux:` section of `~/.trusty-tools/trusty-mpm/config.yaml` (#2398).
+///
+/// Why: managed sessions inherited tmux's tiny default `history-limit`
+/// (2000 lines), making long PM sessions unscrollable. Both fields are
+/// optional so an absent section (or a partly-filled one) falls back to the
+/// built-in defaults — no regression for existing configs.
+/// What: `history_limit` (scrollback lines retained per pane) and `mouse`
+/// (server-wide wheel-scroll/copy-mode toggle). Resolution precedence
+/// (config > built-in default) lives in [`resolve_tmux_options`], not here —
+/// this is purely the on-disk shape.
+/// Test: `tmux_config_yaml_round_trip`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TmuxConfig {
+    /// Scrollback lines retained per pane (tmux `history-limit`).
+    ///
+    /// `None` → [`DEFAULT_TMUX_HISTORY_LIMIT`]. Only affects panes created
+    /// AFTER this is applied — tmux captures `history-limit` into a pane's
+    /// ring buffer at creation time, so an already-running pane's scrollback
+    /// is never retroactively grown (a tmux limitation, not a trusty-mpm one).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_limit: Option<u32>,
+
+    /// Whether mouse-wheel scrolling / copy-mode is enabled (tmux `mouse`).
+    ///
+    /// `None` → [`DEFAULT_TMUX_MOUSE`] (`true`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mouse: Option<bool>,
+}
+
+/// Resolved tmux scrollback + mouse ergonomics, after applying config
+/// overrides on top of the built-in defaults (#2398).
+///
+/// Why: [`crate::daemon::tmux::TmuxDriver::apply_scrollback_options`] needs
+/// concrete `u32`/`bool` values, not the optional on-disk shape; resolving
+/// once here keeps the precedence logic in a single tested place.
+/// What: `history_limit` and `mouse`, both always populated.
+/// Test: `tmux_options_default_when_no_config`, `tmux_options_config_override`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedTmuxOptions {
+    /// Scrollback lines retained per pane.
+    pub history_limit: u32,
+    /// Whether mouse-wheel scrolling / copy-mode is enabled.
+    pub mouse: bool,
+}
+
+/// Resolve the effective tmux scrollback + mouse options for managed
+/// sessions (#2398).
+///
+/// Why: gives every tmux-session-creating call site (normal spawn, resume/
+/// restart, GUI spawn-mode, config-restart) a single answer, so a future
+/// config change cannot land in one call site and be forgotten in another.
+/// What: applies precedence **config `tmux.history_limit`/`tmux.mouse`
+/// override > built-in default** ([`DEFAULT_TMUX_HISTORY_LIMIT`] /
+/// [`DEFAULT_TMUX_MOUSE`]) for each field independently.
+/// Test: `tmux_options_default_when_no_config`, `tmux_options_config_override`.
+pub fn resolve_tmux_options(config: &TrustyToolsConfig) -> ResolvedTmuxOptions {
+    let section = config.tmux.as_ref();
+    ResolvedTmuxOptions {
+        history_limit: section
+            .and_then(|t| t.history_limit)
+            .unwrap_or(DEFAULT_TMUX_HISTORY_LIMIT),
+        mouse: section.and_then(|t| t.mouse).unwrap_or(DEFAULT_TMUX_MOUSE),
+    }
 }
 
 /// The `github:` section of `~/.trusty-tools/trusty-mpm/config.yaml` (#1265).
@@ -786,6 +882,70 @@ mod tests {
         let empty = TrustyToolsConfig::default();
         let yaml_empty = serde_yaml::to_string(&empty).expect("serialise");
         assert!(!yaml_empty.contains("daemon"), "yaml: {yaml_empty}");
+    }
+
+    /// Why: the `tmux:` section (#2398) must round-trip through YAML, and an
+    /// absent section must not serialise at all (matching every other
+    /// optional top-level section).
+    /// Test: itself.
+    #[test]
+    fn tmux_config_yaml_round_trip() {
+        let cfg = TrustyToolsConfig {
+            tmux: Some(TmuxConfig {
+                history_limit: Some(50_000),
+                mouse: Some(false),
+            }),
+            ..Default::default()
+        };
+        let yaml = serde_yaml::to_string(&cfg).expect("serialise");
+        let back: TrustyToolsConfig = serde_yaml::from_str(&yaml).expect("deserialise");
+        assert_eq!(cfg, back);
+        assert!(yaml.contains("history_limit"), "yaml: {yaml}");
+        assert!(yaml.contains("mouse"), "yaml: {yaml}");
+
+        // Absent tmux section must not serialise.
+        let empty = TrustyToolsConfig::default();
+        let yaml_empty = serde_yaml::to_string(&empty).expect("serialise");
+        assert!(!yaml_empty.contains("tmux"), "yaml: {yaml_empty}");
+    }
+
+    /// Why: with no `tmux:` section at all, resolution must fall back to the
+    /// built-in defaults (100,000-line history-limit, mouse on).
+    /// Test: itself.
+    #[test]
+    fn tmux_options_default_when_no_config() {
+        let opts = resolve_tmux_options(&TrustyToolsConfig::default());
+        assert_eq!(opts.history_limit, DEFAULT_TMUX_HISTORY_LIMIT);
+        assert_eq!(opts.mouse, DEFAULT_TMUX_MOUSE);
+    }
+
+    /// Why: an explicit `tmux:` section must override the built-in defaults,
+    /// field-by-field (a partial section still falls back per-field).
+    /// Test: itself.
+    #[test]
+    fn tmux_options_config_override() {
+        let cfg = TrustyToolsConfig {
+            tmux: Some(TmuxConfig {
+                history_limit: Some(250_000),
+                mouse: Some(false),
+            }),
+            ..Default::default()
+        };
+        let opts = resolve_tmux_options(&cfg);
+        assert_eq!(opts.history_limit, 250_000);
+        assert!(!opts.mouse);
+
+        // Partial override: only history_limit set, mouse falls back to default.
+        let partial = TrustyToolsConfig {
+            tmux: Some(TmuxConfig {
+                history_limit: Some(10_000),
+                mouse: None,
+            }),
+            ..Default::default()
+        };
+        let opts = resolve_tmux_options(&partial);
+        assert_eq!(opts.history_limit, 10_000);
+        assert_eq!(opts.mouse, DEFAULT_TMUX_MOUSE);
     }
 
     /// Why: the project subpath must nest `<owner>/<repo>` under the root in that

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -212,6 +212,23 @@ pub const DEFAULT_TMUX_HISTORY_LIMIT: u32 = 100_000;
 /// Test: `tmux_options_default_when_no_config`.
 pub const DEFAULT_TMUX_MOUSE: bool = true;
 
+/// Minimum tmux `history-limit` accepted from config (#2398 QA finding).
+///
+/// Why: `history-limit 0` does NOT mean "unlimited" in tmux — it means "keep
+/// no scrollback beyond the visible screen", the exact opposite of what an
+/// operator setting `tmux.history_limit: 0` almost certainly intended (this
+/// is a common mental-model mismatch with tools where `0` conventionally
+/// means unbounded). Rather than silently honouring a self-defeating value
+/// that reintroduces the unscrollable-session problem #2398 exists to fix, a
+/// configured value below this floor is clamped UP to it.
+/// What: `1_000`. Deliberately below [`DEFAULT_TMUX_HISTORY_LIMIT`] so an
+/// operator who intentionally wants a SMALL (but still usable) scrollback
+/// can still dial it down — only the pathological `0` (or another
+/// near-zero value) is corrected.
+/// Test: `tmux_options_clamps_zero_history_limit`,
+/// `tmux_options_clamps_below_minimum`.
+pub const MIN_TMUX_HISTORY_LIMIT: u32 = 1_000;
+
 /// The `tmux:` section of `~/.trusty-tools/trusty-mpm/config.yaml` (#2398).
 ///
 /// Why: managed sessions inherited tmux's tiny default `history-limit`
@@ -220,17 +237,20 @@ pub const DEFAULT_TMUX_MOUSE: bool = true;
 /// built-in defaults — no regression for existing configs.
 /// What: `history_limit` (scrollback lines retained per pane) and `mouse`
 /// (server-wide wheel-scroll/copy-mode toggle). Resolution precedence
-/// (config > built-in default) lives in [`resolve_tmux_options`], not here —
-/// this is purely the on-disk shape.
+/// (config > built-in default, clamped to [`MIN_TMUX_HISTORY_LIMIT`]) lives
+/// in [`resolve_tmux_options`], not here — this is purely the on-disk shape.
 /// Test: `tmux_config_yaml_round_trip`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TmuxConfig {
     /// Scrollback lines retained per pane (tmux `history-limit`).
     ///
-    /// `None` → [`DEFAULT_TMUX_HISTORY_LIMIT`]. Only affects panes created
-    /// AFTER this is applied — tmux captures `history-limit` into a pane's
-    /// ring buffer at creation time, so an already-running pane's scrollback
-    /// is never retroactively grown (a tmux limitation, not a trusty-mpm one).
+    /// `None` → [`DEFAULT_TMUX_HISTORY_LIMIT`]. A configured value below
+    /// [`MIN_TMUX_HISTORY_LIMIT`] (including `0`, which tmux treats as "no
+    /// scrollback", not "unlimited") is clamped up to it — see
+    /// [`resolve_tmux_options`]. Only affects panes created AFTER this is
+    /// applied — tmux captures `history-limit` into a pane's ring buffer at
+    /// creation time, so an already-running pane's scrollback is never
+    /// retroactively grown (a tmux limitation, not a trusty-mpm one).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub history_limit: Option<u32>,
 
@@ -261,18 +281,25 @@ pub struct ResolvedTmuxOptions {
 /// sessions (#2398).
 ///
 /// Why: gives every tmux-session-creating call site (normal spawn, resume/
-/// restart, GUI spawn-mode, config-restart) a single answer, so a future
-/// config change cannot land in one call site and be forgotten in another.
+/// restart, GUI spawn-mode, config-restart, and the CLI/TUI paths that create
+/// sessions directly) a single answer, so a future config change cannot land
+/// in one call site and be forgotten in another.
 /// What: applies precedence **config `tmux.history_limit`/`tmux.mouse`
 /// override > built-in default** ([`DEFAULT_TMUX_HISTORY_LIMIT`] /
-/// [`DEFAULT_TMUX_MOUSE`]) for each field independently.
-/// Test: `tmux_options_default_when_no_config`, `tmux_options_config_override`.
+/// [`DEFAULT_TMUX_MOUSE`]) for each field independently, then clamps
+/// `history_limit` up to [`MIN_TMUX_HISTORY_LIMIT`] — a configured `0` (or
+/// any other near-zero value) does NOT mean "unlimited" in tmux, so it is
+/// corrected rather than honoured verbatim (#2398 QA finding).
+/// Test: `tmux_options_default_when_no_config`, `tmux_options_config_override`,
+/// `tmux_options_clamps_zero_history_limit`, `tmux_options_clamps_below_minimum`.
 pub fn resolve_tmux_options(config: &TrustyToolsConfig) -> ResolvedTmuxOptions {
     let section = config.tmux.as_ref();
+    let history_limit = section
+        .and_then(|t| t.history_limit)
+        .unwrap_or(DEFAULT_TMUX_HISTORY_LIMIT)
+        .max(MIN_TMUX_HISTORY_LIMIT);
     ResolvedTmuxOptions {
-        history_limit: section
-            .and_then(|t| t.history_limit)
-            .unwrap_or(DEFAULT_TMUX_HISTORY_LIMIT),
+        history_limit,
         mouse: section.and_then(|t| t.mouse).unwrap_or(DEFAULT_TMUX_MOUSE),
     }
 }
@@ -946,6 +973,54 @@ mod tests {
         let opts = resolve_tmux_options(&partial);
         assert_eq!(opts.history_limit, 10_000);
         assert_eq!(opts.mouse, DEFAULT_TMUX_MOUSE);
+    }
+
+    /// Why (#2398 QA finding): `history-limit 0` means "no scrollback" in
+    /// tmux, not "unlimited" — a configured `0` must be clamped up to
+    /// [`MIN_TMUX_HISTORY_LIMIT`] rather than honoured verbatim, which would
+    /// silently reintroduce the unscrollable-session problem this feature
+    /// exists to fix.
+    /// Test: itself.
+    #[test]
+    fn tmux_options_clamps_zero_history_limit() {
+        let cfg = TrustyToolsConfig {
+            tmux: Some(TmuxConfig {
+                history_limit: Some(0),
+                mouse: None,
+            }),
+            ..Default::default()
+        };
+        let opts = resolve_tmux_options(&cfg);
+        assert_eq!(opts.history_limit, MIN_TMUX_HISTORY_LIMIT);
+    }
+
+    /// Why: any near-zero configured value below the floor is clamped, not
+    /// just the literal `0` case.
+    /// Test: itself.
+    #[test]
+    fn tmux_options_clamps_below_minimum() {
+        let cfg = TrustyToolsConfig {
+            tmux: Some(TmuxConfig {
+                history_limit: Some(42),
+                mouse: None,
+            }),
+            ..Default::default()
+        };
+        let opts = resolve_tmux_options(&cfg);
+        assert_eq!(opts.history_limit, MIN_TMUX_HISTORY_LIMIT);
+
+        // A value AT the floor is left untouched (not bumped further).
+        let at_floor = TrustyToolsConfig {
+            tmux: Some(TmuxConfig {
+                history_limit: Some(MIN_TMUX_HISTORY_LIMIT),
+                mouse: None,
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_tmux_options(&at_floor).history_limit,
+            MIN_TMUX_HISTORY_LIMIT
+        );
     }
 
     /// Why: the project subpath must nest `<owner>/<repo>` under the root in that

--- a/crates/trusty-mpm/src/daemon/claude_config/restarter.rs
+++ b/crates/trusty-mpm/src/daemon/claude_config/restarter.rs
@@ -48,14 +48,25 @@ impl ClaudeCodeRestarter {
     /// Restart Claude Code inside a named tmux session.
     ///
     /// Why: a Claude Code session hosted in tmux is restarted in place — send
-    /// an interrupt to stop the current process, then relaunch `claude`.
-    /// What: discovers tmux, sends `C-c` to the session's pane, waits briefly
-    /// for the process to exit, then types `claude` + Enter. tmux being absent
-    /// surfaces as an `Err`.
+    /// an interrupt to stop the current process, then relaunch `claude`. The
+    /// scrollback/mouse server options (#2398) are re-applied defensively
+    /// before the relaunch: this is the "restarter/relaunch-on-exit" path, so
+    /// re-applying here guards the edge case where the tmux server was
+    /// started or restarted independently of trusty-mpm (e.g. `tmux
+    /// kill-server` followed by an operator's own `tmux new-session`) since
+    /// this session's pane was created. `set-option -g` is idempotent and
+    /// best-effort (never fails the restart) — see
+    /// [`crate::daemon::tmux::TmuxDriver::apply_scrollback_options`]. It does
+    /// NOT retroactively grow THIS session's already-created pane; only
+    /// panes created after the option lands benefit.
+    /// What: discovers tmux, re-applies the scrollback/mouse options, sends
+    /// `C-c` to the session's pane, waits briefly for the process to exit,
+    /// then types `claude` + Enter. tmux being absent surfaces as an `Err`.
     /// Test: `restart_in_session_errors_without_tmux` (skipped when tmux is
     /// installed).
     pub fn restart_in_session(tmux_session: &str) -> Result<()> {
         let driver = crate::daemon::tmux::TmuxDriver::discover()?;
+        driver.apply_scrollback_options();
         let target = TmuxTarget::session(tmux_session);
         // Interrupt the running Claude Code process.
         driver.send_interrupt(&target)?;

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -19,6 +19,8 @@
 
 use std::process::Command;
 
+use tracing::warn;
+
 use crate::core::external_session::ExternalSession;
 use crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR;
 use crate::core::tmux::{TmuxCommand, TmuxTarget, tmux_argv};
@@ -237,12 +239,59 @@ impl TmuxDriver {
     /// Idempotent: if a session with the same name already exists, the
     /// underlying `tmux new-session -A` attaches to it instead of failing
     /// with a "duplicate session" error.
+    ///
+    /// Why (#2398): the scrollback/mouse server options MUST be applied
+    /// before this method's `new-session` call — `history-limit` is captured
+    /// into a pane's ring buffer at creation time, so ordering here is load
+    /// bearing (see [`Self::apply_scrollback_options`]).
     pub fn create_session(&self, name: &str, workdir: Option<&str>) -> Result<()> {
+        self.apply_scrollback_options();
         self.run(&TmuxCommand::NewSession {
             name: name.to_string(),
             workdir: workdir.map(str::to_string),
         })?;
         Ok(())
+    }
+
+    /// Apply the configured scrollback + mouse ergonomics to the tmux
+    /// SERVER, before any pane is created (#2398).
+    ///
+    /// Why: tmux's own default `history-limit` is 2000 lines — a long-running
+    /// PM session scrolls off the top almost immediately. `history-limit` is
+    /// captured into a pane's ring buffer AT CREATION TIME; a per-session
+    /// `set-option` issued after a pane already exists does not retroactively
+    /// grow it (a tmux limitation — existing panes are unaffected by this
+    /// call; only NEW panes/sessions created after it benefit). Because
+    /// trusty-mpm runs every managed session on the ONE default tmux server
+    /// (no dedicated `-S` socket — confirmed: no call site in this crate
+    /// passes `-S`/`-L`), setting these as GLOBAL (`-g`) options once, right
+    /// before [`Self::create_session`]'s `new-session`, benefits every
+    /// session subsequently created without per-session bookkeeping. `mouse
+    /// on` additionally maps the wheel to pane-scroll/copy-mode entry, the
+    /// actual "scroll" gesture operators expect.
+    /// What: loads [`crate::core::trusty_tools_config::TrustyToolsConfig`],
+    /// resolves the `tmux:` section via
+    /// [`crate::core::trusty_tools_config::resolve_tmux_options`] (defaults:
+    /// 100,000-line history-limit, mouse on), and runs each
+    /// [`crate::core::tmux::scrollback_option_commands`] entry via
+    /// [`Self::run`]. Best-effort: `set-option -g` is idempotent (safe to
+    /// call before every session creation) and virtually never fails on a
+    /// tmux new enough to run trusty-mpm at all, but a failure here must
+    /// never block session creation/restart — each failure is logged and the
+    /// next option (or the caller's subsequent tmux call) still runs.
+    /// Test: argv construction is covered by `core::tmux`'s
+    /// `scrollback_option_commands_*` tests and config resolution by
+    /// `core::trusty_tools_config`'s `tmux_options_*` tests; this method's
+    /// live-server call site is exercised transitively by every
+    /// `create_session` caller with a real `tmux` binary (`#[ignore]` tests).
+    pub fn apply_scrollback_options(&self) {
+        let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
+        let opts = crate::core::trusty_tools_config::resolve_tmux_options(&config);
+        for cmd in crate::core::tmux::scrollback_option_commands(opts.history_limit, opts.mouse) {
+            if let Err(e) = self.run(&cmd) {
+                warn!("tmux scrollback/mouse option {cmd:?} failed (non-fatal): {e}");
+            }
+        }
     }
 
     /// Kill the tmux session named `name`.

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -211,16 +211,22 @@ impl TmuxDriver {
     /// Run a typed tmux command, returning captured stdout on success.
     ///
     /// Why: every other method routes through here so exit-status handling
-    /// lives in one place.
-    /// What: renders argv via `core::tmux::tmux_argv`, runs `tmux`, and maps a
-    /// non-zero exit to `Error::Protocol` carrying stderr.
+    /// lives in one place. The actual process spawn is delegated to
+    /// [`crate::core::tmux::run_tmux_with_bin`] (#2398 architecture
+    /// consolidation) — `TmuxDriver` WRAPS that single crate-wide entry point
+    /// rather than spawning independently, using its own already-resolved
+    /// `self.tmux_path` (cached at [`Self::discover`] time for the
+    /// fail-fast-if-absent contract) instead of re-resolving on every call.
+    /// What: renders argv via `core::tmux::tmux_argv` (for the error message
+    /// only — the actual spawn happens inside `run_tmux_with_bin`), runs
+    /// `tmux`, and maps a non-zero exit to `Error::Protocol` carrying stderr.
     /// Test: exercised indirectly by the `#[ignore]` integration tests.
     fn run(&self, cmd: &TmuxCommand) -> Result<String> {
-        let argv = tmux_argv(cmd);
-        let output = Command::new(&self.tmux_path).args(&argv).output()?;
+        let output = crate::core::tmux::run_tmux_with_bin(&self.tmux_path, cmd)?;
         if output.status.success() {
             Ok(String::from_utf8_lossy(&output.stdout).into_owned())
         } else {
+            let argv = tmux_argv(cmd);
             let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
             // #2246: the argv can embed a cleartext CLAUDE_CODE_OAUTH_TOKEN
             // (managed-spawn pane command). Redact at this single source so the
@@ -242,15 +248,22 @@ impl TmuxDriver {
     ///
     /// Why (#2398): the scrollback/mouse server options MUST be applied
     /// before this method's `new-session` call — `history-limit` is captured
-    /// into a pane's ring buffer at creation time, so ordering here is load
-    /// bearing (see [`Self::apply_scrollback_options`]).
+    /// into a pane's ring buffer at creation time. Delegates to
+    /// [`crate::core::tmux::create_managed_session`], the crate-wide session-
+    /// creation choke point EVERY session-creating call site (daemon, CLI,
+    /// TUI client, control-plane backend) now routes through, so the
+    /// ordering can never be bypassed by a future call site again.
     pub fn create_session(&self, name: &str, workdir: Option<&str>) -> Result<()> {
-        self.apply_scrollback_options();
-        self.run(&TmuxCommand::NewSession {
-            name: name.to_string(),
-            workdir: workdir.map(str::to_string),
-        })?;
-        Ok(())
+        let output =
+            crate::core::tmux::create_managed_session(Some(&self.tmux_path), name, workdir)?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+            Err(Error::Protocol(redact_oauth_token(&format!(
+                "tmux new-session for {name} failed: {stderr}"
+            ))))
+        }
     }
 
     /// Apply the configured scrollback + mouse ergonomics to the tmux


### PR DESCRIPTION
## Summary

Bob's ask: managed `tm` tmux sessions inherited tmux's default `history-limit` (2000 lines), making long PM sessions unscrollable. The fix adds a configurable, generous scrollback (default 100,000 lines) plus mouse-wheel scroll ergonomics.

**QA rejected the first version of this PR**: the daemon-side wiring (`daemon::tmux::TmuxDriver`) was correct, but 5 CLI/TUI call sites shelled out to `tmux new-session` independently and bypassed the daemon entirely, so they never got the ergonomics. **Bob's follow-up architecture directive**: *"all tmux commands should share a common entry point"* — do not patch the 5 bypass sites individually; consolidate the whole crate onto one shared tmux-spawning entry point so nothing can bypass it again. This PR implements that directive. The entry-point consolidation IS the fix; scrollback rides on top of it.

## Architecture: the shared entry point

New in `crates/trusty-mpm/src/core/tmux.rs` (previously argv-construction only):

- **`resolve_tmux_binary()` / `resolve_tmux_binary_or_bare()`** — one binary-resolution path (PATH first, well-known-dirs fallback via `trusty_common::bin_resolve`) used by every caller, daemon or CLI.
- **`run_tmux_with_bin(bin, cmd)` / `run_tmux(cmd)`** — the crate's SINGLE output-capturing tmux-spawning primitive. Every other function funnels through this.
- **`create_managed_session(bin, name, workdir)`** — the session-creation choke point: applies the configured `set-option -g history-limit`/`set-option -g mouse` commands (best-effort, logged on failure), THEN `new-session`, atomically. `history-limit` is captured into a pane's ring buffer at creation time, so this ordering is load-bearing and is now impossible to get wrong at a call site — there's only one function that creates a session.
- **`send_line(bin, target, text)`** — shared "type literal text, then press Enter" idiom (mirrors `TmuxDriver::send_line`), used by every call site that starts `claude` in a freshly-created pane.

`daemon::tmux::TmuxDriver` now **wraps** `run_tmux_with_bin`/`create_managed_session` instead of spawning independently — it keeps its own `discover()`-time binary caching (for its fail-fast-if-tmux-absent contract) and its OAuth-token redaction on error paths, but the actual process spawn is the shared primitive.

## What moved onto the shared entry point

**Daemon (already correct pre-QA, unchanged behavior, now formally routed through the shared primitive):**
- `daemon::tmux::TmuxDriver::run` / `create_session` (covers `session_manager::create`, `resume_workdir`'s recreate-on-exit path, `daemon::services::tmux_service::spawn_claude`, `control::backend::tmux::TmuxBackend::new`)
- `daemon::claude_config::restarter::ClaudeCodeRestarter::restart_in_session` (defensive re-apply on relaunch)

**CLI / TUI client (the QA-flagged bypass — now fixed):**
1. `bin/tm/commands/launch.rs` — `tm launch`'s `new-session` + `send-keys` + the `LaunchSessionGuard`'s `kill-session` on drop
2. `bin/tm/commands/launch.rs` — `tm connect`'s `new-session` + `send-keys`
3. `client/http_client/session_connect.rs` — `DaemonClient::launch_session` (TUI `/connect`)
4. `client/http_client/session_connect.rs` — `DaemonClient::connect_session` (`new-session`, `send-keys`, `has-session` probe)
5. `bin/tm/commands/session/start.rs` — `start_session_in_place`'s in-place fallback

**Also migrated while sweeping the crate:**
- `bin/tm/formatters/banner/mod.rs::tmux_has_session` — now `run_tmux(HasSession)`
- `control::backend::tmux::TmuxBackend::recv` — deleted a private `run_tmux_cmd` duplicate entirely; now reuses `TmuxDriver::capture` directly (which already routes through the shared primitive)
- `bin/tm/commands/tmux_attach.rs::tmux_attach` — the interactive `attach-session`/`switch-client` spawn now resolves its binary through `resolve_tmux_binary_or_bare()` (its stdio-inheriting `.status()` call doesn't fit `run_tmux`'s output-capturing `.output()` shape, so only binary resolution is unified there, not the full spawn)

## Scope carve-out (follow-up filed: #2414)

Four READ-ONLY probes against an *existing* session still shell out directly — they cannot bypass session-creation ergonomics (nothing is created), and no `TmuxCommand` variant models their argv shape yet (`display-message`, `show-environment`):
- `tmux_attach.rs::current_tmux_session_name` / `statusline/branch.rs::tmux_session_name` (identical `display-message -p '#S'` — also flagged as a dedup opportunity)
- `guided_inplace.rs::read_tmux_env_managed_session_id` (`show-environment`)
- `core/process.rs::tmux_pane_pid` (`display-message -t <s> -p '#{pane_pid}'`)

Migrating them was judged out of scope to keep this diff reviewable; #2414 tracks the follow-up.

## Config knobs

```yaml
# ~/.trusty-tools/trusty-mpm/config.yaml
tmux:
  history_limit: 100000   # optional, default 100000, clamped to a 1000-line floor
  mouse: true              # optional, default true
```

**QA-flagged edge case fixed**: `history-limit 0` means "no scrollback" in tmux, not "unlimited" (an easy mental-model mismatch with tools where `0` = unbounded). `resolve_tmux_options` now clamps any configured value below `MIN_TMUX_HISTORY_LIMIT` (1,000) up to that floor.

## Known limitation (documented, not fixed here)

Existing panes are **not** retroactively grown — a tmux limitation (history-limit is fixed at pane creation). Only sessions/panes created *after* this change lands get the larger scrollback + mouse scroll.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-mpm` — 2671 passed, 0 failed (new tests: `set_global_option_argv`, `scrollback_option_commands_*`, `resolve_tmux_binary_does_not_panic`, `resolve_tmux_binary_or_bare_never_empty`, `run_tmux_with_bin_does_not_panic_on_missing_binary`, `create_managed_session_does_not_panic_on_missing_binary`, `tmux_config_yaml_round_trip`, `tmux_options_default_when_no_config`, `tmux_options_config_override`, `tmux_options_clamps_zero_history_limit`, `tmux_options_clamps_below_minimum`)
- [x] `cargo test --workspace --no-fail-fast` — 0 failed (one `trusty-console::proxy::routes::tests::test_connect_retry_recovers_on_second_attempt` flake reproduced once under parallel port contention — confirmed pre-existing/known #2331, passes in isolation and on re-run; unrelated to this change)
- [x] `cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations
- [x] `git grep -c '<<<<<<<'` — 0 matches in any file this PR touches

Closes #2398

🤖 Generated with [Claude Code](https://claude.com/claude-code)