### PR TITLE
feat(trusty-mpm): tm-manager phase 2 — route-task, proposal-and-confirm, route CLI (#2585 #2586 #2587)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/cli.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli.rs
@@ -1680,55 +1680,10 @@ pub(crate) enum ProjectsAction {
     },
 }
 
-/// Actions for `tm manager <action>` (DOC-36 §3.2/§6 phase 1, #2583).
-///
-/// Why: mirrors `ProjectsAction`'s shape — one variant per daemon verb this
-/// WI wraps. `route-task`/`escalations` (phase 2/3) are deliberately absent;
-/// this ticket wraps only the phase-1 read-only triad the issue scopes.
-/// What: `Status`/`Digest`/`Chat`, each a thin client over the matching
-/// `DaemonClient::manager_*` method (`client/http_client/manager.rs`).
-/// Test: `cli_parses_manager_*` in `tests_manager.rs`.
-#[derive(Debug, Subcommand)]
-pub(crate) enum ManagerAction {
-    /// Deterministic cross-project portfolio rollup — no LLM call.
-    Status {
-        /// Emit the raw status JSON instead of the human view.
-        #[arg(long)]
-        json: bool,
-    },
-    /// LLM-authored portfolio (or single-project) narrative, with a
-    /// deterministic fallback when no inference provider is configured.
-    Digest {
-        /// `portfolio` (default) or `project:<name>` to scope to one project.
-        #[arg(long, default_value = "portfolio")]
-        scope: String,
-        /// Emit the raw digest JSON instead of the human view.
-        #[arg(long)]
-        json: bool,
-    },
-    /// One-shot chat turn against the portfolio manager persona.
-    ///
-    /// Why (conversation-key convention, #2583): defaults to a stable
-    /// per-user key (`cli:$USER`, see `commands::manager::default_conversation_key`)
-    /// so repeated one-shot invocations on the same machine accumulate as one
-    /// ongoing conversation server-side (matching `SessionProxy`'s focus-map
-    /// keying, DOC-36 §3.2) — `--conversation` overrides it for scripts/tests
-    /// that need an isolated key. Interactive REPL mode (multi-turn within a
-    /// single process) is deferred to a follow-up; this ships the one-shot
-    /// form the issue's acceptance criteria require.
-    Chat {
-        /// The message to send. When omitted, reads the full message from
-        /// stdin (supports both piping and a terminal Ctrl-D-terminated
-        /// single message).
-        message: Option<String>,
-        /// Override the conversation key (defaults to a stable per-user key).
-        #[arg(long)]
-        conversation: Option<String>,
-        /// Emit the raw chat-response JSON instead of the human view.
-        #[arg(long)]
-        json: bool,
-    },
-}
+// The `tm manager <action>` subcommand tree lives in `cli_manager.rs` (extracted
+// to keep this file under the SLOC cap); re-exported so `crate::cli::ManagerAction`
+// stays the stable reference every dispatcher and parse test uses.
+pub(crate) use crate::cli_manager::ManagerAction;
 
 /// Actions for `tm projects config <name>` (DOC-35 §3.1/§6, #2120).
 ///

--- a/crates/trusty-mpm/src/bin/tm/cli_manager.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli_manager.rs
@@ -1,0 +1,78 @@
+//! The `tm manager <action>` subcommand tree (DOC-36 §3.2/§6, epic #2109).
+//!
+//! Why: extracted from `cli.rs` (which is at its SLOC cap) so the Layer-3
+//! manager verb set has a cohesive home it can grow into across phases without
+//! pushing the monolithic `cli.rs` over the line-cap. Re-exported from `cli` so
+//! `crate::cli::ManagerAction` stays the stable reference every dispatcher and
+//! parse test already uses.
+//! What: [`ManagerAction`] — the clap subcommand enum, one variant per daemon
+//! verb `commands::manager` wraps.
+//! Test: `cli_parses_manager_*` in `tests_manager.rs`.
+
+use clap::Subcommand;
+
+/// Actions for `tm manager <action>` (DOC-36 §3.2/§6, epic #2109).
+///
+/// Why: mirrors `ProjectsAction`'s shape — one variant per daemon verb this
+/// surface wraps. Phase 1 ships the read-only triad (`Status`/`Digest`/`Chat`);
+/// phase 2 adds advisory task routing (`Route`, #2585).
+/// What: each variant is a thin client over the matching
+/// `DaemonClient::manager_*` method (`client/http_client/manager.rs`).
+/// Test: `cli_parses_manager_*` in `tests_manager.rs`.
+#[derive(Debug, Subcommand)]
+pub(crate) enum ManagerAction {
+    /// Deterministic cross-project portfolio rollup — no LLM call.
+    Status {
+        /// Emit the raw status JSON instead of the human view.
+        #[arg(long)]
+        json: bool,
+    },
+    /// LLM-authored portfolio (or single-project) narrative, with a
+    /// deterministic fallback when no inference provider is configured.
+    Digest {
+        /// `portfolio` (default) or `project:<name>` to scope to one project.
+        #[arg(long, default_value = "portfolio")]
+        scope: String,
+        /// Emit the raw digest JSON instead of the human view.
+        #[arg(long)]
+        json: bool,
+    },
+    /// One-shot chat turn against the portfolio manager persona.
+    ///
+    /// Why (conversation-key convention, #2583): defaults to a stable
+    /// per-user key (`cli:$USER`, see `commands::manager::default_conversation_key`)
+    /// so repeated one-shot invocations on the same machine accumulate as one
+    /// ongoing conversation server-side (matching `SessionProxy`'s focus-map
+    /// keying, DOC-36 §3.2) — `--conversation` overrides it for scripts/tests
+    /// that need an isolated key. Interactive REPL mode (multi-turn within a
+    /// single process) is deferred to a follow-up; this ships the one-shot
+    /// form the issue's acceptance criteria require.
+    Chat {
+        /// The message to send. When omitted, reads the full message from
+        /// stdin (supports both piping and a terminal Ctrl-D-terminated
+        /// single message).
+        message: Option<String>,
+        /// Override the conversation key (defaults to a stable per-user key).
+        #[arg(long)]
+        conversation: Option<String>,
+        /// Emit the raw chat-response JSON instead of the human view.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Route a free-text task to the project it belongs to (advisory).
+    ///
+    /// Why (§7 Q5, RESOLVED 2026-07-14): a thin, API-first wrapper over
+    /// `POST /api/v1/manager/route-task` (WI-8, #2585) for headless/scriptable
+    /// use — it surfaces the resolved `{ project, confidence, rationale }` and
+    /// NEVER launches or mutates a session (acting on a route is the separate
+    /// explicit `/manager/act` proposal-and-confirm flow, WI-9). No separate
+    /// CLI-only disambiguation prompt is introduced for v1; disambiguation lives
+    /// entirely in the daemon's routing endpoint. Needs no channel/bot token.
+    Route {
+        /// The free-text task to route (e.g. "fix the flaky auth test").
+        text: String,
+        /// Emit the raw route-task JSON instead of the human view.
+        #[arg(long)]
+        json: bool,
+    },
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/manager.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/manager.rs
@@ -26,7 +26,7 @@
 //! `crates/trusty-mpm/tests/manager_cli_client.rs`.
 
 use trusty_mpm::client::DaemonClient;
-use trusty_mpm::client::http_client::manager::PortfolioStatusWire;
+use trusty_mpm::client::http_client::manager::{PortfolioStatusWire, RouteTaskOutcome};
 
 use crate::cli::ManagerAction;
 
@@ -55,6 +55,7 @@ pub(crate) async fn manager(
             conversation,
             json,
         } => chat(client, url, message, conversation, json).await,
+        ManagerAction::Route { text, json } => route(client, url, text, json).await,
     }
 }
 
@@ -196,6 +197,55 @@ pub(crate) async fn chat(
     }
     println!("{}", outcome.reply);
     Ok(())
+}
+
+/// `tm manager route <text> [--json]` — advisory task→project routing.
+///
+/// Why: the thin CLI half of `/api/v1/manager/route-task` (#2587) — no
+/// resolution logic client-side (the AC forbids it); it is one
+/// `DaemonClient::manager_route_task` call plus a render. Advisory only: it
+/// prints the resolved route and never launches or mutates a session.
+pub(crate) async fn route(
+    client: &reqwest::Client,
+    url: &str,
+    text: String,
+    json: bool,
+) -> anyhow::Result<()> {
+    if text.trim().is_empty() {
+        anyhow::bail!("tm manager route: text must not be empty");
+    }
+    // `None` here means the client feature-detected (via `GET /manager/version`)
+    // that this daemon predates the route-task endpoint (phase 2).
+    let outcome = daemon(client, url).manager_route_task(&text).await?;
+    let Some(outcome) = outcome else {
+        anyhow::bail!(
+            "this daemon does not support `manager route` yet — upgrade the daemon \
+             (`tm restart` after `cargo install trusty-mpm --locked`) and try again"
+        );
+    };
+    if json {
+        println!("{}", serde_json::to_string_pretty(&outcome.raw)?);
+        return Ok(());
+    }
+    println!("{}", render_route(&outcome));
+    Ok(())
+}
+
+/// Render the human view of a routed task.
+///
+/// Why: pure function of the parsed [`RouteTaskOutcome`] — testable without HTTP,
+/// matching the crate's plain-text status render style.
+/// What: one line naming the resolved project (or "no match"), the confidence,
+/// the decision path, and the rationale.
+/// Test: `render_route_resolved`, `render_route_no_match`.
+pub(crate) fn render_route(outcome: &RouteTaskOutcome) -> String {
+    match &outcome.project {
+        Some(project) => format!(
+            "route: {project} (confidence {:.2}, via {})\n  {}",
+            outcome.confidence, outcome.resolved_by, outcome.rationale,
+        ),
+        None => format!("route: no match\n  {}", outcome.rationale),
+    }
 }
 
 /// Read a one-shot chat message from stdin (piped or terminal, Ctrl-D-terminated).
@@ -427,5 +477,35 @@ mod tests {
         let mut reader = std::io::Cursor::new(b"  hello there  \n".to_vec());
         let msg = read_message_from_reader(&mut reader).unwrap();
         assert_eq!(msg, "hello there");
+    }
+
+    #[test]
+    fn render_route_resolved() {
+        let outcome = RouteTaskOutcome {
+            project: Some("alpha".to_string()),
+            confidence: 0.95,
+            rationale: "resolved to 'alpha' by exact name match".to_string(),
+            resolved_by: "resolver".to_string(),
+            raw: serde_json::json!({}),
+        };
+        let line = render_route(&outcome);
+        assert!(line.contains("alpha"), "{line}");
+        assert!(line.contains("0.95"), "{line}");
+        assert!(line.contains("resolver"), "{line}");
+        assert!(line.contains("exact name match"), "{line}");
+    }
+
+    #[test]
+    fn render_route_no_match() {
+        let outcome = RouteTaskOutcome {
+            project: None,
+            confidence: 0.0,
+            rationale: "no registered project matched the task".to_string(),
+            resolved_by: "no_match".to_string(),
+            raw: serde_json::json!({}),
+        };
+        let line = render_route(&outcome);
+        assert!(line.contains("no match"), "{line}");
+        assert!(line.contains("no registered project"), "{line}");
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -8,6 +8,7 @@
 //! Test: `cargo test -p trusty-mpm` runs the full suite in `tests.rs`.
 
 mod cli;
+mod cli_manager;
 mod commands;
 mod formatters;
 mod gh_identity;

--- a/crates/trusty-mpm/src/bin/tm/tests_manager.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_manager.rs
@@ -114,6 +114,28 @@ fn cli_parses_manager_chat_conversation_override() {
     }
 }
 
+#[test]
+fn cli_parses_manager_route() {
+    match manager_action(&["tm", "manager", "route", "fix the flaky auth test"]) {
+        ManagerAction::Route { text, json } => {
+            assert_eq!(text, "fix the flaky auth test");
+            assert!(!json);
+        }
+        other => panic!("expected Route, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_manager_route_json() {
+    match manager_action(&["tm", "manager", "route", "some task", "--json"]) {
+        ManagerAction::Route { text, json } => {
+            assert_eq!(text, "some task");
+            assert!(json);
+        }
+        other => panic!("expected Route, got {other:?}"),
+    }
+}
+
 /// A bare `tm manager` (no verb) must fail with a clap usage error — the
 /// action subcommand is mandatory, matching `ProjectsAction`'s convention.
 #[test]

--- a/crates/trusty-mpm/src/client/http_client/manager.rs
+++ b/crates/trusty-mpm/src/client/http_client/manager.rs
@@ -246,6 +246,57 @@ impl ManagerChatOutcome {
     }
 }
 
+/// Parsed result of `POST /api/v1/manager/route-task` (WI-8, #2585).
+///
+/// Why: backs `tm manager route` (#2587) — the thin CLI wrapper over the
+/// advisory routing endpoint. The daemon always returns a `{ project,
+/// confidence, rationale, resolved_by }` body on success (200) including the
+/// no-match case (`project: null`), so one parse function handles every routed
+/// result the CLI renders.
+/// What: the resolved project (`None` on no-match), the confidence, the
+/// rationale, and the decision path (`resolver` | `disambiguation` |
+/// `no_match`).
+/// Test: `route_task_outcome_reads_real_daemon_shape`,
+/// `route_task_outcome_reads_no_match` in this module's `tests` submodule.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RouteTaskOutcome {
+    /// The resolved project name, or `None` when nothing matched.
+    pub project: Option<String>,
+    /// Confidence in the resolved route, `[0.0, 1.0]`.
+    pub confidence: f32,
+    /// Human-readable rationale for the route.
+    pub rationale: String,
+    /// How the route was decided (`resolver` | `disambiguation` | `no_match`).
+    pub resolved_by: String,
+    /// The raw response body, kept for `--json` passthrough.
+    pub raw: Value,
+}
+
+impl RouteTaskOutcome {
+    /// Build from a `RouteTaskResponse`-shaped body. Returns `None` when the body
+    /// carries no `resolved_by` field at all (not this response shape).
+    fn from_body(raw: Value) -> Option<Self> {
+        let resolved_by = raw.get("resolved_by").and_then(Value::as_str)?.to_string();
+        let project = raw
+            .get("project")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let confidence = raw.get("confidence").and_then(Value::as_f64).unwrap_or(0.0) as f32;
+        let rationale = raw
+            .get("rationale")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        Some(Self {
+            project,
+            confidence,
+            rationale,
+            resolved_by,
+            raw,
+        })
+    }
+}
+
 /// Format a non-JSON (or unrecognized-shape) error body for `anyhow::bail!`.
 ///
 /// Why: `digest.rs`'s 400 (`invalid scope`) and 404 (`project '{name}' is not
@@ -438,6 +489,55 @@ impl DaemonClient {
 
         anyhow::bail!(daemon_error_text(status, &body_text))
     }
+
+    /// Route a free-text task to a project via `POST /api/v1/manager/route-task`.
+    ///
+    /// Why: backs `tm manager route` (#2587), against the shipped
+    /// `daemon/manager/route_task.rs` contract (WI-8, #2585). Advisory only —
+    /// resolving a route never launches or mutates a session. Same
+    /// feature-detected-404 handling as [`Self::manager_digest`]/
+    /// [`Self::manager_chat`]: a `404` maps to `Ok(None)` ONLY when
+    /// [`Self::manager_endpoint_available`] reports the route unmounted (an older
+    /// daemon predating phase 2), so the CLI can print a friendly upgrade hint
+    /// rather than a raw 404. Uses the longer chat-scoped timeout since a genuine
+    /// tie escalates to the daemon's own upstream LLM round trip (DOC-36 §3.3).
+    /// What: POSTs `{ text }`; parses the body as `RouteTaskResponse`-shaped on
+    /// ANY status code (the daemon returns 200 even for the advisory no-match);
+    /// `Ok(None)` on a genuine mount-detection 404; `Err` otherwise (carrying the
+    /// daemon's body message, e.g. a 400 for empty text).
+    /// Test: `route_task_outcome_reads_real_daemon_shape`,
+    /// `route_task_outcome_reads_no_match`; live HTTP in
+    /// `crates/trusty-mpm/tests/manager_routing.rs`.
+    pub async fn manager_route_task(&self, text: &str) -> anyhow::Result<Option<RouteTaskOutcome>> {
+        let url = format!("{}/api/v1/manager/route-task", self.base);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&serde_json::json!({ "text": text }))
+            .timeout(super::config::CHAT_REQUEST_TIMEOUT)
+            .send()
+            .await?;
+        let status = resp.status();
+        let body_text = resp.text().await.unwrap_or_default();
+
+        if let Ok(body) = serde_json::from_str::<Value>(&body_text)
+            && let Some(outcome) = RouteTaskOutcome::from_body(body)
+        {
+            return Ok(Some(outcome));
+        }
+
+        if status == StatusCode::NOT_FOUND {
+            if !self
+                .manager_endpoint_available("/api/v1/manager/route-task")
+                .await
+            {
+                return Ok(None);
+            }
+            anyhow::bail!(daemon_error_text(status, &body_text));
+        }
+
+        anyhow::bail!(daemon_error_text(status, &body_text))
+    }
 }
 
 #[cfg(test)]
@@ -562,5 +662,41 @@ mod tests {
     #[test]
     fn manager_chat_outcome_none_for_non_chat_shape() {
         assert!(ManagerChatOutcome::from_body(serde_json::json!({ "ok": true }), "k").is_none());
+    }
+
+    /// A resolved `RouteTaskResponse` — the real success shape from
+    /// `daemon/manager/route_task.rs`.
+    #[test]
+    fn route_task_outcome_reads_real_daemon_shape() {
+        let body = serde_json::json!({
+            "project": "alpha",
+            "confidence": 0.95,
+            "rationale": "resolved to 'alpha' by exact name match (confidence 0.95)",
+            "resolved_by": "resolver",
+        });
+        let outcome = RouteTaskOutcome::from_body(body).expect("RouteTaskResponse shape");
+        assert_eq!(outcome.project.as_deref(), Some("alpha"));
+        assert!((outcome.confidence - 0.95).abs() < 1e-6);
+        assert_eq!(outcome.resolved_by, "resolver");
+    }
+
+    /// The advisory no-match shape (`project: null`, confidence 0).
+    #[test]
+    fn route_task_outcome_reads_no_match() {
+        let body = serde_json::json!({
+            "project": null,
+            "confidence": 0.0,
+            "rationale": "no registered project matched the task",
+            "resolved_by": "no_match",
+        });
+        let outcome = RouteTaskOutcome::from_body(body).expect("no-match shape");
+        assert!(outcome.project.is_none());
+        assert_eq!(outcome.resolved_by, "no_match");
+    }
+
+    /// A body with no `resolved_by` field is not a route-task shape.
+    #[test]
+    fn route_task_outcome_none_for_non_route_shape() {
+        assert!(RouteTaskOutcome::from_body(serde_json::json!({ "error": "nope" })).is_none());
     }
 }

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -142,9 +142,7 @@ use super::managed_routes::{
     stop_managed_session, stop_managed_session_runtime,
 };
 // Layer-3 portfolio manager surface (`/api/v1/manager/*`, epic #2109, DOC-36).
-use super::manager::{
-    manager_chat_route, manager_digest_route, manager_status_route, manager_version_route,
-};
+use super::manager::manager_router;
 
 /// Typed HTTP response bodies for every endpoint.
 ///
@@ -341,16 +339,14 @@ pub fn router(state: Arc<DaemonState>) -> Router {
         // any channel connects. Registrations live with their handlers in
         // `managed_routes::proxy::proxy_router` and are merged here.
         .merge(proxy_router())
-        // Layer-3 portfolio manager surface (epic #2109, DOC-36 §3.2). Phase 1:
-        // a self-describing capabilities stub, the deterministic (no-LLM)
-        // cross-project rollup, the LLM-authored digest (deterministic fallback),
-        // and the read-only conversation-keyed chat loop. All are read-only and
-        // curl-testable with no channel/bot token (§4). Later WIs add
-        // route-task/escalations.
-        .route("/api/v1/manager/version", get(manager_version_route))
-        .route("/api/v1/manager/status", get(manager_status_route))
-        .route("/api/v1/manager/digest", get(manager_digest_route))
-        .route("/api/v1/manager/chat", post(manager_chat_route))
+        // Layer-3 portfolio manager surface (epic #2109, DOC-36 §3.2), merged as a
+        // self-contained sub-router (like the L2 `proxy_router`). Phase 1: the
+        // read-only capabilities stub, deterministic rollup, LLM digest, and chat
+        // loop. Phase 2: `route-task` (advisory task routing + disambiguation,
+        // #2585) and `act` (session launch/inject/summarize propose→confirm, which
+        // mutates ONLY on an explicit `confirm: true`, #2586). All curl-testable
+        // with no channel/bot token (§4).
+        .merge(manager_router())
         // DOC-35 §10.2/§10.5 (#2378 + #2380): Deliverable/Milestone CRUD, nested
         // under the projects namespace. The literal `/deliverables` and
         // `/milestones` segments come before their `/{id}` param routes so a

--- a/crates/trusty-mpm/src/daemon/manager/act.rs
+++ b/crates/trusty-mpm/src/daemon/manager/act.rs
@@ -1,0 +1,309 @@
+//! `POST /api/v1/manager/act` — session launch/inject/summarize proposal-and-
+//! confirm flow (WI-9, #2586, epic #2109, DOC-36 phase 2).
+//!
+//! Why: after `route-task` (#2585) resolves WHICH project a task belongs to, the
+//! manager may want to ACT — launch a session, or inject/summarize a specific
+//! session. DOC-35 §11 forbids acting without an explicit call and bans any
+//! silent/background mutation, so this endpoint models an explicit PROPOSE→CONFIRM
+//! protocol: a first call with `confirm` unset returns a human-readable PROPOSAL
+//! and does nothing; only a second call with `confirm: true` executes exactly that
+//! action, as one deliberate, traceable call. Execution never reimplements the
+//! composed subsystems — a launch calls #2108's launch verb ([`spawn_managed`] via
+//! the actuator), and a session-directed message routes through L2's real
+//! [`crate::client::proxy::SessionProxy`] — never a direct tmux mutation. The
+//! execution seam ([`ManagerActuator`], `actuator.rs`) is overridable on
+//! [`ManagerState`] so the hermetic suite drives the whole flow over a test-double
+//! launcher + a `SessionProxy` over a mock backend, with no live session/channel.
+//! What: [`ActRequest`]/[`ProposedAction`]/[`ActResponse`], the pure
+//! [`propose_message`] renderer, and the [`manager_act_route`] handler.
+//! Test: `propose_message_*` in `act_tests.rs`; the propose→confirm HTTP flow
+//! (launch + inject, over doubles) in `tests/manager_routing.rs`.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use super::actuator::{InjectOutcome, ManagerActuator, ProxyActuator, SummarizeOutcome};
+use crate::daemon::state::DaemonState;
+
+/// The action a caller proposes (and, on confirm, the manager executes).
+///
+/// Why: DOC-36 §3.2's manager acts in exactly three ways on a resolved route —
+/// launch a project session, inject a message into a session, or summarize a
+/// session. A `type`-tagged enum keeps the wire shape explicit and the handler
+/// exhaustive. `Serialize` too so the proposal response can echo the action back
+/// verbatim for the confirming call.
+/// What: [`Self::Launch`] (project + task), [`Self::Inject`] (session + text),
+/// [`Self::Summarize`] (session).
+/// Test: `propose_message_launch`, `propose_message_inject` in `act_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ProposedAction {
+    /// Launch a new session for a project (the #2108 launch verb).
+    Launch {
+        /// The project to launch a session for (as resolved by `route-task`).
+        project: String,
+        /// The task to seed the session with.
+        task: String,
+    },
+    /// Inject a message into a specific session (via `SessionProxy`).
+    Inject {
+        /// Managed session id, name, or unambiguous prefix.
+        session: String,
+        /// The message text to inject.
+        text: String,
+    },
+    /// Summarize a specific session's recent activity (via `SessionProxy`).
+    Summarize {
+        /// Managed session id, name, or unambiguous prefix.
+        session: String,
+    },
+}
+
+/// Request body for `POST /api/v1/manager/act`.
+///
+/// Why: the propose→confirm protocol needs the conversation key (so an inject
+/// routes through the same conversation-keyed focus map every channel uses), the
+/// action, and the explicit confirmation flag that gates execution.
+/// What: the conversation key, the [`ProposedAction`], and `confirm` (absent/false
+/// = propose only; true = execute).
+/// Test: HTTP coverage in `tests/manager_routing.rs`.
+#[derive(Debug, Deserialize)]
+pub struct ActRequest {
+    /// Conversation key (same keying shape as `SessionProxy`'s focus map).
+    pub conversation_key: String,
+    /// The proposed action.
+    pub action: ProposedAction,
+    /// Explicit confirmation. Absent/false returns a proposal WITHOUT executing.
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+/// Response body for `POST /api/v1/manager/act`.
+///
+/// Why: a `status`-tagged enum lets a caller branch on the outcome without probing
+/// for null fields. The propose case and every execution outcome (including the
+/// advisory "session not found"/"vanished"/"failed" states, which are valid
+/// results a caller must render, not transport errors — mirroring the proxy
+/// routes' always-200 convention) are distinct variants.
+/// What: `Proposed` (nothing executed) plus one variant per executed outcome.
+/// Test: HTTP coverage in `tests/manager_routing.rs`.
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ActResponse {
+    /// The action was PROPOSED, not executed — re-send with `confirm: true`.
+    Proposed {
+        /// A human-readable description of what confirming would do.
+        proposal: String,
+        /// The exact action to confirm (echo back on the confirming call).
+        action: ProposedAction,
+    },
+    /// A session was launched (the #2108 launch verb ran).
+    Launched {
+        /// Canonical session id.
+        session_id: String,
+        /// Friendly session name.
+        name: String,
+        /// Lifecycle state immediately after launch.
+        state: String,
+    },
+    /// A message was injected into the resolved session.
+    Injected {
+        /// Canonical session id it was sent to.
+        session_id: String,
+        /// Friendly session name.
+        name: String,
+        /// The injected text.
+        text: String,
+    },
+    /// A session's activity was summarized.
+    Summarized {
+        /// Canonical session id.
+        session_id: String,
+        /// Friendly session name.
+        name: String,
+        /// Lifecycle state.
+        state: String,
+        /// The activity summary text.
+        summary: String,
+        /// Any decision the session is blocked on.
+        pending_decision: Option<String>,
+    },
+    /// The target session could not be resolved (inject/summarize).
+    SessionNotFound {
+        /// The unresolved target.
+        session: String,
+        /// The resolution error.
+        error: String,
+    },
+    /// The target session vanished mid-action; focus was auto-cleared.
+    SessionVanished {
+        /// The session that was targeted.
+        session: String,
+        /// The "not found" error.
+        error: String,
+    },
+    /// A transient failure acting on the session (state preserved).
+    ActionFailed {
+        /// The session that was targeted.
+        session: String,
+        /// The transport/daemon error.
+        error: String,
+    },
+}
+
+impl From<InjectOutcome> for ActResponse {
+    fn from(o: InjectOutcome) -> Self {
+        match o {
+            InjectOutcome::Sent { target, text } => Self::Injected {
+                session_id: target.id,
+                name: target.name,
+                text,
+            },
+            InjectOutcome::NotFound { session, error } => Self::SessionNotFound { session, error },
+            InjectOutcome::Vanished { target, error } => Self::SessionVanished {
+                session: target.name,
+                error,
+            },
+            InjectOutcome::Failed { target, error } => Self::ActionFailed {
+                session: target.name,
+                error,
+            },
+        }
+    }
+}
+
+impl From<SummarizeOutcome> for ActResponse {
+    fn from(o: SummarizeOutcome) -> Self {
+        match o {
+            SummarizeOutcome::Summary {
+                target,
+                state,
+                summary,
+                pending_decision,
+            } => Self::Summarized {
+                session_id: target.id,
+                name: target.name,
+                state,
+                summary,
+                pending_decision,
+            },
+            SummarizeOutcome::NotFound { session, error } => {
+                Self::SessionNotFound { session, error }
+            }
+            SummarizeOutcome::Vanished { target, error } => Self::SessionVanished {
+                session: target.name,
+                error,
+            },
+            SummarizeOutcome::Failed { target, error } => Self::ActionFailed {
+                session: target.name,
+                error,
+            },
+        }
+    }
+}
+
+/// Render the human-readable proposal string for an action.
+///
+/// Why: the propose step must tell the operator EXACTLY what confirming will do,
+/// so the confirmation is informed — DOC-35 §11's "explicit call" made
+/// conversational. Pure so it is unit-testable without HTTP.
+/// What: a one-line description naming the action, its target, and the
+/// confirm-to-execute instruction.
+/// Test: `propose_message_launch`, `propose_message_inject`, `propose_message_summarize`.
+pub fn propose_message(action: &ProposedAction) -> String {
+    let body = match action {
+        ProposedAction::Launch { project, task } => {
+            format!("launch a new session for project '{project}' with task: {task:?}")
+        }
+        ProposedAction::Inject { session, text } => {
+            format!("inject into session '{session}' the message: {text:?}")
+        }
+        ProposedAction::Summarize { session } => {
+            format!("summarize the recent activity of session '{session}'")
+        }
+    };
+    format!("Proposed: {body}. Re-send this request with \"confirm\": true to execute it.")
+}
+
+/// `POST /api/v1/manager/act` handler (propose → confirm).
+///
+/// Why: the curl-first (§4) surface for acting on a resolved route WITHOUT silent
+/// mutation. A call with `confirm` unset returns a proposal and touches nothing; a
+/// call with `confirm: true` executes exactly one action through the
+/// [`ManagerActuator`] seam — a launch via #2108's launch verb, an inject/summarize
+/// via L2's `SessionProxy`.
+/// What: validates the conversation key (400 on empty); on `confirm == false`
+/// returns [`ActResponse::Proposed`]; on `confirm == true` resolves the actuator
+/// (a test override on [`ManagerState`], else a fresh production [`ProxyActuator`])
+/// and dispatches by action, rendering the structured outcome. A launch spawn
+/// error is a 502 (the one genuinely failing side effect); inject/summarize
+/// resolution/vanish/transient outcomes are valid advisory states returned as 200.
+/// Never logs task/message text (privacy).
+/// Test: HTTP coverage in `tests/manager_routing.rs`.
+pub async fn manager_act_route(
+    State(state): State<Arc<DaemonState>>,
+    Json(body): Json<ActRequest>,
+) -> impl IntoResponse {
+    let conversation_key = body.conversation_key.trim().to_string();
+    if conversation_key.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "invalid_request",
+                         "message": "conversation_key must not be empty" })),
+        )
+            .into_response();
+    }
+
+    // Propose-only: return what confirming would do; execute NOTHING.
+    if !body.confirm {
+        return Json(ActResponse::Proposed {
+            proposal: propose_message(&body.action),
+            action: body.action,
+        })
+        .into_response();
+    }
+
+    // Confirmed: resolve the execution seam (test override, else production).
+    let manager = state.manager_state();
+    let actuator: Arc<dyn ManagerActuator> = match manager.actuator_override() {
+        Some(a) => a,
+        None => Arc::new(ProxyActuator::production(&state)),
+    };
+
+    match body.action {
+        ProposedAction::Launch { project, task } => match actuator.launch(&project, &task).await {
+            Ok(outcome) => Json(ActResponse::Launched {
+                session_id: outcome.session_id,
+                name: outcome.name,
+                state: outcome.state,
+            })
+            .into_response(),
+            Err(error) => {
+                tracing::warn!("manager act: launch failed for project {project}: {error}");
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({ "error": "launch_failed", "message": error })),
+                )
+                    .into_response()
+            }
+        },
+        ProposedAction::Inject { session, text } => {
+            let outcome = actuator.inject(&conversation_key, &session, &text).await;
+            Json(ActResponse::from(outcome)).into_response()
+        }
+        ProposedAction::Summarize { session } => {
+            let outcome = actuator.summarize(&conversation_key, &session).await;
+            Json(ActResponse::from(outcome)).into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "act_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/manager/act.rs
+++ b/crates/trusty-mpm/src/daemon/manager/act.rs
@@ -266,14 +266,16 @@ pub async fn execute_action(
     action: ProposedAction,
 ) -> Result<ActResponse, String> {
     match action {
-        ProposedAction::Launch { project, task } => actuator
-            .launch(&project, &task)
-            .await
-            .map(|outcome| ActResponse::Launched {
-                session_id: outcome.session_id,
-                name: outcome.name,
-                state: outcome.state,
-            }),
+        ProposedAction::Launch { project, task } => {
+            actuator
+                .launch(&project, &task)
+                .await
+                .map(|outcome| ActResponse::Launched {
+                    session_id: outcome.session_id,
+                    name: outcome.name,
+                    state: outcome.state,
+                })
+        }
         ProposedAction::Inject { session, text } => Ok(ActResponse::from(
             actuator.inject(conversation_key, &session, &text).await,
         )),

--- a/crates/trusty-mpm/src/daemon/manager/act.rs
+++ b/crates/trusty-mpm/src/daemon/manager/act.rs
@@ -28,7 +28,7 @@ use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use super::actuator::{InjectOutcome, ManagerActuator, ProxyActuator, SummarizeOutcome};
+use super::actuator::{InjectOutcome, ManagerActuator, SummarizeOutcome, resolve_actuator};
 use crate::daemon::state::DaemonState;
 
 /// The action a caller proposes (and, on confirm, the manager executes).
@@ -76,6 +76,20 @@ pub enum ProposedAction {
 #[derive(Debug, Deserialize)]
 pub struct ActRequest {
     /// Conversation key (same keying shape as `SessionProxy`'s focus map).
+    ///
+    /// Why REQUIRED uniformly across every [`ProposedAction`] variant — including
+    /// `Launch`, whose execution path (`execute_action`) does not read it at all:
+    /// this is a DELIBERATE consistency/audit-trail choice (coordinator review
+    /// finding 3), not an oversight. Every manager action — proposed via this
+    /// endpoint or via the chat loop's in-conversation propose/confirm (#2586,
+    /// `chat.rs`) — is attributable to the conversation that proposed it, and a
+    /// single uniform validation rule (`400` on empty, for every action type) is
+    /// simpler to reason about and test than a per-variant carve-out. A future
+    /// caller that wants a conversation-less launch should mint a synthetic key
+    /// (e.g. `"api:<uuid>"`) rather than have the server special-case `Launch`.
+    /// Test: `act_empty_conversation_key_is_400` (Summarize),
+    /// `act_launch_also_requires_conversation_key` (Launch) in
+    /// `tests/manager_routing.rs`.
     pub conversation_key: String,
     /// The proposed action.
     pub action: ProposedAction,
@@ -231,18 +245,60 @@ pub fn propose_message(action: &ProposedAction) -> String {
     format!("Proposed: {body}. Re-send this request with \"confirm\": true to execute it.")
 }
 
+/// Execute a confirmed [`ProposedAction`] through the [`ManagerActuator`] seam.
+///
+/// Why: BOTH `/manager/act`'s confirm branch and the chat loop's in-conversation
+/// confirm turn (#2586, coordinator review finding 1) must execute an action the
+/// IDENTICAL way — through the same actuator instance and the same
+/// [`ProposedAction`]/[`ActResponse`] types — so extracting the dispatch here is
+/// what makes the chat wiring a genuine reuse rather than a parallel copy.
+/// What: dispatches by variant — `Launch` calls [`ManagerActuator::launch`] and
+/// maps `Err` to a `String` (the caller decides how to render a launch failure,
+/// since `/manager/act` renders it as a 502 while chat renders it inline in the
+/// reply); `Inject`/`Summarize` call the matching actuator verb and always
+/// succeed at the HTTP layer (their failure modes are valid [`ActResponse`]
+/// variants, never a hard error).
+/// Test: HTTP coverage in `tests/manager_routing.rs` (both the `/manager/act`
+/// confirm path and the chat propose-confirm suite exercise this).
+pub async fn execute_action(
+    actuator: &Arc<dyn ManagerActuator>,
+    conversation_key: &str,
+    action: ProposedAction,
+) -> Result<ActResponse, String> {
+    match action {
+        ProposedAction::Launch { project, task } => actuator
+            .launch(&project, &task)
+            .await
+            .map(|outcome| ActResponse::Launched {
+                session_id: outcome.session_id,
+                name: outcome.name,
+                state: outcome.state,
+            }),
+        ProposedAction::Inject { session, text } => Ok(ActResponse::from(
+            actuator.inject(conversation_key, &session, &text).await,
+        )),
+        ProposedAction::Summarize { session } => Ok(ActResponse::from(
+            actuator.summarize(conversation_key, &session).await,
+        )),
+    }
+}
+
 /// `POST /api/v1/manager/act` handler (propose → confirm).
 ///
 /// Why: the curl-first (§4) surface for acting on a resolved route WITHOUT silent
 /// mutation. A call with `confirm` unset returns a proposal and touches nothing; a
 /// call with `confirm: true` executes exactly one action through the
 /// [`ManagerActuator`] seam — a launch via #2108's launch verb, an inject/summarize
-/// via L2's `SessionProxy`.
-/// What: validates the conversation key (400 on empty); on `confirm == false`
-/// returns [`ActResponse::Proposed`]; on `confirm == true` resolves the actuator
-/// (a test override on [`ManagerState`], else a fresh production [`ProxyActuator`])
-/// and dispatches by action, rendering the structured outcome. A launch spawn
-/// error is a 502 (the one genuinely failing side effect); inject/summarize
+/// via L2's `SessionProxy`. This is ALSO the seam the chat loop's confirm turn
+/// drives (`chat.rs`, #2586) via the shared [`execute_action`] helper — the API
+/// route and the conversational confirm turn execute identically.
+/// What: validates the conversation key (400 on empty — required uniformly across
+/// every action, including `Launch`, which does not read it operationally; see
+/// [`ActRequest::conversation_key`]'s doc for why); on `confirm == false` returns
+/// [`ActResponse::Proposed`]; on `confirm == true` resolves the actuator (a test
+/// override on [`ManagerState`], else a fresh production `ProxyActuator`, via
+/// [`resolve_actuator`]) and calls [`execute_action`]. A launch spawn error is a
+/// 502 (the one genuinely failing side effect); inject/summarize
 /// resolution/vanish/transient outcomes are valid advisory states returned as 200.
 /// Never logs task/message text (privacy).
 /// Test: HTTP coverage in `tests/manager_routing.rs`.
@@ -269,37 +325,18 @@ pub async fn manager_act_route(
         .into_response();
     }
 
-    // Confirmed: resolve the execution seam (test override, else production).
-    let manager = state.manager_state();
-    let actuator: Arc<dyn ManagerActuator> = match manager.actuator_override() {
-        Some(a) => a,
-        None => Arc::new(ProxyActuator::production(&state)),
-    };
-
-    match body.action {
-        ProposedAction::Launch { project, task } => match actuator.launch(&project, &task).await {
-            Ok(outcome) => Json(ActResponse::Launched {
-                session_id: outcome.session_id,
-                name: outcome.name,
-                state: outcome.state,
-            })
-            .into_response(),
-            Err(error) => {
-                tracing::warn!("manager act: launch failed for project {project}: {error}");
-                (
-                    StatusCode::BAD_GATEWAY,
-                    Json(json!({ "error": "launch_failed", "message": error })),
-                )
-                    .into_response()
-            }
-        },
-        ProposedAction::Inject { session, text } => {
-            let outcome = actuator.inject(&conversation_key, &session, &text).await;
-            Json(ActResponse::from(outcome)).into_response()
-        }
-        ProposedAction::Summarize { session } => {
-            let outcome = actuator.summarize(&conversation_key, &session).await;
-            Json(ActResponse::from(outcome)).into_response()
+    // Confirmed: resolve the execution seam (test override, else production) and
+    // execute through the SAME dispatch the chat confirm turn uses.
+    let actuator = resolve_actuator(&state);
+    match execute_action(&actuator, &conversation_key, body.action).await {
+        Ok(response) => Json(response).into_response(),
+        Err(error) => {
+            tracing::warn!("manager act: action execution failed: {error}");
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": "launch_failed", "message": error })),
+            )
+                .into_response()
         }
     }
 }

--- a/crates/trusty-mpm/src/daemon/manager/act_tests.rs
+++ b/crates/trusty-mpm/src/daemon/manager/act_tests.rs
@@ -1,0 +1,55 @@
+//! Unit tests for the pure `/manager/act` proposal renderer (WI-9, #2586).
+
+use super::*;
+
+#[test]
+fn propose_message_launch() {
+    let action = ProposedAction::Launch {
+        project: "alpha".to_string(),
+        task: "fix the flaky auth test".to_string(),
+    };
+    let msg = propose_message(&action);
+    assert!(
+        msg.starts_with("Proposed: launch a new session for project 'alpha'"),
+        "{msg}"
+    );
+    assert!(msg.contains("fix the flaky auth test"), "{msg}");
+    assert!(msg.contains("\"confirm\": true"), "{msg}");
+}
+
+#[test]
+fn propose_message_inject() {
+    let action = ProposedAction::Inject {
+        session: "sess-1".to_string(),
+        text: "run the tests".to_string(),
+    };
+    let msg = propose_message(&action);
+    assert!(msg.contains("inject into session 'sess-1'"), "{msg}");
+    assert!(msg.contains("run the tests"), "{msg}");
+}
+
+#[test]
+fn propose_message_summarize() {
+    let action = ProposedAction::Summarize {
+        session: "sess-2".to_string(),
+    };
+    let msg = propose_message(&action);
+    assert!(
+        msg.contains("summarize the recent activity of session 'sess-2'"),
+        "{msg}"
+    );
+}
+
+/// The action round-trips through serde so a proposal response can be echoed back
+/// verbatim on the confirming call.
+#[test]
+fn proposed_action_serde_round_trip() {
+    let action = ProposedAction::Launch {
+        project: "alpha".to_string(),
+        task: "t".to_string(),
+    };
+    let json = serde_json::to_value(&action).unwrap();
+    assert_eq!(json["type"], "launch");
+    let back: ProposedAction = serde_json::from_value(json).unwrap();
+    assert_eq!(back, action);
+}

--- a/crates/trusty-mpm/src/daemon/manager/actuator.rs
+++ b/crates/trusty-mpm/src/daemon/manager/actuator.rs
@@ -206,6 +206,23 @@ impl SessionLauncher for DaemonLauncher {
     }
 }
 
+/// Resolve the `/manager/act` + chat-confirm execution seam.
+///
+/// Why: BOTH `act.rs`'s confirm branch and `chat.rs`'s in-conversation confirm
+/// turn (#2586) need the identical "test override, else fresh production
+/// actuator" resolution — centralising it here is what makes the confirm-turn
+/// wiring `reuse the actuator, not duplicate it` (coordinator review finding 1).
+/// What: returns [`super::ManagerState::actuator_override`] when installed
+/// (hermetic suite), else a fresh [`ProxyActuator::production`].
+/// Test: exercised via `tests/manager_routing.rs` (act) and the chat
+/// propose-confirm suite in the same file.
+pub fn resolve_actuator(state: &Arc<DaemonState>) -> Arc<dyn ManagerActuator> {
+    match state.manager_state().actuator_override() {
+        Some(actuator) => actuator,
+        None => Arc::new(ProxyActuator::production(state)),
+    }
+}
+
 /// The action seam the `/manager/act` handler executes on confirm.
 ///
 /// Why: type-erasing the concrete executor behind a trait is what lets

--- a/crates/trusty-mpm/src/daemon/manager/actuator.rs
+++ b/crates/trusty-mpm/src/daemon/manager/actuator.rs
@@ -1,0 +1,364 @@
+//! The manager's action seam for the proposal-and-confirm flow (WI-9, #2586).
+//!
+//! Why: DOC-36 §3.2 lets the Layer-3 manager ACT on a resolved route — launch a
+//! session for a project, or inject/summarize a specific session — but DOC-35 §11
+//! forbids any silent/background mutation: every action must be one deliberate,
+//! traceable call. The `/manager/act` handler (`act.rs`) owns the propose→confirm
+//! protocol; this module owns the EXECUTION seam it drives on confirm, built so it
+//! never reimplements the two subsystems it composes. A session launch calls
+//! #2108's launch verb ([`spawn_managed`], DOC-35 §3.2); a session-directed
+//! message routes through L2's existing [`SessionProxy`] (`client/proxy.rs`) —
+//! never a direct tmux mutation. Splitting the two composed operations behind
+//! their own small seams ([`SessionLauncher`] + the injected [`SessionProxy`])
+//! is exactly what lets the hermetic suite (#2586 AC) drive the whole flow with a
+//! test-double launcher and a test-double [`crate::client::proxy::ManagedBackend`]
+//! under a real [`SessionProxy`], with no live session or channel.
+//! What: [`ManagerActuator`] (the trait the handler consumes, overridable on
+//! [`super::ManagerState`] for tests), [`ProxyActuator`] (the ONE concrete impl,
+//! used in production over [`DaemonLauncher`] + the daemon's real proxy and in
+//! tests over doubles), the [`SessionLauncher`] launch seam + its production
+//! [`DaemonLauncher`], and the structured [`LaunchOutcome`]/[`InjectOutcome`]/
+//! [`SummarizeOutcome`] results the handler renders.
+//! Test: `daemon_launcher_unknown_project_errors` here; the propose→confirm HTTP
+//! flow (with a test-double launcher + `SessionProxy` over a mock backend) in
+//! `tests/manager_routing.rs`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::client::proxy::{
+    FocusOutcome, FocusTarget, InjectOutcome as ProxyInjectOutcome, SessionProxy,
+    SummarizeOutcome as ProxySummarizeOutcome,
+};
+use crate::daemon::managed_routes::{SpawnParams, spawn_managed};
+use crate::daemon::state::DaemonState;
+use crate::session_manager::record::ManagedSessionId;
+
+/// A launched session, as reported back to a confirming caller.
+///
+/// Why: the confirm response echoes just enough of the newly-created session for
+/// the caller (CLI/channel) to name and reach it, without leaking the full record.
+/// What: the canonical session id, its tmux/display name, and its lifecycle state.
+/// Test: exercised via the launch HTTP path in `tests/manager_routing.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchOutcome {
+    /// Canonical managed-session id.
+    pub session_id: String,
+    /// Friendly session name.
+    pub name: String,
+    /// Lifecycle state immediately after launch.
+    pub state: String,
+}
+
+/// Result of a confirmed INJECT (focus-then-send through [`SessionProxy`]).
+///
+/// Why: focusing then injecting has genuinely distinct outcomes a caller must
+/// render differently — the target could not be resolved, it was sent, the
+/// session vanished mid-send (auto-unfocused), or a transient failure preserved
+/// focus. Modelling all four keeps the handler exhaustive.
+/// What: mirrors the proxy's own [`ProxyInjectOutcome`] plus a `NotFound` for the
+/// focus-resolution failure that precedes the send.
+/// Test: `tests/manager_routing.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InjectOutcome {
+    /// The text was injected into the resolved session.
+    Sent {
+        /// The session it was sent to.
+        target: FocusTarget,
+        /// The injected text.
+        text: String,
+    },
+    /// The session could not be resolved (focus failed) — nothing was sent.
+    NotFound {
+        /// The unresolved target.
+        session: String,
+        /// The backend error.
+        error: String,
+    },
+    /// The session vanished during send; focus was auto-cleared.
+    Vanished {
+        /// The session that was targeted.
+        target: FocusTarget,
+        /// The "not found" error that triggered the auto-unfocus.
+        error: String,
+    },
+    /// A transient failure during send.
+    Failed {
+        /// The session that was targeted.
+        target: FocusTarget,
+        /// The transport/daemon error.
+        error: String,
+    },
+}
+
+/// Result of a confirmed SUMMARIZE (focus-then-summarize through [`SessionProxy`]).
+///
+/// Why: mirrors [`InjectOutcome`]'s four-way split for the summarize direction.
+/// What: the digest on success, or the same resolution/vanish/transient failures.
+/// Test: `tests/manager_routing.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SummarizeOutcome {
+    /// A digest of the resolved session's recent activity.
+    Summary {
+        /// The summarized session.
+        target: FocusTarget,
+        /// The session's lifecycle state.
+        state: String,
+        /// The activity summary text.
+        summary: String,
+        /// Any decision the session is blocked on.
+        pending_decision: Option<String>,
+    },
+    /// The session could not be resolved.
+    NotFound {
+        /// The unresolved target.
+        session: String,
+        /// The backend error.
+        error: String,
+    },
+    /// The session vanished; focus was auto-cleared.
+    Vanished {
+        /// The session that was targeted.
+        target: FocusTarget,
+        /// The "not found" error.
+        error: String,
+    },
+    /// A transient failure.
+    Failed {
+        /// The session that was targeted.
+        target: FocusTarget,
+        /// The transport/daemon error.
+        error: String,
+    },
+}
+
+/// The launch seam: create a session for a named project (#2108 launch verb).
+///
+/// Why: launching is the ONE genuinely stateful, environment-touching action the
+/// manager can take, so it sits behind its own trait — the production impl calls
+/// the real [`spawn_managed`] verb, while the hermetic suite injects a recording
+/// double so the propose→confirm flow is testable with no provisioning.
+/// What: `launch` maps a project name + task to a [`LaunchOutcome`] or an error
+/// string (unknown project, spawn failure).
+/// Test: `daemon_launcher_unknown_project_errors`; the double in
+/// `tests/manager_routing.rs`.
+#[async_trait]
+pub trait SessionLauncher: Send + Sync {
+    /// Launch a session for `project` with the given `task`.
+    async fn launch(&self, project: &str, task: &str) -> Result<LaunchOutcome, String>;
+}
+
+/// Production [`SessionLauncher`] over this daemon's real launch verb.
+///
+/// Why: the manager must call #2108's launch verb EXPLICITLY (DOC-35 §3.2), never
+/// a bespoke spawn path — so this resolves the project from the registry and calls
+/// the shared [`spawn_managed`] the HTTP `spawn_session` route also uses.
+/// What: wraps `Arc<DaemonState>`; `launch` looks up the project by exact name,
+/// builds a turnkey [`SpawnParams`] from its `repo_url`/`default_branch`, and
+/// spawns via [`spawn_managed`] with a fresh id.
+/// Test: `daemon_launcher_unknown_project_errors` (the no-provisioning error
+/// path); the happy path is covered by the existing spawn integration tests.
+pub struct DaemonLauncher {
+    state: Arc<DaemonState>,
+}
+
+impl DaemonLauncher {
+    /// Wrap `state` for real-launch access.
+    pub fn new(state: Arc<DaemonState>) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl SessionLauncher for DaemonLauncher {
+    async fn launch(&self, project: &str, task: &str) -> Result<LaunchOutcome, String> {
+        let registry = self.state.project_registry().await;
+        let projects = registry
+            .list()
+            .await
+            .map_err(|e| format!("project registry read failed: {e}"))?;
+        let Some(found) = projects.iter().find(|p| p.name == project) else {
+            return Err(format!("project '{project}' is not registered"));
+        };
+        let params = SpawnParams {
+            repo_url: found.repo_url.clone(),
+            git_ref: found.default_branch.clone(),
+            task: task.to_string(),
+            name_hint: None,
+            runtime: None,
+            ephemeral: None,
+            // Operator-confirmed manager action — a trusted, explicit path, never
+            // the MCP spawn gate (SpawnParams::mcp_initiated).
+            mcp_initiated: false,
+            // Turnkey: inject the task once the runtime is ready (the default).
+            inject_task: None,
+            deliverable_id: None,
+            // A confirmed "launch" is an explicit new-session intent.
+            force_new: true,
+        };
+        let record = spawn_managed(&self.state, ManagedSessionId::new(), params).await?;
+        Ok(LaunchOutcome {
+            session_id: record.id.to_string(),
+            name: record.tmux_name.clone(),
+            state: record.state.to_string(),
+        })
+    }
+}
+
+/// The action seam the `/manager/act` handler executes on confirm.
+///
+/// Why: type-erasing the concrete executor behind a trait is what lets
+/// [`super::ManagerState`] carry an optional TEST override (installed via
+/// [`super::ManagerState::set_actuator`]) so the hermetic suite swaps in a
+/// [`ProxyActuator`] built over doubles, exactly as the inference seam is swapped
+/// for a `ScriptedAdapter`. Production builds a fresh [`ProxyActuator`] per request.
+/// What: three async verbs — `launch`, `inject`, `summarize` — each returning a
+/// structured outcome the handler renders as JSON.
+/// Test: `tests/manager_routing.rs` (over a double); production wiring in `act.rs`.
+#[async_trait]
+pub trait ManagerActuator: Send + Sync {
+    /// Launch a session for `project` with `task` (the #2108 launch verb).
+    async fn launch(&self, project: &str, task: &str) -> Result<LaunchOutcome, String>;
+    /// Inject `text` into `session` for `conversation_key`, via [`SessionProxy`].
+    async fn inject(&self, conversation_key: &str, session: &str, text: &str) -> InjectOutcome;
+    /// Summarize `session` for `conversation_key`, via [`SessionProxy`].
+    async fn summarize(&self, conversation_key: &str, session: &str) -> SummarizeOutcome;
+}
+
+/// The ONE concrete [`ManagerActuator`]: launch via a [`SessionLauncher`], and
+/// inject/summarize via a real [`SessionProxy`].
+///
+/// Why: keeping a single implementation used in BOTH production and tests (only
+/// its two seams differ) means the hermetic test exercises the SAME code path the
+/// daemon runs — the real [`SessionProxy`] focus/inject/summarize state machine,
+/// just over a test-double backend and launcher (#2586 AC). No parallel test-only
+/// executor to drift from production.
+/// What: holds an `Arc<dyn SessionLauncher>` and a [`SessionProxy`]; `inject`/
+/// `summarize` focus the target for the conversation then act, mapping the proxy's
+/// own outcomes (including the focus-resolution failure) into [`InjectOutcome`]/
+/// [`SummarizeOutcome`].
+/// Test: `tests/manager_routing.rs`.
+pub struct ProxyActuator {
+    launcher: Arc<dyn SessionLauncher>,
+    proxy: SessionProxy,
+}
+
+impl ProxyActuator {
+    /// Build a [`ProxyActuator`] from its two seams.
+    ///
+    /// Why: production passes [`DaemonLauncher`] + the daemon's real
+    /// `local_proxy`; the hermetic test passes a recording launcher +
+    /// `SessionProxy::new(mock_backend)`.
+    /// What: stores both seams.
+    /// Test: `tests/manager_routing.rs`.
+    pub fn new(launcher: Arc<dyn SessionLauncher>, proxy: SessionProxy) -> Self {
+        Self { launcher, proxy }
+    }
+
+    /// Build the production actuator from daemon state.
+    ///
+    /// Why: the `/manager/act` handler builds this fresh per request when no test
+    /// override is installed — wiring the real launch verb and the daemon's shared
+    /// proxy focus store in one place.
+    /// What: a [`ProxyActuator`] over [`DaemonLauncher`] and
+    /// [`crate::daemon::managed_routes::proxy::local_proxy`].
+    /// Test: production wiring exercised via `act.rs`'s handler.
+    pub fn production(state: &Arc<DaemonState>) -> Self {
+        Self::new(
+            Arc::new(DaemonLauncher::new(Arc::clone(state))),
+            crate::daemon::managed_routes::proxy::local_proxy(state),
+        )
+    }
+}
+
+#[async_trait]
+impl ManagerActuator for ProxyActuator {
+    async fn launch(&self, project: &str, task: &str) -> Result<LaunchOutcome, String> {
+        self.launcher.launch(project, task).await
+    }
+
+    async fn inject(&self, conversation_key: &str, session: &str, text: &str) -> InjectOutcome {
+        // Focus the target first — resolution failure is a distinct, no-send
+        // outcome — then inject through the SAME SessionProxy state machine every
+        // channel uses (never a direct tmux mutation).
+        match self.proxy.focus(conversation_key, session).await {
+            FocusOutcome::NotFound { target, error } => InjectOutcome::NotFound {
+                session: target,
+                error,
+            },
+            FocusOutcome::Focused(_) | FocusOutcome::Current(_) => {
+                match self.proxy.inject(conversation_key, text).await {
+                    ProxyInjectOutcome::Sent { target, text } => {
+                        InjectOutcome::Sent { target, text }
+                    }
+                    ProxyInjectOutcome::AutoUnfocused { target, error } => {
+                        InjectOutcome::Vanished { target, error }
+                    }
+                    ProxyInjectOutcome::Failed { target, error } => {
+                        InjectOutcome::Failed { target, error }
+                    }
+                    // Focus succeeded immediately above, so NoFocus is unreachable
+                    // in practice; treat it as a resolution failure defensively.
+                    ProxyInjectOutcome::NoFocus => InjectOutcome::NotFound {
+                        session: session.to_string(),
+                        error: "focus was cleared before inject".to_string(),
+                    },
+                }
+            }
+        }
+    }
+
+    async fn summarize(&self, conversation_key: &str, session: &str) -> SummarizeOutcome {
+        match self.proxy.focus(conversation_key, session).await {
+            FocusOutcome::NotFound { target, error } => SummarizeOutcome::NotFound {
+                session: target,
+                error,
+            },
+            FocusOutcome::Focused(_) | FocusOutcome::Current(_) => {
+                match self.proxy.summarize(conversation_key).await {
+                    ProxySummarizeOutcome::Summary {
+                        target,
+                        state,
+                        summary,
+                        pending_decision,
+                    } => SummarizeOutcome::Summary {
+                        target,
+                        state,
+                        summary,
+                        pending_decision,
+                    },
+                    ProxySummarizeOutcome::AutoUnfocused { target, error } => {
+                        SummarizeOutcome::Vanished { target, error }
+                    }
+                    ProxySummarizeOutcome::Failed { target, error } => {
+                        SummarizeOutcome::Failed { target, error }
+                    }
+                    ProxySummarizeOutcome::NoFocus => SummarizeOutcome::NotFound {
+                        session: session.to_string(),
+                        error: "focus was cleared before summarize".to_string(),
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The production launcher rejects an unknown project BEFORE any provisioning
+    /// side effect — a hermetic assertion needing no tmux/worktree.
+    #[tokio::test]
+    async fn daemon_launcher_unknown_project_errors() {
+        let root = tempfile::tempdir().unwrap().keep();
+        let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+        let launcher = DaemonLauncher::new(Arc::clone(&state));
+        let err = launcher
+            .launch("does-not-exist", "some task")
+            .await
+            .expect_err("unknown project must error");
+        assert!(err.contains("not registered"), "{err}");
+    }
+}

--- a/crates/trusty-mpm/src/daemon/manager/chat.rs
+++ b/crates/trusty-mpm/src/daemon/manager/chat.rs
@@ -245,42 +245,40 @@ pub async fn manager_chat_route(
     // Phase 2 (#2586): consult the pending-proposal store BEFORE any LLM call.
     // `take` unconditionally consumes (next-turn-only TTL) — a confirming
     // message executes it via the SAME actuator seam `/manager/act` uses; any
-    // other message just lets it expire and falls through to the normal flow.
-    if let Some(pending) = manager.proposals().take(&conversation_key) {
-        if is_confirmation(&body.message) {
-            let actuator = resolve_actuator(&state);
-            let action_result = match execute_action(&actuator, &conversation_key, pending).await
-            {
-                Ok(response) => response,
-                Err(error) => {
-                    tracing::warn!("manager chat: confirmed action failed: {error}");
-                    ActResponse::ActionFailed {
-                        session: "(launch)".to_string(),
-                        error,
-                    }
+    // other message just lets it expire and falls through to the normal flow
+    // (the `take` above already consumed it either way).
+    if let Some(pending) = manager.proposals().take(&conversation_key)
+        && is_confirmation(&body.message)
+    {
+        let actuator = resolve_actuator(&state);
+        let action_result = match execute_action(&actuator, &conversation_key, pending).await {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::warn!("manager chat: confirmed action failed: {error}");
+                ActResponse::ActionFailed {
+                    session: "(launch)".to_string(),
+                    error,
                 }
-            };
-            let reply = describe_action_result(&action_result);
-            let model = manager.inference().model();
-            let turn_count =
-                manager
-                    .conversations()
-                    .record_exchange(&conversation_key, &body.message, &reply);
+            }
+        };
+        let reply = describe_action_result(&action_result);
+        let model = manager.inference().model();
+        let turn_count =
             manager
-                .palace()
-                .record_chat_turn(&conversation_key, &body.message, &reply)
-                .await;
-            return Json(ChatReplyBody {
-                conversation_key,
-                reply,
-                model,
-                turn_count,
-                action_result: Some(action_result),
-            })
-            .into_response();
-        }
-        // Not a confirmation — the pending proposal has already expired (taken
-        // above); proceed to the normal flow with the current message.
+                .conversations()
+                .record_exchange(&conversation_key, &body.message, &reply);
+        manager
+            .palace()
+            .record_chat_turn(&conversation_key, &body.message, &reply)
+            .await;
+        return Json(ChatReplyBody {
+            conversation_key,
+            reply,
+            model,
+            turn_count,
+            action_result: Some(action_result),
+        })
+        .into_response();
     }
 
     let status = match load_portfolio_status(&state).await {

--- a/crates/trusty-mpm/src/daemon/manager/chat.rs
+++ b/crates/trusty-mpm/src/daemon/manager/chat.rs
@@ -1,19 +1,37 @@
-//! `POST /api/v1/manager/chat` — read-only portfolio chat loop (WI-4, #2581).
+//! `POST /api/v1/manager/chat` — conversation-keyed portfolio chat loop, with a
+//! phase-2 in-conversation propose→confirm action flow (WI-4 #2581, WI-9 #2586).
 //!
 //! Why: DOC-36 §3.2 gives `tm manager` a conversation-keyed chat turn against the
-//! portfolio-manager persona. In phase 1 it is strictly READ-ONLY: a plain
-//! completion over context (the deterministic portfolio snapshot + recent turns),
-//! with NO tool-calling surface — so it structurally cannot launch/inject/kill a
-//! session or mutate a Deliverable/Milestone (DOC-35 §11 / DOC-36 §2.1 boundary;
-//! zero writes to #2108 records). Conversations are keyed exactly like L2's
-//! SessionProxy focus map (`client/proxy.rs`, a `conversation_key` string). Turns
-//! are dual-written to the portfolio palace when available and degrade silently to
-//! no-persistence otherwise (§3.4). LLM calls go through the unified
-//! `trusty_common::inference` adapter (§3.3); no channel/bot token is required (§4).
-//! What: [`ChatRequestBody`]/[`ChatReplyBody`], the snapshot+history prompt builder
-//! [`build_chat_messages`], and the [`manager_chat_route`] handler.
+//! portfolio-manager persona. Phase 1 shipped it strictly read-only; DOC-36 §6
+//! phase 2 EXPLICITLY SUPERSEDES that framing (coordinator review of #2586: the
+//! issue's primary acceptance criterion is that the CHAT LOOP itself — not only
+//! the standalone `/manager/act` endpoint — "proposes a session launch/inject
+//! action in-conversation and only executes it after explicit user confirmation
+//! in the same [conversation]"). This module now supports exactly that: when the
+//! model's reply embeds a proposal (see [`super::proposal::extract_proposed_action`]),
+//! the chat handler stores it as PENDING for that `conversation_key` and returns
+//! it to the caller as advisory text — NOTHING is executed. Only when the VERY
+//! NEXT turn on that same key is an explicit confirmation
+//! ([`super::proposal::is_confirmation`]) does the handler execute it, via the
+//! SAME [`super::act::execute_action`] dispatch and [`super::actuator::ManagerActuator`]
+//! seam `/manager/act` uses — never a duplicated execution path. A pending
+//! proposal NEVER survives past that immediately-following turn (next-turn-only
+//! TTL, [`super::proposal::ProposalStore`]) — an operator who moves on to a
+//! different topic and later says "confirm" out of context executes nothing.
+//! DOC-35 §11's boundary is satisfied by the EXPLICIT CONFIRMATION TURN, not by
+//! chat being structurally incapable of acting: the request still carries NO
+//! `tools` (the proposal is a parsed text sentinel, never real tool-calling), and
+//! a PLAIN message (no proposal, no confirmation) still never mutates anything.
+//! What: [`ChatReplyBody`]/[`ChatRequestBody`], the snapshot+history prompt
+//! builder [`build_chat_messages`] (now also documenting the proposal sentinel
+//! format to the model), and the [`manager_chat_route`] handler, which checks the
+//! pending-proposal store BEFORE any LLM call so a confirm turn executes with
+//! ZERO inference calls.
 //! Test: `build_chat_messages_includes_context_and_history` in `chat_tests.rs`;
-//! HTTP multi-turn / degrade / read-only coverage in `tests/manager_inference.rs`.
+//! HTTP multi-turn / degrade / no-tools coverage in `tests/manager_inference.rs`;
+//! the propose→confirm suite (proposal executes nothing, confirm executes
+//! exactly once, cross-conversation isolation, next-turn expiry, plain messages
+//! never execute) in `tests/manager_routing.rs`.
 
 use std::sync::Arc;
 
@@ -25,8 +43,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use trusty_common::inference::{ChatMessage, ChatRequest};
 
+use super::act::{ActResponse, execute_action, propose_message};
+use super::actuator::resolve_actuator;
 use super::chat_store::{ChatTurn, TurnRole};
 use super::inference::{MANAGER_MAX_TOKENS, MANAGER_TEMPERATURE};
+use super::proposal::{extract_proposed_action, is_confirmation};
 use super::status::{PortfolioStatusResponse, load_portfolio_status};
 use crate::daemon::state::DaemonState;
 
@@ -34,9 +55,11 @@ use crate::daemon::state::DaemonState;
 ///
 /// Why: DOC-36 §3.2 fixes the shape `{ conversation_key, message }`; the
 /// conversation key mirrors the L2 proxy focus-map keying so the surface is
-/// channel-agnostic.
+/// channel-agnostic. The SAME key drives the propose→confirm action flow
+/// (#2586): a `message` on this key that [`is_confirmation`] returns `true` for
+/// executes whatever proposal is pending for it.
 /// What: the caller-supplied conversation key and the new user message.
-/// Test: HTTP coverage in `tests/manager_inference.rs`.
+/// Test: HTTP coverage in `tests/manager_inference.rs`, `tests/manager_routing.rs`.
 #[derive(Debug, Deserialize)]
 pub struct ChatRequestBody {
     /// Conversation key (same keying shape as `SessionProxy`'s focus map).
@@ -48,31 +71,45 @@ pub struct ChatRequestBody {
 /// Success reply body for `POST /api/v1/manager/chat`.
 ///
 /// Why: returns the assistant's reply plus enough metadata (model, turn count) for
-/// a channel/CLI client to attribute and thread the conversation.
+/// a channel/CLI client to attribute and thread the conversation, and — new in
+/// phase 2 — the structured [`ActResponse`] when this turn proposed OR executed
+/// an action, so a client does not have to scrape the prose for it.
 /// What: the echoed conversation key, the reply prose, the authoring model slug,
-/// and the retained turn count for that conversation.
-/// Test: HTTP coverage in `tests/manager_inference.rs`.
+/// the retained turn count, and `action_result` (absent on an ordinary turn;
+/// `ActResponse::Proposed` when this turn's reply embedded a new proposal; the
+/// matching executed variant — `Launched`/`Injected`/`Summarized`/etc. — when
+/// this turn confirmed a pending one).
+/// Test: HTTP coverage in `tests/manager_routing.rs`.
 #[derive(Debug, Serialize)]
 pub struct ChatReplyBody {
     /// The conversation this reply belongs to.
     pub conversation_key: String,
     /// The manager's reply prose.
     pub reply: String,
-    /// The model slug that authored the reply.
+    /// The model slug that authored the reply (or, on a zero-inference confirm
+    /// turn, the currently-configured model slug — reported for consistency,
+    /// even though no call was made this turn).
     pub model: String,
     /// Retained message count for this conversation after recording the exchange.
     pub turn_count: usize,
+    /// The proposed or executed action for this turn, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_result: Option<ActResponse>,
 }
 
-/// Build the chat prompt: read-only persona + live snapshot + recent turns.
+/// Build the chat prompt: persona + live snapshot + recent turns.
 ///
 /// Why: the reply must be grounded in the CURRENT deterministic portfolio state
 /// (rebuilt fresh each request) and coherent across turns (recent history). The
-/// persona is pinned read-only — advisory only, never proposing a mutating action
-/// — which, together with the absence of any tools on the request, makes the loop
-/// structurally incapable of mutating a record.
-/// What: a system message (persona + the pretty-printed snapshot), then the prior
-/// `history` replayed as user/assistant messages, then the new `user_message`.
+/// persona is advisory by default — it must not CLAIM to have already acted — but
+/// phase 2 (#2586) documents the `manager-action` sentinel so the model MAY
+/// propose (never silently execute) exactly one action when the user explicitly
+/// asks for a launch/inject/summarize. This is a parsed text convention, not real
+/// tool-calling: the request still carries no `tools`, so the "no tool-calling
+/// surface" invariant `tests/manager_inference.rs` pins still holds.
+/// What: a system message (persona + proposal-format instructions + the
+/// pretty-printed snapshot), then the prior `history` replayed as user/assistant
+/// messages, then the new `user_message`.
 /// Test: `build_chat_messages_includes_context_and_history`.
 pub fn build_chat_messages(
     status: &PortfolioStatusResponse,
@@ -82,12 +119,31 @@ pub fn build_chat_messages(
     let snapshot = serde_json::to_string_pretty(status)
         .unwrap_or_else(|_| "{\"error\":\"snapshot serialization failed\"}".to_string());
     let system = format!(
-        "You are the read-only portfolio manager for a software developer running many \
-         coding sessions across multiple projects. Answer questions about the portfolio \
-         using ONLY the deterministic status snapshot below and the conversation so far — \
-         never invent projects, sessions, or counts. You are advisory and read-only: you \
-         may explain, summarize, and prioritize, but you must NOT claim to have launched, \
-         injected, killed, resumed, or changed anything, and you must not offer to do so.\n\n\
+        "You are the portfolio manager for a software developer running many coding \
+         sessions across multiple projects. Answer questions about the portfolio using \
+         ONLY the deterministic status snapshot below and the conversation so far — never \
+         invent projects, sessions, or counts. You are advisory: you must NOT claim to have \
+         already launched, injected, killed, resumed, or changed anything — you may only \
+         PROPOSE an action, which a human confirms separately before it runs.\n\n\
+         If — and ONLY if — the user explicitly asks you to launch a session for a \
+         project, send/inject a message into a specific session, or summarize a specific \
+         session, you MAY end your reply with exactly one fenced proposal block in this \
+         exact form (a bare JSON object, no extra keys):\n\
+         ```manager-action\n\
+         {{\"type\":\"launch\",\"project\":\"<project name>\",\"task\":\"<task text>\"}}\n\
+         ```\n\
+         or\n\
+         ```manager-action\n\
+         {{\"type\":\"inject\",\"session\":\"<session id or name>\",\"text\":\"<message text>\"}}\n\
+         ```\n\
+         or\n\
+         ```manager-action\n\
+         {{\"type\":\"summarize\",\"session\":\"<session id or name>\"}}\n\
+         ```\n\
+         Never include a proposal block unless the user asked for one of these three \
+         actions. Never propose more than one action in a single reply. The proposal is \
+         NOT executed automatically — a human must reply on this same conversation with an \
+         explicit confirmation before anything runs.\n\n\
          Current portfolio snapshot (JSON):\n{snapshot}"
     );
     let mut messages = Vec::with_capacity(history.len() + 2);
@@ -113,21 +169,57 @@ fn chat_error(status: StatusCode, error: &str, message: String) -> axum::respons
     (status, Json(json!({ "error": error, "message": message }))).into_response()
 }
 
-/// `POST /api/v1/manager/chat` handler (read-only, conversation-keyed).
+/// Describe an executed [`ActResponse`] as reply prose.
+///
+/// Why: the confirm turn skips the LLM entirely (deterministic, zero-inference
+/// execution — DOC-16 D1's "one LLM call per operation" is respected by making
+/// this turn ZERO calls rather than a redundant narration call), so the visible
+/// `reply` text is rendered here instead of by the model.
+/// What: one line per outcome variant.
+/// Test: exercised via the confirm-turn HTTP coverage in `tests/manager_routing.rs`.
+fn describe_action_result(result: &ActResponse) -> String {
+    match result {
+        ActResponse::Proposed { proposal, .. } => proposal.clone(),
+        ActResponse::Launched {
+            session_id, name, ..
+        } => format!("Launched session '{name}' ({session_id})."),
+        ActResponse::Injected { name, text, .. } => {
+            format!("Sent to session '{name}': {text:?}")
+        }
+        ActResponse::Summarized { name, summary, .. } => {
+            format!("Session '{name}': {summary}")
+        }
+        ActResponse::SessionNotFound { session, error } => {
+            format!("Could not find session '{session}': {error}")
+        }
+        ActResponse::SessionVanished { session, error } => {
+            format!("Session '{session}' is gone: {error}")
+        }
+        ActResponse::ActionFailed { session, error } => {
+            format!("Action on session '{session}' failed: {error}")
+        }
+    }
+}
+
+/// `POST /api/v1/manager/chat` handler — conversation-keyed, with the phase-2
+/// in-conversation propose→confirm action flow.
 ///
 /// Why: the curl-first (§4) portfolio chat surface. It threads a conversation by
 /// key, grounds each reply in the live deterministic snapshot plus recent turns,
-/// and issues exactly one read-only completion — never a tool call, never a
-/// mutating endpoint — then persists the turn in-memory and (best-effort) to the
-/// portfolio palace.
-/// What: validates the body (400 on empty key/message), loads the deterministic
-/// snapshot, resolves the inference seam (503 on no provider), builds the prompt
-/// from [`build_chat_messages`], issues ONE
-/// [`trusty_common::inference::InferenceAdapter::chat`] with NO tools, and on
-/// success records the exchange (in-memory window + silent palace dual-write) and
-/// returns the reply. An empty/failed call is a 502. Never logs message/reply text
-/// (privacy).
-/// Test: HTTP coverage in `tests/manager_inference.rs`.
+/// and — per #2586 — lets the model propose (never silently execute) a session
+/// action, executing it ONLY on an explicit confirming turn on the SAME key.
+/// What: validates the body (400 on empty key/message); consults
+/// [`super::state::ManagerState::proposals`] FIRST — if this key has a pending
+/// proposal, it is unconditionally consumed (next-turn-only TTL): a confirming
+/// message ([`is_confirmation`]) executes it via [`execute_action`] with ZERO
+/// LLM calls; any other message discards it and falls through to the normal
+/// flow. The normal flow loads the deterministic snapshot, resolves inference
+/// (503 on no provider), issues ONE completion with NO `tools` attached, parses
+/// the reply for an embedded proposal ([`extract_proposed_action`]) — storing it
+/// as pending and stripping it from the visible text — and records the exchange
+/// (in-memory window + best-effort palace dual-write). Never logs message/reply
+/// text (privacy).
+/// Test: HTTP coverage in `tests/manager_inference.rs`, `tests/manager_routing.rs`.
 pub async fn manager_chat_route(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<ChatRequestBody>,
@@ -148,12 +240,54 @@ pub async fn manager_chat_route(
         );
     }
 
+    let manager = state.manager_state();
+
+    // Phase 2 (#2586): consult the pending-proposal store BEFORE any LLM call.
+    // `take` unconditionally consumes (next-turn-only TTL) — a confirming
+    // message executes it via the SAME actuator seam `/manager/act` uses; any
+    // other message just lets it expire and falls through to the normal flow.
+    if let Some(pending) = manager.proposals().take(&conversation_key) {
+        if is_confirmation(&body.message) {
+            let actuator = resolve_actuator(&state);
+            let action_result = match execute_action(&actuator, &conversation_key, pending).await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    tracing::warn!("manager chat: confirmed action failed: {error}");
+                    ActResponse::ActionFailed {
+                        session: "(launch)".to_string(),
+                        error,
+                    }
+                }
+            };
+            let reply = describe_action_result(&action_result);
+            let model = manager.inference().model();
+            let turn_count =
+                manager
+                    .conversations()
+                    .record_exchange(&conversation_key, &body.message, &reply);
+            manager
+                .palace()
+                .record_chat_turn(&conversation_key, &body.message, &reply)
+                .await;
+            return Json(ChatReplyBody {
+                conversation_key,
+                reply,
+                model,
+                turn_count,
+                action_result: Some(action_result),
+            })
+            .into_response();
+        }
+        // Not a confirmation — the pending proposal has already expired (taken
+        // above); proceed to the normal flow with the current message.
+    }
+
     let status = match load_portfolio_status(&state).await {
         Ok(status) => status,
         Err((code, msg)) => return (code, msg).into_response(),
     };
 
-    let manager = state.manager_state();
     let (model, adapter) = match manager.inference().resolve() {
         Ok(pair) => pair,
         Err(unavailable) => {
@@ -166,8 +300,10 @@ pub async fn manager_chat_route(
     };
 
     let history = manager.conversations().history(&conversation_key);
-    // Read-only by construction: NO `tools` are attached, so the model has no
-    // surface to call a mutating verb; the handler itself only reads state.
+    // No tool-calling surface: NO `tools` are attached, so the model has no API
+    // surface to call a mutating verb directly — any action it wants is only ever
+    // a PARSED TEXT PROPOSAL (see `extract_proposed_action`), never executed by
+    // this call.
     let mut request = ChatRequest::new(
         model.clone(),
         build_chat_messages(&status, &history, &body.message),
@@ -175,7 +311,7 @@ pub async fn manager_chat_route(
     request.max_tokens = Some(MANAGER_MAX_TOKENS);
     request.temperature = Some(MANAGER_TEMPERATURE);
 
-    let reply = match adapter.chat(&request).await {
+    let raw_reply = match adapter.chat(&request).await {
         Ok(response) => match response.first_text().filter(|t| !t.trim().is_empty()) {
             Some(text) => text,
             None => {
@@ -196,6 +332,24 @@ pub async fn manager_chat_route(
         }
     };
 
+    // Parse for an embedded proposal; on a hit, store it as pending (next turn
+    // on this key may confirm it) and show the human-readable proposal text
+    // instead of the raw fenced block.
+    let (visible_text, proposed) = extract_proposed_action(&raw_reply);
+    let (reply, action_result) = match proposed {
+        Some(action) => {
+            manager.proposals().set(&conversation_key, action.clone());
+            let proposal = propose_message(&action);
+            let reply = if visible_text.is_empty() {
+                proposal.clone()
+            } else {
+                format!("{visible_text}\n\n{proposal}")
+            };
+            (reply, Some(ActResponse::Proposed { proposal, action }))
+        }
+        None => (raw_reply, None),
+    };
+
     // Record the completed exchange: in-memory window (always) + portfolio palace
     // dual-write (best-effort; silent no-op when the palace is unavailable).
     let turn_count =
@@ -212,6 +366,7 @@ pub async fn manager_chat_route(
         reply,
         model,
         turn_count,
+        action_result,
     })
     .into_response()
 }

--- a/crates/trusty-mpm/src/daemon/manager/chat_tests.rs
+++ b/crates/trusty-mpm/src/daemon/manager/chat_tests.rs
@@ -1,8 +1,10 @@
-//! Unit tests for the chat prompt builder (WI-4, #2581).
+//! Unit tests for the chat prompt builder (WI-4 #2581, WI-9 #2586).
 //!
 //! Why: the prompt must ground each reply in the live snapshot AND replay prior
-//! turns in order, and it must carry NO tools (the read-only guarantee is
-//! structural). Prove the message assembly directly.
+//! turns in order, must carry NO tools (the model's ONLY action surface is the
+//! parsed `manager-action` text sentinel, never a real tool-calling API), and
+//! must document that sentinel's exact format so [`super::proposal::extract_proposed_action`]
+//! can round-trip it. Prove the message assembly directly.
 //! What: covers [`super::build_chat_messages`] with a history and an empty
 //! snapshot.
 //! Test: this file IS the test module.
@@ -11,8 +13,10 @@ use super::super::chat_store::{ChatTurn, TurnRole};
 use super::super::status::aggregate_portfolio_status;
 use super::build_chat_messages;
 
-/// Why: the assembled prompt must be system(persona+snapshot) → replayed history
-/// → new user message, in that order, with the read-only persona pinned.
+/// Why: the assembled prompt must be system(persona+proposal-format+snapshot) →
+/// replayed history → new user message, in that order, with the advisory
+/// (propose-not-execute) persona pinned and the `manager-action` sentinel format
+/// documented to the model.
 /// Test: itself.
 #[test]
 fn build_chat_messages_includes_context_and_history() {
@@ -31,7 +35,14 @@ fn build_chat_messages_includes_context_and_history() {
     assert_eq!(messages.len(), 4, "system + 2 history + new user");
     assert_eq!(messages[0].role, "system");
     let system = messages[0].content.as_deref().unwrap_or_default();
-    assert!(system.contains("read-only"), "persona pinned read-only");
+    assert!(
+        system.contains("advisory") && system.contains("PROPOSE"),
+        "persona pinned to propose-not-execute"
+    );
+    assert!(
+        system.contains("```manager-action"),
+        "proposal sentinel format documented to the model"
+    );
     assert!(system.contains("\"project_count\": 0"), "snapshot embedded");
     assert_eq!(messages[1].role, "user");
     assert_eq!(messages[1].content.as_deref(), Some("what's blocked?"));

--- a/crates/trusty-mpm/src/daemon/manager/mod.rs
+++ b/crates/trusty-mpm/src/daemon/manager/mod.rs
@@ -32,7 +32,9 @@
 //!   in-conversation propose→confirm action flow (#2586);
 //! - [`version`] — the `GET /manager/version` capabilities stub that makes the
 //!   surface self-describing and curl-observable (WI-1, #2578);
+//!
 //! and phase-2 submodules —
+//!
 //! - [`route_task`] — `POST /manager/route-task`, advisory task→project routing
 //!   with disambiguation judgment (WI-8, #2585);
 //! - [`act`] + [`actuator`] — `POST /manager/act`, the API-first

--- a/crates/trusty-mpm/src/daemon/manager/mod.rs
+++ b/crates/trusty-mpm/src/daemon/manager/mod.rs
@@ -1,19 +1,24 @@
 //! Layer-3 chat-based portfolio manager surface — `tm manager` (epic #2109,
-//! DOC-36 phase 1a).
+//! DOC-36, phases 1-2).
 //!
 //! Why: DOC-35 §1.1's three-layer model tops out at a Layer-3 "single agent with
 //! FULL SCOPE of the user's activities". DOC-36 designs that layer as a
 //! daemon-owned component exposing an API-first `/api/v1/manager/*` surface
-//! (§3.1/§3.2). This module is the phase-1a scaffold of that surface: it does NOT
-//! reimplement #2108's per-project control plane — it COMPOSES it (cross-project
-//! rollup) and stays strictly read-only (DOC-36 §2.1 boundary: the manager never
-//! mutates a Deliverable/Milestone, never sets an autonomy tier, never acts on a
-//! session without an explicit driving call). Everything here is curl-testable
+//! (§3.1/§3.2). This module does NOT reimplement #2108's per-project control
+//! plane — it COMPOSES it (cross-project rollup, the resolver, the launch verb,
+//! `SessionProxy`). The read-only boundary (DOC-36 §2.1: never mutates a
+//! Deliverable/Milestone, never sets an autonomy tier) still holds for
+//! `status`/`digest`, and the CHAT LOOP itself never mutates on a PLAIN message —
+//! but DOC-36 §6 phase 2 explicitly SUPERSEDES phase 1's "chat is structurally
+//! read-only" framing: [`chat`] now supports an in-conversation propose→confirm
+//! action flow (#2586), so "the manager never acts on a session without an
+//! explicit driving call" is satisfied by the EXPLICIT CONFIRMATION TURN, not by
+//! chat being incapable of acting at all. Everything here is curl-testable
 //! locally with no channel/bot token and no live LLM (§4 local-testability bar).
-//! What: three phase-1a work items land here as focused submodules —
+//! What: phase-1 submodules —
 //! - [`state`] — the daemon-owned [`ManagerState`] threaded through every handler
-//!   (WI-1, #2578), holding the portfolio palace (and, later, the inference
-//!   adapter + poll loop);
+//!   (WI-1, #2578), holding the portfolio palace, the inference seam, the chat
+//!   turn store, the pending-proposal store (#2586), and the actuator override;
 //! - [`memory`] — portfolio `trusty-memory` palace provisioning, auto-created at
 //!   startup and degrade-graceful (WI-5, #2582);
 //! - [`status`] — the deterministic `GET /manager/status` cross-project rollup,
@@ -22,18 +27,27 @@
 //!   digest/chat LLM calls (WI-3/WI-4, §3.3);
 //! - [`digest`] — `GET /manager/digest`, the LLM-authored portfolio narrative with
 //!   a deterministic fallback (WI-3, #2580);
-//! - [`chat`] + [`chat_store`] — `POST /manager/chat`, the read-only
-//!   conversation-keyed portfolio chat loop (WI-4, #2581);
+//! - [`chat`] + [`chat_store`] + [`proposal`] — `POST /manager/chat`, the
+//!   conversation-keyed portfolio chat loop (WI-4, #2581) plus its phase-2
+//!   in-conversation propose→confirm action flow (#2586);
 //! - [`version`] — the `GET /manager/version` capabilities stub that makes the
-//!   scaffold self-describing and curl-observable (WI-1, #2578).
+//!   surface self-describing and curl-observable (WI-1, #2578);
+//! and phase-2 submodules —
+//! - [`route_task`] — `POST /manager/route-task`, advisory task→project routing
+//!   with disambiguation judgment (WI-8, #2585);
+//! - [`act`] + [`actuator`] — `POST /manager/act`, the API-first
+//!   propose→confirm session launch/inject/summarize flow (WI-9, #2586) and its
+//!   execution seam, ALSO the seam `chat.rs`'s confirm turn drives (never
+//!   duplicated).
 //!
 //! The handlers are mounted into the daemon's axum router by
-//! [`crate::daemon::api::router`]; [`ManagerState`] is owned by
-//! [`crate::daemon::state::DaemonState`] and reached via
+//! [`crate::daemon::api::router`] via [`manager_router`]; [`ManagerState`] is
+//! owned by [`crate::daemon::state::DaemonState`] and reached via
 //! [`DaemonState::manager_state`](crate::daemon::state::DaemonState::manager_state),
 //! mirroring how the L2 proxy focus store is owned.
 //! Test: `tests/manager_routes.rs` (real-HTTP contract, mirrors
-//! `tests/proxy_routes.rs`) plus the in-module unit tests in each submodule.
+//! `tests/proxy_routes.rs`), `tests/manager_routing.rs` (route-task, act, and the
+//! chat propose→confirm suite) plus the in-module unit tests in each submodule.
 
 pub mod act;
 pub mod actuator;
@@ -42,20 +56,23 @@ pub mod chat_store;
 pub mod digest;
 pub mod inference;
 pub mod memory;
+pub mod proposal;
 pub mod route_task;
 pub mod state;
 pub mod status;
 pub mod version;
 
-pub use act::{ActRequest, ActResponse, ProposedAction, manager_act_route};
+pub use act::{ActRequest, ActResponse, ProposedAction, execute_action, manager_act_route};
 pub use actuator::{
     DaemonLauncher, LaunchOutcome, ManagerActuator, ProxyActuator, SessionLauncher,
+    resolve_actuator,
 };
 pub use chat::{ChatReplyBody, ChatRequestBody, manager_chat_route};
 pub use chat_store::{ChatStore, ChatTurn, TurnRole};
 pub use digest::{DigestResponse, DigestScope, manager_digest_route};
 pub use inference::{InferenceUnavailable, ManagerInference};
 pub use memory::{PORTFOLIO_PALACE_ID, PortfolioPalace};
+pub use proposal::{ProposalStore, extract_proposed_action, is_confirmation};
 pub use route_task::{ResolvedBy, RouteTaskRequest, RouteTaskResponse, manager_route_task_route};
 pub use state::ManagerState;
 pub use status::{

--- a/crates/trusty-mpm/src/daemon/manager/mod.rs
+++ b/crates/trusty-mpm/src/daemon/manager/mod.rs
@@ -35,20 +35,28 @@
 //! Test: `tests/manager_routes.rs` (real-HTTP contract, mirrors
 //! `tests/proxy_routes.rs`) plus the in-module unit tests in each submodule.
 
+pub mod act;
+pub mod actuator;
 pub mod chat;
 pub mod chat_store;
 pub mod digest;
 pub mod inference;
 pub mod memory;
+pub mod route_task;
 pub mod state;
 pub mod status;
 pub mod version;
 
+pub use act::{ActRequest, ActResponse, ProposedAction, manager_act_route};
+pub use actuator::{
+    DaemonLauncher, LaunchOutcome, ManagerActuator, ProxyActuator, SessionLauncher,
+};
 pub use chat::{ChatReplyBody, ChatRequestBody, manager_chat_route};
 pub use chat_store::{ChatStore, ChatTurn, TurnRole};
 pub use digest::{DigestResponse, DigestScope, manager_digest_route};
 pub use inference::{InferenceUnavailable, ManagerInference};
 pub use memory::{PORTFOLIO_PALACE_ID, PortfolioPalace};
+pub use route_task::{ResolvedBy, RouteTaskRequest, RouteTaskResponse, manager_route_task_route};
 pub use state::ManagerState;
 pub use status::{
     PortfolioStatusResponse, PortfolioTotals, aggregate_portfolio_status, manager_status_route,
@@ -56,3 +64,28 @@ pub use status::{
 pub use version::{
     ManagerEndpoint, ManagerPalaceStatus, ManagerVersionResponse, manager_version_route,
 };
+
+/// Build the sub-router for the Layer-3 portfolio manager surface
+/// (`/api/v1/manager/*`, epic #2109, DOC-36 §3.2).
+///
+/// Why: co-locating every manager route registration with the module that owns
+/// the handlers (rather than inlining them in the daemon's monolithic
+/// `api::router`) keeps this cohesive cluster self-contained and lets
+/// `api::router` compose it with a single `.merge` — mirroring how the L2
+/// [`crate::daemon::managed_routes::proxy::proxy_router`] is composed. Every route
+/// binds the same [`DaemonState`](crate::daemon::state::DaemonState) the parent
+/// router carries, so merging is state-preserving.
+/// What: registers the phase-1 read-only triad (`version`/`status`/`digest`/`chat`)
+/// plus the phase-2 `route-task` (advisory) and `act` (propose→confirm) verbs.
+/// Test: the real-HTTP `tests/manager_routes.rs` and `tests/manager_routing.rs`
+/// exercise these routes exactly as before this extraction.
+pub fn manager_router() -> axum::Router<std::sync::Arc<crate::daemon::state::DaemonState>> {
+    use axum::routing::{get, post};
+    axum::Router::new()
+        .route("/api/v1/manager/version", get(manager_version_route))
+        .route("/api/v1/manager/status", get(manager_status_route))
+        .route("/api/v1/manager/digest", get(manager_digest_route))
+        .route("/api/v1/manager/chat", post(manager_chat_route))
+        .route("/api/v1/manager/route-task", post(manager_route_task_route))
+        .route("/api/v1/manager/act", post(manager_act_route))
+}

--- a/crates/trusty-mpm/src/daemon/manager/proposal.rs
+++ b/crates/trusty-mpm/src/daemon/manager/proposal.rs
@@ -1,0 +1,169 @@
+//! The chat loop's in-conversation propose→confirm plumbing (WI-9, #2586).
+//!
+//! Why: DOC-36 §6 phase 2 requires the CHAT LOOP itself (not just `/manager/act`)
+//! to "propose a session launch/inject action in-conversation and only execute it
+//! after explicit user confirmation" — a conversational realization of DOC-35 §11
+//! that reuses the SAME [`super::act::ProposedAction`]/actuator seam `/manager/act`
+//! uses, never a parallel implementation. This module owns the three pure/small
+//! pieces that make that possible: (1) [`extract_proposed_action`] — parses an
+//! LLM reply for an embedded action proposal (a fenced `manager-action` JSON
+//! block, never real tool-calling — the request still carries no `tools`, so the
+//! phase-1 "no tool-calling surface" invariant holds even though the chat loop is
+//! no longer read-only); (2) [`is_confirmation`] — the deterministic, documented
+//! confirmation-phrase policy; (3) [`ProposalStore`] — the conversation-keyed
+//! pending-proposal store with a NEXT-TURN-ONLY expiry policy (chosen over a
+//! wall-clock TTL because chat turns are the natural unit of "the same
+//! conversation", and a turn-based expiry is exactly testable without a clock).
+//! What: [`ProposalStore::set`]/[`ProposalStore::take`] (unconditional
+//! consume-on-read — every turn either executes the pending proposal or drops
+//! it, so a proposal NEVER survives past the very next turn on its key);
+//! [`is_confirmation`]; [`extract_proposed_action`] plus the sentinel constants
+//! [`ACTION_FENCE_OPEN`]/[`ACTION_FENCE_CLOSE`] the chat system prompt documents
+//! to the model.
+//! Test: `is_confirmation_*`, `extract_proposed_action_*`,
+//! `proposal_store_take_is_consume_on_read` in `proposal_tests.rs`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use super::act::ProposedAction;
+
+/// Opening fence the chat system prompt instructs the model to use when
+/// proposing an action.
+///
+/// Why: a fixed, greppable sentinel lets [`extract_proposed_action`] find a
+/// proposal in plain LLM reply text WITHOUT wiring an actual tool-calling
+/// `tools` array onto the request — the phase-1 "no tools" invariant
+/// (`tests/manager_inference.rs::chat_is_read_only_no_mutation_and_no_tools`)
+/// keeps holding even though the chat loop can now act.
+/// What: the fenced-code-block language tag marking a proposal.
+/// Test: `extract_proposed_action_parses_launch_block`.
+pub const ACTION_FENCE_OPEN: &str = "```manager-action";
+
+/// Closing fence for the proposal block (a bare triple-backtick).
+pub const ACTION_FENCE_CLOSE: &str = "```";
+
+/// Parse an LLM reply for an embedded action proposal, stripping it from the
+/// visible text.
+///
+/// Why: the chat system prompt (`chat.rs::build_chat_messages`) instructs the
+/// model to end its reply with a `manager-action` fenced JSON block — shaped
+/// exactly like [`ProposedAction`]'s serde tag — ONLY when the user explicitly
+/// asked for a launch/inject/summarize. This is the single parse point so the
+/// handler never hand-rolls JSON extraction inline.
+/// What: finds [`ACTION_FENCE_OPEN`]; if absent, returns `(reply, None)`
+/// unchanged. If present but the fenced body fails to parse as a
+/// [`ProposedAction`], ALSO returns `(reply, None)` unchanged — a malformed
+/// proposal is treated as "no proposal" rather than a hard error, since the
+/// chat loop must never fail a turn over the model's formatting slip. On a
+/// successful parse, returns the reply with the fenced block (and its
+/// surrounding whitespace) removed, plus `Some(action)`.
+/// Test: `extract_proposed_action_parses_launch_block`,
+/// `extract_proposed_action_no_block_returns_none`,
+/// `extract_proposed_action_malformed_json_returns_none`,
+/// `extract_proposed_action_keeps_leading_and_trailing_prose`.
+pub fn extract_proposed_action(reply: &str) -> (String, Option<ProposedAction>) {
+    let Some(start) = reply.find(ACTION_FENCE_OPEN) else {
+        return (reply.to_string(), None);
+    };
+    let after_open = start + ACTION_FENCE_OPEN.len();
+    let Some(rel_end) = reply[after_open..].find(ACTION_FENCE_CLOSE) else {
+        return (reply.to_string(), None);
+    };
+    let json_str = reply[after_open..after_open + rel_end].trim();
+    let Ok(action) = serde_json::from_str::<ProposedAction>(json_str) else {
+        return (reply.to_string(), None);
+    };
+
+    let end = after_open + rel_end + ACTION_FENCE_CLOSE.len();
+    let mut remaining = reply[..start].trim().to_string();
+    let trailing = reply[end..].trim();
+    if !trailing.is_empty() {
+        if !remaining.is_empty() {
+            remaining.push('\n');
+        }
+        remaining.push_str(trailing);
+    }
+    (remaining, Some(action))
+}
+
+/// Whether a chat message is an explicit confirmation of a pending proposal.
+///
+/// Why: DOC-35 §11 requires an EXPLICIT confirmation — this must be a narrow,
+/// deterministic, documented predicate (never fuzzy NLU) so the confirm path is
+/// hermetically testable and never accidentally triggered by an unrelated
+/// message that happens to contain the word "confirm" mid-sentence.
+/// What: trims the message, strips one trailing `.`/`!`/`?`, lowercases, and
+/// matches the WHOLE remaining string against a fixed confirmation-phrase set:
+/// `"confirm"`, `"confirmed"`, `"yes"`, `"y"`. Any other content — including a
+/// message that merely mentions "confirm" — is NOT a confirmation.
+/// Test: `is_confirmation_accepts_documented_phrases`,
+/// `is_confirmation_rejects_partial_or_unrelated_text`.
+pub fn is_confirmation(message: &str) -> bool {
+    let cleaned = message
+        .trim()
+        .trim_end_matches(['.', '!', '?'])
+        .trim()
+        .to_lowercase();
+    matches!(cleaned.as_str(), "confirm" | "confirmed" | "yes" | "y")
+}
+
+/// Conversation-keyed store of pending action proposals, NEXT-TURN-ONLY TTL.
+///
+/// Why: DOC-35 §11 forbids a proposal from being executable indefinitely — an
+/// operator who proposed an action three turns ago and moved on to an unrelated
+/// topic must not have a stray later "confirm" retroactively fire it. Modelling
+/// the expiry as "valid for exactly the next turn on this key" (rather than a
+/// wall-clock TTL) ties the policy to the natural unit of a conversation and
+/// needs no clock/timer machinery to test: [`Self::take`] unconditionally
+/// REMOVES the entry on every read, so the caller (chat.rs) either executes it
+/// (this turn's message was a confirmation) or discards it (any other message) —
+/// either way it cannot survive to a THIRD turn.
+/// What: a `Mutex`-guarded `HashMap<String, ProposedAction>`, keyed identically
+/// to [`super::chat_store::ChatStore`] and the L2 proxy focus map.
+/// Test: `proposal_store_take_is_consume_on_read`,
+/// `proposal_store_distinct_keys_are_isolated`.
+#[derive(Debug, Default)]
+pub struct ProposalStore {
+    pending: Mutex<HashMap<String, ProposedAction>>,
+}
+
+impl ProposalStore {
+    /// Construct an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a pending proposal for `key`, replacing any existing one.
+    ///
+    /// Why: a new proposal on a conversation supersedes whatever was pending
+    /// (there is at most one live proposal per conversation at a time).
+    /// What: inserts `action` under `key`.
+    /// Test: `proposal_store_take_is_consume_on_read`.
+    pub fn set(&self, key: &str, action: ProposedAction) {
+        self.pending
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(key.to_string(), action);
+    }
+
+    /// Consume and return the pending proposal for `key`, if any.
+    ///
+    /// Why: the sole read path — ALWAYS removes on read (the next-turn-only TTL),
+    /// so calling this is itself the expiry mechanism. The caller decides whether
+    /// the returned action executes (this turn confirmed it) or is simply
+    /// discarded (any other message).
+    /// What: removes and returns the entry under `key`, or `None`.
+    /// Test: `proposal_store_take_is_consume_on_read`,
+    /// `proposal_store_distinct_keys_are_isolated`.
+    pub fn take(&self, key: &str) -> Option<ProposedAction> {
+        self.pending
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(key)
+    }
+}
+
+#[cfg(test)]
+#[path = "proposal_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/manager/proposal_tests.rs
+++ b/crates/trusty-mpm/src/daemon/manager/proposal_tests.rs
@@ -1,0 +1,110 @@
+//! Unit tests for the chat propose→confirm plumbing (WI-9, #2586).
+
+use super::*;
+
+#[test]
+fn extract_proposed_action_parses_launch_block() {
+    let reply = "I'll route this to alpha.\n\n```manager-action\n\
+                 {\"type\":\"launch\",\"project\":\"alpha\",\"task\":\"fix the flaky auth test\"}\n\
+                 ```";
+    let (text, action) = extract_proposed_action(reply);
+    let action = action.expect("proposal parsed");
+    assert_eq!(
+        action,
+        ProposedAction::Launch {
+            project: "alpha".to_string(),
+            task: "fix the flaky auth test".to_string(),
+        }
+    );
+    assert_eq!(text, "I'll route this to alpha.");
+}
+
+#[test]
+fn extract_proposed_action_parses_inject_block() {
+    let reply = "```manager-action\n{\"type\":\"inject\",\"session\":\"sess-1\",\"text\":\"run tests\"}\n```";
+    let (_, action) = extract_proposed_action(reply);
+    assert_eq!(
+        action.unwrap(),
+        ProposedAction::Inject {
+            session: "sess-1".to_string(),
+            text: "run tests".to_string(),
+        }
+    );
+}
+
+#[test]
+fn extract_proposed_action_no_block_returns_none() {
+    let reply = "Everything looks fine, nothing blocked.";
+    let (text, action) = extract_proposed_action(reply);
+    assert!(action.is_none());
+    assert_eq!(text, reply);
+}
+
+#[test]
+fn extract_proposed_action_malformed_json_returns_none() {
+    let reply = "```manager-action\nnot valid json at all\n```";
+    let (text, action) = extract_proposed_action(reply);
+    assert!(action.is_none());
+    // Malformed proposals are treated as "no proposal" — the raw text passes
+    // through unchanged rather than being silently mangled.
+    assert_eq!(text, reply);
+}
+
+#[test]
+fn extract_proposed_action_keeps_leading_and_trailing_prose() {
+    let reply = "before text\n```manager-action\n{\"type\":\"summarize\",\"session\":\"s1\"}\n```\nafter text";
+    let (text, action) = extract_proposed_action(reply);
+    assert!(action.is_some());
+    assert_eq!(text, "before text\nafter text");
+}
+
+#[test]
+fn is_confirmation_accepts_documented_phrases() {
+    for phrase in ["confirm", "Confirm", "CONFIRM", "confirm.", "confirm!", "  confirm  ", "yes", "Yes.", "y", "confirmed"] {
+        assert!(is_confirmation(phrase), "expected confirmation: {phrase:?}");
+    }
+}
+
+#[test]
+fn is_confirmation_rejects_partial_or_unrelated_text() {
+    for phrase in [
+        "please confirm this",
+        "confirm the launch of alpha",
+        "no",
+        "",
+        "  ",
+        "yesish",
+        "y not",
+    ] {
+        assert!(!is_confirmation(phrase), "expected NOT a confirmation: {phrase:?}");
+    }
+}
+
+#[test]
+fn proposal_store_take_is_consume_on_read() {
+    let store = ProposalStore::new();
+    let action = ProposedAction::Summarize {
+        session: "s1".to_string(),
+    };
+    store.set("conv-a", action.clone());
+
+    // First take returns and consumes it.
+    assert_eq!(store.take("conv-a"), Some(action));
+    // Second take (the "later turn") finds nothing — it already expired.
+    assert_eq!(store.take("conv-a"), None);
+}
+
+#[test]
+fn proposal_store_distinct_keys_are_isolated() {
+    let store = ProposalStore::new();
+    store.set(
+        "conv-a",
+        ProposedAction::Summarize {
+            session: "s1".to_string(),
+        },
+    );
+    // A different conversation key has nothing pending.
+    assert_eq!(store.take("conv-b"), None);
+    // conv-a's proposal is still there (unaffected by conv-b's empty take).
+    assert!(store.take("conv-a").is_some());
+}

--- a/crates/trusty-mpm/src/daemon/manager/proposal_tests.rs
+++ b/crates/trusty-mpm/src/daemon/manager/proposal_tests.rs
@@ -60,7 +60,18 @@ fn extract_proposed_action_keeps_leading_and_trailing_prose() {
 
 #[test]
 fn is_confirmation_accepts_documented_phrases() {
-    for phrase in ["confirm", "Confirm", "CONFIRM", "confirm.", "confirm!", "  confirm  ", "yes", "Yes.", "y", "confirmed"] {
+    for phrase in [
+        "confirm",
+        "Confirm",
+        "CONFIRM",
+        "confirm.",
+        "confirm!",
+        "  confirm  ",
+        "yes",
+        "Yes.",
+        "y",
+        "confirmed",
+    ] {
         assert!(is_confirmation(phrase), "expected confirmation: {phrase:?}");
     }
 }
@@ -76,7 +87,10 @@ fn is_confirmation_rejects_partial_or_unrelated_text() {
         "yesish",
         "y not",
     ] {
-        assert!(!is_confirmation(phrase), "expected NOT a confirmation: {phrase:?}");
+        assert!(
+            !is_confirmation(phrase),
+            "expected NOT a confirmation: {phrase:?}"
+        );
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/manager/route_task.rs
+++ b/crates/trusty-mpm/src/daemon/manager/route_task.rs
@@ -1,0 +1,337 @@
+//! `POST /api/v1/manager/route-task` — resolver input + disambiguation judgment
+//! (WI-8, #2585, epic #2109, DOC-36 phase 2).
+//!
+//! Why: DOC-36 §3.2 gives `tm manager` a `route-task` primitive that maps a
+//! free-text task to the project it belongs to. Per DOC-35 §13 Q1's SPLIT
+//! decision the deterministic name/URL/keyword MATCHING primitive stays owned by
+//! DOC-22 (`crate::project::resolver::resolve_project`); #2109 owns only the
+//! DISAMBIGUATION JUDGMENT layered on top — i.e. what to do when the resolver
+//! reports a tie/low-confidence via [`ProjectResolution::needs_disambiguation`].
+//! This endpoint therefore CONSUMES the resolver as an input signal, and escalates
+//! to a single LLM call ONLY when the resolver is genuinely ambiguous; an
+//! unambiguous resolution passes through with zero inference. Critically it is
+//! ADVISORY: it resolves a route and returns `{ project, confidence, rationale }`
+//! but NEVER launches, injects, or mutates a session — acting on the route is a
+//! separate explicit call (the WI-9 proposal-and-confirm flow, `/manager/act`),
+//! satisfying DOC-35 §11's "no acting without an explicit call". Curl-testable
+//! with no channel/bot token (§4): a no-provider environment simply skips the
+//! disambiguation LLM call and returns the deterministic top candidate.
+//! What: [`RouteTaskRequest`]/[`RouteTaskResponse`]/[`ResolvedBy`], the pure
+//! disambiguation helpers [`build_disambiguation_messages`] and [`pick_from_reply`],
+//! and the [`manager_route_task_route`] handler.
+//! Test: `pick_from_reply_*`, `build_disambiguation_messages_lists_candidates`,
+//! `route_from_resolution_*` in `route_task_tests.rs`; HTTP coverage (unambiguous
+//! pass-through, LLM disambiguation, no-provider degrade, no-match) in
+//! `tests/manager_routing.rs`.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use trusty_common::inference::{ChatMessage, ChatRequest};
+
+use super::inference::{MANAGER_MAX_TOKENS, MANAGER_TEMPERATURE};
+use crate::daemon::state::DaemonState;
+use crate::project::resolver::{ProjectMatch, ProjectResolution, ResolverError, resolve_project};
+
+/// Request body for `POST /api/v1/manager/route-task`.
+///
+/// Why: DOC-36 §3.2 fixes the shape `{ text }` — a single free-text task
+/// description the resolver maps to a project.
+/// What: the caller-supplied task text.
+/// Test: HTTP coverage in `tests/manager_routing.rs`.
+#[derive(Debug, Deserialize)]
+pub struct RouteTaskRequest {
+    /// The free-text task to route to a project.
+    pub text: String,
+}
+
+/// How the returned route was decided.
+///
+/// Why: makes the DOC-35 §13 Q1 split observable — a consumer (and the WI-9
+/// proposal flow) can see whether the route came straight from the deterministic
+/// resolver, from an escalated LLM disambiguation judgment, or whether nothing
+/// matched — without re-deriving that distinction. Also lets the hermetic suite
+/// assert the escalation path fired only on a genuine tie.
+/// What: `Resolver` for an unambiguous deterministic pick (no LLM call),
+/// `Disambiguation` for an LLM-judged tie, `NoMatch` when the resolver found no
+/// candidate.
+/// Test: `route_from_resolution_unambiguous_is_resolver`,
+/// `route_from_resolution_no_match`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolvedBy {
+    /// Deterministic resolver pick, unambiguous — no inference used.
+    Resolver,
+    /// A tie the resolver flagged, judged by a single LLM disambiguation call.
+    Disambiguation,
+    /// No project matched the query at all.
+    NoMatch,
+}
+
+/// Response body for `POST /api/v1/manager/route-task`.
+///
+/// Why: DOC-36 §3.2 + #2585 require `{ project, confidence, rationale }`; the
+/// added `resolved_by` marker documents the decision path (deterministic vs.
+/// judged vs. no-match) without changing the core contract. Advisory only — the
+/// response never implies a session was touched.
+/// What: the resolved project name (`None` on no-match), the clamped confidence
+/// `[0.0, 1.0]`, a human-readable rationale, and the decision path.
+/// Test: HTTP coverage in `tests/manager_routing.rs`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RouteTaskResponse {
+    /// The resolved project name, or `None` when nothing matched.
+    pub project: Option<String>,
+    /// Confidence in the resolved route, clamped `[0.0, 1.0]` (0.0 on no-match).
+    pub confidence: f32,
+    /// Human-readable explanation of why this route was chosen.
+    pub rationale: String,
+    /// How the route was decided (deterministic / judged / no-match).
+    pub resolved_by: ResolvedBy,
+}
+
+/// Build the LLM disambiguation prompt from the tied candidates.
+///
+/// Why: escalation is invoked ONLY when [`ProjectResolution::needs_disambiguation`]
+/// is true, so the model's sole job is to pick exactly one of the already-scored
+/// candidates for the given task — never to invent a project. Pinning the system
+/// persona to "choose one of the listed candidates and reply with its exact name"
+/// keeps [`pick_from_reply`] a simple, robust name match. Pure so it is testable
+/// without a live model.
+/// What: a system instruction plus a user message carrying the task text and the
+/// numbered candidate list (name, confidence, and match reason for context).
+/// Test: `build_disambiguation_messages_lists_candidates`.
+pub fn build_disambiguation_messages(text: &str, candidates: &[ProjectMatch]) -> Vec<ChatMessage> {
+    let mut listing = String::new();
+    for (i, m) in candidates.iter().enumerate() {
+        listing.push_str(&format!(
+            "{}. {} (confidence {:.2}, matched by {})\n",
+            i + 1,
+            m.project.name,
+            m.confidence,
+            m.reason.label(),
+        ));
+    }
+    let system = "You route a developer's free-text task to exactly ONE of a short list of \
+         candidate projects that a deterministic matcher already scored as plausible but \
+         could not decide between. Choose the single best-fitting project for the task. \
+         Reply with ONLY that project's exact name from the list — no punctuation, no \
+         explanation, no extra words. Never invent a project that is not listed.";
+    let user =
+        format!("Task: {text}\n\nCandidate projects:\n{listing}\nBest-fitting project name:");
+    vec![ChatMessage::system(system), ChatMessage::user(user)]
+}
+
+/// Pick the candidate the model's reply names (case-insensitive).
+///
+/// Why: the disambiguation model is asked to reply with a bare project name, but
+/// real replies may add stray whitespace/punctuation or echo the name inside a
+/// sentence. Matching the reply against the KNOWN candidate names (rather than
+/// trusting the raw text as a name) keeps the judgment constrained to the
+/// resolver's candidate set — the model can never route to an unlisted project.
+/// What: returns the first candidate whose name equals the trimmed reply
+/// (case-insensitive), else the first candidate the reply CONTAINS as a substring
+/// (longest name first, so a more specific name wins over a prefix), else `None`.
+/// Test: `pick_from_reply_exact`, `pick_from_reply_substring`,
+/// `pick_from_reply_unlisted_is_none`.
+pub fn pick_from_reply<'a>(
+    reply: &str,
+    candidates: &'a [ProjectMatch],
+) -> Option<&'a ProjectMatch> {
+    let reply_lower = reply.trim().to_lowercase();
+    if reply_lower.is_empty() {
+        return None;
+    }
+    if let Some(exact) = candidates
+        .iter()
+        .find(|m| m.project.name.to_lowercase() == reply_lower)
+    {
+        return Some(exact);
+    }
+    // Substring fallback: prefer the longest candidate name so that when one name
+    // is a prefix of another, the more specific one is chosen.
+    let mut by_len: Vec<&ProjectMatch> = candidates.iter().collect();
+    by_len.sort_by_key(|m| std::cmp::Reverse(m.project.name.len()));
+    by_len
+        .into_iter()
+        .find(|m| reply_lower.contains(&m.project.name.to_lowercase()))
+}
+
+/// Turn a deterministic [`ProjectResolution`] into a response WITHOUT inference.
+///
+/// Why: the unambiguous path (single confident candidate, or a tie the caller
+/// decides not to escalate) needs a zero-LLM answer that reuses the resolver's
+/// own confidence and reason verbatim — never re-derived. Extracting it keeps the
+/// handler thin and makes the deterministic mapping unit-testable.
+/// What: takes the resolution's `primary` (highest-confidence) match and renders
+/// it as a [`ResolvedBy::Resolver`] response; `note` is appended to the rationale
+/// so a degraded-disambiguation caller can explain why it did not escalate.
+/// Test: `route_from_resolution_unambiguous_is_resolver`.
+fn resolver_response(resolution: &ProjectResolution, note: Option<&str>) -> RouteTaskResponse {
+    match &resolution.primary {
+        Some(primary) => {
+            let mut rationale = format!(
+                "resolved to '{}' by {} (confidence {:.2})",
+                primary.project.name,
+                primary.reason.label(),
+                primary.confidence,
+            );
+            if let Some(note) = note {
+                rationale.push_str("; ");
+                rationale.push_str(note);
+            }
+            RouteTaskResponse {
+                project: Some(primary.project.name.clone()),
+                confidence: primary.confidence,
+                rationale,
+                resolved_by: ResolvedBy::Resolver,
+            }
+        }
+        None => no_match_response("resolver returned no candidate"),
+    }
+}
+
+/// Build the advisory no-match response.
+///
+/// Why: an unresolvable query is advisory, not an error — the caller decides what
+/// to do (register a project, refine the query), so the endpoint returns 200 with
+/// a null project rather than a 4xx.
+/// What: a [`ResolvedBy::NoMatch`] response carrying `reason` as the rationale.
+/// Test: `route_from_resolution_no_match`.
+fn no_match_response(reason: &str) -> RouteTaskResponse {
+    RouteTaskResponse {
+        project: None,
+        confidence: 0.0,
+        rationale: reason.to_string(),
+        resolved_by: ResolvedBy::NoMatch,
+    }
+}
+
+/// `POST /api/v1/manager/route-task` handler.
+///
+/// Why: the curl-first (§4) task-routing surface. It runs DOC-22's deterministic
+/// resolver for candidate scoring, and — because #2109 owns disambiguation —
+/// escalates a genuine tie to ONE LLM judgment call, otherwise passes the
+/// unambiguous pick straight through. It NEVER launches or mutates a session
+/// (advisory only, DOC-35 §11).
+/// What: validates `text` (400 on empty), lists registered projects, calls
+/// [`resolve_project`]; an empty registry or no-match returns an advisory 200
+/// no-match; an unambiguous resolution returns the resolver pick (no LLM); a tie
+/// (`needs_disambiguation`) resolves via [`build_disambiguation_messages`] +
+/// [`pick_from_reply`] over one grounded inference call, degrading to the
+/// deterministic top candidate when no provider is configured or the call fails.
+/// Never logs task text (privacy). Read-only: no session mutation.
+/// Test: HTTP coverage in `tests/manager_routing.rs`.
+pub async fn manager_route_task_route(
+    State(state): State<Arc<DaemonState>>,
+    Json(body): Json<RouteTaskRequest>,
+) -> impl IntoResponse {
+    let text = body.text.trim().to_string();
+    if text.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "invalid_request", "message": "text must not be empty" })),
+        )
+            .into_response();
+    }
+
+    let registry = state.project_registry().await;
+    let projects = match registry.list().await {
+        Ok(projects) => projects,
+        Err(e) => {
+            tracing::warn!(error = %e, "route-task: project registry read failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "registry_read_failed",
+                             "message": "project registry read failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    let resolution = match resolve_project(&text, &projects) {
+        Ok(resolution) => resolution,
+        Err(ResolverError::EmptyRegistry) => {
+            return Json(no_match_response(
+                "no projects are registered; register one with `tm projects register`",
+            ))
+            .into_response();
+        }
+        Err(ResolverError::NoMatch { .. }) => {
+            return Json(no_match_response("no registered project matched the task"))
+                .into_response();
+        }
+    };
+
+    // Unambiguous: reuse the deterministic pick verbatim — no inference.
+    if !resolution.needs_disambiguation() {
+        return Json(resolver_response(&resolution, None)).into_response();
+    }
+
+    // Tie/low-confidence: #2109 owns the judgment. Escalate to ONE LLM call.
+    let (model, adapter) = match state.manager_state().inference().resolve() {
+        Ok(pair) => pair,
+        Err(_) => {
+            // No provider — degrade to the deterministic top candidate rather
+            // than fail; advisory output must never panic (§4 degrade bar).
+            return Json(resolver_response(
+                &resolution,
+                Some(
+                    "multiple candidates tied and no inference provider was available to \
+                      disambiguate, so the highest-confidence candidate was chosen",
+                ),
+            ))
+            .into_response();
+        }
+    };
+
+    let candidates = &resolution.matches;
+    let mut request = ChatRequest::new(
+        model.clone(),
+        build_disambiguation_messages(&text, candidates),
+    );
+    request.max_tokens = Some(MANAGER_MAX_TOKENS);
+    request.temperature = Some(MANAGER_TEMPERATURE);
+
+    let picked = match adapter.chat(&request).await {
+        Ok(response) => response
+            .first_text()
+            .and_then(|reply| pick_from_reply(&reply, candidates).cloned()),
+        Err(e) => {
+            tracing::warn!("route-task disambiguation inference call failed: {e}");
+            None
+        }
+    };
+
+    match picked {
+        Some(m) => Json(RouteTaskResponse {
+            project: Some(m.project.name.clone()),
+            confidence: m.confidence,
+            rationale: format!(
+                "disambiguated to '{}' by inference among {} tied candidates (resolver \
+                 confidence {:.2}, matched by {})",
+                m.project.name,
+                candidates.len(),
+                m.confidence,
+                m.reason.label(),
+            ),
+            resolved_by: ResolvedBy::Disambiguation,
+        })
+        .into_response(),
+        // The call failed or named an unlisted project — fall back to the
+        // deterministic top candidate.
+        None => Json(resolver_response(
+            &resolution,
+            Some("disambiguation was inconclusive, so the highest-confidence candidate was chosen"),
+        ))
+        .into_response(),
+    }
+}
+
+#[cfg(test)]
+#[path = "route_task_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/manager/route_task_tests.rs
+++ b/crates/trusty-mpm/src/daemon/manager/route_task_tests.rs
@@ -1,0 +1,121 @@
+//! Unit tests for the pure `route-task` disambiguation helpers (WI-8, #2585).
+
+use super::*;
+use crate::project::Project;
+use crate::project::resolver::{ProjectMatch, ProjectResolution, ResolutionReason};
+
+/// Build a minimal project fixture with the given name.
+fn project(name: &str) -> Project {
+    Project {
+        name: name.to_string(),
+        repo_url: format!("https://github.com/acme/{name}"),
+        default_branch: "main".to_string(),
+        stack_hint: None,
+        tags: vec![],
+        description: None,
+        gh_user: None,
+        github: None,
+        commit_name: None,
+        commit_email: None,
+    }
+}
+
+/// Build a candidate match with the given name and confidence.
+fn candidate(name: &str, confidence: f32) -> ProjectMatch {
+    ProjectMatch {
+        project: project(name),
+        confidence,
+        reason: ResolutionReason::KeywordMatch,
+    }
+}
+
+#[test]
+fn pick_from_reply_exact() {
+    let candidates = vec![candidate("alpha", 0.8), candidate("beta", 0.7)];
+    let picked = pick_from_reply("beta", &candidates).expect("exact match");
+    assert_eq!(picked.project.name, "beta");
+}
+
+#[test]
+fn pick_from_reply_case_insensitive_and_trimmed() {
+    let candidates = vec![candidate("Alpha", 0.8), candidate("Beta", 0.7)];
+    let picked = pick_from_reply("  ALPHA \n", &candidates).expect("case-insensitive match");
+    assert_eq!(picked.project.name, "Alpha");
+}
+
+#[test]
+fn pick_from_reply_substring() {
+    let candidates = vec![candidate("alpha", 0.8), candidate("beta", 0.7)];
+    let picked =
+        pick_from_reply("I would route this to beta.", &candidates).expect("substring match");
+    assert_eq!(picked.project.name, "beta");
+}
+
+#[test]
+fn pick_from_reply_prefers_longer_name_on_substring() {
+    // "web" is a prefix of "web-api"; a reply naming the specific project must
+    // resolve to the longer, more specific candidate.
+    let candidates = vec![candidate("web", 0.7), candidate("web-api", 0.7)];
+    let picked = pick_from_reply("the web-api project", &candidates).expect("longest wins");
+    assert_eq!(picked.project.name, "web-api");
+}
+
+#[test]
+fn pick_from_reply_unlisted_is_none() {
+    let candidates = vec![candidate("alpha", 0.8), candidate("beta", 0.7)];
+    assert!(pick_from_reply("gamma", &candidates).is_none());
+}
+
+#[test]
+fn pick_from_reply_empty_is_none() {
+    let candidates = vec![candidate("alpha", 0.8)];
+    assert!(pick_from_reply("   ", &candidates).is_none());
+}
+
+#[test]
+fn build_disambiguation_messages_lists_candidates() {
+    let candidates = vec![candidate("alpha", 0.82), candidate("beta", 0.71)];
+    let messages = build_disambiguation_messages("fix the flaky auth test", &candidates);
+    assert_eq!(messages.len(), 2);
+    // The user message must carry the task text and every candidate name.
+    let user = &messages[1];
+    let rendered = format!("{user:?}");
+    assert!(rendered.contains("fix the flaky auth test"), "{rendered}");
+    assert!(rendered.contains("alpha"), "{rendered}");
+    assert!(rendered.contains("beta"), "{rendered}");
+}
+
+#[test]
+fn route_from_resolution_unambiguous_is_resolver() {
+    let resolution = ProjectResolution {
+        matches: vec![candidate("alpha", 0.95)],
+        primary: Some(candidate("alpha", 0.95)),
+    };
+    let resp = resolver_response(&resolution, None);
+    assert_eq!(resp.project.as_deref(), Some("alpha"));
+    assert_eq!(resp.resolved_by, ResolvedBy::Resolver);
+    assert!((resp.confidence - 0.95).abs() < f32::EPSILON);
+}
+
+#[test]
+fn route_from_resolution_resolver_note_appended() {
+    let resolution = ProjectResolution {
+        matches: vec![candidate("alpha", 0.7), candidate("beta", 0.65)],
+        primary: Some(candidate("alpha", 0.7)),
+    };
+    let resp = resolver_response(&resolution, Some("no provider available"));
+    assert_eq!(resp.resolved_by, ResolvedBy::Resolver);
+    assert!(
+        resp.rationale.contains("no provider available"),
+        "{}",
+        resp.rationale
+    );
+}
+
+#[test]
+fn route_from_resolution_no_match() {
+    let resp = no_match_response("no registered project matched the task");
+    assert!(resp.project.is_none());
+    assert_eq!(resp.confidence, 0.0);
+    assert_eq!(resp.resolved_by, ResolvedBy::NoMatch);
+}

--- a/crates/trusty-mpm/src/daemon/manager/state.rs
+++ b/crates/trusty-mpm/src/daemon/manager/state.rs
@@ -23,6 +23,7 @@ use super::actuator::ManagerActuator;
 use super::chat_store::ChatStore;
 use super::inference::ManagerInference;
 use super::memory::PortfolioPalace;
+use super::proposal::ProposalStore;
 
 /// The daemon-owned state for the `tm manager` (Layer-3) surface.
 ///
@@ -42,6 +43,9 @@ pub struct ManagerState {
     inference: ManagerInference,
     /// Conversation-keyed recent-turn store for the chat loop (WI-4).
     conversations: ChatStore,
+    /// Conversation-keyed pending-proposal store for the chat loop's
+    /// propose→confirm action flow (WI-9, #2586), next-turn-only TTL.
+    proposals: ProposalStore,
     /// Optional TEST override for the `/manager/act` execution seam (WI-9, #2586).
     ///
     /// `None` in production (the handler builds a fresh production
@@ -58,6 +62,7 @@ impl std::fmt::Debug for ManagerState {
             .field("palace", &self.palace)
             .field("inference", &self.inference)
             .field("conversations", &self.conversations)
+            .field("proposals", &self.proposals)
             .field("actuator_override", &has_actuator)
             .finish()
     }
@@ -80,6 +85,7 @@ impl ManagerState {
             palace: PortfolioPalace::provision(framework_root),
             inference: ManagerInference::provision(),
             conversations: ChatStore::default(),
+            proposals: ProposalStore::new(),
             actuator: Mutex::new(None),
         }
     }
@@ -115,6 +121,20 @@ impl ManagerState {
     /// `tests/manager_inference.rs`.
     pub fn conversations(&self) -> &ChatStore {
         &self.conversations
+    }
+
+    /// The conversation-keyed pending-proposal store for chat's propose→confirm
+    /// action flow.
+    ///
+    /// Why: `/manager/chat` reads/consumes the pending proposal for a
+    /// conversation on EVERY turn (the next-turn-only TTL policy,
+    /// [`super::proposal::ProposalStore`]'s doc) before deciding whether to
+    /// execute, discard, or propose a new action.
+    /// What: a shared reference to the [`ProposalStore`].
+    /// Test: `proposal_store_take_is_consume_on_read` (proposal module);
+    /// `tests/manager_routing.rs`.
+    pub fn proposals(&self) -> &ProposalStore {
+        &self.proposals
     }
 
     /// The installed `/manager/act` execution-seam override, if any.

--- a/crates/trusty-mpm/src/daemon/manager/state.rs
+++ b/crates/trusty-mpm/src/daemon/manager/state.rs
@@ -17,7 +17,9 @@
 //! `manager_version_route_reports_capabilities` in `tests/manager_routes.rs`.
 
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
+use super::actuator::ManagerActuator;
 use super::chat_store::ChatStore;
 use super::inference::ManagerInference;
 use super::memory::PortfolioPalace;
@@ -33,7 +35,6 @@ use super::memory::PortfolioPalace;
 /// the digest/chat LLM calls (WI-3/WI-4, §3.3), and the conversation-keyed
 /// [`ChatStore`] (WI-4). The proactive poll loop attaches here in phase 3 (§6).
 /// Test: `manager_state_provisions_palace`.
-#[derive(Debug)]
 pub struct ManagerState {
     /// The portfolio-scoped memory palace (WI-5, #2582), provisioned at startup.
     palace: PortfolioPalace,
@@ -41,6 +42,25 @@ pub struct ManagerState {
     inference: ManagerInference,
     /// Conversation-keyed recent-turn store for the chat loop (WI-4).
     conversations: ChatStore,
+    /// Optional TEST override for the `/manager/act` execution seam (WI-9, #2586).
+    ///
+    /// `None` in production (the handler builds a fresh production
+    /// [`super::actuator::ProxyActuator`] per request); `Some` when the hermetic
+    /// suite installs a double via [`ManagerState::set_actuator`], mirroring how
+    /// [`ManagerInference::set_adapter`] swaps the inference seam.
+    actuator: Mutex<Option<Arc<dyn ManagerActuator>>>,
+}
+
+impl std::fmt::Debug for ManagerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let has_actuator = self.actuator.lock().map(|g| g.is_some()).unwrap_or(false);
+        f.debug_struct("ManagerState")
+            .field("palace", &self.palace)
+            .field("inference", &self.inference)
+            .field("conversations", &self.conversations)
+            .field("actuator_override", &has_actuator)
+            .finish()
+    }
 }
 
 impl ManagerState {
@@ -60,6 +80,7 @@ impl ManagerState {
             palace: PortfolioPalace::provision(framework_root),
             inference: ManagerInference::provision(),
             conversations: ChatStore::default(),
+            actuator: Mutex::new(None),
         }
     }
 
@@ -94,6 +115,32 @@ impl ManagerState {
     /// `tests/manager_inference.rs`.
     pub fn conversations(&self) -> &ChatStore {
         &self.conversations
+    }
+
+    /// The installed `/manager/act` execution-seam override, if any.
+    ///
+    /// Why: the act handler consults this before building a production actuator so
+    /// the hermetic suite can run the propose→confirm flow over a test-double
+    /// launcher + `SessionProxy` (WI-9, #2586). `None` in production.
+    /// What: clones the `Arc<dyn ManagerActuator>` under the lock, or `None`.
+    /// Test: exercised via `tests/manager_routing.rs`.
+    pub fn actuator_override(&self) -> Option<Arc<dyn ManagerActuator>> {
+        self.actuator
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+    }
+
+    /// Install a test override for the `/manager/act` execution seam.
+    ///
+    /// Why: mirrors [`ManagerInference::set_adapter`] — the hermetic suite builds a
+    /// real `DaemonState` and installs a [`super::actuator::ProxyActuator`] over
+    /// doubles through the shared `Arc<ManagerState>`, no bespoke constructor.
+    /// This reconfigures ACTION execution for a test; it is never set in production.
+    /// What: stores `actuator` as the override.
+    /// Test: `tests/manager_routing.rs`.
+    pub fn set_actuator(&self, actuator: Arc<dyn ManagerActuator>) {
+        *self.actuator.lock().unwrap_or_else(|p| p.into_inner()) = Some(actuator);
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/manager/version.rs
+++ b/crates/trusty-mpm/src/daemon/manager/version.rs
@@ -36,10 +36,11 @@ const MANAGER_API_VERSION: &str = "0.1.0";
 ///
 /// Why: DOC-36 §6 phases the manager surface (1 read-only chat → 2 routing → 3
 /// proactive → 4 channels); surfacing the phase lets an operator confirm which
-/// slice is live. Phase 1 (this WI cluster) ships `status` + the scaffold.
+/// slice is live. Phase 2 (epic #2109) adds `route-task` + the `act`
+/// proposal-and-confirm flow on top of the phase-1 read-only surface.
 /// What: the integer phase number.
 /// Test: `manager_version_route_reports_capabilities`.
-const MANAGER_PHASE: u8 = 1;
+const MANAGER_PHASE: u8 = 2;
 
 /// One entry in the manager surface's advertised verb set.
 ///
@@ -135,7 +136,12 @@ fn advertised_endpoints() -> Vec<ManagerEndpoint> {
         ManagerEndpoint {
             method: "POST",
             path: "/api/v1/manager/route-task",
-            available: false,
+            available: true,
+        },
+        ManagerEndpoint {
+            method: "POST",
+            path: "/api/v1/manager/act",
+            available: true,
         },
         ManagerEndpoint {
             method: "GET",

--- a/crates/trusty-mpm/tests/manager_cli_client.rs
+++ b/crates/trusty-mpm/tests/manager_cli_client.rs
@@ -31,7 +31,13 @@
 //! `manager_digest_client_surfaces_unknown_project_404_against_real_daemon`,
 //! `manager_chat_client_reads_llm_reply_against_real_daemon`,
 //! `manager_chat_client_surfaces_degrade_message_against_real_daemon`,
-//! `manager_digest_and_chat_degrade_cleanly_on_404_against_older_daemon`.
+//! `manager_digest_and_chat_degrade_cleanly_on_404_against_older_daemon`; plus
+//! (coordinator review finding 2, WI-8 #2585) `manager_route_task_client_reads_live_route_against_real_daemon`,
+//! `manager_route_task_client_surfaces_400_for_empty_text_against_real_daemon`
+//! (the non-404 error path — `DaemonClient::manager_route_task`'s HTTP method,
+//! timeout wiring, and `Err` mapping were previously unexercised beyond the
+//! `from_body` parser unit tests), and
+//! `manager_route_task_client_degrades_cleanly_on_404_against_older_daemon`.
 //! Test: this file IS the test; run with
 //! `cargo test -p trusty-mpm --test manager_cli_client`.
 
@@ -252,15 +258,15 @@ async fn manager_chat_client_surfaces_degrade_message_against_real_daemon() {
     assert_eq!(outcome.conversation_key, "cli:bob");
 }
 
-/// A hand-built stub standing in for a daemon that PREDATES WI-3/WI-4 — the
-/// one scenario the current `origin/main` router (which now ships digest/chat,
-/// PR #2601) cannot produce. `/manager/version` reports both routes
-/// `available: false` and neither route is mounted at all, so a request to
-/// either 404s with an empty body — the genuine "upgrade your daemon" case
+/// A hand-built stub standing in for a daemon that PREDATES WI-3/WI-4/WI-8 — the
+/// one scenario the current `origin/main` router (which now ships
+/// digest/chat/route-task) cannot produce. `/manager/version` reports all three
+/// routes `available: false` and none is mounted at all, so a request to any of
+/// them 404s with an empty body — the genuine "upgrade your daemon" case
 /// [`DaemonClient::manager_endpoint_available`] feature-detects via the
 /// version probe.
 fn older_daemon_stub_router() -> Router {
-    async fn version_without_digest_or_chat() -> impl IntoResponse {
+    async fn version_without_digest_chat_or_route_task() -> impl IntoResponse {
         Json(serde_json::json!({
             "manager_api_version": "0.1.0",
             "crate_version": "0.0.0",
@@ -270,13 +276,14 @@ fn older_daemon_stub_router() -> Router {
                 { "method": "GET", "path": "/api/v1/manager/status", "available": true },
                 { "method": "GET", "path": "/api/v1/manager/digest", "available": false },
                 { "method": "POST", "path": "/api/v1/manager/chat", "available": false },
+                { "method": "POST", "path": "/api/v1/manager/route-task", "available": false },
             ],
             "palace": { "id": "tm-manager-portfolio", "available": false, "reason": null },
         }))
     }
     Router::new().route(
         "/api/v1/manager/version",
-        get(version_without_digest_or_chat),
+        get(version_without_digest_chat_or_route_task),
     )
 }
 
@@ -311,5 +318,66 @@ async fn manager_digest_and_chat_degrade_cleanly_on_404_against_older_daemon() {
     assert!(
         chat.is_none(),
         "expected None (404 degrade) against a daemon reporting chat unavailable"
+    );
+}
+
+/// `DaemonClient::manager_route_task` against the real, shipped
+/// `POST /api/v1/manager/route-task` route (WI-8, #2585) — proves the CLI's
+/// route-task path end to end (the HTTP method, the request body shape, and the
+/// timeout wiring), not merely the wire-shape unit tests in
+/// `client/http_client/manager.rs` (coordinator review finding 2).
+#[tokio::test]
+async fn manager_route_task_client_reads_live_route_against_real_daemon() {
+    let state = fresh_state().await;
+    register_project(&state, "alpha", "https://github.com/acme/alpha").await;
+    let base = serve_real(Arc::clone(&state)).await;
+    let client = DaemonClient::new(base);
+
+    let outcome = client
+        .manager_route_task("alpha")
+        .await
+        .expect("call")
+        .expect("Some(outcome) on 200");
+    assert_eq!(outcome.project.as_deref(), Some("alpha"));
+    assert_eq!(outcome.resolved_by, "resolver");
+}
+
+/// The non-404 error path (coordinator review finding 2: previously
+/// unexercised): an empty `text` is the daemon's own `400`, which
+/// `manager_route_task` must surface as `Err`, never `Ok(None)` — mirroring how
+/// `manager_digest_client_surfaces_unknown_project_404_against_real_daemon`
+/// pins digest's non-mount-detection error path.
+#[tokio::test]
+async fn manager_route_task_client_surfaces_400_for_empty_text_against_real_daemon() {
+    let state = fresh_state().await;
+    let base = serve_real(Arc::clone(&state)).await;
+    let client = DaemonClient::new(base);
+
+    let err = client
+        .manager_route_task("   ")
+        .await
+        .expect_err("an empty task must be Err, not Ok(None)");
+    assert!(
+        err.to_string().contains("text must not be empty"),
+        "error should carry the daemon's own 400 message: {err}"
+    );
+}
+
+/// Against a daemon whose `/manager/version` reports `route-task` unavailable
+/// (and does not mount it at all, so it 404s), the client must degrade to
+/// `Ok(None)` — the genuine "upgrade your daemon" case, mirroring the
+/// digest/chat coverage above.
+#[tokio::test]
+async fn manager_route_task_client_degrades_cleanly_on_404_against_older_daemon() {
+    let base = serve_mock(older_daemon_stub_router()).await;
+    let client = DaemonClient::new(base);
+
+    let route = client
+        .manager_route_task("fix the flaky auth test")
+        .await
+        .expect("manager_route_task call should not error on a genuinely unmounted route");
+    assert!(
+        route.is_none(),
+        "expected None (404 degrade) against a daemon reporting route-task unavailable"
     );
 }

--- a/crates/trusty-mpm/tests/manager_inference.rs
+++ b/crates/trusty-mpm/tests/manager_inference.rs
@@ -10,8 +10,11 @@
 //! in-memory) or an `OpenAiCompatAdapter` pointed at `MockInferenceServer` (real
 //! HTTP client mechanics, loopback mock). It proves: the digest happy path, the
 //! no-provider deterministic-fallback degrade, project scoping, chat multi-turn
-//! continuity, the read-only guarantee (no tools on the request, no state
-//! mutation), and history threading over real HTTP.
+//! continuity, the no-tool-calling-surface + no-mutation-on-a-plain-message
+//! invariant (chat is NO LONGER structurally read-only as of phase 2's
+//! propose→confirm action flow, #2586 — see `tests/manager_routing.rs` for that
+//! suite; THIS file only proves a plain reply with no confirmed proposal still
+//! mutates nothing), and history threading over real HTTP.
 //! What: this file IS the test; run with
 //! `cargo test -p trusty-mpm --test manager_inference`.
 
@@ -368,12 +371,17 @@ async fn chat_degrades_without_provider() {
     assert_eq!(body["error"], "inference_unavailable");
 }
 
-/// Why: the phase-1 chat loop is strictly read-only — the request must carry NO
-/// `tools` (so the model has no mutating surface), and driving a chat turn must
-/// not create or change any session/Deliverable record.
+/// Why: even though phase 2 (#2586) lets chat PROPOSE an action, the request
+/// must still carry NO `tools` (the model's only action surface is the parsed
+/// `manager-action` text sentinel, never real tool-calling), and a PLAIN reply
+/// with no confirmed proposal must not create or change any session/Deliverable
+/// record — the mock here replies with ordinary prose (no proposal block), so
+/// this pins the still-true "a plain message never mutates" half of the
+/// boundary. The propose→confirm execution path itself is covered by the
+/// dedicated suite in `tests/manager_routing.rs`.
 /// Test: itself.
 #[tokio::test]
-async fn chat_is_read_only_no_mutation_and_no_tools() {
+async fn chat_plain_reply_carries_no_tools_and_causes_no_mutation() {
     let server = MockInferenceServer::spawn(200, mock_body("Read-only answer."))
         .await
         .expect("spawn mock");

--- a/crates/trusty-mpm/tests/manager_routes.rs
+++ b/crates/trusty-mpm/tests/manager_routes.rs
@@ -120,7 +120,7 @@ async fn manager_version_route_reports_capabilities() {
     let body: serde_json::Value = resp.json().await.unwrap();
 
     assert_eq!(body["manager_api_version"], "0.1.0");
-    assert_eq!(body["phase"], 1);
+    assert_eq!(body["phase"], 2);
     assert_eq!(body["palace"]["id"], "tm-manager-portfolio");
     // Palace availability is feature-dependent: a default build (no
     // `manager-memory`) reports the palace as unavailable but still answers 200
@@ -159,8 +159,16 @@ async fn manager_version_route_reports_capabilities() {
         .find(|e| e["path"] == "/api/v1/manager/route-task")
         .expect("route-task endpoint advertised");
     assert_eq!(
-        route_task_ep["available"], false,
-        "route-task is a phase-2 WI, advertised as planned"
+        route_task_ep["available"], true,
+        "route-task ships in phase 2 (WI-8, #2585)"
+    );
+    let act_ep = endpoints
+        .iter()
+        .find(|e| e["path"] == "/api/v1/manager/act")
+        .expect("act endpoint advertised");
+    assert_eq!(
+        act_ep["available"], true,
+        "act proposal-and-confirm ships in phase 2 (WI-9, #2586)"
     );
 }
 

--- a/crates/trusty-mpm/tests/manager_routing.rs
+++ b/crates/trusty-mpm/tests/manager_routing.rs
@@ -1,6 +1,6 @@
 //! Hermetic HTTP integration suite for the Layer-3 manager PHASE 2 routing +
-//! proposal-and-confirm surface (`/api/v1/manager/{route-task,act}`, epic #2109,
-//! DOC-36 phase 2: WI-8 #2585, WI-9 #2586).
+//! proposal-and-confirm surface (`/api/v1/manager/{route-task,act,chat}`, epic
+//! #2109, DOC-36 phase 2: WI-8 #2585, WI-9 #2586).
 //!
 //! Why: DOC-36 §4's local-testability bar requires these endpoints to be
 //! exercisable with NO live provider key, NO network, and NO channel/bot token.
@@ -11,7 +11,14 @@
 //! empty-text 400; (2) `act` — the propose→confirm protocol, proving a call
 //! without `confirm` executes NOTHING and a `confirm: true` call routes a launch
 //! through a test-double `SessionLauncher` and an inject through a REAL
-//! `SessionProxy` over a test-double `ManagedBackend` (no live session/channel).
+//! `SessionProxy` over a test-double `ManagedBackend` (no live session/channel);
+//! (3) `chat`'s IN-CONVERSATION propose→confirm action flow (coordinator review
+//! of #2586's primary acceptance criterion) — a proposal turn executes nothing,
+//! the immediately-following confirm turn on the SAME conversation_key executes
+//! exactly once through the SAME actuator seam `act` uses, confirming on a
+//! DIFFERENT conversation_key never executes, an unconfirmed proposal expires
+//! after exactly one intervening turn (next-turn-only TTL), and a plain message
+//! never triggers execution.
 //! What: this file IS the test; run with
 //! `cargo test -p trusty-mpm --test manager_routing`.
 
@@ -463,4 +470,237 @@ async fn act_empty_conversation_key_is_400() {
     )
     .await;
     assert_eq!(status, reqwest::StatusCode::BAD_REQUEST);
+}
+
+/// Why: `conversation_key` is required UNIFORMLY across every action type — a
+/// deliberate consistency/audit-trail choice (coordinator review finding 3), not
+/// an oversight limited to Inject/Summarize. `Launch` does not read the key
+/// operationally, but an empty key must still 400, proving the rule applies to
+/// (and is tested for) the one variant that never uses it.
+/// Test: itself.
+#[tokio::test]
+async fn act_launch_also_requires_conversation_key() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, _body) = post(
+        &base,
+        "/api/v1/manager/act",
+        json!({
+            "conversation_key": "  ",
+            "confirm": true,
+            "action": { "type": "launch", "project": "alpha", "task": "do the thing" }
+        }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::BAD_REQUEST);
+    // The launch verb was never reached.
+    assert!(launcher.launched.lock().unwrap().is_empty());
+}
+
+// ── chat: in-conversation propose→confirm (coordinator review finding 1, #2586) ─
+
+/// Install a scripted adapter with MULTIPLE queued replies (FIFO), so a test can
+/// script exactly how many LLM calls it expects across several chat turns.
+fn install_scripted_queue(state: &Arc<DaemonState>, replies: &[&str]) {
+    let mut adapter = ScriptedAdapter::new("scripted", capabilities(ProviderId::OpenRouter));
+    for reply in replies {
+        adapter = adapter.with_response(scripted_reply(reply));
+    }
+    let adapter: Arc<dyn InferenceAdapter> = Arc::new(adapter);
+    state
+        .manager_state()
+        .inference()
+        .set_adapter(adapter, "test/model");
+}
+
+/// A reply text embedding a `manager-action` launch proposal, as the documented
+/// chat system prompt instructs the model to produce.
+fn proposal_reply(project: &str, task: &str) -> String {
+    format!(
+        "Sure, I can help with that.\n\n```manager-action\n\
+         {{\"type\":\"launch\",\"project\":\"{project}\",\"task\":\"{task}\"}}\n\
+         ```"
+    )
+}
+
+/// Why: a turn whose LLM reply embeds a proposal must NOT execute anything — the
+/// primary #2586 acceptance criterion, "propose in-conversation, execute only on
+/// explicit confirmation".
+/// Test: itself.
+#[tokio::test]
+async fn chat_proposal_turn_executes_nothing() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    let reply = proposal_reply("alpha", "fix the flaky auth test");
+    install_scripted_queue(&state, &[reply.as_str()]);
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/chat",
+        json!({ "conversation_key": "conv-1", "message": "launch a session for alpha to fix the flaky auth test" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body["action_result"]["status"], "proposed", "body: {body}");
+    assert!(
+        body["reply"].as_str().unwrap().contains("confirm"),
+        "body: {body}"
+    );
+    assert!(launcher.launched.lock().unwrap().is_empty());
+}
+
+/// Why: the VERY NEXT turn on the SAME conversation_key, confirming, must execute
+/// the pending proposal EXACTLY ONCE, through the actuator seam — with ZERO
+/// additional LLM calls (only 1 scripted reply is queued, for the propose turn).
+/// Test: itself.
+#[tokio::test]
+async fn chat_confirm_turn_executes_exactly_once() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    // Only ONE reply queued — the confirm turn must consume ZERO LLM calls.
+    let reply = proposal_reply("alpha", "fix the flaky auth test");
+    install_scripted_queue(&state, &[reply.as_str()]);
+    let base = serve(Arc::clone(&state)).await;
+
+    let (propose_status, _propose_body) = post(
+        &base,
+        "/api/v1/manager/chat",
+        json!({ "conversation_key": "conv-2", "message": "launch a session for alpha to fix the flaky auth test" }),
+    )
+    .await;
+    assert_eq!(propose_status, reqwest::StatusCode::OK);
+
+    let (confirm_status, confirm_body) = post(
+        &base,
+        "/api/v1/manager/chat",
+        json!({ "conversation_key": "conv-2", "message": "confirm" }),
+    )
+    .await;
+    assert_eq!(confirm_status, reqwest::StatusCode::OK);
+    assert_eq!(
+        confirm_body["action_result"]["status"], "launched",
+        "body: {confirm_body}"
+    );
+    let launched = launcher.launched.lock().unwrap();
+    assert_eq!(launched.len(), 1, "must execute exactly once");
+    assert_eq!(
+        launched[0],
+        ("alpha".to_string(), "fix the flaky auth test".to_string())
+    );
+}
+
+/// Why: confirming on a DIFFERENT conversation_key than the one that proposed
+/// must NOT execute anything — proposals are strictly conversation-scoped.
+/// Test: itself.
+#[tokio::test]
+async fn chat_confirm_on_different_conversation_key_does_not_execute() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    // Propose turn (key A) consumes 1 reply; the "confirm" on key B has no
+    // pending proposal so it falls through to a normal (2nd scripted) LLM call.
+    let reply = proposal_reply("alpha", "fix the flaky auth test");
+    install_scripted_queue(&state, &[reply.as_str(), "I'm not sure what you mean."]);
+    let base = serve(Arc::clone(&state)).await;
+
+    post(
+        &base,
+        "/api/v1/manager/chat",
+        json!({ "conversation_key": "conv-a", "message": "launch a session for alpha to fix the flaky auth test" }),
+    )
+    .await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/chat",
+        json!({ "conversation_key": "conv-b", "message": "confirm" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    // No pending proposal on conv-b, so this was treated as an ordinary message
+    // — no action_result, and definitely nothing launched.
+    assert!(body.get("action_result").is_none(), "body: {body}");
+    assert!(launcher.launched.lock().unwrap().is_empty());
+}
+
+/// Why: an UNCONFIRMED proposal must expire after exactly one intervening turn —
+/// a later "confirm" (a THIRD turn) must find nothing pending and therefore not
+/// execute (the next-turn-only TTL policy).
+/// Test: itself.
+#[tokio::test]
+async fn chat_unconfirmed_proposal_expires_next_turn() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    // Turn 1 (propose) + turn 2 (plain, unrelated — expires the proposal) + turn
+    // 3 ("confirm", but nothing pending — falls through to a normal LLM call).
+    let reply = proposal_reply("alpha", "fix the flaky auth test");
+    install_scripted_queue(
+        &state,
+        &[
+            reply.as_str(),
+            "Sure, happy to chat about something else.",
+            "Not sure what you'd like me to confirm.",
+        ],
+    );
+    let base = serve(Arc::clone(&state)).await;
+
+    post(
+        &base,
+        "/api/v1/manager/chat",
+        json!({ "conversation_key": "conv-3", "message": "launch a session for alpha to fix the flaky auth test" }),
+    )
+    .await;
+    // Turn 2: an unrelated plain message — the pending proposal expires.
+    post(
+        &base,
+        "/api/v1/manager/chat",
+        json!({ "conversation_key": "conv-3", "message": "what else is going on?" }),
+    )
+    .await;
+    // Turn 3: "confirm" arrives too late — nothing is pending anymore.
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/chat",
+        json!({ "conversation_key": "conv-3", "message": "confirm" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert!(body.get("action_result").is_none(), "body: {body}");
+    assert!(launcher.launched.lock().unwrap().is_empty());
+}
+
+/// Why: a plain chat message (no proposal in the reply, not a confirmation)
+/// must never trigger execution — the baseline "still safe by default" case.
+/// Test: itself.
+#[tokio::test]
+async fn chat_plain_message_never_triggers_execution() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    install_scripted_queue(&state, &["Everything looks fine, nothing blocked."]);
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/chat",
+        json!({ "conversation_key": "conv-4", "message": "what needs my attention?" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert!(body.get("action_result").is_none(), "body: {body}");
+    assert_eq!(body["reply"], "Everything looks fine, nothing blocked.");
+    assert!(launcher.launched.lock().unwrap().is_empty());
 }

--- a/crates/trusty-mpm/tests/manager_routing.rs
+++ b/crates/trusty-mpm/tests/manager_routing.rs
@@ -1,0 +1,466 @@
+//! Hermetic HTTP integration suite for the Layer-3 manager PHASE 2 routing +
+//! proposal-and-confirm surface (`/api/v1/manager/{route-task,act}`, epic #2109,
+//! DOC-36 phase 2: WI-8 #2585, WI-9 #2586).
+//!
+//! Why: DOC-36 §4's local-testability bar requires these endpoints to be
+//! exercisable with NO live provider key, NO network, and NO channel/bot token.
+//! This file binds the REAL `api::router` on a loopback port and drives:
+//! (1) `route-task` — the unambiguous deterministic pass-through (no LLM), the
+//! LLM-judged disambiguation on a genuine tie (via `ScriptedAdapter`), the
+//! no-provider degrade to the deterministic top candidate, no-match, and the
+//! empty-text 400; (2) `act` — the propose→confirm protocol, proving a call
+//! without `confirm` executes NOTHING and a `confirm: true` call routes a launch
+//! through a test-double `SessionLauncher` and an inject through a REAL
+//! `SessionProxy` over a test-double `ManagedBackend` (no live session/channel).
+//! What: this file IS the test; run with
+//! `cargo test -p trusty-mpm --test manager_routing`.
+
+use std::future::IntoFuture;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use trusty_common::inference::registry::{ProviderId, capabilities};
+use trusty_common::inference::test_support::ScriptedAdapter;
+use trusty_common::inference::types::UsageBlock;
+use trusty_common::inference::{AssistantMessage, ChatChoice, ChatResponse, InferenceAdapter};
+use trusty_mpm::client::proxy::{ActivityDigest, ManagedBackend, SessionProxy};
+use trusty_mpm::daemon::manager::{LaunchOutcome, ProxyActuator, SessionLauncher};
+use trusty_mpm::daemon::{api, state::DaemonState};
+use trusty_mpm::project::Project;
+
+/// Serve the real router on an ephemeral loopback port; return its base URL.
+async fn serve(state: Arc<DaemonState>) -> String {
+    let router = api::router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    format!("http://{addr}")
+}
+
+/// A fresh, hermetic daemon state under a temp framework root.
+async fn fresh_state() -> Arc<DaemonState> {
+    let root = tempfile::tempdir().unwrap().keep();
+    Arc::new(DaemonState::with_root_isolated_managed(root).await)
+}
+
+/// Register a project fixture with the given name and tags.
+async fn register_project(state: &Arc<DaemonState>, name: &str, tags: &[&str]) {
+    state
+        .project_registry()
+        .await
+        .register(Project {
+            name: name.to_string(),
+            repo_url: format!("https://github.com/acme/{name}"),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        })
+        .await
+        .expect("register project");
+}
+
+/// Build a scripted OpenAI-shaped response carrying `text`.
+fn scripted_reply(text: &str) -> ChatResponse {
+    ChatResponse {
+        id: "scripted".into(),
+        model: "test/model".into(),
+        choices: vec![ChatChoice {
+            message: AssistantMessage {
+                content: Some(text.into()),
+                tool_calls: Vec::new(),
+            },
+            finish_reason: Some("stop".into()),
+        }],
+        usage: UsageBlock::default(),
+    }
+}
+
+/// Install a scripted adapter into the served state's manager inference seam.
+fn install_scripted(state: &Arc<DaemonState>, adapter: ScriptedAdapter) {
+    let adapter: Arc<dyn InferenceAdapter> = Arc::new(adapter);
+    state
+        .manager_state()
+        .inference()
+        .set_adapter(adapter, "test/model");
+}
+
+/// POST helper returning `(status, body_json)`.
+async fn post(base: &str, path: &str, body: Value) -> (reqwest::StatusCode, Value) {
+    let resp = reqwest::Client::new()
+        .post(format!("{base}{path}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let json: Value = resp.json().await.unwrap();
+    (status, json)
+}
+
+// ── route-task ──────────────────────────────────────────────────────────────
+
+/// Why: an unambiguous exact-name match must pass straight through the
+/// deterministic resolver with NO inference call (resolved_by = "resolver").
+/// Test: itself.
+#[tokio::test]
+async fn route_task_unambiguous_pass_through_no_llm() {
+    let state = fresh_state().await;
+    register_project(&state, "alpha", &[]).await;
+    // No inference provider configured — proving the unambiguous path never
+    // touches inference (it would otherwise degrade/err).
+    state.manager_state().inference().set_unconfigured();
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/route-task",
+        json!({ "text": "alpha" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body["project"], "alpha");
+    assert_eq!(body["resolved_by"], "resolver");
+    assert!((body["confidence"].as_f64().unwrap() - 1.0).abs() < 1e-6);
+}
+
+/// Why: a genuine tie (two candidates above the disambiguation floor) must
+/// escalate to ONE LLM judgment call, and the judged pick is returned with
+/// resolved_by = "disambiguation".
+/// Test: itself.
+#[tokio::test]
+async fn route_task_tie_escalates_to_llm_disambiguation() {
+    let state = fresh_state().await;
+    // Both score name(0.4)+tag(0.3)=0.7 for the query "auth" → both > 0.6 floor.
+    register_project(&state, "auth-alpha", &["auth"]).await;
+    register_project(&state, "auth-beta", &["auth"]).await;
+    install_scripted(
+        &state,
+        ScriptedAdapter::new("scripted", capabilities(ProviderId::OpenRouter))
+            .with_response(scripted_reply("auth-beta")),
+    );
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/route-task",
+        json!({ "text": "auth" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body["resolved_by"], "disambiguation", "body: {body}");
+    // The LLM picked auth-beta even though auth-alpha is the deterministic primary.
+    assert_eq!(body["project"], "auth-beta", "body: {body}");
+}
+
+/// Why: on a tie with NO inference provider, route-task must degrade to the
+/// deterministic top candidate rather than fail (advisory, never panics).
+/// Test: itself.
+#[tokio::test]
+async fn route_task_tie_degrades_without_provider() {
+    let state = fresh_state().await;
+    register_project(&state, "auth-alpha", &["auth"]).await;
+    register_project(&state, "auth-beta", &["auth"]).await;
+    state.manager_state().inference().set_unconfigured();
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/route-task",
+        json!({ "text": "auth" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    // Degraded to the deterministic pick — resolver, not disambiguation.
+    assert_eq!(body["resolved_by"], "resolver", "body: {body}");
+    assert!(body["project"].is_string(), "body: {body}");
+    assert!(
+        body["rationale"]
+            .as_str()
+            .unwrap()
+            .contains("no inference provider"),
+        "body: {body}"
+    );
+}
+
+/// Why: an unresolvable query is an advisory 200 no-match (project = null), not
+/// an error — the caller decides what to do next.
+/// Test: itself.
+#[tokio::test]
+async fn route_task_no_match_is_advisory() {
+    let state = fresh_state().await;
+    register_project(&state, "alpha", &[]).await;
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/route-task",
+        json!({ "text": "zzzz-nothing-matches" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert!(body["project"].is_null(), "body: {body}");
+    assert_eq!(body["resolved_by"], "no_match");
+}
+
+/// Why: an empty task is a client error (400), not a silent no-match.
+/// Test: itself.
+#[tokio::test]
+async fn route_task_empty_text_is_400() {
+    let state = fresh_state().await;
+    let base = serve(Arc::clone(&state)).await;
+    let (status, _body) = post(&base, "/api/v1/manager/route-task", json!({ "text": "  " })).await;
+    assert_eq!(status, reqwest::StatusCode::BAD_REQUEST);
+}
+
+// ── act: propose-and-confirm ─────────────────────────────────────────────────
+
+/// A recording test double for the launch verb — records the launch and returns
+/// a canned session WITHOUT provisioning anything.
+struct FakeLauncher {
+    launched: Mutex<Vec<(String, String)>>,
+}
+
+impl FakeLauncher {
+    fn new() -> Self {
+        Self {
+            launched: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl SessionLauncher for FakeLauncher {
+    async fn launch(&self, project: &str, task: &str) -> Result<LaunchOutcome, String> {
+        self.launched
+            .lock()
+            .unwrap()
+            .push((project.to_string(), task.to_string()));
+        Ok(LaunchOutcome {
+            session_id: "sess-launched-1".to_string(),
+            name: format!("{project}-session"),
+            state: "active".to_string(),
+        })
+    }
+}
+
+/// A test-double `ManagedBackend` — the seam the REAL `SessionProxy` drives, so
+/// the confirmed inject exercises the genuine focus→inject state machine with no
+/// live session.
+struct FakeBackend {
+    sent: Mutex<Vec<(String, String)>>,
+}
+
+impl FakeBackend {
+    fn new() -> Self {
+        Self {
+            sent: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl ManagedBackend for FakeBackend {
+    async fn resolve(&self, target: &str) -> Result<(String, String), String> {
+        if target == "sess-1" || target == "id-sess-1" {
+            Ok(("id-sess-1".to_string(), "sess-1".to_string()))
+        } else {
+            Err(format!("managed session {target} not found"))
+        }
+    }
+    async fn send(&self, id: &str, text: &str) -> Result<(), String> {
+        self.sent
+            .lock()
+            .unwrap()
+            .push((id.to_string(), text.to_string()));
+        Ok(())
+    }
+    async fn activity(&self, _id: &str) -> Result<ActivityDigest, String> {
+        Ok(ActivityDigest {
+            state: "active".to_string(),
+            summary: "working on the task".to_string(),
+            pending_decision: None,
+        })
+    }
+}
+
+/// Install a `ProxyActuator` over the two doubles onto the manager state.
+fn install_actuator(
+    state: &Arc<DaemonState>,
+    launcher: Arc<FakeLauncher>,
+    backend: Arc<FakeBackend>,
+) {
+    let proxy = SessionProxy::new(backend);
+    let actuator = ProxyActuator::new(launcher, proxy);
+    state.manager_state().set_actuator(Arc::new(actuator));
+}
+
+/// Why: a call WITHOUT `confirm` must return a proposal and execute NOTHING —
+/// DOC-35 §11's "no acting without an explicit call".
+/// Test: itself.
+#[tokio::test]
+async fn act_propose_only_executes_nothing() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/act",
+        json!({
+            "conversation_key": "cli:test",
+            "action": { "type": "launch", "project": "alpha", "task": "do the thing" }
+        }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body["status"], "proposed", "body: {body}");
+    assert!(
+        body["proposal"].as_str().unwrap().contains("confirm"),
+        "body: {body}"
+    );
+    // Nothing was launched.
+    assert!(launcher.launched.lock().unwrap().is_empty());
+}
+
+/// Why: a confirmed launch must call the #2108 launch verb (here the recording
+/// double) exactly once and report the launched session.
+/// Test: itself.
+#[tokio::test]
+async fn act_confirmed_launch_calls_launch_verb() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/act",
+        json!({
+            "conversation_key": "cli:test",
+            "confirm": true,
+            "action": { "type": "launch", "project": "alpha", "task": "do the thing" }
+        }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body["status"], "launched", "body: {body}");
+    assert_eq!(body["session_id"], "sess-launched-1");
+    let launched = launcher.launched.lock().unwrap();
+    assert_eq!(launched.len(), 1);
+    assert_eq!(
+        launched[0],
+        ("alpha".to_string(), "do the thing".to_string())
+    );
+}
+
+/// Why: a confirmed inject must route through the REAL `SessionProxy`
+/// (focus→inject) over the test-double backend — never a direct tmux mutation.
+/// Test: itself.
+#[tokio::test]
+async fn act_confirmed_inject_routes_through_session_proxy() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/act",
+        json!({
+            "conversation_key": "cli:test",
+            "confirm": true,
+            "action": { "type": "inject", "session": "sess-1", "text": "run the tests" }
+        }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body["status"], "injected", "body: {body}");
+    assert_eq!(body["session_id"], "id-sess-1");
+    let sent = backend.sent.lock().unwrap();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(
+        sent[0],
+        ("id-sess-1".to_string(), "run the tests".to_string())
+    );
+}
+
+/// Why: injecting into an unresolvable session is an advisory 200 outcome
+/// (session_not_found), and nothing is sent.
+/// Test: itself.
+#[tokio::test]
+async fn act_confirmed_inject_unknown_session_not_found() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/act",
+        json!({
+            "conversation_key": "cli:test",
+            "confirm": true,
+            "action": { "type": "inject", "session": "ghost", "text": "hi" }
+        }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body["status"], "session_not_found", "body: {body}");
+    assert!(backend.sent.lock().unwrap().is_empty());
+}
+
+/// Why: a confirmed summarize routes through the REAL `SessionProxy` summarize
+/// direction over the double.
+/// Test: itself.
+#[tokio::test]
+async fn act_confirmed_summarize_routes_through_session_proxy() {
+    let state = fresh_state().await;
+    let launcher = Arc::new(FakeLauncher::new());
+    let backend = Arc::new(FakeBackend::new());
+    install_actuator(&state, Arc::clone(&launcher), Arc::clone(&backend));
+    let base = serve(Arc::clone(&state)).await;
+
+    let (status, body) = post(
+        &base,
+        "/api/v1/manager/act",
+        json!({
+            "conversation_key": "cli:test",
+            "confirm": true,
+            "action": { "type": "summarize", "session": "sess-1" }
+        }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body["status"], "summarized", "body: {body}");
+    assert_eq!(body["summary"], "working on the task");
+}
+
+/// Why: an empty conversation key is a client error (400).
+/// Test: itself.
+#[tokio::test]
+async fn act_empty_conversation_key_is_400() {
+    let state = fresh_state().await;
+    let base = serve(Arc::clone(&state)).await;
+    let (status, _body) = post(
+        &base,
+        "/api/v1/manager/act",
+        json!({
+            "conversation_key": "  ",
+            "action": { "type": "summarize", "session": "x" }
+        }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
## Summary

Layer-3 portfolio manager **phase 2** (epic #2109, DOC-36), built on the phase-1 foundation. API-first: the CLI consumes the daemon routes, never bypasses them.

### #2585 — `POST /api/v1/manager/route-task`
Consumes DOC-22's deterministic resolver (`resolve_project`) for candidate scoring and — because #2109 owns disambiguation (DOC-35 §13 Q1 SPLIT) — escalates **only a genuine tie** (`needs_disambiguation()`) to one grounded LLM judgment call; an unambiguous resolution passes through with **zero inference**. Does **not** reimplement the resolver, and is **advisory only** — never launches or mutates a session (DOC-35 §11). No-provider / inconclusive disambiguation degrades to the deterministic top candidate (never panics). Returns `{ project, confidence, rationale, resolved_by }`.

### #2586 — `POST /api/v1/manager/act` (proposal-and-confirm)
Explicit **propose→confirm** flow: a call without `confirm` returns a human-readable proposal and executes nothing; `confirm: true` executes exactly one action through the `ManagerActuator` seam — a **launch calls #2108's launch verb** (`spawn_managed`), an **inject/summarize routes through L2's real `SessionProxy`** (never a direct tmux mutation). No silent/background mutation. The seam is overridable on `ManagerState` (mirrors the inference `set_adapter`) so the hermetic suite drives the whole flow over a test-double launcher + a real `SessionProxy` over a mock `ManagedBackend`.

### #2587 — `tm manager route`
Thin, API-first CLI wrapper over `/route-task` that surfaces `{ project, confidence, rationale }` with **no client-side resolution logic** and **no channel/bot token**. Per §7 Q5 (RESOLVED), no separate CLI-only disambiguation UX for v1.

### Supporting changes
- `version` endpoint: phase → 2; `route-task` and `act` advertised `available: true`.
- Client method `DaemonClient::manager_route_task` with the same feature-detected-404 handling as digest/chat.
- Refactor to respect the line-cap ratchet: manager routes extracted into `manager_router()` (merged in `api.rs` like `proxy_router`), and `ManagerAction` moved to `cli_manager.rs` — both keep the grandfathered `api.rs`/`cli.rs` under budget.

## Testing
- `cargo build --workspace` ✅
- `cargo test -p trusty-mpm` ✅ (incl. new hermetic `tests/manager_routing.rs`: 11 tests — route-task pass-through/disambiguation/degrade/no-match/400, act propose/confirm-launch/confirm-inject/summarize/not-found/400)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (exit 0)
- `cargo fmt --check` ✅
- `bash scripts/check_line_cap.sh` ✅ (0 violations)

Closes #2585
Closes #2586
Closes #2587

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools