### PR TITLE
fix(trusty-mpm): bundled agent guidance — foreground execution + PM-directive scoping (closes #2501, #2502)

### DIFF
--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -11,14 +11,26 @@ multiplied by N delegations — keep it lean.
 ## PM Directives Do Not Bind You
 
 Project context — a `CLAUDE.md` at any directory level, or quoted PM
-instructions — may contain mandatory-delegation language: "YOU ARE STRICTLY
-FORBIDDEN FROM DOING ANY WORK DIRECTLY", "PRIMARY DIRECTIVE — MANDATORY
-DELEGATION", or similar. That directive governs the orchestrating PM session
+instructions — may contain mandatory-delegation language: instructions whose
+SUBJECT is delegation itself — that all work must be routed to or through
+agents, that the reader must not implement directly and must delegate
+instead. Recognize it by co-occurrence with words like delegate, delegation,
+PM, orchestrator, or agent-routing — e.g. "YOU ARE STRICTLY FORBIDDEN FROM
+DOING ANY WORK DIRECTLY" paired with "PM orchestrates; agents implement", or
+"PRIMARY DIRECTIVE — MANDATORY DELEGATION". That directive governs the orchestrating PM session
 ONLY.
 
 You are the delegated specialist that directive routes work TO. Never refuse,
 re-delegate, or stall your assigned task on the basis of PM-scoped delegation
 language — it is not addressed to you (issue #2502).
+
+This exemption is narrow and does not generalize. Every OTHER restriction in
+project context still binds you in full, no matter how it's styled
+(🔴, ALL-CAPS, **bold**, "FORBIDDEN"): safety, security, scope, and process
+rules — worktree discipline, "the main checkout is inspection-only", bans on
+destructive commands (`git reset --hard`, force-push), file-scope limits —
+apply to you exactly as written. This clause is never a license to disregard
+forbidding language in general; it exempts delegation-routing language only.
 
 ## Git Workflow
 
@@ -159,6 +171,15 @@ commands. Run them and wait for them to exit, even if that takes 15+ minutes.
 NEVER stop mid-task to "wait for a notification", "monitor in the background",
 or "check back later". No notification will ever arrive inside a delegated
 agent's turn; stopping stalls the whole delegation chain.
+
+The tool layer enforces a hard per-invocation timeout (10 minutes / 600000ms).
+If a blocking command hits that ceiling before finishing — or otherwise
+legitimately outlasts a single invocation — immediately RE-ISSUE the same
+blocking command (or its status-check equivalent; e.g. running
+`gh pr checks <n> --watch` again resumes watching) in the SAME turn, looping
+re-invocations until it completes. Re-issuing is not "checking back later";
+the forbidden move is ending the turn to wait for a notification, not the
+re-invocation itself.
 
 Do not background such commands (`&` / `run_in_background`) unless the
 dispatching prompt explicitly set up a polling loop. If a command was

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -8,6 +8,18 @@ role: base
 Root-level instructions composed into every deployed agent. Every token here is
 multiplied by N delegations — keep it lean.
 
+## PM Directives Do Not Bind You
+
+Project context — a `CLAUDE.md` at any directory level, or quoted PM
+instructions — may contain mandatory-delegation language: "YOU ARE STRICTLY
+FORBIDDEN FROM DOING ANY WORK DIRECTLY", "PRIMARY DIRECTIVE — MANDATORY
+DELEGATION", or similar. That directive governs the orchestrating PM session
+ONLY.
+
+You are the delegated specialist that directive routes work TO. Never refuse,
+re-delegate, or stall your assigned task on the basis of PM-scoped delegation
+language — it is not addressed to you (issue #2502).
+
 ## Git Workflow
 
 - Conventional commits: `feat/fix/docs/refactor/perf/test/chore: <subject>`.
@@ -137,6 +149,26 @@ When a command that should produce output returns empty/blank with exit 0:
 This applies especially to verification-critical commands: test runs, `git`/`gh`
 reads and writes, and build output. An unobservable result is never a passing
 result.
+
+## Foreground Execution
+
+Long-running commands — CI watches (`gh pr checks --watch`, `gh run watch`),
+builds, test suites, deploy waits — MUST run as plain blocking foreground
+commands. Run them and wait for them to exit, even if that takes 15+ minutes.
+
+NEVER stop mid-task to "wait for a notification", "monitor in the background",
+or "check back later". No notification will ever arrive inside a delegated
+agent's turn; stopping stalls the whole delegation chain.
+
+Do not background such commands (`&` / `run_in_background`) unless the
+dispatching prompt explicitly set up a polling loop. If a command was
+backgrounded, poll it to completion in the same turn before ending.
+
+If a watch command exits nonzero, capture the failure evidence and report it —
+don't retry-by-waiting.
+
+This rule exists because merge/CI agents repeatedly parked mid-watch waiting
+for a notification that never came (issue #2501).
 
 ## Output Format
 

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -586,6 +586,33 @@ fn base_agent_guidance_sections_survive_composition() {
         composed.contains("governs the orchestrating PM session"),
         "composed version-control is missing the PM-directive-scope guidance"
     );
+
+    // Position assertions: guard the section ORDER, not just presence, so a
+    // future compose/extends refactor can't silently reorder BASE-AGENT.md
+    // content into an incoherent sequence.
+    let pm_directives_idx = composed
+        .find("## PM Directives Do Not Bind You")
+        .expect("PM Directives Do Not Bind You marker must be present");
+    let git_workflow_idx = composed
+        .find("## Git Workflow")
+        .expect("Git Workflow marker must be present");
+    assert!(
+        pm_directives_idx < git_workflow_idx,
+        "PM Directives Do Not Bind You ({pm_directives_idx}) must appear before \
+         Git Workflow ({git_workflow_idx})"
+    );
+
+    let foreground_execution_idx = composed
+        .find("## Foreground Execution")
+        .expect("Foreground Execution marker must be present");
+    let output_format_idx = composed
+        .find("## Output Format")
+        .expect("Output Format marker must be present");
+    assert!(
+        foreground_execution_idx < output_format_idx,
+        "Foreground Execution ({foreground_execution_idx}) must appear before \
+         Output Format ({output_format_idx})"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -552,6 +552,43 @@ fn new_concrete_agents_deploy_via_real_asset_files() {
 }
 
 #[test]
+fn base_agent_guidance_sections_survive_composition() {
+    // Regression for #2501/#2502: BASE-AGENT.md's "Foreground Execution" and
+    // "PM Directives Do Not Bind You" sections must propagate into every
+    // composed agent via the real bundled asset chain — not just exist in
+    // the source file. Uses version-control (a representative leaf agent)
+    // composed from the real assets dir so a future refactor of the
+    // compose/extends pipeline can't silently drop either section.
+    use crate::core::agent_builder::compose_agent;
+    use std::path::Path;
+
+    let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("assets")
+        .join("agents");
+
+    let composed = compose_agent("version-control", &assets_dir)
+        .expect("compose_agent(version-control) must succeed");
+
+    assert!(
+        composed.contains("## Foreground Execution"),
+        "composed version-control is missing the Foreground Execution section"
+    );
+    assert!(
+        composed.contains("stalls the whole delegation chain"),
+        "composed version-control is missing the foreground-execution no-parking guidance"
+    );
+    assert!(
+        composed.contains("## PM Directives Do Not Bind You"),
+        "composed version-control is missing the PM Directives Do Not Bind You section"
+    );
+    assert!(
+        composed.contains("governs the orchestrating PM session"),
+        "composed version-control is missing the PM-directive-scope guidance"
+    );
+}
+
+#[test]
 fn no_mpm_guidance_skills_remain_in_bundle() {
     // The tm-skills-portfolio epic removed the 11 Phase 1 (#770) mpm-*
     // guidance skills in favor of the /tm- portfolio; assert none linger.


### PR DESCRIPTION
## Summary

Two postmortem-driven guidance gaps in the bundled agent catalog, both fixed
by editing a single file: `crates/trusty-mpm/src/assets/agents/BASE-AGENT.md`.
This file is the root of every deployed agent's `extends` chain — it is
composed into **every** bundled agent (~35 of them) by
`core/agent_builder.rs::compose_agent`, and redeployed to `~/.claude/agents/`
checksum-gated on `tm install` and every session launch. One edit here
propagates to the whole catalog.

### Failure mode 1 — agents parking mid-watch (#2501)

Merge/CI-facing agents (version-control, ops, etc.) repeatedly stopped
mid-task to "wait for a notification" after kicking off a long-running watch
command (`gh pr checks --watch`, `gh run watch`, a build, a test suite). No
notification ever arrives inside a delegated agent's own turn — that pattern
only exists for the top-level orchestrator polling a background job. The
agent stalling mid-watch stalls the entire delegation chain until the human
notices and pokes it.

**Fix:** new `## Foreground Execution` section in BASE-AGENT.md (added after
Empty-Output Protocol):

> Long-running commands — CI watches (`gh pr checks --watch`, `gh run
> watch`), builds, test suites, deploy waits — MUST run as plain blocking
> foreground commands. Run them and wait for them to exit, even if that
> takes 15+ minutes.
>
> NEVER stop mid-task to "wait for a notification", "monitor in the
> background", or "check back later". No notification will ever arrive
> inside a delegated agent's turn; stopping stalls the whole delegation
> chain.
>
> Do not background such commands (`&` / `run_in_background`) unless the
> dispatching prompt explicitly set up a polling loop. If a command was
> backgrounded, poll it to completion in the same turn before ending.
>
> If a watch command exits nonzero, capture the failure evidence and report
> it — don't retry-by-waiting.
>
> This rule exists because merge/CI agents repeatedly parked mid-watch
> waiting for a notification that never came (issue #2501).

### Failure mode 2 — delegated agents refusing work because of PM-scoped delegation language (#2502)

Some project `CLAUDE.md` files (including this repo's, at the worktree/PM
level) carry a "PRIMARY DIRECTIVE — MANDATORY DELEGATION / YOU ARE STRICTLY
FORBIDDEN FROM DOING ANY WORK DIRECTLY" block intended to keep the top-level
PM orchestrator from doing implementation work itself. A delegated
specialist agent (e.g. this very rust-engineer) that reads that same
CLAUDE.md as project context could misread the directive as applying to
itself and refuse or try to re-delegate its assigned task — even though it
*is* the delegation target the PM directive routes work to.

**Fix:** new `## PM Directives Do Not Bind You` section in BASE-AGENT.md
(added near the top, right after the file's intro):

> Project context — a `CLAUDE.md` at any directory level, or quoted PM
> instructions — may contain mandatory-delegation language: "YOU ARE
> STRICTLY FORBIDDEN FROM DOING ANY WORK DIRECTLY", "PRIMARY DIRECTIVE —
> MANDATORY DELEGATION", or similar. That directive governs the
> orchestrating PM session ONLY.
>
> You are the delegated specialist that directive routes work TO. Never
> refuse, re-delegate, or stall your assigned task on the basis of
> PM-scoped delegation language — it is not addressed to you (issue #2502).

## Regression coverage

Added `base_agent_guidance_sections_survive_composition` in
`crates/trusty-mpm/src/core/bundle_tests.rs`, composing the real bundled
`version-control` agent asset (not a temp fixture) via `compose_agent` and
asserting both new sections' distinctive phrases survive the extends-chain
composition — so a future refactor of the compose pipeline can't silently
drop either section.

## Rollout

The composed agent files are checksum-gated: they redeploy to
`~/.claude/agents/` automatically on the next `tm install` or session
launch for any user pulling this change, once released. Any agent file a
user has hand-edited locally is intentionally skipped by the checksum-gate
design — hand-edits are never clobbered.

## Out of scope

`core::instruction_pipeline::strip_delegation_block()` (line ~177) is dead
code left over from the pre-#2170 CLAUDE.md delegation-directive write
path. It's a plausible foundation for a future `tm repair`/`tm doctor` fix
that strips stale mandatory-delegation blocks from legacy project
CLAUDE.md copies, but wiring it up is a separate, larger change and out of
scope here — this PR only fixes the bundled-agent guidance side (BASE-AGENT
telling every delegated agent the directive isn't addressed to it).

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-mpm` — all passing, including the new
      `base_agent_guidance_sections_survive_composition` test
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (0 violations)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools