### PR TITLE
fix(trusty-mpm): any-pane-live aggregation in session_end_pane_still_live (closes #2463)

### DIFF
--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -1396,32 +1396,35 @@ async fn correlate_session_start(
 /// supervisor) type into a pane the outgoing runtime hasn't relinquished yet.
 /// This reuses the EXACT SAME classification the 60-second runtime-exit
 /// reaper already trusts for this question —
-/// [`crate::daemon::runtime_reap::pane_runtime_exited`] (idle-shell allowlist
-/// combined with the [`ChildLivenessProbe`] fail-closed gate) — instead of
-/// inventing a second one, so the two call sites can never disagree about
-/// what "exited" means.
-/// What: finds the pane whose `session_name` matches `tmux_name` in `panes`
-/// and returns `true` (defer) only when a match exists AND
-/// [`pane_runtime_exited`](crate::daemon::runtime_reap::pane_runtime_exited)
-/// reports it as NOT yet exited. When no matching pane is found (already
-/// gone, or tmux/pane enumeration was unavailable and `panes` is empty) this
-/// returns `false` (proceed) — there is nothing to protect from a destructive
-/// teardown here, since `mark_runtime_exited_stopped` never touches the pane
-/// either way; a genuinely vanished session is left to the #1744 reaper as
-/// before. Pure — no I/O — so it is unit-testable without a live tmux.
+/// [`crate::daemon::runtime_reap::session_has_live_pane`] (any-pane-live
+/// aggregation over the idle-shell allowlist and the [`ChildLivenessProbe`]
+/// fail-closed gate) — instead of inventing a second one, so the two call
+/// sites can never disagree about what "exited" means.
+/// What: delegates directly to
+/// [`session_has_live_pane`](crate::daemon::runtime_reap::session_has_live_pane),
+/// which returns `true` (defer) when ANY pane whose `session_name` matches
+/// `tmux_name` is NOT yet exited. Fixed by #2463: this previously used
+/// `panes.iter().find(...)` — the FIRST matching pane only — which
+/// misclassified a manually-split, multi-pane managed session as idle
+/// whenever `tmux list-panes -a` happened to return an idle pane ahead of a
+/// live one. When no matching pane is found (already gone, or tmux/pane
+/// enumeration was unavailable and `panes` is empty) this returns `false`
+/// (proceed) — there is nothing to protect from a destructive teardown here,
+/// since `mark_runtime_exited_stopped` never touches the pane either way; a
+/// genuinely vanished session is left to the #1744 reaper as before. Pure —
+/// no I/O — so it is unit-testable without a live tmux.
 /// Test: `session_end_pane_still_live_true_for_running_agent`,
 /// `session_end_pane_still_live_false_for_idle_shell`,
-/// `session_end_pane_still_live_false_when_pane_missing` in `api_tests.rs`.
+/// `session_end_pane_still_live_false_when_pane_missing`,
+/// `session_end_pane_still_live_true_when_any_of_multiple_panes_live`,
+/// `session_end_pane_still_live_false_when_all_of_multiple_panes_idle` in
+/// `api_tests.rs`.
 fn session_end_pane_still_live(
     tmux_name: &str,
     panes: &[crate::daemon::orphan_gc::PaneInfo],
     probe: &dyn crate::daemon::orphan_gc::ChildLivenessProbe,
 ) -> bool {
-    panes
-        .iter()
-        .find(|p| p.session_name == tmux_name)
-        .map(|p| !crate::daemon::runtime_reap::pane_runtime_exited(p, probe))
-        .unwrap_or(false)
+    crate::daemon::runtime_reap::session_has_live_pane(tmux_name, panes, probe)
 }
 
 /// Immediately mark a managed session Stopped on `SessionEnd`, WITHOUT killing

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1829,3 +1829,38 @@ fn session_end_pane_still_live_false_when_pane_missing() {
         "a missing pane must fail open (not classified as still-live)"
     );
 }
+
+#[test]
+fn session_end_pane_still_live_true_when_any_of_multiple_panes_live() {
+    // Why (#2463): a manually-split managed session has multiple panes
+    // sharing the same `tmux_name`. If `tmux list-panes -a` returns the IDLE
+    // pane before the LIVE one, the old `.find()`-based check picked the
+    // first match and misclassified a genuinely-live session as idle. The
+    // gate must aggregate across ALL panes for the session, exactly like
+    // `runtime_reap::find_runtime_exited`.
+    use crate::daemon::orphan_gc::AlwaysIdleProbe;
+    let panes = vec![
+        pane_for_gate_test("tmpm-split", "zsh"),
+        pane_for_gate_test("tmpm-split", "claude"),
+    ];
+    assert!(
+        session_end_pane_still_live("tmpm-split", &panes, &AlwaysIdleProbe),
+        "an idle pane listed before a live sibling pane must not mask the live one"
+    );
+}
+
+#[test]
+fn session_end_pane_still_live_false_when_all_of_multiple_panes_idle() {
+    // Why (#2463): the multi-pane aggregation must still return `false` when
+    // every pane for the session is genuinely idle — parity with the
+    // single-pane case, not an over-broad "any pane present" check.
+    use crate::daemon::orphan_gc::AlwaysIdleProbe;
+    let panes = vec![
+        pane_for_gate_test("tmpm-split", "zsh"),
+        pane_for_gate_test("tmpm-split", "-bash"),
+    ];
+    assert!(
+        !session_end_pane_still_live("tmpm-split", &panes, &AlwaysIdleProbe),
+        "a session whose every pane is idle must not be classified as still-live"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/runtime_reap.rs
+++ b/crates/trusty-mpm/src/daemon/runtime_reap.rs
@@ -45,8 +45,8 @@
 //! `graceful_terminate_runtime` and kill the pane, because those are
 //! human/client-initiated teardown requests, not self-healing state reconciles.
 //!
-//! Test: `pane_runtime_exited_*`, `find_runtime_exited_*`, and the end-to-end
-//! `stop_runtime_exited_transitions_active_to_stopped` /
+//! Test: `pane_runtime_exited_*`, `session_has_live_pane_*`, `find_runtime_exited_*`,
+//! and the end-to-end `stop_runtime_exited_transitions_active_to_stopped` /
 //! `stop_runtime_exited_keeps_running_session` /
 //! `stop_runtime_exited_does_not_kill_pane` in the `tests` module below drive a
 //! real [`SessionManager`] backed by [`crate::session_manager::FakeNoopTmuxDriver`]
@@ -75,6 +75,35 @@ use crate::session_manager::{
 /// `pane_runtime_exited_false_for_agent`, `pane_runtime_exited_false_with_live_child`.
 pub fn pane_runtime_exited(pane: &PaneInfo, probe: &dyn ChildLivenessProbe) -> bool {
     is_idle_shell(&pane.pane_current_command) && !probe.has_live_child(pane.pane_pid)
+}
+
+/// True when ANY pane belonging to `tmux_name` still shows a live runtime.
+///
+/// Why (#2463): a manually-split managed session can have more than one pane
+/// sharing the same `tmux_name`. Any single-pane check (e.g. `panes.iter().find(...)`)
+/// is at the mercy of `tmux list-panes -a` ordering — if an idle pane happens to
+/// sort before a live one, a genuinely-live session gets misclassified as idle.
+/// [`find_runtime_exited`] already gets this right by aggregating across every
+/// pane for a session; this helper extracts that same any-pane-live rule as a
+/// single, reusable, per-session primitive so every call site (the runtime
+/// reaper here and the `SessionEnd` gate in `daemon::api`) agrees on what "the
+/// session's pane(s) are live" means.
+/// What: returns `true` iff at least one pane in `panes` has `session_name ==
+/// tmux_name` AND is NOT [`pane_runtime_exited`]. A session with no matching
+/// pane at all (already gone, or enumeration failed) returns `false` — there is
+/// nothing to protect. Pure — no I/O.
+/// Test: `session_has_live_pane_true_when_any_pane_live`,
+/// `session_has_live_pane_false_when_all_panes_idle`,
+/// `session_has_live_pane_false_when_no_pane_matches`.
+pub fn session_has_live_pane(
+    tmux_name: &str,
+    panes: &[PaneInfo],
+    probe: &dyn ChildLivenessProbe,
+) -> bool {
+    panes
+        .iter()
+        .filter(|p| p.session_name == tmux_name)
+        .any(|p| !pane_runtime_exited(p, probe))
 }
 
 /// Collect the ids of `Active` sessions whose tmux pane is present but exited.
@@ -293,6 +322,52 @@ mod tests {
         assert!(!pane_runtime_exited(
             &pane("tmpm-a", "zsh"),
             &AlwaysLiveProbe
+        ));
+    }
+
+    #[test]
+    fn session_has_live_pane_true_when_any_pane_live() {
+        // #2463: a manually-split session where `tmux list-panes -a` returns the
+        // IDLE pane before the LIVE one must still be classified as live overall —
+        // ordering must never matter.
+        let panes = vec![pane("tmpm-split", "zsh"), pane("tmpm-split", "claude")];
+        assert!(
+            session_has_live_pane("tmpm-split", &panes, &AlwaysIdleProbe),
+            "any live pane in the session must make the whole session live"
+        );
+    }
+
+    #[test]
+    fn session_has_live_pane_false_when_all_panes_idle() {
+        let panes = vec![pane("tmpm-split", "zsh"), pane("tmpm-split", "-bash")];
+        assert!(
+            !session_has_live_pane("tmpm-split", &panes, &AlwaysIdleProbe),
+            "a session whose every pane is idle must not be classified as live"
+        );
+    }
+
+    #[test]
+    fn session_has_live_pane_false_when_no_pane_matches() {
+        let panes = vec![pane("some-other-session", "claude")];
+        assert!(
+            !session_has_live_pane("tmpm-gone", &panes, &AlwaysIdleProbe),
+            "no matching pane means nothing to protect — must fail open (not live)"
+        );
+    }
+
+    #[test]
+    fn session_has_live_pane_single_pane_unchanged() {
+        // Parity check: single-pane sessions (the common case) behave exactly as
+        // the old `.find()`-based check did.
+        assert!(session_has_live_pane(
+            "tmpm-a",
+            &[pane("tmpm-a", "claude")],
+            &AlwaysIdleProbe
+        ));
+        assert!(!session_has_live_pane(
+            "tmpm-a",
+            &[pane("tmpm-a", "zsh")],
+            &AlwaysIdleProbe
         ));
     }
 


### PR DESCRIPTION
## Root cause

`session_end_pane_still_live` (added in #2455, `crates/trusty-mpm/src/daemon/api.rs`) used `panes.iter().find(|p| p.session_name == tmux_name)` — the FIRST matching pane only. `runtime_reap::find_runtime_exited` (the 60s runtime-exit reaper) instead aggregates across ALL panes for a session and treats it as live if ANY pane is live.

For a manually-split multi-pane managed session, if `tmux list-panes -a` happened to return an idle pane before a live one, the `SessionEnd` gate would misclassify a genuinely-live session as idle and let the `Stopped` transition proceed early — the exact race #2455 was written to prevent, just re-opened for the multi-pane case. Narrow edge case (managed sessions are single-pane by construction) but real once an operator splits the window by hand.

## Fix — shared helper

Extracted the any-pane-live aggregation rule into a new pure function in `crates/trusty-mpm/src/daemon/runtime_reap.rs`:

```rust
pub fn session_has_live_pane(
    tmux_name: &str,
    panes: &[PaneInfo],
    probe: &dyn ChildLivenessProbe,
) -> bool {
    panes
        .iter()
        .filter(|p| p.session_name == tmux_name)
        .any(|p| !pane_runtime_exited(p, probe))
}
```

`session_end_pane_still_live` in `daemon/api.rs` now delegates to this helper directly (one line), so the `SessionEnd` gate and the runtime reaper share the exact same "is this session's runtime still alive" definition and can never disagree again. `find_runtime_exited` was left as-is — its existing hash-set-based aggregation already implements the same any-pane-live rule efficiently over many records at once; no behavior change there, just a second call site now backed by the same primitive semantics.

Kept the edit in `api.rs` minimal (net +3 lines in api.rs, doc-comment reference update + one-line body swap) since `api.rs` is already ~1210 real SLOC and known to evade the line-cap counter (#2489); the new logic lives in the smaller sibling module `runtime_reap.rs` instead.

## Test evidence

Added to `runtime_reap.rs`: `session_has_live_pane_true_when_any_pane_live` (idle pane listed before a live sibling — the exact #2463 repro), `session_has_live_pane_false_when_all_panes_idle`, `session_has_live_pane_false_when_no_pane_matches`, `session_has_live_pane_single_pane_unchanged` (parity with the old `.find()` behavior for the common single-pane case).

Added to `api_tests.rs`: `session_end_pane_still_live_true_when_any_of_multiple_panes_live`, `session_end_pane_still_live_false_when_all_of_multiple_panes_idle`, alongside the existing #2454 single-pane tests (`session_end_pane_still_live_true_for_running_agent` / `_false_for_idle_shell` / `_false_when_pane_missing`), all still passing.

```
$ cargo test -p trusty-mpm --lib -- session_end_pane_still_live session_has_live_pane find_runtime_exited pane_runtime_exited --test-threads=4
running 15 tests
test daemon::api::tests::session_end_pane_still_live_false_when_pane_missing ... ok
test daemon::api::tests::session_end_pane_still_live_false_for_idle_shell ... ok
test daemon::api::tests::session_end_pane_still_live_true_for_running_agent ... ok
test daemon::api::tests::session_end_pane_still_live_false_when_all_of_multiple_panes_idle ... ok
test daemon::api::tests::session_end_pane_still_live_true_when_any_of_multiple_panes_live ... ok
test daemon::runtime_reap::tests::pane_runtime_exited_false_for_agent ... ok
test daemon::runtime_reap::tests::pane_runtime_exited_false_with_live_child ... ok
test daemon::runtime_reap::tests::pane_runtime_exited_true_for_bare_shell ... ok
test daemon::runtime_reap::tests::session_has_live_pane_false_when_all_panes_idle ... ok
test daemon::runtime_reap::tests::session_has_live_pane_false_when_no_pane_matches ... ok
test daemon::runtime_reap::tests::session_has_live_pane_single_pane_unchanged ... ok
test daemon::runtime_reap::tests::session_has_live_pane_true_when_any_pane_live ... ok
test daemon::runtime_reap::tests::find_runtime_exited_skips_missing_pane ... ok
test daemon::runtime_reap::tests::find_runtime_exited_skips_non_active ... ok
test daemon::runtime_reap::tests::find_runtime_exited_selects_only_exited_active ... ok
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 2925 filtered out; finished in 0.00s
```

Full `cargo test -p trusty-mpm`: 2934 passed, 1 failed (`services::manifest::tests::manifest_expands_tilde` — unrelated pre-existing HOME-env-var test-parallelism flake, same category as the documented `home_trust_seed::tests::is_idempotent` flake; confirmed passing in isolation, untouched by this change).

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-mpm` — 2934 passed, 1 unrelated pre-existing flake (passes in isolation)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations — OK`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
