### PR TITLE
fix(trusty-mpm): manifest adoption + --reset-agents so bundled guidance reaches deployed agents (closes #2504)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -267,10 +267,25 @@ pub(crate) enum Command {
         cmd: SlackCmd,
     },
     /// Install the bundled framework artifacts to `~/.trusty-mpm/framework/`.
+    ///
+    /// `--reset-agents` (issue #2504) is the explicit reconciliation path for
+    /// composed agent files that predate per-file manifest tracking: a
+    /// normal deploy conservatively skips any target file absent from the
+    /// manifest (it might be user-owned), which meant such files could never
+    /// receive bundle updates again. Passing `--reset-agents` with no names
+    /// force-recomposes every bundled agent; passing a comma-separated list
+    /// restricts the reset to those agents. Content that cannot be proven to
+    /// already be trusty-mpm's own prior output is backed up (`<file>.bak-
+    /// <unix_nanos>`) before being overwritten — nothing is silently lost.
     Install {
         /// Overwrite artifacts that already exist on disk.
         #[arg(long)]
         force: bool,
+        /// Force-recompose agent files from the current bundle (issue #2504).
+        /// With no value, resets every bundled agent. Pass a comma-separated
+        /// list (e.g. `--reset-agents engineer,qa`) to restrict the scope.
+        #[arg(long, num_args = 0.., value_delimiter = ',')]
+        reset_agents: Option<Vec<String>>,
     },
     /// Handle a Claude Code lifecycle hook (PreToolUse / PostToolUse / Stop).
     ///

--- a/crates/trusty-mpm/src/bin/tm/commands/install.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install.rs
@@ -4,8 +4,8 @@
 //! assembles the PM prompt, deploys agents and skills, and wires Claude Code
 //! hooks — and benefits from its own file so it stays reviewable.
 //! What: `install`, `install_claude_hooks`, `mpm_hook_additions`, `install_to`,
-//! `deploy_report_lines`, `skill_report_lines`, `remove_global_trusty_mpm_hooks`,
-//! `write_project_hooks_for_dir`.
+//! `deploy_report_lines`, `reset_report_lines`, `skill_report_lines`,
+//! `remove_global_trusty_mpm_hooks`, `write_project_hooks_for_dir`.
 //! Test: `install_writes_all_artifacts`, `install_skips_existing_without_force`,
 //! `install_claude_hooks_is_idempotent`, `install_then_deploy_deploys_skills`.
 
@@ -19,13 +19,22 @@
 /// the full PM system prompt (overwriting the bundle stub — fixes #383),
 /// deploys composed agents and skills, and wires MPM lifecycle hooks into
 /// every Claude Code settings file. All edits are idempotent.
+///
+/// `reset_agents` (issue #2504) is the explicit reconciliation path for
+/// composed agent files a normal deploy conservatively skips because they
+/// predate per-file manifest tracking. `Some(vec![])` (the CLI's `--reset-
+/// agents` with no value) resets every bundled agent; `Some(names)` restricts
+/// the reset to those agents. The normal deploy always runs first — reset
+/// only forces the specific files a plain deploy would otherwise leave
+/// alone, and re-registers everything else it touches.
 /// What: resolves [`FrameworkPaths::default`], calls [`install_to`] then
 /// [`install_system_prompt_to`] to write the real assembled PM prompt,
-/// deploys agents and skills, then calls [`install_claude_hooks`].
+/// deploys agents and skills, optionally resets the requested agent scope,
+/// then calls [`install_claude_hooks`].
 /// Test: `install_writes_all_artifacts`, `install_skips_existing_without_force`,
 /// `install_claude_hooks_is_idempotent`,
 /// `instruction_pipeline::install_system_prompt_to_writes_assembled`.
-pub(crate) fn install(force: bool) -> anyhow::Result<()> {
+pub(crate) fn install(force: bool, reset_agents: Option<Vec<String>>) -> anyhow::Result<()> {
     let paths = trusty_mpm::core::paths::FrameworkPaths::default();
     let report = install_to(&paths, force)?;
     println!(
@@ -54,6 +63,30 @@ pub(crate) fn install(force: bool) -> anyhow::Result<()> {
     )?;
     for line in deploy_report_lines(&deploy, &paths.agent_source_dir()) {
         println!("  {line}");
+    }
+
+    // Issue #2504: force-recompose the requested agent scope. Runs AFTER the
+    // normal deploy above so it only has to touch files the conservative
+    // deploy left alone (untracked + differing from the bundle); everything
+    // else is already at the fresh composition and gets adopted, not rewritten.
+    if let Some(names) = reset_agents {
+        let filter = if names.is_empty() { None } else { Some(names) };
+        println!(
+            "Resetting agents ({}) into {}",
+            filter
+                .as_ref()
+                .map(|n| n.join(", "))
+                .unwrap_or_else(|| "all".to_string()),
+            paths.claude_agents_dir().display()
+        );
+        let reset = trusty_mpm::core::agent_reset::reset_agents(
+            &paths.agent_source_dir(),
+            &paths.claude_agents_dir(),
+            filter.as_deref(),
+        )?;
+        for line in reset_report_lines(&reset) {
+            println!("  {line}");
+        }
     }
 
     // Deploy bundled skills into `~/.claude/skills/`. The bundle install above
@@ -262,10 +295,18 @@ pub(crate) fn mpm_hook_additions_with_exe(
 /// Render per-file status lines for an agent [`DeployResult`].
 ///
 /// Why: `install` and `session start` both print agent deploy results; one
-/// formatter keeps the output identical and the call sites small.
+/// formatter keeps the output identical and the call sites small. Issue
+/// #2504 added silent adoption of untracked-but-identical files and a
+/// dedicated warning for untracked files that differ from the bundle — the
+/// operator needs to see both without 36 near-duplicate warning lines.
 /// What: a `✓ <file> (composed: a → b → c)` line per deployed agent, a
-/// `~ <file> (skipped — user-modified)` line per skipped one, and a `=` line
-/// per unchanged one; the chain comes from the agent's resolved source chain.
+/// `◆ <file> (adopted — untracked, now managed)` line per silently-adopted
+/// file, a `~ <file> (skipped — user-modified)` line per skipped file the
+/// manifest already tracked with a diverged checksum, a `= <file>
+/// (unchanged)` line per already-current file, and — ONLY when
+/// [`DeployResult::untracked_modified`] is non-empty — one trailing summary
+/// line naming the count and `tm install --reset-agents` (not one line per
+/// file, to stay readable when dozens of files predate manifest tracking).
 /// Test: covered indirectly by `install_writes_all_artifacts`.
 pub(crate) fn deploy_report_lines(
     deploy: &trusty_mpm::core::agent_deployer::DeployResult,
@@ -279,12 +320,67 @@ pub(crate) fn deploy_report_lines(
             .unwrap_or_else(|_| name.to_string());
         lines.push(format!("\u{2713} {file} (composed: {chain})"));
     }
+    for file in &deploy.adopted {
+        lines.push(format!(
+            "\u{25c6} {file} (adopted \u{2014} untracked, now managed)"
+        ));
+    }
     for file in &deploy.skipped {
-        lines.push(format!("~ {file} (skipped \u{2014} user-modified)"));
+        if deploy.untracked_modified.contains(file) {
+            lines.push(format!(
+                "~ {file} (skipped \u{2014} untracked, differs from bundle)"
+            ));
+        } else {
+            lines.push(format!("~ {file} (skipped \u{2014} user-modified)"));
+        }
     }
     for file in &deploy.unchanged {
         lines.push(format!("= {file} (unchanged)"));
     }
+    if !deploy.untracked_modified.is_empty() {
+        lines.push(format!(
+            "\u{26a0} {} untracked agent file(s) differ from the bundle and were skipped; \
+             run `tm install --reset-agents` to review and reconcile them.",
+            deploy.untracked_modified.len()
+        ));
+    }
+    lines
+}
+
+/// Render per-file status lines plus a summary for a [`ResetResult`].
+///
+/// Why: `--reset-agents` (issue #2504) can touch dozens of files at once;
+/// the operator needs both the per-file detail and a one-line total so a
+/// large reset is scannable at a glance.
+/// What: a `\u{27f3} <file> (recomposed, backed up)` or `\u{27f3} <file>
+/// (recomposed)` line per rewritten file, a `\u{25c6} <file> (adopted)` line
+/// per already-current file, and a `? <name>` line per requested name with no
+/// matching source agent — followed by one summary line with the four totals.
+/// Test: `reset_report_lines_summarizes_counts`.
+pub(crate) fn reset_report_lines(
+    reset: &trusty_mpm::core::agent_reset::ResetResult,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    for file in &reset.recomposed {
+        if reset.backed_up.contains(file) {
+            lines.push(format!("\u{27f3} {file} (recomposed, backed up)"));
+        } else {
+            lines.push(format!("\u{27f3} {file} (recomposed)"));
+        }
+    }
+    for file in &reset.adopted {
+        lines.push(format!("\u{25c6} {file} (adopted)"));
+    }
+    for name in &reset.not_found {
+        lines.push(format!("? {name} (no matching source agent)"));
+    }
+    lines.push(format!(
+        "reset summary: {} recomposed, {} adopted, {} backed up, {} not found",
+        reset.recomposed.len(),
+        reset.adopted.len(),
+        reset.backed_up.len(),
+        reset.not_found.len()
+    ));
     lines
 }
 

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -57,6 +57,10 @@ mod tests_behavior_d;
 mod tests_behavior_e;
 
 #[cfg(test)]
+#[path = "tests_behavior_reset_agents_tests.rs"]
+mod tests_behavior_reset_agents;
+
+#[cfg(test)]
 #[path = "tests_projects.rs"]
 mod tests_projects;
 
@@ -324,7 +328,10 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Gui) => launch_gui(),
         Some(Command::Telegram { cmd }) => telegram(&url, cmd).await,
         Some(Command::Slack { cmd }) => slack(cmd).await,
-        Some(Command::Install { force }) => install(force),
+        Some(Command::Install {
+            force,
+            reset_agents,
+        }) => install(force, reset_agents),
         Some(Command::Hook { pm_guard }) => {
             if pm_guard {
                 commands::pm_guard::pm_guard(&url).await

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
@@ -64,7 +64,7 @@ fn project_init_keeps_existing_config() {
 fn cli_parses_install_no_force() {
     let cli = Cli::try_parse_from(["trusty-mpm", "install"]).unwrap();
     match cli.command.unwrap() {
-        Command::Install { force } => assert!(!force),
+        Command::Install { force, .. } => assert!(!force),
         other => panic!("expected Install, got {other:?}"),
     }
 }
@@ -73,7 +73,7 @@ fn cli_parses_install_no_force() {
 fn cli_parses_install_with_force() {
     let cli = Cli::try_parse_from(["trusty-mpm", "install", "--force"]).unwrap();
     match cli.command.unwrap() {
-        Command::Install { force } => assert!(force),
+        Command::Install { force, .. } => assert!(force),
         other => panic!("expected Install, got {other:?}"),
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_reset_agents_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_reset_agents_tests.rs
@@ -1,0 +1,125 @@
+//! CLI parse and report-line tests for `tm install --reset-agents`
+//! (issue #2504) — kept in their own `_tests.rs`-suffixed file (1500-SLOC
+//! test cap) rather than growing `tests_behavior_a.rs`, which sits close to
+//! the 500-SLOC production cap despite living in `src/bin/tm/`, following the
+//! existing `tests_behavior_a/b/c/d/e` split convention.
+//!
+//! Why: issue #2504 found that composed agent files deployed before per-file
+//! manifest tracking existed can never receive bundle updates — the deployer
+//! conservatively (and correctly) treats an untracked target file as
+//! potentially user-owned and skips it forever. These tests cover the CLI
+//! surface for the fix's three parts: `--reset-agents` argument parsing
+//! (bare flag = all agents, comma list = filtered), and the human-readable
+//! report lines for both the deploy adoption/warning path and the reset
+//! summary. Core reconciliation logic (adoption, backup-before-overwrite) is
+//! covered by `crates/trusty-mpm/src/core/agent_deployer.rs` and
+//! `crates/trusty-mpm/src/core/agent_reset.rs` unit tests.
+//! What: `cli_parses_install_reset_agents_all`,
+//! `cli_parses_install_reset_agents_filtered`,
+//! `deploy_report_lines_flags_adopted_and_untracked_modified`,
+//! `reset_report_lines_summarizes_counts`.
+//! Test: `cargo test -p trusty-mpm` runs this file as part of the `tm` binary
+//! test suite.
+
+use clap::Parser;
+
+use crate::cli::{Cli, Command};
+use crate::commands::install::{deploy_report_lines, reset_report_lines};
+
+#[test]
+fn cli_parses_install_reset_agents_all() {
+    // Issue #2504: `--reset-agents` with no value resets every bundled agent.
+    let cli = Cli::try_parse_from(["trusty-mpm", "install", "--reset-agents"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Install { reset_agents, .. } => {
+            assert_eq!(reset_agents, Some(vec![]));
+        }
+        other => panic!("expected Install, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_install_reset_agents_filtered() {
+    // A comma-separated value list restricts the reset scope.
+    let cli =
+        Cli::try_parse_from(["trusty-mpm", "install", "--reset-agents", "engineer,qa"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Install { reset_agents, .. } => {
+            assert_eq!(
+                reset_agents,
+                Some(vec!["engineer".to_string(), "qa".to_string()])
+            );
+        }
+        other => panic!("expected Install, got {other:?}"),
+    }
+}
+
+#[test]
+fn deploy_report_lines_flags_adopted_and_untracked_modified() {
+    // Issue #2504: adopted files get a distinct glyph, untracked-modified
+    // files that are also skipped get a distinct message, and a single
+    // trailing summary line points at `--reset-agents` — never one warning
+    // line per untracked file.
+    let mut result = trusty_mpm::core::agent_deployer::DeployResult::default();
+    result.adopted.push("adopted-agent.md".to_string());
+    result.skipped.push("stale-agent.md".to_string());
+    result.untracked_modified.push("stale-agent.md".to_string());
+    result.skipped.push("edited-agent.md".to_string());
+
+    let dir = tempfile::tempdir().unwrap();
+    let lines = deploy_report_lines(&result, dir.path());
+
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("adopted-agent.md") && l.contains("adopted")),
+        "lines = {lines:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("stale-agent.md") && l.contains("differs from bundle")),
+        "lines = {lines:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("edited-agent.md") && l.contains("user-modified")),
+        "lines = {lines:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("1 untracked agent file") && l.contains("--reset-agents")),
+        "lines = {lines:?}"
+    );
+}
+
+#[test]
+fn reset_report_lines_summarizes_counts() {
+    // Issue #2504: `--reset-agents` output must include a scannable total,
+    // not just per-file lines, since a full reset can touch dozens of files.
+    let result = trusty_mpm::core::agent_reset::ResetResult {
+        recomposed: vec!["a.md".to_string(), "b.md".to_string()],
+        adopted: vec!["c.md".to_string()],
+        backed_up: vec!["b.md".to_string()],
+        not_found: vec!["missing-agent".to_string()],
+    };
+
+    let lines = reset_report_lines(&result);
+    assert!(lines.iter().any(|l| l.contains("a.md (recomposed)")));
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("b.md (recomposed, backed up)"))
+    );
+    assert!(lines.iter().any(|l| l.contains("c.md (adopted)")));
+    assert!(lines.iter().any(|l| l.contains("missing-agent")));
+    assert!(
+        lines.iter().any(|l| l.contains("2 recomposed")
+            && l.contains("1 adopted")
+            && l.contains("1 backed up")
+            && l.contains("1 not found")),
+        "lines = {lines:?}"
+    );
+}

--- a/crates/trusty-mpm/src/core/agent_deployer.rs
+++ b/crates/trusty-mpm/src/core/agent_deployer.rs
@@ -25,17 +25,31 @@ use crate::core::agent_manifest::{
 ///
 /// Why: the CLI prints per-file status; callers need the file lists split by
 /// outcome to render that summary and to know whether any work was skipped.
-/// What: filenames grouped into freshly written, skipped (user-modified), and
-/// unchanged (checksum already current).
+/// What: filenames grouped into freshly written, skipped (user-modified),
+/// unchanged (checksum already current), and silently adopted (untracked but
+/// byte-identical to the fresh composition — see [`adopted`]).
+/// [`untracked_modified`] is a subset of `skipped`: files that were absent
+/// from the manifest AND differ from the fresh composition, which is the
+/// specific case `--reset-agents` exists to resolve (issue #2504).
 /// Test: every `deploy_*` test asserts on these vectors.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DeployResult {
     /// Filenames successfully (re)written this run.
     pub deployed: Vec<String>,
-    /// Filenames skipped because the user modified them.
+    /// Filenames skipped because the user modified them, or because they were
+    /// untracked and differ from the fresh composition.
     pub skipped: Vec<String>,
     /// Filenames left untouched because their checksum already matched.
     pub unchanged: Vec<String>,
+    /// Filenames that were untracked by the manifest but byte-identical to
+    /// the fresh composition — registered into the manifest without a
+    /// rewrite (issue #2504 adoption path).
+    pub adopted: Vec<String>,
+    /// Filenames that were untracked by the manifest AND differ from the
+    /// fresh composition — skipped conservatively, but flagged so the
+    /// operator knows `tm install --reset-agents` is available to reconcile
+    /// them. Always a subset of `skipped`.
+    pub untracked_modified: Vec<String>,
 }
 
 /// Whether a source filename names a trusty-mpm agent to compose.
@@ -44,7 +58,7 @@ pub struct DeployResult {
 /// and the manifest file (if it ever appears there) must be ignored.
 /// What: returns `true` for `*.md` files other than the manifest.
 /// Test: covered indirectly by `deploy_new_agent`.
-fn is_agent_file(name: &str) -> bool {
+pub(crate) fn is_agent_file(name: &str) -> bool {
     name.ends_with(".md")
 }
 
@@ -143,8 +157,30 @@ pub fn deploy_agents_filtered(
         // Classify the existing target file, if any.
         if target_path.exists() {
             if !manifest.is_managed(&filename) {
-                // User dropped their own file here — never touch it.
-                result.skipped.push(filename);
+                // Untracked (issue #2504): the manifest predates per-file
+                // tracking for this file, or it was never registered. Rather
+                // than permanently orphaning it, compare against the fresh
+                // composition — if byte-identical, silently adopt it (the
+                // content already matches what trusty-mpm would have written,
+                // so registering it is safe and reconciles the manifest gap).
+                // Otherwise keep the conservative skip (it may be genuinely
+                // user-owned) but flag it for the `--reset-agents` warning.
+                let current = std::fs::read_to_string(&target_path)?;
+                if checksum(&current) == checksum(&composed) {
+                    manifest.managed.insert(
+                        filename.clone(),
+                        ManifestEntry {
+                            source_chain: source_chain(&name, source_dir)?,
+                            checksum: checksum(&composed),
+                            deployed_at: now.clone(),
+                            origin: Origin::Bundled,
+                        },
+                    );
+                    result.adopted.push(filename);
+                } else {
+                    result.skipped.push(filename.clone());
+                    result.untracked_modified.push(filename);
+                }
                 continue;
             }
             let current = std::fs::read_to_string(&target_path)?;
@@ -181,6 +217,28 @@ pub fn deploy_agents_filtered(
             },
         );
         result.deployed.push(filename);
+    }
+
+    // Issue #2504: warn ONCE with a count + short preview rather than one
+    // line per untracked-modified file (this set can be dozens of files wide
+    // on a machine that predates per-file manifest tracking) — actionable
+    // without spamming the operator's terminal.
+    if !result.untracked_modified.is_empty() {
+        let count = result.untracked_modified.len();
+        let preview = result
+            .untracked_modified
+            .iter()
+            .take(5)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let ellipsis = if count > 5 { ", …" } else { "" };
+        tracing::warn!(
+            count,
+            "{count} agent file(s) untracked by the deploy manifest differ from the \
+             bundled composition and were skipped: {preview}{ellipsis}. Run \
+             `tm install --reset-agents` to review and reconcile them."
+        );
     }
 
     manifest.save(target_dir).map_err(|e| match e {
@@ -263,6 +321,78 @@ mod tests {
 
         let still = fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
         assert!(still.contains("USER HAND-EDIT"));
+    }
+
+    #[test]
+    fn deploy_adopts_untracked_byte_identical_file() {
+        // Issue #2504: a target file present on disk but absent from the
+        // manifest (predates per-file tracking) must be silently adopted
+        // when its content already equals the fresh composition — no
+        // rewrite, just registration — so a later bundle change can reach it.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+
+        // Pre-create the target with exactly what compose_agent would
+        // produce, simulating a file deployed before manifest tracking
+        // existed for it.
+        let composed = crate::core::agent_builder::compose_agent("engineer", src.path()).unwrap();
+        fs::write(tgt.path().join("engineer.md"), &composed).unwrap();
+        let before = fs::metadata(tgt.path().join("engineer.md"))
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        let result = deploy_agents(src.path(), tgt.path()).unwrap();
+        assert!(result.adopted.contains(&"engineer.md".to_string()));
+        assert!(!result.skipped.contains(&"engineer.md".to_string()));
+        assert!(!result.deployed.contains(&"engineer.md".to_string()));
+
+        // Not rewritten — adoption is registration-only.
+        let after = fs::metadata(tgt.path().join("engineer.md"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        assert_eq!(before, after, "adopted file must not be rewritten");
+
+        // Now registered — a subsequent bundle change must be able to reach
+        // it (the whole point of adoption).
+        let manifest = AgentManifest::load(tgt.path());
+        assert!(manifest.is_managed("engineer.md"));
+
+        fs::write(
+            src.path().join("engineer.md"),
+            "---\nname: engineer\nrole: engineer\nextends: base-agent\nmodel: sonnet\n---\n\n# Engineer\n\nUPDATED.\n",
+        )
+        .unwrap();
+        let second = deploy_agents(src.path(), tgt.path()).unwrap();
+        assert!(second.deployed.contains(&"engineer.md".to_string()));
+        let updated = fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
+        assert!(updated.contains("UPDATED."));
+    }
+
+    #[test]
+    fn deploy_flags_untracked_modified_file_for_reset() {
+        // An untracked file whose content differs from the fresh composition
+        // must be skipped AND recorded in `untracked_modified` so the CLI can
+        // point the operator at `tm install --reset-agents`.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+        fs::write(
+            tgt.path().join("engineer.md"),
+            "PRE-EXISTING, NOT TRUSTY-MPM'S CURRENT COMPOSITION\n",
+        )
+        .unwrap();
+
+        let result = deploy_agents(src.path(), tgt.path()).unwrap();
+        assert!(result.skipped.contains(&"engineer.md".to_string()));
+        assert!(
+            result
+                .untracked_modified
+                .contains(&"engineer.md".to_string())
+        );
+        assert!(!AgentManifest::load(tgt.path()).is_managed("engineer.md"));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/agent_reset.rs
+++ b/crates/trusty-mpm/src/core/agent_reset.rs
@@ -1,0 +1,405 @@
+//! `tm install --reset-agents` — force-recompose managed agent files.
+//!
+//! Why: [`crate::core::agent_deployer::deploy_agents_filtered`] is
+//! deliberately conservative — a target file absent from the manifest is
+//! always treated as potentially user-owned and skipped, with no path back to
+//! a managed state (issue #2504). That conservatism is correct as a default,
+//! but it means a fleet of composed agent files deployed before per-file
+//! manifest tracking existed can never receive bundle updates again. This
+//! module provides the explicit, operator-invoked escape hatch: force
+//! every targeted agent back to the current bundle's composition, preserving
+//! any content that cannot be proven to already be a fresh copy by backing it
+//! up first.
+//! What: [`reset_agents`] recomposes every requested source agent (default:
+//! all of them) and writes it into `target_dir`, registering the result in
+//! the deploy manifest. A target file whose content already matches the
+//! fresh composition is adopted without a rewrite; a target file whose
+//! content differs from BOTH the manifest's last-known checksum (if any) AND
+//! the fresh composition is backed up to `<file>.bak-<unix_nanos>` before
+//! being overwritten, so no content is ever silently discarded.
+//! Test: `reset_writes_all_by_default`, `reset_filters_by_name`,
+//! `reset_adopts_matching_untracked_file`, `reset_backs_up_diverged_file`,
+//! `reset_recomposes_without_backup_when_matching_manifest_checksum`,
+//! `reset_reports_unknown_names`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::agent_builder::{AgentBuildError, compose_agent, source_chain};
+use crate::core::agent_deployer::is_agent_file;
+use crate::core::agent_manifest::{
+    AgentManifest, ManifestEntry, ManifestLoad, Origin, atomic_write, checksum,
+};
+
+/// Summary of one [`reset_agents`] run.
+///
+/// Why: the CLI prints a per-file table plus totals; splitting outcomes into
+/// named buckets keeps that report mechanical rather than string-sniffed.
+/// What: `recomposed` is every filename actually (re)written (a superset of
+/// `backed_up`, since a backed-up file is also rewritten); `adopted` is every
+/// filename whose content already matched the fresh composition and so was
+/// only (re-)registered in the manifest; `backed_up` is the subset of
+/// `recomposed` that required preserving prior content first; `not_found` is
+/// any requested name with no matching source agent.
+/// Test: every `reset_*` test in this module asserts on these vectors.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResetResult {
+    /// Filenames rewritten from the fresh composition.
+    pub recomposed: Vec<String>,
+    /// Filenames already matching the fresh composition — registered without
+    /// a rewrite.
+    pub adopted: Vec<String>,
+    /// Filenames backed up (subset of `recomposed`) before being overwritten.
+    pub backed_up: Vec<String>,
+    /// Requested names with no matching source agent file.
+    pub not_found: Vec<String>,
+}
+
+/// Suffix template for reset backups: `<file>.bak-<unix_nanos>`.
+///
+/// Why: naming it once keeps [`backup_path`] and any operator-facing docs in
+/// agreement; mirrors the `.old-layout-backup-<unix_nanos>` convention already
+/// used for clone-directory migrations
+/// ([`crate::daemon::managed_routes::inproject::OLD_LAYOUT_BACKUP_SUFFIX`]) so
+/// backup naming stays consistent across the codebase.
+/// What: `".bak-"` — the timestamp is appended by [`backup_path`].
+/// Test: `reset_backs_up_diverged_file` asserts a sibling matching this
+/// pattern is created.
+pub const RESET_BACKUP_SUFFIX: &str = ".bak-";
+
+/// Build the backup path for `target_path`, e.g. `engineer.md.bak-<nanos>`.
+///
+/// Why: factored out so the timestamp source is exercised identically in
+/// tests and production.
+/// What: appends [`RESET_BACKUP_SUFFIX`] plus nanoseconds-since-epoch to the
+/// target's file name, in the same directory.
+/// Test: `reset_backs_up_diverged_file`.
+fn backup_path(target_path: &Path) -> PathBuf {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let name = target_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "agent.md".to_string());
+    target_path.with_file_name(format!("{name}{RESET_BACKUP_SUFFIX}{ts}"))
+}
+
+/// Force-recompose agent files from the current bundle into `target_dir`.
+///
+/// Why: the explicit, operator-invoked reconciliation path for issue #2504 —
+/// bundled BASE-AGENT.md guidance updates are inert for any deployed agent
+/// file that predates per-file manifest tracking. This is the only way to
+/// bring such a file back under management without manually deleting it.
+/// What: `names` restricts the reset to those source-agent stems (e.g.
+/// `["engineer", "qa"]`); `None` resets every source agent. For each targeted
+/// name: composes fresh content; if no target file exists, writes it and
+/// registers it (counted as `recomposed`); if a target file exists and
+/// already matches the fresh composition, registers it without a rewrite
+/// (`adopted`); if it differs, backs it up first ONLY when its content also
+/// differs from the manifest's last-known checksum for that file (or there is
+/// no such record), then overwrites it (`recomposed`, plus `backed_up` when a
+/// backup was written). The manifest is saved atomically once at the end.
+/// Test: `reset_writes_all_by_default`, `reset_filters_by_name`,
+/// `reset_adopts_matching_untracked_file`, `reset_backs_up_diverged_file`,
+/// `reset_recomposes_without_backup_when_matching_manifest_checksum`,
+/// `reset_reports_unknown_names`.
+pub fn reset_agents(
+    source_dir: &Path,
+    target_dir: &Path,
+    names: Option<&[String]>,
+) -> Result<ResetResult, AgentBuildError> {
+    let mut result = ResetResult::default();
+
+    if !source_dir.is_dir() {
+        return Ok(result);
+    }
+
+    let mut manifest = match AgentManifest::load_checked(target_dir) {
+        ManifestLoad::Ok(m) => m,
+        ManifestLoad::Corrupt(detail) => {
+            return Err(AgentBuildError::FrontmatterParse(format!(
+                "agent manifest is corrupt and cannot be safely loaded; \
+                 run `tm repair deploy` to recover. Detail: {detail}"
+            )));
+        }
+    };
+    let now = chrono::Utc::now().to_rfc3339();
+
+    let mut available: Vec<String> = Vec::new();
+    for entry in std::fs::read_dir(source_dir)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if entry.file_type()?.is_file() && is_agent_file(name) {
+            available.push(name.trim_end_matches(".md").to_string());
+        }
+    }
+    available.sort_unstable();
+
+    let targets: Vec<String> = match names {
+        None => available.clone(),
+        Some(requested) => {
+            for n in requested {
+                if !available.contains(n) {
+                    result.not_found.push(n.clone());
+                }
+            }
+            let mut filtered: Vec<String> = available
+                .iter()
+                .filter(|a| requested.contains(a))
+                .cloned()
+                .collect();
+            filtered.sort_unstable();
+            filtered
+        }
+    };
+
+    for name in targets {
+        let filename = format!("{name}.md");
+        let composed = compose_agent(&name, source_dir)?;
+        let target_path = target_dir.join(&filename);
+        let fresh_checksum = checksum(&composed);
+
+        let needs_backup = if target_path.exists() {
+            let current = std::fs::read_to_string(&target_path)?;
+            let current_checksum = checksum(&current);
+            if current_checksum == fresh_checksum {
+                // Already the latest composition — adopt without a rewrite.
+                manifest.managed.insert(
+                    filename.clone(),
+                    ManifestEntry {
+                        source_chain: source_chain(&name, source_dir)?,
+                        checksum: fresh_checksum,
+                        deployed_at: now.clone(),
+                        origin: Origin::Bundled,
+                    },
+                );
+                result.adopted.push(filename);
+                continue;
+            }
+            let old_checksum = manifest.managed.get(&filename).map(|e| e.checksum.clone());
+            old_checksum.as_deref() != Some(current_checksum.as_str())
+        } else {
+            false
+        };
+
+        if needs_backup {
+            let dest = backup_path(&target_path);
+            std::fs::copy(&target_path, &dest)?;
+            tracing::warn!(
+                original = %target_path.display(),
+                backup = %dest.display(),
+                "tm install --reset-agents: preserved diverged content before recompose"
+            );
+            result.backed_up.push(filename.clone());
+        }
+
+        std::fs::create_dir_all(target_dir)?;
+        atomic_write(&target_path, &composed).map_err(|e| match e {
+            crate::core::error::Error::Io(io) => AgentBuildError::Io(io),
+            other => AgentBuildError::FrontmatterParse(other.to_string()),
+        })?;
+        manifest.managed.insert(
+            filename.clone(),
+            ManifestEntry {
+                source_chain: source_chain(&name, source_dir)?,
+                checksum: fresh_checksum,
+                deployed_at: now.clone(),
+                origin: Origin::Bundled,
+            },
+        );
+        result.recomposed.push(filename);
+    }
+
+    manifest.save(target_dir).map_err(|e| match e {
+        crate::core::error::Error::Io(io) => AgentBuildError::Io(io),
+        other => AgentBuildError::FrontmatterParse(other.to_string()),
+    })?;
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_sources(dir: &Path) {
+        fs::write(
+            dir.join("base-agent.md"),
+            "---\nname: base-agent\nrole: base\n---\n\n# Base\n\nBase content.\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("engineer.md"),
+            "---\nname: engineer\nrole: engineer\nextends: base-agent\nmodel: sonnet\n---\n\n# Engineer\n\nEngineer content.\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn reset_writes_all_by_default() {
+        // With no `names` filter, every source agent is (re)composed and
+        // registered — this is the "nuke and pave" path for a manifest gap.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+
+        let result = reset_agents(src.path(), tgt.path(), None).unwrap();
+        assert_eq!(result.recomposed.len(), 2);
+        assert!(result.adopted.is_empty());
+        assert!(result.backed_up.is_empty());
+        assert!(result.not_found.is_empty());
+
+        let manifest = AgentManifest::load(tgt.path());
+        assert!(manifest.is_managed("engineer.md"));
+        assert!(manifest.is_managed("base-agent.md"));
+    }
+
+    #[test]
+    fn reset_filters_by_name() {
+        // Passing a name filter must restrict the reset to that agent only.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+
+        let result = reset_agents(src.path(), tgt.path(), Some(&["engineer".to_string()])).unwrap();
+        assert_eq!(result.recomposed, vec!["engineer.md".to_string()]);
+        assert!(!tgt.path().join("base-agent.md").exists());
+    }
+
+    #[test]
+    fn reset_reports_unknown_names() {
+        // A requested name with no matching source file is reported, not
+        // silently dropped, and does not abort the rest of the reset.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+
+        let result = reset_agents(
+            src.path(),
+            tgt.path(),
+            Some(&["engineer".to_string(), "nonexistent".to_string()]),
+        )
+        .unwrap();
+        assert_eq!(result.recomposed, vec!["engineer.md".to_string()]);
+        assert_eq!(result.not_found, vec!["nonexistent".to_string()]);
+    }
+
+    #[test]
+    fn reset_adopts_matching_untracked_file() {
+        // An untracked file whose content already equals the fresh
+        // composition must be adopted (registered) without a rewrite or
+        // backup — this is the silent-adoption half of issue #2504.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+        let composed = compose_agent("engineer", src.path()).unwrap();
+        fs::write(tgt.path().join("engineer.md"), &composed).unwrap();
+        let before = fs::metadata(tgt.path().join("engineer.md"))
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        let result = reset_agents(src.path(), tgt.path(), Some(&["engineer".to_string()])).unwrap();
+        assert_eq!(result.adopted, vec!["engineer.md".to_string()]);
+        assert!(result.recomposed.is_empty());
+        assert!(result.backed_up.is_empty());
+
+        let after = fs::metadata(tgt.path().join("engineer.md"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        assert_eq!(before, after, "adopted file must not be rewritten");
+
+        let manifest = AgentManifest::load(tgt.path());
+        assert!(manifest.is_managed("engineer.md"));
+    }
+
+    #[test]
+    fn reset_backs_up_diverged_file() {
+        // An untracked file whose content differs from the fresh composition
+        // must be backed up before being overwritten — no content loss.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+        fs::write(
+            tgt.path().join("engineer.md"),
+            "USER OR STALE CONTENT — not the current bundle\n",
+        )
+        .unwrap();
+
+        let result = reset_agents(src.path(), tgt.path(), Some(&["engineer".to_string()])).unwrap();
+        assert_eq!(result.recomposed, vec!["engineer.md".to_string()]);
+        assert_eq!(result.backed_up, vec!["engineer.md".to_string()]);
+
+        // Fresh content lands at the original path.
+        let fresh = fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
+        assert!(fresh.contains("Engineer content."));
+
+        // A backup sibling preserves the prior content.
+        let backups: Vec<_> = fs::read_dir(tgt.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("engineer.md.bak-"))
+            .collect();
+        assert_eq!(backups.len(), 1, "expected exactly one backup file");
+        let backup_content = fs::read_to_string(tgt.path().join(&backups[0])).unwrap();
+        assert_eq!(
+            backup_content,
+            "USER OR STALE CONTENT — not the current bundle\n"
+        );
+
+        let manifest = AgentManifest::load(tgt.path());
+        assert!(manifest.is_managed("engineer.md"));
+    }
+
+    #[test]
+    fn reset_recomposes_without_backup_when_matching_manifest_checksum() {
+        // A managed file whose content matches the LAST deploy (manifest
+        // checksum) but differs from the FRESH composition (the bundle
+        // changed) is a routine bundle update — no backup needed, since the
+        // content is known to be trusty-mpm's own prior output, not a user
+        // edit.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+
+        // Establish a normal managed deploy first.
+        crate::core::agent_deployer::deploy_agents(src.path(), tgt.path()).unwrap();
+
+        // Bundle changes: engineer.md source now has different body content.
+        fs::write(
+            src.path().join("engineer.md"),
+            "---\nname: engineer\nrole: engineer\nextends: base-agent\nmodel: sonnet\n---\n\n# Engineer\n\nUPDATED engineer content.\n",
+        )
+        .unwrap();
+
+        let result = reset_agents(src.path(), tgt.path(), Some(&["engineer".to_string()])).unwrap();
+        assert_eq!(result.recomposed, vec!["engineer.md".to_string()]);
+        assert!(
+            result.backed_up.is_empty(),
+            "no backup expected for a routine bundle update"
+        );
+
+        let fresh = fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
+        assert!(fresh.contains("UPDATED engineer content."));
+    }
+
+    #[test]
+    fn reset_missing_source_dir_is_empty_result() {
+        let tgt = TempDir::new().unwrap();
+        let result = reset_agents(
+            Path::new("/nonexistent/trusty-mpm/agents"),
+            tgt.path(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(result, ResetResult::default());
+    }
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -13,6 +13,7 @@ pub mod agent;
 pub mod agent_builder;
 pub mod agent_deployer;
 pub mod agent_manifest;
+pub mod agent_reset;
 pub mod artifact;
 pub mod auto_resume;
 pub mod budget;


### PR DESCRIPTION
## Root cause

`~/.claude/agents/.trusty-mpm-manifest.json` tracked only the 5 `BASE-*.md` files. The ~36 composed per-agent files (`version-control.md`, `local-ops.md`, `rust-engineer.md`, …) were absent from the manifest, so `AgentManifest::is_managed()` returned `false` for every one of them and `deploy_agents_filtered` (`crates/trusty-mpm/src/core/agent_deployer.rs`) conservatively skipped them as user-owned — on both `tm install` and `tm install --force` (`--force` only governs the framework-artifact step, not the per-file composition checksum gate). There was no adoption or reset path, so an untracked file could never be reconciled again. Net effect: PR #2503's BASE-AGENT guidance (closing postmortems #2501/#2502) was live in `BASE-AGENT.md` but inert for every actually-dispatched agent.

## Fix (three parts, per the issue)

**1. Adoption.** In `deploy_agents_filtered`, a target file that exists but is untracked by the manifest is now compared against the fresh composition:
- Byte-identical → silently adopted (registered in the manifest, no rewrite). This is the common case for files that predate manifest tracking but were never hand-edited.
- Differs → still conservatively skipped (it may be genuinely user-owned), but now recorded in the new `DeployResult::untracked_modified` field. A single summary warning (not 36 individual lines) is emitted via `tracing::warn!` and surfaced in the CLI report, naming the count and pointing at `tm install --reset-agents`.

**2. `tm install --reset-agents [names...]`** (new file `crates/trusty-mpm/src/core/agent_reset.rs`, `reset_agents()`). Flag shape: `#[arg(long, num_args = 0.., value_delimiter = ',')] reset_agents: Option<Vec<String>>` — bare `--reset-agents` resets every bundled agent (`Some(vec![])`), `--reset-agents engineer,qa` restricts the scope. For each targeted agent:
- Target already matches the fresh composition → adopted (registered only, no rewrite).
- Target differs from fresh composition but matches the manifest's last-known checksum (a routine bundle update, not a user edit) → recomposed, no backup.
- Target differs from BOTH the manifest checksum (or has none) AND the fresh composition → backed up to `<file>.bak-<unix_nanos>` (mirroring the existing `<repo>.old-layout-backup-<unix_nanos>` convention in `daemon/managed_routes/inproject.rs`) before being overwritten, so no content is ever silently discarded.
- Requested name with no matching source agent → reported in `not_found`, doesn't abort the rest.

Prints a `recomposed / adopted / backed-up / not-found` summary table (`reset_report_lines` in `commands/install.rs`).

**3. Fresh-deploy registration** was already correct (every newly-deployed file was registered) — verified via `deploy_new_agent` and unaffected by this change.

**4. Session-launch path.** `session_launch::deploy_agents_filtered` and `managed_config::deploy_agents` both call directly into the same `deploy_agents_filtered` core function, so they inherit the adoption/warning behavior automatically — no divergent logic, confirmed by reading both call sites.

## Files changed

- `crates/trusty-mpm/src/core/agent_deployer.rs` — adoption + untracked-modified warning logic, `DeployResult::{adopted, untracked_modified}`, 2 new tests.
- `crates/trusty-mpm/src/core/agent_reset.rs` (new) — `reset_agents()` + `ResetResult`, 7 tests.
- `crates/trusty-mpm/src/core/mod.rs` — registers `agent_reset`.
- `crates/trusty-mpm/src/bin/tm/cli.rs` — `--reset-agents` flag on `Install`.
- `crates/trusty-mpm/src/bin/tm/main.rs` — dispatch wiring + new test module registration.
- `crates/trusty-mpm/src/bin/tm/commands/install.rs` — `install()` threads `reset_agents` through, `deploy_report_lines` renders adoption/warning lines, new `reset_report_lines`.
- `crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs` — updated `Install` match arms for the new field.
- `crates/trusty-mpm/src/bin/tm/tests_behavior_reset_agents_tests.rs` (new) — CLI parse + report-line tests, split into its own `_tests.rs`-suffixed file (1500-SLOC test cap) because `tests_behavior_a.rs` sits close to the 500-SLOC production cap (it doesn't match the test-file naming pattern despite living in `src/bin/tm/`).

## Test evidence

```
cargo build --workspace                                    → clean
cargo test -p trusty-mpm                                   → 2920 passed (lib) + 866 passed ×2 (tm/trusty-mpm bins) + integration suites, 0 failed
cargo clippy --workspace --all-targets -- -D warnings       → exit 0, no new warnings
cargo fmt --check                                           → clean
bash scripts/check_line_cap.sh                              → line-cap: 0 allowlisted, 0 violations — OK
```

New/updated tests: `deploy_adopts_untracked_byte_identical_file`, `deploy_flags_untracked_modified_file_for_reset` (agent_deployer.rs); `reset_writes_all_by_default`, `reset_filters_by_name`, `reset_reports_unknown_names`, `reset_adopts_matching_untracked_file`, `reset_backs_up_diverged_file`, `reset_recomposes_without_backup_when_matching_manifest_checksum`, `reset_missing_source_dir_is_empty_result` (agent_reset.rs); `cli_parses_install_reset_agents_all`, `cli_parses_install_reset_agents_filtered`, `deploy_report_lines_flags_adopted_and_untracked_modified`, `reset_report_lines_summarizes_counts` (tests_behavior_reset_agents_tests.rs). No test touches a real `~/.claude` — all use `tempfile::TempDir`.

## Operational note

After merging and re-installing, run `tm install --reset-agents` once to force-reconcile the ~36 pre-existing untracked agent files (they'll be backed up first if hand-edited, otherwise silently recomposed/adopted). That is what finally lets the #2503 BASE-AGENT guidance reach every live agent. Subsequent installs will adopt any remaining untracked-but-identical files automatically, and warn with the `--reset-agents` pointer for any that still diverge.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools