### PR TITLE
feat(trusty-mpm): SessionRecord.deliverable_id + --deliverable launch wiring (WI-13, closes #2379)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -1887,6 +1887,13 @@ pub(crate) enum SessionAction {
         /// task is stored but you deliver it yourself with `tm sessions send`.
         #[arg(long)]
         no_inject: bool,
+        /// Bind this session to an existing Deliverable (DOC-35 §10.6, #2379).
+        ///
+        /// The daemon validates the id exists AND belongs to this session's
+        /// project BEFORE spawning anything (a 404 otherwise); this is a
+        /// pointer-only link — it never changes the Deliverable's own status.
+        #[arg(long)]
+        deliverable: Option<String>,
     },
     /// List managed sessions (session-manager MVP).
     ///

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
@@ -56,6 +56,7 @@ pub(crate) fn to_command(action: &SessionAction) -> Option<TrustyCommand> {
             name_hint,
             runtime,
             no_inject,
+            deliverable,
         } => TrustyCommand::ManagedNew {
             repo_url: repo.clone(),
             git_ref: git_ref.clone(),
@@ -70,6 +71,9 @@ pub(crate) fn to_command(action: &SessionAction) -> Option<TrustyCommand> {
             // (which builds a New action) posts the same minimal wire shape it
             // always has.
             inject_task: if *no_inject { Some(false) } else { None },
+            // `--deliverable <id>` (DOC-35 §10.6, #2379): omitted entirely when
+            // absent, same additive wire pattern as `inject_task` above.
+            deliverable_id: deliverable.clone(),
         },
         SessionAction::Ls { .. } => TrustyCommand::ManagedList,
         SessionAction::Send { id, text } => TrustyCommand::ManagedSend {
@@ -243,6 +247,7 @@ mod tests {
             name_hint: Some("api".to_string()),
             runtime: trusty_mpm::runtime::RuntimeKind::ClaudeCode,
             no_inject: false,
+            deliverable: None,
         };
         match to_command(&action) {
             Some(TrustyCommand::ManagedNew {
@@ -252,6 +257,7 @@ mod tests {
                 name_hint,
                 runtime,
                 inject_task,
+                deliverable_id,
             }) => {
                 assert_eq!(repo_url, "https://example/r.git");
                 assert_eq!(git_ref, "main");
@@ -261,6 +267,8 @@ mod tests {
                 // Default (no `--no-inject`) → field omitted so the daemon's
                 // turnkey default (inject) applies.
                 assert_eq!(inject_task, None);
+                // Default (no `--deliverable`) → no link (#2379).
+                assert_eq!(deliverable_id, None);
             }
             other => panic!("expected ManagedNew, got {other:?}"),
         }
@@ -276,10 +284,34 @@ mod tests {
             name_hint: None,
             runtime: trusty_mpm::runtime::RuntimeKind::ClaudeCode,
             no_inject: true,
+            deliverable: None,
         };
         match to_command(&action) {
             Some(TrustyCommand::ManagedNew { inject_task, .. }) => {
                 assert_eq!(inject_task, Some(false));
+            }
+            other => panic!("expected ManagedNew, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_command_new_deliverable_maps_to_deliverable_id() {
+        // `--deliverable <id>` maps to `deliverable_id: Some(<id>)` (#2379).
+        let action = SessionAction::New {
+            repo: "https://example/r.git".to_string(),
+            git_ref: "main".to_string(),
+            task: "do it".to_string(),
+            name_hint: None,
+            runtime: trusty_mpm::runtime::RuntimeKind::ClaudeCode,
+            no_inject: false,
+            deliverable: Some("11111111-1111-1111-1111-111111111111".to_string()),
+        };
+        match to_command(&action) {
+            Some(TrustyCommand::ManagedNew { deliverable_id, .. }) => {
+                assert_eq!(
+                    deliverable_id,
+                    Some("11111111-1111-1111-1111-111111111111".to_string())
+                );
             }
             other => panic!("expected ManagedNew, got {other:?}"),
         }

--- a/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
@@ -73,6 +73,8 @@ pub(crate) async fn start_session(
             // Empty task → injection is a no-op regardless; keep the turnkey
             // default so `session start` mirrors `session new` semantics (#1903).
             no_inject: false,
+            // `session start` has no `--deliverable` surface of its own (#2379).
+            deliverable: None,
         };
         crate::commands::managed_route::run(client, url, &new_action).await?;
         return Ok(());

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -45,6 +45,7 @@ fn cli_parses_session_new() {
                     name_hint,
                     runtime,
                     no_inject,
+                    deliverable,
                 },
         } => {
             assert_eq!(repo, "https://github.com/owner/repo");
@@ -55,6 +56,35 @@ fn cli_parses_session_new() {
             assert_eq!(runtime, trusty_mpm::runtime::RuntimeKind::ClaudeCode);
             // No --no-inject → turnkey injection is the default (#1903/#1299).
             assert!(!no_inject);
+            // No --deliverable → no link (#2379).
+            assert_eq!(deliverable, None);
+        }
+        other => panic!("expected session new, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_session_new_with_deliverable() {
+    // Why: #2379 — `--deliverable <id>` binds the new session to a Deliverable.
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "new",
+        "https://github.com/owner/repo",
+        "--task",
+        "do the thing",
+        "--deliverable",
+        "11111111-1111-1111-1111-111111111111",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::New { deliverable, .. },
+        } => {
+            assert_eq!(
+                deliverable.as_deref(),
+                Some("11111111-1111-1111-1111-111111111111")
+            );
         }
         other => panic!("expected session new, got {other:?}"),
     }

--- a/crates/trusty-mpm/src/client/command.rs
+++ b/crates/trusty-mpm/src/client/command.rs
@@ -172,6 +172,9 @@ pub enum TrustyCommand {
         /// (`--no-inject`); `None`/`Some(true)` → the daemon auto-injects the
         /// task once the runtime is ready (the turnkey default).
         inject_task: Option<bool>,
+        /// Optional Deliverable id to bind this session to (`--deliverable`,
+        /// DOC-35 §10.6, #2379). `None` → no link, the common case.
+        deliverable_id: Option<String>,
     },
     /// List every managed session (`sessions.list`).
     ManagedList,
@@ -308,6 +311,7 @@ mod tests {
             name_hint: Some("api".into()),
             runtime: Some("tcode".into()),
             inject_task: None,
+            deliverable_id: None,
         };
         assert_eq!(spawn.clone(), spawn);
         let answer = TrustyCommand::ManagedAnswer {

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -45,6 +45,7 @@ impl CommandExecutor {
     }
 
     /// `managed-new` — spawn a managed session from a repo + ref + task.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn managed_new(
         &self,
         repo_url: String,
@@ -53,6 +54,7 @@ impl CommandExecutor {
         name_hint: Option<String>,
         runtime: Option<String>,
         inject_task: Option<bool>,
+        deliverable_id: Option<String>,
     ) -> CommandResult {
         let req = ManagedSpawnRequest {
             repo_url,
@@ -61,6 +63,7 @@ impl CommandExecutor {
             name_hint,
             runtime,
             inject_task,
+            deliverable_id,
         };
         match self.client().spawn_managed_session(&req).await {
             Ok(resp) => CommandResult::ManagedSpawned {

--- a/crates/trusty-mpm/src/client/executor/mod.rs
+++ b/crates/trusty-mpm/src/client/executor/mod.rs
@@ -134,9 +134,18 @@ impl CommandExecutor {
                 name_hint,
                 runtime,
                 inject_task,
+                deliverable_id,
             } => {
-                self.managed_new(repo_url, git_ref, task, name_hint, runtime, inject_task)
-                    .await
+                self.managed_new(
+                    repo_url,
+                    git_ref,
+                    task,
+                    name_hint,
+                    runtime,
+                    inject_task,
+                    deliverable_id,
+                )
+                .await
             }
             TrustyCommand::ManagedList => self.managed_list().await,
             TrustyCommand::ManagedFleet => self.managed_fleet().await,

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -405,12 +405,17 @@ fn managed_spawn_request_serializes() {
         name_hint: Some("tmpm-custom".to_string()),
         runtime: Some("tcode".to_string()),
         inject_task: None,
+        deliverable_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
     };
     let v = serde_json::to_value(&req).unwrap();
     assert_eq!(v["ref"], "main");
     assert_eq!(v["repo_url"], "https://example.com/r.git");
     assert_eq!(v["name_hint"], "tmpm-custom");
     assert_eq!(v["runtime"], "tcode");
+    assert_eq!(
+        v["deliverable_id"], "11111111-1111-1111-1111-111111111111",
+        "Some(deliverable_id) must serialize as its string value"
+    );
     assert!(v.get("git_ref").is_none(), "must use wire key `ref`");
 
     let bare = ManagedSpawnRequest {
@@ -420,6 +425,7 @@ fn managed_spawn_request_serializes() {
         name_hint: None,
         runtime: None,
         inject_task: None,
+        deliverable_id: None,
     };
     let v = serde_json::to_value(&bare).unwrap();
     assert!(v.get("name_hint").is_none(), "None name_hint is omitted");
@@ -427,6 +433,10 @@ fn managed_spawn_request_serializes() {
     assert!(
         v.get("inject_task").is_none(),
         "None inject_task is omitted"
+    );
+    assert!(
+        v.get("deliverable_id").is_none(),
+        "None deliverable_id is omitted (#2379, same additive pattern as inject_task)"
     );
 }
 

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -465,6 +465,12 @@ pub struct ManagedSpawnRequest {
     /// task once the runtime is ready). Absent → the daemon default (inject).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inject_task: Option<bool>,
+    /// Optional Deliverable id to bind this session to (DOC-35 §10.6, #2379).
+    /// Absent → no link, the common case; the CLI omits the field entirely
+    /// when `--deliverable` was not passed (same additive wire pattern
+    /// `inject_task` established in #2361).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deliverable_id: Option<String>,
 }
 
 /// Response body for `POST /api/v1/sessions/managed` (spawn).

--- a/crates/trusty-mpm/src/daemon/api/deliverable_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/deliverable_routes.rs
@@ -314,10 +314,15 @@ pub async fn list_deliverables(
 ///
 /// Why: a Deliverable id is global, but the route nests it under a project; a
 /// mismatched project must 404 rather than leak another project's record.
+/// `pub(crate)` (not private) so the pre-spawn `--deliverable` validation gate
+/// (`daemon::managed_routes::deliverable_link`, #2379) reuses this EXACT
+/// existence+scope check rather than re-implementing it — the Deliverable
+/// CRUD routes and the session-spawn validation must never be able to drift
+/// on what "belongs to this project" means.
 /// What: looks up by id, maps `NotFound` to a typed 404, then enforces the
 /// project scope.
 /// Test: `get_wrong_project_is_404`.
-async fn fetch_scoped(
+pub(crate) async fn fetch_scoped(
     state: &Arc<DaemonState>,
     project: &str,
     id: &str,

--- a/crates/trusty-mpm/src/daemon/error.rs
+++ b/crates/trusty-mpm/src/daemon/error.rs
@@ -85,6 +85,24 @@ pub enum DaemonError {
         id: String,
     },
 
+    /// No registered project matches the given `repo_url`, so a Deliverable
+    /// id cannot be scoped against it (#2379 review MEDIUM).
+    ///
+    /// Why: distinct from [`DeliverableNotFound`](Self::DeliverableNotFound) —
+    /// the Deliverable itself may well exist; what's missing is the PROJECT
+    /// identity to scope it against. Returning `DeliverableNotFound` here
+    /// would misleadingly imply the id itself was bad, when the actual gap is
+    /// "no project is registered for this repo at all".
+    /// What: carries the `repo_url` that failed to resolve; maps to HTTP 404
+    /// (there is genuinely no project resource for this identity).
+    /// Test: `error_status_codes_map`, and
+    /// `validate_deliverable_scope_unknown_project_is_404`.
+    #[error("no registered project matches repo_url {repo_url:?}; cannot scope deliverable")]
+    ProjectNotFoundForRepoUrl {
+        /// The `repo_url` that did not resolve to any registered project.
+        repo_url: String,
+    },
+
     /// A requested Deliverable status change is not a legal transition (#2380).
     ///
     /// Why: the §10.3 state machine rejects illegal `set-status` requests (e.g.
@@ -157,7 +175,8 @@ impl DaemonError {
             Self::SessionNotFound { .. }
             | Self::CheckpointNotFound { .. }
             | Self::DeliverableNotFound { .. }
-            | Self::MilestoneNotFound { .. } => StatusCode::NOT_FOUND,
+            | Self::MilestoneNotFound { .. }
+            | Self::ProjectNotFoundForRepoUrl { .. } => StatusCode::NOT_FOUND,
             Self::SessionNotActive { .. } | Self::InvalidTransition { .. } => StatusCode::CONFLICT,
             Self::OverseerBlocked { .. } | Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::InvalidRequest(_) | Self::InvalidPairCode => StatusCode::BAD_REQUEST,
@@ -264,6 +283,13 @@ mod tests {
             StatusCode::NOT_FOUND
         );
         assert_eq!(
+            DaemonError::ProjectNotFoundForRepoUrl {
+                repo_url: "x".into()
+            }
+            .status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
             DaemonError::InvalidTransition {
                 from: "proposed".into(),
                 to: "complete".into(),
@@ -304,5 +330,21 @@ mod tests {
         };
         assert!(e.to_string().contains("abc"));
         assert!(e.to_string().contains("stopped"));
+    }
+
+    #[test]
+    fn project_not_found_message_names_repo_url_not_deliverable() {
+        // #2379 review MEDIUM: the message must talk about the missing
+        // PROJECT, never imply the deliverable id itself was bad.
+        let e = DaemonError::ProjectNotFoundForRepoUrl {
+            repo_url: "/local/path/checkout".into(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("/local/path/checkout"), "{msg}");
+        assert!(msg.contains("project"), "{msg}");
+        assert!(
+            !msg.contains("deliverable not found"),
+            "must not read as a deliverable-not-found error: {msg}"
+        );
     }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/deliverable_link.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/deliverable_link.rs
@@ -1,0 +1,204 @@
+//! Pre-spawn `--deliverable` validation gate (DOC-35 §10.6, #2379).
+//!
+//! Why: `managed_routes/mod.rs` was near its 500-SLOC production cap; this
+//! validation is also a single, cohesive concern (mirroring why `summary.rs`
+//! and `mcp_spawn_gate.rs` already live as siblings rather than inline in
+//! `mod.rs`). The check itself must run BEFORE any provisioning side effect —
+//! the same "fail closed before touching disk" shape the MCP spawn gate
+//! already uses — so an invalid `--deliverable <id>` never leaves an orphan
+//! workspace or tmux session behind.
+//! What: [`validate_deliverable_scope`] resolves the spawning project from a
+//! bare `repo_url` via [`crate::project::resolver::resolve_project_by_repo_url`],
+//! then reuses [`crate::daemon::api::deliverable_routes::fetch_scoped`] — the
+//! EXACT existence+project-scope check the Deliverable CRUD routes already
+//! enforce — so this gate can never drift from what "belongs to this
+//! project" means there. A 404-style [`DaemonError`] renders identically
+//! whether it originated here or from the CRUD routes.
+//! Test: `validate_deliverable_scope_unknown_project_is_404`,
+//! `validate_deliverable_scope_unknown_deliverable_is_404`,
+//! `validate_deliverable_scope_wrong_project_is_404`,
+//! `validate_deliverable_scope_valid_id_passes` in this module's own `tests`.
+
+use std::sync::Arc;
+
+use axum::response::{IntoResponse, Response};
+
+use crate::daemon::api::deliverable_routes::fetch_scoped;
+use crate::daemon::error::DaemonError;
+use crate::daemon::state::DaemonState;
+use crate::project::resolver::resolve_project_by_repo_url;
+
+/// Validate that `deliverable_id` exists and belongs to the project that owns
+/// `repo_url`, rendering a ready-to-return [`Response`] on failure.
+///
+/// Why: `spawn_session` must reject an invalid `--deliverable` BEFORE calling
+/// `spawn_managed` (mirroring the existing runtime-selector 400 pre-check) so
+/// a typo'd or cross-project id never mints workspace/tmux infrastructure for
+/// a link that was never going to be recorded (§11: this is a pointer check,
+/// not a Deliverable mutation — nothing here writes to the Deliverable store).
+/// What: (1) lists registered projects and resolves one whose `repo_url`
+/// matches; no match → 404 (there is no project to scope the id against).
+/// (2) delegates to [`fetch_scoped`] for the existence+scope check, mapping
+/// any [`DaemonError`] straight to its response.
+/// Test: see module doc.
+pub(super) async fn validate_deliverable_scope(
+    state: &Arc<DaemonState>,
+    repo_url: &str,
+    deliverable_id: &str,
+) -> Result<(), Response> {
+    let projects = state
+        .project_registry()
+        .await
+        .list()
+        .await
+        .unwrap_or_default();
+    let Some(project) = resolve_project_by_repo_url(repo_url, &projects) else {
+        return Err(DaemonError::DeliverableNotFound {
+            id: deliverable_id.to_string(),
+        }
+        .into_response());
+    };
+    fetch_scoped(state, &project.name, deliverable_id)
+        .await
+        .map(|_| ())
+        .map_err(IntoResponse::into_response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    use crate::deliverable::{
+        Deliverable, DeliverableId, DeliverableKind, DeliverableStatus, EstimationTier,
+    };
+    use crate::project::record::Project;
+
+    fn state() -> (Arc<DaemonState>, TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let st = Arc::new(DaemonState::with_root(dir.path().to_path_buf()));
+        (st, dir)
+    }
+
+    fn project(name: &str, repo_url: &str) -> Project {
+        Project {
+            name: name.to_string(),
+            repo_url: repo_url.to_string(),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        }
+    }
+
+    fn deliverable(project_name: &str) -> Deliverable {
+        Deliverable {
+            id: DeliverableId::new(),
+            project_name: project_name.to_string(),
+            name: "sample".into(),
+            description: String::new(),
+            kind: DeliverableKind::Feature,
+            ticket_ref: None,
+            spec_ref: None,
+            status: DeliverableStatus::Proposed,
+            estimated_effort: EstimationTier::M,
+            created_at: Utc::now(),
+            target_date: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_deliverable_scope_unknown_project_is_404() {
+        let (st, _g) = state();
+        // No project registered for this repo_url at all.
+        let err = validate_deliverable_scope(&st, "https://github.com/org/unregistered", "any-id")
+            .await
+            .expect_err("no project to scope against");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn validate_deliverable_scope_unknown_deliverable_is_404() {
+        let (st, _g) = state();
+        st.project_registry()
+            .await
+            .register(project(
+                "trusty-tools",
+                "https://github.com/org/trusty-tools",
+            ))
+            .await
+            .expect("register");
+
+        let err = validate_deliverable_scope(
+            &st,
+            "https://github.com/org/trusty-tools",
+            &DeliverableId::new().to_string(),
+        )
+        .await
+        .expect_err("deliverable does not exist");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn validate_deliverable_scope_wrong_project_is_404() {
+        let (st, _g) = state();
+        st.project_registry()
+            .await
+            .register(project(
+                "trusty-tools",
+                "https://github.com/org/trusty-tools",
+            ))
+            .await
+            .expect("register");
+        // Deliverable exists, but belongs to a DIFFERENT project than the one
+        // `repo_url` resolves to.
+        let d = deliverable("some-other-project");
+        st.deliverable_manager()
+            .await
+            .upsert_deliverable(d.clone())
+            .await
+            .expect("upsert");
+
+        let err = validate_deliverable_scope(
+            &st,
+            "https://github.com/org/trusty-tools",
+            &d.id.to_string(),
+        )
+        .await
+        .expect_err("wrong-project deliverable must 404, not leak");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn validate_deliverable_scope_valid_id_passes() {
+        let (st, _g) = state();
+        st.project_registry()
+            .await
+            .register(project(
+                "trusty-tools",
+                "https://github.com/org/trusty-tools",
+            ))
+            .await
+            .expect("register");
+        let d = deliverable("trusty-tools");
+        st.deliverable_manager()
+            .await
+            .upsert_deliverable(d.clone())
+            .await
+            .expect("upsert");
+
+        validate_deliverable_scope(
+            &st,
+            "https://github.com/org/trusty-tools",
+            &d.id.to_string(),
+        )
+        .await
+        .expect("matching project + existing deliverable must pass");
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/deliverable_link.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/deliverable_link.rs
@@ -8,25 +8,113 @@
 //! already uses — so an invalid `--deliverable <id>` never leaves an orphan
 //! workspace or tmux session behind.
 //! What: [`validate_deliverable_scope`] resolves the spawning project from a
-//! bare `repo_url` via [`crate::project::resolver::resolve_project_by_repo_url`],
-//! then reuses [`crate::daemon::api::deliverable_routes::fetch_scoped`] — the
-//! EXACT existence+project-scope check the Deliverable CRUD routes already
+//! bare `repo_url` via [`resolve_project_for_deliverable_scope`], then reuses
+//! [`crate::daemon::api::deliverable_routes::fetch_scoped`] — the EXACT
+//! existence+project-scope check the Deliverable CRUD routes already
 //! enforce — so this gate can never drift from what "belongs to this
 //! project" means there. A 404-style [`DaemonError`] renders identically
 //! whether it originated here or from the CRUD routes.
+//!
+//! Project resolution mirrors the identity the in-project spawn path already
+//! derives for `source_id` (`daemon::managed_routes::lifecycle`,
+//! `format!("{owner}/{repo}")`) rather than a bare string compare of
+//! `repo_url` against `Project::repo_url` (review HIGH, #2379): a LOCAL-PATH
+//! spawn's `repo_url` is a filesystem path, never a registered project's URL
+//! string, and an SSH-form `repo_url` never string-matches an
+//! HTTPS-registered project (or vice versa) even though both name the same
+//! GitHub repo. [`resolve_project_for_deliverable_scope`] parses BOTH sides
+//! down to a slugified `{owner, repo}`
+//! ([`trusty_common::github_path::parse_github_path`]) before comparing, and
+//! for a local directory reads its actual git remote first — exactly what
+//! [`super::inproject::try_inproject_spawn`] already does. It falls back to
+//! [`crate::project::resolver::resolve_project_by_repo_url`]'s exact-string
+//! match only when no GitHub identity is derivable from either side (a
+//! non-GitHub-hosted project, or a local directory with no git remote).
+//!
+//! TOCTOU note: this validates the Deliverable exists and is in-scope, then
+//! the spawn proceeds, and only AFTER the session record is created does
+//! [`crate::session_manager::SessionManager::set_deliverable_id`] persist the
+//! pointer — if the Deliverable is deleted in that window the persisted link
+//! becomes a stale pointer to a since-deleted id. This is accepted under the
+//! pointer-only contract (§11): the link is bookkeeping, not a live
+//! foreign-key relationship the daemon enforces continuously, and a stale
+//! pointer is no different in kind from decommissioning a session without
+//! ever unlinking it (§10.6) — both are inert history, not correctness bugs.
 //! Test: `validate_deliverable_scope_unknown_project_is_404`,
 //! `validate_deliverable_scope_unknown_deliverable_is_404`,
 //! `validate_deliverable_scope_wrong_project_is_404`,
-//! `validate_deliverable_scope_valid_id_passes` in this module's own `tests`.
+//! `validate_deliverable_scope_valid_id_passes`,
+//! `validate_deliverable_scope_local_path_matches_registered_project`,
+//! `validate_deliverable_scope_ssh_repo_url_matches_https_registered_project`
+//! in this module's own `tests`.
 
 use std::sync::Arc;
 
 use axum::response::{IntoResponse, Response};
+use trusty_common::github_path::{GithubPath, parse_github_path};
 
 use crate::daemon::api::deliverable_routes::fetch_scoped;
 use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
+use crate::project::record::Project;
 use crate::project::resolver::resolve_project_by_repo_url;
+
+/// Derive the slugified GitHub `{owner, repo}` identity of a spawn's
+/// `repo_url`, resolving a LOCAL-PATH `repo_url` via its actual git remote.
+///
+/// Why: a local-path spawn's `repo_url` (#1433/#1706 — the dominant
+/// in-project path) is a filesystem path, not a URL; deriving its identity
+/// requires reading `remote.origin.url` first, exactly like
+/// [`super::inproject::try_inproject_spawn`] does. `parse_github_path` alone
+/// would happily (and WRONGLY) mis-derive an `{owner, repo}` pair from a bare
+/// path's trailing segments, so the local-directory branch must run FIRST.
+/// What: `is_local_workdir` → read `remote.origin.url` via
+/// `inproject::get_origin_url`, then parse that; otherwise parse `repo_url`
+/// directly (the remote-URL, HTTPS-or-SSH case). Either way the result is
+/// normalised via [`trusty_common::github_path::parse_github_path`], which
+/// already treats SSH and HTTPS forms identically.
+/// Test: covered transitively by `validate_deliverable_scope_local_path_*`
+/// and `validate_deliverable_scope_ssh_repo_url_*`.
+fn github_identity_for_repo_url(repo_url: &str) -> Option<GithubPath> {
+    if super::is_local_workdir(repo_url) {
+        let origin = super::inproject::get_origin_url(std::path::Path::new(repo_url))?;
+        parse_github_path(&origin)
+    } else {
+        parse_github_path(repo_url)
+    }
+}
+
+/// Resolve the registered [`Project`] that owns a spawn's `repo_url`, for
+/// Deliverable-linkage validation (DOC-35 §10.6, #2379 review HIGH).
+///
+/// Why: see the module doc's "Project resolution" section — a bare
+/// `repo_url`-string compare (the pre-review implementation) 404s a valid
+/// `--deliverable` for the two dominant real-world mismatches: a local-path
+/// spawn, and an SSH-vs-HTTPS form mismatch.
+/// What: derives `repo_url`'s `{owner, repo}` via
+/// [`github_identity_for_repo_url`] and looks for a registered project whose
+/// OWN `repo_url` parses to the SAME `{owner, repo}` (each project's
+/// `repo_url` is parsed the same way `parse_github_path` always is — no
+/// local-path branch needed there since a registered `Project::repo_url` is
+/// always a remote URL, never a filesystem path). Falls back to
+/// [`resolve_project_by_repo_url`]'s exact-string match when either side has
+/// no parseable GitHub identity, so a project registered under a literal,
+/// non-GitHub URL (or a local repo_url with no git remote at all) still
+/// resolves exactly as before.
+/// Test: see module doc.
+fn resolve_project_for_deliverable_scope<'a>(
+    repo_url: &str,
+    projects: &'a [Project],
+) -> Option<&'a Project> {
+    if let Some(target) = github_identity_for_repo_url(repo_url)
+        && let Some(project) = projects
+            .iter()
+            .find(|p| parse_github_path(&p.repo_url).as_ref() == Some(&target))
+    {
+        return Some(project);
+    }
+    resolve_project_by_repo_url(repo_url, projects)
+}
 
 /// Validate that `deliverable_id` exists and belongs to the project that owns
 /// `repo_url`, rendering a ready-to-return [`Response`] on failure.
@@ -36,10 +124,13 @@ use crate::project::resolver::resolve_project_by_repo_url;
 /// a typo'd or cross-project id never mints workspace/tmux infrastructure for
 /// a link that was never going to be recorded (§11: this is a pointer check,
 /// not a Deliverable mutation — nothing here writes to the Deliverable store).
-/// What: (1) lists registered projects and resolves one whose `repo_url`
-/// matches; no match → 404 (there is no project to scope the id against).
-/// (2) delegates to [`fetch_scoped`] for the existence+scope check, mapping
-/// any [`DaemonError`] straight to its response.
+/// What: (1) lists registered projects and resolves one that owns `repo_url`
+/// via [`resolve_project_for_deliverable_scope`]; no match →
+/// [`DaemonError::ProjectNotFoundForRepoUrl`] (distinct from a Deliverable
+/// 404 — the deliverable itself may well exist, there is simply no project
+/// to scope it against). (2) delegates to [`fetch_scoped`] for the
+/// existence+scope check, mapping any [`DaemonError`] straight to its
+/// response.
 /// Test: see module doc.
 pub(super) async fn validate_deliverable_scope(
     state: &Arc<DaemonState>,
@@ -52,9 +143,9 @@ pub(super) async fn validate_deliverable_scope(
         .list()
         .await
         .unwrap_or_default();
-    let Some(project) = resolve_project_by_repo_url(repo_url, &projects) else {
-        return Err(DaemonError::DeliverableNotFound {
-            id: deliverable_id.to_string(),
+    let Some(project) = resolve_project_for_deliverable_scope(repo_url, &projects) else {
+        return Err(DaemonError::ProjectNotFoundForRepoUrl {
+            repo_url: repo_url.to_string(),
         }
         .into_response());
     };
@@ -113,6 +204,34 @@ mod tests {
         }
     }
 
+    /// Initialise a temp git repo with a `remote.origin.url` and return its path.
+    ///
+    /// Why: exercising the LOCAL-PATH branch of
+    /// [`github_identity_for_repo_url`] needs a real directory `git` will
+    /// treat as a repo with an origin — mirrors
+    /// `get_origin_url_returns_some_for_git_repo_with_origin` in
+    /// `tests/local_spawn.rs`.
+    /// What: `git init` then `git remote add origin <origin_url>`.
+    fn git_repo_with_origin(dir: &std::path::Path, origin_url: &str) {
+        let init = std::process::Command::new("git")
+            .args(["init", dir.to_str().expect("path is utf8")])
+            .output()
+            .expect("git init");
+        assert!(init.status.success(), "git init failed");
+        let remote = std::process::Command::new("git")
+            .args([
+                "-C",
+                dir.to_str().expect("path is utf8"),
+                "remote",
+                "add",
+                "origin",
+                origin_url,
+            ])
+            .output()
+            .expect("git remote add");
+        assert!(remote.status.success(), "git remote add failed");
+    }
+
     #[tokio::test]
     async fn validate_deliverable_scope_unknown_project_is_404() {
         let (st, _g) = state();
@@ -121,6 +240,71 @@ mod tests {
             .await
             .expect_err("no project to scope against");
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn validate_deliverable_scope_local_path_matches_registered_project() {
+        // #2379 review HIGH: a local-path spawn's `repo_url` is a filesystem
+        // path, never a registered project's URL string — resolution must
+        // read the directory's actual git remote and match by {owner, repo},
+        // not by exact `repo_url` string equality.
+        let (st, _g) = state();
+        st.project_registry()
+            .await
+            .register(project(
+                "trusty-tools",
+                "https://github.com/org/trusty-tools",
+            ))
+            .await
+            .expect("register");
+        let d = deliverable("trusty-tools");
+        st.deliverable_manager()
+            .await
+            .upsert_deliverable(d.clone())
+            .await
+            .expect("upsert");
+
+        let repo_dir = tempfile::tempdir().expect("repo tempdir");
+        git_repo_with_origin(repo_dir.path(), "https://github.com/org/trusty-tools.git");
+
+        validate_deliverable_scope(
+            &st,
+            repo_dir.path().to_str().expect("path is utf8"),
+            &d.id.to_string(),
+        )
+        .await
+        .expect("local-path repo_url must resolve to the matching registered project");
+    }
+
+    #[tokio::test]
+    async fn validate_deliverable_scope_ssh_repo_url_matches_https_registered_project() {
+        // #2379 review HIGH: `normalise_url`'s exact-string fallback only
+        // trims `/`/`.git`; it does not understand SSH-vs-HTTPS equivalence.
+        // An SSH-form `repo_url` must still match an HTTPS-registered project
+        // naming the SAME GitHub repo.
+        let (st, _g) = state();
+        st.project_registry()
+            .await
+            .register(project(
+                "trusty-tools",
+                "https://github.com/org/trusty-tools",
+            ))
+            .await
+            .expect("register");
+        let d = deliverable("trusty-tools");
+        st.deliverable_manager()
+            .await
+            .upsert_deliverable(d.clone())
+            .await
+            .expect("upsert");
+
+        validate_deliverable_scope(
+            &st,
+            "git@github.com:org/trusty-tools.git",
+            &d.id.to_string(),
+        )
+        .await
+        .expect("SSH-form repo_url must resolve to the HTTPS-registered project");
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -78,6 +78,21 @@ pub struct SpawnParams {
     /// additionally gated by [`crate::session_manager::should_inject_task`]
     /// (non-empty task, Claude Code runtime, session reached `Active`).
     pub inject_task: Option<bool>,
+    /// Optional Deliverable id to bind this session to (DOC-35 §10.6, #2379).
+    ///
+    /// Why: `tm sessions new --deliverable <id>` links a session to a
+    /// Deliverable so its status/ls output can surface which unit of work the
+    /// session is advancing (§10.6: 1 Deliverable ↔ many Sessions). Carried as
+    /// the raw stringified id here — the HTTP route (`spawn_session`) is
+    /// responsible for validating the Deliverable exists AND belongs to the
+    /// spawning project BEFORE any provisioning side effect (a 404-style
+    /// [`crate::daemon::error::DaemonError::DeliverableNotFound`] otherwise);
+    /// [`spawn_managed`] trusts that pre-validation and just persists the
+    /// pointer post-creation via
+    /// [`crate::session_manager::SessionManager::set_deliverable_id`]. A
+    /// malformed or absent id is silently a no-op link (`None`) — never a
+    /// reason to fail an otherwise-successful spawn.
+    pub deliverable_id: Option<String>,
 }
 
 /// Spawn a managed session, shared by the HTTP handler and the MCP tool.
@@ -143,15 +158,45 @@ pub async fn spawn_managed(
         params.repo_url.clone(),
         state.event_tx.clone(),
     );
-    // Capture the injection opt-out before `params` is moved into the routed
-    // dispatch. `None`/`Some(true)` → turnkey (inject); `Some(false)` →
+    // Capture the injection opt-out and the (already HTTP-layer-validated)
+    // Deliverable link before `params` is moved into the routed dispatch.
+    // inject_task: `None`/`Some(true)` → turnkey (inject); `Some(false)` →
     // metadata-only (`--no-inject`).
     let inject_flag = params.inject_task != Some(false);
-    let record = crate::core::provisioning_stage::scoped(
+    let deliverable_id = params.deliverable_id.clone();
+    let mut record = crate::core::provisioning_stage::scoped(
         emitter,
         spawn_managed_routed(state, session_id, params, runtime, config),
     )
     .await?;
+
+    // Deliverable linkage (DOC-35 §10.6, #2379): the HTTP route already
+    // validated `deliverable_id` exists and belongs to this project BEFORE
+    // provisioning started, so this is a trusting, non-fatal persist of a
+    // PURE POINTER — never a reason to fail an otherwise-successful spawn,
+    // and never a mutation of the Deliverable itself (§11 forbids
+    // auto-transitions). The local `record` is updated too so the immediate
+    // spawn response already reflects the link, not just later `GET`s.
+    if let Some(raw_id) = deliverable_id {
+        match raw_id.parse::<crate::deliverable::DeliverableId>() {
+            Ok(did) => match state
+                .session_manager()
+                .await
+                .set_deliverable_id(&record.id, did)
+                .await
+            {
+                Ok(()) => record.deliverable_id = Some(did),
+                Err(e) => warn!(
+                    id = %record.id,
+                    "spawn_managed: set_deliverable_id failed: {e}; deliverable link not recorded"
+                ),
+            },
+            Err(e) => warn!(
+                id = %record.id,
+                "spawn_managed: deliverable_id {raw_id:?} failed to re-parse (already validated by the HTTP layer): {e}"
+            ),
+        }
+    }
 
     // Turnkey task injection (#1903 / #1299): once the pane is up and the
     // runtime is ready, deliver the task through the same seam `tm session send`
@@ -1571,6 +1616,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         }
     }
 
@@ -1827,6 +1873,7 @@ mod tests {
             ephemeral: Some(true),
             mcp_initiated: false,
             inject_task: None,
+            deliverable_id: None,
         };
 
         let config = crate::core::trusty_tools_config::TrustyToolsConfig::default();

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -26,6 +26,7 @@ use crate::daemon::state::DaemonState;
 use crate::runtime::RuntimeKind;
 
 pub mod activity;
+mod deliverable_link;
 mod fleet;
 pub mod front_gate;
 pub mod inproject;
@@ -106,6 +107,15 @@ pub struct SpawnRequest {
     /// (the caller delivers the task via `POST .../{id}/send`).
     #[serde(default)]
     pub inject_task: Option<bool>,
+    /// Optional Deliverable id to bind this session to (DOC-35 §10.6, #2379).
+    ///
+    /// Why: `tm sessions new --deliverable <id>` links a fresh session to an
+    /// existing Deliverable so its ledger accumulates the sessions that
+    /// worked on it. Validated at spawn time (must exist AND belong to this
+    /// project) BEFORE any provisioning side effect; an invalid id is a 404,
+    /// never a silently-dropped link. Absent/null → no link (the common case).
+    #[serde(default)]
+    pub deliverable_id: Option<String>,
 }
 
 /// Response body for POST /api/v1/sessions/managed (spawn, 201 Created).
@@ -134,6 +144,10 @@ pub struct SpawnResponse {
     pub attach_cmd: String,
     /// Runtime backend that hosts the session (`"claude-code"` | `"tcode"`).
     pub runtime: String,
+    /// The Deliverable this session is bound to, if `--deliverable` was passed
+    /// (DOC-35 §10.6, #2379). `None` for the common ad-hoc-session case.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deliverable_id: Option<String>,
 }
 
 /// Request body for POST /api/v1/sessions/managed/adopt (#1433).
@@ -254,6 +268,10 @@ pub struct SessionSummary {
     /// landed yet, or for legacy records predating the field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub claude_session_id: Option<String>,
+    /// The Deliverable this session is working on, if bound (DOC-35 §10.6,
+    /// #2379; additive — absent for legacy records and sessions with no link).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deliverable_id: Option<String>,
 }
 
 /// Response body for POST /api/v1/sessions/managed/{id}/decommission.
@@ -418,6 +436,18 @@ pub async fn spawn_session(
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
+    // Deliverable linkage (DOC-35 §10.6, #2379): validate BEFORE any
+    // provisioning side effect, mirroring the runtime-selector pre-check
+    // above — an invalid `--deliverable` must never mint infrastructure for a
+    // link that was never going to be recorded.
+    if let Some(deliverable_id) = req.deliverable_id.as_deref()
+        && let Err(resp) =
+            deliverable_link::validate_deliverable_scope(&state, &req.repo_url, deliverable_id)
+                .await
+    {
+        return resp;
+    }
+
     let params = SpawnParams {
         repo_url: req.repo_url,
         git_ref: req.git_ref,
@@ -431,6 +461,7 @@ pub async fn spawn_session(
         // Turnkey by default (#1903/#1299); a client sets `inject_task: false`
         // to opt into the legacy metadata-only behavior (`--no-inject`).
         inject_task: req.inject_task,
+        deliverable_id: req.deliverable_id,
     };
 
     match spawn_managed(&state, params).await {
@@ -448,6 +479,7 @@ pub async fn spawn_session(
                 created_at: final_record.created_at.to_rfc3339(),
                 attach_cmd: attach_cmd_for(&final_record.tmux_name),
                 runtime: final_record.runtime.as_str().to_owned(),
+                deliverable_id: final_record.deliverable_id.map(|id| id.to_string()),
             };
             (StatusCode::CREATED, Json(resp)).into_response()
         }

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_status/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_status/tests.rs
@@ -47,6 +47,7 @@ fn session(
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -46,6 +46,7 @@ pub fn record_to_json(r: &SessionRecord) -> serde_json::Value {
         "pending_decision": r.pending_decision,
         "proposed_default": r.proposed_default,
         "source_id": r.source_id,
+        "deliverable_id": r.deliverable_id.map(|id| id.to_string()),
     })
 }
 
@@ -74,6 +75,7 @@ pub(super) fn record_to_summary(r: &SessionRecord) -> SessionSummary {
         task: Some(r.task.clone()),
         cwd: Some(r.cwd.to_string_lossy().to_string()),
         claude_session_id: r.claude_session_id.clone(),
+        deliverable_id: r.deliverable_id.map(|id| id.to_string()),
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -36,6 +36,7 @@ fn make_record(source_id: Option<&str>) -> SessionRecord {
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     }
 }
 
@@ -87,6 +88,49 @@ fn serializers_include_source_id() {
     );
 }
 
+/// Why: `record_to_json` (MCP path) and `record_to_summary` (HTTP path) must
+/// both surface `deliverable_id` (DOC-35 §10.6, #2379) so `tm sessions ls`/
+/// `status` and the MCP tools can show which Deliverable a session is bound
+/// to, exactly as they already do for `source_id`.
+/// What: asserts a bound session serializes the stringified id on both paths,
+/// and an unbound session serializes JSON `null` / `None` respectively.
+/// Test: this test.
+#[test]
+fn serializers_include_deliverable_id() {
+    use crate::deliverable::DeliverableId;
+
+    // ── Case 1: deliverable_id is set ─────────────────────────────────────
+    let mut r = make_record(None);
+    let did = DeliverableId::new();
+    r.deliverable_id = Some(did);
+
+    let json = record_to_json(&r);
+    assert_eq!(
+        json["deliverable_id"].as_str(),
+        Some(did.to_string().as_str()),
+        "record_to_json must serialize deliverable_id when present"
+    );
+    let summary = record_to_summary(&r);
+    assert_eq!(
+        summary.deliverable_id.as_deref(),
+        Some(did.to_string().as_str()),
+        "record_to_summary must include deliverable_id when present"
+    );
+
+    // ── Case 2: deliverable_id is None (the common, unbound case) ─────────
+    let r_none = make_record(None);
+    let json_none = record_to_json(&r_none);
+    assert!(
+        json_none["deliverable_id"].is_null(),
+        "record_to_json must serialize deliverable_id as null when absent"
+    );
+    let summary_none = record_to_summary(&r_none);
+    assert_eq!(
+        summary_none.deliverable_id, None,
+        "record_to_summary must carry None deliverable_id when absent"
+    );
+}
+
 /// Verify that `DecommissionResponse.workspace_removed` correctly reflects
 /// workspace ownership rather than being inferred from the post-call filesystem.
 ///
@@ -121,6 +165,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         task: None,
         cwd: None,
         claude_session_id: None,
+        deliverable_id: None,
     };
     let resp_owned = DecommissionResponse {
         summary: owned_summary,
@@ -151,6 +196,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         task: None,
         cwd: None,
         claude_session_id: None,
+        deliverable_id: None,
     };
     let resp_unowned = DecommissionResponse {
         summary: unowned_summary,

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -80,6 +80,9 @@ pub async fn session_new(
         mcp_initiated: true,
         // Turnkey by default (#1903/#1299): an MCP `session_new` spawns to work.
         inject_task: None,
+        // The MCP `session_new` tool does not expose Deliverable linkage
+        // (#2379's CLI surface is `tm sessions new --deliverable`, HTTP-only).
+        deliverable_id: None,
     };
     let record = spawn_managed(state, params).await?;
     Ok(record_to_json(&record))

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -142,6 +142,9 @@ impl SessionControl for DaemonSessionControl {
             mcp_initiated: false,
             // Turnkey by default (#1903/#1299): the SM driver launches to work.
             inject_task: None,
+            // The SM-STDIO adapter does not expose Deliverable linkage
+            // (#2379's CLI surface is `tm sessions new --deliverable`, HTTP-only).
+            deliverable_id: None,
         };
         let record = spawn_managed(&self.state, spawn)
             .await

--- a/crates/trusty-mpm/src/project/registry.rs
+++ b/crates/trusty-mpm/src/project/registry.rs
@@ -216,6 +216,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         }
     }
 
@@ -241,6 +242,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/project/resolver/mod.rs
+++ b/crates/trusty-mpm/src/project/resolver/mod.rs
@@ -338,16 +338,39 @@ pub fn resolve_project(
     })
 }
 
+/// Find the registered project whose `repo_url` matches `repo_url` exactly
+/// (case-insensitive, `.git`-suffix-normalised).
+///
+/// Why: both a live session ([`resolve_session_project`]) and a pre-spawn
+/// request that only carries a bare `repo_url` (the Deliverable-linkage
+/// validation in `daemon::managed_routes::spawn_session`, DOC-35 §10.6,
+/// #2379) need to bind a repo URL to its registry-B project name; extracting
+/// the shared match rule keeps the normalisation logic in exactly one place
+/// rather than duplicating it at the new call site.
+/// What: normalises both sides and returns the first exact match. Per #1532
+/// item 5, when the same `repo_url` is registered under multiple project
+/// names the first match in `projects` order wins.
+/// Test: `resolver_by_repo_url_matches`, `resolver_by_repo_url_no_match`
+/// (`resolve_session_project`'s own tests exercise this transitively).
+pub fn resolve_project_by_repo_url<'a>(
+    repo_url: &str,
+    projects: &'a [Project],
+) -> Option<&'a Project> {
+    let repo_lower = repo_url.to_lowercase();
+    let repo_norm = normalise_url(&repo_lower);
+    projects.iter().find(|p| {
+        let proj_lower = p.repo_url.to_lowercase();
+        normalise_url(&proj_lower) == repo_norm
+    })
+}
+
 /// Bind a live session to its registered project by `repo_url`.
 ///
 /// Why: `SessionRecord` carries `repo_url` but not a project name reference;
 /// this function performs the lookup so fleet grouping and focused-session
 /// routing do not need to replicate the matching logic.
-/// What: returns the first project whose `repo_url` (case-insensitive) equals
-/// the session's `repo_url`. Per #1532 item 5, when the same `repo_url` is
-/// registered under multiple project names the first match in `projects` order
-/// is returned — callers that need determinism should ensure `repo_url`
-/// uniqueness in the registry.
+/// What: delegates to [`resolve_project_by_repo_url`] once the session's
+/// `repo_url` is confirmed present.
 /// Test: `resolver_session_project_binding`, `resolver_session_no_repo`,
 /// `resolver_session_url_tie_break`.
 pub fn resolve_session_project<'a>(
@@ -355,14 +378,7 @@ pub fn resolve_session_project<'a>(
     projects: &'a [Project],
 ) -> Option<&'a Project> {
     let session_url = session.repo_url.as_ref()?;
-    let session_url_lower = session_url.to_lowercase();
-    // Normalise by stripping a trailing ".git" for comparison.
-    let session_norm = normalise_url(&session_url_lower);
-    projects.iter().find(|p| {
-        let proj_lower = p.repo_url.to_lowercase();
-        let proj_norm = normalise_url(&proj_lower);
-        proj_norm == session_norm
-    })
+    resolve_project_by_repo_url(session_url, projects)
 }
 
 /// Group a slice of session records by their bound project.

--- a/crates/trusty-mpm/src/project/resolver/tests.rs
+++ b/crates/trusty-mpm/src/project/resolver/tests.rs
@@ -66,6 +66,7 @@ fn session_with_repo(repo_url: &str) -> SessionRecord {
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     }
 }
 
@@ -91,6 +92,7 @@ fn session_no_repo() -> SessionRecord {
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     }
 }
 
@@ -379,6 +381,28 @@ fn resolver_session_project_binding() {
     let session = session_with_repo("https://github.com/org/trusty-tools");
     let bound = resolve_session_project(&session, &projects).expect("should bind");
     assert_eq!(bound.name, "trusty-tools");
+}
+
+#[test]
+fn resolver_by_repo_url_matches() {
+    // #2379: the pre-spawn Deliverable-linkage validation path binds a bare
+    // `repo_url` (no `SessionRecord` exists yet) the same way a live session
+    // would via `resolve_session_project`.
+    let projects = vec![
+        proj("trusty-tools", "https://github.com/org/trusty-tools"),
+        proj("other", "https://github.com/org/other"),
+    ];
+    let bound = resolve_project_by_repo_url("https://github.com/org/trusty-tools", &projects)
+        .expect("should match");
+    assert_eq!(bound.name, "trusty-tools");
+}
+
+#[test]
+fn resolver_by_repo_url_no_match() {
+    let projects = vec![proj("trusty-tools", "https://github.com/org/trusty-tools")];
+    assert!(
+        resolve_project_by_repo_url("https://github.com/org/unregistered", &projects).is_none()
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -185,6 +185,7 @@ impl SessionManager {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
 
         // ── Atomic already-adopted check + upsert under ONE held write guard ──────
@@ -240,6 +241,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         }
     }
 
@@ -265,6 +267,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/session_manager/backfill_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/backfill_tests.rs
@@ -81,6 +81,7 @@ async fn reconcile_backfills_source_id_from_workspace_git_remote() {
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     };
     mgr.store.write().await.upsert(record).await.expect("seed");
 
@@ -166,6 +167,7 @@ async fn reconcile_backfills_source_id_for_stopped_record() {
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     };
     mgr.store.write().await.upsert(record).await.expect("seed");
 

--- a/crates/trusty-mpm/src/session_manager/create.rs
+++ b/crates/trusty-mpm/src/session_manager/create.rs
@@ -223,6 +223,7 @@ impl SessionManager {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
 
         // Persist the record. On failure the freshly-created tmux session has

--- a/crates/trusty-mpm/src/session_manager/dedup_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup_tests.rs
@@ -71,6 +71,7 @@ fn rec(
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -7,9 +7,11 @@
 //! What: [`SessionManager`] wraps a [`SessionStore`] and a [`ManagedTmuxDriver`]
 //! and provides `create`, `list`, `get`, `send_input`, `stop`,
 //! `mark_runtime_exited_stopped` (non-destructive counterpart to `stop`,
-//! #2023 A), `resume`, `decommission`, and `reconcile_on_boot`.
+//! #2023 A), `resume`, and `decommission`.
 //! `mark_reactivated` (the in-place counterpart to `resume`, #2023 C) lives in
-//! the sibling `reactivate.rs` to keep this file under the 500-SLOC cap.
+//! the sibling `reactivate.rs`, and `reconcile_on_boot` lives in the sibling
+//! `reconcile.rs` (#2379) — both extracted to keep this file under the
+//! 500-SLOC cap.
 //! [`ReconcileReport`] describes what the reconciliation pass found.
 //! [`ManagedError`] is the module's error type.
 //! Test: `manager_create_record`, `manager_stop_keeps_workspace`,
@@ -602,186 +604,6 @@ impl SessionManager {
         Ok(record)
     }
 
-    /// Reconcile daemon state against live tmux sessions after a restart.
-    ///
-    /// Why: the daemon may have crashed or been restarted while sessions were
-    /// running. A persisted record whose tmux session is GONE (e.g. after reboot)
-    /// must become `Stopped` (resumable), NOT a "lost" or "orphaned" session —
-    /// a stopped runtime does NOT mean the session itself is lost.
-    /// What: lists all tmux sessions, filters to managed names (current `tm-`
-    /// or legacy `tmpm-`/`trusty-mpm-`, issue #1955) via
-    /// [`crate::core::names::is_managed_session_name`], cross-references
-    /// against the store: live → `Active`; gone → `Stopped` (unless already
-    /// `Decommissioned`). External managed sessions unknown to the store are
-    /// adopted as `Active`.
-    /// When `auto_resume` is true, all `Stopped` sessions are immediately resumed.
-    /// Test: `manager_reconcile_gone_tmux_yields_stopped`,
-    /// `manager_reconcile_adopts_new_prefix_session`.
-    pub async fn reconcile_on_boot(
-        &self,
-        auto_resume: bool,
-    ) -> Result<ReconcileReport, ManagedError> {
-        let live_names: std::collections::HashSet<String> = self
-            .tmux
-            .list_sessions()
-            .unwrap_or_else(|e| {
-                warn!("reconcile: list_sessions failed: {e}; assuming no live sessions");
-                Vec::new()
-            })
-            .into_iter()
-            .filter(|n| crate::core::names::is_managed_session_name(n))
-            .collect();
-
-        let mut report = ReconcileReport::default();
-        let mut guard = self.store.write().await;
-        let mut all_records = guard.all().await?;
-
-        // Build a set of store-known tmux names.
-        let known_names: std::collections::HashSet<String> =
-            all_records.iter().map(|r| r.tmux_name.clone()).collect();
-
-        // Collect ids of sessions to auto-resume after the write guard is released.
-        let mut to_resume: Vec<ManagedSessionId> = Vec::new();
-
-        // Backfill source_id (#1780) before the loop — one spawn_blocking for
-        // all N null-source_id records instead of N blocking git calls inside
-        // the async loop. Idempotent; failures are silently skipped per record.
-        super::adopt::backfill_source_ids(&mut all_records).await;
-
-        // Reconcile store records against live sessions.
-        for mut record in all_records {
-            // Decommissioned tombstones are never touched by reconciliation.
-            if matches!(record.state, ManagedSessionState::Decommissioned) {
-                continue;
-            }
-
-            if live_names.contains(&record.tmux_name) {
-                // Session is alive — re-adopt as Active.
-                record.state = ManagedSessionState::Active;
-                report.adopted.push(record.tmux_name.clone());
-                info!(name = %record.tmux_name, "reconcile: re-adopted live session");
-            } else {
-                // Session is gone — mark Stopped (resumable), never Orphaned.
-                record.state = ManagedSessionState::Stopped;
-                report.stopped.push(record.id.to_string());
-                warn!(name = %record.tmux_name, "reconcile: tmux session gone, marked Stopped (workspace intact, resumable)");
-                if auto_resume {
-                    to_resume.push(record.id);
-                }
-            }
-            guard.upsert(record).await?;
-        }
-
-        // Adopt tmux sessions the store has never seen. Issue #2158: an
-        // adopted session must never be left as a silent half-record with
-        // cwd/workspace_path permanently stubbed to "/unknown" — re-resolve
-        // the pane's real working directory via `get_pane_cwd` (the same
-        // primitive the idle-auto-stop snapshot uses) so it can be validated
-        // and provisioned like any other managed workspace; a pane whose cwd
-        // cannot be resolved is left CLEARLY flagged as unmanaged in `task`
-        // rather than an indistinguishable-from-normal "adopted session".
-        let mut newly_resolved: Vec<(ManagedSessionId, PathBuf)> = Vec::new();
-        for name in &live_names {
-            if !known_names.contains(name) {
-                let resolved_cwd = self.tmux.get_pane_cwd(name).filter(|p| p.is_dir());
-                let (cwd, workspace_path, task) = match &resolved_cwd {
-                    Some(path) => (
-                        path.clone(),
-                        Some(path.clone()),
-                        "adopted session".to_string(),
-                    ),
-                    None => (
-                        PathBuf::from("/unknown"),
-                        None,
-                        "adopted session (unmanaged — workspace path could not be resolved)"
-                            .to_string(),
-                    ),
-                };
-                let id = ManagedSessionId::new();
-                let external = SessionRecord {
-                    id,
-                    tmux_name: name.clone(),
-                    cwd,
-                    task,
-                    state: ManagedSessionState::Active,
-                    created_at: Utc::now(),
-                    last_activity_at: None,
-                    workspace_path,
-                    repo_url: None,
-                    branch: None,
-                    pending_decision: None,
-                    proposed_default: None,
-                    correlation: Default::default(),
-                    // Externally-created tmux sessions have unknown provenance;
-                    // assume the default (claude-code) backend.
-                    runtime: crate::runtime::RuntimeKind::default(),
-                    // Adopted external sessions are NEVER ephemeral: their
-                    // provenance is unknown, so they must never be auto-reaped.
-                    ephemeral: false,
-                    // Externally-adopted sessions are NEVER SM-owned — the SM
-                    // did not create the workspace; decommission must not delete
-                    // it (#1511).
-                    workspace_owned: false,
-                    // External sessions have no tracked source project.
-                    source_id: None,
-                    claude_session_id: None,
-                    scrollback_path: None,
-                    last_cwd: None,
-                };
-                if let Some(path) = resolved_cwd {
-                    newly_resolved.push((id, path));
-                }
-                guard.upsert(external).await?;
-                report.external_adopted.push(name.clone());
-                info!(name = %name, "reconcile: adopted external managed session");
-            }
-        }
-
-        // Release write guard before auto-resume (which needs its own locks).
-        drop(guard);
-
-        // #2306: collapse stale duplicate records per project. Runs after the
-        // main reconcile persisted states and the write guard was dropped;
-        // decommissions quiesced (no-live-tmux) losers via the safe path and
-        // prunes any of them from the pending auto-resume set. See dedup.rs.
-        self.dedup_stale_duplicates(&mut to_resume).await?;
-
-        // #2158: best-effort validate + auto-repair the deployed `.claude/`
-        // payload for every adopted session whose workspace was resolved
-        // above. Non-fatal — a repair failure only leaves the workspace as-is;
-        // the operator can run `tm validate --path <dir> --repair` manually.
-        for (id, workspace) in newly_resolved {
-            let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&workspace);
-            let outcome = crate::core::deploy_validate::validate_and_repair(&fw, &workspace, None);
-            if outcome.before.is_complete() {
-                continue;
-            }
-            if outcome.is_complete() {
-                info!(id = %id, "reconcile: auto-repaired adopted session's deployment");
-            } else {
-                warn!(
-                    id = %id,
-                    gaps = outcome.after.gaps.len(),
-                    "reconcile: adopted session's deployment remains incomplete after auto-repair"
-                );
-            }
-        }
-
-        if auto_resume && !to_resume.is_empty() {
-            info!(
-                "reconcile: auto_resume=true, resuming {} stopped sessions",
-                to_resume.len()
-            );
-            for sid in to_resume {
-                if let Err(e) = self.resume(&sid).await {
-                    warn!(id = %sid, "reconcile: auto_resume failed: {e}");
-                }
-            }
-        }
-
-        Ok(report)
-    }
-
     /// Return the data directory the store is backed by.
     ///
     /// Why: tests need to inspect the data directory; callers constructing
@@ -1024,6 +846,36 @@ impl SessionManager {
              repairs it from repo_url/workspace_path"
         );
         Err(last_err.unwrap_or_else(|| ManagedError::SessionNotFound(id.to_string())))
+    }
+
+    /// Record which Deliverable a session is working on (DOC-35 §10.6, #2379).
+    ///
+    /// Why: `tm sessions new --deliverable <id>` binds a fresh session to a
+    /// Deliverable AFTER the session record already exists (mirroring
+    /// [`Self::set_source_id`]'s post-creation setter shape, which keeps
+    /// [`Self::create_with_id`]'s already-long parameter list from growing
+    /// further). The caller (the daemon spawn path,
+    /// `daemon::managed_routes::lifecycle`) validates the Deliverable exists
+    /// and belongs to the session's project via `DeliverableManager` BEFORE
+    /// calling this — this setter trusts that validation and does no lookup of
+    /// its own. Per §11, this is a PURE POINTER write: it never mutates the
+    /// Deliverable record itself (no auto-transition of its status).
+    /// What: a plain read-modify-write — look up the record, set
+    /// `deliverable_id`, persist. No retry loop (unlike `set_source_id`):
+    /// losing this link on a rare transient store error is a stale pointer,
+    /// not a session made invisible to a whole filtered listing, so the
+    /// simpler shape matches `set_workspace`/`set_pending_decision`.
+    /// Test: `set_deliverable_id_persists`,
+    /// `set_deliverable_id_missing_session_errors` in `tests.rs`.
+    pub async fn set_deliverable_id(
+        &self,
+        id: &ManagedSessionId,
+        deliverable_id: crate::deliverable::DeliverableId,
+    ) -> Result<(), ManagedError> {
+        let mut record = self.get(id).await?;
+        record.deliverable_id = Some(deliverable_id);
+        self.store.write().await.upsert(record).await?;
+        Ok(())
     }
 
     /// Clear a pending decision WITHOUT injecting any text into the pane.

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -866,7 +866,7 @@ impl SessionManager {
     /// not a session made invisible to a whole filtered listing, so the
     /// simpler shape matches `set_workspace`/`set_pending_decision`.
     /// Test: `set_deliverable_id_persists`,
-    /// `set_deliverable_id_missing_session_errors` in `tests.rs`.
+    /// `set_deliverable_id_missing_session_errors` in `set_deliverable_id_tests.rs`.
     pub async fn set_deliverable_id(
         &self,
         id: &ManagedSessionId,

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -19,6 +19,7 @@ pub mod manager;
 pub mod naming;
 pub mod prune;
 pub mod reactivate;
+mod reconcile;
 pub mod record;
 pub mod restart_ops;
 mod resume_workdir;
@@ -61,6 +62,9 @@ mod resume_reattach_tests;
 
 #[cfg(test)]
 mod set_source_id_tests;
+
+#[cfg(test)]
+mod set_deliverable_id_tests;
 
 #[cfg(test)]
 mod dedup_tests;

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -861,6 +861,7 @@ mod orphan_tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
         mgr.store
             .write()

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -1,0 +1,207 @@
+//! Boot-time reconciliation of daemon state against live tmux sessions.
+//!
+//! Why: `reconcile_on_boot` grew large enough that leaving it inline pushed
+//! `manager.rs` over its 500-SLOC production cap (a #2379 field addition —
+//! `SessionRecord::deliverable_id` — was the field that tipped it over).
+//! Extracting it here follows the exact precedent `create.rs`/`reactivate.rs`/
+//! `hook_sync.rs` already established for this file: a single, cohesive
+//! method moves to its own sibling module rather than the cap being gamed or
+//! raised. No behavior changes — this is a pure relocation.
+//! What: [`SessionManager::reconcile_on_boot`] lists live tmux sessions,
+//! cross-references them against the persisted store (live → `Active`, gone →
+//! `Stopped`, unknown-to-the-store → adopted as an external `Active` record),
+//! and optionally auto-resumes every session it marked `Stopped`.
+//! Test: `manager_reconcile_gone_tmux_yields_stopped`,
+//! `manager_reconcile_adopts_new_prefix_session` in `tests.rs`.
+
+use std::path::PathBuf;
+
+use chrono::Utc;
+use tracing::{info, warn};
+
+use super::manager::{ManagedError, ReconcileReport, SessionManager};
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+impl SessionManager {
+    /// Reconcile daemon state against live tmux sessions after a restart.
+    ///
+    /// Why: the daemon may have crashed or been restarted while sessions were
+    /// running. A persisted record whose tmux session is GONE (e.g. after reboot)
+    /// must become `Stopped` (resumable), NOT a "lost" or "orphaned" session —
+    /// a stopped runtime does NOT mean the session itself is lost.
+    /// What: lists all tmux sessions, filters to managed names (current `tm-`
+    /// or legacy `tmpm-`/`trusty-mpm-`, issue #1955) via
+    /// [`crate::core::names::is_managed_session_name`], cross-references
+    /// against the store: live → `Active`; gone → `Stopped` (unless already
+    /// `Decommissioned`). External managed sessions unknown to the store are
+    /// adopted as `Active`.
+    /// When `auto_resume` is true, all `Stopped` sessions are immediately resumed.
+    /// Test: `manager_reconcile_gone_tmux_yields_stopped`,
+    /// `manager_reconcile_adopts_new_prefix_session`.
+    pub async fn reconcile_on_boot(
+        &self,
+        auto_resume: bool,
+    ) -> Result<ReconcileReport, ManagedError> {
+        let live_names: std::collections::HashSet<String> = self
+            .tmux
+            .list_sessions()
+            .unwrap_or_else(|e| {
+                warn!("reconcile: list_sessions failed: {e}; assuming no live sessions");
+                Vec::new()
+            })
+            .into_iter()
+            .filter(|n| crate::core::names::is_managed_session_name(n))
+            .collect();
+
+        let mut report = ReconcileReport::default();
+        let mut guard = self.store.write().await;
+        let mut all_records = guard.all().await?;
+
+        // Build a set of store-known tmux names.
+        let known_names: std::collections::HashSet<String> =
+            all_records.iter().map(|r| r.tmux_name.clone()).collect();
+
+        // Collect ids of sessions to auto-resume after the write guard is released.
+        let mut to_resume: Vec<ManagedSessionId> = Vec::new();
+
+        // Backfill source_id (#1780) before the loop — one spawn_blocking for
+        // all N null-source_id records instead of N blocking git calls inside
+        // the async loop. Idempotent; failures are silently skipped per record.
+        super::adopt::backfill_source_ids(&mut all_records).await;
+
+        // Reconcile store records against live sessions.
+        for mut record in all_records {
+            // Decommissioned tombstones are never touched by reconciliation.
+            if matches!(record.state, ManagedSessionState::Decommissioned) {
+                continue;
+            }
+
+            if live_names.contains(&record.tmux_name) {
+                // Session is alive — re-adopt as Active.
+                record.state = ManagedSessionState::Active;
+                report.adopted.push(record.tmux_name.clone());
+                info!(name = %record.tmux_name, "reconcile: re-adopted live session");
+            } else {
+                // Session is gone — mark Stopped (resumable), never Orphaned.
+                record.state = ManagedSessionState::Stopped;
+                report.stopped.push(record.id.to_string());
+                warn!(name = %record.tmux_name, "reconcile: tmux session gone, marked Stopped (workspace intact, resumable)");
+                if auto_resume {
+                    to_resume.push(record.id);
+                }
+            }
+            guard.upsert(record).await?;
+        }
+
+        // Adopt tmux sessions the store has never seen. Issue #2158: an
+        // adopted session must never be left as a silent half-record with
+        // cwd/workspace_path permanently stubbed to "/unknown" — re-resolve
+        // the pane's real working directory via `get_pane_cwd` (the same
+        // primitive the idle-auto-stop snapshot uses) so it can be validated
+        // and provisioned like any other managed workspace; a pane whose cwd
+        // cannot be resolved is left CLEARLY flagged as unmanaged in `task`
+        // rather than an indistinguishable-from-normal "adopted session".
+        let mut newly_resolved: Vec<(ManagedSessionId, PathBuf)> = Vec::new();
+        for name in &live_names {
+            if !known_names.contains(name) {
+                let resolved_cwd = self.tmux.get_pane_cwd(name).filter(|p| p.is_dir());
+                let (cwd, workspace_path, task) = match &resolved_cwd {
+                    Some(path) => (
+                        path.clone(),
+                        Some(path.clone()),
+                        "adopted session".to_string(),
+                    ),
+                    None => (
+                        PathBuf::from("/unknown"),
+                        None,
+                        "adopted session (unmanaged — workspace path could not be resolved)"
+                            .to_string(),
+                    ),
+                };
+                let id = ManagedSessionId::new();
+                let external = SessionRecord {
+                    id,
+                    tmux_name: name.clone(),
+                    cwd,
+                    task,
+                    state: ManagedSessionState::Active,
+                    created_at: Utc::now(),
+                    last_activity_at: None,
+                    workspace_path,
+                    repo_url: None,
+                    branch: None,
+                    pending_decision: None,
+                    proposed_default: None,
+                    correlation: Default::default(),
+                    // Externally-created tmux sessions have unknown provenance;
+                    // assume the default (claude-code) backend.
+                    runtime: crate::runtime::RuntimeKind::default(),
+                    // Adopted external sessions are NEVER ephemeral: their
+                    // provenance is unknown, so they must never be auto-reaped.
+                    ephemeral: false,
+                    // Externally-adopted sessions are NEVER SM-owned — the SM
+                    // did not create the workspace; decommission must not delete
+                    // it (#1511).
+                    workspace_owned: false,
+                    // External sessions have no tracked source project.
+                    source_id: None,
+                    claude_session_id: None,
+                    scrollback_path: None,
+                    last_cwd: None,
+                    // External sessions have no known Deliverable linkage.
+                    deliverable_id: None,
+                };
+                if let Some(path) = resolved_cwd {
+                    newly_resolved.push((id, path));
+                }
+                guard.upsert(external).await?;
+                report.external_adopted.push(name.clone());
+                info!(name = %name, "reconcile: adopted external managed session");
+            }
+        }
+
+        // Release write guard before auto-resume (which needs its own locks).
+        drop(guard);
+
+        // #2306: collapse stale duplicate records per project. Runs after the
+        // main reconcile persisted states and the write guard was dropped;
+        // decommissions quiesced (no-live-tmux) losers via the safe path and
+        // prunes any of them from the pending auto-resume set. See dedup.rs.
+        self.dedup_stale_duplicates(&mut to_resume).await?;
+
+        // #2158: best-effort validate + auto-repair the deployed `.claude/`
+        // payload for every adopted session whose workspace was resolved
+        // above. Non-fatal — a repair failure only leaves the workspace as-is;
+        // the operator can run `tm validate --path <dir> --repair` manually.
+        for (id, workspace) in newly_resolved {
+            let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&workspace);
+            let outcome = crate::core::deploy_validate::validate_and_repair(&fw, &workspace, None);
+            if outcome.before.is_complete() {
+                continue;
+            }
+            if outcome.is_complete() {
+                info!(id = %id, "reconcile: auto-repaired adopted session's deployment");
+            } else {
+                warn!(
+                    id = %id,
+                    gaps = outcome.after.gaps.len(),
+                    "reconcile: adopted session's deployment remains incomplete after auto-repair"
+                );
+            }
+        }
+
+        if auto_resume && !to_resume.is_empty() {
+            info!(
+                "reconcile: auto_resume=true, resuming {} stopped sessions",
+                to_resume.len()
+            );
+            for sid in to_resume {
+                if let Err(e) = self.resume(&sid).await {
+                    warn!(id = %sid, "reconcile: auto_resume failed: {e}");
+                }
+            }
+        }
+
+        Ok(report)
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -265,6 +265,23 @@ pub struct SessionRecord {
     /// they resume from `workspace_path` / `cwd` as before.
     #[serde(default)]
     pub last_cwd: Option<PathBuf>,
+
+    /// Which Deliverable this session is working on (DOC-35 §10.6, #2379).
+    ///
+    /// Why: 1 Deliverable ↔ many Sessions (DOC-30 Decision #7, carried forward
+    /// unchanged) — a session works on at most ONE Deliverable at a time;
+    /// `None` is the common case for ad-hoc sessions not tracked against a
+    /// Deliverable. This is a PURE POINTER: linking a session to a Deliverable
+    /// never auto-transitions the Deliverable's status (§11 forbids
+    /// auto-transitions — only an explicit `set-status` call, #2380, mutates
+    /// it) and decommissioning the session never auto-unlinks the pointer —
+    /// a tombstoned session still records which Deliverable it worked on.
+    ///
+    /// `#[serde(default)]` keeps every pre-#2379 record deserializable — they
+    /// load with `deliverable_id = None`, which is correct: no session before
+    /// this field existed was ever bound to a Deliverable.
+    #[serde(default)]
+    pub deliverable_id: Option<crate::deliverable::DeliverableId>,
 }
 
 /// Error types for session record operations.
@@ -331,6 +348,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -364,6 +382,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -395,6 +414,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -451,6 +471,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
         record.runtime = crate::runtime::RuntimeKind::Tcode;
         let json = serde_json::to_string(&record).expect("serialize");
@@ -511,6 +532,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -601,6 +623,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: Some(PathBuf::from("/managed/ws/.trusty-mpm/scrollback.txt")),
             last_cwd: Some(PathBuf::from("/managed/ws/src")),
+            deliverable_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -636,9 +659,74 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
         assert!(back.workspace_owned, "workspace_owned=true must round-trip");
+    }
+
+    #[test]
+    fn record_without_deliverable_id_field_defaults_to_none() {
+        // Why (#2379): every record persisted before this field existed has no
+        // `deliverable_id` key; it MUST deserialize as `None` (unbound) — no
+        // session created before the Deliverable layer existed was ever bound
+        // to one. This pins the `#[serde(default)]` back-compat contract that
+        // lets an old store load cleanly under the new binary, and (by the
+        // same additive-field contract) lets an OLD binary reading a NEWER
+        // store simply ignore the extra key it does not know about.
+        let legacy_json = serde_json::json!({
+            "id": ManagedSessionId::new(),
+            "tmux_name": "tmpm-legacy",
+            "cwd": "/tmp",
+            "task": "legacy task",
+            "state": "active",
+            "created_at": Utc::now().to_rfc3339(),
+            "last_activity_at": null,
+            "workspace_path": null,
+            "repo_url": null,
+            "branch": null,
+            "pending_decision": null,
+            "proposed_default": null
+        })
+        .to_string();
+        let back: SessionRecord = serde_json::from_str(&legacy_json).expect("deserialize legacy");
+        assert!(
+            back.deliverable_id.is_none(),
+            "a record with no `deliverable_id` key must default to None (unbound)"
+        );
+    }
+
+    #[test]
+    fn record_round_trips_deliverable_id() {
+        // Why (#2379): a session bound via `tm sessions new --deliverable <id>`
+        // must persist the link so `resume`/`ls`/`status` all see it.
+        let did = crate::deliverable::DeliverableId::new();
+        let record = SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: "tmpm-bound".into(),
+            cwd: PathBuf::from("/tmp"),
+            task: "implement WI-13".into(),
+            state: ManagedSessionState::Active,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: None,
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: false,
+            workspace_owned: false,
+            source_id: None,
+            claude_session_id: None,
+            scrollback_path: None,
+            last_cwd: None,
+            deliverable_id: Some(did),
+        };
+        let json = serde_json::to_string(&record).expect("serialize");
+        let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.deliverable_id, Some(did));
     }
 }

--- a/crates/trusty-mpm/src/session_manager/resume_workdir.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_workdir.rs
@@ -177,6 +177,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd,
+            deliverable_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/session_manager/set_deliverable_id_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/set_deliverable_id_tests.rs
@@ -1,0 +1,58 @@
+//! Unit tests for `SessionManager::set_deliverable_id` (DOC-35 §10.6, #2379).
+//!
+//! Why: split out of `tests.rs` rather than grown further, mirroring the
+//! established `set_source_id_tests.rs`/`restart_tests.rs`/`reactivate_tests.rs`
+//! sibling-test-file pattern.
+//! What: the happy path (persists and round-trips through `get`) and the
+//! missing-session path (a typed `SessionNotFound`, not a panic or silent no-op).
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use super::manager::ManagedError;
+use super::record::ManagedSessionId;
+use super::tests::make_manager;
+use crate::deliverable::DeliverableId;
+
+#[tokio::test]
+async fn set_deliverable_id_persists() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/wt")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+
+    let did = DeliverableId::new();
+    mgr.set_deliverable_id(&record.id, did)
+        .await
+        .expect("set_deliverable_id");
+
+    let reloaded = mgr.get(&record.id).await.expect("get after set");
+    assert_eq!(reloaded.deliverable_id, Some(did));
+}
+
+#[tokio::test]
+async fn set_deliverable_id_missing_session_errors() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let unknown_id = ManagedSessionId::new();
+
+    let result = mgr
+        .set_deliverable_id(&unknown_id, DeliverableId::new())
+        .await;
+    assert!(
+        matches!(result, Err(ManagedError::SessionNotFound(_))),
+        "expected SessionNotFound for a session that does not exist, got {result:?}"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/snapshot.rs
+++ b/crates/trusty-mpm/src/session_manager/snapshot.rs
@@ -238,6 +238,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/session_manager/store.rs
+++ b/crates/trusty-mpm/src/session_manager/store.rs
@@ -370,6 +370,7 @@ mod tests {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -587,6 +587,7 @@ fn make_active_test_record(tmux_name: &str, task: &str, ws_path: &str) -> Sessio
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     }
 }
 
@@ -680,6 +681,7 @@ async fn manager_reconcile_skips_decommissioned() {
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     };
     {
         let mut store = mgr.store.write().await;
@@ -1422,6 +1424,7 @@ pub(super) async fn seed_record(
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     };
     if seeds_live_tmux {
         mgr.tmux
@@ -1856,6 +1859,7 @@ async fn reap_aged_ephemeral_picks_old_ephemeral_only() {
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
         mgr.store.write().await.upsert(record).await.expect("seed");
     }
@@ -1941,6 +1945,7 @@ async fn manager_decommission_unowned_skips_deletion() {
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     };
     mgr.store.write().await.upsert(record).await.unwrap();
 

--- a/crates/trusty-mpm/src/slack/commands.rs
+++ b/crates/trusty-mpm/src/slack/commands.rs
@@ -211,6 +211,8 @@ impl From<SlackCommand> for TrustyCommand {
                     name_hint: None,
                     runtime: None,
                     inject_task: None,
+                    // Slack `/launch` has no `--deliverable` surface (#2379).
+                    deliverable_id: None,
                 }
             }
             SlackCommand::Fleet => TrustyCommand::ManagedList,
@@ -383,6 +385,7 @@ mod tests {
                 name_hint: None,
                 runtime: None,
                 inject_task: None,
+                deliverable_id: None,
             }
         );
     }

--- a/crates/trusty-mpm/src/supervisor/tests.rs
+++ b/crates/trusty-mpm/src/supervisor/tests.rs
@@ -178,6 +178,7 @@ async fn seed_sessions(
             claude_session_id: None,
             scrollback_path: None,
             last_cwd: None,
+            deliverable_id: None,
         };
         store.upsert(rec).await.expect("seed upsert");
         ids.push(id);
@@ -309,6 +310,7 @@ fn rec(state: ManagedSessionState, pending: Option<&str>) -> SessionRecord {
         claude_session_id: None,
         scrollback_path: None,
         last_cwd: None,
+        deliverable_id: None,
     }
 }
 

--- a/crates/trusty-mpm/src/telegram/commands.rs
+++ b/crates/trusty-mpm/src/telegram/commands.rs
@@ -174,6 +174,8 @@ impl From<TelegramCommand> for TrustyCommand {
                     name_hint: None,
                     runtime: None,
                     inject_task: None,
+                    // Telegram `/launch` has no `--deliverable` surface (#2379).
+                    deliverable_id: None,
                 }
             }
             TelegramCommand::Fleet => TrustyCommand::ManagedFleet,
@@ -426,6 +428,7 @@ mod tests {
                 name_hint: None,
                 runtime: None,
                 inject_task: None,
+                deliverable_id: None,
             }
         );
     }

--- a/crates/trusty-mpm/src/tui/coordinator/dispatch.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/dispatch.rs
@@ -217,6 +217,9 @@ fn route_new(args: &str) -> Dispatch {
         name_hint: None,
         runtime: None,
         inject_task: None,
+        // The TUI `/new` chat command has no `--deliverable` surface (#2379;
+        // TUI Deliverable affordances are #2383's scope).
+        deliverable_id: None,
     })
 }
 

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -1313,6 +1313,7 @@ fn route_new_builds_managed_new() {
             name_hint: None,
             runtime: None,
             inject_task: None,
+            deliverable_id: None,
         })
     );
 }

--- a/crates/trusty-mpm/tests/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/tests/mcp_spawn_gate.rs
@@ -76,6 +76,7 @@ fn base_params(repo_url: &str, mcp_initiated: bool) -> SpawnParams {
         ephemeral: Some(true),
         mcp_initiated,
         inject_task: None,
+        deliverable_id: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Implements WI-13 (DOC-35 §10.6) — the Session <-> Deliverable binding: a
1-Deliverable-to-many-Sessions pointer, plus the `--deliverable` launch flag
that sets it at spawn time.

- **`SessionRecord.deliverable_id: Option<DeliverableId>`** — additive,
  `#[serde(default)]`. Old records (and an old binary reading a newer store)
  load unaffected.
- **`tm sessions new --deliverable <id>`** — threaded end-to-end through the
  exact additive wire pattern #2361 established for `inject_task`:
  `SessionAction::New` -> `TrustyCommand::ManagedNew` -> `ManagedSpawnRequest`
  (client) -> `SpawnRequest`/`SpawnParams` (daemon), each hop `Option<String>`,
  omitted when absent.
- **Validation** (`daemon::managed_routes::deliverable_link`) runs BEFORE any
  provisioning side effect: resolves the spawning project from `repo_url` via
  a new `project::resolver::resolve_project_by_repo_url` helper, then reuses
  `deliverable_routes::fetch_scoped` (now `pub(crate)`) — the exact
  existence+project-scope check the Deliverable CRUD routes (#2378) already
  enforce, so this can never drift from "belongs to this project" there. An
  unknown or cross-project id is a structured 404
  (`DaemonError::DeliverableNotFound`), never silently dropped.
- **No auto-anything** (per §11): linking never transitions the Deliverable's
  status; decommissioning a session never unlinks the pointer — it's history.
- **Surfaced additively** in `SessionSummary` / `record_to_json` /
  `record_to_summary` / `SpawnResponse` (the `tm sessions ls`/`status`/MCP
  paths that already serialize the record).
- **`SessionManager::set_deliverable_id`** — a plain post-creation setter
  mirroring `set_source_id`'s shape (keeps `create_with_id`'s already-long
  parameter list from growing further), called by the daemon spawn path once
  validation passes.
- **Side quest**: the new field's mandatory entry in `manager.rs`'s "adopt
  external session" literal tipped that file from 500 to 501 SLOC. Extracted
  `reconcile_on_boot` into a new sibling `reconcile.rs` — the same split this
  file already documents using for `create.rs`/`reactivate.rs`/`hook_sync.rs`.
  Pure relocation, zero behavior change.

## Field / wire shapes

```rust
// session_manager/record.rs
pub deliverable_id: Option<crate::deliverable::DeliverableId>,  // #[serde(default)]

// daemon/managed_routes/mod.rs (HTTP wire)
pub deliverable_id: Option<String>,  // #[serde(default)] on SpawnRequest
                                       // #[serde(default, skip_serializing_if)] on SessionSummary/SpawnResponse

// daemon/managed_routes/lifecycle.rs
pub deliverable_id: Option<String>,  // SpawnParams (plain, in-process)

// client/http_client/types.rs (outbound client wire)
pub deliverable_id: Option<String>,  // #[serde(skip_serializing_if = "Option::is_none")]

// client/command.rs
deliverable_id: Option<String>,  // TrustyCommand::ManagedNew

// bin/tm/cli.rs
#[arg(long)]
deliverable: Option<String>,  // SessionAction::New
```

## Validation behavior

`POST /api/v1/sessions/managed` with `deliverable_id` set:
1. No project registered for `repo_url` -> `404 DeliverableNotFound`.
2. Project resolved, but the id doesn't exist -> `404`.
3. Id exists but belongs to a different project -> `404` (never leaks).
4. Id exists and belongs to the resolved project -> spawn proceeds, and
   `SessionManager::set_deliverable_id` persists the pointer post-creation.

## Files changed (highlights)

- `crates/trusty-mpm/src/session_manager/record.rs` — the field + serde
  back-compat/round-trip tests.
- `crates/trusty-mpm/src/session_manager/manager.rs` — `set_deliverable_id`.
- `crates/trusty-mpm/src/session_manager/reconcile.rs` — **new**, extracted
  `reconcile_on_boot` (SLOC-cap split, see above).
- `crates/trusty-mpm/src/session_manager/set_deliverable_id_tests.rs` —
  **new**, mirrors `set_source_id_tests.rs`.
- `crates/trusty-mpm/src/daemon/managed_routes/deliverable_link.rs` — **new**,
  the pre-spawn validation gate + its own test module.
- `crates/trusty-mpm/src/daemon/managed_routes/{mod,lifecycle,summary}.rs` —
  wire fields + wiring + serializer updates.
- `crates/trusty-mpm/src/daemon/api/deliverable_routes.rs` — `fetch_scoped`
  visibility bump to `pub(crate)` (reused by the new gate).
- `crates/trusty-mpm/src/project/resolver/mod.rs` — new
  `resolve_project_by_repo_url` helper (`resolve_session_project` now
  delegates to it).
- `crates/trusty-mpm/src/client/{command,executor/*,http_client/*}.rs` — the
  client-side wire threading.
- `crates/trusty-mpm/src/bin/tm/{cli,commands/managed_route,commands/session/start}.rs`
  — the `--deliverable` flag + its CLI-to-command mapping.
- Every other modified file is a mechanical `SessionRecord`/`SpawnParams`/
  `TrustyCommand::ManagedNew`/`SessionSummary` literal-completion fix required
  by the new field (telegram/slack/tui adapters, test helpers across
  `session_manager/*`, `project/registry.rs`, `mcp_session.rs`,
  `sm_stdio/control.rs`) — no unrelated refactors.

## Gate output (raw)

`cargo build --workspace` — clean build, all crates compile.

`cargo test -p trusty-mpm` (lib): `2721 passed; 0 failed; 5 ignored`
`cargo test -p trusty-mpm --all-targets`: every integration-test binary
reports `0 failed` (`tests_behavior_d` includes the new
`cli_parses_session_new_with_deliverable`).

`cargo test --workspace`: every crate reports `0 failed`.

`cargo clippy -p trusty-mpm --all-targets -- -D warnings`: exit 0.
`cargo clippy --workspace --all-targets -- -D warnings`: exit 0.

`cargo fmt --check`: exit 0.

`bash scripts/check_line_cap.sh`: `line-cap: 0 allowlisted, 0 violations — OK.`

(One pre-existing, unrelated flaky test —
`core::standalone::trust_seed::tests::test_preseed_managed_trust_no_home_write`
— failed once under full-suite parallelism and passed cleanly on every
isolated/rerun; confirmed via `git stash` that it reproduces on unmodified
`origin/main` too, so it is not a regression from this change.)

## Test plan

- [x] `record_without_deliverable_id_field_defaults_to_none` /
      `record_round_trips_deliverable_id` (serde back-compat + round-trip)
- [x] `managed_spawn_request_serializes` extended: `deliverable_id` omitted
      when `None`, serialized when `Some` (wire-shape, mirrors `inject_task`)
- [x] `validate_deliverable_scope_{unknown_project,unknown_deliverable,wrong_project}_is_404`
      / `_valid_id_passes`
- [x] `set_deliverable_id_persists` / `set_deliverable_id_missing_session_errors`
- [x] `to_command_new_deliverable_maps_to_deliverable_id`,
      `cli_parses_session_new_with_deliverable`
- [x] `serializers_include_deliverable_id` (record_to_json/record_to_summary)

Closes #2379

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools