### PR TITLE
fix(trusty-code): turn-recorder writes via tools/call envelope + ensure-palace (closes #2424)

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -186,7 +186,6 @@ crates/trusty-code/src/run_task/mod.rs	resolve_agent_model_slug_honours_override
 crates/trusty-code/src/run_task/recorder.rs	recorder_flags_ran_test_command_on_matching_bash_call
 crates/trusty-code/src/runner/in_process.rs	with_timeout_secs_overrides_only_timeout
 crates/trusty-code/src/serve/http.rs	http_session_events_sse_streams_replay_then_live_event
-crates/trusty-code/src/session/memory_sink.rs	write_turn_passes_force_true_for_memory_remember
 crates/trusty-code/src/session/registry.rs	cancel_is_idempotent_on_terminal_session
 crates/trusty-code/src/session/registry.rs	detach_stops_the_forwarder
 crates/trusty-code/src/session/registry.rs	get_transcript_returns_stored_record

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -299,6 +299,19 @@ pub mod verify_gate;
 /// Test: `catchup::tests::pm_catchup_context_does_not_panic_on_empty_repo`.
 pub mod catchup;
 
+/// Shared trusty-memory `tools/call` envelope helpers (#2424).
+///
+/// Why: trusty-memory direct-dispatches only its `TOOL_METHODS` allowlist —
+/// every `chat_*` tool is reachable ONLY via the MCP `tools/call` envelope,
+/// which the #2343 soak found the turn recorder was not using (100% of
+/// durable writes failed `-32601`). One shared implementation of the
+/// envelope build/unwrap keeps the write side (`session::memory_sink`) and
+/// the read side (`tools::recall_session`) on the same verified shape.
+/// What: `tools_call_params`, `parse_tools_call_envelope`,
+/// `call_tool_wrapped`.
+/// Test: `memory_envelope::tests::*`.
+pub mod memory_envelope;
+
 /// System-prompt assembly layer implementing the parity spec.
 ///
 /// Why: The cross-model comparison harness must assemble the same fixed

--- a/crates/trusty-code/src/memory_envelope.rs
+++ b/crates/trusty-code/src/memory_envelope.rs
@@ -1,0 +1,177 @@
+//! Shared trusty-memory `tools/call` envelope helpers (#2424).
+//!
+//! Why: trusty-memory's JSON-RPC surface direct-dispatches only the methods
+//! in its `TOOL_METHODS` allowlist (`crates/trusty-memory/src/transport/
+//! rpc.rs`); everything else — notably every `chat_*` tool — is reachable
+//! ONLY via the MCP-style `tools/call` envelope. The #2343 soak
+//! (2026-07-11) found `memory_sink::write_turn`'s direct-method dispatch of
+//! `chat_turn_append` failing `-32601 Method not found` on 100% of turns
+//! (#2424), while #2348's `recall_session` — which already used the
+//! `tools/call` envelope — worked. This module is the SINGLE shared
+//! implementation of that spike-verified envelope shape (build the
+//! `{"name", "arguments"}` params; unwrap the STRINGIFIED JSON blob the
+//! daemon returns inside `result.content[0].text`) so the write side
+//! (`session::memory_sink`) and the read side (`tools::recall_session`) can
+//! never drift apart again.
+//! What: [`tools_call_params`] builds the request params;
+//! [`parse_tools_call_envelope`] unwraps a response envelope;
+//! [`call_tool_wrapped`] composes both around
+//! `trusty_common::mcp::memory_rpc::call_memory_tool_at` for callers that
+//! want a one-shot "call this tool, give me its parsed result" helper.
+//! Test: `memory_envelope::tests::*`.
+
+use anyhow::{Context, anyhow};
+use serde_json::{Value, json};
+use trusty_common::mcp::memory_rpc::call_memory_tool_at;
+
+/// Build the `params` object for a JSON-RPC `tools/call` request.
+///
+/// Why: keeps the MCP `{"name": <tool>, "arguments": <args>}` convention in
+/// exactly one place — a typo'd key here (e.g. `"args"`) would silently
+/// break every trusty-memory write, which is precisely the failure class
+/// #2424 is about.
+/// What: wraps `tool` and `arguments` into the MCP `tools/call` params
+/// shape trusty-memory's dispatcher expects.
+/// Test: `tests::tools_call_params_shape`.
+pub fn tools_call_params(tool: &str, arguments: Value) -> Value {
+    json!({
+        "name": tool,
+        "arguments": arguments,
+    })
+}
+
+/// Extract and parse the inner tool-result JSON from a `tools/call`
+/// response envelope.
+///
+/// Why: isolates the spike-verified unwrap (issue #2348: the daemon returns
+/// the tool result as a STRINGIFIED JSON blob inside
+/// `result.content[0].text`, not a nested `Value`) as one shared, testable
+/// step. Previously private to `tools::recall_session`
+/// (`parse_recall_envelope`); promoted here so `session::memory_sink` can
+/// reuse it (#2424).
+/// What: `envelope` is the raw `result` field of the JSON-RPC response
+/// (i.e. `call_memory_tool_at`'s `Ok` payload for a `tools/call` request).
+/// Returns `Some(parsed_body)` on a well-formed envelope, `None` otherwise
+/// (never panics on an unexpected shape).
+/// Test: `tests::parse_tools_call_envelope_unwraps_stringified_content`,
+/// `tests::parse_tools_call_envelope_none_on_missing_content`,
+/// `tests::parse_tools_call_envelope_none_on_malformed_inner_json`.
+pub fn parse_tools_call_envelope(envelope: &Value) -> Option<Value> {
+    let text = envelope
+        .get("content")
+        .and_then(|c| c.get(0))
+        .and_then(|c0| c0.get("text"))
+        .and_then(|t| t.as_str())?;
+    serde_json::from_str(text).ok()
+}
+
+/// Call one trusty-memory tool through the `tools/call` envelope and return
+/// its parsed inner result.
+///
+/// Why: the one-shot composition the turn recorder's dual-write needs —
+/// after #2424 every `memory_sink` write goes through this so the parsed
+/// result it inspects (e.g. `memory_remember`'s `"status":"skipped"`
+/// detection, #2363) has the SAME shape it had under the old direct
+/// dispatch, keeping the caller's success/skipped logic unchanged.
+/// What: builds the params via [`tools_call_params`], POSTs via
+/// `call_memory_tool_at(base_url, "tools/call", ..)`, and unwraps the
+/// response via [`parse_tools_call_envelope`]. A JSON-RPC error (the shape
+/// trusty-memory returns when the inner tool itself fails — its dispatcher
+/// converts tool errors via `JsonRpcResponse::from_anyhow`) surfaces as
+/// `Err` from `call_memory_tool_at`; an unparseable envelope surfaces as
+/// its own `Err` so fail-open callers can warn on it distinctly.
+/// Test: `tests::call_tool_wrapped_round_trips_against_mock`,
+/// `tests::call_tool_wrapped_errs_on_malformed_envelope`; exercised
+/// end-to-end by `session::memory_sink::tests::*` and
+/// `tools::recall_session::tests::*`.
+pub async fn call_tool_wrapped(
+    base_url: &str,
+    tool: &str,
+    arguments: Value,
+) -> anyhow::Result<Value> {
+    let envelope = call_memory_tool_at(base_url, "tools/call", tools_call_params(tool, arguments))
+        .await
+        .with_context(|| format!("tools/call '{tool}'"))?;
+    parse_tools_call_envelope(&envelope).ok_or_else(|| {
+        anyhow!("unexpected tools/call envelope shape from trusty-memory for '{tool}'")
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use axum::routing::post;
+    use axum::{Json, Router};
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    #[test]
+    fn tools_call_params_shape() {
+        let params = tools_call_params("memory_recall", json!({"palace": "p", "query": "q"}));
+        assert_eq!(params["name"], "memory_recall");
+        assert_eq!(params["arguments"]["palace"], "p");
+        assert_eq!(params["arguments"]["query"], "q");
+    }
+
+    #[test]
+    fn parse_tools_call_envelope_unwraps_stringified_content() {
+        let inner = json!({"palace": "p", "results": [{"content": "hello"}]}).to_string();
+        let envelope = json!({"content": [{"type": "text", "text": inner}]});
+        let body = parse_tools_call_envelope(&envelope).expect("should parse");
+        assert_eq!(body["palace"], "p");
+        assert_eq!(body["results"][0]["content"], "hello");
+    }
+
+    #[test]
+    fn parse_tools_call_envelope_none_on_missing_content() {
+        assert!(parse_tools_call_envelope(&json!({"not_content": []})).is_none());
+    }
+
+    #[test]
+    fn parse_tools_call_envelope_none_on_malformed_inner_json() {
+        let envelope = json!({"content": [{"type": "text", "text": "not valid json"}]});
+        assert!(parse_tools_call_envelope(&envelope).is_none());
+    }
+
+    /// Spin up a one-route mock `/rpc` server replying with `reply` wrapped
+    /// (or not) per the closure, and return its base URL.
+    async fn spawn_mock(result: Value) -> String {
+        async fn handle(
+            axum::extract::State(result): axum::extract::State<Value>,
+            Json(_body): Json<Value>,
+        ) -> Json<Value> {
+            Json(json!({"jsonrpc": "2.0", "id": 1, "result": result}))
+        }
+        let app = Router::new()
+            .route("/rpc", post(handle))
+            .with_state(result);
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn call_tool_wrapped_round_trips_against_mock() {
+        let inner = json!({"status": "stored", "drawer_id": "d1"}).to_string();
+        let base_url = spawn_mock(json!({"content": [{"type": "text", "text": inner}]})).await;
+        let result = call_tool_wrapped(&base_url, "memory_remember", json!({"palace": "p"}))
+            .await
+            .expect("wrapped call should succeed");
+        assert_eq!(result["status"], "stored");
+        assert_eq!(result["drawer_id"], "d1");
+    }
+
+    #[tokio::test]
+    async fn call_tool_wrapped_errs_on_malformed_envelope() {
+        let base_url = spawn_mock(json!({"content": [{"type": "text", "text": "not json"}]})).await;
+        let err = call_tool_wrapped(&base_url, "memory_remember", json!({"palace": "p"}))
+            .await
+            .expect_err("malformed envelope must surface as Err");
+        assert!(err.to_string().contains("unexpected tools/call envelope"));
+    }
+}

--- a/crates/trusty-code/src/memory_envelope.rs
+++ b/crates/trusty-code/src/memory_envelope.rs
@@ -144,9 +144,7 @@ mod tests {
         ) -> Json<Value> {
             Json(json!({"jsonrpc": "2.0", "id": 1, "result": result}))
         }
-        let app = Router::new()
-            .route("/rpc", post(handle))
-            .with_state(result);
+        let app = Router::new().route("/rpc", post(handle)).with_state(result);
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
         let addr = listener.local_addr().expect("addr");
         tokio::spawn(async move {

--- a/crates/trusty-code/src/session/memory_sink.rs
+++ b/crates/trusty-code/src/session/memory_sink.rs
@@ -14,10 +14,18 @@
 //! boundary. The drain task calls BOTH `chat_turn_append` (the exact
 //! chronological record) and `memory_remember` (tagged
 //! `["session:<id>", "turn"]`, `force: true` — the semantic recall surface
-//! for #2348) via `trusty_common::mcp::memory_rpc::call_memory_tool_at`,
-//! against a base URL resolved ONCE at construction — never blocking or
-//! failing the calling turn: any RPC failure is logged via `tracing::warn!`
-//! and dropped. (#2363) `memory_remember`'s dedup gate (jaro_winkler >0.92,
+//! for #2348) via the MCP `tools/call` envelope
+//! (`crate::memory_envelope::call_tool_wrapped`; #2424 — trusty-memory's
+//! direct-dispatch allowlist has no `chat_*` methods, so direct dispatch of
+//! `chat_turn_append` fails `-32601` on every write), against a base URL
+//! resolved ONCE at construction — never blocking or failing the calling
+//! turn: any RPC failure is logged via `tracing::warn!` and dropped.
+//! (#2424) Before the FIRST write, the drain task ensures the target palace
+//! exists ([`ensure_palace`]) — `memory_remember` does NOT auto-create a
+//! palace and fails `-32603 "palace metadata missing"` against a missing
+//! one, which is exactly how the #2343 soak lost all 50 turns. The ensure
+//! result is cached on success so steady state adds zero extra RPCs.
+//! (#2363) `memory_remember`'s dedup gate (jaro_winkler >0.92,
 //! 5-min same-palace window) is documented as hostile to sequential
 //! conversational turns, so every turn-recorder write passes `force: true`
 //! to bypass it outright, along with the other content-QUALITY gates
@@ -43,8 +51,9 @@ use std::path::Path;
 
 use serde_json::json;
 use tokio::sync::mpsc;
-use tracing::warn;
-use trusty_common::mcp::memory_rpc::call_memory_tool_at;
+use tracing::{info, warn};
+
+use crate::memory_envelope::call_tool_wrapped;
 
 /// Bounded mpsc queue capacity (#2345 scope: "~50").
 ///
@@ -180,10 +189,74 @@ impl TurnMemorySink {
 }
 
 /// Background drain loop: pop turns off the channel and dual-write each one,
-/// fail-open (see [`write_turn`]).
+/// fail-open (see [`write_turn`]), ensuring the target palace exists before
+/// the first write (#2424).
+///
+/// Why: the ensure lives HERE (drain-task-local state) rather than on the
+/// sink struct so it needs no locking — the drain task is the only writer —
+/// and so a failed ensure is naturally retried on the next turn (the flag is
+/// only set on success), covering a daemon that comes up mid-session.
+/// What: on success `palace_ensured` latches true and steady state adds
+/// zero extra RPCs per turn; on failure the turn's writes are still
+/// attempted (fail-open — they carry their own warnings).
+/// Test: `memory_sink::tests::ensure_palace_creates_missing_palace_once`,
+/// `memory_sink::tests::ensure_palace_skips_create_when_palace_exists`.
 async fn drain(base_url: String, palace: String, mut rx: mpsc::Receiver<QueuedTurn>) {
+    let mut palace_ensured = false;
     while let Some(turn) = rx.recv().await {
+        if !palace_ensured {
+            palace_ensured = ensure_palace(&base_url, &palace).await;
+        }
         write_turn(&base_url, &palace, &turn).await;
+    }
+}
+
+/// Ensure `palace` exists on the target daemon, creating it if missing
+/// (#2424). Returns `true` when the palace is known to exist afterwards.
+///
+/// Why: `memory_remember` does NOT auto-create its palace — against a
+/// missing one it fails `-32603 "palace metadata missing"`, which silently
+/// killed the semantic half of every soak write. Probe-then-create (rather
+/// than unconditional `palace_create`) because trusty-memory's
+/// `handle_palace_create` OVERWRITES `palace.json` for an existing palace
+/// (resetting `created_at`/`description`) — an existing project palace
+/// shared with the PM catch-up digest must not have its metadata clobbered
+/// on every session start.
+/// What: `palace_info` via `tools/call`; on error (the daemon's signal for
+/// "metadata missing" — or any other failure, in which case the create
+/// simply fails too and we stay fail-open), `palace_create` with
+/// `force: true` (the spec-001 documented bypass for app-managed palaces
+/// whose slug does not match the DAEMON's cwd-derived project slug; a no-op
+/// authz gate in default single-tenant mode) via `tools/call`. Never
+/// propagates an error — failure is logged and reported as `false` so the
+/// caller retries on the next turn.
+/// Test: `memory_sink::tests::ensure_palace_creates_missing_palace_once`,
+/// `memory_sink::tests::ensure_palace_skips_create_when_palace_exists`.
+async fn ensure_palace(base_url: &str, palace: &str) -> bool {
+    if call_tool_wrapped(base_url, "palace_info", json!({"palace": palace}))
+        .await
+        .is_ok()
+    {
+        return true;
+    }
+    let create_params = json!({
+        "name": palace,
+        "force": true,
+        "description": "trusty-code session turn history (auto-created by the turn recorder)",
+    });
+    match call_tool_wrapped(base_url, "palace_create", create_params).await {
+        Ok(_) => {
+            info!(palace = %palace, "turn_recorder: created missing palace (#2424)");
+            true
+        }
+        Err(e) => {
+            warn!(
+                palace = %palace,
+                error = %e,
+                "turn_recorder: palace ensure failed (fail-open, will retry next turn)"
+            );
+            false
+        }
     }
 }
 
@@ -193,18 +266,27 @@ async fn drain(base_url: String, palace: String, mut rx: mpsc::Receiver<QueuedTu
 /// Why: the exact and semantic representations are independent trusty-memory
 /// endpoints; a mid-outage failure of one must not block the other, so each
 /// call's error is handled separately rather than short-circuiting on the
-/// first failure. (#2363) `memory_remember` passes `force: true` because
+/// first failure. (#2424) BOTH calls go through the MCP `tools/call`
+/// envelope (`call_tool_wrapped`) — trusty-memory's direct-dispatch
+/// allowlist (`TOOL_METHODS`) has no `chat_*` entries, so the previous
+/// direct-method dispatch of `chat_turn_append` failed `-32601 Method not
+/// found` on 100% of writes; `memory_remember` IS direct-dispatchable but
+/// uses the same envelope anyway so both halves share one verified shape.
+/// (#2363) `memory_remember` passes `force: true` because
 /// its dedup gate (jaro_winkler >0.92, same-palace, 5-min window) is
 /// documented as hostile to sequential conversational turns — near-duplicate
 /// consecutive turns are the NORMAL case here, not noise; `force: true` also
 /// bypasses the other content-QUALITY gates (blocklist, short-content, noise
 /// pattern). Issue #2520: `force` does NOT bypass secret/credential
 /// detection — a turn whose content looks secret-shaped comes back as an
-/// `Err` from `call_memory_tool_at` (not a `"skipped"` status) and is logged
+/// `Err` from `call_tool_wrapped` (not a `"skipped"` status) and is logged
 /// via the fail-open `Err(e)` arm below, same as any other RPC failure. A
-/// `"status": "skipped"` response (from a quality gate that some OTHER path
-/// still applies) is still checked and warned on so a silently thinned
-/// recall surface is at least observable in logs.
+/// `"status": "skipped"` response (from a gate `force` does NOT bypass, e.g.
+/// a quality/blocklist gate that some OTHER path still applies) is still
+/// checked and warned on so a silently thinned recall surface is at least
+/// observable in logs — (#2424) `call_tool_wrapped` returns the PARSED inner
+/// tool result, so the skipped detection sees the same shape it did under
+/// direct dispatch.
 /// What: never propagates an error — every failure is logged via
 /// `tracing::warn!` and swallowed, matching
 /// `resolve_memory_base_url_or_unreachable`'s fail-open contract (mirrored
@@ -212,7 +294,6 @@ async fn drain(base_url: String, palace: String, mut rx: mpsc::Receiver<QueuedTu
 /// caller of [`TurnMemorySink::new`]).
 /// Test: `memory_sink::tests::enqueue_drain_happy_path`,
 /// `memory_sink::tests::write_turn_is_fail_open_on_unreachable_daemon`,
-/// `memory_sink::tests::write_turn_passes_force_true_for_memory_remember`,
 /// `memory_sink::tests::write_turn_warns_on_skipped_status`.
 async fn write_turn(base_url: &str, palace: &str, turn: &QueuedTurn) {
     let append_params = json!({
@@ -221,7 +302,7 @@ async fn write_turn(base_url: &str, palace: &str, turn: &QueuedTurn) {
         "prompt": turn.prompt,
         "response": turn.response,
     });
-    if let Err(e) = call_memory_tool_at(base_url, "chat_turn_append", append_params).await {
+    if let Err(e) = call_tool_wrapped(base_url, "chat_turn_append", append_params).await {
         warn!(
             session_id = %turn.session_id,
             error = %e,
@@ -235,7 +316,7 @@ async fn write_turn(base_url: &str, palace: &str, turn: &QueuedTurn) {
         "tags": [format!("session:{}", turn.session_id), "turn"],
         "force": true,
     });
-    match call_memory_tool_at(base_url, "memory_remember", remember_params).await {
+    match call_tool_wrapped(base_url, "memory_remember", remember_params).await {
         Ok(result) => {
             if result.get("status").and_then(|v| v.as_str()) == Some("skipped") {
                 let reason = result

--- a/crates/trusty-code/src/session/memory_sink_tests.rs
+++ b/crates/trusty-code/src/session/memory_sink_tests.rs
@@ -1,19 +1,26 @@
 //! Unit tests for [`super::TurnMemorySink`] and
-//! [`super::derive_palace_id_for_project`] (#2345).
+//! [`super::derive_palace_id_for_project`] (#2345, #2424).
 //!
 //! Why: the turn recorder must never block/fail a running turn even when
 //! trusty-memory is unreachable, must dual-write both `chat_turn_append` and
-//! `memory_remember` with the documented params/tags against a live mock
-//! daemon, and must apply its documented "drop newest" overflow policy —
+//! `memory_remember` — via the MCP `tools/call` envelope, the ONLY dispatch
+//! shape trusty-memory accepts for `chat_*` tools (#2424; the previous
+//! direct-method dispatch failed `-32601` on 100% of writes in the #2343
+//! soak) — with the documented params/tags against a live mock daemon, must
+//! ensure the target palace exists exactly once before the first write
+//! (#2424), and must apply its documented "drop newest" overflow policy —
 //! none of that is exercised anywhere else.
-//! What: `enqueue_drain_happy_path` spins up a tiny in-process axum mock
-//! `/rpc` server (mirrors `trusty_common::mcp::memory_rpc`'s own test
-//! pattern) and asserts both calls land with the right shape;
-//! `enqueue_drops_newest_when_queue_full` exercises the overflow policy
-//! directly against the raw channel (no networking, fully deterministic);
-//! `write_turn_is_fail_open_on_unreachable_daemon` proves an unreachable
-//! `base_url` never panics or hangs; `derive_palace_id_for_project_*` cover
-//! the palace-derivation fallback chain.
+//! What: the mock `/rpc` servers here reply with the REAL daemon's
+//! `tools/call` response shape (the tool result STRINGIFIED inside
+//! `result.content[0].text` — mirrors `transport/rpc.rs`'s `tools/call`
+//! arm), so the assertions cover both the request envelope
+//! (`method == "tools/call"`, `params.name`/`params.arguments`) and the
+//! response unwrap. `enqueue_drops_newest_when_queue_full` exercises the
+//! overflow policy directly against the raw channel (no networking, fully
+//! deterministic); `write_turn_is_fail_open_on_unreachable_daemon` proves an
+//! unreachable `base_url` never panics or hangs;
+//! `derive_palace_id_for_project_*` cover the palace-derivation fallback
+//! chain.
 //! Test: this file.
 
 use std::sync::{Arc, Mutex};
@@ -32,30 +39,75 @@ use super::*;
 /// One captured `/rpc` call: the JSON-RPC `method` and its `params`.
 type Captured = Arc<Mutex<Vec<(String, Value)>>>;
 
+/// Wrap `inner` as the real daemon's `tools/call` response envelope: the
+/// tool result STRINGIFIED inside `content[0].text` (mirrors the
+/// `transport/rpc.rs` `tools/call` arm).
+fn wrapped_result(inner: &Value) -> Value {
+    json!({"content": [{"type": "text", "text": inner.to_string()}]})
+}
+
+/// Extract the tool name from a captured `tools/call` params object.
+fn tool_name(params: &Value) -> &str {
+    params["name"].as_str().unwrap_or_default()
+}
+
+/// Shared mock behaviour: whether `palace_info` should report the palace as
+/// already existing.
+#[derive(Clone, Copy)]
+enum PalaceState {
+    Exists,
+    MissingUntilCreated,
+}
+
 /// Spin up a tiny in-process `/rpc` mock that captures every request and
-/// always replies with a successful JSON-RPC envelope.
+/// replies with the daemon's real `tools/call` envelope shape.
 ///
 /// Why: `TurnMemorySink`'s drain task must be observed making REAL HTTP
-/// calls with the correct method/params shape — a mock server is the only
-/// way to assert that without a live trusty-memory daemon.
+/// calls with the correct `tools/call` method/params shape (#2424) — a mock
+/// server is the only way to assert that without a live trusty-memory
+/// daemon.
 /// What: binds an ephemeral port, spawns `axum::serve` detached (the test
 /// process exits with it), and returns the base URL plus the shared capture
-/// buffer.
-async fn spawn_capturing_mock() -> (String, Captured) {
+/// buffer. `palace_state` controls the `palace_info` reply: `Exists` always
+/// succeeds; `MissingUntilCreated` returns a JSON-RPC error (the daemon's
+/// "palace metadata missing" signal) until a `palace_create` lands, after
+/// which it succeeds — a stateful stand-in for the real registry.
+async fn spawn_capturing_mock(palace_state: PalaceState) -> (String, Captured) {
     let captured: Captured = Arc::new(Mutex::new(Vec::new()));
     let store = Arc::clone(&captured);
+    let created = Arc::new(Mutex::new(matches!(palace_state, PalaceState::Exists)));
 
-    async fn handle(State(store): State<Captured>, Json(body): Json<Value>) -> Json<Value> {
+    async fn handle(
+        State((store, created)): State<(Captured, Arc<Mutex<bool>>)>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
         let method = body["method"].as_str().unwrap_or_default().to_string();
         let params = body["params"].clone();
         store
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .push((method, params));
-        Json(json!({"jsonrpc": "2.0", "id": 1, "result": {"ok": true}}))
+            .push((method, params.clone()));
+        let name = tool_name(&params);
+        if name == "palace_create" {
+            *created.lock().unwrap_or_else(|e| e.into_inner()) = true;
+        }
+        if name == "palace_info" && !*created.lock().unwrap_or_else(|e| e.into_inner()) {
+            return Json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32603, "message": "palace metadata missing"}
+            }));
+        }
+        Json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": wrapped_result(&json!({"ok": true}))
+        }))
     }
 
-    let app = Router::new().route("/rpc", post(handle)).with_state(store);
+    let app = Router::new()
+        .route("/rpc", post(handle))
+        .with_state((store, created));
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
     let addr = listener.local_addr().expect("addr");
     tokio::spawn(async move {
@@ -79,33 +131,44 @@ async fn wait_for_captures(captured: &Captured, n: usize, timeout: Duration) {
 
 /// Enqueuing one turn against a live mock daemon must land BOTH
 /// `chat_turn_append` (exact record) and `memory_remember` (semantic recall
-/// surface, tagged `session:<id>` + `turn`) with the documented params.
+/// surface, tagged `session:<id>` + `turn`) — each as a `tools/call`
+/// envelope (#2424) with the documented inner arguments.
 #[tokio::test]
 async fn enqueue_drain_happy_path() {
-    let (base_url, captured) = spawn_capturing_mock().await;
+    let (base_url, captured) = spawn_capturing_mock(PalaceState::Exists).await;
     let sink = TurnMemorySink::new(base_url, "test-palace".to_string());
 
     sink.enqueue("sess-1", "what is 2+2?", "4");
-    wait_for_captures(&captured, 2, Duration::from_secs(2)).await;
+    // 3 calls: palace_info (ensure, #2424) + the two dual-write calls.
+    wait_for_captures(&captured, 3, Duration::from_secs(2)).await;
 
     let calls = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
-    assert_eq!(calls.len(), 2, "expected both dual-write calls to land");
+    assert_eq!(calls.len(), 3, "expected ensure + both dual-write calls");
+    for (method, _) in &calls {
+        assert_eq!(
+            method, "tools/call",
+            "#2424: every write must use the tools/call envelope — \
+             direct dispatch of chat_* methods is -32601"
+        );
+    }
 
     let append = calls
         .iter()
-        .find(|(m, _)| m == "chat_turn_append")
+        .find(|(_, p)| tool_name(p) == "chat_turn_append")
         .expect("chat_turn_append call");
-    assert_eq!(append.1["palace"], "test-palace");
-    assert_eq!(append.1["session_id"], "sess-1");
-    assert_eq!(append.1["prompt"], "what is 2+2?");
-    assert_eq!(append.1["response"], "4");
+    let args = &append.1["arguments"];
+    assert_eq!(args["palace"], "test-palace");
+    assert_eq!(args["session_id"], "sess-1");
+    assert_eq!(args["prompt"], "what is 2+2?");
+    assert_eq!(args["response"], "4");
 
     let remember = calls
         .iter()
-        .find(|(m, _)| m == "memory_remember")
+        .find(|(_, p)| tool_name(p) == "memory_remember")
         .expect("memory_remember call");
-    assert_eq!(remember.1["palace"], "test-palace");
-    let tags: Vec<String> = remember.1["tags"]
+    let args = &remember.1["arguments"];
+    assert_eq!(args["palace"], "test-palace");
+    let tags: Vec<String> = args["tags"]
         .as_array()
         .expect("tags array")
         .iter()
@@ -114,7 +177,7 @@ async fn enqueue_drain_happy_path() {
     assert!(tags.contains(&"session:sess-1".to_string()));
     assert!(tags.contains(&"turn".to_string()));
     assert!(
-        remember.1["text"]
+        args["text"]
             .as_str()
             .unwrap_or_default()
             .contains("what is 2+2?")
@@ -122,7 +185,76 @@ async fn enqueue_drain_happy_path() {
     // #2363: every turn-recorder `memory_remember` write must pass
     // `force: true` to bypass the dedup gate documented as hostile to
     // sequential conversational turns.
-    assert_eq!(remember.1["force"], json!(true));
+    assert_eq!(args["force"], json!(true));
+}
+
+/// (#2424) A missing palace must be created via `palace_create`
+/// (`force: true` — the spec-001 app-managed-palace bypass) exactly ONCE;
+/// later turns must reuse the cached ensure and add zero extra RPCs.
+#[tokio::test]
+async fn ensure_palace_creates_missing_palace_once() {
+    let (base_url, captured) = spawn_capturing_mock(PalaceState::MissingUntilCreated).await;
+    let sink = TurnMemorySink::new(base_url, "test-palace".to_string());
+
+    sink.enqueue("sess-1", "p1", "r1");
+    sink.enqueue("sess-1", "p2", "r2");
+    // 6 calls: (palace_info + palace_create) once, then 2 writes per turn.
+    wait_for_captures(&captured, 6, Duration::from_secs(2)).await;
+
+    let calls = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let names: Vec<&str> = calls.iter().map(|(_, p)| tool_name(p)).collect();
+    assert_eq!(
+        names,
+        vec![
+            "palace_info",
+            "palace_create",
+            "chat_turn_append",
+            "memory_remember",
+            "chat_turn_append",
+            "memory_remember",
+        ],
+        "ensure must run (probe + create) exactly once, before the first write"
+    );
+
+    let create = calls
+        .iter()
+        .find(|(_, p)| tool_name(p) == "palace_create")
+        .expect("palace_create call");
+    assert_eq!(create.1["arguments"]["name"], "test-palace");
+    assert_eq!(
+        create.1["arguments"]["force"],
+        json!(true),
+        "app-managed palace slugs need the spec-001 force bypass — the \
+         daemon's cwd-derived project slug will not match"
+    );
+}
+
+/// (#2424) An already-existing palace must NOT be re-created —
+/// `handle_palace_create` overwrites `palace.json` (resetting
+/// `created_at`/`description`), so the ensure probes with `palace_info`
+/// first and never calls `palace_create` when it succeeds; the ensure is
+/// also cached, so a second turn adds no extra probe.
+#[tokio::test]
+async fn ensure_palace_skips_create_when_palace_exists() {
+    let (base_url, captured) = spawn_capturing_mock(PalaceState::Exists).await;
+    let sink = TurnMemorySink::new(base_url, "test-palace".to_string());
+
+    sink.enqueue("sess-1", "p1", "r1");
+    sink.enqueue("sess-1", "p2", "r2");
+    // 5 calls: palace_info once, then 2 writes per turn.
+    wait_for_captures(&captured, 5, Duration::from_secs(2)).await;
+
+    let calls = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let names: Vec<&str> = calls.iter().map(|(_, p)| tool_name(p)).collect();
+    assert_eq!(
+        names.iter().filter(|n| **n == "palace_info").count(),
+        1,
+        "ensure result must be cached — one probe for the whole session"
+    );
+    assert!(
+        !names.contains(&"palace_create"),
+        "an existing palace must never be re-created (metadata clobber)"
+    );
 }
 
 /// (#2363) A `"status":"skipped"` `memory_remember` response (e.g. tripped by
@@ -131,23 +263,24 @@ async fn enqueue_drain_happy_path() {
 ///
 /// Why: this is the belt-and-braces half of #2363 — `force: true` handles
 /// the dedup gate specifically, but this detection covers any OTHER gate
-/// that still returns a skipped envelope.
-/// What: mock server always replies with a `status: skipped` envelope for
-/// `memory_remember`; the test only asserts the call still lands (no panic,
-/// no hang) — the warning itself is inspected via the tracing subscriber in
-/// a real deployment, not asserted on here (no test-local tracing capture
-/// exists in this crate yet), so this test's assertion is: the drain task
-/// tolerates a skipped envelope exactly like a stored one.
+/// that still returns a skipped envelope. Post-#2424 the skipped payload
+/// arrives STRINGIFIED inside the `tools/call` envelope, so this also pins
+/// that the detection reads the PARSED inner result, not the raw envelope.
+/// What: mock server always replies with a wrapped `status: skipped` body
+/// for `memory_remember`; the test only asserts the call still lands (no
+/// panic, no hang) — the warning itself is inspected via the tracing
+/// subscriber in a real deployment, not asserted on here (no test-local
+/// tracing capture exists in this crate yet), so this test's assertion is:
+/// the drain task tolerates a skipped envelope exactly like a stored one.
 #[tokio::test]
 async fn write_turn_warns_on_skipped_status() {
     async fn handle_skipped(Json(body): Json<Value>) -> Json<Value> {
-        let method = body["method"].as_str().unwrap_or_default();
-        let result = if method == "memory_remember" {
+        let inner = if body["params"]["name"].as_str() == Some("memory_remember") {
             json!({"palace": "test-palace", "status": "skipped", "reason": "content gate"})
         } else {
             json!({"ok": true})
         };
-        Json(json!({"jsonrpc": "2.0", "id": 1, "result": result}))
+        Json(json!({"jsonrpc": "2.0", "id": 1, "result": wrapped_result(&inner)}))
     }
 
     let app = Router::new().route("/rpc", post(handle_skipped));
@@ -180,7 +313,8 @@ fn base_url_and_palace_expose_construction_args() {
 }
 
 /// An unreachable `base_url` must never panic or hang the drain task — the
-/// core fail-open contract (#2345 acceptance criteria).
+/// core fail-open contract (#2345 acceptance criteria), which post-#2424
+/// also covers a failed palace ensure (probe AND create both unreachable).
 #[tokio::test]
 async fn write_turn_is_fail_open_on_unreachable_daemon() {
     let sink = TurnMemorySink::new("http://127.0.0.1:1".to_string(), "p".to_string());

--- a/crates/trusty-code/src/tools/recall_session.rs
+++ b/crates/trusty-code/src/tools/recall_session.rs
@@ -14,7 +14,9 @@
 //! trusty-memory's `memory_recall` via the `tools/call` MCP envelope
 //! (spike-verified on issue #2348: the daemon wraps the tool result as a
 //! STRINGIFIED JSON blob inside `result.content[0].text`, not a raw JSON
-//! value — [`parse_recall_envelope`] handles that unwrap), over-fetching
+//! value — `crate::memory_envelope::parse_tools_call_envelope`, the shared
+//! unwrap this module originally owned and #2424 promoted so the turn
+//! recorder writes through the same shape, handles that), over-fetching
 //! `top_k * `[`OVER_FETCH_FACTOR`] results because the daemon cannot
 //! tag-filter server-side (filtering happens client-side, AFTER the
 //! daemon's own truncation — see the spike comment on #2348). Results are
@@ -36,6 +38,7 @@ use tracing::warn;
 use trusty_common::mcp::memory_rpc::call_memory_tool_at;
 
 use crate::agent_loop::estimate_tokens;
+use crate::memory_envelope::{parse_tools_call_envelope, tools_call_params};
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
 /// The tool's registered/advertised name.
@@ -104,27 +107,6 @@ impl RecallSessionTool {
     fn session_tag(&self) -> String {
         format!("session:{}", self.session_id)
     }
-}
-
-/// Extract and parse the inner recall JSON from a `tools/call` envelope.
-///
-/// Why: isolates the spike-verified unwrap (`result.content[0].text` is a
-/// STRINGIFIED JSON blob, not a nested `Value`) as its own testable step,
-/// distinct from the tag-filter/budget logic below it.
-/// What: `envelope` is the raw `result` field of the JSON-RPC response
-/// (i.e. `call_memory_tool_at`'s `Ok` payload for a `tools/call` request).
-/// Returns `Some(parsed_body)` on a well-formed envelope, `None` otherwise
-/// (never panics on an unexpected shape).
-/// Test: `tests::parse_recall_envelope_unwraps_stringified_content`,
-/// `tests::parse_recall_envelope_none_on_missing_content`,
-/// `tests::parse_recall_envelope_none_on_malformed_inner_json`.
-fn parse_recall_envelope(envelope: &Value) -> Option<Value> {
-    let text = envelope
-        .get("content")
-        .and_then(|c| c.get(0))
-        .and_then(|c0| c0.get("text"))
-        .and_then(|t| t.as_str())?;
-    serde_json::from_str(text).ok()
 }
 
 /// Whether a single `memory_recall` result entry carries `tag`.
@@ -245,14 +227,14 @@ impl ToolExecutor for RecallSessionTool {
         let top_k = parsed.top_k.unwrap_or(DEFAULT_TOP_K).clamp(1, MAX_TOP_K);
         let fetch_k = top_k * OVER_FETCH_FACTOR;
 
-        let rpc_params = json!({
-            "name": "memory_recall",
-            "arguments": {
+        let rpc_params = tools_call_params(
+            "memory_recall",
+            json!({
                 "palace": self.palace,
                 "query": parsed.query,
                 "top_k": fetch_k,
-            }
-        });
+            }),
+        );
 
         let envelope = match call_memory_tool_at(&self.base_url, "tools/call", rpc_params).await {
             Ok(v) => v,
@@ -268,7 +250,7 @@ impl ToolExecutor for RecallSessionTool {
             }
         };
 
-        let Some(body) = parse_recall_envelope(&envelope) else {
+        let Some(body) = parse_tools_call_envelope(&envelope) else {
             warn!(
                 session_id = %self.session_id,
                 "recall_session: unexpected memory_recall response shape (fail-open)"
@@ -330,30 +312,9 @@ mod tests {
         json!({"content": [{"type": "text", "text": inner}]})
     }
 
-    // ── `parse_recall_envelope` ──────────────────────────────────────────
-
-    #[test]
-    fn parse_recall_envelope_unwraps_stringified_content() {
-        let envelope = tools_call_envelope(
-            "p",
-            "q",
-            vec![result_entry("hello", 0.9, &["session:s1", "turn"])],
-        );
-        let body = parse_recall_envelope(&envelope).expect("should parse");
-        assert_eq!(body["palace"], "p");
-        assert_eq!(body["results"][0]["content"], "hello");
-    }
-
-    #[test]
-    fn parse_recall_envelope_none_on_missing_content() {
-        assert!(parse_recall_envelope(&json!({"not_content": []})).is_none());
-    }
-
-    #[test]
-    fn parse_recall_envelope_none_on_malformed_inner_json() {
-        let envelope = json!({"content": [{"type": "text", "text": "not valid json"}]});
-        assert!(parse_recall_envelope(&envelope).is_none());
-    }
+    // NOTE (#2424): the envelope-unwrap unit tests moved with the helper to
+    // `crate::memory_envelope::tests` when `parse_recall_envelope` was
+    // promoted to the shared `parse_tools_call_envelope`.
 
     // ── `filter_and_cap` ─────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #2424. Refs #2345, #2348, epic #2343.

## Root causes (from the epic #2343 live soak, 2026-07-11 — 0/50 turns stored)

1. **Wrong dispatch method.** `memory_sink::write_turn` dispatched `chat_turn_append` as a direct JSON-RPC method, but trusty-memory's `TOOL_METHODS` direct-dispatch allowlist (`crates/trusty-memory/src/transport/rpc.rs:185`) contains no `chat_*` methods → `-32601 Method not found` on every write. The `tools/call` envelope routes through `dispatch_tool`, which handles `chat_turn_append`.
2. **Missing palace.** The `memory_remember` half fails `-32603 "palace metadata missing"` when the palace was never created — `memory_remember` does not auto-create, and the sink never called `palace_create`.

## Fix (tcode side only — no trusty-memory changes)

- **New shared module `crates/trusty-code/src/memory_envelope.rs`**: `tools_call_params` / `parse_tools_call_envelope` / `call_tool_wrapped` — the single implementation of the spike-verified `tools/call` shape (result STRINGIFIED in `result.content[0].text`). `recall_session`'s private `parse_recall_envelope` was promoted into it (common-entry-point principle), so the read and write sides can never drift apart again.
- **`memory_sink::write_turn`**: both `chat_turn_append` and `memory_remember` now go through `call_tool_wrapped`. The parsed inner result has the same shape as the old direct-dispatch result, so the #2363 `status: "skipped"` detection (and `force: true`) is preserved unchanged.
- **Ensure-palace-once** (`memory_sink::ensure_palace`, drain-task-local state): before the first write, probe `palace_info`; only when that fails, `palace_create` with `force: true` (the spec-001 documented bypass for app-managed palace slugs; no-op authz in single-tenant mode). Probe-first because `handle_palace_create` **overwrites** `palace.json` for an existing palace (resets `created_at`/`description`) — an existing project palace shared with the PM catch-up digest must not be clobbered per session. Success latches (zero extra RPCs at steady state); failure warns, stays fail-open, and retries on the next turn (covers a daemon that comes up mid-session).
- **Tests**: mock servers now reply with the daemon's real `tools/call` envelope; assertions cover `method == "tools/call"`, `params.name`, inner `arguments` (incl. `force: true`), plus new `ensure_palace_creates_missing_palace_once` (exact call order: probe → create → writes; create carries `force: true`) and `ensure_palace_skips_create_when_palace_exists` (one cached probe, never re-created). Fail-open and overflow tests kept green.

## Live verification (trusty-memory 0.19.2 @ 127.0.0.1:7070, throwaway palace `tcode-2424-probe`, deleted after)

Bug repro first, then the fixed path, all via `curl`:

| Step | Call | Result |
|---|---|---|
| repro 1 | direct-method `chat_turn_append` | `-32601 Method not found: chat_turn_append` |
| repro 2 | `tools/call palace_info` on missing palace | `-32603 … palace metadata missing at …/tcode-2424-probe/palace.json` |
| fix 1 | `tools/call palace_create` `{name, force:true}` | `{"palace_id":"tcode-2424-probe","status":"created"}` |
| fix 2 | `tools/call chat_turn_append` | `{"message_count":2,"updated_at":…}` |
| fix 3 | `tools/call memory_remember` `{tags:["session:probe-s1","turn"], force:true}` | `{"drawer_id":"32ef5dd7-…","status":"stored"}` |
| readback | `tools/call chat_session_get` | history contains both user+assistant messages verbatim |
| cleanup | `tools/call palace_delete` `{palace_id, force:true}` | `{"deleted":"tcode-2424-probe"}`; follow-up `palace_info` confirms gone |

Bonus live finding: `memory_remember` with a very short text hit the content gate (`status:"skipped"`, `reason:"content gate: skipped (short prompt, no context)"`) even with `force:true` — exactly the #2363 belt-and-braces case the skipped-detection warn covers; real turn payloads are well past that gate.

## Gates

- `cargo build --workspace` — clean
- `cargo test -p trusty-code` — all green (incl. 6 new/updated `memory_envelope`/`memory_sink` tests)
- `cargo test --workspace` — 1781 passed / 2 failed: only the KNOWN trusty-agents flakes `telegram_pid_guard_garbage_is_overwritten` + `telegram_pid_guard_live_conflict_is_rejected`; isolate-verified — both pass with `--test-threads=1` (pre-existing parallel-isolation race, untouched by this diff which is trusty-code-only)
- `cargo +stable clippy --workspace --all-targets --exclude trusty-mpm-gui -- -D warnings` — exit 0, clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations — OK`
- No conflict markers in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
