### PR TITLE
fix(trusty-mpm): drop decommissioned sessions from TUI Sessions pane (closes #2476)

### DIFF
--- a/crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs
@@ -49,7 +49,13 @@ pub const DECOMMISSIONED_GLYPH: char = '⊘';
 /// `stopped`/`errored`/`decommissioned`, see `session_manager::record`) is
 /// the only state this issue's skeleton has available — the live
 /// "awaiting approval" / "idle Nm" detail the mockup shows comes from the
-/// `/activity` endpoint, deferred to #2119.
+/// `/activity` endpoint, deferred to #2119. The `"decommissioned"` arm is
+/// kept for completeness and stays directly unit tested, but is DEAD in the
+/// live poll path as of #2476:
+/// [`super::super::poll::live_session_rows`] drops every decommissioned
+/// session before a [`SessionRow`] is ever built, so this function never
+/// actually receives that word from [`render`] — a decommissioned session's
+/// row simply stops existing rather than rendering tombstoned.
 /// What: maps each of the five known state words to its glyph; any other
 /// (forward-compat) value falls back to [`STOPPED_GLYPH`].
 /// Test: `state_glyph_maps_every_known_state`, `state_glyph_unknown_falls_back`.

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/mod.rs
@@ -18,24 +18,34 @@
 //! daemon-down poll has no session left selected to attribute it to; see
 //! [`refresh_activity`]'s own doc for the narrower "fetch failed but the
 //! daemon is otherwise up" case that DOES keep the last-known activity,
-//! marked stale) plus the pure projections [`project_to_row`],
-//! [`session_to_row`], and [`activity_from_response`].
-//! Test: `tests` covers the pure projections and the daemon-down branches
-//! against a guaranteed-dead client (mirroring
+//! marked stale). The pure DTO → row projections ([`rows::project_to_row`],
+//! [`rows::live_session_rows`], [`rows::session_to_row`],
+//! [`rows::activity_from_response`]) live in the [`rows`] submodule (split
+//! out by #2476 to keep this file under the 500-SLOC production cap) and are
+//! re-exported here so existing callers keep using `poll::project_to_row`
+//! etc.
+//! Test: `tests` covers the daemon-down / stale-keep branches against a
+//! guaranteed-dead client (mirroring
 //! `tui::coordinator::poll::tests::poll_marks_unreachable_clears_sessions`);
-//! the daemon-UP path is exercised manually / by launching the TUI.
+//! [`rows`]'s own `tests` covers the pure projections; the daemon-UP path is
+//! exercised manually / by launching the TUI.
 
-use crate::client::{
-    DaemonClient, FleetProjectGroupWire, ManagedActivityResponse, ManagedSessionSummary,
-};
+mod rows;
+
+pub(crate) use rows::{activity_from_response, live_session_rows, project_to_row};
+// Only reachable from `super::tests` (this module's daemon-down test
+// fixtures) and `super::super::tests` (the project_ctl-level integration
+// tests) — both `#[cfg(test)]`-gated, so a plain `cargo build` never sees a
+// caller and would otherwise warn on the re-export.
+#[cfg(test)]
+pub(crate) use rows::session_to_row;
+
+use crate::client::DaemonClient;
 use crate::project::Project;
-use crate::tui::coordinator::rows::session_short_id;
 
-use super::state::{ActivityInfo, ProjectCtlState, ProjectRow, SessionRow};
-
-/// How many trailing lines of a session's raw tmux pane the Activity pane
-/// previews (DOC-35 §5.1 mockup: "last 3 lines of raw_pane").
-const RAW_PANE_TAIL_LINES: usize = 3;
+#[cfg(test)]
+use super::state::ActivityInfo;
+use super::state::{ProjectCtlState, ProjectRow, SessionRow};
 
 /// Refresh [`ProjectCtlState`] from one daemon poll.
 ///
@@ -256,12 +266,13 @@ fn rediscover(client: &mut DaemonClient, reachable: bool) -> bool {
 /// builds the `Vec<ProjectRow>` (registry order, counts from the matching
 /// fleet group), the `sessions_by_project` map (every fleet group, even a
 /// project the registry list omitted — defensive against a transient
-/// registry/fleet mismatch), and a `name -> Project` map of the FULL records
-/// `registry_list_projects` already returned (DOC-35 §6, #2120) — the config
-/// form needs the full record to seed its baseline values; retaining it here
-/// (rather than re-fetching per-project when the form opens) costs nothing,
-/// since `projects` was already in hand before being projected down to
-/// `ProjectRow`.
+/// registry/fleet mismatch) via [`live_session_rows`] (which drops
+/// decommissioned sessions, #2476), and a `name -> Project` map of the FULL
+/// records `registry_list_projects` already returned (DOC-35 §6, #2120) —
+/// the config form needs the full record to seed its baseline values;
+/// retaining it here (rather than re-fetching per-project when the form
+/// opens) costs nothing, since `projects` was already in hand before being
+/// projected down to `ProjectRow`.
 async fn fetch_projects_and_sessions(
     client: &DaemonClient,
 ) -> anyhow::Result<(
@@ -274,7 +285,7 @@ async fn fetch_projects_and_sessions(
 
     let mut sessions_by_project = std::collections::BTreeMap::new();
     for group in &groups {
-        let rows = group.sessions.iter().cloned().map(session_to_row).collect();
+        let rows = live_session_rows(group.sessions.clone());
         sessions_by_project.insert(group.project_name.clone(), rows);
     }
 
@@ -291,126 +302,10 @@ async fn fetch_projects_and_sessions(
     Ok((rows, sessions_by_project, projects_full))
 }
 
-/// Project one registry [`Project`] (plus its matching fleet group, if any)
-/// into a [`ProjectRow`].
-///
-/// Why: the Projects pane needs the aggregate-state glyph + live session
-/// count (DOC-35 §5), not the raw registry/fleet DTOs.
-/// What: `live_count` is the number of sessions in `group` whose `state` is
-/// `"active"` or `"provisioning"`; `total_count` is `group.sessions.len()`.
-/// A project with no matching fleet group (never spawned a session) gets
-/// `0`/`0`.
-/// Test: `project_to_row_counts_live_and_total`,
-/// `project_to_row_missing_group_is_zeroed`.
-pub(crate) fn project_to_row(p: &Project, group: Option<&FleetProjectGroupWire>) -> ProjectRow {
-    let (live_count, total_count) = match group {
-        Some(g) => (
-            g.sessions
-                .iter()
-                .filter(|s| matches!(s.state.as_str(), "active" | "provisioning"))
-                .count(),
-            g.sessions.len(),
-        ),
-        None => (0, 0),
-    };
-    ProjectRow {
-        name: p.name.clone(),
-        repo_url: p.repo_url.clone(),
-        live_count,
-        total_count,
-    }
-}
-
-/// Project one fleet [`ManagedSessionSummary`] into a [`SessionRow`].
-///
-/// Why: the Sessions pane needs a numbered, compact row per session; the
-/// fleet poll is one call for every session regardless of count, so this
-/// projection stays over the STATIC record fields even after #2119 — only the
-/// one selected session's activity gets the extra live `/activity` fetch (see
-/// [`refresh_activity`]), never the whole list.
-/// What: derives the 8-hex short id via [`session_short_id`] and copies the
-/// rest through unchanged, including `deliverable_id` (DOC-35 §10.6, #2383 —
-/// drives the Sessions-pane deliverable glyph).
-/// Test: `session_to_row_derives_short_id_and_copies_fields`,
-/// `session_to_row_carries_deliverable_id`.
-pub(crate) fn session_to_row(s: ManagedSessionSummary) -> SessionRow {
-    let short_id = session_short_id(&s.id);
-    SessionRow {
-        id: s.id,
-        short_id,
-        name: s.name,
-        branch: s.branch,
-        task: s.task,
-        state: s.state,
-        pending_decision: s.pending_decision,
-        proposed_default: s.proposed_default,
-        deliverable_id: s.deliverable_id,
-    }
-}
-
-/// Project a [`ManagedActivityResponse`] into an [`ActivityInfo`] for `session_id`.
-///
-/// Why: the Activity pane needs a lean, render-ready shape (DOC-35 §5.4) with
-/// a bounded pane-tail preview rather than the full wire response.
-/// What: copies `state`/`summary`/`pending_decision`/`proposed_default`
-/// through unchanged, tags the snapshot with `session_id`, sets `stale` to
-/// `false` (a just-succeeded fetch is by definition fresh), and derives
-/// `raw_pane_tail` as the last [`RAW_PANE_TAIL_LINES`] non-empty lines of
-/// `raw_pane` via [`tail_lines`].
-/// Test: `activity_from_response_derives_fields_and_tail`,
-/// `activity_from_response_handles_short_pane`.
-pub(crate) fn activity_from_response(
-    session_id: String,
-    resp: ManagedActivityResponse,
-) -> ActivityInfo {
-    ActivityInfo {
-        session_id,
-        state: resp.state,
-        summary: resp.summary,
-        pending_decision: resp.pending_decision,
-        proposed_default: resp.proposed_default,
-        raw_pane_tail: tail_lines(&resp.raw_pane, RAW_PANE_TAIL_LINES),
-        stale: false,
-    }
-}
-
-/// The last `n` non-empty, trimmed lines of `text`, in original order.
-///
-/// Why: a raw tmux pane capture is typically newline-padded and much longer
-/// than the Activity pane's fixed 4-row height can show; a small pure helper
-/// keeps the "which lines" rule unit-testable independent of rendering.
-/// What: splits on `\n`, trims each line, drops empty ones, then keeps the
-/// last `n` (or fewer, if `text` has fewer than `n` non-empty lines).
-/// Test: `tail_lines_keeps_last_n_non_empty_lines`,
-/// `tail_lines_handles_fewer_lines_than_requested`.
-fn tail_lines(text: &str, n: usize) -> Vec<String> {
-    let non_empty: Vec<&str> = text
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty())
-        .collect();
-    let start = non_empty.len().saturating_sub(n);
-    non_empty[start..].iter().map(|l| l.to_string()).collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn project(name: &str) -> Project {
-        Project {
-            name: name.to_string(),
-            repo_url: format!("https://github.com/acme/{name}"),
-            default_branch: "main".to_string(),
-            stack_hint: None,
-            tags: vec![],
-            description: None,
-            gh_user: None,
-            github: None,
-            commit_name: None,
-            commit_email: None,
-        }
-    }
+    use crate::client::ManagedSessionSummary;
 
     fn summary(id: &str, state: &str) -> ManagedSessionSummary {
         ManagedSessionSummary {
@@ -431,108 +326,6 @@ mod tests {
             deliverable_id: None,
             pane_id: None,
         }
-    }
-
-    #[test]
-    fn project_to_row_counts_live_and_total() {
-        let p = project("widget");
-        let group = FleetProjectGroupWire {
-            project_name: "widget".to_string(),
-            repo_url: p.repo_url.clone(),
-            sessions: vec![
-                summary("a1111111", "active"),
-                summary("b2222222", "provisioning"),
-                summary("c3333333", "stopped"),
-            ],
-        };
-        let row = project_to_row(&p, Some(&group));
-        assert_eq!(row.live_count, 2);
-        assert_eq!(row.total_count, 3);
-        assert_eq!(row.name, "widget");
-    }
-
-    #[test]
-    fn project_to_row_missing_group_is_zeroed() {
-        let p = project("widget");
-        let row = project_to_row(&p, None);
-        assert_eq!(row.live_count, 0);
-        assert_eq!(row.total_count, 0);
-    }
-
-    #[test]
-    fn session_to_row_derives_short_id_and_copies_fields() {
-        let row = session_to_row(summary("4f9ca1b2ffff", "active"));
-        assert_eq!(row.short_id, "4f9ca1b2");
-        assert_eq!(row.id, "4f9ca1b2ffff");
-        assert_eq!(row.state, "active");
-        assert_eq!(row.branch.as_deref(), Some("main"));
-        assert_eq!(row.task.as_deref(), Some("do the thing"));
-    }
-
-    #[test]
-    fn session_to_row_carries_deliverable_id() {
-        let mut s = summary("4f9ca1b2ffff", "active");
-        s.deliverable_id = Some("11111111-1111-1111-1111-111111111111".to_string());
-        let row = session_to_row(s);
-        assert_eq!(
-            row.deliverable_id.as_deref(),
-            Some("11111111-1111-1111-1111-111111111111")
-        );
-
-        let none_row = session_to_row(summary("aaaaaaaabbbb", "active"));
-        assert!(none_row.deliverable_id.is_none());
-    }
-
-    fn activity_response(raw_pane: &str) -> ManagedActivityResponse {
-        ManagedActivityResponse {
-            raw_pane: raw_pane.to_string(),
-            runtime_active: true,
-            pane_stale: false,
-            state: "working".to_string(),
-            summary: "running tests".to_string(),
-            confidence: 0.9,
-            cache_hit: false,
-            input_tokens: 0,
-            output_tokens: 0,
-            latency_ms: 12,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-            classification: None,
-            pending_decision: Some("write to ci.yml?".to_string()),
-            proposed_default: Some("yes".to_string()),
-        }
-    }
-
-    #[test]
-    fn activity_from_response_derives_fields_and_tail() {
-        let resp = activity_response("line1\nline2\nline3\nline4\n");
-        let info = activity_from_response("sess-1".to_string(), resp);
-        assert_eq!(info.session_id, "sess-1");
-        assert_eq!(info.state, "working");
-        assert_eq!(info.summary, "running tests");
-        assert_eq!(info.pending_decision.as_deref(), Some("write to ci.yml?"));
-        assert_eq!(info.proposed_default.as_deref(), Some("yes"));
-        assert_eq!(info.raw_pane_tail, vec!["line2", "line3", "line4"]);
-        assert!(!info.stale);
-    }
-
-    #[test]
-    fn activity_from_response_handles_short_pane() {
-        let resp = activity_response("only one line");
-        let info = activity_from_response("sess-1".to_string(), resp);
-        assert_eq!(info.raw_pane_tail, vec!["only one line"]);
-    }
-
-    #[test]
-    fn tail_lines_keeps_last_n_non_empty_lines() {
-        let text = "a\nb\n\nc\nd\n";
-        assert_eq!(tail_lines(text, 2), vec!["c", "d"]);
-    }
-
-    #[test]
-    fn tail_lines_handles_fewer_lines_than_requested() {
-        assert_eq!(tail_lines("only", 3), vec!["only"]);
-        assert_eq!(tail_lines("", 3), Vec::<String>::new());
     }
 
     // ---- daemon-down branches (guaranteed-dead client, no live daemon needed) ---

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
@@ -1,0 +1,363 @@
+//! Pure DTO → pane-row projections for the `tm projects` TUI poll pipeline.
+//!
+//! Why: split out of `poll.rs` (#2476) to keep that file under the 500-SLOC
+//! production cap. [`super::fetch_projects_and_sessions`] and
+//! [`super::refresh_activity`] both need to turn a daemon wire DTO into the
+//! render-ready shape its pane consumes; keeping that projection logic here,
+//! with zero async and zero [`crate::client::DaemonClient`] dependency,
+//! means every rule is directly `#[test]`-able against hand-built DTOs — no
+//! dead-loopback client, no tokio runtime.
+//! What: [`project_to_row`], [`live_session_rows`] (drops decommissioned
+//! sessions, #2476), [`session_to_row`], [`activity_from_response`], and the
+//! small [`tail_lines`] helper the last of those uses.
+//! Test: `tests` covers every function directly against hand-built DTOs.
+
+use crate::client::{FleetProjectGroupWire, ManagedActivityResponse, ManagedSessionSummary};
+use crate::project::Project;
+use crate::tui::coordinator::rows::session_short_id;
+use crate::tui::project_ctl::state::{ActivityInfo, ProjectRow, SessionRow};
+
+/// How many trailing lines of a session's raw tmux pane the Activity pane
+/// previews (DOC-35 §5.1 mockup: "last 3 lines of raw_pane").
+const RAW_PANE_TAIL_LINES: usize = 3;
+
+/// Project one registry [`Project`] (plus its matching fleet group, if any)
+/// into a [`ProjectRow`].
+///
+/// Why: the Projects pane needs the aggregate-state glyph + live session
+/// count (DOC-35 §5), not the raw registry/fleet DTOs.
+/// What: `live_count` is the number of sessions in `group` whose `state` is
+/// `"active"` or `"provisioning"`; `total_count` is `group.sessions.len()`.
+/// A project with no matching fleet group (never spawned a session) gets
+/// `0`/`0`.
+/// Test: `project_to_row_counts_live_and_total`,
+/// `project_to_row_missing_group_is_zeroed`.
+pub(crate) fn project_to_row(p: &Project, group: Option<&FleetProjectGroupWire>) -> ProjectRow {
+    let (live_count, total_count) = match group {
+        Some(g) => (
+            g.sessions
+                .iter()
+                .filter(|s| matches!(s.state.as_str(), "active" | "provisioning"))
+                .count(),
+            g.sessions.len(),
+        ),
+        None => (0, 0),
+    };
+    ProjectRow {
+        name: p.name.clone(),
+        repo_url: p.repo_url.clone(),
+        live_count,
+        total_count,
+    }
+}
+
+/// Project one fleet group's sessions into Sessions-pane rows, dropping
+/// decommissioned (tombstoned) ones (#2476).
+///
+/// Why: decommissioning a session (via `tm sessions decommission`, the TUI's
+/// own `d` action, or the idle reaper) flips the session record's `state` to
+/// `"decommissioned"` in the daemon's session store, but does NOT delete the
+/// record — that is a separate, explicit `session_delete`/prune step. Since
+/// [`super::fetch_projects_and_sessions`] rebuilds `sessions_by_project` from
+/// scratch off the fleet response on every poll tick, an unfiltered
+/// projection would let a decommissioned session's row persist in the
+/// Sessions pane — and inflate its `(N)` header count — forever, even though
+/// the session it names is gone for good and its live-refresh "removal"
+/// never has anywhere else to happen. The pane header counts *sessions*, so
+/// a permanently-visible tombstone row is the bug, not a feature (issue
+/// #2476's own analysis, confirmed here: decommissioned rows were reachable
+/// through [`session_to_row`]/[`crate::tui::project_ctl::panes::sessions::state_glyph`]
+/// but no caller ever dropped them). Filtering here — once, at the
+/// projection step — means every downstream consumer (`sessions_nav`'s
+/// selection model, the Sessions pane render, the `(N)` header) sees only
+/// live rows and never has to special-case a dead one.
+/// What: keeps every session whose `state` is not exactly `"decommissioned"`
+/// and projects each survivor via [`session_to_row`]. A session later
+/// replaced by a new session that reuses its `name` (different `id`) can
+/// never ghost or duplicate: this rebuilds the row list wholesale from the
+/// daemon's current fleet snapshot on every tick rather than diffing against
+/// the previous tick's rows, so the decommissioned original (filtered out)
+/// and the new session (kept, its own row) never coexist.
+/// Test: `live_session_rows_drops_decommissioned`,
+/// `live_session_rows_keeps_live_states`,
+/// `live_session_rows_same_name_replacement_is_clean`.
+pub(crate) fn live_session_rows(sessions: Vec<ManagedSessionSummary>) -> Vec<SessionRow> {
+    sessions
+        .into_iter()
+        .filter(|s| s.state != "decommissioned")
+        .map(session_to_row)
+        .collect()
+}
+
+/// Project one fleet [`ManagedSessionSummary`] into a [`SessionRow`].
+///
+/// Why: the Sessions pane needs a numbered, compact row per session; the
+/// fleet poll is one call for every session regardless of count, so this
+/// projection stays over the STATIC record fields even after #2119 — only the
+/// one selected session's activity gets the extra live `/activity` fetch (see
+/// [`super::refresh_activity`]), never the whole list.
+/// What: derives the 8-hex short id via [`session_short_id`] and copies the
+/// rest through unchanged, including `deliverable_id` (DOC-35 §10.6, #2383 —
+/// drives the Sessions-pane deliverable glyph).
+/// Test: `session_to_row_derives_short_id_and_copies_fields`,
+/// `session_to_row_carries_deliverable_id`.
+pub(crate) fn session_to_row(s: ManagedSessionSummary) -> SessionRow {
+    let short_id = session_short_id(&s.id);
+    SessionRow {
+        id: s.id,
+        short_id,
+        name: s.name,
+        branch: s.branch,
+        task: s.task,
+        state: s.state,
+        pending_decision: s.pending_decision,
+        proposed_default: s.proposed_default,
+        deliverable_id: s.deliverable_id,
+    }
+}
+
+/// Project a [`ManagedActivityResponse`] into an [`ActivityInfo`] for `session_id`.
+///
+/// Why: the Activity pane needs a lean, render-ready shape (DOC-35 §5.4) with
+/// a bounded pane-tail preview rather than the full wire response.
+/// What: copies `state`/`summary`/`pending_decision`/`proposed_default`
+/// through unchanged, tags the snapshot with `session_id`, sets `stale` to
+/// `false` (a just-succeeded fetch is by definition fresh), and derives
+/// `raw_pane_tail` as the last [`RAW_PANE_TAIL_LINES`] non-empty lines of
+/// `raw_pane` via [`tail_lines`].
+/// Test: `activity_from_response_derives_fields_and_tail`,
+/// `activity_from_response_handles_short_pane`.
+pub(crate) fn activity_from_response(
+    session_id: String,
+    resp: ManagedActivityResponse,
+) -> ActivityInfo {
+    ActivityInfo {
+        session_id,
+        state: resp.state,
+        summary: resp.summary,
+        pending_decision: resp.pending_decision,
+        proposed_default: resp.proposed_default,
+        raw_pane_tail: tail_lines(&resp.raw_pane, RAW_PANE_TAIL_LINES),
+        stale: false,
+    }
+}
+
+/// The last `n` non-empty, trimmed lines of `text`, in original order.
+///
+/// Why: a raw tmux pane capture is typically newline-padded and much longer
+/// than the Activity pane's fixed 4-row height can show; a small pure helper
+/// keeps the "which lines" rule unit-testable independent of rendering.
+/// What: splits on `\n`, trims each line, drops empty ones, then keeps the
+/// last `n` (or fewer, if `text` has fewer than `n` non-empty lines).
+/// Test: `tail_lines_keeps_last_n_non_empty_lines`,
+/// `tail_lines_handles_fewer_lines_than_requested`.
+fn tail_lines(text: &str, n: usize) -> Vec<String> {
+    let non_empty: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    let start = non_empty.len().saturating_sub(n);
+    non_empty[start..].iter().map(|l| l.to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project(name: &str) -> Project {
+        Project {
+            name: name.to_string(),
+            repo_url: format!("https://github.com/acme/{name}"),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        }
+    }
+
+    fn summary(id: &str, state: &str) -> ManagedSessionSummary {
+        ManagedSessionSummary {
+            id: id.to_string(),
+            name: format!("s-{id}"),
+            state: state.to_string(),
+            workspace_path: None,
+            repo_url: None,
+            branch: Some("main".to_string()),
+            created_at: None,
+            last_activity_at: None,
+            pending_decision: None,
+            proposed_default: None,
+            source_id: None,
+            task: Some("do the thing".to_string()),
+            cwd: None,
+            claude_session_id: None,
+            deliverable_id: None,
+            pane_id: None,
+        }
+    }
+
+    #[test]
+    fn project_to_row_counts_live_and_total() {
+        let p = project("widget");
+        let group = FleetProjectGroupWire {
+            project_name: "widget".to_string(),
+            repo_url: p.repo_url.clone(),
+            sessions: vec![
+                summary("a1111111", "active"),
+                summary("b2222222", "provisioning"),
+                summary("c3333333", "stopped"),
+            ],
+        };
+        let row = project_to_row(&p, Some(&group));
+        assert_eq!(row.live_count, 2);
+        assert_eq!(row.total_count, 3);
+        assert_eq!(row.name, "widget");
+    }
+
+    #[test]
+    fn project_to_row_missing_group_is_zeroed() {
+        let p = project("widget");
+        let row = project_to_row(&p, None);
+        assert_eq!(row.live_count, 0);
+        assert_eq!(row.total_count, 0);
+    }
+
+    #[test]
+    fn session_to_row_derives_short_id_and_copies_fields() {
+        let row = session_to_row(summary("4f9ca1b2ffff", "active"));
+        assert_eq!(row.short_id, "4f9ca1b2");
+        assert_eq!(row.id, "4f9ca1b2ffff");
+        assert_eq!(row.state, "active");
+        assert_eq!(row.branch.as_deref(), Some("main"));
+        assert_eq!(row.task.as_deref(), Some("do the thing"));
+    }
+
+    #[test]
+    fn session_to_row_carries_deliverable_id() {
+        let mut s = summary("4f9ca1b2ffff", "active");
+        s.deliverable_id = Some("11111111-1111-1111-1111-111111111111".to_string());
+        let row = session_to_row(s);
+        assert_eq!(
+            row.deliverable_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+
+        let none_row = session_to_row(summary("aaaaaaaabbbb", "active"));
+        assert!(none_row.deliverable_id.is_none());
+    }
+
+    // ---- #2476: decommissioned sessions never reach the Sessions pane ----
+
+    #[test]
+    fn live_session_rows_drops_decommissioned() {
+        // (a) a session present, then decommissioned, drops out of the row
+        // list — and with it, the Sessions pane's `(N)` header count.
+        let sessions = vec![
+            summary("a1111111", "active"),
+            summary("b2222222", "decommissioned"),
+        ];
+        let rows = live_session_rows(sessions);
+        assert_eq!(
+            rows.len(),
+            1,
+            "decommissioned row must be dropped: {rows:?}"
+        );
+        assert_eq!(rows[0].id, "a1111111");
+    }
+
+    #[test]
+    fn live_session_rows_keeps_live_states() {
+        // (b) the add path: every non-decommissioned state still projects a
+        // row (active/provisioning/stopped/errored all render distinct
+        // glyphs — see panes::sessions::state_glyph — none of that changes).
+        let sessions = vec![
+            summary("a1111111", "active"),
+            summary("b2222222", "provisioning"),
+            summary("c3333333", "stopped"),
+            summary("d4444444", "errored"),
+        ];
+        let rows = live_session_rows(sessions);
+        assert_eq!(rows.len(), 4);
+        assert_eq!(
+            rows.iter().map(|r| r.state.as_str()).collect::<Vec<_>>(),
+            vec!["active", "provisioning", "stopped", "errored"]
+        );
+    }
+
+    #[test]
+    fn live_session_rows_same_name_replacement_is_clean() {
+        // (c) a decommissioned session and a newer, differently-id'd session
+        // that reuses its `name` must never ghost (old row lingering) or
+        // duplicate (both rows shown) — only the live one survives.
+        let mut old = summary("a1111111", "decommissioned");
+        old.name = "worker".to_string();
+        let mut replacement = summary("b2222222", "active");
+        replacement.name = "worker".to_string();
+
+        let rows = live_session_rows(vec![old, replacement]);
+        assert_eq!(
+            rows.len(),
+            1,
+            "expected exactly one surviving row: {rows:?}"
+        );
+        assert_eq!(rows[0].id, "b2222222");
+        assert_eq!(rows[0].name, "worker");
+    }
+
+    fn activity_response(raw_pane: &str) -> ManagedActivityResponse {
+        ManagedActivityResponse {
+            raw_pane: raw_pane.to_string(),
+            runtime_active: true,
+            pane_stale: false,
+            state: "working".to_string(),
+            summary: "running tests".to_string(),
+            confidence: 0.9,
+            cache_hit: false,
+            input_tokens: 0,
+            output_tokens: 0,
+            latency_ms: 12,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            classification: None,
+            pending_decision: Some("write to ci.yml?".to_string()),
+            proposed_default: Some("yes".to_string()),
+        }
+    }
+
+    #[test]
+    fn activity_from_response_derives_fields_and_tail() {
+        let resp = activity_response("line1\nline2\nline3\nline4\n");
+        let info = activity_from_response("sess-1".to_string(), resp);
+        assert_eq!(info.session_id, "sess-1");
+        assert_eq!(info.state, "working");
+        assert_eq!(info.summary, "running tests");
+        assert_eq!(info.pending_decision.as_deref(), Some("write to ci.yml?"));
+        assert_eq!(info.proposed_default.as_deref(), Some("yes"));
+        assert_eq!(info.raw_pane_tail, vec!["line2", "line3", "line4"]);
+        assert!(!info.stale);
+    }
+
+    #[test]
+    fn activity_from_response_handles_short_pane() {
+        let resp = activity_response("only one line");
+        let info = activity_from_response("sess-1".to_string(), resp);
+        assert_eq!(info.raw_pane_tail, vec!["only one line"]);
+    }
+
+    #[test]
+    fn tail_lines_keeps_last_n_non_empty_lines() {
+        let text = "a\nb\n\nc\nd\n";
+        assert_eq!(tail_lines(text, 2), vec!["c", "d"]);
+    }
+
+    #[test]
+    fn tail_lines_handles_fewer_lines_than_requested() {
+        assert_eq!(tail_lines("only", 3), vec!["only"]);
+        assert_eq!(tail_lines("", 3), Vec::<String>::new());
+    }
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/state/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/state/mod.rs
@@ -83,7 +83,7 @@ impl Pane {
 /// What: the registry name/repo URL plus `live_count` (sessions currently
 /// `active` or `provisioning`) and `total_count` (every session bound to the
 /// project, any state).
-/// Test: `poll::tests::project_to_row_*`.
+/// Test: `poll::rows::tests::project_to_row_*`.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ProjectRow {
     /// Registry key / short project name.
@@ -108,7 +108,9 @@ pub struct ProjectRow {
 /// that live wiring is deferred to #2119.
 /// What: id/short-id/name/branch/task plus the lifecycle `state` word and the
 /// two static activity fields.
-/// Test: `poll::tests::session_to_row_*`.
+/// Test: `poll::rows::tests::session_to_row_*`,
+/// `poll::rows::tests::live_session_rows_*` (#2476 — decommissioned rows are
+/// filtered before this type is ever constructed for a tombstoned session).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SessionRow {
     /// Full session id (UUID string).
@@ -156,7 +158,7 @@ pub struct SessionRow {
 /// What: the four DOC-35 §5.4 fields (`state`, `summary`, `pending_decision`,
 /// `proposed_default`) plus a short `raw_pane_tail` (the mockup's "last 3
 /// lines of raw_pane") and the `stale` flag.
-/// Test: `poll::tests::activity_from_response_*`,
+/// Test: `poll::rows::tests::activity_from_response_*`,
 /// `panes::activity::tests::activity_lines_*`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActivityInfo {

--- a/docs/specs/tm-project-control-plane.md
+++ b/docs/specs/tm-project-control-plane.md
@@ -420,7 +420,14 @@ already used in `tui/coordinator/layout.rs` and `tui/health/render.rs`):
    project (registry B), a glyph for aggregate state, and a live session count. `▸` marks focus.
 2. **Sessions pane** (right column, `Constraint::Percentage(75)`) — the selected project's
    sessions, numbered (DOC-16 §3.2 convention), sourced from `GET
-   .../fleet?project=<name>` (§4).
+   .../fleet?project=<name>` (§4). **RESOLVED (#2476):** decommissioned (tombstoned) sessions
+   are filtered OUT of this pane and its `(N)` header count on every poll tick — decommissioning
+   flips a session record's `state` to `"decommissioned"` in the daemon's store but does not
+   delete it, so an unfiltered projection would let a dead row (and an inflated count) persist
+   forever. The pane counts *live* sessions; a session later replaced by a new one reusing its
+   `name` never ghosts or duplicates, since every tick rebuilds the row list wholesale from the
+   daemon's current fleet snapshot rather than diffing against the previous tick's rows. See
+   `tui/project_ctl/poll/rows.rs::live_session_rows`.
 3. **Activity pane** (bottom, `Constraint::Length(4)`) — the focused session's status line,
    sourced from `GET .../{id}/activity` (§4) — the same fields DOC-16 §6.2 already specifies
    (`state`, `summary`/`last_summary` equivalent, `pending_decision`, `proposed_default`).
@@ -917,6 +924,11 @@ as §8: file after resolving design questions).
 
 ## 15. Change log
 
+- **2026-07-12 (v3.1, #2476)** — RESOLVED bug: decommissioned sessions were persisting in the
+  Sessions pane (§5.1 item 2) instead of dropping on the next refresh tick, with the `(N)` header
+  count never decrementing. Decided and implemented: filter tombstoned/decommissioned sessions OUT
+  of the Sessions pane rather than keep them visible with a live-only count. §5.1 item 2 updated
+  to document the resolved behavior.
 - **2026-07-10 (v3)** — Owner articulated the three-layer communication model and retired DOC-30
   (issue #1878), directing its salvage into this spec. Added §1.1 (three-layer model, the new
   organizing frame for the whole document, mapping every existing/planned surface to L1/L2/L3);


### PR DESCRIPTION
## Root cause

With the `tm projects` TUI open, decommissioning a session (via `tm sessions decommission`, the TUI's own `d` action, or the idle reaper) flips the session record's `state` to `"decommissioned"` in the daemon's session store — but does **not** delete the record; that's a separate, explicit `session_delete`/prune step. `fetch_projects_and_sessions` rebuilds `sessions_by_project` wholesale from `GET /api/v1/sessions/managed/fleet` on every poll tick, and the old projection (`session_to_row` applied unconditionally to every fleet session) had no filter — so a decommissioned session's row persisted in the Sessions pane forever, and the pane's `(N)` header count (`sessions.len()`) never decremented. The live-refresh "add" path worked fine because a genuinely new session simply appeared in the next fleet response; there was just no code path that ever dropped a row.

## Decision taken: filter, not count-only

Per the issue's own analysis, this is "probably correct": the pane header counts *sessions*, and a permanently-visible tombstone row is the bug, not a feature. I found no evidence in DOC-35 or the existing tests that persistent tombstone-display was a deliberate design choice — the `DECOMMISSIONED_GLYPH`/`state_glyph` mapping for `"decommissioned"` (added in the #2118 skeleton, `ea895585`) is a generic state→glyph mapper with no accompanying rationale for *why* a tombstoned row should stay visible, and the DOC-35 §5.1 ASCII mockup only ever shows active/provisioning/idle sessions. So I implemented the filter: decommissioned sessions are dropped from the Sessions pane entirely, and the `(N)` header naturally reflects only live rows since it's just `sessions.len()` on the already-filtered list.

The `state_glyph`/`DECOMMISSIONED_GLYPH` mapping itself is left in place (still directly unit tested) as a documented-dead defensive fallback — noted in its doc comment that it's unreachable via the live poll path as of this fix.

## Implementation

- New pure function `live_session_rows` (`crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs`) filters out `state == "decommissioned"` before projecting each survivor via `session_to_row`. Used in `fetch_projects_and_sessions` in place of the old unconditional `.map(session_to_row)`.
- Because `sessions_by_project` is rebuilt wholesale from the daemon's current fleet snapshot every tick (not diffed against the previous tick), a decommissioned session later replaced by a new session reusing its `name` (different `id`) can never ghost (old row lingering) or duplicate (both rows shown) — the old row is filtered out, the new one gets its own fresh row.
- Split `poll.rs` into `poll/mod.rs` (async polling: `project_ctl_poll_daemon`, `refresh_activity`, `refresh_deliverables`, `fetch_projects_and_sessions`, `rediscover`) + `poll/rows.rs` (pure DTO → row projections: `project_to_row`, `live_session_rows`, `session_to_row`, `activity_from_response`, `tail_lines`) to stay under the 500-SLOC production cap after adding the new function, its doc comments, and its tests. `poll/rows.rs`'s functions are re-exported from `poll::mod` so existing callers (`poll::project_to_row` etc.) are unaffected.
- Updated DOC-35 §5.1 item 2 (Sessions pane) and the change log (§15) to document the resolved behavior.

## Tests

Three new unit tests in `poll/rows.rs`, all pure (no live daemon needed), directly satisfying the ticket's three required cases:

- `live_session_rows_drops_decommissioned` — (a) a session present, then decommissioned, is dropped from the row list.
- `live_session_rows_keeps_live_states` — (b) the add path: active/provisioning/stopped/errored all still project a row.
- `live_session_rows_same_name_replacement_is_clean` — (c) a decommissioned session and a same-named replacement never ghost or duplicate; exactly the live one survives.

## Quality gate (raw tails)

`cargo build --workspace`:
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.82s
```

`cargo test -p trusty-mpm` (full suite, including the new tests):
```
test result: ok. 116 passed; 0 failed; 0 ignored; 0 measured; 2790 filtered out; finished in 0.09s
```
(zero `FAILED` anywhere across the full `cargo test -p trusty-mpm` run, all binaries/integration suites included; the known pre-existing `core::home_trust_seed::tests::is_idempotent` flake was not hit)

`cargo clippy --workspace --all-targets -- -D warnings`:
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 45.90s
```
(exit 0; remaining warnings are pre-existing/unrelated — MSRV mismatch in `clippy.toml`, `tga` crate warnings, duplicate bin-target manifest warnings)

`cargo fmt --check`: exit 0, no diff.

`bash scripts/check_line_cap.sh`:
```
line-cap: 0 allowlisted, 0 violations — OK.
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools