### PR TITLE
fix(trusty-review): render all synthesized Top Risks rows (no 3-row cap)

### DIFF
--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -309,12 +309,18 @@ fn build_scope(model: &ReportModel) -> Scope {
 /// `inferred` (live-QA wave-2 defect #1 — the marker was defined but never
 /// wired to any synthesized content).
 /// What: sets the executive-summary scalar (tagged once, section granularity)
-/// and the `risk_N_description` / `risk_N_cost` scalars (tagged per field) from
-/// the synthesis's verified top-risk rows.  `risk_N_severity` / `risk_N_apps`
-/// are left untagged — they restate categorical/identifier data (the RED/AMBER
-/// band, the affected application names) rather than narrative prose.
+/// and pushes one `top_risk_row` block per verified top-risk row — the
+/// `risk_description` / `risk_cost` prose fields are tagged per field, while
+/// `risk_severity` / `risk_apps` are left untagged (they restate
+/// categorical/identifier data — the RED/AMBER band, the affected application
+/// names — rather than narrative prose).  `risk_rank` numbers the rows
+/// sequentially (1..N).  Because the template row is a repeatable block, ALL
+/// synthesized rows render (previously the template hard-capped at 3/5 fixed
+/// placeholder rows, silently dropping any beyond the cap — #2373); with zero
+/// top risks no block is pushed and the section collapses via omit-empty.
 /// Test: `reporter_tests.rs::{reporter_injects_synthesis_prose,
-/// reporter_tags_top_risks_as_inferred}`.
+/// reporter_tags_top_risks_as_inferred, reporter_renders_all_top_risk_rows,
+/// reporter_collapses_empty_top_risks}`.
 fn inject_synthesis_summary(root: &mut Scope, syn: &super::synthesize::Synthesis) {
     if let Some(exec) = &syn.executive_summary {
         root.set(
@@ -324,17 +330,16 @@ fn inject_synthesis_summary(root: &mut Scope, syn: &super::synthesize::Synthesis
     }
 
     for (i, risk) in syn.top_risks.iter().enumerate() {
-        let n = i + 1;
-        root.set(
-            format!("risk_{n}_description"),
+        let mut row = Scope::new();
+        row.set("risk_rank", (i + 1).to_string());
+        row.set(
+            "risk_description",
             tag(risk.description.clone(), Provenance::Inferred),
         );
-        root.set(format!("risk_{n}_severity"), risk.severity.clone());
-        root.set(
-            format!("risk_{n}_cost"),
-            tag(risk.cost.clone(), Provenance::Inferred),
-        );
-        root.set(format!("risk_{n}_apps"), risk.apps.clone());
+        row.set("risk_severity", risk.severity.clone());
+        row.set("risk_cost", tag(risk.cost.clone(), Provenance::Inferred));
+        row.set("risk_apps", risk.apps.clone());
+        root.push_block("top_risk_row", row);
     }
 }
 

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -1197,6 +1197,101 @@ fn reporter_tags_top_risks_as_inferred() {
     assert!(md.matches(inferred).count() >= 3);
 }
 
+/// Why: #2373 — the Top Risks table hard-capped at 3 fixed placeholder rows, so
+/// synthesized rows 4-5 were silently dropped even though the JSON twin carried
+/// them and the synthesis schema caps `top_risks` at 5. The repeatable
+/// `top_risk_row` block must render EVERY synthesized row, in order, with
+/// sequential 1..N ranks and the `⁽ⁱ⁾` provenance tag intact on the prose cells.
+/// What: attaches a `Synthesis` carrying the full 5 top-risk rows and asserts all
+/// five descriptions render (rows 4 and 5 explicitly), the ranks number 1..5, and
+/// the inferred marker survives on the synthesized prose.
+/// Test: this test itself.
+#[test]
+fn reporter_renders_all_top_risk_rows() {
+    use crate::report::synthesize::{RiskRow, Synthesis, SynthesisStatus};
+
+    let risk = |n: usize| RiskRow {
+        description: format!("Risk number {n} description"),
+        severity: "RED".to_string(),
+        cost: format!("cost-{n}"),
+        apps: format!("App {n}"),
+    };
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model(tmp.path());
+    model.synthesis = Some(Synthesis {
+        status: SynthesisStatus::Available,
+        executive_summary: Some("Summary.".to_string()),
+        top_risks: (1..=5).map(risk).collect(),
+        findings: vec![],
+        notes: vec![],
+    });
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    // All five rows render — rows 4 and 5 were the ones previously dropped.
+    for n in 1..=5 {
+        assert!(
+            md.contains(&format!("Risk number {n} description")),
+            "row {n} missing from rendered markdown"
+        );
+    }
+    // Ranks number sequentially 1..5 within the Top Risks table rows.
+    for n in 1..=5 {
+        assert!(
+            md.contains(&format!("| {n} | Risk number {n} description")),
+            "row {n} not ranked sequentially"
+        );
+    }
+    // The ⁽ⁱ⁾ provenance tag survives on the synthesized prose cells.
+    let inferred = crate::report::provenance::INFERRED_TAG.trim();
+    assert!(md.contains(inferred));
+    // description + cost per row (5 rows) plus the exec summary → >= 11 markers.
+    assert!(
+        md.matches(inferred).count() >= 11,
+        "expected >=11 inferred tags across 5 risk rows, got {}",
+        md.matches(inferred).count()
+    );
+}
+
+/// Why: #2373 omit-empty — with zero synthesized top risks (deterministic-only
+/// run, or synthesis absent), no `top_risk_row` block is pushed, so the table
+/// must collapse per the existing rules rather than leaving an empty header +
+/// separator skeleton behind.
+/// What: renders a model whose synthesis carries no top risks and asserts the
+/// Top Risks table header row is absent from the polished markdown (the section
+/// collapsed) while no raw placeholder leaks through.
+/// Test: this test itself.
+#[test]
+fn reporter_collapses_empty_top_risks() {
+    use crate::report::synthesize::{Synthesis, SynthesisStatus};
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model(tmp.path());
+    model.synthesis = Some(Synthesis {
+        status: SynthesisStatus::Available,
+        executive_summary: Some("Summary.".to_string()),
+        top_risks: vec![],
+        findings: vec![],
+        notes: vec![],
+    });
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    // No empty table skeleton: the Top Risks header row is collapsed away.
+    assert!(
+        !md.contains("| # | Risk | Severity | Est. cost/effort |"),
+        "empty Top Risks table skeleton should have collapsed"
+    );
+    // The unfilled per-row placeholders never leak as literal text.
+    assert!(!md.contains("{{risk_description}}"));
+    assert!(!md.contains("{{risk_rank}}"));
+}
+
 /// Why: live-QA wave-2 defect #5 — the per-language LoC breakdown was computed
 /// (both by the scanner and from an external metrics file) but only language
 /// NAMES reached the rendered Profile table; the actual split (the useful

--- a/crates/trusty-review/templates/report-technical-dd-cast.md
+++ b/crates/trusty-review/templates/report-technical-dd-cast.md
@@ -91,12 +91,8 @@ in the coverage data provided — and name it specifically.
 ### Top Risks
 
 | # | Risk | Severity | Est. cost/effort | Affected application(s) |
-|---|---|---|---|---|
-| 1 | {{risk_1_description}} | {{risk_1_severity}} | {{risk_1_cost}} | {{risk_1_apps}} |
-| 2 | {{risk_2_description}} | {{risk_2_severity}} | {{risk_2_cost}} | {{risk_2_apps}} |
-| 3 | {{risk_3_description}} | {{risk_3_severity}} | {{risk_3_cost}} | {{risk_3_apps}} |
-| 4 | {{risk_4_description}} | {{risk_4_severity}} | {{risk_4_cost}} | {{risk_4_apps}} |
-| 5 | {{risk_5_description}} | {{risk_5_severity}} | {{risk_5_cost}} | {{risk_5_apps}} |
+|---|---|---|---|---|<!-- BEGIN top_risk_row -->
+| {{risk_rank}} | {{risk_description}} | {{risk_severity}} | {{risk_cost}} | {{risk_apps}} |<!-- END top_risk_row -->
 
 ## 3. CAST Scoring Model & Normalization
 

--- a/crates/trusty-review/templates/report-technical-dd.md
+++ b/crates/trusty-review/templates/report-technical-dd.md
@@ -82,11 +82,8 @@
 ### Top Risks
 
 | # | Risk | Severity | Est. cost/effort | Affected application(s) |
-|---|---|---|---|---|
-| 1 | {{risk_1_description}} | {{risk_1_severity}} | {{risk_1_cost}} | {{risk_1_apps}} |
-| 2 | {{risk_2_description}} | {{risk_2_severity}} | {{risk_2_cost}} | {{risk_2_apps}} |
-| 3 | {{risk_3_description}} | {{risk_3_severity}} | {{risk_3_cost}} | {{risk_3_apps}} |
-<!-- extend to 4-5 rows if the source supports it; do not pad with filler -->
+|---|---|---|---|---|<!-- BEGIN top_risk_row -->
+| {{risk_rank}} | {{risk_description}} | {{risk_severity}} | {{risk_cost}} | {{risk_apps}} |<!-- END top_risk_row -->
 
 ## 3. Scoring Model Normalization
 


### PR DESCRIPTION
fixes #2373 — the Top Risks table in both bundled templates hardcoded a fixed number of risk rows (3 generic / 5 CAST) so synthesized rows beyond the cap were silently dropped despite being in the JSON twin and within the schema's 5-row max. Fix converts the table body to a repeatable BEGIN/END block (same pattern as findings/benchmark rows), rendering one row per synthesized risk with sequential numbering and ⁽ⁱ⁾ provenance tags; empty case collapses via omit-empty. Gates: trusty-review 1321 tests 0 failed; workspace 0 failed; crate+workspace clippy exit 0; fmt clean; line-cap 0 violations; new tests assert 5-row rendering (rows 4&5 present) and empty-collapse.

Closes #2373

🤖 Generated with [Claude Code](https://claude.com/claude-code)