### PR TITLE
fix(trusty-mpm): guided-default cwd's own repo wins over an ancestor (#2542)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -639,6 +639,7 @@ fn find_git_root(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
 /// Test: `guided_classify_cwd_usable_for_tracked_subdir`,
 /// `guided_classify_cwd_untracked_for_uncommitted_subdir`,
 /// `guided_classify_cwd_not_git_for_plain_dir`.
+#[derive(Debug)]
 pub(crate) enum CwdProject {
     /// `cwd` belongs to this git root's tracked tree (or IS the root).
     Usable(std::path::PathBuf),
@@ -648,26 +649,69 @@ pub(crate) enum CwdProject {
     NotGit,
 }
 
+/// Does `cwd` directly own a `.git` entry — i.e. is `cwd` itself a working-tree
+/// root, whose identity must never be inherited from an enclosing ancestor?
+///
+/// Why: the own-repo-wins guard (#2542). A `.git` entry is either a directory
+/// (normal repository) or a *file* (a linked-worktree / submodule gitlink whose
+/// content is `gitdir: <path>`) — BOTH mean `cwd` is a working-tree root. The
+/// match MUST be on the EXACT entry name `.git`: a `.git`-prefixed sibling such as
+/// `.git.hotstats-backup-20260713` (a preserved gitdir from a rescue) is NOT a
+/// repo marker and must be ignored, so a `starts_with(".git")`/glob test would be
+/// a bug. `Path::join(".git")` composes the exact name and `try_exists` follows a
+/// `.git` symlink to its target while still reporting a broken/absent entry as
+/// not-owned.
+/// What: returns `true` when `cwd/.git` exists as any file-system entry (dir,
+/// file, or a symlink resolving to one), `false` when it is absent or a query
+/// error occurs (fail-open to the git-walk path — never falsely claim ownership).
+/// Test: `guided_cwd_owns_git_entry_true_for_dir`,
+/// `guided_cwd_owns_git_entry_true_for_pointer_file`,
+/// `guided_cwd_owns_git_entry_false_for_dotgit_prefixed_sibling`,
+/// `guided_cwd_owns_git_entry_false_when_absent`.
+pub(crate) fn cwd_owns_git_entry(cwd: &std::path::Path) -> bool {
+    cwd.join(".git").try_exists().unwrap_or(false)
+}
+
 /// Classify `cwd` against its nearest enclosing git working tree, verifying
 /// tracked-tree membership before trusting an *ancestor* repo's identity.
 ///
-/// Why: closes the ancestor-`.git` trust gap (#2534). `find_git_root` alone
-/// cannot tell an intentionally-nested tracked subdirectory apart from an
-/// unrelated directory that merely falls inside a repo's path span (the APFS
-/// case-fold collision that made `~/Duetto/cto` resolve to the enclosing
+/// Why: closes the ancestor-`.git` trust gap (#2534) AND the inverse gap where a
+/// directory that DOES own its repo was wrongly adopted into an ancestor (#2542).
+/// `find_git_root` alone cannot tell an intentionally-nested tracked subdirectory
+/// apart from an unrelated directory that merely falls inside a repo's path span
+/// (the APFS case-fold collision that made `~/Duetto/cto` resolve to the enclosing
 /// `hotstats/hotstats-knowledgebase` repo). The tracked-tree check does.
-/// What: resolves the git root. When the root IS `cwd` (the common top-level
-/// case) it is trusted unconditionally — behavior UNCHANGED. When the root is a
-/// strict ancestor, `cwd`'s path relative to the root is checked for tracked-tree
-/// membership via [`cwd_is_tracked_within`]; a hit is `Usable`, a miss is
-/// `UntrackedInsideAncestor`. A prefix mismatch (e.g. symlink canonicalisation
-/// differences between `current_dir` and `git rev-parse --show-toplevel`) cannot
-/// yield a relpath, so it conservatively trusts the root (`Usable`) rather than
-/// newly refusing a previously-working checkout.
-/// Test: `guided_classify_cwd_usable_for_tracked_subdir`,
+/// Separately, `git rev-parse --show-toplevel` walks *past* a `cwd/.git` that is
+/// present but transiently invalid (e.g. a partially-reconstructed gitdir left by
+/// a concurrent `git` rescue) all the way up to an ancestor repo — observed live
+/// as `~/Duetto/cto` (its own repo) being reported as "inside another repository's
+/// working tree (`~/Duetto`)". A directory that physically contains a `.git` entry
+/// IS a working-tree root; its identity is its OWN repo, never an ancestor's.
+/// What: (0) OWN-REPO-WINS — if `cwd` directly contains a `.git` entry (a
+/// directory for a normal repo, or a worktree/submodule gitlink *file*; matched by
+/// EXACT name via [`cwd_owns_git_entry`], never a `.git`-prefixed sibling such as
+/// `.git.backup`), classify `Usable(cwd)` immediately without consulting git's
+/// upward walk. Otherwise (1) resolve the git root; when the root IS `cwd` it is
+/// trusted unconditionally; when the root is a strict ancestor, `cwd`'s relative
+/// path is checked for tracked-tree membership via [`cwd_is_tracked_within`] — a
+/// hit is `Usable`, a miss is `UntrackedInsideAncestor`. A prefix mismatch (e.g.
+/// symlink canonicalisation differences) conservatively trusts the root
+/// (`Usable`) rather than newly refusing a previously-working checkout.
+/// Test: `guided_classify_cwd_own_git_wins_over_ancestor` (#2542 differential),
+/// `guided_classify_cwd_own_git_ignores_dotgit_prefixed_sibling` (#2542),
+/// `guided_classify_cwd_own_git_worktree_pointer_file` (#2542 gitlink file),
+/// `guided_classify_cwd_usable_for_tracked_subdir`,
 /// `guided_classify_cwd_untracked_for_uncommitted_subdir`,
 /// `guided_classify_cwd_usable_for_repo_root`.
 pub(crate) fn classify_cwd_project(cwd: &std::path::Path) -> CwdProject {
+    // (0) Own-repo-wins (#2542): a `.git` entry directly in `cwd` means `cwd` is a
+    // working-tree root — resolve to its OWN repo and never let git's upward walk
+    // adopt an enclosing ancestor. This is deterministic and independent of
+    // whether `cwd/.git` is currently a *valid* gitdir (it may be mid-rescue),
+    // which is exactly the transient that made the walk skip past it.
+    if cwd_owns_git_entry(cwd) {
+        return CwdProject::Usable(cwd.to_path_buf());
+    }
     let Some(git_root) = find_git_root(cwd) else {
         return CwdProject::NotGit;
     };

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -26,10 +26,10 @@ use crate::commands::first_run::needs_first_run_clone;
 /// racing `needs_first_run_clone_returns_some_when_no_clone`.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 use crate::commands::guided::{
-    CwdProject, classify_cwd_project, derive_project, fallback_protected, github_host,
-    is_github_remote, ls_tree_reports_tracked_dir, nested_guard_notice, nested_managed_match,
-    non_github_refusal_message, pane_identity_confirmed, print_non_tty_hint, print_project_context,
-    tty_gate, untracked_ancestor_message,
+    CwdProject, classify_cwd_project, cwd_owns_git_entry, derive_project, fallback_protected,
+    github_host, is_github_remote, ls_tree_reports_tracked_dir, nested_guard_notice,
+    nested_managed_match, non_github_refusal_message, pane_identity_confirmed, print_non_tty_hint,
+    print_project_context, tty_gate, untracked_ancestor_message,
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{ResumeAction, is_zombie, needs_restart, plan_resume};
@@ -484,6 +484,151 @@ fn guided_derive_project_returns_none_for_untracked_ancestor_subdir() {
         derive_project(&untracked).is_none(),
         "derive_project must return None for an untracked ancestor subdir"
     );
+}
+
+// ── #2542: own-repo-wins (cwd's own `.git` beats an ancestor's) ───────────────
+
+#[test]
+fn guided_cwd_owns_git_entry_true_for_dir() {
+    // Why: a `.git` DIRECTORY is the normal repository marker.
+    let tmp = tempdir_with_name("trusty_test_owns_git_dir_2542");
+    std::fs::create_dir_all(tmp.join(".git")).unwrap();
+    assert!(cwd_owns_git_entry(&tmp));
+}
+
+#[test]
+fn guided_cwd_owns_git_entry_true_for_pointer_file() {
+    // Why: a `.git` FILE is a linked-worktree / submodule gitlink — still a
+    // working-tree root. Even a dangling pointer (target moved by a rescue)
+    // means "this dir is its own repo", so it must count as owned.
+    let tmp = tempdir_with_name("trusty_test_owns_git_file_2542");
+    std::fs::write(tmp.join(".git"), b"gitdir: ./moved-away\n").unwrap();
+    assert!(cwd_owns_git_entry(&tmp));
+}
+
+#[test]
+fn guided_cwd_owns_git_entry_false_for_dotgit_prefixed_sibling() {
+    // Why: the exact-name guarantee — a `.git`-PREFIXED sibling such as
+    // `.git.hotstats-backup-20260713` (a preserved gitdir from a rescue) is NOT
+    // a repo marker. A `starts_with(".git")`/glob test would be the bug.
+    let tmp = tempdir_with_name("trusty_test_owns_git_prefixed_2542");
+    std::fs::create_dir_all(tmp.join(".git.hotstats-backup-20260713")).unwrap();
+    assert!(
+        !cwd_owns_git_entry(&tmp),
+        "a `.git`-prefixed sibling must NOT be treated as owning a repo"
+    );
+}
+
+#[test]
+fn guided_cwd_owns_git_entry_false_when_absent() {
+    // Why: a plain directory owns no repo.
+    let tmp = tempdir_with_name("trusty_test_owns_git_absent_2542");
+    assert!(!cwd_owns_git_entry(&tmp));
+}
+
+#[test]
+fn guided_classify_cwd_own_git_wins_over_ancestor() {
+    // Why: the #2542 differential. `cwd` owns a `.git` entry that is present but
+    // transiently INVALID (an empty, partially-reconstructed gitdir — the exact
+    // shape a concurrent `git` rescue leaves). `git rev-parse --show-toplevel`
+    // walks PAST it up to the enclosing `outer` repo (asserted below), so the
+    // pre-fix code classified this as `UntrackedInsideAncestor(outer)` and bare
+    // `tm` wrongly reported "inside another repository's working tree". Own-repo
+    // -wins must classify it as `Usable(cwd)` — its OWN repo, never the ancestor.
+    let outer = tempdir_with_name("trusty_test_own_git_wins_2542");
+    if !git_init_with_commit(&outer) {
+        return; // git unavailable — skip
+    }
+    let inner = outer.join("inner");
+    std::fs::create_dir_all(inner.join(".git")).unwrap(); // present-but-invalid gitdir
+
+    // Precondition: git's upward walk skips the invalid `inner/.git` and lands
+    // on `outer` — the exact behavior the fast-path overrides.
+    if let Some(walked) = find_git_root_via_cli(&inner) {
+        let walked = walked.canonicalize().unwrap_or(walked);
+        let outer_c = outer.canonicalize().unwrap_or_else(|_| outer.clone());
+        assert_eq!(
+            walked, outer_c,
+            "precondition: git walks up to the ancestor"
+        );
+    }
+
+    match classify_cwd_project(&inner) {
+        CwdProject::Usable(root) => {
+            let root = root.canonicalize().unwrap_or(root);
+            let inner_c = inner.canonicalize().unwrap_or_else(|_| inner.clone());
+            assert_eq!(
+                root, inner_c,
+                "must resolve to cwd's OWN repo, not the ancestor"
+            );
+        }
+        other => panic!("cwd owning a `.git` must be Usable(cwd), got {other:?}"),
+    }
+}
+
+#[test]
+fn guided_classify_cwd_own_git_ignores_dotgit_prefixed_sibling() {
+    // Why: task guarantee (a)+(b) — an inner repo with a `.git`-suffixed sibling
+    // dir in its ancestor resolves to ITSELF, never the sibling or the ancestor.
+    let outer = tempdir_with_name("trusty_test_own_git_sibling_2542");
+    if !git_init_with_commit(&outer) {
+        return;
+    }
+    // A `.git`-prefixed backup sibling in the ancestor — must be inert.
+    std::fs::create_dir_all(outer.join(".git.backup-20260713")).unwrap();
+    let inner = outer.join("inner");
+    std::fs::create_dir_all(inner.join(".git")).unwrap();
+    match classify_cwd_project(&inner) {
+        CwdProject::Usable(root) => {
+            let root = root.canonicalize().unwrap_or(root);
+            let inner_c = inner.canonicalize().unwrap_or_else(|_| inner.clone());
+            assert_eq!(root, inner_c);
+        }
+        other => panic!("inner repo must be Usable(inner), got {other:?}"),
+    }
+}
+
+#[test]
+fn guided_classify_cwd_own_git_worktree_pointer_file() {
+    // Why: a `.git` POINTER FILE (linked worktree / submodule gitlink) is a
+    // working-tree root just like a `.git` directory — must be Usable(cwd).
+    let outer = tempdir_with_name("trusty_test_own_git_ptr_2542");
+    if !git_init_with_commit(&outer) {
+        return;
+    }
+    let inner = outer.join("wt");
+    std::fs::create_dir_all(&inner).unwrap();
+    std::fs::write(inner.join(".git"), b"gitdir: /somewhere/else\n").unwrap();
+    match classify_cwd_project(&inner) {
+        CwdProject::Usable(root) => {
+            let root = root.canonicalize().unwrap_or(root);
+            let inner_c = inner.canonicalize().unwrap_or_else(|_| inner.clone());
+            assert_eq!(root, inner_c);
+        }
+        other => panic!("cwd with a `.git` pointer file must be Usable(cwd), got {other:?}"),
+    }
+}
+
+#[test]
+fn guided_classify_cwd_untracked_ancestor_still_refuses_without_own_git() {
+    // Why: the #2534 guarantee must survive the #2542 fast-path. An untracked
+    // directory that has NO own `.git`, nested in a REAL ancestor repo, must
+    // still be `UntrackedInsideAncestor` — the fast-path only fires when cwd
+    // owns a `.git`, so this path is unchanged.
+    let outer = tempdir_with_name("trusty_test_untracked_still_refuses_2542");
+    if !git_init_with_commit(&outer) {
+        return;
+    }
+    let untracked = outer.join("notes");
+    std::fs::create_dir_all(&untracked).unwrap();
+    assert!(
+        !cwd_owns_git_entry(&untracked),
+        "precondition: untracked dir owns no `.git`"
+    );
+    match classify_cwd_project(&untracked) {
+        CwdProject::UntrackedInsideAncestor(_) => {}
+        other => panic!("#2534 case must still refuse the ancestor, got {other:?}"),
+    }
 }
 
 /// Local helper: resolve the git working-tree root via the CLI (mirrors the


### PR DESCRIPTION
Closes #2542. Regression surfaced with 0.19.5 (#2535 / PR #2538).

## Problem

Bare `tm` (0.19.5), run from a real git repo `/Users/masa/Duetto/cto`, refused with:
```
tm: this directory is inside another repository's working tree (/Users/masa/Duetto) but is not part of it — not launching that project.
```
even though `cto` owns its own `.git`.

## Root cause

`crates/trusty-mpm/src/bin/tm/commands/guided.rs`: `find_git_root` shells to
`git rev-parse --show-toplevel`, and `classify_cwd_project` only fast-paths when
`git_root == cwd`. `git rev-parse --show-toplevel` **walks past a `cwd/.git` that is present but
transiently invalid** (an empty / partially-reconstructed gitdir — exactly what the concurrent
`git` rescue under `~/Duetto` left) up to the enclosing directory, so tm adopts the ancestor and
refuses. There is **no** `.git` prefix/glob matching in the code — the `.git.hotstats-backup-*`
sibling is inert to `git`; the prefix angle was a red herring.

Hermetic proof: `outer/` a real repo, `outer/inner/.git/` an empty dir →
`git -C outer/inner rev-parse --show-toplevel` returns `outer`, and pre-fix
`classify_cwd_project(outer/inner)` → `UntrackedInsideAncestor(outer)`.

## Fix

`classify_cwd_project` gains an **own-repo-wins** fast-path: if `cwd` directly owns a `.git` entry
(dir OR worktree/submodule gitlink *file*; EXACT name, never a `.git`-prefixed sibling) →
`Usable(cwd)` before consulting git's walk. Deterministic, independent of gitdir validity. #2534's
untracked-ancestor refusal (cwd owns no `.git`) is unchanged.

The Run-2 `cto-personal-notes` mis-target is **not** a tm defect — it is `std::env::current_dir()`
(getcwd) printed verbatim after the rescue renamed the shell's cwd inode. No code fix warranted;
documented in #2542.

## Tests (hermetic, `tests_behavior_c_tests.rs`)

- `guided_classify_cwd_own_git_wins_over_ancestor` — the differential (invalid `inner/.git`; asserts
  git walks up to `outer`, then that classify returns `Usable(inner)`).
- `guided_classify_cwd_own_git_ignores_dotgit_prefixed_sibling` — `.git`-suffixed sibling in the
  ancestor is inert; cwd resolves to itself.
- `guided_classify_cwd_own_git_worktree_pointer_file` — a `.git` pointer *file* counts.
- `guided_cwd_owns_git_entry_*` — dir / pointer-file / prefixed-sibling / absent.
- `guided_classify_cwd_untracked_ancestor_still_refuses_without_own_git` — #2534 preserved.

## Gate (raw)

- `cargo fmt --check` → exit 0
- `bash scripts/check_line_cap.sh` → `0 allowlisted, 0 violations — OK`
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` → exit 0; `cargo clippy --workspace` clean
- `cargo build --workspace` → exit 0
- `cargo test --workspace` → trusty-mpm all green (1783 in the tm bin; new tests pass). One
  unrelated failure in `trusty-common update::tests::verify_installed_binary_finds_binary_in_cargo_bin`
  (a pre-existing parallel `set_var` HOME/CARGO_HOME/PATH env-race flake, last touched by #2523
  "fix flaky env isolation") — **passes single-threaded**, untouched by this change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
