### PR TITLE
fix(trusty-mpm): harden agents against idle parking — never end a turn to wait (closes #2610)

### DIFF
--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -162,34 +162,58 @@ This applies especially to verification-critical commands: test runs, `git`/`gh`
 reads and writes, and build output. An unobservable result is never a passing
 result.
 
-## Foreground Execution
+## Foreground Execution — NEVER End Your Turn To Wait
 
-Long-running commands — CI watches (`gh pr checks --watch`, `gh run watch`),
-builds, test suites, deploy waits — MUST run as plain blocking foreground
-commands. Run them and wait for them to exit, even if that takes 15+ minutes.
+🔴 **You must NEVER end your turn to "wait" for anything.** Nothing re-invokes a
+stopped agent. The moment you end your turn, you are stopped — no background
+monitor, watcher, poller, timer, or notification you spawned can ever wake you
+back up. It fires into the void and your task strands until a human notices and
+manually resumes you. Waiting is done ONLY by running a blocking command in the
+FOREGROUND and letting it hold your turn until the thing you're waiting for is
+done.
 
-NEVER stop mid-task to "wait for a notification", "monitor in the background",
-or "check back later". No notification will ever arrive inside a delegated
-agent's turn; stopping stalls the whole delegation chain.
+**Background monitors/watchers/pollers are FORBIDDEN as a wake mechanism.** Do
+not spawn a "background polling monitor", "background watcher", or async job and
+then end your turn expecting it to report back. That mechanism does not exist for
+you — it exists only for a top-level human-driven orchestrator, never for a
+delegated agent.
 
-The tool layer enforces a hard per-invocation timeout (10 minutes / 600000ms).
-If a blocking command hits that ceiling before finishing — or otherwise
-legitimately outlasts a single invocation — immediately RE-ISSUE the same
-blocking command (or its status-check equivalent; e.g. running
-`gh pr checks <n> --watch` again resumes watching) in the SAME turn, looping
-re-invocations until it completes. Re-issuing is not "checking back later";
-the forbidden move is ending the turn to wait for a notification, not the
-re-invocation itself.
+**Ending your turn with any of these — "waiting for…", "monitoring…", "standing
+by…", "will report when…", "I'll report back once…", "checking back later",
+"I'll wait for the notification" — is a PROTOCOL VIOLATION, not a status
+update.** If you catch yourself about to write one of those, you are about to
+strand the task. Instead: run the blocking command now, in this turn.
 
-Do not background such commands (`&` / `run_in_background`) unless the
-dispatching prompt explicitly set up a polling loop. If a command was
-backgrounded, poll it to completion in the same turn before ending.
+### Canonical CI-wait pattern (blocking, foreground)
 
-If a watch command exits nonzero, capture the failure evidence and report it —
-don't retry-by-waiting.
+```bash
+gh pr checks <pr> --watch --fail-fast    # blocks until all checks settle
+```
 
-This rule exists because merge/CI agents repeatedly parked mid-watch waiting
-for a notification that never came (issue #2501).
+Run it as a plain foreground command and let it hold the turn — even 15+ minutes.
+Do NOT background it (`&` / `run_in_background`). Do NOT end the turn to "monitor
+the checks". When it exits, read the result and act. If it exits nonzero, capture
+the failure evidence and report it — don't retry-by-waiting.
+
+### Canonical long-command pattern (blocking, foreground)
+
+Run builds, test suites, and deploy waits as plain foreground commands with a
+long timeout and wait for them to exit. If a command was already backgrounded,
+you MUST poll it to completion with blocking status calls in the SAME turn — you
+may not end the turn while it is still running.
+
+### When a single invocation times out
+
+The tool layer enforces a hard per-invocation timeout (10 minutes / 600000ms). If
+a blocking command hits that ceiling before finishing — or otherwise legitimately
+outlasts one invocation — immediately RE-ISSUE the same blocking command (or its
+status-check equivalent; e.g. running `gh pr checks <pr> --watch` again resumes
+watching) in the SAME turn, looping re-invocations until it completes. Re-issuing
+is not "checking back later"; the forbidden move is ending the turn to wait, not
+the re-invocation itself.
+
+This rule exists because merge/CI/release agents repeatedly parked mid-watch
+waiting for a notification that never came (issues #2501, #2610).
 
 ## Output Format
 

--- a/crates/trusty-mpm/src/assets/agents/BASE-ENGINEER.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-ENGINEER.md
@@ -189,6 +189,12 @@ Before returning, re-read the prompt for "Deliverables" / "Requirements" /
 - [ ] Build passes — run the full verify command before returning:
       `cargo check --all-targets && cargo test && cargo clippy -- -D warnings`.
 
+Run that verify/quality-gate command as a BLOCKING FOREGROUND call and wait for it
+to exit — even 15+ minutes. NEVER end your turn to "wait for the gate to finish"
+or hand it to a background monitor: nothing wakes a stopped agent, so the run
+strands until a human resumes you. See BASE-AGENT "Foreground Execution — NEVER
+End Your Turn To Wait" (issues #2501, #2610).
+
 ## Output Requirements
 
 - Actual code, not pseudocode. Include error handling and logging.

--- a/crates/trusty-mpm/src/assets/agents/local-ops.md
+++ b/crates/trusty-mpm/src/assets/agents/local-ops.md
@@ -84,6 +84,31 @@ npm audit / cargo audit / bandit -r src/
 
 Surface failures with the failing command output and remediation steps — do not silently swallow errors.
 
+## Long Waits — Block In The Foreground, NEVER Park (issues #2501, #2610)
+
+🔴 Release cuts, CI watches, `cargo build --release`, publish waits, and
+`gh pr checks --watch` are where ops/release agents strand tasks. **You must NEVER
+end your turn to "wait" for one — and NEVER spawn a background polling monitor and
+end your turn expecting it to notify you.** Nothing wakes a stopped agent; a
+self-created monitor/watcher fires into the void and the release hangs until a
+human manually resumes you. Ending a turn with "waiting for…", "monitoring in the
+background", "will report back once…", or "standing by" is a PROTOCOL VIOLATION.
+
+Wait ONLY by blocking in the foreground:
+
+```bash
+gh pr checks <pr> --watch --fail-fast    # CI: blocks until checks settle
+cargo build --release -p <crate>         # long build: run it, wait for exit
+```
+
+- Run long commands in the FOREGROUND with a long timeout and wait for them to
+  exit — do NOT background them (`&` / `run_in_background`).
+- If a command was already backgrounded, poll it to completion with blocking
+  status calls in the SAME turn; do not end the turn while it runs.
+- If an invocation hits the 10-min tool ceiling, RE-ISSUE the same blocking
+  command in the SAME turn and loop until it completes.
+- On failure, capture the output and report it — do not retry-by-waiting.
+
 ## GitHub Account Management
 
 Two GitHub CLI accounts are registered:

--- a/crates/trusty-mpm/src/assets/agents/version-control.md
+++ b/crates/trusty-mpm/src/assets/agents/version-control.md
@@ -26,6 +26,29 @@ Manage all git operations, versioning, and release coordination. Maintain clean 
 
 For most features, use main-based PRs (each PR from `main`). Use stacked PRs only when the user explicitly requests them.
 
+## CI Waits — Block In The Foreground, NEVER Park (issues #2501, #2610)
+
+🔴 Waiting on PR checks, a merge queue, or `gh run watch` is where version-control
+agents strand tasks. **You must NEVER end your turn to "monitor" checks or wait
+for a notification** — nothing wakes a stopped agent, so a self-spawned watcher or
+"background monitor" fires into the void and the merge hangs until a human resumes
+you. This is a protocol violation, not a status update.
+
+Wait ONLY by blocking in the foreground:
+
+```bash
+gh pr checks <pr> --watch --fail-fast    # blocks until checks settle; run it and wait
+```
+
+- Run it as a plain foreground command — do NOT background it (`&` /
+  `run_in_background`) and do NOT stop to "monitor".
+- If the invocation times out (10-min tool ceiling), RE-ISSUE the same
+  `gh pr checks <pr> --watch` in the SAME turn and keep looping until it exits.
+- On a nonzero exit, capture the failing check output and report it — do not
+  retry-by-waiting.
+- Ending a turn with "monitoring the checks", "waiting for CI", "will report when
+  green", or "standing by" is FORBIDDEN.
+
 ## Memory Management for Git Operations
 
 - Use `git log --oneline -n 50` for history — never unlimited `git log -p`

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -434,13 +434,33 @@ pub(crate) async fn read_stdin_hook_payload() -> Option<serde_json::Value> {
 /// the Stop/SubagentStop hook can never block the user's prompt. A tail read may
 /// slice mid-line; the detector tolerates a truncated leading line, so we accept
 /// the boundary rather than paying to align it.
-/// What: opens `path`, seeks to `len - max_bytes` (clamped at 0), reads up to
-/// `max_bytes`, and returns the bytes as a lossy UTF-8 string. Any I/O error
-/// yields `None` (fail-open — detection is advisory, never load-bearing).
-/// Test: exercised end-to-end via [`detect_idle_parking_from_payload`]'s callers
-/// and the `core::idle_parking` unit tests that cover truncated tails.
+///
+/// Code-critic finding (PR #2620): the caller wraps this whole function in
+/// `tokio::time::timeout`, but that only bounds the `.await` — the underlying
+/// `open()` syscall still runs to completion on a `spawn_blocking` worker
+/// thread. If `transcript_path` ever pointed at a FIFO with no writer, `open()`
+/// blocks the kernel thread indefinitely; the `timeout` future resolves (the
+/// hook process still exits promptly), but the leaked blocking task pins a
+/// worker thread forever. `stat()` (unlike `open()`) never blocks on a FIFO, so
+/// checking the file type first — and refusing anything that is not a regular
+/// file — closes that leak before the `open()` call can ever be reached.
+/// What: `tokio::fs::metadata` (stat)-checks `path` first and returns `None`
+/// immediately unless it names a regular file (rejects FIFOs, sockets, device
+/// nodes, directories, and anything `stat` can't resolve). Only then opens
+/// `path`, seeks to `len - max_bytes` (clamped at 0), reads up to `max_bytes`,
+/// and returns the bytes as a lossy UTF-8 string. Any I/O error yields `None`
+/// (fail-open — detection is advisory, never load-bearing).
+/// Test: `rejects_fifo_without_blocking` (unix-only, `#[cfg(unix)]`) proves the
+/// FIFO case returns promptly instead of hanging; also exercised end-to-end via
+/// [`detect_idle_parking_from_payload`]'s callers and the `core::idle_parking`
+/// unit tests that cover truncated tails.
 async fn read_transcript_tail(path: &std::path::Path, max_bytes: u64) -> Option<String> {
     use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    let meta = tokio::fs::metadata(path).await.ok()?;
+    if !meta.file_type().is_file() {
+        return None;
+    }
 
     let mut file = tokio::fs::File::open(path).await.ok()?;
     let len = file.metadata().await.ok()?.len();

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -426,6 +426,67 @@ pub(crate) async fn read_stdin_hook_payload() -> Option<serde_json::Value> {
     }
 }
 
+/// Best-effort, bounded read of the last `max_bytes` of a transcript file.
+///
+/// Why (#2610): the idle-parking detector needs the agent's final assistant
+/// message, which lives at the END of Claude Code's JSONL transcript. Reading
+/// only the tail bounds both time and memory on a large session transcript, so
+/// the Stop/SubagentStop hook can never block the user's prompt. A tail read may
+/// slice mid-line; the detector tolerates a truncated leading line, so we accept
+/// the boundary rather than paying to align it.
+/// What: opens `path`, seeks to `len - max_bytes` (clamped at 0), reads up to
+/// `max_bytes`, and returns the bytes as a lossy UTF-8 string. Any I/O error
+/// yields `None` (fail-open — detection is advisory, never load-bearing).
+/// Test: exercised end-to-end via [`detect_idle_parking_from_payload`]'s callers
+/// and the `core::idle_parking` unit tests that cover truncated tails.
+async fn read_transcript_tail(path: &std::path::Path, max_bytes: u64) -> Option<String> {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    let mut file = tokio::fs::File::open(path).await.ok()?;
+    let len = file.metadata().await.ok()?.len();
+    let start = len.saturating_sub(max_bytes);
+    if start > 0 {
+        file.seek(std::io::SeekFrom::Start(start)).await.ok()?;
+    }
+    let mut bytes = Vec::new();
+    file.take(max_bytes).read_to_end(&mut bytes).await.ok()?;
+    Some(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// Detect an idle-parking final message from a Stop/SubagentStop hook payload.
+///
+/// Why (#2610): prompt-level prohibitions did not fully stop delegated agents
+/// from ending their turn to "wait" for a self-spawned monitor. This is the
+/// mechanical back-stop: on a turn-end event, check what the agent actually said
+/// last and flag the stall so it can be surfaced (and later auto-nudged).
+/// What: reads `transcript_path` from the hook payload, tail-reads the transcript
+/// (bounded to [`MAX_TRANSCRIPT_TAIL`]) under a short [`DETECT_TIMEOUT`] so the
+/// hook stays within its non-blocking budget, then runs
+/// [`trusty_mpm::core::idle_parking::detect_idle_parking_in_transcript`]. Returns
+/// the matched phrase, or `None` on any missing field / timeout / I/O error /
+/// clean message. Entirely fail-open.
+/// Test: the pure detection is covered by `core::idle_parking` tests;
+/// `hook_flags_idle_parking_final_message` (integration) drives this end to end.
+async fn detect_idle_parking_from_payload(
+    payload: Option<&serde_json::Value>,
+) -> Option<&'static str> {
+    /// Cap on transcript bytes read from the tail (256 KiB is far more than one
+    /// final assistant turn, yet bounds cost on a multi-MB session transcript).
+    const MAX_TRANSCRIPT_TAIL: u64 = 256 * 1024;
+    /// Hard ceiling on the whole detection so the hook never blocks the prompt.
+    const DETECT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(300);
+
+    let path = payload?.get("transcript_path")?.as_str()?;
+    let path = std::path::PathBuf::from(path);
+    let jsonl = tokio::time::timeout(
+        DETECT_TIMEOUT,
+        read_transcript_tail(&path, MAX_TRANSCRIPT_TAIL),
+    )
+    .await
+    .ok()??;
+    trusty_mpm::core::idle_parking::detect_idle_parking_in_transcript(&jsonl)
+}
+
 /// `hook` subcommand — handle a Claude Code lifecycle hook event.
 ///
 /// Why: Claude Code invokes the configured hook command on every PreToolUse /
@@ -539,6 +600,25 @@ pub(crate) async fn hook(client: &reqwest::Client, url: &str) -> anyhow::Result<
         return Ok(());
     }
 
+    // #2610: on turn-end events (main agent Stop / delegated SubagentStop),
+    // flag a final message that "parks" the agent — one that ends the turn to
+    // wait on a monitor/watcher/notification that can never re-wake a stopped
+    // agent. Fail-open and bounded so this never blocks the user's prompt.
+    let idle_parking = if matches!(event.as_str(), "Stop" | "SubagentStop") {
+        detect_idle_parking_from_payload(stdin_payload.as_ref()).await
+    } else {
+        None
+    };
+    if let Some(phrase) = idle_parking {
+        // Loud, greppable structured warning to stderr so operators and session
+        // logs see the stall even before the daemon/dashboard surfaces it.
+        eprintln!(
+            "trusty-mpm: IDLE-PARKING WARNING (#2610) event={event} session={session_id} \
+             phrase={phrase:?} — the agent ended its turn with parking language; a stopped \
+             agent cannot be re-woken by a self-spawned monitor. It needs a foreground nudge."
+        );
+    }
+
     // Include the caller's cwd so the daemon can correlate this SessionStart
     // event to the right managed session by workspace_path (issue #1744).
     let cwd = std::env::current_dir()
@@ -546,6 +626,13 @@ pub(crate) async fn hook(client: &reqwest::Client, url: &str) -> anyhow::Result<
         .and_then(|p| p.to_str().map(str::to_owned))
         .unwrap_or_default();
     let mut payload = serde_json::json!({ "cwd": cwd });
+    // #2610: forward the idle-parking signal in the structured hook payload so
+    // the daemon can surface it (dashboard / errors feed) and a future pass can
+    // auto-nudge. Additive fields — harmless to existing hook_service consumers.
+    if let Some(phrase) = idle_parking {
+        payload["idle_parking"] = serde_json::Value::Bool(true);
+        payload["idle_parking_phrase"] = serde_json::Value::String(phrase.to_string());
+    }
     // #1956: enrich the observability payload with tool/input when present —
     // the daemon's hook_service already reads `payload["tool"]`/`["input"]`
     // (see `daemon::services::hook_service::OverseerContext` construction).

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -553,12 +553,13 @@ fn new_concrete_agents_deploy_via_real_asset_files() {
 
 #[test]
 fn base_agent_guidance_sections_survive_composition() {
-    // Regression for #2501/#2502: BASE-AGENT.md's "Foreground Execution" and
-    // "PM Directives Do Not Bind You" sections must propagate into every
-    // composed agent via the real bundled asset chain — not just exist in
-    // the source file. Uses version-control (a representative leaf agent)
-    // composed from the real assets dir so a future refactor of the
-    // compose/extends pipeline can't silently drop either section.
+    // Regression for #2501/#2502/#2610: BASE-AGENT.md's "Foreground Execution"
+    // and "PM Directives Do Not Bind You" sections — plus the version-control
+    // persona's own CI-wait reinforcement — must propagate into the composed
+    // agent via the real bundled asset chain, not just exist in the source
+    // files. Uses version-control (the worst parking offender) composed from
+    // the real assets dir so a future refactor of the compose/extends pipeline
+    // can't silently drop the no-parking guidance.
     use crate::core::agent_builder::compose_agent;
     use std::path::Path;
 
@@ -575,8 +576,20 @@ fn base_agent_guidance_sections_survive_composition() {
         "composed version-control is missing the Foreground Execution section"
     );
     assert!(
-        composed.contains("stalls the whole delegation chain"),
-        "composed version-control is missing the foreground-execution no-parking guidance"
+        composed.contains("NEVER end your turn to \"wait\""),
+        "composed version-control is missing the BASE-AGENT hard no-parking rule (#2610)"
+    );
+    assert!(
+        composed.contains("PROTOCOL VIOLATION"),
+        "composed version-control is missing the parking-is-a-protocol-violation rule (#2610)"
+    );
+    assert!(
+        composed.contains("gh pr checks <pr> --watch --fail-fast"),
+        "composed version-control is missing the canonical CI-wait blocking pattern (#2610)"
+    );
+    assert!(
+        composed.contains("## CI Waits — Block In The Foreground, NEVER Park"),
+        "composed version-control is missing its persona-level CI-wait section (#2610)"
     );
     assert!(
         composed.contains("## PM Directives Do Not Bind You"),
@@ -612,6 +625,19 @@ fn base_agent_guidance_sections_survive_composition() {
         foreground_execution_idx < output_format_idx,
         "Foreground Execution ({foreground_execution_idx}) must appear before \
          Output Format ({output_format_idx})"
+    );
+
+    // #2610: local-ops (the release-agent offender) must carry its own
+    // long-wait reinforcement on top of the inherited BASE-AGENT rule.
+    let local_ops =
+        compose_agent("local-ops", &assets_dir).expect("compose_agent(local-ops) must succeed");
+    assert!(
+        local_ops.contains("## Long Waits — Block In The Foreground, NEVER Park"),
+        "composed local-ops is missing its persona-level long-wait section (#2610)"
+    );
+    assert!(
+        local_ops.contains("NEVER end your turn to \"wait\""),
+        "composed local-ops is missing the inherited BASE-AGENT no-parking rule (#2610)"
     );
 }
 

--- a/crates/trusty-mpm/src/core/idle_parking.rs
+++ b/crates/trusty-mpm/src/core/idle_parking.rs
@@ -106,7 +106,14 @@ pub fn detect_idle_parking(final_message: &str) -> Option<&'static str> {
 /// `content` for forward-compat — and returns the first non-empty result found
 /// scanning backward. Returns `None` when no assistant text is present. Tolerant
 /// of a truncated leading line (e.g. when only the file tail was read): a line
-/// that fails to parse is simply skipped.
+/// that fails to parse is simply skipped. Known tradeoff (code-critic, PR #2620):
+/// the caller only hands this the last `MAX_TRANSCRIPT_TAIL` (256 KiB) bytes of
+/// the transcript, so a single final JSONL line LARGER than that window (e.g. an
+/// unusually long assistant turn) is itself truncated, fails to parse, and is
+/// skipped like any other broken leading line — an advisory false negative by
+/// design, not a bug: this detector is a best-effort warning back-stop, never a
+/// hard gate, so silently missing an oversized final line is an acceptable
+/// tradeoff for bounding the read cost on multi-MB session transcripts.
 /// Test: `extracts_last_assistant_text`, `extracts_across_tool_use_blocks`,
 /// `tolerates_truncated_and_blank_lines`, `returns_none_without_assistant`.
 pub fn last_assistant_text_from_transcript(jsonl: &str) -> Option<String> {

--- a/crates/trusty-mpm/src/core/idle_parking.rs
+++ b/crates/trusty-mpm/src/core/idle_parking.rs
@@ -1,0 +1,323 @@
+//! Detection of agent "idle parking" — a delegated agent ending its turn to
+//! "wait" for a self-spawned monitor/watcher/notification that can never
+//! re-wake it (issues #2501, #2610).
+//!
+//! Why: prompt-level prohibitions in the bundled agent guidance reduced but did
+//! NOT eliminate the failure mode where merge/CI/release agents stop mid-task
+//! with "monitoring the checks" / "standing by" / "will report back once…"
+//! language after spawning a background watcher. Nothing re-invokes a stopped
+//! agent, so the task strands until a human resumes it. A cheap, mechanical
+//! back-stop that flags a parking final message on turn-end lets the daemon /
+//! dashboard surface the stall (and, later, auto-nudge it) instead of relying
+//! solely on the agent obeying its instructions.
+//! What: two pure, side-effect-free helpers with no I/O. [`detect_idle_parking`]
+//! scans an agent's final assistant text for high-signal parking idioms and
+//! returns the first phrase matched. [`last_assistant_text_from_transcript`]
+//! extracts the last assistant message's concatenated text blocks from a
+//! Claude Code JSONL transcript so a Stop/SubagentStop hook can feed it to the
+//! detector. Both are deliberately advisory (high recall, warning-only): a
+//! false positive costs a spurious warning, never a blocked or killed agent.
+//! Test: the inline `tests` module below.
+
+/// High-signal, lowercased phrases that indicate an agent is ending its turn to
+/// wait on a monitor/watcher/notification that cannot re-invoke a stopped agent.
+///
+/// Why: these are the exact idioms observed across the #2501 (9 incidents) and
+/// #2610 (6 incidents) parking episodes — merge agents "monitoring PR checks",
+/// a release agent on a "background polling monitor", an engineer "waiting for
+/// the monitor to report the quality gate run". The list is curated to the
+/// turn-ending idiom rather than the bare words "waiting"/"monitoring" so that a
+/// legitimate final message ("I ran `gh pr checks --watch` in the foreground and
+/// it finished") does not trip it. It is intentionally advisory: matches drive a
+/// warning, never a hard action, so erring toward recall is safe.
+/// What: substrings compared against the lowercased haystack by
+/// [`detect_idle_parking`]. Order is roughly most-specific first so the returned
+/// phrase is the most informative match.
+/// Test: `detects_each_parking_phrase`, `ignores_benign_final_message` below.
+const PARKING_PHRASES: &[&str] = &[
+    "background polling monitor",
+    "background poll",
+    "background monitor",
+    "background watcher",
+    "monitor in the background",
+    "monitoring in the background",
+    "monitoring the checks",
+    "monitoring pr",
+    "monitoring the pr",
+    "waiting for the monitor",
+    "the monitor to report",
+    "monitor to report back",
+    "standing by",
+    "will report back",
+    "will report when",
+    "report back once",
+    "report back when",
+    "i'll report back",
+    "check back later",
+    "checking back later",
+    "wait for the notification",
+    "waiting for the notification",
+    "waiting for a notification",
+    "wait for a notification",
+    "await the notification",
+    "let me know once",
+    "let me know when the",
+    "notify me when",
+    "ping me when",
+    "i'll wait for the",
+    "i will wait for the",
+    "will resume once",
+];
+
+/// Scan an agent's final assistant text for idle-parking language.
+///
+/// Why: a delegated agent that ends its turn with "monitoring the checks" or
+/// "standing by" after spawning a background watcher has stranded its task — the
+/// watcher can never wake it. Detecting that phrase at turn-end (via the
+/// Stop/SubagentStop hook) is a mechanical back-stop for when the bundled
+/// prompt guidance fails to prevent the stall.
+/// What: lowercases `final_message` once and returns the first [`PARKING_PHRASES`]
+/// entry that appears as a substring, or `None` when the message is clean. Pure;
+/// no allocation beyond the single lowercased copy; no I/O.
+/// Test: `detects_each_parking_phrase`, `ignores_benign_final_message`,
+/// `detection_is_case_insensitive`, `empty_message_is_clean`.
+pub fn detect_idle_parking(final_message: &str) -> Option<&'static str> {
+    if final_message.trim().is_empty() {
+        return None;
+    }
+    let haystack = final_message.to_lowercase();
+    PARKING_PHRASES
+        .iter()
+        .copied()
+        .find(|phrase| haystack.contains(phrase))
+}
+
+/// Extract the last assistant message's text from a Claude Code JSONL transcript.
+///
+/// Why: the Stop / SubagentStop hook payload carries a `transcript_path`, not the
+/// message text itself. To run [`detect_idle_parking`] against what the agent
+/// actually said as its final turn, the hook must pull the last assistant
+/// message out of the transcript. Keeping the parse here (pure, string-in /
+/// string-out) makes it unit-testable without touching the filesystem.
+/// What: iterates the JSONL lines from the END (the final assistant turn is near
+/// the tail), skipping blank and unparseable lines. For each line whose
+/// top-level `type` is `"assistant"`, concatenates the `message.content[*].text`
+/// blocks (Claude Code's array-of-blocks shape) — or accepts a bare string
+/// `content` for forward-compat — and returns the first non-empty result found
+/// scanning backward. Returns `None` when no assistant text is present. Tolerant
+/// of a truncated leading line (e.g. when only the file tail was read): a line
+/// that fails to parse is simply skipped.
+/// Test: `extracts_last_assistant_text`, `extracts_across_tool_use_blocks`,
+/// `tolerates_truncated_and_blank_lines`, `returns_none_without_assistant`.
+pub fn last_assistant_text_from_transcript(jsonl: &str) -> Option<String> {
+    for line in jsonl.lines().rev() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if val.get("type").and_then(serde_json::Value::as_str) != Some("assistant") {
+            continue;
+        }
+        let content = val.get("message").and_then(|m| m.get("content"));
+        let text = extract_text_blocks(content);
+        if !text.trim().is_empty() {
+            return Some(text);
+        }
+    }
+    None
+}
+
+/// Concatenate the `text` from a Claude Code message `content` value.
+///
+/// Why: assistant `content` is normally an array of typed blocks
+/// (`{"type":"text","text":…}`, `{"type":"tool_use",…}`, …); only the text
+/// blocks carry what the agent "said". A bare-string `content` is also accepted
+/// for robustness against transcript-shape drift.
+/// What: for an array, joins every element's `text` field (skipping non-text
+/// blocks) with newlines; for a string, returns it directly; otherwise returns
+/// an empty string.
+/// Test: covered via `extracts_last_assistant_text`,
+/// `extracts_across_tool_use_blocks`.
+fn extract_text_blocks(content: Option<&serde_json::Value>) -> String {
+    match content {
+        Some(serde_json::Value::Array(blocks)) => blocks
+            .iter()
+            .filter_map(|b| b.get("text").and_then(serde_json::Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Some(serde_json::Value::String(s)) => s.clone(),
+        _ => String::new(),
+    }
+}
+
+/// Convenience: detect idle-parking directly from a JSONL transcript.
+///
+/// Why: the hook call site wants a one-shot "does this agent's final turn park?"
+/// answer without threading the intermediate last-message string through itself.
+/// What: composes [`last_assistant_text_from_transcript`] with
+/// [`detect_idle_parking`], returning the matched phrase (a `'static` slice) when
+/// the last assistant turn parks, else `None`.
+/// Test: `detects_parking_from_transcript`, `clean_transcript_yields_none`.
+pub fn detect_idle_parking_in_transcript(jsonl: &str) -> Option<&'static str> {
+    let last = last_assistant_text_from_transcript(jsonl)?;
+    detect_idle_parking(&last)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_each_parking_phrase() {
+        for phrase in PARKING_PHRASES {
+            let msg = format!("All set. {phrase} the CI completes and I'll continue.");
+            assert_eq!(
+                detect_idle_parking(&msg),
+                Some(*phrase),
+                "phrase {phrase:?} must be detected"
+            );
+        }
+    }
+
+    #[test]
+    fn detects_observed_incident_messages() {
+        // Verbatim-style samples from #2501 / #2610.
+        let samples = [
+            "I've kicked off a background polling monitor for the release and will \
+             resume once it reports.",
+            "Monitoring PR #2606 checks via a passive watcher; standing by.",
+            "Waiting for the monitor to report the quality gate run.",
+            "I'll report back once the checks go green.",
+        ];
+        for s in samples {
+            assert!(
+                detect_idle_parking(s).is_some(),
+                "incident message must be flagged: {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_benign_final_message() {
+        let clean = [
+            "I ran `gh pr checks 2606 --watch --fail-fast` in the foreground; all \
+             12 checks passed. PR is green.",
+            "cargo test → test result: ok. 68 passed; 0 failed. Done.",
+            "Fixed the race condition in the async handler and verified the build.",
+            "",
+            "   ",
+        ];
+        for c in clean {
+            assert_eq!(detect_idle_parking(c), None, "must be clean: {c:?}");
+        }
+    }
+
+    #[test]
+    fn detection_is_case_insensitive() {
+        assert_eq!(detect_idle_parking("STANDING BY."), Some("standing by"));
+        assert_eq!(
+            detect_idle_parking("Will Report Back when it finishes"),
+            Some("will report back")
+        );
+    }
+
+    #[test]
+    fn empty_message_is_clean() {
+        assert_eq!(detect_idle_parking(""), None);
+        assert_eq!(detect_idle_parking("\n\t  "), None);
+    }
+
+    #[test]
+    fn extracts_last_assistant_text() {
+        let jsonl = concat!(
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"go"}]}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"first"}]}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"final answer"}]}}"#,
+            "\n",
+        );
+        assert_eq!(
+            last_assistant_text_from_transcript(jsonl).as_deref(),
+            Some("final answer")
+        );
+    }
+
+    #[test]
+    fn extracts_across_tool_use_blocks() {
+        // Last assistant turn mixes a text block and a tool_use block; only the
+        // text must surface.
+        let jsonl = concat!(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"standing by"},{"type":"tool_use","name":"Bash","input":{}}]}}"#,
+            "\n",
+        );
+        let text = last_assistant_text_from_transcript(jsonl).expect("has assistant text");
+        assert_eq!(text, "standing by");
+        assert_eq!(detect_idle_parking(&text), Some("standing by"));
+    }
+
+    #[test]
+    fn tolerates_truncated_and_blank_lines() {
+        // A tail-read transcript can start with a truncated (invalid-JSON) line
+        // and contain blank lines; both must be skipped without error.
+        let jsonl = concat!(
+            r#"pe":"assistant","message":{"content":[{"type":"text","text":"truncated"}"#,
+            "\n",
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"monitoring the checks"}]}}"#,
+            "\n",
+            "   \n",
+        );
+        assert_eq!(
+            detect_idle_parking_in_transcript(jsonl),
+            Some("monitoring the checks")
+        );
+    }
+
+    #[test]
+    fn returns_none_without_assistant() {
+        let jsonl = concat!(
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"waiting for the notification"}]}}"#,
+            "\n",
+            r#"{"type":"system","message":{"content":"standing by"}}"#,
+            "\n",
+        );
+        // No assistant turn → nothing to detect, even though user/system text
+        // contains parking words (we must never flag the user's own words).
+        assert_eq!(last_assistant_text_from_transcript(jsonl), None);
+        assert_eq!(detect_idle_parking_in_transcript(jsonl), None);
+    }
+
+    #[test]
+    fn detects_parking_from_transcript() {
+        let jsonl = concat!(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"I'll report back once green."}]}}"#,
+            "\n",
+        );
+        assert_eq!(
+            detect_idle_parking_in_transcript(jsonl),
+            Some("report back once")
+        );
+    }
+
+    #[test]
+    fn clean_transcript_yields_none() {
+        let jsonl = concat!(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"All checks passed. Merged."}]}}"#,
+            "\n",
+        );
+        assert_eq!(detect_idle_parking_in_transcript(jsonl), None);
+    }
+
+    #[test]
+    fn bare_string_content_is_supported() {
+        let jsonl = r#"{"type":"assistant","message":{"content":"standing by for CI"}}"#;
+        assert_eq!(
+            last_assistant_text_from_transcript(jsonl).as_deref(),
+            Some("standing by for CI")
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -43,6 +43,7 @@ pub mod gh_identity;
 pub mod git_identity;
 pub mod home_trust_seed;
 pub mod hook;
+pub mod idle_parking;
 pub mod instruction_overrides;
 pub mod instruction_pipeline;
 pub mod ipc;

--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -99,7 +99,7 @@ fn resolve_stable_hook_exe(exe_override: Option<&Path>) -> Option<PathBuf> {
         .filter(|p| p.is_absolute())
 }
 
-/// Build the MPM lifecycle hook additions JSON block (five events).
+/// Build the MPM lifecycle hook additions JSON block (six events).
 ///
 /// Why: every call site — the managed global config writer AND `tm install` — must
 /// use the exact same shape so [`trusty_common::claude_config::merge_hook_entries`]
@@ -113,10 +113,13 @@ fn resolve_stable_hook_exe(exe_override: Option<&Path>) -> Option<PathBuf> {
 /// The `merge_hook_entries` dedup logic preserves any existing `SessionStart` entry
 /// (e.g. `trusty-memory inbox-check` from the project-level config) — adding the
 /// `trusty-mpm hook` entry alongside it does NOT clobber the memory hook.
-/// What: returns a JSON object with five `hooks` arrays:
-/// `PreToolUse`, `PostToolUse` (async), `Stop`, `SessionStart`, `SessionEnd`.
+/// What: returns a JSON object with six `hooks` arrays:
+/// `PreToolUse`, `PostToolUse` (async), `Stop`, `SubagentStop`, `SessionStart`,
+/// `SessionEnd`. `SubagentStop` (#2610) fires when a delegated Task-tool
+/// subagent ends its turn, letting the hook handler flag an idle-parking final
+/// message (see `commands::misc::hook` / `core::idle_parking`).
 /// `PostToolUse` is marked `async: true` so Claude Code does not block waiting for
-/// the daemon to ingest tool results; the other four use short synchronous timeouts.
+/// the daemon to ingest tool results; the other five use short synchronous timeouts.
 /// `exe_override` pins the binary path for the hook command; pass `None` to resolve
 /// via `mpm_hook_command(None)`.
 /// Test: `test_mpm_hook_additions_has_five_events`,
@@ -143,6 +146,14 @@ pub fn mpm_hook_additions_with_exe(exe_override: Option<&Path>) -> serde_json::V
                 }]
             }],
             "Stop": [{
+                "matcher": "*",
+                "hooks": [{
+                    "type": "command",
+                    "command": cmd,
+                    "timeout": 5
+                }]
+            }],
+            "SubagentStop": [{
                 "matcher": "*",
                 "hooks": [{
                     "type": "command",

--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -122,7 +122,7 @@ fn resolve_stable_hook_exe(exe_override: Option<&Path>) -> Option<PathBuf> {
 /// the daemon to ingest tool results; the other five use short synchronous timeouts.
 /// `exe_override` pins the binary path for the hook command; pass `None` to resolve
 /// via `mpm_hook_command(None)`.
-/// Test: `test_mpm_hook_additions_has_five_events`,
+/// Test: `test_mpm_hook_additions_has_six_events`,
 /// covered by `test_ensure_managed_hooks_writes_triad`.
 pub fn mpm_hook_additions_with_exe(exe_override: Option<&Path>) -> serde_json::Value {
     let cmd = mpm_hook_command(exe_override);
@@ -186,7 +186,7 @@ pub fn mpm_hook_additions_with_exe(exe_override: Option<&Path>) -> serde_json::V
 /// Why: convenience wrapper that calls `mpm_hook_additions_with_exe(None)` so
 /// existing call sites that do not need to pin the exe path stay concise.
 /// What: delegates to [`mpm_hook_additions_with_exe`] with `None`.
-/// Test: covered by `test_mpm_hook_additions_has_five_events`.
+/// Test: covered by `test_mpm_hook_additions_has_six_events`.
 pub fn mpm_hook_additions() -> serde_json::Value {
     mpm_hook_additions_with_exe(None)
 }

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -68,14 +68,20 @@ fn test_hook_command_rejects_ephemeral_exe_override() {
 }
 
 #[test]
-fn test_mpm_hook_additions_has_five_events() {
+fn test_mpm_hook_additions_has_six_events() {
     // #1744: SessionStart/SessionEnd must be present so the daemon receives
     // them for claude_session_id capture and immediate-Stopped marking.
+    // #2610: SubagentStop must be present so the hook handler sees a delegated
+    // subagent's turn-end and can flag an idle-parking final message.
     let v = mpm_hook_additions();
     let hooks = v.get("hooks").expect("missing 'hooks' key");
     assert!(hooks.get("PreToolUse").is_some(), "missing PreToolUse");
     assert!(hooks.get("PostToolUse").is_some(), "missing PostToolUse");
     assert!(hooks.get("Stop").is_some(), "missing Stop");
+    assert!(
+        hooks.get("SubagentStop").is_some(),
+        "missing SubagentStop (#2610)"
+    );
     assert!(
         hooks.get("SessionStart").is_some(),
         "missing SessionStart (#1744)"
@@ -97,6 +103,7 @@ fn test_mpm_hook_additions_with_exe_embeds_absolute_path() {
         "PreToolUse",
         "PostToolUse",
         "Stop",
+        "SubagentStop",
         "SessionStart",
         "SessionEnd",
     ] {
@@ -513,6 +520,7 @@ fn test_write_project_hooks_collapses_stale_hash_and_mvp_entries() {
         "PreToolUse",
         "PostToolUse",
         "Stop",
+        "SubagentStop",
         "SessionStart",
         "SessionEnd",
     ] {
@@ -611,7 +619,13 @@ fn test_write_project_hooks_replaces_stale_exe_path_group() {
     );
 
     // Every other event started empty, so exactly one (MPM) group must survive.
-    for event in &["PostToolUse", "Stop", "SessionStart", "SessionEnd"] {
+    for event in &[
+        "PostToolUse",
+        "Stop",
+        "SubagentStop",
+        "SessionStart",
+        "SessionEnd",
+    ] {
         let arr = hooks[*event]
             .as_array()
             .unwrap_or_else(|| panic!("event {event} must be present after two writes"));

--- a/crates/trusty-mpm/tests/tm_hook_idle_parking.rs
+++ b/crates/trusty-mpm/tests/tm_hook_idle_parking.rs
@@ -1,0 +1,126 @@
+//! Integration test for `tm hook` idle-parking detection (issue #2610).
+//!
+//! Why: `core::idle_parking`'s unit tests cover the pure detection logic, but
+//! none exercises the actual Stop/SubagentStop → read-transcript → warn path
+//! end to end through the real binary. This is the mechanical back-stop that
+//! flags a delegated agent that ended its turn to "wait" for a self-spawned
+//! monitor that can never re-wake it; it must fire on real turn-end payloads and
+//! stay silent otherwise. This file closes that gap.
+//! What: runs the built `tm` binary as `tm --url <unreachable> hook` with a
+//! `SubagentStop` (or other) stdin payload that names a temp transcript file,
+//! then asserts on the process stderr (the loud IDLE-PARKING WARNING) and a
+//! clean `exit 0` (fail-open — the best-effort daemon POST to the unreachable
+//! URL must never fail the hook). The `session_id`/`transcript_path` field names
+//! match the live Claude Code hooks reference
+//! (<https://code.claude.com/docs/en/hooks>).
+//! Test: `cargo test -p trusty-mpm --test tm_hook_idle_parking`.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Run `tm hook` with the given stdin JSON, returning `(exit_ok, stderr)`.
+fn run_hook(stdin_json: &str) -> (bool, String) {
+    let bin = env!("CARGO_BIN_EXE_tm");
+    let mut child = Command::new(bin)
+        .args(["--url", "http://127.0.0.1:1", "hook"])
+        .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
+        .env_remove("CLAUDE_MPM_SUB_AGENT")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn `tm hook`");
+
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(stdin_json.as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for tm hook");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Write a single-line JSONL transcript with one assistant message and return
+/// the temp file (kept alive by the caller so the path stays valid).
+fn transcript_with_assistant(text: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().expect("create temp transcript");
+    let line = serde_json::json!({
+        "type": "assistant",
+        "message": { "content": [{ "type": "text", "text": text }] }
+    });
+    writeln!(f, "{line}").expect("write transcript line");
+    f.flush().expect("flush transcript");
+    f
+}
+
+fn payload(event: &str, transcript_path: &std::path::Path) -> String {
+    serde_json::json!({
+        "hook_event_name": event,
+        "session_id": "sess-2610",
+        "transcript_path": transcript_path.to_string_lossy(),
+    })
+    .to_string()
+}
+
+#[test]
+fn hook_flags_idle_parking_final_message_on_subagent_stop() {
+    let tf = transcript_with_assistant(
+        "I've started a background polling monitor for the checks and will report back once green.",
+    );
+    let (ok, stderr) = run_hook(&payload("SubagentStop", tf.path()));
+
+    assert!(ok, "hook must exit 0 (fail-open), stderr={stderr}");
+    assert!(
+        stderr.contains("IDLE-PARKING WARNING (#2610)"),
+        "expected idle-parking warning on stderr, got: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("session=sess-2610"),
+        "warning must identify the session, got: {stderr:?}"
+    );
+}
+
+#[test]
+fn hook_flags_idle_parking_on_main_stop() {
+    let tf = transcript_with_assistant("Standing by for the CI run to complete.");
+    let (ok, stderr) = run_hook(&payload("Stop", tf.path()));
+
+    assert!(ok, "hook must exit 0 (fail-open), stderr={stderr}");
+    assert!(
+        stderr.contains("IDLE-PARKING WARNING (#2610)"),
+        "expected idle-parking warning on stderr for Stop, got: {stderr:?}"
+    );
+}
+
+#[test]
+fn hook_stays_silent_for_clean_final_message() {
+    let tf = transcript_with_assistant(
+        "I ran `gh pr checks 2606 --watch --fail-fast` in the foreground; all checks passed. Done.",
+    );
+    let (ok, stderr) = run_hook(&payload("SubagentStop", tf.path()));
+
+    assert!(ok, "hook must exit 0, stderr={stderr}");
+    assert!(
+        !stderr.contains("IDLE-PARKING WARNING"),
+        "clean final message must NOT be flagged, got: {stderr:?}"
+    );
+}
+
+#[test]
+fn hook_does_not_scan_non_turn_end_events() {
+    // A PreToolUse/PostToolUse event must never trigger the transcript scan,
+    // even if the transcript happens to contain parking language.
+    let tf = transcript_with_assistant("standing by for the monitor to report back");
+    let (ok, stderr) = run_hook(&payload("PostToolUse", tf.path()));
+
+    assert!(ok, "hook must exit 0, stderr={stderr}");
+    assert!(
+        !stderr.contains("IDLE-PARKING WARNING"),
+        "non-turn-end event must not scan for parking, got: {stderr:?}"
+    );
+}

--- a/crates/trusty-mpm/tests/tm_hook_idle_parking.rs
+++ b/crates/trusty-mpm/tests/tm_hook_idle_parking.rs
@@ -124,3 +124,79 @@ fn hook_does_not_scan_non_turn_end_events() {
         "non-turn-end event must not scan for parking, got: {stderr:?}"
     );
 }
+
+/// Code-critic finding (PR #2620): `read_transcript_tail`'s caller wraps the
+/// whole read in `tokio::time::timeout`, but that only bounds the `.await` —
+/// the underlying blocking `open()` syscall (run on a `spawn_blocking` worker)
+/// still runs to completion. `open()` on a FIFO with no writer blocks
+/// indefinitely at the kernel level, which would leak a stuck blocking-pool
+/// thread even though the hook process itself still exits promptly. The fix
+/// `stat()`s the path first (which never blocks on a FIFO) and refuses
+/// anything that is not a regular file before ever calling `open()`.
+///
+/// This proves the FIFO case end to end: `tm hook` must return promptly (well
+/// under the test's generous bound) with a clean `exit 0` and no idle-parking
+/// warning — not hang waiting on the FIFO to be opened for writing (which
+/// never happens, since nothing else opens it).
+///
+/// `mkfifo` is a POSIX-only primitive, hence `#[cfg(unix)]`; the equivalent
+/// Windows named-pipe API has different open semantics and is out of scope —
+/// this test skips cleanly (does not compile / run at all) on non-unix.
+#[cfg(unix)]
+#[test]
+fn rejects_fifo_without_blocking() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let fifo_path = dir.path().join("transcript.fifo");
+
+    let mkfifo_status = Command::new("mkfifo")
+        .arg(&fifo_path)
+        .status()
+        .expect("failed to spawn mkfifo");
+    assert!(mkfifo_status.success(), "mkfifo must succeed");
+
+    let bin = env!("CARGO_BIN_EXE_tm");
+    let mut child = Command::new(bin)
+        .args(["--url", "http://127.0.0.1:1", "hook"])
+        .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
+        .env_remove("CLAUDE_MPM_SUB_AGENT")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn `tm hook`");
+
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(payload("SubagentStop", &fifo_path).as_bytes())
+        .expect("write stdin");
+
+    // Bounded poll instead of `wait_with_output()`: if the `stat`-first guard
+    // regresses and `open()` is reached, this must fail LOUDLY (assertion) —
+    // it must never hang the test suite waiting on a FIFO nothing will write to.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("try_wait") {
+            break status;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "tm hook did not exit within the bound — the stat-before-open FIFO \
+             guard has regressed and open() is blocking on the FIFO"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    };
+
+    let output = child.wait_with_output().expect("collect output after exit");
+    assert!(
+        status.success(),
+        "tm hook must exit 0 even for an unreadable transcript path (fail-open), \
+         status={status:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("IDLE-PARKING WARNING"),
+        "a FIFO transcript path must never be scanned, got: {stderr:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Delegated merge/release/engineer agents kept **ending their turn to "wait"** on a self-spawned background monitor/watcher/notification that can never re-wake a stopped agent — stranding the whole delegation chain until a human manually resumed them. The #2501 remediation (PR #2503, the BASE-AGENT *Foreground Execution* section) reduced but did **not** eliminate this: 2026-07-14 (session 2eb72dca) saw **6 fresh incidents** even where the dispatch prompt explicitly forbade parking. Prompt-level prohibitions alone don't hold, so this hardens the fix at the asset/instruction layer **and** adds a mechanical back-stop.

## Layers

### 1. BASE-AGENT hard rule (`assets/agents/BASE-AGENT.md`)
Promotes *Foreground Execution* into **"NEVER End Your Turn To Wait"**:
- 🔴 Nothing re-invokes a stopped agent; background monitors/watchers/pollers are **FORBIDDEN** as a wake mechanism.
- Ending a turn with *"waiting for… / monitoring… / standing by… / will report when…"* is a **PROTOCOL VIOLATION**, not a status update.
- Canonical **CI-wait** pattern (`gh pr checks <pr> --watch --fail-fast`, blocking foreground, re-issue on the 10-min tool-timeout) and canonical **long-command** pattern (foreground with long timeout; if backgrounded, poll to completion in the same turn).

### 2. Persona reinforcement
- `version-control.md` — full **"CI Waits — Block In The Foreground, NEVER Park"** section (worst offender).
- `local-ops.md` — full **"Long Waits — Block In The Foreground, NEVER Park"** section (release-agent offender).
- `BASE-ENGINEER.md` — short pointer for the quality-gate-run case (inherited by every engineer persona).

### 3. Mechanical enforcement (detection + warning)
- New pure, unit-tested `core::idle_parking`: `detect_idle_parking` (curated high-signal parking-phrase scan) + `last_assistant_text_from_transcript` (extracts the last assistant turn from a Claude Code JSONL transcript, tolerant of tail-truncation) + `detect_idle_parking_in_transcript`.
- Registers the **`SubagentStop`** hook (so a delegated Task subagent's turn-end is seen) and wires the `Stop`/`SubagentStop` handler in `commands::misc::hook` to tail-read the transcript (bounded, time-limited, **fully fail-open**), and on a parking final message:
  - emit a loud, greppable **`IDLE-PARKING WARNING (#2610)`** to stderr, and
  - enrich the daemon hook payload with `idle_parking` / `idle_parking_phrase` so the dashboard / errors feed can surface it.

### 4. Follow-up
Full daemon-side dashboard surfacing + **auto-nudge** (re-injecting a continue prompt into the stalled pane) is larger and filed as a follow-up issue — this PR ships detection + warning per the proportionate/testable bar.

## Verification (raw)
- `cargo build --workspace` → Finished
- `cargo test -p trusty-mpm` → `test result: ok. 3091 passed; 0 failed` (+ integration bins incl. new `tm_hook_idle_parking`: 4 passed; `idle_parking` unit: 12 passed; `hooks::tests`: 16 passed; composition regression: ok)
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0 (only pre-existing `tga` MSRV-config warning, untouched crate)
- `cargo fmt --check` → clean
- `bash scripts/check_line_cap.sh` → 0 violations

References #2501 / PR #2503.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools