### PR TITLE
fix(trusty-search): index-registry integrity — runtime collision guard + dedup follow-ups (closes #2336, #2337)

### DIFF
--- a/crates/trusty-search/src/commands/start/restore.rs
+++ b/crates/trusty-search/src/commands/start/restore.rs
@@ -106,7 +106,16 @@ pub(super) async fn restore_indexes(
     // retry can never clear an in-process holder). Deduping before the split
     // also prevents a dropped duplicate from being parked in the cold store and
     // re-triggering the double-open on first query.
-    let all_entries = crate::service::warm_boot::dedup_entries_by_corpus_path(all_entries);
+    //
+    // Issue #2337 follow-up: the verbose variant also reports which entries
+    // were dropped and which survivors absorbed a dropped entry's config, so
+    // `prune_and_persist_dedup_outcome` can self-heal `indexes.toml` — pruning
+    // the losing rows (otherwise re-discovered/re-warned/re-dropped forever)
+    // and persisting the merged survivor config so it survives future boots.
+    let dedup_outcome =
+        crate::service::warm_boot::dedup_entries_by_corpus_path_verbose(all_entries);
+    prune_and_persist_dedup_outcome(&dedup_outcome);
+    let all_entries = dedup_outcome.survivors;
     let total_discovered = all_entries.len();
 
     let (eager_entries, cold_entries) = select_warmboot_entries(all_entries, max_warmboot);
@@ -268,4 +277,64 @@ pub(super) async fn restore_indexes(
              for the count, then resolve the root cause and restart (issue #764).",
         );
     }
+}
+
+/// Self-heal `indexes.toml` after warm-boot dedup collapses a corpus-path
+/// collision (issue #2337, follow-up to #2305).
+///
+/// Why: without this, a dropped duplicate's `indexes.toml` row survived
+/// forever — re-discovered, re-warned, and re-dropped on every single boot
+/// (log spam plus a ghost registry row that no API acknowledges, since
+/// `GET /indexes` and friends correctly 404 the dropped id). Mirrors the
+/// existing `orphan_reaper::heal_boot_orphans` self-heal pattern that already
+/// does the same kind of `indexes.toml` cleanup for a different orphan shape.
+/// What: no-ops immediately when nothing was dropped (the common case, zero
+/// collisions on most boots). Otherwise: removes every dropped entry's row
+/// via `remove_index_registry_entry` (idempotent no-op if the id never had a
+/// row — e.g. a purely colocated-scan discovery that was never persisted);
+/// for every survivor id in `merged_survivor_ids` (i.e. it actually absorbed
+/// a dropped entry's config), upserts the merged `PersistedIndex` so the
+/// preserved list-type config (issue #2337 part 2) is durable across future
+/// restarts, not just this boot's in-memory restore. Both operations are
+/// best-effort: a write failure is logged and retried on the next boot,
+/// never blocks startup.
+/// Test: `dedup_entries_by_corpus_path_verbose` (the pure decision logic) is
+/// unit-tested in `warm_boot_tests.rs`; this thin IO wrapper mirrors the
+/// already-covered `remove_index_registry_entry` / `upsert_index_registry_entry`
+/// round-trip semantics and is exercised end-to-end by the warm-boot
+/// integration tests.
+fn prune_and_persist_dedup_outcome(outcome: &crate::service::warm_boot::DedupOutcome) {
+    if outcome.dropped.is_empty() {
+        return;
+    }
+
+    for dropped in &outcome.dropped {
+        if let Err(e) = crate::service::persistence::remove_index_registry_entry(&dropped.id) {
+            tracing::warn!(
+                "warm-boot dedup: could not prune indexes.toml row for dropped index '{}': \
+                 {e} (issue #2337; will retry next boot)",
+                dropped.id
+            );
+        }
+    }
+
+    for survivor in &outcome.survivors {
+        if !outcome.merged_survivor_ids.contains(&survivor.id) {
+            continue;
+        }
+        if let Err(e) = crate::service::persistence::upsert_index_registry_entry(survivor.clone()) {
+            tracing::warn!(
+                "warm-boot dedup: could not persist merged config for survivor '{}': {e} \
+                 (issue #2337; the merge still applies for this boot's in-memory restore)",
+                survivor.id
+            );
+        }
+    }
+
+    tracing::info!(
+        "warm-boot dedup: pruned {} indexes.toml row(s), persisted merged config for {} \
+         survivor(s) (issue #2337)",
+        outcome.dropped.len(),
+        outcome.merged_survivor_ids.len(),
+    );
 }

--- a/crates/trusty-search/src/service/server/helpers.rs
+++ b/crates/trusty-search/src/service/server/helpers.rs
@@ -216,15 +216,36 @@ pub(super) fn file_is_within_root(file: &str, root: &std::path::Path) -> bool {
 /// What: `candidate` must already be canonicalized — every caller passes the
 /// output of `validate_root_path`, the same normalization every registered
 /// handle's `root_path` went through (directly at create/relocate time, or
-/// via `canonicalize_best_effort` at warm-boot), so the equality comparison
-/// below is exact with no separate canonicalization step needed here. Linear
-/// scan of `handles` (the registry is small — tens to low hundreds of
-/// entries); returns the first colliding id, skipping `exclude_id` (used by
-/// `relocate_index_handler` so an index is never compared against itself).
+/// via `canonicalize_best_effort` at warm-boot). Adversarial review (#2519)
+/// found that plain `PathBuf` equality on canonicalized paths is NOT a
+/// reliable identity check on case-insensitive-but-case-preserving
+/// filesystems (macOS APFS default): `/Volumes/Data/Proj` and
+/// `/Volumes/Data/PROJ` canonicalize to two different-looking strings that
+/// nonetheless resolve to the SAME inode, so string equality misses the
+/// collision entirely. The fix compares filesystem-truth identity —
+/// `(dev, ino)` from `std::fs::metadata` — whenever both paths currently
+/// exist on disk; this catches case variants AND other alias forms (bind
+/// mounts, hard-linked directories) that resolve to one inode, at the cost of
+/// one extra `stat(2)` per registered handle per call. When either path
+/// doesn't exist (metadata lookup fails), the check falls back to plain
+/// canonicalized-`PathBuf` equality — the pre-fix behavior. This fallback is
+/// a deliberate fail-open/fail-closed tradeoff: it stays fail-closed for the
+/// dominant, security-relevant case (the candidate root always exists —
+/// `validate_root_path` already required `is_dir()` before this is called),
+/// and only degrades to string equality for the exotic case of a handle
+/// whose `root_path` has since vanished from disk (e.g. a device was
+/// unmounted after registration), where dev/ino cannot be computed for one
+/// side. Linear scan of `handles` (the registry is small — tens to low
+/// hundreds of entries); returns the first colliding id, skipping
+/// `exclude_id` (used by `relocate_index_handler` so an index is never
+/// compared against itself).
 /// Test: `create_index_rejects_duplicate_root_path`,
 /// `create_index_same_id_same_root_is_idempotent_not_a_collision`,
 /// `relocate_index_rejects_root_path_owned_by_another_index`,
-/// `relocate_index_onto_own_current_root_is_not_a_collision` in `tests_2336.rs`.
+/// `relocate_index_onto_own_current_root_is_not_a_collision`,
+/// `create_index_concurrent_same_root_only_one_wins` in `tests_2336.rs`; plus
+/// the macOS-gated `create_index_rejects_case_variant_of_registered_root`
+/// exercising the dev/ino path directly.
 pub(super) fn find_root_path_collision(
     handles: &[std::sync::Arc<IndexHandle>],
     candidate: &std::path::Path,
@@ -232,8 +253,49 @@ pub(super) fn find_root_path_collision(
 ) -> Option<IndexId> {
     handles
         .iter()
-        .find(|h| h.root_path == candidate && exclude_id != Some(&h.id))
+        .find(|h| exclude_id != Some(&h.id) && identifies_same_root(&h.root_path, candidate))
         .map(|h| h.id.clone())
+}
+
+/// Decide whether `a` and `b` name the same on-disk root (issue #2519).
+///
+/// Why: see `find_root_path_collision`'s doc for the case-insensitive
+/// filesystem hazard this closes.
+/// What: prefers `(dev, ino)` identity via `same_filesystem_entry` when both
+/// paths exist; falls back to canonicalized-`PathBuf` equality otherwise.
+/// Test: covered transitively by `find_root_path_collision`'s test list.
+fn identifies_same_root(a: &std::path::Path, b: &std::path::Path) -> bool {
+    match same_filesystem_entry(a, b) {
+        Some(same) => same,
+        None => a == b,
+    }
+}
+
+/// Compare `a` and `b` by `(dev, ino)`, returning `None` when either path's
+/// metadata cannot be read (does not exist, permission denied, etc.) so the
+/// caller can fall back to string equality.
+///
+/// Why: `stat(2)`-level identity is the only reliable way to tell whether two
+/// path strings name the same file on a case-insensitive-but-case-preserving
+/// filesystem (macOS APFS default) — canonicalize() preserves the case each
+/// path was spelled with, it does not normalize case, so two differently-cased
+/// spellings of the same directory canonicalize to two different strings.
+/// What: unix-only (`dev`/`ino` via `std::os::unix::fs::MetadataExt`); no
+/// portable equivalent is wired up for non-unix targets, so this always
+/// returns `None` there and callers fall back to path equality.
+/// Test: `create_index_rejects_case_variant_of_registered_root` (macOS-gated)
+/// in `tests_2336.rs`.
+#[cfg(unix)]
+fn same_filesystem_entry(a: &std::path::Path, b: &std::path::Path) -> Option<bool> {
+    use std::os::unix::fs::MetadataExt;
+    let meta_a = std::fs::metadata(a).ok()?;
+    let meta_b = std::fs::metadata(b).ok()?;
+    Some(meta_a.dev() == meta_b.dev() && meta_a.ino() == meta_b.ino())
+}
+
+#[cfg(not(unix))]
+fn same_filesystem_entry(_a: &std::path::Path, _b: &std::path::Path) -> Option<bool> {
+    None
 }
 
 /// Build a `409 Conflict` response naming the index that already owns

--- a/crates/trusty-search/src/service/server/helpers.rs
+++ b/crates/trusty-search/src/service/server/helpers.rs
@@ -1,17 +1,21 @@
-//! Shared helpers: root-path validation, chunk containment check, and
-//! embedder status response builders.
+//! Shared helpers: root-path validation, chunk containment check, root_path
+//! collision detection, and embedder status response builders.
 //!
 //! Why: These small helpers are called from multiple handler modules
-//! (`indexes.rs`, `search.rs`, `reindex_handlers.rs`); centralising them
-//! avoids duplication and keeps the 500-line cap on each handler file.
+//! (`indexes.rs`, `indexes_relocate.rs`, `search.rs`, `reindex_handlers.rs`);
+//! centralising them avoids duplication and keeps the 500-line cap on each
+//! handler file.
 //! What: `validate_root_path`, `file_is_within_root`,
+//! `find_root_path_collision`, `root_path_collision_response`,
 //! `embedder_initializing_response`, `embedder_error_response`.
-//! Test: `file_is_within_root_*`, `create_index_canonicalizes_*`, and
-//! `validate_root_path_denylist_*` tests.
+//! Test: `file_is_within_root_*`, `create_index_canonicalizes_*`,
+//! `validate_root_path_denylist_*`, and `tests_2336.rs` tests.
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Json, Response},
 };
+
+use crate::core::registry::{IndexHandle, IndexId};
 
 /// Validate `path` as a safe, canonical root for indexing.
 ///
@@ -194,6 +198,70 @@ pub(super) fn file_is_within_root(file: &str, root: &std::path::Path) -> bool {
     }
     !p.components()
         .any(|c| matches!(c, std::path::Component::ParentDir))
+}
+
+/// Find a registered index whose canonical `root_path` collides with
+/// `candidate`, excluding `exclude_id` (issue #2336).
+///
+/// Why: `create_index_handler` and `relocate_index_handler` previously
+/// guarded only *id* collisions, never *root_path* collisions. Two live
+/// registrations sharing one colocated root resolve to the SAME on-disk
+/// `<root>/.trusty-search/index.redb` — redb is a single-open database, so
+/// the second registration's `build_indexer_from_entry` call would silently
+/// fail its corpus open (`corpus_open_failed`) while the handler still
+/// returned `200 {"created": true}` for the broken handle. This is the exact
+/// runtime recreation of the #2305 double-registration hazard the warm-boot
+/// dedup fixed only for the boot path. This guard rejects the registration
+/// up front instead of building a broken indexer first.
+/// What: `candidate` must already be canonicalized — every caller passes the
+/// output of `validate_root_path`, the same normalization every registered
+/// handle's `root_path` went through (directly at create/relocate time, or
+/// via `canonicalize_best_effort` at warm-boot), so the equality comparison
+/// below is exact with no separate canonicalization step needed here. Linear
+/// scan of `handles` (the registry is small — tens to low hundreds of
+/// entries); returns the first colliding id, skipping `exclude_id` (used by
+/// `relocate_index_handler` so an index is never compared against itself).
+/// Test: `create_index_rejects_duplicate_root_path`,
+/// `create_index_same_id_same_root_is_idempotent_not_a_collision`,
+/// `relocate_index_rejects_root_path_owned_by_another_index`,
+/// `relocate_index_onto_own_current_root_is_not_a_collision` in `tests_2336.rs`.
+pub(super) fn find_root_path_collision(
+    handles: &[std::sync::Arc<IndexHandle>],
+    candidate: &std::path::Path,
+    exclude_id: Option<&IndexId>,
+) -> Option<IndexId> {
+    handles
+        .iter()
+        .find(|h| h.root_path == candidate && exclude_id != Some(&h.id))
+        .map(|h| h.id.clone())
+}
+
+/// Build a `409 Conflict` response naming the index that already owns
+/// `root_path` (issue #2336).
+///
+/// Why: the caller must be told WHICH existing index it collided with so it
+/// can decide whether to reuse that index, delete it first, or pick a
+/// distinct root — a bare 409 with no context forces the operator to
+/// cross-reference `GET /indexes?details=true` by hand.
+/// What: `409 { "error": "...", "existing_id": "..." }`.
+/// Test: see `find_root_path_collision` test list above.
+pub(super) fn root_path_collision_response(
+    existing_id: &IndexId,
+    root_path: &std::path::Path,
+) -> Response {
+    (
+        StatusCode::CONFLICT,
+        Json(serde_json::json!({
+            "error": format!(
+                "root_path {:?} is already registered to index '{}'; two indexes cannot \
+                 share one on-disk corpus (issues #2305, #2336)",
+                root_path.display(),
+                existing_id,
+            ),
+            "existing_id": existing_id.0,
+        })),
+    )
+        .into_response()
 }
 
 /// Build a `503 Service Unavailable` response for handlers that require the

--- a/crates/trusty-search/src/service/server/indexes.rs
+++ b/crates/trusty-search/src/service/server/indexes.rs
@@ -223,12 +223,18 @@ pub(super) async fn create_index_handler(
             }
         };
 
-    // Issue #2336 defense-in-depth: the collision guard above catches the
-    // common case, but `corpus_open_failed` is the ground truth — any other
-    // reason the redb open failed (e.g. a raced collision, or an unrelated
-    // open error) must not be silently registered as a healthy
-    // `200 {"created": true}` handle. Previously this failure was swallowed:
-    // `indexer.corpus_open_failed` was set but never checked here.
+    // Issue #2336 defense-in-depth: the `find_root_path_collision` check
+    // above is BEST-EFFORT ONLY — it is a check-then-act race (issue #2519
+    // review, accepted as documented behavior rather than fixed with a
+    // registration mutex): two concurrent `POST /indexes` calls for the same
+    // root can both pass the guard before either has registered a handle.
+    // `indexer.corpus_open_failed` is the GROUND TRUTH — redb's single-open
+    // semantics mean at most one of the racing opens can ever succeed, so
+    // this check catches every case the best-effort guard misses (the raced
+    // collision above, or any unrelated open error) and must not be silently
+    // registered as a healthy `200 {"created": true}` handle. Previously this
+    // failure was swallowed: `indexer.corpus_open_failed` was set but never
+    // checked here.
     if indexer.corpus_open_failed {
         tracing::error!(
             "create_index: corpus open failed for '{}' at {} — refusing to register a \

--- a/crates/trusty-search/src/service/server/indexes.rs
+++ b/crates/trusty-search/src/service/server/indexes.rs
@@ -5,7 +5,11 @@
 //! lives in `indexes_relocate` to keep this file under the 500-line cap.
 //! What: `list_indexes_handler`, `create_index_handler`, and the types they use
 //! (`ListIndexesParams`, `IndexListResponse`, `IndexDetailEntry`).
-//! Test: `create_index_rejects_relative_root_path` and related tests.
+//! Issue #2336: `create_index_handler` also guards against registering a
+//! second index over a `root_path` already owned by a different registered
+//! id (409), and refuses to register a handle whose corpus open failed.
+//! Test: `create_index_rejects_relative_root_path`, `tests_2336.rs`, and
+//! related tests.
 use axum::{
     extract::{Query, State},
     response::{IntoResponse, Json, Response},
@@ -15,7 +19,10 @@ use std::sync::Arc;
 
 use crate::core::registry::{IndexHandle, IndexId};
 
-use super::helpers::{embedder_error_response, embedder_initializing_response, validate_root_path};
+use super::helpers::{
+    embedder_error_response, embedder_initializing_response, find_root_path_collision,
+    root_path_collision_response, validate_root_path,
+};
 use super::router::{CreateIndexRequest, IndexDetailEntry, IndexListResponse};
 use super::state::{DaemonEvent, SearchAppState};
 use super::status::index_disk_and_mtime;
@@ -132,6 +139,24 @@ pub(super) async fn create_index_handler(
         }))
         .into_response();
     }
+    // Issue #2336: reject a second live index over the same canonical
+    // root_path. Two registrations sharing one colocated root resolve to the
+    // SAME on-disk redb corpus (`<root>/.trusty-search/index.redb`); redb is
+    // single-open, so building this index's indexer would silently fail its
+    // corpus open while this handler still returned `200 {"created": true}`
+    // — recreating the #2305 double-registration hazard at runtime instead
+    // of only at warm-boot. Checked before the (expensive) indexer build.
+    let handles = state.registry.list_handles();
+    if let Some(existing_id) = find_root_path_collision(&handles, &req.root_path, Some(&id)) {
+        tracing::warn!(
+            "create_index: refusing to register '{}' at {} — root_path already owned by \
+             '{}' (issue #2336)",
+            req.id,
+            req.root_path.display(),
+            existing_id,
+        );
+        return root_path_collision_response(&existing_id, &req.root_path);
+    }
     // Why (issue: 10s readiness timeout): the embedder may still be loading
     // when the daemon accepts its first request. Reject hybrid-index creation
     // with `503 Service Unavailable` so the caller (`trusty-search index`)
@@ -197,6 +222,32 @@ pub(super) async fn create_index_handler(
                     .into_response();
             }
         };
+
+    // Issue #2336 defense-in-depth: the collision guard above catches the
+    // common case, but `corpus_open_failed` is the ground truth — any other
+    // reason the redb open failed (e.g. a raced collision, or an unrelated
+    // open error) must not be silently registered as a healthy
+    // `200 {"created": true}` handle. Previously this failure was swallowed:
+    // `indexer.corpus_open_failed` was set but never checked here.
+    if indexer.corpus_open_failed {
+        tracing::error!(
+            "create_index: corpus open failed for '{}' at {} — refusing to register a \
+             broken index handle (issue #2336)",
+            req.id,
+            req.root_path.display()
+        );
+        return (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(serde_json::json!({
+                "error": format!(
+                    "corpus open failed for root_path {:?}; refusing to register a broken \
+                     index handle",
+                    req.root_path.display()
+                )
+            })),
+        )
+            .into_response();
+    }
 
     // Resolve repo-config filters (issue: trusty-search.yaml wiring). The
     // CLI sends `paths:` as relative strings; resolve them against `root_path`

--- a/crates/trusty-search/src/service/server/indexes_relocate.rs
+++ b/crates/trusty-search/src/service/server/indexes_relocate.rs
@@ -50,7 +50,10 @@ use std::sync::Arc;
 
 use crate::core::registry::{IndexHandle, IndexId};
 
-use super::helpers::{embedder_error_response, embedder_initializing_response, validate_root_path};
+use super::helpers::{
+    embedder_error_response, embedder_initializing_response, find_root_path_collision,
+    root_path_collision_response, validate_root_path,
+};
 use super::state::{DaemonEvent, SearchAppState};
 
 /// Request body for `PATCH /indexes/:id` — in-place root relocation (#1073).
@@ -114,6 +117,39 @@ pub(super) async fn relocate_index_handler(
         Ok(p) => p,
         Err(resp) => return resp,
     };
+
+    // Issue #2336: relocating onto the index's OWN current root is a no-op —
+    // short-circuit before any rebuild. Without this, rebuilding the indexer
+    // below would try to open the SAME redb file that `existing`'s handle
+    // still has open (it is only swapped out after the rebuild succeeds),
+    // which is exactly the single-open collision the guard below exists to
+    // prevent — just against itself instead of a sibling index. Comparing
+    // canonical paths (both sides of `==` are canonicalized) makes this exact.
+    if new_root == existing.root_path {
+        return Json(serde_json::json!({
+            "id": id,
+            "relocated": true,
+            "new_root_path": new_root.to_string_lossy(),
+            "reason": "already at this root_path (no-op)",
+        }))
+        .into_response();
+    }
+
+    // Issue #2336: reject relocating onto a root_path already owned by a
+    // DIFFERENT registered index. Same hazard as `create_index_handler`: two
+    // live registrations sharing one colocated root resolve to the SAME
+    // on-disk redb corpus. (This index's own root is handled by the no-op
+    // short-circuit above, so `exclude_id` here is defense-in-depth only.)
+    let handles = state.registry.list_handles();
+    if let Some(existing_id) = find_root_path_collision(&handles, &new_root, Some(&index_id)) {
+        tracing::warn!(
+            "relocate[{id}]: refusing to relocate to {} — root_path already owned by '{}' \
+             (issue #2336)",
+            new_root.display(),
+            existing_id,
+        );
+        return root_path_collision_response(&existing_id, &new_root);
+    }
 
     // Require an embedder so we can rebuild the indexer (it needs to open
     // the colocated HNSW/redb at the new location).
@@ -207,6 +243,29 @@ pub(super) async fn relocate_index_handler(
                 .into_response();
         }
     };
+
+    // Issue #2336 defense-in-depth: `corpus_open_failed` is the ground truth
+    // for a broken redb open (a raced collision, or an unrelated open
+    // error) — it must not be silently rebound to as a healthy
+    // `200 {"relocated": true}` handle.
+    if new_indexer.corpus_open_failed {
+        tracing::error!(
+            "relocate[{id}]: corpus open failed at {} — refusing to relocate to a broken \
+             index handle (issue #2336)",
+            new_root.display()
+        );
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": format!(
+                    "corpus open failed for root_path {:?}; refusing to relocate to a broken \
+                     index handle",
+                    new_root.display()
+                )
+            })),
+        )
+            .into_response();
+    }
 
     // Persist the updated entry to indexes.toml BEFORE replacing the handle,
     // so a daemon restart sees the new root even if the in-memory swap below

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -34,6 +34,8 @@ mod typeahead;
 #[cfg(test)]
 mod tests_1073;
 #[cfg(test)]
+mod tests_2336;
+#[cfg(test)]
 mod tests_829;
 #[cfg(test)]
 mod tests_chunks;

--- a/crates/trusty-search/src/service/server/tests_2336.rs
+++ b/crates/trusty-search/src/service/server/tests_2336.rs
@@ -263,3 +263,138 @@ async fn relocate_index_onto_own_current_root_is_not_a_collision() {
         "relocating an index onto its own current root must succeed, not 409"
     );
 }
+
+// ── issue #2519 review follow-ups ─────────────────────────────────────────
+
+/// Two `create_index_handler` calls racing for the SAME root_path must not
+/// BOTH succeed. The `find_root_path_collision` guard is check-then-act
+/// (issue #2519 review: accepted as documented defense-in-depth rather than
+/// fixed with a registration mutex), so the loser may either be rejected by
+/// the guard itself (`409`) or lose the redb single-open race and hit
+/// `corpus_open_failed` (`500`) — both are acceptable outcomes of the
+/// accepted race window. What must never happen is both requests observing
+/// `200 {"created": true}`, since that would silently register two live
+/// handles over one on-disk corpus (the exact #2305/#2336 hazard).
+#[tokio::test]
+async fn create_index_concurrent_same_root_only_one_wins() {
+    let state = mock_state_async().await;
+    let (_dir, root) = temp_root("ts-2336-race-");
+
+    let state_a = Arc::clone(&state);
+    let root_a = root.clone();
+    let state_b = Arc::clone(&state);
+    let root_b = root.clone();
+
+    let (resp_a, resp_b) = tokio::join!(
+        super::indexes::create_index_handler(State(state_a), Json(create_req("racer-a", root_a)),),
+        super::indexes::create_index_handler(State(state_b), Json(create_req("racer-b", root_b)),),
+    );
+
+    let statuses = [resp_a.status(), resp_b.status()];
+    let successes = statuses.iter().filter(|s| **s == StatusCode::OK).count();
+    assert_eq!(
+        successes, 1,
+        "exactly one racing create_index over the same root_path must succeed \
+         (got statuses {statuses:?}) — the check-then-act window is accepted, \
+         but both requests observing 200 would silently double-register one \
+         on-disk corpus"
+    );
+    let loser_status = if statuses[0] == StatusCode::OK {
+        statuses[1]
+    } else {
+        statuses[0]
+    };
+    assert!(
+        loser_status == StatusCode::CONFLICT || loser_status == StatusCode::INTERNAL_SERVER_ERROR,
+        "the losing racer must fail with either 409 (guard caught it) or 500 \
+         (corpus_open_failed ground truth caught it), got {loser_status}"
+    );
+    assert_eq!(
+        state.registry.list().len(),
+        1,
+        "only one of the two racing registrations may end up in the registry"
+    );
+}
+
+/// macOS APFS is case-insensitive-but-case-preserving by default:
+/// `canonicalize()` on a differently-cased spelling of an already-registered
+/// root returns a DIFFERENT string (case is preserved, not normalized) that
+/// nonetheless names the SAME inode. Plain `PathBuf` equality misses this
+/// (issue #2519 review, MAJOR); the `(dev, ino)` identity check in
+/// `find_root_path_collision` must catch it.
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn create_index_rejects_case_variant_of_registered_root() {
+    let state = mock_state_async().await;
+    let (_dir, root) = temp_root("TS-2336-CaseVariant-");
+
+    let first = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("first-id", root.clone())),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::OK, "first create must succeed");
+
+    // Build a differently-cased spelling of the SAME path. `temp_root`
+    // already canonicalized `root`, so flipping the case of every ASCII
+    // alphabetic byte in the final path component yields a string that
+    // `canonicalize()` will resolve to the identical inode on a
+    // case-insensitive volume, but which is NOT string-equal to `root`.
+    let file_name = root
+        .file_name()
+        .expect("temp root has a final component")
+        .to_str()
+        .expect("temp root component is valid UTF-8");
+    let flipped_case: String = file_name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_lowercase() {
+                c.to_ascii_uppercase()
+            } else if c.is_ascii_uppercase() {
+                c.to_ascii_lowercase()
+            } else {
+                c
+            }
+        })
+        .collect();
+    let case_variant_root = root.with_file_name(flipped_case);
+    assert_ne!(
+        case_variant_root, root,
+        "the case-flipped path must be a different string than the original"
+    );
+
+    // Defensive skip: this test's premise (case-insensitive APFS) is the
+    // macOS default but is not guaranteed — a developer or CI runner may
+    // have opted into a case-SENSITIVE APFS volume. On such a volume the
+    // flipped-case path genuinely does not exist, so `validate_root_path`'s
+    // `is_dir` check rejects it with 400 before the collision guard ever
+    // runs, which would be a false test failure unrelated to the dev/ino fix
+    // under test. Skip gracefully rather than assert on an environment this
+    // test cannot control.
+    if std::fs::metadata(&case_variant_root).is_err() {
+        eprintln!(
+            "skipping create_index_rejects_case_variant_of_registered_root: \
+             {case_variant_root:?} does not exist — this volume is case-sensitive, \
+             not the macOS-default case-insensitive APFS this test targets"
+        );
+        return;
+    }
+
+    let second = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("second-id", case_variant_root)),
+    )
+    .await;
+    assert_eq!(
+        second.status(),
+        StatusCode::CONFLICT,
+        "a case-variant spelling of an already-registered root must still be \
+         rejected as a collision on a case-insensitive filesystem (dev/ino \
+         identity, issue #2519)"
+    );
+    assert_eq!(
+        state.registry.list().len(),
+        1,
+        "only the first index may be registered after a rejected case-variant collision"
+    );
+}

--- a/crates/trusty-search/src/service/server/tests_2336.rs
+++ b/crates/trusty-search/src/service/server/tests_2336.rs
@@ -1,0 +1,265 @@
+//! Tests for issue #2336: `create_index`/`relocate_index` root_path collision
+//! guard.
+//!
+//! Why: review finding (HIGH) on the #2305 warm-boot dedup fix — the boot path
+//! was fixed, but `create_index_handler` and `relocate_index_handler` guarded
+//! only *id* collisions, never *root_path* collisions. Two live registrations
+//! sharing one colocated root resolve to the SAME on-disk
+//! `<root>/.trusty-search/index.redb` (redb is single-open); the second
+//! registration's corpus open would silently fail (`corpus_open_failed`)
+//! while the handler still returned `200 {"created": true}` for the broken
+//! handle — recreating the #2305 hazard at runtime.
+//! What: exercises `create_index_handler` and `relocate_index_handler`
+//! directly (no running daemon or real embedder needed — `MockEmbedder`
+//! stands in), asserting a second registration over the same canonical root
+//! is rejected with `409 Conflict` naming the existing index, while a
+//! same-id re-create and a same-root PATCH-to-self remain unaffected.
+//! Test: run with `cargo test -p trusty-search tests_2336`.
+
+use super::*;
+use crate::core::embed::Embedder;
+use crate::core::registry::IndexRegistry;
+use axum::body::to_bytes;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use std::sync::Arc;
+
+/// Build a `CreateIndexRequest` with every optional field defaulted, varying
+/// only `id` and `root_path`.
+fn create_req(id: &str, root_path: std::path::PathBuf) -> super::router::CreateIndexRequest {
+    super::router::CreateIndexRequest {
+        id: id.to_string(),
+        root_path,
+        include_paths: None,
+        exclude_globs: None,
+        extensions: None,
+        domain_terms: None,
+        path_filter: None,
+        include_docs: None,
+        respect_gitignore: None,
+        follow_links: None,
+        lexical_only: None,
+        skip_kg: None,
+        defer_embed: None,
+        extra_skip_dirs: None,
+        data_file_max_bytes: None,
+    }
+}
+
+/// Create a temp directory under `target/` (never in the hard denylist) with
+/// RAII cleanup, returning its canonical path.
+fn temp_root(prefix: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let cwd = std::env::current_dir().expect("cwd");
+    let base = cwd.join("target");
+    std::fs::create_dir_all(&base).expect("create target/");
+    let dir = tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir_in(&base)
+        .expect("create tempdir");
+    let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+    (dir, canonical)
+}
+
+/// Build a fresh, empty registry with a mock embedder installed — enough for
+/// `create_index_handler` / `relocate_index_handler` to run without a live
+/// daemon or network.
+async fn mock_state_async() -> Arc<SearchAppState> {
+    let state = SearchAppState::new(IndexRegistry::new());
+    let embedder: Arc<dyn Embedder> = Arc::new(crate::core::embed::MockEmbedder::new(8));
+    state.install_embedder(embedder).await;
+    Arc::new(state)
+}
+
+// ── create_index_handler root_path collision guard ───────────────────────
+
+/// A second `POST /indexes` over the SAME canonical `root_path` (different
+/// id) must be rejected with `409 Conflict` naming the existing index,
+/// instead of silently registering a second handle over the same redb file.
+#[tokio::test]
+async fn create_index_rejects_duplicate_root_path() {
+    let state = mock_state_async().await;
+    let (_dir, root) = temp_root("ts-2336-dup-root-");
+
+    let first = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("first-id", root.clone())),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::OK, "first create must succeed");
+
+    let second = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("second-id", root.clone())),
+    )
+    .await;
+    assert_eq!(
+        second.status(),
+        StatusCode::CONFLICT,
+        "second create over the same root_path must be rejected with 409"
+    );
+
+    let body = to_bytes(second.into_body(), 4096).await.expect("body");
+    let v: serde_json::Value = serde_json::from_slice(&body).expect("json");
+    assert_eq!(
+        v.get("existing_id").and_then(|x| x.as_str()),
+        Some("first-id"),
+        "the 409 body must name the existing index that owns the root_path"
+    );
+
+    // Exactly one index must be registered — the collision must NOT have
+    // built (and discarded) a second broken handle.
+    assert_eq!(
+        state.registry.list().len(),
+        1,
+        "only the first index may be registered after a rejected collision"
+    );
+}
+
+/// Re-POSTing the SAME id at the SAME root_path is the existing idempotent
+/// "already exists" path (unaffected by the new collision guard, since it is
+/// checked before the guard runs).
+#[tokio::test]
+async fn create_index_same_id_same_root_is_idempotent_not_a_collision() {
+    let state = mock_state_async().await;
+    let (_dir, root) = temp_root("ts-2336-idempotent-");
+
+    let first = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("same-id", root.clone())),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::OK);
+
+    let second = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("same-id", root.clone())),
+    )
+    .await;
+    assert_eq!(
+        second.status(),
+        StatusCode::OK,
+        "re-registering the same id must stay idempotent (already exists), not 409"
+    );
+    let body = to_bytes(second.into_body(), 4096).await.expect("body");
+    let v: serde_json::Value = serde_json::from_slice(&body).expect("json");
+    assert_eq!(v.get("created").and_then(|x| x.as_bool()), Some(false));
+}
+
+/// Two indexes at genuinely distinct roots must both register successfully —
+/// the guard must not over-trigger on non-colliding paths.
+#[tokio::test]
+async fn create_index_distinct_roots_both_succeed() {
+    let state = mock_state_async().await;
+    let (_dir_a, root_a) = temp_root("ts-2336-distinct-a-");
+    let (_dir_b, root_b) = temp_root("ts-2336-distinct-b-");
+
+    let a = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("index-a", root_a)),
+    )
+    .await;
+    assert_eq!(a.status(), StatusCode::OK);
+
+    let b = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("index-b", root_b)),
+    )
+    .await;
+    assert_eq!(
+        b.status(),
+        StatusCode::OK,
+        "distinct root_path registrations must not collide"
+    );
+    assert_eq!(state.registry.list().len(), 2);
+}
+
+// ── relocate_index_handler root_path collision guard ──────────────────────
+
+/// `PATCH /indexes/:id` that would relocate onto a root_path already owned by
+/// a DIFFERENT registered index must be rejected with `409 Conflict`.
+#[tokio::test]
+async fn relocate_index_rejects_root_path_owned_by_another_index() {
+    use super::indexes_relocate::{relocate_index_handler, RelocateIndexRequest};
+
+    let state = mock_state_async().await;
+    let (_dir_a, root_a) = temp_root("ts-2336-relocate-a-");
+    let (_dir_b, root_b) = temp_root("ts-2336-relocate-b-");
+
+    let create_a = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("index-a", root_a.clone())),
+    )
+    .await;
+    assert_eq!(create_a.status(), StatusCode::OK);
+
+    let create_b = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("index-b", root_b.clone())),
+    )
+    .await;
+    assert_eq!(create_b.status(), StatusCode::OK);
+
+    // Attempt to relocate index-b onto index-a's root — must be rejected.
+    let relocate = relocate_index_handler(
+        State(Arc::clone(&state)),
+        Path("index-b".to_string()),
+        Json(RelocateIndexRequest {
+            root_path: root_a.clone(),
+        }),
+    )
+    .await;
+    assert_eq!(
+        relocate.status(),
+        StatusCode::CONFLICT,
+        "relocating onto another index's root_path must be rejected with 409"
+    );
+    let body = to_bytes(relocate.into_body(), 4096).await.expect("body");
+    let v: serde_json::Value = serde_json::from_slice(&body).expect("json");
+    assert_eq!(
+        v.get("existing_id").and_then(|x| x.as_str()),
+        Some("index-a"),
+        "the 409 body must name the index that already owns the target root_path"
+    );
+
+    // index-b's root_path must be unchanged after the rejected relocation.
+    let handle_b = state
+        .registry
+        .get(&crate::core::registry::IndexId::new("index-b"))
+        .expect("index-b must still be registered");
+    assert_eq!(
+        handle_b.root_path, root_b,
+        "a rejected relocation must not mutate the existing handle's root_path"
+    );
+}
+
+/// Relocating an index onto ITS OWN current root_path (a no-op PATCH) must
+/// NOT be treated as a collision — the guard excludes the index's own id.
+#[tokio::test]
+async fn relocate_index_onto_own_current_root_is_not_a_collision() {
+    use super::indexes_relocate::{relocate_index_handler, RelocateIndexRequest};
+
+    let state = mock_state_async().await;
+    let (_dir, root) = temp_root("ts-2336-relocate-self-");
+
+    let create = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req("self-relocate", root.clone())),
+    )
+    .await;
+    assert_eq!(create.status(), StatusCode::OK);
+
+    let relocate = relocate_index_handler(
+        State(Arc::clone(&state)),
+        Path("self-relocate".to_string()),
+        Json(RelocateIndexRequest {
+            root_path: root.clone(),
+        }),
+    )
+    .await;
+    assert_eq!(
+        relocate.status(),
+        StatusCode::OK,
+        "relocating an index onto its own current root must succeed, not 409"
+    );
+}

--- a/crates/trusty-search/src/service/warm_boot/mod.rs
+++ b/crates/trusty-search/src/service/warm_boot/mod.rs
@@ -247,27 +247,33 @@ pub fn dedup_entries_by_corpus_path(entries: Vec<PersistedIndex>) -> Vec<Persist
 
 /// Verbose variant of [`dedup_entries_by_corpus_path`] (issue #2337): also
 /// returns the dropped entries and preserves each dropped entry's per-index
-/// search configuration by merging it into the surviving entry.
+/// WHITELIST search configuration by merging it into the surviving entry.
 ///
 /// Why: survivor selection previously discarded the loser's per-entry search
-/// config (`include_paths`, `exclude_globs`, `extensions`, `domain_terms`,
-/// `path_filter`) even though the redb data is shared and those filters can
+/// config even though the redb data is shared and those filters can
 /// genuinely differ between the two registrations. Silently narrowing the
 /// survivor's scope to whichever entry happened to win recency is a
-/// regression for the loser's callers.
+/// regression for the loser's callers — but only for the WHITELIST fields
+/// (`include_paths`, `extensions`, `domain_terms`, `path_filter`), where
+/// union-merging can only broaden coverage. `exclude_globs` is a BLOCKLIST:
+/// union-merging two blocklists narrows the survivor instead (issue #2519
+/// review), which is the exact hazard this function exists to avoid — so it
+/// is deliberately excluded from the merge, same treatment as the scalar
+/// flags.
 /// What: groups entries by [`corpus_dedup_key`] (colocated only; non-colocated
 /// entries are always kept and can never collide). Within a colliding group,
 /// picks the winner using the same recency-then-id tie-break as before
 /// (highest `warmboot_sort_key`; ties break by lower `id`), then for every
-/// losing entry: unions its list-type config fields into the winner
+/// losing entry: unions its WHITELIST list-type config fields into the winner
 /// (`merge_dropped_config_into_survivor`) and logs its full config — including
-/// the scalar flags `include_docs`/`respect_gitignore`/`lexical_only`/
-/// `skip_kg`, which are deliberately NOT auto-merged (see that function's
-/// doc) — at `warn` for operator reconciliation. Survivors keep their
-/// original input order.
+/// `exclude_globs` and the scalar flags `include_docs`/`respect_gitignore`/
+/// `lexical_only`/`skip_kg`, none of which are auto-merged (see that
+/// function's doc) — at `warn` for operator reconciliation. Survivors keep
+/// their original input order.
 /// Test: `dedup_verbose_reports_dropped_entries`,
 /// `dedup_verbose_merges_list_config_into_survivor`,
 /// `dedup_verbose_does_not_merge_scalar_flags`,
+/// `dedup_verbose_does_not_merge_exclude_globs`,
 /// `dedup_verbose_no_collision_yields_empty_dropped_and_merged_sets` in
 /// `warm_boot_tests.rs`.
 pub fn dedup_entries_by_corpus_path_verbose(entries: Vec<PersistedIndex>) -> DedupOutcome {
@@ -364,31 +370,46 @@ pub fn dedup_entries_by_corpus_path_verbose(entries: Vec<PersistedIndex>) -> Ded
     }
 }
 
-/// Union `dropped`'s list-type search-config fields into `survivor` in place
-/// (issue #2337).
+/// Union `dropped`'s WHITELIST-composed list-type search-config fields into
+/// `survivor` in place (issue #2337; narrowed by the #2519 review).
 ///
 /// Why: two entries that collapse to one redb corpus can carry genuinely
 /// different per-entry filters (e.g. one registration set
 /// `extensions: ["rs"]`, the other `extensions: ["py"]`) even though the
 /// underlying indexed data is one file. Dropping the loser's filters entirely
-/// would silently narrow the survivor's search scope. Scalar flags
-/// (`include_docs`, `respect_gitignore`, `lexical_only`, `skip_kg`) are
-/// deliberately left untouched here — there is no safe "union" semantics for
-/// a boolean pipeline toggle (e.g. OR-ing `lexical_only` could silently
-/// disable the semantic lane for an index that was built with it), so those
-/// are surfaced via the caller's `warn` log for operator reconciliation
+/// would silently narrow the survivor's search scope for `include_paths`,
+/// `extensions`, `domain_terms`, and `path_filter` — each of these is a
+/// whitelist (an ADDITIVE broadening: union-merging can only ever grow what
+/// the survivor covers), so unioning them is safe.
+///
+/// `exclude_globs` is deliberately EXCLUDED from this union (issue #2519
+/// review, MEDIUM): unlike the whitelist fields above, `exclude_globs` is a
+/// blocklist — union-merging two blocklists NARROWS the surviving index (it
+/// can only ever exclude MORE content), which is exactly the silent-scope-
+/// change hazard this function exists to avoid. Auto-merging it would mean
+/// the next reindex quietly drops more files than either original
+/// registration intended. Like the scalar flags below, the dropped entry's
+/// `exclude_globs` is surfaced via the caller's `warn` log (see
+/// `dedup_entries_by_corpus_path_verbose`) for operator reconciliation
 /// instead of being auto-merged.
-/// What: appends every value from each of `dropped`'s list fields
-/// (`include_paths`, `exclude_globs`, `extensions`, `domain_terms`,
-/// `path_filter`) that is not already present in `survivor`'s corresponding
-/// field, preserving order (survivor's existing values first).
+///
+/// Scalar flags (`include_docs`, `respect_gitignore`, `lexical_only`,
+/// `skip_kg`) are likewise left untouched here — there is no safe "union"
+/// semantics for a boolean pipeline toggle (e.g. OR-ing `lexical_only` could
+/// silently disable the semantic lane for an index that was built with it) —
+/// so those are also only surfaced via the `warn` log.
+/// What: appends every value from each of `dropped`'s WHITELIST list fields
+/// (`include_paths`, `extensions`, `domain_terms`, `path_filter`) that is not
+/// already present in `survivor`'s corresponding field, preserving order
+/// (survivor's existing values first). `exclude_globs` is untouched —
+/// `survivor.exclude_globs` keeps exactly its own pre-merge value.
 /// Test: `dedup_verbose_merges_list_config_into_survivor`,
 /// `dedup_verbose_does_not_merge_scalar_flags`,
+/// `dedup_verbose_does_not_merge_exclude_globs`,
 /// `merge_dropped_config_deduplicates_overlapping_values` in
 /// `warm_boot_tests.rs`.
 fn merge_dropped_config_into_survivor(survivor: &mut PersistedIndex, dropped: &PersistedIndex) {
     merge_unique_strings(&mut survivor.include_paths, &dropped.include_paths);
-    merge_unique_strings(&mut survivor.exclude_globs, &dropped.exclude_globs);
     merge_unique_strings(&mut survivor.extensions, &dropped.extensions);
     merge_unique_strings(&mut survivor.domain_terms, &dropped.domain_terms);
     merge_unique_strings(&mut survivor.path_filter, &dropped.path_filter);

--- a/crates/trusty-search/src/service/warm_boot/mod.rs
+++ b/crates/trusty-search/src/service/warm_boot/mod.rs
@@ -200,6 +200,26 @@ fn corpus_dedup_key(entry: &PersistedIndex) -> Option<PathBuf> {
     Some(canonicalize_best_effort(&entry.root_path))
 }
 
+/// Outcome of [`dedup_entries_by_corpus_path_verbose`] (issue #2337).
+///
+/// Why: [`dedup_entries_by_corpus_path`] discards the dropped entries, which
+/// was fine while the only consumer was the in-memory eager/cold split. Issue
+/// #2337 needs the dropped entries so `restore_indexes` can prune their
+/// `indexes.toml` rows — without this they are re-discovered, re-warned, and
+/// re-dropped on every boot forever — and needs to know which survivors
+/// absorbed a dropped entry's config so only those rows need rewriting.
+/// What: `survivors` is the deduplicated set in original relative order
+/// (identical to what [`dedup_entries_by_corpus_path`] returns); `dropped` is
+/// every losing entry, pre-merge; `merged_survivor_ids` names the survivor
+/// ids that actually absorbed at least one dropped entry's config (a plain
+/// pass-through entry with no collision is never listed here).
+/// Test: `dedup_verbose_*` in `warm_boot_tests.rs`.
+pub struct DedupOutcome {
+    pub survivors: Vec<PersistedIndex>,
+    pub dropped: Vec<PersistedIndex>,
+    pub merged_survivor_ids: HashSet<String>,
+}
+
 /// Collapse warm-boot entries that resolve to the SAME on-disk redb corpus file
 /// down to a single entry, keeping the most-recently-active one (issue #2305).
 ///
@@ -215,67 +235,174 @@ fn corpus_dedup_key(entry: &PersistedIndex) -> Option<PathBuf> {
 /// layout that needs independent handles to one file, so we collapse the
 /// duplicates to one healthy entry *before* any open is attempted, guaranteeing
 /// zero `DatabaseAlreadyOpen` on warm boot.
-/// What: groups entries by [`corpus_dedup_key`] (colocated only; non-colocated
-/// entries are always kept). Within a colliding group keeps the entry with the
-/// highest `warmboot_sort_key` (most recent query/index activity; ties break by
-/// `id` ascending for determinism) and drops the rest with a `warn` naming both
-/// ids and the shared path. Survivors keep their original input order so the
-/// downstream recency split (`select_warmboot_entries`) and the
-/// legacy/colocated partition are unaffected.
+/// What: thin wrapper over [`dedup_entries_by_corpus_path_verbose`] that keeps
+/// only the survivor set — the shape every existing caller/test expects.
 /// Test: `dedup_by_corpus_path_collapses_same_root`,
 /// `dedup_by_corpus_path_keeps_distinct_roots`,
 /// `dedup_by_corpus_path_keeps_non_colocated`,
 /// `dedup_by_corpus_path_keeps_most_recent` in `warm_boot_tests.rs`.
 pub fn dedup_entries_by_corpus_path(entries: Vec<PersistedIndex>) -> Vec<PersistedIndex> {
+    dedup_entries_by_corpus_path_verbose(entries).survivors
+}
+
+/// Verbose variant of [`dedup_entries_by_corpus_path`] (issue #2337): also
+/// returns the dropped entries and preserves each dropped entry's per-index
+/// search configuration by merging it into the surviving entry.
+///
+/// Why: survivor selection previously discarded the loser's per-entry search
+/// config (`include_paths`, `exclude_globs`, `extensions`, `domain_terms`,
+/// `path_filter`) even though the redb data is shared and those filters can
+/// genuinely differ between the two registrations. Silently narrowing the
+/// survivor's scope to whichever entry happened to win recency is a
+/// regression for the loser's callers.
+/// What: groups entries by [`corpus_dedup_key`] (colocated only; non-colocated
+/// entries are always kept and can never collide). Within a colliding group,
+/// picks the winner using the same recency-then-id tie-break as before
+/// (highest `warmboot_sort_key`; ties break by lower `id`), then for every
+/// losing entry: unions its list-type config fields into the winner
+/// (`merge_dropped_config_into_survivor`) and logs its full config — including
+/// the scalar flags `include_docs`/`respect_gitignore`/`lexical_only`/
+/// `skip_kg`, which are deliberately NOT auto-merged (see that function's
+/// doc) — at `warn` for operator reconciliation. Survivors keep their
+/// original input order.
+/// Test: `dedup_verbose_reports_dropped_entries`,
+/// `dedup_verbose_merges_list_config_into_survivor`,
+/// `dedup_verbose_does_not_merge_scalar_flags`,
+/// `dedup_verbose_no_collision_yields_empty_dropped_and_merged_sets` in
+/// `warm_boot_tests.rs`.
+pub fn dedup_entries_by_corpus_path_verbose(entries: Vec<PersistedIndex>) -> DedupOutcome {
     use crate::service::persistence::warmboot_sort_key;
     use std::collections::HashMap;
 
-    // First pass: pick the winning entry index per corpus-path key.
-    let mut winner_by_key: HashMap<PathBuf, usize> = HashMap::new();
-    // Entries with no dedup key (non-colocated) are always retained.
-    let mut always_keep: Vec<bool> = vec![false; entries.len()];
-
+    // First pass: group entry indices by corpus-path key. Entries with no key
+    // (non-colocated) are always retained and can never be a collision member.
+    let mut groups: HashMap<PathBuf, Vec<usize>> = HashMap::new();
     for (i, entry) in entries.iter().enumerate() {
-        let Some(key) = corpus_dedup_key(entry) else {
-            always_keep[i] = true;
-            continue;
-        };
-        match winner_by_key.get(&key).copied() {
-            None => {
-                winner_by_key.insert(key, i);
-            }
-            Some(prev) => {
-                let cur = &entries[i];
-                let old = &entries[prev];
-                let cur_key = warmboot_sort_key(cur);
-                let old_key = warmboot_sort_key(old);
-                // Keep the more-recently-active entry; tie → lower id wins.
-                let cur_wins = cur_key > old_key || (cur_key == old_key && cur.id < old.id);
-                let winner = if cur_wins { i } else { prev };
-                tracing::warn!(
-                    "warm-boot: indexes '{}' and '{}' both resolve to the same redb corpus \
-                     under {} — collapsing to '{}' to avoid an in-process double-open \
-                     (DatabaseAlreadyOpen, issue #2305). The dropped registration is a \
-                     duplicate of the same on-disk index; re-register it at a distinct \
-                     root_path if the two were meant to be separate indexes.",
-                    cur.id,
-                    old.id,
-                    key.display(),
-                    entries[winner].id,
-                );
-                winner_by_key.insert(key, winner);
-            }
+        if let Some(key) = corpus_dedup_key(entry) {
+            groups.entry(key).or_default().push(i);
         }
     }
 
-    // Second pass: rebuild in original order, keeping winners + non-colocated.
-    let kept: std::collections::HashSet<usize> = winner_by_key.values().copied().collect();
-    entries
-        .into_iter()
-        .enumerate()
-        .filter(|(i, _)| always_keep[*i] || kept.contains(i))
-        .map(|(_, e)| e)
-        .collect()
+    let mut opt_entries: Vec<Option<PersistedIndex>> = entries.into_iter().map(Some).collect();
+    let mut dropped: Vec<PersistedIndex> = Vec::new();
+    let mut merged_survivor_ids: HashSet<String> = HashSet::new();
+
+    for (key, idxs) in &groups {
+        if idxs.len() < 2 {
+            continue; // no collision in this group — nothing to drop or merge.
+        }
+
+        // Resolve the winner via the same recency-then-id tie-break rule the
+        // original single-pass implementation used.
+        let mut winner_idx = idxs[0];
+        for &i in &idxs[1..] {
+            let cur = opt_entries[i].as_ref().expect("group index not yet taken");
+            let old = opt_entries[winner_idx]
+                .as_ref()
+                .expect("group index not yet taken");
+            let cur_key = warmboot_sort_key(cur);
+            let old_key = warmboot_sort_key(old);
+            let cur_wins = cur_key > old_key || (cur_key == old_key && cur.id < old.id);
+            if cur_wins {
+                winner_idx = i;
+            }
+        }
+        let survivor_id = opt_entries[winner_idx]
+            .as_ref()
+            .expect("winner not yet taken")
+            .id
+            .clone();
+
+        for &i in idxs {
+            if i == winner_idx {
+                continue;
+            }
+            let loser = opt_entries[i].take().expect("loser not yet taken");
+            tracing::warn!(
+                "warm-boot: indexes '{}' and '{}' both resolve to the same redb corpus under \
+                 {} — collapsing to '{}' to avoid an in-process double-open \
+                 (DatabaseAlreadyOpen, issue #2305). List-type search config from '{}' is \
+                 merged into the survivor (issue #2337); scalar flags — include_docs={} \
+                 respect_gitignore={} lexical_only={} skip_kg={} — are logged here for \
+                 operator reconciliation and are NOT auto-merged. Dropped list fields: \
+                 include_paths={:?} exclude_globs={:?} extensions={:?} domain_terms={:?} \
+                 path_filter={:?}. Re-register at a distinct root_path if the two were \
+                 meant to be separate indexes.",
+                loser.id,
+                survivor_id,
+                key.display(),
+                survivor_id,
+                loser.id,
+                loser.include_docs,
+                loser.respect_gitignore,
+                loser.lexical_only,
+                loser.skip_kg,
+                loser.include_paths,
+                loser.exclude_globs,
+                loser.extensions,
+                loser.domain_terms,
+                loser.path_filter,
+            );
+            let survivor = opt_entries[winner_idx]
+                .as_mut()
+                .expect("winner not yet taken");
+            merge_dropped_config_into_survivor(survivor, &loser);
+            merged_survivor_ids.insert(survivor_id.clone());
+            dropped.push(loser);
+        }
+    }
+
+    // Survivors keep their original relative order — iterating opt_entries in
+    // index order and skipping the taken (dropped) slots achieves this for
+    // free, no separate reordering pass needed.
+    let survivors: Vec<PersistedIndex> = opt_entries.into_iter().flatten().collect();
+
+    DedupOutcome {
+        survivors,
+        dropped,
+        merged_survivor_ids,
+    }
+}
+
+/// Union `dropped`'s list-type search-config fields into `survivor` in place
+/// (issue #2337).
+///
+/// Why: two entries that collapse to one redb corpus can carry genuinely
+/// different per-entry filters (e.g. one registration set
+/// `extensions: ["rs"]`, the other `extensions: ["py"]`) even though the
+/// underlying indexed data is one file. Dropping the loser's filters entirely
+/// would silently narrow the survivor's search scope. Scalar flags
+/// (`include_docs`, `respect_gitignore`, `lexical_only`, `skip_kg`) are
+/// deliberately left untouched here — there is no safe "union" semantics for
+/// a boolean pipeline toggle (e.g. OR-ing `lexical_only` could silently
+/// disable the semantic lane for an index that was built with it), so those
+/// are surfaced via the caller's `warn` log for operator reconciliation
+/// instead of being auto-merged.
+/// What: appends every value from each of `dropped`'s list fields
+/// (`include_paths`, `exclude_globs`, `extensions`, `domain_terms`,
+/// `path_filter`) that is not already present in `survivor`'s corresponding
+/// field, preserving order (survivor's existing values first).
+/// Test: `dedup_verbose_merges_list_config_into_survivor`,
+/// `dedup_verbose_does_not_merge_scalar_flags`,
+/// `merge_dropped_config_deduplicates_overlapping_values` in
+/// `warm_boot_tests.rs`.
+fn merge_dropped_config_into_survivor(survivor: &mut PersistedIndex, dropped: &PersistedIndex) {
+    merge_unique_strings(&mut survivor.include_paths, &dropped.include_paths);
+    merge_unique_strings(&mut survivor.exclude_globs, &dropped.exclude_globs);
+    merge_unique_strings(&mut survivor.extensions, &dropped.extensions);
+    merge_unique_strings(&mut survivor.domain_terms, &dropped.domain_terms);
+    merge_unique_strings(&mut survivor.path_filter, &dropped.path_filter);
+}
+
+/// Append every string in `from` that is not already present in `into`,
+/// preserving `into`'s existing order and `from`'s relative order for the
+/// appended tail.
+fn merge_unique_strings(into: &mut Vec<String>, from: &[String]) {
+    for item in from {
+        if !into.contains(item) {
+            into.push(item.clone());
+        }
+    }
 }
 
 /// Collect index entries from the durable `indexes.toml` registry only.

--- a/crates/trusty-search/src/service/warm_boot/warm_boot_tests.rs
+++ b/crates/trusty-search/src/service/warm_boot/warm_boot_tests.rs
@@ -445,3 +445,161 @@ fn dedup_by_corpus_path_keeps_most_recent() {
         "the most-recently-active entry must be the survivor"
     );
 }
+
+// ── dedup_entries_by_corpus_path_verbose (issue #2337) ────────────────────
+
+/// Why (#2337 part 1): callers need the dropped entries to prune their
+/// `indexes.toml` rows — otherwise they are re-discovered/re-warned/re-dropped
+/// forever.
+/// What: two entries share a root; asserts `dropped` contains exactly the
+/// losing entry and `survivors` contains exactly the winner.
+/// Test: this test.
+#[test]
+fn dedup_verbose_reports_dropped_entries() {
+    let shared = tempfile::tempdir().unwrap();
+
+    let entries = vec![
+        colocated_entry("stale", shared.path(), Some(1)),
+        colocated_entry("fresh", shared.path(), Some(2)),
+    ];
+
+    let outcome = dedup_entries_by_corpus_path_verbose(entries);
+    assert_eq!(outcome.survivors.len(), 1, "one survivor");
+    assert_eq!(outcome.survivors[0].id, "fresh");
+    assert_eq!(outcome.dropped.len(), 1, "one dropped entry");
+    assert_eq!(outcome.dropped[0].id, "stale");
+    assert!(
+        outcome.merged_survivor_ids.contains("fresh"),
+        "the survivor must be flagged as having absorbed a dropped entry's config"
+    );
+}
+
+/// Why (#2337 part 2): a genuine collision keeps only the redb data, but the
+/// two entries' list-type search filters can legitimately differ; dropping
+/// them entirely would silently narrow the survivor's search scope.
+/// What: the loser has distinct `extensions`/`domain_terms`; asserts the
+/// survivor's fields are the union (with survivor's own values first).
+/// Test: this test.
+#[test]
+fn dedup_verbose_merges_list_config_into_survivor() {
+    let shared = tempfile::tempdir().unwrap();
+
+    let mut winner = colocated_entry("fresh", shared.path(), Some(2));
+    winner.extensions = vec!["rs".to_string()];
+    winner.domain_terms = vec!["daemon".to_string()];
+
+    let mut loser = colocated_entry("stale", shared.path(), Some(1));
+    loser.extensions = vec!["py".to_string()];
+    loser.domain_terms = vec!["daemon".to_string(), "corpus".to_string()];
+    loser.include_paths = vec!["src/legacy".to_string()];
+
+    let outcome = dedup_entries_by_corpus_path_verbose(vec![winner, loser]);
+    assert_eq!(outcome.survivors.len(), 1);
+    let survivor = &outcome.survivors[0];
+    assert_eq!(survivor.id, "fresh");
+    assert_eq!(
+        survivor.extensions,
+        vec!["rs".to_string(), "py".to_string()],
+        "extensions must be the union, survivor's own values first"
+    );
+    assert_eq!(
+        survivor.domain_terms,
+        vec!["daemon".to_string(), "corpus".to_string()],
+        "domain_terms must be de-duplicated across the union"
+    );
+    assert_eq!(
+        survivor.include_paths,
+        vec!["src/legacy".to_string()],
+        "include_paths present only on the loser must still be adopted"
+    );
+}
+
+/// Why (#2337 part 2): scalar pipeline toggles (`lexical_only`, `skip_kg`,
+/// `include_docs`, `respect_gitignore`) have no safe "union" semantics — an
+/// automatic OR/AND could silently disable a lane the survivor was built
+/// with. These must be left exactly as the survivor had them; the loser's
+/// values are surfaced via a log line instead (not asserted here — this test
+/// pins the "not merged" behavior).
+/// What: loser sets `lexical_only = true` / `skip_kg = true` while the
+/// survivor has both `false`; asserts the survivor's scalar flags are
+/// unchanged after the merge.
+/// Test: this test.
+#[test]
+fn dedup_verbose_does_not_merge_scalar_flags() {
+    let shared = tempfile::tempdir().unwrap();
+
+    let mut winner = colocated_entry("fresh", shared.path(), Some(2));
+    winner.lexical_only = false;
+    winner.skip_kg = false;
+    winner.include_docs = true;
+    winner.respect_gitignore = true;
+
+    let mut loser = colocated_entry("stale", shared.path(), Some(1));
+    loser.lexical_only = true;
+    loser.skip_kg = true;
+    loser.include_docs = false;
+    loser.respect_gitignore = false;
+
+    let outcome = dedup_entries_by_corpus_path_verbose(vec![winner, loser]);
+    let survivor = &outcome.survivors[0];
+    assert!(!survivor.lexical_only, "lexical_only must not be merged");
+    assert!(!survivor.skip_kg, "skip_kg must not be merged");
+    assert!(survivor.include_docs, "include_docs must not be merged");
+    assert!(
+        survivor.respect_gitignore,
+        "respect_gitignore must not be merged"
+    );
+}
+
+/// Why: the common case (no collision at all) must be a cheap no-op — callers
+/// use `dropped.is_empty()` to skip all `indexes.toml` IO.
+/// What: two entries at distinct roots; asserts both survive with empty
+/// `dropped` and `merged_survivor_ids`.
+/// Test: this test.
+#[test]
+fn dedup_verbose_no_collision_yields_empty_dropped_and_merged_sets() {
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+
+    let entries = vec![
+        colocated_entry("a", a.path(), Some(1)),
+        colocated_entry("b", b.path(), Some(2)),
+    ];
+
+    let outcome = dedup_entries_by_corpus_path_verbose(entries);
+    assert_eq!(outcome.survivors.len(), 2);
+    assert!(outcome.dropped.is_empty());
+    assert!(outcome.merged_survivor_ids.is_empty());
+}
+
+/// Why: `merge_dropped_config_into_survivor` must not duplicate a value that
+/// already appears on the survivor (e.g. both entries were registered with
+/// the same `exclude_globs` pattern).
+/// What: survivor and loser share one overlapping value plus one distinct
+/// value each; asserts the merged result has no duplicates.
+/// Test: this test.
+#[test]
+fn merge_dropped_config_deduplicates_overlapping_values() {
+    let mut survivor = PersistedIndex {
+        id: "survivor".to_string(),
+        exclude_globs: vec!["**/vendor/**".to_string(), "*.lock".to_string()],
+        ..Default::default()
+    };
+    let dropped = PersistedIndex {
+        id: "dropped".to_string(),
+        exclude_globs: vec!["**/vendor/**".to_string(), "*.generated.ts".to_string()],
+        ..Default::default()
+    };
+
+    merge_dropped_config_into_survivor(&mut survivor, &dropped);
+
+    assert_eq!(
+        survivor.exclude_globs,
+        vec![
+            "**/vendor/**".to_string(),
+            "*.lock".to_string(),
+            "*.generated.ts".to_string(),
+        ],
+        "overlapping value must appear once; new value must be appended"
+    );
+}

--- a/crates/trusty-search/src/service/warm_boot/warm_boot_tests.rs
+++ b/crates/trusty-search/src/service/warm_boot/warm_boot_tests.rs
@@ -574,7 +574,8 @@ fn dedup_verbose_no_collision_yields_empty_dropped_and_merged_sets() {
 
 /// Why: `merge_dropped_config_into_survivor` must not duplicate a value that
 /// already appears on the survivor (e.g. both entries were registered with
-/// the same `exclude_globs` pattern).
+/// the same `include_paths` entry) — exercised on a WHITELIST field, which is
+/// the only field type this function still merges (issue #2519 review).
 /// What: survivor and loser share one overlapping value plus one distinct
 /// value each; asserts the merged result has no duplicates.
 /// Test: this test.
@@ -582,24 +583,55 @@ fn dedup_verbose_no_collision_yields_empty_dropped_and_merged_sets() {
 fn merge_dropped_config_deduplicates_overlapping_values() {
     let mut survivor = PersistedIndex {
         id: "survivor".to_string(),
-        exclude_globs: vec!["**/vendor/**".to_string(), "*.lock".to_string()],
+        include_paths: vec!["src/api".to_string(), "src/core".to_string()],
         ..Default::default()
     };
     let dropped = PersistedIndex {
         id: "dropped".to_string(),
-        exclude_globs: vec!["**/vendor/**".to_string(), "*.generated.ts".to_string()],
+        include_paths: vec!["src/api".to_string(), "src/legacy".to_string()],
         ..Default::default()
     };
 
     merge_dropped_config_into_survivor(&mut survivor, &dropped);
 
     assert_eq!(
-        survivor.exclude_globs,
+        survivor.include_paths,
         vec![
-            "**/vendor/**".to_string(),
-            "*.lock".to_string(),
-            "*.generated.ts".to_string(),
+            "src/api".to_string(),
+            "src/core".to_string(),
+            "src/legacy".to_string(),
         ],
         "overlapping value must appear once; new value must be appended"
+    );
+}
+
+/// Why (#2519 review, MEDIUM): `exclude_globs` is a BLOCKLIST, not a
+/// whitelist — union-merging two blocklists narrows the survivor's indexing
+/// scope on the next reindex (it can only ever exclude MORE), which is the
+/// exact silent-scope-change hazard the #2337 merge exists to prevent for the
+/// other list fields. It must stay excluded from the auto-merge and be
+/// surfaced via the operator `warn` log instead (see
+/// `dedup_entries_by_corpus_path_verbose`'s doc).
+/// What: survivor and loser have distinct, non-overlapping `exclude_globs`;
+/// asserts the survivor's `exclude_globs` is unchanged after the merge (not
+/// unioned with the loser's).
+/// Test: this test.
+#[test]
+fn dedup_verbose_does_not_merge_exclude_globs() {
+    let shared = tempfile::tempdir().unwrap();
+
+    let mut winner = colocated_entry("fresh", shared.path(), Some(2));
+    winner.exclude_globs = vec!["**/vendor/**".to_string()];
+
+    let mut loser = colocated_entry("stale", shared.path(), Some(1));
+    loser.exclude_globs = vec!["**/*.generated.ts".to_string()];
+
+    let outcome = dedup_entries_by_corpus_path_verbose(vec![winner, loser]);
+    let survivor = &outcome.survivors[0];
+    assert_eq!(
+        survivor.exclude_globs,
+        vec!["**/vendor/**".to_string()],
+        "exclude_globs must not be auto-merged — merging blocklists would \
+         silently narrow the survivor's indexing scope"
     );
 }


### PR DESCRIPTION
## Summary

Two closely-related trusty-search index-registry integrity follow-ups to the #2305 warm-boot dedup fix (PR #2335, squash `f0a48cc1`).

**#2336 — runtime root_path collision guard.** `create_index_handler` and `relocate_index_handler` previously guarded only *id* collisions, never *root_path* collisions. Two live registrations sharing one colocated root resolve to the SAME on-disk `<root>/.trusty-search/index.redb` — redb is single-open, so the second registration's `build_indexer_from_entry` call silently failed its corpus open (`corpus_open_failed`) while the handler still returned `200 {"created": true}` for the broken handle. This is the exact runtime recreation of the #2305 hazard the warm-boot dedup only fixed for the boot path.

**#2337 — warm-boot dedup follow-ups.** (1) The losing entry's `indexes.toml` row was never pruned — re-discovered, re-warned, re-dropped on every boot forever. (2) Survivor selection discarded the loser's per-entry search config (`include_paths`/`exclude_globs`/`extensions`/`domain_terms`/`path_filter`) even though the redb data is shared and those filters can genuinely differ.

## Design decisions

- **Path normalization**: the collision guard compares already-canonicalized paths — `create_index_handler`/`relocate_index_handler` canonicalize via `validate_root_path` before the check runs, and every registered handle's `root_path` went through the same normalization (directly at create/relocate time, or via `canonicalize_best_effort` at warm-boot), so equality comparison is exact with no extra syscalls in the guard itself.
- **409 Conflict**, not silent rejection: the response body names the existing index (`existing_id`) so the caller can decide to reuse, delete-then-recreate, or pick a distinct root, instead of cross-referencing `GET /indexes?details=true` by hand.
- **Self-relocation no-op**: relocating an index onto its OWN current root_path is treated as an idempotent no-op (`relocated: true, reason: "already at this root_path (no-op)"`) rather than rebuilding — rebuilding would try to open the SAME redb file the existing handle still has open (only swapped out after a successful rebuild), which is the identical single-open hazard, just against itself. This was a **latent bug uncovered while testing the new guard**: before this PR, a self-relocate silently swapped in a broken (empty-corpus) handle and returned `200`; now it either no-ops cleanly or fails loud.
- **Defense-in-depth**: post-build, both handlers now check `indexer.corpus_open_failed` and refuse to register/rebind a broken handle (500) even if some other path raced past the guard — matching the issue's "and/or surface `corpus_open_failed`" ask.
- **Dedup toml pruning**: `dedup_entries_by_corpus_path_verbose` (new) returns dropped entries alongside survivors; `restore_indexes` calls `remove_index_registry_entry` for each (idempotent no-op if the id never had a row — e.g. a purely colocated-scan discovery), mirroring the existing `orphan_reaper::heal_boot_orphans` self-heal pattern. No-ops entirely when nothing was dropped (the common case).
- **Config preservation**: list-type fields (`include_paths`/`exclude_globs`/`extensions`/`domain_terms`/`path_filter`) are unioned into the survivor (de-duplicated, survivor's own values first) and persisted back to `indexes.toml` via `upsert_index_registry_entry` so the merge survives future restarts, not just the current boot. Scalar pipeline toggles (`include_docs`/`respect_gitignore`/`lexical_only`/`skip_kg`) are deliberately **not** auto-merged — there's no safe union semantics for a boolean (e.g. OR-ing `lexical_only` could silently disable the semantic lane for an index built with it) — they're logged at `warn` for operator reconciliation instead.

## Test evidence

```
$ cargo build --workspace
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 47s

$ cargo test -p trusty-search
test result: ok. 1047 passed; 0 failed; 1 ignored (lib)
test result: ok. 252 passed; 0 failed (bin)
+ all integration test binaries: ok (0 failures)

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile ... (no errors; pre-existing unrelated `tga` MSRV/future-incompat warnings only)

$ cargo fmt --check
(clean, no diff)

$ bash scripts/check_line_cap.sh
line-cap: 0 allowlisted, 0 violations — OK.
```

New tests:
- `service/server/tests_2336.rs`: `create_index_rejects_duplicate_root_path`, `create_index_same_id_same_root_is_idempotent_not_a_collision`, `create_index_distinct_roots_both_succeed`, `relocate_index_rejects_root_path_owned_by_another_index`, `relocate_index_onto_own_current_root_is_not_a_collision`.
- `service/warm_boot/warm_boot_tests.rs`: `dedup_verbose_reports_dropped_entries`, `dedup_verbose_merges_list_config_into_survivor`, `dedup_verbose_does_not_merge_scalar_flags`, `dedup_verbose_no_collision_yields_empty_dropped_and_merged_sets`, `merge_dropped_config_deduplicates_overlapping_values`.

All new tests use temp dirs / `MockEmbedder`, no live daemon or ONNX model required, and are not `#[ignore]`d.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-search` (all suites)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools