### PR TITLE
chore: bump trusty-embedderd 0.3.8 + trusty-search 0.32.4 for crates.io publish (#2222)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6284,7 +6284,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10975,7 +10975,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-embedderd"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -11199,7 +11199,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.32.3"
+version = "0.32.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.2.1"
 trusty-common = { path = "crates/trusty-common", version = "0.22.4" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
-trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.7" }
+trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.8" }
 # trusty-bm25-daemon: per-palace BM25 lexical-index daemon — referenced by
 # trusty-memory so `cargo install trusty-memory` produces both binaries from
 # one command (mirrors the trusty-embedderd / trusty-search pattern, PR #190).

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -49,7 +49,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.19.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.32.2" }
+trusty-search = { path = "../trusty-search", version = "0.32.4" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-embedderd/CHANGELOG.md
+++ b/crates/trusty-embedderd/CHANGELOG.md
@@ -1,3 +1,29 @@
+# Changelog
+
+All notable changes are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+## [0.3.8] — 2026-07-13
+
+### Fixed
+
+- AL2023 close-out — CI gate + startup glibc probe + docs (refs #2222) ([#2525](https://github.com/bobmatnyc/trusty-tools/pull/2525)) ([`db59ebe`](https://github.com/bobmatnyc/trusty-tools/commit/db59ebeb4a4a5148f57ac7a47243247c3bd8c337))
+
+  `bundled-ort` was hardcoded unconditionally in `[dependencies]`, so Cargo
+  feature unification pulled the glibc-2.38-bound static ORT libs into any
+  build regardless of `--features load-dynamic` passed to `trusty-search`.
+  It is now gated behind this crate's own `bundled-ort` Cargo feature
+  (still on by default — no runtime behavior change for existing installs).
+  Also adds a fast startup glibc-version probe on Linux/glibc builds that
+  fails loudly before the 180s ORT-init timeout when the host is below the
+  glibc 2.38 floor.
+
+### Documentation (carried from prior Unreleased entry)
+
+- add missing package metadata to 7 crates ([#2293](https://github.com/bobmatnyc/trusty-tools/pull/2293)) ([`ee58b6a`](https://github.com/bobmatnyc/trusty-tools/commit/ee58b6a4ae01e1338e4761aaa5c27053c49f192b))
+
 # Changelog — trusty-embedderd
 
 ## [0.3.7] — 2026-07-09

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-embedderd"
-version = "0.3.7"
+version = "0.3.8"
 publish = true
 edition = "2021"
 license.workspace = true

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [0.32.4] — 2026-07-13
+
+Note: `trusty-search-v0.32.3` was published without a corresponding git tag,
+so `git-cliff`'s `--unreleased` window (scoped to the `trusty-search-v*` tag
+series) walked all the way back to `trusty-search-v0.32.2`. This section
+therefore includes commits already shipped in 0.32.3 in addition to the
+actual new content for this release — the AL2023 CI-gate / glibc-probe fix
+(#2525, refs #2222). Tag `trusty-search-v0.32.4` when publishing to close
+this gap going forward.
+
+### Added
+
+- credential resolver + secure KeyStore (closes #2401) ([#2427](https://github.com/bobmatnyc/trusty-tools/pull/2427)) ([`98d0eb9`](https://github.com/bobmatnyc/trusty-tools/commit/98d0eb993cdaf640842761aaf9299d7013d2ee01))
+- add follow_links symlink policy to indexer ([#2355](https://github.com/bobmatnyc/trusty-tools/pull/2355)) ([`4b95ccc`](https://github.com/bobmatnyc/trusty-tools/commit/4b95ccc45662cdce87367dc708d2a0dbec4a7a09))
+
+### Fixed
+
+- AL2023 close-out — CI gate + startup glibc probe + docs (refs #2222) ([#2525](https://github.com/bobmatnyc/trusty-tools/pull/2525)) ([`db59ebe`](https://github.com/bobmatnyc/trusty-tools/commit/db59ebeb4a4a5148f57ac7a47243247c3bd8c337))
+- index-registry integrity — runtime collision guard + dedup follow-ups (closes #2336, #2337) ([#2519](https://github.com/bobmatnyc/trusty-tools/pull/2519)) ([`1c609cf`](https://github.com/bobmatnyc/trusty-tools/commit/1c609cfbae2d9ca12ca22ab06d90c2cb449bba8f))
+- launchd-aware bridge no-spawn + /health supervised flag (closes #2486) ([#2491](https://github.com/bobmatnyc/trusty-tools/pull/2491)) ([`e993c18`](https://github.com/bobmatnyc/trusty-tools/commit/e993c18ace1fe9a86f4b5315be7887ed767da710))
+- dedup warm-boot entries sharing one redb corpus path (closes #2305) ([#2335](https://github.com/bobmatnyc/trusty-tools/pull/2335)) ([`f0a48cc`](https://github.com/bobmatnyc/trusty-tools/commit/f0a48cc127b8631bc4297a8f7574392b02d5cec2))
+- enable embedder idle-shutdown by default and guard in-flight requests (closes #2315) ([#2320](https://github.com/bobmatnyc/trusty-tools/pull/2320)) ([`0531e9d`](https://github.com/bobmatnyc/trusty-tools/commit/0531e9d944918b1b6eb408dc2c3c08d5e90bd746))
+- warm-boot health reports degraded when corpus fails to open (closes #1870) ([#2307](https://github.com/bobmatnyc/trusty-tools/pull/2307)) ([`9c3e88f`](https://github.com/bobmatnyc/trusty-tools/commit/9c3e88f652ec03a7ee03a266e85862c9c15ac03a))
+- return doc hits for Unknown-intent queries instead of empty (Closes #2203) ([#2287](https://github.com/bobmatnyc/trusty-tools/pull/2287)) ([`89ea057`](https://github.com/bobmatnyc/trusty-tools/commit/89ea05763330a56beb4b90876f27c7c3a5b7f6af))
+
+### Changed
+
+- split 3 files under SLOC caps ([#1195](https://github.com/bobmatnyc/trusty-tools/pull/1195)) ([#2289](https://github.com/bobmatnyc/trusty-tools/pull/2289)) ([`60a58e3`](https://github.com/bobmatnyc/trusty-tools/commit/60a58e326c23b211f93b36d50c603982593e1bb1))
+- split doctor_checks/ruby/review under 500-SLOC cap ([#1195](https://github.com/bobmatnyc/trusty-tools/pull/1195)) ([#2283](https://github.com/bobmatnyc/trusty-tools/pull/2283)) ([`eeabe56`](https://github.com/bobmatnyc/trusty-tools/commit/eeabe562c20172c8b6f4c9d63618a4bcd8838868))
+- release trusty-common 0.22.2 + trusty-mpm 0.19.1 ([#2241](https://github.com/bobmatnyc/trusty-tools/pull/2241)) ([`f7ab5f4`](https://github.com/bobmatnyc/trusty-tools/commit/f7ab5f43c8a5cc41ed4d821e2a53800974e74207))
+
+### Documentation
+
+- add trusty-mpm package metadata + repoint trusty-search CI badge to monorepo ([#2292](https://github.com/bobmatnyc/trusty-tools/pull/2292)) ([`cba43a5`](https://github.com/bobmatnyc/trusty-tools/commit/cba43a5698c03ea611f731b6a5bef0809547a93f))
 
 ## [0.32.3] — 2026-07-09
 

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.32.3"
+version = "0.32.4"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -78,7 +78,7 @@ trusty-common = { version = "0.22.2", default-features = false, features = ["axu
 # glibc-2.38-bound bundled ORT libs into the bundled trusty-embedderd binary.
 # The `bundled-ort`/`load-dynamic`/`cuda` features below forward this crate's
 # own ORT-mode selection down to `trusty-embedderd/*` explicitly.
-trusty-embedderd = { path = "../trusty-embedderd", version = "0.3.7", default-features = false, features = [
+trusty-embedderd = { path = "../trusty-embedderd", version = "0.3.8", default-features = false, features = [
     "http-server",
 ] }
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console


### PR DESCRIPTION
## Summary

Version-bump-and-ship leg for #2222. The underlying code fix (glibc probe + `bundled-ort`/`load-dynamic` feature-gating for the bundled `trusty-embedderd` binary) already landed on main via #2525 — this PR only bumps versions and fixes a dependency pin so the fix can be published to crates.io.

- **trusty-embedderd 0.3.7 → 0.3.8 (patch)** — carries #2525's fix (`bundled-ort` now gated behind this crate's own Cargo feature instead of being hardcoded, plus the fast startup glibc-version probe). No public API change, bug-fix only → patch.
- **trusty-search 0.32.3 → 0.32.4 (patch)** — carries #2525's fix (forwards its own `bundled-ort`/`load-dynamic`/`cuda` selection down to the bundled `trusty-embedderd` binary explicitly) plus everything merged since the last *tagged* release (`trusty-search-v0.32.2`; note `0.32.3` was published without a corresponding tag — see CHANGELOG note). No public API break → patch.
- **Pin-drift fix**: `crates/trusty-agents/Cargo.toml` pinned `trusty-search = "0.32.2"` (already stale vs. the published 0.32.3) → bumped to `"0.32.4"`. Root `Cargo.toml` and `crates/trusty-search/Cargo.toml`'s `trusty-embedderd` pins bumped `0.3.7` → `0.3.8` to match.

## Quality gates (all green from a dedicated worktree off `origin/main`)

- `cargo build --workspace` — clean
- `cargo test -p trusty-embedderd` — 26 + 4 passed, 0 failed
- `cargo test -p trusty-search` — 1049 passed, 1 flaky pre-existing timing test unrelated to this change (`probe_all_volumes_multi_volume_no_fast_starvation`, confirmed present/flaky on unmodified `warm_boot/probe` code, not touched by this PR)
- `cargo test -p trusty-agents` — 1783 + 6 + 4 + 2 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations

`scripts/check-publish-ready.sh` correctly refuses pre-merge (no pushed tag yet, per issue #2227's publish-only-from-merged-main guard) — expected at this stage, not a failure.

## Test plan

- [x] Quality gates above, raw output captured
- [ ] Phase 2 (human-authorized, post-merge): tag + push + `cargo publish` in dependency order (embedderd before search)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools