### PR TITLE
feat(trusty-common): OpenAI-compat adapter core + OpenRouter + Fireworks adapters

### DIFF
--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -50,6 +50,15 @@ name = "inference_foundation"
 path = "tests/inference_foundation.rs"
 required-features = ["inference-client"]
 
+# Concrete inference-adapter integration suite (issue #2403). Drives the
+# OpenRouter/Fireworks/OpenAI adapters through the `Configurator` against the
+# axum `MockInferenceServer`, so it needs BOTH `inference-client` (the adapters)
+# and `axum-server` (the HTTP mock); `required-features` skips it otherwise.
+[[test]]
+name = "inference_adapters"
+path = "tests/inference_adapters.rs"
+required-features = ["inference-client", "axum-server"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/trusty-common/src/inference/mod.rs
+++ b/crates/trusty-common/src/inference/mod.rs
@@ -31,6 +31,8 @@ pub mod configurator;
 #[cfg(feature = "inference-client")]
 pub mod error;
 #[cfg(feature = "inference-client")]
+pub mod providers;
+#[cfg(feature = "inference-client")]
 pub mod registry;
 #[cfg(feature = "inference-client")]
 pub mod test_support;
@@ -46,6 +48,8 @@ pub use adapter::InferenceAdapter;
 pub use configurator::{AdapterFactory, Configurator, ResolvedProvider, provider_for};
 #[cfg(feature = "inference-client")]
 pub use error::InferenceError;
+#[cfg(feature = "inference-client")]
+pub use providers::{OpenAiCompatAdapter, OpenAiCompatConfig, register_default_factories};
 #[cfg(feature = "inference-client")]
 pub use registry::{
     Pricing, ProviderCapabilities, ProviderId, ToolDialect, capabilities, capabilities_for,

--- a/crates/trusty-common/src/inference/providers/fireworks.rs
+++ b/crates/trusty-common/src/inference/providers/fireworks.rs
@@ -1,0 +1,166 @@
+//! Fireworks adapter — a thin config over the OpenAI-compatible core.
+//!
+//! Why: Fireworks AI serves `accounts/fireworks/models/*` slugs behind the same
+//! OpenAI-compatible `/chat/completions` schema, so it reuses the shared core
+//! wholesale. Its only deltas from OpenRouter are the base URL
+//! (`api.fireworks.ai/inference/v1`), no attribution headers, and — per the
+//! acceptance criteria — `wants_detailed_usage = false` with no prompt caching
+//! (both already encoded in the capability registry seed, so the core neither
+//! injects the usage directive nor advertises caching). Native tool-calling
+//! stays on the registry's conservative allow-list posture.
+//! What: [`build`] constructs an [`OpenAiCompatAdapter`] for a resolved Fireworks
+//! credential against a given base URL; [`factory`] is the production factory
+//! (real base URL) registered into the [`Configurator`].
+//! Test: inline `#[ignore]` `live_fireworks_call`; offline round-trip in
+//! `crates/trusty-common/tests/inference_adapters.rs`.
+
+use super::openai_compat::{OpenAiCompatAdapter, OpenAiCompatConfig};
+use crate::inference::adapter::InferenceAdapter;
+use crate::inference::configurator::ResolvedProvider;
+use crate::inference::error::InferenceError;
+use crate::inference::registry::ProviderId;
+
+/// Fireworks API root; the core appends `/chat/completions`.
+pub const FIREWORKS_BASE_URL: &str = "https://api.fireworks.ai/inference/v1";
+
+/// Build a Fireworks adapter for a resolved credential against `base_url`.
+///
+/// Why: the base URL is a parameter (not a constant) so tests can point the
+/// exact same adapter at [`crate::inference::test_support::MockInferenceServer`]
+/// while production uses [`FIREWORKS_BASE_URL`].
+/// What: requires the resolved key (Fireworks is a keyed provider — a missing
+/// key is [`InferenceError::MissingCredential`]), then constructs an
+/// [`OpenAiCompatAdapter`] with no attribution headers and Fireworks' registry
+/// capabilities (`detailed_usage_accounting = false`, `prompt_caching = false`),
+/// so the core sends a bare OpenAI-compatible body.
+/// Test: `crates/trusty-common/tests/inference_adapters.rs`.
+pub fn build(
+    resolved: &ResolvedProvider,
+    base_url: &str,
+) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    let key = resolved
+        .key()
+        .ok_or(InferenceError::MissingCredential {
+            provider: ProviderId::Fireworks,
+        })?
+        .clone();
+    let config = OpenAiCompatConfig {
+        name: ProviderId::Fireworks.as_str().to_string(),
+        base_url: base_url.to_string(),
+        api_key: key,
+        extra_headers: Vec::new(),
+        capabilities: *resolved.capabilities(),
+    };
+    Ok(Box::new(OpenAiCompatAdapter::new(config)?))
+}
+
+/// Production factory: build a Fireworks adapter against the real base URL.
+///
+/// Why: this is what [`super::register_default_factories`] registers into the
+/// [`crate::inference::Configurator`] so a `fireworks/*` slug (whose key
+/// resolves) yields a live Fireworks adapter.
+/// What: delegates to [`build`] with [`FIREWORKS_BASE_URL`].
+/// Test: `crates/trusty-common/tests/inference_adapters.rs` (via a mock-URL
+/// factory) and the `#[ignore]` live smoke test below.
+pub fn factory(resolved: &ResolvedProvider) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    build(resolved, FIREWORKS_BASE_URL)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::types::{ChatMessage, ChatRequest, SecretString};
+
+    const FIREWORKS_MODEL: &str = "accounts/fireworks/models/llama-v3p1-8b-instruct";
+
+    fn resolved(key: &str) -> ResolvedProvider {
+        ResolvedProvider::new(
+            ProviderId::Fireworks,
+            "fireworks/llama-v3p1-8b-instruct".to_string(),
+            Some(SecretString::new(key)),
+        )
+    }
+
+    /// Why: the factory must build a named Fireworks adapter that does NOT
+    /// request detailed usage and does NOT advertise prompt caching.
+    /// Test: itself.
+    #[test]
+    fn factory_builds_named_adapter() {
+        let adapter = build(&resolved("fw-test"), FIREWORKS_BASE_URL).expect("built");
+        assert_eq!(adapter.name(), "fireworks");
+        assert!(!adapter.wants_detailed_usage());
+        assert!(!adapter.supports_prompt_caching());
+        assert!(adapter.supports_native_tools());
+    }
+
+    /// Why: a resolved provider with no key must be an explicit alarm.
+    /// Test: itself.
+    #[test]
+    fn missing_key_errors() {
+        let resolved =
+            ResolvedProvider::new(ProviderId::Fireworks, "fireworks/llama".to_string(), None);
+        let Err(err) = build(&resolved, FIREWORKS_BASE_URL) else {
+            panic!("expected MissingCredential");
+        };
+        assert!(matches!(
+            err,
+            InferenceError::MissingCredential {
+                provider: ProviderId::Fireworks
+            }
+        ));
+    }
+
+    /// Live smoke test: send a trivial prompt to a cheap Fireworks model.
+    ///
+    /// Why: end-to-end validation against the real API that the Fireworks config
+    /// + core produce a non-empty response and non-zero usage. Ignored so CI
+    /// stays offline; run locally with a real key.
+    /// What: reads `FIREWORKS_API_KEY` from env and SKIPS (does not fail) when
+    /// absent/empty; otherwise builds the adapter via [`build`] and asserts a
+    /// non-empty reply with `prompt_tokens > 0`.
+    /// Test: `cargo test -p trusty-common --features inference-client,axum-server \
+    ///        fireworks -- --ignored --nocapture` (with `FIREWORKS_API_KEY` set).
+    #[tokio::test]
+    #[ignore = "requires FIREWORKS_API_KEY; skipped in CI"]
+    async fn live_fireworks_call() {
+        let Ok(key) = std::env::var("FIREWORKS_API_KEY") else {
+            eprintln!("FIREWORKS_API_KEY not set — skipping live test");
+            return;
+        };
+        if key.trim().is_empty() {
+            eprintln!("FIREWORKS_API_KEY is empty — skipping live test");
+            return;
+        }
+
+        let resolved = ResolvedProvider::new(
+            ProviderId::Fireworks,
+            FIREWORKS_MODEL.to_string(),
+            Some(SecretString::new(key)),
+        );
+        let adapter = build(&resolved, FIREWORKS_BASE_URL).expect("build adapter");
+
+        let mut req = ChatRequest::new(
+            FIREWORKS_MODEL,
+            vec![
+                ChatMessage::system("You are a concise assistant."),
+                ChatMessage::user("Reply with exactly the word: pong"),
+            ],
+        );
+        req.temperature = Some(0.0);
+        req.max_tokens = Some(16);
+
+        let resp = adapter.chat(&req).await.expect("live chat");
+        let text = resp.first_text().expect("assistant text");
+        assert!(!text.is_empty(), "assistant text was empty");
+        assert!(
+            resp.usage().prompt_tokens > 0,
+            "prompt_tokens should be > 0"
+        );
+        eprintln!(
+            "live fireworks ok — text: {text:?}, usage: {:?}",
+            resp.usage()
+        );
+    }
+}

--- a/crates/trusty-common/src/inference/providers/mod.rs
+++ b/crates/trusty-common/src/inference/providers/mod.rs
@@ -1,0 +1,42 @@
+//! Concrete inference provider adapters (issue #2403, epic #2400 Wave 1).
+//!
+//! Why: the #2402 foundation shipped the [`InferenceAdapter`] trait, the
+//! capability registry, and the [`crate::inference::Configurator`] seam but left
+//! the construction step to a test-only [`crate::inference::test_support::ScriptedAdapter`].
+//! This module realises the seam: a shared OpenAI-compatible HTTP core plus one
+//! thin config per OpenAI-dialect provider, and the [`register_default_factories`]
+//! entry point that wires them into the configurator so
+//! `provider_for("openrouter" | "fireworks" | "openai", &store)` builds a REAL
+//! `Box<dyn InferenceAdapter>`.
+//! What: [`openai_compat::OpenAiCompatAdapter`] (the core) and the
+//! [`openrouter`]/[`fireworks`]/[`openai`] provider configs, plus
+//! [`register_default_factories`]. Anthropic-dialect providers (Bedrock #2407,
+//! Anthropic-direct #2408) are out of scope here.
+//! Test: each submodule's inline `tests` + the offline mock-server round-trip in
+//! `crates/trusty-common/tests/inference_adapters.rs`.
+
+pub mod fireworks;
+pub mod openai;
+pub mod openai_compat;
+pub mod openrouter;
+
+pub use openai_compat::{OpenAiCompatAdapter, OpenAiCompatConfig};
+
+use crate::inference::configurator::Configurator;
+use crate::inference::registry::ProviderId;
+
+/// Register the built-in OpenAI-dialect provider factories into `cfg`.
+///
+/// Why: consumers want one call that makes the configurator able to build every
+/// adapter this ticket ships, rather than remembering each `register` line. The
+/// configurator stays empty by default (no implicit adapters) — this is the
+/// explicit opt-in that turns resolution into live adapters.
+/// What: registers the OpenRouter, Fireworks, and OpenAI production factories
+/// (each pointed at its real base URL) under their [`ProviderId`]. Bedrock and
+/// Anthropic-direct are intentionally NOT registered here (later waves).
+/// Test: `crates/trusty-common/tests/inference_adapters.rs::default_factories_register_three`.
+pub fn register_default_factories(cfg: &mut Configurator) {
+    cfg.register(ProviderId::OpenRouter, Box::new(openrouter::factory));
+    cfg.register(ProviderId::Fireworks, Box::new(fireworks::factory));
+    cfg.register(ProviderId::OpenAI, Box::new(openai::factory));
+}

--- a/crates/trusty-common/src/inference/providers/openai.rs
+++ b/crates/trusty-common/src/inference/providers/openai.rs
@@ -1,0 +1,108 @@
+//! OpenAI-direct adapter — the reference thin config over the shared core.
+//!
+//! Why: OpenAI's first-party `/chat/completions` IS the schema the core speaks,
+//! so the OpenAI adapter is the minimal possible config: base URL + `Bearer`
+//! auth (from the core), no attribution headers, no detailed-usage directive
+//! (`detailed_usage_accounting = false` in the registry). It exists so the
+//! two-stage resolver's `openai/*` explicit-family path (when `OPENAI_API_KEY`
+//! resolves) builds a real first-party adapter rather than routing through
+//! OpenRouter.
+//! What: [`build`] constructs an [`OpenAiCompatAdapter`] for a resolved OpenAI
+//! credential against a given base URL; [`factory`] is the production factory
+//! (real base URL) registered into the [`Configurator`].
+//! Test: inline `tests`; offline round-trip in
+//! `crates/trusty-common/tests/inference_adapters.rs`.
+
+use super::openai_compat::{OpenAiCompatAdapter, OpenAiCompatConfig};
+use crate::inference::adapter::InferenceAdapter;
+use crate::inference::configurator::ResolvedProvider;
+use crate::inference::error::InferenceError;
+use crate::inference::registry::ProviderId;
+
+/// OpenAI API root; the core appends `/chat/completions`.
+pub const OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+
+/// Build an OpenAI-direct adapter for a resolved credential against `base_url`.
+///
+/// Why: the base URL is a parameter (not a constant) so tests can point the
+/// exact same adapter at [`crate::inference::test_support::MockInferenceServer`]
+/// while production uses [`OPENAI_BASE_URL`].
+/// What: requires the resolved key (OpenAI is a keyed provider — a missing key
+/// is [`InferenceError::MissingCredential`]), then constructs an
+/// [`OpenAiCompatAdapter`] with no attribution headers and OpenAI's registry
+/// capabilities.
+/// Test: `crates/trusty-common/tests/inference_adapters.rs`.
+pub fn build(
+    resolved: &ResolvedProvider,
+    base_url: &str,
+) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    let key = resolved
+        .key()
+        .ok_or(InferenceError::MissingCredential {
+            provider: ProviderId::OpenAI,
+        })?
+        .clone();
+    let config = OpenAiCompatConfig {
+        name: ProviderId::OpenAI.as_str().to_string(),
+        base_url: base_url.to_string(),
+        api_key: key,
+        extra_headers: Vec::new(),
+        capabilities: *resolved.capabilities(),
+    };
+    Ok(Box::new(OpenAiCompatAdapter::new(config)?))
+}
+
+/// Production factory: build an OpenAI adapter against the real base URL.
+///
+/// Why: registered by [`super::register_default_factories`] so an `openai/*`
+/// slug (whose key resolves) yields a live first-party OpenAI adapter.
+/// What: delegates to [`build`] with [`OPENAI_BASE_URL`].
+/// Test: `crates/trusty-common/tests/inference_adapters.rs` (via a mock-URL
+/// factory).
+pub fn factory(resolved: &ResolvedProvider) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    build(resolved, OPENAI_BASE_URL)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::types::SecretString;
+
+    fn resolved(key: &str) -> ResolvedProvider {
+        ResolvedProvider::new(
+            ProviderId::OpenAI,
+            "gpt-4o-mini".to_string(),
+            Some(SecretString::new(key)),
+        )
+    }
+
+    /// Why: the factory must build a named OpenAI adapter that does NOT request
+    /// detailed usage accounting.
+    /// Test: itself.
+    #[test]
+    fn factory_builds_named_adapter() {
+        let adapter = build(&resolved("sk-openai-test"), OPENAI_BASE_URL) // pragma: allowlist secret
+            .expect("built");
+        assert_eq!(adapter.name(), "openai");
+        assert!(!adapter.wants_detailed_usage());
+        assert_eq!(adapter.capabilities().id, ProviderId::OpenAI);
+    }
+
+    /// Why: a resolved provider with no key must be an explicit alarm.
+    /// Test: itself.
+    #[test]
+    fn missing_key_errors() {
+        let resolved = ResolvedProvider::new(ProviderId::OpenAI, "gpt-4o-mini".to_string(), None);
+        let Err(err) = build(&resolved, OPENAI_BASE_URL) else {
+            panic!("expected MissingCredential");
+        };
+        assert!(matches!(
+            err,
+            InferenceError::MissingCredential {
+                provider: ProviderId::OpenAI
+            }
+        ));
+    }
+}

--- a/crates/trusty-common/src/inference/providers/openai_compat.rs
+++ b/crates/trusty-common/src/inference/providers/openai_compat.rs
@@ -1,0 +1,280 @@
+//! [`OpenAiCompatAdapter`] — the shared OpenAI-compatible HTTP inference core.
+//!
+//! Why: OpenRouter, Fireworks, and OpenAI-direct all speak the identical
+//! `/chat/completions` schema (OpenAI-style `messages`/`tools`/`tool_choice`,
+//! and an OpenAI-shaped response with a `usage` block). Hand-rolling three
+//! near-identical HTTP clients is exactly the duplication epic #2400 exists to
+//! kill. This is the ONE client every OpenAI-dialect provider is a thin config
+//! over: it owns the reqwest mechanics, auth-header injection, the OpenRouter
+//! detailed-usage request flag, HTTP→[`InferenceError`] classification, and
+//! response parsing. Behaviour-compatible with tcode's `llm::client::LlmClient`
+//! so #2406 can drop this in.
+//! What: [`OpenAiCompatConfig`] (per-provider knobs: name, base URL, key,
+//! extra headers, capabilities) and [`OpenAiCompatAdapter`] implementing
+//! [`InferenceAdapter`]. The API key is held as a [`SecretString`] and only ever
+//! placed in the `Authorization` header — never logged, never in an error.
+//! Test: inline `tests` — `endpoint_appends_path`, `usage_directive_injected`,
+//! `usage_directive_absent_without_detailed`, `usage_directive_not_overwritten`;
+//! full HTTP round-trip in `crates/trusty-common/tests/inference_adapters.rs`.
+
+use async_trait::async_trait;
+use reqwest::Client;
+
+use crate::inference::adapter::InferenceAdapter;
+use crate::inference::error::InferenceError;
+use crate::inference::registry::ProviderCapabilities;
+use crate::inference::types::{ChatRequest, ChatResponse, RequestUsageConfig, SecretString};
+
+/// Per-provider configuration for an [`OpenAiCompatAdapter`].
+///
+/// Why: the only things that differ between OpenRouter, Fireworks, and
+/// OpenAI-direct are their base URL, attribution headers, and capability
+/// descriptor — everything else (the wire schema, auth scheme, error mapping)
+/// is shared. Bundling the deltas in one struct keeps each provider module a
+/// tiny config factory instead of a bespoke client.
+/// What: `name` is the stable provider label; `base_url` is the API root the
+/// `/chat/completions` path is appended to; `api_key` is the bearer credential
+/// (redacting [`SecretString`]); `extra_headers` are provider attribution
+/// headers (e.g. OpenRouter's `HTTP-Referer`/`X-Title`); `capabilities` drives
+/// the trait introspection defaults (incl. the OpenRouter detailed-usage flag).
+/// Test: `endpoint_appends_path`.
+pub struct OpenAiCompatConfig {
+    /// Stable provider name for logging/diagnostics (e.g. `"openrouter"`).
+    pub name: String,
+    /// API root URL; `/chat/completions` is appended to it.
+    pub base_url: String,
+    /// Bearer API key, held redacted; only ever written to the auth header.
+    pub api_key: SecretString,
+    /// Provider-specific attribution headers as (name, value) pairs.
+    pub extra_headers: Vec<(String, String)>,
+    /// The provider's capability descriptor (from the registry).
+    pub capabilities: ProviderCapabilities,
+}
+
+/// The shared OpenAI-compatible HTTP inference adapter.
+///
+/// Why: one client behind every OpenAI-dialect provider so the request/response
+/// translation, auth, and error classification live in exactly one place.
+/// What: wraps a cloneable `reqwest::Client`, the precomputed `/chat/completions`
+/// endpoint, the redacted key, attribution headers, and the capability
+/// descriptor. [`Self::chat`] serialises the (usage-augmented) [`ChatRequest`],
+/// POSTs it with a `Bearer` auth header, and maps the outcome to a
+/// [`ChatResponse`] or a classified [`InferenceError`].
+/// Test: inline `tests` + `crates/trusty-common/tests/inference_adapters.rs`.
+pub struct OpenAiCompatAdapter {
+    name: String,
+    endpoint: String,
+    api_key: SecretString,
+    extra_headers: Vec<(String, String)>,
+    capabilities: ProviderCapabilities,
+    http: Client,
+}
+
+impl OpenAiCompatAdapter {
+    /// Build an adapter from a provider config.
+    ///
+    /// Why: the single construction path every provider factory funnels through.
+    /// What: precomputes the `/chat/completions` endpoint from `base_url`
+    /// (tolerating a trailing slash), builds a rustls `reqwest::Client`, and
+    /// stores the config. A client-build failure (extremely rare) maps to
+    /// [`InferenceError::Transport`] rather than panicking.
+    /// Test: `endpoint_appends_path`.
+    pub fn new(config: OpenAiCompatConfig) -> Result<Self, InferenceError> {
+        let endpoint = format!("{}/chat/completions", config.base_url.trim_end_matches('/'));
+        let http = Client::builder()
+            .use_rustls_tls()
+            .build()
+            .map_err(|e| InferenceError::Transport(e.to_string()))?;
+        Ok(Self {
+            name: config.name,
+            endpoint,
+            api_key: config.api_key,
+            extra_headers: config.extra_headers,
+            capabilities: config.capabilities,
+            http,
+        })
+    }
+
+    /// The resolved `/chat/completions` endpoint this adapter POSTs to.
+    ///
+    /// Why: exposed for diagnostics and the inline endpoint-construction test.
+    /// What: the precomputed absolute URL.
+    /// Test: `endpoint_appends_path`.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Produce the outbound request body, injecting the detailed-usage directive
+    /// when this provider wants it.
+    ///
+    /// Why: OpenRouter only returns its authoritative, cache-discounted
+    /// `usage.cost` and nested cache counters when asked via `usage:{include:true}`;
+    /// every other provider must never see the directive. Centralising the
+    /// decision here (driven by [`InferenceAdapter::wants_detailed_usage`]) keeps
+    /// the caller provider-agnostic.
+    /// What: clones `request`; if [`Self::wants_detailed_usage`] is `true` and the
+    /// caller did not already set `usage`, sets it to
+    /// [`RequestUsageConfig::detailed`]. Otherwise returns the request unchanged.
+    /// Test: `usage_directive_injected`, `usage_directive_absent_without_detailed`,
+    /// `usage_directive_not_overwritten`.
+    fn prepare_body(&self, request: &ChatRequest) -> ChatRequest {
+        let mut req = request.clone();
+        if self.wants_detailed_usage() && req.usage.is_none() {
+            req.usage = Some(RequestUsageConfig::detailed());
+        }
+        req
+    }
+}
+
+#[async_trait]
+impl InferenceAdapter for OpenAiCompatAdapter {
+    /// The configured provider name.
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The provider's capability descriptor.
+    fn capabilities(&self) -> &ProviderCapabilities {
+        &self.capabilities
+    }
+
+    /// POST a chat request and translate the response.
+    ///
+    /// Why: the one method the whole agent loop depends on; all HTTP mechanics
+    /// (auth, headers, status classification, parsing) live here so callers only
+    /// speak [`ChatRequest`]/[`ChatResponse`].
+    /// What: serialises [`Self::prepare_body`] as JSON, adds `Authorization:
+    /// Bearer <key>` plus any attribution headers, and POSTs to the endpoint. A
+    /// transport failure maps to [`InferenceError::Transport`]; a non-2xx status
+    /// to [`InferenceError::Api`] (retryable for 429/5xx via
+    /// [`InferenceError::is_retryable`]); a body that will not parse to
+    /// [`InferenceError::Deserialise`]. The API key is only ever placed in the
+    /// auth header and never appears in any returned error.
+    /// Test: `crates/trusty-common/tests/inference_adapters.rs`.
+    async fn chat(&self, request: &ChatRequest) -> Result<ChatResponse, InferenceError> {
+        let body = self.prepare_body(request);
+
+        let mut builder = self
+            .http
+            .post(&self.endpoint)
+            .header(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {}", self.api_key.expose()),
+            )
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
+        for (name, value) in &self.extra_headers {
+            builder = builder.header(name, value);
+        }
+
+        // `reqwest::Error` display carries the URL/kind but never a header value,
+        // so stringifying it cannot leak the API key.
+        let resp = builder
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| InferenceError::Transport(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(InferenceError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        // Read the full body first so the raw text can accompany a parse error.
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| InferenceError::Transport(e.to_string()))?;
+        serde_json::from_str::<ChatResponse>(&text).map_err(|e| InferenceError::Deserialise {
+            message: e.to_string(),
+            body: text,
+        })
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::registry::{ProviderId, capabilities};
+    use crate::inference::types::ChatMessage;
+
+    fn config_for(id: ProviderId, base_url: &str) -> OpenAiCompatConfig {
+        OpenAiCompatConfig {
+            name: id.as_str().to_string(),
+            base_url: base_url.to_string(),
+            api_key: SecretString::new("sk-test"), // pragma: allowlist secret
+            extra_headers: Vec::new(),
+            capabilities: *capabilities(id),
+        }
+    }
+
+    /// Why: the endpoint must be `<base>/chat/completions` regardless of a
+    /// trailing slash on the base URL.
+    /// Test: itself.
+    #[test]
+    fn endpoint_appends_path() {
+        let a =
+            OpenAiCompatAdapter::new(config_for(ProviderId::OpenAI, "https://api.openai.com/v1"))
+                .expect("build");
+        assert_eq!(a.endpoint(), "https://api.openai.com/v1/chat/completions");
+        let b =
+            OpenAiCompatAdapter::new(config_for(ProviderId::OpenAI, "https://api.openai.com/v1/"))
+                .expect("build");
+        assert_eq!(b.endpoint(), "https://api.openai.com/v1/chat/completions");
+    }
+
+    /// Why: OpenRouter (detailed_usage_accounting = true) must inject
+    /// `usage:{include:true}` so cost/cache accounting is returned.
+    /// Test: itself.
+    #[test]
+    fn usage_directive_injected() {
+        let a = OpenAiCompatAdapter::new(config_for(
+            ProviderId::OpenRouter,
+            "https://openrouter.ai/api/v1",
+        ))
+        .expect("build");
+        let req = ChatRequest::new("openai/gpt-4o-mini", vec![ChatMessage::user("hi")]);
+        let prepared = a.prepare_body(&req);
+        assert_eq!(prepared.usage, Some(RequestUsageConfig::detailed()));
+    }
+
+    /// Why: providers without detailed-usage accounting (Fireworks/OpenAI) must
+    /// never send the directive.
+    /// Test: itself.
+    #[test]
+    fn usage_directive_absent_without_detailed() {
+        for id in [ProviderId::Fireworks, ProviderId::OpenAI] {
+            let a =
+                OpenAiCompatAdapter::new(config_for(id, "https://example.test/v1")).expect("build");
+            let req = ChatRequest::new("m", vec![ChatMessage::user("hi")]);
+            assert!(
+                a.prepare_body(&req).usage.is_none(),
+                "{} must not inject usage",
+                id.as_str()
+            );
+        }
+    }
+
+    /// Why: a caller that already set `usage` must have it preserved, not
+    /// clobbered by the injection.
+    /// Test: itself.
+    #[test]
+    fn usage_directive_not_overwritten() {
+        let a = OpenAiCompatAdapter::new(config_for(
+            ProviderId::OpenRouter,
+            "https://openrouter.ai/api/v1",
+        ))
+        .expect("build");
+        let mut req = ChatRequest::new("m", vec![ChatMessage::user("hi")]);
+        req.usage = Some(RequestUsageConfig { include: false });
+        assert_eq!(
+            a.prepare_body(&req).usage,
+            Some(RequestUsageConfig { include: false })
+        );
+    }
+}

--- a/crates/trusty-common/src/inference/providers/openrouter.rs
+++ b/crates/trusty-common/src/inference/providers/openrouter.rs
@@ -1,0 +1,182 @@
+//! OpenRouter adapter — a thin config over the OpenAI-compatible core.
+//!
+//! Why: OpenRouter fronts dozens of model families behind one OpenAI-compatible
+//! `/chat/completions` schema and is the epic's default backend. Everything it
+//! needs beyond the shared core is a base URL, `Bearer` auth (handled by the
+//! core), attribution headers, and the `usage:{include:true}` detailed-usage
+//! flag — the last of which is already driven by the capability registry's
+//! `detailed_usage_accounting = true` for OpenRouter, so the core injects it
+//! automatically. Anthropic-style `cache_control` breakpoints set by the caller
+//! on `ChatMessage`/`FunctionDefinition` pass through unchanged (the core clones
+//! and serialises the request verbatim).
+//! What: [`build`] constructs an [`OpenAiCompatAdapter`] for a resolved
+//! OpenRouter credential against a given base URL; [`factory`] is the
+//! production factory (real base URL) registered into the [`Configurator`].
+//! Test: inline `#[ignore]` `live_openrouter_call`; offline round-trip in
+//! `crates/trusty-common/tests/inference_adapters.rs`.
+
+use super::openai_compat::{OpenAiCompatAdapter, OpenAiCompatConfig};
+use crate::inference::adapter::InferenceAdapter;
+use crate::inference::configurator::ResolvedProvider;
+use crate::inference::error::InferenceError;
+use crate::inference::registry::ProviderId;
+
+/// OpenRouter API root; the core appends `/chat/completions`.
+pub const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+
+/// `HTTP-Referer` attribution header value (mirrors tcode's live client).
+const OPENROUTER_REFERER: &str = "https://github.com/bobmatnyc/trusty-tools";
+
+/// `X-Title` attribution header value shown in OpenRouter dashboards.
+const OPENROUTER_TITLE: &str = "trusty-tools";
+
+/// Build an OpenRouter adapter for a resolved credential against `base_url`.
+///
+/// Why: the base URL is a parameter (not a constant) so tests can point the
+/// exact same adapter at [`crate::inference::test_support::MockInferenceServer`]
+/// while production uses [`OPENROUTER_BASE_URL`].
+/// What: requires the resolved key (OpenRouter is a keyed provider — a missing
+/// key is [`InferenceError::MissingCredential`], never a silent anonymous call),
+/// then constructs an [`OpenAiCompatAdapter`] with OpenRouter's attribution
+/// headers and its registry capabilities (which carry `detailed_usage_accounting
+/// = true`, so the core auto-injects `usage:{include:true}`).
+/// Test: `crates/trusty-common/tests/inference_adapters.rs`.
+pub fn build(
+    resolved: &ResolvedProvider,
+    base_url: &str,
+) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    let key = resolved
+        .key()
+        .ok_or(InferenceError::MissingCredential {
+            provider: ProviderId::OpenRouter,
+        })?
+        .clone();
+    let config = OpenAiCompatConfig {
+        name: ProviderId::OpenRouter.as_str().to_string(),
+        base_url: base_url.to_string(),
+        api_key: key,
+        extra_headers: vec![
+            ("HTTP-Referer".to_string(), OPENROUTER_REFERER.to_string()),
+            ("X-Title".to_string(), OPENROUTER_TITLE.to_string()),
+        ],
+        capabilities: *resolved.capabilities(),
+    };
+    Ok(Box::new(OpenAiCompatAdapter::new(config)?))
+}
+
+/// Production factory: build an OpenRouter adapter against the real base URL.
+///
+/// Why: this is what [`super::register_default_factories`] registers into the
+/// [`crate::inference::Configurator`] so `build("<slug>", &store)` yields a live
+/// OpenRouter adapter.
+/// What: delegates to [`build`] with [`OPENROUTER_BASE_URL`].
+/// Test: `crates/trusty-common/tests/inference_adapters.rs` (via a mock-URL
+/// factory) and the `#[ignore]` live smoke test below.
+pub fn factory(resolved: &ResolvedProvider) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    build(resolved, OPENROUTER_BASE_URL)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::registry::capabilities;
+    use crate::inference::types::{ChatMessage, ChatRequest, SecretString};
+
+    /// Construct a `ResolvedProvider` with a fake OpenRouter key, without going
+    /// through the env-sensitive resolver.
+    fn resolved(key: &str) -> ResolvedProvider {
+        ResolvedProvider::new(
+            ProviderId::OpenRouter,
+            "openai/gpt-4o-mini".to_string(),
+            Some(SecretString::new(key)),
+        )
+    }
+
+    /// Why: the factory must build a named OpenRouter adapter whose capabilities
+    /// request detailed usage accounting.
+    /// Test: itself.
+    #[test]
+    fn factory_builds_named_adapter() {
+        let adapter = build(&resolved("sk-or-test"), OPENROUTER_BASE_URL) // pragma: allowlist secret
+            .expect("built");
+        assert_eq!(adapter.name(), "openrouter");
+        assert!(adapter.wants_detailed_usage());
+        assert_eq!(adapter.capabilities().id, ProviderId::OpenRouter);
+    }
+
+    /// Why: a resolved provider with no key must be an explicit alarm, never a
+    /// silent anonymous adapter.
+    /// Test: itself.
+    #[test]
+    fn missing_key_errors() {
+        let resolved = ResolvedProvider::new(
+            ProviderId::OpenRouter,
+            "openai/gpt-4o-mini".to_string(),
+            None,
+        );
+        let Err(err) = build(&resolved, OPENROUTER_BASE_URL) else {
+            panic!("expected MissingCredential");
+        };
+        assert!(matches!(
+            err,
+            InferenceError::MissingCredential {
+                provider: ProviderId::OpenRouter
+            }
+        ));
+    }
+
+    /// Live smoke test: send a trivial prompt to a cheap OpenRouter model.
+    ///
+    /// Why: end-to-end validation against the real API that the OpenRouter
+    /// config + core produce a non-empty response and non-zero usage. Ignored so
+    /// CI stays offline; run locally with a real key.
+    /// What: reads `OPENROUTER_API_KEY` from env and SKIPS (does not fail) when
+    /// absent/empty; otherwise builds the adapter via [`build`] and asserts a
+    /// non-empty reply with `prompt_tokens > 0`.
+    /// Test: `cargo test -p trusty-common --features inference-client,axum-server \
+    ///        openrouter -- --ignored --nocapture` (with `OPENROUTER_API_KEY` set).
+    #[tokio::test]
+    #[ignore = "requires OPENROUTER_API_KEY; skipped in CI"]
+    async fn live_openrouter_call() {
+        let Ok(key) = std::env::var("OPENROUTER_API_KEY") else {
+            eprintln!("OPENROUTER_API_KEY not set — skipping live test");
+            return;
+        };
+        if key.trim().is_empty() {
+            eprintln!("OPENROUTER_API_KEY is empty — skipping live test");
+            return;
+        }
+
+        let resolved = ResolvedProvider::new(
+            ProviderId::OpenRouter,
+            "openai/gpt-4o-mini".to_string(),
+            Some(SecretString::new(key)),
+        );
+        let adapter = build(&resolved, OPENROUTER_BASE_URL).expect("build adapter");
+        let _ = capabilities(ProviderId::OpenRouter); // ensure registry link
+
+        let mut req = ChatRequest::new(
+            "openai/gpt-4o-mini",
+            vec![
+                ChatMessage::system("You are a concise assistant."),
+                ChatMessage::user("Reply with exactly the word: pong"),
+            ],
+        );
+        req.temperature = Some(0.0);
+        req.max_tokens = Some(16);
+
+        let resp = adapter.chat(&req).await.expect("live chat");
+        let text = resp.first_text().expect("assistant text");
+        assert!(!text.is_empty(), "assistant text was empty");
+        assert!(
+            resp.usage().prompt_tokens > 0,
+            "prompt_tokens should be > 0"
+        );
+        eprintln!(
+            "live openrouter ok — text: {text:?}, usage: {:?}",
+            resp.usage()
+        );
+    }
+}

--- a/crates/trusty-common/src/inference/test_support/http_mock.rs
+++ b/crates/trusty-common/src/inference/test_support/http_mock.rs
@@ -1,20 +1,27 @@
 //! [`MockInferenceServer`] — an in-process axum HTTP mock for adapter tests.
 //!
-//! Why: the concrete HTTP adapters that land in #2403/#2407 need to be tested
-//! against a real socket that returns canned chat/completions JSON — without a
+//! Why: the concrete HTTP adapters (#2403 OpenRouter/Fireworks/OpenAI, #2407
+//! Bedrock) must be tested against a real socket that returns canned
+//! chat/completions JSON AND records the request the adapter sent — without a
 //! live provider or credentials. This spins up a throwaway axum server on an
-//! ephemeral loopback port that answers every request with a fixed status+body,
-//! giving those future adapters a URL to point at. It is gated behind the
+//! ephemeral loopback port that answers every request with a fixed status+body
+//! while capturing each inbound request (method, path, headers, JSON body) so a
+//! test can assert the adapter's request translation. It is gated behind the
 //! `axum-server` feature so the base `inference-client` feature pulls in NO
 //! HTTP-server dependency (per the crate's axum-gating discipline).
 //! What: [`MockInferenceServer::spawn`] binds `127.0.0.1:0`, serves a fixed
-//! response from a fallback handler, and exposes [`MockInferenceServer::url`];
-//! dropping it triggers graceful shutdown.
-//! Test: inline `tests` — `mock_serves_canned_body` (feature-gated).
+//! response from a fallback handler, records every request into a shared buffer
+//! exposed via [`MockInferenceServer::requests`]/[`MockInferenceServer::last_request`],
+//! and exposes [`MockInferenceServer::url`]; dropping it triggers graceful
+//! shutdown.
+//! Test: inline `tests` — `mock_serves_canned_body`, `mock_captures_request_body`.
+
+use std::sync::{Arc, Mutex};
 
 use axum::Router;
+use axum::body::Bytes;
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
 use axum::response::IntoResponse;
 use serde_json::Value;
 use tokio::sync::oneshot;
@@ -22,28 +29,74 @@ use tokio::task::JoinHandle;
 
 use crate::inference::error::InferenceError;
 
+/// One request the mock received, captured for request-translation assertions.
+///
+/// Why: an adapter's whole job is turning a [`crate::inference::ChatRequest`]
+/// into the right wire bytes + headers; a test can only verify that if the mock
+/// remembers exactly what arrived. Recording the parsed JSON body plus the
+/// method/path/headers lets a test assert the outbound translation precisely.
+/// What: `method`/`path` from the request line, `headers` as lowercase
+/// name→value pairs, and `body` as the parsed JSON (or `None` when the body was
+/// absent or not JSON).
+/// Test: `mock_captures_request_body`.
+#[derive(Debug, Clone)]
+pub struct CapturedRequest {
+    /// HTTP method (e.g. `"POST"`).
+    pub method: String,
+    /// Request path (e.g. `"/v1/chat/completions"`).
+    pub path: String,
+    /// Request headers as lowercase-name → value pairs.
+    pub headers: Vec<(String, String)>,
+    /// Parsed JSON request body; `None` if the body was empty or not JSON.
+    pub body: Option<Value>,
+}
+
+impl CapturedRequest {
+    /// Look up a request header value by (case-insensitive) name.
+    ///
+    /// Why: header assertions (`Authorization`, `HTTP-Referer`, `X-Title`) read
+    /// cleaner as `req.header("authorization")` than by scanning the vec.
+    /// What: returns the first header whose lowercased name equals `name`
+    /// lowercased, or `None`.
+    /// Test: `mock_captures_request_body`.
+    pub fn header(&self, name: &str) -> Option<&str> {
+        let lower = name.to_ascii_lowercase();
+        self.headers
+            .iter()
+            .find(|(k, _)| *k == lower)
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+/// Shared, thread-safe buffer of captured requests.
+type CaptureBuf = Arc<Mutex<Vec<CapturedRequest>>>;
+
 /// A running in-process HTTP mock returning one fixed response.
 ///
-/// Why: the smallest real HTTP surface a future adapter can exercise end-to-end.
-/// What: owns the server task and a shutdown channel; [`Self::url`] is the base
-/// URL (`http://127.0.0.1:<port>`). Dropping the value signals graceful
-/// shutdown so no test leaks a listener.
-/// Test: `mock_serves_canned_body`.
+/// Why: the smallest real HTTP surface a concrete adapter can exercise
+/// end-to-end, with request capture so the adapter's translation is assertable.
+/// What: owns the server task, a shutdown channel, and the shared capture
+/// buffer; [`Self::url`] is the base URL (`http://127.0.0.1:<port>`). Dropping
+/// the value signals graceful shutdown so no test leaks a listener.
+/// Test: `mock_serves_canned_body`, `mock_captures_request_body`.
 pub struct MockInferenceServer {
     url: String,
+    captured: CaptureBuf,
     shutdown: Option<oneshot::Sender<()>>,
     handle: JoinHandle<()>,
 }
 
 impl MockInferenceServer {
-    /// Spawn a mock that answers every request with `status` + `body`.
+    /// Spawn a mock that answers every request with `status` + `body` and
+    /// records each inbound request.
     ///
-    /// Why: adapter tests script one provider response and point the adapter at
-    /// [`Self::url`].
+    /// Why: adapter tests script one provider response, point the adapter at
+    /// [`Self::url`], then read back the captured request via [`Self::requests`].
     /// What: binds an ephemeral loopback port, serves a fallback handler that
-    /// returns the canned `status`/`body` for any method/path, and returns the
-    /// running handle. Errors as [`InferenceError::Provider`] if the bind fails.
-    /// Test: `mock_serves_canned_body`.
+    /// captures the request and returns the canned `status`/`body` for any
+    /// method/path, and returns the running handle. Errors as
+    /// [`InferenceError::Provider`] if the bind fails.
+    /// Test: `mock_serves_canned_body`, `mock_captures_request_body`.
     pub async fn spawn(status: u16, body: Value) -> Result<Self, InferenceError> {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
@@ -55,9 +108,11 @@ impl MockInferenceServer {
 
         let status = StatusCode::from_u16(status)
             .map_err(|e| InferenceError::Provider(format!("invalid mock status: {e}")))?;
-        let app = Router::new()
-            .fallback(canned_handler)
-            .with_state((status, body));
+        let captured: CaptureBuf = Arc::new(Mutex::new(Vec::new()));
+        let app =
+            Router::new()
+                .fallback(canned_handler)
+                .with_state((status, body, captured.clone()));
 
         let (tx, rx) = oneshot::channel::<()>();
         let handle = tokio::spawn(async move {
@@ -70,6 +125,7 @@ impl MockInferenceServer {
 
         Ok(Self {
             url,
+            captured,
             shutdown: Some(tx),
             handle,
         })
@@ -82,6 +138,33 @@ impl MockInferenceServer {
     /// Test: `mock_serves_canned_body`.
     pub fn url(&self) -> &str {
         &self.url
+    }
+
+    /// Every request the mock has received so far, in arrival order.
+    ///
+    /// Why: request-translation assertions read the captured outbound body/headers.
+    /// What: returns a clone of the capture buffer; a poisoned lock is recovered
+    /// rather than propagated (test-support code must not panic the caller).
+    /// Test: `mock_captures_request_body`.
+    pub fn requests(&self) -> Vec<CapturedRequest> {
+        self.captured
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+    }
+
+    /// The most recent request the mock received, if any.
+    ///
+    /// Why: the common single-call assertion wants just "what did the adapter
+    /// send" without indexing.
+    /// What: the last element of [`Self::requests`], or `None` when none yet.
+    /// Test: `mock_captures_request_body`.
+    pub fn last_request(&self) -> Option<CapturedRequest> {
+        self.captured
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .last()
+            .cloned()
     }
 }
 
@@ -99,13 +182,40 @@ impl Drop for MockInferenceServer {
     }
 }
 
-/// Fallback handler returning the configured canned response.
+/// Fallback handler: capture the request, then return the canned response.
 ///
 /// Why: one handler answers every method/path so an adapter can target any
-/// endpoint shape (e.g. `/v1/chat/completions`).
-/// What: returns the `(status, body)` from router state as a JSON response.
-/// Test: `mock_serves_canned_body`.
-async fn canned_handler(State((status, body)): State<(StatusCode, Value)>) -> impl IntoResponse {
+/// endpoint shape (e.g. `/v1/chat/completions`) while its request is recorded.
+/// What: records method/path/headers/body into the shared buffer, then returns
+/// the `(status, body)` from router state as a JSON response. The `Bytes`
+/// body extractor is last, per axum's body-consuming-extractor ordering rule.
+/// Test: `mock_captures_request_body`.
+async fn canned_handler(
+    State((status, body, captured)): State<(StatusCode, Value, CaptureBuf)>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    raw: Bytes,
+) -> impl IntoResponse {
+    let recorded = CapturedRequest {
+        method: method.to_string(),
+        path: uri.path().to_string(),
+        headers: headers
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.as_str().to_ascii_lowercase(),
+                    v.to_str().unwrap_or_default().to_string(),
+                )
+            })
+            .collect(),
+        body: serde_json::from_slice::<Value>(&raw).ok(),
+    };
+    captured
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .push(recorded);
+
     (status, axum::Json(body))
 }
 
@@ -139,5 +249,28 @@ mod tests {
             .expect("json");
         assert_eq!(got["id"], "gen-mock");
         assert_eq!(got["choices"][0]["message"]["content"], "mocked");
+    }
+
+    /// Why: the mock must capture the outbound request body + headers so adapter
+    /// translation can be asserted.
+    /// Test: itself.
+    #[tokio::test]
+    async fn mock_captures_request_body() {
+        let server = MockInferenceServer::spawn(200, json!({"id": "x", "choices": []}))
+            .await
+            .expect("spawn");
+        reqwest::Client::new()
+            .post(format!("{}/v1/chat/completions", server.url()))
+            .header("Authorization", "Bearer sk-test") // pragma: allowlist secret
+            .json(&json!({"model": "m", "messages": []}))
+            .send()
+            .await
+            .expect("send");
+
+        let req = server.last_request().expect("one request captured");
+        assert_eq!(req.method, "POST");
+        assert_eq!(req.path, "/v1/chat/completions");
+        assert_eq!(req.header("authorization"), Some("Bearer sk-test")); // pragma: allowlist secret
+        assert_eq!(req.body.expect("json body")["model"], "m");
     }
 }

--- a/crates/trusty-common/tests/inference_adapters.rs
+++ b/crates/trusty-common/tests/inference_adapters.rs
@@ -1,0 +1,336 @@
+//! Offline e2e for the concrete inference adapters (issue #2403, epic #2400).
+//!
+//! Why: the acceptance criteria demand each adapter be driven through the full
+//! `Configurator` resolve→build→`chat`→`usage` cycle against a REAL socket
+//! ([`MockInferenceServer`]) — asserting BOTH the outbound request translation
+//! (the mock captures the body + headers the adapter sent) AND the response /
+//! usage parsing, without a live provider or network. This is the cycle #2402's
+//! `inference_foundation.rs` left as a placeholder ("where #2403's live-provider
+//! e2e attaches"); this file realises it for OpenRouter, Fireworks, and OpenAI.
+//! What: black-box tests against `trusty_common::inference::*`, pointing each
+//! provider's adapter core at the mock's URL through a `Configurator` factory.
+//! Requires `inference-client` (adapters) + `axum-server` (the mock).
+//! Test: this file — run with
+//! `cargo test -p trusty-common --features inference-client,axum-server`.
+
+use serde_json::{Value, json};
+use serial_test::serial;
+use trusty_common::inference::credentials::{KeyStore, MemoryKeyStore};
+use trusty_common::inference::providers::{fireworks, openai, openrouter};
+use trusty_common::inference::test_support::MockInferenceServer;
+use trusty_common::inference::{
+    CacheControl, ChatMessage, ChatRequest, Configurator, FunctionDefinition, InferenceError,
+    ProviderId, ResolvedProvider, ToolChoice, ToolDefinition, register_default_factories,
+};
+
+/// Clear every provider env var so the injected `MemoryKeyStore` is the only
+/// credential source (a stray `OPENROUTER_API_KEY` would otherwise shadow it).
+fn clear_provider_env() {
+    for var in [
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "FIREWORKS_API_KEY",
+    ] {
+        // SAFETY: every caller is `#[serial(dotenv_credential_env)]`, matching
+        // the lock the credential resolver's own env-mutating tests use.
+        unsafe { std::env::remove_var(var) };
+    }
+}
+
+/// A minimal successful chat/completions response body (text turn).
+fn text_response_body() -> Value {
+    json!({
+        "id": "gen-mock",
+        "model": "served/model",
+        "choices": [{
+            "message": {"role": "assistant", "content": "pong"},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 7, "completion_tokens": 1, "total_tokens": 8}
+    })
+}
+
+// ── OpenRouter: request translation + detailed-usage directive ───────────────────
+
+/// Why: driving OpenRouter through the `Configurator` must (a) send an
+/// OpenAI-shaped body with the model + messages, (b) inject `usage:{include:true}`
+/// (OpenRouter's detailed-usage flag), (c) attach the `Authorization` bearer and
+/// attribution headers, and (d) parse the response text back.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn openrouter_translates_request_and_parses_response() {
+    clear_provider_env();
+    let server = MockInferenceServer::spawn(200, text_response_body())
+        .await
+        .expect("spawn mock");
+    let base = server.url().to_string();
+
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-fake").unwrap(); // pragma: allowlist secret
+
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::OpenRouter,
+        Box::new(move |r: &ResolvedProvider| openrouter::build(r, &base)),
+    );
+
+    let adapter = cfg.build("openai/gpt-4o-mini", &store).expect("build");
+    assert_eq!(adapter.name(), "openrouter");
+
+    let req = ChatRequest::new("openai/gpt-4o-mini", vec![ChatMessage::user("ping")]);
+    let resp = adapter.chat(&req).await.expect("chat ok");
+
+    // Response parsing.
+    assert_eq!(resp.first_text().as_deref(), Some("pong"));
+    assert_eq!(resp.usage().total_tokens(), 8);
+
+    // Request translation captured by the mock.
+    let sent = server.last_request().expect("captured request");
+    assert_eq!(sent.method, "POST");
+    assert_eq!(sent.path, "/chat/completions");
+    assert_eq!(sent.header("authorization"), Some("Bearer sk-or-fake")); // pragma: allowlist secret
+    assert_eq!(
+        sent.header("http-referer"),
+        Some("https://github.com/bobmatnyc/trusty-tools")
+    );
+    assert_eq!(sent.header("x-title"), Some("trusty-tools"));
+    let body = sent.body.expect("json body");
+    assert_eq!(body["model"], "openai/gpt-4o-mini");
+    assert_eq!(body["messages"][0]["content"], "ping");
+    // OpenRouter detailed-usage directive injected by the core.
+    assert_eq!(body["usage"], json!({"include": true}));
+}
+
+/// Why: the cache-token accounting path must parse OpenRouter's nested
+/// `prompt_tokens_details` into the normalized `Usage` cache buckets, and a
+/// caller-set `cache_control` breakpoint must pass through onto the wire.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn openrouter_cache_accounting_and_passthrough() {
+    clear_provider_env();
+    let body = json!({
+        "id": "gen-cache",
+        "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+        "usage": {
+            "prompt_tokens": 1200,
+            "completion_tokens": 40,
+            "cost": 0.0021,
+            "prompt_tokens_details": {"cached_tokens": 900, "cache_write_tokens": 300}
+        }
+    });
+    let server = MockInferenceServer::spawn(200, body).await.expect("spawn");
+    let base = server.url().to_string();
+
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-fake").unwrap(); // pragma: allowlist secret
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::OpenRouter,
+        Box::new(move |r: &ResolvedProvider| openrouter::build(r, &base)),
+    );
+    let adapter = cfg
+        .build("anthropic/claude-sonnet-4-5", &store)
+        .expect("build");
+
+    // Caller marks the system prefix as a cache breakpoint.
+    let mut sys = ChatMessage::system("cache me");
+    sys.cache_control = Some(CacheControl::ephemeral());
+    let req = ChatRequest::new(
+        "anthropic/claude-sonnet-4-5",
+        vec![sys, ChatMessage::user("go")],
+    );
+    let resp = adapter.chat(&req).await.expect("chat ok");
+
+    // Nested cache counters flowed into normalized Usage.
+    let usage = resp.usage();
+    assert_eq!(usage.cache_read_tokens, 900);
+    assert_eq!(usage.cache_creation_tokens, 300);
+    assert_eq!(usage.cost_usd, Some(0.0021));
+
+    // cache_control passthrough: system content serialised as the block array.
+    let sent = server.last_request().expect("captured");
+    let body = sent.body.expect("json");
+    assert_eq!(
+        body["messages"][0]["content"],
+        json!([{
+            "type": "text",
+            "text": "cache me",
+            "cache_control": {"type": "ephemeral"}
+        }])
+    );
+}
+
+// ── Fireworks: no detailed-usage directive + tool-call round-trip ────────────────
+
+/// Why: Fireworks must NOT inject the detailed-usage directive, must send tools +
+/// the OpenAI-dialect `tool_choice`, and must parse a tool-call response
+/// (round-trip through the full configurator cycle).
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn fireworks_tool_call_round_trip_no_usage_directive() {
+    clear_provider_env();
+    let body = json!({
+        "id": "gen-fw",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{\"loc\":\"SEA\"}"}
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 20, "completion_tokens": 8}
+    });
+    let server = MockInferenceServer::spawn(200, body).await.expect("spawn");
+    let base = server.url().to_string();
+
+    let store = MemoryKeyStore::new();
+    // Fireworks key present AND explicit fireworks/ prefix → resolves to Fireworks.
+    store.set("fireworks", "fw-fake").unwrap(); // pragma: allowlist secret
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::Fireworks,
+        Box::new(move |r: &ResolvedProvider| fireworks::build(r, &base)),
+    );
+
+    let adapter = cfg
+        .build("fireworks/llama-v3p1-8b-instruct", &store)
+        .expect("build");
+    assert_eq!(adapter.name(), "fireworks");
+
+    let mut req = ChatRequest::new(
+        "accounts/fireworks/models/llama-v3p1-8b-instruct",
+        vec![ChatMessage::user("weather in SEA?")],
+    );
+    req.tools = Some(vec![ToolDefinition::function(FunctionDefinition {
+        name: "get_weather".into(),
+        description: Some("look up weather".into()),
+        parameters: Some(json!({"type": "object"})),
+        cache_control: None,
+    })]);
+    req.tool_choice = Some(adapter.map_tool_choice(ToolChoice::Auto));
+
+    let resp = adapter.chat(&req).await.expect("chat ok");
+
+    // Tool-call response parsing.
+    let calls = resp.first_tool_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.name, "get_weather");
+
+    // Request translation: tools + tool_choice present, NO usage directive.
+    let sent = server.last_request().expect("captured");
+    assert_eq!(sent.header("authorization"), Some("Bearer fw-fake")); // pragma: allowlist secret
+    let body = sent.body.expect("json");
+    assert_eq!(body["tools"][0]["function"]["name"], "get_weather");
+    assert_eq!(body["tool_choice"], "auto");
+    assert!(
+        body.get("usage").is_none() || body["usage"].is_null(),
+        "Fireworks must not send the detailed-usage directive: {body}"
+    );
+}
+
+// ── OpenAI-direct: bare OpenAI body via the shared core ──────────────────────────
+
+/// Why: the OpenAI-direct adapter must send a bare OpenAI-compatible body (bearer
+/// auth, no attribution headers, no usage directive) and parse the response.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn openai_direct_sends_bare_body() {
+    clear_provider_env();
+    let server = MockInferenceServer::spawn(200, text_response_body())
+        .await
+        .expect("spawn");
+    let base = server.url().to_string();
+
+    let store = MemoryKeyStore::new();
+    store.set("openai", "sk-openai-fake").unwrap(); // pragma: allowlist secret
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::OpenAI,
+        Box::new(move |r: &ResolvedProvider| openai::build(r, &base)),
+    );
+
+    // Explicit openai/ prefix + resolvable OPENAI key → OpenAI-direct.
+    let adapter = cfg.build("openai/gpt-4o-mini", &store).expect("build");
+    assert_eq!(adapter.name(), "openai");
+
+    let req = ChatRequest::new("gpt-4o-mini", vec![ChatMessage::user("ping")]);
+    let resp = adapter.chat(&req).await.expect("chat ok");
+    assert_eq!(resp.first_text().as_deref(), Some("pong"));
+
+    let sent = server.last_request().expect("captured");
+    assert_eq!(sent.header("authorization"), Some("Bearer sk-openai-fake")); // pragma: allowlist secret
+    assert!(sent.header("http-referer").is_none());
+    let body = sent.body.expect("json");
+    assert!(
+        body.get("usage").is_none() || body["usage"].is_null(),
+        "OpenAI-direct must not send the detailed-usage directive"
+    );
+}
+
+// ── Error classification through a real socket ───────────────────────────────────
+
+/// Why: a non-2xx provider status must surface as a classified `InferenceError`
+/// — a 429 is retryable (not an alarm), driven end-to-end through the adapter.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn http_429_maps_to_retryable_api_error() {
+    clear_provider_env();
+    let server = MockInferenceServer::spawn(429, json!({"error": "rate limited"}))
+        .await
+        .expect("spawn");
+    let base = server.url().to_string();
+
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-fake").unwrap(); // pragma: allowlist secret
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::OpenRouter,
+        Box::new(move |r: &ResolvedProvider| openrouter::build(r, &base)),
+    );
+    let adapter = cfg.build("x/y", &store).expect("build");
+
+    let req = ChatRequest::new("x/y", vec![ChatMessage::user("hi")]);
+    let Err(err) = adapter.chat(&req).await else {
+        panic!("expected an API error");
+    };
+    assert!(matches!(err, InferenceError::Api { status: 429, .. }));
+    assert!(err.is_retryable());
+    assert!(!err.is_alarm());
+}
+
+// ── Default factory registration ─────────────────────────────────────────────────
+
+/// Why: `register_default_factories` must wire the three OpenAI-dialect providers
+/// so a bare/OpenRouter slug builds a real adapter through the public entry point
+/// (Bedrock stays unregistered — a later wave).
+#[test]
+#[serial(dotenv_credential_env)]
+fn default_factories_register_three() {
+    clear_provider_env();
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-fake").unwrap(); // pragma: allowlist secret
+
+    let mut cfg = Configurator::new();
+    register_default_factories(&mut cfg);
+
+    // OpenRouter default path builds a real adapter.
+    let adapter = cfg.build("some/model", &store).expect("build openrouter");
+    assert_eq!(adapter.name(), "openrouter");
+
+    // Bedrock is intentionally not registered by the default set.
+    let Err(err) = cfg.build("bedrock/us.anthropic.claude-sonnet-4-5", &store) else {
+        panic!("expected NoAdapterRegistered for Bedrock");
+    };
+    assert!(matches!(
+        err,
+        InferenceError::NoAdapterRegistered {
+            provider: ProviderId::Bedrock
+        }
+    ));
+}


### PR DESCRIPTION
## Summary

Wave-1 slice 3 of the inference-adapter epic #2400, built directly on the merged foundation from #2401 (KeyStore) and #2402 (InferenceAdapter trait, capability registry, Configurator).

- **`providers::openai_compat::OpenAiCompatAdapter`** — the shared OpenAI-compatible HTTP core. Translates `ChatRequest` -> OpenAI `/chat/completions` JSON (messages, tools, tool_choice via the existing `openai_tool_choice` mapper, temperature, max_tokens, stop), conditionally injects the OpenRouter detailed-usage directive (`usage:{include:true}`) only for capabilities that request it, POSTs via `reqwest`, and maps HTTP/status/error bodies to `InferenceError` with correct `is_retryable` classification (429/5xx retryable, 4xx auth/validation not). The API key never appears in a log line or error — it only ever reaches the `Authorization` header, held as a `SecretString` end to end.
- **`providers::openrouter`** / **`providers::fireworks`** / **`providers::openai`** — thin configs (base URL, attribution headers, capabilities) over the shared core. OpenRouter carries the `HTTP-Referer`/`X-Title` attribution headers; Fireworks and OpenAI send a bare body. A third provider (OpenAI-direct) is included beyond the two named in the issue title — the registry/resolver from #2402 already special-case `openai/*` slugs and the core needed zero changes to support it, so it was effectively free.
- **`register_default_factories(&mut Configurator)`** wires all three into the construction seam #2402 left open, so `provider_for("openrouter"|"fireworks"|"openai", &store)` (via `Configurator::build`) now produces a real `Box<dyn InferenceAdapter>` instead of only the test-only `ScriptedAdapter`. Bedrock/Anthropic-direct stay unregistered (later waves, #2407/#2408).
- **`test_support::MockInferenceServer`** gained request capture (method, path, headers, parsed JSON body) via `requests()`/`last_request()`, so the offline e2e suite can assert BOTH the outbound request translation the adapter sent AND the response/usage parsing it produced — not just one side of the round trip.

## Testability

- **Offline / deterministic (runs in CI):** `crates/trusty-common/tests/inference_adapters.rs` drives all three adapters through the full `Configurator` resolve -> build -> `chat` -> `usage` cycle against the mock server:
  - OpenRouter: request translation (model/messages/headers/bearer-auth), the `usage:{include:true}` directive injection, OpenRouter's nested `prompt_tokens_details` cache-token accounting, and `cache_control` passthrough on a system message.
  - Fireworks: a full tool-call round trip (tools + `tool_choice` sent, `tool_calls` parsed back) with confirmation the detailed-usage directive is NOT sent.
  - OpenAI-direct: a bare-body round trip with no attribution headers and no usage directive.
  - HTTP 429 mapped through a live socket to a retryable, non-alarm `InferenceError::Api`.
  - `register_default_factories` end-to-end (OpenRouter builds; Bedrock correctly stays `NoAdapterRegistered`).
- **Live smoke (`#[ignore]`, never runs in CI):** `live_openrouter_call` and `live_fireworks_call` hit the real API only when `OPENROUTER_API_KEY`/`FIREWORKS_API_KEY` are present in env, and skip gracefully (not fail) otherwise. Run locally with:
  ```
  OPENROUTER_API_KEY=... cargo test -p trusty-common --features inference-client,axum-server openrouter -- --ignored --nocapture
  FIREWORKS_API_KEY=... cargo test -p trusty-common --features inference-client,axum-server fireworks -- --ignored --nocapture
  ```

## Feature gating

Everything lands behind `inference-client` (the new `providers` module is `#[cfg(feature = "inference-client")]`, matching `adapter`/`configurator`/`registry`). `reqwest` was already an unconditional workspace dependency of `trusty-common` pre-existing this PR (used by the `rpc`/`server` modules) — this PR does not change its gating or add a new dependency, it reuses what was already present. Confirmed `cargo build -p trusty-common` (no features) still builds and does not compile the `providers` module.

## Quality gates (raw output)

- `cargo build --workspace` — clean, `Finished` in 2m08s
- `cargo build -p trusty-common` (no features) — clean
- `cargo test -p trusty-common --features inference-client` — clean, 225 lib tests passed, 8 ignored (both live smokes + pre-existing ignored tests), 0 failed
- `cargo test -p trusty-common --features inference-client,axum-server` — clean, 230 lib tests + 6/6 `inference_adapters.rs` + 9/9 `inference_foundation.rs`, 0 failed
- `cargo test --workspace` — clean, 0 failed across the whole workspace (the known `trusty-console` loopback-port flake did not manifest this run)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo clippy -p trusty-common --features inference-client -- -D warnings` and `--features inference-client,axum-server --all-targets` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations`

## Scope divergence vs #2403

- Added a third adapter (**OpenAI-direct**) beyond the two named in the issue title (OpenRouter, Fireworks). The issue's own acceptance criteria only list OpenRouter + Fireworks, but the #2402 registry/resolver already model `ProviderId::OpenAI` with its own credential env and slug prefix, and the shared core requires zero provider-specific code to support it — so it was added as a natural extension of "OpenAI-compat core" rather than treated as out of scope. Happy to split it into a follow-up if preferred.
- Per the review comment on #2403, `UsageBlock` serde deserialization is correct for all three providers in this ticket (OpenRouter/Fireworks/OpenAI all speak the OpenAI-shaped wire format) — no hand-construction of `Usage` was needed here. That caveat applies only to Bedrock/Anthropic-native (#2407/#2408), out of scope.

## Test plan

- [x] `cargo test -p trusty-common --features inference-client,axum-server` — offline e2e drives OpenRouter, Fireworks, and OpenAI through the full Configurator cycle
- [x] `cargo test --workspace` — no regressions
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check_line_cap.sh` — clean
- [ ] Live smoke tests (`--ignored`) — not run in this PR (require real provider keys); documented above for local verification

Closes #2403
Part of epic #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)