### PR TITLE
fix(trusty-mpm): bound the manager ChatStore conversation-key set with an LRU cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11090,6 +11090,7 @@ dependencies = [
  "http-body-util",
  "jsonwebtoken",
  "libc",
+ "lru",
  "nix 0.29.0",
  "notify 6.1.1",
  "parking_lot",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -211,6 +211,9 @@ jsonwebtoken.workspace = true
 utoipa.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 tokio.workspace = true
+# #2602: bounds the manager ChatStore's distinct conversation-key set with a
+# capacity-evicting LRU cache — see daemon/manager/chat_store.rs.
+lru.workspace = true
 # async-trait is needed by the SM providers' `LlmProvider` trait (SM-2), which is
 # compiled unconditionally in the `core` library. (The `mcp` feature also lists it
 # below for the OrchestratorBackend trait; declaring it here makes it always-on.)

--- a/crates/trusty-mpm/src/daemon/manager/chat_store.rs
+++ b/crates/trusty-mpm/src/daemon/manager/chat_store.rs
@@ -7,16 +7,24 @@
 //! coherent, but must stay bounded so a long-lived key cannot grow without limit.
 //! This is the in-memory half of that state; the durable half is the portfolio
 //! palace dual-write (WI-5), which degrades silently when unavailable.
-//! What: [`ChatStore`] wraps a `Mutex<HashMap<String, Vec<ChatTurn>>>` keyed
+//! What: [`ChatStore`] wraps a `Mutex<LruCache<String, Vec<ChatTurn>>>` keyed
 //! IDENTICALLY to the proxy focus map (plain `String` conversation key), with a
 //! bounded [`ChatStore::history`]/[`ChatStore::record_exchange`] surface. Each
-//! [`ChatTurn`] carries a [`TurnRole`] and its text; the window keeps the most
-//! recent [`DEFAULT_MAX_TURNS`] messages per conversation.
+//! [`ChatTurn`] carries a [`TurnRole`] and its text; the per-key window keeps the
+//! most recent [`DEFAULT_MAX_TURNS`] messages, and the key SET itself is capped at
+//! [`DEFAULT_MAX_KEYS`] distinct conversations, least-recently-used evicted (#2602)
+//! — a local/authenticated-only caller couldn't mint enough distinct keys to
+//! matter, but phase 4 fronts this endpoint with public channels (Telegram/Slack),
+//! where every inbound chat could carry a fresh key and grow the map forever
+//! without this cap.
 //! Test: `record_and_history_round_trips`, `history_is_bounded`,
-//! `distinct_keys_are_isolated` in `chat_store_tests.rs`.
+//! `distinct_keys_are_isolated`, `key_set_is_bounded_lru_eviction`,
+//! `evicted_key_reads_as_empty_and_can_restart` in `chat_store_tests.rs`.
 
-use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::Mutex;
+
+use lru::LruCache;
 
 /// Maximum stored messages (user + assistant) retained per conversation.
 ///
@@ -26,6 +34,19 @@ use std::sync::Mutex;
 /// What: the per-key cap enforced by [`ChatStore::record_exchange`].
 /// Test: `history_is_bounded`.
 pub const DEFAULT_MAX_TURNS: usize = 20;
+
+/// Maximum number of distinct conversation keys retained at once.
+///
+/// Why: #2602 — the per-key turn cap bounds memory PER conversation, but never
+/// bounded the KEY SET itself; any caller minting distinct keys (e.g. one per
+/// inbound message from an unauthenticated public channel) could grow daemon
+/// memory forever. 512 distinct live conversations is generously above any
+/// expected phase-4 concurrent-channel load while keeping worst-case memory
+/// small (512 keys × 20 turns × a short message ≈ low single-digit MB).
+/// What: the capacity passed to the backing [`LruCache`]; the least-recently-used
+/// key is evicted once a `record_exchange` for a NEW key would exceed it.
+/// Test: `key_set_is_bounded_lru_eviction`.
+pub const DEFAULT_MAX_KEYS: usize = 512;
 
 /// The speaker of a stored conversation turn.
 ///
@@ -61,34 +82,44 @@ pub struct ChatTurn {
 /// Why: the shared, daemon-owned context store threaded through
 /// [`crate::daemon::manager::ManagerState`]; keying it exactly like the L2 proxy
 /// focus map keeps the L3 chat surface channel-agnostic and consistent with the
-/// existing conversation-keying convention.
-/// What: a `Mutex`-guarded map from conversation key to a capped `Vec<ChatTurn>`.
-/// Cheap to read/write (a short vector clone); no async, no I/O.
-/// Test: `record_and_history_round_trips`, `history_is_bounded`, `distinct_keys_are_isolated`.
+/// existing conversation-keying convention. Bounding the key set itself (#2602)
+/// with an LRU cache — not just the per-key turn window — keeps daemon memory
+/// flat under public-channel-scale key churn once phase 4 lands.
+/// What: a `Mutex`-guarded [`LruCache`] from conversation key to a capped
+/// `Vec<ChatTurn>`. Cheap to read/write (a short vector clone); no async, no I/O.
+/// Test: `record_and_history_round_trips`, `history_is_bounded`,
+/// `distinct_keys_are_isolated`, `key_set_is_bounded_lru_eviction`,
+/// `evicted_key_reads_as_empty_and_can_restart`.
 #[derive(Debug)]
 pub struct ChatStore {
-    /// conversation key → recent turns (most-recent-last), capped at `max_turns`.
-    conversations: Mutex<HashMap<String, Vec<ChatTurn>>>,
+    /// conversation key → recent turns (most-recent-last), capped at
+    /// `max_turns`; the map itself holds at most `max_keys` entries, evicting
+    /// least-recently-used keys on overflow.
+    conversations: Mutex<LruCache<String, Vec<ChatTurn>>>,
     /// Per-conversation retention cap.
     max_turns: usize,
 }
 
 impl Default for ChatStore {
     fn default() -> Self {
-        Self::new(DEFAULT_MAX_TURNS)
+        Self::new(DEFAULT_MAX_TURNS, DEFAULT_MAX_KEYS)
     }
 }
 
 impl ChatStore {
-    /// Construct an empty store with the given per-conversation retention cap.
+    /// Construct an empty store with the given per-conversation turn cap and
+    /// distinct-key cap.
     ///
-    /// Why: the cap is injectable so a test can prove the bounding without pushing
-    /// 20 turns.
-    /// What: an empty map plus the retention cap.
-    /// Test: `history_is_bounded`.
-    pub fn new(max_turns: usize) -> Self {
+    /// Why: both caps are injectable so a test can prove either bound without
+    /// pushing hundreds of turns/keys.
+    /// What: an empty LRU-backed map with capacity `max_keys` (floored at 1, since
+    /// [`LruCache`] requires a `NonZeroUsize`), plus the per-key turn retention
+    /// cap (floored at 2 so a single exchange always fits).
+    /// Test: `history_is_bounded`, `key_set_is_bounded_lru_eviction`.
+    pub fn new(max_turns: usize, max_keys: usize) -> Self {
+        let capacity = NonZeroUsize::new(max_keys.max(1)).unwrap_or(NonZeroUsize::MIN);
         Self {
-            conversations: Mutex::new(HashMap::new()),
+            conversations: Mutex::new(LruCache::new(capacity)),
             max_turns: max_turns.max(2),
         }
     }
@@ -96,9 +127,12 @@ impl ChatStore {
     /// The recent turns for a conversation key, oldest-first.
     ///
     /// Why: the chat handler replays these as prior history before the new user
-    /// message so the reply is contextual.
-    /// What: clones the capped turn vector under `key`, or an empty vector.
-    /// Test: `record_and_history_round_trips`.
+    /// message so the reply is contextual. Reading via [`LruCache::get`] also
+    /// promotes `key` to most-recently-used, so an active conversation survives
+    /// eviction as long as it keeps being read or written.
+    /// What: clones the capped turn vector under `key`, or an empty vector if the
+    /// key was never recorded OR has since been LRU-evicted.
+    /// Test: `record_and_history_round_trips`, `evicted_key_reads_as_empty_and_can_restart`.
     pub fn history(&self, key: &str) -> Vec<ChatTurn> {
         self.conversations
             .lock()
@@ -112,13 +146,26 @@ impl ChatStore {
     ///
     /// Why: a turn is only recorded after a successful reply, so a failed/degraded
     /// request never pollutes history. Trimming from the front keeps the window on
-    /// the most recent turns.
-    /// What: pushes the user then assistant turn under `key`, then truncates the
-    /// front so at most `max_turns` remain. Returns the resulting turn count.
-    /// Test: `record_and_history_round_trips`, `history_is_bounded`.
+    /// the most recent turns; using [`LruCache::get_mut`]/[`LruCache::put`] keeps
+    /// `key` promoted to most-recently-used so a live conversation is never the
+    /// eviction candidate while it's still exchanging turns.
+    /// What: pushes the user then assistant turn under `key` (inserting a fresh
+    /// entry — and possibly evicting the least-recently-used OTHER key — if `key`
+    /// is new), then truncates the front so at most `max_turns` remain. Returns
+    /// the resulting turn count.
+    /// Test: `record_and_history_round_trips`, `history_is_bounded`,
+    /// `key_set_is_bounded_lru_eviction`.
     pub fn record_exchange(&self, key: &str, user: &str, assistant: &str) -> usize {
         let mut map = self.conversations.lock().unwrap_or_else(|p| p.into_inner());
-        let turns = map.entry(key.to_string()).or_default();
+        if map.get_mut(key).is_none() {
+            map.put(key.to_string(), Vec::new());
+        }
+        // Just inserted-or-present above, so this lookup always succeeds; a
+        // `HashMap`-shaped `entry(..).or_default()` isn't available on
+        // `LruCache`, so `get_mut` (promoting `key` to MRU) is the equivalent.
+        let Some(turns) = map.get_mut(key) else {
+            return 0;
+        };
         turns.push(ChatTurn {
             role: TurnRole::User,
             content: user.to_string(),

--- a/crates/trusty-mpm/src/daemon/manager/chat_store.rs
+++ b/crates/trusty-mpm/src/daemon/manager/chat_store.rs
@@ -146,23 +146,43 @@ impl ChatStore {
     ///
     /// Why: a turn is only recorded after a successful reply, so a failed/degraded
     /// request never pollutes history. Trimming from the front keeps the window on
-    /// the most recent turns; using [`LruCache::get_mut`]/[`LruCache::put`] keeps
+    /// the most recent turns; using [`LruCache::get_mut`]/[`LruCache::push`] keeps
     /// `key` promoted to most-recently-used so a live conversation is never the
-    /// eviction candidate while it's still exchanging turns.
+    /// eviction candidate while it's still exchanging turns. Logging every
+    /// eviction at debug level (#2602 review) gives an observable signal that the
+    /// key-set cap is actually being hit in production, without needing a new
+    /// metrics seam for what should be a rare event under normal load.
     /// What: pushes the user then assistant turn under `key` (inserting a fresh
     /// entry — and possibly evicting the least-recently-used OTHER key — if `key`
     /// is new), then truncates the front so at most `max_turns` remain. Returns
     /// the resulting turn count.
+    ///
+    /// Trade-off: `lru` 0.12.5's `get_or_insert_mut` would collapse the
+    /// check-then-insert below into one lookup, but it doesn't surface the
+    /// evicted entry on overflow — and the eviction log needs exactly that entry.
+    /// Eviction observability wins over shaving one lookup, so this stays the
+    /// explicit two-step `get_mut` + `push` form.
     /// Test: `record_and_history_round_trips`, `history_is_bounded`,
     /// `key_set_is_bounded_lru_eviction`.
     pub fn record_exchange(&self, key: &str, user: &str, assistant: &str) -> usize {
         let mut map = self.conversations.lock().unwrap_or_else(|p| p.into_inner());
         if map.get_mut(key).is_none() {
-            map.put(key.to_string(), Vec::new());
+            // `push` returns `Some((old_key, old_value))` both when it evicts the
+            // least-recently-used entry to make room, AND when `key` itself
+            // already existed (a same-key value replace). We only reach this
+            // branch after `get_mut` just confirmed `key` is ABSENT, so any
+            // `Some` here is necessarily a DIFFERENT key that the LRU cap
+            // evicted — the `evicted_key != key` guard documents that invariant
+            // defensively rather than relying on it silently.
+            if let Some((evicted_key, _evicted_turns)) = map.push(key.to_string(), Vec::new())
+                && evicted_key != key
+            {
+                tracing::debug!(
+                    evicted_key = %evicted_key,
+                    "chat_store: LRU-evicted conversation key to stay within the key-set cap"
+                );
+            }
         }
-        // Just inserted-or-present above, so this lookup always succeeds; a
-        // `HashMap`-shaped `entry(..).or_default()` isn't available on
-        // `LruCache`, so `get_mut` (promoting `key` to MRU) is the equivalent.
         let Some(turns) = map.get_mut(key) else {
             return 0;
         };

--- a/crates/trusty-mpm/src/daemon/manager/chat_store_tests.rs
+++ b/crates/trusty-mpm/src/daemon/manager/chat_store_tests.rs
@@ -1,8 +1,11 @@
-//! Unit tests for [`super::ChatStore`] (WI-4, #2581).
+//! Unit tests for [`super::ChatStore`] (WI-4, #2581; key-set bound #2602).
 //!
-//! Why: the conversation store's round-trip, bounding, and per-key isolation are
-//! the invariants the multi-turn chat loop depends on; prove them directly.
-//! What: covers record→history round-trip, the retention cap, and key isolation.
+//! Why: the conversation store's round-trip, bounding, per-key isolation, AND
+//! the distinct-key-set LRU eviction are the invariants the multi-turn chat loop
+//! (and, from phase 4 on, unauthenticated public channels) depend on; prove them
+//! directly.
+//! What: covers record→history round-trip, the per-key retention cap, key
+//! isolation, and the #2602 key-set cap's least-recently-used eviction.
 //! Test: this file IS the test module.
 
 use super::{ChatStore, TurnRole};
@@ -27,7 +30,7 @@ fn record_and_history_round_trips() {
 /// Test: itself.
 #[test]
 fn history_is_bounded() {
-    let store = ChatStore::new(4);
+    let store = ChatStore::new(4, super::DEFAULT_MAX_KEYS);
     for i in 0..5 {
         store.record_exchange("conv-1", &format!("q{i}"), &format!("a{i}"));
     }
@@ -48,4 +51,76 @@ fn distinct_keys_are_isolated() {
     assert_eq!(store.history("conv-a").len(), 2);
     assert_eq!(store.history("conv-b")[0].content, "hi b");
     assert!(store.history("conv-missing").is_empty());
+}
+
+/// Why: #2602 — the KEY SET must be bounded independent of the per-key turn
+/// cap, or a caller minting distinct keys (unauthenticated public channels from
+/// phase 4 on) grows daemon memory forever. A 2-key-capacity store must evict
+/// the least-recently-used key once a third distinct key is recorded.
+/// Test: itself.
+#[test]
+fn key_set_is_bounded_lru_eviction() {
+    let store = ChatStore::new(super::DEFAULT_MAX_TURNS, 2);
+    store.record_exchange("conv-1", "hi 1", "reply 1");
+    store.record_exchange("conv-2", "hi 2", "reply 2");
+    // Recording a third distinct key overflows the 2-key capacity; "conv-1" is
+    // the least-recently-used (never read/re-written since insertion) and is
+    // evicted, while "conv-2" and the new "conv-3" both survive.
+    store.record_exchange("conv-3", "hi 3", "reply 3");
+
+    assert!(
+        store.history("conv-1").is_empty(),
+        "least-recently-used key must be evicted"
+    );
+    assert_eq!(store.history("conv-2").len(), 2, "conv-2 survives eviction");
+    assert_eq!(
+        store.history("conv-3").len(),
+        2,
+        "newly-inserted key survives"
+    );
+}
+
+/// Why: reading a key via [`super::ChatStore::history`] promotes it to
+/// most-recently-used, so an actively-read (but not recently-written)
+/// conversation must survive eviction in place of a truly idle one.
+/// Test: itself.
+#[test]
+fn reading_a_key_promotes_it_and_protects_from_eviction() {
+    let store = ChatStore::new(super::DEFAULT_MAX_TURNS, 2);
+    store.record_exchange("conv-1", "hi 1", "reply 1");
+    store.record_exchange("conv-2", "hi 2", "reply 2");
+    // Touch "conv-1" so it becomes MRU; "conv-2" is now the LRU candidate.
+    let _ = store.history("conv-1");
+    store.record_exchange("conv-3", "hi 3", "reply 3");
+
+    assert_eq!(
+        store.history("conv-1").len(),
+        2,
+        "recently-read key survives"
+    );
+    assert!(
+        store.history("conv-2").is_empty(),
+        "un-touched key is evicted instead"
+    );
+    assert_eq!(store.history("conv-3").len(), 2);
+}
+
+/// Why: an evicted key must degrade gracefully, not error — the next chat turn
+/// on that (now-stale) key simply starts a fresh empty history rather than
+/// panicking or corrupting the store.
+/// Test: itself.
+#[test]
+fn evicted_key_reads_as_empty_and_can_restart() {
+    let store = ChatStore::new(super::DEFAULT_MAX_TURNS, 1);
+    store.record_exchange("conv-1", "hi 1", "reply 1");
+    store.record_exchange("conv-2", "hi 2", "reply 2");
+    assert!(
+        store.history("conv-1").is_empty(),
+        "evicted by the 1-key cap"
+    );
+
+    // "conv-1" restarts cleanly as a brand-new conversation.
+    let count = store.record_exchange("conv-1", "hi again", "reply again");
+    assert_eq!(count, 2);
+    assert_eq!(store.history("conv-1")[0].content, "hi again");
 }


### PR DESCRIPTION
## Summary

- `ChatStore` (`crates/trusty-mpm/src/daemon/manager/chat_store.rs`) already bounded the per-conversation turn window (`DEFAULT_MAX_TURNS = 20`), but never bounded the distinct-key SET — a caller minting fresh `conversation_key`s could grow daemon memory without limit.
- Deferred (APPROVE) from PR #2601's review because phase 1 only exposes `/api/v1/manager/chat` to local/authenticated clients — becomes a real OOM vector the moment DOC-36 phase 4 fronts the endpoint with public channels (Telegram/Slack), where every inbound chat could carry a fresh key.
- Swaps the backing `HashMap<String, Vec<ChatTurn>>` for `lru::LruCache<String, Vec<ChatTurn>>` capped at `DEFAULT_MAX_KEYS = 512` distinct conversations; `record_exchange`/`history` now naturally promote a key to most-recently-used on read/write, so an active conversation survives eviction while idle ones get reclaimed first.
- `lru = "0.12"` was already a workspace dependency (used by `trusty-common`); added `lru.workspace = true` to `trusty-mpm/Cargo.toml`.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — 154 test-result blocks, all `ok`, 0 failed (new tests: `key_set_is_bounded_lru_eviction`, `reading_a_key_promotes_it_and_protects_from_eviction`, `evicted_key_reads_as_empty_and_can_restart`, alongside the 4 pre-existing `chat_store` tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings, exit 0
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations

Closes #2602

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools