### PR TITLE
fix(trusty-mpm): harden inject/observe/dashboard-restart against active-pane ambiguity (closes #2468)

### DIFF
--- a/crates/trusty-mpm/src/daemon/api/claude_config_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/claude_config_routes.rs
@@ -26,6 +26,7 @@ use crate::daemon::api::types::{
     RestoreResponse,
 };
 use crate::daemon::state::DaemonState;
+use crate::session_manager::record::{ManagedSessionState, SessionRecord};
 
 // ---- Claude Code configuration analyzer ---------------------------------
 
@@ -380,6 +381,35 @@ pub struct RestartRequest {
     pub tmux_session: String,
 }
 
+/// Select the `pane_id` to restart into from the full managed-session record
+/// set, given the target tmux session name (#2514 review, minor finding 4).
+///
+/// Why: `tmux_name` is recycled once a session is decommissioned — a fresh
+/// session provisioned later can be assigned the SAME tmux name a
+/// decommissioned record used. A naive `.find(|r| r.tmux_name == name)` over
+/// the full record list can therefore match the stale, decommissioned
+/// tombstone instead of the live record, silently threading a dead/garbage
+/// `pane_id` (or a `None` that masks a real one) into the restart call.
+/// What: filters to records matching `tmux_session` whose state is NOT
+/// `Decommissioned` (the terminal, unresumable state — see
+/// [`ManagedSessionState`]'s doc), then — since more than one non-terminal
+/// record can theoretically share a recycled name during a narrow
+/// provisioning race — prefers the most recently created match. Returns
+/// `None` when no live record matches (unmanaged/legacy session name) or the
+/// surviving record never captured a `pane_id`; the session-scoped restart
+/// fallback then applies exactly as before #2468.
+/// Test: `select_restart_pane_id_skips_decommissioned_record`,
+/// `select_restart_pane_id_prefers_most_recent_when_multiple_live_match`,
+/// `select_restart_pane_id_none_when_no_match`.
+fn select_restart_pane_id(records: &[SessionRecord], tmux_session: &str) -> Option<String> {
+    records
+        .iter()
+        .filter(|r| r.tmux_name == tmux_session)
+        .filter(|r| !matches!(r.state, ManagedSessionState::Decommissioned))
+        .max_by_key(|r| r.created_at)
+        .and_then(|r| r.pane_id.clone())
+}
+
 /// `POST /claude-config/restart` — restart Claude Code in a tmux session.
 ///
 /// Why: after applying config changes the operator wants a clean Claude Code
@@ -389,14 +419,18 @@ pub struct RestartRequest {
 /// pane rather than tmux's session-scoped "active pane" resolution — the
 /// same sibling-window hijack risk #2467 fixed for resume/restart respawn
 /// (issue #2468).
-/// What: looks up `body.tmux_session` against the managed-session store for
-/// a matching `pane_id` (`None` when the session is unmanaged/legacy — the
-/// session-scoped fallback then applies exactly as before #2468), then calls
-/// `ClaudeCodeRestarter::restart_in_session`. tmux being absent, or a
+/// What: looks up `body.tmux_session` against the managed-session store via
+/// [`select_restart_pane_id`], which excludes decommissioned (tombstone)
+/// records and prefers the most recently created live match — a recycled
+/// `tmux_name` can otherwise resolve to a stale decommissioned record (#2514
+/// review). `None` (unmanaged/legacy session, or no matching live record)
+/// falls back to the session-scoped restart exactly as before #2468. Then
+/// calls `ClaudeCodeRestarter::restart_in_session`. tmux being absent, or a
 /// confirmed-gone recorded pane, both surface as `500`.
 /// Test: `restart_claude_code_handles_missing_tmux`;
 /// `ClaudeCodeRestarter::restart_target`'s pane/session decision is
-/// unit-tested directly in `daemon::claude_config::restarter`.
+/// unit-tested directly in `daemon::claude_config::restarter`;
+/// [`select_restart_pane_id`]'s own unit tests cover the stale-record fix.
 #[utoipa::path(
     post,
     path = "/claude-config/restart",
@@ -411,14 +445,8 @@ pub async fn restart_claude_code(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<RestartRequest>,
 ) -> Result<Json<RestartResponse>, StatusCode> {
-    let pane_id = state
-        .session_manager()
-        .await
-        .list()
-        .await
-        .into_iter()
-        .find(|r| r.tmux_name == body.tmux_session)
-        .and_then(|r| r.pane_id);
+    let records = state.session_manager().await.list().await;
+    let pane_id = select_restart_pane_id(&records, &body.tmux_session);
     crate::daemon::claude_config::ClaudeCodeRestarter::restart_in_session(
         &body.tmux_session,
         pane_id.as_deref(),
@@ -430,4 +458,106 @@ pub async fn restart_claude_code(
     Ok(Json(RestartResponse {
         restarted: body.tmux_session,
     }))
+}
+
+#[cfg(test)]
+mod restart_pane_selection_tests {
+    use super::*;
+    use crate::session_manager::record::ManagedSessionId;
+
+    /// Builds a minimal, otherwise-default [`SessionRecord`] for the pure
+    /// selection-fn tests below — only `tmux_name`, `state`, `pane_id`, and
+    /// `created_at` matter to [`select_restart_pane_id`].
+    fn make_record(
+        tmux_name: &str,
+        state: ManagedSessionState,
+        pane_id: Option<&str>,
+        created_at: chrono::DateTime<chrono::Utc>,
+    ) -> SessionRecord {
+        SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: tmux_name.to_string(),
+            cwd: PathBuf::from("/tmp"),
+            task: "task".to_string(),
+            state,
+            created_at,
+            last_activity_at: None,
+            workspace_path: None,
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: crate::driver::SessionCorrelation::new(),
+            runtime: crate::runtime::RuntimeKind::default(),
+            ephemeral: true,
+            workspace_owned: false,
+            source_id: None,
+            claude_session_id: None,
+            scrollback_path: None,
+            last_cwd: None,
+            deliverable_id: None,
+            pane_id: pane_id.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn select_restart_pane_id_skips_decommissioned_record() {
+        // A decommissioned record's tmux_name has been recycled by a live
+        // record; the stale tombstone must never win.
+        let now = chrono::Utc::now();
+        let stale = make_record(
+            "tmpm-proj-1",
+            ManagedSessionState::Decommissioned,
+            Some("%old"),
+            now - chrono::Duration::hours(1),
+        );
+        let live = make_record(
+            "tmpm-proj-1",
+            ManagedSessionState::Active,
+            Some("%new"),
+            now,
+        );
+        let records = vec![stale, live];
+
+        assert_eq!(
+            select_restart_pane_id(&records, "tmpm-proj-1"),
+            Some("%new".to_string())
+        );
+    }
+
+    #[test]
+    fn select_restart_pane_id_prefers_most_recent_when_multiple_live_match() {
+        let now = chrono::Utc::now();
+        let older = make_record(
+            "tmpm-proj-1",
+            ManagedSessionState::Stopped,
+            Some("%older"),
+            now - chrono::Duration::minutes(5),
+        );
+        let newer = make_record(
+            "tmpm-proj-1",
+            ManagedSessionState::Active,
+            Some("%newer"),
+            now,
+        );
+        let records = vec![older, newer];
+
+        assert_eq!(
+            select_restart_pane_id(&records, "tmpm-proj-1"),
+            Some("%newer".to_string())
+        );
+    }
+
+    #[test]
+    fn select_restart_pane_id_none_when_no_match() {
+        let now = chrono::Utc::now();
+        let records = vec![make_record(
+            "tmpm-other",
+            ManagedSessionState::Active,
+            Some("%x"),
+            now,
+        )];
+
+        assert_eq!(select_restart_pane_id(&records, "tmpm-proj-1"), None);
+    }
 }

--- a/crates/trusty-mpm/src/daemon/api/claude_config_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/claude_config_routes.rs
@@ -383,10 +383,20 @@ pub struct RestartRequest {
 /// `POST /claude-config/restart` — restart Claude Code in a tmux session.
 ///
 /// Why: after applying config changes the operator wants a clean Claude Code
-/// process; this sends Ctrl-C then `claude` into the session's pane.
-/// What: calls `ClaudeCodeRestarter::restart_in_session`. tmux being absent
-/// surfaces as `500`.
-/// Test: `restart_claude_code_handles_missing_tmux`.
+/// process; this sends Ctrl-C then `claude` into the session's pane. The
+/// managed-session record's `pane_id`, when one is tracked for this tmux
+/// session, is threaded through so the restart lands in the record's OWN
+/// pane rather than tmux's session-scoped "active pane" resolution — the
+/// same sibling-window hijack risk #2467 fixed for resume/restart respawn
+/// (issue #2468).
+/// What: looks up `body.tmux_session` against the managed-session store for
+/// a matching `pane_id` (`None` when the session is unmanaged/legacy — the
+/// session-scoped fallback then applies exactly as before #2468), then calls
+/// `ClaudeCodeRestarter::restart_in_session`. tmux being absent, or a
+/// confirmed-gone recorded pane, both surface as `500`.
+/// Test: `restart_claude_code_handles_missing_tmux`;
+/// `ClaudeCodeRestarter::restart_target`'s pane/session decision is
+/// unit-tested directly in `daemon::claude_config::restarter`.
 #[utoipa::path(
     post,
     path = "/claude-config/restart",
@@ -398,14 +408,25 @@ pub struct RestartRequest {
     )
 )]
 pub async fn restart_claude_code(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Json(body): Json<RestartRequest>,
 ) -> Result<Json<RestartResponse>, StatusCode> {
-    crate::daemon::claude_config::ClaudeCodeRestarter::restart_in_session(&body.tmux_session)
-        .map_err(|e| {
-            tracing::warn!("restart in {} failed: {e}", body.tmux_session);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    let pane_id = state
+        .session_manager()
+        .await
+        .list()
+        .await
+        .into_iter()
+        .find(|r| r.tmux_name == body.tmux_session)
+        .and_then(|r| r.pane_id);
+    crate::daemon::claude_config::ClaudeCodeRestarter::restart_in_session(
+        &body.tmux_session,
+        pane_id.as_deref(),
+    )
+    .map_err(|e| {
+        tracing::warn!("restart in {} failed: {e}", body.tmux_session);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     Ok(Json(RestartResponse {
         restarted: body.tmux_session,
     }))

--- a/crates/trusty-mpm/src/daemon/claude_config/restarter.rs
+++ b/crates/trusty-mpm/src/daemon/claude_config/restarter.rs
@@ -4,10 +4,12 @@
 //! them up; this drives the restart.
 //! What: `find_claude_processes` lists `claude` PIDs via `pgrep`;
 //! `restart_in_session` sends Ctrl-C then `claude` into a tmux session's pane.
-//! Test: `find_claude_processes_does_not_panic`.
+//! Test: `find_claude_processes_does_not_panic`; `restart_target_*` (below)
+//! cover the pane-vs-session target decision without a live tmux binary.
 
 use std::process::Command;
 
+use crate::core::Error;
 use crate::core::Result;
 use crate::core::tmux::TmuxTarget;
 
@@ -45,7 +47,8 @@ impl ClaudeCodeRestarter {
             .collect()
     }
 
-    /// Restart Claude Code inside a named tmux session.
+    /// Restart Claude Code inside a named tmux session, optionally pinned to
+    /// a specific recorded pane.
     ///
     /// Why: a Claude Code session hosted in tmux is restarted in place — send
     /// an interrupt to stop the current process, then relaunch `claude`. The
@@ -58,21 +61,91 @@ impl ClaudeCodeRestarter {
     /// best-effort (never fails the restart) — see
     /// [`crate::daemon::tmux::TmuxDriver::apply_scrollback_options`]. It does
     /// NOT retroactively grow THIS session's already-created pane; only
-    /// panes created after the option lands benefit.
-    /// What: discovers tmux, re-applies the scrollback/mouse options, sends
-    /// `C-c` to the session's pane, waits briefly for the process to exit,
-    /// then types `claude` + Enter. tmux being absent surfaces as an `Err`.
-    /// Test: `restart_in_session_errors_without_tmux` (skipped when tmux is
-    /// installed).
-    pub fn restart_in_session(tmux_session: &str) -> Result<()> {
+    /// panes created after the option lands benefit. `pane_id` closes the
+    /// same sibling-window hijack risk #2467 fixed for resume/restart respawn
+    /// (issue #2468, dashboard restart route site): addressing "the session"
+    /// alone lets tmux resolve the target to whichever pane is currently
+    /// ACTIVE, possibly a sibling window with nothing to do with this record.
+    /// What: discovers tmux, re-applies the scrollback/mouse options,
+    /// resolves the tmux target via [`restart_target`] (pane-scoped when
+    /// `pane_id` is known and confirmed alive; session-scoped for a legacy
+    /// caller with no `pane_id`; a loud `Err` — the session-scoped target is
+    /// NEVER constructed — when `pane_id` is known but confirmed gone), sends
+    /// `C-c`, waits briefly for the process to exit, then types `claude` +
+    /// Enter. tmux being absent surfaces as an `Err`.
+    /// Test: `find_claude_processes_does_not_panic`; the pane/session target
+    /// DECISION is unit-tested (no live tmux needed) via `restart_target_*`.
+    pub fn restart_in_session(tmux_session: &str, pane_id: Option<&str>) -> Result<()> {
         let driver = crate::daemon::tmux::TmuxDriver::discover()?;
         driver.apply_scrollback_options();
-        let target = TmuxTarget::session(tmux_session);
+        let pane_alive = pane_id.is_some_and(|p| driver.pane_exists(tmux_session, p));
+        let target = restart_target(tmux_session, pane_id, pane_alive)?;
         // Interrupt the running Claude Code process.
         driver.send_interrupt(&target)?;
         std::thread::sleep(std::time::Duration::from_millis(500));
         // Relaunch Claude Code.
         driver.send_line(&target, crate::daemon::spawn_command::relaunch_command())?;
         Ok(())
+    }
+}
+
+/// Decide which tmux target [`ClaudeCodeRestarter::restart_in_session`]
+/// should address for a given recorded `pane_id` — pure decision logic,
+/// unit-testable without a live tmux binary (issue #2468).
+///
+/// Why: mirrors the refusal semantics `SessionManager::resume`
+/// ([`crate::session_manager::manager::ManagedError::PaneGone`]) established
+/// (#2467) for the identical sibling-window hijack risk, so the dashboard
+/// restart route fails loudly instead of guessing when the recorded pane is
+/// gone.
+/// What: `pane_id = None` (legacy caller, no recorded pane) → session-scoped
+/// target, matching #2467's legacy fallback. `Some(pane_id)` with
+/// `pane_alive == true` → pane-scoped target. `Some(pane_id)` with
+/// `pane_alive == false` → `Err` naming the session and pane; the
+/// session-scoped target is NEVER constructed in this branch.
+/// Test: `restart_target_uses_pane_when_alive`,
+/// `restart_target_refuses_when_pane_gone`,
+/// `restart_target_falls_back_to_session_for_legacy_caller`.
+fn restart_target(
+    tmux_session: &str,
+    pane_id: Option<&str>,
+    pane_alive: bool,
+) -> Result<TmuxTarget> {
+    match pane_id {
+        Some(p) if pane_alive => Ok(TmuxTarget::pane(tmux_session, p)),
+        Some(p) => Err(Error::Protocol(format!(
+            "recorded pane {p} for session {tmux_session} no longer exists; refusing to \
+             restart into an unrelated active pane"
+        ))),
+        None => Ok(TmuxTarget::session(tmux_session)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restart_target_uses_pane_when_alive() {
+        let target = restart_target("trusty-mpm-xyz", Some("%6015"), true).expect("pane target");
+        assert_eq!(target.as_target(), "%6015");
+    }
+
+    #[test]
+    fn restart_target_refuses_when_pane_gone() {
+        let err = restart_target("trusty-mpm-xyz", Some("%6015"), false)
+            .expect_err("a confirmed-gone recorded pane must refuse, not fall back");
+        let msg = err.to_string();
+        assert!(msg.contains("%6015"), "error must name the pane: {msg}");
+        assert!(
+            msg.contains("trusty-mpm-xyz"),
+            "error must name the session: {msg}"
+        );
+    }
+
+    #[test]
+    fn restart_target_falls_back_to_session_for_legacy_caller() {
+        let target = restart_target("trusty-mpm-xyz", None, false).expect("session target");
+        assert_eq!(target.as_target(), "trusty-mpm-xyz");
     }
 }

--- a/crates/trusty-mpm/src/session_manager/adopt_existing_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt_existing_tests.rs
@@ -1,0 +1,194 @@
+//! Tests for `SessionManager::adopt_existing` (#1433).
+//!
+//! Why: extracted from `tests.rs` (issue #2468) to keep that file under its
+//! own 1500-SLOC test cap after the pane-scoped inject/observe `FakeTmuxDriver`
+//! additions — mirrors why `reload_error_tests.rs` was split out earlier.
+//! What: the explicit-adopt happy path (registers `Active`, never calls
+//! `create_session`), the `TmuxSessionMissing`/`AlreadyAdopted` typed-error
+//! guards, the non-`tmpm-`-prefix allowance (unlike reconcile's automatic
+//! adoption), and the persisted `ephemeral` flag.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use super::manager::ManagedError;
+use super::record::ManagedSessionState;
+use super::tests::make_manager;
+
+#[tokio::test]
+async fn manager_adopt_existing_registers_active() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    // The pane already exists (operator started it outside trusty-mpm).
+    fake.seeded_names
+        .lock()
+        .unwrap()
+        .push("tmpm-hand-started".into());
+
+    let record = mgr
+        .adopt_existing(
+            "tmpm-hand-started",
+            PathBuf::from("/Users/op/work/proj"),
+            "drive my hand-started session".into(),
+            crate::runtime::RuntimeKind::default(),
+            false,
+        )
+        .await
+        .expect("adopt existing");
+
+    assert_eq!(record.tmux_name, "tmpm-hand-started");
+    assert_eq!(record.state, ManagedSessionState::Active);
+    assert_eq!(record.cwd, PathBuf::from("/Users/op/work/proj"));
+    assert_eq!(record.task, "drive my hand-started session");
+
+    // Adoption must NOT spawn a new tmux session — the pane already exists.
+    assert!(
+        fake.create_cwd_calls.lock().unwrap().is_empty(),
+        "adopt_existing must NOT call create_session; calls: {:?}",
+        fake.create_cwd_calls.lock().unwrap()
+    );
+
+    // The record is durably queryable.
+    let got = mgr.get(&record.id).await.expect("get adopted");
+    assert_eq!(got.id, record.id);
+    assert_eq!(got.state, ManagedSessionState::Active);
+}
+
+/// Adopting a tmux name that does NOT exist on the host must error — you cannot
+/// adopt a pane that is not there (#1433).
+///
+/// Why: this is the inverse of `create`'s NameCollision guard. The error must be
+/// the dedicated `TmuxSessionMissing` variant so the HTTP layer maps it to a 404.
+/// What: adopts a name the driver does not report and asserts the typed error.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_adopt_existing_missing_tmux_errors() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let err = mgr
+        .adopt_existing(
+            "tmpm-not-here",
+            PathBuf::from("/tmp/x"),
+            String::new(),
+            crate::runtime::RuntimeKind::default(),
+            false,
+        )
+        .await
+        .expect_err("adopting a nonexistent pane must fail");
+
+    assert!(
+        matches!(err, ManagedError::TmuxSessionMissing(ref n) if n == "tmpm-not-here"),
+        "expected TmuxSessionMissing, got {err:?}"
+    );
+}
+
+/// Adopting a tmux name the store ALREADY tracks must error — no double records
+/// for one pane (#1433).
+///
+/// Why: a second record for the same pane would split ownership and confuse every
+/// downstream verb. The dedicated `AlreadyAdopted` variant lets the HTTP layer map
+/// it to a 409 Conflict.
+/// What: adopts once (succeeds), then adopts the same live name again and asserts
+/// the second call returns `AlreadyAdopted`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_adopt_existing_double_adopt_errors() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    fake.seeded_names.lock().unwrap().push("tmpm-once".into());
+
+    mgr.adopt_existing(
+        "tmpm-once",
+        PathBuf::from("/tmp/once"),
+        String::new(),
+        crate::runtime::RuntimeKind::default(),
+        false,
+    )
+    .await
+    .expect("first adopt succeeds");
+
+    let err = mgr
+        .adopt_existing(
+            "tmpm-once",
+            PathBuf::from("/tmp/once"),
+            String::new(),
+            crate::runtime::RuntimeKind::default(),
+            false,
+        )
+        .await
+        .expect_err("second adopt of the same pane must fail");
+
+    assert!(
+        matches!(err, ManagedError::AlreadyAdopted(ref n) if n == "tmpm-once"),
+        "expected AlreadyAdopted, got {err:?}"
+    );
+}
+
+/// The explicit adopt path must allow NON-`tmpm-` names (unlike reconcile, which
+/// filters to the `tmpm-` prefix for safe automatic adoption) (#1433).
+///
+/// Why: an operator naming a pane explicitly knows what they are adopting; the
+/// `tmpm-` prefix filter exists only to make AUTOMATIC boot adoption safe. The
+/// explicit path must not reject a session just because it lacks the prefix.
+/// What: seeds a non-`tmpm-` live name, adopts it, and asserts success.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_adopt_existing_allows_non_tmpm_name() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    fake.seeded_names
+        .lock()
+        .unwrap()
+        .push("my-cli-session".into());
+
+    let record = mgr
+        .adopt_existing(
+            "my-cli-session",
+            PathBuf::from("/Users/op/repo"),
+            "adopt non-prefixed".into(),
+            crate::runtime::RuntimeKind::default(),
+            false,
+        )
+        .await
+        .expect("non-tmpm names are adoptable on the explicit path");
+
+    assert_eq!(record.tmux_name, "my-cli-session");
+    assert_eq!(record.state, ManagedSessionState::Active);
+}
+
+/// `adopt_existing` persists the caller-supplied `ephemeral` flag (#1508).
+///
+/// Why: the e2e harness adopts panes as ephemeral; the flag must reach the record.
+/// What: seeds a live pane, adopts it with `ephemeral=true`, asserts it persisted.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_adopt_existing_persists_ephemeral_flag() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+    fake.seeded_names
+        .lock()
+        .unwrap()
+        .push("tmpm-eph-adopt".into());
+
+    let record = mgr
+        .adopt_existing(
+            "tmpm-eph-adopt",
+            PathBuf::from("/tmp/adopt"),
+            "throwaway adopt".into(),
+            crate::runtime::RuntimeKind::default(),
+            true,
+        )
+        .await
+        .expect("adopt ephemeral");
+
+    assert!(
+        mgr.get(&record.id).await.unwrap().ephemeral,
+        "adopted ephemeral flag persisted"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/driver.rs
+++ b/crates/trusty-mpm/src/session_manager/driver.rs
@@ -79,6 +79,28 @@ pub trait ManagedTmuxDriver: Send + Sync {
         self.send_line(name, text)
     }
 
+    /// Send literal text WITHOUT a trailing Enter to a SPECIFIC pane (#2468,
+    /// same rationale as [`Self::send_line_to_pane`]).
+    ///
+    /// What: the pane-scoped counterpart to [`Self::send_keys_literal`],
+    /// used by `SessionManager::inject`'s `Submit::NoSubmit` dispatch when
+    /// `record.pane_id` is known. The default falls back to
+    /// `send_keys_literal(name, text)` (session-scoped) — correct for a
+    /// legacy record or a driver that predates pane-level addressing.
+    /// [`super::real_tmux::RealTmuxDriver`] overrides this to build an actual
+    /// pane-scoped `TmuxTarget`.
+    /// Test: `inject_dispatch_nosubmit_targets_pane_when_known` in
+    /// `pane_scoped_tests.rs`.
+    fn send_keys_literal_to_pane(
+        &self,
+        name: &str,
+        pane_id: &str,
+        text: &str,
+    ) -> Result<(), ManagedError> {
+        let _ = pane_id;
+        self.send_keys_literal(name, text)
+    }
+
     /// Report whether `pane_id` still exists as a live pane within `name`'s
     /// tmux session.
     ///
@@ -125,6 +147,23 @@ pub trait ManagedTmuxDriver: Send + Sync {
         ))
     }
 
+    /// Send Ctrl-C to a SPECIFIC pane rather than the session (#2468, same
+    /// rationale as [`Self::send_line_to_pane`]).
+    ///
+    /// What: the pane-scoped counterpart to [`Self::send_interrupt`], used by
+    /// `SessionManager::inject`'s `Submit::Interrupt` dispatch when
+    /// `record.pane_id` is known. The default falls back to
+    /// `send_interrupt(name)` (session-scoped) for a legacy record or a
+    /// driver that predates pane-level addressing.
+    /// [`super::real_tmux::RealTmuxDriver`] overrides this to build an actual
+    /// pane-scoped `TmuxTarget`.
+    /// Test: `inject_dispatch_interrupt_targets_pane_when_known` in
+    /// `pane_scoped_tests.rs`.
+    fn send_interrupt_to_pane(&self, name: &str, pane_id: &str) -> Result<(), ManagedError> {
+        let _ = pane_id;
+        self.send_interrupt(name)
+    }
+
     /// Capture the last `lines` of pane output for the session named `name`.
     ///
     /// `lines` is `usize` to match the harness-agnostic
@@ -133,6 +172,30 @@ pub trait ManagedTmuxDriver: Send + Sync {
     /// tmux `-S` argv requires is confined to the real-tmux driver edge, so no
     /// caller in the observe path needs a `try_from`.
     fn capture(&self, name: &str, lines: usize) -> Result<String, ManagedError>;
+
+    /// Capture the last `lines` of output from a SPECIFIC pane rather than
+    /// whichever pane the session name currently resolves to (#2468).
+    ///
+    /// Why: `SessionManager::observe`'s LLM-free pane read had the same
+    /// sibling-window-hijack hole #2467 fixed for resume/restart — a
+    /// session-scoped capture reads whatever pane tmux considers active,
+    /// which need not be the pane this record is actually about.
+    /// What: the pane-scoped counterpart to [`Self::capture`]. The default
+    /// falls back to `capture(name, lines)` (session-scoped) for a legacy
+    /// record or a driver that predates pane-level addressing.
+    /// [`super::real_tmux::RealTmuxDriver`] overrides this to build an actual
+    /// pane-scoped `TmuxTarget`.
+    /// Test: `observe_captures_pane_scoped_when_pane_id_known` in
+    /// `pane_scoped_tests.rs`.
+    fn capture_pane(
+        &self,
+        name: &str,
+        pane_id: &str,
+        lines: usize,
+    ) -> Result<String, ManagedError> {
+        let _ = pane_id;
+        self.capture(name, lines)
+    }
 
     /// Return the pane's current working directory for snapshot-before-stop (#1816).
     ///

--- a/crates/trusty-mpm/src/session_manager/driver.rs
+++ b/crates/trusty-mpm/src/session_manager/driver.rs
@@ -84,21 +84,30 @@ pub trait ManagedTmuxDriver: Send + Sync {
     ///
     /// What: the pane-scoped counterpart to [`Self::send_keys_literal`],
     /// used by `SessionManager::inject`'s `Submit::NoSubmit` dispatch when
-    /// `record.pane_id` is known. The default falls back to
-    /// `send_keys_literal(name, text)` (session-scoped) — correct for a
-    /// legacy record or a driver that predates pane-level addressing.
-    /// [`super::real_tmux::RealTmuxDriver`] overrides this to build an actual
-    /// pane-scoped `TmuxTarget`.
-    /// Test: `inject_dispatch_nosubmit_targets_pane_when_known` in
-    /// `pane_scoped_tests.rs`.
+    /// `record.pane_id` is known. The default returns an explicit
+    /// `TmuxUnavailable` error rather than silently falling back to
+    /// `send_keys_literal(name, text)` (#2514 review, minor finding 5): a
+    /// silent session-scoped fallback here is exactly the sibling-window
+    /// hijack #2468 exists to close, and a future driver that forgets to
+    /// override this method would silently REGAIN the vulnerability with no
+    /// compiler signal. Mirrors the fail-closed pattern already used by
+    /// [`Self::send_keys_literal`]'s own default. Any driver actually used
+    /// with a known `pane_id` MUST override this — both
+    /// [`super::real_tmux::RealTmuxDriver`] and the test-only
+    /// `FakeTmuxDriver` do.
+    /// Test: `inject_nosubmit_targets_pane_when_pane_id_known` in
+    /// `pane_scoped_tests.rs`; `send_keys_literal_to_pane_default_fails_closed`
+    /// in this module's tests.
     fn send_keys_literal_to_pane(
         &self,
         name: &str,
         pane_id: &str,
         text: &str,
     ) -> Result<(), ManagedError> {
-        let _ = pane_id;
-        self.send_keys_literal(name, text)
+        let _ = (name, pane_id, text);
+        Err(ManagedError::TmuxUnavailable(
+            "send_keys_literal_to_pane not implemented for this driver".into(),
+        ))
     }
 
     /// Report whether `pane_id` still exists as a live pane within `name`'s
@@ -152,16 +161,24 @@ pub trait ManagedTmuxDriver: Send + Sync {
     ///
     /// What: the pane-scoped counterpart to [`Self::send_interrupt`], used by
     /// `SessionManager::inject`'s `Submit::Interrupt` dispatch when
-    /// `record.pane_id` is known. The default falls back to
-    /// `send_interrupt(name)` (session-scoped) for a legacy record or a
-    /// driver that predates pane-level addressing.
-    /// [`super::real_tmux::RealTmuxDriver`] overrides this to build an actual
-    /// pane-scoped `TmuxTarget`.
-    /// Test: `inject_dispatch_interrupt_targets_pane_when_known` in
-    /// `pane_scoped_tests.rs`.
+    /// `record.pane_id` is known. The default returns an explicit
+    /// `TmuxUnavailable` error rather than silently falling back to
+    /// `send_interrupt(name)` (#2514 review, minor finding 5) — the same
+    /// fail-closed rationale as [`Self::send_keys_literal_to_pane`]'s default:
+    /// a silent session-scoped fallback would regain the sibling-window
+    /// hijack #2468 fixed, with no compiler signal warning a future driver
+    /// that it forgot to override this. Any driver actually used with a known
+    /// `pane_id` MUST override this — both
+    /// [`super::real_tmux::RealTmuxDriver`] and the test-only
+    /// `FakeTmuxDriver` do.
+    /// Test: `inject_interrupt_targets_pane_when_pane_id_known` in
+    /// `pane_scoped_tests.rs`; `send_interrupt_to_pane_default_fails_closed`
+    /// in this module's tests.
     fn send_interrupt_to_pane(&self, name: &str, pane_id: &str) -> Result<(), ManagedError> {
-        let _ = pane_id;
-        self.send_interrupt(name)
+        let _ = (name, pane_id);
+        Err(ManagedError::TmuxUnavailable(
+            "send_interrupt_to_pane not implemented for this driver".into(),
+        ))
     }
 
     /// Capture the last `lines` of pane output for the session named `name`.
@@ -181,20 +198,28 @@ pub trait ManagedTmuxDriver: Send + Sync {
     /// session-scoped capture reads whatever pane tmux considers active,
     /// which need not be the pane this record is actually about.
     /// What: the pane-scoped counterpart to [`Self::capture`]. The default
-    /// falls back to `capture(name, lines)` (session-scoped) for a legacy
-    /// record or a driver that predates pane-level addressing.
-    /// [`super::real_tmux::RealTmuxDriver`] overrides this to build an actual
-    /// pane-scoped `TmuxTarget`.
+    /// returns an explicit `TmuxUnavailable` error rather than silently
+    /// falling back to `capture(name, lines)` (session-scoped) (#2514 review,
+    /// minor finding 5) — the same fail-closed rationale as
+    /// [`Self::send_keys_literal_to_pane`]'s default: a silent session-scoped
+    /// fallback would regain the sibling-window hijack #2468 fixed for reads
+    /// too, with no compiler signal warning a future driver that it forgot to
+    /// override this. Any driver actually used with a known `pane_id` MUST
+    /// override this — both [`super::real_tmux::RealTmuxDriver`] and the
+    /// test-only `FakeTmuxDriver` do.
     /// Test: `observe_captures_pane_scoped_when_pane_id_known` in
-    /// `pane_scoped_tests.rs`.
+    /// `pane_scoped_tests.rs`; `capture_pane_default_fails_closed` in this
+    /// module's tests.
     fn capture_pane(
         &self,
         name: &str,
         pane_id: &str,
         lines: usize,
     ) -> Result<String, ManagedError> {
-        let _ = pane_id;
-        self.capture(name, lines)
+        let _ = (name, pane_id, lines);
+        Err(ManagedError::TmuxUnavailable(
+            "capture_pane not implemented for this driver".into(),
+        ))
     }
 
     /// Return the pane's current working directory for snapshot-before-stop (#1816).
@@ -347,5 +372,66 @@ pub trait ManagedTmuxDriver: Send + Sync {
             // No pid — best effort interrupt via tmux send-keys.
             let _ = self.send_interrupt(name);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal driver that overrides only the REQUIRED (non-defaulted)
+    /// trait methods, so `send_keys_literal_to_pane`, `send_interrupt_to_pane`,
+    /// and `capture_pane` all run the trait's own default bodies — exactly
+    /// the "a driver forgot to override this" scenario minor finding 5
+    /// (#2514 review) is guarding against.
+    struct MinimalDriver;
+
+    impl ManagedTmuxDriver for MinimalDriver {
+        fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+            Ok(())
+        }
+        fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
+            Ok(String::new())
+        }
+        fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn send_keys_literal_to_pane_default_fails_closed() {
+        let err = MinimalDriver
+            .send_keys_literal_to_pane("sess", "%1", "text")
+            .expect_err(
+                "a driver that does not override this must fail loudly, never \
+                 silently fall back to the session-scoped send",
+            );
+        assert!(matches!(err, ManagedError::TmuxUnavailable(_)));
+    }
+
+    #[test]
+    fn send_interrupt_to_pane_default_fails_closed() {
+        let err = MinimalDriver
+            .send_interrupt_to_pane("sess", "%1")
+            .expect_err(
+                "a driver that does not override this must fail loudly, never \
+                 silently fall back to the session-scoped interrupt",
+            );
+        assert!(matches!(err, ManagedError::TmuxUnavailable(_)));
+    }
+
+    #[test]
+    fn capture_pane_default_fails_closed() {
+        let err = MinimalDriver.capture_pane("sess", "%1", 50).expect_err(
+            "a driver that does not override this must fail loudly, never \
+                 silently fall back to the session-scoped capture",
+        );
+        assert!(matches!(err, ManagedError::TmuxUnavailable(_)));
     }
 }

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -254,21 +254,35 @@ impl SessionManager {
     ///
     /// Why: the calling agentic process resolves pending decisions by calling
     /// POST /sessions/{id}/answer; this method persists the answer and clears
-    /// pending_decision/proposed_default so they are not re-surfaced.
-    /// What: looks up the record, sends the answer text to the pane via tmux,
-    /// clears the pending fields, and persists.
-    /// Test: `manager_answer_decision` in tests.
+    /// pending_decision/proposed_default so they are not re-surfaced. This
+    /// route has the exact same sibling-window hijack risk #2468 fixed for
+    /// `inject`/`observe`: a session-scoped `send_line` lands in whichever
+    /// pane tmux currently considers active, not necessarily the pane the
+    /// pending decision was raised in.
+    /// What: looks up the record, [`Self::ensure_pane_alive`]-gates the
+    /// recorded `pane_id`, sends the answer text via `send_line_to_pane` when
+    /// `pane_id` is known (falling back to the session-scoped `send_line` for
+    /// a legacy record with no captured pane), clears the pending fields, and
+    /// persists.
+    /// Test: `manager_answer_decision` in tests;
+    /// `answer_decision_targets_pane_when_pane_id_known`,
+    /// `answer_decision_refuses_when_stored_pane_gone`,
+    /// `answer_decision_legacy_record_without_pane_id_falls_back_to_session_target`
+    /// in `pane_scoped_tests.rs`.
     pub async fn answer_decision(
         &self,
         id: &ManagedSessionId,
         answer: &str,
     ) -> Result<(), ManagedError> {
         let mut record = self.get(id).await?;
+        self.ensure_pane_alive(id, &record)?;
+        match record.pane_id.as_deref() {
+            Some(p) => self.tmux.send_line_to_pane(&record.tmux_name, p, answer),
+            None => self.tmux.send_line(&record.tmux_name, answer),
+        }
+        .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
         record.pending_decision = None;
         record.proposed_default = None;
-        self.tmux
-            .send_line(&record.tmux_name, answer)
-            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
         record.last_activity_at = Some(Utc::now());
         self.store.write().await.upsert(record).await?;
         Ok(())

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -353,16 +353,28 @@ impl SessionManager {
     /// Stopped/Decommissioned guard as [`send_input`](Self::send_input) so input
     /// is never sent to a dead pane.
     /// What: looks up the record, rejects Stopped/Decommissioned sessions, then
-    /// dispatches: [`Submit::Enter`] → `send_line` (literal + Enter),
-    /// [`Submit::NoSubmit`] → `send_keys_literal` (literal only),
-    /// [`Submit::Interrupt`] → `send_interrupt` (Ctrl-C). Bumps
-    /// `last_activity_at` ONLY for `Enter`/`NoSubmit`: an `Interrupt` (Ctrl-C) is
-    /// a STOP signal, not forward progress, so treating it as activity would
-    /// mislead the idle/orphan-GC reconciliation into believing a stalled session
-    /// is still working.
+    /// [`Self::ensure_pane_alive`]-gates the record's recorded `pane_id`
+    /// (issue #2468 — the same sibling-window hijack risk #2467 fixed for
+    /// resume/restart: typing into "the session" lands in whichever pane
+    /// tmux considers active, possibly an unrelated sibling shell) before
+    /// dispatching: [`Submit::Enter`] → `send_line`/`send_line_to_pane`
+    /// (literal + Enter), [`Submit::NoSubmit`] →
+    /// `send_keys_literal`/`send_keys_literal_to_pane` (literal only),
+    /// [`Submit::Interrupt`] → `send_interrupt`/`send_interrupt_to_pane`
+    /// (Ctrl-C) — the pane-scoped variant is used whenever `record.pane_id`
+    /// is known, the session-scoped one otherwise (legacy record, matching
+    /// #2467's fallback). Bumps `last_activity_at` ONLY for
+    /// `Enter`/`NoSubmit`: an `Interrupt` (Ctrl-C) is a STOP signal, not
+    /// forward progress, so treating it as activity would mislead the
+    /// idle/orphan-GC reconciliation into believing a stalled session is
+    /// still working.
     /// Test: `inject_dispatch_enter_sends_literal_then_enter`,
     /// `inject_dispatch_nosubmit_sends_literal_only`,
-    /// `inject_dispatch_interrupt_sends_ctrl_c` in tests/session_control_api.rs.
+    /// `inject_dispatch_interrupt_sends_ctrl_c` in tests/session_control_api.rs;
+    /// `inject_targets_pane_when_pane_id_known`,
+    /// `inject_refuses_when_stored_pane_gone`,
+    /// `inject_legacy_record_without_pane_id_falls_back_to_session_target`
+    /// in `pane_scoped_tests.rs`.
     pub async fn inject(
         &self,
         id: &ManagedSessionId,
@@ -379,10 +391,18 @@ impl SessionManager {
                 record.tmux_name, record.state
             )));
         }
-        let result = match submit {
-            Submit::Enter => self.tmux.send_line(&record.tmux_name, text),
-            Submit::NoSubmit => self.tmux.send_keys_literal(&record.tmux_name, text),
-            Submit::Interrupt => self.tmux.send_interrupt(&record.tmux_name),
+        self.ensure_pane_alive(id, &record)?;
+        let pane_id = record.pane_id.clone();
+        let result = match (submit, pane_id.as_deref()) {
+            (Submit::Enter, Some(p)) => self.tmux.send_line_to_pane(&record.tmux_name, p, text),
+            (Submit::Enter, None) => self.tmux.send_line(&record.tmux_name, text),
+            (Submit::NoSubmit, Some(p)) => {
+                self.tmux
+                    .send_keys_literal_to_pane(&record.tmux_name, p, text)
+            }
+            (Submit::NoSubmit, None) => self.tmux.send_keys_literal(&record.tmux_name, text),
+            (Submit::Interrupt, Some(p)) => self.tmux.send_interrupt_to_pane(&record.tmux_name, p),
+            (Submit::Interrupt, None) => self.tmux.send_interrupt(&record.tmux_name),
         };
         result.map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))?;
         // Interrupt is a STOP signal, not activity — do not bump last_activity_at.
@@ -399,20 +419,30 @@ impl SessionManager {
     /// actually showing (pane + liveness + any pending escalation) WITHOUT an LLM
     /// key. This bundles the three reads the managed activity route already does
     /// into one manager helper so `SessionControl::observe` is a thin mapping.
-    /// What: captures the last `lines` pane rows (empty string if the pane is
-    /// gone), probes `runtime_active` via `session_exists`, and reads the record's
+    /// [`Self::ensure_pane_alive`]-gates the recorded `pane_id` first (issue
+    /// #2468, same sibling-window hijack risk #2467 fixed for resume/restart):
+    /// capturing "the session" without this check could silently read a
+    /// sibling window's pane instead of the one this record actually owns.
+    /// What: captures the last `lines` pane rows via the pane-scoped
+    /// `capture_pane` when `record.pane_id` is known (session-scoped `capture`
+    /// otherwise — legacy record, matching #2467's fallback), probes
+    /// `runtime_active` via `session_exists`, and reads the record's
     /// `pending_decision` / `proposed_default`. Never calls the LLM.
-    /// Test: `observe_returns_raw_pane_without_llm`, `observe_reports_runtime_active`.
+    /// Test: `observe_returns_raw_pane_without_llm`, `observe_reports_runtime_active`,
+    /// `observe_captures_pane_scoped_when_pane_id_known`,
+    /// `observe_refuses_when_stored_pane_gone` in `pane_scoped_tests.rs`.
     pub async fn observe(
         &self,
         id: &ManagedSessionId,
         lines: usize,
     ) -> Result<crate::core::sm::control::RawObservation, ManagedError> {
         let record = self.get(id).await?;
-        let raw_pane = self
-            .tmux
-            .capture(&record.tmux_name, lines)
-            .unwrap_or_default();
+        self.ensure_pane_alive(id, &record)?;
+        let raw_pane = match record.pane_id.as_deref() {
+            Some(p) => self.tmux.capture_pane(&record.tmux_name, p, lines),
+            None => self.tmux.capture(&record.tmux_name, lines),
+        }
+        .unwrap_or_default();
         let runtime_active = self.tmux.session_exists(&record.tmux_name);
         Ok(crate::core::sm::control::RawObservation {
             raw_pane,
@@ -446,6 +476,51 @@ impl SessionManager {
         self.store.write().await.upsert(record.clone()).await?;
         info!(id = %id, name = %record.tmux_name, "managed session stopped (workspace intact)");
         Ok(record)
+    }
+
+    /// Confirm the record's recorded `pane_id` (when known) is still alive,
+    /// refusing loudly rather than letting a caller fall through to a
+    /// session-scoped tmux target that could resolve to an unrelated pane
+    /// (sibling-window hijack, follow-up to #2456/#2467, issue #2468).
+    ///
+    /// Why: `resume`, `inject`/`send_input`, and `observe` all address a
+    /// session's tmux pane, and all three share the SAME hole — a tmux
+    /// session stays "alive" as long as ANY pane/window in it is open, so
+    /// [`ManagedTmuxDriver::session_exists`] cannot tell "the recorded pane
+    /// survived" apart from "an unrelated sibling window is keeping the
+    /// session alive". #2467 closed this for the resume/restart respawn
+    /// path only; #2468 centralises the same check here so `inject` and
+    /// `observe` share it instead of duplicating (and risking drifting)
+    /// the logic.
+    /// What: a no-op (`Ok(())`) when `record.pane_id` is `None` — a legacy
+    /// record (pre-#2453) has no stronger signal than `session_exists`, so
+    /// it keeps the prior session-scoped behavior exactly as #2467
+    /// established — or when [`ManagedTmuxDriver::pane_exists`] confirms the
+    /// pane is present. Returns `Err(ManagedError::PaneGone(id, pane_id))`
+    /// when the pane is confirmed gone.
+    /// Test: `resume_refuses_when_stored_pane_gone_but_session_alive`
+    /// (`resume_reattach_tests.rs`); `inject_refuses_when_stored_pane_gone`,
+    /// `observe_refuses_when_stored_pane_gone`,
+    /// `inject_legacy_record_without_pane_id_falls_back_to_session_target`
+    /// (`pane_scoped_tests.rs`).
+    fn ensure_pane_alive(
+        &self,
+        id: &ManagedSessionId,
+        record: &SessionRecord,
+    ) -> Result<(), ManagedError> {
+        if let Some(pane_id) = record.pane_id.as_deref()
+            && !self.tmux.pane_exists(&record.tmux_name, pane_id)
+        {
+            warn!(
+                id = %id,
+                name = %record.tmux_name,
+                pane_id = %pane_id,
+                "recorded pane is gone but the tmux session is still alive (sibling window) \
+                 — refusing to operate on an unrelated active pane"
+            );
+            return Err(ManagedError::PaneGone(id.to_string(), pane_id.to_string()));
+        }
+        Ok(())
     }
 
     /// Mark a runtime-exited session `Stopped` WITHOUT killing its tmux pane (#2023 A).
@@ -679,22 +754,9 @@ impl SessionManager {
             // Sibling-window hijack fix (follow-up to #2456): `session_exists`
             // only proves SOME pane in this tmux session is alive — it says
             // nothing about whether it is the SPECIFIC pane this record is
-            // bound to. When a `pane_id` was captured, confirm that exact
-            // pane is still there before trusting the reuse; a legacy record
-            // with no captured `pane_id` (pre-#2453) has no stronger signal
-            // available and keeps the prior session-scoped behavior.
-            if let Some(pane_id) = record.pane_id.as_deref()
-                && !self.tmux.pane_exists(&record.tmux_name, pane_id)
-            {
-                warn!(
-                    id = %id,
-                    name = %record.tmux_name,
-                    pane_id = %pane_id,
-                    "resume: recorded pane is gone but the tmux session is still alive \
-                     (sibling window) — refusing to respawn into an unrelated active pane"
-                );
-                return Err(ManagedError::PaneGone(id.to_string(), pane_id.to_string()));
-            }
+            // bound to. `ensure_pane_alive` confirms that before trusting the
+            // reuse (see its doc for the legacy-record fallback).
+            self.ensure_pane_alive(id, &record)?;
             info!(
                 id = %id,
                 name = %record.tmux_name,

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -75,6 +75,12 @@ mod runtime_exit_reconcile_tests;
 #[cfg(test)]
 mod reload_error_tests;
 
+#[cfg(test)]
+mod pane_scoped_tests;
+
+#[cfg(test)]
+mod adopt_existing_tests;
+
 /// Real tmux driver adapter — only available when the `daemon` feature (and thus
 /// the daemon's `TmuxDriver`) is compiled in.
 #[cfg(feature = "daemon")]

--- a/crates/trusty-mpm/src/session_manager/pane_scoped_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/pane_scoped_tests.rs
@@ -1,17 +1,19 @@
-//! Tests for `SessionManager::inject`/`observe` pane-scoped targeting (#2468,
-//! the follow-up to #2467 that closes the same sibling-window hijack risk for
-//! `inject`/`send_input` and `observe`).
+//! Tests for `SessionManager::inject`/`observe`/`answer_decision` pane-scoped
+//! targeting (#2468, the follow-up to #2467 that closes the same
+//! sibling-window hijack risk for `inject`/`send_input`, `observe`, and the
+//! `answer_decision` route added in the #2514 adversarial-review pass).
 //!
 //! Why: `session_manager/tests.rs` and `resume_reattach_tests.rs` already
 //! cover `resume`'s pane-scoped respawn (#2467); this file is the parallel
-//! coverage for the two sites #2467 deliberately left out of scope — typing
-//! into a live session (`inject`) and reading its pane (`observe`) both
-//! addressed "the session" rather than the record's own recorded pane, which
-//! tmux resolves to whichever pane/window is currently ACTIVE.
-//! What: for both `inject` (across all three `Submit` dispatch variants) and
-//! `observe`, proves (a) a known-and-alive `pane_id` routes through the
-//! pane-scoped driver call, never the session-scoped one; (b) a
-//! confirmed-gone `pane_id` refuses loudly with `ManagedError::PaneGone`
+//! coverage for the sites #2467 deliberately left out of scope — typing
+//! into a live session (`inject`), reading its pane (`observe`), and
+//! answering a pending decision (`answer_decision`) all addressed "the
+//! session" rather than the record's own recorded pane, which tmux resolves
+//! to whichever pane/window is currently ACTIVE.
+//! What: for `inject` (across all three `Submit` dispatch variants),
+//! `observe`, and `answer_decision`, proves (a) a known-and-alive `pane_id`
+//! routes through the pane-scoped driver call, never the session-scoped one;
+//! (b) a confirmed-gone `pane_id` refuses loudly with `ManagedError::PaneGone`
 //! WITHOUT ever calling a session-scoped primitive; (c) a legacy record with
 //! no captured `pane_id` falls back to the session-scoped call exactly as
 //! #2467 established for `resume`.
@@ -166,6 +168,74 @@ async fn inject_legacy_record_without_pane_id_falls_back_to_session_target() {
     assert_eq!(
         fake.send_calls.lock().unwrap().as_slice(),
         [(record.tmux_name.clone(), "hello".to_string())],
+        "a legacy record (no captured pane_id) must use the session-scoped \
+         target exactly like pre-#2468 behavior"
+    );
+    assert!(fake.pane_send_calls.lock().unwrap().is_empty());
+}
+
+// ── answer_decision: pane-scoped-when-known / refuse-when-gone / legacy-fallback ──
+
+#[tokio::test]
+async fn answer_decision_targets_pane_when_pane_id_known() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+
+    mgr.answer_decision(&record.id, "rebase")
+        .await
+        .expect("answer_decision");
+
+    assert_eq!(
+        fake.pane_send_calls.lock().unwrap().as_slice(),
+        [(
+            record.tmux_name.clone(),
+            "%6015".to_string(),
+            "rebase".to_string()
+        )]
+    );
+    assert!(
+        fake.send_calls.lock().unwrap().is_empty(),
+        "a known-alive pane_id must never fall through to the session-scoped send"
+    );
+}
+
+#[tokio::test]
+async fn answer_decision_refuses_when_stored_pane_gone() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+    *fake.pane_exists_override.lock().unwrap() = Some(false);
+
+    let err = mgr
+        .answer_decision(&record.id, "rebase")
+        .await
+        .expect_err("a confirmed-gone recorded pane must refuse, not fall back");
+
+    assert!(
+        matches!(&err, ManagedError::PaneGone(sid, pid) if sid == &record.id.to_string() && pid == "%6015"),
+        "expected PaneGone(session_id, \"%6015\"), got: {err:?}"
+    );
+    assert!(
+        fake.send_calls.lock().unwrap().is_empty(),
+        "the session-scoped target must NEVER be constructed on refusal"
+    );
+    assert!(
+        fake.pane_send_calls.lock().unwrap().is_empty(),
+        "the pane-scoped call must not fire either — the whole operation refuses"
+    );
+}
+
+#[tokio::test]
+async fn answer_decision_legacy_record_without_pane_id_falls_back_to_session_target() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, None).await;
+
+    mgr.answer_decision(&record.id, "rebase")
+        .await
+        .expect("answer_decision on legacy record");
+
+    assert_eq!(
+        fake.send_calls.lock().unwrap().as_slice(),
+        [(record.tmux_name.clone(), "rebase".to_string())],
         "a legacy record (no captured pane_id) must use the session-scoped \
          target exactly like pre-#2468 behavior"
     );

--- a/crates/trusty-mpm/src/session_manager/pane_scoped_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/pane_scoped_tests.rs
@@ -1,0 +1,229 @@
+//! Tests for `SessionManager::inject`/`observe` pane-scoped targeting (#2468,
+//! the follow-up to #2467 that closes the same sibling-window hijack risk for
+//! `inject`/`send_input` and `observe`).
+//!
+//! Why: `session_manager/tests.rs` and `resume_reattach_tests.rs` already
+//! cover `resume`'s pane-scoped respawn (#2467); this file is the parallel
+//! coverage for the two sites #2467 deliberately left out of scope — typing
+//! into a live session (`inject`) and reading its pane (`observe`) both
+//! addressed "the session" rather than the record's own recorded pane, which
+//! tmux resolves to whichever pane/window is currently ACTIVE.
+//! What: for both `inject` (across all three `Submit` dispatch variants) and
+//! `observe`, proves (a) a known-and-alive `pane_id` routes through the
+//! pane-scoped driver call, never the session-scoped one; (b) a
+//! confirmed-gone `pane_id` refuses loudly with `ManagedError::PaneGone`
+//! WITHOUT ever calling a session-scoped primitive; (c) a legacy record with
+//! no captured `pane_id` falls back to the session-scoped call exactly as
+//! #2467 established for `resume`.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use tempfile::TempDir;
+
+use crate::core::sm::control::Submit;
+
+use super::manager::ManagedError;
+use super::record::ManagedSessionState;
+use super::tests::make_manager;
+
+/// Creates an Active session whose record carries the given `pane_id` (or
+/// none, for the legacy-record case), seeding the fake driver's
+/// `pane_id_override` BEFORE `create()` so it is captured into the record —
+/// mirrors `resume_reattach_tests.rs`'s seeding pattern.
+async fn make_active_session(
+    dir: &TempDir,
+    pane_id: Option<&str>,
+) -> (
+    super::manager::SessionManager,
+    std::sync::Arc<super::tests::FakeTmuxDriver>,
+    super::record::SessionRecord,
+) {
+    let (mgr, fake) = make_manager(dir).await;
+    *fake.pane_id_override.lock().unwrap() = pane_id.map(str::to_owned);
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(dir.path().to_path_buf()),
+            Some("pane-scoped-session".into()),
+            Some(dir.path().to_path_buf()),
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    assert_eq!(
+        record.pane_id.as_deref(),
+        pane_id,
+        "sanity: pane_id captured"
+    );
+
+    mgr.set_workspace(
+        &record.id,
+        dir.path().to_path_buf(),
+        ManagedSessionState::Active,
+    )
+    .await
+    .expect("set Active");
+
+    (mgr, fake, record)
+}
+
+// ── inject: pane-scoped-when-known / refuse-when-gone / legacy-fallback ─────
+
+#[tokio::test]
+async fn inject_targets_pane_when_pane_id_known() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+
+    mgr.inject(&record.id, "hello", Submit::Enter)
+        .await
+        .expect("inject enter");
+
+    assert_eq!(
+        fake.pane_send_calls.lock().unwrap().as_slice(),
+        [(
+            record.tmux_name.clone(),
+            "%6015".to_string(),
+            "hello".to_string()
+        )]
+    );
+    assert!(
+        fake.send_calls.lock().unwrap().is_empty(),
+        "a known-alive pane_id must never fall through to the session-scoped send"
+    );
+}
+
+#[tokio::test]
+async fn inject_nosubmit_targets_pane_when_pane_id_known() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+
+    mgr.inject(&record.id, "partial", Submit::NoSubmit)
+        .await
+        .expect("inject nosubmit");
+
+    assert_eq!(
+        fake.pane_literal_calls.lock().unwrap().as_slice(),
+        [(
+            record.tmux_name.clone(),
+            "%6015".to_string(),
+            "partial".to_string()
+        )]
+    );
+    assert!(fake.send_calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn inject_interrupt_targets_pane_when_pane_id_known() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+
+    mgr.inject(&record.id, "ignored", Submit::Interrupt)
+        .await
+        .expect("inject interrupt");
+
+    assert_eq!(
+        fake.pane_interrupt_calls.lock().unwrap().as_slice(),
+        [(record.tmux_name.clone(), "%6015".to_string())]
+    );
+    assert!(fake.interrupt_calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn inject_refuses_when_stored_pane_gone() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+    *fake.pane_exists_override.lock().unwrap() = Some(false);
+
+    let err = mgr
+        .inject(&record.id, "hello", Submit::Enter)
+        .await
+        .expect_err("a confirmed-gone recorded pane must refuse, not fall back");
+
+    assert!(
+        matches!(&err, ManagedError::PaneGone(sid, pid) if sid == &record.id.to_string() && pid == "%6015"),
+        "expected PaneGone(session_id, \"%6015\"), got: {err:?}"
+    );
+    assert!(
+        fake.send_calls.lock().unwrap().is_empty(),
+        "the session-scoped target must NEVER be constructed on refusal"
+    );
+    assert!(
+        fake.pane_send_calls.lock().unwrap().is_empty(),
+        "the pane-scoped call must not fire either — the whole operation refuses"
+    );
+}
+
+#[tokio::test]
+async fn inject_legacy_record_without_pane_id_falls_back_to_session_target() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, None).await;
+
+    mgr.inject(&record.id, "hello", Submit::Enter)
+        .await
+        .expect("inject enter on legacy record");
+
+    assert_eq!(
+        fake.send_calls.lock().unwrap().as_slice(),
+        [(record.tmux_name.clone(), "hello".to_string())],
+        "a legacy record (no captured pane_id) must use the session-scoped \
+         target exactly like pre-#2468 behavior"
+    );
+    assert!(fake.pane_send_calls.lock().unwrap().is_empty());
+}
+
+// ── observe: pane-scoped-when-known / refuse-when-gone / legacy-fallback ────
+
+#[tokio::test]
+async fn observe_captures_pane_scoped_when_pane_id_known() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+    // Keyed by PANE id (not session name) — proves observe used the
+    // pane-scoped capture, not the session-scoped one.
+    fake.capture_responses
+        .lock()
+        .unwrap()
+        .insert("%6015".to_string(), "pane-owned output".to_string());
+
+    let obs = mgr.observe(&record.id, 50).await.expect("observe");
+
+    assert_eq!(obs.raw_pane, "pane-owned output");
+    assert_eq!(
+        fake.pane_capture_calls.lock().unwrap().as_slice(),
+        [(record.tmux_name.clone(), "%6015".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn observe_refuses_when_stored_pane_gone() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+    *fake.pane_exists_override.lock().unwrap() = Some(false);
+
+    let err = mgr
+        .observe(&record.id, 50)
+        .await
+        .expect_err("a confirmed-gone recorded pane must refuse observe too");
+
+    assert!(
+        matches!(&err, ManagedError::PaneGone(sid, pid) if sid == &record.id.to_string() && pid == "%6015"),
+        "expected PaneGone(session_id, \"%6015\"), got: {err:?}"
+    );
+    assert!(fake.pane_capture_calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn observe_legacy_record_without_pane_id_falls_back_to_session_capture() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, None).await;
+    // Keyed by SESSION name — the legacy/session-scoped lookup path.
+    fake.capture_responses.lock().unwrap().insert(
+        record.tmux_name.clone(),
+        "session-scoped output".to_string(),
+    );
+
+    let obs = mgr.observe(&record.id, 50).await.expect("observe");
+
+    assert_eq!(obs.raw_pane, "session-scoped output");
+    assert!(fake.pane_capture_calls.lock().unwrap().is_empty());
+}

--- a/crates/trusty-mpm/src/session_manager/real_tmux.rs
+++ b/crates/trusty-mpm/src/session_manager/real_tmux.rs
@@ -87,10 +87,33 @@ impl ManagedTmuxDriver for RealTmuxDriver {
         self.driver.pane_exists(name, pane_id)
     }
 
+    /// Type literal text with NO trailing Enter into a SPECIFIC pane
+    /// (overrides the trait default so `inject`'s `Submit::NoSubmit`
+    /// dispatch actually lands in the recorded pane; #2468).
+    fn send_keys_literal_to_pane(
+        &self,
+        name: &str,
+        pane_id: &str,
+        text: &str,
+    ) -> Result<(), ManagedError> {
+        self.driver
+            .send_keys_literal(&TmuxTarget::pane(name, pane_id), text)
+            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
+    }
+
     /// Send Ctrl-C to the session (overrides the no-op trait default; #1461).
     fn send_interrupt(&self, name: &str) -> Result<(), ManagedError> {
         self.driver
             .send_interrupt(&TmuxTarget::session(name))
+            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
+    }
+
+    /// Send Ctrl-C to a SPECIFIC pane (overrides the trait default so
+    /// `inject`'s `Submit::Interrupt` dispatch actually targets the recorded
+    /// pane instead of tmux's session-scoped "active pane" resolution; #2468).
+    fn send_interrupt_to_pane(&self, name: &str, pane_id: &str) -> Result<(), ManagedError> {
+        self.driver
+            .send_interrupt(&TmuxTarget::pane(name, pane_id))
             .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
     }
 
@@ -102,6 +125,21 @@ impl ManagedTmuxDriver for RealTmuxDriver {
         let lines = u32::try_from(lines).unwrap_or(u32::MAX);
         self.driver
             .capture(&TmuxTarget::session(name), Some(lines))
+            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
+    }
+
+    /// Capture a SPECIFIC pane's output (overrides the trait default so
+    /// `observe` actually reads the recorded pane instead of tmux's
+    /// session-scoped "active pane" resolution; #2468).
+    fn capture_pane(
+        &self,
+        name: &str,
+        pane_id: &str,
+        lines: usize,
+    ) -> Result<String, ManagedError> {
+        let lines = u32::try_from(lines).unwrap_or(u32::MAX);
+        self.driver
+            .capture(&TmuxTarget::pane(name, pane_id), Some(lines))
             .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
     }
 

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -1,7 +1,11 @@
 //! Unit tests for the session manager.
 //!
 //! Why: tests in a separate file keep manager.rs under the 500 SLOC production
-//! cap while the 1500 SLOC test cap gives the test suite room to grow.
+//! cap while the 1500 SLOC test cap gives the test suite room to grow. The
+//! `manager_adopt_existing_*` tests were extracted to `adopt_existing_tests.rs`
+//! (issue #2468, same reason `reload_error_tests.rs` was split out — staying
+//! under this file's own 1500-SLOC test cap after the pane-scoped inject/observe
+//! `FakeTmuxDriver` additions).
 //! What: full lifecycle tests for create, stop (keep workspace), resume
 //! (re-spawn in existing workspace), decommission (remove workspace from disk),
 //! send_input, reconcile (gone tmux → Stopped), answer_decision,
@@ -74,6 +78,17 @@ pub struct FakeTmuxDriver {
     /// Records every `send_line_to_pane` call as `(session_name, pane_id,
     /// text)` (sibling-window hijack fix, follow-up to #2456).
     pub pane_send_calls: Mutex<Vec<(String, String, String)>>,
+    /// Records every `send_keys_literal_to_pane` call as `(session_name,
+    /// pane_id, text)` (issue #2468).
+    pub pane_literal_calls: Mutex<Vec<(String, String, String)>>,
+    /// Records every `send_interrupt_to_pane` call as `(session_name,
+    /// pane_id)` (issue #2468).
+    pub pane_interrupt_calls: Mutex<Vec<(String, String)>>,
+    /// Records every `capture_pane` call as `(session_name, pane_id)`; the
+    /// returned body is looked up from `capture_responses` BY PANE ID (not
+    /// session name), so a test can assert the pane-scoped path returns
+    /// pane-owned content distinct from a session-keyed response (#2468).
+    pub pane_capture_calls: Mutex<Vec<(String, String)>>,
 }
 
 impl FakeTmuxDriver {
@@ -91,6 +106,9 @@ impl FakeTmuxDriver {
             pane_id_override: Mutex::new(None),
             pane_exists_override: Mutex::new(None),
             pane_send_calls: Mutex::new(Vec::new()),
+            pane_literal_calls: Mutex::new(Vec::new()),
+            pane_interrupt_calls: Mutex::new(Vec::new()),
+            pane_capture_calls: Mutex::new(Vec::new()),
         })
     }
 }
@@ -201,6 +219,68 @@ impl ManagedTmuxDriver for FakeTmuxDriver {
             text.to_owned(),
         ));
         Ok(())
+    }
+
+    /// Overrides the trait default (which errors "not implemented") so
+    /// `inject`'s `Submit::NoSubmit` legacy (no `pane_id`) path is testable;
+    /// records `(name, text)` into `send_calls` — the SAME session-scoped log
+    /// `send_line` uses — so a legacy-record test can assert a session-scoped
+    /// call landed without caring which literal-vs-Enter primitive it was.
+    fn send_keys_literal(&self, name: &str, text: &str) -> Result<(), ManagedError> {
+        self.send_calls
+            .lock()
+            .unwrap()
+            .push((name.to_owned(), text.to_owned()));
+        Ok(())
+    }
+
+    /// Records `(name, pane_id, text)` (issue #2468) — proves `inject`'s
+    /// `Submit::NoSubmit` dispatch chose the pane-scoped path.
+    fn send_keys_literal_to_pane(
+        &self,
+        name: &str,
+        pane_id: &str,
+        text: &str,
+    ) -> Result<(), ManagedError> {
+        self.pane_literal_calls.lock().unwrap().push((
+            name.to_owned(),
+            pane_id.to_owned(),
+            text.to_owned(),
+        ));
+        Ok(())
+    }
+
+    /// Records `(name, pane_id)` (issue #2468) — proves `inject`'s
+    /// `Submit::Interrupt` dispatch chose the pane-scoped path.
+    fn send_interrupt_to_pane(&self, name: &str, pane_id: &str) -> Result<(), ManagedError> {
+        self.pane_interrupt_calls
+            .lock()
+            .unwrap()
+            .push((name.to_owned(), pane_id.to_owned()));
+        Ok(())
+    }
+
+    /// Records `(name, pane_id)` and returns the response keyed BY PANE ID —
+    /// deliberately a different keyspace than `capture`'s session-name
+    /// lookup, so a test can prove `observe` returned pane-owned content
+    /// rather than session-scoped content (issue #2468).
+    fn capture_pane(
+        &self,
+        name: &str,
+        pane_id: &str,
+        _lines: usize,
+    ) -> Result<String, ManagedError> {
+        self.pane_capture_calls
+            .lock()
+            .unwrap()
+            .push((name.to_owned(), pane_id.to_owned()));
+        Ok(self
+            .capture_responses
+            .lock()
+            .unwrap()
+            .get(pane_id)
+            .cloned()
+            .unwrap_or_default())
     }
 }
 
@@ -1161,151 +1241,6 @@ async fn manager_get_reflects_out_of_process_write() {
 /// What: seeds a live tmux name on the fake driver, adopts it, and asserts the
 /// record is `Active`, NOT created via `create_session`, and is retrievable.
 /// Test: this function IS the test.
-#[tokio::test]
-async fn manager_adopt_existing_registers_active() {
-    let dir = TempDir::new().unwrap();
-    let (mgr, fake) = make_manager(&dir).await;
-
-    // The pane already exists (operator started it outside trusty-mpm).
-    fake.seeded_names
-        .lock()
-        .unwrap()
-        .push("tmpm-hand-started".into());
-
-    let record = mgr
-        .adopt_existing(
-            "tmpm-hand-started",
-            PathBuf::from("/Users/op/work/proj"),
-            "drive my hand-started session".into(),
-            crate::runtime::RuntimeKind::default(),
-            false,
-        )
-        .await
-        .expect("adopt existing");
-
-    assert_eq!(record.tmux_name, "tmpm-hand-started");
-    assert_eq!(record.state, ManagedSessionState::Active);
-    assert_eq!(record.cwd, PathBuf::from("/Users/op/work/proj"));
-    assert_eq!(record.task, "drive my hand-started session");
-
-    // Adoption must NOT spawn a new tmux session — the pane already exists.
-    assert!(
-        fake.create_cwd_calls.lock().unwrap().is_empty(),
-        "adopt_existing must NOT call create_session; calls: {:?}",
-        fake.create_cwd_calls.lock().unwrap()
-    );
-
-    // The record is durably queryable.
-    let got = mgr.get(&record.id).await.expect("get adopted");
-    assert_eq!(got.id, record.id);
-    assert_eq!(got.state, ManagedSessionState::Active);
-}
-
-/// Adopting a tmux name that does NOT exist on the host must error — you cannot
-/// adopt a pane that is not there (#1433).
-///
-/// Why: this is the inverse of `create`'s NameCollision guard. The error must be
-/// the dedicated `TmuxSessionMissing` variant so the HTTP layer maps it to a 404.
-/// What: adopts a name the driver does not report and asserts the typed error.
-/// Test: this function IS the test.
-#[tokio::test]
-async fn manager_adopt_existing_missing_tmux_errors() {
-    let dir = TempDir::new().unwrap();
-    let (mgr, _fake) = make_manager(&dir).await;
-
-    let err = mgr
-        .adopt_existing(
-            "tmpm-not-here",
-            PathBuf::from("/tmp/x"),
-            String::new(),
-            crate::runtime::RuntimeKind::default(),
-            false,
-        )
-        .await
-        .expect_err("adopting a nonexistent pane must fail");
-
-    assert!(
-        matches!(err, ManagedError::TmuxSessionMissing(ref n) if n == "tmpm-not-here"),
-        "expected TmuxSessionMissing, got {err:?}"
-    );
-}
-
-/// Adopting a tmux name the store ALREADY tracks must error — no double records
-/// for one pane (#1433).
-///
-/// Why: a second record for the same pane would split ownership and confuse every
-/// downstream verb. The dedicated `AlreadyAdopted` variant lets the HTTP layer map
-/// it to a 409 Conflict.
-/// What: adopts once (succeeds), then adopts the same live name again and asserts
-/// the second call returns `AlreadyAdopted`.
-/// Test: this function IS the test.
-#[tokio::test]
-async fn manager_adopt_existing_double_adopt_errors() {
-    let dir = TempDir::new().unwrap();
-    let (mgr, fake) = make_manager(&dir).await;
-
-    fake.seeded_names.lock().unwrap().push("tmpm-once".into());
-
-    mgr.adopt_existing(
-        "tmpm-once",
-        PathBuf::from("/tmp/once"),
-        String::new(),
-        crate::runtime::RuntimeKind::default(),
-        false,
-    )
-    .await
-    .expect("first adopt succeeds");
-
-    let err = mgr
-        .adopt_existing(
-            "tmpm-once",
-            PathBuf::from("/tmp/once"),
-            String::new(),
-            crate::runtime::RuntimeKind::default(),
-            false,
-        )
-        .await
-        .expect_err("second adopt of the same pane must fail");
-
-    assert!(
-        matches!(err, ManagedError::AlreadyAdopted(ref n) if n == "tmpm-once"),
-        "expected AlreadyAdopted, got {err:?}"
-    );
-}
-
-/// The explicit adopt path must allow NON-`tmpm-` names (unlike reconcile, which
-/// filters to the `tmpm-` prefix for safe automatic adoption) (#1433).
-///
-/// Why: an operator naming a pane explicitly knows what they are adopting; the
-/// `tmpm-` prefix filter exists only to make AUTOMATIC boot adoption safe. The
-/// explicit path must not reject a session just because it lacks the prefix.
-/// What: seeds a non-`tmpm-` live name, adopts it, and asserts success.
-/// Test: this function IS the test.
-#[tokio::test]
-async fn manager_adopt_existing_allows_non_tmpm_name() {
-    let dir = TempDir::new().unwrap();
-    let (mgr, fake) = make_manager(&dir).await;
-
-    fake.seeded_names
-        .lock()
-        .unwrap()
-        .push("my-cli-session".into());
-
-    let record = mgr
-        .adopt_existing(
-            "my-cli-session",
-            PathBuf::from("/Users/op/repo"),
-            "adopt non-prefixed".into(),
-            crate::runtime::RuntimeKind::default(),
-            false,
-        )
-        .await
-        .expect("non-tmpm names are adoptable on the explicit path");
-
-    assert_eq!(record.tmux_name, "my-cli-session");
-    assert_eq!(record.state, ManagedSessionState::Active);
-}
-
 /// Corrupt the manager's backing `sessions.json` so the next reload-on-read
 /// fails. Writing garbage (a) changes the file length so `reload_if_changed`
 /// detects a change and re-reads, and (b) makes `serde_json::from_str` fail with
@@ -1504,37 +1439,6 @@ async fn manager_create_persists_ephemeral_flag() {
     assert!(
         !mgr.get(&durable.id).await.unwrap().ephemeral,
         "durable stays false"
-    );
-}
-
-/// `adopt_existing` persists the caller-supplied `ephemeral` flag (#1508).
-///
-/// Why: the e2e harness adopts panes as ephemeral; the flag must reach the record.
-/// What: seeds a live pane, adopts it with `ephemeral=true`, asserts it persisted.
-/// Test: this function IS the test.
-#[tokio::test]
-async fn manager_adopt_existing_persists_ephemeral_flag() {
-    let dir = TempDir::new().unwrap();
-    let (mgr, fake) = make_manager(&dir).await;
-    fake.seeded_names
-        .lock()
-        .unwrap()
-        .push("tmpm-eph-adopt".into());
-
-    let record = mgr
-        .adopt_existing(
-            "tmpm-eph-adopt",
-            PathBuf::from("/tmp/adopt"),
-            "throwaway adopt".into(),
-            crate::runtime::RuntimeKind::default(),
-            true,
-        )
-        .await
-        .expect("adopt ephemeral");
-
-    assert!(
-        mgr.get(&record.id).await.unwrap().ephemeral,
-        "adopted ephemeral flag persisted"
     );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #2467, which fixed the resume/restart respawn path to target the session record's stored `pane_id` instead of a session-scoped tmux target — tmux resolves a session-scoped target to whichever pane is currently ACTIVE, which can be an unrelated sibling window opened after the original pane. #2467 deliberately left three same-risk call sites out of scope; this PR closes all three (issue #2468):

1. **`SessionManager::inject`/`send_input`** (`crates/trusty-mpm/src/session_manager/manager.rs`) — typed input (e.g. answers, task injection) previously addressed "the session," which could land in an arbitrary sibling shell.
2. **`SessionManager::observe`** (same file) — the LLM-free pane read previously captured "the session," which could silently read the wrong pane's content.
3. **Dashboard `claude-config` restart route** (`crates/trusty-mpm/src/daemon/claude_config/restarter.rs` + `crates/trusty-mpm/src/daemon/api/claude_config_routes.rs`) — `ClaudeCodeRestarter::restart_in_session` sent Ctrl-C + relaunch to a session-scoped target only.

## How each site now resolves the pane

- `ManagedTmuxDriver` (`session_manager/driver.rs`) gained `send_keys_literal_to_pane`, `send_interrupt_to_pane`, and `capture_pane`, following #2467's `send_line_to_pane`/`pane_exists` precedent exactly — each has a session-scoped default fallback, and `RealTmuxDriver` (`session_manager/real_tmux.rs`) overrides all three to build a genuine pane-scoped `TmuxTarget`.
- `SessionManager::inject` now dispatches all three `Submit` variants (`Enter`/`NoSubmit`/`Interrupt`) through the pane-scoped primitive whenever `record.pane_id` is known, session-scoped otherwise.
- `SessionManager::observe` now captures via `capture_pane` whenever `record.pane_id` is known, `capture` otherwise.
- `ClaudeCodeRestarter::restart_in_session` gained a `pane_id: Option<&str>` parameter and a new pure `restart_target` decision function; the daemon route (`restart_claude_code`) looks up the managed record whose `tmux_name` matches the request and passes its `pane_id` through.

## Refusal semantics (matches #2467 exactly)

A new shared `SessionManager::ensure_pane_alive` helper — now also used by `resume` (replacing its inline check, no behavior change) — refuses with `ManagedError::PaneGone(session_id, pane_id)` whenever `record.pane_id` is known but `ManagedTmuxDriver::pane_exists` reports it gone. The session-scoped target is **never constructed** in that branch. The dashboard restart route mirrors this via `restart_target`, which returns an `Err` naming the session and pane instead of falling back to a session-scoped target.

## Legacy-record behavior

A record with no captured `pane_id` (pre-#2453) keeps the exact prior session-scoped behavior at every site — `ensure_pane_alive`/`restart_target` no-op in that case, matching #2467's documented fallback convention.

## Test evidence

New pure/unit-level coverage (no live tmux required):
- `session_manager/pane_scoped_tests.rs` — `inject`/`observe` × {pane known+alive → pane-scoped call, pane known+gone → `PaneGone` refusal with no session-scoped fallback, no pane_id → session-scoped legacy fallback}, across all three `Submit` variants for `inject`.
- `daemon/claude_config/restarter.rs`'s new `tests` module — `restart_target_uses_pane_when_alive`, `restart_target_refuses_when_pane_gone`, `restart_target_falls_back_to_session_for_legacy_caller`.
- `session_manager/tests.rs`'s `FakeTmuxDriver` gained pane-scoped call recording (`pane_literal_calls`, `pane_interrupt_calls`, `pane_capture_calls`) mirroring #2467's `pane_send_calls`.
- No live-tmux tests added — #2467's existing `#[ignore]` live integration test (`live_pane_scoped_send_targets_original_pane_not_sibling`) was left as-is per the task scope (extending it was optional).
- `session_manager/tests.rs`'s `manager_adopt_existing_*` tests were extracted to a new `adopt_existing_tests.rs` to stay under the 1500-SLOC test cap after the `FakeTmuxDriver` additions (same precedent as the earlier `reload_error_tests.rs` split).

## Quality gate (raw tails)

```
$ cargo build --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.21s

$ cargo test -p trusty-mpm
test result: ok. 2931 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out
(all other test binaries: 0 failed across the full suite)

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 34.28s
(zero clippy warnings for trusty-mpm; unrelated pre-existing tga MSRV warning only)

$ cargo fmt --check
(clean — no diff)

$ bash scripts/check_line_cap.sh
line-cap: 0 allowlisted, 0 violations — OK.
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-mpm` (full suite, 0 failures)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools