### PR TITLE
chore(trusty-review): v0.9.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11094,7 +11094,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "0.15.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.8.1" }
+trusty-review = { path = "crates/trusty-review", version = "0.9.0" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [0.9.0] — 2026-07-11
+
+### Added
+
+- `report --analyze` — deterministic `complexity_distribution` + RED/AMBER findings from the trusty-analyze daemon, fail-open to scan; balanced severity map ([#2452](https://github.com/bobmatnyc/trusty-tools/pull/2452), epic [#2445](https://github.com/bobmatnyc/trusty-tools/issues/2445)) ([`569a88a`](https://github.com/bobmatnyc/trusty-tools/commit/569a88ab2be33551ed46f6a938160523e8d0c7a7))
+
+### Changed
+
+- Root workspace `[workspace.dependencies]` pin for `trusty-review` bumped 0.8.1 → 0.9.0 (consumed by `trusty-analyze`'s optional `review` feature).
+
 ## [0.8.1] — 2026-07-11
 
 ### Fixed

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.8.1"
+version     = "0.9.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/README.md
+++ b/crates/trusty-review/README.md
@@ -420,6 +420,15 @@ brief still layers on top as an additive emphasis overlay.
 Full detail on the scan heuristics, provenance model, and instruction
 layering: [docs/trusty-review/spec/report-generation.md](../../docs/trusty-review/spec/report-generation.md).
 
+### `--analyze` (deterministic trusty-analyze integration)
+
+`--analyze` populates the metrics-driven sections (the complexity-distribution
+chart + RED/AMBER findings) from a live trusty-analyze daemon (`:7879`)
+without an LLM or a hand-authored metrics JSON. It is fully deterministic and
+fail-open: any probe, fetch, or parse failure degrades to the built-in scan
+rather than erroring — a missing analyze index is never fatal. Full detail:
+[docs/trusty-review/spec/report-generation.md](../../docs/trusty-review/spec/report-generation.md).
+
 ### Mermaid charts (`--no-mermaid`)
 
 Every populated Graph-Ready Data Appendix table (tagged with a


### PR DESCRIPTION
## Summary
- Bumps `trusty-review` 0.8.1 -> 0.9.0 (MINOR) to release the deterministic trusty-analyze integration: `report --analyze` populates complexity_distribution + RED/AMBER findings from the trusty-analyze daemon, fail-open to the built-in scan (epic #2445, PR #2452, merged 569a88ab).
- Root workspace `[workspace.dependencies]` pin for `trusty-review` bumped 0.8.1 -> 0.9.0 (consumed by trusty-analyze's optional `review` feature).
- README `report --analyze` section added; CHANGELOG 0.9.0 entry added.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings`
- [x] `cargo test -p trusty-review` (1336 + 39 + 2 + 3 + 3 passed, 0 failed, 4 ignored)
- [x] `cargo check --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)