### PR TITLE
refactor(trusty-code): migrate onto trusty_common::inference — Fireworks usable in tcode

### DIFF
--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -69,7 +69,13 @@ regex = { workspace = true }
 # `axum-server` enables `trusty_common::server::with_standard_middleware`
 # (CORS/trace/gzip) so `tcode serve --http` matches the trusty-memory/
 # trusty-search middleware stack exactly.
-trusty-common = { workspace = true, features = ["catchup", "mcp", "axum-server"] }
+# `inference-client` (#2406, epic #2400) provides the shared inference adapter
+# layer (`trusty_common::inference`) tcode's OpenRouter/Fireworks transport is
+# built on: the OpenAI-compatible HTTP core, the two-stage credential resolver
+# (env > .env.local > secure store), and the capability registry. It composes
+# with `axum-server` to expose `inference::test_support::MockInferenceServer`
+# for the offline black-box e2e in `tests/inference_shared_adapter_e2e.rs`.
+trusty-common = { workspace = true, features = ["catchup", "mcp", "axum-server", "inference-client"] }
 
 # `tcode serve --http`: POST /rpc + GET /health over axum (#2053). Per
 # CLAUDE.md, axum stays feature-gated in *library* crates

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -1591,14 +1591,14 @@ async fn finish_gate_inert_without_named_test_command() {
 ///
 /// Why: End-to-end confidence that the loop drives a real model to a final
 /// answer. Gated on `OPENROUTER_API_KEY` so CI stays offline-green.
-/// What: Build a real `LlmClient`, register the echo tool, and ask the model to
-/// reply with a short word; assert a non-empty final answer and that usage
-/// accrued.
+/// What: Build a real `OpenAiCompatClient` (shared-adapter transport, #2406),
+/// register the echo tool, and ask the model to reply with a short word; assert
+/// a non-empty final answer and that usage accrued.
 /// Test: `cargo test -p trusty-code -- --include-ignored agent_loop_live`.
 #[tokio::test]
 #[ignore = "requires OPENROUTER_API_KEY; skipped in CI"]
 async fn agent_loop_live() {
-    use crate::llm::{LlmClient, LlmClientConfig};
+    use crate::llm::OpenAiCompatClient;
 
     let Ok(key) = std::env::var("OPENROUTER_API_KEY") else {
         eprintln!("OPENROUTER_API_KEY not set — skipping live agent-loop test");
@@ -1609,12 +1609,9 @@ async fn agent_loop_live() {
         return;
     }
 
-    let client = LlmClient::from_config(
-        LlmClientConfig::new(key)
-            .expect("config")
-            .with_title("trusty-code-agent-loop-test"),
-    )
-    .expect("client");
+    // Construction is credential-free; the shared resolver reads
+    // `OPENROUTER_API_KEY` (confirmed present above) at first use.
+    let client = OpenAiCompatClient::new();
 
     let registry = registry_with_echo(false);
     let agent = AgentLoop::new(

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -133,17 +133,22 @@ pub mod rbac;
 
 // ── Phase 3 agents + LLM layer (per #642) ──
 
-/// Native OpenRouter LLM client.
+/// LLM transports for trusty-code.
 ///
-/// Why: trusty-code agents need to invoke LLMs via the OpenRouter API without
-/// depending on third-party Rust SDK crates that pin us to specific provider
-/// contracts. A thin native client gives full control over the wire format,
-/// headers, and error handling.
-/// What: Exports `LlmClient`, `LlmClientConfig`, all request/response types
-/// (`ChatRequest`, `ChatResponse`, `ChatMessage`, `ToolDefinition`, …), and
-/// `LlmError`. The API key is injected at construction time.
+/// Why: trusty-code agents invoke LLMs via OpenAI-compatible endpoints
+/// (OpenRouter / Fireworks) and AWS Bedrock. Since #2406 (epic #2400) the
+/// OpenAI-compatible HTTP mechanics live in the shared `trusty_common::inference`
+/// adapter layer rather than a bespoke tcode client, so credential resolution,
+/// error classification, and the wire schema are shared across the ecosystem.
+/// What: Exports `OpenAiCompatClient` (shared OpenRouter/Fireworks transport),
+/// `DispatchingLlmClient` (slug-routed transport), `BedrockChatClient`, all
+/// request/response types (`ChatRequest`, `ChatResponse`, `ChatMessage`,
+/// `ToolDefinition`, …), and `LlmError`. Credentials resolve via the shared
+/// 3-tier chain (env > `.env.local` > secure store) at first use.
 /// Test: `cargo test -p trusty-code` covers serialisation, deserialisation,
-/// and error-mapping unit tests. `--include-ignored` adds the live HTTP test.
+/// type-conversion, and error-mapping unit tests plus the offline black-box
+/// e2e (`tests/inference_shared_adapter_e2e.rs`). `--include-ignored` adds the
+/// live provider tests.
 pub mod llm;
 
 /// Agent configuration loading.

--- a/crates/trusty-code/src/llm/client.rs
+++ b/crates/trusty-code/src/llm/client.rs
@@ -1,176 +1,279 @@
-//! HTTP client for the OpenRouter `/v1/chat/completions` endpoint.
+//! OpenAI-compatible inference transport, backed by the shared
+//! `trusty_common::inference` adapter layer (#2406, epic #2400).
 //!
-//! Why: trusty-code needs a native LLM client that speaks the OpenAI
-//! chat-completions schema and works with any OpenRouter-hosted model slug —
-//! without pulling in the `async-openai` crate (which adds dependency weight
-//! and couples us to Anthropic's published API directly).
-//! What: `LlmClient` wraps a `reqwest::Client`, holds the API key and optional
-//! HTTP-Referer header, and exposes a single `chat` method that posts a
-//! `ChatRequest` and returns a `ChatResponse`.  API-key injection happens at
-//! construction time so library code never reads from `std::env` itself.
-//! Test: Unit tests in `llm::types::tests` cover serialisation / deserialisation.
-//! The ignore-gated integration test `live_openrouter_call` in this file sends a
-//! real request (requires `OPENROUTER_API_KEY` in env).
+//! Why: trusty-code used to hand-roll its own OpenRouter `reqwest` client. Epic
+//! #2400 centralises the OpenAI-compatible HTTP mechanics (auth, the OpenRouter
+//! detailed-usage directive, HTTP→error classification, response parsing) in
+//! ONE shared core so every consumer shares it instead of six near-identical
+//! copies. This module is tcode's thin consumer of that core: it selects the
+//! provider (OpenRouter or Fireworks) by model slug, resolves the credential via
+//! the shared 3-tier resolver (process env > `.env.local` > secure store),
+//! builds the matching `trusty_common::inference` adapter once (caching it so
+//! the underlying `reqwest` connection pool is reused across a run's many
+//! turns — a bake-off latency concern), and bridges tcode's request/response
+//! types across the seam (`super::convert`). Bedrock stays on its own Converse
+//! transport (`super::bedrock`, routed by `super::dispatch`) — its migration
+//! into commons is #2407.
+//! What: [`OpenAiCompatClient`] implements [`LlmClientTrait`]. `fireworks/*`
+//! slugs route to the Fireworks adapter (stripping the `fireworks/` routing
+//! prefix to the provider-native model id and requiring `FIREWORKS_API_KEY`);
+//! everything else routes to OpenRouter, sending the slug unchanged (identical
+//! to the pre-#2406 behaviour). A missing credential surfaces at `chat()` time
+//! (not construction), preserving the #2245 deferred-failure contract. The base
+//! URLs are overridable (`TCODE_OPENROUTER_BASE_URL` / `TCODE_FIREWORKS_BASE_URL`
+//! or [`OpenAiCompatClient::with_config`]) so an offline mock server can be
+//! targeted end-to-end.
+//! Test: `client::tests::*` (provider selection, prefix stripping, hermetic
+//! missing-credential path against an injected empty store) and the black-box
+//! HTTP round-trip in `tests/inference_shared_adapter_e2e.rs`; the `#[ignore]`
+//! `live_openrouter_call` / `live_fireworks_call` smokes hit the real APIs.
 
-use reqwest::Client;
+use std::collections::HashMap;
+use std::sync::Arc;
 
-use super::{error::LlmError, request::ChatRequest, response::ChatResponse};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use trusty_common::inference::{
+    InferenceAdapter,
+    credentials::{KeyStore, default_store, resolve_key_with},
+    provider_for,
+    providers::{fireworks, openrouter},
+    registry::ProviderId,
+};
 
-/// Base URL for OpenRouter's chat-completions endpoint.
-const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
+use super::client_trait::LlmClientTrait;
+use super::convert;
+use super::error::LlmError;
+use super::request::ChatRequest;
+use super::response::ChatResponse;
 
-/// Configuration for `LlmClient`.
+/// Env var overriding the OpenRouter API base URL (for offline mock testing /
+/// self-hosted gateways). Defaults to [`openrouter::OPENROUTER_BASE_URL`].
+const OPENROUTER_BASE_URL_ENV: &str = "TCODE_OPENROUTER_BASE_URL";
+
+/// Env var overriding the Fireworks API base URL. Defaults to
+/// [`fireworks::FIREWORKS_BASE_URL`].
+const FIREWORKS_BASE_URL_ENV: &str = "TCODE_FIREWORKS_BASE_URL";
+
+/// The provider name `crate::provider::provider_for` reports for `fireworks/*`
+/// slugs — the single routing condition this client checks (mirroring how
+/// `super::dispatch` keys Bedrock routing off the same factory).
+const FIREWORKS_PROVIDER_NAME: &str = "fireworks";
+
+/// OpenAI-compatible transport over the shared inference adapter, routing
+/// OpenRouter and Fireworks by model slug.
 ///
-/// Why: Separating config from the client struct makes it easy to construct the
-/// client from different sources (env, TOML config, tests) without duplicating
-/// the validation logic.
-/// What: Carries the API key (mandatory), an optional HTTP-Referer, and an
-/// optional X-Title header forwarded to OpenRouter for analytics.
-/// Test: `LlmClientConfig::from_env` unit-tested in `client_config_from_env`.
-#[derive(Debug, Clone)]
-pub struct LlmClientConfig {
-    /// OpenRouter API key (Bearer token).
-    pub api_key: String,
-
-    /// Optional HTTP-Referer sent to OpenRouter for request attribution.
-    pub http_referer: Option<String>,
-
-    /// Optional X-Title header sent to OpenRouter (appears in dashboards).
-    pub x_title: Option<String>,
+/// Why: one place that owns "which OpenAI-dialect provider, whose key, which
+/// base URL" so the dispatch layer and the agent loop stay backend-agnostic.
+/// What: holds the shared credential [`KeyStore`], the (overridable) per-provider
+/// base URLs, and a lazily-populated cache of built adapters keyed by
+/// [`ProviderId`] so each provider's `reqwest` client (and its connection pool)
+/// is constructed at most once per process.
+/// Test: `client::tests::*`.
+pub struct OpenAiCompatClient {
+    store: Box<dyn KeyStore>,
+    openrouter_base: String,
+    fireworks_base: String,
+    adapters: Mutex<HashMap<ProviderId, Arc<dyn InferenceAdapter>>>,
 }
 
-impl LlmClientConfig {
-    /// Construct from an explicit API key string.
+impl std::fmt::Debug for OpenAiCompatClient {
+    /// Redacting `Debug`: the [`KeyStore`] and built adapters hold credential
+    /// material, so this prints only the opaque type name.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAiCompatClient").finish_non_exhaustive()
+    }
+}
+
+impl OpenAiCompatClient {
+    /// Construct with the process-default secure store and base URLs.
     ///
-    /// Why: Tests and callers that already hold the key don't need an env read.
-    /// What: Validates that `api_key` is non-empty; returns `MissingConfig` if
-    /// it is.
-    /// Test: `client_config_direct_construction`.
-    pub fn new(api_key: impl Into<String>) -> Result<Self, LlmError> {
-        let api_key = api_key.into();
-        if api_key.is_empty() {
-            return Err(LlmError::MissingConfig("api_key must not be empty".into()));
+    /// Why: the production entry point — binary code funnels here so credential
+    /// resolution uses the same env > `.env.local` > store chain everywhere.
+    /// What: uses [`default_store`] and reads the base-URL env overrides once
+    /// (falling back to the real provider URLs). Never touches credentials, so
+    /// construction cannot fail on a missing key (#2245): that surfaces at
+    /// `chat()` time.
+    /// Test: `client::tests::selects_openrouter_for_plain_slug`.
+    pub fn new() -> Self {
+        Self::with_store(default_store())
+    }
+
+    /// Construct with an explicit [`KeyStore`], reading base URLs from the env
+    /// overrides (or the real provider defaults).
+    ///
+    /// Why: lets a hermetic test inject a `MemoryKeyStore` so credential
+    /// resolution never depends on the machine's real environment or `$HOME`.
+    /// What: as [`Self::new`] but with the caller's store.
+    /// Test: `client::tests::missing_openrouter_key_errors_at_chat_time`.
+    pub fn with_store(store: Box<dyn KeyStore>) -> Self {
+        let openrouter_base = std::env::var(OPENROUTER_BASE_URL_ENV)
+            .unwrap_or_else(|_| openrouter::OPENROUTER_BASE_URL.to_string());
+        let fireworks_base = std::env::var(FIREWORKS_BASE_URL_ENV)
+            .unwrap_or_else(|_| fireworks::FIREWORKS_BASE_URL.to_string());
+        Self::with_config(store, openrouter_base, fireworks_base)
+    }
+
+    /// Construct with an explicit store AND explicit base URLs.
+    ///
+    /// Why: the offline black-box e2e points both providers at a
+    /// [`trusty_common::inference::test_support::MockInferenceServer`] without
+    /// mutating process env (so the test stays parallel-safe).
+    /// What: stores all three inputs and an empty adapter cache.
+    /// Test: `tests/inference_shared_adapter_e2e.rs`.
+    pub fn with_config(
+        store: Box<dyn KeyStore>,
+        openrouter_base: String,
+        fireworks_base: String,
+    ) -> Self {
+        Self {
+            store,
+            openrouter_base,
+            fireworks_base,
+            adapters: Mutex::new(HashMap::new()),
         }
-        Ok(Self {
-            api_key,
-            http_referer: None,
-            x_title: None,
-        })
     }
 
-    /// Read the API key from the `OPENROUTER_API_KEY` environment variable.
+    /// Select the OpenAI-dialect provider for a model slug.
     ///
-    /// Why: Binary entry points call this once at startup; library helpers
-    /// never read env variables directly (convention from CLAUDE.md).
-    /// What: Reads `OPENROUTER_API_KEY`; returns `MissingConfig` if unset or
-    /// empty.
-    /// Test: `client_config_from_env_missing` (key absent → error).
-    pub fn from_env() -> Result<Self, LlmError> {
-        let key = std::env::var("OPENROUTER_API_KEY").unwrap_or_default();
-        Self::new(key)
+    /// Why: single source of truth — reuses `crate::provider::provider_for`, the
+    /// same factory `super::dispatch` consults for Bedrock routing and
+    /// `AgentLoop::build_request` consults for usage/caching decisions, so
+    /// routing can never disagree with normalisation.
+    /// What: [`ProviderId::Fireworks`] iff that factory reports `"fireworks"`,
+    /// else [`ProviderId::OpenRouter`] (the default for every other slug).
+    /// Test: `client::tests::selects_fireworks_for_prefixed_slug`,
+    /// `client::tests::selects_openrouter_for_plain_slug`.
+    fn provider_for_slug(model: &str) -> ProviderId {
+        if crate::provider::provider_for(model).name() == FIREWORKS_PROVIDER_NAME {
+            ProviderId::Fireworks
+        } else {
+            ProviderId::OpenRouter
+        }
     }
 
-    /// Set the optional HTTP-Referer attribution header.
+    /// The provider-native wire model id for a routing slug.
     ///
-    /// Why: OpenRouter uses this for per-project analytics in their dashboard.
-    /// What: Builder-style setter; returns `self` for chaining.
-    /// Test: `client_config_builder`.
-    pub fn with_referer(mut self, referer: impl Into<String>) -> Self {
-        self.http_referer = Some(referer.into());
-        self
+    /// Why: Fireworks serves bare `accounts/fireworks/models/*` ids, but tcode
+    /// routes on a `fireworks/`-prefixed slug; the prefix is a routing artefact
+    /// that must be stripped before the id is sent. OpenRouter takes the slug
+    /// verbatim (identical to pre-#2406).
+    /// What: strips a leading `fireworks/` for [`ProviderId::Fireworks`]; returns
+    /// the slug unchanged otherwise.
+    /// Test: `client::tests::fireworks_wire_model_strips_prefix`.
+    fn wire_model(provider: ProviderId, model: &str) -> String {
+        match provider {
+            ProviderId::Fireworks => model
+                .strip_prefix("fireworks/")
+                .unwrap_or(model)
+                .to_string(),
+            _ => model.to_string(),
+        }
     }
 
-    /// Set the optional X-Title attribution header.
+    /// Get (or lazily build + cache) the adapter for a provider.
     ///
-    /// Why: Appears in OpenRouter's request logs as a human-readable label.
-    /// What: Builder-style setter; returns `self` for chaining.
-    /// Test: `client_config_builder`.
-    pub fn with_title(mut self, title: impl Into<String>) -> Self {
-        self.x_title = Some(title.into());
-        self
-    }
-}
-
-/// Async HTTP client for the OpenRouter chat-completions API.
-///
-/// Why: Centralises all HTTP mechanics (header injection, error handling,
-/// response parsing) so call sites only deal with `ChatRequest` / `ChatResponse`.
-/// What: Wraps a `reqwest::Client` and `LlmClientConfig`; exposes `chat` as the
-/// sole public method.  The client is cheaply cloneable (`reqwest::Client` uses
-/// an `Arc` internally).
-/// Test: Serialisation/deserialisation unit tests live in `llm::types::tests`.
-/// The `#[ignore]`-gated `live_openrouter_call` test below validates the full
-/// HTTP round-trip.
-#[derive(Debug, Clone)]
-pub struct LlmClient {
-    http: Client,
-    config: LlmClientConfig,
-}
-
-impl LlmClient {
-    /// Construct an `LlmClient` from an explicit config.
-    ///
-    /// Why: Allows dependency injection in tests and in callers that manage
-    /// their own key source.
-    /// What: Builds a `reqwest::Client` with rustls TLS; returns an error if
-    /// the HTTP client cannot be constructed (extremely rare).
-    /// Test: `lm_client_from_config`.
-    pub fn from_config(config: LlmClientConfig) -> Result<Self, LlmError> {
-        let http = Client::builder()
-            .use_rustls_tls()
-            .build()
-            .map_err(LlmError::Transport)?;
-        Ok(Self { http, config })
+    /// Why: building an adapter constructs a `reqwest` client; doing that once
+    /// per provider and reusing it preserves connection pooling across a run's
+    /// turns (a latency/cost baseline concern), mirroring the original client's
+    /// build-once-at-startup behaviour.
+    /// What: returns the cached `Arc` on a hit; on a miss builds via
+    /// [`Self::build_adapter`], inserts, and returns it. A build failure is
+    /// returned (not cached), so a later turn can retry once the credential is
+    /// fixed.
+    /// Test: exercised by every `chat` path.
+    async fn adapter_for(
+        &self,
+        provider: ProviderId,
+    ) -> Result<Arc<dyn InferenceAdapter>, LlmError> {
+        {
+            let cache = self.adapters.lock().await;
+            if let Some(adapter) = cache.get(&provider) {
+                return Ok(adapter.clone());
+            }
+        }
+        let built: Arc<dyn InferenceAdapter> = Arc::from(self.build_adapter(provider)?);
+        let mut cache = self.adapters.lock().await;
+        Ok(cache.entry(provider).or_insert(built).clone())
     }
 
-    /// Construct from the `OPENROUTER_API_KEY` environment variable.
+    /// Resolve the credential and build the shared adapter for a provider.
     ///
-    /// Why: Convenience entry point for binary code that reads config from env.
-    /// What: Delegates to `LlmClientConfig::from_env`, then `from_config`.
-    /// Test: Integration test `live_openrouter_call` uses this path.
-    pub fn from_env() -> Result<Self, LlmError> {
-        Self::from_config(LlmClientConfig::from_env()?)
+    /// Why: this is the seam that reuses the shared resolver + provider factory
+    /// while keeping tcode's routing decision authoritative — we build ONLY the
+    /// provider tcode selected, never letting the shared resolver's own
+    /// prefix-based fallbacks silently re-home a request to OpenAI-direct or
+    /// Anthropic-direct.
+    /// What: for Fireworks, first resolves the `FIREWORKS_API_KEY` explicitly via
+    /// the shared resolver so a missing key is ALWAYS a clear, Fireworks-specific
+    /// [`LlmError::MissingConfig`] — never the shared two-stage resolver's silent
+    /// fall-back to OpenRouter (which would be a wrong-provider misroute), and
+    /// never an OpenRouter-flavoured error when both keys happen to be absent;
+    /// only once the key is confirmed does it resolve + build the Fireworks
+    /// adapter. For OpenRouter, resolves on an `openrouter/` routing slug (a
+    /// missing key surfaces as the resolver's own `MissingCredential`, mapped to
+    /// `MissingConfig`). The resolved model slug is irrelevant to the built
+    /// adapter (it sends the per-request wire model), so a fixed routing slug is
+    /// used.
+    /// Test: `client::tests::missing_openrouter_key_errors_at_chat_time`,
+    /// `client::tests::missing_fireworks_key_errors_not_falls_back`.
+    fn build_adapter(&self, provider: ProviderId) -> Result<Box<dyn InferenceAdapter>, LlmError> {
+        match provider {
+            ProviderId::Fireworks => {
+                if resolve_key_with("fireworks", self.store.as_ref()).is_none() {
+                    return Err(LlmError::MissingConfig(
+                        "FIREWORKS_API_KEY is required to reach a fireworks/* model. Export it \
+                         (e.g. `export FIREWORKS_API_KEY=fw_...`), add it to .env.local, or set it \
+                         via `tcode config keys set fireworks`."
+                            .to_string(),
+                    ));
+                }
+                // The key is present, so stage-1 of the resolver returns Fireworks.
+                let resolved = provider_for("fireworks/route", self.store.as_ref())
+                    .map_err(convert::map_error)?;
+                fireworks::build(&resolved, &self.fireworks_base).map_err(convert::map_error)
+            }
+            _ => {
+                let resolved = provider_for("openrouter/route", self.store.as_ref())
+                    .map_err(convert::map_error)?;
+                openrouter::build(&resolved, &self.openrouter_base).map_err(convert::map_error)
+            }
+        }
     }
 
-    /// POST a `ChatRequest` to OpenRouter and return the parsed `ChatResponse`.
+    /// Route + issue one chat call through the shared adapter.
     ///
-    /// Why: Single-method surface keeps call sites simple and makes mocking
-    /// (for future test doubles) easy.
-    /// What: Serialises `req` to JSON, adds required OpenRouter headers
-    /// (`Authorization`, optional `HTTP-Referer`, optional `X-Title`), sends
-    /// the POST, and deserialises the response body.  Non-2xx responses are
-    /// mapped to `LlmError::ApiError` with the raw body included.
-    /// Test: `live_openrouter_call` (#[ignore]) validates the happy path.
-    /// Unit tests in `types.rs` cover the serialisation/deserialisation paths.
+    /// Why: the single method [`LlmClientTrait`] exposes; all provider selection,
+    /// prefix stripping, credential resolution, and type bridging live behind it.
+    /// What: selects the provider from `req.model`, gets its cached adapter,
+    /// converts the request (with the provider-native wire model), calls the
+    /// shared adapter, maps any error, and converts the response back.
+    /// Test: `client::tests::*` and `tests/inference_shared_adapter_e2e.rs`.
     pub async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
-        let mut builder = self
-            .http
-            .post(OPENROUTER_BASE_URL)
-            .header("Authorization", format!("Bearer {}", self.config.api_key))
-            .header("Content-Type", "application/json");
+        let provider = Self::provider_for_slug(&req.model);
+        let adapter = self.adapter_for(provider).await?;
+        let wire_model = Self::wire_model(provider, &req.model);
+        let shared_req = convert::to_shared_request(req, wire_model);
+        let shared_resp = adapter
+            .chat(&shared_req)
+            .await
+            .map_err(convert::map_error)?;
+        Ok(convert::from_shared_response(shared_resp))
+    }
+}
 
-        if let Some(referer) = &self.config.http_referer {
-            builder = builder.header("HTTP-Referer", referer.as_str());
-        }
-        if let Some(title) = &self.config.x_title {
-            builder = builder.header("X-Title", title.as_str());
-        }
+impl Default for OpenAiCompatClient {
+    /// Delegates to [`OpenAiCompatClient::new`].
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
-        let resp = builder.json(req).send().await?;
-
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(LlmError::ApiError {
-                status: status.as_u16(),
-                body,
-            });
-        }
-
-        // Read the full body first so we can include it in deserialisation errors.
-        let body = resp.text().await?;
-        serde_json::from_str::<ChatResponse>(&body)
-            .map_err(|source| LlmError::Deserialise { source, body })
+#[async_trait]
+impl LlmClientTrait for OpenAiCompatClient {
+    /// Forward to the inherent [`OpenAiCompatClient::chat`].
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        OpenAiCompatClient::chat(self, req).await
     }
 }
 
@@ -179,100 +282,150 @@ impl LlmClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::llm::{ChatMessage, ChatRequest};
+    use trusty_common::inference::credentials::MemoryKeyStore;
 
-    /// `LlmClientConfig::new` rejects an empty API key.
+    /// A plain (non-fireworks) slug selects OpenRouter.
     ///
-    /// Why: An empty key would produce a confusing 401 from the API; we want
-    /// to fail at construction time with a clear error.
-    /// What: Pass an empty string, assert `MissingConfig` error.
+    /// Why: preserves the pre-#2406 default — every non-fireworks, non-bedrock
+    /// slug goes to OpenRouter unchanged.
+    /// What: assert the provider selection for representative OpenRouter slugs.
     /// Test: this test.
     #[test]
-    fn client_config_rejects_empty_key() {
-        let err = LlmClientConfig::new("").unwrap_err();
+    fn selects_openrouter_for_plain_slug() {
+        for slug in [
+            "openai/gpt-4o-mini",
+            "anthropic/claude-sonnet-4-5",
+            "qwen/qwen-2.5-coder-32b-instruct",
+        ] {
+            assert_eq!(
+                OpenAiCompatClient::provider_for_slug(slug),
+                ProviderId::OpenRouter,
+                "{slug} must select OpenRouter"
+            );
+        }
+    }
+
+    /// A `fireworks/*` slug selects Fireworks.
+    ///
+    /// Why: this is the routing decision that makes Fireworks reachable (#2406).
+    /// What: assert the provider selection for a fireworks slug.
+    /// Test: this test.
+    #[test]
+    fn selects_fireworks_for_prefixed_slug() {
+        assert_eq!(
+            OpenAiCompatClient::provider_for_slug(
+                "fireworks/accounts/fireworks/models/llama-v3p1-70b-instruct"
+            ),
+            ProviderId::Fireworks
+        );
+    }
+
+    /// The Fireworks wire model strips the `fireworks/` routing prefix; the
+    /// OpenRouter wire model is the slug verbatim.
+    ///
+    /// Why: Fireworks 404s on the prefixed id; OpenRouter needs the slug as-is.
+    /// What: assert both directions.
+    /// Test: this test.
+    #[test]
+    fn fireworks_wire_model_strips_prefix() {
+        assert_eq!(
+            OpenAiCompatClient::wire_model(
+                ProviderId::Fireworks,
+                "fireworks/accounts/fireworks/models/llama-v3p1-70b-instruct"
+            ),
+            "accounts/fireworks/models/llama-v3p1-70b-instruct"
+        );
+        assert_eq!(
+            OpenAiCompatClient::wire_model(ProviderId::OpenRouter, "openai/gpt-4o-mini"),
+            "openai/gpt-4o-mini"
+        );
+    }
+
+    /// With an empty store and (assumed) no `OPENROUTER_API_KEY` env, an
+    /// OpenRouter chat fails at `chat()` time with a `MissingConfig` — never at
+    /// construction (#2245 deferred-failure contract).
+    ///
+    /// Why: pins that construction is credential-free and that the missing-key
+    /// error is actionable and surfaces only when a request needs it.
+    /// What: build with an empty `MemoryKeyStore`; if the ambient env happens to
+    /// carry a real key (dev machines), skip the assertion rather than make a
+    /// live call — the hermetic case (no env key) is what CI exercises.
+    /// Test: this test.
+    #[tokio::test]
+    async fn missing_openrouter_key_errors_at_chat_time() {
+        if std::env::var("OPENROUTER_API_KEY").is_ok_and(|v| !v.is_empty()) {
+            return; // real key present locally — don't issue a live call
+        }
+        let client = OpenAiCompatClient::with_store(Box::new(MemoryKeyStore::new())); // empty store
+        let req = ChatRequest {
+            model: "openai/gpt-4o-mini".into(),
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            tool_choice: None,
+            usage: None,
+        };
+        let err = client
+            .chat(&req)
+            .await
+            .expect_err("must fail without a key");
         assert!(
             matches!(err, LlmError::MissingConfig(_)),
             "expected MissingConfig, got: {err:?}"
         );
     }
 
-    /// `LlmClientConfig::new` accepts a non-empty key.
+    /// A `fireworks/*` request with no `FIREWORKS_API_KEY` fails with an
+    /// explicit `MissingConfig` — it must NOT silently fall back to OpenRouter.
     ///
-    /// Why: Baseline happy-path for construction.
-    /// What: Pass a fake key, assert `Ok`.
+    /// Why: the shared resolver's stage-1 falls through to OpenRouter when a
+    /// family key is absent; for an explicit tcode fireworks route that would be
+    /// a wrong-provider misroute, so `build_adapter` turns it into a clear error.
+    /// What: with an empty store (and, when present locally, a real
+    /// `FIREWORKS_API_KEY` shadowing it, in which case skip), assert
+    /// `MissingConfig`.
     /// Test: this test.
-    #[test]
-    fn client_config_direct_construction() {
-        let cfg = LlmClientConfig::new("sk-or-test-key").expect("should succeed");
-        assert_eq!(cfg.api_key, "sk-or-test-key");
-        assert!(cfg.http_referer.is_none());
-        assert!(cfg.x_title.is_none());
-    }
-
-    /// Builder methods chain correctly.
-    ///
-    /// Why: Verify the builder pattern sets optional fields.
-    /// What: Chain `with_referer` and `with_title`, assert both are set.
-    /// Test: this test.
-    #[test]
-    fn client_config_builder() {
-        let cfg = LlmClientConfig::new("sk-or-x")
-            .unwrap()
-            .with_referer("https://example.com")
-            .with_title("trusty-code");
-        assert_eq!(cfg.http_referer.as_deref(), Some("https://example.com"));
-        assert_eq!(cfg.x_title.as_deref(), Some("trusty-code"));
-    }
-
-    /// `LlmClientConfig::from_env` returns `MissingConfig` when the env var is absent.
-    ///
-    /// Why: Prevent silent failures when the key is not configured.
-    /// What: Remove the env var, call `from_env`, assert error.
-    /// Test: this test.
-    #[test]
-    fn client_config_from_env_missing() {
-        // Temporarily unset the key (may already be absent in CI).
-        let prev = std::env::var("OPENROUTER_API_KEY").ok();
-        unsafe {
-            std::env::remove_var("OPENROUTER_API_KEY");
+    #[tokio::test]
+    async fn missing_fireworks_key_errors_not_falls_back() {
+        if std::env::var("FIREWORKS_API_KEY").is_ok_and(|v| !v.is_empty()) {
+            return; // real key present locally — the fall-back guard isn't exercised
         }
-        let result = LlmClientConfig::from_env();
-        // Restore before asserting (so other tests are not affected even if this
-        // assertion panics).
-        if let Some(k) = prev {
-            unsafe { std::env::set_var("OPENROUTER_API_KEY", k) };
+        let client = OpenAiCompatClient::with_store(Box::new(MemoryKeyStore::new()));
+        let req = ChatRequest {
+            model: "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct".into(),
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            tool_choice: None,
+            usage: None,
+        };
+        let err = client
+            .chat(&req)
+            .await
+            .expect_err("must fail without a key");
+        match err {
+            LlmError::MissingConfig(msg) => {
+                assert!(
+                    msg.contains("FIREWORKS_API_KEY"),
+                    "unhelpful message: {msg}"
+                )
+            }
+            other => panic!("expected MissingConfig naming FIREWORKS_API_KEY, got: {other:?}"),
         }
-        assert!(
-            result.is_err(),
-            "expected Err when OPENROUTER_API_KEY is unset"
-        );
     }
 
-    /// `LlmClient::from_config` succeeds with a valid config.
+    /// Live integration: a real OpenRouter round-trip via the shared adapter.
     ///
-    /// Why: Verifies the reqwest client builds without error.
-    /// What: Construct with a fake key, assert `Ok`.
-    /// Test: this test.
-    #[test]
-    fn lm_client_from_config() {
-        let cfg = LlmClientConfig::new("sk-or-test").unwrap();
-        let client = LlmClient::from_config(cfg);
-        assert!(client.is_ok(), "expected Ok, got: {client:?}");
-    }
-
-    /// Live integration test: send a trivial prompt to a cheap OpenRouter model.
-    ///
-    /// Why: End-to-end validation that `LlmClient::chat` produces a non-empty
-    /// assistant response and non-zero `TokenUsage`.
-    /// What: Read `OPENROUTER_API_KEY` from env; skip (not fail) if absent.
-    /// POST a single-turn prompt to `openai/gpt-4o-mini`; assert non-empty
-    /// `first_text()` and `usage.prompt_tokens > 0`.
-    /// Test: Run with `cargo test -p trusty-code -- --include-ignored`.
+    /// Why: end-to-end validation (ported from the pre-#2406 `live_openrouter_call`)
+    /// that tcode's transport, now on the shared adapter, still produces a
+    /// non-empty reply and non-zero usage.
+    /// What: reads `OPENROUTER_API_KEY`; SKIPS (does not fail) when absent.
+    /// Test: `cargo test -p trusty-code -- --include-ignored live_openrouter`.
     #[tokio::test]
     #[ignore = "requires OPENROUTER_API_KEY; skipped in CI"]
     async fn live_openrouter_call() {
-        // Skip gracefully when the key is not present (e.g. in a dev env that
-        // hasn't set it up yet) so the test doesn't block others.
         let Ok(key) = std::env::var("OPENROUTER_API_KEY") else {
             eprintln!("OPENROUTER_API_KEY not set — skipping live test");
             return;
@@ -281,19 +434,12 @@ mod tests {
             eprintln!("OPENROUTER_API_KEY is empty — skipping live test");
             return;
         }
-
-        let config = LlmClientConfig::new(key)
-            .unwrap()
-            .with_referer("https://github.com/bobmatnyc/trusty-tools")
-            .with_title("trusty-code-integration-test");
-
-        let client = LlmClient::from_config(config).expect("build client");
-
+        let client = OpenAiCompatClient::new();
         let req = ChatRequest {
             model: "openai/gpt-4o-mini".into(),
             messages: vec![
-                ChatMessage::system("You are a concise assistant."),
-                ChatMessage::user("Reply with exactly the word: pong"),
+                super::super::ChatMessage::system("You are a concise assistant."),
+                super::super::ChatMessage::user("Reply with exactly the word: pong"),
             ],
             temperature: Some(0.0),
             max_tokens: Some(16),
@@ -301,21 +447,54 @@ mod tests {
             tool_choice: None,
             usage: None,
         };
-
         let resp = client.chat(&req).await.expect("chat call succeeded");
-
-        // Assert assistant text is non-empty.
         let text = resp.first_text().expect("assistant produced text");
         assert!(!text.is_empty(), "assistant text was empty");
-
-        // Assert usage is non-zero.
-        let usage = resp.token_usage();
-        assert!(usage.prompt_tokens > 0, "prompt_tokens should be > 0");
         assert!(
-            usage.completion_tokens > 0,
-            "completion_tokens should be > 0"
+            resp.token_usage().prompt_tokens > 0,
+            "prompt_tokens should be > 0"
         );
+        eprintln!("live openrouter ok — text: {text:?}");
+    }
 
-        eprintln!("live test passed — text: {text:?}, usage: {usage:?}");
+    /// Live integration: a real Fireworks round-trip via the shared adapter
+    /// (the concrete payoff of #2406).
+    ///
+    /// Why: proves `fireworks/*` routing + prefix stripping + `FIREWORKS_API_KEY`
+    /// resolution work against the real API.
+    /// What: reads `FIREWORKS_API_KEY`; SKIPS when absent.
+    /// Test: `cargo test -p trusty-code -- --include-ignored live_fireworks`.
+    #[tokio::test]
+    #[ignore = "requires FIREWORKS_API_KEY; skipped in CI"]
+    async fn live_fireworks_call() {
+        let Ok(key) = std::env::var("FIREWORKS_API_KEY") else {
+            eprintln!("FIREWORKS_API_KEY not set — skipping live test");
+            return;
+        };
+        if key.trim().is_empty() {
+            eprintln!("FIREWORKS_API_KEY is empty — skipping live test");
+            return;
+        }
+        let client = OpenAiCompatClient::new();
+        let req = ChatRequest {
+            model: "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct".into(),
+            messages: vec![
+                super::super::ChatMessage::system("You are a concise assistant."),
+                super::super::ChatMessage::user("Reply with exactly the word: pong"),
+            ],
+            temperature: Some(0.0),
+            max_tokens: Some(16),
+            tools: None,
+            tool_choice: None,
+            usage: None,
+        };
+        let resp = client.chat(&req).await.expect("chat call succeeded");
+        let text = resp.first_text().expect("assistant produced text");
+        assert!(!text.is_empty(), "assistant text was empty");
+        assert!(
+            resp.token_usage().prompt_tokens > 0,
+            "prompt_tokens should be > 0"
+        );
+        eprintln!("live fireworks ok — text: {text:?}");
     }
 }

--- a/crates/trusty-code/src/llm/client_trait.rs
+++ b/crates/trusty-code/src/llm/client_trait.rs
@@ -1,16 +1,18 @@
-//! Object-safe trait abstraction over the concrete `LlmClient`.
+//! Object-safe trait abstraction over the concrete inference transports.
 //!
 //! Why: The multi-turn agent loop must be unit-testable without issuing real
-//! HTTP requests. The concrete `LlmClient` performs network I/O in its inherent
-//! `chat` method, so the loop depends on this trait instead — production wires in
-//! the real `LlmClient`, tests wire in a scripted mock. Defining the seam here
-//! keeps `LlmClient` itself free of test-only machinery.
-//! What: Declares `LlmClientTrait` with a single `chat` method mirroring
-//! `LlmClient::chat`, and provides the blanket-free impl for `LlmClient` that
-//! delegates to the existing inherent method.
-//! Test: `client_trait::tests::llm_client_implements_trait` proves `LlmClient`
-//! satisfies the trait via a `dyn` coercion; the loop's mock (in
-//! `agent_loop::tests`) exercises the trait independently of the network.
+//! HTTP requests. The production transports (`OpenAiCompatClient`,
+//! `DispatchingLlmClient`, `BedrockChatClient`) perform network I/O in their
+//! inherent `chat` methods, so the loop depends on this trait instead —
+//! production wires in a real transport, tests wire in a scripted mock. Defining
+//! the seam here keeps the transports free of test-only machinery.
+//! What: Declares `LlmClientTrait` with a single `chat` method mirroring the
+//! transports' `chat`. Each concrete transport implements it in its own module
+//! (`client`, `dispatch`, `bedrock`).
+//! Test: `client_trait::tests::transport_implements_trait` proves
+//! `OpenAiCompatClient` satisfies the trait via a `dyn` coercion; the loop's
+//! mock (in `agent_loop::tests`) exercises the trait independently of the
+//! network.
 
 use async_trait::async_trait;
 
@@ -37,19 +39,6 @@ pub trait LlmClientTrait: Send + Sync {
     async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError>;
 }
 
-#[async_trait]
-impl LlmClientTrait for super::LlmClient {
-    /// Delegate to the inherent `LlmClient::chat`.
-    ///
-    /// Why: Keeps a single implementation of the HTTP mechanics; the trait is a
-    /// thin dispatch seam only.
-    /// What: Forwards `req` to the inherent method.
-    /// Test: `llm_client_implements_trait`.
-    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
-        super::LlmClient::chat(self, req).await
-    }
-}
-
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -57,19 +46,19 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::llm::{LlmClient, LlmClientConfig};
+    use crate::llm::OpenAiCompatClient;
 
-    /// `LlmClient` can be coerced to `Arc<dyn LlmClientTrait>`.
+    /// The production `OpenAiCompatClient` can be coerced to
+    /// `Arc<dyn LlmClientTrait>`.
     ///
     /// Why: The agent loop stores its client as `Arc<dyn LlmClientTrait>`; this
-    /// guards that the production client actually satisfies the trait (object
-    /// safety + impl presence) without making a network call.
-    /// What: Build a client with a fake key and coerce it to the trait object.
+    /// guards that the production transport actually satisfies the trait (object
+    /// safety + impl presence) without making a network call. Construction is
+    /// credential-free (#2245), so this needs no key.
+    /// What: Build a client and coerce it to the trait object.
     /// Test: this test.
     #[test]
-    fn llm_client_implements_trait() {
-        let cfg = LlmClientConfig::new("sk-or-test").expect("config");
-        let client = LlmClient::from_config(cfg).expect("client");
-        let _erased: Arc<dyn LlmClientTrait> = Arc::new(client);
+    fn transport_implements_trait() {
+        let _erased: Arc<dyn LlmClientTrait> = Arc::new(OpenAiCompatClient::new());
     }
 }

--- a/crates/trusty-code/src/llm/convert.rs
+++ b/crates/trusty-code/src/llm/convert.rs
@@ -1,0 +1,425 @@
+//! Lossless conversions between trusty-code's LLM wire types and the shared
+//! `trusty_common::inference` types, plus error mapping (#2406, epic #2400).
+//!
+//! Why: #2406 migrates tcode's OpenRouter/OpenAI-compatible transport onto the
+//! shared `trusty_common::inference` adapter while keeping every existing call
+//! site — `LlmClientTrait`, `AgentLoop`, the `ScriptedLlm` test doubles, the
+//! recorder — depending on tcode's own `ChatRequest`/`ChatResponse`/`LlmError`
+//! (which are deeply integrated with `crate::perf::TokenUsage`, the Bedrock
+//! transport, and the prompt-cache request shaping). Rather than ripple those
+//! types through the whole crate, the shared adapter is bridged at exactly one
+//! seam: this module. The two type families are structurally identical (both
+//! are the OpenAI `/chat/completions` schema, incl. the #2156 `cache_control`
+//! content-block wire shape), so the mapping is a field-by-field copy — NOT a
+//! serde round-trip, because the request-side `cache_control` marker is a
+//! `#[serde(skip)]` struct field that only becomes a content block at
+//! serialisation time; a `to_value`/`from_value` round-trip would silently drop
+//! it and disable prompt caching (a #2406 merge-gate concern).
+//! What: `to_shared_request` (with an explicit wire model so the caller can
+//! strip a provider routing prefix), `from_shared_response`, and `map_error`.
+//! Test: `convert::tests::*` — request/response field round-trips, the
+//! cache-control carry-through, and the error-variant mapping.
+
+use trusty_common::inference as tci;
+
+use super::error::LlmError;
+use super::message::ChatMessage;
+use super::request::{
+    CacheControl, ChatRequest, FunctionCall, RequestUsageConfig, ToolCall, ToolDefinition,
+};
+use super::response::{AssistantMessage, ChatChoice, ChatResponse};
+use super::usage::{PromptTokensDetails, UsageBlock};
+
+/// Convert a tcode [`ChatRequest`] into the shared [`tci::ChatRequest`], using
+/// `wire_model` as the outbound `model` field.
+///
+/// Why: the shared adapters send the `ChatRequest.model` verbatim on the wire,
+/// but tcode routes on a prefixed slug (e.g. `fireworks/…`) that must be
+/// stripped to the provider-native id before it is sent — so the wire model is
+/// a parameter here, decoupled from the routing decision the transport already
+/// made.
+/// What: copies every field across; `messages`/`tools` map element-wise
+/// (carrying the `cache_control` breakpoint), `stop` has no tcode equivalent so
+/// it is `None`, and the OpenRouter detailed-usage directive maps 1:1.
+/// Test: `to_shared_request_maps_all_fields`, `cache_control_carries_through`.
+pub fn to_shared_request(req: &ChatRequest, wire_model: String) -> tci::ChatRequest {
+    tci::ChatRequest {
+        model: wire_model,
+        messages: req.messages.iter().map(to_shared_message).collect(),
+        temperature: req.temperature,
+        max_tokens: req.max_tokens,
+        tools: req
+            .tools
+            .as_ref()
+            .map(|tools| tools.iter().map(to_shared_tool_def).collect()),
+        tool_choice: req.tool_choice.clone(),
+        stop: None,
+        usage: req.usage.as_ref().map(to_shared_usage_directive),
+    }
+}
+
+/// Convert a shared [`tci::ChatResponse`] back into tcode's [`ChatResponse`].
+///
+/// Why: every caller downstream of the transport (the agent loop, the recorder,
+/// `perf`) speaks tcode's response type and its `TokenUsage` conversion; the
+/// shared response is translated back at this one seam.
+/// What: copies `id`/`model`, maps each choice element-wise, and reshapes the
+/// usage block field-for-field (the two `UsageBlock`s are identical, incl. the
+/// nested OpenRouter `prompt_tokens_details` cache counters and the
+/// authoritative `cost`).
+/// Test: `from_shared_response_maps_all_fields`, `usage_block_round_trips`.
+pub fn from_shared_response(resp: tci::ChatResponse) -> ChatResponse {
+    let u = &resp.usage;
+    // The two `UsageBlock`s are field-identical (incl. the nested OpenRouter
+    // `prompt_tokens_details` cache counters and the authoritative `cost`); this
+    // is a verbatim copy that preserves tcode's `into_token_usage` cost path.
+    // Inlined (rather than a named-type helper) because the shared `UsageBlock`
+    // is not re-exported at the `inference` root — only its fields are read.
+    let usage = UsageBlock {
+        prompt_tokens: u.prompt_tokens,
+        completion_tokens: u.completion_tokens,
+        total_tokens: u.total_tokens,
+        cache_read_input_tokens: u.cache_read_input_tokens,
+        cache_creation_input_tokens: u.cache_creation_input_tokens,
+        prompt_tokens_details: u
+            .prompt_tokens_details
+            .as_ref()
+            .map(|d| PromptTokensDetails {
+                cached_tokens: d.cached_tokens,
+                cache_write_tokens: d.cache_write_tokens,
+            }),
+        cost: u.cost,
+    };
+    ChatResponse {
+        id: resp.id,
+        model: resp.model,
+        choices: resp.choices.iter().map(from_shared_choice).collect(),
+        usage,
+    }
+}
+
+/// Map a shared [`tci::InferenceError`] onto tcode's [`LlmError`].
+///
+/// Why: the agent loop, recorder, and telemetry all speak `LlmError`; the two
+/// shared errors that carry actionable, structured detail — a non-2xx API
+/// status and a missing credential — are preserved as the matching
+/// status-carrying / config-missing tcode variants so 401/429 handling and the
+/// "set this key" operator guidance survive the migration. Everything else
+/// (transport blips, parse failures, unregistered/unsupported alarms) is carried
+/// verbatim as [`LlmError::Inference`] rather than lossily reshaped.
+/// What: `Api → ApiError`, `MissingCredential → MissingConfig` (with a resolver
+/// hint), all other variants → `Inference(display)`.
+/// Test: `map_error_preserves_api_status`, `map_error_maps_missing_credential`,
+/// `map_error_wraps_other`.
+pub fn map_error(err: tci::InferenceError) -> LlmError {
+    match err {
+        tci::InferenceError::Api { status, body } => LlmError::ApiError { status, body },
+        tci::InferenceError::MissingCredential { provider } => LlmError::MissingConfig(format!(
+            "no API key resolved for provider '{provider}' (checked its env var, .env.local, \
+             and the secure credential store)"
+        )),
+        other => LlmError::Inference(other.to_string()),
+    }
+}
+
+// ── Element mappers (tcode → shared) ─────────────────────────────────────────
+
+/// Map a tcode [`ChatMessage`] to the shared one, carrying the cache breakpoint.
+///
+/// Why: the `cache_control` field is the #2156 prompt-cache marker; it must
+/// survive the conversion as a struct field so the shared `ChatMessage`'s own
+/// hand-written `Serialize` emits the identical content-block wire shape.
+/// What: copies `role`/`content`/`tool_calls`/`tool_call_id`/`name` and maps
+/// `cache_control`.
+/// Test: `cache_control_carries_through`.
+fn to_shared_message(msg: &ChatMessage) -> tci::ChatMessage {
+    tci::ChatMessage {
+        role: msg.role.clone(),
+        content: msg.content.clone(),
+        tool_calls: msg
+            .tool_calls
+            .as_ref()
+            .map(|calls| calls.iter().map(to_shared_tool_call).collect()),
+        tool_call_id: msg.tool_call_id.clone(),
+        name: msg.name.clone(),
+        cache_control: msg.cache_control.as_ref().map(to_shared_cache_control),
+    }
+}
+
+/// Map a tcode [`ToolCall`] to the shared one (assistant-emitted call echoed in
+/// history).
+fn to_shared_tool_call(call: &ToolCall) -> tci::ToolCall {
+    tci::ToolCall {
+        id: call.id.clone(),
+        kind: call.kind.clone(),
+        function: tci::FunctionCall {
+            name: call.function.name.clone(),
+            arguments: call.function.arguments.clone(),
+        },
+    }
+}
+
+/// Map a tcode [`ToolDefinition`] to the shared one, carrying the last-tool
+/// cache breakpoint.
+fn to_shared_tool_def(def: &ToolDefinition) -> tci::ToolDefinition {
+    tci::ToolDefinition {
+        kind: def.kind.clone(),
+        function: tci::FunctionDefinition {
+            name: def.function.name.clone(),
+            description: def.function.description.clone(),
+            parameters: def.function.parameters.clone(),
+            cache_control: def
+                .function
+                .cache_control
+                .as_ref()
+                .map(to_shared_cache_control),
+        },
+    }
+}
+
+/// Map the ephemeral cache breakpoint across (both are `{ kind }`).
+fn to_shared_cache_control(cc: &CacheControl) -> tci::CacheControl {
+    tci::CacheControl {
+        kind: cc.kind.clone(),
+    }
+}
+
+/// Map the OpenRouter detailed-usage directive across.
+fn to_shared_usage_directive(cfg: &RequestUsageConfig) -> tci::RequestUsageConfig {
+    tci::RequestUsageConfig {
+        include: cfg.include,
+    }
+}
+
+// ── Element mappers (shared → tcode) ─────────────────────────────────────────
+
+/// Map a shared choice back to tcode's [`ChatChoice`].
+fn from_shared_choice(choice: &tci::ChatChoice) -> ChatChoice {
+    ChatChoice {
+        message: AssistantMessage {
+            content: choice.message.content.clone(),
+            tool_calls: choice
+                .message
+                .tool_calls
+                .iter()
+                .map(from_shared_tool_call)
+                .collect(),
+        },
+        finish_reason: choice.finish_reason.clone(),
+    }
+}
+
+/// Map a shared [`tci::ToolCall`] back to tcode's [`ToolCall`].
+fn from_shared_tool_call(call: &tci::ToolCall) -> ToolCall {
+    ToolCall {
+        id: call.id.clone(),
+        kind: call.kind.clone(),
+        function: FunctionCall {
+            name: call.function.name.clone(),
+            arguments: call.function.arguments.clone(),
+        },
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::super::request::FunctionDefinition;
+    use super::*;
+
+    /// Every tcode request field must map onto the shared request, with the
+    /// caller-supplied wire model replacing the routing slug.
+    ///
+    /// Why: a dropped field (tools, tool_choice, max_tokens, usage) would
+    /// silently change the wire payload and regress behaviour/cost.
+    /// What: build a fully-populated request, convert with a distinct wire
+    /// model, assert every field.
+    /// Test: this test.
+    #[test]
+    fn to_shared_request_maps_all_fields() {
+        let req = ChatRequest {
+            model: "fireworks/accounts/fireworks/models/llama".into(),
+            messages: vec![ChatMessage::system("sys"), ChatMessage::user("hi")],
+            temperature: Some(0.0),
+            max_tokens: Some(4096),
+            tools: Some(vec![ToolDefinition::function(FunctionDefinition {
+                name: "search".into(),
+                description: Some("d".into()),
+                parameters: Some(serde_json::json!({"type": "object"})),
+                cache_control: None,
+            })]),
+            tool_choice: Some(serde_json::json!("auto")),
+            usage: Some(RequestUsageConfig::detailed()),
+        };
+        let shared = to_shared_request(&req, "accounts/fireworks/models/llama".into());
+        assert_eq!(shared.model, "accounts/fireworks/models/llama");
+        assert_eq!(shared.messages.len(), 2);
+        assert_eq!(shared.messages[0].role, "system");
+        assert_eq!(shared.temperature, Some(0.0));
+        assert_eq!(shared.max_tokens, Some(4096));
+        assert_eq!(shared.tools.as_ref().unwrap().len(), 1);
+        assert_eq!(shared.tools.as_ref().unwrap()[0].function.name, "search");
+        assert_eq!(shared.tool_choice, Some(serde_json::json!("auto")));
+        assert!(shared.stop.is_none());
+        assert_eq!(
+            shared.usage,
+            Some(tci::RequestUsageConfig { include: true })
+        );
+    }
+
+    /// The #2156 cache breakpoint must survive the conversion as a struct field
+    /// on BOTH the system message and the last tool definition — proving it
+    /// still serialises to the Anthropic content-block / sibling shape.
+    ///
+    /// Why: a serde round-trip would drop `#[serde(skip)]` `cache_control`; this
+    /// pins that the field-by-field copy preserves it (prompt-caching merge
+    /// gate).
+    /// What: set `cache_control` on a message and a tool, convert, assert the
+    /// shared values are present AND that the shared message serialises to the
+    /// cached content-block shape.
+    /// Test: this test.
+    #[test]
+    fn cache_control_carries_through() {
+        let mut msg = ChatMessage::system("prefix");
+        msg.cache_control = Some(CacheControl::ephemeral());
+        let tool = ToolDefinition::function(FunctionDefinition {
+            name: "write_file".into(),
+            description: None,
+            parameters: None,
+            cache_control: Some(CacheControl::ephemeral()),
+        });
+        let req = ChatRequest {
+            model: "anthropic/claude-sonnet-4-5".into(),
+            messages: vec![msg],
+            temperature: None,
+            max_tokens: None,
+            tools: Some(vec![tool]),
+            tool_choice: None,
+            usage: None,
+        };
+        let shared = to_shared_request(&req, "anthropic/claude-sonnet-4-5".into());
+        assert!(shared.messages[0].cache_control.is_some());
+        assert!(
+            shared.tools.as_ref().unwrap()[0]
+                .function
+                .cache_control
+                .is_some()
+        );
+
+        // The shared message must serialise to the Anthropic cached-content-block
+        // shape (not a bare string) — the #2156 wire contract.
+        let v = serde_json::to_value(&shared.messages[0]).expect("serialise");
+        assert_eq!(
+            v["content"],
+            serde_json::json!([{
+                "type": "text",
+                "text": "prefix",
+                "cache_control": {"type": "ephemeral"}
+            }])
+        );
+    }
+
+    /// A shared response must map back onto tcode's response with text, tool
+    /// calls, finish reason, and usage all intact.
+    ///
+    /// Why: the agent loop reads `first_text`/`first_tool_calls`/`finish_reason`
+    /// and the recorder reads usage; a dropped field breaks the loop.
+    /// What: deserialise a shared response fixture, convert, assert accessors.
+    /// Test: this test.
+    #[test]
+    fn from_shared_response_maps_all_fields() {
+        let fixture = r#"{
+          "id": "gen-1",
+          "model": "openai/gpt-4o-mini",
+          "choices": [{"message": {"role": "assistant", "content": null,
+              "tool_calls": [{"id": "c1", "type": "function",
+                  "function": {"name": "bash", "arguments": "{}"}}]},
+              "finish_reason": "tool_calls"}],
+          "usage": {"prompt_tokens": 12, "completion_tokens": 3, "total_tokens": 15,
+                    "cache_read_input_tokens": 4, "cache_creation_input_tokens": 1}
+        }"#;
+        let shared: tci::ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        let resp = from_shared_response(shared);
+        assert_eq!(resp.id, "gen-1");
+        assert_eq!(resp.resolved_model("asked"), "openai/gpt-4o-mini");
+        assert!(resp.first_text().is_none());
+        assert_eq!(resp.first_tool_calls().len(), 1);
+        assert_eq!(resp.first_tool_calls()[0].function.name, "bash");
+        assert_eq!(resp.finish_reason(), Some("tool_calls"));
+        let usage = resp.token_usage();
+        assert_eq!(usage.prompt_tokens, 12);
+        assert_eq!(usage.cache_read_tokens, 4);
+        assert_eq!(usage.cache_creation_tokens, 1);
+    }
+
+    /// OpenRouter's nested cache accounting + authoritative cost must survive
+    /// the usage-block conversion (the exact fields the token-efficiency thesis
+    /// depends on).
+    ///
+    /// Why: cost/telemetry capture is a #2406 preservation requirement.
+    /// What: deserialise an OpenRouter-shaped usage fixture, convert, assert the
+    /// nested counters and cost flow through into `TokenUsage`.
+    /// Test: this test.
+    #[test]
+    fn usage_block_round_trips() {
+        let fixture = r#"{
+          "id": "z", "choices": [],
+          "usage": {"prompt_tokens": 1200, "completion_tokens": 80,
+                    "prompt_tokens_details": {"cached_tokens": 900, "cache_write_tokens": 300},
+                    "cost": 0.00123}
+        }"#;
+        let shared: tci::ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        let usage = from_shared_response(shared).token_usage();
+        assert_eq!(usage.cache_read_tokens, 900);
+        assert_eq!(usage.cache_creation_tokens, 300);
+        assert_eq!(usage.cost_usd, Some(0.00123));
+    }
+
+    /// A non-2xx API status maps to `ApiError` preserving the code + body.
+    ///
+    /// Why: 401/429 handling and telemetry key off the preserved status.
+    /// Test: this test.
+    #[test]
+    fn map_error_preserves_api_status() {
+        let err = map_error(tci::InferenceError::Api {
+            status: 429,
+            body: "slow down".into(),
+        });
+        match err {
+            LlmError::ApiError { status, body } => {
+                assert_eq!(status, 429);
+                assert_eq!(body, "slow down");
+            }
+            other => panic!("expected ApiError, got {other:?}"),
+        }
+    }
+
+    /// A missing credential maps to `MissingConfig` with a resolver hint.
+    ///
+    /// Why: preserves the actionable "set this key" operator guidance.
+    /// Test: this test.
+    #[test]
+    fn map_error_maps_missing_credential() {
+        let err = map_error(tci::InferenceError::MissingCredential {
+            provider: tci::ProviderId::OpenRouter,
+        });
+        match err {
+            LlmError::MissingConfig(msg) => assert!(msg.contains("openrouter"), "{msg}"),
+            other => panic!("expected MissingConfig, got {other:?}"),
+        }
+    }
+
+    /// Every other shared error is carried verbatim as `Inference`.
+    ///
+    /// Why: transport/parse/alarm failures keep their honest display text.
+    /// Test: this test.
+    #[test]
+    fn map_error_wraps_other() {
+        let err = map_error(tci::InferenceError::Transport("connection refused".into()));
+        match err {
+            LlmError::Inference(msg) => assert!(msg.contains("connection refused"), "{msg}"),
+            other => panic!("expected Inference, got {other:?}"),
+        }
+    }
+}

--- a/crates/trusty-code/src/llm/dispatch.rs
+++ b/crates/trusty-code/src/llm/dispatch.rs
@@ -1,39 +1,33 @@
-//! Transport dispatch: route each `ChatRequest` to OpenRouter or Bedrock by
-//! model slug (#1021 phase 1).
+//! Transport dispatch: route each `ChatRequest` to Bedrock or the shared
+//! OpenAI-compatible transport (OpenRouter / Fireworks) by model slug
+//! (#1021 phase 1; #2406 migration).
 //!
 //! Why: Every caller of `LlmClientTrait::chat` (`AgentLoop`, `run_task`,
 //! `task::executor`) is constructed with exactly ONE `Arc<dyn LlmClientTrait>`
 //! shared across every agent in a run, but different agents can be routed to
-//! different model slugs (`crate::provider::resolve_model`) — some
-//! `bedrock/*`, most not. Rather than threading a second client through every
-//! call site, `DispatchingLlmClient` is itself an `LlmClientTrait` impl that
-//! picks the real transport per-request from `req.model`, using the exact
-//! same `crate::provider::provider_for` routing `AgentLoop::build_request`
-//! already consults for tool-choice/caching decisions (#1021's `provider`
-//! module) — so there is exactly one source of truth for "is this a Bedrock
-//! slug".
-//! What: Wraps an OPTIONAL OpenRouter `LlmClient` (built eagerly when a
-//! config is supplied, matching the original behaviour) plus a
-//! lazily-constructed `BedrockChatClient` behind a `tokio::sync::OnceCell`.
-//! The Bedrock client is only ever built the first time a `bedrock/*` slug is
-//! actually requested — a pure-OpenRouter run never touches the AWS SDK or
-//! needs AWS credentials, preserving the "default configuration works
-//! standalone" rule. Symmetrically (#2245), the OpenRouter transport is
-//! OPTIONAL at construction time: a pure-Bedrock run must not be blocked by a
-//! missing `OPENROUTER_API_KEY` — that error now surfaces only if a
-//! non-bedrock model slug is actually dispatched through a client built
-//! without OpenRouter config.
-//! Test: `dispatch::tests::*` — routing by slug prefix (mocked, no network),
-//! `bedrock_construction_is_lazy` proves the OpenRouter-only path never
-//! initialises the Bedrock cell, `construction_succeeds_with_no_openrouter_config`
-//! and `openrouter_request_without_config_fails_at_chat_time` prove the
-//! reverse: a Bedrock-only client builds fine and only fails at request time.
+//! different model slugs (`crate::provider::resolve_model`) — some `bedrock/*`,
+//! some `fireworks/*`, most plain OpenRouter. Rather than threading multiple
+//! clients through every call site, `DispatchingLlmClient` is itself an
+//! `LlmClientTrait` impl that picks the real transport per-request from
+//! `req.model`, using the exact same `crate::provider::provider_for` routing
+//! `AgentLoop::build_request` already consults for tool-choice/caching/usage
+//! decisions — so there is exactly one source of truth for "which backend".
+//! What: `bedrock/*` slugs go to a lazily-constructed `BedrockChatClient`
+//! (behind a `tokio::sync::OnceCell`, so a pure-OpenRouter/Fireworks run never
+//! touches the AWS SDK). Every other slug goes to the shared-adapter-backed
+//! `OpenAiCompatClient` (#2406), which itself routes OpenRouter vs Fireworks by
+//! prefix and resolves credentials via the shared env > `.env.local` > store
+//! chain — so no key is required at construction (#2245); a missing key only
+//! surfaces if a slug that needs it is actually dispatched.
+//! Test: `dispatch::tests::*` — routing by slug prefix (no network),
+//! `bedrock_construction_is_lazy` proves the OpenAI-compat path never
+//! initialises the Bedrock cell.
 
 use async_trait::async_trait;
 use tokio::sync::OnceCell;
 
 use super::bedrock::BedrockChatClient;
-use super::client::{LlmClient, LlmClientConfig};
+use super::client::OpenAiCompatClient;
 use super::client_trait::LlmClientTrait;
 use super::error::LlmError;
 use super::request::ChatRequest;
@@ -43,92 +37,56 @@ use super::response::ChatResponse;
 /// slugs — the single dispatch condition this client checks.
 const BEDROCK_PROVIDER_NAME: &str = "bedrock";
 
-/// Routes each chat request to the OpenRouter HTTP transport or the Bedrock
-/// Converse transport, by model slug.
+/// Routes each chat request to the Bedrock Converse transport or the shared
+/// OpenAI-compatible transport (OpenRouter / Fireworks), by model slug.
 ///
-/// Why: This is the seam that makes `bedrock/*` model slugs actually reach
-/// AWS Bedrock instead of being sent (nonsensically) to OpenRouter's HTTP
-/// endpoint — closing the "transport is hardcoded to OpenRouter" gap #1021
-/// identified. Production call sites (`main.rs`, `task::mock_llm`) construct
-/// this instead of a bare `LlmClient`; every other caller keeps depending on
-/// the object-safe `LlmClientTrait`, so no signature at any call site changes.
-/// What: `openrouter` is `Some(LlmClient)` when a config was supplied at
-/// construction (built eagerly — the reqwest client itself is cheap and
-/// synchronous to build), `None` otherwise; `bedrock` is a `OnceCell`
+/// Why: this is the seam that makes `bedrock/*` model slugs reach AWS Bedrock
+/// while `fireworks/*` and plain OpenRouter slugs reach the shared adapter —
+/// keeping every call site depending only on the object-safe `LlmClientTrait`
+/// so no signature changes when routing evolves. Production call sites
+/// (`main.rs`, `task::mock_llm`) construct this instead of a bare transport.
+/// What: `openai_compat` is the shared-adapter-backed transport (built eagerly —
+/// it holds no credentials until first use); `bedrock` is a `OnceCell`
 /// populated on the first `bedrock/*` request via `BedrockChatClient::from_env`
-/// (standard AWS credential chain — no key required at construction time; a
-/// missing/invalid credential surfaces as an `LlmError` on that first call,
-/// not at startup). A request that resolves to the missing transport (either
-/// direction) fails with `LlmError::MissingConfig` at `chat()` time, never at
-/// construction — so a pure-Bedrock run never needs `OPENROUTER_API_KEY` and
-/// a pure-OpenRouter run never needs AWS credentials (#2245).
+/// (standard AWS credential chain — no key required at construction). A request
+/// that needs a missing credential fails at `chat()` time, never at
+/// construction (#2245) — so a pure-Bedrock run never needs `OPENROUTER_API_KEY`
+/// and a pure-OpenRouter run never needs AWS credentials.
 /// Test: `dispatch::tests::*`.
 #[derive(Debug)]
 pub struct DispatchingLlmClient {
-    openrouter: Option<LlmClient>,
+    openai_compat: OpenAiCompatClient,
     bedrock: OnceCell<BedrockChatClient>,
 }
 
 impl DispatchingLlmClient {
-    /// Construct from an optional OpenRouter config.
+    /// Construct the dispatcher.
     ///
-    /// Why: The single constructor every entry point (`main.rs`,
-    /// `task::mock_llm`) should funnel through: whether OpenRouter creds are
-    /// available is decided by the CALLER (typically "did
-    /// `LlmClientConfig::from_env()` succeed"), and this type must not
-    /// second-guess that decision by hard-failing when it's `None` — only a
-    /// request that actually needs OpenRouter should ever surface that
-    /// error (#2245).
-    /// What: Builds the OpenRouter `LlmClient` eagerly when `config.is_some()`
-    /// (identical behaviour to the pre-#2245 mandatory path); leaves it unset
-    /// otherwise. The Bedrock cell always starts empty. Only fails if a
-    /// SUPPLIED config fails to build (the underlying reqwest/TLS setup,
-    /// "extremely rare" per `LlmClient::from_config`'s own docs).
-    /// Test: `dispatch::tests::construction_succeeds_with_no_openrouter_config`,
-    /// `dispatch::tests::openrouter_slug_never_touches_bedrock_cell`.
-    pub fn new(openrouter_config: Option<LlmClientConfig>) -> Result<Self, LlmError> {
-        let openrouter = openrouter_config.map(LlmClient::from_config).transpose()?;
-        Ok(Self {
-            openrouter,
+    /// Why: the single constructor every entry point (`main.rs`,
+    /// `task::mock_llm`) funnels through. Since the shared OpenAI-compat
+    /// transport resolves credentials lazily (env > `.env.local` > store) and
+    /// the Bedrock cell starts empty, construction touches NO credentials and
+    /// cannot fail — a missing key only surfaces when a request that needs it is
+    /// dispatched (#2245).
+    /// What: builds the `OpenAiCompatClient` with the process-default store and
+    /// an empty Bedrock cell.
+    /// Test: `dispatch::tests::construction_touches_no_credentials`.
+    pub fn new() -> Self {
+        Self {
+            openai_compat: OpenAiCompatClient::new(),
             bedrock: OnceCell::new(),
-        })
-    }
-
-    /// Construct from an explicit, MANDATORY OpenRouter config.
-    ///
-    /// Why: Back-compat convenience for callers that already know they need
-    /// OpenRouter (e.g. tests constructing a client for an OpenRouter-only
-    /// scenario) and want construction itself to fail fast on a bad config.
-    /// What: `Self::new(Some(config))`.
-    /// Test: `dispatch::tests::openrouter_slug_never_touches_bedrock_cell`.
-    pub fn from_config(config: LlmClientConfig) -> Result<Self, LlmError> {
-        Self::new(Some(config))
-    }
-
-    /// Construct from the `OPENROUTER_API_KEY` environment variable,
-    /// MANDATORY (fails if unset).
-    ///
-    /// Why: Convenience entry point mirroring `LlmClient::from_env` for
-    /// callers that want the original "key required" behaviour. Production
-    /// call sites that must tolerate a Bedrock-only run instead call
-    /// [`Self::new`] with `LlmClientConfig::from_env().ok()` (#2245).
-    /// What: Delegates to [`Self::from_config`] via `LlmClientConfig::from_env`.
-    /// Test: Exercised transitively wherever `LlmClient::from_env` already was.
-    pub fn from_env() -> Result<Self, LlmError> {
-        Self::from_config(LlmClientConfig::from_env()?)
+        }
     }
 
     /// Get (or lazily build) the Bedrock Converse transport.
     ///
-    /// Why: AWS credential resolution is async and must never run for a
-    /// request that doesn't need it; `OnceCell::get_or_try_init` guarantees
-    /// at most one build attempt is ever made, and a failed attempt can be
-    /// retried on the next `bedrock/*` request rather than poisoning the
-    /// client forever.
-    /// What: Returns the cached client, or builds one via
+    /// Why: AWS credential resolution is async and must never run for a request
+    /// that doesn't need it; `OnceCell::get_or_try_init` guarantees at most one
+    /// build attempt, and a failed attempt can be retried on the next
+    /// `bedrock/*` request rather than poisoning the client forever.
+    /// What: returns the cached client, or builds one via
     /// `BedrockChatClient::from_env` on first use.
-    /// Test: `dispatch::tests::bedrock_slug_routes_through_bedrock_client`
-    /// (via a construction-failure path, since no AWS creds exist in tests).
+    /// Test: `dispatch::tests::bedrock_construction_is_lazy`.
     async fn bedrock(&self) -> Result<&BedrockChatClient, LlmError> {
         self.bedrock
             .get_or_try_init(BedrockChatClient::from_env)
@@ -137,10 +95,10 @@ impl DispatchingLlmClient {
 
     /// Whether `model` routes to the Bedrock transport.
     ///
-    /// Why: Single source of truth — reuses `crate::provider::provider_for`,
-    /// the exact factory `AgentLoop::build_request` already consults for
-    /// tool-choice/caching decisions, so routing can never disagree between
-    /// "which transport sends this" and "which `Provider` normalises this".
+    /// Why: single source of truth — reuses `crate::provider::provider_for`, the
+    /// exact factory `AgentLoop::build_request` already consults, so routing can
+    /// never disagree between "which transport sends this" and "which `Provider`
+    /// normalises this".
     /// What: `true` iff `provider_for(model).name() == "bedrock"`.
     /// Test: `dispatch::tests::routes_bedrock_prefix_true`,
     /// `dispatch::tests::routes_non_bedrock_prefix_false`.
@@ -149,30 +107,30 @@ impl DispatchingLlmClient {
     }
 }
 
+impl Default for DispatchingLlmClient {
+    /// Delegates to [`DispatchingLlmClient::new`].
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl LlmClientTrait for DispatchingLlmClient {
-    /// Dispatch `req` to Bedrock or OpenRouter based on `req.model`.
+    /// Dispatch `req` to Bedrock or the shared OpenAI-compat transport based on
+    /// `req.model`.
     ///
-    /// Why: The single method every caller (`AgentLoop`, `run_task`,
+    /// Why: the single method every caller (`AgentLoop`, `run_task`,
     /// `task::executor`) invokes through `Arc<dyn LlmClientTrait>`.
-    /// What: `bedrock/*` slugs go through [`Self::bedrock`]; every other
-    /// slug goes through the OpenRouter `LlmClient::chat` path IF one was
-    /// configured — a request that needs the missing transport returns
-    /// `LlmError::MissingConfig` naming the model and the env var to set
-    /// (#2245), rather than the client having refused to construct at all.
+    /// What: `bedrock/*` slugs go through [`Self::bedrock`]; every other slug
+    /// (OpenRouter default and `fireworks/*`) goes through the
+    /// `OpenAiCompatClient`, which handles the OpenRouter-vs-Fireworks split and
+    /// surfaces a missing credential as `LlmError::MissingConfig` at this point.
     /// Test: `dispatch::tests::*`.
     async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
         if Self::routes_to_bedrock(&req.model) {
             self.bedrock().await?.chat(req).await
         } else {
-            let client = self.openrouter.as_ref().ok_or_else(|| {
-                LlmError::MissingConfig(format!(
-                    "OPENROUTER_API_KEY is required to reach model '{}' (not a bedrock/* \
-                     slug). Export it before running, e.g. `export OPENROUTER_API_KEY=sk-or-...`.",
-                    req.model
-                ))
-            })?;
-            client.chat(req).await
+            self.openai_compat.chat(req).await
         }
     }
 }
@@ -185,10 +143,9 @@ mod tests {
 
     /// `routes_to_bedrock` is `true` for `bedrock/*` slugs.
     ///
-    /// Why: This is the exact gate `chat` uses to pick a transport; a wrong
-    /// answer here means Bedrock slugs silently go to OpenRouter (or a
-    /// missing AWS credential blocks an OpenRouter-only run).
-    /// What: Assert `true` for a representative Bedrock inference-profile slug.
+    /// Why: this is the exact gate `chat` uses to pick the Bedrock transport; a
+    /// wrong answer means Bedrock slugs silently go to the OpenAI-compat path.
+    /// What: assert `true` for a representative Bedrock inference-profile slug.
     /// Test: this test.
     #[test]
     fn routes_bedrock_prefix_true() {
@@ -197,11 +154,13 @@ mod tests {
         ));
     }
 
-    /// `routes_to_bedrock` is `false` for every non-Bedrock slug family.
+    /// `routes_to_bedrock` is `false` for every non-Bedrock slug family,
+    /// including `fireworks/*` (which routes through the OpenAI-compat transport,
+    /// not Bedrock).
     ///
-    /// Why: Guards against a routing regression sending ordinary OpenRouter
-    /// traffic to the (uninitialised, credential-less) Bedrock cell.
-    /// What: Assert `false` for representative OpenRouter-namespaced slugs.
+    /// Why: guards against a routing regression sending ordinary OpenRouter or
+    /// Fireworks traffic to the (credential-less) Bedrock cell.
+    /// What: assert `false` for representative OpenRouter and Fireworks slugs.
     /// Test: this test.
     #[test]
     fn routes_non_bedrock_prefix_false() {
@@ -209,6 +168,7 @@ mod tests {
             "anthropic/claude-sonnet-4-5",
             "openai/gpt-4o-mini",
             "qwen/qwen-2.5-coder-32b-instruct",
+            "fireworks/accounts/fireworks/models/llama-v3p1-70b-instruct",
         ] {
             assert!(
                 !DispatchingLlmClient::routes_to_bedrock(slug),
@@ -217,51 +177,38 @@ mod tests {
         }
     }
 
-    /// Constructing a `DispatchingLlmClient` never touches the Bedrock cell.
+    /// Constructing a `DispatchingLlmClient` never touches credentials and never
+    /// initialises the Bedrock cell.
     ///
-    /// Why: Pins the "default configuration works standalone" guarantee —
-    /// building the client (e.g. at CLI startup) must not require AWS
-    /// credentials just because the Bedrock transport exists in-process.
-    /// What: Build with a fake OpenRouter key; assert construction succeeds
-    /// (the Bedrock `OnceCell` is never even inspected until `chat` is
-    /// called with a `bedrock/*` model).
+    /// Why: pins the "default configuration works standalone" guarantee (#2245) —
+    /// building the client (e.g. at CLI startup) must not require AWS credentials
+    /// or any API key just because the transports exist in-process.
+    /// What: build the client; assert the Bedrock `OnceCell` is still empty (it
+    /// is only inspected on a `bedrock/*` `chat`).
     /// Test: this test.
     #[test]
-    fn openrouter_slug_never_touches_bedrock_cell() {
-        let config = LlmClientConfig::new("sk-or-test").expect("config");
-        let client = DispatchingLlmClient::from_config(config);
-        assert!(client.is_ok(), "expected Ok, got: {client:?}");
+    fn construction_touches_no_credentials() {
+        let client = DispatchingLlmClient::new();
+        assert!(
+            client.bedrock.get().is_none(),
+            "Bedrock cell must be lazy — untouched at construction"
+        );
     }
 
-    /// A client built with NO OpenRouter config still constructs successfully
-    /// — the exact shape a Bedrock-only run takes (#2245).
+    /// A non-bedrock dispatch never initialises the Bedrock cell.
     ///
-    /// Why: Pins the fix for the reported bug: building `DispatchingLlmClient`
-    /// must not require `OPENROUTER_API_KEY` just because the OpenRouter
-    /// transport theoretically exists — only an OpenRouter-bound `chat()`
-    /// call should ever need it.
-    /// What: `DispatchingLlmClient::new(None)` returns `Ok`.
-    /// Test: this test.
-    #[test]
-    fn construction_succeeds_with_no_openrouter_config() {
-        let client = DispatchingLlmClient::new(None);
-        assert!(client.is_ok(), "expected Ok, got: {client:?}");
-    }
-
-    /// A non-bedrock request through a Bedrock-only client (no OpenRouter
-    /// config) fails at `chat()` time with a clear `MissingConfig` error —
-    /// not silently, and not at construction time (#2245).
-    ///
-    /// Why: Confirms the deferred failure actually surfaces a useful error
-    /// instead of e.g. a panic or a confusing transport-level failure.
-    /// What: Build with `new(None)`, dispatch an `anthropic/*`-slugged
-    /// request, assert `LlmError::MissingConfig`.
+    /// Why: proves the OpenAI-compat path is fully independent of the AWS SDK —
+    /// a pure-OpenRouter/Fireworks run must not construct the Bedrock client.
+    /// What: build with an empty store so an OpenRouter chat fails fast on the
+    /// missing key (when no ambient key exists), then assert the Bedrock cell is
+    /// still empty. Skips the chat when a real key is present locally, but still
+    /// asserts the cell stays empty.
     /// Test: this test.
     #[tokio::test]
-    async fn openrouter_request_without_config_fails_at_chat_time() {
-        let client = DispatchingLlmClient::new(None).expect("construction succeeds");
+    async fn bedrock_construction_is_lazy() {
+        let client = DispatchingLlmClient::new();
         let req = ChatRequest {
-            model: "anthropic/claude-sonnet-4-5".to_string(),
+            model: "openai/gpt-4o-mini".into(),
             messages: vec![],
             temperature: None,
             max_tokens: None,
@@ -269,19 +216,15 @@ mod tests {
             tool_choice: None,
             usage: None,
         };
-        let err = client.chat(&req).await.unwrap_err();
+        // Best-effort: the call may error (missing key) or, with a real ambient
+        // key, would attempt a live request — either way we only care that the
+        // Bedrock cell was never touched. Guard the live case out.
+        if !std::env::var("OPENROUTER_API_KEY").is_ok_and(|v| !v.is_empty()) {
+            let _ = client.chat(&req).await;
+        }
         assert!(
-            matches!(err, LlmError::MissingConfig(_)),
-            "expected MissingConfig, got: {err:?}"
+            client.bedrock.get().is_none(),
+            "a non-bedrock dispatch must never initialise the Bedrock cell"
         );
     }
-
-    // NOTE: `chat()` end-to-end dispatch for a `bedrock/*` slug is
-    // deliberately NOT exercised here with a real `BedrockChatClient::from_env`
-    // call: on a machine with real AWS credentials configured (e.g.
-    // `AWS_PROFILE=cto`, per this repo's CLAUDE.md), that would make a live
-    // network call to Bedrock from an ordinary `cargo test` run — not
-    // gated behind `--include-ignored`. `routes_bedrock_prefix_true` already
-    // proves the routing decision itself; `bedrock::tests::live_bedrock_call`
-    // (in `llm/bedrock/tests.rs`, `#[ignore]`-gated) covers the real call.
 }

--- a/crates/trusty-code/src/llm/error.rs
+++ b/crates/trusty-code/src/llm/error.rs
@@ -69,6 +69,21 @@ pub enum LlmError {
     /// error message honest.
     #[error("Bedrock error: {0}")]
     Bedrock(String),
+
+    /// A failure originating in the shared `trusty_common::inference` adapter
+    /// layer that does not map cleanly onto a status-carrying variant (#2406):
+    /// a transport error (the adapter stringifies `reqwest::Error` before it
+    /// reaches tcode, so it cannot be a [`Self::Transport`]), a response the
+    /// shared parser rejected, or a missing/unregistered-provider alarm. The
+    /// two shared errors that DO map cleanly — a non-2xx API status and a
+    /// missing credential — are translated to [`Self::ApiError`] and
+    /// [`Self::MissingConfig`] respectively (see `llm::convert::map_error`) so
+    /// their status code / operator guidance is preserved.
+    ///
+    /// Why: keeps the shared error's own `Display` text verbatim rather than
+    /// forcing a lossy re-shape into a status-carrying variant it does not fit.
+    #[error("inference error: {0}")]
+    Inference(String),
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/trusty-code/src/llm/mod.rs
+++ b/crates/trusty-code/src/llm/mod.rs
@@ -1,33 +1,38 @@
-//! Native LLM clients for trusty-code: OpenRouter (HTTP) and AWS Bedrock
-//! (Converse API).
+//! LLM transports for trusty-code: the shared OpenAI-compatible adapter
+//! (OpenRouter / Fireworks) and AWS Bedrock (Converse API).
 //!
-//! Why: trusty-code agents need to invoke LLMs via OpenRouter's chat-
-//! completions endpoint OR, for organisations running on AWS (#1021), via
-//! Bedrock's Converse API — without pulling in a third-party SDK
-//! (`async-openai`, etc.) that pins us to one provider's contract. Both
-//! transports speak the same provider-neutral `ChatRequest`/`ChatResponse`
-//! shape so `AgentLoop` and every other caller never branches on the
-//! backend.
-//! What: This module exports `LlmClient` (OpenRouter HTTP), `BedrockChatClient`
-//! (Bedrock Converse), `DispatchingLlmClient` (routes each request to the
-//! right transport by model slug via `crate::provider::provider_for`),
-//! `LlmClientConfig`, all request/response types (`ChatRequest`,
-//! `ChatResponse`, `ChatMessage`, `ToolDefinition`, …), `LlmError`, and
-//! (#2264) the opt-in `debug_capture` module — `DebugCaptureSink` +
-//! `wrap_with_debug_capture` — that dumps the FULL wire-level request/
-//! response of every round-trip to JSONL when `TCODE_DEBUG_TRANSCRIPT` is
-//! set. The OpenRouter API key is injected at construction time via
-//! `LlmClientConfig::new`/`from_env`; Bedrock uses the standard AWS
-//! credential chain (no key). Library helpers never read `std::env` directly
-//! except at these documented construction seams.
+//! Why: trusty-code agents need to invoke LLMs via OpenAI-compatible endpoints
+//! (OpenRouter, and — since #2406 — Fireworks) OR, for organisations running on
+//! AWS (#1021), via Bedrock's Converse API. Both transports speak the same
+//! provider-neutral `ChatRequest`/`ChatResponse` shape so `AgentLoop` and every
+//! other caller never branches on the backend. The OpenAI-compatible HTTP
+//! mechanics now live in the shared `trusty_common::inference` adapter layer
+//! (epic #2400) rather than a bespoke tcode client — `OpenAiCompatClient`
+//! (`client`) is the thin consumer of that core, bridged to tcode's wire types
+//! by `convert`.
+//! What: This module exports `OpenAiCompatClient` (shared OpenRouter/Fireworks
+//! transport), `BedrockChatClient` (Bedrock Converse), `DispatchingLlmClient`
+//! (routes each request to the right transport by model slug via
+//! `crate::provider::provider_for`), all request/response types (`ChatRequest`,
+//! `ChatResponse`, `ChatMessage`, `ToolDefinition`, …), `LlmError`, and (#2264)
+//! the opt-in `debug_capture` module — `DebugCaptureSink` +
+//! `wrap_with_debug_capture` — that dumps the FULL wire-level request/response
+//! of every round-trip to JSONL when `TCODE_DEBUG_TRANSCRIPT` is set.
+//! OpenRouter/Fireworks credentials are resolved via the shared 3-tier chain
+//! (process env > `.env.local` > secure store); Bedrock uses the standard AWS
+//! credential chain (no key). Library helpers never read `std::env` for secrets
+//! directly — resolution is centralised in the shared resolver.
 //! Test: `cargo test -p trusty-code` covers all unit tests (serialisation,
-//! deserialisation, error mapping, Bedrock message/tool-choice/response
-//! conversion, debug-capture). `cargo test -p trusty-code -- --include-ignored`
-//! additionally runs the live `live_openrouter_call`/`live_bedrock_call` tests.
+//! deserialisation, type conversion + error mapping, Bedrock message/tool-choice/
+//! response conversion, debug-capture) plus the offline black-box HTTP round-trip
+//! in `tests/inference_shared_adapter_e2e.rs`. `cargo test -p trusty-code --
+//! --include-ignored` additionally runs the live
+//! `live_openrouter_call`/`live_fireworks_call`/`live_bedrock_call` tests.
 
 mod bedrock;
 mod client;
 mod client_trait;
+mod convert;
 mod debug_capture;
 mod dispatch;
 mod error;
@@ -40,7 +45,7 @@ mod usage;
 // ── Public API re-exports ─────────────────────────────────────────────────────
 
 pub use bedrock::BedrockChatClient;
-pub use client::{LlmClient, LlmClientConfig};
+pub use client::OpenAiCompatClient;
 pub use client_trait::LlmClientTrait;
 pub use debug_capture::{DebugCaptureSink, wrap_with_debug_capture};
 pub use dispatch::DispatchingLlmClient;

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -30,7 +30,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use tracing::info;
 
-use trusty_code::llm::{DispatchingLlmClient, LlmClientConfig, LlmClientTrait};
+use trusty_code::llm::{DispatchingLlmClient, LlmClientTrait};
 use trusty_code::run_task::{ExitCode, RunTaskParams, execute_run_task};
 
 mod cli;
@@ -560,37 +560,27 @@ async fn run_task(
 }
 
 /// Build the real LLM client, dispatching `bedrock/*` model slugs to AWS
-/// Bedrock and everything else to OpenRouter via `OPENROUTER_API_KEY` (#1021
-/// phase 1).
+/// Bedrock, `fireworks/*` to Fireworks, and everything else to OpenRouter —
+/// all via the shared `trusty_common::inference` adapter for the OpenAI-dialect
+/// providers (#1021 phase 1; #2406 migration).
 ///
-/// Why: The binary is the only place that reads the API key from the environment
-/// (library code never touches `std::env` for secrets). Attribution headers help
-/// OpenRouter dashboards label tcode traffic. `DispatchingLlmClient` (rather than
-/// a bare `LlmClient`) is what lets `--engineer-model bedrock/us.anthropic.*` (or
-/// `TCODE_ENGINEER_MODEL`) actually reach AWS Bedrock instead of OpenRouter's
-/// HTTP endpoint; the Bedrock transport is only constructed lazily on first use
+/// Why: `DispatchingLlmClient` is what lets `--engineer-model bedrock/us.anthropic.*`
+/// (or `TCODE_ENGINEER_MODEL`) reach AWS Bedrock, `fireworks/*` reach Fireworks,
+/// and every other slug reach OpenRouter — the caller keeps depending only on
+/// `LlmClientTrait`. The Bedrock transport is constructed lazily on first use
 /// (standard AWS credential chain, e.g. `AWS_PROFILE=cto`), so a pure-OpenRouter
-/// run never needs AWS credentials. Symmetrically (#2245), a MISSING
-/// `OPENROUTER_API_KEY` is no longer a hard construction-time error here: a
-/// pure-Bedrock run (`TCODE_ENGINEER_MODEL=bedrock/...`) must not be blocked
-/// by a key it will never use. `OPENROUTER_API_KEY` still surfaces as a clear
-/// error the moment a non-bedrock model actually needs it (from
-/// `DispatchingLlmClient::chat`), just no longer at startup.
-/// What: Attempts `LlmClientConfig::from_env`, attaching referer/title on
-/// success; on failure (key unset) passes `None` through instead of
-/// propagating the error. Always constructs a `DispatchingLlmClient` — it
-/// can only fail here if a PRESENT key somehow fails to build the underlying
-/// HTTP client (see `LlmClient::from_config`'s docs: "extremely rare").
+/// run never needs AWS credentials. Credentials for the OpenAI-dialect providers
+/// are resolved by the shared 3-tier chain (process env > `.env.local` > secure
+/// store) at first use, not read here — so construction touches no secrets and
+/// cannot fail on a missing key (#2245); a missing key surfaces as a clear error
+/// the moment a model that needs it is actually dispatched
+/// (`DispatchingLlmClient::chat`), never at startup.
+/// What: constructs a `DispatchingLlmClient` (infallible — no credential access
+/// at construction) and boxes it as the shared `Arc<dyn LlmClientTrait>`.
 /// Test: `tests::build_llm_client_succeeds_without_openrouter_key`; a live
-/// run against either backend is exercised manually.
+/// run against each backend is exercised manually.
 fn build_llm_client() -> Result<Arc<dyn LlmClientTrait>> {
-    let openrouter_config = LlmClientConfig::from_env().ok().map(|cfg| {
-        cfg.with_referer("https://github.com/bobmatnyc/trusty-tools")
-            .with_title("trusty-code run-task")
-    });
-    let client = DispatchingLlmClient::new(openrouter_config)
-        .map_err(|e| anyhow::anyhow!("failed to build LLM client: {e}"))?;
-    Ok(Arc::new(client))
+    Ok(Arc::new(DispatchingLlmClient::new()))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/trusty-code/src/provider/adapter.rs
+++ b/crates/trusty-code/src/provider/adapter.rs
@@ -11,23 +11,30 @@
 use std::sync::Arc;
 
 use super::bedrock::BedrockProvider;
+use super::fireworks::FireworksProvider;
 use super::openrouter::OpenRouterProvider;
 use super::traits::Provider;
 
 /// Slug prefix that routes to the Bedrock backend.
 const BEDROCK_PREFIX: &str = "bedrock/";
 
+/// Slug prefix that routes to the Fireworks backend (#2406).
+const FIREWORKS_PREFIX: &str = "fireworks/";
+
 /// Select the provider implementation for a model slug.
 ///
 /// Why: The loop must stay backend-agnostic; this factory is the only place that
 /// knows how to map a slug to a backend, so adding a backend touches one site.
-/// What: Returns [`BedrockProvider`] for slugs beginning with `bedrock/`, and
-/// the default [`OpenRouterProvider`] (carrying the slug for its
+/// What: Returns [`BedrockProvider`] for slugs beginning with `bedrock/`,
+/// [`FireworksProvider`] for slugs beginning with `fireworks/` (#2406), and the
+/// default [`OpenRouterProvider`] (carrying the slug for its
 /// `supports_native_tools` decision) for everything else.
 /// Test: `adapter::tests::provider_for_routes_*`.
 pub fn provider_for(slug: &str) -> Arc<dyn Provider> {
     if slug.starts_with(BEDROCK_PREFIX) {
         Arc::new(BedrockProvider::new())
+    } else if slug.starts_with(FIREWORKS_PREFIX) {
+        Arc::new(FireworksProvider::new())
     } else {
         Arc::new(OpenRouterProvider::new(slug))
     }
@@ -51,7 +58,19 @@ mod tests {
         assert_eq!(p.name(), "bedrock");
     }
 
-    /// Non-Bedrock slugs route to OpenRouter (the default).
+    /// `fireworks/*` slugs route to the Fireworks provider (#2406).
+    ///
+    /// Why: per-agent routing must direct Fireworks-hosted models to the
+    /// Fireworks normalisation profile, not the OpenRouter default.
+    /// What: Resolve a `fireworks/...` slug, assert `name() == "fireworks"`.
+    /// Test: this test.
+    #[test]
+    fn provider_for_routes_fireworks() {
+        let p = provider_for("fireworks/accounts/fireworks/models/llama-v3p1-70b-instruct");
+        assert_eq!(p.name(), "fireworks");
+    }
+
+    /// Non-Bedrock, non-Fireworks slugs route to OpenRouter (the default).
     ///
     /// Why: Qwen/DeepSeek/Gemma/OpenAI/Anthropic-via-OR all go through
     /// OpenRouter; verify the default branch for several families.

--- a/crates/trusty-code/src/provider/fireworks.rs
+++ b/crates/trusty-code/src/provider/fireworks.rs
@@ -1,0 +1,187 @@
+//! Fireworks provider — request-shaping normalisation for `fireworks/*` slugs
+//! (#2406, epic #2400).
+//!
+//! Why: enabling Fireworks in tcode (#2406) is not only a transport concern —
+//! `AgentLoop::build_request` consults `crate::provider::provider_for` to decide
+//! whether to request OpenRouter's detailed-usage directive, whether to attach
+//! prompt-cache breakpoints, and whether to send a native `tools` array. Routing
+//! a `fireworks/*` slug to the default `OpenRouterProvider` would (wrongly)
+//! request `usage:{include:true}` — a directive Fireworks doesn't understand —
+//! so Fireworks needs its own normalisation profile, mirroring the shared
+//! capability registry's Fireworks seed (`detailed_usage_accounting = false`,
+//! `prompt_caching = false`, native OpenAI-style function calling).
+//! What: [`FireworksProvider`] implements [`Provider`] with the OpenAI-dialect
+//! `tool_choice` mapping (identical to OpenRouter's), the standard usage
+//! extraction, native tool support, NO prompt caching, and NO detailed-usage
+//! request. The transport (`crate::llm::client::OpenAiCompatClient`) is what
+//! actually reaches `api.fireworks.ai`; this type only shapes the request.
+//! Test: `fireworks::tests::*`.
+
+use serde_json::{Value, json};
+
+use super::traits::{Provider, ToolChoice};
+use crate::llm::ChatResponse;
+use crate::perf::TokenUsage;
+
+/// Provider for Fireworks-hosted models (`fireworks/*` slugs), served behind the
+/// OpenAI-compatible `/chat/completions` schema.
+///
+/// Why: gives `build_request` a Fireworks-correct normalisation profile so the
+/// wire payload matches what Fireworks accepts (no OpenRouter-only directives).
+/// What: zero-sized marker type implementing [`Provider`].
+/// Test: `fireworks::tests::*`.
+#[derive(Debug, Clone, Default)]
+pub struct FireworksProvider;
+
+impl FireworksProvider {
+    /// Construct a `FireworksProvider`.
+    ///
+    /// Why: gives the factory a uniform constructor call site.
+    /// What: returns the zero-sized marker.
+    /// Test: `fireworks::tests::name_is_fireworks`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for FireworksProvider {
+    fn name(&self) -> &str {
+        "fireworks"
+    }
+
+    /// Translate a neutral [`ToolChoice`] into OpenAI-dialect wire JSON.
+    ///
+    /// Why: Fireworks uses the OpenAI `tool_choice` spelling (string policies +
+    /// `{type:function, function:{name}}` object), identical to OpenRouter.
+    /// What: the OpenAI mapping.
+    /// Test: `fireworks::tests::map_tool_choice_scalars`.
+    fn map_tool_choice(&self, choice: ToolChoice) -> Value {
+        match choice {
+            ToolChoice::None => json!("none"),
+            ToolChoice::Auto => json!("auto"),
+            ToolChoice::Required => json!("required"),
+            ToolChoice::Function(name) => json!({
+                "type": "function",
+                "function": { "name": name },
+            }),
+        }
+    }
+
+    /// Extract canonical token usage from a Fireworks response.
+    ///
+    /// Why: Fireworks returns the standard OpenAI `usage` block, already
+    /// normalised into `ChatResponse.usage` by the shared adapter's parse.
+    /// What: delegates to `ChatResponse::token_usage` (identical to the other
+    /// OpenAI-dialect providers).
+    /// Test: `fireworks::tests::extract_usage_maps_fields`.
+    fn extract_usage(&self, response: &ChatResponse) -> TokenUsage {
+        response.clone().token_usage()
+    }
+
+    fn supports_native_tools(&self) -> bool {
+        // Fireworks' tool-capable models accept the native OpenAI `tools` array;
+        // mirrors the shared registry's Fireworks `native_tool_calling = true`.
+        true
+    }
+
+    fn supports_prompt_caching(&self) -> bool {
+        // Fireworks does not honour Anthropic-style `cache_control` breakpoints;
+        // mirrors the shared registry's Fireworks `prompt_caching = false`.
+        false
+    }
+
+    fn wants_detailed_usage(&self) -> bool {
+        // `usage:{include:true}` is an OpenRouter-only directive; Fireworks would
+        // not understand it. Mirrors the shared registry's Fireworks
+        // `detailed_usage_accounting = false`.
+        false
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `name()` returns `"fireworks"`.
+    ///
+    /// Why: routing and telemetry distinguish Fireworks by name; the transport's
+    /// `provider_for_slug` and `dispatch`'s bedrock check both key off it.
+    /// What: assert the name.
+    /// Test: this test.
+    #[test]
+    fn name_is_fireworks() {
+        assert_eq!(FireworksProvider::new().name(), "fireworks");
+    }
+
+    /// Fireworks reports native-tool support.
+    ///
+    /// Why: `build_request` sends the native `tools` array for tool-capable
+    /// Fireworks models.
+    /// What: assert `supports_native_tools()` is `true`.
+    /// Test: this test.
+    #[test]
+    fn fireworks_supports_native_tools() {
+        assert!(FireworksProvider::new().supports_native_tools());
+    }
+
+    /// Fireworks does NOT request OpenRouter's detailed usage accounting.
+    ///
+    /// Why: this is the exact gate that would otherwise attach the
+    /// OpenRouter-only `usage:{include:true}` directive to a Fireworks request —
+    /// the core reason a Fireworks-specific provider is needed.
+    /// What: assert `wants_detailed_usage()` is `false`.
+    /// Test: this test.
+    #[test]
+    fn fireworks_does_not_want_detailed_usage() {
+        assert!(!FireworksProvider::new().wants_detailed_usage());
+    }
+
+    /// Fireworks does NOT advertise prompt caching.
+    ///
+    /// Why: `build_request` must never mark a Fireworks request with an
+    /// Anthropic-style `cache_control` breakpoint it cannot honour.
+    /// What: assert `supports_prompt_caching()` is `false`.
+    /// Test: this test.
+    #[test]
+    fn fireworks_does_not_support_prompt_caching() {
+        assert!(!FireworksProvider::new().supports_prompt_caching());
+    }
+
+    /// `map_tool_choice` maps the scalar policies to the OpenAI wire strings.
+    ///
+    /// Why: Fireworks expects the OpenAI spelling; a wrong shape breaks
+    /// tool routing.
+    /// What: map each scalar variant, assert the JSON value.
+    /// Test: this test.
+    #[test]
+    fn map_tool_choice_scalars() {
+        let p = FireworksProvider::new();
+        assert_eq!(p.map_tool_choice(ToolChoice::None), json!("none"));
+        assert_eq!(p.map_tool_choice(ToolChoice::Auto), json!("auto"));
+        assert_eq!(p.map_tool_choice(ToolChoice::Required), json!("required"));
+        assert_eq!(
+            p.map_tool_choice(ToolChoice::Function("search".into())),
+            json!({"type": "function", "function": {"name": "search"}})
+        );
+    }
+
+    /// `extract_usage` maps a normalised usage block into `TokenUsage`.
+    ///
+    /// Why: pins that Fireworks performs no extra (inconsistent) usage transform.
+    /// What: deserialise a response fixture, extract usage, assert fields.
+    /// Test: this test.
+    #[test]
+    fn extract_usage_maps_fields() {
+        let fixture = r#"{
+          "id": "fw-1",
+          "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 40, "completion_tokens": 8, "total_tokens": 48}
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        let usage = FireworksProvider::new().extract_usage(&resp);
+        assert_eq!(usage.prompt_tokens, 40);
+        assert_eq!(usage.completion_tokens, 8);
+    }
+}

--- a/crates/trusty-code/src/provider/mod.rs
+++ b/crates/trusty-code/src/provider/mod.rs
@@ -5,8 +5,9 @@
 //! not branch on the backend; it depends on the [`Provider`] trait and asks a
 //! factory for the right implementation given a model slug. This module is that
 //! seam (#1021) and the precedence resolver for which slug to use.
-//! What: Re-exports the [`Provider`] trait and [`ToolChoice`] enum, the two
-//! concrete providers ([`OpenRouterProvider`], [`BedrockProvider`]), the
+//! What: Re-exports the [`Provider`] trait and [`ToolChoice`] enum, the three
+//! concrete providers ([`OpenRouterProvider`], [`BedrockProvider`],
+//! [`FireworksProvider`]), the
 //! [`provider_for`] factory, the [`resolve_model`] precedence function plus
 //! its [`DEFAULT_MODEL`] constant, the [`resolve_max_tokens`] precedence
 //! function plus its [`DEFAULT_MAX_TOKENS`] constant, and (#2207) the
@@ -19,12 +20,14 @@
 
 mod adapter;
 mod bedrock;
+mod fireworks;
 mod openrouter;
 mod routing;
 mod traits;
 
 pub use adapter::provider_for;
 pub use bedrock::BedrockProvider;
+pub use fireworks::FireworksProvider;
 pub use openrouter::OpenRouterProvider;
 pub use routing::{
     DEFAULT_CONTEXT_WINDOW, DEFAULT_MAX_TOKENS, DEFAULT_MODEL, DEFAULT_RUN_DEADLINE_SECS,

--- a/crates/trusty-code/src/task/mock_llm.rs
+++ b/crates/trusty-code/src/task/mock_llm.rs
@@ -24,9 +24,7 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use crate::jsonrpc::RpcError;
-use crate::llm::{
-    ChatRequest, ChatResponse, DispatchingLlmClient, LlmClientConfig, LlmClientTrait, LlmError,
-};
+use crate::llm::{ChatRequest, ChatResponse, DispatchingLlmClient, LlmClientTrait, LlmError};
 
 /// Environment variable selecting the mock LLM. Set to [`MOCK_LLM_ECHO`] to
 /// enable [`EchoLlmClient`] instead of a real OpenRouter client.
@@ -42,24 +40,21 @@ pub const MOCK_LLM_ECHO: &str = "echo";
 /// once and is easy to find.
 /// What: if [`MOCK_LLM_ENV`] is set to [`MOCK_LLM_ECHO`], returns an
 /// [`EchoLlmClient`]. Otherwise builds a real `DispatchingLlmClient` — routing
-/// `bedrock/*` model slugs to AWS Bedrock and everything else to OpenRouter
-/// via `OPENROUTER_API_KEY` (#1021 phase 1). `OPENROUTER_API_KEY` is read
-/// best-effort (via `LlmClientConfig::from_env().ok()`): a pure-Bedrock
-/// `task.run` must not be blocked by a key it will never use (#2245) — a
-/// missing key only surfaces as `RpcError::internal` if a non-bedrock model
-/// actually needs OpenRouter and it turns out to be unconfigured, at which
-/// point `DispatchingLlmClient::chat` returns that error and the caller
-/// still gets an actionable message naming both escape hatches.
+/// `bedrock/*` slugs to AWS Bedrock, `fireworks/*` to Fireworks, and everything
+/// else to OpenRouter (#1021 phase 1; #2406). Construction touches no
+/// credentials: the OpenAI-dialect providers resolve their key lazily via the
+/// shared env > `.env.local` > store chain at first use, and Bedrock uses the
+/// AWS credential chain — so a pure-Bedrock `task.run` is never blocked by a key
+/// it will never use (#2245). A missing key only surfaces (via
+/// `DispatchingLlmClient::chat` → an actionable error) when a model that needs
+/// it is actually dispatched.
 /// Test: `task::mock_llm::tests::mock_env_selects_echo_client`,
 /// `task::mock_llm::tests::real_client_builds_without_openrouter_key`.
 pub fn build_llm_client() -> Result<Arc<dyn LlmClientTrait>, RpcError> {
     if std::env::var(MOCK_LLM_ENV).ok().as_deref() == Some(MOCK_LLM_ECHO) {
         return Ok(Arc::new(EchoLlmClient::new()));
     }
-    let openrouter_config = LlmClientConfig::from_env().ok();
-    let client = DispatchingLlmClient::new(openrouter_config)
-        .map_err(|e| RpcError::internal(format!("build LLM client: {e}")))?;
-    Ok(Arc::new(client))
+    Ok(Arc::new(DispatchingLlmClient::new()))
 }
 
 /// A deterministic, scripted `LlmClientTrait` for offline task-execution

--- a/crates/trusty-code/tests/inference_shared_adapter_e2e.rs
+++ b/crates/trusty-code/tests/inference_shared_adapter_e2e.rs
@@ -1,0 +1,160 @@
+//! Black-box e2e: prove trusty-code's OpenRouter/Fireworks inference flows
+//! through the shared `trusty_common::inference` adapter (#2406, epic #2400).
+//!
+//! Why: #2406's core claim is that tcode's OpenAI-compatible transport is now
+//! the shared adapter, and that Fireworks is reachable. tcode's standing
+//! directive requires that claim be proven end-to-end, black-box, offline, and
+//! deterministic — not merely via internal code paths. This drives tcode's real
+//! production transport (`OpenAiCompatClient`, the same type `main.rs` and
+//! `task::mock_llm` construct) over a REAL loopback socket served by the shared
+//! `test_support::MockInferenceServer`, then asserts on the exact wire request
+//! the shared adapter emitted. That request shape (endpoint path, `Bearer` auth,
+//! provider-specific `usage` directive, and the Fireworks prefix-stripped model)
+//! is producible ONLY by the shared adapter — so a green run is direct evidence
+//! the migration is wired correctly.
+//! What: two cases — OpenRouter (asserts the shared adapter injected
+//! `usage:{include:true}` and sent the slug verbatim) and Fireworks (asserts NO
+//! usage directive and the `fireworks/` routing prefix stripped to the
+//! provider-native model id). Credentials come from an injected `MemoryKeyStore`
+//! and base URLs from `OpenAiCompatClient::with_config`, so the test mutates no
+//! process env and is fully parallel-safe.
+//! Test: this file (`cargo test -p trusty-code --test inference_shared_adapter_e2e`).
+
+use serde_json::json;
+
+use trusty_code::llm::{ChatMessage, ChatRequest, OpenAiCompatClient};
+use trusty_common::inference::credentials::{KeyStore, MemoryKeyStore};
+use trusty_common::inference::test_support::MockInferenceServer;
+
+/// A canned OpenAI-compatible chat/completions response the mock serves.
+fn canned_response() -> serde_json::Value {
+    json!({
+        "id": "gen-mock",
+        "model": "served/model",
+        "choices": [{
+            "message": {"role": "assistant", "content": "pong-mock", "tool_calls": []},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}
+    })
+}
+
+/// Build a minimal single-turn tcode request for `model` with no usage directive
+/// set by the caller (so any directive on the wire came from the shared adapter).
+fn request_for(model: &str) -> ChatRequest {
+    ChatRequest {
+        model: model.to_string(),
+        messages: vec![
+            ChatMessage::system("You are a concise assistant."),
+            ChatMessage::user("Reply with exactly the word: pong"),
+        ],
+        temperature: Some(0.0),
+        max_tokens: Some(16),
+        tools: None,
+        tool_choice: None,
+        usage: None,
+    }
+}
+
+/// An OpenRouter-routed request flows through the shared adapter, which injects
+/// the OpenRouter-only `usage:{include:true}` directive and sends the slug
+/// verbatim.
+///
+/// Why: proves the OpenRouter path is the shared adapter (the usage-directive
+/// injection is shared-adapter behaviour driven by the capability registry, not
+/// anything tcode does) and that behaviour is preserved unchanged.
+/// What: point the OpenRouter base URL at the mock, chat, then assert the parsed
+/// response AND the captured wire request (path, auth, model, usage directive).
+/// Test: this test.
+#[tokio::test]
+async fn openrouter_routes_through_shared_adapter_and_injects_usage() {
+    let server = MockInferenceServer::spawn(200, canned_response())
+        .await
+        .expect("spawn mock");
+
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-mock").expect("seed key"); // pragma: allowlist secret
+
+    // OpenRouter → mock; Fireworks base URL is unused in this case.
+    let client = OpenAiCompatClient::with_config(
+        Box::new(store),
+        server.url().to_string(),
+        "http://127.0.0.1:1/unused".to_string(),
+    );
+
+    let resp = client
+        .chat(&request_for("openai/gpt-4o-mini"))
+        .await
+        .expect("chat through shared adapter");
+
+    // Response flowed back through the tcode conversion.
+    assert_eq!(resp.first_text().as_deref(), Some("pong-mock"));
+    assert_eq!(resp.token_usage().prompt_tokens, 5);
+
+    // The shared adapter's outbound wire request.
+    let captured = server.last_request().expect("one request captured");
+    assert_eq!(captured.method, "POST");
+    assert_eq!(captured.path, "/chat/completions");
+    assert!(
+        captured
+            .header("authorization")
+            .is_some_and(|v| v.starts_with("Bearer ")),
+        "shared adapter must send a Bearer auth header"
+    );
+    let body = captured.body.expect("json body");
+    assert_eq!(body["model"], "openai/gpt-4o-mini", "slug sent verbatim");
+    assert_eq!(body["messages"][0]["role"], "system");
+    assert_eq!(
+        body["usage"],
+        json!({"include": true}),
+        "shared OpenRouter adapter must inject the detailed-usage directive"
+    );
+}
+
+/// A Fireworks-routed request flows through the shared adapter, which strips the
+/// `fireworks/` routing prefix to the provider-native model id and sends NO
+/// usage directive (Fireworks does not support it).
+///
+/// Why: this is the concrete payoff of #2406 — Fireworks is reachable, routed
+/// through the shared adapter, with the correct provider-specific wire shape.
+/// What: point the Fireworks base URL at the mock, chat with a `fireworks/`
+/// slug, then assert the captured request carries the stripped model and no
+/// usage directive.
+/// Test: this test.
+#[tokio::test]
+async fn fireworks_routes_through_shared_adapter_strips_prefix_and_omits_usage() {
+    let server = MockInferenceServer::spawn(200, canned_response())
+        .await
+        .expect("spawn mock");
+
+    let store = MemoryKeyStore::new();
+    store.set("fireworks", "fw-mock").expect("seed key"); // pragma: allowlist secret
+
+    // Fireworks → mock; OpenRouter base URL is unused in this case.
+    let client = OpenAiCompatClient::with_config(
+        Box::new(store),
+        "http://127.0.0.1:1/unused".to_string(),
+        server.url().to_string(),
+    );
+
+    let resp = client
+        .chat(&request_for(
+            "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct",
+        ))
+        .await
+        .expect("chat through shared fireworks adapter");
+
+    assert_eq!(resp.first_text().as_deref(), Some("pong-mock"));
+
+    let captured = server.last_request().expect("one request captured");
+    assert_eq!(captured.path, "/chat/completions");
+    let body = captured.body.expect("json body");
+    assert_eq!(
+        body["model"], "accounts/fireworks/models/llama-v3p1-8b-instruct",
+        "the fireworks/ routing prefix must be stripped to the provider-native id"
+    );
+    assert!(
+        body.get("usage").is_none() || body["usage"].is_null(),
+        "Fireworks must NOT receive the OpenRouter-only usage directive"
+    );
+}


### PR DESCRIPTION
Wave-1 slice 4 of epic #2400. Rewires trusty-code's OpenRouter/OpenAI-compat inference transport onto the shared `trusty_common::inference` adapter layer (from #2401 KeyStore / #2402 trait+registry+configurator / #2403 OpenAI-compat + OpenRouter + Fireworks adapters, all merged) and **enables Fireworks in tcode** — the concrete payoff of this ticket.

## What was migrated (the OpenRouter / OpenAI-compat path)
- Retired the bespoke tcode OpenRouter `reqwest` client (`llm::client::LlmClient` / `LlmClientConfig`). The new **`OpenAiCompatClient`** is a thin consumer of the shared `OpenAiCompatAdapter`:
  - selects OpenRouter vs Fireworks by slug via `crate::provider::provider_for` (the **same** factory `dispatch` uses for Bedrock and `AgentLoop::build_request` uses for usage/caching — one routing source of truth);
  - resolves credentials through the shared **3-tier resolver** (process env > `.env.local` > secure store) — retiring tcode's ad-hoc `OPENROUTER_API_KEY`-only read;
  - **caches** the built adapter per provider so the underlying reqwest connection pool is reused across a run's many turns (latency/cost baseline concern).
- **`llm::convert`** bridges tcode's wire types ↔ the shared types at exactly one seam, field-by-field so the #2156 `cache_control` breakpoint survives (a serde round-trip would silently drop the `#[serde(skip)]` marker and disable prompt caching).
- Added `LlmError::Inference(String)`; `Api → ApiError` and `MissingCredential → MissingConfig` are preserved so 401/429 status codes and the "set this key" operator guidance survive.

## Fireworks now enabled
- `fireworks/*` slugs route to the shared Fireworks adapter with `FIREWORKS_API_KEY` (resolved via the shared chain). The `fireworks/` routing prefix is **stripped** to the provider-native `accounts/fireworks/models/*` id on the wire. A missing key is an explicit, Fireworks-specific `MissingConfig` — **never a silent fall-back to OpenRouter**.
- New `provider::FireworksProvider` gives `build_request` a Fireworks-correct profile (**no** OpenRouter-only `usage:{include:true}` directive, **no** prompt caching, native OpenAI tools), mirroring the shared capability registry seed.

## What was PRESERVED
- **Bedrock left EXACTLY intact** (deferred to #2407). Resolution of the "two bedrock surfaces" question: there is no `unimplemented!()` stub today — the transport `llm::bedrock::BedrockChatClient` (Converse via AWS SDK) and the normalization `provider::bedrock::BedrockProvider` are both fully working and untouched; `DispatchingLlmClient` still routes `bedrock/*` to the Converse transport. The old research's `unimplemented!()` note described the historical #1021-phase-1 stub, since replaced.
- Cost/telemetry capture (authoritative OpenRouter usage accounting incl. nested cache counters + `cost`), prompt-caching request+response handling, `max_tokens`, deadline + failure-path telemetry, and the `TCODE_MOCK_LLM=echo` hook — all unchanged. Construction stays credential-free (#2245 deferred-failure contract preserved).

## Testability (merge gate)
- All existing tcode e2e stay green, incl. the offline `session_e2e` / `task_e2e` (`TCODE_MOCK_LLM=echo`).
- **New `tests/inference_shared_adapter_e2e.rs`** drives tcode's real `OpenAiCompatClient` over a **real loopback socket** served by the shared `test_support::MockInferenceServer`, asserting the exact wire request only the shared adapter can produce — OpenRouter injects `usage:{include:true}` and sends the slug verbatim; Fireworks omits the directive and strips the routing prefix. Offline, deterministic, black-box.
- `#[ignore]` live smokes ported: `live_openrouter_call` + new `live_fireworks_call` (and `agent_loop_live` re-pointed at the shared transport).

## Verification (raw)
- `cargo test -p trusty-code` → `874 passed; 0 failed; 4 ignored` (lib) + cli_e2e 7, inference_shared_adapter_e2e 2, m1_cutline 4, session_e2e 2, task_e2e 3 — all `0 failed`.
- `cargo test -p trusty-common --features inference-client` → `225 passed; 0 failed` (+8) — shared layer not regressed.
- `cargo test --workspace` → EXIT 0, zero failures.
- `cargo clippy --workspace --all-targets -- -D warnings` → EXIT 0.
- `cargo fmt --check` → clean. `bash scripts/check_line_cap.sh` → 0 violations.

> HARD MERGE GATE note: the M3 bake-off L1+L2 rerun (no regression vs the run-4 / run-5 baselines) and the live `fireworks/*` completion smoke require a post-merge install + live keys — recommended as a separate follow-up before close.

Closes #2406
Refs epic #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)