### PR TITLE
docs: codify common-entry-point / clean-domain-demarcation principle

### DIFF
--- a/.trusty-mpm/INSTRUCTIONS.md
+++ b/.trusty-mpm/INSTRUCTIONS.md
@@ -226,6 +226,21 @@ throughout.
 `axum-server` feature flag. Do not add axum as an unconditional dependency in
 any library crate. Enable it explicitly in crates that serve HTTP.
 
+🔴 **Common entry point, clean domain demarcation** — Every capability shared across
+two or more crates — spawning an external tool (git, gh, tmux, launchctl), building
+an HTTP client, resolving a daemon's address, reading a secret or config value,
+redacting sensitive output, retrying a fallible call — MUST have exactly one
+implementation, living in trusty-common (or the crate that most naturally owns that
+domain), that every consumer routes through. Before writing `Command::new(...)`,
+`reqwest::Client::builder()`, `std::env::var(...)` for a cross-crate concern, or any
+bespoke read-this-config / find-this-daemon / scrub-this-string logic: search for an
+existing entry point first (`git grep`, then trusty-common source tree) and extend it
+rather than duplicating. A second independent implementation of a shared capability is
+a defect, not a convenience — behavior fixes, security patches, and safety guardrails
+must land once, not N times, and silent drift between copies is a hidden risk. See the
+domain consolidation audit table below for 2026-07-11 baseline status. First enforcement
+instances: inference-adapter epic #2400, tmux common entry point #2398/PR #2399.
+
 🟡 **Rust editions** — `edition = "2024"` for `trusty-mpm`, `trusty-mpm-gui`, `trusty-agents`, `trusty-agents-common`, `trusty-agents-local`, and `trusty-code`
 (they use let-chains); `edition = "2021"` for all other crates. Check the crate
 `Cargo.toml` before assuming an edition.
@@ -544,3 +559,22 @@ Full-length reference materials for less-frequent lookups:
 - **Environment variables (full table):** [docs/reference/environment-variables.md](docs/reference/environment-variables.md)
 - **IDE setup (detailed):** [docs/reference/ide-setup.md](docs/reference/ide-setup.md)
 - **Running MCP servers (examples & wiring):** [docs/reference/running-mcp-servers.md](docs/reference/running-mcp-servers.md)
+
+## Domain Consolidation Audit
+
+**Baseline audit 2026-07-11** (session d72fb4a3-f9ff-4394-b148-8200d17a2d5a). Update verdicts
+as consolidations land. Reference: common-entry-point principle above.
+
+| Domain | Verdict | Scale | Status |
+|--------|---------|-------|--------|
+| HTTP clients (reqwest) | FRAGMENTED | 150+ builder sites incl. 20+ inside trusty-common | backlog |
+| git invocations | FRAGMENTED | ~90 production spawn sites, 7 crates | backlog (after tmux pattern proves) |
+| Shared env-var access | FRAGMENTED | OPENROUTER_API_KEY ×22 files/8 crates; GITHUB_TOKEN ×13/6 | partially covered by epic #2400 (#2401) |
+| gh CLI | FRAGMENTED | 3 wrappers (trusty-agents ticketing/gh_cli most complete) | backlog |
+| Config-file loading | FRAGMENTED | 5 implementations (2 pairs within single crates) | backlog |
+| Secret redaction | FRAGMENTED (security) | 4 rule sets (3 inside trusty-mpm) | partially covered by #2401 redact_secret |
+| launchctl | SCATTERED | shared LaunchdConfig exists; 9 bypass sites/4 crates | backlog |
+| Daemon addr discovery | SCATTERED | common resolver exists; 3 daemons re-implement | backlog |
+| Daemon PID discovery | FRAGMENTED | 3 copy-pasted find_daemon_pids() | backlog |
+| tmux (trusty-mpm) | SCATTERED→fixing | 19 sites | in flight: #2398/PR #2399 |
+| LLM inference | FRAGMENTED→fixing | 6 bespoke clients | epic #2400 |

--- a/docs/reference/common-pitfalls.md
+++ b/docs/reference/common-pitfalls.md
@@ -1,5 +1,15 @@
 # Common Pitfalls Reference
 
+🔴 **Duplicating a shared capability instead of extending the common entry point** —
+every cross-crate capability (external tool spawning, HTTP clients, config/secret
+loading, daemon discovery) has exactly one canonical implementation. A second
+implementation is a defect: fixes land N times, security patches miss copies, and
+silent behavioral drift emerges. Before writing `Command::new(...)`, `reqwest::Client`,
+`std::env::var()` for a concern used in multiple crates, search for an existing
+entry point (`git grep`, then trusty-common source tree) and extend it. See the
+common-entry-point principle and domain consolidation audit in
+[.trusty-mpm/INSTRUCTIONS.md](../../.trusty-mpm/INSTRUCTIONS.md).
+
 🔴 **Using `unwrap()` in library crates** — the compiler does not stop you, but
 it violates the project's hard rule. Use `?` with `thiserror` error types in
 libraries. `expect()` is allowed only for invariants that genuinely cannot


### PR DESCRIPTION
## Summary

- Add 🔴 **Common entry point, clean domain demarcation** principle to Key Conventions in `.trusty-mpm/INSTRUCTIONS.md`: every cross-crate capability has exactly one implementation; second independent implementation is a defect
- Add **Domain Consolidation Audit** table (11 domains, 2026-07-11 baseline): documents fragmented/scattered state of reqwest builders, git spawns, env-var access, gh CLI, config, secrets, launchctl, daemon/PID discovery, tmux, and LLM inference
- Add cross-reference in `docs/reference/common-pitfalls.md` as leading 🔴 entry for discoverability
- References epic #2400 (inference adapter) and #2398/PR #2399 (tmux consolidation) as first enforcement instances

**Principle:** Before writing `Command::new(...)`, `reqwest::Client::builder()`, `std::env::var(...)` for a cross-crate concern or bespoke config/secret/daemon-finding logic, search for existing entry point (`git grep`, then trusty-common) and extend it. Silent drift between copies is a hidden risk; fixes and security patches must land once.

**Verification:**
- `bash scripts/check_line_cap.sh` → OK
- Markdown structure verified by eye
- Docs-only change (no code dependencies)

## Test plan

- [x] Line-cap check passes (no code changes)
- [x] Markdown structure verified
- [x] Cross-references validated (INSTRUCTIONS.md ↔ common-pitfalls.md)
- [] Team review + acknowledgment (readiness for enforcement)

Closes #2412
Part of epic #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)