### PR TITLE
feat(trusty-slack): scaffold native Slack MCP server crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11276,6 +11276,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "trusty-slack"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "trusty-common",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/trusty-slack/Cargo.toml
+++ b/crates/trusty-slack/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "trusty-slack"
+version = "0.1.0"
+publish = false
+edition = "2021"
+description = "Native Slack MCP server (chat-as-tools) for the Trusty suite — scaffold"
+license.workspace = true
+
+[lib]
+crate-type = ["rlib"]
+
+[[bin]]
+name = "slack-mcp"
+path = "src/bin/slack-mcp.rs"
+
+[dependencies]
+trusty-common = { workspace = true, features = ["mcp"] }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+tracing = { workspace = true }

--- a/crates/trusty-slack/README.md
+++ b/crates/trusty-slack/README.md
@@ -1,0 +1,96 @@
+# trusty-slack
+
+Native Slack MCP server (chat-as-tools) for the Trusty suite.
+
+> **Status: scaffold.** This crate is the skeleton of a native-Rust Slack
+> [Model Context Protocol](https://modelcontextprotocol.io/) server. The tool
+> schemas below are authoritative and the MCP handshake works, but every
+> `tools/call` handler is a stub that returns a clear `not-yet-implemented`
+> error. **Live Slack Web API calls and authentication are deferred** pending a
+> token (bot vs user) decision. See ADR-0014.
+
+## Installation
+
+```sh
+cargo install --path crates/trusty-slack
+```
+
+This installs the `slack-mcp` binary into `~/.cargo/bin`.
+
+## Quick Start
+
+1. **Wire into Claude Code** (or any MCP client):
+
+   ```jsonc
+   // ~/.claude.json
+   {
+     "mcpServers": {
+       "slack": {
+         "command": "slack-mcp"
+       }
+     }
+   }
+   ```
+
+2. **Handshake works today.** `initialize` and `tools/list` return real
+   responses; the model can discover the planned tool surface. Calling any tool
+   currently returns a JSON-RPC error explaining that the live call is deferred.
+
+## Tool Surface (planned / stubbed)
+
+Nine chat-as-tools operations. Schemas are authoritative; handlers are stubs.
+
+| Tool | Purpose | Status |
+|------|---------|--------|
+| `slack_send_message`    | Post a message (or thread reply) to a channel | stubbed |
+| `slack_read_channel`    | Read recent messages from a channel            | stubbed |
+| `slack_read_thread`     | Read all replies in a thread                   | stubbed |
+| `slack_list_channels`   | List visible channels                          | stubbed |
+| `slack_search_messages` | Search messages across the workspace           | stubbed |
+| `slack_search_channels` | Search channels by name/topic                  | stubbed |
+| `slack_list_users`      | List workspace users                           | stubbed |
+| `slack_get_user`        | Fetch a single user's profile                  | stubbed |
+| `slack_add_reaction`    | Add an emoji reaction to a message             | stubbed |
+
+The authoritative list with JSON Schemas is in [`src/tools.rs`](src/tools.rs).
+
+## Configuration
+
+| Env var           | Purpose                                                            |
+|-------------------|-------------------------------------------------------------------|
+| `SLACK_BOT_TOKEN` | Slack token placeholder consulted at startup (auth wiring deferred) |
+| `RUST_LOG`        | Standard `tracing` filter (e.g. `trusty_slack=debug`)             |
+
+> Auth is not yet implemented. The intended source is
+> `trusty_common::inference::credentials` (env var / file store / OS keyring)
+> once the token decision is made — `SLACK_BOT_TOKEN` is only a documented
+> placeholder today.
+
+## Architecture
+
+Two layers, deliberately decoupled — mirroring `trusty-gworkspace`:
+
+- **`api::`** — pure Slack Web API client. `BaseClient` wraps a
+  `reqwest::Client` and holds a resolved token placeholder;
+  `api::constants` centralises the API base URL. (No live HTTP yet.)
+- **`server`** — MCP JSON-RPC dispatch. `handle_message` routes `initialize`,
+  `tools/list`, and `tools/call`; `run_stdio` wires it into
+  `trusty_common::mcp::run_stdio_loop`.
+
+Adding a live tool means: implement the Slack call in `api::`, replace the
+`NotImplemented` stub arm in `server::handle_tool_call`, and (if the surface
+changes) update the schema in `tools::tool_list_response`.
+
+## Testing
+
+```sh
+cargo test -p trusty-slack
+```
+
+Covers the `initialize` handshake, the `tools/list` shape/count, and that a
+`tools/call` returns the `not-yet-implemented` stub error. Live Slack API calls
+are out of scope until they are implemented.
+
+## License
+
+Licensed under the [MIT License](https://opensource.org/licenses/MIT).

--- a/crates/trusty-slack/src/api/client.rs
+++ b/crates/trusty-slack/src/api/client.rs
@@ -1,0 +1,73 @@
+//! BaseClient: authenticated HTTP wrapper over the Slack Web API (scaffold).
+//!
+//! Why: Every future Slack method (`chat.postMessage`, `conversations.history`,
+//! …) needs the same token + JSON-envelope handling. Centralising it here
+//! mirrors `trusty-gworkspace::api::client::BaseClient` and lets us add
+//! tracing / rate-limiting / retry in one place once live calls land.
+//! What: Holds a `reqwest::Client` and an optional resolved token. This is a
+//! *stub*: `new()` builds the HTTP client and records whether a token is
+//! present, but performs no network I/O and no interactive auth. The live
+//! request methods are intentionally absent until the token decision is made.
+//! Test: `new_succeeds_without_token` asserts construction works with no
+//! credentials configured (CI-safe, matching the gworkspace smoke test).
+
+use anyhow::{Context, Result};
+
+/// Authenticated Slack Web API client (scaffold).
+///
+/// Why: One handle per process; a future live implementation will send bearer
+/// tokens on every request and unwrap Slack's `{"ok": bool, ...}` envelope.
+/// What: Wraps a `reqwest::Client` and an `Option<String>` token placeholder.
+/// `token` is `None` when no credential is configured — construction still
+/// succeeds so `tools/list` and the MCP handshake work without secrets.
+/// Test: Smoke test asserts construction succeeds with no env vars set.
+pub struct BaseClient {
+    /// Shared HTTP client. Unused until live methods land; retained so the
+    /// constructor signature and connection-pool ownership match the final
+    /// shape and future handlers need no wiring changes.
+    #[allow(dead_code)]
+    http: reqwest::Client,
+    /// Resolved Slack token, or `None` when unconfigured.
+    #[allow(dead_code)]
+    token: Option<String>,
+}
+
+impl BaseClient {
+    /// Construct with a shared HTTP client and a best-effort token lookup.
+    ///
+    /// Why: The binary builds exactly one client at startup; keeping the
+    /// constructor infallible-on-missing-token (returns `Ok` with `token:
+    /// None`) means the server boots for `tools/list` without credentials.
+    /// What: Builds the `reqwest::Client`; resolves the token as a
+    /// placeholder. Returns `Err` only if the HTTP client fails to build.
+    ///
+    /// TODO(auth, deferred): resolve the token via
+    /// `trusty_common::inference::credentials` (its `resolve_key` /
+    /// `default_store` resolver — env var / file store / OS keyring) once the
+    /// bot-vs-user token decision is made. Do NOT implement live auth here yet;
+    /// the current lookup is a documented placeholder only. See ADR-0014.
+    pub fn new() -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .user_agent(concat!("trusty-slack/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .context("build reqwest client")?;
+        // Placeholder token resolution — deferred, see the TODO above.
+        let token = std::env::var(crate::api::constants::SLACK_TOKEN_ENV).ok();
+        Ok(Self { http, token })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_succeeds_without_token() {
+        // Constructing must not require any Slack credentials, so the MCP
+        // handshake and tools/list work in CI without secrets.
+        let client = BaseClient::new().expect("construct base client");
+        // Field is intentionally private; presence is asserted via Debug-free
+        // construction success. Nothing else to assert on a stub.
+        let _ = client;
+    }
+}

--- a/crates/trusty-slack/src/api/constants.rs
+++ b/crates/trusty-slack/src/api/constants.rs
@@ -1,0 +1,29 @@
+//! Slack Web API endpoint constants.
+//!
+//! Why: Centralise base URLs so future service/method modules don't drift on
+//! path roots and we can swap to an enterprise/Gov Slack endpoint in one place
+//! if needed.
+//! What: `const &str` for the Slack Web API root and the env var used to
+//! resolve a bot/user token. No string interpolation here — callers append
+//! method paths (e.g. `chat.postMessage`).
+//! Test: `base_url_parses` asserts the root parses as a valid `reqwest::Url`.
+
+/// Slack Web API root. Methods are appended, e.g. `{SLACK_API_BASE}/chat.postMessage`.
+pub const SLACK_API_BASE: &str = "https://slack.com/api";
+
+/// Environment variable consulted for a Slack token when credential
+/// resolution is wired up. The final auth source is deferred (see
+/// `client::BaseClient`); this constant documents the intended env fallback.
+pub const SLACK_TOKEN_ENV: &str = "SLACK_BOT_TOKEN";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_url_parses() {
+        let url = reqwest::Url::parse(SLACK_API_BASE).expect("SLACK_API_BASE is a valid URL");
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), Some("slack.com"));
+    }
+}

--- a/crates/trusty-slack/src/api/mod.rs
+++ b/crates/trusty-slack/src/api/mod.rs
@@ -1,0 +1,11 @@
+//! Slack Web API client layer.
+//!
+//! Why: Keep the pure HTTP/auth concerns isolated from MCP framing so the same
+//! client can be reused outside of MCP (CLI tools, tests, a future REST
+//! daemon), matching the `trusty-gworkspace` split.
+//! What: Re-exports the endpoint constants and the `BaseClient` HTTP wrapper.
+//! Test: Constants are smoke-tested in `constants`; the client constructor is
+//! smoke-tested in `client`.
+
+pub mod client;
+pub mod constants;

--- a/crates/trusty-slack/src/bin/slack-mcp.rs
+++ b/crates/trusty-slack/src/bin/slack-mcp.rs
@@ -1,0 +1,24 @@
+//! `slack-mcp` binary — stdio MCP server (scaffold).
+//!
+//! Why: Claude Code (and other MCP hosts) launch this process per session and
+//! talk to it over stdin/stdout JSON-RPC.
+//! What: Initialises tracing (to stderr, keeping stdout clean for JSON-RPC
+//! framing), builds an `AppState` with a shared `BaseClient`, then runs the
+//! stdio loop until EOF. Tool calls currently return a `not-yet-implemented`
+//! MCP error — live Slack API calls are deferred (see ADR-0014).
+//! Test: Manual via `claude mcp add` / direct stdin piping.
+
+use std::sync::Arc;
+
+use trusty_slack::api::client::BaseClient;
+use trusty_slack::server::{run_stdio, AppState};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    trusty_common::init_tracing(0);
+    let client = BaseClient::new()?;
+    let state = AppState {
+        client: Arc::new(client),
+    };
+    run_stdio(state).await
+}

--- a/crates/trusty-slack/src/lib.rs
+++ b/crates/trusty-slack/src/lib.rs
@@ -1,0 +1,20 @@
+//! Native Slack MCP server for the Trusty suite (scaffold).
+//!
+//! Why: The trusty-* ecosystem wants a single, native-Rust MCP surface over
+//! Slack (chat-as-tools) rather than depending on the hosted connector, so
+//! agents can send/read messages, list channels/users, search, and react
+//! through the same stdio JSON-RPC transport every other trusty MCP server
+//! uses. See ADR-0014.
+//! What: Two logical layers mirroring `trusty-gworkspace` — a pure Slack Web
+//! API client under `api::` (`BaseClient` + endpoint constants) and an MCP
+//! server in `server` + `bin/slack-mcp.rs` that dispatches `initialize`,
+//! `tools/list`, and `tools/call`. This is a *scaffold*: the tool schemas are
+//! authoritative, but every `tools/call` handler is a stub that returns a
+//! clear `not-yet-implemented` MCP error. Live Slack HTTP calls and auth are
+//! deferred pending a token decision.
+//! Test: `cargo test -p trusty-slack` covers the `initialize` handshake, the
+//! `tools/list` shape/count, and that a `tools/call` returns the stub error.
+
+pub mod api;
+pub mod server;
+pub mod tools;

--- a/crates/trusty-slack/src/server.rs
+++ b/crates/trusty-slack/src/server.rs
@@ -1,0 +1,227 @@
+//! MCP JSON-RPC dispatch + stdio loop for `slack-mcp`.
+//!
+//! Why: Every trusty-* MCP server shares the same shape — `initialize`,
+//! `tools/list`, `tools/call`, with notifications suppressed. Centralising it
+//! here means future Slack tool handlers focus on Slack Web API specifics.
+//! What: `AppState` holds an `Arc<BaseClient>`; `handle_message` is the pure
+//! JSON-RPC dispatcher; `handle_tool_call` is the (currently all-stub) tool
+//! router; `run_stdio` wires it into `trusty_common::mcp::run_stdio_loop`.
+//! Test: `handle_message_initialize_returns_server_info`,
+//! `handle_message_tools_list_returns_tools`, and
+//! `tools_call_returns_not_implemented` in `mod tests`.
+
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+use thiserror::Error;
+
+use crate::api::client::BaseClient;
+use trusty_common::mcp::{error_codes, initialize_response, run_stdio_loop, Request, Response};
+
+/// Shared state passed to every dispatcher invocation.
+///
+/// Why: Tool handlers will need the Slack client; nothing else is shared yet.
+/// What: `Clone`-able via `Arc<BaseClient>`.
+/// Test: Smoke-constructed in `mod tests`.
+#[derive(Clone)]
+pub struct AppState {
+    pub client: Arc<BaseClient>,
+}
+
+/// Error returned by the tool dispatcher.
+///
+/// Why: The scaffold must distinguish a known-but-unimplemented tool from a
+/// genuinely unknown one, and surface each as a proper JSON-RPC error rather
+/// than a panic (`todo!()`/`unimplemented!()` are banned here).
+/// What: A `thiserror` enum whose `code()` maps to a JSON-RPC error code.
+/// Test: `tools_call_returns_not_implemented` and
+/// `tools_call_unknown_tool_returns_method_not_found`.
+#[derive(Debug, Error)]
+pub enum ToolCallError {
+    /// A planned tool whose live handler has not been implemented yet.
+    #[error("tool '{0}' is not yet implemented: live Slack API calls are deferred pending the token decision (see ADR-0014)")]
+    NotImplemented(String),
+    /// A tool name that is not part of the planned surface at all.
+    #[error("unknown tool: {0}")]
+    UnknownTool(String),
+}
+
+impl ToolCallError {
+    /// JSON-RPC error code for this failure.
+    ///
+    /// Why: `handle_message` needs a numeric code for the wire response.
+    /// What: Unknown tools map to `METHOD_NOT_FOUND`; unimplemented (but
+    /// planned) tools map to `INTERNAL_ERROR`.
+    /// Test: Covered by the dispatcher tests.
+    pub fn code(&self) -> i32 {
+        match self {
+            ToolCallError::NotImplemented(_) => error_codes::INTERNAL_ERROR,
+            ToolCallError::UnknownTool(_) => error_codes::METHOD_NOT_FOUND,
+        }
+    }
+}
+
+/// Dispatch a single tool call by name.
+///
+/// Why: One routing table keeps the tool surface greppable; live handlers land
+/// on the matching arm here as each Slack method is implemented.
+/// What: Every planned tool currently routes to a `NotImplemented` stub;
+/// anything else is `UnknownTool`. The `_state`/`_args` are accepted now so the
+/// signature is stable when real handlers replace the stubs.
+/// Test: `tools_call_returns_not_implemented`.
+pub async fn handle_tool_call(
+    _state: &AppState,
+    name: &str,
+    _args: Value,
+) -> Result<Value, ToolCallError> {
+    if crate::tools::is_known_tool(name) {
+        // Stub: schema is authoritative, live call deferred (see ADR-0014).
+        return Err(ToolCallError::NotImplemented(name.to_string()));
+    }
+    Err(ToolCallError::UnknownTool(name.to_string()))
+}
+
+/// Translate a parsed JSON-RPC request into a JSON-RPC response payload.
+///
+/// Why: Same shape used across the trusty-* family — handle init, ping,
+/// notifications, tools/list, tools/call.
+/// What: Returns `Value::Null` for notifications (suppressed); returns an
+/// `{"error": {code, message}}` map for tool failures and unknown methods so
+/// `run_stdio` can emit a proper JSON-RPC error.
+/// Test: `handle_message_initialize_returns_server_info`,
+/// `tools_call_returns_not_implemented`, `unknown_method_returns_error_payload`.
+pub async fn handle_message(state: AppState, req: Value) -> Value {
+    let method = req["method"].as_str().unwrap_or("");
+    match method {
+        "initialize" => initialize_response("slack-mcp", env!("CARGO_PKG_VERSION"), None),
+        "notifications/initialized" | "notifications/cancelled" => Value::Null,
+        "ping" => json!({}),
+        "tools/list" => crate::tools::tool_list_response(),
+        "tools/call" => {
+            let params = &req["params"];
+            let name = params["name"].as_str().unwrap_or("");
+            let args = params.get("arguments").cloned().unwrap_or(Value::Null);
+            let args = if args.is_null() { json!({}) } else { args };
+            match handle_tool_call(&state, name, args).await {
+                Ok(result) => {
+                    let text = serde_json::to_string(&result).unwrap_or_default();
+                    json!({ "content": [{ "type": "text", "text": text }] })
+                }
+                Err(e) => json!({
+                    "error": { "code": e.code(), "message": e.to_string() }
+                }),
+            }
+        }
+        _ => json!({
+            "error": {
+                "code": error_codes::METHOD_NOT_FOUND,
+                "message": format!("Method not found: {method}"),
+            }
+        }),
+    }
+}
+
+/// Run the stdio MCP loop wired to this server.
+///
+/// Why: Single entry point for `bin/slack-mcp.rs`.
+/// What: Forwards every parsed `Request` to `handle_message` and wraps the
+/// JSON result back into a `Response` (or a JSON-RPC error / suppressed reply).
+/// Test: Manual — driven from Claude Code; the stdio loop itself is tested in
+/// `trusty-common`.
+pub async fn run_stdio(state: AppState) -> anyhow::Result<()> {
+    run_stdio_loop(move |req: Request| {
+        let state = state.clone();
+        async move {
+            let id = req.id.clone();
+            let raw = serde_json::to_value(&req).unwrap_or(Value::Null);
+            let resp = handle_message(state, raw).await;
+            if resp.is_null() {
+                return Response::suppressed();
+            }
+            if let Some(err) = resp.get("error") {
+                let code =
+                    err.get("code")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(error_codes::INTERNAL_ERROR as i64) as i32;
+                let message = err
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Internal error")
+                    .to_string();
+                return Response::err(id, code, message);
+            }
+            Response::ok(id, resp)
+        }
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_state() -> AppState {
+        // BaseClient::new() reads no required env vars and returns Ok, so this
+        // works in CI without any Slack credentials.
+        let client = BaseClient::new().expect("construct base client");
+        AppState {
+            client: Arc::new(client),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn handle_message_initialize_returns_server_info() {
+        let state = make_state();
+        let req = json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} });
+        let resp = handle_message(state, req).await;
+        assert_eq!(resp["serverInfo"]["name"], "slack-mcp");
+        assert!(resp["capabilities"]["tools"].is_object());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn handle_message_tools_list_returns_tools() {
+        let state = make_state();
+        let req = json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" });
+        let resp = handle_message(state, req).await;
+        let tools = resp["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), crate::tools::TOOL_NAMES.len());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tools_call_returns_not_implemented() {
+        let state = make_state();
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": { "name": "slack_send_message", "arguments": { "channel": "C1", "text": "hi" } }
+        });
+        let resp = handle_message(state, req).await;
+        assert_eq!(resp["error"]["code"], error_codes::INTERNAL_ERROR);
+        assert!(resp["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("not yet implemented"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tools_call_unknown_tool_returns_method_not_found() {
+        let state = make_state();
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": { "name": "slack_not_a_tool", "arguments": {} }
+        });
+        let resp = handle_message(state, req).await;
+        assert_eq!(resp["error"]["code"], error_codes::METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn unknown_method_returns_error_payload() {
+        let state = make_state();
+        let req = json!({ "jsonrpc": "2.0", "id": 5, "method": "no/such/method" });
+        let resp = handle_message(state, req).await;
+        assert_eq!(resp["error"]["code"], error_codes::METHOD_NOT_FOUND);
+    }
+}

--- a/crates/trusty-slack/src/tools.rs
+++ b/crates/trusty-slack/src/tools.rs
@@ -1,0 +1,240 @@
+//! MCP `tools/list` response — JSON Schema for every planned Slack tool.
+//!
+//! Why: Claude Code (and any MCP client) needs a machine-readable contract
+//! describing each tool's arguments so the model can fill them correctly. This
+//! is the single source of truth for the Slack MCP surface; the dispatcher in
+//! `server` routes on the same names. Every schema here is authoritative even
+//! though the handlers are still stubs (live calls deferred, see ADR-0014).
+//! What: `tool_list_response()` returns `{"tools": [{name, description,
+//! inputSchema}, ...]}`; `is_known_tool()` reports whether a name is part of
+//! the planned surface so the dispatcher can distinguish "not yet implemented"
+//! from "unknown tool".
+//! Test: Unit tests below assert the tool count, required-field shape, name
+//! uniqueness, and `is_known_tool` agreement with the registry.
+
+use serde_json::{json, Value};
+
+/// The authoritative list of planned Slack tool names.
+///
+/// Why: Both `tool_list_response` (indirectly) and `is_known_tool` must agree
+/// on the exact surface; a single constant array prevents drift.
+/// What: The nine chat-as-tools operations planned for the native Slack MCP.
+/// Test: `known_tools_match_registry` cross-checks this against the built list.
+pub const TOOL_NAMES: &[&str] = &[
+    "slack_send_message",
+    "slack_read_channel",
+    "slack_read_thread",
+    "slack_list_channels",
+    "slack_search_messages",
+    "slack_search_channels",
+    "slack_list_users",
+    "slack_get_user",
+    "slack_add_reaction",
+];
+
+/// Report whether `name` is a planned Slack tool.
+///
+/// Why: The dispatcher returns a distinct MCP error for an unknown tool vs a
+/// known-but-unimplemented one; this predicate draws that line.
+/// What: Linear membership check against `TOOL_NAMES`.
+/// Test: `known_tools_match_registry`.
+pub fn is_known_tool(name: &str) -> bool {
+    TOOL_NAMES.contains(&name)
+}
+
+/// Assemble a single MCP tool definition.
+///
+/// Why: The `tools/list` response requires a uniform `{name, description,
+/// inputSchema}` object per tool; centralising avoids drift.
+/// What: Wraps `properties` and `required` into an object-typed input schema
+/// alongside the name and description.
+/// Test: Covered via `tool_list_response()` in `tests`.
+fn tool(name: &str, description: &str, properties: Value, required: &[&str]) -> Value {
+    json!({
+        "name": name,
+        "description": description,
+        "inputSchema": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        }
+    })
+}
+
+/// A `channel` id/name string-schema fragment shared by several tools.
+fn channel_prop() -> Value {
+    json!({
+        "type": "string",
+        "description": "Channel ID (e.g. C0123ABCD) or name (e.g. #general).",
+    })
+}
+
+/// Build the full `tools/list` response.
+///
+/// Why: One function = one source of truth for the MCP contract.
+/// What: Returns the nine planned Slack tools with minimal-but-valid schemas.
+/// Test: `tool_list_has_expected_count` asserts exactly nine tools.
+pub fn tool_list_response() -> Value {
+    let tools = vec![
+        tool(
+            "slack_send_message",
+            "Post a message to a Slack channel (or reply in a thread).",
+            json!({
+                "channel": channel_prop(),
+                "text": { "type": "string", "description": "Message text to send." },
+                "thread_ts": {
+                    "type": "string",
+                    "description": "Optional parent message ts to reply in-thread.",
+                },
+            }),
+            &["channel", "text"],
+        ),
+        tool(
+            "slack_read_channel",
+            "Read recent messages from a Slack channel.",
+            json!({
+                "channel": channel_prop(),
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of messages to return (default 50).",
+                },
+            }),
+            &["channel"],
+        ),
+        tool(
+            "slack_read_thread",
+            "Read all replies in a Slack thread.",
+            json!({
+                "channel": channel_prop(),
+                "thread_ts": {
+                    "type": "string",
+                    "description": "The ts of the thread's parent message.",
+                },
+            }),
+            &["channel", "thread_ts"],
+        ),
+        tool(
+            "slack_list_channels",
+            "List channels visible to the authenticated principal.",
+            json!({
+                "types": {
+                    "type": "string",
+                    "description": "Comma-separated channel types (e.g. public_channel,private_channel).",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of channels to return.",
+                },
+            }),
+            &[],
+        ),
+        tool(
+            "slack_search_messages",
+            "Search messages across the workspace.",
+            json!({
+                "query": { "type": "string", "description": "Slack search query string." },
+                "count": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return.",
+                },
+            }),
+            &["query"],
+        ),
+        tool(
+            "slack_search_channels",
+            "Search channels by name or topic.",
+            json!({
+                "query": { "type": "string", "description": "Channel search query string." },
+            }),
+            &["query"],
+        ),
+        tool(
+            "slack_list_users",
+            "List users in the workspace.",
+            json!({
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of users to return.",
+                },
+            }),
+            &[],
+        ),
+        tool(
+            "slack_get_user",
+            "Fetch a single user's profile by ID.",
+            json!({
+                "user": { "type": "string", "description": "Slack user ID (e.g. U0123ABCD)." },
+            }),
+            &["user"],
+        ),
+        tool(
+            "slack_add_reaction",
+            "Add an emoji reaction to a message.",
+            json!({
+                "channel": channel_prop(),
+                "timestamp": {
+                    "type": "string",
+                    "description": "The ts of the message to react to.",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Emoji name without colons (e.g. thumbsup).",
+                },
+            }),
+            &["channel", "timestamp", "name"],
+        ),
+    ];
+    json!({ "tools": tools })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn tool_list_has_expected_count() {
+        let v = tool_list_response();
+        let tools = v["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), TOOL_NAMES.len(), "expected all planned tools");
+        for t in tools {
+            assert!(t["name"].is_string(), "every tool has a name");
+            assert!(t["description"].is_string(), "every tool has a description");
+            assert_eq!(
+                t["inputSchema"]["type"], "object",
+                "every tool has an object inputSchema"
+            );
+            assert!(
+                t["inputSchema"]["required"].is_array(),
+                "every tool declares a required array"
+            );
+        }
+    }
+
+    #[test]
+    fn every_tool_name_is_unique() {
+        let v = tool_list_response();
+        let mut seen = HashSet::new();
+        for t in v["tools"].as_array().unwrap() {
+            let name = t["name"].as_str().unwrap().to_string();
+            assert!(seen.insert(name.clone()), "duplicate tool: {name}");
+        }
+    }
+
+    #[test]
+    fn known_tools_match_registry() {
+        let v = tool_list_response();
+        let built: HashSet<&str> = v["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        let declared: HashSet<&str> = TOOL_NAMES.iter().copied().collect();
+        assert_eq!(built, declared, "TOOL_NAMES must match the built registry");
+        for name in TOOL_NAMES {
+            assert!(is_known_tool(name), "{name} must be a known tool");
+        }
+        assert!(!is_known_tool("slack_not_a_tool"));
+    }
+}


### PR DESCRIPTION
## Summary

Scaffolds `crates/trusty-slack` — the skeleton of a **native-Rust Slack MCP server** (chat-as-tools), following the `crates/trusty-gworkspace` template. **Structure + stubs only; no live Slack API calls.** Live tools and auth are deferred pending the token (bot vs user) decision.

Closes #2637. Part of epic #2636 (native Slack/Telegram MCP servers). See ADR-0014 (PR #2624).

## Crate tree

```
crates/trusty-slack/
├── Cargo.toml              # trusty-common (mcp) + anyhow/thiserror/serde/serde_json/tokio/reqwest/tracing; [[bin]] slack-mcp; publish=false; edition 2021
├── README.md               # planned/stubbed tool table, config, quick-start, deferred note
└── src/
    ├── lib.rs              # module decls + crate doc
    ├── api/
    │   ├── mod.rs
    │   ├── client.rs       # BaseClient stub (reqwest::Client + token placeholder) + TODO(auth) → trusty_common::inference::credentials
    │   └── constants.rs    # SLACK_API_BASE + SLACK_TOKEN_ENV
    ├── server.rs           # handle_message (initialize/tools/list/tools/call) + typed ToolCallError + run_stdio
    ├── tools.rs            # authoritative tools/list schema builder (9 tools) + is_known_tool
    └── bin/
        └── slack-mcp.rs    # init_tracing (stderr) + build client + run_stdio
```

## Behavior

- `initialize` and `tools/list` return real responses (nine planned tools with minimal-but-valid JSON Schemas).
- `tools/call` dispatches to a `thiserror`-typed `NotImplemented` stub → proper JSON-RPC error (`INTERNAL_ERROR`); unknown tools → `METHOD_NOT_FOUND`. **No `todo!()`/`unimplemented!()`/panics.**
- Auth deferred: `BaseClient::new()` builds the HTTP client and records a token placeholder but performs no network I/O; a documented `TODO(auth)` points at `trusty_common::inference::credentials`.

## Verification

- `cargo build -p trusty-slack` — clean
- `cargo test -p trusty-slack` — **10 passed; 0 failed**
- `cargo clippy -p trusty-slack --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean; `bash scripts/check_line_cap.sh` — 0 violations
- `cargo check --workspace` — clean (trusty-slack auto-included via `crates/*` glob)

Conventions mirrored from trusty-gworkspace: Why/What/Test doc pattern, no `unwrap()` in lib code, logs to stderr, all files under the 500-SLOC cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)