### PR TITLE
feat(trusty-common,trusty-code): add AtlasCloud direct inference provider (openai/gpt-5.6-sol)

### DIFF
--- a/crates/trusty-code/src/llm/client.rs
+++ b/crates/trusty-code/src/llm/client.rs
@@ -6,7 +6,7 @@
 //! detailed-usage directive, HTTP→error classification, response parsing) in
 //! ONE shared core so every consumer shares it instead of six near-identical
 //! copies. This module is tcode's thin consumer of that core: it selects the
-//! provider (OpenRouter, Fireworks, or Together) by model slug, resolves the
+//! provider (OpenRouter, Fireworks, Together, or AtlasCloud) by model slug, resolves the
 //! credential via the shared 3-tier resolver (process env > `.env.local` >
 //! secure store), builds the matching `trusty_common::inference` adapter once
 //! (caching it so the underlying `reqwest` connection pool is reused across a
@@ -18,13 +18,16 @@
 //! slugs route to the Fireworks adapter (stripping the `fireworks/` routing
 //! prefix to the provider-native model id and requiring `FIREWORKS_API_KEY`);
 //! `together/*` slugs route to the Together adapter (#2494 — stripping the
-//! `together/` routing prefix and requiring `TOGETHER_API_KEY`); everything else
+//! `together/` routing prefix and requiring `TOGETHER_API_KEY`); `atlascloud/*`
+//! slugs route to the AtlasCloud adapter (#2536 — stripping the `atlascloud/`
+//! routing prefix and requiring `ATLASCLOUD_API_KEY`); everything else
 //! routes to OpenRouter, sending the slug unchanged (identical to the pre-#2406
 //! behaviour). A missing credential surfaces at `chat()` time (not
 //! construction), preserving the #2245 deferred-failure contract. The base URLs
 //! are overridable (`TCODE_OPENROUTER_BASE_URL` / `TCODE_FIREWORKS_BASE_URL` /
-//! `TCODE_TOGETHER_BASE_URL` or [`OpenAiCompatClient::with_config`]) so an
-//! offline mock server can be targeted end-to-end.
+//! `TCODE_TOGETHER_BASE_URL` / `TCODE_ATLASCLOUD_BASE_URL` or
+//! [`OpenAiCompatClient::with_config`]) so an offline mock server can be targeted
+//! end-to-end.
 //! Test: `client::tests::*` (provider selection, prefix stripping, hermetic
 //! missing-credential path against an injected empty store) and the black-box
 //! HTTP round-trip in `tests/inference_shared_adapter_e2e.rs`; the `#[ignore]`
@@ -40,7 +43,7 @@ use trusty_common::inference::{
     InferenceAdapter,
     credentials::{KeyStore, default_store, resolve_key_with},
     provider_for,
-    providers::{fireworks, openrouter, together},
+    providers::{atlascloud, fireworks, openrouter, together},
     registry::ProviderId,
 };
 
@@ -62,6 +65,10 @@ const FIREWORKS_BASE_URL_ENV: &str = "TCODE_FIREWORKS_BASE_URL";
 /// [`together::TOGETHER_BASE_URL`].
 const TOGETHER_BASE_URL_ENV: &str = "TCODE_TOGETHER_BASE_URL";
 
+/// Env var overriding the AtlasCloud API base URL. Defaults to
+/// [`atlascloud::ATLASCLOUD_BASE_URL`].
+const ATLASCLOUD_BASE_URL_ENV: &str = "TCODE_ATLASCLOUD_BASE_URL";
+
 /// The provider name `crate::provider::provider_for` reports for `fireworks/*`
 /// slugs — the single routing condition this client checks (mirroring how
 /// `super::dispatch` keys Bedrock routing off the same factory).
@@ -71,6 +78,11 @@ const FIREWORKS_PROVIDER_NAME: &str = "fireworks";
 /// slugs — the second OpenAI-dialect routing condition this client checks
 /// (#2494), keyed off the same factory as Fireworks.
 const TOGETHER_PROVIDER_NAME: &str = "together";
+
+/// The provider name `crate::provider::provider_for` reports for `atlascloud/*`
+/// slugs — the third OpenAI-dialect routing condition this client checks
+/// (#2536), keyed off the same factory as Fireworks and Together.
+const ATLASCLOUD_PROVIDER_NAME: &str = "atlascloud";
 
 /// OpenAI-compatible transport over the shared inference adapter, routing
 /// OpenRouter and Fireworks by model slug.
@@ -87,6 +99,7 @@ pub struct OpenAiCompatClient {
     openrouter_base: String,
     fireworks_base: String,
     together_base: String,
+    atlascloud_base: String,
     adapters: Mutex<HashMap<ProviderId, Arc<dyn InferenceAdapter>>>,
 }
 
@@ -126,7 +139,15 @@ impl OpenAiCompatClient {
             .unwrap_or_else(|_| fireworks::FIREWORKS_BASE_URL.to_string());
         let together_base = std::env::var(TOGETHER_BASE_URL_ENV)
             .unwrap_or_else(|_| together::TOGETHER_BASE_URL.to_string());
-        Self::with_config(store, openrouter_base, fireworks_base, together_base)
+        let atlascloud_base = std::env::var(ATLASCLOUD_BASE_URL_ENV)
+            .unwrap_or_else(|_| atlascloud::ATLASCLOUD_BASE_URL.to_string());
+        Self::with_config(
+            store,
+            openrouter_base,
+            fireworks_base,
+            together_base,
+            atlascloud_base,
+        )
     }
 
     /// Construct with an explicit store AND explicit per-provider base URLs.
@@ -134,19 +155,21 @@ impl OpenAiCompatClient {
     /// Why: the offline black-box e2e points each provider at a
     /// [`trusty_common::inference::test_support::MockInferenceServer`] without
     /// mutating process env (so the test stays parallel-safe).
-    /// What: stores all four inputs and an empty adapter cache.
+    /// What: stores all five inputs and an empty adapter cache.
     /// Test: `tests/inference_shared_adapter_e2e.rs`.
     pub fn with_config(
         store: Box<dyn KeyStore>,
         openrouter_base: String,
         fireworks_base: String,
         together_base: String,
+        atlascloud_base: String,
     ) -> Self {
         Self {
             store,
             openrouter_base,
             fireworks_base,
             together_base,
+            atlascloud_base,
             adapters: Mutex::new(HashMap::new()),
         }
     }
@@ -158,15 +181,18 @@ impl OpenAiCompatClient {
     /// `AgentLoop::build_request` consults for usage/caching decisions, so
     /// routing can never disagree with normalisation.
     /// What: [`ProviderId::Fireworks`] iff that factory reports `"fireworks"`,
-    /// [`ProviderId::Together`] iff it reports `"together"` (#2494), else
+    /// [`ProviderId::Together`] iff it reports `"together"` (#2494),
+    /// [`ProviderId::AtlasCloud`] iff it reports `"atlascloud"` (#2536), else
     /// [`ProviderId::OpenRouter`] (the default for every other slug).
     /// Test: `client::tests::selects_fireworks_for_prefixed_slug`,
     /// `client::tests::selects_together_for_prefixed_slug`,
+    /// `client::tests::selects_atlascloud_for_prefixed_slug`,
     /// `client::tests::selects_openrouter_for_plain_slug`.
     fn provider_for_slug(model: &str) -> ProviderId {
         match crate::provider::provider_for(model).name() {
             FIREWORKS_PROVIDER_NAME => ProviderId::Fireworks,
             TOGETHER_PROVIDER_NAME => ProviderId::Together,
+            ATLASCLOUD_PROVIDER_NAME => ProviderId::AtlasCloud,
             _ => ProviderId::OpenRouter,
         }
     }
@@ -178,11 +204,14 @@ impl OpenAiCompatClient {
     /// `fireworks/`- or `together/`-prefixed slug; the prefix is a routing
     /// artefact that must be stripped before the id is sent. OpenRouter takes the
     /// slug verbatim (identical to pre-#2406).
-    /// What: strips a leading `fireworks/` for [`ProviderId::Fireworks`] and a
-    /// leading `together/` for [`ProviderId::Together`] (#2494); returns the slug
+    /// What: strips a leading `fireworks/` for [`ProviderId::Fireworks`], a
+    /// leading `together/` for [`ProviderId::Together`] (#2494), and a leading
+    /// `atlascloud/` for [`ProviderId::AtlasCloud`] (#2536 — the remainder, e.g.
+    /// `openai/gpt-5.6-sol`, is the AtlasCloud-native wire id); returns the slug
     /// unchanged otherwise.
     /// Test: `client::tests::fireworks_wire_model_strips_prefix`,
-    /// `client::tests::together_wire_model_strips_prefix`.
+    /// `client::tests::together_wire_model_strips_prefix`,
+    /// `client::tests::atlascloud_wire_model_strips_prefix`.
     fn wire_model(provider: ProviderId, model: &str) -> String {
         match provider {
             ProviderId::Fireworks => model
@@ -190,6 +219,10 @@ impl OpenAiCompatClient {
                 .unwrap_or(model)
                 .to_string(),
             ProviderId::Together => model.strip_prefix("together/").unwrap_or(model).to_string(),
+            ProviderId::AtlasCloud => model
+                .strip_prefix("atlascloud/")
+                .unwrap_or(model)
+                .to_string(),
             _ => model.to_string(),
         }
     }
@@ -233,15 +266,17 @@ impl OpenAiCompatClient {
     /// fall-back to OpenRouter (which would be a wrong-provider misroute), and
     /// never an OpenRouter-flavoured error when both keys happen to be absent;
     /// only once the key is confirmed does it resolve + build the Fireworks
-    /// adapter. Together (#2494) follows the identical contract against
-    /// `TOGETHER_API_KEY`. For OpenRouter, resolves on an `openrouter/` routing
+    /// adapter. Together (#2494) and AtlasCloud (#2536) follow the identical
+    /// contract against `TOGETHER_API_KEY` / `ATLASCLOUD_API_KEY` respectively.
+    /// For OpenRouter, resolves on an `openrouter/` routing
     /// slug (a missing key surfaces as the resolver's own `MissingCredential`,
     /// mapped to `MissingConfig`). The resolved model slug is irrelevant to the
     /// built adapter (it sends the per-request wire model), so a fixed routing
     /// slug is used.
     /// Test: `client::tests::missing_openrouter_key_errors_at_chat_time`,
     /// `client::tests::missing_fireworks_key_errors_not_falls_back`,
-    /// `client::tests::missing_together_key_errors_not_falls_back`.
+    /// `client::tests::missing_together_key_errors_not_falls_back`,
+    /// `client::tests::missing_atlascloud_key_errors_not_falls_back`.
     fn build_adapter(&self, provider: ProviderId) -> Result<Box<dyn InferenceAdapter>, LlmError> {
         match provider {
             ProviderId::Fireworks => {
@@ -271,6 +306,20 @@ impl OpenAiCompatClient {
                 let resolved = provider_for("together/route", self.store.as_ref())
                     .map_err(convert::map_error)?;
                 together::build(&resolved, &self.together_base).map_err(convert::map_error)
+            }
+            ProviderId::AtlasCloud => {
+                if resolve_key_with("atlascloud", self.store.as_ref()).is_none() {
+                    return Err(LlmError::MissingConfig(
+                        "ATLASCLOUD_API_KEY is required to reach an atlascloud/* model. Export it \
+                         (e.g. `export ATLASCLOUD_API_KEY=ac_...`), add it to .env.local, or set \
+                         it via `tcode config keys set atlascloud`."
+                            .to_string(),
+                    ));
+                }
+                // The key is present, so stage-1 of the resolver returns AtlasCloud.
+                let resolved = provider_for("atlascloud/route", self.store.as_ref())
+                    .map_err(convert::map_error)?;
+                atlascloud::build(&resolved, &self.atlascloud_base).map_err(convert::map_error)
             }
             _ => {
                 let resolved = provider_for("openrouter/route", self.store.as_ref())
@@ -374,6 +423,25 @@ mod tests {
         );
     }
 
+    /// An `atlascloud/*` slug selects AtlasCloud, including the nested
+    /// `atlascloud/openai/gpt-5.6-sol` form.
+    ///
+    /// Why: this is the routing decision that makes AtlasCloud reachable (#2536),
+    /// and the nested `openai/`-shaped model id must not re-home to OpenRouter.
+    /// What: assert the provider selection for the nested and a bare atlascloud slug.
+    /// Test: this test.
+    #[test]
+    fn selects_atlascloud_for_prefixed_slug() {
+        assert_eq!(
+            OpenAiCompatClient::provider_for_slug("atlascloud/openai/gpt-5.6-sol"),
+            ProviderId::AtlasCloud
+        );
+        assert_eq!(
+            OpenAiCompatClient::provider_for_slug("atlascloud/deepseek-v3"),
+            ProviderId::AtlasCloud
+        );
+    }
+
     /// The Fireworks wire model strips the `fireworks/` routing prefix; the
     /// OpenRouter wire model is the slug verbatim.
     ///
@@ -410,6 +478,28 @@ mod tests {
                 "together/meta-llama/Llama-3.3-70B-Instruct-Turbo"
             ),
             "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+        );
+    }
+
+    /// The AtlasCloud wire model strips the `atlascloud/` routing prefix down to
+    /// the AtlasCloud-native slug — including the nested `openai/gpt-5.6-sol`
+    /// remainder (the `atlascloud/` segment is the ONLY routing artefact stripped)
+    /// and the bare `deepseek-v3` remainder.
+    ///
+    /// Why: AtlasCloud 404s on the `atlascloud/`-prefixed id; the prefix is a
+    /// tcode routing artefact only, but the model id may itself be `vendor/model`
+    /// shaped, so only the leading `atlascloud/` segment must be removed (#2536).
+    /// What: assert the stripped slug for both the nested and bare forms.
+    /// Test: this test.
+    #[test]
+    fn atlascloud_wire_model_strips_prefix() {
+        assert_eq!(
+            OpenAiCompatClient::wire_model(ProviderId::AtlasCloud, "atlascloud/openai/gpt-5.6-sol"),
+            "openai/gpt-5.6-sol"
+        );
+        assert_eq!(
+            OpenAiCompatClient::wire_model(ProviderId::AtlasCloud, "atlascloud/deepseek-v3"),
+            "deepseek-v3"
         );
     }
 
@@ -523,6 +613,48 @@ mod tests {
                 assert!(msg.contains("TOGETHER_API_KEY"), "unhelpful message: {msg}")
             }
             other => panic!("expected MissingConfig naming TOGETHER_API_KEY, got: {other:?}"),
+        }
+    }
+
+    /// An `atlascloud/*` request with no `ATLASCLOUD_API_KEY` fails with an
+    /// explicit `MissingConfig` — it must NOT silently fall back to OpenRouter
+    /// (#2536).
+    ///
+    /// Why: the shared resolver's stage-1 falls through to OpenRouter when a
+    /// family key is absent; for an explicit tcode atlascloud route that would be
+    /// a wrong-provider misroute, so `build_adapter` turns it into a clear error —
+    /// the same contract as Fireworks and Together.
+    /// What: with an empty store (and, when present locally, a real
+    /// `ATLASCLOUD_API_KEY` shadowing it, in which case skip), assert
+    /// `MissingConfig` naming `ATLASCLOUD_API_KEY`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn missing_atlascloud_key_errors_not_falls_back() {
+        if std::env::var("ATLASCLOUD_API_KEY").is_ok_and(|v| !v.is_empty()) {
+            return; // real key present locally — the fall-back guard isn't exercised
+        }
+        let client = OpenAiCompatClient::with_store(Box::new(MemoryKeyStore::new()));
+        let req = ChatRequest {
+            model: "atlascloud/openai/gpt-5.6-sol".into(),
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            tool_choice: None,
+            usage: None,
+        };
+        let err = client
+            .chat(&req)
+            .await
+            .expect_err("must fail without a key");
+        match err {
+            LlmError::MissingConfig(msg) => {
+                assert!(
+                    msg.contains("ATLASCLOUD_API_KEY"),
+                    "unhelpful message: {msg}"
+                )
+            }
+            other => panic!("expected MissingConfig naming ATLASCLOUD_API_KEY, got: {other:?}"),
         }
     }
 

--- a/crates/trusty-code/src/provider/adapter.rs
+++ b/crates/trusty-code/src/provider/adapter.rs
@@ -12,6 +12,7 @@
 
 use std::sync::Arc;
 
+use super::atlascloud::AtlasCloudProvider;
 use super::bedrock::BedrockProvider;
 use super::fireworks::FireworksProvider;
 use super::openrouter::OpenRouterProvider;
@@ -27,17 +28,21 @@ const FIREWORKS_PREFIX: &str = "fireworks/";
 /// Slug prefix that routes to the Together.ai backend (#2494).
 const TOGETHER_PREFIX: &str = "together/";
 
+/// Slug prefix that routes to the AtlasCloud backend (#2536).
+const ATLASCLOUD_PREFIX: &str = "atlascloud/";
+
 /// Select the provider implementation for a model slug.
 ///
 /// Why: The loop must stay backend-agnostic; this factory is the only place that
 /// knows how to map a slug to a backend, so adding a backend touches one site.
 /// What: Returns [`BedrockProvider`] for slugs beginning with `bedrock/`,
 /// [`FireworksProvider`] for slugs beginning with `fireworks/` (#2406),
-/// [`TogetherProvider`] for slugs beginning with `together/` (#2494), and the
+/// [`TogetherProvider`] for slugs beginning with `together/` (#2494),
+/// [`AtlasCloudProvider`] for slugs beginning with `atlascloud/` (#2536), and the
 /// default [`OpenRouterProvider`] (carrying the slug for its
-/// `supports_native_tools` decision) for everything else. The `together/` check
-/// sits alongside `fireworks/` — after `bedrock/` — so no `together/*` slug can
-/// fall through to the OpenRouter default.
+/// `supports_native_tools` decision) for everything else. The `together/` and
+/// `atlascloud/` checks sit alongside `fireworks/` — after `bedrock/` — so no
+/// `together/*` or `atlascloud/*` slug can fall through to the OpenRouter default.
 /// Test: `adapter::tests::provider_for_routes_*`.
 pub fn provider_for(slug: &str) -> Arc<dyn Provider> {
     if slug.starts_with(BEDROCK_PREFIX) {
@@ -46,6 +51,8 @@ pub fn provider_for(slug: &str) -> Arc<dyn Provider> {
         Arc::new(FireworksProvider::new())
     } else if slug.starts_with(TOGETHER_PREFIX) {
         Arc::new(TogetherProvider::new())
+    } else if slug.starts_with(ATLASCLOUD_PREFIX) {
+        Arc::new(AtlasCloudProvider::new())
     } else {
         Arc::new(OpenRouterProvider::new(slug))
     }
@@ -93,8 +100,27 @@ mod tests {
         assert_eq!(p.name(), "together");
     }
 
-    /// Non-Bedrock, non-Fireworks, non-Together slugs route to OpenRouter (the
-    /// default).
+    /// `atlascloud/*` slugs route to the AtlasCloud provider (#2536), including
+    /// the nested `atlascloud/openai/gpt-5.6-sol` form whose model id is itself
+    /// `vendor/model`-shaped.
+    ///
+    /// Why: per-agent routing must direct AtlasCloud-hosted models to the
+    /// AtlasCloud normalisation profile, not the OpenRouter default — and the
+    /// nested `openai/`-shaped model id must NOT re-home the slug to OpenRouter.
+    /// What: Resolve both the nested and a bare `atlascloud/...` slug, assert
+    /// `name() == "atlascloud"`.
+    /// Test: this test.
+    #[test]
+    fn provider_for_routes_atlascloud() {
+        assert_eq!(
+            provider_for("atlascloud/openai/gpt-5.6-sol").name(),
+            "atlascloud"
+        );
+        assert_eq!(provider_for("atlascloud/deepseek-v3").name(), "atlascloud");
+    }
+
+    /// Non-Bedrock, non-Fireworks, non-Together, non-AtlasCloud slugs route to
+    /// OpenRouter (the default).
     ///
     /// Why: Qwen/DeepSeek/Gemma/OpenAI/Anthropic-via-OR all go through
     /// OpenRouter; verify the default branch for several families.

--- a/crates/trusty-code/src/provider/atlascloud.rs
+++ b/crates/trusty-code/src/provider/atlascloud.rs
@@ -1,0 +1,195 @@
+//! AtlasCloud provider — request-shaping normalisation for `atlascloud/*` slugs
+//! (#2536, epic #2400).
+//!
+//! Why: enabling AtlasCloud in tcode (#2536) is not only a transport concern —
+//! `AgentLoop::build_request` consults `crate::provider::provider_for` to decide
+//! whether to request OpenRouter's detailed-usage directive, whether to attach
+//! prompt-cache breakpoints, and whether to send a native `tools` array. Routing
+//! an `atlascloud/*` slug to the default `OpenRouterProvider` would (wrongly)
+//! request `usage:{include:true}` — a directive AtlasCloud doesn't understand —
+//! so AtlasCloud needs its own normalisation profile, mirroring the Together
+//! precedent (#2494) and the shared capability registry's AtlasCloud seed
+//! (`detailed_usage_accounting = false`, no explicit `cache_control`
+//! breakpoints, native OpenAI-style function calling).
+//! What: [`AtlasCloudProvider`] implements [`Provider`] with the OpenAI-dialect
+//! `tool_choice` mapping (identical to OpenRouter/Fireworks/Together), the
+//! standard usage extraction, native tool support, NO explicit prompt-cache
+//! breakpoints, and NO detailed-usage request. The transport
+//! (`crate::llm::client::OpenAiCompatClient`) is what actually reaches
+//! `api.atlascloud.ai`; this type only shapes the request.
+//! Test: `atlascloud::tests::*`.
+
+use serde_json::{Value, json};
+
+use super::traits::{Provider, ToolChoice};
+use crate::llm::ChatResponse;
+use crate::perf::TokenUsage;
+
+/// Provider for AtlasCloud-hosted models (`atlascloud/*` slugs), served behind the
+/// OpenAI-compatible `/chat/completions` schema.
+///
+/// Why: gives `build_request` an AtlasCloud-correct normalisation profile so the
+/// wire payload matches what AtlasCloud accepts (no OpenRouter-only directives,
+/// no `cache_control` breakpoints).
+/// What: zero-sized marker type implementing [`Provider`].
+/// Test: `atlascloud::tests::*`.
+#[derive(Debug, Clone, Default)]
+pub struct AtlasCloudProvider;
+
+impl AtlasCloudProvider {
+    /// Construct an `AtlasCloudProvider`.
+    ///
+    /// Why: gives the factory a uniform constructor call site.
+    /// What: returns the zero-sized marker.
+    /// Test: `atlascloud::tests::name_is_atlascloud`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for AtlasCloudProvider {
+    fn name(&self) -> &str {
+        "atlascloud"
+    }
+
+    /// Translate a neutral [`ToolChoice`] into OpenAI-dialect wire JSON.
+    ///
+    /// Why: AtlasCloud uses the OpenAI `tool_choice` spelling (string policies +
+    /// `{type:function, function:{name}}` object), identical to OpenRouter,
+    /// Fireworks, and Together.
+    /// What: the OpenAI mapping.
+    /// Test: `atlascloud::tests::map_tool_choice_scalars`.
+    fn map_tool_choice(&self, choice: ToolChoice) -> Value {
+        match choice {
+            ToolChoice::None => json!("none"),
+            ToolChoice::Auto => json!("auto"),
+            ToolChoice::Required => json!("required"),
+            ToolChoice::Function(name) => json!({
+                "type": "function",
+                "function": { "name": name },
+            }),
+        }
+    }
+
+    /// Extract canonical token usage from an AtlasCloud response.
+    ///
+    /// Why: AtlasCloud returns the standard OpenAI `usage` block, already
+    /// normalised into `ChatResponse.usage` by the shared adapter's parse.
+    /// What: delegates to `ChatResponse::token_usage` (identical to the other
+    /// OpenAI-dialect providers).
+    /// Test: `atlascloud::tests::extract_usage_maps_fields`.
+    fn extract_usage(&self, response: &ChatResponse) -> TokenUsage {
+        response.clone().token_usage()
+    }
+
+    fn supports_native_tools(&self) -> bool {
+        // AtlasCloud's tool-capable models accept the native OpenAI `tools`
+        // array; mirrors the shared registry's AtlasCloud `native_tool_calling =
+        // true`.
+        true
+    }
+
+    fn supports_prompt_caching(&self) -> bool {
+        // AtlasCloud caching is provider-side/implicit: the caller cannot place
+        // Anthropic-style `cache_control` breakpoints, so tcode must never mark
+        // an AtlasCloud request with one (matching the Together precedent — the
+        // wire body carries no `cache_control` markers).
+        false
+    }
+
+    fn wants_detailed_usage(&self) -> bool {
+        // `usage:{include:true}` is an OpenRouter-only directive; AtlasCloud would
+        // not understand it. Mirrors the shared registry's AtlasCloud
+        // `detailed_usage_accounting = false`.
+        false
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `name()` returns `"atlascloud"`.
+    ///
+    /// Why: routing and telemetry distinguish AtlasCloud by name; the transport's
+    /// `provider_for_slug` and `dispatch`'s bedrock check both key off it.
+    /// What: assert the name.
+    /// Test: this test.
+    #[test]
+    fn name_is_atlascloud() {
+        assert_eq!(AtlasCloudProvider::new().name(), "atlascloud");
+    }
+
+    /// AtlasCloud reports native-tool support.
+    ///
+    /// Why: `build_request` sends the native `tools` array for tool-capable
+    /// AtlasCloud models.
+    /// What: assert `supports_native_tools()` is `true`.
+    /// Test: this test.
+    #[test]
+    fn atlascloud_supports_native_tools() {
+        assert!(AtlasCloudProvider::new().supports_native_tools());
+    }
+
+    /// AtlasCloud does NOT request OpenRouter's detailed usage accounting.
+    ///
+    /// Why: this is the exact gate that would otherwise attach the
+    /// OpenRouter-only `usage:{include:true}` directive to an AtlasCloud request —
+    /// the core reason an AtlasCloud-specific provider is needed.
+    /// What: assert `wants_detailed_usage()` is `false`.
+    /// Test: this test.
+    #[test]
+    fn atlascloud_does_not_want_detailed_usage() {
+        assert!(!AtlasCloudProvider::new().wants_detailed_usage());
+    }
+
+    /// AtlasCloud does NOT place explicit prompt-cache breakpoints.
+    ///
+    /// Why: `build_request` must never mark an AtlasCloud request with an
+    /// Anthropic-style `cache_control` breakpoint — AtlasCloud caching is
+    /// provider-side and rejects caller-placed markers.
+    /// What: assert `supports_prompt_caching()` is `false`.
+    /// Test: this test.
+    #[test]
+    fn atlascloud_does_not_support_prompt_caching() {
+        assert!(!AtlasCloudProvider::new().supports_prompt_caching());
+    }
+
+    /// `map_tool_choice` maps the scalar policies to the OpenAI wire strings.
+    ///
+    /// Why: AtlasCloud expects the OpenAI spelling; a wrong shape breaks
+    /// tool routing.
+    /// What: map each scalar variant, assert the JSON value.
+    /// Test: this test.
+    #[test]
+    fn map_tool_choice_scalars() {
+        let p = AtlasCloudProvider::new();
+        assert_eq!(p.map_tool_choice(ToolChoice::None), json!("none"));
+        assert_eq!(p.map_tool_choice(ToolChoice::Auto), json!("auto"));
+        assert_eq!(p.map_tool_choice(ToolChoice::Required), json!("required"));
+        assert_eq!(
+            p.map_tool_choice(ToolChoice::Function("search".into())),
+            json!({"type": "function", "function": {"name": "search"}})
+        );
+    }
+
+    /// `extract_usage` maps a normalised usage block into `TokenUsage`.
+    ///
+    /// Why: pins that AtlasCloud performs no extra (inconsistent) usage transform.
+    /// What: deserialise a response fixture, extract usage, assert fields.
+    /// Test: this test.
+    #[test]
+    fn extract_usage_maps_fields() {
+        let fixture = r#"{
+          "id": "ac-1",
+          "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 40, "completion_tokens": 8, "total_tokens": 48}
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+        let usage = AtlasCloudProvider::new().extract_usage(&resp);
+        assert_eq!(usage.prompt_tokens, 40);
+        assert_eq!(usage.completion_tokens, 8);
+    }
+}

--- a/crates/trusty-code/src/provider/mod.rs
+++ b/crates/trusty-code/src/provider/mod.rs
@@ -5,9 +5,9 @@
 //! not branch on the backend; it depends on the [`Provider`] trait and asks a
 //! factory for the right implementation given a model slug. This module is that
 //! seam (#1021) and the precedence resolver for which slug to use.
-//! What: Re-exports the [`Provider`] trait and [`ToolChoice`] enum, the four
+//! What: Re-exports the [`Provider`] trait and [`ToolChoice`] enum, the five
 //! concrete providers ([`OpenRouterProvider`], [`BedrockProvider`],
-//! [`FireworksProvider`], [`TogetherProvider`]), the
+//! [`FireworksProvider`], [`TogetherProvider`], [`AtlasCloudProvider`]), the
 //! [`provider_for`] factory, the [`resolve_model`] precedence function plus
 //! its [`DEFAULT_MODEL`] constant, the [`resolve_max_tokens`] precedence
 //! function plus its [`DEFAULT_MAX_TOKENS`] constant, and (#2207) the
@@ -19,6 +19,7 @@
 //! `routing.rs` and `adapter.rs`.
 
 mod adapter;
+mod atlascloud;
 mod bedrock;
 mod fireworks;
 mod openrouter;
@@ -27,6 +28,7 @@ mod together;
 mod traits;
 
 pub use adapter::provider_for;
+pub use atlascloud::AtlasCloudProvider;
 pub use bedrock::BedrockProvider;
 pub use fireworks::FireworksProvider;
 pub use openrouter::OpenRouterProvider;

--- a/crates/trusty-code/src/provider/routing.rs
+++ b/crates/trusty-code/src/provider/routing.rs
@@ -152,15 +152,21 @@ pub const DEFAULT_CONTEXT_WINDOW: usize = 128_000;
 /// Anthropic slug and the Bedrock-routed
 /// `bedrock/us.anthropic.claude-sonnet-4-6` / `-opus-*` inference-profile
 /// format, see `crate::llm::bedrock::bedrock_model_id`) -> 200,000; (2) any
-/// slug containing `gpt-4o` -> 128,000; else (3) [`DEFAULT_CONTEXT_WINDOW`].
-/// Deliberately NOT a config file or per-agent override — the window size is
-/// a property of the model itself, not something an operator should need to
-/// tune per project.
+/// slug beginning with the `atlascloud/` routing prefix -> 1,050,000 (#2536 —
+/// AtlasCloud's catalog default `openai/gpt-5.6-sol` has a 1.05M-token window,
+/// keyed off the routing prefix rather than the nested model id so the whole
+/// AtlasCloud family gets the large window); (3) any slug containing `gpt-4o` ->
+/// 128,000; else (4) [`DEFAULT_CONTEXT_WINDOW`]. Deliberately NOT a config file
+/// or per-agent override — the window size is a property of the model itself, not
+/// something an operator should need to tune per project.
 /// Test: `routing::tests::resolve_context_window_maps_bedrock_sonnet_to_200k`,
+/// `routing::tests::resolve_context_window_maps_atlascloud_to_1m`,
 /// `routing::tests::resolve_context_window_falls_back_to_default_for_unknown_model`.
 pub fn resolve_context_window(model: &str) -> usize {
     if model.contains("claude-sonnet") || model.contains("claude-opus") {
         200_000
+    } else if model.starts_with("atlascloud/") {
+        1_050_000
     } else if model.contains("gpt-4o") {
         128_000
     } else {
@@ -400,6 +406,24 @@ mod tests {
             resolve_context_window("bedrock/us.anthropic.claude-opus-4-6"),
             200_000
         );
+    }
+
+    /// An `atlascloud/*` slug maps to AtlasCloud's 1.05M-token window (#2536),
+    /// including the nested `atlascloud/openai/gpt-5.6-sol` form.
+    ///
+    /// Why: AtlasCloud's default `openai/gpt-5.6-sol` carries a 1,050,000-token
+    /// context window; keying off the `atlascloud/` routing prefix (not the
+    /// nested `gpt-4o`-adjacent model id) gives the whole family the large window
+    /// so compaction scales correctly.
+    /// What: Assert the nested and a bare AtlasCloud slug resolve to 1,050,000.
+    /// Test: this test.
+    #[test]
+    fn resolve_context_window_maps_atlascloud_to_1m() {
+        assert_eq!(
+            resolve_context_window("atlascloud/openai/gpt-5.6-sol"),
+            1_050_000
+        );
+        assert_eq!(resolve_context_window("atlascloud/deepseek-v3"), 1_050_000);
     }
 
     /// An unrecognised model slug falls back to [`DEFAULT_CONTEXT_WINDOW`].

--- a/crates/trusty-code/tests/inference_shared_adapter_e2e.rs
+++ b/crates/trusty-code/tests/inference_shared_adapter_e2e.rs
@@ -1,6 +1,6 @@
-//! Black-box e2e: prove trusty-code's OpenRouter/Fireworks/Together inference
-//! flows through the shared `trusty_common::inference` adapter (#2406, #2494,
-//! epic #2400).
+//! Black-box e2e: prove trusty-code's OpenRouter/Fireworks/Together/AtlasCloud
+//! inference flows through the shared `trusty_common::inference` adapter (#2406,
+//! #2494, #2536, epic #2400).
 //!
 //! Why: #2406's core claim is that tcode's OpenAI-compatible transport is now
 //! the shared adapter, and that Fireworks is reachable; #2494 extends the same
@@ -79,10 +79,11 @@ async fn openrouter_routes_through_shared_adapter_and_injects_usage() {
     let store = MemoryKeyStore::new();
     store.set("openrouter", "sk-or-mock").expect("seed key"); // pragma: allowlist secret
 
-    // OpenRouter → mock; Fireworks and Together base URLs are unused here.
+    // OpenRouter → mock; Fireworks, Together, AtlasCloud base URLs are unused here.
     let client = OpenAiCompatClient::with_config(
         Box::new(store),
         server.url().to_string(),
+        "http://127.0.0.1:1/unused".to_string(),
         "http://127.0.0.1:1/unused".to_string(),
         "http://127.0.0.1:1/unused".to_string(),
     );
@@ -135,11 +136,12 @@ async fn fireworks_routes_through_shared_adapter_strips_prefix_and_omits_usage()
     let store = MemoryKeyStore::new();
     store.set("fireworks", "fw-mock").expect("seed key"); // pragma: allowlist secret
 
-    // Fireworks → mock; OpenRouter and Together base URLs are unused here.
+    // Fireworks → mock; OpenRouter, Together, AtlasCloud base URLs are unused here.
     let client = OpenAiCompatClient::with_config(
         Box::new(store),
         "http://127.0.0.1:1/unused".to_string(),
         server.url().to_string(),
+        "http://127.0.0.1:1/unused".to_string(),
         "http://127.0.0.1:1/unused".to_string(),
     );
 
@@ -185,12 +187,13 @@ async fn together_routes_through_shared_adapter_strips_prefix_and_omits_usage() 
     let store = MemoryKeyStore::new();
     store.set("together", "tgp_v1_mock").expect("seed key"); // pragma: allowlist secret
 
-    // Together → mock; OpenRouter and Fireworks base URLs are unused here.
+    // Together → mock; OpenRouter, Fireworks, AtlasCloud base URLs are unused here.
     let client = OpenAiCompatClient::with_config(
         Box::new(store),
         "http://127.0.0.1:1/unused".to_string(),
         "http://127.0.0.1:1/unused".to_string(),
         server.url().to_string(),
+        "http://127.0.0.1:1/unused".to_string(),
     );
 
     let resp = client
@@ -221,5 +224,66 @@ async fn together_routes_through_shared_adapter_strips_prefix_and_omits_usage() 
     assert!(
         body.get("usage").is_none() || body["usage"].is_null(),
         "Together must NOT receive the OpenRouter-only usage directive"
+    );
+}
+
+/// An AtlasCloud-routed request flows through the shared adapter, which strips
+/// the `atlascloud/` routing prefix down to the AtlasCloud-native slug (here the
+/// nested `openai/gpt-5.6-sol`) and sends NO usage directive (AtlasCloud does not
+/// support the OpenRouter directive).
+///
+/// Why: this is the concrete payoff of #2536 — AtlasCloud is reachable, routed
+/// through the shared adapter, with the correct provider-specific wire shape:
+/// `Bearer` auth, the prefix-stripped model id (only the leading `atlascloud/`
+/// segment removed, the nested `openai/`-shaped id preserved), and no usage
+/// directive.
+/// What: point the AtlasCloud base URL at the mock, chat with a nested
+/// `atlascloud/openai/gpt-5.6-sol` slug, then assert the parsed response AND the
+/// captured wire request (path, auth, stripped model, absent usage directive).
+/// Test: this test.
+#[tokio::test]
+async fn atlascloud_routes_through_shared_adapter_strips_prefix_and_omits_usage() {
+    let server = MockInferenceServer::spawn(200, canned_response())
+        .await
+        .expect("spawn mock");
+
+    let store = MemoryKeyStore::new();
+    store.set("atlascloud", "ac_mock").expect("seed key"); // pragma: allowlist secret
+
+    // AtlasCloud → mock; OpenRouter, Fireworks, Together base URLs are unused here.
+    let client = OpenAiCompatClient::with_config(
+        Box::new(store),
+        "http://127.0.0.1:1/unused".to_string(),
+        "http://127.0.0.1:1/unused".to_string(),
+        "http://127.0.0.1:1/unused".to_string(),
+        server.url().to_string(),
+    );
+
+    let resp = client
+        .chat(&request_for("atlascloud/openai/gpt-5.6-sol"))
+        .await
+        .expect("chat through shared atlascloud adapter");
+
+    // Response flowed back through the tcode conversion.
+    assert_eq!(resp.first_text().as_deref(), Some("pong-mock"));
+    assert_eq!(resp.token_usage().prompt_tokens, 5);
+
+    let captured = server.last_request().expect("one request captured");
+    assert_eq!(captured.method, "POST");
+    assert_eq!(captured.path, "/chat/completions");
+    assert!(
+        captured
+            .header("authorization")
+            .is_some_and(|v| v.starts_with("Bearer ")),
+        "shared adapter must send a Bearer auth header"
+    );
+    let body = captured.body.expect("json body");
+    assert_eq!(
+        body["model"], "openai/gpt-5.6-sol",
+        "only the leading atlascloud/ routing prefix must be stripped, preserving the nested id"
+    );
+    assert!(
+        body.get("usage").is_none() || body["usage"].is_null(),
+        "AtlasCloud must NOT receive the OpenRouter-only usage directive"
     );
 }

--- a/crates/trusty-common/src/inference/credentials/resolver.rs
+++ b/crates/trusty-common/src/inference/credentials/resolver.rs
@@ -45,6 +45,7 @@ pub fn env_var_for(provider: &str) -> Option<&'static str> {
         "anthropic" => Some("ANTHROPIC_API_KEY"),
         "openai" => Some("OPENAI_API_KEY"),
         "together" => Some("TOGETHER_API_KEY"),
+        "atlascloud" => Some("ATLASCLOUD_API_KEY"),
         _ => None,
     }
 }
@@ -136,6 +137,7 @@ mod tests {
         assert_eq!(env_var_for("anthropic"), Some("ANTHROPIC_API_KEY"));
         assert_eq!(env_var_for("OPENAI"), Some("OPENAI_API_KEY"));
         assert_eq!(env_var_for("together"), Some("TOGETHER_API_KEY"));
+        assert_eq!(env_var_for("atlascloud"), Some("ATLASCLOUD_API_KEY"));
     }
 
     /// Why: an unmapped provider must not panic or synthesise a guess.

--- a/crates/trusty-common/src/inference/providers/atlascloud.rs
+++ b/crates/trusty-common/src/inference/providers/atlascloud.rs
@@ -1,0 +1,168 @@
+//! AtlasCloud adapter — a thin config over the OpenAI-compatible core (#2536).
+//!
+//! Why: AtlasCloud (atlascloud.ai) serves its catalog behind the same
+//! OpenAI-compatible `/chat/completions` schema, so it reuses the shared core
+//! wholesale. Its only deltas from OpenRouter are the base URL
+//! (`api.atlascloud.ai/v1`), no attribution headers, and — per the capability
+//! registry seed — `detailed_usage_accounting = false` (the `usage:{include:true}`
+//! directive is OpenRouter-specific). Native OpenAI-style tool-calling stays on.
+//! Modeled exactly like the Together adapter (#2488).
+//! What: [`build`] constructs an [`OpenAiCompatAdapter`] for a resolved AtlasCloud
+//! credential against a given base URL; [`factory`] is the production factory
+//! (real base URL) registered into the [`crate::inference::Configurator`].
+//! Test: inline `#[ignore]` `live_atlascloud_call`; offline unit tests below.
+
+use super::openai_compat::{OpenAiCompatAdapter, OpenAiCompatConfig};
+use crate::inference::adapter::InferenceAdapter;
+use crate::inference::configurator::ResolvedProvider;
+use crate::inference::error::InferenceError;
+use crate::inference::registry::ProviderId;
+
+/// AtlasCloud API root; the core appends `/chat/completions`.
+pub const ATLASCLOUD_BASE_URL: &str = "https://api.atlascloud.ai/v1";
+
+/// Build an AtlasCloud adapter for a resolved credential against `base_url`.
+///
+/// Why: the base URL is a parameter (not a constant) so tests can point the
+/// exact same adapter at [`crate::inference::test_support::MockInferenceServer`]
+/// while production uses [`ATLASCLOUD_BASE_URL`].
+/// What: requires the resolved key (AtlasCloud is a keyed provider — a missing
+/// key is [`InferenceError::MissingCredential`]), then constructs an
+/// [`OpenAiCompatAdapter`] with no attribution headers and AtlasCloud's registry
+/// capabilities (`detailed_usage_accounting = false`), so the core sends a bare
+/// OpenAI-compatible body.
+/// Test: `factory_builds_named_adapter`, `missing_key_errors`.
+pub fn build(
+    resolved: &ResolvedProvider,
+    base_url: &str,
+) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    let key = resolved
+        .key()
+        .ok_or(InferenceError::MissingCredential {
+            provider: ProviderId::AtlasCloud,
+        })?
+        .clone();
+    let config = OpenAiCompatConfig {
+        name: ProviderId::AtlasCloud.as_str().to_string(),
+        base_url: base_url.to_string(),
+        api_key: key,
+        extra_headers: Vec::new(),
+        capabilities: *resolved.capabilities(),
+    };
+    Ok(Box::new(OpenAiCompatAdapter::new(config)?))
+}
+
+/// Production factory: build an AtlasCloud adapter against the real base URL.
+///
+/// Why: this is what [`super::register_default_factories`] registers into the
+/// [`crate::inference::Configurator`] so an `atlascloud/*` slug (whose key
+/// resolves) yields a live AtlasCloud adapter.
+/// What: delegates to [`build`] with [`ATLASCLOUD_BASE_URL`].
+/// Test: the offline default-factory round-trip in
+/// `crates/trusty-common/tests/inference_adapters.rs` and the `#[ignore]` live
+/// smoke test below.
+pub fn factory(resolved: &ResolvedProvider) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    build(resolved, ATLASCLOUD_BASE_URL)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::types::{ChatMessage, ChatRequest, SecretString};
+
+    const ATLASCLOUD_MODEL: &str = "openai/gpt-5.6-sol";
+
+    fn resolved(key: &str) -> ResolvedProvider {
+        ResolvedProvider::new(
+            ProviderId::AtlasCloud,
+            "atlascloud/openai/gpt-5.6-sol".to_string(),
+            Some(SecretString::new(key)),
+        )
+    }
+
+    /// Why: the factory must build a named AtlasCloud adapter that does NOT
+    /// request detailed usage accounting and advertises native OpenAI-style tools.
+    /// Test: itself.
+    #[test]
+    fn factory_builds_named_adapter() {
+        let adapter = build(&resolved("ac_test_key"), ATLASCLOUD_BASE_URL).expect("built");
+        assert_eq!(adapter.name(), "atlascloud");
+        assert!(!adapter.wants_detailed_usage());
+        assert!(adapter.supports_native_tools());
+        assert_eq!(adapter.capabilities().id, ProviderId::AtlasCloud);
+    }
+
+    /// Why: a resolved provider with no key must be an explicit alarm.
+    /// Test: itself.
+    #[test]
+    fn missing_key_errors() {
+        let resolved = ResolvedProvider::new(
+            ProviderId::AtlasCloud,
+            "atlascloud/openai/gpt-5.6-sol".to_string(),
+            None,
+        );
+        let Err(err) = build(&resolved, ATLASCLOUD_BASE_URL) else {
+            panic!("expected MissingCredential");
+        };
+        assert!(matches!(
+            err,
+            InferenceError::MissingCredential {
+                provider: ProviderId::AtlasCloud
+            }
+        ));
+    }
+
+    /// Live smoke test: send a trivial prompt to AtlasCloud's default model.
+    ///
+    /// Why: end-to-end validation against the real API that the AtlasCloud config
+    /// + core produce a non-empty response and non-zero usage. Ignored so CI
+    /// stays offline; run locally with a real key.
+    /// What: reads `ATLASCLOUD_API_KEY` from env and SKIPS (does not fail) when
+    /// absent/empty; otherwise builds the adapter via [`build`] and asserts a
+    /// non-empty reply with `prompt_tokens > 0`.
+    /// Test: `cargo test -p trusty-common --features inference-client,axum-server \
+    ///        atlascloud -- --ignored --nocapture` (with `ATLASCLOUD_API_KEY` set).
+    #[tokio::test]
+    #[ignore = "requires ATLASCLOUD_API_KEY; skipped in CI"]
+    async fn live_atlascloud_call() {
+        let Ok(key) = std::env::var("ATLASCLOUD_API_KEY") else {
+            eprintln!("ATLASCLOUD_API_KEY not set — skipping live test");
+            return;
+        };
+        if key.trim().is_empty() {
+            eprintln!("ATLASCLOUD_API_KEY is empty — skipping live test");
+            return;
+        }
+
+        let resolved = ResolvedProvider::new(
+            ProviderId::AtlasCloud,
+            ATLASCLOUD_MODEL.to_string(),
+            Some(SecretString::new(key)),
+        );
+        let adapter = build(&resolved, ATLASCLOUD_BASE_URL).expect("build adapter");
+
+        let mut req = ChatRequest::new(
+            ATLASCLOUD_MODEL,
+            vec![
+                ChatMessage::system("You are a concise assistant."),
+                ChatMessage::user("Reply with exactly the word: pong"),
+            ],
+        );
+        req.temperature = Some(0.0);
+        req.max_tokens = Some(16);
+
+        let resp = adapter.chat(&req).await.expect("live chat");
+        let text = resp.first_text().expect("assistant text");
+        assert!(!text.is_empty(), "assistant text was empty");
+        assert!(
+            resp.usage().prompt_tokens > 0,
+            "prompt_tokens should be > 0"
+        );
+        eprintln!(
+            "live atlascloud ok — text: {text:?}, usage: {:?}",
+            resp.usage()
+        );
+    }
+}

--- a/crates/trusty-common/src/inference/providers/mod.rs
+++ b/crates/trusty-common/src/inference/providers/mod.rs
@@ -15,6 +15,7 @@
 //! Test: each submodule's inline `tests` + the offline mock-server round-trip in
 //! `crates/trusty-common/tests/inference_adapters.rs`.
 
+pub mod atlascloud;
 pub mod fireworks;
 pub mod openai;
 pub mod openai_compat;
@@ -32,8 +33,8 @@ use crate::inference::registry::ProviderId;
 /// adapter this ticket ships, rather than remembering each `register` line. The
 /// configurator stays empty by default (no implicit adapters) — this is the
 /// explicit opt-in that turns resolution into live adapters.
-/// What: registers the OpenRouter, Fireworks, OpenAI, and Together (#2488)
-/// production factories (each pointed at its real base URL) under their
+/// What: registers the OpenRouter, Fireworks, OpenAI, Together (#2488), and
+/// AtlasCloud (#2536) production factories (each pointed at its real base URL) under their
 /// [`ProviderId`]. Bedrock and Anthropic-direct are intentionally NOT registered
 /// here (later waves).
 /// Test: `crates/trusty-common/tests/inference_adapters.rs::default_factories_register_openai_dialect`.
@@ -42,4 +43,5 @@ pub fn register_default_factories(cfg: &mut Configurator) {
     cfg.register(ProviderId::Fireworks, Box::new(fireworks::factory));
     cfg.register(ProviderId::OpenAI, Box::new(openai::factory));
     cfg.register(ProviderId::Together, Box::new(together::factory));
+    cfg.register(ProviderId::AtlasCloud, Box::new(atlascloud::factory));
 }

--- a/crates/trusty-common/src/inference/registry/mod.rs
+++ b/crates/trusty-common/src/inference/registry/mod.rs
@@ -46,6 +46,8 @@ pub enum ProviderId {
     OpenAI,
     /// Together.ai (OpenAI-compatible inference; extension provider, #2488).
     Together,
+    /// AtlasCloud (OpenAI-compatible inference; extension provider, #2536).
+    AtlasCloud,
 }
 
 impl ProviderId {
@@ -55,7 +57,7 @@ impl ProviderId {
     /// Why: one canonical spelling per provider that never changes across
     /// releases.
     /// What: `"openrouter"`, `"fireworks"`, `"bedrock"`, `"anthropic"`,
-    /// `"openai"`, `"together"`.
+    /// `"openai"`, `"together"`, `"atlascloud"`.
     /// Test: `provider_id_round_trips`.
     pub fn as_str(self) -> &'static str {
         match self {
@@ -65,6 +67,7 @@ impl ProviderId {
             Self::Anthropic => "anthropic",
             Self::OpenAI => "openai",
             Self::Together => "together",
+            Self::AtlasCloud => "atlascloud",
         }
     }
 
@@ -88,7 +91,7 @@ impl ProviderId {
     ///
     /// Why: stage 1 of the configurator's two-stage resolver keys off the slug
     /// prefix (`bedrock/`, `fireworks/`, `anthropic/`, `openai/`, `together/`,
-    /// `openrouter/`); this is the single mapping it uses.
+    /// `atlascloud/`, `openrouter/`); this is the single mapping it uses.
     /// What: matches the segment before the first `/` case-insensitively;
     /// returns `None` for a bare slug or an unrecognised prefix (the caller then
     /// falls back to the OpenRouter default).
@@ -102,6 +105,7 @@ impl ProviderId {
             "anthropic" => Some(Self::Anthropic),
             "openai" => Some(Self::OpenAI),
             "together" => Some(Self::Together),
+            "atlascloud" => Some(Self::AtlasCloud),
             _ => None,
         }
     }
@@ -188,7 +192,7 @@ pub struct ProviderCapabilities {
 /// trusty-review's model notes (structured output).
 /// What: one entry per [`ProviderId`], indexed by [`capabilities`].
 /// Test: `all_providers_seeded`.
-const SEED: [ProviderCapabilities; 6] = [
+const SEED: [ProviderCapabilities; 7] = [
     ProviderCapabilities {
         id: ProviderId::OpenRouter,
         native_tool_calling: true,
@@ -276,6 +280,27 @@ const SEED: [ProviderCapabilities; 6] = [
         default_model: "meta-llama/Llama-3.3-70B-Instruct-Turbo",
         credential_env: Some("TOGETHER_API_KEY"),
     },
+    // AtlasCloud (#2536) — OpenAI-compatible `/chat/completions`, Bearer auth,
+    // native OpenAI-style tool calling. Modeled exactly like Together/OpenAI-direct:
+    // `prompt_caching = true` (caching happens provider-side; the caller cannot
+    // place `cache_control` breakpoints) and `detailed_usage_accounting = false`
+    // (the `usage:{include:true}` directive is OpenRouter-specific — a live probe
+    // is confirming AtlasCloud's `usage` shape; flip this only if it reports
+    // cost/cache fields). Default model + context window are AtlasCloud's own
+    // catalog numbers for `openai/gpt-5.6-sol` (1.05M-token window).
+    ProviderCapabilities {
+        id: ProviderId::AtlasCloud,
+        native_tool_calling: true,
+        tool_dialect: ToolDialect::OpenAiFunctions,
+        streaming: true,
+        prompt_caching: true,
+        structured_output: true,
+        vision: false,
+        detailed_usage_accounting: false,
+        max_context_window: 1_050_000,
+        default_model: "openai/gpt-5.6-sol",
+        credential_env: Some("ATLASCLOUD_API_KEY"),
+    },
 ];
 
 /// Look up the capability descriptor for a provider.
@@ -331,6 +356,7 @@ mod tests {
             ProviderId::Anthropic,
             ProviderId::OpenAI,
             ProviderId::Together,
+            ProviderId::AtlasCloud,
         ] {
             assert_eq!(id.to_string(), id.as_str());
             assert_eq!(ProviderId::from_slug_prefix(&format!("{id}/x")), Some(id));
@@ -373,7 +399,7 @@ mod tests {
     /// Test: itself.
     #[test]
     fn all_providers_seeded() {
-        assert_eq!(all().len(), 6);
+        assert_eq!(all().len(), 7);
         for id in [
             ProviderId::OpenRouter,
             ProviderId::Fireworks,
@@ -381,6 +407,7 @@ mod tests {
             ProviderId::Anthropic,
             ProviderId::OpenAI,
             ProviderId::Together,
+            ProviderId::AtlasCloud,
         ] {
             let caps = capabilities(id);
             assert_eq!(caps.id, id);
@@ -408,6 +435,38 @@ mod tests {
             Some(ProviderId::Together)
         );
         assert_eq!(ProviderId::Together.credential_name(), Some("together"));
+    }
+
+    /// Why: AtlasCloud (#2536) must resolve by id, by name, and by slug prefix,
+    /// carry its OpenAI-compat capability posture (native tools, OpenAI dialect,
+    /// `ATLASCLOUD_API_KEY` credential env), and expose its catalog defaults
+    /// (`openai/gpt-5.6-sol`, 1.05M-token window). The nested `openai/`-shaped
+    /// default model must NOT trip the prefix resolver — the routing prefix is
+    /// `atlascloud/`, not the model id.
+    /// Test: itself.
+    #[test]
+    fn atlascloud_seeded_with_openai_compat_posture() {
+        assert_eq!(
+            ProviderId::from_slug_prefix("atlascloud/openai/gpt-5.6-sol"),
+            Some(ProviderId::AtlasCloud)
+        );
+        assert_eq!(
+            ProviderId::from_slug_prefix("atlascloud/deepseek-v3"),
+            Some(ProviderId::AtlasCloud)
+        );
+        let caps = capabilities(ProviderId::AtlasCloud);
+        assert_eq!(caps.id, ProviderId::AtlasCloud);
+        assert!(caps.native_tool_calling);
+        assert_eq!(caps.tool_dialect, ToolDialect::OpenAiFunctions);
+        assert!(!caps.detailed_usage_accounting);
+        assert_eq!(caps.credential_env, Some("ATLASCLOUD_API_KEY"));
+        assert_eq!(caps.default_model, "openai/gpt-5.6-sol");
+        assert_eq!(caps.max_context_window, 1_050_000);
+        assert_eq!(
+            capabilities_for("AtlasCloud").map(|c| c.id),
+            Some(ProviderId::AtlasCloud)
+        );
+        assert_eq!(ProviderId::AtlasCloud.credential_name(), Some("atlascloud"));
     }
 
     /// Why: the by-name query must be case-insensitive and total for knowns.

--- a/crates/trusty-common/tests/inference_adapters.rs
+++ b/crates/trusty-common/tests/inference_adapters.rs
@@ -16,7 +16,7 @@
 use serde_json::{Value, json};
 use serial_test::serial;
 use trusty_common::inference::credentials::{KeyStore, MemoryKeyStore};
-use trusty_common::inference::providers::{fireworks, openai, openrouter, together};
+use trusty_common::inference::providers::{atlascloud, fireworks, openai, openrouter, together};
 use trusty_common::inference::test_support::MockInferenceServer;
 use trusty_common::inference::{
     CacheControl, ChatMessage, ChatRequest, Configurator, FunctionDefinition, InferenceError,
@@ -32,6 +32,7 @@ fn clear_provider_env() {
         "OPENAI_API_KEY",
         "FIREWORKS_API_KEY",
         "TOGETHER_API_KEY",
+        "ATLASCLOUD_API_KEY",
     ] {
         // SAFETY: every caller is `#[serial(dotenv_credential_env)]`, matching
         // the lock the credential resolver's own env-mutating tests use.
@@ -356,6 +357,56 @@ async fn together_tool_call_round_trip_no_usage_directive() {
     );
 }
 
+// ── AtlasCloud: bare OpenAI body, no usage directive, nested-slug routing ────────
+
+/// Why: driving AtlasCloud through the `Configurator` must (a) resolve the
+/// `atlascloud/openai/gpt-5.6-sol` slug (whose model id is itself `vendor/model`
+/// shaped) to the AtlasCloud adapter, (b) send a bare OpenAI-shaped body (bearer
+/// auth, no attribution headers, NO detailed-usage directive), and (c) parse the
+/// response text back — the full resolve→build→chat→usage cycle against a real
+/// socket, exactly like the Together e2e.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn atlascloud_round_trip_no_usage_directive() {
+    clear_provider_env();
+    let server = MockInferenceServer::spawn(200, text_response_body())
+        .await
+        .expect("spawn");
+    let base = server.url().to_string();
+
+    let store = MemoryKeyStore::new();
+    // AtlasCloud key present AND explicit atlascloud/ prefix → resolves to AtlasCloud.
+    store.set("atlascloud", "ac_fake").unwrap(); // pragma: allowlist secret
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::AtlasCloud,
+        Box::new(move |r: &ResolvedProvider| atlascloud::build(r, &base)),
+    );
+
+    let adapter = cfg
+        .build("atlascloud/openai/gpt-5.6-sol", &store)
+        .expect("build");
+    assert_eq!(adapter.name(), "atlascloud");
+    assert_eq!(adapter.capabilities().id, ProviderId::AtlasCloud);
+
+    let req = ChatRequest::new("openai/gpt-5.6-sol", vec![ChatMessage::user("ping")]);
+    let resp = adapter.chat(&req).await.expect("chat ok");
+    assert_eq!(resp.first_text().as_deref(), Some("pong"));
+
+    // Request translation: bearer auth, no attribution, NO detailed-usage directive.
+    let sent = server.last_request().expect("captured");
+    assert_eq!(sent.method, "POST");
+    assert_eq!(sent.path, "/chat/completions");
+    assert_eq!(sent.header("authorization"), Some("Bearer ac_fake")); // pragma: allowlist secret
+    assert!(sent.header("http-referer").is_none());
+    let body = sent.body.expect("json");
+    assert_eq!(body["model"], "openai/gpt-5.6-sol");
+    assert!(
+        body.get("usage").is_none() || body["usage"].is_null(),
+        "AtlasCloud must not send the detailed-usage directive: {body}"
+    );
+}
+
 // ── Error classification through a real socket ───────────────────────────────────
 
 /// Why: a non-2xx provider status must surface as a classified `InferenceError`
@@ -401,6 +452,7 @@ fn default_factories_register_openai_dialect() {
     let store = MemoryKeyStore::new();
     store.set("openrouter", "sk-or-fake").unwrap(); // pragma: allowlist secret
     store.set("together", "tgp_v1_fake").unwrap(); // pragma: allowlist secret
+    store.set("atlascloud", "ac_fake").unwrap(); // pragma: allowlist secret
 
     let mut cfg = Configurator::new();
     register_default_factories(&mut cfg);
@@ -414,6 +466,13 @@ fn default_factories_register_openai_dialect() {
         .build("together/meta-llama/Llama-3.3-70B-Instruct-Turbo", &store)
         .expect("build together");
     assert_eq!(together.name(), "together");
+
+    // AtlasCloud (#2536) is registered by the default set.
+    let atlascloud = cfg
+        .build("atlascloud/openai/gpt-5.6-sol", &store)
+        .expect("build atlascloud");
+    assert_eq!(atlascloud.name(), "atlascloud");
+    assert_eq!(atlascloud.capabilities().id, ProviderId::AtlasCloud);
 
     // Bedrock is intentionally not registered by the default set.
     let Err(err) = cfg.build("bedrock/us.anthropic.claude-sonnet-4-5", &store) else {

--- a/crates/trusty-common/tests/inference_foundation.rs
+++ b/crates/trusty-common/tests/inference_foundation.rs
@@ -49,6 +49,7 @@ fn registry_seeds_all_providers() {
         (ProviderId::Anthropic, "anthropic", true),
         (ProviderId::OpenAI, "openai", true),
         (ProviderId::Together, "together", true),
+        (ProviderId::AtlasCloud, "atlascloud", true),
     ];
     for (id, name, has_key_env) in expected {
         let by_id = capabilities(id);


### PR DESCRIPTION
Closes #2536

## Summary

Adds **AtlasCloud** (atlascloud.ai) as a first-class, OpenAI chat-completions-compatible direct inference provider, wired end-to-end so it is routable from trusty-code's agent loop. Mirrors the Together provider precedent (#2488/#2494).

- Base URL `https://api.atlascloud.ai/v1` (`POST /v1/chat/completions`), `Authorization: Bearer <key>`, no custom headers.
- Credential env var `ATLASCLOUD_API_KEY` (resolved at runtime — no key in code).
- Default model `openai/gpt-5.6-sol`, context window **1,050,000** tokens.
- Model slug: `atlascloud/<model>` (e.g. `atlascloud/openai/gpt-5.6-sol`).

## Part 1 — trusty-common (the provider)

- `registry/mod.rs`: `ProviderId::AtlasCloud` + `as_str()`/`from_slug_prefix()`/`credential_name()` arms; new `SEED` `ProviderCapabilities` entry (OpenAI dialect, `native_tool_calling: true`, streaming on, `detailed_usage_accounting: false`, `credential_env: Some("ATLASCLOUD_API_KEY")`, `default_model: "openai/gpt-5.6-sol"`, `max_context_window: 1_050_000`). Provider count `6 → 7`.
- `credentials/resolver.rs`: `"atlascloud" => Some("ATLASCLOUD_API_KEY")` (kept in sync with the SEED's `credential_env`).
- New `providers/atlascloud.rs`: `ATLASCLOUD_BASE_URL` + `build`/`factory` over the shared `OpenAiCompatAdapter`, no extra headers.
- `providers/mod.rs`: `pub mod atlascloud;` + registration in `register_default_factories`.

## Part 2 — trusty-code (routable in the agent loop)

- `llm/client.rs`: `provider_for_slug`/`wire_model`/`build_adapter` arms so `atlascloud/*` routes to `ProviderId::AtlasCloud` (requiring `ATLASCLOUD_API_KEY`, no silent OpenRouter fallback). New `TCODE_ATLASCLOUD_BASE_URL` override + `atlascloud_base` plumbed through `with_config`.
- `provider/atlascloud.rs` (new): `AtlasCloudProvider` normalisation profile (OpenAI `tool_choice`, native tools, no `cache_control` breakpoints, no detailed-usage directive).
- `provider/adapter.rs`: `atlascloud/` routing prefix. `provider/routing.rs`: `atlascloud/` → 1,050,000-token context-window default.

### Routing-prefix + collision handling

AtlasCloud model ids are themselves `vendor/model`-shaped, so the full user slug is `atlascloud/openai/gpt-5.6-sol`. Only the leading `atlascloud/` routing segment is stripped; the remainder (`openai/gpt-5.6-sol`) is sent as the wire `model`. A bare `atlascloud/deepseek-v3` → wire `deepseek-v3`. Covered by dedicated prefix-strip unit tests (nested + bare) plus an offline mock-server e2e.

## Tests / gate (all green, offline)

- `cargo build --workspace` ✓
- `cargo test -p trusty-common --features inference-client,axum-server` ✓
- `cargo test -p trusty-code` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ (exit 0)
- `cargo fmt --check` ✓
- `bash scripts/check_line_cap.sh` ✓ (0 violations; both new files well under the 500-SLOC prod cap)

The `#[ignore]`d `live_atlascloud_call` is not run here (validated separately with a real key).

## Note

`detailed_usage_accounting` is **false** for now (same posture as Together/OpenAI/Fireworks). A live probe of AtlasCloud's `usage` shape is running separately — flip to `true` only if it returns cost/cache fields.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools