### PR TITLE
feat(trusty-common): universal config keys CLI module (set/list/test/unset)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7956,6 +7956,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7963,6 +7974,16 @@ checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10851,6 +10872,7 @@ dependencies = [
  "candle-nn 0.8.4",
  "candle-transformers",
  "chrono",
+ "clap",
  "colored 2.2.0",
  "crossterm",
  "dashmap 6.2.1",
@@ -10880,6 +10902,7 @@ dependencies = [
  "redb 4.1.0",
  "regex",
  "reqwest 0.12.28",
+ "rpassword",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,10 @@ tar = "0.4"
 # Semantic-version parsing for GitHub release tag comparison (trusty-installer Phase 2).
 semver = { version = "1", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
+# Hidden (no-echo) terminal input for the universal `config keys set` verb
+# (issue #2404), gated behind trusty-common's `config-cli` feature. Reads a
+# secret from the TTY without echoing it so keys never land in shell history.
+rpassword = "7"
 toml = "0.8"
 libc = "0.2"
 unicode-width = "0.2"

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -59,6 +59,16 @@ name = "inference_adapters"
 path = "tests/inference_adapters.rs"
 required-features = ["inference-client", "axum-server"]
 
+# Universal `config keys` CLI suite (issue #2404). Drives the `config keys`
+# argv grammar + the set/list/test/unset operations through the injectable
+# `inference::config::ops` seam, with the live `test` probe hitting the axum
+# `MockInferenceServer`. Needs BOTH `config-cli` (the command + ops) and
+# `axum-server` (the HTTP mock); `required-features` skips it otherwise.
+[[test]]
+name = "config_keys_cli"
+path = "tests/config_keys_cli.rs"
+required-features = ["config-cli", "axum-server"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -159,6 +169,13 @@ dotenvy = { workspace = true, optional = true }
 # Optional: enabled by the `keyring-store` feature (issue #2401). OS-keychain
 # backend for `inference::credentials::KeyringStore`.
 keyring = { workspace = true, optional = true }
+# Optional: enabled by the `config-cli` feature (issue #2404). `clap` provides
+# the derive surface for the universal `config` command; `rpassword` reads a key
+# from the TTY without echo for `config keys set`. Both are workspace deps used
+# elsewhere; gating them keeps the base library (and its `inference-client`
+# consumers) free of a clap/CLI dependency.
+clap = { workspace = true, optional = true }
+rpassword = { workspace = true, optional = true }
 
 # Optional: enabled by the `cli-help` feature. Declarative help-config parsing
 # (YAML → `HelpConfig`) plus the "did you mean?" suggester for unknown
@@ -503,3 +520,11 @@ keyring-store = ["credentials", "dep:keyring"]
 # is not pulled in by this feature, keeping the base surface HTTP-server-free.
 # Concrete provider adapters (OpenRouter/Fireworks/Bedrock) land in #2403/#2407.
 inference-client = ["credentials"]
+# Enables the `inference::config` module (issue #2404, epic #2400 Wave 1): the
+# universal `config` clap command (`ConfigCommand`) that any binary mounts with
+# two lines, exposing `config keys set/list/test/unset` for inference-provider
+# credentials. Implies `inference-client` (it builds adapters for the live `test`
+# probe) and pulls in `clap` (the derive surface) plus `rpassword` (hidden TTY
+# input for `set`). A default (no-features) `trusty-common` build compiles
+# neither this module nor `clap`; only binaries that mount the command enable it.
+config-cli = ["inference-client", "dep:clap", "dep:rpassword"]

--- a/crates/trusty-common/src/inference/config/keys.rs
+++ b/crates/trusty-common/src/inference/config/keys.rs
@@ -106,6 +106,15 @@ impl KeysCommand {
         let stdout = std::io::stdout();
         match self.verb {
             KeysVerb::Set(args) => {
+                if args.value.is_some() {
+                    // Best-effort nudge: an inline VALUE argument lands in shell
+                    // history/process-list on most systems. Warn on stderr (never
+                    // the value itself) without blocking the scriptable path.
+                    eprintln!(
+                        "warning: passing the key inline may leave it in your shell history; \
+                         omit VALUE for a hidden prompt, or pipe it via stdin."
+                    );
+                }
                 let value = source_set_value(args.value)?;
                 ops::set(store.as_ref(), &args.provider, &value, &mut stdout.lock())
             }

--- a/crates/trusty-common/src/inference/config/keys.rs
+++ b/crates/trusty-common/src/inference/config/keys.rs
@@ -1,0 +1,152 @@
+//! `config keys <verb>` — the credential-management feature (issue #2404).
+//!
+//! Why: this is the credential half of the universal `config` module — the
+//! verbs every binary needs to manage inference provider keys without ever
+//! echoing a value. The clap types here are the parse surface; the actual work
+//! lives in [`super::ops`] so it stays testable without a TTY or a live network.
+//! What: [`KeysCommand`] (the `keys` feature), [`KeysVerb`] (`set`/`list`/
+//! `test`/`unset` — deliberately NO `get`, per the redaction mandate), and
+//! [`KeysCommand::run`], which resolves the production secure store +
+//! configurator and dispatches to [`super::ops`]. Interactive/stdin value
+//! sourcing for `set` lives in [`source_set_value`] so the hidden-prompt path
+//! is isolated from the (fully testable) [`super::ops`] core.
+//! Test: `crates/trusty-common/tests/config_keys_cli.rs` (argv grammar + the
+//! set→list→test→unset flow via `super::ops`).
+
+use std::io::IsTerminal;
+
+use anyhow::Context;
+
+use crate::inference::configurator::Configurator;
+use crate::inference::credentials::{default_store, load_env_local_once};
+use crate::inference::providers::register_default_factories;
+
+use super::ops;
+
+/// The `keys` feature: manage inference provider API keys.
+///
+/// Why: groups the four credential verbs under one `config keys …` namespace so
+/// the grammar reads `<bin> config keys <verb> <provider>`.
+/// What: a clap [`clap::Args`] wrapping the [`KeysVerb`] subcommand.
+/// Test: `config_keys_argv_grammar_parses`.
+#[derive(Debug, clap::Args)]
+pub struct KeysCommand {
+    #[command(subcommand)]
+    verb: KeysVerb,
+}
+
+/// The credential verbs. There is intentionally no `get` — a verb that printed a
+/// stored key would violate the epic's never-echo-a-value mandate.
+///
+/// Why: `set`/`list`/`test`/`unset` cover the full lifecycle a human or a script
+/// needs while keeping the raw value write-only and probe-only — it is set, its
+/// presence/tier is listed, its validity is tested live, and it is removed, but
+/// it is never read back out.
+/// What: each verb carries only the arguments it needs; `list` takes none.
+/// Test: `config_keys_argv_grammar_parses`, `config_keys_rejects_get`.
+#[derive(Debug, clap::Subcommand)]
+enum KeysVerb {
+    /// Store a provider's API key in the secure store (File-0600 or OS keyring).
+    ///
+    /// Omit VALUE to read it interactively without echo (or from a stdin pipe),
+    /// so the key never lands in your shell history.
+    Set(SetArgs),
+    /// List which providers have a key and via which tier (names/tiers only).
+    List,
+    /// Cheap live auth check: probe the provider with the resolved key.
+    Test(ProviderArg),
+    /// Remove a provider's key from the secure store (never touches env/.env.local).
+    Unset(ProviderArg),
+}
+
+/// Arguments for `config keys set`.
+///
+/// Why: `provider` names which credential to store; `value` is optional so the
+/// key can be supplied non-interactively (arg or stdin pipe — scriptable) OR
+/// read from a hidden prompt when omitted on a TTY.
+/// What: a positional provider slug and an optional positional value.
+/// Test: `config_keys_argv_grammar_parses`.
+#[derive(Debug, clap::Args)]
+struct SetArgs {
+    /// Provider name (e.g. `openrouter`, `anthropic`, `openai`, `fireworks`, `together`).
+    provider: String,
+    /// The API key value. Omit to read it hidden from a TTY or piped via stdin.
+    value: Option<String>,
+}
+
+/// Arguments for verbs that take just a provider (`test`, `unset`).
+///
+/// Why: `test` and `unset` each act on one named provider and nothing else.
+/// What: a single positional provider slug.
+/// Test: `config_keys_argv_grammar_parses`.
+#[derive(Debug, clap::Args)]
+struct ProviderArg {
+    /// Provider name to act on.
+    provider: String,
+}
+
+impl KeysCommand {
+    /// Run the parsed `keys` verb against the production environment.
+    ///
+    /// Why: the production wiring the mount recipe relies on — it resolves the
+    /// real secure [`crate::inference::credentials::KeyStore`] and, for `test`,
+    /// the default provider [`Configurator`], so a mounting binary supplies
+    /// nothing. Every operation is delegated to the injectable [`super::ops`]
+    /// seam so this method stays a thin, side-effecting shell.
+    /// What: builds `stdout` as the output sink and dispatches. `set` sources its
+    /// value via [`source_set_value`] (hidden prompt / stdin pipe / arg); `test`
+    /// first loads `.env.local` (so the env tier reflects it) and registers the
+    /// default adapter factories before probing. `list` deliberately does NOT
+    /// pre-load `.env.local`, so its tier report distinguishes the shell-env tier
+    /// from the `.env.local` tier honestly.
+    /// Test: exercised end-to-end through `super::ops` in
+    /// `crates/trusty-common/tests/config_keys_cli.rs`.
+    pub(crate) async fn run(self) -> anyhow::Result<()> {
+        let store = default_store();
+        let stdout = std::io::stdout();
+        match self.verb {
+            KeysVerb::Set(args) => {
+                let value = source_set_value(args.value)?;
+                ops::set(store.as_ref(), &args.provider, &value, &mut stdout.lock())
+            }
+            KeysVerb::List => ops::list(store.as_ref(), &mut stdout.lock()),
+            KeysVerb::Unset(args) => ops::unset(store.as_ref(), &args.provider, &mut stdout.lock()),
+            KeysVerb::Test(args) => {
+                // Load `.env.local` so the resolver's env tier reflects it, then
+                // wire the built-in adapter factories for the live probe.
+                load_env_local_once();
+                let mut cfg = Configurator::new();
+                register_default_factories(&mut cfg);
+                let outcome = ops::probe(store.as_ref(), &cfg, &args.provider).await?;
+                ops::report_probe(&args.provider, &outcome, &mut stdout.lock())?;
+                outcome.into_result()
+            }
+        }
+    }
+}
+
+/// Resolve the value for `set`: explicit arg, piped stdin, or a hidden TTY prompt.
+///
+/// Why: keys must never land in shell history, so the default (no VALUE arg)
+/// path reads the secret from stdin — hidden when stdin is a terminal, plain
+/// line-read when it is a pipe (the scriptable path). Keeping this here, out of
+/// [`super::ops`], means the `rpassword`/`is_terminal` interactive machinery is
+/// never on a test's code path — tests drive [`super::ops::set`] with a value
+/// directly, and the piped-line parsing via [`super::ops::read_key_line`].
+/// What: returns `value` when present; otherwise, on a TTY, prompts with echo
+/// suppressed via `rpassword`; on a pipe, reads one line from stdin via
+/// [`super::ops::read_key_line`]. Never prints the value.
+/// Test: the non-interactive branches are covered by
+/// `config_keys_cli.rs::read_key_line_trims_piped_value` (stdin line) and the
+/// `set` flow (explicit value); the hidden-prompt branch is interactive-only.
+fn source_set_value(value: Option<String>) -> anyhow::Result<String> {
+    if let Some(value) = value {
+        return Ok(value);
+    }
+    if std::io::stdin().is_terminal() {
+        return rpassword::prompt_password("API key (input hidden): ")
+            .context("failed to read hidden key input from the terminal");
+    }
+    let mut stdin = std::io::stdin().lock();
+    ops::read_key_line(&mut stdin).context("failed to read key from stdin")
+}

--- a/crates/trusty-common/src/inference/config/mod.rs
+++ b/crates/trusty-common/src/inference/config/mod.rs
@@ -1,0 +1,109 @@
+//! Universal `config` clap module (issue #2404, epic #2400 Wave 1).
+//!
+//! Why: every trusty-* binary that talks to an inference provider needs the
+//! SAME credential-management CLI — set a provider's key, list which providers
+//! are configured (and via which tier), probe a key with a cheap live auth
+//! check, and remove a key. Before this module each binary would grow its own
+//! divergent `config`/`keys` handling. This is the one implementation ALL ten
+//! clap binaries mount identically (#2405 does the mounting); adding it to a new
+//! binary is two lines and never diverges.
+//!
+//! What: [`ConfigCommand`] is a clap [`clap::Args`] a binary embeds as a single
+//! variant of its own top-level subcommand enum. It nests a `<feature>`
+//! subcommand ([`ConfigFeature`]) so the grammar is
+//! `<bin> config <feature> <verb> …`; Wave 1 ships the `keys` feature
+//! ([`keys::KeysCommand`]) with `set` / `list` / `test` / `unset`. The
+//! operations themselves live in the injectable [`ops`] seam so they are 100%
+//! testable without a TTY or a live provider. [`ConfigCommand::run`] resolves its
+//! own secure [`crate::inference::credentials::KeyStore`] and
+//! [`crate::inference::Configurator`], so a mounting binary needs no wiring.
+//!
+//! # Mount recipe for #2405 (the entire integration — two lines)
+//!
+//! Add the variant to your binary's top-level clap enum:
+//!
+//! ```ignore
+//! use trusty_common::inference::config::ConfigCommand;
+//!
+//! #[derive(clap::Subcommand)]
+//! enum Commands {
+//!     // … your existing subcommands …
+//!     /// Manage inference provider configuration (API keys).
+//!     Config(ConfigCommand),          // line 1: mount
+//! }
+//! ```
+//!
+//! Then dispatch it (inside your `#[tokio::main]` async entry point):
+//!
+//! ```ignore
+//! match cli.command {
+//!     // … your existing arms …
+//!     Commands::Config(cmd) => cmd.run().await?,   // line 2: dispatch
+//! }
+//! ```
+//!
+//! Adding a future `config <feature>` (e.g. `config model …`) is a new
+//! [`ConfigFeature`] variant here — mount sites do not change (the
+//! extensibility contract in the acceptance criteria).
+//!
+//! Enable the `config-cli` feature in the mounting binary's dependency on
+//! `trusty-common`. It implies `inference-client`; a default (no-features)
+//! `trusty-common` build compiles neither this module nor `clap`.
+//!
+//! Test: `ops` inline tests + `crates/trusty-common/tests/config_keys_cli.rs`
+//! (argv parsing, set→list→test→unset flow, tier reporting, and the
+//! never-print-a-value guarantee).
+
+pub mod keys;
+pub mod ops;
+
+use keys::KeysCommand;
+
+/// The universal `config` subcommand a binary mounts as one enum variant.
+///
+/// Why: one embeddable type is the whole public mount surface — a binary adds
+/// `Config(ConfigCommand)` and calls [`Self::run`]; everything else (feature
+/// routing, store/configurator resolution, secret redaction) is internal so the
+/// mount is identical across binaries and cannot drift.
+/// What: a clap [`clap::Args`] wrapping the `<feature>` subcommand. `run`
+/// dispatches to the selected feature's own runner.
+/// Test: `crates/trusty-common/tests/config_keys_cli.rs::config_command_mounts_and_parses`.
+#[derive(Debug, clap::Args)]
+pub struct ConfigCommand {
+    #[command(subcommand)]
+    feature: ConfigFeature,
+}
+
+/// The `<feature>` layer of the `config` grammar.
+///
+/// Why: `config` is a namespace, not a single command — keys today, potentially
+/// model/provider defaults later. Modelling the feature as its own subcommand
+/// enum means a new feature is one variant added HERE with zero mount-site
+/// churn.
+/// What: Wave 1 exposes only [`Self::Keys`]. Each variant owns a feature command
+/// type that implements its own verbs.
+/// Test: `config_keys_argv_grammar_parses`.
+#[derive(Debug, clap::Subcommand)]
+enum ConfigFeature {
+    /// Manage inference provider API keys (set / list / test / unset).
+    Keys(KeysCommand),
+}
+
+impl ConfigCommand {
+    /// Execute the parsed `config` command.
+    ///
+    /// Why: the single dispatch entry a mounting binary calls — one `.await`
+    /// after the one-line mount. Async because `config keys test` performs a
+    /// live provider auth probe.
+    /// What: routes to the selected [`ConfigFeature`]'s runner, which resolves
+    /// its own secure store + configurator. Surfaces `anyhow::Result` at the
+    /// boundary (matching every binary's top-level error printer); never returns
+    /// or logs a key value.
+    /// Test: `crates/trusty-common/tests/config_keys_cli.rs` drives the verbs
+    /// through the [`ops`] seam this delegates to.
+    pub async fn run(self) -> anyhow::Result<()> {
+        match self.feature {
+            ConfigFeature::Keys(cmd) => cmd.run().await,
+        }
+    }
+}

--- a/crates/trusty-common/src/inference/config/ops.rs
+++ b/crates/trusty-common/src/inference/config/ops.rs
@@ -26,17 +26,33 @@ use crate::inference::types::{ChatMessage, ChatRequest};
 ///
 /// Why: `config keys list` must report WHERE a key comes from (so an operator
 /// knows whether it is pinned in the shell, committed to `.env.local`, or held
-/// in the secure store) — using the same precedence the resolver applies.
-/// What: the three keyed tiers, highest-precedence first. Rendered via
-/// [`Self::label`]; never carries a value.
+/// in the secure store) — using the same precedence the resolver applies. A
+/// mounting binary that pre-loads `.env.local` at startup (as trusty-search and
+/// trusty-agents already do — see [`Self::EnvOrEnvLocal`]) folds the file's
+/// values into the process env BEFORE `config` ever runs, so a bare "process env
+/// var is set" check cannot tell "independently exported in the shell" apart
+/// from "loaded from `.env.local` by the binary itself". Rather than assert a
+/// precise-but-possibly-wrong tier in that case, [`detect_tier`] reports the
+/// honest ambiguity.
+/// What: [`Self::Env`] and [`Self::EnvLocal`] are the unambiguous single-source
+/// tiers; [`Self::EnvOrEnvLocal`] covers the double-signal case; [`Self::Store`]
+/// is the secure-store fallback. Rendered via [`Self::label`]; never carries a
+/// value.
 /// Test: `classify_tier_follows_precedence`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyTier {
-    /// A process environment variable (highest precedence).
+    /// A process environment variable, with no matching `.env.local` entry
+    /// found — unambiguously an independently-set env var.
     Env,
-    /// A repo-root `.env.local` entry.
+    /// A repo-root `.env.local` entry, with no value in the process env.
     EnvLocal,
-    /// The secure key store (File-0600 / OS keyring).
+    /// The key is present BOTH in the process env AND in the `.env.local` file.
+    /// Ambiguous: it may be an independently-exported shell var, or it may be
+    /// the `.env.local` value the mounting binary already folded into its own
+    /// env at startup (trusty-search/trusty-agents both do this today). See the
+    /// [`list`] docs for the long-term fix landing with #2405.
+    EnvOrEnvLocal,
+    /// The secure key store (File-0600 / OS keyring) — lowest precedence.
     Store,
 }
 
@@ -45,12 +61,14 @@ impl KeyTier {
     ///
     /// Why: the list is for humans; the tier needs a clear label, not an enum
     /// name.
-    /// What: a short phrase per tier.
+    /// What: a short phrase per tier; [`Self::EnvOrEnvLocal`] spells out the
+    /// ambiguity rather than picking one guess.
     /// Test: `classify_tier_follows_precedence` (values are asserted via callers).
     pub fn label(self) -> &'static str {
         match self {
             Self::Env => "environment variable",
             Self::EnvLocal => ".env.local",
+            Self::EnvOrEnvLocal => "environment variable or .env.local (ambiguous)",
             Self::Store => "secure store",
         }
     }
@@ -60,11 +78,17 @@ impl KeyTier {
 ///
 /// Why: the pure decision at the heart of `list`'s tier reporting — separated so
 /// it is unit-testable without touching the environment, a file, or a store.
-/// What: env beats `.env.local` beats store (matching
-/// [`resolve_key_with`]/`resolve_key`); `None` when no tier supplies the key.
+/// What: when both `env` and `env_local` are true, the tier is the ambiguous
+/// [`KeyTier::EnvOrEnvLocal`] (a mounting binary may have folded the file into
+/// its env at startup — see [`KeyTier`] docs); otherwise env alone beats
+/// `.env.local` alone beats store (matching
+/// [`resolve_key_with`]/`resolve_key`'s actual precedence); `None` when no tier
+/// supplies the key.
 /// Test: `classify_tier_follows_precedence`.
 pub fn classify_tier(env: bool, env_local: bool, store: bool) -> Option<KeyTier> {
-    if env {
+    if env && env_local {
+        Some(KeyTier::EnvOrEnvLocal)
+    } else if env {
         Some(KeyTier::Env)
     } else if env_local {
         Some(KeyTier::EnvLocal)
@@ -198,12 +222,25 @@ pub fn unset(store: &dyn KeyStore, provider: &str, out: &mut dyn Write) -> anyho
 ///
 /// Why: the `list` verb. It answers "which providers can I use, and where does
 /// each key come from" WITHOUT ever revealing a value — names and tiers only.
+///
+/// NOTE for mounting binaries (#2405): if your `main()` pre-loads `.env.local`
+/// into the process env before dispatching to `config` — as trusty-search
+/// (`main.rs`) and trusty-agents (`runtime/startup.rs`) already do via their own
+/// ad hoc `dotenvy` calls — this verb cannot tell "you exported this in your
+/// shell" apart from "your binary loaded it from `.env.local` at startup" for a
+/// key present in both places; it reports [`KeyTier::EnvOrEnvLocal`] rather than
+/// guessing. The clean long-term fix is for every binary to route its startup
+/// dotenv load through the shared `credentials::load_env_local_once` (so this
+/// module owns the one loader and can observe load order); that migration lands
+/// alongside #2405.
 /// What: walks the capability registry ([`all`]); for keyed providers reports the
-/// resolution tier via [`detect_tier`] (env > `.env.local` > store) or
+/// resolution tier via [`detect_tier`] (env-only > `.env.local`-only > store,
+/// with the ambiguous both-present case reported honestly — see [`KeyTier`]) or
 /// "not configured"; for the keyless Bedrock chain reports that it uses AWS
 /// credentials. Writes to `out`.
 /// Test: `config_keys_cli.rs::set_then_list_reports_store_tier_without_value`,
-/// `list_reports_env_tier`.
+/// `list_reports_env_tier`,
+/// `list_reports_ambiguous_tier_when_env_and_env_local_both_present`.
 pub fn list(store: &dyn KeyStore, out: &mut dyn Write) -> anyhow::Result<()> {
     writeln!(
         out,
@@ -234,9 +271,14 @@ pub fn list(store: &dyn KeyStore, out: &mut dyn Write) -> anyhow::Result<()> {
 /// two-stage resolver will not fall back), builds the adapter from `cfg`, and
 /// issues a minimal 1-token chat as the auth probe. A 401/403 is
 /// [`ProbeOutcome::Unauthorized`]; a not-yet-wired provider is
-/// [`ProbeOutcome::Unsupported`]; any other error is [`ProbeOutcome::Failed`]
-/// (never carrying the key). Returns `Err` only on an unknown provider.
-/// Test: `config_keys_cli.rs` OK / 401 / unconfigured probe cases.
+/// [`ProbeOutcome::Unsupported`]; any other error is [`ProbeOutcome::Failed`],
+/// its message run through [`scrub_key`] first — a provider's non-2xx response
+/// BODY is attacker/provider-controlled and could echo the credential back
+/// (some providers include the offending header value in a 401/400 body); the
+/// scrub guarantees the resolved key never reaches `Failed`'s message even in
+/// that case. Returns `Err` only on an unknown provider.
+/// Test: `config_keys_cli.rs` OK / 401 / unconfigured probe cases,
+/// `probe_error_body_never_leaks_the_resolved_key`.
 pub async fn probe(
     store: &dyn KeyStore,
     cfg: &Configurator,
@@ -254,10 +296,11 @@ pub async fn probe(
         )));
     }
 
-    // Clean degrade when nothing resolves.
-    if resolve_key_with(name, store).is_none() {
+    // Clean degrade when nothing resolves. Keep the resolved value so any error
+    // text surfaced below can be scrubbed of it (see `scrub_key`).
+    let Some(resolved_key) = resolve_key_with(name, store) else {
         return Ok(ProbeOutcome::Unconfigured);
-    }
+    };
 
     // Prefix the slug so the resolver picks THIS provider (its key resolves, so
     // stage 1 wins and there is no OpenRouter fallback).
@@ -270,7 +313,12 @@ pub async fn probe(
             )));
         }
         Err(InferenceError::MissingCredential { .. }) => return Ok(ProbeOutcome::Unconfigured),
-        Err(err) => return Ok(ProbeOutcome::Failed(err.to_string())),
+        Err(err) => {
+            return Ok(ProbeOutcome::Failed(scrub_key(
+                &err.to_string(),
+                &resolved_key,
+            )));
+        }
     };
 
     // Minimal, cheap 1-token request as the auth probe.
@@ -282,8 +330,33 @@ pub async fn probe(
         Err(InferenceError::Api {
             status: 401 | 403, ..
         }) => Ok(ProbeOutcome::Unauthorized),
-        Err(err) => Ok(ProbeOutcome::Failed(err.to_string())),
+        Err(err) => Ok(ProbeOutcome::Failed(scrub_key(
+            &err.to_string(),
+            &resolved_key,
+        ))),
     }
+}
+
+/// Remove any occurrence of `key` from `message`, defensively.
+///
+/// Why: [`InferenceError::Api`]'s `Display` embeds the provider's raw,
+/// non-2xx response BODY verbatim — provider-controlled content that could
+/// (accidentally or via a misbehaving/malicious endpoint) echo the credential
+/// back, e.g. in a "your key `sk-…` is invalid" message. `Failed`'s message
+/// reaches stdout unredacted via [`report_probe`], so this is the one place in
+/// the credential-management CLI that must never let that happen. Generic
+/// substring removal (rather than a provider-specific parser) keeps the guard
+/// correct for every current and future adapter.
+/// What: returns `message` with every occurrence of `key` replaced by
+/// `[REDACTED]`; a no-op when `key` is empty (an empty needle would match
+/// everywhere) or does not occur in `message`.
+/// Test: `probe_error_body_never_leaks_the_resolved_key`,
+/// `scrub_key_is_noop_for_empty_key`.
+fn scrub_key(message: &str, key: &str) -> String {
+    if key.is_empty() {
+        return message.to_string();
+    }
+    message.replace(key, "[REDACTED]")
 }
 
 /// Write a probe outcome as a value-free status line.
@@ -340,13 +413,15 @@ fn known_keyed_provider(provider: &str) -> anyhow::Result<&'static ProviderCapab
 ///
 /// Why: the production tier lookup behind `list`. It reads the process env and
 /// the `.env.local` file INDEPENDENTLY (rather than after loading the file into
-/// the env) so it can tell the two tiers apart honestly — see the `list`/`run`
-/// contract about not pre-loading `.env.local`.
+/// the env) so it CAN tell the two tiers apart when only one of them supplies
+/// the key. It cannot, however, un-fold a value a mounting binary already
+/// merged into its own env at startup — when both signals are true, the result
+/// is [`KeyTier::EnvOrEnvLocal`], not a guess (see [`KeyTier`]/[`list`] docs).
 /// What: checks a non-empty process env var, a non-empty `.env.local` entry (via
 /// [`env_local_value`], non-mutating), and store presence, then defers to
 /// [`classify_tier`].
-/// Test: the pure classifier is unit-tested; the env and store tiers are covered
-/// by `config_keys_cli.rs`.
+/// Test: the pure classifier is unit-tested; the env, `.env.local`, ambiguous,
+/// and store tiers are covered by `config_keys_cli.rs`.
 fn detect_tier(env_var: &str, provider: &str, store: &dyn KeyStore) -> Option<KeyTier> {
     let env = std::env::var(env_var)
         .ok()
@@ -377,12 +452,19 @@ fn known_names() -> String {
 mod tests {
     use super::*;
 
-    /// Why: `list`'s tier report must follow the resolver's precedence exactly —
-    /// env over `.env.local` over store — and report `None` when absent.
+    /// Why: `list`'s tier report must follow the resolver's precedence exactly
+    /// for single-signal cases — env-only over `.env.local`-only over store —
+    /// report the honest ambiguity when BOTH env and `.env.local` supply the
+    /// key (a mounting binary may have folded the file into its env at
+    /// startup), and report `None` when absent everywhere.
     /// Test: itself.
     #[test]
     fn classify_tier_follows_precedence() {
-        assert_eq!(classify_tier(true, true, true), Some(KeyTier::Env));
+        assert_eq!(
+            classify_tier(true, true, true),
+            Some(KeyTier::EnvOrEnvLocal)
+        );
+        assert_eq!(classify_tier(true, false, true), Some(KeyTier::Env));
         assert_eq!(classify_tier(false, true, true), Some(KeyTier::EnvLocal));
         assert_eq!(classify_tier(false, false, true), Some(KeyTier::Store));
         assert_eq!(classify_tier(false, false, false), None);
@@ -395,5 +477,26 @@ mod tests {
     fn read_key_line_strips_newline() {
         let mut reader = std::io::Cursor::new(b"sk-piped-value\n".to_vec()); // pragma: allowlist secret
         assert_eq!(read_key_line(&mut reader).unwrap(), "sk-piped-value");
+    }
+
+    /// Why: a probe-error message that echoes the resolved key verbatim (e.g. a
+    /// provider that includes the offending credential in its error body) must
+    /// have every occurrence of the key removed, never partially redacted.
+    /// Test: itself.
+    #[test]
+    fn scrub_key_removes_every_occurrence() {
+        let key = "sk-or-verysecret1234"; // pragma: allowlist secret
+        let msg = format!("inference API error 400: bad key {key}, retry without {key}");
+        let scrubbed = scrub_key(&msg, key);
+        assert!(!scrubbed.contains(key), "leaked: {scrubbed}");
+        assert_eq!(scrubbed.matches("[REDACTED]").count(), 2);
+    }
+
+    /// Why: an empty key must never be treated as a wildcard needle — that would
+    /// corrupt every message it touches.
+    /// Test: itself.
+    #[test]
+    fn scrub_key_is_noop_for_empty_key() {
+        assert_eq!(scrub_key("some message", ""), "some message");
     }
 }

--- a/crates/trusty-common/src/inference/config/ops.rs
+++ b/crates/trusty-common/src/inference/config/ops.rs
@@ -1,0 +1,399 @@
+//! Injectable `config keys` operations (issue #2404) — the testable core.
+//!
+//! Why: the clap layer ([`super::keys`]) is a thin shell around these functions
+//! so the whole `config keys` surface is exercisable non-interactively (a merge
+//! gate): tests inject a [`crate::inference::credentials::MemoryKeyStore`], a
+//! [`Configurator`] pointed at a mock server, and an in-memory output buffer,
+//! then assert behaviour AND that no key value ever appears. Every function here
+//! takes its store / configurator / output sink as parameters — none reaches for
+//! process globals or a real network except where a caller wires them.
+//! What: [`set`], [`list`], [`unset`], and the async [`probe`] (+ [`report_probe`]),
+//! plus the [`KeyTier`] tier classifier and [`ProbeOutcome`] result type. Values
+//! are only ever surfaced through [`redact_secret`]; the raw key is written to
+//! the store and (for the probe) placed on the wire by the adapter, nowhere else.
+//! Test: inline `tests` (tier classification, line parsing) + the full flow and
+//! mock-server probe in `crates/trusty-common/tests/config_keys_cli.rs`.
+
+use std::io::{BufRead, Write};
+
+use crate::inference::configurator::Configurator;
+use crate::inference::credentials::{KeyStore, env_local_value, redact_secret, resolve_key_with};
+use crate::inference::error::InferenceError;
+use crate::inference::registry::{ProviderCapabilities, all, capabilities_for};
+use crate::inference::types::{ChatMessage, ChatRequest};
+
+/// Which resolution tier currently supplies a provider's key.
+///
+/// Why: `config keys list` must report WHERE a key comes from (so an operator
+/// knows whether it is pinned in the shell, committed to `.env.local`, or held
+/// in the secure store) — using the same precedence the resolver applies.
+/// What: the three keyed tiers, highest-precedence first. Rendered via
+/// [`Self::label`]; never carries a value.
+/// Test: `classify_tier_follows_precedence`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyTier {
+    /// A process environment variable (highest precedence).
+    Env,
+    /// A repo-root `.env.local` entry.
+    EnvLocal,
+    /// The secure key store (File-0600 / OS keyring).
+    Store,
+}
+
+impl KeyTier {
+    /// Human-readable tier name for the `list` output.
+    ///
+    /// Why: the list is for humans; the tier needs a clear label, not an enum
+    /// name.
+    /// What: a short phrase per tier.
+    /// Test: `classify_tier_follows_precedence` (values are asserted via callers).
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Env => "environment variable",
+            Self::EnvLocal => ".env.local",
+            Self::Store => "secure store",
+        }
+    }
+}
+
+/// Classify the resolution tier from the three source signals, in precedence.
+///
+/// Why: the pure decision at the heart of `list`'s tier reporting — separated so
+/// it is unit-testable without touching the environment, a file, or a store.
+/// What: env beats `.env.local` beats store (matching
+/// [`resolve_key_with`]/`resolve_key`); `None` when no tier supplies the key.
+/// Test: `classify_tier_follows_precedence`.
+pub fn classify_tier(env: bool, env_local: bool, store: bool) -> Option<KeyTier> {
+    if env {
+        Some(KeyTier::Env)
+    } else if env_local {
+        Some(KeyTier::EnvLocal)
+    } else if store {
+        Some(KeyTier::Store)
+    } else {
+        None
+    }
+}
+
+/// The outcome of a `config keys test` live auth probe.
+///
+/// Why: a structured result so both the human-facing report and the process exit
+/// code derive from one classification, and so tests can assert the outcome
+/// directly without scraping stdout.
+/// What: `Ok` (accepted), `Unauthorized` (401/403), `Unconfigured` (no key
+/// resolved — the clean-degrade case), `Unsupported` (no probeable adapter, e.g.
+/// Bedrock's AWS chain or a not-yet-wired provider), and `Failed` (any other
+/// error — never contains the key, since [`InferenceError`] never does).
+/// Test: `crates/trusty-common/tests/config_keys_cli.rs` (OK / 401 / unconfigured).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeOutcome {
+    /// The provider accepted the credential.
+    Ok,
+    /// The provider rejected the credential (HTTP 401/403).
+    Unauthorized,
+    /// No key resolved for the provider; nothing to probe.
+    Unconfigured,
+    /// The provider cannot be probed by this verb (reason attached).
+    Unsupported(String),
+    /// The probe failed for another reason (redacted message attached).
+    Failed(String),
+}
+
+impl ProbeOutcome {
+    /// Human-readable, value-free status line for `report_probe`.
+    ///
+    /// Why: each outcome needs an actionable one-liner (and the `Unconfigured`
+    /// case must point the operator at `set`).
+    /// What: a short phrase; the `Unsupported`/`Failed` variants embed their
+    /// (already key-free) reason.
+    /// Test: asserted in `config_keys_cli.rs` probe tests.
+    pub fn label(&self) -> String {
+        match self {
+            Self::Ok => "OK — credentials accepted".to_string(),
+            Self::Unauthorized => "UNAUTHORIZED — provider rejected the key (401/403)".to_string(),
+            Self::Unconfigured => {
+                "UNCONFIGURED — no key resolved; set one with `config keys set <provider>`"
+                    .to_string()
+            }
+            Self::Unsupported(reason) => format!("SKIPPED — {reason}"),
+            Self::Failed(reason) => format!("ERROR — {reason}"),
+        }
+    }
+
+    /// Map the outcome to a process-exit result.
+    ///
+    /// Why: scripts driving `config keys test` need a non-zero exit on a genuine
+    /// failure (a rejected or broken key) while a clean "nothing to test" or
+    /// "can't test this provider" degrades to success.
+    /// What: `Ok`, `Unconfigured`, and `Unsupported` return `Ok(())`;
+    /// `Unauthorized` and `Failed` return an `Err` whose message is the label.
+    /// Test: covered structurally; the outcome itself is the asserted surface.
+    pub fn into_result(self) -> anyhow::Result<()> {
+        match self {
+            Self::Ok | Self::Unconfigured | Self::Unsupported(_) => Ok(()),
+            other => Err(anyhow::anyhow!("{}", other.label())),
+        }
+    }
+}
+
+/// Store `value` as `provider`'s key in the secure store.
+///
+/// Why: the `set` verb — the only sanctioned way a key enters the store. The raw
+/// value is written to the store and never printed; the confirmation shows only
+/// the [`redact_secret`] preview so a human can confirm *which* key landed
+/// without seeing it.
+/// What: validates `provider` is a known, keyed provider (rejecting unknowns and
+/// the keyless Bedrock chain), refuses an empty value, writes it under the
+/// canonical provider name, and prints a redacted confirmation to `out`.
+/// Test: `config_keys_cli.rs::set_then_list_reports_store_tier_without_value`.
+pub fn set(
+    store: &dyn KeyStore,
+    provider: &str,
+    value: &str,
+    out: &mut dyn Write,
+) -> anyhow::Result<()> {
+    let caps = known_keyed_provider(provider)?;
+    let name = caps.id.as_str();
+    if value.is_empty() {
+        anyhow::bail!("refusing to store an empty key for {name}");
+    }
+    store
+        .set(name, value)
+        .map_err(|e| anyhow::anyhow!("failed to store key for {name}: {e}"))?;
+    writeln!(
+        out,
+        "Stored key for {name} in the secure store [{}].",
+        redact_secret(value)
+    )?;
+    Ok(())
+}
+
+/// Remove `provider`'s key from the secure store (store tier only).
+///
+/// Why: the `unset` verb. It must touch ONLY the secure store — never the
+/// process env or `.env.local` (those are not ours to mutate) — and report
+/// honestly whether anything was actually removed.
+/// What: validates the provider, checks prior presence in the store, removes it,
+/// and prints whether a key was removed or none was set.
+/// Test: `config_keys_cli.rs::unset_removes_key_and_reports_absence`.
+pub fn unset(store: &dyn KeyStore, provider: &str, out: &mut dyn Write) -> anyhow::Result<()> {
+    let caps = known_keyed_provider(provider)?;
+    let name = caps.id.as_str();
+    let was_present = store.get(name).is_some();
+    store
+        .unset(name)
+        .map_err(|e| anyhow::anyhow!("failed to remove key for {name}: {e}"))?;
+    if was_present {
+        writeln!(out, "Removed key for {name} from the secure store.")?;
+    } else {
+        writeln!(
+            out,
+            "No key for {name} was set in the secure store; nothing to remove."
+        )?;
+    }
+    Ok(())
+}
+
+/// List every known provider's key status: configured tier or "not configured".
+///
+/// Why: the `list` verb. It answers "which providers can I use, and where does
+/// each key come from" WITHOUT ever revealing a value — names and tiers only.
+/// What: walks the capability registry ([`all`]); for keyed providers reports the
+/// resolution tier via [`detect_tier`] (env > `.env.local` > store) or
+/// "not configured"; for the keyless Bedrock chain reports that it uses AWS
+/// credentials. Writes to `out`.
+/// Test: `config_keys_cli.rs::set_then_list_reports_store_tier_without_value`,
+/// `list_reports_env_tier`.
+pub fn list(store: &dyn KeyStore, out: &mut dyn Write) -> anyhow::Result<()> {
+    writeln!(
+        out,
+        "Provider key status (names and tiers only — values are never shown):"
+    )?;
+    for caps in all() {
+        let name = caps.id.as_str();
+        match caps.credential_env {
+            None => writeln!(out, "  {name:<12} AWS credential chain (no API key)")?,
+            Some(env_var) => match detect_tier(env_var, name, store) {
+                Some(tier) => writeln!(out, "  {name:<12} configured via {}", tier.label())?,
+                None => writeln!(out, "  {name:<12} not configured")?,
+            },
+        }
+    }
+    Ok(())
+}
+
+/// Cheap live auth probe for `provider` using the resolved key.
+///
+/// Why: the `test` verb — the "api-testable-locally" check. It confirms a key is
+/// actually accepted (or rejected) by the provider without leaking it, and
+/// degrades cleanly when no key is configured.
+/// What: validates the provider; the keyless Bedrock chain is
+/// [`ProbeOutcome::Unsupported`]. Resolves the key (env > `.env.local` via the
+/// caller's prior load > `store`); a miss is [`ProbeOutcome::Unconfigured`]. Then
+/// forces this exact provider by prefixing its slug (a resolvable key means the
+/// two-stage resolver will not fall back), builds the adapter from `cfg`, and
+/// issues a minimal 1-token chat as the auth probe. A 401/403 is
+/// [`ProbeOutcome::Unauthorized`]; a not-yet-wired provider is
+/// [`ProbeOutcome::Unsupported`]; any other error is [`ProbeOutcome::Failed`]
+/// (never carrying the key). Returns `Err` only on an unknown provider.
+/// Test: `config_keys_cli.rs` OK / 401 / unconfigured probe cases.
+pub async fn probe(
+    store: &dyn KeyStore,
+    cfg: &Configurator,
+    provider: &str,
+) -> anyhow::Result<ProbeOutcome> {
+    let caps = capabilities_for(provider).ok_or_else(|| {
+        anyhow::anyhow!("unknown provider {provider:?}; known: {}", known_names())
+    })?;
+    let name = caps.id.as_str();
+
+    // Bedrock (and any future keyless provider): no API key to probe.
+    if caps.credential_env.is_none() {
+        return Ok(ProbeOutcome::Unsupported(format!(
+            "{name} authenticates via the AWS credential chain, not an API key"
+        )));
+    }
+
+    // Clean degrade when nothing resolves.
+    if resolve_key_with(name, store).is_none() {
+        return Ok(ProbeOutcome::Unconfigured);
+    }
+
+    // Prefix the slug so the resolver picks THIS provider (its key resolves, so
+    // stage 1 wins and there is no OpenRouter fallback).
+    let slug = format!("{name}/{}", caps.default_model);
+    let adapter = match cfg.build(&slug, store) {
+        Ok(adapter) => adapter,
+        Err(InferenceError::NoAdapterRegistered { .. }) => {
+            return Ok(ProbeOutcome::Unsupported(format!(
+                "no inference adapter is wired for {name} yet"
+            )));
+        }
+        Err(InferenceError::MissingCredential { .. }) => return Ok(ProbeOutcome::Unconfigured),
+        Err(err) => return Ok(ProbeOutcome::Failed(err.to_string())),
+    };
+
+    // Minimal, cheap 1-token request as the auth probe.
+    let mut req = ChatRequest::new(caps.default_model, vec![ChatMessage::user("ping")]);
+    req.max_tokens = Some(1);
+    req.temperature = Some(0.0);
+    match adapter.chat(&req).await {
+        Ok(_) => Ok(ProbeOutcome::Ok),
+        Err(InferenceError::Api {
+            status: 401 | 403, ..
+        }) => Ok(ProbeOutcome::Unauthorized),
+        Err(err) => Ok(ProbeOutcome::Failed(err.to_string())),
+    }
+}
+
+/// Write a probe outcome as a value-free status line.
+///
+/// Why: keeps the human report in one place so the `test` runner is a one-liner.
+/// What: writes `test <provider>: <label>` to `out`.
+/// Test: asserted in `config_keys_cli.rs` probe cases.
+pub fn report_probe(
+    provider: &str,
+    outcome: &ProbeOutcome,
+    out: &mut dyn Write,
+) -> anyhow::Result<()> {
+    writeln!(out, "test {provider}: {}", outcome.label())?;
+    Ok(())
+}
+
+/// Read one key value from a `BufRead` (the scriptable stdin-pipe path).
+///
+/// Why: `set` with no VALUE arg on a non-TTY reads the key from a pipe; factoring
+/// the line read out of the interactive machinery makes the scriptable path
+/// unit-testable with an in-memory reader.
+/// What: reads a single line and strips the trailing newline / carriage return;
+/// the value is returned, never printed.
+/// Test: `config_keys_cli.rs::read_key_line_trims_piped_value`.
+pub fn read_key_line(reader: &mut dyn BufRead) -> anyhow::Result<String> {
+    let mut buf = String::new();
+    reader.read_line(&mut buf)?;
+    Ok(buf.trim_end_matches(['\n', '\r']).to_string())
+}
+
+/// Resolve `provider` to its capabilities, requiring it be known AND keyed.
+///
+/// Why: `set`/`unset` act on a key, so an unknown provider or the keyless Bedrock
+/// chain is a user error with an actionable message (rather than silently
+/// storing an orphan entry).
+/// What: looks the provider up case-insensitively in the registry; errors on an
+/// unknown name (listing the known keyed ones) or on a provider with no
+/// `credential_env`.
+/// Test: covered via `set`/`unset` error paths in `config_keys_cli.rs`.
+fn known_keyed_provider(provider: &str) -> anyhow::Result<&'static ProviderCapabilities> {
+    let caps = capabilities_for(provider).ok_or_else(|| {
+        anyhow::anyhow!("unknown provider {provider:?}; known: {}", known_names())
+    })?;
+    if caps.credential_env.is_none() {
+        anyhow::bail!(
+            "{} authenticates via the AWS credential chain, not an API key",
+            caps.id.as_str()
+        );
+    }
+    Ok(caps)
+}
+
+/// Gather the three tier signals for `provider` and classify them.
+///
+/// Why: the production tier lookup behind `list`. It reads the process env and
+/// the `.env.local` file INDEPENDENTLY (rather than after loading the file into
+/// the env) so it can tell the two tiers apart honestly — see the `list`/`run`
+/// contract about not pre-loading `.env.local`.
+/// What: checks a non-empty process env var, a non-empty `.env.local` entry (via
+/// [`env_local_value`], non-mutating), and store presence, then defers to
+/// [`classify_tier`].
+/// Test: the pure classifier is unit-tested; the env and store tiers are covered
+/// by `config_keys_cli.rs`.
+fn detect_tier(env_var: &str, provider: &str, store: &dyn KeyStore) -> Option<KeyTier> {
+    let env = std::env::var(env_var)
+        .ok()
+        .filter(|v| !v.is_empty())
+        .is_some();
+    let env_local = env_local_value(env_var).is_some();
+    let stored = store.get(provider).is_some();
+    classify_tier(env, env_local, stored)
+}
+
+/// Comma-separated list of known keyed provider names (for error messages).
+///
+/// Why: an unknown-provider error should tell the user what IS valid.
+/// What: the canonical names of registry providers that use an API key.
+/// Test: surfaced via `set`/`probe` unknown-provider errors.
+fn known_names() -> String {
+    all()
+        .iter()
+        .filter(|c| c.credential_env.is_some())
+        .map(|c| c.id.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: `list`'s tier report must follow the resolver's precedence exactly —
+    /// env over `.env.local` over store — and report `None` when absent.
+    /// Test: itself.
+    #[test]
+    fn classify_tier_follows_precedence() {
+        assert_eq!(classify_tier(true, true, true), Some(KeyTier::Env));
+        assert_eq!(classify_tier(false, true, true), Some(KeyTier::EnvLocal));
+        assert_eq!(classify_tier(false, false, true), Some(KeyTier::Store));
+        assert_eq!(classify_tier(false, false, false), None);
+    }
+
+    /// Why: the scriptable stdin path must return the piped value with the
+    /// trailing newline stripped, and nothing else.
+    /// Test: itself.
+    #[test]
+    fn read_key_line_strips_newline() {
+        let mut reader = std::io::Cursor::new(b"sk-piped-value\n".to_vec()); // pragma: allowlist secret
+        assert_eq!(read_key_line(&mut reader).unwrap(), "sk-piped-value");
+    }
+}

--- a/crates/trusty-common/src/inference/credentials/dotenv.rs
+++ b/crates/trusty-common/src/inference/credentials/dotenv.rs
@@ -86,6 +86,48 @@ pub fn load_env_local_once() {
     });
 }
 
+/// Read a single variable's value from a specific `.env.local` file **without**
+/// mutating the process environment.
+///
+/// Why: the `config keys list` verb reports which tier (process env >
+/// `.env.local` > secure store) currently supplies each provider's key. To
+/// distinguish "set in the shell env" from "loaded from `.env.local`" honestly,
+/// the lister must inspect the file directly rather than call
+/// [`load_env_local_once`] (which would fold the file's values into the process
+/// env and erase the distinction). This hermetic, path-injectable reader is that
+/// inspection primitive.
+/// What: parses `path` with `dotenvy`'s non-mutating iterator, skipping malformed
+/// entries, and returns the first non-empty value bound to `var`, or `None` when
+/// the file is unreadable, has no such key, or binds it to an empty value.
+/// Test: `dotenv_tests::read_var_from_env_local_finds_value`,
+/// `dotenv_tests::read_var_from_env_local_absent_is_none`.
+pub fn read_var_from_env_local(path: &Path, var: &str) -> Option<String> {
+    let iter = dotenvy::from_path_iter(path).ok()?;
+    iter.flatten()
+        .find(|(k, _)| k == var)
+        .map(|(_, v)| v)
+        .filter(|v| !v.is_empty())
+}
+
+/// Value of `var` in the nearest ancestor `.env.local`, without mutating the
+/// process environment.
+///
+/// Why: the production `.env.local` tier check for `config keys list` — it must
+/// use the same cwd-upward search [`load_env_local_once`] uses so the reported
+/// tier matches what resolution would actually pick, but observe the file
+/// read-only.
+/// What: searches upward from the current working directory via
+/// [`find_workspace_env_local`] and delegates to [`read_var_from_env_local`];
+/// `None` when there is no `.env.local` or it does not bind `var`.
+/// Test: covered structurally via `read_var_from_env_local` (the cwd-search wrap
+/// is not independently unit tested — it depends on the real cwd, exactly like
+/// [`load_env_local_once`]).
+pub fn env_local_value(var: &str) -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    let path = find_workspace_env_local(&cwd)?;
+    read_var_from_env_local(&path, var)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,6 +153,34 @@ mod tests {
     fn absent_env_local_returns_none() {
         let tmp = tempfile::TempDir::new().unwrap();
         assert_eq!(find_workspace_env_local(tmp.path()), None);
+    }
+
+    /// Why: the `config keys list` tier check must read a var out of a
+    /// `.env.local` file WITHOUT touching the process environment.
+    /// Test: itself.
+    #[test]
+    fn read_var_from_env_local_finds_value() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join(".env.local");
+        std::fs::write(&path, "OPENAI_API_KEY=from-dotenv\nEMPTY=\n").unwrap();
+        assert_eq!(
+            read_var_from_env_local(&path, "OPENAI_API_KEY"),
+            Some("from-dotenv".to_string())
+        );
+        // The read is non-mutating: the process env is untouched.
+        assert!(std::env::var("OPENAI_API_KEY").is_err());
+    }
+
+    /// Why: an absent key (or one bound to an empty value) must read back as
+    /// `None`, not as a spurious empty-string "configured" signal.
+    /// Test: itself.
+    #[test]
+    fn read_var_from_env_local_absent_is_none() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join(".env.local");
+        std::fs::write(&path, "EMPTY=\n").unwrap();
+        assert_eq!(read_var_from_env_local(&path, "EMPTY"), None);
+        assert_eq!(read_var_from_env_local(&path, "MISSING"), None);
     }
 
     /// Why: `load_env_from_path` must set a var not already in the process

--- a/crates/trusty-common/src/inference/credentials/mod.rs
+++ b/crates/trusty-common/src/inference/credentials/mod.rs
@@ -30,7 +30,10 @@ mod memory_store;
 mod redact;
 mod resolver;
 
-pub use dotenv::{find_workspace_env_local, load_env_from_path, load_env_local_once};
+pub use dotenv::{
+    env_local_value, find_workspace_env_local, load_env_from_path, load_env_local_once,
+    read_var_from_env_local,
+};
 pub use file_store::FileKeyStore;
 #[cfg(feature = "keyring-store")]
 pub use keyring_store::KeyringStore;

--- a/crates/trusty-common/src/inference/mod.rs
+++ b/crates/trusty-common/src/inference/mod.rs
@@ -26,6 +26,8 @@ pub mod credentials;
 
 #[cfg(feature = "inference-client")]
 pub mod adapter;
+#[cfg(feature = "config-cli")]
+pub mod config;
 #[cfg(feature = "inference-client")]
 pub mod configurator;
 #[cfg(feature = "inference-client")]
@@ -44,6 +46,8 @@ pub mod types;
 // reaching into each submodule.
 #[cfg(feature = "inference-client")]
 pub use adapter::InferenceAdapter;
+#[cfg(feature = "config-cli")]
+pub use config::ConfigCommand;
 #[cfg(feature = "inference-client")]
 pub use configurator::{AdapterFactory, Configurator, ResolvedProvider, provider_for};
 #[cfg(feature = "inference-client")]

--- a/crates/trusty-common/tests/config_keys_cli.rs
+++ b/crates/trusty-common/tests/config_keys_cli.rs
@@ -190,6 +190,54 @@ fn list_reports_env_tier() {
     unsafe { std::env::remove_var("OPENAI_API_KEY") };
 }
 
+/// Why: some mounting binaries (trusty-search `main.rs`, trusty-agents
+/// `runtime/startup.rs`) already `dotenvy::from_filename(".env.local")` at
+/// startup, folding the file's values into the process env BEFORE `config`
+/// ever runs. When a provider's key is present in BOTH the process env AND the
+/// `.env.local` file, `list` cannot honestly tell "independently exported in
+/// the shell" apart from "the binary's own startup load" — it must report the
+/// ambiguous tier rather than confidently (and possibly wrongly) claiming
+/// "environment variable".
+/// Test: itself.
+#[test]
+#[serial(dotenv_credential_env)]
+fn list_reports_ambiguous_tier_when_env_and_env_local_both_present() {
+    clear_provider_env();
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(
+        tmp.path().join(".env.local"),
+        "ANTHROPIC_API_KEY=file-value\n",
+    )
+    .expect("write .env.local");
+
+    let prior_cwd = std::env::current_dir().expect("cwd");
+    std::env::set_current_dir(tmp.path()).expect("chdir into tempdir");
+    // SAFETY: guarded by `#[serial(dotenv_credential_env)]`; the same guard
+    // also protects this test's exclusive use of the process cwd within this
+    // test binary (every other test in this file is annotated the same way).
+    unsafe { std::env::set_var("ANTHROPIC_API_KEY", "env-value") };
+
+    let store = MemoryKeyStore::new();
+    let mut out = Vec::new();
+    let list_result = ops::list(&store, &mut out);
+
+    // Restore process-global state before any assertion/panic can leak it into
+    // other tests.
+    unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
+    std::env::set_current_dir(&prior_cwd).expect("restore cwd");
+
+    list_result.expect("list ok");
+    let s = out_string(&out);
+    assert!(
+        s.contains("anthropic") && s.contains(KeyTier::EnvOrEnvLocal.label()),
+        "anthropic should report the ambiguous env/.env.local tier: {s}"
+    );
+    assert!(
+        !s.contains("env-value") && !s.contains("file-value"),
+        "list leaked a value: {s}"
+    );
+}
+
 /// Why: `set`/`unset` must reject a provider that does not use an API key
 /// (Bedrock — AWS chain) and an unknown provider, with an actionable message.
 /// Test: itself.
@@ -273,6 +321,48 @@ async fn test_probe_401_is_unauthorized() {
     let mut out = Vec::new();
     ops::report_probe("openrouter", &outcome, &mut out).expect("report");
     assert!(!out_string(&out).contains(FAKE_KEY));
+}
+
+/// Why: `InferenceError::Api`'s `Display` embeds the raw, provider-controlled
+/// response BODY verbatim. A provider that echoes the offending credential back
+/// in a non-401/403 error body (landing on the `ProbeOutcome::Failed` catch-all)
+/// must NOT have that value reach `report_probe`'s output — the one place in
+/// this credential-management CLI that must never leak a key. This drives the
+/// full probe→report pipeline with a mock body that CONTAINS the fake key and
+/// asserts it never surfaces.
+/// Test: itself.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn probe_error_body_never_leaks_the_resolved_key() {
+    clear_provider_env();
+    // 400 (not 401/403) so this lands on the `Failed` catch-all, not
+    // `Unauthorized` — and the body echoes the key back, as a misbehaving or
+    // overly-verbose provider error page might.
+    let server = MockInferenceServer::spawn(
+        400,
+        serde_json::json!({"error": {"message": format!("invalid credential: {FAKE_KEY}")}}),
+    )
+    .await
+    .expect("spawn");
+    let cfg = mock_configurator(server.url().to_string());
+
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", FAKE_KEY).unwrap();
+
+    let outcome = ops::probe(&store, &cfg, "openrouter").await.expect("probe");
+    let ProbeOutcome::Failed(reason) = &outcome else {
+        panic!("expected a Failed outcome for a 400 response, got {outcome:?}");
+    };
+    assert!(
+        !reason.contains(FAKE_KEY),
+        "ProbeOutcome::Failed leaked the key: {reason}"
+    );
+
+    let mut out = Vec::new();
+    ops::report_probe("openrouter", &outcome, &mut out).expect("report");
+    let s = out_string(&out);
+    assert!(!s.contains(FAKE_KEY), "report_probe leaked the key: {s}");
+    assert!(s.contains("ERROR"), "{s}");
 }
 
 /// Why: probing a provider with no key configured must degrade cleanly to

--- a/crates/trusty-common/tests/config_keys_cli.rs
+++ b/crates/trusty-common/tests/config_keys_cli.rs
@@ -1,0 +1,310 @@
+//! End-to-end tests for the universal `config keys` CLI (issue #2404).
+//!
+//! Why: the acceptance criteria make the whole `config keys` surface a merge
+//! gate — it must be 100% exercisable non-interactively. This suite proves the
+//! argv grammar parses (the canonical forms + the deliberately-absent `get`),
+//! the mount-once/extensibility contract holds, and the full set→list→test→unset
+//! flow works through the injectable `inference::config::ops` seam against a
+//! `MemoryKeyStore` and a mock provider — asserting throughout that NO key value
+//! ever appears in any output.
+//! What: black-box tests against `trusty_common::inference::config::*`, with the
+//! live `test` probe pointed at the axum `MockInferenceServer`. Requires
+//! `config-cli` (the command + ops) + `axum-server` (the mock).
+//! Test: this file — run with
+//! `cargo test -p trusty-common --features config-cli,axum-server`.
+
+use std::io::Cursor;
+
+use clap::Parser;
+use serial_test::serial;
+
+use trusty_common::inference::config::ops::{KeyTier, ProbeOutcome};
+use trusty_common::inference::config::{ConfigCommand, ops};
+use trusty_common::inference::credentials::{KeyStore, MemoryKeyStore};
+use trusty_common::inference::providers::openrouter;
+use trusty_common::inference::test_support::MockInferenceServer;
+use trusty_common::inference::{Configurator, ProviderId, ResolvedProvider};
+
+/// A fake secret used across the flow tests; asserted NEVER to appear in output.
+const FAKE_KEY: &str = "sk-or-supersecretvalue-must-never-print-9999"; // pragma: allowlist secret
+
+/// Minimal clap harness that mounts `ConfigCommand` exactly as a real binary
+/// would — this both drives the argv-grammar tests AND demonstrates the two-line
+/// mount recipe / zero-mount-churn extensibility contract.
+#[derive(Parser)]
+#[command(name = "harness")]
+struct Harness {
+    #[command(subcommand)]
+    command: HarnessCmd,
+}
+
+#[derive(clap::Subcommand)]
+enum HarnessCmd {
+    /// The single mount point — line 1 of the #2405 recipe.
+    Config(ConfigCommand),
+}
+
+/// Clear every provider env var so the injected `MemoryKeyStore` is the only
+/// credential source in a test (a stray env var would shadow it / skew tiers).
+fn clear_provider_env() {
+    for var in [
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "FIREWORKS_API_KEY",
+        "TOGETHER_API_KEY",
+    ] {
+        // SAFETY: every caller is `#[serial(dotenv_credential_env)]`, matching
+        // the lock the credential resolver's own env-mutating tests use.
+        unsafe { std::env::remove_var(var) };
+    }
+}
+
+/// Decode a captured output buffer to a string for assertions.
+fn out_string(buf: &[u8]) -> String {
+    String::from_utf8(buf.to_vec()).expect("output is valid UTF-8")
+}
+
+// ── argv grammar ─────────────────────────────────────────────────────────────
+
+/// Why: the canonical `config keys …` argv forms must parse, and the mount is a
+/// single `Config(ConfigCommand)` variant (the extensibility contract: nothing
+/// at the mount site knows about verbs).
+/// Test: itself.
+#[test]
+fn config_keys_argv_grammar_parses() {
+    let canonical: &[&[&str]] = &[
+        &["harness", "config", "keys", "set", "openrouter"],
+        &["harness", "config", "keys", "set", "openrouter", "sk-value"], // pragma: allowlist secret
+        &["harness", "config", "keys", "list"],
+        &["harness", "config", "keys", "test", "anthropic"],
+        &["harness", "config", "keys", "unset", "fireworks"],
+        &["harness", "config", "keys", "test", "together"],
+    ];
+    for argv in canonical {
+        assert!(
+            Harness::try_parse_from(*argv).is_ok(),
+            "canonical grammar should parse: {argv:?}"
+        );
+    }
+}
+
+/// Why: there is deliberately NO `config keys get` — a value-reading verb would
+/// violate the never-echo mandate. It must fail to parse.
+/// Test: itself.
+#[test]
+fn config_keys_rejects_get() {
+    assert!(
+        Harness::try_parse_from(["harness", "config", "keys", "get", "openrouter"]).is_err(),
+        "`config keys get` must not exist"
+    );
+}
+
+// ── read_key_line: the scriptable stdin-pipe path ────────────────────────────
+
+/// Why: `set` with no VALUE arg on a pipe reads the key from stdin; the value
+/// must come back with its trailing newline stripped and nothing echoed.
+/// Test: itself.
+#[test]
+fn read_key_line_trims_piped_value() {
+    let mut reader = Cursor::new(format!("{FAKE_KEY}\n").into_bytes());
+    assert_eq!(ops::read_key_line(&mut reader).unwrap(), FAKE_KEY);
+}
+
+// ── set → list → unset flow (no network) ─────────────────────────────────────
+
+/// Why: the core credential lifecycle must work through the injectable ops and
+/// never reveal the value: `set` stores it (confirmation redacted), `list`
+/// reports the store tier by name only, `unset` removes it, and a second `unset`
+/// reports absence. The fake key must appear in NONE of the captured output.
+/// Test: itself.
+#[test]
+#[serial(dotenv_credential_env)]
+fn set_then_list_reports_store_tier_without_value() {
+    clear_provider_env();
+    let store = MemoryKeyStore::new();
+
+    // set
+    let mut set_out = Vec::new();
+    ops::set(&store, "openrouter", FAKE_KEY, &mut set_out).expect("set ok");
+    let set_str = out_string(&set_out);
+    assert!(set_str.contains("openrouter"), "{set_str}");
+    assert!(!set_str.contains(FAKE_KEY), "set leaked the key: {set_str}");
+    // The value really landed in the store.
+    assert_eq!(store.get("openrouter").as_deref(), Some(FAKE_KEY));
+
+    // list — reports the store tier, no value.
+    let mut list_out = Vec::new();
+    ops::list(&store, &mut list_out).expect("list ok");
+    let list_str = out_string(&list_out);
+    assert!(
+        list_str.contains("openrouter") && list_str.contains(KeyTier::Store.label()),
+        "list should show openrouter via the secure store: {list_str}"
+    );
+    // A provider with no key is reported as not configured.
+    assert!(list_str.contains("not configured"), "{list_str}");
+    assert!(
+        !list_str.contains(FAKE_KEY),
+        "list leaked the key: {list_str}"
+    );
+
+    // unset — removes it and reports removal.
+    let mut unset_out = Vec::new();
+    ops::unset(&store, "openrouter", &mut unset_out).expect("unset ok");
+    assert!(store.get("openrouter").is_none(), "key should be gone");
+    let unset_str = out_string(&unset_out);
+    assert!(unset_str.contains("Removed"), "{unset_str}");
+    assert!(!unset_str.contains(FAKE_KEY));
+
+    // second unset — reports absence, not an error.
+    let mut again = Vec::new();
+    ops::unset(&store, "openrouter", &mut again).expect("idempotent unset");
+    assert!(out_string(&again).contains("nothing to remove"));
+}
+
+/// Why: `list` must report the ENV tier (highest precedence) when a provider's
+/// env var is set, distinct from the store tier — the tier-aware requirement.
+/// Test: itself.
+#[test]
+#[serial(dotenv_credential_env)]
+fn list_reports_env_tier() {
+    clear_provider_env();
+    let store = MemoryKeyStore::new();
+    // Store also has a key, but the env var must win the tier report.
+    store.set("openai", FAKE_KEY).unwrap();
+    // SAFETY: guarded by `#[serial(dotenv_credential_env)]`.
+    unsafe { std::env::set_var("OPENAI_API_KEY", "env-value") };
+
+    let mut out = Vec::new();
+    ops::list(&store, &mut out).expect("list ok");
+    let s = out_string(&out);
+    assert!(
+        s.contains("openai") && s.contains(KeyTier::Env.label()),
+        "openai should report the env tier: {s}"
+    );
+    assert!(
+        !s.contains(FAKE_KEY) && !s.contains("env-value"),
+        "list leaked a value: {s}"
+    );
+
+    unsafe { std::env::remove_var("OPENAI_API_KEY") };
+}
+
+/// Why: `set`/`unset` must reject a provider that does not use an API key
+/// (Bedrock — AWS chain) and an unknown provider, with an actionable message.
+/// Test: itself.
+#[test]
+#[serial(dotenv_credential_env)]
+fn set_rejects_unknown_and_keyless_providers() {
+    clear_provider_env();
+    let store = MemoryKeyStore::new();
+    let mut out = Vec::new();
+    assert!(ops::set(&store, "bedrock", "x", &mut out).is_err());
+    assert!(ops::set(&store, "cohere", "x", &mut out).is_err());
+    // Nothing should have been written for the rejected providers.
+    assert!(store.list().is_empty());
+}
+
+// ── test (live probe) against the mock server ────────────────────────────────
+
+/// Build a `Configurator` whose OpenRouter factory targets the mock server URL
+/// instead of the real API — the same injection the adapter e2e suite uses.
+fn mock_configurator(base_url: String) -> Configurator {
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::OpenRouter,
+        Box::new(move |r: &ResolvedProvider| openrouter::build(r, &base_url)),
+    );
+    cfg
+}
+
+/// Why: `config keys test` with a valid key must probe the provider and report
+/// OK, without the key appearing in any output — the happy path of the
+/// api-testable-locally check.
+/// Test: itself.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn test_probe_ok_against_mock() {
+    clear_provider_env();
+    let body = serde_json::json!({
+        "id": "gen-mock",
+        "choices": [{"message": {"role": "assistant", "content": "pong"},
+                     "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+    });
+    let server = MockInferenceServer::spawn(200, body).await.expect("spawn");
+    let cfg = mock_configurator(server.url().to_string());
+
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", FAKE_KEY).unwrap();
+
+    let outcome = ops::probe(&store, &cfg, "openrouter").await.expect("probe");
+    assert_eq!(outcome, ProbeOutcome::Ok);
+
+    let mut out = Vec::new();
+    ops::report_probe("openrouter", &outcome, &mut out).expect("report");
+    let s = out_string(&out);
+    assert!(s.contains("OK"), "{s}");
+    assert!(!s.contains(FAKE_KEY), "probe report leaked the key: {s}");
+}
+
+/// Why: a 401/403 from the provider must classify as UNAUTHORIZED (not OK, not a
+/// generic error), still without leaking the key.
+/// Test: itself.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn test_probe_401_is_unauthorized() {
+    clear_provider_env();
+    let server = MockInferenceServer::spawn(401, serde_json::json!({"error": "invalid key"}))
+        .await
+        .expect("spawn");
+    let cfg = mock_configurator(server.url().to_string());
+
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", FAKE_KEY).unwrap();
+
+    let outcome = ops::probe(&store, &cfg, "openrouter").await.expect("probe");
+    assert_eq!(outcome, ProbeOutcome::Unauthorized);
+    assert!(
+        outcome.clone().into_result().is_err(),
+        "401 must be a failure exit"
+    );
+
+    let mut out = Vec::new();
+    ops::report_probe("openrouter", &outcome, &mut out).expect("report");
+    assert!(!out_string(&out).contains(FAKE_KEY));
+}
+
+/// Why: probing a provider with no key configured must degrade cleanly to
+/// UNCONFIGURED (a clear message, no panic, no network call).
+/// Test: itself.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn test_probe_unconfigured_when_no_key() {
+    clear_provider_env();
+    // No mock even needed — resolution short-circuits before any network call.
+    let cfg = mock_configurator("http://127.0.0.1:1".to_string());
+    let store = MemoryKeyStore::new();
+
+    let outcome = ops::probe(&store, &cfg, "openrouter").await.expect("probe");
+    assert_eq!(outcome, ProbeOutcome::Unconfigured);
+    // Clean degrade: exit success, not an error.
+    assert!(outcome.into_result().is_ok());
+}
+
+/// Why: Bedrock has no API key (AWS credential chain) so `test` must report it as
+/// unsupported rather than attempting a key probe.
+/// Test: itself.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn test_probe_bedrock_is_unsupported() {
+    clear_provider_env();
+    let cfg = mock_configurator("http://127.0.0.1:1".to_string());
+    let store = MemoryKeyStore::new();
+
+    let outcome = ops::probe(&store, &cfg, "bedrock").await.expect("probe");
+    assert!(
+        matches!(outcome, ProbeOutcome::Unsupported(_)),
+        "{outcome:?}"
+    );
+}


### PR DESCRIPTION
Wave-1 slice of the inference-adapter epic #2400: the single universal `config` clap module that **any** trusty-* binary mounts identically. #2405 will mount it on all ten binaries — this PR builds the shared module and designs its public API for that.

## What it does

`inference::config::ConfigCommand` (a clap `Args`) nests a `<feature>` subcommand, so the grammar is `<bin> config <feature> <verb> …`. Wave 1 ships the `keys` feature with four verbs — deliberately **no `get`** (the never-echo-a-value mandate):

| Verb | Behavior |
|------|----------|
| `config keys set <provider> [<value>]` | Store a key in the **secure store** (File-0600 / OS keyring). Value omitted → **hidden TTY prompt** (`rpassword`) or **stdin pipe**, so keys never land in shell history; an explicit arg / pipe keeps it scriptable. Confirmation shows only a **redacted preview**, never the value. |
| `config keys list` | Every known provider's status by **name + tier only** (`environment variable` / `.env.local` / `secure store`), never values. Bedrock reports "AWS credential chain (no API key)". |
| `config keys test <provider>` | **Cheap live auth check**: resolve the key (env > `.env.local` > store), build the shared adapter via the `Configurator`, issue a minimal 1-token chat probe; reports `OK` / `UNAUTHORIZED(401/403)` / `UNCONFIGURED` / `SKIPPED` / `ERROR` **without leaking the key**. Degrades cleanly when no key is set. |
| `config keys unset <provider>` | Remove the key from the **secure store only** (never touches env / `.env.local`); reports if it wasn't set. |

## Secure-store default & tier-aware `list`

`set`/`unset` operate on the `KeyStore`'s default secure backend (`default_store()` → OS keyring when available, else File-0600). `list`'s tier report reads the process env and `.env.local` **independently** (via a new non-mutating `read_var_from_env_local` / `env_local_value` in the credentials module) so it distinguishes the shell-env tier from the `.env.local` tier honestly, matching resolver precedence.

## 2-line mount recipe for #2405

```rust
use trusty_common::inference::config::ConfigCommand;

#[derive(clap::Subcommand)]
enum Commands {
    // …
    Config(ConfigCommand),          // line 1: mount
}
// dispatch (inside the async entry point):
Commands::Config(cmd) => cmd.run().await?,   // line 2
```

Adding a future `config <feature>` is a new `ConfigFeature` variant in the module — **mount sites do not change** (the extensibility contract). The full recipe is documented in the module doc.

## Feature gating

Behind a new `config-cli` feature (`= ["inference-client", "dep:clap", "dep:rpassword"]`). Verified:
- `cargo build -p trusty-common` (no features) compiles **neither** the module **nor** clap (`cargo tree` confirms clap/rpassword absent).
- `inference-client` consumers (e.g. tcode #2406) stay **clap-free** — clap absent from that tree too.

## Security

No key value is ever printed, logged, or `Debug`-formatted: values flow through `SecretString` / `redact_secret`, the store, and (for the probe) the adapter's `Authorization` header only. Tests assert the fake key appears in **no** captured output.

## Tests

`crates/trusty-common/tests/config_keys_cli.rs` (+ inline unit tests), gated `config-cli,axum-server`: six canonical argv parses, `get` rejected, full set→list→test→unset flow, env-vs-store tier reporting, and the live probe (OK + 401 UNAUTHORIZED + UNCONFIGURED + Bedrock-unsupported) against the `MockInferenceServer`.

```
config_keys_cli.rs:  10 passed
lib unit tests:      237 passed (incl. new ops + .env.local reader tests)
```

## Gates (all green)

- `cargo build -p trusty-common` (no features): clean; clap excluded
- `cargo test -p trusty-common --features config-cli,axum-server`: 10 + 2 + all pass
- `cargo test -p trusty-common --features inference-client`: config/clap excluded, 230 pass
- `cargo build --workspace`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: exit 0
- `cargo fmt --check`: clean
- `bash scripts/check_line_cap.sh`: 0 violations (largest new file 399 SLOC)

Closes #2404
Refs #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)