### PR TITLE
feat(trusty-mpm): multipane TUI skeleton — 4-pane projects control plane

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -148,6 +148,15 @@ pub(crate) enum Command {
     /// cover the L3-substrate work-tracking ledger (§10). Mutating session verbs
     /// deliberately live at `tm sessions`; `tm projects show` surfaces sessions
     /// read-only per the naming split.
+    ///
+    /// `action` stays a MANDATORY clap subcommand (#2118 does not relax this):
+    /// a bare, non-interactive `tm projects` must keep failing with clap's own
+    /// "requires a subcommand" usage error (exit code 2), unchanged. The
+    /// interactive case — bare `tm projects` on a TTY launches the 4-pane
+    /// project-control-plane TUI skeleton — is intercepted in `main.rs` BEFORE
+    /// `Cli::try_parse()` even runs (see `main.rs`'s module doc and
+    /// `commands::projects::launch_bare_tui`), so it never has to touch this
+    /// mandatory-subcommand shape at all.
     /// What: the `tm projects <action>` command group.
     /// Test: `cli_parses_projects_*` in `tests_projects.rs`.
     Projects {

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs
@@ -5,9 +5,13 @@
 //! subtree — `registry` (list/register/show/status), `deliverables`, and
 //! `milestones` — each a sibling file well under the 500-SLOC cap, with this
 //! `mod.rs` a thin dispatcher plus the shared clap-arg → domain-type conversions.
-//! What: [`projects`] routes a [`ProjectsAction`] to the right subtree handler;
-//! the `convert` submodule maps the CLI value enums to `trusty_mpm::deliverable`
-//! domain types so `cli.rs` stays free of a domain dependency.
+//! What: [`projects`] routes a [`ProjectsAction`] to the right subtree handler
+//! (unchanged since #2115); [`launch_bare_tui`] is the interactive-TTY entry
+//! point `main.rs` calls for a bare `tm projects` BEFORE clap parsing even
+//! runs (#2118 — see `main.rs`'s module doc for why the interception happens
+//! there rather than by relaxing `ProjectsAction` to `Option`). The `convert`
+//! submodule maps the CLI value enums to `trusty_mpm::deliverable` domain types
+//! so `cli.rs` stays free of a domain dependency.
 //! Test: `cli_parses_projects_*` (parse) in `tests_projects.rs`; the per-subtree
 //! rendering/serialization tests live in each submodule.
 
@@ -17,6 +21,58 @@ pub(crate) mod milestones;
 pub(crate) mod registry;
 
 use crate::cli::ProjectsAction;
+
+/// Poll interval (ms) for the `tm projects` TUI launched from a bare, TTY
+/// invocation (#2118).
+///
+/// Why: named separately from `Command::Tui`'s / `SessionAction::Tui`'s own
+/// `--interval-ms` flags because a bare `tm projects` has no flag surface of
+/// its own to read one from; 1500ms matches `tm sessions tui`'s default.
+const PROJECT_CTL_INTERVAL_MS: u64 = 1500;
+
+/// Launch the `tm projects` 4-pane TUI for a bare, interactive invocation (#2118).
+///
+/// Why: `main.rs` intercepts a bare `tm projects` (exactly `["tm", "projects"]`,
+/// no further arguments) BEFORE `Cli::try_parse()` runs, once stdout is
+/// confirmed a TTY — see `main.rs`'s module doc. Doing the interception there
+/// (rather than by making `ProjectsAction` an `Option` and branching inside
+/// this module's dispatcher) means `tm projects <verb>` and a non-interactive
+/// bare `tm projects` both flow through the UNMODIFIED clap definition, so
+/// clap's own pre-#2118 "requires a subcommand" usage error (exit code 2) for
+/// the latter is preserved byte-for-byte — reproducing that error manually
+/// was tried and does not exactly match clap's internal formatting (it omits
+/// the `[subcommands: …]` hint clap derives from richer internal match
+/// context), so delegating to the untouched parse path is the more reliable
+/// choice.
+/// What: resolves the daemon URL exactly as the normal dispatch path would
+/// for an unspecified `--url` (a bare invocation has no flags to read one
+/// from) and hands off to `trusty_mpm::tui::project_ctl::run`.
+/// Test: terminal glue, exercised by launching the TUI; the argv-shape half
+/// of the interception condition is [`is_bare_projects_argv`], which IS unit
+/// tested (the `stdout().is_terminal()` half is not — see its doc).
+pub(crate) async fn launch_bare_tui() -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let url =
+        trusty_mpm::core::resolve_daemon_url_via_gateway(&client, Some(crate::cli::DEFAULT_URL))
+            .await;
+    trusty_mpm::tui::project_ctl::run(url, PROJECT_CTL_INTERVAL_MS).await
+}
+
+/// True when `argv` is exactly a bare `tm projects` invocation (#2118).
+///
+/// Why: `main.rs` combines this with a real `stdout().is_terminal()` check
+/// before intercepting ahead of `Cli::try_parse()`. Pulling the argv-shape
+/// half out into its own pure function keeps it unit-testable without
+/// spawning a subprocess or faking a TTY (the actual liveness check is a
+/// one-line, untestable `std::io` call left in `main.rs`).
+/// What: true only when `argv` has exactly two elements and the second is
+/// literally `"projects"` — any flag (e.g. `--url ...`) or any verb makes
+/// this false, so `tm projects list`, `tm --url … projects`, and every other
+/// shape falls through to the unmodified clap parse path unaffected.
+/// Test: `tests::is_bare_projects_argv_matches_only_the_exact_bare_form`.
+pub(crate) fn is_bare_projects_argv(argv: &[String]) -> bool {
+    argv.len() == 2 && argv[1] == "projects"
+}
 
 /// Dispatch a `tm projects <action>` invocation to its subtree handler.
 ///
@@ -63,5 +119,22 @@ pub(crate) async fn projects(
             deliverables::dispatch(client, url, action).await
         }
         ProjectsAction::Milestones { action } => milestones::dispatch(client, url, action).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_bare_projects_argv_matches_only_the_exact_bare_form() {
+        let owned = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert!(is_bare_projects_argv(&owned(&["tm", "projects"])));
+        assert!(!is_bare_projects_argv(&owned(&["tm", "projects", "list"])));
+        assert!(!is_bare_projects_argv(&owned(&[
+            "tm", "--url", "http://x", "projects"
+        ])));
+        assert!(!is_bare_projects_argv(&owned(&["tm"])));
+        assert!(!is_bare_projects_argv(&owned(&["tm", "sessions"])));
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs
@@ -6,12 +6,14 @@
 //! `milestones` — each a sibling file well under the 500-SLOC cap, with this
 //! `mod.rs` a thin dispatcher plus the shared clap-arg → domain-type conversions.
 //! What: [`projects`] routes a [`ProjectsAction`] to the right subtree handler
-//! (unchanged since #2115); [`launch_bare_tui`] is the interactive-TTY entry
-//! point `main.rs` calls for a bare `tm projects` BEFORE clap parsing even
-//! runs (#2118 — see `main.rs`'s module doc for why the interception happens
-//! there rather than by relaxing `ProjectsAction` to `Option`). The `convert`
-//! submodule maps the CLI value enums to `trusty_mpm::deliverable` domain types
-//! so `cli.rs` stays free of a domain dependency.
+//! (unchanged since #2115); [`launch_bare_tui`] is the interactive entry point
+//! `main.rs` calls for a bare `tm projects` BEFORE clap parsing even runs
+//! (#2118 — see `main.rs`'s module doc for why the interception happens there
+//! rather than by relaxing `ProjectsAction` to `Option`), gated by
+//! [`should_launch_bare_tui`] on BOTH stdin and stdout being real terminals
+//! (not stdout alone — see that function's doc for the footgun this avoids).
+//! The `convert` submodule maps the CLI value enums to `trusty_mpm::deliverable`
+//! domain types so `cli.rs` stays free of a domain dependency.
 //! Test: `cli_parses_projects_*` (parse) in `tests_projects.rs`; the per-subtree
 //! rendering/serialization tests live in each submodule.
 
@@ -33,23 +35,22 @@ const PROJECT_CTL_INTERVAL_MS: u64 = 1500;
 /// Launch the `tm projects` 4-pane TUI for a bare, interactive invocation (#2118).
 ///
 /// Why: `main.rs` intercepts a bare `tm projects` (exactly `["tm", "projects"]`,
-/// no further arguments) BEFORE `Cli::try_parse()` runs, once stdout is
-/// confirmed a TTY — see `main.rs`'s module doc. Doing the interception there
-/// (rather than by making `ProjectsAction` an `Option` and branching inside
-/// this module's dispatcher) means `tm projects <verb>` and a non-interactive
-/// bare `tm projects` both flow through the UNMODIFIED clap definition, so
-/// clap's own pre-#2118 "requires a subcommand" usage error (exit code 2) for
-/// the latter is preserved byte-for-byte — reproducing that error manually
-/// was tried and does not exactly match clap's internal formatting (it omits
-/// the `[subcommands: …]` hint clap derives from richer internal match
-/// context), so delegating to the untouched parse path is the more reliable
-/// choice.
+/// no further arguments, both stdin AND stdout confirmed real terminals — see
+/// [`should_launch_bare_tui`]) BEFORE `Cli::try_parse()` runs — see `main.rs`'s
+/// module doc. Doing the interception there (rather than by making
+/// `ProjectsAction` an `Option` and branching inside this module's dispatcher)
+/// means `tm projects <verb>` and a non-interactive bare `tm projects` both
+/// flow through the UNMODIFIED clap definition, so clap's own pre-#2118
+/// "requires a subcommand" usage error (exit code 2) for the latter is
+/// preserved byte-for-byte — reproducing that error manually was tried and
+/// does not exactly match clap's internal formatting (it omits the
+/// `[subcommands: …]` hint clap derives from richer internal match context),
+/// so delegating to the untouched parse path is the more reliable choice.
 /// What: resolves the daemon URL exactly as the normal dispatch path would
 /// for an unspecified `--url` (a bare invocation has no flags to read one
 /// from) and hands off to `trusty_mpm::tui::project_ctl::run`.
-/// Test: terminal glue, exercised by launching the TUI; the argv-shape half
-/// of the interception condition is [`is_bare_projects_argv`], which IS unit
-/// tested (the `stdout().is_terminal()` half is not — see its doc).
+/// Test: terminal glue, exercised by launching the TUI; the gate condition
+/// itself is [`should_launch_bare_tui`], which IS unit tested.
 pub(crate) async fn launch_bare_tui() -> anyhow::Result<()> {
     let client = reqwest::Client::new();
     let url =
@@ -60,11 +61,8 @@ pub(crate) async fn launch_bare_tui() -> anyhow::Result<()> {
 
 /// True when `argv` is exactly a bare `tm projects` invocation (#2118).
 ///
-/// Why: `main.rs` combines this with a real `stdout().is_terminal()` check
-/// before intercepting ahead of `Cli::try_parse()`. Pulling the argv-shape
-/// half out into its own pure function keeps it unit-testable without
-/// spawning a subprocess or faking a TTY (the actual liveness check is a
-/// one-line, untestable `std::io` call left in `main.rs`).
+/// Why: split out of [`should_launch_bare_tui`] so the argv-shape rule and the
+/// stream-liveness rule are each independently testable.
 /// What: true only when `argv` has exactly two elements and the second is
 /// literally `"projects"` — any flag (e.g. `--url ...`) or any verb makes
 /// this false, so `tm projects list`, `tm --url … projects`, and every other
@@ -72,6 +70,27 @@ pub(crate) async fn launch_bare_tui() -> anyhow::Result<()> {
 /// Test: `tests::is_bare_projects_argv_matches_only_the_exact_bare_form`.
 pub(crate) fn is_bare_projects_argv(argv: &[String]) -> bool {
     argv.len() == 2 && argv[1] == "projects"
+}
+
+/// True when a bare `tm projects` invocation should launch the interactive TUI.
+///
+/// Why: launching a full-screen, raw-mode TUI requires BOTH stdin and stdout
+/// to be real terminals. The initial #2118 landing checked stdout alone,
+/// which left a footgun: a supervisor/wrapper that redirects stdin from
+/// `/dev/null` while leaving stdout attached to a pty (systemd, launchd, some
+/// CI runners) would still see `stdout.is_terminal() == true` and launch a
+/// raw-mode TUI against a dead stdin — with no keyboard path able to ever
+/// send `q`/Ctrl-C, only an external signal can kill it. Mirrors
+/// `session_picker::should_show_picker`'s established "require both streams"
+/// convention in this same codebase. Taking `stdin_tty`/`stdout_tty` as plain
+/// `bool` parameters (rather than calling `std::io::stdin()/stdout()` here)
+/// keeps this pure and unit-testable without faking a real terminal; `main.rs`
+/// supplies the real `is_terminal()` results at the one call site.
+/// What: true only when [`is_bare_projects_argv`] AND `stdin_tty` AND
+/// `stdout_tty` are all true.
+/// Test: `tests::should_launch_bare_tui_requires_both_streams`.
+pub(crate) fn should_launch_bare_tui(argv: &[String], stdin_tty: bool, stdout_tty: bool) -> bool {
+    is_bare_projects_argv(argv) && stdin_tty && stdout_tty
 }
 
 /// Dispatch a `tm projects <action>` invocation to its subtree handler.
@@ -136,5 +155,29 @@ mod tests {
         ])));
         assert!(!is_bare_projects_argv(&owned(&["tm"])));
         assert!(!is_bare_projects_argv(&owned(&["tm", "sessions"])));
+    }
+
+    #[test]
+    fn should_launch_bare_tui_requires_both_streams() {
+        let argv = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        let bare = argv(&["tm", "projects"]);
+
+        // Both streams are real terminals: launch.
+        assert!(should_launch_bare_tui(&bare, true, true));
+
+        // stdout is a tty but stdin is NOT (the reviewer-reported footgun: a
+        // supervisor/wrapper redirects stdin from /dev/null while stdout stays
+        // attached to a pty) — must NOT launch a raw-mode TUI with a dead stdin.
+        assert!(!should_launch_bare_tui(&bare, false, true));
+
+        // stdin is a tty but stdout is NOT (piped output) — must not launch.
+        assert!(!should_launch_bare_tui(&bare, true, false));
+
+        // Neither stream is a tty (fully non-interactive) — must not launch.
+        assert!(!should_launch_bare_tui(&bare, false, false));
+
+        // Even with both streams live, a non-bare invocation never launches.
+        let verb = argv(&["tm", "projects", "list"]);
+        assert!(!should_launch_bare_tui(&verb, true, true));
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -13,6 +13,8 @@ mod formatters;
 mod gh_identity;
 mod types;
 
+use std::io::IsTerminal as _;
+
 use clap::Parser;
 use cli::{Cli, Command};
 use commands::{
@@ -77,12 +79,31 @@ static HELP: std::sync::LazyLock<trusty_common::help::HelpConfig> =
 /// tracing init, exit codes) while the handlers own the domain logic.
 /// What: tries to parse via `clap::Parser::try_parse`, prints a "did you
 /// mean?" hint on an unknown-subcommand error, then dispatches.
-/// Test: integration tests in `tests.rs` exercise every dispatch branch.
+///
+/// #2118: a bare `tm projects` (no verb) on an interactive TTY is intercepted
+/// HERE, before `Cli::try_parse()` even runs, and launches the 4-pane
+/// project-control-plane TUI skeleton. The interception happens this early —
+/// rather than by relaxing `ProjectsAction` to `Option` and branching inside
+/// the dispatcher — specifically so `tm projects <verb>` and a
+/// non-interactive bare `tm projects` both flow through the completely
+/// unmodified clap definition: the latter must keep failing with clap's own
+/// "requires a subcommand" usage error (exit code 2), byte-for-byte identical
+/// to the pre-#2118 behavior. See `commands::projects::is_bare_projects_argv`
+/// and `commands::projects::launch_bare_tui`.
+/// Test: integration tests in `tests.rs` exercise every dispatch branch; the
+/// argv-shape half of the #2118 interception is unit tested in
+/// `commands::projects::tests`.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Why: parse via `try_parse` so we can attach the workspace-shared
     // "did you mean?" suggestion (issue #216) before exiting on a clap error.
     let argv: Vec<String> = std::env::args().collect();
+
+    // #2118: see this function's module doc for why this runs before parsing.
+    if commands::projects::is_bare_projects_argv(&argv) && std::io::stdout().is_terminal() {
+        return commands::projects::launch_bare_tui().await;
+    }
+
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
         Err(e) => {

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -86,13 +86,18 @@ static HELP: std::sync::LazyLock<trusty_common::help::HelpConfig> =
 /// early — rather than by relaxing `ProjectsAction` to `Option` and branching
 /// inside the dispatcher — specifically so `tm projects <verb>` and a
 /// non-interactive bare `tm projects` both flow through the completely
-/// unmodified clap definition: the latter must keep failing with clap's own
-/// "requires a subcommand" usage error (exit code 2), byte-for-byte identical
-/// to the pre-#2118 behavior. "Interactive" requires BOTH stdin and stdout to
-/// be real terminals (`commands::projects::should_launch_bare_tui`) — stdout
-/// alone is not enough: a supervisor/wrapper that redirects stdin from
-/// `/dev/null` while leaving stdout attached to a pty would otherwise launch a
-/// raw-mode TUI with no keyboard path able to exit it. See
+/// unmodified clap definition: the latter must keep failing with a clap usage
+/// error (exit code 2), unchanged from the pre-#2118 behavior. (The EXACT
+/// clap `ErrorKind` — and therefore the exact rendered wording — for that
+/// bare-invocation usage error is not itself a stable cross-environment
+/// property of this unmodified definition; see `tests_projects::
+/// cli_rejects_bare_projects_with_a_usage_error`'s doc for the evidence. The
+/// invariant this interception actually depends on, and the one that IS
+/// stable, is the non-zero exit code.) "Interactive" requires BOTH stdin and
+/// stdout to be real terminals (`commands::projects::should_launch_bare_tui`)
+/// — stdout alone is not enough: a supervisor/wrapper that redirects stdin
+/// from `/dev/null` while leaving stdout attached to a pty would otherwise
+/// launch a raw-mode TUI with no keyboard path able to exit it. See
 /// `commands::projects::should_launch_bare_tui` and
 /// `commands::projects::launch_bare_tui`.
 /// Test: integration tests in `tests.rs` exercise every dispatch branch; the

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -80,19 +80,23 @@ static HELP: std::sync::LazyLock<trusty_common::help::HelpConfig> =
 /// What: tries to parse via `clap::Parser::try_parse`, prints a "did you
 /// mean?" hint on an unknown-subcommand error, then dispatches.
 ///
-/// #2118: a bare `tm projects` (no verb) on an interactive TTY is intercepted
-/// HERE, before `Cli::try_parse()` even runs, and launches the 4-pane
-/// project-control-plane TUI skeleton. The interception happens this early —
-/// rather than by relaxing `ProjectsAction` to `Option` and branching inside
-/// the dispatcher — specifically so `tm projects <verb>` and a
+/// #2118: a bare `tm projects` (no verb) on an interactive terminal is
+/// intercepted HERE, before `Cli::try_parse()` even runs, and launches the
+/// 4-pane project-control-plane TUI skeleton. The interception happens this
+/// early — rather than by relaxing `ProjectsAction` to `Option` and branching
+/// inside the dispatcher — specifically so `tm projects <verb>` and a
 /// non-interactive bare `tm projects` both flow through the completely
 /// unmodified clap definition: the latter must keep failing with clap's own
 /// "requires a subcommand" usage error (exit code 2), byte-for-byte identical
-/// to the pre-#2118 behavior. See `commands::projects::is_bare_projects_argv`
-/// and `commands::projects::launch_bare_tui`.
+/// to the pre-#2118 behavior. "Interactive" requires BOTH stdin and stdout to
+/// be real terminals (`commands::projects::should_launch_bare_tui`) — stdout
+/// alone is not enough: a supervisor/wrapper that redirects stdin from
+/// `/dev/null` while leaving stdout attached to a pty would otherwise launch a
+/// raw-mode TUI with no keyboard path able to exit it. See
+/// `commands::projects::should_launch_bare_tui` and
+/// `commands::projects::launch_bare_tui`.
 /// Test: integration tests in `tests.rs` exercise every dispatch branch; the
-/// argv-shape half of the #2118 interception is unit tested in
-/// `commands::projects::tests`.
+/// #2118 interception gate is unit tested in `commands::projects::tests`.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Why: parse via `try_parse` so we can attach the workspace-shared
@@ -100,7 +104,13 @@ async fn main() -> anyhow::Result<()> {
     let argv: Vec<String> = std::env::args().collect();
 
     // #2118: see this function's module doc for why this runs before parsing.
-    if commands::projects::is_bare_projects_argv(&argv) && std::io::stdout().is_terminal() {
+    // Requires BOTH stdin and stdout to be real terminals — stdout alone is
+    // not a safe interactivity signal (see the module doc).
+    if commands::projects::should_launch_bare_tui(
+        &argv,
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+    ) {
         return commands::projects::launch_bare_tui().await;
     }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_projects.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_projects.rs
@@ -25,6 +25,19 @@ fn projects_action(argv: &[&str]) -> ProjectsAction {
     }
 }
 
+/// #2118: `ProjectsAction` stays a MANDATORY clap subcommand — a bare
+/// `tm projects` (no verb) must still fail to parse with clap's own
+/// "requires a subcommand" error, unchanged from before #2118. The
+/// interactive-TTY TUI launch is intercepted in `main.rs` BEFORE
+/// `Cli::try_parse()` even runs (see `commands::projects::is_bare_projects_argv`),
+/// so it never reaches this parse path at all.
+#[test]
+fn cli_rejects_bare_projects_with_missing_subcommand() {
+    let err =
+        Cli::try_parse_from(["tm", "projects"]).expect_err("bare `projects` must fail to parse");
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingSubcommand);
+}
+
 // ───────────────────────── registry verbs (#2115) ─────────────────────────
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/tests_projects.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_projects.rs
@@ -26,16 +26,45 @@ fn projects_action(argv: &[&str]) -> ProjectsAction {
 }
 
 /// #2118: `ProjectsAction` stays a MANDATORY clap subcommand — a bare
-/// `tm projects` (no verb) must still fail to parse with clap's own
-/// "requires a subcommand" error, unchanged from before #2118. The
-/// interactive-TTY TUI launch is intercepted in `main.rs` BEFORE
-/// `Cli::try_parse()` even runs (see `commands::projects::is_bare_projects_argv`),
-/// so it never reaches this parse path at all.
+/// `tm projects` (no verb) must still fail to parse with a clap usage error,
+/// unchanged from before #2118. The interactive-TTY TUI launch is intercepted
+/// in `main.rs` BEFORE `Cli::try_parse()` even runs (see
+/// `commands::projects::is_bare_projects_argv`), so it never reaches this
+/// parse path at all.
+///
+/// Why this asserts `exit_code()` rather than a specific `ErrorKind`: clap's
+/// internal validator (`clap_builder`'s `parser::validator::Validator::validate`)
+/// checks `is_arg_required_else_help_set()` BEFORE `is_subcommand_required_set()`
+/// — whichever is true first decides between
+/// `ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand` and
+/// `ErrorKind::MissingSubcommand`. That internal, non-`Option`-derived
+/// resolution was observed to differ between this project's local dev
+/// environment (always `MissingSubcommand`, confirmed via
+/// `cargo test --workspace` too, not just `-p trusty-mpm`) and CI's Linux
+/// runner (`DisplayHelpOnMissingArgumentOrSubcommand`) despite an identical
+/// locked `clap_builder` version (4.6.0, verified via `Cargo.lock`) — i.e. it
+/// is not this project's dependency resolution that differs. Both kinds are
+/// `Stream::Stderr` in `clap_builder`'s `error::Error::stream()` (only
+/// `DisplayHelp`/`DisplayVersion` map to `Stream::Stdout`), so both share
+/// `exit_code() == 2` regardless of which one fires — that shared, portable
+/// contract (a non-zero exit, not clap's internal error-kind taxonomy) is
+/// what `main.rs`'s bare-invocation interception actually depends on, so it
+/// is what this test pins.
+/// Test: this test.
 #[test]
-fn cli_rejects_bare_projects_with_missing_subcommand() {
+fn cli_rejects_bare_projects_with_a_usage_error() {
     let err =
         Cli::try_parse_from(["tm", "projects"]).expect_err("bare `projects` must fail to parse");
-    assert_eq!(err.kind(), clap::error::ErrorKind::MissingSubcommand);
+    assert_eq!(err.exit_code(), 2);
+    assert!(
+        matches!(
+            err.kind(),
+            clap::error::ErrorKind::MissingSubcommand
+                | clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        ),
+        "expected a 'needs a subcommand' usage error, got {:?}",
+        err.kind()
+    );
 }
 
 // ───────────────────────── registry verbs (#2115) ─────────────────────────

--- a/crates/trusty-mpm/src/tui/mod.rs
+++ b/crates/trusty-mpm/src/tui/mod.rs
@@ -18,6 +18,7 @@ pub mod dashboard;
 mod event_loop;
 pub mod health;
 pub mod iterm2;
+pub mod project_ctl;
 
 use crossterm::{
     execute,

--- a/crates/trusty-mpm/src/tui/project_ctl/actions.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/actions.rs
@@ -1,0 +1,102 @@
+//! Async action dispatch for the `tm projects` TUI (#2118).
+//!
+//! Why: [`super::events::handle_key`] stays pure (no IO) and returns a
+//! [`PendingAction`] describing what the operator asked for; this module is
+//! the one place that awaits the matching [`DaemonClient`] call and folds the
+//! result into a notice, mirroring `tui::coordinator`'s
+//! `dispatch_submitted_line` split between pure routing and async dispatch.
+//!
+//! **Launch is a stub, by design** (documented per the issue's request):
+//! spawning a managed session requires a `task` description and a `git_ref`
+//! (see [`crate::client::ManagedSpawnRequest`]) that a 4-pane skeleton has no
+//! text-entry surface to collect — building that form is explicitly out of
+//! scope here (mirrors why `c`/config is also a stub; a real launch form is a
+//! natural follow-up alongside #2120's config form). Rather than silently
+//! doing nothing, `l` shows a notice pointing at the existing
+//! `tm sessions new` CLI verb, which already does the real work.
+//!
+//! **Decommission has no confirmation step**, matching the issue's keybinding
+//! table verbatim (`d` → decommission, no modal). This is a permanent,
+//! destructive action (the workspace is deleted); a confirmation modal would
+//! be a reasonable fast-follow but is out of scope for this skeleton.
+//!
+//! What: [`dispatch`] matches a [`PendingAction`] to its `DaemonClient` call
+//! and calls [`ProjectCtlState::set_notice`] with the outcome, requesting an
+//! immediate re-poll after any action that changed the fleet.
+//! Test: the pure notice text is not independently unit-tested (it is a
+//! terminal string, not branch logic); the routing itself is covered by
+//! `events::tests` (which `PendingAction` a key produces). The live HTTP calls
+//! are exercised manually / by `tests/session_manager_mvp.rs`'s coverage of
+//! the underlying `DaemonClient` methods.
+
+use crate::client::DaemonClient;
+
+use super::events::PendingAction;
+use super::state::ProjectCtlState;
+
+/// Route one [`PendingAction`] to its `DaemonClient` call and update `state`.
+///
+/// Why: the single async seam the run loop calls after `handle_key` returns
+/// `Some(action)`.
+/// What: `Launch`/`Config` are stubs — see the module doc — that set an
+/// explanatory notice with no daemon call. `Kill`/`Resume`/`Decommission`
+/// call the matching mutating endpoint and, on success, request an immediate
+/// re-poll ([`ProjectCtlState::request_repoll`]) so the fleet reflects the
+/// change now. `Attach` fetches and displays the tmux attach command
+/// (read-only — no repoll).
+pub(crate) async fn dispatch(
+    state: &mut ProjectCtlState,
+    client: &DaemonClient,
+    action: PendingAction,
+) {
+    match action {
+        PendingAction::Launch(project) => {
+            state.set_notice(format!(
+                "launch form not built yet — run `tm sessions new --repo-url <url> --task <task>` for '{project}' (see actions.rs doc)"
+            ));
+        }
+        PendingAction::Kill(id) => {
+            let result = client.runtime_stop_managed_session(&id).await;
+            apply_mutation_result(state, result, "killed");
+        }
+        PendingAction::Resume(id) => {
+            let result = client.resume_managed_session(&id).await;
+            apply_mutation_result(state, result, "resumed");
+        }
+        PendingAction::Decommission(id) => {
+            let result = client.decommission_managed_session(&id).await;
+            apply_mutation_result(state, result, "decommissioned");
+        }
+        PendingAction::Attach(id) => match client.managed_session_attach_cmd(&id).await {
+            Ok(resp) => state.set_notice(format!("attach: {}", resp.attach_cmd)),
+            Err(e) => state.set_notice(format!("attach failed: {e}")),
+        },
+        PendingAction::Config(project) => {
+            state.set_notice(format!(
+                "config for '{project}' is not available yet (#2120)"
+            ));
+        }
+    }
+}
+
+/// Fold a mutating endpoint's result into a notice, requesting a repoll on success.
+///
+/// Why: `Kill`/`Resume`/`Decommission` share the identical
+/// result-to-notice-plus-repoll shape; factoring it out keeps [`dispatch`]'s
+/// match arms one line each.
+/// What: on `Ok`, sets a `"{verb} {name} — now {state}"` notice and calls
+/// [`ProjectCtlState::request_repoll`]; on `Err`, sets a `"{verb} failed: {e}"`
+/// notice with no repoll.
+fn apply_mutation_result(
+    state: &mut ProjectCtlState,
+    result: anyhow::Result<crate::client::ManagedSessionSummary>,
+    verb: &str,
+) {
+    match result {
+        Ok(summary) => {
+            state.set_notice(format!("{verb} {} — now {}", summary.name, summary.state));
+            state.request_repoll();
+        }
+        Err(e) => state.set_notice(format!("{verb} failed: {e}")),
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/events.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/events.rs
@@ -1,0 +1,360 @@
+//! Key dispatch for the `tm projects` TUI (#2118).
+//!
+//! Why: separating "a key arrives → mutate state, maybe request an async
+//! action" from the terminal pump keeps the dispatch pure and unit-testable,
+//! mirroring `tui::coordinator::events::handle_key`.
+//!
+//! **Deviation from the issue's keybinding table, documented here**: the
+//! issue's key table lists `j`/`k` as motion aliases for ↑/↓ (vim-style)
+//! AND, separately, binds the bare letter `k` to "kill" in the Sessions pane —
+//! those two conflict outright (`k` cannot mean both "up" and "kill" without
+//! a modal mode switch, which is out of scope for a skeleton). The issue's own
+//! ASCII mockup resolves this in practice: its key-hint bar lists only `↑↓`
+//! for selection and reserves every bare letter (`l`/`k`/`r`/`d`/`a`/`c`) for
+//! an action. This module follows the mockup: motion is ↑/↩ arrow keys only,
+//! and every lettered key is an unambiguous action binding.
+//! What: [`PendingAction`] (the async actions a key can request — the actual
+//! HTTP dispatch lives in [`super::actions`]), [`is_quit`], and [`handle_key`]
+//! which routes a [`KeyEvent`] into [`ProjectCtlState`] mutations (focus
+//! cycling, selection, drill-in, notice-clear) and returns `Some(action)` for
+//! the lettered verbs.
+//! Test: `super::tests` covers focus cycling, selection movement, the
+//! project-switch reset, and every lettered action's valid/invalid-context
+//! branches via synthetic [`KeyEvent`]s.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::state::{Pane, ProjectCtlState};
+
+/// An action a key press requested that needs an async daemon round trip.
+///
+/// Why: [`handle_key`] must stay a pure, terminal-free, IO-free function to
+/// remain unit-testable; the actual HTTP calls live in [`super::actions::dispatch`],
+/// which the run loop awaits after `handle_key` returns.
+/// What: one variant per lettered verb (DOC-35 §5 keybinding table); `Launch`
+/// and `Config` carry the target project name, the rest carry the target
+/// session id.
+/// Test: `handle_key_*` in `super::tests`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingAction {
+    /// `l` in the Sessions pane — launch a new session for the given project.
+    Launch(String),
+    /// `k` in the Sessions pane — runtime-stop the given session.
+    Kill(String),
+    /// `r` in the Sessions pane — resume the given session.
+    Resume(String),
+    /// `d` in the Sessions pane — decommission the given session.
+    Decommission(String),
+    /// `a` in the Sessions pane — fetch and display the attach command.
+    Attach(String),
+    /// `c` in the Projects pane — config stub (no-op notice; real form is #2120).
+    Config(String),
+}
+
+/// True when this key event means "quit" (`q` or Ctrl-C).
+///
+/// Why: shared by [`handle_key`] and its tests; mirrors
+/// `tui::coordinator::events::is_quit` minus the input-buffer carve-out (this
+/// screen has no text input box).
+/// What: matches bare `q` or Ctrl-C.
+pub fn is_quit(key: &KeyEvent) -> bool {
+    let ctrl_c = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
+    let bare_q = key.code == KeyCode::Char('q');
+    ctrl_c || bare_q
+}
+
+/// Route one key event into [`ProjectCtlState`] mutations, returning any
+/// action that needs an async daemon call.
+///
+/// Why: the single seam the terminal pump calls per key; keeping it a pure
+/// `&mut state` function (no terminal, no IO) makes every branch unit
+/// testable with synthetic [`KeyEvent`]s.
+/// What: Ctrl-C / `q` set `should_exit`. Tab/Shift+Tab cycle pane focus.
+/// ↑/↓ move the selection in the focused pane (Projects-pane movement also
+/// resets the Sessions-pane selection via
+/// [`ProjectCtlState::on_project_selection_changed`]); the Activity pane has
+/// no navigable rows, so movement there is a no-op. Enter on the Projects
+/// pane drills into Sessions. `l`/`k`/`r`/`d`/`a` in the Sessions pane and `c`
+/// in the Projects pane return the matching [`PendingAction`] when a
+/// target is selected, else set an explanatory notice and return `None`. Esc
+/// clears any shown notice.
+/// Test: `super::tests`.
+pub fn handle_key(state: &mut ProjectCtlState, key: KeyEvent) -> Option<PendingAction> {
+    if is_quit(&key) {
+        state.should_exit = true;
+        return None;
+    }
+
+    match key.code {
+        KeyCode::Tab => {
+            state.cycle_focus_next();
+            None
+        }
+        KeyCode::BackTab => {
+            state.cycle_focus_prev();
+            None
+        }
+        KeyCode::Up => {
+            move_selection(state, Direction::Up);
+            None
+        }
+        KeyCode::Down => {
+            move_selection(state, Direction::Down);
+            None
+        }
+        KeyCode::Enter if state.focus == Pane::Projects => {
+            state.drill_into_sessions();
+            None
+        }
+        KeyCode::Esc => {
+            state.clear_notice();
+            None
+        }
+        KeyCode::Char('l') if state.focus == Pane::Sessions => {
+            match state.selected_project_name() {
+                Some(name) => Some(PendingAction::Launch(name.to_string())),
+                None => {
+                    state.set_notice("no project selected");
+                    None
+                }
+            }
+        }
+        KeyCode::Char('k') if state.focus == Pane::Sessions => {
+            selected_session_action(state, PendingAction::Kill)
+        }
+        KeyCode::Char('r') if state.focus == Pane::Sessions => {
+            selected_session_action(state, PendingAction::Resume)
+        }
+        KeyCode::Char('d') if state.focus == Pane::Sessions => {
+            selected_session_action(state, PendingAction::Decommission)
+        }
+        KeyCode::Char('a') if state.focus == Pane::Sessions => {
+            selected_session_action(state, PendingAction::Attach)
+        }
+        KeyCode::Char('c') if state.focus == Pane::Projects => {
+            match state.selected_project_name() {
+                Some(name) => Some(PendingAction::Config(name.to_string())),
+                None => {
+                    state.set_notice("no project selected");
+                    None
+                }
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Which way ↑/↓ moves the selection.
+enum Direction {
+    Up,
+    Down,
+}
+
+/// Move the selection in the currently focused pane.
+///
+/// Why: factored out of [`handle_key`] so the Projects-pane branch's
+/// session-reset side effect ([`ProjectCtlState::on_project_selection_changed`])
+/// lives in one place.
+/// What: Projects — moves `projects_nav`, then resets the Sessions selection;
+/// Sessions — moves `sessions_nav`; Activity — no-op (nothing to navigate).
+fn move_selection(state: &mut ProjectCtlState, dir: Direction) {
+    match state.focus {
+        Pane::Projects => {
+            match dir {
+                Direction::Up => state.projects_nav.up(),
+                Direction::Down => state.projects_nav.down(),
+            }
+            state.on_project_selection_changed();
+        }
+        Pane::Sessions => match dir {
+            Direction::Up => state.sessions_nav.up(),
+            Direction::Down => state.sessions_nav.down(),
+        },
+        Pane::Activity => {}
+    }
+}
+
+/// Build a session-targeted [`PendingAction`] from the current selection, or
+/// set an explanatory notice when none is selected.
+///
+/// Why: `k`/`r`/`d`/`a` share the identical "need a selected session" guard;
+/// factoring it out keeps [`handle_key`]'s match arms one line each.
+/// What: `build` is a tuple-variant constructor (e.g. `PendingAction::Kill`);
+/// returns `Some(build(selected session id))` or sets a notice and returns
+/// `None`.
+fn selected_session_action(
+    state: &mut ProjectCtlState,
+    build: fn(String) -> PendingAction,
+) -> Option<PendingAction> {
+    match state.selected_session() {
+        Some(session) => Some(build(session.id.clone())),
+        None => {
+            state.set_notice("select a session first");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::project_ctl::state::{ProjectRow, SessionRow};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl_c() -> KeyEvent {
+        KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)
+    }
+
+    fn seeded_state() -> ProjectCtlState {
+        let mut state = ProjectCtlState {
+            projects: vec![
+                ProjectRow {
+                    name: "alpha".to_string(),
+                    repo_url: "https://github.com/acme/alpha".to_string(),
+                    live_count: 1,
+                    total_count: 1,
+                },
+                ProjectRow {
+                    name: "beta".to_string(),
+                    repo_url: "https://github.com/acme/beta".to_string(),
+                    live_count: 0,
+                    total_count: 0,
+                },
+            ],
+            ..Default::default()
+        };
+        state.sessions_by_project.insert(
+            "alpha".to_string(),
+            vec![SessionRow {
+                id: "sess-1".to_string(),
+                short_id: "sess-1".chars().take(8).collect(),
+                name: "alpha-session".to_string(),
+                branch: Some("main".to_string()),
+                task: Some("ship it".to_string()),
+                state: "active".to_string(),
+                pending_decision: None,
+                proposed_default: None,
+            }],
+        );
+        state.projects_nav.sync_len(state.projects.len());
+        state.sessions_nav.sync_len(state.current_sessions().len());
+        state
+    }
+
+    #[test]
+    fn quit_on_bare_q_and_ctrl_c() {
+        let mut state = seeded_state();
+        assert!(handle_key(&mut state, key(KeyCode::Char('q'))).is_none());
+        assert!(state.should_exit);
+
+        let mut state = seeded_state();
+        assert!(handle_key(&mut state, ctrl_c()).is_none());
+        assert!(state.should_exit);
+    }
+
+    #[test]
+    fn tab_cycles_focus_forward_and_back() {
+        let mut state = seeded_state();
+        assert_eq!(state.focus, Pane::Projects);
+        handle_key(&mut state, key(KeyCode::Tab));
+        assert_eq!(state.focus, Pane::Sessions);
+        handle_key(&mut state, key(KeyCode::Tab));
+        assert_eq!(state.focus, Pane::Activity);
+        handle_key(&mut state, key(KeyCode::BackTab));
+        assert_eq!(state.focus, Pane::Sessions);
+    }
+
+    #[test]
+    fn arrow_keys_move_projects_selection_and_reset_sessions() {
+        let mut state = seeded_state();
+        state.sessions_nav.down(); // no-op (only one session), but exercises the path
+        handle_key(&mut state, key(KeyCode::Down));
+        assert_eq!(state.selected_project().unwrap().name, "beta");
+        assert_eq!(state.sessions_nav.selected(), 0);
+    }
+
+    #[test]
+    fn enter_on_projects_pane_drills_into_sessions() {
+        let mut state = seeded_state();
+        handle_key(&mut state, key(KeyCode::Enter));
+        assert_eq!(state.focus, Pane::Sessions);
+    }
+
+    #[test]
+    fn enter_on_sessions_pane_is_a_noop() {
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        assert!(handle_key(&mut state, key(KeyCode::Enter)).is_none());
+        assert_eq!(state.focus, Pane::Sessions);
+    }
+
+    #[test]
+    fn launch_requires_sessions_focus_and_a_selected_project() {
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        let action = handle_key(&mut state, key(KeyCode::Char('l')));
+        assert_eq!(action, Some(PendingAction::Launch("alpha".to_string())));
+    }
+
+    #[test]
+    fn kill_requires_a_selected_session() {
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        let action = handle_key(&mut state, key(KeyCode::Char('k')));
+        assert_eq!(action, Some(PendingAction::Kill("sess-1".to_string())));
+    }
+
+    #[test]
+    fn kill_without_selection_sets_notice_and_returns_none() {
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        state.projects_nav.down(); // select "beta", which has no sessions
+        let action = handle_key(&mut state, key(KeyCode::Char('k')));
+        assert!(action.is_none());
+        assert_eq!(state.notice.as_deref(), Some("select a session first"));
+    }
+
+    #[test]
+    fn resume_decommission_attach_target_selected_session() {
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        assert_eq!(
+            handle_key(&mut state, key(KeyCode::Char('r'))),
+            Some(PendingAction::Resume("sess-1".to_string()))
+        );
+        assert_eq!(
+            handle_key(&mut state, key(KeyCode::Char('d'))),
+            Some(PendingAction::Decommission("sess-1".to_string()))
+        );
+        assert_eq!(
+            handle_key(&mut state, key(KeyCode::Char('a'))),
+            Some(PendingAction::Attach("sess-1".to_string()))
+        );
+    }
+
+    #[test]
+    fn config_requires_projects_focus_and_a_selected_project() {
+        let mut state = seeded_state();
+        let action = handle_key(&mut state, key(KeyCode::Char('c')));
+        assert_eq!(action, Some(PendingAction::Config("alpha".to_string())));
+    }
+
+    #[test]
+    fn lettered_actions_are_ignored_outside_their_pane() {
+        let mut state = seeded_state();
+        // Projects pane focused: Sessions-only verbs are ignored (no notice).
+        assert!(handle_key(&mut state, key(KeyCode::Char('l'))).is_none());
+        assert!(state.notice.is_none());
+    }
+
+    #[test]
+    fn esc_clears_notice() {
+        let mut state = seeded_state();
+        state.set_notice("hi");
+        handle_key(&mut state, key(KeyCode::Esc));
+        assert!(state.notice.is_none());
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/events.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/events.rs
@@ -12,19 +12,36 @@
 //! ASCII mockup resolves this in practice: its key-hint bar lists only `↑↓`
 //! for selection and reserves every bare letter (`l`/`k`/`r`/`d`/`a`/`c`) for
 //! an action. This module follows the mockup: motion is ↑/↩ arrow keys only,
-//! and every lettered key is an unambiguous action binding.
+//! and every lettered key is an unambiguous action binding. (`j` had no such
+//! collision and could have stayed bound to "down" — left out anyway so the
+//! screen has exactly one motion scheme rather than a mixed one; noted here
+//! as an intentional, disclosed, non-blocking deviation.)
+//!
+//! **Confirmation gate (DOC-35 §5.2), NORMATIVE**: `k` (kill) on a session
+//! whose `state` is `"active"`, and `d` (decommission) UNCONDITIONALLY (it is
+//! terminal — the workspace is deleted), may never execute on the keypress
+//! that requested them. Both route through [`ProjectCtlState::pending_confirm`]
+//! (built by [`super::state::PendingConfirm`] / [`super::state::ConfirmKind`])
+//! instead of returning a [`PendingAction`] directly; the operator's next
+//! keypress resolves it (`y`/`Y`/Enter → confirm, `n`/`N`/Esc → cancel, any
+//! other key → the modal stays open, matching the spec's "any modal/form"
+//! contract). Per the same table, `q`/`Ctrl-C` quits only when NOT in a
+//! modal — while `pending_confirm` is `Some`, quit keys are swallowed by the
+//! modal like every other key.
 //! What: [`PendingAction`] (the async actions a key can request — the actual
 //! HTTP dispatch lives in [`super::actions`]), [`is_quit`], and [`handle_key`]
 //! which routes a [`KeyEvent`] into [`ProjectCtlState`] mutations (focus
-//! cycling, selection, drill-in, notice-clear) and returns `Some(action)` for
-//! the lettered verbs.
+//! cycling, selection, drill-in, notice-clear, the confirm gate) and returns
+//! `Some(action)` for the lettered verbs (once confirmed, for `k`-on-Active
+//! and `d`).
 //! Test: `super::tests` covers focus cycling, selection movement, the
-//! project-switch reset, and every lettered action's valid/invalid-context
-//! branches via synthetic [`KeyEvent`]s.
+//! project-switch reset, every lettered action's valid/invalid-context
+//! branches, and the confirm-gate's request/confirm/cancel/ignore branches,
+//! via synthetic [`KeyEvent`]s.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use super::state::{Pane, ProjectCtlState};
+use super::state::{ConfirmKind, Pane, PendingConfirm, ProjectCtlState, SessionRow};
 
 /// An action a key press requested that needs an async daemon round trip.
 ///
@@ -69,17 +86,26 @@ pub fn is_quit(key: &KeyEvent) -> bool {
 /// Why: the single seam the terminal pump calls per key; keeping it a pure
 /// `&mut state` function (no terminal, no IO) makes every branch unit
 /// testable with synthetic [`KeyEvent`]s.
-/// What: Ctrl-C / `q` set `should_exit`. Tab/Shift+Tab cycle pane focus.
-/// ↑/↓ move the selection in the focused pane (Projects-pane movement also
-/// resets the Sessions-pane selection via
+/// What: when [`ProjectCtlState::pending_confirm`] is `Some`, EVERY key
+/// routes through [`handle_confirm_key`] instead (DOC-35 §5.2 — see the
+/// module doc). Otherwise: Ctrl-C / `q` set `should_exit`. Tab/Shift+Tab
+/// cycle pane focus. ↑/↓ move the selection in the focused pane
+/// (Projects-pane movement also resets the Sessions-pane selection via
 /// [`ProjectCtlState::on_project_selection_changed`]); the Activity pane has
 /// no navigable rows, so movement there is a no-op. Enter on the Projects
-/// pane drills into Sessions. `l`/`k`/`r`/`d`/`a` in the Sessions pane and `c`
-/// in the Projects pane return the matching [`PendingAction`] when a
-/// target is selected, else set an explanatory notice and return `None`. Esc
-/// clears any shown notice.
+/// pane drills into Sessions. `l`/`r`/`a` in the Sessions pane and `c` in the
+/// Projects pane return the matching [`PendingAction`] immediately when a
+/// target is selected, else set an explanatory notice and return `None`.
+/// `k`/`d` (see [`request_kill`] / [`request_decommission`]) open the confirm
+/// gate instead of returning an action directly, except a `k` on a
+/// non-Active session, which is not destructive-pending and fires
+/// immediately. Esc clears any shown notice.
 /// Test: `super::tests`.
 pub fn handle_key(state: &mut ProjectCtlState, key: KeyEvent) -> Option<PendingAction> {
+    if state.pending_confirm.is_some() {
+        return handle_confirm_key(state, key);
+    }
+
     if is_quit(&key) {
         state.should_exit = true;
         return None;
@@ -119,15 +145,11 @@ pub fn handle_key(state: &mut ProjectCtlState, key: KeyEvent) -> Option<PendingA
                 }
             }
         }
-        KeyCode::Char('k') if state.focus == Pane::Sessions => {
-            selected_session_action(state, PendingAction::Kill)
-        }
+        KeyCode::Char('k') if state.focus == Pane::Sessions => request_kill(state),
         KeyCode::Char('r') if state.focus == Pane::Sessions => {
             selected_session_action(state, PendingAction::Resume)
         }
-        KeyCode::Char('d') if state.focus == Pane::Sessions => {
-            selected_session_action(state, PendingAction::Decommission)
-        }
+        KeyCode::Char('d') if state.focus == Pane::Sessions => request_decommission(state),
         KeyCode::Char('a') if state.focus == Pane::Sessions => {
             selected_session_action(state, PendingAction::Attach)
         }
@@ -142,6 +164,98 @@ pub fn handle_key(state: &mut ProjectCtlState, key: KeyEvent) -> Option<PendingA
         }
         _ => None,
     }
+}
+
+/// Resolve the currently open confirmation gate against one key event.
+///
+/// Why: split out of [`handle_key`] so the "confirm gate captures ALL input"
+/// contract (DOC-35 §5.2, plus the spec's "`q`/`Ctrl-C` not in a modal" /
+/// "`Esc` any modal/form" rules) lives in one place, independent of whatever
+/// pane happened to have focus when the gate opened.
+/// What: `y`/`Y`/Enter → clears the gate and returns the confirmed
+/// [`PendingAction`] (`Kill` or `Decommission`, per [`ConfirmKind`]);
+/// `n`/`N`/Esc → clears the gate, sets a "cancelled" notice, returns `None`;
+/// any other key (including `q`/Ctrl-C) → the gate stays open, returns
+/// `None` — a destructive action can only ever be resolved by an explicit
+/// yes/no, never dismissed as a side effect of an unrelated keypress.
+fn handle_confirm_key(state: &mut ProjectCtlState, key: KeyEvent) -> Option<PendingAction> {
+    let confirm = state
+        .pending_confirm
+        .clone()
+        .expect("caller checked pending_confirm.is_some()");
+    match key.code {
+        KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+            state.clear_confirm();
+            Some(resolve_confirm(confirm))
+        }
+        KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+            state.clear_confirm();
+            state.set_notice("cancelled");
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Map a resolved [`PendingConfirm`] to its confirmed [`PendingAction`].
+fn resolve_confirm(confirm: PendingConfirm) -> PendingAction {
+    match confirm.kind {
+        ConfirmKind::Kill => PendingAction::Kill(confirm.session_id),
+        ConfirmKind::Decommission => PendingAction::Decommission(confirm.session_id),
+    }
+}
+
+/// A short, human-readable label for a session, used in confirm prompts.
+///
+/// Why: `PendingConfirm::session_label` needs something more legible than
+/// the raw UUID; the tmux session `name` is the most recognisable field.
+fn confirm_label(session: &SessionRow) -> String {
+    session.name.clone()
+}
+
+/// `k` in the Sessions pane: kill (runtime-stop) the selected session.
+///
+/// Why: DOC-35 §5.2 — kill requires a confirmation gate ONLY when the target
+/// session is currently `active` (mirrors DOC-16 §5.6's active-session
+/// confirmation); a non-Active session (provisioning/stopped/errored/
+/// decommissioned) has no live runtime to interrupt, so kill proceeds
+/// immediately, matching the spec's narrower "if Active" wording rather than
+/// gating every kill unconditionally like decommission.
+/// What: no selection → notice, `None`. Active → opens the confirm gate,
+/// `None`. Otherwise → `Some(PendingAction::Kill(id))` immediately.
+/// Test: `super::tests::kill_on_active_session_opens_confirm_gate`,
+/// `super::tests::kill_on_non_active_session_fires_immediately`.
+fn request_kill(state: &mut ProjectCtlState) -> Option<PendingAction> {
+    let Some(session) = state.selected_session().cloned() else {
+        state.set_notice("select a session first");
+        return None;
+    };
+    if session.state == "active" {
+        let label = confirm_label(&session);
+        state.request_confirm(ConfirmKind::Kill, session.id, label);
+        None
+    } else {
+        Some(PendingAction::Kill(session.id))
+    }
+}
+
+/// `d` in the Sessions pane: decommission the selected session.
+///
+/// Why: DOC-35 §5.2 — decommission ALWAYS requires a confirmation gate
+/// (unconditionally, unlike kill): it is terminal, permanently deleting the
+/// workspace, regardless of the session's current lifecycle state.
+/// What: no selection → notice, `None`. Otherwise → opens the confirm gate
+/// unconditionally, `None`; the real [`PendingAction::Decommission`] fires
+/// only once [`handle_confirm_key`] sees `y`.
+/// Test: `super::tests::decommission_always_opens_confirm_gate`.
+fn request_decommission(state: &mut ProjectCtlState) -> Option<PendingAction> {
+    let Some(session) = state.selected_session().cloned() else {
+        state.set_notice("select a session first");
+        return None;
+    };
+    let label = confirm_label(&session);
+    state.request_confirm(ConfirmKind::Decommission, session.id, label);
+    None
 }
 
 /// Which way ↑/↓ moves the selection.
@@ -198,7 +312,7 @@ fn selected_session_action(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tui::project_ctl::state::{ProjectRow, SessionRow};
+    use crate::tui::project_ctl::state::ProjectRow;
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -300,14 +414,6 @@ mod tests {
     }
 
     #[test]
-    fn kill_requires_a_selected_session() {
-        let mut state = seeded_state();
-        state.focus = Pane::Sessions;
-        let action = handle_key(&mut state, key(KeyCode::Char('k')));
-        assert_eq!(action, Some(PendingAction::Kill("sess-1".to_string())));
-    }
-
-    #[test]
     fn kill_without_selection_sets_notice_and_returns_none() {
         let mut state = seeded_state();
         state.focus = Pane::Sessions;
@@ -315,24 +421,25 @@ mod tests {
         let action = handle_key(&mut state, key(KeyCode::Char('k')));
         assert!(action.is_none());
         assert_eq!(state.notice.as_deref(), Some("select a session first"));
+        assert!(state.pending_confirm.is_none());
     }
 
     #[test]
-    fn resume_decommission_attach_target_selected_session() {
+    fn resume_and_attach_target_selected_session_immediately() {
+        // Neither verb is destructive, so DOC-35 §5.2's confirm gate does not
+        // apply — both fire on the first keypress.
         let mut state = seeded_state();
         state.focus = Pane::Sessions;
         assert_eq!(
             handle_key(&mut state, key(KeyCode::Char('r'))),
             Some(PendingAction::Resume("sess-1".to_string()))
         );
-        assert_eq!(
-            handle_key(&mut state, key(KeyCode::Char('d'))),
-            Some(PendingAction::Decommission("sess-1".to_string()))
-        );
+        assert!(state.pending_confirm.is_none());
         assert_eq!(
             handle_key(&mut state, key(KeyCode::Char('a'))),
             Some(PendingAction::Attach("sess-1".to_string()))
         );
+        assert!(state.pending_confirm.is_none());
     }
 
     #[test]
@@ -356,5 +463,137 @@ mod tests {
         state.set_notice("hi");
         handle_key(&mut state, key(KeyCode::Esc));
         assert!(state.notice.is_none());
+    }
+
+    // ---- DOC-35 §5.2 confirmation gate ----------------------------------
+
+    #[test]
+    fn kill_on_active_session_opens_confirm_gate_instead_of_firing() {
+        // seeded_state's lone session is "active".
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        let action = handle_key(&mut state, key(KeyCode::Char('k')));
+        assert!(action.is_none(), "must not fire on the first keypress");
+        let confirm = state.pending_confirm.expect("confirm gate should be open");
+        assert_eq!(confirm.kind, ConfirmKind::Kill);
+        assert_eq!(confirm.session_id, "sess-1");
+    }
+
+    #[test]
+    fn kill_on_non_active_session_fires_immediately() {
+        let mut state = seeded_state();
+        state.sessions_by_project.get_mut("alpha").unwrap()[0].state = "stopped".to_string();
+        state.focus = Pane::Sessions;
+        let action = handle_key(&mut state, key(KeyCode::Char('k')));
+        assert_eq!(action, Some(PendingAction::Kill("sess-1".to_string())));
+        assert!(state.pending_confirm.is_none());
+    }
+
+    #[test]
+    fn decommission_always_opens_confirm_gate_regardless_of_state() {
+        for state_word in ["active", "stopped", "provisioning", "errored"] {
+            let mut state = seeded_state();
+            state.sessions_by_project.get_mut("alpha").unwrap()[0].state = state_word.to_string();
+            state.focus = Pane::Sessions;
+            let action = handle_key(&mut state, key(KeyCode::Char('d')));
+            assert!(action.is_none(), "must not fire for state {state_word}");
+            let confirm = state
+                .pending_confirm
+                .expect("confirm gate should be open for state {state_word}");
+            assert_eq!(confirm.kind, ConfirmKind::Decommission);
+            assert_eq!(confirm.session_id, "sess-1");
+        }
+    }
+
+    #[test]
+    fn confirm_gate_y_resolves_to_the_real_action_and_clears() {
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        handle_key(&mut state, key(KeyCode::Char('d'))); // open the gate
+        assert!(state.pending_confirm.is_some());
+
+        let action = handle_key(&mut state, key(KeyCode::Char('y')));
+        assert_eq!(
+            action,
+            Some(PendingAction::Decommission("sess-1".to_string()))
+        );
+        assert!(state.pending_confirm.is_none());
+    }
+
+    #[test]
+    fn confirm_gate_uppercase_y_and_enter_also_confirm() {
+        for confirm_key in [key(KeyCode::Char('Y')), key(KeyCode::Enter)] {
+            let mut state = seeded_state();
+            state.focus = Pane::Sessions;
+            handle_key(&mut state, key(KeyCode::Char('d')));
+            let action = handle_key(&mut state, confirm_key);
+            assert_eq!(
+                action,
+                Some(PendingAction::Decommission("sess-1".to_string()))
+            );
+        }
+    }
+
+    #[test]
+    fn confirm_gate_n_or_esc_cancels_and_sets_notice() {
+        for cancel_key in [
+            key(KeyCode::Char('n')),
+            key(KeyCode::Char('N')),
+            key(KeyCode::Esc),
+        ] {
+            let mut state = seeded_state();
+            state.focus = Pane::Sessions;
+            handle_key(&mut state, key(KeyCode::Char('d')));
+            let action = handle_key(&mut state, cancel_key);
+            assert!(action.is_none());
+            assert!(state.pending_confirm.is_none());
+            assert_eq!(state.notice.as_deref(), Some("cancelled"));
+        }
+    }
+
+    #[test]
+    fn confirm_gate_swallows_unrelated_keys_and_stays_open() {
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        handle_key(&mut state, key(KeyCode::Char('d')));
+        assert!(state.pending_confirm.is_some());
+
+        // An unrelated key must not resolve or dismiss the gate.
+        let action = handle_key(&mut state, key(KeyCode::Char('x')));
+        assert!(action.is_none());
+        assert!(
+            state.pending_confirm.is_some(),
+            "gate must stay open for an unrecognised key"
+        );
+    }
+
+    #[test]
+    fn confirm_gate_blocks_quit_keys_matching_the_spec_not_in_a_modal_rule() {
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        handle_key(&mut state, key(KeyCode::Char('d')));
+
+        handle_key(&mut state, key(KeyCode::Char('q')));
+        assert!(!state.should_exit, "q must not quit while a modal is open");
+        assert!(state.pending_confirm.is_some());
+
+        handle_key(&mut state, ctrl_c());
+        assert!(
+            !state.should_exit,
+            "Ctrl-C must not quit while a modal is open"
+        );
+        assert!(state.pending_confirm.is_some());
+    }
+
+    #[test]
+    fn quit_still_works_once_the_gate_is_resolved() {
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        handle_key(&mut state, key(KeyCode::Char('d')));
+        handle_key(&mut state, key(KeyCode::Esc)); // cancel — gate closes
+        assert!(state.pending_confirm.is_none());
+
+        handle_key(&mut state, key(KeyCode::Char('q')));
+        assert!(state.should_exit);
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/layout.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/layout.rs
@@ -1,0 +1,63 @@
+//! Frame layout for the `tm projects` 4-pane TUI (#2118, DOC-35 §5).
+//!
+//! Why: the spec pins a fixed vertical/horizontal `Layout` — Projects (25%) |
+//! Sessions (75%) on top, a fixed-height Activity strip, and a 1-row action
+//! bar — mirroring the `Constraint` conventions already used by
+//! `tui::coordinator::layout` and `tui::health::render`. Composing the
+//! `Rect`s here (rather than in each pane module) keeps the frame's shape in
+//! one place.
+//! What: [`render`] draws the full frame each tick, delegating each region's
+//! content to its [`super::panes`] submodule.
+//! Test: the pane submodules unit-test their own content; this terminal-
+//! touching composition is exercised by launching the TUI.
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout},
+};
+
+use super::panes::{actions_bar, activity, projects, sessions};
+use super::state::ProjectCtlState;
+
+/// Minimum height (rows, including the two border rows) of the main
+/// Projects/Sessions row.
+///
+/// Why: floors the main row so a short terminal still shows a handful of
+/// project/session rows rather than collapsing to nothing; taller terminals
+/// flex the row larger via `Constraint::Min`.
+const MIN_MAIN_ROWS: u16 = 7;
+
+/// Fixed height (rows, including the two border rows) of the Activity pane.
+///
+/// Why: DOC-35 §5 pins this pane at `Constraint::Length(4)`.
+const ACTIVITY_ROWS: u16 = 4;
+
+/// Draw one full frame: Projects | Sessions on top, Activity below, the
+/// action bar at the bottom.
+///
+/// Why: the single entry point the run loop's `terminal.draw` calls each
+/// tick.
+/// What: splits `frame.area()` vertically into the main row (flexing, floored
+/// at [`MIN_MAIN_ROWS`]), the Activity strip ([`ACTIVITY_ROWS`]), and the
+/// 1-row action bar; splits the main row horizontally 25/75 for
+/// Projects/Sessions per DOC-35 §5.
+pub fn render(frame: &mut Frame, state: &mut ProjectCtlState) {
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(MIN_MAIN_ROWS),
+            Constraint::Length(ACTIVITY_ROWS),
+            Constraint::Length(1),
+        ])
+        .split(frame.area());
+
+    let main_row = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(25), Constraint::Percentage(75)])
+        .split(outer[0]);
+
+    projects::render(frame, main_row[0], state);
+    sessions::render(frame, main_row[1], state);
+    activity::render(frame, outer[1], state);
+    actions_bar::render(frame, outer[2], state);
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/mod.rs
@@ -1,0 +1,144 @@
+//! `tm projects` 4-pane TUI skeleton — the project control plane (#2118, DOC-35 §5).
+//!
+//! Why: operators managing several projects' worth of managed sessions need
+//! one screen that shows every registered project's aggregate health
+//! (Projects pane), drills into one project's sessions (Sessions pane), and
+//! previews the focused session's static record fields (Activity pane
+//! skeleton — live `/activity` polling is #2119) — with the lifecycle verbs
+//! (launch/kill/resume/decommission/attach) one keystroke away. This is the
+//! FULL 4-pane layout landing as v1 (the owner resolved #2118 to skip a
+//! 2-pane MVP).
+//! What: [`run`] is the `tm projects` (bare, TTY) entry point — it primes the
+//! state with one poll, then hands off to [`run_loop`] with a panic-safe
+//! terminal guard (mirroring `tui::coordinator::run`'s `TerminalGuard`
+//! pattern, since this screen also needs to restore the terminal on an
+//! unexpected panic, not just a clean return). The event loop itself follows
+//! the same draw → poll-key → dispatch → maybe-repoll shape as
+//! `tui::coordinator::run_loop`.
+//! Test: the pure pieces (state, poll projections, key routing, pane content)
+//! are unit-tested in their own modules; this terminal-bound loop is
+//! exercised by launching the TUI.
+
+pub mod actions;
+pub mod events;
+pub mod layout;
+pub mod panes;
+pub mod poll;
+pub mod state;
+
+#[cfg(test)]
+mod tests;
+
+use std::io::{self, Stdout};
+use std::time::{Duration, Instant};
+
+use crossterm::{
+    event::{self, Event},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, backend::CrosstermBackend};
+
+use crate::client::DaemonClient;
+use events::handle_key;
+use poll::project_ctl_poll_daemon;
+use state::ProjectCtlState;
+
+/// RAII guard that restores the terminal on drop — including during a panic.
+///
+/// Why: mirrors `tui::coordinator::TerminalGuard` — a `Drop` impl runs on both
+/// the normal return and the unwind path, so a panic anywhere in the loop
+/// never leaves the operator's terminal in raw mode / the alternate screen.
+/// What: constructed right after entering raw mode + the alternate screen;
+/// its `Drop` best-effort restores cooked mode, the main screen, and the
+/// cursor, ignoring errors (nothing useful can be done while unwinding).
+/// Test: side-effect-only teardown; covered by launching the TUI.
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen, crossterm::cursor::Show);
+    }
+}
+
+/// How long [`run_loop`] blocks waiting for a key before redrawing.
+///
+/// Why: matches the coordinator/dashboard screens' input cadence — short
+/// enough to feel responsive, independent of the daemon refresh cadence.
+const KEY_POLL: Duration = Duration::from_millis(50);
+
+/// Launch the `tm projects` 4-pane TUI against `url`, polling every `interval_ms`.
+///
+/// Why: the bare-`tm projects`-on-a-TTY entry point (#2118); `main.rs`'s
+/// bare-dispatch branch calls this after confirming stdout is a TTY.
+/// What: builds a [`DaemonClient`] for `url`, primes the state with one poll
+/// (so the first frame is never an empty flash), enters raw mode + the
+/// alternate screen, installs a [`TerminalGuard`], then runs [`run_loop`] on
+/// the `interval_ms` cadence.
+/// Test: terminal glue is exercised by launching the TUI; the loop's pure
+/// pieces are unit-tested in their own modules.
+pub async fn run(url: String, interval_ms: u64) -> anyhow::Result<()> {
+    let mut client = DaemonClient::new(url);
+    let mut state = ProjectCtlState::default();
+    project_ctl_poll_daemon(&mut state, &mut client).await;
+
+    enable_raw_mode()?;
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    // The guard restores the terminal on every exit path — normal return AND
+    // panic unwind — so it is the SOLE teardown (no manual cleanup follows
+    // `run_loop`).
+    let _guard = TerminalGuard;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    run_loop(&mut terminal, &mut client, state, interval_ms).await
+    // `_guard` drops here (or during an unwind), restoring the terminal.
+}
+
+/// The live render + poll + input loop.
+///
+/// Why: kept separate from [`run`] so terminal setup/teardown wraps it
+/// cleanly and the loop body stays focused on draw → poll-key → dispatch →
+/// maybe-repoll.
+/// What: each iteration draws the frame, polls the keyboard for [`KEY_POLL`]
+/// and routes any key through [`handle_key`], awaiting
+/// [`actions::dispatch`] for any returned [`events::PendingAction`]. Re-polls
+/// the daemon immediately after a successful mutating action (via
+/// [`ProjectCtlState::take_repoll`]) or once at least `interval_ms` has
+/// elapsed since the last poll. Exits once `should_exit` is set (`q` /
+/// Ctrl-C).
+async fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    client: &mut DaemonClient,
+    mut state: ProjectCtlState,
+    interval_ms: u64,
+) -> anyhow::Result<()> {
+    let interval = Duration::from_millis(interval_ms);
+    let mut last_poll = Instant::now();
+
+    loop {
+        terminal.draw(|frame| layout::render(frame, &mut state))?;
+
+        if event::poll(KEY_POLL)?
+            && let Event::Key(key) = event::read()?
+        {
+            if let Some(action) = handle_key(&mut state, key) {
+                actions::dispatch(&mut state, client, action).await;
+            }
+            if state.should_exit {
+                return Ok(());
+            }
+        }
+
+        // A requested repoll (post-mutation) or the timer elapsing both mean
+        // the same thing: refresh now and restart the interval clock. Merged
+        // into one branch (rather than an if/else-if with duplicate bodies)
+        // to satisfy clippy::if_same_then_else.
+        if state.take_repoll() || last_poll.elapsed() >= interval {
+            project_ctl_poll_daemon(&mut state, client).await;
+            last_poll = Instant::now();
+        }
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/actions_bar.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/actions_bar.rs
@@ -2,11 +2,16 @@
 //!
 //! Why: a single-line always-visible reference for the contextual verbs bound
 //! to the focused pane, plus a live daemon-reachability indicator — mirrors
-//! `tui::coordinator::layout`'s status bar.
-//! What: [`bar_text`] is a pure builder (unit tested without a terminal);
-//! [`render`] draws it reversed, matching every other TUI screen's status bar.
-//! Test: `tests` covers the hint text and the notice/daemon-indicator
-//! precedence.
+//! `tui::coordinator::layout`'s status bar. DOC-35 §5.1 ("contextual verbs
+//! bound to the focused pane") and issue #2118 both require the hint text to
+//! change with [`Pane`] focus, not read as one fixed string: showing
+//! `[k] kill  [d] decommission  …` while the Projects or Activity pane is
+//! focused would be misleading — those keys are no-ops there.
+//! What: [`focus_hint`] / [`confirm_prompt_text`] / [`bar_text`] are pure
+//! builders (unit tested without a terminal); [`render`] draws the result
+//! reversed, matching every other TUI screen's status bar.
+//! Test: `tests` covers each focus's hint text, notice/confirm precedence
+//! over the hint, and the daemon indicator.
 
 use ratatui::{
     Frame,
@@ -16,26 +21,71 @@ use ratatui::{
     widgets::Paragraph,
 };
 
-use crate::tui::project_ctl::state::ProjectCtlState;
+use crate::tui::project_ctl::state::{Pane, PendingConfirm, ProjectCtlState};
 
-/// The static key-hint text (DOC-35 §5 keybinding table, ASCII-mockup form —
-/// see `events`'s module doc for why bare letters, not `j`/`k`, are the
-/// action bindings).
-pub const KEY_HINT: &str = "[l] launch  [k] kill  [r] resume  [d] decommission  [a] attach-cmd  [c] config   [Tab] switch pane  [↑↓] select  [Enter] drill in  [q] quit";
+/// Key-hint text shown while the Projects pane has focus.
+pub const PROJECTS_HINT: &str =
+    "[Enter] drill in  [c] config  [Tab] switch pane  [↑↓] select  [q] quit";
+/// Key-hint text shown while the Sessions pane has focus.
+pub const SESSIONS_HINT: &str = "[l] launch  [k] kill  [r] resume  [d] decommission  [a] attach-cmd  [Tab] switch pane  [↑↓] select  [q] quit";
+/// Key-hint text shown while the Activity pane has focus (no verbs bound
+/// there — it is a read-only status strip).
+pub const ACTIVITY_HINT: &str = "[Tab] switch pane  [q] quit";
 
 /// The indicator shown when the daemon answered its last health probe.
 pub const DAEMON_REACHABLE: &str = "daemon ●";
 /// The indicator shown when the daemon is unreachable.
 pub const DAEMON_UNREACHABLE: &str = "daemon ✗";
 
+/// Pick the key-hint text for a given pane focus (DOC-35 §5.1).
+///
+/// Why: pulled out of [`bar_text`] so the per-focus mapping is directly
+/// unit-testable without going through the notice/confirm precedence chain.
+/// What: [`PROJECTS_HINT`] / [`SESSIONS_HINT`] / [`ACTIVITY_HINT`] per
+/// [`Pane`] variant.
+/// Test: `focus_hint_differs_per_pane`.
+pub fn focus_hint(focus: Pane) -> &'static str {
+    match focus {
+        Pane::Projects => PROJECTS_HINT,
+        Pane::Sessions => SESSIONS_HINT,
+        Pane::Activity => ACTIVITY_HINT,
+    }
+}
+
+/// Build the confirmation-gate prompt text for a [`PendingConfirm`] (DOC-35 §5.2).
+///
+/// Why: a pure builder keeps the exact prompt wording testable without a
+/// terminal; `kill` and `decommission` get distinct wording since only the
+/// latter is described as permanent.
+/// What: names the verb, the target session's label, the consequence, and the
+/// `y`/`n` keys that resolve it.
+/// Test: `confirm_prompt_text_names_verb_and_target`.
+pub fn confirm_prompt_text(confirm: &PendingConfirm) -> String {
+    use crate::tui::project_ctl::state::ConfirmKind;
+    match confirm.kind {
+        ConfirmKind::Kill => format!(
+            "⚠ kill '{}' — session is Active. Confirm? [y] yes  [n/Esc] cancel",
+            confirm.session_label
+        ),
+        ConfirmKind::Decommission => format!(
+            "⚠ decommission '{}' — PERMANENT, deletes the workspace. Confirm? [y] yes  [n/Esc] cancel",
+            confirm.session_label
+        ),
+    }
+}
+
 /// Build the action bar's text for the current state.
 ///
-/// Why: a transient notice (the result of a launch/kill/resume/decommission/
-/// attach/config action) takes priority over the static key hints so the
-/// operator sees the outcome of what they just did; either way the daemon
-/// indicator stays visible on the right.
-/// What: `"{notice or KEY_HINT}   ·   {daemon indicator}"`.
-/// Test: `bar_text_shows_hint_by_default`, `bar_text_prefers_notice`,
+/// Why: three things can occupy the left side of the bar, in strict priority
+/// order — an open confirmation gate (DOC-35 §5.2) is effectively a modal and
+/// must dominate everything else; failing that, a transient notice (the
+/// result of the operator's last action) should be seen before it is
+/// overwritten by the next poll; failing that, the focus-contextual hint
+/// (DOC-35 §5.1). The daemon indicator stays visible on the right regardless.
+/// What: `"{confirm-prompt or notice or focus_hint}   ·   {daemon indicator}"`.
+/// Test: `bar_text_shows_focus_hint_by_default`,
+/// `bar_text_prefers_notice_over_hint`,
+/// `bar_text_prefers_confirm_over_notice`,
 /// `bar_text_shows_daemon_indicator`.
 pub fn bar_text(state: &ProjectCtlState) -> String {
     let daemon = if state.daemon_reachable {
@@ -43,7 +93,13 @@ pub fn bar_text(state: &ProjectCtlState) -> String {
     } else {
         DAEMON_UNREACHABLE
     };
-    let left = state.notice.as_deref().unwrap_or(KEY_HINT);
+    let left = if let Some(confirm) = &state.pending_confirm {
+        confirm_prompt_text(confirm)
+    } else if let Some(notice) = &state.notice {
+        notice.clone()
+    } else {
+        focus_hint(state.focus).to_string()
+    };
     format!("{left}   ·   {daemon}")
 }
 
@@ -65,20 +121,82 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ProjectCtlState) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tui::project_ctl::state::ConfirmKind;
 
     #[test]
-    fn bar_text_shows_hint_by_default() {
-        let state = ProjectCtlState::default();
-        assert!(bar_text(&state).contains(KEY_HINT));
+    fn focus_hint_differs_per_pane() {
+        let projects = focus_hint(Pane::Projects);
+        let sessions = focus_hint(Pane::Sessions);
+        let activity = focus_hint(Pane::Activity);
+        assert_ne!(projects, sessions);
+        assert_ne!(sessions, activity);
+        assert_ne!(projects, activity);
+
+        // Destructive/session verbs only appear in the Sessions hint.
+        assert!(sessions.contains("[k] kill"));
+        assert!(sessions.contains("[d] decommission"));
+        assert!(!projects.contains("[k] kill"));
+        assert!(!activity.contains("[k] kill"));
+
+        // The Projects-only config verb only appears there.
+        assert!(projects.contains("[c] config"));
+        assert!(!sessions.contains("[c] config"));
     }
 
     #[test]
-    fn bar_text_prefers_notice() {
+    fn bar_text_shows_focus_hint_by_default() {
+        let mut state = ProjectCtlState::default();
+        assert_eq!(state.focus, Pane::Projects);
+        assert!(bar_text(&state).contains(PROJECTS_HINT));
+
+        state.focus = Pane::Sessions;
+        assert!(bar_text(&state).contains(SESSIONS_HINT));
+
+        state.focus = Pane::Activity;
+        assert!(bar_text(&state).contains(ACTIVITY_HINT));
+    }
+
+    #[test]
+    fn bar_text_prefers_notice_over_hint() {
         let mut state = ProjectCtlState::default();
         state.set_notice("killed foo — now stopped");
         let text = bar_text(&state);
         assert!(text.contains("killed foo — now stopped"));
-        assert!(!text.contains(KEY_HINT));
+        assert!(!text.contains(PROJECTS_HINT));
+    }
+
+    #[test]
+    fn bar_text_prefers_confirm_over_notice() {
+        let mut state = ProjectCtlState::default();
+        state.set_notice("this should be hidden");
+        state.request_confirm(ConfirmKind::Decommission, "sess-1", "my-session");
+        let text = bar_text(&state);
+        assert!(text.contains("decommission"));
+        assert!(text.contains("my-session"));
+        assert!(!text.contains("this should be hidden"));
+    }
+
+    #[test]
+    fn confirm_prompt_text_names_verb_and_target() {
+        let kill = PendingConfirm {
+            kind: ConfirmKind::Kill,
+            session_id: "id".to_string(),
+            session_label: "my-session".to_string(),
+        };
+        let kill_text = confirm_prompt_text(&kill);
+        assert!(kill_text.contains("kill"));
+        assert!(kill_text.contains("my-session"));
+        assert!(kill_text.contains("[y] yes"));
+        assert!(kill_text.contains("[n/Esc] cancel"));
+
+        let decommission = PendingConfirm {
+            kind: ConfirmKind::Decommission,
+            session_id: "id".to_string(),
+            session_label: "my-session".to_string(),
+        };
+        let decommission_text = confirm_prompt_text(&decommission);
+        assert!(decommission_text.contains("decommission"));
+        assert!(decommission_text.contains("PERMANENT"));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/actions_bar.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/actions_bar.rs
@@ -1,0 +1,91 @@
+//! Actions / key-hint bar (bottom row, 1 line) — DOC-35 §5 pane 4.
+//!
+//! Why: a single-line always-visible reference for the contextual verbs bound
+//! to the focused pane, plus a live daemon-reachability indicator — mirrors
+//! `tui::coordinator::layout`'s status bar.
+//! What: [`bar_text`] is a pure builder (unit tested without a terminal);
+//! [`render`] draws it reversed, matching every other TUI screen's status bar.
+//! Test: `tests` covers the hint text and the notice/daemon-indicator
+//! precedence.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::Line,
+    widgets::Paragraph,
+};
+
+use crate::tui::project_ctl::state::ProjectCtlState;
+
+/// The static key-hint text (DOC-35 §5 keybinding table, ASCII-mockup form —
+/// see `events`'s module doc for why bare letters, not `j`/`k`, are the
+/// action bindings).
+pub const KEY_HINT: &str = "[l] launch  [k] kill  [r] resume  [d] decommission  [a] attach-cmd  [c] config   [Tab] switch pane  [↑↓] select  [Enter] drill in  [q] quit";
+
+/// The indicator shown when the daemon answered its last health probe.
+pub const DAEMON_REACHABLE: &str = "daemon ●";
+/// The indicator shown when the daemon is unreachable.
+pub const DAEMON_UNREACHABLE: &str = "daemon ✗";
+
+/// Build the action bar's text for the current state.
+///
+/// Why: a transient notice (the result of a launch/kill/resume/decommission/
+/// attach/config action) takes priority over the static key hints so the
+/// operator sees the outcome of what they just did; either way the daemon
+/// indicator stays visible on the right.
+/// What: `"{notice or KEY_HINT}   ·   {daemon indicator}"`.
+/// Test: `bar_text_shows_hint_by_default`, `bar_text_prefers_notice`,
+/// `bar_text_shows_daemon_indicator`.
+pub fn bar_text(state: &ProjectCtlState) -> String {
+    let daemon = if state.daemon_reachable {
+        DAEMON_REACHABLE
+    } else {
+        DAEMON_UNREACHABLE
+    };
+    let left = state.notice.as_deref().unwrap_or(KEY_HINT);
+    format!("{left}   ·   {daemon}")
+}
+
+/// Draw the action bar into `area`.
+///
+/// Why: the single entry point [`super::super::layout::render`] calls for the
+/// bottom row.
+/// What: a single reversed/bold `Paragraph` line, matching every other TUI
+/// screen's status-bar styling.
+pub fn render(frame: &mut Frame, area: Rect, state: &ProjectCtlState) {
+    let paragraph = Paragraph::new(Line::from(bar_text(state))).style(
+        Style::default()
+            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::REVERSED),
+    );
+    frame.render_widget(paragraph, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bar_text_shows_hint_by_default() {
+        let state = ProjectCtlState::default();
+        assert!(bar_text(&state).contains(KEY_HINT));
+    }
+
+    #[test]
+    fn bar_text_prefers_notice() {
+        let mut state = ProjectCtlState::default();
+        state.set_notice("killed foo — now stopped");
+        let text = bar_text(&state);
+        assert!(text.contains("killed foo — now stopped"));
+        assert!(!text.contains(KEY_HINT));
+    }
+
+    #[test]
+    fn bar_text_shows_daemon_indicator() {
+        let mut state = ProjectCtlState::default();
+        assert!(bar_text(&state).contains(DAEMON_UNREACHABLE));
+        state.daemon_reachable = true;
+        assert!(bar_text(&state).contains(DAEMON_REACHABLE));
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs
@@ -1,0 +1,148 @@
+//! Activity pane (bottom strip, 4 rows) — DOC-35 §5 pane 3, SKELETON ONLY.
+//!
+//! Why: the design spec sources this pane from `GET .../{id}/activity`
+//! (`state`, `summary`, `pending_decision`, `proposed_default`), but per
+//! #2118's scope that live wiring is deferred to #2119. This skeleton instead
+//! renders the focused session's already-polled STATIC record fields —
+//! `state`, `task`, `pending_decision`, `proposed_default` — which travel
+//! through [`super::super::poll::session_to_row`] on the same fleet poll the
+//! Sessions pane uses, at zero extra HTTP cost.
+//! What: [`activity_lines`] is a pure builder (unit tested without a
+//! terminal); [`render`] wraps it in a bordered `Paragraph`.
+//! Test: `tests` covers the no-selection, no-pending, and pending-decision
+//! text shapes.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::Line,
+    widgets::{Block, Borders, Paragraph},
+};
+
+use crate::tui::project_ctl::state::{Pane, ProjectCtlState};
+
+/// Build the Activity pane's body lines for the currently focused session.
+///
+/// Why: a pure text builder keeps the "no selection" / "no pending decision" /
+/// "pending decision" shapes testable without a terminal.
+/// What: with no session selected, a single placeholder line naming the
+/// deferred live wiring (#2119). Otherwise: a header line (`session <name>
+/// (<short-id>)`), a state line naming the static `state` word plus the
+/// pending-decision question and proposed default when present (else
+/// "no pending decision"), and a task line when the record has one.
+/// Test: `activity_lines_no_selection`, `activity_lines_no_pending_decision`,
+/// `activity_lines_shows_pending_decision`.
+pub fn activity_lines(state: &ProjectCtlState) -> Vec<String> {
+    let Some(session) = state.selected_session() else {
+        return vec![
+            "no session selected".to_string(),
+            "(live activity polling is deferred to #2119 — this pane shows only the \
+             already-fetched session record)"
+                .to_string(),
+        ];
+    };
+
+    let mut lines = vec![format!("session {} ({})", session.name, session.short_id)];
+
+    let decision_segment = match (&session.pending_decision, &session.proposed_default) {
+        (Some(q), Some(d)) => format!(" · pending: \"{q}\" · proposed default: {d}"),
+        (Some(q), None) => format!(" · pending: \"{q}\""),
+        _ => " · no pending decision".to_string(),
+    };
+    lines.push(format!("state: {}{decision_segment}", session.state));
+
+    if let Some(task) = &session.task {
+        lines.push(format!("task: {task}"));
+    }
+
+    lines
+}
+
+/// Draw the Activity pane into `area`.
+///
+/// Why: the single entry point [`super::super::layout::render`] calls for the
+/// bottom strip.
+/// What: a bordered, titled (`ACTIVITY`) `Paragraph` over [`activity_lines`];
+/// the title is styled cyan/bold when this pane has focus.
+pub fn render(frame: &mut Frame, area: Rect, state: &ProjectCtlState) {
+    let focused = state.focus == Pane::Activity;
+    let title_style = if focused {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().add_modifier(Modifier::BOLD)
+    };
+    let lines: Vec<Line<'static>> = activity_lines(state).into_iter().map(Line::from).collect();
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(Line::from("ACTIVITY").style(title_style)),
+    );
+    frame.render_widget(paragraph, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::project_ctl::state::{ProjectRow, SessionRow};
+
+    fn state_with_session(session: SessionRow) -> ProjectCtlState {
+        let mut state = ProjectCtlState {
+            projects: vec![ProjectRow {
+                name: "widget".to_string(),
+                repo_url: "https://github.com/acme/widget".to_string(),
+                live_count: 1,
+                total_count: 1,
+            }],
+            ..Default::default()
+        };
+        state
+            .sessions_by_project
+            .insert("widget".to_string(), vec![session]);
+        state.projects_nav.sync_len(state.projects.len());
+        state.sessions_nav.sync_len(state.current_sessions().len());
+        state
+    }
+
+    fn base_session() -> SessionRow {
+        SessionRow {
+            id: "4f9ca1b2ffff".to_string(),
+            short_id: "4f9ca1b2".to_string(),
+            name: "widget-session".to_string(),
+            branch: Some("main".to_string()),
+            task: Some("ship the thing".to_string()),
+            state: "active".to_string(),
+            pending_decision: None,
+            proposed_default: None,
+        }
+    }
+
+    #[test]
+    fn activity_lines_no_selection() {
+        let state = ProjectCtlState::default();
+        let lines = activity_lines(&state);
+        assert!(lines[0].contains("no session selected"));
+    }
+
+    #[test]
+    fn activity_lines_no_pending_decision() {
+        let state = state_with_session(base_session());
+        let lines = activity_lines(&state);
+        assert!(lines.iter().any(|l| l.contains("state: active")));
+        assert!(lines.iter().any(|l| l.contains("no pending decision")));
+        assert!(lines.iter().any(|l| l.contains("ship the thing")));
+    }
+
+    #[test]
+    fn activity_lines_shows_pending_decision() {
+        let mut session = base_session();
+        session.pending_decision = Some("write to ci.yml?".to_string());
+        session.proposed_default = Some("yes".to_string());
+        let state = state_with_session(session);
+        let lines = activity_lines(&state);
+        assert!(lines.iter().any(|l| l.contains("write to ci.yml?")));
+        assert!(lines.iter().any(|l| l.contains("proposed default: yes")));
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/mod.rs
@@ -1,0 +1,17 @@
+//! Pane renderers for the `tm projects` TUI (#2118, DOC-35 §5).
+//!
+//! Why: DOC-35 §5 pins one submodule per pane so each stays small, focused,
+//! and independently testable (the pure row/line builders vs. the terminal-
+//! touching `render` calls). [`super::layout::render`] composes the frame's
+//! `Rect`s and calls into each of these.
+//! What: [`projects`] (left, 25%), [`sessions`] (right, 75%),
+//! [`activity`] (bottom strip, static-fields skeleton), and [`actions_bar`]
+//! (the 1-row key-hint / notice line).
+//! Test: each submodule's pure builders are unit-tested in its own `tests`
+//! block; the `render` functions are terminal glue exercised by launching the
+//! TUI.
+
+pub mod actions_bar;
+pub mod activity;
+pub mod projects;
+pub mod sessions;

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/projects.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/projects.rs
@@ -1,0 +1,142 @@
+//! Projects pane (left column, 25% width) — DOC-35 §5 pane 1.
+//!
+//! Why: one row per registered project with an aggregate-state glyph and its
+//! live session count, so an operator can scan fleet health across every
+//! project without drilling into any one of them.
+//! What: [`aggregate_glyph`] / [`project_line`] are pure builders (unit
+//! tested without a terminal); [`render`] composes them into a ratatui
+//! stateful `List`.
+//! Test: `tests` covers the glyph rule and the line content.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, HighlightSpacing, List, ListItem},
+};
+
+use crate::tui::project_ctl::state::{Pane, ProjectCtlState, ProjectRow};
+
+/// Glyph shown when a project has at least one live (active/provisioning) session.
+pub const LIVE_GLYPH: char = '●';
+/// Glyph shown when a project has no live sessions.
+pub const IDLE_GLYPH: char = '○';
+
+/// Pick the aggregate-state glyph for one project row.
+///
+/// Why: DOC-35 §5 calls for "one row per registered project, aggregate-state
+/// glyph, live session count" — this is the glyph half of that contract.
+/// What: [`LIVE_GLYPH`] when `row.live_count > 0`, else [`IDLE_GLYPH`].
+/// Test: `aggregate_glyph_reflects_live_count`.
+pub fn aggregate_glyph(row: &ProjectRow) -> char {
+    if row.live_count > 0 {
+        LIVE_GLYPH
+    } else {
+        IDLE_GLYPH
+    }
+}
+
+/// Build one project row's display line: `<glyph><live_count>  <name>`.
+///
+/// Why: a pure builder keeps the row TEXT testable without a terminal; the
+/// `▸` focus marker is applied by the `List` widget's `highlight_symbol` in
+/// [`render`], not baked into this line.
+/// What: returns e.g. `●3  trusty-tools`.
+/// Test: `project_line_shows_glyph_count_and_name`.
+pub fn project_line(row: &ProjectRow) -> Line<'static> {
+    let glyph = aggregate_glyph(row);
+    let glyph_style = if row.live_count > 0 {
+        Style::default().fg(Color::Green)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    Line::from(vec![
+        Span::styled(format!("{glyph}{}", row.live_count), glyph_style),
+        Span::raw("  "),
+        Span::styled(
+            row.name.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+    ])
+}
+
+/// Draw the Projects pane into `area`.
+///
+/// Why: the single entry point [`super::super::layout::render`] calls for the
+/// left column.
+/// What: a bordered, titled (`PROJECTS (N)`) stateful `List`; the title and
+/// the `▸` highlight symbol are styled cyan/bold when this pane has focus, so
+/// the operator can see at a glance which pane Tab will act on.
+pub fn render(frame: &mut Frame, area: Rect, state: &mut ProjectCtlState) {
+    let focused = state.focus == Pane::Projects;
+    let items: Vec<ListItem> = state
+        .projects
+        .iter()
+        .map(|p| ListItem::new(project_line(p)))
+        .collect();
+    let title =
+        Line::from(format!("PROJECTS ({})", state.projects.len())).style(title_style(focused));
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .highlight_style(
+            Style::default()
+                .fg(Color::White)
+                .bg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ")
+        .highlight_spacing(HighlightSpacing::Always);
+    frame.render_stateful_widget(list, area, state.projects_nav.state_mut());
+}
+
+/// Style the pane title, brighter when it holds focus.
+fn title_style(focused: bool) -> Style {
+    if focused {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().add_modifier(Modifier::BOLD)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(live: usize) -> ProjectRow {
+        ProjectRow {
+            name: "widget".to_string(),
+            repo_url: "https://github.com/acme/widget".to_string(),
+            live_count: live,
+            total_count: live + 1,
+        }
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn aggregate_glyph_reflects_live_count() {
+        assert_eq!(aggregate_glyph(&row(0)), IDLE_GLYPH);
+        assert_eq!(aggregate_glyph(&row(1)), LIVE_GLYPH);
+    }
+
+    #[test]
+    fn project_line_shows_glyph_count_and_name() {
+        let text = line_text(&project_line(&row(3)));
+        assert!(
+            text.starts_with("●3"),
+            "expected leading glyph+count: {text}"
+        );
+        assert!(text.contains("widget"), "missing name: {text}");
+    }
+
+    #[test]
+    fn project_line_idle_uses_hollow_glyph() {
+        let text = line_text(&project_line(&row(0)));
+        assert!(text.starts_with("○0"), "expected hollow glyph: {text}");
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs
@@ -1,0 +1,185 @@
+//! Sessions pane (right column, 75% width) — DOC-35 §5 pane 2.
+//!
+//! Why: the selected project's sessions, numbered per DOC-16 §3.2, each
+//! showing a lifecycle-state glyph, branch, and a one-line detail. The glyph
+//! is driven ONLY by the session record's static `ManagedSessionState` word —
+//! there is no live `/activity` polling in this issue's scope (#2119 wires
+//! that live "awaiting approval" / "idle Nm" detail into this pane later).
+//! What: [`state_glyph`] / [`session_line`] are pure builders (unit tested
+//! without a terminal); [`render`] composes them into a ratatui stateful
+//! `List`.
+//! Test: `tests` covers the glyph rule and the line content.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, HighlightSpacing, List, ListItem},
+};
+
+use crate::tui::project_ctl::state::{Pane, ProjectCtlState, SessionRow};
+
+/// Glyph for a session whose runtime is currently running.
+pub const ACTIVE_GLYPH: char = '●';
+/// Glyph for a session whose workspace is being provisioned.
+pub const PROVISIONING_GLYPH: char = '◍';
+/// Glyph for a session with an intact, resumable, stopped runtime.
+pub const STOPPED_GLYPH: char = '○';
+/// Glyph for a session whose provisioning or runtime spawn failed.
+pub const ERRORED_GLYPH: char = '✗';
+/// Glyph for a decommissioned (tombstoned) session.
+pub const DECOMMISSIONED_GLYPH: char = '⊘';
+
+/// Pick the lifecycle-state glyph for one session's `state` word.
+///
+/// Why: the static `ManagedSessionState` word (`active`/`provisioning`/
+/// `stopped`/`errored`/`decommissioned`, see `session_manager::record`) is
+/// the only state this issue's skeleton has available — the live
+/// "awaiting approval" / "idle Nm" detail the mockup shows comes from the
+/// `/activity` endpoint, deferred to #2119.
+/// What: maps each of the five known state words to its glyph; any other
+/// (forward-compat) value falls back to [`STOPPED_GLYPH`].
+/// Test: `state_glyph_maps_every_known_state`, `state_glyph_unknown_falls_back`.
+pub fn state_glyph(state: &str) -> char {
+    match state {
+        "active" => ACTIVE_GLYPH,
+        "provisioning" => PROVISIONING_GLYPH,
+        "errored" => ERRORED_GLYPH,
+        "decommissioned" => DECOMMISSIONED_GLYPH,
+        _ => STOPPED_GLYPH,
+    }
+}
+
+/// Build one numbered session row: `N. <glyph> <short-id>  <branch>  <detail>`.
+///
+/// Why: DOC-16 §3.2 numbers session rows so an operator can refer to one by
+/// its list position; the detail column prefers the task description and
+/// falls back to the raw state word when no task is recorded.
+/// What: returns e.g. `1. ● 4f9ca1b2  main  ship the thing`.
+/// Test: `session_line_shows_number_glyph_branch_and_task`,
+/// `session_line_falls_back_to_state_word`.
+pub fn session_line(number: usize, row: &SessionRow) -> Line<'static> {
+    let glyph = state_glyph(&row.state);
+    let branch = row.branch.clone().unwrap_or_else(|| "-".to_string());
+    let detail = row.task.clone().unwrap_or_else(|| row.state.clone());
+    Line::from(vec![
+        Span::styled(
+            format!("{number:>2}. "),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(format!("{glyph} "), glyph_style(&row.state)),
+        Span::styled(
+            format!("{}  ", row.short_id),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!("{branch}  ")),
+        Span::styled(detail, Style::default().fg(Color::DarkGray)),
+    ])
+}
+
+/// Style a state glyph by its lifecycle state.
+fn glyph_style(state: &str) -> Style {
+    match state {
+        "active" => Style::default().fg(Color::Green),
+        "provisioning" => Style::default().fg(Color::Yellow),
+        "errored" => Style::default().fg(Color::Red),
+        "decommissioned" => Style::default().fg(Color::DarkGray),
+        _ => Style::default().fg(Color::Gray),
+    }
+}
+
+/// Draw the Sessions pane into `area`.
+///
+/// Why: the single entry point [`super::super::layout::render`] calls for the
+/// right column.
+/// What: a bordered, titled (`SESSIONS — <project> (N)`) stateful `List`
+/// scoped to `state.current_sessions()`; the title names the selected
+/// project, or reads `SESSIONS` when none is selected (empty registry).
+pub fn render(frame: &mut Frame, area: Rect, state: &mut ProjectCtlState) {
+    let focused = state.focus == Pane::Sessions;
+    let sessions = state.current_sessions().to_vec();
+    let items: Vec<ListItem> = sessions
+        .iter()
+        .enumerate()
+        .map(|(i, s)| ListItem::new(session_line(i + 1, s)))
+        .collect();
+    let project_label = state.selected_project_name().unwrap_or("-");
+    let title = Line::from(format!("SESSIONS — {project_label} ({})", sessions.len()))
+        .style(title_style(focused));
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .highlight_style(
+            Style::default()
+                .fg(Color::White)
+                .bg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_spacing(HighlightSpacing::Always);
+    frame.render_stateful_widget(list, area, state.sessions_nav.state_mut());
+}
+
+/// Style the pane title, brighter when it holds focus.
+fn title_style(focused: bool) -> Style {
+    if focused {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().add_modifier(Modifier::BOLD)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(state: &str) -> SessionRow {
+        SessionRow {
+            id: "4f9ca1b2ffff".to_string(),
+            short_id: "4f9ca1b2".to_string(),
+            name: "session".to_string(),
+            branch: Some("feat/x".to_string()),
+            task: Some("ship the thing".to_string()),
+            state: state.to_string(),
+            pending_decision: None,
+            proposed_default: None,
+        }
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn state_glyph_maps_every_known_state() {
+        assert_eq!(state_glyph("active"), ACTIVE_GLYPH);
+        assert_eq!(state_glyph("provisioning"), PROVISIONING_GLYPH);
+        assert_eq!(state_glyph("stopped"), STOPPED_GLYPH);
+        assert_eq!(state_glyph("errored"), ERRORED_GLYPH);
+        assert_eq!(state_glyph("decommissioned"), DECOMMISSIONED_GLYPH);
+    }
+
+    #[test]
+    fn state_glyph_unknown_falls_back() {
+        assert_eq!(state_glyph("something-new"), STOPPED_GLYPH);
+    }
+
+    #[test]
+    fn session_line_shows_number_glyph_branch_and_task() {
+        let text = line_text(&session_line(1, &row("active")));
+        assert!(text.starts_with(" 1. "), "missing number: {text}");
+        assert!(text.contains(ACTIVE_GLYPH), "missing glyph: {text}");
+        assert!(text.contains("4f9ca1b2"), "missing short id: {text}");
+        assert!(text.contains("feat/x"), "missing branch: {text}");
+        assert!(text.contains("ship the thing"), "missing task: {text}");
+    }
+
+    #[test]
+    fn session_line_falls_back_to_state_word() {
+        let mut r = row("stopped");
+        r.task = None;
+        let text = line_text(&session_line(2, &r));
+        assert!(text.contains("stopped"), "missing state fallback: {text}");
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/poll.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll.rs
@@ -1,0 +1,250 @@
+//! Live daemon polling for the `tm projects` TUI (#2118).
+//!
+//! Why: the run loop repeats one async step on its `--interval-ms` cadence —
+//! probe daemon health, self-heal the URL on failure, pull the registry-B
+//! project list plus the fleet-by-project session groups, and project both
+//! into the pure row shapes [`super::state`] renders. Mirrors
+//! `tui::coordinator::poll::coord_poll_daemon` so every TUI screen self-heals
+//! the daemon URL identically. Fetching the fleet ONCE per tick (rather than
+//! per-project) keeps this to two HTTP calls regardless of project count.
+//! What: [`project_ctl_poll_daemon`] (health → rediscover-on-fail → registry
+//! list + fleet → map; on daemon-down clears both) plus the pure projections
+//! [`project_to_row`] and [`session_to_row`].
+//! Test: `tests` covers the pure projections; the async glue mirrors the
+//! coordinator's poller and is exercised by launching the TUI.
+
+use crate::client::{DaemonClient, FleetProjectGroupWire, ManagedSessionSummary};
+use crate::project::Project;
+use crate::tui::coordinator::rows::session_short_id;
+
+use super::state::{ProjectCtlState, ProjectRow, SessionRow};
+
+/// Refresh [`ProjectCtlState`] from one daemon poll.
+///
+/// Why: keeps the poll logic out of the key-driven run loop so the loop can
+/// re-poll on its timer (and, after a mutating action, on demand) without
+/// duplicating the health/rediscover/fetch sequence.
+/// What: probes health; if the daemon looks down, re-resolves the URL from
+/// the lock file via [`rediscover`] and retries one health probe. When
+/// reachable it pulls `GET /api/v1/projects` and
+/// `GET /api/v1/sessions/managed/fleet`, merges them into `state.projects` /
+/// `state.sessions_by_project`; on a transport error or an unreachable daemon
+/// it clears both and sets `daemon_reachable = false`. Always re-syncs both
+/// navigation models so a shrunk list never leaves a selection past the end;
+/// the Sessions-pane selection is PRESERVED across a refresh (only an
+/// explicit project switch resets it — see
+/// [`ProjectCtlState::on_project_selection_changed`]).
+/// Test: `poll_marks_unreachable_clears_state` drives the daemon-down branch;
+/// the daemon-up path requires a live daemon and is exercised manually.
+pub(crate) async fn project_ctl_poll_daemon(
+    state: &mut ProjectCtlState,
+    client: &mut DaemonClient,
+) {
+    state.daemon_reachable = client.is_healthy().await;
+    if rediscover(client, state.daemon_reachable) {
+        state.daemon_reachable = client.is_healthy().await;
+    }
+    if state.daemon_reachable {
+        match fetch_projects_and_sessions(client).await {
+            Ok((projects, sessions_by_project)) => {
+                state.projects = projects;
+                state.sessions_by_project = sessions_by_project;
+            }
+            Err(_) => {
+                state.daemon_reachable = false;
+                state.projects.clear();
+                state.sessions_by_project.clear();
+            }
+        }
+    } else {
+        state.projects.clear();
+        state.sessions_by_project.clear();
+    }
+    state.projects_nav.sync_len(state.projects.len());
+    state.sessions_nav.sync_len(state.current_sessions().len());
+}
+
+/// Re-resolve the daemon URL from the lock file when the daemon is unreachable.
+///
+/// Why: [`DaemonClient`] is built once at startup; if the daemon later
+/// restarted onto a fresh ephemeral port the client would stay pinned to a
+/// stale address forever. Mirrors `tui::coordinator::poll::rediscover`.
+/// What: when `reachable` is `false`, re-resolves via
+/// [`crate::core::resolve_daemon_url`] and, if it differs from the client's
+/// current URL, re-points the client and returns `true` so the caller retries
+/// one health probe.
+fn rediscover(client: &mut DaemonClient, reachable: bool) -> bool {
+    if reachable {
+        return false;
+    }
+    let resolved = crate::core::resolve_daemon_url(None);
+    if resolved != client.base_url() {
+        client.set_base_url(resolved);
+        true
+    } else {
+        false
+    }
+}
+
+/// Fetch the registry project list and the fleet session groups, merged.
+///
+/// Why: one place owns the two-call fetch + merge so [`project_ctl_poll_daemon`]
+/// stays a thin health/rediscover wrapper.
+/// What: GETs `registry_list_projects` and `fleet_managed_sessions`, then
+/// builds the `Vec<ProjectRow>` (registry order, counts from the matching
+/// fleet group) and the `sessions_by_project` map (every fleet group, even a
+/// project the registry list omitted — defensive against a transient
+/// registry/fleet mismatch).
+async fn fetch_projects_and_sessions(
+    client: &DaemonClient,
+) -> anyhow::Result<(
+    Vec<ProjectRow>,
+    std::collections::BTreeMap<String, Vec<SessionRow>>,
+)> {
+    let projects = client.registry_list_projects(None).await?;
+    let groups = client.fleet_managed_sessions().await?;
+
+    let mut sessions_by_project = std::collections::BTreeMap::new();
+    for group in &groups {
+        let rows = group.sessions.iter().cloned().map(session_to_row).collect();
+        sessions_by_project.insert(group.project_name.clone(), rows);
+    }
+
+    let rows = projects
+        .iter()
+        .map(|p| {
+            let group = groups.iter().find(|g| g.project_name == p.name);
+            project_to_row(p, group)
+        })
+        .collect();
+
+    Ok((rows, sessions_by_project))
+}
+
+/// Project one registry [`Project`] (plus its matching fleet group, if any)
+/// into a [`ProjectRow`].
+///
+/// Why: the Projects pane needs the aggregate-state glyph + live session
+/// count (DOC-35 §5), not the raw registry/fleet DTOs.
+/// What: `live_count` is the number of sessions in `group` whose `state` is
+/// `"active"` or `"provisioning"`; `total_count` is `group.sessions.len()`.
+/// A project with no matching fleet group (never spawned a session) gets
+/// `0`/`0`.
+/// Test: `project_to_row_counts_live_and_total`,
+/// `project_to_row_missing_group_is_zeroed`.
+pub(crate) fn project_to_row(p: &Project, group: Option<&FleetProjectGroupWire>) -> ProjectRow {
+    let (live_count, total_count) = match group {
+        Some(g) => (
+            g.sessions
+                .iter()
+                .filter(|s| matches!(s.state.as_str(), "active" | "provisioning"))
+                .count(),
+            g.sessions.len(),
+        ),
+        None => (0, 0),
+    };
+    ProjectRow {
+        name: p.name.clone(),
+        repo_url: p.repo_url.clone(),
+        live_count,
+        total_count,
+    }
+}
+
+/// Project one fleet [`ManagedSessionSummary`] into a [`SessionRow`].
+///
+/// Why: the Sessions pane needs a numbered, compact row per session, plus the
+/// static `pending_decision`/`proposed_default` fields the Activity pane
+/// skeleton renders (#2118 does NOT call the live `/activity` endpoint — that
+/// is #2119).
+/// What: derives the 8-hex short id via [`session_short_id`] and copies the
+/// rest through unchanged.
+/// Test: `session_to_row_derives_short_id_and_copies_fields`.
+pub(crate) fn session_to_row(s: ManagedSessionSummary) -> SessionRow {
+    let short_id = session_short_id(&s.id);
+    SessionRow {
+        id: s.id,
+        short_id,
+        name: s.name,
+        branch: s.branch,
+        task: s.task,
+        state: s.state,
+        pending_decision: s.pending_decision,
+        proposed_default: s.proposed_default,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project(name: &str) -> Project {
+        Project {
+            name: name.to_string(),
+            repo_url: format!("https://github.com/acme/{name}"),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        }
+    }
+
+    fn summary(id: &str, state: &str) -> ManagedSessionSummary {
+        ManagedSessionSummary {
+            id: id.to_string(),
+            name: format!("s-{id}"),
+            state: state.to_string(),
+            workspace_path: None,
+            repo_url: None,
+            branch: Some("main".to_string()),
+            created_at: None,
+            last_activity_at: None,
+            pending_decision: None,
+            proposed_default: None,
+            source_id: None,
+            task: Some("do the thing".to_string()),
+            cwd: None,
+            claude_session_id: None,
+        }
+    }
+
+    #[test]
+    fn project_to_row_counts_live_and_total() {
+        let p = project("widget");
+        let group = FleetProjectGroupWire {
+            project_name: "widget".to_string(),
+            repo_url: p.repo_url.clone(),
+            sessions: vec![
+                summary("a1111111", "active"),
+                summary("b2222222", "provisioning"),
+                summary("c3333333", "stopped"),
+            ],
+        };
+        let row = project_to_row(&p, Some(&group));
+        assert_eq!(row.live_count, 2);
+        assert_eq!(row.total_count, 3);
+        assert_eq!(row.name, "widget");
+    }
+
+    #[test]
+    fn project_to_row_missing_group_is_zeroed() {
+        let p = project("widget");
+        let row = project_to_row(&p, None);
+        assert_eq!(row.live_count, 0);
+        assert_eq!(row.total_count, 0);
+    }
+
+    #[test]
+    fn session_to_row_derives_short_id_and_copies_fields() {
+        let row = session_to_row(summary("4f9ca1b2ffff", "active"));
+        assert_eq!(row.short_id, "4f9ca1b2");
+        assert_eq!(row.id, "4f9ca1b2ffff");
+        assert_eq!(row.state, "active");
+        assert_eq!(row.branch.as_deref(), Some("main"));
+        assert_eq!(row.task.as_deref(), Some("do the thing"));
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/poll.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll.rs
@@ -209,6 +209,7 @@ mod tests {
             task: Some("do the thing".to_string()),
             cwd: None,
             claude_session_id: None,
+            pane_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/state.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/state.rs
@@ -10,9 +10,12 @@
 //! [`SessionRow`]) and the [`Pane`] focus enum. Sessions are keyed by owning
 //! project name in [`ProjectCtlState::sessions_by_project`] so switching the
 //! Projects-pane selection never requires a new daemon round trip — the
-//! Sessions pane simply re-reads the already-polled map.
-//! Test: `super::tests` covers focus cycling, selection clamp/reset, and the
-//! notice/repoll flags.
+//! Sessions pane simply re-reads the already-polled map. [`ConfirmKind`] /
+//! [`PendingConfirm`] are the shared confirmation-gate mechanism DOC-35 §5.2
+//! requires before `k` (kill, when Active) or `d` (decommission, always) may
+//! execute.
+//! Test: `super::tests` covers focus cycling, selection clamp/reset, the
+//! notice/repoll flags, and the confirm-gate request/clear/override rules.
 
 use std::collections::BTreeMap;
 
@@ -113,6 +116,45 @@ pub struct SessionRow {
     pub proposed_default: Option<String>,
 }
 
+/// Which destructive verb a [`PendingConfirm`] is gating.
+///
+/// Why: DOC-35 §5.2 requires a confirmation gate before `k` (kill) executes
+/// on an Active session, and unconditionally before `d` (decommission)
+/// executes at all — a single keypress must never fire either. Sharing ONE
+/// confirmation mechanism for both (rather than two parallel modal types)
+/// keeps the gate/render/dispatch plumbing in one place.
+/// What: `Kill` and `Decommission` map 1:1 to [`super::events::PendingAction::Kill`]
+/// / [`super::events::PendingAction::Decommission`] once confirmed.
+/// Test: `super::events::tests` covers both confirm flows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfirmKind {
+    /// Confirming `k` (kill / runtime-stop) on an Active session.
+    Kill,
+    /// Confirming `d` (decommission) — always gated, any state (terminal action).
+    Decommission,
+}
+
+/// A destructive action awaiting operator confirmation (DOC-35 §5.2).
+///
+/// Why: holds everything [`super::panes::actions_bar`] needs to render the
+/// confirm prompt and everything [`super::events::handle_key`] needs to
+/// resolve it (confirm → the real [`super::events::PendingAction`]; cancel →
+/// discard) without re-deriving either from the current selection, which may
+/// have moved on by the time the operator answers.
+/// What: the verb ([`ConfirmKind`]), the target session's id (for dispatch),
+/// and a human-readable label (name or short id, for the prompt text).
+/// Test: `super::events::tests`, `super::panes::actions_bar::tests`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingConfirm {
+    /// Which verb is being confirmed.
+    pub kind: ConfirmKind,
+    /// The target session's full id — threaded into the eventual
+    /// [`super::events::PendingAction`] on confirmation.
+    pub session_id: String,
+    /// A human-readable label for the target session, shown in the prompt.
+    pub session_label: String,
+}
+
 /// Everything the `tm projects` TUI renders and mutates this frame.
 ///
 /// Why: a single owned struct (mirroring `CoordinatorState`) keeps the
@@ -142,6 +184,14 @@ pub struct ProjectCtlState {
     /// A transient notice (toast) shown in the action bar, e.g. the result of
     /// a launch/kill/resume/decommission/attach/config action.
     pub notice: Option<String>,
+    /// A destructive action (kill-on-Active / decommission) awaiting
+    /// operator confirmation (DOC-35 §5.2). While `Some`, [`handle_key`] in
+    /// `events.rs` routes EVERY key through the confirm/cancel gate instead
+    /// of normal dispatch — mirroring the spec's "`q`/`Ctrl-C` — not in a
+    /// modal" / "`Esc` — any modal/form — cancel" contract.
+    ///
+    /// [`handle_key`]: super::events::handle_key
+    pub pending_confirm: Option<PendingConfirm>,
     /// Set when a mutating action just succeeded and the operator should see
     /// the fleet refreshed without waiting for the next timer tick.
     ///
@@ -231,6 +281,34 @@ impl ProjectCtlState {
     /// Clear the transient action-bar notice (Esc).
     pub fn clear_notice(&mut self) {
         self.notice = None;
+    }
+
+    /// Open the confirmation gate for a destructive action (DOC-35 §5.2).
+    ///
+    /// Why: the single seam [`super::events`]'s `k`/`d` handlers call instead
+    /// of returning the real [`super::events::PendingAction`] directly — no
+    /// destructive verb may execute on the keypress that requested it.
+    /// What: sets [`Self::pending_confirm`], overriding any prior one (a new
+    /// request always wins — there is only ever one target at a time since
+    /// the modal captures all input while open).
+    /// Test: `super::events::tests`.
+    pub fn request_confirm(
+        &mut self,
+        kind: ConfirmKind,
+        session_id: impl Into<String>,
+        session_label: impl Into<String>,
+    ) {
+        self.pending_confirm = Some(PendingConfirm {
+            kind,
+            session_id: session_id.into(),
+            session_label: session_label.into(),
+        });
+    }
+
+    /// Close the confirmation gate without acting (`n`/`N`/Esc, or after `y`
+    /// resolves it).
+    pub fn clear_confirm(&mut self) {
+        self.pending_confirm = None;
     }
 
     /// Request an immediate daemon re-poll on the next run-loop tick.
@@ -347,5 +425,28 @@ mod tests {
         state.request_repoll();
         assert!(state.take_repoll());
         assert!(!state.take_repoll());
+    }
+
+    #[test]
+    fn confirm_request_set_and_clear() {
+        let mut state = ProjectCtlState::default();
+        assert!(state.pending_confirm.is_none());
+        state.request_confirm(ConfirmKind::Decommission, "sess-1", "my-session");
+        let confirm = state.pending_confirm.clone().expect("confirm requested");
+        assert_eq!(confirm.kind, ConfirmKind::Decommission);
+        assert_eq!(confirm.session_id, "sess-1");
+        assert_eq!(confirm.session_label, "my-session");
+        state.clear_confirm();
+        assert!(state.pending_confirm.is_none());
+    }
+
+    #[test]
+    fn confirm_request_overrides_a_prior_one() {
+        let mut state = ProjectCtlState::default();
+        state.request_confirm(ConfirmKind::Kill, "sess-1", "one");
+        state.request_confirm(ConfirmKind::Decommission, "sess-2", "two");
+        let confirm = state.pending_confirm.expect("confirm requested");
+        assert_eq!(confirm.kind, ConfirmKind::Decommission);
+        assert_eq!(confirm.session_id, "sess-2");
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/state.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/state.rs
@@ -1,0 +1,351 @@
+//! Application state for the `tm projects` 4-pane TUI skeleton (#2118).
+//!
+//! Why: the render loop and the key dispatcher both read and mutate one piece
+//! of state — the registered-project list, the sessions grouped per project,
+//! which pane has focus, and the current row selections. Holding it in a
+//! single struct with pure, unit-testable mutators keeps the terminal glue
+//! thin and the selection logic verifiable without a terminal, mirroring
+//! `tui::coordinator::state::CoordinatorState`.
+//! What: [`ProjectCtlState`] plus its row types ([`ProjectRow`],
+//! [`SessionRow`]) and the [`Pane`] focus enum. Sessions are keyed by owning
+//! project name in [`ProjectCtlState::sessions_by_project`] so switching the
+//! Projects-pane selection never requires a new daemon round trip — the
+//! Sessions pane simply re-reads the already-polled map.
+//! Test: `super::tests` covers focus cycling, selection clamp/reset, and the
+//! notice/repoll flags.
+
+use std::collections::BTreeMap;
+
+use crate::tui::coordinator::nav::ListNav;
+
+/// Which of the three navigable panes currently has keyboard focus.
+///
+/// Why: Tab/Shift+Tab cycle focus Projects → Sessions → Activity (DOC-35 §5);
+/// a typed enum keeps the cycle exhaustive and the render path's highlight
+/// branch unambiguous. The Activity pane is a skeleton in this issue (#2118)
+/// — it renders the focused session's static fields only — but it is still a
+/// stop in the focus cycle per the spec's keybinding table.
+/// What: three variants in cycle order; [`Pane::next`] / [`Pane::prev`] wrap.
+/// Test: `pane_cycle_wraps_forward_and_backward`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Pane {
+    /// The left-column project list (25% width).
+    #[default]
+    Projects,
+    /// The right-column session list for the selected project (75% width).
+    Sessions,
+    /// The bottom activity strip for the focused session.
+    Activity,
+}
+
+impl Pane {
+    /// Advance to the next pane in the cycle, wrapping after Activity.
+    pub fn next(self) -> Self {
+        match self {
+            Pane::Projects => Pane::Sessions,
+            Pane::Sessions => Pane::Activity,
+            Pane::Activity => Pane::Projects,
+        }
+    }
+
+    /// Step back to the previous pane in the cycle, wrapping before Projects.
+    pub fn prev(self) -> Self {
+        match self {
+            Pane::Projects => Pane::Activity,
+            Pane::Sessions => Pane::Projects,
+            Pane::Activity => Pane::Sessions,
+        }
+    }
+}
+
+/// One registered project as rendered by the Projects pane.
+///
+/// Why: the pane shows an aggregate-state glyph plus a live session count
+/// (DOC-35 §5) rather than the raw registry record; a small projection keeps
+/// the render layer free of the wire DTOs.
+/// What: the registry name/repo URL plus `live_count` (sessions currently
+/// `active` or `provisioning`) and `total_count` (every session bound to the
+/// project, any state).
+/// Test: `poll::tests::project_to_row_*`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProjectRow {
+    /// Registry key / short project name.
+    pub name: String,
+    /// Full repository URL.
+    pub repo_url: String,
+    /// Sessions currently `active` or `provisioning` — the "aggregate-state
+    /// glyph, live session count" the spec calls for.
+    pub live_count: usize,
+    /// Every session bound to this project, any lifecycle state.
+    pub total_count: usize,
+}
+
+/// One managed session as rendered by the Sessions pane.
+///
+/// Why: the Sessions pane needs a numbered, compact row per session; a small
+/// projection off [`crate::client::ManagedSessionSummary`] keeps the render
+/// layer decoupled from the wire DTO. `pending_decision` / `proposed_default`
+/// are carried through UNCHANGED from the session record (they are static
+/// fields on the record itself, not a live `/activity` poll) so the Activity
+/// pane skeleton can render them without calling the `/activity` endpoint —
+/// that live wiring is deferred to #2119.
+/// What: id/short-id/name/branch/task plus the lifecycle `state` word and the
+/// two static activity fields.
+/// Test: `poll::tests::session_to_row_*`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SessionRow {
+    /// Full session id (UUID string).
+    pub id: String,
+    /// Short (8-hex) session id shown in the list.
+    pub short_id: String,
+    /// tmux session name.
+    pub name: String,
+    /// Git branch or ref checked out, if known.
+    pub branch: Option<String>,
+    /// Task description, if known.
+    pub task: Option<String>,
+    /// Lifecycle state word (`active`, `provisioning`, `stopped`, `errored`,
+    /// `decommissioned`).
+    pub state: String,
+    /// A pending decision question, if surfaced on the record.
+    pub pending_decision: Option<String>,
+    /// Proposed default answer to the pending decision.
+    pub proposed_default: Option<String>,
+}
+
+/// Everything the `tm projects` TUI renders and mutates this frame.
+///
+/// Why: a single owned struct (mirroring `CoordinatorState`) keeps the
+/// data/render split clean — the event loop and the poller mutate it, the
+/// layout reads it.
+/// What: the project list + its navigation, the per-project session map + its
+/// navigation, the focused pane, daemon reachability, a transient notice
+/// (toast) line, and the repoll/exit flags.
+/// Test: `super::tests` covers focus cycling, selection, and the flags.
+#[derive(Debug, Clone, Default)]
+pub struct ProjectCtlState {
+    /// Registered projects, in registry order.
+    pub projects: Vec<ProjectRow>,
+    /// Projects-pane selection + scroll offset.
+    pub projects_nav: ListNav,
+    /// Every project's sessions, keyed by project name — populated by one
+    /// `GET /api/v1/sessions/managed/fleet` poll per tick rather than a
+    /// per-project round trip.
+    pub sessions_by_project: BTreeMap<String, Vec<SessionRow>>,
+    /// Sessions-pane selection + scroll offset (scoped to the currently
+    /// selected project).
+    pub sessions_nav: ListNav,
+    /// Which pane currently has keyboard focus.
+    pub focus: Pane,
+    /// Whether the daemon answered its last health probe.
+    pub daemon_reachable: bool,
+    /// A transient notice (toast) shown in the action bar, e.g. the result of
+    /// a launch/kill/resume/decommission/attach/config action.
+    pub notice: Option<String>,
+    /// Set when a mutating action just succeeded and the operator should see
+    /// the fleet refreshed without waiting for the next timer tick.
+    ///
+    /// `pub(crate)`, not private: sibling modules within this crate build
+    /// [`ProjectCtlState`] via struct-update syntax (`..Default::default()`)
+    /// in their own test seeds, which requires every field to be visible at
+    /// the construction site even when not explicitly listed. External
+    /// crates still cannot name or set it directly — only
+    /// [`Self::request_repoll`] / [`Self::take_repoll`] mutate it outside
+    /// this crate.
+    pub(crate) needs_repoll: bool,
+    /// Set when the operator asks to quit; the event loop exits on the next tick.
+    pub should_exit: bool,
+}
+
+impl ProjectCtlState {
+    /// The currently selected project row, if any.
+    ///
+    /// Why: the Sessions/Activity panes and the `l`/`c` actions all need to
+    /// know which project is selected.
+    /// What: `projects[projects_nav.selected()]`, or `None` on an empty list.
+    /// Test: `selected_project_reads_nav_index`.
+    pub fn selected_project(&self) -> Option<&ProjectRow> {
+        self.projects.get(self.projects_nav.selected())
+    }
+
+    /// The currently selected project's name, if any.
+    pub fn selected_project_name(&self) -> Option<&str> {
+        self.selected_project().map(|p| p.name.as_str())
+    }
+
+    /// The session list for the currently selected project (may be empty).
+    ///
+    /// Why: the Sessions pane and the `k`/`r`/`d`/`a` actions read this rather
+    /// than re-deriving it from `sessions_by_project` at every call site.
+    /// What: `sessions_by_project[selected project name]`, or `&[]` when no
+    /// project is selected or the project has no sessions.
+    /// Test: `current_sessions_follows_selected_project`.
+    pub fn current_sessions(&self) -> &[SessionRow] {
+        self.selected_project_name()
+            .and_then(|name| self.sessions_by_project.get(name))
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// The currently selected session row, if any.
+    pub fn selected_session(&self) -> Option<&SessionRow> {
+        self.current_sessions().get(self.sessions_nav.selected())
+    }
+
+    /// Re-sync the Sessions-pane navigation to a freshly selected project.
+    ///
+    /// Why: switching WHICH project is selected in the Projects pane means the
+    /// Sessions pane now shows an unrelated list; carrying over the old scroll
+    /// position would highlight an arbitrary, unrelated row. Resetting to the
+    /// top on an explicit project switch (but NOT on every poll — see
+    /// [`super::poll::project_ctl_poll_daemon`], which preserves the Sessions
+    /// selection across a refresh) matches the operator's expectation.
+    /// What: replaces `sessions_nav` with a fresh default, then syncs its
+    /// length to `current_sessions().len()`.
+    /// Test: `project_switch_resets_session_selection`.
+    pub fn on_project_selection_changed(&mut self) {
+        self.sessions_nav = ListNav::default();
+        self.sessions_nav.sync_len(self.current_sessions().len());
+    }
+
+    /// Cycle focus forward (Projects → Sessions → Activity → …).
+    pub fn cycle_focus_next(&mut self) {
+        self.focus = self.focus.next();
+    }
+
+    /// Cycle focus backward (Activity → Sessions → Projects → …).
+    pub fn cycle_focus_prev(&mut self) {
+        self.focus = self.focus.prev();
+    }
+
+    /// Drill into a project's Sessions pane (Enter on the Projects pane).
+    pub fn drill_into_sessions(&mut self) {
+        self.focus = Pane::Sessions;
+    }
+
+    /// Set the transient action-bar notice.
+    pub fn set_notice(&mut self, msg: impl Into<String>) {
+        self.notice = Some(msg.into());
+    }
+
+    /// Clear the transient action-bar notice (Esc).
+    pub fn clear_notice(&mut self) {
+        self.notice = None;
+    }
+
+    /// Request an immediate daemon re-poll on the next run-loop tick.
+    ///
+    /// Why: after a mutating action (kill/resume/decommission) the operator
+    /// expects the fleet to refresh now, not up to a whole `--interval-ms`
+    /// later. Mirrors `CoordinatorState::request_repoll`.
+    pub fn request_repoll(&mut self) {
+        self.needs_repoll = true;
+    }
+
+    /// Read-and-clear the immediate-re-poll request.
+    pub fn take_repoll(&mut self) -> bool {
+        std::mem::take(&mut self.needs_repoll)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(name: &str) -> ProjectRow {
+        ProjectRow {
+            name: name.to_string(),
+            repo_url: format!("https://github.com/acme/{name}"),
+            live_count: 0,
+            total_count: 0,
+        }
+    }
+
+    fn session(id: &str) -> SessionRow {
+        SessionRow {
+            id: id.to_string(),
+            short_id: id.chars().take(8).collect(),
+            name: format!("session-{id}"),
+            branch: Some("main".to_string()),
+            task: Some("do the thing".to_string()),
+            state: "active".to_string(),
+            pending_decision: None,
+            proposed_default: None,
+        }
+    }
+
+    #[test]
+    fn pane_cycle_wraps_forward_and_backward() {
+        assert_eq!(Pane::Projects.next(), Pane::Sessions);
+        assert_eq!(Pane::Sessions.next(), Pane::Activity);
+        assert_eq!(Pane::Activity.next(), Pane::Projects);
+        assert_eq!(Pane::Projects.prev(), Pane::Activity);
+        assert_eq!(Pane::Activity.prev(), Pane::Sessions);
+        assert_eq!(Pane::Sessions.prev(), Pane::Projects);
+    }
+
+    #[test]
+    fn selected_project_reads_nav_index() {
+        let mut state = ProjectCtlState {
+            projects: vec![row("a"), row("b")],
+            ..Default::default()
+        };
+        state.projects_nav.sync_len(state.projects.len());
+        assert_eq!(state.selected_project().unwrap().name, "a");
+        state.projects_nav.down();
+        assert_eq!(state.selected_project().unwrap().name, "b");
+    }
+
+    #[test]
+    fn current_sessions_follows_selected_project() {
+        let mut state = ProjectCtlState {
+            projects: vec![row("a"), row("b")],
+            ..Default::default()
+        };
+        state
+            .sessions_by_project
+            .insert("a".to_string(), vec![session("aaaaaaaa1111")]);
+        state.sessions_by_project.insert("b".to_string(), vec![]);
+        state.projects_nav.sync_len(state.projects.len());
+        assert_eq!(state.current_sessions().len(), 1);
+        state.projects_nav.down();
+        assert!(state.current_sessions().is_empty());
+    }
+
+    #[test]
+    fn project_switch_resets_session_selection() {
+        let mut state = ProjectCtlState {
+            projects: vec![row("a"), row("b")],
+            ..Default::default()
+        };
+        state.sessions_by_project.insert(
+            "a".to_string(),
+            vec![session("id1111111111"), session("id2222222222")],
+        );
+        state.projects_nav.sync_len(state.projects.len());
+        state.sessions_nav.sync_len(state.current_sessions().len());
+        state.sessions_nav.down();
+        assert_eq!(state.sessions_nav.selected(), 1);
+        state.on_project_selection_changed();
+        assert_eq!(state.sessions_nav.selected(), 0);
+    }
+
+    #[test]
+    fn notice_set_and_clear() {
+        let mut state = ProjectCtlState::default();
+        assert!(state.notice.is_none());
+        state.set_notice("hello");
+        assert_eq!(state.notice.as_deref(), Some("hello"));
+        state.clear_notice();
+        assert!(state.notice.is_none());
+    }
+
+    #[test]
+    fn repoll_request_is_take_once() {
+        let mut state = ProjectCtlState::default();
+        assert!(!state.take_repoll());
+        state.request_repoll();
+        assert!(state.take_repoll());
+        assert!(!state.take_repoll());
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -49,6 +49,7 @@ fn summary(id: &str, state: &str) -> ManagedSessionSummary {
         task: Some("ship it".to_string()),
         cwd: None,
         claude_session_id: None,
+        pane_id: None,
     }
 }
 
@@ -109,18 +110,29 @@ fn seeded_state_renders_live_project_and_its_session() {
 }
 
 #[test]
-fn drilling_in_then_killing_targets_the_right_session() {
+fn drilling_in_then_killing_an_active_session_requires_confirmation() {
+    // The seeded session is "active", so DOC-35 §5.2's confirm gate applies:
+    // `k` alone must not fire — it takes drill-in, `k`, THEN `y` to reach the
+    // real PendingAction.
     let mut state = seeded_state();
     let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
     assert!(handle_key(&mut state, enter).is_none());
     assert_eq!(state.focus, Pane::Sessions);
 
     let kill = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE);
-    let action = handle_key(&mut state, kill);
+    assert!(
+        handle_key(&mut state, kill).is_none(),
+        "kill on an Active session must open the confirm gate, not fire"
+    );
+    assert!(state.pending_confirm.is_some());
+
+    let confirm = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
+    let action = handle_key(&mut state, confirm);
     assert_eq!(
         action,
         Some(PendingAction::Kill("a1b2c3d4e5f6".to_string()))
     );
+    assert!(state.pending_confirm.is_none());
 }
 
 #[test]

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -1,0 +1,142 @@
+//! Cross-module integration tests for the `tm projects` TUI skeleton (#2118).
+//!
+//! Why: each submodule (`state`, `poll`, `events`, `panes::*`) unit-tests its
+//! own pure logic in isolation; this file instead wires them together the way
+//! the real run loop does — poll projections feeding state, then key events
+//! reading that state — catching seams the per-module tests cannot (mirrors
+//! `tui::coordinator::tests` / `tui::health::tests`).
+//! What: covers the full poll → state → key-dispatch → pane-render pipeline
+//! with synthetic daemon data (no network, no terminal).
+//! Test: this IS the test module.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::events::{PendingAction, handle_key};
+use super::panes::{actions_bar, projects, sessions};
+use super::poll::{project_to_row, session_to_row};
+use super::state::{Pane, ProjectCtlState};
+use crate::client::{FleetProjectGroupWire, ManagedSessionSummary};
+use crate::project::Project;
+
+fn project(name: &str) -> Project {
+    Project {
+        name: name.to_string(),
+        repo_url: format!("https://github.com/acme/{name}"),
+        default_branch: "main".to_string(),
+        stack_hint: None,
+        tags: vec![],
+        description: None,
+        gh_user: None,
+        github: None,
+        commit_name: None,
+        commit_email: None,
+    }
+}
+
+fn summary(id: &str, state: &str) -> ManagedSessionSummary {
+    ManagedSessionSummary {
+        id: id.to_string(),
+        name: format!("s-{id}"),
+        state: state.to_string(),
+        workspace_path: None,
+        repo_url: None,
+        branch: Some("main".to_string()),
+        created_at: None,
+        last_activity_at: None,
+        pending_decision: None,
+        proposed_default: None,
+        source_id: None,
+        task: Some("ship it".to_string()),
+        cwd: None,
+        claude_session_id: None,
+    }
+}
+
+/// Build a state that mirrors what `project_ctl_poll_daemon` would produce
+/// from two projects, one of which has a live session — without a network
+/// call.
+fn seeded_state() -> ProjectCtlState {
+    let trusty_tools = project("trusty-tools");
+    let genealogy = project("genealogy");
+    let group = FleetProjectGroupWire {
+        project_name: "trusty-tools".to_string(),
+        repo_url: trusty_tools.repo_url.clone(),
+        sessions: vec![summary("a1b2c3d4e5f6", "active")],
+    };
+
+    let mut state = ProjectCtlState {
+        projects: vec![
+            project_to_row(&trusty_tools, Some(&group)),
+            project_to_row(&genealogy, None),
+        ],
+        ..Default::default()
+    };
+    state.sessions_by_project.insert(
+        "trusty-tools".to_string(),
+        group.sessions.into_iter().map(session_to_row).collect(),
+    );
+    state.projects_nav.sync_len(state.projects.len());
+    state.sessions_nav.sync_len(state.current_sessions().len());
+    state
+}
+
+#[test]
+fn seeded_state_renders_live_project_and_its_session() {
+    let state = seeded_state();
+    assert_eq!(state.projects.len(), 2);
+    assert_eq!(state.selected_project().unwrap().name, "trusty-tools");
+    assert_eq!(state.current_sessions().len(), 1);
+
+    let projects_line = projects::project_line(&state.projects[0]);
+    let text: String = projects_line
+        .spans
+        .iter()
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert!(
+        text.starts_with("●1"),
+        "expected a live glyph+count: {text}"
+    );
+
+    let session_line = sessions::session_line(1, &state.current_sessions()[0]);
+    let text: String = session_line
+        .spans
+        .iter()
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert!(text.contains("a1b2c3d4"), "missing short id: {text}");
+    assert!(text.contains("ship it"), "missing task: {text}");
+}
+
+#[test]
+fn drilling_in_then_killing_targets_the_right_session() {
+    let mut state = seeded_state();
+    let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+    assert!(handle_key(&mut state, enter).is_none());
+    assert_eq!(state.focus, Pane::Sessions);
+
+    let kill = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE);
+    let action = handle_key(&mut state, kill);
+    assert_eq!(
+        action,
+        Some(PendingAction::Kill("a1b2c3d4e5f6".to_string()))
+    );
+}
+
+#[test]
+fn switching_to_the_empty_project_clears_the_sessions_pane() {
+    let mut state = seeded_state();
+    let down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
+    handle_key(&mut state, down);
+    assert_eq!(state.selected_project().unwrap().name, "genealogy");
+    assert!(state.current_sessions().is_empty());
+    assert!(state.selected_session().is_none());
+}
+
+#[test]
+fn action_bar_reflects_daemon_reachability_by_default() {
+    let state = seeded_state();
+    // Freshly seeded state (no poll ran) starts unreachable, matching the
+    // real poller's default until the first health probe succeeds.
+    assert!(actions_bar::bar_text(&state).contains(actions_bar::DAEMON_UNREACHABLE));
+}


### PR DESCRIPTION
## Summary

Implements #2118 — the full 4-pane `tm projects` TUI skeleton (Projects | Sessions | Activity | Actions), landing as v1 per the issue owner's resolution (no 2-pane MVP).

`tm projects` with **no further arguments** and both stdin AND stdout attached to a real terminal now launches the TUI. Every existing `tm projects <verb>` (`list`/`register`/`show`/`status`/`deliverables`/`milestones`, shipped by #2428) is completely unchanged, and a **non-interactive** bare `tm projects` still fails with clap's own pre-#2118 "requires a subcommand" error — verified byte-for-byte identical to the pre-change output (see Verification below).

This PR has gone through two rounds of adversarial review. Both rounds' findings are fixed below; nothing is silently absorbed — every deviation from the cited spec sections is disclosed explicitly in "Intentional, disclosed deviations" at the end of this description.

## Round 2 fixes (CRITICAL/HIGH/MEDIUM)

### Finding 1 (CRITICAL) + Finding 2 (HIGH) — confirmation gate for `d`/`k`

DOC-35 §5.2 requires: `d` (decommission) — confirmation gate, unconditionally, because it is terminal (the workspace is deleted); `k` (kill) — confirmation gate specifically when the target session is `Active` (mirrors DOC-16 §5.6's active-session confirmation).

Fixed by adding a shared confirmation mechanism (`state::ConfirmKind` / `state::PendingConfirm` / `ProjectCtlState::pending_confirm`) that BOTH verbs route through instead of firing directly:

- `d` always opens the gate, regardless of the session's current state.
- `k` opens the gate only when the selected session's `state == "active"`; a non-Active session (provisioning/stopped/errored/decommissioned) has no live runtime to interrupt, so it fires immediately — matching the spec's narrower "if Active" wording rather than gating every kill unconditionally like decommission.
- While the gate is open, `y`/`Y`/Enter confirms (dispatches the real action and clears the gate), `n`/`N`/Esc cancels (clears the gate, sets a "cancelled" notice), and every OTHER key — including `q`/`Ctrl-C` — is swallowed and the gate stays open, per the spec's "`q`/`Ctrl-C` — not in a modal" / "`Esc` — any modal/form — cancel" rules.
- The prompt is rendered in the action bar (pane 4), taking priority over both the notice and the per-focus hint (see Finding 3): `⚠ kill '<name>' — session is Active. Confirm? [y] yes  [n/Esc] cancel` / `⚠ decommission '<name>' — PERMANENT, deletes the workspace. Confirm? [y] yes  [n/Esc] cancel`.

### Finding 3 (MEDIUM) — contextual key-hint bar

DOC-35 §5.1 ("contextual verbs bound to the focused pane") and issue #2118 both require the hint line to change with `state.focus`. Fixed: `panes::actions_bar::focus_hint(Pane) -> &'static str` now returns a distinct hint per pane —

- Projects: `[Enter] drill in  [c] config  [Tab] switch pane  [↑↓] select  [q] quit`
- Sessions: `[l] launch  [k] kill  [r] resume  [d] decommission  [a] attach-cmd  [Tab] switch pane  [↑↓] select  [q] quit`
- Activity: `[Tab] switch pane  [q] quit` (read-only strip, no verbs bound there)

`bar_text`'s priority order is now: open confirm gate > transient notice > focus-contextual hint > (daemon indicator always visible on the right). Unit tests (`focus_hint_differs_per_pane`, `bar_text_shows_focus_hint_by_default`, etc.) assert the hint content differs per focus value.

## Round 1 fix (HIGH) — stdin+stdout TTY gate

The original TTY-interception gate checked stdout only. A supervisor/wrapper that redirects stdin from `/dev/null` while leaving stdout attached to a pty (systemd, launchd, some CI runners) would launch a raw-mode, full-screen TUI with a dead stdin — no keyboard path could ever send `q`/Ctrl-C, only an external signal could kill it.

Fixed: `commands::projects::should_launch_bare_tui(argv, stdin_tty, stdout_tty)` now requires **both** streams, mirroring the codebase's existing `session_picker::should_show_picker` "require both streams" convention. Verified with a real pty (Python's `pty.openpty()`, stdin explicitly `/dev/null`, stdout a real tty): the process now exits 2 (clap's parse error) instead of hanging in raw mode; the legitimate both-streams-tty case still launches the TUI as expected.

### Module map (all under `crates/trusty-mpm/src/tui/project_ctl/`)

| File | Responsibility |
|---|---|
| `mod.rs` | Facade: `run()` entry point, panic-safe `TerminalGuard`, the draw→poll-key→dispatch→repoll event loop (mirrors `tui::coordinator`) |
| `state.rs` | `ProjectCtlState`, `ProjectRow`, `SessionRow`, `Pane` focus enum, `ConfirmKind`/`PendingConfirm` (the shared confirmation-gate mechanism), selection/notice/confirm/repoll mutators |
| `poll.rs` | One daemon poll per tick: health + self-healing URL rediscovery, `registry_list_projects` + `fleet_managed_sessions` merge into `ProjectRow`/`SessionRow` |
| `events.rs` | Pure key→`PendingAction` routing (no IO), including the confirm-gate resolution; `PendingAction` enum |
| `actions.rs` | Async dispatch of `PendingAction` → `DaemonClient` calls (kill/resume/decommission/attach; launch/config stubs) |
| `layout.rs` | Frame composition: Projects(25%)\|Sessions(75%) main row, Activity strip, action bar |
| `panes/projects.rs` | Left pane: aggregate glyph + live count per project |
| `panes/sessions.rs` | Right pane: numbered, state-glyphed session rows |
| `panes/activity.rs` | Bottom strip: focused session's **static** record fields only (skeleton) |
| `panes/actions_bar.rs` | Per-focus key-hint bar, confirm prompt, transient notice, daemon indicator |
| `panes/mod.rs` | Re-export facade |
| `tests.rs` | Cross-module integration tests (poll→state→dispatch→render) |

Plus small, surgical edits outside the module:
- `crates/trusty-mpm/src/tui/mod.rs` — `pub mod project_ctl;`
- `crates/trusty-mpm/src/bin/tm/main.rs` — intercepts bare `tm projects` + stdin+stdout TTY **before** `Cli::try_parse()` (see Design decisions)
- `crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs` — adds `is_bare_projects_argv` + `should_launch_bare_tui` (both pure, unit-tested) + `launch_bare_tui`; `projects()`/`ProjectsAction` dispatch untouched
- `crates/trusty-mpm/src/bin/tm/tests_projects.rs` — replaces the (now redundant) informal assumption with an explicit `cli_rejects_bare_projects_with_missing_subcommand` regression test

### Pane map

| Pane | Shows | Source |
|---|---|---|
| Projects (left, 25%) | One row per registered project, aggregate glyph (`●`/`○`) + live session count | `GET /api/v1/projects` (`registry_list_projects`) merged with the fleet counts below |
| Sessions (right, 75%) | Selected project's sessions, numbered (DOC-16 §3.2), state glyph (`●`/`◍`/`○`/`✗`/`⊘`), branch, task/state detail | `GET /api/v1/sessions/managed/fleet` (`fleet_managed_sessions`), filtered client-side by project — one call covers every project per tick |
| Activity (bottom, 4 rows) | Focused session's **static** record fields: `state`, `task`, `pending_decision`, `proposed_default` | Same fleet-poll `ManagedSessionSummary` — **no** call to `GET .../{id}/activity` (that's #2119) |
| Actions (1 row) | Focus-contextual key hints, OR an open confirm gate, OR the most recent action's outcome as a transient notice (in that priority order), plus a live daemon-reachability indicator | Local state only |

### Keybinding table (as implemented)

| Key | Context | Action |
|---|---|---|
| ↑ / ↓ | any pane | move selection in the focused pane |
| Tab / Shift+Tab | — | cycle focus: Projects → Sessions → Activity → … |
| Enter | Projects pane | drill into that project's Sessions pane |
| `l` | Sessions pane | **stub** — notice pointing at `tm sessions new` (see Design decisions) |
| `k` | Sessions pane, row selected | kill (`runtime-stop`) — **confirmation gate if the session is Active**, immediate otherwise |
| `r` | Sessions pane, row selected | resume (not destructive — immediate) |
| `d` | Sessions pane, row selected | decommission — **confirmation gate, unconditionally** |
| `a` | Sessions pane, row selected | fetch + display attach-cmd (not destructive — immediate) |
| `c` | Projects pane, row selected | **stub** — no-op notice (#2120 is the real form) |
| `y`/`Y`/Enter | confirm gate open | confirm the pending destructive action |
| `n`/`N`/Esc | confirm gate open | cancel the pending action |
| `q` / Ctrl-C | not in a modal | quit, restore terminal |
| Esc | any modal, or to dismiss a notice | cancel / dismiss |

## Design decisions

1. **Bare-invocation interception happens in `main.rs`, before `Cli::try_parse()`** — not by relaxing `ProjectsAction` to `Option` and branching inside the dispatcher. I tried the `Option` approach first; reproducing clap's own "requires a subcommand" error manually via `Command::error()` was NOT byte-identical to the original (it drops the `[subcommands: …]` hint clap derives from its internal match context, and the `Usage:` line loses the `tm` prefix / `[OPTIONS] <COMMAND>` shape). Intercepting `argv == ["…", "projects"]` + BOTH `stdin.is_terminal()` AND `stdout.is_terminal()` ahead of parsing instead means the non-interactive path is **the literal unmodified original code** — verified identical byte-for-byte (see Verification). `is_bare_projects_argv` and the combined gate `should_launch_bare_tui` are pure and unit-tested; the two `is_terminal()` calls themselves are one-line, untestable `std::io` calls left in `main.rs`.
2. **`l` (launch) is a stub, not wired to a real spawn**: `ManagedSpawnRequest` requires `task` and `git_ref` fields a 4-pane skeleton has no text-entry surface to collect. Rather than silently no-op, `l` shows a notice pointing at the existing `tm sessions new` CLI verb. A real launch form is a natural fast-follow alongside #2120's config form.
3. **Sessions data sourced via ONE `fleet_managed_sessions()` call per poll tick** (not per-project), merged client-side against `registry_list_projects()` — avoids an N+1 HTTP pattern as the project count grows.
4. Reused `tui::coordinator::nav::ListNav` for both the Projects and Sessions list navigation/scroll state (avoids re-implementing a well-tested selection+scroll model), and `tui::coordinator::rows::session_short_id` for the 8-hex id derivation.

## Intentional, disclosed spec deviations

Per the reviewer's binding process note: any deviation from a cited DOC-35 spec section must be explicitly disclosed here going forward. All known deviations, in one place:

1. **`j`/`k` vim-motion aliases dropped in favor of arrow-only motion.** DOC-35 §5.2's keybinding table lists `j`/`k` as ↑/↓ motion aliases AND separately binds bare `k` to "kill" in the Sessions pane — a direct conflict (`k` cannot mean both "move up" and "kill" without a mode switch). The spec's own ASCII mockup (§5.1) resolves this in practice: its key-hint bar lists only `↑↓` for selection and reserves every bare letter for an action. This implementation follows the mockup. `j` (down) had no actual collision and could have stayed bound to "down" — left out anyway so the screen has exactly one consistent motion scheme rather than a mixed one. Non-blocking (confirmed by reviewer both rounds); documented in `events.rs`'s module doc.
2. **`TerminalGuard` may not run if `EnterAlternateScreen` itself errors.** In `tui/project_ctl/mod.rs::run`, if `execute!(stdout, EnterAlternateScreen)?` returns `Err`, the function returns before the `TerminalGuard` is constructed, leaving the terminal in raw mode with no restore. This mirrors a **pre-existing** pattern in `tui::coordinator::mod.rs` (not a regression introduced by this PR) — left as a shared cross-screen fast-follow rather than a one-off fix scoped to only the new module. Non-blocking (confirmed by reviewer).

## Verification performed

**1. `cargo build -p trusty-mpm`** — clean.

**2. `cargo test -p trusty-mpm`** — all green:
```
trusty-mpm (lib):      test result: ok. 2820 passed; 0 failed; 5 ignored
trusty-mpm (bin "tm"):  test result: ok. 840 passed; 0 failed; 1 ignored
```
(counts include tests gained from rebasing onto latest `origin/main`, plus this PR's own new tests: TTY gate combinator, confirm-gate request/confirm/cancel/ignore/quit-blocked branches, per-focus hint-bar tests.)

**3. `cargo clippy -p trusty-mpm --all-targets -- -D warnings`** — clean, zero `error:` lines.

**4. `cargo fmt --check`** — exit code 0.

**5. `bash scripts/check_line_cap.sh`** — `line-cap: 0 allowlisted, 0 violations — OK.`

**6. Non-TTY byte-for-byte regression check** (re-verified after rebase):
```
$ ./target/debug/tm projects < /dev/null
exit 2
error: 'tm projects' requires a subcommand but one was not provided
  [subcommands: list, register, show, status, deliverables, milestones, help]

Usage: tm projects [OPTIONS] <COMMAND>

For more information, try '--help'.
```
`diff` against the pre-#2118 baseline output reports no differences.

**7. stdin=`/dev/null`, stdout=pty (the Round-1 footgun)** — via Python's `pty.openpty()`:
```
exit code: 2   (good — did not hang)
```

**8. Both streams live** — TUI launches and stays running (confirmed via `pty.openpty()` with both stdin/stdout on the same pty, and separately via `script`-wrapped alternate-screen escape sequences).

**9. Rebase**: branch is rebased onto `origin/main` inclusive of `16d4365d` (`fix(trusty-mpm): reconcile stale-Active session before refusing in-place relaunch (#2456)`); `git merge-base --is-ancestor origin/main HEAD` confirms. One mechanical fixup was needed (a `pane_id: Option<String>` field added to `ManagedSessionSummary` upstream after this branch was created — added to this module's two test-only struct literals; no production logic touched by the rebase).

## Deferred to follow-up (explicitly NOT in this PR's scope)

- **#2119** — live Activity-pane wiring (`GET .../{id}/activity` polling for `pending_decision`/live classification). This PR's Activity pane renders only the already-polled session record's static fields.
- **#2120** — the real `c` config form. This PR's `c` is a no-op notice stub.
- A real `l` (launch) text-entry form — noted as a fast-follow in Design decisions above.
- The two disclosed deviations above (shared `TerminalGuard`-construction-order edge case across both TUI screens; `j`-only vim alias) — non-blocking, explicitly deferred.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
