### PR TITLE
fix(trusty-mpm): activity pane unavailable state after persistent per-session fetch failures (closes #2470)

### DIFF
--- a/crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs
@@ -1,4 +1,6 @@
-//! Activity pane (bottom strip, 4 rows) — DOC-35 §5 pane 3, live-wired (#2119).
+//! Activity pane (bottom strip, 4 rows) — DOC-35 §5 pane 3, live-wired
+//! (#2119). Explicit "unavailable" state after persistent per-session fetch
+//! failures (#2470).
 //!
 //! Why: DOC-35 §5.4 sources this pane from `GET .../{id}/activity` (`state`,
 //! `summary`, `pending_decision`, `proposed_default`, plus a short
@@ -8,17 +10,25 @@
 //! now prefers [`ProjectCtlState::activity_for_selected`] (populated by
 //! [`super::super::poll::refresh_activity`] on the same poll cadence as the
 //! Projects/Sessions panes) and falls back to the static [`SessionRow`]
-//! fields — with an explanatory suffix, never silently — for the two windows
-//! where no live snapshot is available yet: right after a selection changes
-//! (the fetch for the new selection has not landed) and while the daemon is
-//! down with no prior live fetch to show as stale.
+//! fields — with an explanatory suffix, never silently — for the windows
+//! where no live snapshot is available: right after a selection changes (the
+//! fetch for the new selection has not landed), while the daemon is down
+//! with no prior live fetch to show as stale, and — #2470 — when the daemon
+//! IS reachable but this session's `/activity` fetch has failed
+//! non-transport-classified [`super::super::state::ACTIVITY_UNAVAILABLE_THRESHOLD`]
+//! times in a row (a 404 from an older daemon lacking the endpoint, a GC'd
+//! session, a malformed body): without this branch, `activity_for_selected`
+//! stays `None` forever and the pane would render "loading…" indefinitely
+//! instead of ever surfacing the persistent failure.
 //! What: [`activity_lines`] is a pure builder (unit tested without a
-//! terminal) covering four shapes: no session selected; live data available
+//! terminal) covering five shapes: no session selected; live data available
 //! (optionally suffixed `[stale]` when the last fetch failed but a prior one
-//! is being kept); daemon reachable but no live fetch has landed for this
-//! selection yet ("loading…"); daemon down with nothing live to show yet
-//! ("daemon unreachable"). [`render`] wraps it in a bordered `Paragraph`.
-//! Test: `tests` covers all four shapes above.
+//! is being kept); no live snapshot and the failure streak has crossed the
+//! threshold ("activity unavailable for this session"); daemon reachable, no
+//! live snapshot yet, streak below threshold ("loading…"); daemon down with
+//! nothing live to show yet ("daemon unreachable"). [`render`] wraps it in a
+//! bordered `Paragraph`.
+//! Test: `tests` covers all five shapes above.
 
 use ratatui::{
     Frame,
@@ -54,8 +64,13 @@ fn decision_segment(pending: &Option<String>, proposed: &Option<String>) -> Stri
 /// What: no selection → a placeholder. A live snapshot that matches the
 /// current selection (`state.activity_for_selected()`) → header, `state:
 /// <word><decision segment>[ [stale]]`, `summary: <text>`, then the raw-pane
-/// tail lines verbatim. No live snapshot yet, daemon reachable → header plus
-/// the static record's state/decision segment suffixed `· loading live
+/// tail lines verbatim. No live snapshot, and
+/// `state.activity_unavailable_for_selected()` (#2470) → header plus an
+/// explicit "activity unavailable for this session" line — checked BEFORE
+/// the loading/daemon-down fallbacks below, since a persistent per-session
+/// failure is a more specific, more useful signal than either. No live
+/// snapshot yet, daemon reachable, streak below threshold → header plus the
+/// static record's state/decision segment suffixed `· loading live
 /// activity…`. No live snapshot yet, daemon down → header plus an explicit
 /// "daemon unreachable" line (DOC-35's graceful-daemon-down requirement: an
 /// explicit message, never a silent blank pane).
@@ -63,7 +78,8 @@ fn decision_segment(pending: &Option<String>, proposed: &Option<String>) -> Stri
 /// `activity_lines_shows_pending_decision_from_live_activity`,
 /// `activity_lines_marks_stale_activity`,
 /// `activity_lines_falls_back_while_loading`,
-/// `activity_lines_reports_daemon_unreachable_with_no_prior_fetch`.
+/// `activity_lines_reports_daemon_unreachable_with_no_prior_fetch`,
+/// `activity_lines_reports_unavailable_after_persistent_failures`.
 pub fn activity_lines(state: &ProjectCtlState) -> Vec<String> {
     let Some(session) = state.selected_session() else {
         return vec![
@@ -87,6 +103,15 @@ pub fn activity_lines(state: &ProjectCtlState) -> Vec<String> {
         ];
         lines.extend(activity.raw_pane_tail.iter().cloned());
         return lines;
+    }
+
+    if state.activity_unavailable_for_selected() {
+        return vec![
+            header,
+            "activity unavailable for this session".to_string(),
+            "(the daemon is reachable, but repeated fetches for this session's activity failed)"
+                .to_string(),
+        ];
     }
 
     if state.daemon_reachable {
@@ -259,5 +284,26 @@ mod tests {
         let lines = activity_lines(&state);
         assert!(lines.iter().any(|l| l.contains("daemon unreachable")));
         assert!(lines.iter().any(|l| l.contains("last known state: active")));
+    }
+
+    /// #2470 — a persistent per-session `/activity` failure (daemon healthy,
+    /// this session's fetch itself keeps failing) must eventually stop
+    /// rendering "loading…" forever and report an explicit unavailable
+    /// state instead.
+    #[test]
+    fn activity_lines_reports_unavailable_after_persistent_failures() {
+        let session = base_session();
+        let mut state = state_with_session(session.clone());
+        state.daemon_reachable = true;
+        for _ in 0..3 {
+            state.activity_failures.record_failure(&session.id);
+        }
+        let lines = activity_lines(&state);
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("activity unavailable for this session"))
+        );
+        assert!(!lines.iter().any(|l| l.contains("loading live activity")));
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/mod.rs
@@ -23,10 +23,18 @@
 //! [`rows::activity_from_response`]) live in the [`rows`] submodule (split
 //! out by #2476 to keep this file under the 500-SLOC production cap) and are
 //! re-exported here so existing callers keep using `poll::project_to_row`
-//! etc.
-//! Test: `tests` covers the daemon-down / stale-keep branches against a
-//! guaranteed-dead client (mirroring
-//! `tui::coordinator::poll::tests::poll_marks_unreachable_clears_sessions`);
+//! etc. A PERSISTENT non-transport `/activity` fetch failure for the
+//! selected session (an older daemon lacking the endpoint, a GC'd session, a
+//! malformed body) is classified by [`classify_activity_error`] and tracked
+//! by [`super::state::ActivityFailureStreak`] so the pane can eventually
+//! report it explicitly instead of rendering "loading…" forever (#2470); see
+//! [`apply_activity_outcome`] for the pure state-transition rules.
+//! Test: `tests` (split into the sibling `tests.rs` file, a recognized
+//! test-file path under the 1500-SLOC test cap, to keep THIS file under the
+//! 500-SLOC production cap once the #2470 tests were added) covers the
+//! daemon-down / stale-keep branches against a guaranteed-dead client
+//! (mirroring `tui::coordinator::poll::tests::poll_marks_unreachable_clears_sessions`)
+//! plus the failure-classification and failure-streak state machine;
 //! [`rows`]'s own `tests` covers the pure projections; the daemon-UP path is
 //! exercised manually / by launching the TUI.
 
@@ -40,7 +48,7 @@ pub(crate) use rows::{activity_from_response, live_session_rows, project_to_row}
 #[cfg(test)]
 pub(crate) use rows::session_to_row;
 
-use crate::client::DaemonClient;
+use crate::client::{DaemonClient, ManagedActivityResponse};
 use crate::project::Project;
 
 #[cfg(test)]
@@ -206,28 +214,116 @@ fn sync_open_view_deliverables(state: &mut ProjectCtlState, project_name: &str) 
 /// larger poll function. Runs AFTER the project/session refresh above so
 /// `state.selected_session()` reflects the just-synced navigation, not a
 /// pre-refresh selection that may have shrunk out of range.
-/// What: no selection → clears `state.activity`. A selection with the daemon
-/// unreachable, or whose fetch errors, → if `state.activity` already targets
-/// this session id it is marked `stale` (kept, not discarded, per the
-/// graceful-daemon-down requirement); otherwise cleared (nothing recent
-/// enough to show as stale). A successful fetch replaces `state.activity`
-/// outright with a fresh, non-stale [`ActivityInfo`].
+/// What: no selection → clears `state.activity` and the failure streak. A
+/// daemon-unreachable poll is treated as a [`ActivityFetchFailure::Transport`]
+/// outcome (the whole daemon looks down, same as a connect/timeout error);
+/// otherwise the fetch's `Result` is classified via
+/// [`classify_activity_error`] and handed to [`apply_activity_outcome`],
+/// which owns the actual stale-keep / failure-streak / unavailable rules
+/// (#2470).
 /// Test: `refresh_activity_marks_existing_activity_stale_on_fetch_failure`,
-/// `refresh_activity_clears_when_no_session_is_selected`.
+/// `refresh_activity_clears_when_no_session_is_selected`;
+/// [`apply_activity_outcome`]'s own doc covers the failure-streak rules.
 async fn refresh_activity(state: &mut ProjectCtlState, client: &DaemonClient) {
     let Some(session_id) = state.selected_session().map(|s| s.id.clone()) else {
         state.activity = None;
+        state.activity_failures.reset();
         return;
     };
 
-    if state.daemon_reachable {
-        match client.managed_session_activity(&session_id).await {
-            Ok(resp) => {
-                state.activity = Some(activity_from_response(session_id, resp));
-                return;
-            }
-            Err(_) => { /* fall through to the stale-or-clear handling below */ }
+    if !state.daemon_reachable {
+        apply_activity_outcome(state, session_id, Err(ActivityFetchFailure::Transport));
+        return;
+    }
+
+    let outcome = client
+        .managed_session_activity(&session_id)
+        .await
+        .map_err(|e| classify_activity_error(&e));
+    apply_activity_outcome(state, session_id, outcome);
+}
+
+/// Coarse classification of a `/activity` fetch failure (#2470).
+///
+/// Why: distinguishes "the whole daemon looks down or is restarting"
+/// (transport — connection refused/timeout) from "the daemon answered, but
+/// THIS session's activity fetch is itself broken" (non-transport — an HTTP
+/// error status or an undecodable body: an older daemon lacking the
+/// endpoint, a GC'd session, a malformed payload). Only the latter should
+/// ever advance [`super::state::ActivityFailureStreak`] — a transport
+/// failure means the daemon itself is unreachable, which the existing
+/// stale-keep path already covers on its own, and flapping connectivity must
+/// never be mistaken for "this session's activity is permanently gone".
+/// What: [`classify_activity_error`] walks the `anyhow::Error` cause chain
+/// for a [`reqwest::Error`] whose `is_connect()` or `is_timeout()` is `true`
+/// → [`Self::Transport`]; anything else (a status/body error from
+/// [`crate::client::http_client::error::response_or_body_error`], a decode
+/// error, or no `reqwest::Error` in the chain at all) → [`Self::NonTransport`].
+/// Test: `classify_status_error_is_non_transport`,
+/// `classify_connect_error_is_transport` (in `tests`, below).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActivityFetchFailure {
+    /// Connection refused/timeout — the whole daemon looks down.
+    Transport,
+    /// The daemon answered; this session's activity fetch failed anyway.
+    NonTransport,
+}
+
+/// See [`ActivityFetchFailure`]'s own doc.
+fn classify_activity_error(err: &anyhow::Error) -> ActivityFetchFailure {
+    let is_transport = err
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<reqwest::Error>())
+        .any(|e| e.is_connect() || e.is_timeout());
+    if is_transport {
+        ActivityFetchFailure::Transport
+    } else {
+        ActivityFetchFailure::NonTransport
+    }
+}
+
+/// Apply one `/activity` fetch's outcome to `state.activity` and
+/// `state.activity_failures` (#2470).
+///
+/// Why: pulled out of [`refresh_activity`] as a pure, synchronously testable
+/// function — no daemon, no async, no `reqwest` types in its signature — so
+/// the exact state-transition rules (stale-keep vs. reset vs. crossing the
+/// unavailable threshold) are unit-testable with typed inputs, mirroring how
+/// [`rows::activity_from_response`] keeps the pure DTO projection out of the
+/// async fetch.
+/// What: `Ok(resp)` → replaces `state.activity` with a fresh, non-stale
+/// [`ActivityInfo`] and resets the failure streak
+/// ([`super::state::ActivityFailureStreak::reset`]).
+/// `Err(ActivityFetchFailure::NonTransport)` → records one failure in the
+/// streak for `session_id` ([`super::state::ActivityFailureStreak::record_failure`]);
+/// once that streak crosses [`super::state::ACTIVITY_UNAVAILABLE_THRESHOLD`],
+/// [`ProjectCtlState::activity_unavailable_for_selected`] flips to `true`
+/// and the Activity pane renders "unavailable" instead of "loading…"/stale
+/// data. `Err(ActivityFetchFailure::Transport)` → never touches the streak.
+/// Both `Err` arms then apply the SAME stale-keep-or-clear rule to
+/// `state.activity` itself: mark `stale = true` if it already targets
+/// `session_id`, else clear it (nothing recent enough to show as stale) —
+/// unchanged from the pre-#2470 behavior.
+/// Test: `apply_activity_outcome_success_resets_streak_and_shows_data`,
+/// `apply_activity_outcome_non_transport_failures_reach_unavailable_threshold`,
+/// `apply_activity_outcome_transport_failure_never_advances_streak`,
+/// `apply_activity_outcome_success_after_failures_resets_streak`,
+/// `apply_activity_outcome_session_switch_starts_a_fresh_streak`.
+fn apply_activity_outcome(
+    state: &mut ProjectCtlState,
+    session_id: String,
+    outcome: Result<ManagedActivityResponse, ActivityFetchFailure>,
+) {
+    match outcome {
+        Ok(resp) => {
+            state.activity = Some(activity_from_response(session_id, resp));
+            state.activity_failures.reset();
+            return;
         }
+        Err(ActivityFetchFailure::NonTransport) => {
+            state.activity_failures.record_failure(&session_id);
+        }
+        Err(ActivityFetchFailure::Transport) => { /* never touches the streak */ }
     }
 
     match &mut state.activity {
@@ -303,222 +399,4 @@ async fn fetch_projects_and_sessions(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::client::ManagedSessionSummary;
-
-    fn summary(id: &str, state: &str) -> ManagedSessionSummary {
-        ManagedSessionSummary {
-            id: id.to_string(),
-            name: format!("s-{id}"),
-            state: state.to_string(),
-            workspace_path: None,
-            repo_url: None,
-            branch: Some("main".to_string()),
-            created_at: None,
-            last_activity_at: None,
-            pending_decision: None,
-            proposed_default: None,
-            source_id: None,
-            task: Some("do the thing".to_string()),
-            cwd: None,
-            claude_session_id: None,
-            deliverable_id: None,
-            pane_id: None,
-        }
-    }
-
-    // ---- daemon-down branches (guaranteed-dead client, no live daemon needed) ---
-
-    /// A `127.0.0.1` URL bound to an ephemeral port, then immediately dropped
-    /// so a later connect is refused — mirrors
-    /// `tui::coordinator::tests::dead_loopback_url`.
-    fn dead_loopback_url() -> String {
-        let listener =
-            std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral loopback port");
-        let port = listener.local_addr().expect("read bound local addr").port();
-        drop(listener);
-        format!("http://127.0.0.1:{port}")
-    }
-
-    #[tokio::test]
-    async fn poll_marks_unreachable_clears_state() {
-        let discovered = crate::core::resolve_daemon_url(None);
-        let probe = DaemonClient::new(discovered.clone());
-        if probe.is_healthy().await {
-            eprintln!("skipping: a reachable daemon was discovered at {discovered}");
-            return;
-        }
-
-        let mut state = ProjectCtlState {
-            projects: vec![ProjectRow {
-                name: "widget".to_string(),
-                repo_url: "https://github.com/acme/widget".to_string(),
-                live_count: 1,
-                total_count: 1,
-            }],
-            daemon_reachable: true, // pretend a prior poll had succeeded
-            ..Default::default()
-        };
-        state
-            .sessions_by_project
-            .insert("widget".to_string(), vec![]);
-        let mut client = DaemonClient::new(dead_loopback_url());
-
-        project_ctl_poll_daemon(&mut state, &mut client).await;
-
-        assert!(!state.daemon_reachable);
-        assert!(state.projects.is_empty());
-        assert!(state.sessions_by_project.is_empty());
-    }
-
-    fn seeded_activity_state(session_id: &str) -> ProjectCtlState {
-        let mut state = ProjectCtlState {
-            projects: vec![ProjectRow {
-                name: "widget".to_string(),
-                repo_url: "https://github.com/acme/widget".to_string(),
-                live_count: 1,
-                total_count: 1,
-            }],
-            daemon_reachable: true,
-            ..Default::default()
-        };
-        state.sessions_by_project.insert(
-            "widget".to_string(),
-            vec![session_to_row(summary(session_id, "active"))],
-        );
-        state.projects_nav.sync_len(state.projects.len());
-        state.sessions_nav.sync_len(state.current_sessions().len());
-        state
-    }
-
-    /// `refresh_activity` is called directly (bypassing `project_ctl_poll_daemon`'s
-    /// own health probe) so this test stays deterministic regardless of whether
-    /// a real daemon happens to be discoverable on this machine — it only needs
-    /// the `/activity` HTTP call itself to fail, which a dead loopback port
-    /// guarantees.
-    #[tokio::test]
-    async fn refresh_activity_marks_existing_activity_stale_on_fetch_failure() {
-        let mut state = seeded_activity_state("s1");
-        state.activity = Some(ActivityInfo {
-            session_id: "s1".to_string(),
-            state: "working".to_string(),
-            summary: "last known summary".to_string(),
-            pending_decision: None,
-            proposed_default: None,
-            raw_pane_tail: vec!["$ cargo test".to_string()],
-            stale: false,
-        });
-        let client = DaemonClient::new(dead_loopback_url());
-
-        refresh_activity(&mut state, &client).await;
-
-        let activity = state
-            .activity
-            .expect("last-known activity must be kept, not discarded");
-        assert!(activity.stale, "a failed fetch must mark it stale");
-        assert_eq!(
-            activity.summary, "last known summary",
-            "the last-known data must be kept, not cleared"
-        );
-    }
-
-    #[tokio::test]
-    async fn refresh_activity_clears_when_no_session_is_selected() {
-        let mut state = ProjectCtlState {
-            daemon_reachable: true,
-            activity: Some(ActivityInfo {
-                session_id: "orphaned".to_string(),
-                state: "working".to_string(),
-                summary: "stale from a since-deselected session".to_string(),
-                pending_decision: None,
-                proposed_default: None,
-                raw_pane_tail: vec![],
-                stale: false,
-            }),
-            ..Default::default()
-        };
-        let client = DaemonClient::new(dead_loopback_url());
-
-        refresh_activity(&mut state, &client).await;
-
-        assert!(state.activity.is_none());
-    }
-
-    #[tokio::test]
-    async fn refresh_deliverables_clears_when_no_project_selected() {
-        let mut state = ProjectCtlState {
-            daemon_reachable: true,
-            deliverables: Some(vec![]),
-            ..Default::default()
-        };
-        let client = DaemonClient::new(dead_loopback_url());
-
-        refresh_deliverables(&mut state, &client).await;
-
-        assert!(state.deliverables.is_none());
-    }
-
-    #[tokio::test]
-    async fn refresh_deliverables_clears_on_daemon_down() {
-        let mut state = seeded_activity_state("s1");
-        state.daemon_reachable = false;
-        let client = DaemonClient::new(dead_loopback_url());
-
-        refresh_deliverables(&mut state, &client).await;
-
-        assert!(
-            state.deliverables.is_none(),
-            "a project IS selected here, but daemon_reachable=false must still reset to \
-             Unknown, matching state.projects/sessions_by_project's own daemon-down handling"
-        );
-    }
-
-    /// THE review-required regression test: `daemon_reachable == true` (the
-    /// daemon is otherwise healthy — the earlier health probe succeeded) but
-    /// `list_deliverables` itself fails on this one tick. Previously this
-    /// cleared `state.deliverables` outright, which made
-    /// `deliverable_link_state` report every previously-resolved session as
-    /// `Dangling` — a false "the Deliverable was deleted" signal for what was
-    /// really just one dropped HTTP call. The fix: keep the last-known-good
-    /// `Some(list)` untouched, mirroring `refresh_activity`'s stale-keep
-    /// pattern for `ActivityInfo`.
-    #[tokio::test]
-    async fn refresh_deliverables_keeps_stale_list_on_transient_fetch_failure() {
-        let mut state = seeded_activity_state("s1");
-        let known_id = crate::deliverable::DeliverableId::new();
-        state.deliverables = Some(vec![crate::deliverable::Deliverable {
-            id: known_id,
-            project_name: "widget".to_string(),
-            name: "OAuth2 flow".to_string(),
-            description: String::new(),
-            kind: crate::deliverable::DeliverableKind::Feature,
-            ticket_ref: None,
-            spec_ref: None,
-            status: crate::deliverable::DeliverableStatus::InProgress,
-            estimated_effort: crate::deliverable::EstimationTier::M,
-            created_at: chrono::Utc::now(),
-            target_date: None,
-        }]);
-        // `seeded_activity_state` leaves `daemon_reachable = true` — the
-        // failure here is scoped to `list_deliverables` alone, via a dead
-        // loopback client, exactly the "endpoint fails, daemon otherwise up"
-        // case the review flagged.
-        let client = DaemonClient::new(dead_loopback_url());
-
-        refresh_deliverables(&mut state, &client).await;
-
-        let kept = state
-            .deliverables
-            .as_ref()
-            .expect("a transient fetch failure must KEEP the last-known-good list, not clear it");
-        assert_eq!(kept.len(), 1);
-        assert_eq!(kept[0].id, known_id);
-        assert_eq!(
-            state.deliverable_link_state(&known_id.to_string()),
-            crate::tui::project_ctl::state::DeliverableLinkState::Resolved,
-            "a previously-resolved link must stay Resolved through one bad poll, \
-             never flip to Dangling"
-        );
-    }
-}
+mod tests;

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs
@@ -1,0 +1,464 @@
+//! Unit tests for [`super`] (`poll::mod`) — split into a `tests.rs` file
+//! (recognized test-file path, 1500-SLOC cap) so the production poll logic
+//! in `mod.rs` stays under the 500-SLOC production cap once the #2470
+//! failure-streak tests were added.
+//!
+//! Why: `mod.rs` shares its private items via `use super::*;`, so this file
+//! is a plain extraction (behavior unchanged) — see git history for the
+//! pre-split version. Split out during #2470's fix rather than at the
+//! (already exercised, #2476) `rows` split point, since these tests are
+//! specific to `refresh_activity`/`refresh_deliverables`/`project_ctl_poll_daemon`,
+//! not the pure row projections `rows.rs` covers.
+//! What: daemon-down / stale-keep branches against a guaranteed-dead client
+//! (mirroring `tui::coordinator::poll::tests::poll_marks_unreachable_clears_sessions`),
+//! plus the #2470 failure-classification and failure-streak state-machine
+//! tests.
+//! Test: this *is* the test module.
+
+use super::*;
+use crate::client::ManagedSessionSummary;
+
+fn summary(id: &str, state: &str) -> ManagedSessionSummary {
+    ManagedSessionSummary {
+        id: id.to_string(),
+        name: format!("s-{id}"),
+        state: state.to_string(),
+        workspace_path: None,
+        repo_url: None,
+        branch: Some("main".to_string()),
+        created_at: None,
+        last_activity_at: None,
+        pending_decision: None,
+        proposed_default: None,
+        source_id: None,
+        task: Some("do the thing".to_string()),
+        cwd: None,
+        claude_session_id: None,
+        deliverable_id: None,
+        pane_id: None,
+    }
+}
+
+// ---- daemon-down branches (guaranteed-dead client, no live daemon needed) ---
+
+/// A `127.0.0.1` URL bound to an ephemeral port, then immediately dropped
+/// so a later connect is refused — mirrors
+/// `tui::coordinator::tests::dead_loopback_url`.
+fn dead_loopback_url() -> String {
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral loopback port");
+    let port = listener.local_addr().expect("read bound local addr").port();
+    drop(listener);
+    format!("http://127.0.0.1:{port}")
+}
+
+#[tokio::test]
+async fn poll_marks_unreachable_clears_state() {
+    let discovered = crate::core::resolve_daemon_url(None);
+    let probe = DaemonClient::new(discovered.clone());
+    if probe.is_healthy().await {
+        eprintln!("skipping: a reachable daemon was discovered at {discovered}");
+        return;
+    }
+
+    let mut state = ProjectCtlState {
+        projects: vec![ProjectRow {
+            name: "widget".to_string(),
+            repo_url: "https://github.com/acme/widget".to_string(),
+            live_count: 1,
+            total_count: 1,
+        }],
+        daemon_reachable: true, // pretend a prior poll had succeeded
+        ..Default::default()
+    };
+    state
+        .sessions_by_project
+        .insert("widget".to_string(), vec![]);
+    let mut client = DaemonClient::new(dead_loopback_url());
+
+    project_ctl_poll_daemon(&mut state, &mut client).await;
+
+    assert!(!state.daemon_reachable);
+    assert!(state.projects.is_empty());
+    assert!(state.sessions_by_project.is_empty());
+}
+
+fn seeded_activity_state(session_id: &str) -> ProjectCtlState {
+    let mut state = ProjectCtlState {
+        projects: vec![ProjectRow {
+            name: "widget".to_string(),
+            repo_url: "https://github.com/acme/widget".to_string(),
+            live_count: 1,
+            total_count: 1,
+        }],
+        daemon_reachable: true,
+        ..Default::default()
+    };
+    state.sessions_by_project.insert(
+        "widget".to_string(),
+        vec![session_to_row(summary(session_id, "active"))],
+    );
+    state.projects_nav.sync_len(state.projects.len());
+    state.sessions_nav.sync_len(state.current_sessions().len());
+    state
+}
+
+/// `refresh_activity` is called directly (bypassing `project_ctl_poll_daemon`'s
+/// own health probe) so this test stays deterministic regardless of whether
+/// a real daemon happens to be discoverable on this machine — it only needs
+/// the `/activity` HTTP call itself to fail, which a dead loopback port
+/// guarantees.
+#[tokio::test]
+async fn refresh_activity_marks_existing_activity_stale_on_fetch_failure() {
+    let mut state = seeded_activity_state("s1");
+    state.activity = Some(ActivityInfo {
+        session_id: "s1".to_string(),
+        state: "working".to_string(),
+        summary: "last known summary".to_string(),
+        pending_decision: None,
+        proposed_default: None,
+        raw_pane_tail: vec!["$ cargo test".to_string()],
+        stale: false,
+    });
+    let client = DaemonClient::new(dead_loopback_url());
+
+    refresh_activity(&mut state, &client).await;
+
+    let activity = state
+        .activity
+        .expect("last-known activity must be kept, not discarded");
+    assert!(activity.stale, "a failed fetch must mark it stale");
+    assert_eq!(
+        activity.summary, "last known summary",
+        "the last-known data must be kept, not cleared"
+    );
+}
+
+#[tokio::test]
+async fn refresh_activity_clears_when_no_session_is_selected() {
+    let mut state = ProjectCtlState {
+        daemon_reachable: true,
+        activity: Some(ActivityInfo {
+            session_id: "orphaned".to_string(),
+            state: "working".to_string(),
+            summary: "stale from a since-deselected session".to_string(),
+            pending_decision: None,
+            proposed_default: None,
+            raw_pane_tail: vec![],
+            stale: false,
+        }),
+        ..Default::default()
+    };
+    let client = DaemonClient::new(dead_loopback_url());
+
+    refresh_activity(&mut state, &client).await;
+
+    assert!(state.activity.is_none());
+}
+
+// ---- #2470: classification + the pure failure-streak state machine ----
+
+fn activity_response(state: &str, summary: &str) -> ManagedActivityResponse {
+    ManagedActivityResponse {
+        raw_pane: String::new(),
+        runtime_active: true,
+        pane_stale: false,
+        state: state.to_string(),
+        summary: summary.to_string(),
+        confidence: 0.9,
+        cache_hit: false,
+        input_tokens: 0,
+        output_tokens: 0,
+        latency_ms: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        classification: None,
+        pending_decision: None,
+        proposed_default: None,
+    }
+}
+
+/// Mirrors the plain `anyhow` message
+/// [`crate::client::http_client::error::response_or_body_error`] bails
+/// with on a non-success status — no `reqwest::Error` in the chain — so
+/// it must classify as non-transport (404, malformed body, etc. all take
+/// this shape).
+#[test]
+fn classify_status_error_is_non_transport() {
+    let err = anyhow::anyhow!("404 Not Found: session not found");
+    assert_eq!(
+        classify_activity_error(&err),
+        ActivityFetchFailure::NonTransport
+    );
+}
+
+/// A genuine connection-refused `reqwest::Error` (same dead-loopback
+/// fixture the daemon-down tests above use) must classify as transport.
+#[tokio::test]
+async fn classify_connect_error_is_transport() {
+    let client = DaemonClient::new(dead_loopback_url());
+    let err = client
+        .managed_session_activity("s1")
+        .await
+        .expect_err("a dead loopback port must fail the request");
+    assert_eq!(
+        classify_activity_error(&err),
+        ActivityFetchFailure::Transport
+    );
+}
+
+/// (a) N consecutive non-transport ("404-class") failures for the same
+/// session must eventually flip [`ProjectCtlState::activity_unavailable_for_selected`]
+/// to `true`, but not before the threshold is reached.
+#[test]
+fn apply_activity_outcome_non_transport_failures_reach_unavailable_threshold() {
+    let mut state = seeded_activity_state("s1");
+
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    assert!(
+        !state.activity_unavailable_for_selected(),
+        "1 failure must not yet flip to unavailable"
+    );
+
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    assert!(
+        !state.activity_unavailable_for_selected(),
+        "2 failures must not yet flip to unavailable"
+    );
+
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    assert!(
+        state.activity_unavailable_for_selected(),
+        "3 consecutive non-transport failures must flip to unavailable"
+    );
+}
+
+/// (b) a success after failures must show the fresh data AND actually
+/// reset the streak (not merely mask it while `Some` data exists).
+#[test]
+fn apply_activity_outcome_success_after_failures_resets_streak_and_shows_data() {
+    let mut state = seeded_activity_state("s1");
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Ok(activity_response("working", "back online")),
+    );
+
+    assert!(
+        !state.activity_unavailable_for_selected(),
+        "a success must reset the streak"
+    );
+    let activity = state
+        .activity
+        .as_ref()
+        .expect("a successful fetch must populate activity");
+    assert_eq!(activity.summary, "back online");
+    assert!(!activity.stale);
+
+    // Two MORE failures alone (not three) must still fall short of the
+    // threshold -- proving the streak was actually zeroed, not masked.
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    assert!(
+        !state.activity_unavailable_for_selected(),
+        "the streak must have restarted from zero after the success"
+    );
+}
+
+/// (c) transport-class failures (the whole daemon looks down) must never
+/// advance the non-transport streak, however many occur in a row or
+/// interleaved with real non-transport failures.
+#[test]
+fn apply_activity_outcome_transport_failure_never_advances_streak() {
+    let mut state = seeded_activity_state("s1");
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+
+    for _ in 0..5 {
+        apply_activity_outcome(
+            &mut state,
+            "s1".to_string(),
+            Err(ActivityFetchFailure::Transport),
+        );
+    }
+    assert!(
+        !state.activity_unavailable_for_selected(),
+        "transport failures must never advance the non-transport streak"
+    );
+
+    // The ORIGINAL streak of 2 non-transport failures is still intact --
+    // one more completes it to 3.
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    assert!(
+        state.activity_unavailable_for_selected(),
+        "the non-transport streak must have survived the interleaved transport failures"
+    );
+}
+
+/// (d) switching the Sessions-pane selection to a different session must
+/// not let that session inherit the previous session's failure count.
+#[test]
+fn apply_activity_outcome_session_switch_starts_a_fresh_streak() {
+    let mut state = seeded_activity_state("s1");
+    state
+        .sessions_by_project
+        .get_mut("widget")
+        .unwrap()
+        .push(session_to_row(summary("s2", "active")));
+    state.sessions_nav.sync_len(state.current_sessions().len());
+    assert_eq!(state.selected_session().unwrap().id, "s1");
+
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    apply_activity_outcome(
+        &mut state,
+        "s1".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    assert!(
+        !state.activity_unavailable_for_selected(),
+        "2 failures for s1 must not yet be unavailable"
+    );
+
+    // The operator moves the Sessions-pane selection to "s2".
+    state.sessions_nav.select(1);
+    assert_eq!(state.selected_session().unwrap().id, "s2");
+    assert!(
+        !state.activity_unavailable_for_selected(),
+        "s2 has no failure history of its own yet"
+    );
+
+    // One failure for s2 must NOT inherit s1's count-of-2.
+    apply_activity_outcome(
+        &mut state,
+        "s2".to_string(),
+        Err(ActivityFetchFailure::NonTransport),
+    );
+    assert!(
+        !state.activity_unavailable_for_selected(),
+        "s2's own streak must start from zero, not resume s1's count"
+    );
+}
+
+#[tokio::test]
+async fn refresh_deliverables_clears_when_no_project_selected() {
+    let mut state = ProjectCtlState {
+        daemon_reachable: true,
+        deliverables: Some(vec![]),
+        ..Default::default()
+    };
+    let client = DaemonClient::new(dead_loopback_url());
+
+    refresh_deliverables(&mut state, &client).await;
+
+    assert!(state.deliverables.is_none());
+}
+
+#[tokio::test]
+async fn refresh_deliverables_clears_on_daemon_down() {
+    let mut state = seeded_activity_state("s1");
+    state.daemon_reachable = false;
+    let client = DaemonClient::new(dead_loopback_url());
+
+    refresh_deliverables(&mut state, &client).await;
+
+    assert!(
+        state.deliverables.is_none(),
+        "a project IS selected here, but daemon_reachable=false must still reset to \
+         Unknown, matching state.projects/sessions_by_project's own daemon-down handling"
+    );
+}
+
+/// THE review-required regression test: `daemon_reachable == true` (the
+/// daemon is otherwise healthy — the earlier health probe succeeded) but
+/// `list_deliverables` itself fails on this one tick. Previously this
+/// cleared `state.deliverables` outright, which made
+/// `deliverable_link_state` report every previously-resolved session as
+/// `Dangling` — a false "the Deliverable was deleted" signal for what was
+/// really just one dropped HTTP call. The fix: keep the last-known-good
+/// `Some(list)` untouched, mirroring `refresh_activity`'s stale-keep
+/// pattern for `ActivityInfo`.
+#[tokio::test]
+async fn refresh_deliverables_keeps_stale_list_on_transient_fetch_failure() {
+    let mut state = seeded_activity_state("s1");
+    let known_id = crate::deliverable::DeliverableId::new();
+    state.deliverables = Some(vec![crate::deliverable::Deliverable {
+        id: known_id,
+        project_name: "widget".to_string(),
+        name: "OAuth2 flow".to_string(),
+        description: String::new(),
+        kind: crate::deliverable::DeliverableKind::Feature,
+        ticket_ref: None,
+        spec_ref: None,
+        status: crate::deliverable::DeliverableStatus::InProgress,
+        estimated_effort: crate::deliverable::EstimationTier::M,
+        created_at: chrono::Utc::now(),
+        target_date: None,
+    }]);
+    // `seeded_activity_state` leaves `daemon_reachable = true` — the
+    // failure here is scoped to `list_deliverables` alone, via a dead
+    // loopback client, exactly the "endpoint fails, daemon otherwise up"
+    // case the review flagged.
+    let client = DaemonClient::new(dead_loopback_url());
+
+    refresh_deliverables(&mut state, &client).await;
+
+    let kept = state
+        .deliverables
+        .as_ref()
+        .expect("a transient fetch failure must KEEP the last-known-good list, not clear it");
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].id, known_id);
+    assert_eq!(
+        state.deliverable_link_state(&known_id.to_string()),
+        crate::tui::project_ctl::state::DeliverableLinkState::Resolved,
+        "a previously-resolved link must stay Resolved through one bad poll, \
+         never flip to Dangling"
+    );
+}

--- a/crates/trusty-mpm/src/tui/project_ctl/state/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/state/mod.rs
@@ -180,6 +180,62 @@ pub struct ActivityInfo {
     pub stale: bool,
 }
 
+/// Consecutive-failure threshold before the Activity pane gives up on
+/// "loading…"/"stale" and reports the fetch as unavailable for the selected
+/// session (#2470).
+pub(crate) const ACTIVITY_UNAVAILABLE_THRESHOLD: u8 = 3;
+
+/// Per-session consecutive-failure tracking for the `/activity` fetch,
+/// independent of [`ActivityInfo`]/[`ProjectCtlState::activity`] (#2470).
+///
+/// Why: a session whose `/activity` fetch has NEVER succeeded leaves
+/// `ProjectCtlState::activity == None`, which is indistinguishable from
+/// "not fetched yet" — the exact bug this streak fixes. A PERSISTENT
+/// non-transport failure (404 from an older daemon lacking the endpoint, a
+/// GC'd session, a malformed body) while the daemon is otherwise healthy
+/// must eventually surface as an explicit "unavailable" state instead of an
+/// infinite "loading live activity…". A transport failure (connection
+/// refused/timeout — the whole daemon looks down or is restarting) never
+/// advances this streak; see `poll::refresh_activity`.
+/// What: tracks the session id the streak currently belongs to and how many
+/// consecutive non-transport failures it has accumulated.
+/// [`Self::record_failure`] increments it (resetting to 1 first if
+/// `session_id` differs from the one already tracked — a session switch
+/// implicitly starts a fresh streak). [`Self::reset`] clears it outright on
+/// a successful fetch or when no session is selected.
+/// [`Self::is_unavailable_for`] reports whether the streak, for the given
+/// session id, has crossed [`ACTIVITY_UNAVAILABLE_THRESHOLD`].
+/// Test: `poll::tests::activity_failure_streak_*`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ActivityFailureStreak {
+    session_id: Option<String>,
+    consecutive_failures: u8,
+}
+
+impl ActivityFailureStreak {
+    /// Record one non-transport failure for `session_id`, resetting the
+    /// streak first if it belonged to a different (or no) session.
+    pub(crate) fn record_failure(&mut self, session_id: &str) {
+        if self.session_id.as_deref() != Some(session_id) {
+            self.session_id = Some(session_id.to_string());
+            self.consecutive_failures = 0;
+        }
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+    }
+
+    /// Clear the streak — a successful fetch, or no session selected.
+    pub(crate) fn reset(&mut self) {
+        self.session_id = None;
+        self.consecutive_failures = 0;
+    }
+
+    /// Whether `session_id` has crossed [`ACTIVITY_UNAVAILABLE_THRESHOLD`].
+    fn is_unavailable_for(&self, session_id: &str) -> bool {
+        self.session_id.as_deref() == Some(session_id)
+            && self.consecutive_failures >= ACTIVITY_UNAVAILABLE_THRESHOLD
+    }
+}
+
 /// Which destructive verb a [`PendingConfirm`] is gating.
 ///
 /// Why: DOC-35 §5.2 requires a confirmation gate before `k` (kill) executes
@@ -293,6 +349,11 @@ pub struct ProjectCtlState {
     /// mismatched (stale-selection) snapshot is never rendered under the
     /// wrong session's header.
     pub activity: Option<ActivityInfo>,
+    /// Consecutive-non-transport-failure tracking for the `/activity` fetch
+    /// (#2470) — see [`ActivityFailureStreak`]'s own doc for why this must
+    /// live independent of `activity` itself. Read it through
+    /// [`Self::activity_unavailable_for_selected`], not directly.
+    pub(crate) activity_failures: ActivityFailureStreak,
     /// The currently selected project's Deliverables, refreshed on the same
     /// poll cadence as `projects`/`sessions_by_project` (DOC-35 §10.6,
     /// #2383). `None` means UNKNOWN — no project selected, the selection just
@@ -414,6 +475,23 @@ impl ProjectCtlState {
         self.activity
             .as_ref()
             .filter(|a| &a.session_id == selected_id)
+    }
+
+    /// Whether the Activity pane should report "unavailable" for the
+    /// currently selected session (#2470) — i.e. its `/activity` fetch has
+    /// failed [`ACTIVITY_UNAVAILABLE_THRESHOLD`]-or-more times in a row with
+    /// no intervening success, while the daemon itself was reachable (a
+    /// transport failure — the whole daemon down — never counts; see
+    /// [`ActivityFailureStreak`]).
+    /// What: `false` when no session is selected or the streak belongs to a
+    /// different session id; otherwise delegates to
+    /// [`ActivityFailureStreak::is_unavailable_for`].
+    /// Test: `poll::tests::activity_failure_streak_*`.
+    pub fn activity_unavailable_for_selected(&self) -> bool {
+        let Some(selected_id) = self.selected_session().map(|s| s.id.as_str()) else {
+            return false;
+        };
+        self.activity_failures.is_unavailable_for(selected_id)
     }
 
     /// Re-sync the Sessions-pane navigation to a freshly selected project.


### PR DESCRIPTION
## Root cause

`tm projects` TUI: a PERSISTENT per-session `/activity` fetch failure while
the daemon is otherwise healthy (404 from an older daemon lacking the
endpoint, a GC'd session, a malformed body) left `state.activity == None`
forever — indistinguishable from "not fetched yet". The Activity pane
(`panes/activity.rs`) rendered "loading live activity…" indefinitely,
never resolving to an explicit error (follow-up from PR #2469's review,
refs #2119).

## Design

Consecutive-failure counter (`ActivityFailureStreak`, threshold **N = 3**),
tracked in `ProjectCtlState` independently of `ActivityInfo` — necessary
because a session that has never had a successful fetch leaves `activity`
at `None`, which has nowhere else to record the failure history.

Failures are classified by `classify_activity_error` in
`poll/mod.rs`, walking the `anyhow::Error` chain for a `reqwest::Error`
whose `is_connect()`/`is_timeout()` is true:

- **Transport** (connection refused/timeout — the whole daemon looks down
  or is restarting) — never advances the streak; falls through to the
  existing stale-keep-or-clear behavior unchanged.
- **NonTransport** (an HTTP status/body error via
  `response_or_body_error`, or any other reqwest error such as a decode
  failure) — advances the streak. Once it crosses the threshold, the pane
  renders `"activity unavailable for this session"` instead of
  `"loading…"`/stale data.

The streak resets to a fresh count the moment a *different* session id is
recorded against it (an implicit switch-reset — no separate flag needed)
and is explicitly reset on any successful fetch.

The state-transition rules live in a pure `apply_activity_outcome`
function (typed `Result<ManagedActivityResponse, ActivityFetchFailure>`
input, no `reqwest`/daemon types in its signature) so they're unit
testable without a live daemon, mirroring how `rows.rs` keeps pure DTO
projections out of the async fetch path.

## Files changed

- `crates/trusty-mpm/src/tui/project_ctl/poll/mod.rs` — `ActivityFetchFailure`
  enum, `classify_activity_error`, `apply_activity_outcome`,
  `refresh_activity` now routes through them.
- `crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs` (new) — the
  existing `mod tests` block moved out of `mod.rs` verbatim (test-file
  SLOC path, 1500 cap) to keep `mod.rs` under the 500-SLOC production cap
  after the new #2470 tests landed, plus 6 new tests for the
  classification + streak state machine.
- `crates/trusty-mpm/src/tui/project_ctl/state/mod.rs` — `ActivityFailureStreak`
  struct + `ACTIVITY_UNAVAILABLE_THRESHOLD` constant,
  `ProjectCtlState::activity_failures` field,
  `ProjectCtlState::activity_unavailable_for_selected()` accessor.
- `crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs` — new render
  branch (checked before the loading/daemon-down fallbacks) + a unit test.

## Test evidence

```
cargo test -p trusty-mpm --lib tui::project_ctl
test result: ok. 123 passed; 0 failed; 0 ignored

cargo test -p trusty-mpm
test result: ok. 2927 passed; 0 failed; 5 ignored   (unit)
test result: ok. 866 passed; 0 failed; 1 ignored    (x2 — behavior suites)
... every integration binary: ok, 0 failed

cargo build --workspace          -> clean
cargo clippy --workspace --all-targets -- -D warnings -> exit 0, no new warnings
cargo fmt --check                -> exit 0
bash scripts/check_line_cap.sh   -> line-cap: 0 allowlisted, 0 violations — OK.
```

New tests covering the four required scenarios:
- `apply_activity_outcome_non_transport_failures_reach_unavailable_threshold` (a)
- `apply_activity_outcome_success_after_failures_resets_streak_and_shows_data` (b)
- `apply_activity_outcome_transport_failure_never_advances_streak` (c)
- `apply_activity_outcome_session_switch_starts_a_fresh_streak` (d)
- plus `classify_status_error_is_non_transport` / `classify_connect_error_is_transport`
  and `activity_lines_reports_unavailable_after_persistent_failures` (pane render).

Closes #2470

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools