### PR TITLE
fix(trusty-mpm): surface server error bodies in registry mutation client errors (closes #2485)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/projects/registry.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/registry.rs
@@ -256,9 +256,9 @@ async fn config_view(
 /// What: builds the wire args via [`project_config::build_patch_args`] (the
 /// SAME builder the TUI form's submit uses), PATCHes, and renders the
 /// server's returned (authoritative, post-write) record. A 400/404 surfaces
-/// as an `anyhow::Error` via `DaemonClient::registry_patch_project`'s
-/// `error_for_status` — propagated unchanged, printed by `main`'s default
-/// error handler.
+/// as an `anyhow::Error` via `DaemonClient::registry_patch_project`, whose
+/// message now carries the daemon's actual rejection reason (#2485) —
+/// propagated unchanged, printed by `main`'s default error handler.
 async fn config_apply(
     client: &reqwest::Client,
     url: &str,

--- a/crates/trusty-mpm/src/client/http_client/deliverables.rs
+++ b/crates/trusty-mpm/src/client/http_client/deliverables.rs
@@ -25,6 +25,7 @@ use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
 use super::DaemonClient;
+use super::error::response_or_body_error;
 use crate::deliverable::{
     Deliverable, DeliverableKind, DeliverableStatus, EstimationTier, Milestone,
 };
@@ -174,10 +175,9 @@ impl DaemonClient {
         if let Some(status) = status {
             req = req.query(&[("status", status.as_str())]);
         }
-        let body: DeliverablesListWire = req
-            .send()
+        let resp = req.send().await?;
+        let body: DeliverablesListWire = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize deliverable list")?;
@@ -195,13 +195,9 @@ impl DaemonClient {
         args: &CreateDeliverableArgs,
     ) -> anyhow::Result<Deliverable> {
         let url = format!("{}/api/v1/projects/{project}/deliverables", self.base);
-        let created: Deliverable = self
-            .http
-            .post(&url)
-            .json(args)
-            .send()
+        let resp = self.http.post(&url).json(args).send().await?;
+        let created: Deliverable = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize created deliverable")?;
@@ -215,12 +211,9 @@ impl DaemonClient {
     /// Test: live HTTP via `deliverable_routes`.
     pub async fn get_deliverable(&self, project: &str, id: &str) -> anyhow::Result<Deliverable> {
         let url = format!("{}/api/v1/projects/{project}/deliverables/{id}", self.base);
-        let d: Deliverable = self
-            .http
-            .get(&url)
-            .send()
+        let resp = self.http.get(&url).send().await?;
+        let d: Deliverable = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize deliverable")?;
@@ -264,9 +257,9 @@ impl DaemonClient {
             });
         }
 
-        let resp = resp
-            .error_for_status()
-            .map_err(|e| SetStatusError::Other(e.into()))?;
+        let resp = response_or_body_error(resp)
+            .await
+            .map_err(SetStatusError::Other)?;
         resp.json()
             .await
             .context("deserialize updated deliverable")
@@ -280,12 +273,9 @@ impl DaemonClient {
     /// Test: `milestones_list_deserializes`; live HTTP via `deliverable_routes`.
     pub async fn list_milestones(&self, project: &str) -> anyhow::Result<Vec<Milestone>> {
         let url = format!("{}/api/v1/projects/{project}/milestones", self.base);
-        let body: MilestonesListWire = self
-            .http
-            .get(&url)
-            .send()
+        let resp = self.http.get(&url).send().await?;
+        let body: MilestonesListWire = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize milestone list")?;
@@ -303,13 +293,9 @@ impl DaemonClient {
         args: &CreateMilestoneArgs,
     ) -> anyhow::Result<Milestone> {
         let url = format!("{}/api/v1/projects/{project}/milestones", self.base);
-        let created: Milestone = self
-            .http
-            .post(&url)
-            .json(args)
-            .send()
+        let resp = self.http.post(&url).json(args).send().await?;
+        let created: Milestone = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize created milestone")?;
@@ -323,12 +309,9 @@ impl DaemonClient {
     /// Test: live HTTP via `deliverable_routes`.
     pub async fn get_milestone(&self, project: &str, id: &str) -> anyhow::Result<Milestone> {
         let url = format!("{}/api/v1/projects/{project}/milestones/{id}", self.base);
-        let m: Milestone = self
-            .http
-            .get(&url)
-            .send()
+        let resp = self.http.get(&url).send().await?;
+        let m: Milestone = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize milestone")?;

--- a/crates/trusty-mpm/src/client/http_client/error.rs
+++ b/crates/trusty-mpm/src/client/http_client/error.rs
@@ -1,0 +1,109 @@
+//! Shared error-body extraction for [`super::DaemonClient`] HTTP calls.
+//!
+//! Why: `reqwest::Response::error_for_status` builds its `anyhow::Error` from
+//! only the status line, discarding whatever body the daemon sent. The
+//! registry-B `PATCH /api/v1/projects/{name}` endpoint (#2114/#2120) is
+//! deliberately the single validation surface `tm projects config` and the
+//! TUI config form share, and it sends a human-readable rejection reason
+//! (blank tag, immutable name, blank `default_branch`) in that body — losing
+//! it left both front ends rendering a bare "400 Bad Request" with no field
+//! or rule information (#2485). The Deliverable/Milestone CRUD routes
+//! (#2378/#2380) nested under the same `/api/v1/projects/{name}/...` tree
+//! have the identical shape (a validation/conflict message in the body that
+//! `error_for_status` would silently drop), so this lives in its own module
+//! rather than being duplicated per call site.
+//! What: [`response_or_body_error`] consumes a `reqwest::Response`; on a
+//! success status it is returned unchanged (a transparent no-op) so the
+//! caller can keep chaining `.json().await` exactly as before; on a
+//! non-success status it reads the body and returns `Err` formatted as
+//! `"<status>: <message>"`, extracting an `error`/`message` string field when
+//! the body parses as JSON (the daemon's `DaemonError::into_response` shape),
+//! falling back to the raw trimmed text (the plain-`(StatusCode,
+//! String)::into_response` shape `project_registry_routes.rs` uses), and
+//! finally to the bare status when the body is empty or unreadable.
+//! Test: `extract_message_reads_json_error_field`,
+//! `extract_message_reads_json_message_field`,
+//! `extract_message_falls_back_to_plain_text`,
+//! `extract_message_empty_body_is_none`,
+//! `extract_message_non_object_json_falls_back_to_raw_text` in this module's
+//! `tests` submodule; `patch_rejects_blank_repo_url_surfaces_server_message`
+//! in `tests/project_registry_routes.rs` exercises it end-to-end through
+//! `DaemonClient::registry_patch_project`.
+
+use anyhow::{Result, bail};
+
+/// See module docs.
+pub(in crate::client::http_client) async fn response_or_body_error(
+    resp: reqwest::Response,
+) -> Result<reqwest::Response> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let body = resp.text().await.unwrap_or_default();
+    match extract_message(&body) {
+        Some(msg) => bail!("{status}: {msg}"),
+        None => bail!("{status}"),
+    }
+}
+
+/// Pull a human message out of an error body: a JSON `error`/`message`
+/// string field when the body parses as JSON, else the raw trimmed text,
+/// else `None` for an empty/whitespace-only body.
+fn extract_message(body: &str) -> Option<String> {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        for key in ["error", "message"] {
+            if let Some(s) = value.get(key).and_then(|v| v.as_str()) {
+                return Some(s.to_string());
+            }
+        }
+    }
+    Some(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_message_reads_json_error_field() {
+        assert_eq!(
+            extract_message(r#"{"error":"tag must not be blank"}"#).as_deref(),
+            Some("tag must not be blank")
+        );
+    }
+
+    #[test]
+    fn extract_message_reads_json_message_field() {
+        assert_eq!(
+            extract_message(r#"{"message":"nope"}"#).as_deref(),
+            Some("nope")
+        );
+    }
+
+    #[test]
+    fn extract_message_falls_back_to_plain_text() {
+        assert_eq!(
+            extract_message("repo_url must not be empty").as_deref(),
+            Some("repo_url must not be empty")
+        );
+    }
+
+    #[test]
+    fn extract_message_empty_body_is_none() {
+        assert_eq!(extract_message("   "), None);
+        assert_eq!(extract_message(""), None);
+    }
+
+    #[test]
+    fn extract_message_non_object_json_falls_back_to_raw_text() {
+        // A body that parses as JSON but isn't an `{error|message: ...}`
+        // object (e.g. a bare array) still surfaces as raw text rather than
+        // silently becoming `None`.
+        assert_eq!(extract_message("[1,2,3]").as_deref(), Some("[1,2,3]"));
+    }
+}

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -13,6 +13,7 @@
 //! in-process test daemon and by the daemon's own API tests.
 
 pub mod deliverables;
+mod error;
 mod managed;
 pub mod projects;
 mod session_connect;

--- a/crates/trusty-mpm/src/client/http_client/projects.rs
+++ b/crates/trusty-mpm/src/client/http_client/projects.rs
@@ -25,6 +25,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::DaemonClient;
+use super::error::response_or_body_error;
 use crate::project::Project;
 
 /// Serializable body for `POST /api/v1/projects` (registry-B register).
@@ -192,12 +193,9 @@ impl DaemonClient {
     /// Test: `projects_list_deserializes`; live HTTP via the daemon route tests.
     pub async fn registry_list_projects(&self, tag: Option<&str>) -> anyhow::Result<Vec<Project>> {
         let url = format!("{}/api/v1/projects", self.base);
-        let body: ProjectsListWire = self
-            .http
-            .get(&url)
-            .send()
+        let resp = self.http.get(&url).send().await?;
+        let body: ProjectsListWire = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize project list")?;
@@ -220,13 +218,9 @@ impl DaemonClient {
         args: &RegisterProjectArgs,
     ) -> anyhow::Result<Project> {
         let url = format!("{}/api/v1/projects", self.base);
-        let project: Project = self
-            .http
-            .post(&url)
-            .json(args)
-            .send()
+        let resp = self.http.post(&url).json(args).send().await?;
+        let project: Project = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize registered project")?;
@@ -237,16 +231,13 @@ impl DaemonClient {
     ///
     /// Why: backs the config half of `tm projects show` (#2115).
     /// What: GETs the point-lookup, returns the [`Project`]; a 404 surfaces as an
-    /// error via `error_for_status`.
+    /// error via [`response_or_body_error`], carrying the daemon's body text.
     /// Test: live HTTP via the daemon route tests.
     pub async fn registry_get_project(&self, name: &str) -> anyhow::Result<Project> {
         let url = format!("{}/api/v1/projects/{name}", self.base);
-        let project: Project = self
-            .http
-            .get(&url)
-            .send()
+        let resp = self.http.get(&url).send().await?;
+        let project: Project = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize project")?;
@@ -261,23 +252,22 @@ impl DaemonClient {
     /// unset/tags contract.
     /// What: PATCHes `args` to the named project, returns the updated
     /// [`Project`]; a 404 (unknown project) or 400 (blank required field, or a
-    /// body that tried to change `name`) surfaces as an error via
-    /// `error_for_status`.
-    /// Test: live HTTP via the daemon route tests
-    /// (`tests/project_registry_routes.rs`).
+    /// body that tried to change `name`) surfaces as an [`anyhow::Error`] via
+    /// [`response_or_body_error`] carrying the daemon's actual rejection
+    /// message (#2485) — e.g. `"400 Bad Request: repo_url must not be
+    /// empty"` — rather than a bare status line.
+    /// Test: `patch_rejects_blank_repo_url_surfaces_server_message` in
+    /// `tests/project_registry_routes.rs`; live HTTP via the other daemon
+    /// route tests there.
     pub async fn registry_patch_project(
         &self,
         name: &str,
         args: &PatchProjectArgs,
     ) -> anyhow::Result<Project> {
         let url = format!("{}/api/v1/projects/{name}", self.base);
-        let project: Project = self
-            .http
-            .patch(&url)
-            .json(args)
-            .send()
+        let resp = self.http.patch(&url).json(args).send().await?;
+        let project: Project = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize patched project")?;
@@ -293,12 +283,9 @@ impl DaemonClient {
     /// daemon route tests.
     pub async fn project_status(&self, name: &str) -> anyhow::Result<ProjectStatusWire> {
         let url = format!("{}/api/v1/projects/{name}/status", self.base);
-        let status: ProjectStatusWire = self
-            .http
-            .get(&url)
-            .send()
+        let resp = self.http.get(&url).send().await?;
+        let status: ProjectStatusWire = response_or_body_error(resp)
             .await?
-            .error_for_status()?
             .json()
             .await
             .context("deserialize project status")?;

--- a/crates/trusty-mpm/tests/project_registry_routes.rs
+++ b/crates/trusty-mpm/tests/project_registry_routes.rs
@@ -345,7 +345,45 @@ async fn patch_unknown_project_is_404() {
         )
         .await
         .expect_err("unknown project must error via the typed client too");
-    drop(err);
+    // #2485: the typed client's error must carry the daemon's actual body
+    // text, not just a bare status line.
+    let msg = err.to_string();
+    assert!(msg.contains("project nope not found"), "{msg}");
+}
+
+/// #2485: a PATCH rejected for a validation reason (blank `repo_url`) must
+/// surface the daemon's actual rejection message through the typed client,
+/// not a bare "400 Bad Request" — this is the exact regression the fast-follow
+/// from PR #2484's review fixes for `tm projects config` / the TUI form.
+#[tokio::test]
+async fn patch_rejects_blank_repo_url_surfaces_server_message() {
+    let client = serve().await;
+    client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: None,
+            description: None,
+            tags: None,
+            stack_hint: None,
+            gh_user: None,
+        })
+        .await
+        .unwrap();
+
+    let err = client
+        .registry_patch_project(
+            "widget",
+            &PatchProjectArgs {
+                repo_url: Some("   ".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("blank repo_url must be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("repo_url must not be empty"), "{msg}");
+    assert!(msg.contains("400"), "{msg}");
 }
 
 /// A body carrying a `name` different from the `{name}` path segment is


### PR DESCRIPTION
## Root cause

`DaemonClient::registry_patch_project` (`crates/trusty-mpm/src/client/http_client/projects.rs`) used `.error_for_status()?`, which builds its `anyhow::Error` from the response status line alone and discards the body. `PATCH /api/v1/projects/{name}` is deliberately the single validation surface `tm projects config` and the TUI config form share (#2114/#2120), and it sends a human-readable rejection reason in that body — e.g. `"repo_url must not be empty"`, `"project name is the identity key and cannot be changed via PATCH"`, a blank-tag rejection. Losing the body left both front ends rendering a bare `"400 Bad Request"` with no field/rule information. Fast-follow from PR #2484's review (LOW, deviation 7).

## Fix

Added `crates/trusty-mpm/src/client/http_client/error.rs`: `response_or_body_error(resp)` is a transparent pass-through on a success status; on a non-success status it reads the body and returns an `anyhow::Error` formatted `"<status>: <message>"`, extracting a JSON `error`/`message` field when the body is JSON (the shape `DaemonError::into_response` emits), else falling back to the raw trimmed text (the shape `project_registry_routes.rs`'s bare `(StatusCode, &str)` handlers emit), else the bare status when the body is empty/unreadable.

## Call-site sweep (`crates/trusty-mpm/src/client/`)

**Changed** — all in the `/api/v1/projects/{name}/...` mutation-validation family (#2114/#2115/#2378/#2380/#2428):

| File | Method | Why changed |
|---|---|---|
| `projects.rs` | `registry_patch_project` | **The bug.** PATCH is the single validation surface (#2114/#2120). |
| `projects.rs` | `registry_register_project` | POST to the same registry endpoint; daemon rejects blank `name`/`repo_url` with a body. |
| `projects.rs` | `registry_get_project` | 404 body is `"project {name} not found"` — useful context. |
| `projects.rs` | `registry_list_projects` | Same registry family; consistency (no meaningful body expected today, but transparent on success). |
| `projects.rs` | `project_status` | Same registry family; 404 body useful. |
| `deliverables.rs` | `list_deliverables`, `create_deliverable`, `get_deliverable`, `list_milestones`, `create_milestone`, `get_milestone` | Deliverable/Milestone CRUD nested under the same `/api/v1/projects/{name}/...` tree (#2378), backed by `DaemonError`'s JSON `{"error": ...}` body (400 blank-name rejection, 404 not-found, etc.). |
| `deliverables.rs` | `set_deliverable_status` (non-409 fallback branch) | The 409 branch already parsed the structured `{from,to,allowed_next}` body (#2380); the fallback for every OTHER status (400/404/500) still used `error_for_status()` and dropped the body — now consistent. |

**Left unchanged** (documented, not silently skipped):

| File | Sites | Reason |
|---|---|---|
| `mod.rs` | ~13 (`registry_list_projects`-adjacent session/breaker/health/chat/pairing calls) | `mod.rs` is at **498/500 SLOC** after adding `mod error;` — zero headroom to touch more call sites without a file split, which is out of scope for this fast-follow. Several of these (health snapshot, event feed) also don't carry a validation body worth surfacing. |
| `managed.rs` | 10 (spawn/adopt/answer/send_input/etc., `/api/v1/sessions/managed/*`) | Different endpoint family — not "registry/projects" per the issue's explicit scope. Some (adopt's 409, session-not-found) do carry a useful body; worth a targeted follow-up issue. |
| `session_connect.rs` | 2 (`launch_session`, `connect_session`) | Session-launch bootstrapping against `/sessions`, not a registry/projects validation surface. |

## Consumer verification

- CLI: `tm projects config <name> set/unset` → `config_apply` in `bin/tm/commands/projects/registry.rs` propagates `registry_patch_project`'s `anyhow::Error` unchanged to `main`'s default error handler, which prints `Display` — now shows the server message.
- TUI: `actions.rs`'s submit handler does `Err(e) => state.set_config_form_error(format!("{e}"))` — now receives the server message. **Note:** the config form overlay (`panes/config_form.rs`) is a fixed `72x12` `Paragraph` with no `.wrap()` — a very long error line will be clipped by the box width/height rather than wrapped. Not redesigned here (out of scope per the ticket); flagging for awareness.

## Tests

- New unit tests in `error.rs`: JSON `error` field, JSON `message` field, plain-text fallback, empty-body → `None`, non-object JSON → raw text fallback.
- `tests/project_registry_routes.rs`: extended `patch_unknown_project_is_404` to assert the message contains `"project nope not found"`; added `patch_rejects_blank_repo_url_surfaces_server_message` — a 400-with-body PATCH now yields an error whose `Display` contains `"repo_url must not be empty"` and the status.

```
cargo test -p trusty-mpm --test project_registry_routes
test result: ok. 15 passed; 0 failed; 0 ignored
```

## Quality gates (raw tails)

```
$ cargo build --workspace
   Finished `dev` profile [unoptimized + debuginfo] target(s) in ...
   (exit 0)

$ cargo test -p trusty-mpm
test result: ok. 2903 passed; 0 failed; 5 ignored ...  (lib)
test result: ok. 15 passed; 0 failed; 0 ignored ...    (project_registry_routes, incl. 2 new)
(all other integration binaries: ok, 0 failed)
core::home_trust_seed::tests::is_idempotent ... ok      (known-flake, passed clean this run)

$ cargo clippy --workspace --all-targets -- -D warnings
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.51s   (exit 0)

$ cargo fmt --check
   (exit 0, no diff)

$ bash scripts/check_line_cap.sh
line-cap: 0 allowlisted, 0 violations — OK.
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools