### PR TITLE
feat(trusty-installer): turnkey launchd bootstrap for the shared daemon set (closes #2557, #2556)

### DIFF
--- a/crates/trusty-common/src/launchd.rs
+++ b/crates/trusty-common/src/launchd.rs
@@ -293,6 +293,29 @@ impl LaunchdConfig {
         Ok(())
     }
 
+    /// Report whether the agent is currently loaded in the GUI domain.
+    ///
+    /// Why: `tctl start` right after `tctl install` (#2556) would otherwise
+    /// unconditionally call [`bootstrap`](Self::bootstrap) — which itself
+    /// boots the agent OUT first — bouncing a daemon that the install's own
+    /// service-bootstrap step just started seconds earlier. A cheap
+    /// `launchctl print` check lets the caller skip that redundant restart
+    /// when the agent is already loaded and running (#2566 review, item 4).
+    /// What: runs `launchctl print gui/<uid>/<label>` and returns whether it
+    /// exited successfully (launchctl exits non-zero when the label is not
+    /// loaded). Never errors — an inability to query is treated as "not
+    /// loaded" so the caller falls back to the safe (bootstrap) path.
+    /// Test: side-effecting `launchctl` call; exercised manually (mirrors the
+    /// `service status` subcommands' identical `launchctl print` check).
+    pub fn is_loaded(&self) -> bool {
+        let target = format!("gui/{}/{}", current_uid(), self.label);
+        Command::new("launchctl")
+            .args(["print", &target])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
     /// Bootout (stop and unload) the agent via `launchctl`.
     ///
     /// Why: uninstalling or re-bootstrapping an agent requires removing the

--- a/crates/trusty-console/src/lib.rs
+++ b/crates/trusty-console/src/lib.rs
@@ -48,6 +48,7 @@ pub mod poller;
 pub mod proxy;
 pub mod routes;
 pub mod server;
+pub mod service;
 pub(crate) mod url_util;
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
@@ -86,6 +87,16 @@ pub enum Commands {
     /// `config keys set/list/test/unset` surface shared by every trusty-*
     /// binary (epic #2400 Wave 1, #2405).
     Config(trusty_common::inference::config::ConfigCommand),
+    /// Manage the macOS launchd LaunchAgent for the console daemon (#2557).
+    ///
+    /// `install` writes `~/Library/LaunchAgents/com.trusty.trusty-console.plist`
+    /// (running `trusty-console serve`) and bootstraps it; `uninstall` unloads
+    /// and removes it; `status` / `logs` inspect the running agent. macOS-only.
+    /// `tctl install` / `tctl start` call `install` on the operator's behalf.
+    Service {
+        #[command(subcommand)]
+        action: service::ServiceAction,
+    },
 }
 
 /// Arguments for `trusty-console port`.
@@ -186,6 +197,8 @@ pub async fn run_from(argv: Vec<String>) -> Result<()> {
         Commands::Serve(args) => run_serve(args).await,
         Commands::Port(args) => run_port(args),
         Commands::Config(cmd) => cmd.run().await,
+        // `service` drives macOS launchd synchronously; no async work needed.
+        Commands::Service { action } => service::run_service_action(&action),
     }
 }
 

--- a/crates/trusty-console/src/service.rs
+++ b/crates/trusty-console/src/service.rs
@@ -248,4 +248,55 @@ mod tests {
     fn serve_args_are_serve() {
         assert_eq!(serve_args(), vec!["serve".to_string()]);
     }
+
+    /// Cross-crate port-uniqueness contract (#2566 review finding).
+    ///
+    /// Why: trusty-review's original `DEFAULT_PORT` (7880) silently collided
+    /// with trusty-mpm's live `DEFAULT_DAEMON_ADDR`, crash-looping a launchd
+    /// agent on install. This mirrors that fix's guard for the console's own
+    /// default (`crate::DEFAULT_PORT`), pointer-commented to each sibling's
+    /// real source constant, so a future edit here that reintroduces a
+    /// collision fails this test instead of shipping a crash-loop.
+    /// What: asserts `crate::DEFAULT_PORT` is absent from the known-sibling
+    /// ports list.
+    /// Test: this is the test.
+    #[test]
+    fn default_port_does_not_collide_with_known_siblings() {
+        // (binary, port, source-of-truth pointer)
+        let known_siblings: &[(&str, u16, &str)] = &[
+            (
+                "trusty-memory",
+                7070,
+                "trusty-memory/src/http_server.rs::DEFAULT_HTTP_PORT",
+            ),
+            (
+                "trusty-search",
+                7878,
+                "trusty-search/src/service/constants.rs::DEFAULT_PORT",
+            ),
+            (
+                "trusty-analyze",
+                7879,
+                "trusty-analyze/src/service/events.rs::DEFAULT_PORT",
+            ),
+            (
+                "trusty-review",
+                7890,
+                "trusty-review/src/service/mod.rs::DEFAULT_PORT",
+            ),
+            (
+                "trusty-mpm",
+                7880,
+                "trusty-mpm/src/core/discovery.rs::DEFAULT_DAEMON_ADDR",
+            ),
+        ];
+        for (binary, port, source) in known_siblings {
+            assert_ne!(
+                crate::DEFAULT_PORT,
+                *port,
+                "trusty-console DEFAULT_PORT {} collides with {binary}'s {port} ({source})",
+                crate::DEFAULT_PORT
+            );
+        }
+    }
 }

--- a/crates/trusty-console/src/service.rs
+++ b/crates/trusty-console/src/service.rs
@@ -1,0 +1,251 @@
+//! Handler for `trusty-console service` (macOS launchd integration).
+//!
+//! Why: `stable_set()` in trusty-installer marks trusty-console
+//! `ManageStrategy::Launchd`, so `tctl start trusty-console` calls
+//! `launchctl bootstrap … com.trusty.trusty-console.plist` — but no code path
+//! in the repository ever WROTE that plist, so a fresh-machine `tctl start`
+//! hard-failed for the console daemon (#2557). This subcommand supplies the
+//! missing launchd install/uninstall/status/logs mechanics, mirroring the
+//! `trusty-search` / `trusty-analyze` `service` pattern.
+//!
+//! Note (design decision, umbrella #2555 open question): whether the console
+//! SHOULD be launchd-managed or process-managed (like trusty-mpm's own
+//! `start`/`stop` verbs) is an owner decision left open. The console exposes a
+//! real long-lived HTTP daemon (`trusty-console serve`, graceful SIGTERM
+//! shutdown), which launchd supervises correctly, and `stable_set()` already
+//! classifies it `Launchd`; this module makes that existing classification
+//! FUNCTION rather than deciding it is the right lifecycle model. If the owner
+//! later chooses process-management, the console would need its own
+//! `start`/`stop` verbs and the stable-set strategy would flip to `OwnVerb`.
+//!
+//! What: on macOS routes `ServiceAction` to a single launchd operation via the
+//! shared `trusty_common::launchd` module; the agent runs `trusty-console
+//! serve` (the dashboard HTTP daemon). On non-macOS the entry point returns a
+//! clear error.
+//! Test: `service_label_matches_tctl_convention` and `serve_args_are_serve`
+//! (macOS-only, pure) pin the load-bearing label + args; install/uninstall are
+//! side-effecting `launchctl` calls exercised manually (never in tests).
+
+use anyhow::Result;
+use clap::Subcommand;
+
+/// Subcommand actions for `trusty-console service`.
+///
+/// Why: launchd keeps the long-lived console dashboard daemon alive on macOS;
+/// wrapping the plist mechanics in `service` subcommands gives `tctl` a stable
+/// `trusty-console service install` hook and spares operators hand-editing XML.
+/// What: each variant maps to one launchd operation (or `tail -F` for Logs).
+/// Test: `cargo run -p trusty-console -- service --help` lists the four
+/// actions; on Linux any action returns Err with the platform message.
+#[derive(Debug, Clone, Subcommand)]
+pub enum ServiceAction {
+    /// Install the LaunchAgent plist and load it.
+    Install,
+    /// Unload the LaunchAgent and remove the plist.
+    Uninstall,
+    /// Show launchd status for the agent.
+    Status,
+    /// Tail the launchd stdout / stderr logs.
+    Logs,
+}
+
+/// Reverse-DNS label for the LaunchAgent.
+///
+/// Why: this MUST equal `trusty_installer`'s
+/// `plist_label::plist_label_for("trusty-console")` (`com.trusty.trusty-console`
+/// by convention) or `tctl start`/`tctl stop` would target a launchd job that
+/// `service install` never created.
+/// What: the `Label` key value and the `<label>.plist` base name.
+/// Test: `service_label_matches_tctl_convention`.
+#[cfg(target_os = "macos")]
+pub const LAUNCHD_LABEL: &str = "com.trusty.trusty-console";
+
+/// Dispatch a `trusty-console service <action>` invocation.
+///
+/// Why: launchd is macOS-specific; on other platforms we return a clear error.
+/// What: macOS routes to install / uninstall / status / logs. Non-macOS bails.
+/// Test: on Linux every action returns Err; the macOS paths are side-effecting
+/// and validated manually.
+pub fn run_service_action(action: &ServiceAction) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        match action {
+            ServiceAction::Install => service_install(),
+            ServiceAction::Uninstall => service_uninstall(),
+            ServiceAction::Status => service_status(),
+            ServiceAction::Logs => service_logs(),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = action;
+        anyhow::bail!(
+            "`trusty-console service` is only supported on macOS — \
+             use your distro's service manager (systemd, OpenRC, etc.) directly."
+        );
+    }
+}
+
+/// The daemon serve args embedded in the launchd plist.
+///
+/// Why: the launchd agent must start the dashboard HTTP daemon, which is
+/// `trusty-console serve`.
+/// What: returns `["serve"]`.
+/// Test: `serve_args_are_serve`.
+#[cfg(target_os = "macos")]
+fn serve_args() -> Vec<String> {
+    vec!["serve".to_string()]
+}
+
+/// Resolve the log directory for the console launchd agent.
+///
+/// Why: align with the other trusty-* daemons (`~/.trusty-<name>/logs`).
+/// What: returns `~/.trusty-console/logs`, creating it on demand.
+/// Test: side-effecting; exercised transitively by `service install`.
+#[cfg(target_os = "macos")]
+fn launchd_log_dir() -> Result<std::path::PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve $HOME"))?;
+    let dir = home.join(".trusty-console").join("logs");
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Build the shared `LaunchdConfig` for the console daemon.
+///
+/// Why: install / uninstall / status all need the same label, exe path, args,
+/// and log directory; building it once keeps them in agreement.
+/// What: resolves the current executable and log dir and returns a
+/// `LaunchdConfig` that runs `trusty-console serve`, kept alive always with a
+/// 10-second restart throttle and a seeded daemon `PATH` (#1298 — the console
+/// shells out to `tailscale`).
+/// Test: side-effecting resolution; exercised transitively by every macOS
+/// `service` subcommand.
+#[cfg(target_os = "macos")]
+fn launchd_config() -> Result<trusty_common::launchd::LaunchdConfig> {
+    use trusty_common::launchd::{KeepAlive, LaunchdConfig};
+
+    let exe = std::env::current_exe()
+        .map_err(|e| anyhow::anyhow!("could not resolve current exe: {e}"))?;
+    let log_dir = launchd_log_dir()?;
+    Ok(LaunchdConfig {
+        label: LAUNCHD_LABEL.to_string(),
+        exe_path: exe,
+        args: serve_args(),
+        log_dir,
+        keep_alive: KeepAlive::Always,
+        throttle_interval: 10,
+        env_vars: Vec::new(),
+        fd_limit: None,
+    }
+    .with_daemon_path())
+}
+
+#[cfg(target_os = "macos")]
+fn service_install() -> Result<()> {
+    let cfg = launchd_config()?;
+    cfg.install()
+        .map_err(|e| anyhow::anyhow!("install LaunchAgent plist: {e}"))?;
+    let plist_path = cfg.plist_path()?;
+    println!("[ok] Wrote LaunchAgent plist: {}", plist_path.display());
+
+    cfg.bootstrap()
+        .map_err(|e| anyhow::anyhow!("launchctl bootstrap: {e}"))?;
+    let domain = format!("gui/{}", trusty_common::launchd::current_uid());
+    println!(
+        "[ok] trusty-console service installed and started ({LAUNCHD_LABEL} loaded into {domain})."
+    );
+    println!(
+        "  Logs:    {}\n  Status:  trusty-console service status",
+        cfg.log_dir.display()
+    );
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn service_uninstall() -> Result<()> {
+    let cfg = launchd_config()?;
+    let plist_path = cfg.plist_path()?;
+    if plist_path.exists() {
+        let _ = cfg.bootout();
+        std::fs::remove_file(&plist_path)
+            .map_err(|e| anyhow::anyhow!("remove {}: {e}", plist_path.display()))?;
+        println!(
+            "[ok] trusty-console service uninstalled ({} removed).",
+            plist_path.display()
+        );
+    } else {
+        println!(
+            "[skip] {} not installed — nothing to do",
+            plist_path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn service_status() -> Result<()> {
+    let uid = trusty_common::launchd::current_uid();
+    let target = format!("gui/{uid}/{LAUNCHD_LABEL}");
+    let output = std::process::Command::new("launchctl")
+        .args(["print", &target])
+        .output()
+        .map_err(|e| anyhow::anyhow!("launchctl print failed: {e}"))?;
+    if output.status.success() {
+        println!("{}", String::from_utf8_lossy(&output.stdout));
+        Ok(())
+    } else {
+        eprintln!("  Install with: trusty-console service install");
+        anyhow::bail!(
+            "{target} is not loaded ({})",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn service_logs() -> Result<()> {
+    let log_dir = launchd_log_dir()?;
+    let stdout_log = log_dir.join("stdout.log");
+    let stderr_log = log_dir.join("stderr.log");
+    if !stdout_log.exists() && !stderr_log.exists() {
+        eprintln!(
+            "[skip] No logs at {} yet — start the service first.",
+            log_dir.display()
+        );
+        return Ok(());
+    }
+    let status = std::process::Command::new("tail")
+        .arg("-F")
+        .arg(&stdout_log)
+        .arg(&stderr_log)
+        .status()
+        .map_err(|e| anyhow::anyhow!("tail failed: {e}"))?;
+    if !status.success() {
+        anyhow::bail!("tail exited with {status}");
+    }
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    /// Why: the label is a cross-crate contract — `tctl` derives
+    /// `com.trusty.trusty-console` in `plist_label_for` and bootstraps THAT
+    /// plist; drift here silently breaks `tctl start trusty-console`.
+    /// What: asserts the constant equals the convention-derived label.
+    /// Test: this is the test.
+    #[test]
+    fn service_label_matches_tctl_convention() {
+        assert_eq!(LAUNCHD_LABEL, "com.trusty.trusty-console");
+    }
+
+    /// Why: the launchd agent must start the dashboard HTTP daemon, i.e.
+    /// `trusty-console serve`.
+    /// What: asserts the embedded args are exactly `["serve"]`.
+    /// Test: this is the test.
+    #[test]
+    fn serve_args_are_serve() {
+        assert_eq!(serve_args(), vec!["serve".to_string()]);
+    }
+}

--- a/crates/trusty-installer/src/cli.rs
+++ b/crates/trusty-installer/src/cli.rs
@@ -170,6 +170,11 @@ pub enum Commands {
     Install {
         /// Specific member(s) to install; omit for all enabled members.
         members: Vec<String>,
+
+        /// Install binaries only — skip the post-install launchd service
+        /// bootstrap (#2556). Also settable via `TCTL_NO_SERVICE_BOOTSTRAP`.
+        #[arg(long)]
+        no_service: bool,
     },
 
     /// Upgrade the stack (or named members) to the BOM-pinned versions, then restart. (DOC-9)

--- a/crates/trusty-installer/src/cli_tests.rs
+++ b/crates/trusty-installer/src/cli_tests.rs
@@ -215,8 +215,20 @@ fn parse_install_members() {
         "trusty-memory",
     ])
     .expect("install members parses");
-    if let Commands::Install { members } = &cli.command {
+    if let Commands::Install { members, .. } = &cli.command {
         assert_eq!(members, &["trusty-search", "trusty-memory"]);
+    } else {
+        panic!("expected Install");
+    }
+}
+
+/// Parse `trusty-installer install --no-service` (#2556 opt-out flag).
+#[test]
+fn parse_install_no_service() {
+    let cli = Cli::try_parse_from(["trusty-installer", "install", "--no-service"])
+        .expect("install --no-service parses");
+    if let Commands::Install { no_service, .. } = &cli.command {
+        assert!(*no_service, "--no-service must set the flag");
     } else {
         panic!("expected Install");
     }

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -27,7 +27,8 @@ use trusty_progress::{Component, ComponentTracker};
 use super::dependency_graph::describe_added;
 use super::progress_ui::{narrator, prompt_yes_no};
 use super::runtime::block_on;
-use super::stable_set::{select_members_transitive, StableMember};
+use super::service_bootstrap::{bootstrap_enabled, bootstrap_member_service, NO_SERVICE_ENV};
+use super::stable_set::{select_members_transitive, ManageStrategy, StableMember};
 use crate::output::render_json;
 
 /// One member's install outcome for the `--json` report.
@@ -103,9 +104,14 @@ impl InstallReport {
 /// rendering progress rows; emits either the human component table + summary or
 /// the `--json` [`InstallReport`]. Returns the process exit code.
 ///
+/// `no_service` (the `--no-service` flag) — together with the [`NO_SERVICE_ENV`]
+/// environment opt-out — suppresses the Phase-7b launchd service bootstrap
+/// (#2556) so operators who manage launchd themselves, or CI, install binaries
+/// only.
+///
 /// Test: `tests::run_unknown_member_is_error`; the install path itself is
 /// side-effecting (`cargo install`) and validated manually.
-pub fn run(members: &[String], yes: bool, json: bool) -> i32 {
+pub fn run(members: &[String], yes: bool, json: bool, no_service: bool) -> i32 {
     // Phase 4: interactive component picker.
     // Only activates when: no explicit members, stdin is a TTY, and not --json.
     // When members are passed, or in --json / non-TTY mode, behaviour is unchanged.
@@ -204,7 +210,11 @@ pub fn run(members: &[String], yes: bool, json: bool) -> i32 {
         }
     }
 
-    let report = block_on(install_all(&selected, json));
+    // #2556: whether to bootstrap each daemon member's launchd plist after it
+    // installs. Disabled by the `--no-service` flag or the env opt-out.
+    let service_enabled = bootstrap_enabled(no_service, std::env::var_os(NO_SERVICE_ENV).is_some());
+
+    let report = block_on(install_all(&selected, json, service_enabled));
     if json {
         // A failed machine-readable write must not exit 0: automation would
         // read success from the exit code while the JSON never arrived.
@@ -225,8 +235,16 @@ pub fn run(members: &[String], yes: bool, json: bool) -> i32 {
 /// What: For each member, runs `perform_upgrade` then `verify_installed_binary`,
 /// rendering a `trusty-progress` narration line per member and a final component
 /// table of the installed binaries (with on-disk sizes when resolvable).
-/// Test: Side-effecting; the report shaping is tested via `InstallReport`.
-async fn install_all(selected: &[StableMember], json: bool) -> InstallReport {
+/// When `service_enabled`, each launchd-managed daemon member also has its own
+/// `<binary> service install` run after it lands (#2556, Phase 7b) so the plist
+/// exists before `tctl start`.
+/// Test: Side-effecting; the report shaping is tested via `InstallReport` and the
+/// per-member service policy is tested in `super::service_bootstrap::tests`.
+async fn install_all(
+    selected: &[StableMember],
+    json: bool,
+    service_enabled: bool,
+) -> InstallReport {
     let narr = narrator(json);
     let _ = narr.info(&format!("installing {} component(s)", selected.len()));
 
@@ -261,6 +279,16 @@ async fn install_all(selected: &[StableMember], json: bool) -> InstallReport {
                 // Phase 8: codesign + FDA guidance for trusty-search.
                 if m.crate_name == "trusty-search" {
                     super::macos_signing::post_install_search(&install_dir, json);
+                }
+                // Phase 7b (#2556): bootstrap the launchd plist for each shared
+                // daemon (search/memory/analyze/review/console) via its own
+                // `<binary> service install`, so `tctl start` has a plist to
+                // load. trusty-mpm (OwnVerb, handled above) and tga (non-daemon)
+                // are excluded. Fail-soft + idempotent + non-clobbering; see
+                // `service_bootstrap`.
+                if service_enabled && m.manage == ManageStrategy::Launchd {
+                    let action = bootstrap_member_service(&m.binary);
+                    let _ = narr.info(&action.note(&m.binary));
                 }
             }
             Err(e) => {
@@ -483,7 +511,7 @@ mod tests {
     /// Test: This is the test.
     #[test]
     fn run_unknown_member_is_error() {
-        let code = run(&["not-a-real-tool".to_owned()], true, true);
+        let code = run(&["not-a-real-tool".to_owned()], true, true, false);
         assert_eq!(code, 3);
     }
 }

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -27,16 +27,29 @@ use trusty_progress::{Component, ComponentTracker};
 use super::dependency_graph::describe_added;
 use super::progress_ui::{narrator, prompt_yes_no};
 use super::runtime::block_on;
-use super::service_bootstrap::{bootstrap_enabled, bootstrap_member_service, NO_SERVICE_ENV};
+use super::service_bootstrap::{
+    bootstrap_enabled, bootstrap_member_service, BootstrapAction, NO_SERVICE_ENV,
+};
 use super::stable_set::{select_members_transitive, ManageStrategy, StableMember};
 use crate::output::render_json;
 
 /// One member's install outcome for the `--json` report.
 ///
 /// Why: A typed per-member result keeps the machine output stable and testable.
-/// What: `member` is the crate name; `ok` whether it installed + health-gated;
-/// `detail` a human note (e.g. the error on failure).
-/// Test: `tests::report_serialises`.
+/// `service_ok` / `service_detail` were added after a review of #2566 found
+/// that a genuine `service install` failure was reported ONLY via an info-level
+/// narration line — `--json` output claimed `all_ok: true` / exit 0 even when
+/// every daemon's launchd bootstrap had failed, which is precisely the failure
+/// class #2557 existed because of (a broken daemon that LOOKS installed).
+/// What: `member` is the crate name; `ok` whether the binary install +
+/// health-gate succeeded; `detail` a human note (e.g. the error on binary
+/// failure). `service_ok` is `true` when the post-install launchd service
+/// bootstrap was not attempted (bootstrap disabled, non-service member, or a
+/// plist already present — none of those are failures) OR when it ran and
+/// succeeded; it is `false` ONLY when `service install` was attempted and
+/// genuinely errored. `service_detail` carries the human note for whichever
+/// case applied.
+/// Test: `tests::report_serialises`, `tests::report_all_ok_reflects_service_failure`.
 #[derive(Clone, Debug, Serialize)]
 pub struct InstallOutcome {
     /// Crate name installed.
@@ -45,6 +58,28 @@ pub struct InstallOutcome {
     pub ok: bool,
     /// Human detail / error message.
     pub detail: String,
+    /// Whether the post-install service bootstrap succeeded or was not
+    /// attempted (see field doc above for the false-only-on-genuine-failure
+    /// contract).
+    pub service_ok: bool,
+    /// Human note for the service bootstrap outcome.
+    pub service_detail: String,
+}
+
+impl InstallOutcome {
+    /// Build the `service_ok = true`, empty-detail outcome for a member whose
+    /// binary install failed (never reached the service-bootstrap step).
+    ///
+    /// Why: a binary-install failure and a service-bootstrap failure are
+    /// distinct failure classes; a binary that never installed cannot have a
+    /// "failed" service bootstrap — centralising this avoids a copy-pasted
+    /// `service_ok: true, service_detail: String::new()` at every call site.
+    /// What: returns `(true, "")`&nbsp;— not-applicable, not a failure.
+    /// Test: exercised via `tests::report_all_ok` (binary failure alone still
+    /// yields `all_ok == false` from `ok`, independent of this default).
+    fn service_not_attempted() -> (bool, String) {
+        (true, String::new())
+    }
 }
 
 /// The aggregate install report.
@@ -52,25 +87,31 @@ pub struct InstallOutcome {
 /// Why: `--json` consumers want the whole rollup in one object with an overall
 /// verdict; the human path renders the same data as a component table.
 /// What: Holds per-member outcomes and the computed `all_ok`.
-/// Test: `tests::report_serialises`, `tests::report_all_ok`.
+/// Test: `tests::report_serialises`, `tests::report_all_ok`,
+/// `tests::report_all_ok_reflects_service_failure`.
 #[derive(Clone, Debug, Serialize)]
 pub struct InstallReport {
     /// Fixed command tag for JSON consumers.
     pub command: &'static str,
     /// Per-member install outcomes in install order.
     pub members: Vec<InstallOutcome>,
-    /// Whether every member installed successfully.
+    /// Whether every member installed AND every attempted service bootstrap
+    /// succeeded (see [`InstallOutcome`]'s field docs for what counts as a
+    /// service failure).
     pub all_ok: bool,
 }
 
 impl InstallReport {
     /// Build a report from per-member outcomes.
     ///
-    /// Why: Centralises the `all_ok` derivation so the exit code and JSON agree.
-    /// What: Sets `command = "install"` and `all_ok = every outcome ok`.
-    /// Test: `tests::report_all_ok`.
+    /// Why: Centralises the `all_ok` derivation so the exit code and JSON agree,
+    /// and so the report cannot claim success while a genuine service-bootstrap
+    /// failure occurred (#2566 review finding).
+    /// What: Sets `command = "install"` and
+    /// `all_ok = every outcome has ok == true AND service_ok == true`.
+    /// Test: `tests::report_all_ok`, `tests::report_all_ok_reflects_service_failure`.
     fn build(members: Vec<InstallOutcome>) -> Self {
-        let all_ok = members.iter().all(|m| m.ok);
+        let all_ok = members.iter().all(|m| m.ok && m.service_ok);
         Self {
             command: "install",
             members,
@@ -262,11 +303,6 @@ async fn install_all(
         let _ = narr.info(&format!("installing {}", m.crate_name));
         match install_one(m).await {
             Ok(()) => {
-                outcomes.push(InstallOutcome {
-                    member: m.crate_name.clone(),
-                    ok: true,
-                    detail: "installed".to_owned(),
-                });
                 tracker.add(Component::new(m.binary.clone(), binary_size(&m.binary)));
                 // Phase 7: bootstrap trusty-mpm supervisor plist (fail-soft).
                 if m.crate_name == "trusty-mpm" {
@@ -284,19 +320,46 @@ async fn install_all(
                 // daemon (search/memory/analyze/review/console) via its own
                 // `<binary> service install`, so `tctl start` has a plist to
                 // load. trusty-mpm (OwnVerb, handled above) and tga (non-daemon)
-                // are excluded. Fail-soft + idempotent + non-clobbering; see
-                // `service_bootstrap`.
-                if service_enabled && m.manage == ManageStrategy::Launchd {
-                    let action = bootstrap_member_service(&m.binary);
-                    let _ = narr.info(&action.note(&m.binary));
-                }
+                // are excluded. Fail-soft for the BINARY install phase (the
+                // member is still reported `ok: true` — the binary is on PATH
+                // and healthy) but the REPORT must not lie: a genuine bootstrap
+                // failure is routed through `narr.error()` (not `info()`) and
+                // folds into `service_ok` / `all_ok` / the exit code (#2566
+                // review — `--json` previously reported `all_ok: true` even
+                // when every daemon's service bootstrap had failed).
+                let (service_ok, service_detail) =
+                    if service_enabled && m.manage == ManageStrategy::Launchd {
+                        let action = bootstrap_member_service(&m.binary);
+                        let note = action.note(&m.binary);
+                        match &action {
+                            BootstrapAction::Failed(_) => {
+                                let _ = narr.error(&note);
+                            }
+                            BootstrapAction::Skipped(_) | BootstrapAction::Installed => {
+                                let _ = narr.info(&note);
+                            }
+                        }
+                        (!matches!(action, BootstrapAction::Failed(_)), note)
+                    } else {
+                        InstallOutcome::service_not_attempted()
+                    };
+                outcomes.push(InstallOutcome {
+                    member: m.crate_name.clone(),
+                    ok: true,
+                    detail: "installed".to_owned(),
+                    service_ok,
+                    service_detail,
+                });
             }
             Err(e) => {
                 let _ = narr.error(&format!("{}: {e}", m.crate_name));
+                let (service_ok, service_detail) = InstallOutcome::service_not_attempted();
                 outcomes.push(InstallOutcome {
                     member: m.crate_name.clone(),
                     ok: false,
                     detail: e.to_string(),
+                    service_ok,
+                    service_detail,
                 });
             }
         }
@@ -419,46 +482,92 @@ fn print_human_summary(report: &InstallReport) {
     for m in report.members.iter().filter(|m| !m.ok) {
         let _ = narr.error(&format!("{}: {}", m.member, m.detail));
     }
+    // #2566 review: a binary can install cleanly (`ok: true`) while its
+    // service bootstrap genuinely failed — surface that on the human path too,
+    // not just fold it silently into the exit code.
+    for m in report.members.iter().filter(|m| m.ok && !m.service_ok) {
+        let _ = narr.error(&format!("{}: {}", m.member, m.service_detail));
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Build an `InstallOutcome` with the pre-#2566 default service state
+    /// (not attempted — `service_ok: true`, empty detail), so tests that only
+    /// care about the binary-install dimension don't have to repeat the two
+    /// new fields at every call site.
+    fn outcome(member: &str, ok: bool, detail: &str) -> InstallOutcome {
+        InstallOutcome {
+            member: member.to_owned(),
+            ok,
+            detail: detail.to_owned(),
+            service_ok: true,
+            service_detail: String::new(),
+        }
+    }
+
     /// Why: The JSON envelope is a public contract; pin its shape.
     /// What: Builds a report and asserts the serialised keys/values.
     /// Test: This is the test.
     #[test]
     fn report_serialises() {
-        let report = InstallReport::build(vec![InstallOutcome {
-            member: "trusty-search".to_owned(),
-            ok: true,
-            detail: "installed".to_owned(),
-        }]);
+        let report = InstallReport::build(vec![outcome("trusty-search", true, "installed")]);
         let v = serde_json::to_value(&report).expect("serialises");
         assert_eq!(v["command"], "install");
         assert_eq!(v["all_ok"], true);
         assert_eq!(v["members"][0]["member"], "trusty-search");
+        assert_eq!(v["members"][0]["service_ok"], true);
     }
 
-    /// Why: `all_ok` must be false if any member failed.
+    /// Why: `all_ok` must be false if any member's BINARY install failed.
     /// What: Mixes an ok and a failed outcome; asserts `all_ok = false`.
     /// Test: This is the test.
     #[test]
     fn report_all_ok() {
-        let report = InstallReport::build(vec![
-            InstallOutcome {
-                member: "a".to_owned(),
-                ok: true,
-                detail: String::new(),
-            },
-            InstallOutcome {
-                member: "b".to_owned(),
-                ok: false,
-                detail: "boom".to_owned(),
-            },
-        ]);
+        let report =
+            InstallReport::build(vec![outcome("a", true, ""), outcome("b", false, "boom")]);
         assert!(!report.all_ok);
+    }
+
+    /// Why: #2566 review — a binary can install cleanly (`ok: true`) while its
+    /// SERVICE bootstrap genuinely fails; the report must not claim
+    /// `all_ok: true` in that case (the exact failure class #2557 existed
+    /// because of: a "successfully installed" daemon that never actually
+    /// works). A `Skipped` service outcome (opt-out, non-service member, or
+    /// plist already present) must NOT be treated as a failure.
+    /// What: one member with `ok: true, service_ok: false` → `all_ok == false`;
+    /// a second report with `ok: true, service_ok: true` (skip case) →
+    /// `all_ok == true`.
+    /// Test: this is the test.
+    #[test]
+    fn report_all_ok_reflects_service_failure() {
+        let failed = InstallReport::build(vec![InstallOutcome {
+            member: "trusty-search".to_owned(),
+            ok: true,
+            detail: "installed".to_owned(),
+            service_ok: false,
+            service_detail: "service bootstrap failed (non-fatal): boom".to_owned(),
+        }]);
+        assert!(
+            !failed.all_ok,
+            "a genuine service bootstrap failure must flip all_ok to false"
+        );
+        assert_eq!(failed.exit_code(), 2);
+
+        let skipped = InstallReport::build(vec![InstallOutcome {
+            member: "trusty-search".to_owned(),
+            ok: true,
+            detail: "installed".to_owned(),
+            service_ok: true,
+            service_detail: "launchd plist already present — left untouched".to_owned(),
+        }]);
+        assert!(
+            skipped.all_ok,
+            "a skipped (not failed) service bootstrap must not flip all_ok"
+        );
+        assert_eq!(skipped.exit_code(), 0);
     }
 
     /// Why: The exit code must track the verdict for automation.
@@ -466,17 +575,9 @@ mod tests {
     /// Test: This is the test.
     #[test]
     fn exit_code_reflects_all_ok() {
-        let ok = InstallReport::build(vec![InstallOutcome {
-            member: "a".to_owned(),
-            ok: true,
-            detail: String::new(),
-        }]);
+        let ok = InstallReport::build(vec![outcome("a", true, "")]);
         assert_eq!(ok.exit_code(), 0);
-        let bad = InstallReport::build(vec![InstallOutcome {
-            member: "a".to_owned(),
-            ok: false,
-            detail: "x".to_owned(),
-        }]);
+        let bad = InstallReport::build(vec![outcome("a", false, "x")]);
         assert_eq!(bad.exit_code(), 2);
     }
 

--- a/crates/trusty-installer/src/commands/lifecycle.rs
+++ b/crates/trusty-installer/src/commands/lifecycle.rs
@@ -275,15 +275,22 @@ fn apply_to_member(verb: Verb, m: &StableMember) -> anyhow::Result<String> {
 /// [`super::plist_label`].
 /// What (macOS): builds a minimal `LaunchdConfig` carrying only the resolved
 /// `label` (the field `bootout`/`bootstrap` actually use) and calls `bootout`
-/// (stop), `bootstrap` (start), or both (restart). On non-macOS this is
-/// unsupported (launchd is macOS-only) and returns an error.
-/// Test: side-effecting `launchctl`; never exercised in unit tests.
+/// (stop), `bootstrap` (start), or both (restart). For `Start` (#2556) the
+/// "plist must already exist" assumption is relaxed: if no plist is present for
+/// this tctl-managed member, it runs the daemon's own `<binary> service
+/// install` (which writes AND bootstraps the plist) instead of failing. On
+/// non-macOS this is unsupported (launchd is macOS-only) and returns an error.
+/// Test: the `Start` plist-presence decision is pinned by
+/// `super::service_bootstrap::tests::start_plan_maps_presence`; the actual
+/// `launchctl`/subprocess calls are side-effecting and never run in unit tests.
 #[cfg(target_os = "macos")]
 fn launchd_control(verb: Verb, binary: &str) -> anyhow::Result<String> {
+    use super::service_bootstrap::{start_plan, RealServiceEnv, ServiceEnv, StartPlan};
     use trusty_common::launchd::{KeepAlive, LaunchdConfig};
 
     // Only `label` matters for bootout/bootstrap; the rest are inert because we
-    // never render or install a plist here (the daemon's own `setup` did that).
+    // never render or install a plist here (the daemon's own `service install`
+    // did that — and, for Start on a fresh machine, we now trigger it below).
     let cfg = LaunchdConfig {
         label: super::plist_label::plist_label_for(binary),
         exe_path: std::path::PathBuf::from(binary),
@@ -300,8 +307,26 @@ fn launchd_control(verb: Verb, binary: &str) -> anyhow::Result<String> {
             Ok(format!("booted out {}", cfg.label))
         }
         Verb::Start => {
-            cfg.bootstrap()?;
-            Ok(format!("bootstrapped {}", cfg.label))
+            // #2556: relax the "plist must already exist" assumption. If the
+            // plist is present, bootstrap it (existing behaviour); if absent,
+            // run the daemon's own `service install` to write + bootstrap it.
+            let present = super::plist_label::plist_path_for(binary)
+                .map(|p| p.exists())
+                .unwrap_or(false);
+            match start_plan(present) {
+                StartPlan::Bootstrap => {
+                    cfg.bootstrap()?;
+                    Ok(format!("bootstrapped {}", cfg.label))
+                }
+                StartPlan::ServiceInstall => {
+                    RealServiceEnv.run_service_install(binary).map_err(|e| {
+                        anyhow::anyhow!(
+                            "no launchd plist for {binary} and `service install` failed: {e}"
+                        )
+                    })?;
+                    Ok(format!("installed + bootstrapped {}", cfg.label))
+                }
+            }
         }
         Verb::Restart => {
             // Bootout first (stop); only then bootstrap (start). If bootstrap

--- a/crates/trusty-installer/src/commands/lifecycle.rs
+++ b/crates/trusty-installer/src/commands/lifecycle.rs
@@ -315,6 +315,15 @@ fn launchd_control(verb: Verb, binary: &str) -> anyhow::Result<String> {
                 .unwrap_or(false);
             match start_plan(present) {
                 StartPlan::Bootstrap => {
+                    // #2566 review (item 4): `bootstrap()` boots the agent OUT
+                    // before reloading it — a redundant restart when `tctl
+                    // start` runs right after `tctl install` already bootstrapped
+                    // this same daemon seconds earlier. Skip the bounce when the
+                    // agent is already loaded; this is a cheap `launchctl print`
+                    // check (mirrors the daemons' own `service status`).
+                    if cfg.is_loaded() {
+                        return Ok(format!("{} already running (skipped restart)", cfg.label));
+                    }
                     cfg.bootstrap()?;
                     Ok(format!("bootstrapped {}", cfg.label))
                 }

--- a/crates/trusty-installer/src/commands/mod.rs
+++ b/crates/trusty-installer/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub mod probe;
 pub mod progress_ui;
 pub mod runtime;
 pub mod self_update;
+pub mod service_bootstrap;
 pub mod stable_set;
 pub mod stack;
 pub mod status;

--- a/crates/trusty-installer/src/commands/service_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap.rs
@@ -1,0 +1,407 @@
+//! Post-install launchd bootstrap for the shared daemon members (#2556).
+//!
+//! Why: `tctl install` placed binaries on PATH but only turnkeyed ONE daemon
+//! end-to-end (trusty-mpm, via [`super::plist_bootstrap`]). The shared daemons
+//! (search/memory/analyze — and, after #2557, review/console) each own their
+//! launchd plist behind a `<binary> service install` subcommand, but `tctl
+//! install` never invoked any of them. So a fresh-machine `tctl install`
+//! followed by `tctl start` failed for those members with "no such plist"
+//! (`lifecycle.rs` bootstraps a plist path nothing ever wrote). This module
+//! wires each daemon member's own `service install` into the install flow so
+//! the plist exists before `tctl start`/`tctl up` runs.
+//!
+//! What: [`bootstrap_member_service`] shells out to `<binary> service install`
+//! (reusing the daemon's own audited launchd logic rather than duplicating
+//! plist XML in the installer) after the binary lands. It is FAIL-SOFT
+//! (mirroring [`super::plist_bootstrap`]): a failure logs and returns a
+//! [`BootstrapAction::Failed`] rather than aborting the install. It is
+//! IDEMPOTENT and NON-CLOBBERING: if a launchd plist already exists for the
+//! member it is left untouched (skip-with-message) — re-running install neither
+//! overwrites a possibly operator-customised plist nor needlessly restarts a
+//! healthy daemon. An opt-out ([`NO_SERVICE_ENV`] / the `--no-service` flag)
+//! disables the whole step.
+//!
+//! Testability: every side effect is behind the [`ServiceEnv`] seam so the
+//! decision logic is unit-tested against an in-memory fake — the tests NEVER
+//! touch `~/Library/LaunchAgents` or invoke `launchctl` against the live
+//! daemons on the host (mirrors trusty-mpm's `FakeNoopTmuxDriver` pattern).
+//!
+//! Test: `tests` covers the member predicate, the opt-out truth table, every
+//! [`bootstrap_one`] branch (via `FakeServiceEnv`), and the [`start_plan`]
+//! relaxation used by `lifecycle.rs`.
+
+/// Environment-variable opt-out for the post-install service bootstrap.
+///
+/// Why: automation / CI and operators who manage launchd themselves need a way
+/// to keep `tctl install` from touching launchd at all, without a CLI flag on
+/// every call site.
+/// What: when set to any value, [`bootstrap_enabled`] returns `false`.
+/// Test: `bootstrap_enabled_respects_env`.
+pub const NO_SERVICE_ENV: &str = "TCTL_NO_SERVICE_BOOTSTRAP";
+
+/// One member's service-bootstrap outcome.
+///
+/// Why: the install flow narrates a per-member line and must distinguish "we
+/// installed the service", "we intentionally skipped", and "it failed but we
+/// carried on" — a typed result keeps that reporting honest and testable.
+/// What: `Skipped` carries the human reason; `Installed` means `service
+/// install` ran clean; `Failed` carries the (non-fatal) error text.
+/// Test: `bootstrap_one_*` tests assert each variant.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BootstrapAction {
+    /// Not attempted — opt-out, not a service member, or plist already present.
+    Skipped(String),
+    /// `<binary> service install` ran successfully.
+    Installed,
+    /// Shell-out failed; install continues (fail-soft) but this is surfaced.
+    Failed(String),
+}
+
+impl BootstrapAction {
+    /// A one-line human summary for the installer narration.
+    ///
+    /// Why: `install.rs` renders one line per member; centralising the phrasing
+    /// keeps the human + reasoning in one place.
+    /// What: maps each variant to a concise message including `binary`.
+    /// Test: `note_mentions_binary`.
+    pub fn note(&self, binary: &str) -> String {
+        match self {
+            BootstrapAction::Installed => {
+                format!("{binary}: launchd service installed and bootstrapped")
+            }
+            BootstrapAction::Skipped(reason) => {
+                format!("{binary}: service bootstrap skipped ({reason})")
+            }
+            BootstrapAction::Failed(err) => {
+                format!("{binary}: service bootstrap failed (non-fatal): {err}")
+            }
+        }
+    }
+}
+
+/// Whether a member ships a `<binary> service install` subcommand.
+///
+/// Why: only the launchd-managed shared daemons expose `service install`.
+/// trusty-mpm is process-managed (its own supervisor plist is handled by
+/// [`super::plist_bootstrap`]) and `tga` is not a daemon at all — attempting a
+/// service bootstrap for either would shell out to a subcommand that does not
+/// exist.
+/// What: `true` for search/memory/analyze/review/console; `false` otherwise.
+/// Test: `service_members_recognised`, `non_service_members_excluded`.
+pub fn member_has_service_install(binary: &str) -> bool {
+    matches!(
+        binary,
+        "trusty-search" | "trusty-memory" | "trusty-analyze" | "trusty-review" | "trusty-console"
+    )
+}
+
+/// Whether the post-install service-bootstrap step should run.
+///
+/// Why: the operator can opt out via the `--no-service` install flag or the
+/// [`NO_SERVICE_ENV`] environment variable; keeping the decision a pure
+/// function makes it testable without mutating the process environment.
+/// What: `true` unless the flag is set OR the env opt-out is present.
+/// Test: `bootstrap_enabled_truth_table`, `bootstrap_enabled_respects_env`.
+pub fn bootstrap_enabled(no_service_flag: bool, env_opt_out: bool) -> bool {
+    !no_service_flag && !env_opt_out
+}
+
+/// Side-effecting operations the bootstrap needs, behind a seam for testing.
+///
+/// Why: the decision logic (skip vs install, idempotency, member filtering)
+/// must be unit-tested WITHOUT writing to `~/Library/LaunchAgents` or running
+/// `launchctl` against the host's live daemons. Abstracting the two effects —
+/// "does a plist already exist?" and "run `service install`" — lets a fake
+/// drive the logic hermetically (the `FakeNoopTmuxDriver` pattern).
+/// What: `plist_present` reports whether the member's LaunchAgent plist exists;
+/// `run_service_install` shells out to `<binary> service install`.
+/// Test: exercised via `RealServiceEnv` (production) and `FakeServiceEnv` (unit
+/// tests, `bootstrap_one_*`).
+pub trait ServiceEnv {
+    /// Does a launchd plist already exist on disk for this member?
+    fn plist_present(&self, binary: &str) -> bool;
+    /// Run `<binary> service install` (writes the plist and bootstraps it).
+    fn run_service_install(&self, binary: &str) -> anyhow::Result<()>;
+}
+
+/// Decide and (via the seam) execute the service bootstrap for one member.
+///
+/// Why: this is the whole per-member policy — filter non-service members, honour
+/// idempotency / non-clobber by skipping when a plist already exists, and
+/// otherwise delegate to `service install`. Keeping it seam-driven makes every
+/// branch testable with no real launchd contact.
+/// What: returns [`BootstrapAction::Skipped`] when the member has no `service
+/// install` subcommand or a plist is already present; otherwise runs
+/// `run_service_install` and returns [`BootstrapAction::Installed`] or
+/// [`BootstrapAction::Failed`].
+/// Test: `bootstrap_one_skips_non_service_member`,
+/// `bootstrap_one_skips_when_plist_present`, `bootstrap_one_installs_when_absent`,
+/// `bootstrap_one_reports_failure`.
+pub fn bootstrap_one(env: &dyn ServiceEnv, binary: &str) -> BootstrapAction {
+    if !member_has_service_install(binary) {
+        return BootstrapAction::Skipped(format!("{binary} has no `service install` subcommand"));
+    }
+    if env.plist_present(binary) {
+        return BootstrapAction::Skipped(
+            "launchd plist already present — left untouched (re-run `service install` to refresh)"
+                .to_string(),
+        );
+    }
+    match env.run_service_install(binary) {
+        Ok(()) => BootstrapAction::Installed,
+        Err(e) => BootstrapAction::Failed(e.to_string()),
+    }
+}
+
+/// Bootstrap a member's launchd service after install (fail-soft, macOS-only).
+///
+/// Why: the install flow calls this once per successfully-installed daemon
+/// member. launchd is macOS-only, so on other platforms it is a no-op skip
+/// (matching [`super::plist_bootstrap`]'s non-macOS behaviour).
+/// What: on macOS delegates to [`bootstrap_one`] with the production
+/// [`RealServiceEnv`]; elsewhere returns a `Skipped` no-op.
+/// Test: the pure policy is covered by `bootstrap_one_*`; this thin cfg wrapper
+/// is side-effecting (real `launchctl`) and never invoked in the test suite.
+pub fn bootstrap_member_service(binary: &str) -> BootstrapAction {
+    #[cfg(target_os = "macos")]
+    {
+        bootstrap_one(&RealServiceEnv, binary)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = binary;
+        BootstrapAction::Skipped("launchd is macOS-only".to_string())
+    }
+}
+
+/// How `tctl start` should bring up a launchd member, given plist presence.
+///
+/// Why: `lifecycle.rs`'s launchd Start assumed the plist already existed and
+/// `launchctl bootstrap`-ed it — which hard-failed on a fresh machine where
+/// nothing wrote the plist. Relaxing that to "bootstrap if the plist exists,
+/// otherwise run `service install` (which writes AND bootstraps)" is the whole
+/// fix; encoding it as a pure enum keeps the relaxation testable.
+/// What: [`StartPlan::Bootstrap`] when the plist is present; otherwise
+/// [`StartPlan::ServiceInstall`].
+/// Test: `start_plan_maps_presence`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StartPlan {
+    /// Plist exists — `launchctl bootstrap` it (existing behaviour).
+    Bootstrap,
+    /// Plist absent — run `<binary> service install` to write + bootstrap it.
+    ServiceInstall,
+}
+
+/// Choose the `tctl start` plan for a launchd member from plist presence.
+///
+/// Why: see [`StartPlan`] — one pure decision the side-effecting caller acts on.
+/// What: `present → Bootstrap`, `absent → ServiceInstall`.
+/// Test: `start_plan_maps_presence`.
+pub fn start_plan(plist_present: bool) -> StartPlan {
+    if plist_present {
+        StartPlan::Bootstrap
+    } else {
+        StartPlan::ServiceInstall
+    }
+}
+
+/// Production [`ServiceEnv`]: real plist path check + real `service install`.
+///
+/// Why: the live install/start path needs the actual filesystem + subprocess
+/// behaviour; isolating it in one type keeps every other function pure.
+/// What: `plist_present` checks
+/// `~/Library/LaunchAgents/<plist_label_for(binary)>.plist`;
+/// `run_service_install` spawns `<binary> service install` and maps a non-zero
+/// exit to an error.
+/// Test: side-effecting; never constructed in the test suite (the fake is used).
+pub struct RealServiceEnv;
+
+impl ServiceEnv for RealServiceEnv {
+    fn plist_present(&self, binary: &str) -> bool {
+        super::plist_label::plist_path_for(binary)
+            .map(|p| p.exists())
+            .unwrap_or(false)
+    }
+
+    fn run_service_install(&self, binary: &str) -> anyhow::Result<()> {
+        if which::which(binary).is_err() {
+            anyhow::bail!("{binary} is not on PATH");
+        }
+        let status = std::process::Command::new(binary)
+            .args(["service", "install"])
+            .status()
+            .map_err(|e| anyhow::anyhow!("spawn `{binary} service install`: {e}"))?;
+        if status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!("`{binary} service install` exited with {status}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    /// In-memory [`ServiceEnv`] fake — records `service install` calls and
+    /// simulates plist presence, so tests never touch launchd or the real
+    /// `~/Library/LaunchAgents`.
+    struct FakeServiceEnv {
+        present: bool,
+        fail: bool,
+        installed: RefCell<Vec<String>>,
+    }
+
+    impl FakeServiceEnv {
+        fn new(present: bool, fail: bool) -> Self {
+            Self {
+                present,
+                fail,
+                installed: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ServiceEnv for FakeServiceEnv {
+        fn plist_present(&self, _binary: &str) -> bool {
+            self.present
+        }
+        fn run_service_install(&self, binary: &str) -> anyhow::Result<()> {
+            self.installed.borrow_mut().push(binary.to_string());
+            if self.fail {
+                anyhow::bail!("simulated failure");
+            }
+            Ok(())
+        }
+    }
+
+    /// Why: the member predicate gates which daemons get a service bootstrap;
+    /// every launchd-managed shared daemon must be recognised.
+    /// What: asserts the five service members return `true`.
+    /// Test: this is the test.
+    #[test]
+    fn service_members_recognised() {
+        for b in [
+            "trusty-search",
+            "trusty-memory",
+            "trusty-analyze",
+            "trusty-review",
+            "trusty-console",
+        ] {
+            assert!(
+                member_has_service_install(b),
+                "{b} should be a service member"
+            );
+        }
+    }
+
+    /// Why: process-managed / non-daemon members must NOT be shelled out to a
+    /// non-existent `service install` subcommand.
+    /// What: asserts trusty-mpm and tga are excluded.
+    /// Test: this is the test.
+    #[test]
+    fn non_service_members_excluded() {
+        assert!(!member_has_service_install("trusty-mpm"));
+        assert!(!member_has_service_install("tga"));
+        assert!(!member_has_service_install("nope"));
+    }
+
+    /// Why: both opt-out paths must disable the step; neither set must enable it.
+    /// What: exercises the four-way truth table.
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_enabled_truth_table() {
+        assert!(bootstrap_enabled(false, false));
+        assert!(!bootstrap_enabled(true, false));
+        assert!(!bootstrap_enabled(false, true));
+        assert!(!bootstrap_enabled(true, true));
+    }
+
+    /// Why: the env opt-out is the automation escape hatch; pin that a present
+    /// env value disables the step (flag unset).
+    /// What: `bootstrap_enabled(false, true)` is `false`.
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_enabled_respects_env() {
+        assert!(!bootstrap_enabled(false, true));
+        assert!(bootstrap_enabled(false, false));
+    }
+
+    /// Why: a non-service member must be skipped without any install attempt.
+    /// What: asserts `Skipped` and that no install was recorded.
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_one_skips_non_service_member() {
+        let env = FakeServiceEnv::new(false, false);
+        let action = bootstrap_one(&env, "trusty-mpm");
+        assert!(matches!(action, BootstrapAction::Skipped(_)));
+        assert!(env.installed.borrow().is_empty());
+    }
+
+    /// Why: idempotency + non-clobber — an existing plist must be left untouched
+    /// with NO `service install` call (no needless restart, no overwrite).
+    /// What: with `present = true`, asserts `Skipped` and no recorded install.
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_one_skips_when_plist_present() {
+        let env = FakeServiceEnv::new(true, false);
+        let action = bootstrap_one(&env, "trusty-search");
+        assert!(matches!(action, BootstrapAction::Skipped(_)));
+        assert!(
+            env.installed.borrow().is_empty(),
+            "must not re-install over an existing plist"
+        );
+    }
+
+    /// Why: the core happy path — a service member with no plist yet gets
+    /// `service install` run exactly once.
+    /// What: with `present = false`, asserts `Installed` and one recorded call.
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_one_installs_when_absent() {
+        let env = FakeServiceEnv::new(false, false);
+        let action = bootstrap_one(&env, "trusty-memory");
+        assert_eq!(action, BootstrapAction::Installed);
+        assert_eq!(env.installed.borrow().as_slice(), ["trusty-memory"]);
+    }
+
+    /// Why: a `service install` failure must be fail-soft — surfaced as
+    /// `Failed`, not a panic or an aborted install.
+    /// What: with the fake set to fail, asserts a `Failed` carrying the error.
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_one_reports_failure() {
+        let env = FakeServiceEnv::new(false, true);
+        let action = bootstrap_one(&env, "trusty-analyze");
+        match action {
+            BootstrapAction::Failed(e) => assert!(e.contains("simulated failure")),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    /// Why: the narration note must name the member for a scannable install log.
+    /// What: asserts each variant's note contains the binary name.
+    /// Test: this is the test.
+    #[test]
+    fn note_mentions_binary() {
+        assert!(BootstrapAction::Installed
+            .note("trusty-search")
+            .contains("trusty-search"));
+        assert!(BootstrapAction::Skipped("x".into())
+            .note("trusty-memory")
+            .contains("trusty-memory"));
+        assert!(BootstrapAction::Failed("boom".into())
+            .note("trusty-review")
+            .contains("trusty-review"));
+    }
+
+    /// Why: the `tctl start` relaxation is the #2556 lifecycle fix; pin the map.
+    /// What: present → Bootstrap, absent → ServiceInstall.
+    /// Test: this is the test.
+    #[test]
+    fn start_plan_maps_presence() {
+        assert_eq!(start_plan(true), StartPlan::Bootstrap);
+        assert_eq!(start_plan(false), StartPlan::ServiceInstall);
+    }
+}

--- a/crates/trusty-installer/src/main.rs
+++ b/crates/trusty-installer/src/main.rs
@@ -122,8 +122,11 @@ fn dispatch(cli: Cli) {
             ));
         }
 
-        Commands::Install { members } => {
-            std::process::exit(install::run(&members, yes, json));
+        Commands::Install {
+            members,
+            no_service,
+        } => {
+            std::process::exit(install::run(&members, yes, json, no_service));
         }
 
         Commands::Ensure { wait } => {

--- a/crates/trusty-review/src/commands/mod.rs
+++ b/crates/trusty-review/src/commands/mod.rs
@@ -20,3 +20,4 @@ pub mod port;
 pub mod run;
 #[cfg(feature = "http-server")]
 pub mod serve;
+pub mod service;

--- a/crates/trusty-review/src/commands/mod.rs
+++ b/crates/trusty-review/src/commands/mod.rs
@@ -9,7 +9,9 @@
 //! behind `http-server`). Also re-exports the shared helpers `build_deps_async`,
 //! `resolve_diff_source_run`, `resolve_diff_source_compare`, and
 //! `print_compare_table`/`truncate_str` used by the compare printer.
-//! `cmd_calibrate` (calibration harness, #1422) is always present.
+//! `cmd_calibrate` (calibration harness, #1422) is always present. `service`
+//! (the launchd wrapper, #2557) is gated behind `http-server` because it
+//! daemonizes `trusty-review serve`, which does not exist without that feature.
 //!
 //! Test: handlers are tested transitively via `runner::tests` (unit) and the
 //! CLI smoke-tests in this file's sibling modules.
@@ -20,4 +22,5 @@ pub mod port;
 pub mod run;
 #[cfg(feature = "http-server")]
 pub mod serve;
+#[cfg(feature = "http-server")]
 pub mod service;

--- a/crates/trusty-review/src/commands/serve.rs
+++ b/crates/trusty-review/src/commands/serve.rs
@@ -37,13 +37,16 @@ use crate::cli_verify;
 ///
 /// Why: collects the port, bind address, and mode flags so the server can be
 /// configured purely from CLI flags without requiring env-var wrangling.
-/// What: `--port` sets the listen port (default 7880); `--stdio` activates the
+/// What: `--port` sets the listen port (default 7890); `--stdio` activates the
 /// MCP JSON-RPC stdio loop instead of binding TCP.
 /// Test: `cargo run -p trusty-review --features http-server -- serve --help`.
 #[derive(Debug, clap::Parser)]
 pub struct ServeArgs {
     /// HTTP listen port.
-    /// Default: 7880 (distinct from trusty-search :7878 and trusty-analyze :7879).
+    /// Default: 7890 — distinct from every known sibling default: trusty-memory
+    /// :7070, trusty-search :7878, trusty-analyze :7879, trusty-console :7788,
+    /// AND trusty-mpm (`tm`) :7880 (the collision a live host reproduced —
+    /// #2566 review; see `service::DEFAULT_PORT`'s doc for the incident).
     /// Ignored when --stdio is set.
     #[arg(long, default_value_t = DEFAULT_PORT, value_name = "PORT")]
     pub port: u16,

--- a/crates/trusty-review/src/commands/service.rs
+++ b/crates/trusty-review/src/commands/service.rs
@@ -13,10 +13,11 @@
 //! shared `trusty_common::launchd` module; the agent runs `trusty-review serve`
 //! (the long-lived HTTP webhook daemon). On non-macOS the entry point returns a
 //! clear error rather than emitting confusing plist output.
-//! Test: `service_label_matches_tctl_convention` and `serve_args_are_serve`
-//! (macOS-only, pure) pin the load-bearing label + args; the install/uninstall
-//! paths are side-effecting `launchctl` calls exercised manually (never in the
-//! test suite, per the hermetic-test rule).
+//! Test: `service_label_matches_tctl_convention` and
+//! `serve_args_pass_explicit_default_port` (macOS-only, pure) pin the
+//! load-bearing label + args; the install/uninstall paths are side-effecting
+//! `launchctl` calls exercised manually (never in the test suite, per the
+//! hermetic-test rule).
 
 use anyhow::Result;
 use clap::Subcommand;
@@ -85,13 +86,22 @@ pub fn run_service_action(action: &ServiceAction) -> Result<()> {
 /// The daemon serve args embedded in the launchd plist.
 ///
 /// Why: the launchd agent must start the long-lived HTTP webhook server, which
-/// is `trusty-review serve`; centralising the args keeps install and the label
-/// contract in one testable place.
-/// What: returns `["serve"]`.
-/// Test: `serve_args_are_serve`.
+/// is `trusty-review serve`. The port is passed EXPLICITLY (rather than
+/// relying solely on `serve`'s `default_value_t = DEFAULT_PORT`) as defense in
+/// depth (#2566 review): a `KeepAlive::Always` / 10s-throttle launchd agent
+/// that silently inherited a colliding default would crash-loop indefinitely
+/// with no obvious cause, whereas an explicit `--port` here makes the bound
+/// port a visible, testable part of the plist contract, independent of
+/// whatever `serve`'s CLI default happens to be at any given moment.
+/// What: returns `["serve", "--port", "<DEFAULT_PORT>"]`.
+/// Test: `serve_args_pass_explicit_default_port`.
 #[cfg(target_os = "macos")]
 fn serve_args() -> Vec<String> {
-    vec!["serve".to_string()]
+    vec![
+        "serve".to_string(),
+        "--port".to_string(),
+        trusty_review::service::DEFAULT_PORT.to_string(),
+    ]
 }
 
 /// Resolve the log directory for the review launchd agent.
@@ -239,13 +249,24 @@ mod tests {
         assert_eq!(LAUNCHD_LABEL, "com.trusty.trusty-review");
     }
 
-    /// Why: the launchd agent must start the HTTP webhook daemon, i.e.
-    /// `trusty-review serve`; a wrong arg would load a plist that runs the
-    /// wrong (or no) subcommand.
-    /// What: asserts the embedded args are exactly `["serve"]`.
+    /// Why: the launchd agent must start the HTTP webhook daemon with an
+    /// EXPLICIT `--port` (#2566 review — defense in depth against a future
+    /// `DEFAULT_PORT` drift silently reintroducing the trusty-mpm :7880
+    /// collision); a wrong or missing port arg would load a plist that either
+    /// runs the wrong subcommand or falls back to whatever `serve`'s CLI
+    /// default happens to be.
+    /// What: asserts the embedded args are exactly
+    /// `["serve", "--port", "<DEFAULT_PORT>"]`.
     /// Test: this is the test.
     #[test]
-    fn serve_args_are_serve() {
-        assert_eq!(serve_args(), vec!["serve".to_string()]);
+    fn serve_args_pass_explicit_default_port() {
+        assert_eq!(
+            serve_args(),
+            vec![
+                "serve".to_string(),
+                "--port".to_string(),
+                trusty_review::service::DEFAULT_PORT.to_string(),
+            ]
+        );
     }
 }

--- a/crates/trusty-review/src/commands/service.rs
+++ b/crates/trusty-review/src/commands/service.rs
@@ -1,0 +1,251 @@
+//! Handler for `trusty-review service` (macOS launchd integration).
+//!
+//! Why: `stable_set()` in trusty-installer marks trusty-review
+//! `ManageStrategy::Launchd`, and `tctl start trusty-review` calls
+//! `launchctl bootstrap … com.trusty.trusty-review.plist` — but until this
+//! module existed no code path in the repository ever WROTE that plist, so a
+//! fresh-machine `tctl start` hard-failed for the review daemon (#2557). This
+//! subcommand supplies the missing launchd install/uninstall/status/logs
+//! mechanics, mirroring the established `trusty-search` / `trusty-analyze`
+//! `service` pattern so `tctl install` (#2556) and `tctl start` have a real
+//! plist to bootstrap.
+//! What: on macOS routes `ServiceAction` to a single launchd operation via the
+//! shared `trusty_common::launchd` module; the agent runs `trusty-review serve`
+//! (the long-lived HTTP webhook daemon). On non-macOS the entry point returns a
+//! clear error rather than emitting confusing plist output.
+//! Test: `service_label_matches_tctl_convention` and `serve_args_are_serve`
+//! (macOS-only, pure) pin the load-bearing label + args; the install/uninstall
+//! paths are side-effecting `launchctl` calls exercised manually (never in the
+//! test suite, per the hermetic-test rule).
+
+use anyhow::Result;
+use clap::Subcommand;
+
+/// Subcommand actions for `trusty-review service`.
+///
+/// Why: launchd is the canonical way to keep the long-lived review webhook
+/// daemon alive on macOS; wrapping the plist mechanics in `service`
+/// subcommands keeps operators from hand-editing XML and gives `tctl` a stable
+/// `trusty-review service install` hook to call.
+/// What: each variant maps to one launchd operation (or `tail -F` for Logs).
+/// Test: `cargo run -p trusty-review -- service --help` lists the four actions;
+/// on Linux any action returns Err with the platform message.
+#[derive(Debug, Clone, Subcommand)]
+pub enum ServiceAction {
+    /// Install the LaunchAgent plist and load it.
+    Install,
+    /// Unload the LaunchAgent and remove the plist.
+    Uninstall,
+    /// Show launchd status for the agent.
+    Status,
+    /// Tail the launchd stdout / stderr logs.
+    Logs,
+}
+
+/// Reverse-DNS label for the LaunchAgent.
+///
+/// Why: this MUST equal `trusty_installer`'s
+/// `plist_label::plist_label_for("trusty-review")` (which derives
+/// `com.trusty.trusty-review` by convention) or `tctl start`/`tctl stop` would
+/// target a launchd job that `service install` never created. Pinning the
+/// constant here and asserting it in a test guards that cross-crate contract.
+/// What: the `Label` key value and the `<label>.plist` base name.
+/// Test: `service_label_matches_tctl_convention`.
+#[cfg(target_os = "macos")]
+pub const LAUNCHD_LABEL: &str = "com.trusty.trusty-review";
+
+/// Dispatch a `trusty-review service <action>` invocation.
+///
+/// Why: launchd is macOS-specific; on other platforms we return a clear error
+/// rather than emitting confusing plist / launchctl failures.
+/// What: macOS routes to install / uninstall / status / logs. Non-macOS bails
+/// with a platform message.
+/// Test: on Linux every action returns Err (see module doc); the macOS paths
+/// are side-effecting and validated manually.
+pub fn run_service_action(action: &ServiceAction) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        match action {
+            ServiceAction::Install => service_install(),
+            ServiceAction::Uninstall => service_uninstall(),
+            ServiceAction::Status => service_status(),
+            ServiceAction::Logs => service_logs(),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = action;
+        anyhow::bail!(
+            "`trusty-review service` is only supported on macOS — \
+             use your distro's service manager (systemd, OpenRC, etc.) directly."
+        );
+    }
+}
+
+/// The daemon serve args embedded in the launchd plist.
+///
+/// Why: the launchd agent must start the long-lived HTTP webhook server, which
+/// is `trusty-review serve`; centralising the args keeps install and the label
+/// contract in one testable place.
+/// What: returns `["serve"]`.
+/// Test: `serve_args_are_serve`.
+#[cfg(target_os = "macos")]
+fn serve_args() -> Vec<String> {
+    vec!["serve".to_string()]
+}
+
+/// Resolve the log directory for the review launchd agent.
+///
+/// Why: align with the other trusty-* daemons by writing logs under
+/// `~/.trusty-review/logs/` (matches `trusty-analyze`'s convention).
+/// What: returns `~/.trusty-review/logs`, creating it on demand.
+/// Test: side-effecting; exercised transitively by `service install`.
+#[cfg(target_os = "macos")]
+fn launchd_log_dir() -> Result<std::path::PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve $HOME"))?;
+    let dir = home.join(".trusty-review").join("logs");
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Build the shared `LaunchdConfig` for the review daemon.
+///
+/// Why: install / uninstall / status all need the same label, exe path, args,
+/// and log directory; building it once keeps them in agreement.
+/// What: resolves the current executable and log dir and returns a
+/// `LaunchdConfig` that runs `trusty-review serve`, kept alive always with a
+/// 10-second restart throttle and a seeded daemon `PATH` (#1298).
+/// Test: side-effecting resolution; exercised transitively by every macOS
+/// `service` subcommand.
+#[cfg(target_os = "macos")]
+fn launchd_config() -> Result<trusty_common::launchd::LaunchdConfig> {
+    use trusty_common::launchd::{KeepAlive, LaunchdConfig};
+
+    let exe = std::env::current_exe()
+        .map_err(|e| anyhow::anyhow!("could not resolve current exe: {e}"))?;
+    let log_dir = launchd_log_dir()?;
+    Ok(LaunchdConfig {
+        label: LAUNCHD_LABEL.to_string(),
+        exe_path: exe,
+        args: serve_args(),
+        log_dir,
+        keep_alive: KeepAlive::Always,
+        throttle_interval: 10,
+        env_vars: Vec::new(),
+        fd_limit: None,
+    }
+    .with_daemon_path())
+}
+
+#[cfg(target_os = "macos")]
+fn service_install() -> Result<()> {
+    let cfg = launchd_config()?;
+    cfg.install()
+        .map_err(|e| anyhow::anyhow!("install LaunchAgent plist: {e}"))?;
+    let plist_path = cfg.plist_path()?;
+    println!("[ok] Wrote LaunchAgent plist: {}", plist_path.display());
+
+    cfg.bootstrap()
+        .map_err(|e| anyhow::anyhow!("launchctl bootstrap: {e}"))?;
+    let domain = format!("gui/{}", trusty_common::launchd::current_uid());
+    println!(
+        "[ok] trusty-review service installed and started ({LAUNCHD_LABEL} loaded into {domain})."
+    );
+    println!(
+        "  Logs:    {}\n  Status:  trusty-review service status",
+        cfg.log_dir.display()
+    );
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn service_uninstall() -> Result<()> {
+    let cfg = launchd_config()?;
+    let plist_path = cfg.plist_path()?;
+    if plist_path.exists() {
+        // bootout is best-effort: a not-loaded agent is fine here.
+        let _ = cfg.bootout();
+        std::fs::remove_file(&plist_path)
+            .map_err(|e| anyhow::anyhow!("remove {}: {e}", plist_path.display()))?;
+        println!(
+            "[ok] trusty-review service uninstalled ({} removed).",
+            plist_path.display()
+        );
+    } else {
+        println!(
+            "[skip] {} not installed — nothing to do",
+            plist_path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn service_status() -> Result<()> {
+    let uid = trusty_common::launchd::current_uid();
+    let target = format!("gui/{uid}/{LAUNCHD_LABEL}");
+    let output = std::process::Command::new("launchctl")
+        .args(["print", &target])
+        .output()
+        .map_err(|e| anyhow::anyhow!("launchctl print failed: {e}"))?;
+    if output.status.success() {
+        println!("{}", String::from_utf8_lossy(&output.stdout));
+        Ok(())
+    } else {
+        eprintln!("  Install with: trusty-review service install");
+        anyhow::bail!(
+            "{target} is not loaded ({})",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn service_logs() -> Result<()> {
+    let log_dir = launchd_log_dir()?;
+    let stdout_log = log_dir.join("stdout.log");
+    let stderr_log = log_dir.join("stderr.log");
+    if !stdout_log.exists() && !stderr_log.exists() {
+        eprintln!(
+            "[skip] No logs at {} yet — start the service first.",
+            log_dir.display()
+        );
+        return Ok(());
+    }
+    // Defer to `tail -F` for a familiar follow-mode experience.
+    let status = std::process::Command::new("tail")
+        .arg("-F")
+        .arg(&stdout_log)
+        .arg(&stderr_log)
+        .status()
+        .map_err(|e| anyhow::anyhow!("tail failed: {e}"))?;
+    if !status.success() {
+        anyhow::bail!("tail exited with {status}");
+    }
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    /// Why: the label is a cross-crate contract — `tctl` derives
+    /// `com.trusty.trusty-review` in `plist_label_for` and bootstraps THAT
+    /// plist; a drift here silently breaks `tctl start trusty-review`.
+    /// What: asserts the constant equals the convention-derived label.
+    /// Test: this is the test.
+    #[test]
+    fn service_label_matches_tctl_convention() {
+        assert_eq!(LAUNCHD_LABEL, "com.trusty.trusty-review");
+    }
+
+    /// Why: the launchd agent must start the HTTP webhook daemon, i.e.
+    /// `trusty-review serve`; a wrong arg would load a plist that runs the
+    /// wrong (or no) subcommand.
+    /// What: asserts the embedded args are exactly `["serve"]`.
+    /// Test: this is the test.
+    #[test]
+    fn serve_args_are_serve() {
+        assert_eq!(serve_args(), vec!["serve".to_string()]);
+    }
+}

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -82,9 +82,9 @@ enum Commands {
     /// Reads the `http_addr` discovery file written at daemon bind time and
     /// prints the address in one of three machine-readable formats:
     ///
-    ///   trusty-review port          → bare port:  7880
-    ///   trusty-review port --addr   → host:port:  127.0.0.1:7880
-    ///   trusty-review port --json   → JSON:       {"addr":"127.0.0.1","port":7880}
+    ///   trusty-review port          → bare port:  7890
+    ///   trusty-review port --addr   → host:port:  127.0.0.1:7890
+    ///   trusty-review port --json   → JSON:       {"addr":"127.0.0.1","port":7890}
     ///
     /// Exits non-zero when no daemon discovery file is found so shell
     /// substitution (`$(trusty-review port)`) fails safely.
@@ -98,7 +98,7 @@ enum Commands {
         json: bool,
     },
 
-    /// Start the long-lived HTTP webhook server (port 7880 by default).
+    /// Start the long-lived HTTP webhook server (port 7890 by default).
     ///
     /// Exposes:
     ///   GET  /health                  — liveness + dep status
@@ -167,6 +167,9 @@ enum Commands {
     /// (running `trusty-review serve`) and bootstraps it; `uninstall` unloads
     /// and removes it; `status` / `logs` inspect the running agent. macOS-only.
     /// `tctl install` / `tctl start` call `install` on the operator's behalf.
+    /// Requires the `http-server` feature (enabled by default) since it
+    /// daemonizes `trusty-review serve`.
+    #[cfg(feature = "http-server")]
     Service {
         #[command(subcommand)]
         action: commands::service::ServiceAction,
@@ -204,6 +207,7 @@ fn main() -> Result<()> {
     // `service` drives macOS launchd (`launchctl`) synchronously — dispatch
     // before the async runtime so `tctl install`/`tctl start` hooks pay no
     // tokio start-up cost for a plist write.
+    #[cfg(feature = "http-server")]
     if let Commands::Service { action } = &cli.command {
         return commands::service::run_service_action(action);
     }
@@ -231,6 +235,7 @@ async fn async_main(cli: Cli) -> Result<()> {
         // exhaustive match.
         Commands::Port { .. } => unreachable!("port dispatched before async_main"),
         // `service` is likewise dispatched synchronously in `main`.
+        #[cfg(feature = "http-server")]
         Commands::Service { .. } => unreachable!("service dispatched before async_main"),
     }
 }

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -160,6 +160,17 @@ enum Commands {
     /// `config keys set/list/test/unset` surface shared by every trusty-*
     /// binary (epic #2400 Wave 1, #2405).
     Config(trusty_common::inference::config::ConfigCommand),
+
+    /// Manage the macOS launchd LaunchAgent for the review daemon (#2557).
+    ///
+    /// `install` writes `~/Library/LaunchAgents/com.trusty.trusty-review.plist`
+    /// (running `trusty-review serve`) and bootstraps it; `uninstall` unloads
+    /// and removes it; `status` / `logs` inspect the running agent. macOS-only.
+    /// `tctl install` / `tctl start` call `install` on the operator's behalf.
+    Service {
+        #[command(subcommand)]
+        action: commands::service::ServiceAction,
+    },
 }
 
 // ─── Entry point ──────────────────────────────────────────────────────────────
@@ -190,6 +201,13 @@ fn main() -> Result<()> {
         return handle_port(format);
     }
 
+    // `service` drives macOS launchd (`launchctl`) synchronously — dispatch
+    // before the async runtime so `tctl install`/`tctl start` hooks pay no
+    // tokio start-up cost for a plist write.
+    if let Commands::Service { action } = &cli.command {
+        return commands::service::run_service_action(action);
+    }
+
     let rt = tokio::runtime::Runtime::new().context("build tokio runtime")?;
     rt.block_on(async_main(cli))
 }
@@ -212,5 +230,7 @@ async fn async_main(cli: Cli) -> Result<()> {
         // called; this arm is unreachable at runtime but required for
         // exhaustive match.
         Commands::Port { .. } => unreachable!("port dispatched before async_main"),
+        // `service` is likewise dispatched synchronously in `main`.
+        Commands::Service { .. } => unreachable!("service dispatched before async_main"),
     }
 }

--- a/crates/trusty-review/src/service/mod.rs
+++ b/crates/trusty-review/src/service/mod.rs
@@ -37,10 +37,21 @@ use crate::service::webhook::handle_github_webhook;
 
 /// Default listen port for the trusty-review daemon.
 ///
-/// Why: must be distinct from sibling daemons (7878 = search, 7879 = analyze).
-/// What: 7880 per spec REV-803.
-/// Test: `serve_help_shows_default_port` checks the CLI default.
-pub const DEFAULT_PORT: u16 = 7880;
+/// Why: must be distinct from EVERY sibling daemon's default, not just the
+/// ones spec REV-803 originally enumerated. The original default (7880) was
+/// discovered live (#2566 review) to collide with trusty-mpm's
+/// `DEFAULT_DAEMON_ADDR` (`crates/trusty-mpm/src/core/discovery.rs`) — the
+/// `tm` daemon binds `127.0.0.1:7880` on every managed machine, so a launchd
+/// agent that runs `trusty-review serve` with no explicit `--port` collided
+/// with it and crash-looped (`KeepAlive::Always`, 10s throttle) on install.
+/// 7890 is verified free against the full known set: 7070 = trusty-memory,
+/// 7878 = trusty-search, 7879 = trusty-analyze, 7788 = trusty-console,
+/// 7880 = trusty-mpm (`tm`).
+/// What: 7890 (superseding the REV-803 spec's original 7880).
+/// Test: `serve_help_shows_default_port` checks the CLI default;
+/// `default_port_does_not_collide_with_known_siblings` pins uniqueness
+/// against the full known-port table.
+pub const DEFAULT_PORT: u16 = 7890;
 
 /// Resolve the dotfile discovery path `~/.trusty-review/http_addr`.
 ///
@@ -246,5 +257,55 @@ mod tests {
         write_addr_to_path(&target, "127.0.0.1:7880").expect("write_addr_to_path");
         let content = std::fs::read_to_string(&target).expect("read back");
         assert_eq!(content, "127.0.0.1:7880");
+    }
+
+    /// Cross-crate port-uniqueness contract (#2566 review finding).
+    ///
+    /// Why: the original `DEFAULT_PORT` value (7880) silently collided with
+    /// trusty-mpm's `DEFAULT_DAEMON_ADDR` (`core/discovery.rs`), which is bound
+    /// on every managed machine — a launchd agent running `trusty-review serve`
+    /// crash-looped against the live `tm` daemon on install. This table encodes
+    /// every sibling daemon's known default port (pointer-commented to its real
+    /// source constant, mirroring `trusty-installer`'s `plist_label.rs` override
+    /// table) so a future edit to `DEFAULT_PORT` that reintroduces a collision
+    /// fails this test instead of shipping a crash-loop.
+    /// What: asserts `DEFAULT_PORT` is absent from the known-sibling-ports list.
+    /// Test: this is the test.
+    #[test]
+    fn default_port_does_not_collide_with_known_siblings() {
+        // (binary, port, source-of-truth pointer)
+        let known_siblings: &[(&str, u16, &str)] = &[
+            (
+                "trusty-memory",
+                7070,
+                "trusty-memory/src/http_server.rs::DEFAULT_HTTP_PORT",
+            ),
+            (
+                "trusty-search",
+                7878,
+                "trusty-search/src/service/constants.rs::DEFAULT_PORT",
+            ),
+            (
+                "trusty-analyze",
+                7879,
+                "trusty-analyze/src/service/events.rs::DEFAULT_PORT",
+            ),
+            (
+                "trusty-console",
+                7788,
+                "trusty-console/src/lib.rs::DEFAULT_PORT",
+            ),
+            (
+                "trusty-mpm",
+                7880,
+                "trusty-mpm/src/core/discovery.rs::DEFAULT_DAEMON_ADDR",
+            ),
+        ];
+        for (binary, port, source) in known_siblings {
+            assert_ne!(
+                DEFAULT_PORT, *port,
+                "trusty-review DEFAULT_PORT {DEFAULT_PORT} collides with {binary}'s {port} ({source})"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

First installer turnkey slice (milestone **Session Manager**, umbrella #2555). Composes two children so `tctl install` + `tctl start` bring up the full daemon set on a fresh machine without any undocumented manual `<binary> service install` step.

### #2557 — trusty-review / trusty-console shipped no launchd code
Both were marked `ManageStrategy::Launchd` in `stable_set()`, so `tctl start` `launchctl bootstrap`s `com.trusty.trusty-{review,console}.plist` — but no code path ever wrote those plists, so `tctl start` hard-failed for 2 of 5 daemon members on a fresh machine.

**Finding:** both binaries expose a **real long-lived HTTP daemon** (`trusty-review serve` behind the default `http-server` feature; `trusty-console serve`, graceful SIGTERM). Per the issue's minimal-correct rule (*add plist support where a real daemon mode exists*), this adds a `service install/uninstall/status/logs` subcommand to each, mirroring the `trusty-search` / `trusty-analyze` pattern and reusing the labels already reserved in `plist_label.rs` (`com.trusty.trusty-review`, `com.trusty.trusty-console`).

**Design decision left to the owner (umbrella open question):** whether trusty-console should be launchd-managed *or* process-managed like trusty-mpm (`OwnVerb`) is **not** resolved here. This makes the **existing** `Launchd` classification *function*; it does not decide it is the right lifecycle model. If the owner chooses process-management, the console would need its own `start`/`stop` verbs and the stable-set strategy would flip to `OwnVerb`. Documented inline in `trusty-console/src/service.rs`.

### #2556 — `tctl install` never bootstrapped the shared daemons' plists
`install_all` only turnkeyed trusty-mpm. New `service_bootstrap` module wires each daemon member's own `<binary> service install` into the post-install hooks (search/memory/analyze + review/console), **reusing the daemon's audited launchd logic** rather than duplicating plist XML. Properties:
- **Fail-soft** — a failure logs a warning and continues (never aborts the install), matching the `plist_bootstrap` precedent.
- **Idempotent + non-clobbering** — an existing plist is left untouched (skip-with-message), so a re-run neither overwrites an operator-customised plist nor needlessly restarts a healthy daemon.
- **Opt-out** — `tctl install --no-service` or `TCTL_NO_SERVICE_BOOTSTRAP=1`.
- Search **FDA guidance** (`macos_signing::post_install_search`) preserved.
- `tctl start`'s *"plist must already exist"* assumption relaxed to *"bootstrap if present, else run `service install`"* for tctl-managed members (`lifecycle.rs`).

## Safety / testability
Every side effect is behind a `ServiceEnv` seam (the `FakeNoopTmuxDriver` pattern). The decision logic is unit-tested against an in-memory fake — **no test touches `~/Library/LaunchAgents` or the host's live `com.trusty.*` daemons**. All launchctl/plist paths are macOS-gated and side-effecting (never invoked in the suite).

## Verification (raw)
- `cargo build --workspace` → `BUILD_EXIT=0`
- `cargo test --workspace` → all pass except one **pre-existing ephemeral-port flake** (`trusty-console proxy::routes::tests::test_connect_retry_recovers_on_second_attempt`, `ConnectionRefused` race; passes in isolation; not touched by this PR)
- `cargo test -p trusty-installer service_bootstrap` → 10 passed; new cli flag test passes
- review/console `service::tests` (label + serve-args) → passed
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo fmt --check` → clean
- `bash scripts/check_line_cap.sh` → 0 violations (new files 152/152/209 SLOC)
- `bash scripts/check_test_pointers.sh` → 0 dangling pointers
- `tctl install --help` shows `--no-service`; `trusty-{review,console} service --help` list install/uninstall/status/logs

Closes #2557
Closes #2556

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools