### PR TITLE
fix(trusty-mpm): guided-default no longer inherits an ancestor repo's project when cwd is untracked (closes #2534)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -264,7 +264,10 @@ async fn try_show_picker(
 /// `source_id`), the managed workspace path (for display), and the git root
 /// path (to pass as `repo_url` so the daemon sets `source_id` correctly even
 /// when `tm` is invoked from a subdirectory — #1705 LOW fix).
-/// What: finds the git root, reads `remote.origin.url`, guards that it is a
+/// What: finds a *usable* git root (via [`usable_git_root`] — an ancestor `.git`
+/// is trusted only when `cwd` is genuinely part of that repo's tracked tree, so
+/// an untracked directory nested inside another repo does NOT inherit that
+/// repo's identity — #2534), reads `remote.origin.url`, guards that it is a
 /// GitHub URL, parses `owner/repo` via `parse_github_path`, and returns
 /// `(source_id, workspace_path, git_root)` where `source_id = "owner/repo"`,
 /// `workspace_path = ~/trusty-mpm-projects/<owner>/<repo>` (the canonical base),
@@ -272,12 +275,13 @@ async fn try_show_picker(
 /// Test: `guided_derive_project_returns_none_for_non_git_dir`,
 /// `guided_derive_project_rejects_non_github_remote`,
 /// `guided_derive_project_accepts_github_https_remote`,
-/// `guided_derive_project_returns_some_from_subdir`.
+/// `guided_derive_project_returns_some_from_subdir`,
+/// `guided_derive_project_returns_none_for_untracked_ancestor_subdir`.
 pub(crate) fn derive_project(
     cwd: &std::path::Path,
 ) -> Option<(String, std::path::PathBuf, std::path::PathBuf)> {
     use trusty_mpm::daemon::managed_routes::inproject;
-    let git_root = find_git_root(cwd)?;
+    let git_root = usable_git_root(cwd)?;
     let origin_url = inproject::get_origin_url(&git_root).filter(|u| is_github_remote(u))?;
     let gh = trusty_common::github_path::parse_github_path(&origin_url)?;
     let source_id = format!("{}/{}", gh.owner, gh.repo);
@@ -614,6 +618,167 @@ fn find_git_root(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
     (!root.is_empty()).then_some(std::path::PathBuf::from(root))
 }
 
+// ── Ancestor-repo trust guard (#2534) ────────────────────────────────────────
+
+/// Classification of `cwd` with respect to the nearest enclosing git working tree.
+///
+/// Why: [`find_git_root`] happily walks *up* to an ancestor `.git`. That is
+/// correct for a subdirectory the operator actually committed, but WRONG when
+/// `cwd` is an unrelated directory that merely happens to live inside another
+/// repository's working-tree span — e.g. an untracked notes folder `~/Duetto/cto`
+/// that case-folds onto the enclosing repo's tracked `CTO/` dir on a
+/// case-insensitive filesystem (APFS). Trusting the ancestor there made bare
+/// `tm` silently resolve to the ancestor repo's project and offer its sessions
+/// (#2534). This enum lets both `cwd → project` resolution paths distinguish the
+/// three cases with a single git query.
+/// What: `Usable` = `cwd` is the repo root itself, or a subdirectory that IS part
+/// of the tracked tree — safe to inherit the repo's identity. `UntrackedInsideAncestor`
+/// = `cwd` is a strict subdirectory of a git working tree but is NOT in its
+/// tracked tree — must be treated as a non-project. `NotGit` = `cwd` is not inside
+/// any git working tree.
+/// Test: `guided_classify_cwd_usable_for_tracked_subdir`,
+/// `guided_classify_cwd_untracked_for_uncommitted_subdir`,
+/// `guided_classify_cwd_not_git_for_plain_dir`.
+pub(crate) enum CwdProject {
+    /// `cwd` belongs to this git root's tracked tree (or IS the root).
+    Usable(std::path::PathBuf),
+    /// `cwd` sits inside this git root's working tree but is not tracked by it.
+    UntrackedInsideAncestor(std::path::PathBuf),
+    /// `cwd` is not inside any git working tree.
+    NotGit,
+}
+
+/// Classify `cwd` against its nearest enclosing git working tree, verifying
+/// tracked-tree membership before trusting an *ancestor* repo's identity.
+///
+/// Why: closes the ancestor-`.git` trust gap (#2534). `find_git_root` alone
+/// cannot tell an intentionally-nested tracked subdirectory apart from an
+/// unrelated directory that merely falls inside a repo's path span (the APFS
+/// case-fold collision that made `~/Duetto/cto` resolve to the enclosing
+/// `hotstats/hotstats-knowledgebase` repo). The tracked-tree check does.
+/// What: resolves the git root. When the root IS `cwd` (the common top-level
+/// case) it is trusted unconditionally — behavior UNCHANGED. When the root is a
+/// strict ancestor, `cwd`'s path relative to the root is checked for tracked-tree
+/// membership via [`cwd_is_tracked_within`]; a hit is `Usable`, a miss is
+/// `UntrackedInsideAncestor`. A prefix mismatch (e.g. symlink canonicalisation
+/// differences between `current_dir` and `git rev-parse --show-toplevel`) cannot
+/// yield a relpath, so it conservatively trusts the root (`Usable`) rather than
+/// newly refusing a previously-working checkout.
+/// Test: `guided_classify_cwd_usable_for_tracked_subdir`,
+/// `guided_classify_cwd_untracked_for_uncommitted_subdir`,
+/// `guided_classify_cwd_usable_for_repo_root`.
+pub(crate) fn classify_cwd_project(cwd: &std::path::Path) -> CwdProject {
+    let Some(git_root) = find_git_root(cwd) else {
+        return CwdProject::NotGit;
+    };
+    // `git rev-parse --show-toplevel` canonicalises symlinks (e.g. macOS
+    // /var → /private/var); canonicalise `cwd` the same way so the prefix
+    // comparison is apples-to-apples and a strict subdir is not misread as a
+    // prefix mismatch. Both fall back to the raw path if canonicalisation fails.
+    let cwd_canon = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let root_canon = git_root.canonicalize().unwrap_or_else(|_| git_root.clone());
+    match cwd_canon.strip_prefix(&root_canon) {
+        // `cwd` IS the repo root (empty relpath): the normal top-level case —
+        // trust it unconditionally, behavior unchanged.
+        Ok(rel) if rel.as_os_str().is_empty() => CwdProject::Usable(git_root),
+        // Strict subdirectory: only trust the ancestor when `cwd` is tracked.
+        Ok(rel) => {
+            if cwd_is_tracked_within(&git_root, rel) {
+                CwdProject::Usable(git_root)
+            } else {
+                CwdProject::UntrackedInsideAncestor(git_root)
+            }
+        }
+        // Prefix mismatch (symlink canonicalisation, etc.): cannot compute a
+        // relpath — preserve the pre-existing trust-the-root behavior.
+        Err(_) => CwdProject::Usable(git_root),
+    }
+}
+
+/// Return the git root for `cwd` only when `cwd` genuinely belongs to that repo.
+///
+/// Why: thin adapter so the `cwd → project` derivation paths that only care about
+/// the *usable* root (e.g. [`derive_project`]) need not match the full
+/// [`CwdProject`] enum. Both an untracked-ancestor `cwd` and a non-git `cwd`
+/// collapse to `None` — neither should inherit a git identity.
+/// What: returns `Some(root)` for [`CwdProject::Usable`], `None` otherwise.
+/// Test: covered transitively via `guided_derive_project_returns_none_for_untracked_ancestor_subdir`
+/// and the `classify_cwd_project` unit tests.
+fn usable_git_root(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
+    match classify_cwd_project(cwd) {
+        CwdProject::Usable(root) => Some(root),
+        CwdProject::UntrackedInsideAncestor(_) | CwdProject::NotGit => None,
+    }
+}
+
+/// Is `relpath` (a strict subdirectory of `git_root`) part of the repo's
+/// tracked tree?
+///
+/// Why: the authoritative test for the ancestor-trust guard (#2534). Git's
+/// index/tree is case-SENSITIVE, so on a case-insensitive filesystem an untracked
+/// `cto` directory that shadows a tracked `CTO` still produces NO tree entry for
+/// `cto` — exactly the discriminator needed to reject the case-fold collision.
+/// What: shells `git -C <git_root> ls-tree -d --name-only HEAD -- <relpath>` and
+/// delegates the yes/no decision to the pure [`ls_tree_reports_tracked_dir`].
+/// Fails CLOSED (returns `false`) when git errors or the repo has no `HEAD`
+/// (e.g. a commit-less repo has no tracked tree to belong to), so an
+/// unverifiable ancestor is never trusted.
+/// Test: decision logic is unit-tested via [`ls_tree_reports_tracked_dir`]; the
+/// live-git path is exercised by `guided_classify_cwd_*` integration tests.
+fn cwd_is_tracked_within(git_root: &std::path::Path, relpath: &std::path::Path) -> bool {
+    let rel = relpath.to_string_lossy();
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(git_root)
+        .args(["ls-tree", "-d", "--name-only", "HEAD", "--"])
+        .arg(rel.as_ref())
+        .output();
+    match output {
+        Ok(o) if o.status.success() => {
+            ls_tree_reports_tracked_dir(&String::from_utf8_lossy(&o.stdout))
+        }
+        _ => false,
+    }
+}
+
+/// Pure predicate: does `git ls-tree -d --name-only HEAD -- <relpath>` stdout
+/// indicate the queried path is a tracked directory?
+///
+/// Why: isolates the decision from the git shell-out so the tracked-vs-untracked
+/// rule is exhaustively unit-testable without a live repo (mirrors the
+/// `is_github_remote` pure-helper pattern). `ls-tree` emits one line naming the
+/// path only when a matching tracked tree object exists; it emits nothing for an
+/// untracked (or case-mismatched) path.
+/// What: returns `true` when any output line is non-empty after trimming, `false`
+/// otherwise. Empty stdout ⇒ untracked ⇒ `false`.
+/// Test: `guided_ls_tree_reports_tracked_dir_true_for_named_entry`,
+/// `guided_ls_tree_reports_tracked_dir_false_for_empty`,
+/// `guided_ls_tree_reports_tracked_dir_false_for_blank_lines`.
+pub(crate) fn ls_tree_reports_tracked_dir(ls_tree_stdout: &str) -> bool {
+    ls_tree_stdout.lines().any(|line| !line.trim().is_empty())
+}
+
+/// Build the operator-facing notice for the untracked-ancestor case (#2534).
+///
+/// Why: when `cwd` sits inside another repository's working tree but is not part
+/// of it, silently launching that ancestor repo's project is the bug we are
+/// fixing. The operator needs to know WHY `tm` declined to adopt the enclosing
+/// repo — extracting the wording into a pure helper keeps it unit-testable.
+/// What: returns a two-line stderr notice naming the enclosing `git_root` as the
+/// reason `tm` is not launching that project, and reassuring the operator that
+/// nothing was written.
+/// Test: `guided_untracked_ancestor_message_names_root`,
+/// `guided_untracked_ancestor_message_does_not_claim_launch`.
+pub(crate) fn untracked_ancestor_message(git_root: &std::path::Path) -> String {
+    format!(
+        "tm: this directory is inside another repository's working tree ({}) \
+         but is not part of it — not launching that project.\n\
+         tm: nothing was touched. (Use an explicit `tm` subcommand, or run `tm` \
+         from a tracked directory of the repo you intend to work in.)",
+        git_root.display()
+    )
+}
+
 /// Daemon-unreachable fallback that protects ALL live git checkouts (#1724).
 ///
 /// Why: the guided default MUST NOT deploy framework files into ANY git
@@ -632,7 +797,8 @@ fn find_git_root(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
 ///       consistent with the daemon's local-path fast path.
 /// Test: `guided_fallback_never_pollutes_github_git_checkout`,
 /// `guided_fallback_blocks_non_github_git_checkout`,
-/// `guided_fallback_blocks_github_git_from_subdirectory`, and
+/// `guided_fallback_blocks_github_git_from_subdirectory`,
+/// `guided_fallback_untracked_ancestor_does_not_redirect`, and
 /// `guided_fallback_redirect_success_worktree_not_live_checkout` in
 /// `tests_behavior_b_tests.rs`.
 pub(crate) async fn fallback_protected(
@@ -640,40 +806,52 @@ pub(crate) async fn fallback_protected(
     url: &str,
     cwd: &std::path::Path,
 ) -> anyhow::Result<()> {
-    if let Some(git_root) = find_git_root(cwd) {
-        // cwd is inside a git working tree (at any depth) — protect it.
-        // Read the origin remote from the REPO ROOT so subdirectory calls
-        // find the same remote as top-level calls would.
-        //
-        // NOTE: `parse_github_path` accepts *any* remote URL (not just GitHub);
-        // we therefore gate on `is_github_remote` (github.com substring) to
-        // distinguish GitHub from Gitea/GitLab/bare-SSH remotes.
-        let origin_url = trusty_mpm::daemon::managed_routes::inproject::get_origin_url(&git_root);
-
-        if let Some(ref raw_url) = origin_url
-            && is_github_remote(raw_url)
-        {
-            // GitHub project: redirect deploy to the protected managed clone.
-            return redirect_to_managed_clone(client, url, cwd, raw_url).await;
+    let git_root = match classify_cwd_project(cwd) {
+        CwdProject::Usable(root) => root,
+        CwdProject::UntrackedInsideAncestor(root) => {
+            // cwd is inside another repo's working tree but is NOT part of it
+            // (#2534). Do NOT inherit that ancestor's identity — neither the
+            // managed-clone redirect nor the non-GitHub refusal is appropriate,
+            // because this directory is not that project. Route to the same
+            // clean, non-fatal exit as a plain non-git directory.
+            eprintln!("{}", untracked_ancestor_message(&root));
+            return Ok(());
         }
+        CwdProject::NotGit => {
+            // Not inside a git working tree: print a helpful note and exit cleanly (#1839).
+            eprintln!("{}", super::misc::NON_GIT_FALLBACK_HINT);
+            return Ok(());
+        }
+    };
 
-        // Non-GitHub remote or no remote: refuse to write to the live tree.
-        // NOTE: the daemon's reachability is irrelevant here — this branch is
-        // reached even when the daemon is UP. The real reason for refusal is
-        // that `tm` only auto-manages GitHub repositories (#1777).
-        let remote_desc = origin_url.as_deref().unwrap_or("(no remote configured)");
-        eprintln!("{}", non_github_refusal_message(remote_desc));
-        anyhow::bail!(
-            "not auto-managing: live git checkout at '{}' is a non-GitHub repository — \
-             auto-managed clones require a GitHub remote; \
-             use an explicit `tm` subcommand to work here manually",
-            git_root.display()
-        );
+    // cwd is inside a git working tree it genuinely belongs to — protect it.
+    // Read the origin remote from the REPO ROOT so subdirectory calls
+    // find the same remote as top-level calls would.
+    //
+    // NOTE: `parse_github_path` accepts *any* remote URL (not just GitHub);
+    // we therefore gate on `is_github_remote` (github.com substring) to
+    // distinguish GitHub from Gitea/GitLab/bare-SSH remotes.
+    let origin_url = trusty_mpm::daemon::managed_routes::inproject::get_origin_url(&git_root);
+
+    if let Some(ref raw_url) = origin_url
+        && is_github_remote(raw_url)
+    {
+        // GitHub project: redirect deploy to the protected managed clone.
+        return redirect_to_managed_clone(client, url, cwd, raw_url).await;
     }
 
-    // Not inside a git working tree: print a helpful note and exit cleanly (#1839).
-    eprintln!("{}", super::misc::NON_GIT_FALLBACK_HINT);
-    Ok(())
+    // Non-GitHub remote or no remote: refuse to write to the live tree.
+    // NOTE: the daemon's reachability is irrelevant here — this branch is
+    // reached even when the daemon is UP. The real reason for refusal is
+    // that `tm` only auto-manages GitHub repositories (#1777).
+    let remote_desc = origin_url.as_deref().unwrap_or("(no remote configured)");
+    eprintln!("{}", non_github_refusal_message(remote_desc));
+    anyhow::bail!(
+        "not auto-managing: live git checkout at '{}' is a non-GitHub repository — \
+         auto-managed clones require a GitHub remote; \
+         use an explicit `tm` subcommand to work here manually",
+        git_root.display()
+    );
 }
 
 /// Redirect the guided-default fallback to the protected managed-clone workspace.

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -1070,6 +1070,91 @@ async fn guided_fallback_blocks_non_github_git_checkout() {
     );
 }
 
+/// Why (#2534): bare `tm` run from a directory that physically sits inside a
+/// GitHub repo's working tree but is NOT part of its tracked tree (the same shape
+/// as the APFS `~/Duetto/cto` case-fold collision) must NOT inherit the enclosing
+/// repo's identity. It must NOT redirect to that repo's managed clone (which would
+/// attempt a real `git clone` of the github.com URL and fail on the network); it
+/// must route to the clean non-git fallback and return `Ok(())` without writing
+/// any framework files.
+/// What: inits a real git repo with a committed file + a github.com remote, then
+/// creates an UNTRACKED subdir inside it and calls `fallback_protected` from that
+/// subdir. Asserts `Ok(())`, no framework artifacts, and no managed-clone attempt.
+/// Test: this is the test.
+#[tokio::test]
+async fn guided_fallback_untracked_ancestor_does_not_redirect() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path();
+
+    // git init + identity + an initial commit (so HEAD's tree exists).
+    let git_ok = std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(project)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !git_ok {
+        eprintln!(
+            "guided_fallback_untracked_ancestor_does_not_redirect: git unavailable, skipping"
+        );
+        return;
+    }
+    for (k, v) in [("user.email", "t@example.com"), ("user.name", "T")] {
+        let _ = std::process::Command::new("git")
+            .args(["config", k, v])
+            .current_dir(project)
+            .status();
+    }
+    std::fs::write(project.join("README.md"), b"x").unwrap();
+    let _ = std::process::Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(project)
+        .status();
+    let _ = std::process::Command::new("git")
+        .args(["commit", "-m", "init", "-q"])
+        .current_dir(project)
+        .status();
+    // A github.com remote — if the ancestor were (wrongly) trusted, the fallback
+    // would try to clone THIS into the managed workspace.
+    let _ = std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ])
+        .current_dir(project)
+        .status();
+
+    // An UNTRACKED sibling directory inside the working tree — never `git add`ed.
+    let untracked = project.join("cto");
+    std::fs::create_dir_all(&untracked).unwrap();
+
+    let client = reqwest::Client::new();
+    let result =
+        crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", &untracked)
+            .await;
+
+    // Must exit cleanly (non-git fallback), NOT Err (non-github refusal) and NOT
+    // a redirect (which would network-fail cloning the github remote).
+    assert!(
+        result.is_ok(),
+        "#2534: untracked ancestor subdir must route to the clean non-git \
+         fallback (Ok), not the ancestor's managed-clone redirect; got: {result:?}"
+    );
+    // No framework artifacts anywhere.
+    for p in ["CLAUDE.md", ".mcp.json", ".trusty-mpm", ".claude"] {
+        assert!(
+            !untracked.join(p).exists(),
+            "#2534: {p} must NOT be written to the untracked directory"
+        );
+        assert!(
+            !project.join(p).exists(),
+            "#2534: {p} must NOT be written to the enclosing repo"
+        );
+    }
+}
+
 /// Why (#1724 non-git path + #1839 Fix 2): the protected-checkout guarantee applies
 /// only to git projects. A plain directory (no `.git`) should exit cleanly with a
 /// helpful hint rather than attempting `launch()` which would fail with a confusing
@@ -1132,6 +1217,12 @@ async fn guided_fallback_blocks_github_git_from_subdirectory() {
         eprintln!("guided_fallback_blocks_github_git_from_subdirectory: git unavailable, skipping");
         return;
     }
+    for (k, v) in [("user.email", "t@example.com"), ("user.name", "T")] {
+        let _ = std::process::Command::new("git")
+            .args(["config", k, v])
+            .current_dir(repo_dir.path())
+            .status();
+    }
     let _ = std::process::Command::new("git")
         .args([
             "remote",
@@ -1142,9 +1233,21 @@ async fn guided_fallback_blocks_github_git_from_subdirectory() {
         .current_dir(repo_dir.path())
         .status();
 
-    // Run from a NESTED subdirectory inside the repo.
+    // Run from a NESTED, TRACKED subdirectory inside the repo. The subdir is
+    // committed so it genuinely belongs to the repo's tracked tree — as of #2534
+    // an UNTRACKED ancestor subdir instead routes to the clean non-git fallback
+    // (covered by `guided_fallback_untracked_ancestor_does_not_redirect`).
     let subdir = repo_dir.path().join("src").join("module");
     std::fs::create_dir_all(&subdir).unwrap();
+    std::fs::write(subdir.join(".keep"), b"").unwrap();
+    let _ = std::process::Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(repo_dir.path())
+        .status();
+    let _ = std::process::Command::new("git")
+        .args(["commit", "-m", "init", "-q"])
+        .current_dir(repo_dir.path())
+        .status();
 
     let client = reqwest::Client::new();
     let result =

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -26,9 +26,10 @@ use crate::commands::first_run::needs_first_run_clone;
 /// racing `needs_first_run_clone_returns_some_when_no_clone`.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 use crate::commands::guided::{
-    derive_project, fallback_protected, github_host, is_github_remote, nested_guard_notice,
-    nested_managed_match, non_github_refusal_message, pane_identity_confirmed, print_non_tty_hint,
-    print_project_context, tty_gate,
+    CwdProject, classify_cwd_project, derive_project, fallback_protected, github_host,
+    is_github_remote, ls_tree_reports_tracked_dir, nested_guard_notice, nested_managed_match,
+    non_github_refusal_message, pane_identity_confirmed, print_non_tty_hint, print_project_context,
+    tty_gate, untracked_ancestor_message,
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{ResumeAction, is_zombie, needs_restart, plan_resume};
@@ -326,6 +327,8 @@ fn guided_derive_project_returns_some_from_subdir() {
     // repo, and the returned git_root must be the repo root (not the subdir)
     // so that `launch_new_session_and_attach` passes the git root as repo_url
     // and the daemon finds .git, sets source_id correctly (#1705 LOW fix).
+    // The subdir here is TRACKED (committed) — an untracked ancestor subdir is
+    // deliberately rejected as of #2534 (see the dedicated test below).
     let tmp = tempdir_with_name("trusty_test_subdir_1705");
     let ok = git_init_with_commit(&tmp);
     if !ok {
@@ -333,9 +336,10 @@ fn guided_derive_project_returns_some_from_subdir() {
     }
     git_remote_add(&tmp, "https://github.com/owner/my-repo.git");
 
-    // Create a nested subdirectory and call derive_project from it.
+    // Create a nested subdirectory, TRACK it, then call derive_project from it.
     let subdir = tmp.join("src").join("lib");
     std::fs::create_dir_all(&subdir).unwrap();
+    git_track_dir(&tmp, "src/lib");
 
     let result = derive_project(&subdir);
     match result {
@@ -352,6 +356,149 @@ fn guided_derive_project_returns_some_from_subdir() {
         }
         None => panic!("expected Some when calling derive_project from a subdir"),
     }
+}
+
+// ── Ancestor-repo trust guard (#2534) ─────────────────────────────────────────
+
+#[test]
+fn guided_ls_tree_reports_tracked_dir_true_for_named_entry() {
+    // Why: git prints the queried path (one line) when it names a tracked tree.
+    assert!(ls_tree_reports_tracked_dir("CTO\n"));
+    assert!(ls_tree_reports_tracked_dir("src/lib\n"));
+}
+
+#[test]
+fn guided_ls_tree_reports_tracked_dir_false_for_empty() {
+    // Why: an untracked (or case-mismatched) path yields empty stdout — the
+    // exact discriminator for the APFS `cto` vs tracked `CTO` collision (#2534).
+    assert!(!ls_tree_reports_tracked_dir(""));
+}
+
+#[test]
+fn guided_ls_tree_reports_tracked_dir_false_for_blank_lines() {
+    // Why: whitespace-only output must not be mistaken for a tracked entry.
+    assert!(!ls_tree_reports_tracked_dir("\n  \n\t\n"));
+}
+
+#[test]
+fn guided_untracked_ancestor_message_names_root() {
+    // Why: the operator must see WHICH enclosing repo was declined.
+    let msg = untracked_ancestor_message(std::path::Path::new("/Users/masa/Duetto"));
+    assert!(
+        msg.contains("/Users/masa/Duetto"),
+        "message must name the enclosing git root: {msg}"
+    );
+    assert!(
+        msg.contains("not part of it"),
+        "message must explain the untracked-ancestor reason: {msg}"
+    );
+}
+
+#[test]
+fn guided_untracked_ancestor_message_does_not_claim_launch() {
+    // Why: the whole point is that we did NOT launch the ancestor project.
+    let msg = untracked_ancestor_message(std::path::Path::new("/repo"));
+    assert!(
+        msg.contains("not launching that project"),
+        "message must state the project was not launched: {msg}"
+    );
+}
+
+#[test]
+fn guided_classify_cwd_not_git_for_plain_dir() {
+    // Why: a directory outside any git working tree is NotGit.
+    let tmp = tempdir_with_name("trusty_test_classify_plain_2534");
+    // Skip if the temp dir happens to be inside a git tree (dev machines vary).
+    if find_git_root_via_cli(&tmp).is_some() {
+        return;
+    }
+    assert!(matches!(classify_cwd_project(&tmp), CwdProject::NotGit));
+}
+
+#[test]
+fn guided_classify_cwd_usable_for_repo_root() {
+    // Why: the top-level case is trusted unconditionally — behavior unchanged.
+    let tmp = tempdir_with_name("trusty_test_classify_root_2534");
+    if !git_init_with_commit(&tmp) {
+        return;
+    }
+    let canonical = tmp.canonicalize().unwrap_or_else(|_| tmp.clone());
+    match classify_cwd_project(&canonical) {
+        CwdProject::Usable(root) => {
+            let root = root.canonicalize().unwrap_or(root);
+            assert_eq!(root, canonical, "repo root must classify as Usable(root)");
+        }
+        _ => panic!("repo root must be Usable"),
+    }
+}
+
+#[test]
+fn guided_classify_cwd_usable_for_tracked_subdir() {
+    // Why: a committed subdirectory genuinely belongs to the repo — Usable.
+    let tmp = tempdir_with_name("trusty_test_classify_tracked_2534");
+    if !git_init_with_commit(&tmp) {
+        return;
+    }
+    git_track_dir(&tmp, "src/lib");
+    let subdir = tmp.join("src").join("lib");
+    match classify_cwd_project(&subdir) {
+        CwdProject::Usable(_) => {}
+        _ => panic!("tracked subdir must be Usable"),
+    }
+}
+
+#[test]
+fn guided_classify_cwd_untracked_for_uncommitted_subdir() {
+    // Why: the core #2534 regression — a directory that physically exists inside
+    // a repo's working tree but is NOT in its tracked tree (the same shape as the
+    // APFS `~/Duetto/cto` case-fold collision) must be UntrackedInsideAncestor,
+    // NOT trusted as part of the enclosing repo.
+    let tmp = tempdir_with_name("trusty_test_classify_untracked_2534");
+    if !git_init_with_commit(&tmp) {
+        return;
+    }
+    // Create a subdir but never `git add` it → not in HEAD's tree.
+    let untracked = tmp.join("notes");
+    std::fs::create_dir_all(&untracked).unwrap();
+    match classify_cwd_project(&untracked) {
+        CwdProject::UntrackedInsideAncestor(_) => {}
+        CwdProject::Usable(_) => {
+            panic!("untracked subdir must NOT be trusted as part of the ancestor repo")
+        }
+        CwdProject::NotGit => panic!("subdir is inside a git tree — must not be NotGit"),
+    }
+}
+
+#[test]
+fn guided_derive_project_returns_none_for_untracked_ancestor_subdir() {
+    // Why: the end-to-end #2534 guarantee — bare `tm` from an untracked directory
+    // nested inside a GitHub repo must NOT resolve to that ancestor's project.
+    let tmp = tempdir_with_name("trusty_test_derive_untracked_2534");
+    if !git_init_with_commit(&tmp) {
+        return;
+    }
+    git_remote_add(&tmp, "https://github.com/owner/my-repo.git");
+    let untracked = tmp.join("notes");
+    std::fs::create_dir_all(&untracked).unwrap();
+    assert!(
+        derive_project(&untracked).is_none(),
+        "derive_project must return None for an untracked ancestor subdir"
+    );
+}
+
+/// Local helper: resolve the git working-tree root via the CLI (mirrors the
+/// production `find_git_root`) so the NotGit test can skip when a dev machine's
+/// temp dir happens to sit inside a git tree.
+fn find_git_root_via_cli(dir: &PathBuf) -> Option<PathBuf> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let root = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!root.is_empty()).then(|| PathBuf::from(root))
 }
 
 // ── print_project_context / print_non_tty_hint ────────────────────────────────
@@ -464,6 +611,25 @@ fn git_remote_add(dir: &PathBuf, url: &str) {
     std::process::Command::new("git")
         .args(["remote", "add", "origin", url])
         .current_dir(dir)
+        .status()
+        .ok();
+}
+
+/// Create `<repo>/<rel>/.keep`, stage it, and commit so `<rel>` becomes a
+/// tracked directory in the repo's HEAD tree. Used to distinguish a genuinely
+/// tracked subdir from an untracked ancestor subdir (#2534).
+fn git_track_dir(repo: &PathBuf, rel: &str) {
+    let dir = repo.join(rel);
+    std::fs::create_dir_all(&dir).expect("create tracked subdir");
+    std::fs::write(dir.join(".keep"), b"").expect("write .keep");
+    std::process::Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(repo)
+        .status()
+        .ok();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "track", "-q"])
+        .current_dir(repo)
         .status()
         .ok();
 }


### PR DESCRIPTION
## What

Bare `tm` (guided default, `#1705`) run from a directory that physically sits **inside another repository's working-tree span** but is **not part of that repo's tracked tree** silently resolved to the ancestor repo's project and offered its active sessions.

Closes #2534.

## Root cause — ancestor-`.git` trust gap

`find_git_root()` shells `git -C <cwd> rev-parse --show-toplevel` and walks up to **any** ancestor `.git`. `derive_project()` and `fallback_protected()` then trusted that root's `origin` remote **unconditionally**, never verifying `cwd` is actually a tracked part of the repo.

Concrete repro: `~/Duetto` is the working tree of `hotstats/hotstats-knowledgebase` (tracks `CTO/`). On case-insensitive APFS the user's unrelated `~/Duetto/cto` notes folder case-folds onto the tracked `CTO/`, so it has no `.git` of its own → `tm` resolved to `hotstats/hotstats-knowledgebase`. The registry was never corrupt; this is purely a cwd→project trust-model gap. Git's tree is case-sensitive, so `git ls-tree -d --name-only HEAD -- cto` returns nothing — the exact missing discriminator.

## Fix (surgical)

When the discovered git root is a **strict ancestor** of `cwd`, verify `cwd`'s relpath is in the repo's tracked tree (`git ls-tree -d --name-only HEAD -- <relpath>`) before trusting the ancestor's identity:

- New `classify_cwd_project(cwd) -> CwdProject` returns `Usable(root)` (root itself, or a tracked subdir), `UntrackedInsideAncestor(root)`, or `NotGit`. `git_root == cwd` is trusted unconditionally — **behavior unchanged**.
- `derive_project()` now uses the `Usable`-only `usable_git_root()`, so an untracked ancestor subdir yields `None` (no picker, no ancestor identity).
- `fallback_protected()` routes `UntrackedInsideAncestor` to the same **clean non-git fallback** (`Ok(())`, live checkout untouched) as a plain non-git dir — never the managed-clone redirect or non-GitHub refusal — and prints an explanatory notice via the new pure `untracked_ancestor_message()`.
- The membership decision is the pure, unit-testable `ls_tree_reports_tracked_dir()` (mirrors the `is_github_remote` pure-helper pattern). Path comparison canonicalises both sides so macOS `/var`→`/private/var` symlink differences don't misread a strict subdir as a prefix mismatch.

`guided.rs` stays at **385 SLOC** (well under the 500 cap — no split needed).

## Tests

- Pure predicate: `guided_ls_tree_reports_tracked_dir_{true_for_named_entry,false_for_empty,false_for_blank_lines}`, `guided_untracked_ancestor_message_{names_root,does_not_claim_launch}`.
- Classifier (real temp git repos): `guided_classify_cwd_{usable_for_repo_root,usable_for_tracked_subdir,untracked_for_uncommitted_subdir,not_git_for_plain_dir}`.
- End-to-end: `guided_derive_project_returns_none_for_untracked_ancestor_subdir`, `guided_fallback_untracked_ancestor_does_not_redirect`.
- Adjusted two existing tests (`guided_derive_project_returns_some_from_subdir`, `guided_fallback_blocks_github_git_from_subdirectory`) to use **tracked** subdirs — the untracked case is now deliberately rerouted, and both retain their original tracked-subdir assertions.

## Gate (all green)

`cargo build --workspace`, `cargo test -p trusty-mpm` (2963 + 887 pass, 0 fail), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `bash scripts/check_line_cap.sh` — all pass.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
