### PR TITLE
fix(trusty-mpm): launchd-aware bridge no-spawn + /health supervised flag (closes #2486)

### DIFF
--- a/.trusty-mpm/INSTRUCTIONS.md
+++ b/.trusty-mpm/INSTRUCTIONS.md
@@ -369,12 +369,13 @@ the daemon logs an error with the actionable FDA re-grant hint.
 
 ### Connection-safe daemon restart convention (issue #534)
 
-As of trusty-common 0.10.0, all three HTTP daemons (trusty-memory, trusty-search,
-trusty-analyze) implement graceful shutdown: they drain in-flight requests before
-exiting when they receive SIGTERM. The `serve --stdio` proxy reconnects automatically
-with exponential backoff when the daemon restarts (the `trusty-memory-mcp-bridge`
-binary is a deprecated shim that forwards to `serve --stdio`; update your
-`.mcp.json` to `"command": "trusty-memory", "args": ["serve", "--stdio"]`).
+As of trusty-common 0.10.0, all four HTTP daemons (trusty-memory, trusty-search,
+trusty-analyze, trusty-mpm) implement graceful shutdown: they drain in-flight
+requests before exiting when they receive SIGTERM. The `serve --stdio` proxy
+reconnects automatically with exponential backoff when the daemon restarts (the
+`trusty-memory-mcp-bridge` binary is a deprecated shim that forwards to
+`serve --stdio`; update your `.mcp.json` to `"command": "trusty-memory", "args":
+["serve", "--stdio"]`).
 
 **Use `launchctl bootout` (SIGTERM), not `launchctl kickstart -k` (SIGKILL):**
 
@@ -384,6 +385,29 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/<label>.plist
 cargo install --path crates/<dir> --locked
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/<label>.plist
 # NOTE: re-grant Full Disk Access only for trusty-search (and external-volume daemons), not for trusty-mpm (see FDA section above)
+```
+
+🔴 **A 200 `GET /health` is NOT sufficient evidence the restart succeeded**
+(issue #2486). During this exact `bootout → cargo install → bootstrap` window,
+trusty-mpm's `tm serve --stdio` MCP bridge (e.g. trusty-console's auto-reconnect)
+can race the restart: it spawns before launchd relaunches the daemon and, on an
+older binary, would auto-spawn an ORPHAN `tm daemon` — PPID pointing at the
+client chain, not launchd. That orphan answers `/health` 200 but is missing the
+plist's `EnvironmentVariables` (`TELEGRAM_BOT_TOKEN`, `OPENROUTER_API_KEY`) and
+runs with `cwd=$HOME`, so features like the Telegram poller silently never
+start. As of the #2486 fix the bridge refuses to auto-spawn while a trusty-mpm
+launchd unit is registered, and `GET /health` reports a `supervised` flag — but
+always verify the restart with ONE of:
+
+```bash
+# (a) does launchd itself think it owns the process?
+launchctl print gui/$(id -u)/com.trusty.mpm.supervisor   # or com.trusty.mpm
+
+# (b) is launchd (PID 1) the parent of the running daemon?
+ps -o ppid= -p "$(pgrep -fx 'tm daemon' | head -1)"       # must print "1"
+
+# (c) does /health say so directly?
+curl -s http://127.0.0.1:<port>/health | jq '.supervised' # must print true
 ```
 
 Prefer restarting between Claude Code sessions. See the cargo-publish skill

--- a/.trusty-mpm/INSTRUCTIONS.md
+++ b/.trusty-mpm/INSTRUCTIONS.md
@@ -397,17 +397,30 @@ plist's `EnvironmentVariables` (`TELEGRAM_BOT_TOKEN`, `OPENROUTER_API_KEY`) and
 runs with `cwd=$HOME`, so features like the Telegram poller silently never
 start. As of the #2486 fix the bridge refuses to auto-spawn while a trusty-mpm
 launchd unit is registered, and `GET /health` reports a `supervised` flag — but
-always verify the restart with ONE of:
+always verify the restart with ONE of the two robust checks below:
 
 ```bash
-# (a) does launchd itself think it owns the process?
+# (a) does launchd itself think it owns the process? (most direct)
 launchctl print gui/$(id -u)/com.trusty.mpm.supervisor   # or com.trusty.mpm
 
-# (b) is launchd (PID 1) the parent of the running daemon?
-ps -o ppid= -p "$(pgrep -fx 'tm daemon' | head -1)"       # must print "1"
-
-# (c) does /health say so directly?
+# (b) does /health say so directly?
 curl -s http://127.0.0.1:<port>/health | jq '.supervised' # must print true
+```
+
+A third, weaker variant — is launchd (PID 1) the parent of the running daemon
+process — is sometimes useful but has two sharp edges: the daemon binary on
+disk is named `trusty-mpm`, not `tm` (both binary names exist, but launchd's
+plist invokes `trusty-mpm daemon`), and `pgrep -fx` requires an exact full
+cmdline match, which never matches launchd's absolute-path invocation
+(`/Users/…/.cargo/bin/trusty-mpm daemon`). Use an anchored, non-exact match
+against BOTH binary names instead:
+
+```bash
+# (c) is launchd (PID 1) the parent of the running daemon? (weaker — PID 1 is
+# also where macOS reparents ANY orphaned process, so this alone does not
+# distinguish "launchd-supervised service" from "orphan that got reparented
+# to init"; prefer (a) or (b) above and use this only as a quick sanity check)
+ps -o ppid= -p "$(pgrep -f 'trusty-mpm daemon|tm daemon' | head -1)"  # must print "1"
 ```
 
 Prefer restarting between Claude Code sessions. See the cargo-publish skill

--- a/crates/trusty-analyze/src/commands/daemon_guard.rs
+++ b/crates/trusty-analyze/src/commands/daemon_guard.rs
@@ -141,7 +141,8 @@ pub async fn ensure_mcp_daemon_up(analyzer_url: &str) -> anyhow::Result<String> 
         ),
         startup_timeout: None,
         poll_interval: None,
-        no_spawn: false, // trusty-analyze bridge may auto-start its sidecar
+        no_spawn: false,     // trusty-analyze bridge may auto-start its sidecar
+        no_spawn_hint: None, // unused: no_spawn is false
     };
     trusty_common::mcp::ensure_daemon_up(&config).await
 }

--- a/crates/trusty-common/src/mcp/daemon_bridge.rs
+++ b/crates/trusty-common/src/mcp/daemon_bridge.rs
@@ -51,9 +51,14 @@ pub const DAEMON_START_TIMEOUT: Duration = Duration::from_secs(30);
 /// What: holds the service name (for diagnostics), the arguments appended to
 /// `current_exe()` when spawning the daemon, the path for health probing (e.g.
 /// `/health` or `/api/v1/health`), a URL-resolver closure, optional timeout
-/// overrides, and the `no_spawn` flag (issue #1152).
+/// overrides, the `no_spawn` flag (issue #1152), and an optional
+/// `no_spawn_hint` override for the `no_spawn` error's operator guidance
+/// (issue #2491).
 /// Test: `daemon_bridge_config_health_url` unit test;
-/// `no_spawn_returns_err_without_spawning` covers the new field.
+/// `no_spawn_returns_err_without_spawning` covers the `no_spawn` field;
+/// `no_spawn_error_uses_hint_when_set` /
+/// `no_spawn_error_falls_back_to_generic_when_hint_unset` cover
+/// `no_spawn_hint`.
 pub struct DaemonBridgeConfig {
     /// Human-readable service name, used in diagnostic messages.
     pub service_name: String,
@@ -90,6 +95,26 @@ pub struct DaemonBridgeConfig {
     /// spawning `current_exe() + spawn_args`.
     /// Test: `no_spawn_returns_err_without_spawning`.
     pub no_spawn: bool,
+    /// Optional per-service override for the `no_spawn` error's operator
+    /// guidance text.
+    ///
+    /// Why (#2491 review): the generic `no_spawn` error assumed every caller
+    /// has a `{service_name} setup` subcommand and a
+    /// `~/Library/LaunchAgents/io.trusty.{service_name}.plist` unit. Neither is
+    /// true for trusty-mpm — there is no `trusty-mpm setup` subcommand, and the
+    /// real plists are `com.trusty.mpm.plist` /
+    /// `com.trusty.mpm.supervisor.plist` — so the generic hint told the
+    /// operator to run a nonexistent command against a nonexistent path. When
+    /// `Some`, this text REPLACES the generic setup/plist advice in the error
+    /// message; when `None`, the original generic wording is used unchanged so
+    /// existing callers (trusty-memory, trusty-search, trusty-analyze) are
+    /// unaffected.
+    /// What: appended verbatim after the "daemon is not reachable at {addr}"
+    /// preamble instead of the generic `` `{name} start`/`{name} setup` ``
+    /// text.
+    /// Test: `no_spawn_error_uses_hint_when_set`,
+    /// `no_spawn_error_falls_back_to_generic_when_hint_unset`.
+    pub no_spawn_hint: Option<String>,
 }
 
 impl DaemonBridgeConfig {
@@ -161,17 +186,20 @@ pub async fn ensure_daemon_up(config: &DaemonBridgeConfig) -> Result<String> {
     // knows exactly what to do.
     if config.no_spawn {
         let addr = (config.base_url_fn)();
+        let hint = match &config.no_spawn_hint {
+            Some(hint) => hint.clone(),
+            None => format!(
+                "start it with `{} start` (launchd-managed) before using the MCP bridge. \
+                 If already installed via `{} setup`, run `launchctl bootstrap gui/$(id -u) \
+                 ~/Library/LaunchAgents/io.trusty.{}.plist` or `{} start`.",
+                config.service_name, config.service_name, config.service_name, config.service_name,
+            ),
+        };
         return Err(anyhow!(
-            "{} daemon is not reachable at {} — \
-             start it with `{} start` (launchd-managed) before using the MCP bridge. \
-             If already installed via `{} setup`, run `launchctl bootstrap gui/$(id -u) \
-             ~/Library/LaunchAgents/io.trusty.{}.plist` or `{} start`.",
+            "{} daemon is not reachable at {} — {}",
             config.service_name,
             addr,
-            config.service_name,
-            config.service_name,
-            config.service_name,
-            config.service_name,
+            hint,
         ));
     }
 
@@ -238,6 +266,7 @@ mod tests {
             startup_timeout: Some(Duration::from_millis(100)), // very short for tests
             poll_interval: Some(Duration::from_millis(20)),
             no_spawn: false,
+            no_spawn_hint: None,
         }
     }
 
@@ -301,6 +330,7 @@ mod tests {
             startup_timeout: Some(Duration::from_secs(5)),
             poll_interval: Some(Duration::from_millis(50)),
             no_spawn: false,
+            no_spawn_hint: None,
         };
         let result = ensure_daemon_up(&cfg).await;
         assert!(
@@ -343,6 +373,7 @@ mod tests {
             startup_timeout: Some(Duration::from_millis(100)),
             poll_interval: Some(Duration::from_millis(20)),
             no_spawn: true,
+            no_spawn_hint: None,
         };
         let result = ensure_daemon_up(&cfg).await;
         assert!(result.is_err(), "no_spawn must return Err when probe fails");
@@ -354,6 +385,80 @@ mod tests {
         assert!(
             msg.contains("start"),
             "error must mention how to start the daemon; got: {msg}"
+        );
+    }
+
+    /// Why (#2491 review): a service with a `no_spawn_hint` set (e.g.
+    /// trusty-mpm, whose real operator guidance differs from the generic
+    /// `{name} setup` / `io.trusty.{name}.plist` text) must see ITS hint in the
+    /// error, not the generic wording that names a nonexistent subcommand and
+    /// plist path.
+    /// What: builds a config with `no_spawn: true` and a distinctive
+    /// `no_spawn_hint`, asserts the hint text appears verbatim and the generic
+    /// `setup`/`io.trusty.` wording does not.
+    /// Test: this test.
+    #[tokio::test]
+    async fn no_spawn_error_uses_hint_when_set() {
+        let cfg = DaemonBridgeConfig {
+            service_name: "trusty-mpm".to_string(),
+            spawn_args: vec![],
+            health_path: "/health".to_string(),
+            base_url_fn: Box::new(|| "http://127.0.0.1:65534".to_string()),
+            startup_timeout: Some(Duration::from_millis(100)),
+            poll_interval: Some(Duration::from_millis(20)),
+            no_spawn: true,
+            no_spawn_hint: Some(
+                "trusty-mpm daemon is launchd-managed on this machine — start it with \
+                 `launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.trusty.mpm.plist`."
+                    .to_string(),
+            ),
+        };
+        let result = ensure_daemon_up(&cfg).await;
+        assert!(result.is_err(), "no_spawn must return Err when probe fails");
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("com.trusty.mpm.plist"),
+            "error must contain the service-specific hint; got: {msg}"
+        );
+        assert!(
+            !msg.contains("trusty-mpm setup"),
+            "error must NOT contain the generic (wrong-for-trusty-mpm) setup advice; got: {msg}"
+        );
+        assert!(
+            !msg.contains("io.trusty."),
+            "error must NOT contain the generic io.trusty.* plist path; got: {msg}"
+        );
+    }
+
+    /// Why (#2491 review): when `no_spawn_hint` is left `None` (every caller
+    /// except trusty-mpm), the original generic setup/plist wording must still
+    /// appear — the new field must not change existing behaviour for
+    /// trusty-memory, trusty-search, or trusty-analyze.
+    /// What: reuses `no_spawn_returns_err_without_spawning`'s config shape with
+    /// `no_spawn_hint: None` and asserts the generic wording is present.
+    /// Test: this test.
+    #[tokio::test]
+    async fn no_spawn_error_falls_back_to_generic_when_hint_unset() {
+        let cfg = DaemonBridgeConfig {
+            service_name: "trusty-memory".to_string(),
+            spawn_args: vec![],
+            health_path: "/health".to_string(),
+            base_url_fn: Box::new(|| "http://127.0.0.1:65534".to_string()),
+            startup_timeout: Some(Duration::from_millis(100)),
+            poll_interval: Some(Duration::from_millis(20)),
+            no_spawn: true,
+            no_spawn_hint: None,
+        };
+        let result = ensure_daemon_up(&cfg).await;
+        assert!(result.is_err(), "no_spawn must return Err when probe fails");
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("trusty-memory setup"),
+            "generic hint must still mention `{{service}} setup`; got: {msg}"
+        );
+        assert!(
+            msg.contains("io.trusty.trusty-memory.plist"),
+            "generic hint must still mention the io.trusty.* plist path; got: {msg}"
         );
     }
 }

--- a/crates/trusty-memory/src/commands/serve_stdio_bridge.rs
+++ b/crates/trusty-memory/src/commands/serve_stdio_bridge.rs
@@ -107,6 +107,10 @@ fn build_bridge_config() -> DaemonBridgeConfig {
         // Issue #1152: NEVER spawn an unmanaged daemon from the stdio bridge.
         // If the launchd daemon at :7070 is not reachable, fail loudly.
         no_spawn: true,
+        // trusty-memory's real operator guidance matches the shared helper's
+        // generic `{service} setup` / `io.trusty.{service}.plist` wording, so
+        // no override is needed here (issue #2491).
+        no_spawn_hint: None,
     }
 }
 

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -152,6 +152,10 @@ trusty-common = { workspace = true, features = [
     # SPEC-ONESM-01 / DOC-33: canonical tmux-session naming was hoisted into
     # trusty-common so trusty-agents can reuse it. `core::names` re-exports it.
     "session-naming",
+    # #2486: reuses `trusty_common::update::is_launchd_supervised` for the
+    # daemon-restart-race supervision signal (see daemon_run.rs / api/types.rs).
+    # Zero extra transitive deps — see the feature's Cargo.toml comment.
+    "update-check",
 ] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # `console-metrics` enables `trusty_common::console_metrics` (used unconditionally by

--- a/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
@@ -41,6 +41,13 @@ pub(crate) async fn run_daemon(addr: SocketAddr, tailscale: bool, mcp: bool) -> 
     }
 
     let state = trusty_mpm::daemon::DaemonState::shared();
+
+    // #2486: compute the launchd-supervision signal once, up front, so both
+    // the MCP-mode early return and the HTTP-serving path below carry it on
+    // `GET /health`. See `crate::commands::launchd_probe` for the full
+    // restart-race rationale and the pure decision table.
+    apply_supervision_signal(&state);
+
     if mcp {
         return trusty_mpm::daemon::run_mcp(state).await;
     }
@@ -184,6 +191,38 @@ async fn wait_for_shutdown_signal() {
     #[cfg(not(unix))]
     {
         let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+/// Compute and store the launchd-supervision signal on `state` (issue #2486).
+///
+/// Why: a green `/health` alone does not prove launchd owns this process —
+/// during a `bootout → cargo install → bootstrap` restart, a racing MCP stdio
+/// bridge can auto-spawn an orphan daemon that answers `/health` 200 but is
+/// missing the plist's `EnvironmentVariables` and runs with `cwd=$HOME`.
+/// `crate::commands::launchd_probe::compute_supervised` combines "is THIS
+/// process launchd-supervised" with "does a trusty-mpm launchd unit exist at
+/// all" into the single safe/hazardous signal `GET /health` exposes.
+/// What: probes for a trusty-mpm launchd plist, combines it with
+/// `trusty_common::update::is_launchd_supervised()`, stores the result on
+/// `state` via [`trusty_mpm::daemon::DaemonState::set_supervised`], and logs a
+/// `tracing::warn!` exactly once at startup when the result is hazardous.
+/// Test: the pure decision table is covered by
+/// `crate::commands::launchd_probe::tests`; this wrapper is side-effect-only
+/// (env/filesystem probes + a state mutation) and is exercised via the daemon
+/// e2e suite's boot path.
+fn apply_supervision_signal(state: &trusty_mpm::daemon::DaemonState) {
+    let plist_exists = crate::commands::launchd_probe::mpm_launchd_plist_exists();
+    let is_launchd = trusty_common::update::is_launchd_supervised();
+    let supervised = crate::commands::launchd_probe::compute_supervised(is_launchd, plist_exists);
+    state.set_supervised(supervised);
+    if !supervised {
+        tracing::warn!(
+            "unsupervised trusty-mpm daemon running alongside a launchd unit — \
+             likely spawned by a client during a restart race; kill it and use \
+             `launchctl kickstart -k gui/$(id -u)/com.trusty.mpm.supervisor` \
+             (or `com.trusty.mpm`) to let launchd own the daemon."
+        );
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/launchd_probe.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launchd_probe.rs
@@ -67,7 +67,8 @@ pub(crate) fn mpm_launchd_plist_exists() -> bool {
 /// Test: `compute_supervised_true_when_no_plist`,
 /// `compute_supervised_true_when_plist_and_launchd`,
 /// `compute_supervised_false_when_plist_without_launchd`,
-/// `compute_supervised_true_when_no_plist_and_not_launchd`.
+/// `compute_supervised_true_when_launchd_and_no_plist` (all four quadrants of
+/// the (`is_launchd_supervised`, `plist_exists`) truth table are covered).
 pub(crate) fn compute_supervised(is_launchd_supervised: bool, plist_exists: bool) -> bool {
     !plist_exists || is_launchd_supervised
 }
@@ -97,9 +98,11 @@ mod tests {
     }
 
     #[test]
-    fn compute_supervised_true_when_no_plist_and_not_launchd() {
-        // No plist at all — even an unsupervised process is fine (dev machine).
-        assert!(compute_supervised(false, false));
+    fn compute_supervised_true_when_launchd_and_no_plist() {
+        // Launchd-supervised with no plist registered (e.g. probed before the
+        // plist path convention existed, or a unit under a third path) — still
+        // safe: `is_launchd_supervised` alone is sufficient.
+        assert!(compute_supervised(true, false));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/launchd_probe.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launchd_probe.rs
@@ -1,0 +1,126 @@
+//! Launchd-unit probing shared by daemon startup and the MCP stdio bridge (#2486).
+//!
+//! Why: during the documented `launchctl bootout → cargo install → launchctl
+//! bootstrap` restart, trusty-console's auto-reconnect can race the restart —
+//! it spawns a fresh `tm serve --stdio` bridge child whose startup auto-spawns
+//! an ORPHAN daemon before launchd has a chance to relaunch the supervised one.
+//! The orphan answers `/health` 200 (so a green health check is NOT sufficient
+//! evidence launchd won) but runs without the plist's `EnvironmentVariables`
+//! (`TELEGRAM_BOT_TOKEN`, `OPENROUTER_API_KEY`) and with `cwd=$HOME`, silently
+//! breaking features like the Telegram poller. Both the daemon (to report
+//! `supervised` on `/health`) and the stdio bridge (to decide whether
+//! auto-spawn is safe) need the same "does a trusty-mpm launchd unit exist"
+//! signal, so it is centralised here instead of duplicated.
+//!
+//! What: [`mpm_launchd_plist_exists`] probes the two plist paths a trusty-mpm
+//! launchd unit could be registered under. [`compute_supervised`] and
+//! [`compute_no_spawn`] are pure functions over that boolean (plus, for
+//! supervision, [`trusty_common::update::is_launchd_supervised`]) so the
+//! decision logic is unit-testable without touching the filesystem or launchd.
+//!
+//! Test: `compute_supervised_*` and `compute_no_spawn_*` below exercise every
+//! combination of the pure decision tables. `mpm_launchd_plist_exists` itself
+//! is a thin `Path::exists` probe and is not unit-tested (no hermetic way to
+//! fake `$HOME/Library/LaunchAgents` without real filesystem I/O).
+
+/// Candidate launchd plist paths for a trusty-mpm daemon unit.
+///
+/// Why: the supervisor installer (`trusty-installer`) uses the label
+/// `com.trusty.mpm.supervisor`, but operators may also run a plain
+/// `com.trusty.mpm` unit; there is no single canonical in-repo daemon plist,
+/// so both are treated as "a trusty-mpm launchd unit exists".
+/// What: returns the two absolute paths under `~/Library/LaunchAgents/`,
+/// falling back to an empty list when `$HOME` cannot be resolved (e.g. a
+/// stripped-down CI sandbox) — treated the same as "no plist" by callers.
+/// Test: covered indirectly via `mpm_launchd_plist_exists`.
+fn launchd_plist_paths() -> Vec<std::path::PathBuf> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    let agents = home.join("Library/LaunchAgents");
+    vec![
+        agents.join("com.trusty.mpm.plist"),
+        agents.join("com.trusty.mpm.supervisor.plist"),
+    ]
+}
+
+/// Returns `true` when a trusty-mpm launchd unit is registered on this host.
+///
+/// Why: the presence of a plist is the operator's declared intent that
+/// launchd should own the daemon's lifecycle; both the health-supervision
+/// signal and the bridge's no-spawn decision key off this fact.
+/// What: `true` when either candidate path in [`launchd_plist_paths`] exists.
+/// Test: exercised manually — see module doc; the pure decisions that consume
+/// this boolean are unit-tested below.
+pub(crate) fn mpm_launchd_plist_exists() -> bool {
+    launchd_plist_paths().iter().any(|p| p.exists())
+}
+
+/// Pure decision: is this daemon process in a hazardous unsupervised state?
+///
+/// Why: factored out of any filesystem/env access so the four-quadrant truth
+/// table is testable without launchd, a plist, or environment variables.
+/// What: `true` (safe) when no launchd unit exists at all (a dev-run daemon
+/// with no plist is fine) OR this process itself is launchd-supervised.
+/// `false` (hazardous) exactly when a launchd unit exists but this process
+/// was NOT launched by launchd — the #2486 orphan-daemon signature.
+/// Test: `compute_supervised_true_when_no_plist`,
+/// `compute_supervised_true_when_plist_and_launchd`,
+/// `compute_supervised_false_when_plist_without_launchd`,
+/// `compute_supervised_true_when_no_plist_and_not_launchd`.
+pub(crate) fn compute_supervised(is_launchd_supervised: bool, plist_exists: bool) -> bool {
+    !plist_exists || is_launchd_supervised
+}
+
+/// Pure decision: should the MCP stdio bridge refuse to auto-spawn a daemon?
+///
+/// Why: when a launchd unit is registered, `launchctl bootstrap` is the
+/// correct (and eventually consistent) way to bring the daemon back after a
+/// restart; a bridge-side auto-spawn during the restart gap creates the #2486
+/// orphan. When no launchd unit exists (a dev machine), auto-spawn remains the
+/// convenient default, matching the pre-existing `tm start` behaviour.
+/// What: `no_spawn` is exactly `plist_exists` — spawn is refused if and only
+/// if a trusty-mpm launchd unit is present.
+/// Test: `compute_no_spawn_true_when_plist_exists`,
+/// `compute_no_spawn_false_when_no_plist`.
+pub(crate) fn compute_no_spawn(plist_exists: bool) -> bool {
+    plist_exists
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_supervised_true_when_no_plist() {
+        assert!(compute_supervised(false, false));
+    }
+
+    #[test]
+    fn compute_supervised_true_when_no_plist_and_not_launchd() {
+        // No plist at all — even an unsupervised process is fine (dev machine).
+        assert!(compute_supervised(false, false));
+    }
+
+    #[test]
+    fn compute_supervised_true_when_plist_and_launchd() {
+        assert!(compute_supervised(true, true));
+    }
+
+    #[test]
+    fn compute_supervised_false_when_plist_without_launchd() {
+        // The hazardous #2486 state: a unit is registered but this process
+        // was not launched by launchd.
+        assert!(!compute_supervised(false, true));
+    }
+
+    #[test]
+    fn compute_no_spawn_true_when_plist_exists() {
+        assert!(compute_no_spawn(true));
+    }
+
+    #[test]
+    fn compute_no_spawn_false_when_no_plist() {
+        assert!(!compute_no_spawn(false));
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod hook_rewrite;
 pub(crate) mod install;
 pub(crate) mod issue;
 pub(crate) mod launch;
+pub(crate) mod launchd_probe;
 pub(crate) mod managed;
 pub(crate) mod managed_root;
 pub(crate) mod managed_route;

--- a/crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs
@@ -75,12 +75,19 @@ fn build_rpc_client() -> Result<reqwest::Client> {
 /// with no registered launchd unit, auto-spawn remains the convenient default,
 /// unchanged from `tm start`'s existing behaviour.
 /// What: returns a config that probes `/health`, resolves the base URL from
-/// the lock file each poll, and sets `no_spawn` to
+/// the lock file each poll, sets `no_spawn` to
 /// [`crate::commands::launchd_probe::compute_no_spawn`] applied to
-/// [`crate::commands::launchd_probe::mpm_launchd_plist_exists`].
-/// Test: `build_bridge_config_no_spawn_matches_plist_probe` below;
+/// [`crate::commands::launchd_probe::mpm_launchd_plist_exists`], and sets a
+/// trusty-mpm-specific `no_spawn_hint` (issue #2491) — the shared helper's
+/// generic hint names a `{service} setup` subcommand and an
+/// `io.trusty.{service}.plist` path that do not exist for trusty-mpm (there is
+/// no `trusty-mpm setup` subcommand; the real plists are `com.trusty.mpm.plist`
+/// / `com.trusty.mpm.supervisor.plist`).
+/// Test: `build_bridge_config_no_spawn_matches_plist_probe` and
+/// `build_bridge_config_no_spawn_hint_names_real_plists` below;
 /// `ensure_daemon_up`'s no-spawn error path is unit-tested in
-/// `trusty_common::mcp::daemon_bridge` (`no_spawn_returns_err_without_spawning`).
+/// `trusty_common::mcp::daemon_bridge` (`no_spawn_returns_err_without_spawning`,
+/// `no_spawn_error_uses_hint_when_set`).
 fn build_bridge_config() -> DaemonBridgeConfig {
     let no_spawn = crate::commands::launchd_probe::compute_no_spawn(
         crate::commands::launchd_probe::mpm_launchd_plist_exists(),
@@ -102,7 +109,28 @@ fn build_bridge_config() -> DaemonBridgeConfig {
         startup_timeout: None, // shared 30s default
         poll_interval: None,   // shared 500ms default
         no_spawn,
+        no_spawn_hint: Some(mpm_no_spawn_hint()),
     }
+}
+
+/// Build trusty-mpm's operator guidance for the `no_spawn` error (issue #2491).
+///
+/// Why: the shared `DaemonBridgeConfig`'s generic `no_spawn` hint templates
+/// `{service_name} setup` and `~/Library/LaunchAgents/io.trusty.{service_name}.plist`
+/// — for trusty-mpm that yields a nonexistent `trusty-mpm setup` subcommand and
+/// a wrong plist path. This function returns the correct, trusty-mpm-specific
+/// text instead: the real plist names and the `launchctl bootstrap`/`kickstart`
+/// commands that actually restart it, plus a pointer back to the #2486 restart
+/// race this `no_spawn` guard exists to avoid.
+/// What: a fixed, service-specific string passed as
+/// `DaemonBridgeConfig::no_spawn_hint`.
+/// Test: `build_bridge_config_no_spawn_hint_names_real_plists`.
+fn mpm_no_spawn_hint() -> String {
+    "trusty-mpm daemon is launchd-managed on this machine — start it with \
+     `launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.trusty.mpm.plist` \
+     (or kickstart: `launchctl kickstart -k gui/$UID/com.trusty.mpm`); this \
+     bridge will not auto-spawn to avoid the #2486 restart race."
+        .to_string()
 }
 
 /// Returns true if the request is a JSON-RPC notification.
@@ -254,19 +282,51 @@ mod tests {
         assert!(build_rpc_client().is_ok());
     }
 
-    /// Why (#2486): `build_bridge_config`'s `no_spawn` must be wired straight
-    /// through `compute_no_spawn(mpm_launchd_plist_exists())` — this test
-    /// pins the wiring without faking the filesystem (the pure decision table
-    /// itself is covered by `commands::launchd_probe::tests`).
+    /// Why (#2486): `build_bridge_config`'s `no_spawn` must track whether a
+    /// trusty-mpm launchd unit is registered on this host — this test compares
+    /// against `mpm_launchd_plist_exists()` directly (not via
+    /// `compute_no_spawn`, since `compute_no_spawn` is currently the identity
+    /// function over that boolean) so the assertion pins the actual invariant
+    /// rather than restating `build_bridge_config`'s own call chain. The pure
+    /// decision table itself is covered by `commands::launchd_probe::tests`.
     #[test]
     fn build_bridge_config_no_spawn_matches_plist_probe() {
-        let expected = crate::commands::launchd_probe::compute_no_spawn(
-            crate::commands::launchd_probe::mpm_launchd_plist_exists(),
-        );
+        let plist_exists = crate::commands::launchd_probe::mpm_launchd_plist_exists();
         let cfg = build_bridge_config();
         assert_eq!(
-            cfg.no_spawn, expected,
+            cfg.no_spawn, plist_exists,
             "no_spawn must track the live plist probe"
+        );
+    }
+
+    /// Why (#2491 review): the shared helper's generic `no_spawn` hint names a
+    /// `{service} setup` subcommand and an `io.trusty.{service}.plist` path
+    /// that do not exist for trusty-mpm. `build_bridge_config` must override
+    /// that with the real plist names and a working `launchctl` recipe.
+    /// What: asserts the built config's `no_spawn_hint` contains both real
+    /// plist basenames and does NOT contain the wrong generic wording.
+    /// Test: this test.
+    #[test]
+    fn build_bridge_config_no_spawn_hint_names_real_plists() {
+        let cfg = build_bridge_config();
+        let hint = cfg
+            .no_spawn_hint
+            .expect("trusty-mpm must set a no_spawn_hint");
+        assert!(
+            hint.contains("com.trusty.mpm.plist"),
+            "hint must name the real plist; got: {hint}"
+        );
+        assert!(
+            hint.contains("launchctl bootstrap") || hint.contains("launchctl kickstart"),
+            "hint must give a working launchctl recipe; got: {hint}"
+        );
+        assert!(
+            !hint.contains("trusty-mpm setup"),
+            "hint must NOT reference the nonexistent `trusty-mpm setup` subcommand; got: {hint}"
+        );
+        assert!(
+            !hint.contains("io.trusty."),
+            "hint must NOT reference the wrong io.trusty.* plist path; got: {hint}"
         );
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs
@@ -55,15 +55,36 @@ fn build_rpc_client() -> Result<reqwest::Client> {
 /// Why: the daemon discovers its own (possibly ephemeral) port and records it in
 /// `~/.trusty-mpm/daemon.lock`. `resolve_daemon_url(None)` re-reads that lock on
 /// every call, so passing it as `base_url_fn` lets `ensure_daemon_up` track a
-/// dynamic port as soon as the daemon writes the lock. Unlike trusty-memory
-/// (which sets `no_spawn` to avoid squatting a redb write lock), the trusty-mpm
-/// daemon is HTTP-only and singleton-guarded, so auto-spawn is safe and matches
-/// the existing `tm start` behaviour.
-/// What: returns a config that probes `/health`, auto-spawns `tm daemon` when
-/// absent, and resolves the base URL from the lock file each poll.
-/// Test: covered indirectly; `ensure_daemon_up` itself is unit-tested in
-/// `trusty_common::mcp::daemon_bridge`.
+/// dynamic port as soon as the daemon writes the lock.
+///
+/// `no_spawn` is now launchd-aware (issue #2486, precedent: trusty-memory's
+/// #1152 fix). The doc comment this replaced claimed singleton-guarding made
+/// unconditional auto-spawn "safe" — #2486 disproved that: during the
+/// documented `launchctl bootout → cargo install → launchctl bootstrap`
+/// restart, this bridge's auto-reconnect can race the restart and spawn an
+/// ORPHAN daemon (PPID pointing at the client chain, not launchd) *before*
+/// launchd relaunches the real one. The orphan answers `/health` 200 — so the
+/// old "singleton-guarded" reasoning silently masked the bug — but it lacks
+/// the plist's `EnvironmentVariables` (`TELEGRAM_BOT_TOKEN`,
+/// `OPENROUTER_API_KEY`) and runs with `cwd=$HOME`, so features like the
+/// Telegram poller never start. When a trusty-mpm launchd unit IS registered,
+/// `launchctl bootstrap`/`kickstart` is the correct way to bring the daemon
+/// back, so this bridge must refuse to auto-spawn and instead surface a clear
+/// error (`ensure_daemon_up`'s `no_spawn` path) — the console's existing
+/// backoff/retry recovers once launchd finishes the restart. On a dev machine
+/// with no registered launchd unit, auto-spawn remains the convenient default,
+/// unchanged from `tm start`'s existing behaviour.
+/// What: returns a config that probes `/health`, resolves the base URL from
+/// the lock file each poll, and sets `no_spawn` to
+/// [`crate::commands::launchd_probe::compute_no_spawn`] applied to
+/// [`crate::commands::launchd_probe::mpm_launchd_plist_exists`].
+/// Test: `build_bridge_config_no_spawn_matches_plist_probe` below;
+/// `ensure_daemon_up`'s no-spawn error path is unit-tested in
+/// `trusty_common::mcp::daemon_bridge` (`no_spawn_returns_err_without_spawning`).
 fn build_bridge_config() -> DaemonBridgeConfig {
+    let no_spawn = crate::commands::launchd_probe::compute_no_spawn(
+        crate::commands::launchd_probe::mpm_launchd_plist_exists(),
+    );
     DaemonBridgeConfig {
         service_name: "trusty-mpm".to_string(),
         // The daemon picks its own port and records it in the lock file; no addr
@@ -80,7 +101,7 @@ fn build_bridge_config() -> DaemonBridgeConfig {
         base_url_fn: Box::new(|| trusty_mpm::core::resolve_daemon_url(None)),
         startup_timeout: None, // shared 30s default
         poll_interval: None,   // shared 500ms default
-        no_spawn: false,
+        no_spawn,
     }
 }
 
@@ -231,6 +252,22 @@ mod tests {
     #[test]
     fn build_rpc_client_succeeds() {
         assert!(build_rpc_client().is_ok());
+    }
+
+    /// Why (#2486): `build_bridge_config`'s `no_spawn` must be wired straight
+    /// through `compute_no_spawn(mpm_launchd_plist_exists())` — this test
+    /// pins the wiring without faking the filesystem (the pure decision table
+    /// itself is covered by `commands::launchd_probe::tests`).
+    #[test]
+    fn build_bridge_config_no_spawn_matches_plist_probe() {
+        let expected = crate::commands::launchd_probe::compute_no_spawn(
+            crate::commands::launchd_probe::mpm_launchd_plist_exists(),
+        );
+        let cfg = build_bridge_config();
+        assert_eq!(
+            cfg.no_spawn, expected,
+            "no_spawn must track the live plist probe"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -393,12 +393,16 @@ pub fn router(state: Arc<DaemonState>) -> Router {
 /// from the synced catalog so the TUI can show an indicator and the operator can
 /// rebuild. The check is a cheap, offline SHA compare (no network pull on the
 /// hot path), and an unreachable/never-synced catalog degrades to `unknown`
-/// (never `stale`, never an error) per the spec's "never block" rule.
-/// What: returns `status: "ok"` with `catalog_stale`/`catalog_unknown` flags and
-/// a small `catalog_changes` summary, computed via
+/// (never `stale`, never an error) per the spec's "never block" rule. Also
+/// surfaces the #2486 `supervised` restart-race signal — a 200 response here
+/// does NOT by itself prove launchd owns this process; check `supervised` too.
+/// What: returns `status: "ok"` with `catalog_stale`/`catalog_unknown` flags, a
+/// small `catalog_changes` summary computed via
 /// [`crate::core::update_check::detect_for_framework`] anchored at the daemon's
-/// framework root.
-/// Test: `health_reports_ok_status`, `health_reports_catalog_unknown_without_catalog`.
+/// framework root, and `supervised` read from `state` (set once at daemon
+/// startup by `daemon_run::run_daemon`).
+/// Test: `health_reports_ok_status`, `health_reports_catalog_unknown_without_catalog`,
+/// `health_response_serializes_supervised_field`.
 #[utoipa::path(
     get,
     path = "/health",
@@ -415,6 +419,7 @@ pub async fn health(State(state): State<Arc<DaemonState>>) -> Json<HealthRespons
         catalog_stale: report.stale,
         catalog_unknown: report.unknown,
         catalog_changes: report.summary_lines(),
+        supervised: state.supervised(),
     })
 }
 

--- a/crates/trusty-mpm/src/daemon/api/types.rs
+++ b/crates/trusty-mpm/src/daemon/api/types.rs
@@ -33,9 +33,10 @@ use crate::daemon::tmux::{AdoptedSession, SessionSnapshot};
 /// What: `status` is the liveness word; `catalog_stale` is true when deployed
 /// content drifts from the synced catalog; `catalog_unknown` is true when the
 /// catalog has never been synced (distinct from "fresh"); `catalog_changes` is a
-/// small human summary of WHAT changed (empty unless stale).
+/// small human summary of WHAT changed (empty unless stale); `supervised`
+/// carries the #2486 restart-race signal (see the field's own doc comment).
 /// Test: `health_reports_catalog_unknown_without_catalog`,
-/// `health_reports_ok_status`.
+/// `health_reports_ok_status`, `health_response_serializes_supervised_field`.
 #[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct HealthResponse {
     /// Liveness word — `"ok"` while the daemon is up.
@@ -46,6 +47,32 @@ pub struct HealthResponse {
     pub catalog_unknown: bool,
     /// Short human summary of changed artifacts (empty unless `catalog_stale`).
     pub catalog_changes: Vec<String>,
+    /// Whether this daemon process is safely supervised (issue #2486).
+    ///
+    /// Why: a green `/health` alone is NOT sufficient evidence that launchd
+    /// won a `bootout → cargo install → bootstrap` restart — a stdio bridge
+    /// racing the restart can auto-spawn an ORPHAN daemon (PPID pointing at
+    /// the client chain, not launchd) that answers `/health` 200 but lacks the
+    /// plist's `EnvironmentVariables` (`TELEGRAM_BOT_TOKEN`,
+    /// `OPENROUTER_API_KEY`) and runs with `cwd=$HOME`. Operators and tooling
+    /// verifying a restart must check this flag, not just the HTTP status.
+    /// What: `true` when either (a) this process is itself launchd-supervised,
+    /// or (b) no trusty-mpm launchd unit is registered on this host at all (a
+    /// bare dev-run daemon with no plist is not hazardous). `false` only in
+    /// the hazardous state: a launchd unit IS registered but this process was
+    /// NOT launched by launchd — the #2486 orphan-daemon signature. Computed
+    /// once at daemon startup by `commands::launchd_probe::compute_supervised`.
+    /// Test: `health_response_serializes_supervised_field`;
+    /// `compute_supervised_*` in `commands::launchd_probe::tests`.
+    #[serde(default = "default_supervised")]
+    pub supervised: bool,
+}
+
+/// Default for [`HealthResponse::supervised`] on deserialize — matches the
+/// "safe" default so an older daemon response missing the field never reads
+/// as hazardous.
+fn default_supervised() -> bool {
+    true
 }
 
 /// Response of `GET /sessions`.

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -72,6 +72,25 @@ async fn health_reports_catalog_unknown_without_catalog() {
 }
 
 #[tokio::test]
+async fn health_response_serializes_supervised_field() {
+    // #2486: `supervised` must be a real field on the `/health` wire shape,
+    // defaulted `true` (safe) until `daemon_run` computes and sets it.
+    let state = DaemonState::shared();
+    let Json(body) = health(State(state)).await;
+    assert!(
+        body.supervised,
+        "supervised defaults true before daemon_run sets it"
+    );
+
+    let value = serde_json::to_value(&body).expect("HealthResponse must serialize");
+    assert_eq!(
+        value.get("supervised"),
+        Some(&serde_json::Value::Bool(true)),
+        "wire shape must carry `supervised`: {value}"
+    );
+}
+
+#[tokio::test]
 async fn current_project_found_and_missing() {
     // `GET /projects/current` returns the project for a registered path
     // and `404` for an unregistered one.

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -273,6 +273,23 @@ pub struct DaemonState {
     /// Test: `daemon::managed_routes::proxy::tests`, `tests/proxy_routes.rs`.
     pub(super) proxy_focus:
         Arc<std::sync::Mutex<HashMap<String, crate::client::proxy::FocusTarget>>>,
+    /// Launchd-supervision signal for `GET /health` (issue #2486).
+    ///
+    /// Why: a green `/health` alone does not prove launchd owns this process —
+    /// see [`crate::daemon::api::types::HealthResponse::supervised`] for the
+    /// full restart-race rationale. This field is the mutable half of that
+    /// signal: it defaults to the safe value (`true`) at construction because
+    /// the real probe (`commands::launchd_probe::compute_supervised`) needs
+    /// process startup context (env vars, PPID) that only `daemon_run` — the
+    /// actual `tm daemon` entry point — has readily at hand; test-only
+    /// constructors never override it.
+    /// What: an `AtomicBool` so `daemon_run` can set it once, post-construction,
+    /// without requiring `&mut DaemonState` through the shared `Arc`. Read via
+    /// [`Self::supervised`], written via [`Self::set_supervised`].
+    /// Test: `health_response_serializes_supervised_field` asserts the default;
+    /// `commands::launchd_probe::tests` cover the pure decision logic that
+    /// `daemon_run` uses to compute the value passed to `set_supervised`.
+    pub(super) supervised: std::sync::atomic::AtomicBool,
 }
 
 impl Default for DaemonState {
@@ -359,6 +376,7 @@ impl DaemonState {
             deliverable_manager: tokio::sync::OnceCell::new(),
             session_registry,
             proxy_focus: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            supervised: std::sync::atomic::AtomicBool::new(true),
         }
     }
 
@@ -418,6 +436,7 @@ impl DaemonState {
             deliverable_manager: tokio::sync::OnceCell::new(),
             session_registry,
             proxy_focus: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            supervised: std::sync::atomic::AtomicBool::new(true),
         }
     }
 
@@ -433,6 +452,26 @@ impl DaemonState {
     /// `with_root` a tempdir and asserts the handler reads it.
     pub fn framework_root(&self) -> &std::path::Path {
         &self.framework_root
+    }
+
+    /// Whether this daemon process is currently considered safely supervised
+    /// (issue #2486). See [`Self::supervised`] field doc for the full rationale.
+    /// What: relaxed-ordering read — this is a startup-once flag, not a
+    /// synchronization primitive; any ordering suffices.
+    /// Test: `health_response_serializes_supervised_field`.
+    pub fn supervised(&self) -> bool {
+        self.supervised.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Set the launchd-supervision signal (issue #2486). Called exactly once
+    /// by `daemon_run::run_daemon` right after startup, using the value
+    /// computed by `commands::launchd_probe::compute_supervised`.
+    /// What: relaxed-ordering store — see [`Self::supervised`].
+    /// Test: `health_response_serializes_supervised_field` exercises the
+    /// default; the daemon e2e suite exercises the post-`run_daemon` value.
+    pub fn set_supervised(&self, value: bool) {
+        self.supervised
+            .store(value, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// The shared focus-state store for the local session-manager PROXY routes.

--- a/crates/trusty-search/src/commands/serve.rs
+++ b/crates/trusty-search/src/commands/serve.rs
@@ -121,7 +121,8 @@ async fn ensure_search_daemon_up() -> Result<String> {
         }),
         startup_timeout: None,
         poll_interval: None,
-        no_spawn: false, // trusty-search bridge may auto-start its daemon
+        no_spawn: false,     // trusty-search bridge may auto-start its daemon
+        no_spawn_hint: None, // unused: no_spawn is false
     };
     trusty_common::mcp::ensure_daemon_up(&config).await
 }

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -203,6 +203,18 @@ After the first signed install, grant Full Disk Access once:
 After this one-time grant, future `scripts/install-trusty-search-signed.sh`
 reinstalls keep the FDA grant — no re-granting needed.
 
+🔴 **A 200 `GET /health` right after `bootstrap` is NOT sufficient evidence the
+restart succeeded** (issue #2486) — a client racing the restart window (e.g. an
+MCP stdio bridge's auto-reconnect) can spawn an orphan daemon that answers
+`/health` 200 while missing the plist's `EnvironmentVariables` and running with
+the wrong `cwd`. Verify launchd actually owns the new process with one of:
+
+```bash
+launchctl print gui/$(id -u)/<label>                       # launchd's own view
+ps -o ppid= -p "$(pgrep -fx '<daemon process>' | head -1)"  # must print "1"
+curl -s http://127.0.0.1:<port>/health | jq '.supervised'   # trusty-mpm only; must print true
+```
+
 ### Notarization Appendix (Optional — for distributing to OTHER machines)
 
 Notarization is **not required** for local FDA persistence. It is only needed


### PR DESCRIPTION
## Root cause

During the documented `launchctl bootout → cargo install → launchctl bootstrap` restart of the trusty-mpm daemon, trusty-console's auto-reconnect can win the race: it spawns a fresh `tm serve --stdio` bridge child, whose startup calls `ensure_daemon_up` with `no_spawn: false` (hardcoded), which auto-spawns an **orphan** daemon (PPID pointing at the client chain, not launchd) *before* launchd relaunches the supervised one.

The orphan answers `GET /health` with 200 — so a green health check is **not** sufficient evidence launchd won the race — but it is missing the plist's `EnvironmentVariables` (`TELEGRAM_BOT_TOKEN`, `OPENROUTER_API_KEY`) and runs with `cwd=$HOME`, so features like the Telegram poller silently never start.

## Fixes

1. **Bridge no-spawn gate** (`crates/trusty-mpm/src/bin/tm/commands/serve_stdio.rs`): `build_bridge_config()` now sets `no_spawn: true` whenever a trusty-mpm launchd unit is registered (probed at `~/Library/LaunchAgents/com.trusty.mpm{,.supervisor}.plist`), mirroring trusty-memory's #1152 fix. When no launchd unit exists (dev machine), auto-spawn stays the default, matching `tm start`'s pre-existing behaviour. The console's existing backoff/retry recovers once launchd finishes the restart — no trusty-console changes needed.
2. **`/health` supervision signal** (`crates/trusty-mpm/src/daemon/api/types.rs`, `state/core.rs`, `daemon_run.rs`): `HealthResponse` gains `supervised: bool`. Computed once at daemon startup (`daemon_run::apply_supervision_signal`, reusing `trusty_common::update::is_launchd_supervised` — newly enabled via the zero-dependency `update-check` feature), stored on `DaemonState` as an `AtomicBool`, and logged with `tracing::warn!` once when hazardous. Semantics: `true` when either the process is itself launchd-supervised OR no trusty-mpm launchd unit exists at all (dev-run daemon, not hazardous); `false` only in the hazardous #2486 state — a launchd unit is registered but this process was NOT launched by launchd.
3. **Shared pure decision layer** (`crates/trusty-mpm/src/bin/tm/commands/launchd_probe.rs`, new file): `mpm_launchd_plist_exists()` (the fs probe), `compute_supervised(is_launchd, plist_exists)` and `compute_no_spawn(plist_exists)` — both pure functions, unit-tested for every truth-table combination without touching launchd or the filesystem.
4. **Docs**: `.trusty-mpm/INSTRUCTIONS.md` (Connection-safe daemon restart convention) and `docs/reference/release-workflow.md` gain a verification callout — `launchctl print`, a PPID==1 check, or `GET /health | jq .supervised` — making explicit that a bare 200 health check does not prove launchd owns the process.

## Test evidence

- `commands::launchd_probe::tests` — 6/6 pure decision-table tests pass (every (is_launchd, plist_exists) combination).
- `commands::serve_stdio::tests::build_bridge_config_no_spawn_matches_plist_probe` — pins the wiring from `build_bridge_config` to the shared probe.
- `daemon::api::tests::health_response_serializes_supervised_field` — asserts the field defaults `true` and is present on the wire (`serde_json::to_value`).
- `cargo test -p trusty-mpm`: **2898 + 860 + 860 + … all `ok`, 0 failed** across every target (lib, both bin targets, all integration test files).
- `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `bash scripts/check_line_cap.sh` — all clean.
- `cargo check -p trusty-mpm --features swagger-ui` — confirms the new `HealthResponse` field doesn't break the OpenAPI schema derive.

Note: two workspace-wide `cargo test --workspace` runs surfaced pre-existing, unrelated flakes in different crates each run (`trusty-common::update::tests` — a nanosecond-timestamp cache-file race between two parallel tests; `trusty-console::proxy::routes::tests` — a retry-timing test) — neither crate is touched by this diff, and `trusty-common`'s flake reproduces identically with `--test-threads=1` disabled and disappears with it enabled, confirming pure test-isolation timing, not a regression from this change.

Closes #2486

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools