### PR TITLE
chore(trusty-common): bump 0.22.4 → 0.22.5 to publish config-cli feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6284,7 +6284,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10859,7 +10859,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- universal config keys CLI module (set/list/test/unset) ([#2518](https://github.com/bobmatnyc/trusty-tools/pull/2518)) ([`17f0aa9`](https://github.com/bobmatnyc/trusty-tools/commit/17f0aa950bb0ed71c5364e1b55b1dc0503e4c0b2))
+- route together/* models through the shared Together adapter ([#2495](https://github.com/bobmatnyc/trusty-tools/pull/2495)) ([`2bdfccf`](https://github.com/bobmatnyc/trusty-tools/commit/2bdfccfa65c7a5c34cd325b88e3ce78ba4c3c427))
+- add Together.ai as an OpenAI-compat inference provider ([#2490](https://github.com/bobmatnyc/trusty-tools/pull/2490)) ([`98405bb`](https://github.com/bobmatnyc/trusty-tools/commit/98405bbaada82f62bb59805d54f3a9cd0f35236e))
+- OpenAI-compat adapter core + OpenRouter + Fireworks adapters ([#2482](https://github.com/bobmatnyc/trusty-tools/pull/2482)) ([`3101b36`](https://github.com/bobmatnyc/trusty-tools/commit/3101b36e452fca82a275368a1eb0a2a9e9b1c5fe))
+- inference foundation — types, InferenceAdapter trait, capability registry, configurator ([#2478](https://github.com/bobmatnyc/trusty-tools/pull/2478)) ([`e5d71f0`](https://github.com/bobmatnyc/trusty-tools/commit/e5d71f075e480c6714a39bd6bec8212e22c70347))
+- credential resolver + secure KeyStore (closes #2401) ([#2427](https://github.com/bobmatnyc/trusty-tools/pull/2427)) ([`98d0eb9`](https://github.com/bobmatnyc/trusty-tools/commit/98d0eb993cdaf640842761aaf9299d7013d2ee01))
+- fading-memories resurface pass in dream cycle ([#2353](https://github.com/bobmatnyc/trusty-tools/pull/2353)) ([`4dbc0c2`](https://github.com/bobmatnyc/trusty-tools/commit/4dbc0c235043b78159b4a24960259242dc215651))
+
+### Fixed
+
+- force:true honors its contract + secret/blocklist heuristics stop over-matching (closes #2442) ([#2520](https://github.com/bobmatnyc/trusty-tools/pull/2520)) ([`2671f10`](https://github.com/bobmatnyc/trusty-tools/commit/2671f107b256c353940e793e65eb947b99acb4d1))
+- launchd-aware bridge no-spawn + /health supervised flag (closes #2486) ([#2491](https://github.com/bobmatnyc/trusty-tools/pull/2491)) ([`e993c18`](https://github.com/bobmatnyc/trusty-tools/commit/e993c18ace1fe9a86f4b5315be7887ed767da710))
+
+### Changed
+
+- mount config command on all 10 primary binaries ([#2528](https://github.com/bobmatnyc/trusty-tools/pull/2528)) ([`a58ea52`](https://github.com/bobmatnyc/trusty-tools/commit/a58ea5223167553f0d90fb5258d582d510dca316))
+## [Unreleased]
+
 ### Fixed
 
 - idle-to-disk palace eviction + unpin dream scheduler + configurable max-open ([#2276](https://github.com/bobmatnyc/trusty-tools/pull/2276)) ([`0e8e504`](https://github.com/bobmatnyc/trusty-tools/commit/0e8e50440cea09a8f5eedf2c7bba9613f96cd8a8))

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.22.4"
+version = "0.22.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- The published `trusty-common@0.22.4` on crates.io is **missing** the `config-cli` Cargo feature: PR #2518 (commit `17f0aa95`) added `config-cli = ["inference-client", "dep:clap", "dep:rpassword"]` to `crates/trusty-common/Cargo.toml`'s `[features]` block but never bumped the package version, so the tagged/published 0.22.4 predates the feature.
- Three more feature-adding PRs landed on `crates/trusty-common/Cargo.toml` after the `trusty-common-v0.22.4` tag without a version bump: #2427 (`credentials`), #2478 (`inference-client` foundation), #2482 (adapter core), and finally #2518 (`config-cli`). PR #2528 then mounted `config-cli` on all 10 primary binaries' manifests — all of which now require a `trusty-common` published version that doesn't exist yet.
- This blocks `cargo publish -p trusty-search` (trusty-search's manifest requires trusty-common feature `config-cli`) and breaks `cargo install trusty-search` for anyone pulling from crates.io.
- Bump only: `crates/trusty-common/Cargo.toml` `version = "0.22.4"` → `"0.22.5"`, staged CHANGELOG section (via `scripts/bump-version.sh trusty-common patch`), and the resulting `Cargo.lock` refresh. No dependent manifests were touched — all their `trusty-common` version requirements are caret ranges (`"0.22.2"` / `"0.22.4"`), which already resolve to 0.22.5.

## Blast radius — crates enabling `config-cli` on trusty-common (would all be broken by publishing against un-bumped 0.22.4)

1. `trusty-agents` (`crates/trusty-agents/Cargo.toml:44`)
2. `trusty-analyze` (`crates/trusty-analyze/Cargo.toml:79`)
3. `trusty-code` (`crates/trusty-code/Cargo.toml:78`)
4. `trusty-console` (`crates/trusty-console/Cargo.toml:52`)
5. `trusty-git-analytics` / tga (`crates/trusty-git-analytics/Cargo.toml:34`)
6. `trusty-installer` (`crates/trusty-installer/Cargo.toml:72`)
7. `trusty-memory` (`crates/trusty-memory/Cargo.toml:86`)
8. `trusty-search` (`crates/trusty-search/Cargo.toml:57`) — the immediate blocker
9. `trusty-review` (`crates/trusty-review/Cargo.toml:87`)
10. `trusty-mpm` (`crates/trusty-mpm/Cargo.toml:142-159`)

All 10 match PR #2528's "mount config command on all 10 primary binaries." None of their `trusty-common` deps use an exact `=` pin, so no manifest edits were required here — republishing 0.22.5 alone satisfies all of them.

## Test plan

- [x] `cargo build --workspace` — clean build, all crates compiled.
- [x] `cargo test -p trusty-common` — 133 passed, 0 failed, 6 ignored.
- [x] `cargo test -p trusty-search` — 1049 passed, 1 failed (`service::warm_boot::probe::tests::probe_all_volumes_multi_volume_no_fast_starvation`), 1 ignored. The failure is a **pre-existing wall-clock timing flake** (asserts total elapsed < 2× a 50ms deadline; observed 120-124ms under parallel test-suite load) unrelated to this version-only change — reran in isolation and it still exceeds the bound purely from scheduler jitter.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `bash scripts/check_line_cap.sh` — `0 allowlisted, 0 violations — OK.`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools