### PR TITLE
fix(trusty-code): require eager construction-time DB-schema init, not just a startup hook

### DIFF
--- a/crates/trusty-code/src/prompt/preamble.rs
+++ b/crates/trusty-code/src/prompt/preamble.rs
@@ -78,14 +78,18 @@ wrapper functions, separate from the core logic they feed.
 ## Persistent-store initialization
 
 - When the service you build is backed by a database or other persistent store, \
-initialize its schema — create the tables, or run the migrations — at \
-application startup, BEFORE the service handles its first request. An app that \
-declares data models but never creates their tables will fail the first read or \
-write with a missing-table error.
-- Perform this initialization so it also runs under an in-process test client \
-(for example a startup hook the client triggers, or an explicit init call the \
-app makes when it is constructed), so the very first request in a test cannot \
-reach an uninitialized store.
+you MUST create its schema — create the tables, or run the migrations — eagerly \
+as part of constructing the application object, so it has already happened \
+BEFORE the service handles its first request. Eager initialization when the \
+application is constructed is the required, primary mechanism, not an optional \
+alternative. An app that declares data models but never creates their tables \
+will fail the first read or write with a missing-table error.
+- A startup or lifecycle event hook alone is NOT sufficient: an in-process test \
+client may construct the application WITHOUT triggering its startup or lifecycle \
+event hooks, so a store initialized only inside such a hook stays uninitialized \
+and the very first request fails with a missing-table error. You may add a hook \
+in addition, but it must never be the sole mechanism — the eager \
+construction-time initialization must always be present.
 
 ## Finish convention
 

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -245,19 +245,25 @@ fn base_preamble_nudges_testable_design() {
     );
 }
 
-/// `BASE_PREAMBLE` instructs initializing a persistent store's schema at
-/// startup, before serving, and in a way that also runs under a test client
-/// (#2622 bake-off L3 diagnosis: generated DB-backed services intermittently
-/// omitted `create_all`/migrations, so the first CRUD request hit a missing
-/// table).
+/// `BASE_PREAMBLE` makes eager schema initialization at application
+/// construction the PRIMARY, required mechanism, and explicitly warns that a
+/// startup/lifecycle hook alone is insufficient because an in-process test
+/// client may construct the app without firing those hooks (#2622 bake-off L3
+/// diagnosis, strengthened: the first 1.3.0 fix offered eager init only as an
+/// "OR" alternative, so a generated service picked the hook-only branch and the
+/// first CRUD request still hit a missing table under the bare test client).
 ///
 /// Why: This is a general product-quality nudge for any service backed by a
 /// database or persistent store, not a benchmark- or provider-specific patch —
 /// it must apply to every agent's assembled prompt, so it belongs in the
-/// model-agnostic BASE preamble alongside the neighbouring design nudges.
-/// What: Asserts the preamble names both halves of the principle: initialize
-/// the schema before serving the first request, and do it so it also runs
-/// under a test client.
+/// model-agnostic BASE preamble alongside the neighbouring design nudges. The
+/// eager-at-construction directive must be unambiguously primary so the model
+/// cannot satisfy it with a fragile hook-only initialization.
+/// What: Asserts the preamble (a) requires creating the schema as part of
+/// constructing the application object before the first request, names that the
+/// required/primary mechanism, and (b) warns that a startup/lifecycle hook alone
+/// is not sufficient because an in-process test client may construct the app
+/// without triggering those hooks.
 /// Test: this test.
 #[test]
 fn base_preamble_requires_persistent_store_init() {
@@ -269,9 +275,26 @@ fn base_preamble_requires_persistent_store_init() {
         BASE_PREAMBLE.contains("BEFORE the service handles its first request"),
         "must instruct initializing the schema before the first request"
     );
+    // (a) Eager init at application construction is the PRIMARY, required
+    // mechanism — not merely one alternative among several.
     assert!(
-        BASE_PREAMBLE.contains("in-process test client"),
-        "must ensure initialization also runs under a test client"
+        BASE_PREAMBLE.contains("as part of constructing the application object"),
+        "must require creating the schema as part of constructing the application object"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("required, primary mechanism"),
+        "must name eager construction-time initialization as the required, primary mechanism"
+    );
+    // (b) A startup/lifecycle hook alone is insufficient because an in-process
+    // test client may construct the app without firing those hooks.
+    assert!(
+        BASE_PREAMBLE.contains("lifecycle event hook alone is NOT sufficient"),
+        "must warn that a startup or lifecycle hook alone is not sufficient"
+    );
+    assert!(
+        BASE_PREAMBLE
+            .contains("in-process test client may construct the application WITHOUT triggering"),
+        "must warn that an in-process test client may construct the app without firing its hooks"
     );
 }
 
@@ -312,7 +335,7 @@ fn base_preamble_version_is_semver_shaped() {
 /// Expected FNV-1a-style fold of [`BASE_PREAMBLE`]'s bytes, folded with its
 /// byte length. Regenerate this whenever the preamble legitimately changes
 /// (see [`base_preamble_hash_tripwire`] for the contributor instructions).
-const EXPECTED_PREAMBLE_HASH: u64 = 0x83d8_0652_3fc6_0053;
+const EXPECTED_PREAMBLE_HASH: u64 = 0xb631_9159_c613_0d4b;
 
 /// Test-time guard coupling `BASE_PREAMBLE` *content* to its version constant.
 ///

--- a/crates/trusty-code/src/prompt/version.rs
+++ b/crates/trusty-code/src/prompt/version.rs
@@ -18,4 +18,4 @@
 /// `BASE_PREAMBLE` text so reports referencing an old run remain interpretable.
 /// Test: `prompt::tests::base_preamble_version_is_semver_shaped` asserts the
 /// three-component shape.
-pub const BASE_PREAMBLE_VERSION: &str = "1.3.0";
+pub const BASE_PREAMBLE_VERSION: &str = "1.4.0";


### PR DESCRIPTION
## Summary

The first #2622 fix (689a11ee, BASE_PREAMBLE 1.3.0) offered eager construction-time schema init only as an alternative to a startup/lifecycle hook. In an L3 bake-off run, a generated DB-backed service initialized its schema only inside a startup hook, and the bake-off test fixture constructs the app via a bare in-process test client that never fires that hook — so the first CRUD request still hit `no such table` (3/7 failures).

This PR rewrites the BASE_PREAMBLE persistent-store block to make eager initialization at application construction the required, primary mechanism, and explicitly warns that a startup/lifecycle hook alone is insufficient because an in-process test client may construct the app without triggering it. A hook may still be added in addition, but never as the sole mechanism.

- `crates/trusty-code/src/prompt/preamble.rs` — strengthened persistent-store init guidance (provider/challenge-agnostic, applies to every agent's assembled prompt)
- `crates/trusty-code/src/prompt/version.rs` — `BASE_PREAMBLE_VERSION` 1.3.0 -> 1.4.0
- `crates/trusty-code/src/prompt/tests.rs` — refreshed hash tripwire + expanded guard test asserting both the primary eager-init requirement and the hook-insufficiency warning

## Verification

- `cargo test -p trusty-code` — 872 passed (868 lib + integration suites), 0 failed
- `cargo fmt --check -p trusty-code` — clean
- `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean
- `bash scripts/check_line_cap.sh` — 10 allowlisted, 0 violations
- code-critic review — APPROVE

Closes #2622

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools