### PR TITLE
feat(trusty-common): Anthropic-direct + OpenAI-direct inference adapters (closes #2408)

### DIFF
--- a/crates/trusty-common/src/inference/providers/anthropic/mod.rs
+++ b/crates/trusty-common/src/inference/providers/anthropic/mod.rs
@@ -1,0 +1,348 @@
+//! Anthropic-direct adapter — the native Messages-API inference backend
+//! (issue #2408, epic #2400 Wave 2).
+//!
+//! Why: Anthropic's first-party API speaks its OWN wire format (`/v1/messages`
+//! with `x-api-key` + `anthropic-version` headers, a top-level `system` param,
+//! `content` blocks, `cache_control` breakpoints, and `input_tokens`-shaped
+//! usage) — NOT the OpenAI `/chat/completions` schema the shared
+//! [`super::openai_compat`] core speaks. Routing it through that core would drop
+//! the system prompt, mis-shape tools, and report zero usage. So Anthropic-direct
+//! needs a dedicated adapter with its own request/response translation (in the
+//! [`request`]/[`response`] submodules) rather than a thin config over the
+//! OpenAI-compat core.
+//! What: [`AnthropicAdapter`] (the [`InferenceAdapter`] impl owning the reqwest
+//! POST with Anthropic auth/version headers), [`build`]/[`factory`] (the
+//! configurator construction path), and the [`ANTHROPIC_BASE_URL`]/
+//! [`ANTHROPIC_VERSION`] constants. The neutral↔Anthropic translation lives in
+//! the two submodules; this file owns transport + trait wiring.
+//! Test: inline `tests` — `factory_builds_named_adapter`, `missing_key_errors`,
+//! `endpoint_appends_messages_path`, `map_tool_choice_uses_anthropic_dialect`,
+//! and the `#[ignore]` `live_anthropic_call`; offline HTTP round-trip in
+//! `crates/trusty-common/tests/inference_adapters.rs`.
+
+pub mod request;
+pub mod response;
+
+pub use request::anthropic_tool_choice;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::inference::adapter::InferenceAdapter;
+use crate::inference::configurator::ResolvedProvider;
+use crate::inference::error::InferenceError;
+use crate::inference::registry::{ProviderCapabilities, ProviderId};
+use crate::inference::types::{ChatRequest, ChatResponse, SecretString, ToolChoice};
+
+/// Anthropic API root; the adapter appends `/messages`.
+pub const ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com/v1";
+
+/// The `anthropic-version` header value (the current stable Messages API date).
+pub const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Fallback `max_tokens` when the caller left it unset — Anthropic REQUIRES the
+/// field, so an adapter that forwarded `None` would 400 on every call.
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+/// The native Anthropic Messages-API inference adapter.
+///
+/// Why: Anthropic's wire format has no OpenAI-compatible equivalent, so it owns a
+/// bespoke adapter rather than a thin config over the shared core — the request
+/// and response translation are handled by the [`request`]/[`response`]
+/// submodules, and this struct owns only the HTTP transport (auth via `x-api-key`,
+/// not `Authorization: Bearer`).
+/// What: wraps a cloneable `reqwest::Client`, the precomputed `/messages`
+/// endpoint, the redacted key, and the capability descriptor. The API key is held
+/// as a [`SecretString`] and only ever placed in the `x-api-key` header.
+/// Test: inline `tests`; offline round-trip in
+/// `crates/trusty-common/tests/inference_adapters.rs`.
+pub struct AnthropicAdapter {
+    endpoint: String,
+    api_key: SecretString,
+    capabilities: ProviderCapabilities,
+    http: Client,
+}
+
+impl AnthropicAdapter {
+    /// Build an adapter for a resolved credential against `base_url`.
+    ///
+    /// Why: the single construction path the factory funnels through; `base_url`
+    /// is a parameter so tests can point the same adapter at
+    /// [`crate::inference::test_support::MockInferenceServer`].
+    /// What: precomputes the `/messages` endpoint (tolerating a trailing slash),
+    /// builds a rustls `reqwest::Client`, and stores the config. A client-build
+    /// failure maps to [`InferenceError::Transport`] rather than panicking.
+    /// Test: `endpoint_appends_messages_path`.
+    pub fn new(
+        base_url: &str,
+        api_key: SecretString,
+        capabilities: ProviderCapabilities,
+    ) -> Result<Self, InferenceError> {
+        let endpoint = format!("{}/messages", base_url.trim_end_matches('/'));
+        let http = Client::builder()
+            .use_rustls_tls()
+            .build()
+            .map_err(|e| InferenceError::Transport(e.to_string()))?;
+        Ok(Self {
+            endpoint,
+            api_key,
+            capabilities,
+            http,
+        })
+    }
+
+    /// The resolved `/messages` endpoint this adapter POSTs to.
+    ///
+    /// Why: exposed for diagnostics and the inline endpoint-construction test.
+    /// What: the precomputed absolute URL.
+    /// Test: `endpoint_appends_messages_path`.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+/// Build an Anthropic-direct adapter for a resolved credential against `base_url`.
+///
+/// Why: the base URL is a parameter (not a constant) so tests point the exact
+/// same adapter at the mock server while production uses [`ANTHROPIC_BASE_URL`].
+/// What: requires the resolved key (Anthropic is a keyed provider — a missing key
+/// is [`InferenceError::MissingCredential`]), then constructs an
+/// [`AnthropicAdapter`] with Anthropic's registry capabilities.
+/// Test: `factory_builds_named_adapter`, `missing_key_errors`;
+/// `crates/trusty-common/tests/inference_adapters.rs`.
+pub fn build(
+    resolved: &ResolvedProvider,
+    base_url: &str,
+) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    let key = resolved
+        .key()
+        .ok_or(InferenceError::MissingCredential {
+            provider: ProviderId::Anthropic,
+        })?
+        .clone();
+    Ok(Box::new(AnthropicAdapter::new(
+        base_url,
+        key,
+        *resolved.capabilities(),
+    )?))
+}
+
+/// Production factory: build an Anthropic adapter against the real base URL.
+///
+/// Why: registered by [`super::register_default_factories`] so an `anthropic/*`
+/// slug (whose key resolves) yields a live first-party Anthropic adapter.
+/// What: delegates to [`build`] with [`ANTHROPIC_BASE_URL`].
+/// Test: `crates/trusty-common/tests/inference_adapters.rs` (via a mock-URL
+/// factory) and the `#[ignore]` `live_anthropic_call` below.
+pub fn factory(resolved: &ResolvedProvider) -> Result<Box<dyn InferenceAdapter>, InferenceError> {
+    build(resolved, ANTHROPIC_BASE_URL)
+}
+
+#[async_trait]
+impl InferenceAdapter for AnthropicAdapter {
+    /// The stable provider name (`"anthropic"`).
+    fn name(&self) -> &str {
+        ProviderId::Anthropic.as_str()
+    }
+
+    /// The provider's capability descriptor.
+    fn capabilities(&self) -> &ProviderCapabilities {
+        &self.capabilities
+    }
+
+    /// Translate a neutral [`ToolChoice`] into the Anthropic dialect.
+    ///
+    /// Why: Anthropic spells tool-choice differently from OpenAI (`any` forces a
+    /// call; a specific call is `{type:"tool",name}`); overriding the default
+    /// keeps callers dialect-agnostic.
+    /// What: delegates to [`anthropic_tool_choice`].
+    /// Test: `map_tool_choice_uses_anthropic_dialect`.
+    fn map_tool_choice(&self, choice: ToolChoice) -> Value {
+        anthropic_tool_choice(choice)
+    }
+
+    /// POST a chat request to the Anthropic Messages API and translate the reply.
+    ///
+    /// Why: the one method the agent loop depends on; all Anthropic-specific HTTP
+    /// mechanics (auth via `x-api-key`, the `anthropic-version` header, status
+    /// classification, native response parsing) live here so callers only speak
+    /// [`ChatRequest`]/[`ChatResponse`].
+    /// What: translates the request via [`request::build_body`], POSTs it with the
+    /// `x-api-key` + `anthropic-version` headers, and maps the outcome — a
+    /// transport failure to [`InferenceError::Transport`], a non-2xx status to
+    /// [`InferenceError::Api`], and the success body through [`response::parse`].
+    /// The API key is only ever placed in the `x-api-key` header and never appears
+    /// in a returned error.
+    /// Test: `crates/trusty-common/tests/inference_adapters.rs`.
+    async fn chat(&self, request: &ChatRequest) -> Result<ChatResponse, InferenceError> {
+        let body = request::build_body(request, DEFAULT_MAX_TOKENS);
+
+        // `reqwest::Error` display carries the URL/kind but never a header value,
+        // so stringifying it cannot leak the API key.
+        let resp = self
+            .http
+            .post(&self.endpoint)
+            .header("x-api-key", self.api_key.expose())
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| InferenceError::Transport(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(InferenceError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| InferenceError::Transport(e.to_string()))?;
+        response::parse(&text)
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::types::{ChatMessage, ChatRequest, SecretString};
+
+    fn resolved(key: &str) -> ResolvedProvider {
+        ResolvedProvider::new(
+            ProviderId::Anthropic,
+            "anthropic/claude-sonnet-4-5".to_string(),
+            Some(SecretString::new(key)),
+        )
+    }
+
+    /// Why: the factory must build a named Anthropic adapter carrying Anthropic's
+    /// capabilities (prompt caching supported, no detailed-usage directive).
+    /// Test: itself.
+    #[test]
+    fn factory_builds_named_adapter() {
+        let adapter = build(&resolved("sk-ant-test"), ANTHROPIC_BASE_URL) // pragma: allowlist secret
+            .expect("built");
+        assert_eq!(adapter.name(), "anthropic");
+        assert!(adapter.supports_prompt_caching());
+        assert!(!adapter.wants_detailed_usage());
+        assert_eq!(adapter.capabilities().id, ProviderId::Anthropic);
+    }
+
+    /// Why: a resolved provider with no key must be an explicit alarm, never a
+    /// silent anonymous call.
+    /// Test: itself.
+    #[test]
+    fn missing_key_errors() {
+        let resolved = ResolvedProvider::new(
+            ProviderId::Anthropic,
+            "anthropic/claude-sonnet-4-5".to_string(),
+            None,
+        );
+        let Err(err) = build(&resolved, ANTHROPIC_BASE_URL) else {
+            panic!("expected MissingCredential");
+        };
+        assert!(matches!(
+            err,
+            InferenceError::MissingCredential {
+                provider: ProviderId::Anthropic
+            }
+        ));
+    }
+
+    /// Why: the endpoint must be `<base>/messages` regardless of a trailing slash.
+    /// Test: itself.
+    #[test]
+    fn endpoint_appends_messages_path() {
+        let caps = *crate::inference::registry::capabilities(ProviderId::Anthropic);
+        let a = AnthropicAdapter::new(
+            "https://api.anthropic.com/v1",
+            SecretString::new("sk-ant-test"), // pragma: allowlist secret
+            caps,
+        )
+        .expect("build");
+        assert_eq!(a.endpoint(), "https://api.anthropic.com/v1/messages");
+        let b = AnthropicAdapter::new(
+            "https://api.anthropic.com/v1/",
+            SecretString::new("sk-ant-test"), // pragma: allowlist secret
+            caps,
+        )
+        .expect("build");
+        assert_eq!(b.endpoint(), "https://api.anthropic.com/v1/messages");
+    }
+
+    /// Why: the adapter must map tool-choice through the Anthropic dialect
+    /// (`Required`→`{type:any}`), not the OpenAI default (`"required"`).
+    /// Test: itself.
+    #[test]
+    fn map_tool_choice_uses_anthropic_dialect() {
+        let adapter = build(&resolved("sk-ant-test"), ANTHROPIC_BASE_URL).expect("built"); // pragma: allowlist secret
+        assert_eq!(
+            adapter.map_tool_choice(ToolChoice::Required),
+            serde_json::json!({"type": "any"})
+        );
+        assert_eq!(
+            adapter.map_tool_choice(ToolChoice::Function("f".into())),
+            serde_json::json!({"type": "tool", "name": "f"})
+        );
+    }
+
+    /// Live smoke test: send a trivial prompt to a cheap Anthropic model.
+    ///
+    /// Why: end-to-end validation against the real API that the Anthropic request
+    /// build + response parse produce a non-empty reply and non-zero usage.
+    /// Ignored so CI stays offline; run locally with a real key.
+    /// What: reads `ANTHROPIC_API_KEY` from env and SKIPS (does not fail) when
+    /// absent/empty; otherwise builds the adapter via [`build`] and asserts a
+    /// non-empty reply with `prompt_tokens > 0`.
+    /// Test: `cargo test -p trusty-common --features inference-client,axum-server \
+    ///        anthropic -- --ignored --nocapture` (with `ANTHROPIC_API_KEY` set).
+    #[tokio::test]
+    #[ignore = "requires ANTHROPIC_API_KEY; skipped in CI"]
+    async fn live_anthropic_call() {
+        let Ok(key) = std::env::var("ANTHROPIC_API_KEY") else {
+            eprintln!("ANTHROPIC_API_KEY not set — skipping live test");
+            return;
+        };
+        if key.trim().is_empty() {
+            eprintln!("ANTHROPIC_API_KEY is empty — skipping live test");
+            return;
+        }
+
+        let resolved = ResolvedProvider::new(
+            ProviderId::Anthropic,
+            "anthropic/claude-3-5-haiku-latest".to_string(),
+            Some(SecretString::new(key)),
+        );
+        let adapter = build(&resolved, ANTHROPIC_BASE_URL).expect("build adapter");
+
+        let mut req = ChatRequest::new(
+            "claude-3-5-haiku-latest",
+            vec![
+                ChatMessage::system("You are a concise assistant."),
+                ChatMessage::user("Reply with exactly the word: pong"),
+            ],
+        );
+        req.temperature = Some(0.0);
+        req.max_tokens = Some(16);
+
+        let resp = adapter.chat(&req).await.expect("live chat");
+        let text = resp.first_text().expect("assistant text");
+        assert!(!text.is_empty(), "assistant text was empty");
+        assert!(
+            resp.usage().prompt_tokens > 0,
+            "prompt_tokens should be > 0"
+        );
+        eprintln!(
+            "live anthropic ok — text: {text:?}, usage: {:?}",
+            resp.usage()
+        );
+    }
+}

--- a/crates/trusty-common/src/inference/providers/anthropic/request.rs
+++ b/crates/trusty-common/src/inference/providers/anthropic/request.rs
@@ -1,0 +1,422 @@
+//! Anthropic Messages-API request translation (issue #2408, epic #2400 Wave 2).
+//!
+//! Why: the Anthropic first-party `/v1/messages` wire format is NOT the OpenAI
+//! `/chat/completions` schema the shared [`super::super::openai_compat`] core
+//! speaks — `system` is a top-level parameter (not a message role), tool results
+//! are `tool_result` content blocks inside a `user` turn (not a `tool` role),
+//! tools are `{name, description, input_schema}` (not `{type, function}`),
+//! `max_tokens` is REQUIRED, and stop sequences ride `stop_sequences` (not
+//! `stop`). Shoehorning the neutral [`ChatRequest`] through OpenAI serde would
+//! silently drop the system prompt and mis-shape every tool. This module owns the
+//! neutral→Anthropic translation as pure, testable functions.
+//! What: [`build_body`] converts a [`ChatRequest`] into the Anthropic request
+//! `Value` (hoisting `system`, coalescing tool results into `user` turns, honoring
+//! `cache_control` breakpoints on system/message/tool blocks per #2156), and
+//! [`anthropic_tool_choice`] maps the neutral [`ToolChoice`] into the Anthropic
+//! `tool_choice` dialect.
+//! Test: inline `tests` — `hoists_system_and_defaults_max_tokens`,
+//! `builds_alternating_user_assistant_turns`, `tool_result_becomes_user_turn`,
+//! `converts_tools_to_input_schema`, `cache_control_marks_system_and_blocks`,
+//! `strips_anthropic_prefix`, `anthropic_tool_choice_maps_every_variant`.
+
+use serde_json::{Map, Value, json};
+
+use crate::inference::types::{ChatRequest, ToolChoice, ToolDefinition};
+
+/// Convert a neutral [`ChatRequest`] into an Anthropic `/v1/messages` body.
+///
+/// Why: the adapter's [`super::AnthropicAdapter::chat`] must POST the exact
+/// Anthropic wire shape; keeping the translation a pure function makes every
+/// structural rule (system hoist, role remap, cache markers, required
+/// `max_tokens`) unit-testable without a socket.
+/// What: emits `model` (with any leading `anthropic/` routing prefix stripped),
+/// `max_tokens` (the request's value or `default_max_tokens`, since Anthropic
+/// requires it), the `messages` array (system messages hoisted to the top-level
+/// `system` param; `tool` messages remapped to `user` `tool_result` blocks;
+/// consecutive same-role turns coalesced), and the optional `system`,
+/// `temperature`, `stop_sequences`, `tools`, and `tool_choice` fields. Any
+/// `cache_control` breakpoint on a message/tool is rendered as
+/// `{"type":"ephemeral"}` on the corresponding block.
+/// Test: `hoists_system_and_defaults_max_tokens`,
+/// `builds_alternating_user_assistant_turns`, `tool_result_becomes_user_turn`.
+pub fn build_body(request: &ChatRequest, default_max_tokens: u32) -> Value {
+    let mut system_blocks: Vec<Value> = Vec::new();
+    let mut system_has_cache = false;
+    // (role, blocks) conversation turns, pre-coalescing.
+    let mut turns: Vec<(&'static str, Vec<Value>)> = Vec::new();
+
+    for msg in &request.messages {
+        match msg.role.as_str() {
+            "system" => {
+                if let Some(text) = &msg.content {
+                    let mut block = json!({ "type": "text", "text": text });
+                    if msg.cache_control.is_some() {
+                        system_has_cache = true;
+                        block["cache_control"] = json!({ "type": "ephemeral" });
+                    }
+                    system_blocks.push(block);
+                }
+            }
+            "tool" => {
+                // Anthropic tool results are `tool_result` blocks in a USER turn.
+                let mut block = json!({
+                    "type": "tool_result",
+                    "tool_use_id": msg.tool_call_id.clone().unwrap_or_default(),
+                    "content": msg.content.clone().unwrap_or_default(),
+                });
+                if msg.cache_control.is_some() {
+                    block["cache_control"] = json!({ "type": "ephemeral" });
+                }
+                push_turn(&mut turns, "user", vec![block]);
+            }
+            role => {
+                let is_assistant = role == "assistant";
+                let mut blocks: Vec<Value> = Vec::new();
+                if let Some(text) = &msg.content {
+                    blocks.push(json!({ "type": "text", "text": text }));
+                }
+                if let Some(calls) = msg.tool_calls.as_ref().filter(|_| is_assistant) {
+                    for call in calls {
+                        let input: Value = serde_json::from_str(&call.function.arguments)
+                            .unwrap_or_else(|_| json!({}));
+                        blocks.push(json!({
+                            "type": "tool_use",
+                            "id": call.id,
+                            "name": call.function.name,
+                            "input": input,
+                        }));
+                    }
+                }
+                if blocks.is_empty() {
+                    // An assistant turn with neither text nor tool calls has no
+                    // Anthropic content block — skip it rather than emit an empty
+                    // (and API-rejected) content array.
+                    continue;
+                }
+                // Cache breakpoint attaches to this message's LAST block.
+                if let Some(last) = blocks.last_mut().filter(|_| msg.cache_control.is_some()) {
+                    last["cache_control"] = json!({ "type": "ephemeral" });
+                }
+                let anth_role = if is_assistant { "assistant" } else { "user" };
+                push_turn(&mut turns, anth_role, blocks);
+            }
+        }
+    }
+
+    let messages: Vec<Value> = turns
+        .into_iter()
+        .map(|(role, blocks)| json!({ "role": role, "content": blocks }))
+        .collect();
+
+    let mut body = Map::new();
+    body.insert("model".into(), json!(strip_prefix(&request.model)));
+    body.insert(
+        "max_tokens".into(),
+        json!(request.max_tokens.unwrap_or(default_max_tokens)),
+    );
+    body.insert("messages".into(), Value::Array(messages));
+
+    if !system_blocks.is_empty() {
+        if system_has_cache {
+            // A cache breakpoint can only be expressed on the content-block form.
+            body.insert("system".into(), Value::Array(system_blocks));
+        } else {
+            let joined = system_blocks
+                .iter()
+                .filter_map(|b| b["text"].as_str())
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            body.insert("system".into(), json!(joined));
+        }
+    }
+    if let Some(t) = request.temperature {
+        body.insert("temperature".into(), json!(t));
+    }
+    if let Some(stop) = &request.stop {
+        body.insert("stop_sequences".into(), json!(stop));
+    }
+    if let Some(tools) = &request.tools {
+        body.insert("tools".into(), Value::Array(convert_tools(tools)));
+    }
+    if let Some(tc) = &request.tool_choice {
+        body.insert("tool_choice".into(), tc.clone());
+    }
+    Value::Object(body)
+}
+
+/// Map the neutral [`ToolChoice`] into the Anthropic `tool_choice` wire value.
+///
+/// Why: Anthropic spells tool-choice differently from OpenAI — `any` (not
+/// `required`) forces some call, a specific call is `{"type":"tool","name":…}`
+/// (not a nested `function` object), and there is a first-class `{"type":"none"}`.
+/// The adapter overrides [`crate::inference::InferenceAdapter::map_tool_choice`]
+/// with this so callers stay dialect-agnostic.
+/// What: `None`→`{"type":"none"}`, `Auto`→`{"type":"auto"}`,
+/// `Required`→`{"type":"any"}`, `Function(name)`→`{"type":"tool","name":name}`.
+/// Test: `anthropic_tool_choice_maps_every_variant`.
+pub fn anthropic_tool_choice(choice: ToolChoice) -> Value {
+    match choice {
+        ToolChoice::None => json!({ "type": "none" }),
+        ToolChoice::Auto => json!({ "type": "auto" }),
+        ToolChoice::Required => json!({ "type": "any" }),
+        ToolChoice::Function(name) => json!({ "type": "tool", "name": name }),
+    }
+}
+
+/// Append `blocks` to the previous turn when it shares `role`, else push a new
+/// turn.
+///
+/// Why: Anthropic requires strictly alternating `user`/`assistant` turns; a
+/// sequence of tool results (each a `user` `tool_result` block) plus a preceding
+/// user message must collapse into ONE user turn or the API rejects consecutive
+/// same-role messages.
+/// What: mutates `turns`, coalescing adjacent same-role block lists.
+/// Test: `tool_result_becomes_user_turn`.
+fn push_turn(
+    turns: &mut Vec<(&'static str, Vec<Value>)>,
+    role: &'static str,
+    mut blocks: Vec<Value>,
+) {
+    match turns.last_mut() {
+        Some(last) if last.0 == role => last.1.append(&mut blocks),
+        _ => turns.push((role, blocks)),
+    }
+}
+
+/// Convert neutral [`ToolDefinition`]s into Anthropic tool objects.
+///
+/// Why: Anthropic tools are `{name, description, input_schema}` with an optional
+/// `cache_control` breakpoint — not the OpenAI `{type:"function", function:{…}}`
+/// envelope; the schema key is `input_schema`, not `parameters`.
+/// What: maps each function tool, defaulting a missing schema to
+/// `{"type":"object"}` and forwarding a `cache_control` marker when set.
+/// Test: `converts_tools_to_input_schema`, `cache_control_marks_system_and_blocks`.
+fn convert_tools(tools: &[ToolDefinition]) -> Vec<Value> {
+    tools
+        .iter()
+        .map(|t| {
+            let f = &t.function;
+            let mut tool = Map::new();
+            tool.insert("name".into(), json!(f.name));
+            if let Some(desc) = &f.description {
+                tool.insert("description".into(), json!(desc));
+            }
+            tool.insert(
+                "input_schema".into(),
+                f.parameters
+                    .clone()
+                    .unwrap_or_else(|| json!({ "type": "object" })),
+            );
+            if f.cache_control.is_some() {
+                tool.insert("cache_control".into(), json!({ "type": "ephemeral" }));
+            }
+            Value::Object(tool)
+        })
+        .collect()
+}
+
+/// Strip a leading `anthropic/` routing prefix from a model slug.
+///
+/// Why: the resolver preserves the explicit `anthropic/claude-…` slug so the
+/// two-stage resolver can route it, but the Anthropic API expects the bare model
+/// id (`claude-…`); sending the prefixed form is an unknown-model 404.
+/// What: removes a leading `anthropic/` if present, else returns the slug as-is.
+/// Test: `strips_anthropic_prefix`.
+fn strip_prefix(model: &str) -> &str {
+    model.strip_prefix("anthropic/").unwrap_or(model)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::types::CacheControl;
+    use crate::inference::types::{
+        ChatMessage, FunctionCall, FunctionDefinition, ToolCall, ToolDefinition,
+    };
+
+    /// Why: `system` must be hoisted out of the message list to the top-level
+    /// param, and `max_tokens` must always be present (Anthropic requires it),
+    /// defaulting when the caller left it unset.
+    /// Test: itself.
+    #[test]
+    fn hoists_system_and_defaults_max_tokens() {
+        let req = ChatRequest::new(
+            "claude-sonnet-4-5",
+            vec![ChatMessage::system("be terse"), ChatMessage::user("hi")],
+        );
+        let body = build_body(&req, 4096);
+        assert_eq!(body["system"], json!("be terse"));
+        assert_eq!(body["max_tokens"], json!(4096));
+        // The system message is NOT in the messages array.
+        assert_eq!(body["messages"].as_array().unwrap().len(), 1);
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"][0]["text"], "hi");
+    }
+
+    /// Why: user and assistant turns must serialise as content-block arrays in
+    /// order, and an explicit `max_tokens` must be honored over the default.
+    /// Test: itself.
+    #[test]
+    fn builds_alternating_user_assistant_turns() {
+        let mut req = ChatRequest::new(
+            "claude-sonnet-4-5",
+            vec![
+                ChatMessage::user("q1"),
+                ChatMessage::assistant("a1"),
+                ChatMessage::user("q2"),
+            ],
+        );
+        req.max_tokens = Some(256);
+        req.temperature = Some(0.2);
+        req.stop = Some(vec!["STOP".into()]);
+        let body = build_body(&req, 4096);
+        assert_eq!(body["max_tokens"], json!(256));
+        assert_eq!(body["temperature"], json!(0.2_f32));
+        assert_eq!(body["stop_sequences"], json!(["STOP"]));
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0]["role"], "user");
+        assert_eq!(msgs[1]["role"], "assistant");
+        assert_eq!(msgs[1]["content"][0]["text"], "a1");
+        assert_eq!(msgs[2]["role"], "user");
+    }
+
+    /// Why: a `tool` role message must remap to a `user` turn carrying a
+    /// `tool_result` block, and consecutive user turns (a user message followed
+    /// by a tool result) must coalesce into one turn — Anthropic forbids adjacent
+    /// same-role messages.
+    /// Test: itself.
+    #[test]
+    fn tool_result_becomes_user_turn() {
+        let assistant_call = ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "toolu_1".into(),
+                kind: "function".into(),
+                function: FunctionCall {
+                    name: "get_weather".into(),
+                    arguments: r#"{"loc":"SEA"}"#.into(),
+                },
+            }]),
+            tool_call_id: None,
+            name: None,
+            cache_control: None,
+        };
+        let req = ChatRequest::new(
+            "claude-sonnet-4-5",
+            vec![
+                ChatMessage::user("weather?"),
+                assistant_call,
+                ChatMessage::tool_result("toolu_1", "get_weather", r#"{"t":72}"#),
+                ChatMessage::tool_result("toolu_2", "get_time", "noon"),
+            ],
+        );
+        let body = build_body(&req, 4096);
+        let msgs = body["messages"].as_array().unwrap();
+        // user, assistant(tool_use), user(2 coalesced tool_results)
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[1]["role"], "assistant");
+        assert_eq!(msgs[1]["content"][0]["type"], "tool_use");
+        assert_eq!(msgs[1]["content"][0]["id"], "toolu_1");
+        assert_eq!(msgs[1]["content"][0]["input"]["loc"], "SEA");
+        assert_eq!(msgs[2]["role"], "user");
+        let results = msgs[2]["content"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0]["type"], "tool_result");
+        assert_eq!(results[0]["tool_use_id"], "toolu_1");
+        assert_eq!(results[1]["tool_use_id"], "toolu_2");
+    }
+
+    /// Why: tools must serialise as `{name, input_schema}` (Anthropic's key),
+    /// with a default object schema when the caller supplied none, and the
+    /// caller-supplied `tool_choice` value must pass through verbatim.
+    /// Test: itself.
+    #[test]
+    fn converts_tools_to_input_schema() {
+        let mut req = ChatRequest::new("claude-sonnet-4-5", vec![ChatMessage::user("hi")]);
+        req.tools = Some(vec![ToolDefinition::function(FunctionDefinition {
+            name: "get_weather".into(),
+            description: Some("look up weather".into()),
+            parameters: Some(json!({"type": "object", "properties": {}})),
+            cache_control: None,
+        })]);
+        req.tool_choice = Some(anthropic_tool_choice(ToolChoice::Auto));
+        let body = build_body(&req, 4096);
+        assert_eq!(body["tools"][0]["name"], "get_weather");
+        assert_eq!(body["tools"][0]["description"], "look up weather");
+        assert_eq!(body["tools"][0]["input_schema"]["type"], "object");
+        // No `parameters`/`function` OpenAI envelope leaks through.
+        assert!(body["tools"][0].get("parameters").is_none());
+        assert!(body["tools"][0].get("function").is_none());
+        assert_eq!(body["tool_choice"], json!({"type": "auto"}));
+    }
+
+    /// Why: `cache_control` breakpoints (#2156) must render as
+    /// `{"type":"ephemeral"}` on the system block, a message's last content
+    /// block, and a tool — driving the `system` param to its array form.
+    /// Test: itself.
+    #[test]
+    fn cache_control_marks_system_and_blocks() {
+        let mut sys = ChatMessage::system("stable prefix");
+        sys.cache_control = Some(CacheControl::ephemeral());
+        let mut user = ChatMessage::user("cache me too");
+        user.cache_control = Some(CacheControl::ephemeral());
+        let mut req = ChatRequest::new("claude-sonnet-4-5", vec![sys, user]);
+        req.tools = Some(vec![ToolDefinition::function(FunctionDefinition {
+            name: "t".into(),
+            description: None,
+            parameters: None,
+            cache_control: Some(CacheControl::ephemeral()),
+        })]);
+        let body = build_body(&req, 4096);
+        // system rendered as a block array with a cache marker.
+        assert_eq!(
+            body["system"],
+            json!([{ "type": "text", "text": "stable prefix", "cache_control": {"type": "ephemeral"} }])
+        );
+        assert_eq!(
+            body["messages"][0]["content"][0]["cache_control"],
+            json!({"type": "ephemeral"})
+        );
+        assert_eq!(
+            body["tools"][0]["cache_control"],
+            json!({"type": "ephemeral"})
+        );
+    }
+
+    /// Why: the explicit `anthropic/` routing prefix must be stripped so the API
+    /// receives the bare model id.
+    /// Test: itself.
+    #[test]
+    fn strips_anthropic_prefix() {
+        let req = ChatRequest::new("anthropic/claude-sonnet-4-5", vec![ChatMessage::user("x")]);
+        let body = build_body(&req, 4096);
+        assert_eq!(body["model"], "claude-sonnet-4-5");
+    }
+
+    /// Why: every neutral tool-choice variant must map to its Anthropic spelling;
+    /// a typo would silently break tool routing.
+    /// Test: itself.
+    #[test]
+    fn anthropic_tool_choice_maps_every_variant() {
+        assert_eq!(
+            anthropic_tool_choice(ToolChoice::None),
+            json!({"type": "none"})
+        );
+        assert_eq!(
+            anthropic_tool_choice(ToolChoice::Auto),
+            json!({"type": "auto"})
+        );
+        assert_eq!(
+            anthropic_tool_choice(ToolChoice::Required),
+            json!({"type": "any"})
+        );
+        assert_eq!(
+            anthropic_tool_choice(ToolChoice::Function("get_weather".into())),
+            json!({"type": "tool", "name": "get_weather"})
+        );
+    }
+}

--- a/crates/trusty-common/src/inference/providers/anthropic/response.rs
+++ b/crates/trusty-common/src/inference/providers/anthropic/response.rs
@@ -1,0 +1,311 @@
+//! Anthropic Messages-API response translation (issue #2408, epic #2400 Wave 2).
+//!
+//! Why: an Anthropic `/v1/messages` response does NOT match the OpenAI response
+//! the shared core parses — text/tool calls arrive as a `content` block array
+//! (not `choices[].message`), the stop condition is `stop_reason`
+//! (`end_turn`/`tool_use`/`max_tokens`), and — the trap the #2403 review flagged —
+//! its `usage` uses `input_tokens`/`output_tokens`, which deserialise to ZERO
+//! through the OpenAI-shaped [`UsageBlock`] (`prompt_tokens`/`completion_tokens`).
+//! So the usage must be HAND-constructed, not serde-mapped through the OpenAI
+//! shape. This module parses the native response and normalises it into the same
+//! [`ChatResponse`] every other adapter returns, so callers stay uniform.
+//! What: [`parse`] deserialises the Anthropic body and converts it — text blocks
+//! concatenated into `content`, `tool_use` blocks into OpenAI-style [`ToolCall`]s,
+//! `stop_reason` mapped to the neutral `finish_reason`, and usage hand-built into
+//! a [`UsageBlock`] with the Anthropic token names mapped correctly.
+//! Test: inline `tests` — `parses_text_and_native_usage`, `parses_tool_use_blocks`,
+//! `maps_stop_reasons`, `ignores_unknown_block_types`, `parse_error_is_deserialise`.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::inference::error::InferenceError;
+use crate::inference::types::{
+    AssistantMessage, ChatChoice, ChatResponse, FunctionCall, ToolCall, UsageBlock,
+};
+
+/// Parse an Anthropic `/v1/messages` response body into the neutral
+/// [`ChatResponse`].
+///
+/// Why: the adapter's `chat` must return the identical [`ChatResponse`] every
+/// other provider yields, so downstream `first_text`/`first_tool_calls`/`usage`
+/// accessors work unchanged regardless of backend.
+/// What: deserialises the Anthropic envelope (surfacing a parse failure as
+/// [`InferenceError::Deserialise`] with the raw body, never the API key) and
+/// converts it via [`AnthropicResponse::into_chat_response`].
+/// Test: `parses_text_and_native_usage`, `parse_error_is_deserialise`.
+pub fn parse(text: &str) -> Result<ChatResponse, InferenceError> {
+    let raw: AnthropicResponse =
+        serde_json::from_str(text).map_err(|e| InferenceError::Deserialise {
+            message: e.to_string(),
+            body: text.to_string(),
+        })?;
+    Ok(raw.into_chat_response())
+}
+
+/// The top-level Anthropic Messages response envelope.
+///
+/// Why: a dedicated deserialisation target keeps the Anthropic wire-field names
+/// (`content` blocks, `stop_reason`) isolated from the neutral response type.
+/// What: `id`/`model` identity, the `content` block array, the `stop_reason`
+/// string, and the native `usage` block.
+/// Test: `parses_text_and_native_usage`.
+#[derive(Debug, Deserialize)]
+struct AnthropicResponse {
+    id: String,
+    #[serde(default)]
+    model: String,
+    #[serde(default)]
+    content: Vec<ContentBlock>,
+    #[serde(default)]
+    stop_reason: Option<String>,
+    #[serde(default)]
+    usage: AnthropicUsage,
+}
+
+/// One Anthropic content block: text, a tool call, or an ignored other kind.
+///
+/// Why: Anthropic returns heterogeneous, internally-tagged content blocks;
+/// modelling only the two we consume (plus a catch-all) keeps unknown future
+/// block types — `thinking`, `redacted_thinking` — from failing the parse.
+/// What: `Text` carries generated prose; `ToolUse` carries a function
+/// invocation; `Other` absorbs any unrecognised `type`.
+/// Test: `parses_tool_use_blocks`, `ignores_unknown_block_types`.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ContentBlock {
+    /// A generated text span.
+    Text {
+        /// The text content.
+        #[serde(default)]
+        text: String,
+    },
+    /// A model-emitted tool call.
+    ToolUse {
+        /// Opaque tool-call id (echoed as the `tool_result` `tool_use_id`).
+        id: String,
+        /// The invoked function name.
+        name: String,
+        /// The function arguments as a JSON object.
+        #[serde(default)]
+        input: Value,
+    },
+    /// Any other block type (e.g. `thinking`), ignored.
+    #[serde(other)]
+    Other,
+}
+
+/// The Anthropic-native `usage` block.
+///
+/// Why: Anthropic names its token counters `input_tokens`/`output_tokens` — NOT
+/// the OpenAI `prompt_tokens`/`completion_tokens` the shared [`UsageBlock`]
+/// deserialises. Parsing into this dedicated struct, then hand-mapping, is what
+/// prevents the tokens silently deserialising to zero.
+/// What: the four token counters Anthropic reports (cache fields share the
+/// Anthropic-native names the [`UsageBlock`] already uses).
+/// Test: `parses_text_and_native_usage`.
+#[derive(Debug, Default, Deserialize)]
+struct AnthropicUsage {
+    #[serde(default)]
+    input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
+    #[serde(default)]
+    cache_read_input_tokens: u32,
+    #[serde(default)]
+    cache_creation_input_tokens: u32,
+}
+
+impl AnthropicResponse {
+    /// Convert the parsed Anthropic response into the neutral [`ChatResponse`].
+    ///
+    /// Why: normalising here (rather than at each call site) keeps the block/
+    /// stop-reason/usage remapping in one place and guarantees the returned shape
+    /// is byte-for-byte the shape callers already handle.
+    /// What: concatenates `Text` blocks into `content` (`None` when empty), maps
+    /// each `ToolUse` into an OpenAI-style [`ToolCall`] (arguments re-serialised
+    /// from the `input` object), maps `stop_reason` via [`map_stop_reason`], and
+    /// HAND-builds the [`UsageBlock`] so `input_tokens`/`output_tokens` land in
+    /// `prompt_tokens`/`completion_tokens` instead of deserialising to zero.
+    /// Test: `parses_text_and_native_usage`, `parses_tool_use_blocks`.
+    fn into_chat_response(self) -> ChatResponse {
+        let mut text = String::new();
+        let mut tool_calls: Vec<ToolCall> = Vec::new();
+        for block in self.content {
+            match block {
+                ContentBlock::Text { text: t } => text.push_str(&t),
+                ContentBlock::ToolUse { id, name, input } => tool_calls.push(ToolCall {
+                    id,
+                    kind: "function".into(),
+                    function: FunctionCall {
+                        name,
+                        arguments: serde_json::to_string(&input)
+                            .unwrap_or_else(|_| "{}".to_string()),
+                    },
+                }),
+                ContentBlock::Other => {}
+            }
+        }
+        let content = if text.is_empty() { None } else { Some(text) };
+        let finish_reason = self.stop_reason.as_deref().map(map_stop_reason);
+
+        // Hand-construct the usage block: Anthropic's input/output token names do
+        // not deserialise through the OpenAI-shaped `UsageBlock`, so map them
+        // explicitly (cache fields already share the Anthropic-native names).
+        let usage = UsageBlock {
+            prompt_tokens: self.usage.input_tokens,
+            completion_tokens: self.usage.output_tokens,
+            total_tokens: self
+                .usage
+                .input_tokens
+                .saturating_add(self.usage.output_tokens),
+            cache_read_input_tokens: self.usage.cache_read_input_tokens,
+            cache_creation_input_tokens: self.usage.cache_creation_input_tokens,
+            prompt_tokens_details: None,
+            cost: None,
+        };
+
+        ChatResponse {
+            id: self.id,
+            model: self.model,
+            choices: vec![ChatChoice {
+                message: AssistantMessage {
+                    content,
+                    tool_calls,
+                },
+                finish_reason,
+            }],
+            usage,
+        }
+    }
+}
+
+/// Map an Anthropic `stop_reason` to the neutral OpenAI-style `finish_reason`.
+///
+/// Why: [`crate::inference::ChatResponse::stop_reason`] parses the wire string
+/// through [`crate::inference::StopReason::from_wire`], which speaks the OpenAI
+/// vocabulary; translating here lets Anthropic responses drive the same typed
+/// stop-condition branching as every other provider.
+/// What: `end_turn`/`stop_sequence`→`stop`, `max_tokens`→`length`,
+/// `tool_use`→`tool_calls`; any other value is preserved verbatim.
+/// Test: `maps_stop_reasons`.
+fn map_stop_reason(reason: &str) -> String {
+    match reason {
+        "end_turn" | "stop_sequence" => "stop".to_string(),
+        "max_tokens" => "length".to_string(),
+        "tool_use" => "tool_calls".to_string(),
+        other => other.to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::types::StopReason;
+
+    /// Why: text must extract into `content`, and — the critical trap — the
+    /// Anthropic `input_tokens`/`output_tokens` must map to
+    /// `prompt_tokens`/`completion_tokens` (NOT deserialise to zero), with cache
+    /// counters flowing through.
+    /// Test: itself.
+    #[test]
+    fn parses_text_and_native_usage() {
+        let body = r#"{
+          "id": "msg_1",
+          "model": "claude-sonnet-4-5",
+          "content": [{"type": "text", "text": "pong"}],
+          "stop_reason": "end_turn",
+          "usage": {
+            "input_tokens": 12,
+            "output_tokens": 3,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 2
+          }
+        }"#;
+        let resp = parse(body).expect("parse");
+        assert_eq!(resp.id, "msg_1");
+        assert_eq!(resp.first_text().as_deref(), Some("pong"));
+        assert_eq!(resp.stop_reason(), Some(StopReason::Stop));
+        let usage = resp.usage();
+        assert_eq!(
+            usage.prompt_tokens, 12,
+            "input_tokens must not deserialise to 0"
+        );
+        assert_eq!(usage.completion_tokens, 3);
+        assert_eq!(usage.cache_read_tokens, 5);
+        assert_eq!(usage.cache_creation_tokens, 2);
+        assert_eq!(usage.total_tokens(), 15);
+    }
+
+    /// Why: `tool_use` blocks must become OpenAI-style tool calls with the
+    /// arguments re-serialised from the `input` object, and a `tool_use` stop
+    /// reason maps to the tool-loop `finish_reason`.
+    /// Test: itself.
+    #[test]
+    fn parses_tool_use_blocks() {
+        let body = r#"{
+          "id": "msg_2",
+          "model": "claude-sonnet-4-5",
+          "content": [
+            {"type": "text", "text": "let me check"},
+            {"type": "tool_use", "id": "toolu_9", "name": "get_weather",
+             "input": {"loc": "SEA"}}
+          ],
+          "stop_reason": "tool_use",
+          "usage": {"input_tokens": 20, "output_tokens": 8}
+        }"#;
+        let resp = parse(body).expect("parse");
+        assert_eq!(resp.first_text().as_deref(), Some("let me check"));
+        assert_eq!(resp.stop_reason(), Some(StopReason::ToolCalls));
+        let calls = resp.first_tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "toolu_9");
+        assert_eq!(calls[0].kind, "function");
+        assert_eq!(calls[0].function.name, "get_weather");
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["loc"], "SEA");
+    }
+
+    /// Why: every known Anthropic stop reason must translate to its neutral
+    /// equivalent, and an unknown one preserved.
+    /// Test: itself.
+    #[test]
+    fn maps_stop_reasons() {
+        assert_eq!(map_stop_reason("end_turn"), "stop");
+        assert_eq!(map_stop_reason("stop_sequence"), "stop");
+        assert_eq!(map_stop_reason("max_tokens"), "length");
+        assert_eq!(map_stop_reason("tool_use"), "tool_calls");
+        assert_eq!(map_stop_reason("refusal"), "refusal");
+    }
+
+    /// Why: unknown content-block types (`thinking`) must be ignored, not fail
+    /// the parse, so a future block kind never breaks the adapter.
+    /// Test: itself.
+    #[test]
+    fn ignores_unknown_block_types() {
+        let body = r#"{
+          "id": "msg_3",
+          "content": [
+            {"type": "thinking", "thinking": "hmm"},
+            {"type": "text", "text": "answer"}
+          ],
+          "stop_reason": "end_turn",
+          "usage": {"input_tokens": 1, "output_tokens": 1}
+        }"#;
+        let resp = parse(body).expect("parse");
+        assert_eq!(resp.first_text().as_deref(), Some("answer"));
+    }
+
+    /// Why: a malformed body must surface as a classified `Deserialise` error
+    /// carrying the raw body, never a panic.
+    /// Test: itself.
+    #[test]
+    fn parse_error_is_deserialise() {
+        let Err(err) = parse("{not json") else {
+            panic!("expected a Deserialise error");
+        };
+        assert!(matches!(err, InferenceError::Deserialise { .. }));
+    }
+}

--- a/crates/trusty-common/src/inference/providers/mod.rs
+++ b/crates/trusty-common/src/inference/providers/mod.rs
@@ -9,12 +9,13 @@
 //! `provider_for("openrouter" | "fireworks" | "openai", &store)` builds a REAL
 //! `Box<dyn InferenceAdapter>`.
 //! What: [`openai_compat::OpenAiCompatAdapter`] (the core) and the
-//! [`openrouter`]/[`fireworks`]/[`openai`]/[`together`] provider configs, plus
-//! [`register_default_factories`]. Anthropic-dialect providers (Bedrock #2407,
-//! Anthropic-direct #2408) are out of scope here.
+//! [`openrouter`]/[`fireworks`]/[`openai`]/[`together`] provider configs, the
+//! native [`anthropic`] adapter (its own Messages-API wire format, #2408), plus
+//! [`register_default_factories`]. Bedrock (#2407) is still out of scope here.
 //! Test: each submodule's inline `tests` + the offline mock-server round-trip in
 //! `crates/trusty-common/tests/inference_adapters.rs`.
 
+pub mod anthropic;
 pub mod atlascloud;
 pub mod fireworks;
 pub mod openai;
@@ -33,15 +34,17 @@ use crate::inference::registry::ProviderId;
 /// adapter this ticket ships, rather than remembering each `register` line. The
 /// configurator stays empty by default (no implicit adapters) — this is the
 /// explicit opt-in that turns resolution into live adapters.
-/// What: registers the OpenRouter, Fireworks, OpenAI, Together (#2488), and
-/// AtlasCloud (#2536) production factories (each pointed at its real base URL) under their
-/// [`ProviderId`]. Bedrock and Anthropic-direct are intentionally NOT registered
-/// here (later waves).
-/// Test: `crates/trusty-common/tests/inference_adapters.rs::default_factories_register_openai_dialect`.
+/// What: registers the OpenRouter, Fireworks, OpenAI, Together (#2488),
+/// AtlasCloud (#2536), and Anthropic-direct (#2408) production factories (each
+/// pointed at its real base URL) under their [`ProviderId`]. Bedrock is
+/// intentionally NOT registered here (later wave, #2407).
+/// Test: `crates/trusty-common/tests/inference_adapters.rs::default_factories_register_openai_dialect`
+/// and `default_factories_register_anthropic_direct`.
 pub fn register_default_factories(cfg: &mut Configurator) {
     cfg.register(ProviderId::OpenRouter, Box::new(openrouter::factory));
     cfg.register(ProviderId::Fireworks, Box::new(fireworks::factory));
     cfg.register(ProviderId::OpenAI, Box::new(openai::factory));
     cfg.register(ProviderId::Together, Box::new(together::factory));
     cfg.register(ProviderId::AtlasCloud, Box::new(atlascloud::factory));
+    cfg.register(ProviderId::Anthropic, Box::new(anthropic::factory));
 }

--- a/crates/trusty-common/src/inference/providers/openai.rs
+++ b/crates/trusty-common/src/inference/providers/openai.rs
@@ -68,7 +68,7 @@ pub fn factory(resolved: &ResolvedProvider) -> Result<Box<dyn InferenceAdapter>,
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::inference::types::SecretString;
+    use crate::inference::types::{ChatMessage, ChatRequest, SecretString};
 
     fn resolved(key: &str) -> ResolvedProvider {
         ResolvedProvider::new(
@@ -104,5 +104,54 @@ mod tests {
                 provider: ProviderId::OpenAI
             }
         ));
+    }
+
+    /// Live smoke test: send a trivial prompt to a cheap OpenAI model.
+    ///
+    /// Why: end-to-end validation against the real first-party OpenAI API that
+    /// the OpenAI-direct config + shared core produce a non-empty response and
+    /// non-zero usage. Ignored so CI stays offline; run locally with a real key.
+    /// What: reads `OPENAI_API_KEY` from env and SKIPS (does not fail) when
+    /// absent/empty; otherwise builds the adapter via [`build`] and asserts a
+    /// non-empty reply with `prompt_tokens > 0`.
+    /// Test: `cargo test -p trusty-common --features inference-client,axum-server \
+    ///        openai -- --ignored --nocapture` (with `OPENAI_API_KEY` set).
+    #[tokio::test]
+    #[ignore = "requires OPENAI_API_KEY; skipped in CI"]
+    async fn live_openai_call() {
+        let Ok(key) = std::env::var("OPENAI_API_KEY") else {
+            eprintln!("OPENAI_API_KEY not set — skipping live test");
+            return;
+        };
+        if key.trim().is_empty() {
+            eprintln!("OPENAI_API_KEY is empty — skipping live test");
+            return;
+        }
+
+        let resolved = ResolvedProvider::new(
+            ProviderId::OpenAI,
+            "gpt-4o-mini".to_string(),
+            Some(SecretString::new(key)),
+        );
+        let adapter = build(&resolved, OPENAI_BASE_URL).expect("build adapter");
+
+        let mut req = ChatRequest::new(
+            "gpt-4o-mini",
+            vec![
+                ChatMessage::system("You are a concise assistant."),
+                ChatMessage::user("Reply with exactly the word: pong"),
+            ],
+        );
+        req.temperature = Some(0.0);
+        req.max_tokens = Some(16);
+
+        let resp = adapter.chat(&req).await.expect("live chat");
+        let text = resp.first_text().expect("assistant text");
+        assert!(!text.is_empty(), "assistant text was empty");
+        assert!(
+            resp.usage().prompt_tokens > 0,
+            "prompt_tokens should be > 0"
+        );
+        eprintln!("live openai ok — text: {text:?}, usage: {:?}", resp.usage());
     }
 }

--- a/crates/trusty-common/tests/inference_adapters.rs
+++ b/crates/trusty-common/tests/inference_adapters.rs
@@ -16,7 +16,9 @@
 use serde_json::{Value, json};
 use serial_test::serial;
 use trusty_common::inference::credentials::{KeyStore, MemoryKeyStore};
-use trusty_common::inference::providers::{atlascloud, fireworks, openai, openrouter, together};
+use trusty_common::inference::providers::{
+    anthropic, atlascloud, fireworks, openai, openrouter, together,
+};
 use trusty_common::inference::test_support::MockInferenceServer;
 use trusty_common::inference::{
     CacheControl, ChatMessage, ChatRequest, Configurator, FunctionDefinition, InferenceError,
@@ -407,6 +409,167 @@ async fn atlascloud_round_trip_no_usage_directive() {
     );
 }
 
+// ── Anthropic-direct: native Messages-API wire format ────────────────────────────
+
+/// A minimal successful Anthropic `/v1/messages` response body (text turn).
+fn anthropic_text_response_body() -> Value {
+    json!({
+        "id": "msg_mock",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5",
+        "content": [{"type": "text", "text": "pong"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 12, "output_tokens": 3}
+    })
+}
+
+/// Why: driving Anthropic-direct through the `Configurator` must (a) POST to the
+/// `/messages` endpoint with the `x-api-key` + `anthropic-version` headers (NOT
+/// an OpenAI `Authorization: Bearer`), (b) hoist `system` to the top-level param
+/// and strip the `anthropic/` routing prefix from the model, and (c) parse the
+/// native response text back — the full resolve→build→chat→usage cycle against a
+/// real socket, exercising the bespoke (non-OpenAI) wire format.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn anthropic_direct_translates_messages_api_request() {
+    clear_provider_env();
+    let server = MockInferenceServer::spawn(200, anthropic_text_response_body())
+        .await
+        .expect("spawn mock");
+    let base = server.url().to_string();
+
+    let store = MemoryKeyStore::new();
+    // Anthropic key present AND explicit anthropic/ prefix → resolves to Anthropic.
+    store.set("anthropic", "sk-ant-fake").unwrap(); // pragma: allowlist secret
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::Anthropic,
+        Box::new(move |r: &ResolvedProvider| anthropic::build(r, &base)),
+    );
+
+    let adapter = cfg
+        .build("anthropic/claude-sonnet-4-5", &store)
+        .expect("build");
+    assert_eq!(adapter.name(), "anthropic");
+    assert_eq!(adapter.capabilities().id, ProviderId::Anthropic);
+
+    let req = ChatRequest::new(
+        "anthropic/claude-sonnet-4-5",
+        vec![ChatMessage::system("be terse"), ChatMessage::user("ping")],
+    );
+    let resp = adapter.chat(&req).await.expect("chat ok");
+
+    // Native response parsing.
+    assert_eq!(resp.first_text().as_deref(), Some("pong"));
+    assert_eq!(resp.usage().prompt_tokens, 12);
+    assert_eq!(resp.usage().completion_tokens, 3);
+
+    // Request translation captured by the mock.
+    let sent = server.last_request().expect("captured request");
+    assert_eq!(sent.method, "POST");
+    assert_eq!(sent.path, "/messages");
+    assert_eq!(sent.header("x-api-key"), Some("sk-ant-fake")); // pragma: allowlist secret
+    assert_eq!(sent.header("anthropic-version"), Some("2023-06-01"));
+    // Anthropic-direct authenticates via x-api-key, NOT an OpenAI bearer header.
+    assert!(sent.header("authorization").is_none());
+    let body = sent.body.expect("json body");
+    // Model prefix stripped; system hoisted; max_tokens defaulted.
+    assert_eq!(body["model"], "claude-sonnet-4-5");
+    assert_eq!(body["system"], "be terse");
+    assert!(body["max_tokens"].is_number());
+    // The system turn is NOT in the messages array.
+    assert_eq!(body["messages"].as_array().unwrap().len(), 1);
+    assert_eq!(body["messages"][0]["role"], "user");
+    assert_eq!(body["messages"][0]["content"][0]["text"], "ping");
+}
+
+/// Why: the Anthropic-native usage payload (`input_tokens`/`output_tokens` plus
+/// flat cache fields) must map into the normalized `Usage` (NOT deserialise to
+/// zero through the OpenAI-shaped block — the #2403-review trap), a `tool_use`
+/// content block must parse into an OpenAI-style tool call, and a caller-set
+/// `cache_control` breakpoint must render on the wire as an ephemeral marker.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn anthropic_direct_parses_native_usage_and_tool_use() {
+    clear_provider_env();
+    let body = json!({
+        "id": "msg_tool",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5",
+        "content": [
+            {"type": "tool_use", "id": "toolu_1", "name": "get_weather",
+             "input": {"loc": "SEA"}}
+        ],
+        "stop_reason": "tool_use",
+        "usage": {
+            "input_tokens": 1200,
+            "output_tokens": 40,
+            "cache_read_input_tokens": 900,
+            "cache_creation_input_tokens": 300
+        }
+    });
+    let server = MockInferenceServer::spawn(200, body).await.expect("spawn");
+    let base = server.url().to_string();
+
+    let store = MemoryKeyStore::new();
+    store.set("anthropic", "sk-ant-fake").unwrap(); // pragma: allowlist secret
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::Anthropic,
+        Box::new(move |r: &ResolvedProvider| anthropic::build(r, &base)),
+    );
+    let adapter = cfg
+        .build("anthropic/claude-sonnet-4-5", &store)
+        .expect("build");
+
+    // Caller marks the system prefix as a cache breakpoint and supplies a tool.
+    let mut sys = ChatMessage::system("cache me");
+    sys.cache_control = Some(CacheControl::ephemeral());
+    let mut req = ChatRequest::new(
+        "anthropic/claude-sonnet-4-5",
+        vec![sys, ChatMessage::user("weather?")],
+    );
+    req.tools = Some(vec![ToolDefinition::function(FunctionDefinition {
+        name: "get_weather".into(),
+        description: Some("look up weather".into()),
+        parameters: Some(json!({"type": "object"})),
+        cache_control: None,
+    })]);
+    req.tool_choice = Some(adapter.map_tool_choice(ToolChoice::Auto));
+
+    let resp = adapter.chat(&req).await.expect("chat ok");
+
+    // Native usage mapped correctly (input/output → prompt/completion, cache).
+    let usage = resp.usage();
+    assert_eq!(usage.prompt_tokens, 1200);
+    assert_eq!(usage.completion_tokens, 40);
+    assert_eq!(usage.cache_read_tokens, 900);
+    assert_eq!(usage.cache_creation_tokens, 300);
+
+    // tool_use block parsed into an OpenAI-style tool call.
+    let calls = resp.first_tool_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.name, "get_weather");
+
+    // Wire translation: system as a cache-annotated block array, Anthropic
+    // tool shape, and the Anthropic tool_choice dialect.
+    let sent = server.last_request().expect("captured");
+    let body = sent.body.expect("json");
+    assert_eq!(
+        body["system"],
+        json!([{
+            "type": "text",
+            "text": "cache me",
+            "cache_control": {"type": "ephemeral"}
+        }])
+    );
+    assert_eq!(body["tools"][0]["name"], "get_weather");
+    assert_eq!(body["tools"][0]["input_schema"]["type"], "object");
+    assert_eq!(body["tool_choice"], json!({"type": "auto"}));
+}
+
 // ── Error classification through a real socket ───────────────────────────────────
 
 /// Why: a non-2xx provider status must surface as a classified `InferenceError`
@@ -484,4 +647,29 @@ fn default_factories_register_openai_dialect() {
             provider: ProviderId::Bedrock
         }
     ));
+}
+
+/// Why: `register_default_factories` must also wire Anthropic-direct (#2408) so
+/// an explicit `anthropic/` slug (with a resolvable `ANTHROPIC_API_KEY`) builds a
+/// real native Anthropic adapter through the public entry point.
+#[test]
+#[serial(dotenv_credential_env)]
+fn default_factories_register_anthropic_direct() {
+    clear_provider_env();
+    let store = MemoryKeyStore::new();
+    store.set("anthropic", "sk-ant-fake").unwrap(); // pragma: allowlist secret
+
+    let mut cfg = Configurator::new();
+    register_default_factories(&mut cfg);
+
+    let anthropic = cfg
+        .build("anthropic/claude-sonnet-4-5", &store)
+        .expect("build anthropic");
+    assert_eq!(anthropic.name(), "anthropic");
+    assert_eq!(anthropic.capabilities().id, ProviderId::Anthropic);
+    // Native Anthropic dialect: `Required` → `{type:any}`, not OpenAI's "required".
+    assert_eq!(
+        anthropic.map_tool_choice(ToolChoice::Required),
+        serde_json::json!({"type": "any"})
+    );
 }


### PR DESCRIPTION
## Summary

Implements **issue #2408** (epic #2400 Wave 2, milestone *Inference Adapter Layer*): native **Anthropic-direct** and **OpenAI-direct** adapters in `trusty-common`'s inference layer.

### Anthropic-direct (the substantial work)
A **bespoke** adapter — deliberately NOT routed through the OpenAI-compat serde, because the Messages API is a different wire format:
- POSTs `/v1/messages` with `x-api-key` + `anthropic-version: 2023-06-01` headers (not `Authorization: Bearer`).
- Hoists `system` to the top-level param; strips the `anthropic/` routing prefix from the model id; always emits `max_tokens` (Anthropic requires it).
- Remaps `tool` role messages → `user` `tool_result` blocks and **coalesces** consecutive same-role turns (Anthropic forbids adjacent same-role messages).
- Converts tools to `{name, description, input_schema}` and maps the Anthropic `tool_choice` dialect (`Required`→`{type:any}`, `Function`→`{type:tool,name}`).
- Honors `cache_control` breakpoints (#2156) on system/message/tool blocks; the `cache_control`-dropped-when-content-None caveat (#2479) is not worsened.
- **The #2403-review trap:** Anthropic usage uses `input_tokens`/`output_tokens`, which deserialise to **0** through the OpenAI-shaped `UsageBlock`. Usage is therefore **hand-constructed**, mapping the Anthropic token names correctly.

Request/response translation live in focused submodules (`anthropic/request.rs`, `anthropic/response.rs`) so each file stays under the 500-SLOC cap.

### OpenAI-direct
Already wired by #2403 as a registry binding over the shared OpenAI-compat core (`prompt_caching` precision from #2483 preserved). The only gap the issue named was the missing ignore-gated `live_openai_call` test — **added**.

### Registration & registry
- Both register into the configurator via `register_default_factories`. **Bedrock (#2407) stays unregistered** — the registration diff is minimal/additive so the second-merging PR rebases cleanly.
- Capability-registry entries (context windows, caching) were already accurate for both providers — no changes needed.

## Testing
- Offline e2e via `MockInferenceServer` for the Anthropic Messages-API wire format (request translation + native-usage/tool_use response parsing) and OpenAI-direct.
- 17 new inline unit tests (request/response translation, tool_choice dialect, prefix stripping, the input_tokens→prompt_tokens trap).
- Live tests `live_anthropic_call` / `live_openai_call` are `#[ignore]` (skip cleanly when the key is absent).

### Quality gate (raw)
- `cargo check -p trusty-common --features inference-client,axum-server` — clean
- `cargo test -p trusty-common --features inference-client,axum-server` — **254 lib + 11 adapter e2e + 9 foundation passed; 0 failed** (12 ignored: live/ONNX)
- `cargo clippy -p trusty-common --all-targets --features inference-client,axum-server -- -D warnings` — clean
- `cargo fmt --check` — clean
- `scripts/check_line_cap.sh` — 0 violations
- `scripts/check_test_pointers.sh` — 0 dangling pointers
- `cargo build --workspace` — clean

> Note: one **pre-existing, unrelated** flake in `trusty-search` (`probe_all_volumes_multi_volume_no_fast_starvation`, a wall-clock `elapsed < 100ms` timing assertion at `probe_tests.rs:440`) fails under load on the build machine. It is in code this PR does not touch (diff is trusty-common only) and is not a regression.

Closes #2408

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools