### PR TITLE
fix(trusty-mpm): force_new opt-out so the picker's "launch new session" never adopts a live session (closes #2450)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided_launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_launch.rs
@@ -127,6 +127,11 @@ pub(crate) async fn launch_new_session_and_attach(
             "repo_url": repo_url,
             "ref": "HEAD",
             "task": "",
+            // #2450: this is the picker's EXPLICIT "launch new session" choice —
+            // force a fresh session so the daemon's in-project reconnect
+            // pre-flight (#1707) never adopts an unrelated live session for the
+            // same project (which would inject this launch into it).
+            "force_new": true,
         }))
         .send()
         .await;

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
@@ -74,6 +74,15 @@ pub(crate) fn to_command(action: &SessionAction) -> Option<TrustyCommand> {
             // `--deliverable <id>` (DOC-35 §10.6, #2379): omitted entirely when
             // absent, same additive wire pattern as `inject_task` above.
             deliverable_id: deliverable.clone(),
+            // #2450: the explicit `new`/`start` verb means "launch a NEW
+            // session" — force it so the daemon's in-project reconnect
+            // pre-flight (#1707) never adopts an existing live session for the
+            // same project (and injects this task into it). `session start`
+            // builds the same New action and is deliberately kept identical
+            // (#1916), so it forces new too; programmatic surfaces (MCP,
+            // SM-STDIO, chat, TUI) keep the reconnect by setting
+            // `force_new: false` at their own construction sites.
+            force_new: true,
         },
         SessionAction::Ls { .. } => TrustyCommand::ManagedList,
         SessionAction::Send { id, text } => TrustyCommand::ManagedSend {
@@ -258,6 +267,7 @@ mod tests {
                 runtime,
                 inject_task,
                 deliverable_id,
+                force_new,
             }) => {
                 assert_eq!(repo_url, "https://example/r.git");
                 assert_eq!(git_ref, "main");
@@ -269,6 +279,9 @@ mod tests {
                 assert_eq!(inject_task, None);
                 // Default (no `--deliverable`) → no link (#2379).
                 assert_eq!(deliverable_id, None);
+                // #2450: the explicit `new` verb forces a fresh session (never
+                // adopts an existing live one for the same project).
+                assert!(force_new, "session new must force a fresh session");
             }
             other => panic!("expected ManagedNew, got {other:?}"),
         }

--- a/crates/trusty-mpm/src/bin/tm/commands/session/start_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start_tests.rs
@@ -275,11 +275,16 @@ async fn session_start_posts_the_same_wire_shape_bare_tm_guided_default_sends() 
     // default omits it and lets the daemon default — semantically identical
     // (both resolve to `claude-code`), just spelled differently on the wire,
     // so it is asserted separately below rather than folded into `expected`.
+    // #2450: both `session start` (this request) and the picker's "launch new
+    // session" (`launch_new_session_and_attach`) now send `force_new: true` —
+    // an explicit launch verb must never adopt an existing live session for the
+    // same project. The two surfaces stay identical on this field too (#1916).
     let expected = serde_json::json!({
         "repo_url": repo.to_string_lossy(),
         "ref": "HEAD",
         "task": "",
         "runtime": "claude-code",
+        "force_new": true,
     });
     assert_eq!(
         body, expected,

--- a/crates/trusty-mpm/src/client/command.rs
+++ b/crates/trusty-mpm/src/client/command.rs
@@ -175,6 +175,11 @@ pub enum TrustyCommand {
         /// Optional Deliverable id to bind this session to (`--deliverable`,
         /// DOC-35 §10.6, #2379). `None` → no link, the common case.
         deliverable_id: Option<String>,
+        /// Force-new control (#2450): `true` → skip the daemon's in-project
+        /// reconnect pre-flight and always spawn a FRESH session (the explicit
+        /// `tm session new`/`session start` verbs); `false` → the reconnect
+        /// default (#1707), so chat/TUI surfaces adopt an existing live session.
+        force_new: bool,
     },
     /// List every managed session (`sessions.list`).
     ManagedList,
@@ -312,6 +317,7 @@ mod tests {
             runtime: Some("tcode".into()),
             inject_task: None,
             deliverable_id: None,
+            force_new: false,
         };
         assert_eq!(spawn.clone(), spawn);
         let answer = TrustyCommand::ManagedAnswer {

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -55,6 +55,7 @@ impl CommandExecutor {
         runtime: Option<String>,
         inject_task: Option<bool>,
         deliverable_id: Option<String>,
+        force_new: bool,
     ) -> CommandResult {
         let req = ManagedSpawnRequest {
             repo_url,
@@ -64,6 +65,7 @@ impl CommandExecutor {
             runtime,
             inject_task,
             deliverable_id,
+            force_new,
         };
         match self.client().spawn_managed_session(&req).await {
             Ok(resp) => CommandResult::ManagedSpawned {

--- a/crates/trusty-mpm/src/client/executor/mod.rs
+++ b/crates/trusty-mpm/src/client/executor/mod.rs
@@ -135,6 +135,7 @@ impl CommandExecutor {
                 runtime,
                 inject_task,
                 deliverable_id,
+                force_new,
             } => {
                 self.managed_new(
                     repo_url,
@@ -144,6 +145,7 @@ impl CommandExecutor {
                     runtime,
                     inject_task,
                     deliverable_id,
+                    force_new,
                 )
                 .await
             }

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -406,6 +406,7 @@ fn managed_spawn_request_serializes() {
         runtime: Some("tcode".to_string()),
         inject_task: None,
         deliverable_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
+        force_new: false,
     };
     let v = serde_json::to_value(&req).unwrap();
     assert_eq!(v["ref"], "main");
@@ -426,6 +427,7 @@ fn managed_spawn_request_serializes() {
         runtime: None,
         inject_task: None,
         deliverable_id: None,
+        force_new: false,
     };
     let v = serde_json::to_value(&bare).unwrap();
     assert!(v.get("name_hint").is_none(), "None name_hint is omitted");
@@ -437,6 +439,10 @@ fn managed_spawn_request_serializes() {
     assert!(
         v.get("deliverable_id").is_none(),
         "None deliverable_id is omitted (#2379, same additive pattern as inject_task)"
+    );
+    assert!(
+        v.get("force_new").is_none(),
+        "false force_new is omitted (#2450) so the wire matches the pre-existing shape"
     );
 }
 

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -471,6 +471,26 @@ pub struct ManagedSpawnRequest {
     /// `inject_task` established in #2361).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deliverable_id: Option<String>,
+    /// Force-new control (#2450): `true` requests a FRESH session even when a
+    /// live in-project session for the same project exists (the explicit `tm
+    /// session new`/`session start` verbs). Omitted from the wire when `false`
+    /// so the daemon's `#[serde(default)]` reconnect default (#1707) applies —
+    /// keeping the request byte-identical to the pre-#2450 shape for every
+    /// non-forcing caller.
+    #[serde(skip_serializing_if = "is_false")]
+    pub force_new: bool,
+}
+
+/// Whether a bool is `false` — the `skip_serializing_if` predicate that omits a
+/// defaulted `force_new` from the spawn request wire (#2450).
+///
+/// Why: `serde`'s `skip_serializing_if` needs a `fn(&T) -> bool`; there is no
+/// built-in for "skip when false" (`std::ops::Not::not` takes `bool` by value,
+/// not `&bool`), so this tiny predicate provides it.
+/// What: returns `!*v`.
+/// Test: exercised by `managed_spawn_request_serializes` (bare case omits it).
+fn is_false(v: &bool) -> bool {
+    !*v
 }
 
 /// Response body for `POST /api/v1/sessions/managed` (spawn).

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -93,6 +93,19 @@ pub struct SpawnParams {
     /// malformed or absent id is silently a no-op link (`None`) — never a
     /// reason to fail an otherwise-successful spawn.
     pub deliverable_id: Option<String>,
+    /// Whether to FORCE a brand-new session even when a live in-project session
+    /// for the same project already exists (#2450).
+    ///
+    /// Why: the #1707 in-project reconnect pre-flight silently ADOPTS an
+    /// existing live session for the same `source_id` (returning it instead of
+    /// spawning). A surface that explicitly means "launch a NEW session" — the
+    /// `tm` picker's "[N] launch new session" choice, `tm session new`/`session
+    /// start` — would otherwise have its `--task` injected into an unrelated
+    /// live session. `true` SKIPS the reconnect pre-flight (always spawns
+    /// fresh); `false` (the default, so programmatic/idempotent callers — MCP
+    /// `session_new`, the SM-STDIO adapter, the chat surfaces — keep
+    /// reconnecting) preserves #1707.
+    pub force_new: bool,
 }
 
 /// Spawn a managed session, shared by the HTTP handler and the MCP tool.
@@ -301,6 +314,34 @@ async fn spawn_managed_routed(
         let local_path = std::path::Path::new(&params.repo_url);
         match try_inproject_spawn(local_path) {
             Ok(Some((base, owner, repo))) => {
+                // Reconnect pre-flight (#1707), HOISTED AHEAD of worktree
+                // reservation (#2450): the reconnect used to live inside
+                // `spawn_managed_inproject`, which meant `reserve_inproject_worktree`
+                // had already created (then left for pruning) a fresh
+                // `.worktrees/<name>` slice before the reconnect returned the
+                // existing session — worktree litter, including a locked orphan.
+                // Running the check here, before any worktree is reserved, means
+                // a reconnect creates ZERO worktrees. Gated by `force_new` so an
+                // explicit "launch new" surface always spawns fresh instead of
+                // adopting an unrelated live session for the same project.
+                {
+                    let mgr = state.session_manager().await;
+                    let existing = mgr.list().await;
+                    let source_id = format!("{owner}/{repo}");
+                    if let Some(live) = reconnect_candidate(
+                        params.force_new,
+                        &existing,
+                        &source_id,
+                        &*mgr.tmux_driver(),
+                    ) {
+                        info!(
+                            id = %live.id,
+                            source_id = %source_id,
+                            "spawn_managed (inproject): reconnecting to existing live session"
+                        );
+                        return Ok(live);
+                    }
+                }
                 match reserve_inproject_worktree(
                     state,
                     &session_id,
@@ -688,6 +729,34 @@ fn find_reusable_inproject_session(
         .cloned()
 }
 
+/// Decide whether an in-project spawn should RECONNECT to an existing live
+/// session rather than provision a fresh worktree (#1707 + `force_new` opt-out).
+///
+/// Why (issue #2450): the reconnect decision is exactly what the `force_new`
+/// opt-out gates — an explicit "launch new" surface (the `tm` picker's "launch
+/// new session" choice) must be able to bypass it, otherwise its task is
+/// injected into an unrelated live session for the same project. Keeping the
+/// decision a pure function (the `force_new` short-circuit composed with
+/// [`find_reusable_inproject_session`]) makes BOTH branches — skip-when-forced
+/// AND still-reconnect-when-not-forced — unit-testable without a live
+/// `DaemonState`, tmux, or git worktree.
+/// What: returns `None` immediately when `force_new` is set (never reconnect);
+/// otherwise delegates to [`find_reusable_inproject_session`] (the unchanged
+/// #1707 predicate).
+/// Test: `reconnect_candidate_none_when_force_new`,
+/// `reconnect_candidate_reconnects_when_not_forced`.
+fn reconnect_candidate(
+    force_new: bool,
+    records: &[SessionRecord],
+    source_id: &str,
+    tmux: &dyn crate::session_manager::ManagedTmuxDriver,
+) -> Option<SessionRecord> {
+    if force_new {
+        return None;
+    }
+    find_reusable_inproject_session(records, source_id, tmux)
+}
+
 /// Spawn a managed session rooted at a per-session git worktree (#1706).
 ///
 /// Why: the in-project spawn path gives every managed session its own isolated
@@ -734,26 +803,12 @@ async fn spawn_managed_inproject(
     use crate::core::provisioning_stage::{ProvisioningStage, emit};
     use crate::session_manager::ManagedSessionState;
 
-    // Pre-flight reconnect check (#1707): if an Active managed session with the
-    // same source_id already exists and its tmux session is still live, return it
-    // directly instead of spawning a duplicate. This is the primary mechanism by
-    // which `tm` (bare or with a path) reconnects to an in-progress session for
-    // the same project without creating a second worktree.
-    let candidate_source_id = format!("{owner}/{repo}");
-    {
-        let mgr = state.session_manager().await;
-        let existing = mgr.list().await;
-        if let Some(live) =
-            find_reusable_inproject_session(&existing, &candidate_source_id, &*mgr.tmux_driver())
-        {
-            info!(
-                id = %live.id,
-                source_id = %candidate_source_id,
-                "spawn_managed (inproject): reconnecting to existing live session"
-            );
-            return Ok(live);
-        }
-    }
+    // NOTE (#2450): the #1707 reconnect pre-flight that used to run here has
+    // been hoisted into `spawn_managed_routed`, AHEAD of the worktree
+    // reservation, so a reconnect no longer creates-then-prunes a worktree and
+    // the `force_new` opt-out can skip it before any side effect. By the time
+    // this function runs, the caller has already decided a fresh session is
+    // wanted and reserved its worktree.
 
     info!(
         id = %session_id,
@@ -1683,6 +1738,54 @@ mod tests {
         );
     }
 
+    /// #2450: `force_new = true` must SKIP the reconnect entirely — even when a
+    /// perfectly reusable Active+live session for the same project exists. This
+    /// is the exact opt-out the picker's "launch new session" choice relies on
+    /// so it can never inject its task into an unrelated live session.
+    #[test]
+    fn reconnect_candidate_none_when_force_new() {
+        let records = vec![stub_record(
+            Some("bobmatnyc/trusty-tools"),
+            ManagedSessionState::Active,
+            "tmpm-trusty-tools-abc123",
+        )];
+        let tmux = StubTmux {
+            alive: vec!["tmpm-trusty-tools-abc123".to_owned()],
+        };
+
+        // Sanity: without force_new this same input DOES reconnect (below).
+        let forced = reconnect_candidate(true, &records, "bobmatnyc/trusty-tools", &tmux);
+
+        assert!(
+            forced.is_none(),
+            "force_new must skip the reconnect even when a live session exists"
+        );
+    }
+
+    /// #2450 companion: `force_new = false` must PRESERVE the #1707 reconnect —
+    /// `reconnect_candidate` delegates to the unchanged predicate, so an
+    /// Active+live session for the same project is still adopted. Guards against
+    /// the opt-out accidentally disabling reconnect for the default path.
+    #[test]
+    fn reconnect_candidate_reconnects_when_not_forced() {
+        let records = vec![stub_record(
+            Some("bobmatnyc/trusty-tools"),
+            ManagedSessionState::Active,
+            "tmpm-trusty-tools-abc123",
+        )];
+        let tmux = StubTmux {
+            alive: vec!["tmpm-trusty-tools-abc123".to_owned()],
+        };
+
+        let found = reconnect_candidate(false, &records, "bobmatnyc/trusty-tools", &tmux);
+
+        assert_eq!(
+            found.map(|r| r.tmux_name),
+            Some("tmpm-trusty-tools-abc123".to_owned()),
+            "without force_new the #1707 reconnect must still adopt a live session"
+        );
+    }
+
     /// #1913 regression guard: [`prepare_inproject_session`] — the call this fix
     /// adds to [`spawn_managed_inproject`] BEFORE `adapter.spawn` — must actually
     /// run the preparation pipeline and land its most visible symptom (the
@@ -1874,6 +1977,7 @@ mod tests {
             mcp_initiated: false,
             inject_task: None,
             deliverable_id: None,
+            force_new: false,
         };
 
         let config = crate::core::trusty_tools_config::TrustyToolsConfig::default();

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -120,8 +120,12 @@ pub struct SpawnRequest {
     /// pre-flight so an explicit "launch new session" surface (the `tm` picker's
     /// "launch new session" choice, `tm session new`) always spawns a FRESH
     /// session + worktree instead of adopting an existing live one for the same
-    /// project. Absent/null/`false` → the reconnect default (#1707), so
-    /// programmatic/idempotent callers are unaffected.
+    /// project. Absent or `false` → the reconnect default (#1707), so
+    /// programmatic/idempotent callers are unaffected. Unlike `inject_task`
+    /// above, this is a plain `bool` (not `Option<bool>`): `#[serde(default)]`
+    /// on a bool only supplies the default when the KEY IS ABSENT — an
+    /// explicit `"force_new": null` in the request body is a type mismatch and
+    /// fails the whole request with a 400, it is not tolerated as `false`.
     #[serde(default)]
     pub force_new: bool,
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -116,6 +116,14 @@ pub struct SpawnRequest {
     /// never a silently-dropped link. Absent/null → no link (the common case).
     #[serde(default)]
     pub deliverable_id: Option<String>,
+    /// Optional force-new control (#2450): `true` SKIPS the in-project reconnect
+    /// pre-flight so an explicit "launch new session" surface (the `tm` picker's
+    /// "launch new session" choice, `tm session new`) always spawns a FRESH
+    /// session + worktree instead of adopting an existing live one for the same
+    /// project. Absent/null/`false` → the reconnect default (#1707), so
+    /// programmatic/idempotent callers are unaffected.
+    #[serde(default)]
+    pub force_new: bool,
 }
 
 /// Response body for POST /api/v1/sessions/managed (spawn, 201 Created).
@@ -462,6 +470,10 @@ pub async fn spawn_session(
         // to opt into the legacy metadata-only behavior (`--no-inject`).
         inject_task: req.inject_task,
         deliverable_id: req.deliverable_id,
+        // Force-new opt-out (#2450): a client (the picker's "launch new
+        // session", `tm session new`) sets `force_new: true` to skip the
+        // in-project reconnect pre-flight and always spawn fresh.
+        force_new: req.force_new,
     };
 
     match spawn_managed(&state, params).await {

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -83,6 +83,11 @@ pub async fn session_new(
         // The MCP `session_new` tool does not expose Deliverable linkage
         // (#2379's CLI surface is `tm sessions new --deliverable`, HTTP-only).
         deliverable_id: None,
+        // Keep the #1707 reconnect (#2450): an MCP `session_new` re-issued for a
+        // project that already has a live session should ADOPT it, not spawn a
+        // duplicate — idempotent reconnect is the safe default for automated
+        // callers (prevents LLM-driven session proliferation).
+        force_new: false,
     };
     let record = spawn_managed(state, params).await?;
     Ok(record_to_json(&record))

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -145,6 +145,10 @@ impl SessionControl for DaemonSessionControl {
             // The SM-STDIO adapter does not expose Deliverable linkage
             // (#2379's CLI surface is `tm sessions new --deliverable`, HTTP-only).
             deliverable_id: None,
+            // Keep the #1707 reconnect (#2450): the SM-STDIO adapter is a
+            // programmatic driver; an idempotent reconnect for a project that
+            // already has a live session is the safe default here too.
+            force_new: false,
         };
         let record = spawn_managed(&self.state, spawn)
             .await

--- a/crates/trusty-mpm/src/slack/commands.rs
+++ b/crates/trusty-mpm/src/slack/commands.rs
@@ -213,6 +213,8 @@ impl From<SlackCommand> for TrustyCommand {
                     inject_task: None,
                     // Slack `/launch` has no `--deliverable` surface (#2379).
                     deliverable_id: None,
+                    // #2450: the Slack `/launch` surface keeps the #1707 reconnect default.
+                    force_new: false,
                 }
             }
             SlackCommand::Fleet => TrustyCommand::ManagedList,
@@ -386,6 +388,7 @@ mod tests {
                 runtime: None,
                 inject_task: None,
                 deliverable_id: None,
+                force_new: false,
             }
         );
     }

--- a/crates/trusty-mpm/src/telegram/commands.rs
+++ b/crates/trusty-mpm/src/telegram/commands.rs
@@ -176,6 +176,8 @@ impl From<TelegramCommand> for TrustyCommand {
                     inject_task: None,
                     // Telegram `/launch` has no `--deliverable` surface (#2379).
                     deliverable_id: None,
+                    // #2450: the Telegram `/launch` surface keeps the #1707 reconnect default.
+                    force_new: false,
                 }
             }
             TelegramCommand::Fleet => TrustyCommand::ManagedFleet,
@@ -429,6 +431,7 @@ mod tests {
                 runtime: None,
                 inject_task: None,
                 deliverable_id: None,
+                force_new: false,
             }
         );
     }

--- a/crates/trusty-mpm/src/tui/coordinator/dispatch.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/dispatch.rs
@@ -220,6 +220,8 @@ fn route_new(args: &str) -> Dispatch {
         // The TUI `/new` chat command has no `--deliverable` surface (#2379;
         // TUI Deliverable affordances are #2383's scope).
         deliverable_id: None,
+        // #2450: the TUI `/new` verb keeps the #1707 reconnect default.
+        force_new: false,
     })
 }
 

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -1314,6 +1314,7 @@ fn route_new_builds_managed_new() {
             runtime: None,
             inject_task: None,
             deliverable_id: None,
+            force_new: false,
         })
     );
 }

--- a/crates/trusty-mpm/tests/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/tests/mcp_spawn_gate.rs
@@ -77,6 +77,7 @@ fn base_params(repo_url: &str, mcp_initiated: bool) -> SpawnParams {
         mcp_initiated,
         inject_task: None,
         deliverable_id: None,
+        force_new: false,
     }
 }
 


### PR DESCRIPTION
Closes #2450

## Problem

The `tm` session picker's explicit **"[N] launch new session"** choice did not reliably create a new session. When a live in-project managed session for the same project already existed, the daemon's #1707 reconnect pre-flight **silently adopted** it and returned it — so an operator asking for a *new* session was attached to an *unrelated live one*, and any `--task` was injected into a session doing other work (**P1, cross-session task injection**). Pre-existing behavior from #1707 / #1715 / #1931 — not a regression from #2306 / #2325 / #2297.

## Fix

- **`force_new: bool`** (serde default `false`) added to `SpawnRequest` (wire, `#[serde(default)]`) and `SpawnParams` (transport-agnostic) — additive, mirroring the `inject_task` convention (#1903/#2361). Client `ManagedSpawnRequest` omits it from the wire when `false` (`skip_serializing_if`), so every non-forcing caller's request stays byte-identical to the pre-fix shape.
- Reconnect decision extracted to a pure `reconnect_candidate(force_new, …)` helper: returns `None` immediately when `force_new`, else delegates to the unchanged `find_reusable_inproject_session` predicate.

### Ordering-fix shape

The #1707 reconnect check used to live **inside** `spawn_managed_inproject`, which meant `spawn_managed_routed` had already called `reserve_inproject_worktree` (creating a `.worktrees/<name>` slice) **before** the reconnect returned the pre-existing session — create-then-prune worktree litter, including a locked orphan. The check is now **hoisted into `spawn_managed_routed`, ahead of `reserve_inproject_worktree`**, gated on `!params.force_new`. On a reconnect the worktree reservation is now **unreachable** → zero worktrees created. The old in-place block in `spawn_managed_inproject` is removed (replaced by a NOTE).

### Per-surface `force_new` decisions

| Surface | force_new | Rationale |
|---|---|---|
| Picker "launch new session" (`launch_new_session_and_attach`) | **true** | The reported P1 — an explicit "launch new" must never adopt an existing session. |
| `tm session new` (CLI verb) | **true** | An explicit `new` verb means new (per diagnosis). |
| `tm session start` | **true** | #1916 keeps it byte-identical to `session new`; the wire-parity test is updated to assert the shared `force_new: true`. |
| MCP `session_new` tool | **false** | Programmatic caller; idempotent reconnect prevents LLM-driven session proliferation. |
| SM-STDIO `sm.sessions.launch` | **false** | Programmatic driver; idempotent reconnect is the safe default. |
| Slack `/launch`, Telegram `/launch`, TUI `/new` | **false** | Chat/TUI surfaces keep the #1707 reconnect. |

> Note: no `--reconnect` escape hatch is added for `tm session new` in this PR; the daemon wire field now supports one as a clean follow-up if idempotent scripting needs it.

## Tests

- Unit (`lifecycle.rs`): `reconnect_candidate_none_when_force_new` (skips reconnect even when a reusable live session exists) and `reconnect_candidate_reconnects_when_not_forced` (preserves #1707 on the default path). The existing `find_reusable_inproject_session_*` predicate tests are retained.
- Wire: `to_command_maps_new` asserts `force_new: true`; `managed_spawn_request_serializes` asserts `force_new` is omitted when false; the `session start` ↔ picker wire-parity test asserts the shared `force_new: true`.
- The "distinct id + fresh worktree on second force_new spawn" / "zero worktrees on reconnect" end-to-end assertions are **structurally guaranteed** by the reordering (reserve is unreachable past the reconnect early-return) and covered by the pure decision test — a full live in-project spawn (git clone + worktree + tmux + `claude`) is out of scope here, matching the crate's documented avoidance of live-spawn tests in CI (`#[ignore]` e2e only).

## Gate (raw output)

- `cargo build --workspace` / `cargo check -p trusty-mpm --all-targets` — clean.
- `cargo test -p trusty-mpm --all-targets` — 25 `test result: ok` blocks, 0 failed; new tests ran.
- `cargo test --workspace` — 128 `test result: ok` blocks, 0 failed.
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0.
- `cargo fmt --check` — clean. `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations — OK`.

## Rebase risk vs #2439

Branched off `origin/main` at `e0446ea8`. **#2439 also touches `SpawnRequest`/`SpawnParams`** (adds `deliverable_id`). This PR's additions are appended at the end of each struct/initializer, so a conflict with #2439 would be **adjacent-line only** — a trivial rebase (keep both fields). If #2439 lands first, rebase and re-add `force_new` beside `deliverable_id` in `SpawnRequest`, `SpawnParams`, the `spawn_session` handler, and the two test `SpawnParams` initializers.

## Manual follow-up

The locked orphan worktree `.worktrees/tm-trusty-tools-01` at the repo base (a runtime artifact, not repo state) predates this fix — remove it manually with `git worktree remove --force` if still present. This PR does not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
