### PR TITLE
fix(trusty-mpm): target stored pane_id on resume/restart respawn

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -131,21 +131,21 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
                 }
                 super::guided_inplace::InPlaceOutcome::FallThrough => {
                     eprintln!(
-                        "tm: in-place relaunch unavailable for '{}' (state={}) — \
-                         this tmux session is already a managed session; \
-                         refusing to launch a nested session here.",
-                        record.name, record.state
+                        "tm: in-place relaunch unavailable for '{}' (state={}) — {}",
+                        record.name,
+                        record.state,
+                        nested_guard_notice(&record.name)
                     );
                 }
             }
         } else {
             eprintln!(
-                "tm: this tmux session ('{}') is already a managed session (state={}) — \
-                 refusing to launch a nested session here.",
-                record.name, record.state
+                "tm: this tmux session ('{}') is already a managed session (state={}) — {}",
+                record.name,
+                record.state,
+                nested_guard_notice(&record.name)
             );
         }
-        eprintln!("tm: reconnecting to '{}' instead…", record.name);
         return super::guided_resume::resume_guided_session(client, url, &record).await;
     }
 
@@ -395,6 +395,29 @@ pub(crate) fn pane_identity_confirmed(
         (Some(cur), Some(rec)) => cur == rec,
         _ => false,
     }
+}
+
+/// Build the operator-facing notice for the nested-session guard's fallback
+/// path — reused by both call sites that print it before falling through to
+/// [`super::guided_resume::resume_guided_session`].
+///
+/// Why: the two call sites previously printed "…refusing to launch a nested
+/// session here." as a standalone line, immediately followed by a SEPARATE
+/// "reconnecting to '{name}' instead…" line. When the subsequent reconcile
+/// (or plain restart) succeeds, that reads as a contradiction: the operator
+/// sees "refusing" — which sounds like a hard failure — immediately followed
+/// by a session that comes up fine anyway. Nothing was actually refused: `tm`
+/// deliberately chose the reconnect path over nesting a new session, and that
+/// choice went on to work. Folding both lines into one, reworded message
+/// removes the false "this failed" signal without hiding WHY a fresh session
+/// was not launched here.
+/// What: returns the single-sentence notice — "not nesting a new session
+/// here; reconnecting to '{name}' instead…" — that replaces both the old
+/// "refusing…" line and the old separate "reconnecting…" line.
+/// Test: `nested_guard_notice_never_says_refusing`,
+/// `nested_guard_notice_mentions_reconnect_target`.
+pub(crate) fn nested_guard_notice(name: &str) -> String {
+    format!("not nesting a new session here; reconnecting to '{name}' instead…")
 }
 
 /// Fetch EVERY managed session, unfiltered — `GET /api/v1/sessions/managed`

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -26,9 +26,9 @@ use crate::commands::first_run::needs_first_run_clone;
 /// racing `needs_first_run_clone_returns_some_when_no_clone`.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 use crate::commands::guided::{
-    derive_project, fallback_protected, github_host, is_github_remote, nested_managed_match,
-    non_github_refusal_message, pane_identity_confirmed, print_non_tty_hint, print_project_context,
-    tty_gate,
+    derive_project, fallback_protected, github_host, is_github_remote, nested_guard_notice,
+    nested_managed_match, non_github_refusal_message, pane_identity_confirmed, print_non_tty_hint,
+    print_project_context, tty_gate,
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{ResumeAction, is_zombie, needs_restart, plan_resume};
@@ -1432,4 +1432,36 @@ fn pane_identity_confirmed_false_when_inherited_env_but_different_pane_id() {
         sibling_window_current_pane_id,
         healed_record_pane_id
     ));
+}
+
+// ── nested_guard_notice (sibling-window hijack fix, follow-up to #2456) ─────
+
+#[test]
+fn nested_guard_notice_never_says_refusing() {
+    // Regression guard: the old wording ("…refusing to launch a nested
+    // session here.") read as a hard failure even when the immediately
+    // following reconcile-relaunch succeeded. The reworded notice must never
+    // contain that alarming phrasing.
+    let msg = nested_guard_notice("my-session");
+    assert!(
+        !msg.to_lowercase().contains("refus"),
+        "nested_guard_notice must not read as a refusal: {msg:?}"
+    );
+}
+
+#[test]
+fn nested_guard_notice_mentions_reconnect_target() {
+    // The notice replaces two previously-separate lines (the refusal line and
+    // a standalone "reconnecting to '{name}' instead…" line) with one — the
+    // session name must still be present so the operator knows where they are
+    // being reconnected.
+    let msg = nested_guard_notice("my-session");
+    assert!(
+        msg.contains("my-session"),
+        "nested_guard_notice must name the session being reconnected to: {msg:?}"
+    );
+    assert!(
+        msg.contains("reconnecting"),
+        "nested_guard_notice must still communicate the reconnect action: {msg:?}"
+    );
 }

--- a/crates/trusty-mpm/src/core/tmux.rs
+++ b/crates/trusty-mpm/src/core/tmux.rs
@@ -59,9 +59,9 @@ use serde::{Deserialize, Serialize};
 /// Addresses a tmux session, optionally a specific pane within it.
 ///
 /// Why: every tmux I/O command needs a `-t` target; modelling it once avoids
-/// re-deriving the `session:pane` string at each call site.
+/// re-deriving the target string at each call site.
 /// What: a session name plus an optional pane id (`%0`, `%1`, ...).
-/// Test: `target_renders_session_and_pane`.
+/// Test: `target_renders_session_and_bare_pane`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TmuxTarget {
     /// tmux session name (the daemon names these `trusty-mpm-<session-id>`).
@@ -88,10 +88,25 @@ impl TmuxTarget {
         }
     }
 
-    /// Render the tmux `-t` target string (`session` or `session:pane`).
+    /// Render the tmux `-t` target string.
+    ///
+    /// Why (CRITICAL fix, follow-up to #2467): tmux pane ids (`%NNNN`) are
+    /// GLOBALLY unique across the whole server, not scoped to a session — but
+    /// `-t "<session>:<pane_id>"` still parses everything after the `:` as a
+    /// WINDOW spec, not a pane spec. Live tmux 3.6b proof: `send-keys -t
+    /// "sess:%6028" ...` fails with `can't find window: %6028`, while `-t
+    /// "%6028"` (bare) works. Every resume/restart with a stored `pane_id`
+    /// hit this — `spawn_resume` returned `Err` and the record flipped to
+    /// `Errored`. The session-qualified form was never valid tmux syntax for
+    /// a pane target.
+    /// What: a pane target renders as the BARE pane id (`%NNNN`) with no
+    /// session qualifier; a session-only target still renders the session
+    /// name.
+    /// Test: `target_renders_session_and_bare_pane`;
+    /// `send_keys_pane_target_is_bare_id`.
     pub fn as_target(&self) -> String {
         match &self.pane {
-            Some(p) => format!("{}:{}", self.session, p),
+            Some(p) => p.clone(),
             None => self.session.clone(),
         }
     }
@@ -133,7 +148,18 @@ pub enum TmuxCommand {
         /// Session whose windows to list.
         name: String,
     },
-    /// `list-panes -t <name> -F <fmt>` — enumerate a session's panes.
+    /// `list-panes -s -t <name> -F <fmt>` — enumerate ALL of a session's
+    /// panes, across every window (`-s`).
+    ///
+    /// Why (CRITICAL follow-up, discovered by the live-tmux test written for
+    /// #2467's fix): without `-s`, tmux resolves a session-name target to
+    /// only the session's currently ACTIVE window and lists that window's
+    /// panes — exactly the sibling-window-hijack scenario this feature
+    /// exists to guard against. A pane in a non-active window (e.g. the
+    /// original pane, once a sibling window steals focus) would silently
+    /// vanish from this list even though it is still alive, making
+    /// `pane_exists` wrongly report `false` and `resume` wrongly refuse with
+    /// `PaneGone`.
     ListPanes {
         /// Session whose panes to list.
         name: String,
@@ -492,6 +518,9 @@ pub fn tmux_argv(cmd: &TmuxCommand) -> Vec<String> {
         TmuxCommand::ListPanes { name } => {
             vec![
                 "list-panes".into(),
+                // `-s`: list every pane in the SESSION (all windows), not just
+                // the currently active window's panes. See the variant doc.
+                "-s".into(),
                 "-t".into(),
                 name.clone(),
                 "-F".into(),
@@ -556,9 +585,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn target_renders_session_and_pane() {
+    fn target_renders_session_and_bare_pane() {
+        // Session-only targets still render the session name.
         assert_eq!(TmuxTarget::session("s").as_target(), "s");
-        assert_eq!(TmuxTarget::pane("s", "%2").as_target(), "s:%2");
+        // Pane targets render the BARE pane id — no `session:` prefix.
+        // tmux pane ids are globally unique; `-t "session:%2"` parses `%2` as
+        // a WINDOW spec and fails with "can't find window: %2" (live tmux
+        // 3.6b), while `-t "%2"` correctly resolves the pane regardless of
+        // which window/session currently owns the terminal focus.
+        assert_eq!(TmuxTarget::pane("s", "%2").as_target(), "%2");
     }
 
     #[test]
@@ -609,7 +644,27 @@ mod tests {
             keys: "Enter".into(),
             literal: false,
         });
-        assert_eq!(argv, ["send-keys", "-t", "s:%1", "Enter"]);
+        assert_eq!(argv, ["send-keys", "-t", "%1", "Enter"]);
+    }
+
+    /// CRITICAL regression guard (follow-up to #2467): asserts the literal
+    /// `-t` string built for a pane target is the bare `%NNNN` form with no
+    /// `session:` prefix, so a regression back to the session-qualified form
+    /// (which tmux parses as an invalid WINDOW spec, not a pane spec) fails
+    /// fast in CI without needing a live tmux binary.
+    #[test]
+    fn send_keys_pane_target_is_bare_id() {
+        let argv = tmux_argv(&TmuxCommand::SendKeys {
+            target: TmuxTarget::pane("trusty-mpm-xyz", "%6015"),
+            keys: "claude --resume".into(),
+            literal: true,
+        });
+        let target_arg = &argv[argv.iter().position(|a| a == "-t").unwrap() + 1];
+        assert_eq!(target_arg, "%6015", "pane target must be the bare pane id");
+        assert!(
+            !target_arg.contains(':'),
+            "pane target must not be session-qualified: {target_arg}"
+        );
     }
 
     #[test]
@@ -646,10 +701,17 @@ mod tests {
 
     #[test]
     fn list_panes_argv() {
+        // `-s` is required so the listing spans every window in the session,
+        // not just the currently active one — without it, a pane in a
+        // non-active window (e.g. the original pane once a sibling window
+        // steals focus) silently drops out of the list.
         let argv = tmux_argv(&TmuxCommand::ListPanes {
             name: "work".into(),
         });
-        assert_eq!(argv, ["list-panes", "-t", "work", "-F", PANE_LIST_FORMAT]);
+        assert_eq!(
+            argv,
+            ["list-panes", "-s", "-t", "work", "-F", PANE_LIST_FORMAT]
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -1414,8 +1414,14 @@ pub async fn resume_managed(
     // SessionStart; fall back to --continue (most-recent conversation in the
     // workspace) when the id is absent. ClaudeCodeAdapter overrides spawn_resume
     // to implement this; TcodeAdapter's default delegates to plain spawn.
+    // Sibling-window hijack fix (follow-up to #2456): pass the record's OWN
+    // `record.pane_id` through so the adapter targets that SPECIFIC pane
+    // (`SessionManager::resume`, just above, already confirmed it — or a
+    // freshly recreated one — still exists) instead of a session-scoped
+    // target that tmux could resolve to an unrelated active sibling pane.
     if let Err(e) = adapter.spawn_resume(
         &record.tmux_name,
+        record.pane_id.as_deref(),
         &workspace,
         &record.task,
         record.claude_session_id.as_deref(),

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -675,6 +675,34 @@ impl TmuxDriver {
             .map(String::from)
             .collect())
     }
+
+    /// Return whether `pane_id` still exists as a live pane within
+    /// `session_name`'s tmux session (sibling-window hijack, follow-up to
+    /// #2456).
+    ///
+    /// Why: `session_exists` alone cannot distinguish "the recorded pane
+    /// survived" from "the tmux SESSION merely has some OTHER pane alive"
+    /// (e.g. a sibling window opened after the recorded pane was closed) —
+    /// `SessionManager::resume`'s reuse branch needs the stronger,
+    /// pane-specific answer before it trusts a session-scoped respawn target.
+    /// What: runs `list-panes -t <session_name> -F` (via [`Self::list_panes`],
+    /// format `#{pane_id}:#{pane_active}`) and checks whether `pane_id`
+    /// matches the id portion of any row. Returns `false` on any query
+    /// failure (session gone, tmux unavailable) — the safe direction for a
+    /// presence check feeding a refusal path is to treat "cannot confirm" as
+    /// "not present" (fail toward refusing the unsafe respawn, never toward
+    /// silently trusting a pane that might not be there).
+    /// Test: argv shape covered by `core::tmux::list_panes_argv`; behavior is
+    /// exercised by the `#[ignore]` live integration test and by
+    /// `RealTmuxDriver::pane_exists`'s call-through.
+    pub fn pane_exists(&self, session_name: &str, pane_id: &str) -> bool {
+        match self.list_panes(session_name) {
+            Ok(rows) => rows
+                .iter()
+                .any(|row| row.split(':').next() == Some(pane_id)),
+            Err(_) => false,
+        }
+    }
 }
 
 /// A non-destructive registration of an external tmux session.

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -660,10 +660,17 @@ impl TmuxDriver {
             .collect())
     }
 
-    /// List the pane `id:active` rows for a session.
+    /// List the pane `id:active` rows for a session, across ALL of its
+    /// windows.
     ///
-    /// Why: snapshot and adoption both need a session's pane list.
-    /// What: runs `list-panes -F` and returns each row verbatim.
+    /// Why: snapshot and adoption both need a session's FULL pane list, not
+    /// just the currently active window's — a plain `list-panes -t <session>`
+    /// (no `-s`) resolves the session target down to its active window only,
+    /// which silently drops any pane living in a non-active window (exactly
+    /// the sibling-window-hijack shape this feature guards against). This bug
+    /// was caught by the live-tmux test written for the #2467 follow-up, not
+    /// by the mock-only unit tests.
+    /// What: runs `list-panes -s -t <name> -F` and returns each row verbatim.
     /// Test: argv shape covered by `core::tmux::list_panes_argv`.
     fn list_panes(&self, name: &str) -> Result<Vec<String>> {
         let raw = self.run(&TmuxCommand::ListPanes {
@@ -692,9 +699,13 @@ impl TmuxDriver {
     /// presence check feeding a refusal path is to treat "cannot confirm" as
     /// "not present" (fail toward refusing the unsafe respawn, never toward
     /// silently trusting a pane that might not be there).
-    /// Test: argv shape covered by `core::tmux::list_panes_argv`; behavior is
-    /// exercised by the `#[ignore]` live integration test and by
-    /// `RealTmuxDriver::pane_exists`'s call-through.
+    /// Test: argv shape covered by `core::tmux::list_panes_argv`; behavior
+    /// (true for a real pane, false for a fabricated pane id in a live,
+    /// still-alive session) is exercised by the `#[ignore]` live integration
+    /// test `live_pane_scoped_send_targets_original_pane_not_sibling` in
+    /// `tests/session_manager_mvp.rs` — that test also covers
+    /// `RealTmuxDriver::pane_exists`'s call-through and
+    /// `send_line`/`send_line_to_pane`'s pane-scoped `-t` targeting.
     pub fn pane_exists(&self, session_name: &str, pane_id: &str) -> bool {
         match self.list_panes(session_name) {
             Ok(rows) => rows

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -876,14 +876,23 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
     /// resolves an optional `CLAUDE_CODE_OAUTH_TOKEN` via
     /// [`crate::core::oauth_token::resolve_oauth_token`] (#2246 — same carrier
     /// `spawn` uses), then sends the appropriate [`resume_command`] to the
-    /// tmux pane.
+    /// tmux pane — targeting the SPECIFIC `pane_id` (via
+    /// [`ManagedTmuxDriver::send_line_to_pane`]) when the caller supplies one,
+    /// rather than the session-scoped [`ManagedTmuxDriver::send_line`], which
+    /// tmux resolves to whichever pane/window is currently active (sibling-
+    /// window hijack fix, follow-up to #2456). `pane_id: None` (a legacy
+    /// record that predates pane-id capture) falls back to the session-scoped
+    /// send, preserving prior behavior for that case.
     /// Test: `spawn_resume_with_id_uses_resume_flag`,
     /// `spawn_resume_without_id_no_prior_conv_sends_plain_spawn`,
     /// `spawn_resume_sends_prompt_file_when_binary_available`,
-    /// `spawn_resume_sends_oauth_token_when_available`.
+    /// `spawn_resume_sends_oauth_token_when_available`,
+    /// `spawn_resume_targets_stored_pane_id_when_known`,
+    /// `spawn_resume_falls_back_to_session_target_when_pane_id_unknown`.
     fn spawn_resume(
         &self,
         tmux_name: &str,
+        pane_id: Option<&str>,
         cwd: &Path,
         task: &str,
         claude_session_id: Option<&str>,
@@ -942,6 +951,7 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
         let prior = effective_id.is_some() || file_history;
         debug!(
             session = %tmux_name,
+            pane_id = pane_id.unwrap_or("<none>"),
             cwd = %cwd.display(),
             task = %task,
             claude = %claude_bin,
@@ -949,21 +959,28 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             has_prior_conv = file_history, // reflects actual .jsonl file check, not the combined value
             "resuming claude-code in tmux pane"
         );
-        self.tmux
-            .send_line(
-                tmux_name,
-                &resume_command(
-                    cwd,
-                    &claude_bin,
-                    config_dir.as_deref(),
-                    effective_id,
-                    prior,
-                    session_id,
-                    prompt_file.as_deref(),
-                    oauth_token.as_deref(),
-                ),
-            )
-            .map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))?;
+        let cmd = resume_command(
+            cwd,
+            &claude_bin,
+            config_dir.as_deref(),
+            effective_id,
+            prior,
+            session_id,
+            prompt_file.as_deref(),
+            oauth_token.as_deref(),
+        );
+        // Sibling-window hijack fix (follow-up to #2456): when the caller
+        // supplies the record's own `pane_id`, target it directly — tmux's
+        // session-scoped `send_line` resolves to whichever pane/window is
+        // currently ACTIVE, which is not necessarily (and after this bug,
+        // often was not) the pane this resume is actually about. `None`
+        // (a legacy record predating pane-id capture) preserves the prior
+        // session-scoped behavior — there is no stronger signal available.
+        let send_result = match pane_id {
+            Some(pane_id) => self.tmux.send_line_to_pane(tmux_name, pane_id, &cmd),
+            None => self.tmux.send_line(tmux_name, &cmd),
+        };
+        send_result.map_err(|e| RuntimeError::TmuxUnavailable(e.to_string()))?;
         // #2157 item 1: durable publish for the RESUME path too — a fresh tmux
         // session is created on resume, so it needs the same belt-and-suspenders
         // set-environment call as spawn().
@@ -1847,6 +1864,7 @@ mod tests {
         adapter
             .spawn_resume(
                 "tmpm-test",
+                None,
                 cwd,
                 "task",
                 Some("my-session-id"),
@@ -1890,6 +1908,7 @@ mod tests {
         adapter
             .spawn_resume(
                 "tmpm-test",
+                None,
                 Path::new("/tmp/does-not-exist-2230"),
                 "task",
                 None,
@@ -1928,6 +1947,7 @@ mod tests {
         let adapter = ClaudeCodeAdapter::new(fake.clone());
         let result = adapter.spawn_resume(
             "tmpm-test",
+            None,
             Path::new("/tmp/does-not-exist-2246"),
             "task",
             None,
@@ -1964,6 +1984,7 @@ mod tests {
         adapter
             .spawn_resume(
                 "tmpm-test",
+                None,
                 Path::new("/tmp/does-not-exist-2013"),
                 "task",
                 Some("stale-session-id"),
@@ -1987,6 +2008,96 @@ mod tests {
             sends[0].1.contains("env -u ANTHROPIC_API_KEY"),
             "fallback command must still scrub the API key: {}",
             sends[0].1
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn spawn_resume_targets_stored_pane_id_when_known() {
+        // Sibling-window hijack fix, follow-up to #2456: when the caller
+        // supplies `record.pane_id`, spawn_resume MUST target that SPECIFIC
+        // pane (via `send_line_to_pane`), never the bare session name (via
+        // `send_line`, which tmux resolves to whichever pane/window happens
+        // to be active — e.g. a sibling window opened after the original
+        // pane). This is the exact regression that let a resume/restart
+        // respawn `claude` into an unrelated active pane while the original
+        // pane sat at a bare shell.
+        let _home = HomeGuard::set();
+        if ClaudeCodeAdapter::resolve_claude().is_none() {
+            return;
+        };
+        let fake = FakeTmux::new();
+        let adapter = ClaudeCodeAdapter::new(fake.clone());
+        adapter
+            .spawn_resume(
+                "tmpm-test",
+                Some("%6015"),
+                Path::new("/tmp/does-not-exist-pane-target"),
+                "task",
+                None,
+                TEST_SESSION_ID,
+            )
+            .expect("spawn_resume with known pane_id");
+
+        let pane_sends = fake.pane_sends.lock().unwrap();
+        assert_eq!(
+            pane_sends.len(),
+            1,
+            "spawn_resume with a known pane_id must call send_line_to_pane exactly once: \
+             {pane_sends:?}"
+        );
+        assert_eq!(
+            pane_sends[0].0, "tmpm-test",
+            "pane-scoped send must target the record's tmux session name"
+        );
+        assert_eq!(
+            pane_sends[0].1, "%6015",
+            "pane-scoped send must target the record's STORED pane_id, not whatever pane \
+             tmux considers active"
+        );
+
+        let sends = fake.sends.lock().unwrap();
+        assert!(
+            sends.is_empty(),
+            "spawn_resume with a known pane_id must NEVER fall back to the session-scoped \
+             send_line (which tmux resolves to the active pane): {sends:?}"
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn spawn_resume_falls_back_to_session_target_when_pane_id_unknown() {
+        // The inverse of the above: a legacy record that predates pane-id
+        // capture (`pane_id: None`) has no stronger signal to target than the
+        // session name — spawn_resume must fall back to the pre-existing
+        // session-scoped `send_line`, not silently drop the command.
+        let _home = HomeGuard::set();
+        if ClaudeCodeAdapter::resolve_claude().is_none() {
+            return;
+        };
+        let fake = FakeTmux::new();
+        let adapter = ClaudeCodeAdapter::new(fake.clone());
+        adapter
+            .spawn_resume(
+                "tmpm-test",
+                None,
+                Path::new("/tmp/does-not-exist-no-pane"),
+                "task",
+                None,
+                TEST_SESSION_ID,
+            )
+            .expect("spawn_resume with no pane_id");
+
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(
+            sends.len(),
+            1,
+            "spawn_resume with no pane_id must fall back to session-scoped send_line: {sends:?}"
+        );
+        let pane_sends = fake.pane_sends.lock().unwrap();
+        assert!(
+            pane_sends.is_empty(),
+            "spawn_resume with no pane_id must never call send_line_to_pane: {pane_sends:?}"
         );
     }
 
@@ -2139,6 +2250,7 @@ mod tests {
         adapter
             .spawn_resume(
                 "test-tmux-session",
+                None,
                 tmp.path(),
                 "task",
                 None,

--- a/crates/trusty-mpm/src/runtime/mod.rs
+++ b/crates/trusty-mpm/src/runtime/mod.rs
@@ -94,21 +94,28 @@ pub trait RuntimeAdapter: Send + Sync {
     /// which is correct for the `tcode` adapter and any other runtime that does
     /// not support conversation continuity.
     /// What: same contract as `spawn` but with an optional `claude_session_id` for
-    /// the `--resume` flag, plus the same `session_id` (managed session UUID,
-    /// #2023 component B) forwarded to [`Self::spawn`] for the
-    /// `TM_MANAGED_SESSION_ID` pane-shell export. Called by `resume_managed`
-    /// instead of `spawn`.
+    /// the `--resume` flag, an optional `pane_id` (the record's stored
+    /// tmux pane identity, sibling-window hijack fix, follow-up to #2456) so
+    /// the resume command lands in the SPECIFIC pane the session is bound to
+    /// rather than whichever pane tmux considers active, plus the same
+    /// `session_id` (managed session UUID, #2023 component B) forwarded to
+    /// [`Self::spawn`] for the `TM_MANAGED_SESSION_ID` pane-shell export.
+    /// Called by `resume_managed` instead of `spawn`.
     /// Test: `spawn_resume_with_id_uses_resume_flag`,
-    /// `spawn_resume_without_id_uses_continue_flag` in `claude_code` tests.
+    /// `spawn_resume_without_id_uses_continue_flag`,
+    /// `spawn_resume_targets_stored_pane_id_when_known`,
+    /// `spawn_resume_falls_back_to_session_target_when_pane_id_unknown` in
+    /// `claude_code` tests.
     fn spawn_resume(
         &self,
         tmux_name: &str,
+        pane_id: Option<&str>,
         cwd: &Path,
         task: &str,
         claude_session_id: Option<&str>,
         session_id: &str,
     ) -> Result<(), RuntimeError> {
-        let _ = claude_session_id;
+        let _ = (pane_id, claude_session_id);
         self.spawn(tmux_name, cwd, task, session_id)
     }
 

--- a/crates/trusty-mpm/src/runtime/test_helpers.rs
+++ b/crates/trusty-mpm/src/runtime/test_helpers.rs
@@ -7,7 +7,10 @@
 //! the #1212 review (#1213); this module is the single source of truth.
 //! What: defines [`FakeTmux`], a `Mutex`-guarded recorder implementing
 //! [`ManagedTmuxDriver`]; every method is a no-op except `send_line`, which
-//! appends `(session_name, text)` so tests can assert exactly what was sent.
+//! appends `(session_name, text)`, and `send_line_to_pane`, which appends
+//! `(session_name, pane_id, text)` (sibling-window hijack fix, follow-up to
+//! #2456), so tests can assert exactly what was sent and whether it was
+//! session-scoped or pane-scoped.
 //! Test: consumed by the `tcode`/`claude_code`/`mod` test blocks; its own
 //! behaviour is verified transitively through those tests (e.g.
 //! `tcode_adapter_spawn_sends_run_task`).
@@ -16,17 +19,26 @@ use std::sync::{Arc, Mutex};
 
 use crate::session_manager::{ManagedError, ManagedTmuxDriver};
 
-/// In-memory [`ManagedTmuxDriver`] that records every `send_line` call.
+/// In-memory [`ManagedTmuxDriver`] that records every `send_line` /
+/// `send_line_to_pane` call.
 ///
 /// Why: adapter tests must assert the exact shell line an adapter sends to the
 /// pane without spawning `tmux`; recording sends in a `Mutex<Vec<…>>` makes that
-/// assertion trivial and deterministic.
-/// What: stores a `Vec<(session_name, text)>` behind a `Mutex`; all driver
-/// methods are inert except `send_line`, which pushes the call. `sends` is
-/// `pub(crate)` so test blocks can lock and inspect it.
-/// Test: exercised by every runtime adapter test that calls `spawn`.
+/// assertion trivial and deterministic. Separating the two logs
+/// (`sends` vs. `pane_sends`) lets a test assert not just WHAT was sent but
+/// whether it targeted the session-scoped "active pane" or a SPECIFIC pane —
+/// the exact distinction the sibling-window hijack fix depends on.
+/// What: stores `Vec<(session_name, text)>` (`sends`) and
+/// `Vec<(session_name, pane_id, text)>` (`pane_sends`) behind separate
+/// `Mutex`es; all driver methods are inert except those two. Both are
+/// `pub(crate)` so test blocks can lock and inspect them.
+/// Test: exercised by every runtime adapter test that calls `spawn`/
+/// `spawn_resume`.
 pub(crate) struct FakeTmux {
     pub(crate) sends: Mutex<Vec<(String, String)>>,
+    /// Records every `send_line_to_pane` call as `(session_name, pane_id,
+    /// text)` (sibling-window hijack fix, follow-up to #2456).
+    pub(crate) pane_sends: Mutex<Vec<(String, String, String)>>,
     /// Records every `set_environment` call as `(session, key, value)` (#2157
     /// item 1) so adapter tests can assert `TM_MANAGED_SESSION_ID` is durably
     /// published at spawn/resume, not just exported into the pane shell line.
@@ -39,11 +51,12 @@ impl FakeTmux {
     /// Why: adapters take `Arc<dyn ManagedTmuxDriver + Send + Sync>`, so the fake
     /// is handed out pre-wrapped; returning `Arc<Self>` (not `Arc<dyn …>`) lets
     /// the caller keep a typed handle for `clone()` + later inspection.
-    /// What: allocates a `FakeTmux` with an empty send log inside an `Arc`.
+    /// What: allocates a `FakeTmux` with empty send logs inside an `Arc`.
     /// Test: called at the top of every runtime adapter test.
     pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self {
             sends: Mutex::new(Vec::new()),
+            pane_sends: Mutex::new(Vec::new()),
             env_sets: Mutex::new(Vec::new()),
         })
     }
@@ -63,6 +76,18 @@ impl ManagedTmuxDriver for FakeTmux {
             .lock()
             .expect("FakeTmux send log mutex poisoned")
             .push((name.to_owned(), text.to_owned()));
+        Ok(())
+    }
+
+    /// Records `(name, pane_id, text)` instead of delegating to `send_line`
+    /// (the trait default) — a test asserting `pane_sends` got the call and
+    /// `sends` stayed empty is exactly what proves the adapter chose the
+    /// pane-scoped path over the session-scoped one.
+    fn send_line_to_pane(&self, name: &str, pane_id: &str, text: &str) -> Result<(), ManagedError> {
+        self.pane_sends
+            .lock()
+            .expect("FakeTmux pane-send log mutex poisoned")
+            .push((name.to_owned(), pane_id.to_owned(), text.to_owned()));
         Ok(())
     }
 

--- a/crates/trusty-mpm/src/session_manager/driver.rs
+++ b/crates/trusty-mpm/src/session_manager/driver.rs
@@ -51,6 +51,60 @@ pub trait ManagedTmuxDriver: Send + Sync {
         ))
     }
 
+    /// Send literal text followed by Enter to a SPECIFIC pane within `name`'s
+    /// tmux session, rather than whichever pane happens to be active.
+    ///
+    /// Why (sibling-window hijack, follow-up to #2456): `send_line` addresses
+    /// the tmux SESSION only. tmux resolves a session-scoped target to
+    /// whichever pane/window is currently ACTIVE — not necessarily the pane
+    /// this call is actually about. `SessionManager::resume`'s reuse branch
+    /// discovered this the hard way: a sibling window opened after the
+    /// original pane, left active, silently received the respawned `claude`
+    /// process while the original pane sat at a bare shell. This method is
+    /// the pane-scoped alternative: it must land in the exact pane addressed
+    /// by `pane_id`, regardless of tmux's notion of "active".
+    /// What: sends `text` + Enter to the pane addressed by `name:pane_id`
+    /// (tmux's `-t <session>:<pane_id>` form). The default falls back to
+    /// [`Self::send_line`] (session-scoped) — correct for any driver that
+    /// predates pane-level addressing or has no pane to target yet (e.g. a
+    /// freshly created session, where the session-scoped target IS the only
+    /// pane). [`super::real_tmux::RealTmuxDriver`] overrides this to build an
+    /// actual pane-scoped `TmuxTarget`.
+    /// Test: `RealTmuxDriver`'s override is exercised by `core::tmux`'s
+    /// pane-target argv coverage (`TmuxTarget::pane`); call-site assertions
+    /// live in `runtime::test_helpers::FakeTmux` (`pane_sends`) and
+    /// `claude_code`'s `spawn_resume_targets_stored_pane_id_when_known` test.
+    fn send_line_to_pane(&self, name: &str, pane_id: &str, text: &str) -> Result<(), ManagedError> {
+        let _ = pane_id;
+        self.send_line(name, text)
+    }
+
+    /// Report whether `pane_id` still exists as a live pane within `name`'s
+    /// tmux session.
+    ///
+    /// Why (sibling-window hijack, follow-up to #2456): `resume`'s reuse
+    /// branch must distinguish "the recorded pane is still there" from "the
+    /// tmux SESSION merely has some OTHER pane alive" (e.g. a sibling window
+    /// opened after the original pane was closed) — `session_exists` alone
+    /// conflates the two, which is exactly how the hijack happens: the
+    /// session look-alive check passes, so the code reuses it, then respawns
+    /// via a session-scoped target that resolves to the sibling.
+    /// What: returns `true` when the pane is confirmed present, `false` when
+    /// confirmed absent. The default is `true` — "cannot verify" is treated
+    /// as "assume present," so a driver that does not implement pane-level
+    /// listing keeps today's session-scoped reuse behavior; this is a
+    /// STRICTER check layered on top for drivers that opt in, not a new
+    /// failure mode for ones that do not.
+    /// [`super::real_tmux::RealTmuxDriver`] overrides this to actually query
+    /// `tmux list-panes`.
+    /// Test: `RealTmuxDriver`'s override is covered by `core::tmux`'s
+    /// `list_panes_argv`; the manager-level refusal path is covered by
+    /// `resume_refuses_when_stored_pane_gone_but_session_alive` in
+    /// `resume_reattach_tests.rs`.
+    fn pane_exists(&self, _name: &str, _pane_id: &str) -> bool {
+        true
+    }
+
     /// Send an interrupt (Ctrl-C) to the session named `name` (#1461).
     ///
     /// Why: the [`Submit::Interrupt`](crate::core::sm::control::Submit::Interrupt)

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -118,6 +118,28 @@ pub enum ManagedError {
         "workspace directory {1} no longer exists; cannot resume session {0} — the worktree may have been removed"
     )]
     WorkspaceMissing(String, String),
+
+    /// The session's recorded `pane_id` no longer exists, though its tmux
+    /// SESSION is still alive (sibling-window hijack, follow-up to #2456).
+    ///
+    /// Why: `resume`'s reuse branch previously trusted `session_exists` alone
+    /// to mean "the recorded pane survived" — but a tmux session stays alive
+    /// as long as ANY pane/window in it is open, including a sibling that has
+    /// nothing to do with this record. Recreating in that situation via the
+    /// existing `kill_session` + `create_and_verify_pane` path would destroy
+    /// the sibling too; silently respawning via a session-scoped target would
+    /// land the runtime in the sibling instead of failing. Neither is safe,
+    /// so this variant surfaces the ambiguity to the operator explicitly
+    /// rather than guessing.
+    /// What: `(session_id, pane_id)` — the missing pane's id, surfaced in the
+    /// error message so the operator knows exactly what vanished.
+    #[error(
+        "recorded pane {1} for session {0} no longer exists, but its tmux session is still \
+         alive (likely a sibling window) — refusing to respawn into an unrelated active pane; \
+         close the sibling window and delete/recreate this session, or manually verify pane \
+         state with `tmux list-panes`"
+    )]
+    PaneGone(String, String),
 }
 
 // [`ManagedTmuxDriver`] lives in `driver.rs` (issue #1955 SLOC split — the
@@ -591,18 +613,30 @@ impl SessionManager {
     /// existence-checks `last_cwd` → `workspace_path` → `cwd` in order,
     /// erroring with [`ManagedError::WorkspaceMissing`] rather than handing a
     /// stale/removed path to tmux when none remain), then branches on
-    /// [`ManagedTmuxDriver::session_exists`]: if the tmux pane is STILL alive, it
-    /// is reused as-is — no `kill_session`, no `create_session` — because the
-    /// caller (e.g. `resume_managed`) re-spawns the runtime via
-    /// `RuntimeAdapter::spawn_resume`, which types the resume command straight
-    /// into that same pane (already rooted at the right cwd from its original
-    /// creation). If the pane is gone: a best-effort `kill_session` guard
-    /// followed by [`resume_workdir::create_and_verify_pane`], which creates the
-    /// fresh session AND verifies (#2250) the pane actually landed at the
-    /// resolved workdir — tmux `-c <dir>` can exit 0 while silently falling back
-    /// to `$HOME`, which this catches and fails loudly on rather than typing the
-    /// resume command into a mis-rooted pane. Either way the record is marked
-    /// `Active` and persisted.
+    /// [`ManagedTmuxDriver::session_exists`]: if the tmux SESSION is STILL
+    /// alive, it is (usually) reused as-is — no `kill_session`, no
+    /// `create_session` — because the caller (e.g. `resume_managed`)
+    /// re-spawns the runtime via `RuntimeAdapter::spawn_resume`, which now
+    /// types the resume command straight into the record's OWN recorded
+    /// `pane_id` (sibling-window hijack fix, follow-up to #2456) rather than a
+    /// session-scoped target that tmux could resolve to any other pane. Before
+    /// trusting that reuse, when `record.pane_id` is known this branch
+    /// additionally confirms via [`ManagedTmuxDriver::pane_exists`] that the
+    /// SPECIFIC recorded pane — not just some pane in the session — is still
+    /// there: `session_exists` alone cannot tell "the recorded pane survived"
+    /// apart from "a sibling window opened after it was closed is keeping the
+    /// session alive". A confirmed-gone recorded pane fails loudly with
+    /// [`ManagedError::PaneGone`] rather than either (a) silently respawning
+    /// into the unrelated active sibling, or (b) killing the whole session
+    /// (which would destroy the sibling too) to recreate it. If the whole
+    /// session is gone: a best-effort `kill_session` guard followed by
+    /// [`resume_workdir::create_and_verify_pane`], which creates the fresh
+    /// session AND verifies (#2250) the pane actually landed at the resolved
+    /// workdir — tmux `-c <dir>` can exit 0 while silently falling back to
+    /// `$HOME`, which this catches and fails loudly on rather than typing the
+    /// resume command into a mis-rooted pane; the freshly created pane's id is
+    /// then captured to refresh the stale `pane_id`. Either way (reuse or
+    /// recreate) the record is marked `Active` and persisted.
     /// Test: `manager_resume_respawns_in_existing_workspace` (`tests.rs`) —
     /// asserts a new `create_session` call is issued when no pane survives (the
     /// `stop()` path, which kills the pane); `resume_reattach_tests.rs`'s
@@ -610,7 +644,11 @@ impl SessionManager {
     /// `kill_session` NOR `create_session` fires when the pane survives (the
     /// `mark_runtime_exited_stopped` path, #2148); `resume_reattach_tests.rs`'s
     /// `manager_resume_errors_when_recreated_pane_cwd_mismatches` — asserts a
-    /// pane-cwd mismatch on the recreate path fails loudly (#2250).
+    /// pane-cwd mismatch on the recreate path fails loudly (#2250);
+    /// `resume_reattach_tests.rs`'s
+    /// `resume_refuses_when_stored_pane_gone_but_session_alive` — asserts a
+    /// confirmed-gone recorded pane refuses with `PaneGone` and never falls
+    /// through to a session-scoped reuse or a session-wide kill/recreate.
     pub async fn resume(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
         let mut record = self.get(id).await?;
         match record.state {
@@ -638,6 +676,25 @@ impl SessionManager {
         // `mark_runtime_exited_stopped`, #2023 A) must be REUSED, not destroyed.
         // Only recreate the tmux session when no live pane remains.
         if self.tmux.session_exists(&record.tmux_name) {
+            // Sibling-window hijack fix (follow-up to #2456): `session_exists`
+            // only proves SOME pane in this tmux session is alive — it says
+            // nothing about whether it is the SPECIFIC pane this record is
+            // bound to. When a `pane_id` was captured, confirm that exact
+            // pane is still there before trusting the reuse; a legacy record
+            // with no captured `pane_id` (pre-#2453) has no stronger signal
+            // available and keeps the prior session-scoped behavior.
+            if let Some(pane_id) = record.pane_id.as_deref()
+                && !self.tmux.pane_exists(&record.tmux_name, pane_id)
+            {
+                warn!(
+                    id = %id,
+                    name = %record.tmux_name,
+                    pane_id = %pane_id,
+                    "resume: recorded pane is gone but the tmux session is still alive \
+                     (sibling window) — refusing to respawn into an unrelated active pane"
+                );
+                return Err(ManagedError::PaneGone(id.to_string(), pane_id.to_string()));
+            }
             info!(
                 id = %id,
                 name = %record.tmux_name,

--- a/crates/trusty-mpm/src/session_manager/real_tmux.rs
+++ b/crates/trusty-mpm/src/session_manager/real_tmux.rs
@@ -71,6 +71,22 @@ impl ManagedTmuxDriver for RealTmuxDriver {
             .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
     }
 
+    /// Overrides the trait default so a resume/restart respawn actually lands
+    /// in the recorded pane instead of tmux's session-scoped "active pane"
+    /// resolution (sibling-window hijack, follow-up to #2456).
+    fn send_line_to_pane(&self, name: &str, pane_id: &str, text: &str) -> Result<(), ManagedError> {
+        self.driver
+            .send_line(&TmuxTarget::pane(name, pane_id), text)
+            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
+    }
+
+    /// Overrides the trait's optimistic `true` default so the production path
+    /// actually calls `tmux list-panes` and confirms the recorded pane is
+    /// still among them (sibling-window hijack, follow-up to #2456).
+    fn pane_exists(&self, name: &str, pane_id: &str) -> bool {
+        self.driver.pane_exists(name, pane_id)
+    }
+
     /// Send Ctrl-C to the session (overrides the no-op trait default; #1461).
     fn send_interrupt(&self, name: &str) -> Result<(), ManagedError> {
         self.driver

--- a/crates/trusty-mpm/src/session_manager/resume_reattach_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_reattach_tests.rs
@@ -148,3 +148,107 @@ async fn manager_resume_errors_when_recreated_pane_cwd_mismatches() {
         "a failed resume must leave the record Stopped, not Active"
     );
 }
+
+/// Sibling-window hijack fix (follow-up to #2456): `resume` must refuse —
+/// never silently reuse a session-scoped target, never kill the whole
+/// session to recreate — when the record's recorded `pane_id` is confirmed
+/// gone but the tmux SESSION is still alive (a sibling window keeping it
+/// open).
+///
+/// Why: prior to this fix, `resume`'s reuse branch trusted
+/// `ManagedTmuxDriver::session_exists` alone as proof the ORIGINAL pane
+/// survived. But a tmux session stays "alive" as long as ANY pane/window in
+/// it is open — including a sibling that has nothing to do with this record.
+/// The respawn command was then sent via a session-scoped target, which tmux
+/// resolves to whichever pane is currently ACTIVE — the sibling, not the
+/// original pane. This is the exact live-reproduced bug (issue: sibling-
+/// window hijack survives #2456's pane-identity gate).
+/// What: creates a session with a known `pane_id` (via the fake driver's
+/// `pane_id_override`), marks it Stopped via `mark_runtime_exited_stopped`
+/// (pane preserved, #2023 A), then configures `pane_exists_override =
+/// Some(false)` to simulate the original pane having been closed while the
+/// tmux SESSION remains alive (sibling window). Asserts `resume` returns
+/// `Err(ManagedError::PaneGone)`, the record stays `Stopped` (never flipped
+/// to `Active`), and NEITHER `kill_session` NOR `create_session` fired — the
+/// sibling window is left completely untouched.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn resume_refuses_when_stored_pane_gone_but_session_alive() {
+    let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    let workspace_path = workspace_dir.path().to_owned();
+
+    // Simulate a real driver having captured the pane_id at creation time
+    // (#2453) — the fake's default `get_pane_id` returns `None`.
+    *fake.pane_id_override.lock().unwrap() = Some("%6015".to_string());
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_path.clone()),
+            Some("my-hijacked-session".into()),
+            Some(workspace_path.clone()),
+            Some("https://github.com/owner/repo".into()),
+            Some("main".into()),
+        )
+        .await
+        .expect("create");
+    assert_eq!(
+        record.pane_id.as_deref(),
+        Some("%6015"),
+        "sanity: create() must have captured the seeded pane_id"
+    );
+
+    mgr.set_workspace(
+        &record.id,
+        workspace_path.clone(),
+        ManagedSessionState::Active,
+    )
+    .await
+    .expect("set Active");
+
+    // Runtime-exit reaper path (#2023 A): marks Stopped WITHOUT killing the
+    // pane, and (backfill-only-when-None) leaves the known-good pane_id
+    // untouched.
+    mgr.mark_runtime_exited_stopped(&record.id)
+        .await
+        .expect("mark_runtime_exited_stopped");
+
+    // Simulate: the original pane %6015 was closed, but a sibling window
+    // (e.g. %6016) keeps the tmux SESSION alive — `session_exists` still
+    // reports true, but the SPECIFIC recorded pane is gone.
+    *fake.pane_exists_override.lock().unwrap() = Some(false);
+
+    let kills_before = fake.kill_calls.lock().unwrap().len();
+    let creates_before = fake.create_cwd_calls.lock().unwrap().len();
+
+    let err = mgr
+        .resume(&record.id)
+        .await
+        .expect_err("resume must refuse when the recorded pane is confirmed gone");
+    assert!(
+        matches!(&err, ManagedError::PaneGone(sid, pid) if sid == &record.id.to_string() && pid == "%6015"),
+        "expected PaneGone(session_id, \"%6015\"), got: {err:?}"
+    );
+
+    assert_eq!(
+        fake.kill_calls.lock().unwrap().len(),
+        kills_before,
+        "resume must NOT kill the tmux session (which would destroy the sibling window too) \
+         when only the recorded pane is confirmed gone"
+    );
+    assert_eq!(
+        fake.create_cwd_calls.lock().unwrap().len(),
+        creates_before,
+        "resume must NOT recreate a session when only the recorded pane is confirmed gone"
+    );
+
+    let after = mgr.get(&record.id).await.expect("get after refused resume");
+    assert_eq!(
+        after.state,
+        ManagedSessionState::Stopped,
+        "a refused resume must leave the record Stopped, not Active"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -57,6 +57,23 @@ pub struct FakeTmuxDriver {
     /// simulate a real driver reporting the pane's actual cwd, including a
     /// deliberate mismatch against the requested workdir.
     pub pane_cwd_override: Mutex<Option<PathBuf>>,
+    /// Controllable `get_pane_id` response (sibling-window hijack fix,
+    /// follow-up to #2456) — `None` by default, matching the trait's "cannot
+    /// verify" default (this fake never captures a real pane_id at
+    /// `create_session` time); set to `Some(id)` to simulate a real driver
+    /// having captured one, so tests can exercise the pane-scoped resume
+    /// respawn / pane-gone-refusal paths.
+    pub pane_id_override: Mutex<Option<String>>,
+    /// Controllable `pane_exists` response (sibling-window hijack fix,
+    /// follow-up to #2456) — `None` by default, which falls through to the
+    /// trait's optimistic `true` default (matches every existing test's
+    /// assumption that a reused pane is still there); set to `Some(false)`
+    /// to simulate the recorded pane having been closed while a sibling
+    /// window keeps the tmux session alive.
+    pub pane_exists_override: Mutex<Option<bool>>,
+    /// Records every `send_line_to_pane` call as `(session_name, pane_id,
+    /// text)` (sibling-window hijack fix, follow-up to #2456).
+    pub pane_send_calls: Mutex<Vec<(String, String, String)>>,
 }
 
 impl FakeTmuxDriver {
@@ -71,6 +88,9 @@ impl FakeTmuxDriver {
             graceful_stop_calls: Mutex::new(Vec::new()),
             interrupt_calls: Mutex::new(Vec::new()),
             pane_cwd_override: Mutex::new(None),
+            pane_id_override: Mutex::new(None),
+            pane_exists_override: Mutex::new(None),
+            pane_send_calls: Mutex::new(Vec::new()),
         })
     }
 }
@@ -152,6 +172,35 @@ impl ManagedTmuxDriver for FakeTmuxDriver {
     /// confirming (or disagreeing with) the pane's actual cwd.
     fn get_pane_cwd(&self, _name: &str) -> Option<PathBuf> {
         self.pane_cwd_override.lock().unwrap().clone()
+    }
+
+    /// Report the controllable `pane_id_override` (sibling-window hijack fix,
+    /// follow-up to #2456) instead of the trait's silent `None` default, so
+    /// tests can simulate a real driver having captured a `pane_id` at
+    /// `create_session` time.
+    fn get_pane_id(&self, _name: &str) -> Option<String> {
+        self.pane_id_override.lock().unwrap().clone()
+    }
+
+    /// Report the controllable `pane_exists_override` (sibling-window hijack
+    /// fix, follow-up to #2456) when set; otherwise fall through to the
+    /// trait's optimistic `true` default — matches every existing test's
+    /// implicit assumption that a reused pane is still there.
+    fn pane_exists(&self, _name: &str, _pane_id: &str) -> bool {
+        self.pane_exists_override.lock().unwrap().unwrap_or(true)
+    }
+
+    /// Records `(name, pane_id, text)` instead of delegating to `send_line`
+    /// (the trait default) — a test asserting `pane_send_calls` got the call
+    /// and `send_calls` stayed empty is exactly what proves the manager chose
+    /// the pane-scoped path over the session-scoped one.
+    fn send_line_to_pane(&self, name: &str, pane_id: &str, text: &str) -> Result<(), ManagedError> {
+        self.pane_send_calls.lock().unwrap().push((
+            name.to_owned(),
+            pane_id.to_owned(),
+            text.to_owned(),
+        ));
+        Ok(())
     }
 }
 

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -2,8 +2,8 @@
 //!
 //! Why: the session-manager MVP spans several units (provisioner, catalog sync,
 //! session manager, daemon routes). These tests verify the units that can be
-//! exercised without a live tmux/git/LLM, plus a single `#[ignore]` live test
-//! that drives the real tmux + git path on a developer machine.
+//! exercised without a live tmux/git/LLM, plus `#[ignore]` live tests that
+//! drive the real tmux + git path on a developer machine.
 //! What: provisioner isolation, catalog sync TTL behavior, the session
 //! manager's create/answer flow with in-memory fakes, handler-level
 //! anti-stub tests proving provision+spawn are wired, and an activity
@@ -2037,4 +2037,148 @@ async fn isolated_managed_state_guard_panics_on_production_root() {
     let prod_root = home.join(".trusty-mpm");
     // This MUST panic with the production-root guard message.
     let _ = DaemonState::with_root_isolated_managed(prod_root).await;
+}
+
+// ── Live pane-target coverage (CRITICAL fix, follow-up to #2467) ────────────
+//
+// PR #2467 fixed `resume`/`restart` to target `record.pane_id` instead of
+// tmux's session-scoped active pane. The FIRST cut of `TmuxTarget::as_target`
+// rendered pane targets as `"<session>:<pane_id>"`, which tmux parses as a
+// WINDOW spec, not a pane spec — every resume with a known `pane_id` (i.e.
+// every post-#2456 session) hard-failed with "can't find window: %NNNN".
+// This test is the missing live-tmux coverage: mock-only tests could not
+// catch an invalid `-t` string because the mocks never parse it.
+
+use trusty_mpm::core::tmux::TmuxTarget;
+use trusty_mpm::daemon::tmux::TmuxDriver;
+
+/// Kills a throwaway tmux session on drop, including on test-assertion panic.
+///
+/// Why: a live-tmux test that panics partway through must not leak the tmux
+/// session it created — a bare `driver.kill_session(...)` call at the end of
+/// the test function would never run if an earlier `assert_eq!` panicked.
+/// What: wraps a `TmuxDriver` reference and a session name; `Drop::drop` best-
+/// effort kills the session (`kill_session`'s error is intentionally
+/// swallowed — cleanup must never itself panic during unwind).
+/// Test: exercised by every test below that constructs one.
+struct KillSessionGuard<'a> {
+    driver: &'a TmuxDriver,
+    name: String,
+}
+
+impl Drop for KillSessionGuard<'_> {
+    fn drop(&mut self) {
+        let _ = self.driver.kill_session(&self.name);
+    }
+}
+
+/// Live proof that a pane-scoped send lands in the ORIGINAL pane, never a
+/// sibling window that happens to be tmux's "active" pane.
+///
+/// Why: this is the exact sibling-window-hijack scenario #2467 set out to
+/// fix, driven against a REAL `tmux` binary rather than the `FakeTmuxDriver`
+/// mocks used elsewhere in this crate — the invalid `"session:%pane"` target
+/// string bug shipped past review specifically because coverage was
+/// mock-only (mocks never invoke real tmux argv parsing). It is `#[ignore]`
+/// (needs a live tmux); run locally with
+/// `cargo test -p trusty-mpm -- --include-ignored`.
+/// What: creates a throwaway session (original pane = the session's sole
+/// pane), opens a sibling window via `tmux new-window` (which tmux makes the
+/// new ACTIVE pane), then sends a marker line via `TmuxDriver::send_line`
+/// with a pane-scoped `TmuxTarget` addressing the ORIGINAL (now inactive)
+/// pane. Asserts the marker landed in the original pane's `capture-pane`
+/// output and did NOT land in the sibling's. Also exercises
+/// `TmuxDriver::pane_exists`: `true` for the real original pane, `false` for
+/// a fabricated pane id within the same (still-alive) session — the exact
+/// signal `SessionManager::resume` relies on to distinguish "pane gone" from
+/// "session gone". Cleans up via [`KillSessionGuard`] even on assertion
+/// failure.
+/// Test: this function IS the coverage `TmuxDriver::pane_exists`'s `Test:`
+/// doc pointer now names (previously falsely claimed by a comment that
+/// pointed at coverage which did not exist).
+#[test]
+#[ignore = "requires a live tmux binary; run with --include-ignored"]
+fn live_pane_scoped_send_targets_original_pane_not_sibling() {
+    let driver = TmuxDriver::discover().expect("tmux must be installed for this live test");
+    let session_name = format!("trusty-mpm-test-pane-{}", std::process::id());
+
+    // Clean slate: a leftover session from a prior crashed run must not
+    // confuse this test.
+    let _ = driver.kill_session(&session_name);
+    driver
+        .create_session(&session_name, None)
+        .expect("create throwaway session");
+    let _guard = KillSessionGuard {
+        driver: &driver,
+        name: session_name.clone(),
+    };
+
+    // Immediately after creation the session has exactly one pane, which is
+    // also the active one — `pane_id` (session-scoped `display-message`)
+    // resolves to it.
+    let original_pane = driver
+        .pane_id(&session_name)
+        .expect("original pane id must resolve");
+
+    // Open a sibling window. tmux makes the new window (and its pane) the
+    // active one — this is precisely the state that caused the hijack: any
+    // SESSION-scoped send would now land here instead of the original pane.
+    let status = std::process::Command::new("tmux")
+        .args(["new-window", "-t", &session_name])
+        .status()
+        .expect("spawn tmux new-window");
+    assert!(status.success(), "tmux new-window must succeed");
+
+    let sibling_pane = driver
+        .pane_id(&session_name)
+        .expect("sibling pane id must resolve once it is active");
+    assert_ne!(
+        original_pane, sibling_pane,
+        "sibling window must be a distinct pane from the original"
+    );
+
+    // Pane-scoped send: must land in the ORIGINAL pane, not the (now active)
+    // sibling — this is the exact call shape `spawn_resume` uses via
+    // `send_line_to_pane` -> `RealTmuxDriver::send_line_to_pane` ->
+    // `TmuxDriver::send_line(&TmuxTarget::pane(...), ...)`.
+    let marker = "trusty_mpm_pane_target_marker_2467";
+    driver
+        .send_line(&TmuxTarget::pane(&session_name, &original_pane), marker)
+        .expect("pane-scoped send_line must succeed against the ORIGINAL pane");
+
+    // Give tmux a moment to render the sent keys into the pane buffer before
+    // capturing (send-keys itself is synchronous, but the shell's own echo
+    // of the typed line can lag by a beat under load).
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let original_capture = driver
+        .capture(&TmuxTarget::pane(&session_name, &original_pane), None)
+        .expect("capture original pane");
+    assert!(
+        original_capture.contains(marker),
+        "marker must land in the ORIGINAL pane; captured: {original_capture:?}"
+    );
+
+    let sibling_capture = driver
+        .capture(&TmuxTarget::pane(&session_name, &sibling_pane), None)
+        .expect("capture sibling pane");
+    assert!(
+        !sibling_capture.contains(marker),
+        "marker must NOT land in the sibling pane (that is the hijack this test \
+         guards against); captured: {sibling_capture:?}"
+    );
+
+    // `pane_exists` must confirm the real pane and refuse a fabricated one
+    // within the same (still-alive) session — the signal `resume` relies on
+    // to distinguish "pane gone" (refuse) from "session gone" (different
+    // path entirely).
+    assert!(
+        driver.pane_exists(&session_name, &original_pane),
+        "pane_exists must report true for the real original pane"
+    );
+    assert!(
+        !driver.pane_exists(&session_name, "%999999999"),
+        "pane_exists must report false for a pane id that was never created \
+         in this session"
+    );
 }


### PR DESCRIPTION
## Summary

Closes #2466.

Fixes the residual sibling-window hijack vector left after #2456: `SessionManager::resume()`'s reuse branch, and the `RuntimeAdapter::spawn_resume`/`send_line` call it feeds into, respawn `claude` into whichever tmux pane happens to be **active** rather than the session's own recorded `pane_id` — so a sibling window opened after the original pane silently receives the respawned runtime while the original pane sits at a bare shell.

## Confirmed root cause

#2456's pane-identity gate (`guided.rs`'s `pane_identity_confirmed`) correctly refuses the **in-place exec** path when the current pane doesn't match the record's `pane_id`. That refusal falls through to `guided_resume::resume_guided_session` → `plan_resume` → (when the record has since flipped to `Stopped`) the `Restart` branch → HTTP `POST /resume` → `resume_managed` (`crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs:1379`) → `SessionManager::resume()` (`crates/trusty-mpm/src/session_manager/manager.rs:636`, pre-fix).

The precise mechanism, confirmed by reading the code (not just the hypothesis):

1. `SessionManager::resume()`'s reuse branch (`manager.rs:662`, pre-fix) checked **only** `ManagedTmuxDriver::session_exists(&record.tmux_name)` — true as long as **any** pane/window in that tmux session is alive, including an unrelated sibling. It never checked whether the record's own `pane_id` specifically survived.
2. On success it fell through to `resume_managed` (`lifecycle.rs:1417`, pre-fix), which called `adapter.spawn_resume(&record.tmux_name, &workspace, ...)` — **no `pane_id` was passed at all**, even though `record.pane_id` was sitting right there on the returned record.
3. `ClaudeCodeAdapter::spawn_resume` (`runtime/claude_code.rs:884`, pre-fix) built the resume command and sent it via `self.tmux.send_line(tmux_name, &cmd)` — a **session-scoped** call.
4. `RealTmuxDriver::send_line` (`session_manager/real_tmux.rs:60`, pre-fix) unconditionally built `TmuxTarget::session(name)` — never `TmuxTarget::pane(name, pane_id)`. Grepping the whole crate for `TmuxTarget::pane(` confirmed it was used **only in tests**, never in any production call site.
5. tmux resolves a session-scoped `-t <session>` target to whichever pane/window is **currently active** in that session. `tmux new-window` auto-activates the new window, so a sibling window opened after the original pane is exactly that "currently active" pane — and receives the respawned `claude` process instead of the original (now-dead) pane.

This matches the issue's own analysis almost exactly; the one refinement from reading the code is that the bug isn't in `resume()`'s reuse-vs-recreate branch selection itself (that part is fine — reuse is the right call when the session survives) but one layer down, in the fact that **the actual respawn command dispatch had no pane-scoped code path in production at all** — `pane_id` was captured (#2453/#2456) and used only for the identity-gate *comparison*, never for building the tmux target that matters for the respawn.

## Audited send-keys / respawn / `-t`-target sites

Grepped for `send-keys`, `respawn`, `TmuxTarget::session(`, and `TmuxTarget::pane(` across `crates/trusty-mpm/src`. Disposition per site:

| Site | Context | Disposition |
|---|---|---|
| `session_manager/real_tmux.rs:60` `send_line` | Resume/restart respawn + general injected text | **FIXED** — new `send_line_to_pane` override targets `TmuxTarget::pane(name, pane_id)` when a pane_id is supplied |
| `runtime/claude_code.rs:952` (`spawn_resume`) | The actual `claude` respawn command | **FIXED** — now calls `send_line_to_pane` when `pane_id: Some(_)`, falls back to `send_line` only for legacy records with no captured pane_id |
| `daemon/managed_routes/lifecycle.rs:1417` (`resume_managed`) | Wires `record.pane_id` through to `spawn_resume` | **FIXED** — was not passing `pane_id` at all pre-fix |
| `session_manager/manager.rs:662` (`resume()` reuse branch) | Decides reuse vs. recreate | **FIXED** — now confirms the recorded pane specifically survived (`pane_exists`) before trusting reuse; refuses explicitly (`PaneGone`) rather than falling through to an active-pane respawn or destructively killing the whole session (which would also nuke the sibling) |
| `session_manager/manager.rs:361-363` (`inject`/`send_input`, `Submit::Enter`/`NoSubmit`/`Interrupt`) | MCP `session_send` / CLI `tm session send` into an already-**Active** session | **Vulnerable to the same class in theory** (a sibling window active at Enter/NoSubmit/Interrupt time would receive the injected text/interrupt) — **NOT fixed in this PR**; scoped out because the issue is specifically about the resume/restart respawn, and widening `inject`'s three verbs to pane-scoped targeting needs its own trait surface (`send_keys_literal_to_pane`, `send_interrupt_to_pane`) and test pass. Tracked as a natural follow-up. |
| `session_manager/manager.rs:392` (`observe`'s `capture`) | Read-only pane capture for `SessionControl::observe` | **Vulnerable in theory** (captures whatever pane is active) but read-only — no destructive/incorrect-launch consequence; **not fixed**, same follow-up bucket as `inject` |
| `daemon/services/tmux_service.rs:45,73` (`TmuxService::capture`/`send_command`) | Legacy **unmanaged** `Session`/`TmuxService` control surface (predates the managed-session `pane_id` work entirely) | **Not applicable** — no `pane_id` concept exists on this legacy path at all; would need a broader design change, out of scope |
| `daemon/claude_config/restarter.rs:70` (`ClaudeCodeRestarter::restart_in_session`) | Dashboard "restart claude in this tmux session" HTTP route (`POST /claude-config/restart`) | **Vulnerable in theory** — takes a raw `tmux_session: String` straight from the HTTP body, no `SessionRecord`/`pane_id` plumbed to this route at all; **not fixed**, would require a broader API change, tracked as follow-up |
| `control/backend/tmux.rs:117,150,174` (`TmuxBackend::new`/`send`/`recv`) | Separate control-plane actor session backend (`tm:<project-id>:<n>`), unrelated to `session_manager`'s managed sessions | **Not applicable** — this backend creates and exclusively owns its own dedicated tmux session; no sibling-window creation exists in this subsystem today. Same theoretical exposure would exist if an operator manually opened a second window in one of these sessions, but there's no `pane_id`-equivalent state to key off; out of scope |
| `client/http_client/session_connect.rs:109,214` (`launch_session`/`connect_session`) | CLI `/connect` — sends `claude` only immediately after creating a **fresh** session (`!already_running` gate) | **Already safe** — fires before any sibling window can exist |
| `bin/tm/commands/launch.rs:352,547`, `bin/tm/commands/session/start.rs:198` | Classic (non-managed) `tm launch`/`tm session start` — sends `claude` only immediately after `create_managed_session` | **Already safe** — same "fresh session, single pane" reasoning |
| `daemon/managed_routes/lifecycle.rs:628,902,1137,1198` (`adapter.spawn(...)`, 4 call sites) | `spawn_managed_cloned`/adopt/in-project spawn paths — brand-new session, single pane | **Already safe** — `spawn()` (not `spawn_resume()`) is only ever called right after `create_session`; no change needed |

## Fix

1. `ManagedTmuxDriver` (`session_manager/driver.rs`) gains two new trait methods with safe defaults (`send_line_to_pane` falls back to `send_line`; `pane_exists` defaults to `true` — "cannot verify" means "assume present," preserving prior behavior for drivers that don't opt in).
2. `RealTmuxDriver` overrides both: `send_line_to_pane` builds a real `TmuxTarget::pane(name, pane_id)`; `pane_exists` calls a new `TmuxDriver::pane_exists` (`daemon/tmux.rs`) that runs `tmux list-panes` and checks membership.
3. `SessionManager::resume()`'s reuse branch now confirms the recorded `pane_id` (when known) still exists before trusting reuse. A confirmed-gone pane — session alive (sibling window), specific pane gone — returns the new `ManagedError::PaneGone` rather than (a) silently respawning into the sibling or (b) killing the whole session (which would destroy the sibling too) to recreate.
4. `RuntimeAdapter::spawn_resume` now takes `pane_id: Option<&str>`; `ClaudeCodeAdapter::spawn_resume` targets `send_line_to_pane` when it's `Some`, falling back to the session-scoped `send_line` only for legacy records that never captured a `pane_id`.
5. `resume_managed` (`lifecycle.rs`) now passes `record.pane_id.as_deref()` through to `spawn_resume`.
6. Cosmetic (issue's "additional observations"): `guided.rs`'s nested-guard fallback messaging no longer prints "…refusing to launch a nested session here." followed by a separate "reconnecting…" line (which read as a failure even when the subsequent reconcile-relaunch succeeded). Both call sites now use a single reworded `nested_guard_notice()` helper ("not nesting a new session here; reconnecting to '{name}' instead…").

## Tests added

- `runtime/claude_code.rs`: `spawn_resume_targets_stored_pane_id_when_known` / `spawn_resume_falls_back_to_session_target_when_pane_id_unknown` — asserts the adapter calls `send_line_to_pane` (not `send_line`) when a `pane_id` is known, and the exact pane_id string passed, via a new `pane_sends` log on the shared `FakeTmux` test double.
- `session_manager/resume_reattach_tests.rs`: `resume_refuses_when_stored_pane_gone_but_session_alive` — creates a session with a known `pane_id`, marks it Stopped (pane preserved), simulates the pane being closed while the session stays alive (sibling window), and asserts `resume()` returns `PaneGone`, never kills/recreates the session, and leaves the record `Stopped`.
- `bin/tm/tests_behavior_c_tests.rs`: `nested_guard_notice_never_says_refusing` / `nested_guard_notice_mentions_reconnect_target` — locks the reworded messaging.

## Verification

```
cargo build --workspace                              -> clean
cargo test --workspace                                -> all green, 0 failed (grepped every "test result:" line)
cargo clippy --workspace --all-targets -- -D warnings -> clean (fixed one collapsible-if via let-chain, edition 2024)
cargo fmt --check                                     -> clean
bash scripts/check_line_cap.sh                        -> "0 allowlisted, 0 violations — OK"
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools