### PR TITLE
chore(trusty-review): v0.8.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11055,7 +11055,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.15.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.8.0" }
+trusty-review = { path = "crates/trusty-review", version = "0.8.1" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [0.8.1] — 2026-07-11
+
+### Fixed
+
+- Top Risks table in both bundled templates (`report-technical-dd.md`, `report-technical-dd-cast.md`) hardcapped a fixed number of risk rows (3 generic / 5 CAST), silently dropping synthesized rows 4-5 despite them being present in the JSON twin and within the schema's 5-row max (closes #2373). Converted to a repeatable `BEGIN`/`END` block (same pattern as findings/benchmark rows), rendering one row per synthesized risk with sequential numbering and provenance tags; empty case collapses via omit-empty. ([#2430](https://github.com/bobmatnyc/trusty-tools/pull/2430)) ([`7d844b7`](https://github.com/bobmatnyc/trusty-tools/commit/7d844b7af4a52ed244d5c61c4ed30424c1b2c5f4))
+
+### Changed
+
+- Root workspace `[workspace.dependencies]` pin for `trusty-review` bumped 0.8.0 → 0.8.1 (consumed by `trusty-analyze`'s optional `review` feature).
+
 ## [0.8.0] — 2026-07-10
 
 ### Added

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.8.0"
+version     = "0.8.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
## Summary
- Patch release trusty-review 0.8.0 → 0.8.1
- Carries the #2373 fix (merged via #2430): Top Risks table in both bundled templates now renders all synthesized rows via a repeatable BEGIN/END block instead of hardcapping at 3/5 rows
- Root workspace `[workspace.dependencies]` pin for `trusty-review` bumped 0.8.0 → 0.8.1 (consumed by `trusty-analyze`'s optional `review` feature)
- CHANGELOG.md updated with the 0.8.1 Fixed/Changed entries

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test -p trusty-review` — 1321 passed; 0 failed; 4 ignored
- [x] `cargo check --workspace` — clean

Closes #2373 (via #2430, already merged to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)