### PR TITLE
feat(trusty-mpm): tm manager phase-1a — scaffold, status rollup, portfolio palace

### DIFF
--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -90,6 +90,19 @@ bedrock = ["trusty-common/bedrock-client"]
 # `cargo build --features sm-memory` does not.
 sm-memory = ["trusty-common/memory-core"]
 
+# `manager-memory` gates the Layer-3 `tm manager` PORTFOLIO memory palace (WI-5,
+# #2582, DOC-36 §3.4) — a single portfolio-scoped `trusty-memory` palace holding
+# digest history, escalation dispositions, and portfolio chat turns, distinct
+# from the SM palace and every per-project palace. Like `sm-memory` it is NOT in
+# `default`: it turns on `trusty-common/memory-core` (the heavy HNSW/ONNX Memory
+# Palace engine), so a default daemon build pays no ONNX/usearch cost. Without
+# this feature the portfolio palace reports "unavailable" and the manager surface
+# still works (DOC-36 §4 degrade bar). The `daemon::manager::memory` live binding
+# is compiled only under this flag. Build/test with `--features manager-memory`;
+# the `embedder-test-support` dev-dependency below supplies the mock embedder so
+# `cargo test --features manager-memory` runs without the ONNX model.
+manager-memory = ["trusty-common/memory-core"]
+
 # `gui` is intentionally a no-dep CLI-gating feature. The `tm gui` subcommand
 # is ALWAYS available; this flag exists only so the subcommand can optionally
 # advertise itself. The Tauri GUI lives in the separate, publish=false

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -136,11 +136,10 @@ use super::managed_routes::{
     adopt_existing_session, answer_session_decision, decommission_ephemeral_route,
     decommission_managed_session, delete_managed_session, fleet_by_project_route, get_attach_cmd,
     get_managed_session, get_project_registry_route, get_session_activity, list_managed_sessions,
-    list_projects_registry_route, patch_project_registry_route, project_status_route, proxy_focus,
-    proxy_get_focus, proxy_message, proxy_summary, proxy_unfocus, prune_managed_route,
-    prune_worktrees_route, reactivate_managed_session, register_project_registry_route,
-    resume_managed_session, send_to_session, spawn_session, stop_managed_session,
-    stop_managed_session_runtime,
+    list_projects_registry_route, patch_project_registry_route, project_status_route, proxy_router,
+    prune_managed_route, prune_worktrees_route, reactivate_managed_session,
+    register_project_registry_route, resume_managed_session, send_to_session, spawn_session,
+    stop_managed_session, stop_managed_session_runtime,
 };
 // Layer-3 portfolio manager surface (`/api/v1/manager/*`, epic #2109, DOC-36).
 use super::manager::{manager_status_route, manager_version_route};
@@ -335,21 +334,9 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         // TELUI-6 (#1440): the local session-manager PROXY surface — the SAME
         // focus/inject/summarize state machine every channel (Telegram, Slack)
         // binds to, exposed here as plain HTTP so it is `curl`-testable before
-        // any channel connects. Literal segments (`/focus`, `/unfocus`,
-        // `/message`) are registered as their own routes; the two GET routes
-        // take `conversation_key` as a path param, mirroring the `/{id}`
-        // convention used throughout this managed-session block.
-        .route("/api/v1/sessions/proxy/focus", post(proxy_focus))
-        .route(
-            "/api/v1/sessions/proxy/focus/{conversation_key}",
-            get(proxy_get_focus),
-        )
-        .route("/api/v1/sessions/proxy/unfocus", post(proxy_unfocus))
-        .route("/api/v1/sessions/proxy/message", post(proxy_message))
-        .route(
-            "/api/v1/sessions/proxy/summary/{conversation_key}",
-            get(proxy_summary),
-        )
+        // any channel connects. Registrations live with their handlers in
+        // `managed_routes::proxy::proxy_router` and are merged here.
+        .merge(proxy_router())
         // Layer-3 portfolio manager surface (epic #2109, DOC-36 §3.2). Phase 1a:
         // a self-describing capabilities stub + the deterministic (no-LLM)
         // cross-project rollup. Both are read-only and curl-testable with no

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -142,6 +142,8 @@ use super::managed_routes::{
     resume_managed_session, send_to_session, spawn_session, stop_managed_session,
     stop_managed_session_runtime,
 };
+// Layer-3 portfolio manager surface (`/api/v1/manager/*`, epic #2109, DOC-36).
+use super::manager::{manager_status_route, manager_version_route};
 
 /// Typed HTTP response bodies for every endpoint.
 ///
@@ -348,6 +350,12 @@ pub fn router(state: Arc<DaemonState>) -> Router {
             "/api/v1/sessions/proxy/summary/{conversation_key}",
             get(proxy_summary),
         )
+        // Layer-3 portfolio manager surface (epic #2109, DOC-36 §3.2). Phase 1a:
+        // a self-describing capabilities stub + the deterministic (no-LLM)
+        // cross-project rollup. Both are read-only and curl-testable with no
+        // channel/bot token (§4). Later WIs add digest/chat/route-task/escalations.
+        .route("/api/v1/manager/version", get(manager_version_route))
+        .route("/api/v1/manager/status", get(manager_status_route))
         // DOC-35 §10.2/§10.5 (#2378 + #2380): Deliverable/Milestone CRUD, nested
         // under the projects namespace. The literal `/deliverables` and
         // `/milestones` segments come before their `/{id}` param routes so a

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -59,7 +59,7 @@ pub use project_status::{
 pub use proxy::{
     DirectManagedBackend, ProxyFocusRequest, ProxyFocusResponse, ProxyMessageRequest,
     ProxyMessageResponse, ProxySummaryResponse, ProxyTargetWire, ProxyUnfocusRequest,
-    ProxyUnfocusResponse, proxy_focus, proxy_get_focus, proxy_message, proxy_summary,
+    ProxyUnfocusResponse, proxy_focus, proxy_get_focus, proxy_message, proxy_router, proxy_summary,
     proxy_unfocus,
 };
 pub use prune::{

--- a/crates/trusty-mpm/src/daemon/managed_routes/proxy/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/proxy/mod.rs
@@ -367,5 +367,32 @@ pub async fn proxy_summary(
     Json(ProxySummaryResponse::from(outcome)).into_response()
 }
 
+/// Build the sub-router for the local session-manager PROXY surface.
+///
+/// Why: co-locating the five `/api/v1/sessions/proxy/*` route registrations with
+/// their handlers (rather than inlining them in the daemon's monolithic
+/// `api::router`) keeps this cohesive TELUI-6 cluster self-contained and lets
+/// `api::router` compose it with a single `.merge`. Every route here binds the
+/// same [`DaemonState`] the parent router carries, so merging is state-preserving.
+/// What: returns a [`Router`] with the focus/unfocus/message/summary handlers
+/// wired, ready to `.merge` into the daemon router before `.with_state`.
+/// Test: exercised end-to-end by `tests/proxy_routes.rs` (the routes reach the
+/// daemon exactly as before this extraction).
+pub fn proxy_router() -> axum::Router<Arc<DaemonState>> {
+    use axum::routing::{get, post};
+    axum::Router::new()
+        .route("/api/v1/sessions/proxy/focus", post(proxy_focus))
+        .route(
+            "/api/v1/sessions/proxy/focus/{conversation_key}",
+            get(proxy_get_focus),
+        )
+        .route("/api/v1/sessions/proxy/unfocus", post(proxy_unfocus))
+        .route("/api/v1/sessions/proxy/message", post(proxy_message))
+        .route(
+            "/api/v1/sessions/proxy/summary/{conversation_key}",
+            get(proxy_summary),
+        )
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/trusty-mpm/src/daemon/manager/memory.rs
+++ b/crates/trusty-mpm/src/daemon/manager/memory.rs
@@ -1,0 +1,447 @@
+//! Portfolio `trusty-memory` palace provisioning for `tm manager` (WI-5, #2582).
+//!
+//! Why: DOC-36 §3.4 gives the Layer-3 portfolio manager ONE additional
+//! `trusty-memory` palace — scoped to `tm manager` itself, distinct from every
+//! per-project palace — to hold digest history, escalation dispositions, and
+//! portfolio chat-session turns (manager-level observations *about* the
+//! portfolio, never project-scoped facts). §7 Q3 (RESOLVED 2026-07-14) fixes the
+//! provisioning convention: the palace is **auto-created at daemon startup**
+//! (consistent with §3.1's "daemon as source of truth"), idempotently
+//! (create-if-absent, never clobber) — not a separate `tm manager init` step.
+//! Crucially, reaching the memory engine must NEVER be able to fail daemon
+//! startup: if the palace cannot be opened (unwritable root, corrupt store) — or
+//! the heavy `memory-core` engine is not even compiled into this build — the
+//! manager surface stays fully operable and simply reports the palace as
+//! unavailable (DOC-36 §4 degrade-graceful bar). This mirrors the SM palace's
+//! own "log and disable recall, never crash" posture ([`crate::core::sm::memory`]).
+//! What: [`PortfolioPalace`] is the ALWAYS-present handle threaded into
+//! [`crate::daemon::manager::ManagerState`]; it carries the fixed palace id
+//! ([`PORTFOLIO_PALACE_ID`]) plus an availability flag/reason so callers can read
+//! "is the palace usable, and if not why" without any feature-cfg of their own.
+//! Under the opt-in `manager-memory` feature it also owns a live
+//! [`PortfolioMemory`] — a direct `memory-core` library binding (no MCP/network
+//! hop) mirroring [`crate::core::sm::memory::SmMemory`] — that idempotently
+//! ensures the single portfolio palace and offers the minimal remember/recall
+//! surface later phases (digest history, chat turns) build on.
+//! Test: `portfolio_palace_reports_unavailable_without_feature` (default build)
+//! and, under `--features manager-memory`,
+//! `portfolio_palace_provisions_and_is_idempotent` /
+//! `portfolio_memory_remember_then_recall_round_trips` in this file's `tests`.
+
+use std::path::Path;
+
+/// The fixed palace id for the single portfolio-scoped manager palace.
+///
+/// Why: DOC-36 §3.4 mandates exactly ONE portfolio palace, distinct from the
+/// SM palace (`"session-manager"`) and every per-project palace. Pinning the id
+/// to a stable constant makes provisioning idempotent across restarts (the same
+/// id always resolves the same on-disk palace) and makes the scope auditable —
+/// there is no code path here that targets any other id.
+/// What: the string id used for the portfolio palace directory + registry key.
+/// Test: `portfolio_palace_exposes_stable_id`.
+pub const PORTFOLIO_PALACE_ID: &str = "tm-manager-portfolio";
+
+/// Subdirectory under the framework root that holds `tm manager` runtime state.
+///
+/// Why: keeps the portfolio palace under one well-known directory, mirroring how
+/// SM state lives under `<root>/sm` and the managed store under
+/// `<root>/session-manager`. Isolating it means the portfolio palace never
+/// collides with a per-project or SM palace on disk.
+/// What: the `manager` segment joined onto the framework root; the palace itself
+/// lives at `<root>/manager/palace/<PORTFOLIO_PALACE_ID>/`.
+/// Test: exercised via [`PortfolioPalace::provision`] in the feature-gated tests.
+const MANAGER_DATA_SUBDIR: &str = "manager";
+
+/// The daemon-owned handle to the portfolio manager palace.
+///
+/// Why: [`ManagerState`](crate::daemon::manager::ManagerState) needs a single,
+/// always-constructible handle it can thread through regardless of whether the
+/// heavy `memory-core` engine is compiled or reachable — the manager routes must
+/// be able to answer "is the palace available?" on every build. Making the
+/// availability flag + reason live OUTSIDE any feature-cfg means route handlers
+/// (and the `GET /manager/version` capabilities stub) read one plain struct with
+/// no `#[cfg]` of their own.
+/// What: the stable palace `id`, an `available` flag, an optional
+/// human-readable `reason` when unavailable, and — only under `manager-memory` —
+/// the live [`PortfolioMemory`] binding. Built once at daemon startup via
+/// [`Self::provision`]; a failure to open the palace degrades to
+/// `available = false` with the error captured in `reason`, never a panic.
+/// Test: `portfolio_palace_reports_unavailable_without_feature`,
+/// `portfolio_palace_provisions_and_is_idempotent`.
+pub struct PortfolioPalace {
+    /// Stable palace id ([`PORTFOLIO_PALACE_ID`]).
+    id: String,
+    /// Whether the palace is provisioned and usable for reads/writes.
+    available: bool,
+    /// Why the palace is unavailable, when `available` is false (feature not
+    /// compiled, or the open/create failed). `None` when available.
+    reason: Option<String>,
+    /// The live `memory-core` binding — present only when `manager-memory` is
+    /// compiled AND the open/create succeeded.
+    #[cfg(feature = "manager-memory")]
+    memory: Option<PortfolioMemory>,
+}
+
+impl std::fmt::Debug for PortfolioPalace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Deliberately omit the `memory-core` registry handle (not `Debug`, and
+        // uninteresting in logs); the id + availability are the diagnostic bits.
+        f.debug_struct("PortfolioPalace")
+            .field("id", &self.id)
+            .field("available", &self.available)
+            .field("reason", &self.reason)
+            .finish()
+    }
+}
+
+impl PortfolioPalace {
+    /// Provision the portfolio palace under `framework_root`, degrading on any
+    /// failure (WI-5, §7 Q3).
+    ///
+    /// Why: this is the "auto-created at daemon startup" seam. It MUST be
+    /// infallible from the daemon's perspective — a missing feature, an
+    /// unwritable root, or a corrupt store yields an unavailable-but-constructed
+    /// handle, never an error the daemon startup could propagate. Idempotency is
+    /// inherited from the underlying open-or-create: calling this across restarts
+    /// against the same root converges on exactly one palace.
+    /// What: under `manager-memory`, opens (or creates) the single portfolio
+    /// palace at `<framework_root>/manager/palace`; on success stores the live
+    /// binding and marks available, on failure logs a warning and marks
+    /// unavailable with the error string. Without the feature, returns an
+    /// unavailable handle whose reason names the missing feature.
+    /// Test: `portfolio_palace_reports_unavailable_without_feature`,
+    /// `portfolio_palace_provisions_and_is_idempotent`.
+    pub fn provision(framework_root: &Path) -> Self {
+        let id = PORTFOLIO_PALACE_ID.to_string();
+
+        #[cfg(feature = "manager-memory")]
+        {
+            let data_root = framework_root.join(MANAGER_DATA_SUBDIR).join("palace");
+            match PortfolioMemory::open(data_root) {
+                Ok(memory) => Self {
+                    id,
+                    available: true,
+                    reason: None,
+                    memory: Some(memory),
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        "portfolio manager palace unavailable: {e}; palace features disabled"
+                    );
+                    Self {
+                        id,
+                        available: false,
+                        reason: Some(e.to_string()),
+                        memory: None,
+                    }
+                }
+            }
+        }
+
+        #[cfg(not(feature = "manager-memory"))]
+        {
+            let _ = (framework_root, MANAGER_DATA_SUBDIR);
+            Self {
+                id,
+                available: false,
+                reason: Some(
+                    "portfolio memory engine not compiled (build with --features \
+                     manager-memory to enable)"
+                        .to_string(),
+                ),
+            }
+        }
+    }
+
+    /// The stable portfolio palace id.
+    ///
+    /// Why: the `GET /manager/version` capabilities stub and every later-phase
+    /// consumer needs to name the palace without reaching into private state.
+    /// What: returns [`PORTFOLIO_PALACE_ID`].
+    /// Test: `portfolio_palace_exposes_stable_id`.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Whether the palace is provisioned and usable.
+    ///
+    /// Why: manager routes branch on this to decide whether palace-backed
+    /// features (digest history, chat-turn persistence) can run; a `false` here
+    /// is a normal degraded state, not an error.
+    /// What: the `available` flag set by [`Self::provision`].
+    /// Test: `portfolio_palace_reports_unavailable_without_feature`,
+    /// `portfolio_palace_provisions_and_is_idempotent`.
+    pub fn is_available(&self) -> bool {
+        self.available
+    }
+
+    /// Why the palace is unavailable, when it is.
+    ///
+    /// Why: surfacing the reason over the capabilities stub turns "palace down"
+    /// into an actionable curl-observable signal (missing feature vs. failed
+    /// open) rather than a silent gap.
+    /// What: the captured reason string, or `None` when available.
+    /// Test: `portfolio_palace_reports_unavailable_without_feature`.
+    pub fn unavailable_reason(&self) -> Option<&str> {
+        self.reason.as_deref()
+    }
+
+    /// The live `memory-core` binding, when compiled and available.
+    ///
+    /// Why: later phases (WI-3 digest history, WI-4 chat turns) read/write the
+    /// palace through this handle; exposing it lets those phases attach without
+    /// re-plumbing provisioning.
+    /// What: `Some` only under `manager-memory` with a successful open.
+    /// Test: `portfolio_memory_remember_then_recall_round_trips`.
+    #[cfg(feature = "manager-memory")]
+    pub fn memory(&self) -> Option<&PortfolioMemory> {
+        self.memory.as_ref()
+    }
+}
+
+/// Structured errors for the portfolio palace subsystem (library → `thiserror`).
+///
+/// Why: this is library code in `trusty-mpm`; per the workspace convention
+/// library errors are typed `thiserror` enums, never `unwrap()`/`panic!`. A
+/// memory backend that is unavailable must degrade into a matchable error the
+/// provisioning path can log and continue past — never crash the daemon.
+/// What: wraps the palace-lifecycle and recall/remember failure surfaces,
+/// preserving the underlying `anyhow` source chain.
+/// Test: exercised via the feature-gated tests below.
+#[cfg(feature = "manager-memory")]
+#[derive(Debug, thiserror::Error)]
+pub enum PortfolioMemoryError {
+    /// Ensuring the portfolio palace exists (open-or-create) failed.
+    #[error("portfolio palace '{palace}' unavailable: {source}")]
+    Palace {
+        /// The portfolio palace id the operation targeted.
+        palace: String,
+        /// The underlying registry/store error.
+        source: anyhow::Error,
+    },
+
+    /// A recall / remember operation against the portfolio palace failed.
+    #[error("portfolio memory operation '{op}' failed: {source}")]
+    Operation {
+        /// Short operation tag (`"recall"`, `"remember"`) for actionable logs.
+        op: &'static str,
+        /// The underlying engine error.
+        source: anyhow::Error,
+    },
+}
+
+/// The live portfolio palace binding (opt-in `manager-memory` feature).
+///
+/// Why: mirrors [`crate::core::sm::memory::SmMemory`] — a DIRECT `memory-core`
+/// library call (not over MCP) scoped to a single [`PalaceId`] so the manager
+/// can never touch another namespace. Binding one id for the struct's lifetime
+/// makes "manager only ever reads/writes its own portfolio palace" a structural
+/// invariant, not caller discipline (the DOC-36 §3.4 "never duplicates project
+/// state" guarantee).
+/// What: owns the open-handle [`PalaceRegistry`], the on-disk `data_root`, and
+/// the bound `palace_id`. Built via [`Self::open`], which idempotently ensures
+/// exactly one palace. Phase 1a exposes the minimal remember/recall surface
+/// later phases extend; it deliberately does NOT reimplement the SM palace's
+/// full API.
+/// Test: `portfolio_palace_provisions_and_is_idempotent`,
+/// `portfolio_memory_remember_then_recall_round_trips`.
+#[cfg(feature = "manager-memory")]
+#[derive(Clone)]
+pub struct PortfolioMemory {
+    /// Open-handle registry (LRU-bounded). Cheap to clone — state is behind `Arc`.
+    registry: trusty_common::memory_core::registry::PalaceRegistry,
+    /// Directory under which the portfolio palace's `<id>/` subtree lives.
+    data_root: std::path::PathBuf,
+    /// The single palace this instance is bound to. Never changes.
+    palace_id: trusty_common::memory_core::palace::PalaceId,
+}
+
+#[cfg(feature = "manager-memory")]
+mod live {
+    use super::{PORTFOLIO_PALACE_ID, PortfolioMemory, PortfolioMemoryError};
+
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use chrono::Utc;
+    use trusty_common::memory_core::palace::{Palace, PalaceId, RoomType};
+    use trusty_common::memory_core::registry::PalaceRegistry;
+    use trusty_common::memory_core::retrieval::{
+        PalaceHandle, RecallResult, RememberOptions, recall_with_default_embedder,
+    };
+
+    /// Result alias for portfolio memory operations.
+    pub type PortfolioMemoryResult<T> = std::result::Result<T, PortfolioMemoryError>;
+
+    /// Default importance assigned to portfolio-remembered drawers.
+    ///
+    /// Why: manager observations (digest deltas, escalation dispositions) are
+    /// curated, high-signal facts — they should rank above incidental capture but
+    /// need not be pinned at the ceiling. `0.7` matches the SM palace's curated
+    /// importance so ranking behaves consistently across the two daemon palaces.
+    /// What: a `0.0..=1.0` weight passed to the write path; the engine re-clamps.
+    /// Test: exercised by `portfolio_memory_remember_then_recall_round_trips`.
+    const PORTFOLIO_DEFAULT_IMPORTANCE: f32 = 0.7;
+
+    /// How many recall hits the portfolio palace returns by default.
+    ///
+    /// Why: a small fixed top-k keeps phase-1a recall bounded and deterministic;
+    /// later phases can make it configurable if a digest needs a wider window.
+    /// What: the `top_k` passed to `recall_with_default_embedder`.
+    /// Test: `portfolio_memory_remember_then_recall_round_trips`.
+    const PORTFOLIO_RECALL_TOP_K: usize = 8;
+
+    impl PortfolioMemory {
+        /// Open the portfolio palace, idempotently ensuring it exists.
+        ///
+        /// Why: startup must guarantee the single portfolio palace is present
+        /// without erroring when it already exists (the daemon restarts against a
+        /// populated store). Calling this twice — in one process or across
+        /// restarts — must leave EXACTLY ONE palace on disk, never duplicate or
+        /// wipe it.
+        /// What: opens the registry at `data_root`, binds [`PORTFOLIO_PALACE_ID`],
+        /// then eagerly materialises the palace via the race-safe open-or-create
+        /// [`Self::ensure_palace`]. Any failure is wrapped in
+        /// [`PortfolioMemoryError::Palace`].
+        /// Test: `portfolio_palace_provisions_and_is_idempotent`.
+        pub fn open(data_root: impl Into<PathBuf>) -> PortfolioMemoryResult<Self> {
+            let data_root = data_root.into();
+            let palace_id = PalaceId::new(PORTFOLIO_PALACE_ID.to_string());
+            let registry = PalaceRegistry::open(&data_root).map_err(|source| {
+                PortfolioMemoryError::Palace {
+                    palace: palace_id.to_string(),
+                    source,
+                }
+            })?;
+            let me = Self {
+                registry,
+                data_root,
+                palace_id,
+            };
+            me.ensure_palace()?;
+            Ok(me)
+        }
+
+        /// The palace id this instance is bound to.
+        ///
+        /// Why: lets tests and the capabilities stub confirm the bound namespace
+        /// without reaching into private state, keeping the "manager-only" scope
+        /// auditable.
+        /// What: returns the bound [`PalaceId`].
+        /// Test: `portfolio_palace_provisions_and_is_idempotent`.
+        pub fn palace_id(&self) -> &PalaceId {
+            &self.palace_id
+        }
+
+        /// Open-or-create the bound palace, returning a live handle (race-safe).
+        ///
+        /// Why: every operation needs a handle; centralising the idempotent
+        /// open-or-create here means one well-tested path enforces "exactly one
+        /// palace" for both construction and every later call, closing the
+        /// TOCTOU window a `exists()`-then-branch form would open.
+        /// What: returns the cached handle if registered; else tries `open_palace`
+        /// (succeeds when `palace.json` is already on disk, including a concurrent
+        /// creator that just finished) and falls back to the idempotent
+        /// `create_palace`. Both branches are scoped entirely to `self.palace_id`.
+        /// Test: `portfolio_palace_provisions_and_is_idempotent`.
+        fn ensure_palace(&self) -> PortfolioMemoryResult<Arc<PalaceHandle>> {
+            if let Some(handle) = self.registry.get(&self.palace_id) {
+                return Ok(handle);
+            }
+            if let Ok(handle) = self.registry.open_palace(&self.data_root, &self.palace_id) {
+                return Ok(handle);
+            }
+            let palace = Palace {
+                id: self.palace_id.clone(),
+                name: "tm manager (portfolio)".to_string(),
+                description: Some(
+                    "Portfolio-scoped tm manager palace (DOC-36 §3.4): digest \
+                     history, escalation dispositions, and portfolio chat turns — \
+                     manager-level observations about the portfolio, never \
+                     project-scoped facts."
+                        .to_string(),
+                ),
+                created_at: Utc::now(),
+                data_dir: self.data_root.join(self.palace_id.as_str()),
+            };
+            self.registry
+                .create_palace(&self.data_root, palace)
+                .map_err(|source| PortfolioMemoryError::Palace {
+                    palace: self.palace_id.to_string(),
+                    source,
+                })
+        }
+
+        /// Remember a curated, short-fact-tolerant observation into the palace.
+        ///
+        /// Why: the single write path later phases persist digest deltas,
+        /// escalation dispositions, and chat turns through. Routing every write
+        /// through the bound palace id guarantees the manager never writes
+        /// elsewhere; the curated-note preset lets terse observations land past
+        /// the engine's min-token gate.
+        /// What: ensures the palace, then calls `remember_with_options` in the
+        /// `General` room at [`PORTFOLIO_DEFAULT_IMPORTANCE`] with the supplied
+        /// `tags` and [`RememberOptions::note`]. Returns the new drawer's UUID.
+        /// Test: `portfolio_memory_remember_then_recall_round_trips`.
+        pub async fn remember(
+            &self,
+            text: impl Into<String>,
+            tags: Vec<String>,
+        ) -> PortfolioMemoryResult<String> {
+            let handle = self.ensure_palace()?;
+            handle
+                .remember_with_options(
+                    text.into(),
+                    RoomType::General,
+                    tags,
+                    PORTFOLIO_DEFAULT_IMPORTANCE,
+                    RememberOptions::note(),
+                )
+                .await
+                .map(|id| id.to_string())
+                .map_err(|source| PortfolioMemoryError::Operation {
+                    op: "remember",
+                    source,
+                })
+        }
+
+        /// Recall the top-k portfolio observations matching `query`.
+        ///
+        /// Why: feeds later-phase framing ("what changed since the last digest")
+        /// from the manager's own durable observations. Scoped to the portfolio
+        /// palace only, so recall can never surface another namespace's facts.
+        /// What: ensures the palace, then runs `recall_with_default_embedder`
+        /// against the bound handle with [`PORTFOLIO_RECALL_TOP_K`].
+        /// Test: `portfolio_memory_remember_then_recall_round_trips`.
+        pub async fn recall(&self, query: &str) -> PortfolioMemoryResult<Vec<RecallResult>> {
+            let handle = self.ensure_palace()?;
+            recall_with_default_embedder(&handle, query, PORTFOLIO_RECALL_TOP_K)
+                .await
+                .map_err(|source| PortfolioMemoryError::Operation {
+                    op: "recall",
+                    source,
+                })
+        }
+
+        /// Number of palaces currently persisted under the portfolio data root.
+        ///
+        /// Why: the idempotency contract ("create twice → one palace") is most
+        /// directly asserted by counting palaces on disk; exposing this keeps the
+        /// test honest without reaching into registry internals.
+        /// What: lists persisted palaces via [`PalaceRegistry::list_palaces`] and
+        /// returns the count. Wrapped errors use [`PortfolioMemoryError::Palace`].
+        /// Test: `portfolio_palace_provisions_and_is_idempotent`.
+        pub fn persisted_palace_count(&self) -> PortfolioMemoryResult<usize> {
+            PalaceRegistry::list_palaces(&self.data_root)
+                .map(|palaces| palaces.len())
+                .map_err(|source| PortfolioMemoryError::Palace {
+                    palace: self.palace_id.to_string(),
+                    source,
+                })
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "memory_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/manager/memory_tests.rs
+++ b/crates/trusty-mpm/src/daemon/manager/memory_tests.rs
@@ -1,0 +1,102 @@
+//! Tests for the portfolio manager palace provisioning (WI-5, #2582).
+//!
+//! Why: prove the DOC-36 §3.4 / §7 Q3 contract — the portfolio palace is
+//! auto-provisioned idempotently at startup, is scoped to a single stable id,
+//! degrades gracefully (never panics) when the memory engine is unavailable, and
+//! offers a working remember→recall round-trip for later phases to build on. The
+//! feature-gated tests point the engine at a `tempdir` (never `~/.trusty-mpm`)
+//! and seed the MOCK embedder so they run without the ONNX model.
+//! What: a default-build degrade assertion plus, under `manager-memory`,
+//! idempotency and remember/recall round-trip assertions.
+
+use super::*;
+
+/// The palace id is stable regardless of build/availability — it is the DOC-36
+/// §3.4 convention, not a runtime-derived value.
+#[test]
+fn portfolio_palace_exposes_stable_id() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let palace = PortfolioPalace::provision(dir.path());
+    assert_eq!(palace.id(), PORTFOLIO_PALACE_ID);
+    assert_eq!(palace.id(), "tm-manager-portfolio");
+}
+
+/// In a default build (no `manager-memory` feature) the palace is constructed
+/// but reports unavailable with an actionable reason — the daemon still starts,
+/// the manager surface still works (DOC-36 §4 degrade bar).
+#[cfg(not(feature = "manager-memory"))]
+#[test]
+fn portfolio_palace_reports_unavailable_without_feature() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let palace = PortfolioPalace::provision(dir.path());
+    assert!(!palace.is_available());
+    let reason = palace
+        .unavailable_reason()
+        .expect("unavailable palace must name a reason");
+    assert!(
+        reason.contains("manager-memory"),
+        "reason should point at the missing feature: {reason}"
+    );
+}
+
+/// Under the feature, provisioning creates exactly one palace and is idempotent
+/// across repeated startups against the same root (create-if-absent, never
+/// clobber) — the headline §7 Q3 guarantee.
+#[cfg(feature = "manager-memory")]
+#[test]
+fn portfolio_palace_provisions_and_is_idempotent() {
+    use trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock;
+
+    seed_shared_embedder_with_mock();
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // First startup: palace is created and available.
+    let first = PortfolioPalace::provision(dir.path());
+    assert!(first.is_available(), "first provision must be available");
+    let mem = first.memory().expect("live memory under feature");
+    assert_eq!(mem.persisted_palace_count().expect("count"), 1);
+    assert_eq!(mem.palace_id().as_str(), PORTFOLIO_PALACE_ID);
+
+    // Second startup against the same root: still exactly ONE palace.
+    let second = PortfolioPalace::provision(dir.path());
+    assert!(second.is_available());
+    assert_eq!(
+        second
+            .memory()
+            .expect("live memory")
+            .persisted_palace_count()
+            .expect("count"),
+        1,
+        "provisioning twice must yield exactly ONE portfolio palace"
+    );
+}
+
+/// Under the feature, a remembered observation round-trips through recall —
+/// proving the read-write wiring later phases (digest history, chat turns) use
+/// is functional, not a stub.
+#[cfg(feature = "manager-memory")]
+#[tokio::test]
+async fn portfolio_memory_remember_then_recall_round_trips() {
+    use trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock;
+
+    seed_shared_embedder_with_mock();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let palace = PortfolioPalace::provision(dir.path());
+    let mem = palace.memory().expect("live memory under feature");
+
+    mem.remember(
+        "Portfolio digest 2026-07-14: widget shipped, gizmo stalled on review.",
+        vec!["digest".to_string()],
+    )
+    .await
+    .expect("remember");
+
+    let hits = mem
+        .recall("what shipped in the portfolio")
+        .await
+        .expect("recall");
+    assert!(
+        !hits.is_empty(),
+        "a remembered portfolio observation must be recallable"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/manager/mod.rs
+++ b/crates/trusty-mpm/src/daemon/manager/mod.rs
@@ -1,0 +1,44 @@
+//! Layer-3 chat-based portfolio manager surface — `tm manager` (epic #2109,
+//! DOC-36 phase 1a).
+//!
+//! Why: DOC-35 §1.1's three-layer model tops out at a Layer-3 "single agent with
+//! FULL SCOPE of the user's activities". DOC-36 designs that layer as a
+//! daemon-owned component exposing an API-first `/api/v1/manager/*` surface
+//! (§3.1/§3.2). This module is the phase-1a scaffold of that surface: it does NOT
+//! reimplement #2108's per-project control plane — it COMPOSES it (cross-project
+//! rollup) and stays strictly read-only (DOC-36 §2.1 boundary: the manager never
+//! mutates a Deliverable/Milestone, never sets an autonomy tier, never acts on a
+//! session without an explicit driving call). Everything here is curl-testable
+//! locally with no channel/bot token and no live LLM (§4 local-testability bar).
+//! What: three phase-1a work items land here as focused submodules —
+//! - [`state`] — the daemon-owned [`ManagerState`] threaded through every handler
+//!   (WI-1, #2578), holding the portfolio palace (and, later, the inference
+//!   adapter + poll loop);
+//! - [`memory`] — portfolio `trusty-memory` palace provisioning, auto-created at
+//!   startup and degrade-graceful (WI-5, #2582);
+//! - [`status`] — the deterministic `GET /manager/status` cross-project rollup,
+//!   NO LLM (WI-2, #2579);
+//! - [`version`] — the `GET /manager/version` capabilities stub that makes the
+//!   scaffold self-describing and curl-observable (WI-1, #2578).
+//!
+//! The handlers are mounted into the daemon's axum router by
+//! [`crate::daemon::api::router`]; [`ManagerState`] is owned by
+//! [`crate::daemon::state::DaemonState`] and reached via
+//! [`DaemonState::manager_state`](crate::daemon::state::DaemonState::manager_state),
+//! mirroring how the L2 proxy focus store is owned.
+//! Test: `tests/manager_routes.rs` (real-HTTP contract, mirrors
+//! `tests/proxy_routes.rs`) plus the in-module unit tests in each submodule.
+
+pub mod memory;
+pub mod state;
+pub mod status;
+pub mod version;
+
+pub use memory::{PORTFOLIO_PALACE_ID, PortfolioPalace};
+pub use state::ManagerState;
+pub use status::{
+    PortfolioStatusResponse, PortfolioTotals, aggregate_portfolio_status, manager_status_route,
+};
+pub use version::{
+    ManagerEndpoint, ManagerPalaceStatus, ManagerVersionResponse, manager_version_route,
+};

--- a/crates/trusty-mpm/src/daemon/manager/state.rs
+++ b/crates/trusty-mpm/src/daemon/manager/state.rs
@@ -1,0 +1,80 @@
+//! Daemon-owned [`ManagerState`] for the Layer-3 portfolio manager (WI-1, #2578).
+//!
+//! Why: DOC-36 §3.1 makes `tm manager` a component INSIDE the existing `tm`
+//! daemon ("daemon as source of truth"), with a `ManagerState` sitting alongside
+//! `DaemonState` — exactly as the L2 proxy focus store does. This is the single
+//! struct every manager route reaches through; owning it on [`DaemonState`]
+//! (mirroring `proxy_focus_store`) keeps one source of truth and no global
+//! statics. Phase 1a threads in the portfolio palace handle (§3.4, WI-5); later
+//! phases attach the configured `trusty_common::inference::InferenceAdapter`
+//! (§3.3) and the proactive poll loop (§6 phase 3) onto this same struct without
+//! re-plumbing route wiring.
+//! What: [`ManagerState`] holds the [`PortfolioPalace`] provisioned at daemon
+//! startup. Built once via [`ManagerState::provision`] from the framework root;
+//! shared into handlers as an `Arc<ManagerState>` via
+//! [`DaemonState::manager_state`](crate::daemon::state::DaemonState::manager_state).
+//! Test: `manager_state_provisions_palace` here plus the HTTP-level
+//! `manager_version_route_reports_capabilities` in `tests/manager_routes.rs`.
+
+use std::path::Path;
+
+use super::memory::PortfolioPalace;
+
+/// The daemon-owned state for the `tm manager` (Layer-3) surface.
+///
+/// Why: a single injectable struct for the manager routes, provisioned once at
+/// startup and shared read-only through `Arc` — the same ownership shape as
+/// every other daemon subsystem. Keeping it distinct from `DaemonState` (rather
+/// than scattering manager fields across it) means the L3 surface has one
+/// cohesive home the later phases grow into.
+/// What: phase 1a holds only the [`PortfolioPalace`]; the inference adapter and
+/// poll-loop handle attach in later phases (§3.3, §6).
+/// Test: `manager_state_provisions_palace`.
+#[derive(Debug)]
+pub struct ManagerState {
+    /// The portfolio-scoped memory palace (WI-5, #2582), provisioned at startup.
+    palace: PortfolioPalace,
+}
+
+impl ManagerState {
+    /// Provision the manager state at daemon startup (§7 Q3 auto-create).
+    ///
+    /// Why: DOC-36 §7 Q3 fixes provisioning as "auto-created at daemon startup",
+    /// so the daemon constructs this eagerly in its own constructor. It must be
+    /// infallible from the daemon's perspective — a palace that cannot be opened
+    /// degrades inside [`PortfolioPalace::provision`], never bubbling an error
+    /// that could fail startup (§4 degrade bar).
+    /// What: provisions the portfolio palace rooted at `framework_root` and wraps
+    /// it into the manager state.
+    /// Test: `manager_state_provisions_palace`.
+    pub fn provision(framework_root: &Path) -> Self {
+        Self {
+            palace: PortfolioPalace::provision(framework_root),
+        }
+    }
+
+    /// The portfolio palace handle.
+    ///
+    /// Why: the `version` capabilities stub and later-phase consumers read palace
+    /// availability / write observations through this handle.
+    /// What: a shared reference to the provisioned [`PortfolioPalace`].
+    /// Test: `manager_state_provisions_palace`.
+    pub fn palace(&self) -> &PortfolioPalace {
+        &self.palace
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Provisioning always yields a palace handle carrying the stable id — the
+    /// availability of that palace is a build/runtime concern the palace tests
+    /// cover; here we assert the state wires one through at all.
+    #[test]
+    fn manager_state_provisions_palace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = ManagerState::provision(dir.path());
+        assert_eq!(state.palace().id(), super::super::PORTFOLIO_PALACE_ID);
+    }
+}

--- a/crates/trusty-mpm/src/daemon/manager/status.rs
+++ b/crates/trusty-mpm/src/daemon/manager/status.rs
@@ -1,0 +1,261 @@
+//! Deterministic cross-project portfolio status rollup (WI-2, #2579).
+//!
+//! Why: DOC-36 §3.2 gives `tm manager` a `GET /api/v1/manager/status` endpoint
+//! that answers "what's going on across EVERYTHING" — the one thing Layer 2
+//! structurally cannot do (it is single-session/single-project by construction).
+//! Per DOC-35 §11 this cross-project synthesis belongs to #2109 EVEN THOUGH it is
+//! non-inferential: "reason across MULTIPLE projects" is scoped here regardless
+//! of whether the reasoning happens to be a pure aggregation. Critically, this
+//! endpoint must NOT reimplement #2108's per-project registry, status
+//! computation, or Deliverable/Milestone state machine — it COMPOSES the existing
+//! [`aggregate_project_status`] over every registered project (DOC-36 §5 "never
+//! reimplements #2108's status computation") and never mutates anything (§2.1
+//! read-only boundary). It contains NO LLM call: given the same materialized
+//! state it returns a byte-identical rollup every time.
+//! What: defines [`PortfolioStatusResponse`]/[`PortfolioTotals`], the pure
+//! aggregation [`aggregate_portfolio_status`] (fetch-once, fold across projects,
+//! deterministic name ordering), and the axum handler [`manager_status_route`].
+//! Test: the `aggregate_portfolio_status_*` unit tests in this file plus the
+//! real-HTTP `manager_status_route_rolls_up_all_projects` /
+//! `manager_status_route_empty_portfolio` in `tests/manager_routes.rs`.
+
+use std::sync::Arc;
+
+use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tracing::warn;
+
+use crate::daemon::managed_routes::{
+    DeliverableStatusCounts, MilestoneStatusCounts, ProjectStatusResponse, SessionStateCounts,
+    aggregate_project_status,
+};
+use crate::daemon::state::DaemonState;
+use crate::deliverable::{Deliverable, Milestone};
+use crate::project::Project;
+use crate::session_manager::SessionRecord;
+
+/// Portfolio-wide aggregate totals summed across every registered project.
+///
+/// Why: the headline "L2 can't do this" number — one histogram per dimension
+/// covering the WHOLE portfolio, so an operator sees "11 active sessions, 3
+/// blocked deliverables across all my work" without walking each project. Every
+/// field is a pure sum of the per-project [`ProjectStatusResponse`] histograms,
+/// so the totals are self-evidently consistent with the `projects` breakdown.
+/// What: the summed session, Deliverable, and Milestone histograms plus the
+/// single most-recent `last_activity_at` across the entire portfolio.
+/// Test: `aggregate_portfolio_status_sums_across_projects`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PortfolioTotals {
+    /// Session-state histogram summed across all projects.
+    pub sessions: SessionStateCounts,
+    /// Deliverable-status histogram summed across all projects.
+    pub deliverables: DeliverableStatusCounts,
+    /// Milestone-status histogram (incl. dangling refs) summed across all projects.
+    pub milestones: MilestoneStatusCounts,
+    /// Most recent `last_activity_at` across every project's sessions, if any.
+    pub last_activity_at: Option<DateTime<Utc>>,
+}
+
+/// Deterministic rollup of the whole portfolio (`GET /api/v1/manager/status`).
+///
+/// Why: the single response body for #2579. It is deliberately a COMPOSITION of
+/// #2108's per-project rollup, not a reimplementation: `projects` carries each
+/// project's verbatim [`ProjectStatusResponse`] and `totals` is their fold. A
+/// consumer can drill into any project or read the portfolio total from one call.
+/// What: the number of registered projects, the portfolio-wide `totals`, and the
+/// per-project breakdown in deterministic (name-sorted) order. Every field is a
+/// pure function of the inputs — zero inference, zero LLM, zero mutation.
+/// Test: `aggregate_portfolio_status_sums_across_projects`,
+/// `aggregate_portfolio_status_is_deterministic`,
+/// `aggregate_portfolio_status_empty_portfolio`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PortfolioStatusResponse {
+    /// Number of registered projects included in the rollup.
+    pub project_count: usize,
+    /// Portfolio-wide aggregate totals.
+    pub totals: PortfolioTotals,
+    /// Per-project deterministic rollups, sorted by project name.
+    pub projects: Vec<ProjectStatusResponse>,
+}
+
+/// Compute the deterministic portfolio rollup across all registered projects.
+///
+/// Why: the pure core of #2579, extracted from the handler so its determinism is
+/// self-evident (owned/borrowed state in, counting + `max` only, zero I/O, no LLM,
+/// no mutation) and it is unit-testable with hand-built inputs. It fetches the
+/// session/Deliverable/Milestone stores ONCE and folds
+/// [`aggregate_project_status`] over each project — avoiding an N+1 re-read per
+/// project and reusing #2108's exact per-project scoping so binding stays
+/// identical to the per-project endpoint.
+/// What: sorts `projects` by name (deterministic output order), computes each
+/// project's [`ProjectStatusResponse`] against the shared slices, folds them into
+/// [`PortfolioTotals`], and returns the combined [`PortfolioStatusResponse`].
+/// Test: `aggregate_portfolio_status_sums_across_projects`,
+/// `aggregate_portfolio_status_is_deterministic`,
+/// `aggregate_portfolio_status_empty_portfolio`.
+pub fn aggregate_portfolio_status(
+    projects: &[Project],
+    all_sessions: &[SessionRecord],
+    all_deliverables: &[Deliverable],
+    all_milestones: &[Milestone],
+) -> PortfolioStatusResponse {
+    let mut ordered: Vec<&Project> = projects.iter().collect();
+    ordered.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let per_project: Vec<ProjectStatusResponse> = ordered
+        .into_iter()
+        .map(|p| aggregate_project_status(p, all_sessions, all_deliverables, all_milestones))
+        .collect();
+
+    let totals = fold_totals(&per_project);
+
+    PortfolioStatusResponse {
+        project_count: per_project.len(),
+        totals,
+        projects: per_project,
+    }
+}
+
+/// Fold per-project rollups into portfolio-wide totals.
+///
+/// Why: keeps the summation logic in one exhaustive place so a future histogram
+/// field added to [`ProjectStatusResponse`] is a single edit here, and so the
+/// pure fold is testable without HTTP. The sum is over already-computed
+/// per-project histograms, so it can never disagree with the `projects` breakdown.
+/// What: zero-initialises each histogram, then adds every project's counts
+/// field-by-field and takes the running `max` of `last_activity_at`.
+/// Test: `aggregate_portfolio_status_sums_across_projects`.
+fn fold_totals(per_project: &[ProjectStatusResponse]) -> PortfolioTotals {
+    let mut sessions = SessionStateCounts {
+        provisioning: 0,
+        active: 0,
+        stopped: 0,
+        errored: 0,
+        decommissioned: 0,
+        total: 0,
+    };
+    let mut deliverables = DeliverableStatusCounts {
+        proposed: 0,
+        in_progress: 0,
+        blocked: 0,
+        complete: 0,
+        delivered: 0,
+        shipped: 0,
+        total: 0,
+    };
+    let mut milestones = MilestoneStatusCounts {
+        proposed: 0,
+        in_progress: 0,
+        complete: 0,
+        shipped: 0,
+        total: 0,
+        dangling_deliverable_refs: 0,
+    };
+    let mut last_activity_at: Option<DateTime<Utc>> = None;
+
+    for p in per_project {
+        sessions.provisioning += p.sessions.provisioning;
+        sessions.active += p.sessions.active;
+        sessions.stopped += p.sessions.stopped;
+        sessions.errored += p.sessions.errored;
+        sessions.decommissioned += p.sessions.decommissioned;
+        sessions.total += p.sessions.total;
+
+        deliverables.proposed += p.deliverables.proposed;
+        deliverables.in_progress += p.deliverables.in_progress;
+        deliverables.blocked += p.deliverables.blocked;
+        deliverables.complete += p.deliverables.complete;
+        deliverables.delivered += p.deliverables.delivered;
+        deliverables.shipped += p.deliverables.shipped;
+        deliverables.total += p.deliverables.total;
+
+        milestones.proposed += p.milestones.proposed;
+        milestones.in_progress += p.milestones.in_progress;
+        milestones.complete += p.milestones.complete;
+        milestones.shipped += p.milestones.shipped;
+        milestones.total += p.milestones.total;
+        milestones.dangling_deliverable_refs += p.milestones.dangling_deliverable_refs;
+
+        if let Some(ts) = p.last_activity_at {
+            last_activity_at = Some(match last_activity_at {
+                Some(current) => current.max(ts),
+                None => ts,
+            });
+        }
+    }
+
+    PortfolioTotals {
+        sessions,
+        deliverables,
+        milestones,
+        last_activity_at,
+    }
+}
+
+/// `GET /api/v1/manager/status` — deterministic cross-project portfolio rollup.
+///
+/// Why: exposes [`aggregate_portfolio_status`] over HTTP so the manager CLI/TUI
+/// (later WIs) and a local `curl` can read the whole-portfolio view without an
+/// LLM call and without any channel/bot token (DOC-36 §4 local-testability bar).
+/// The handler is a thin, read-only composition over the same registry / session
+/// / Deliverable stores the per-project endpoint reads — it adds no persistence,
+/// no reasoning, and never mutates a record (§2.1 boundary).
+/// What: lists every registered project plus all session/Deliverable/Milestone
+/// records ONCE, then returns `Json(aggregate_portfolio_status(..))`. A store
+/// read error degrades to 500 with a logged warning rather than a panic — the
+/// library never `unwrap`s a store result.
+/// Test: `manager_status_route_rolls_up_all_projects`,
+/// `manager_status_route_empty_portfolio` in `tests/manager_routes.rs`.
+pub async fn manager_status_route(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
+    let registry = state.project_registry().await;
+    let projects = match registry.list().await {
+        Ok(projects) => projects,
+        Err(e) => {
+            warn!(error = %e, "manager_status_route: project registry read failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "project registry read failed".to_string(),
+            )
+                .into_response();
+        }
+    };
+
+    let sessions = state.session_manager().await.list().await;
+
+    let deliverable_mgr = state.deliverable_manager().await;
+    let deliverables = match deliverable_mgr.all_deliverables().await {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(error = %e, "manager_status_route: deliverable store read failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "deliverable store read failed".to_string(),
+            )
+                .into_response();
+        }
+    };
+    let milestones = match deliverable_mgr.all_milestones().await {
+        Ok(m) => m,
+        Err(e) => {
+            warn!(error = %e, "manager_status_route: milestone store read failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "milestone store read failed".to_string(),
+            )
+                .into_response();
+        }
+    };
+
+    Json(aggregate_portfolio_status(
+        &projects,
+        &sessions,
+        &deliverables,
+        &milestones,
+    ))
+    .into_response()
+}
+
+#[cfg(test)]
+#[path = "status_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/manager/status_tests.rs
+++ b/crates/trusty-mpm/src/daemon/manager/status_tests.rs
@@ -1,0 +1,146 @@
+//! Pure-rollup tests for the cross-project portfolio aggregation (WI-2, #2579).
+//!
+//! Why: prove the DOC-36 §11 contract for `aggregate_portfolio_status` — it sums
+//! the per-project histograms correctly, is deterministic (byte-identical output
+//! for identical inputs, name-sorted project order), and handles the empty
+//! portfolio without panicking. These drive the pure function directly; the
+//! real-HTTP composition is covered by `tests/manager_routes.rs`.
+//! What: hand-built `Project`/`Deliverable`/`Milestone` fixtures (sessions left
+//! empty — session summation is already covered by the per-project rollup tests
+//! and end-to-end by the HTTP test) exercised through `aggregate_portfolio_status`.
+
+use super::*;
+
+use chrono::Utc;
+
+use crate::deliverable::{
+    Deliverable, DeliverableId, DeliverableKind, DeliverableStatus, EstimationTier, Milestone,
+    MilestoneId, MilestoneStatus,
+};
+use crate::project::Project;
+
+/// Build a bare project fixture with the given name.
+fn project(name: &str) -> Project {
+    Project {
+        name: name.to_string(),
+        repo_url: format!("https://github.com/acme/{name}"),
+        default_branch: "main".to_string(),
+        stack_hint: None,
+        tags: vec![],
+        description: None,
+        gh_user: None,
+        github: None,
+        commit_name: None,
+        commit_email: None,
+    }
+}
+
+/// Build a Deliverable scoped to `project_name` with `status`.
+fn deliverable(project_name: &str, status: DeliverableStatus) -> Deliverable {
+    Deliverable {
+        id: DeliverableId::new(),
+        project_name: project_name.to_string(),
+        name: "fixture".to_string(),
+        description: String::new(),
+        kind: DeliverableKind::Feature,
+        ticket_ref: None,
+        spec_ref: None,
+        status,
+        estimated_effort: EstimationTier::M,
+        created_at: Utc::now(),
+        target_date: None,
+    }
+}
+
+/// Build a Milestone scoped to `project_name` with `status` and member ids.
+fn milestone(
+    project_name: &str,
+    status: MilestoneStatus,
+    deliverables: Vec<DeliverableId>,
+) -> Milestone {
+    Milestone {
+        id: MilestoneId::new(),
+        project_name: project_name.to_string(),
+        name: "fixture milestone".to_string(),
+        description: String::new(),
+        target_date: Utc::now(),
+        status,
+        deliverables,
+        created_at: Utc::now(),
+    }
+}
+
+/// Totals sum every project's histograms, `project_count` matches, and a dangling
+/// Milestone→Deliverable ref is surfaced as a portfolio-wide count.
+#[test]
+fn aggregate_portfolio_status_sums_across_projects() {
+    let projects = vec![project("alpha"), project("beta")];
+
+    let missing = DeliverableId::new();
+    let alpha_live = deliverable("alpha", DeliverableStatus::InProgress);
+    let alpha_live_id = alpha_live.id;
+    let deliverables = vec![
+        alpha_live,
+        deliverable("beta", DeliverableStatus::Complete),
+        deliverable("beta", DeliverableStatus::Blocked),
+    ];
+    let milestones = vec![
+        // alpha milestone references one live + one missing id → 1 dangling.
+        milestone(
+            "alpha",
+            MilestoneStatus::InProgress,
+            vec![alpha_live_id, missing],
+        ),
+        milestone("beta", MilestoneStatus::Shipped, vec![]),
+    ];
+
+    let rollup = aggregate_portfolio_status(&projects, &[], &deliverables, &milestones);
+
+    assert_eq!(rollup.project_count, 2);
+    assert_eq!(rollup.totals.deliverables.total, 3);
+    assert_eq!(rollup.totals.deliverables.in_progress, 1);
+    assert_eq!(rollup.totals.deliverables.complete, 1);
+    assert_eq!(rollup.totals.deliverables.blocked, 1);
+    assert_eq!(rollup.totals.milestones.total, 2);
+    assert_eq!(rollup.totals.milestones.in_progress, 1);
+    assert_eq!(rollup.totals.milestones.shipped, 1);
+    assert_eq!(
+        rollup.totals.milestones.dangling_deliverable_refs, 1,
+        "alpha's milestone references a missing deliverable id: {rollup:?}"
+    );
+    // No sessions were supplied, so the session histogram is all-zero.
+    assert_eq!(rollup.totals.sessions.total, 0);
+    assert_eq!(rollup.totals.last_activity_at, None);
+}
+
+/// Identical inputs yield byte-identical output, and projects come back sorted by
+/// name regardless of registration order (determinism, DOC-35 §11).
+#[test]
+fn aggregate_portfolio_status_is_deterministic() {
+    // Registered out of order — output must be name-sorted (alpha before beta).
+    let projects = vec![project("beta"), project("alpha")];
+    let deliverables = vec![deliverable("alpha", DeliverableStatus::Proposed)];
+
+    let first = aggregate_portfolio_status(&projects, &[], &deliverables, &[]);
+    let second = aggregate_portfolio_status(&projects, &[], &deliverables, &[]);
+    assert_eq!(first, second, "same inputs must produce identical output");
+
+    let names: Vec<&str> = first
+        .projects
+        .iter()
+        .map(|p| p.project_name.as_str())
+        .collect();
+    assert_eq!(names, vec!["alpha", "beta"], "projects must be name-sorted");
+}
+
+/// An empty portfolio rolls up to zero everywhere without panicking.
+#[test]
+fn aggregate_portfolio_status_empty_portfolio() {
+    let rollup = aggregate_portfolio_status(&[], &[], &[], &[]);
+    assert_eq!(rollup.project_count, 0);
+    assert!(rollup.projects.is_empty());
+    assert_eq!(rollup.totals.sessions.total, 0);
+    assert_eq!(rollup.totals.deliverables.total, 0);
+    assert_eq!(rollup.totals.milestones.total, 0);
+    assert_eq!(rollup.totals.last_activity_at, None);
+}

--- a/crates/trusty-mpm/src/daemon/manager/version.rs
+++ b/crates/trusty-mpm/src/daemon/manager/version.rs
@@ -1,0 +1,170 @@
+//! `GET /api/v1/manager/version` — the manager surface's self-describing
+//! capabilities stub (WI-1, #2578).
+//!
+//! Why: DOC-36 §4's local-testability bar requires the `/api/v1/manager/*`
+//! surface to be reachable and meaningful via `curl` "from day one", before any
+//! channel/bot token exists and before the later-phase endpoints (digest, chat,
+//! route-task, escalations) are implemented. A version/capabilities endpoint is
+//! the smallest thing that makes the scaffold observably alive: it names the
+//! manager API version, the delivery phase, the full DOC-36 §3.2 verb set with a
+//! per-endpoint `available` flag (so the roadmap is honest — implemented vs.
+//! planned), and the portfolio palace status (WI-5, #2582) so provisioning is
+//! curl-observable. This single endpoint therefore ties all three phase-1a work
+//! items into one hermetic, token-free smoke surface.
+//! What: [`ManagerVersionResponse`] + the [`manager_version_route`] handler,
+//! which reads the daemon-owned [`crate::daemon::manager::ManagerState`] for
+//! live palace availability and returns a static-plus-live capabilities snapshot.
+//! Test: `manager_version_route_reports_capabilities` in `tests/manager_routes.rs`.
+
+use std::sync::Arc;
+
+use axum::{Json, extract::State, response::IntoResponse};
+use serde::Serialize;
+
+use crate::daemon::state::DaemonState;
+
+/// The manager HTTP API version this daemon serves.
+///
+/// Why: pins a stable contract version for the `/api/v1/manager/*` surface,
+/// independent of the crate version, so a channel/CLI client can feature-detect
+/// against a value that only changes when the manager wire contract does.
+/// What: the manager-surface semantic version string.
+/// Test: `manager_version_route_reports_capabilities`.
+const MANAGER_API_VERSION: &str = "0.1.0";
+
+/// The DOC-36 delivery phase this build implements.
+///
+/// Why: DOC-36 §6 phases the manager surface (1 read-only chat → 2 routing → 3
+/// proactive → 4 channels); surfacing the phase lets an operator confirm which
+/// slice is live. Phase 1 (this WI cluster) ships `status` + the scaffold.
+/// What: the integer phase number.
+/// Test: `manager_version_route_reports_capabilities`.
+const MANAGER_PHASE: u8 = 1;
+
+/// One entry in the manager surface's advertised verb set.
+///
+/// Why: makes the DOC-36 §3.2 roadmap self-describing over HTTP — a consumer
+/// reads which endpoints exist NOW (`available = true`) versus which are planned
+/// for a later phase (`available = false`), instead of discovering a 404 by
+/// trial. Later WIs flip their own flag to `true` as they land.
+/// What: the HTTP `method`, the `path`, and whether it is live in this build.
+/// Test: `manager_version_route_reports_capabilities`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManagerEndpoint {
+    /// HTTP method (`GET`/`POST`).
+    pub method: &'static str,
+    /// Route path under the manager namespace.
+    pub path: &'static str,
+    /// Whether the endpoint is implemented and live in this build.
+    pub available: bool,
+}
+
+/// Live status of the portfolio manager palace (WI-5, #2582).
+///
+/// Why: DOC-36 §4's degrade bar means the palace may be absent (feature not
+/// compiled) or unavailable (open failed) while the manager surface still works;
+/// surfacing that here makes provisioning success/failure curl-observable without
+/// a separate diagnostic endpoint.
+/// What: the stable palace id, an `available` flag, and an optional `reason`
+/// string when unavailable.
+/// Test: `manager_version_route_reports_capabilities`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManagerPalaceStatus {
+    /// The stable portfolio palace id.
+    pub id: String,
+    /// Whether the palace is provisioned and usable.
+    pub available: bool,
+    /// Why the palace is unavailable, when it is (`None` when available).
+    pub reason: Option<String>,
+}
+
+/// Response body for `GET /api/v1/manager/version`.
+///
+/// Why: the single self-describing snapshot of the manager surface — versions,
+/// phase, verb-set roadmap, and palace status — that the DOC-36 §4 local-test
+/// bar exercises first.
+/// What: the manager API version, the crate version, the delivery phase, the
+/// advertised endpoint set, and the portfolio palace status.
+/// Test: `manager_version_route_reports_capabilities`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManagerVersionResponse {
+    /// The manager HTTP API contract version ([`MANAGER_API_VERSION`]).
+    pub manager_api_version: &'static str,
+    /// The `trusty-mpm` crate version serving this surface.
+    pub crate_version: &'static str,
+    /// The DOC-36 delivery phase implemented ([`MANAGER_PHASE`]).
+    pub phase: u8,
+    /// The advertised verb set (implemented + planned).
+    pub endpoints: Vec<ManagerEndpoint>,
+    /// Live portfolio palace status.
+    pub palace: ManagerPalaceStatus,
+}
+
+/// The advertised DOC-36 §3.2 verb set for the manager surface.
+///
+/// Why: centralises the roadmap so `version` stays the single source of truth for
+/// "what does `/api/v1/manager/*` offer". Phase-1a ships `version` + `status`;
+/// the rest are advertised as planned so the surface documents its own trajectory
+/// without pretending to serve endpoints later WIs own.
+/// What: the five §3.2 endpoints plus this `version` stub, each tagged with its
+/// current availability in this build.
+/// Test: `manager_version_route_reports_capabilities`.
+fn advertised_endpoints() -> Vec<ManagerEndpoint> {
+    vec![
+        ManagerEndpoint {
+            method: "GET",
+            path: "/api/v1/manager/version",
+            available: true,
+        },
+        ManagerEndpoint {
+            method: "GET",
+            path: "/api/v1/manager/status",
+            available: true,
+        },
+        ManagerEndpoint {
+            method: "GET",
+            path: "/api/v1/manager/digest",
+            available: false,
+        },
+        ManagerEndpoint {
+            method: "POST",
+            path: "/api/v1/manager/chat",
+            available: false,
+        },
+        ManagerEndpoint {
+            method: "POST",
+            path: "/api/v1/manager/route-task",
+            available: false,
+        },
+        ManagerEndpoint {
+            method: "GET",
+            path: "/api/v1/manager/escalations",
+            available: false,
+        },
+    ]
+}
+
+/// `GET /api/v1/manager/version` — capabilities + palace status snapshot.
+///
+/// Why: the curl-first smoke endpoint (DOC-36 §4) that proves the manager
+/// scaffold is mounted and reports the live portfolio palace state (§2582)
+/// without any LLM call, channel, or bot token.
+/// What: reads the daemon-owned [`crate::daemon::manager::ManagerState`] palace
+/// handle and returns a [`ManagerVersionResponse`] combining static version/phase
+/// /verb-set data with the live palace availability. Read-only; never mutates.
+/// Test: `manager_version_route_reports_capabilities` in `tests/manager_routes.rs`.
+pub async fn manager_version_route(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
+    let manager = state.manager_state();
+    let palace = manager.palace();
+    Json(ManagerVersionResponse {
+        manager_api_version: MANAGER_API_VERSION,
+        crate_version: env!("CARGO_PKG_VERSION"),
+        phase: MANAGER_PHASE,
+        endpoints: advertised_endpoints(),
+        palace: ManagerPalaceStatus {
+            id: palace.id().to_string(),
+            available: palace.is_available(),
+            reason: palace.unavailable_reason().map(str::to_string),
+        },
+    })
+}

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -22,6 +22,7 @@ pub mod idle_reaper;
 pub mod llm_overseer;
 pub mod lock;
 pub mod managed_routes;
+pub mod manager;
 pub mod mcp_backend;
 pub mod mcp_bugreport;
 pub mod mcp_console;

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -290,6 +290,20 @@ pub struct DaemonState {
     /// `commands::launchd_probe::tests` cover the pure decision logic that
     /// `daemon_run` uses to compute the value passed to `set_supervised`.
     pub(super) supervised: std::sync::atomic::AtomicBool,
+    /// Layer-3 portfolio manager state (`tm manager`, epic #2109, DOC-36 §3.1).
+    ///
+    /// Why: DOC-36 §3.1 makes `tm manager` a daemon-owned component whose
+    /// `ManagerState` "sits alongside `DaemonState`" — so it is owned HERE and
+    /// threaded into the `/api/v1/manager/*` handlers, exactly as
+    /// [`proxy_focus`](Self::proxy_focus) is owned for the L2 proxy surface.
+    /// Provisioned once at construction (§7 Q3 "auto-created at daemon startup");
+    /// held behind an `Arc` so the accessor hands out cheap clones without
+    /// requiring `&mut self` through the shared daemon `Arc`.
+    /// What: the portfolio palace handle (WI-5) today; the inference adapter and
+    /// proactive poll loop attach onto the same `ManagerState` in later phases.
+    /// Test: `manager_state_is_provisioned` in `state/tests.rs`;
+    /// `manager_version_route_reports_capabilities` in `tests/manager_routes.rs`.
+    pub(super) manager: Arc<crate::daemon::manager::ManagerState>,
 }
 
 impl Default for DaemonState {
@@ -350,6 +364,9 @@ impl DaemonState {
         // §9 (WI-5): build the control-plane registry with the operator's
         // [control_plane] auth+cost config (cap, stagger, classifier gate).
         let session_registry = Arc::new(build_session_registry(&root));
+        // §7 Q3: auto-provision the portfolio manager palace at startup; a palace
+        // failure degrades inside `provision` and never fails daemon startup.
+        let manager = Arc::new(crate::daemon::manager::ManagerState::provision(&root));
         Self {
             sessions: DashMap::new(),
             delegations: DashMap::new(),
@@ -377,6 +394,7 @@ impl DaemonState {
             session_registry,
             proxy_focus: Arc::new(std::sync::Mutex::new(HashMap::new())),
             supervised: std::sync::atomic::AtomicBool::new(true),
+            manager,
         }
     }
 
@@ -410,6 +428,11 @@ impl DaemonState {
         // this (possibly temp-dir) framework root, so e2e tests can inject a
         // hermetic auth+cost config and the real daemon reads the operator's.
         let session_registry = Arc::new(build_session_registry(&framework_root));
+        // §7 Q3: auto-provision the portfolio manager palace at startup; a palace
+        // failure degrades inside `provision` and never fails daemon startup.
+        let manager = Arc::new(crate::daemon::manager::ManagerState::provision(
+            &framework_root,
+        ));
         Self {
             sessions: DashMap::new(),
             delegations: DashMap::new(),
@@ -437,6 +460,7 @@ impl DaemonState {
             session_registry,
             proxy_focus: Arc::new(std::sync::Mutex::new(HashMap::new())),
             supervised: std::sync::atomic::AtomicBool::new(true),
+            manager,
         }
     }
 
@@ -488,6 +512,20 @@ impl DaemonState {
         &self,
     ) -> Arc<std::sync::Mutex<HashMap<String, crate::client::proxy::FocusTarget>>> {
         Arc::clone(&self.proxy_focus)
+    }
+
+    /// The Layer-3 portfolio manager state (`tm manager`, epic #2109).
+    ///
+    /// Why: the `/api/v1/manager/*` handlers reach the portfolio palace (and, in
+    /// later phases, the inference adapter + poll loop) through this shared
+    /// handle — the same cheap-`Arc`-clone accessor shape as
+    /// [`Self::proxy_focus_store`], provisioned once at daemon startup.
+    /// What: clones the `Arc<ManagerState>` (cheap); every clone shares the SAME
+    /// provisioned manager state.
+    /// Test: `manager_state_is_provisioned` in `state/tests.rs`;
+    /// `manager_version_route_reports_capabilities` in `tests/manager_routes.rs`.
+    pub fn manager_state(&self) -> Arc<crate::daemon::manager::ManagerState> {
+        Arc::clone(&self.manager)
     }
 
     /// The PID-file registry rooted under this daemon's framework root.

--- a/crates/trusty-mpm/src/daemon/state/tests.rs
+++ b/crates/trusty-mpm/src/daemon/state/tests.rs
@@ -712,3 +712,18 @@ async fn reap_dead_managed_sessions_marks_stopped() {
         "reap_managed_against must mark Active session Stopped when tmux_name absent (#1744)"
     );
 }
+
+/// The Layer-3 manager state is provisioned at daemon construction and reachable
+/// via the shared accessor (#2578) — the palace handle it threads through always
+/// carries the stable portfolio id, regardless of whether the memory engine is
+/// compiled/available (that availability is the palace tests' concern).
+#[test]
+fn manager_state_is_provisioned() {
+    let (state, _dir) = hermetic_state();
+    let manager = state.manager_state();
+    assert_eq!(
+        manager.palace().id(),
+        crate::daemon::manager::PORTFOLIO_PALACE_ID,
+        "daemon startup must auto-provision the portfolio manager palace"
+    );
+}

--- a/crates/trusty-mpm/tests/manager_routes.rs
+++ b/crates/trusty-mpm/tests/manager_routes.rs
@@ -1,0 +1,217 @@
+//! HTTP-level integration tests for the Layer-3 `tm manager` surface
+//! (`/api/v1/manager/*`, epic #2109, DOC-36 phase 1a: WI-1 #2578 + WI-2 #2579).
+//!
+//! Why: the in-crate unit tests drive the pure `aggregate_portfolio_status`
+//! rollup and the palace provisioning directly; this file instead binds the REAL
+//! `api::router` on a loopback port and drives the routes with `reqwest`, so it
+//! is the literal proof the manager scaffold is reachable over the daemon HTTP
+//! API with NO channel/bot token and NO live LLM (DOC-36 §4 local-testability
+//! bar). Mirrors the real-network harness in `tests/proxy_routes.rs` /
+//! `tests/project_status_route.rs` (axum::serve on an ephemeral port + reqwest).
+//! What: exercises the capabilities stub (`GET /manager/version`) and the
+//! deterministic cross-project rollup (`GET /manager/status`) — the latter
+//! against a multi-project fixture, asserting the portfolio totals sum the
+//! per-project histograms and the per-project breakdown is present and sorted.
+//! Test: this file IS the test; run with
+//! `cargo test -p trusty-mpm --test manager_routes`.
+
+use std::future::IntoFuture;
+use std::sync::Arc;
+
+use trusty_mpm::daemon::{api, state::DaemonState};
+use trusty_mpm::deliverable::{
+    Deliverable, DeliverableId, DeliverableKind, DeliverableStatus, EstimationTier,
+};
+use trusty_mpm::project::Project;
+use trusty_mpm::runtime::RuntimeKind;
+use trusty_mpm::session_manager::ManagedSessionId;
+
+/// Serve the real router on an ephemeral loopback port; return its base URL.
+async fn serve(state: Arc<DaemonState>) -> String {
+    let router = api::router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    format!("http://{addr}")
+}
+
+/// Register a project fixture on the given daemon state.
+async fn register_project(state: &Arc<DaemonState>, name: &str, repo_url: &str) {
+    state
+        .project_registry()
+        .await
+        .register(Project {
+            name: name.to_string(),
+            repo_url: repo_url.to_string(),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        })
+        .await
+        .expect("register project");
+}
+
+/// Seed a managed session bound to `repo_url` (starts in `Provisioning`).
+async fn seed_session(state: &Arc<DaemonState>, repo_url: &str, task: &str) {
+    let id = ManagedSessionId::new();
+    state
+        .session_manager()
+        .await
+        .create_with_id(
+            id,
+            task.to_string(),
+            None,
+            None,
+            None,
+            Some(repo_url.to_string()),
+            Some("main".to_string()),
+            RuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session");
+}
+
+/// Seed a Deliverable scoped to `project_name` with the given status.
+async fn seed_deliverable(state: &Arc<DaemonState>, project_name: &str, status: DeliverableStatus) {
+    let d = Deliverable {
+        id: DeliverableId::new(),
+        project_name: project_name.to_string(),
+        name: "fixture".to_string(),
+        description: String::new(),
+        kind: DeliverableKind::Feature,
+        ticket_ref: None,
+        spec_ref: None,
+        status,
+        estimated_effort: EstimationTier::M,
+        created_at: chrono::Utc::now(),
+        target_date: None,
+    };
+    state
+        .deliverable_manager()
+        .await
+        .upsert_deliverable(d)
+        .await
+        .expect("seed deliverable");
+}
+
+/// `GET /api/v1/manager/version` returns the self-describing capabilities snapshot
+/// over real HTTP — API version, phase, the advertised verb set (status+version
+/// live, later endpoints planned), and the portfolio palace status (unavailable
+/// in a default build with no `manager-memory` feature, per the §4 degrade bar).
+#[tokio::test]
+async fn manager_version_route_reports_capabilities() {
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let base = serve(Arc::clone(&state)).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/api/v1/manager/version"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    assert_eq!(body["manager_api_version"], "0.1.0");
+    assert_eq!(body["phase"], 1);
+    assert_eq!(body["palace"]["id"], "tm-manager-portfolio");
+    // Default build: no `manager-memory` feature → palace reports unavailable,
+    // but the surface still answered 200 (degrade bar).
+    assert_eq!(body["palace"]["available"], false, "body: {body}");
+
+    let endpoints = body["endpoints"].as_array().expect("endpoints array");
+    let status_ep = endpoints
+        .iter()
+        .find(|e| e["path"] == "/api/v1/manager/status")
+        .expect("status endpoint advertised");
+    assert_eq!(status_ep["available"], true);
+    let digest_ep = endpoints
+        .iter()
+        .find(|e| e["path"] == "/api/v1/manager/digest")
+        .expect("digest endpoint advertised");
+    assert_eq!(
+        digest_ep["available"], false,
+        "digest is a later-phase WI, advertised as planned"
+    );
+}
+
+/// `GET /api/v1/manager/status` returns the deterministic cross-project rollup
+/// over real HTTP: it composes the per-project rollup across EVERY registered
+/// project, sums the histograms into portfolio totals, and orders projects by
+/// name — the thing L2 cannot do, with no LLM call.
+#[tokio::test]
+async fn manager_status_route_rolls_up_all_projects() {
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+
+    let beta_url = "https://github.com/acme/beta";
+    let alpha_url = "https://github.com/acme/alpha";
+    // Registered out of order — output must be name-sorted.
+    register_project(&state, "beta", beta_url).await;
+    register_project(&state, "alpha", alpha_url).await;
+
+    // alpha: two provisioning sessions + one in-progress deliverable.
+    seed_session(&state, alpha_url, "a-1").await;
+    seed_session(&state, alpha_url, "a-2").await;
+    seed_deliverable(&state, "alpha", DeliverableStatus::InProgress).await;
+    // beta: one provisioning session + one complete deliverable.
+    seed_session(&state, beta_url, "b-1").await;
+    seed_deliverable(&state, "beta", DeliverableStatus::Complete).await;
+
+    let base = serve(Arc::clone(&state)).await;
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/api/v1/manager/status"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    assert_eq!(body["project_count"], 2);
+    // Portfolio totals sum across BOTH projects.
+    assert_eq!(
+        body["totals"]["sessions"]["provisioning"], 3,
+        "body: {body}"
+    );
+    assert_eq!(body["totals"]["sessions"]["total"], 3);
+    assert_eq!(body["totals"]["deliverables"]["total"], 2);
+    assert_eq!(body["totals"]["deliverables"]["in_progress"], 1);
+    assert_eq!(body["totals"]["deliverables"]["complete"], 1);
+
+    // Per-project breakdown is present and name-sorted.
+    let projects = body["projects"].as_array().expect("projects array");
+    assert_eq!(projects.len(), 2);
+    assert_eq!(projects[0]["project_name"], "alpha");
+    assert_eq!(projects[1]["project_name"], "beta");
+    assert_eq!(projects[0]["sessions"]["provisioning"], 2);
+    assert_eq!(projects[1]["sessions"]["provisioning"], 1);
+}
+
+/// `GET /api/v1/manager/status` on an empty portfolio returns a zeroed rollup
+/// (not a 404 or an error) — the manager surface is operable before any project
+/// is registered.
+#[tokio::test]
+async fn manager_status_route_empty_portfolio() {
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let base = serve(Arc::clone(&state)).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/api/v1/manager/status"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["project_count"], 0);
+    assert_eq!(body["totals"]["sessions"]["total"], 0);
+    assert_eq!(body["totals"]["deliverables"]["total"], 0);
+    assert!(body["projects"].as_array().unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary

Foundation slice (phase 1a) of the DOC-36 Layer-3 chat-based portfolio manager
(`tm manager`, epic #2109), landed as one additive daemon module under
`crates/trusty-mpm/src/daemon/manager/`. Three work items, one PR:

- **`Closes #2578`** — `/api/v1/manager/*` route skeleton + daemon-owned
  `ManagerState`. `ManagerState` is owned by `DaemonState` (accessor
  `manager_state()`, mirroring `proxy_focus_store`) and provisioned once at
  startup. A self-describing `GET /api/v1/manager/version` capabilities stub makes
  the surface curl-testable from day one and advertises the full DOC-36 §3.2 verb
  set (status + version live; digest/chat/route-task/escalations advertised as
  planned for later WIs).
- **`Closes #2579`** — `GET /api/v1/manager/status`, a **deterministic (NO LLM)**
  cross-project rollup. It *composes* #2108's per-project `aggregate_project_status`
  across every registered project into portfolio-wide totals — it does **not**
  reimplement the registry, status computation, or Deliverable/Milestone state
  machine (DOC-35 §11 / DOC-36 §5). Fetch-once, fold-across-projects,
  name-sorted, byte-identical output for identical state. Read-only — mutates
  nothing.
- **`Closes #2582`** — portfolio `trusty-memory` palace, **auto-provisioned at
  daemon startup** (§7 Q3), idempotent (create-if-absent, never clobber), and
  **degrade-graceful**: a failed or absent memory engine leaves the manager
  surface fully operable and reports the palace unavailable — the daemon never
  fails startup on memory being down (DOC-36 §4). Gated behind the opt-in
  `manager-memory` feature so the heavy `memory-core`/ONNX stack stays out of the
  default build (mirrors the existing `sm-memory` gate).

### Boundary conformance (DOC-35 §11 / DOC-36 §2.1)

Phase 1 is strictly **read-only**: the manager never mutates a
Deliverable/Milestone, never sets an autonomy tier, and never acts on a session.
No LLM call in this slice.

## Module layout

```
crates/trusty-mpm/src/daemon/manager/
├── mod.rs          facade + submodule decls + re-exports
├── state.rs        ManagerState (owned by DaemonState) + provisioning
├── memory.rs       PortfolioPalace (always) + PortfolioMemory (feature-gated)
├── status.rs       portfolio rollup shapes + aggregate_portfolio_status + handler
├── version.rs      capabilities/version stub response + handler
├── memory_tests.rs / status_tests.rs   (path-attr sibling test modules)
```

Also: proxy route *registration* co-located into
`managed_routes::proxy::proxy_router()` and `.merge`d in `api::router` — a genuine
improvement (route defs next to handlers) that also keeps the grandfathered
`api.rs` under its frozen line-cap budget.

## Local testability (DOC-36 §4) — curl recipes

No channel/bot token, no live LLM. Against a locally-running daemon
(`cargo run -p trusty-mpm -- daemon`, default port 7880):

```bash
# Capabilities stub — version, phase, verb-set roadmap, live palace status
curl -s http://127.0.0.1:7880/api/v1/manager/version | jq

# Deterministic cross-project portfolio rollup (NO LLM)
curl -s http://127.0.0.1:7880/api/v1/manager/status | jq

# Portfolio totals only
curl -s http://127.0.0.1:7880/api/v1/manager/status | jq '.totals'
```

`/version` reports `palace.available: false` in a default build (memory engine not
compiled) — the surface still answers 200 (degrade bar). Build with
`--features manager-memory` to provision the live palace.

## Verification

- `cargo build --workspace` — clean
- `cargo test -p trusty-mpm --lib` — `3045 passed; 0 failed`
- `cargo test -p trusty-mpm --test manager_routes` — `3 passed; 0 failed`
- `cargo test -p trusty-mpm --features manager-memory --lib daemon::manager` —
  `7 passed; 0 failed` (palace idempotency + remember/recall round-trip)
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 errors
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations
- `bash scripts/check_test_pointers.sh` — 0 dangling pointers

Part of epic #2109. Spec: DOC-36 `docs/specs/tm-manager-vision.md` (approved
2026-07-14).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
