### PR TITLE
fix(trusty-mpm): reconcile stale-Active session before refusing in-place relaunch

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -73,32 +73,31 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
         // no-op: the operator was already inside the very session being
         // "reconnected" to.
         //
-        // #2456 review finding 1 (CRITICAL): `nested_session_guard` matches
-        // on EITHER the tmux SESSION name (shared by every window/pane in
-        // that session) OR the process-level `TM_MANAGED_SESSION_ID` env var
-        // (pane/process-scoped — only ever set in the exact shell that ran
-        // the spawn/resume export prefix, see `runtime::claude_code::
-        // session_id_export_prefix`). A session-name-only match is NOT proof
-        // this is the pane bound to `record` — a genuinely different, idle
-        // window in the SAME tmux session (e.g. window 1, while window 0
-        // holds the just-exited `claude` pane) matches on session name
-        // alone. Driving the destructive `run_inplace_relaunch` (which
-        // `exec`s `claude` into WHATEVER pane this process is literally
-        // running in, chdir'd to `record`'s workspace) off that weaker
-        // signal would silently discard the invoking pane's shell and drop
-        // the operator into a DIFFERENT pane's conversation. Re-derive the
-        // SAME process-env signal `nested_session_guard` / `try_inplace_
-        // relaunch`'s primary gate already uses (never the looser,
-        // session-wide `tmux show-environment` fallback, which cannot
-        // discriminate between panes either) and require it to name THIS
-        // exact record before attempting the in-place path; a
-        // session-name-only match falls back to the pre-existing, harmless
-        // refuse+switch-client behavior.
-        let env_session_id = std::env::var("TM_MANAGED_SESSION_ID")
-            .ok()
-            .filter(|v| !v.trim().is_empty());
+        // #2456 review finding 1 (CRITICAL, ROUND 2): `nested_session_guard`
+        // matches on the tmux SESSION name (shared by every window/pane in
+        // that session) — NOT proof this is the pane bound to `record`. A
+        // ROUND-1 fix compared the process-level `TM_MANAGED_SESSION_ID` env
+        // var, reasoning it was pane/process-scoped; that premise was
+        // EMPIRICALLY DISPROVEN (live tmux 3.6b): the healing step in
+        // `SessionManager::mark_runtime_exited_stopped` calls `tmux
+        // set-environment -t <session>` — SESSION-scoped — and tmux applies
+        // a session's stored environment to the process env of every NEW
+        // pane/window created in that session AFTERWARD. Any session that
+        // has exited-and-relaunched once therefore has a "poisoned" session
+        // env that a genuinely different sibling window inherits into its
+        // OWN process env — the env-based gate would have passed that
+        // sibling. The authoritative signal is tmux's own stable `pane_id`
+        // (never inherited across panes, unlike an env var or `pane_pid`,
+        // which the OS can reuse across a pane's lifetime) — see
+        // `pane_identity_confirmed`'s doc for the full rationale. A record
+        // with no captured `pane_id` (legacy, pre-#2453) or a tmux query
+        // failure both fail CLOSED — never trust a weaker signal to justify
+        // the destructive `run_inplace_relaunch` `exec`, which lands in
+        // WHATEVER pane this process is literally running in, chdir'd to
+        // `record`'s workspace.
+        let current_pane_id = super::tmux_attach::current_tmux_pane_id();
 
-        if pane_identity_confirmed(env_session_id.as_deref(), &record.id) {
+        if pane_identity_confirmed(current_pane_id.as_deref(), record.pane_id.as_deref()) {
             // Safe to attempt: its daemon reactivate call independently
             // reconciles a stale-`Active` record whose pane is confirmed
             // idle (#2453 daemon-side fix, `daemon::managed_routes::
@@ -352,35 +351,50 @@ pub(crate) fn nested_managed_match<'a>(
     })
 }
 
-/// Pure predicate (#2456 review finding 1): does the CURRENT pane's own
-/// process-level `TM_MANAGED_SESSION_ID` env var confirm THIS pane is the
-/// one bound to `record_id` — as opposed to [`nested_managed_match`] having
-/// matched purely on tmux SESSION name (a signal every window/pane in that
-/// session shares)?
+/// Pure predicate (#2456 review finding 1, ROUND 2 — the round-1 env-var
+/// gate was empirically disproven): does the CURRENT pane's own stable tmux
+/// `pane_id` confirm THIS pane is the one bound to `record_pane_id` — as
+/// opposed to [`nested_managed_match`] having matched purely on tmux SESSION
+/// name (a signal every window/pane in that session shares)?
 ///
-/// Why: [`nested_managed_match`] deliberately matches on session name alone
-/// as a fallback (a pane that never got the durable env-var publish, #2157
-/// item 2) — correct for the ORIGINAL harmless refuse+switch-client
-/// behavior, but NOT sufficient to justify driving [`super::guided_inplace::
-/// run_inplace_relaunch`]'s destructive `exec`, which lands in WHATEVER pane
-/// this process is literally running in. Isolating the confirmation check
-/// from the `std::env::var` read makes the exact cross-pane hijack scenario
-/// (two idle panes in the same tmux session, `tm` invoked from the one that
-/// is NOT bound to the matched record) unit-testable without mutating
-/// process env or spawning tmux.
-/// What: `true` only when `env_session_id` is `Some` and equals `record_id`
-/// exactly — this is the SAME process-scoped signal
-/// `guided_inplace::read_env_managed_session_id` uses as its primary gate,
-/// never the looser, session-wide `tmux show-environment` fallback (which
-/// cannot discriminate between panes either). `false` for a missing env var
-/// OR one that names a DIFFERENT session — including the two-idle-panes
-/// case — meaning the caller must fall back to refuse+switch-client rather
-/// than attempt the in-place relaunch.
-/// Test: `pane_identity_confirmed_true_when_env_matches_record`,
-/// `pane_identity_confirmed_false_when_env_absent`,
-/// `pane_identity_confirmed_false_when_env_names_different_session`.
-pub(crate) fn pane_identity_confirmed(env_session_id: Option<&str>, record_id: &str) -> bool {
-    env_session_id.is_some_and(|id| id == record_id)
+/// Why: the round-1 fix compared `TM_MANAGED_SESSION_ID` process env values,
+/// reasoning that env var was pane/process-scoped. That premise was proven
+/// FALSE against a live tmux 3.6b: `mark_runtime_exited_stopped`'s healing
+/// step calls `tmux set-environment -t <session>` — SESSION-scoped — and
+/// tmux applies a session's stored environment to the process env of every
+/// NEW pane/window created in that session AFTERWARD. Concretely: `tmux
+/// set-environment -t sess ID abc; tmux new-window -t sess` then reading
+/// `$ID` inside that BRAND NEW window returns `abc` — inherited, not
+/// exported by THIS pane's own spawn command. Since the healing step runs on
+/// every runtime-exit reconcile (the periodic reap tick, #2453's own
+/// reconcile-then-reactivate route, and #2455's hook), any session that has
+/// exited-and-relaunched once has this poisoned session env, and every
+/// window opened afterward inherits the id into ITS OWN process env — the
+/// exact env-based gate this predicate replaces would have passed a
+/// genuinely different, unrelated sibling pane. tmux's own `pane_id` (e.g.
+/// `"%5"`, distinct from `pane_pid`, which the OS can reuse across a pane's
+/// lifetime) is NEVER inherited across panes — see
+/// [`SessionRecord::pane_id`](trusty_mpm::session_manager::SessionRecord::pane_id)'s
+/// doc for the full rationale and [`super::tmux_attach::current_tmux_pane_id`]
+/// for how the CURRENT pane's id is resolved.
+/// What: `true` only when BOTH `current_pane_id` and `record_pane_id` are
+/// `Some` and equal. `false` when either is `None` (a legacy record that
+/// never had a `pane_id` captured, or a tmux query failure) OR they differ —
+/// fails CLOSED in every ambiguous case, meaning the caller must fall back
+/// to refuse+switch-client rather than attempt the in-place relaunch.
+/// Test: `pane_identity_confirmed_true_when_pane_id_matches_record`,
+/// `pane_identity_confirmed_false_when_current_pane_id_absent`,
+/// `pane_identity_confirmed_false_when_record_pane_id_absent`,
+/// `pane_identity_confirmed_false_when_inherited_env_but_different_pane_id`
+/// (the exact two-idle-panes/inherited-session-env hijack scenario).
+pub(crate) fn pane_identity_confirmed(
+    current_pane_id: Option<&str>,
+    record_pane_id: Option<&str>,
+) -> bool {
+    match (current_pane_id, record_pane_id) {
+        (Some(cur), Some(rec)) => cur == rec,
+        _ => false,
+    }
 }
 
 /// Fetch EVERY managed session, unfiltered — `GET /api/v1/sessions/managed`

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -64,11 +64,36 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
     // would nest one tmux client's session inside another (the root cause of
     // #2157). Check BEFORE any project detection or picker logic runs.
     if let Some(record) = nested_session_guard(client, url).await {
-        eprintln!(
-            "tm: this tmux session ('{}') is already a managed session (state={}) — \
-             refusing to launch a nested session here.",
-            record.name, record.state
-        );
+        // #2453: `record.state` can lag reality by up to 60s after the
+        // pane's `claude` process exits (the periodic reap tick / a racing
+        // `SessionEnd` hook has not caught up yet). Previously this branch
+        // trusted that stale state unconditionally and fell straight to
+        // `resume_guided_session`, which — because the tmux SESSION is
+        // (correctly) still alive — always resolved to a `switch-client`
+        // no-op: the operator was already inside the very session being
+        // "reconnected" to. Try the SAME in-place-relaunch primitive #2023
+        // component C uses instead: its daemon reactivate call independently
+        // reconciles a stale-`Active` record whose pane is confirmed idle
+        // (#2453 daemon-side fix, `daemon::managed_routes::reactivate::
+        // reconcile_stale_active_then_reactivate`) and refuses — falling
+        // through to the notice + reconnect below — when the runtime, or a
+        // genuinely different sibling pane in the same tmux session (#2157),
+        // is still live. Safe to attempt unconditionally: a hard failure
+        // (e.g. no `claude` binary) still surfaces as `Err` below rather than
+        // silently falling through.
+        match super::guided_inplace::run_inplace_relaunch(client, url, &record.id, record.clone())
+            .await
+        {
+            super::guided_inplace::InPlaceOutcome::Result(r) => return r,
+            super::guided_inplace::InPlaceOutcome::FallThrough => {
+                eprintln!(
+                    "tm: in-place relaunch unavailable for '{}' (state={}) — \
+                     this tmux session is already a managed session; \
+                     refusing to launch a nested session here.",
+                    record.name, record.state
+                );
+            }
+        }
         eprintln!("tm: reconnecting to '{}' instead…", record.name);
         return super::guided_resume::resume_guided_session(client, url, &record).await;
     }

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -71,28 +71,80 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
         // `resume_guided_session`, which — because the tmux SESSION is
         // (correctly) still alive — always resolved to a `switch-client`
         // no-op: the operator was already inside the very session being
-        // "reconnected" to. Try the SAME in-place-relaunch primitive #2023
-        // component C uses instead: its daemon reactivate call independently
-        // reconciles a stale-`Active` record whose pane is confirmed idle
-        // (#2453 daemon-side fix, `daemon::managed_routes::reactivate::
-        // reconcile_stale_active_then_reactivate`) and refuses — falling
-        // through to the notice + reconnect below — when the runtime, or a
-        // genuinely different sibling pane in the same tmux session (#2157),
-        // is still live. Safe to attempt unconditionally: a hard failure
-        // (e.g. no `claude` binary) still surfaces as `Err` below rather than
-        // silently falling through.
-        match super::guided_inplace::run_inplace_relaunch(client, url, &record.id, record.clone())
+        // "reconnected" to.
+        //
+        // #2456 review finding 1 (CRITICAL): `nested_session_guard` matches
+        // on EITHER the tmux SESSION name (shared by every window/pane in
+        // that session) OR the process-level `TM_MANAGED_SESSION_ID` env var
+        // (pane/process-scoped — only ever set in the exact shell that ran
+        // the spawn/resume export prefix, see `runtime::claude_code::
+        // session_id_export_prefix`). A session-name-only match is NOT proof
+        // this is the pane bound to `record` — a genuinely different, idle
+        // window in the SAME tmux session (e.g. window 1, while window 0
+        // holds the just-exited `claude` pane) matches on session name
+        // alone. Driving the destructive `run_inplace_relaunch` (which
+        // `exec`s `claude` into WHATEVER pane this process is literally
+        // running in, chdir'd to `record`'s workspace) off that weaker
+        // signal would silently discard the invoking pane's shell and drop
+        // the operator into a DIFFERENT pane's conversation. Re-derive the
+        // SAME process-env signal `nested_session_guard` / `try_inplace_
+        // relaunch`'s primary gate already uses (never the looser,
+        // session-wide `tmux show-environment` fallback, which cannot
+        // discriminate between panes either) and require it to name THIS
+        // exact record before attempting the in-place path; a
+        // session-name-only match falls back to the pre-existing, harmless
+        // refuse+switch-client behavior.
+        let env_session_id = std::env::var("TM_MANAGED_SESSION_ID")
+            .ok()
+            .filter(|v| !v.trim().is_empty());
+
+        if pane_identity_confirmed(env_session_id.as_deref(), &record.id) {
+            // Safe to attempt: its daemon reactivate call independently
+            // reconciles a stale-`Active` record whose pane is confirmed
+            // idle (#2453 daemon-side fix, `daemon::managed_routes::
+            // reactivate::reconcile_stale_active_then_reactivate`) and
+            // refuses — falling through to the notice + reconnect below —
+            // when the runtime is still genuinely live.
+            match super::guided_inplace::run_inplace_relaunch(
+                client,
+                url,
+                &record.id,
+                record.clone(),
+            )
             .await
-        {
-            super::guided_inplace::InPlaceOutcome::Result(r) => return r,
-            super::guided_inplace::InPlaceOutcome::FallThrough => {
-                eprintln!(
-                    "tm: in-place relaunch unavailable for '{}' (state={}) — \
-                     this tmux session is already a managed session; \
-                     refusing to launch a nested session here.",
-                    record.name, record.state
-                );
+            {
+                super::guided_inplace::InPlaceOutcome::Result(Ok(())) => return Ok(()),
+                super::guided_inplace::InPlaceOutcome::Result(Err(e)) => {
+                    // #2456 review finding 2: a failure here — whether it
+                    // happened BEFORE any daemon mutation (cwd resolution,
+                    // resolving the `claude` binary) or the `exec` syscall
+                    // itself failing AFTER a successful reactivate — must
+                    // not hard-fail this call site the way it correctly does
+                    // for `try_inplace_relaunch`'s OWN env-var entry point
+                    // (component C). Pre-#2453 this whole branch always fell
+                    // back to `resume_guided_session`'s switch-client
+                    // reconnect for every one of these scenarios; regressing
+                    // that to a hard non-zero exit — e.g. simply because
+                    // `claude` is not on THIS pane's `PATH` — would be worse
+                    // than the original bug. Report the concrete error and
+                    // fall back exactly like a daemon-refused reactivate.
+                    eprintln!("tm: in-place relaunch failed ({e}) — falling back to reconnect…");
+                }
+                super::guided_inplace::InPlaceOutcome::FallThrough => {
+                    eprintln!(
+                        "tm: in-place relaunch unavailable for '{}' (state={}) — \
+                         this tmux session is already a managed session; \
+                         refusing to launch a nested session here.",
+                        record.name, record.state
+                    );
+                }
             }
+        } else {
+            eprintln!(
+                "tm: this tmux session ('{}') is already a managed session (state={}) — \
+                 refusing to launch a nested session here.",
+                record.name, record.state
+            );
         }
         eprintln!("tm: reconnecting to '{}' instead…", record.name);
         return super::guided_resume::resume_guided_session(client, url, &record).await;
@@ -298,6 +350,37 @@ pub(crate) fn nested_managed_match<'a>(
         current_session_name.is_some_and(|n| n == r.name)
             || env_session_id.is_some_and(|id| id == r.id)
     })
+}
+
+/// Pure predicate (#2456 review finding 1): does the CURRENT pane's own
+/// process-level `TM_MANAGED_SESSION_ID` env var confirm THIS pane is the
+/// one bound to `record_id` — as opposed to [`nested_managed_match`] having
+/// matched purely on tmux SESSION name (a signal every window/pane in that
+/// session shares)?
+///
+/// Why: [`nested_managed_match`] deliberately matches on session name alone
+/// as a fallback (a pane that never got the durable env-var publish, #2157
+/// item 2) — correct for the ORIGINAL harmless refuse+switch-client
+/// behavior, but NOT sufficient to justify driving [`super::guided_inplace::
+/// run_inplace_relaunch`]'s destructive `exec`, which lands in WHATEVER pane
+/// this process is literally running in. Isolating the confirmation check
+/// from the `std::env::var` read makes the exact cross-pane hijack scenario
+/// (two idle panes in the same tmux session, `tm` invoked from the one that
+/// is NOT bound to the matched record) unit-testable without mutating
+/// process env or spawning tmux.
+/// What: `true` only when `env_session_id` is `Some` and equals `record_id`
+/// exactly — this is the SAME process-scoped signal
+/// `guided_inplace::read_env_managed_session_id` uses as its primary gate,
+/// never the looser, session-wide `tmux show-environment` fallback (which
+/// cannot discriminate between panes either). `false` for a missing env var
+/// OR one that names a DIFFERENT session — including the two-idle-panes
+/// case — meaning the caller must fall back to refuse+switch-client rather
+/// than attempt the in-place relaunch.
+/// Test: `pane_identity_confirmed_true_when_env_matches_record`,
+/// `pane_identity_confirmed_false_when_env_absent`,
+/// `pane_identity_confirmed_false_when_env_names_different_session`.
+pub(crate) fn pane_identity_confirmed(env_session_id: Option<&str>, record_id: &str) -> bool {
+    env_session_id.is_some_and(|id| id == record_id)
 }
 
 /// Fetch EVERY managed session, unfiltered — `GET /api/v1/sessions/managed`

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -59,14 +59,22 @@
 //!
 //! #2453: [`run_inplace_relaunch`] and [`InPlaceOutcome`] are `pub(crate)` so
 //! `super::guided::run_guided_default`'s nested-session guard can drive this
-//! SAME primitive for a second, distinct entry point — the operator's own
-//! current pane matched by tmux session/pane identity, independent of
+//! SAME primitive for a second, distinct entry point, independent of
 //! [`try_inplace_relaunch`]'s env-var + Stopped-state gate. This closes the
 //! bare-`tm` self-switch (no-op) bug: previously that call site trusted a
 //! possibly-stale `record.state == "active"` and unconditionally attached/
 //! switch-cliented, which is a guaranteed no-op when the operator is already
 //! sitting in that exact pane. See `run_inplace_relaunch`'s doc for the safety
 //! argument (the daemon's reactivate round-trip remains the sole authority).
+//! CORRECTION (#2456 review finding 1): the nested-session guard's OWN match
+//! is by tmux SESSION name alone — every window/pane in a tmux session
+//! shares the same session name, so that match is NOT pane-level identity.
+//! `guided.rs` therefore re-derives the SAME process-scoped
+//! `TM_MANAGED_SESSION_ID` signal this module's own primary gate
+//! ([`read_env_managed_session_id`]) uses and requires it to name the
+//! matched record before calling [`run_inplace_relaunch`] at all — a
+//! session-name-only match (a genuinely different pane/window) falls back to
+//! the pre-existing refuse+switch-client behavior instead.
 
 use anyhow::Context as _;
 
@@ -371,19 +379,30 @@ pub(crate) enum InPlaceOutcome {
 /// Why: separated from [`try_inplace_relaunch`] so the "should we take this
 /// path at all" decision and the "how do we execute it" mechanics are
 /// distinct, readable steps. `pub(crate)` (#2453): the nested-session guard in
-/// `guided.rs` matches a record by tmux session/pane identity BEFORE the
-/// record's `state` is known to be `Stopped` — its `record.state` field can
-/// lag reality by up to 60s (the same staleness race #2148 hardens
-/// [`fetch_managed_session_until_stopped`] against). Rather than duplicate the
-/// Stopped-only gate [`plan_inplace`] enforces for the env-var entry point,
-/// that call site drives this function directly with whatever record it
-/// matched (any state) and trusts the SAME safety boundary every caller of
-/// this function already relies on: [`reactivate_managed_session`]'s daemon
-/// round-trip (backed, as of #2453, by the daemon's own independent pane-idle
-/// reconciliation — see `daemon::managed_routes::reactivate::
-/// reconcile_stale_active_then_reactivate`) is the single source of truth,
-/// and a refused/failed reactivate here folds into [`InPlaceOutcome::FallThrough`]
-/// exactly as it does for the env-var path — never an unconditional exec.
+/// `guided.rs` matches a record by tmux SESSION name (or, when it is able to
+/// additionally confirm pane-level identity via the SAME process-scoped
+/// `TM_MANAGED_SESSION_ID` signal [`read_env_managed_session_id`] uses, drives
+/// this function ONLY in that confirmed case — see the `#2456 review finding
+/// 1` correction in this module's top doc comment; a session-name-only match
+/// never reaches here) BEFORE the record's `state` is known to be `Stopped` —
+/// its `record.state` field can lag reality by up to 60s (the same staleness
+/// race #2148 hardens [`fetch_managed_session_until_stopped`] against).
+/// Rather than duplicate the Stopped-only gate [`plan_inplace`] enforces for
+/// the env-var entry point, that call site drives this function directly
+/// with whatever record it matched (any state) and trusts the SAME safety
+/// boundary every caller of this function already relies on:
+/// [`reactivate_managed_session`]'s daemon round-trip (backed, as of #2453,
+/// by the daemon's own independent pane-idle reconciliation — see
+/// `daemon::managed_routes::reactivate::reconcile_stale_active_then_reactivate`)
+/// is the single source of truth, and a refused/failed reactivate here folds
+/// into [`InPlaceOutcome::FallThrough`] exactly as it does for the env-var
+/// path — never an unconditional exec. Note (#2456 review finding 2): unlike
+/// [`try_inplace_relaunch`]'s own contract (a command-build failure there is
+/// a deliberate hard error), the nested-guard caller treats EVERY
+/// `InPlaceOutcome::Result(Err(_))` from THIS call site — pre-mutation
+/// (cwd/binary resolution) or post-reactivate (`exec` itself failing) alike
+/// — as a fall-back-to-reconnect condition, matching that call site's
+/// pre-#2453 behavior of never hard-failing.
 /// What, IN ORDER (#2027 exec-ordering fix): (1) prints a one-line notice;
 /// (2) resolves the workdir and builds the resume argv via
 /// [`trusty_mpm::runtime::build_inplace_resume_command`] (the SAME

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -56,6 +56,17 @@
 //! [`parse_show_environment_value`], is pure and exhaustively unit-tested. Every
 //! rejected gate now also emits a `tracing::debug!` so a stuck-in-the-picker
 //! report is diagnosable from `RUST_LOG=debug` output without code archaeology.
+//!
+//! #2453: [`run_inplace_relaunch`] and [`InPlaceOutcome`] are `pub(crate)` so
+//! `super::guided::run_guided_default`'s nested-session guard can drive this
+//! SAME primitive for a second, distinct entry point — the operator's own
+//! current pane matched by tmux session/pane identity, independent of
+//! [`try_inplace_relaunch`]'s env-var + Stopped-state gate. This closes the
+//! bare-`tm` self-switch (no-op) bug: previously that call site trusted a
+//! possibly-stale `record.state == "active"` and unconditionally attached/
+//! switch-cliented, which is a guaranteed no-op when the operator is already
+//! sitting in that exact pane. See `run_inplace_relaunch`'s doc for the safety
+//! argument (the daemon's reactivate round-trip remains the sole authority).
 
 use anyhow::Context as _;
 
@@ -340,8 +351,10 @@ fn exec_claude_in_place(mut cmd: std::process::Command) -> anyhow::Result<()> {
 /// which is exactly the same outcome as [`plan_inplace`] returning `None`.
 /// Separating the two outcomes lets [`try_inplace_relaunch`] route a
 /// reactivate failure back into the `None`/fall-through path instead of
-/// wrapping it in `Some(Err(..))`.
-enum InPlaceOutcome {
+/// wrapping it in `Some(Err(..))`. `pub(crate)` (#2453): `super::guided::
+/// run_guided_default`'s nested-session-guard branch also drives this enum
+/// directly — see [`run_inplace_relaunch`]'s doc for why.
+pub(crate) enum InPlaceOutcome {
     /// The exec attempt concluded (never returns on success; carries the
     /// error when `exec` itself failed, or when command resolution failed
     /// before any daemon mutation occurred).
@@ -351,11 +364,26 @@ enum InPlaceOutcome {
     FallThrough,
 }
 
-/// Drive the full in-place relaunch once [`plan_inplace`] selected it.
+/// Drive the full in-place relaunch once [`plan_inplace`] selected it — OR
+/// once `guided::run_guided_default`'s nested-session guard confirms the
+/// current tmux pane belongs to a managed record (#2453).
 ///
 /// Why: separated from [`try_inplace_relaunch`] so the "should we take this
 /// path at all" decision and the "how do we execute it" mechanics are
-/// distinct, readable steps.
+/// distinct, readable steps. `pub(crate)` (#2453): the nested-session guard in
+/// `guided.rs` matches a record by tmux session/pane identity BEFORE the
+/// record's `state` is known to be `Stopped` — its `record.state` field can
+/// lag reality by up to 60s (the same staleness race #2148 hardens
+/// [`fetch_managed_session_until_stopped`] against). Rather than duplicate the
+/// Stopped-only gate [`plan_inplace`] enforces for the env-var entry point,
+/// that call site drives this function directly with whatever record it
+/// matched (any state) and trusts the SAME safety boundary every caller of
+/// this function already relies on: [`reactivate_managed_session`]'s daemon
+/// round-trip (backed, as of #2453, by the daemon's own independent pane-idle
+/// reconciliation — see `daemon::managed_routes::reactivate::
+/// reconcile_stale_active_then_reactivate`) is the single source of truth,
+/// and a refused/failed reactivate here folds into [`InPlaceOutcome::FallThrough`]
+/// exactly as it does for the env-var path — never an unconditional exec.
 /// What, IN ORDER (#2027 exec-ordering fix): (1) prints a one-line notice;
 /// (2) resolves the workdir and builds the resume argv via
 /// [`trusty_mpm::runtime::build_inplace_resume_command`] (the SAME
@@ -368,7 +396,7 @@ enum InPlaceOutcome {
 /// refused/failed reactivate this returns [`InPlaceOutcome::FallThrough`]
 /// rather than proceeding; (4) execs `claude` in place.
 /// Test: I/O path; not unit-tested (requires a live daemon + real `claude`).
-async fn run_inplace_relaunch(
+pub(crate) async fn run_inplace_relaunch(
     client: &reqwest::Client,
     url: &str,
     id: &str,

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -66,15 +66,24 @@
 //! switch-cliented, which is a guaranteed no-op when the operator is already
 //! sitting in that exact pane. See `run_inplace_relaunch`'s doc for the safety
 //! argument (the daemon's reactivate round-trip remains the sole authority).
-//! CORRECTION (#2456 review finding 1): the nested-session guard's OWN match
-//! is by tmux SESSION name alone — every window/pane in a tmux session
-//! shares the same session name, so that match is NOT pane-level identity.
-//! `guided.rs` therefore re-derives the SAME process-scoped
-//! `TM_MANAGED_SESSION_ID` signal this module's own primary gate
-//! ([`read_env_managed_session_id`]) uses and requires it to name the
-//! matched record before calling [`run_inplace_relaunch`] at all — a
-//! session-name-only match (a genuinely different pane/window) falls back to
-//! the pre-existing refuse+switch-client behavior instead.
+//! CORRECTION (#2456 review finding 1, ROUND 2): the nested-session guard's
+//! OWN match is by tmux SESSION name alone — every window/pane in a tmux
+//! session shares the same session name, so that match is NOT pane-level
+//! identity. A first attempt at closing this gap re-derived the process-scoped
+//! `TM_MANAGED_SESSION_ID` env var this module's own primary gate
+//! ([`read_env_managed_session_id`]) uses — that was EMPIRICALLY DISPROVEN:
+//! the healing step in `SessionManager::mark_runtime_exited_stopped` calls
+//! `tmux set-environment -t <session>` (SESSION-scoped), and tmux applies a
+//! session's stored environment to the process env of every NEW pane/window
+//! created in that session AFTERWARD — a genuinely different sibling window
+//! inherits the SAME env value, defeating an env-var-only gate. `guided.rs`
+//! now compares tmux's own stable `pane_id` (`super::tmux_attach::
+//! current_tmux_pane_id`) against the matched record's `pane_id`
+//! (`SessionRecord::pane_id`, captured at spawn/reconcile time) — a signal
+//! that is NEVER inherited across panes — before calling
+//! [`run_inplace_relaunch`] at all. A session-name-only match, a missing
+//! `pane_id` (legacy record), or a pane_id mismatch all fall back to the
+//! pre-existing refuse+switch-client behavior instead.
 
 use anyhow::Context as _;
 
@@ -379,12 +388,14 @@ pub(crate) enum InPlaceOutcome {
 /// Why: separated from [`try_inplace_relaunch`] so the "should we take this
 /// path at all" decision and the "how do we execute it" mechanics are
 /// distinct, readable steps. `pub(crate)` (#2453): the nested-session guard in
-/// `guided.rs` matches a record by tmux SESSION name (or, when it is able to
-/// additionally confirm pane-level identity via the SAME process-scoped
-/// `TM_MANAGED_SESSION_ID` signal [`read_env_managed_session_id`] uses, drives
-/// this function ONLY in that confirmed case — see the `#2456 review finding
-/// 1` correction in this module's top doc comment; a session-name-only match
-/// never reaches here) BEFORE the record's `state` is known to be `Stopped` —
+/// `guided.rs` matches a record by tmux SESSION name, then — ONLY when it can
+/// additionally confirm pane-level identity via tmux's own stable `pane_id`
+/// (`super::tmux_attach::current_tmux_pane_id` vs. the record's
+/// `SessionRecord::pane_id`; see the `#2456 review finding 1, ROUND 2`
+/// correction in this module's top doc comment for why the process-env
+/// signal this paragraph used to describe was proven insufficient) — drives
+/// this function; a session-name-only match never reaches here) BEFORE the
+/// record's `state` is known to be `Stopped` —
 /// its `record.state` field can lag reality by up to 60s (the same staleness
 /// race #2148 hardens [`fetch_managed_session_until_stopped`] against).
 /// Rather than duplicate the Stopped-only gate [`plan_inplace`] enforces for
@@ -516,6 +527,32 @@ pub(crate) async fn try_inplace_relaunch(
     match plan_inplace(Some(&env_id), record_state) {
         Some(ResumeAction::InPlace) => {
             let record = record.expect("plan_inplace only selects InPlace when record is Some");
+            // #2453 review finding 1 (round 2), extended to this PRE-EXISTING
+            // env-var entry point: `env_id` alone only proves SOME shell in
+            // this tmux session/process tree carries `TM_MANAGED_SESSION_ID`
+            // — including a sibling pane that merely INHERITED it via tmux's
+            // session-scoped healing `set-environment` (see `guided::
+            // pane_identity_confirmed`'s doc for the full empirical proof).
+            // That is not proof THIS pane is the one bound to `record`.
+            // Require the SAME pane_id confirmation the nested-session guard
+            // uses before driving the destructive exec. In the common case
+            // (bare `tm` typed in the exact pane whose runtime just exited)
+            // `record.pane_id` was just refreshed by the SessionEnd-hook-
+            // triggered `mark_runtime_exited_stopped` moments before this
+            // fetch resolved "stopped", so this adds no friction there.
+            let current_pane_id = super::tmux_attach::current_tmux_pane_id();
+            if !super::guided::pane_identity_confirmed(
+                current_pane_id.as_deref(),
+                record.pane_id.as_deref(),
+            ) {
+                tracing::debug!(
+                    id = %env_id,
+                    "tm: in-place relaunch gate: pane_id could not be confirmed for \
+                     this pane (env var may be inherited from a healed sibling \
+                     session/window) — falling through to guided default"
+                );
+                return None;
+            }
             match run_inplace_relaunch(client, url, &env_id, record).await {
                 InPlaceOutcome::Result(r) => Some(r),
                 InPlaceOutcome::FallThrough => {
@@ -871,6 +908,7 @@ mod tests {
             task: None,
             cwd: None,
             claude_session_id: None,
+            pane_id: None,
         };
         let client = reqwest::Client::new();
 

--- a/crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/tmux_attach.rs
@@ -83,6 +83,41 @@ pub(crate) fn current_tmux_session_name() -> Option<String> {
     (!name.is_empty()).then_some(name)
 }
 
+/// Resolve the tmux `pane_id` (e.g. `"%5"`) of the CURRENT client's pane
+/// (#2453 review finding 1, round 2).
+///
+/// Why: [`current_tmux_session_name`] only proves the tmux SESSION matches —
+/// every window/pane in that session shares the same name — which is not
+/// proof the CURRENT pane is the one bound to a specific managed record. A
+/// process-env-var comparison was tried and PROVEN insufficient: tmux's
+/// session-scoped `set-environment` (used to heal `TM_MANAGED_SESSION_ID`
+/// into a pane that never got the durable publish, #2157 item 3) is
+/// inherited into the process env of every NEW pane/window created in that
+/// session AFTERWARD — verified empirically against a live tmux 3.6b. tmux's
+/// own `pane_id` is never inherited across panes, making it the only
+/// reliable "is this literally the same pane" signal available to the CLI.
+/// What: returns `None` immediately when [`inside_tmux`] is `false`.
+/// Otherwise runs `tmux display-message -p '#{pane_id}'` and returns the
+/// trimmed, non-empty stdout, or `None` on any I/O failure, non-zero exit,
+/// or empty output — mirrors [`current_tmux_session_name`]'s exact shape.
+/// Test: I/O path, not unit-tested (requires a live tmux server); the pure
+/// decision that CONSUMES this value
+/// (`guided::pane_identity_confirmed`) is unit-tested separately.
+pub(crate) fn current_tmux_pane_id() -> Option<String> {
+    if !inside_tmux() {
+        return None;
+    }
+    let output = std::process::Command::new("tmux")
+        .args(["display-message", "-p", "#{pane_id}"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!id.is_empty()).then_some(id)
+}
+
 /// Attach (or switch) the current terminal into the tmux session `name`.
 ///
 /// Why: single choke point for the nested-tmux-safe attach behavior so

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -27,7 +27,8 @@ use crate::commands::first_run::needs_first_run_clone;
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 use crate::commands::guided::{
     derive_project, fallback_protected, github_host, is_github_remote, nested_managed_match,
-    non_github_refusal_message, print_non_tty_hint, print_project_context, tty_gate,
+    non_github_refusal_message, pane_identity_confirmed, print_non_tty_hint, print_project_context,
+    tty_gate,
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{ResumeAction, is_zombie, needs_restart, plan_resume};
@@ -1364,4 +1365,43 @@ fn nested_managed_match_finds_record_missing_from_source_id_filtered_list() {
         matched.is_some(),
         "must match by session name regardless of source_id"
     );
+}
+
+// ── pane_identity_confirmed (#2456 review finding 1) ─────────────────────────
+// The cross-pane-hijack guard: `nested_managed_match` alone only proves the
+// tmux SESSION matches (every window/pane in that session shares the same
+// session name) — it is NOT proof the CURRENT pane is the one bound to the
+// matched record. `pane_identity_confirmed` is the additional predicate that
+// must independently confirm pane-level identity before the caller may drive
+// the destructive `run_inplace_relaunch`.
+
+#[test]
+fn pane_identity_confirmed_true_when_env_matches_record() {
+    // THIS pane's own process env names the SAME record nested_managed_match
+    // found — genuinely the pane bound to that record; safe to relaunch.
+    assert!(pane_identity_confirmed(
+        Some("tm-proj-01-id"),
+        "tm-proj-01-id"
+    ));
+}
+
+#[test]
+fn pane_identity_confirmed_false_when_env_absent() {
+    // No process-level env var at all — e.g. a plain shell window that was
+    // never used to spawn claude for this session (or a pre-durable-publish
+    // pane, #2157). Must refuse to drive the in-place relaunch here.
+    assert!(!pane_identity_confirmed(None, "tm-proj-01-id"));
+}
+
+#[test]
+fn pane_identity_confirmed_false_when_env_names_different_session() {
+    // #2456 review finding 1's exact hijack scenario: TWO idle panes share
+    // one tmux session (so `nested_managed_match` matches on session name
+    // for either), but `tm` is invoked from the pane bound to a DIFFERENT
+    // managed session than the one the guard matched. The env var is
+    // present, but for the wrong id — must still refuse.
+    assert!(!pane_identity_confirmed(
+        Some("some-other-session-id"),
+        "tm-proj-01-id"
+    ));
 }

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -489,6 +489,7 @@ fn make_session(
         task: None,
         cwd: None,
         claude_session_id: None,
+        pane_id: None,
     }
 }
 
@@ -1367,41 +1368,68 @@ fn nested_managed_match_finds_record_missing_from_source_id_filtered_list() {
     );
 }
 
-// ── pane_identity_confirmed (#2456 review finding 1) ─────────────────────────
+// ── pane_identity_confirmed (#2456 review finding 1, ROUND 2) ────────────────
 // The cross-pane-hijack guard: `nested_managed_match` alone only proves the
 // tmux SESSION matches (every window/pane in that session shares the same
 // session name) — it is NOT proof the CURRENT pane is the one bound to the
-// matched record. `pane_identity_confirmed` is the additional predicate that
-// must independently confirm pane-level identity before the caller may drive
-// the destructive `run_inplace_relaunch`.
+// matched record. A ROUND-1 fix compared the process-level
+// `TM_MANAGED_SESSION_ID` env var; that was EMPIRICALLY DISPROVEN (live tmux
+// 3.6b) — tmux's session-scoped `set-environment` (used by the runtime-exit
+// healing step) is inherited into the process env of every NEW pane/window
+// created in that session AFTERWARD, so an env-var comparison can be
+// satisfied by a genuinely different, unrelated pane. `pane_identity_confirmed`
+// now compares tmux's own stable `pane_id` (never inherited across panes)
+// instead.
 
 #[test]
-fn pane_identity_confirmed_true_when_env_matches_record() {
-    // THIS pane's own process env names the SAME record nested_managed_match
-    // found — genuinely the pane bound to that record; safe to relaunch.
-    assert!(pane_identity_confirmed(
-        Some("tm-proj-01-id"),
-        "tm-proj-01-id"
-    ));
+fn pane_identity_confirmed_true_when_pane_id_matches_record() {
+    // THIS pane's own tmux pane_id equals the SAME record's captured
+    // pane_id — genuinely the pane bound to that record; safe to relaunch.
+    assert!(pane_identity_confirmed(Some("%5"), Some("%5")));
 }
 
 #[test]
-fn pane_identity_confirmed_false_when_env_absent() {
-    // No process-level env var at all — e.g. a plain shell window that was
-    // never used to spawn claude for this session (or a pre-durable-publish
-    // pane, #2157). Must refuse to drive the in-place relaunch here.
-    assert!(!pane_identity_confirmed(None, "tm-proj-01-id"));
+fn pane_identity_confirmed_false_when_current_pane_id_absent() {
+    // The CURRENT pane's tmux query failed (or we are not inside tmux at
+    // all) — cannot confirm identity; must refuse to drive the in-place
+    // relaunch here, even if the record DOES have a pane_id.
+    assert!(!pane_identity_confirmed(None, Some("%5")));
 }
 
 #[test]
-fn pane_identity_confirmed_false_when_env_names_different_session() {
-    // #2456 review finding 1's exact hijack scenario: TWO idle panes share
-    // one tmux session (so `nested_managed_match` matches on session name
-    // for either), but `tm` is invoked from the pane bound to a DIFFERENT
-    // managed session than the one the guard matched. The env var is
-    // present, but for the wrong id — must still refuse.
+fn pane_identity_confirmed_false_when_record_pane_id_absent() {
+    // A legacy record (created before #2453) never had a pane_id captured —
+    // `None` must be treated as "identity unconfirmed", never an implicit
+    // match, regardless of what the current pane's own id is.
+    assert!(!pane_identity_confirmed(Some("%5"), None));
+}
+
+#[test]
+fn pane_identity_confirmed_false_when_pane_ids_differ() {
+    // Both resolved, but for genuinely DIFFERENT panes — must still refuse.
+    assert!(!pane_identity_confirmed(Some("%7"), Some("%5")));
+}
+
+#[test]
+fn pane_identity_confirmed_false_when_inherited_env_but_different_pane_id() {
+    // #2456 review finding 1's ROUND-2 exact hijack scenario, reproduced at
+    // the pane_id layer: a session whose runtime-exit healing has fired once
+    // (so `TM_MANAGED_SESSION_ID` is now poisoned into the tmux SESSION
+    // environment) gets a second window opened afterward. That new window's
+    // process env INHERITS the healed session's id — an env-var-only gate
+    // would wrongly treat this as belonging to the healed session's record.
+    // Modeled here directly at the pane_id layer (env inheritance is a tmux
+    // process-env mechanism, not observable from pure Rust — the point this
+    // test proves is that pane_id comparison does NOT share that weakness):
+    // the healed record's `pane_id` is `"%5"` (the ORIGINAL pane), but the
+    // NEW sibling window bare `tm` is actually invoked from resolves to a
+    // DIFFERENT pane_id, `"%9"` — even though (in the real system) both
+    // panes' process env would read the SAME inherited
+    // `TM_MANAGED_SESSION_ID`. The gate must reject this pane_id mismatch.
+    let healed_record_pane_id = Some("%5");
+    let sibling_window_current_pane_id = Some("%9");
     assert!(!pane_identity_confirmed(
-        Some("some-other-session-id"),
-        "tm-proj-01-id"
+        sibling_window_current_pane_id,
+        healed_record_pane_id
     ));
 }

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -423,6 +423,19 @@ pub struct ManagedSessionSummary {
     /// sessions with no captured conversation id or predating this field.
     #[serde(default)]
     pub claude_session_id: Option<String>,
+    /// The tmux `pane_id` of this session's original pane, if captured
+    /// (additive; #2453 review finding 1, round 2).
+    ///
+    /// Why: the bare-`tm` in-pane relaunch's nested-session guard
+    /// (`bin/tm/commands/guided.rs`) compares THIS against the CURRENT
+    /// pane's own `tmux display-message -p '#{pane_id}'` to confirm pane-level
+    /// identity before driving a destructive `exec` — a session-name or
+    /// process-env-var match alone was proven insufficient (tmux's
+    /// session-scoped `set-environment` is inherited by sibling panes
+    /// created afterward). `None` for legacy records or when the driver
+    /// could not resolve one; the gate treats `None` as "unconfirmed."
+    #[serde(default)]
+    pub pane_id: Option<String>,
 }
 
 /// Wrapper for `GET /api/v1/sessions/managed` (the list endpoint).

--- a/crates/trusty-mpm/src/client/resolver.rs
+++ b/crates/trusty-mpm/src/client/resolver.rs
@@ -184,6 +184,7 @@ mod tests {
             task: None,
             cwd: None,
             claude_session_id: None,
+            pane_id: None,
         };
         let items = vec![summary("m-1", "tmpm-red-owl"), summary("m-2", "api")];
         assert_eq!(

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -1672,6 +1672,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -284,6 +284,17 @@ pub struct SessionSummary {
     /// #2379; additive — absent for legacy records and sessions with no link).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deliverable_id: Option<String>,
+    /// The tmux `pane_id` of this session's original pane, if captured
+    /// (additive; #2453 review finding 1, round 2 — absent for legacy
+    /// records, or when the driver could not resolve one).
+    ///
+    /// Why: the bare-`tm` in-pane relaunch's nested-session guard needs this
+    /// to confirm the operator's CURRENT pane is genuinely the one bound to
+    /// this record before driving a destructive `exec` — see
+    /// `SessionRecord::pane_id`'s doc for the full rationale (a session-name
+    /// or process-env-var match alone is provably insufficient).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane_id: Option<String>,
 }
 
 /// Response body for POST /api/v1/sessions/managed/{id}/decommission.

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_status/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_status/tests.rs
@@ -48,6 +48,7 @@ fn session(
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
@@ -184,6 +184,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
@@ -1,12 +1,16 @@
-//! POST /api/v1/sessions/managed/{id}/reactivate route handler (#2023 C).
+//! POST /api/v1/sessions/managed/{id}/reactivate route handler (#2023 C, #2453).
 //!
 //! Why: `managed_routes/mod.rs` was at the 500-SLOC production cap; this
 //! route (and its doc comment) is extracted here, mirroring how `lifecycle.rs`
 //! and `activity.rs` already keep `mod.rs` under budget.
 //! What: one axum handler, `reactivate_managed_session`, that delegates to
-//! [`crate::session_manager::SessionManager::mark_reactivated`].
+//! [`crate::session_manager::SessionManager::mark_reactivated`], falling back
+//! to [`reconcile_stale_active_then_reactivate`] (#2453) when the record is
+//! `Active` but the daemon's own periodic reap tick has not yet caught up
+//! with the pane's actual runtime-exited state.
 //! Test: `mark_reactivated_flips_stopped_to_active`,
-//! `mark_reactivated_rejects_non_stopped` in `session_manager::reactivate_tests`.
+//! `mark_reactivated_rejects_non_stopped` in `session_manager::reactivate_tests`;
+//! `should_reconcile_stale_active_*` below.
 
 use std::sync::Arc;
 
@@ -17,8 +21,12 @@ use axum::{
     response::IntoResponse,
 };
 
+use crate::daemon::orphan_gc::{ChildLivenessProbe, PaneInfo, ProcessTreeProbe};
+use crate::daemon::runtime_reap::find_runtime_exited;
 use crate::daemon::state::DaemonState;
-use crate::session_manager::ManagedError;
+use crate::session_manager::{
+    ManagedError, ManagedSessionId, ManagedSessionState, SessionManager, SessionRecord,
+};
 
 use super::{parse_id, record_to_summary};
 
@@ -33,11 +41,17 @@ use super::{parse_id, record_to_summary};
 /// pane. This route gives that path a dedicated, non-destructive transition —
 /// [`crate::session_manager::SessionManager::mark_reactivated`] only flips the
 /// record's state.
-/// What: 404 when the id is unknown, 409 when the record is not currently
-/// `Stopped` (mirrors `resume_managed_session`'s typed-error → status
-/// mapping), 200 with the updated summary on success.
+/// What: 404 when the id is unknown; on a non-`Stopped` record, tries
+/// [`reconcile_stale_active_then_reactivate`] (#2453) before giving up — this
+/// closes the up-to-60s window where a pane's `claude` process has already
+/// exited but the periodic reap tick (or a racing `SessionEnd` hook) has not
+/// yet flipped the record's `state` to `Stopped`; still 409 when the record is
+/// genuinely not reconcilable (a live runtime, a different lifecycle state, or
+/// a sibling pane in the same tmux session that is still active). 200 with the
+/// updated summary on success either way.
 /// Test: `mark_reactivated_flips_stopped_to_active`,
-/// `mark_reactivated_rejects_non_stopped` in `session_manager::reactivate_tests`.
+/// `mark_reactivated_rejects_non_stopped` in `session_manager::reactivate_tests`;
+/// `should_reconcile_stale_active_*` below.
 pub async fn reactivate_managed_session(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
@@ -53,8 +67,203 @@ pub async fn reactivate_managed_session(
             (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
         }
         Err(ManagedError::InvalidState(_, reason)) => {
-            (StatusCode::CONFLICT, reason).into_response()
+            match reconcile_stale_active_then_reactivate(&mgr, &id).await {
+                Some(record) => Json(record_to_summary(&record)).into_response(),
+                None => (StatusCode::CONFLICT, reason).into_response(),
+            }
         }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+/// #2453: reconcile a stale-`Active` record before refusing a reactivate.
+///
+/// Why: `mark_reactivated` above is Stopped-only by design (#2023 C) — but a
+/// pane whose `claude` process just exited reads `Active` on the record for up
+/// to 60 seconds (the daemon's `REAP_INTERVAL_SECS`, `daemon/mod.rs`) of lag
+/// before the periodic `runtime_reap` tick (or a racing `SessionEnd` hook)
+/// catches up.
+/// Bare `tm`, run in that exact pane within that window, would otherwise be
+/// told "not Stopped" and fall through to the destructive guided-picker
+/// resume/attach path (#2453's root cause). This closes that gap by
+/// independently re-checking the record's OWN pane with the SAME conservative
+/// classification [`crate::daemon::runtime_reap::stop_runtime_exited`] uses on
+/// its periodic tick, and — only when that confirms the runtime has genuinely
+/// exited — folding the `mark_runtime_exited_stopped` transition into this
+/// call before reactivating, instead of leaving the operator to wait out the
+/// reap tick.
+/// What: re-fetches the record; bails (`None`) unless it is `Active` and
+/// [`should_reconcile_stale_active`] confirms every pane belonging to its tmux
+/// session is idle (a still-live pane — including a genuinely different,
+/// still-active sibling window in the SAME tmux session, #2157 — keeps the
+/// existing 409 refusal, preserving that safety boundary). On confirmation,
+/// calls [`SessionManager::mark_runtime_exited_stopped`] then
+/// [`SessionManager::mark_reactivated`]; any failure at either step (tmux
+/// discovery, pane listing, or either state transition) also yields `None` so
+/// the caller falls back to the ordinary 409.
+/// Test: I/O path (shells out to a real `tmux`); not unit-tested — mirrors the
+/// rest of this binary's daemon-tmux-discovery call sites. The pure
+/// classification it delegates to is `should_reconcile_stale_active_*` below.
+async fn reconcile_stale_active_then_reactivate(
+    mgr: &SessionManager,
+    id: &ManagedSessionId,
+) -> Option<SessionRecord> {
+    let record = mgr.get(id).await.ok()?;
+    let panes = crate::daemon::tmux::TmuxDriver::discover()
+        .ok()?
+        .list_managed_panes()
+        .ok()?;
+    if !should_reconcile_stale_active(&record, &panes, &ProcessTreeProbe) {
+        return None;
+    }
+    mgr.mark_runtime_exited_stopped(id).await.ok()?;
+    mgr.mark_reactivated(id).await.ok()
+}
+
+/// Pure predicate (#2453): should a non-`Stopped` reactivate request be
+/// reconciled rather than refused?
+///
+/// Why: isolating the decision from the tmux round-trip
+/// ([`reconcile_stale_active_then_reactivate`]) makes it exhaustively
+/// unit-testable without a live daemon or tmux server. Reuses
+/// [`find_runtime_exited`] — the SAME session-level classification the
+/// periodic `runtime_reap` tick uses — rather than reimplementing pane
+/// idleness, so a genuinely live sibling pane in the same tmux session (a
+/// different window, #2157) keeps the WHOLE session "live" and this predicate
+/// correctly returns `false`, preserving the existing refuse+switch-client
+/// contract for that case.
+/// What: `true` only when `record.state == Active` AND `find_runtime_exited`
+/// (scoped to just this one record) selects it — i.e. its tmux session has at
+/// least one present pane and NONE of them are still running an agent.
+/// `false` for every other state (Provisioning/Errored/Decommissioned — those
+/// fall through to the ordinary 409, matching `mark_reactivated`'s Stopped-only
+/// contract) and for a missing/still-live pane.
+/// Test: `should_reconcile_stale_active_true_when_active_and_idle`,
+/// `should_reconcile_stale_active_false_when_pane_still_live`,
+/// `should_reconcile_stale_active_false_when_pane_missing`,
+/// `should_reconcile_stale_active_false_when_not_active`.
+pub(crate) fn should_reconcile_stale_active(
+    record: &SessionRecord,
+    panes: &[PaneInfo],
+    probe: &dyn ChildLivenessProbe,
+) -> bool {
+    record.state == ManagedSessionState::Active
+        && !find_runtime_exited(std::slice::from_ref(record), panes, probe).is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::orphan_gc::AlwaysIdleProbe;
+    use chrono::Utc;
+    use std::path::PathBuf;
+
+    /// Build a minimal `Active` record for a given tmux name — every other
+    /// field is a placeholder; only `state` and `tmux_name` drive the
+    /// predicate under test.
+    fn active_record(tmux_name: &str) -> SessionRecord {
+        SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: tmux_name.to_string(),
+            cwd: PathBuf::from("/tmp/test"),
+            task: "test".into(),
+            state: ManagedSessionState::Active,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: None,
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: false,
+            workspace_owned: false,
+            source_id: None,
+            claude_session_id: None,
+            scrollback_path: None,
+            last_cwd: None,
+            deliverable_id: None,
+        }
+    }
+
+    fn pane(name: &str, cmd: &str) -> PaneInfo {
+        PaneInfo {
+            session_name: name.to_string(),
+            pane_current_command: cmd.to_string(),
+            pane_pid: Some(4242),
+        }
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_true_when_active_and_idle() {
+        // The #2453 repro case: the record still reads Active, but the pane
+        // has genuinely dropped back to a bare shell — reconcile, don't 409.
+        let record = active_record("tm-demo");
+        let panes = vec![pane("tm-demo", "zsh")];
+        assert!(should_reconcile_stale_active(
+            &record,
+            &panes,
+            &AlwaysIdleProbe
+        ));
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_false_when_pane_still_live() {
+        // A genuinely running claude in the record's OWN pane must not be
+        // reconciled — this is the ordinary "record is correctly Active" case.
+        let record = active_record("tm-demo");
+        let panes = vec![pane("tm-demo", "claude")];
+        assert!(!should_reconcile_stale_active(
+            &record,
+            &panes,
+            &AlwaysIdleProbe
+        ));
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_false_when_sibling_pane_live() {
+        // #2157 safety boundary: a DIFFERENT window in the SAME tmux session
+        // still running claude must keep the whole session "live" — the
+        // existing refuse+switch-client behavior for a genuine sibling window
+        // must be preserved, not silently reconciled out from under it.
+        let record = active_record("tm-demo");
+        let panes = vec![pane("tm-demo", "zsh"), pane("tm-demo", "claude")];
+        assert!(!should_reconcile_stale_active(
+            &record,
+            &panes,
+            &AlwaysIdleProbe
+        ));
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_false_when_pane_missing() {
+        // No pane at all for this tmux session (session fully gone) is the
+        // #1744 reaper's job, not this reconcile path — must not reconcile.
+        let record = active_record("tm-demo");
+        assert!(!should_reconcile_stale_active(
+            &record,
+            &[],
+            &AlwaysIdleProbe
+        ));
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_false_when_not_active() {
+        // Every other lifecycle state must fall through to the ordinary 409 —
+        // `mark_reactivated`'s Stopped-only contract is unchanged for these.
+        for state in [
+            ManagedSessionState::Provisioning,
+            ManagedSessionState::Errored,
+            ManagedSessionState::Decommissioned,
+        ] {
+            let mut record = active_record("tm-demo");
+            record.state = state.clone();
+            let panes = vec![pane("tm-demo", "zsh")];
+            assert!(
+                !should_reconcile_stale_active(&record, &panes, &AlwaysIdleProbe),
+                "state {state} must not be reconciled"
+            );
+        }
     }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -47,6 +47,7 @@ pub fn record_to_json(r: &SessionRecord) -> serde_json::Value {
         "proposed_default": r.proposed_default,
         "source_id": r.source_id,
         "deliverable_id": r.deliverable_id.map(|id| id.to_string()),
+        "pane_id": r.pane_id,
     })
 }
 
@@ -76,6 +77,7 @@ pub(super) fn record_to_summary(r: &SessionRecord) -> SessionSummary {
         cwd: Some(r.cwd.to_string_lossy().to_string()),
         claude_session_id: r.claude_session_id.clone(),
         deliverable_id: r.deliverable_id.map(|id| id.to_string()),
+        pane_id: r.pane_id.clone(),
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -37,6 +37,7 @@ fn make_record(source_id: Option<&str>) -> SessionRecord {
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     }
 }
 
@@ -166,6 +167,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         cwd: None,
         claude_session_id: None,
         deliverable_id: None,
+        pane_id: None,
     };
     let resp_owned = DecommissionResponse {
         summary: owned_summary,
@@ -197,6 +199,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         cwd: None,
         claude_session_id: None,
         deliverable_id: None,
+        pane_id: None,
     };
     let resp_unowned = DecommissionResponse {
         summary: unowned_summary,

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -587,6 +587,41 @@ impl TmuxDriver {
         }
     }
 
+    /// Return the pane's stable tmux `pane_id` (e.g. `"%5"`) via `display-message`.
+    ///
+    /// Why: `#2453` review finding 1 (round 2) — pane-identity confirmation for
+    /// the bare-`tm` in-pane relaunch's nested-session guard needs a signal
+    /// that is NEVER inherited across panes, unlike a tmux session-scoped env
+    /// var (`set-environment` is applied to every new pane/window created in
+    /// that session afterward, defeating an env-var-only gate — see
+    /// [`crate::session_manager::record::SessionRecord::pane_id`]'s doc for
+    /// the full empirical proof). tmux's own `pane_id` (distinct from
+    /// `pane_pid`, which the OS can reuse across a pane's lifetime) is that
+    /// signal.
+    /// What: runs `tmux display-message -t <name> -p '#{pane_id}'`, trims the
+    /// output, and returns `Some(id)` on success or `None` if the session does
+    /// not exist, tmux is unavailable, or the id is empty. Mirrors
+    /// [`Self::pane_current_path`]'s exact shape.
+    /// Test: exercised indirectly via `SessionManager::create`/
+    /// `mark_runtime_exited_stopped` with a live tmux;
+    /// `RealTmuxDriver::get_pane_id` wraps this method.
+    pub fn pane_id(&self, session_name: &str) -> Option<String> {
+        let output = Command::new(&self.tmux_path)
+            .args(["display-message", "-t", session_name, "-p", "#{pane_id}"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let raw = String::from_utf8_lossy(&output.stdout);
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
     /// Register an external session for oversight without modifying it.
     ///
     /// Why: before trusty-mpm watches an externally-created session it records

--- a/crates/trusty-mpm/src/project/registry.rs
+++ b/crates/trusty-mpm/src/project/registry.rs
@@ -217,6 +217,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         }
     }
 
@@ -243,6 +244,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/project/resolver/tests.rs
+++ b/crates/trusty-mpm/src/project/resolver/tests.rs
@@ -67,6 +67,7 @@ fn session_with_repo(repo_url: &str) -> SessionRecord {
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     }
 }
 
@@ -93,6 +94,7 @@ fn session_no_repo() -> SessionRecord {
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -160,6 +160,11 @@ impl SessionManager {
         if !self.tmux_driver().session_exists(tmux_name) {
             return Err(ManagedError::TmuxSessionMissing(tmux_name.to_string()));
         }
+        // Capture the pre-existing pane's stable tmux `pane_id` (#2453 review
+        // finding 1, round 2) — best-effort, `None` if the driver cannot
+        // resolve one. Adoption connects to an ALREADY-LIVE pane, so this is
+        // available immediately, unlike a fresh spawn.
+        let pane_id = self.tmux_driver().get_pane_id(tmux_name);
 
         let record = SessionRecord {
             id: ManagedSessionId::new(),
@@ -186,6 +191,7 @@ impl SessionManager {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id,
         };
 
         // ── Atomic already-adopted check + upsert under ONE held write guard ──────
@@ -242,6 +248,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         }
     }
 
@@ -268,6 +275,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/session_manager/backfill_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/backfill_tests.rs
@@ -82,6 +82,7 @@ async fn reconcile_backfills_source_id_from_workspace_git_remote() {
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     };
     mgr.store.write().await.upsert(record).await.expect("seed");
 
@@ -168,6 +169,7 @@ async fn reconcile_backfills_source_id_for_stopped_record() {
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     };
     mgr.store.write().await.upsert(record).await.expect("seed");
 

--- a/crates/trusty-mpm/src/session_manager/create.rs
+++ b/crates/trusty-mpm/src/session_manager/create.rs
@@ -175,6 +175,15 @@ impl SessionManager {
             .create_session(&tmux_name, &workdir)
             .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
 
+        // Capture the freshly-created pane's stable tmux `pane_id` (#2453
+        // review finding 1, round 2) — best-effort; `None` when the driver
+        // does not support it (fake drivers in tests) or the call fails.
+        // This is the ONLY signal the bare-`tm` in-pane relaunch's
+        // nested-session guard can trust to confirm pane-level identity; a
+        // session-scoped env var is inherited by sibling panes/windows and
+        // therefore insufficient (see `SessionRecord::pane_id`'s doc).
+        let pane_id = self.tmux.get_pane_id(&tmux_name);
+
         // OWN the freshly-created tmux session immediately (#1453). From here
         // until the record is durably persisted, this guard is the session's
         // sole owner: any early return (e.g. a failing `store.upsert`) drops the
@@ -224,6 +233,7 @@ impl SessionManager {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id,
         };
 
         // Persist the record. On failure the freshly-created tmux session has

--- a/crates/trusty-mpm/src/session_manager/dedup_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup_tests.rs
@@ -72,6 +72,7 @@ fn rec(
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/driver.rs
+++ b/crates/trusty-mpm/src/session_manager/driver.rs
@@ -93,6 +93,27 @@ pub trait ManagedTmuxDriver: Send + Sync {
         None
     }
 
+    /// Return the session's pane's stable tmux `pane_id` (e.g. `"%5"`),
+    /// captured at spawn/reconcile time for pane-identity confirmation
+    /// (#2453 review finding 1, round 2).
+    ///
+    /// Why: a session-name or process-env-var match is not proof the
+    /// operator's CURRENT pane is the one bound to a record — see
+    /// [`super::record::SessionRecord::pane_id`]'s doc for the full
+    /// rationale (session-scoped `tmux set-environment` is inherited by
+    /// sibling panes created afterward, which defeats an env-var-only gate).
+    /// `pane_id` is tmux's own identifier and is never inherited across
+    /// panes.
+    /// What: returns the `pane_id` tmux format string value, or `None` if
+    /// the driver does not support it or the call fails — the safe default,
+    /// mirroring [`Self::get_pane_cwd`]. Callers MUST treat `None` as
+    /// "identity unconfirmed," never as an implicit match.
+    /// Test: `RealTmuxDriver` runs `tmux display-message`; fake drivers
+    /// return `None` unless a test explicitly seeds one.
+    fn get_pane_id(&self, _name: &str) -> Option<String> {
+        None
+    }
+
     /// Return all live tmux session names on the host.
     fn list_sessions(&self) -> Result<Vec<String>, ManagedError>;
 

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -518,6 +518,16 @@ impl SessionManager {
             ));
         }
         super::snapshot::capture_into(&mut record, &*self.tmux).await;
+        // #2453 review finding 1 (round 2): refresh `pane_id` — the pane
+        // survives this transition (never killed/recreated), so its id is not
+        // expected to change, but re-resolving it here heals legacy records
+        // that never had one captured at spawn time (created before this
+        // field existed). Only overwrite on a successful resolve — a
+        // transient tmux hiccup must not regress a previously-known-good id
+        // back to `None`.
+        if let Some(pane_id) = self.tmux.get_pane_id(&record.tmux_name) {
+            record.pane_id = Some(pane_id);
+        }
         record.state = ManagedSessionState::Stopped;
         guard.upsert(record.clone()).await?;
         drop(guard);
@@ -632,6 +642,14 @@ impl SessionManager {
                 &record.tmux_name,
                 &workdir,
             )?;
+            // #2453 review finding 1 (round 2): the recreated pane is a BRAND
+            // NEW tmux pane — the record's previously-captured `pane_id` now
+            // refers to the DESTROYED pane and must be refreshed, or the
+            // bare-`tm` in-pane relaunch's pane-identity gate would never
+            // match this session again until the next runtime-exit reconcile
+            // heals it. Best-effort — `None` on failure, consistent with
+            // every other `get_pane_id` call site.
+            record.pane_id = self.tmux.get_pane_id(&record.tmux_name);
             info!(
                 id = %id,
                 name = %record.tmux_name,

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -518,15 +518,32 @@ impl SessionManager {
             ));
         }
         super::snapshot::capture_into(&mut record, &*self.tmux).await;
-        // #2453 review finding 1 (round 2): refresh `pane_id` — the pane
-        // survives this transition (never killed/recreated), so its id is not
-        // expected to change, but re-resolving it here heals legacy records
-        // that never had one captured at spawn time (created before this
-        // field existed). Only overwrite on a successful resolve — a
-        // transient tmux hiccup must not regress a previously-known-good id
-        // back to `None`.
-        if let Some(pane_id) = self.tmux.get_pane_id(&record.tmux_name) {
-            record.pane_id = Some(pane_id);
+        // #2453 review finding 1 (round 3 — round 2's re-derive-on-every-call
+        // approach was proven UNSOUND): `get_pane_id` shells out to `tmux
+        // display-message -t <SESSION_NAME> -p '#{pane_id}'`, which is
+        // SESSION-scoped — tmux resolves it to the session's CURRENTLY
+        // ACTIVE window's pane, not necessarily the pane this reconcile is
+        // about. Verified against a live tmux 3.6b: `display-message -t
+        // testsess` reads `%0` with one window, then reads `%1` after `tmux
+        // new-window -t testsess` (which auto-activates the new window) —
+        // the SAME session-scoped query now resolves to a DIFFERENT pane.
+        // Since this function runs on every runtime-exit reconcile (the
+        // periodic reaper, the #2455 SessionEnd hook, and the #2453
+        // reconcile-then-reactivate route), a sibling window merely being
+        // tmux-active at reconcile time would silently OVERWRITE a
+        // known-good `pane_id` with the active sibling's — reopening the
+        // cross-pane hijack via a new vector AND breaking the legitimate
+        // relaunch for the pane that actually exited. Backfill-only-when-
+        // `None` (chosen over re-verifying the stored pane_id via a
+        // pane-scoped `display-message -t <pane_id>` query, #2456 review's
+        // alternative option) is simpler and sufficient: it still heals a
+        // legacy record that never had a `pane_id` captured (created before
+        // this field existed, where session-scoped ambiguity does not yet
+        // matter — no earlier capture exists to protect), but a
+        // known-good id, once captured at spawn/adopt time, is NEVER
+        // re-derived here again.
+        if record.pane_id.is_none() {
+            record.pane_id = self.tmux.get_pane_id(&record.tmux_name);
         }
         record.state = ManagedSessionState::Stopped;
         guard.upsert(record.clone()).await?;

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -470,15 +470,57 @@ impl SessionManager {
     /// Test: `stop_runtime_exited_transitions_active_to_stopped` (in
     /// `daemon::runtime_reap`) asserts the record becomes `Stopped`;
     /// `stop_runtime_exited_does_not_kill_pane` (same module) asserts
-    /// `kill_session` is never invoked on the fake driver.
+    /// `kill_session` is never invoked on the fake driver;
+    /// `mark_runtime_exited_stopped_rejects_concurrently_decommissioned`
+    /// (this module's tests) asserts the CAS guard below.
+    ///
+    /// CAS guard (#2453 review finding 3): the pre-fix implementation read
+    /// the record via [`Self::get`] (which acquires and releases the store's
+    /// write lock internally), then — AFTER that lock was released — did a
+    /// SECOND, separate `self.store.write().await` to upsert. A concurrent
+    /// `decommission`/`stop` landing in the gap between those two lock
+    /// acquisitions would be silently clobbered: this function would blindly
+    /// write back a `Stopped` record built from the stale pre-decommission
+    /// read, resurrecting a session that had just been torn down. This
+    /// implementation now holds ONE write-lock guard across the entire
+    /// read-check-write sequence and re-validates the record is STILL
+    /// `Active` immediately before mutating it — a state change that landed
+    /// while we were not holding the lock (there is no other window) is
+    /// therefore impossible to observe as anything but the CURRENT state,
+    /// and a record that is no longer `Active` (already reconciled,
+    /// decommissioned, or errored by a concurrent caller) is rejected
+    /// with [`ManagedError::InvalidState`] rather than overwritten. The
+    /// periodic `runtime_reap` tick and the `#2453` reconcile-then-reactivate
+    /// path both call this SAME function, so the guard protects both.
     pub async fn mark_runtime_exited_stopped(
         &self,
         id: &ManagedSessionId,
     ) -> Result<SessionRecord, ManagedError> {
-        let mut record = self.get(id).await?;
+        let mut guard = self.store.write().await;
+        if let Err(e) = guard.reload_if_changed().await {
+            // Reload failed (transient I/O): do NOT surface as "not found" —
+            // fall through to the last-known in-memory record, mirroring
+            // `Self::get`'s own tolerance for a transient reload error.
+            warn!(id = %id, "mark_runtime_exited_stopped: reload failed: {e}; using last-known record");
+        }
+        let mut record = guard.cached_get(id).map_err(|e| match e {
+            StoreError::NotFound(k) => ManagedError::SessionNotFound(k),
+            other => ManagedError::Store(other),
+        })?;
+        if record.state != ManagedSessionState::Active {
+            return Err(ManagedError::InvalidState(
+                id.to_string(),
+                format!(
+                    "cannot mark runtime-exited-stopped: session is '{}', not 'active' — \
+                     a concurrent operation already changed its state",
+                    record.state
+                ),
+            ));
+        }
         super::snapshot::capture_into(&mut record, &*self.tmux).await;
         record.state = ManagedSessionState::Stopped;
-        self.store.write().await.upsert(record.clone()).await?;
+        guard.upsert(record.clone()).await?;
+        drop(guard);
         info!(
             id = %id,
             name = %record.tmux_name,

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -69,6 +69,9 @@ mod set_deliverable_id_tests;
 #[cfg(test)]
 mod dedup_tests;
 
+#[cfg(test)]
+mod runtime_exit_reconcile_tests;
+
 /// Real tmux driver adapter — only available when the `daemon` feature (and thus
 /// the daemon's `TmuxDriver`) is compiled in.
 #[cfg(feature = "daemon")]

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -72,6 +72,9 @@ mod dedup_tests;
 #[cfg(test)]
 mod runtime_exit_reconcile_tests;
 
+#[cfg(test)]
+mod reload_error_tests;
+
 /// Real tmux driver adapter — only available when the `daemon` feature (and thus
 /// the daemon's `TmuxDriver`) is compiled in.
 #[cfg(feature = "daemon")]

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -862,6 +862,7 @@ mod orphan_tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         };
         mgr.store
             .write()

--- a/crates/trusty-mpm/src/session_manager/real_tmux.rs
+++ b/crates/trusty-mpm/src/session_manager/real_tmux.rs
@@ -100,6 +100,13 @@ impl ManagedTmuxDriver for RealTmuxDriver {
         self.driver.pane_current_path(name)
     }
 
+    /// Overrides the trait's `None` default so the production path actually
+    /// calls `tmux display-message -p '#{pane_id}'` (#2453 review finding 1,
+    /// round 2).
+    fn get_pane_id(&self, name: &str) -> Option<String> {
+        self.driver.pane_id(name)
+    }
+
     /// Report the runtime ready when the `claude` child PID has appeared under
     /// the pane shell (overrides the trait's weaker `session_exists` default;
     /// issue #1903 / #1299).

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -150,6 +150,10 @@ impl SessionManager {
                     last_cwd: None,
                     // External sessions have no known Deliverable linkage.
                     deliverable_id: None,
+                    // Best-effort capture (#2453 review finding 1, round 2) —
+                    // the adopted pane already exists, so this is available
+                    // immediately, mirroring `adopt.rs`'s explicit adoption path.
+                    pane_id: self.tmux.get_pane_id(name),
                 };
                 if let Some(path) = resolved_cwd {
                     newly_resolved.push((id, path));

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -282,6 +282,38 @@ pub struct SessionRecord {
     /// this field existed was ever bound to a Deliverable.
     #[serde(default)]
     pub deliverable_id: Option<crate::deliverable::DeliverableId>,
+
+    /// The tmux `pane_id` (e.g. `"%5"`) of this session's ORIGINAL pane,
+    /// captured at spawn time and refreshed whenever the runtime-exit
+    /// reconcile confirms the pane is still alive (#2453 review finding 1,
+    /// round 2).
+    ///
+    /// Why: the bare-`tm` in-pane relaunch (`guided::run_guided_default`'s
+    /// nested-session guard, #2453) must confirm the OPERATOR'S CURRENT pane
+    /// is genuinely the one bound to this record before driving a destructive
+    /// `exec` into it — a session-name-only match (every window/pane in a
+    /// tmux session shares the session name) is not enough, and a
+    /// process-env-var comparison was PROVEN insufficient too: tmux's
+    /// session-scoped `set-environment` (used to heal `TM_MANAGED_SESSION_ID`
+    /// into a pane that never got the durable publish, #2157 item 3) is
+    /// inherited into the process env of every NEW pane/window created in
+    /// that tmux session AFTER the healing call — verified empirically
+    /// against a live tmux 3.6b. `pane_id` is tmux's own stable per-pane
+    /// identifier (distinct from `pane_pid`, which the OS can reuse across a
+    /// pane's lifetime); it is NEVER inherited across panes, making it the
+    /// only reliable "is this literally the same pane" signal available.
+    /// What: `None` for every record created before this field existed, or
+    /// whenever the driver could not resolve a pane_id (fails CLOSED — the
+    /// nested-session guard treats an absent/mismatched `pane_id` as
+    /// "identity unconfirmed" and refuses the in-place relaunch rather than
+    /// trusting a weaker signal).
+    ///
+    /// `#[serde(default)]` (→ `None`) keeps every pre-#2453 record
+    /// deserializable — they load with `pane_id = None`, which is correct:
+    /// no session before this field existed had one captured. Mirrors the
+    /// `deliverable_id` rollback-safety pattern immediately above.
+    #[serde(default)]
+    pub pane_id: Option<String>,
 }
 
 /// Error types for session record operations.
@@ -349,6 +381,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -383,6 +416,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -415,6 +449,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -472,6 +507,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         };
         record.runtime = crate::runtime::RuntimeKind::Tcode;
         let json = serde_json::to_string(&record).expect("serialize");
@@ -533,6 +569,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -624,6 +661,7 @@ mod tests {
             scrollback_path: Some(PathBuf::from("/managed/ws/.trusty-mpm/scrollback.txt")),
             last_cwd: Some(PathBuf::from("/managed/ws/src")),
             deliverable_id: None,
+            pane_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -660,6 +698,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");
@@ -724,6 +763,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: Some(did),
+            pane_id: None,
         };
         let json = serde_json::to_string(&record).expect("serialize");
         let back: SessionRecord = serde_json::from_str(&json).expect("deserialize");

--- a/crates/trusty-mpm/src/session_manager/reload_error_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/reload_error_tests.rs
@@ -1,0 +1,62 @@
+//! Tests for `SessionManager::get`'s tolerance of a transient store-reload error.
+//!
+//! Why: `session_manager/tests.rs` is at the 1500-SLOC test cap; this single
+//! test (extracted verbatim, #2453 review finding 1 round 2 — the `pane_id`
+//! field addition pushed `tests.rs` 5 SLOC over budget) lives here, mirroring
+//! `reactivate_tests.rs` / `restart_tests.rs`'s established extraction pattern.
+//! What: `manager_get_returns_last_known_on_reload_error`.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use super::manager::ManagedError;
+use super::record::ManagedSessionId;
+use super::tests::{corrupt_store_file, make_manager};
+
+/// Why: #1219 follow-up — a transient reload error on a single-session lookup
+/// must NOT surface as a false `SessionNotFound`; that would make a still-present
+/// session look gone. `get()` must fall back to the last-known in-memory record.
+/// What: creates a session, corrupts `sessions.json` so the next `get()` reload
+/// fails, and asserts `get()` still returns the previously-loaded record instead
+/// of erroring.
+/// Test: this test.
+#[tokio::test]
+async fn manager_get_returns_last_known_on_reload_error() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "single-session task".into(),
+            Some(PathBuf::from("/tmp/wt-getlastknown")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    let id = record.id;
+
+    // Inject a transient reload failure by corrupting the backing file.
+    corrupt_store_file(&mgr);
+
+    // get() must fall back to the last-known record, not a false not-found.
+    let got = mgr
+        .get(&id)
+        .await
+        .expect("get must return last-known record on reload error");
+    assert_eq!(got.id, id, "get() returned the last-known record");
+
+    // A genuinely-absent id must still be a not-found, even under reload error.
+    let missing = ManagedSessionId::new();
+    assert!(
+        matches!(
+            mgr.get(&missing).await,
+            Err(ManagedError::SessionNotFound(_))
+        ),
+        "an unknown id must still yield SessionNotFound"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/resume_reattach_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_reattach_tests.rs
@@ -51,6 +51,21 @@ async fn manager_resume_reuses_live_pane_without_recreate() {
         .await
         .expect("create");
 
+    // `create` leaves the record `Provisioning`; the real spawn path flips it
+    // to `Active` once the runtime starts. `mark_runtime_exited_stopped`'s
+    // CAS guard (#2453 review finding 3) now requires the record be observed
+    // `Active` at write time — mirroring every real production caller
+    // (`runtime_reap::find_runtime_exited` only ever selects `Active`
+    // records) — so activate it first rather than relying on the pre-guard
+    // behavior of transitioning from ANY prior state.
+    mgr.set_workspace(
+        &record.id,
+        workspace_path.clone(),
+        ManagedSessionState::Active,
+    )
+    .await
+    .expect("set Active");
+
     // Runtime-exit reaper path (#2023 A): marks Stopped WITHOUT killing the pane.
     mgr.mark_runtime_exited_stopped(&record.id)
         .await

--- a/crates/trusty-mpm/src/session_manager/resume_workdir.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_workdir.rs
@@ -178,6 +178,7 @@ mod tests {
             scrollback_path: None,
             last_cwd,
             deliverable_id: None,
+            pane_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/session_manager/runtime_exit_reconcile_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/runtime_exit_reconcile_tests.rs
@@ -1,0 +1,129 @@
+//! Tests for `SessionManager::mark_runtime_exited_stopped`'s CAS guard (#2453
+//! review finding 3).
+//!
+//! Why: `session_manager/tests.rs` is at the 1500-SLOC test cap; this
+//! concurrency-safety regression coverage lives here (mirroring
+//! `reactivate_tests.rs` / `restart_tests.rs`) so neither file grows past its
+//! limit.
+//! What: proves `mark_runtime_exited_stopped` refuses to clobber a record
+//! that moved off `Active` (e.g. via a concurrent decommission) between an
+//! earlier observation and this call, instead of silently overwriting it
+//! back to `Stopped`.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use tempfile::TempDir;
+
+use super::manager::ManagedError;
+use super::record::ManagedSessionState;
+use super::tests::make_manager;
+
+/// A session that moved off `Active` (e.g. decommissioned) between an
+/// earlier read and a `mark_runtime_exited_stopped` call must NOT be
+/// silently resurrected as `Stopped` — the concurrent write must win.
+///
+/// Why: the pre-#2453-review-fix implementation read the record via `get`
+/// (which acquires and releases the store's write lock internally), then did
+/// a SEPARATE `self.store.write().await` to upsert. A decommission landing
+/// in that gap was clobbered: the stale pre-decommission read would be
+/// blindly written back with `state = Stopped`, resurrecting a torn-down
+/// session. The fix holds one write-lock guard across the whole
+/// read-check-write sequence and re-validates `state == Active` immediately
+/// before mutating.
+/// What: creates and activates a session, then simulates the race by forcing
+/// the record to `Decommissioned` (standing in for a concurrent
+/// decommission's effect — `set_workspace` is a direct, unconditional store
+/// write, exactly like the real race would produce), then calls
+/// `mark_runtime_exited_stopped` and asserts it is rejected with
+/// `InvalidState` rather than succeeding, and that the record on disk is
+/// STILL `Decommissioned` afterward (not overwritten to `Stopped`).
+/// Test: this function IS the test.
+#[tokio::test]
+async fn mark_runtime_exited_stopped_rejects_concurrently_decommissioned() {
+    let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_dir.path().to_owned()),
+            None,
+            Some(workspace_dir.path().to_owned()),
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    mgr.set_workspace(
+        &record.id,
+        workspace_dir.path().to_owned(),
+        ManagedSessionState::Active,
+    )
+    .await
+    .expect("set Active");
+
+    // Simulate the race: a concurrent decommission lands BEFORE the
+    // runtime-exit reconcile (periodic reap tick, or the #2453
+    // reconcile-then-reactivate route) observes it.
+    mgr.set_workspace(
+        &record.id,
+        workspace_dir.path().to_owned(),
+        ManagedSessionState::Decommissioned,
+    )
+    .await
+    .expect("set Decommissioned");
+
+    let result = mgr.mark_runtime_exited_stopped(&record.id).await;
+    assert!(
+        matches!(result, Err(ManagedError::InvalidState(_, _))),
+        "must reject a non-Active record instead of clobbering it: {result:?}"
+    );
+
+    let after = mgr
+        .get(&record.id)
+        .await
+        .expect("get after rejected reconcile");
+    assert_eq!(
+        after.state,
+        ManagedSessionState::Decommissioned,
+        "the concurrent decommission must win the race, not be overwritten back to Stopped"
+    );
+}
+
+/// The happy path (record genuinely `Active`) must be unaffected by the CAS
+/// guard — this is a narrow smoke test alongside the negative case above;
+/// the full behavioral coverage (pane preserved, env healed, etc.) already
+/// lives in `daemon::runtime_reap`'s `stop_runtime_exited_*` suite.
+///
+/// Test: this function IS the test.
+#[tokio::test]
+async fn mark_runtime_exited_stopped_still_succeeds_when_active() {
+    let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_dir.path().to_owned()),
+            None,
+            Some(workspace_dir.path().to_owned()),
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    mgr.set_workspace(
+        &record.id,
+        workspace_dir.path().to_owned(),
+        ManagedSessionState::Active,
+    )
+    .await
+    .expect("set Active");
+
+    let stopped = mgr
+        .mark_runtime_exited_stopped(&record.id)
+        .await
+        .expect("mark_runtime_exited_stopped on a genuinely Active record");
+    assert_eq!(stopped.state, ManagedSessionState::Stopped);
+}

--- a/crates/trusty-mpm/src/session_manager/runtime_exit_reconcile_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/runtime_exit_reconcile_tests.rs
@@ -1,5 +1,6 @@
 //! Tests for `SessionManager::mark_runtime_exited_stopped`'s CAS guard (#2453
-//! review finding 3).
+//! review finding 3) and `pane_id` backfill-only-when-`None` guard (#2453
+//! review finding 1, round 3).
 //!
 //! Why: `session_manager/tests.rs` is at the 1500-SLOC test cap; this
 //! concurrency-safety regression coverage lives here (mirroring
@@ -8,12 +9,17 @@
 //! What: proves `mark_runtime_exited_stopped` refuses to clobber a record
 //! that moved off `Active` (e.g. via a concurrent decommission) between an
 //! earlier observation and this call, instead of silently overwriting it
-//! back to `Stopped`.
+//! back to `Stopped`; and proves a known-good `pane_id` is never re-derived
+//! via the SESSION-scoped `get_pane_id` query (which tmux resolves to
+//! whichever window is CURRENTLY ACTIVE, not necessarily the pane this
+//! reconcile is about).
 //! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use std::sync::Arc;
 
 use tempfile::TempDir;
 
-use super::manager::ManagedError;
+use super::manager::{ManagedError, ManagedTmuxDriver, SessionManager};
 use super::record::ManagedSessionState;
 use super::tests::make_manager;
 
@@ -126,4 +132,161 @@ async fn mark_runtime_exited_stopped_still_succeeds_when_active() {
         .await
         .expect("mark_runtime_exited_stopped on a genuinely Active record");
     assert_eq!(stopped.state, ManagedSessionState::Stopped);
+}
+
+/// A driver whose `get_pane_id` always reports a DIFFERENT pane than the one
+/// already recorded — stands in for tmux's session-scoped `display-message`
+/// resolving to a SIBLING window that happens to be tmux-active at the
+/// moment a runtime-exit reconcile fires (#2453 review finding 1, round 3;
+/// live-verified against tmux 3.6b: `display-message -t <session>` tracks
+/// whichever window was most recently activated, NOT a specific pane).
+/// Every other method is a trivial success/no-op — this driver exists
+/// solely to exercise the `get_pane_id` call path.
+struct SiblingActiveTmuxDriver;
+
+impl ManagedTmuxDriver for SiblingActiveTmuxDriver {
+    fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+    fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+    fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
+        Ok(String::new())
+    }
+    fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+        Ok(Vec::new())
+    }
+    fn get_pane_id(&self, _name: &str) -> Option<String> {
+        // The session-scoped query resolving to the SIBLING window's pane —
+        // deliberately different from the record's already-known pane_id.
+        Some("%9-sibling-active".to_string())
+    }
+}
+
+/// A known-good `pane_id` (already captured at spawn/adopt time, or by an
+/// earlier reconcile) must NEVER be overwritten by a later
+/// `mark_runtime_exited_stopped` call, even when the SESSION-scoped
+/// `get_pane_id` query resolves to a DIFFERENT (sibling-window) pane.
+///
+/// Why: `get_pane_id` shells out to `tmux display-message -t <SESSION_NAME>
+/// -p '#{pane_id}'`, which tmux resolves to the session's CURRENTLY ACTIVE
+/// window — not necessarily the pane this reconcile is about. Since this
+/// function runs on every runtime-exit reconcile (the periodic reaper, the
+/// #2455 `SessionEnd` hook, and the #2453 reconcile-then-reactivate route),
+/// re-deriving `pane_id` unconditionally would let a sibling window merely
+/// being tmux-active at reconcile time silently overwrite a known-good id —
+/// reopening the cross-pane hijack (#2456 review finding 1) via a new
+/// vector, and breaking the legitimate relaunch for the pane that actually
+/// exited. The fix is backfill-only-when-`None`: a KNOWN pane_id is left
+/// alone; only a genuinely absent one (a legacy record, or one never
+/// captured) is backfilled.
+/// What: seeds a record with a known-good `pane_id` directly (standing in
+/// for a spawn-time capture), points the manager at
+/// [`SiblingActiveTmuxDriver`] (whose `get_pane_id` always returns a
+/// DIFFERENT id), calls `mark_runtime_exited_stopped`, and asserts the
+/// returned record's `pane_id` is STILL the original — never overwritten
+/// with the driver's "sibling active" value.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn mark_runtime_exited_stopped_never_overwrites_known_pane_id() {
+    let dir = TempDir::new().unwrap();
+    let driver: Arc<dyn ManagedTmuxDriver> = Arc::new(SiblingActiveTmuxDriver);
+    let mgr = SessionManager::new(dir.path(), driver)
+        .await
+        .expect("manager");
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(std::path::PathBuf::from("/tmp/sibling-active-test")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+
+    // Seed a KNOWN-GOOD pane_id directly (standing in for the id a real
+    // spawn/adopt would have captured) and activate the record — mirroring
+    // what a genuinely-running session looks like right before its runtime
+    // exits.
+    let original_pane_id = "%0-original".to_string();
+    {
+        let mut seeded = mgr.get(&record.id).await.expect("get");
+        seeded.pane_id = Some(original_pane_id.clone());
+        seeded.state = ManagedSessionState::Active;
+        mgr.store
+            .write()
+            .await
+            .upsert(seeded)
+            .await
+            .expect("seed known-good pane_id");
+    }
+
+    let stopped = mgr
+        .mark_runtime_exited_stopped(&record.id)
+        .await
+        .expect("mark_runtime_exited_stopped");
+
+    assert_eq!(
+        stopped.pane_id.as_deref(),
+        Some(original_pane_id.as_str()),
+        "a known-good pane_id must NEVER be overwritten by the session-scoped \
+         re-derive, even when a sibling window is tmux-active at reconcile time \
+         (driver reports a different id: {:?})",
+        SiblingActiveTmuxDriver.get_pane_id(&stopped.tmux_name)
+    );
+}
+
+/// The inverse of the above: a record that never had a `pane_id` captured
+/// (a legacy record, or one whose spawn-time capture failed) MUST still be
+/// healed by a runtime-exit reconcile — backfill-only-when-`None` heals,
+/// it just never clobbers a KNOWN value.
+///
+/// Test: this function IS the test.
+#[tokio::test]
+async fn mark_runtime_exited_stopped_backfills_when_pane_id_absent() {
+    let dir = TempDir::new().unwrap();
+    let driver: Arc<dyn ManagedTmuxDriver> = Arc::new(SiblingActiveTmuxDriver);
+    let mgr = SessionManager::new(dir.path(), driver)
+        .await
+        .expect("manager");
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(std::path::PathBuf::from("/tmp/backfill-test")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    // `create` never captures a pane_id against this fake driver (its
+    // `create_session` is a no-op) — the record starts with `pane_id: None`,
+    // mirroring a genuinely legacy pre-#2453 record.
+    mgr.set_workspace(
+        &record.id,
+        std::path::PathBuf::from("/tmp/backfill-test"),
+        ManagedSessionState::Active,
+    )
+    .await
+    .expect("set Active");
+
+    let stopped = mgr
+        .mark_runtime_exited_stopped(&record.id)
+        .await
+        .expect("mark_runtime_exited_stopped");
+
+    assert_eq!(
+        stopped.pane_id.as_deref(),
+        Some("%9-sibling-active"),
+        "an absent pane_id must still be backfilled from the driver"
+    );
 }

--- a/crates/trusty-mpm/src/session_manager/snapshot.rs
+++ b/crates/trusty-mpm/src/session_manager/snapshot.rs
@@ -239,6 +239,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/session_manager/store.rs
+++ b/crates/trusty-mpm/src/session_manager/store.rs
@@ -371,6 +371,7 @@ mod tests {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -588,6 +588,7 @@ fn make_active_test_record(tmux_name: &str, task: &str, ws_path: &str) -> Sessio
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     }
 }
 
@@ -682,6 +683,7 @@ async fn manager_reconcile_skips_decommissioned() {
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     };
     {
         let mut store = mgr.store.write().await;
@@ -1260,7 +1262,11 @@ async fn manager_adopt_existing_allows_non_tmpm_name() {
 /// detects a change and re-reads, and (b) makes `serde_json::from_str` fail with
 /// `StoreError::Serialize` — a faithful stand-in for a transient reload I/O error
 /// (NFS hiccup, partial write observed by a reader, etc.).
-fn corrupt_store_file(mgr: &SessionManager) {
+///
+/// `pub(super)`: also used by `reload_error_tests.rs` (#2453 review finding 1,
+/// round 2 — extracted from this file to stay under the 1500-SLOC test cap
+/// after the `pane_id` field addition).
+pub(super) fn corrupt_store_file(mgr: &SessionManager) {
     let path = mgr.data_dir().join("sessions.json");
     std::fs::write(&path, b"{ this is not valid json ]").expect("corrupt store file");
 }
@@ -1316,51 +1322,9 @@ async fn manager_list_returns_last_known_on_reload_error() {
     );
 }
 
-/// Why: #1219 follow-up — a transient reload error on a single-session lookup
-/// must NOT surface as a false `SessionNotFound`; that would make a still-present
-/// session look gone. `get()` must fall back to the last-known in-memory record.
-/// What: creates a session, corrupts `sessions.json` so the next `get()` reload
-/// fails, and asserts `get()` still returns the previously-loaded record instead
-/// of erroring.
-/// Test: this test.
-#[tokio::test]
-async fn manager_get_returns_last_known_on_reload_error() {
-    let dir = TempDir::new().unwrap();
-    let (mgr, _fake) = make_manager(&dir).await;
-
-    let record = mgr
-        .create(
-            "single-session task".into(),
-            Some(PathBuf::from("/tmp/wt-getlastknown")),
-            None,
-            None,
-            None,
-            None,
-        )
-        .await
-        .expect("create");
-    let id = record.id;
-
-    // Inject a transient reload failure by corrupting the backing file.
-    corrupt_store_file(&mgr);
-
-    // get() must fall back to the last-known record, not a false not-found.
-    let got = mgr
-        .get(&id)
-        .await
-        .expect("get must return last-known record on reload error");
-    assert_eq!(got.id, id, "get() returned the last-known record");
-
-    // A genuinely-absent id must still be a not-found, even under reload error.
-    let missing = ManagedSessionId::new();
-    assert!(
-        matches!(
-            mgr.get(&missing).await,
-            Err(ManagedError::SessionNotFound(_))
-        ),
-        "an unknown id must still yield SessionNotFound"
-    );
-}
+// `manager_get_returns_last_known_on_reload_error` was extracted to
+// `reload_error_tests.rs` (#2453 review finding 1 round 2 — keeps this file
+// under the 1500-SLOC test cap after the `pane_id` field addition).
 
 // ── #1508: ephemeral tagging, bulk teardown, by-state prune, compaction ─────────
 
@@ -1425,6 +1389,7 @@ pub(super) async fn seed_record(
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     };
     if seeds_live_tmux {
         mgr.tmux
@@ -1860,6 +1825,7 @@ async fn reap_aged_ephemeral_picks_old_ephemeral_only() {
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         };
         mgr.store.write().await.upsert(record).await.expect("seed");
     }
@@ -1946,6 +1912,7 @@ async fn manager_decommission_unowned_skips_deletion() {
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     };
     mgr.store.write().await.upsert(record).await.unwrap();
 

--- a/crates/trusty-mpm/src/supervisor/tests.rs
+++ b/crates/trusty-mpm/src/supervisor/tests.rs
@@ -179,6 +179,7 @@ async fn seed_sessions(
             scrollback_path: None,
             last_cwd: None,
             deliverable_id: None,
+            pane_id: None,
         };
         store.upsert(rec).await.expect("seed upsert");
         ids.push(id);
@@ -311,6 +312,7 @@ fn rec(state: ManagedSessionState, pending: Option<&str>) -> SessionRecord {
         scrollback_path: None,
         last_cwd: None,
         deliverable_id: None,
+        pane_id: None,
     }
 }
 


### PR DESCRIPTION
## Root cause

`SessionRecord.state` lags reality by up to 60s after a managed pane's
`claude` process exits (the periodic `runtime_reap` tick, or a racing
`SessionEnd` hook, hasn't caught up yet). Two independent code paths both
trusted that stale state:

1. `guided_inplace::try_inplace_relaunch` only takes the in-place path when
   the fetched record reads `"stopped"` (bounded ~400ms poll). A record still
   `"active"` at that point falls through.
2. `guided::run_guided_default`'s nested-session guard then matches the
   current tmux session against that same stale-`"active"` record and calls
   `guided_resume::resume_guided_session`, which — because the tmux *session*
   is (correctly) still alive — resolves to `tmux_attach`'s `switch-client`:
   a no-op back into the pane the operator is already sitting in.

Net effect: the exit banner promises "run `tm` to relaunch this session,"
but bare `tm` typed immediately after `claude` exits just switch-clients to
the same pane, leaving it at a bare shell prompt.

## Fix

- **`crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs`** — when a
  reactivate request (`POST /api/v1/sessions/managed/{id}/reactivate`) hits
  a non-`Stopped` record, `reconcile_stale_active_then_reactivate` now
  independently re-classifies the record's own tmux pane(s) using the SAME
  conservative gate `runtime_reap::find_runtime_exited` already uses on its
  periodic tick, and folds the `mark_runtime_exited_stopped` transition into
  the reactivate call when the runtime is confirmed idle — instead of a bare
  409. A genuinely live runtime, or a still-active sibling window in the same
  tmux session (#2157's concern), still keeps the 409 refusal. The pure
  decision (`should_reconcile_stale_active`) is exhaustively unit-tested.
- **`crates/trusty-mpm/src/bin/tm/commands/guided.rs`** — the nested-session
  guard now routes its match through the SAME in-place-relaunch primitive
  #2023 component C uses (`guided_inplace::run_inplace_relaunch`) instead of
  going straight to `resume_guided_session` -> `tmux_attach`. The daemon
  reactivate round-trip above is the sole safety authority (never an
  unconditional exec); a refusal falls back to the existing
  refuse+reconnect(switch-client) notice, now with an explicit
  "in-place relaunch unavailable" line first.
- **`crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs`** —
  `run_inplace_relaunch` / `InPlaceOutcome` made `pub(crate)` for the new
  call site, with doc comments explaining the safety argument (state-agnostic
  by design; the daemon's reactivate response is the single source of truth).

`RELAUNCH_HINT` in `runtime/claude_code.rs` was left unchanged — it becomes
accurate in every reachable state after this fix (the remaining refusal case,
a genuinely live sibling window in the same tmux session, is the same
concurrent-runtime hazard #2157 already guards against and prints its own
explicit fallback notice for).

## Test evidence

New unit tests (daemon-side pure predicate, the crux of the fix):
```
test daemon::managed_routes::reactivate::tests::should_reconcile_stale_active_false_when_not_active ... ok
test daemon::managed_routes::reactivate::tests::should_reconcile_stale_active_false_when_pane_still_live ... ok
test daemon::managed_routes::reactivate::tests::should_reconcile_stale_active_false_when_sibling_pane_live ... ok
test daemon::managed_routes::reactivate::tests::should_reconcile_stale_active_false_when_pane_missing ... ok
test daemon::managed_routes::reactivate::tests::should_reconcile_stale_active_true_when_active_and_idle ... ok

test result: ok. 5 passed; 0 failed
```

CLI-side guided/guided_inplace suite (unchanged tests still green):
```
test result: ok. 77 passed; 0 failed; 0 ignored; 0 measured; 756 filtered out
```

Full workspace quality gate, run in order from a dedicated worktree branched
off `origin/main`:
```
$ cargo build --workspace
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.19s

$ cargo test --workspace
130 test binaries, 0 failures (grep -c "^test result: ok" == 130; no "0 failed"-violating lines)

$ cargo clippy --workspace --all-targets -- -D warnings
EXIT CODE: 0   (0 error lines)

$ cargo fmt --check
EXIT fmt: 0

$ bash scripts/check_line_cap.sh
line-cap: 0 allowlisted, 0 violations — OK.
```

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 130/130 test binaries pass, 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 errors
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] New regression tests for the reconcile predicate (`should_reconcile_stale_active_*`)

Closes #2453

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools