### PR TITLE
fix(trusty-mpm): per-request DaemonClient timeouts + TUI input protection (closes #2471)

### DIFF
--- a/crates/trusty-mpm/src/client/http_client/claude_config.rs
+++ b/crates/trusty-mpm/src/client/http_client/claude_config.rs
@@ -1,0 +1,136 @@
+//! Claude Code config-analyzer methods for [`DaemonClient`].
+//!
+//! Why: the `/config` command family (analyze, apply a recommendation, list
+//! checkpoints, deploy a built-in profile) is one cohesive concern against the
+//! daemon's `/claude-config*` routes. It lives in a sibling file (not
+//! `mod.rs`) so the client `mod.rs` stays under the 500-SLOC production cap
+//! (issue #2471) — the same reason [`super::managed`] and [`super::projects`]
+//! already live in their own files; this file can reach the `base`/`http`
+//! fields because they are `pub(in crate::client::http_client)`.
+//! What: one async method per config-analyzer endpoint, each building the URL
+//! from [`DaemonClient::base`], sending via the shared `reqwest::Client`, and
+//! deserializing the response.
+//! Test: covered by the executor's config test and the daemon's claude-config
+//! tests (live HTTP); no wire-shape unit test lives here today.
+
+use super::DaemonClient;
+use super::types::ConfigRecommendation;
+
+impl DaemonClient {
+    /// Analyze a project's Claude Code config via `GET /claude-config`.
+    ///
+    /// Why: the `/config` command surfaces analyzer recommendations.
+    /// What: `GET /claude-config?project=<path>`, returns one
+    /// [`ConfigRecommendation`] per recommendation.
+    /// Test: covered by the executor's config test.
+    pub async fn analyze_config(&self, project: &str) -> anyhow::Result<Vec<ConfigRecommendation>> {
+        let url = format!("{}/claude-config", self.base);
+        let body: serde_json::Value = self
+            .http
+            .get(&url)
+            .query(&[("project", project)])
+            .send()
+            .await?
+            .json()
+            .await?;
+        let recs = body["recommendations"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        Ok(recs
+            .iter()
+            .map(|r| ConfigRecommendation {
+                id: r
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                message: r
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| r.as_str())
+                    .unwrap_or("?")
+                    .to_string(),
+            })
+            .collect())
+    }
+
+    /// Apply a config recommendation via `POST /claude-config/apply`.
+    ///
+    /// Why: lets a UI act on a recommendation without hand-editing JSON.
+    /// What: POSTs the project path and recommendation id; returns the
+    /// checkpoint id on success.
+    /// Test: covered by the daemon's claude-config tests.
+    pub async fn apply_recommendation(
+        &self,
+        project: &str,
+        recommendation_id: &str,
+    ) -> anyhow::Result<String> {
+        let url = format!("{}/claude-config/apply", self.base);
+        let body: serde_json::Value = self
+            .http
+            .post(&url)
+            .json(&serde_json::json!({
+                "project": project,
+                "recommendation_id": recommendation_id,
+            }))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(body
+            .get("checkpoint_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string())
+    }
+
+    /// List a project's config checkpoints via `GET /claude-config/checkpoints`.
+    ///
+    /// Why: a UI offers a restore picker fed by this list.
+    /// What: returns the raw checkpoint JSON array.
+    /// Test: covered by the daemon's claude-config tests.
+    pub async fn list_checkpoints(&self, project: &str) -> anyhow::Result<Vec<serde_json::Value>> {
+        let url = format!("{}/claude-config/checkpoints", self.base);
+        let body: serde_json::Value = self
+            .http
+            .get(&url)
+            .query(&[("project", project)])
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(body["checkpoints"].as_array().cloned().unwrap_or_default())
+    }
+
+    /// Deploy a built-in profile via `POST /claude-config/deploy`.
+    ///
+    /// Why: lets a UI apply a configuration preset in one call.
+    /// What: POSTs the project path and profile name; returns the checkpoint id.
+    /// Test: covered by the daemon's claude-config tests.
+    pub async fn deploy_profile(
+        &self,
+        project: &str,
+        profile_name: &str,
+    ) -> anyhow::Result<String> {
+        let url = format!("{}/claude-config/deploy", self.base);
+        let body: serde_json::Value = self
+            .http
+            .post(&url)
+            .json(&serde_json::json!({
+                "project": project,
+                "profile_name": profile_name,
+            }))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(body
+            .get("checkpoint_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string())
+    }
+}

--- a/crates/trusty-mpm/src/client/http_client/config.rs
+++ b/crates/trusty-mpm/src/client/http_client/config.rs
@@ -1,0 +1,167 @@
+//! Timeout configuration and `reqwest::Client` construction for
+//! [`super::DaemonClient`].
+//!
+//! Why: `DaemonClient::new` used to mint a bare `reqwest::Client::new()` with
+//! no timeout at all (issue #2471, pre-existing since #2118). A daemon that
+//! accepts the TCP connection but never answers — e.g. wedged, or mid-restart
+//! with a stale listener — hung every caller forever, and the `tm projects`
+//! TUI awaits its poll step in the SAME task that reads keyboard input
+//! (`tui/project_ctl/mod.rs`), so the hang froze the whole screen, including
+//! `q`/Ctrl-C, until the OS-level socket timeout (minutes, platform-
+//! dependent). Bounding the client-level timeout turns an indefinite freeze
+//! into a bounded one. Split into its own file (not `mod.rs`) both because
+//! the timeout logic is a distinct, independently-testable concern and
+//! because `mod.rs` was already at 498/500 SLOC with no headroom to absorb it
+//! (same reasoning as the `claude_config`/`managed`/`projects` sibling-file
+//! split).
+//! What: [`default_client`] is what [`super::DaemonClient::new`] calls; it
+//! delegates to [`build_client`] (a pure function of the two `Duration`
+//! bounds) so the timeout behavior itself is unit-testable against tiny
+//! durations rather than the real 3s/10s production values.
+//! [`CHAT_REQUEST_TIMEOUT`] is a longer, explicit per-request override for
+//! the two endpoints that legitimately run long (see its own doc).
+//! Test: `tests::build_client_bounds_a_stalled_connection` drives a real
+//! request against a `TcpListener` that accepts but never answers, and
+//! asserts it errors within the (small, test-only) configured bound rather
+//! than hanging.
+
+use std::time::Duration;
+
+/// Ceiling on establishing the TCP connection to the daemon.
+///
+/// Why: the daemon is loopback-local in every deployed configuration, so a
+/// healthy connect completes in low single-digit milliseconds; 3s is
+/// generous slack for a loaded machine while still failing fast when the
+/// daemon process is simply not there.
+/// What: passed to `reqwest::ClientBuilder::connect_timeout` in
+/// [`build_client`].
+/// Test: `tests::default_client_uses_default_bounds` pins the value.
+pub(super) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Ceiling on one request/response round trip against the daemon.
+///
+/// Why: every non-chat `DaemonClient` endpoint is a simple local JSON call
+/// (list sessions, read breaker state, kill a session, …) that normally
+/// completes in milliseconds; 10s is well above any legitimate latency and
+/// still bounds a wedged daemon to a short, operator-visible freeze instead
+/// of the multi-minute OS socket timeout this replaces.
+/// What: passed to `reqwest::ClientBuilder::timeout` in [`build_client`] —
+/// this is the CLIENT-LEVEL default; [`CHAT_REQUEST_TIMEOUT`] overrides it
+/// per-request on the two endpoints that need longer.
+/// Test: `tests::default_client_uses_default_bounds` pins the value;
+/// `tests::build_client_bounds_a_stalled_connection` exercises the mechanism
+/// with a scaled-down bound.
+pub(super) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Per-request timeout override for the LLM-backed chat endpoints.
+///
+/// Why: `DaemonClient::llm_chat` (`POST /llm/chat`) and
+/// `DaemonClient::coordinator_chat` (`POST /api/v1/sessions/chat`) both wait
+/// SYNCHRONOUSLY for the daemon's own upstream OpenRouter round trip, which
+/// the daemon itself bounds at up to 120s
+/// (`OPENROUTER_REQUEST_TIMEOUT_SECS` in
+/// `trusty_common::chat::openai_compat::providers`). Applying
+/// [`DEFAULT_REQUEST_TIMEOUT`] to these two calls would abort a legitimate,
+/// merely-slow completion before the daemon's own timeout even has a chance
+/// to fire — trading a real hang for spurious failures on ordinary slow
+/// responses. 130s gives the daemon a 10s margin to answer (success or its
+/// own timeout error) after its upstream call resolves, while still being a
+/// hard, finite bound (never the pre-#2471 "no timeout at all").
+/// What: passed to `reqwest::RequestBuilder::timeout` at the `llm_chat` /
+/// `coordinator_chat` call sites — a per-request override, not a change to
+/// the client-level default every other endpoint uses.
+/// Test: `tests::default_client_uses_default_bounds` asserts it exceeds
+/// [`DEFAULT_REQUEST_TIMEOUT`].
+pub(super) const CHAT_REQUEST_TIMEOUT: Duration = Duration::from_secs(130);
+
+/// Build the `reqwest::Client` [`super::DaemonClient::new`] uses by default.
+///
+/// Why: the one production call site for [`build_client`], pinned to this
+/// module's default bounds so `DaemonClient::new` never regresses back to an
+/// unbounded client.
+/// What: delegates to [`build_client`] with [`DEFAULT_CONNECT_TIMEOUT`] and
+/// [`DEFAULT_REQUEST_TIMEOUT`].
+/// Test: `tests::default_client_uses_default_bounds`.
+pub(super) fn default_client() -> reqwest::Client {
+    build_client(DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT)
+}
+
+/// Build a `reqwest::Client` bounded by `connect_timeout` / `request_timeout`.
+///
+/// Why: factored out as a pure function of its bounds so the timeout
+/// behavior is unit-testable against tiny durations without waiting out the
+/// real 3s/10s production values (a full-duration test would be both slow
+/// and, on a loaded CI runner, borderline flaky).
+/// What: `reqwest::Client::builder().connect_timeout(..).timeout(..).build()`,
+/// falling back to `Client::default()` (an unbounded client) on the
+/// (practically unreachable — no TLS backend to fail to initialize for a
+/// plain-HTTP loopback client) builder error, matching
+/// `trusty_common::monitor::memory_client::MemoryClient::new`'s precedent
+/// rather than `unwrap()`-ing in library code.
+/// Test: `tests::build_client_bounds_a_stalled_connection`.
+pub(super) fn build_client(
+    connect_timeout: Duration,
+    request_timeout: Duration,
+) -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout)
+        .build()
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::time::Instant;
+
+    /// Why: proves `build_client` actually bounds a hung daemon rather than
+    /// trusting reqwest's defaults — issue #2471's TUI freeze was exactly
+    /// this shape: a peer that completes the TCP handshake but never writes
+    /// a response. A `TcpListener` that is bound and kept alive but never
+    /// `.accept()`-serviced reproduces that stall without a mock-server
+    /// dependency: the kernel completes the handshake from its accept
+    /// backlog, so the client's `connect()` succeeds and the request body is
+    /// written, but no response ever arrives.
+    /// What: builds a client with tiny (200ms connect / 300ms request)
+    /// bounds, issues a GET against the stalled listener, and asserts the
+    /// call errors well within a generous CI margin rather than hanging.
+    #[tokio::test]
+    async fn build_client_bounds_a_stalled_connection() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind stalling listener");
+        let addr = listener.local_addr().expect("read local_addr");
+
+        let client = build_client(Duration::from_millis(200), Duration::from_millis(300));
+        let url = format!("http://{addr}/");
+
+        let start = Instant::now();
+        let result = client.get(&url).send().await;
+        let elapsed = start.elapsed();
+
+        // `listener` stays alive (dropped at function end) for the whole
+        // request so the connection stalls rather than being refused outright.
+        assert!(result.is_err(), "expected the stalled request to time out");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "request took {elapsed:?}, expected it to be bounded by the ~300ms timeout"
+        );
+    }
+
+    /// Why: pins the production constants and their delegation so a future
+    /// edit can't silently widen [`DEFAULT_REQUEST_TIMEOUT`] back toward
+    /// "unbounded" or shrink [`CHAT_REQUEST_TIMEOUT`] below the daemon's own
+    /// upstream bound without a visible test failure.
+    /// What: asserts the three constants' values and that `default_client`
+    /// builds without panicking.
+    #[test]
+    fn default_client_uses_default_bounds() {
+        assert_eq!(DEFAULT_CONNECT_TIMEOUT, Duration::from_secs(3));
+        assert_eq!(DEFAULT_REQUEST_TIMEOUT, Duration::from_secs(10));
+        assert!(
+            CHAT_REQUEST_TIMEOUT > DEFAULT_REQUEST_TIMEOUT,
+            "the chat override must be longer than the default, not shorter"
+        );
+        let _ = default_client();
+    }
+}

--- a/crates/trusty-mpm/src/client/http_client/config.rs
+++ b/crates/trusty-mpm/src/client/http_client/config.rs
@@ -18,8 +18,9 @@
 //! delegates to [`build_client`] (a pure function of the two `Duration`
 //! bounds) so the timeout behavior itself is unit-testable against tiny
 //! durations rather than the real 3s/10s production values.
-//! [`CHAT_REQUEST_TIMEOUT`] is a longer, explicit per-request override for
-//! the two endpoints that legitimately run long (see its own doc).
+//! [`CHAT_REQUEST_TIMEOUT`] and [`PROVISION_REQUEST_TIMEOUT`] are longer,
+//! explicit per-request overrides for the endpoints that legitimately run
+//! long (see each constant's own doc).
 //! Test: `tests::build_client_bounds_a_stalled_connection` drives a real
 //! request against a `TcpListener` that accepts but never answers, and
 //! asserts it errors within the (small, test-only) configured bound rather
@@ -74,6 +75,28 @@ pub(super) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 /// [`DEFAULT_REQUEST_TIMEOUT`].
 pub(super) const CHAT_REQUEST_TIMEOUT: Duration = Duration::from_secs(130);
 
+/// Per-request timeout override for session-provisioning endpoints.
+///
+/// Why: `DaemonClient::spawn_managed_session` (`POST
+/// /api/v1/sessions/managed`) has a server handler that runs
+/// `WorkspaceProvisioner::provision`/`provision_in` SYNCHRONOUSLY inside the
+/// request — a git clone/fetch plus worktree add plus agent/skill deploy. The
+/// first spawn against a newly-registered project pays a full clone and can
+/// easily exceed [`DEFAULT_REQUEST_TIMEOUT`]'s 10s, which would hard-fail the
+/// client mid-provision while the daemon keeps working, orphaning a session
+/// the caller believes failed. 180s is bounded but generous: well above any
+/// legitimate clone/worktree/deploy sequence on a slow network or loaded
+/// machine, while still being a hard, finite bound (never the pre-#2471 "no
+/// timeout at all").
+/// What: passed to `reqwest::RequestBuilder::timeout` at the
+/// `spawn_managed_session` call site — a per-request override, not a change
+/// to the client-level default every other endpoint uses. Mirrors the
+/// [`CHAT_REQUEST_TIMEOUT`] pattern for the same reason: the endpoint's own
+/// server-side work legitimately runs long.
+/// Test: `tests::default_client_uses_default_bounds` asserts it exceeds
+/// [`DEFAULT_REQUEST_TIMEOUT`].
+pub(super) const PROVISION_REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
+
 /// Build the `reqwest::Client` [`super::DaemonClient::new`] uses by default.
 ///
 /// Why: the one production call site for [`build_client`], pinned to this
@@ -97,7 +120,10 @@ pub(super) fn default_client() -> reqwest::Client {
 /// (practically unreachable — no TLS backend to fail to initialize for a
 /// plain-HTTP loopback client) builder error, matching
 /// `trusty_common::monitor::memory_client::MemoryClient::new`'s precedent
-/// rather than `unwrap()`-ing in library code.
+/// rather than `unwrap()`-ing in library code. The fallback is logged at
+/// `warn` level (issue #2512 review) so a silent regression back to an
+/// UNBOUNDED default client — the exact failure mode this module exists to
+/// prevent — can never happen without a trace.
 /// Test: `tests::build_client_bounds_a_stalled_connection`.
 pub(super) fn build_client(
     connect_timeout: Duration,
@@ -107,7 +133,14 @@ pub(super) fn build_client(
         .connect_timeout(connect_timeout)
         .timeout(request_timeout)
         .build()
-        .unwrap_or_default()
+        .unwrap_or_else(|e| {
+            tracing::warn!(
+                error = %e,
+                "DaemonClient: reqwest::ClientBuilder::build failed, falling back to an \
+                 UNBOUNDED default client (connect_timeout/timeout bounds are NOT applied)"
+            );
+            reqwest::Client::default()
+        })
 }
 
 #[cfg(test)]
@@ -150,9 +183,11 @@ mod tests {
 
     /// Why: pins the production constants and their delegation so a future
     /// edit can't silently widen [`DEFAULT_REQUEST_TIMEOUT`] back toward
-    /// "unbounded" or shrink [`CHAT_REQUEST_TIMEOUT`] below the daemon's own
-    /// upstream bound without a visible test failure.
-    /// What: asserts the three constants' values and that `default_client`
+    /// "unbounded" or shrink [`CHAT_REQUEST_TIMEOUT`]/[`PROVISION_REQUEST_TIMEOUT`]
+    /// below the bound each exists to protect (the daemon's own upstream chat
+    /// timeout, and a worst-case first-clone provisioning respectively)
+    /// without a visible test failure.
+    /// What: asserts the four constants' values and that `default_client`
     /// builds without panicking.
     #[test]
     fn default_client_uses_default_bounds() {
@@ -161,6 +196,11 @@ mod tests {
         assert!(
             CHAT_REQUEST_TIMEOUT > DEFAULT_REQUEST_TIMEOUT,
             "the chat override must be longer than the default, not shorter"
+        );
+        assert_eq!(PROVISION_REQUEST_TIMEOUT, Duration::from_secs(180));
+        assert!(
+            PROVISION_REQUEST_TIMEOUT > DEFAULT_REQUEST_TIMEOUT,
+            "the provisioning override must be longer than the default, not shorter"
         );
         let _ = default_client();
     }

--- a/crates/trusty-mpm/src/client/http_client/managed.rs
+++ b/crates/trusty-mpm/src/client/http_client/managed.rs
@@ -17,6 +17,7 @@
 use anyhow::Context;
 
 use super::DaemonClient;
+use super::config;
 use super::types::{
     FleetByProjectWireResponse, FleetProjectGroupWire, ManagedActivityResponse,
     ManagedAdoptRequest, ManagedAdoptResponse, ManagedAnswerRequest, ManagedAnswerResponse,
@@ -89,9 +90,21 @@ impl DaemonClient {
 
     /// Spawn a managed session via `POST /api/v1/sessions/managed`.
     ///
-    /// Why: provision an isolated workspace and start a harness in it.
-    /// What: POSTs `req` and returns the daemon's [`ManagedSpawnResponse`].
-    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    /// Why: provision an isolated workspace and start a harness in it. The
+    /// server handler runs `WorkspaceProvisioner::provision`/`provision_in`
+    /// SYNCHRONOUSLY inside the request (git clone/fetch, worktree add,
+    /// agent/skill deploy) for both the clone-based and in-project spawn
+    /// paths — a first spawn against a newly-registered project can easily
+    /// exceed [`config::DEFAULT_REQUEST_TIMEOUT`]'s 10s client-level default.
+    /// Applying that default here would hard-fail the client mid-provision
+    /// while the daemon keeps working, orphaning a session the caller
+    /// believes failed, so this call opts into the longer
+    /// [`config::PROVISION_REQUEST_TIMEOUT`] instead (issue #2471 review
+    /// follow-up).
+    /// What: POSTs `req` with the provision-scoped request timeout and
+    /// returns the daemon's [`ManagedSpawnResponse`].
+    /// Test: live HTTP via `tests/session_manager_mvp.rs`;
+    /// `config::tests::default_client_uses_default_bounds` pins the constant.
     pub async fn spawn_managed_session(
         &self,
         req: &ManagedSpawnRequest,
@@ -101,6 +114,7 @@ impl DaemonClient {
             .http
             .post(&url)
             .json(req)
+            .timeout(config::PROVISION_REQUEST_TIMEOUT)
             .send()
             .await?
             .error_for_status()?

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -7,11 +7,19 @@
 //! What: [`DaemonClient`] holds a base URL plus a shared `reqwest::Client` and
 //! exposes one async method per daemon endpoint the UIs need — session listing
 //! and lifecycle, the event feed, breaker state, the overseer / tmux / config
-//! analyzer views, and the pairing handshake.
+//! analyzer views, and the pairing handshake. [`Self::new`] builds that
+//! `reqwest::Client` with the bounded connect/request timeouts from
+//! [`config`] (issue #2471) so a daemon that accepts a TCP connection but
+//! never answers cannot hang a caller forever — before this fix the TUI's
+//! poll loop shared a task with keyboard input, so an unbounded hang froze
+//! `q`/Ctrl-C too.
 //! Test: `cargo test -p trusty-mpm-client` checks URL construction and wire-shape
 //! deserialization; live HTTP is exercised by the executor tests against an
-//! in-process test daemon and by the daemon's own API tests.
+//! in-process test daemon and by the daemon's own API tests; `config`'s own
+//! tests exercise the timeout bound against a stalled socket.
 
+mod claude_config;
+mod config;
 pub mod deliverables;
 mod error;
 mod managed;
@@ -50,11 +58,17 @@ impl DaemonClient {
     /// Build a client targeting `base` (e.g. `http://127.0.0.1:7880`).
     ///
     /// Why: a UI is pointed at a daemon address resolved from a flag or the
-    /// service lock file.
-    /// What: stores the base URL and a fresh pooled `reqwest::Client`.
-    /// Test: `base_url_is_stored`.
+    /// service lock file. A daemon that accepted the TCP connection but never
+    /// answers must not be able to hang the caller indefinitely (issue
+    /// #2471) — the TUI polls this client from the same task that reads
+    /// keyboard input, so an unbounded client froze `q`/Ctrl-C along with
+    /// everything else.
+    /// What: stores the base URL and a fresh pooled `reqwest::Client` built
+    /// via [`config::default_client`] with bounded connect/request timeouts.
+    /// Test: `base_url_is_stored`; the timeout bound itself is covered by
+    /// `config::tests::build_client_bounds_a_stalled_connection`.
     pub fn new(base: impl Into<String>) -> Self {
-        Self::with_client(reqwest::Client::new(), base)
+        Self::with_client(config::default_client(), base)
     }
 
     /// Build a client targeting `base`, REUSING an existing `reqwest::Client`.
@@ -504,123 +518,6 @@ impl DaemonClient {
             .unwrap_or(0) as usize)
     }
 
-    /// Analyze a project's Claude Code config via `GET /claude-config`.
-    ///
-    /// Why: the `/config` command surfaces analyzer recommendations.
-    /// What: `GET /claude-config?project=<path>`, returns one
-    /// [`ConfigRecommendation`] per recommendation.
-    /// Test: covered by the executor's config test.
-    pub async fn analyze_config(&self, project: &str) -> anyhow::Result<Vec<ConfigRecommendation>> {
-        let url = format!("{}/claude-config", self.base);
-        let body: serde_json::Value = self
-            .http
-            .get(&url)
-            .query(&[("project", project)])
-            .send()
-            .await?
-            .json()
-            .await?;
-        let recs = body["recommendations"]
-            .as_array()
-            .cloned()
-            .unwrap_or_default();
-        Ok(recs
-            .iter()
-            .map(|r| ConfigRecommendation {
-                id: r
-                    .get("id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-                message: r
-                    .get("message")
-                    .and_then(|v| v.as_str())
-                    .or_else(|| r.as_str())
-                    .unwrap_or("?")
-                    .to_string(),
-            })
-            .collect())
-    }
-
-    /// Apply a config recommendation via `POST /claude-config/apply`.
-    ///
-    /// Why: lets a UI act on a recommendation without hand-editing JSON.
-    /// What: POSTs the project path and recommendation id; returns the
-    /// checkpoint id on success.
-    /// Test: covered by the daemon's claude-config tests.
-    pub async fn apply_recommendation(
-        &self,
-        project: &str,
-        recommendation_id: &str,
-    ) -> anyhow::Result<String> {
-        let url = format!("{}/claude-config/apply", self.base);
-        let body: serde_json::Value = self
-            .http
-            .post(&url)
-            .json(&serde_json::json!({
-                "project": project,
-                "recommendation_id": recommendation_id,
-            }))
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
-        Ok(body
-            .get("checkpoint_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string())
-    }
-
-    /// List a project's config checkpoints via `GET /claude-config/checkpoints`.
-    ///
-    /// Why: a UI offers a restore picker fed by this list.
-    /// What: returns the raw checkpoint JSON array.
-    /// Test: covered by the daemon's claude-config tests.
-    pub async fn list_checkpoints(&self, project: &str) -> anyhow::Result<Vec<serde_json::Value>> {
-        let url = format!("{}/claude-config/checkpoints", self.base);
-        let body: serde_json::Value = self
-            .http
-            .get(&url)
-            .query(&[("project", project)])
-            .send()
-            .await?
-            .json()
-            .await?;
-        Ok(body["checkpoints"].as_array().cloned().unwrap_or_default())
-    }
-
-    /// Deploy a built-in profile via `POST /claude-config/deploy`.
-    ///
-    /// Why: lets a UI apply a configuration preset in one call.
-    /// What: POSTs the project path and profile name; returns the checkpoint id.
-    /// Test: covered by the daemon's claude-config tests.
-    pub async fn deploy_profile(
-        &self,
-        project: &str,
-        profile_name: &str,
-    ) -> anyhow::Result<String> {
-        let url = format!("{}/claude-config/deploy", self.base);
-        let body: serde_json::Value = self
-            .http
-            .post(&url)
-            .json(&serde_json::json!({
-                "project": project,
-                "profile_name": profile_name,
-            }))
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
-        Ok(body
-            .get("checkpoint_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string())
-    }
-
     /// Request a one-time pairing code via `POST /pair/request`.
     ///
     /// Why: `tm pair` asks the local daemon for a code to type into the bot.
@@ -661,10 +558,18 @@ impl DaemonClient {
     ///
     /// Why: free-text Telegram messages and the TUI's `/chat` command route to
     /// the daemon's conversational endpoint; the UI owns the rolling history
-    /// and threads it through each turn.
-    /// What: POSTs `{ message, history }`; returns `Ok(Some(outcome))` with the
-    /// reply and updated history on success, `Ok(None)` when the daemon answers
-    /// `503` (LLM chat not configured), and `Err` on transport failure.
+    /// and threads it through each turn. The daemon answers synchronously
+    /// only after its own upstream LLM round trip completes, which is bounded
+    /// at up to 120s (`OPENROUTER_REQUEST_TIMEOUT_SECS` in
+    /// `trusty_common::chat::openai_compat::providers`) — [`config::DEFAULT_REQUEST_TIMEOUT`]
+    /// would abort a legitimate slow completion before the daemon's own
+    /// timeout even fires, so this call opts into
+    /// [`config::CHAT_REQUEST_TIMEOUT`] instead (issue #2471's audit of
+    /// long-running endpoints).
+    /// What: POSTs `{ message, history }` with the chat-scoped request
+    /// timeout; returns `Ok(Some(outcome))` with the reply and updated
+    /// history on success, `Ok(None)` when the daemon answers `503` (LLM chat
+    /// not configured), and `Err` on transport failure.
     /// Test: `llm_chat_response_deserializes` covers the wire shape.
     pub async fn llm_chat(
         &self,
@@ -676,6 +581,7 @@ impl DaemonClient {
             .http
             .post(&url)
             .json(&serde_json::json!({ "message": message, "history": history }))
+            .timeout(config::CHAT_REQUEST_TIMEOUT)
             .send()
             .await?;
         if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
@@ -720,7 +626,10 @@ impl DaemonClient {
     /// `Ok(Some(outcome))` on success, `Ok(None)` when the daemon answers `503`
     /// (LLM not configured for a non-prefixed message), and `Err` on transport
     /// failure. On the action path the outcome's `actions_taken` lists any verbs
-    /// that ran.
+    /// that ran. Like [`Self::llm_chat`], this waits on the daemon's own
+    /// upstream LLM round trip (up to 120s), so it opts into
+    /// [`config::CHAT_REQUEST_TIMEOUT`] rather than the shorter client
+    /// default (issue #2471).
     /// Test: `coordinator_chat_outcome_deserializes`,
     /// `coordinator_chat_serializes_actions_flag` cover the wire shape.
     pub async fn coordinator_chat(
@@ -734,6 +643,7 @@ impl DaemonClient {
             .http
             .post(&url)
             .json(&coordinator_chat_body(message, history, actions))
+            .timeout(config::CHAT_REQUEST_TIMEOUT)
             .send()
             .await?;
         if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {


### PR DESCRIPTION
## Root cause

`DaemonClient::new` (`crates/trusty-mpm/src/client/http_client/mod.rs:55-57`, pre-fix) built a bare `reqwest::Client::new()` with **no timeout at all**. The `tm projects` TUI (`tui/project_ctl/mod.rs`'s `run_loop`) `.await`s its poll step (`project_ctl_poll_daemon`) sequentially in the SAME task that reads keyboard input. A daemon that accepts the TCP connection but never answers therefore froze the entire TUI — including `q`/Ctrl-C — until the OS-level socket timeout (multi-minute, platform-dependent). Pre-existing since #2118; surfaced in #2469's review.

## Fix

**1. Bounded client-level timeout.** `DaemonClient::new` now builds its client via a new `client/http_client/config.rs`: `connect_timeout = 3s`, `request timeout = 10s`. Every `DaemonClient::new` consumer (the `tm projects`/coordinator TUIs, and any CLI path that doesn't hand in its own pre-configured client via `with_client`) gets this automatically.

Precedent for these values: `trusty_common::monitor::memory_client::MemoryClient::new` (3s `REQUEST_TIMEOUT`), `trusty_common::daemon_guard`/`mcp::daemon_bridge` (750ms one-shot probes), `trusty-console`'s proxy client (30s, but that one deliberately proxies arbitrary upstream calls). 3s connect / 10s request is generous for a loopback JSON call while still bounding a wedged daemon to a short, visible freeze instead of an indefinite one.

`with_client` (the CLI's shared-client constructor) is left untouched — its documented contract is that callers who already configured a `reqwest::Client` own that configuration; changing that is a separate, broader change outside this issue's scope.

**2. Long-running-endpoint audit.** Grepped every `DaemonClient` method for anything that isn't a fast local JSON call. Two are NOT fast: `llm_chat` (`POST /llm/chat`) and `coordinator_chat` (`POST /api/v1/sessions/chat`) both wait synchronously on the daemon's own upstream OpenRouter round trip, which the daemon itself bounds at up to **120s** (`OPENROUTER_REQUEST_TIMEOUT_SECS` in `trusty_common::chat::openai_compat::providers`). Applying the 10s default there would abort a legitimate slow completion before the daemon's own timeout even fires. Both now opt into `config::CHAT_REQUEST_TIMEOUT` (130s — a 10s margin over the daemon's own bound) via `RequestBuilder::timeout(..)`, a per-request override rather than raising the global default. `doctor`, `session_output`, tmux/config-analyzer calls, etc. are all fast local calls and stay on the 10s default.

**3. SLOC split.** `mod.rs` was at 498/500 SLOC; adding the builder wiring would have breached the cap. Split into:
   - `client/http_client/config.rs` — the timeout constants + `default_client`/`build_client` (pure, parameterized by `Duration` so it's testable against tiny bounds).
   - `client/http_client/claude_config.rs` — moved the four claude-config methods (`analyze_config`, `apply_recommendation`, `list_checkpoints`, `deploy_profile`) out verbatim, following the existing `managed.rs`/`projects.rs`/`deliverables.rs` sibling-file precedent (impl blocks split across files, reaching `base`/`http` via their `pub(in crate::client::http_client)` visibility).
   `mod.rs` is now well under 500 SLOC; `bash scripts/check_line_cap.sh` passes with 0 allowlisted / 0 violations.

**4. TUI input-loop hardening — timeout-only, restructuring deferred.** Evaluated racing the daemon poll against keyboard input via `tokio::select!` (would need `crossterm::event::EventStream` instead of the current blocking `event::poll`/`event::read`). Did NOT implement it, for two concrete reasons:
   - The sibling screen (`tui/coordinator/mod.rs` `run_loop`) has the identical shape and an existing, explicit comment: *"Converting the input pump to `crossterm::event::EventStream` + `tokio::select!` is tracked as a separate follow-up."* The team already scoped this as its own dedicated change, not something to bundle into an unrelated fix.
   - `tui/project_ctl/poll/mod.rs` is being concurrently modified by another engineer fixing #2470 (activity-pane state) in a separate worktree; restructuring the run loop's poll/input relationship there risks unnecessary merge conflicts.

   So this PR bounds the freeze to ~10s (down from potentially minutes) rather than eliminating it. **Follow-up shape**, applicable to both `tui/project_ctl/mod.rs::run_loop` and `tui/coordinator/mod.rs::run_loop`: replace the blocking `crossterm::event::{poll,read}` pump with `crossterm::event::EventStream` (a `Stream`), and `tokio::select!` it against the daemon poll future so a keypress is serviced immediately even mid-poll — likely by spawning the poll onto a background task that reports back over an `mpsc` channel, since `ProjectCtlState`/`CoordinatorState` are single-owned by the render loop today.

## Tests

New tests in `client/http_client/config.rs`:
- `default_client_uses_default_bounds` — pins the three constants (3s / 10s / 130s) and that the chat override exceeds the default, plus a smoke-build of `default_client()`.
- `build_client_bounds_a_stalled_connection` — no mock-server harness exists for this crate's client tests, so per the issue's suggested fallback: a `std::net::TcpListener` bound but never `.accept()`-serviced (the kernel completes the handshake from its backlog, so `connect()` succeeds and the request is written, but no response ever arrives) — proves a real request against it errors within a small (200ms/300ms) override rather than hanging.

## Verification

```
cargo build --workspace                                    → clean
cargo test -p trusty-mpm                                    → 2922 passed lib + 866+866 (bin unittests) + all integration binaries, 0 failed
cargo test -p trusty-mpm --lib client::http_client           → 55 passed (incl. the 2 new config tests), 0 failed
cargo clippy --workspace --all-targets -- -D warnings        → clean (only pre-existing unrelated tga MSRV-mismatch warnings)
cargo fmt --check                                            → clean
bash scripts/check_line_cap.sh                                → line-cap: 0 allowlisted, 0 violations — OK.
```

Known flake `core::home_trust_seed::tests::is_idempotent` ran clean in isolation and as part of the full suite.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools