### PR TITLE
feat(trusty-mpm): TUI live-refresh + activity-pane wiring

### DIFF
--- a/crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs
@@ -1,16 +1,24 @@
-//! Activity pane (bottom strip, 4 rows) — DOC-35 §5 pane 3, SKELETON ONLY.
+//! Activity pane (bottom strip, 4 rows) — DOC-35 §5 pane 3, live-wired (#2119).
 //!
-//! Why: the design spec sources this pane from `GET .../{id}/activity`
-//! (`state`, `summary`, `pending_decision`, `proposed_default`), but per
-//! #2118's scope that live wiring is deferred to #2119. This skeleton instead
-//! renders the focused session's already-polled STATIC record fields —
-//! `state`, `task`, `pending_decision`, `proposed_default` — which travel
-//! through [`super::super::poll::session_to_row`] on the same fleet poll the
-//! Sessions pane uses, at zero extra HTTP cost.
+//! Why: DOC-35 §5.4 sources this pane from `GET .../{id}/activity` (`state`,
+//! `summary`, `pending_decision`, `proposed_default`, plus a short
+//! `raw_pane` tail per the §5.1 mockup); #2118 shipped a skeleton that
+//! rendered only the focused session's already-polled STATIC record fields
+//! because that live wiring was explicitly this issue's scope. This module
+//! now prefers [`ProjectCtlState::activity_for_selected`] (populated by
+//! [`super::super::poll::refresh_activity`] on the same poll cadence as the
+//! Projects/Sessions panes) and falls back to the static [`SessionRow`]
+//! fields — with an explanatory suffix, never silently — for the two windows
+//! where no live snapshot is available yet: right after a selection changes
+//! (the fetch for the new selection has not landed) and while the daemon is
+//! down with no prior live fetch to show as stale.
 //! What: [`activity_lines`] is a pure builder (unit tested without a
-//! terminal); [`render`] wraps it in a bordered `Paragraph`.
-//! Test: `tests` covers the no-selection, no-pending, and pending-decision
-//! text shapes.
+//! terminal) covering four shapes: no session selected; live data available
+//! (optionally suffixed `[stale]` when the last fetch failed but a prior one
+//! is being kept); daemon reachable but no live fetch has landed for this
+//! selection yet ("loading…"); daemon down with nothing live to show yet
+//! ("daemon unreachable"). [`render`] wraps it in a bordered `Paragraph`.
+//! Test: `tests` covers all four shapes above.
 
 use ratatui::{
     Frame,
@@ -22,41 +30,81 @@ use ratatui::{
 
 use crate::tui::project_ctl::state::{Pane, ProjectCtlState};
 
-/// Build the Activity pane's body lines for the currently focused session.
+/// Format the shared "pending decision" segment from a question/default pair.
 ///
-/// Why: a pure text builder keeps the "no selection" / "no pending decision" /
-/// "pending decision" shapes testable without a terminal.
-/// What: with no session selected, a single placeholder line naming the
-/// deferred live wiring (#2119). Otherwise: a header line (`session <name>
-/// (<short-id>)`), a state line naming the static `state` word plus the
-/// pending-decision question and proposed default when present (else
-/// "no pending decision"), and a task line when the record has one.
-/// Test: `activity_lines_no_selection`, `activity_lines_no_pending_decision`,
-/// `activity_lines_shows_pending_decision`.
+/// Why: both the live-activity render path and the static-fallback path build
+/// the identical `" · pending: \"...\" · proposed default: ..."` /
+/// `" · no pending decision"` segment off differently-sourced (but
+/// identically-shaped) `Option<String>` pairs; factoring it out avoids
+/// duplicating the three-way match.
+/// What: `(Some(q), Some(d))` → both; `(Some(q), None)` → question only;
+/// otherwise → the "no pending decision" fallback.
+fn decision_segment(pending: &Option<String>, proposed: &Option<String>) -> String {
+    match (pending, proposed) {
+        (Some(q), Some(d)) => format!(" · pending: \"{q}\" · proposed default: {d}"),
+        (Some(q), None) => format!(" · pending: \"{q}\""),
+        _ => " · no pending decision".to_string(),
+    }
+}
+
+/// Build the Activity pane's body lines for the currently selected session.
+///
+/// Why: a pure text builder keeps every rendered shape testable without a
+/// terminal; see the module doc for the four shapes.
+/// What: no selection → a placeholder. A live snapshot that matches the
+/// current selection (`state.activity_for_selected()`) → header, `state:
+/// <word><decision segment>[ [stale]]`, `summary: <text>`, then the raw-pane
+/// tail lines verbatim. No live snapshot yet, daemon reachable → header plus
+/// the static record's state/decision segment suffixed `· loading live
+/// activity…`. No live snapshot yet, daemon down → header plus an explicit
+/// "daemon unreachable" line (DOC-35's graceful-daemon-down requirement: an
+/// explicit message, never a silent blank pane).
+/// Test: `activity_lines_no_selection`, `activity_lines_shows_live_activity`,
+/// `activity_lines_shows_pending_decision_from_live_activity`,
+/// `activity_lines_marks_stale_activity`,
+/// `activity_lines_falls_back_while_loading`,
+/// `activity_lines_reports_daemon_unreachable_with_no_prior_fetch`.
 pub fn activity_lines(state: &ProjectCtlState) -> Vec<String> {
     let Some(session) = state.selected_session() else {
         return vec![
             "no session selected".to_string(),
-            "(live activity polling is deferred to #2119 — this pane shows only the \
-             already-fetched session record)"
-                .to_string(),
+            "(select a project and a session to see its live activity)".to_string(),
         ];
     };
 
-    let mut lines = vec![format!("session {} ({})", session.name, session.short_id)];
+    let header = format!("session {} ({})", session.name, session.short_id);
 
-    let decision_segment = match (&session.pending_decision, &session.proposed_default) {
-        (Some(q), Some(d)) => format!(" · pending: \"{q}\" · proposed default: {d}"),
-        (Some(q), None) => format!(" · pending: \"{q}\""),
-        _ => " · no pending decision".to_string(),
-    };
-    lines.push(format!("state: {}{decision_segment}", session.state));
-
-    if let Some(task) = &session.task {
-        lines.push(format!("task: {task}"));
+    if let Some(activity) = state.activity_for_selected() {
+        let stale_suffix = if activity.stale { " [stale]" } else { "" };
+        let mut lines = vec![
+            header,
+            format!(
+                "state: {}{}{stale_suffix}",
+                activity.state,
+                decision_segment(&activity.pending_decision, &activity.proposed_default)
+            ),
+            format!("summary: {}", activity.summary),
+        ];
+        lines.extend(activity.raw_pane_tail.iter().cloned());
+        return lines;
     }
 
-    lines
+    if state.daemon_reachable {
+        vec![
+            header,
+            format!(
+                "state: {}{} · loading live activity…",
+                session.state,
+                decision_segment(&session.pending_decision, &session.proposed_default)
+            ),
+        ]
+    } else {
+        vec![
+            header,
+            "daemon unreachable — live activity unavailable".to_string(),
+            format!("last known state: {}", session.state),
+        ]
+    }
 }
 
 /// Draw the Activity pane into `area`.
@@ -86,7 +134,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ProjectCtlState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tui::project_ctl::state::{ProjectRow, SessionRow};
+    use crate::tui::project_ctl::state::{ActivityInfo, ProjectRow, SessionRow};
 
     fn state_with_session(session: SessionRow) -> ProjectCtlState {
         let mut state = ProjectCtlState {
@@ -119,6 +167,18 @@ mod tests {
         }
     }
 
+    fn live_activity(session_id: &str) -> ActivityInfo {
+        ActivityInfo {
+            session_id: session_id.to_string(),
+            state: "blocked_on_permission".to_string(),
+            summary: "waiting on a ci.yml write approval".to_string(),
+            pending_decision: None,
+            proposed_default: None,
+            raw_pane_tail: vec!["$ echo hi".to_string(), "hi".to_string()],
+            stale: false,
+        }
+    }
+
     #[test]
     fn activity_lines_no_selection() {
         let state = ProjectCtlState::default();
@@ -127,22 +187,76 @@ mod tests {
     }
 
     #[test]
-    fn activity_lines_no_pending_decision() {
-        let state = state_with_session(base_session());
+    fn activity_lines_shows_live_activity() {
+        let mut state = state_with_session(base_session());
+        state.activity = Some(live_activity("4f9ca1b2ffff"));
         let lines = activity_lines(&state);
-        assert!(lines.iter().any(|l| l.contains("state: active")));
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("state: blocked_on_permission"))
+        );
         assert!(lines.iter().any(|l| l.contains("no pending decision")));
-        assert!(lines.iter().any(|l| l.contains("ship the thing")));
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("summary: waiting on a ci.yml write approval"))
+        );
+        assert!(lines.iter().any(|l| l.contains("$ echo hi")));
+        assert!(!lines.iter().any(|l| l.contains("[stale]")));
     }
 
     #[test]
-    fn activity_lines_shows_pending_decision() {
-        let mut session = base_session();
-        session.pending_decision = Some("write to ci.yml?".to_string());
-        session.proposed_default = Some("yes".to_string());
-        let state = state_with_session(session);
+    fn activity_lines_shows_pending_decision_from_live_activity() {
+        let mut activity = live_activity("4f9ca1b2ffff");
+        activity.pending_decision = Some("write to ci.yml?".to_string());
+        activity.proposed_default = Some("yes".to_string());
+        let mut state = state_with_session(base_session());
+        state.activity = Some(activity);
         let lines = activity_lines(&state);
         assert!(lines.iter().any(|l| l.contains("write to ci.yml?")));
         assert!(lines.iter().any(|l| l.contains("proposed default: yes")));
+    }
+
+    #[test]
+    fn activity_lines_marks_stale_activity() {
+        let mut activity = live_activity("4f9ca1b2ffff");
+        activity.stale = true;
+        let mut state = state_with_session(base_session());
+        state.activity = Some(activity);
+        let lines = activity_lines(&state);
+        assert!(lines.iter().any(|l| l.contains("[stale]")));
+    }
+
+    #[test]
+    fn activity_lines_falls_back_while_loading() {
+        // No live activity yet for this selection, but the daemon is up — the
+        // static session-record fields are shown, clearly labeled "loading".
+        let mut state = state_with_session(base_session());
+        state.daemon_reachable = true;
+        let lines = activity_lines(&state);
+        assert!(lines.iter().any(|l| l.contains("state: active")));
+        assert!(lines.iter().any(|l| l.contains("loading live activity")));
+    }
+
+    #[test]
+    fn activity_lines_falls_back_while_activity_is_stale_selection() {
+        // A live fetch landed, but for a DIFFERENT session than the one now
+        // selected (the selection moved between polls) — it must not render
+        // under this session's header.
+        let mut state = state_with_session(base_session());
+        state.daemon_reachable = true;
+        state.activity = Some(live_activity("some-other-session"));
+        let lines = activity_lines(&state);
+        assert!(lines.iter().any(|l| l.contains("loading live activity")));
+    }
+
+    #[test]
+    fn activity_lines_reports_daemon_unreachable_with_no_prior_fetch() {
+        let mut state = state_with_session(base_session());
+        state.daemon_reachable = false;
+        let lines = activity_lines(&state);
+        assert!(lines.iter().any(|l| l.contains("daemon unreachable")));
+        assert!(lines.iter().any(|l| l.contains("last known state: active")));
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/mod.rs
@@ -5,8 +5,8 @@
 //! touching `render` calls). [`super::layout::render`] composes the frame's
 //! `Rect`s and calls into each of these.
 //! What: [`projects`] (left, 25%), [`sessions`] (right, 75%),
-//! [`activity`] (bottom strip, static-fields skeleton), and [`actions_bar`]
-//! (the 1-row key-hint / notice line).
+//! [`activity`] (bottom strip, live `/activity`-endpoint wiring per #2119),
+//! and [`actions_bar`] (the 1-row key-hint / notice line).
 //! Test: each submodule's pure builders are unit-tested in its own `tests`
 //! block; the `render` functions are terminal glue exercised by launching the
 //! TUI.

--- a/crates/trusty-mpm/src/tui/project_ctl/poll.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll.rs
@@ -1,29 +1,48 @@
-//! Live daemon polling for the `tm projects` TUI (#2118).
+//! Live daemon polling for the `tm projects` TUI (#2118, live-refresh + activity
+//! wiring #2119).
 //!
 //! Why: the run loop repeats one async step on its `--interval-ms` cadence —
 //! probe daemon health, self-heal the URL on failure, pull the registry-B
-//! project list plus the fleet-by-project session groups, and project both
-//! into the pure row shapes [`super::state`] renders. Mirrors
-//! `tui::coordinator::poll::coord_poll_daemon` so every TUI screen self-heals
-//! the daemon URL identically. Fetching the fleet ONCE per tick (rather than
-//! per-project) keeps this to two HTTP calls regardless of project count.
+//! project list plus the fleet-by-project session groups, fetch the selected
+//! session's live activity, and project all three into the pure shapes
+//! [`super::state`] renders. Mirrors `tui::coordinator::poll::coord_poll_daemon`
+//! so every TUI screen self-heals the daemon URL identically. Fetching the
+//! fleet ONCE per tick (rather than per-project) keeps the project/session
+//! refresh to two HTTP calls regardless of project count; the activity fetch
+//! is a third call, made only when a session is selected (DOC-35 §5.4).
 //! What: [`project_ctl_poll_daemon`] (health → rediscover-on-fail → registry
-//! list + fleet → map; on daemon-down clears both) plus the pure projections
-//! [`project_to_row`] and [`session_to_row`].
-//! Test: `tests` covers the pure projections; the async glue mirrors the
-//! coordinator's poller and is exercised by launching the TUI.
+//! list + fleet → map → selected-session activity via [`refresh_activity`];
+//! on daemon-down clears the project/session state — which in turn clears
+//! `activity` too, since a daemon-down poll has no session left selected to
+//! attribute it to; see [`refresh_activity`]'s own doc for the narrower
+//! "fetch failed but the daemon is otherwise up" case that DOES keep the
+//! last-known activity, marked stale) plus the pure projections
+//! [`project_to_row`], [`session_to_row`], and [`activity_from_response`].
+//! Test: `tests` covers the pure projections and the daemon-down branches
+//! against a guaranteed-dead client (mirroring
+//! `tui::coordinator::poll::tests::poll_marks_unreachable_clears_sessions`);
+//! the daemon-UP path is exercised manually / by launching the TUI.
 
-use crate::client::{DaemonClient, FleetProjectGroupWire, ManagedSessionSummary};
+use crate::client::{
+    DaemonClient, FleetProjectGroupWire, ManagedActivityResponse, ManagedSessionSummary,
+};
 use crate::project::Project;
 use crate::tui::coordinator::rows::session_short_id;
 
-use super::state::{ProjectCtlState, ProjectRow, SessionRow};
+use super::state::{ActivityInfo, ProjectCtlState, ProjectRow, SessionRow};
+
+/// How many trailing lines of a session's raw tmux pane the Activity pane
+/// previews (DOC-35 §5.1 mockup: "last 3 lines of raw_pane").
+const RAW_PANE_TAIL_LINES: usize = 3;
 
 /// Refresh [`ProjectCtlState`] from one daemon poll.
 ///
 /// Why: keeps the poll logic out of the key-driven run loop so the loop can
 /// re-poll on its timer (and, after a mutating action, on demand) without
-/// duplicating the health/rediscover/fetch sequence.
+/// duplicating the health/rediscover/fetch sequence. Note this function never
+/// touches [`ProjectCtlState::pending_confirm`] — the confirmation gate pins a
+/// target session id at the moment it opens (DOC-35 §5.2) and a poll racing
+/// with an open confirm modal must not reassign or clear it.
 /// What: probes health; if the daemon looks down, re-resolves the URL from
 /// the lock file via [`rediscover`] and retries one health probe. When
 /// reachable it pulls `GET /api/v1/projects` and
@@ -33,9 +52,13 @@ use super::state::{ProjectCtlState, ProjectRow, SessionRow};
 /// navigation models so a shrunk list never leaves a selection past the end;
 /// the Sessions-pane selection is PRESERVED across a refresh (only an
 /// explicit project switch resets it — see
-/// [`ProjectCtlState::on_project_selection_changed`]).
-/// Test: `poll_marks_unreachable_clears_state` drives the daemon-down branch;
-/// the daemon-up path requires a live daemon and is exercised manually.
+/// [`ProjectCtlState::on_project_selection_changed`]). Finally refreshes
+/// [`ProjectCtlState::activity`] for whichever session is selected AFTER the
+/// project/session refresh above (see [`refresh_activity`]).
+/// Test: `poll_marks_unreachable_clears_state` drives the full-poll
+/// daemon-down branch; `poll_never_touches_pending_confirm` (in
+/// `super::tests`) covers the confirm-gate invariant; the daemon-up path
+/// requires a live daemon and is exercised manually.
 pub(crate) async fn project_ctl_poll_daemon(
     state: &mut ProjectCtlState,
     client: &mut DaemonClient,
@@ -62,6 +85,46 @@ pub(crate) async fn project_ctl_poll_daemon(
     }
     state.projects_nav.sync_len(state.projects.len());
     state.sessions_nav.sync_len(state.current_sessions().len());
+    refresh_activity(state, client).await;
+}
+
+/// Refresh [`ProjectCtlState::activity`] for the currently selected session
+/// (DOC-35 §5.4, #2119).
+///
+/// Why: split out of [`project_ctl_poll_daemon`] so the "no session selected"
+/// / "daemon down, keep last known" / "fetch failed, keep last known" /
+/// "fetch succeeded" branches are each one arm instead of nested inside the
+/// larger poll function. Runs AFTER the project/session refresh above so
+/// `state.selected_session()` reflects the just-synced navigation, not a
+/// pre-refresh selection that may have shrunk out of range.
+/// What: no selection → clears `state.activity`. A selection with the daemon
+/// unreachable, or whose fetch errors, → if `state.activity` already targets
+/// this session id it is marked `stale` (kept, not discarded, per the
+/// graceful-daemon-down requirement); otherwise cleared (nothing recent
+/// enough to show as stale). A successful fetch replaces `state.activity`
+/// outright with a fresh, non-stale [`ActivityInfo`].
+/// Test: `refresh_activity_marks_existing_activity_stale_on_fetch_failure`,
+/// `refresh_activity_clears_when_no_session_is_selected`.
+async fn refresh_activity(state: &mut ProjectCtlState, client: &DaemonClient) {
+    let Some(session_id) = state.selected_session().map(|s| s.id.clone()) else {
+        state.activity = None;
+        return;
+    };
+
+    if state.daemon_reachable {
+        match client.managed_session_activity(&session_id).await {
+            Ok(resp) => {
+                state.activity = Some(activity_from_response(session_id, resp));
+                return;
+            }
+            Err(_) => { /* fall through to the stale-or-clear handling below */ }
+        }
+    }
+
+    match &mut state.activity {
+        Some(existing) if existing.session_id == session_id => existing.stale = true,
+        _ => state.activity = None,
+    }
 }
 
 /// Re-resolve the daemon URL from the lock file when the daemon is unreachable.
@@ -153,10 +216,11 @@ pub(crate) fn project_to_row(p: &Project, group: Option<&FleetProjectGroupWire>)
 
 /// Project one fleet [`ManagedSessionSummary`] into a [`SessionRow`].
 ///
-/// Why: the Sessions pane needs a numbered, compact row per session, plus the
-/// static `pending_decision`/`proposed_default` fields the Activity pane
-/// skeleton renders (#2118 does NOT call the live `/activity` endpoint — that
-/// is #2119).
+/// Why: the Sessions pane needs a numbered, compact row per session; the
+/// fleet poll is one call for every session regardless of count, so this
+/// projection stays over the STATIC record fields even after #2119 — only the
+/// one selected session's activity gets the extra live `/activity` fetch (see
+/// [`refresh_activity`]), never the whole list.
 /// What: derives the 8-hex short id via [`session_short_id`] and copies the
 /// rest through unchanged.
 /// Test: `session_to_row_derives_short_id_and_copies_fields`.
@@ -172,6 +236,51 @@ pub(crate) fn session_to_row(s: ManagedSessionSummary) -> SessionRow {
         pending_decision: s.pending_decision,
         proposed_default: s.proposed_default,
     }
+}
+
+/// Project a [`ManagedActivityResponse`] into an [`ActivityInfo`] for `session_id`.
+///
+/// Why: the Activity pane needs a lean, render-ready shape (DOC-35 §5.4) with
+/// a bounded pane-tail preview rather than the full wire response.
+/// What: copies `state`/`summary`/`pending_decision`/`proposed_default`
+/// through unchanged, tags the snapshot with `session_id`, sets `stale` to
+/// `false` (a just-succeeded fetch is by definition fresh), and derives
+/// `raw_pane_tail` as the last [`RAW_PANE_TAIL_LINES`] non-empty lines of
+/// `raw_pane` via [`tail_lines`].
+/// Test: `activity_from_response_derives_fields_and_tail`,
+/// `activity_from_response_handles_short_pane`.
+pub(crate) fn activity_from_response(
+    session_id: String,
+    resp: ManagedActivityResponse,
+) -> ActivityInfo {
+    ActivityInfo {
+        session_id,
+        state: resp.state,
+        summary: resp.summary,
+        pending_decision: resp.pending_decision,
+        proposed_default: resp.proposed_default,
+        raw_pane_tail: tail_lines(&resp.raw_pane, RAW_PANE_TAIL_LINES),
+        stale: false,
+    }
+}
+
+/// The last `n` non-empty, trimmed lines of `text`, in original order.
+///
+/// Why: a raw tmux pane capture is typically newline-padded and much longer
+/// than the Activity pane's fixed 4-row height can show; a small pure helper
+/// keeps the "which lines" rule unit-testable independent of rendering.
+/// What: splits on `\n`, trims each line, drops empty ones, then keeps the
+/// last `n` (or fewer, if `text` has fewer than `n` non-empty lines).
+/// Test: `tail_lines_keeps_last_n_non_empty_lines`,
+/// `tail_lines_handles_fewer_lines_than_requested`.
+fn tail_lines(text: &str, n: usize) -> Vec<String> {
+    let non_empty: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    let start = non_empty.len().saturating_sub(n);
+    non_empty[start..].iter().map(|l| l.to_string()).collect()
 }
 
 #[cfg(test)]
@@ -247,5 +356,174 @@ mod tests {
         assert_eq!(row.state, "active");
         assert_eq!(row.branch.as_deref(), Some("main"));
         assert_eq!(row.task.as_deref(), Some("do the thing"));
+    }
+
+    fn activity_response(raw_pane: &str) -> ManagedActivityResponse {
+        ManagedActivityResponse {
+            raw_pane: raw_pane.to_string(),
+            runtime_active: true,
+            pane_stale: false,
+            state: "working".to_string(),
+            summary: "running tests".to_string(),
+            confidence: 0.9,
+            cache_hit: false,
+            input_tokens: 0,
+            output_tokens: 0,
+            latency_ms: 12,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            classification: None,
+            pending_decision: Some("write to ci.yml?".to_string()),
+            proposed_default: Some("yes".to_string()),
+        }
+    }
+
+    #[test]
+    fn activity_from_response_derives_fields_and_tail() {
+        let resp = activity_response("line1\nline2\nline3\nline4\n");
+        let info = activity_from_response("sess-1".to_string(), resp);
+        assert_eq!(info.session_id, "sess-1");
+        assert_eq!(info.state, "working");
+        assert_eq!(info.summary, "running tests");
+        assert_eq!(info.pending_decision.as_deref(), Some("write to ci.yml?"));
+        assert_eq!(info.proposed_default.as_deref(), Some("yes"));
+        assert_eq!(info.raw_pane_tail, vec!["line2", "line3", "line4"]);
+        assert!(!info.stale);
+    }
+
+    #[test]
+    fn activity_from_response_handles_short_pane() {
+        let resp = activity_response("only one line");
+        let info = activity_from_response("sess-1".to_string(), resp);
+        assert_eq!(info.raw_pane_tail, vec!["only one line"]);
+    }
+
+    #[test]
+    fn tail_lines_keeps_last_n_non_empty_lines() {
+        let text = "a\nb\n\nc\nd\n";
+        assert_eq!(tail_lines(text, 2), vec!["c", "d"]);
+    }
+
+    #[test]
+    fn tail_lines_handles_fewer_lines_than_requested() {
+        assert_eq!(tail_lines("only", 3), vec!["only"]);
+        assert_eq!(tail_lines("", 3), Vec::<String>::new());
+    }
+
+    // ---- daemon-down branches (guaranteed-dead client, no live daemon needed) ---
+
+    /// A `127.0.0.1` URL bound to an ephemeral port, then immediately dropped
+    /// so a later connect is refused — mirrors
+    /// `tui::coordinator::tests::dead_loopback_url`.
+    fn dead_loopback_url() -> String {
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral loopback port");
+        let port = listener.local_addr().expect("read bound local addr").port();
+        drop(listener);
+        format!("http://127.0.0.1:{port}")
+    }
+
+    #[tokio::test]
+    async fn poll_marks_unreachable_clears_state() {
+        let discovered = crate::core::resolve_daemon_url(None);
+        let probe = DaemonClient::new(discovered.clone());
+        if probe.is_healthy().await {
+            eprintln!("skipping: a reachable daemon was discovered at {discovered}");
+            return;
+        }
+
+        let mut state = ProjectCtlState {
+            projects: vec![ProjectRow {
+                name: "widget".to_string(),
+                repo_url: "https://github.com/acme/widget".to_string(),
+                live_count: 1,
+                total_count: 1,
+            }],
+            daemon_reachable: true, // pretend a prior poll had succeeded
+            ..Default::default()
+        };
+        state
+            .sessions_by_project
+            .insert("widget".to_string(), vec![]);
+        let mut client = DaemonClient::new(dead_loopback_url());
+
+        project_ctl_poll_daemon(&mut state, &mut client).await;
+
+        assert!(!state.daemon_reachable);
+        assert!(state.projects.is_empty());
+        assert!(state.sessions_by_project.is_empty());
+    }
+
+    fn seeded_activity_state(session_id: &str) -> ProjectCtlState {
+        let mut state = ProjectCtlState {
+            projects: vec![ProjectRow {
+                name: "widget".to_string(),
+                repo_url: "https://github.com/acme/widget".to_string(),
+                live_count: 1,
+                total_count: 1,
+            }],
+            daemon_reachable: true,
+            ..Default::default()
+        };
+        state.sessions_by_project.insert(
+            "widget".to_string(),
+            vec![session_to_row(summary(session_id, "active"))],
+        );
+        state.projects_nav.sync_len(state.projects.len());
+        state.sessions_nav.sync_len(state.current_sessions().len());
+        state
+    }
+
+    /// `refresh_activity` is called directly (bypassing `project_ctl_poll_daemon`'s
+    /// own health probe) so this test stays deterministic regardless of whether
+    /// a real daemon happens to be discoverable on this machine — it only needs
+    /// the `/activity` HTTP call itself to fail, which a dead loopback port
+    /// guarantees.
+    #[tokio::test]
+    async fn refresh_activity_marks_existing_activity_stale_on_fetch_failure() {
+        let mut state = seeded_activity_state("s1");
+        state.activity = Some(ActivityInfo {
+            session_id: "s1".to_string(),
+            state: "working".to_string(),
+            summary: "last known summary".to_string(),
+            pending_decision: None,
+            proposed_default: None,
+            raw_pane_tail: vec!["$ cargo test".to_string()],
+            stale: false,
+        });
+        let client = DaemonClient::new(dead_loopback_url());
+
+        refresh_activity(&mut state, &client).await;
+
+        let activity = state
+            .activity
+            .expect("last-known activity must be kept, not discarded");
+        assert!(activity.stale, "a failed fetch must mark it stale");
+        assert_eq!(
+            activity.summary, "last known summary",
+            "the last-known data must be kept, not cleared"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_activity_clears_when_no_session_is_selected() {
+        let mut state = ProjectCtlState {
+            daemon_reachable: true,
+            activity: Some(ActivityInfo {
+                session_id: "orphaned".to_string(),
+                state: "working".to_string(),
+                summary: "stale from a since-deselected session".to_string(),
+                pending_decision: None,
+                proposed_default: None,
+                raw_pane_tail: vec![],
+                stale: false,
+            }),
+            ..Default::default()
+        };
+        let client = DaemonClient::new(dead_loopback_url());
+
+        refresh_activity(&mut state, &client).await;
+
+        assert!(state.activity.is_none());
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/state.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/state.rs
@@ -116,6 +116,46 @@ pub struct SessionRow {
     pub proposed_default: Option<String>,
 }
 
+/// Live per-session activity fetched from `GET .../{id}/activity` (DOC-35
+/// §5.4, #2119).
+///
+/// Why: the Activity pane skeleton (#2118) rendered only the already-polled
+/// STATIC [`SessionRow`] fields; this issue wires the pane to the live
+/// `/activity` endpoint instead. `session_id` is carried alongside the fetched
+/// fields (rather than trusting the caller to only ever read this when it is
+/// current) so [`ProjectCtlState::activity_for_selected`] can detect a fetch
+/// that has not yet caught up with a just-changed selection and fall back
+/// rather than showing one session's live data under another's header.
+/// `stale` marks a fetch that failed while the daemon was unreachable — the
+/// last-known data is KEPT rather than discarded (the issue's "graceful
+/// daemon-down behavior: stale-data indicator... recover when the daemon
+/// returns" requirement), and clears automatically the next time a fetch for
+/// the same session succeeds.
+/// What: the four DOC-35 §5.4 fields (`state`, `summary`, `pending_decision`,
+/// `proposed_default`) plus a short `raw_pane_tail` (the mockup's "last 3
+/// lines of raw_pane") and the `stale` flag.
+/// Test: `poll::tests::activity_from_response_*`,
+/// `panes::activity::tests::activity_lines_*`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActivityInfo {
+    /// The session this activity snapshot belongs to.
+    pub session_id: String,
+    /// Activity state word (`working`/`idle`/`blocked_on_permission`/
+    /// `errored`/`done`/`unknown`).
+    pub state: String,
+    /// Human-readable summary of what the session is doing.
+    pub summary: String,
+    /// A pending decision question, if surfaced.
+    pub pending_decision: Option<String>,
+    /// Proposed default answer to the pending decision.
+    pub proposed_default: Option<String>,
+    /// The last few lines of the session's raw tmux pane, oldest first.
+    pub raw_pane_tail: Vec<String>,
+    /// True when this snapshot is carried over from a prior successful fetch
+    /// because the daemon was unreachable on the most recent poll.
+    pub stale: bool,
+}
+
 /// Which destructive verb a [`PendingConfirm`] is gating.
 ///
 /// Why: DOC-35 §5.2 requires a confirmation gate before `k` (kill) executes
@@ -192,6 +232,14 @@ pub struct ProjectCtlState {
     ///
     /// [`handle_key`]: super::events::handle_key
     pub pending_confirm: Option<PendingConfirm>,
+    /// Live activity for the currently selected session (DOC-35 §5.4, #2119),
+    /// refreshed on the same poll cadence as `projects`/`sessions_by_project`.
+    /// `None` before the first successful fetch, when no session is selected,
+    /// or once the selection moves off the session this snapshot belongs to.
+    /// Read it through [`Self::activity_for_selected`], not directly, so a
+    /// mismatched (stale-selection) snapshot is never rendered under the
+    /// wrong session's header.
+    pub activity: Option<ActivityInfo>,
     /// Set when a mutating action just succeeded and the operator should see
     /// the fleet refreshed without waiting for the next timer tick.
     ///
@@ -240,6 +288,28 @@ impl ProjectCtlState {
     /// The currently selected session row, if any.
     pub fn selected_session(&self) -> Option<&SessionRow> {
         self.current_sessions().get(self.sessions_nav.selected())
+    }
+
+    /// The live [`ActivityInfo`] for the currently selected session, only
+    /// when it matches that session's id.
+    ///
+    /// Why: [`Self::activity`] is refreshed once per poll for whichever
+    /// session was selected AT THE TIME of that poll; if the operator moves
+    /// the Sessions-pane selection between polls, a stale fetch for the
+    /// PREVIOUS session must never render under the new session's header.
+    /// Comparing ids on every read (rather than clearing `activity` eagerly
+    /// on every selection change, which would need re-plumbing into every
+    /// selection-mutating call site) keeps the id-freshness rule in exactly
+    /// one place.
+    /// What: `None` when no session is selected, no fetch has landed yet, or
+    /// the last fetch's `session_id` no longer matches the current selection;
+    /// otherwise `Some(&ActivityInfo)`.
+    /// Test: `panes::activity::tests::activity_lines_falls_back_while_activity_is_stale_selection`.
+    pub fn activity_for_selected(&self) -> Option<&ActivityInfo> {
+        let selected_id = &self.selected_session()?.id;
+        self.activity
+            .as_ref()
+            .filter(|a| &a.session_id == selected_id)
     }
 
     /// Re-sync the Sessions-pane navigation to a freshly selected project.
@@ -438,6 +508,62 @@ mod tests {
         assert_eq!(confirm.session_label, "my-session");
         state.clear_confirm();
         assert!(state.pending_confirm.is_none());
+    }
+
+    fn activity(session_id: &str) -> ActivityInfo {
+        ActivityInfo {
+            session_id: session_id.to_string(),
+            state: "working".to_string(),
+            summary: "running tests".to_string(),
+            pending_decision: None,
+            proposed_default: None,
+            raw_pane_tail: vec!["$ cargo test".to_string()],
+            stale: false,
+        }
+    }
+
+    #[test]
+    fn activity_for_selected_matches_by_session_id() {
+        let mut state = ProjectCtlState {
+            projects: vec![row("a")],
+            ..Default::default()
+        };
+        state
+            .sessions_by_project
+            .insert("a".to_string(), vec![session("sess-1")]);
+        state.projects_nav.sync_len(state.projects.len());
+        state.sessions_nav.sync_len(state.current_sessions().len());
+        state.activity = Some(activity("sess-1"));
+        assert_eq!(
+            state.activity_for_selected().unwrap().summary,
+            "running tests"
+        );
+    }
+
+    #[test]
+    fn activity_for_selected_is_none_when_it_targets_a_different_session() {
+        let mut state = ProjectCtlState {
+            projects: vec![row("a")],
+            ..Default::default()
+        };
+        state
+            .sessions_by_project
+            .insert("a".to_string(), vec![session("sess-1")]);
+        state.projects_nav.sync_len(state.projects.len());
+        state.sessions_nav.sync_len(state.current_sessions().len());
+        // Simulates a fetch that landed for a session the selection has since
+        // moved off of.
+        state.activity = Some(activity("some-other-session"));
+        assert!(state.activity_for_selected().is_none());
+    }
+
+    #[test]
+    fn activity_for_selected_is_none_with_no_selection() {
+        let state = ProjectCtlState {
+            activity: Some(activity("sess-1")),
+            ..Default::default()
+        };
+        assert!(state.activity_for_selected().is_none());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -13,9 +13,9 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::events::{PendingAction, handle_key};
 use super::panes::{actions_bar, projects, sessions};
-use super::poll::{project_to_row, session_to_row};
-use super::state::{Pane, ProjectCtlState};
-use crate::client::{FleetProjectGroupWire, ManagedSessionSummary};
+use super::poll::{project_ctl_poll_daemon, project_to_row, session_to_row};
+use super::state::{ConfirmKind, Pane, ProjectCtlState};
+use crate::client::{DaemonClient, FleetProjectGroupWire, ManagedSessionSummary};
 use crate::project::Project;
 
 fn project(name: &str) -> Project {
@@ -151,4 +151,41 @@ fn action_bar_reflects_daemon_reachability_by_default() {
     // Freshly seeded state (no poll ran) starts unreachable, matching the
     // real poller's default until the first health probe succeeds.
     assert!(actions_bar::bar_text(&state).contains(actions_bar::DAEMON_UNREACHABLE));
+}
+
+/// A `127.0.0.1` URL bound to an ephemeral port, then immediately dropped so
+/// a later connect is refused — mirrors
+/// `tui::coordinator::tests::dead_loopback_url` / `poll::tests::dead_loopback_url`.
+fn dead_loopback_url() -> String {
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral loopback port");
+    let port = listener.local_addr().expect("read bound local addr").port();
+    drop(listener);
+    format!("http://127.0.0.1:{port}")
+}
+
+/// A daemon poll racing with an open confirmation gate must never reassign or
+/// clear it (DOC-35 §5.2) — the gate pins its target session id at the moment
+/// it opens, and a refresh (even one that clears the whole fleet, as a
+/// daemon-down poll does) must leave that pin untouched. This is the
+/// regression test the #2119 task explicitly calls for on any change that
+/// touches the refresh path.
+#[tokio::test]
+async fn poll_never_touches_pending_confirm() {
+    let mut state = seeded_state();
+    state.request_confirm(
+        ConfirmKind::Decommission,
+        "a1b2c3d4e5f6",
+        "trusty-tools-session",
+    );
+    let before = state.pending_confirm.clone().expect("confirm requested");
+
+    let mut client = DaemonClient::new(dead_loopback_url());
+    project_ctl_poll_daemon(&mut state, &mut client).await;
+
+    assert_eq!(
+        state.pending_confirm,
+        Some(before),
+        "a poll must never mutate an open confirmation gate's pinned target"
+    );
 }


### PR DESCRIPTION
## Summary

Wires the `tm projects` 4-pane TUI's Activity pane to the live
`GET /api/v1/sessions/managed/{id}/activity` endpoint (DOC-35 §5.4),
replacing the #2118 skeleton's static-record-field placeholder. This is
slice 6 of the `tm project` control-plane epic (#2108), depends on the
#2118 skeleton (`ea895585`, merged), and closes #2119.

## What shipped

- **`ActivityInfo`** (`state.rs`) — a lean render-ready projection of
  `ManagedActivityResponse`: `state`, `summary`, `pending_decision`,
  `proposed_default`, a bounded `raw_pane_tail` (last 3 non-empty lines,
  matching the DOC-35 §5.1 mockup), and a `stale` flag.
- **`refresh_activity`** (`poll.rs`) — a new step in
  `project_ctl_poll_daemon`, run after the existing Projects/Sessions
  refresh, that fetches the currently selected session's `/activity`
  endpoint on the same poll cadence.
- **`activity_for_selected()`** (`state.rs`) — gates every read of the
  live snapshot on a `session_id` match, so a fetch that hasn't caught
  up with a just-changed selection is never rendered under the wrong
  session's header.
- **Activity pane rewrite** (`panes/activity.rs`) — four render shapes:
  no session selected; live data available (optionally suffixed
  `[stale]`); daemon reachable but no live fetch has landed yet for
  this selection ("loading live activity…"); daemon down with nothing
  live to show ("daemon unreachable — live activity unavailable").

## Refresh design

The #2118 skeleton's `run_loop` (`mod.rs`) already implemented DOC-35
§5.3's timer-poll (`--interval-ms`, default 1500ms) plus immediate
repoll-after-mutation via `ProjectCtlState::request_repoll` — **no
changes were needed there**. This PR adds a third HTTP call
(`GET .../{id}/activity`) inside the same `project_ctl_poll_daemon`
step, made only when a session is selected, so it inherits the
existing cadence/repoll behavior for free. Projects/Sessions panes are
one fleet call regardless of project count (unchanged); only the one
*selected* session gets the extra live-activity fetch, never the whole
list.

## Daemon-down behavior

- **No session selected**: `activity` is cleared.
- **A session is selected, daemon down or the fetch fails**: if the
  existing `activity` snapshot already targets this session, it is kept
  and marked `stale: true` (never discarded) — the pane renders it with
  a `[stale]` suffix. If there's no prior snapshot for this session, the
  pane shows an explicit "daemon unreachable — live activity
  unavailable" message (never a silent blank pane).
- **Recovery**: the next successful poll replaces `activity` outright
  with fresh, non-stale data — no manual reset needed.

## Confirmation-gate invariant (DOC-35 §5.2)

The task explicitly required that refresh logic never invalidate a
pending confirm's session binding. `project_ctl_poll_daemon` was
audited and never touches `pending_confirm`; added a regression test,
`poll_never_touches_pending_confirm` (`tests.rs`), that opens a confirm
gate, runs a full poll against a dead daemon (which clears the entire
fleet), and asserts the gate's `kind`/`session_id`/`session_label` are
byte-for-byte unchanged.

## Disclosed deviations from the cited spec sections

1. **`task` dropped from the live Activity-pane view.** The #2118
   skeleton rendered the session's `task` field in the Activity pane;
   DOC-35 §5.4 lists exactly `state`/`summary`/`pending_decision`/
   `proposed_default` as the live fields, with no mention of `task`. The
   live-data render path now shows only the spec's four fields (plus
   the raw-pane tail per §5.1's mockup) — `task` is omitted rather than
   added as an extra. It is still visible via `tm sessions list`/the
   Sessions pane.
2. **No immediate repoll on selection change.** Moving the
   Sessions-pane selection does not trigger an out-of-cadence refetch —
   the Activity pane falls back to a "loading live activity…" message
   (using the static record fields) for up to one `--interval-ms` tick.
   This matches §5.3's literal text ("timer-poll... plus an immediate
   re-poll after any **mutating action**") — selection is not a
   mutation — and DOC-16 §9's "no event-stream/push channel in v1"
   deferral this spec explicitly inherits.

Neither is a scope gap against the issue's text; both are noted here
per this repo's "every deviation from spec MUST be disclosed" rule.

## Test evidence

- `cargo test -p trusty-mpm --lib tui::project_ctl` — 66 passed, 0
  failed (up from the pre-existing skeleton's tests; new coverage:
  `ActivityInfo`/`activity_for_selected` unit tests, `poll.rs`'s
  `activity_from_response`/`tail_lines`/`refresh_activity` unit +
  async tests against a guaranteed-dead loopback client, all six
  `activity_lines` render-shape tests, and the cross-module
  `poll_never_touches_pending_confirm` regression).
- `cargo test --workspace` — full suite, 0 failures.
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 errors
  (pre-existing unrelated warnings only: `tga` MSRV note, pnpm
  placeholder-UI warnings, duplicate bin-target warnings).
- `cargo fmt --check` — clean.
- `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations — OK`
  (largest touched file, `poll.rs`, is well under the 500-SLOC
  production cap).

## Files changed

- `crates/trusty-mpm/src/tui/project_ctl/state.rs` (+126 lines) —
  `ActivityInfo`, `ProjectCtlState::activity`,
  `activity_for_selected()`.
- `crates/trusty-mpm/src/tui/project_ctl/poll.rs` (+~290 net) —
  `refresh_activity`, `activity_from_response`, `tail_lines`, plus
  daemon-down/confirm-gate tests.
- `crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs` (rewrite,
  ~204 line diff) — live-data render path + four-shape test suite.
- `crates/trusty-mpm/src/tui/project_ctl/panes/mod.rs` (doc comment
  only).
- `crates/trusty-mpm/src/tui/project_ctl/tests.rs` (+43 lines) —
  `poll_never_touches_pending_confirm`.

Not merging — adversarial review requested first.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools