### PR TITLE
feat(trusty-mpm): PATCH /api/v1/projects/{name} — registry-B field-level config update

### DIFF
--- a/crates/trusty-mpm/src/client/http_client/projects.rs
+++ b/crates/trusty-mpm/src/client/http_client/projects.rs
@@ -95,10 +95,12 @@ pub struct PatchProjectArgs {
     /// validation is deferred to #2121).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gh_user: Option<Option<String>>,
-    /// Tags to add, deduplicated server-side against the current set.
+    /// Tags to add, deduplicated server-side against the current set. A
+    /// blank/whitespace-only entry rejects the whole PATCH with 400.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags_add: Option<Vec<String>>,
-    /// Tags to remove; applied AFTER `tags_add` server-side.
+    /// Tags to remove; applied AFTER `tags_add` server-side. Same
+    /// blank-rejection rule as `tags_add`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags_remove: Option<Vec<String>>,
 }

--- a/crates/trusty-mpm/src/client/http_client/projects.rs
+++ b/crates/trusty-mpm/src/client/http_client/projects.rs
@@ -1,22 +1,24 @@
-//! Registry-B project methods for [`DaemonClient`] (DOC-35 §3.1/§4, #2115).
+//! Registry-B project methods for [`DaemonClient`] (DOC-35 §3.1/§4/§6, #2115/#2114).
 //!
-//! Why: the `tm projects list/register/show/status` CLI verbs are thin HTTP
-//! clients (DOC-35 §1.3). Wiring each endpoint once here — as typed
+//! Why: the `tm projects list/register/show/status/config` CLI verbs are thin
+//! HTTP clients (DOC-35 §1.3). Wiring each endpoint once here — as typed
 //! [`DaemonClient`] methods — keeps every consumer (the CLI today, the TUI next)
 //! off hand-rolled `reqwest` calls, exactly as the managed-session methods in the
 //! sibling `managed.rs` do. This file lives beside `mod.rs` (not in it) so the
 //! near-cap client `mod.rs` stays under the 500-SLOC bar; it reaches the
 //! `base`/`http` fields because they are `pub(in crate::client::http_client)`.
 //! What: the registry-B response DTOs the client owns ([`ProjectStatusWire`] and
-//! its parts, plus [`RegisterProjectArgs`] for the POST body) and four methods:
-//! [`DaemonClient::registry_list_projects`], [`DaemonClient::registry_register_project`],
-//! [`DaemonClient::registry_get_project`], and [`DaemonClient::project_status`].
+//! its parts, plus [`RegisterProjectArgs`]/[`PatchProjectArgs`] for the
+//! POST/PATCH bodies) and five methods: [`DaemonClient::registry_list_projects`],
+//! [`DaemonClient::registry_register_project`], [`DaemonClient::registry_get_project`],
+//! [`DaemonClient::registry_patch_project`], and [`DaemonClient::project_status`].
 //! The status DTO deliberately does NOT `deny_unknown_fields` so the additive
 //! Deliverable/Milestone histogram fields #2382 adds to the endpoint deserialize
 //! cleanly against an older client (wire-compat, forward-tolerant).
 //! Test: `project_status_wire_tolerates_additive_fields`,
-//! `register_args_serializes_to_wire_shape`, `projects_list_deserializes` in the
-//! `tests` submodule; live HTTP via the daemon's own route tests.
+//! `register_args_serializes_to_wire_shape`,
+//! `patch_args_serializes_double_option_semantics`, `projects_list_deserializes`
+//! in the `tests` submodule; live HTTP via the daemon's own route tests.
 
 use anyhow::Context;
 use chrono::{DateTime, Utc};
@@ -53,6 +55,52 @@ pub struct RegisterProjectArgs {
     /// Preferred `gh` login (#2081).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gh_user: Option<String>,
+}
+
+/// Serializable body for `PATCH /api/v1/projects/{name}` (registry-B partial
+/// update, #2114, DOC-35 §6).
+///
+/// Why: `tm projects config <name> set/unset` and the TUI config form (#2120)
+/// build this from their flags; mirrors the daemon's `PatchProjectBody` wire
+/// shape exactly, including the double-`Option` unset story for
+/// `description`/`stack_hint`/`gh_user` and the `tags_add`/`tags_remove`
+/// add/remove pair (§6: "no free-text replace-whole-list footgun" — there is
+/// deliberately no plain `tags` replacement field).
+/// What: every field optional and omitted from the JSON when the OUTER
+/// `Option` is `None` (`skip_serializing_if`); for the three double-`Option`
+/// fields, `Some(None)` serializes as JSON `null` (serde's stock `Option<T>`
+/// `Serialize` impl already does this — no custom serializer is needed on the
+/// SEND side, only on the daemon's receive side), clearing the field, while
+/// `Some(Some(v))` serializes as the value. `name` is intentionally NOT a
+/// field here: the identity key is always the `{name}` path segment
+/// [`DaemonClient::registry_patch_project`] takes separately, so this DTO's
+/// shape cannot even express the (always-rejected) name-change attempt.
+/// Test: `patch_args_serializes_double_option_semantics`,
+/// `patch_args_omits_absent_fields`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct PatchProjectArgs {
+    /// New repository URL, if changing (rejected by the daemon when blank).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_url: Option<String>,
+    /// New default branch, if changing (rejected by the daemon when blank).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_branch: Option<String>,
+    /// `None` = unchanged; `Some(None)` = clear; `Some(Some(v))` = set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<Option<String>>,
+    /// Same three-state semantics as `description`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stack_hint: Option<Option<String>>,
+    /// Same three-state semantics as `description` (#2081; `gh auth status`
+    /// validation is deferred to #2121).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gh_user: Option<Option<String>>,
+    /// Tags to add, deduplicated server-side against the current set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags_add: Option<Vec<String>>,
+    /// Tags to remove; applied AFTER `tags_add` server-side.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags_remove: Option<Vec<String>>,
 }
 
 /// Per-state session histogram (client mirror of the daemon `SessionStateCounts`).
@@ -203,6 +251,37 @@ impl DaemonClient {
         Ok(project)
     }
 
+    /// Partially update a project via `PATCH /api/v1/projects/{name}`.
+    ///
+    /// Why: backs `tm projects config <name> set/unset` and the TUI config form
+    /// (#2120) — both are thin clients over the daemon's single PATCH
+    /// implementation (§6). See [`PatchProjectArgs`] for the field-by-field
+    /// unset/tags contract.
+    /// What: PATCHes `args` to the named project, returns the updated
+    /// [`Project`]; a 404 (unknown project) or 400 (blank required field, or a
+    /// body that tried to change `name`) surfaces as an error via
+    /// `error_for_status`.
+    /// Test: live HTTP via the daemon route tests
+    /// (`tests/project_registry_routes.rs`).
+    pub async fn registry_patch_project(
+        &self,
+        name: &str,
+        args: &PatchProjectArgs,
+    ) -> anyhow::Result<Project> {
+        let url = format!("{}/api/v1/projects/{name}", self.base);
+        let project: Project = self
+            .http
+            .patch(&url)
+            .json(args)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("deserialize patched project")?;
+        Ok(project)
+    }
+
     /// Fetch the deterministic status rollup via `GET .../{name}/status`.
     ///
     /// Why: backs `tm projects status` (#2115). The [`ProjectStatusWire`] target is
@@ -305,5 +384,47 @@ mod tests {
         let body: ProjectsListWire = serde_json::from_value(json).unwrap();
         assert_eq!(body.projects.len(), 1);
         assert_eq!(body.projects[0].name, "widget");
+    }
+
+    /// `Some(None)` (clear) serializes as JSON `null`; `Some(Some(v))` (set)
+    /// serializes as the value — the double-`Option` unset story the daemon's
+    /// `deserialize_double_option` expects on the receiving end.
+    #[test]
+    fn patch_args_serializes_double_option_semantics() {
+        let args = PatchProjectArgs {
+            description: Some(None),
+            stack_hint: Some(Some("rust".into())),
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&args).unwrap();
+        assert!(v["description"].is_null(), "{v}");
+        assert_eq!(v["stack_hint"], "rust");
+    }
+
+    /// Every field defaults to `None` (outer), so a default `PatchProjectArgs`
+    /// serializes to an empty object — a true "change nothing" PATCH body.
+    #[test]
+    fn patch_args_omits_absent_fields() {
+        let args = PatchProjectArgs::default();
+        let v = serde_json::to_value(&args).unwrap();
+        assert_eq!(v, serde_json::json!({}));
+    }
+
+    /// `tags_add`/`tags_remove` and the two required-string fields serialize
+    /// plainly when present.
+    #[test]
+    fn patch_args_serializes_tags_and_required_fields() {
+        let args = PatchProjectArgs {
+            repo_url: Some("https://github.com/acme/widget2".into()),
+            default_branch: Some("release".into()),
+            tags_add: Some(vec!["ml".into()]),
+            tags_remove: Some(vec!["oss".into()]),
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&args).unwrap();
+        assert_eq!(v["repo_url"], "https://github.com/acme/widget2");
+        assert_eq!(v["default_branch"], "release");
+        assert_eq!(v["tags_add"][0], "ml");
+        assert_eq!(v["tags_remove"][0], "oss");
     }
 }

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -136,10 +136,11 @@ use super::managed_routes::{
     adopt_existing_session, answer_session_decision, decommission_ephemeral_route,
     decommission_managed_session, delete_managed_session, fleet_by_project_route, get_attach_cmd,
     get_managed_session, get_project_registry_route, get_session_activity, list_managed_sessions,
-    list_projects_registry_route, project_status_route, proxy_focus, proxy_get_focus,
-    proxy_message, proxy_summary, proxy_unfocus, prune_managed_route, prune_worktrees_route,
-    reactivate_managed_session, register_project_registry_route, resume_managed_session,
-    send_to_session, spawn_session, stop_managed_session, stop_managed_session_runtime,
+    list_projects_registry_route, patch_project_registry_route, project_status_route, proxy_focus,
+    proxy_get_focus, proxy_message, proxy_summary, proxy_unfocus, prune_managed_route,
+    prune_worktrees_route, reactivate_managed_session, register_project_registry_route,
+    resume_managed_session, send_to_session, spawn_session, stop_managed_session,
+    stop_managed_session_runtime,
 };
 
 /// Typed HTTP response bodies for every endpoint.
@@ -176,16 +177,20 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         .route("/projects/current", get(current_project))
         .route("/projects/discover", get(discover_projects))
         // #2114 (DOC-35 §4): registry-B project HTTP surface — the plain-HTTP
-        // list/register/get the deterministic `tm projects` CLI (#2115) calls,
-        // mirroring the `project_list`/`project_register`/`project_get` MCP tools.
-        // The bare `/api/v1/projects` collection route is registered here; the
-        // `{name}` point-lookup sits below the more specific `/status` and
+        // list/register/get/patch the deterministic `tm projects` CLI (#2115)
+        // and `tm projects config` field editor (#2120) call, mirroring the
+        // `project_list`/`project_register`/`project_get` MCP tools. The bare
+        // `/api/v1/projects` collection route is registered here; the `{name}`
+        // point-lookup/PATCH sits below the more specific `/status` and
         // `/deliverables` param routes (matchit disambiguates by segment count).
         .route(
             "/api/v1/projects",
             get(list_projects_registry_route).post(register_project_registry_route),
         )
-        .route("/api/v1/projects/{name}", get(get_project_registry_route))
+        .route(
+            "/api/v1/projects/{name}",
+            get(get_project_registry_route).patch(patch_project_registry_route),
+        )
         // #2117 (DOC-35 §4.1): deterministic project status-aggregation rollup —
         // session-state histogram + most-recent activity + config-completeness
         // flags for ONE named project. Pure composition over ProjectRegistry::get

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -49,8 +49,8 @@ pub use lifecycle::{
     spawn_runtime_for, write_task_md,
 };
 pub use project_registry_routes::{
-    ProjectsListResponse, RegisterProjectBody, get_project_registry_route,
-    list_projects_registry_route, register_project_registry_route,
+    PatchProjectBody, ProjectsListResponse, RegisterProjectBody, get_project_registry_route,
+    list_projects_registry_route, patch_project_registry_route, register_project_registry_route,
 };
 pub use project_status::{
     DeliverableStatusCounts, MilestoneStatusCounts, ProjectConfigFlags, ProjectStatusResponse,

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
@@ -269,11 +269,14 @@ pub struct PatchProjectBody {
     /// #2121 — this endpoint accepts and stores the string as-is.
     #[serde(default, deserialize_with = "deserialize_double_option")]
     pub gh_user: Option<Option<String>>,
-    /// Tags to add, deduplicated against the current set.
+    /// Tags to add, deduplicated against the current set. Each entry is
+    /// trimmed; a blank/whitespace-only entry rejects the WHOLE request with
+    /// 400 (see [`trim_and_reject_blank_tags`]).
     #[serde(default)]
     pub tags_add: Option<Vec<String>>,
     /// Tags to remove. Applied AFTER `tags_add`, so a tag present in both
-    /// lists in the same request ends up removed.
+    /// lists in the same request ends up removed. Same trim/blank-rejection
+    /// rule as `tags_add`.
     #[serde(default)]
     pub tags_remove: Option<Vec<String>>,
 }
@@ -286,20 +289,28 @@ pub struct PatchProjectBody {
 /// validation and persistence never drift between the two front ends. See
 /// [`PatchProjectBody`] for the full field-by-field unset/tags contract.
 /// What: validates the body BEFORE touching the store (name-change rejection,
-/// then blank-value rejection on the two required string fields — matching
+/// blank-value rejection on the two required string fields, and blank/
+/// whitespace-only-tag rejection on `tags_add`/`tags_remove` — matching
 /// [`register_project_registry_route`]'s "validate then touch the store"
-/// order), 404s an unknown project (same shape as
-/// [`get_project_registry_route`]), applies only the fields present in the
-/// body to a clone of the existing record, persists via
-/// [`ProjectRegistry::register`](crate::project::ProjectRegistry::register)
-/// (the same idempotent upsert `POST` uses), and returns 200 with the updated
-/// record. Re-issuing an identical PATCH is idempotent: the second call
+/// order), then applies the merge under
+/// [`ProjectRegistry::update_with`](crate::project::ProjectRegistry::update_with) — ONE
+/// write-lock guard held across the whole fetch→mutate→persist sequence
+/// (#2481 review HIGH fix: a `get` followed by a LATER, separate `register`
+/// call left a window where a concurrent PATCH to a different field could be
+/// silently discarded — see `update_with`'s doc comment for the full
+/// mechanism). 404s an unknown project (same shape as
+/// [`get_project_registry_route`]) and returns 200 with the updated record on
+/// success. Re-issuing an identical PATCH is idempotent: the second call
 /// applies the same (already-applied) values and tag adds/removes are
 /// membership-checked, so it is a true no-op.
 /// Test: `patch_body_distinguishes_absent_null_and_value` (in-module), and in
 /// `tests/project_registry_routes.rs`: `patch_round_trip_updates_fields`,
 /// `patch_absent_fields_untouched`, `patch_unknown_project_is_404`,
-/// `patch_rejects_name_change`, `patch_is_idempotent`.
+/// `patch_rejects_name_change`, `patch_is_idempotent`,
+/// `patch_rejects_blank_tags_add`, `patch_rejects_blank_tags_remove`; and in
+/// `crate::project::registry::tests`:
+/// `update_with_serializes_concurrent_field_edits`,
+/// `get_then_register_pattern_reproduces_lost_update_pre_fix`.
 pub async fn patch_project_registry_route(
     State(state): State<Arc<DaemonState>>,
     AxumPath(name): AxumPath<String>,
@@ -325,57 +336,103 @@ pub async fn patch_project_registry_route(
         return (StatusCode::BAD_REQUEST, "default_branch must not be empty").into_response();
     }
 
+    let tags_add = match body
+        .tags_add
+        .map(|tags| trim_and_reject_blank_tags(tags, "tags_add"))
+    {
+        Some(Ok(tags)) => Some(tags),
+        Some(Err(msg)) => return (StatusCode::BAD_REQUEST, msg).into_response(),
+        None => None,
+    };
+    let tags_remove = match body
+        .tags_remove
+        .map(|tags| trim_and_reject_blank_tags(tags, "tags_remove"))
+    {
+        Some(Ok(tags)) => Some(tags),
+        Some(Err(msg)) => return (StatusCode::BAD_REQUEST, msg).into_response(),
+        None => None,
+    };
+    let repo_url = body.repo_url;
+    let default_branch = body.default_branch;
+    let description = body.description;
+    let stack_hint = body.stack_hint;
+    let gh_user = body.gh_user;
+
     let registry = state.project_registry().await;
-    let mut project = match registry.get(&name).await {
-        Ok(project) => project,
+    let result = registry
+        .update_with(&name, move |mut project| {
+            if let Some(repo_url) = repo_url {
+                project.repo_url = repo_url;
+            }
+            if let Some(default_branch) = default_branch {
+                project.default_branch = default_branch;
+            }
+            if let Some(description) = description {
+                project.description = description;
+            }
+            if let Some(stack_hint) = stack_hint {
+                project.stack_hint = stack_hint;
+            }
+            if let Some(gh_user) = gh_user {
+                project.gh_user = gh_user;
+            }
+            if let Some(add) = tags_add {
+                for tag in add {
+                    if !project.tags.contains(&tag) {
+                        project.tags.push(tag);
+                    }
+                }
+            }
+            if let Some(remove) = tags_remove {
+                project.tags.retain(|t| !remove.contains(t));
+            }
+            project
+        })
+        .await;
+
+    match result {
+        Ok(project) => Json(project).into_response(),
         Err(ProjectStoreError::NotFound(_)) => {
-            return (StatusCode::NOT_FOUND, format!("project {name} not found")).into_response();
+            (StatusCode::NOT_FOUND, format!("project {name} not found")).into_response()
         }
         Err(e) => {
-            warn!(error = %e, project = %name, "patch_project_registry_route: registry read failed");
-            return (
+            warn!(error = %e, project = %name, "patch_project_registry_route: registry write failed");
+            (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "project registry read failed".to_string(),
+                "project registry write failed".to_string(),
             )
-                .into_response();
-        }
-    };
-
-    if let Some(repo_url) = body.repo_url {
-        project.repo_url = repo_url;
-    }
-    if let Some(default_branch) = body.default_branch {
-        project.default_branch = default_branch;
-    }
-    if let Some(description) = body.description {
-        project.description = description;
-    }
-    if let Some(stack_hint) = body.stack_hint {
-        project.stack_hint = stack_hint;
-    }
-    if let Some(gh_user) = body.gh_user {
-        project.gh_user = gh_user;
-    }
-    if let Some(add) = body.tags_add {
-        for tag in add {
-            if !project.tags.contains(&tag) {
-                project.tags.push(tag);
-            }
+                .into_response()
         }
     }
-    if let Some(remove) = body.tags_remove {
-        project.tags.retain(|t| !remove.contains(t));
-    }
+}
 
-    if let Err(e) = registry.register(project.clone()).await {
-        warn!(error = %e, project = %project.name, "patch_project_registry_route: registry write failed");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "project registry write failed".to_string(),
-        )
-            .into_response();
+/// Trim every tag in a `tags_add`/`tags_remove` list and reject the whole
+/// request (400) if any entry is blank/whitespace-only after trimming.
+///
+/// Why (#2481 review MEDIUM): `repo_url`/`default_branch` already reject a
+/// blank value; `tags_add` previously pushed entries as-is with no trim/blank
+/// check, so a blank tag would persist silently with a 200. Since this
+/// endpoint is THE server-side validation surface #2120's CLI/TUI depend on,
+/// silently accepting a blank tag would let a client-side typo (e.g. a
+/// trailing comma in `--add a,b,`) persist unnoticed. Rejecting — rather than
+/// silently dropping the blank entry — surfaces the mistake to the caller
+/// immediately, matching the `repo_url`/`default_branch` precedent.
+/// What: returns the trimmed tags on success, or an `Err(message)` naming
+/// which field (`tags_add`/`tags_remove`) failed, suitable for a 400 body.
+/// Test: `patch_rejects_blank_tags_add`, `patch_rejects_blank_tags_remove`
+/// (`tests/project_registry_routes.rs`).
+fn trim_and_reject_blank_tags(tags: Vec<String>, field: &str) -> Result<Vec<String>, String> {
+    let mut trimmed = Vec::with_capacity(tags.len());
+    for tag in tags {
+        let tag = tag.trim().to_string();
+        if tag.is_empty() {
+            return Err(format!(
+                "{field} must not contain blank/whitespace-only tags"
+            ));
+        }
+        trimmed.push(tag);
     }
-    Json(project).into_response()
+    Ok(trimmed)
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
@@ -1,22 +1,27 @@
-//! Registry-B project HTTP surface (DOC-35 §4, #2114) — list / register / get.
+//! Registry-B project HTTP surface (DOC-35 §4, #2114) — list / register / get /
+//! patch.
 //!
-//! Why: `tm projects list/register/show` (#2115) are thin deterministic HTTP
-//! clients (DOC-35 §1.3) and need `GET/POST /api/v1/projects` and
-//! `GET /api/v1/projects/{name}` to call. Registry B (`crate::project`) was until
-//! now reachable only via the MCP tools (`mcp_project.rs`) and the `/status`
-//! rollup route; the plain-HTTP list/register/get surface those verbs require did
-//! not exist, so this module adds it. Each handler is a thin, deterministic
+//! Why: `tm projects list/register/show` (#2115) and the `tm projects config
+//! set/unset` field editor + TUI config form (#2120) are thin deterministic HTTP
+//! clients (DOC-35 §1.3/§6) and need `GET/POST /api/v1/projects` and
+//! `GET/PATCH /api/v1/projects/{name}` to call. Registry B (`crate::project`) was
+//! until now reachable only via the MCP tools (`mcp_project.rs`) and the
+//! `/status` rollup route; the plain-HTTP surface those verbs require did not
+//! exist, so this module adds it. Each handler is a thin, deterministic
 //! composition over [`crate::project::ProjectRegistry`] — no LLM, no cross-store
 //! reasoning (§11) — mirroring the existing `mcp_project` bodies so the HTTP and
 //! MCP surfaces stay behaviourally identical (idempotent upsert keyed on `name`,
 //! preserving the per-project `gh`/commit identity binding across a re-register).
-//! What: [`RegisterProjectBody`], [`ProjectsListResponse`], and the three axum
-//! handlers [`list_projects_registry_route`], [`register_project_registry_route`],
-//! and [`get_project_registry_route`]. `PATCH` (the `tm projects config` field
-//! editor, §3.1) is intentionally NOT added here — it belongs to the config-verb
-//! work, not #2115's read/register slice.
-//! Test: `register_body_deserializes`, `register_body_minimal`, and the HTTP
-//! handler tests in `tests/project_registry_routes.rs`.
+//! What: [`RegisterProjectBody`], [`PatchProjectBody`], [`ProjectsListResponse`],
+//! and the four axum handlers [`list_projects_registry_route`],
+//! [`register_project_registry_route`], [`get_project_registry_route`], and
+//! [`patch_project_registry_route`] — the single validation/persistence
+//! implementation §6 requires both the `tm projects config` CLI (#2120) and its
+//! TUI form to share, so the two front ends can never drift on what a valid
+//! field edit looks like.
+//! Test: `register_body_deserializes`, `register_body_minimal`,
+//! `patch_body_distinguishes_absent_null_and_value`, and the HTTP handler tests
+//! in `tests/project_registry_routes.rs`.
 
 use std::sync::Arc;
 
@@ -187,6 +192,192 @@ pub async fn get_project_registry_route(
     }
 }
 
+/// Deserialize a `PATCH` field so "key absent" (leave unchanged, outer `None`)
+/// is distinguishable from "key present with value `null`" (clear the field,
+/// `Some(None)`) and "key present with a value" (`Some(Some(v))`, set it).
+///
+/// Why: serde's default `Option<Option<T>>` handling collapses JSON `null`
+/// into the OUTER `None` — the same value `#[serde(default)]` produces for a
+/// fully absent key — so a naive derive cannot express "explicitly clear this
+/// field" separately from "don't touch it". This is the `double_option` idiom
+/// `serde_with::rust::double_option` documents; trusty-tools already uses it
+/// (without the `serde_with` dependency) in trusty-search's `PATCH /config`
+/// (`crates/trusty-search/src/service/server/admin.rs`,
+/// `deserialize_optional_option_u64`) — mirrored here for `Option<String>`
+/// fields rather than adding a new dependency for one helper.
+/// What: only invoked by serde when the JSON key IS present (the
+/// `#[serde(default)]` on each field covers "key absent" by leaving the outer
+/// `Option` at its `Default::default()`, i.e. `None`); wraps whatever
+/// `Option<T>` the value deserializes to (`None` for `null`, `Some(v)`
+/// otherwise) in an outer `Some`.
+/// Test: `patch_body_distinguishes_absent_null_and_value`.
+fn deserialize_double_option<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Some(Option::deserialize(deserializer)?))
+}
+
+/// JSON body for `PATCH /api/v1/projects/{name}` — a field-level partial update
+/// of a registry-B project (#2114, DOC-35 §6).
+///
+/// Why: `tm projects config <name> set/unset` and the TUI config form (#2120)
+/// are both thin clients over this one endpoint (§6 RESOLVED), so every field
+/// validation rule lives here exactly once. `name` is carried in the body only
+/// so a client that echoes the full record back can be rejected with a clear
+/// message rather than a confusing "field not recognised" — the identity key
+/// comes from the URL path, never the body.
+/// What: `name` — present and different from the path `{name}` is rejected
+/// (400) by [`patch_project_registry_route`]; present and equal is a harmless
+/// no-op. `repo_url`/`default_branch` are the two REQUIRED `String` fields on
+/// [`Project`]: absent leaves them unchanged, present-and-blank is rejected
+/// (400), present-and-non-blank replaces the value — there is deliberately no
+/// "clear" story for either (§6: both are effectively non-empty-or-absent).
+/// `description`/`stack_hint`/`gh_user` are the three `Option<String>` fields
+/// on [`Project`]: they use [`deserialize_double_option`] so absent=unchanged,
+/// JSON `null`=clear, a string=set — giving `tm projects config <name> unset
+/// <field>` (#2120) a real wire mechanism (send `null`) rather than the
+/// "clearing is unsupported in v1" limitation `PatchDeliverable`
+/// (`daemon/api/deliverable_routes.rs`) documents for its single-`Option`
+/// fields. `tags` deliberately does NOT accept a full-replacement array — §6
+/// requires "`--add`/`--remove`, no free-text replace-whole-list footgun" — so
+/// mutation goes through `tags_add`/`tags_remove` instead; `gh_user`'s `gh auth
+/// status` validation is out of scope here (#2081/#2121, accepted as-is);
+/// `jira_config` is NOT a field on this body (#2082/#2122 territory).
+/// Test: `patch_body_distinguishes_absent_null_and_value`, and the HTTP tests
+/// in `tests/project_registry_routes.rs`.
+#[derive(Debug, Default, Deserialize)]
+pub struct PatchProjectBody {
+    /// Echoed identity key; must equal the path `{name}` if present at all.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// New repository URL, if changing (non-blank when present).
+    #[serde(default)]
+    pub repo_url: Option<String>,
+    /// New default branch, if changing (non-blank when present).
+    #[serde(default)]
+    pub default_branch: Option<String>,
+    /// New description; absent=unchanged, `null`=clear, string=set.
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    pub description: Option<Option<String>>,
+    /// New stack hint; absent=unchanged, `null`=clear, string=set.
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    pub stack_hint: Option<Option<String>>,
+    /// New preferred `gh` login (#2081); absent=unchanged, `null`=clear,
+    /// string=set. Deep validation against `gh auth status` is deferred to
+    /// #2121 — this endpoint accepts and stores the string as-is.
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    pub gh_user: Option<Option<String>>,
+    /// Tags to add, deduplicated against the current set.
+    #[serde(default)]
+    pub tags_add: Option<Vec<String>>,
+    /// Tags to remove. Applied AFTER `tags_add`, so a tag present in both
+    /// lists in the same request ends up removed.
+    #[serde(default)]
+    pub tags_remove: Option<Vec<String>>,
+}
+
+/// `PATCH /api/v1/projects/{name}` — field-level partial update of a
+/// registry-B project (#2114, DOC-35 §4/§6).
+///
+/// Why: backs `tm projects config <name> set/unset` and the TUI config form
+/// (#2120) — both are thin clients over this ONE endpoint (§6 RESOLVED) so
+/// validation and persistence never drift between the two front ends. See
+/// [`PatchProjectBody`] for the full field-by-field unset/tags contract.
+/// What: validates the body BEFORE touching the store (name-change rejection,
+/// then blank-value rejection on the two required string fields — matching
+/// [`register_project_registry_route`]'s "validate then touch the store"
+/// order), 404s an unknown project (same shape as
+/// [`get_project_registry_route`]), applies only the fields present in the
+/// body to a clone of the existing record, persists via
+/// [`ProjectRegistry::register`](crate::project::ProjectRegistry::register)
+/// (the same idempotent upsert `POST` uses), and returns 200 with the updated
+/// record. Re-issuing an identical PATCH is idempotent: the second call
+/// applies the same (already-applied) values and tag adds/removes are
+/// membership-checked, so it is a true no-op.
+/// Test: `patch_body_distinguishes_absent_null_and_value` (in-module), and in
+/// `tests/project_registry_routes.rs`: `patch_round_trip_updates_fields`,
+/// `patch_absent_fields_untouched`, `patch_unknown_project_is_404`,
+/// `patch_rejects_name_change`, `patch_is_idempotent`.
+pub async fn patch_project_registry_route(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(name): AxumPath<String>,
+    Json(body): Json<PatchProjectBody>,
+) -> impl IntoResponse {
+    if let Some(new_name) = &body.name
+        && new_name.trim() != name
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            "project name is the identity key and cannot be changed via PATCH",
+        )
+            .into_response();
+    }
+    if let Some(repo_url) = &body.repo_url
+        && repo_url.trim().is_empty()
+    {
+        return (StatusCode::BAD_REQUEST, "repo_url must not be empty").into_response();
+    }
+    if let Some(default_branch) = &body.default_branch
+        && default_branch.trim().is_empty()
+    {
+        return (StatusCode::BAD_REQUEST, "default_branch must not be empty").into_response();
+    }
+
+    let registry = state.project_registry().await;
+    let mut project = match registry.get(&name).await {
+        Ok(project) => project,
+        Err(ProjectStoreError::NotFound(_)) => {
+            return (StatusCode::NOT_FOUND, format!("project {name} not found")).into_response();
+        }
+        Err(e) => {
+            warn!(error = %e, project = %name, "patch_project_registry_route: registry read failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "project registry read failed".to_string(),
+            )
+                .into_response();
+        }
+    };
+
+    if let Some(repo_url) = body.repo_url {
+        project.repo_url = repo_url;
+    }
+    if let Some(default_branch) = body.default_branch {
+        project.default_branch = default_branch;
+    }
+    if let Some(description) = body.description {
+        project.description = description;
+    }
+    if let Some(stack_hint) = body.stack_hint {
+        project.stack_hint = stack_hint;
+    }
+    if let Some(gh_user) = body.gh_user {
+        project.gh_user = gh_user;
+    }
+    if let Some(add) = body.tags_add {
+        for tag in add {
+            if !project.tags.contains(&tag) {
+                project.tags.push(tag);
+            }
+        }
+    }
+    if let Some(remove) = body.tags_remove {
+        project.tags.retain(|t| !remove.contains(t));
+    }
+
+    if let Err(e) = registry.register(project.clone()).await {
+        warn!(error = %e, project = %project.name, "patch_project_registry_route: registry write failed");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "project registry write failed".to_string(),
+        )
+            .into_response();
+    }
+    Json(project).into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,5 +418,57 @@ mod tests {
         assert!(body.tags.is_none());
         assert!(body.stack_hint.is_none());
         assert!(body.gh_user.is_none());
+    }
+
+    /// The PATCH body's three-state fields (`description`/`stack_hint`/
+    /// `gh_user`) distinguish "key absent" from "key present with `null`" from
+    /// "key present with a value" — the double-`Option` wire idiom this
+    /// endpoint's unset story depends on.
+    #[test]
+    fn patch_body_distinguishes_absent_null_and_value() {
+        // Key entirely absent → outer None (leave unchanged).
+        let absent: PatchProjectBody = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(absent.description, None);
+        assert_eq!(absent.stack_hint, None);
+        assert_eq!(absent.gh_user, None);
+
+        // Key present, value null → Some(None) (clear).
+        let cleared: PatchProjectBody = serde_json::from_value(serde_json::json!({
+            "description": null,
+            "stack_hint": null,
+            "gh_user": null
+        }))
+        .unwrap();
+        assert_eq!(cleared.description, Some(None));
+        assert_eq!(cleared.stack_hint, Some(None));
+        assert_eq!(cleared.gh_user, Some(None));
+
+        // Key present, value a string → Some(Some(v)) (set).
+        let set: PatchProjectBody = serde_json::from_value(serde_json::json!({
+            "description": "new desc",
+            "stack_hint": "python",
+            "gh_user": "acme-bot"
+        }))
+        .unwrap();
+        assert_eq!(set.description, Some(Some("new desc".to_string())));
+        assert_eq!(set.stack_hint, Some(Some("python".to_string())));
+        assert_eq!(set.gh_user, Some(Some("acme-bot".to_string())));
+    }
+
+    /// A `name` field identical to no path context still deserializes fine —
+    /// the equality check against the path `{name}` happens in the handler,
+    /// not in deserialization. `repo_url`/`default_branch`/`tags_add`/
+    /// `tags_remove` all default to absent when omitted.
+    #[test]
+    fn patch_body_minimal_defaults_to_all_absent() {
+        let body: PatchProjectBody = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(body.name.is_none());
+        assert!(body.repo_url.is_none());
+        assert!(body.default_branch.is_none());
+        assert!(body.description.is_none());
+        assert!(body.stack_hint.is_none());
+        assert!(body.gh_user.is_none());
+        assert!(body.tags_add.is_none());
+        assert!(body.tags_remove.is_none());
     }
 }

--- a/crates/trusty-mpm/src/project/registry.rs
+++ b/crates/trusty-mpm/src/project/registry.rs
@@ -7,10 +7,21 @@
 //! What: [`ProjectRegistry`] wraps a [`ProjectStore`] in an async `RwLock`,
 //! exposes `register` (idempotent upsert), `get`, and `list`; `seed_from_config`
 //! upserts statically-declared entries; `auto_register_from_sessions` derives
-//! implicit entries from existing session records.
+//! implicit entries from existing session records. [`update_with`](ProjectRegistry::update_with)
+//! is the atomic read-mutate-persist seam a PATCH handler MUST use (#2481 review
+//! HIGH): it holds ONE write-lock guard across the whole fetch→mutate→persist
+//! sequence, mirroring [`crate::deliverable::manager::DeliverableManager::update_deliverable_with`]
+//! (#2395) — `get` followed later by a separate `register` call (two distinct
+//! lock acquisitions) leaves a window where a concurrent caller's own
+//! get-then-register can land in between, and whichever `register` runs last
+//! silently discards the other's update because each call persists a FULL
+//! record built from its own (by-then-stale) snapshot.
 //! Test: `registry_register_idempotent`, `registry_list`, `registry_get`,
 //! `registry_seed_from_config`, `registry_auto_register_from_sessions`,
-//! `registry_derive_name_skips_missing_url`.
+//! `registry_derive_name_skips_missing_url`,
+//! `get_then_register_pattern_reproduces_lost_update_pre_fix`,
+//! `update_with_serializes_concurrent_field_edits`,
+//! `update_with_unknown_project_errors`.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -84,6 +95,43 @@ impl ProjectRegistry {
     pub async fn list(&self) -> Result<Vec<Project>, ProjectStoreError> {
         let mut guard = self.store.write().await;
         guard.all().await
+    }
+
+    /// Atomically read-mutate-persist a project under ONE lock.
+    ///
+    /// Why (fixes the #2481 review HIGH): `PATCH /api/v1/projects/{name}`
+    /// originally called [`get`](Self::get) (one write-lock acquisition),
+    /// released the lock, mutated a CLONE in the caller, then separately
+    /// called [`register`](Self::register) (a SECOND, later acquisition) to
+    /// persist the FULL replacement record. Two concurrent PATCHes to the
+    /// SAME project — even ones editing completely DIFFERENT fields — can
+    /// both fetch the same stale snapshot in the gap between those two calls;
+    /// each then persists a full record built from that stale snapshot, so
+    /// whichever `register` lands last silently overwrites the other's
+    /// already-"successful" field edit with no error ever surfacing to that
+    /// caller. This is the exact lost-update hazard #2395 already fixed for
+    /// `DeliverableManager::update_deliverable_with`.
+    /// What: acquires `self.store.write().await` ONCE and holds the guard for
+    /// the ENTIRE fetch→mutate→persist sequence. Fetches the CURRENT on-disk
+    /// record via the store's own reload-on-read `get` (`NotFound` propagates
+    /// unchanged), calls `f` with that freshly-reloaded record, persists `f`'s
+    /// (infallible — Project PATCH has no state-machine rejection path, unlike
+    /// Deliverable's §10.3 transitions) result, and returns it — all before
+    /// releasing the lock, so no other task can observe or clobber the
+    /// intermediate state.
+    /// Test: `update_with_serializes_concurrent_field_edits` (the concurrency
+    /// regression test — proves two concurrent edits to DIFFERENT fields are
+    /// both present in the final persisted record, never one lost), and
+    /// `update_with_unknown_project_errors`.
+    pub async fn update_with<F>(&self, name: &str, f: F) -> Result<Project, ProjectStoreError>
+    where
+        F: FnOnce(Project) -> Project,
+    {
+        let mut guard = self.store.write().await;
+        let current = guard.get(name).await?;
+        let updated = f(current);
+        guard.upsert(updated.clone()).await?;
+        Ok(updated)
     }
 
     /// Seed the registry from statically-declared `projects:` config entries.
@@ -302,6 +350,150 @@ mod tests {
 
         let err = registry.get("nonexistent").await;
         assert!(matches!(err, Err(ProjectStoreError::NotFound(_))));
+    }
+
+    fn make_project(name: &str) -> Project {
+        Project {
+            name: name.into(),
+            repo_url: format!("https://github.com/o/{name}"),
+            default_branch: "main".into(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        }
+    }
+
+    /// `update_with` propagates `NotFound` for an unregistered project and
+    /// never calls the mutation closure (there is nothing to mutate).
+    #[tokio::test]
+    async fn update_with_unknown_project_errors() {
+        let dir = TempDir::new().expect("tempdir");
+        let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+        let err = registry
+            .update_with("nope", |p| p)
+            .await
+            .expect_err("unknown project must error");
+        assert!(matches!(err, ProjectStoreError::NotFound(_)));
+    }
+
+    /// Reproduces, using the still-available low-level primitives (`get` +
+    /// `register`), the EXACT pre-fix PATCH hazard the #2481 review flagged as
+    /// a HIGH: a `get` under one lock followed LATER by a separate `register`
+    /// under a second lock leaves a window in which another task's own
+    /// get-then-register sequence can run to completion entirely — both tasks
+    /// build their full replacement record from the SAME stale snapshot, so
+    /// whichever `register` lands last silently discards the other's
+    /// already-"successful" field edit. This is the exact two-call shape the
+    /// OLD `patch_project_registry_route` used (fetch under one lock, mutate a
+    /// clone, then persist under a later, separate lock) — the shape
+    /// `update_with` replaces. A `tokio::sync::Notify` gate forces the
+    /// deterministic interleave (B's whole get-mutate-register sequence
+    /// completes while A is parked between its OWN get and its OWN register),
+    /// so the outcome never depends on scheduler luck.
+    /// Test: this IS the test (the #2481 HIGH regression guard, negative case).
+    #[tokio::test]
+    async fn get_then_register_pattern_reproduces_lost_update_pre_fix() {
+        let dir = TempDir::new().expect("tempdir");
+        let registry = Arc::new(ProjectRegistry::load(dir.path()).await.expect("load"));
+        registry
+            .register(make_project("widget"))
+            .await
+            .expect("seed");
+
+        // Gate: task A fetches, then PARKS here — simulating the exact window
+        // the two-lock pattern leaves open between its `get` and its
+        // `register` — until B has fetched, mutated, AND registered its own
+        // (different field) edit.
+        let gate = Arc::new(tokio::sync::Notify::new());
+
+        let reg_a = Arc::clone(&registry);
+        let gate_a = Arc::clone(&gate);
+        let a = tokio::spawn(async move {
+            // Lock #1 (fetch), released as soon as `get` returns — exactly the
+            // OLD handler's read.
+            let mut current = reg_a.get("widget").await.unwrap();
+            // Park until B's own get-mutate-register has fully landed.
+            gate_a.notified().await;
+            current.description = Some("set by A".into());
+            // Lock #2 (register) — a SEPARATE, later acquisition than lock #1.
+            reg_a.register(current).await.unwrap();
+        });
+
+        let reg_b = Arc::clone(&registry);
+        let gate_b = Arc::clone(&gate);
+        let b = tokio::spawn(async move {
+            let mut current = reg_b.get("widget").await.unwrap();
+            current.stack_hint = Some("rust".into());
+            reg_b.register(current).await.unwrap();
+            // B's committed write has landed — release A to clobber it.
+            gate_b.notify_one();
+        });
+
+        b.await.unwrap();
+        a.await.unwrap();
+
+        // The bug: B's committed `stack_hint` edit is silently discarded — A's
+        // later `register` persists a full record built from a snapshot taken
+        // BEFORE B's write, so A's own field lands but B's is gone, with no
+        // error ever surfaced to B's caller (B's own call returned Ok).
+        let final_state = registry.get("widget").await.unwrap();
+        assert_eq!(final_state.description.as_deref(), Some("set by A"));
+        assert_eq!(
+            final_state.stack_hint, None,
+            "demonstrates the pre-fix hazard: B's committed stack_hint edit is \
+             lost — silently clobbered by A's later register() against a \
+             stale snapshot, even though B's own call reported success"
+        );
+    }
+
+    /// Proves the fix: racing two `update_with` calls that edit DIFFERENT
+    /// fields of the SAME project can never lose either edit — both are
+    /// present in the final persisted record, regardless of which task's
+    /// write lands first. Pre-fix (the two-lock pattern exercised by
+    /// `get_then_register_pattern_reproduces_lost_update_pre_fix` above), this
+    /// same race would silently drop whichever edit lost the race.
+    /// Test: this IS the test (the #2481 HIGH regression guard, positive case).
+    #[tokio::test]
+    async fn update_with_serializes_concurrent_field_edits() {
+        let dir = TempDir::new().expect("tempdir");
+        let registry = Arc::new(ProjectRegistry::load(dir.path()).await.expect("load"));
+        registry
+            .register(make_project("widget"))
+            .await
+            .expect("seed");
+
+        let reg_a = Arc::clone(&registry);
+        let a = tokio::spawn(async move {
+            reg_a
+                .update_with("widget", |mut p| {
+                    p.description = Some("set by A".into());
+                    p
+                })
+                .await
+        });
+
+        let reg_b = Arc::clone(&registry);
+        let b = tokio::spawn(async move {
+            reg_b
+                .update_with("widget", |mut p| {
+                    p.stack_hint = Some("rust".into());
+                    p
+                })
+                .await
+        });
+
+        a.await.unwrap().expect("A's update must succeed");
+        b.await.unwrap().expect("B's update must succeed");
+
+        // Both concurrent field edits must be present — neither was lost,
+        // regardless of which task's write landed first.
+        let final_state = registry.get("widget").await.unwrap();
+        assert_eq!(final_state.description.as_deref(), Some("set by A"));
+        assert_eq!(final_state.stack_hint.as_deref(), Some("rust"));
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/tests/project_registry_routes.rs
+++ b/crates/trusty-mpm/tests/project_registry_routes.rs
@@ -24,7 +24,7 @@ use trusty_mpm::client::DaemonClient;
 use trusty_mpm::client::http_client::deliverables::{
     CreateDeliverableArgs, CreateMilestoneArgs, SetStatusError,
 };
-use trusty_mpm::client::http_client::projects::RegisterProjectArgs;
+use trusty_mpm::client::http_client::projects::{PatchProjectArgs, RegisterProjectArgs};
 use trusty_mpm::core::trusty_tools_config::GithubConfig;
 use trusty_mpm::daemon::{api, state::DaemonState};
 use trusty_mpm::deliverable::{DeliverableKind, DeliverableStatus, EstimationTier};
@@ -47,6 +47,21 @@ async fn serve_with_state() -> (DaemonClient, Arc<DaemonState>) {
 /// Bind the real router on an ephemeral loopback port; return a client for it.
 async fn serve() -> DaemonClient {
     serve_with_state().await.0
+}
+
+/// Bind the real router on an ephemeral loopback port; return a client for it
+/// plus the plain `http://host:port` base URL (needed by the one test that
+/// must send a raw wire body the typed [`DaemonClient`] methods cannot
+/// express — `DaemonClient`'s `base` field is crate-private).
+async fn serve_with_base() -> (DaemonClient, String) {
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let router = api::router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    let base = format!("http://{addr}");
+    (DaemonClient::new(base.clone()), base)
 }
 
 /// register → get → list → status round-trips over real HTTP.
@@ -215,6 +230,198 @@ async fn register_preserves_identity_binding_not_expressible_in_body() {
 async fn get_unknown_project_errors() {
     let client = serve().await;
     assert!(client.registry_get_project("nope").await.is_err());
+}
+
+// ───────────────────────── PATCH /api/v1/projects/{name} (#2114) ──────────
+
+/// register → patch → get round-trips: every mutable field type (required
+/// string, clearable optional, tag add/remove) is reflected by a follow-up
+/// `GET`, not just the PATCH response.
+#[tokio::test]
+async fn patch_round_trip_updates_fields() {
+    let client = serve().await;
+    client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: Some("main".into()),
+            description: Some("original".into()),
+            tags: Some(vec!["backend".into(), "keep-me".into()]),
+            stack_hint: Some("rust".into()),
+            gh_user: Some("acme-bot".into()),
+        })
+        .await
+        .unwrap();
+
+    let patched = client
+        .registry_patch_project(
+            "widget",
+            &PatchProjectArgs {
+                default_branch: Some("develop".into()),
+                description: Some(Some("updated".into())),
+                stack_hint: Some(None), // clear
+                tags_add: Some(vec!["ml".into()]),
+                tags_remove: Some(vec!["backend".into()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(patched.default_branch, "develop");
+    assert_eq!(patched.description.as_deref(), Some("updated"));
+    assert_eq!(patched.stack_hint, None, "explicit null must clear");
+    assert!(patched.tags.contains(&"ml".to_string()));
+    assert!(patched.tags.contains(&"keep-me".to_string()));
+    assert!(!patched.tags.contains(&"backend".to_string()));
+    // gh_user was not touched by this PATCH — must survive unchanged.
+    assert_eq!(patched.gh_user.as_deref(), Some("acme-bot"));
+
+    // A follow-up GET, independent of the PATCH response, shows the same state.
+    let refetched = client.registry_get_project("widget").await.unwrap();
+    assert_eq!(refetched, patched);
+}
+
+/// Fields absent from the PATCH body are left completely untouched, including
+/// fields that could look ambiguous (an empty `tags_add`/`tags_remove` array
+/// vs. the key being absent entirely).
+#[tokio::test]
+async fn patch_absent_fields_untouched() {
+    let client = serve().await;
+    client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: Some("main".into()),
+            description: Some("keep this".into()),
+            tags: Some(vec!["backend".into()]),
+            stack_hint: Some("rust".into()),
+            gh_user: Some("acme-bot".into()),
+        })
+        .await
+        .unwrap();
+
+    // A PATCH that only touches repo_url must leave every other field alone.
+    let patched = client
+        .registry_patch_project(
+            "widget",
+            &PatchProjectArgs {
+                repo_url: Some("https://github.com/acme/widget2".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(patched.repo_url, "https://github.com/acme/widget2");
+    assert_eq!(patched.default_branch, "main");
+    assert_eq!(patched.description.as_deref(), Some("keep this"));
+    assert_eq!(patched.stack_hint.as_deref(), Some("rust"));
+    assert_eq!(patched.gh_user.as_deref(), Some("acme-bot"));
+    assert_eq!(patched.tags, vec!["backend".to_string()]);
+}
+
+/// PATCHing an unregistered project 404s (same shape as `GET .../{name}`).
+#[tokio::test]
+async fn patch_unknown_project_is_404() {
+    let (client, base) = serve_with_base().await;
+    // The typed client only surfaces "is this an error", so assert the exact
+    // status via a raw request to confirm it is a 404, not some other 4xx/5xx.
+    let resp = reqwest::Client::new()
+        .patch(format!("{base}/api/v1/projects/nope"))
+        .json(&serde_json::json!({ "description": "x" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let err = client
+        .registry_patch_project(
+            "nope",
+            &PatchProjectArgs {
+                description: Some(Some("x".into())),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("unknown project must error via the typed client too");
+    drop(err);
+}
+
+/// A body carrying a `name` different from the `{name}` path segment is
+/// rejected — `name` is the identity key and PATCH cannot change it.
+#[tokio::test]
+async fn patch_rejects_name_change() {
+    let (client, base) = serve_with_base().await;
+    client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: None,
+            description: None,
+            tags: None,
+            stack_hint: None,
+            gh_user: None,
+        })
+        .await
+        .unwrap();
+
+    // The typed client DTO cannot express a `name` field at all (by design —
+    // see `PatchProjectArgs`'s doc comment); drive the raw wire body directly
+    // to prove the daemon itself rejects the attempt.
+    let url = format!("{base}/api/v1/projects/widget");
+    let resp = reqwest::Client::new()
+        .patch(&url)
+        .json(&serde_json::json!({ "name": "renamed" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    // The record must be unchanged after the rejected attempt.
+    let unchanged = client.registry_get_project("widget").await.unwrap();
+    assert_eq!(unchanged.name, "widget");
+}
+
+/// Re-issuing an identical PATCH is idempotent: the second call produces the
+/// same resulting record as the first (no duplicate tag entries, no drift).
+#[tokio::test]
+async fn patch_is_idempotent() {
+    let client = serve().await;
+    client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: None,
+            description: None,
+            tags: Some(vec!["backend".into()]),
+            stack_hint: None,
+            gh_user: None,
+        })
+        .await
+        .unwrap();
+
+    let args = PatchProjectArgs {
+        description: Some(Some("stable".into())),
+        tags_add: Some(vec!["ml".into()]),
+        ..Default::default()
+    };
+    let first = client
+        .registry_patch_project("widget", &args)
+        .await
+        .unwrap();
+    let second = client
+        .registry_patch_project("widget", &args)
+        .await
+        .unwrap();
+
+    assert_eq!(first.description, second.description);
+    assert_eq!(first.tags, second.tags);
+    assert_eq!(
+        second.tags.iter().filter(|t| *t == "ml").count(),
+        1,
+        "re-applying tags_add must not duplicate the tag"
+    );
 }
 
 /// Deliverable create → list → set-status legal → illegal-409 round-trips, and

--- a/crates/trusty-mpm/tests/project_registry_routes.rs
+++ b/crates/trusty-mpm/tests/project_registry_routes.rs
@@ -424,6 +424,100 @@ async fn patch_is_idempotent() {
     );
 }
 
+/// A blank/whitespace-only entry in `tags_add` is rejected with 400 rather
+/// than silently persisted — this endpoint is the server-side validation
+/// surface #2120's CLI/TUI depend on, so a client-side mistake (e.g. a
+/// trailing comma in `--add a,b,`) must surface immediately.
+#[tokio::test]
+async fn patch_rejects_blank_tags_add() {
+    let (client, base) = serve_with_base().await;
+    client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: None,
+            description: None,
+            tags: None,
+            stack_hint: None,
+            gh_user: None,
+        })
+        .await
+        .unwrap();
+
+    let resp = reqwest::Client::new()
+        .patch(format!("{base}/api/v1/projects/widget"))
+        .json(&serde_json::json!({ "tags_add": ["backend", "   "] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    // Rejected request must not have partially applied "backend".
+    let unchanged = client.registry_get_project("widget").await.unwrap();
+    assert!(unchanged.tags.is_empty(), "{:?}", unchanged.tags);
+}
+
+/// Same rejection rule applies to `tags_remove`.
+#[tokio::test]
+async fn patch_rejects_blank_tags_remove() {
+    let (client, base) = serve_with_base().await;
+    client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: None,
+            description: None,
+            tags: Some(vec!["backend".into()]),
+            stack_hint: None,
+            gh_user: None,
+        })
+        .await
+        .unwrap();
+
+    let resp = reqwest::Client::new()
+        .patch(format!("{base}/api/v1/projects/widget"))
+        .json(&serde_json::json!({ "tags_remove": [""] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    // Rejected request must not have removed "backend".
+    let unchanged = client.registry_get_project("widget").await.unwrap();
+    assert_eq!(unchanged.tags, vec!["backend".to_string()]);
+}
+
+/// A tag with leading/trailing whitespace is trimmed before being persisted
+/// (not rejected — only fully-blank entries are rejected).
+#[tokio::test]
+async fn patch_trims_tags_add_whitespace() {
+    let client = serve().await;
+    client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: None,
+            description: None,
+            tags: None,
+            stack_hint: None,
+            gh_user: None,
+        })
+        .await
+        .unwrap();
+
+    let patched = client
+        .registry_patch_project(
+            "widget",
+            &PatchProjectArgs {
+                tags_add: Some(vec!["  rust  ".into()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(patched.tags, vec!["rust".to_string()]);
+}
+
 /// Deliverable create → list → set-status legal → illegal-409 round-trips, and
 /// the illegal transition surfaces as `SetStatusError::Rejected` with the legal
 /// next states (#2380).


### PR DESCRIPTION
## Summary

Adds `PATCH /api/v1/projects/{name}` — the registry-B field-level config-update
endpoint from DOC-35 (`docs/specs/tm-project-control-plane.md`) §4/§6. Issue
#2114 was re-scoped during Wave 2: `GET/POST /api/v1/projects` and
`GET /api/v1/projects/{name}` already shipped in #2428
(`crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs`).
This PR adds ONLY the PATCH route alongside them, following the shipped
handlers' idioms exactly (plain `(StatusCode, &str)`/`(StatusCode, String)`
tuple error responses, not a `DaemonError` envelope — matching this file, not
the sibling `deliverable_routes.rs`).

`tm projects config <name> set/unset` (#2120) and its TUI config form are both
designed as thin clients over this ONE endpoint (§6 RESOLVED), so validation
and persistence for the config editor lives here exactly once, never
duplicated client-side.

## Endpoint contract

**Request body** (`PatchProjectBody` / client `PatchProjectArgs`) — every
field optional; only fields present in the JSON body are applied:

| Field | Type on `Project` | PATCH semantics |
|---|---|---|
| `name` | `String` (identity key) | If present and differs from the `{name}` path segment → **400**, "project name is the identity key and cannot be changed via PATCH". Present-and-equal is a harmless no-op. |
| `repo_url` | `String` (required) | Absent = unchanged. Present + blank → **400**. Present + non-blank → replace. No "clear" story (required field). |
| `default_branch` | `String` (required) | Same rule as `repo_url` (§6: "non-empty"). |
| `description` | `Option<String>` | **Double-`Option` wire idiom**: absent = unchanged; JSON `null` = clear; a string = set. |
| `stack_hint` | `Option<String>` | Same double-`Option` semantics as `description`. |
| `gh_user` | `Option<String>` | Same double-`Option` semantics. Deep validation against `gh auth status` is explicitly **out of scope** — deferred to #2121 per this issue's instructions; the string is accepted and stored as-is. |
| `tags_add` / `tags_remove` | `Vec<String>` | §6 requires "`--add`/`--remove`, no free-text replace-whole-list footgun" — so PATCH does **not** accept a full replacement `tags` array. `tags_add` is applied first (deduplicated against the current set), then `tags_remove` (so a tag in both lists ends up removed). |
| `jira_config` | — | **Not a field on this body at all** — #2082/#2122 territory, explicitly out of scope per the issue. |

**Responses:**
- `200 OK` with the updated `Project` on success.
- `400 Bad Request` (plain text) for a name-change attempt or a blank
  `repo_url`/`default_branch`.
- `404 Not Found` (plain text, `"project {name} not found"`) for an unknown
  project — same shape as the existing `GET /api/v1/projects/{name}` 404.
- `500 Internal Server Error` on a registry read/write failure (logged with
  `tracing::warn!`, never a panic/`unwrap`).

Validation happens BEFORE the store lookup (name-change + blank-value checks
first), matching `register_project_registry_route`'s existing
"validate-then-touch-the-store" order.

## The unset story (double-`Option`, disclosed deviation)

The sibling `PatchDeliverable` (`daemon/api/deliverable_routes.rs`) documents
a v1 limitation: its single-`Option` fields cannot distinguish "absent" from
"explicit `null`", so clearing a field is unsupported. This PR deliberately
does **not** follow that precedent for `description`/`stack_hint`/`gh_user`,
because #2120's `tm projects config <name> unset <field>` CLI verb needs a
real wire mechanism to express "clear this field" — a single-`Option` field
cannot give it one. Instead this endpoint uses the `Option<Option<T>>`
("double-`Option`") idiom `serde_with::rust::double_option` documents, which
trusty-tools already uses (without the `serde_with` dependency) in
trusty-search's `PATCH /config`
(`crates/trusty-search/src/service/server/admin.rs`,
`deserialize_optional_option_u64`) — mirrored here as a generic
`deserialize_double_option` helper for `Option<String>` fields. On the client
`Serialize` side no custom code is needed: serde's stock `Option<T>` impl
already writes `null` for an inner `None`, so `Some(None)` on the wire body
serializes correctly with only `skip_serializing_if = "Option::is_none"` on
the outer `Option`.

`repo_url`/`default_branch` do NOT get this treatment — they are required
`String` fields on `Project`, not `Option<String>`, so there is no "clear"
state to express; a blank value is simply rejected.

## Tags: add/remove, not full-replace (spec-prescribed, not a free choice)

DOC-35 §6 explicitly states: *"tags | `Vec<String>` | registry B |
`--add`/`--remove`, no free-text replace-whole-list footgun"*. This is
prescriptive, not a case where I had to pick between the two options the
issue offered — the spec already resolved it. `tags_add`/`tags_remove` are
therefore the only tag-mutation surface on this endpoint; there is no
`tags` field accepting a full replacement array.

## Scope deviation: `repo_url` is patchable

DOC-35 §6's field table (the CLI-facing `tm projects config` table) does not
list `repo_url` as a configurable field — only `default_branch`,
`description`, `tags`, `stack_hint`, `gh_user`, `jira_config`. This PR's task
instructions explicitly named `repo_url` as one of the fields this endpoint
must support ("Field-level partial update ... fields per the struct —
`repo_url`, `default_branch`, `stack_hint`, `tags`, `description`,
`gh_user`"), since it's a plain mutable field on the `Project` struct and a
reasonable thing to correct via PATCH (e.g. a typo'd/renamed remote) even if
the CLI's v1 `config` verb table doesn't expose a `set repo_url` shortcut yet.
Disclosing this since it's a scope expansion beyond the literal §6 table.

## Test plan

- [x] HTTP round-trip: register → patch (branch, description, clear
  stack_hint, tags add/remove) → verify in the PATCH response AND an
  independent follow-up `GET` (`patch_round_trip_updates_fields`)
- [x] Absent-field-untouched: a PATCH touching only `repo_url` leaves every
  other field (including tags) exactly as registered
  (`patch_absent_fields_untouched`)
- [x] Unknown-name 404, verified via both raw status-code assertion and the
  typed client's error path (`patch_unknown_project_is_404`)
- [x] Name-change rejection: raw wire body with a differing `name` → 400,
  record unchanged after (`patch_rejects_name_change`)
- [x] Idempotent re-patch: identical PATCH issued twice produces identical
  results, no duplicate tag entries (`patch_is_idempotent`)
- [x] In-module deserialization unit tests for the double-`Option` wire
  semantics (`patch_body_distinguishes_absent_null_and_value`) and the
  client-side `Serialize` mirror (`patch_args_serializes_double_option_semantics`,
  `patch_args_omits_absent_fields`, `patch_args_serializes_tags_and_required_fields`)

### Gate evidence (run from the worktree, foreground)

```
cargo build --workspace                            → Finished (clean)
cargo test --workspace                              → 0 failures anywhere (grep for FAILED/error[ across full log: none)
cargo test -p trusty-mpm --test project_registry_routes → 11 passed; 0 failed
cargo test -p trusty-mpm --lib project_registry_routes  → 4 passed; 0 failed
cargo test -p trusty-mpm --lib client::http_client::projects → 7 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings   → Finished (clean; only pre-existing unrelated `tga` MSRV-mismatch tool warning)
cargo fmt --check                                    → exit 0
bash scripts/check_line_cap.sh                       → "line-cap: 0 allowlisted, 0 violations — OK."
```

## Files changed (SLOC)

- `crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs` — 474 SLOC total (under the 500 cap): +`PatchProjectBody`, `deserialize_double_option`, `patch_project_registry_route`, in-module tests
- `crates/trusty-mpm/src/daemon/managed_routes/mod.rs` — re-export `PatchProjectBody`/`patch_project_registry_route`
- `crates/trusty-mpm/src/daemon/api.rs` — wire `PATCH` onto the existing `/api/v1/projects/{name}` route
- `crates/trusty-mpm/src/client/http_client/projects.rs` — 430 SLOC total: +`PatchProjectArgs`, `DaemonClient::registry_patch_project`, unit tests
- `crates/trusty-mpm/tests/project_registry_routes.rs` — 536 SLOC total (under the 1500 test cap): +5 HTTP round-trip tests, `serve_with_base()` helper

Closes #2114

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools