### PR TITLE
fix(trusty-mpm): pane-scope session capture reads to the recorded harness pane (closes #2515)

### DIFF
--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -346,19 +346,19 @@ struct DaemonVerdictProvider {
 impl idle_reaper::IdleVerdictProvider for DaemonVerdictProvider {
     async fn verdict(&self, session_name: &str) -> Option<String> {
         use crate::activity::ActivityState;
-        // Capture the most recent pane output via the tmux driver (300 lines is
-        // enough for the LLM classifier). Note: TmuxDriver::capture() shells out
-        // via std::process::Command — the same blocking pattern used throughout
-        // the daemon (observe(), reap_loop, etc.); sub-millisecond latency is
-        // acceptable here and is consistent with the existing codebase.
+        // Capture the most recent output of the session's RECORDED harness pane
+        // (300 lines is enough for the LLM classifier). Routing through
+        // `capture_pane_by_tmux_name` rather than the raw session-scoped
+        // `tmux_driver().capture()` (#2515) ensures we classify the pane this
+        // record actually owns, not whichever sibling window an operator left
+        // active — otherwise a busy session can be auto-stopped as idle (or a
+        // quiet one kept alive). `None` when no live record matches the name, the
+        // recorded pane is confirmed gone, or the capture is empty: in every case
+        // we skip this poll rather than act on ambiguous content.
         let pane_text = self
             .mgr
-            .tmux_driver()
-            .capture(session_name, 300)
-            .unwrap_or_default();
-        if pane_text.is_empty() {
-            return None;
-        }
+            .capture_pane_by_tmux_name(session_name, 300)
+            .await?;
         // Use the shared ActivityMonitor (hash-cached — no LLM call if content unchanged).
         let monitor = self.state.activity_monitor();
         match monitor.check(session_name, &pane_text).await {

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -906,21 +906,93 @@ impl SessionManager {
         self.tmux.clone()
     }
 
-    /// Capture the last `lines` of pane output for a session.
+    /// Capture the last `lines` of the session's RECORDED harness pane.
     ///
-    /// Why: the activity route needs the pane content to classify activity state.
-    /// What: looks up the session's tmux_name and delegates to the driver's
-    /// `capture` method.
-    /// Test: covered by handler_activity_cache_hit in session_manager_mvp.rs.
+    /// Why: activity classification (`managed_routes/activity`), the MCP
+    /// `session_activity` read (`mcp_session`), the CLI transcript
+    /// (`sm_stdio/control`, `bin/tm/commands/meta/launch`), and the supervisor
+    /// idle classifier (`supervisor/poller`) all read "the session's pane" to
+    /// decide state or show output. A session-scoped `capture` resolves to
+    /// whichever pane tmux considers ACTIVE — which need not be the harness pane
+    /// this record owns (an operator's sibling window keeps the session alive
+    /// but steals the active-pane slot). That silently fed wrong-pane content to
+    /// every one of those consumers and could misclassify a busy session as idle
+    /// (issue #2515). This shares the exact pane-scoping [`Self::observe`] uses.
+    /// What: [`Self::ensure_pane_alive`]-gates the recorded `pane_id` first
+    /// (refusing with `ManagedError::PaneGone` rather than reading a sibling
+    /// pane when the recorded pane is confirmed gone but the session lives on),
+    /// then captures the last `lines` rows via the pane-scoped `capture_pane`
+    /// when `record.pane_id` is known, or the session-scoped `capture` otherwise
+    /// (a legacy pre-#2453 record with no captured pane_id — same fallback
+    /// #2467/#2468 established). Every consumer already degrades a capture error
+    /// to empty/no-verdict, so a `PaneGone` refusal fails closed, never louder.
+    /// Test: `capture_pane_targets_recorded_pane_when_pane_id_known`,
+    /// `capture_pane_refuses_when_stored_pane_gone`,
+    /// `capture_pane_legacy_record_falls_back_to_session_capture` in
+    /// `pane_scoped_tests.rs`.
     pub async fn capture_pane(
         &self,
         id: &ManagedSessionId,
         lines: usize,
     ) -> Result<String, ManagedError> {
         let record = self.get(id).await?;
-        self.tmux
-            .capture(&record.tmux_name, lines)
-            .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
+        self.ensure_pane_alive(id, &record)?;
+        match record.pane_id.as_deref() {
+            Some(pane_id) => self.tmux.capture_pane(&record.tmux_name, pane_id, lines),
+            None => self.tmux.capture(&record.tmux_name, lines),
+        }
+        .map_err(|e| ManagedError::TmuxUnavailable(e.to_string()))
+    }
+
+    /// Capture the recorded harness pane for the LIVE managed session whose tmux
+    /// session name is `tmux_name`, pane-scoped when a `pane_id` is tracked.
+    ///
+    /// Why: the idle reaper (`daemon::mod::DaemonVerdictProvider::verdict`) knows
+    /// a session only by its tmux name and captured via the raw driver's
+    /// session-scoped `capture`, which tmux resolves to whichever pane is ACTIVE
+    /// — a sibling operator window could make a busy session read as idle and be
+    /// auto-stopped, or a quiet one read as busy (issue #2515). Unlike
+    /// [`Self::capture_pane`] the reaper has no `ManagedSessionId`, so this
+    /// resolves the record from the tmux name first.
+    /// What: selects the record whose `tmux_name` matches and whose state is NOT
+    /// `Decommissioned` (a `tmux_name` is recycled after decommission, so a naive
+    /// match can hit a stale tombstone — same guard as
+    /// `daemon::api::claude_config_routes::select_restart_pane_id`, #2514),
+    /// preferring the most recently created on the narrow provisioning-race
+    /// overlap. With a tracked `pane_id` it captures pane-scoped, returning `None`
+    /// (no verdict — fail closed) when [`ManagedTmuxDriver::pane_exists`] reports
+    /// the recorded pane gone rather than reading a sibling. A legacy record
+    /// (no `pane_id`) or an unmanaged/legacy tmux name with no live record falls
+    /// back to the session-scoped `capture`, exactly as before #2515. `None` on
+    /// any capture error or empty output so the caller skips the poll.
+    /// Test: `capture_pane_by_tmux_name_targets_recorded_pane`,
+    /// `capture_pane_by_tmux_name_refuses_when_pane_gone`,
+    /// `capture_pane_by_tmux_name_legacy_falls_back_to_session` in
+    /// `pane_scoped_tests.rs`.
+    pub async fn capture_pane_by_tmux_name(&self, tmux_name: &str, lines: usize) -> Option<String> {
+        let record = self
+            .list()
+            .await
+            .into_iter()
+            .filter(|r| r.tmux_name == tmux_name)
+            .filter(|r| !matches!(r.state, ManagedSessionState::Decommissioned))
+            .max_by_key(|r| r.created_at);
+        let text = match record.as_ref().and_then(|r| r.pane_id.as_deref()) {
+            Some(pane_id) => {
+                if !self.tmux.pane_exists(tmux_name, pane_id) {
+                    warn!(
+                        name = %tmux_name,
+                        pane_id = %pane_id,
+                        "idle-reaper capture: recorded pane is gone but the tmux session is \
+                         still alive (sibling window) — refusing to read an unrelated pane"
+                    );
+                    return None;
+                }
+                self.tmux.capture_pane(tmux_name, pane_id, lines).ok()?
+            }
+            None => self.tmux.capture(tmux_name, lines).ok()?,
+        };
+        (!text.is_empty()).then_some(text)
     }
 
     /// Mark a session as errored with a message.

--- a/crates/trusty-mpm/src/session_manager/pane_scoped_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/pane_scoped_tests.rs
@@ -297,3 +297,146 @@ async fn observe_legacy_record_without_pane_id_falls_back_to_session_capture() {
     assert_eq!(obs.raw_pane, "session-scoped output");
     assert!(fake.pane_capture_calls.lock().unwrap().is_empty());
 }
+
+// ── capture_pane (by id): the shared read behind activity/mcp/cli/supervisor ──
+// (issue #2515 — same three-way contract as observe, applied to the read helper
+// every non-observe consumer routes through).
+
+#[tokio::test]
+async fn capture_pane_targets_recorded_pane_when_pane_id_known() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+    // Keyed by PANE id — proves the read used the pane-scoped capture, not the
+    // session-scoped one (which the fake keys by session name).
+    fake.capture_responses
+        .lock()
+        .unwrap()
+        .insert("%6015".to_string(), "pane-owned output".to_string());
+
+    let text = mgr
+        .capture_pane(&record.id, 60)
+        .await
+        .expect("capture_pane");
+
+    assert_eq!(text, "pane-owned output");
+    assert_eq!(
+        fake.pane_capture_calls.lock().unwrap().as_slice(),
+        [(record.tmux_name.clone(), "%6015".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn capture_pane_refuses_when_stored_pane_gone() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+    *fake.pane_exists_override.lock().unwrap() = Some(false);
+
+    let err = mgr
+        .capture_pane(&record.id, 60)
+        .await
+        .expect_err("a confirmed-gone recorded pane must refuse the read too");
+
+    assert!(
+        matches!(&err, ManagedError::PaneGone(sid, pid) if sid == &record.id.to_string() && pid == "%6015"),
+        "expected PaneGone(session_id, \"%6015\"), got: {err:?}"
+    );
+    assert!(
+        fake.pane_capture_calls.lock().unwrap().is_empty(),
+        "the pane-scoped capture must not fire on refusal — the whole read refuses"
+    );
+}
+
+#[tokio::test]
+async fn capture_pane_legacy_record_falls_back_to_session_capture() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, None).await;
+    // Keyed by SESSION name — the legacy/session-scoped lookup path.
+    fake.capture_responses.lock().unwrap().insert(
+        record.tmux_name.clone(),
+        "session-scoped output".to_string(),
+    );
+
+    let text = mgr
+        .capture_pane(&record.id, 60)
+        .await
+        .expect("capture_pane");
+
+    assert_eq!(text, "session-scoped output");
+    assert!(fake.pane_capture_calls.lock().unwrap().is_empty());
+}
+
+// ── capture_pane_by_tmux_name: the idle-reaper read keyed by tmux name ───────
+// (issue #2515 — the reaper knows a session only by tmux name; resolve the
+// record, then apply the same pane-scoped-or-refuse contract).
+
+#[tokio::test]
+async fn capture_pane_by_tmux_name_targets_recorded_pane() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+    fake.capture_responses
+        .lock()
+        .unwrap()
+        .insert("%6015".to_string(), "pane-owned output".to_string());
+
+    let text = mgr
+        .capture_pane_by_tmux_name(&record.tmux_name, 300)
+        .await
+        .expect("live record with an alive pane yields pane content");
+
+    assert_eq!(text, "pane-owned output");
+    assert_eq!(
+        fake.pane_capture_calls.lock().unwrap().as_slice(),
+        [(record.tmux_name.clone(), "%6015".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn capture_pane_by_tmux_name_refuses_when_pane_gone() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, Some("%6015")).await;
+    *fake.pane_exists_override.lock().unwrap() = Some(false);
+
+    let out = mgr.capture_pane_by_tmux_name(&record.tmux_name, 300).await;
+
+    assert!(
+        out.is_none(),
+        "a confirmed-gone recorded pane must yield None (no verdict), not a sibling read"
+    );
+    assert!(
+        fake.pane_capture_calls.lock().unwrap().is_empty(),
+        "the pane-scoped capture must not fire when the pane is gone"
+    );
+}
+
+#[tokio::test]
+async fn capture_pane_by_tmux_name_legacy_falls_back_to_session() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake, record) = make_active_session(&dir, None).await;
+    fake.capture_responses.lock().unwrap().insert(
+        record.tmux_name.clone(),
+        "session-scoped output".to_string(),
+    );
+
+    let text = mgr
+        .capture_pane_by_tmux_name(&record.tmux_name, 300)
+        .await
+        .expect("legacy record falls back to session-scoped capture");
+
+    assert_eq!(text, "session-scoped output");
+    assert!(fake.pane_capture_calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn capture_pane_by_tmux_name_none_for_unmanaged_name() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake, _record) = make_active_session(&dir, Some("%6015")).await;
+
+    let out = mgr
+        .capture_pane_by_tmux_name("tm-no-such-session", 300)
+        .await;
+
+    assert!(
+        out.is_none(),
+        "an unmanaged/unknown tmux name with no live record and no seeded capture yields None"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #2467/#2468/#2514, which pane-scoped the tmux **inject** and **observe** paths. This PR closes the remaining **read** sites (issue #2515): session-scoped tmux `capture` resolves to whichever pane tmux considers **ACTIVE**, which need not be the harness pane the `SessionRecord` owns. An operator's sibling window silently fed wrong-pane content to:

- activity classification (`daemon/managed_routes/activity.rs`)
- the MCP `session_activity` read (`daemon/mcp_session.rs`)
- CLI transcripts (`daemon/sm_stdio/control.rs`, `bin/tm/commands/meta/launch.rs`)
- the supervisor idle classifier (`supervisor/poller.rs`)
- the **idle reaper** (`daemon/mod.rs`) — the P1-adjacent case: a busy session could be auto-stopped as idle (or a quiet one kept alive).

## Root fix (shared helpers, not per-callsite)

All five `ManagedSessionId` consumers route through **one** helper, `SessionManager::capture_pane`, and the reaper through **one** new helper — so this is two root fixes, no scattered patches:

1. **`SessionManager::capture_pane`** now `ensure_pane_alive`-gates the recorded `pane_id`, captures **pane-scoped** via `capture_pane` when `pane_id` is known, and falls back to session-scoped `capture` only for legacy pre-#2453 records with no captured `pane_id` — mirroring `observe` exactly.
2. **`SessionManager::capture_pane_by_tmux_name`** (new) resolves the live record from the tmux name — excluding recycled decommissioned tombstones and preferring the most-recently-created match, the same guard as `select_restart_pane_id` (#2514) — then applies the same pane-scoped-or-refuse contract. The idle reaper's `DaemonVerdictProvider::verdict` now routes through it instead of the raw `tmux_driver().capture()`.

## Fails closed

A confirmed-gone recorded pane refuses (`ManagedError::PaneGone` for `capture_pane`; `None` for the reaper helper) rather than reading a sibling pane. Every consumer already degrades a capture error to empty/no-verdict, so the refusal never surfaces louder than the prior behavior. Legacy records (no `pane_id`) and unmanaged/legacy tmux names keep exact pre-#2515 session-scoped behavior. Preserves the #2468 session-scoped-target hardening.

## Tests

Added to `session_manager/pane_scoped_tests.rs`, following the #2468 `FakeTmuxDriver` pattern (pane-scoped-when-known / refuse-when-gone / legacy-fallback for both helpers + unmanaged-name `None`).

## Gate (all green)

- `cargo build --workspace` — clean
- `cargo test --workspace` — 14090 passed, 0 failed (trusty-mpm lib: 2970 passed, 0 failed, 5 ignored)
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — clean
- `scripts/check_line_cap.sh` — 0 violations
- `scripts/check_test_pointers.sh` — 0 dangling pointers

Closes #2515

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools