### PR TITLE
test(trusty-code): make cadence override test hermetic (fix pre-existing CI flake)

### DIFF
--- a/crates/trusty-code/src/agent_loop/cadence_env_helper.rs
+++ b/crates/trusty-code/src/agent_loop/cadence_env_helper.rs
@@ -1,0 +1,47 @@
+//! Shared test helper for cadence environment variable mutation tests.
+//!
+//! Serializes tests that mutate the process-wide cadence env vars, mirroring
+//! `crate::mode::MODE_ENV_LOCK`'s identical rationale. All cadence-related
+//! tests (across cadence_tests.rs and other test modules) must use
+//! `with_cadence_env` to prevent env-var races under cargo's parallel scheduler.
+
+/// Serializes tests that mutate the process-wide cadence env vars, mirroring
+/// `crate::mode::MODE_ENV_LOCK`'s identical rationale.
+pub(crate) static CADENCE_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Wraps a test function to safely mutate cadence env vars with serialization.
+///
+/// Holds `CADENCE_ENV_LOCK` for the duration of the closure, preventing
+/// concurrent env-var races. Sets the specified env vars before the closure
+/// and clears them after, ensuring hermetic test isolation.
+///
+/// # Arguments
+/// - `turns`: If `Some`, sets `TCODE_CADENCE_TURNS` to this value; if `None`, removes it.
+/// - `pct`: If `Some`, sets `TCODE_CADENCE_MAX_OVERHEAD_FRACTION_PCT` to this value; if `None`, removes it.
+/// - `f`: The closure to execute with the env vars set.
+pub(crate) async fn with_cadence_env<T>(
+    turns: Option<&str>,
+    pct: Option<&str>,
+    f: impl FnOnce() -> T,
+) -> T {
+    use super::cadence::{CADENCE_OVERHEAD_FRACTION_ENV_VAR, CADENCE_TURNS_ENV_VAR};
+
+    let _guard = CADENCE_ENV_LOCK.lock().await;
+    // SAFETY: test-only env mutation, serialized by `CADENCE_ENV_LOCK`.
+    unsafe {
+        match turns {
+            Some(v) => std::env::set_var(CADENCE_TURNS_ENV_VAR, v),
+            None => std::env::remove_var(CADENCE_TURNS_ENV_VAR),
+        }
+        match pct {
+            Some(v) => std::env::set_var(CADENCE_OVERHEAD_FRACTION_ENV_VAR, v),
+            None => std::env::remove_var(CADENCE_OVERHEAD_FRACTION_ENV_VAR),
+        }
+    }
+    let result = f();
+    unsafe {
+        std::env::remove_var(CADENCE_TURNS_ENV_VAR);
+        std::env::remove_var(CADENCE_OVERHEAD_FRACTION_ENV_VAR);
+    }
+    result
+}

--- a/crates/trusty-code/src/agent_loop/cadence_tests.rs
+++ b/crates/trusty-code/src/agent_loop/cadence_tests.rs
@@ -5,32 +5,8 @@
 
 use super::super::CompactionConfig;
 use super::*;
+use crate::agent_loop::with_cadence_env;
 use crate::llm::{ChatMessage, FunctionCall, ToolCall};
-
-/// Serializes tests that mutate the process-wide cadence env vars, mirroring
-/// `crate::mode::MODE_ENV_LOCK`'s identical rationale.
-static CADENCE_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-async fn with_cadence_env<T>(turns: Option<&str>, pct: Option<&str>, f: impl FnOnce() -> T) -> T {
-    let _guard = CADENCE_ENV_LOCK.lock().await;
-    // SAFETY: test-only env mutation, serialized by `CADENCE_ENV_LOCK`.
-    unsafe {
-        match turns {
-            Some(v) => std::env::set_var(CADENCE_TURNS_ENV_VAR, v),
-            None => std::env::remove_var(CADENCE_TURNS_ENV_VAR),
-        }
-        match pct {
-            Some(v) => std::env::set_var(CADENCE_OVERHEAD_FRACTION_ENV_VAR, v),
-            None => std::env::remove_var(CADENCE_OVERHEAD_FRACTION_ENV_VAR),
-        }
-    }
-    let result = f();
-    unsafe {
-        std::env::remove_var(CADENCE_TURNS_ENV_VAR);
-        std::env::remove_var(CADENCE_OVERHEAD_FRACTION_ENV_VAR);
-    }
-    result
-}
 
 fn project_with_settings(json: Option<&str>) -> tempfile::TempDir {
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/trusty-code/src/agent_loop/cadence_tests.rs
+++ b/crates/trusty-code/src/agent_loop/cadence_tests.rs
@@ -134,41 +134,53 @@ async fn resolve_cadence_config_env_wins_over_settings_json() {
 /// fired at all — proving the settings.json override is what changed the
 /// observed behaviour, not some incidental default.
 /// Test: this test.
-#[test]
-fn settings_json_cadence_turns_override_changes_fire_schedule_end_to_end() {
+///
+/// Hermeticity: `resolve_cadence_config` reads the process-global
+/// `TCODE_CADENCE_TURNS` / `TCODE_CADENCE_MAX_OVERHEAD_FRACTION_PCT` env vars,
+/// which the sibling `resolve_cadence_config_env_wins_over_settings_json` test
+/// sets to `"5"`/`"50"` while it runs. This test therefore resolves under
+/// `with_cadence_env(None, None, …)` — holding `CADENCE_ENV_LOCK` and forcing
+/// the env vars unset — so a concurrent env-setting test cannot bleed its
+/// `TCODE_CADENCE_TURNS=5` into this resolver and make the `== 3` assertion
+/// observe `5` (the pre-existing flake this guards against).
+#[tokio::test]
+async fn settings_json_cadence_turns_override_changes_fire_schedule_end_to_end() {
     let project = project_with_settings(Some(r#"{"code_harness": {"cadence_turns": 3}}"#));
-    let overridden_cfg = resolve_cadence_config(project.path());
-    assert_eq!(overridden_cfg.cadence_turns, 3);
+    with_cadence_env(None, None, || {
+        let overridden_cfg = resolve_cadence_config(project.path());
+        assert_eq!(overridden_cfg.cadence_turns, 3);
 
-    let context_window = 1_000_000;
-    let mut overridden_transcript = Transcript::seed("s", "task");
-    for turn in 1..=4 {
-        push_sized_turn(&mut overridden_transcript, turn, 10);
-        maybe_cadence_compress(
-            &mut overridden_transcript,
-            &overridden_cfg,
+        let context_window = 1_000_000;
+        let mut overridden_transcript = Transcript::seed("s", "task");
+        for turn in 1..=4 {
+            push_sized_turn(&mut overridden_transcript, turn, 10);
+            maybe_cadence_compress(
+                &mut overridden_transcript,
+                &overridden_cfg,
+                1,
+                context_window,
+            );
+        }
+        assert_eq!(
+            overridden_transcript.cadence_fire_count(),
             1,
-            context_window,
+            "cadence_turns=3 from settings.json must have fired once by turn 4"
         );
-    }
-    assert_eq!(
-        overridden_transcript.cadence_fire_count(),
-        1,
-        "cadence_turns=3 from settings.json must have fired once by turn 4"
-    );
 
-    let default_cfg = CadenceConfig::default();
-    let mut default_transcript = Transcript::seed("s", "task");
-    for turn in 1..=4 {
-        push_sized_turn(&mut default_transcript, turn, 10);
-        maybe_cadence_compress(&mut default_transcript, &default_cfg, 1, context_window);
-    }
-    assert_eq!(
-        default_transcript.cadence_fire_count(),
-        0,
-        "the built-in default (cadence_turns=8) must NOT have fired by turn 4 — \
-         proving the settings.json override, not the default, drove the difference"
-    );
+        let default_cfg = CadenceConfig::default();
+        let mut default_transcript = Transcript::seed("s", "task");
+        for turn in 1..=4 {
+            push_sized_turn(&mut default_transcript, turn, 10);
+            maybe_cadence_compress(&mut default_transcript, &default_cfg, 1, context_window);
+        }
+        assert_eq!(
+            default_transcript.cadence_fire_count(),
+            0,
+            "the built-in default (cadence_turns=8) must NOT have fired by turn 4 — \
+             proving the settings.json override, not the default, drove the difference"
+        );
+    })
+    .await;
 }
 
 /// Cadence fires exactly every N turns (N=3 override) — not on any other

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -42,6 +42,10 @@ mod sink;
 mod transcript;
 
 #[cfg(test)]
+mod cadence_env_helper;
+#[cfg(test)]
+pub(crate) use cadence_env_helper::with_cadence_env;
+#[cfg(test)]
 mod tests;
 
 use std::sync::Arc;

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -11,6 +11,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use super::*;
+use crate::agent_loop::with_cadence_env;
 use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
 use crate::session::{SessionRegistry, SessionStatus};
 use crate::task::mock_llm::EchoLlmClient;
@@ -159,24 +160,36 @@ fn daily_driver_skills_catalog_none_when_no_skills_dir() {
 /// `cadence_turns` to `3`; assert `crate::agent_loop::resolve_cadence_config`
 /// against `p.project` returns `3`, not the built-in default of `8`.
 /// Test: this test.
-#[test]
-fn settings_json_cadence_turns_override_reaches_resolver() {
-    let agents = agents_dir();
-    let project = tempfile::tempdir().expect("project tempdir");
-    std::fs::create_dir_all(project.path().join(".claude")).expect("mkdir .claude");
-    std::fs::write(
-        project.path().join(".claude").join("settings.json"),
-        r#"{"code_harness": {"cadence_turns": 3}}"#,
-    )
-    .expect("write settings.json");
+///
+/// Hermeticity: `resolve_cadence_config` reads the process-global
+/// `TCODE_CADENCE_TURNS` env var, which the sibling
+/// `crate::agent_loop::cadence::tests::resolve_cadence_config_env_wins_over_settings_json`
+/// test sets to `"5"` while it runs. This test therefore resolves under
+/// `with_cadence_env(None, None, …)` — holding `CADENCE_ENV_LOCK` and forcing
+/// the env var unset — so a concurrent env-setting test cannot bleed its
+/// `TCODE_CADENCE_TURNS=5` into this resolver and make the `== 3` assertion
+/// observe `5` (fixing the pre-existing flake this test guards against).
+#[tokio::test]
+async fn settings_json_cadence_turns_override_reaches_resolver() {
+    with_cadence_env(None, None, || {
+        let agents = agents_dir();
+        let project = tempfile::tempdir().expect("project tempdir");
+        std::fs::create_dir_all(project.path().join(".claude")).expect("mkdir .claude");
+        std::fs::write(
+            project.path().join(".claude").join("settings.json"),
+            r#"{"code_harness": {"cadence_turns": 3}}"#,
+        )
+        .expect("write settings.json");
 
-    let p = params(&agents, &project, "s");
-    let cfg = crate::agent_loop::resolve_cadence_config(&p.project);
-    assert_eq!(cfg.cadence_turns, 3);
-    assert_ne!(
-        cfg.cadence_turns,
-        crate::agent_loop::CadenceConfig::default().cadence_turns
-    );
+        let p = params(&agents, &project, "s");
+        let cfg = crate::agent_loop::resolve_cadence_config(&p.project);
+        assert_eq!(cfg.cadence_turns, 3);
+        assert_ne!(
+            cfg.cadence_turns,
+            crate::agent_loop::CadenceConfig::default().cadence_turns
+        );
+    })
+    .await;
 }
 
 /// `daily_driver_skills_catalog` returns the rendered catalog + a working


### PR DESCRIPTION
## Summary

Fixes a pre-existing CI flake in `settings_json_cadence_turns_override…` test caused by parallel test env-var bleed.

## Root Cause

Sibling tests set `TCODE_CADENCE_TURNS=5` without holding `CADENCE_ENV_LOCK`, so the resolver reads 5 instead of settings.json's configured 3, tripping the assertion at `cadence_tests.rs:141`. This causes intermittent CI failures on any PR when tests run in parallel.

## Fix

Wrap the test body in `with_cadence_env` to serialize environment access and clear the env-var state after the test completes. This ensures the cadence resolver reads the correct settings.json value regardless of sibling test execution order.

## Test Only

This is a test-only change to `crates/trusty-code/src/agent_loop/cadence_tests.rs` making the test hermetic. No production code is modified.

## Unblocks

- PR #2427 and all other in-flight PRs affected by this CI flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)