### PR TITLE
chore(trusty-mpm): bump version to 0.19.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11073,7 +11073,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.19.9"
+version = "0.19.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- async managed-spawn provisioning with live progress poll route (closes #2605) ([#2607](https://github.com/bobmatnyc/trusty-tools/pull/2607)) ([`f440192`](https://github.com/bobmatnyc/trusty-tools/commit/f44019266928e96973d16ab83cc618a4ac0894ff))
+- tm manager status|digest|chat CLI (TMMGR phase 1) ([#2600](https://github.com/bobmatnyc/trusty-tools/pull/2600)) ([`ed9390a`](https://github.com/bobmatnyc/trusty-tools/commit/ed9390a8a0f3e491f2aa6416cf68b5603975536a))
+- tm manager phase-1b — digest, read-only chat, hermetic suite ([#2601](https://github.com/bobmatnyc/trusty-tools/pull/2601)) ([`6f80f36`](https://github.com/bobmatnyc/trusty-tools/commit/6f80f36999c66ff679f194fe3e2d3bd9b3214c79))
+
+### Fixed
+
+- pm_guard permits PM single-file writes to non-source paths ([#2606](https://github.com/bobmatnyc/trusty-tools/pull/2606)) ([`3c6f9f7`](https://github.com/bobmatnyc/trusty-tools/commit/3c6f9f705760f1e94a37f6b9d966b45bf483c2ed))
+## [Unreleased]
+
+### Added
+
 - tm manager phase-1a — scaffold, status rollup, portfolio palace ([#2598](https://github.com/bobmatnyc/trusty-tools/pull/2598)) ([`3084a3c`](https://github.com/bobmatnyc/trusty-tools/commit/3084a3c406c2aa935c4c736950b81954c47fea39))
 
 ### Fixed

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.19.9"
+version = "0.19.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- Cut the trusty-mpm 0.19.10 patch release: bumps `crates/trusty-mpm/Cargo.toml` version 0.19.9 → 0.19.10 and stages the changelog.
- Since 0.19.9, main gained: tm-manager phase-1 routes + `tm manager` CLI (#2578–#2584, #2598, #2600, #2601), the pm_guard single-file-write fix (#2606, `3c6f9f70`), and async managed-spawn provisioning with live progress (#2607, `f4401926`).

## Test plan
- [x] `cargo build --workspace` — clean build
- [x] `cargo test -p trusty-mpm` — all suites pass (3079 + 922 + 922 + ... ; 0 failed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] `cargo fmt --check` — exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools