### PR TITLE
chore(trusty-agents): repoint gworkspace MCP to native + retire dead external stubs

### DIFF
--- a/crates/trusty-agents/src/mcp/config/defaults.rs
+++ b/crates/trusty-agents/src/mcp/config/defaults.rs
@@ -18,15 +18,25 @@ pub(super) const DEFAULT_CONFIG_TOML: &str = r#"# trusty-agents global configura
 # Agent roles that receive MCP tool descriptions in their system prompt
 inject_for_roles = ["ctrl", "pm", "research", "observe"]
 
-# Remote and service-tier MCPs — these are external platforms agents can reference.
-# Local native integrations (kuzu-memory, mcp-vector-search) are handled by the
-# harness directly and do not appear here.
+# Service-tier MCPs agents can reference. Local native integrations
+# (kuzu-memory, mcp-vector-search) are handled by the harness directly and
+# do not appear here.
 
+# gworkspace-mcp — the NATIVE in-workspace stdio MCP server built from crate
+# `trusty-gworkspace` (bin `gworkspace-mcp`, src/bin/gworkspace-mcp.rs). Per
+# ADR-0014 (native Rust MCP, PR #2624) this repoints off the retired external
+# Python upstream: the native binary is a pure stdio server that takes NO
+# subcommand, so `args = []` (the old external upstream required `["mcp"]`).
+#
+# ⚠️ NAME COLLISION: the native cargo-installed `gworkspace-mcp` and the legacy
+# pipx Python package share the same binary name on $PATH, so which one launches
+# depends on PATH order. `args = []` targets the native contract, but full
+# disambiguation needs a binary rename (follow-up) or removing the pipx package.
 [[mcp.services]]
 name = "gworkspace-mcp"
-description = "Google Workspace — Gmail, Calendar, Drive, Docs, Sheets, Tasks"
+description = "Google Workspace (native trusty-gworkspace) — Gmail, Calendar, Drive, Docs, Sheets, Tasks"
 command = "gworkspace-mcp"
-args = ["mcp"]
+args = []
 transport = "stdio"
 enabled = true
 
@@ -102,25 +112,9 @@ description = "Create a Google Task"
 name = "tasks_complete"
 description = "Mark a Google Task as complete"
 
-[[mcp.services]]
-name = "slack-user-proxy"
-description = "Slack messaging — send messages, read channels, search"
-command = "slack-user-proxy"
-args = []
-transport = "stdio"
-enabled = false
-
-[[mcp.services.tools]]
-name = "slack_post"
-description = "Post a message to a Slack channel"
-
-[[mcp.services.tools]]
-name = "slack_search"
-description = "Search Slack messages"
-
-[[mcp.services.tools]]
-name = "slack_read"
-description = "Read messages from a Slack channel"
+# slack-user-proxy retired per ADR-0014 (native Rust MCP, PR #2624): it was a
+# disabled external (Python) stdio stub with no native in-workspace successor,
+# so it is dropped rather than repointed.
 
 # Granola — meeting notes, transcripts, and action items (#256).
 # Enabled by default; harmless when the binary is absent (the harness
@@ -285,17 +279,7 @@ eager_discovery = true
 [tool_registry.endpoints.transport]
 timeout_ms = 5000
 
-[[tool_registry.endpoints]]
-name = "commons-ticketing"
-driver = "direct"
-description = "Commons ticketing — create/update/close GitHub issues and PRs via OpenRPC stdio"
-command = "commons-ticketing"
-args = ["--rpc"]
-enabled = false
-scopes = ["ticketing.read", "ticketing.write", "ticketing.admin"]
-discovery_ttl_secs = 300
-eager_discovery = true
-
-[tool_registry.endpoints.transport]
-timeout_ms = 5000
+# commons-ticketing retired per ADR-0014 (native Rust MCP, PR #2624): a disabled
+# external OpenRPC stub with no consumers, superseded by the native tickets-mcp
+# endpoint above.
 "#;

--- a/crates/trusty-agents/src/mcp/config/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/mod.rs
@@ -8,8 +8,8 @@
 //! What: `GlobalConfig` is the on-disk schema (formerly `McpConfig`; renamed
 //! in #245 to reflect that it composes multiple subsystems — MCP registry +
 //! GitHub identities — rather than only MCP). `load_or_create()` creates the
-//! file with default content (gworkspace-mcp enabled + slack-user-proxy
-//! disabled) when missing. The registry only lists *remote/service-tier*
+//! file with default content (native gworkspace-mcp enabled) when missing.
+//! The registry only lists *remote/service-tier*
 //! MCPs that agents should know about — local native integrations
 //! (kuzu-memory, mcp-vector-search) are wired into the harness directly and
 //! deliberately do not appear here.
@@ -176,7 +176,7 @@ impl GlobalConfig {
     /// changes made via the `mcp_*` tools. When the file is missing the
     /// prompt-build path must not fail — and previously it returned an empty
     /// registry (`Self::default()`), which silently dropped the documented
-    /// gworkspace-mcp + slack-user-proxy defaults from in-memory state. We
+    /// native gworkspace-mcp defaults from in-memory state. We
     /// now parse `DEFAULT_CONFIG_TOML` so the in-memory defaults match what
     /// `load_or_create` would write to disk. Parse failure (a programmer
     /// error in the literal) falls back to `Self::default()` rather than
@@ -202,7 +202,7 @@ impl GlobalConfig {
     /// dispatch (called from async contexts).
     /// What: Reads `$HOME/.trusty-agents/config.toml` via `tokio::fs`. If the
     /// file is missing returns `default_config()` (the documented defaults
-    /// — gworkspace-mcp + slack-user-proxy). Parse failures log a warning
+    /// — native gworkspace-mcp). Parse failures log a warning
     /// and fall back to the same defaults rather than failing loudly.
     /// Test: `tests::load_returns_documented_defaults_when_absent`,
     /// `tests::save_and_reload_roundtrip`.

--- a/crates/trusty-agents/src/mcp/config/tests/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/mod.rs
@@ -44,9 +44,10 @@ async fn load_or_create_writes_default_when_absent() {
         "config file should exist after load_or_create"
     );
 
-    // Defaults (#256): gworkspace-mcp (enabled), slack-user-proxy (disabled),
-    // granola-notes (enabled), duetto-memory (disabled).
-    assert_eq!(cfg.mcp.services.len(), 4);
+    // Defaults after ADR-0014 (#256, native-MCP retire): gworkspace-mcp
+    // (enabled, native), granola-notes (enabled), duetto-memory (disabled).
+    // slack-user-proxy was retired as a dead external stub.
+    assert_eq!(cfg.mcp.services.len(), 3);
     let gw = cfg
         .mcp
         .services
@@ -54,13 +55,13 @@ async fn load_or_create_writes_default_when_absent() {
         .find(|s| s.name == "gworkspace-mcp")
         .expect("gworkspace-mcp present in defaults");
     assert!(gw.enabled);
-    let slack = cfg
-        .mcp
-        .services
-        .iter()
-        .find(|s| s.name == "slack-user-proxy")
-        .expect("slack-user-proxy present in defaults");
-    assert!(!slack.enabled);
+    assert!(
+        !cfg.mcp
+            .services
+            .iter()
+            .any(|s| s.name == "slack-user-proxy"),
+        "slack-user-proxy retired per ADR-0014"
+    );
     let granola = cfg
         .mcp
         .services
@@ -136,9 +137,9 @@ enabled = true
 #[tokio::test]
 async fn load_returns_documented_defaults_when_absent() {
     // (#244, #245) load() must not create the file (unlike load_or_create),
-    // but must return the documented defaults (gworkspace-mcp +
-    // slack-user-proxy) so prompt-build paths see the same registry that
-    // `load_or_create` would write.
+    // but must return the documented defaults (native gworkspace-mcp,
+    // granola-notes, duetto-memory) so prompt-build paths see the same registry
+    // that `load_or_create` would write.
     let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let home = tempdir();
     unsafe {
@@ -147,12 +148,12 @@ async fn load_returns_documented_defaults_when_absent() {
     let cfg = GlobalConfig::load().await;
     let path = home.join(".trusty-agents").join("config.toml");
     assert!(!path.exists(), "load() must not create the config file");
-    // #245/#256: defaults now mirror DEFAULT_CONFIG_TOML — 4 services
-    // (gworkspace-mcp, slack-user-proxy, granola-notes, duetto-memory).
-    assert_eq!(cfg.mcp.services.len(), 4);
+    // #245/#256 + ADR-0014: defaults mirror DEFAULT_CONFIG_TOML — 3 services
+    // (gworkspace-mcp, granola-notes, duetto-memory) after slack-user-proxy retire.
+    assert_eq!(cfg.mcp.services.len(), 3);
     assert!(cfg.mcp.services.iter().any(|s| s.name == "gworkspace-mcp"));
     assert!(
-        cfg.mcp
+        !cfg.mcp
             .services
             .iter()
             .any(|s| s.name == "slack-user-proxy")

--- a/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
@@ -234,7 +234,8 @@ fn default_config_includes_local_inference_section() {
 #[test]
 fn default_config_is_valid_toml() {
     let cfg = GlobalConfig::from_toml_str(DEFAULT_CONFIG_TOML).expect("default parses");
-    assert_eq!(cfg.mcp.services.len(), 4);
+    // ADR-0014: 3 services after slack-user-proxy retire.
+    assert_eq!(cfg.mcp.services.len(), 3);
     let gw = cfg
         .mcp
         .services
@@ -242,15 +243,17 @@ fn default_config_is_valid_toml() {
         .find(|s| s.name == "gworkspace-mcp")
         .expect("gworkspace-mcp present");
     assert!(gw.enabled);
+    // Native gworkspace-mcp takes no subcommand (external upstream used ["mcp"]).
+    assert!(gw.args.is_empty(), "native gworkspace-mcp takes no args");
     assert!(gw.tools.iter().any(|t| t.name == "gmail_search"));
     assert!(gw.tools.iter().any(|t| t.name == "calendar_list"));
-    let slack = cfg
-        .mcp
-        .services
-        .iter()
-        .find(|s| s.name == "slack-user-proxy")
-        .expect("slack-user-proxy present");
-    assert!(!slack.enabled);
+    assert!(
+        !cfg.mcp
+            .services
+            .iter()
+            .any(|s| s.name == "slack-user-proxy"),
+        "slack-user-proxy retired per ADR-0014"
+    );
     // Native local integrations stay out of the registry.
     assert!(!cfg.mcp.services.iter().any(|s| s.name == "kuzu-memory"));
     assert!(

--- a/crates/trusty-agents/src/tools/mcp_tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mcp_tools/mod.rs
@@ -108,9 +108,9 @@ mod tests {
         assert!(out.contains("beta"));
 
         // Verify it persists by reloading. Note: #245 — load() now returns
-        // documented defaults (gworkspace-mcp + slack-user-proxy) when the
-        // file doesn't exist, so mcp_add against a missing file persists
-        // those defaults plus the new "beta" service (3 total).
+        // documented defaults (native gworkspace-mcp, granola-notes,
+        // duetto-memory) when the file doesn't exist, so mcp_add against a
+        // missing file persists those defaults plus the new "beta" service.
         let reloaded = GlobalConfig::load().await;
         let beta = reloaded
             .mcp

--- a/docs/specs/SPEC-MCPSVC-01-trusty-mcp-service.md
+++ b/docs/specs/SPEC-MCPSVC-01-trusty-mcp-service.md
@@ -1,6 +1,16 @@
 # DOC-27 — `trusty-mcp-service`: Unified Native Sidecar Services via MCP-A
 
-**Status:** Draft
+> **⚠️ SUPERSEDED BY ADR-0014 (native Rust MCP, PR #2624).** The unified
+> `trusty-mcp-service` / MCP-A gateway approach described below was **not**
+> adopted. Its intent — retiring the out-of-band Python sidecars (`gworkspace-mcp`,
+> `slack-mpm`) in favor of native Rust MCP servers — is instead delivered directly:
+> each service ships as its own native stdio MCP binary in-workspace (e.g. the
+> `gworkspace-mcp` binary in crate `trusty-gworkspace`), wired into
+> `trusty-agents`' default MCP config rather than through a single MCP-A gateway.
+> This document is retained for historical/design context only; do not implement
+> against it. See the closed tracking work under #1606.
+
+**Status:** Superseded (was: Draft)
 **Subsystem:** trusty-mcp-service (new) — unified native sidecar services / MCP-A gateway
 **Owner:** Engineering (Bob Matsuoka)
 **Last-updated:** 2026-06-23


### PR DESCRIPTION
Removes the last external/non-Rust MCP wiring from `trusty-agents`' default MCP config and retires dead stubs, per **ADR-0014** (native Rust MCP, PR #2624). Surgical, single-crate change (+ one doc banner).

## Changes (`crates/trusty-agents/src/mcp/config/defaults.rs` unless noted)

1. **Repoint `gworkspace-mcp` `[[mcp.services]]` to the native binary.** Was launching the external Python upstream via `args = ["mcp"]`. The native in-workspace binary (crate `trusty-gworkspace`, `src/bin/gworkspace-mcp.rs`) is a pure stdio MCP server that takes **no** subcommand, so `args` is now `[]`. Description/comment updated to flag it as native.
   - ⚠️ **Residual name-collision (documented, not fully resolved):** the native cargo-installed `gworkspace-mcp` and the legacy pipx Python package share the same binary name on `$PATH`, so which one launches depends on PATH order. `args = []` makes the config target the native contract unambiguously (native ignores args; the external upstream *required* `["mcp"]`), but full disambiguation needs a **binary rename** (e.g. `trusty-gworkspace-mcp`) or removing the pipx package. Recommend a follow-up issue — not forced here per scope.

2. **Retire `slack-user-proxy` `[[mcp.services]]` stub.** Grep confirmed it is a disabled external Python stdio stub referenced only by default-shape tests, with **no native in-workspace successor** (the `tm slack` CLI command is unrelated). Dropped rather than repointed.

3. **Retire `commons-ticketing` `tool_registry` endpoint.** Grep confirmed it appears **only** in `defaults.rs` — a disabled external OpenRPC stub with zero consumers, superseded by the native `tickets-mcp` endpoint. Removed cleanly.

4. **Test + doc-comment updates.** Default service count 4 → 3 (`gworkspace-mcp`, `granola-notes`, `duetto-memory`); added a positive assertion that native `gworkspace-mcp` carries no args and that `slack-user-proxy` is gone. Refreshed stale enumerations in `config/mod.rs` and `tools/mcp_tools/mod.rs`. Render-logic unit-test fixtures (which use `slack-user-proxy` as a synthetic disabled-service example) left as-is — they don't depend on the defaults.

5. **`docs/specs/SPEC-MCPSVC-01-trusty-mcp-service.md`:** added a **SUPERSEDED BY ADR-0014** banner at the top (the unified `trusty-mcp-service`/MCP-A gateway approach was not adopted; native per-service binaries deliver the intent). History preserved — not deleted.

**Out of scope / untouched:** `granola-notes` (third-party), `duetto-memory` (Duetto infra), and `tickets-mcp` (left disabled — separate consolidation effort). Native MCP servers themselves unchanged.

## Verification

```
cargo build -p trusty-agents            → Finished (clean)
cargo test  -p trusty-agents            → 1783 passed; 0 failed; 7 ignored (+ integration suites all ok)
cargo clippy -p trusty-agents --all-targets -- -D warnings → Finished, no warnings
cargo fmt --check                       → clean
bash scripts/check_line_cap.sh          → 10 allowlisted, 0 violations — OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)