### PR TITLE
fix(trusty-code): guide generated DB-backed services to init schema before serving

### DIFF
--- a/crates/trusty-code/src/prompt/preamble.rs
+++ b/crates/trusty-code/src/prompt/preamble.rs
@@ -75,6 +75,18 @@ accept plain data as input and return plain data as output.
 - Keep I/O (subprocess invocation, network calls, filesystem access) in thin \
 wrapper functions, separate from the core logic they feed.
 
+## Persistent-store initialization
+
+- When the service you build is backed by a database or other persistent store, \
+initialize its schema — create the tables, or run the migrations — at \
+application startup, BEFORE the service handles its first request. An app that \
+declares data models but never creates their tables will fail the first read or \
+write with a missing-table error.
+- Perform this initialization so it also runs under an in-process test client \
+(for example a startup hook the client triggers, or an explicit init call the \
+app makes when it is constructed), so the very first request in a test cannot \
+reach an uninitialized store.
+
 ## Finish convention
 
 - You signal that the task is complete by producing an assistant turn that \

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -245,6 +245,36 @@ fn base_preamble_nudges_testable_design() {
     );
 }
 
+/// `BASE_PREAMBLE` instructs initializing a persistent store's schema at
+/// startup, before serving, and in a way that also runs under a test client
+/// (#2622 bake-off L3 diagnosis: generated DB-backed services intermittently
+/// omitted `create_all`/migrations, so the first CRUD request hit a missing
+/// table).
+///
+/// Why: This is a general product-quality nudge for any service backed by a
+/// database or persistent store, not a benchmark- or provider-specific patch —
+/// it must apply to every agent's assembled prompt, so it belongs in the
+/// model-agnostic BASE preamble alongside the neighbouring design nudges.
+/// What: Asserts the preamble names both halves of the principle: initialize
+/// the schema before serving the first request, and do it so it also runs
+/// under a test client.
+/// Test: this test.
+#[test]
+fn base_preamble_requires_persistent_store_init() {
+    assert!(
+        BASE_PREAMBLE.contains("persistent store"),
+        "must address services backed by a database or other persistent store"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("BEFORE the service handles its first request"),
+        "must instruct initializing the schema before the first request"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("in-process test client"),
+        "must ensure initialization also runs under a test client"
+    );
+}
+
 /// `BASE_PREAMBLE` carries no host- or model-specific tokens (spec §2a/§3).
 ///
 /// Why: Any model name, provider name, or host path in the BASE preamble would
@@ -282,7 +312,7 @@ fn base_preamble_version_is_semver_shaped() {
 /// Expected FNV-1a-style fold of [`BASE_PREAMBLE`]'s bytes, folded with its
 /// byte length. Regenerate this whenever the preamble legitimately changes
 /// (see [`base_preamble_hash_tripwire`] for the contributor instructions).
-const EXPECTED_PREAMBLE_HASH: u64 = 0xcdfb_41b6_3f06_2396;
+const EXPECTED_PREAMBLE_HASH: u64 = 0x83d8_0652_3fc6_0053;
 
 /// Test-time guard coupling `BASE_PREAMBLE` *content* to its version constant.
 ///

--- a/crates/trusty-code/src/prompt/version.rs
+++ b/crates/trusty-code/src/prompt/version.rs
@@ -18,4 +18,4 @@
 /// `BASE_PREAMBLE` text so reports referencing an old run remain interpretable.
 /// Test: `prompt::tests::base_preamble_version_is_semver_shaped` asserts the
 /// three-component shape.
-pub const BASE_PREAMBLE_VERSION: &str = "1.2.0";
+pub const BASE_PREAMBLE_VERSION: &str = "1.3.0";


### PR DESCRIPTION
## Summary

Generated DB-backed web services intermittently omitted schema creation /
migration before serving, so the first CRUD request against a fresh
generated service failed with a missing-table error (e.g. "no such table").
This was a model-output gap: the preamble that steers generated code gave no
explicit instruction to initialize the persistent store at startup.

## Fix

- Add a provider- and challenge-agnostic **"Persistent-store initialization"**
  section to `BASE_PREAMBLE` (`crates/trusty-code/src/prompt/preamble.rs`)
  instructing the engineer to create tables / run migrations at startup,
  before the first request is served — including under an in-process test
  client, not just a live server boot.
- Bump `BASE_PREAMBLE_VERSION` `1.2.0` -> `1.3.0`
  (`crates/trusty-code/src/prompt/version.rs`).
- Refresh `EXPECTED_PREAMBLE_HASH` and add
  `base_preamble_requires_persistent_store_init`, a preamble-content guard
  test asserting the new section is present
  (`crates/trusty-code/src/prompt/tests.rs`).

The guidance is conditioned on DB-backed tasks and does not assume any
specific database, ORM, or challenge type.

## Review status

- code-critic: **APPROVE**
- Gates green locally: 868 tests passed, clippy clean, fmt clean, line-cap clean.

Closes #2622

## Test plan

- [x] `cargo test -p trusty-code` — 868 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean
- [x] code-critic adversarial review — APPROVE
- [ ] CI green on this PR

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools