### PR TITLE
chore(trusty-mpm): bump version to 0.19.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11075,7 +11075,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.19.5"
+version = "0.19.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- guided-default cwd's own repo wins over an ancestor ([#2542](https://github.com/bobmatnyc/trusty-tools/pull/2542)) ([#2543](https://github.com/bobmatnyc/trusty-tools/pull/2543)) ([`51f5041`](https://github.com/bobmatnyc/trusty-tools/commit/51f50417e23c76a4bea4beabc854c4e75cacd526))
+## [Unreleased]
+
 ### Added
 
 - Test-pointer lint gate (closes #2458) ([#2529](https://github.com/bobmatnyc/trusty-tools/pull/2529)) ([`9876b44`](https://github.com/bobmatnyc/trusty-tools/commit/9876b44d72d2a68dd9df213e027d2f15a119e2b9))

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.19.5"
+version = "0.19.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bump trusty-mpm version 0.19.5 -> 0.19.6 for release, shipping the #2542 guided-default hardening (PR #2543) to the installed binary.
- CHANGELOG staged via scripts/generate-changelog.sh.

## Test plan
- [x] cargo build --workspace
- [x] cargo test -p trusty-mpm (0 failed)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --check
- [x] bash scripts/check_line_cap.sh

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools