### PR TITLE
fix(trusty-mpm): SessionEnd hook uses non-destructive pane-preserving stop

### DIFF
--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -1373,18 +1373,33 @@ async fn correlate_session_start(
     }
 }
 
-/// Immediately mark a managed session Stopped on `SessionEnd`.
+/// Immediately mark a managed session Stopped on `SessionEnd`, WITHOUT killing
+/// its tmux pane (#2454).
 ///
-/// Why (#1744): without this, a managed session that exits ungracefully (tmux
-/// pane killed, terminal closed) stays `Active` in the store until the 60-second
-/// reap loop fires. On `SessionEnd`, Claude Code's internal session has already
-/// ended; marking the managed session `Stopped` immediately keeps the daemon's
-/// view consistent and lets the operator see the correct state right away.
+/// Why (#1744, revised #2454): without this, a managed session that exits
+/// ungracefully (tmux pane killed, terminal closed) stays `Active` in the store
+/// until the 60-second reap loop fires. On `SessionEnd`, Claude Code's internal
+/// session has already ended; marking the managed session `Stopped` immediately
+/// keeps the daemon's view consistent and lets the operator see the correct
+/// state right away. This originally called [`SessionManager::stop`], which is
+/// the EXPLICIT-stop contract (`tm session stop`) and therefore also
+/// `graceful_terminate_runtime`s / `kill_session`s the tmux pane — but a
+/// `SessionEnd` correlation is a self-healing state reconcile, not a
+/// human/client teardown request, exactly like the 60-second runtime-exit
+/// reaper (see [`crate::daemon::runtime_reap`] #2023 A). Routing it through
+/// `stop` could destroy a pane the operator was still attached to, purely
+/// because the daemon correlated the exit a few hundred milliseconds before
+/// they noticed. This now mirrors the reaper and calls
+/// [`SessionManager::mark_runtime_exited_stopped`] instead, leaving the pane
+/// alive.
 /// What: searches Active managed sessions for one whose `claude_session_id`
-/// matches the hook's `session_id`; calls `SessionManager::stop` which kills the
-/// tmux session (best-effort, already gone) and marks the record `Stopped`.
-/// Best-effort — failures are logged and swallowed so the hook response is unaffected.
-/// Test: `session_end_hook_marks_managed_stopped` in `api_tests.rs`.
+/// matches the hook's `session_id`; calls
+/// `SessionManager::mark_runtime_exited_stopped`, which marks the record
+/// `Stopped` and persists WITHOUT calling `graceful_terminate_runtime` /
+/// `kill_session`. Best-effort — failures are logged and swallowed so the hook
+/// response is unaffected.
+/// Test: `session_end_hook_marks_managed_stopped` and
+/// `session_end_hook_does_not_kill_pane` in `api_tests.rs`.
 async fn handle_session_end(state: &Arc<DaemonState>, claude_session_id: &str) {
     let mgr = state.session_manager().await;
     let records = mgr.list().await;
@@ -1394,11 +1409,11 @@ async fn handle_session_end(state: &Arc<DaemonState>, claude_session_id: &str) {
     });
     if let Some(r) = matched {
         let id = r.id;
-        match mgr.stop(&id).await {
+        match mgr.mark_runtime_exited_stopped(&id).await {
             Ok(_) => tracing::info!(
                 managed_id = %id,
                 claude_session_id = %claude_session_id,
-                "SessionEnd: marked managed session Stopped immediately (#1744)"
+                "SessionEnd: marked managed session Stopped immediately (#1744, pane left alive #2454)"
             ),
             Err(e) => tracing::warn!(
                 managed_id = %id,

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -1373,6 +1373,47 @@ async fn correlate_session_start(
     }
 }
 
+/// Pure decision: should `handle_session_end` DEFER its `Stopped` transition
+/// because the record's own tmux pane still shows a live runtime? (#2454)
+///
+/// Why: `SessionEnd` firing is Claude Code self-reporting that its session is
+/// "ending / being torn down" ([`crate::core::hook::HookEvent::SessionEnd`])
+/// — NOT proof the OS process (and therefore the tmux pane) has already fully
+/// exited; the hook POST can race the pane's actual fall-back to a bare idle
+/// shell. `SessionManager::resume` decides pane reuse purely on
+/// `tmux.session_exists()`, so flipping the record to `Stopped` while the
+/// pane is still occupied could let a `resume` (manual or the auto-resume
+/// supervisor) type into a pane the outgoing runtime hasn't relinquished yet.
+/// This reuses the EXACT SAME classification the 60-second runtime-exit
+/// reaper already trusts for this question —
+/// [`crate::daemon::runtime_reap::pane_runtime_exited`] (idle-shell allowlist
+/// combined with the [`ChildLivenessProbe`] fail-closed gate) — instead of
+/// inventing a second one, so the two call sites can never disagree about
+/// what "exited" means.
+/// What: finds the pane whose `session_name` matches `tmux_name` in `panes`
+/// and returns `true` (defer) only when a match exists AND
+/// [`pane_runtime_exited`](crate::daemon::runtime_reap::pane_runtime_exited)
+/// reports it as NOT yet exited. When no matching pane is found (already
+/// gone, or tmux/pane enumeration was unavailable and `panes` is empty) this
+/// returns `false` (proceed) — there is nothing to protect from a destructive
+/// teardown here, since `mark_runtime_exited_stopped` never touches the pane
+/// either way; a genuinely vanished session is left to the #1744 reaper as
+/// before. Pure — no I/O — so it is unit-testable without a live tmux.
+/// Test: `session_end_pane_still_live_true_for_running_agent`,
+/// `session_end_pane_still_live_false_for_idle_shell`,
+/// `session_end_pane_still_live_false_when_pane_missing` in `api_tests.rs`.
+fn session_end_pane_still_live(
+    tmux_name: &str,
+    panes: &[crate::daemon::orphan_gc::PaneInfo],
+    probe: &dyn crate::daemon::orphan_gc::ChildLivenessProbe,
+) -> bool {
+    panes
+        .iter()
+        .find(|p| p.session_name == tmux_name)
+        .map(|p| !crate::daemon::runtime_reap::pane_runtime_exited(p, probe))
+        .unwrap_or(false)
+}
+
 /// Immediately mark a managed session Stopped on `SessionEnd`, WITHOUT killing
 /// its tmux pane (#2454).
 ///
@@ -1391,15 +1432,28 @@ async fn correlate_session_start(
 /// because the daemon correlated the exit a few hundred milliseconds before
 /// they noticed. This now mirrors the reaper and calls
 /// [`SessionManager::mark_runtime_exited_stopped`] instead, leaving the pane
-/// alive.
+/// alive. It also gates that transition behind
+/// [`session_end_pane_still_live`] (#2454 follow-up): the hook can race the
+/// pane's actual teardown, so if the pane is found and still shows a live
+/// runtime the transition is DEFERRED for this hook receipt — the 60-second
+/// reaper will pick the session up once its pane is genuinely idle. This gate
+/// is best-effort: it needs a real `tmux` binary to enumerate panes, so on a
+/// host with no `tmux` (or a `list_managed_panes` failure) it fails OPEN and
+/// proceeds with the transition unchecked, same as pre-gate behavior.
 /// What: searches Active managed sessions for one whose `claude_session_id`
-/// matches the hook's `session_id`; calls
-/// `SessionManager::mark_runtime_exited_stopped`, which marks the record
-/// `Stopped` and persists WITHOUT calling `graceful_terminate_runtime` /
-/// `kill_session`. Best-effort — failures are logged and swallowed so the hook
-/// response is unaffected.
+/// matches the hook's `session_id`. If found, best-effort discovers the live
+/// tmux panes ([`crate::daemon::tmux::TmuxDriver::discover`] +
+/// `list_managed_panes`) and calls [`session_end_pane_still_live`]; when that
+/// reports the pane is still live, logs and returns WITHOUT transitioning.
+/// Otherwise calls `SessionManager::mark_runtime_exited_stopped`, which marks
+/// the record `Stopped` and persists WITHOUT calling
+/// `graceful_terminate_runtime` / `kill_session`. Best-effort — failures are
+/// logged and swallowed so the hook response is unaffected.
 /// Test: `session_end_hook_marks_managed_stopped` and
-/// `session_end_hook_does_not_kill_pane` in `api_tests.rs`.
+/// `session_end_hook_does_not_kill_pane` in `api_tests.rs` cover the
+/// transition itself (tmux is unavailable/pane-not-found in that harness, so
+/// the gate fails open); the gate's own decision logic is covered by the
+/// `session_end_pane_still_live_*` unit tests above.
 async fn handle_session_end(state: &Arc<DaemonState>, claude_session_id: &str) {
     let mgr = state.session_manager().await;
     let records = mgr.list().await;
@@ -1409,6 +1463,29 @@ async fn handle_session_end(state: &Arc<DaemonState>, claude_session_id: &str) {
     });
     if let Some(r) = matched {
         let id = r.id;
+        let tmux_name = r.tmux_name.clone();
+
+        // #2454: best-effort gate — defer if the pane still shows a live
+        // runtime. Fails open (proceeds) when tmux is unavailable or pane
+        // enumeration fails, matching the transition's own non-destructive
+        // nature (nothing here ever touches the pane regardless).
+        if let Ok(driver) = crate::daemon::tmux::TmuxDriver::discover()
+            && let Ok(panes) = driver.list_managed_panes()
+            && session_end_pane_still_live(
+                &tmux_name,
+                &panes,
+                &crate::daemon::orphan_gc::ProcessTreeProbe,
+            )
+        {
+            tracing::info!(
+                managed_id = %id,
+                claude_session_id = %claude_session_id,
+                name = %tmux_name,
+                "SessionEnd: deferring Stopped transition — pane still shows a live runtime (#2454); the 60s reaper will retry once idle"
+            );
+            return;
+        }
+
         match mgr.mark_runtime_exited_stopped(&id).await {
             Ok(_) => tracing::info!(
                 managed_id = %id,

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1647,3 +1647,100 @@ async fn session_end_hook_marks_managed_stopped() {
         "SessionEnd hook must immediately mark the managed session Stopped (#1744)"
     );
 }
+
+#[tokio::test]
+async fn session_end_hook_does_not_kill_pane() {
+    // Why (#2454): `handle_session_end` previously routed through
+    // `SessionManager::stop`, which kills the tmux pane via
+    // `graceful_terminate_runtime` — destroying a pane the operator might
+    // still be attached to. Per #2023 A this correlation is a self-healing
+    // reconcile, not an explicit human/client stop request, so it must use
+    // the non-destructive `mark_runtime_exited_stopped` path instead (same as
+    // the 60-second runtime-exit reaper in `daemon::runtime_reap`). This test
+    // proves the SessionEnd hook never calls `kill_session`.
+    use crate::session_manager::{ManagedError, ManagedSessionState, SessionManager};
+    use std::sync::{Arc as SArc, Mutex};
+
+    // Spy driver: records every `kill_session` call, mirroring
+    // `runtime_reap::tests::KillSpyTmuxDriver` (#2023 A).
+    #[derive(Default)]
+    struct KillSpyTmuxDriver {
+        kill_calls: Mutex<Vec<String>>,
+    }
+    impl crate::session_manager::ManagedTmuxDriver for KillSpyTmuxDriver {
+        fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn kill_session(&self, name: &str) -> Result<(), ManagedError> {
+            self.kill_calls.lock().unwrap().push(name.to_owned());
+            Ok(())
+        }
+        fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
+            Ok(String::new())
+        }
+        fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+            Ok(Vec::new())
+        }
+    }
+
+    let ws = std::path::PathBuf::from("/tmp/test-ws-session-end-no-kill");
+    let tmp = tempfile::TempDir::new().unwrap();
+    let driver = SArc::new(KillSpyTmuxDriver::default());
+    let mgr = SessionManager::new(tmp.path(), driver.clone() as SArc<_>)
+        .await
+        .unwrap();
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(ws.clone()),
+            None,
+            Some(ws.clone()),
+            None,
+            None,
+        )
+        .await
+        .expect("create managed session");
+    let managed_id = record.id;
+    mgr.set_workspace(&managed_id, ws, ManagedSessionState::Active)
+        .await
+        .expect("set Active");
+
+    let claude_id = "550e8400-e29b-41d4-a716-446655440003";
+    mgr.set_claude_session_id(&managed_id, claude_id)
+        .await
+        .expect("set claude_session_id for no-kill test");
+
+    let mgr_arc = SArc::new(mgr);
+    let state = Arc::new(DaemonState::with_session_manager(mgr_arc));
+    std::mem::forget(tmp);
+
+    let post = HookPost {
+        session_id: claude_id.to_string(),
+        event: HookEvent::SessionEnd,
+        payload: serde_json::json!({}),
+    };
+    let result = ingest_hook(State(Arc::clone(&state)), Json(post)).await;
+    assert!(
+        result.is_ok(),
+        "ingest_hook(SessionEnd) must succeed: {result:?}"
+    );
+
+    let mgr = state.session_manager().await;
+    let after = mgr
+        .get(&managed_id)
+        .await
+        .expect("get managed session after SessionEnd");
+    assert_eq!(
+        after.state,
+        ManagedSessionState::Stopped,
+        "SessionEnd hook must still mark the managed session Stopped (#1744)"
+    );
+
+    assert!(
+        driver.kill_calls.lock().unwrap().is_empty(),
+        "SessionEnd correlation must NEVER kill the tmux pane (#2454, mirrors #2023 A)"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1662,17 +1662,33 @@ async fn session_end_hook_does_not_kill_pane() {
     use std::sync::{Arc as SArc, Mutex};
 
     // Spy driver: records every `kill_session` call, mirroring
-    // `runtime_reap::tests::KillSpyTmuxDriver` (#2023 A).
+    // `runtime_reap::tests::KillSpyTmuxDriver` (#2023 A). Unlike that sibling
+    // (which never needs `session_exists` to be truthful because the reaper
+    // path it drives doesn't gate on it), THIS spy must track live session
+    // names in `sessions` and return them from `list_sessions` — the default
+    // `ManagedTmuxDriver::session_exists` derives from `list_sessions`, and
+    // `graceful_terminate_runtime` (invoked by the destructive `stop()` this
+    // test must distinguish from) fast-path RETURNS before ever calling
+    // `kill_session` when `session_exists` is false. An always-empty
+    // `list_sessions` (as a prior revision of this spy had) made
+    // `kill_calls` empty NO MATTER which method — `stop` or
+    // `mark_runtime_exited_stopped` — `handle_session_end` called, so the
+    // assertion below proved nothing. Mutation-tested: reverting the api.rs
+    // call site back to `mgr.stop(&id)` now makes this test FAIL (see PR
+    // #2455 review discussion, finding 1).
     #[derive(Default)]
     struct KillSpyTmuxDriver {
+        sessions: Mutex<Vec<String>>,
         kill_calls: Mutex<Vec<String>>,
     }
     impl crate::session_manager::ManagedTmuxDriver for KillSpyTmuxDriver {
-        fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+        fn create_session(&self, name: &str, _workdir: &str) -> Result<(), ManagedError> {
+            self.sessions.lock().unwrap().push(name.to_owned());
             Ok(())
         }
         fn kill_session(&self, name: &str) -> Result<(), ManagedError> {
             self.kill_calls.lock().unwrap().push(name.to_owned());
+            self.sessions.lock().unwrap().retain(|n| n != name);
             Ok(())
         }
         fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
@@ -1682,7 +1698,7 @@ async fn session_end_hook_does_not_kill_pane() {
             Ok(String::new())
         }
         fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
-            Ok(Vec::new())
+            Ok(self.sessions.lock().unwrap().clone())
         }
     }
 
@@ -1742,5 +1758,55 @@ async fn session_end_hook_does_not_kill_pane() {
     assert!(
         driver.kill_calls.lock().unwrap().is_empty(),
         "SessionEnd correlation must NEVER kill the tmux pane (#2454, mirrors #2023 A)"
+    );
+}
+
+// ─── #2454 finding-2: session_end_pane_still_live liveness gate ───────────
+
+fn pane_for_gate_test(name: &str, cmd: &str) -> crate::daemon::orphan_gc::PaneInfo {
+    crate::daemon::orphan_gc::PaneInfo {
+        session_name: name.to_string(),
+        pane_current_command: cmd.to_string(),
+        pane_pid: Some(4242),
+    }
+}
+
+#[test]
+fn session_end_pane_still_live_true_for_running_agent() {
+    // Why (#2454): a pane whose matching record still shows the runtime
+    // running (`claude`) must be classified as "still live" so the caller
+    // defers the Stopped transition to the next reaper tick.
+    use crate::daemon::orphan_gc::AlwaysIdleProbe;
+    let panes = vec![pane_for_gate_test("tmpm-live", "claude")];
+    assert!(
+        session_end_pane_still_live("tmpm-live", &panes, &AlwaysIdleProbe),
+        "a pane still running the agent must be classified as still-live"
+    );
+}
+
+#[test]
+fn session_end_pane_still_live_false_for_idle_shell() {
+    // Why (#2454): a pane that has already fallen back to a bare idle shell
+    // (matching the reaper's own `pane_runtime_exited` classification) must
+    // NOT be deferred — the transition should proceed immediately.
+    use crate::daemon::orphan_gc::AlwaysIdleProbe;
+    let panes = vec![pane_for_gate_test("tmpm-idle", "zsh")];
+    assert!(
+        !session_end_pane_still_live("tmpm-idle", &panes, &AlwaysIdleProbe),
+        "an idle-shell pane with no live child must NOT be classified as still-live"
+    );
+}
+
+#[test]
+fn session_end_pane_still_live_false_when_pane_missing() {
+    // Why (#2454): when no pane matches (already gone, or tmux/pane
+    // enumeration was unavailable and `panes` is empty) there is nothing to
+    // protect — the transition must proceed (fail open), matching this
+    // gate's documented default.
+    use crate::daemon::orphan_gc::AlwaysIdleProbe;
+    let panes: Vec<crate::daemon::orphan_gc::PaneInfo> = Vec::new();
+    assert!(
+        !session_end_pane_still_live("tmpm-gone", &panes, &AlwaysIdleProbe),
+        "a missing pane must fail open (not classified as still-live)"
     );
 }


### PR DESCRIPTION
## Problem

`handle_session_end` in `crates/trusty-mpm/src/daemon/api.rs` (previously around lines 1287-1289 and 1388-1409) called the OLD destructive `SessionManager::stop` when the `SessionEnd` hook correlates a claude exit to an Active managed session. `stop()` calls `graceful_terminate_runtime`, which ultimately KILLS the tmux pane (see `crates/trusty-mpm/src/session_manager/manager.rs:414-427`, and `restart_ops.rs:139`).

This predates issue #2023 (#1744) and was never reconciled with #2023-A, which introduced the non-destructive `mark_runtime_exited_stopped` (`manager.rs:474-506`) specifically so a runtime-exit transition never tears down the tmux pane. The rationale is documented at `crates/trusty-mpm/src/daemon/runtime_reap.rs:1-54` — the 60-second reaper already uses this non-destructive transition for the exact same class of event (the inner `claude` process exiting on its own). If the `SessionEnd` hook correlates successfully while the operator is still attached to the pane, the daemon was destroying the pane out from under them.

## Fix

`handle_session_end` (`crates/trusty-mpm/src/daemon/api.rs:1388-1432`) now calls `SessionManager::mark_runtime_exited_stopped` instead of `SessionManager::stop`. Both functions share the same signature (`&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError>`), so the call site needed no argument/error-handling changes beyond the method name — only the doc comments needed updating to reflect the non-destructive behavior, referencing #2023 A and the runtime-exit reaper as the mirrored pattern.

Explicit `tm session stop` / decommission requests are UNCHANGED — they still call `stop()` and kill the pane, because those are human/client-initiated teardown requests, not self-healing state reconciles.

## Test evidence

Added `session_end_hook_does_not_kill_pane` in `crates/trusty-mpm/src/daemon/api_tests.rs`, mirroring the `KillSpyTmuxDriver` pattern already used in `daemon::runtime_reap::tests` (#2023 A) — a driver spy that records every `kill_session` call, drives the `SessionEnd` hook end-to-end through `ingest_hook`, and asserts the record transitions to `Stopped` while `kill_session` is never invoked.

```
test daemon::api::tests::session_end_hook_does_not_kill_pane ... ok
test daemon::api::tests::session_end_hook_marks_managed_stopped ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2758 filtered out; finished in 0.00s
```

### Full gate results

**1. `cargo build --workspace`** — clean build, `Finished dev profile [unoptimized + debuginfo] target(s) in 1m 41s`.

**2. `cargo test --workspace --no-fail-fast`**
- `trusty-mpm` lib: `test result: ok. 2755 passed; 0 failed; 5 ignored`
- Two known pre-existing flakes hit and both passed on retry (unrelated to this change):
  - `trusty-agents skills::sources::tests::sources_resolved_paths_expands_tilde` — `$TMPDIR`/tilde flake, passed on retry
  - `trusty-console proxy::routes::tests::test_connect_retry_recovers_on_second_attempt` — documented pre-existing flake, passed on retry

**3. `cargo clippy --workspace --all-targets -- -D warnings`** — clean, no warnings in touched files.

**4. `cargo fmt --check`** — clean, no diffs.

**5. `bash scripts/check_line_cap.sh`** — `line-cap: 0 allowlisted, 0 violations — OK.`

Closes #2454

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools