### PR TITLE
feat(trusty-code): route together/* models through the shared Together adapter

### DIFF
--- a/crates/trusty-code/src/llm/client.rs
+++ b/crates/trusty-code/src/llm/client.rs
@@ -6,27 +6,30 @@
 //! detailed-usage directive, HTTP→error classification, response parsing) in
 //! ONE shared core so every consumer shares it instead of six near-identical
 //! copies. This module is tcode's thin consumer of that core: it selects the
-//! provider (OpenRouter or Fireworks) by model slug, resolves the credential via
-//! the shared 3-tier resolver (process env > `.env.local` > secure store),
-//! builds the matching `trusty_common::inference` adapter once (caching it so
-//! the underlying `reqwest` connection pool is reused across a run's many
-//! turns — a bake-off latency concern), and bridges tcode's request/response
-//! types across the seam (`super::convert`). Bedrock stays on its own Converse
-//! transport (`super::bedrock`, routed by `super::dispatch`) — its migration
-//! into commons is #2407.
+//! provider (OpenRouter, Fireworks, or Together) by model slug, resolves the
+//! credential via the shared 3-tier resolver (process env > `.env.local` >
+//! secure store), builds the matching `trusty_common::inference` adapter once
+//! (caching it so the underlying `reqwest` connection pool is reused across a
+//! run's many turns — a bake-off latency concern), and bridges tcode's
+//! request/response types across the seam (`super::convert`). Bedrock stays on
+//! its own Converse transport (`super::bedrock`, routed by `super::dispatch`) —
+//! its migration into commons is #2407.
 //! What: [`OpenAiCompatClient`] implements [`LlmClientTrait`]. `fireworks/*`
 //! slugs route to the Fireworks adapter (stripping the `fireworks/` routing
 //! prefix to the provider-native model id and requiring `FIREWORKS_API_KEY`);
-//! everything else routes to OpenRouter, sending the slug unchanged (identical
-//! to the pre-#2406 behaviour). A missing credential surfaces at `chat()` time
-//! (not construction), preserving the #2245 deferred-failure contract. The base
-//! URLs are overridable (`TCODE_OPENROUTER_BASE_URL` / `TCODE_FIREWORKS_BASE_URL`
-//! or [`OpenAiCompatClient::with_config`]) so an offline mock server can be
-//! targeted end-to-end.
+//! `together/*` slugs route to the Together adapter (#2494 — stripping the
+//! `together/` routing prefix and requiring `TOGETHER_API_KEY`); everything else
+//! routes to OpenRouter, sending the slug unchanged (identical to the pre-#2406
+//! behaviour). A missing credential surfaces at `chat()` time (not
+//! construction), preserving the #2245 deferred-failure contract. The base URLs
+//! are overridable (`TCODE_OPENROUTER_BASE_URL` / `TCODE_FIREWORKS_BASE_URL` /
+//! `TCODE_TOGETHER_BASE_URL` or [`OpenAiCompatClient::with_config`]) so an
+//! offline mock server can be targeted end-to-end.
 //! Test: `client::tests::*` (provider selection, prefix stripping, hermetic
 //! missing-credential path against an injected empty store) and the black-box
 //! HTTP round-trip in `tests/inference_shared_adapter_e2e.rs`; the `#[ignore]`
-//! `live_openrouter_call` / `live_fireworks_call` smokes hit the real APIs.
+//! `live_openrouter_call` / `live_fireworks_call` / `live_together_call` smokes
+//! hit the real APIs.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -37,7 +40,7 @@ use trusty_common::inference::{
     InferenceAdapter,
     credentials::{KeyStore, default_store, resolve_key_with},
     provider_for,
-    providers::{fireworks, openrouter},
+    providers::{fireworks, openrouter, together},
     registry::ProviderId,
 };
 
@@ -55,10 +58,19 @@ const OPENROUTER_BASE_URL_ENV: &str = "TCODE_OPENROUTER_BASE_URL";
 /// [`fireworks::FIREWORKS_BASE_URL`].
 const FIREWORKS_BASE_URL_ENV: &str = "TCODE_FIREWORKS_BASE_URL";
 
+/// Env var overriding the Together API base URL. Defaults to
+/// [`together::TOGETHER_BASE_URL`].
+const TOGETHER_BASE_URL_ENV: &str = "TCODE_TOGETHER_BASE_URL";
+
 /// The provider name `crate::provider::provider_for` reports for `fireworks/*`
 /// slugs — the single routing condition this client checks (mirroring how
 /// `super::dispatch` keys Bedrock routing off the same factory).
 const FIREWORKS_PROVIDER_NAME: &str = "fireworks";
+
+/// The provider name `crate::provider::provider_for` reports for `together/*`
+/// slugs — the second OpenAI-dialect routing condition this client checks
+/// (#2494), keyed off the same factory as Fireworks.
+const TOGETHER_PROVIDER_NAME: &str = "together";
 
 /// OpenAI-compatible transport over the shared inference adapter, routing
 /// OpenRouter and Fireworks by model slug.
@@ -74,6 +86,7 @@ pub struct OpenAiCompatClient {
     store: Box<dyn KeyStore>,
     openrouter_base: String,
     fireworks_base: String,
+    together_base: String,
     adapters: Mutex<HashMap<ProviderId, Arc<dyn InferenceAdapter>>>,
 }
 
@@ -111,25 +124,29 @@ impl OpenAiCompatClient {
             .unwrap_or_else(|_| openrouter::OPENROUTER_BASE_URL.to_string());
         let fireworks_base = std::env::var(FIREWORKS_BASE_URL_ENV)
             .unwrap_or_else(|_| fireworks::FIREWORKS_BASE_URL.to_string());
-        Self::with_config(store, openrouter_base, fireworks_base)
+        let together_base = std::env::var(TOGETHER_BASE_URL_ENV)
+            .unwrap_or_else(|_| together::TOGETHER_BASE_URL.to_string());
+        Self::with_config(store, openrouter_base, fireworks_base, together_base)
     }
 
-    /// Construct with an explicit store AND explicit base URLs.
+    /// Construct with an explicit store AND explicit per-provider base URLs.
     ///
-    /// Why: the offline black-box e2e points both providers at a
+    /// Why: the offline black-box e2e points each provider at a
     /// [`trusty_common::inference::test_support::MockInferenceServer`] without
     /// mutating process env (so the test stays parallel-safe).
-    /// What: stores all three inputs and an empty adapter cache.
+    /// What: stores all four inputs and an empty adapter cache.
     /// Test: `tests/inference_shared_adapter_e2e.rs`.
     pub fn with_config(
         store: Box<dyn KeyStore>,
         openrouter_base: String,
         fireworks_base: String,
+        together_base: String,
     ) -> Self {
         Self {
             store,
             openrouter_base,
             fireworks_base,
+            together_base,
             adapters: Mutex::new(HashMap::new()),
         }
     }
@@ -141,32 +158,38 @@ impl OpenAiCompatClient {
     /// `AgentLoop::build_request` consults for usage/caching decisions, so
     /// routing can never disagree with normalisation.
     /// What: [`ProviderId::Fireworks`] iff that factory reports `"fireworks"`,
-    /// else [`ProviderId::OpenRouter`] (the default for every other slug).
+    /// [`ProviderId::Together`] iff it reports `"together"` (#2494), else
+    /// [`ProviderId::OpenRouter`] (the default for every other slug).
     /// Test: `client::tests::selects_fireworks_for_prefixed_slug`,
+    /// `client::tests::selects_together_for_prefixed_slug`,
     /// `client::tests::selects_openrouter_for_plain_slug`.
     fn provider_for_slug(model: &str) -> ProviderId {
-        if crate::provider::provider_for(model).name() == FIREWORKS_PROVIDER_NAME {
-            ProviderId::Fireworks
-        } else {
-            ProviderId::OpenRouter
+        match crate::provider::provider_for(model).name() {
+            FIREWORKS_PROVIDER_NAME => ProviderId::Fireworks,
+            TOGETHER_PROVIDER_NAME => ProviderId::Together,
+            _ => ProviderId::OpenRouter,
         }
     }
 
     /// The provider-native wire model id for a routing slug.
     ///
-    /// Why: Fireworks serves bare `accounts/fireworks/models/*` ids, but tcode
-    /// routes on a `fireworks/`-prefixed slug; the prefix is a routing artefact
-    /// that must be stripped before the id is sent. OpenRouter takes the slug
-    /// verbatim (identical to pre-#2406).
-    /// What: strips a leading `fireworks/` for [`ProviderId::Fireworks`]; returns
-    /// the slug unchanged otherwise.
-    /// Test: `client::tests::fireworks_wire_model_strips_prefix`.
+    /// Why: Fireworks serves bare `accounts/fireworks/models/*` ids and Together
+    /// serves bare `meta-llama/*` (etc.) ids, but tcode routes on a
+    /// `fireworks/`- or `together/`-prefixed slug; the prefix is a routing
+    /// artefact that must be stripped before the id is sent. OpenRouter takes the
+    /// slug verbatim (identical to pre-#2406).
+    /// What: strips a leading `fireworks/` for [`ProviderId::Fireworks`] and a
+    /// leading `together/` for [`ProviderId::Together`] (#2494); returns the slug
+    /// unchanged otherwise.
+    /// Test: `client::tests::fireworks_wire_model_strips_prefix`,
+    /// `client::tests::together_wire_model_strips_prefix`.
     fn wire_model(provider: ProviderId, model: &str) -> String {
         match provider {
             ProviderId::Fireworks => model
                 .strip_prefix("fireworks/")
                 .unwrap_or(model)
                 .to_string(),
+            ProviderId::Together => model.strip_prefix("together/").unwrap_or(model).to_string(),
             _ => model.to_string(),
         }
     }
@@ -210,13 +233,15 @@ impl OpenAiCompatClient {
     /// fall-back to OpenRouter (which would be a wrong-provider misroute), and
     /// never an OpenRouter-flavoured error when both keys happen to be absent;
     /// only once the key is confirmed does it resolve + build the Fireworks
-    /// adapter. For OpenRouter, resolves on an `openrouter/` routing slug (a
-    /// missing key surfaces as the resolver's own `MissingCredential`, mapped to
-    /// `MissingConfig`). The resolved model slug is irrelevant to the built
-    /// adapter (it sends the per-request wire model), so a fixed routing slug is
-    /// used.
+    /// adapter. Together (#2494) follows the identical contract against
+    /// `TOGETHER_API_KEY`. For OpenRouter, resolves on an `openrouter/` routing
+    /// slug (a missing key surfaces as the resolver's own `MissingCredential`,
+    /// mapped to `MissingConfig`). The resolved model slug is irrelevant to the
+    /// built adapter (it sends the per-request wire model), so a fixed routing
+    /// slug is used.
     /// Test: `client::tests::missing_openrouter_key_errors_at_chat_time`,
-    /// `client::tests::missing_fireworks_key_errors_not_falls_back`.
+    /// `client::tests::missing_fireworks_key_errors_not_falls_back`,
+    /// `client::tests::missing_together_key_errors_not_falls_back`.
     fn build_adapter(&self, provider: ProviderId) -> Result<Box<dyn InferenceAdapter>, LlmError> {
         match provider {
             ProviderId::Fireworks => {
@@ -232,6 +257,20 @@ impl OpenAiCompatClient {
                 let resolved = provider_for("fireworks/route", self.store.as_ref())
                     .map_err(convert::map_error)?;
                 fireworks::build(&resolved, &self.fireworks_base).map_err(convert::map_error)
+            }
+            ProviderId::Together => {
+                if resolve_key_with("together", self.store.as_ref()).is_none() {
+                    return Err(LlmError::MissingConfig(
+                        "TOGETHER_API_KEY is required to reach a together/* model. Export it \
+                         (e.g. `export TOGETHER_API_KEY=tgp_...`), add it to .env.local, or set \
+                         it via `tcode config keys set together`."
+                            .to_string(),
+                    ));
+                }
+                // The key is present, so stage-1 of the resolver returns Together.
+                let resolved = provider_for("together/route", self.store.as_ref())
+                    .map_err(convert::map_error)?;
+                together::build(&resolved, &self.together_base).map_err(convert::map_error)
             }
             _ => {
                 let resolved = provider_for("openrouter/route", self.store.as_ref())
@@ -320,6 +359,21 @@ mod tests {
         );
     }
 
+    /// A `together/*` slug selects Together.
+    ///
+    /// Why: this is the routing decision that makes Together reachable (#2494).
+    /// What: assert the provider selection for a together slug.
+    /// Test: this test.
+    #[test]
+    fn selects_together_for_prefixed_slug() {
+        assert_eq!(
+            OpenAiCompatClient::provider_for_slug(
+                "together/meta-llama/Llama-3.3-70B-Instruct-Turbo"
+            ),
+            ProviderId::Together
+        );
+    }
+
     /// The Fireworks wire model strips the `fireworks/` routing prefix; the
     /// OpenRouter wire model is the slug verbatim.
     ///
@@ -338,6 +392,24 @@ mod tests {
         assert_eq!(
             OpenAiCompatClient::wire_model(ProviderId::OpenRouter, "openai/gpt-4o-mini"),
             "openai/gpt-4o-mini"
+        );
+    }
+
+    /// The Together wire model strips the `together/` routing prefix down to the
+    /// bare Together catalog slug.
+    ///
+    /// Why: Together 404s on the prefixed id; the prefix is a tcode routing
+    /// artefact only (#2494).
+    /// What: assert the stripped slug.
+    /// Test: this test.
+    #[test]
+    fn together_wire_model_strips_prefix() {
+        assert_eq!(
+            OpenAiCompatClient::wire_model(
+                ProviderId::Together,
+                "together/meta-llama/Llama-3.3-70B-Instruct-Turbo"
+            ),
+            "meta-llama/Llama-3.3-70B-Instruct-Turbo"
         );
     }
 
@@ -413,6 +485,44 @@ mod tests {
                 )
             }
             other => panic!("expected MissingConfig naming FIREWORKS_API_KEY, got: {other:?}"),
+        }
+    }
+
+    /// A `together/*` request with no `TOGETHER_API_KEY` fails with an explicit
+    /// `MissingConfig` — it must NOT silently fall back to OpenRouter (#2494).
+    ///
+    /// Why: the shared resolver's stage-1 falls through to OpenRouter when a
+    /// family key is absent; for an explicit tcode together route that would be a
+    /// wrong-provider misroute, so `build_adapter` turns it into a clear error —
+    /// the same contract as Fireworks.
+    /// What: with an empty store (and, when present locally, a real
+    /// `TOGETHER_API_KEY` shadowing it, in which case skip), assert
+    /// `MissingConfig` naming `TOGETHER_API_KEY`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn missing_together_key_errors_not_falls_back() {
+        if std::env::var("TOGETHER_API_KEY").is_ok_and(|v| !v.is_empty()) {
+            return; // real key present locally — the fall-back guard isn't exercised
+        }
+        let client = OpenAiCompatClient::with_store(Box::new(MemoryKeyStore::new()));
+        let req = ChatRequest {
+            model: "together/meta-llama/Llama-3.3-70B-Instruct-Turbo".into(),
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            tool_choice: None,
+            usage: None,
+        };
+        let err = client
+            .chat(&req)
+            .await
+            .expect_err("must fail without a key");
+        match err {
+            LlmError::MissingConfig(msg) => {
+                assert!(msg.contains("TOGETHER_API_KEY"), "unhelpful message: {msg}")
+            }
+            other => panic!("expected MissingConfig naming TOGETHER_API_KEY, got: {other:?}"),
         }
     }
 
@@ -496,5 +606,46 @@ mod tests {
             "prompt_tokens should be > 0"
         );
         eprintln!("live fireworks ok — text: {text:?}");
+    }
+
+    /// Live integration: a real Together round-trip via the shared adapter
+    /// (the concrete payoff of #2494).
+    ///
+    /// Why: proves `together/*` routing + prefix stripping + `TOGETHER_API_KEY`
+    /// resolution work against the real API.
+    /// What: reads `TOGETHER_API_KEY`; SKIPS when absent.
+    /// Test: `cargo test -p trusty-code -- --include-ignored live_together`.
+    #[tokio::test]
+    #[ignore = "requires TOGETHER_API_KEY; skipped in CI"]
+    async fn live_together_call() {
+        let Ok(key) = std::env::var("TOGETHER_API_KEY") else {
+            eprintln!("TOGETHER_API_KEY not set — skipping live test");
+            return;
+        };
+        if key.trim().is_empty() {
+            eprintln!("TOGETHER_API_KEY is empty — skipping live test");
+            return;
+        }
+        let client = OpenAiCompatClient::new();
+        let req = ChatRequest {
+            model: "together/meta-llama/Llama-3.3-70B-Instruct-Turbo".into(),
+            messages: vec![
+                super::super::ChatMessage::system("You are a concise assistant."),
+                super::super::ChatMessage::user("Reply with exactly the word: pong"),
+            ],
+            temperature: Some(0.0),
+            max_tokens: Some(16),
+            tools: None,
+            tool_choice: None,
+            usage: None,
+        };
+        let resp = client.chat(&req).await.expect("chat call succeeded");
+        let text = resp.first_text().expect("assistant produced text");
+        assert!(!text.is_empty(), "assistant text was empty");
+        assert!(
+            resp.token_usage().prompt_tokens > 0,
+            "prompt_tokens should be > 0"
+        );
+        eprintln!("live together ok — text: {text:?}");
     }
 }

--- a/crates/trusty-code/src/llm/dispatch.rs
+++ b/crates/trusty-code/src/llm/dispatch.rs
@@ -122,9 +122,10 @@ impl LlmClientTrait for DispatchingLlmClient {
     /// Why: the single method every caller (`AgentLoop`, `run_task`,
     /// `task::executor`) invokes through `Arc<dyn LlmClientTrait>`.
     /// What: `bedrock/*` slugs go through [`Self::bedrock`]; every other slug
-    /// (OpenRouter default and `fireworks/*`) goes through the
-    /// `OpenAiCompatClient`, which handles the OpenRouter-vs-Fireworks split and
-    /// surfaces a missing credential as `LlmError::MissingConfig` at this point.
+    /// (OpenRouter default, `fireworks/*`, and `together/*`) goes through the
+    /// `OpenAiCompatClient`, which handles the OpenRouter/Fireworks/Together split
+    /// and surfaces a missing credential as `LlmError::MissingConfig` at this
+    /// point.
     /// Test: `dispatch::tests::*`.
     async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
         if Self::routes_to_bedrock(&req.model) {
@@ -155,12 +156,13 @@ mod tests {
     }
 
     /// `routes_to_bedrock` is `false` for every non-Bedrock slug family,
-    /// including `fireworks/*` (which routes through the OpenAI-compat transport,
-    /// not Bedrock).
+    /// including `fireworks/*` and `together/*` (which route through the
+    /// OpenAI-compat transport, not Bedrock).
     ///
-    /// Why: guards against a routing regression sending ordinary OpenRouter or
-    /// Fireworks traffic to the (credential-less) Bedrock cell.
-    /// What: assert `false` for representative OpenRouter and Fireworks slugs.
+    /// Why: guards against a routing regression sending ordinary OpenRouter,
+    /// Fireworks, or Together traffic to the (credential-less) Bedrock cell.
+    /// What: assert `false` for representative OpenRouter, Fireworks, and
+    /// Together slugs.
     /// Test: this test.
     #[test]
     fn routes_non_bedrock_prefix_false() {
@@ -169,6 +171,7 @@ mod tests {
             "openai/gpt-4o-mini",
             "qwen/qwen-2.5-coder-32b-instruct",
             "fireworks/accounts/fireworks/models/llama-v3p1-70b-instruct",
+            "together/meta-llama/Llama-3.3-70B-Instruct-Turbo",
         ] {
             assert!(
                 !DispatchingLlmClient::routes_to_bedrock(slug),

--- a/crates/trusty-code/src/provider/adapter.rs
+++ b/crates/trusty-code/src/provider/adapter.rs
@@ -5,7 +5,9 @@
 //! slug→provider decision in one place instead of scattering `if slug.starts_with`
 //! branches across the loop (#1021).
 //! What: [`provider_for`] returns an `Arc<dyn Provider>` — [`BedrockProvider`]
-//! for `bedrock/*` slugs and [`OpenRouterProvider`] for everything else.
+//! for `bedrock/*` slugs, [`FireworksProvider`] for `fireworks/*`,
+//! [`TogetherProvider`] for `together/*`, and [`OpenRouterProvider`] for
+//! everything else.
 //! Test: `adapter::tests::*`.
 
 use std::sync::Arc;
@@ -13,6 +15,7 @@ use std::sync::Arc;
 use super::bedrock::BedrockProvider;
 use super::fireworks::FireworksProvider;
 use super::openrouter::OpenRouterProvider;
+use super::together::TogetherProvider;
 use super::traits::Provider;
 
 /// Slug prefix that routes to the Bedrock backend.
@@ -21,20 +24,28 @@ const BEDROCK_PREFIX: &str = "bedrock/";
 /// Slug prefix that routes to the Fireworks backend (#2406).
 const FIREWORKS_PREFIX: &str = "fireworks/";
 
+/// Slug prefix that routes to the Together.ai backend (#2494).
+const TOGETHER_PREFIX: &str = "together/";
+
 /// Select the provider implementation for a model slug.
 ///
 /// Why: The loop must stay backend-agnostic; this factory is the only place that
 /// knows how to map a slug to a backend, so adding a backend touches one site.
 /// What: Returns [`BedrockProvider`] for slugs beginning with `bedrock/`,
-/// [`FireworksProvider`] for slugs beginning with `fireworks/` (#2406), and the
+/// [`FireworksProvider`] for slugs beginning with `fireworks/` (#2406),
+/// [`TogetherProvider`] for slugs beginning with `together/` (#2494), and the
 /// default [`OpenRouterProvider`] (carrying the slug for its
-/// `supports_native_tools` decision) for everything else.
+/// `supports_native_tools` decision) for everything else. The `together/` check
+/// sits alongside `fireworks/` — after `bedrock/` — so no `together/*` slug can
+/// fall through to the OpenRouter default.
 /// Test: `adapter::tests::provider_for_routes_*`.
 pub fn provider_for(slug: &str) -> Arc<dyn Provider> {
     if slug.starts_with(BEDROCK_PREFIX) {
         Arc::new(BedrockProvider::new())
     } else if slug.starts_with(FIREWORKS_PREFIX) {
         Arc::new(FireworksProvider::new())
+    } else if slug.starts_with(TOGETHER_PREFIX) {
+        Arc::new(TogetherProvider::new())
     } else {
         Arc::new(OpenRouterProvider::new(slug))
     }
@@ -70,7 +81,20 @@ mod tests {
         assert_eq!(p.name(), "fireworks");
     }
 
-    /// Non-Bedrock, non-Fireworks slugs route to OpenRouter (the default).
+    /// `together/*` slugs route to the Together provider (#2494).
+    ///
+    /// Why: per-agent routing must direct Together-hosted models to the Together
+    /// normalisation profile, not the OpenRouter default.
+    /// What: Resolve a `together/...` slug, assert `name() == "together"`.
+    /// Test: this test.
+    #[test]
+    fn provider_for_routes_together() {
+        let p = provider_for("together/meta-llama/Llama-3.3-70B-Instruct-Turbo");
+        assert_eq!(p.name(), "together");
+    }
+
+    /// Non-Bedrock, non-Fireworks, non-Together slugs route to OpenRouter (the
+    /// default).
     ///
     /// Why: Qwen/DeepSeek/Gemma/OpenAI/Anthropic-via-OR all go through
     /// OpenRouter; verify the default branch for several families.

--- a/crates/trusty-code/src/provider/mod.rs
+++ b/crates/trusty-code/src/provider/mod.rs
@@ -5,9 +5,9 @@
 //! not branch on the backend; it depends on the [`Provider`] trait and asks a
 //! factory for the right implementation given a model slug. This module is that
 //! seam (#1021) and the precedence resolver for which slug to use.
-//! What: Re-exports the [`Provider`] trait and [`ToolChoice`] enum, the three
+//! What: Re-exports the [`Provider`] trait and [`ToolChoice`] enum, the four
 //! concrete providers ([`OpenRouterProvider`], [`BedrockProvider`],
-//! [`FireworksProvider`]), the
+//! [`FireworksProvider`], [`TogetherProvider`]), the
 //! [`provider_for`] factory, the [`resolve_model`] precedence function plus
 //! its [`DEFAULT_MODEL`] constant, the [`resolve_max_tokens`] precedence
 //! function plus its [`DEFAULT_MAX_TOKENS`] constant, and (#2207) the
@@ -23,6 +23,7 @@ mod bedrock;
 mod fireworks;
 mod openrouter;
 mod routing;
+mod together;
 mod traits;
 
 pub use adapter::provider_for;
@@ -34,4 +35,5 @@ pub use routing::{
     RUN_DEADLINE_ENV_VAR, resolve_context_window, resolve_deadline_secs, resolve_max_tokens,
     resolve_model,
 };
+pub use together::TogetherProvider;
 pub use traits::{Provider, ToolChoice};

--- a/crates/trusty-code/src/provider/together.rs
+++ b/crates/trusty-code/src/provider/together.rs
@@ -1,0 +1,194 @@
+//! Together.ai provider — request-shaping normalisation for `together/*` slugs
+//! (#2494, epic #2400).
+//!
+//! Why: enabling Together in tcode (#2494) is not only a transport concern —
+//! `AgentLoop::build_request` consults `crate::provider::provider_for` to decide
+//! whether to request OpenRouter's detailed-usage directive, whether to attach
+//! prompt-cache breakpoints, and whether to send a native `tools` array. Routing
+//! a `together/*` slug to the default `OpenRouterProvider` would (wrongly)
+//! request `usage:{include:true}` — a directive Together doesn't understand —
+//! so Together needs its own normalisation profile, mirroring the Fireworks
+//! precedent (#2406) and the shared capability registry's Together seed
+//! (`detailed_usage_accounting = false`, no explicit `cache_control`
+//! breakpoints, native OpenAI-style function calling).
+//! What: [`TogetherProvider`] implements [`Provider`] with the OpenAI-dialect
+//! `tool_choice` mapping (identical to OpenRouter/Fireworks), the standard usage
+//! extraction, native tool support, NO explicit prompt-cache breakpoints (Together
+//! caching is automatic — the caller cannot place `cache_control` markers), and
+//! NO detailed-usage request. The transport (`crate::llm::client::OpenAiCompatClient`)
+//! is what actually reaches `api.together.xyz`; this type only shapes the request.
+//! Test: `together::tests::*`.
+
+use serde_json::{Value, json};
+
+use super::traits::{Provider, ToolChoice};
+use crate::llm::ChatResponse;
+use crate::perf::TokenUsage;
+
+/// Provider for Together.ai-hosted models (`together/*` slugs), served behind the
+/// OpenAI-compatible `/chat/completions` schema.
+///
+/// Why: gives `build_request` a Together-correct normalisation profile so the
+/// wire payload matches what Together accepts (no OpenRouter-only directives, no
+/// `cache_control` breakpoints).
+/// What: zero-sized marker type implementing [`Provider`].
+/// Test: `together::tests::*`.
+#[derive(Debug, Clone, Default)]
+pub struct TogetherProvider;
+
+impl TogetherProvider {
+    /// Construct a `TogetherProvider`.
+    ///
+    /// Why: gives the factory a uniform constructor call site.
+    /// What: returns the zero-sized marker.
+    /// Test: `together::tests::name_is_together`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for TogetherProvider {
+    fn name(&self) -> &str {
+        "together"
+    }
+
+    /// Translate a neutral [`ToolChoice`] into OpenAI-dialect wire JSON.
+    ///
+    /// Why: Together uses the OpenAI `tool_choice` spelling (string policies +
+    /// `{type:function, function:{name}}` object), identical to OpenRouter and
+    /// Fireworks.
+    /// What: the OpenAI mapping.
+    /// Test: `together::tests::map_tool_choice_scalars`.
+    fn map_tool_choice(&self, choice: ToolChoice) -> Value {
+        match choice {
+            ToolChoice::None => json!("none"),
+            ToolChoice::Auto => json!("auto"),
+            ToolChoice::Required => json!("required"),
+            ToolChoice::Function(name) => json!({
+                "type": "function",
+                "function": { "name": name },
+            }),
+        }
+    }
+
+    /// Extract canonical token usage from a Together response.
+    ///
+    /// Why: Together returns the standard OpenAI `usage` block, already
+    /// normalised into `ChatResponse.usage` by the shared adapter's parse.
+    /// What: delegates to `ChatResponse::token_usage` (identical to the other
+    /// OpenAI-dialect providers).
+    /// Test: `together::tests::extract_usage_maps_fields`.
+    fn extract_usage(&self, response: &ChatResponse) -> TokenUsage {
+        response.clone().token_usage()
+    }
+
+    fn supports_native_tools(&self) -> bool {
+        // Together's tool-capable models accept the native OpenAI `tools` array;
+        // mirrors the shared registry's Together `native_tool_calling = true`.
+        true
+    }
+
+    fn supports_prompt_caching(&self) -> bool {
+        // Together caching is AUTOMATIC/implicit: the caller cannot place
+        // Anthropic-style `cache_control` breakpoints, so tcode must never mark a
+        // Together request with one (matching the Fireworks precedent — the wire
+        // body carries no `cache_control` markers).
+        false
+    }
+
+    fn wants_detailed_usage(&self) -> bool {
+        // `usage:{include:true}` is an OpenRouter-only directive; Together would
+        // not understand it. Mirrors the shared registry's Together
+        // `detailed_usage_accounting = false`.
+        false
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `name()` returns `"together"`.
+    ///
+    /// Why: routing and telemetry distinguish Together by name; the transport's
+    /// `provider_for_slug` and `dispatch`'s bedrock check both key off it.
+    /// What: assert the name.
+    /// Test: this test.
+    #[test]
+    fn name_is_together() {
+        assert_eq!(TogetherProvider::new().name(), "together");
+    }
+
+    /// Together reports native-tool support.
+    ///
+    /// Why: `build_request` sends the native `tools` array for tool-capable
+    /// Together models.
+    /// What: assert `supports_native_tools()` is `true`.
+    /// Test: this test.
+    #[test]
+    fn together_supports_native_tools() {
+        assert!(TogetherProvider::new().supports_native_tools());
+    }
+
+    /// Together does NOT request OpenRouter's detailed usage accounting.
+    ///
+    /// Why: this is the exact gate that would otherwise attach the
+    /// OpenRouter-only `usage:{include:true}` directive to a Together request —
+    /// the core reason a Together-specific provider is needed.
+    /// What: assert `wants_detailed_usage()` is `false`.
+    /// Test: this test.
+    #[test]
+    fn together_does_not_want_detailed_usage() {
+        assert!(!TogetherProvider::new().wants_detailed_usage());
+    }
+
+    /// Together does NOT place explicit prompt-cache breakpoints.
+    ///
+    /// Why: `build_request` must never mark a Together request with an
+    /// Anthropic-style `cache_control` breakpoint — Together caching is automatic
+    /// and rejects caller-placed markers.
+    /// What: assert `supports_prompt_caching()` is `false`.
+    /// Test: this test.
+    #[test]
+    fn together_does_not_support_prompt_caching() {
+        assert!(!TogetherProvider::new().supports_prompt_caching());
+    }
+
+    /// `map_tool_choice` maps the scalar policies to the OpenAI wire strings.
+    ///
+    /// Why: Together expects the OpenAI spelling; a wrong shape breaks
+    /// tool routing.
+    /// What: map each scalar variant, assert the JSON value.
+    /// Test: this test.
+    #[test]
+    fn map_tool_choice_scalars() {
+        let p = TogetherProvider::new();
+        assert_eq!(p.map_tool_choice(ToolChoice::None), json!("none"));
+        assert_eq!(p.map_tool_choice(ToolChoice::Auto), json!("auto"));
+        assert_eq!(p.map_tool_choice(ToolChoice::Required), json!("required"));
+        assert_eq!(
+            p.map_tool_choice(ToolChoice::Function("search".into())),
+            json!({"type": "function", "function": {"name": "search"}})
+        );
+    }
+
+    /// `extract_usage` maps a normalised usage block into `TokenUsage`.
+    ///
+    /// Why: pins that Together performs no extra (inconsistent) usage transform.
+    /// What: deserialise a response fixture, extract usage, assert fields.
+    /// Test: this test.
+    #[test]
+    fn extract_usage_maps_fields() {
+        let fixture = r#"{
+          "id": "tg-1",
+          "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 40, "completion_tokens": 8, "total_tokens": 48}
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        let usage = TogetherProvider::new().extract_usage(&resp);
+        assert_eq!(usage.prompt_tokens, 40);
+        assert_eq!(usage.completion_tokens, 8);
+    }
+}

--- a/crates/trusty-code/tests/inference_shared_adapter_e2e.rs
+++ b/crates/trusty-code/tests/inference_shared_adapter_e2e.rs
@@ -1,23 +1,27 @@
-//! Black-box e2e: prove trusty-code's OpenRouter/Fireworks inference flows
-//! through the shared `trusty_common::inference` adapter (#2406, epic #2400).
+//! Black-box e2e: prove trusty-code's OpenRouter/Fireworks/Together inference
+//! flows through the shared `trusty_common::inference` adapter (#2406, #2494,
+//! epic #2400).
 //!
 //! Why: #2406's core claim is that tcode's OpenAI-compatible transport is now
-//! the shared adapter, and that Fireworks is reachable. tcode's standing
-//! directive requires that claim be proven end-to-end, black-box, offline, and
-//! deterministic — not merely via internal code paths. This drives tcode's real
-//! production transport (`OpenAiCompatClient`, the same type `main.rs` and
-//! `task::mock_llm` construct) over a REAL loopback socket served by the shared
+//! the shared adapter, and that Fireworks is reachable; #2494 extends the same
+//! claim to Together. tcode's standing directive requires that claim be proven
+//! end-to-end, black-box, offline, and deterministic — not merely via internal
+//! code paths. This drives tcode's real production transport
+//! (`OpenAiCompatClient`, the same type `main.rs` and `task::mock_llm`
+//! construct) over a REAL loopback socket served by the shared
 //! `test_support::MockInferenceServer`, then asserts on the exact wire request
 //! the shared adapter emitted. That request shape (endpoint path, `Bearer` auth,
-//! provider-specific `usage` directive, and the Fireworks prefix-stripped model)
-//! is producible ONLY by the shared adapter — so a green run is direct evidence
-//! the migration is wired correctly.
-//! What: two cases — OpenRouter (asserts the shared adapter injected
-//! `usage:{include:true}` and sent the slug verbatim) and Fireworks (asserts NO
+//! provider-specific `usage` directive, and the Fireworks/Together
+//! prefix-stripped model) is producible ONLY by the shared adapter — so a green
+//! run is direct evidence the migration is wired correctly.
+//! What: three cases — OpenRouter (asserts the shared adapter injected
+//! `usage:{include:true}` and sent the slug verbatim), Fireworks (asserts NO
 //! usage directive and the `fireworks/` routing prefix stripped to the
-//! provider-native model id). Credentials come from an injected `MemoryKeyStore`
-//! and base URLs from `OpenAiCompatClient::with_config`, so the test mutates no
-//! process env and is fully parallel-safe.
+//! provider-native model id), and Together (asserts NO usage directive, `Bearer`
+//! auth, and the `together/` routing prefix stripped to the bare Together
+//! catalog slug). Credentials come from an injected `MemoryKeyStore` and base
+//! URLs from `OpenAiCompatClient::with_config`, so the test mutates no process
+//! env and is fully parallel-safe.
 //! Test: this file (`cargo test -p trusty-code --test inference_shared_adapter_e2e`).
 
 use serde_json::json;
@@ -75,10 +79,11 @@ async fn openrouter_routes_through_shared_adapter_and_injects_usage() {
     let store = MemoryKeyStore::new();
     store.set("openrouter", "sk-or-mock").expect("seed key"); // pragma: allowlist secret
 
-    // OpenRouter → mock; Fireworks base URL is unused in this case.
+    // OpenRouter → mock; Fireworks and Together base URLs are unused here.
     let client = OpenAiCompatClient::with_config(
         Box::new(store),
         server.url().to_string(),
+        "http://127.0.0.1:1/unused".to_string(),
         "http://127.0.0.1:1/unused".to_string(),
     );
 
@@ -130,11 +135,12 @@ async fn fireworks_routes_through_shared_adapter_strips_prefix_and_omits_usage()
     let store = MemoryKeyStore::new();
     store.set("fireworks", "fw-mock").expect("seed key"); // pragma: allowlist secret
 
-    // Fireworks → mock; OpenRouter base URL is unused in this case.
+    // Fireworks → mock; OpenRouter and Together base URLs are unused here.
     let client = OpenAiCompatClient::with_config(
         Box::new(store),
         "http://127.0.0.1:1/unused".to_string(),
         server.url().to_string(),
+        "http://127.0.0.1:1/unused".to_string(),
     );
 
     let resp = client
@@ -156,5 +162,64 @@ async fn fireworks_routes_through_shared_adapter_strips_prefix_and_omits_usage()
     assert!(
         body.get("usage").is_none() || body["usage"].is_null(),
         "Fireworks must NOT receive the OpenRouter-only usage directive"
+    );
+}
+
+/// A Together-routed request flows through the shared adapter, which strips the
+/// `together/` routing prefix to the bare Together catalog slug and sends NO
+/// usage directive (Together does not support the OpenRouter directive).
+///
+/// Why: this is the concrete payoff of #2494 — Together is reachable, routed
+/// through the shared adapter, with the correct provider-specific wire shape:
+/// `Bearer` auth, the prefix-stripped model id, and no usage directive.
+/// What: point the Together base URL at the mock, chat with a `together/` slug,
+/// then assert the parsed response AND the captured wire request (path, auth,
+/// stripped model, absent usage directive).
+/// Test: this test.
+#[tokio::test]
+async fn together_routes_through_shared_adapter_strips_prefix_and_omits_usage() {
+    let server = MockInferenceServer::spawn(200, canned_response())
+        .await
+        .expect("spawn mock");
+
+    let store = MemoryKeyStore::new();
+    store.set("together", "tgp_v1_mock").expect("seed key"); // pragma: allowlist secret
+
+    // Together → mock; OpenRouter and Fireworks base URLs are unused here.
+    let client = OpenAiCompatClient::with_config(
+        Box::new(store),
+        "http://127.0.0.1:1/unused".to_string(),
+        "http://127.0.0.1:1/unused".to_string(),
+        server.url().to_string(),
+    );
+
+    let resp = client
+        .chat(&request_for(
+            "together/meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        ))
+        .await
+        .expect("chat through shared together adapter");
+
+    // Response flowed back through the tcode conversion.
+    assert_eq!(resp.first_text().as_deref(), Some("pong-mock"));
+    assert_eq!(resp.token_usage().prompt_tokens, 5);
+
+    let captured = server.last_request().expect("one request captured");
+    assert_eq!(captured.method, "POST");
+    assert_eq!(captured.path, "/chat/completions");
+    assert!(
+        captured
+            .header("authorization")
+            .is_some_and(|v| v.starts_with("Bearer ")),
+        "shared adapter must send a Bearer auth header"
+    );
+    let body = captured.body.expect("json body");
+    assert_eq!(
+        body["model"], "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        "the together/ routing prefix must be stripped to the bare Together slug"
+    );
+    assert!(
+        body.get("usage").is_none() || body["usage"].is_null(),
+        "Together must NOT receive the OpenRouter-only usage directive"
     );
 }

--- a/crates/trusty-common/src/inference/credentials/resolver.rs
+++ b/crates/trusty-common/src/inference/credentials/resolver.rs
@@ -44,6 +44,7 @@ pub fn env_var_for(provider: &str) -> Option<&'static str> {
         "openrouter" => Some("OPENROUTER_API_KEY"),
         "anthropic" => Some("ANTHROPIC_API_KEY"),
         "openai" => Some("OPENAI_API_KEY"),
+        "together" => Some("TOGETHER_API_KEY"),
         _ => None,
     }
 }
@@ -134,6 +135,7 @@ mod tests {
         assert_eq!(env_var_for("OpenRouter"), Some("OPENROUTER_API_KEY"));
         assert_eq!(env_var_for("anthropic"), Some("ANTHROPIC_API_KEY"));
         assert_eq!(env_var_for("OPENAI"), Some("OPENAI_API_KEY"));
+        assert_eq!(env_var_for("together"), Some("TOGETHER_API_KEY"));
     }
 
     /// Why: an unmapped provider must not panic or synthesise a guess.


### PR DESCRIPTION
Follow-up to #2406 (tcode migrated onto `trusty_common::inference`, Fireworks made usable) and #2488 (Together added to trusty-common). This wires Together **end-to-end** into tcode so `TCODE_ENGINEER_MODEL=together/...` + `TOGETHER_API_KEY` actually drives Together — a near-exact mirror of how #2406 enabled Fireworks.

## What changed

- **`together/*` route** (`provider/adapter.rs`): `together/` slugs resolve to `TogetherProvider`, checked alongside `fireworks/` and after `bedrock/` — the same place/order as the Fireworks branch, so no misrouting and no fallthrough to the OpenRouter default.
- **Together request profile** (`provider/together.rs`, new): mirrors `provider/fireworks.rs` — OpenAI-dialect `tool_choice`, native tools on, **no** `usage:{include:true}` directive (`detailed_usage_accounting = false`), and **no** `cache_control` breakpoints (Together caching is automatic; the caller cannot place markers).
- **Prefix-strip** (`llm/client.rs`): the `together/` routing prefix is stripped so the wire model is the bare Together slug (e.g. `meta-llama/Llama-3.3-70B-Instruct-Turbo`), exactly like the Fireworks prefix-strip.
- **Missing-key contract** (`llm/client.rs`): a missing `TOGETHER_API_KEY` returns an explicit `MissingConfig` **naming `TOGETHER_API_KEY`** — **no** silent OpenRouter fallback, the same contract as Fireworks. Credential resolved via the shared 3-tier resolver (env > `.env.local` > KeyStore). Base URL overridable via `TCODE_TOGETHER_BASE_URL` for offline testing.
- **Shared resolver fix** (`trusty-common` `env_var_for`): map `"together"` → `TOGETHER_API_KEY` so the env / `.env.local` tier honors the key. This mapping was missing after #2488, which would have silently ignored `TOGETHER_API_KEY` from the environment — required for the acceptance criterion.

## Tests

- **Offline e2e** (`tests/inference_shared_adapter_e2e.rs`): a `MockInferenceServer` over a real loopback socket proves tcode routes `together/*` through the shared adapter — asserts the captured wire body (bare model slug after prefix-strip, `Bearer` auth, no usage directive) and the parsed response/usage. Mirrors the Fireworks e2e.
- Unit tests: route selection, wire-model strip, and the no-fallback missing-key path.
- `#[ignore]` + `TOGETHER_API_KEY`-gated live smoke.

## Untouched

Bedrock, Fireworks, and OpenRouter paths are unchanged. Telemetry/cost capture, deadline/failure-path, prompt-caching handling, and `TCODE_MOCK_LLM=echo` preserved.

Closes #2494. Refs epic #2400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)