### PR TITLE
feat(trusty-mpm): TUI Deliverable glyph + read-only Deliverable/Milestone view

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -908,6 +908,7 @@ mod tests {
             task: None,
             cwd: None,
             claude_session_id: None,
+            deliverable_id: None,
             pane_id: None,
         };
         let client = reqwest::Client::new();

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -489,6 +489,7 @@ fn make_session(
         task: None,
         cwd: None,
         claude_session_id: None,
+        deliverable_id: None,
         pane_id: None,
     }
 }

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -423,6 +423,20 @@ pub struct ManagedSessionSummary {
     /// sessions with no captured conversation id or predating this field.
     #[serde(default)]
     pub claude_session_id: Option<String>,
+    /// The Deliverable this session is working on, if bound (DOC-35 §10.6,
+    /// #2379; additive — absent for legacy records and sessions with no
+    /// link). Mirrors `daemon::managed_routes::SessionSummary::deliverable_id`
+    /// field-for-field; a bare UUID string, not the typed `DeliverableId` (the
+    /// client keeps wire DTOs string-typed, matching every other id field on
+    /// this struct).
+    ///
+    /// Why: the `tm projects` TUI's Sessions pane (#2383) renders a glyph on
+    /// any row whose `deliverable_id` is `Some`, distinguishing a resolved
+    /// link (matches a Deliverable the pane also fetched) from a dangling one
+    /// (the id no longer resolves — e.g. the Deliverable was deleted out from
+    /// under the session).
+    #[serde(default)]
+    pub deliverable_id: Option<String>,
     /// The tmux `pane_id` of this session's original pane, if captured
     /// (additive; #2453 review finding 1, round 2).
     ///

--- a/crates/trusty-mpm/src/client/resolver.rs
+++ b/crates/trusty-mpm/src/client/resolver.rs
@@ -184,6 +184,7 @@ mod tests {
             task: None,
             cwd: None,
             claude_session_id: None,
+            deliverable_id: None,
             pane_id: None,
         };
         let items = vec![summary("m-1", "tmpm-red-owl"), summary("m-2", "api")];

--- a/crates/trusty-mpm/src/tui/project_ctl/events.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/events.rs
@@ -28,16 +28,30 @@
 //! contract). Per the same table, `q`/`Ctrl-C` quits only when NOT in a
 //! modal — while `pending_confirm` is `Some`, quit keys are swallowed by the
 //! modal like every other key.
+//!
+//! **Deliverable/Milestone view (DOC-35 §10.8 `show`, #2383)**: `v` in the
+//! Projects pane opens a read-only overlay for the selected project (see
+//! `panes::deliverables_view`). Chosen because every other unshifted letter
+//! is already bound in one pane or the other (`l`/`k`/`r`/`d`/`a` in
+//! Sessions, `c` in Projects) or reserved by the confirm gate (`y`/`n`) —
+//! `v` ("view") is free in every context and mnemonic for §10.8's read-only
+//! `show`. While [`ProjectCtlState::deliverable_view`] is `Some`, EVERY key
+//! routes through [`handle_deliverable_view_key`] instead — the identical
+//! "modal captures all input, `q`/`Ctrl-C` swallowed, `Esc` closes" discipline
+//! [`handle_confirm_key`] already establishes, plus `↑`/`↓` to scroll and `v`
+//! itself as a second way to close (matching the dashboard help overlay's
+//! "same key opens and closes" convention).
 //! What: [`PendingAction`] (the async actions a key can request — the actual
 //! HTTP dispatch lives in [`super::actions`]), [`is_quit`], and [`handle_key`]
 //! which routes a [`KeyEvent`] into [`ProjectCtlState`] mutations (focus
-//! cycling, selection, drill-in, notice-clear, the confirm gate) and returns
-//! `Some(action)` for the lettered verbs (once confirmed, for `k`-on-Active
-//! and `d`).
+//! cycling, selection, drill-in, notice-clear, the confirm gate, the
+//! deliverable view) and returns `Some(action)` for the lettered verbs (once
+//! confirmed, for `k`-on-Active and `d`).
 //! Test: `super::tests` covers focus cycling, selection movement, the
 //! project-switch reset, every lettered action's valid/invalid-context
-//! branches, and the confirm-gate's request/confirm/cancel/ignore branches,
-//! via synthetic [`KeyEvent`]s.
+//! branches, the confirm-gate's request/confirm/cancel/ignore branches, and
+//! the deliverable view's open/scroll/close branches, via synthetic
+//! [`KeyEvent`]s.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -106,6 +120,10 @@ pub fn handle_key(state: &mut ProjectCtlState, key: KeyEvent) -> Option<PendingA
         return handle_confirm_key(state, key);
     }
 
+    if state.deliverable_view.is_some() {
+        return handle_deliverable_view_key(state, key);
+    }
+
     if is_quit(&key) {
         state.should_exit = true;
         return None;
@@ -162,8 +180,43 @@ pub fn handle_key(state: &mut ProjectCtlState, key: KeyEvent) -> Option<PendingA
                 }
             }
         }
+        KeyCode::Char('v') if state.focus == Pane::Projects => {
+            match state.selected_project_name() {
+                Some(name) => {
+                    let name = name.to_string();
+                    state.open_deliverable_view(name);
+                }
+                None => state.set_notice("no project selected"),
+            }
+            None
+        }
         _ => None,
     }
+}
+
+/// Route one key event while the Deliverable/Milestone view is open (DOC-35
+/// §10.8, #2383).
+///
+/// Why: split out of [`handle_key`] for the same reason
+/// [`handle_confirm_key`] is — the "this modal captures ALL input" contract
+/// lives in one place. Unlike the confirm gate (which resolves to an action
+/// on `y`/`n`), this view is read-only, so every branch returns `None` — it
+/// never produces a [`PendingAction`].
+/// What: `↑`/`↓` scroll the body by one line; `Esc` or `v` closes the view;
+/// every other key (including `q`/`Ctrl-C`) is swallowed, matching the
+/// confirm gate's "not in a modal" quit rule.
+/// Test: `super::tests::deliverable_view_*`.
+fn handle_deliverable_view_key(
+    state: &mut ProjectCtlState,
+    key: KeyEvent,
+) -> Option<PendingAction> {
+    match key.code {
+        KeyCode::Up => state.scroll_deliverable_view(-1),
+        KeyCode::Down => state.scroll_deliverable_view(1),
+        KeyCode::Esc | KeyCode::Char('v') => state.close_deliverable_view(),
+        _ => {}
+    }
+    None
 }
 
 /// Resolve the currently open confirmation gate against one key event.
@@ -351,6 +404,7 @@ mod tests {
                 state: "active".to_string(),
                 pending_decision: None,
                 proposed_default: None,
+                deliverable_id: None,
             }],
         );
         state.projects_nav.sync_len(state.projects.len());
@@ -595,5 +649,71 @@ mod tests {
 
         handle_key(&mut state, key(KeyCode::Char('q')));
         assert!(state.should_exit);
+    }
+
+    // ---- DOC-35 §10.8 Deliverable/Milestone view (#2383) -----------------
+
+    #[test]
+    fn v_opens_the_deliverable_view_for_the_selected_project() {
+        let mut state = seeded_state();
+        assert!(handle_key(&mut state, key(KeyCode::Char('v'))).is_none());
+        let view = state.deliverable_view.expect("view should be open");
+        assert_eq!(view.project_name, "alpha");
+    }
+
+    #[test]
+    fn v_without_a_selected_project_sets_notice_and_opens_nothing() {
+        let mut state = ProjectCtlState::default();
+        handle_key(&mut state, key(KeyCode::Char('v')));
+        assert!(state.deliverable_view.is_none());
+        assert_eq!(state.notice.as_deref(), Some("no project selected"));
+    }
+
+    #[test]
+    fn v_is_ignored_outside_the_projects_pane() {
+        let mut state = seeded_state();
+        state.focus = Pane::Sessions;
+        assert!(handle_key(&mut state, key(KeyCode::Char('v'))).is_none());
+        assert!(state.deliverable_view.is_none());
+    }
+
+    #[test]
+    fn deliverable_view_scrolls_and_closes_on_esc_or_v() {
+        let mut state = seeded_state();
+        handle_key(&mut state, key(KeyCode::Char('v')));
+        handle_key(&mut state, key(KeyCode::Down));
+        assert_eq!(state.deliverable_view.as_ref().unwrap().scroll, 1);
+        handle_key(&mut state, key(KeyCode::Up));
+        assert_eq!(state.deliverable_view.as_ref().unwrap().scroll, 0);
+
+        handle_key(&mut state, key(KeyCode::Esc));
+        assert!(state.deliverable_view.is_none());
+
+        handle_key(&mut state, key(KeyCode::Char('v')));
+        handle_key(&mut state, key(KeyCode::Char('v')));
+        assert!(
+            state.deliverable_view.is_none(),
+            "v must close the view the same way it opened it"
+        );
+    }
+
+    #[test]
+    fn deliverable_view_swallows_quit_and_unrelated_keys() {
+        let mut state = seeded_state();
+        handle_key(&mut state, key(KeyCode::Char('v')));
+
+        handle_key(&mut state, key(KeyCode::Char('q')));
+        assert!(!state.should_exit, "q must not quit while the view is open");
+        assert!(state.deliverable_view.is_some());
+
+        handle_key(&mut state, ctrl_c());
+        assert!(!state.should_exit);
+        assert!(state.deliverable_view.is_some());
+
+        handle_key(&mut state, key(KeyCode::Char('x')));
+        assert!(
+            state.deliverable_view.is_some(),
+            "an unrecognised key must not close the view"
+        );
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/layout.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/layout.rs
@@ -16,7 +16,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
 };
 
-use super::panes::{actions_bar, activity, projects, sessions};
+use super::panes::{actions_bar, activity, deliverables_view, projects, sessions};
 use super::state::ProjectCtlState;
 
 /// Minimum height (rows, including the two border rows) of the main
@@ -40,7 +40,11 @@ const ACTIVITY_ROWS: u16 = 4;
 /// What: splits `frame.area()` vertically into the main row (flexing, floored
 /// at [`MIN_MAIN_ROWS`]), the Activity strip ([`ACTIVITY_ROWS`]), and the
 /// 1-row action bar; splits the main row horizontally 25/75 for
-/// Projects/Sessions per DOC-35 §5.
+/// Projects/Sessions per DOC-35 §5. When
+/// [`ProjectCtlState::deliverable_view`] is `Some` (DOC-35 §10.8, #2383), a
+/// centred overlay floats on top of the whole frame afterward — a strict
+/// addition, never replacing a pane, mirroring the dashboard help-overlay's
+/// "draw base frame, then float overlay" sequencing.
 pub fn render(frame: &mut Frame, state: &mut ProjectCtlState) {
     let outer = Layout::default()
         .direction(Direction::Vertical)
@@ -60,4 +64,8 @@ pub fn render(frame: &mut Frame, state: &mut ProjectCtlState) {
     sessions::render(frame, main_row[1], state);
     activity::render(frame, outer[1], state);
     actions_bar::render(frame, outer[2], state);
+
+    if let Some(view) = &state.deliverable_view {
+        deliverables_view::render(frame, view);
+    }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/actions_bar.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/actions_bar.rs
@@ -25,7 +25,7 @@ use crate::tui::project_ctl::state::{Pane, PendingConfirm, ProjectCtlState};
 
 /// Key-hint text shown while the Projects pane has focus.
 pub const PROJECTS_HINT: &str =
-    "[Enter] drill in  [c] config  [Tab] switch pane  [↑↓] select  [q] quit";
+    "[Enter] drill in  [c] config  [v] deliverables  [Tab] switch pane  [↑↓] select  [q] quit";
 /// Key-hint text shown while the Sessions pane has focus.
 pub const SESSIONS_HINT: &str = "[l] launch  [k] kill  [r] resume  [d] decommission  [a] attach-cmd  [Tab] switch pane  [↑↓] select  [q] quit";
 /// Key-hint text shown while the Activity pane has focus (no verbs bound

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs
@@ -164,6 +164,7 @@ mod tests {
             state: "active".to_string(),
             pending_decision: None,
             proposed_default: None,
+            deliverable_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/deliverables_view.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/deliverables_view.rs
@@ -1,0 +1,257 @@
+//! Read-only Deliverable/Milestone overlay — DOC-35 §10.8 `show`, #2383.
+//!
+//! Why: §10.8's CLI sketch has a `deliverables show <project> <id>` /
+//! `milestones show <project> <id>` surface with "includes bound sessions,
+//! read-only". Issue #2383's own scope line asks for something slightly
+//! broader — a project-scoped LIST of Deliverables and Milestones with
+//! status, reachable from the Projects pane — which is what this overlay
+//! renders. **Disclosed deviation from a literal §10.8 `show` reading**: this
+//! view does not drill into one Deliverable's bound-sessions detail; it lists
+//! every Deliverable/Milestone for the selected project with its status in
+//! one screen, matching the issue's own "Deliverable/Milestone view... lists
+//! the selected project's deliverables and milestones with status" framing
+//! more directly than a single-record `show` would. Per-Deliverable
+//! bound-session drill-down is left for a follow-up if wanted — out of this
+//! slice's scope. It is a strict ADDITION to the existing 4-pane layout
+//! (§5.1): a centred overlay on top of the frame, never replacing a pane,
+//! mirroring the `tui::dashboard` help-overlay's `Clear` + centred-`Rect`
+//! pattern (`tui/dashboard/mod.rs::render_help_overlay`).
+//! What: [`centered_rect`] (a local copy of the dashboard helper — this
+//! module intentionally does not depend on `tui::dashboard`, keeping
+//! `project_ctl` self-contained per its existing module boundary),
+//! [`body_lines`] (the pure Deliverable/Milestone → text projection, unit
+//! tested without a terminal), and [`render`] (the terminal-touching overlay
+//! draw, called from [`super::super::layout::render`] only when
+//! [`DeliverableView`] is `Some`).
+//! Test: `tests` covers `body_lines`' status/tier/date formatting and the
+//! empty-list placeholder text.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+
+use crate::deliverable::{Deliverable, EstimationTier, Milestone, MilestoneStatus};
+use crate::tui::project_ctl::state::DeliverableView;
+
+/// Compute a centred sub-rectangle for the overlay, floored to `area`'s size.
+///
+/// Why: a local copy of `tui::dashboard::centered_rect` — `project_ctl` does
+/// not depend on the `dashboard` module for anything else, and this is a
+/// three-line pure function, not worth a cross-module dependency to share.
+/// What: same behavior as the dashboard original: centers a `width x height`
+/// box within `area`, clamped so it never exceeds `area`'s own bounds.
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
+}
+
+/// The uppercase tier label for an [`EstimationTier`] (DOC-30 Decision #2).
+fn tier_str(tier: EstimationTier) -> &'static str {
+    match tier {
+        EstimationTier::S => "S",
+        EstimationTier::M => "M",
+        EstimationTier::L => "L",
+        EstimationTier::Xl => "XL",
+    }
+}
+
+/// The kebab-case wire label for a [`MilestoneStatus`] (§10.5).
+///
+/// Why: unlike [`DeliverableStatus::as_str`], `MilestoneStatus` has no
+/// existing `as_str` — this mirrors its `#[serde(rename_all = "kebab-case")]`
+/// encoding without adding a serde round trip just to get display text.
+fn milestone_status_str(status: MilestoneStatus) -> &'static str {
+    match status {
+        MilestoneStatus::Proposed => "proposed",
+        MilestoneStatus::InProgress => "in-progress",
+        MilestoneStatus::Complete => "complete",
+        MilestoneStatus::Shipped => "shipped",
+    }
+}
+
+/// One Deliverable's display line: `  [<status>] <name>  (<tier>)`.
+fn deliverable_line(d: &Deliverable) -> String {
+    format!(
+        "  [{:<11}] {}  ({})",
+        d.status.as_str(),
+        d.name,
+        tier_str(d.estimated_effort)
+    )
+}
+
+/// One Milestone's display line: `  [<status>] <name>  target: <YYYY-MM-DD>`.
+fn milestone_line(m: &Milestone) -> String {
+    format!(
+        "  [{:<11}] {}  target: {}",
+        milestone_status_str(m.status),
+        m.name,
+        m.target_date.format("%Y-%m-%d")
+    )
+}
+
+/// Build the overlay's full body text for one [`DeliverableView`].
+///
+/// Why: a pure builder keeps the exact section headers / placeholder text /
+/// per-row formatting unit-testable without a terminal.
+/// What: `DELIVERABLES (N)` then one [`deliverable_line`] per entry (or a
+/// `(none)` placeholder), a blank separator, then the same shape for
+/// `MILESTONES (N)` / [`milestone_line`].
+/// Test: `body_lines_lists_deliverables_and_milestones_with_status`,
+/// `body_lines_shows_placeholder_when_empty`.
+pub fn body_lines(view: &DeliverableView) -> Vec<String> {
+    let mut lines = vec![format!("DELIVERABLES ({})", view.deliverables.len())];
+    if view.deliverables.is_empty() {
+        lines.push("  (none)".to_string());
+    } else {
+        lines.extend(view.deliverables.iter().map(deliverable_line));
+    }
+    lines.push(String::new());
+    lines.push(format!("MILESTONES ({})", view.milestones.len()));
+    if view.milestones.is_empty() {
+        lines.push("  (none)".to_string());
+    } else {
+        lines.extend(view.milestones.iter().map(milestone_line));
+    }
+    lines
+}
+
+/// Width/height of the overlay box, in terminal cells.
+const OVERLAY_WIDTH: u16 = 72;
+const OVERLAY_HEIGHT: u16 = 20;
+
+/// Render the Deliverable/Milestone overlay, when open.
+///
+/// Why: the single entry point [`super::super::layout::render`] calls AFTER
+/// the base 4-pane frame, only when [`super::super::state::ProjectCtlState::deliverable_view`]
+/// is `Some` — mirrors the dashboard help-overlay's "draw the base frame,
+/// then float the overlay on top via `Clear`" sequencing.
+/// What: a centred, bordered, titled (`Deliverables/Milestones — <project>`)
+/// `Paragraph` over [`body_lines`], scrolled by `view.scroll`.
+pub fn render(frame: &mut Frame, view: &DeliverableView) {
+    let area = centered_rect(OVERLAY_WIDTH, OVERLAY_HEIGHT, frame.area());
+    frame.render_widget(Clear, area);
+    let title = Line::from(vec![Span::styled(
+        format!("Deliverables/Milestones — {}", view.project_name),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )]);
+    let body = body_lines(view).join("\n");
+    let footer = "\n[↑↓] scroll  [Esc/v] close";
+    frame.render_widget(
+        Paragraph::new(format!("{body}{footer}"))
+            .style(Style::default().fg(Color::Reset))
+            .scroll((view.scroll, 0))
+            .block(Block::default().borders(Borders::ALL).title(title)),
+        area,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deliverable::{DeliverableId, DeliverableKind, DeliverableStatus, MilestoneId};
+    use chrono::{DateTime, Utc};
+
+    fn deliverable(name: &str, status: DeliverableStatus) -> Deliverable {
+        Deliverable {
+            id: DeliverableId::new(),
+            project_name: "widget".to_string(),
+            name: name.to_string(),
+            description: String::new(),
+            kind: DeliverableKind::Feature,
+            ticket_ref: None,
+            spec_ref: None,
+            status,
+            estimated_effort: EstimationTier::M,
+            created_at: Utc::now(),
+            target_date: None,
+        }
+    }
+
+    fn milestone(name: &str, status: MilestoneStatus) -> Milestone {
+        Milestone {
+            id: MilestoneId::new(),
+            project_name: "widget".to_string(),
+            name: name.to_string(),
+            description: String::new(),
+            target_date: DateTime::parse_from_rfc3339("2026-09-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            status,
+            deliverables: vec![],
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn body_lines_lists_deliverables_and_milestones_with_status() {
+        let view = DeliverableView {
+            project_name: "widget".to_string(),
+            deliverables: vec![deliverable("OAuth2 flow", DeliverableStatus::InProgress)],
+            milestones: vec![milestone("v1.0 Alpha", MilestoneStatus::Proposed)],
+            scroll: 0,
+        };
+        let lines = body_lines(&view).join("\n");
+        assert!(lines.contains("DELIVERABLES (1)"));
+        assert!(lines.contains("OAuth2 flow"));
+        assert!(lines.contains("in-progress"));
+        assert!(lines.contains("(M)"));
+        assert!(lines.contains("MILESTONES (1)"));
+        assert!(lines.contains("v1.0 Alpha"));
+        assert!(lines.contains("proposed"));
+        assert!(lines.contains("2026-09-01"));
+    }
+
+    #[test]
+    fn body_lines_shows_placeholder_when_empty() {
+        let view = DeliverableView {
+            project_name: "widget".to_string(),
+            deliverables: vec![],
+            milestones: vec![],
+            scroll: 0,
+        };
+        let lines = body_lines(&view).join("\n");
+        assert!(lines.contains("DELIVERABLES (0)"));
+        assert!(lines.contains("MILESTONES (0)"));
+        assert_eq!(lines.matches("(none)").count(), 2);
+    }
+
+    #[test]
+    fn tier_str_maps_every_tier() {
+        assert_eq!(tier_str(EstimationTier::S), "S");
+        assert_eq!(tier_str(EstimationTier::Xl), "XL");
+    }
+
+    #[test]
+    fn milestone_status_str_matches_wire_format() {
+        assert_eq!(
+            milestone_status_str(MilestoneStatus::InProgress),
+            "in-progress"
+        );
+        assert_eq!(milestone_status_str(MilestoneStatus::Shipped), "shipped");
+    }
+
+    #[test]
+    fn centered_rect_clamps_to_area_bounds() {
+        let small = Rect {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 5,
+        };
+        let r = centered_rect(OVERLAY_WIDTH, OVERLAY_HEIGHT, small);
+        assert_eq!(r.width, 10);
+        assert_eq!(r.height, 5);
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/mod.rs
@@ -6,12 +6,16 @@
 //! `Rect`s and calls into each of these.
 //! What: [`projects`] (left, 25%), [`sessions`] (right, 75%),
 //! [`activity`] (bottom strip, live `/activity`-endpoint wiring per #2119),
-//! and [`actions_bar`] (the 1-row key-hint / notice line).
+//! [`actions_bar`] (the 1-row key-hint / notice line), and
+//! [`deliverables_view`] (a centred overlay, the read-only Deliverable/
+//! Milestone view reachable from the Projects pane, DOC-35 §10.8 `show`,
+//! #2383).
 //! Test: each submodule's pure builders are unit-tested in its own `tests`
 //! block; the `render` functions are terminal glue exercised by launching the
 //! TUI.
 
 pub mod actions_bar;
 pub mod activity;
+pub mod deliverables_view;
 pub mod projects;
 pub mod sessions;

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs
@@ -5,10 +5,17 @@
 //! is driven ONLY by the session record's static `ManagedSessionState` word —
 //! there is no live `/activity` polling in this issue's scope (#2119 wires
 //! that live "awaiting approval" / "idle Nm" detail into this pane later).
-//! What: [`state_glyph`] / [`session_line`] are pure builders (unit tested
-//! without a terminal); [`render`] composes them into a ratatui stateful
-//! `List`.
-//! Test: `tests` covers the glyph rule and the line content.
+//! A second, independent glyph (DOC-35 §10.6, #2383) marks a row whose
+//! `deliverable_id` is bound to a Deliverable — resolved (`◆`) when it
+//! matches one of [`ProjectCtlState::deliverables`], dangling (`◈`, dim red)
+//! when it does not. The spec (§12 as filed) enumerates the WORK ITEM but
+//! does not pin an exact glyph/color — this is a disclosed design choice, not
+//! a literal spec transcription; see the PR body for the full disclosure.
+//! What: [`state_glyph`] / [`deliverable_glyph`] / [`session_line`] are pure
+//! builders (unit tested without a terminal); [`render`] composes them into a
+//! ratatui stateful `List`, passing the current tick's known deliverable ids
+//! so the glyph resolves without a second daemon round trip per row.
+//! Test: `tests` covers both glyph rules and the line content.
 
 use ratatui::{
     Frame,
@@ -51,19 +58,54 @@ pub fn state_glyph(state: &str) -> char {
     }
 }
 
-/// Build one numbered session row: `N. <glyph> <short-id>  <branch>  <detail>`.
+/// Glyph for a session bound to a Deliverable that resolves (DOC-35 §10.6,
+/// #2383).
+pub const DELIVERABLE_GLYPH: char = '◆';
+/// Glyph for a session bound to a Deliverable id that does NOT resolve
+/// against the currently fetched deliverable set — a dangling reference
+/// (e.g. the Deliverable was deleted out from under the session).
+pub const DELIVERABLE_DANGLING_GLYPH: char = '◈';
+
+/// Pick the deliverable-link glyph (and whether to show one at all) for a
+/// session row.
+///
+/// Why: a session row's `deliverable_id` alone cannot say whether the link is
+/// live — that requires checking it against the project's currently fetched
+/// Deliverable set (DOC-35 §10.6). Kept as a small pure function so the
+/// resolved/dangling distinction is unit-testable independent of rendering.
+/// What: `None` when `deliverable_id` is `None` (no glyph at all — the
+/// common case). `Some((`[`DELIVERABLE_GLYPH`]`, Color::Cyan))` when
+/// `known` is true (the id resolves). `Some((`[`DELIVERABLE_DANGLING_GLYPH`]`,
+/// Color::Red))` when `known` is false (bound, but dangling).
+/// Test: `deliverable_glyph_none_when_unbound`,
+/// `deliverable_glyph_resolved_and_dangling`.
+pub fn deliverable_glyph(deliverable_id: Option<&str>, known: bool) -> Option<(char, Color)> {
+    deliverable_id?;
+    Some(if known {
+        (DELIVERABLE_GLYPH, Color::Cyan)
+    } else {
+        (DELIVERABLE_DANGLING_GLYPH, Color::Red)
+    })
+}
+
+/// Build one numbered session row: `N. <glyph> <short-id>  <branch>  <detail>`,
+/// with an optional trailing deliverable-link glyph (DOC-35 §10.6, #2383).
 ///
 /// Why: DOC-16 §3.2 numbers session rows so an operator can refer to one by
 /// its list position; the detail column prefers the task description and
-/// falls back to the raw state word when no task is recorded.
-/// What: returns e.g. `1. ● 4f9ca1b2  main  ship the thing`.
+/// falls back to the raw state word when no task is recorded. `known_deliverable`
+/// is resolved by the caller ([`render`]) against [`ProjectCtlState::deliverables`]
+/// so this function stays a pure, terminal-free builder.
+/// What: returns e.g. `1. ● 4f9ca1b2  main  ship the thing ◆` when bound and
+/// resolved, `… ◈` when bound but dangling, or no trailing glyph when unbound.
 /// Test: `session_line_shows_number_glyph_branch_and_task`,
-/// `session_line_falls_back_to_state_word`.
-pub fn session_line(number: usize, row: &SessionRow) -> Line<'static> {
+/// `session_line_falls_back_to_state_word`,
+/// `session_line_appends_deliverable_glyph_when_bound`.
+pub fn session_line(number: usize, row: &SessionRow, known_deliverable: bool) -> Line<'static> {
     let glyph = state_glyph(&row.state);
     let branch = row.branch.clone().unwrap_or_else(|| "-".to_string());
     let detail = row.task.clone().unwrap_or_else(|| row.state.clone());
-    Line::from(vec![
+    let mut spans = vec![
         Span::styled(
             format!("{number:>2}. "),
             Style::default().fg(Color::DarkGray),
@@ -75,7 +117,16 @@ pub fn session_line(number: usize, row: &SessionRow) -> Line<'static> {
         ),
         Span::raw(format!("{branch}  ")),
         Span::styled(detail, Style::default().fg(Color::DarkGray)),
-    ])
+    ];
+    if let Some((glyph, color)) =
+        deliverable_glyph(row.deliverable_id.as_deref(), known_deliverable)
+    {
+        spans.push(Span::styled(
+            format!("  {glyph}"),
+            Style::default().fg(color),
+        ));
+    }
+    Line::from(spans)
 }
 
 /// Style a state glyph by its lifecycle state.
@@ -102,7 +153,13 @@ pub fn render(frame: &mut Frame, area: Rect, state: &mut ProjectCtlState) {
     let items: Vec<ListItem> = sessions
         .iter()
         .enumerate()
-        .map(|(i, s)| ListItem::new(session_line(i + 1, s)))
+        .map(|(i, s)| {
+            let known = s
+                .deliverable_id
+                .as_deref()
+                .is_some_and(|id| state.deliverable_for(id).is_some());
+            ListItem::new(session_line(i + 1, s, known))
+        })
         .collect();
     let project_label = state.selected_project_name().unwrap_or("-");
     let title = Line::from(format!("SESSIONS — {project_label} ({})", sessions.len()))
@@ -144,6 +201,7 @@ mod tests {
             state: state.to_string(),
             pending_decision: None,
             proposed_default: None,
+            deliverable_id: None,
         }
     }
 
@@ -167,7 +225,7 @@ mod tests {
 
     #[test]
     fn session_line_shows_number_glyph_branch_and_task() {
-        let text = line_text(&session_line(1, &row("active")));
+        let text = line_text(&session_line(1, &row("active"), false));
         assert!(text.starts_with(" 1. "), "missing number: {text}");
         assert!(text.contains(ACTIVE_GLYPH), "missing glyph: {text}");
         assert!(text.contains("4f9ca1b2"), "missing short id: {text}");
@@ -179,7 +237,48 @@ mod tests {
     fn session_line_falls_back_to_state_word() {
         let mut r = row("stopped");
         r.task = None;
-        let text = line_text(&session_line(2, &r));
+        let text = line_text(&session_line(2, &r, false));
         assert!(text.contains("stopped"), "missing state fallback: {text}");
+    }
+
+    #[test]
+    fn deliverable_glyph_none_when_unbound() {
+        assert_eq!(deliverable_glyph(None, true), None);
+        assert_eq!(deliverable_glyph(None, false), None);
+    }
+
+    #[test]
+    fn deliverable_glyph_resolved_and_dangling() {
+        assert_eq!(
+            deliverable_glyph(Some("d-1"), true),
+            Some((DELIVERABLE_GLYPH, Color::Cyan))
+        );
+        assert_eq!(
+            deliverable_glyph(Some("d-1"), false),
+            Some((DELIVERABLE_DANGLING_GLYPH, Color::Red))
+        );
+    }
+
+    #[test]
+    fn session_line_appends_deliverable_glyph_when_bound() {
+        let mut r = row("active");
+        r.deliverable_id = None;
+        assert!(
+            !line_text(&session_line(1, &r, false)).contains(DELIVERABLE_GLYPH),
+            "unbound row must show no deliverable glyph"
+        );
+
+        r.deliverable_id = Some("d-1".to_string());
+        let resolved_text = line_text(&session_line(1, &r, true));
+        assert!(
+            resolved_text.contains(DELIVERABLE_GLYPH),
+            "resolved link must show the resolved glyph: {resolved_text}"
+        );
+
+        let dangling_text = line_text(&session_line(1, &r, false));
+        assert!(
+            dangling_text.contains(DELIVERABLE_DANGLING_GLYPH),
+            "dangling link must show the dangling glyph: {dangling_text}"
+        );
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs
@@ -6,16 +6,21 @@
 //! there is no live `/activity` polling in this issue's scope (#2119 wires
 //! that live "awaiting approval" / "idle Nm" detail into this pane later).
 //! A second, independent glyph (DOC-35 §10.6, #2383) marks a row whose
-//! `deliverable_id` is bound to a Deliverable — resolved (`◆`) when it
+//! `deliverable_id` is bound to a Deliverable — resolved (`◆`, cyan) when it
 //! matches one of [`ProjectCtlState::deliverables`], dangling (`◈`, dim red)
-//! when it does not. The spec (§12 as filed) enumerates the WORK ITEM but
-//! does not pin an exact glyph/color — this is a disclosed design choice, not
-//! a literal spec transcription; see the PR body for the full disclosure.
+//! when it CONFIRMS the id does not resolve, and no glyph at all when the
+//! link state is [`DeliverableLinkState::Unknown`] (no successfully fetched
+//! Deliverable set exists yet — a transient fetch failure must never be
+//! rendered as a confirmed-dangling reference, see
+//! [`ProjectCtlState::deliverable_link_state`]'s own doc for the full
+//! rationale). The spec (§12 as filed) enumerates the WORK ITEM but does not
+//! pin an exact glyph/color — this is a disclosed design choice, not a
+//! literal spec transcription; see the PR body for the full disclosure.
 //! What: [`state_glyph`] / [`deliverable_glyph`] / [`session_line`] are pure
 //! builders (unit tested without a terminal); [`render`] composes them into a
-//! ratatui stateful `List`, passing the current tick's known deliverable ids
-//! so the glyph resolves without a second daemon round trip per row.
-//! Test: `tests` covers both glyph rules and the line content.
+//! ratatui stateful `List`, passing the current tick's [`DeliverableLinkState`]
+//! per row so the glyph resolves without a second daemon round trip per row.
+//! Test: `tests` covers all three glyph states and the line content.
 
 use ratatui::{
     Frame,
@@ -25,7 +30,7 @@ use ratatui::{
     widgets::{Block, Borders, HighlightSpacing, List, ListItem},
 };
 
-use crate::tui::project_ctl::state::{Pane, ProjectCtlState, SessionRow};
+use crate::tui::project_ctl::state::{DeliverableLinkState, Pane, ProjectCtlState, SessionRow};
 
 /// Glyph for a session whose runtime is currently running.
 pub const ACTIVE_GLYPH: char = '●';
@@ -71,21 +76,36 @@ pub const DELIVERABLE_DANGLING_GLYPH: char = '◈';
 ///
 /// Why: a session row's `deliverable_id` alone cannot say whether the link is
 /// live — that requires checking it against the project's currently fetched
-/// Deliverable set (DOC-35 §10.6). Kept as a small pure function so the
-/// resolved/dangling distinction is unit-testable independent of rendering.
-/// What: `None` when `deliverable_id` is `None` (no glyph at all — the
-/// common case). `Some((`[`DELIVERABLE_GLYPH`]`, Color::Cyan))` when
-/// `known` is true (the id resolves). `Some((`[`DELIVERABLE_DANGLING_GLYPH`]`,
-/// Color::Red))` when `known` is false (bound, but dangling).
+/// Deliverable set (DOC-35 §10.6) via [`DeliverableLinkState`]. Kept as a
+/// small pure function so all three states are unit-testable independent of
+/// rendering. The dangling case is styled DIM (in addition to red) so it
+/// reads as visually distinct from [`ERRORED_GLYPH`]'s full-intensity red —
+/// two identical reds on one row would otherwise conflate "this session
+/// errored" with "this session's Deliverable link is dangling".
+/// What: `None` when `deliverable_id` is `None` (unbound — the common case)
+/// OR `link_state` is [`DeliverableLinkState::Unknown`] (nothing confirmed
+/// yet — showing a glyph here would be a guess, never a confirmed dangling
+/// ref). `Some((`[`DELIVERABLE_GLYPH`]`, cyan))` when [`DeliverableLinkState::Resolved`].
+/// `Some((`[`DELIVERABLE_DANGLING_GLYPH`]`, dim red))` when
+/// [`DeliverableLinkState::Dangling`].
 /// Test: `deliverable_glyph_none_when_unbound`,
+/// `deliverable_glyph_none_when_unknown`,
 /// `deliverable_glyph_resolved_and_dangling`.
-pub fn deliverable_glyph(deliverable_id: Option<&str>, known: bool) -> Option<(char, Color)> {
+pub fn deliverable_glyph(
+    deliverable_id: Option<&str>,
+    link_state: DeliverableLinkState,
+) -> Option<(char, Style)> {
     deliverable_id?;
-    Some(if known {
-        (DELIVERABLE_GLYPH, Color::Cyan)
-    } else {
-        (DELIVERABLE_DANGLING_GLYPH, Color::Red)
-    })
+    match link_state {
+        DeliverableLinkState::Unknown => None,
+        DeliverableLinkState::Resolved => {
+            Some((DELIVERABLE_GLYPH, Style::default().fg(Color::Cyan)))
+        }
+        DeliverableLinkState::Dangling => Some((
+            DELIVERABLE_DANGLING_GLYPH,
+            Style::default().fg(Color::Red).add_modifier(Modifier::DIM),
+        )),
+    }
 }
 
 /// Build one numbered session row: `N. <glyph> <short-id>  <branch>  <detail>`,
@@ -93,15 +113,22 @@ pub fn deliverable_glyph(deliverable_id: Option<&str>, known: bool) -> Option<(c
 ///
 /// Why: DOC-16 §3.2 numbers session rows so an operator can refer to one by
 /// its list position; the detail column prefers the task description and
-/// falls back to the raw state word when no task is recorded. `known_deliverable`
-/// is resolved by the caller ([`render`]) against [`ProjectCtlState::deliverables`]
-/// so this function stays a pure, terminal-free builder.
+/// falls back to the raw state word when no task is recorded.
+/// `deliverable_link_state` is resolved by the caller ([`render`]) via
+/// [`ProjectCtlState::deliverable_link_state`] so this function stays a pure,
+/// terminal-free builder.
 /// What: returns e.g. `1. ● 4f9ca1b2  main  ship the thing ◆` when bound and
-/// resolved, `… ◈` when bound but dangling, or no trailing glyph when unbound.
+/// resolved, `… ◈` (dim) when bound and confirmed dangling, or no trailing
+/// glyph when unbound OR the link state is still
+/// [`DeliverableLinkState::Unknown`].
 /// Test: `session_line_shows_number_glyph_branch_and_task`,
 /// `session_line_falls_back_to_state_word`,
 /// `session_line_appends_deliverable_glyph_when_bound`.
-pub fn session_line(number: usize, row: &SessionRow, known_deliverable: bool) -> Line<'static> {
+pub fn session_line(
+    number: usize,
+    row: &SessionRow,
+    deliverable_link_state: DeliverableLinkState,
+) -> Line<'static> {
     let glyph = state_glyph(&row.state);
     let branch = row.branch.clone().unwrap_or_else(|| "-".to_string());
     let detail = row.task.clone().unwrap_or_else(|| row.state.clone());
@@ -118,13 +145,10 @@ pub fn session_line(number: usize, row: &SessionRow, known_deliverable: bool) ->
         Span::raw(format!("{branch}  ")),
         Span::styled(detail, Style::default().fg(Color::DarkGray)),
     ];
-    if let Some((glyph, color)) =
-        deliverable_glyph(row.deliverable_id.as_deref(), known_deliverable)
+    if let Some((glyph, style)) =
+        deliverable_glyph(row.deliverable_id.as_deref(), deliverable_link_state)
     {
-        spans.push(Span::styled(
-            format!("  {glyph}"),
-            Style::default().fg(color),
-        ));
+        spans.push(Span::styled(format!("  {glyph}"), style));
     }
     Line::from(spans)
 }
@@ -154,11 +178,12 @@ pub fn render(frame: &mut Frame, area: Rect, state: &mut ProjectCtlState) {
         .iter()
         .enumerate()
         .map(|(i, s)| {
-            let known = s
+            let link_state = s
                 .deliverable_id
                 .as_deref()
-                .is_some_and(|id| state.deliverable_for(id).is_some());
-            ListItem::new(session_line(i + 1, s, known))
+                .map(|id| state.deliverable_link_state(id))
+                .unwrap_or(DeliverableLinkState::Unknown);
+            ListItem::new(session_line(i + 1, s, link_state))
         })
         .collect();
     let project_label = state.selected_project_name().unwrap_or("-");
@@ -225,7 +250,11 @@ mod tests {
 
     #[test]
     fn session_line_shows_number_glyph_branch_and_task() {
-        let text = line_text(&session_line(1, &row("active"), false));
+        let text = line_text(&session_line(
+            1,
+            &row("active"),
+            DeliverableLinkState::Unknown,
+        ));
         assert!(text.starts_with(" 1. "), "missing number: {text}");
         assert!(text.contains(ACTIVE_GLYPH), "missing glyph: {text}");
         assert!(text.contains("4f9ca1b2"), "missing short id: {text}");
@@ -237,25 +266,50 @@ mod tests {
     fn session_line_falls_back_to_state_word() {
         let mut r = row("stopped");
         r.task = None;
-        let text = line_text(&session_line(2, &r, false));
+        let text = line_text(&session_line(2, &r, DeliverableLinkState::Unknown));
         assert!(text.contains("stopped"), "missing state fallback: {text}");
     }
 
     #[test]
     fn deliverable_glyph_none_when_unbound() {
-        assert_eq!(deliverable_glyph(None, true), None);
-        assert_eq!(deliverable_glyph(None, false), None);
+        assert_eq!(
+            deliverable_glyph(None, DeliverableLinkState::Resolved),
+            None
+        );
+        assert_eq!(
+            deliverable_glyph(None, DeliverableLinkState::Dangling),
+            None
+        );
+        assert_eq!(deliverable_glyph(None, DeliverableLinkState::Unknown), None);
+    }
+
+    #[test]
+    fn deliverable_glyph_none_when_unknown() {
+        // Bound (id is Some), but no successfully fetched Deliverable set
+        // exists yet — must show NO glyph, never the dangling one (the bug
+        // this fix addresses: a transient fetch failure must not read as
+        // "confirmed deleted").
+        assert_eq!(
+            deliverable_glyph(Some("d-1"), DeliverableLinkState::Unknown),
+            None
+        );
     }
 
     #[test]
     fn deliverable_glyph_resolved_and_dangling() {
-        assert_eq!(
-            deliverable_glyph(Some("d-1"), true),
-            Some((DELIVERABLE_GLYPH, Color::Cyan))
-        );
-        assert_eq!(
-            deliverable_glyph(Some("d-1"), false),
-            Some((DELIVERABLE_DANGLING_GLYPH, Color::Red))
+        let (glyph, style) = deliverable_glyph(Some("d-1"), DeliverableLinkState::Resolved)
+            .expect("resolved must show a glyph");
+        assert_eq!(glyph, DELIVERABLE_GLYPH);
+        assert_eq!(style.fg, Some(Color::Cyan));
+
+        let (glyph, style) = deliverable_glyph(Some("d-1"), DeliverableLinkState::Dangling)
+            .expect("dangling must show a glyph");
+        assert_eq!(glyph, DELIVERABLE_DANGLING_GLYPH);
+        assert_eq!(style.fg, Some(Color::Red));
+        assert!(
+            style.add_modifier.contains(Modifier::DIM),
+            "the dangling glyph must be dimmed so it reads distinct from the \
+             full-intensity red ERRORED_GLYPH: {style:?}"
         );
     }
 
@@ -264,18 +318,26 @@ mod tests {
         let mut r = row("active");
         r.deliverable_id = None;
         assert!(
-            !line_text(&session_line(1, &r, false)).contains(DELIVERABLE_GLYPH),
+            !line_text(&session_line(1, &r, DeliverableLinkState::Resolved))
+                .contains(DELIVERABLE_GLYPH),
             "unbound row must show no deliverable glyph"
         );
 
         r.deliverable_id = Some("d-1".to_string());
-        let resolved_text = line_text(&session_line(1, &r, true));
+        let unknown_text = line_text(&session_line(1, &r, DeliverableLinkState::Unknown));
+        assert!(
+            !unknown_text.contains(DELIVERABLE_GLYPH)
+                && !unknown_text.contains(DELIVERABLE_DANGLING_GLYPH),
+            "a bound row with an Unknown link state must show NO deliverable glyph: {unknown_text}"
+        );
+
+        let resolved_text = line_text(&session_line(1, &r, DeliverableLinkState::Resolved));
         assert!(
             resolved_text.contains(DELIVERABLE_GLYPH),
             "resolved link must show the resolved glyph: {resolved_text}"
         );
 
-        let dangling_text = line_text(&session_line(1, &r, false));
+        let dangling_text = line_text(&session_line(1, &r, DeliverableLinkState::Dangling));
         assert!(
             dangling_text.contains(DELIVERABLE_DANGLING_GLYPH),
             "dangling link must show the dangling glyph: {dangling_text}"

--- a/crates/trusty-mpm/src/tui/project_ctl/poll.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll.rs
@@ -11,13 +11,15 @@
 //! refresh to two HTTP calls regardless of project count; the activity fetch
 //! is a third call, made only when a session is selected (DOC-35 §5.4).
 //! What: [`project_ctl_poll_daemon`] (health → rediscover-on-fail → registry
-//! list + fleet → map → selected-session activity via [`refresh_activity`];
-//! on daemon-down clears the project/session state — which in turn clears
-//! `activity` too, since a daemon-down poll has no session left selected to
-//! attribute it to; see [`refresh_activity`]'s own doc for the narrower
-//! "fetch failed but the daemon is otherwise up" case that DOES keep the
-//! last-known activity, marked stale) plus the pure projections
-//! [`project_to_row`], [`session_to_row`], and [`activity_from_response`].
+//! list + fleet → map → selected-session activity via [`refresh_activity`] →
+//! selected-project Deliverables (+ Milestones when the view is open) via
+//! [`refresh_deliverables`], DOC-35 §10.6/§10.8, #2383; on daemon-down clears
+//! the project/session state — which in turn clears `activity` too, since a
+//! daemon-down poll has no session left selected to attribute it to; see
+//! [`refresh_activity`]'s own doc for the narrower "fetch failed but the
+//! daemon is otherwise up" case that DOES keep the last-known activity,
+//! marked stale) plus the pure projections [`project_to_row`],
+//! [`session_to_row`], and [`activity_from_response`].
 //! Test: `tests` covers the pure projections and the daemon-down branches
 //! against a guaranteed-dead client (mirroring
 //! `tui::coordinator::poll::tests::poll_marks_unreachable_clears_sessions`);
@@ -86,6 +88,79 @@ pub(crate) async fn project_ctl_poll_daemon(
     state.projects_nav.sync_len(state.projects.len());
     state.sessions_nav.sync_len(state.current_sessions().len());
     refresh_activity(state, client).await;
+    refresh_deliverables(state, client).await;
+}
+
+/// Refresh [`ProjectCtlState::deliverables`] for the currently selected
+/// project, and — while [`ProjectCtlState::deliverable_view`] is open —
+/// [`super::state::DeliverableView::milestones`] too (DOC-35 §10.6/§10.8,
+/// #2383).
+///
+/// Why: split out of [`project_ctl_poll_daemon`] for the same reason
+/// [`refresh_activity`] is — one focused function per "what does this fetch,
+/// under what conditions" concern. This is the poll loop's ONE additional
+/// steady-state call (Deliverables for the selected project, mirroring how
+/// `refresh_activity` scopes its own fetch to the selected session) plus a
+/// SECOND call that only fires while the view is open (Milestones) — bounded
+/// by "is a modal open", never by session/project count, so it never becomes
+/// an O(n) per-session loop. Runs AFTER the project/session refresh so
+/// `state.selected_project_name()` reflects the just-synced navigation.
+/// What: no project selected, or the daemon unreachable → clears
+/// `state.deliverables` (matching `state.projects`/`sessions_by_project`'s
+/// own daemon-down handling in this function, NOT `refresh_activity`'s
+/// narrower stale-keep treatment — there is no "last known glyph" concept
+/// worth preserving through a daemon outage). A selected project with the
+/// daemon reachable → fetches `list_deliverables`, replacing
+/// `state.deliverables` on success or clearing it on a transport error. When
+/// [`ProjectCtlState::deliverable_view`] is `Some` for the SAME project, also
+/// fetches `list_milestones` and updates its `milestones` field in place
+/// (leaving `deliverables` alone — [`ProjectCtlState::open_deliverable_view`]
+/// seeded it, and this function's own `state.deliverables` update above keeps
+/// it current on every subsequent tick via [`sync_open_view_deliverables`]).
+/// Test: `refresh_deliverables_clears_when_no_project_selected`,
+/// `refresh_deliverables_clears_on_daemon_down`.
+async fn refresh_deliverables(state: &mut ProjectCtlState, client: &DaemonClient) {
+    let Some(project_name) = state.selected_project_name().map(str::to_string) else {
+        state.deliverables.clear();
+        return;
+    };
+
+    if !state.daemon_reachable {
+        state.deliverables.clear();
+        return;
+    }
+
+    match client.list_deliverables(&project_name, None).await {
+        Ok(deliverables) => state.deliverables = deliverables,
+        Err(_) => state.deliverables.clear(),
+    }
+    sync_open_view_deliverables(state, &project_name);
+
+    if let Some(view) = &state.deliverable_view
+        && view.project_name == project_name
+        && let Ok(milestones) = client.list_milestones(&project_name).await
+        && let Some(view) = &mut state.deliverable_view
+    {
+        view.milestones = milestones;
+    }
+}
+
+/// Keep an open [`super::state::DeliverableView`]'s `deliverables` in sync
+/// with [`ProjectCtlState::deliverables`] on every tick, when the view is
+/// still scoped to `project_name`.
+///
+/// Why: [`ProjectCtlState::open_deliverable_view`] seeds the view from
+/// whatever `state.deliverables` held at the moment it opened; without this,
+/// a status change (e.g. an operator running `tm projects deliverables
+/// set-status` in another terminal) would never appear in an already-open
+/// view until it was closed and reopened.
+fn sync_open_view_deliverables(state: &mut ProjectCtlState, project_name: &str) {
+    let deliverables = state.deliverables.clone();
+    if let Some(view) = &mut state.deliverable_view
+        && view.project_name == project_name
+    {
+        view.deliverables = deliverables;
+    }
 }
 
 /// Refresh [`ProjectCtlState::activity`] for the currently selected session
@@ -222,8 +297,10 @@ pub(crate) fn project_to_row(p: &Project, group: Option<&FleetProjectGroupWire>)
 /// one selected session's activity gets the extra live `/activity` fetch (see
 /// [`refresh_activity`]), never the whole list.
 /// What: derives the 8-hex short id via [`session_short_id`] and copies the
-/// rest through unchanged.
-/// Test: `session_to_row_derives_short_id_and_copies_fields`.
+/// rest through unchanged, including `deliverable_id` (DOC-35 §10.6, #2383 —
+/// drives the Sessions-pane deliverable glyph).
+/// Test: `session_to_row_derives_short_id_and_copies_fields`,
+/// `session_to_row_carries_deliverable_id`.
 pub(crate) fn session_to_row(s: ManagedSessionSummary) -> SessionRow {
     let short_id = session_short_id(&s.id);
     SessionRow {
@@ -235,6 +312,7 @@ pub(crate) fn session_to_row(s: ManagedSessionSummary) -> SessionRow {
         state: s.state,
         pending_decision: s.pending_decision,
         proposed_default: s.proposed_default,
+        deliverable_id: s.deliverable_id,
     }
 }
 
@@ -318,6 +396,7 @@ mod tests {
             task: Some("do the thing".to_string()),
             cwd: None,
             claude_session_id: None,
+            deliverable_id: None,
             pane_id: None,
         }
     }
@@ -356,6 +435,20 @@ mod tests {
         assert_eq!(row.state, "active");
         assert_eq!(row.branch.as_deref(), Some("main"));
         assert_eq!(row.task.as_deref(), Some("do the thing"));
+    }
+
+    #[test]
+    fn session_to_row_carries_deliverable_id() {
+        let mut s = summary("4f9ca1b2ffff", "active");
+        s.deliverable_id = Some("11111111-1111-1111-1111-111111111111".to_string());
+        let row = session_to_row(s);
+        assert_eq!(
+            row.deliverable_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+
+        let none_row = session_to_row(summary("aaaaaaaabbbb", "active"));
+        assert!(none_row.deliverable_id.is_none());
     }
 
     fn activity_response(raw_pane: &str) -> ManagedActivityResponse {
@@ -525,5 +618,34 @@ mod tests {
         refresh_activity(&mut state, &client).await;
 
         assert!(state.activity.is_none());
+    }
+
+    #[tokio::test]
+    async fn refresh_deliverables_clears_when_no_project_selected() {
+        let mut state = ProjectCtlState {
+            daemon_reachable: true,
+            deliverables: vec![],
+            ..Default::default()
+        };
+        let client = DaemonClient::new(dead_loopback_url());
+
+        refresh_deliverables(&mut state, &client).await;
+
+        assert!(state.deliverables.is_empty());
+    }
+
+    #[tokio::test]
+    async fn refresh_deliverables_clears_on_daemon_down() {
+        let mut state = seeded_activity_state("s1");
+        state.daemon_reachable = false;
+        let client = DaemonClient::new(dead_loopback_url());
+
+        refresh_deliverables(&mut state, &client).await;
+
+        assert!(
+            state.deliverables.is_empty(),
+            "a project IS selected here, but daemon_reachable=false must still clear, \
+             matching state.projects/sessions_by_project's own daemon-down handling"
+        );
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/poll.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll.rs
@@ -105,34 +105,44 @@ pub(crate) async fn project_ctl_poll_daemon(
 /// by "is a modal open", never by session/project count, so it never becomes
 /// an O(n) per-session loop. Runs AFTER the project/session refresh so
 /// `state.selected_project_name()` reflects the just-synced navigation.
-/// What: no project selected, or the daemon unreachable → clears
-/// `state.deliverables` (matching `state.projects`/`sessions_by_project`'s
-/// own daemon-down handling in this function, NOT `refresh_activity`'s
-/// narrower stale-keep treatment — there is no "last known glyph" concept
-/// worth preserving through a daemon outage). A selected project with the
-/// daemon reachable → fetches `list_deliverables`, replacing
-/// `state.deliverables` on success or clearing it on a transport error. When
-/// [`ProjectCtlState::deliverable_view`] is `Some` for the SAME project, also
-/// fetches `list_milestones` and updates its `milestones` field in place
-/// (leaving `deliverables` alone — [`ProjectCtlState::open_deliverable_view`]
-/// seeded it, and this function's own `state.deliverables` update above keeps
-/// it current on every subsequent tick via [`sync_open_view_deliverables`]).
+/// What: no project selected, or the daemon unreachable → resets
+/// `state.deliverables` to `None` (Unknown; matching `state.projects`/
+/// `sessions_by_project`'s own daemon-down handling in this function — every
+/// session row also vanishes from the Sessions pane in that case, so the
+/// glyph question is moot). A selected project with the daemon reachable →
+/// fetches `list_deliverables`; on success replaces `state.deliverables`
+/// with `Some(list)`. **On a transient fetch error, `state.deliverables` is
+/// left UNCHANGED** (neither cleared nor reset to `None`) — mirrors
+/// [`refresh_activity`]'s stale-keep pattern: a `None` (still-unknown) stays
+/// `None`, and a `Some(last-known-good-list)` stays exactly that, so
+/// [`ProjectCtlState::deliverable_link_state`] keeps resolving previously-
+/// resolved sessions correctly instead of flipping them to a false
+/// "dangling" reading on one bad poll (review finding on #2383's initial
+/// PR). When [`ProjectCtlState::deliverable_view`] is `Some` for the SAME
+/// project, also fetches `list_milestones` and updates its `milestones`
+/// field in place (leaving `deliverables` alone —
+/// [`ProjectCtlState::open_deliverable_view`] seeded it, and this function's
+/// own `state.deliverables` update above keeps it current on every
+/// subsequent tick via [`sync_open_view_deliverables`]).
 /// Test: `refresh_deliverables_clears_when_no_project_selected`,
-/// `refresh_deliverables_clears_on_daemon_down`.
+/// `refresh_deliverables_clears_on_daemon_down`,
+/// `refresh_deliverables_keeps_stale_list_on_transient_fetch_failure`.
 async fn refresh_deliverables(state: &mut ProjectCtlState, client: &DaemonClient) {
     let Some(project_name) = state.selected_project_name().map(str::to_string) else {
-        state.deliverables.clear();
+        state.deliverables = None;
         return;
     };
 
     if !state.daemon_reachable {
-        state.deliverables.clear();
+        state.deliverables = None;
         return;
     }
 
-    match client.list_deliverables(&project_name, None).await {
-        Ok(deliverables) => state.deliverables = deliverables,
-        Err(_) => state.deliverables.clear(),
+    // A transient `Err` deliberately falls through WITHOUT touching
+    // `state.deliverables` — see the doc above for why (stale-keep, not
+    // clear, to avoid a false "dangling" glyph on one bad poll).
+    if let Ok(deliverables) = client.list_deliverables(&project_name, None).await {
+        state.deliverables = Some(deliverables);
     }
     sync_open_view_deliverables(state, &project_name);
 
@@ -153,9 +163,14 @@ async fn refresh_deliverables(state: &mut ProjectCtlState, client: &DaemonClient
 /// whatever `state.deliverables` held at the moment it opened; without this,
 /// a status change (e.g. an operator running `tm projects deliverables
 /// set-status` in another terminal) would never appear in an already-open
-/// view until it was closed and reopened.
+/// view until it was closed and reopened. Only syncs on `Some` — a `None`
+/// (Unknown, e.g. this tick's fetch failed) leaves the view's last-known
+/// list on screen rather than blanking it, the same stale-keep principle
+/// [`refresh_deliverables`] applies to `state.deliverables` itself.
 fn sync_open_view_deliverables(state: &mut ProjectCtlState, project_name: &str) {
-    let deliverables = state.deliverables.clone();
+    let Some(deliverables) = state.deliverables.clone() else {
+        return;
+    };
     if let Some(view) = &mut state.deliverable_view
         && view.project_name == project_name
     {
@@ -624,14 +639,14 @@ mod tests {
     async fn refresh_deliverables_clears_when_no_project_selected() {
         let mut state = ProjectCtlState {
             daemon_reachable: true,
-            deliverables: vec![],
+            deliverables: Some(vec![]),
             ..Default::default()
         };
         let client = DaemonClient::new(dead_loopback_url());
 
         refresh_deliverables(&mut state, &client).await;
 
-        assert!(state.deliverables.is_empty());
+        assert!(state.deliverables.is_none());
     }
 
     #[tokio::test]
@@ -643,9 +658,57 @@ mod tests {
         refresh_deliverables(&mut state, &client).await;
 
         assert!(
-            state.deliverables.is_empty(),
-            "a project IS selected here, but daemon_reachable=false must still clear, \
-             matching state.projects/sessions_by_project's own daemon-down handling"
+            state.deliverables.is_none(),
+            "a project IS selected here, but daemon_reachable=false must still reset to \
+             Unknown, matching state.projects/sessions_by_project's own daemon-down handling"
+        );
+    }
+
+    /// THE review-required regression test: `daemon_reachable == true` (the
+    /// daemon is otherwise healthy — the earlier health probe succeeded) but
+    /// `list_deliverables` itself fails on this one tick. Previously this
+    /// cleared `state.deliverables` outright, which made
+    /// `deliverable_link_state` report every previously-resolved session as
+    /// `Dangling` — a false "the Deliverable was deleted" signal for what was
+    /// really just one dropped HTTP call. The fix: keep the last-known-good
+    /// `Some(list)` untouched, mirroring `refresh_activity`'s stale-keep
+    /// pattern for `ActivityInfo`.
+    #[tokio::test]
+    async fn refresh_deliverables_keeps_stale_list_on_transient_fetch_failure() {
+        let mut state = seeded_activity_state("s1");
+        let known_id = crate::deliverable::DeliverableId::new();
+        state.deliverables = Some(vec![crate::deliverable::Deliverable {
+            id: known_id,
+            project_name: "widget".to_string(),
+            name: "OAuth2 flow".to_string(),
+            description: String::new(),
+            kind: crate::deliverable::DeliverableKind::Feature,
+            ticket_ref: None,
+            spec_ref: None,
+            status: crate::deliverable::DeliverableStatus::InProgress,
+            estimated_effort: crate::deliverable::EstimationTier::M,
+            created_at: chrono::Utc::now(),
+            target_date: None,
+        }]);
+        // `seeded_activity_state` leaves `daemon_reachable = true` — the
+        // failure here is scoped to `list_deliverables` alone, via a dead
+        // loopback client, exactly the "endpoint fails, daemon otherwise up"
+        // case the review flagged.
+        let client = DaemonClient::new(dead_loopback_url());
+
+        refresh_deliverables(&mut state, &client).await;
+
+        let kept = state
+            .deliverables
+            .as_ref()
+            .expect("a transient fetch failure must KEEP the last-known-good list, not clear it");
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].id, known_id);
+        assert_eq!(
+            state.deliverable_link_state(&known_id.to_string()),
+            crate::tui::project_ctl::state::DeliverableLinkState::Resolved,
+            "a previously-resolved link must stay Resolved through one bad poll, \
+             never flip to Dangling"
         );
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/state.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/state.rs
@@ -19,6 +19,7 @@
 
 use std::collections::BTreeMap;
 
+use crate::deliverable::{Deliverable, Milestone};
 use crate::tui::coordinator::nav::ListNav;
 
 /// Which of the three navigable panes currently has keyboard focus.
@@ -114,6 +115,14 @@ pub struct SessionRow {
     pub pending_decision: Option<String>,
     /// Proposed default answer to the pending decision.
     pub proposed_default: Option<String>,
+    /// The Deliverable this session is bound to, if any (DOC-35 §10.6,
+    /// #2379). `Some` drives the Sessions-pane deliverable glyph (#2383);
+    /// whether the id resolves against [`ProjectCtlState::deliverables`] (a
+    /// live link) or not (a dangling ref — the Deliverable was deleted or
+    /// belongs to a project mismatch) is resolved at render time, not stored
+    /// here, so a poll-driven change in the deliverable set is picked up on
+    /// the very next frame without re-deriving this row.
+    pub deliverable_id: Option<String>,
 }
 
 /// Live per-session activity fetched from `GET .../{id}/activity` (DOC-35
@@ -195,6 +204,36 @@ pub struct PendingConfirm {
     pub session_label: String,
 }
 
+/// The read-only Deliverable/Milestone view for one project (DOC-35 §10.8
+/// `show`, #2383), reachable from the Projects pane.
+///
+/// Why: the view is opened for exactly the project selected when the
+/// operator requested it, and — like [`PendingConfirm`] — must pin that
+/// target rather than silently following a later Projects-pane selection
+/// change (which cannot happen anyway while the view is open, since it
+/// captures all input, but pinning by value keeps the render layer from
+/// re-deriving "which project" from a selection that a same-tick poll could
+/// otherwise race). `deliverables` is populated from the same per-tick fetch
+/// [`ProjectCtlState::deliverables`] uses for the Sessions-pane glyph (no
+/// duplicate call — see `poll.rs`); `milestones` is fetched only while this
+/// view is open, the one extra per-tick call this feature adds (disclosed in
+/// the PR body).
+/// What: the target project's name, its Deliverables and Milestones as of
+/// the last successful fetch, and a line-based `scroll` offset for a list
+/// too tall for the overlay.
+/// Test: `super::panes::deliverables_view::tests`, `super::tests`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeliverableView {
+    /// The project this view is scoped to.
+    pub project_name: String,
+    /// The project's Deliverables, as of the last successful fetch.
+    pub deliverables: Vec<Deliverable>,
+    /// The project's Milestones, as of the last successful fetch.
+    pub milestones: Vec<Milestone>,
+    /// How many lines the body is scrolled down from the top.
+    pub scroll: u16,
+}
+
 /// Everything the `tm projects` TUI renders and mutates this frame.
 ///
 /// Why: a single owned struct (mirroring `CoordinatorState`) keeps the
@@ -240,6 +279,23 @@ pub struct ProjectCtlState {
     /// mismatched (stale-selection) snapshot is never rendered under the
     /// wrong session's header.
     pub activity: Option<ActivityInfo>,
+    /// The currently selected project's Deliverables, refreshed on the same
+    /// poll cadence as `projects`/`sessions_by_project` (DOC-35 §10.6,
+    /// #2383). Empty when no project is selected, the project has none, or
+    /// the fetch failed. This is the ONE additional per-tick call the
+    /// Sessions-pane deliverable glyph adds to the poll loop — see
+    /// `poll::project_ctl_poll_daemon`'s doc for the exact budget accounting.
+    /// Also backs [`DeliverableView::deliverables`] when the view is open for
+    /// this same project, so opening it never triggers a second fetch.
+    pub deliverables: Vec<Deliverable>,
+    /// A read-only Deliverable/Milestone view awaiting display (DOC-35 §10.8
+    /// `show`, #2383). While `Some`, [`handle_key`] in `events.rs` routes
+    /// EVERY key through the view's own scroll/close handling instead of
+    /// normal dispatch — the identical "modal captures all input, `Esc`
+    /// closes" discipline [`PendingConfirm`] already establishes.
+    ///
+    /// [`handle_key`]: super::events::handle_key
+    pub deliverable_view: Option<DeliverableView>,
     /// Set when a mutating action just succeeded and the operator should see
     /// the fleet refreshed without waiting for the next timer tick.
     ///
@@ -381,6 +437,58 @@ impl ProjectCtlState {
         self.pending_confirm = None;
     }
 
+    /// Look up a Deliverable by id against the currently fetched
+    /// [`Self::deliverables`] (DOC-35 §10.6, #2383).
+    ///
+    /// Why: the Sessions-pane glyph (`panes::sessions`) needs an O(1)-ish
+    /// membership check per row to decide "resolved link" vs. "dangling
+    /// ref"; a linear scan over the (small, single-project-scoped) list is
+    /// simpler than maintaining a parallel `HashSet` and is only ever run
+    /// once per render, not per poll.
+    /// What: returns the matching [`Deliverable`] when `id` equals one
+    /// entry's `id.to_string()`, else `None` — covers both "never bound"
+    /// (caller already filtered on `Some`) and "bound but no longer resolves"
+    /// (a genuinely dangling ref).
+    /// Test: `deliverable_for_resolves_known_id_and_flags_dangling`.
+    pub fn deliverable_for(&self, id: &str) -> Option<&Deliverable> {
+        self.deliverables.iter().find(|d| d.id.to_string() == id)
+    }
+
+    /// Open the Deliverable/Milestone view for the given project (`v` in the
+    /// Projects pane, DOC-35 §10.8 `show`, #2383).
+    ///
+    /// Why: the single seam [`super::events`]'s `v` handler calls; seeds the
+    /// view with whatever `deliverables` the last poll already fetched (no
+    /// duplicate call — see [`Self::deliverables`]'s doc) and an empty
+    /// `milestones` list that [`super::poll::project_ctl_poll_daemon`] fills
+    /// in on the next tick now that the view is open.
+    /// What: sets [`Self::deliverable_view`], overriding any prior one.
+    /// Test: `super::events::tests`.
+    pub fn open_deliverable_view(&mut self, project_name: impl Into<String>) {
+        self.deliverable_view = Some(DeliverableView {
+            project_name: project_name.into(),
+            deliverables: self.deliverables.clone(),
+            milestones: Vec::new(),
+            scroll: 0,
+        });
+    }
+
+    /// Close the Deliverable/Milestone view (`Esc`/`v` while it is open).
+    pub fn close_deliverable_view(&mut self) {
+        self.deliverable_view = None;
+    }
+
+    /// Scroll the open Deliverable/Milestone view by `delta` lines, floored
+    /// at zero (no known-max clamp — the render layer clamps visually; an
+    /// operator scrolling past the end just sees the last page, matching
+    /// `ListNav`'s existing "clamp at render, not at input" pattern used
+    /// elsewhere in this screen).
+    pub fn scroll_deliverable_view(&mut self, delta: i16) {
+        if let Some(view) = &mut self.deliverable_view {
+            view.scroll = view.scroll.saturating_add_signed(delta);
+        }
+    }
+
     /// Request an immediate daemon re-poll on the next run-loop tick.
     ///
     /// Why: after a mutating action (kill/resume/decommission) the operator
@@ -419,6 +527,7 @@ mod tests {
             state: "active".to_string(),
             pending_decision: None,
             proposed_default: None,
+            deliverable_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/state.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/state.rs
@@ -204,6 +204,35 @@ pub struct PendingConfirm {
     pub session_label: String,
 }
 
+/// The resolution of a session's `deliverable_id` against the currently
+/// known Deliverable set (DOC-35 §10.6, #2383).
+///
+/// Why: a two-state (resolved/dangling) model conflates "confirmed the
+/// Deliverable no longer exists" with "we simply don't know yet" — e.g. the
+/// very first poll after launch, or a transient `list_deliverables` failure
+/// on an otherwise-healthy daemon. Rendering the latter as a red "dangling"
+/// glyph is a false signal (adversarial review finding on #2383's initial
+/// PR): an operator seeing it would reasonably conclude the Deliverable was
+/// deleted, when in fact the daemon just missed one HTTP round trip. A third,
+/// explicit `Unknown` state lets the render layer show NO glyph (rather than
+/// guess) until a fetch actually succeeds or actually confirms absence.
+/// What: `Unknown` when [`ProjectCtlState::deliverables`] is `None` (nothing
+/// fetched yet, or the poll deliberately kept stale-but-unclassified data —
+/// see that field's own doc). `Resolved`/`Dangling` when `Some(list)` either
+/// does or does not contain a matching id.
+/// Test: `super::tests::deliverable_link_state_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliverableLinkState {
+    /// No successfully fetched Deliverable set exists yet for the current
+    /// project — render no glyph, never a dangling one.
+    Unknown,
+    /// The id resolves against the last successfully fetched set.
+    Resolved,
+    /// The id does NOT resolve against the last successfully fetched set —
+    /// a confirmed dangling reference.
+    Dangling,
+}
+
 /// The read-only Deliverable/Milestone view for one project (DOC-35 §10.8
 /// `show`, #2383), reachable from the Projects pane.
 ///
@@ -281,13 +310,23 @@ pub struct ProjectCtlState {
     pub activity: Option<ActivityInfo>,
     /// The currently selected project's Deliverables, refreshed on the same
     /// poll cadence as `projects`/`sessions_by_project` (DOC-35 §10.6,
-    /// #2383). Empty when no project is selected, the project has none, or
-    /// the fetch failed. This is the ONE additional per-tick call the
-    /// Sessions-pane deliverable glyph adds to the poll loop — see
+    /// #2383). `None` means UNKNOWN — no project selected, the selection just
+    /// changed (not yet fetched for the new project), or every fetch so far
+    /// has failed; it does NOT mean "confirmed no Deliverables." `Some(list)`
+    /// — even a `Some(vec![])` — means a fetch for the current project has
+    /// succeeded at least once; a transient fetch failure after that point
+    /// leaves the last-known-good `Some(list)` in place rather than
+    /// overwriting it (mirrors [`ActivityInfo`]'s stale-keep pattern via
+    /// [`refresh_activity`]: `poll::refresh_activity`). This distinction
+    /// matters because [`Self::deliverable_link_state`] must never render a
+    /// bound session's link as "confirmed dangling" just because ONE poll's
+    /// `list_deliverables` call happened to time out — see the review finding
+    /// this fixed. This is the ONE additional per-tick call the Sessions-pane
+    /// deliverable glyph adds to the poll loop — see
     /// `poll::project_ctl_poll_daemon`'s doc for the exact budget accounting.
     /// Also backs [`DeliverableView::deliverables`] when the view is open for
     /// this same project, so opening it never triggers a second fetch.
-    pub deliverables: Vec<Deliverable>,
+    pub deliverables: Option<Vec<Deliverable>>,
     /// A read-only Deliverable/Milestone view awaiting display (DOC-35 §10.8
     /// `show`, #2383). While `Some`, [`handle_key`] in `events.rs` routes
     /// EVERY key through the view's own scroll/close handling instead of
@@ -376,12 +415,19 @@ impl ProjectCtlState {
     /// top on an explicit project switch (but NOT on every poll — see
     /// [`super::poll::project_ctl_poll_daemon`], which preserves the Sessions
     /// selection across a refresh) matches the operator's expectation.
+    /// [`Self::deliverables`] is ALSO reset to `Unknown` (`None`) here — it
+    /// belonged to the PREVIOUS project, and carrying it over would let a new
+    /// project's session rows resolve against a stranger project's Deliverable
+    /// set (harmless by UUID uniqueness, but semantically wrong and worth
+    /// avoiding outright rather than relying on that coincidence).
     /// What: replaces `sessions_nav` with a fresh default, then syncs its
-    /// length to `current_sessions().len()`.
-    /// Test: `project_switch_resets_session_selection`.
+    /// length to `current_sessions().len()`; clears `deliverables` to `None`.
+    /// Test: `project_switch_resets_session_selection`,
+    /// `project_switch_resets_deliverables_to_unknown`.
     pub fn on_project_selection_changed(&mut self) {
         self.sessions_nav = ListNav::default();
         self.sessions_nav.sync_len(self.current_sessions().len());
+        self.deliverables = None;
     }
 
     /// Cycle focus forward (Projects → Sessions → Activity → …).
@@ -437,21 +483,33 @@ impl ProjectCtlState {
         self.pending_confirm = None;
     }
 
-    /// Look up a Deliverable by id against the currently fetched
-    /// [`Self::deliverables`] (DOC-35 §10.6, #2383).
+    /// Resolve one session's `deliverable_id` against the currently fetched
+    /// [`Self::deliverables`] (DOC-35 §10.6, #2383) — a THREE-state result,
+    /// not a boolean, so a transient fetch failure is never rendered as a
+    /// confirmed-dangling reference (see [`DeliverableLinkState`]'s own doc
+    /// for why this distinction exists).
     ///
-    /// Why: the Sessions-pane glyph (`panes::sessions`) needs an O(1)-ish
-    /// membership check per row to decide "resolved link" vs. "dangling
-    /// ref"; a linear scan over the (small, single-project-scoped) list is
-    /// simpler than maintaining a parallel `HashSet` and is only ever run
-    /// once per render, not per poll.
-    /// What: returns the matching [`Deliverable`] when `id` equals one
-    /// entry's `id.to_string()`, else `None` — covers both "never bound"
-    /// (caller already filtered on `Some`) and "bound but no longer resolves"
-    /// (a genuinely dangling ref).
-    /// Test: `deliverable_for_resolves_known_id_and_flags_dangling`.
-    pub fn deliverable_for(&self, id: &str) -> Option<&Deliverable> {
-        self.deliverables.iter().find(|d| d.id.to_string() == id)
+    /// Why: the Sessions-pane glyph (`panes::sessions`) needs this per row; a
+    /// linear scan over the (small, single-project-scoped) list is simpler
+    /// than maintaining a parallel `HashSet` and is only ever run once per
+    /// render, not per poll.
+    /// What: [`Self::deliverables`] is `None` → [`DeliverableLinkState::Unknown`].
+    /// `Some(list)` and `id` matches an entry's `id.to_string()` →
+    /// [`DeliverableLinkState::Resolved`]. `Some(list)` and no entry matches →
+    /// [`DeliverableLinkState::Dangling`].
+    /// Test: `deliverable_link_state_unknown_when_not_yet_fetched`,
+    /// `deliverable_link_state_resolved_and_dangling`.
+    pub fn deliverable_link_state(&self, id: &str) -> DeliverableLinkState {
+        match &self.deliverables {
+            None => DeliverableLinkState::Unknown,
+            Some(list) => {
+                if list.iter().any(|d| d.id.to_string() == id) {
+                    DeliverableLinkState::Resolved
+                } else {
+                    DeliverableLinkState::Dangling
+                }
+            }
+        }
     }
 
     /// Open the Deliverable/Milestone view for the given project (`v` in the
@@ -461,13 +519,16 @@ impl ProjectCtlState {
     /// view with whatever `deliverables` the last poll already fetched (no
     /// duplicate call — see [`Self::deliverables`]'s doc) and an empty
     /// `milestones` list that [`super::poll::project_ctl_poll_daemon`] fills
-    /// in on the next tick now that the view is open.
+    /// in on the next tick now that the view is open. When `deliverables` is
+    /// still `None` (unknown — nothing successfully fetched yet), the view
+    /// opens with an empty Deliverables section that the same next-tick fetch
+    /// backfills; it is not treated as "confirmed zero".
     /// What: sets [`Self::deliverable_view`], overriding any prior one.
     /// Test: `super::events::tests`.
     pub fn open_deliverable_view(&mut self, project_name: impl Into<String>) {
         self.deliverable_view = Some(DeliverableView {
             project_name: project_name.into(),
-            deliverables: self.deliverables.clone(),
+            deliverables: self.deliverables.clone().unwrap_or_default(),
             milestones: Vec::new(),
             scroll: 0,
         });
@@ -588,6 +649,21 @@ mod tests {
     }
 
     #[test]
+    fn project_switch_resets_deliverables_to_unknown() {
+        let mut state = ProjectCtlState {
+            deliverables: Some(vec![]),
+            ..Default::default()
+        };
+        assert!(state.deliverables.is_some());
+        state.on_project_selection_changed();
+        assert!(
+            state.deliverables.is_none(),
+            "switching projects must reset deliverables to Unknown, not carry over the \
+             previous project's (possibly stale) list"
+        );
+    }
+
+    #[test]
     fn notice_set_and_clear() {
         let mut state = ProjectCtlState::default();
         assert!(state.notice.is_none());
@@ -683,5 +759,53 @@ mod tests {
         let confirm = state.pending_confirm.expect("confirm requested");
         assert_eq!(confirm.kind, ConfirmKind::Decommission);
         assert_eq!(confirm.session_id, "sess-2");
+    }
+
+    // ---- DOC-35 §10.6 DeliverableLinkState (#2383 review fix) -------------
+
+    fn sample_deliverable(id: crate::deliverable::DeliverableId) -> Deliverable {
+        Deliverable {
+            id,
+            project_name: "widget".to_string(),
+            name: "OAuth2 flow".to_string(),
+            description: String::new(),
+            kind: crate::deliverable::DeliverableKind::Feature,
+            ticket_ref: None,
+            spec_ref: None,
+            status: crate::deliverable::DeliverableStatus::InProgress,
+            estimated_effort: crate::deliverable::EstimationTier::M,
+            created_at: chrono::Utc::now(),
+            target_date: None,
+        }
+    }
+
+    #[test]
+    fn deliverable_link_state_unknown_when_not_yet_fetched() {
+        let state = ProjectCtlState::default();
+        assert!(state.deliverables.is_none());
+        assert_eq!(
+            state.deliverable_link_state("any-id"),
+            DeliverableLinkState::Unknown,
+            "before any successful fetch (or after one keeps failing), the link state \
+             must be Unknown, never Dangling"
+        );
+    }
+
+    #[test]
+    fn deliverable_link_state_resolved_and_dangling() {
+        let id = crate::deliverable::DeliverableId::new();
+        let state = ProjectCtlState {
+            deliverables: Some(vec![sample_deliverable(id)]),
+            ..Default::default()
+        };
+        assert_eq!(
+            state.deliverable_link_state(&id.to_string()),
+            DeliverableLinkState::Resolved
+        );
+        assert_eq!(
+            state.deliverable_link_state("00000000-0000-0000-0000-000000000000"),
+            DeliverableLinkState::Dangling,
+            "a Some(list) that does not contain the id is a CONFIRMED dangling ref"
+        );
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -14,7 +14,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use super::events::{PendingAction, handle_key};
 use super::panes::{actions_bar, projects, sessions};
 use super::poll::{project_ctl_poll_daemon, project_to_row, session_to_row};
-use super::state::{ConfirmKind, Pane, ProjectCtlState};
+use super::state::{ConfirmKind, DeliverableLinkState, Pane, ProjectCtlState};
 use crate::client::{DaemonClient, FleetProjectGroupWire, ManagedSessionSummary};
 use crate::project::Project;
 
@@ -100,7 +100,11 @@ fn seeded_state_renders_live_project_and_its_session() {
         "expected a live glyph+count: {text}"
     );
 
-    let session_line = sessions::session_line(1, &state.current_sessions()[0], false);
+    let session_line = sessions::session_line(
+        1,
+        &state.current_sessions()[0],
+        DeliverableLinkState::Unknown,
+    );
     let text: String = session_line
         .spans
         .iter()

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -49,6 +49,7 @@ fn summary(id: &str, state: &str) -> ManagedSessionSummary {
         task: Some("ship it".to_string()),
         cwd: None,
         claude_session_id: None,
+        deliverable_id: None,
         pane_id: None,
     }
 }
@@ -99,7 +100,7 @@ fn seeded_state_renders_live_project_and_its_session() {
         "expected a live glyph+count: {text}"
     );
 
-    let session_line = sessions::session_line(1, &state.current_sessions()[0]);
+    let session_line = sessions::session_line(1, &state.current_sessions()[0], false);
     let text: String = session_line
         .spans
         .iter()
@@ -187,5 +188,30 @@ async fn poll_never_touches_pending_confirm() {
         state.pending_confirm,
         Some(before),
         "a poll must never mutate an open confirmation gate's pinned target"
+    );
+}
+
+/// A daemon poll racing with an open Deliverable/Milestone view must never
+/// close it (DOC-35 §10.8, #2383) — mirrors `poll_never_touches_pending_confirm`
+/// for the second modal this screen now has. A daemon-down poll MAY leave the
+/// view's cached `deliverables`/`milestones` stale (there is no live
+/// connection to refresh them from), but must not clear `deliverable_view`
+/// itself out from under the operator.
+#[tokio::test]
+async fn poll_never_closes_an_open_deliverable_view() {
+    let mut state = seeded_state();
+    state.open_deliverable_view("trusty-tools");
+    assert!(state.deliverable_view.is_some());
+
+    let mut client = DaemonClient::new(dead_loopback_url());
+    project_ctl_poll_daemon(&mut state, &mut client).await;
+
+    assert_eq!(
+        state
+            .deliverable_view
+            .as_ref()
+            .map(|v| v.project_name.as_str()),
+        Some("trusty-tools"),
+        "a poll must never close an open Deliverable/Milestone view"
     );
 }


### PR DESCRIPTION
## Summary

Closes #2383 — WI-17, the last work item of epic #2108. Adds:

1. **Sessions-pane deliverable glyph**: any session row whose `SessionRecord.deliverable_id` is `Some` (already wired end-to-end by #2379) now renders a trailing glyph, resolved via a three-state `DeliverableLinkState` (see the post-review fix below for why it's three states, not two):
   - `◆` (cyan) — the id resolves against the currently fetched Deliverable set for the selected project.
   - `◈` (dim red) — the id is CONFIRMED not to resolve against a successfully fetched set — a genuine dangling reference (e.g. the Deliverable was deleted out from under the session).
   - No glyph at all — either `deliverable_id` is `None` (unbound, the common case), or no Deliverable set has been successfully fetched yet for the current project (`Unknown` — never guessed as dangling).
2. **Read-only Deliverable/Milestone view**, reachable from the Projects pane, listing the selected project's Deliverables and Milestones with status (DOC-35 §10.8 `show` semantics, read-only — no create/update/delete/assign from the TUI in this slice).

## Disclosed deviations from the spec

- **§12 has no visual glyph spec.** The issue text points to "§12" for "the Sessions-pane deliverable glyph visual spec," but §12 of `docs/specs/tm-project-control-plane.md` is the *work-items table* (the row that filed #2383 itself) — it contains no glyph/color spec, and a full-text search of the doc for "glyph" turns up only the pre-existing aggregate-state glyph in §5.1's Projects-pane description. The exact glyph (`◆`/`◈`), colors (cyan/dim-red), and the Unknown/Resolved/Dangling tri-state are therefore an original design choice, not a spec transcription. Chosen to sit visually next to (not collide with) the existing session-state glyph vocabulary (`●`/`◍`/`○`/`✗`/`⊘`) already defined in `panes/sessions.rs`.
- **§10.8's `show` is a single-record lookup with bound sessions; this view is a project-scoped list instead.** §10.8's CLI sketch is `deliverables show <project> <id>` (one record + its bound sessions). Issue #2383's own scope line asks for "Deliverable/Milestone view... reachable from Projects pane" without pinning the single-record `show` shape, and the task brief for this issue explicitly asks for something that "lists the selected project's deliverables and milestones with status." This PR implements the list reading, not a per-Deliverable bound-sessions drill-down. Per-Deliverable drill-down is left for a future slice if wanted.
- **Deliverables reset to Unknown on daemon-down or project switch, but are KEPT (stale) on a transient single-endpoint fetch failure.** This is a refinement made during review (see below) — the two cases are handled differently on purpose: a full daemon outage also clears `state.projects`/`sessions_by_project` (every session row vanishes, so the glyph question is moot), while a `list_deliverables`-only failure with the daemon otherwise healthy now mirrors `refresh_activity`'s stale-keep pattern instead of clearing.

## View design

- Opened via **`v`** in the Projects pane (see keybinding rationale below) for the currently-selected project; closed via **`Esc`** or a second **`v`** (mirrors the existing `tui::dashboard` help-overlay's "same key opens and closes" convention).
- Rendered as a centred overlay (`Clear` + bordered `Paragraph`, `72x20` cells, clamped to the terminal), a strict *addition* to the existing 4-pane layout (§5.1) — no pane is replaced or resized.
- Body: `DELIVERABLES (N)` then one line per Deliverable (`[status] name (tier)`), a blank separator, then `MILESTONES (N)` the same shape (`[status] name  target: YYYY-MM-DD`). `↑`/`↓` scroll the body.
- **Modal key-swallowing discipline mirrors the existing confirm gate exactly**: while `ProjectCtlState::deliverable_view` is `Some`, `handle_key` routes every key through `handle_deliverable_view_key` before the normal dispatch table (checked right after `pending_confirm`) — `q`/`Ctrl-C` are swallowed (not "not in a modal"), unrecognised keys are no-ops, only `Esc`/`v` close it.

## Keybinding choice + collision check

`v` was chosen because every other unshifted letter is already bound: `l`/`k`/`r`/`d`/`a` in the Sessions pane, `c` in the Projects pane, and `y`/`n` are reserved by the confirm gate. `v` is free in every pane/context and is mnemonic for "view" / §10.8's read-only `show`. Bound only in the Projects pane (mirrors `c`'s existing Projects-only scoping), with a `no project selected` notice (same pattern as `l`/`c`) when the registry is empty.

## Poll-budget impact

- **+1 steady-state call per tick**: `list_deliverables(<selected project>, None)`, scoped to the currently selected project only (mirrors how `refresh_activity` scopes its own fetch to the selected session, not the whole fleet) — never a per-session loop. This same fetched list backs both the Sessions-pane glyph resolution *and* the view's `deliverables` section when open, so opening the view never triggers a duplicate fetch.
- **+1 call only while the view is open**: `list_milestones(<selected project>)`, bounded by "is a modal open," never by session/project count.
- `pending_confirm` is untouched by any of this — `refresh_deliverables` never reads or writes it, and the existing `poll_never_touches_pending_confirm` regression test stays green. Added a matching `poll_never_closes_an_open_deliverable_view` regression test for the second modal.

## Post-review fix (adversarial review round — code-critic, WARN verdict)

Two findings from an independent adversarial review of the initial PR, both fixed in the follow-up commit on this same branch:

- **HIGH — false "dangling" glyph on a transient fetch failure.** The original `refresh_deliverables` collapsed "not yet fetched," "transient failure," and "confirmed absent" into one `state.deliverables: Vec<Deliverable>` that got `.clear()`-ed on ANY `Err`, even when `daemon_reachable == true` (i.e. only the `list_deliverables` endpoint itself failed, everything else on that poll succeeded). That made every validly-linked session render the red "dangling" glyph until the next successful tick — a false "this Deliverable was deleted" signal. **Fix**: `state.deliverables` is now `Option<Vec<Deliverable>>` backing a new `DeliverableLinkState::{Unknown,Resolved,Dangling}` tri-state (`state.rs`). `None` means genuinely unknown (never fetched yet, or reset on project switch/daemon-down); `Some(list)` means a fetch has succeeded at least once. On a transient `Err`, `refresh_deliverables` (`poll.rs`) now leaves `state.deliverables` **untouched** — `None` stays `None`, `Some(stale-but-good)` stays exactly that — mirroring `refresh_activity`'s existing stale-keep idiom. The Sessions-pane glyph (`panes/sessions.rs`) now renders NO glyph at all for `Unknown`, never guessing dangling. New regression test: `poll::tests::refresh_deliverables_keeps_stale_list_on_transient_fetch_failure` — asserts `daemon_reachable == true` + a dead-loopback `list_deliverables` error + a previously-populated list → the list is kept and `deliverable_link_state` still reports `Resolved`, not `Dangling`.
- **LOW — doc/impl mismatch on the dangling glyph's color.** The module doc said "dim red" but the implementation used plain `Color::Red` (visually identical to the errored-session state glyph). **Fix**: `deliverable_glyph` now returns a `Style` (not just a `Color`) and adds `Modifier::DIM` to the dangling branch, matching the doc's stated intent and disambiguating it from `ERRORED_GLYPH`'s full-intensity red. Covered by `panes::sessions::tests::deliverable_glyph_resolved_and_dangling`, which now asserts `style.add_modifier.contains(Modifier::DIM)`.

**Advisory (not acted on, disclosed per the review's own instruction):** `events.rs` is now at **491/500 SLOC** — close to the cap. A pre-emptive split (hoisting `handle_deliverable_view_key` and the confirm-gate handler into a sibling `modal.rs`) is recommended before any future feature touches this file. Deferring the actual split is acceptable since #2383 is the last item of epic #2108 and nothing else is currently queued to grow this file.

## Test evidence

Initial implementation:
```
cargo build --workspace                                    → Finished, 0 errors
cargo test --workspace                                      → 13586 passed; 0 failed; 103 ignored
cargo clippy --workspace --all-targets -- -D warnings        → clean
cargo fmt --check                                            → clean
bash scripts/check_line_cap.sh                                → line-cap: 0 allowlisted, 0 violations — OK.
```

Post-review fix (final state on this branch):
```
cargo build --workspace                                    → Finished, 0 errors
cargo test --workspace                                      → 13591 passed; 0 failed; 103 ignored
cargo clippy --workspace --all-targets -- -D warnings        → clean (0 errors; pre-existing unrelated tga MSRV note only)
cargo fmt --check                                            → clean
bash scripts/check_line_cap.sh                                → line-cap: 0 allowlisted, 0 violations — OK.
```

`cargo test -p trusty-mpm --lib project_ctl` (scoped): **88 passed, 0 failed** (was 83 before the fix — 5 new tests: `deliverable_link_state_unknown_when_not_yet_fetched`, `deliverable_link_state_resolved_and_dangling`, `project_switch_resets_deliverables_to_unknown`, `refresh_deliverables_keeps_stale_list_on_transient_fetch_failure`, `deliverable_glyph_none_when_unknown`), including both `poll_never_touches_*` regression tests.

## Files changed (by crate — all `trusty-mpm`)

- `crates/trusty-mpm/src/client/http_client/types.rs` — `ManagedSessionSummary.deliverable_id` (mirrors the daemon's existing `SessionSummary.deliverable_id`, #2379)
- `crates/trusty-mpm/src/tui/project_ctl/state.rs` — `SessionRow.deliverable_id`, `DeliverableView`, `DeliverableLinkState`, `ProjectCtlState.deliverables` (now `Option<Vec<Deliverable>>`) / `.deliverable_view`, open/close/scroll/link-state methods
- `crates/trusty-mpm/src/tui/project_ctl/poll.rs` — `refresh_deliverables` (stale-keep on transient failure) + `sync_open_view_deliverables`
- `crates/trusty-mpm/src/tui/project_ctl/events.rs` — `v` binding, `handle_deliverable_view_key` (491/500 SLOC — flagged above for a future split)
- `crates/trusty-mpm/src/tui/project_ctl/layout.rs` — overlay composition
- `crates/trusty-mpm/src/tui/project_ctl/panes/deliverables_view.rs` — new: overlay render + pure body-text builders
- `crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs` — deliverable glyph (tri-state + dim dangling style)
- `crates/trusty-mpm/src/tui/project_ctl/panes/{actions_bar,activity,mod}.rs`, `tests.rs` — hint text, test literal updates, cross-module regression tests
- `crates/trusty-mpm/src/{bin/tm/commands/guided_inplace.rs,bin/tm/tests_behavior_c_tests.rs,client/resolver.rs}` — mechanical `deliverable_id: None` additions to pre-existing `ManagedSessionSummary` test literals (additive field, non-functional)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
