### PR TITLE
fix(trusty-mpm): reconcile agent roster drift across deploy destinations

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -277,6 +277,16 @@ pub(crate) enum Command {
     /// restricts the reset to those agents. Content that cannot be proven to
     /// already be trusty-mpm's own prior output is backed up (`<file>.bak-
     /// <unix_nanos>`) before being overwritten — nothing is silently lost.
+    ///
+    /// `--reset-agents-workspaces` (issue #2508) extends the SAME reset to
+    /// every intact session workspace's PROJECT-LOCAL `.claude/agents/` —
+    /// without it, `--reset-agents` only ever reconciles the USER-LEVEL
+    /// `~/.claude/agents/` copy, leaving every already-provisioned session
+    /// worktree stale. Each workspace is reset through its OWN resolved
+    /// harness plan, so an agent that workspace's manifest deliberately
+    /// excludes is never resurrected (issue #2462's `[agents].exclude` roster
+    /// filter). Requires `--reset-agents` (there is nothing "workspace" to
+    /// reset without it).
     Install {
         /// Overwrite artifacts that already exist on disk.
         #[arg(long)]
@@ -286,6 +296,10 @@ pub(crate) enum Command {
         /// list (e.g. `--reset-agents engineer,qa`) to restrict the scope.
         #[arg(long, num_args = 0.., value_delimiter = ',')]
         reset_agents: Option<Vec<String>>,
+        /// Also reset every intact session workspace's project-local
+        /// `.claude/agents/` (issue #2508). Requires `--reset-agents`.
+        #[arg(long, requires = "reset_agents")]
+        reset_agents_workspaces: bool,
     },
     /// Handle a Claude Code lifecycle hook (PreToolUse / PostToolUse / Stop).
     ///

--- a/crates/trusty-mpm/src/bin/tm/commands/install.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install.rs
@@ -118,6 +118,15 @@ pub(crate) async fn install(
                     outcome.tmux_name,
                     outcome.workspace_path.display()
                 );
+                // Issue #1511: a session the ownership gate rejected is
+                // reported explicitly (never silently absent) and its
+                // `result` is always empty — do not run it through
+                // `reset_report_lines`, which would print a misleading
+                // all-zero summary instead of the actual reason.
+                if let Some(reason) = &outcome.skipped_reason {
+                    println!("    {reason}");
+                    continue;
+                }
                 for line in reset_report_lines(&outcome.result) {
                     println!("    {line}");
                 }

--- a/crates/trusty-mpm/src/bin/tm/commands/install.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install.rs
@@ -27,14 +27,25 @@
 /// the reset to those agents. The normal deploy always runs first — reset
 /// only forces the specific files a plain deploy would otherwise leave
 /// alone, and re-registers everything else it touches.
+///
+/// `reset_agents_workspaces` (issue #2508) additionally sweeps every intact
+/// session workspace's project-local `.claude/agents/` through the SAME
+/// reset, each gated by that workspace's OWN resolved harness plan (so an
+/// agent one project's manifest excludes is never resurrected there — the
+/// #2462 cross-warning). Only takes effect when `reset_agents` is `Some`.
 /// What: resolves [`FrameworkPaths::default`], calls [`install_to`] then
 /// [`install_system_prompt_to`] to write the real assembled PM prompt,
-/// deploys agents and skills, optionally resets the requested agent scope,
-/// then calls [`install_claude_hooks`].
+/// deploys agents and skills, optionally resets the requested agent scope
+/// (user-level, then every intact session workspace when requested), then
+/// calls [`install_claude_hooks`].
 /// Test: `install_writes_all_artifacts`, `install_skips_existing_without_force`,
 /// `install_claude_hooks_is_idempotent`,
 /// `instruction_pipeline::install_system_prompt_to_writes_assembled`.
-pub(crate) fn install(force: bool, reset_agents: Option<Vec<String>>) -> anyhow::Result<()> {
+pub(crate) async fn install(
+    force: bool,
+    reset_agents: Option<Vec<String>>,
+    reset_agents_workspaces: bool,
+) -> anyhow::Result<()> {
     let paths = trusty_mpm::core::paths::FrameworkPaths::default();
     let report = install_to(&paths, force)?;
     println!(
@@ -86,6 +97,31 @@ pub(crate) fn install(force: bool, reset_agents: Option<Vec<String>>) -> anyhow:
         )?;
         for line in reset_report_lines(&reset) {
             println!("  {line}");
+        }
+
+        // Issue #2508: the user-level reset above never touches a project's
+        // own `.claude/agents/` — sweep every intact session workspace through
+        // the identical reset, each gated by ITS OWN resolved harness plan.
+        if reset_agents_workspaces {
+            println!("Resetting agents in every intact session workspace…");
+            let outcomes = trusty_mpm::core::agent_reset_workspace::reset_active_workspace_agents(
+                &paths.root,
+                filter.as_deref(),
+            )
+            .await?;
+            if outcomes.is_empty() {
+                println!("  (no intact session workspaces found)");
+            }
+            for outcome in &outcomes {
+                println!(
+                    "  {} ({})",
+                    outcome.tmux_name,
+                    outcome.workspace_path.display()
+                );
+                for line in reset_report_lines(&outcome.result) {
+                    println!("    {line}");
+                }
+            }
         }
     }
 
@@ -354,9 +390,13 @@ pub(crate) fn deploy_report_lines(
 /// large reset is scannable at a glance.
 /// What: a `\u{27f3} <file> (recomposed, backed up)` or `\u{27f3} <file>
 /// (recomposed)` line per rewritten file, a `\u{25c6} <file> (adopted)` line
-/// per already-current file, and a `? <name>` line per requested name with no
-/// matching source agent — followed by one summary line with the four totals.
-/// Test: `reset_report_lines_summarizes_counts`.
+/// per already-current file, a `? <name>` line per requested name with no
+/// matching source agent, and — for a [`reset_project_agents`](trusty_mpm::core::agent_reset::reset_project_agents)
+/// result (issue #2508) — a `\u{2298} <name> (excluded by this workspace's
+/// manifest)` line per requested name the target's own harness plan rejected,
+/// followed by one summary line with all five totals.
+/// Test: `reset_report_lines_summarizes_counts`,
+/// `reset_report_lines_shows_deselected`.
 pub(crate) fn reset_report_lines(
     reset: &trusty_mpm::core::agent_reset::ResetResult,
 ) -> Vec<String> {
@@ -374,12 +414,18 @@ pub(crate) fn reset_report_lines(
     for name in &reset.not_found {
         lines.push(format!("? {name} (no matching source agent)"));
     }
+    for name in &reset.deselected {
+        lines.push(format!(
+            "\u{2298} {name} (excluded by this workspace's manifest)"
+        ));
+    }
     lines.push(format!(
-        "reset summary: {} recomposed, {} adopted, {} backed up, {} not found",
+        "reset summary: {} recomposed, {} adopted, {} backed up, {} not found, {} deselected",
         reset.recomposed.len(),
         reset.adopted.len(),
         reset.backed_up.len(),
-        reset.not_found.len()
+        reset.not_found.len(),
+        reset.deselected.len()
     ));
     lines
 }

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -349,7 +349,8 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Install {
             force,
             reset_agents,
-        }) => install(force, reset_agents),
+            reset_agents_workspaces,
+        }) => install(force, reset_agents, reset_agents_workspaces).await,
         Some(Command::Hook { pm_guard }) => {
             if pm_guard {
                 commands::pm_guard::pm_guard(&url).await

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_reset_agents_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_reset_agents_tests.rs
@@ -104,6 +104,7 @@ fn reset_report_lines_summarizes_counts() {
         adopted: vec!["c.md".to_string()],
         backed_up: vec!["b.md".to_string()],
         not_found: vec!["missing-agent".to_string()],
+        deselected: vec![],
     };
 
     let lines = reset_report_lines(&result);
@@ -119,7 +120,64 @@ fn reset_report_lines_summarizes_counts() {
         lines.iter().any(|l| l.contains("2 recomposed")
             && l.contains("1 adopted")
             && l.contains("1 backed up")
-            && l.contains("1 not found")),
+            && l.contains("1 not found")
+            && l.contains("0 deselected")),
         "lines = {lines:?}"
     );
+}
+
+#[test]
+fn reset_report_lines_shows_deselected() {
+    // Issue #2508: a `reset_project_agents` result that DESELECTED a
+    // manifest-excluded agent must surface it distinctly, not silently.
+    let result = trusty_mpm::core::agent_reset::ResetResult {
+        recomposed: vec!["base-agent.md".to_string()],
+        adopted: vec![],
+        backed_up: vec![],
+        not_found: vec![],
+        deselected: vec!["engineer".to_string()],
+    };
+
+    let lines = reset_report_lines(&result);
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("engineer") && l.contains("excluded")),
+        "lines = {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|l| l.contains("1 deselected")),
+        "lines = {lines:?}"
+    );
+}
+
+#[test]
+fn cli_parses_install_reset_agents_workspaces() {
+    // Issue #2508: `--reset-agents-workspaces` requires `--reset-agents` and
+    // defaults to false when omitted.
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "install",
+        "--reset-agents",
+        "--reset-agents-workspaces",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Install {
+            reset_agents,
+            reset_agents_workspaces,
+            ..
+        } => {
+            assert_eq!(reset_agents, Some(vec![]));
+            assert!(reset_agents_workspaces);
+        }
+        other => panic!("expected Install, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_rejects_reset_agents_workspaces_without_reset_agents() {
+    // The flag is meaningless (and forbidden) without `--reset-agents`.
+    let result = Cli::try_parse_from(["trusty-mpm", "install", "--reset-agents-workspaces"]);
+    assert!(result.is_err());
 }

--- a/crates/trusty-mpm/src/core/agent_reset.rs
+++ b/crates/trusty-mpm/src/core/agent_reset.rs
@@ -17,11 +17,16 @@
 //! content differs from BOTH the manifest's last-known checksum (if any) AND
 //! the fresh composition is backed up to `<file>.bak-<unix_nanos>` before
 //! being overwritten, so no content is ever silently discarded.
-//! [`reset_project_agents`] (issue #2508) is the project/session-worktree-safe
-//! variant: it narrows the reset to a resolved harness plan's `agent_selected`
-//! roster BEFORE delegating to [`reset_agents`], so it can reconcile a
-//! project-local `.claude/agents/` dir without resurrecting an agent the
-//! project's manifest deliberately excludes.
+//! [`reset_project_agents`] (issue #2508) is the ROSTER-safe variant: it
+//! narrows the reset to a resolved harness plan's `agent_selected` roster
+//! BEFORE delegating to [`reset_agents`], so it never resurrects an agent
+//! the target's manifest deliberately excludes. It is NOT, by itself,
+//! workspace-OWNERSHIP-safe — it will happily force-recompose files into
+//! whatever `target_dir` it is given. The caller owns verifying that
+//! `target_dir` is a workspace trusty-mpm actually provisioned before
+//! calling this function; [`crate::core::agent_reset_workspace::
+//! reset_active_workspace_agents`] is the caller that does so (issue #1511
+//! incident class — see that module's doc comment for the ownership gate).
 //! Test: `reset_writes_all_by_default`, `reset_filters_by_name`,
 //! `reset_adopts_matching_untracked_file`, `reset_backs_up_diverged_file`,
 //! `reset_recomposes_without_backup_when_matching_manifest_checksum`,
@@ -248,8 +253,10 @@ fn available_agent_names(source_dir: &Path) -> std::io::Result<Vec<String>> {
     Ok(available)
 }
 
-/// Force-recompose agent files into a PROJECT-LOCAL `.claude/agents/` dir,
-/// respecting a harness plan's deploy-roster selection (issue #2508).
+/// Force-recompose agent files into a target `.claude/agents/` dir,
+/// respecting a harness plan's deploy-roster selection (issue #2508). This
+/// function is ROSTER-safe, NOT workspace-ownership-safe — see the caller
+/// contract below.
 ///
 /// Why: [`reset_agents`] alone is unsafe to point at a project/session-worktree
 /// target — a project's resolved [`crate::core::manifest::HarnessPlan`] may
@@ -268,6 +275,18 @@ fn available_agent_names(source_dir: &Path) -> std::io::Result<Vec<String>> {
 /// and delegates the actual compose/backup/adopt/write logic to [`reset_agents`]
 /// with that narrowed set (so the two entry points can never diverge in
 /// backup/adoption semantics).
+///
+/// CALLER CONTRACT (issue #1511 incident class): this function does NOT check
+/// whether `target_dir` belongs to a workspace trusty-mpm actually
+/// provisioned — it will force-recompose into whatever directory it is
+/// given. A local-path/adopted session's workspace is the operator's REAL,
+/// long-lived checkout, not a disposable trusty-mpm clone/worktree. The
+/// CALLER must verify workspace ownership (`workspace_owned ||
+/// is_session_worktree(path)` — the same predicate
+/// `session_manager::decommission` and `session_manager::search_gc` gate on)
+/// BEFORE calling this function.
+/// [`crate::core::agent_reset_workspace::reset_active_workspace_agents`] is
+/// the only caller that sweeps multiple sessions, and it enforces this gate.
 /// Test: `reset_project_agents_respects_plan_selection`,
 /// `reset_project_agents_reports_deselected_requested_name`,
 /// `reset_project_agents_defaults_to_all_selected`.

--- a/crates/trusty-mpm/src/core/agent_reset.rs
+++ b/crates/trusty-mpm/src/core/agent_reset.rs
@@ -17,10 +17,18 @@
 //! content differs from BOTH the manifest's last-known checksum (if any) AND
 //! the fresh composition is backed up to `<file>.bak-<unix_nanos>` before
 //! being overwritten, so no content is ever silently discarded.
+//! [`reset_project_agents`] (issue #2508) is the project/session-worktree-safe
+//! variant: it narrows the reset to a resolved harness plan's `agent_selected`
+//! roster BEFORE delegating to [`reset_agents`], so it can reconcile a
+//! project-local `.claude/agents/` dir without resurrecting an agent the
+//! project's manifest deliberately excludes.
 //! Test: `reset_writes_all_by_default`, `reset_filters_by_name`,
 //! `reset_adopts_matching_untracked_file`, `reset_backs_up_diverged_file`,
 //! `reset_recomposes_without_backup_when_matching_manifest_checksum`,
-//! `reset_reports_unknown_names`.
+//! `reset_reports_unknown_names`,
+//! `reset_project_agents_respects_plan_selection`,
+//! `reset_project_agents_reports_deselected_requested_name`,
+//! `reset_project_agents_defaults_to_all_selected`.
 
 use std::path::{Path, PathBuf};
 
@@ -52,6 +60,11 @@ pub struct ResetResult {
     pub backed_up: Vec<String>,
     /// Requested names with no matching source agent file.
     pub not_found: Vec<String>,
+    /// Requested names that exist in the source but were rejected by the
+    /// target harness's `agent_selected` roster filter (issue #2508/#2462).
+    /// Only ever populated by [`reset_project_agents`] — always empty for a
+    /// plain [`reset_agents`] call, which has no roster filter to apply.
+    pub deselected: Vec<String>,
 }
 
 /// Suffix template for reset backups: `<file>.bak-<unix_nanos>`.
@@ -126,18 +139,7 @@ pub fn reset_agents(
     };
     let now = chrono::Utc::now().to_rfc3339();
 
-    let mut available: Vec<String> = Vec::new();
-    for entry in std::fs::read_dir(source_dir)? {
-        let entry = entry?;
-        let file_name = entry.file_name();
-        let Some(name) = file_name.to_str() else {
-            continue;
-        };
-        if entry.file_type()?.is_file() && is_agent_file(name) {
-            available.push(name.trim_end_matches(".md").to_string());
-        }
-    }
-    available.sort_unstable();
+    let available = available_agent_names(source_dir)?;
 
     let targets: Vec<String> = match names {
         None => available.clone(),
@@ -219,6 +221,86 @@ pub fn reset_agents(
         other => AgentBuildError::FrontmatterParse(other.to_string()),
     })?;
 
+    Ok(result)
+}
+
+/// List the `.md` agent stems directly under `source_dir`, sorted.
+///
+/// Why: [`reset_agents`] and [`reset_project_agents`] both need the same
+/// "what can be reset" enumeration; factoring it out keeps the scan logic
+/// single-sourced.
+/// What: reads `source_dir`, keeps regular files [`is_agent_file`] accepts,
+/// strips the `.md` suffix, and returns the sorted stems.
+/// Test: exercised indirectly by every `reset_*` test.
+fn available_agent_names(source_dir: &Path) -> std::io::Result<Vec<String>> {
+    let mut available: Vec<String> = Vec::new();
+    for entry in std::fs::read_dir(source_dir)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if entry.file_type()?.is_file() && is_agent_file(name) {
+            available.push(name.trim_end_matches(".md").to_string());
+        }
+    }
+    available.sort_unstable();
+    Ok(available)
+}
+
+/// Force-recompose agent files into a PROJECT-LOCAL `.claude/agents/` dir,
+/// respecting a harness plan's deploy-roster selection (issue #2508).
+///
+/// Why: [`reset_agents`] alone is unsafe to point at a project/session-worktree
+/// target — a project's resolved [`crate::core::manifest::HarnessPlan`] may
+/// `exclude` an agent from that harness's roster (issue #2462's root cause:
+/// `[agents].exclude` is the SAME predicate `deploy_agents_filtered` honors for
+/// session/worktree launches). Resetting "all bundled agents" into a project dir
+/// without that filter would silently resurrect an agent the operator
+/// deliberately excluded, trading the #2508 staleness bug for a roster-exclusion
+/// regression (flagged in the #2508/#2462 cross-review). This function threads
+/// the SAME `agent_selected` predicate `prepare_session` uses, so a project-level
+/// reset can never deploy an agent that harness's own launch path would not.
+/// What: computes the candidate set exactly as [`reset_agents`] does (every
+/// available source agent, or the caller's `names` filter), then narrows it to
+/// stems `agent_selected` accepts — any requested name the plan rejects is
+/// recorded in [`ResetResult::deselected`] instead of being silently dropped —
+/// and delegates the actual compose/backup/adopt/write logic to [`reset_agents`]
+/// with that narrowed set (so the two entry points can never diverge in
+/// backup/adoption semantics).
+/// Test: `reset_project_agents_respects_plan_selection`,
+/// `reset_project_agents_reports_deselected_requested_name`,
+/// `reset_project_agents_defaults_to_all_selected`.
+pub fn reset_project_agents(
+    source_dir: &Path,
+    target_dir: &Path,
+    names: Option<&[String]>,
+    agent_selected: impl Fn(&str) -> bool,
+) -> Result<ResetResult, AgentBuildError> {
+    if !source_dir.is_dir() {
+        return Ok(ResetResult::default());
+    }
+    let available = available_agent_names(source_dir)?;
+    let candidates: Vec<String> = match names {
+        None => available.clone(),
+        Some(requested) => requested.to_vec(),
+    };
+
+    let mut deselected = Vec::new();
+    let mut effective = Vec::new();
+    for name in candidates {
+        // A name absent from `available` is left for `reset_agents` to report
+        // as `not_found` — only a plan REJECTION is `deselected` here.
+        if available.contains(&name) && !agent_selected(&name) {
+            deselected.push(name);
+        } else {
+            effective.push(name);
+        }
+    }
+    deselected.sort_unstable();
+
+    let mut result = reset_agents(source_dir, target_dir, Some(&effective))?;
+    result.deselected = deselected;
     Ok(result)
 }
 
@@ -401,5 +483,61 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result, ResetResult::default());
+    }
+
+    #[test]
+    fn reset_project_agents_respects_plan_selection() {
+        // Issue #2508 cross-warning: a project-level reset must never write an
+        // agent the harness plan excludes, even with no explicit `names` filter.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+
+        let result =
+            reset_project_agents(src.path(), tgt.path(), None, |name| name != "engineer").unwrap();
+
+        assert_eq!(result.recomposed, vec!["base-agent.md".to_string()]);
+        assert_eq!(result.deselected, vec!["engineer".to_string()]);
+        assert!(
+            !tgt.path().join("engineer.md").exists(),
+            "a plan-excluded agent must never be written to a project dir"
+        );
+    }
+
+    #[test]
+    fn reset_project_agents_reports_deselected_requested_name() {
+        // An explicitly-requested name the plan rejects is reported as
+        // `deselected`, not silently dropped or conflated with `not_found`.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+
+        let result = reset_project_agents(
+            src.path(),
+            tgt.path(),
+            Some(&["engineer".to_string()]),
+            |name| name != "engineer",
+        )
+        .unwrap();
+
+        assert!(result.recomposed.is_empty());
+        assert!(result.not_found.is_empty(), "engineer DOES exist in source");
+        assert_eq!(result.deselected, vec!["engineer".to_string()]);
+    }
+
+    #[test]
+    fn reset_project_agents_defaults_to_all_selected() {
+        // A plan that selects everything must behave exactly like a plain
+        // `reset_agents(..., None)` — zero regression for the common case.
+        let src = TempDir::new().unwrap();
+        let tgt = TempDir::new().unwrap();
+        write_sources(src.path());
+
+        let result = reset_project_agents(src.path(), tgt.path(), None, |_| true).unwrap();
+
+        assert_eq!(result.recomposed.len(), 2);
+        assert!(result.deselected.is_empty());
+        assert!(tgt.path().join("engineer.md").exists());
+        assert!(tgt.path().join("base-agent.md").exists());
     }
 }

--- a/crates/trusty-mpm/src/core/agent_reset_workspace.rs
+++ b/crates/trusty-mpm/src/core/agent_reset_workspace.rs
@@ -1,0 +1,324 @@
+//! Sweep active session/project workspaces into `tm install --reset-agents`
+//! (issue #2508).
+//!
+//! Why: [`super::agent_reset::reset_agents`] only ever targeted the USER-LEVEL
+//! `~/.claude/agents/` directory `tm install` writes to. PROJECT-LEVEL
+//! `.claude/agents/` directories — deployed by [`super::session_launch`] into
+//! every managed session's workspace/worktree — carry their OWN independently
+//! stale composition and never receive the fix `--reset-agents` applies to the
+//! user-level copy. #2508's observed symptom: a user-level reset verified
+//! clean while the active session worktree's `.claude/agents/` still had zero
+//! files containing the new BASE-AGENT sections, reproducing the #2501 parking
+//! failure the reset was meant to close. This module is the sweep that
+//! reconciles every INTACT (non-decommissioned) session's workspace alongside
+//! the user-level reset, using the session's OWN resolved harness plan so an
+//! agent one project's manifest excludes is never resurrected there (the
+//! #2462 cross-warning) even while a sibling project's copy IS refreshed.
+//! What: [`reset_active_workspace_agents`] loads the on-disk session store
+//! (the SAME `sessions.json` the daemon and CLI both read — no live daemon
+//! required), filters to sessions with an intact `workspace_path`, resolves
+//! each one's [`crate::core::manifest::HarnessPlan`] exactly as
+//! [`super::session_launch::prepare_session`] does, and calls
+//! [`super::agent_reset::reset_project_agents`] against that workspace's
+//! `.claude/agents/` with the plan's `agent_selected` predicate. Returns one
+//! [`WorkspaceResetOutcome`] per swept workspace so the CLI can render a
+//! per-session report.
+//! Test: `sweep_resets_intact_workspace`, `sweep_skips_decommissioned_session`,
+//! `sweep_skips_session_without_workspace`,
+//! `sweep_respects_per_workspace_manifest_exclude`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::agent_builder::AgentBuildError;
+use crate::core::agent_reset::{ResetResult, reset_project_agents};
+use crate::core::manifest::{HarnessPlan, ManifestSources, resolve_manifest};
+use crate::core::paths::FrameworkPaths;
+use crate::session_manager::{ManagedSessionState, SessionStore, StoreError};
+
+/// The outcome of resetting one session's project-local agent roster.
+///
+/// Why: the CLI reports per-session results (which session, which workspace,
+/// what changed) so an operator sweeping dozens of sessions can see exactly
+/// which ones were touched.
+/// What: the session's tmux name (human-identifiable), its workspace path, and
+/// the [`ResetResult`] `reset_project_agents` produced for it.
+/// Test: `sweep_resets_intact_workspace`.
+#[derive(Debug, Clone)]
+pub struct WorkspaceResetOutcome {
+    /// The session's tmux name (e.g. `tm-quiet-falcon`).
+    pub tmux_name: String,
+    /// The workspace/worktree directory the reset targeted.
+    pub workspace_path: PathBuf,
+    /// The reset result for this workspace's `.claude/agents/`.
+    pub result: ResetResult,
+}
+
+/// A failure raised while sweeping session workspaces.
+///
+/// Why: the sweep touches two independent I/O surfaces (the session store,
+/// and each workspace's agent reset); a typed error lets the CLI distinguish
+/// "could not even enumerate sessions" from "one workspace's reset failed".
+/// What: `Store` wraps a [`StoreError`] loading `sessions.json`; `Reset` wraps
+/// an [`AgentBuildError`] from one workspace's [`reset_project_agents`] call,
+/// tagged with the tmux name that failed so the operator knows which session
+/// to investigate.
+/// Test: surfaced indirectly; the happy path is covered by this module's
+/// other tests.
+#[derive(Debug, thiserror::Error)]
+pub enum WorkspaceSweepError {
+    /// Loading the session store failed.
+    #[error("failed to load session store: {0}")]
+    Store(#[from] StoreError),
+    /// Resetting one workspace's agents failed.
+    #[error("agent reset failed for session {tmux_name}: {source}")]
+    Reset {
+        /// The tmux name of the session whose reset failed.
+        tmux_name: String,
+        /// The underlying reset error.
+        #[source]
+        source: AgentBuildError,
+    },
+}
+
+/// Reset the project-local agent roster of every intact session workspace.
+///
+/// Why: this is the #2508 fix's sweep entry point — `tm install --reset-agents
+/// --reset-agents-workspaces` calls it AFTER the normal user-level reset so a
+/// single invocation reconciles both destinations with the same
+/// adoption/backup semantics, each gated by its own project's manifest.
+/// What: loads the session store at `<fw_root>/session-manager/sessions.json`,
+/// keeps sessions whose `state` is not [`ManagedSessionState::Decommissioned`]
+/// and whose `workspace_path` still exists on disk (a decommissioned or
+/// never-provisioned session has no `.claude/agents/` to reconcile), and for
+/// each one: resolves the harness manifest via [`ManifestSources::resolve`]
+/// (project override > user config > catalog > default — identical precedence
+/// to a real launch), builds the [`HarnessPlan`] via
+/// [`FrameworkPaths::for_managed_project`] (agent SOURCE stays at `fw_root`;
+/// only the deploy TARGET moves to the workspace's `.claude/agents/`), and
+/// calls [`reset_project_agents`] with `names` and the plan's `agent_selected`
+/// predicate. Returns one [`WorkspaceResetOutcome`] per swept workspace, in
+/// session-store iteration order.
+/// Test: `sweep_resets_intact_workspace`, `sweep_skips_decommissioned_session`,
+/// `sweep_skips_session_without_workspace`,
+/// `sweep_respects_per_workspace_manifest_exclude`.
+pub async fn reset_active_workspace_agents(
+    fw_root: &Path,
+    names: Option<&[String]>,
+) -> Result<Vec<WorkspaceResetOutcome>, WorkspaceSweepError> {
+    let data_dir = fw_root.join("session-manager");
+    let mut store = SessionStore::load(&data_dir).await?;
+    let sessions = store.all().await?;
+
+    let catalog_root = crate::content::catalog_root_for(fw_root);
+    let mut outcomes = Vec::new();
+
+    for session in sessions {
+        if session.state == ManagedSessionState::Decommissioned {
+            continue;
+        }
+        let Some(workspace_path) = &session.workspace_path else {
+            continue;
+        };
+        if !workspace_path.is_dir() {
+            continue;
+        }
+
+        let sources = ManifestSources::resolve(workspace_path, fw_root, &catalog_root);
+        let manifest = resolve_manifest(&sources);
+        let fw = FrameworkPaths::for_managed_project(fw_root, workspace_path);
+        let plan = HarnessPlan::from_manifest(&manifest, &fw, &catalog_root);
+
+        let result =
+            reset_project_agents(&plan.agent_source, &fw.claude_agents_dir(), names, |n| {
+                plan.agent_selected(n)
+            })
+            .map_err(|source| WorkspaceSweepError::Reset {
+                tmux_name: session.tmux_name.clone(),
+                source,
+            })?;
+
+        outcomes.push(WorkspaceResetOutcome {
+            tmux_name: session.tmux_name,
+            workspace_path: workspace_path.clone(),
+            result,
+        });
+    }
+
+    Ok(outcomes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_manager::record::{ManagedSessionId, SessionRecord};
+    use chrono::Utc;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Write a minimal source agent pair (mirrors `agent_reset::tests`).
+    fn write_sources(dir: &Path) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(
+            dir.join("base-agent.md"),
+            "---\nname: base-agent\nrole: base\n---\n\n# Base\n\nBase content.\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("engineer.md"),
+            "---\nname: engineer\nrole: engineer\nextends: base-agent\nmodel: sonnet\n---\n\n# Engineer\n\nEngineer content.\n",
+        )
+        .unwrap();
+    }
+
+    /// Build a minimal `SessionRecord` with no workspace (mirrors
+    /// `session_manager::store::tests::make_record`).
+    fn bare_session(tmux_name: &str) -> SessionRecord {
+        SessionRecord {
+            id: ManagedSessionId::new(),
+            tmux_name: tmux_name.to_string(),
+            cwd: PathBuf::from("/tmp"),
+            task: "test task".into(),
+            state: ManagedSessionState::Active,
+            created_at: Utc::now(),
+            last_activity_at: None,
+            workspace_path: None,
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: false,
+            workspace_owned: false,
+            source_id: None,
+            claude_session_id: None,
+            scrollback_path: None,
+            last_cwd: None,
+            deliverable_id: None,
+            pane_id: None,
+        }
+    }
+
+    /// Build a minimal intact `SessionRecord` pointing at `workspace`.
+    fn intact_session(tmux_name: &str, workspace: &Path) -> SessionRecord {
+        SessionRecord {
+            workspace_path: Some(workspace.to_path_buf()),
+            state: ManagedSessionState::Active,
+            ..bare_session(tmux_name)
+        }
+    }
+
+    /// Build a `.trusty-mpm`-named framework root under a fresh temp dir.
+    ///
+    /// Why: [`FrameworkPaths::from_root`] special-cases a root literally named
+    /// `.trusty-mpm` (round-tripping to the SAME path via its parent); a bare
+    /// tempdir name does not round-trip, silently nesting an extra
+    /// `.trusty-mpm` segment and breaking the `write_sources`/`agent_source_dir`
+    /// path agreement these tests depend on. Mirrors production, where
+    /// `fw_root` is always `~/.trusty-mpm`.
+    fn fw_root_under(base: &TempDir) -> PathBuf {
+        let root = base.path().join(".trusty-mpm");
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    /// Seed `<fw_root>/session-manager/sessions.json` with `sessions` directly
+    /// (bypassing the async manager) so tests stay hermetic and fast.
+    async fn seed_sessions(fw_root: &Path, sessions: Vec<SessionRecord>) {
+        let data_dir = fw_root.join("session-manager");
+        fs::create_dir_all(&data_dir).unwrap();
+        let mut store = SessionStore::load(&data_dir).await.unwrap();
+        for session in sessions {
+            store.upsert(session).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn sweep_resets_intact_workspace() {
+        let fw_base = TempDir::new().unwrap();
+        let fw_root = fw_root_under(&fw_base);
+        write_sources(&fw_root.join("framework").join("agents"));
+        let workspace = TempDir::new().unwrap();
+
+        seed_sessions(
+            &fw_root,
+            vec![intact_session("tm-sweep-test", workspace.path())],
+        )
+        .await;
+
+        let outcomes = reset_active_workspace_agents(&fw_root, None).await.unwrap();
+
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].tmux_name, "tm-sweep-test");
+        assert_eq!(outcomes[0].result.recomposed.len(), 2);
+        assert!(workspace.path().join(".claude/agents/engineer.md").exists());
+    }
+
+    #[tokio::test]
+    async fn sweep_skips_decommissioned_session() {
+        let fw_base = TempDir::new().unwrap();
+        let fw_root = fw_root_under(&fw_base);
+        write_sources(&fw_root.join("framework").join("agents"));
+        let workspace = TempDir::new().unwrap();
+
+        let mut session = intact_session("tm-gone", workspace.path());
+        session.state = ManagedSessionState::Decommissioned;
+        seed_sessions(&fw_root, vec![session]).await;
+
+        let outcomes = reset_active_workspace_agents(&fw_root, None).await.unwrap();
+        assert!(
+            outcomes.is_empty(),
+            "a decommissioned session has no workspace to reconcile"
+        );
+    }
+
+    #[tokio::test]
+    async fn sweep_skips_session_without_workspace() {
+        let fw_base = TempDir::new().unwrap();
+        let fw_root = fw_root_under(&fw_base);
+        write_sources(&fw_root.join("framework").join("agents"));
+
+        let session = bare_session("tm-no-workspace");
+        seed_sessions(&fw_root, vec![session]).await;
+
+        let outcomes = reset_active_workspace_agents(&fw_root, None).await.unwrap();
+        assert!(outcomes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sweep_respects_per_workspace_manifest_exclude() {
+        // Issue #2462/#2508: a workspace whose PROJECT manifest excludes
+        // `engineer` must come back from the sweep WITHOUT engineer.md, and
+        // the exclusion must be visible in `deselected`.
+        let fw_base = TempDir::new().unwrap();
+        let fw_root = fw_root_under(&fw_base);
+        write_sources(&fw_root.join("framework").join("agents"));
+        let workspace = TempDir::new().unwrap();
+        let project_manifest_dir = workspace.path().join(".trusty-mpm");
+        fs::create_dir_all(&project_manifest_dir).unwrap();
+        fs::write(
+            project_manifest_dir.join("manifest.toml"),
+            "[agents]\nexclude = [\"engineer\"]\n",
+        )
+        .unwrap();
+
+        seed_sessions(
+            &fw_root,
+            vec![intact_session("tm-excluded", workspace.path())],
+        )
+        .await;
+
+        let outcomes = reset_active_workspace_agents(&fw_root, None).await.unwrap();
+
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(
+            outcomes[0].result.recomposed,
+            vec!["base-agent.md".to_string()]
+        );
+        assert_eq!(outcomes[0].result.deselected, vec!["engineer".to_string()]);
+        assert!(
+            !workspace.path().join(".claude/agents/engineer.md").exists(),
+            "a project-excluded agent must never land in that project's workspace"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/agent_reset_workspace.rs
+++ b/crates/trusty-mpm/src/core/agent_reset_workspace.rs
@@ -14,18 +14,33 @@
 //! the user-level reset, using the session's OWN resolved harness plan so an
 //! agent one project's manifest excludes is never resurrected there (the
 //! #2462 cross-warning) even while a sibling project's copy IS refreshed.
+//!
+//! CRITICAL SAFETY GATE (#1511 incident class): NOT every session's
+//! `workspace_path` is a directory trusty-mpm provisioned. A local-path/
+//! adopted session's `workspace_path` points at the OPERATOR'S REAL, live
+//! checkout — the very same directory class `session_manager::decommission`
+//! refuses to `remove_dir_all` and `session_manager::search_gc` refuses to
+//! drop the search index for. This module reuses that IDENTICAL ownership
+//! predicate (`workspace_owned || is_session_worktree(path)`) before ever
+//! writing a byte into a workspace's `.claude/agents/` — a sweep must never
+//! force-recompose the bundled roster into a real repository the operator
+//! did not hand to trusty-mpm to manage.
 //! What: [`reset_active_workspace_agents`] loads the on-disk session store
 //! (the SAME `sessions.json` the daemon and CLI both read — no live daemon
-//! required), filters to sessions with an intact `workspace_path`, resolves
-//! each one's [`crate::core::manifest::HarnessPlan`] exactly as
+//! required), filters to sessions with an intact `workspace_path`, SKIPS any
+//! session that fails the ownership gate above (recording a
+//! [`WorkspaceResetOutcome`] with `skipped_reason` set so the operator sees a
+//! deliberate exclusion rather than silent absence), resolves each remaining
+//! session's [`crate::core::manifest::HarnessPlan`] exactly as
 //! [`super::session_launch::prepare_session`] does, and calls
 //! [`super::agent_reset::reset_project_agents`] against that workspace's
 //! `.claude/agents/` with the plan's `agent_selected` predicate. Returns one
-//! [`WorkspaceResetOutcome`] per swept workspace so the CLI can render a
-//! per-session report.
+//! [`WorkspaceResetOutcome`] per considered workspace (reset OR skipped) so
+//! the CLI can render a per-session report.
 //! Test: `sweep_resets_intact_workspace`, `sweep_skips_decommissioned_session`,
 //! `sweep_skips_session_without_workspace`,
-//! `sweep_respects_per_workspace_manifest_exclude`.
+//! `sweep_respects_per_workspace_manifest_exclude`,
+//! `sweep_skips_unowned_non_worktree_session`.
 
 use std::path::{Path, PathBuf};
 
@@ -33,24 +48,34 @@ use crate::core::agent_builder::AgentBuildError;
 use crate::core::agent_reset::{ResetResult, reset_project_agents};
 use crate::core::manifest::{HarnessPlan, ManifestSources, resolve_manifest};
 use crate::core::paths::FrameworkPaths;
+use crate::session_manager::decommission::is_session_worktree;
 use crate::session_manager::{ManagedSessionState, SessionStore, StoreError};
 
-/// The outcome of resetting one session's project-local agent roster.
+/// The outcome of considering one session's project-local agent roster.
 ///
 /// Why: the CLI reports per-session results (which session, which workspace,
-/// what changed) so an operator sweeping dozens of sessions can see exactly
-/// which ones were touched.
-/// What: the session's tmux name (human-identifiable), its workspace path, and
-/// the [`ResetResult`] `reset_project_agents` produced for it.
-/// Test: `sweep_resets_intact_workspace`.
+/// what changed OR why it was skipped) so an operator sweeping dozens of
+/// sessions can see exactly which ones were touched and which were
+/// deliberately excluded by the #1511 ownership gate.
+/// What: the session's tmux name (human-identifiable), its workspace path,
+/// the [`ResetResult`] `reset_project_agents` produced for it (empty/default
+/// when skipped), and `skipped_reason` — `None` for a normal reset, `Some`
+/// human-readable explanation when the ownership gate rejected this session.
+/// Test: `sweep_resets_intact_workspace`,
+/// `sweep_skips_unowned_non_worktree_session`.
 #[derive(Debug, Clone)]
 pub struct WorkspaceResetOutcome {
     /// The session's tmux name (e.g. `tm-quiet-falcon`).
     pub tmux_name: String,
-    /// The workspace/worktree directory the reset targeted.
+    /// The workspace/worktree directory the reset targeted (or would have).
     pub workspace_path: PathBuf,
-    /// The reset result for this workspace's `.claude/agents/`.
+    /// The reset result for this workspace's `.claude/agents/`. Default
+    /// (all-empty) when `skipped_reason` is `Some`.
     pub result: ResetResult,
+    /// `Some(reason)` when the #1511 ownership gate excluded this session
+    /// from the reset — the workspace was NOT touched. `None` for a normal
+    /// reset attempt.
+    pub skipped_reason: Option<String>,
 }
 
 /// A failure raised while sweeping session workspaces.
@@ -100,7 +125,8 @@ pub enum WorkspaceSweepError {
 /// session-store iteration order.
 /// Test: `sweep_resets_intact_workspace`, `sweep_skips_decommissioned_session`,
 /// `sweep_skips_session_without_workspace`,
-/// `sweep_respects_per_workspace_manifest_exclude`.
+/// `sweep_respects_per_workspace_manifest_exclude`,
+/// `sweep_skips_unowned_non_worktree_session`.
 pub async fn reset_active_workspace_agents(
     fw_root: &Path,
     names: Option<&[String]>,
@@ -123,6 +149,28 @@ pub async fn reset_active_workspace_agents(
             continue;
         }
 
+        // CRITICAL (#1511 incident class): only ever write into a workspace
+        // trusty-mpm itself provisioned — a clone it owns, or an in-project
+        // `.worktrees/<id>` worktree it created. A local-path/adopted
+        // session's `workspace_path` is the operator's REAL, long-lived
+        // checkout; force-recomposing the bundled roster into it would
+        // silently overwrite real project files. Mirrors the identical
+        // guard `session_manager::decommission`'s filesystem-removal path
+        // and `session_manager::search_gc`'s index-lifecycle path both use.
+        if !(session.workspace_owned || is_session_worktree(workspace_path)) {
+            outcomes.push(WorkspaceResetOutcome {
+                tmux_name: session.tmux_name,
+                workspace_path: workspace_path.clone(),
+                result: ResetResult::default(),
+                skipped_reason: Some(
+                    "skipped — not tm-owned (adopted/local-path session; refusing to \
+                     force-recompose files into a real checkout)"
+                        .to_string(),
+                ),
+            });
+            continue;
+        }
+
         let sources = ManifestSources::resolve(workspace_path, fw_root, &catalog_root);
         let manifest = resolve_manifest(&sources);
         let fw = FrameworkPaths::for_managed_project(fw_root, workspace_path);
@@ -141,6 +189,7 @@ pub async fn reset_active_workspace_agents(
             tmux_name: session.tmux_name,
             workspace_path: workspace_path.clone(),
             result,
+            skipped_reason: None,
         });
     }
 
@@ -199,11 +248,16 @@ mod tests {
         }
     }
 
-    /// Build a minimal intact `SessionRecord` pointing at `workspace`.
+    /// Build a minimal intact, tm-OWNED `SessionRecord` pointing at
+    /// `workspace` (simulates an SM-provisioned clone — passes the #1511
+    /// ownership gate). Use [`bare_session`] directly (or set
+    /// `workspace_owned: false` on an unqualified path) to build a
+    /// gate-rejected fixture instead.
     fn intact_session(tmux_name: &str, workspace: &Path) -> SessionRecord {
         SessionRecord {
             workspace_path: Some(workspace.to_path_buf()),
             state: ManagedSessionState::Active,
+            workspace_owned: true,
             ..bare_session(tmux_name)
         }
     }
@@ -283,6 +337,71 @@ mod tests {
 
         let outcomes = reset_active_workspace_agents(&fw_root, None).await.unwrap();
         assert!(outcomes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sweep_skips_unowned_non_worktree_session() {
+        // CRITICAL (#1511 incident class): an adopted-shaped session —
+        // `workspace_owned: false`, and a workspace path whose immediate
+        // parent is NOT `.worktrees` (so `is_session_worktree` also says
+        // no) — is the operator's REAL, long-lived checkout. The sweep must
+        // neither touch its `.claude/agents/` contents NOR silently drop it
+        // from the report: it must appear with `skipped_reason` set.
+        let fw_base = TempDir::new().unwrap();
+        let fw_root = fw_root_under(&fw_base);
+        write_sources(&fw_root.join("framework").join("agents"));
+
+        // A "real" checkout: NOT nested under `.worktrees`.
+        let real_repo = TempDir::new().unwrap();
+        assert_ne!(
+            real_repo
+                .path()
+                .parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str()),
+            Some(".worktrees"),
+            "fixture must not accidentally look like a session worktree"
+        );
+        let agents_dir = real_repo.path().join(".claude").join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        let sentinel_path = agents_dir.join("my-custom-agent.md");
+        let original_bytes = b"---\nname: my-custom-agent\n---\n\nHand-authored, not bundled.\n";
+        fs::write(&sentinel_path, original_bytes).unwrap();
+
+        let mut session = intact_session("tm-adopted-real-repo", real_repo.path());
+        session.workspace_owned = false;
+        seed_sessions(&fw_root, vec![session]).await;
+
+        let outcomes = reset_active_workspace_agents(&fw_root, None).await.unwrap();
+
+        assert_eq!(
+            outcomes.len(),
+            1,
+            "the skipped session must still be reported, not silently absent"
+        );
+        assert_eq!(outcomes[0].tmux_name, "tm-adopted-real-repo");
+        let reason = outcomes[0]
+            .skipped_reason
+            .as_deref()
+            .expect("unowned non-worktree session must carry a skip reason");
+        assert!(reason.contains("not tm-owned"), "reason = {reason:?}");
+        assert!(
+            outcomes[0].result.recomposed.is_empty(),
+            "a skipped session must not report any recomposed files"
+        );
+
+        // The decisive assertion: the real file's bytes are byte-for-byte
+        // untouched — no `engineer.md`/`base-agent.md` were ever written.
+        let after_bytes = fs::read(&sentinel_path).unwrap();
+        assert_eq!(
+            after_bytes, original_bytes,
+            "a real, unowned checkout must never be written to"
+        );
+        assert!(
+            !agents_dir.join("engineer.md").exists(),
+            "the bundled roster must never be force-recomposed into a real checkout"
+        );
+        assert!(!agents_dir.join("base-agent.md").exists());
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/core/manifest/apply.rs
+++ b/crates/trusty-mpm/src/core/manifest/apply.rs
@@ -36,6 +36,12 @@ pub struct HarnessPlan {
     pub agent_include: Vec<String>,
     /// Agent exclude patterns.
     pub agent_exclude: Vec<String>,
+    /// Agent name/glob patterns exempt from catalog-staleness reporting only
+    /// (issue #2462). Does NOT affect [`Self::agent_selected`] — an agent
+    /// listed here still deploys normally; this only silences the drift
+    /// warning for agents the operator has intentionally customized. See
+    /// [`super::schema::AgentSet::ignore_staleness`] for the full rationale.
+    pub agent_ignore_staleness: Vec<String>,
     /// Directory the skill *source* files are read from.
     pub skill_source: PathBuf,
     /// Skill include patterns (empty = all).
@@ -77,16 +83,22 @@ impl HarnessPlan {
         let catalog_agents = catalog_root.join("repo").join(".claude").join("agents");
         let catalog_skills = catalog_root.join("repo").join(".claude").join("skills");
 
-        let (agent_source, agent_include, agent_exclude) = match &manifest.agents {
-            Some(set) => {
-                let source = match set.source {
-                    ContentSource::Bundled => fw.agent_source_dir(),
-                    ContentSource::Catalog => catalog_agents,
-                };
-                (source, set.include.clone(), set.exclude.clone())
-            }
-            None => (fw.agent_source_dir(), Vec::new(), Vec::new()),
-        };
+        let (agent_source, agent_include, agent_exclude, agent_ignore_staleness) =
+            match &manifest.agents {
+                Some(set) => {
+                    let source = match set.source {
+                        ContentSource::Bundled => fw.agent_source_dir(),
+                        ContentSource::Catalog => catalog_agents,
+                    };
+                    (
+                        source,
+                        set.include.clone(),
+                        set.exclude.clone(),
+                        set.ignore_staleness.clone(),
+                    )
+                }
+                None => (fw.agent_source_dir(), Vec::new(), Vec::new(), Vec::new()),
+            };
 
         let (skill_source, skill_include, skill_exclude) = match &manifest.skills {
             Some(set) => {
@@ -114,6 +126,7 @@ impl HarnessPlan {
             agent_source,
             agent_include,
             agent_exclude,
+            agent_ignore_staleness,
             skill_source,
             skill_include,
             skill_exclude,
@@ -132,6 +145,19 @@ impl HarnessPlan {
     /// Test: `plan_selection_filters`.
     pub fn agent_selected(&self, stem: &str) -> bool {
         selection_matches(stem, &self.agent_include, &self.agent_exclude)
+    }
+
+    /// Whether an agent stem is exempt from catalog-staleness reporting.
+    ///
+    /// Why (issue #2462): `detect_staleness` must be able to silence the drift
+    /// warning for an agent the operator deliberately customized WITHOUT that
+    /// exemption also removing the agent from [`Self::agent_selected`]'s deploy
+    /// roster — the two concerns are independent (see
+    /// [`super::schema::AgentSet::ignore_staleness`]).
+    /// What: `true` iff `stem` matches any `agent_ignore_staleness` pattern.
+    /// Test: `plan_ignore_staleness_does_not_affect_agent_selected`.
+    pub fn agent_staleness_ignored(&self, stem: &str) -> bool {
+        super::schema::matches_any(stem, &self.agent_ignore_staleness)
     }
 
     /// Whether a skill stem is selected by this plan.
@@ -178,6 +204,7 @@ mod tests {
                 include: vec![],
                 exclude: vec![],
                 source: ContentSource::Catalog,
+                ..AgentSet::default()
             }),
             ..default_manifest()
         };
@@ -203,6 +230,7 @@ mod tests {
                 include: vec!["*-engineer".into()],
                 exclude: vec!["php-engineer".into()],
                 source: ContentSource::Bundled,
+                ..AgentSet::default()
             }),
             skills: Some(SkillSet {
                 include: vec!["example-skill".into()],
@@ -217,6 +245,35 @@ mod tests {
         assert!(!plan.agent_selected("qa"), "not in include");
         assert!(plan.skill_selected("example-skill"));
         assert!(!plan.skill_selected("tm-doctor"));
+    }
+
+    #[test]
+    fn plan_ignore_staleness_does_not_affect_agent_selected() {
+        // Issue #2462: `ignore_staleness` must silence the staleness-only
+        // predicate while leaving `agent_selected` (the deploy roster) fully
+        // unaffected — the exact confusion that let `exclude = ["engineer"]`
+        // (meant only to silence /health) silently drop `engineer.md` from
+        // every session-local `.claude/agents/`.
+        let fw = FrameworkPaths::under("/base");
+        let manifest = HarnessManifest {
+            agents: Some(AgentSet {
+                include: vec![],
+                exclude: vec![],
+                ignore_staleness: vec!["engineer".into()],
+                source: ContentSource::Bundled,
+            }),
+            ..default_manifest()
+        };
+        let plan = HarnessPlan::from_manifest(&manifest, &fw, std::path::Path::new("/c"));
+        assert!(
+            plan.agent_selected("engineer"),
+            "ignore_staleness must not remove an agent from the deploy roster"
+        );
+        assert!(plan.agent_staleness_ignored("engineer"));
+        assert!(
+            !plan.agent_staleness_ignored("qa"),
+            "unrelated agent unaffected"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/manifest/default.rs
+++ b/crates/trusty-mpm/src/core/manifest/default.rs
@@ -34,6 +34,7 @@ pub fn default_manifest() -> HarnessManifest {
         agents: Some(AgentSet {
             include: Vec::new(), // empty = all available agents
             exclude: Vec::new(),
+            ignore_staleness: Vec::new(),
             source: ContentSource::Bundled,
         }),
         skills: Some(all_skills()),

--- a/crates/trusty-mpm/src/core/manifest/mod.rs
+++ b/crates/trusty-mpm/src/core/manifest/mod.rs
@@ -26,5 +26,5 @@ pub use default::default_manifest;
 pub use resolve::{MANIFEST_FILE, ManifestSources, resolve_manifest};
 pub use schema::{
     AgentSet, ContentSource, HarnessManifest, InstructionLayers, MANIFEST_VERSION, McpServers,
-    ModelTiers, SkillSet, StyleSelection, selection_matches,
+    ModelTiers, SkillSet, StyleSelection, matches_any, selection_matches,
 };

--- a/crates/trusty-mpm/src/core/manifest/project_lang.rs
+++ b/crates/trusty-mpm/src/core/manifest/project_lang.rs
@@ -177,6 +177,7 @@ pub fn language_agent_scope(project_dir: &Path) -> Option<AgentSet> {
     Some(AgentSet {
         include: Vec::new(),
         exclude,
+        ignore_staleness: Vec::new(),
         source: ContentSource::Bundled,
     })
 }

--- a/crates/trusty-mpm/src/core/manifest/schema.rs
+++ b/crates/trusty-mpm/src/core/manifest/schema.rs
@@ -77,17 +77,40 @@ pub struct HarnessManifest {
 /// without enumerating every agent.
 /// What: `include` is a list of agent names or glob patterns (`*` wildcard); an
 /// empty or absent `include` means "all available agents". `exclude` removes
-/// names/patterns from the included set and always wins over `include`. `source`
-/// selects where the agent *source files* come from (`bundled` or `catalog`).
-/// Test: `selection_matches`, `agent_set_source_default_is_bundled`.
+/// names/patterns from the included set and always wins over `include` — this is
+/// the DEPLOY-ROSTER filter: an excluded agent is never written to ANY deploy
+/// destination `agent_selected` gates (session/worktree launches, `tm catalog
+/// apply`, pruning). `ignore_staleness` (issue #2462) is a SEPARATE, narrower
+/// concern: it only suppresses the `/health`/`tm catalog apply` drift warning for
+/// an agent the operator has deliberately customized, WITHOUT removing it from
+/// any deploy roster. Do not put a name in `exclude` merely to silence a
+/// staleness warning — that also deletes it from every filtered deploy
+/// destination (the exact drift #2462 diagnosed: `exclude = ["engineer"]`,
+/// written only to quiet `/health`, silently dropped `engineer.md` from every
+/// session-local `.claude/agents/`). `source` selects where the agent *source
+/// files* come from (`bundled` or `catalog`).
+/// Test: `selection_matches`, `agent_set_source_default_is_bundled`,
+/// `plan_ignore_staleness_does_not_affect_agent_selected`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AgentSet {
     /// Agent names or glob patterns to deploy. Empty → all available.
     #[serde(default)]
     pub include: Vec<String>,
-    /// Agent names or glob patterns to drop. Wins over `include`.
+    /// Agent names or glob patterns to drop from every deploy destination.
+    /// Wins over `include`. Does NOT affect staleness reporting — use
+    /// `ignore_staleness` to quiet drift warnings for a customized agent that
+    /// should still deploy.
     #[serde(default)]
     pub exclude: Vec<String>,
+    /// Agent names or glob patterns to exempt from catalog-staleness
+    /// reporting ONLY (issue #2462). An agent listed here still deploys
+    /// normally (subject to `include`/`exclude` and the conservative
+    /// user-modified-file skip) — this list purely silences the `/health` /
+    /// `tm catalog apply` "this agent drifted from the catalog" warning, for
+    /// agents the operator has intentionally customized. Distinct from
+    /// `exclude`, which removes an agent from deploy entirely.
+    #[serde(default)]
+    pub ignore_staleness: Vec<String>,
     /// Where the agent source files are read from.
     #[serde(default)]
     pub source: ContentSource,
@@ -345,9 +368,22 @@ fn merge_optional<T>(lower: Option<T>, higher: Option<T>, f: impl FnOnce(T, T) -
 /// exact name or a trailing/leading `*` glob via [`glob_matches`].
 /// Test: `selection_matches`.
 pub fn selection_matches(name: &str, include: &[String], exclude: &[String]) -> bool {
-    let included = include.is_empty() || include.iter().any(|p| glob_matches(p, name));
-    let excluded = exclude.iter().any(|p| glob_matches(p, name));
+    let included = include.is_empty() || matches_any(name, include);
+    let excluded = matches_any(name, exclude);
     included && !excluded
+}
+
+/// Whether `name` matches any pattern in `patterns` (exact name or `*`-glob).
+///
+/// Why: [`AgentSet::ignore_staleness`] needs a plain membership test against the
+/// same glob vocabulary [`selection_matches`] uses for include/exclude, without
+/// the include/exclude pairing — factoring it out keeps both callers on
+/// identical match semantics.
+/// What: `true` iff any entry in `patterns` matches `name` via [`glob_matches`].
+/// Test: `selection_matches` (via `selection_matches`'s reuse of this helper),
+/// `plan_ignore_staleness_does_not_affect_agent_selected`.
+pub fn matches_any(name: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|p| glob_matches(p, name))
 }
 
 /// Match `name` against a simple glob `pattern` supporting any number of `*`.
@@ -425,6 +461,7 @@ mod tests {
             agents: Some(AgentSet {
                 include: vec!["rust-engineer".into(), "qa".into()],
                 exclude: vec!["*-ops".into()],
+                ignore_staleness: vec!["engineer".into()],
                 source: ContentSource::Catalog,
             }),
             skills: Some(SkillSet {

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -14,6 +14,7 @@ pub mod agent_builder;
 pub mod agent_deployer;
 pub mod agent_manifest;
 pub mod agent_reset;
+pub mod agent_reset_workspace;
 pub mod artifact;
 pub mod auto_resume;
 pub mod budget;

--- a/crates/trusty-mpm/src/core/update_check/mod.rs
+++ b/crates/trusty-mpm/src/core/update_check/mod.rs
@@ -214,16 +214,18 @@ fn classify_drift(
 /// harness's set). An agent that fails to compose is skipped rather than reported
 /// (it cannot be deployed either, so it is not actionable drift).
 /// Test: `detect_flags_changed_agent`, `detect_not_stale_when_identical`,
-/// `detect_respects_selection`, `detect_reconciles_deployed_but_unmanifested`.
+/// `detect_respects_selection`, `detect_reconciles_deployed_but_unmanifested`,
+/// `detect_respects_ignore_staleness`.
 fn agent_changes(
     catalog_agents: &Path,
     deployed: &AgentManifest,
     deployed_dir: &Path,
     select: &impl Fn(&str) -> bool,
+    ignore_staleness: &impl Fn(&str) -> bool,
     out: &mut Vec<CatalogChange>,
 ) {
     for stem in md_stems(catalog_agents) {
-        if !select(&stem) {
+        if !select(&stem) || ignore_staleness(&stem) {
             continue;
         }
         let Ok(composed) = compose_agent(&stem, catalog_agents) else {
@@ -308,10 +310,14 @@ fn skill_changes(
 /// deployed-but-unmanifested file is reconciled rather than reported as a false
 /// `new` (#1940). `stale` is true iff any selected artifact would be
 /// deployed/refreshed by `apply`. The change list is capped at [`MAX_CHANGES`].
+/// `agent_ignore_staleness` (issue #2462) additionally exempts a selected agent
+/// from drift reporting WITHOUT removing it from `agent_select`'s deploy roster
+/// — see [`crate::core::manifest::AgentSet::ignore_staleness`] for why this is a
+/// separate predicate from selection.
 /// Test: `detect_unknown_when_never_synced`, `detect_flags_changed_agent`,
 /// `detect_flags_new_skill`, `detect_not_stale_when_identical`,
 /// `detect_respects_selection`, `detect_caps_change_list`,
-/// `detect_reconciles_deployed_but_unmanifested`.
+/// `detect_reconciles_deployed_but_unmanifested`, `detect_respects_ignore_staleness`.
 #[allow(clippy::too_many_arguments)]
 pub fn detect_staleness(
     catalog_agents: &Path,
@@ -322,6 +328,7 @@ pub fn detect_staleness(
     deployed_skills_dir: &Path,
     agent_select: impl Fn(&str) -> bool,
     skill_select: impl Fn(&str) -> bool,
+    agent_ignore_staleness: impl Fn(&str) -> bool,
 ) -> StalenessReport {
     // Never-synced: neither source tree is present. Report `unknown` rather than
     // fabricating staleness — there is nothing authoritative to compare against.
@@ -339,6 +346,7 @@ pub fn detect_staleness(
         deployed_agents,
         deployed_agents_dir,
         &agent_select,
+        &agent_ignore_staleness,
         &mut changes,
     );
     skill_changes(
@@ -402,6 +410,7 @@ pub fn detect_for_framework(
         &skills_dir,
         |name| plan.agent_selected(name),
         |name| plan.skill_selected(name),
+        |name| plan.agent_staleness_ignored(name),
     )
 }
 

--- a/crates/trusty-mpm/src/core/update_check/tests.rs
+++ b/crates/trusty-mpm/src/core/update_check/tests.rs
@@ -84,6 +84,7 @@ fn detect_unknown_when_never_synced() {
         &root.path().join("dep-skills"),
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(report.unknown, "never-synced must be unknown");
     assert!(!report.stale, "never-synced must not be stale");
@@ -112,6 +113,7 @@ fn detect_not_stale_when_identical() {
         &root.path().join("dep-skills"),
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(!report.unknown, "synced catalog is not unknown");
     assert!(!report.stale, "identical content is not stale: {report:?}");
@@ -142,6 +144,7 @@ fn detect_flags_changed_agent() {
         &root.path().join("dep-skills"),
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(report.stale, "changed agent must be stale");
     assert!(!report.unknown);
@@ -167,6 +170,7 @@ fn detect_flags_new_agent() {
         &root.path().join("dep-skills"),
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(report.stale);
     assert_eq!(report.changes[0].kind, ChangeKind::New);
@@ -189,6 +193,7 @@ fn detect_flags_new_skill() {
         &root.path().join("dep-skills"),
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(report.stale);
     assert_eq!(report.changes.len(), 1);
@@ -215,6 +220,7 @@ fn detect_flags_changed_skill() {
         &root.path().join("dep-skills"),
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(report.stale);
     assert_eq!(report.changes[0].kind, ChangeKind::Changed);
@@ -242,10 +248,43 @@ fn detect_respects_selection() {
         &root.path().join("dep-skills"),
         |name| name == "rust-engineer", // exclude php-engineer
         |_| true,
+        |_| false,
     );
     assert!(
         !report.stale,
         "a deselected new agent must not make the harness stale: {report:?}"
+    );
+}
+
+#[test]
+fn detect_respects_ignore_staleness() {
+    // Issue #2462: an agent matched by `ignore_staleness` must not count toward
+    // staleness, even though it is fully SELECTED (unlike `detect_respects_
+    // selection`, which tests the deploy-roster predicate). This is the
+    // narrower, deploy-preserving exemption `AgentSet::ignore_staleness` adds.
+    let root = TempDir::new().unwrap();
+    let agents = root.path().join("agents");
+    write_agent(&agents, "rust-engineer", "BODY");
+    write_agent(&agents, "engineer", "BODY");
+
+    // Deploy matches rust-engineer; engineer is new (never deployed) but the
+    // operator has flagged it as a known, intentional customization.
+    let dep_agents = deployed_agent_matching(&agents, "rust-engineer");
+
+    let report = detect_staleness(
+        &agents,
+        &root.path().join("skills"),
+        &dep_agents,
+        &SkillManifest::default(),
+        &root.path().join("dep-agents"),
+        &root.path().join("dep-skills"),
+        |_| true, // both agents SELECTED (deploy roster unaffected)
+        |_| true,
+        |name| name == "engineer", // but staleness-exempt
+    );
+    assert!(
+        !report.stale,
+        "an ignore_staleness agent must not make the harness stale: {report:?}"
     );
 }
 
@@ -268,6 +307,7 @@ fn detect_caps_change_list() {
         &root.path().join("dep-skills"),
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(report.stale);
     assert_eq!(
@@ -333,6 +373,7 @@ fn detect_unknown_when_only_one_tree_missing_is_not_unknown() {
         &root.path().join("dep-skills"),
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(
         !report.unknown,
@@ -384,6 +425,7 @@ fn detect_reconciles_deployed_but_unmanifested() {
         &dep_skills_dir,
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(!report.unknown);
     assert!(
@@ -418,6 +460,7 @@ fn detect_user_owned_on_disk_not_reported() {
         &root.path().join("dep-skills"),
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(
         !report.stale,
@@ -450,6 +493,7 @@ fn detect_user_modified_managed_not_reported() {
         &root.path().join("dep-skills"),
         |_| true,
         |_| true,
+        |_| false,
     );
     assert!(
         !report.stale,

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -81,11 +81,16 @@ pub(crate) const GIT_WORKTREE_REMOVE_TIMEOUT: std::time::Duration =
 /// paths like `<base>/.worktrees/deep/nested` where `.worktrees` is a grandparent.
 /// Test: `is_session_worktree_detects_dot_worktrees_component`.
 ///
-/// Visibility (#2033): `pub(super)` — reused by `session_manager::search_gc`
-/// so the "is this path a disposable in-project worktree?" rule lives in
-/// exactly one place and the search-index lifecycle (delete-on-decommission,
-/// orphan sweep) can never diverge from the filesystem-removal safety gate.
-pub(super) fn is_session_worktree(path: &Path) -> bool {
+/// Visibility (#2033, widened #2508): `pub(crate)` — reused by
+/// `session_manager::search_gc` (same "disposable workspace?" rule for the
+/// search-index lifecycle) and by `core::agent_reset_workspace` (the same
+/// rule gates which session workspaces `--reset-agents-workspaces` is
+/// allowed to force-recompose files into — a local-path/adopted session's
+/// real, long-lived checkout must never be mistaken for a disposable
+/// SM-provisioned one, the #1511 incident class). Keeping this in exactly one
+/// place means the filesystem-removal guard, the search-index GC guard, and
+/// the agent-reset guard can never diverge.
+pub(crate) fn is_session_worktree(path: &Path) -> bool {
     path.parent()
         .and_then(|p| p.file_name())
         .map(|n| n == WORKTREES_DIRNAME)


### PR DESCRIPTION
## Summary

Two related agent-roster drift bugs, both rooted in the fact that trusty-mpm has THREE independent agent-deploy destinations (`tm install` → `~/.claude/agents`, managed `CLAUDE_CONFIG_DIR`, and session/worktree launch → project-local `.claude/agents`) that can silently disagree about which agents are present.

### #2462 — session-local roster drift (missing `engineer.md`)

**Root cause** (confirmed empirically in the issue thread): `[agents].exclude` in `manifest.toml` is documented as — and consumed by `deploy_agents_filtered` as — the DEPLOY-ROSTER filter for session/worktree launches. `detect_staleness` (the `/health` drift check) reused that *same* predicate. An operator who added a name to `exclude` purely to silence the "this agent drifted from the catalog" staleness warning for a customized agent *also* silently dropped that agent from every filtered deploy destination — but NOT from the two unfiltered destinations (`tm install`, managed config), so the rosters silently diverged.

**Fix**: added `AgentSet.ignore_staleness` — a distinct, deploy-safe field. Agents listed there are exempt from the staleness/drift report but remain fully selected for deploy. `HarnessPlan::agent_staleness_ignored` exposes the predicate; `detect_staleness`/`agent_changes` thread it through independently of `agent_select`, so the two concerns (deploy roster vs. staleness suppression) can never collide again. `[agents].exclude` keeps its existing, documented deploy-roster meaning — zero behavior change there.

### #2508 — `tm install --reset-agents` only covers `~/.claude/agents`

**Root cause**: the reset added in #2504/#2505 only ever targeted the USER-LEVEL directory. Project-local `.claude/agents/` dirs deployed into managed session workspaces/worktrees carry their own independently-stale composition and never receive the fix.

**Fix**: added `reset_project_agents` (the project-dir-safe variant of `reset_agents`) that narrows the reset scope to a target harness's `agent_selected` roster *before* writing anything — so a project-level reset can never resurrect an agent that project's own manifest deliberately excludes (the cross-review hazard flagged on #2508 by the #2462 investigation). Requested names the plan rejects surface in a new `ResetResult.deselected` field instead of being silently dropped. Added `reset_active_workspace_agents`, which loads the on-disk session store, sweeps every intact (non-decommissioned) session with a live workspace, resolves *each* workspace's own harness plan exactly as `prepare_session` does, and resets through it. Wired up as `tm install --reset-agents --reset-agents-workspaces` (requires `--reset-agents`), with a per-session report.

## Why one PR

Both fixes revolve around the same `agent_selected` / `[agents].exclude` predicate — #2508's project-level reset explicitly has to respect the semantics #2462 clarifies (see the cross-warning comment on #2508), so implementing them independently would have created an ordering/consistency hazard. Delivered as two atomic commits (one per issue) on a single branch/PR.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (trusty-mpm: 2979 lib + 898×2 bin tests, 0 failed; one unrelated pre-existing timing flake in `trusty-search::probe_all_volumes_multi_volume_no_fast_starvation`, confirmed to pass in isolation and untouched by this diff)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`
- [x] `bash scripts/check_test_pointers.sh`

Closes #2462
Closes #2508

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools