### PR TITLE
feat(trusty-gworkspace): 4 correctness/parity fixes (Drive binary+upload, Tasks get/search, Gmail reply/attachments)

### DIFF
--- a/crates/trusty-gworkspace/README.md
+++ b/crates/trusty-gworkspace/README.md
@@ -132,6 +132,14 @@ adding a new tool means: write the function, add a `match` arm in
 - **Errors as data.** Tool failures return `{"error": "..."}` inside the
   MCP `content` envelope rather than JSON-RPC framing errors, so the
   model gets actionable feedback.
+- **Local filesystem access is intentionally broad.** `compose_email`
+  attachments (`path`/`local_path`), `manage_drive_file`'s `upload` action
+  (`local_path`), and `get_drive_file_content`'s `save_path` all read or
+  write arbitrary local paths the calling agent supplies. There is no path
+  confinement — an LLM-driven agent processing untrusted content (e.g. a
+  malicious email body instructing it to attach `~/.ssh/id_rsa`) can read or
+  exfiltrate any file the process's user can access. Treat this server the
+  same as any other tool granting a model direct filesystem read/write.
 
 ## Testing
 

--- a/crates/trusty-gworkspace/src/api/client.rs
+++ b/crates/trusty-gworkspace/src/api/client.rs
@@ -15,6 +15,59 @@ use tracing::{debug, warn};
 
 use crate::api::auth::{OAuthManager, StoredToken, TokenStorage};
 
+/// Request body variants understood by [`BaseClient::send_with_retry`].
+///
+/// Why: The client must speak three wire encodings — no body (GET/DELETE),
+/// JSON (`application/json`), and arbitrary raw bytes with a caller-chosen
+/// `Content-Type` (Drive multipart upload, Gmail already-encoded payloads).
+/// Modelling them as one enum lets the 401-refresh-retry logic live in a
+/// single place instead of being duplicated per encoding.
+/// What: Borrowed so `send_with_retry` can rebuild the request cheaply for
+/// the one retry attempt.
+/// Test: Exercised transitively by every `get`/`post`/`post_raw`/`get_bytes`.
+enum ReqBody<'a> {
+    None,
+    Json(&'a Value),
+    Raw {
+        content_type: &'a str,
+        bytes: &'a [u8],
+    },
+}
+
+impl ReqBody<'_> {
+    /// Attach this body to a request builder.
+    ///
+    /// Why: Both the initial send and the post-refresh retry need identical
+    /// body application; centralising avoids drift between the two.
+    /// What: Sets JSON body, or raw bytes with an explicit `Content-Type`.
+    /// Test: Covered transitively by the raw-body service tests.
+    fn apply(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match self {
+            ReqBody::None => req,
+            ReqBody::Json(v) => req.json(v),
+            ReqBody::Raw {
+                content_type,
+                bytes,
+            } => req
+                .header(reqwest::header::CONTENT_TYPE, *content_type)
+                .body(bytes.to_vec()),
+        }
+    }
+}
+
+/// A non-JSON HTTP response captured as raw bytes plus its `Content-Type`.
+///
+/// Why: Binary Drive downloads (`alt=media` on images/PDFs/zips) must not be
+/// force-decoded as UTF-8; callers need the bytes and the MIME to decide.
+/// What: Holds the status, optional `Content-Type` header, and the body bytes.
+/// Test: Consumed by `drive::files::get_drive_file_content`; branching logic
+/// is unit-tested via `is_textual_mime`.
+pub struct RawResponse {
+    pub status: reqwest::StatusCode,
+    pub content_type: Option<String>,
+    pub bytes: Vec<u8>,
+}
+
 /// Authenticated Google API client.
 ///
 /// Why: One handle per process; `Arc<TokenStorage>` because tools may run
@@ -105,14 +158,11 @@ impl BaseClient {
         &self,
         method: reqwest::Method,
         url: &str,
-        body: Option<&Value>,
+        body: ReqBody<'_>,
         account: Option<&str>,
     ) -> Result<reqwest::Response> {
         let token = self.get_access_token(account).await?;
-        let mut req = self.http.request(method.clone(), url).bearer_auth(&token);
-        if let Some(b) = body {
-            req = req.json(b);
-        }
+        let req = body.apply(self.http.request(method.clone(), url).bearer_auth(&token));
         debug!(method = %method, url = %url, "google api request");
         let resp = req
             .send()
@@ -122,13 +172,11 @@ impl BaseClient {
             warn!(url = %url, "401 received — forcing refresh and retrying once");
             if let (Some(oauth), Ok((profile, _))) = (&self.oauth, self.resolve_stored(account)) {
                 let new = oauth.refresh(&self.storage, &profile).await?;
-                let mut retry = self
-                    .http
-                    .request(method.clone(), url)
-                    .bearer_auth(new.access_token);
-                if let Some(b) = body {
-                    retry = retry.json(b);
-                }
+                let retry = body.apply(
+                    self.http
+                        .request(method.clone(), url)
+                        .bearer_auth(new.access_token),
+                );
                 return retry.send().await.context("retry after refresh");
             }
         }
@@ -157,35 +205,90 @@ impl BaseClient {
 
     pub async fn get(&self, url: &str, account: Option<&str>) -> Result<Value> {
         let resp = self
-            .send_with_retry(reqwest::Method::GET, url, None, account)
+            .send_with_retry(reqwest::Method::GET, url, ReqBody::None, account)
             .await?;
         Self::json_or_error(resp).await
     }
 
+    /// GET a URL and return the raw bytes plus `Content-Type` (no JSON parse).
+    ///
+    /// Why: Binary Drive downloads (`alt=media` on non-text files) and Drive
+    /// attachments must be fetched as bytes; parsing as UTF-8 text corrupts
+    /// images, PDFs, and archives.
+    /// What: Issues the request through the shared 401-refresh path, then reads
+    /// the body as bytes and captures the `Content-Type` header.
+    /// Test: Consumed by `drive::files::get_drive_file_content`.
+    pub async fn get_bytes(&self, url: &str, account: Option<&str>) -> Result<RawResponse> {
+        let resp = self
+            .send_with_retry(reqwest::Method::GET, url, ReqBody::None, account)
+            .await?;
+        let status = resp.status();
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        let bytes = resp.bytes().await.context("read response bytes")?.to_vec();
+        Ok(RawResponse {
+            status,
+            content_type,
+            bytes,
+        })
+    }
+
     pub async fn post(&self, url: &str, body: Value, account: Option<&str>) -> Result<Value> {
         let resp = self
-            .send_with_retry(reqwest::Method::POST, url, Some(&body), account)
+            .send_with_retry(reqwest::Method::POST, url, ReqBody::Json(&body), account)
+            .await?;
+        Self::json_or_error(resp).await
+    }
+
+    /// POST a raw byte body with an explicit `Content-Type`.
+    ///
+    /// Why: Drive multipart upload (`multipart/related`) and other non-JSON
+    /// wire formats cannot go through the JSON helper.
+    /// What: Sends `bytes` verbatim under `content_type` through the shared
+    /// 401-refresh path, then parses the JSON response envelope.
+    /// Test: Consumed by `drive::files::manage_drive_file` (`upload`); body
+    /// shape is unit-tested via `build_multipart_related`.
+    pub async fn post_raw(
+        &self,
+        url: &str,
+        content_type: &str,
+        bytes: Vec<u8>,
+        account: Option<&str>,
+    ) -> Result<Value> {
+        let resp = self
+            .send_with_retry(
+                reqwest::Method::POST,
+                url,
+                ReqBody::Raw {
+                    content_type,
+                    bytes: &bytes,
+                },
+                account,
+            )
             .await?;
         Self::json_or_error(resp).await
     }
 
     pub async fn patch(&self, url: &str, body: Value, account: Option<&str>) -> Result<Value> {
         let resp = self
-            .send_with_retry(reqwest::Method::PATCH, url, Some(&body), account)
+            .send_with_retry(reqwest::Method::PATCH, url, ReqBody::Json(&body), account)
             .await?;
         Self::json_or_error(resp).await
     }
 
     pub async fn put(&self, url: &str, body: Value, account: Option<&str>) -> Result<Value> {
         let resp = self
-            .send_with_retry(reqwest::Method::PUT, url, Some(&body), account)
+            .send_with_retry(reqwest::Method::PUT, url, ReqBody::Json(&body), account)
             .await?;
         Self::json_or_error(resp).await
     }
 
     pub async fn delete(&self, url: &str, account: Option<&str>) -> Result<Value> {
         let resp = self
-            .send_with_retry(reqwest::Method::DELETE, url, None, account)
+            .send_with_retry(reqwest::Method::DELETE, url, ReqBody::None, account)
             .await?;
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();

--- a/crates/trusty-gworkspace/src/api/constants.rs
+++ b/crates/trusty-gworkspace/src/api/constants.rs
@@ -17,6 +17,8 @@ pub const GMAIL_API_BASE: &str = "https://gmail.googleapis.com/gmail/v1";
 pub const CALENDAR_API_BASE: &str = "https://www.googleapis.com/calendar/v3";
 /// Google Drive REST API v3 root.
 pub const DRIVE_API_BASE: &str = "https://www.googleapis.com/drive/v3";
+/// Google Drive **upload** endpoint root (multipart/simple/resumable uploads).
+pub const DRIVE_UPLOAD_BASE: &str = "https://www.googleapis.com/upload/drive/v3/files";
 /// Google Docs REST API v1 root.
 pub const DOCS_API_BASE: &str = "https://docs.googleapis.com/v1";
 /// Google Sheets REST API v4 root.

--- a/crates/trusty-gworkspace/src/api/services/drive/files.rs
+++ b/crates/trusty-gworkspace/src/api/services/drive/files.rs
@@ -11,8 +11,8 @@ use base64::engine::general_purpose::STANDARD;
 use serde_json::{Value, json};
 
 use crate::api::client::BaseClient;
-use crate::api::constants::DRIVE_API_BASE;
-use crate::api::services::{account_of, opt_str, require_str};
+use crate::api::constants::{DRIVE_API_BASE, DRIVE_UPLOAD_BASE};
+use crate::api::services::{account_of, guess_mime_from_path, opt_str, require_str};
 
 /// Why: Folder listing is the entry point for any Drive navigation tool.
 /// What: Queries `/files` filtered by parent id, returning name/mimeType/id for each child.
@@ -182,9 +182,12 @@ pub async fn list_shared_drives(client: &BaseClient, args: Value) -> Result<Valu
     client.get(&url, account).await
 }
 
-/// Why: File-level mutations (create folder, rename, trash) share one Drive API surface.
-/// What: Dispatches `create_folder|rename|trash|untrash|delete` to the Drive `/files` API.
-/// Test: Live API.
+/// Why: File-level mutations (create folder, rename, trash, upload) share one
+/// Drive API surface.
+/// What: Dispatches `create_folder|rename|trash|delete|copy|move|upload` to the
+/// Drive `/files` (and `/upload/.../files`) endpoints.
+/// Test: `upload` multipart-body shape is unit-tested via
+/// `build_multipart_related`; live 200 validation is deferred.
 pub async fn manage_drive_file(client: &BaseClient, args: Value) -> Result<Value> {
     let action = require_str(&args, "action")?;
     let account = account_of(&args);
@@ -235,8 +238,67 @@ pub async fn manage_drive_file(client: &BaseClient, args: Value) -> Result<Value
                 format!("{DRIVE_API_BASE}/files/{id}?addParents={parent}&supportsAllDrives=true");
             client.patch(&url, json!({}), account).await
         }
+        "upload" => {
+            let name = require_str(&args, "name")?;
+            let parent = opt_str(&args, "parent_id");
+            let mime_arg = opt_str(&args, "mime_type");
+
+            // Source bytes come from either a local file or inline content.
+            let (bytes, resolved_mime) = if let Some(path) = opt_str(&args, "local_path") {
+                let data =
+                    std::fs::read(path).with_context(|| format!("read upload source {path}"))?;
+                let mime = mime_arg
+                    .map(str::to_string)
+                    .unwrap_or_else(|| guess_mime_from_path(path));
+                (data, mime)
+            } else if let Some(content) = opt_str(&args, "content") {
+                let mime = mime_arg.unwrap_or("text/plain").to_string();
+                (content.as_bytes().to_vec(), mime)
+            } else {
+                return Err(anyhow!(
+                    "upload requires either 'local_path' or inline 'content'"
+                ));
+            };
+
+            let mut metadata = json!({ "name": name, "mimeType": resolved_mime });
+            if let Some(p) = parent {
+                metadata["parents"] = json!([p]);
+            }
+
+            let boundary = format!("gworkspace-{}", uuid::Uuid::new_v4().simple());
+            let body = build_multipart_related(&metadata, &resolved_mime, &bytes, &boundary)?;
+            let content_type = format!("multipart/related; boundary={boundary}");
+            let url = format!(
+                "{DRIVE_UPLOAD_BASE}?uploadType=multipart&supportsAllDrives=true&fields=id,name,mimeType,size,parents"
+            );
+            client.post_raw(&url, &content_type, body, account).await
+        }
         other => Err(anyhow!("unknown action for manage_drive_file: {other}")),
     }
+}
+
+/// Why: Drive's multipart upload endpoint expects a `multipart/related` body
+/// pairing a JSON metadata part with the raw media part; getting the CRLF
+/// framing wrong yields a 400.
+/// What: Serialises `metadata` as the first part and `content` (under `mime`)
+/// as the second, delimited by `boundary` per RFC 2387.
+/// Test: `multipart_body_has_metadata_and_media_parts` below.
+fn build_multipart_related(
+    metadata: &Value,
+    mime: &str,
+    content: &[u8],
+    boundary: &str,
+) -> Result<Vec<u8>> {
+    let meta_json = serde_json::to_vec(metadata).context("serialize upload metadata")?;
+    let mut body = Vec::with_capacity(meta_json.len() + content.len() + 256);
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(b"Content-Type: application/json; charset=UTF-8\r\n\r\n");
+    body.extend_from_slice(&meta_json);
+    body.extend_from_slice(format!("\r\n--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(format!("Content-Type: {mime}\r\n\r\n").as_bytes());
+    body.extend_from_slice(content);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    Ok(body)
 }
 
 pub(crate) fn encode(s: &str) -> String {
@@ -295,5 +357,24 @@ mod tests {
             .decode(v["content"].as_str().unwrap())
             .expect("valid base64");
         assert_eq!(decoded, bytes);
+    }
+
+    #[test]
+    fn multipart_body_has_metadata_and_media_parts() {
+        let metadata = json!({ "name": "hi.txt", "mimeType": "text/plain" });
+        let body =
+            build_multipart_related(&metadata, "text/plain", b"hello world", "BOUND").unwrap();
+        let text = String::from_utf8(body).expect("ascii-framed multipart");
+        // Two boundaries + closing delimiter.
+        assert_eq!(text.matches("--BOUND\r\n").count(), 2);
+        assert!(text.ends_with("--BOUND--\r\n"));
+        // JSON metadata part precedes the media part.
+        assert!(text.contains("Content-Type: application/json; charset=UTF-8\r\n\r\n"));
+        assert!(text.contains("\"name\":\"hi.txt\""));
+        assert!(text.contains("Content-Type: text/plain\r\n\r\nhello world\r\n"));
+        // Metadata part must come before the media body.
+        let meta_at = text.find("\"name\":\"hi.txt\"").unwrap();
+        let media_at = text.find("hello world").unwrap();
+        assert!(meta_at < media_at);
     }
 }

--- a/crates/trusty-gworkspace/src/api/services/drive/files.rs
+++ b/crates/trusty-gworkspace/src/api/services/drive/files.rs
@@ -5,7 +5,9 @@
 //! What: Each tool is a thin wrapper over the v3 REST endpoints.
 //! Test: Live only.
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use serde_json::{Value, json};
 
 use crate::api::client::BaseClient;
@@ -47,47 +49,128 @@ pub async fn search_drive_files(client: &BaseClient, args: Value) -> Result<Valu
     client.get(&url, account).await
 }
 
-/// Why: Fetching file body (export for native Google types) needs MIME-aware handling.
-/// What: For Google MIME types calls `/export`; for others calls `/files/{id}?alt=media`.
-/// Test: Live API.
+/// Why: Fetching a file body must be MIME-aware — Google-native docs need
+/// `/export`, and binary files (images, PDFs, zips) must never be forced
+/// through UTF-8 decoding, which silently corrupts them (parity fix #2627).
+/// What: Resolves the file's MIME, downloads the body as raw bytes, then:
+/// text-like content is returned inline as `content`; binary content is
+/// base64-encoded (`encoding: "base64"`) unless `save_path` is set, in which
+/// case the raw bytes are written to disk. `output_format: "raw"` forces the
+/// binary path even for text MIME types (mirrors Python's `auto|raw`).
+/// Test: `is_textual_mime` branching is unit-tested below; end-to-end 200 is
+/// live-only.
 pub async fn get_drive_file_content(client: &BaseClient, args: Value) -> Result<Value> {
     let account = account_of(&args);
     let id = require_str(&args, "file_id")?;
     let export_mime = opt_str(&args, "export_mime_type");
+    let save_path = opt_str(&args, "save_path");
+    let output_format = opt_str(&args, "output_format").unwrap_or("auto");
 
-    // Get metadata first to know mime type
-    let meta_url = format!("{DRIVE_API_BASE}/files/{id}?fields=id,name,mimeType");
+    // Get metadata first to know mime type.
+    let meta_url =
+        format!("{DRIVE_API_BASE}/files/{id}?fields=id,name,mimeType&supportsAllDrives=true");
     let meta = client.get(&meta_url, account).await?;
     let mime = meta.get("mimeType").and_then(|v| v.as_str()).unwrap_or("");
+    let name = meta.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    let is_google_native = mime.starts_with("application/vnd.google-apps");
 
-    let content_url = if mime.starts_with("application/vnd.google-apps") {
-        // Google native doc — must use export
+    let content_url = if is_google_native {
+        // Google native doc — must use export.
         let target = export_mime.unwrap_or("text/plain");
         format!(
             "{DRIVE_API_BASE}/files/{id}/export?mimeType={}",
             encode(target)
         )
     } else {
-        format!("{DRIVE_API_BASE}/files/{id}?alt=media")
+        format!("{DRIVE_API_BASE}/files/{id}?alt=media&supportsAllDrives=true")
     };
 
-    let token = client.get_access_token(account).await?;
-    let raw = reqwest::Client::new()
-        .get(&content_url)
-        .bearer_auth(token)
-        .send()
-        .await?;
-    let status = raw.status();
-    let text = raw.text().await.unwrap_or_default();
-    if !status.is_success() {
-        return Ok(json!({ "error": text, "status": status.as_u16() }));
+    let raw = client.get_bytes(&content_url, account).await?;
+    if !raw.status.is_success() {
+        let text = String::from_utf8_lossy(&raw.bytes).into_owned();
+        return Ok(json!({ "error": text, "status": raw.status.as_u16() }));
     }
-    Ok(json!({
+
+    // Effective MIME: an export target, else the response header, else metadata.
+    let effective_mime: String = if is_google_native {
+        export_mime.unwrap_or("text/plain").to_string()
+    } else {
+        raw.content_type
+            .as_deref()
+            .map(|ct| ct.split(';').next().unwrap_or(ct).trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| mime.to_string())
+    };
+
+    // Persisting to disk always writes the exact bytes, text or binary.
+    if let Some(path) = save_path {
+        std::fs::write(path, &raw.bytes).with_context(|| format!("write drive file to {path}"))?;
+        return Ok(json!({
+            "id": id,
+            "name": name,
+            "mimeType": effective_mime,
+            "savedTo": path,
+            "bytesWritten": raw.bytes.len(),
+        }));
+    }
+
+    let treat_as_text = output_format != "raw" && is_textual_mime(&effective_mime);
+    if treat_as_text {
+        // Only return inline text when the bytes are valid UTF-8; otherwise
+        // fall through to base64 so we never emit lossy content.
+        match String::from_utf8(raw.bytes) {
+            Ok(text) => {
+                return Ok(json!({
+                    "id": id,
+                    "name": name,
+                    "mimeType": effective_mime,
+                    "content": text,
+                }));
+            }
+            Err(e) => {
+                return Ok(binary_content_json(id, name, &effective_mime, e.as_bytes()));
+            }
+        }
+    }
+    Ok(binary_content_json(id, name, &effective_mime, &raw.bytes))
+}
+
+/// Why: Binary payloads must round-trip losslessly through JSON.
+/// What: Base64-encodes `bytes` and tags the payload `encoding: "base64"`.
+/// Test: Covered indirectly by the `get_drive_file_content` binary branch.
+fn binary_content_json(id: &str, name: &str, mime: &str, bytes: &[u8]) -> Value {
+    json!({
         "id": id,
-        "name": meta.get("name"),
+        "name": name,
         "mimeType": mime,
-        "content": text,
-    }))
+        "encoding": "base64",
+        "size": bytes.len(),
+        "content": STANDARD.encode(bytes),
+    })
+}
+
+/// Why: Deciding text-vs-binary handling requires a MIME classifier that
+/// covers the common textual families Drive serves.
+/// What: Returns true for `text/*`, JSON/XML (incl. `+json`/`+xml` suffixes),
+/// CSV, JavaScript, and SVG; false otherwise. Case- and parameter-insensitive.
+/// Test: `textual_mime_classification` below.
+pub(crate) fn is_textual_mime(mime: &str) -> bool {
+    let m = mime
+        .split(';')
+        .next()
+        .unwrap_or(mime)
+        .trim()
+        .to_ascii_lowercase();
+    m.starts_with("text/")
+        || m == "application/json"
+        || m == "application/xml"
+        || m == "application/xhtml+xml"
+        || m == "application/javascript"
+        || m == "application/x-ndjson"
+        || m == "application/csv"
+        || m == "image/svg+xml"
+        || m.ends_with("+json")
+        || m.ends_with("+xml")
 }
 
 /// Why: Shared drives are a separate Drive endpoint from regular `/files`.
@@ -168,4 +251,49 @@ pub(crate) fn encode(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn textual_mime_classification() {
+        // Text families are inline-able.
+        for m in [
+            "text/plain",
+            "text/html; charset=UTF-8",
+            "application/json",
+            "application/vnd.api+json",
+            "application/xml",
+            "image/svg+xml",
+            "application/csv",
+            "TEXT/CSV",
+        ] {
+            assert!(is_textual_mime(m), "{m} should be textual");
+        }
+        // Binary families must not be decoded as UTF-8.
+        for m in [
+            "image/png",
+            "application/pdf",
+            "application/zip",
+            "application/octet-stream",
+            "video/mp4",
+        ] {
+            assert!(!is_textual_mime(m), "{m} should be binary");
+        }
+    }
+
+    #[test]
+    fn binary_content_json_is_base64_encoded() {
+        // Non-UTF-8 bytes must survive JSON round-tripping via base64.
+        let bytes = [0x89u8, 0x50, 0x4E, 0x47, 0x00, 0xFF];
+        let v = binary_content_json("id1", "logo.png", "image/png", &bytes);
+        assert_eq!(v["encoding"], "base64");
+        assert_eq!(v["size"], 6);
+        let decoded = STANDARD
+            .decode(v["content"].as_str().unwrap())
+            .expect("valid base64");
+        assert_eq!(decoded, bytes);
+    }
 }

--- a/crates/trusty-gworkspace/src/api/services/drive/files.rs
+++ b/crates/trusty-gworkspace/src/api/services/drive/files.rs
@@ -12,7 +12,9 @@ use serde_json::{Value, json};
 
 use crate::api::client::BaseClient;
 use crate::api::constants::{DRIVE_API_BASE, DRIVE_UPLOAD_BASE};
-use crate::api::services::{account_of, guess_mime_from_path, opt_str, require_str};
+use crate::api::services::{
+    account_of, guess_mime_from_path, opt_str, require_str, sanitize_header_value,
+};
 
 /// Why: Folder listing is the entry point for any Drive navigation tool.
 /// What: Queries `/files` filtered by parent id, returning name/mimeType/id for each child.
@@ -279,16 +281,21 @@ pub async fn manage_drive_file(client: &BaseClient, args: Value) -> Result<Value
 
 /// Why: Drive's multipart upload endpoint expects a `multipart/related` body
 /// pairing a JSON metadata part with the raw media part; getting the CRLF
-/// framing wrong yields a 400.
-/// What: Serialises `metadata` as the first part and `content` (under `mime`)
-/// as the second, delimited by `boundary` per RFC 2387.
-/// Test: `multipart_body_has_metadata_and_media_parts` below.
+/// framing wrong yields a 400. `mime` comes from a caller-supplied
+/// `mime_type` argument (or our own extension guess), so it must be
+/// CRLF-sanitized before landing in the raw `Content-Type:` header line —
+/// the same header-injection class as the Gmail compose headers.
+/// What: Serialises `metadata` as the first part and `content` (under the
+/// sanitized `mime`) as the second, delimited by `boundary` per RFC 2387.
+/// Test: `multipart_body_has_metadata_and_media_parts`,
+/// `multipart_related_sanitizes_crlf_in_mime` below.
 fn build_multipart_related(
     metadata: &Value,
     mime: &str,
     content: &[u8],
     boundary: &str,
 ) -> Result<Vec<u8>> {
+    let mime = sanitize_header_value(mime);
     let meta_json = serde_json::to_vec(metadata).context("serialize upload metadata")?;
     let mut body = Vec::with_capacity(meta_json.len() + content.len() + 256);
     body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
@@ -376,5 +383,19 @@ mod tests {
         let meta_at = text.find("\"name\":\"hi.txt\"").unwrap();
         let media_at = text.find("hello world").unwrap();
         assert!(meta_at < media_at);
+    }
+
+    #[test]
+    fn multipart_related_sanitizes_crlf_in_mime() {
+        // A malicious mime_type must not be able to smuggle a NEW header line
+        // into the multipart/related part it is formatted into — the value
+        // survives (merged harmlessly onto the Content-Type line) but the
+        // CRLF that would have started a fresh "X-Injected:" header is gone.
+        let metadata = json!({ "name": "hi.txt" });
+        let malicious_mime = "text/plain\r\nX-Injected: evil";
+        let body = build_multipart_related(&metadata, malicious_mime, b"data", "BOUND").unwrap();
+        let text = String::from_utf8(body).expect("ascii-framed multipart");
+        assert!(!text.contains("\r\nX-Injected:"));
+        assert!(text.contains("Content-Type: text/plainX-Injected: evil\r\n\r\ndata"));
     }
 }

--- a/crates/trusty-gworkspace/src/api/services/gmail/compose.rs
+++ b/crates/trusty-gworkspace/src/api/services/gmail/compose.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 use crate::api::client::BaseClient;
 use crate::api::constants::DRIVE_API_BASE;
-use crate::api::services::guess_mime_from_path;
+use crate::api::services::{guess_mime_from_path, sanitize_header_value};
 
 /// A resolved attachment ready for MIME encoding.
 ///
@@ -87,18 +87,26 @@ pub(super) fn build_mime(parts: &MessageParts, attachments: &[Attachment]) -> St
         multipart("mixed", &boundary, &sub)
     };
 
+    // Every value below is attacker-influenceable (direct MCP args, or —
+    // for `reply` — a fetched message's Subject/From) and is formatted
+    // straight into a raw header line, so each MUST be CRLF-sanitized here
+    // to prevent header injection (e.g. a smuggled `Bcc:`).
     let mut headers = vec![
-        format!("To: {}", parts.to),
-        format!("Subject: {}", parts.subject),
+        format!("To: {}", sanitize_header_value(parts.to)),
+        format!("Subject: {}", sanitize_header_value(parts.subject)),
     ];
     if let Some(c) = parts.cc {
-        headers.push(format!("Cc: {c}"));
+        headers.push(format!("Cc: {}", sanitize_header_value(c)));
     }
     if let Some(b) = parts.bcc {
-        headers.push(format!("Bcc: {b}"));
+        headers.push(format!("Bcc: {}", sanitize_header_value(b)));
     }
     for (k, v) in &parts.extra_headers {
-        headers.push(format!("{k}: {v}"));
+        headers.push(format!(
+            "{}: {}",
+            sanitize_header_value(k),
+            sanitize_header_value(v)
+        ));
     }
     headers.push("MIME-Version: 1.0".to_string());
 
@@ -270,12 +278,20 @@ fn text_part(subtype: &str, body: &str) -> String {
 }
 
 /// Render an attachment leaf part (headers + base64 body).
+///
+/// Why: `mime`/`filename` can originate from caller-supplied `mime_type` /
+/// `filename` arguments (or a Drive file's own `mimeType`/`name`), so they
+/// must be CRLF-sanitized before landing in a raw header line — the same
+/// injection class as the top-level `To`/`Subject` headers.
+/// What: Sanitizes both values, then formats the `Content-Type` and
+/// `Content-Disposition` header lines.
+/// Test: `build_mime_rejects_crlf_injection_in_attachment_filename` below.
 fn attachment_part(a: &Attachment) -> String {
     let b64 = wrap_base64(&STANDARD.encode(&a.bytes));
+    let mime = sanitize_header_value(&a.mime);
+    let name = sanitize_header_value(&a.filename);
     format!(
-        "Content-Type: {mime}; name=\"{name}\"\r\nContent-Disposition: attachment; filename=\"{name}\"\r\nContent-Transfer-Encoding: base64\r\n\r\n{b64}",
-        mime = a.mime,
-        name = a.filename,
+        "Content-Type: {mime}; name=\"{name}\"\r\nContent-Disposition: attachment; filename=\"{name}\"\r\nContent-Transfer-Encoding: base64\r\n\r\n{b64}"
     )
 }
 
@@ -389,6 +405,122 @@ mod tests {
         assert!(mime.contains("In-Reply-To: <abc@mail>\r\n"));
         assert!(mime.contains("References: <abc@mail>\r\n"));
         assert!(mime.contains("Subject: Re: Question\r\n"));
+    }
+
+    #[test]
+    fn build_mime_alternative_with_attachment_nests_correctly() {
+        // The most error-prone nesting: multipart/mixed(multipart/alternative(
+        // plain, html), attachment) — html+plain body plus one attachment.
+        let p = MessageParts {
+            to: "to@x.com",
+            cc: None,
+            bcc: None,
+            subject: "S",
+            plain: Some("plain text"),
+            html: Some("<b>rich</b>"),
+            extra_headers: Vec::new(),
+        };
+        let att = Attachment {
+            filename: "note.txt".to_string(),
+            mime: "text/plain".to_string(),
+            bytes: b"attached bytes".to_vec(),
+        };
+        let mime = build_mime(&p, std::slice::from_ref(&att));
+
+        assert!(mime.contains("Content-Type: multipart/mixed"));
+        assert!(mime.contains("Content-Type: multipart/alternative"));
+        assert!(mime.contains(&STANDARD.encode("plain text")));
+        assert!(mime.contains(&STANDARD.encode("<b>rich</b>")));
+        assert!(mime.contains("Content-Disposition: attachment; filename=\"note.txt\""));
+
+        // Nesting order: mixed's own header precedes the nested alternative's
+        // header, which precedes the attachment part.
+        let mixed_at = mime.find("Content-Type: multipart/mixed").unwrap();
+        let alt_at = mime.find("Content-Type: multipart/alternative").unwrap();
+        let att_at = mime.find("Content-Disposition: attachment").unwrap();
+        assert!(mixed_at < alt_at, "mixed header must precede alternative");
+        assert!(alt_at < att_at, "alternative body must precede attachment");
+    }
+
+    /// A sanitized value still contains its original characters (minus CR/LF)
+    /// merged into the header line it belongs to — that's expected and
+    /// harmless. The actual security property is that CR/LF can never
+    /// terminate the current header and start a new one, so every injection
+    /// test below asserts the ABSENCE of a new header line (`"\r\n<Name>:"`),
+    /// not the absence of the raw attacker substring.
+    fn asserts_no_injected_header_line(mime: &str, injected_header_name: &str) {
+        let needle = format!("\r\n{injected_header_name}:");
+        assert!(
+            !mime.contains(&needle),
+            "expected no injected '{injected_header_name}:' header line, got:\n{mime}"
+        );
+    }
+
+    #[test]
+    fn build_mime_rejects_crlf_injection_in_subject() {
+        let malicious_subject = "Hi\r\nBcc: attacker@evil.example";
+        let p = parts_plain("to@x.com", malicious_subject, "body");
+        let mime = build_mime(&p, &[]);
+        asserts_no_injected_header_line(&mime, "Bcc");
+        // The value survives, merged harmlessly onto the Subject line.
+        assert!(mime.contains("Subject: HiBcc: attacker@evil.example\r\n"));
+    }
+
+    #[test]
+    fn build_mime_rejects_crlf_injection_in_to_cc_bcc() {
+        let p = MessageParts {
+            to: "to@x.com\r\nBcc: attacker1@evil.example",
+            cc: Some("cc@x.com\r\nBcc: attacker2@evil.example"),
+            bcc: None,
+            subject: "S",
+            plain: Some("body"),
+            html: None,
+            extra_headers: Vec::new(),
+        };
+        let mime = build_mime(&p, &[]);
+        asserts_no_injected_header_line(&mime, "Bcc");
+    }
+
+    #[test]
+    fn build_mime_rejects_crlf_injection_in_reply_headers() {
+        let p = MessageParts {
+            to: "to@x.com",
+            cc: None,
+            bcc: None,
+            subject: "S",
+            plain: Some("body"),
+            html: None,
+            extra_headers: vec![(
+                "In-Reply-To".to_string(),
+                "<abc@mail>\r\nBcc: attacker@evil.example".to_string(),
+            )],
+        };
+        let mime = build_mime(&p, &[]);
+        asserts_no_injected_header_line(&mime, "Bcc");
+    }
+
+    #[test]
+    fn build_mime_rejects_crlf_injection_in_attachment_filename() {
+        let p = parts_plain("to@x.com", "S", "body");
+        let att = Attachment {
+            filename: "evil.txt\r\nBcc: attacker@evil.example".to_string(),
+            mime: "text/plain".to_string(),
+            bytes: b"x".to_vec(),
+        };
+        let mime = build_mime(&p, std::slice::from_ref(&att));
+        asserts_no_injected_header_line(&mime, "Bcc");
+    }
+
+    #[test]
+    fn build_mime_rejects_crlf_injection_in_attachment_mime() {
+        let p = parts_plain("to@x.com", "S", "body");
+        let att = Attachment {
+            filename: "note.txt".to_string(),
+            mime: "text/plain\r\nX-Injected: evil".to_string(),
+            bytes: b"x".to_vec(),
+        };
+        let mime = build_mime(&p, std::slice::from_ref(&att));
+        asserts_no_injected_header_line(&mime, "X-Injected");
     }
 
     #[test]

--- a/crates/trusty-gworkspace/src/api/services/gmail/compose.rs
+++ b/crates/trusty-gworkspace/src/api/services/gmail/compose.rs
@@ -1,0 +1,403 @@
+//! Gmail MIME message composition: multipart bodies + attachment resolution.
+//!
+//! Why: Sending anything beyond a bare plain-text email — HTML alternatives,
+//! attachments, replies — requires building a correct RFC 2822 / MIME
+//! (multipart/alternative, multipart/mixed) envelope and base64url-encoding it
+//! for the Gmail `raw` field. Keeping that construction here keeps
+//! `messages.rs` focused on dispatch and under the SLOC cap.
+//! What: Pure builders (`build_mime`, `encode_raw`) plus async attachment
+//! resolution (`resolve_attachments`) that reads local files, decodes inline
+//! base64, or fetches Drive files by id.
+//! Test: The pure builders are unit-tested below; attachment fetch is live.
+
+use anyhow::{Context, Result, anyhow};
+use base64::Engine;
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::api::client::BaseClient;
+use crate::api::constants::DRIVE_API_BASE;
+use crate::api::services::guess_mime_from_path;
+
+/// A resolved attachment ready for MIME encoding.
+///
+/// Why: Attachment sources differ (disk / inline / Drive) but the MIME builder
+/// only needs the concrete name, type, and bytes.
+/// What: The normalised triple every source resolves to.
+/// Test: Constructed in `build_mime_*` tests.
+pub(super) struct Attachment {
+    pub filename: String,
+    pub mime: String,
+    pub bytes: Vec<u8>,
+}
+
+/// The logical fields of an outgoing message, pre-MIME.
+///
+/// Why: `build_mime` takes many optional inputs; a struct keeps the call site
+/// readable and the argument order safe.
+/// What: Recipients, subject, optional plain/HTML bodies, and extra headers
+/// (e.g. `In-Reply-To`/`References` for replies).
+/// Test: Exercised by every `build_mime_*` test.
+pub(super) struct MessageParts<'a> {
+    pub to: &'a str,
+    pub cc: Option<&'a str>,
+    pub bcc: Option<&'a str>,
+    pub subject: &'a str,
+    pub plain: Option<&'a str>,
+    pub html: Option<&'a str>,
+    pub extra_headers: Vec<(String, String)>,
+}
+
+/// Build the full RFC 2822 / MIME message string.
+///
+/// Why: Gmail's `raw` field needs a complete, correctly-framed MIME message;
+/// mis-nesting alternative/mixed parts or mis-encoding bodies yields broken or
+/// rejected mail.
+/// What: Chooses text/plain, text/html, or multipart/alternative for the body,
+/// wraps it in multipart/mixed when attachments are present, and prepends the
+/// address/subject/extra headers. All leaf bodies use base64 transfer-encoding
+/// so UTF-8 and boundary-colliding content are always safe.
+/// Test: `build_mime_plain_only`, `build_mime_alternative`,
+/// `build_mime_with_attachment`, `build_mime_reply_headers`.
+pub(super) fn build_mime(parts: &MessageParts, attachments: &[Attachment]) -> String {
+    let body_node = match (parts.plain, parts.html) {
+        (Some(p), Some(h)) => {
+            let boundary = make_boundary();
+            multipart(
+                "alternative",
+                &boundary,
+                &[text_part("plain", p), text_part("html", h)],
+            )
+        }
+        (None, Some(h)) => text_part("html", h),
+        (Some(p), None) => text_part("plain", p),
+        (None, None) => text_part("plain", ""),
+    };
+
+    let content = if attachments.is_empty() {
+        body_node
+    } else {
+        let boundary = make_boundary();
+        let mut sub = Vec::with_capacity(attachments.len() + 1);
+        sub.push(body_node);
+        for a in attachments {
+            sub.push(attachment_part(a));
+        }
+        multipart("mixed", &boundary, &sub)
+    };
+
+    let mut headers = vec![
+        format!("To: {}", parts.to),
+        format!("Subject: {}", parts.subject),
+    ];
+    if let Some(c) = parts.cc {
+        headers.push(format!("Cc: {c}"));
+    }
+    if let Some(b) = parts.bcc {
+        headers.push(format!("Bcc: {b}"));
+    }
+    for (k, v) in &parts.extra_headers {
+        headers.push(format!("{k}: {v}"));
+    }
+    headers.push("MIME-Version: 1.0".to_string());
+
+    // `content` begins with its own Content-Type header, so it continues the
+    // header block (no blank line before it) until its own blank separator.
+    format!("{}\r\n{}", headers.join("\r\n"), content)
+}
+
+/// base64url-encode a MIME string for the Gmail `raw` field.
+///
+/// Why: Gmail's send/draft endpoints require the whole message base64url
+/// (unpadded) encoded.
+/// What: Thin wrapper over the URL-safe base64 engine.
+/// Test: `encode_raw_round_trips`.
+pub(super) fn encode_raw(mime: &str) -> String {
+    URL_SAFE_NO_PAD.encode(mime.as_bytes())
+}
+
+/// Resolve the `attachments` argument into concrete byte payloads.
+///
+/// Why: Callers describe attachments abstractly (path / inline base64 / Drive
+/// id); the MIME builder needs bytes.
+/// What: Maps each array element to an [`Attachment`], reading disk, decoding
+/// base64, or fetching Drive bytes as needed.
+/// Test: Live (I/O + Drive); shape covered indirectly by `build_mime` tests.
+pub(super) async fn resolve_attachments(
+    client: &BaseClient,
+    account: Option<&str>,
+    args: &Value,
+) -> Result<Vec<Attachment>> {
+    let Some(arr) = args.get("attachments").and_then(|v| v.as_array()) else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::with_capacity(arr.len());
+    for item in arr {
+        out.push(resolve_one(client, account, item).await?);
+    }
+    Ok(out)
+}
+
+async fn resolve_one(
+    client: &BaseClient,
+    account: Option<&str>,
+    item: &Value,
+) -> Result<Attachment> {
+    // Bare string is a local path shorthand.
+    if let Some(path) = item.as_str() {
+        return read_local(path, None, None);
+    }
+    let filename_arg = item.get("filename").and_then(|v| v.as_str());
+    let mime_arg = item.get("mime_type").and_then(|v| v.as_str());
+
+    if let Some(drive_id) = item
+        .get("driveFileId")
+        .or_else(|| item.get("drive_file_id"))
+        .and_then(|v| v.as_str())
+    {
+        return fetch_drive_attachment(client, account, drive_id, filename_arg, mime_arg).await;
+    }
+    if let Some(b64) = item.get("content").and_then(|v| v.as_str()) {
+        let filename =
+            filename_arg.ok_or_else(|| anyhow!("inline attachment requires 'filename'"))?;
+        // Accept both standard and url-safe base64.
+        let bytes = STANDARD
+            .decode(b64)
+            .or_else(|_| URL_SAFE_NO_PAD.decode(b64.trim_end_matches('=')))
+            .map_err(|e| anyhow!("decode inline attachment '{filename}': {e}"))?;
+        let mime = mime_arg
+            .map(str::to_string)
+            .unwrap_or_else(|| guess_mime_from_path(filename));
+        return Ok(Attachment {
+            filename: filename.to_string(),
+            mime,
+            bytes,
+        });
+    }
+    if let Some(path) = item
+        .get("path")
+        .or_else(|| item.get("local_path"))
+        .and_then(|v| v.as_str())
+    {
+        return read_local(path, filename_arg, mime_arg);
+    }
+    Err(anyhow!(
+        "attachment must be a path string or an object with 'path', 'content'+'filename', or 'driveFileId'"
+    ))
+}
+
+fn read_local(path: &str, filename: Option<&str>, mime: Option<&str>) -> Result<Attachment> {
+    let bytes = std::fs::read(path).with_context(|| format!("read attachment {path}"))?;
+    let filename = filename
+        .map(str::to_string)
+        .unwrap_or_else(|| basename(path));
+    let mime = mime
+        .map(str::to_string)
+        .unwrap_or_else(|| guess_mime_from_path(path));
+    Ok(Attachment {
+        filename,
+        mime,
+        bytes,
+    })
+}
+
+async fn fetch_drive_attachment(
+    client: &BaseClient,
+    account: Option<&str>,
+    drive_id: &str,
+    filename: Option<&str>,
+    mime: Option<&str>,
+) -> Result<Attachment> {
+    let meta = client
+        .get(
+            &format!(
+                "{DRIVE_API_BASE}/files/{drive_id}?fields=id,name,mimeType&supportsAllDrives=true"
+            ),
+            account,
+        )
+        .await?;
+    let meta_name = meta.get("name").and_then(|v| v.as_str());
+    let meta_mime = meta.get("mimeType").and_then(|v| v.as_str());
+    let raw = client
+        .get_bytes(
+            &format!("{DRIVE_API_BASE}/files/{drive_id}?alt=media&supportsAllDrives=true"),
+            account,
+        )
+        .await?;
+    if !raw.status.is_success() {
+        return Err(anyhow!(
+            "fetch Drive attachment {drive_id} failed: HTTP {}",
+            raw.status.as_u16()
+        ));
+    }
+    let filename = filename.or(meta_name).unwrap_or(drive_id).to_string();
+    let mime = mime
+        .map(str::to_string)
+        .or_else(|| {
+            raw.content_type
+                .as_deref()
+                .map(|ct| ct.split(';').next().unwrap_or(ct).trim().to_string())
+        })
+        .or_else(|| meta_mime.map(str::to_string))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+    Ok(Attachment {
+        filename,
+        mime,
+        bytes: raw.bytes,
+    })
+}
+
+fn basename(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
+fn make_boundary() -> String {
+    format!("=_gw_{}", Uuid::new_v4().simple())
+}
+
+/// Render a base64 leaf text part (headers + encoded body).
+fn text_part(subtype: &str, body: &str) -> String {
+    let b64 = wrap_base64(&STANDARD.encode(body.as_bytes()));
+    format!(
+        "Content-Type: text/{subtype}; charset=\"UTF-8\"\r\nContent-Transfer-Encoding: base64\r\n\r\n{b64}"
+    )
+}
+
+/// Render an attachment leaf part (headers + base64 body).
+fn attachment_part(a: &Attachment) -> String {
+    let b64 = wrap_base64(&STANDARD.encode(&a.bytes));
+    format!(
+        "Content-Type: {mime}; name=\"{name}\"\r\nContent-Disposition: attachment; filename=\"{name}\"\r\nContent-Transfer-Encoding: base64\r\n\r\n{b64}",
+        mime = a.mime,
+        name = a.filename,
+    )
+}
+
+/// Wrap a multipart container around already-rendered sub-parts.
+fn multipart(subtype: &str, boundary: &str, parts: &[String]) -> String {
+    let mut s = format!("Content-Type: multipart/{subtype}; boundary=\"{boundary}\"\r\n\r\n");
+    for p in parts {
+        s.push_str(&format!("--{boundary}\r\n"));
+        s.push_str(p);
+        s.push_str("\r\n");
+    }
+    s.push_str(&format!("--{boundary}--"));
+    s
+}
+
+/// Wrap base64 at 76 characters per RFC 2045 line-length limits.
+fn wrap_base64(b64: &str) -> String {
+    b64.as_bytes()
+        .chunks(76)
+        .map(|c| std::str::from_utf8(c).unwrap_or_default())
+        .collect::<Vec<_>>()
+        .join("\r\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parts_plain<'a>(to: &'a str, subject: &'a str, body: &'a str) -> MessageParts<'a> {
+        MessageParts {
+            to,
+            cc: None,
+            bcc: None,
+            subject,
+            plain: Some(body),
+            html: None,
+            extra_headers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn encode_raw_round_trips() {
+        let mime = "To: a@b.com\r\nSubject: hi\r\n\r\nbody";
+        let raw = encode_raw(mime);
+        let decoded = URL_SAFE_NO_PAD.decode(raw).expect("valid base64url");
+        assert_eq!(String::from_utf8(decoded).unwrap(), mime);
+    }
+
+    #[test]
+    fn build_mime_plain_only() {
+        let p = parts_plain("to@x.com", "Hello", "the body");
+        let mime = build_mime(&p, &[]);
+        assert!(mime.contains("To: to@x.com\r\n"));
+        assert!(mime.contains("Subject: Hello\r\n"));
+        assert!(mime.contains("MIME-Version: 1.0\r\n"));
+        assert!(mime.contains("Content-Type: text/plain; charset=\"UTF-8\""));
+        // Body is base64 of "the body".
+        assert!(mime.contains(&STANDARD.encode("the body")));
+        assert!(!mime.contains("multipart/"));
+    }
+
+    #[test]
+    fn build_mime_alternative() {
+        let p = MessageParts {
+            to: "to@x.com",
+            cc: Some("cc@x.com"),
+            bcc: None,
+            subject: "S",
+            plain: Some("plain text"),
+            html: Some("<b>rich</b>"),
+            extra_headers: Vec::new(),
+        };
+        let mime = build_mime(&p, &[]);
+        assert!(mime.contains("Cc: cc@x.com\r\n"));
+        assert!(mime.contains("multipart/alternative"));
+        assert!(mime.contains("Content-Type: text/plain"));
+        assert!(mime.contains("Content-Type: text/html"));
+        assert!(mime.contains(&STANDARD.encode("<b>rich</b>")));
+    }
+
+    #[test]
+    fn build_mime_with_attachment() {
+        let p = parts_plain("to@x.com", "S", "body");
+        let att = Attachment {
+            filename: "note.txt".to_string(),
+            mime: "text/plain".to_string(),
+            bytes: b"attached bytes".to_vec(),
+        };
+        let mime = build_mime(&p, std::slice::from_ref(&att));
+        assert!(mime.contains("multipart/mixed"));
+        assert!(mime.contains("Content-Disposition: attachment; filename=\"note.txt\""));
+        assert!(mime.contains("Content-Type: text/plain; name=\"note.txt\""));
+        assert!(mime.contains(&STANDARD.encode("attached bytes")));
+    }
+
+    #[test]
+    fn build_mime_reply_headers() {
+        let p = MessageParts {
+            to: "orig@x.com",
+            cc: None,
+            bcc: None,
+            subject: "Re: Question",
+            plain: Some("answer"),
+            html: None,
+            extra_headers: vec![
+                ("In-Reply-To".to_string(), "<abc@mail>".to_string()),
+                ("References".to_string(), "<abc@mail>".to_string()),
+            ],
+        };
+        let mime = build_mime(&p, &[]);
+        assert!(mime.contains("In-Reply-To: <abc@mail>\r\n"));
+        assert!(mime.contains("References: <abc@mail>\r\n"));
+        assert!(mime.contains("Subject: Re: Question\r\n"));
+    }
+
+    #[test]
+    fn wrap_base64_wraps_at_76() {
+        let long = "A".repeat(200);
+        let wrapped = wrap_base64(&long);
+        for line in wrapped.split("\r\n") {
+            assert!(line.len() <= 76, "line too long: {}", line.len());
+        }
+        assert_eq!(wrapped.replace("\r\n", ""), long);
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/gmail/messages.rs
+++ b/crates/trusty-gworkspace/src/api/services/gmail/messages.rs
@@ -12,6 +12,7 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use serde_json::{Value, json};
 
+use super::compose;
 use crate::api::client::BaseClient;
 use crate::api::constants::GMAIL_API_BASE;
 use crate::api::services::{account_of, opt_str, require_str};
@@ -111,75 +112,187 @@ fn collect_attachments(part: &Value, out: &mut Vec<Value>) {
     }
 }
 
-/// Compose an email: send, draft, or send an existing draft.
+/// Compose an email: send, draft, send an existing draft, or reply.
 ///
-/// Why: Single tool covers the three common write paths in Gmail; we build
-/// the RFC 2822 MIME envelope here so callers pass logical fields.
-/// What: Builds a `From/To/Subject/Body` message, base64url-encodes it, and
-/// POSTs to either `/messages/send` or `/drafts`.
-/// Test: Live only (real Gmail send).
+/// Why: One tool covers every Gmail write path, now including replies and
+/// attachments at parity with the Python upstream (#2630).
+/// What: Resolves plain/HTML bodies and attachments, builds the MIME envelope
+/// via `compose::build_mime`, base64url-encodes it, and POSTs to the right
+/// endpoint. `reply` fetches the original message to set
+/// `In-Reply-To`/`References` headers and the send `threadId`, defaulting the
+/// recipient/subject from the original when omitted.
+/// Test: MIME construction is unit-tested in `compose`; live send is deferred.
 pub async fn compose_email(client: &BaseClient, args: Value) -> Result<Value> {
     let account = account_of(&args);
     let action = opt_str(&args, "action").unwrap_or("send");
 
     if action == "send_draft" {
         let draft_id = require_str(&args, "draft_id")?;
-        let body = json!({ "id": draft_id });
         let url = format!("{GMAIL_API_BASE}/users/me/drafts/send");
-        return client.post(&url, body, account).await;
+        return client.post(&url, json!({ "id": draft_id }), account).await;
     }
 
-    let to = require_str(&args, "to")?;
-    let subject = opt_str(&args, "subject").unwrap_or("");
-    let body_text = opt_str(&args, "body").unwrap_or("");
-    let cc = opt_str(&args, "cc");
-    let bcc = opt_str(&args, "bcc");
-    let html = args.get("html").and_then(|v| v.as_bool()).unwrap_or(false);
+    let plain_body = opt_str(&args, "body");
+    let html_body = opt_str(&args, "html_body");
+    let html_flag = args.get("html").and_then(|v| v.as_bool()).unwrap_or(false);
+    // html_body wins; else the legacy `html: true` flag re-labels `body` as HTML.
+    let (plain, html): (Option<&str>, Option<&str>) = if html_body.is_some() {
+        (plain_body, html_body)
+    } else if html_flag {
+        (None, plain_body)
+    } else {
+        (plain_body, None)
+    };
 
-    let mime = build_mime_message(to, cc, bcc, subject, body_text, html);
-    let encoded = URL_SAFE_NO_PAD.encode(mime.as_bytes());
+    let attachments = compose::resolve_attachments(client, account, &args).await?;
 
-    let payload = json!({ "raw": encoded });
+    // Reply context supplies headers, a default recipient/subject, and threadId.
+    let mut extra_headers: Vec<(String, String)> = Vec::new();
+    let mut thread_id: Option<String> = None;
+    let mut to_default: Option<String> = None;
+    let mut subject_default: Option<String> = None;
+    if action == "reply" {
+        let ctx = fetch_reply_context(client, account, require_str(&args, "message_id")?).await?;
+        thread_id = ctx.thread_id.clone();
+        if let Some(mid) = &ctx.message_id_header {
+            extra_headers.push(("In-Reply-To".to_string(), mid.clone()));
+            extra_headers.push(("References".to_string(), ctx.references_chain(mid)));
+        }
+        if opt_str(&args, "to").is_none() {
+            to_default = ctx.from.clone();
+        }
+        if opt_str(&args, "subject").is_none() {
+            subject_default = ctx.subject.as_deref().map(reply_subject);
+        }
+    }
+
+    let to = match (opt_str(&args, "to"), to_default.as_deref()) {
+        (Some(t), _) | (None, Some(t)) => t,
+        (None, None) => {
+            return Err(anyhow!(
+                "'to' is required (or reply to a message that has a sender)"
+            ));
+        }
+    };
+    let subject = opt_str(&args, "subject")
+        .or(subject_default.as_deref())
+        .unwrap_or("");
+
+    let parts = compose::MessageParts {
+        to,
+        cc: opt_str(&args, "cc"),
+        bcc: opt_str(&args, "bcc"),
+        subject,
+        plain,
+        html,
+        extra_headers,
+    };
+    let raw = compose::encode_raw(&compose::build_mime(&parts, &attachments));
+
     match action {
         "send" => {
+            let url = format!("{GMAIL_API_BASE}/users/me/messages/send");
+            client.post(&url, json!({ "raw": raw }), account).await
+        }
+        "reply" => {
+            let mut payload = json!({ "raw": raw });
+            if let Some(tid) = thread_id {
+                payload["threadId"] = json!(tid);
+            }
             let url = format!("{GMAIL_API_BASE}/users/me/messages/send");
             client.post(&url, payload, account).await
         }
         "draft" => {
-            let body = json!({ "message": { "raw": encoded } });
             let url = format!("{GMAIL_API_BASE}/users/me/drafts");
-            client.post(&url, body, account).await
+            client
+                .post(&url, json!({ "message": { "raw": raw } }), account)
+                .await
         }
         other => Err(anyhow!("unknown action for compose_email: {other}")),
     }
 }
 
-fn build_mime_message(
-    to: &str,
-    cc: Option<&str>,
-    bcc: Option<&str>,
-    subject: &str,
-    body: &str,
-    html: bool,
-) -> String {
-    let content_type = if html {
-        "text/html; charset=UTF-8"
-    } else {
-        "text/plain; charset=UTF-8"
+/// The subset of an original message needed to build a threaded reply.
+///
+/// Why: A well-formed reply must chain `In-Reply-To`/`References` to the
+/// original `Message-ID`, ride the same `threadId`, and default To/Subject.
+/// What: Carries the original thread id, `Message-ID`, `References`, subject,
+/// and sender.
+/// Test: `references_chain`/`reply_subject` are unit-tested below.
+struct ReplyContext {
+    thread_id: Option<String>,
+    message_id_header: Option<String>,
+    references: Option<String>,
+    subject: Option<String>,
+    from: Option<String>,
+}
+
+impl ReplyContext {
+    /// Append this message id to any existing References chain.
+    fn references_chain(&self, msg_id: &str) -> String {
+        match self.references.as_deref().filter(|r| !r.is_empty()) {
+            Some(prev) => format!("{prev} {msg_id}"),
+            None => msg_id.to_string(),
+        }
+    }
+}
+
+/// Fetch the reply context (threadId + relevant headers) for a message.
+///
+/// Why: Replies need the original's headers to thread correctly.
+/// What: GETs the message with `format=metadata` limited to the four headers
+/// we consume, then extracts them case-insensitively.
+/// Test: Live (network); pure header parsing is exercised via the message JSON.
+async fn fetch_reply_context(
+    client: &BaseClient,
+    account: Option<&str>,
+    message_id: &str,
+) -> Result<ReplyContext> {
+    let url = format!(
+        "{GMAIL_API_BASE}/users/me/messages/{message_id}?format=metadata&metadataHeaders=Message-ID&metadataHeaders=References&metadataHeaders=Subject&metadataHeaders=From"
+    );
+    let msg = client.get(&url, account).await?;
+    let thread_id = msg
+        .get("threadId")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let headers = msg
+        .get("payload")
+        .and_then(|p| p.get("headers"))
+        .and_then(|h| h.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let header = |name: &str| -> Option<String> {
+        headers
+            .iter()
+            .find(|h| {
+                h.get("name")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|n| n.eq_ignore_ascii_case(name))
+            })
+            .and_then(|h| h.get("value").and_then(|v| v.as_str()))
+            .map(String::from)
     };
-    let mut headers = vec![
-        format!("To: {to}"),
-        format!("Subject: {subject}"),
-        format!("Content-Type: {content_type}"),
-        "MIME-Version: 1.0".to_string(),
-    ];
-    if let Some(c) = cc {
-        headers.push(format!("Cc: {c}"));
+    Ok(ReplyContext {
+        thread_id,
+        message_id_header: header("Message-ID"),
+        references: header("References"),
+        subject: header("Subject"),
+        from: header("From"),
+    })
+}
+
+/// Prefix a subject with `Re: ` unless it already has one.
+fn reply_subject(original: &str) -> String {
+    if original
+        .trim_start()
+        .to_ascii_lowercase()
+        .starts_with("re:")
+    {
+        original.to_string()
+    } else {
+        format!("Re: {original}")
     }
-    if let Some(b) = bcc {
-        headers.push(format!("Bcc: {b}"));
-    }
-    format!("{}\r\n\r\n{}", headers.join("\r\n"), body)
 }
 
 /// Why: Bulk label add/remove (incl. archive/trash) is one Gmail batchModify call.
@@ -239,4 +352,38 @@ fn urlencode(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reply_subject_prefixes_once() {
+        assert_eq!(reply_subject("Question"), "Re: Question");
+        // Already a reply -> unchanged, case-insensitive.
+        assert_eq!(reply_subject("Re: Question"), "Re: Question");
+        assert_eq!(reply_subject("RE: Loud"), "RE: Loud");
+    }
+
+    #[test]
+    fn references_chain_appends_to_existing() {
+        let with_prev = ReplyContext {
+            thread_id: None,
+            message_id_header: Some("<b@m>".to_string()),
+            references: Some("<a@m>".to_string()),
+            subject: None,
+            from: None,
+        };
+        assert_eq!(with_prev.references_chain("<b@m>"), "<a@m> <b@m>");
+
+        let no_prev = ReplyContext {
+            thread_id: None,
+            message_id_header: Some("<b@m>".to_string()),
+            references: None,
+            subject: None,
+            from: None,
+        };
+        assert_eq!(no_prev.references_chain("<b@m>"), "<b@m>");
+    }
 }

--- a/crates/trusty-gworkspace/src/api/services/gmail/mod.rs
+++ b/crates/trusty-gworkspace/src/api/services/gmail/mod.rs
@@ -6,6 +6,7 @@
 //! `gmail::manage_gmail_labels`, etc.
 //! Test: Each sub-module has its own tests where applicable.
 
+pub mod compose;
 pub mod labels;
 pub mod messages;
 pub mod organize;

--- a/crates/trusty-gworkspace/src/api/services/mod.rs
+++ b/crates/trusty-gworkspace/src/api/services/mod.rs
@@ -45,3 +45,65 @@ pub(crate) fn opt_str<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
 }
+
+/// Guess a MIME type from a filename extension (best-effort).
+///
+/// Why: Drive uploads and Gmail attachments both need a `Content-Type` when
+/// the caller doesn't supply one; a small extension map covers the common
+/// cases without pulling in a heavyweight mime-sniffing dependency.
+/// What: Lowercases the file extension and maps it; unknown extensions fall
+/// back to `application/octet-stream`.
+/// Test: `guess_mime_covers_common_extensions` below.
+pub(crate) fn guess_mime_from_path(path: &str) -> String {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let mime = match ext.as_str() {
+        "txt" | "text" | "log" => "text/plain",
+        "html" | "htm" => "text/html",
+        "csv" => "text/csv",
+        "md" | "markdown" => "text/markdown",
+        "json" => "application/json",
+        "xml" => "application/xml",
+        "pdf" => "application/pdf",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "svg" => "image/svg+xml",
+        "webp" => "image/webp",
+        "zip" => "application/zip",
+        "gz" | "gzip" => "application/gzip",
+        "doc" => "application/msword",
+        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "xls" => "application/vnd.ms-excel",
+        "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "ppt" => "application/vnd.ms-powerpoint",
+        "pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        _ => "application/octet-stream",
+    };
+    mime.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guess_mime_covers_common_extensions() {
+        assert_eq!(guess_mime_from_path("/a/b/report.pdf"), "application/pdf");
+        assert_eq!(guess_mime_from_path("logo.PNG"), "image/png");
+        assert_eq!(guess_mime_from_path("notes.txt"), "text/plain");
+        assert_eq!(guess_mime_from_path("data.json"), "application/json");
+        assert_eq!(
+            guess_mime_from_path("archive"),
+            "application/octet-stream",
+            "no extension -> octet-stream"
+        );
+        assert_eq!(
+            guess_mime_from_path("weird.qwerty"),
+            "application/octet-stream"
+        );
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/mod.rs
+++ b/crates/trusty-gworkspace/src/api/services/mod.rs
@@ -46,6 +46,25 @@ pub(crate) fn opt_str<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
         .filter(|s| !s.is_empty())
 }
 
+/// Strip CR/LF from a value about to be interpolated into a raw RFC 2822
+/// header line.
+///
+/// Why: Header values (Gmail `To`/`Cc`/`Bcc`/`Subject`/`In-Reply-To`, Drive
+/// upload `Content-Type`) are formatted directly into hand-built header
+/// lines. Several sources are attacker-influenceable: MCP tool arguments
+/// directly, and — via the `reply` action — a fetched message's `Subject`/
+/// `From` headers. An embedded `\r` or `\n` lets the value terminate the
+/// current header and inject an arbitrary new one (e.g. a covert `Bcc:`),
+/// a classic CRLF/header-injection vector. Every value placed into a header
+/// line MUST be passed through this first.
+/// What: Removes every `\r` and `\n` character; the result can never
+/// terminate the header line it is placed into.
+/// Test: `sanitize_header_value_strips_crlf` below; injection regression
+/// tests live alongside each header-building call site.
+pub(crate) fn sanitize_header_value(value: &str) -> String {
+    value.chars().filter(|c| *c != '\r' && *c != '\n').collect()
+}
+
 /// Guess a MIME type from a filename extension (best-effort).
 ///
 /// Why: Drive uploads and Gmail attachments both need a `Content-Type` when
@@ -89,6 +108,16 @@ pub(crate) fn guess_mime_from_path(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sanitize_header_value_strips_crlf() {
+        assert_eq!(sanitize_header_value("plain value"), "plain value");
+        assert_eq!(
+            sanitize_header_value("a\r\nBcc: evil@x.com"),
+            "aBcc: evil@x.com"
+        );
+        assert_eq!(sanitize_header_value("a\nb\rc"), "abc");
+    }
 
     #[test]
     fn guess_mime_covers_common_extensions() {

--- a/crates/trusty-gworkspace/src/api/services/tasks.rs
+++ b/crates/trusty-gworkspace/src/api/services/tasks.rs
@@ -76,7 +76,7 @@ pub async fn complete_task(client: &BaseClient, args: Value) -> Result<Value> {
 }
 
 /// Why: Task list CRUD is small enough to share one tool action enum.
-/// What: Routes `list|create|delete|update` to `users/@me/lists` on the Tasks API.
+/// What: Routes `list|get|create|update|delete` to `users/@me/lists`.
 /// Test: Live API.
 pub async fn manage_task_lists(client: &BaseClient, args: Value) -> Result<Value> {
     let action = require_str(&args, "action")?;
@@ -84,6 +84,11 @@ pub async fn manage_task_lists(client: &BaseClient, args: Value) -> Result<Value
     match action {
         "list" => {
             let url = format!("{TASKS_API_BASE}/users/@me/lists");
+            client.get(&url, account).await
+        }
+        "get" => {
+            let id = require_str(&args, "tasklist_id")?;
+            let url = format!("{TASKS_API_BASE}/users/@me/lists/{id}");
             client.get(&url, account).await
         }
         "create" => {
@@ -106,9 +111,11 @@ pub async fn manage_task_lists(client: &BaseClient, args: Value) -> Result<Value
     }
 }
 
-/// Why: Task CRUD inside a list is the bulk of the Tasks API surface.
-/// What: Routes `list|get|create|update|delete|complete` to `lists/{id}/tasks`.
-/// Test: Live API.
+/// Why: Task CRUD inside a list is the bulk of the Tasks API surface, plus a
+/// cross-list search agents frequently need ("find the task about X").
+/// What: Routes `list|get|create|update|delete|complete|move|search` to
+/// `lists/{id}/tasks`; `search` fans out across every tasklist.
+/// Test: `search` filter is unit-tested via `task_matches`; live 200 deferred.
 pub async fn manage_tasks(client: &BaseClient, args: Value) -> Result<Value> {
     let action = require_str(&args, "action")?;
     let account = account_of(&args);
@@ -118,6 +125,12 @@ pub async fn manage_tasks(client: &BaseClient, args: Value) -> Result<Value> {
             let url = format!("{TASKS_API_BASE}/lists/{tasklist}/tasks");
             client.get(&url, account).await
         }
+        "get" => {
+            let id = require_str(&args, "task_id")?;
+            let url = format!("{TASKS_API_BASE}/lists/{tasklist}/tasks/{id}");
+            client.get(&url, account).await
+        }
+        "search" => search_tasks(client, account, &args).await,
         "create" => {
             let body = args
                 .get("task")
@@ -159,5 +172,93 @@ pub async fn manage_tasks(client: &BaseClient, args: Value) -> Result<Value> {
             client.post(&url, json!({}), account).await
         }
         other => Err(anyhow!("unknown action for manage_tasks: {other}")),
+    }
+}
+
+/// Why: The Tasks API has no cross-list search; agents need one call to find a
+/// task by keyword regardless of which list holds it.
+/// What: Lists every tasklist, then lists each list's tasks and keeps those
+/// whose title or notes contain `query` (case-insensitive). Each hit is
+/// annotated with its owning `tasklist_id`/`tasklist_title`.
+/// Test: The per-task predicate is unit-tested via `task_matches`.
+async fn search_tasks(client: &BaseClient, account: Option<&str>, args: &Value) -> Result<Value> {
+    let query = require_str(args, "query")?;
+    let needle = query.to_ascii_lowercase();
+    let show_completed = args
+        .get("show_completed")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+
+    let lists = client
+        .get(&format!("{TASKS_API_BASE}/users/@me/lists"), account)
+        .await?;
+    let list_items = lists
+        .get("items")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    // Sequential fan-out: a user has few tasklists (typically < 10), so this
+    // keeps the `&client` borrow trivial and avoids a `futures` dependency
+    // while remaining well within any practical latency budget.
+    let mut results = Vec::<Value>::new();
+    for list in &list_items {
+        let Some(list_id) = list.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let list_title = list.get("title").and_then(|v| v.as_str()).unwrap_or("");
+        let tasks_url = format!(
+            "{TASKS_API_BASE}/lists/{list_id}/tasks?showCompleted={show_completed}&showHidden=true&maxResults=100"
+        );
+        let tasks = client.get(&tasks_url, account).await?;
+        let items = tasks
+            .get("items")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        for task in items {
+            if task_matches(&task, &needle) {
+                results.push(json!({
+                    "tasklist_id": list_id,
+                    "tasklist_title": list_title,
+                    "id": task.get("id"),
+                    "title": task.get("title"),
+                    "notes": task.get("notes"),
+                    "due": task.get("due"),
+                    "status": task.get("status"),
+                }));
+            }
+        }
+    }
+    Ok(json!({ "query": query, "count": results.len(), "results": results }))
+}
+
+/// Why: The cross-list search filter must be pure to be unit-testable offline.
+/// What: Returns true when the (already-lowercased) `needle` is a substring of
+/// the task's title or notes.
+/// Test: `task_matches_title_and_notes` below.
+fn task_matches(task: &Value, needle_lower: &str) -> bool {
+    let title = task.get("title").and_then(|v| v.as_str()).unwrap_or("");
+    let notes = task.get("notes").and_then(|v| v.as_str()).unwrap_or("");
+    title.to_ascii_lowercase().contains(needle_lower)
+        || notes.to_ascii_lowercase().contains(needle_lower)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_matches_title_and_notes() {
+        let t = json!({ "title": "Ship the Release", "notes": "coordinate with QA" });
+        // Case-insensitive substring on the title.
+        assert!(task_matches(&t, "release"));
+        // Match in the notes field.
+        assert!(task_matches(&t, "qa"));
+        // No match.
+        assert!(!task_matches(&t, "invoice"));
+        // Missing fields must not panic and must not match.
+        let empty = json!({});
+        assert!(!task_matches(&empty, "anything"));
     }
 }

--- a/crates/trusty-gworkspace/src/api/services/tasks.rs
+++ b/crates/trusty-gworkspace/src/api/services/tasks.rs
@@ -177,10 +177,12 @@ pub async fn manage_tasks(client: &BaseClient, args: Value) -> Result<Value> {
 
 /// Why: The Tasks API has no cross-list search; agents need one call to find a
 /// task by keyword regardless of which list holds it.
-/// What: Lists every tasklist, then lists each list's tasks and keeps those
-/// whose title or notes contain `query` (case-insensitive). Each hit is
-/// annotated with its owning `tasklist_id`/`tasklist_title`.
-/// Test: The per-task predicate is unit-tested via `task_matches`.
+/// What: Lists every tasklist (fully paginated), then lists each list's tasks
+/// (also fully paginated) and keeps those whose title or notes contain
+/// `query` (case-insensitive). Each hit is annotated with its owning
+/// `tasklist_id`/`tasklist_title`.
+/// Test: The per-task predicate is unit-tested via `task_matches`; the
+/// pagination termination condition via `next_page_token_present_and_absent`.
 async fn search_tasks(client: &BaseClient, account: Option<&str>, args: &Value) -> Result<Value> {
     let query = require_str(args, "query")?;
     let needle = query.to_ascii_lowercase();
@@ -189,14 +191,12 @@ async fn search_tasks(client: &BaseClient, account: Option<&str>, args: &Value) 
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
 
-    let lists = client
-        .get(&format!("{TASKS_API_BASE}/users/@me/lists"), account)
-        .await?;
-    let list_items = lists
-        .get("items")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
+    let list_items = fetch_all_items(
+        client,
+        account,
+        &format!("{TASKS_API_BASE}/users/@me/lists?maxResults=100"),
+    )
+    .await?;
 
     // Sequential fan-out: a user has few tasklists (typically < 10), so this
     // keeps the `&client` borrow trivial and avoids a `futures` dependency
@@ -210,12 +210,7 @@ async fn search_tasks(client: &BaseClient, account: Option<&str>, args: &Value) 
         let tasks_url = format!(
             "{TASKS_API_BASE}/lists/{list_id}/tasks?showCompleted={show_completed}&showHidden=true&maxResults=100"
         );
-        let tasks = client.get(&tasks_url, account).await?;
-        let items = tasks
-            .get("items")
-            .and_then(|v| v.as_array())
-            .cloned()
-            .unwrap_or_default();
+        let items = fetch_all_items(client, account, &tasks_url).await?;
         for task in items {
             if task_matches(&task, &needle) {
                 results.push(json!({
@@ -231,6 +226,57 @@ async fn search_tasks(client: &BaseClient, account: Option<&str>, args: &Value) 
         }
     }
     Ok(json!({ "query": query, "count": results.len(), "results": results }))
+}
+
+/// Fetch every page of a paginated Tasks API list endpoint, concatenating
+/// each page's `items` array.
+///
+/// Why: Both `/users/@me/lists` and `lists/{id}/tasks` paginate via
+/// `nextPageToken`; a single unpaged GET silently truncates results once an
+/// account has many tasklists, or a list has many tasks — a false negative
+/// that defeats the point of a cross-list `search`.
+/// What: GETs `base_url` (which already carries its own query string),
+/// collects `items`, and follows `nextPageToken` by appending
+/// `&pageToken=...` until the API stops returning one.
+/// Test: The termination predicate is unit-tested via `next_page_token`;
+/// the loop itself is live-only (network).
+async fn fetch_all_items(
+    client: &BaseClient,
+    account: Option<&str>,
+    base_url: &str,
+) -> Result<Vec<Value>> {
+    let mut items = Vec::new();
+    let mut page_token: Option<String> = None;
+    loop {
+        let url = match &page_token {
+            Some(tok) => format!("{base_url}&pageToken={tok}"),
+            None => base_url.to_string(),
+        };
+        let page = client.get(&url, account).await?;
+        if let Some(arr) = page.get("items").and_then(|v| v.as_array()) {
+            items.extend(arr.iter().cloned());
+        }
+        page_token = next_page_token(&page);
+        if page_token.is_none() {
+            break;
+        }
+    }
+    Ok(items)
+}
+
+/// Extract the next-page continuation token from a Tasks API list response.
+///
+/// Why: Isolating the termination condition as a pure function lets the
+/// pagination loop's stopping behavior be unit-tested without a live HTTP
+/// round-trip.
+/// What: Returns `Some(token)` when `nextPageToken` is present and non-empty,
+/// else `None`.
+/// Test: `next_page_token_present_and_absent` below.
+fn next_page_token(page: &Value) -> Option<String> {
+    page.get("nextPageToken")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from)
 }
 
 /// Why: The cross-list search filter must be pure to be unit-testable offline.
@@ -260,5 +306,19 @@ mod tests {
         // Missing fields must not panic and must not match.
         let empty = json!({});
         assert!(!task_matches(&empty, "anything"));
+    }
+
+    #[test]
+    fn next_page_token_present_and_absent() {
+        let with_token = json!({ "items": [], "nextPageToken": "abc123" });
+        assert_eq!(next_page_token(&with_token).as_deref(), Some("abc123"));
+
+        let without_token = json!({ "items": [] });
+        assert_eq!(next_page_token(&without_token), None);
+
+        // An empty-string token must be treated as "no more pages", not as
+        // a token to loop forever on.
+        let empty_token = json!({ "items": [], "nextPageToken": "" });
+        assert_eq!(next_page_token(&empty_token), None);
     }
 }

--- a/crates/trusty-gworkspace/src/tools/drive.rs
+++ b/crates/trusty-gworkspace/src/tools/drive.rs
@@ -35,11 +35,17 @@ pub(super) fn append(tools: &mut Vec<Value>) {
     ));
     tools.push(tool(
         "get_drive_file_content",
-        "Fetch the textual content of a Drive file (auto-exports Google native docs).",
+        "Fetch a Drive file's content (auto-exports Google native docs). Text is returned inline; binary files are base64-encoded, or written to disk when save_path is set.",
         json!({
             "account": account_schema(),
             "file_id": { "type": "string" },
             "export_mime_type": { "type": "string", "description": "Override export MIME for Google native files." },
+            "save_path": { "type": "string", "description": "If set, the raw bytes are written to this local path (required for large binaries)." },
+            "output_format": {
+                "type": "string",
+                "enum": ["auto", "raw"],
+                "description": "auto: text inline / binary base64 (default). raw: always treat as bytes (base64 or save_path).",
+            },
         }),
         &["file_id"],
     ));

--- a/crates/trusty-gworkspace/src/tools/drive.rs
+++ b/crates/trusty-gworkspace/src/tools/drive.rs
@@ -57,13 +57,16 @@ pub(super) fn append(tools: &mut Vec<Value>) {
     ));
     tools.push(tool(
         "manage_drive_file",
-        "Create folders, rename/move/copy/trash/delete files in Drive.",
+        "Create folders, rename/move/copy/trash/delete, or upload files in Drive.",
         json!({
             "account": account_schema(),
-            "action": action_enum(&["create_folder", "rename", "trash", "delete", "copy", "move"]),
+            "action": action_enum(&["create_folder", "rename", "trash", "delete", "copy", "move", "upload"]),
             "file_id": { "type": "string" },
-            "name": { "type": "string" },
-            "parent_id": { "type": "string" },
+            "name": { "type": "string", "description": "New/target file or folder name (required for create_folder, rename, upload)." },
+            "parent_id": { "type": "string", "description": "Parent folder id (target for move/upload, optional for create_folder)." },
+            "local_path": { "type": "string", "description": "upload: read bytes from this local file." },
+            "content": { "type": "string", "description": "upload: inline text content (alternative to local_path)." },
+            "mime_type": { "type": "string", "description": "upload: MIME type of the content (guessed from local_path extension, else text/plain)." },
         }),
         &["action"],
     ));

--- a/crates/trusty-gworkspace/src/tools/gmail.rs
+++ b/crates/trusty-gworkspace/src/tools/gmail.rs
@@ -55,17 +55,24 @@ pub(super) fn append(tools: &mut Vec<Value>) {
     ));
     tools.push(tool(
         "compose_email",
-        "Send, draft, or send-an-existing-draft email via Gmail.",
+        "Send, draft, send-an-existing-draft, or reply to email via Gmail, with attachments and HTML.",
         json!({
             "account": account_schema(),
-            "action": action_enum(&["send", "draft", "send_draft"]),
-            "to": { "type": "string" },
+            "action": action_enum(&["send", "draft", "send_draft", "reply"]),
+            "to": { "type": "string", "description": "Recipient(s). Optional for reply (defaults to the original sender)." },
             "cc": { "type": "string" },
             "bcc": { "type": "string" },
-            "subject": { "type": "string" },
-            "body": { "type": "string" },
-            "html": { "type": "boolean" },
+            "subject": { "type": "string", "description": "Optional for reply (defaults to 'Re: <original subject>')." },
+            "body": { "type": "string", "description": "Plain-text body." },
+            "html_body": { "type": "string", "description": "HTML body; sent as a text/html alternative alongside `body` when both are present." },
+            "html": { "type": "boolean", "description": "Legacy: if true and no html_body, `body` is treated as HTML." },
+            "message_id": { "type": "string", "description": "Required when action=reply: the message being replied to." },
             "draft_id": { "type": "string", "description": "Required when action=send_draft." },
+            "attachments": {
+                "type": "array",
+                "description": "Attachments: a local path string, or an object {path|local_path}, {content(base64), filename}, or {driveFileId, filename?}.",
+                "items": { "type": ["string", "object"] },
+            },
         }),
         &[],
     ));

--- a/crates/trusty-gworkspace/src/tools/tasks.rs
+++ b/crates/trusty-gworkspace/src/tools/tasks.rs
@@ -15,11 +15,11 @@ use serde_json::{Value, json};
 pub(super) fn append(tools: &mut Vec<Value>) {
     tools.push(tool(
         "manage_task_lists",
-        "CRUD Google Tasks lists.",
+        "CRUD Google Tasks lists (list, get one by id, create, update, delete).",
         json!({
             "account": account_schema(),
-            "action": action_enum(&["list", "create", "update", "delete"]),
-            "tasklist_id": { "type": "string" },
+            "action": action_enum(&["list", "get", "create", "update", "delete"]),
+            "tasklist_id": { "type": "string", "description": "Required for get/update/delete." },
             "title": { "type": "string" },
             "updates": { "type": "object" },
         }),
@@ -27,16 +27,18 @@ pub(super) fn append(tools: &mut Vec<Value>) {
     ));
     tools.push(tool(
         "manage_tasks",
-        "CRUD or complete/move tasks within a Google Tasks list.",
+        "CRUD, complete/move, get one, or search tasks within Google Tasks lists.",
         json!({
             "account": account_schema(),
-            "action": action_enum(&["list", "create", "update", "delete", "complete", "move"]),
+            "action": action_enum(&["list", "get", "create", "update", "delete", "complete", "move", "search"]),
             "tasklist_id": { "type": "string" },
-            "task_id": { "type": "string" },
+            "task_id": { "type": "string", "description": "Required for get/update/delete/complete/move." },
             "task": { "type": "object" },
             "updates": { "type": "object" },
             "parent": { "type": "string" },
             "previous": { "type": "string" },
+            "query": { "type": "string", "description": "search: case-insensitive substring matched against task title/notes across all lists." },
+            "show_completed": { "type": "boolean", "description": "search: include completed tasks (default true)." },
         }),
         &["action"],
     ));


### PR DESCRIPTION
Brings `trusty-gworkspace` toward parity with the Python upstream `bobmatnyc/gworkspace-mcp` v0.5.8. Four correctness/parity fixes, one commit each. Part of epic #2626.

## Fixes

### 1. Drive binary-download corruption — `get_drive_file_content` (Closes #2627)
`.text()` was called on the `alt=media` response for every file, forcing binary content (images/PDFs/zips) through lossy UTF-8 decoding. Now fetches raw bytes (new `BaseClient::get_bytes`) and branches on MIME: text stays inline as `content`; binary is base64-encoded (`encoding: "base64"`); `save_path` writes exact bytes to disk; `output_format: "raw"` forces the binary path. Mirrors Python's `output_format: auto|raw` + `save_path`.

### 2. `upload` action for `manage_drive_file` (Closes #2628)
Adds the missing upload path. Accepts `local_path` (bytes from disk, MIME guessed from extension) or inline `content` + `mime_type`, and POSTs a correctly-framed `multipart/related` body to the Drive multipart upload endpoint, with optional `parent_id`.

### 3. Tasks `get` + `search` (Closes #2629)
`manage_task_lists` gains `get` (one tasklist by id). `manage_tasks` gains `get` (one task by id) and `search` — a cross-tasklist case-insensitive substring search over title/notes, annotating each hit with its owning tasklist. Fan-out is sequential (few tasklists; no `futures` dep).

### 4. `reply` action + attachments + `html_body` for `compose_email` (Closes #2630)
Adds `reply` (fetches the original to set `In-Reply-To`/`References` + `threadId`, defaulting To/Subject), `attachments` (local path / inline base64 / `driveFileId` fetched from Drive), and `html_body` (multipart/alternative alongside plain `body`). MIME construction lives in a focused new `gmail/compose.rs`; all leaf parts use base64 transfer-encoding.

## Shared plumbing
- `BaseClient` refactored onto a `ReqBody` enum so the raw-bytes GET (`get_bytes`) and raw-body POST (`post_raw`, used by Drive upload) reuse the single 401-refresh-retry path.
- Shared `guess_mime_from_path` helper (Drive upload + Gmail attachments).
- Auth models under `src/api/auth/**` were **not** touched (token-file format stays serde-compatible with the Python `tokens.json`).

## Testing / validation
Gate is green: `cargo build` / `cargo test` (25 lib tests pass) / `cargo clippy --all-targets -D warnings` (0 warnings) / `cargo fmt --check` / `scripts/check_line_cap.sh` (0 violations). New unit tests cover MIME/binary branching, multipart body framing, base64url raw encoding, the cross-tasklist search filter, reply-header/References chaining, and MIME guessing.

**Deferred:** this crate could not be live end-to-end tested this session — the stored OAuth tokens are expired and refresh needs `GOOGLE_OAUTH_CLIENT_ID`/`_SECRET`, which are not set. Live 200 validation against Google APIs is deferred pending OAuth/creds. Logic testable offline is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)