### PR TITLE
feat(trusty-mpm): tm projects CLI — list/register/show/status + deliverables/milestones subtrees (closes #2115, #2381)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -137,6 +137,24 @@ pub(crate) enum Command {
         #[command(subcommand)]
         action: SessionAction,
     },
+    /// Manage the project registry (registry B) and its Deliverable/Milestone
+    /// ledger.
+    ///
+    /// Why (#2115/#2381, DOC-35 §3.1/§10.8): `tm projects` is the deterministic
+    /// CLI half of the project control plane — a sibling top-level plural noun
+    /// alongside `tm sessions` (#2116). Its verbs are thin HTTP clients over the
+    /// daemon's registry-B surface (§1.3): `list`/`register`/`show`/`status` cover
+    /// the project registry itself, and the `deliverables`/`milestones` subtrees
+    /// cover the L3-substrate work-tracking ledger (§10). Mutating session verbs
+    /// deliberately live at `tm sessions`; `tm projects show` surfaces sessions
+    /// read-only per the naming split.
+    /// What: the `tm projects <action>` command group.
+    /// Test: `cli_parses_projects_*` in `tests_projects.rs`.
+    Projects {
+        /// Project action to perform.
+        #[command(subcommand)]
+        action: ProjectsAction,
+    },
     /// Show the recent hook-event feed.
     Events,
     /// Run a full system diagnostic of the trusty-mpm stack.
@@ -1483,6 +1501,229 @@ pub(crate) enum ProjectAction {
         #[arg(long)]
         dir: Option<String>,
     },
+}
+
+/// Actions for the `tm projects` subcommand (DOC-35 §3.1/§10.8, #2115/#2381).
+///
+/// Why: the registry-B project surface plus the Deliverable/Milestone ledger,
+/// exposed as a deterministic verb tree of thin HTTP clients.
+/// What: the four registry verbs (`list`/`register`/`show`/`status`) and the two
+/// nested subtrees (`deliverables`/`milestones`).
+/// Test: `cli_parses_projects_*` in `tests_projects.rs`.
+#[derive(Debug, Subcommand)]
+pub(crate) enum ProjectsAction {
+    /// List registered projects (optionally filtered by tag).
+    List {
+        /// Emit the raw project JSON instead of the table.
+        #[arg(long)]
+        json: bool,
+        /// Only show projects carrying this tag.
+        #[arg(long)]
+        tag: Option<String>,
+    },
+    /// Register (idempotent upsert) a project in registry B.
+    Register {
+        /// Registry key / short project name.
+        name: String,
+        /// Full repository URL.
+        #[arg(long)]
+        repo_url: String,
+        /// Default branch (daemon defaults to `main` when omitted).
+        #[arg(long)]
+        default_branch: Option<String>,
+        /// Free-form description.
+        #[arg(long)]
+        description: Option<String>,
+        /// Comma-separated classification tags.
+        #[arg(long, value_delimiter = ',')]
+        tags: Vec<String>,
+        /// Technology-stack hint (e.g. `rust`).
+        #[arg(long)]
+        stack_hint: Option<String>,
+        /// Preferred `gh` login for this project (#2081).
+        #[arg(long)]
+        gh_user: Option<String>,
+    },
+    /// Show a project's config PLUS a read-only nested sessions listing.
+    Show {
+        /// Project name.
+        name: String,
+        /// Emit raw JSON (config + sessions) instead of the human view.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a project's deterministic status rollup (session histogram + flags).
+    Status {
+        /// Project name.
+        name: String,
+        /// Emit the raw status JSON instead of the human view.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Manage a project's Deliverables (§10.8).
+    Deliverables {
+        /// Deliverable action to perform.
+        #[command(subcommand)]
+        action: DeliverablesAction,
+    },
+    /// Manage a project's Milestones (§10.8).
+    Milestones {
+        /// Milestone action to perform.
+        #[command(subcommand)]
+        action: MilestonesAction,
+    },
+}
+
+/// Actions for `tm projects deliverables` (DOC-35 §10.8, #2381).
+#[derive(Debug, Subcommand)]
+pub(crate) enum DeliverablesAction {
+    /// List a project's Deliverables (optionally filtered by status).
+    List {
+        /// Project name.
+        project: String,
+        /// Emit raw JSON instead of the table.
+        #[arg(long)]
+        json: bool,
+        /// Only show Deliverables in this status.
+        #[arg(long)]
+        status: Option<DeliverableStatusArg>,
+    },
+    /// Create a Deliverable (starts in `proposed`).
+    #[command(alias = "create")]
+    Add {
+        /// Project name.
+        project: String,
+        /// Human-readable name.
+        #[arg(long)]
+        name: String,
+        /// Category of work.
+        #[arg(long)]
+        kind: DeliverableKindArg,
+        /// Coarse effort tier (S/M/L/XL).
+        #[arg(long)]
+        estimate: EstimationTierArg,
+        /// Free-form description.
+        #[arg(long)]
+        description: Option<String>,
+        /// Repo-relative spec path (plain string, §10.4).
+        #[arg(long)]
+        spec_ref: Option<String>,
+        /// Opaque gh-first ticket reference (plain string, §13 Q6).
+        #[arg(long)]
+        ticket_ref: Option<String>,
+    },
+    /// Show one Deliverable by id.
+    Show {
+        /// Project name.
+        project: String,
+        /// Deliverable id (UUID).
+        id: String,
+        /// Emit raw JSON instead of the human view.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Transition a Deliverable's status (enforces the §10.3 state machine).
+    SetStatus {
+        /// Project name.
+        project: String,
+        /// Deliverable id (UUID).
+        id: String,
+        /// Target status.
+        status: DeliverableStatusArg,
+    },
+}
+
+/// Actions for `tm projects milestones` (DOC-35 §10.8, #2381).
+#[derive(Debug, Subcommand)]
+pub(crate) enum MilestonesAction {
+    /// List a project's Milestones.
+    List {
+        /// Project name.
+        project: String,
+        /// Emit raw JSON instead of the table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Create a Milestone.
+    #[command(alias = "create")]
+    Add {
+        /// Project name.
+        project: String,
+        /// Human-readable name.
+        #[arg(long)]
+        name: String,
+        /// Target date (RFC 3339, e.g. `2026-09-01T00:00:00Z`).
+        #[arg(long)]
+        target_date: String,
+        /// Free-form description.
+        #[arg(long)]
+        description: Option<String>,
+    },
+    /// Show one Milestone by id.
+    Show {
+        /// Project name.
+        project: String,
+        /// Milestone id (UUID).
+        id: String,
+        /// Emit raw JSON instead of the human view.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// CLI value for a Deliverable kind (§10.2); maps 1:1 to
+/// `trusty_mpm::deliverable::DeliverableKind`. Kept local so `cli.rs` carries no
+/// domain dependency; the projects command module does the mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum DeliverableKindArg {
+    /// A new capability.
+    Feature,
+    /// A defect repair.
+    Bugfix,
+    /// A behavior-preserving restructuring.
+    Refactor,
+    /// Maintenance / housekeeping.
+    Chore,
+    /// Test-only work.
+    Test,
+    /// Documentation-only work.
+    Docs,
+}
+
+/// CLI value for an estimation tier (§10.2); the value names are the exact
+/// uppercase `S`/`M`/`L`/`XL` letters the spec uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum EstimationTierArg {
+    /// Small.
+    #[value(name = "S")]
+    S,
+    /// Medium.
+    #[value(name = "M")]
+    M,
+    /// Large.
+    #[value(name = "L")]
+    L,
+    /// Extra-large.
+    #[value(name = "XL")]
+    Xl,
+}
+
+/// CLI value for a Deliverable status (§10.3); default kebab-case value names
+/// match the wire encoding (`in-progress`, `proposed`, …).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum DeliverableStatusArg {
+    /// Planned but not started.
+    Proposed,
+    /// Actively worked.
+    InProgress,
+    /// Paused on an external blocker.
+    Blocked,
+    /// Objective gate passed or user-confirmed.
+    Complete,
+    /// Terminal: delivered.
+    Delivered,
+    /// Terminal: shipped.
+    Shipped,
 }
 
 /// Actions for the `sessions` subcommand (canonical since #2116; also

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod pm_guard;
 pub(crate) mod pm_guard_bash;
 pub(crate) mod pm_guard_deny_by_default;
 pub(crate) mod project;
+pub(crate) mod projects;
 pub(crate) mod prune;
 pub(crate) mod repair;
 pub(crate) mod serve_stdio;

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/convert.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/convert.rs
@@ -1,0 +1,92 @@
+//! Clap-arg → domain-type conversions for the `tm projects` command group.
+//!
+//! Why: the CLI value enums (`DeliverableKindArg`, `EstimationTierArg`,
+//! `DeliverableStatusArg`) live in `cli.rs` so that file carries no dependency on
+//! the `trusty_mpm::deliverable` domain types. The mapping to those domain types
+//! has to live somewhere the command handlers can call; centralizing it here
+//! keeps the three subtree files free of repeated `match` arms and gives the
+//! mapping a single tested home.
+//! What: `From` impls converting each CLI value enum to its domain counterpart.
+//! Test: `kind_maps`, `tier_maps`, `status_maps` in the `tests` submodule assert
+//! every variant round-trips to the right domain value.
+
+use crate::cli::{DeliverableKindArg, DeliverableStatusArg, EstimationTierArg};
+use trusty_mpm::deliverable::{DeliverableKind, DeliverableStatus, EstimationTier};
+
+impl From<DeliverableKindArg> for DeliverableKind {
+    fn from(arg: DeliverableKindArg) -> Self {
+        match arg {
+            DeliverableKindArg::Feature => DeliverableKind::Feature,
+            DeliverableKindArg::Bugfix => DeliverableKind::Bugfix,
+            DeliverableKindArg::Refactor => DeliverableKind::Refactor,
+            DeliverableKindArg::Chore => DeliverableKind::Chore,
+            DeliverableKindArg::Test => DeliverableKind::Test,
+            DeliverableKindArg::Docs => DeliverableKind::Docs,
+        }
+    }
+}
+
+impl From<EstimationTierArg> for EstimationTier {
+    fn from(arg: EstimationTierArg) -> Self {
+        match arg {
+            EstimationTierArg::S => EstimationTier::S,
+            EstimationTierArg::M => EstimationTier::M,
+            EstimationTierArg::L => EstimationTier::L,
+            EstimationTierArg::Xl => EstimationTier::Xl,
+        }
+    }
+}
+
+impl From<DeliverableStatusArg> for DeliverableStatus {
+    fn from(arg: DeliverableStatusArg) -> Self {
+        match arg {
+            DeliverableStatusArg::Proposed => DeliverableStatus::Proposed,
+            DeliverableStatusArg::InProgress => DeliverableStatus::InProgress,
+            DeliverableStatusArg::Blocked => DeliverableStatus::Blocked,
+            DeliverableStatusArg::Complete => DeliverableStatus::Complete,
+            DeliverableStatusArg::Delivered => DeliverableStatus::Delivered,
+            DeliverableStatusArg::Shipped => DeliverableStatus::Shipped,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_maps() {
+        assert_eq!(
+            DeliverableKind::from(DeliverableKindArg::Feature),
+            DeliverableKind::Feature
+        );
+        assert_eq!(
+            DeliverableKind::from(DeliverableKindArg::Docs),
+            DeliverableKind::Docs
+        );
+    }
+
+    #[test]
+    fn tier_maps() {
+        assert_eq!(
+            EstimationTier::from(EstimationTierArg::S),
+            EstimationTier::S
+        );
+        assert_eq!(
+            EstimationTier::from(EstimationTierArg::Xl),
+            EstimationTier::Xl
+        );
+    }
+
+    #[test]
+    fn status_maps() {
+        assert_eq!(
+            DeliverableStatus::from(DeliverableStatusArg::InProgress),
+            DeliverableStatus::InProgress
+        );
+        assert_eq!(
+            DeliverableStatus::from(DeliverableStatusArg::Shipped),
+            DeliverableStatus::Shipped
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/deliverables.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/deliverables.rs
@@ -1,0 +1,217 @@
+//! `tm projects deliverables` subtree: list / add / show / set-status (#2381).
+//!
+//! Why: the CLI over the Deliverable CRUD API (§10.8). `set-status` is the one
+//! verb with a state machine behind it (§10.3, enforced daemon-side by #2380):
+//! an illegal transition returns a structured 409 the client parses into
+//! [`SetStatusError::Rejected`]; this handler renders those legal next states so
+//! the operator can self-correct instead of seeing a bare "409 Conflict".
+//! What: [`dispatch`] routes a [`DeliverablesAction`]; the per-verb handlers are
+//! thin `DaemonClient` calls with human/`--json` rendering; [`render_rejection`]
+//! is the pure, tested formatter for the illegal-transition surface.
+//! Test: `render_rejection_lists_allowed`, `render_rejection_terminal` in the
+//! `tests` submodule; live HTTP via the daemon's `deliverable_routes::tests`.
+
+use trusty_mpm::client::DaemonClient;
+use trusty_mpm::client::http_client::deliverables::{CreateDeliverableArgs, SetStatusError};
+use trusty_mpm::deliverable::{Deliverable, DeliverableStatus};
+
+use crate::cli::DeliverablesAction;
+
+/// Build a `DaemonClient` from the CLI's shared `(reqwest::Client, url)` pair.
+fn daemon(client: &reqwest::Client, url: &str) -> DaemonClient {
+    DaemonClient::with_client(client.clone(), url.to_string())
+}
+
+/// Route a `tm projects deliverables <action>` invocation.
+pub(crate) async fn dispatch(
+    client: &reqwest::Client,
+    url: &str,
+    action: DeliverablesAction,
+) -> anyhow::Result<()> {
+    match action {
+        DeliverablesAction::List {
+            project,
+            json,
+            status,
+        } => {
+            let deliverables = daemon(client, url)
+                .list_deliverables(&project, status.map(Into::into))
+                .await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&deliverables)?);
+            } else if deliverables.is_empty() {
+                println!("no deliverables for project '{project}'");
+            } else {
+                for d in &deliverables {
+                    println!("{}", render_deliverable_line(d));
+                }
+            }
+            Ok(())
+        }
+        DeliverablesAction::Add {
+            project,
+            name,
+            kind,
+            estimate,
+            description,
+            spec_ref,
+            ticket_ref,
+        } => {
+            let args = CreateDeliverableArgs {
+                name,
+                description,
+                kind: kind.into(),
+                estimated_effort: estimate.into(),
+                ticket_ref,
+                spec_ref,
+            };
+            let created = daemon(client, url)
+                .create_deliverable(&project, &args)
+                .await?;
+            println!("created deliverable {}", created.id);
+            println!("{}", render_deliverable_line(&created));
+            Ok(())
+        }
+        DeliverablesAction::Show { project, id, json } => {
+            let d = daemon(client, url).get_deliverable(&project, &id).await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&d)?);
+            } else {
+                for line in render_deliverable_detail(&d) {
+                    println!("{line}");
+                }
+            }
+            Ok(())
+        }
+        DeliverablesAction::SetStatus {
+            project,
+            id,
+            status,
+        } => set_status(client, url, &project, &id, status.into()).await,
+    }
+}
+
+/// Handle `set-status`, rendering the structured 409 clearly on rejection.
+///
+/// Why: the illegal-transition case is the whole point of #2380's structured
+/// error — the operator must SEE the legal next states. On rejection this prints
+/// [`render_rejection`] to stderr and returns an error (non-zero exit) so scripts
+/// can detect the failure; a genuine transport/404 error propagates unchanged.
+/// What: calls [`DaemonClient::set_deliverable_status`]; on
+/// [`SetStatusError::Rejected`] prints the guidance and errors out; on success
+/// prints the new status; on [`SetStatusError::Other`] propagates the error.
+/// Test: rendering covered by `render_rejection_lists_allowed`; live 409 path by
+/// the daemon route test.
+async fn set_status(
+    client: &reqwest::Client,
+    url: &str,
+    project: &str,
+    id: &str,
+    status: DeliverableStatus,
+) -> anyhow::Result<()> {
+    match daemon(client, url)
+        .set_deliverable_status(project, id, status)
+        .await
+    {
+        Ok(updated) => {
+            println!("deliverable {} is now '{}'", updated.id, updated.status);
+            Ok(())
+        }
+        Err(SetStatusError::Rejected {
+            from,
+            to,
+            allowed_next,
+        }) => {
+            eprintln!("{}", render_rejection(&from, &to, &allowed_next));
+            anyhow::bail!("status transition rejected");
+        }
+        Err(SetStatusError::Other(e)) => Err(e),
+    }
+}
+
+/// Render an illegal-transition rejection as an operator-facing message (#2380).
+///
+/// Why: this is the surface the task calls out — the operator must see WHICH
+/// states are legal next. A pure function of the three parts keeps it testable.
+/// What: a two-line message naming the rejected `from → to` and the legal next
+/// states (or "none (terminal state)" when the from-state is terminal).
+/// Test: `render_rejection_lists_allowed`, `render_rejection_terminal`.
+pub(crate) fn render_rejection(from: &str, to: &str, allowed_next: &[String]) -> String {
+    let allowed = if allowed_next.is_empty() {
+        "none (terminal state)".to_string()
+    } else {
+        allowed_next.join(", ")
+    };
+    format!(
+        "error: cannot transition deliverable from '{from}' to '{to}'\n  legal next states from '{from}': {allowed}"
+    )
+}
+
+/// Render one Deliverable as a compact `id  status  kind  tier  name` line.
+fn render_deliverable_line(d: &Deliverable) -> String {
+    format!(
+        "{}\t{}\t{:?}\t{:?}\t{}",
+        d.id, d.status, d.kind, d.estimated_effort, d.name
+    )
+}
+
+/// Render a Deliverable's full detail as human lines.
+fn render_deliverable_detail(d: &Deliverable) -> Vec<String> {
+    let mut lines = vec![
+        format!("{} — {}", d.id, d.name),
+        format!("  project: {}", d.project_name),
+        format!("  status: {}", d.status),
+        format!("  kind: {:?}   estimate: {:?}", d.kind, d.estimated_effort),
+    ];
+    if let Some(t) = &d.ticket_ref {
+        lines.push(format!("  ticket: {t}"));
+    }
+    if let Some(s) = &d.spec_ref {
+        lines.push(format!("  spec: {s}"));
+    }
+    if !d.description.is_empty() {
+        lines.push(format!("  description: {}", d.description));
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_rejection_lists_allowed() {
+        let msg = render_rejection("proposed", "complete", &["in-progress".to_string()]);
+        assert!(msg.contains("proposed"), "{msg}");
+        assert!(msg.contains("complete"), "{msg}");
+        assert!(msg.contains("in-progress"), "{msg}");
+        assert!(msg.contains("legal next states"), "{msg}");
+    }
+
+    #[test]
+    fn render_rejection_terminal() {
+        // A terminal from-state has no legal successors.
+        let msg = render_rejection("shipped", "complete", &[]);
+        assert!(msg.contains("none (terminal state)"), "{msg}");
+    }
+
+    #[test]
+    fn render_deliverable_line_has_status_and_name() {
+        let d = Deliverable {
+            id: trusty_mpm::deliverable::DeliverableId::new(),
+            project_name: "widget".into(),
+            name: "OAuth2 flow".into(),
+            description: String::new(),
+            kind: trusty_mpm::deliverable::DeliverableKind::Feature,
+            ticket_ref: None,
+            spec_ref: None,
+            status: DeliverableStatus::Proposed,
+            estimated_effort: trusty_mpm::deliverable::EstimationTier::L,
+            created_at: chrono::Utc::now(),
+            target_date: None,
+        };
+        let line = render_deliverable_line(&d);
+        assert!(line.contains("proposed"), "{line}");
+        assert!(line.contains("OAuth2 flow"), "{line}");
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/milestones.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/milestones.rs
@@ -1,0 +1,155 @@
+//! `tm projects milestones` subtree: list / add / show (#2381, §10.8).
+//!
+//! Why: the CLI over the Milestone CRUD API. Milestone status is a rollup, not a
+//! user-driven state machine (§10.5), so there is no `set-status` verb here —
+//! §10.8 lists only `list|add|show` for milestones, and this subtree matches it
+//! exactly.
+//! What: [`dispatch`] routes a [`MilestonesAction`]; the per-verb handlers are
+//! thin `DaemonClient` calls with human/`--json` rendering. `add` parses the
+//! `--target-date` RFC-3339 string into the `DateTime<Utc>` the API expects,
+//! failing loudly on a malformed value.
+//! Test: `render_milestone_line_has_name`, `parse_target_date_*` in the `tests`
+//! submodule; live HTTP via the daemon's `deliverable_routes::tests`.
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+
+use trusty_mpm::client::DaemonClient;
+use trusty_mpm::client::http_client::deliverables::CreateMilestoneArgs;
+use trusty_mpm::deliverable::Milestone;
+
+use crate::cli::MilestonesAction;
+
+/// Build a `DaemonClient` from the CLI's shared `(reqwest::Client, url)` pair.
+fn daemon(client: &reqwest::Client, url: &str) -> DaemonClient {
+    DaemonClient::with_client(client.clone(), url.to_string())
+}
+
+/// Route a `tm projects milestones <action>` invocation.
+pub(crate) async fn dispatch(
+    client: &reqwest::Client,
+    url: &str,
+    action: MilestonesAction,
+) -> anyhow::Result<()> {
+    match action {
+        MilestonesAction::List { project, json } => {
+            let milestones = daemon(client, url).list_milestones(&project).await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&milestones)?);
+            } else if milestones.is_empty() {
+                println!("no milestones for project '{project}'");
+            } else {
+                for m in &milestones {
+                    println!("{}", render_milestone_line(m));
+                }
+            }
+            Ok(())
+        }
+        MilestonesAction::Add {
+            project,
+            name,
+            target_date,
+            description,
+        } => {
+            let target_date = parse_target_date(&target_date)?;
+            let args = CreateMilestoneArgs {
+                name,
+                description,
+                target_date,
+            };
+            let created = daemon(client, url)
+                .create_milestone(&project, &args)
+                .await?;
+            println!("created milestone {}", created.id);
+            println!("{}", render_milestone_line(&created));
+            Ok(())
+        }
+        MilestonesAction::Show { project, id, json } => {
+            let m = daemon(client, url).get_milestone(&project, &id).await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&m)?);
+            } else {
+                for line in render_milestone_detail(&m) {
+                    println!("{line}");
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Parse an RFC-3339 `--target-date` into a UTC timestamp, failing loudly.
+///
+/// Why: the Milestone API requires a concrete `target_date`; a malformed value
+/// must be a clear CLI error, not a silent default.
+/// What: parses via `DateTime::parse_from_rfc3339` and normalizes to UTC.
+/// Test: `parse_target_date_ok`, `parse_target_date_rejects_garbage`.
+fn parse_target_date(s: &str) -> anyhow::Result<DateTime<Utc>> {
+    Ok(DateTime::parse_from_rfc3339(s)
+        .with_context(|| {
+            format!("invalid --target-date {s:?}; expected RFC 3339 (e.g. 2026-09-01T00:00:00Z)")
+        })?
+        .with_timezone(&Utc))
+}
+
+/// Render one Milestone as a compact `id  status  target  name` line.
+fn render_milestone_line(m: &Milestone) -> String {
+    format!(
+        "{}\t{:?}\t{}\t{}",
+        m.id,
+        m.status,
+        m.target_date.to_rfc3339(),
+        m.name
+    )
+}
+
+/// Render a Milestone's full detail as human lines.
+fn render_milestone_detail(m: &Milestone) -> Vec<String> {
+    let mut lines = vec![
+        format!("{} — {}", m.id, m.name),
+        format!("  project: {}", m.project_name),
+        format!("  status: {:?}", m.status),
+        format!("  target: {}", m.target_date.to_rfc3339()),
+        format!("  deliverables: {}", m.deliverables.len()),
+    ];
+    if !m.description.is_empty() {
+        lines.push(format!("  description: {}", m.description));
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn milestone() -> Milestone {
+        Milestone {
+            id: trusty_mpm::deliverable::MilestoneId::new(),
+            project_name: "widget".into(),
+            name: "v1.0 Alpha".into(),
+            description: String::new(),
+            target_date: Utc::now(),
+            status: trusty_mpm::deliverable::MilestoneStatus::Proposed,
+            deliverables: vec![],
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn render_milestone_line_has_name() {
+        let line = render_milestone_line(&milestone());
+        assert!(line.contains("v1.0 Alpha"), "{line}");
+        assert!(line.contains("Proposed"), "{line}");
+    }
+
+    #[test]
+    fn parse_target_date_ok() {
+        let dt = parse_target_date("2026-09-01T00:00:00Z").unwrap();
+        assert_eq!(dt.to_rfc3339(), "2026-09-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn parse_target_date_rejects_garbage() {
+        assert!(parse_target_date("not-a-date").is_err());
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs
@@ -1,0 +1,67 @@
+//! `tm projects` command group (DOC-35 §3.1/§10.8, #2115/#2381).
+//!
+//! Why: the deterministic CLI half of the project control plane. The verb tree is
+//! large (four registry verbs + two nested CRUD subtrees), so it is split per
+//! subtree — `registry` (list/register/show/status), `deliverables`, and
+//! `milestones` — each a sibling file well under the 500-SLOC cap, with this
+//! `mod.rs` a thin dispatcher plus the shared clap-arg → domain-type conversions.
+//! What: [`projects`] routes a [`ProjectsAction`] to the right subtree handler;
+//! the `convert` submodule maps the CLI value enums to `trusty_mpm::deliverable`
+//! domain types so `cli.rs` stays free of a domain dependency.
+//! Test: `cli_parses_projects_*` (parse) in `tests_projects.rs`; the per-subtree
+//! rendering/serialization tests live in each submodule.
+
+pub(crate) mod convert;
+pub(crate) mod deliverables;
+pub(crate) mod milestones;
+pub(crate) mod registry;
+
+use crate::cli::ProjectsAction;
+
+/// Dispatch a `tm projects <action>` invocation to its subtree handler.
+///
+/// Why: `main.rs` stays a thin bootstrap; all `projects` routing lives here.
+/// What: matches the top-level action and forwards to the registry verb handlers
+/// or the deliverables/milestones subtree dispatchers, threading the CLI's shared
+/// `(reqwest::Client, url)` pair through to the typed `DaemonClient` methods.
+/// Test: exercised end-to-end by the daemon integration tests; parse coverage in
+/// `tests_projects.rs`.
+pub(crate) async fn projects(
+    client: &reqwest::Client,
+    url: &str,
+    action: ProjectsAction,
+) -> anyhow::Result<()> {
+    match action {
+        ProjectsAction::List { json, tag } => registry::list(client, url, json, tag).await,
+        ProjectsAction::Register {
+            name,
+            repo_url,
+            default_branch,
+            description,
+            tags,
+            stack_hint,
+            gh_user,
+        } => {
+            registry::register(
+                client,
+                url,
+                registry::RegisterInput {
+                    name,
+                    repo_url,
+                    default_branch,
+                    description,
+                    tags,
+                    stack_hint,
+                    gh_user,
+                },
+            )
+            .await
+        }
+        ProjectsAction::Show { name, json } => registry::show(client, url, &name, json).await,
+        ProjectsAction::Status { name, json } => registry::status(client, url, &name, json).await,
+        ProjectsAction::Deliverables { action } => {
+            deliverables::dispatch(client, url, action).await
+        }
+        ProjectsAction::Milestones { action } => milestones::dispatch(client, url, action).await,
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/registry.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/registry.rs
@@ -1,0 +1,302 @@
+//! `tm projects` registry verbs: list / register / show / status (#2115).
+//!
+//! Why: the registry-B half of the project control plane — enumerate, upsert,
+//! inspect (config + read-only nested sessions), and roll up a project's status.
+//! Each verb is a thin client over a `DaemonClient` method (`projects.rs`),
+//! rendering either a human view or, with `--json`, the raw wire JSON for
+//! scripting (matching the `--json`-everywhere convention of `tm sessions`).
+//! What: [`list`], [`register`], [`show`], [`status`] plus the pure human-render
+//! helpers they delegate to. `show`'s nested sessions come from the fleet endpoint
+//! (read-only per §3.1); the render explicitly points mutation at `tm sessions`.
+//! Test: `render_status_line_*`, `render_project_line_*` (pure render) in the
+//! `tests` submodule; live HTTP via the daemon route tests.
+
+use trusty_mpm::client::DaemonClient;
+use trusty_mpm::client::http_client::projects::{ProjectStatusWire, RegisterProjectArgs};
+use trusty_mpm::project::Project;
+
+/// Owned inputs for [`register`], mirroring the `Register` clap variant.
+///
+/// Why: passing the seven register fields as one struct keeps the dispatcher and
+/// this handler's signature readable (clippy `too_many_arguments`).
+/// What: the register flags; `tags` is empty (not `None`) when unspecified.
+/// Test: covered via `register`'s live-HTTP path.
+pub(crate) struct RegisterInput {
+    pub name: String,
+    pub repo_url: String,
+    pub default_branch: Option<String>,
+    pub description: Option<String>,
+    pub tags: Vec<String>,
+    pub stack_hint: Option<String>,
+    pub gh_user: Option<String>,
+}
+
+/// Build a `DaemonClient` from the CLI's shared `(reqwest::Client, url)` pair.
+fn daemon(client: &reqwest::Client, url: &str) -> DaemonClient {
+    DaemonClient::with_client(client.clone(), url.to_string())
+}
+
+/// `tm projects list [--json] [--tag <t>]` — enumerate registered projects.
+pub(crate) async fn list(
+    client: &reqwest::Client,
+    url: &str,
+    json: bool,
+    tag: Option<String>,
+) -> anyhow::Result<()> {
+    let projects = daemon(client, url)
+        .registry_list_projects(tag.as_deref())
+        .await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&projects)?);
+        return Ok(());
+    }
+    if projects.is_empty() {
+        println!("no projects registered");
+        return Ok(());
+    }
+    for p in &projects {
+        println!("{}", render_project_line(p));
+    }
+    Ok(())
+}
+
+/// `tm projects register <name> --repo-url ...` — idempotent upsert.
+pub(crate) async fn register(
+    client: &reqwest::Client,
+    url: &str,
+    input: RegisterInput,
+) -> anyhow::Result<()> {
+    let args = RegisterProjectArgs {
+        name: input.name,
+        repo_url: input.repo_url,
+        default_branch: input.default_branch,
+        description: input.description,
+        tags: if input.tags.is_empty() {
+            None
+        } else {
+            Some(input.tags)
+        },
+        stack_hint: input.stack_hint,
+        gh_user: input.gh_user,
+    };
+    let project = daemon(client, url).registry_register_project(&args).await?;
+    println!(
+        "registered project '{}' ({} @ {})",
+        project.name, project.repo_url, project.default_branch
+    );
+    Ok(())
+}
+
+/// `tm projects show <name> [--json]` — config + read-only nested sessions.
+pub(crate) async fn show(
+    client: &reqwest::Client,
+    url: &str,
+    name: &str,
+    json: bool,
+) -> anyhow::Result<()> {
+    let daemon = daemon(client, url);
+    let project = daemon.registry_get_project(name).await?;
+
+    // Read-only nested sessions via the fleet endpoint (§3.1). A fleet read
+    // failure must not sink the whole `show` — the config is the primary payload
+    // — so degrade to an empty session list on error.
+    let sessions = daemon
+        .fleet_managed_sessions()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .find(|g| g.project_name == project.name)
+        .map(|g| g.sessions)
+        .unwrap_or_default();
+
+    if json {
+        let out = serde_json::json!({
+            "project": project,
+            "sessions": sessions.iter().map(|s| serde_json::json!({
+                "id": s.id, "name": s.name, "state": s.state,
+                "branch": s.branch, "task": s.task,
+            })).collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    println!("{}", render_project_line(&project));
+    if let Some(desc) = &project.description {
+        println!("  description: {desc}");
+    }
+    if !project.tags.is_empty() {
+        println!("  tags: {}", project.tags.join(", "));
+    }
+    if let Some(gh) = &project.gh_user {
+        println!("  gh_user: {gh}");
+    }
+    println!(
+        "  sessions ({}) [read-only — mutate via `tm sessions <verb>`]:",
+        sessions.len()
+    );
+    if sessions.is_empty() {
+        println!("    (none)");
+    } else {
+        for s in &sessions {
+            let branch = s.branch.as_deref().unwrap_or("-");
+            println!("    {} {} [{}] {}", s.id, s.name, s.state, branch);
+        }
+    }
+    Ok(())
+}
+
+/// `tm projects status <name> [--json]` — deterministic status rollup.
+pub(crate) async fn status(
+    client: &reqwest::Client,
+    url: &str,
+    name: &str,
+    json: bool,
+) -> anyhow::Result<()> {
+    let status = daemon(client, url).project_status(name).await?;
+    if json {
+        // Re-serialize the parsed rollup. Additive #2382 fields the client does
+        // not model are dropped here; `--json` consumers that need them can hit
+        // the endpoint directly. The human view below is the stable surface.
+        let out = serde_json::json!({
+            "project_name": status.project_name,
+            "repo_url": status.repo_url,
+            "sessions": {
+                "provisioning": status.sessions.provisioning,
+                "active": status.sessions.active,
+                "stopped": status.sessions.stopped,
+                "errored": status.sessions.errored,
+                "decommissioned": status.sessions.decommissioned,
+                "total": status.sessions.total,
+            },
+            "last_activity_at": status.last_activity_at,
+            "config": {
+                "gh_user_set": status.config.gh_user_set,
+                "github_binding_set": status.config.github_binding_set,
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+    for line in render_status(&status) {
+        println!("{line}");
+    }
+    Ok(())
+}
+
+/// Render one project as a compact `name  repo_url  (branch)` line.
+///
+/// Why: shared between `list` and `show`; a pure helper keeps it testable.
+/// What: name, repo URL, and default branch on one line.
+/// Test: `render_project_line_basic`.
+fn render_project_line(p: &Project) -> String {
+    format!("{}\t{}\t({})", p.name, p.repo_url, p.default_branch)
+}
+
+/// Render the status rollup as human lines.
+///
+/// Why: `tm projects status` prints a small multi-line rollup; a pure function of
+/// the parsed [`ProjectStatusWire`] keeps it deterministic and testable.
+/// What: the identity line, the session histogram, last activity, and the config
+/// flags.
+/// Test: `render_status_line_counts`, `render_status_no_activity`.
+fn render_status(s: &ProjectStatusWire) -> Vec<String> {
+    let c = &s.sessions;
+    let activity = s
+        .last_activity_at
+        .map(|t| t.to_rfc3339())
+        .unwrap_or_else(|| "never".to_string());
+    vec![
+        format!("{} ({})", s.project_name, s.repo_url),
+        format!(
+            "  sessions: {} total  ({} active, {} provisioning, {} stopped, {} errored, {} decommissioned)",
+            c.total, c.active, c.provisioning, c.stopped, c.errored, c.decommissioned
+        ),
+        format!("  last activity: {activity}"),
+        format!(
+            "  config: gh_user {}, gh-binding {}",
+            if s.config.gh_user_set { "set" } else { "unset" },
+            if s.config.github_binding_set {
+                "set"
+            } else {
+                "unset"
+            }
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trusty_mpm::client::http_client::projects::{
+        ProjectConfigFlagsWire, SessionStateCountsWire,
+    };
+
+    fn project() -> Project {
+        Project {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: "main".into(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        }
+    }
+
+    #[test]
+    fn render_project_line_basic() {
+        let line = render_project_line(&project());
+        assert!(line.contains("widget"));
+        assert!(line.contains("https://github.com/acme/widget"));
+        assert!(line.contains("main"));
+    }
+
+    #[test]
+    fn render_status_line_counts() {
+        let s = ProjectStatusWire {
+            project_name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            sessions: SessionStateCountsWire {
+                provisioning: 1,
+                active: 2,
+                stopped: 0,
+                errored: 1,
+                decommissioned: 0,
+                total: 4,
+            },
+            last_activity_at: Some(
+                chrono::DateTime::parse_from_rfc3339("2026-07-10T12:00:00Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+            ),
+            config: ProjectConfigFlagsWire {
+                gh_user_set: true,
+                github_binding_set: false,
+            },
+        };
+        let lines = render_status(&s);
+        assert!(lines[0].contains("widget"));
+        assert!(lines[1].contains("4 total"));
+        assert!(lines[1].contains("2 active"));
+        assert!(lines[2].contains("2026-07-10"));
+        assert!(lines[3].contains("gh_user set"));
+    }
+
+    #[test]
+    fn render_status_no_activity() {
+        let s = ProjectStatusWire {
+            project_name: "widget".into(),
+            repo_url: "u".into(),
+            sessions: SessionStateCountsWire::default(),
+            last_activity_at: None,
+            config: ProjectConfigFlagsWire::default(),
+        };
+        let lines = render_status(&s);
+        assert!(lines[2].contains("never"));
+        assert!(lines[3].contains("gh_user unset"));
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/registry.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/registry.rs
@@ -99,15 +99,19 @@ pub(crate) async fn show(
 
     // Read-only nested sessions via the fleet endpoint (§3.1). A fleet read
     // failure must not sink the whole `show` — the config is the primary payload
-    // — so degrade to an empty session list on error.
-    let sessions = daemon
-        .fleet_managed_sessions()
-        .await
-        .unwrap_or_default()
-        .into_iter()
-        .find(|g| g.project_name == project.name)
-        .map(|g| g.sessions)
-        .unwrap_or_default();
+    // — so degrade to an empty session list on error, but warn so the operator
+    // knows the session list may be incomplete rather than genuinely empty.
+    let sessions = match daemon.fleet_managed_sessions().await {
+        Ok(groups) => groups
+            .into_iter()
+            .find(|g| g.project_name == project.name)
+            .map(|g| g.sessions)
+            .unwrap_or_default(),
+        Err(e) => {
+            eprintln!("warning: could not read sessions: {e}");
+            Vec::new()
+        }
+    };
 
     if json {
         let out = serde_json::json!({

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -22,6 +22,7 @@ use commands::{
     launch::{connect, launch},
     misc::{attach_cmd, coordinator, doctor, health, hook, optimizer, overseer, status, validate},
     project::project,
+    projects::projects,
     repair::repair_deploy,
     services::services,
     session::session,
@@ -52,6 +53,10 @@ mod tests_behavior_d;
 #[cfg(test)]
 #[path = "tests_behavior_e_tests.rs"]
 mod tests_behavior_e;
+
+#[cfg(test)]
+#[path = "tests_projects.rs"]
+mod tests_projects;
 
 /// Lazy-loaded help configuration for "did you mean?" suggestions (issue #216).
 ///
@@ -249,6 +254,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Project { action }) => project(&client, &url, action).await,
         // #2116: `sessions` (plural) is the canonical top-level command.
         Some(Command::Sessions { action }) => session(&client, &url, action).await,
+        Some(Command::Projects { action }) => projects(&client, &url, action).await,
         // #2116: `session` (singular) is a hidden deprecated alias of `sessions`.
         // The notice fires here — exactly once per invocation, regardless of
         // which verb was invoked — before dispatching to the identical handler.

--- a/crates/trusty-mpm/src/bin/tm/tests_projects.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_projects.rs
@@ -1,0 +1,380 @@
+//! CLI parse tests for the `tm projects` verb tree (DOC-35 §3.1/§10.8).
+//!
+//! Why: `tm projects` (#2115) and its `deliverables`/`milestones` subtrees
+//! (#2381) build a large clap namespace; a parse test per verb pins the exact
+//! flag/positional shape so a rename or a moved flag fails loudly here rather
+//! than silently at runtime. Split into its own file to keep `tests.rs` under the
+//! test-file line cap.
+//! What: `Cli::try_parse_from` round-trips for every projects verb, asserting the
+//! parsed `Command`/action variant and its salient fields.
+//! Test: this file is the test.
+
+use clap::Parser;
+
+use crate::cli::{
+    Cli, Command, DeliverableKindArg, DeliverableStatusArg, DeliverablesAction, EstimationTierArg,
+    MilestonesAction, ProjectsAction,
+};
+
+/// Assert `argv` parses to a `Command::Projects` and hand its action to `check`.
+fn projects_action(argv: &[&str]) -> ProjectsAction {
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command.expect("subcommand") {
+        Command::Projects { action } => action,
+        other => panic!("expected Command::Projects, got {other:?}"),
+    }
+}
+
+// ───────────────────────── registry verbs (#2115) ─────────────────────────
+
+#[test]
+fn cli_parses_projects_list_bare() {
+    match projects_action(&["trusty-mpm", "projects", "list"]) {
+        ProjectsAction::List { json, tag } => {
+            assert!(!json);
+            assert_eq!(tag, None);
+        }
+        other => panic!("expected list, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_list_json_and_tag() {
+    match projects_action(&[
+        "trusty-mpm",
+        "projects",
+        "list",
+        "--json",
+        "--tag",
+        "backend",
+    ]) {
+        ProjectsAction::List { json, tag } => {
+            assert!(json);
+            assert_eq!(tag.as_deref(), Some("backend"));
+        }
+        other => panic!("expected list, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_register_full() {
+    let action = projects_action(&[
+        "trusty-mpm",
+        "projects",
+        "register",
+        "widget",
+        "--repo-url",
+        "https://github.com/acme/widget",
+        "--default-branch",
+        "develop",
+        "--description",
+        "the widget",
+        "--tags",
+        "backend,oss",
+        "--stack-hint",
+        "rust",
+        "--gh-user",
+        "acme-bot",
+    ]);
+    match action {
+        ProjectsAction::Register {
+            name,
+            repo_url,
+            default_branch,
+            description,
+            tags,
+            stack_hint,
+            gh_user,
+        } => {
+            assert_eq!(name, "widget");
+            assert_eq!(repo_url, "https://github.com/acme/widget");
+            assert_eq!(default_branch.as_deref(), Some("develop"));
+            assert_eq!(description.as_deref(), Some("the widget"));
+            assert_eq!(tags, vec!["backend".to_string(), "oss".to_string()]);
+            assert_eq!(stack_hint.as_deref(), Some("rust"));
+            assert_eq!(gh_user.as_deref(), Some("acme-bot"));
+        }
+        other => panic!("expected register, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_register_minimal() {
+    match projects_action(&[
+        "trusty-mpm",
+        "projects",
+        "register",
+        "minimal",
+        "--repo-url",
+        "https://github.com/acme/minimal",
+    ]) {
+        ProjectsAction::Register {
+            name,
+            repo_url,
+            default_branch,
+            tags,
+            ..
+        } => {
+            assert_eq!(name, "minimal");
+            assert_eq!(repo_url, "https://github.com/acme/minimal");
+            assert_eq!(default_branch, None);
+            assert!(tags.is_empty());
+        }
+        other => panic!("expected register, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_show() {
+    match projects_action(&["trusty-mpm", "projects", "show", "widget", "--json"]) {
+        ProjectsAction::Show { name, json } => {
+            assert_eq!(name, "widget");
+            assert!(json);
+        }
+        other => panic!("expected show, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_status() {
+    match projects_action(&["trusty-mpm", "projects", "status", "widget"]) {
+        ProjectsAction::Status { name, json } => {
+            assert_eq!(name, "widget");
+            assert!(!json);
+        }
+        other => panic!("expected status, got {other:?}"),
+    }
+}
+
+// ─────────────────────── deliverables subtree (#2381) ──────────────────────
+
+fn deliverables_action(argv: &[&str]) -> DeliverablesAction {
+    match projects_action(argv) {
+        ProjectsAction::Deliverables { action } => action,
+        other => panic!("expected deliverables, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_deliverables_list_with_status() {
+    match deliverables_action(&[
+        "trusty-mpm",
+        "projects",
+        "deliverables",
+        "list",
+        "widget",
+        "--status",
+        "in-progress",
+        "--json",
+    ]) {
+        DeliverablesAction::List {
+            project,
+            json,
+            status,
+        } => {
+            assert_eq!(project, "widget");
+            assert!(json);
+            assert_eq!(status, Some(DeliverableStatusArg::InProgress));
+        }
+        other => panic!("expected list, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_deliverables_add() {
+    match deliverables_action(&[
+        "trusty-mpm",
+        "projects",
+        "deliverables",
+        "add",
+        "widget",
+        "--name",
+        "OAuth2 flow",
+        "--kind",
+        "feature",
+        "--estimate",
+        "L",
+        "--spec-ref",
+        "docs/specs/tm-project-control-plane.md",
+        "--ticket-ref",
+        "#2117",
+    ]) {
+        DeliverablesAction::Add {
+            project,
+            name,
+            kind,
+            estimate,
+            spec_ref,
+            ticket_ref,
+            ..
+        } => {
+            assert_eq!(project, "widget");
+            assert_eq!(name, "OAuth2 flow");
+            assert_eq!(kind, DeliverableKindArg::Feature);
+            assert_eq!(estimate, EstimationTierArg::L);
+            assert_eq!(
+                spec_ref.as_deref(),
+                Some("docs/specs/tm-project-control-plane.md")
+            );
+            assert_eq!(ticket_ref.as_deref(), Some("#2117"));
+        }
+        other => panic!("expected add, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_deliverables_create_alias() {
+    // `create` is an accepted alias of `add` (the prompt's spelling).
+    match deliverables_action(&[
+        "trusty-mpm",
+        "projects",
+        "deliverables",
+        "create",
+        "widget",
+        "--name",
+        "x",
+        "--kind",
+        "bugfix",
+        "--estimate",
+        "S",
+    ]) {
+        DeliverablesAction::Add { kind, estimate, .. } => {
+            assert_eq!(kind, DeliverableKindArg::Bugfix);
+            assert_eq!(estimate, EstimationTierArg::S);
+        }
+        other => panic!("expected add (via create alias), got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_deliverables_show() {
+    match deliverables_action(&[
+        "trusty-mpm",
+        "projects",
+        "deliverables",
+        "show",
+        "widget",
+        "00000000-0000-0000-0000-000000000001",
+    ]) {
+        DeliverablesAction::Show { project, id, json } => {
+            assert_eq!(project, "widget");
+            assert_eq!(id, "00000000-0000-0000-0000-000000000001");
+            assert!(!json);
+        }
+        other => panic!("expected show, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_deliverables_set_status() {
+    match deliverables_action(&[
+        "trusty-mpm",
+        "projects",
+        "deliverables",
+        "set-status",
+        "widget",
+        "00000000-0000-0000-0000-000000000001",
+        "complete",
+    ]) {
+        DeliverablesAction::SetStatus {
+            project,
+            id,
+            status,
+        } => {
+            assert_eq!(project, "widget");
+            assert_eq!(id, "00000000-0000-0000-0000-000000000001");
+            assert_eq!(status, DeliverableStatusArg::Complete);
+        }
+        other => panic!("expected set-status, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_estimate_xl_uppercase() {
+    // The estimation tier value names are the exact uppercase letters.
+    match deliverables_action(&[
+        "trusty-mpm",
+        "projects",
+        "deliverables",
+        "add",
+        "widget",
+        "--name",
+        "x",
+        "--kind",
+        "chore",
+        "--estimate",
+        "XL",
+    ]) {
+        DeliverablesAction::Add { estimate, .. } => {
+            assert_eq!(estimate, EstimationTierArg::Xl);
+        }
+        other => panic!("expected add, got {other:?}"),
+    }
+}
+
+// ──────────────────────── milestones subtree (#2381) ───────────────────────
+
+fn milestones_action(argv: &[&str]) -> MilestonesAction {
+    match projects_action(argv) {
+        ProjectsAction::Milestones { action } => action,
+        other => panic!("expected milestones, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_milestones_list() {
+    match milestones_action(&["trusty-mpm", "projects", "milestones", "list", "widget"]) {
+        MilestonesAction::List { project, json } => {
+            assert_eq!(project, "widget");
+            assert!(!json);
+        }
+        other => panic!("expected list, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_milestones_add() {
+    match milestones_action(&[
+        "trusty-mpm",
+        "projects",
+        "milestones",
+        "add",
+        "widget",
+        "--name",
+        "v1.0 Alpha",
+        "--target-date",
+        "2026-09-01T00:00:00Z",
+    ]) {
+        MilestonesAction::Add {
+            project,
+            name,
+            target_date,
+            ..
+        } => {
+            assert_eq!(project, "widget");
+            assert_eq!(name, "v1.0 Alpha");
+            assert_eq!(target_date, "2026-09-01T00:00:00Z");
+        }
+        other => panic!("expected add, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_projects_milestones_show() {
+    match milestones_action(&[
+        "trusty-mpm",
+        "projects",
+        "milestones",
+        "show",
+        "widget",
+        "00000000-0000-0000-0000-000000000002",
+        "--json",
+    ]) {
+        MilestonesAction::Show { project, id, json } => {
+            assert_eq!(project, "widget");
+            assert_eq!(id, "00000000-0000-0000-0000-000000000002");
+            assert!(json);
+        }
+        other => panic!("expected show, got {other:?}"),
+    }
+}

--- a/crates/trusty-mpm/src/client/http_client/deliverables.rs
+++ b/crates/trusty-mpm/src/client/http_client/deliverables.rs
@@ -1,0 +1,443 @@
+//! Deliverable/Milestone methods for [`DaemonClient`] (DOC-35 §10.8, #2381).
+//!
+//! Why: the `tm projects deliverables|milestones` CLI subtrees are thin HTTP
+//! clients over the Deliverable/Milestone CRUD API (#2378/#2380). Wiring each
+//! endpoint once here keeps the CLI off hand-rolled `reqwest` calls, matching the
+//! `managed.rs`/`projects.rs` sibling pattern. The one non-trivial seam is
+//! `set-status`: the daemon enforces the §10.3 state machine and rejects an
+//! illegal transition with a structured 409 (`{ from, to, allowed_next }`, #2380).
+//! [`DaemonClient::set_deliverable_status`] parses that body into a typed
+//! [`SetStatusError::Rejected`] so the CLI can show the operator the LEGAL next
+//! states instead of a bare "409 Conflict".
+//! What: request DTOs the client owns ([`CreateDeliverableArgs`],
+//! [`CreateMilestoneArgs`]), the [`SetStatusError`] type, and the CRUD methods for
+//! both resources. Response bodies deserialize into the domain types
+//! (`crate::deliverable::{Deliverable, Milestone}`), which already derive
+//! `Deserialize`. Status values serialize kebab-case via [`DeliverableStatus`]'s
+//! own serde, matching the daemon's `PatchDeliverable.status`.
+//! Test: `create_deliverable_args_serializes`, `create_milestone_args_serializes`,
+//! `transition_rejection_body_deserializes`, `deliverables_list_deserializes` in
+//! the `tests` submodule; live HTTP via the daemon's `deliverable_routes::tests`.
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+
+use super::DaemonClient;
+use crate::deliverable::{
+    Deliverable, DeliverableKind, DeliverableStatus, EstimationTier, Milestone,
+};
+
+/// Serializable body for `POST .../deliverables`.
+///
+/// Why: `tm projects deliverables add` builds this from its flags; a typed struct
+/// keeps the body checkable in a unit test. Matches the daemon's
+/// `CreateDeliverable` (which fixes `status = Proposed` and assigns `id`/
+/// `created_at` server-side, so neither is sent).
+/// What: required `name`/`kind`/`estimated_effort` plus optional description and
+/// the opaque `ticket_ref`/`spec_ref`/`target_date` slots.
+/// Test: `create_deliverable_args_serializes`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateDeliverableArgs {
+    /// Human-readable name.
+    pub name: String,
+    /// Free-form description (daemon defaults to empty when omitted).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Category of work.
+    pub kind: DeliverableKind,
+    /// Coarse effort tier (S/M/L/XL).
+    pub estimated_effort: EstimationTier,
+    /// Opaque gh-first ticket reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ticket_ref: Option<String>,
+    /// Repo-relative spec path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spec_ref: Option<String>,
+}
+
+/// Serializable body for `POST .../milestones`.
+///
+/// Why: `tm projects milestones add` builds this. Matches the daemon's
+/// `CreateMilestone`; `status` defaults to `Proposed` server-side and member
+/// deliverable ids are not settable from the CLI at creation (§10.8 `add` takes
+/// name + target date), so neither is sent here.
+/// What: required `name` and `target_date`, optional description.
+/// Test: `create_milestone_args_serializes`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateMilestoneArgs {
+    /// Human-readable name.
+    pub name: String,
+    /// Free-form description (daemon defaults to empty when omitted).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// The date this Milestone targets.
+    pub target_date: DateTime<Utc>,
+}
+
+/// The structured `409 Conflict` body the daemon returns for an illegal
+/// `set-status` transition (#2380).
+///
+/// Why: the CLI must show the operator the legal next states; parsing this body
+/// is how [`SetStatusError::Rejected`] carries them out of the client.
+/// What: mirrors the daemon `DaemonError::InvalidTransition` JSON shape.
+/// Test: `transition_rejection_body_deserializes`.
+#[derive(Debug, Clone, Deserialize)]
+struct TransitionRejectionBody {
+    #[serde(default)]
+    from: String,
+    #[serde(default)]
+    to: String,
+    #[serde(default)]
+    allowed_next: Vec<String>,
+}
+
+/// Outcome of a rejected or failed [`DaemonClient::set_deliverable_status`].
+///
+/// Why: `set-status` has two failure modes the CLI treats differently — an
+/// illegal transition (409, recoverable: the caller picks a legal state) versus
+/// any other error (network, 404, 500). Splitting them lets the CLI render the
+/// legal-next-states guidance only for the transition case.
+/// What: `Rejected` carries the §10.3 legal next states; `Other` wraps everything
+/// else as an [`anyhow::Error`].
+/// Test: driven via `set_deliverable_status`'s 409 branch (client route tests) and
+/// `transition_rejection_body_deserializes`.
+#[derive(Debug)]
+pub enum SetStatusError {
+    /// The daemon rejected the transition; carries the legal next states (#2380).
+    Rejected {
+        /// The deliverable's current status (as the daemon reported it).
+        from: String,
+        /// The rejected target status.
+        to: String,
+        /// The states that WOULD have been legal from `from`.
+        allowed_next: Vec<String>,
+    },
+    /// Any non-409 failure (network, 404, 500, deserialization).
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for SetStatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SetStatusError::Rejected {
+                from,
+                to,
+                allowed_next,
+            } => {
+                let allowed = if allowed_next.is_empty() {
+                    "none (terminal state)".to_string()
+                } else {
+                    allowed_next.join(", ")
+                };
+                write!(
+                    f,
+                    "illegal status transition {from} -> {to}; legal next states from {from}: [{allowed}]"
+                )
+            }
+            SetStatusError::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for SetStatusError {}
+
+/// Wire wrapper for `GET .../deliverables` (`{ deliverables: [...] }`).
+#[derive(Debug, Deserialize)]
+struct DeliverablesListWire {
+    #[serde(default)]
+    deliverables: Vec<Deliverable>,
+}
+
+/// Wire wrapper for `GET .../milestones` (`{ milestones: [...] }`).
+#[derive(Debug, Deserialize)]
+struct MilestonesListWire {
+    #[serde(default)]
+    milestones: Vec<Milestone>,
+}
+
+impl DaemonClient {
+    /// List a project's Deliverables via `GET .../deliverables[?status=]`.
+    ///
+    /// Why: backs `tm projects deliverables list <project> [--status <s>]`.
+    /// What: GETs the collection with an optional `?status=` filter, returns the
+    /// `deliverables` array.
+    /// Test: `deliverables_list_deserializes`; live HTTP via `deliverable_routes`.
+    pub async fn list_deliverables(
+        &self,
+        project: &str,
+        status: Option<DeliverableStatus>,
+    ) -> anyhow::Result<Vec<Deliverable>> {
+        let url = format!("{}/api/v1/projects/{project}/deliverables", self.base);
+        let mut req = self.http.get(&url);
+        if let Some(status) = status {
+            req = req.query(&[("status", status.as_str())]);
+        }
+        let body: DeliverablesListWire = req
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize deliverable list")?;
+        Ok(body.deliverables)
+    }
+
+    /// Create a Deliverable via `POST .../deliverables`.
+    ///
+    /// Why: backs `tm projects deliverables add`.
+    /// What: POSTs `args`, returns the created [`Deliverable`] (status `Proposed`).
+    /// Test: `create_deliverable_args_serializes`; live HTTP via `deliverable_routes`.
+    pub async fn create_deliverable(
+        &self,
+        project: &str,
+        args: &CreateDeliverableArgs,
+    ) -> anyhow::Result<Deliverable> {
+        let url = format!("{}/api/v1/projects/{project}/deliverables", self.base);
+        let created: Deliverable = self
+            .http
+            .post(&url)
+            .json(args)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize created deliverable")?;
+        Ok(created)
+    }
+
+    /// Fetch one Deliverable via `GET .../deliverables/{id}`.
+    ///
+    /// Why: backs `tm projects deliverables show <project> <id>`.
+    /// What: GETs the point-lookup, returns the [`Deliverable`].
+    /// Test: live HTTP via `deliverable_routes`.
+    pub async fn get_deliverable(&self, project: &str, id: &str) -> anyhow::Result<Deliverable> {
+        let url = format!("{}/api/v1/projects/{project}/deliverables/{id}", self.base);
+        let d: Deliverable = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize deliverable")?;
+        Ok(d)
+    }
+
+    /// Transition a Deliverable's status via `PATCH .../deliverables/{id}`.
+    ///
+    /// Why: backs `tm projects deliverables set-status`. The daemon enforces the
+    /// §10.3 state machine (#2380); an illegal transition returns a structured 409
+    /// this method converts into [`SetStatusError::Rejected`] carrying the legal
+    /// next states, so the CLI can guide the operator.
+    /// What: PATCHes `{ "status": <status> }`; on 409 parses the transition body,
+    /// otherwise returns the updated [`Deliverable`].
+    /// Test: `transition_rejection_body_deserializes`; live HTTP via
+    /// `deliverable_routes::patch_illegal_transition_is_409_with_allowed_next`.
+    pub async fn set_deliverable_status(
+        &self,
+        project: &str,
+        id: &str,
+        status: DeliverableStatus,
+    ) -> Result<Deliverable, SetStatusError> {
+        let url = format!("{}/api/v1/projects/{project}/deliverables/{id}", self.base);
+        let resp = self
+            .http
+            .patch(&url)
+            .json(&serde_json::json!({ "status": status }))
+            .send()
+            .await
+            .map_err(|e| SetStatusError::Other(e.into()))?;
+
+        if resp.status() == StatusCode::CONFLICT {
+            let body: TransitionRejectionBody = resp
+                .json()
+                .await
+                .map_err(|e| SetStatusError::Other(e.into()))?;
+            return Err(SetStatusError::Rejected {
+                from: body.from,
+                to: body.to,
+                allowed_next: body.allowed_next,
+            });
+        }
+
+        let resp = resp
+            .error_for_status()
+            .map_err(|e| SetStatusError::Other(e.into()))?;
+        resp.json()
+            .await
+            .context("deserialize updated deliverable")
+            .map_err(SetStatusError::Other)
+    }
+
+    /// List a project's Milestones via `GET .../milestones`.
+    ///
+    /// Why: backs `tm projects milestones list <project>`.
+    /// What: GETs the collection, returns the `milestones` array.
+    /// Test: `milestones_list_deserializes`; live HTTP via `deliverable_routes`.
+    pub async fn list_milestones(&self, project: &str) -> anyhow::Result<Vec<Milestone>> {
+        let url = format!("{}/api/v1/projects/{project}/milestones", self.base);
+        let body: MilestonesListWire = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize milestone list")?;
+        Ok(body.milestones)
+    }
+
+    /// Create a Milestone via `POST .../milestones`.
+    ///
+    /// Why: backs `tm projects milestones add`.
+    /// What: POSTs `args`, returns the created [`Milestone`].
+    /// Test: `create_milestone_args_serializes`; live HTTP via `deliverable_routes`.
+    pub async fn create_milestone(
+        &self,
+        project: &str,
+        args: &CreateMilestoneArgs,
+    ) -> anyhow::Result<Milestone> {
+        let url = format!("{}/api/v1/projects/{project}/milestones", self.base);
+        let created: Milestone = self
+            .http
+            .post(&url)
+            .json(args)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize created milestone")?;
+        Ok(created)
+    }
+
+    /// Fetch one Milestone via `GET .../milestones/{id}`.
+    ///
+    /// Why: backs `tm projects milestones show <project> <id>`.
+    /// What: GETs the point-lookup, returns the [`Milestone`].
+    /// Test: live HTTP via `deliverable_routes`.
+    pub async fn get_milestone(&self, project: &str, id: &str) -> anyhow::Result<Milestone> {
+        let url = format!("{}/api/v1/projects/{project}/milestones/{id}", self.base);
+        let m: Milestone = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize milestone")?;
+        Ok(m)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_deliverable_args_serializes() {
+        let args = CreateDeliverableArgs {
+            name: "OAuth2 flow".into(),
+            description: None,
+            kind: DeliverableKind::Feature,
+            estimated_effort: EstimationTier::L,
+            ticket_ref: Some("#2117".into()),
+            spec_ref: None,
+        };
+        let v = serde_json::to_value(&args).unwrap();
+        assert_eq!(v["name"], "OAuth2 flow");
+        // kind serializes lowercase, tier uppercase — matching the daemon DTO.
+        assert_eq!(v["kind"], "feature");
+        assert_eq!(v["estimated_effort"], "L");
+        assert_eq!(v["ticket_ref"], "#2117");
+        assert!(v.get("description").is_none());
+        assert!(v.get("spec_ref").is_none());
+    }
+
+    #[test]
+    fn create_milestone_args_serializes() {
+        let args = CreateMilestoneArgs {
+            name: "v1.0 Alpha".into(),
+            description: Some("first alpha".into()),
+            target_date: DateTime::parse_from_rfc3339("2026-09-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        };
+        let v = serde_json::to_value(&args).unwrap();
+        assert_eq!(v["name"], "v1.0 Alpha");
+        assert_eq!(v["description"], "first alpha");
+        assert!(v["target_date"].is_string());
+    }
+
+    /// The 409 body parses into the typed rejection the CLI renders.
+    #[test]
+    fn transition_rejection_body_deserializes() {
+        let json = serde_json::json!({
+            "error": "invalid status transition proposed → complete; ...",
+            "from": "proposed",
+            "to": "complete",
+            "allowed_next": ["in-progress"]
+        });
+        let body: TransitionRejectionBody = serde_json::from_value(json).unwrap();
+        assert_eq!(body.from, "proposed");
+        assert_eq!(body.to, "complete");
+        assert_eq!(body.allowed_next, vec!["in-progress".to_string()]);
+    }
+
+    /// The `SetStatusError::Rejected` Display names the legal next states.
+    #[test]
+    fn set_status_rejected_display_lists_allowed() {
+        let e = SetStatusError::Rejected {
+            from: "proposed".into(),
+            to: "complete".into(),
+            allowed_next: vec!["in-progress".into()],
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("proposed"), "{msg}");
+        assert!(msg.contains("complete"), "{msg}");
+        assert!(msg.contains("in-progress"), "{msg}");
+    }
+
+    #[test]
+    fn deliverables_list_deserializes() {
+        let json = serde_json::json!({
+            "deliverables": [{
+                "id": "00000000-0000-0000-0000-000000000001",
+                "project_name": "widget",
+                "name": "OAuth2 flow",
+                "kind": "feature",
+                "status": "proposed",
+                "estimated_effort": "L",
+                "created_at": "2026-07-10T12:00:00Z"
+            }]
+        });
+        let body: DeliverablesListWire = serde_json::from_value(json).unwrap();
+        assert_eq!(body.deliverables.len(), 1);
+        assert_eq!(body.deliverables[0].name, "OAuth2 flow");
+        assert_eq!(body.deliverables[0].status, DeliverableStatus::Proposed);
+    }
+
+    #[test]
+    fn milestones_list_deserializes() {
+        let json = serde_json::json!({
+            "milestones": [{
+                "id": "00000000-0000-0000-0000-000000000002",
+                "project_name": "widget",
+                "name": "v1.0 Alpha",
+                "target_date": "2026-09-01T00:00:00Z",
+                "status": "proposed",
+                "deliverables": [],
+                "created_at": "2026-07-10T12:00:00Z"
+            }]
+        });
+        let body: MilestonesListWire = serde_json::from_value(json).unwrap();
+        assert_eq!(body.milestones.len(), 1);
+        assert_eq!(body.milestones[0].name, "v1.0 Alpha");
+    }
+}

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -12,7 +12,9 @@
 //! deserialization; live HTTP is exercised by the executor tests against an
 //! in-process test daemon and by the daemon's own API tests.
 
+pub mod deliverables;
 mod managed;
+pub mod projects;
 mod session_connect;
 #[cfg(test)]
 mod tests;

--- a/crates/trusty-mpm/src/client/http_client/projects.rs
+++ b/crates/trusty-mpm/src/client/http_client/projects.rs
@@ -1,0 +1,309 @@
+//! Registry-B project methods for [`DaemonClient`] (DOC-35 §3.1/§4, #2115).
+//!
+//! Why: the `tm projects list/register/show/status` CLI verbs are thin HTTP
+//! clients (DOC-35 §1.3). Wiring each endpoint once here — as typed
+//! [`DaemonClient`] methods — keeps every consumer (the CLI today, the TUI next)
+//! off hand-rolled `reqwest` calls, exactly as the managed-session methods in the
+//! sibling `managed.rs` do. This file lives beside `mod.rs` (not in it) so the
+//! near-cap client `mod.rs` stays under the 500-SLOC bar; it reaches the
+//! `base`/`http` fields because they are `pub(in crate::client::http_client)`.
+//! What: the registry-B response DTOs the client owns ([`ProjectStatusWire`] and
+//! its parts, plus [`RegisterProjectArgs`] for the POST body) and four methods:
+//! [`DaemonClient::registry_list_projects`], [`DaemonClient::registry_register_project`],
+//! [`DaemonClient::registry_get_project`], and [`DaemonClient::project_status`].
+//! The status DTO deliberately does NOT `deny_unknown_fields` so the additive
+//! Deliverable/Milestone histogram fields #2382 adds to the endpoint deserialize
+//! cleanly against an older client (wire-compat, forward-tolerant).
+//! Test: `project_status_wire_tolerates_additive_fields`,
+//! `register_args_serializes_to_wire_shape`, `projects_list_deserializes` in the
+//! `tests` submodule; live HTTP via the daemon's own route tests.
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::DaemonClient;
+use crate::project::Project;
+
+/// Serializable body for `POST /api/v1/projects` (registry-B register).
+///
+/// Why: `tm projects register` builds this from its flags; a typed struct keeps
+/// the wire body checkable in a unit test rather than a hand-built `json!`.
+/// What: mirrors the daemon's `RegisterProjectBody` — `name`/`repo_url` required,
+/// the rest optional and omitted from the JSON when `None`.
+/// Test: `register_args_serializes_to_wire_shape`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RegisterProjectArgs {
+    /// Registry key.
+    pub name: String,
+    /// Full repository URL.
+    pub repo_url: String,
+    /// Default branch; the daemon defaults to `"main"` when omitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_branch: Option<String>,
+    /// Free-form description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Classification tags.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    /// Technology-stack hint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stack_hint: Option<String>,
+    /// Preferred `gh` login (#2081).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gh_user: Option<String>,
+}
+
+/// Per-state session histogram (client mirror of the daemon `SessionStateCounts`).
+///
+/// Why: the `tm projects status` rollup needs the per-state counts; every field
+/// is `#[serde(default)]` so a daemon that renames or drops a state (unlikely,
+/// but forward-safe) still deserializes.
+/// What: one count per lifecycle state plus the total.
+/// Test: `project_status_wire_tolerates_additive_fields`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SessionStateCountsWire {
+    /// Sessions in `Provisioning`.
+    #[serde(default)]
+    pub provisioning: usize,
+    /// Sessions in `Active`.
+    #[serde(default)]
+    pub active: usize,
+    /// Sessions in `Stopped`.
+    #[serde(default)]
+    pub stopped: usize,
+    /// Sessions in `Errored`.
+    #[serde(default)]
+    pub errored: usize,
+    /// Sessions in `Decommissioned` (tombstones).
+    #[serde(default)]
+    pub decommissioned: usize,
+    /// Total bound session records.
+    #[serde(default)]
+    pub total: usize,
+}
+
+/// Config-completeness flags (client mirror of the daemon `ProjectConfigFlags`).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ProjectConfigFlagsWire {
+    /// Whether `gh_user` is set.
+    #[serde(default)]
+    pub gh_user_set: bool,
+    /// Whether the per-project `gh` identity binding is set.
+    #[serde(default)]
+    pub github_binding_set: bool,
+}
+
+/// Deserialized `GET /api/v1/projects/{name}/status` rollup.
+///
+/// Why: the daemon's `ProjectStatusResponse` is `Serialize`-only and lives in the
+/// daemon module; the client needs its own `Deserialize` mirror. It is
+/// intentionally forward-tolerant — no `deny_unknown_fields` — so the additive
+/// `deliverables`/`milestones` histogram fields #2382 adds land in an older client
+/// without error (the client simply ignores fields it does not model).
+/// What: the project identity, the session histogram, the newest activity
+/// timestamp, and the config flags.
+/// Test: `project_status_wire_tolerates_additive_fields`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProjectStatusWire {
+    /// Registered project name.
+    #[serde(default)]
+    pub project_name: String,
+    /// Repository URL.
+    #[serde(default)]
+    pub repo_url: String,
+    /// Per-state session histogram.
+    #[serde(default)]
+    pub sessions: SessionStateCountsWire,
+    /// Most recent activity across the project's sessions, if any.
+    #[serde(default)]
+    pub last_activity_at: Option<DateTime<Utc>>,
+    /// Config-completeness flags.
+    #[serde(default)]
+    pub config: ProjectConfigFlagsWire,
+}
+
+/// Wire wrapper for `GET /api/v1/projects` (`{ projects, count }`).
+#[derive(Debug, Deserialize)]
+struct ProjectsListWire {
+    #[serde(default)]
+    projects: Vec<Project>,
+}
+
+impl DaemonClient {
+    /// List registry-B projects via `GET /api/v1/projects`, optional tag filter.
+    ///
+    /// Why: backs `tm projects list [--tag <t>]` (#2115). Tag filtering is applied
+    /// client-side (a pure `retain`) so the endpoint stays a plain list and the
+    /// filter rule lives in one place.
+    /// What: GETs the collection, returns the `projects` array; when `tag` is
+    /// `Some`, keeps only projects whose `tags` contain it.
+    /// Test: `projects_list_deserializes`; live HTTP via the daemon route tests.
+    pub async fn registry_list_projects(&self, tag: Option<&str>) -> anyhow::Result<Vec<Project>> {
+        let url = format!("{}/api/v1/projects", self.base);
+        let body: ProjectsListWire = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize project list")?;
+        let mut projects = body.projects;
+        if let Some(tag) = tag {
+            projects.retain(|p| p.tags.iter().any(|t| t == tag));
+        }
+        Ok(projects)
+    }
+
+    /// Register (idempotent upsert) a project via `POST /api/v1/projects`.
+    ///
+    /// Why: backs `tm projects register` (#2115). The daemon upserts on `name` and
+    /// preserves any existing `gh`/commit identity binding.
+    /// What: POSTs `args`, returns the stored [`Project`].
+    /// Test: `register_args_serializes_to_wire_shape`; live HTTP via the daemon
+    /// route tests.
+    pub async fn registry_register_project(
+        &self,
+        args: &RegisterProjectArgs,
+    ) -> anyhow::Result<Project> {
+        let url = format!("{}/api/v1/projects", self.base);
+        let project: Project = self
+            .http
+            .post(&url)
+            .json(args)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize registered project")?;
+        Ok(project)
+    }
+
+    /// Fetch one project via `GET /api/v1/projects/{name}`.
+    ///
+    /// Why: backs the config half of `tm projects show` (#2115).
+    /// What: GETs the point-lookup, returns the [`Project`]; a 404 surfaces as an
+    /// error via `error_for_status`.
+    /// Test: live HTTP via the daemon route tests.
+    pub async fn registry_get_project(&self, name: &str) -> anyhow::Result<Project> {
+        let url = format!("{}/api/v1/projects/{name}", self.base);
+        let project: Project = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize project")?;
+        Ok(project)
+    }
+
+    /// Fetch the deterministic status rollup via `GET .../{name}/status`.
+    ///
+    /// Why: backs `tm projects status` (#2115). The [`ProjectStatusWire`] target is
+    /// forward-tolerant of #2382's additive histogram fields.
+    /// What: GETs the rollup, returns the parsed [`ProjectStatusWire`].
+    /// Test: `project_status_wire_tolerates_additive_fields`; live HTTP via the
+    /// daemon route tests.
+    pub async fn project_status(&self, name: &str) -> anyhow::Result<ProjectStatusWire> {
+        let url = format!("{}/api/v1/projects/{name}/status", self.base);
+        let status: ProjectStatusWire = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize project status")?;
+        Ok(status)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The status DTO ignores unknown fields, so #2382's additive
+    /// `deliverables`/`milestones` histograms deserialize against this client.
+    #[test]
+    fn project_status_wire_tolerates_additive_fields() {
+        let json = serde_json::json!({
+            "project_name": "widget",
+            "repo_url": "https://github.com/acme/widget",
+            "sessions": { "provisioning": 1, "active": 2, "stopped": 0,
+                          "errored": 0, "decommissioned": 1, "total": 4 },
+            "last_activity_at": "2026-07-10T12:00:00Z",
+            "config": { "gh_user_set": true, "github_binding_set": false },
+            // Fields #2382 (Wave 2) adds — an older client must ignore them.
+            "deliverables": { "proposed": 3, "complete": 1 },
+            "milestones": { "in-progress": 1 }
+        });
+        let status: ProjectStatusWire = serde_json::from_value(json).unwrap();
+        assert_eq!(status.project_name, "widget");
+        assert_eq!(status.sessions.active, 2);
+        assert_eq!(status.sessions.total, 4);
+        assert!(status.config.gh_user_set);
+        assert!(status.last_activity_at.is_some());
+    }
+
+    /// A status body missing the newer `config`/`last_activity_at` still parses
+    /// (backward tolerance): every field defaults.
+    #[test]
+    fn project_status_wire_tolerates_missing_fields() {
+        let json = serde_json::json!({
+            "project_name": "widget",
+            "repo_url": "https://github.com/acme/widget",
+            "sessions": { "total": 0 }
+        });
+        let status: ProjectStatusWire = serde_json::from_value(json).unwrap();
+        assert_eq!(status.sessions.total, 0);
+        assert!(status.last_activity_at.is_none());
+        assert!(!status.config.gh_user_set);
+    }
+
+    /// The register body omits absent optionals and keeps the required pair.
+    #[test]
+    fn register_args_serializes_to_wire_shape() {
+        let args = RegisterProjectArgs {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: Some("develop".into()),
+            description: None,
+            tags: Some(vec!["backend".into()]),
+            stack_hint: None,
+            gh_user: None,
+        };
+        let v = serde_json::to_value(&args).unwrap();
+        assert_eq!(v["name"], "widget");
+        assert_eq!(v["repo_url"], "https://github.com/acme/widget");
+        assert_eq!(v["default_branch"], "develop");
+        assert_eq!(v["tags"][0], "backend");
+        // Absent optionals must not appear in the body.
+        assert!(v.get("description").is_none());
+        assert!(v.get("stack_hint").is_none());
+        assert!(v.get("gh_user").is_none());
+    }
+
+    /// The list wrapper deserializes the `{ projects, count }` shape and drops the
+    /// extra `count` field the client does not model.
+    #[test]
+    fn projects_list_deserializes() {
+        let json = serde_json::json!({
+            "projects": [{
+                "name": "widget",
+                "repo_url": "https://github.com/acme/widget",
+                "default_branch": "main"
+            }],
+            "count": 1
+        });
+        let body: ProjectsListWire = serde_json::from_value(json).unwrap();
+        assert_eq!(body.projects.len(), 1);
+        assert_eq!(body.projects[0].name, "widget");
+    }
+}

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -135,10 +135,11 @@ pub use deliverable_routes::{
 use super::managed_routes::{
     adopt_existing_session, answer_session_decision, decommission_ephemeral_route,
     decommission_managed_session, delete_managed_session, fleet_by_project_route, get_attach_cmd,
-    get_managed_session, get_session_activity, list_managed_sessions, project_status_route,
-    proxy_focus, proxy_get_focus, proxy_message, proxy_summary, proxy_unfocus, prune_managed_route,
-    prune_worktrees_route, reactivate_managed_session, resume_managed_session, send_to_session,
-    spawn_session, stop_managed_session, stop_managed_session_runtime,
+    get_managed_session, get_project_registry_route, get_session_activity, list_managed_sessions,
+    list_projects_registry_route, project_status_route, proxy_focus, proxy_get_focus,
+    proxy_message, proxy_summary, proxy_unfocus, prune_managed_route, prune_worktrees_route,
+    reactivate_managed_session, register_project_registry_route, resume_managed_session,
+    send_to_session, spawn_session, stop_managed_session, stop_managed_session_runtime,
 };
 
 /// Typed HTTP response bodies for every endpoint.
@@ -174,6 +175,17 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .route("/projects", get(list_projects).post(register_project))
         .route("/projects/current", get(current_project))
         .route("/projects/discover", get(discover_projects))
+        // #2114 (DOC-35 §4): registry-B project HTTP surface — the plain-HTTP
+        // list/register/get the deterministic `tm projects` CLI (#2115) calls,
+        // mirroring the `project_list`/`project_register`/`project_get` MCP tools.
+        // The bare `/api/v1/projects` collection route is registered here; the
+        // `{name}` point-lookup sits below the more specific `/status` and
+        // `/deliverables` param routes (matchit disambiguates by segment count).
+        .route(
+            "/api/v1/projects",
+            get(list_projects_registry_route).post(register_project_registry_route),
+        )
+        .route("/api/v1/projects/{name}", get(get_project_registry_route))
         // #2117 (DOC-35 §4.1): deterministic project status-aggregation rollup —
         // session-state histogram + most-recent activity + config-completeness
         // flags for ONE named project. Pure composition over ProjectRegistry::get

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -32,6 +32,7 @@ pub mod inproject;
 pub mod inproject_hygiene;
 mod lifecycle;
 mod mcp_spawn_gate;
+mod project_registry_routes;
 mod project_status;
 pub mod proxy;
 pub mod prune;
@@ -45,6 +46,10 @@ pub use front_gate::{
 pub use lifecycle::{
     ResumeManagedError, SpawnParams, is_local_workdir, resume_managed, spawn_managed,
     spawn_runtime_for, write_task_md,
+};
+pub use project_registry_routes::{
+    ProjectsListResponse, RegisterProjectBody, get_project_registry_route,
+    list_projects_registry_route, register_project_registry_route,
 };
 pub use project_status::{
     ProjectConfigFlags, ProjectStatusResponse, SessionStateCounts, aggregate_project_status,

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
@@ -71,7 +71,7 @@ pub struct RegisterProjectBody {
 /// Why: mirrors the `project_list` MCP tool's `{ projects, count }` shape so a
 /// consumer can read the inventory and its size in one call.
 /// What: the registered projects plus their count.
-/// Test: `tests/project_registry_routes.rs::list_returns_registered_projects`.
+/// Test: `tests/project_registry_routes.rs::register_get_list_status_round_trip`.
 #[derive(Debug, Serialize)]
 pub struct ProjectsListResponse {
     /// Every registered project.
@@ -87,7 +87,7 @@ pub struct ProjectsListResponse {
 /// What: returns `{ projects, count }`; a store read failure degrades to 500 with
 /// a logged warning rather than a panic (the library never `unwrap`s a store
 /// result).
-/// Test: `tests/project_registry_routes.rs::list_returns_registered_projects`.
+/// Test: `tests/project_registry_routes.rs::register_get_list_status_round_trip`.
 pub async fn list_projects_registry_route(
     State(state): State<Arc<DaemonState>>,
 ) -> impl IntoResponse {
@@ -117,8 +117,8 @@ pub async fn list_projects_registry_route(
 /// (defaulting `default_branch` to `"main"`), preserves the existing binding,
 /// persists via [`ProjectRegistry::register`](crate::project::ProjectRegistry::register),
 /// and returns 201 with the stored record.
-/// Test: `tests/project_registry_routes.rs::register_then_get_round_trips`,
-/// `register_preserves_existing_identity_binding`.
+/// Test: `tests/project_registry_routes.rs::register_get_list_status_round_trip`,
+/// `register_is_idempotent_upsert`, `register_preserves_identity_binding_not_expressible_in_body`.
 pub async fn register_project_registry_route(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<RegisterProjectBody>,
@@ -164,8 +164,8 @@ pub async fn register_project_registry_route(
 /// project view (the nested sessions half comes from the fleet endpoint, §3.1).
 /// What: returns the project (200) or a 404 when unregistered; any other store
 /// error degrades to 500 with a logged warning.
-/// Test: `tests/project_registry_routes.rs::register_then_get_round_trips`,
-/// `get_unknown_project_is_404`.
+/// Test: `tests/project_registry_routes.rs::register_get_list_status_round_trip`,
+/// `get_unknown_project_errors`.
 pub async fn get_project_registry_route(
     State(state): State<Arc<DaemonState>>,
     AxumPath(name): AxumPath<String>,

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
@@ -1,0 +1,231 @@
+//! Registry-B project HTTP surface (DOC-35 §4, #2114) — list / register / get.
+//!
+//! Why: `tm projects list/register/show` (#2115) are thin deterministic HTTP
+//! clients (DOC-35 §1.3) and need `GET/POST /api/v1/projects` and
+//! `GET /api/v1/projects/{name}` to call. Registry B (`crate::project`) was until
+//! now reachable only via the MCP tools (`mcp_project.rs`) and the `/status`
+//! rollup route; the plain-HTTP list/register/get surface those verbs require did
+//! not exist, so this module adds it. Each handler is a thin, deterministic
+//! composition over [`crate::project::ProjectRegistry`] — no LLM, no cross-store
+//! reasoning (§11) — mirroring the existing `mcp_project` bodies so the HTTP and
+//! MCP surfaces stay behaviourally identical (idempotent upsert keyed on `name`,
+//! preserving the per-project `gh`/commit identity binding across a re-register).
+//! What: [`RegisterProjectBody`], [`ProjectsListResponse`], and the three axum
+//! handlers [`list_projects_registry_route`], [`register_project_registry_route`],
+//! and [`get_project_registry_route`]. `PATCH` (the `tm projects config` field
+//! editor, §3.1) is intentionally NOT added here — it belongs to the config-verb
+//! work, not #2115's read/register slice.
+//! Test: `register_body_deserializes`, `register_body_minimal`, and the HTTP
+//! handler tests in `tests/project_registry_routes.rs`.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::daemon::state::DaemonState;
+use crate::project::{Project, ProjectStoreError};
+
+/// JSON body for `POST /api/v1/projects` — an idempotent project upsert.
+///
+/// Why: registering a project from the deterministic CLI (#2115) mirrors the
+/// `project_register` MCP tool's arguments so the two surfaces never drift. Only
+/// `name` and `repo_url` are required; the rest are optional descriptive config.
+/// The per-project `gh`/commit identity binding (#2184) is deliberately absent —
+/// like `project_register`, a re-register PRESERVES any existing binding rather
+/// than wiping it (operators set those via the config path).
+/// What: the register arguments, all optional beyond `name`/`repo_url`, with
+/// `default_branch` defaulting to `"main"` when omitted.
+/// Test: `register_body_deserializes`, `register_body_minimal`.
+#[derive(Debug, Deserialize)]
+pub struct RegisterProjectBody {
+    /// Registry key (non-empty).
+    pub name: String,
+    /// Full repository URL (non-empty).
+    pub repo_url: String,
+    /// Default branch; defaults to `"main"` when omitted.
+    #[serde(default)]
+    pub default_branch: Option<String>,
+    /// Free-form description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Classification tags.
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+    /// Technology-stack hint (e.g. `rust`).
+    #[serde(default)]
+    pub stack_hint: Option<String>,
+    /// Preferred `gh` login for this project (#2081).
+    #[serde(default)]
+    pub gh_user: Option<String>,
+}
+
+/// Response body for `GET /api/v1/projects`.
+///
+/// Why: mirrors the `project_list` MCP tool's `{ projects, count }` shape so a
+/// consumer can read the inventory and its size in one call.
+/// What: the registered projects plus their count.
+/// Test: `tests/project_registry_routes.rs::list_returns_registered_projects`.
+#[derive(Debug, Serialize)]
+pub struct ProjectsListResponse {
+    /// Every registered project.
+    pub projects: Vec<Project>,
+    /// `projects.len()`, surfaced so scripts need not count client-side.
+    pub count: usize,
+}
+
+/// `GET /api/v1/projects` — list every registered registry-B project.
+///
+/// Why: backs `tm projects list` (#2115). A pure read over
+/// [`ProjectRegistry::list`](crate::project::ProjectRegistry::list).
+/// What: returns `{ projects, count }`; a store read failure degrades to 500 with
+/// a logged warning rather than a panic (the library never `unwrap`s a store
+/// result).
+/// Test: `tests/project_registry_routes.rs::list_returns_registered_projects`.
+pub async fn list_projects_registry_route(
+    State(state): State<Arc<DaemonState>>,
+) -> impl IntoResponse {
+    let registry = state.project_registry().await;
+    match registry.list().await {
+        Ok(projects) => {
+            let count = projects.len();
+            Json(ProjectsListResponse { projects, count }).into_response()
+        }
+        Err(e) => {
+            warn!(error = %e, "list_projects_registry_route: registry read failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "project registry read failed".to_string(),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// `POST /api/v1/projects` — register (idempotent upsert) a registry-B project.
+///
+/// Why: backs `tm projects register` (#2115). Mirrors the `project_register` MCP
+/// tool: upsert keyed on `name`, preserving any existing `gh`/commit identity
+/// binding so a plain re-register never silently wipes config set elsewhere.
+/// What: rejects a blank `name`/`repo_url` with 400; builds a [`Project`]
+/// (defaulting `default_branch` to `"main"`), preserves the existing binding,
+/// persists via [`ProjectRegistry::register`](crate::project::ProjectRegistry::register),
+/// and returns 201 with the stored record.
+/// Test: `tests/project_registry_routes.rs::register_then_get_round_trips`,
+/// `register_preserves_existing_identity_binding`.
+pub async fn register_project_registry_route(
+    State(state): State<Arc<DaemonState>>,
+    Json(body): Json<RegisterProjectBody>,
+) -> impl IntoResponse {
+    if body.name.trim().is_empty() {
+        return (StatusCode::BAD_REQUEST, "project name must not be empty").into_response();
+    }
+    if body.repo_url.trim().is_empty() {
+        return (StatusCode::BAD_REQUEST, "repo_url must not be empty").into_response();
+    }
+
+    let registry = state.project_registry().await;
+    // #2184 parity with `project_register`: a re-register REPLACES the record, so
+    // carry any existing per-project `gh`/commit identity binding forward rather
+    // than clobbering it (this route's body cannot express those fields).
+    let existing = registry.get(&body.name).await.ok();
+    let project = Project {
+        name: body.name,
+        repo_url: body.repo_url,
+        default_branch: body.default_branch.unwrap_or_else(|| "main".to_string()),
+        stack_hint: body.stack_hint,
+        tags: body.tags.unwrap_or_default(),
+        description: body.description,
+        gh_user: body.gh_user,
+        github: existing.as_ref().and_then(|p| p.github.clone()),
+        commit_name: existing.as_ref().and_then(|p| p.commit_name.clone()),
+        commit_email: existing.as_ref().and_then(|p| p.commit_email.clone()),
+    };
+    if let Err(e) = registry.register(project.clone()).await {
+        warn!(error = %e, project = %project.name, "register_project_registry_route: register failed");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "project registry write failed".to_string(),
+        )
+            .into_response();
+    }
+    (StatusCode::CREATED, Json(project)).into_response()
+}
+
+/// `GET /api/v1/projects/{name}` — fetch one registry-B project by name.
+///
+/// Why: backs `tm projects show` (#2115) — the config half of the read-only
+/// project view (the nested sessions half comes from the fleet endpoint, §3.1).
+/// What: returns the project (200) or a 404 when unregistered; any other store
+/// error degrades to 500 with a logged warning.
+/// Test: `tests/project_registry_routes.rs::register_then_get_round_trips`,
+/// `get_unknown_project_is_404`.
+pub async fn get_project_registry_route(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(name): AxumPath<String>,
+) -> impl IntoResponse {
+    let registry = state.project_registry().await;
+    match registry.get(&name).await {
+        Ok(project) => Json(project).into_response(),
+        Err(ProjectStoreError::NotFound(_)) => {
+            (StatusCode::NOT_FOUND, format!("project {name} not found")).into_response()
+        }
+        Err(e) => {
+            warn!(error = %e, project = %name, "get_project_registry_route: registry read failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "project registry read failed".to_string(),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A full register body deserializes with every field populated.
+    #[test]
+    fn register_body_deserializes() {
+        let json = serde_json::json!({
+            "name": "widget",
+            "repo_url": "https://github.com/acme/widget",
+            "default_branch": "develop",
+            "description": "the widget",
+            "tags": ["backend", "oss"],
+            "stack_hint": "rust",
+            "gh_user": "acme-bot"
+        });
+        let body: RegisterProjectBody = serde_json::from_value(json).unwrap();
+        assert_eq!(body.name, "widget");
+        assert_eq!(body.repo_url, "https://github.com/acme/widget");
+        assert_eq!(body.default_branch.as_deref(), Some("develop"));
+        assert_eq!(
+            body.tags.as_deref(),
+            Some(&["backend".to_string(), "oss".to_string()][..])
+        );
+        assert_eq!(body.gh_user.as_deref(), Some("acme-bot"));
+    }
+
+    /// Only `name`/`repo_url` are required; the rest default to absent.
+    #[test]
+    fn register_body_minimal() {
+        let json = serde_json::json!({
+            "name": "minimal",
+            "repo_url": "https://github.com/acme/minimal"
+        });
+        let body: RegisterProjectBody = serde_json::from_value(json).unwrap();
+        assert_eq!(body.name, "minimal");
+        assert!(body.default_branch.is_none());
+        assert!(body.tags.is_none());
+        assert!(body.stack_hint.is_none());
+        assert!(body.gh_user.is_none());
+    }
+}

--- a/crates/trusty-mpm/tests/project_registry_routes.rs
+++ b/crates/trusty-mpm/tests/project_registry_routes.rs
@@ -1,0 +1,233 @@
+//! End-to-end HTTP tests for the registry-B project routes (#2114/#2115) and the
+//! Deliverable/Milestone client methods (#2381), driven through the REAL
+//! `DaemonClient` against the REAL `api::router` on a loopback port.
+//!
+//! Why: the in-crate unit tests cover the pure pieces (wire-shape serde in
+//! `client::http_client::{projects,deliverables}::tests`, the daemon handlers'
+//! request DTOs). This file is the literal proof that the CLI's client methods
+//! and the daemon's new routes agree over the wire — `registry_register_project`
+//! → `registry_get_project` → `registry_list_projects` → `project_status`
+//! round-trips, the §10.3 illegal-transition 409 surfaces as
+//! `SetStatusError::Rejected` carrying the legal next states, and the
+//! Deliverable/Milestone CRUD path works through the client. Mirrors the harness
+//! in `tests/project_status_route.rs` (axum::serve on an ephemeral port +
+//! reqwest), so no external daemon is needed in CI.
+//! What: binds the router once per test, points a `DaemonClient` at it, and drives
+//! the full verb surface.
+//! Test: this file IS the test; run with
+//! `cargo test -p trusty-mpm --test project_registry_routes`.
+
+use std::future::IntoFuture;
+use std::sync::Arc;
+
+use trusty_mpm::client::DaemonClient;
+use trusty_mpm::client::http_client::deliverables::{
+    CreateDeliverableArgs, CreateMilestoneArgs, SetStatusError,
+};
+use trusty_mpm::client::http_client::projects::RegisterProjectArgs;
+use trusty_mpm::daemon::{api, state::DaemonState};
+use trusty_mpm::deliverable::{DeliverableKind, DeliverableStatus, EstimationTier};
+
+/// Bind the real router on an ephemeral loopback port; return a client for it.
+async fn serve() -> DaemonClient {
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let router = api::router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    DaemonClient::new(format!("http://{addr}"))
+}
+
+/// register → get → list → status round-trips over real HTTP.
+#[tokio::test]
+async fn register_get_list_status_round_trip() {
+    let client = serve().await;
+
+    let args = RegisterProjectArgs {
+        name: "widget".into(),
+        repo_url: "https://github.com/acme/widget".into(),
+        default_branch: Some("develop".into()),
+        description: Some("the widget".into()),
+        tags: Some(vec!["backend".into()]),
+        stack_hint: Some("rust".into()),
+        gh_user: Some("acme-bot".into()),
+    };
+    let registered = client.registry_register_project(&args).await.unwrap();
+    assert_eq!(registered.name, "widget");
+    assert_eq!(registered.default_branch, "develop");
+    assert_eq!(registered.gh_user.as_deref(), Some("acme-bot"));
+
+    let got = client.registry_get_project("widget").await.unwrap();
+    assert_eq!(got, registered);
+
+    let all = client.registry_list_projects(None).await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].name, "widget");
+
+    // Tag filter keeps the match and drops non-matches.
+    assert_eq!(
+        client
+            .registry_list_projects(Some("backend"))
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        client
+            .registry_list_projects(Some("nope"))
+            .await
+            .unwrap()
+            .len(),
+        0
+    );
+
+    // Status rollup: no sessions yet, gh_user flag set.
+    let status = client.project_status("widget").await.unwrap();
+    assert_eq!(status.project_name, "widget");
+    assert_eq!(status.sessions.total, 0);
+    assert!(status.config.gh_user_set);
+    assert!(status.last_activity_at.is_none());
+}
+
+/// A re-register (upsert) preserves an existing per-project identity binding that
+/// the register body cannot express (parity with `project_register`).
+#[tokio::test]
+async fn register_is_idempotent_upsert() {
+    let client = serve().await;
+    let base = RegisterProjectArgs {
+        name: "widget".into(),
+        repo_url: "https://github.com/acme/widget".into(),
+        default_branch: None,
+        description: None,
+        tags: None,
+        stack_hint: None,
+        gh_user: None,
+    };
+    client.registry_register_project(&base).await.unwrap();
+    // Re-register with a different branch — upsert on name, not a duplicate.
+    let mut updated = base.clone();
+    updated.default_branch = Some("release".into());
+    let out = client.registry_register_project(&updated).await.unwrap();
+    assert_eq!(out.default_branch, "release");
+    assert_eq!(client.registry_list_projects(None).await.unwrap().len(), 1);
+}
+
+/// Fetching an unregistered project surfaces an error (the daemon 404s).
+#[tokio::test]
+async fn get_unknown_project_errors() {
+    let client = serve().await;
+    assert!(client.registry_get_project("nope").await.is_err());
+}
+
+/// Deliverable create → list → set-status legal → illegal-409 round-trips, and
+/// the illegal transition surfaces as `SetStatusError::Rejected` with the legal
+/// next states (#2380).
+#[tokio::test]
+async fn deliverable_crud_and_illegal_transition_409() {
+    let client = serve().await;
+    // No project registration is required — deliverables defer referential
+    // integrity by design (daemon `CreateDeliverable` doc).
+    let created = client
+        .create_deliverable(
+            "widget",
+            &CreateDeliverableArgs {
+                name: "OAuth2 flow".into(),
+                description: None,
+                kind: DeliverableKind::Feature,
+                estimated_effort: EstimationTier::L,
+                ticket_ref: Some("#2117".into()),
+                spec_ref: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.status, DeliverableStatus::Proposed);
+
+    let id = created.id.to_string();
+    let listed = client.list_deliverables("widget", None).await.unwrap();
+    assert_eq!(listed.len(), 1);
+
+    // Status filter: proposed matches, in-progress does not (yet).
+    assert_eq!(
+        client
+            .list_deliverables("widget", Some(DeliverableStatus::Proposed))
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        client
+            .list_deliverables("widget", Some(DeliverableStatus::InProgress))
+            .await
+            .unwrap()
+            .len(),
+        0
+    );
+
+    // Legal transition proposed → in-progress.
+    let moved = client
+        .set_deliverable_status("widget", &id, DeliverableStatus::InProgress)
+        .await
+        .unwrap();
+    assert_eq!(moved.status, DeliverableStatus::InProgress);
+
+    // Illegal transition in-progress → delivered → structured 409.
+    let err = client
+        .set_deliverable_status("widget", &id, DeliverableStatus::Delivered)
+        .await
+        .expect_err("must be rejected");
+    match err {
+        SetStatusError::Rejected {
+            from,
+            to,
+            allowed_next,
+        } => {
+            assert_eq!(from, "in-progress");
+            assert_eq!(to, "delivered");
+            // in-progress → {blocked, complete} are the legal successors.
+            assert!(
+                allowed_next.contains(&"complete".to_string()),
+                "{allowed_next:?}"
+            );
+            assert!(
+                allowed_next.contains(&"blocked".to_string()),
+                "{allowed_next:?}"
+            );
+        }
+        SetStatusError::Other(e) => panic!("expected Rejected, got {e}"),
+    }
+
+    // get round-trips the updated record.
+    let fetched = client.get_deliverable("widget", &id).await.unwrap();
+    assert_eq!(fetched.status, DeliverableStatus::InProgress);
+}
+
+/// Milestone create → list → get round-trips over real HTTP.
+#[tokio::test]
+async fn milestone_crud_round_trip() {
+    let client = serve().await;
+    let created = client
+        .create_milestone(
+            "widget",
+            &CreateMilestoneArgs {
+                name: "v1.0 Alpha".into(),
+                description: Some("first alpha".into()),
+                target_date: chrono::DateTime::parse_from_rfc3339("2026-09-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.name, "v1.0 Alpha");
+
+    let id = created.id.to_string();
+    let listed = client.list_milestones("widget").await.unwrap();
+    assert_eq!(listed.len(), 1);
+
+    let got = client.get_milestone("widget", &id).await.unwrap();
+    assert_eq!(got, created);
+}

--- a/crates/trusty-mpm/tests/project_registry_routes.rs
+++ b/crates/trusty-mpm/tests/project_registry_routes.rs
@@ -25,18 +25,28 @@ use trusty_mpm::client::http_client::deliverables::{
     CreateDeliverableArgs, CreateMilestoneArgs, SetStatusError,
 };
 use trusty_mpm::client::http_client::projects::RegisterProjectArgs;
+use trusty_mpm::core::trusty_tools_config::GithubConfig;
 use trusty_mpm::daemon::{api, state::DaemonState};
 use trusty_mpm::deliverable::{DeliverableKind, DeliverableStatus, EstimationTier};
+use trusty_mpm::project::Project;
 
-/// Bind the real router on an ephemeral loopback port; return a client for it.
-async fn serve() -> DaemonClient {
+/// Bind the real router on an ephemeral loopback port; return a client plus the
+/// backing [`DaemonState`] (some tests need to seed the store directly, bypassing
+/// HTTP, to set up state the HTTP request body cannot express — e.g. the
+/// per-project `github`/commit identity binding, #2184).
+async fn serve_with_state() -> (DaemonClient, Arc<DaemonState>) {
     let root = tempfile::tempdir().unwrap().keep();
     let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
     let router = api::router(Arc::clone(&state));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(axum::serve(listener, router).into_future());
-    DaemonClient::new(format!("http://{addr}"))
+    (DaemonClient::new(format!("http://{addr}")), state)
+}
+
+/// Bind the real router on an ephemeral loopback port; return a client for it.
+async fn serve() -> DaemonClient {
+    serve_with_state().await.0
 }
 
 /// register → get → list → status round-trips over real HTTP.
@@ -112,6 +122,92 @@ async fn register_is_idempotent_upsert() {
     let out = client.registry_register_project(&updated).await.unwrap();
     assert_eq!(out.default_branch, "release");
     assert_eq!(client.registry_list_projects(None).await.unwrap().len(), 1);
+}
+
+/// The highest-risk clobber path: a project already carries a per-project
+/// `github`/commit identity binding (#2184, set out-of-band — e.g. via
+/// `seed_from_config` or a direct `registry.register` call, since the HTTP
+/// register body has no fields for them). Re-registering that SAME project
+/// through `POST /api/v1/projects` — whose body cannot express `github`/
+/// `commit_name`/`commit_email` — must NOT wipe the binding; the route
+/// preserves it by reading the existing record before building the replacement
+/// (see `register_project_registry_route`'s `existing.as_ref().and_then(...)`
+/// carry-forward).
+#[tokio::test]
+async fn register_preserves_identity_binding_not_expressible_in_body() {
+    let (client, state) = serve_with_state().await;
+
+    // Seed directly on the store (bypassing HTTP) with a full identity binding —
+    // this is state the register HTTP body has no way to set.
+    state
+        .project_registry()
+        .await
+        .register(Project {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: "main".into(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            github: Some(GithubConfig {
+                config_dir: Some("/home/bob/.config/gh-work".into()),
+                token_env: None,
+                account: None,
+                host: None,
+            }),
+            commit_name: Some("Bob".into()),
+            commit_email: Some("bob@example.com".into()),
+        })
+        .await
+        .expect("seed project with identity binding");
+
+    // Re-register the SAME project over HTTP, changing only the branch — the
+    // body cannot carry `github`/`commit_name`/`commit_email` at all.
+    let updated = client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: Some("develop".into()),
+            description: None,
+            tags: None,
+            stack_hint: None,
+            gh_user: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        updated.default_branch, "develop",
+        "the field the request DID carry must still apply"
+    );
+    assert_eq!(
+        updated.commit_name.as_deref(),
+        Some("Bob"),
+        "commit_name must survive a re-register the body cannot express it in"
+    );
+    assert_eq!(
+        updated.commit_email.as_deref(),
+        Some("bob@example.com"),
+        "commit_email must survive a re-register the body cannot express it in"
+    );
+    let github = updated
+        .github
+        .as_ref()
+        .expect("github binding must survive the re-register");
+    assert_eq!(
+        github.config_dir.as_deref(),
+        Some(std::path::Path::new("/home/bob/.config/gh-work")),
+        "github.config_dir must survive unchanged"
+    );
+
+    // The persisted record (read back independently of the register response)
+    // must show the same preserved binding — proving it is durable, not just an
+    // artifact of the immediate response body.
+    let refetched = client.registry_get_project("widget").await.unwrap();
+    assert_eq!(refetched.commit_name.as_deref(), Some("Bob"));
+    assert_eq!(refetched.commit_email.as_deref(), Some("bob@example.com"));
+    assert!(refetched.github.is_some());
 }
 
 /// Fetching an unregistered project surfaces an error (the daemon 404s).


### PR DESCRIPTION
## Summary

Implements the deterministic `tm projects` verb tree — the thin CLI half of the project control plane (epic #2108, DOC-35 §3.1/§10.8) — plus the `DaemonClient` methods it calls. Delivers **#2115** and **#2381** together in one PR (they build the same `tm projects` clap namespace; splitting would guarantee a CLI-tree collision).

### Verb tree
```
tm projects list [--json] [--tag <t>]
tm projects register <name> --repo-url <url> [--default-branch] [--description] [--tags a,b] [--stack-hint] [--gh-user]
tm projects show <name> [--json]        # config + READ-ONLY nested sessions (fleet endpoint)
tm projects status <name> [--json]      # GET /api/v1/projects/{name}/status rollup
tm projects deliverables list <project> [--json] [--status <s>]
tm projects deliverables add|create <project> --name --kind --estimate S|M|L|XL [--spec-ref] [--ticket-ref]
tm projects deliverables show <project> <id> [--json]
tm projects deliverables set-status <project> <id> <status>   # surfaces the 409 allowed_next
tm projects milestones list|add|show <project> ...
```

### #2115 — registry verbs
`list`/`register`/`show`/`status`. `show` adds a read-only nested sessions view via the fleet endpoint (mutation is pointed at `tm sessions`). Status rendering is **forward-tolerant of the additive #2382 histogram fields** (`ProjectStatusWire` has no `deny_unknown_fields`) so this CLI won't collide with the sibling histogram work.

### #2381 — deliverables/milestones subtrees
CRUD over the #2395 endpoints. `set-status` enforces nothing client-side — it relays the daemon's structured **409 `allowed_next`** into a typed `SetStatusError::Rejected` and renders the legal next states clearly. `spec_ref`/`ticket_ref` pass through as plain strings; estimation tiers `S/M/L/XL`. Milestones are `list|add|show` (no `set-status` — milestone status is a rollup, §10.5), matching §10.8 exactly.

## ⚠️ Scope note — #2114 dependency was not shipped
`tm projects list/register/show` require the registry-B HTTP surface (**#2114**: `GET/POST /api/v1/projects`, `GET /api/v1/projects/{name}`). That issue is **still OPEN** — only `/status` (#2117) and the deliverable CRUD (#2395) had shipped; registry B was otherwise reachable only via MCP tools. To deliver **working** verbs, this PR adds those three thin routes (in `daemon/managed_routes/project_registry_routes.rs`), mirroring the existing `project_list/register/get` MCP tools. `PATCH` (the `tm projects config` verb) is intentionally left for #2114/config work. **Recommend closing #2114 as delivered-here, or re-scoping it to PATCH only.**

## Naming
`tm projects` (plural) is a brand-new namespace — no collision with the existing singular `tm project` (registry A / working directories) or the `tm ls --projects` flag. Canonical plural per #2116.

## Overlap flags (per "flag, don't race")
- **feat-2382** (status histogram): will add `deliverables`/`milestones` fields to the same status endpoint + `ProjectStatusResponse`. My client is additive-tolerant, so no runtime collision; a text conflict is possible in `project_status.rs` docs only (I did not touch that file).
- **#2114**: overlaps the three registry routes added here (see scope note).
- **feat-2379** (session_manager): no overlap.

## Tests / gate (all green, raw output in the delivering report)
- CLI parse test per verb (`tests_projects.rs`, 15 tests)
- Client wire-shape + request-serialization tests + 409 body parse
- 409 `allowed_next` rendering test
- End-to-end HTTP integration test driving `DaemonClient` against the real router: register→get→list→status, the illegal-transition 409 path, milestone CRUD (`tests/project_registry_routes.rs`, 5 tests)
- `cargo build --workspace` ✓ · `cargo test -p trusty-mpm` (2722 lib + 830 bin + integration, 0 failed) ✓ · `cargo clippy --all-targets -- -D warnings` ✓ · `cargo fmt --check` ✓ · line-cap ✓

Closes #2115
Closes #2381

🤖 Generated with [Claude Code](https://claude.com/claude-code)