### PR TITLE
feat(trusty-common): inference foundation — types, InferenceAdapter trait, capability registry, configurator

### DIFF
--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -41,6 +41,15 @@ name = "memory_palace"
 path = "tests/memory_palace.rs"
 required-features = ["memory-core", "embedder-test-support"]
 
+# Inference-foundation integration suite (issue #2402). References
+# `trusty_common::inference::{InferenceAdapter, Configurator, …}`, which only
+# exist behind the `inference-client` feature, so — like `memory_palace` above —
+# `required-features` tells cargo to skip building it unless that feature is on.
+[[test]]
+name = "inference_foundation"
+path = "tests/inference_foundation.rs"
+required-features = ["inference-client"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -473,3 +482,15 @@ credentials = ["dep:thiserror", "dep:toml", "dep:dotenvy"]
 # `FileKeyStore` as the runtime-probed fallback (issue #2401). Pulls in the
 # `keyring` crate in addition to everything `credentials` already requires.
 keyring-store = ["credentials", "dep:keyring"]
+# Enables the `inference` adapter foundation (issue #2402, epic #2400 Wave 1):
+# the `types` request/response model, `InferenceError`, the `InferenceAdapter`
+# trait, the capability `registry` (context windows incl. the #2330 haiku fix,
+# pricing, caching, tool dialects), the two-stage `configurator` (`provider_for`
+# + `Configurator`), and the `test_support::ScriptedAdapter` double. Composes
+# with `credentials` for the resolver's env > `.env.local` > store precedence.
+# Adds NO new dependencies — `async-trait`, `serde`, `serde_json`, and (via
+# `credentials`) `thiserror` are already required. The axum HTTP mock
+# (`test_support::MockInferenceServer`) additionally requires `axum-server`; it
+# is not pulled in by this feature, keeping the base surface HTTP-server-free.
+# Concrete provider adapters (OpenRouter/Fireworks/Bedrock) land in #2403/#2407.
+inference-client = ["credentials"]

--- a/crates/trusty-common/src/inference/adapter.rs
+++ b/crates/trusty-common/src/inference/adapter.rs
@@ -1,0 +1,131 @@
+//! [`InferenceAdapter`] — the object-safe async inference surface.
+//!
+//! Why: the whole epic exists to replace six bespoke LLM clients with ONE trait
+//! every consumer depends on. It unions tcode's `LlmClientTrait` (the async
+//! `chat` seam) and `Provider` (name, tool-choice mapping, capability
+//! introspection) plus trusty-review's `supports_structured_output`, so a
+//! consumer can drive any provider through `Box<dyn InferenceAdapter>` without
+//! branching on the backend. Concrete HTTP adapters (OpenRouter/Fireworks/
+//! Bedrock) land in #2403/#2407 — this ticket defines only the surface and a
+//! test-only implementation.
+//! What: [`InferenceAdapter`] — `async fn chat`, `name`, `capabilities`, a
+//! `map_tool_choice` hook, and capability-introspection defaults derived from
+//! the adapter's [`ProviderCapabilities`]. Object-safe (async via
+//! `async_trait`), so it is boxable/`Arc`-able for the configurator.
+//! Test: exercised by `test_support::ScriptedAdapter` and the configurator
+//! round-trip in `crates/trusty-common/tests/inference_foundation.rs`.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::inference::error::InferenceError;
+use crate::inference::registry::{ProviderCapabilities, context_window};
+use crate::inference::types::{ChatRequest, ChatResponse, ToolChoice, openai_tool_choice};
+
+/// The async inference surface every provider implements.
+///
+/// Why: one seam lets the agent loop, trusty-review, and tga issue a chat call
+/// against any provider identically; the concrete HTTP mechanics live in each
+/// adapter, not in the caller. `Send + Sync` are required because callers share
+/// adapters across `tokio` tasks.
+/// What: implementors MUST provide [`Self::name`], [`Self::capabilities`], and
+/// [`Self::chat`]. The remaining methods have capability-derived defaults an
+/// implementor overrides only when its wire behaviour differs (e.g. an
+/// Anthropic-dialect adapter overriding [`Self::map_tool_choice`]). Object-safe:
+/// `async_trait` boxes the `chat` future so `Box<dyn InferenceAdapter>` works.
+/// Test: `ScriptedAdapter` (test_support) implements it; the configurator drives
+/// it as a trait object.
+#[async_trait]
+pub trait InferenceAdapter: Send + Sync {
+    /// Stable provider name for logging and diagnostics.
+    ///
+    /// Why: telemetry and error messages need a human-readable backend label.
+    /// What: a short identifier such as `"openrouter"` or `"scripted"`.
+    /// Test: configurator round-trip asserts the built adapter's name.
+    fn name(&self) -> &str;
+
+    /// The capability descriptor for this adapter's provider.
+    ///
+    /// Why: the introspection defaults below read from it, and consumers query
+    /// it directly to decide per-model behaviour before issuing a call.
+    /// What: returns a borrowed [`ProviderCapabilities`] (typically a `&'static`
+    /// from [`crate::inference::registry::capabilities`], but an adapter may own
+    /// a customised copy).
+    /// Test: `supports_*` defaults are derived from it.
+    fn capabilities(&self) -> &ProviderCapabilities;
+
+    /// Issue one chat/completions call.
+    ///
+    /// Why: the single method the whole agent loop depends on; a one-call surface
+    /// keeps test doubles trivial and the caller's dependency minimal.
+    /// What: sends `request` to the provider and yields a [`ChatResponse`]
+    /// (which carries the normalized [`crate::inference::Usage`]) or an
+    /// [`InferenceError`] the caller classifies via
+    /// [`InferenceError::is_retryable`]/[`InferenceError::is_alarm`].
+    /// Test: `ScriptedAdapter::chat` returns queued scripted responses.
+    async fn chat(&self, request: &ChatRequest) -> Result<ChatResponse, InferenceError>;
+
+    /// Translate a neutral [`ToolChoice`] into this provider's wire JSON.
+    ///
+    /// Why: OpenAI-dialect and Anthropic-dialect providers spell tool-choice
+    /// differently; centralising the mapping keeps the caller dialect-agnostic.
+    /// What: defaults to the OpenAI spelling ([`openai_tool_choice`]); an
+    /// Anthropic-dialect adapter overrides this.
+    /// Test: default asserted via the OpenAI mapper's own tests.
+    fn map_tool_choice(&self, choice: ToolChoice) -> Value {
+        openai_tool_choice(choice)
+    }
+
+    /// Whether the provider supports native function-calling.
+    ///
+    /// Why: models without native tool support need prompt-emulated guidance
+    /// instead of a `tools` array; this flag drives that selection.
+    /// What: defaults to `capabilities().native_tool_calling`.
+    /// Test: registry seed assertions.
+    fn supports_native_tools(&self) -> bool {
+        self.capabilities().native_tool_calling
+    }
+
+    /// Whether the provider honours Anthropic-style prompt-cache breakpoints.
+    ///
+    /// Why: gating the `cache_control` marker to caching-capable providers keeps
+    /// the wire payload minimal for models that can never benefit.
+    /// What: defaults to `capabilities().prompt_caching`.
+    /// Test: registry seed assertions.
+    fn supports_prompt_caching(&self) -> bool {
+        self.capabilities().prompt_caching
+    }
+
+    /// Whether the provider supports structured / JSON-schema output.
+    ///
+    /// Why: the capability trusty-review needs to request schema-constrained
+    /// responses; folded into the trait so every consumer shares one answer.
+    /// What: defaults to `capabilities().structured_output`.
+    /// Test: registry seed assertions.
+    fn supports_structured_output(&self) -> bool {
+        self.capabilities().structured_output
+    }
+
+    /// Whether to request detailed usage accounting (OpenRouter's
+    /// `usage: {"include": true}` directive).
+    ///
+    /// Why: only OpenRouter returns its authoritative cache-aware cost when asked;
+    /// other providers must never see the directive.
+    /// What: defaults to `capabilities().detailed_usage_accounting`.
+    /// Test: registry seed assertions.
+    fn wants_detailed_usage(&self) -> bool {
+        self.capabilities().detailed_usage_accounting
+    }
+
+    /// The context window (in tokens) for a model slug served by this provider.
+    ///
+    /// Why: compaction/budget code asks the adapter for the real window rather
+    /// than hard-coding one; the answer is model-specific (incl. the #2330 haiku
+    /// fix) with the provider default as a fallback.
+    /// What: defaults to [`context_window`] with this adapter's capabilities as
+    /// the provider-default tier.
+    /// Test: `context` submodule tests (`haiku_resolves_to_200k`).
+    fn context_window(&self, model: &str) -> usize {
+        context_window(model, Some(self.capabilities()))
+    }
+}

--- a/crates/trusty-common/src/inference/configurator/mod.rs
+++ b/crates/trusty-common/src/inference/configurator/mod.rs
@@ -1,0 +1,193 @@
+//! [`Configurator`] — the provider-name → adapter construction seam.
+//!
+//! Why: the two-stage [`provider_for`] resolver decides WHICH provider and
+//! credential to use, but something must turn that decision into a live
+//! `Box<dyn InferenceAdapter>`. Concrete adapters do not exist in this
+//! foundation ticket (they land in #2403/#2407), so the construction step is a
+//! registration seam: real adapters register a factory per provider, and the
+//! configurator wires resolution → factory → adapter. This ticket exercises the
+//! seam end-to-end against the test-only `ScriptedAdapter`.
+//! What: [`AdapterFactory`] (a per-provider builder, with a blanket impl for
+//! plain closures), [`Configurator`] (a registry of factories plus
+//! [`Configurator::build`], which resolves a slug then invokes the matching
+//! factory), and the re-exported [`provider_for`]/[`ResolvedProvider`].
+//! Test: inline `tests` + the full resolve→build→chat cycle in
+//! `crates/trusty-common/tests/inference_foundation.rs`.
+
+mod resolver;
+
+pub use resolver::{ResolvedProvider, provider_for};
+
+use std::collections::HashMap;
+
+use crate::inference::adapter::InferenceAdapter;
+use crate::inference::credentials::KeyStore;
+use crate::inference::error::InferenceError;
+use crate::inference::registry::ProviderId;
+
+/// Builds a concrete [`InferenceAdapter`] from a [`ResolvedProvider`].
+///
+/// Why: decouples the configurator from any concrete adapter — #2403 registers
+/// real HTTP factories, tests register a scripted-adapter factory, and neither
+/// changes the configurator. `Send + Sync` because a `Configurator` may be
+/// shared across `tokio` tasks.
+/// What: one method mapping a resolution outcome to a boxed adapter (or an
+/// [`InferenceError`] if construction fails, e.g. an unsupported model).
+/// Test: the blanket closure impl is used by the configurator tests.
+pub trait AdapterFactory: Send + Sync {
+    /// Construct an adapter for the resolved provider/credential.
+    ///
+    /// Why: the single construction hook the configurator calls.
+    /// What: returns a boxed [`InferenceAdapter`] or an [`InferenceError`].
+    /// Test: `build_uses_registered_factory`.
+    fn build(
+        &self,
+        resolved: &ResolvedProvider,
+    ) -> Result<Box<dyn InferenceAdapter>, InferenceError>;
+}
+
+impl<F> AdapterFactory for F
+where
+    F: Fn(&ResolvedProvider) -> Result<Box<dyn InferenceAdapter>, InferenceError> + Send + Sync,
+{
+    /// Blanket impl so a plain closure is a factory.
+    ///
+    /// Why: registering an adapter should be one closure, not a bespoke unit
+    /// struct + impl per provider.
+    /// What: forwards to the closure.
+    /// Test: `build_uses_registered_factory` registers a closure.
+    fn build(
+        &self,
+        resolved: &ResolvedProvider,
+    ) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+        self(resolved)
+    }
+}
+
+/// Registry of per-provider adapter factories.
+///
+/// Why: the construction seam that lets adapters be wired in independently of
+/// resolution. Empty by default — a build attempt against an unregistered
+/// provider is an explicit [`InferenceError::NoAdapterRegistered`], never a
+/// silent fallback.
+/// What: a `ProviderId → AdapterFactory` map with [`Configurator::register`] and
+/// [`Configurator::build`] (resolve via [`provider_for`], then dispatch to the
+/// factory).
+/// Test: `build_uses_registered_factory`, `build_unregistered_provider_errors`.
+#[derive(Default)]
+pub struct Configurator {
+    factories: HashMap<ProviderId, Box<dyn AdapterFactory>>,
+}
+
+impl Configurator {
+    /// Create an empty configurator with no factories registered.
+    ///
+    /// Why: consumers start empty and register exactly the providers they wire
+    /// in — no implicit adapters.
+    /// What: an empty factory map.
+    /// Test: `build_unregistered_provider_errors`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a factory for a provider (replacing any existing one).
+    ///
+    /// Why: #2403's real adapters and tests both register through this one door.
+    /// What: inserts `factory` under `id`; a later registration for the same id
+    /// replaces the earlier one.
+    /// Test: `build_uses_registered_factory`.
+    pub fn register(&mut self, id: ProviderId, factory: Box<dyn AdapterFactory>) {
+        self.factories.insert(id, factory);
+    }
+
+    /// Resolve `slug` and build the matching adapter.
+    ///
+    /// Why: the end-to-end entry point — one call turns a model slug + credential
+    /// store into a live adapter.
+    /// What: runs [`provider_for`] (two-stage resolution against `store`), looks
+    /// up the resolved provider's factory, and invokes it. Returns
+    /// [`InferenceError::MissingCredential`] when resolution fails, or
+    /// [`InferenceError::NoAdapterRegistered`] when no factory is registered for
+    /// the resolved provider.
+    /// Test: `build_uses_registered_factory`, `build_unregistered_provider_errors`.
+    pub fn build(
+        &self,
+        slug: &str,
+        store: &dyn KeyStore,
+    ) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+        let resolved = provider_for(slug, store)?;
+        let factory = self.factories.get(&resolved.provider()).ok_or(
+            InferenceError::NoAdapterRegistered {
+                provider: resolved.provider(),
+            },
+        )?;
+        factory.build(&resolved)
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::credentials::MemoryKeyStore;
+    use crate::inference::registry::capabilities;
+    use crate::inference::test_support::ScriptedAdapter;
+    use serial_test::serial;
+
+    fn clear_env() {
+        for var in ["OPENROUTER_API_KEY", "ANTHROPIC_API_KEY"] {
+            // SAFETY: guarded by `#[serial(dotenv_credential_env)]`.
+            unsafe { std::env::remove_var(var) };
+        }
+    }
+
+    /// Why: a registered factory must be invoked with the resolution outcome and
+    /// produce a working adapter.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn build_uses_registered_factory() {
+        clear_env();
+        let store = MemoryKeyStore::new();
+        store.set("openrouter", "sk-or-abc").unwrap(); // pragma: allowlist secret
+
+        let mut cfg = Configurator::new();
+        cfg.register(
+            ProviderId::OpenRouter,
+            Box::new(|resolved: &ResolvedProvider| {
+                let caps = capabilities(resolved.provider());
+                Ok(Box::new(ScriptedAdapter::echo("openrouter", caps))
+                    as Box<dyn InferenceAdapter>)
+            }),
+        );
+
+        let adapter = cfg.build("some/model", &store).expect("built");
+        assert_eq!(adapter.name(), "openrouter");
+    }
+
+    /// Why: resolving to a provider with no registered factory must be an
+    /// explicit alarm error, never a silent fallback.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn build_unregistered_provider_errors() {
+        clear_env();
+        let store = MemoryKeyStore::new();
+        store.set("openrouter", "sk-or-abc").unwrap(); // pragma: allowlist secret
+
+        let cfg = Configurator::new(); // nothing registered
+        // `Box<dyn InferenceAdapter>` is not `Debug`, so `expect_err` won't
+        // compile; match the error out instead.
+        let Err(err) = cfg.build("some/model", &store) else {
+            panic!("expected NoAdapterRegistered");
+        };
+        assert!(err.is_alarm());
+        assert!(matches!(
+            err,
+            InferenceError::NoAdapterRegistered {
+                provider: ProviderId::OpenRouter
+            }
+        ));
+    }
+}

--- a/crates/trusty-common/src/inference/configurator/resolver.rs
+++ b/crates/trusty-common/src/inference/configurator/resolver.rs
@@ -1,0 +1,236 @@
+//! Two-stage provider resolution (issue #2402; the `provider_for` resolver).
+//!
+//! Why: a model slug must map to a provider AND a resolved credential in one
+//! authoritative place, or every consumer re-invents the "which backend, whose
+//! key" decision. The epic's rule is precise: an explicit `<prefix>/…` slug
+//! selects a family, but that family is only used if its credential actually
+//! resolves — otherwise (and for bare slugs) resolution defaults to OpenRouter.
+//! What: [`provider_for`] implements that two-stage ladder against the #2401
+//! credential resolver (env > `.env.local` > secure store), returning a
+//! [`ResolvedProvider`] carrying the provider id, the model slug, and the
+//! resolved key (wrapped in a redacting [`SecretString`]). Bedrock resolves with
+//! no key (AWS credential chain).
+//! Test: inline `tests` — `explicit_prefix_with_key_wins`,
+//! `explicit_prefix_missing_key_falls_back_to_openrouter`, `bare_slug_uses_openrouter`,
+//! `bedrock_resolves_without_key`, `no_credential_anywhere_errors`.
+
+use crate::inference::credentials::{KeyStore, resolve_key_with};
+use crate::inference::error::InferenceError;
+use crate::inference::registry::{ProviderCapabilities, ProviderId, capabilities};
+use crate::inference::types::SecretString;
+
+/// The outcome of resolving a model slug: which provider, which model, and the
+/// credential to build an adapter with.
+///
+/// Why: the configurator needs all three to construct an adapter; bundling them
+/// keeps the resolver's contract explicit and lets the adapter factory stay a
+/// pure function of this value.
+/// What: `provider` is the resolved [`ProviderId`]; `model` is the (possibly
+/// re-homed) slug to send; `key` is the resolved credential or `None` for
+/// Bedrock. `Debug` is safe to log — `key`'s [`SecretString`] redacts itself.
+/// Test: every resolver test asserts the resolved fields.
+#[derive(Debug, Clone)]
+pub struct ResolvedProvider {
+    provider: ProviderId,
+    model: String,
+    key: Option<SecretString>,
+}
+
+impl ResolvedProvider {
+    /// Construct a resolution outcome.
+    ///
+    /// Why: the resolver builds this in a few branches; one constructor keeps
+    /// them uniform.
+    /// What: stores the three fields verbatim.
+    /// Test: exercised by every resolver test.
+    pub(crate) fn new(provider: ProviderId, model: String, key: Option<SecretString>) -> Self {
+        Self {
+            provider,
+            model,
+            key,
+        }
+    }
+
+    /// The resolved provider.
+    ///
+    /// Why: the configurator selects an adapter factory by this id.
+    /// What: returns the [`ProviderId`].
+    /// Test: `explicit_prefix_with_key_wins`.
+    pub fn provider(&self) -> ProviderId {
+        self.provider
+    }
+
+    /// The model slug to send to the provider.
+    ///
+    /// Why: an adapter needs the concrete slug for its request body.
+    /// What: returns the stored slug.
+    /// Test: `bare_slug_uses_openrouter`.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// The resolved API key, if any.
+    ///
+    /// Why: adapter construction (#2403) authenticates with it; Bedrock returns
+    /// `None` (AWS credential chain). Exposed as the redacting wrapper so callers
+    /// must opt into the raw value via [`SecretString::expose`].
+    /// What: returns the stored [`SecretString`] or `None`.
+    /// Test: `bedrock_resolves_without_key`, `explicit_prefix_with_key_wins`.
+    pub fn key(&self) -> Option<&SecretString> {
+        self.key.as_ref()
+    }
+
+    /// The capability descriptor for the resolved provider.
+    ///
+    /// Why: an adapter factory reads capabilities to build the adapter; this
+    /// saves it a separate registry lookup.
+    /// What: delegates to [`capabilities`].
+    /// Test: `explicit_prefix_with_key_wins`.
+    pub fn capabilities(&self) -> &'static ProviderCapabilities {
+        capabilities(self.provider)
+    }
+}
+
+/// Resolve a model slug to a provider + credential via the two-stage ladder.
+///
+/// Why: the single authoritative "which backend, whose key" decision every
+/// consumer shares.
+/// What: **Stage 1** — if `slug` carries an explicit family prefix
+/// ([`ProviderId::from_slug_prefix`]): for Bedrock, resolve immediately with no
+/// key; for a keyed family, use it ONLY when its credential resolves via
+/// [`resolve_key_with`] (env > `.env.local` > `store`), otherwise fall through.
+/// **Stage 2 (default)** — resolve OpenRouter with its credential. If even
+/// OpenRouter has no credential, return [`InferenceError::MissingCredential`].
+/// The `store` is injected (rather than using the process default) so callers —
+/// and tests — control the secure-store tier explicitly.
+/// Test: `explicit_prefix_with_key_wins`,
+/// `explicit_prefix_missing_key_falls_back_to_openrouter`, `bare_slug_uses_openrouter`,
+/// `bedrock_resolves_without_key`, `no_credential_anywhere_errors`.
+pub fn provider_for(slug: &str, store: &dyn KeyStore) -> Result<ResolvedProvider, InferenceError> {
+    // ── Stage 1: explicit family prefix ──
+    if let Some(family) = ProviderId::from_slug_prefix(slug) {
+        match family.credential_name() {
+            // Bedrock authenticates via the AWS chain — no key to resolve.
+            None => return Ok(ResolvedProvider::new(family, slug.to_string(), None)),
+            Some(cred) => {
+                if let Some(key) = resolve_key_with(cred, store) {
+                    return Ok(ResolvedProvider::new(
+                        family,
+                        slug.to_string(),
+                        Some(SecretString::new(key)),
+                    ));
+                }
+                // Family key missing → fall through to the OpenRouter default.
+            }
+        }
+    }
+
+    // ── Stage 2: OpenRouter default (gated by its own credential) ──
+    let or_cred = ProviderId::OpenRouter
+        .credential_name()
+        .unwrap_or("openrouter");
+    match resolve_key_with(or_cred, store) {
+        Some(key) => Ok(ResolvedProvider::new(
+            ProviderId::OpenRouter,
+            slug.to_string(),
+            Some(SecretString::new(key)),
+        )),
+        None => Err(InferenceError::MissingCredential {
+            provider: ProviderId::OpenRouter,
+        }),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::credentials::MemoryKeyStore;
+    use serial_test::serial;
+
+    /// Build a store with the given provider→key entries, and clear any process
+    /// env vars that would otherwise shadow the store tier.
+    fn store_with(entries: &[(&str, &str)]) -> MemoryKeyStore {
+        for var in [
+            "OPENROUTER_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "FIREWORKS_API_KEY",
+        ] {
+            // SAFETY: guarded by `#[serial(dotenv_credential_env)]` on each test.
+            unsafe { std::env::remove_var(var) };
+        }
+        let store = MemoryKeyStore::new();
+        for (p, k) in entries {
+            store.set(p, k).expect("seed store");
+        }
+        store
+    }
+
+    /// Why: an explicit family whose key resolves must be used as-is.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn explicit_prefix_with_key_wins() {
+        let store = store_with(&[("anthropic", "sk-ant-xyz")]); // pragma: allowlist secret
+        let r = provider_for("anthropic/claude-sonnet-4-5", &store).expect("resolves");
+        assert_eq!(r.provider(), ProviderId::Anthropic);
+        assert_eq!(r.model(), "anthropic/claude-sonnet-4-5");
+        assert_eq!(r.key().map(|k| k.expose()), Some("sk-ant-xyz"));
+        assert_eq!(r.capabilities().id, ProviderId::Anthropic);
+    }
+
+    /// Why: an explicit family with NO key must fall back to OpenRouter (when
+    /// OpenRouter's key is present) — the epic's precedence rule.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn explicit_prefix_missing_key_falls_back_to_openrouter() {
+        let store = store_with(&[("openrouter", "sk-or-abc")]); // pragma: allowlist secret
+        let r = provider_for("anthropic/claude-sonnet-4-5", &store).expect("resolves");
+        assert_eq!(r.provider(), ProviderId::OpenRouter);
+        // The original slug is preserved for OpenRouter to route.
+        assert_eq!(r.model(), "anthropic/claude-sonnet-4-5");
+        assert_eq!(r.key().map(|k| k.expose()), Some("sk-or-abc"));
+    }
+
+    /// Why: a bare (prefix-less) slug resolves to OpenRouter by default.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn bare_slug_uses_openrouter() {
+        let store = store_with(&[("openrouter", "sk-or-abc")]); // pragma: allowlist secret
+        let r = provider_for("some-vendor/some-model", &store).expect("resolves");
+        assert_eq!(r.provider(), ProviderId::OpenRouter);
+    }
+
+    /// Why: Bedrock resolves with no key (AWS credential chain) regardless of
+    /// store contents.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn bedrock_resolves_without_key() {
+        let store = store_with(&[]);
+        let r = provider_for("bedrock/us.anthropic.claude-sonnet-4-5", &store).expect("resolves");
+        assert_eq!(r.provider(), ProviderId::Bedrock);
+        assert!(r.key().is_none());
+    }
+
+    /// Why: with no credential anywhere (and no Bedrock prefix), resolution must
+    /// alarm via `MissingCredential`, not panic or synthesise a key.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn no_credential_anywhere_errors() {
+        let store = store_with(&[]);
+        let err = provider_for("openai/gpt-4o-mini", &store).expect_err("must error");
+        assert!(err.is_alarm());
+        assert!(matches!(
+            err,
+            InferenceError::MissingCredential {
+                provider: ProviderId::OpenRouter
+            }
+        ));
+    }
+}

--- a/crates/trusty-common/src/inference/error.rs
+++ b/crates/trusty-common/src/inference/error.rs
@@ -1,0 +1,200 @@
+//! [`InferenceError`] — the structured error surface for inference calls.
+//!
+//! Why: a library must expose structured errors (not `anyhow`) so callers can
+//! programmatically decide "retry this" vs. "this needs an operator". The two
+//! classifications every consumer needs — is this transient/retryable, and is
+//! this an alarm (config/auth/capability problem a human must fix) — are folded
+//! into methods on one enum so the policy lives in one place, not re-derived at
+//! each call site. It unions the failure modes tcode's `LlmError` and
+//! trusty-review's client already distinguish so #2406 maps onto it directly.
+//! What: [`InferenceError`] with a variant per failure class, plus
+//! [`InferenceError::is_retryable`] and [`InferenceError::is_alarm`] classifiers.
+//! Concrete HTTP adapters (#2403) map `reqwest`/SDK errors into these variants.
+//! Test: inline `tests` — `retryable_classification`, `alarm_classification`,
+//! `display_includes_context`.
+
+use crate::inference::registry::ProviderId;
+
+/// Errors raised by an [`super::adapter::InferenceAdapter`] or the configurator.
+///
+/// Why: structured variants let the agent loop pattern-match on failure mode —
+/// a 429 or a transport blip is retryable, a 401 or a missing credential is an
+/// alarm — without parsing display strings.
+/// What: transport, API (non-2xx), deserialisation, credential-resolution,
+/// adapter-registration, provider-specific, and unsupported-capability variants.
+/// Kept `String`-carrying (rather than `#[from] reqwest::Error`) so this
+/// foundation crate stays free of a concrete HTTP dependency; #2403's adapters
+/// stringify their transport errors into [`Self::Transport`].
+/// Test: `retryable_classification`, `alarm_classification`.
+#[derive(Debug, thiserror::Error)]
+pub enum InferenceError {
+    /// The HTTP/transport layer failed (connection refused, TLS, timeout).
+    #[error("inference transport error: {0}")]
+    Transport(String),
+
+    /// The provider returned a non-2xx status.
+    #[error("inference API error {status}: {body}")]
+    Api {
+        /// HTTP status code.
+        status: u16,
+        /// Raw response body (may be JSON or plain text).
+        body: String,
+    },
+
+    /// The response body could not be deserialised into a [`super::ChatResponse`].
+    #[error("inference response deserialisation failed: {message}")]
+    Deserialise {
+        /// Human-readable parse error (never contains the API key).
+        message: String,
+        /// The raw body that failed to parse (aids debugging).
+        body: String,
+    },
+
+    /// No credential could be resolved for the target provider.
+    ///
+    /// Why: distinct from an API 401 — this fires before any network call, when
+    /// the configurator's env/`.env.local`/store chain yields nothing.
+    #[error("no credential resolved for provider {provider}")]
+    MissingCredential {
+        /// The provider whose key could not be found.
+        provider: ProviderId,
+    },
+
+    /// The configurator has no adapter factory registered for the resolved
+    /// provider.
+    ///
+    /// Why: the two-stage resolver picked a provider, but no adapter was wired
+    /// in for it (in this foundation ticket only the test-support factory exists;
+    /// real factories register in #2403).
+    #[error("no adapter registered for provider {provider}")]
+    NoAdapterRegistered {
+        /// The provider that resolved but has no factory.
+        provider: ProviderId,
+    },
+
+    /// A provider-specific failure that does not fit the HTTP shapes (e.g. an
+    /// AWS Bedrock SDK error).
+    #[error("inference provider error: {0}")]
+    Provider(String),
+
+    /// A requested capability is not supported by the target provider/model.
+    #[error("unsupported inference capability: {0}")]
+    Unsupported(String),
+}
+
+impl InferenceError {
+    /// Whether retrying the same call may succeed.
+    ///
+    /// Why: the agent loop applies backoff+retry to transient failures only —
+    /// retrying a 401 or a schema mismatch just wastes budget.
+    /// What: `true` for [`Self::Transport`] and for [`Self::Api`] with a 429 or
+    /// any 5xx status; `false` otherwise.
+    /// Test: `retryable_classification`.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::Transport(_) => true,
+            Self::Api { status, .. } => *status == 429 || (500..=599).contains(status),
+            _ => false,
+        }
+    }
+
+    /// Whether this failure needs operator attention rather than a retry.
+    ///
+    /// Why: config/auth/capability problems are dead-ends for automated retry —
+    /// surfacing them as alarms lets the caller stop and report instead of
+    /// spinning.
+    /// What: `true` for missing-credential, no-adapter-registered, unsupported,
+    /// and authentication/authorisation/not-found API statuses (401/403/404);
+    /// `false` otherwise.
+    /// Test: `alarm_classification`.
+    pub fn is_alarm(&self) -> bool {
+        match self {
+            Self::MissingCredential { .. }
+            | Self::NoAdapterRegistered { .. }
+            | Self::Unsupported(_) => true,
+            Self::Api { status, .. } => matches!(status, 401 | 403 | 404),
+            _ => false,
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: only transient failures may be retried.
+    /// Test: itself.
+    #[test]
+    fn retryable_classification() {
+        assert!(InferenceError::Transport("timeout".into()).is_retryable());
+        assert!(
+            InferenceError::Api {
+                status: 429,
+                body: "slow down".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            InferenceError::Api {
+                status: 503,
+                body: "unavailable".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !InferenceError::Api {
+                status: 401,
+                body: "bad key".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !InferenceError::MissingCredential {
+                provider: ProviderId::OpenRouter
+            }
+            .is_retryable()
+        );
+    }
+
+    /// Why: config/auth/capability failures must alarm, not retry.
+    /// Test: itself.
+    #[test]
+    fn alarm_classification() {
+        assert!(
+            InferenceError::MissingCredential {
+                provider: ProviderId::Anthropic
+            }
+            .is_alarm()
+        );
+        assert!(
+            InferenceError::NoAdapterRegistered {
+                provider: ProviderId::Fireworks
+            }
+            .is_alarm()
+        );
+        assert!(InferenceError::Unsupported("vision".into()).is_alarm());
+        assert!(
+            InferenceError::Api {
+                status: 403,
+                body: "denied".into()
+            }
+            .is_alarm()
+        );
+        assert!(!InferenceError::Transport("blip".into()).is_alarm());
+    }
+
+    /// Why: display strings feed logs and must carry the actionable context.
+    /// Test: itself.
+    #[test]
+    fn display_includes_context() {
+        let e = InferenceError::Api {
+            status: 429,
+            body: "rate limited".into(),
+        };
+        let s = e.to_string();
+        assert!(s.contains("429"), "{s}");
+        assert!(s.contains("rate limited"), "{s}");
+    }
+}

--- a/crates/trusty-common/src/inference/mod.rs
+++ b/crates/trusty-common/src/inference/mod.rs
@@ -6,14 +6,54 @@
 //! centralises all of that in `trusty-common` so every consumer shares one
 //! implementation instead of six.
 //!
-//! What: Wave 1 ticket #2401 (this module) ships the credential resolution
-//! layer: [`credentials::KeyStore`] trait, three backends
-//! (`MemoryKeyStore`, `FileKeyStore`, `KeyringStore`), the `resolve_key`
-//! precedence chain (process env > `.env.local` > secure store), and the
-//! shared `redact_secret` helper. Later Wave 1/2 tickets add sibling modules
-//! under `inference/` — the `InferenceAdapter` trait, the two-stage
-//! configurator, and the capability registry — none of which exist yet.
+//! What: Wave 1 ticket #2401 shipped the credential resolution layer:
+//! [`credentials::KeyStore`] trait, three backends (`MemoryKeyStore`,
+//! `FileKeyStore`, `KeyringStore`), the `resolve_key` precedence chain (process
+//! env > `.env.local` > secure store), and the shared `redact_secret` helper.
+//! Wave 1 ticket #2402 (behind the `inference-client` feature) adds the
+//! inference foundation on top of it: the [`types`] request/response model, the
+//! [`InferenceError`] error surface, the [`InferenceAdapter`] trait, the
+//! capability [`registry`] (context windows incl. the #2330 haiku fix, pricing,
+//! caching, tool dialects), the two-stage [`configurator`] (`provider_for` +
+//! [`Configurator`]), and the [`test_support`] doubles. Concrete provider HTTP
+//! adapters land in #2403/#2407.
 //!
-//! Test: see `credentials` submodule and its `*_tests` sibling files.
+//! Test: see `credentials` submodule and its `*_tests` sibling files; the
+//! `inference-client` surface is covered by each submodule's inline tests and
+//! `crates/trusty-common/tests/inference_foundation.rs`.
 
 pub mod credentials;
+
+#[cfg(feature = "inference-client")]
+pub mod adapter;
+#[cfg(feature = "inference-client")]
+pub mod configurator;
+#[cfg(feature = "inference-client")]
+pub mod error;
+#[cfg(feature = "inference-client")]
+pub mod registry;
+#[cfg(feature = "inference-client")]
+pub mod test_support;
+#[cfg(feature = "inference-client")]
+pub mod types;
+
+// Flat re-exports of the most-used surface so consumers write
+// `trusty_common::inference::{InferenceAdapter, ChatRequest, …}` rather than
+// reaching into each submodule.
+#[cfg(feature = "inference-client")]
+pub use adapter::InferenceAdapter;
+#[cfg(feature = "inference-client")]
+pub use configurator::{AdapterFactory, Configurator, ResolvedProvider, provider_for};
+#[cfg(feature = "inference-client")]
+pub use error::InferenceError;
+#[cfg(feature = "inference-client")]
+pub use registry::{
+    Pricing, ProviderCapabilities, ProviderId, ToolDialect, capabilities, capabilities_for,
+    context_window, pricing,
+};
+#[cfg(feature = "inference-client")]
+pub use types::{
+    AssistantMessage, CacheControl, ChatChoice, ChatMessage, ChatRequest, ChatResponse,
+    FunctionCall, FunctionDefinition, RequestUsageConfig, SecretString, StopReason, ToolCall,
+    ToolChoice, ToolDefinition, Usage, openai_tool_choice,
+};

--- a/crates/trusty-common/src/inference/registry/context.rs
+++ b/crates/trusty-common/src/inference/registry/context.rs
@@ -1,0 +1,127 @@
+//! Per-model context-window resolution (issue #2402; closes #2330).
+//!
+//! Why: compaction/budget code must scale with the model actually in use. A flat
+//! default is model-blind — the #2330 bug was `claude-haiku-*` slugs falling
+//! through to the 128K default instead of Haiku's real 200K window, so Haiku
+//! runs compacted far too aggressively. This resolver turns a slug into its real
+//! window, checking model-family substrings first and falling back to the
+//! provider's declared max.
+//! What: [`context_window`] maps a slug → tokens; [`DEFAULT_CONTEXT_WINDOW`] is
+//! the conservative floor for a slug no substring rule and no provider default
+//! covers.
+//! Test: inline `tests` — `haiku_resolves_to_200k` (#2330 regression guard),
+//! `sonnet_and_opus_200k`, `gpt4o_128k`, `falls_back_to_provider_default`.
+
+use super::ProviderCapabilities;
+
+/// Conservative fallback context window (tokens) when neither a model-family
+/// substring rule nor a provider default applies.
+///
+/// Why: [`context_window`] must always return a usable number even for a typo'd
+/// or brand-new slug with no capabilities context; 128K is a widely-supported
+/// floor.
+/// What: the final fallback tier of [`context_window`].
+/// Test: `falls_back_to_provider_default` (via the `None` caps path).
+pub const DEFAULT_CONTEXT_WINDOW: usize = 128_000;
+
+/// Resolve the real context-window size (in tokens) for a model slug.
+///
+/// Why: a slug's window is a property of the MODEL, not the provider default —
+/// e.g. Bedrock's default is 200K but a Haiku model served through it is still
+/// 200K while a hypothetical smaller model would differ. Substring rules capture
+/// the model families the ecosystem actually uses; `caps` supplies the
+/// provider's max as the next tier so an unlisted model on a known provider
+/// still gets that provider's window rather than the global floor.
+/// What: checked in order — (1) `claude-haiku*` / `haiku-3` / `haiku-4` → 200_000
+/// (the #2330 fix); (2) `claude-sonnet*` / `sonnet-4` / `claude-opus*` /
+/// `opus-4` → 200_000; (3) `gpt-4o` → 128_000; (4) `caps.max_context_window`
+/// when `caps` is `Some`; else (5) [`DEFAULT_CONTEXT_WINDOW`]. Matching is
+/// case-insensitive and covers both bare Anthropic slugs and Bedrock-routed
+/// `bedrock/us.anthropic.claude-*` inference-profile forms.
+/// Test: `haiku_resolves_to_200k`, `sonnet_and_opus_200k`, `gpt4o_128k`,
+/// `falls_back_to_provider_default`.
+pub fn context_window(model: &str, caps: Option<&ProviderCapabilities>) -> usize {
+    let m = model.to_ascii_lowercase();
+
+    // (1) #2330: Haiku's real window is 200K, not the 128K default.
+    if m.contains("claude-haiku") || m.contains("haiku-3") || m.contains("haiku-4") {
+        return 200_000;
+    }
+    // (2) Sonnet / Opus — 200K (bare + Bedrock-routed forms).
+    if m.contains("claude-sonnet")
+        || m.contains("sonnet-4")
+        || m.contains("claude-opus")
+        || m.contains("opus-4")
+    {
+        return 200_000;
+    }
+    // (3) GPT-4o family — 128K.
+    if m.contains("gpt-4o") {
+        return 128_000;
+    }
+    // (4) Provider default, when known; (5) else the global floor.
+    caps.map(|c| c.max_context_window)
+        .unwrap_or(DEFAULT_CONTEXT_WINDOW)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::super::{ProviderId, capabilities};
+    use super::*;
+
+    /// Why: #2330 regression guard — Haiku slugs must resolve to 200K, not the
+    /// 128K default. Covers the bare, versioned, and Bedrock-routed forms.
+    /// Test: itself.
+    #[test]
+    fn haiku_resolves_to_200k() {
+        assert_eq!(context_window("anthropic/claude-haiku-4-5", None), 200_000);
+        assert_eq!(context_window("claude-haiku-3-5", None), 200_000);
+        assert_eq!(
+            context_window("bedrock/us.anthropic.claude-haiku-4-5", None),
+            200_000
+        );
+        // The exact regression: WITHOUT the #2330 rule this returned 128_000.
+        assert_ne!(
+            context_window("claude-haiku-4-5", None),
+            DEFAULT_CONTEXT_WINDOW
+        );
+    }
+
+    /// Why: Sonnet and Opus share Haiku's 200K window.
+    /// Test: itself.
+    #[test]
+    fn sonnet_and_opus_200k() {
+        assert_eq!(
+            context_window("bedrock/us.anthropic.claude-sonnet-4-6", None),
+            200_000
+        );
+        assert_eq!(context_window("anthropic/claude-opus-4-1", None), 200_000);
+    }
+
+    /// Why: the GPT-4o family is a 128K window.
+    /// Test: itself.
+    #[test]
+    fn gpt4o_128k() {
+        assert_eq!(context_window("openai/gpt-4o-mini", None), 128_000);
+    }
+
+    /// Why: an unlisted model on a known provider gets that provider's max;
+    /// with no caps it gets the global floor.
+    /// Test: itself.
+    #[test]
+    fn falls_back_to_provider_default() {
+        // Fireworks default is 128K in the seed table.
+        let fw = capabilities(ProviderId::Fireworks);
+        assert_eq!(
+            context_window("fireworks/some-new-model", Some(fw)),
+            128_000
+        );
+        // No caps → global floor.
+        assert_eq!(
+            context_window("some/unheard-of-model", None),
+            DEFAULT_CONTEXT_WINDOW
+        );
+    }
+}

--- a/crates/trusty-common/src/inference/registry/mod.rs
+++ b/crates/trusty-common/src/inference/registry/mod.rs
@@ -1,0 +1,381 @@
+//! Provider capability registry (issue #2402, epic #2400 Wave 1).
+//!
+//! Why: per-model/per-provider behaviour — native tool-calling vs. prompt
+//! emulation, streaming, prompt caching, structured output, vision, the real
+//! context window, and pricing — must be described in ONE queryable place so
+//! adapters, the configurator, and consumers all agree instead of scattering
+//! `slug.starts_with(...)` checks. This is the seam that drives later per-model
+//! decisions (compaction thresholds, cost estimates, tool-format fallback).
+//! What: [`ProviderId`] (the five epic-#2400 providers), [`ToolDialect`],
+//! [`ProviderCapabilities`], the static seed table with
+//! [`capabilities`]/[`capabilities_for`]/[`all`] queries, and — from the
+//! `context` and `pricing` submodules — [`context_window`] (incl. the #2330
+//! haiku fix) and [`pricing`]/[`Pricing`].
+//! Test: inline `tests` + `context`/`pricing` submodule tests; registry queries
+//! in `crates/trusty-common/tests/inference_foundation.rs`.
+
+mod context;
+mod pricing;
+
+pub use context::{DEFAULT_CONTEXT_WINDOW, context_window};
+pub use pricing::{Pricing, pricing};
+
+use std::fmt;
+
+/// One of the five inference providers epic #2400 targets.
+///
+/// Why: a closed enum (rather than a bare string) lets the configurator and the
+/// registry share one exhaustively-matched identity, so adding a provider is a
+/// compile error until every match arm is handled.
+/// What: the five target providers. `Bedrock` authenticates via the AWS
+/// credential chain (no API key), which is why [`Self::credential_name`] returns
+/// `None` for it.
+/// Test: `provider_id_round_trips`, `from_slug_prefix_matches`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProviderId {
+    /// OpenRouter aggregator (the default when no explicit prefix resolves).
+    OpenRouter,
+    /// Fireworks AI.
+    Fireworks,
+    /// AWS Bedrock (Converse API; AWS credential chain, no API key).
+    Bedrock,
+    /// Anthropic first-party API.
+    Anthropic,
+    /// OpenAI first-party API.
+    OpenAI,
+}
+
+impl ProviderId {
+    /// Stable lowercase identifier used in logs, the credential resolver, and
+    /// the `config` CLI grammar.
+    ///
+    /// Why: one canonical spelling per provider that never changes across
+    /// releases.
+    /// What: `"openrouter"`, `"fireworks"`, `"bedrock"`, `"anthropic"`, `"openai"`.
+    /// Test: `provider_id_round_trips`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OpenRouter => "openrouter",
+            Self::Fireworks => "fireworks",
+            Self::Bedrock => "bedrock",
+            Self::Anthropic => "anthropic",
+            Self::OpenAI => "openai",
+        }
+    }
+
+    /// The provider name to hand the credential resolver, or `None` when the
+    /// provider does not use an API key.
+    ///
+    /// Why: [`crate::inference::credentials::resolve_key_with`] keys off a
+    /// provider name; Bedrock has no key (AWS chain), so its resolution is
+    /// skipped entirely by the configurator.
+    /// What: same string as [`Self::as_str`] for the four keyed providers;
+    /// `None` for [`Self::Bedrock`].
+    /// Test: `credential_name_none_only_for_bedrock`.
+    pub fn credential_name(self) -> Option<&'static str> {
+        match self {
+            Self::Bedrock => None,
+            other => Some(other.as_str()),
+        }
+    }
+
+    /// Resolve a provider from an explicit `<prefix>/…` model slug.
+    ///
+    /// Why: stage 1 of the configurator's two-stage resolver keys off the slug
+    /// prefix (`bedrock/`, `fireworks/`, `anthropic/`, `openai/`, `openrouter/`);
+    /// this is the single mapping it uses.
+    /// What: matches the segment before the first `/` case-insensitively;
+    /// returns `None` for a bare slug or an unrecognised prefix (the caller then
+    /// falls back to the OpenRouter default).
+    /// Test: `from_slug_prefix_matches`, `from_slug_prefix_unknown_is_none`.
+    pub fn from_slug_prefix(slug: &str) -> Option<Self> {
+        let prefix = slug.split('/').next()?;
+        match prefix.to_ascii_lowercase().as_str() {
+            "openrouter" => Some(Self::OpenRouter),
+            "fireworks" => Some(Self::Fireworks),
+            "bedrock" => Some(Self::Bedrock),
+            "anthropic" => Some(Self::Anthropic),
+            "openai" => Some(Self::OpenAI),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ProviderId {
+    /// Render the canonical identifier (see [`Self::as_str`]).
+    ///
+    /// Why: error messages ([`crate::inference::InferenceError`]) embed the
+    /// provider; a `Display` impl keeps those `#[error(...)]` templates terse.
+    /// What: writes [`Self::as_str`].
+    /// Test: `provider_id_round_trips`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// How a provider expects tool definitions and tool-choice on the wire.
+///
+/// Why: adapters translate the neutral tool surface into the provider's dialect;
+/// naming the dialect in the registry (rather than per-adapter booleans) lets a
+/// consumer reason about tool compatibility before an adapter is even built.
+/// What: `OpenAiFunctions` (OpenRouter/Fireworks/OpenAI), `AnthropicMessages`
+/// (Bedrock/Anthropic-direct), and `PromptEmulated` (models without native tool
+/// support — the loop injects tool guidance into the prompt).
+/// Test: exercised via the seed-table assertions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolDialect {
+    /// OpenAI-style `tools` array + `tool_choice` string/object.
+    OpenAiFunctions,
+    /// Anthropic Messages-style `tools` + `tool_choice`.
+    AnthropicMessages,
+    /// No native tool support; tools are emulated via prompt injection.
+    PromptEmulated,
+}
+
+/// The capability descriptor for one provider.
+///
+/// Why: a single struct consumers can query for every per-provider behaviour,
+/// so a new capability is one field here rather than a new lookup scattered
+/// across crates.
+/// What: identity, native-tool + dialect, streaming, prompt caching, structured
+/// output, vision, the OpenRouter detailed-usage opt-in, the provider's default
+/// (max) context window, its default model slug, and its credential env var
+/// name (`None` for Bedrock). Per-MODEL context windows come from
+/// [`context_window`]; per-model pricing from [`pricing`].
+/// Test: `all_five_providers_seeded`, and the `context`/`pricing` submodules.
+#[derive(Debug, Clone, Copy)]
+pub struct ProviderCapabilities {
+    /// The provider this describes.
+    pub id: ProviderId,
+    /// Whether the provider supports native function-calling.
+    pub native_tool_calling: bool,
+    /// The wire dialect for tool definitions + tool-choice.
+    pub tool_dialect: ToolDialect,
+    /// Whether streaming responses are supported.
+    pub streaming: bool,
+    /// Whether Anthropic-style prompt caching is honoured.
+    pub prompt_caching: bool,
+    /// Whether structured-output / JSON-schema response formatting is supported
+    /// (the `supports_structured_output` capability merged from trusty-review).
+    pub structured_output: bool,
+    /// Whether image/vision inputs are supported.
+    pub vision: bool,
+    /// Whether the provider should be asked for detailed usage accounting
+    /// (OpenRouter's `usage: {"include": true}` directive).
+    pub detailed_usage_accounting: bool,
+    /// The provider's default/maximum context window in tokens — the fallback
+    /// for a model [`context_window`] does not recognise by substring.
+    pub max_context_window: usize,
+    /// The provider's default model slug when the caller does not specify one.
+    pub default_model: &'static str,
+    /// The API-key env var name, or `None` when the provider uses a non-key
+    /// credential chain (Bedrock → AWS).
+    pub credential_env: Option<&'static str>,
+}
+
+/// Seed capability table for the five target providers.
+///
+/// Why: a single static source of truth. Values are a documented BEST-EFFORT
+/// seed sufficient for the foundation; the concrete adapters in #2403 refine
+/// any that drift from the provider's live capabilities. Sources: tcode's
+/// `provider::openrouter`/`bedrock` (native-tool + caching posture) and
+/// trusty-review's model notes (structured output).
+/// What: one entry per [`ProviderId`], indexed by [`capabilities`].
+/// Test: `all_five_providers_seeded`.
+const SEED: [ProviderCapabilities; 5] = [
+    ProviderCapabilities {
+        id: ProviderId::OpenRouter,
+        native_tool_calling: true,
+        tool_dialect: ToolDialect::OpenAiFunctions,
+        streaming: true,
+        prompt_caching: true,
+        structured_output: true,
+        vision: true,
+        detailed_usage_accounting: true,
+        max_context_window: 200_000,
+        default_model: "openai/gpt-4o-mini",
+        credential_env: Some("OPENROUTER_API_KEY"),
+    },
+    ProviderCapabilities {
+        id: ProviderId::Fireworks,
+        native_tool_calling: true,
+        tool_dialect: ToolDialect::OpenAiFunctions,
+        streaming: true,
+        prompt_caching: false,
+        structured_output: true,
+        vision: false,
+        detailed_usage_accounting: false,
+        max_context_window: 128_000,
+        default_model: "accounts/fireworks/models/llama-v3p1-70b-instruct",
+        credential_env: Some("FIREWORKS_API_KEY"),
+    },
+    ProviderCapabilities {
+        id: ProviderId::Bedrock,
+        native_tool_calling: true,
+        tool_dialect: ToolDialect::AnthropicMessages,
+        streaming: true,
+        prompt_caching: false,
+        structured_output: true,
+        vision: true,
+        detailed_usage_accounting: false,
+        max_context_window: 200_000,
+        default_model: "bedrock/us.anthropic.claude-sonnet-4-5",
+        credential_env: None,
+    },
+    ProviderCapabilities {
+        id: ProviderId::Anthropic,
+        native_tool_calling: true,
+        tool_dialect: ToolDialect::AnthropicMessages,
+        streaming: true,
+        prompt_caching: true,
+        structured_output: true,
+        vision: true,
+        detailed_usage_accounting: false,
+        max_context_window: 200_000,
+        default_model: "claude-sonnet-4-5",
+        credential_env: Some("ANTHROPIC_API_KEY"),
+    },
+    ProviderCapabilities {
+        id: ProviderId::OpenAI,
+        native_tool_calling: true,
+        tool_dialect: ToolDialect::OpenAiFunctions,
+        streaming: true,
+        prompt_caching: true,
+        structured_output: true,
+        vision: true,
+        detailed_usage_accounting: false,
+        max_context_window: 128_000,
+        default_model: "gpt-4o-mini",
+        credential_env: Some("OPENAI_API_KEY"),
+    },
+];
+
+/// Look up the capability descriptor for a provider.
+///
+/// Why: the primary registry query — adapters and the configurator resolve a
+/// [`ProviderId`] to its capabilities here.
+/// What: returns the static [`ProviderCapabilities`] for `id`; total (never
+/// panics) because [`SEED`] has one entry per variant.
+/// Test: `all_five_providers_seeded`.
+pub fn capabilities(id: ProviderId) -> &'static ProviderCapabilities {
+    // SEED is exhaustive over ProviderId, so the find always succeeds; the
+    // `unwrap_or(&SEED[0])` is an unreachable, panic-free floor kept only to
+    // avoid `expect` on a runtime-reachable path per the crate conventions.
+    SEED.iter().find(|c| c.id == id).unwrap_or(&SEED[0])
+}
+
+/// Look up a provider's capabilities by its string name.
+///
+/// Why: the `config` CLI grammar and log lines carry a provider NAME, not a
+/// typed id; this is the by-name query the acceptance criteria call for.
+/// What: matches `name` case-insensitively against [`ProviderId::as_str`];
+/// `None` for an unknown name.
+/// Test: `capabilities_for_by_name`, `capabilities_for_unknown_is_none`.
+pub fn capabilities_for(name: &str) -> Option<&'static ProviderCapabilities> {
+    let lower = name.to_ascii_lowercase();
+    SEED.iter().find(|c| c.id.as_str() == lower)
+}
+
+/// All seeded provider capabilities.
+///
+/// Why: the `config <feature> list` verb and diagnostics enumerate every known
+/// provider.
+/// What: the full static seed slice.
+/// Test: `all_five_providers_seeded`.
+pub fn all() -> &'static [ProviderCapabilities] {
+    &SEED
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the canonical identifier and slug-prefix mapping must round-trip.
+    /// Test: itself.
+    #[test]
+    fn provider_id_round_trips() {
+        for id in [
+            ProviderId::OpenRouter,
+            ProviderId::Fireworks,
+            ProviderId::Bedrock,
+            ProviderId::Anthropic,
+            ProviderId::OpenAI,
+        ] {
+            assert_eq!(id.to_string(), id.as_str());
+            assert_eq!(ProviderId::from_slug_prefix(&format!("{id}/x")), Some(id));
+        }
+    }
+
+    /// Why: stage 1 of the resolver depends on prefix matching being exact.
+    /// Test: itself.
+    #[test]
+    fn from_slug_prefix_matches() {
+        assert_eq!(
+            ProviderId::from_slug_prefix("anthropic/claude-sonnet-4-5"),
+            Some(ProviderId::Anthropic)
+        );
+        assert_eq!(
+            ProviderId::from_slug_prefix("BEDROCK/us.anthropic.claude"),
+            Some(ProviderId::Bedrock)
+        );
+    }
+
+    /// Why: a bare or unknown-prefix slug must not resolve a family (it falls
+    /// back to the OpenRouter default in the configurator).
+    /// Test: itself.
+    #[test]
+    fn from_slug_prefix_unknown_is_none() {
+        assert_eq!(ProviderId::from_slug_prefix("claude-sonnet-4-5"), None);
+        assert_eq!(ProviderId::from_slug_prefix("cohere/command"), None);
+    }
+
+    /// Why: only Bedrock uses a non-key credential chain.
+    /// Test: itself.
+    #[test]
+    fn credential_name_none_only_for_bedrock() {
+        assert_eq!(ProviderId::Bedrock.credential_name(), None);
+        assert_eq!(ProviderId::OpenRouter.credential_name(), Some("openrouter"));
+        assert_eq!(ProviderId::Anthropic.credential_name(), Some("anthropic"));
+    }
+
+    /// Why: every provider must be seeded and queryable by id and by name.
+    /// Test: itself.
+    #[test]
+    fn all_five_providers_seeded() {
+        assert_eq!(all().len(), 5);
+        for id in [
+            ProviderId::OpenRouter,
+            ProviderId::Fireworks,
+            ProviderId::Bedrock,
+            ProviderId::Anthropic,
+            ProviderId::OpenAI,
+        ] {
+            let caps = capabilities(id);
+            assert_eq!(caps.id, id);
+            assert!(caps.max_context_window >= 128_000);
+        }
+    }
+
+    /// Why: the by-name query must be case-insensitive and total for knowns.
+    /// Test: itself.
+    #[test]
+    fn capabilities_for_by_name() {
+        assert_eq!(
+            capabilities_for("OpenRouter").map(|c| c.id),
+            Some(ProviderId::OpenRouter)
+        );
+        assert_eq!(
+            capabilities_for("bedrock").map(|c| c.id),
+            Some(ProviderId::Bedrock)
+        );
+    }
+
+    /// Why: an unknown provider name must be `None`, not a panic or a guess.
+    /// Test: itself.
+    #[test]
+    fn capabilities_for_unknown_is_none() {
+        assert!(capabilities_for("cohere").is_none());
+    }
+}

--- a/crates/trusty-common/src/inference/registry/pricing.rs
+++ b/crates/trusty-common/src/inference/registry/pricing.rs
@@ -1,0 +1,224 @@
+//! Per-model pricing (issue #2402, epic #2400 Wave 1).
+//!
+//! Why: cost estimation (trusty-review's `compare` ranking, tga's SM accounting)
+//! needs one pricing source rather than three hard-coded tables. This is the
+//! seed the epic references ("pricing from trusty-review"), consolidating
+//! tcode's Claude rates and trusty-review's GPT-5/Gemini rates into one lookup.
+//! Rates are a documented BEST-EFFORT snapshot — the provider's authoritative
+//! `usage.cost` (carried on [`crate::inference::Usage::cost_usd`]) is always
+//! preferred when present; this table is the offline/CI fallback.
+//! What: [`Pricing`] (USD per MILLION tokens, four buckets) and [`pricing`], a
+//! substring lookup returning `Some(Pricing)` for known families, `None`
+//! otherwise.
+//! Test: inline `tests` — `claude_family_rates`, `gpt5_and_gemini_rates`,
+//! `unknown_model_is_none`, `estimate_matches_hand_calc`.
+
+/// USD-per-million-tokens pricing for one model family.
+///
+/// Why: a typed rate quartet lets callers compute a cost estimate from a
+/// [`crate::inference::Usage`] without re-deriving the per-token math or the
+/// wire field names.
+/// What: `input`/`output`/`cache_read`/`cache_write` are USD per 1,000,000
+/// tokens. Providers that publish no separate cache rate use `0.0` for those
+/// buckets (a cache-read then bills at the input rate via the caller's own
+/// accounting, or simply contributes nothing here).
+/// Test: `estimate_matches_hand_calc`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Pricing {
+    /// USD per million input (prompt) tokens.
+    pub input: f64,
+    /// USD per million output (completion) tokens.
+    pub output: f64,
+    /// USD per million cache-read tokens.
+    pub cache_read: f64,
+    /// USD per million cache-write tokens.
+    pub cache_write: f64,
+}
+
+impl Pricing {
+    /// Estimate the USD cost of a call from its token buckets.
+    ///
+    /// Why: a convenience for the offline/CI estimate path; live cost should
+    /// prefer the provider's authoritative figure when available.
+    /// What: sums each bucket × its per-million rate.
+    /// Test: `estimate_matches_hand_calc`.
+    pub fn estimate_usd(
+        &self,
+        input_tokens: u32,
+        output_tokens: u32,
+        cache_read_tokens: u32,
+        cache_write_tokens: u32,
+    ) -> f64 {
+        let per_m = |tokens: u32, rate: f64| (tokens as f64 / 1_000_000.0) * rate;
+        per_m(input_tokens, self.input)
+            + per_m(output_tokens, self.output)
+            + per_m(cache_read_tokens, self.cache_read)
+            + per_m(cache_write_tokens, self.cache_write)
+    }
+}
+
+/// Best-effort per-million pricing for a model slug.
+///
+/// Why: the registry's pricing query. Substring matching (rather than exact
+/// slugs) keeps version-stamped point releases priced without a table churn.
+/// What: returns `Some(Pricing)` for the Claude, GPT-5, and Gemini families this
+/// project uses; `None` for anything unrecognised (the caller then relies on the
+/// provider's authoritative cost or reports "unknown"). Claude rates are from
+/// tcode `perf::pricing`; GPT-5/Gemini rates from trusty-review
+/// `llm::openrouter` (OpenRouter pricing page, best-effort, 2026 snapshot).
+/// Test: `claude_family_rates`, `gpt5_and_gemini_rates`, `unknown_model_is_none`.
+pub fn pricing(model: &str) -> Option<Pricing> {
+    let m = model.to_ascii_lowercase();
+
+    // ── Claude family (source: tcode perf::pricing) ──
+    if m.contains("claude-haiku") || m.contains("haiku-3") || m.contains("haiku-4") {
+        return Some(Pricing {
+            input: 0.80,
+            output: 4.0,
+            cache_read: 0.08,
+            cache_write: 1.0,
+        });
+    }
+    if m.contains("claude-opus") || m.contains("opus-4") {
+        return Some(Pricing {
+            input: 15.0,
+            output: 75.0,
+            cache_read: 1.50,
+            cache_write: 18.75,
+        });
+    }
+    if m.contains("claude-sonnet") || m.contains("sonnet-4") {
+        return Some(Pricing {
+            input: 3.0,
+            output: 15.0,
+            cache_read: 0.30,
+            cache_write: 3.75,
+        });
+    }
+
+    // ── GPT-5 family (source: trusty-review llm::openrouter) ──
+    if m.contains("gpt-5.5-pro") {
+        return Some(Pricing {
+            input: 30.0,
+            output: 180.0,
+            cache_read: 0.0,
+            cache_write: 0.0,
+        });
+    }
+    if m.contains("gpt-5.5") {
+        return Some(Pricing {
+            input: 5.0,
+            output: 30.0,
+            cache_read: 0.0,
+            cache_write: 0.0,
+        });
+    }
+    if m.contains("gpt-5.4-nano") {
+        return Some(Pricing {
+            input: 0.20,
+            output: 1.25,
+            cache_read: 0.0,
+            cache_write: 0.0,
+        });
+    }
+    if m.contains("gpt-5.4-mini") {
+        return Some(Pricing {
+            input: 0.75,
+            output: 4.50,
+            cache_read: 0.0,
+            cache_write: 0.0,
+        });
+    }
+    if m.contains("gpt-5.4") {
+        return Some(Pricing {
+            input: 2.50,
+            output: 15.0,
+            cache_read: 0.0,
+            cache_write: 0.0,
+        });
+    }
+
+    // ── Gemini family (source: trusty-review, best-effort tiers) ──
+    if m.contains("gemini") {
+        return Some(if m.contains("flash-lite") {
+            Pricing {
+                input: 0.10,
+                output: 0.40,
+                cache_read: 0.0,
+                cache_write: 0.0,
+            }
+        } else if m.contains("flash") {
+            Pricing {
+                input: 0.30,
+                output: 2.50,
+                cache_read: 0.0,
+                cache_write: 0.0,
+            }
+        } else {
+            Pricing {
+                input: 1.25,
+                output: 10.0,
+                cache_read: 0.0,
+                cache_write: 0.0,
+            }
+        });
+    }
+
+    None
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the Claude rates must match the authoritative tcode table.
+    /// Test: itself.
+    #[test]
+    fn claude_family_rates() {
+        let haiku = pricing("anthropic/claude-haiku-4-5").expect("haiku priced");
+        assert_eq!(haiku.input, 0.80);
+        assert_eq!(haiku.output, 4.0);
+        let sonnet = pricing("bedrock/us.anthropic.claude-sonnet-4-6").expect("sonnet priced");
+        assert_eq!(sonnet.input, 3.0);
+        let opus = pricing("claude-opus-4-1").expect("opus priced");
+        assert_eq!(opus.output, 75.0);
+    }
+
+    /// Why: the GPT-5 and Gemini families must price via substring, most-specific
+    /// first (nano/mini before the bare 5.4; flash-lite before flash).
+    /// Test: itself.
+    #[test]
+    fn gpt5_and_gemini_rates() {
+        assert_eq!(pricing("openai/gpt-5.5-pro-20260423").unwrap().input, 30.0);
+        assert_eq!(pricing("openai/gpt-5.4-nano-20260317").unwrap().input, 0.20);
+        assert_eq!(pricing("openai/gpt-5.4-mini-20260317").unwrap().input, 0.75);
+        assert_eq!(pricing("openai/gpt-5.4-20260305").unwrap().input, 2.50);
+        assert_eq!(pricing("google/gemini-2.5-flash-lite").unwrap().input, 0.10);
+        assert_eq!(pricing("google/gemini-2.5-flash").unwrap().input, 0.30);
+        assert_eq!(pricing("google/gemini-2.5-pro").unwrap().input, 1.25);
+    }
+
+    /// Why: an unknown model must be `None`, not a fabricated rate.
+    /// Test: itself.
+    #[test]
+    fn unknown_model_is_none() {
+        assert!(pricing("cohere/command-r-plus").is_none());
+    }
+
+    /// Why: the estimate math must be a plain per-million weighted sum.
+    /// Test: itself.
+    #[test]
+    fn estimate_matches_hand_calc() {
+        let p = Pricing {
+            input: 3.0,
+            output: 15.0,
+            cache_read: 0.30,
+            cache_write: 3.75,
+        };
+        // 1M input @3 + 1M output @15 + 1M cr @0.30 + 1M cw @3.75 = 22.05
+        let cost = p.estimate_usd(1_000_000, 1_000_000, 1_000_000, 1_000_000);
+        assert!((cost - 22.05).abs() < 1e-9, "cost was {cost}");
+    }
+}

--- a/crates/trusty-common/src/inference/test_support/http_mock.rs
+++ b/crates/trusty-common/src/inference/test_support/http_mock.rs
@@ -1,0 +1,143 @@
+//! [`MockInferenceServer`] — an in-process axum HTTP mock for adapter tests.
+//!
+//! Why: the concrete HTTP adapters that land in #2403/#2407 need to be tested
+//! against a real socket that returns canned chat/completions JSON — without a
+//! live provider or credentials. This spins up a throwaway axum server on an
+//! ephemeral loopback port that answers every request with a fixed status+body,
+//! giving those future adapters a URL to point at. It is gated behind the
+//! `axum-server` feature so the base `inference-client` feature pulls in NO
+//! HTTP-server dependency (per the crate's axum-gating discipline).
+//! What: [`MockInferenceServer::spawn`] binds `127.0.0.1:0`, serves a fixed
+//! response from a fallback handler, and exposes [`MockInferenceServer::url`];
+//! dropping it triggers graceful shutdown.
+//! Test: inline `tests` — `mock_serves_canned_body` (feature-gated).
+
+use axum::Router;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde_json::Value;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use crate::inference::error::InferenceError;
+
+/// A running in-process HTTP mock returning one fixed response.
+///
+/// Why: the smallest real HTTP surface a future adapter can exercise end-to-end.
+/// What: owns the server task and a shutdown channel; [`Self::url`] is the base
+/// URL (`http://127.0.0.1:<port>`). Dropping the value signals graceful
+/// shutdown so no test leaks a listener.
+/// Test: `mock_serves_canned_body`.
+pub struct MockInferenceServer {
+    url: String,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: JoinHandle<()>,
+}
+
+impl MockInferenceServer {
+    /// Spawn a mock that answers every request with `status` + `body`.
+    ///
+    /// Why: adapter tests script one provider response and point the adapter at
+    /// [`Self::url`].
+    /// What: binds an ephemeral loopback port, serves a fallback handler that
+    /// returns the canned `status`/`body` for any method/path, and returns the
+    /// running handle. Errors as [`InferenceError::Provider`] if the bind fails.
+    /// Test: `mock_serves_canned_body`.
+    pub async fn spawn(status: u16, body: Value) -> Result<Self, InferenceError> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(|e| InferenceError::Provider(format!("mock bind failed: {e}")))?;
+        let addr = listener
+            .local_addr()
+            .map_err(|e| InferenceError::Provider(format!("mock addr failed: {e}")))?;
+        let url = format!("http://{addr}");
+
+        let status = StatusCode::from_u16(status)
+            .map_err(|e| InferenceError::Provider(format!("invalid mock status: {e}")))?;
+        let app = Router::new()
+            .fallback(canned_handler)
+            .with_state((status, body));
+
+        let (tx, rx) = oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = rx.await;
+                })
+                .await;
+        });
+
+        Ok(Self {
+            url,
+            shutdown: Some(tx),
+            handle,
+        })
+    }
+
+    /// The base URL the mock is listening on (`http://127.0.0.1:<port>`).
+    ///
+    /// Why: adapters need the endpoint to send requests to.
+    /// What: returns the bound loopback URL.
+    /// Test: `mock_serves_canned_body`.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+impl Drop for MockInferenceServer {
+    /// Signal graceful shutdown and abort the server task.
+    ///
+    /// Why: a test must not leak a bound port or a live task after its mock goes
+    /// out of scope.
+    /// What: sends on the shutdown channel (best-effort) and aborts the handle.
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        self.handle.abort();
+    }
+}
+
+/// Fallback handler returning the configured canned response.
+///
+/// Why: one handler answers every method/path so an adapter can target any
+/// endpoint shape (e.g. `/v1/chat/completions`).
+/// What: returns the `(status, body)` from router state as a JSON response.
+/// Test: `mock_serves_canned_body`.
+async fn canned_handler(State((status, body)): State<(StatusCode, Value)>) -> impl IntoResponse {
+    (status, axum::Json(body))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Why: the mock must serve the exact status + body an adapter will parse.
+    /// Test: itself.
+    #[tokio::test]
+    async fn mock_serves_canned_body() {
+        let body = json!({
+            "id": "gen-mock",
+            "choices": [{"message": {"role": "assistant", "content": "mocked"},
+                         "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+        });
+        let server = MockInferenceServer::spawn(200, body.clone())
+            .await
+            .expect("spawn");
+        let got: Value = reqwest::Client::new()
+            .post(format!("{}/v1/chat/completions", server.url()))
+            .send()
+            .await
+            .expect("send")
+            .json()
+            .await
+            .expect("json");
+        assert_eq!(got["id"], "gen-mock");
+        assert_eq!(got["choices"][0]["message"]["content"], "mocked");
+    }
+}

--- a/crates/trusty-common/src/inference/test_support/mod.rs
+++ b/crates/trusty-common/src/inference/test_support/mod.rs
@@ -1,0 +1,24 @@
+//! Test-support doubles for the inference layer (issue #2402).
+//!
+//! Why: exercising the [`super::adapter::InferenceAdapter`] seam and the
+//! configurator must not require real HTTP or credentials. These doubles are the
+//! only [`super::adapter::InferenceAdapter`] implementation in this foundation
+//! ticket; real adapters land in #2403/#2407 and register into the same
+//! [`super::configurator::Configurator`] the [`ScriptedAdapter`] validates.
+//! Shipped as public support (not `cfg(test)`) so downstream integration tests
+//! reuse them, mirroring `embedder-test-support`.
+//! What: [`ScriptedAdapter`] (a deterministic in-memory adapter — always
+//! available with `inference-client`) and, behind the `axum-server` feature,
+//! [`MockInferenceServer`] (a real loopback HTTP mock for the future concrete
+//! adapters).
+//! Test: each submodule's inline `tests`; cross-cutting use in
+//! `crates/trusty-common/tests/inference_foundation.rs`.
+
+mod scripted;
+
+pub use scripted::ScriptedAdapter;
+
+#[cfg(feature = "axum-server")]
+mod http_mock;
+#[cfg(feature = "axum-server")]
+pub use http_mock::MockInferenceServer;

--- a/crates/trusty-common/src/inference/test_support/scripted.rs
+++ b/crates/trusty-common/src/inference/test_support/scripted.rs
@@ -1,0 +1,248 @@
+//! [`ScriptedAdapter`] — the deterministic test-only inference adapter.
+//!
+//! Why: the configurator seam, the agent loop, and any consumer of
+//! [`InferenceAdapter`] must be unit-testable WITHOUT real HTTP or credentials.
+//! This is the in-memory double that makes that possible — and, in this
+//! foundation ticket, the only [`InferenceAdapter`] implementation, so the
+//! configurator can be exercised end-to-end before real adapters land in #2403.
+//! It is shipped as public test support (not `cfg(test)`) so downstream crates'
+//! integration tests can reuse it, mirroring the crate's `embedder-test-support`
+//! precedent.
+//! What: [`ScriptedAdapter`] answers [`InferenceAdapter::chat`] from a FIFO queue
+//! of scripted outcomes; when the queue is empty it either echoes the last user
+//! message (echo mode) or errors (strict mode). Capability introspection is
+//! driven by the [`ProviderCapabilities`] it is constructed with.
+//! Test: `crates/trusty-common/tests/inference_foundation.rs` drives it through
+//! the trait and the configurator; inline `tests` cover echo + queue behaviour.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use crate::inference::adapter::InferenceAdapter;
+use crate::inference::error::InferenceError;
+use crate::inference::registry::ProviderCapabilities;
+use crate::inference::types::{
+    AssistantMessage, ChatChoice, ChatRequest, ChatResponse, UsageBlock,
+};
+
+/// A deterministic [`InferenceAdapter`] backed by a scripted response queue.
+///
+/// Why: gives tests full control over what `chat` returns — a canned success, a
+/// specific error, or an automatic echo — with zero network or credential
+/// dependency.
+/// What: holds a `name`, a [`ProviderCapabilities`] descriptor (drives the
+/// introspection methods), an `echo` flag, and a `Mutex`-guarded FIFO of
+/// scripted outcomes. `chat` pops the front; on an empty queue it echoes (echo
+/// mode) or returns [`InferenceError::Provider`] (strict mode).
+/// Test: `echo_reflects_last_user_message`, `queue_is_fifo`, `strict_mode_exhaustion_errors`.
+pub struct ScriptedAdapter {
+    name: String,
+    capabilities: ProviderCapabilities,
+    echo: bool,
+    queue: Mutex<Vec<Result<ChatResponse, InferenceError>>>,
+}
+
+impl ScriptedAdapter {
+    /// Construct a strict adapter: an empty queue errors on exhaustion.
+    ///
+    /// Why: tests that assert an exact sequence of responses want a hard failure
+    /// (not a silent echo) if the code under test calls `chat` more than scripted.
+    /// What: `echo = false`, empty queue, cloning `capabilities` into the adapter.
+    /// Test: `strict_mode_exhaustion_errors`.
+    pub fn new(name: impl Into<String>, capabilities: &ProviderCapabilities) -> Self {
+        Self {
+            name: name.into(),
+            capabilities: *capabilities,
+            echo: false,
+            queue: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Construct an echo adapter: an empty queue reflects the last user message.
+    ///
+    /// Why: the simplest possible "it works" double for wiring tests — a full
+    /// request→response→usage cycle without scripting each turn.
+    /// What: `echo = true`, empty queue.
+    /// Test: `echo_reflects_last_user_message`.
+    pub fn echo(name: impl Into<String>, capabilities: &ProviderCapabilities) -> Self {
+        Self {
+            name: name.into(),
+            capabilities: *capabilities,
+            echo: true,
+            queue: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Queue a scripted successful response (FIFO).
+    ///
+    /// Why: builder-style scripting for the exact-sequence tests.
+    /// What: pushes `response` to the back of the queue; returns `self` for
+    /// chaining.
+    /// Test: `queue_is_fifo`.
+    pub fn with_response(self, response: ChatResponse) -> Self {
+        self.push(Ok(response));
+        self
+    }
+
+    /// Queue a scripted error (FIFO).
+    ///
+    /// Why: lets tests drive the caller's retry/alarm handling deterministically.
+    /// What: pushes `error` to the back of the queue; returns `self`.
+    /// Test: exercised via the integration suite.
+    pub fn with_error(self, error: InferenceError) -> Self {
+        self.push(Err(error));
+        self
+    }
+
+    /// Push an outcome onto the back of the queue.
+    ///
+    /// Why: shared by the builder methods; centralises the lock handling.
+    /// What: locks the queue and appends; a poisoned lock is recovered
+    /// (into_inner) rather than propagated — test-support code must not panic a
+    /// caller over a poisoned test mutex.
+    fn push(&self, outcome: Result<ChatResponse, InferenceError>) {
+        let mut q = self.queue.lock().unwrap_or_else(|p| p.into_inner());
+        q.push(outcome);
+    }
+
+    /// Build an echo response reflecting the last user message in `request`.
+    ///
+    /// Why: the echo-mode fallback needs a plausible, deterministic response
+    /// carrying real content and a non-zero [`crate::inference::Usage`].
+    /// What: assistant content is the last `user`-role message's text (or an
+    /// empty string); usage is a crude word-count so cost/usage plumbing has
+    /// non-zero data to flow.
+    fn echo_response(request: &ChatRequest) -> ChatResponse {
+        let content = request
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == "user")
+            .and_then(|m| m.content.clone())
+            .unwrap_or_default();
+        let prompt_tokens = request
+            .messages
+            .iter()
+            .filter_map(|m| m.content.as_ref())
+            .map(|c| c.split_whitespace().count() as u32)
+            .sum();
+        let completion_tokens = content.split_whitespace().count() as u32;
+        ChatResponse {
+            id: "scripted-echo".into(),
+            model: request.model.clone(),
+            choices: vec![ChatChoice {
+                message: AssistantMessage {
+                    content: Some(content),
+                    tool_calls: Vec::new(),
+                },
+                finish_reason: Some("stop".into()),
+            }],
+            usage: UsageBlock {
+                prompt_tokens,
+                completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl InferenceAdapter for ScriptedAdapter {
+    /// The configured adapter name.
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The capabilities this adapter was constructed with.
+    fn capabilities(&self) -> &ProviderCapabilities {
+        &self.capabilities
+    }
+
+    /// Pop the next scripted outcome, or echo/error on exhaustion.
+    ///
+    /// Why: deterministic, network-free `chat` for tests.
+    /// What: returns the front of the queue (FIFO) when non-empty; otherwise
+    /// echoes the last user message (echo mode) or returns
+    /// [`InferenceError::Provider`] (strict mode).
+    /// Test: `echo_reflects_last_user_message`, `queue_is_fifo`,
+    /// `strict_mode_exhaustion_errors`.
+    async fn chat(&self, request: &ChatRequest) -> Result<ChatResponse, InferenceError> {
+        let mut q = self.queue.lock().unwrap_or_else(|p| p.into_inner());
+        if q.is_empty() {
+            drop(q);
+            return if self.echo {
+                Ok(Self::echo_response(request))
+            } else {
+                Err(InferenceError::Provider(
+                    "scripted adapter queue exhausted".into(),
+                ))
+            };
+        }
+        q.remove(0)
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::registry::{ProviderId, capabilities};
+    use crate::inference::types::ChatMessage;
+
+    fn caps() -> &'static ProviderCapabilities {
+        capabilities(ProviderId::OpenRouter)
+    }
+
+    /// Why: echo mode must reflect the last user turn and report non-zero usage.
+    /// Test: itself.
+    #[tokio::test]
+    async fn echo_reflects_last_user_message() {
+        let adapter = ScriptedAdapter::echo("scripted", caps());
+        let req = ChatRequest::new(
+            "x/y",
+            vec![ChatMessage::system("sys"), ChatMessage::user("hello world")],
+        );
+        let resp = adapter.chat(&req).await.expect("echo");
+        assert_eq!(resp.first_text().as_deref(), Some("hello world"));
+        assert!(resp.usage().total_tokens() > 0);
+    }
+
+    /// Why: scripted responses must be served in FIFO order before any echo.
+    /// Test: itself.
+    #[tokio::test]
+    async fn queue_is_fifo() {
+        let first = ScriptedAdapter::echo_response(&ChatRequest::new(
+            "m",
+            vec![ChatMessage::user("first")],
+        ));
+        let adapter = ScriptedAdapter::echo("scripted", caps()).with_response(first);
+        let req = ChatRequest::new("m", vec![ChatMessage::user("second")]);
+        // Queue front (scripted "first") comes before the echo of "second".
+        assert_eq!(
+            adapter.chat(&req).await.expect("q").first_text().as_deref(),
+            Some("first")
+        );
+        assert_eq!(
+            adapter
+                .chat(&req)
+                .await
+                .expect("echo")
+                .first_text()
+                .as_deref(),
+            Some("second")
+        );
+    }
+
+    /// Why: strict mode must error on exhaustion, never silently echo.
+    /// Test: itself.
+    #[tokio::test]
+    async fn strict_mode_exhaustion_errors() {
+        let adapter = ScriptedAdapter::new("scripted", caps());
+        let req = ChatRequest::new("m", vec![ChatMessage::user("x")]);
+        let err = adapter.chat(&req).await.expect_err("exhausted");
+        assert!(matches!(err, InferenceError::Provider(_)));
+    }
+}

--- a/crates/trusty-common/src/inference/types/message.rs
+++ b/crates/trusty-common/src/inference/types/message.rs
@@ -1,0 +1,252 @@
+//! [`ChatMessage`] — the conversation-message wire type.
+//!
+//! Why: the message type is used by both requests (history) and tool-result
+//! injection; isolating it keeps the request/response modules free of message
+//! construction boilerplate. It mirrors tcode's proven type — including the
+//! `cache_control` content-block switch (#2156) — so #2406 migrates without a
+//! wire change.
+//! What: [`ChatMessage`] with `role`, `content`, `tool_calls`, `tool_call_id`,
+//! `name`, and `cache_control`, plus a constructor per standard role. The
+//! hand-written `Serialize` converts `content` into a cache-annotated content
+//! block when `cache_control` is set.
+//! Test: inline `tests` — `constructors_set_role`, `tool_result_fields`,
+//! `serialises_all_roles`, `cache_control_serialises_as_block`,
+//! `plain_content_when_no_cache_control`.
+
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Serialize, Serializer};
+
+use super::tool::{CacheControl, ToolCall};
+
+/// A single message in the chat conversation.
+///
+/// Why: the OpenAI/OpenRouter `/chat/completions` schema distinguishes speaker
+/// identity by `role` and carries the text payload in `content` (or `null` for
+/// tool-call-only assistant turns).
+/// What: `role` is one of `"system"`/`"user"`/`"assistant"`/`"tool"`; `content`
+/// is the text or `None`; `tool_calls` carries outbound calls on assistant
+/// turns; `tool_call_id`/`name` are populated for `tool` messages;
+/// `cache_control` is a prompt-cache breakpoint applied at serialisation time.
+/// Test: `serialises_all_roles`, `cache_control_serialises_as_block`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct ChatMessage {
+    /// Conversation role.
+    pub role: String,
+    /// Text content; `None` on assistant turns that only emit tool calls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    /// Tool calls emitted by the assistant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    /// For `tool` messages: the id of the tool call this responds to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    /// For `tool` messages: the name of the function that was called.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Prompt-cache breakpoint. Request-only, so dropped on deserialise via
+    /// `#[serde(skip)]`; see [`Self::serialize`] for its wire effect.
+    #[serde(skip)]
+    pub cache_control: Option<CacheControl>,
+}
+
+impl Serialize for ChatMessage {
+    /// Serialise, converting `content` into a one-element cache-annotated block
+    /// array when `cache_control` is set, and a bare string otherwise.
+    ///
+    /// Why: the caching passthrough only honours the breakpoint when `content`
+    /// is shaped as `[{"type":"text","text":...,"cache_control":{...}}]` — a
+    /// plain string is never inspected. Hand-writing this keeps `content:
+    /// Option<String>` for every caller while branching only the wire encoding.
+    /// What: `content` serialises as the block array when both `content` and
+    /// `cache_control` are `Some`, a bare string when only `content` is `Some`,
+    /// and is omitted when `content` is `None`. Other fields serialise as their
+    /// `Option::is_none`-skipped selves; `cache_control` never appears as its
+    /// own key.
+    /// Test: `cache_control_serialises_as_block`, `plain_content_when_no_cache_control`.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("ChatMessage", 5)?;
+        state.serialize_field("role", &self.role)?;
+
+        match (&self.content, &self.cache_control) {
+            (Some(text), Some(cache_control)) => {
+                let block = [CachedTextBlock {
+                    kind: "text",
+                    text: text.as_str(),
+                    cache_control,
+                }];
+                state.serialize_field("content", &block)?;
+            }
+            (Some(text), None) => state.serialize_field("content", text)?,
+            (None, _) => state.skip_field("content")?,
+        }
+
+        match &self.tool_calls {
+            Some(calls) => state.serialize_field("tool_calls", calls)?,
+            None => state.skip_field("tool_calls")?,
+        }
+        match &self.tool_call_id {
+            Some(id) => state.serialize_field("tool_call_id", id)?,
+            None => state.skip_field("tool_call_id")?,
+        }
+        match &self.name {
+            Some(name) => state.serialize_field("name", name)?,
+            None => state.skip_field("name")?,
+        }
+
+        state.end()
+    }
+}
+
+/// Wire shape for one Anthropic-ephemeral cached text content block.
+///
+/// Why: `[{"type":"text","text":...,"cache_control":{"type":"ephemeral"}}]` is
+/// the documented content-caching shape; this private struct is the single place
+/// it is expressed instead of building it ad hoc in [`ChatMessage::serialize`].
+/// What: `kind` is always `"text"`; `text`/`cache_control` borrow from the owner
+/// to avoid a clone during serialisation.
+/// Test: exercised via `cache_control_serialises_as_block`.
+#[derive(Serialize)]
+struct CachedTextBlock<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: &'a str,
+    cache_control: &'a CacheControl,
+}
+
+impl ChatMessage {
+    /// Construct a `system` message.
+    ///
+    /// Why: convenience constructor avoiding `role.into()` boilerplate.
+    /// What: `role = "system"`, provided `content`, all optionals `None`.
+    /// Test: `constructors_set_role`.
+    pub fn system(content: impl Into<String>) -> Self {
+        Self::text("system", content)
+    }
+
+    /// Construct a `user` message.
+    ///
+    /// Why: convenience constructor for the most common message type.
+    /// What: `role = "user"`, provided `content`.
+    /// Test: `constructors_set_role`.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self::text("user", content)
+    }
+
+    /// Construct an `assistant` message with text content.
+    ///
+    /// Why: convenience constructor for building history from prior responses.
+    /// What: `role = "assistant"`, provided `content`.
+    /// Test: `constructors_set_role`.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self::text("assistant", content)
+    }
+
+    /// Construct a `tool` result message.
+    ///
+    /// Why: after executing a tool call, the result is fed back in a `tool`
+    /// message referencing the original `tool_call_id`.
+    /// What: `role = "tool"` with the call id, function name, and result content.
+    /// Test: `tool_result_fields`.
+    pub fn tool_result(
+        tool_call_id: impl Into<String>,
+        name: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        Self {
+            role: "tool".into(),
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.into()),
+            name: Some(name.into()),
+            cache_control: None,
+        }
+    }
+
+    /// Private shared constructor for the plain-text roles.
+    ///
+    /// Why: `system`/`user`/`assistant` differ only in the role string; one
+    /// helper removes the triplicated field boilerplate.
+    /// What: builds a text-only message with all optional fields `None`.
+    fn text(role: &str, content: impl Into<String>) -> Self {
+        Self {
+            role: role.into(),
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+            cache_control: None,
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: each constructor must set the right `role` string.
+    /// Test: itself.
+    #[test]
+    fn constructors_set_role() {
+        assert_eq!(ChatMessage::system("s").role, "system");
+        assert_eq!(ChatMessage::user("u").role, "user");
+        assert_eq!(ChatMessage::assistant("a").role, "assistant");
+    }
+
+    /// Why: tool results carry extra required fields.
+    /// Test: itself.
+    #[test]
+    fn tool_result_fields() {
+        let m = ChatMessage::tool_result("call_abc", "get_weather", r#"{"t":72}"#);
+        assert_eq!(m.role, "tool");
+        assert_eq!(m.tool_call_id.as_deref(), Some("call_abc"));
+        assert_eq!(m.name.as_deref(), Some("get_weather"));
+    }
+
+    /// Why: JSON consumers depend on the `role` value; a typo would silently
+    /// break the API.
+    /// Test: itself.
+    #[test]
+    fn serialises_all_roles() {
+        for (m, role) in [
+            (ChatMessage::system("x"), "system"),
+            (ChatMessage::user("x"), "user"),
+            (ChatMessage::assistant("x"), "assistant"),
+            (ChatMessage::tool_result("i", "f", "r"), "tool"),
+        ] {
+            let v: serde_json::Value = serde_json::to_value(&m).expect("serialise");
+            assert_eq!(v["role"].as_str(), Some(role));
+        }
+    }
+
+    /// Why: a `cache_control`-bearing message must emit the block-array shape.
+    /// Test: itself.
+    #[test]
+    fn cache_control_serialises_as_block() {
+        let mut m = ChatMessage::system("you are helpful");
+        m.cache_control = Some(CacheControl::ephemeral());
+        let v: serde_json::Value = serde_json::to_value(&m).expect("serialise");
+        assert_eq!(
+            v["content"],
+            serde_json::json!([{
+                "type": "text",
+                "text": "you are helpful",
+                "cache_control": {"type": "ephemeral"}
+            }])
+        );
+    }
+
+    /// Why: the default (no cache_control) path must stay a bare string.
+    /// Test: itself.
+    #[test]
+    fn plain_content_when_no_cache_control() {
+        let m = ChatMessage::system("hi");
+        let v: serde_json::Value = serde_json::to_value(&m).expect("serialise");
+        assert_eq!(v["content"], serde_json::json!("hi"));
+    }
+}

--- a/crates/trusty-common/src/inference/types/mod.rs
+++ b/crates/trusty-common/src/inference/types/mod.rs
@@ -1,0 +1,29 @@
+//! Normalized inference request/response model (issue #2402, epic #2400).
+//!
+//! Why: six bespoke LLM clients each modelled messages, tools, usage, and the
+//! request/response envelope slightly differently. This module is the single
+//! set of wire+in-memory types every [`super::adapter::InferenceAdapter`]
+//! speaks, shaped to absorb what tcode's OpenRouter + Bedrock clients already
+//! emit so #2406 migrates without a wire-format change.
+//! What: re-exports the message, tool, request, response, usage, and secret
+//! types from their focused submodules (one concept per file to stay well under
+//! the 500-SLOC cap).
+//! Test: each submodule's inline `tests`; cross-type round-trips in
+//! `crates/trusty-common/tests/inference_foundation.rs`.
+
+mod message;
+mod request;
+mod response;
+mod secret;
+mod tool;
+mod usage;
+
+pub use message::ChatMessage;
+pub use request::ChatRequest;
+pub use response::{AssistantMessage, ChatChoice, ChatResponse, StopReason};
+pub use secret::SecretString;
+pub use tool::{
+    CacheControl, FunctionCall, FunctionDefinition, RequestUsageConfig, ToolCall, ToolChoice,
+    ToolDefinition, openai_tool_choice,
+};
+pub use usage::{PromptTokensDetails, Usage, UsageBlock};

--- a/crates/trusty-common/src/inference/types/request.rs
+++ b/crates/trusty-common/src/inference/types/request.rs
@@ -1,0 +1,137 @@
+//! [`ChatRequest`] — the normalized inference request body.
+//!
+//! Why: a dedicated struct keeps the serialisation surface explicit and avoids
+//! ad-hoc `serde_json::json!` construction scattered across call sites. It
+//! matches tcode's OpenAI-compatible request shape so #2406 migrates cleanly,
+//! and it is what [`super::super::adapter::InferenceAdapter::chat`] accepts.
+//! What: [`ChatRequest`] carries the model slug, message history, and the
+//! standard optional knobs (temperature, max_tokens, tools, tool_choice, stop,
+//! and the OpenRouter detailed-usage directive). Optional fields use
+//! `skip_serializing_if` so the wire payload stays minimal.
+//! Test: inline `tests` — `minimal_request_omits_optionals`,
+//! `request_with_tools_and_stop_serialises`, `detailed_usage_toggles`.
+
+use serde::{Deserialize, Serialize};
+
+use super::message::ChatMessage;
+use super::tool::{RequestUsageConfig, ToolDefinition};
+use serde_json::Value;
+
+/// The full request body for a chat/completions call.
+///
+/// Why: every adapter accepts this one shape; provider-specific translation
+/// (tool-choice dialect, usage directive) happens inside the adapter, not here.
+/// What: `model` is the provider slug; `messages` is the conversation history;
+/// the remaining fields are optional sampling/tool/stop knobs plus `usage`
+/// (OpenRouter's detailed-accounting opt-in). `tool_choice` is a raw `Value`
+/// because its wire spelling is provider-dialect-specific (produced by
+/// [`super::tool::openai_tool_choice`] or an adapter's own mapper).
+/// Test: `minimal_request_omits_optionals`, `request_with_tools_and_stop_serialises`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatRequest {
+    /// Provider model slug, e.g. `"anthropic/claude-sonnet-4-5"`.
+    pub model: String,
+    /// Conversation history, including the new user turn.
+    pub messages: Vec<ChatMessage>,
+    /// Sampling temperature.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    /// Maximum tokens to generate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// Tools the model may call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ToolDefinition>>,
+    /// Tool-choice policy in the target provider's wire dialect.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<Value>,
+    /// Stop sequences that end generation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Vec<String>>,
+    /// OpenRouter detailed-usage directive; `None` (omitted) for every other
+    /// provider/path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<RequestUsageConfig>,
+}
+
+impl ChatRequest {
+    /// Construct a minimal request from a model slug and message history.
+    ///
+    /// Why: the overwhelming majority of call sites want "this model, these
+    /// messages, defaults for everything else"; a builder-free constructor keeps
+    /// them terse while the optional knobs stay directly assignable.
+    /// What: sets `model` and `messages`; every optional field starts `None`.
+    /// Test: `minimal_request_omits_optionals`.
+    pub fn new(model: impl Into<String>, messages: Vec<ChatMessage>) -> Self {
+        Self {
+            model: model.into(),
+            messages,
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            tool_choice: None,
+            stop: None,
+            usage: None,
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::super::tool::{FunctionDefinition, ToolDefinition};
+    use super::*;
+    use serde_json::json;
+
+    /// Why: `None` optionals must be omitted so the wire payload stays lean.
+    /// Test: itself.
+    #[test]
+    fn minimal_request_omits_optionals() {
+        let req = ChatRequest::new("openai/gpt-4o-mini", vec![ChatMessage::user("hi")]);
+        let v: Value = serde_json::to_value(&req).expect("serialise");
+        assert_eq!(v["model"], "openai/gpt-4o-mini");
+        assert_eq!(v["messages"][0]["content"], "hi");
+        assert!(v.get("temperature").is_none() || v["temperature"].is_null());
+        assert!(v.get("tools").is_none() || v["tools"].is_null());
+        assert!(v.get("stop").is_none() || v["stop"].is_null());
+        assert!(v.get("usage").is_none() || v["usage"].is_null());
+    }
+
+    /// Why: tool + stop + sampling fields must serialise in the OpenAI shape.
+    /// Test: itself.
+    #[test]
+    fn request_with_tools_and_stop_serialises() {
+        let mut req = ChatRequest::new("openai/gpt-4o-mini", vec![ChatMessage::user("weather?")]);
+        req.temperature = Some(0.0);
+        req.max_tokens = Some(256);
+        req.tools = Some(vec![ToolDefinition::function(FunctionDefinition {
+            name: "get_weather".into(),
+            description: Some("weather".into()),
+            parameters: Some(json!({"type": "object"})),
+            cache_control: None,
+        })]);
+        req.tool_choice = Some(json!("auto"));
+        req.stop = Some(vec!["\n\n".into()]);
+        let v: Value = serde_json::to_value(&req).expect("serialise");
+        assert_eq!(v["tools"][0]["function"]["name"], "get_weather");
+        assert_eq!(v["tool_choice"], "auto");
+        assert_eq!(v["temperature"], 0.0_f32);
+        assert_eq!(v["max_tokens"], 256);
+        assert_eq!(v["stop"][0], "\n\n");
+    }
+
+    /// Why: the detailed-usage directive must appear only when set.
+    /// Test: itself.
+    #[test]
+    fn detailed_usage_toggles() {
+        let mut req = ChatRequest::new("x", vec![ChatMessage::user("hi")]);
+        req.usage = Some(RequestUsageConfig::detailed());
+        let v: Value = serde_json::to_value(&req).expect("serialise");
+        assert_eq!(v["usage"], json!({"include": true}));
+
+        req.usage = None;
+        let v: Value = serde_json::to_value(&req).expect("serialise");
+        assert!(v.get("usage").is_none() || v["usage"].is_null());
+    }
+}

--- a/crates/trusty-common/src/inference/types/response.rs
+++ b/crates/trusty-common/src/inference/types/response.rs
@@ -1,0 +1,279 @@
+//! [`ChatResponse`] — the normalized inference response.
+//!
+//! Why: callers want one typed value from every adapter regardless of provider
+//! wire quirks. This mirrors tcode's response hierarchy (so #2406 migrates
+//! cleanly) and adds a typed [`StopReason`] view over the wire `finish_reason`
+//! string.
+//! What: [`ChatResponse`] wraps the `choices` array and the [`Usage`] block, with
+//! convenience accessors ([`ChatResponse::first_text`],
+//! [`ChatResponse::first_tool_calls`], [`ChatResponse::stop_reason`],
+//! [`ChatResponse::usage`]). [`AssistantMessage`]/[`ChatChoice`] are the nested
+//! wire shapes; [`StopReason`] is the typed stop-condition.
+//! Test: inline `tests` — `deserialises_text_fixture`, `deserialises_tool_call`,
+//! `stop_reason_maps_variants`, `usage_flows_through`, `first_text_empty_choices`.
+
+use serde::{Deserialize, Serialize};
+
+use super::tool::ToolCall;
+use super::usage::{Usage, UsageBlock};
+
+/// Why the model stopped generating, as a typed view over the wire string.
+///
+/// Why: callers branch on the stop condition (continue the tool loop vs. surface
+/// the final text vs. flag a truncation); matching an enum is safer than
+/// comparing raw strings at every site.
+/// What: the four standard OpenAI/OpenRouter finish reasons plus an `Other`
+/// catch-all preserving any unrecognised wire value.
+/// Test: `stop_reason_maps_variants`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StopReason {
+    /// The model reached a natural stopping point (`"stop"`).
+    Stop,
+    /// The model emitted tool calls and is awaiting results (`"tool_calls"`).
+    ToolCalls,
+    /// Generation hit the token limit (`"length"`).
+    Length,
+    /// The content filter halted generation (`"content_filter"`).
+    ContentFilter,
+    /// Any other provider-specific reason, preserved verbatim.
+    Other(String),
+}
+
+impl StopReason {
+    /// Parse a wire `finish_reason` string into a [`StopReason`].
+    ///
+    /// Why: keeps the string→enum mapping in one place so every accessor agrees.
+    /// What: maps the four known values; anything else becomes `Other`.
+    /// Test: `stop_reason_maps_variants`.
+    pub fn from_wire(reason: &str) -> Self {
+        match reason {
+            "stop" => Self::Stop,
+            "tool_calls" => Self::ToolCalls,
+            "length" => Self::Length,
+            "content_filter" => Self::ContentFilter,
+            other => Self::Other(other.to_string()),
+        }
+    }
+}
+
+/// The assistant message within a choice.
+///
+/// Why: an explicit response-side struct (rather than reusing [`super::ChatMessage`])
+/// keeps request and response paths cleanly separated and lets the full response
+/// — including tool-call arguments — be dumped verbatim for debug capture.
+/// What: `content` is the text (or `None` for tool-only turns); `tool_calls`
+/// carries any function invocations.
+/// Test: `deserialises_tool_call`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantMessage {
+    /// Text content; `None` when the turn is solely tool calls.
+    pub content: Option<String>,
+    /// Tool calls emitted this turn.
+    #[serde(default)]
+    pub tool_calls: Vec<ToolCall>,
+}
+
+/// One choice in the model response.
+///
+/// Why: the API returns a `choices` array (allowing `n > 1`); we always request
+/// one but the struct must match the wire schema.
+/// What: `message` holds the assistant turn; `finish_reason` carries the raw
+/// stop condition (viewed typed via [`ChatResponse::stop_reason`]).
+/// Test: `deserialises_text_fixture`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatChoice {
+    /// The assistant message produced for this choice.
+    pub message: AssistantMessage,
+    /// Raw wire stop condition, e.g. `"stop"` or `"tool_calls"`.
+    pub finish_reason: Option<String>,
+}
+
+/// The top-level response from a chat/completions call.
+///
+/// Why: wraps the `choices` array and `usage` so callers receive one typed value
+/// from [`super::super::adapter::InferenceAdapter::chat`].
+/// What: `id` is the provider response id; `model` is the RESOLVED model slug the
+/// provider actually served (may differ from the request under routing/fallback);
+/// `choices` holds the generated turns; `usage` is the normalized [`Usage`]
+/// (parsed from the wire [`UsageBlock`]).
+/// Test: `deserialises_text_fixture`, `usage_flows_through`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatResponse {
+    /// Opaque provider response identifier.
+    pub id: String,
+    /// Resolved model slug the provider actually used. Empty when the response
+    /// omits it — use [`Self::resolved_model`] rather than this field directly.
+    #[serde(default)]
+    pub model: String,
+    /// Generated choices (one per `n`; we always request `n = 1`).
+    pub choices: Vec<ChatChoice>,
+    /// Token + cost accounting for this call.
+    #[serde(default)]
+    pub usage: UsageBlock,
+}
+
+impl ChatResponse {
+    /// The first choice's text content, if any.
+    ///
+    /// Why: most calls want the assistant's text; this avoids repetitive
+    /// indexing at every call site.
+    /// What: `choices[0].message.content`, or `None` when absent.
+    /// Test: `deserialises_text_fixture`, `first_text_empty_choices`.
+    pub fn first_text(&self) -> Option<String> {
+        self.choices.first()?.message.content.clone()
+    }
+
+    /// The first choice's tool calls.
+    ///
+    /// Why: tool-call workflows need the emitted calls without nested indexing.
+    /// What: `choices[0].message.tool_calls`, or an empty slice.
+    /// Test: `deserialises_tool_call`.
+    pub fn first_tool_calls(&self) -> &[ToolCall] {
+        self.choices
+            .first()
+            .map(|c| c.message.tool_calls.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// The typed stop reason from the first choice.
+    ///
+    /// Why: callers decide whether to continue the tool loop or surface the
+    /// response; the typed enum is safer than string comparison.
+    /// What: parses `choices[0].finish_reason` via [`StopReason::from_wire`];
+    /// `None` when there is no choice or no finish reason.
+    /// Test: `stop_reason_maps_variants`.
+    pub fn stop_reason(&self) -> Option<StopReason> {
+        self.choices
+            .first()?
+            .finish_reason
+            .as_deref()
+            .map(StopReason::from_wire)
+    }
+
+    /// The normalized [`Usage`] for this call.
+    ///
+    /// Why: callers speak [`Usage`], not the wire [`UsageBlock`].
+    /// What: clones and converts `self.usage` via [`UsageBlock::into_usage`].
+    /// Test: `usage_flows_through`.
+    pub fn usage(&self) -> Usage {
+        self.usage.clone().into_usage()
+    }
+
+    /// The model slug to attribute this turn to: the resolved model the provider
+    /// reports, falling back to the requested slug when the response omits one.
+    ///
+    /// Why: recorders/pricing must attribute what the provider actually ran, not
+    /// merely what was asked — a routing/fallback slug can resolve differently.
+    /// What: `&self.model` when non-empty, else `requested`.
+    /// Test: `resolved_model_prefers_response_then_requested`.
+    pub fn resolved_model<'a>(&'a self, requested: &'a str) -> &'a str {
+        if self.model.is_empty() {
+            requested
+        } else {
+            &self.model
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the struct layout must match the real wire format.
+    /// Test: itself.
+    #[test]
+    fn deserialises_text_fixture() {
+        let fixture = r#"{
+          "id": "gen-abc",
+          "choices": [{"message": {"role": "assistant", "content": "Hello", "tool_calls": []},
+                       "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14}
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        assert_eq!(resp.id, "gen-abc");
+        assert_eq!(resp.first_text().as_deref(), Some("Hello"));
+        assert_eq!(resp.stop_reason(), Some(StopReason::Stop));
+        assert!(resp.first_tool_calls().is_empty());
+    }
+
+    /// Why: tool-call workflows depend on parsing `tool_calls`.
+    /// Test: itself.
+    #[test]
+    fn deserialises_tool_call() {
+        let fixture = r#"{
+          "id": "gen-xyz",
+          "choices": [{"message": {"role": "assistant", "content": null,
+              "tool_calls": [{"id": "call_1", "type": "function",
+                  "function": {"name": "get_weather", "arguments": "{\"loc\":\"SEA\"}"}}]},
+              "finish_reason": "tool_calls"}],
+          "usage": {}
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        assert!(resp.first_text().is_none());
+        let calls = resp.first_tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(resp.stop_reason(), Some(StopReason::ToolCalls));
+    }
+
+    /// Why: the string→enum mapping must cover every known reason plus `Other`.
+    /// Test: itself.
+    #[test]
+    fn stop_reason_maps_variants() {
+        assert_eq!(StopReason::from_wire("stop"), StopReason::Stop);
+        assert_eq!(StopReason::from_wire("tool_calls"), StopReason::ToolCalls);
+        assert_eq!(StopReason::from_wire("length"), StopReason::Length);
+        assert_eq!(
+            StopReason::from_wire("content_filter"),
+            StopReason::ContentFilter
+        );
+        assert_eq!(
+            StopReason::from_wire("weird"),
+            StopReason::Other("weird".into())
+        );
+    }
+
+    /// Why: usage must flow through the response accessor into `Usage`.
+    /// Test: itself.
+    #[test]
+    fn usage_flows_through() {
+        let fixture = r#"{
+          "id": "z",
+          "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 8, "completion_tokens": 3,
+                    "cache_read_input_tokens": 5, "cache_creation_input_tokens": 2}
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        let u = resp.usage();
+        assert_eq!(u.prompt_tokens, 8);
+        assert_eq!(u.cache_read_tokens, 5);
+        assert_eq!(u.cache_creation_tokens, 2);
+    }
+
+    /// Why: callers must handle an empty choices list without panicking.
+    /// Test: itself.
+    #[test]
+    fn first_text_empty_choices() {
+        let resp: ChatResponse =
+            serde_json::from_str(r#"{"id":"x","choices":[],"usage":{}}"#).expect("deserialise");
+        assert!(resp.first_text().is_none());
+        assert!(resp.stop_reason().is_none());
+        assert!(resp.first_tool_calls().is_empty());
+    }
+
+    /// Why: recorders must prefer the resolved model, falling back to requested.
+    /// Test: itself.
+    #[test]
+    fn resolved_model_prefers_response_then_requested() {
+        let with: ChatResponse =
+            serde_json::from_str(r#"{"id":"x","model":"served/model","choices":[],"usage":{}}"#)
+                .expect("deserialise");
+        assert_eq!(with.resolved_model("asked/model"), "served/model");
+
+        let without: ChatResponse =
+            serde_json::from_str(r#"{"id":"x","choices":[],"usage":{}}"#).expect("deserialise");
+        assert_eq!(without.resolved_model("asked/model"), "asked/model");
+    }
+}

--- a/crates/trusty-common/src/inference/types/secret.rs
+++ b/crates/trusty-common/src/inference/types/secret.rs
@@ -1,0 +1,114 @@
+//! [`SecretString`] — a credential wrapper that never prints its value.
+//!
+//! Why: the configurator ([`super::super::configurator`]) resolves an API key
+//! and carries it inside [`super::super::configurator::ResolvedProvider`] so an
+//! adapter can be built from it. That resolved value must never leak into a log
+//! line, a `Debug` dump, or a serialised payload — slice 1's review caught
+//! exactly this class of Debug-leak. Wrapping the key in this newtype makes the
+//! leak-safe behaviour the default rather than something each call site must
+//! remember.
+//! What: [`SecretString`] holds a `String` whose `Debug`/`Display` render the
+//! redacted preview from [`crate::inference::credentials::redact_secret`]. It
+//! does NOT derive `Serialize`, so it can never be written to the wire. The raw
+//! value is reachable only via the explicit [`SecretString::expose`] method.
+//! Test: inline `tests` — `secret_debug_is_redacted`, `secret_display_is_redacted`,
+//! `secret_expose_returns_raw`.
+
+use std::fmt;
+
+use crate::inference::credentials::redact_secret;
+
+/// A string credential that redacts itself in `Debug`/`Display`.
+///
+/// Why: prevents an API key from ever reaching a log or panic message by
+/// accident — the only way to read the raw value is the named, greppable
+/// [`Self::expose`] call, so credential handling is auditable.
+/// What: a transparent wrapper over `String` with hand-written `Debug`/`Display`
+/// that delegate to [`redact_secret`]. Intentionally NOT `Serialize`,
+/// `Clone`-audited (clone is allowed — the value is already in memory), and
+/// NOT `Deref` (that would re-expose the raw value implicitly).
+/// Test: `secret_debug_is_redacted`, `secret_expose_returns_raw`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SecretString(String);
+
+impl SecretString {
+    /// Wrap a raw credential value.
+    ///
+    /// Why: the single constructor makes every secret enter the type through one
+    /// door.
+    /// What: moves `value` into the wrapper.
+    /// Test: `secret_expose_returns_raw`.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Borrow the raw secret value.
+    ///
+    /// Why: adapter construction (in #2403) needs the actual key to authenticate;
+    /// the explicit method name documents the deliberate exposure at the call
+    /// site rather than hiding it behind `Deref`/`Display`.
+    /// What: returns the wrapped string slice unredacted.
+    /// Test: `secret_expose_returns_raw`.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretString {
+    /// Render the redacted preview, never the raw value.
+    ///
+    /// Why: a `#[derive(Debug)]` struct that transitively contains a
+    /// `SecretString` (e.g. `ResolvedProvider`) must be safe to log; this impl
+    /// guarantees that.
+    /// What: writes `SecretString(<redacted>)`.
+    /// Test: `secret_debug_is_redacted`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SecretString({})", redact_secret(&self.0))
+    }
+}
+
+impl fmt::Display for SecretString {
+    /// Render the redacted preview, never the raw value.
+    ///
+    /// Why: `Display` is the surface most likely to reach a user-facing message
+    /// or a `format!` in a log; it must be as safe as `Debug`.
+    /// What: writes the redacted preview only.
+    /// Test: `secret_display_is_redacted`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&redact_secret(&self.0))
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the raw value must never appear in a `Debug` dump.
+    /// Test: itself.
+    #[test]
+    fn secret_debug_is_redacted() {
+        let s = SecretString::new("sk-or-verysecretvalue1234"); // pragma: allowlist secret
+        let dumped = format!("{s:?}");
+        assert!(!dumped.contains("verysecretvalue"), "leaked: {dumped}");
+        assert!(dumped.contains("chars"), "not redacted shape: {dumped}");
+    }
+
+    /// Why: the raw value must never appear in a `Display` render.
+    /// Test: itself.
+    #[test]
+    fn secret_display_is_redacted() {
+        let s = SecretString::new("sk-or-verysecretvalue1234"); // pragma: allowlist secret
+        let shown = format!("{s}");
+        assert!(!shown.contains("verysecretvalue"), "leaked: {shown}");
+    }
+
+    /// Why: `expose` is the one sanctioned path back to the raw value.
+    /// Test: itself.
+    #[test]
+    fn secret_expose_returns_raw() {
+        let s = SecretString::new("raw-key"); // pragma: allowlist secret
+        assert_eq!(s.expose(), "raw-key");
+    }
+}

--- a/crates/trusty-common/src/inference/types/tool.rs
+++ b/crates/trusty-common/src/inference/types/tool.rs
@@ -1,0 +1,275 @@
+//! Tool-calling + prompt-cache wire types and the neutral [`ToolChoice`] policy.
+//!
+//! Why: tool definitions, tool calls, and the tool-choice policy are shared by
+//! every consumer that lets a model call functions. Isolating them here (rather
+//! than in `request.rs`) keeps the request body free of tool-schema
+//! boilerplate and lets the tool surface evolve independently. These types
+//! mirror tcode's proven OpenAI-compatible shapes so #2406 migrates without a
+//! wire-format change.
+//! What: [`ToolCall`]/[`FunctionCall`] (model-emitted), [`ToolDefinition`]/
+//! [`FunctionDefinition`] (caller-supplied schema), the [`ToolChoice`] neutral
+//! policy enum with its [`openai_tool_choice`] wire mapper, [`CacheControl`]
+//! (Anthropic ephemeral breakpoint), and [`RequestUsageConfig`] (OpenRouter's
+//! detailed-usage directive).
+//! Test: inline `tests` — `tool_definition_serialises`,
+//! `function_definition_round_trip`, `openai_tool_choice_maps_every_variant`,
+//! `cache_control_ephemeral_shape`, `request_usage_detailed_shape`.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+/// An Anthropic-style ephemeral prompt-cache breakpoint.
+///
+/// Why: Anthropic (and OpenRouter's passthrough for `anthropic/*` slugs) prices
+/// everything up to and including a `cache_control` marker as one cached prefix,
+/// so a cache hit on a later turn bills the prefix at ~0.1x the normal input
+/// rate. Callers place this on the byte-stable tools+system prefix they resend
+/// every turn.
+/// What: `kind` is always `"ephemeral"`; serialises to `{"type":"ephemeral"}`.
+/// Test: `cache_control_ephemeral_shape`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheControl {
+    /// Always `"ephemeral"`.
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+impl CacheControl {
+    /// Construct the (only) ephemeral cache-breakpoint marker.
+    ///
+    /// Why: every call site wants the identical value; naming the constructor
+    /// after the wire concept avoids a stringly-typed literal at each use site.
+    /// What: returns `CacheControl { kind: "ephemeral" }`.
+    /// Test: `cache_control_ephemeral_shape`.
+    pub fn ephemeral() -> Self {
+        Self {
+            kind: "ephemeral".into(),
+        }
+    }
+}
+
+/// OpenRouter's request-side "return detailed usage" directive.
+///
+/// Why: requesting detailed usage accounting is what makes OpenRouter return its
+/// authoritative, cache-discount-aware `usage.cost` and nested cache counters —
+/// without it only the bare token counts are guaranteed. Sent only for the
+/// OpenRouter provider (gated by [`super::super::adapter::InferenceAdapter::wants_detailed_usage`]).
+/// What: `include: true` serialises to `{"include":true}` under the request's
+/// top-level `usage` key.
+/// Test: `request_usage_detailed_shape`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestUsageConfig {
+    /// Whether to request detailed (cost + cache-breakdown) usage accounting.
+    pub include: bool,
+}
+
+impl RequestUsageConfig {
+    /// Construct the "include detailed usage" directive.
+    ///
+    /// Why: every call site wants the identical `{"include":true}` value.
+    /// What: returns `RequestUsageConfig { include: true }`.
+    /// Test: `request_usage_detailed_shape`.
+    pub fn detailed() -> Self {
+        Self { include: true }
+    }
+}
+
+/// A tool call emitted by the model.
+///
+/// Why: the model may invoke one or more functions before producing final text;
+/// callers must execute these and feed results back before the conversation can
+/// continue.
+/// What: `id` is the opaque call identifier echoed in the subsequent `tool`
+/// result message; `kind` is always `"function"`; `function` carries the name
+/// and JSON-encoded arguments.
+/// Test: exercised via `super::response` deserialisation tests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolCall {
+    /// Unique call identifier.
+    pub id: String,
+    /// Always `"function"` for the current OpenAI schema.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// The function being called.
+    pub function: FunctionCall,
+}
+
+/// The function name and arguments within a [`ToolCall`].
+///
+/// Why: separating this from [`ToolCall`] matches the wire format, which wraps
+/// function details in a nested object.
+/// What: `name` is the registered function; `arguments` is a JSON string exactly
+/// as emitted by the model (parse with `serde_json::from_str` at the call site).
+/// Test: exercised via `super::response` deserialisation tests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FunctionCall {
+    /// Registered function name.
+    pub name: String,
+    /// JSON-encoded argument object.
+    pub arguments: String,
+}
+
+/// A tool definition submitted with a request.
+///
+/// Why: providing tool definitions tells the model which functions exist so it
+/// can decide when and how to call them.
+/// What: `kind` is always `"function"`; `function` carries the JSON-Schema
+/// description.
+/// Test: `tool_definition_serialises`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolDefinition {
+    /// Always `"function"`.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// The function schema.
+    pub function: FunctionDefinition,
+}
+
+impl ToolDefinition {
+    /// Construct a function-type tool definition.
+    ///
+    /// Why: all current OpenAI-compatible tools are function tools; this
+    /// constructor bakes in that invariant.
+    /// What: sets `kind = "function"` and wraps the provided schema.
+    /// Test: `tool_definition_serialises`.
+    pub fn function(function: FunctionDefinition) -> Self {
+        Self {
+            kind: "function".into(),
+            function,
+        }
+    }
+}
+
+/// JSON-Schema description of a callable function.
+///
+/// Why: the model needs the name, a description, and parameter schema to decide
+/// when and how to call the function correctly.
+/// What: `name` is the call target; `description` guides selection; `parameters`
+/// is a raw `serde_json::Value` JSON-Schema object; `cache_control` optionally
+/// marks this (typically the last) tool as a cache breakpoint.
+/// Test: `function_definition_round_trip`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FunctionDefinition {
+    /// The function name as registered with the model.
+    pub name: String,
+    /// Human-readable description guiding the model's decision to call it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// JSON-Schema object describing the parameter shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Value>,
+    /// Prompt-cache breakpoint; when set, serialises as a sibling
+    /// `"cache_control":{"type":"ephemeral"}` field alongside the schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+/// Provider-neutral tool-choice policy.
+///
+/// Why: callers express intent — "don't call tools", "you may", "you must", or
+/// "call this specific function" — without knowing how each backend spells it on
+/// the wire. The adapter translates this via
+/// [`super::super::adapter::InferenceAdapter::map_tool_choice`].
+/// What: `None` disables tools, `Auto` lets the model decide, `Required` forces
+/// some tool call, `Function(name)` forces a specific named function.
+/// Test: `openai_tool_choice_maps_every_variant`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolChoice {
+    /// The model must not call any tool.
+    None,
+    /// The model may call a tool if it decides to.
+    Auto,
+    /// The model must call some tool this turn.
+    Required,
+    /// The model must call the named function.
+    Function(String),
+}
+
+/// Map a neutral [`ToolChoice`] into the OpenAI-dialect wire value.
+///
+/// Why: OpenAI-compatible backends (OpenRouter, Fireworks, OpenAI-direct) share
+/// one spelling — string policies plus a `{type,function}` object for a specific
+/// call. Centralising it here is the default the [`ToolDialect::OpenAiFunctions`]
+/// adapters reuse rather than re-deriving at each site.
+/// What: returns the `serde_json::Value` to place in `ChatRequest.tool_choice`.
+/// Test: `openai_tool_choice_maps_every_variant`.
+///
+/// [`ToolDialect::OpenAiFunctions`]: super::super::registry::ToolDialect::OpenAiFunctions
+pub fn openai_tool_choice(choice: ToolChoice) -> Value {
+    match choice {
+        ToolChoice::None => json!("none"),
+        ToolChoice::Auto => json!("auto"),
+        ToolChoice::Required => json!("required"),
+        ToolChoice::Function(name) => json!({"type": "function", "function": {"name": name}}),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the wire format requires `type: "function"`.
+    /// Test: itself.
+    #[test]
+    fn tool_definition_serialises() {
+        let tool = ToolDefinition::function(FunctionDefinition {
+            name: "ping".into(),
+            description: None,
+            parameters: None,
+            cache_control: None,
+        });
+        let v: Value = serde_json::to_value(&tool).expect("serialise");
+        assert_eq!(v["type"], "function");
+        assert_eq!(v["function"]["name"], "ping");
+        assert!(v["function"].get("cache_control").is_none());
+    }
+
+    /// Why: parameter schemas are raw JSON; verify the round-trip preserves them.
+    /// Test: itself.
+    #[test]
+    fn function_definition_round_trip() {
+        let params = json!({"type": "object", "properties": {}});
+        let def = FunctionDefinition {
+            name: "my_fn".into(),
+            description: Some("does stuff".into()),
+            parameters: Some(params.clone()),
+            cache_control: Some(CacheControl::ephemeral()),
+        };
+        let s = serde_json::to_string(&def).expect("serialise");
+        let de: FunctionDefinition = serde_json::from_str(&s).expect("deserialise");
+        assert_eq!(de.name, "my_fn");
+        assert_eq!(de.parameters.as_ref(), Some(&params));
+        assert_eq!(de.cache_control, Some(CacheControl::ephemeral()));
+    }
+
+    /// Why: a typo in any wire spelling would silently break tool routing.
+    /// Test: itself.
+    #[test]
+    fn openai_tool_choice_maps_every_variant() {
+        assert_eq!(openai_tool_choice(ToolChoice::None), json!("none"));
+        assert_eq!(openai_tool_choice(ToolChoice::Auto), json!("auto"));
+        assert_eq!(openai_tool_choice(ToolChoice::Required), json!("required"));
+        assert_eq!(
+            openai_tool_choice(ToolChoice::Function("get_weather".into())),
+            json!({"type": "function", "function": {"name": "get_weather"}})
+        );
+    }
+
+    /// Why: this is the literal marker the caching passthrough looks for.
+    /// Test: itself.
+    #[test]
+    fn cache_control_ephemeral_shape() {
+        let v = serde_json::to_value(CacheControl::ephemeral()).expect("serialise");
+        assert_eq!(v, json!({"type": "ephemeral"}));
+    }
+
+    /// Why: a typo would silently disable detailed usage accounting.
+    /// Test: itself.
+    #[test]
+    fn request_usage_detailed_shape() {
+        let v = serde_json::to_value(RequestUsageConfig::detailed()).expect("serialise");
+        assert_eq!(v, json!({"include": true}));
+    }
+}

--- a/crates/trusty-common/src/inference/types/usage.rs
+++ b/crates/trusty-common/src/inference/types/usage.rs
@@ -1,0 +1,256 @@
+//! Token-usage + cost accounting types (issue #2402, epic #2400 Wave 1).
+//!
+//! Why: every inference consumer needs one canonical shape for "how many
+//! tokens did this call cost, and what did it cost in dollars" — the tcode
+//! agent loop, trusty-review's cost ranking, and tga's SM accounting each grew
+//! their own. This is the single [`Usage`] the [`super::ChatResponse`] carries,
+//! modelled to absorb both wire shapes tcode already parses (Anthropic-native
+//! flat cache fields AND OpenRouter's nested `prompt_tokens_details`) so #2406
+//! can migrate its `UsageBlock`→`TokenUsage` mapping here without behaviour
+//! change.
+//! What: [`Usage`] is the normalized in-memory value; [`UsageBlock`] is the
+//! wire representation with [`UsageBlock::into_usage`] merging whichever cache
+//! shape the provider populated. [`PromptTokensDetails`] is OpenRouter's nested
+//! cache-accounting object.
+//! Test: inline `tests` — `usage_block_maps_flat_fields`,
+//! `usage_block_maps_openrouter_details`, `usage_block_prefers_authoritative_cost`,
+//! `default_usage_block_is_zero`, `usage_total_tokens`.
+
+use serde::{Deserialize, Serialize};
+
+/// Normalized token + cost accounting for a single inference call.
+///
+/// Why: cost/telemetry code must not care whether the provider reported cache
+/// tokens as flat Anthropic-native fields or OpenRouter's nested object — it
+/// consumes this one shape. `cost_usd` carries the provider's authoritative,
+/// already-cache-discounted price when available so callers prefer it over a
+/// static per-token recompute.
+/// What: four token buckets plus an optional dollar cost. `cost_usd` is `None`
+/// when the provider does not report an authoritative figure (the caller may
+/// then estimate from [`super::super::registry::pricing`]).
+/// Test: `usage_total_tokens`, and every `UsageBlock` mapping test.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct Usage {
+    /// Prompt (input) tokens billed, including any cached-read tokens.
+    pub prompt_tokens: u32,
+    /// Completion (output) tokens produced.
+    pub completion_tokens: u32,
+    /// Prompt tokens served from the provider's prompt cache (billed at the
+    /// discounted cache-read rate).
+    pub cache_read_tokens: u32,
+    /// Prompt tokens newly written into the prompt cache this turn (billed at
+    /// the cache-write rate).
+    pub cache_creation_tokens: u32,
+    /// Provider-authoritative total USD cost for this call, already netting any
+    /// cache discount. `None` when the provider does not report it.
+    pub cost_usd: Option<f64>,
+}
+
+impl Usage {
+    /// Construct a [`Usage`] from the four token buckets, leaving `cost_usd`
+    /// unset.
+    ///
+    /// Why: the common construction path (a provider that reports token counts
+    /// but no authoritative dollar cost) should not have to spell out `cost_usd:
+    /// None` at every call site.
+    /// What: sets the four token fields; `cost_usd` defaults to `None`.
+    /// Test: `usage_total_tokens`.
+    pub fn new(
+        prompt_tokens: u32,
+        completion_tokens: u32,
+        cache_read_tokens: u32,
+        cache_creation_tokens: u32,
+    ) -> Self {
+        Self {
+            prompt_tokens,
+            completion_tokens,
+            cache_read_tokens,
+            cache_creation_tokens,
+            cost_usd: None,
+        }
+    }
+
+    /// Total tokens (prompt + completion) for this call.
+    ///
+    /// Why: rate-limit and context-budget code wants a single billed-token
+    /// figure; cache buckets are already included in `prompt_tokens` so they
+    /// are not re-added here.
+    /// What: `prompt_tokens + completion_tokens` (saturating, to never panic on
+    /// an adversarial provider response).
+    /// Test: `usage_total_tokens`.
+    pub fn total_tokens(&self) -> u32 {
+        self.prompt_tokens.saturating_add(self.completion_tokens)
+    }
+}
+
+/// OpenRouter-shaped nested cache-accounting object.
+///
+/// Why: OpenRouter's usage-accounting normalisation nests cache counters under
+/// `prompt_tokens_details` using OpenAI-style names (`cached_tokens`,
+/// `cache_write_tokens`) rather than the Anthropic-native flat fields. Without
+/// parsing this shape, cache accounting silently reports zero on every
+/// OpenRouter call.
+/// What: carries the two cache counters OpenRouter reports; `audio_tokens` is
+/// deliberately not modelled (irrelevant to text inference).
+/// Test: `usage_block_maps_openrouter_details`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct PromptTokensDetails {
+    /// Prompt tokens served from cache (OpenAI name for Anthropic's
+    /// `cache_read_input_tokens`).
+    #[serde(default)]
+    pub cached_tokens: u32,
+    /// Prompt tokens newly written to cache (OpenAI name for Anthropic's
+    /// `cache_creation_input_tokens`).
+    #[serde(default)]
+    pub cache_write_tokens: u32,
+}
+
+/// Wire-shape token-usage block from a chat-completions response.
+///
+/// Why: the wire `usage` object comes in two shapes (Anthropic-native flat
+/// fields on the direct/Bedrock path, OpenRouter's nested `prompt_tokens_details`
+/// on the OpenRouter path). Deserialising into this intermediate struct — which
+/// accepts BOTH — then mapping to [`Usage`] keeps the provider-shape knowledge
+/// in one place.
+/// What: carries prompt/completion/total counts, the optional Anthropic-native
+/// flat cache fields, the optional OpenRouter nested object, and the optional
+/// authoritative `cost`.
+/// Test: `usage_block_maps_flat_fields`, `usage_block_maps_openrouter_details`,
+/// `usage_block_prefers_authoritative_cost`, `default_usage_block_is_zero`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UsageBlock {
+    /// Prompt tokens (including cached tokens).
+    #[serde(default)]
+    pub prompt_tokens: u32,
+    /// Completion tokens produced.
+    #[serde(default)]
+    pub completion_tokens: u32,
+    /// Prompt + completion; informational only.
+    #[serde(default)]
+    pub total_tokens: u32,
+    /// Anthropic-native (direct/Bedrock path): prompt tokens served from cache.
+    #[serde(default)]
+    pub cache_read_input_tokens: u32,
+    /// Anthropic-native (direct/Bedrock path): prompt tokens written to cache.
+    #[serde(default)]
+    pub cache_creation_input_tokens: u32,
+    /// OpenRouter-shaped nested cache counters. `None` when the provider
+    /// reports the flat fields instead (or omits cache accounting entirely).
+    #[serde(default)]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
+    /// Provider-authoritative total USD cost, already netting any cache
+    /// discount. `None` for providers that do not report it.
+    #[serde(default)]
+    pub cost: Option<f64>,
+}
+
+impl UsageBlock {
+    /// Convert this wire block into the normalized [`Usage`].
+    ///
+    /// Why: callers speak [`Usage`]; this centralises the wire-field mapping and
+    /// merges whichever of the two cache shapes the provider populated so no
+    /// call site needs to know the wire field names.
+    /// What: `cache_read_tokens` is the flat `cache_read_input_tokens` when
+    /// non-zero, else `prompt_tokens_details.cached_tokens`; `cache_creation_tokens`
+    /// follows the same fallback. `cost_usd` carries `self.cost` verbatim.
+    /// Test: `usage_block_maps_flat_fields`, `usage_block_maps_openrouter_details`,
+    /// `usage_block_prefers_authoritative_cost`.
+    pub fn into_usage(self) -> Usage {
+        let (details_read, details_write) = self
+            .prompt_tokens_details
+            .map(|d| (d.cached_tokens, d.cache_write_tokens))
+            .unwrap_or((0, 0));
+
+        let cache_read = if self.cache_read_input_tokens != 0 {
+            self.cache_read_input_tokens
+        } else {
+            details_read
+        };
+        let cache_creation = if self.cache_creation_input_tokens != 0 {
+            self.cache_creation_input_tokens
+        } else {
+            details_write
+        };
+
+        let mut usage = Usage::new(
+            self.prompt_tokens,
+            self.completion_tokens,
+            cache_read,
+            cache_creation,
+        );
+        usage.cost_usd = self.cost;
+        usage
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: `total_tokens` is what budget code sums; verify cache buckets are
+    /// not double-counted.
+    /// Test: itself.
+    #[test]
+    fn usage_total_tokens() {
+        let u = Usage::new(100, 50, 20, 10);
+        assert_eq!(u.total_tokens(), 150);
+        assert_eq!(u.cost_usd, None);
+    }
+
+    /// Why: the Anthropic-native flat shape must map through unchanged.
+    /// Test: itself.
+    #[test]
+    fn usage_block_maps_flat_fields() {
+        let block = UsageBlock {
+            prompt_tokens: 100,
+            completion_tokens: 50,
+            total_tokens: 150,
+            cache_read_input_tokens: 20,
+            cache_creation_input_tokens: 10,
+            prompt_tokens_details: None,
+            cost: None,
+        };
+        let u = block.into_usage();
+        assert_eq!(u.prompt_tokens, 100);
+        assert_eq!(u.completion_tokens, 50);
+        assert_eq!(u.cache_read_tokens, 20);
+        assert_eq!(u.cache_creation_tokens, 10);
+    }
+
+    /// Why: the OpenRouter nested shape (no flat fields) must still populate the
+    /// cache buckets — the exact gap that made cache accounting report zero.
+    /// Test: itself.
+    #[test]
+    fn usage_block_maps_openrouter_details() {
+        let fixture = r#"{
+          "prompt_tokens": 1200,
+          "completion_tokens": 80,
+          "total_tokens": 1280,
+          "prompt_tokens_details": {"cached_tokens": 900, "cache_write_tokens": 300}
+        }"#;
+        let block: UsageBlock = serde_json::from_str(fixture).expect("deserialise");
+        let u = block.into_usage();
+        assert_eq!(u.cache_read_tokens, 900);
+        assert_eq!(u.cache_creation_tokens, 300);
+    }
+
+    /// Why: the provider's authoritative `cost` must be carried through verbatim.
+    /// Test: itself.
+    #[test]
+    fn usage_block_prefers_authoritative_cost() {
+        let fixture = r#"{"prompt_tokens": 10, "completion_tokens": 2, "cost": 0.001234}"#;
+        let block: UsageBlock = serde_json::from_str(fixture).expect("deserialise");
+        assert_eq!(block.into_usage().cost_usd, Some(0.001234));
+    }
+
+    /// Why: a missing `usage` object must not panic and must produce zeros.
+    /// Test: itself.
+    #[test]
+    fn default_usage_block_is_zero() {
+        let u = UsageBlock::default().into_usage();
+        assert_eq!(u.total_tokens(), 0);
+        assert_eq!(u.cost_usd, None);
+    }
+}

--- a/crates/trusty-common/tests/inference_foundation.rs
+++ b/crates/trusty-common/tests/inference_foundation.rs
@@ -1,0 +1,259 @@
+//! Integration coverage for the inference foundation (issue #2402, epic #2400).
+//!
+//! Why: the unit tests inside each submodule cover the pieces; this suite
+//! exercises the PUBLIC surface exactly as a consumer will use it — the
+//! capability registry queries, type serde round-trips, credential-resolution
+//! wiring through an injected store, the two-stage `provider_for` resolver, and
+//! the full `Configurator → ScriptedAdapter → chat → usage` cycle across the
+//! `InferenceAdapter` trait object. This is where #2403's live-provider e2e will
+//! attach: swap `ScriptedAdapter` for a real HTTP adapter pointed at
+//! `test_support::MockInferenceServer` (see `mock_http_server_serves_response`).
+//! What: black-box tests against `trusty_common::inference::*`.
+//! Test: this file (run with `--features inference-client`).
+
+use serial_test::serial;
+use trusty_common::inference::credentials::{KeyStore, MemoryKeyStore};
+use trusty_common::inference::test_support::ScriptedAdapter;
+use trusty_common::inference::{
+    ChatMessage, ChatRequest, ChatResponse, Configurator, InferenceAdapter, InferenceError,
+    ProviderId, ResolvedProvider, ToolChoice, capabilities, capabilities_for, context_window,
+    openai_tool_choice, pricing, provider_for,
+};
+
+/// Clear every provider env var so the store tier of the resolver is what tests
+/// actually exercise (a stray `OPENROUTER_API_KEY` in the CI env would otherwise
+/// shadow the injected `MemoryKeyStore`).
+fn clear_provider_env() {
+    for var in [
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "FIREWORKS_API_KEY",
+    ] {
+        // SAFETY: every caller is `#[serial(dotenv_credential_env)]`, matching
+        // the lock the credential resolver's own env-mutating tests use.
+        unsafe { std::env::remove_var(var) };
+    }
+}
+
+// ── Capability registry ────────────────────────────────────────────────────────
+
+/// Why: each of the five seeded providers must be queryable by id and by name
+/// and expose a coherent capability descriptor.
+#[test]
+fn registry_seeds_all_five_providers() {
+    let expected = [
+        (ProviderId::OpenRouter, "openrouter", true),
+        (ProviderId::Fireworks, "fireworks", true),
+        (ProviderId::Bedrock, "bedrock", false), // no API-key env (AWS chain)
+        (ProviderId::Anthropic, "anthropic", true),
+        (ProviderId::OpenAI, "openai", true),
+    ];
+    for (id, name, has_key_env) in expected {
+        let by_id = capabilities(id);
+        let by_name = capabilities_for(name).expect("known provider by name");
+        assert_eq!(by_id.id, id);
+        assert_eq!(by_name.id, id);
+        assert_eq!(by_id.credential_env.is_some(), has_key_env);
+        assert!(by_id.native_tool_calling, "{name} should support tools");
+    }
+    assert!(capabilities_for("cohere").is_none());
+}
+
+/// Why: the #2330 fix must be reachable through the public `context_window`
+/// query — haiku resolves to its real 200K window, not the 128K default.
+#[test]
+fn context_window_fixes_haiku_gap_2330() {
+    assert_eq!(context_window("anthropic/claude-haiku-4-5", None), 200_000);
+    assert_eq!(context_window("openai/gpt-4o-mini", None), 128_000);
+    // Provider default tier: an unlisted model on Fireworks gets its 128K max.
+    let fw = capabilities(ProviderId::Fireworks);
+    assert_eq!(context_window("fireworks/new-model", Some(fw)), 128_000);
+}
+
+/// Why: pricing must resolve for the seeded families and be `None` for unknowns.
+#[test]
+fn pricing_resolves_known_families() {
+    assert_eq!(
+        pricing("anthropic/claude-sonnet-4-5").map(|p| p.input),
+        Some(3.0)
+    );
+    assert_eq!(
+        pricing("openai/gpt-5.4-nano-20260317").map(|p| p.input),
+        Some(0.20)
+    );
+    assert!(pricing("cohere/command-r").is_none());
+}
+
+// ── Type round-trips ───────────────────────────────────────────────────────────
+
+/// Why: the request/response wire types must round-trip through JSON so a
+/// migrating consumer (#2406) can serialise a request and parse a response
+/// without a shape change.
+#[test]
+fn request_and_response_round_trip() {
+    let mut req = ChatRequest::new(
+        "anthropic/claude-sonnet-4-5",
+        vec![ChatMessage::system("be terse"), ChatMessage::user("hi")],
+    );
+    req.temperature = Some(0.2);
+    req.tool_choice = Some(openai_tool_choice(ToolChoice::Auto));
+    let wire = serde_json::to_string(&req).expect("serialise request");
+    let back: ChatRequest = serde_json::from_str(&wire).expect("deserialise request");
+    assert_eq!(back.model, "anthropic/claude-sonnet-4-5");
+    assert_eq!(back.messages.len(), 2);
+    assert_eq!(back.tool_choice, Some(serde_json::json!("auto")));
+
+    let resp: ChatResponse = serde_json::from_str(
+        r#"{"id":"g","model":"served/x",
+             "choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+             "usage":{"prompt_tokens":5,"completion_tokens":2,"cost":0.01}}"#,
+    )
+    .expect("deserialise response");
+    assert_eq!(resp.first_text().as_deref(), Some("ok"));
+    assert_eq!(resp.usage().cost_usd, Some(0.01));
+    assert_eq!(resp.resolved_model("asked/x"), "served/x");
+}
+
+// ── Credential resolution + two-stage resolver ──────────────────────────────────
+
+/// Why: `provider_for` must resolve a fake key through the injected store,
+/// honour the explicit-prefix→family rule, and fall back to OpenRouter.
+#[test]
+#[serial(dotenv_credential_env)]
+fn provider_for_two_stage_resolution() {
+    clear_provider_env();
+
+    // Explicit family whose key is present → that family.
+    let store = MemoryKeyStore::new();
+    store.set("anthropic", "sk-ant-key").unwrap(); // pragma: allowlist secret
+    let r = provider_for("anthropic/claude-sonnet-4-5", &store).expect("resolves");
+    assert_eq!(r.provider(), ProviderId::Anthropic);
+    assert_eq!(r.key().map(|k| k.expose()), Some("sk-ant-key"));
+
+    // Explicit family whose key is ABSENT → OpenRouter fallback.
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-key").unwrap(); // pragma: allowlist secret
+    let r = provider_for("anthropic/claude-sonnet-4-5", &store).expect("resolves");
+    assert_eq!(r.provider(), ProviderId::OpenRouter);
+
+    // Bedrock resolves with no key (AWS chain).
+    let r = provider_for(
+        "bedrock/us.anthropic.claude-sonnet-4-5",
+        &MemoryKeyStore::new(),
+    )
+    .expect("resolves");
+    assert_eq!(r.provider(), ProviderId::Bedrock);
+    assert!(r.key().is_none());
+
+    // Nothing anywhere → MissingCredential alarm.
+    let err = provider_for("openai/gpt-4o-mini", &MemoryKeyStore::new()).expect_err("errors");
+    assert!(err.is_alarm());
+}
+
+/// Why: a resolved key must never leak through `Debug` — the redacting
+/// `SecretString` guards the whole `ResolvedProvider`.
+#[test]
+#[serial(dotenv_credential_env)]
+fn resolved_provider_debug_is_redacted() {
+    clear_provider_env();
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-verysecret-abc").unwrap(); // pragma: allowlist secret
+    let r = provider_for("x/y", &store).expect("resolves");
+    let dumped = format!("{r:?}");
+    assert!(
+        !dumped.contains("verysecret"),
+        "key leaked in Debug: {dumped}"
+    );
+}
+
+// ── Configurator → adapter → chat → usage cycle ─────────────────────────────────
+
+/// Why: the whole seam must work end-to-end — resolve a slug, build the
+/// (scripted) adapter, drive it through the `InferenceAdapter` trait object, and
+/// read back a normalized `Usage`. This is the cycle #2403's real adapters slot
+/// into unchanged.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn configurator_builds_and_runs_scripted_adapter() {
+    clear_provider_env();
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-key").unwrap(); // pragma: allowlist secret
+
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::OpenRouter,
+        Box::new(|resolved: &ResolvedProvider| {
+            let caps = capabilities(resolved.provider());
+            Ok(Box::new(ScriptedAdapter::echo("openrouter", caps)) as Box<dyn InferenceAdapter>)
+        }),
+    );
+
+    let adapter: Box<dyn InferenceAdapter> = cfg
+        .build("openai/gpt-4o-mini", &store)
+        .expect("built adapter");
+    assert_eq!(adapter.name(), "openrouter");
+    assert!(adapter.supports_native_tools());
+    assert_eq!(
+        adapter.context_window("anthropic/claude-haiku-4-5"),
+        200_000
+    );
+
+    let req = ChatRequest::new(
+        "openai/gpt-4o-mini",
+        vec![ChatMessage::user("round trip please")],
+    );
+    let resp = adapter.chat(&req).await.expect("chat ok");
+    assert_eq!(resp.first_text().as_deref(), Some("round trip please"));
+    assert!(resp.usage().total_tokens() > 0);
+}
+
+/// Why: building against a provider with no registered factory must be an
+/// explicit alarm, never a silent fallback.
+#[test]
+#[serial(dotenv_credential_env)]
+fn configurator_unregistered_provider_alarms() {
+    clear_provider_env();
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-key").unwrap(); // pragma: allowlist secret
+    let cfg = Configurator::new();
+    // `Box<dyn InferenceAdapter>` is not `Debug`; match the error out.
+    let Err(err) = cfg.build("x/y", &store) else {
+        panic!("expected NoAdapterRegistered");
+    };
+    assert!(matches!(err, InferenceError::NoAdapterRegistered { .. }));
+    assert!(err.is_alarm());
+}
+
+// ── axum HTTP mock (where #2403's live-provider e2e attaches) ────────────────────
+
+/// Why: the future concrete adapters need a real socket to test against; this
+/// proves the `axum-server`-gated mock serves the canned chat/completions body
+/// #2403 will parse. Only compiled when `axum-server` is enabled (e.g.
+/// `--all-features`).
+#[cfg(feature = "axum-server")]
+#[tokio::test]
+async fn mock_http_server_serves_response() {
+    use trusty_common::inference::test_support::MockInferenceServer;
+
+    let body = serde_json::json!({
+        "id": "gen-mock",
+        "choices": [{"message": {"role": "assistant", "content": "from mock"},
+                     "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2}
+    });
+    let server = MockInferenceServer::spawn(200, body)
+        .await
+        .expect("spawn mock");
+    let raw = reqwest::Client::new()
+        .post(format!("{}/v1/chat/completions", server.url()))
+        .send()
+        .await
+        .expect("send")
+        .text()
+        .await
+        .expect("body");
+    // The body a real adapter would deserialise straight into ChatResponse.
+    let resp: ChatResponse = serde_json::from_str(&raw).expect("parse as ChatResponse");
+    assert_eq!(resp.first_text().as_deref(), Some("from mock"));
+}


### PR DESCRIPTION
## Summary

Wave-1 slice 2 of the inference-adapter epic (#2400), building directly on the #2401 credential resolver (merged `98d0eb99`). Everything lands behind a new `inference-client` cargo feature (composing with `credentials`, **zero new dependencies** — `async-trait`/`serde`/`serde_json`/`thiserror` are already present).

## What's in it

**`types/` — normalized request/response model**
- `ChatMessage` (system/user/assistant/tool roles + the `cache_control` content-block serialisation from tcode #2156), tool definitions/calls + a neutral `ToolChoice` with an OpenAI-dialect mapper, `ChatRequest`, `ChatResponse` (+ a typed `StopReason`), and `Usage` (prompt/completion/cache-read/cache-write token buckets + `cost_usd`) that absorbs **both** wire cache shapes (Anthropic-native flat fields AND OpenRouter's nested `prompt_tokens_details`).
- `SecretString`: a redacting credential wrapper (`Debug`/`Display` via the #2401 `redact_secret`; no `Serialize`; raw value only via explicit `expose()`) — addresses the Debug-leak class slice 1 caught.
- Modelled to cover what tcode's OpenRouter + Bedrock clients already emit so **#2406 migrates without a wire-format change**.

**`error.rs` — `InferenceError`** with `is_retryable()` / `is_alarm()` classifiers (transport/5xx/429 → retryable; missing-credential/no-adapter/unsupported/401/403/404 → alarm).

**`adapter.rs` — the `InferenceAdapter` trait**
```rust
#[async_trait]
pub trait InferenceAdapter: Send + Sync {
    fn name(&self) -> &str;
    fn capabilities(&self) -> &ProviderCapabilities;
    async fn chat(&self, request: &ChatRequest) -> Result<ChatResponse, InferenceError>;
    fn map_tool_choice(&self, choice: ToolChoice) -> serde_json::Value { /* OpenAI default */ }
    fn supports_native_tools(&self) -> bool   { /* from capabilities */ }
    fn supports_prompt_caching(&self) -> bool  { /* from capabilities */ }
    fn supports_structured_output(&self) -> bool { /* from capabilities */ }
    fn wants_detailed_usage(&self) -> bool     { /* from capabilities */ }
    fn context_window(&self, model: &str) -> usize { /* registry, incl. #2330 */ }
}
```
Object-safe / boxable (`Box<dyn InferenceAdapter>`). Unions tcode's `LlmClientTrait` + `Provider` and trusty-review's `supports_structured_output`.

**`registry/` — capability registry** seeded for all five epic providers (OpenRouter, Fireworks, Bedrock, Anthropic-direct, OpenAI-direct): native-tool + `ToolDialect`, streaming, prompt caching, structured output, vision, detailed-usage opt-in, default/max context window, default model, credential env. Queryable by `ProviderId` and by name.
- `context_window()` **closes #2330** — `claude-haiku-*` now resolves to its real 200K window instead of the 128K default (regression-guarded).
- `pricing()` seeds Claude rates (from tcode `perf::pricing`) + GPT-5/Gemini rates (from trusty-review `llm::openrouter`).

**`configurator/` — construction seam**
- `provider_for(slug, &KeyStore)`: the two-stage resolver — explicit prefix (`bedrock/`|`fireworks/`|`anthropic/`|`openai/`|`openrouter/`) → family **gated by key presence** → OpenRouter default; resolves credentials via the #2401 chain (env > `.env.local` > store). Returns a redacting `ResolvedProvider` (Bedrock resolves with no key → AWS chain).
- `Configurator`: a `ProviderId → AdapterFactory` registry; `build()` resolves then dispatches to the registered factory. Exercised end-to-end against the test-only `ScriptedAdapter`.

**`test_support/`**
- `ScriptedAdapter` (echo + scripted-queue double) — always available with `inference-client`; the only `InferenceAdapter` impl this ticket ships.
- `MockInferenceServer` (real loopback axum HTTP mock) — gated behind `axum-server`, so the base feature pulls **no** HTTP-server dependency.

## Explicitly deferred
- Concrete OpenRouter/Fireworks/Bedrock HTTP adapters → **#2403 / #2407**. They register real factories into this `Configurator` and slot into the same resolve→build→chat→usage cycle the integration suite already drives.
- Consumer migration (tcode/review/agents/mpm/tga) → **#2406**.
- The universal `config` clap module → Wave 2.

## Where #2403's live-provider e2e attaches
`tests/inference_foundation.rs::mock_http_server_serves_response` already stands up `MockInferenceServer` and parses its body straight into `ChatResponse`; #2403 swaps `ScriptedAdapter` for a real HTTP adapter pointed at that URL.

## Verification
`cargo test -p trusty-common --features inference-client` (215 lib + 8 integration) and `--features inference-client,axum-server` (9 integration incl. the axum mock) pass; workspace build + `cargo clippy --workspace --all-targets -D warnings` + `cargo fmt --check` + `bash scripts/check_line_cap.sh` all green. (One unrelated pre-existing flake in `trusty-console`'s connection-retry proxy test passes on isolated re-run.)

Closes #2402
Refs #2400, #2330

🤖 Generated with [Claude Code](https://claude.com/claude-code)