### PR TITLE
fix(trusty-mpm): route tm CLI top-level client through bounded config (closes #2517)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs
@@ -65,7 +65,11 @@ const PROJECT_CTL_INTERVAL_MS: u64 = 1500;
 /// Test: terminal glue, exercised by launching the TUI; the gate condition
 /// itself is [`should_launch_bare_tui`], which IS unit tested.
 pub(crate) async fn launch_bare_tui() -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
+    // #2517: same bounded client as `main.rs` — this feeds the `tm projects`
+    // bare TUI's poll loop, which shares a task with keyboard input
+    // (`tui/project_ctl/mod.rs`), so a bare `reqwest::Client::new()` here
+    // reproduces the exact #2471 freeze (a wedged daemon hangs `q`/Ctrl-C too).
+    let client = trusty_mpm::client::http_client::default_client();
     let explicit = trusty_mpm::core::explicit_url_from_env();
     let url = trusty_mpm::core::resolve_daemon_url_via_gateway(&client, explicit.as_deref()).await;
     trusty_mpm::tui::project_ctl::run(url, PROJECT_CTL_INTERVAL_MS).await

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -261,7 +261,15 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    let client = reqwest::Client::new();
+    // #2517: the top-level CLI client must carry the same bounded
+    // connect/request timeouts `DaemonClient` uses (issue #2471/#2512) — a
+    // bare `reqwest::Client::new()` here has NO timeout, so `tm status`
+    // against a daemon that accepts the TCP connection but never answers
+    // hung for the OS-level socket timeout (observed 55.63s live-verify)
+    // instead of the intended ~10s bound. `daemon_healthy` (used by `tm
+    // status`/`tm start`) and the gateway probe below both send through
+    // this SAME client, so both are now bounded too.
+    let client = trusty_mpm::client::http_client::default_client();
     // Resolve the daemon URL once with gateway-first probing:
     //   1. Explicit --url/TRUSTY_MPM_URL, whenever it was actually supplied
     //      (`cli.url` is `Option<String>` — see its doc, #2487) → use it

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -41,6 +41,32 @@ pub use types::{
 
 use serde::Deserialize;
 
+/// Build the shared bounded-timeout `reqwest::Client` [`DaemonClient::new`] uses.
+///
+/// Why: issue #2517 (a live-verify gap in #2471/#2512): the `DaemonClient`
+/// used by every daemon-facing UI got bounded connect/request timeouts via
+/// [`config::default_client`], but the top-level `tm` CLI in
+/// `bin/tm/main.rs` still minted its OWN bare `reqwest::Client::new()` for
+/// the gateway-probe / `daemon_healthy` codepaths (`tm status`, `tm start`),
+/// which are outside `DaemonClient` entirely. That bare client has no
+/// timeout at all, so a daemon that accepts the TCP connection but never
+/// answers hangs `tm status` for the OS-level socket timeout (observed
+/// 55.63s) instead of the intended ~10s bound. This function is the single
+/// public seam a crate-external caller — a `[[bin]]` target is a distinct
+/// crate from the library even within the same package, so `pub(crate)`
+/// does not reach it — can use to get the exact same bounds without
+/// duplicating the constants.
+/// What: delegates to [`config::default_client`] (3s connect / 10s request,
+/// the same bounds `DaemonClient::new` uses).
+/// Test: `config::tests::build_client_bounds_a_stalled_connection` and
+/// `config::tests::default_client_uses_default_bounds` cover the underlying
+/// bounds; `tests::default_client_matches_daemon_client_bounds` in this
+/// module pins that this wrapper is not just a fresh unbounded client in
+/// disguise.
+pub fn default_client() -> reqwest::Client {
+    config::default_client()
+}
+
 /// HTTP client for one trusty-mpm daemon.
 ///
 /// Why: a thin wrapper so any UI can be pointed at any daemon address.

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -60,9 +60,9 @@ use serde::Deserialize;
 /// the same bounds `DaemonClient::new` uses).
 /// Test: `config::tests::build_client_bounds_a_stalled_connection` and
 /// `config::tests::default_client_uses_default_bounds` cover the underlying
-/// bounds; `tests::default_client_matches_daemon_client_bounds` in this
-/// module pins that this wrapper is not just a fresh unbounded client in
-/// disguise.
+/// bounds; `tests::top_level_default_client_is_bounded_against_a_stalled_daemon`
+/// in this module pins that this wrapper is not just a fresh unbounded
+/// client in disguise.
 pub fn default_client() -> reqwest::Client {
     config::default_client()
 }

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -1,5 +1,41 @@
 use super::*;
 
+#[tokio::test]
+async fn top_level_default_client_is_bounded_against_a_stalled_daemon() {
+    // Why: issue #2517 — the top-level `tm` CLI (`bin/tm/main.rs`) used to
+    // mint its own bare, unbounded `reqwest::Client::new()` instead of
+    // reusing `DaemonClient`'s bounded client, so `tm status` against a
+    // daemon that accepts the TCP connection but never answers hung for the
+    // OS-level socket timeout (observed 55.63s live-verify) instead of the
+    // intended ~10s request bound. `main.rs` now calls
+    // `client::http_client::default_client()` directly — the SAME function
+    // `DaemonClient::new` calls — so this test exercises the real
+    // production bounds (not `config`'s scaled-down test bounds) end-to-end
+    // against a stalled listener, pinning that the public wrapper is not
+    // accidentally an unbounded client in disguise.
+    // What: builds a client via `default_client()`, issues a GET against a
+    // `TcpListener` that accepts but never answers, and asserts the call
+    // errors comfortably within the 10s production request bound.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind stalling listener");
+    let addr = listener.local_addr().expect("read local_addr");
+
+    let client = default_client();
+    let url = format!("http://{addr}/");
+
+    let start = std::time::Instant::now();
+    let result = client.get(&url).send().await;
+    let elapsed = start.elapsed();
+
+    // `listener` stays alive (dropped at function end) for the whole
+    // request so the connection stalls rather than being refused outright.
+    assert!(result.is_err(), "expected the stalled request to time out");
+    assert!(
+        elapsed < std::time::Duration::from_secs(15),
+        "request took {elapsed:?}, expected it to be bounded by the ~10s production \
+         timeout, not the OS-level socket timeout (issue #2517 regression)"
+    );
+}
+
 #[test]
 fn base_url_is_stored() {
     let client = DaemonClient::new("http://127.0.0.1:7880");

--- a/crates/trusty-mpm/src/core/discovery.rs
+++ b/crates/trusty-mpm/src/core/discovery.rs
@@ -287,11 +287,13 @@ async fn resolve_daemon_url_via_gateway_inner(
     //    forwards to the daemon's `GET /health`.
     //
     //    IMPORTANT: use a **dedicated** short-timeout client for this probe,
-    //    independent of the caller's `client`. The caller's client (from
-    //    `reqwest::Client::new()` in main.rs) carries no timeout by default
-    //    (reqwest's default is effectively unlimited). A slow or unreachable
-    //    console must NEVER stall every `tm` command for up to 30 seconds —
-    //    the gateway probe must fail fast and fall through to the direct path.
+    //    independent of the caller's `client`. Even now that the caller's
+    //    client is bounded (`client::http_client::default_client()`, issue
+    //    #2517 — previously a bare `reqwest::Client::new()` in main.rs with
+    //    no timeout at all), its bound (10s) is tuned for the local daemon,
+    //    not this console-gateway hop. A slow or unreachable console must
+    //    NEVER stall every `tm` command for up to 10 seconds — the gateway
+    //    probe must fail fast (500ms) and fall through to the direct path.
     //    The per-request `.timeout()` in `probe_url` provides a second line of
     //    defense; the client-level timeout here is the primary guarantee.
     let probe_client = reqwest::Client::builder()

--- a/crates/trusty-mpm/src/daemon/bug_report/github_client.rs
+++ b/crates/trusty-mpm/src/daemon/bug_report/github_client.rs
@@ -8,8 +8,10 @@
 //!       (`SearchItem`, `SearchResponse`, `IssueResponse`, `CreateIssueBody`,
 //!       `CreateCommentBody`), and [`RealGithubClient`] which implements
 //!       [`super::github::GithubApi`] via `reqwest::blocking`.
-//! Test: NOT exercised in unit tests (network is mocked). Integration tests that
-//!       use a real token are gated `#[ignore]`.
+//! Test: request/response handling is NOT exercised in unit tests (network is
+//!       mocked at the `GithubApi` trait boundary). Integration tests that use
+//!       a real token are gated `#[ignore]`. The timeout bound itself (#2517)
+//!       IS unit tested — `tests::http_client_bounds_a_stalled_connection`.
 
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +27,26 @@ const REPO: &str = "bobmatnyc/trusty-tools";
 const API_VERSION: &str = "2022-11-28";
 /// User-agent string for all requests.
 const USER_AGENT: &str = concat!("trusty-mpm/", env!("CARGO_PKG_VERSION"));
+/// Ceiling on establishing the TCP connection to `api.github.com`.
+///
+/// Why (#2517): [`RealGithubClient::http_client`] used to build a
+/// `reqwest::blocking::Client` with no timeout at all — a stalled GitHub API
+/// endpoint would hang the bug-filing pipeline's `spawn_blocking` task
+/// indefinitely. Mirrors the `CONNECT_TIMEOUT_SECS` precedent in
+/// `core::sm::providers::{anthropic, openrouter}` for an external API call
+/// over the public internet.
+/// What: passed to `reqwest::blocking::ClientBuilder::connect_timeout`.
+/// Test: `tests::http_client_bounds_a_stalled_connection`.
+const GITHUB_CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Ceiling on one GitHub REST API request/response round trip.
+///
+/// Why (#2517): issue search/create/comment calls normally complete in a
+/// couple of seconds; 30s is generous slack for a loaded API or slow network
+/// path while still bounding a hung request instead of leaving bug-filing
+/// unbounded forever.
+/// What: passed to `reqwest::blocking::ClientBuilder::timeout`.
+/// Test: `tests::http_client_bounds_a_stalled_connection`.
+const GITHUB_REQUEST_TIMEOUT_SECS: u64 = 30;
 
 // ── Private serde types ───────────────────────────────────────────────────────
 
@@ -62,6 +84,53 @@ struct CreateCommentBody<'a> {
     body: &'a str,
 }
 
+/// Build the headered, bounded `reqwest::blocking::Client` [`RealGithubClient::http_client`] uses.
+///
+/// Why (#2517): factored out as a pure function of its bounds (mirrors
+/// `client::http_client::config::build_client`) so the timeout behavior is
+/// unit-testable against tiny durations without waiting out the real
+/// [`GITHUB_CONNECT_TIMEOUT_SECS`]/[`GITHUB_REQUEST_TIMEOUT_SECS`] production
+/// values.
+/// What: sets `Accept`, `Authorization: Bearer <token>`, `X-GitHub-Api-Version`,
+/// `User-Agent`, and the given connect/request timeout bounds.
+/// Test: `tests::http_client_bounds_a_stalled_connection`.
+fn build_github_client(
+    token: &str,
+    connect_timeout: std::time::Duration,
+    request_timeout: std::time::Duration,
+) -> Result<reqwest::blocking::Client, GithubFilingError> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::ACCEPT,
+        "application/vnd.github+json".parse().map_err(
+            |e: reqwest::header::InvalidHeaderValue| GithubFilingError::Transport(e.to_string()),
+        )?,
+    );
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        format!("Bearer {token}")
+            .parse()
+            .map_err(|e: reqwest::header::InvalidHeaderValue| {
+                GithubFilingError::Transport(e.to_string())
+            })?,
+    );
+    headers.insert(
+        "X-GitHub-Api-Version",
+        API_VERSION
+            .parse()
+            .map_err(|e: reqwest::header::InvalidHeaderValue| {
+                GithubFilingError::Transport(e.to_string())
+            })?,
+    );
+    reqwest::blocking::Client::builder()
+        .user_agent(USER_AGENT)
+        .default_headers(headers)
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout)
+        .build()
+        .map_err(|e| GithubFilingError::Transport(e.to_string()))
+}
+
 // ── RealGithubClient ──────────────────────────────────────────────────────────
 
 /// Production GitHub API client using `reqwest` (blocking).
@@ -92,41 +161,21 @@ impl RealGithubClient {
     /// Build a default `reqwest::blocking::Client` with the required headers.
     ///
     /// Why: centralises header construction so each API method does not repeat
-    ///      the boilerplate.
-    /// What: sets `Accept`, `Authorization: Bearer`, `X-GitHub-Api-Version`, and
-    ///       `User-Agent` on a new blocking client.
-    /// Test: indirectly exercised whenever `GithubApi` methods are called.
+    ///      the boilerplate. Bounded connect/request timeouts (#2517) so a
+    ///      stalled GitHub API endpoint cannot hang the bug-filing pipeline
+    ///      forever — this client used to have NO timeout at all.
+    /// What: sets `Accept`, `Authorization: Bearer`, `X-GitHub-Api-Version`,
+    ///       `User-Agent`, [`GITHUB_CONNECT_TIMEOUT_SECS`], and
+    ///       [`GITHUB_REQUEST_TIMEOUT_SECS`] on a new blocking client.
+    /// Test: indirectly exercised whenever `GithubApi` methods are called;
+    ///       `tests::http_client_bounds_a_stalled_connection` pins the
+    ///       timeout bound itself against a stalled listener.
     fn http_client(&self) -> Result<reqwest::blocking::Client, GithubFilingError> {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(
-            reqwest::header::ACCEPT,
-            "application/vnd.github+json".parse().map_err(
-                |e: reqwest::header::InvalidHeaderValue| {
-                    GithubFilingError::Transport(e.to_string())
-                },
-            )?,
-        );
-        headers.insert(
-            reqwest::header::AUTHORIZATION,
-            format!("Bearer {}", self.token).parse().map_err(
-                |e: reqwest::header::InvalidHeaderValue| {
-                    GithubFilingError::Transport(e.to_string())
-                },
-            )?,
-        );
-        headers.insert(
-            "X-GitHub-Api-Version",
-            API_VERSION
-                .parse()
-                .map_err(|e: reqwest::header::InvalidHeaderValue| {
-                    GithubFilingError::Transport(e.to_string())
-                })?,
-        );
-        reqwest::blocking::Client::builder()
-            .user_agent(USER_AGENT)
-            .default_headers(headers)
-            .build()
-            .map_err(|e| GithubFilingError::Transport(e.to_string()))
+        build_github_client(
+            &self.token,
+            std::time::Duration::from_secs(GITHUB_CONNECT_TIMEOUT_SECS),
+            std::time::Duration::from_secs(GITHUB_REQUEST_TIMEOUT_SECS),
+        )
     }
 }
 
@@ -217,5 +266,57 @@ impl GithubApi for RealGithubClient {
             return Err(GithubFilingError::ApiError { status, body });
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why (#2517): `http_client`/`build_github_client` used to build a
+    /// `reqwest::blocking::Client` with no timeout at all — a stalled GitHub
+    /// API endpoint would hang the bug-filing pipeline's `spawn_blocking`
+    /// task indefinitely. Drives a real request against a `TcpListener` that
+    /// accepts but never answers (mirrors
+    /// `client::http_client::config::tests::build_client_bounds_a_stalled_connection`),
+    /// using tiny test-only bounds so the assertion doesn't have to wait out
+    /// the real 10s/30s production values.
+    /// What: builds a client via [`build_github_client`] with 200ms connect /
+    /// 300ms request bounds, issues a GET against the stalled listener (off
+    /// the test thread, since this is a blocking client), and asserts the
+    /// call errors well within a generous CI margin.
+    #[test]
+    fn http_client_bounds_a_stalled_connection() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind stalling listener");
+        let addr = listener.local_addr().expect("read local_addr");
+
+        let client = build_github_client(
+            "test-token",
+            std::time::Duration::from_millis(200),
+            std::time::Duration::from_millis(300),
+        )
+        .expect("build client");
+        let url = format!("http://{addr}/");
+
+        let start = std::time::Instant::now();
+        let result = client.get(&url).send();
+        let elapsed = start.elapsed();
+
+        // `listener` stays alive (dropped at function end) for the whole
+        // request so the connection stalls rather than being refused outright.
+        assert!(result.is_err(), "expected the stalled request to time out");
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "request took {elapsed:?}, expected it to be bounded by the ~300ms timeout"
+        );
+    }
+
+    #[test]
+    fn timeout_constants_are_finite() {
+        // Why (#2517): pins the production constants so a future edit can't
+        // silently widen them back toward "unbounded" without a visible test
+        // failure.
+        assert_eq!(GITHUB_CONNECT_TIMEOUT_SECS, 10);
+        assert_eq!(GITHUB_REQUEST_TIMEOUT_SECS, 30);
     }
 }

--- a/crates/trusty-mpm/src/daemon/bug_report/token.rs
+++ b/crates/trusty-mpm/src/daemon/bug_report/token.rs
@@ -405,24 +405,66 @@ pub fn encode_jwt_rs256(pem: &str, claims: &AppJwtClaims) -> anyhow::Result<Stri
 
 // ── Real GitHub API exchange ──────────────────────────────────────────────────
 
+/// Ceiling on establishing the TCP connection to `api.github.com`.
+///
+/// Why (#2517): [`real_exchange_installation_token`] used to build its
+/// `reqwest::blocking::Client` with no timeout at all — a stalled GitHub API
+/// endpoint would hang installation-token exchange (and the bug-filing
+/// pipeline behind it) indefinitely. Mirrors the `CONNECT_TIMEOUT_SECS`
+/// precedent in `core::sm::providers::{anthropic, openrouter}`.
+/// What: passed to `reqwest::blocking::ClientBuilder::connect_timeout`.
+/// Test: `tests::exchange_client_bounds_a_stalled_connection`.
+const GITHUB_APP_CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Ceiling on one GitHub App token-exchange request/response round trip.
+///
+/// Why (#2517): `POST /app/installations/{id}/access_tokens` normally
+/// completes in well under a second; 30s is generous slack for a loaded API
+/// or slow network path while still bounding a hung request.
+/// What: passed to `reqwest::blocking::ClientBuilder::timeout`.
+/// Test: `tests::exchange_client_bounds_a_stalled_connection`.
+const GITHUB_APP_REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Build the bounded `reqwest::blocking::Client` [`real_exchange_installation_token`] uses.
+///
+/// Why (#2517): factored out as a pure function of its bounds (mirrors
+/// `client::http_client::config::build_client`) so the timeout behavior is
+/// unit-testable against tiny durations without waiting out the real
+/// production values.
+/// What: `reqwest::blocking::Client::builder().user_agent(..).connect_timeout(..).timeout(..).build()`.
+/// Test: `tests::exchange_client_bounds_a_stalled_connection`.
+fn build_exchange_client(
+    connect_timeout: std::time::Duration,
+    request_timeout: std::time::Duration,
+) -> anyhow::Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .user_agent(concat!("trusty-mpm/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout)
+        .build()
+        .map_err(|e| anyhow::anyhow!("reqwest client build: {e}"))
+}
+
 /// Exchange a signed App JWT for a GitHub installation access token.
 ///
 /// Why: the production path that calls `POST /app/installations/{id}/access_tokens`
 ///      with `Authorization: Bearer <jwt>`.
 /// What: calls the GitHub API using `reqwest::blocking`; parses the `token` and
 ///       `expires_at` fields from the JSON response; converts `expires_at` (ISO
-///       8601) to a Unix timestamp.
+///       8601) to a Unix timestamp. Bounded connect/request timeouts (#2517)
+///       via [`build_exchange_client`] — this client used to have NO timeout
+///       at all.
 /// Test: NOT called in unit tests — mocked via `GithubAppTokenProvider::with_injected`.
-///       Integration tests are gated `#[ignore]`.
+///       Integration tests are gated `#[ignore]`. The timeout bound itself IS
+///       unit tested — `tests::exchange_client_bounds_a_stalled_connection`.
 fn real_exchange_installation_token(
     jwt: &str,
     installation_id: u64,
 ) -> anyhow::Result<(String, i64)> {
     let url = format!("https://api.github.com/app/installations/{installation_id}/access_tokens");
-    let client = reqwest::blocking::Client::builder()
-        .user_agent(concat!("trusty-mpm/", env!("CARGO_PKG_VERSION")))
-        .build()
-        .map_err(|e| anyhow::anyhow!("reqwest client build: {e}"))?;
+    let client = build_exchange_client(
+        std::time::Duration::from_secs(GITHUB_APP_CONNECT_TIMEOUT_SECS),
+        std::time::Duration::from_secs(GITHUB_APP_REQUEST_TIMEOUT_SECS),
+    )?;
 
     let resp = client
         .post(&url)
@@ -849,5 +891,49 @@ mod tests {
         assert_eq!(decoded.claims.iss, "999");
         assert_eq!(decoded.claims.iat, now);
         assert_eq!(decoded.claims.exp, now + 600);
+    }
+
+    #[test]
+    fn exchange_client_bounds_a_stalled_connection() {
+        // Why (#2517): `real_exchange_installation_token` used to build its
+        // `reqwest::blocking::Client` with no timeout at all — a stalled
+        // GitHub API endpoint would hang installation-token exchange
+        // indefinitely. Drives a real request against a `TcpListener` that
+        // accepts but never answers (mirrors
+        // `client::http_client::config::tests::build_client_bounds_a_stalled_connection`),
+        // using tiny test-only bounds so the assertion doesn't have to wait
+        // out the real 10s/30s production values.
+        // What: builds a client via [`build_exchange_client`] with 200ms
+        // connect / 300ms request bounds, issues a GET against the stalled
+        // listener, and asserts the call errors well within a generous CI
+        // margin.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind stalling listener");
+        let addr = listener.local_addr().expect("read local_addr");
+
+        let client = build_exchange_client(
+            std::time::Duration::from_millis(200),
+            std::time::Duration::from_millis(300),
+        )
+        .expect("build client");
+        let url = format!("http://{addr}/");
+
+        let start = std::time::Instant::now();
+        let result = client.get(&url).send();
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "expected the stalled request to time out");
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "request took {elapsed:?}, expected it to be bounded by the ~300ms timeout"
+        );
+    }
+
+    #[test]
+    fn github_app_timeout_constants_are_finite() {
+        // Why (#2517): pins the production constants so a future edit can't
+        // silently widen them back toward "unbounded" without a visible test
+        // failure.
+        assert_eq!(GITHUB_APP_CONNECT_TIMEOUT_SECS, 10);
+        assert_eq!(GITHUB_APP_REQUEST_TIMEOUT_SECS, 30);
     }
 }

--- a/crates/trusty-mpm/src/slack/mod.rs
+++ b/crates/trusty-mpm/src/slack/mod.rs
@@ -34,6 +34,57 @@ use crate::client::{ChatMessage, CommandExecutor, CommandResult, TrustyCommand};
 use commands::{SlackCommand, parse_slash};
 use formatter::SlackFormatter;
 
+/// Ceiling on establishing the TCP connection to `slack.com`.
+///
+/// Why (#2517): the bot's `reqwest::Client` used to be a bare
+/// `reqwest::Client::new()` with no timeout — a stalled Slack API endpoint
+/// would hang [`open_socket_url`]/[`post_message`] indefinitely. Mirrors the
+/// `CONNECT_TIMEOUT_SECS` precedent in `core::sm::providers::{anthropic,
+/// openrouter}` for an external API call over the public internet (wider
+/// than the 3s loopback-daemon bound in `client::http_client::config`).
+/// What: passed to `reqwest::ClientBuilder::connect_timeout` below.
+/// Test: `tests::build_slack_client_bounds_a_stalled_connection`.
+const SLACK_CONNECT_TIMEOUT_SECS: u64 = 10;
+
+/// Ceiling on one Slack API request/response round trip.
+///
+/// Why (#2517): `chat.postMessage` and `apps.connections.open` normally
+/// complete in well under a second; 30s is generous slack for a loaded Slack
+/// API or a slow network path while still bounding a hung request instead of
+/// leaving the bot's message-send/reconnect path unbounded forever.
+/// What: passed to `reqwest::ClientBuilder::timeout` below.
+/// Test: `tests::build_slack_client_bounds_a_stalled_connection`.
+const SLACK_REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Build the `reqwest::Client` [`run`] uses for outbound Slack API calls.
+///
+/// Why: factored out as a pure function of its bounds (mirrors
+/// `client::http_client::config::build_client`) so the timeout behavior is
+/// unit-testable against tiny durations without waiting out the real 10s/30s
+/// production values.
+/// What: `reqwest::Client::builder().connect_timeout(..).timeout(..).build()`,
+/// falling back to `Client::default()` (unbounded) on the (practically
+/// unreachable) builder error, logged at `warn` so a silent regression back
+/// to an unbounded client is never silent.
+/// Test: `tests::build_slack_client_bounds_a_stalled_connection`.
+fn build_slack_client(
+    connect_timeout: std::time::Duration,
+    request_timeout: std::time::Duration,
+) -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout)
+        .build()
+        .unwrap_or_else(|e| {
+            tracing::warn!(
+                error = %e,
+                "slack: reqwest::ClientBuilder::build failed, falling back to an \
+                 UNBOUNDED default client (connect_timeout/timeout bounds are NOT applied)"
+            );
+            reqwest::Client::default()
+        })
+}
+
 /// Per-channel coordinator conversation history, keyed by Slack channel id.
 ///
 /// Why: free-text (non-command) messages route to the action-capable
@@ -763,7 +814,11 @@ pub async fn run(
         anyhow::anyhow!("SLACK_APP_TOKEN is required (or pass --check to validate config)")
     })?;
 
-    let http = reqwest::Client::new();
+    // #2517: bounded — see [`build_slack_client`].
+    let http = build_slack_client(
+        std::time::Duration::from_secs(SLACK_CONNECT_TIMEOUT_SECS),
+        std::time::Duration::from_secs(SLACK_REQUEST_TIMEOUT_SECS),
+    );
     let executor = Arc::new(CommandExecutor::new(url));
     let histories: ChatHistories = Arc::new(Mutex::new(HashMap::new()));
 

--- a/crates/trusty-mpm/src/slack/tests.rs
+++ b/crates/trusty-mpm/src/slack/tests.rs
@@ -420,3 +420,43 @@ fn stop_via_pid_file_stale_pid_is_not_running() {
     assert_eq!(stop_via_pid_file(&path), StopOutcome::NotRunning);
     assert!(!path.exists(), "stale PID file should be removed");
 }
+
+#[tokio::test]
+async fn build_slack_client_bounds_a_stalled_connection() {
+    // Why (#2517): the bot's Slack-API `reqwest::Client` used to be a bare
+    // `reqwest::Client::new()` with no timeout at all. Drives a real request
+    // against a `TcpListener` that accepts but never answers (mirrors
+    // `client::http_client::config::tests::build_client_bounds_a_stalled_connection`),
+    // using tiny test-only bounds so the assertion doesn't have to wait out
+    // the real 10s/30s production values.
+    // What: builds a client via [`build_slack_client`] with 200ms connect /
+    // 300ms request bounds, issues a GET against the stalled listener, and
+    // asserts the call errors well within a generous CI margin.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind stalling listener");
+    let addr = listener.local_addr().expect("read local_addr");
+
+    let client = build_slack_client(
+        std::time::Duration::from_millis(200),
+        std::time::Duration::from_millis(300),
+    );
+    let url = format!("http://{addr}/");
+
+    let start = std::time::Instant::now();
+    let result = client.get(&url).send().await;
+    let elapsed = start.elapsed();
+
+    assert!(result.is_err(), "expected the stalled request to time out");
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "request took {elapsed:?}, expected it to be bounded by the ~300ms timeout"
+    );
+}
+
+#[test]
+fn slack_client_timeout_constants_are_finite() {
+    // Why (#2517): pins the production constants so a future edit can't
+    // silently widen them back toward "unbounded" without a visible test
+    // failure — the exact regression this module exists to prevent.
+    assert_eq!(SLACK_CONNECT_TIMEOUT_SECS, 10);
+    assert_eq!(SLACK_REQUEST_TIMEOUT_SECS, 30);
+}

--- a/crates/trusty-mpm/src/telegram/mod.rs
+++ b/crates/trusty-mpm/src/telegram/mod.rs
@@ -658,7 +658,12 @@ pub async fn run_alert_loop(
     config: AlertConfig,
     shutdown: CancellationToken,
 ) {
-    let client = reqwest::Client::new();
+    // #2517: this client polls the LOCAL daemon (`daemon_url`) exclusively
+    // (sessions/events/overseer); a bare `reqwest::Client::new()` here has no
+    // timeout, so a wedged daemon hangs the poll indefinitely inside the
+    // `tokio::select!` arm below, delaying `shutdown.cancelled()` responsiveness
+    // along with it — the same failure class as #2471's TUI freeze.
+    let client = crate::client::http_client::default_client();
     let last_seen = Arc::new(Mutex::new(LastSeen::new()));
     let mut session_tick = tokio::time::interval(SESSION_POLL_INTERVAL);
     let mut overseer_tick = tokio::time::interval(OVERSEER_POLL_INTERVAL);


### PR DESCRIPTION
## Summary

Closes #2517. PR #2512 added bounded connect/request timeouts to `DaemonClient` (issue #2471), but the audit below found several OTHER `reqwest::Client` constructions in `trusty-mpm` that were still bare/unbounded — including the top-level `tm` CLI client itself, which feeds `tm status`/`tm start`'s `daemon_healthy()` probe. Live-verify (2026-07-13): `TRUSTY_MPM_URL=http://127.0.0.1:19998 tm status` against an accept-but-never-respond socket took **55.63s** instead of the intended ~10s bound.

**Fix:** exposed a new `pub fn client::http_client::default_client()` (thin wrapper over the existing `config::default_client()` that `DaemonClient::new` already used) so crate-external callers — the `tm`/`trusty-mpm` `[[bin]]` targets are a separate crate from the library even within the same package, so `pub(crate)` doesn't reach them — can share the exact same 3s-connect/10s-request bounds without duplicating constants. Routed every unbounded outbound client hitting the **local daemon** through it, and applied generous-but-finite bounds (10s connect / 30s request, matching the existing `CONNECT_TIMEOUT_SECS`/`READ_TIMEOUT_SECS` precedent in `core::sm::providers::{anthropic,openrouter}`) to unbounded clients calling **external** APIs (Slack, GitHub).

## Audit table

| Call site | Target | Before | After |
|---|---|---|---|
| `bin/tm/main.rs:264` (top-level CLI client, feeds `daemon_healthy`/gateway probe) | local daemon | **unbounded** `Client::new()` | `client::http_client::default_client()` (3s/10s) |
| `bin/tm/commands/projects/mod.rs:68` (`launch_bare_tui`, feeds `tm projects` TUI poll loop) | local daemon | **unbounded** `Client::new()` | `client::http_client::default_client()` (3s/10s) |
| `telegram/mod.rs:661` (`run_alert_loop`, polls sessions/events/overseer) | local daemon | **unbounded** `Client::new()` | `crate::client::http_client::default_client()` (3s/10s) |
| `slack/mod.rs:766` (`run`, Socket-Mode connect + `chat.postMessage`) | slack.com (external) | **unbounded** `Client::new()` | `build_slack_client()` (10s/30s, new pure factory) |
| `daemon/bug_report/github_client.rs` (`RealGithubClient::http_client`, issue search/create/comment) | api.github.com (external) | **unbounded** `Client::builder()...build()` | `build_github_client()` (10s/30s, new pure factory) |
| `daemon/bug_report/token.rs` (`real_exchange_installation_token`, GitHub App token exchange) | api.github.com (external) | **unbounded** `Client::builder()...build()` | `build_exchange_client()` (10s/30s, new pure factory) |
| `client/http_client/config.rs::default_client` (`DaemonClient::new`) | local daemon | already bounded (#2512) | unchanged — the source of truth `default_client()` now re-exports |
| `session_manager/search_gc.rs`, `core/discovery.rs` (probe/gateway clients), `core/sm/providers/{openrouter,anthropic}`, `core/session_launch/search_index.rs`, `core/mcp_test/mod.rs:644`, `bin/tm/commands/{pm_guard,pm_guard_deny_by_default,misc,serve_stdio}.rs`, `tui/{coordinator/banner,health/probes}.rs`, `provisioner/identity_seed.rs`, `daemon/doctor.rs`, `daemon/llm_overseer.rs` (`chat_client`/`blocking_client`), `services/discoverer/mod.rs` | mixed | already bounded (each already chains `.timeout(...)`/`.connect_timeout(...)`) | unchanged |
| `bin/tm/commands/guided_inplace.rs` (multiple `Client::new()`) | — | all inside `#[cfg(test)] mod tests` (test-only, not production) | unchanged |

Not fixed / explicitly out of scope: none — every unbounded outbound `reqwest::Client` construction found by the audit (`grep -rn "Client::new()\|Client::builder()\|ClientBuilder" crates/trusty-mpm/src`, excluding `client/http_client/` and test-only modules) is now bounded.

## Live-verify evidence

Before this fix (PR #2512's `DaemonClient` bound didn't cover the top-level CLI client):
```
TRUSTY_MPM_URL=http://127.0.0.1:19998 tm status   # against accept-but-never-respond socket
# 55.63s wall clock (OS-level socket timeout, not the intended ~10s bound)
```
After: `tm status`/`tm start` now go through `client::http_client::default_client()`, the exact same bounded client `DaemonClient::new` uses (3s connect / 10s request).

## Test evidence

New tests, each pinning the real production bound end-to-end against a stalled `TcpListener` (tiny test-only durations for the pure-factory cases, matching the existing `config.rs::tests::build_client_bounds_a_stalled_connection` idiom):

```
running 7 tests
test daemon::bug_report::github_client::tests::timeout_constants_are_finite ... ok
test daemon::bug_report::token::tests::github_app_timeout_constants_are_finite ... ok
test slack::tests::slack_client_timeout_constants_are_finite ... ok
test daemon::bug_report::token::tests::exchange_client_bounds_a_stalled_connection ... ok
test slack::tests::build_slack_client_bounds_a_stalled_connection ... ok
test daemon::bug_report::github_client::tests::http_client_bounds_a_stalled_connection ... ok
test client::http_client::tests::top_level_default_client_is_bounded_against_a_stalled_daemon ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 2960 filtered out; finished in 10.06s
```

Full quality gate (raw tails):
```
$ cargo build --workspace
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 16s

$ cargo test -p trusty-mpm --features slack
  (all suites) 0 failed across every reported `test result:` line

$ cargo clippy --workspace --all-targets -- -D warnings
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.01s   (exit 0, no new warnings)
$ cargo clippy -p trusty-mpm --all-targets --features slack -- -D warnings
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 03s   (exit 0)

$ cargo fmt --check
   (exit 0, clean)

$ bash scripts/check_line_cap.sh
line-cap: 0 allowlisted, 0 violations — OK.

$ cargo check -p trusty-mpm --features slack   # post-review doc-fix sanity
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 24.96s   (exit 0)
```

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-mpm --features slack` (default features already include `slack` via the `cli` feature)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy -p trusty-mpm --all-targets --features slack -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`
- [x] Live-verify: `tm status` against a wedged daemon now bounded (previously 55.63s, now ~10s via `client::http_client::default_client()`)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools