### PR TITLE
feat(trusty-common): add Together.ai as an OpenAI-compat inference provider

### DIFF
--- a/crates/trusty-common/src/inference/providers/mod.rs
+++ b/crates/trusty-common/src/inference/providers/mod.rs
@@ -9,7 +9,7 @@
 //! `provider_for("openrouter" | "fireworks" | "openai", &store)` builds a REAL
 //! `Box<dyn InferenceAdapter>`.
 //! What: [`openai_compat::OpenAiCompatAdapter`] (the core) and the
-//! [`openrouter`]/[`fireworks`]/[`openai`] provider configs, plus
+//! [`openrouter`]/[`fireworks`]/[`openai`]/[`together`] provider configs, plus
 //! [`register_default_factories`]. Anthropic-dialect providers (Bedrock #2407,
 //! Anthropic-direct #2408) are out of scope here.
 //! Test: each submodule's inline `tests` + the offline mock-server round-trip in
@@ -19,6 +19,7 @@ pub mod fireworks;
 pub mod openai;
 pub mod openai_compat;
 pub mod openrouter;
+pub mod together;
 
 pub use openai_compat::{OpenAiCompatAdapter, OpenAiCompatConfig};
 
@@ -31,12 +32,14 @@ use crate::inference::registry::ProviderId;
 /// adapter this ticket ships, rather than remembering each `register` line. The
 /// configurator stays empty by default (no implicit adapters) — this is the
 /// explicit opt-in that turns resolution into live adapters.
-/// What: registers the OpenRouter, Fireworks, and OpenAI production factories
-/// (each pointed at its real base URL) under their [`ProviderId`]. Bedrock and
-/// Anthropic-direct are intentionally NOT registered here (later waves).
-/// Test: `crates/trusty-common/tests/inference_adapters.rs::default_factories_register_three`.
+/// What: registers the OpenRouter, Fireworks, OpenAI, and Together (#2488)
+/// production factories (each pointed at its real base URL) under their
+/// [`ProviderId`]. Bedrock and Anthropic-direct are intentionally NOT registered
+/// here (later waves).
+/// Test: `crates/trusty-common/tests/inference_adapters.rs::default_factories_register_openai_dialect`.
 pub fn register_default_factories(cfg: &mut Configurator) {
     cfg.register(ProviderId::OpenRouter, Box::new(openrouter::factory));
     cfg.register(ProviderId::Fireworks, Box::new(fireworks::factory));
     cfg.register(ProviderId::OpenAI, Box::new(openai::factory));
+    cfg.register(ProviderId::Together, Box::new(together::factory));
 }

--- a/crates/trusty-common/src/inference/providers/together.rs
+++ b/crates/trusty-common/src/inference/providers/together.rs
@@ -1,0 +1,170 @@
+//! Together.ai adapter — a thin config over the OpenAI-compatible core (#2488).
+//!
+//! Why: Together.ai serves its catalog (`meta-llama/*`, `Qwen/*`,
+//! `deepseek-ai/*`, …) behind the same OpenAI-compatible `/chat/completions`
+//! schema, so it reuses the shared core wholesale. Its only deltas from
+//! OpenRouter are the base URL (`api.together.xyz/v1`), no attribution headers,
+//! and — per the capability registry seed — `detailed_usage_accounting = false`
+//! (the `usage:{include:true}` directive is OpenRouter-specific). Together's
+//! prompt caching is AUTOMATIC/implicit (no explicit `cache_control`
+//! breakpoints), modeled exactly like OpenAI-direct in the registry. Native
+//! OpenAI-style tool-calling stays on.
+//! What: [`build`] constructs an [`OpenAiCompatAdapter`] for a resolved Together
+//! credential against a given base URL; [`factory`] is the production factory
+//! (real base URL) registered into the [`crate::inference::Configurator`].
+//! Test: inline `#[ignore]` `live_together_call`; offline round-trip in
+//! `crates/trusty-common/tests/inference_adapters.rs`.
+
+use super::openai_compat::{OpenAiCompatAdapter, OpenAiCompatConfig};
+use crate::inference::adapter::InferenceAdapter;
+use crate::inference::configurator::ResolvedProvider;
+use crate::inference::error::InferenceError;
+use crate::inference::registry::ProviderId;
+
+/// Together.ai API root; the core appends `/chat/completions`.
+pub const TOGETHER_BASE_URL: &str = "https://api.together.xyz/v1";
+
+/// Build a Together adapter for a resolved credential against `base_url`.
+///
+/// Why: the base URL is a parameter (not a constant) so tests can point the
+/// exact same adapter at [`crate::inference::test_support::MockInferenceServer`]
+/// while production uses [`TOGETHER_BASE_URL`].
+/// What: requires the resolved key (Together is a keyed provider — a missing key
+/// is [`InferenceError::MissingCredential`]), then constructs an
+/// [`OpenAiCompatAdapter`] with no attribution headers and Together's registry
+/// capabilities (`detailed_usage_accounting = false`), so the core sends a bare
+/// OpenAI-compatible body.
+/// Test: `crates/trusty-common/tests/inference_adapters.rs`.
+pub fn build(
+    resolved: &ResolvedProvider,
+    base_url: &str,
+) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    let key = resolved
+        .key()
+        .ok_or(InferenceError::MissingCredential {
+            provider: ProviderId::Together,
+        })?
+        .clone();
+    let config = OpenAiCompatConfig {
+        name: ProviderId::Together.as_str().to_string(),
+        base_url: base_url.to_string(),
+        api_key: key,
+        extra_headers: Vec::new(),
+        capabilities: *resolved.capabilities(),
+    };
+    Ok(Box::new(OpenAiCompatAdapter::new(config)?))
+}
+
+/// Production factory: build a Together adapter against the real base URL.
+///
+/// Why: this is what [`super::register_default_factories`] registers into the
+/// [`crate::inference::Configurator`] so a `together/*` slug (whose key
+/// resolves) yields a live Together adapter.
+/// What: delegates to [`build`] with [`TOGETHER_BASE_URL`].
+/// Test: `crates/trusty-common/tests/inference_adapters.rs` (via a mock-URL
+/// factory) and the `#[ignore]` live smoke test below.
+pub fn factory(resolved: &ResolvedProvider) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    build(resolved, TOGETHER_BASE_URL)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::types::{ChatMessage, ChatRequest, SecretString};
+
+    const TOGETHER_MODEL: &str = "meta-llama/Llama-3.3-70B-Instruct-Turbo";
+
+    fn resolved(key: &str) -> ResolvedProvider {
+        ResolvedProvider::new(
+            ProviderId::Together,
+            "together/meta-llama/Llama-3.3-70B-Instruct-Turbo".to_string(),
+            Some(SecretString::new(key)),
+        )
+    }
+
+    /// Why: the factory must build a named Together adapter that does NOT request
+    /// detailed usage accounting and advertises native OpenAI-style tools.
+    /// Test: itself.
+    #[test]
+    fn factory_builds_named_adapter() {
+        let adapter = build(&resolved("tgp_v1_test"), TOGETHER_BASE_URL).expect("built");
+        assert_eq!(adapter.name(), "together");
+        assert!(!adapter.wants_detailed_usage());
+        assert!(adapter.supports_native_tools());
+        assert_eq!(adapter.capabilities().id, ProviderId::Together);
+    }
+
+    /// Why: a resolved provider with no key must be an explicit alarm.
+    /// Test: itself.
+    #[test]
+    fn missing_key_errors() {
+        let resolved = ResolvedProvider::new(
+            ProviderId::Together,
+            "together/meta-llama/Llama-3.3-70B-Instruct-Turbo".to_string(),
+            None,
+        );
+        let Err(err) = build(&resolved, TOGETHER_BASE_URL) else {
+            panic!("expected MissingCredential");
+        };
+        assert!(matches!(
+            err,
+            InferenceError::MissingCredential {
+                provider: ProviderId::Together
+            }
+        ));
+    }
+
+    /// Live smoke test: send a trivial prompt to a cheap Together model.
+    ///
+    /// Why: end-to-end validation against the real API that the Together config
+    /// + core produce a non-empty response and non-zero usage. Ignored so CI
+    /// stays offline; run locally with a real key.
+    /// What: reads `TOGETHER_API_KEY` from env and SKIPS (does not fail) when
+    /// absent/empty; otherwise builds the adapter via [`build`] and asserts a
+    /// non-empty reply with `prompt_tokens > 0`.
+    /// Test: `cargo test -p trusty-common --features inference-client,axum-server \
+    ///        together -- --ignored --nocapture` (with `TOGETHER_API_KEY` set).
+    #[tokio::test]
+    #[ignore = "requires TOGETHER_API_KEY; skipped in CI"]
+    async fn live_together_call() {
+        let Ok(key) = std::env::var("TOGETHER_API_KEY") else {
+            eprintln!("TOGETHER_API_KEY not set — skipping live test");
+            return;
+        };
+        if key.trim().is_empty() {
+            eprintln!("TOGETHER_API_KEY is empty — skipping live test");
+            return;
+        }
+
+        let resolved = ResolvedProvider::new(
+            ProviderId::Together,
+            TOGETHER_MODEL.to_string(),
+            Some(SecretString::new(key)),
+        );
+        let adapter = build(&resolved, TOGETHER_BASE_URL).expect("build adapter");
+
+        let mut req = ChatRequest::new(
+            TOGETHER_MODEL,
+            vec![
+                ChatMessage::system("You are a concise assistant."),
+                ChatMessage::user("Reply with exactly the word: pong"),
+            ],
+        );
+        req.temperature = Some(0.0);
+        req.max_tokens = Some(16);
+
+        let resp = adapter.chat(&req).await.expect("live chat");
+        let text = resp.first_text().expect("assistant text");
+        assert!(!text.is_empty(), "assistant text was empty");
+        assert!(
+            resp.usage().prompt_tokens > 0,
+            "prompt_tokens should be > 0"
+        );
+        eprintln!(
+            "live together ok — text: {text:?}, usage: {:?}",
+            resp.usage()
+        );
+    }
+}

--- a/crates/trusty-common/src/inference/registry/mod.rs
+++ b/crates/trusty-common/src/inference/registry/mod.rs
@@ -22,12 +22,13 @@ pub use pricing::{Pricing, pricing};
 
 use std::fmt;
 
-/// One of the five inference providers epic #2400 targets.
+/// One of the inference providers epic #2400 targets (the original five plus the
+/// extension providers added in later waves — Together via #2488).
 ///
 /// Why: a closed enum (rather than a bare string) lets the configurator and the
 /// registry share one exhaustively-matched identity, so adding a provider is a
 /// compile error until every match arm is handled.
-/// What: the five target providers. `Bedrock` authenticates via the AWS
+/// What: the target providers. `Bedrock` authenticates via the AWS
 /// credential chain (no API key), which is why [`Self::credential_name`] returns
 /// `None` for it.
 /// Test: `provider_id_round_trips`, `from_slug_prefix_matches`.
@@ -43,6 +44,8 @@ pub enum ProviderId {
     Anthropic,
     /// OpenAI first-party API.
     OpenAI,
+    /// Together.ai (OpenAI-compatible inference; extension provider, #2488).
+    Together,
 }
 
 impl ProviderId {
@@ -51,7 +54,8 @@ impl ProviderId {
     ///
     /// Why: one canonical spelling per provider that never changes across
     /// releases.
-    /// What: `"openrouter"`, `"fireworks"`, `"bedrock"`, `"anthropic"`, `"openai"`.
+    /// What: `"openrouter"`, `"fireworks"`, `"bedrock"`, `"anthropic"`,
+    /// `"openai"`, `"together"`.
     /// Test: `provider_id_round_trips`.
     pub fn as_str(self) -> &'static str {
         match self {
@@ -60,6 +64,7 @@ impl ProviderId {
             Self::Bedrock => "bedrock",
             Self::Anthropic => "anthropic",
             Self::OpenAI => "openai",
+            Self::Together => "together",
         }
     }
 
@@ -82,8 +87,8 @@ impl ProviderId {
     /// Resolve a provider from an explicit `<prefix>/…` model slug.
     ///
     /// Why: stage 1 of the configurator's two-stage resolver keys off the slug
-    /// prefix (`bedrock/`, `fireworks/`, `anthropic/`, `openai/`, `openrouter/`);
-    /// this is the single mapping it uses.
+    /// prefix (`bedrock/`, `fireworks/`, `anthropic/`, `openai/`, `together/`,
+    /// `openrouter/`); this is the single mapping it uses.
     /// What: matches the segment before the first `/` case-insensitively;
     /// returns `None` for a bare slug or an unrecognised prefix (the caller then
     /// falls back to the OpenRouter default).
@@ -96,6 +101,7 @@ impl ProviderId {
             "bedrock" => Some(Self::Bedrock),
             "anthropic" => Some(Self::Anthropic),
             "openai" => Some(Self::OpenAI),
+            "together" => Some(Self::Together),
             _ => None,
         }
     }
@@ -173,7 +179,7 @@ pub struct ProviderCapabilities {
     pub credential_env: Option<&'static str>,
 }
 
-/// Seed capability table for the five target providers.
+/// Seed capability table for the target providers.
 ///
 /// Why: a single static source of truth. Values are a documented BEST-EFFORT
 /// seed sufficient for the foundation; the concrete adapters in #2403 refine
@@ -181,8 +187,8 @@ pub struct ProviderCapabilities {
 /// `provider::openrouter`/`bedrock` (native-tool + caching posture) and
 /// trusty-review's model notes (structured output).
 /// What: one entry per [`ProviderId`], indexed by [`capabilities`].
-/// Test: `all_five_providers_seeded`.
-const SEED: [ProviderCapabilities; 5] = [
+/// Test: `all_providers_seeded`.
+const SEED: [ProviderCapabilities; 6] = [
     ProviderCapabilities {
         id: ProviderId::OpenRouter,
         native_tool_calling: true,
@@ -248,6 +254,28 @@ const SEED: [ProviderCapabilities; 5] = [
         default_model: "gpt-4o-mini",
         credential_env: Some("OPENAI_API_KEY"),
     },
+    // Together.ai (#2488) — OpenAI-compatible `/chat/completions`, Bearer auth,
+    // native OpenAI-style tool calling. Caching is AUTOMATIC/implicit on
+    // Together's side (no explicit `cache_control` breakpoint markers), so this
+    // is modeled exactly like OpenAI-direct: `prompt_caching = true` (caching
+    // happens, the caller simply cannot place breakpoints) and
+    // `detailed_usage_accounting = false` (the OpenRouter usage directive is
+    // OpenRouter-specific). #2483 is tightening what `prompt_caching` means; when
+    // it lands, revisit this flag alongside OpenAI-direct's. Default model is a
+    // current, tool-calling, 128K-context Llama slug from Together's catalog.
+    ProviderCapabilities {
+        id: ProviderId::Together,
+        native_tool_calling: true,
+        tool_dialect: ToolDialect::OpenAiFunctions,
+        streaming: true,
+        prompt_caching: true,
+        structured_output: true,
+        vision: false,
+        detailed_usage_accounting: false,
+        max_context_window: 128_000,
+        default_model: "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        credential_env: Some("TOGETHER_API_KEY"),
+    },
 ];
 
 /// Look up the capability descriptor for a provider.
@@ -302,6 +330,7 @@ mod tests {
             ProviderId::Bedrock,
             ProviderId::Anthropic,
             ProviderId::OpenAI,
+            ProviderId::Together,
         ] {
             assert_eq!(id.to_string(), id.as_str());
             assert_eq!(ProviderId::from_slug_prefix(&format!("{id}/x")), Some(id));
@@ -343,19 +372,42 @@ mod tests {
     /// Why: every provider must be seeded and queryable by id and by name.
     /// Test: itself.
     #[test]
-    fn all_five_providers_seeded() {
-        assert_eq!(all().len(), 5);
+    fn all_providers_seeded() {
+        assert_eq!(all().len(), 6);
         for id in [
             ProviderId::OpenRouter,
             ProviderId::Fireworks,
             ProviderId::Bedrock,
             ProviderId::Anthropic,
             ProviderId::OpenAI,
+            ProviderId::Together,
         ] {
             let caps = capabilities(id);
             assert_eq!(caps.id, id);
             assert!(caps.max_context_window >= 128_000);
         }
+    }
+
+    /// Why: Together (#2488) must resolve by id, by name, and by slug prefix, and
+    /// carry its OpenAI-compat capability posture (native tools, OpenAI dialect,
+    /// `TOGETHER_API_KEY` credential env).
+    /// Test: itself.
+    #[test]
+    fn together_seeded_with_openai_compat_posture() {
+        assert_eq!(
+            ProviderId::from_slug_prefix("together/meta-llama/Llama-3.3-70B-Instruct-Turbo"),
+            Some(ProviderId::Together)
+        );
+        let caps = capabilities(ProviderId::Together);
+        assert_eq!(caps.id, ProviderId::Together);
+        assert!(caps.native_tool_calling);
+        assert_eq!(caps.tool_dialect, ToolDialect::OpenAiFunctions);
+        assert_eq!(caps.credential_env, Some("TOGETHER_API_KEY"));
+        assert_eq!(
+            capabilities_for("Together").map(|c| c.id),
+            Some(ProviderId::Together)
+        );
+        assert_eq!(ProviderId::Together.credential_name(), Some("together"));
     }
 
     /// Why: the by-name query must be case-insensitive and total for knowns.

--- a/crates/trusty-common/tests/inference_adapters.rs
+++ b/crates/trusty-common/tests/inference_adapters.rs
@@ -16,7 +16,7 @@
 use serde_json::{Value, json};
 use serial_test::serial;
 use trusty_common::inference::credentials::{KeyStore, MemoryKeyStore};
-use trusty_common::inference::providers::{fireworks, openai, openrouter};
+use trusty_common::inference::providers::{fireworks, openai, openrouter, together};
 use trusty_common::inference::test_support::MockInferenceServer;
 use trusty_common::inference::{
     CacheControl, ChatMessage, ChatRequest, Configurator, FunctionDefinition, InferenceError,
@@ -31,6 +31,7 @@ fn clear_provider_env() {
         "ANTHROPIC_API_KEY",
         "OPENAI_API_KEY",
         "FIREWORKS_API_KEY",
+        "TOGETHER_API_KEY",
     ] {
         // SAFETY: every caller is `#[serial(dotenv_credential_env)]`, matching
         // the lock the credential resolver's own env-mutating tests use.
@@ -273,6 +274,88 @@ async fn openai_direct_sends_bare_body() {
     );
 }
 
+// ── Together.ai: bare OpenAI body + tool-call round-trip via the shared core ─────
+
+/// Why: driving Together through the `Configurator` must (a) send a bare
+/// OpenAI-shaped body (bearer auth, no attribution headers, NO detailed-usage
+/// directive), (b) carry tools + the OpenAI-dialect `tool_choice`, and (c) parse
+/// a tool-call response — the full resolve→build→chat→usage cycle against a real
+/// socket, exactly like the Fireworks e2e.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn together_tool_call_round_trip_no_usage_directive() {
+    clear_provider_env();
+    let body = json!({
+        "id": "gen-together",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{\"loc\":\"SEA\"}"}
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 20, "completion_tokens": 8}
+    });
+    let server = MockInferenceServer::spawn(200, body).await.expect("spawn");
+    let base = server.url().to_string();
+
+    let store = MemoryKeyStore::new();
+    // Together key present AND explicit together/ prefix → resolves to Together.
+    store.set("together", "tgp_v1_fake").unwrap(); // pragma: allowlist secret
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::Together,
+        Box::new(move |r: &ResolvedProvider| together::build(r, &base)),
+    );
+
+    let adapter = cfg
+        .build("together/meta-llama/Llama-3.3-70B-Instruct-Turbo", &store)
+        .expect("build");
+    assert_eq!(adapter.name(), "together");
+    assert_eq!(adapter.capabilities().id, ProviderId::Together);
+
+    let mut req = ChatRequest::new(
+        "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        vec![ChatMessage::user("weather in SEA?")],
+    );
+    req.tools = Some(vec![ToolDefinition::function(FunctionDefinition {
+        name: "get_weather".into(),
+        description: Some("look up weather".into()),
+        parameters: Some(json!({"type": "object"})),
+        cache_control: None,
+    })]);
+    req.tool_choice = Some(adapter.map_tool_choice(ToolChoice::Auto));
+
+    let resp = adapter.chat(&req).await.expect("chat ok");
+
+    // Tool-call response parsing.
+    let calls = resp.first_tool_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.name, "get_weather");
+    assert_eq!(resp.usage().total_tokens(), 28);
+
+    // Request translation: bearer auth, no attribution, tools + tool_choice,
+    // and NO detailed-usage directive.
+    let sent = server.last_request().expect("captured");
+    assert_eq!(sent.method, "POST");
+    assert_eq!(sent.path, "/chat/completions");
+    assert_eq!(sent.header("authorization"), Some("Bearer tgp_v1_fake")); // pragma: allowlist secret
+    assert!(sent.header("http-referer").is_none());
+    let body = sent.body.expect("json");
+    assert_eq!(body["model"], "meta-llama/Llama-3.3-70B-Instruct-Turbo");
+    assert_eq!(body["tools"][0]["function"]["name"], "get_weather");
+    assert_eq!(body["tool_choice"], "auto");
+    assert!(
+        body.get("usage").is_none() || body["usage"].is_null(),
+        "Together must not send the detailed-usage directive: {body}"
+    );
+}
+
 // ── Error classification through a real socket ───────────────────────────────────
 
 /// Why: a non-2xx provider status must surface as a classified `InferenceError`
@@ -306,15 +389,18 @@ async fn http_429_maps_to_retryable_api_error() {
 
 // ── Default factory registration ─────────────────────────────────────────────────
 
-/// Why: `register_default_factories` must wire the three OpenAI-dialect providers
-/// so a bare/OpenRouter slug builds a real adapter through the public entry point
-/// (Bedrock stays unregistered — a later wave).
+/// Why: `register_default_factories` must wire the OpenAI-dialect providers
+/// (OpenRouter, Fireworks, OpenAI, Together) so a bare/OpenRouter slug builds a
+/// real adapter through the public entry point, and an explicit `together/` slug
+/// (with a resolvable key) builds a real Together adapter (Bedrock stays
+/// unregistered — a later wave).
 #[test]
 #[serial(dotenv_credential_env)]
-fn default_factories_register_three() {
+fn default_factories_register_openai_dialect() {
     clear_provider_env();
     let store = MemoryKeyStore::new();
     store.set("openrouter", "sk-or-fake").unwrap(); // pragma: allowlist secret
+    store.set("together", "tgp_v1_fake").unwrap(); // pragma: allowlist secret
 
     let mut cfg = Configurator::new();
     register_default_factories(&mut cfg);
@@ -322,6 +408,12 @@ fn default_factories_register_three() {
     // OpenRouter default path builds a real adapter.
     let adapter = cfg.build("some/model", &store).expect("build openrouter");
     assert_eq!(adapter.name(), "openrouter");
+
+    // Together (#2488) is registered by the default set.
+    let together = cfg
+        .build("together/meta-llama/Llama-3.3-70B-Instruct-Turbo", &store)
+        .expect("build together");
+    assert_eq!(together.name(), "together");
 
     // Bedrock is intentionally not registered by the default set.
     let Err(err) = cfg.build("bedrock/us.anthropic.claude-sonnet-4-5", &store) else {

--- a/crates/trusty-common/tests/inference_foundation.rs
+++ b/crates/trusty-common/tests/inference_foundation.rs
@@ -38,16 +38,17 @@ fn clear_provider_env() {
 
 // ── Capability registry ────────────────────────────────────────────────────────
 
-/// Why: each of the five seeded providers must be queryable by id and by name
-/// and expose a coherent capability descriptor.
+/// Why: each seeded provider must be queryable by id and by name and expose a
+/// coherent capability descriptor.
 #[test]
-fn registry_seeds_all_five_providers() {
+fn registry_seeds_all_providers() {
     let expected = [
         (ProviderId::OpenRouter, "openrouter", true),
         (ProviderId::Fireworks, "fireworks", true),
         (ProviderId::Bedrock, "bedrock", false), // no API-key env (AWS chain)
         (ProviderId::Anthropic, "anthropic", true),
         (ProviderId::OpenAI, "openai", true),
+        (ProviderId::Together, "together", true),
     ];
     for (id, name, has_key_env) in expected {
         let by_id = capabilities(id);


### PR DESCRIPTION
Extends the inference-adapter layer (epic #2400) with **Together.ai** as one more OpenAI-compatible provider, modeled exactly on the existing Fireworks adapter.

## What changed
- **Registry entry** (`inference/registry/mod.rs`): `ProviderId::Together` + SEED capabilities — native OpenAI-style tool calling, `ToolDialect::OpenAiFunctions`, `TOGETHER_API_KEY` credential env, 128K max context, default model `meta-llama/Llama-3.3-70B-Instruct-Turbo`. Wired into `as_str`, `from_slug_prefix`, and the by-name query.
- **Thin config** (`inference/providers/together.rs`): thin config over `OpenAiCompatAdapter` — production base URL `https://api.together.xyz/v1`, mock-injectable `build(resolved, base_url)` + production `factory(resolved)`, no OpenRouter-style attribution headers, `detailed_usage_accounting = false`.
- **Factory registration**: Together registered in `register_default_factories`, so `provider_for("together", &store)` builds a real adapter.
- **Offline e2e** (`tests/inference_adapters.rs`): `MockInferenceServer` round-trip through the full Configurator `resolve→build→chat→usage` cycle with a tool-call — asserts outbound bearer auth, no attribution headers, `tools`/`tool_choice`, no usage directive, and parsed response/usage.
- **Ignored live smoke test**: `#[ignore]` + `TOGETHER_API_KEY`-gated (skip-not-fail when the key is absent).

All under the `inference-client` feature; the default no-feature build stays excluded.

## Caching note
Together's prompt caching is **automatic/implicit** — there are no explicit `cache_control` breakpoint markers. It is modeled exactly like OpenAI-direct in the registry (`prompt_caching = true`: caching happens, the caller simply cannot place breakpoints). A code comment flags follow-up #2483, which is tightening that flag's semantics.

No real API key appears anywhere — tests use synthetic keys (`tgp_v1_fake`); the live smoke test reads `TOGETHER_API_KEY` from env.

## Verification
- `cargo build -p trusty-common` (no features) — Together excluded, clean
- `cargo test -p trusty-common --features inference-client` — 228 lib + 8 foundation pass
- `cargo test -p trusty-common --features inference-client,axum-server` — Together mock e2e passes (7 adapter e2e, 0 failed)
- `cargo build --workspace` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations

Closes #2488
Refs epic #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)