### PR TITLE
feat(tickets): enable tickets-mcp + port gh-CLI fallback to trusty-common (ticketing quick-wins)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -22,6 +22,11 @@
         "serve",
         "--stdio"
       ]
+    },
+    "tickets-mcp": {
+      "type": "stdio",
+      "command": "tickets-mcp",
+      "args": []
     }
   }
 }

--- a/crates/trusty-agents/src/mcp/config/defaults.rs
+++ b/crates/trusty-agents/src/mcp/config/defaults.rs
@@ -262,24 +262,10 @@ eager_discovery = true
 [tool_registry.endpoints.transport]
 timeout_ms = 5000
 
-# tickets-mcp — unified ticketing MCP server (GitHub Issues, JIRA, Linear)
-# via JSON-RPC 2.0 stdio. Disabled by default; flip `enabled = true` once
-# the `tickets-mcp` binary is on $PATH.
-[[tool_registry.endpoints]]
-name = "tickets-mcp"
-driver = "direct"
-description = "Unified ticketing MCP server — GitHub Issues, JIRA, Linear"
-command = "tickets-mcp"
-args = []
-enabled = false
-scopes = ["ticketing.*"]
-discovery_ttl_secs = 0
-eager_discovery = true
-
-[tool_registry.endpoints.transport]
-timeout_ms = 5000
-
-# commons-ticketing retired per ADR-0014 (native Rust MCP, PR #2624): a disabled
-# external OpenRPC stub with no consumers, superseded by the native tickets-mcp
-# endpoint above.
+# tickets-mcp is intentionally NOT a `driver = "direct"` (OpenRPC) endpoint:
+# the `tickets-mcp` binary (trusty-common, `tickets` feature) speaks MCP
+# framing, not OpenRPC `rpc.discover`, so a direct endpoint would silently
+# fail discovery. It is wired out-of-process via the repo-root `.mcp.json`
+# stdio server instead. The former dead `tickets-mcp` (and `commons-ticketing`)
+# OpenRPC stubs were retired per ADR-0014 (native Rust MCP, PR #2624).
 "#;

--- a/crates/trusty-common/src/intent_source/backend_fetcher.rs
+++ b/crates/trusty-common/src/intent_source/backend_fetcher.rs
@@ -66,7 +66,9 @@ impl TicketFetcher for BackendTicketFetcher {
             gh_cli_user: None,
             gh_cli_host: None,
         };
-        let backend = GitHubBackend::new(cfg).map_err(|e| IsrError::TicketFetch(e.to_string()))?;
+        let backend = GitHubBackend::new(cfg)
+            .await
+            .map_err(|e| IsrError::TicketFetch(e.to_string()))?;
         // GitHub issue ids are numeric; strip a leading `#` if present.
         let id = ticket_id.trim_start_matches('#');
         let issue = backend

--- a/crates/trusty-common/src/tickets/api/backends/github/auth.rs
+++ b/crates/trusty-common/src/tickets/api/backends/github/auth.rs
@@ -40,7 +40,8 @@ pub(super) enum AuthSource {
 /// `gh` CLI so users authenticated via `gh auth login` need no PAT.
 /// What: Returns `Token` when `cfg.token` is `Some` and non-whitespace, else
 /// `GhCli`.
-/// Test: `tests::select_auth_prefers_token`, `select_auth_falls_back_to_gh`.
+/// Test: `select_auth_prefers_token`, `select_auth_falls_back_to_gh_when_absent`,
+/// `select_auth_falls_back_to_gh_when_blank`.
 pub(super) fn select_auth(cfg: &GithubConfig) -> AuthSource {
     match cfg.token.as_deref() {
         Some(t) if !t.trim().is_empty() => AuthSource::Token,

--- a/crates/trusty-common/src/tickets/api/backends/github/auth.rs
+++ b/crates/trusty-common/src/tickets/api/backends/github/auth.rs
@@ -1,0 +1,182 @@
+//! GitHub token resolution — PAT or `gh` CLI fallback.
+//!
+//! Why: The token-based REST client requires the user to mint and manage a
+//! `GITHUB_TOKEN` PAT. Many users already have the official `gh` CLI installed
+//! and authenticated (`gh auth login`); we should be able to obtain a bearer
+//! token from it instead of demanding a second credential. This mirrors the
+//! `gh`-CLI fallback that the `trusty-agents` `native_ticketing` stack has, and
+//! finally wires the previously-vestigial `gh_cli_user` / `gh_cli_host` config
+//! fields (`config::GithubConfig`).
+//! What: `select_auth` decides — purely — whether an explicit token or the
+//! `gh` CLI is the source; `gh_token_args` builds the `gh auth token` argv
+//! (honouring host/user); `resolve_token` performs the async resolution the
+//! backend constructor calls.
+//! Test: `tests::*` cover the pure auth-selection + argv logic. The subprocess
+//! shell-out itself is environment-dependent and not exercised in unit tests.
+
+use anyhow::{Context, Result, bail};
+use tokio::process::Command;
+
+use crate::tickets::api::config::GithubConfig;
+
+/// Which credential source the GitHub backend will use.
+///
+/// Why: Makes the token-vs-`gh`-CLI decision explicit and unit-testable
+/// instead of buried inside the async constructor.
+/// What: `Token` = an explicit PAT (config/env); `GhCli` = shell out to
+/// `gh auth token`.
+/// Test: `tests::select_auth_*`.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum AuthSource {
+    /// Explicit PAT supplied via config or the `GITHUB_TOKEN` env var.
+    Token,
+    /// Fall back to the authenticated `gh` CLI (`gh auth token`).
+    GhCli,
+}
+
+/// Decide the credential source from config (pure).
+///
+/// Why: A present, non-blank token always wins; otherwise we fall back to the
+/// `gh` CLI so users authenticated via `gh auth login` need no PAT.
+/// What: Returns `Token` when `cfg.token` is `Some` and non-whitespace, else
+/// `GhCli`.
+/// Test: `tests::select_auth_prefers_token`, `select_auth_falls_back_to_gh`.
+pub(super) fn select_auth(cfg: &GithubConfig) -> AuthSource {
+    match cfg.token.as_deref() {
+        Some(t) if !t.trim().is_empty() => AuthSource::Token,
+        _ => AuthSource::GhCli,
+    }
+}
+
+/// Build the `gh auth token` argv, honouring the vestigial host/user fields.
+///
+/// Why: `gh auth token` accepts `--hostname` (for GitHub Enterprise) and
+/// `--user` (to pick among multiple logged-in accounts); the `gh_cli_host` /
+/// `gh_cli_user` config fields exist precisely to drive these.
+/// What: Always starts `["auth", "token"]`, appending `--hostname <h>` and
+/// `--user <u>` only for non-blank values.
+/// Test: `tests::gh_token_args_*`.
+pub(super) fn gh_token_args(cfg: &GithubConfig) -> Vec<String> {
+    let mut args = vec!["auth".to_string(), "token".to_string()];
+    if let Some(host) = cfg.gh_cli_host.as_deref().filter(|s| !s.trim().is_empty()) {
+        args.push("--hostname".to_string());
+        args.push(host.to_string());
+    }
+    if let Some(user) = cfg.gh_cli_user.as_deref().filter(|s| !s.trim().is_empty()) {
+        args.push("--user".to_string());
+        args.push(user.to_string());
+    }
+    args
+}
+
+/// Resolve a bearer token: explicit PAT or `gh auth token`.
+///
+/// Why: The REST client only needs a bearer string; sourcing it from the `gh`
+/// CLI keeps the whole existing transport unchanged.
+/// What: Returns the trimmed config/env token when present, otherwise spawns
+/// `gh auth token [...]` and returns its trimmed stdout.
+/// Test: pure branches covered by `tests::select_auth_*`; the `gh` shell-out
+/// path is environment-dependent and validated manually.
+pub(super) async fn resolve_token(cfg: &GithubConfig) -> Result<String> {
+    match select_auth(cfg) {
+        AuthSource::Token => Ok(cfg.token.as_deref().unwrap_or_default().trim().to_string()),
+        AuthSource::GhCli => gh_auth_token(cfg).await,
+    }
+}
+
+/// Shell out to `gh auth token` and return the token string.
+///
+/// Why: Centralises the subprocess spawn + error mapping so the constructor
+/// stays focused.
+/// What: Runs `gh <gh_token_args>`; on non-zero exit or empty stdout, returns
+/// an actionable error pointing at `GITHUB_TOKEN` / `gh auth login`.
+/// Test: environment-dependent; not unit-tested.
+async fn gh_auth_token(cfg: &GithubConfig) -> Result<String> {
+    let args = gh_token_args(cfg);
+    let output = Command::new("gh")
+        .args(&args)
+        .output()
+        .await
+        .context("failed to spawn 'gh auth token' — is the gh CLI installed and on PATH?")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "gh auth token failed (exit {}): {} — set GITHUB_TOKEN or run 'gh auth login'",
+            output.status,
+            stderr.trim()
+        );
+    }
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if token.is_empty() {
+        bail!("gh auth token returned empty output — run 'gh auth login' to authenticate");
+    }
+    Ok(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with(token: Option<&str>, host: Option<&str>, user: Option<&str>) -> GithubConfig {
+        GithubConfig {
+            token: token.map(String::from),
+            owner: Some("o".into()),
+            repo: Some("r".into()),
+            gh_cli_host: host.map(String::from),
+            gh_cli_user: user.map(String::from),
+        }
+    }
+
+    #[test]
+    fn select_auth_prefers_token() {
+        let cfg = cfg_with(Some("ghp_abc"), None, None);
+        assert_eq!(select_auth(&cfg), AuthSource::Token);
+    }
+
+    #[test]
+    fn select_auth_falls_back_to_gh_when_absent() {
+        let cfg = cfg_with(None, None, None);
+        assert_eq!(select_auth(&cfg), AuthSource::GhCli);
+    }
+
+    #[test]
+    fn select_auth_falls_back_to_gh_when_blank() {
+        let cfg = cfg_with(Some("   "), None, None);
+        assert_eq!(select_auth(&cfg), AuthSource::GhCli);
+    }
+
+    #[test]
+    fn gh_token_args_bare() {
+        let cfg = cfg_with(None, None, None);
+        assert_eq!(gh_token_args(&cfg), vec!["auth", "token"]);
+    }
+
+    #[test]
+    fn gh_token_args_with_host_and_user() {
+        let cfg = cfg_with(None, Some("ghe.example.com"), Some("octocat"));
+        assert_eq!(
+            gh_token_args(&cfg),
+            vec![
+                "auth",
+                "token",
+                "--hostname",
+                "ghe.example.com",
+                "--user",
+                "octocat"
+            ]
+        );
+    }
+
+    #[test]
+    fn gh_token_args_ignores_blank_host_and_user() {
+        let cfg = cfg_with(None, Some("  "), Some(""));
+        assert_eq!(gh_token_args(&cfg), vec!["auth", "token"]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resolve_token_returns_trimmed_explicit_token() {
+        let cfg = cfg_with(Some("  ghp_padded  "), None, None);
+        let tok = resolve_token(&cfg).await.expect("explicit token resolves");
+        assert_eq!(tok, "ghp_padded");
+    }
+}

--- a/crates/trusty-common/src/tickets/api/backends/github/client.rs
+++ b/crates/trusty-common/src/tickets/api/backends/github/client.rs
@@ -12,16 +12,18 @@ use serde_json::{Value, json};
 
 use crate::tickets::api::config::GithubConfig;
 
+use super::auth::resolve_token;
 use super::types::{GRAPHQL_URL, GitHubBackend, REST_BASE, USER_AGENT, ensure_ok};
 
 impl GitHubBackend {
-    /// Why: Caller has validated config; we just wire up the client.
-    /// What: Constructs from `GithubConfig` after env-var fallback applied.
-    /// Test: covered by `client.rs` construction tests.
-    pub fn new(cfg: GithubConfig) -> Result<Self> {
-        let token = cfg
-            .token
-            .ok_or_else(|| anyhow!("github: missing token (set GITHUB_TOKEN)"))?;
+    /// Why: Caller has validated config; we just wire up the client. Auth is a
+    /// PAT (config/env) OR the authenticated `gh` CLI, so users with only
+    /// `gh auth login` need no PAT (see `auth::resolve_token`).
+    /// What: Resolves a bearer token, then constructs from `GithubConfig`
+    /// after env-var fallback applied.
+    /// Test: covered by `client.rs` construction tests and `auth::tests`.
+    pub async fn new(cfg: GithubConfig) -> Result<Self> {
+        let token = resolve_token(&cfg).await?;
         let owner = cfg
             .owner
             .ok_or_else(|| anyhow!("github: missing owner (set GITHUB_OWNER)"))?;

--- a/crates/trusty-common/src/tickets/api/backends/github/mod.rs
+++ b/crates/trusty-common/src/tickets/api/backends/github/mod.rs
@@ -6,6 +6,7 @@
 //! labels/milestones; GraphQL for Projects V2.
 //! Test: shape tests in `backend`; live tests gated by env vars.
 
+mod auth;
 mod backend;
 mod client;
 mod types;

--- a/crates/trusty-common/src/tickets/api/client.rs
+++ b/crates/trusty-common/src/tickets/api/client.rs
@@ -35,7 +35,7 @@ impl BackendClient {
         let mut backends: HashMap<String, Arc<dyn Backend>> = HashMap::new();
         for (name, bc) in config.backends.into_iter() {
             let result: Result<Arc<dyn Backend>> = match bc {
-                BackendConfig::Github(c) => GitHubBackend::new(c).map(|b| Arc::new(b) as _),
+                BackendConfig::Github(c) => GitHubBackend::new(c).await.map(|b| Arc::new(b) as _),
                 BackendConfig::Jira(c) => JiraBackend::new(c).map(|b| Arc::new(b) as _),
                 BackendConfig::Linear(c) => LinearBackend::new(c).map(|b| Arc::new(b) as _),
             };


### PR DESCRIPTION
## Ticketing consolidation — low-risk quick-wins (per ADR-0014)

The **low-risk** subset of the ticketing consolidation. This is **quick-wins-only**: it does **NOT** retire the trusty-agents `native_ticketing` client stack (GitHub/JIRA/Linear clients + trait) — that full-consolidation step is deferred.

> ⚠️ **STACKED on #2635** (`chore/native-mcp-repoint-stubs`). Both PRs touch `crates/trusty-agents/src/mcp/config/defaults.rs`. **Merge #2635 first**; this branch was cut off `origin/chore/native-mcp-repoint-stubs` so it contains those commits until #2635 lands.

### Three changes

**1. Port the `gh` CLI fallback auth into `trusty-common`'s GitHub backend**
- New `crates/trusty-common/src/tickets/api/backends/github/auth.rs`: token auth **OR** `gh auth token` fallback (users authenticated via `gh auth login` need no PAT).
- Wires the previously-vestigial `gh_cli_user` / `gh_cli_host` config fields into `gh auth token --user/--hostname`.
- `GitHubBackend::new` is now async and resolves the bearer token before constructing.
- Unit tests cover the auth-selection logic (`select_auth`, `gh_token_args`, `resolve_token`) — 7 tests, all green.
- The trusty-agents `native_ticketing` copy is intentionally **kept** (deferred retirement).

**2. Enable + wire `tickets-mcp` for out-of-process use**
- Adds `tickets-mcp` (command `tickets-mcp`, `args: []`) to the repo-root `.mcp.json` as a stdio MCP server alongside trusty-memory/trusty-search/trusty-mpm.
- Verified: `cargo build -p trusty-common --features tickets --bin tickets-mcp` builds, and the binary answers an MCP `initialize` handshake.

**3. Drop the dead OpenRPC `tickets-mcp` `tool_registry` endpoint**
- Removed the `[[tool_registry.endpoints]]` `driver = "direct"` (OpenRPC) `tickets-mcp` entry from `defaults.rs`: the server speaks MCP framing, not OpenRPC `rpc.discover`, so enabling it would silently fail discovery. Superseded by the out-of-process `.mcp.json` wiring in change 2. Replaced with an explanatory comment. No default-count tests referenced it.

### Verification (raw output in the delivering agent's report)
- `cargo build -p trusty-common --features tickets` ✅ · `cargo build -p trusty-agents` ✅
- `cargo test -p trusty-common --features tickets` → 202 passed (incl. 7 new auth tests) ✅
- `cargo test -p trusty-agents` → 1783 passed ✅
- `cargo clippy -p trusty-common --features tickets --all-targets -- -D warnings` ✅ · trusty-agents ✅
- `cargo fmt --check` ✅ · `bash scripts/check_line_cap.sh` → 0 violations ✅

### Refs
Partial work toward #2420 (promote gh CLI wrapper to trusty-common), epic #2415 (domain consolidation), and ADR-0014 (native Rust MCP, PR #2624). Referenced, **not closed** — `native_ticketing` retirement remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)