### PR TITLE
fix(trusty-mpm): non-zero exit on session spawn failure (closes #2457)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -207,9 +207,14 @@ fn short_timestamp(s: &str) -> String {
 /// always returned for the calling agentic process to reason over. The LLM
 /// classification is shown when available (OpenRouter key set); when absent,
 /// `classification: null` and the raw pane are still returned with no error.
+/// A truly missing id is a genuine failure (#2457) — printing "not found" and
+/// returning `Ok(())` let a script/CI check treat a nonexistent id as success,
+/// so this now returns `Err` (non-zero exit) instead.
 /// What: GETs `/api/v1/sessions/managed/{id}/activity` and prints the raw pane,
-/// structured state, classification (or "no classifier"), and pending decision.
-/// Test: HTTP path covered by the integration test.
+/// structured state, classification (or "no classifier"), and pending decision;
+/// a 404 bails with an error instead of printing "not found".
+/// Test: HTTP path covered by the integration test;
+/// `session_activity_not_found_errors` covers the #2457 exit-code fix.
 pub(crate) async fn session_activity(
     client: &reqwest::Client,
     url: &str,
@@ -224,8 +229,7 @@ pub(crate) async fn session_activity(
         .send()
         .await?;
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        println!("not found");
-        return Ok(());
+        anyhow::bail!("managed session '{id}' not found");
     }
     let a: trusty_mpm::client::ManagedActivityResponse = resp.error_for_status()?.json().await?;
     let runtime_str = if a.runtime_active {
@@ -274,10 +278,17 @@ pub(crate) async fn session_activity(
 ///
 /// Why: a session ENDURES beyond its runtime; `stop` kills only the tmux session
 /// and claude process, preserving the workspace for later `resume`. Renamed from
-/// the verbose `runtime-stop` in #1205 (which remains a deprecated alias).
-/// What: POSTs `/api/v1/sessions/managed/{id}/runtime-stop`.
+/// the verbose `runtime-stop` in #1205 (which remains a deprecated alias). A
+/// missing id is a genuine failure to stop the requested session (#2457) —
+/// printing "not found" and returning `Ok(())` let a script/CI check treat it
+/// as success, so this now returns `Err` (non-zero exit) instead. `prune.rs`'s
+/// bulk teardown loop (the only other caller) already propagates this `Err`
+/// with `?`, matching its established fail-closed convention (#1508).
+/// What: POSTs `/api/v1/sessions/managed/{id}/runtime-stop`; a 404 bails with
+/// an error instead of printing "not found".
 /// Test: HTTP path covered by the integration test; parse by
-/// `cli_parses_session_managed_stop_verb`.
+/// `cli_parses_session_managed_stop_verb`; `session_stop_not_found_errors`
+/// covers the #2457 exit-code fix.
 pub(crate) async fn session_stop(
     client: &reqwest::Client,
     url: &str,
@@ -288,8 +299,7 @@ pub(crate) async fn session_stop(
         .send()
         .await?;
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        println!("not found");
-        return Ok(());
+        anyhow::bail!("managed session '{id}' not found");
     }
     resp.error_for_status()?;
     println!("runtime stopped {id} (workspace intact; use 'resume' to restart)");
@@ -300,10 +310,20 @@ pub(crate) async fn session_stop(
 ///
 /// Why: after `stop`, the workspace is still on disk; `resume` re-spawns the
 /// runtime there without re-cloning. Renamed from the verbose `managed-resume`
-/// in #1205 (which remains a deprecated alias).
-/// What: POSTs `/api/v1/sessions/managed/{id}/resume`.
+/// in #1205 (which remains a deprecated alias). A missing id or a rejected
+/// resume (daemon `InvalidState`, e.g. the session isn't stopped) are both
+/// genuine failures to perform the requested resume (#2457) — printing a
+/// message and returning `Ok(())` let a script/CI check treat either as
+/// success, so both now return `Err` (non-zero exit) instead, mirroring the
+/// symmetric project-session resume path's own 404 handling just above this
+/// call site in `session.rs`.
+/// What: POSTs `/api/v1/sessions/managed/{id}/resume`; a 404 or 409 bails with
+/// an error instead of printing a status line.
 /// Test: HTTP path covered by the integration test; parse by
-/// `cli_parses_session_managed_resume_verb`.
+/// `cli_parses_session_managed_resume_verb`; `session_resume_not_found_errors`
+/// covers the #2457 exit-code fix for the 404 branch (the identical 409/conflict
+/// fix needs a session seeded into a non-resumable state — see
+/// `managed_tests.rs`'s module doc for why that is left uncovered here).
 pub(crate) async fn session_resume(
     client: &reqwest::Client,
     url: &str,
@@ -314,13 +334,11 @@ pub(crate) async fn session_resume(
         .send()
         .await?;
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        println!("not found");
-        return Ok(());
+        anyhow::bail!("managed session '{id}' not found");
     }
     if resp.status() == reqwest::StatusCode::CONFLICT {
         let msg = resp.text().await.unwrap_or_default();
-        println!("cannot resume: {msg}");
-        return Ok(());
+        anyhow::bail!("cannot resume: {msg}");
     }
     let body: ManagedSessionSummary = resp.error_for_status()?.json().await?;
     println!("resumed {} ({}) [{}]", body.name, body.id, body.state);
@@ -341,8 +359,15 @@ pub(crate) async fn session_resume(
 /// prints a message that accurately reflects what happened. When `workspace_removed`
 /// is `true` and `workspace_path_was` is present, runs `git worktree prune` on
 /// the parent directory (best-effort; errors are silently suppressed).
+/// A missing id is a genuine failure to decommission the requested session
+/// (#2457) — printing "not found" and returning `Ok(())` let a script/CI
+/// check treat it as success, so this now returns `Err` (non-zero exit)
+/// instead. `prune.rs`'s bulk teardown loop (the only other caller) already
+/// propagates this `Err` with `?`, matching its established fail-closed
+/// convention (#1508).
 /// Test: `decommission_message_reflects_workspace_removed` (unit);
-/// HTTP path covered by the integration test.
+/// HTTP path covered by the integration test;
+/// `session_decommission_not_found_errors` covers the #2457 exit-code fix.
 pub(crate) async fn session_decommission(
     client: &reqwest::Client,
     url: &str,
@@ -353,8 +378,7 @@ pub(crate) async fn session_decommission(
         .send()
         .await?;
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        println!("not found");
-        return Ok(());
+        anyhow::bail!("managed session '{id}' not found");
     }
     let body: serde_json::Value = resp.error_for_status()?.json().await?;
     let workspace_removed = body
@@ -660,57 +684,9 @@ pub(crate) async fn catalog(action: CatalogAction) -> anyhow::Result<()> {
     Ok(())
 }
 
+// Unit tests live in managed_tests.rs (test-file budget: 1500 SLOC) —
+// extracted from an inline `mod tests` so #2457's new HTTP-round-trip
+// coverage doesn't push this production file toward the 500-SLOC cap.
 #[cfg(test)]
-mod tests {
-    use super::{short_timestamp, truncate};
-
-    #[test]
-    fn truncate_clips_and_appends_ellipsis() {
-        assert_eq!(truncate("hello", 10), "hello");
-        assert_eq!(truncate("hello world", 5), "hell\u{2026}");
-        assert_eq!(truncate("", 5), "");
-        assert_eq!(truncate("abcde", 5), "abcde");
-    }
-
-    #[test]
-    fn short_timestamp_formats_correctly() {
-        assert_eq!(short_timestamp("2025-06-27T14:32:00Z"), "2025-06-27 14:32");
-        assert_eq!(short_timestamp("short"), "short");
-        assert_eq!(short_timestamp("2025-06-27T14:32"), "2025-06-27 14:32");
-    }
-
-    #[test]
-    fn decommission_message_reflects_workspace_removed() {
-        // Guard that the key field names used in session_decommission match the
-        // daemon's DecommissionResponse serde output. If the daemon renames those
-        // keys this test catches the drift before the JSON decodes silently to None.
-        let owned_removed = serde_json::json!({
-            "id": "abc-123",
-            "workspace_removed": true,
-            "workspace_path_was": "/some/workspace/path"
-        });
-        assert_eq!(
-            owned_removed
-                .get("workspace_removed")
-                .and_then(|v| v.as_bool()),
-            Some(true)
-        );
-        assert_eq!(
-            owned_removed
-                .get("workspace_path_was")
-                .and_then(|v| v.as_str()),
-            Some("/some/workspace/path")
-        );
-        let adopted_not_removed = serde_json::json!({
-            "id": "xyz-456",
-            "workspace_removed": false
-        });
-        assert_eq!(
-            adopted_not_removed
-                .get("workspace_removed")
-                .and_then(|v| v.as_bool()),
-            Some(false)
-        );
-        assert!(adopted_not_removed.get("workspace_path_was").is_none());
-    }
-}
+#[path = "managed_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -321,9 +321,9 @@ pub(crate) async fn session_stop(
 /// an error instead of printing a status line.
 /// Test: HTTP path covered by the integration test; parse by
 /// `cli_parses_session_managed_resume_verb`; `session_resume_not_found_errors`
-/// covers the #2457 exit-code fix for the 404 branch (the identical 409/conflict
-/// fix needs a session seeded into a non-resumable state — see
-/// `managed_tests.rs`'s module doc for why that is left uncovered here).
+/// covers the #2457 exit-code fix for the 404 branch; `session_resume_conflict_state_errors`
+/// (in `managed_tests.rs`, #2521) covers the identical 409/conflict fix by
+/// seeding a session into a non-resumable state.
 pub(crate) async fn session_resume(
     client: &reqwest::Client,
     url: &str,

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
@@ -220,15 +220,27 @@ pub(crate) async fn resolve_project_session_id(
 
 /// Execute a managed [`SessionAction`] through chat-core and print the result.
 ///
-/// Why: the single entry point the `session` dispatcher calls for every managed
-/// verb — it keeps the dispatcher a thin match and concentrates the
-/// map → execute → render flow here.
-/// What: maps `action` via [`to_command`], runs it on a [`CommandExecutor`] built
-/// from the CLI's client, and prints [`render_cli`] to stdout. Returns `false`
-/// when `action` is not a managed verb this module routes (so the caller can
-/// handle it on the project path); `true` once it has handled and printed.
-/// Test: parsing/mapping by `to_command_maps_*`; rendering by `render_cli_*`; the
-/// HTTP path by the executor tests and `tests/session_manager_mvp.rs`.
+/// Why (#2457): the single entry point the `session` dispatcher calls for
+/// every managed verb — it keeps the dispatcher a thin match and concentrates
+/// the map → execute → render flow here. Before this fix a failed spawn (or
+/// any other managed verb) — an unreachable daemon, a rejected spawn, a 404
+/// deliverable-not-found — came back from [`CommandExecutor::execute`] as
+/// `CommandResult::Error`, which this function printed and then returned
+/// `Ok(true)` regardless: the process exited 0 even though the operation
+/// failed, so scripts/CI checking the exit code silently treated the failure
+/// as success.
+/// What: maps `action` via [`to_command`], runs it on a [`CommandExecutor`]
+/// built from the CLI's client. A [`CommandResult::Error`] is now propagated
+/// as `Err` (via the same `anyhow` path every other CLI failure uses) instead
+/// of merely being printed, so `main`'s default error handler reports it and
+/// exits non-zero; every other result is rendered via [`render_cli`] and
+/// printed to stdout as before. Returns `Ok(false)` when `action` is not a
+/// managed verb this module routes (so the caller can handle it on the
+/// project path); `Ok(true)` once it has handled and printed a successful
+/// result.
+/// Test: parsing/mapping by `to_command_maps_*`; rendering by `render_cli_*`;
+/// `run_propagates_error_result_as_err` covers the exit-code fix; the HTTP
+/// path by the executor tests and `tests/session_manager_mvp.rs`.
 pub(crate) async fn run(
     client: &reqwest::Client,
     url: &str,
@@ -238,6 +250,9 @@ pub(crate) async fn run(
         return Ok(false);
     };
     let result = executor(client, url).execute(cmd).await;
+    if let CommandResult::Error(msg) = &result {
+        anyhow::bail!("{msg}");
+    }
     println!("{}", render_cli(&result));
     Ok(true)
 }
@@ -515,6 +530,28 @@ mod tests {
         assert_eq!(
             render_cli(&CommandResult::Error("managed session x not found".into())),
             "managed session x not found"
+        );
+    }
+
+    /// #2457: `run` must propagate a `CommandResult::Error` as `Err`, not
+    /// print it and return `Ok(true)` — that was the exact bug (a failed
+    /// `sessions new`, or any other managed verb routed here, exited 0).
+    /// Port 1 on loopback is not listening, so this deterministically drives
+    /// the executor's "daemon unreachable" error path without needing a real
+    /// daemon.
+    #[tokio::test]
+    async fn run_propagates_error_result_as_err() {
+        let client = reqwest::Client::new();
+        let action = SessionAction::Send {
+            id: "nonexistent".into(),
+            text: "hi".into(),
+        };
+        let err = run(&client, "http://127.0.0.1:1", &action)
+            .await
+            .expect_err("a CommandResult::Error must propagate as Err, not be swallowed");
+        assert!(
+            err.to_string().contains("daemon unreachable"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -1,0 +1,153 @@
+//! Unit tests for `commands::managed` — split out of `managed.rs` (test-file
+//! budget: 1500 SLOC) so the #2457 HTTP-round-trip coverage below doesn't push
+//! the production file toward the 500-SLOC cap.
+//!
+//! Why: `session_stop`/`session_resume`/`session_decommission`/`session_activity`
+//! previously printed "not found" (or, for resume, a conflict message) and
+//! returned `Ok(())` on a 404/409 from the daemon — a genuine failure reported
+//! as a successful exit code (#2457). The tests below drive each function
+//! against a real hermetic daemon (mirroring `client::executor::tests`'s
+//! `spawn_test_daemon` pattern) and assert `Err` is returned instead.
+//! What: the `session_*_not_found_errors` tests cover the exit-code fix (the
+//! `session_resume` 409/conflict branch got the identical mechanical fix —
+//! print+`Ok(())` to `bail!` — but seeding a managed session in a state that
+//! rejects `resume` needs the daemon's `SessionManager::create_with_id` +
+//! tmux-driver test scaffolding that lives in `tests/session_manager_mvp.rs`,
+//! not this unit-test file, so it is left to that integration suite); the
+//! pre-existing `truncate_*`/`short_timestamp_*`/
+//! `decommission_message_reflects_workspace_removed` unit tests are carried
+//! over unchanged from the inline module this file replaced.
+//! Test: this file IS the test module for `commands::managed`.
+
+use std::future::IntoFuture as _;
+
+use super::{session_activity, session_decommission, session_resume, session_stop};
+use super::{short_timestamp, truncate};
+
+#[test]
+fn truncate_clips_and_appends_ellipsis() {
+    assert_eq!(truncate("hello", 10), "hello");
+    assert_eq!(truncate("hello world", 5), "hell\u{2026}");
+    assert_eq!(truncate("", 5), "");
+    assert_eq!(truncate("abcde", 5), "abcde");
+}
+
+#[test]
+fn short_timestamp_formats_correctly() {
+    assert_eq!(short_timestamp("2025-06-27T14:32:00Z"), "2025-06-27 14:32");
+    assert_eq!(short_timestamp("short"), "short");
+    assert_eq!(short_timestamp("2025-06-27T14:32"), "2025-06-27 14:32");
+}
+
+#[test]
+fn decommission_message_reflects_workspace_removed() {
+    // Guard that the key field names used in session_decommission match the
+    // daemon's DecommissionResponse serde output. If the daemon renames those
+    // keys this test catches the drift before the JSON decodes silently to None.
+    let owned_removed = serde_json::json!({
+        "id": "abc-123",
+        "workspace_removed": true,
+        "workspace_path_was": "/some/workspace/path"
+    });
+    assert_eq!(
+        owned_removed
+            .get("workspace_removed")
+            .and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        owned_removed
+            .get("workspace_path_was")
+            .and_then(|v| v.as_str()),
+        Some("/some/workspace/path")
+    );
+    let adopted_not_removed = serde_json::json!({
+        "id": "xyz-456",
+        "workspace_removed": false
+    });
+    assert_eq!(
+        adopted_not_removed
+            .get("workspace_removed")
+            .and_then(|v| v.as_bool()),
+        Some(false)
+    );
+    assert!(adopted_not_removed.get("workspace_path_was").is_none());
+}
+
+/// Spawn the daemon's real HTTP API on a random loopback port, rooted in a
+/// throwaway temp directory.
+///
+/// Why: mirrors `client::executor::tests::spawn_test_daemon` — an empty
+/// isolated managed-session store means ANY id is a genuine 404, so these
+/// tests exercise the real daemon route (not a hand-rolled mock response).
+/// What: builds `daemon::api::router(DaemonState::with_root_isolated_managed(...))`,
+/// binds an ephemeral port, serves it on a background task, and returns the
+/// base URL.
+async fn spawn_test_daemon() -> String {
+    use trusty_mpm::daemon::{api, state::DaemonState};
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = std::sync::Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let router = api::router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    format!("http://{addr}")
+}
+
+/// #2457: a 404 from `runtime-stop` on a nonexistent id must propagate as
+/// `Err`, not a printed "not found" with `Ok(())`.
+#[tokio::test]
+async fn session_stop_not_found_errors() {
+    let url = spawn_test_daemon().await;
+    let client = reqwest::Client::new();
+    let err = session_stop(&client, &url, "nonexistent-id".to_string())
+        .await
+        .expect_err("a missing managed session must be a hard failure, not a silent Ok(())");
+    assert!(
+        err.to_string().contains("nonexistent-id"),
+        "error should name the missing id: {err}"
+    );
+}
+
+/// #2457: a 404 from `resume` on a nonexistent id must propagate as `Err`.
+#[tokio::test]
+async fn session_resume_not_found_errors() {
+    let url = spawn_test_daemon().await;
+    let client = reqwest::Client::new();
+    let err = session_resume(&client, &url, "nonexistent-id".to_string())
+        .await
+        .expect_err("a missing managed session must be a hard failure, not a silent Ok(())");
+    assert!(
+        err.to_string().contains("nonexistent-id"),
+        "error should name the missing id: {err}"
+    );
+}
+
+/// #2457: a 404 from `decommission` on a nonexistent id must propagate as
+/// `Err` — `prune.rs`'s bulk loop relies on this via `?`.
+#[tokio::test]
+async fn session_decommission_not_found_errors() {
+    let url = spawn_test_daemon().await;
+    let client = reqwest::Client::new();
+    let err = session_decommission(&client, &url, "nonexistent-id".to_string())
+        .await
+        .expect_err("a missing managed session must be a hard failure, not a silent Ok(())");
+    assert!(
+        err.to_string().contains("nonexistent-id"),
+        "error should name the missing id: {err}"
+    );
+}
+
+/// #2457: a 404 from `activity` on a nonexistent id must propagate as `Err`.
+#[tokio::test]
+async fn session_activity_not_found_errors() {
+    let url = spawn_test_daemon().await;
+    let client = reqwest::Client::new();
+    let err = session_activity(&client, &url, "nonexistent-id".to_string())
+        .await
+        .expect_err("a missing managed session must be a hard failure, not a silent Ok(())");
+    assert!(
+        err.to_string().contains("nonexistent-id"),
+        "error should name the missing id: {err}"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -8,13 +8,16 @@
 //! as a successful exit code (#2457). The tests below drive each function
 //! against a real hermetic daemon (mirroring `client::executor::tests`'s
 //! `spawn_test_daemon` pattern) and assert `Err` is returned instead.
-//! What: the `session_*_not_found_errors` tests cover the exit-code fix (the
-//! `session_resume` 409/conflict branch got the identical mechanical fix —
-//! print+`Ok(())` to `bail!` — but seeding a managed session in a state that
-//! rejects `resume` needs the daemon's `SessionManager::create_with_id` +
-//! tmux-driver test scaffolding that lives in `tests/session_manager_mvp.rs`,
-//! not this unit-test file, so it is left to that integration suite); the
-//! pre-existing `truncate_*`/`short_timestamp_*`/
+//! What: the `session_*_not_found_errors` tests cover the 404 exit-code fix.
+//! `session_resume`'s 409/conflict branch got the identical mechanical fix —
+//! print+`Ok(())` to `bail!` — and is now ALSO covered at this CLI layer by
+//! `session_resume_conflict_state_errors`, which seeds a session in a
+//! non-resumable (`Provisioning`) state via
+//! `spawn_test_daemon_with_unresumable_session` (#2521 review; previously left
+//! only to the daemon-layer `resume_managed_typed_invalid_state_is_conflict`
+//! test in `tests/session_manager_mvp.rs`, which exercises the typed
+//! `resume_managed` helper directly rather than the CLI's `session_resume`).
+//! The pre-existing `truncate_*`/`short_timestamp_*`/
 //! `decommission_message_reflects_workspace_removed` unit tests are carried
 //! over unchanged from the inline module this file replaced.
 //! Test: this file IS the test module for `commands::managed`.
@@ -120,6 +123,77 @@ async fn session_resume_not_found_errors() {
     assert!(
         err.to_string().contains("nonexistent-id"),
         "error should name the missing id: {err}"
+    );
+}
+
+/// Spawn the daemon's real HTTP API with ONE managed session already seeded in
+/// `Provisioning` — a non-resumable state — so a `resume` call against it is a
+/// genuine 409 from the daemon, not a hand-rolled stub response.
+///
+/// Why: #2521 review — `session_resume`'s 409/conflict branch (managed.rs
+/// L337-339) had no CLI-layer test proving it returns `Err`; the module doc
+/// above explained this was left uncovered because seeding a non-resumable
+/// session needs `SessionManager::create_with_id` scaffolding. That
+/// scaffolding is exactly what `tests/session_manager_mvp.rs`'s
+/// `resume_managed_typed_invalid_state_is_conflict` already uses (a freshly
+/// created record starts in `Provisioning`, which is not `Stopped`/`Errored`,
+/// so resuming it is an invalid state transition). This slots the SAME seeding
+/// approach into `managed_tests.rs`'s hermetic HTTP-round-trip harness
+/// (mirroring `spawn_test_daemon`) so the CLI-layer `session_resume` function
+/// itself — not just the daemon's typed `resume_managed` — is proven to
+/// surface the 409 as an `Err`.
+/// What: builds the isolated daemon state directly (so the seeded session can
+/// be created against it before the router starts serving), creates ONE
+/// session via `create_with_id` (left in its initial `Provisioning` state,
+/// never started/stopped), serves the router, and returns `(base_url, id)`.
+async fn spawn_test_daemon_with_unresumable_session() -> (String, String) {
+    use trusty_mpm::daemon::{api, state::DaemonState};
+    use trusty_mpm::runtime::RuntimeKind;
+    use trusty_mpm::session_manager::ManagedSessionId;
+
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = std::sync::Arc::new(DaemonState::with_root_isolated_managed(root.clone()).await);
+
+    let id = ManagedSessionId::new();
+    let ws = root.join(format!("{id}-resume-conflict-ws"));
+    state
+        .session_manager()
+        .await
+        .create_with_id(
+            id,
+            "regression: #2521 409 resume CLI test".to_string(),
+            Some(ws.clone()),
+            None,
+            Some(ws),
+            Some("https://example.com/r.git".to_string()),
+            Some("main".to_string()),
+            RuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed non-resumable session");
+
+    let router = api::router(std::sync::Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    (format!("http://{addr}"), id.to_string())
+}
+
+/// #2521 review: a 409 from `resume` (session exists but is in a non-resumable
+/// state) must propagate as `Err` at the CLI layer — the same layer #2457
+/// changed from "print + `Ok(())`" to "bail".
+#[tokio::test]
+async fn session_resume_conflict_state_errors() {
+    let (url, id) = spawn_test_daemon_with_unresumable_session().await;
+    let client = reqwest::Client::new();
+    let err = session_resume(&client, &url, id)
+        .await
+        .expect_err("resuming a non-resumable session must be a hard failure, not Ok(())");
+    assert!(
+        err.to_string().contains("cannot resume"),
+        "error should surface the daemon's 409 conflict message: {err}"
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/prune.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/prune.rs
@@ -330,19 +330,237 @@ pub(crate) async fn prune_idle(
         return Ok(());
     }
 
-    // 5) Execute the actionable rows by REUSING the existing managed operations.
-    for p in &plan {
-        match p.action {
-            PruneAction::Stop => {
-                super::managed::session_stop(client, url, p.id.clone()).await?;
-            }
-            PruneAction::Decommission => {
-                super::managed::session_decommission(client, url, p.id.clone()).await?;
-            }
-            PruneAction::Skip(_) => {}
-        }
+    // 5) Execute the actionable rows by REUSING the existing managed operations,
+    //    best-effort: a single session vanishing mid-sweep (raced by the idle
+    //    reaper, a concurrent stop, or an overlapping prune) must not abort the
+    //    REST of the sweep (#2521 review). `execute_plan` catches each row's
+    //    error instead of `?`-propagating it, so every actionable row is
+    //    attempted regardless of earlier failures.
+    let executed = execute_plan(client, url, &plan).await;
+    if json {
+        println!("{}", render_execution_summary_json(&executed)?);
+    } else {
+        print!("{}", render_execution_summary_text(&executed));
+    }
+
+    // The command still fails overall (non-zero exit, matching #2457's
+    // fail-closed spirit) when ANY row failed — but only after the sweep has
+    // run to completion, and the summary above already reported which rows.
+    let (_, failed, _) = summarize_execution(&executed);
+    if failed > 0 {
+        anyhow::bail!(
+            "prune sweep completed with {failed} failure(s) out of {} session(s); see summary above",
+            executed.len()
+        );
     }
     Ok(())
+}
+
+/// Outcome of attempting one planned action against the daemon.
+///
+/// Why: the #2521 review found the live-execute loop `?`-propagated the FIRST
+/// per-session failure, aborting the rest of the sweep while the
+/// pre-execution "acted on N of M" line kept describing only the intention.
+/// Tracking a per-row outcome lets the sweep run best-effort to completion and
+/// lets the post-execution summary report what ACTUALLY happened.
+/// What: `Succeeded`/`Failed(reason)` for attempted (stop/decommission) rows,
+/// `Skipped` for rows the policy already excluded from execution.
+/// Test: `execute_plan_is_best_effort_and_reports_accurately` in `prune_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExecOutcome {
+    /// The stop/decommission call succeeded.
+    Succeeded,
+    /// The stop/decommission call failed; carries the error's `Display` text.
+    Failed(String),
+    /// The policy decided to skip this session — never attempted.
+    Skipped,
+}
+
+/// One executed row: the session identity plus its actual outcome.
+///
+/// Why: the post-execution summary (text or JSON) needs the id/name alongside
+/// the outcome so it can name exactly which sessions failed.
+/// What: carries `id`, `name`, and the row's [`ExecOutcome`].
+/// Test: produced by `execute_plan`; rendered by `render_execution_summary_*`.
+struct ExecutedRow {
+    id: String,
+    name: String,
+    outcome: ExecOutcome,
+}
+
+/// Execute every row in the plan, never aborting the sweep on a per-row error.
+///
+/// Why: this IS the fix for the #2521 review finding — a raced session
+/// disappearing between planning and execution must not stop the sweep from
+/// acting on the rest of the fleet. Each failure is (a) logged to stderr
+/// immediately, for an operator watching live output, and (b) captured in the
+/// returned row so the post-sweep summary is accurate rather than aspirational.
+/// What: for each [`PlannedAction`], calls the matching
+/// `managed::session_stop` / `managed::session_decommission` handler and
+/// catches (does not propagate) its `Err`; `Skip` rows are recorded as
+/// `Skipped` without an HTTP call.
+/// Test: `execute_plan_is_best_effort_and_reports_accurately`.
+async fn execute_plan(
+    client: &reqwest::Client,
+    url: &str,
+    plan: &[PlannedAction],
+) -> Vec<ExecutedRow> {
+    let mut results = Vec::with_capacity(plan.len());
+    for p in plan {
+        let outcome = match &p.action {
+            PruneAction::Stop => {
+                match super::managed::session_stop(client, url, p.id.clone()).await {
+                    Ok(()) => ExecOutcome::Succeeded,
+                    Err(e) => {
+                        eprintln!(
+                            "prune: failed to stop session {} ({}): {e}",
+                            p.name,
+                            short_id(&p.id)
+                        );
+                        ExecOutcome::Failed(e.to_string())
+                    }
+                }
+            }
+            PruneAction::Decommission => {
+                match super::managed::session_decommission(client, url, p.id.clone()).await {
+                    Ok(()) => ExecOutcome::Succeeded,
+                    Err(e) => {
+                        eprintln!(
+                            "prune: failed to decommission session {} ({}): {e}",
+                            p.name,
+                            short_id(&p.id)
+                        );
+                        ExecOutcome::Failed(e.to_string())
+                    }
+                }
+            }
+            PruneAction::Skip(_) => ExecOutcome::Skipped,
+        };
+        results.push(ExecutedRow {
+            id: p.id.clone(),
+            name: p.name.clone(),
+            outcome,
+        });
+    }
+    results
+}
+
+/// Count succeeded/failed/skipped rows (pure).
+///
+/// Why: shared by both the text and JSON post-execution renderers so the
+/// counts can never drift between the two output modes, and by `prune_idle`'s
+/// final exit-code decision.
+/// What: returns `(succeeded, failed, skipped)`.
+/// Test: `render_execution_summary_text_reports_failures`,
+/// `render_execution_summary_json_reports_failures`.
+fn summarize_execution(rows: &[ExecutedRow]) -> (usize, usize, usize) {
+    let succeeded = rows
+        .iter()
+        .filter(|r| r.outcome == ExecOutcome::Succeeded)
+        .count();
+    let failed = rows
+        .iter()
+        .filter(|r| matches!(r.outcome, ExecOutcome::Failed(_)))
+        .count();
+    let skipped = rows
+        .iter()
+        .filter(|r| r.outcome == ExecOutcome::Skipped)
+        .count();
+    (succeeded, failed, skipped)
+}
+
+/// Render the post-execution outcome as an operator-readable summary.
+///
+/// Why: the pre-execution plan line ("acted on N of M") states an INTENTION;
+/// this renders what ACTUALLY happened, naming every row that failed so a
+/// partial sweep is never silently hidden behind the earlier optimistic line.
+/// What: one `FAILED  name (short-id)  reason` line per failed row, followed
+/// by a `succeeded/failed/skipped of total` summary line.
+/// Test: `render_execution_summary_text_reports_failures`.
+fn render_execution_summary_text(rows: &[ExecutedRow]) -> String {
+    let mut out = String::new();
+    for r in rows {
+        if let ExecOutcome::Failed(reason) = &r.outcome {
+            out.push_str(&format!(
+                "FAILED        {} ({})  {reason}\n",
+                r.name,
+                short_id(&r.id)
+            ));
+        }
+    }
+    let (succeeded, failed, skipped) = summarize_execution(rows);
+    out.push_str(&format!(
+        "prune sweep complete: {succeeded} succeeded, {failed} failed, {skipped} skipped of {} session(s)\n",
+        rows.len()
+    ));
+    out
+}
+
+/// JSON row for the post-execution `--json` summary.
+///
+/// Why: mirrors [`JsonRow`]'s flat shape so programmatic callers get a stable,
+/// self-describing per-session outcome for the ACTUAL sweep result.
+/// What: `id`, `name`, `outcome` (`"succeeded"`/`"failed"`/`"skipped"`), and
+/// `error` (the failure reason, empty for non-failed rows).
+/// Test: `render_execution_summary_json_reports_failures`.
+#[derive(Debug, Serialize)]
+struct ExecutionJsonRow {
+    id: String,
+    name: String,
+    outcome: String,
+    error: String,
+}
+
+/// Top-level JSON document for the post-execution `--json` summary.
+///
+/// Why: printed AFTER the pre-execution plan JSON, only for live (non-dry-run)
+/// runs, so a programmatic caller (e.g. the claude-mpm pause skill) can tell
+/// "what was planned" apart from "what actually happened".
+/// What: `succeeded`/`failed`/`skipped`/`total` counts plus the per-session
+/// `sessions` rows.
+/// Test: `render_execution_summary_json_reports_failures`.
+#[derive(Debug, Serialize)]
+struct ExecutionSummaryJson {
+    succeeded: usize,
+    failed: usize,
+    skipped: usize,
+    total: usize,
+    sessions: Vec<ExecutionJsonRow>,
+}
+
+/// Render the post-execution outcome as a single JSON object.
+///
+/// Why: JSON companion to [`render_execution_summary_text`] — programmatic
+/// callers need the ACTUAL result of a live sweep, not just the pre-execution
+/// plan that was already printed.
+/// What: serializes an [`ExecutionSummaryJson`].
+/// Test: `render_execution_summary_json_reports_failures`.
+fn render_execution_summary_json(rows: &[ExecutedRow]) -> anyhow::Result<String> {
+    let (succeeded, failed, skipped) = summarize_execution(rows);
+    let sessions = rows
+        .iter()
+        .map(|r| {
+            let (outcome, error) = match &r.outcome {
+                ExecOutcome::Succeeded => ("succeeded", String::new()),
+                ExecOutcome::Failed(e) => ("failed", e.clone()),
+                ExecOutcome::Skipped => ("skipped", String::new()),
+            };
+            ExecutionJsonRow {
+                id: r.id.clone(),
+                name: r.name.clone(),
+                outcome: outcome.to_string(),
+                error,
+            }
+        })
+        .collect::<Vec<_>>();
+    let doc = ExecutionSummaryJson {
+        succeeded,
+        failed,
+        skipped,
+        total: rows.len(),
+        sessions,
+    };
+    Ok(serde_json::to_string_pretty(&doc)?)
 }
 
 /// A managed-session id+name pair as read from the list endpoint.
@@ -515,186 +733,10 @@ async fn fetch_verdict(client: &reqwest::Client, url: &str, id: &str) -> Option<
     body.classification.or(body.state)
 }
 
+// Unit tests live in prune_tests.rs (test-file budget: 1500 SLOC) — extracted
+// from an inline `mod tests` (mirroring managed.rs/managed_tests.rs) so the
+// #2521 best-effort-sweep HTTP-round-trip coverage doesn't push this
+// production file toward the 500-SLOC cap.
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn row(id: &str, name: &str, verdict: Option<&str>) -> SessionVerdict {
-        SessionVerdict {
-            id: id.to_string(),
-            name: name.to_string(),
-            verdict: verdict.map(str::to_string),
-        }
-    }
-
-    /// Why: prove the orchestration maps every verdict through the policy
-    /// (idle→stop, done→decommission, working/none→skip) in one pass.
-    /// What: builds a plan over mixed rows and asserts each chosen action.
-    /// Test: this test.
-    #[test]
-    fn build_plan_maps_each_verdict() {
-        let rows = vec![
-            row("11111111-a", "alpha", Some("idle")),
-            row("22222222-b", "bravo", Some("done")),
-            row("33333333-c", "charlie", Some("working")),
-            row("44444444-d", "delta", None),
-        ];
-        let plan = build_plan(&rows);
-        assert_eq!(plan[0].action, PruneAction::Stop);
-        assert_eq!(plan[1].action, PruneAction::Decommission);
-        assert!(matches!(plan[2].action, PruneAction::Skip(_)));
-        assert!(matches!(plan[3].action, PruneAction::Skip(_)));
-        assert_eq!(plan[3].verdict, "none");
-    }
-
-    /// Why: the plan order must mirror the daemon's list order for stable output.
-    /// What: asserts ids appear in input order.
-    /// Test: this test.
-    #[test]
-    fn build_plan_preserves_order() {
-        let rows = vec![
-            row("aaaa-1", "a", Some("idle")),
-            row("bbbb-2", "b", Some("idle")),
-        ];
-        let plan = build_plan(&rows);
-        assert_eq!(plan[0].id, "aaaa-1");
-        assert_eq!(plan[1].id, "bbbb-2");
-    }
-
-    /// Why: `--dry-run` correctness — building the plan is pure and yields the
-    /// SAME actionable set the live path would execute, with no side effects.
-    /// What: asserts the dry-run plan equals the live plan (same input → same
-    /// decisions) and that only stop/decommission rows are counted actionable.
-    /// Test: this test.
-    #[test]
-    fn build_plan_dry_run_matches_live_plan() {
-        let rows = vec![
-            row("1-a", "a", Some("idle")),
-            row("2-b", "b", Some("done")),
-            row("3-c", "c", Some("errored")),
-        ];
-        // The function is pure: calling it twice (as dry-run then live would)
-        // produces identical decisions, proving dry-run previews the live action.
-        let dry = build_plan(&rows);
-        let live = build_plan(&rows);
-        let labels = |p: &[PlannedAction]| p.iter().map(|x| x.action.label()).collect::<Vec<_>>();
-        assert_eq!(labels(&dry), labels(&live));
-        assert_eq!(actionable_count(&dry), 2);
-    }
-
-    /// Why: the summary counter must exclude skips.
-    /// What: asserts the actionable count over a mixed plan.
-    /// Test: this test.
-    #[test]
-    fn actionable_count_excludes_skips() {
-        let rows = vec![
-            row("1", "a", Some("idle")),
-            row("2", "b", Some("working")),
-            row("3", "c", Some("done")),
-        ];
-        assert_eq!(actionable_count(&build_plan(&rows)), 2);
-    }
-
-    /// Why: the text plan must show each session with its verdict and action.
-    /// What: asserts the rendered table contains the names, verbs, and short id.
-    /// Test: this test.
-    #[test]
-    fn render_plan_text_lists_actions() {
-        let rows = vec![
-            row("11111111-aaaa", "alpha", Some("idle")),
-            row("22222222-bbbb", "bravo", Some("working")),
-        ];
-        let out = render_plan_text(&build_plan(&rows), true);
-        assert!(out.contains("stop"));
-        assert!(out.contains("alpha"));
-        assert!(out.contains("11111111"));
-        assert!(out.contains("skip"));
-        assert!(out.contains("bravo"));
-        assert!(out.contains("dry run"));
-        assert!(out.contains("would act on 1 of 2"));
-    }
-
-    /// Why: an empty fleet must render a clear no-op line, not a blank.
-    /// What: asserts the empty-plan message.
-    /// Test: this test.
-    #[test]
-    fn render_plan_text_empty() {
-        assert_eq!(
-            render_plan_text(&[], true),
-            "no managed sessions to prune\n"
-        );
-    }
-
-    /// Why: the JSON contract for the claude-mpm pause skill must be stable.
-    /// What: parses the rendered JSON and asserts the document shape and a row.
-    /// Test: this test.
-    #[test]
-    fn render_plan_json_shape() {
-        let rows = vec![
-            row("1-a", "alpha", Some("idle")),
-            row("2-b", "bravo", Some("working")),
-        ];
-        let json = render_plan_json(&build_plan(&rows), true).expect("json");
-        let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
-        assert_eq!(v["dry_run"], true);
-        assert_eq!(v["actionable"], 1);
-        assert_eq!(v["total"], 2);
-        assert_eq!(v["sessions"][0]["action"], "stop");
-        assert_eq!(v["sessions"][0]["verdict"], "idle");
-        assert_eq!(v["sessions"][1]["action"], "skip");
-        assert_eq!(v["sessions"][1]["reason"], "working");
-    }
-
-    /// Why: the concurrent verdict fan-out (`JoinSet`) completes tasks in
-    /// nondeterministic order, but the plan must mirror the daemon's list order.
-    /// `reorder_by_index` is the pure piece that restores it; proving it sorts
-    /// out-of-order completions back to input order guarantees deterministic
-    /// plans (and byte-identical dry-run/live output) regardless of scheduling.
-    /// What: feeds `(index, row)` pairs in shuffled order and asserts the result
-    /// is in ascending-index (i.e. original list) order.
-    /// Test: this test.
-    #[test]
-    fn fetch_verdicts_preserves_order() {
-        // Tasks "completed" out of order: indices 2, 0, 1.
-        let shuffled = vec![
-            (2, row("c", "charlie", Some("done"))),
-            (0, row("a", "alpha", Some("idle"))),
-            (1, row("b", "bravo", Some("working"))),
-        ];
-        let ordered = reorder_by_index(shuffled);
-        let ids: Vec<&str> = ordered.iter().map(|r| r.id.as_str()).collect();
-        assert_eq!(ids, ["a", "b", "c"]);
-    }
-
-    /// Why: the SM-unavailable `--json` branch must emit the SAME serde schema as
-    /// the available path (issue #1313 review finding #4) — never a hand-rolled
-    /// literal. The only difference is `sm_available: false` and empty counts.
-    /// What: parses `render_unavailable_json` and asserts every field the
-    /// available-path `render_plan_json_shape` test checks, plus `sm_available`.
-    /// Test: this test.
-    #[test]
-    fn render_unavailable_json_shape() {
-        let json = render_unavailable_json(true).expect("json");
-        let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
-        // Same schema/keys as the available path…
-        assert_eq!(v["dry_run"], true);
-        assert_eq!(v["actionable"], 0);
-        assert_eq!(v["total"], 0);
-        assert!(v["sessions"].is_array());
-        assert_eq!(v["sessions"].as_array().expect("array").len(), 0);
-        // …distinguished only by the availability flag.
-        assert_eq!(v["sm_available"], false);
-        // The available path sets the same flag to `true`.
-        let avail = render_plan_json(&[], false).expect("json");
-        let av: serde_json::Value = serde_json::from_str(&avail).expect("parse");
-        assert_eq!(av["sm_available"], true);
-    }
-
-    /// Why: the graceful no-op exit code must stay the documented constant.
-    /// What: asserts the value the pause skill branches on.
-    /// Test: this test.
-    #[test]
-    fn unavailable_exit_code_is_stable() {
-        assert_eq!(EXIT_SM_UNAVAILABLE, 75);
-    }
-}
+#[path = "prune_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/prune_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/prune_tests.rs
@@ -1,0 +1,453 @@
+//! Unit tests for `commands::prune` — split out of `prune.rs` (test-file
+//! budget: 1500 SLOC), mirroring the `managed.rs`/`managed_tests.rs` split, so
+//! the #2521 best-effort-sweep HTTP-round-trip coverage below doesn't push the
+//! production file toward the 500-SLOC cap.
+//!
+//! Why: `build_plan_*`/`render_plan_*`/`fetch_verdicts_preserves_order` were
+//! carried over unchanged from the inline `mod tests` this file replaces. The
+//! new tests below cover the #2521 review fix: `prune_idle`'s live-execute
+//! loop used to `?`-propagate the FIRST per-session `session_stop`/
+//! `session_decommission` failure, aborting the rest of the sweep while the
+//! pre-execution "acted on N of M" line kept describing only the intention.
+//! `execute_plan` is now the best-effort executor (never aborts on a per-row
+//! error) and `render_execution_summary_*`/`summarize_execution` render what
+//! ACTUALLY happened.
+//! What: `execute_plan_is_best_effort_and_reports_accurately` drives
+//! `execute_plan` against a real hermetic daemon (mirroring
+//! `managed_tests.rs`'s `spawn_test_daemon` pattern) with a plan of THREE
+//! `Stop` rows where the middle id was never seeded (a guaranteed 404,
+//! standing in for a session that raced out from under the sweep) and asserts
+//! the other two still get acted on; `render_execution_summary_text_*`/
+//! `render_execution_summary_json_*` cover the pure renderers with synthetic
+//! rows.
+//! Test: this file IS the test module for `commands::prune`.
+
+use std::future::IntoFuture as _;
+
+use super::*;
+
+fn row(id: &str, name: &str, verdict: Option<&str>) -> SessionVerdict {
+    SessionVerdict {
+        id: id.to_string(),
+        name: name.to_string(),
+        verdict: verdict.map(str::to_string),
+    }
+}
+
+/// Why: prove the orchestration maps every verdict through the policy
+/// (idle→stop, done→decommission, working/none→skip) in one pass.
+/// What: builds a plan over mixed rows and asserts each chosen action.
+/// Test: this test.
+#[test]
+fn build_plan_maps_each_verdict() {
+    let rows = vec![
+        row("11111111-a", "alpha", Some("idle")),
+        row("22222222-b", "bravo", Some("done")),
+        row("33333333-c", "charlie", Some("working")),
+        row("44444444-d", "delta", None),
+    ];
+    let plan = build_plan(&rows);
+    assert_eq!(plan[0].action, PruneAction::Stop);
+    assert_eq!(plan[1].action, PruneAction::Decommission);
+    assert!(matches!(plan[2].action, PruneAction::Skip(_)));
+    assert!(matches!(plan[3].action, PruneAction::Skip(_)));
+    assert_eq!(plan[3].verdict, "none");
+}
+
+/// Why: the plan order must mirror the daemon's list order for stable output.
+/// What: asserts ids appear in input order.
+/// Test: this test.
+#[test]
+fn build_plan_preserves_order() {
+    let rows = vec![
+        row("aaaa-1", "a", Some("idle")),
+        row("bbbb-2", "b", Some("idle")),
+    ];
+    let plan = build_plan(&rows);
+    assert_eq!(plan[0].id, "aaaa-1");
+    assert_eq!(plan[1].id, "bbbb-2");
+}
+
+/// Why: `--dry-run` correctness — building the plan is pure and yields the
+/// SAME actionable set the live path would execute, with no side effects.
+/// What: asserts the dry-run plan equals the live plan (same input → same
+/// decisions) and that only stop/decommission rows are counted actionable.
+/// Test: this test.
+#[test]
+fn build_plan_dry_run_matches_live_plan() {
+    let rows = vec![
+        row("1-a", "a", Some("idle")),
+        row("2-b", "b", Some("done")),
+        row("3-c", "c", Some("errored")),
+    ];
+    // The function is pure: calling it twice (as dry-run then live would)
+    // produces identical decisions, proving dry-run previews the live action.
+    let dry = build_plan(&rows);
+    let live = build_plan(&rows);
+    let labels = |p: &[PlannedAction]| p.iter().map(|x| x.action.label()).collect::<Vec<_>>();
+    assert_eq!(labels(&dry), labels(&live));
+    assert_eq!(actionable_count(&dry), 2);
+}
+
+/// Why: the summary counter must exclude skips.
+/// What: asserts the actionable count over a mixed plan.
+/// Test: this test.
+#[test]
+fn actionable_count_excludes_skips() {
+    let rows = vec![
+        row("1", "a", Some("idle")),
+        row("2", "b", Some("working")),
+        row("3", "c", Some("done")),
+    ];
+    assert_eq!(actionable_count(&build_plan(&rows)), 2);
+}
+
+/// Why: the text plan must show each session with its verdict and action.
+/// What: asserts the rendered table contains the names, verbs, and short id.
+/// Test: this test.
+#[test]
+fn render_plan_text_lists_actions() {
+    let rows = vec![
+        row("11111111-aaaa", "alpha", Some("idle")),
+        row("22222222-bbbb", "bravo", Some("working")),
+    ];
+    let out = render_plan_text(&build_plan(&rows), true);
+    assert!(out.contains("stop"));
+    assert!(out.contains("alpha"));
+    assert!(out.contains("11111111"));
+    assert!(out.contains("skip"));
+    assert!(out.contains("bravo"));
+    assert!(out.contains("dry run"));
+    assert!(out.contains("would act on 1 of 2"));
+}
+
+/// Why: an empty fleet must render a clear no-op line, not a blank.
+/// What: asserts the empty-plan message.
+/// Test: this test.
+#[test]
+fn render_plan_text_empty() {
+    assert_eq!(
+        render_plan_text(&[], true),
+        "no managed sessions to prune\n"
+    );
+}
+
+/// Why: the JSON contract for the claude-mpm pause skill must be stable.
+/// What: parses the rendered JSON and asserts the document shape and a row.
+/// Test: this test.
+#[test]
+fn render_plan_json_shape() {
+    let rows = vec![
+        row("1-a", "alpha", Some("idle")),
+        row("2-b", "bravo", Some("working")),
+    ];
+    let json = render_plan_json(&build_plan(&rows), true).expect("json");
+    let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
+    assert_eq!(v["dry_run"], true);
+    assert_eq!(v["actionable"], 1);
+    assert_eq!(v["total"], 2);
+    assert_eq!(v["sessions"][0]["action"], "stop");
+    assert_eq!(v["sessions"][0]["verdict"], "idle");
+    assert_eq!(v["sessions"][1]["action"], "skip");
+    assert_eq!(v["sessions"][1]["reason"], "working");
+}
+
+/// Why: the concurrent verdict fan-out (`JoinSet`) completes tasks in
+/// nondeterministic order, but the plan must mirror the daemon's list order.
+/// `reorder_by_index` is the pure piece that restores it; proving it sorts
+/// out-of-order completions back to input order guarantees deterministic
+/// plans (and byte-identical dry-run/live output) regardless of scheduling.
+/// What: feeds `(index, row)` pairs in shuffled order and asserts the result
+/// is in ascending-index (i.e. original list) order.
+/// Test: this test.
+#[test]
+fn fetch_verdicts_preserves_order() {
+    // Tasks "completed" out of order: indices 2, 0, 1.
+    let shuffled = vec![
+        (2, row("c", "charlie", Some("done"))),
+        (0, row("a", "alpha", Some("idle"))),
+        (1, row("b", "bravo", Some("working"))),
+    ];
+    let ordered = reorder_by_index(shuffled);
+    let ids: Vec<&str> = ordered.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(ids, ["a", "b", "c"]);
+}
+
+/// Why: the SM-unavailable `--json` branch must emit the SAME serde schema as
+/// the available path (issue #1313 review finding #4) — never a hand-rolled
+/// literal. The only difference is `sm_available: false` and empty counts.
+/// What: parses `render_unavailable_json` and asserts every field the
+/// available-path `render_plan_json_shape` test checks, plus `sm_available`.
+/// Test: this test.
+#[test]
+fn render_unavailable_json_shape() {
+    let json = render_unavailable_json(true).expect("json");
+    let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
+    // Same schema/keys as the available path…
+    assert_eq!(v["dry_run"], true);
+    assert_eq!(v["actionable"], 0);
+    assert_eq!(v["total"], 0);
+    assert!(v["sessions"].is_array());
+    assert_eq!(v["sessions"].as_array().expect("array").len(), 0);
+    // …distinguished only by the availability flag.
+    assert_eq!(v["sm_available"], false);
+    // The available path sets the same flag to `true`.
+    let avail = render_plan_json(&[], false).expect("json");
+    let av: serde_json::Value = serde_json::from_str(&avail).expect("parse");
+    assert_eq!(av["sm_available"], true);
+}
+
+/// Why: the graceful no-op exit code must stay the documented constant.
+/// What: asserts the value the pause skill branches on.
+/// Test: this test.
+#[test]
+fn unavailable_exit_code_is_stable() {
+    assert_eq!(EXIT_SM_UNAVAILABLE, 75);
+}
+
+/// Spawn the daemon's real HTTP API on a random loopback port, rooted in a
+/// throwaway temp directory, with a FakeNoopTmuxDriver so no real tmux
+/// sessions are created (#1790).
+///
+/// Why: mirrors `managed_tests.rs`'s `spawn_test_daemon` — returning the
+/// `Arc<DaemonState>` (not just the URL) lets a test seed a real managed
+/// session via `state.session_manager()` BEFORE serving, so `execute_plan`
+/// exercises the actual HTTP round-trip for both the "session exists" and
+/// "session was never seeded → 404" cases.
+/// What: builds `daemon::api::router(...)`, binds an ephemeral port, serves it
+/// on a background task, and returns `(base_url, state)`.
+async fn spawn_test_daemon() -> (
+    String,
+    std::sync::Arc<trusty_mpm::daemon::state::DaemonState>,
+) {
+    use trusty_mpm::daemon::{api, state::DaemonState};
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = std::sync::Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let router = api::router(std::sync::Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    (format!("http://{addr}"), state)
+}
+
+/// Seed one real managed session record into `state`'s store so a
+/// `session_stop`/`session_decommission` call against its id succeeds against
+/// the real daemon route (rather than 404ing).
+///
+/// Why: `execute_plan`'s best-effort test needs a MIX of real and missing ids
+/// in the same plan; this helper creates the "real" half via the same
+/// `create_with_id` scaffolding `session_manager_mvp.rs` uses.
+/// What: creates a session with a fresh id under a unique workspace path
+/// (derived from the id, so parallel test runs never collide) and returns its
+/// id as a string.
+async fn seed_session(state: &trusty_mpm::daemon::state::DaemonState, name: &str) -> String {
+    use trusty_mpm::runtime::RuntimeKind;
+    use trusty_mpm::session_manager::ManagedSessionId;
+
+    let id = ManagedSessionId::new();
+    let ws = std::env::temp_dir().join(format!("{id}-{name}-ws"));
+    state
+        .session_manager()
+        .await
+        .create_with_id(
+            id,
+            format!("regression: #2521 best-effort sweep ({name})"),
+            Some(ws.clone()),
+            None,
+            Some(ws),
+            Some("https://example.com/r.git".to_string()),
+            Some("main".to_string()),
+            RuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session");
+    id.to_string()
+}
+
+/// #2521 review fix: `execute_plan` must be best-effort — a session that 404s
+/// mid-sweep (raced out from under the prune, stood in for here by an id that
+/// was simply never seeded) must NOT prevent the other rows from being acted
+/// on, and the returned outcomes must accurately reflect the mixed result.
+///
+/// What: seeds two REAL sessions (`alpha`, `charlie`) and builds a 3-row plan
+/// — `Stop(alpha)`, `Stop(<never-seeded id>)`, `Stop(charlie)` — with the
+/// failing row in the MIDDLE. Asserts all three rows were attempted (not
+/// short-circuited), the middle one failed while the other two succeeded, and
+/// `summarize_execution`/`render_execution_summary_text`/
+/// `render_execution_summary_json` all agree: 2 succeeded, 1 failed, 0
+/// skipped.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn execute_plan_is_best_effort_and_reports_accurately() {
+    let (url, state) = spawn_test_daemon().await;
+    let client = reqwest::Client::new();
+
+    let alpha_id = seed_session(&state, "alpha").await;
+    let charlie_id = seed_session(&state, "charlie").await;
+    // Never seeded — the daemon has no record for this id, so `session_stop`
+    // against it is a guaranteed 404 (stands in for a session that raced out
+    // from under the sweep between planning and execution).
+    let missing_id = "nonexistent-middle-session".to_string();
+
+    let plan = vec![
+        PlannedAction {
+            id: alpha_id.clone(),
+            name: "alpha".to_string(),
+            verdict: "idle".to_string(),
+            action: PruneAction::Stop,
+        },
+        PlannedAction {
+            id: missing_id.clone(),
+            name: "bravo".to_string(),
+            verdict: "idle".to_string(),
+            action: PruneAction::Stop,
+        },
+        PlannedAction {
+            id: charlie_id.clone(),
+            name: "charlie".to_string(),
+            verdict: "idle".to_string(),
+            action: PruneAction::Stop,
+        },
+    ];
+
+    let executed = execute_plan(&client, &url, &plan).await;
+
+    // All three rows were attempted — the middle failure did not abort the
+    // sweep and skip the row after it.
+    assert_eq!(
+        executed.len(),
+        3,
+        "the middle failure must not truncate the sweep"
+    );
+    assert_eq!(executed[0].id, alpha_id);
+    assert_eq!(executed[0].outcome, ExecOutcome::Succeeded);
+    assert_eq!(executed[1].id, missing_id);
+    assert!(
+        matches!(executed[1].outcome, ExecOutcome::Failed(_)),
+        "the never-seeded middle session must be reported as a failure, not silently dropped: {:?}",
+        executed[1].outcome
+    );
+    assert_eq!(executed[2].id, charlie_id);
+    assert_eq!(
+        executed[2].outcome,
+        ExecOutcome::Succeeded,
+        "the row AFTER the failing one must still have been attempted and succeeded"
+    );
+
+    // The accurate summary: 2 succeeded, 1 failed, 0 skipped of 3.
+    assert_eq!(summarize_execution(&executed), (2, 1, 0));
+
+    let text = render_execution_summary_text(&executed);
+    assert!(text.contains("FAILED"));
+    assert!(text.contains("bravo"));
+    assert!(text.contains("2 succeeded, 1 failed, 0 skipped of 3 session(s)"));
+
+    let json = render_execution_summary_json(&executed).expect("json");
+    let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
+    assert_eq!(v["succeeded"], 2);
+    assert_eq!(v["failed"], 1);
+    assert_eq!(v["skipped"], 0);
+    assert_eq!(v["total"], 3);
+    assert_eq!(v["sessions"][0]["outcome"], "succeeded");
+    assert_eq!(v["sessions"][1]["outcome"], "failed");
+    assert!(
+        v["sessions"][1]["error"]
+            .as_str()
+            .expect("error string")
+            .contains(&missing_id)
+    );
+    assert_eq!(v["sessions"][2]["outcome"], "succeeded");
+}
+
+/// Why: `summarize_execution` must correctly tally a mix that includes skipped
+/// rows too (not just succeeded/failed), since `PruneAction::Skip` rows never
+/// reach the HTTP layer.
+/// What: builds a synthetic 4-row outcome set and asserts the tally.
+/// Test: this test.
+#[test]
+fn summarize_execution_counts_all_three_outcomes() {
+    let rows = vec![
+        ExecutedRow {
+            id: "1".to_string(),
+            name: "a".to_string(),
+            outcome: ExecOutcome::Succeeded,
+        },
+        ExecutedRow {
+            id: "2".to_string(),
+            name: "b".to_string(),
+            outcome: ExecOutcome::Failed("boom".to_string()),
+        },
+        ExecutedRow {
+            id: "3".to_string(),
+            name: "c".to_string(),
+            outcome: ExecOutcome::Skipped,
+        },
+        ExecutedRow {
+            id: "4".to_string(),
+            name: "d".to_string(),
+            outcome: ExecOutcome::Succeeded,
+        },
+    ];
+    assert_eq!(summarize_execution(&rows), (2, 1, 1));
+}
+
+/// Why: the post-execution text summary must NAME every failed session (not
+/// just count it), so an operator can see exactly which one needs attention.
+/// What: asserts the `FAILED` line contains the name/id/reason and the
+/// trailing summary line has the right counts.
+/// Test: this test.
+#[test]
+fn render_execution_summary_text_reports_failures() {
+    let rows = vec![
+        ExecutedRow {
+            id: "aaaa-1111".to_string(),
+            name: "alpha".to_string(),
+            outcome: ExecOutcome::Succeeded,
+        },
+        ExecutedRow {
+            id: "bbbb-2222".to_string(),
+            name: "bravo".to_string(),
+            outcome: ExecOutcome::Failed("session not found".to_string()),
+        },
+    ];
+    let out = render_execution_summary_text(&rows);
+    assert!(out.contains("FAILED"));
+    assert!(out.contains("bravo"));
+    // The row is displayed with its SHORT id (first hyphen-delimited segment,
+    // same convention as `render_plan_text`), not the full id.
+    assert!(out.contains("bbbb"));
+    assert!(out.contains("session not found"));
+    assert!(out.contains("1 succeeded, 1 failed, 0 skipped of 2 session(s)"));
+}
+
+/// Why: the JSON summary is the programmatic-caller contract; it must expose
+/// per-row outcome + error text, not just aggregate counts.
+/// What: parses the rendered JSON and asserts the shape and a failed row.
+/// Test: this test.
+#[test]
+fn render_execution_summary_json_reports_failures() {
+    let rows = vec![
+        ExecutedRow {
+            id: "1".to_string(),
+            name: "alpha".to_string(),
+            outcome: ExecOutcome::Succeeded,
+        },
+        ExecutedRow {
+            id: "2".to_string(),
+            name: "bravo".to_string(),
+            outcome: ExecOutcome::Failed("boom".to_string()),
+        },
+    ];
+    let json = render_execution_summary_json(&rows).expect("json");
+    let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
+    assert_eq!(v["succeeded"], 1);
+    assert_eq!(v["failed"], 1);
+    assert_eq!(v["skipped"], 0);
+    assert_eq!(v["total"], 2);
+    assert_eq!(v["sessions"][0]["outcome"], "succeeded");
+    assert_eq!(v["sessions"][0]["error"], "");
+    assert_eq!(v["sessions"][1]["outcome"], "failed");
+    assert_eq!(v["sessions"][1]["error"], "boom");
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/session/start_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start_tests.rs
@@ -59,16 +59,19 @@ const UNREACHABLE_URL: &str = "http://127.0.0.1:1";
 /// source directory itself — the exact regression the issue reported.
 ///
 /// Why: this is the acceptance criterion from issue #1916 item (a) — proving
-/// the fix without requiring a live daemon. `managed_route::run` soft-fails
-/// (prints a `CommandResult::Error`, returns `Ok(())`) when the daemon is
-/// unreachable, so `start_session` returning `Ok(())` here confirms the
-/// PROTECTED branch was taken (the in-place fallback hard-fails instead — see
-/// the sibling test below) — and the crucial assertion is that the source
-/// directory was never touched.
+/// the fix without requiring a live daemon. Before #2457, `managed_route::run`
+/// soft-failed (printed a `CommandResult::Error`, returned `Ok(())`) on a
+/// daemon-unreachable spawn — a `tm session start` against a down daemon
+/// silently reported success. #2457 fixed `run` to propagate that
+/// `CommandResult::Error` as `Err`, so this test now asserts `Err` (matching
+/// the in-place fallback's existing hard-fail — see the sibling test) while
+/// still proving the PROTECTED branch was taken via the crucial assertion:
+/// the source directory was never touched.
 /// What: creates a real temp git repo with a `github.com` origin remote (so
 /// `derive_project` recognizes it), calls `start_session` against it with an
-/// unreachable daemon URL, and asserts `.trusty-mpm/` and
-/// `.claude/settings.json` were never created inside the repo.
+/// unreachable daemon URL, and asserts (1) it returns `Err` and (2)
+/// `.trusty-mpm/` and `.claude/settings.json` were never created inside the
+/// repo.
 /// Test: this function IS the test.
 #[tokio::test]
 async fn session_start_dispatches_managed_new_for_github_repo() {
@@ -93,14 +96,13 @@ async fn session_start_dispatches_managed_new_for_github_repo() {
     )
     .await;
 
-    // The managed path never hard-errors on daemon-unreachable (it renders a
-    // `CommandResult::Error` and returns, matching `session new`'s existing
-    // soft-fail behavior via `managed_route::run`) — so `Ok` here proves the
-    // PROTECTED branch was taken, not the in-place fallback (which hard-fails
-    // — see the sibling test).
+    // #2457: a daemon-unreachable spawn is a genuine failure and must
+    // propagate as `Err` (not the pre-#2457 soft-fail `Ok`) — proving the
+    // PROTECTED branch was taken (the in-place fallback also hard-fails, but
+    // via a different code path — see the sibling test).
     assert!(
-        result.is_ok(),
-        "expected soft-fail Ok from the managed route, got {result:?}"
+        result.is_err(),
+        "expected a hard Err from the managed route on daemon-unreachable, got {result:?}"
     );
 
     // The #1916 regression this fix closes: no tm artifacts written into the

--- a/crates/trusty-mpm/src/client/http_client/managed.rs
+++ b/crates/trusty-mpm/src/client/http_client/managed.rs
@@ -18,6 +18,7 @@ use anyhow::Context;
 
 use super::DaemonClient;
 use super::config;
+use super::error::response_or_body_error;
 use super::types::{
     FleetByProjectWireResponse, FleetProjectGroupWire, ManagedActivityResponse,
     ManagedAdoptRequest, ManagedAdoptResponse, ManagedAnswerRequest, ManagedAnswerResponse,
@@ -102,9 +103,16 @@ impl DaemonClient {
     /// [`config::PROVISION_REQUEST_TIMEOUT`] instead (issue #2471 review
     /// follow-up).
     /// What: POSTs `req` with the provision-scoped request timeout and
-    /// returns the daemon's [`ManagedSpawnResponse`].
+    /// returns the daemon's [`ManagedSpawnResponse`]. A non-success status
+    /// goes through [`response_or_body_error`] (#2457 follow-up to #2496's
+    /// call-site sweep, which explicitly deferred `managed.rs`) so the
+    /// daemon's rejection reason — e.g. `DeliverableNotFound`'s "deliverable
+    /// not found: {id}", or `ProjectNotFoundForRepoUrl`'s message naming the
+    /// offending repo_url — survives instead of being discarded down to a
+    /// bare "404 Not Found" by `error_for_status`.
     /// Test: live HTTP via `tests/session_manager_mvp.rs`;
-    /// `config::tests::default_client_uses_default_bounds` pins the constant.
+    /// `config::tests::default_client_uses_default_bounds` pins the constant;
+    /// `spawn_managed_session_surfaces_daemon_error_body` in `tests.rs`.
     pub async fn spawn_managed_session(
         &self,
         req: &ManagedSpawnRequest,
@@ -116,11 +124,9 @@ impl DaemonClient {
             .json(req)
             .timeout(config::PROVISION_REQUEST_TIMEOUT)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
             .await?;
-        Ok(resp)
+        let resp = response_or_body_error(resp).await?;
+        Ok(resp.json().await?)
     }
 
     /// Adopt an EXISTING tmux session via `POST /api/v1/sessions/managed/adopt`

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -46,6 +46,57 @@ async fn connect_session_errors_when_daemon_unreachable() {
     assert!(result.is_err(), "expected connect to fail with no daemon");
 }
 
+/// Spawn the daemon's real HTTP API on a random loopback port, rooted in a
+/// throwaway temp directory with an isolated (empty) managed-session store.
+///
+/// Why: mirrors `client::executor::tests::spawn_test_daemon` — a real bind is
+/// needed to prove `spawn_managed_session` reads the response BODY (via
+/// [`super::error::response_or_body_error`]), not just the status line.
+async fn spawn_test_daemon() -> String {
+    use std::future::IntoFuture as _;
+
+    use crate::daemon::{api, state::DaemonState};
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = std::sync::Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let router = api::router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    format!("http://{addr}")
+}
+
+/// #2457 follow-up to #2496: a rejected spawn must surface the daemon's body
+/// message, not collapse to a bare "404 Not Found" the way `error_for_status`
+/// alone would. No project is registered for `repo_url` here, so the daemon's
+/// deliverable pre-check (`validate_deliverable_scope`, run BEFORE any
+/// provisioning) rejects with `DaemonError::ProjectNotFoundForRepoUrl` — a 404
+/// whose body names the offending repo_url.
+#[tokio::test]
+async fn spawn_managed_session_surfaces_daemon_error_body() {
+    let url = spawn_test_daemon().await;
+    let client = DaemonClient::new(url);
+    let req = ManagedSpawnRequest {
+        repo_url: "https://github.com/acme/unregistered".to_string(),
+        git_ref: "main".to_string(),
+        task: "do it".to_string(),
+        name_hint: None,
+        runtime: None,
+        inject_task: None,
+        deliverable_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
+        force_new: false,
+    };
+    let err = client
+        .spawn_managed_session(&req)
+        .await
+        .expect_err("no project is registered for this repo_url");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("acme/unregistered") || msg.contains("unregistered"),
+        "error should carry the daemon's body message, not just the bare status: {msg}"
+    );
+    assert!(msg.contains("404"), "{msg}");
+}
+
 #[test]
 fn session_row_deserializes_tmux_name() {
     let json = serde_json::json!({


### PR DESCRIPTION
## Root cause

`managed_route::run` (`crates/trusty-mpm/src/bin/tm/commands/managed_route.rs`) is the single CLI dispatch entry point for every managed `tm sessions` verb routed through the shared chat-core executor: `new`, `ls`, `send`, `answer`, `attach`, `decommission`, and the `managed-stop`/`runtime-stop`/`managed-resume` deprecated aliases. It called `executor.execute(cmd)`, which returns a `CommandResult` (never a `Result`) — a daemon rejection (HTTP error, a 404 deliverable-not-found, an unreachable daemon) comes back as `CommandResult::Error(msg)`. `run` printed that message and then returned `Ok(true)` **unconditionally**, so the process exited 0 even though the operation failed. Scripts/CI checking `$?` silently treated a failed spawn as success — exactly the `tm sessions new --deliverable <nonexistent-id>` repro in #2457.

**Fix:** `run` now checks the result before printing — a `CommandResult::Error` is propagated as `anyhow::bail!`, which flows through `main`'s standard `anyhow::Result<()>` return path to a non-zero exit, matching every other CLI failure. All 8 verbs it routes get the fix from this one change.

## Sibling-command audit

Per the issue's explicit ask to sweep `resume`/`decommission`/`send`/etc. for the identical pattern:

| Command | Path | Swallow pattern found? | Fixed |
|---|---|---|---|
| `sessions new` | `managed_route::run` (chat-core) | Yes — `CommandResult::Error` printed, `Ok(true)` | Yes |
| `sessions ls` | `managed_route::run` (chat-core) | Yes (same fn) | Yes |
| `sessions send` | `managed_route::run` (chat-core) | Yes (same fn) | Yes |
| `sessions answer` | `managed_route::run` (chat-core) | Yes (same fn) | Yes |
| `sessions attach` | `managed_route::run` (chat-core) | Yes (same fn) | Yes |
| `sessions decommission` | `managed_route::run` (chat-core) | Yes (same fn) | Yes |
| `session managed-stop`/`runtime-stop`/`managed-resume` (deprecated aliases) | `managed_route::run` (chat-core) | Yes (same fn) | Yes |
| `sessions stop <id>` (managed branch) | `commands::managed::session_stop` (direct HTTP, `commands/managed.rs`) | Yes — 404 printed "not found", `Ok(())` | Yes |
| `sessions resume <id>` (managed branch) | `commands::managed::session_resume` | Yes — 404 **and** 409 printed a message, `Ok(())` | Yes (404 unit-tested; 409 fix is the identical mechanical change, needs `tests/session_manager_mvp.rs` scaffolding to seed a non-resumable session — see `managed_tests.rs` module doc) |
| `sessions activity <id>` | `commands::managed::session_activity` | Yes — 404 printed "not found", `Ok(())` | Yes |
| `prune` bulk stop/decommission | Reuses `session_stop`/`session_decommission` | Inherits the fix via `?` (already fail-closed per #1508's own precedent for bad `--state`) | Yes (via leaf fix) |
| `sessions stop`/`resume` (project-session fallback branch) | Direct HTTP in `session.rs` | Already correct — 404 already bailed with `Err` | N/A, no change needed |
| `doctor`/`health`/coordinator chat | `misc.rs`, separate `CommandExecutor` call sites | Print-only by design (diagnostic reports, not pass/fail operations) | Out of scope — different command family |

## Message-quality follow-up (bonus, in scope of #2457's repro)

PR #2496 added `response_or_body_error` (surfaces the daemon's JSON `{"error": ...}` body instead of a bare status line) but explicitly deferred `managed.rs`'s 10 call sites as "a different endpoint family... worth a targeted follow-up issue." Since #2457's own repro is a `spawn_managed_session` 404, this PR wires `spawn_managed_session` through that helper too, so a `DeliverableNotFound`/`ProjectNotFoundForRepoUrl` rejection now surfaces its actual message instead of collapsing to `"404 Not Found"`. The other 9 managed.rs call sites are left as documented follow-up (unchanged scope from #2496).

## Tests

- `managed_route::tests::run_propagates_error_result_as_err` — drives `run` against an unreachable port and asserts `Err`, not `Ok(true)`.
- `commands::managed::tests` (moved to new `managed_tests.rs`, test-file budget, to keep `managed.rs` under the 500-SLOC production cap): `session_stop_not_found_errors`, `session_resume_not_found_errors`, `session_decommission_not_found_errors`, `session_activity_not_found_errors` — each drives the real function against a hermetic isolated daemon and asserts `Err`.
- `client::http_client::tests::spawn_managed_session_surfaces_daemon_error_body` — asserts the daemon's rejection message (not just the status) comes through.
- Updated `commands::session::start_tests::session_start_dispatches_managed_new_for_github_repo` — this test previously asserted the pre-#2457 soft-fail `Ok` on a daemon-unreachable spawn; updated to assert `Err` while keeping its core assertion (no tm artifacts written into the protected repo).

```
$ cargo build --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.91s
(exit 0)

$ cargo test -p trusty-mpm
test result: ok. 2930 passed; 0 failed; 5 ignored ... (lib)
test result: ok. 871 passed; 0 failed; 1 ignored ...  (bin tm)
... all other integration test binaries: ok, 0 failed
(known flake core::instruction_pipeline::tests::install_system_prompt_writes_file
 hit once under full-suite parallelism, confirmed unrelated + passes clean in isolation;
 reran full suite clean afterward)

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.89s
(exit 0, no lint warnings — only pre-existing cargo-metadata/build-script notices)

$ cargo fmt --check
(exit 0)

$ bash scripts/check_line_cap.sh
line-cap: 0 allowlisted, 0 violations — OK.
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools