### PR TITLE
refactor(trusty-mpm,tga): retire duplicate Bedrock ports onto trusty-common::inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9808,8 +9808,6 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "async-trait",
- "aws-config",
- "aws-sdk-bedrockruntime",
  "blake3",
  "chrono",
  "clap",
@@ -11079,9 +11077,6 @@ version = "0.19.7"
 dependencies = [
  "anyhow",
  "async-trait",
- "aws-config",
- "aws-sdk-bedrockruntime",
- "aws-types",
  "axum",
  "chrono",
  "clap",

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -29,8 +29,10 @@ path = "src/main.rs"
 
 [dependencies]
 # Shared CLI help system (issue #216): declarative `help.yaml` loader +
-# Jaro-Winkler "did you mean?" suggester. Only the `cli-help` feature is
-# enabled; tga is otherwise independent of trusty-common.
+# Jaro-Winkler "did you mean?" suggester. `cli-help`/`update-check`/`config-cli`
+# are always on; `bedrock-client` (the shared Converse adapter, #2407) is added
+# only under tga's own `bedrock` feature below (#2411) so the AWS SDK stack
+# stays opt-in.
 trusty-common = { workspace = true, features = ["cli-help", "update-check", "config-cli"] }
 # Async runtime
 tokio = { workspace = true }
@@ -98,15 +100,19 @@ async-trait = { workspace = true }
 # Async stream combinators (for bounded-concurrency LLM fallback)
 futures = { workspace = true }
 
-# Optional: AWS Bedrock runtime client for the Bedrock LLM provider.
-aws-config = { workspace = true, optional = true }
-aws-sdk-bedrockruntime = { workspace = true, optional = true }
-
 [features]
 default = []
 # Enable the AWS Bedrock LLM classifier provider. Without this feature,
 # `--provider bedrock` returns a configuration error explaining the build.
-bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime"]
+#
+# As of #2411 the Bedrock wire integration (region resolution, the AWS
+# credential chain, and the Converse request/response conversion) is no longer
+# a private aws-sdk port here — it bridges onto the shared
+# `trusty_common::inference::bedrock` Converse adapter (#2407), so this feature
+# just turns on the commons `bedrock-client` feature, which pulls the AWS SDK
+# stack in ONE place. The direct `aws-config`/`aws-sdk-bedrockruntime` deps
+# were dropped.
+bedrock = ["trusty-common/bedrock-client"]
 
 [dev-dependencies]
 # HTTP mocking for async reqwest tests

--- a/crates/trusty-git-analytics/src/classify/tiers/bedrock.rs
+++ b/crates/trusty-git-analytics/src/classify/tiers/bedrock.rs
@@ -7,7 +7,16 @@
 //! Why: organizations on AWS often prefer Bedrock (private VPC, IAM-based
 //! auth, no per-request data egress to a third-party SaaS) over OpenRouter
 //! or OpenAI for LLM access. Making it an optional feature keeps the
-//! default binary lean for users who don't need it.
+//! default binary lean for users who don't need it. As of #2411 the Bedrock
+//! wire integration (region resolution, the AWS credential chain, and the
+//! Converse request/response conversion) is NO LONGER a private aws-sdk
+//! `InvokeModel` port here — it bridges onto the shared
+//! `trusty_common::inference::bedrock` Converse adapter (#2407), the same one
+//! trusty-code and the trusty-mpm SM provider consume, so the wire mechanics
+//! live in exactly one place. This module keeps the tga-specific policy:
+//! sequential best-effort batch classification (never crashes on a bad
+//! payload) and the shared `SYSTEM_PROMPT`/[`LlmVerdict`] parsing contract
+//! from `llm.rs`.
 
 use crate::classify::tiers::ClassificationResult;
 // Shared prompt and verdict types live in `llm.rs` so both the HTTP and
@@ -21,14 +30,15 @@ use crate::classify::tiers::llm::{LlmVerdict, SYSTEM_PROMPT};
 /// AWS Bedrock-backed LLM classifier targeting Anthropic Claude on Bedrock.
 ///
 /// Uses the AWS default credential provider chain (env vars, profile,
-/// SSO, IMDS, etc.). Requests are formatted as the Anthropic Messages API
-/// with `anthropic_version: "bedrock-2023-05-31"` per Bedrock's contract.
+/// SSO, IMDS, etc.), resolved lazily by the shared
+/// `trusty_common::inference::bedrock::BedrockAdapter` on the first call.
 pub struct BedrockClassifier {
     /// Bedrock model id (e.g. `anthropic.claude-3-haiku-20240307-v1:0`).
     #[allow(dead_code)] // only read under the `bedrock` feature.
     pub(crate) model: String,
+    /// Shared Converse adapter (owns region + lazily-built AWS client).
     #[cfg(feature = "bedrock")]
-    client: aws_sdk_bedrockruntime::Client,
+    inner: trusty_common::inference::BedrockAdapter,
 }
 
 /// Default Bedrock model id when the caller doesn't override it.
@@ -40,26 +50,22 @@ impl BedrockClassifier {
     /// # Errors
     ///
     /// Returns `Err` with a clear message when the binary was built without
-    /// `--features bedrock`. With the feature enabled, this returns `Ok`
-    /// after the AWS credential chain initializes.
+    /// `--features bedrock`. With the feature enabled, this always returns
+    /// `Ok` — the shared adapter defers AWS credential/client construction to
+    /// the first `classify_one` call (#2245 lazy-construction guarantee).
     ///
     /// Why: surfacing the missing-feature condition as an error (rather
     /// than silently no-oping) helps operators diagnose deployments.
-    /// What: loads default AWS config and constructs the SDK client.
+    /// What: builds a [`trusty_common::inference::BedrockAdapter`] pinned to
+    /// the default region resolution (`TRUSTY_AWS_REGION` > `AWS_REGION` >
+    /// `us-east-1`).
     /// Test: building with and without `--features bedrock` verifies both
     /// arms compile and behave correctly at startup.
     #[cfg(feature = "bedrock")]
     pub async fn new(model: &str) -> Result<Self, String> {
-        // Use the explicit BehaviorVersion (latest()) form to avoid the
-        // deprecation on `load_from_env` without taking the cross-version
-        // feature flag.
-        let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .load()
-            .await;
-        let client = aws_sdk_bedrockruntime::Client::new(&config);
         Ok(Self {
             model: model.to_string(),
-            client,
+            inner: trusty_common::inference::BedrockAdapter::new(None),
         })
     }
 
@@ -68,22 +74,16 @@ impl BedrockClassifier {
     /// Why: operators who specify a `region:` in the `llm:` config section
     /// need a way to override the SDK's default region selection without
     /// mutating environment variables.
-    /// What: loads AWS config with the supplied region pinned, then
-    /// constructs the SDK client. Falls back to `new(model)` semantics when
-    /// `region` is `None`.
+    /// What: builds a [`trusty_common::inference::BedrockAdapter`] pinned to
+    /// `region` (falling back to the shared adapter's own resolution when
+    /// `None`, matching `new`'s semantics).
     /// Test: indirectly tested via config-driven construction when `region:`
     /// is set in the `llm:` YAML block.
     #[cfg(feature = "bedrock")]
     pub async fn with_region(model: &str, region: Option<&str>) -> Result<Self, String> {
-        let mut builder = aws_config::defaults(aws_config::BehaviorVersion::latest());
-        if let Some(r) = region {
-            builder = builder.region(aws_config::Region::new(r.to_string()));
-        }
-        let config = builder.load().await;
-        let client = aws_sdk_bedrockruntime::Client::new(&config);
         Ok(Self {
             model: model.to_string(),
-            client,
+            inner: trusty_common::inference::BedrockAdapter::new(region),
         })
     }
 
@@ -116,7 +116,8 @@ impl BedrockClassifier {
     ///
     /// Why: the LLM tier is best-effort; a single bad payload must not
     /// poison an entire batch.
-    /// What: sequentially invokes `InvokeModel` for each message.
+    /// What: sequentially invokes the shared Converse adapter for each
+    /// message via [`Self::classify_one`].
     /// Test: integration-tested when AWS credentials are present; stubbed
     /// path tested in `bedrock_stub_returns_error_without_feature`.
     #[cfg(feature = "bedrock")]
@@ -141,80 +142,46 @@ impl BedrockClassifier {
         vec![None; messages.len()]
     }
 
-    /// Classify a single commit message via Bedrock InvokeModel.
+    /// Classify a single commit message via the shared Bedrock Converse
+    /// adapter.
     ///
-    /// Why: encapsulates the AWS SDK call and JSON parsing so
+    /// Why: encapsulates the shared-adapter call and JSON parsing so
     /// `classify_batch_bedrock` stays readable.
-    /// What: builds an Anthropic Messages API payload (Bedrock wire format),
-    /// invokes the model, parses the response into a shared [`LlmVerdict`],
-    /// and maps it to a [`ClassificationResult`].
+    /// What: builds a shared [`trusty_common::inference::ChatRequest`] with
+    /// the same `SYSTEM_PROMPT`/user-message/temperature(0.0)/max_tokens(256)
+    /// the pre-#2411 `InvokeModel` port sent, delegates to
+    /// [`trusty_common::inference::BedrockAdapter::chat`] (Converse API —
+    /// AWS documents the same on-demand model ids as `InvokeModel` for
+    /// Converse, so [`DEFAULT_BEDROCK_MODEL`] and any bare foundation-model id
+    /// resolve identically), and parses the response text into the shared
+    /// [`LlmVerdict`].
     /// Test: integration path requires live AWS credentials; the stub path
     /// falls through to the `#[cfg(not(feature = "bedrock"))]` branch above.
     #[cfg(feature = "bedrock")]
     async fn classify_one(&self, message: &str) -> Option<ClassificationResult> {
         use crate::core::models::ClassificationMethod;
-        use aws_sdk_bedrockruntime::primitives::Blob;
         use tracing::warn;
+        use trusty_common::inference::{ChatMessage, ChatRequest, InferenceAdapter};
 
-        // Use SYSTEM_PROMPT from llm.rs so both paths send identical
-        // instructions and return the same JSON shape (including complexity).
-        let body = serde_json::json!({
-            "anthropic_version": "bedrock-2023-05-31",
-            "max_tokens": 256,
-            "temperature": 0.0,
-            "system": SYSTEM_PROMPT,
-            "messages": [
-                {"role": "user", "content": format!("Classify this commit message:\n\n{message}")}
-            ]
-        });
-        let body_bytes = match serde_json::to_vec(&body) {
-            Ok(b) => b,
-            Err(e) => {
-                warn!(error = %e, "bedrock body serialize failed");
-                return None;
-            }
-        };
+        let mut req = ChatRequest::new(
+            self.model.clone(),
+            vec![
+                ChatMessage::system(SYSTEM_PROMPT),
+                ChatMessage::user(format!("Classify this commit message:\n\n{message}")),
+            ],
+        );
+        req.temperature = Some(0.0);
+        req.max_tokens = Some(256);
 
-        let resp = match self
-            .client
-            .invoke_model()
-            .model_id(&self.model)
-            .content_type("application/json")
-            .accept("application/json")
-            .body(Blob::new(body_bytes))
-            .send()
-            .await
-        {
+        let resp = match self.inner.chat(&req).await {
             Ok(r) => r,
             Err(e) => {
-                warn!(error = %e, "bedrock invoke_model failed");
+                warn!(error = %e, "bedrock converse call failed");
                 return None;
             }
         };
 
-        let raw = resp.body.into_inner();
-
-        #[derive(serde::Deserialize)]
-        struct BedrockResponse {
-            content: Vec<ContentBlock>,
-        }
-        #[derive(serde::Deserialize)]
-        struct ContentBlock {
-            #[serde(default)]
-            text: Option<String>,
-        }
-        let parsed: BedrockResponse = match serde_json::from_slice(&raw) {
-            Ok(p) => p,
-            Err(e) => {
-                warn!(error = %e, "bedrock response decode failed");
-                return None;
-            }
-        };
-        let text = parsed
-            .content
-            .into_iter()
-            .find_map(|b| b.text)
-            .unwrap_or_default();
+        let text = resp.first_text().unwrap_or_default();
 
         // Parse using the shared LlmVerdict from llm.rs so the Bedrock
         // path produces the same category/subcategory/confidence/complexity

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -63,7 +63,13 @@ slack = ["dep:tokio-tungstenite", "dep:futures-util"]
 # `bedrock` gates the Session Manager's AWS Bedrock provider (SM-2, DOC-14 §5.1).
 # NOT in `default`: it pulls the heavy `aws-sdk-bedrockruntime` stack, so the
 # Bedrock provider weight is strictly opt-in. Build/test with `--features bedrock`.
-bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-types"]
+#
+# As of #2411 the SM Bedrock provider is a thin bridge onto the shared
+# `trusty_common::inference::bedrock` Converse adapter (#2407) instead of a
+# private aws-sdk port — so this feature now just turns on the commons
+# `bedrock-client` feature, which pulls the AWS SDK stack in ONE place. The
+# direct `aws-config`/`aws-sdk-bedrockruntime`/`aws-types` deps were dropped here.
+bedrock = ["trusty-common/bedrock-client"]
 
 # `sm-memory` gates the Session Manager's dedicated memory palace (SM-4, DOC-14
 # §8). NOT in `default`: it turns on `trusty-common/memory-core`, which pulls the
@@ -213,11 +219,12 @@ trusty-progress = { workspace = true }
 
 # ── Optional dependencies (feature-gated) ────────────────────────────────────
 
-# bedrock feature (SM-2): AWS Bedrock Converse provider for the Session Manager.
-# Opt-in only — keeps the heavy aws-sdk stack out of the default build.
-aws-config             = { workspace = true, optional = true }
-aws-sdk-bedrockruntime = { workspace = true, optional = true }
-aws-types              = { workspace = true, optional = true }
+# bedrock feature (SM-2): the AWS SDK stack is no longer a direct dependency
+# here. As of #2411 the SM Bedrock provider bridges onto
+# `trusty_common::inference::bedrock` (the shared #2407 Converse adapter), so the
+# `aws-config`/`aws-sdk-bedrockruntime`/`aws-types` crates are pulled transitively
+# via `trusty-common/bedrock-client` (see the `bedrock` feature above) — the one
+# place the AWS SDK weight lives now.
 
 # daemon feature
 axum = { workspace = true, optional = true }

--- a/crates/trusty-mpm/src/core/sm/providers/bedrock.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/bedrock.rs
@@ -2,72 +2,58 @@
 //!
 //! Why: AWS-resident operators can use Bedrock-hosted models (IAM auth, private
 //! VPC, no third-party SaaS egress) without an OpenRouter or Anthropic key.
-//! This is the SM's third provider, ported from trusty-review's
-//! `llm/bedrock/mod.rs` (text path only — the SM does not need the tool-use
-//! plumbing). It lives behind the `bedrock` cargo feature so the heavy
-//! `aws-sdk-bedrockruntime` dependency is opt-in (§5.1).
-//! What: [`BedrockProvider`] calls `Converse` (non-streaming), maps
-//! [`LlmRequest`] → Bedrock request, extracts text + usage, measures latency,
-//! computes cost, and retries bounded times on transient errors. Config errors
-//! (ModelNotFound/AccessDenied/Validation) never retry and always alarm. The
-//! `us.`/`eu.`/… cross-region inference-profile prefix is required and validated
-//! up front so a bare foundation-model id fails early as [`SmLlmError::Validation`].
+//! This is the SM's third provider. As of #2411 the Bedrock *wire* integration
+//! (region resolution, the AWS credential chain, and the Converse
+//! message/usage/response conversion) is NO LONGER a private aws-sdk port here:
+//! it lives once in the shared `trusty_common::inference::bedrock` Converse
+//! adapter (#2407). This module is the thin bridge that remains — it wraps that
+//! shared [`BedrockAdapter`] and re-applies the SM-specific POLICY the commons
+//! adapter deliberately does not carry: the required cross-region
+//! inference-profile prefix validation (§5.1), the typed [`SmLlmError`]
+//! classification the resolver's retry/alarm loop depends on (§5.3), bounded
+//! retry with backoff, and per-call cost/latency telemetry (§5.5).
+//! What: [`BedrockProvider`] holds a lazily-constructed [`BedrockAdapter`] and
+//! maps [`LlmRequest`] → shared [`ChatRequest`], delegates the Converse call,
+//! maps a shared [`InferenceError`] back to [`SmLlmError`] via [`map_sdk_error`]
+//! (unchanged substring classifier — the commons `DisplayErrorContext` string
+//! carries the same AWS error-class markers the old raw SDK string did), extracts
+//! text + usage, measures latency, computes cost, and retries bounded times on
+//! transient errors. Config errors (ModelNotFound/AccessDenied/Validation) never
+//! retry and always alarm. The `us.`/`eu.`/… inference-profile prefix is required
+//! and validated up front so a bare foundation-model id fails early as
+//! [`SmLlmError::Validation`].
 //! Test: `bedrock_region_resolution`, `bedrock_prefix_validation`,
-//! `bedrock_provider_stores_model_and_region`,
-//! `bedrock_no_credentials_returns_error`,
-//! `bedrock_empty_messages_is_validation_error` in tests; cost estimation is
-//! covered centrally in `pricing_tests.rs`.
+//! `bedrock_provider_stores_model_and_region`, `bedrock_empty_messages_is_validation_error`,
+//! and `map_sdk_error_*` in `bedrock_tests.rs`; the live Converse wire path is
+//! covered by the shared adapter's `#[ignore]`-gated coverage in
+//! `trusty_common::inference::bedrock`. Cost estimation is covered centrally in
+//! `pricing_tests.rs`.
+//!
+//! [`InferenceError`]: trusty_common::inference::InferenceError
 
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use aws_config::BehaviorVersion;
-use aws_sdk_bedrockruntime::Client as BedrockClient;
-use aws_sdk_bedrockruntime::types::{
-    ContentBlock, ConversationRole, InferenceConfiguration, Message, SystemContentBlock,
-};
 use tracing::{debug, warn};
+use trusty_common::inference::{
+    BedrockAdapter, ChatMessage as InferenceChatMessage, ChatRequest, InferenceAdapter,
+};
 
 use super::{LlmProvider, LlmRequest, LlmResponse, error::SmLlmError, pricing};
 
-/// Region env var: trusty-specific override (highest precedence).
-const ENV_REGION_TRUSTY: &str = "TRUSTY_AWS_REGION";
-/// Region env var: standard AWS fallback.
-const ENV_REGION_AWS: &str = "AWS_REGION";
-/// Default AWS region when neither env var is set.
-const DEFAULT_REGION: &str = "us-east-1";
 /// Required cross-region inference-profile prefixes (§5.1).
 const INFERENCE_PROFILE_PREFIXES: &[&str] = &["us.", "eu.", "ap.", "jp.", "global."];
 /// Retry attempts for transient errors.
 const MAX_RETRIES: u32 = 3;
 
-// ─── Region & validation ───────────────────────────────────────────────────────
-
-/// Resolve the AWS region: `explicit` > `TRUSTY_AWS_REGION` > `AWS_REGION` >
-/// `us-east-1`.
-///
-/// Why: operators may set either env var; the trusty-specific one wins (§5.1).
-/// What: returns the first non-empty value in precedence order.
-/// Test: `bedrock_region_resolution`.
-pub fn resolve_bedrock_region(explicit: Option<&str>) -> String {
-    if let Some(r) = explicit.filter(|s| !s.is_empty()) {
-        return r.to_string();
-    }
-    for var in [ENV_REGION_TRUSTY, ENV_REGION_AWS] {
-        if let Ok(val) = std::env::var(var) {
-            let val = val.trim().to_string();
-            if !val.is_empty() {
-                return val;
-            }
-        }
-    }
-    DEFAULT_REGION.to_string()
-}
+// ─── Validation ────────────────────────────────────────────────────────────────
 
 /// Validate that `model_id` carries a cross-region inference-profile prefix.
 ///
 /// Why: Bedrock rejects bare foundation-model ids at runtime; we surface that
-/// at construction so operators see it immediately (§5.1).
+/// at construction so operators see it immediately (§5.1). The shared commons
+/// adapter deliberately does NOT enforce this (it serves every consumer), so the
+/// SM keeps its own up-front check here.
 /// What: `Ok(())` if any [`INFERENCE_PROFILE_PREFIXES`] matches; else
 /// [`SmLlmError::Validation`].
 /// Test: `bedrock_prefix_validation`.
@@ -89,132 +75,102 @@ fn validate_model_id(model_id: &str) -> Result<(), SmLlmError> {
 /// AWS Bedrock Converse provider for the SM.
 ///
 /// Why: satisfies [`LlmProvider`] over Bedrock so the SM works with IAM-based
-/// auth and no SaaS API key (§5.1).
-/// What: holds a `BedrockClient`, the bare model id, and the resolved region.
-/// `complete` calls `Converse`, extracts text + usage, retries transient
+/// auth and no SaaS API key (§5.1), while the Converse wire mechanics live in
+/// the shared `trusty_common::inference::bedrock` adapter (#2411 dedup).
+/// What: holds the shared [`BedrockAdapter`] (which owns the resolved region and
+/// a lazily-built AWS client — construction touches no AWS credentials, #2245)
+/// and the bare, validated model id. `complete` maps to the shared request,
+/// delegates the Converse call, extracts text + usage, and retries transient
 /// errors up to [`MAX_RETRIES`].
-/// Test: `bedrock_provider_stores_model_and_region`,
-/// `bedrock_no_credentials_returns_error`.
+/// Test: `bedrock_provider_stores_model_and_region`.
+#[derive(Debug)]
 pub struct BedrockProvider {
-    client: BedrockClient,
+    /// Shared Converse adapter (owns region + lazy AWS client).
+    inner: BedrockAdapter,
     /// The bare (validated) model id, e.g. `us.anthropic.claude-sonnet-4-6`.
     pub model: String,
-    region: String,
 }
 
 impl BedrockProvider {
     /// Construct using the standard AWS credential chain.
     ///
-    /// Why: the SDK default chain covers env vars, `~/.aws/credentials`, IMDS,
-    /// and SSO without code changes.
-    /// What: validates the model id, resolves the region, loads AWS config, and
-    /// builds the client. Returns [`SmLlmError::Validation`] on a bad model id.
-    /// Async because credential loading may touch the filesystem / IMDS.
-    /// Test: `bedrock_prefix_validation` (validation path; no network).
+    /// Why: the SDK default chain (resolved lazily by the shared adapter on the
+    /// first call) covers env vars, `~/.aws/credentials`, IMDS, and SSO without
+    /// code changes. Region resolution (`region` > `TRUSTY_AWS_REGION` >
+    /// `AWS_REGION` > `us-east-1`) is the shared adapter's, unchanged from the
+    /// SM's prior local copy.
+    /// What: validates the model id, then builds a [`BedrockAdapter`] pinned to
+    /// the resolved region. Returns [`SmLlmError::Validation`] on a bad model id.
+    /// Stays `async` for call-site compatibility (the resolver `.await`s it);
+    /// the AWS client build is deferred to the first `complete`.
+    /// Test: `bedrock_prefix_validation` (validation path; no network),
+    /// `bedrock_provider_stores_model_and_region`.
     pub async fn new(model: impl Into<String>, region: Option<&str>) -> Result<Self, SmLlmError> {
         let model = model.into();
         validate_model_id(&model)?;
-        let region_str = resolve_bedrock_region(region);
-        let config = aws_config::defaults(BehaviorVersion::latest())
-            .region(aws_config::meta::region::RegionProviderChain::first_try(
-                aws_types::region::Region::new(region_str.clone()),
-            ))
-            .load()
-            .await;
-        let client = BedrockClient::new(&config);
         Ok(Self {
-            client,
+            inner: BedrockAdapter::new(region),
             model,
-            region: region_str,
         })
     }
 
-    /// Construct from a pre-built client (testing only; skips validation).
-    ///
-    /// Why: tests inject a `no_credentials()` client to drive provider logic
-    /// without AWS.
-    /// What: stores the client verbatim.
-    /// Test: `bedrock_provider_stores_model_and_region`,
-    /// `bedrock_no_credentials_returns_error`.
-    #[cfg(test)]
-    pub fn from_client(
-        client: BedrockClient,
-        model: impl Into<String>,
-        region: impl Into<String>,
-    ) -> Self {
-        Self {
-            client,
-            model: model.into(),
-            region: region.into(),
-        }
-    }
-
     /// The AWS region the client is configured for.
+    ///
+    /// Why: exposed for diagnostics / telemetry.
+    /// What: delegates to the shared adapter's resolved region.
+    /// Test: `bedrock_provider_stores_model_and_region`, `bedrock_region_resolution`.
     pub fn region(&self) -> &str {
-        &self.region
+        self.inner.region()
     }
 
-    /// Execute a single Converse call.
+    /// Execute a single Converse call via the shared adapter.
     ///
     /// Why: extracted so retry logic in `complete` is visible/testable.
-    /// What: builds a `Converse` request from `req`, sends it, and maps SDK
-    /// errors to [`SmLlmError`] by inspecting the message text.
-    /// Test: error-mapping exercised via `bedrock_no_credentials_returns_error`.
+    /// What: rejects an empty message list up front (deterministic client-side
+    /// [`SmLlmError::Validation`]), converts `req` into the shared [`ChatRequest`]
+    /// (system prompt prepended as a `system`-role message the commons converter
+    /// diverts into Converse's system array; `assistant` role → assistant, all
+    /// other roles → user, matching the SM's prior mapping), delegates to the
+    /// shared adapter, and maps a shared [`InferenceError`] back to a typed
+    /// [`SmLlmError`] via [`map_sdk_error`].
+    /// Test: `bedrock_empty_messages_is_validation_error`; error-mapping via
+    /// `map_sdk_error_*`.
     async fn call_once(&self, req: &LlmRequest) -> Result<LlmResponse, SmLlmError> {
         let start = Instant::now();
 
-        let mut system_blocks: Vec<SystemContentBlock> = Vec::new();
-        if !req.system.is_empty() {
-            system_blocks.push(SystemContentBlock::Text(req.system.clone()));
-        }
-
-        let mut messages: Vec<Message> = Vec::new();
-        for m in &req.messages {
-            let role = if m.role == "assistant" {
-                ConversationRole::Assistant
-            } else {
-                ConversationRole::User
-            };
-            let msg = Message::builder()
-                .role(role)
-                .content(ContentBlock::Text(m.content.clone()))
-                .build()
-                .map_err(|e| SmLlmError::Validation(format!("build Bedrock Message: {e}")))?;
-            messages.push(msg);
-        }
-        if messages.is_empty() {
+        if req.messages.is_empty() {
             return Err(SmLlmError::Validation(
                 "LlmRequest contains no user/assistant messages".to_string(),
             ));
         }
 
-        let inference = InferenceConfiguration::builder()
-            // Saturating, sound conversion: `req.max_tokens` is a `u32`, but the
-            // Bedrock SDK wants an `i32`. A naive `as i32` would wrap any value
-            // above `i32::MAX` into a negative token budget; clamp to `i32::MAX`
-            // instead (`unwrap_or` here cannot panic).
-            .max_tokens(i32::try_from(req.max_tokens).unwrap_or(i32::MAX))
-            .temperature(req.temperature)
-            .build();
-
-        let mut sdk_req = self
-            .client
-            .converse()
-            .model_id(&req.model)
-            .inference_config(inference)
-            .set_messages(Some(messages));
-        if !system_blocks.is_empty() {
-            sdk_req = sdk_req.set_system(Some(system_blocks));
+        let mut messages: Vec<InferenceChatMessage> = Vec::with_capacity(req.messages.len() + 1);
+        if !req.system.is_empty() {
+            messages.push(InferenceChatMessage::system(req.system.clone()));
+        }
+        for m in &req.messages {
+            let msg = if m.role == "assistant" {
+                InferenceChatMessage::assistant(m.content.clone())
+            } else {
+                InferenceChatMessage::user(m.content.clone())
+            };
+            messages.push(msg);
         }
 
-        let resp = sdk_req
-            .send()
+        let mut chat_req = ChatRequest::new(req.model.clone(), messages);
+        chat_req.temperature = Some(req.temperature);
+        chat_req.max_tokens = Some(req.max_tokens);
+
+        let resp = self
+            .inner
+            .chat(&chat_req)
             .await
-            .map_err(|e| map_sdk_error(e.to_string(), &req.model, &self.region))?;
+            .map_err(|e| map_sdk_error(e.to_string(), &req.model, self.region()))?;
 
         let latency_ms = start.elapsed().as_millis() as u64;
-        let text = extract_converse_text(&resp).unwrap_or_default();
-        let (input_tokens, output_tokens) = extract_token_usage(&resp);
+        let text = resp.first_text().unwrap_or_default();
+        let usage = resp.usage();
+        let (input_tokens, output_tokens) = (usage.prompt_tokens, usage.completion_tokens);
         let cost_usd = pricing::estimate_cost_usd(&req.model, input_tokens, output_tokens);
 
         Ok(LlmResponse {
@@ -228,13 +184,18 @@ impl BedrockProvider {
     }
 }
 
-/// Map a Bedrock SDK error string to the right [`SmLlmError`] variant.
+/// Map a Bedrock error string to the right [`SmLlmError`] variant.
 ///
-/// Why: the AWS SDK surfaces typed errors as strings here; classifying them
-/// keeps retry/alarm policy correct (§5.3).
+/// Why: the resolver's retry/alarm loop (§5.3) must distinguish config errors
+/// (never retry, always alarm) from transient ones (retry with backoff). The
+/// shared adapter collapses every Converse failure into `InferenceError::Provider`,
+/// but its message wraps the full AWS source chain via `DisplayErrorContext`, so
+/// the same AWS error-class markers the SM matched on the raw SDK string are
+/// still present — this substring classifier is unchanged from the pre-#2411
+/// local port.
 /// What: substring-matches the lowercased message to the matching variant,
 /// defaulting unknown errors to retryable `Transport`.
-/// Test: exercised by `bedrock_no_credentials_returns_error`.
+/// Test: `map_sdk_error_classifies_*`.
 fn map_sdk_error(msg: String, model: &str, region: &str) -> SmLlmError {
     let lower = msg.to_lowercase();
     if lower.contains("resourcenotfound") || lower.contains("no such model") {
@@ -280,13 +241,13 @@ impl LlmProvider for BedrockProvider {
     /// What: calls `call_once`; retries up to [`MAX_RETRIES`] while
     /// `is_retryable()`; returns other errors immediately. Logs cost/usage to
     /// stderr.
-    /// Test: `bedrock_no_credentials_returns_error` (error path),
-    /// `bedrock_empty_messages_is_validation_error` (validation path).
+    /// Test: `bedrock_empty_messages_is_validation_error` (validation path);
+    /// retry/error classification via `map_sdk_error_*`.
     async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, SmLlmError> {
         debug!(
             provider = "bedrock",
             model = %req.model,
-            region = %self.region,
+            region = %self.region(),
             "sm bedrock complete request"
         );
         let mut attempt = 0u32;
@@ -314,47 +275,6 @@ impl LlmProvider for BedrockProvider {
             }
         }
     }
-}
-
-// ─── Response helpers ───────────────────────────────────────────────────────────
-
-/// Join the `Text` content blocks of a Converse response.
-///
-/// Why: Converse wraps content in typed blocks; the SM only needs the text.
-/// What: joins `Text` blocks with newlines; `None` when empty.
-/// Test: covered by `bedrock_no_credentials_returns_error`.
-fn extract_converse_text(
-    resp: &aws_sdk_bedrockruntime::operation::converse::ConverseOutput,
-) -> Option<String> {
-    let msg = resp.output()?.as_message().ok()?;
-    let mut out = String::new();
-    for block in msg.content() {
-        if let ContentBlock::Text(t) = block {
-            if !out.is_empty() {
-                out.push('\n');
-            }
-            out.push_str(t);
-        }
-    }
-    if out.is_empty() { None } else { Some(out) }
-}
-
-/// Extract `(input_tokens, output_tokens)` from the Converse usage.
-///
-/// Why: needed for cost estimation and telemetry (§5.5).
-/// What: reads `usage.inputTokens`/`outputTokens`; `(0, 0)` when absent.
-/// Test: covered by `bedrock_no_credentials_returns_error`.
-fn extract_token_usage(
-    resp: &aws_sdk_bedrockruntime::operation::converse::ConverseOutput,
-) -> (u32, u32) {
-    resp.usage()
-        .map(|u| {
-            (
-                u.input_tokens().max(0) as u32,
-                u.output_tokens().max(0) as u32,
-            )
-        })
-        .unwrap_or((0, 0))
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/core/sm/providers/bedrock_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/bedrock_tests.rs
@@ -1,39 +1,45 @@
 //! Unit tests for the SM Bedrock provider (`bedrock` feature only).
 //!
-//! Why: extracted from `bedrock.rs` to keep that file under the 500-SLOC cap.
-//! All tests are unit-level — no real AWS calls. The `complete`/`call_once`
-//! path is exercised with a `no_credentials()` client, which errors inside the
-//! SDK before any TCP connection, proving the error-mapping wiring.
-//! What: region resolution, model-id validation, construction, and the
-//! no-credentials `complete` error path. Cost estimation is covered centrally
-//! in `pricing_tests.rs`.
+//! Why: as of #2411 the Bedrock Converse wire path lives in the shared
+//! `trusty_common::inference::bedrock` adapter (covered by its own offline
+//! conversion tests + an `#[ignore]`-gated live call). What remains SM-specific
+//! — and what these tests pin — is the POLICY the bridge re-applies on top of
+//! the shared adapter: cross-region inference-profile prefix validation, region
+//! resolution, the deterministic empty-message guard, and the
+//! [`SmLlmError`] classification the resolver's retry/alarm loop depends on. All
+//! tests are offline: construction is lazy (no AWS client is built), and the
+//! error-classification tests drive the pure `map_sdk_error` string classifier
+//! directly rather than forcing a real SDK failure.
+//! What: region resolution, model-id validation, offline construction, the
+//! empty-message validation path, and error classification.
 //! Test: included as `#[cfg(test)] mod tests` via `#[path]` from `bedrock.rs`.
 
-use super::{BedrockProvider, LlmProvider, LlmRequest, resolve_bedrock_region, validate_model_id};
-use crate::core::sm::providers::{ChatMessage, SmLlmError};
-use aws_config::BehaviorVersion;
-use aws_sdk_bedrockruntime::Client as BedrockClient;
+use super::{BedrockProvider, LlmProvider, LlmRequest, map_sdk_error, validate_model_id};
+use crate::core::sm::providers::SmLlmError;
 
-/// Build a `no_credentials()` Bedrock client for offline tests.
-///
-/// Why: `complete`/`call_once` need a client, but tests must not touch AWS; a
-/// no-credentials client fails in the SDK before any network I/O.
-/// What: loads a default config with a fixed region and no credentials.
-/// Test: used by `bedrock_*` tests below.
-async fn no_creds_client() -> BedrockClient {
-    let config = aws_config::defaults(BehaviorVersion::latest())
-        .region(aws_types::region::Region::new("us-east-1"))
-        .no_credentials()
-        .load()
-        .await;
-    BedrockClient::new(&config)
-}
+/// Why: region resolution (`explicit` > env > `us-east-1`) is the shared
+/// adapter's, but the SM must keep exposing the resolved region through
+/// `BedrockProvider::region()`; pin that the explicit region flows through and
+/// the empty/absent cases default to `us-east-1`.
+/// What: constructs providers (offline — the AWS client is lazy) and asserts
+/// `region()`.
+/// Test: this is the test.
+#[tokio::test]
+async fn bedrock_region_resolution() {
+    let explicit = BedrockProvider::new("us.anthropic.claude-haiku", Some("eu-west-1"))
+        .await
+        .expect("construct");
+    assert_eq!(explicit.region(), "eu-west-1");
 
-#[test]
-fn bedrock_region_resolution() {
-    assert_eq!(resolve_bedrock_region(Some("eu-west-1")), "eu-west-1");
-    assert_eq!(resolve_bedrock_region(Some("")), "us-east-1");
-    assert_eq!(resolve_bedrock_region(None), "us-east-1");
+    // NOTE: this asserts the default only holds when neither TRUSTY_AWS_REGION
+    // nor AWS_REGION is set in the test environment. The shared adapter's own
+    // tests cover the env-var precedence exhaustively.
+    if std::env::var("TRUSTY_AWS_REGION").is_err() && std::env::var("AWS_REGION").is_err() {
+        let empty = BedrockProvider::new("us.anthropic.claude-haiku", Some(""))
+            .await
+            .expect("construct");
+        assert_eq!(empty.region(), "us-east-1");
+    }
 }
 
 #[test]
@@ -53,62 +59,41 @@ fn bedrock_prefix_validation() {
     assert!(!err.is_retryable());
 }
 
-/// Why: the `from_client` accessors must report name/region without AWS calls.
-/// What: builds a no-creds client and checks `name()`/`region()`.
+/// Why: construction must report name/region/model without touching AWS (the
+/// shared adapter's client is lazy).
+/// What: builds a provider and checks `name()`/`region()`/`model`.
 /// Test: no network.
 #[tokio::test]
 async fn bedrock_provider_stores_model_and_region() {
-    let provider = BedrockProvider::from_client(
-        no_creds_client().await,
-        "us.anthropic.claude-haiku",
-        "us-east-1",
-    );
+    let provider = BedrockProvider::new("us.anthropic.claude-haiku", Some("us-east-1"))
+        .await
+        .expect("construct");
     assert_eq!(provider.name(), "bedrock");
     assert_eq!(provider.region(), "us-east-1");
     assert_eq!(provider.model, "us.anthropic.claude-haiku");
 }
 
-/// Why: a misconfigured AWS environment must yield a typed [`SmLlmError`] (the
-/// error-mapping path in `map_sdk_error`), never a panic.
-/// What: calls `complete` on a no-credentials client and asserts it returns an
-/// error mentioning credentials/Bedrock.
-/// Test: the SDK errors before any TCP connection — no real network.
+/// Why: a bad model id must fail at construction, before any AWS work.
+/// What: `new` with a bare (non-prefixed) id returns `Validation`.
+/// Test: no network.
 #[tokio::test]
-async fn bedrock_no_credentials_returns_error() {
-    let provider = BedrockProvider::from_client(
-        no_creds_client().await,
-        "us.anthropic.claude-sonnet-4-6",
-        "us-east-1",
-    );
-    let req = LlmRequest {
-        model: "us.anthropic.claude-sonnet-4-6".to_string(),
-        system: "sys".to_string(),
-        messages: vec![ChatMessage {
-            role: "user".to_string(),
-            content: "go".to_string(),
-        }],
-        temperature: 0.3,
-        max_tokens: 256,
-    };
-    let err = provider.complete(req).await.expect_err("must fail offline");
-    let msg = format!("{err}").to_lowercase();
-    assert!(
-        msg.contains("bedrock") || msg.contains("credential") || msg.contains("access"),
-        "error should mention bedrock/credentials, got: {msg}"
-    );
+async fn bedrock_new_rejects_bare_model_id() {
+    let err = BedrockProvider::new("anthropic.claude-sonnet-4-6", None)
+        .await
+        .expect_err("bare id must fail validation");
+    assert!(matches!(err, SmLlmError::Validation(_)));
 }
 
 /// Why: an empty message list is a deterministic client-side validation error,
-/// not something to send upstream.
+/// not something to send upstream — the bridge must reject it before delegating
+/// to the shared adapter (so this stays offline).
 /// What: calls `complete` with no messages and asserts a `Validation` error.
 /// Test: no network.
 #[tokio::test]
 async fn bedrock_empty_messages_is_validation_error() {
-    let provider = BedrockProvider::from_client(
-        no_creds_client().await,
-        "us.anthropic.claude-sonnet-4-6",
-        "us-east-1",
-    );
+    let provider = BedrockProvider::new("us.anthropic.claude-sonnet-4-6", Some("us-east-1"))
+        .await
+        .expect("construct");
     let req = LlmRequest {
         model: "us.anthropic.claude-sonnet-4-6".to_string(),
         system: "sys".to_string(),
@@ -118,4 +103,74 @@ async fn bedrock_empty_messages_is_validation_error() {
     };
     let err = provider.complete(req).await.expect_err("empty must fail");
     assert!(matches!(err, SmLlmError::Validation(_)));
+}
+
+/// Why: the resolver's retry/alarm loop classifies via `is_retryable`/`is_alarm`;
+/// after #2411 the SM classifies the shared adapter's
+/// `InferenceError::Provider` message string (which wraps the AWS
+/// `DisplayErrorContext` source chain). Pin that the real AWS error-class
+/// markers still route to the right [`SmLlmError`] variant.
+/// What: feeds representative commons-shaped error strings through
+/// `map_sdk_error` and asserts the variant + retry/alarm classification.
+/// Test: this is the test (pure — no client, no network).
+#[test]
+fn map_sdk_error_classifies_aws_markers() {
+    let model = "us.anthropic.claude-sonnet-4-6";
+    let region = "us-east-1";
+    let wrap = |ctx: &str| {
+        format!(
+            "inference provider error: Converse call failed (model={model}, region={region}): {ctx}"
+        )
+    };
+
+    // Access denied / credential failures → non-retryable alarm.
+    for ctx in [
+        "AccessDeniedException: User is not authorized to perform bedrock:InvokeModel",
+        "NoCredentialsError: no credentials in the property bag",
+        "dispatch failure: could not load credentials",
+    ] {
+        let err = map_sdk_error(wrap(ctx), model, region);
+        assert!(
+            matches!(err, SmLlmError::AccessDenied(_)),
+            "{ctx} => {err:?}"
+        );
+        assert!(err.is_alarm() && !err.is_retryable());
+    }
+
+    // ResourceNotFound → model-not-found alarm.
+    let err = map_sdk_error(
+        wrap("ResourceNotFoundException: model not available"),
+        model,
+        region,
+    );
+    assert!(matches!(err, SmLlmError::ModelNotFound(_)));
+    assert!(err.is_alarm());
+
+    // Throttling → retryable rate-limit.
+    let err = map_sdk_error(
+        wrap("ThrottlingException: too many requests"),
+        model,
+        region,
+    );
+    assert!(matches!(err, SmLlmError::RateLimited));
+    assert!(err.is_retryable());
+
+    // 5xx service errors → retryable upstream.
+    let err = map_sdk_error(wrap("ServiceUnavailableException"), model, region);
+    assert!(matches!(err, SmLlmError::Upstream { status: 503, .. }));
+    assert!(err.is_retryable());
+
+    // ValidationException → non-retryable alarm.
+    let err = map_sdk_error(
+        wrap("ValidationException: malformed request"),
+        model,
+        region,
+    );
+    assert!(matches!(err, SmLlmError::Validation(_)));
+    assert!(err.is_alarm());
+
+    // Anything unrecognised → retryable transport (safe default).
+    let err = map_sdk_error(wrap("connection reset by peer"), model, region);
+    assert!(matches!(err, SmLlmError::Transport(_)));
+    assert!(err.is_retryable());
 }


### PR DESCRIPTION
## Summary

Epic #2400 Wave 2 — retires the private AWS Bedrock ports in `trusty-mpm`'s Session Manager and `tga`'s tier-4 LLM classifier onto the shared `trusty_common::inference::bedrock` Converse adapter (#2407, shipped via PR #2541), following the same bridge pattern `trusty-code` adopted.

- **trusty-mpm** (`crates/trusty-mpm/src/core/sm/providers/bedrock.rs`): `BedrockProvider` now wraps a `trusty_common::inference::BedrockAdapter` instead of a private `aws_sdk_bedrockruntime::Client`. All SM-specific policy is preserved unchanged: cross-region inference-profile prefix validation (`us.`/`eu.`/`ap.`/`jp.`/`global.`), the typed `SmLlmError` classification the resolver's retry/alarm loop depends on, bounded retry with backoff, and per-call cost/latency telemetry (DOC-14 §5.1/§5.3/§5.5). Region resolution (`TRUSTY_AWS_REGION` > `AWS_REGION` > `us-east-1`) and credential-chain semantics are unchanged — they now live once in the shared adapter.
- **tga** (`crates/trusty-git-analytics/src/classify/tiers/bedrock.rs`): `BedrockClassifier` bridges the same way. Sequential best-effort batch classification and the shared `SYSTEM_PROMPT`/`LlmVerdict` parsing contract from `llm.rs` are unchanged. The wire call moves from a hand-built `InvokeModel` (Anthropic Messages API JSON) to the shared adapter's `Converse` call — AWS documents the same on-demand model ids for both APIs, so `DEFAULT_BEDROCK_MODEL` (`anthropic.claude-3-haiku-20240307-v1:0`) and any bare foundation-model id resolve identically.
- Both crates' `bedrock` cargo feature now turns on commons' `bedrock-client` feature instead of declaring `aws-config`/`aws-sdk-bedrockruntime`/`aws-types` directly — the AWS SDK stack lives in exactly one place in the workspace.

## Per-crate before/after

| Crate | Before | After |
|---|---|---|
| trusty-mpm | Direct `aws_sdk_bedrockruntime::Client`, hand-rolled region/credential/Converse-request logic (~230 SLOC) | Thin bridge (`BedrockAdapter` + policy layer), same public API (`BedrockProvider::new`/`with_region`/`region`/`complete`) |
| tga | Direct `aws_sdk_bedrockruntime::Client`, hand-rolled `InvokeModel` Anthropic-Messages-format request/response (~150 SLOC) | Thin bridge (`BedrockAdapter` + policy layer), same public API (`BedrockClassifier::new`/`with_region`/`classify_batch_bedrock`) |

Deps dropped from both `Cargo.toml`s: `aws-config`, `aws-sdk-bedrockruntime`, `aws-types` (trusty-mpm only). No files deleted outright — both `bedrock.rs` files were rewritten in place as bridges (the issue's "deleted" acceptance criterion is satisfied in spirit: zero duplicate Bedrock wire logic remains; both files now contain only the thin adapter + policy layer).

## Capability gaps found

None requiring a STOP. The commons adapter's Converse-based, non-streaming, single-call surface covers everything both consumers used (no streaming, no batch API in the wire layer — tga's "batch" was always sequential single calls). SM-specific retry/alarm classification and tga's sequential-batch behavior are fully preserved in the bridge layer, not degraded.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — clean (two unrelated, timing/load-sensitive flakes — `trusty-agents::telegram::tests::telegram_pid_guard_garbage_is_overwritten` and `trusty-search::service::warm_boot::probe::tests::probe_all_volumes_multi_volume_no_fast_starvation` — both confirmed pass in isolation, both in crates untouched by this change)
- [x] `cargo test -p trusty-mpm` — 0 failed (incl. `--features bedrock`)
- [x] `cargo test -p tga` — 0 failed (default features and `--features bedrock`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt` / `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] `bash scripts/check_test_pointers.sh` — 0 dangling pointers

Closes #2411

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools