### PR TITLE
feat(trusty-common): credential resolver + secure KeyStore (closes #2401)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5190,6 +5200,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5852,7 +5877,7 @@ dependencies = [
  "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -6259,7 +6284,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8080,7 +8105,7 @@ dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -8296,6 +8321,19 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -10817,6 +10855,7 @@ dependencies = [
  "crossterm",
  "dashmap 6.2.1",
  "dirs 5.0.1",
+ "dotenvy",
  "fastembed",
  "futures",
  "futures-util",
@@ -10826,6 +10865,7 @@ dependencies = [
  "hf-hub 0.3.2",
  "hnsw_rs",
  "indexmap 2.14.0",
+ "keyring",
  "kuzu",
  "libc",
  "lru",
@@ -12971,6 +13011,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,16 @@ clap = { version = "4", features = ["derive", "env"] }
 toml = "0.8"
 libc = "0.2"
 unicode-width = "0.2"
+# `.env.local` loader for the trusty-common `inference::credentials` resolver
+# (issue #2401). Already used ad hoc by trusty-agents and trusty-search; the
+# workspace-shared pin lets those crates adopt the canonical loader later
+# without a version bump.
+dotenvy = "0.15"
+# OS-keychain credential storage for the `inference::credentials::KeyringStore`
+# backend (issue #2401), gated behind trusty-common's `keyring-store` feature.
+# `apple-native`/`windows-native`/`sync-secret-service` select the per-OS
+# backend transparently; async D-Bus support is not needed here.
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 # CLI / TUI / Telegram (trusty-mpm-tui, trusty-mpm-telegram).
 ratatui = "0.29"

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -60,7 +60,7 @@ thiserror = "1"
 async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-dotenvy = "0.15"
+dotenvy = { workspace = true }
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 bytes = "1"

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -28,6 +28,19 @@ name = "tickets-mcp"
 path = "src/bin/tickets_mcp.rs"
 required-features = ["tickets"]
 
+# Task-drawer + dream-cycle integration test (spec-001 Phase 4, issue #1722).
+# Pre-existing gap fixed incidentally by #2401: this target references
+# `trusty_common::memory_core` and the `embedder-test-support`-gated
+# `seed_shared_embedder_with_mock` unconditionally, so `cargo test
+# -p trusty-common` with default (empty) features failed to compile it.
+# `required-features` tells cargo to skip building this test binary unless
+# both are enabled, matching the pattern already used for the
+# `candle_metal_bench` / `tickets-mcp` binaries above.
+[[test]]
+name = "memory_palace"
+path = "tests/memory_palace.rs"
+required-features = ["memory-core", "embedder-test-support"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -118,8 +131,16 @@ postcard = { workspace = true, optional = true }
 # Optional: enabled by the `tickets` feature (absorbed from `trusty-tickets`).
 # base64 is used by the JIRA backend for Basic-auth encoding.
 base64 = { workspace = true, optional = true }
-# Optional: enabled by the `tickets` feature for config-file parsing.
+# Optional: enabled by the `tickets` feature for config-file parsing. Also
+# reused by the `credentials` feature's `FileKeyStore` backend (issue #2401).
 toml = { version = "0.8", optional = true }
+
+# Optional: enabled by the `credentials` feature (issue #2401). Shared
+# `.env.local` loader for the `inference::credentials` resolver's env tier.
+dotenvy = { workspace = true, optional = true }
+# Optional: enabled by the `keyring-store` feature (issue #2401). OS-keychain
+# backend for `inference::credentials::KeyringStore`.
+keyring = { workspace = true, optional = true }
 
 # Optional: enabled by the `cli-help` feature. Declarative help-config parsing
 # (YAML → `HelpConfig`) plus the "did you mean?" suggester for unknown
@@ -316,6 +337,12 @@ symgraph-server = ["symgraph-parser", "axum-server"]
 # feature — all stores migrated to redb (#44, #45, #46, #56, #57). The
 # migration-era `usearch-migrate` and `sqlite-kg` features have been removed
 # (issue #989) — all production palaces are confirmed migrated to redb.
+#
+# Issue #2401: implies `credentials` so `memory_core::filter::redact_token`
+# can delegate to the single canonical `inference::credentials::redact_secret`
+# implementation without every `memory-core` consumer needing to opt in to
+# `credentials` separately — the two extra deps it pulls (`toml`, `dotenvy`)
+# are negligible next to memory-core's existing footprint.
 memory-core = [
     "dep:hnsw_rs",
     "dep:git2",
@@ -333,6 +360,7 @@ memory-core = [
     "dep:hex",
     "embedder",
     "embedder-bundled-ort",
+    "credentials",
 ]
 # Optional kuzu graph DB read-only integration on top of the memory-core
 # feature. Pulls in the `kuzu` crate. Off by default because kuzu adds a
@@ -429,3 +457,19 @@ stdio-mcp-client = []
 # to decode. Implies `stdio-mcp-client` so the console can poll via the shared
 # client without a separate feature declaration.
 console-metrics = ["stdio-mcp-client"]
+
+# Enables the `inference::credentials` module (issue #2401, epic #2400 Wave
+# 1): the `KeyStore` trait, `MemoryKeyStore`, the `0600`-permission
+# `FileKeyStore` (`~/.trusty-tools/credentials.toml`), the `resolve_key`
+# 3-tier precedence resolver (process env > `.env.local` > secure store),
+# and the shared `redact_secret` helper. Pulls in `thiserror` (error type),
+# `toml` (`FileKeyStore`'s on-disk format), and `dotenvy` (the `.env.local`
+# loader) — all already optional workspace deps. Does NOT pull in the OS
+# keychain backend; see `keyring-store` for that.
+credentials = ["dep:thiserror", "dep:toml", "dep:dotenvy"]
+# Enables `inference::credentials::KeyringStore`, the OS-keychain backend
+# (macOS Keychain / Windows Credential Manager / Secret Service on Linux)
+# selected by `inference::credentials::default_store` when available, with
+# `FileKeyStore` as the runtime-probed fallback (issue #2401). Pulls in the
+# `keyring` crate in addition to everything `credentials` already requires.
+keyring-store = ["credentials", "dep:keyring"]

--- a/crates/trusty-common/src/inference/credentials/dotenv.rs
+++ b/crates/trusty-common/src/inference/credentials/dotenv.rs
@@ -1,0 +1,159 @@
+//! The one shared `.env.local` loader (issue #2401).
+//!
+//! Why: `trusty-agents` (`runtime/startup.rs:114-119`) and `trusty-search`
+//! (`main.rs:1155`) each call `dotenvy` ad hoc today, with slightly
+//! different search strategies (cwd-only vs. cwd + detected project dir).
+//! This module is the canonical replacement — designed so those two crates
+//! can adopt it in their own migration tickets without re-deriving the
+//! search logic — but this ticket does **not** modify either call site; it
+//! only ships the shared loader.
+//! What: [`load_env_local_once`] is the production entry point: idempotent
+//! (a `OnceLock` — repeated calls across a process are free), searches from
+//! the current working directory upward for a `.env.local` file (mirroring
+//! Cargo/git's own upward-search convention for "workspace root" discovery),
+//! and calls `dotenvy::from_path` on the first hit. Because `dotenvy` never
+//! overrides an already-set environment variable, this naturally implements
+//! "process env beats `.env.local`" — the resolver's tier check
+//! (`std::env::var`) is what actually observes the precedence; this loader
+//! just populates the process environment once, then gets out of the way.
+//! [`find_workspace_env_local`] and [`load_env_from_path`] are the hermetic
+//! cores used by the resolver's precedence tests, which must not depend on
+//! `OnceLock`'s once-only semantics or the real repo's `.env.local`.
+//! Test: `dotenv_tests` (sibling file).
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Search `start` and each ancestor directory for a `.env.local` file.
+///
+/// Why: the hermetic core for [`load_env_local_once`]; also directly usable
+/// by tests that want to point the search at a temp directory tree instead
+/// of the real cwd.
+/// What: returns the first `.env.local` found walking upward from `start`,
+/// or `None` if no ancestor has one.
+/// Test: `dotenv_tests::finds_env_local_in_ancestor`,
+/// `dotenv_tests::absent_env_local_returns_none`.
+pub fn find_workspace_env_local(start: &Path) -> Option<PathBuf> {
+    let mut dir = Some(start.to_path_buf());
+    while let Some(d) = dir {
+        let candidate = d.join(".env.local");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        dir = d.parent().map(Path::to_path_buf);
+    }
+    None
+}
+
+/// Load a specific `.env.local` path into the process environment.
+///
+/// Why: the resolver's precedence tests need to simulate "the `.env.local`
+/// tier fired" without touching [`load_env_local_once`]'s process-wide
+/// `OnceLock` (which would make a second test's load a silent no-op) or the
+/// real cwd search.
+/// What: thin wrapper over `dotenvy::from_path`; returns `true` on success.
+/// Like `dotenvy` generally, this never overrides a variable already present
+/// in the process environment.
+/// Test: `dotenv_tests::load_env_from_path_sets_new_var`,
+/// `dotenv_tests::load_env_from_path_does_not_override_existing`.
+pub fn load_env_from_path(path: &Path) -> bool {
+    dotenvy::from_path(path).is_ok()
+}
+
+/// Idempotent, cwd-upward-search `.env.local` loader for production use.
+///
+/// Why: the resolver calls this once before checking `std::env::var` so a
+/// developer's `.env.local` (at the repo root, or any ancestor of cwd) is
+/// picked up regardless of which subdirectory a binary was launched from —
+/// the same problem `trusty-agents` fixed ad hoc for itself in #250.
+/// What: on first call, searches upward from the current working directory
+/// via [`find_workspace_env_local`] and loads the first hit (if any) via
+/// `dotenvy::from_path`. Subsequent calls are a no-op `OnceLock` check.
+/// Errors (missing file, malformed file) are swallowed — a missing
+/// `.env.local` is the common case (production/CI), not a failure.
+/// Test: exercised indirectly via `resolver::resolve_key`'s production path;
+/// the once-only + cwd-search behaviour itself is not independently unit
+/// tested because `OnceLock` fires exactly once per test binary — see
+/// module docs for why precedence tests use [`load_env_from_path`] instead.
+pub fn load_env_local_once() {
+    static LOADED: OnceLock<()> = OnceLock::new();
+    LOADED.get_or_init(|| {
+        if let Ok(cwd) = std::env::current_dir()
+            && let Some(path) = find_workspace_env_local(&cwd)
+        {
+            let _ = dotenvy::from_path(&path);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    /// Why: the upward search must find a `.env.local` in a parent of the
+    /// starting directory, not just the exact directory.
+    /// Test: itself.
+    #[test]
+    fn finds_env_local_in_ancestor() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let child = tmp.path().join("a").join("b");
+        std::fs::create_dir_all(&child).unwrap();
+        std::fs::write(tmp.path().join(".env.local"), "X=1\n").unwrap();
+        let found = find_workspace_env_local(&child).unwrap();
+        assert_eq!(found, tmp.path().join(".env.local"));
+    }
+
+    /// Why: absent `.env.local` anywhere in the ancestor chain must return
+    /// `None`, not error.
+    /// Test: itself.
+    #[test]
+    fn absent_env_local_returns_none() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert_eq!(find_workspace_env_local(tmp.path()), None);
+    }
+
+    /// Why: `load_env_from_path` must set a var not already in the process
+    /// environment.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn load_env_from_path_sets_new_var() {
+        let var = "TRUSTY_TEST_DOTENV_NEW_VAR";
+        // SAFETY: `#[serial(dotenv_credential_env)]` guarantees no other
+        // test in this crate mutates process env concurrently with this one.
+        unsafe {
+            std::env::remove_var(var);
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let env_path = tmp.path().join(".env.local");
+        std::fs::write(&env_path, format!("{var}=from-dotenv\n")).unwrap();
+        assert!(load_env_from_path(&env_path));
+        assert_eq!(std::env::var(var).unwrap(), "from-dotenv");
+        unsafe {
+            std::env::remove_var(var);
+        }
+    }
+
+    /// Why: `dotenvy` must never override a variable already set in the
+    /// process environment — this is the mechanism that gives "process env
+    /// beats `.env.local`" precedence for free.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn load_env_from_path_does_not_override_existing() {
+        let var = "TRUSTY_TEST_DOTENV_EXISTING_VAR";
+        // SAFETY: see `load_env_from_path_sets_new_var`.
+        unsafe {
+            std::env::set_var(var, "already-set");
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let env_path = tmp.path().join(".env.local");
+        std::fs::write(&env_path, format!("{var}=from-dotenv\n")).unwrap();
+        assert!(load_env_from_path(&env_path));
+        assert_eq!(std::env::var(var).unwrap(), "already-set");
+        unsafe {
+            std::env::remove_var(var);
+        }
+    }
+}

--- a/crates/trusty-common/src/inference/credentials/file_store.rs
+++ b/crates/trusty-common/src/inference/credentials/file_store.rs
@@ -35,13 +35,21 @@ const CREDENTIALS_FILE: &str = "credentials.toml";
 /// Why: a nested table (vs. a flat top-level table) leaves room for future
 /// non-key metadata (e.g. a schema-version stamp) without a breaking format
 /// change; documented here per the ticket's "pick simple, document" note.
-#[derive(Debug, Default, Serialize, Deserialize)]
+/// Deliberately does NOT derive `Debug` (QA finding on PR #2427): the struct
+/// holds plaintext credential values and a derived `Debug` would print them.
+#[derive(Default, Serialize, Deserialize)]
 struct CredentialsFile {
     #[serde(default)]
     keys: BTreeMap<String, String>,
 }
 
 /// File-backed credential store. See module docs.
+///
+/// Deriving `Debug` is safe here (unlike `MemoryKeyStore`): the struct holds
+/// only the target path and a `Mutex<()>` — credential values never live in
+/// memory beyond a single call. Pinned by
+/// `tests::debug_output_never_contains_values`.
+#[derive(Debug)]
 pub struct FileKeyStore {
     path: PathBuf,
     // Serialises read-modify-write cycles within this process; the atomic
@@ -78,7 +86,7 @@ impl FileKeyStore {
         match std::fs::read_to_string(&self.path) {
             Ok(raw) => toml::from_str(&raw).map_err(|e| KeyStoreError::Toml {
                 path: self.path.clone(),
-                message: e.to_string(),
+                message: sanitize_toml_error(&e),
             }),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(CredentialsFile::default()),
             Err(e) => Err(KeyStoreError::Io {
@@ -100,11 +108,7 @@ impl FileKeyStore {
             message: e.to_string(),
         })?;
         let tmp = self.path.with_extension("toml.tmp");
-        std::fs::write(&tmp, &toml_str).map_err(|e| KeyStoreError::Io {
-            path: tmp.clone(),
-            source: e,
-        })?;
-        set_permissions_0600(&tmp)?;
+        write_owner_only(&tmp, &toml_str)?;
         std::fs::rename(&tmp, &self.path).map_err(|e| KeyStoreError::Io {
             path: self.path.clone(),
             source: e,
@@ -117,14 +121,90 @@ impl FileKeyStore {
     }
 }
 
+/// Strip file content from a TOML parse error, keeping only the error kind
+/// and byte-offset location.
+///
+/// Why (QA finding on PR #2427): `toml::de::Error`'s `Display` embeds an
+/// annotated snippet of the offending source line — for `credentials.toml`
+/// that line can BE a secret (e.g. a truncated `fireworks = "sk-…` from an
+/// interrupted write). The sanitized message keeps everything a human needs
+/// to diagnose the file (what went wrong, where) without ever echoing the
+/// content into an error that callers will log.
+/// What: `e.message()` (the kind string, no snippet) plus the byte span when
+/// available.
+/// Test: `tests::toml_error_never_contains_file_content`.
+fn sanitize_toml_error(e: &toml::de::Error) -> String {
+    match e.span() {
+        Some(span) => format!(
+            "{} (at byte offset {}..{})",
+            e.message(),
+            span.start,
+            span.end
+        ),
+        None => e.message().to_string(),
+    }
+}
+
+/// Write `content` to `path` such that the file is owner-read-write-only
+/// (`0600`) from the moment it exists.
+///
+/// Why (QA finding on PR #2427): the previous `fs::write` → `set_permissions`
+/// sequence left (a) a window where the file existed world-readable under the
+/// default umask and (b) — if the process died between the two calls — a
+/// *persistent* `0644` tmp file containing every key. Creating the file with
+/// `mode(0o600)` closes both. `set_permissions` is still called afterwards to
+/// handle a pre-existing tmp file (e.g. leftover from a crash before this fix
+/// shipped), since `mode()` applies only at creation.
+/// What: unix builds open with `OpenOptions::mode(0o600)`; non-unix builds
+/// fall back to `fs::write` (best-effort, no POSIX-mode equivalent — see
+/// module docs).
+/// Test: `tests::tmp_write_path_is_0600_from_birth`,
+/// `tests::preexisting_loose_tmp_file_is_tightened`.
+#[cfg(unix)]
+fn write_owner_only(path: &Path, content: &str) -> Result<(), KeyStoreError> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let io_err = |e: std::io::Error| KeyStoreError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    };
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(io_err)?;
+    // `mode()` only applies when the file is CREATED; a pre-existing loose
+    // tmp file (crash leftover) keeps its old mode, so tighten explicitly.
+    std::fs::set_permissions(path, {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::Permissions::from_mode(0o600)
+    })
+    .map_err(io_err)?;
+    file.write_all(content.as_bytes()).map_err(io_err)
+}
+
+/// Non-unix best-effort variant — see [`write_owner_only`] docs.
+#[cfg(not(unix))]
+fn write_owner_only(path: &Path, content: &str) -> Result<(), KeyStoreError> {
+    std::fs::write(path, content).map_err(|e| KeyStoreError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })
+}
+
 /// Set `path`'s permissions to owner-read-write-only (`0600`).
 ///
 /// Why: `credentials.toml` holds plaintext API keys; group/world-readable
-/// permissions would leak them to any other local user.
+/// permissions would leak them to any other local user. Used to re-assert
+/// `0600` on the final path after the rename (some platforms/filesystems
+/// don't preserve permissions across rename; an out-of-band writer could
+/// have loosened them).
 /// What: unix-only via `std::os::unix::fs::PermissionsExt`; on non-unix
 /// targets this is a documented best-effort no-op (see module docs — no
 /// portable POSIX-mode equivalent exists on Windows).
-/// Test: `file_store_tests::file_is_created_with_0600_perms` (unix only).
+/// Test: `tests::file_is_created_with_0600_perms` (unix only).
 #[cfg(unix)]
 fn set_permissions_0600(path: &Path) -> Result<(), KeyStoreError> {
     use std::os::unix::fs::PermissionsExt;
@@ -255,5 +335,84 @@ mod tests {
         let store = FileKeyStore::at(tmp.path());
         assert_eq!(store.list(), Vec::<String>::new());
         assert_eq!(store.get("anything"), None);
+    }
+
+    /// Why: QA regression (PR #2427) — `{:?}` after a `set` must never
+    /// contain the plaintext value. `FileKeyStore` holds no values in
+    /// memory, so its derived `Debug` is safe; this pins that property
+    /// against a future field addition.
+    /// Test: itself.
+    #[test]
+    fn debug_output_never_contains_values() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = FileKeyStore::at(tmp.path());
+        store.set("fireworks", "fw-super-secret-value").unwrap();
+        let dbg = format!("{store:?}");
+        assert!(
+            !dbg.contains("fw-super-secret-value"),
+            "Debug output leaked a credential value: {dbg}"
+        );
+    }
+
+    /// Why: QA regression (PR #2427) — a malformed `credentials.toml` (e.g.
+    /// truncated mid-value by an interrupted write) must not echo the file's
+    /// content — which includes secrets — into the error message that
+    /// callers will log.
+    /// Test: itself.
+    #[test]
+    fn toml_error_never_contains_file_content() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = FileKeyStore::at(tmp.path());
+        let dir = tmp.path().join(".trusty-tools");
+        std::fs::create_dir_all(&dir).unwrap();
+        // A truncated write: unterminated string carrying the secret.
+        std::fs::write(
+            dir.join("credentials.toml"),
+            "[keys]\nfireworks = \"fw-truncated-secret",
+        )
+        .unwrap();
+        // `get` swallows read errors into None by contract…
+        assert_eq!(store.get("fireworks"), None);
+        // …but `set` surfaces the parse failure; its message must be
+        // sanitized (kind + offset only, no source snippet).
+        let err = store.set("openai", "sk-new").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("fw-truncated-secret"),
+            "TOML error leaked file content: {msg}"
+        );
+        assert!(matches!(err, KeyStoreError::Toml { .. }), "got {msg}");
+    }
+
+    /// Why: QA regression (PR #2427) — the tmp file must be `0600` from the
+    /// moment it exists (no `fs::write`-then-chmod read window, no
+    /// persistent loose tmp file if the process dies mid-write).
+    /// Test: itself (unix only).
+    #[cfg(unix)]
+    #[test]
+    fn tmp_write_path_is_0600_from_birth() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let target = tmp.path().join("fresh.toml");
+        write_owner_only(&target, "[keys]\n").unwrap();
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600 at creation, got {mode:o}");
+    }
+
+    /// Why: `OpenOptions::mode` applies only at creation — a loose tmp file
+    /// left over from a crash before this fix must still be tightened when
+    /// reused.
+    /// Test: itself (unix only).
+    #[cfg(unix)]
+    #[test]
+    fn preexisting_loose_tmp_file_is_tightened() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let target = tmp.path().join("stale.toml");
+        std::fs::write(&target, "old").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+        write_owner_only(&target, "[keys]\n").unwrap();
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected tightened 0600, got {mode:o}");
     }
 }

--- a/crates/trusty-common/src/inference/credentials/file_store.rs
+++ b/crates/trusty-common/src/inference/credentials/file_store.rs
@@ -1,0 +1,259 @@
+//! `~/.trusty-tools/credentials.toml` `KeyStore` backend (issue #2401).
+//!
+//! Why: headless/CI environments (and any operator without an OS keychain
+//! session — SSH, containers) need a durable credential store that doesn't
+//! require desktop-session keychain access. Bob-approved: a `0600`-permission
+//! flat file directly under `~/.trusty-tools/` (a sibling of the per-crate
+//! `~/.trusty-tools/<crate>/` directories the `crate_config` module manages,
+//! not nested under one, since credentials are cross-crate) is an acceptable
+//! **permanent** posture for that case, not just a bootstrap fallback.
+//! What: [`FileKeyStore`] persists a `[keys]` TOML table
+//! (`fireworks = "..."` etc.) atomically (write-to-`.tmp` + rename, mirroring
+//! `crate_config::save_at`'s convention) and re-asserts `0600` permissions on
+//! every write. The base directory is injectable via [`FileKeyStore::at`] so
+//! tests never touch the real `$HOME`; [`FileKeyStore::new`] resolves the
+//! real one via `dirs::home_dir()`.
+//! Test: `file_store_tests` (sibling file).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+use super::{KeyStore, KeyStoreError};
+
+/// Cross-crate credentials directory name, sibling to the per-crate
+/// `crate_config` directories, both living directly under `$HOME`.
+const CREDENTIALS_DIR: &str = ".trusty-tools";
+
+/// Credential file name within [`CREDENTIALS_DIR`].
+const CREDENTIALS_FILE: &str = "credentials.toml";
+
+/// On-disk shape: a single `[keys]` table, `provider = "value"` entries.
+///
+/// Why: a nested table (vs. a flat top-level table) leaves room for future
+/// non-key metadata (e.g. a schema-version stamp) without a breaking format
+/// change; documented here per the ticket's "pick simple, document" note.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct CredentialsFile {
+    #[serde(default)]
+    keys: BTreeMap<String, String>,
+}
+
+/// File-backed credential store. See module docs.
+pub struct FileKeyStore {
+    path: PathBuf,
+    // Serialises read-modify-write cycles within this process; the atomic
+    // tmp+rename write additionally protects readers in other processes
+    // from ever observing a torn file.
+    lock: Mutex<()>,
+}
+
+impl FileKeyStore {
+    /// Production constructor: `~/.trusty-tools/credentials.toml`.
+    ///
+    /// Why/What: fails with [`KeyStoreError::HomeUnavailable`] only in a
+    /// stripped environment where `dirs::home_dir()` returns `None`; callers
+    /// (the resolver's `default_store`) fall back to `MemoryKeyStore` in
+    /// that case rather than panicking.
+    pub fn new() -> Result<Self, KeyStoreError> {
+        let home = dirs::home_dir().ok_or(KeyStoreError::HomeUnavailable)?;
+        Ok(Self::at(&home))
+    }
+
+    /// Hermetic constructor: `<base>/.trusty-tools/credentials.toml`.
+    ///
+    /// Why: tests must never write to the real `$HOME`; pointing `base` at a
+    /// tempdir gives byte-identical on-disk layout without touching it.
+    pub fn at(base: &Path) -> Self {
+        let path = base.join(CREDENTIALS_DIR).join(CREDENTIALS_FILE);
+        Self {
+            path,
+            lock: Mutex::new(()),
+        }
+    }
+
+    fn read(&self) -> Result<CredentialsFile, KeyStoreError> {
+        match std::fs::read_to_string(&self.path) {
+            Ok(raw) => toml::from_str(&raw).map_err(|e| KeyStoreError::Toml {
+                path: self.path.clone(),
+                message: e.to_string(),
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(CredentialsFile::default()),
+            Err(e) => Err(KeyStoreError::Io {
+                path: self.path.clone(),
+                source: e,
+            }),
+        }
+    }
+
+    fn write(&self, data: &CredentialsFile) -> Result<(), KeyStoreError> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| KeyStoreError::Io {
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+        }
+        let toml_str = toml::to_string_pretty(data).map_err(|e| KeyStoreError::Toml {
+            path: self.path.clone(),
+            message: e.to_string(),
+        })?;
+        let tmp = self.path.with_extension("toml.tmp");
+        std::fs::write(&tmp, &toml_str).map_err(|e| KeyStoreError::Io {
+            path: tmp.clone(),
+            source: e,
+        })?;
+        set_permissions_0600(&tmp)?;
+        std::fs::rename(&tmp, &self.path).map_err(|e| KeyStoreError::Io {
+            path: self.path.clone(),
+            source: e,
+        })?;
+        // Re-assert 0600 on the final path too: some platforms/filesystems
+        // don't preserve permissions across rename, and a future writer
+        // could have loosened them out-of-band.
+        set_permissions_0600(&self.path)?;
+        Ok(())
+    }
+}
+
+/// Set `path`'s permissions to owner-read-write-only (`0600`).
+///
+/// Why: `credentials.toml` holds plaintext API keys; group/world-readable
+/// permissions would leak them to any other local user.
+/// What: unix-only via `std::os::unix::fs::PermissionsExt`; on non-unix
+/// targets this is a documented best-effort no-op (see module docs — no
+/// portable POSIX-mode equivalent exists on Windows).
+/// Test: `file_store_tests::file_is_created_with_0600_perms` (unix only).
+#[cfg(unix)]
+fn set_permissions_0600(path: &Path) -> Result<(), KeyStoreError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+        KeyStoreError::Io {
+            path: path.to_path_buf(),
+            source: e,
+        }
+    })
+}
+
+/// Non-unix best-effort no-op — see [`set_permissions_0600`] docs.
+#[cfg(not(unix))]
+fn set_permissions_0600(_path: &Path) -> Result<(), KeyStoreError> {
+    Ok(())
+}
+
+impl KeyStore for FileKeyStore {
+    fn get(&self, provider: &str) -> Option<String> {
+        let _guard = self.lock.lock().unwrap_or_else(|p| p.into_inner());
+        self.read().ok()?.keys.get(provider).cloned()
+    }
+
+    fn set(&self, provider: &str, value: &str) -> Result<(), KeyStoreError> {
+        let _guard = self.lock.lock().unwrap_or_else(|p| p.into_inner());
+        let mut data = self.read()?;
+        data.keys.insert(provider.to_string(), value.to_string());
+        self.write(&data)
+    }
+
+    fn unset(&self, provider: &str) -> Result<(), KeyStoreError> {
+        let _guard = self.lock.lock().unwrap_or_else(|p| p.into_inner());
+        let mut data = self.read()?;
+        data.keys.remove(provider);
+        self.write(&data)
+    }
+
+    fn list(&self) -> Vec<String> {
+        let _guard = self.lock.lock().unwrap_or_else(|p| p.into_inner());
+        self.read()
+            .map(|d| d.keys.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the store must round-trip a value through set/get exactly.
+    /// Test: itself.
+    #[test]
+    fn set_then_get_round_trips() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = FileKeyStore::at(tmp.path());
+        assert_eq!(store.get("fireworks"), None);
+        store.set("fireworks", "fw-secret").unwrap();
+        assert_eq!(store.get("fireworks"), Some("fw-secret".to_string()));
+    }
+
+    /// Why: `unset` must remove the entry and be a no-op when absent.
+    /// Test: itself.
+    #[test]
+    fn unset_removes_and_is_idempotent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = FileKeyStore::at(tmp.path());
+        store.set("openai", "sk-abc").unwrap();
+        store.unset("openai").unwrap();
+        assert_eq!(store.get("openai"), None);
+        store.unset("openai").unwrap();
+    }
+
+    /// Why: `list` must return names only, and multiple entries must all
+    /// survive a write/read cycle.
+    /// Test: itself.
+    #[test]
+    fn list_returns_all_provider_names() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = FileKeyStore::at(tmp.path());
+        store.set("anthropic", "sk-ant-secret").unwrap();
+        store.set("openrouter", "or-secret").unwrap();
+        let mut names = store.list();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["anthropic".to_string(), "openrouter".to_string()]
+        );
+    }
+
+    /// Why: the acceptance criterion requires `credentials.toml` to exist
+    /// with exactly `0600` permissions after a write.
+    /// Test: itself (unix only — see `set_permissions_0600` docs for the
+    /// non-unix no-op).
+    #[cfg(unix)]
+    #[test]
+    fn file_is_created_with_0600_perms() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = FileKeyStore::at(tmp.path());
+        store.set("fireworks", "fw-secret").unwrap();
+        let path = tmp.path().join(".trusty-tools").join("credentials.toml");
+        assert!(path.is_file());
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+    }
+
+    /// Why: perms must be re-asserted on every write, not just the first.
+    /// Test: itself.
+    #[cfg(unix)]
+    #[test]
+    fn perms_are_reasserted_on_every_write() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = FileKeyStore::at(tmp.path());
+        store.set("fireworks", "fw-secret").unwrap();
+        let path = tmp.path().join(".trusty-tools").join("credentials.toml");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        store.set("openai", "sk-abc").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected re-asserted 0600, got {mode:o}");
+    }
+
+    /// Why: an absent file must read as an empty store, not an error.
+    /// Test: itself.
+    #[test]
+    fn absent_file_reads_as_empty() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = FileKeyStore::at(tmp.path());
+        assert_eq!(store.list(), Vec::<String>::new());
+        assert_eq!(store.get("anything"), None);
+    }
+}

--- a/crates/trusty-common/src/inference/credentials/keyring_store.rs
+++ b/crates/trusty-common/src/inference/credentials/keyring_store.rs
@@ -1,0 +1,158 @@
+//! OS-keychain `KeyStore` backend (issue #2401), feature `keyring-store`.
+//!
+//! Why: an OS keychain (macOS Keychain, Windows Credential Manager, Secret
+//! Service on Linux) is the strongest available local credential store when
+//! a desktop session is present, but it is unavailable — or errors in
+//! surprising ways — headless (SSH, CI, containers, locked session). Rather
+//! than let every caller special-case that, this backend runs a one-time
+//! probe and caches the result, so a caller can always ask
+//! [`KeyringStore::probe_available`] and fall back to `FileKeyStore`
+//! ([`super::resolver::default_store`] does exactly this).
+//! What: [`KeyringStore`] wraps the `keyring` crate. Service name convention:
+//! `"trusty-tools"`; account = provider name (e.g. `fireworks`). The probe
+//! attempts a harmless `get_password` on a sentinel entry — a `NoEntry`
+//! result still counts as "backend available" (the keychain answered); any
+//! other error (locked, denied, unsupported platform) marks the backend
+//! unavailable for the remainder of the process.
+//! Test: `keyring_store_tests` (sibling file) — compile-check and the
+//! probe-failure path only. **No test in this module touches a real OS
+//! keychain**, per the ticket's acceptance criterion.
+
+use std::sync::OnceLock;
+
+use super::{KeyStore, KeyStoreError};
+
+/// Keychain service name every trusty-* credential lives under.
+const SERVICE: &str = "trusty-tools";
+
+/// Sentinel account name used only by [`KeyringStore::probe`] — never a real
+/// provider, so it can never collide with a stored credential.
+const PROBE_ACCOUNT: &str = "__trusty_probe__";
+
+/// OS-keychain credential store. See module docs.
+pub struct KeyringStore {
+    available: OnceLock<bool>,
+}
+
+impl KeyringStore {
+    /// New store. The probe does not run until first use (`get`/`set`/
+    /// `unset`/`list`/[`probe_available`](Self::probe_available)).
+    pub fn new() -> Self {
+        Self {
+            available: OnceLock::new(),
+        }
+    }
+
+    /// Whether the keychain backend answered the probe successfully. Cached
+    /// after the first call for the lifetime of this store.
+    ///
+    /// Why: exposed so [`super::resolver::default_store`] can decide whether
+    /// to hand out this backend or fall back to `FileKeyStore` without
+    /// duplicating the probe logic.
+    pub fn probe_available(&self) -> bool {
+        *self.available.get_or_init(Self::probe)
+    }
+
+    /// Why: see module docs — any backend error other than "no such entry"
+    /// marks the keychain unavailable.
+    /// What: attempts `Entry::new(SERVICE, PROBE_ACCOUNT).get_password()`;
+    /// `Ok(_)` or `Err(keyring::Error::NoEntry)` both mean "the backend
+    /// answered", so both count as available.
+    /// Test: `keyring_store_tests::probe_does_not_panic`.
+    fn probe() -> bool {
+        match keyring::Entry::new(SERVICE, PROBE_ACCOUNT) {
+            Ok(entry) => matches!(entry.get_password(), Ok(_) | Err(keyring::Error::NoEntry)),
+            Err(_) => false,
+        }
+    }
+}
+
+impl Default for KeyringStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KeyStore for KeyringStore {
+    fn get(&self, provider: &str) -> Option<String> {
+        if !self.probe_available() {
+            return None;
+        }
+        keyring::Entry::new(SERVICE, provider)
+            .ok()?
+            .get_password()
+            .ok()
+    }
+
+    fn set(&self, provider: &str, value: &str) -> Result<(), KeyStoreError> {
+        if !self.probe_available() {
+            return Err(KeyStoreError::Keyring(
+                "keychain backend unavailable".to_string(),
+            ));
+        }
+        let entry = keyring::Entry::new(SERVICE, provider)
+            .map_err(|e| KeyStoreError::Keyring(e.to_string()))?;
+        entry
+            .set_password(value)
+            .map_err(|e| KeyStoreError::Keyring(e.to_string()))
+    }
+
+    fn unset(&self, provider: &str) -> Result<(), KeyStoreError> {
+        if !self.probe_available() {
+            return Err(KeyStoreError::Keyring(
+                "keychain backend unavailable".to_string(),
+            ));
+        }
+        let entry = keyring::Entry::new(SERVICE, provider)
+            .map_err(|e| KeyStoreError::Keyring(e.to_string()))?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(KeyStoreError::Keyring(e.to_string())),
+        }
+    }
+
+    fn list(&self) -> Vec<String> {
+        // Why: no OS keychain exposes a portable "list all accounts for a
+        // service" API through the `keyring` crate. Enumeration is left to
+        // `FileKeyStore`/`MemoryKeyStore`; `KeyringStore::list` documents the
+        // limitation rather than returning a misleading partial result.
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the probe must never panic regardless of whether a real
+    /// keychain is present in the CI/dev environment running this test —
+    /// this is the "compile-check / probe-failure-path only" acceptance
+    /// criterion, not an assertion on the *result* of the probe.
+    /// Test: itself.
+    #[test]
+    fn probe_does_not_panic() {
+        let store = KeyringStore::new();
+        let _ = store.probe_available();
+    }
+
+    /// Why: probe result must be cached — a second call must not re-invoke
+    /// the backend (observable via `OnceLock` returning the same value both
+    /// times without panicking, whatever the environment's answer is).
+    /// Test: itself.
+    #[test]
+    fn probe_is_cached() {
+        let store = KeyringStore::new();
+        let first = store.probe_available();
+        let second = store.probe_available();
+        assert_eq!(first, second);
+    }
+
+    /// Why: `list()` must document the enumeration limitation, not attempt
+    /// (and potentially fail against) a real keychain.
+    /// Test: itself.
+    #[test]
+    fn list_is_always_empty() {
+        let store = KeyringStore::new();
+        assert_eq!(store.list(), Vec::<String>::new());
+    }
+}

--- a/crates/trusty-common/src/inference/credentials/keyring_store.rs
+++ b/crates/trusty-common/src/inference/credentials/keyring_store.rs
@@ -29,28 +29,40 @@ const SERVICE: &str = "trusty-tools";
 /// provider, so it can never collide with a stored credential.
 const PROBE_ACCOUNT: &str = "__trusty_probe__";
 
+/// Process-wide probe cache (QA fix, PR #2427).
+///
+/// Why: the cache was originally a per-instance field, but
+/// [`super::resolver::default_store`] constructs a fresh `KeyringStore` per
+/// call, so every `resolve_key` re-probed the OS keychain — needless cost
+/// and, worse, two calls could observe different availability (breaking the
+/// write-then-read consistency #2404's `config` verbs need). A `static`
+/// makes the probe truly once-per-process, matching the documented
+/// semantics.
+static PROBE_RESULT: OnceLock<bool> = OnceLock::new();
+
 /// OS-keychain credential store. See module docs.
-pub struct KeyringStore {
-    available: OnceLock<bool>,
-}
+///
+/// Deriving `Debug` is safe: the struct is stateless (the probe cache is a
+/// module `static`) and credential values never live in memory beyond a
+/// single call. Pinned by `tests::debug_output_never_contains_values`.
+#[derive(Debug)]
+pub struct KeyringStore;
 
 impl KeyringStore {
     /// New store. The probe does not run until first use (`get`/`set`/
-    /// `unset`/`list`/[`probe_available`](Self::probe_available)).
+    /// `unset`/[`probe_available`](Self::probe_available)).
     pub fn new() -> Self {
-        Self {
-            available: OnceLock::new(),
-        }
+        Self
     }
 
     /// Whether the keychain backend answered the probe successfully. Cached
-    /// after the first call for the lifetime of this store.
+    /// process-wide after the first call (see [`PROBE_RESULT`]).
     ///
     /// Why: exposed so [`super::resolver::default_store`] can decide whether
     /// to hand out this backend or fall back to `FileKeyStore` without
     /// duplicating the probe logic.
     pub fn probe_available(&self) -> bool {
-        *self.available.get_or_init(Self::probe)
+        *PROBE_RESULT.get_or_init(Self::probe)
     }
 
     /// Why: see module docs — any backend error other than "no such entry"
@@ -135,15 +147,15 @@ mod tests {
         let _ = store.probe_available();
     }
 
-    /// Why: probe result must be cached — a second call must not re-invoke
-    /// the backend (observable via `OnceLock` returning the same value both
-    /// times without panicking, whatever the environment's answer is).
+    /// Why: probe result must be cached process-wide — a second call (even
+    /// on a DIFFERENT instance, matching `default_store`'s
+    /// fresh-instance-per-call pattern) must observe the same answer without
+    /// re-invoking the backend.
     /// Test: itself.
     #[test]
-    fn probe_is_cached() {
-        let store = KeyringStore::new();
-        let first = store.probe_available();
-        let second = store.probe_available();
+    fn probe_is_cached_across_instances() {
+        let first = KeyringStore::new().probe_available();
+        let second = KeyringStore::new().probe_available();
         assert_eq!(first, second);
     }
 
@@ -154,5 +166,17 @@ mod tests {
     fn list_is_always_empty() {
         let store = KeyringStore::new();
         assert_eq!(store.list(), Vec::<String>::new());
+    }
+
+    /// Why: QA regression (PR #2427) — `{:?}` of every store type must
+    /// never contain a credential value. `KeyringStore` is stateless, so
+    /// this pins that the type stays value-free (no `set` here: writing to
+    /// a real keychain is forbidden in tests; statelessness makes the
+    /// property structural).
+    /// Test: itself.
+    #[test]
+    fn debug_output_never_contains_values() {
+        let dbg = format!("{:?}", KeyringStore::new());
+        assert_eq!(dbg, "KeyringStore");
     }
 }

--- a/crates/trusty-common/src/inference/credentials/memory_store.rs
+++ b/crates/trusty-common/src/inference/credentials/memory_store.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use super::{KeyStore, KeyStoreError};
 
 /// In-memory credential store. See module docs.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct MemoryKeyStore {
     inner: Mutex<HashMap<String, String>>,
 }
@@ -23,6 +23,30 @@ impl MemoryKeyStore {
     /// New, empty store.
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+/// Hand-written redacting `Debug` — provider names only, never values.
+///
+/// Why: a derived `Debug` would print the raw credential values (QA finding
+/// on PR #2427), and this type is public AND the production fallback when
+/// `$HOME` is unresolvable, so a stray `{:?}` in a log line would leak every
+/// stored key. Hand-writing it keeps the type debuggable (names + count)
+/// while making value leakage structurally impossible.
+/// What: renders as `MemoryKeyStore { providers: [..names..] }`.
+/// Test: `debug_output_never_contains_values`.
+impl std::fmt::Debug for MemoryKeyStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let names: Vec<String> = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .keys()
+            .cloned()
+            .collect();
+        f.debug_struct("MemoryKeyStore")
+            .field("providers", &names)
+            .finish()
     }
 }
 
@@ -105,5 +129,24 @@ mod tests {
         );
         assert!(!names.contains(&"sk-ant-secret".to_string()));
         assert!(!names.contains(&"or-secret".to_string()));
+    }
+
+    /// Why: QA regression (PR #2427) — the previous derived `Debug` printed
+    /// raw credential values; `{:?}` after a `set` must never contain the
+    /// plaintext value (provider names are fine).
+    /// Test: itself.
+    #[test]
+    fn debug_output_never_contains_values() {
+        let store = MemoryKeyStore::new();
+        store.set("fireworks", "fw-super-secret-value").unwrap();
+        let dbg = format!("{store:?}");
+        assert!(
+            !dbg.contains("fw-super-secret-value"),
+            "Debug output leaked a credential value: {dbg}"
+        );
+        assert!(
+            dbg.contains("fireworks"),
+            "names should remain visible: {dbg}"
+        );
     }
 }

--- a/crates/trusty-common/src/inference/credentials/memory_store.rs
+++ b/crates/trusty-common/src/inference/credentials/memory_store.rs
@@ -1,0 +1,109 @@
+//! In-memory `KeyStore` — the test/CI backend.
+//!
+//! Why: unit tests and CI must never touch the real filesystem or an OS
+//! keychain. `MemoryKeyStore` gives every precedence/round-trip test a
+//! process-local, infallible backend so the acceptance criterion "zero tests
+//! touch a real keychain" is trivially satisfiable.
+//! What: a `HashMap<String, String>` behind a `Mutex`. All four `KeyStore`
+//! operations are infallible — `set`/`unset` always return `Ok(())`.
+//! Test: `memory_store_tests` (sibling file).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use super::{KeyStore, KeyStoreError};
+
+/// In-memory credential store. See module docs.
+#[derive(Debug, Default)]
+pub struct MemoryKeyStore {
+    inner: Mutex<HashMap<String, String>>,
+}
+
+impl MemoryKeyStore {
+    /// New, empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl KeyStore for MemoryKeyStore {
+    fn get(&self, provider: &str) -> Option<String> {
+        // A poisoned lock (a prior panic while held) is not the caller's
+        // problem — recover the map rather than propagating the poison, per
+        // the "no unwrap in library code" / "fail gracefully" conventions.
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(provider)
+            .cloned()
+    }
+
+    fn set(&self, provider: &str, value: &str) -> Result<(), KeyStoreError> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(provider.to_string(), value.to_string());
+        Ok(())
+    }
+
+    fn unset(&self, provider: &str) -> Result<(), KeyStoreError> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(provider);
+        Ok(())
+    }
+
+    fn list(&self) -> Vec<String> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .keys()
+            .cloned()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the store must round-trip a value through set/get exactly.
+    /// Test: itself.
+    #[test]
+    fn set_then_get_round_trips() {
+        let store = MemoryKeyStore::new();
+        assert_eq!(store.get("fireworks"), None);
+        store.set("fireworks", "fw-secret").unwrap();
+        assert_eq!(store.get("fireworks"), Some("fw-secret".to_string()));
+    }
+
+    /// Why: `unset` must remove the entry and be a no-op when absent.
+    /// Test: itself.
+    #[test]
+    fn unset_removes_and_is_idempotent() {
+        let store = MemoryKeyStore::new();
+        store.set("openai", "sk-abc").unwrap();
+        store.unset("openai").unwrap();
+        assert_eq!(store.get("openai"), None);
+        // Unsetting an already-absent key must not error.
+        store.unset("openai").unwrap();
+    }
+
+    /// Why: `list` must return names only, never the stored values.
+    /// Test: itself.
+    #[test]
+    fn list_returns_names_only() {
+        let store = MemoryKeyStore::new();
+        store.set("anthropic", "sk-ant-secret").unwrap();
+        store.set("openrouter", "or-secret").unwrap();
+        let mut names = store.list();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["anthropic".to_string(), "openrouter".to_string()]
+        );
+        assert!(!names.contains(&"sk-ant-secret".to_string()));
+        assert!(!names.contains(&"or-secret".to_string()));
+    }
+}

--- a/crates/trusty-common/src/inference/credentials/mod.rs
+++ b/crates/trusty-common/src/inference/credentials/mod.rs
@@ -1,0 +1,112 @@
+//! Credential resolver + secure `KeyStore` (issue #2401, epic #2400 Wave 1).
+//!
+//! Why: every inference-adapter consumer needs the same answer to "where is
+//! the API key for provider X" — checked in the same order, with the same
+//! never-print-the-value discipline. Before this module, each crate either
+//! read `std::env::var` directly (no `.env.local` fallback, no secure-store
+//! fallback) or embedded its own ad hoc dotenv call. Centralising the trait,
+//! the three backends, and the precedence chain here means every future
+//! `inference-client` consumer (and, eventually, the migrated
+//! trusty-agents / trusty-search dotenvy call sites) gets identical
+//! behaviour for free.
+//!
+//! What: [`KeyStore`] is the storage trait ([`memory_store::MemoryKeyStore`],
+//! [`file_store::FileKeyStore`], and — behind the `keyring-store` feature —
+//! `keyring_store::KeyringStore`). [`resolver::resolve_key`] applies the
+//! 3-tier precedence (process env var via [`resolver::env_var_for`] >
+//! `.env.local` via [`dotenv`] > [`resolver::default_store`]).
+//! [`redact::redact_secret`] is the one credential-masking implementation,
+//! also reused by `memory_core::filter`.
+//!
+//! Test: `cargo test -p trusty-common --features credentials -- inference::credentials::`
+//! and (KeyringStore compile/probe-failure-path only, never a real keychain)
+//! `cargo test -p trusty-common --features keyring-store -- inference::credentials::`.
+
+mod dotenv;
+mod file_store;
+#[cfg(feature = "keyring-store")]
+mod keyring_store;
+mod memory_store;
+mod redact;
+mod resolver;
+
+pub use dotenv::{find_workspace_env_local, load_env_from_path, load_env_local_once};
+pub use file_store::FileKeyStore;
+#[cfg(feature = "keyring-store")]
+pub use keyring_store::KeyringStore;
+pub use memory_store::MemoryKeyStore;
+pub use redact::redact_secret;
+pub use resolver::{default_store, env_var_for, resolve_key, resolve_key_with};
+
+use std::path::PathBuf;
+
+/// Errors raised by a [`KeyStore`] backend.
+///
+/// Why: callers (the future `config` clap module, the resolver's store tier)
+/// need to distinguish "no home directory" from a genuine I/O or parse
+/// failure so they can log or degrade appropriately rather than panicking.
+/// What: one variant per failure class the file-backed and keyring-backed
+/// stores can hit. `MemoryKeyStore` never constructs any of these — its
+/// operations are infallible.
+/// Test: `file_store_tests::*`, `keyring_store_tests::*` (probe-failure path
+/// only).
+#[derive(Debug, thiserror::Error)]
+pub enum KeyStoreError {
+    /// Reading or writing the credential file failed (other than a benign
+    /// not-found, which `FileKeyStore` treats as an empty store).
+    #[error("credential store I/O error at {path}: {source}")]
+    Io {
+        /// The path the failed operation targeted.
+        path: PathBuf,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// The credential TOML could not be parsed or serialised.
+    #[error("credential store TOML error at {path}: {message}")]
+    Toml {
+        /// The path being parsed/serialised when the error occurred.
+        path: PathBuf,
+        /// The `toml` crate's error message.
+        message: String,
+    },
+
+    /// `dirs::home_dir()` returned `None` (a stripped CI/container env).
+    #[error("credential store home directory unavailable")]
+    HomeUnavailable,
+
+    /// The OS keychain backend rejected the operation (locked, denied,
+    /// unsupported platform, or no `keyring-store` feature support for this
+    /// target). Carries the backend's message; never the secret value.
+    #[error("keyring backend error: {0}")]
+    Keyring(String),
+}
+
+/// Storage backend for provider API keys.
+///
+/// Why: the resolver's store tier (and the future `config` clap `set` /
+/// `list` / `unset` verbs) must work identically against an in-memory test
+/// double, a `0600` TOML file, or the OS keychain — one trait, three
+/// interchangeable implementations, selected at runtime by
+/// [`resolver::default_store`].
+/// What: `get` returns `None` on any failure (absent key, unreadable store,
+/// locked keychain) — callers cannot distinguish "not set" from "backend
+/// error" by design, since the resolver only ever needs a fallthrough
+/// signal. `set`/`unset` surface [`KeyStoreError`] because a failed *write*
+/// is actionable. `list` returns provider **names only** — a `KeyStore`
+/// implementation must never return a value from `list`.
+/// Test: `memory_store_tests::*`, `file_store_tests::*`.
+pub trait KeyStore: Send + Sync {
+    /// Look up the stored credential for `provider`. `None` on any miss or
+    /// backend failure — never panics, never logs the (absent) value.
+    fn get(&self, provider: &str) -> Option<String>;
+
+    /// Store `value` under `provider`, overwriting any existing entry.
+    fn set(&self, provider: &str, value: &str) -> Result<(), KeyStoreError>;
+
+    /// Remove `provider`'s entry, if present. Not an error when absent.
+    fn unset(&self, provider: &str) -> Result<(), KeyStoreError>;
+
+    /// List every provider **name** currently stored. Never returns values.
+    fn list(&self) -> Vec<String>;
+}

--- a/crates/trusty-common/src/inference/credentials/mod.rs
+++ b/crates/trusty-common/src/inference/credentials/mod.rs
@@ -67,7 +67,9 @@ pub enum KeyStoreError {
     Toml {
         /// The path being parsed/serialised when the error occurred.
         path: PathBuf,
-        /// The `toml` crate's error message.
+        /// Sanitized error description: kind + byte offset only. Never
+        /// contains file content — the offending line of a credentials
+        /// file IS a secret (see `file_store::sanitize_toml_error`).
         message: String,
     },
 

--- a/crates/trusty-common/src/inference/credentials/redact.rs
+++ b/crates/trusty-common/src/inference/credentials/redact.rs
@@ -1,0 +1,64 @@
+//! The one credential-masking implementation (issue #2401).
+//!
+//! Why: `memory_core::filter` had its own private `redact_token` (issue
+//! #1481) with the exact masking shape this ticket's `config` clap module
+//! (Wave 2) also needs: "never echo the secret back verbatim, but show
+//! enough of it that a human can identify *which* credential tripped a
+//! check". Two independent implementations of the same shape is exactly the
+//! duplication BASE-ENGINEER's consolidation rule targets — this module is
+//! now the single implementation; `memory_core::filter::redact_token`
+//! delegates to it.
+//! What: [`redact_secret`] returns `{head}…({N} chars)` where `head` is the
+//! first 4 characters and `N` is the input's byte length — the exact shape
+//! `memory_core::filter`'s prior private implementation produced, verified
+//! by the pre-existing `redact_token_masks_tail` test which now exercises
+//! this function transitively.
+//! Test: `redact_tests` (sibling file, this module) and
+//! `memory_core::filter_tests::redact_token_masks_tail` (format stability).
+
+/// Head length used by [`redact_secret`]'s default (4 characters), matching
+/// the format `memory_core::filter`'s prior private `redact_token` produced.
+const DEFAULT_HEAD_LEN: usize = 4;
+
+/// Produce a short, non-reversible preview of `secret`.
+///
+/// Why: callers (rejection messages, `config list --show-status`, log lines)
+/// need to name *which* credential they're referring to without ever
+/// echoing the value back. See module docs for the format-stability
+/// rationale.
+/// What: returns the first [`DEFAULT_HEAD_LEN`] characters of `secret`
+/// followed by `…` and `(<byte length> chars)`. Secrets shorter than the
+/// head length are returned with their full (short) prefix — there is no
+/// minimum-length guard here; callers gate on "is this actually secret-
+/// shaped" before calling, same as `memory_core::filter::looks_like_secret`
+/// did for its 20-char floor.
+/// Test: `redact_tests::redact_secret_masks_tail`,
+/// `redact_tests::redact_secret_handles_short_input`.
+pub fn redact_secret(secret: &str) -> String {
+    let head: String = secret.chars().take(DEFAULT_HEAD_LEN).collect();
+    format!("{head}…({} chars)", secret.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: pins the exact format `memory_core::filter` depends on.
+    /// Test: itself.
+    #[test]
+    fn redact_secret_masks_tail() {
+        let r = redact_secret("AbCd1234EfGh5678IjKl9012"); // pragma: allowlist secret
+        assert!(r.starts_with("AbCd"));
+        assert!(r.contains('…'));
+        assert!(r.contains("chars"));
+        assert!(!r.contains("9012"), "tail must be masked: {r}");
+    }
+
+    /// Why: short inputs must not panic (no out-of-bounds slicing).
+    /// Test: itself.
+    #[test]
+    fn redact_secret_handles_short_input() {
+        assert_eq!(redact_secret(""), "…(0 chars)");
+        assert_eq!(redact_secret("ab"), "ab…(2 chars)");
+    }
+}

--- a/crates/trusty-common/src/inference/credentials/resolver.rs
+++ b/crates/trusty-common/src/inference/credentials/resolver.rs
@@ -1,0 +1,249 @@
+//! Composite credential resolver (issue #2401).
+//!
+//! Why: every inference-adapter consumer needs the same 3-tier answer to
+//! "what is provider X's API key" — process env var, then `.env.local`,
+//! then the secure store — checked in that exact order every time.
+//! What: [`resolve_key`] is the production entry point (loads `.env.local`
+//! once, then delegates to [`resolve_key_with`] against
+//! [`default_store`]). [`env_var_for`] is the provider→env-var-name mapping.
+//! [`resolve_key_with`] is the hermetic, store-injectable core: it checks
+//! `std::env::var` (which — because `dotenvy` never overrides an existing
+//! var — transparently reflects "process env" *or* "already-loaded
+//! `.env.local`", whichever tier actually populated it) before falling
+//! through to the injected [`super::KeyStore`]. This is why there is no
+//! separate ".env.local tier" function: the tier is realised entirely by
+//! *when* `.env.local` gets loaded relative to the `std::env::var` check,
+//! not by a distinct code path.
+//! Test: `resolver_tests` (sibling file) exercises all three tiers plus the
+//! absent-tier fallthrough using [`resolve_key_with`] directly against a
+//! `MemoryKeyStore`, so no test depends on `load_env_local_once`'s
+//! once-per-process semantics or the real cwd.
+
+use super::KeyStore;
+use super::dotenv;
+use super::file_store::FileKeyStore;
+#[cfg(feature = "keyring-store")]
+use super::keyring_store::KeyringStore;
+use super::memory_store::MemoryKeyStore;
+
+/// Canonical process-env variable name for a provider's API key.
+///
+/// Why: every call site (the resolver, and eventually the `config` clap
+/// module's `--env` hint) must agree on one name per provider rather than
+/// re-deriving `{PROVIDER}_API_KEY` ad hoc (which breaks for providers whose
+/// canonical env var doesn't follow that shape).
+/// What: case-insensitive match on `provider`; extend this list as new
+/// providers are added in later Wave 1/2 tickets. `None` for an unknown
+/// provider — callers treat that as "env tier does not apply", not an
+/// error.
+/// Test: `resolver_tests::env_var_for_known_providers`,
+/// `resolver_tests::env_var_for_unknown_provider_is_none`.
+pub fn env_var_for(provider: &str) -> Option<&'static str> {
+    match provider.to_ascii_lowercase().as_str() {
+        "fireworks" => Some("FIREWORKS_API_KEY"),
+        "openrouter" => Some("OPENROUTER_API_KEY"),
+        "anthropic" => Some("ANTHROPIC_API_KEY"),
+        "openai" => Some("OPENAI_API_KEY"),
+        _ => None,
+    }
+}
+
+/// Resolve `provider`'s credential using the full 3-tier precedence.
+///
+/// Why: the single production entry point every future `InferenceAdapter`
+/// construction path calls.
+/// What: loads `.env.local` once (see [`dotenv::load_env_local_once`]), then
+/// delegates to [`resolve_key_with`] against [`default_store`].
+/// Test: exercised via `resolve_key_with` (the pure core) in
+/// `resolver_tests`; the `load_env_local_once` + `default_store` wiring is
+/// intentionally not independently unit tested — see their own docs for why.
+pub fn resolve_key(provider: &str) -> Option<String> {
+    dotenv::load_env_local_once();
+    resolve_key_with(provider, default_store().as_ref())
+}
+
+/// Hermetic core: env-var tier, then `store`.
+///
+/// Why: separated from [`resolve_key`] so tests can inject a
+/// [`MemoryKeyStore`] and control the process environment directly, without
+/// ever touching the real filesystem, `$HOME`, or an OS keychain.
+/// What: returns the env var's value when [`env_var_for`] maps `provider`
+/// and that var is set to a non-empty value; otherwise `store.get(provider)`.
+/// Test: `resolver_tests::env_beats_store`,
+/// `resolver_tests::dotenv_loaded_value_beats_store`,
+/// `resolver_tests::falls_through_to_store`,
+/// `resolver_tests::absent_everywhere_is_none`.
+pub fn resolve_key_with(provider: &str, store: &dyn KeyStore) -> Option<String> {
+    if let Some(value) = env_tier(provider) {
+        return Some(value);
+    }
+    store.get(provider)
+}
+
+/// Non-empty `std::env::var` lookup for `provider`'s canonical env var.
+///
+/// Why: an env var set to the empty string is almost always an accidental
+/// `FOO=` in a shell profile, not an intentional "use this empty key" — the
+/// resolver treats it as absent so the store tier still gets a chance.
+fn env_tier(provider: &str) -> Option<String> {
+    let var = env_var_for(provider)?;
+    std::env::var(var).ok().filter(|v| !v.is_empty())
+}
+
+/// Select the secure-store backend: OS keychain when available and
+/// compiled in, else the `0600` file store, else (only when even the home
+/// directory is unresolvable) an in-memory store.
+///
+/// Why: the resolver's store tier must always hand back *some* working
+/// `KeyStore` rather than erroring — a missing home directory or an
+/// unavailable keychain degrades the backend, it doesn't break credential
+/// resolution (env-var-only usage still works).
+/// What: behind the `keyring-store` feature, probes [`KeyringStore`] first
+/// (see its docs for the probe/cache semantics) and returns it when
+/// available; otherwise constructs [`FileKeyStore::new`], falling back to
+/// [`MemoryKeyStore`] only in the (CI/container) case where
+/// `dirs::home_dir()` itself fails.
+/// Test: not independently unit tested (it makes real OS/filesystem calls
+/// by design) — the selection logic is exercised structurally by
+/// `resolve_key`'s production path, and each backend is tested in its own
+/// module.
+pub fn default_store() -> Box<dyn KeyStore> {
+    #[cfg(feature = "keyring-store")]
+    {
+        let keyring = KeyringStore::new();
+        if keyring.probe_available() {
+            return Box::new(keyring);
+        }
+    }
+    match FileKeyStore::new() {
+        Ok(store) => Box::new(store),
+        Err(_) => Box::new(MemoryKeyStore::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    /// Why: pins the canonical mapping used everywhere else in the epic.
+    /// Test: itself.
+    #[test]
+    fn env_var_for_known_providers() {
+        assert_eq!(env_var_for("fireworks"), Some("FIREWORKS_API_KEY"));
+        assert_eq!(env_var_for("OpenRouter"), Some("OPENROUTER_API_KEY"));
+        assert_eq!(env_var_for("anthropic"), Some("ANTHROPIC_API_KEY"));
+        assert_eq!(env_var_for("OPENAI"), Some("OPENAI_API_KEY"));
+    }
+
+    /// Why: an unmapped provider must not panic or synthesise a guess.
+    /// Test: itself.
+    #[test]
+    fn env_var_for_unknown_provider_is_none() {
+        assert_eq!(env_var_for("some-future-provider"), None);
+    }
+
+    /// Why: tier 1 (process env) must win over tier 3 (store) — the core
+    /// precedence contract.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn env_beats_store() {
+        // SAFETY: `#[serial(dotenv_credential_env)]` guarantees no other
+        // test in this crate mutates process env concurrently with this one.
+        unsafe {
+            std::env::set_var("FIREWORKS_API_KEY", "from-env");
+        }
+        let store = MemoryKeyStore::new();
+        store.set("fireworks", "from-store").unwrap();
+        assert_eq!(
+            resolve_key_with("fireworks", &store),
+            Some("from-env".to_string())
+        );
+        unsafe {
+            std::env::remove_var("FIREWORKS_API_KEY");
+        }
+    }
+
+    /// Why: tier 2 (`.env.local`, once loaded into the process env) must
+    /// still win over tier 3 (store) even though `resolve_key_with` only
+    /// ever inspects `std::env::var` directly — this proves the "no
+    /// separate .env.local code path" design actually implements the
+    /// documented precedence.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn dotenv_loaded_value_beats_store() {
+        // SAFETY: see `env_beats_store`.
+        unsafe {
+            std::env::remove_var("OPENROUTER_API_KEY");
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let env_path = tmp.path().join(".env.local");
+        std::fs::write(&env_path, "OPENROUTER_API_KEY=from-dotenv\n").unwrap();
+        assert!(dotenv::load_env_from_path(&env_path));
+
+        let store = MemoryKeyStore::new();
+        store.set("openrouter", "from-store").unwrap();
+        assert_eq!(
+            resolve_key_with("openrouter", &store),
+            Some("from-dotenv".to_string())
+        );
+        unsafe {
+            std::env::remove_var("OPENROUTER_API_KEY");
+        }
+    }
+
+    /// Why: with no env var and no `.env.local` value, the store tier must
+    /// still answer — the fallthrough contract.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn falls_through_to_store() {
+        // SAFETY: see `env_beats_store`.
+        unsafe {
+            std::env::remove_var("ANTHROPIC_API_KEY");
+        }
+        let store = MemoryKeyStore::new();
+        store.set("anthropic", "from-store").unwrap();
+        assert_eq!(
+            resolve_key_with("anthropic", &store),
+            Some("from-store".to_string())
+        );
+    }
+
+    /// Why: when every tier is absent, resolution must return `None`, not
+    /// panic or synthesise a value.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn absent_everywhere_is_none() {
+        // SAFETY: see `env_beats_store`.
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+        }
+        let store = MemoryKeyStore::new();
+        assert_eq!(resolve_key_with("openai", &store), None);
+    }
+
+    /// Why: an env var explicitly set to the empty string must not shadow
+    /// the store tier — see [`env_tier`] docs.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn empty_env_var_falls_through_to_store() {
+        // SAFETY: see `env_beats_store`.
+        unsafe {
+            std::env::set_var("FIREWORKS_API_KEY", "");
+        }
+        let store = MemoryKeyStore::new();
+        store.set("fireworks", "from-store").unwrap();
+        assert_eq!(
+            resolve_key_with("fireworks", &store),
+            Some("from-store".to_string())
+        );
+        unsafe {
+            std::env::remove_var("FIREWORKS_API_KEY");
+        }
+    }
+}

--- a/crates/trusty-common/src/inference/mod.rs
+++ b/crates/trusty-common/src/inference/mod.rs
@@ -1,0 +1,19 @@
+//! Unified inference provider adapter layer (epic #2400).
+//!
+//! Why: `trusty-code`, `trusty-review`, and three internal `trusty-agents`
+//! layers each hand-rolled an LLM client, a credential lookup, and an
+//! `.env.local` loader with subtly different precedence rules. Epic #2400
+//! centralises all of that in `trusty-common` so every consumer shares one
+//! implementation instead of six.
+//!
+//! What: Wave 1 ticket #2401 (this module) ships the credential resolution
+//! layer: [`credentials::KeyStore`] trait, three backends
+//! (`MemoryKeyStore`, `FileKeyStore`, `KeyringStore`), the `resolve_key`
+//! precedence chain (process env > `.env.local` > secure store), and the
+//! shared `redact_secret` helper. Later Wave 1/2 tickets add sibling modules
+//! under `inference/` — the `InferenceAdapter` trait, the two-stage
+//! configurator, and the capability registry — none of which exist yet.
+//!
+//! Test: see `credentials` submodule and its `*_tests` sibling files.
+
+pub mod credentials;

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -348,6 +348,21 @@ pub mod error_capture;
 #[cfg(feature = "crate-config")]
 pub mod crate_config;
 
+/// Unified inference provider adapter layer (epic #2400).
+///
+/// Why: six trusty-* crates each hand-rolled their own LLM client, key
+/// lookup, and `.env.local` loading. Epic #2400 centralises the adapter,
+/// credential resolution, and capability registry here so every consumer
+/// shares one implementation.
+/// What: Gated behind the `credentials` feature. Wave 1 ticket #2401 ships
+/// the [`inference::credentials`] submodule (`KeyStore` trait + 3 backends +
+/// `resolve_key` precedence + `redact_secret`); later Wave 1/2 tickets add
+/// sibling modules (adapter trait, capability registry, provider clients).
+/// Test: `cargo test -p trusty-common --features credentials -- inference::`
+/// and `cargo test -p trusty-common --features keyring-store -- inference::`.
+#[cfg(feature = "credentials")]
+pub mod inference;
+
 // ─── Focused submodules (split from lib.rs in issue #1108) ────────────────
 
 /// TCP port auto-walking helper.

--- a/crates/trusty-common/src/memory_core/filter.rs
+++ b/crates/trusty-common/src/memory_core/filter.rs
@@ -625,14 +625,20 @@ fn looks_like_secret(token: &str) -> bool {
 ///
 /// Why (issue #1481): the rejection message must name *which* token tripped the
 /// gate (so the caller can find and remove it) without echoing the full secret
-/// back into logs or responses.
+/// back into logs or responses. Issue #2401 consolidated the masking logic
+/// itself into `inference::credentials::redact_secret` — the `config` clap
+/// module (epic #2400) needs the identical shape, and duplicating it here
+/// would violate the "one implementation per behaviour" rule. This function
+/// is now a thin delegating wrapper kept for call-site stability and doc
+/// continuity at this module's original issue (#1481).
 /// What: returns the first up-to-4 characters followed by `…` and the token
 /// length, e.g. `sk-A…(48 chars)`. Short tokens (≤ 4 chars never reach here
 /// because the secret heuristic requires length) are returned verbatim.
-/// Test: `redact_token_masks_tail`.
+/// Test: `redact_token_masks_tail` (format stability); the masking
+/// implementation itself is tested in
+/// `inference::credentials::redact::tests`.
 fn redact_token(token: &str) -> String {
-    let head: String = token.chars().take(4).collect();
-    format!("{head}…({} chars)", token.len())
+    crate::inference::credentials::redact_secret(token)
 }
 
 /// Classify drawer content into a `DrawerType` using cheap heuristics.

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -97,7 +97,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 colored = "2"
 indicatif = "0.17"
-dotenvy = "0.15"
+dotenvy = { workspace = true }
 open = "5"
 
 # ── Storage / vector / KG / chunking ───────────────────────────────────────


### PR DESCRIPTION
## Scope

Ticket 1 of epic #2400 (unified inference adapter layer), Wave 1. Ships the credential resolution layer as the FIRST `inference/` submodule in trusty-common: the `KeyStore` trait with three backends, the 3-tier `resolve_key` precedence resolver, the one shared `.env.local` loader, and the public `redact_secret` helper.

New module tree (`crates/trusty-common/src/inference/`):

| File | Contents |
|---|---|
| `mod.rs` | inference/ facade — credentials child only; later tickets add siblings |
| `credentials/mod.rs` | `KeyStore` trait, `KeyStoreError` (thiserror), re-exports |
| `credentials/memory_store.rs` | `MemoryKeyStore` — HashMap behind Mutex; test/CI backend |
| `credentials/file_store.rs` | `FileKeyStore` — `~/.trusty-tools/credentials.toml`, 0600 |
| `credentials/keyring_store.rs` | `KeyringStore` — OS keychain, feature `keyring-store` |
| `credentials/resolver.rs` | `resolve_key` / `resolve_key_with` / `env_var_for` / `default_store` |
| `credentials/dotenv.rs` | `load_env_local_once` / `find_workspace_env_local` / `load_env_from_path` |
| `credentials/redact.rs` | public `redact_secret` |

## Backend design

- **`KeyStore` trait**: `get` returns `Option<String>` (any miss or backend failure → `None`, the resolver only needs a fallthrough signal); `set`/`unset` return `Result<(), KeyStoreError>` (failed writes are actionable); `list` returns provider **names only**, never values.
- **`FileKeyStore`**: TOML shape is a single `[keys]` table (`fireworks = "..."`) — nested rather than flat to leave room for future metadata without a format break. Atomic write (tmp + rename, mirroring `crate_config::save_at`), 0600 asserted on the tmp file AND re-asserted on the final path on **every** write. Non-unix: documented best-effort no-op. Base dir injectable (`FileKeyStore::at`) so tests never touch real `$HOME`. Lives directly under `~/.trusty-tools/` (cross-crate, sibling of the per-crate config dirs). Bob-approved permanent posture for headless/CI.
- **`KeyringStore`** (feature `keyring-store`, new optional `keyring` workspace dep): service `"trusty-tools"`, account = provider name. Runtime probe on first use — a `get_password` against a sentinel account; `Ok` or `NoEntry` = backend answered = available; ANY other error = unavailable, cached in a `OnceLock` for the process lifetime. `list()` returns empty by design (no portable service-enumeration API in the `keyring` crate) — documented limitation; enumeration is the file/memory stores' job.
- **`default_store()`**: keyring-if-probe-passes → `FileKeyStore` → `MemoryKeyStore` (only when `dirs::home_dir()` fails).

## Precedence (`resolve_key`)

1. Process env var via `env_var_for(provider)`: fireworks→`FIREWORKS_API_KEY`, openrouter→`OPENROUTER_API_KEY`, anthropic→`ANTHROPIC_API_KEY`, openai→`OPENAI_API_KEY` (case-insensitive match, extensible). Empty-string values fall through (an accidental `FOO=` must not shadow the store).
2. `.env.local` via the shared loader — idempotent (`OnceLock`), cwd-upward workspace-root discovery. Because dotenvy never overrides existing env vars, tier 1 > tier 2 falls out mechanically; there is no separate tier-2 code path.
3. `default_store()`.

The loader is the canonical replacement for trusty-agents' (`runtime/startup.rs:114-119`) and trusty-search's (`main.rs:1155`) ad hoc dotenvy calls — those call sites are intentionally NOT touched here; retirement happens in their own migration tickets.

## redact consolidation

Public `redact_secret()` (`{head4}…({N} chars)`) is now the ONE masking implementation. `memory_core::filter::redact_token` is a thin delegating wrapper — output format unchanged, pre-existing `redact_token_masks_tail` test green. `memory-core` feature now implies `credentials`.

## Incidental fix

`tests/memory_palace.rs` referenced `memory_core` + the `embedder-test-support`-gated mock seeding unconditionally, so `cargo test -p trusty-common` with default features failed to compile on origin/main. Added the missing `[[test]] required-features = ["memory-core", "embedder-test-support"]` gate (same pattern as the `candle_metal_bench`/`tickets-mcp` bins). Verified the test still builds and passes with those features enabled (3/3 ok).

## Test evidence (raw)

- `cargo build --workspace` — exit 0
- `cargo test -p trusty-common` (default features) — **133 passed; 0 failed; 6 ignored**
- `cargo test -p trusty-common --features keyring-store` — **158 passed; 0 failed; 6 ignored** (all 25 new credentials tests included)
- `cargo test -p trusty-common --features memory-core,embedder-test-support` — 487 lib + 3 memory_palace passed; `filter::tests::redact_token_masks_tail` green
- `cargo test --workspace` — exit 0, **128/128 suites ok, zero failures** (known flakes trusty-console #2331 / trusty-agents telegram_pid_guard passed this run; no isolation needed)
- `cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` — exit 0
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations — OK`
- `git grep -c '<<<<<<<' -- '*.rs'` — only `trusty-agents/src/workflow/resolver.rs:2`, which is pre-existing on origin/main and consists of a doc comment + the byte-literal `b"<<<<<<<"` used by conflict *detection* code, not actual conflict markers

## Acceptance criteria

- [x] KeyStore trait + 3 implementations compile and unit-test green
- [x] FileKeyStore 0600 verified in a tempdir test (`file_is_created_with_0600_perms`, `perms_are_reasserted_on_every_write`)
- [x] Precedence tests all 3 tiers (`env_beats_store`, `dotenv_loaded_value_beats_store`, `falls_through_to_store`, `absent_everywhere_is_none`, `empty_env_var_falls_through_to_store`)
- [x] Shared `.env.local` loader shipped (ad hoc call-site retirement deferred to migration tickets per ticket scope)
- [x] Public `redact_secret()`; `memory_core::filter::redact_token` refactored to delegate, format stable
- [x] Zero tests touch a real keychain — KeyringStore tests are compile/probe-cache-path only; MemoryKeyStore everywhere else

Closes #2401
Part of epic #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)