### PR TITLE
fix(trusty-mpm): exclude dead sessions (missing workspace) from resume/restart offers

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -911,6 +911,7 @@ mod tests {
             deliverable_id: None,
             pane_id: None,
             injection_status: None,
+            unresumable: false,
         };
         let client = reqwest::Client::new();
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -120,8 +120,14 @@ pub(crate) async fn session_ls(
 /// What: prints a "no managed sessions[ for <slug>]" line when the list is empty;
 /// otherwise prints the header + one row per session (id, state, truncated name,
 /// task/`(interactive)` placeholder, short created-at, and any pending decision).
+/// The STATE column appends `[dead]` (#2595) when the server-computed
+/// `unresumable` flag is set — the session's workspace no longer exists
+/// anywhere on disk, so `tm session resume`/the picker's restart would only
+/// ever fail; the operator's actionable remedy is `tm session rm`.
 /// Test: `ls_source_id_filter_selects_correct_slug` covers the scoping seam; the
-/// table bytes are exercised by `tests/session_manager_mvp.rs`.
+/// table bytes are exercised by `tests/session_manager_mvp.rs`;
+/// `format_state_column_appends_dead_marker` covers the `[dead]` marker via the
+/// extracted pure helper, [`format_state_column`].
 pub(crate) fn render_session_table(sessions: &[ManagedSessionSummary], source_id: Option<&str>) {
     if sessions.is_empty() {
         if let Some(sid) = source_id {
@@ -153,16 +159,37 @@ pub(crate) fn render_session_table(sessions: &[ManagedSessionSummary], source_id
             .as_deref()
             .map(|d| format!(" [pending: {d}]"))
             .unwrap_or_default();
+        // #2595: flag a dead pick (stopped/errored with no workdir candidate
+        // left on disk) right in the STATE column — the operator sees it
+        // without having to select the session and hit a 422 first.
+        let state = format_state_column(&s.state, s.unresumable);
         println!(
             // #1841 Fix 5: truncate name with ellipsis when it exceeds column width.
             "{:<36}  {:<14}  {:<24}  {:<30}  {}{}",
             s.id,
-            s.state,
+            state,
             truncate(&s.name, 24),
             task,
             created,
             pending
         );
+    }
+}
+
+/// Format the STATE column value for one `tm session ls` row (#2595).
+///
+/// Why: extracted as a pure function so the `[dead]` marker is unit-testable
+/// without capturing `render_session_table`'s stdout.
+/// What: returns `state` unchanged when `unresumable` is `false`; appends
+/// `" [dead]"` when `true` — the session is `stopped`/`errored` with no
+/// workdir candidate left on disk, so a resume is guaranteed to fail.
+/// Test: `format_state_column_appends_dead_marker`,
+/// `format_state_column_leaves_healthy_state_unchanged`.
+fn format_state_column(state: &str, unresumable: bool) -> String {
+    if unresumable {
+        format!("{state} [dead]")
+    } else {
+        state.to_string()
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -24,8 +24,8 @@
 
 use std::future::IntoFuture as _;
 
+use super::{format_state_column, short_timestamp, truncate};
 use super::{session_activity, session_decommission, session_resume, session_stop};
-use super::{short_timestamp, truncate};
 
 #[test]
 fn truncate_clips_and_appends_ellipsis() {
@@ -33,6 +33,23 @@ fn truncate_clips_and_appends_ellipsis() {
     assert_eq!(truncate("hello world", 5), "hell\u{2026}");
     assert_eq!(truncate("", 5), "");
     assert_eq!(truncate("abcde", 5), "abcde");
+}
+
+/// #2595: `tm sessions ls` must mark a dead pick right in the STATE column so
+/// the operator sees it without selecting the session and hitting a 422 first.
+#[test]
+fn format_state_column_appends_dead_marker() {
+    assert_eq!(format_state_column("stopped", true), "stopped [dead]");
+    assert_eq!(format_state_column("errored", true), "errored [dead]");
+}
+
+/// #2595: a healthy (resumable) session's STATE column must render byte-for-byte
+/// unchanged — no regression for the common case.
+#[test]
+fn format_state_column_leaves_healthy_state_unchanged() {
+    assert_eq!(format_state_column("active", false), "active");
+    assert_eq!(format_state_column("stopped", false), "stopped");
+    assert_eq!(format_state_column("provisioning", false), "provisioning");
 }
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
@@ -32,16 +32,21 @@ use super::managed::filter_live_sessions;
 /// Why: extracting the parse-and-decide logic from the I/O driver makes it
 /// unit-testable without stdin/tmux. The driver calls parse, checks the variant,
 /// and shells out only for Resume and LaunchNew.
-/// What: five variants cover every valid and invalid input the picker can
+/// What: six variants cover every valid and invalid input the picker can
 /// receive. [`Self::ConfirmRestart`] is the #2148 safety default: a bare Enter
 /// that WOULD have silently restarted (destructively recreated the tmux pane
 /// of) a stopped/errored session instead asks for an explicit numeric choice.
+/// [`Self::Unresumable`] (#2595) is the analogous safety gate for a DEAD
+/// session — no confirmation would ever help, since the resume/restart is
+/// guaranteed to fail, so the driver never round-trips to the daemon for it.
 /// Test: `guided_picker_bare_enter_no_sessions_launches_new`,
 /// `guided_picker_bare_enter_live_session_resumes_first`,
 /// `guided_picker_bare_enter_stopped_session_requires_confirm`,
 /// `guided_picker_q_returns_quit`, `guided_picker_numeric_valid_resumes`,
 /// `guided_picker_numeric_launch_new`, `guided_picker_out_of_range_unrecognised`,
-/// `guided_picker_non_numeric_unrecognised`.
+/// `guided_picker_non_numeric_unrecognised`,
+/// `guided_picker_bare_enter_unresumable_session_blocked`,
+/// `guided_picker_numeric_unresumable_session_blocked`.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum PickerDecision {
     /// Resume the session at 0-based index into the sessions slice.
@@ -63,6 +68,13 @@ pub(crate) enum PickerDecision {
     /// running session, a force-confirm — before touching the store, so this
     /// variant only signals intent, never an unconditional destructive action.
     Delete(usize),
+    /// Selection (bare Enter OR an explicit numeric choice) targeted the
+    /// 0-based-indexed session whose workspace is gone for good — the
+    /// server-computed `unresumable` flag was `true` (#2595). Resuming it
+    /// would only ever fail (see #2577/#2594): the driver never attempts the
+    /// daemon round-trip; it prints the dead-session notice and points the
+    /// operator at `d<N>` (delete) instead.
+    Unresumable(usize),
 }
 
 /// Scope describing which sessions the picker operates over and how to launch new.
@@ -171,22 +183,34 @@ pub(crate) async fn fetch_live_sessions(
 /// logic unit-testable without needing a real stdin, tmux, or daemon. Folding
 /// `first_needs_restart` in here (rather than deciding safety in the I/O
 /// driver) keeps the destructive-default guard (#2148) exhaustively
-/// unit-testable alongside every other picker-input case.
+/// unit-testable alongside every other picker-input case. `unresumable` (#2595)
+/// is folded in the same way: a session flagged dead by the daemon must never
+/// reach `Resume`/`ConfirmRestart` from EITHER a bare Enter or an explicit
+/// numeric choice — checking it here, ahead of both branches, is the single
+/// place that guarantee can never regress.
 /// What: `session_count` is the number of existing sessions in the menu (the
 /// menu slot `session_count + 1` is always "launch new"); `first_needs_restart`
 /// is true when the session at index 0 is `stopped`/`errored` — i.e. resuming
 /// it goes through the daemon's restart path, which can recreate its tmux pane
-/// (see [`super::guided_resume::needs_restart`]).
+/// (see [`super::guided_resume::needs_restart`]); `unresumable[i]` is the
+/// server-computed dead-workspace flag for the session at 0-based index `i`
+/// (`ManagedSessionSummary::unresumable`, #2595) — a slice, not a single bool,
+/// because an EXPLICIT numeric choice can target ANY index, not just 0.
 ///   • `"q"` / `"Q"` → `Quit`
 ///   • empty / whitespace, `session_count == 0` → `LaunchNew`
+///   • empty / whitespace, `session_count > 0`, session 0 is dead →
+///     `Unresumable(0)` (#2595 — checked BEFORE the restart-confirm gate)
 ///   • empty / whitespace, `session_count > 0`, session 0 is live → `Resume(0)`
 ///   • empty / whitespace, `session_count > 0`, session 0 needs a restart →
 ///     `ConfirmRestart(0)` (#2148: no longer an implicit destructive default)
+///   • `N` (1..=session_count), session `N-1` is dead → `Unresumable(N-1)`
+///     (#2595 — an explicit numeric choice no longer bypasses this gate)
 ///   • `N` (1..=session_count) → `Resume(N-1)` (0-based index) — an EXPLICIT
 ///     numeric choice always restarts/resumes directly, confirm or not
 ///   • `session_count + 1` → `LaunchNew`
 ///   • `d<N>` / `d <N>` (1..=session_count) → `Delete(N-1)` (#2304); the driver
-///     still runs a confirm/force-confirm prompt before deleting
+///     still runs a confirm/force-confirm prompt before deleting — this is the
+///     REMEDY the driver points a dead-session pick at
 ///   • anything else → `Unrecognised`
 /// Test: `guided_picker_bare_enter_no_sessions_launches_new`,
 /// `guided_picker_bare_enter_live_session_resumes_first`,
@@ -194,18 +218,23 @@ pub(crate) async fn fetch_live_sessions(
 /// `guided_picker_q_returns_quit`, `guided_picker_q_uppercase_returns_quit`,
 /// `guided_picker_numeric_valid_resumes`, `guided_picker_numeric_launch_new`,
 /// `guided_picker_out_of_range_unrecognised`,
-/// `guided_picker_non_numeric_unrecognised`.
+/// `guided_picker_non_numeric_unrecognised`,
+/// `guided_picker_bare_enter_unresumable_session_blocked`,
+/// `guided_picker_numeric_unresumable_session_blocked`.
 pub(crate) fn parse_picker_choice(
     line: &str,
     session_count: usize,
     first_needs_restart: bool,
+    unresumable: &[bool],
 ) -> PickerDecision {
     let choice = line.trim();
     if choice.eq_ignore_ascii_case("q") {
         return PickerDecision::Quit;
     }
     // #2304: `d<N>` / `d <N>` deletes the session at menu slot N. Parsed before
-    // the numeric-resume branch so the `d` prefix is unambiguous.
+    // the numeric-resume branch so the `d` prefix is unambiguous. Deleting a
+    // dead session is exactly the intended remedy, so this branch is NOT
+    // gated by `unresumable`.
     if let Some(rest) = choice.strip_prefix(['d', 'D']) {
         if let Ok(n) = rest.trim().parse::<usize>()
             && n >= 1
@@ -219,6 +248,9 @@ pub(crate) fn parse_picker_choice(
         if session_count == 0 {
             return PickerDecision::LaunchNew;
         }
+        if unresumable.first().copied().unwrap_or(false) {
+            return PickerDecision::Unresumable(0);
+        }
         return if first_needs_restart {
             PickerDecision::ConfirmRestart(0)
         } else {
@@ -227,7 +259,11 @@ pub(crate) fn parse_picker_choice(
     }
     if let Ok(n) = choice.parse::<usize>() {
         if n >= 1 && n <= session_count {
-            return PickerDecision::Resume(n - 1);
+            let idx = n - 1;
+            if unresumable.get(idx).copied().unwrap_or(false) {
+                return PickerDecision::Unresumable(idx);
+            }
+            return PickerDecision::Resume(idx);
         }
         if n == session_count + 1 {
             return PickerDecision::LaunchNew;
@@ -253,6 +289,9 @@ pub(crate) fn parse_picker_choice(
 ///     redisplays the menu (fleet-wide `tm ls` has no single launch target);
 ///   • `ConfirmRestart(i)` (#2148) → print a one-line "type the number to
 ///     confirm" notice and redisplay the SAME menu — no daemon round-trip;
+///   • `Unresumable(i)` (#2595) → print the dead-session notice pointing at
+///     `d<N>` and redisplay the SAME menu — no daemon round-trip (a resume
+///     would only ever fail: #2577/#2594);
 ///   • `Delete(i)` (#2304) → [`super::picker_delete::confirm_and_delete`] runs a
 ///     confirm (force-confirm for a running session) then the managed→local
 ///     routed delete; redisplay the re-fetched menu afterwards;
@@ -275,11 +314,27 @@ pub(crate) async fn run_tty_picker(
             .first()
             .map(|s| super::guided_resume::needs_restart(&s.state))
             .unwrap_or(false);
+        // #2595: server-computed dead-workspace flag, one per session, in menu
+        // order — the single source `parse_picker_choice` and the menu render
+        // both read so they can never disagree about which slot is dead.
+        let unresumable: Vec<bool> = sessions.iter().map(|s| s.unresumable).collect();
         if sessions.is_empty() {
             eprintln!("tm:   [Enter] launch new session");
             eprintln!("tm:   [q]     quit");
         } else {
             for (i, s) in sessions.iter().enumerate() {
+                if s.unresumable {
+                    // #2595: workspace is gone for good — never offer resume/restart;
+                    // point straight at the delete remedy instead.
+                    eprintln!(
+                        "tm:   [{}] {} ({}) — DEAD: workspace removed; use [d{}] to remove the record",
+                        i + 1,
+                        s.name,
+                        s.state,
+                        i + 1
+                    );
+                    continue;
+                }
                 // Show "restart" for sessions that are stopped/errored — they have no
                 // live tmux session and will be restarted via the daemon (#1742).
                 let stopped = matches!(s.state.as_str(), "stopped" | "errored");
@@ -289,7 +344,11 @@ pub(crate) async fn run_tty_picker(
             eprintln!("tm:   [{new_idx}] launch new session");
             eprintln!("tm:   [d<N>] delete session N (e.g. d1)");
             eprintln!("tm:   [q] quit");
-            if first_needs_restart {
+            if unresumable.first().copied().unwrap_or(false) {
+                eprintln!(
+                    "tm: [Enter] is DEAD (workspace removed) — type [d1] to remove it, or choose another"
+                );
+            } else if first_needs_restart {
                 // #2148: no implicit destructive default — an explicit [1] is required.
                 eprintln!("tm: [Enter] does NOT restart — type [1] to confirm the restart");
             } else {
@@ -306,7 +365,7 @@ pub(crate) async fn run_tty_picker(
             break;
         } // EOF (Ctrl-D): exit cleanly.
 
-        match parse_picker_choice(&line, sessions.len(), first_needs_restart) {
+        match parse_picker_choice(&line, sessions.len(), first_needs_restart, &unresumable) {
             PickerDecision::Quit => {
                 eprintln!("tm: quit.");
                 break;
@@ -341,6 +400,22 @@ pub(crate) async fn run_tty_picker(
                 );
                 eprintln!(
                     "tm: type [{}] to confirm the restart, or [q] to quit.",
+                    i + 1
+                );
+                continue;
+            }
+            // #2595: selection targeted a dead session — its workspace no longer
+            // exists anywhere on disk, so a resume/restart is guaranteed to fail
+            // (#2577/#2594). No daemon round-trip; point at the delete remedy and
+            // redisplay the SAME menu.
+            PickerDecision::Unresumable(i) => {
+                eprintln!(
+                    "tm: '{}' is dead — its workspace no longer exists anywhere on disk; \
+                     resuming it would only fail.",
+                    sessions[i].name
+                );
+                eprintln!(
+                    "tm: run [d{}] to remove the record, or choose another session.",
                     i + 1
                 );
                 continue;

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -42,9 +42,12 @@ use crate::commands::session_picker::{PickerDecision, parse_picker_choice};
 #[test]
 fn guided_picker_bare_enter_no_sessions_launches_new() {
     // Why: bare Enter with no sessions must launch a new session, not hang.
-    assert_eq!(parse_picker_choice("", 0, false), PickerDecision::LaunchNew);
     assert_eq!(
-        parse_picker_choice("  \t", 0, false),
+        parse_picker_choice("", 0, false, &[]),
+        PickerDecision::LaunchNew
+    );
+    assert_eq!(
+        parse_picker_choice("  \t", 0, false, &[]),
         PickerDecision::LaunchNew
     );
 }
@@ -54,9 +57,12 @@ fn guided_picker_bare_enter_live_session_resumes_first() {
     // Why: bare Enter when the most-recent session is LIVE (not needing a
     // restart) must resume it directly — attaching to a live pane is safe,
     // it never destroys anything (#2148).
-    assert_eq!(parse_picker_choice("", 1, false), PickerDecision::Resume(0));
     assert_eq!(
-        parse_picker_choice("  ", 3, false),
+        parse_picker_choice("", 1, false, &[]),
+        PickerDecision::Resume(0)
+    );
+    assert_eq!(
+        parse_picker_choice("  ", 3, false, &[]),
         PickerDecision::Resume(0)
     );
 }
@@ -66,12 +72,46 @@ fn guided_picker_bare_enter_stopped_session_requires_confirm() {
     // #2148: bare Enter must NOT silently restart (kill+recreate the tmux pane
     // of) a stopped/errored session — the operator must type the number.
     assert_eq!(
-        parse_picker_choice("", 1, true),
+        parse_picker_choice("", 1, true, &[]),
         PickerDecision::ConfirmRestart(0)
     );
     assert_eq!(
-        parse_picker_choice("  ", 3, true),
+        parse_picker_choice("  ", 3, true, &[]),
         PickerDecision::ConfirmRestart(0)
+    );
+}
+
+#[test]
+fn guided_picker_bare_enter_unresumable_session_blocked() {
+    // #2595: bare Enter must NEVER resume/restart a session whose workspace
+    // is gone for good — no confirmation prompt would help, since the resume
+    // is guaranteed to fail (#2577/#2594). This takes priority over
+    // `ConfirmRestart` (`first_needs_restart=true` here too — a dead session
+    // is ALWAYS stopped/errored, so both flags are set; `Unresumable` must win).
+    assert_eq!(
+        parse_picker_choice("", 1, true, &[true]),
+        PickerDecision::Unresumable(0)
+    );
+    assert_eq!(
+        parse_picker_choice("  ", 3, true, &[true, false, false]),
+        PickerDecision::Unresumable(0)
+    );
+}
+
+#[test]
+fn guided_picker_numeric_unresumable_session_blocked() {
+    // #2595: an EXPLICIT numeric choice must ALSO be blocked when it targets a
+    // dead session — the pre-#2595 comment on the numeric branch ("always
+    // restarts/resumes directly") is no longer true for this one case.
+    assert_eq!(
+        parse_picker_choice("2", 3, false, &[false, true, false]),
+        PickerDecision::Unresumable(1)
+    );
+    // A live session at a DIFFERENT index must still resume normally even
+    // when another slot in the same menu is dead.
+    assert_eq!(
+        parse_picker_choice("1", 3, false, &[false, true, false]),
+        PickerDecision::Resume(0)
     );
 }
 
@@ -79,19 +119,19 @@ fn guided_picker_bare_enter_stopped_session_requires_confirm() {
 fn guided_picker_delete_parses_d_prefix() {
     // #2304: `d<N>` / `d <N>` selects the Nth session (0-based) for deletion.
     assert_eq!(
-        parse_picker_choice("d1", 1, false),
+        parse_picker_choice("d1", 1, false, &[]),
         PickerDecision::Delete(0)
     );
     assert_eq!(
-        parse_picker_choice("d2", 3, true),
+        parse_picker_choice("d2", 3, true, &[]),
         PickerDecision::Delete(1)
     );
     assert_eq!(
-        parse_picker_choice("D3\n", 3, false),
+        parse_picker_choice("D3\n", 3, false, &[]),
         PickerDecision::Delete(2)
     );
     assert_eq!(
-        parse_picker_choice("d 2", 3, false),
+        parse_picker_choice("d 2", 3, false, &[]),
         PickerDecision::Delete(1)
     );
 }
@@ -101,15 +141,15 @@ fn guided_picker_delete_out_of_range_unrecognised() {
     // A `d`-prefixed choice outside 1..=session_count (or non-numeric) is
     // rejected — never falls through to the resume/launch branches.
     assert_eq!(
-        parse_picker_choice("d4", 3, false),
+        parse_picker_choice("d4", 3, false, &[]),
         PickerDecision::Unrecognised
     );
     assert_eq!(
-        parse_picker_choice("d0", 3, false),
+        parse_picker_choice("d0", 3, false, &[]),
         PickerDecision::Unrecognised
     );
     assert_eq!(
-        parse_picker_choice("dx", 3, false),
+        parse_picker_choice("dx", 3, false, &[]),
         PickerDecision::Unrecognised
     );
 }
@@ -117,15 +157,24 @@ fn guided_picker_delete_out_of_range_unrecognised() {
 #[test]
 fn guided_picker_q_returns_quit() {
     // Why: "q" must quit cleanly without touching tmux or the daemon.
-    assert_eq!(parse_picker_choice("q", 0, false), PickerDecision::Quit);
-    assert_eq!(parse_picker_choice("q", 3, true), PickerDecision::Quit);
+    assert_eq!(
+        parse_picker_choice("q", 0, false, &[]),
+        PickerDecision::Quit
+    );
+    assert_eq!(parse_picker_choice("q", 3, true, &[]), PickerDecision::Quit);
 }
 
 #[test]
 fn guided_picker_q_uppercase_returns_quit() {
     // Why: "Q" must be treated identically to "q" (case-insensitive).
-    assert_eq!(parse_picker_choice("Q", 2, false), PickerDecision::Quit);
-    assert_eq!(parse_picker_choice("Q\n", 0, false), PickerDecision::Quit);
+    assert_eq!(
+        parse_picker_choice("Q", 2, false, &[]),
+        PickerDecision::Quit
+    );
+    assert_eq!(
+        parse_picker_choice("Q\n", 0, false, &[]),
+        PickerDecision::Quit
+    );
 }
 
 #[test]
@@ -133,19 +182,25 @@ fn guided_picker_numeric_valid_resumes() {
     // Why: "[N]" where 1 <= N <= session_count must resume the Nth session
     // (0-based) — an EXPLICIT numeric choice always dispatches directly,
     // regardless of `first_needs_restart` (that flag only gates bare Enter).
-    assert_eq!(parse_picker_choice("1", 1, true), PickerDecision::Resume(0));
-    assert_eq!(parse_picker_choice("1", 3, true), PickerDecision::Resume(0));
     assert_eq!(
-        parse_picker_choice("2", 3, false),
+        parse_picker_choice("1", 1, true, &[]),
+        PickerDecision::Resume(0)
+    );
+    assert_eq!(
+        parse_picker_choice("1", 3, true, &[]),
+        PickerDecision::Resume(0)
+    );
+    assert_eq!(
+        parse_picker_choice("2", 3, false, &[]),
         PickerDecision::Resume(1)
     );
     assert_eq!(
-        parse_picker_choice("3", 3, false),
+        parse_picker_choice("3", 3, false, &[]),
         PickerDecision::Resume(2)
     );
     // With newline (as stdin read_line returns)
     assert_eq!(
-        parse_picker_choice("2\n", 3, false),
+        parse_picker_choice("2\n", 3, false, &[]),
         PickerDecision::Resume(1)
     );
 }
@@ -154,11 +209,11 @@ fn guided_picker_numeric_valid_resumes() {
 fn guided_picker_numeric_launch_new() {
     // Why: "[session_count+1]" must always launch a new session.
     assert_eq!(
-        parse_picker_choice("1", 0, false),
+        parse_picker_choice("1", 0, false, &[]),
         PickerDecision::LaunchNew
     );
     assert_eq!(
-        parse_picker_choice("4", 3, false),
+        parse_picker_choice("4", 3, false, &[]),
         PickerDecision::LaunchNew
     );
 }
@@ -168,15 +223,15 @@ fn guided_picker_out_of_range_unrecognised() {
     // Why: a number out of range (>session_count+1) must not silently
     // resume or launch — it must be rejected cleanly.
     assert_eq!(
-        parse_picker_choice("5", 3, false),
+        parse_picker_choice("5", 3, false, &[]),
         PickerDecision::Unrecognised
     );
     assert_eq!(
-        parse_picker_choice("100", 1, false),
+        parse_picker_choice("100", 1, false, &[]),
         PickerDecision::Unrecognised
     );
     assert_eq!(
-        parse_picker_choice("0", 3, false),
+        parse_picker_choice("0", 3, false, &[]),
         PickerDecision::Unrecognised
     );
 }
@@ -185,15 +240,15 @@ fn guided_picker_out_of_range_unrecognised() {
 fn guided_picker_non_numeric_unrecognised() {
     // Why: arbitrary text input must be rejected without panicking.
     assert_eq!(
-        parse_picker_choice("abc", 2, false),
+        parse_picker_choice("abc", 2, false, &[]),
         PickerDecision::Unrecognised
     );
     assert_eq!(
-        parse_picker_choice("exit", 0, false),
+        parse_picker_choice("exit", 0, false, &[]),
         PickerDecision::Unrecognised
     );
     assert_eq!(
-        parse_picker_choice("1a", 3, false),
+        parse_picker_choice("1a", 3, false, &[]),
         PickerDecision::Unrecognised
     );
 }
@@ -803,6 +858,7 @@ fn make_session(
         deliverable_id: None,
         pane_id: None,
         injection_status: None,
+        unresumable: false,
     }
 }
 

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -464,6 +464,24 @@ fn managed_session_summary_deserializes() {
     assert!(s.source_id.is_none());
 }
 
+/// #2595: `unresumable` must round-trip when present, and default `false`
+/// (never spuriously flag a session dead) when an older daemon omits it.
+#[test]
+fn managed_session_summary_deserializes_unresumable_flag() {
+    let with_flag = serde_json::json!({
+        "id": "x", "name": "n", "state": "stopped", "unresumable": true
+    });
+    let s: ManagedSessionSummary = serde_json::from_value(with_flag).unwrap();
+    assert!(s.unresumable, "unresumable: true must deserialize to true");
+
+    let omitted = serde_json::json!({"id": "x", "name": "n", "state": "stopped"});
+    let s: ManagedSessionSummary = serde_json::from_value(omitted).unwrap();
+    assert!(
+        !s.unresumable,
+        "an older daemon omitting `unresumable` must default to false"
+    );
+}
+
 #[test]
 fn managed_list_response_deserializes() {
     let json = serde_json::json!({

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -463,6 +463,24 @@ pub struct ManagedSessionSummary {
     /// responses without the field deserialize as `None`.
     #[serde(default)]
     pub injection_status: Option<String>,
+    /// True when this session is a dead pick: `stopped`/`errored` AND no
+    /// workdir candidate exists on disk any more, so a resume/restart is
+    /// guaranteed to fail (additive; #2595). Mirrors
+    /// `daemon::managed_routes::SessionSummary::unresumable` field-for-field.
+    ///
+    /// Why: the guided-default picker, the `tm ls` picker, and `tm sessions
+    /// ls` all read this list endpoint and must not offer — or must clearly
+    /// mark — a session whose workspace was GC-pruned; computing the
+    /// filesystem probe server-side (once) and shipping the verdict on the
+    /// wire keeps the CLI's picker/table logic pure and I/O-free.
+    /// `#[serde(default)]` keeps the client tolerant of an OLDER daemon that
+    /// omits the field — it deserializes to `false` (never spuriously flags a
+    /// session dead against a daemon that hasn't shipped this yet).
+    /// What: a plain bool, `false` for every session except a dead
+    /// `stopped`/`errored` pick.
+    /// Test: `managed_session_summary_deserializes_unresumable_flag`.
+    #[serde(default)]
+    pub unresumable: bool,
 }
 
 /// Wrapper for `GET /api/v1/sessions/managed` (the list endpoint).

--- a/crates/trusty-mpm/src/client/resolver.rs
+++ b/crates/trusty-mpm/src/client/resolver.rs
@@ -187,6 +187,7 @@ mod tests {
             deliverable_id: None,
             pane_id: None,
             injection_status: None,
+            unresumable: false,
         };
         let items = vec![summary("m-1", "tmpm-red-owl"), summary("m-2", "api")];
         assert_eq!(

--- a/crates/trusty-mpm/src/daemon/managed_routes/fleet.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/fleet.rs
@@ -16,7 +16,7 @@ use tracing::warn;
 use crate::daemon::state::DaemonState;
 use crate::session_manager::SessionRecord;
 
-use super::{SessionSummary, record_to_summary};
+use super::{SessionSummary, checked_summaries};
 
 /// Per-project group entry for GET /api/v1/sessions/managed/fleet.
 ///
@@ -56,8 +56,12 @@ pub struct FleetByProjectResponse {
 /// projects from the `ProjectRegistry`, runs `fleet_by_project` to group them,
 /// and returns a `FleetByProjectResponse` with one `FleetProjectGroup` per
 /// project (empty `sessions` list included — the operator sees the full project
-/// landscape, not just active ones).
-/// Test: `fleet_route_groups_by_project` in `tests/session_manager_mvp.rs`.
+/// landscape, not just active ones). Each session's `unresumable` flag (#2595)
+/// is computed via [`checked_summaries`] — the SAME checked, concurrently-probed
+/// path `list_managed_sessions` uses — so the TUI (the primary consumer of
+/// this route) never offers a dead session for resume either.
+/// Test: `fleet_route_groups_by_project` in `tests/session_manager_mvp.rs`;
+/// `fleet_route_marks_dead_session_unresumable` in the same file (#2595).
 pub async fn fleet_by_project_route(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
     let mgr = state.session_manager().await;
     let registry = state.project_registry().await;
@@ -81,14 +85,14 @@ pub async fn fleet_by_project_route(State(state): State<Arc<DaemonState>>) -> im
 
     let fleet = crate::project::fleet_by_project(&raw_sessions, &projects);
 
-    let project_groups: Vec<FleetProjectGroup> = fleet
-        .into_iter()
-        .map(|pf| FleetProjectGroup {
+    let mut project_groups: Vec<FleetProjectGroup> = Vec::with_capacity(fleet.len());
+    for pf in fleet {
+        project_groups.push(FleetProjectGroup {
             project_name: pf.project.name.clone(),
             repo_url: pf.project.repo_url.clone(),
-            sessions: pf.sessions.iter().map(record_to_summary).collect(),
-        })
-        .collect();
+            sessions: checked_summaries(&pf.sessions).await,
+        });
+    }
 
     Json(FleetByProjectResponse {
         projects: project_groups,

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -70,7 +70,9 @@ pub use prune::{
 pub use reactivate::reactivate_managed_session;
 pub use resume_error::ResumeManagedError;
 pub use summary::record_to_json;
-use summary::{attach_cmd_for, parse_id, record_to_summary, record_to_summary_checked};
+use summary::{
+    attach_cmd_for, checked_summaries, parse_id, record_to_summary, record_to_summary_checked,
+};
 
 // ── Request / Response shapes ─────────────────────────────────────────────────
 
@@ -652,7 +654,10 @@ pub async fn adopt_existing_session(
 /// `session_manager::resume_workdir::is_unresumable`, which short-circuits to
 /// `false` without any I/O for every state other than `Stopped`/`Errored` — so
 /// every picker/list surface reading this endpoint sees dead sessions flagged
-/// up front rather than discovering them via a failed resume.
+/// up front rather than discovering them via a failed resume. The per-session
+/// probes run CONCURRENTLY via [`summary::checked_summaries`] (#2595 review,
+/// MEDIUM finding 4) rather than one-at-a-time, so a large fleet's response
+/// latency does not scale with its count of stopped/errored sessions.
 /// Test: list handler test; list-with-source-id-filter test;
 /// `list_marks_dead_stopped_session_unresumable`,
 /// `list_leaves_live_and_healthy_stopped_sessions_unmarked`.
@@ -662,14 +667,13 @@ pub async fn list_managed_sessions(
 ) -> impl IntoResponse {
     let mgr = state.session_manager().await;
     let sid_filter = q.get("source_id").map(String::as_str);
-    let records = mgr.list().await;
-    let mut sessions = Vec::new();
-    for r in records
-        .iter()
+    let records: Vec<_> = mgr
+        .list()
+        .await
+        .into_iter()
         .filter(|r| sid_filter.is_none_or(|sid| r.source_id.as_deref() == Some(sid)))
-    {
-        sessions.push(record_to_summary_checked(r).await);
-    }
+        .collect();
+    let sessions = checked_summaries(&records).await;
     Json(ListSessionsResponse { sessions })
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -70,7 +70,7 @@ pub use prune::{
 pub use reactivate::reactivate_managed_session;
 pub use resume_error::ResumeManagedError;
 pub use summary::record_to_json;
-use summary::{attach_cmd_for, parse_id, record_to_summary};
+use summary::{attach_cmd_for, parse_id, record_to_summary, record_to_summary_checked};
 
 // ── Request / Response shapes ─────────────────────────────────────────────────
 
@@ -323,6 +323,30 @@ pub struct SessionSummary {
     /// reached `Active`) — see `session_manager::InjectionStatus::NotApplicable`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub injection_status: Option<String>,
+    /// True when this session is a dead pick: it is `stopped`/`errored` AND no
+    /// workdir candidate (`last_cwd`, `workspace_path`, `cwd`) exists on disk
+    /// any more, so a resume is guaranteed to fail (#2595).
+    ///
+    /// Why: #2577/#2594 fixed the ERROR an operator sees after picking a
+    /// GC-pruned session to restart (bare 500 → actionable 422); the deeper UX
+    /// defect was that such a session was OFFERED as a restart option at all.
+    /// Computing this once here — server-side, where the full record (`last_cwd`
+    /// included) and filesystem access both live — lets every listing surface
+    /// (the bare-`tm` guided default, the `tm ls` picker, and `tm sessions ls`,
+    /// all of which read this same list endpoint) mark/exclude the session
+    /// BEFORE the operator selects it, instead of only failing loudly after the
+    /// fact. Always `false` for live/provisioning/decommissioned sessions —
+    /// see `session_manager::resume_workdir::is_unresumable`.
+    /// What: computed by [`list_managed_sessions`]/[`get_managed_session`] via
+    /// `session_manager::resume_workdir::is_unresumable`; every other handler
+    /// that builds a `SessionSummary` via `record_to_summary` leaves it at its
+    /// `false` default (freshly spawned/reactivated/decommissioned sessions are
+    /// never mid-flight through this predicate).
+    /// Test: `list_marks_dead_stopped_session_unresumable`,
+    /// `list_leaves_live_and_healthy_stopped_sessions_unmarked` in
+    /// `super::tests`.
+    #[serde(default)]
+    pub unresumable: bool,
 }
 
 /// Response body for POST /api/v1/sessions/managed/{id}/decommission.
@@ -623,21 +647,29 @@ pub async fn adopt_existing_session(
 /// their state, and pending decisions.
 /// What: returns all session records as a JSON list of summaries. When the
 /// optional `?source_id=<id>` query parameter is present, only sessions whose
-/// `source_id` matches exactly are returned.
-/// Test: list handler test; list-with-source-id-filter test.
+/// `source_id` matches exactly are returned. Each summary's `unresumable` flag
+/// (#2595) is computed here — via
+/// `session_manager::resume_workdir::is_unresumable`, which short-circuits to
+/// `false` without any I/O for every state other than `Stopped`/`Errored` — so
+/// every picker/list surface reading this endpoint sees dead sessions flagged
+/// up front rather than discovering them via a failed resume.
+/// Test: list handler test; list-with-source-id-filter test;
+/// `list_marks_dead_stopped_session_unresumable`,
+/// `list_leaves_live_and_healthy_stopped_sessions_unmarked`.
 pub async fn list_managed_sessions(
     State(state): State<Arc<DaemonState>>,
     axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> impl IntoResponse {
     let mgr = state.session_manager().await;
     let sid_filter = q.get("source_id").map(String::as_str);
-    let sessions: Vec<SessionSummary> = mgr
-        .list()
-        .await
+    let records = mgr.list().await;
+    let mut sessions = Vec::new();
+    for r in records
         .iter()
         .filter(|r| sid_filter.is_none_or(|sid| r.source_id.as_deref() == Some(sid)))
-        .map(record_to_summary)
-        .collect();
+    {
+        sessions.push(record_to_summary_checked(r).await);
+    }
     Json(ListSessionsResponse { sessions })
 }
 
@@ -645,7 +677,10 @@ pub async fn list_managed_sessions(
 ///
 /// Why: the calling agentic process needs the full record for a specific session
 /// including workspace_path, repo_url, branch, and pending decision fields.
-/// What: looks up the session by id and returns its summary.
+/// What: looks up the session by id and returns its summary, with `unresumable`
+/// (#2595) computed the same way [`list_managed_sessions`] does — kept
+/// consistent so `tm session info <id>` never disagrees with the list/picker
+/// about whether a session is a dead pick.
 /// Test: get handler test.
 pub async fn get_managed_session(
     State(state): State<Arc<DaemonState>>,
@@ -657,7 +692,7 @@ pub async fn get_managed_session(
     };
     let mgr = state.session_manager().await;
     match mgr.get(&id).await {
-        Ok(record) => Json(record_to_summary(&record)).into_response(),
+        Ok(record) => Json(record_to_summary_checked(&record).await).into_response(),
         Err(_) => (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response(),
     }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -14,7 +14,9 @@
 
 use axum::http::StatusCode;
 
-use crate::session_manager::{InjectionStatus, ManagedSessionId, SessionRecord};
+use crate::session_manager::{
+    InjectionStatus, ManagedSessionId, ManagedSessionState, SessionRecord,
+};
 
 use super::SessionSummary;
 
@@ -125,6 +127,54 @@ pub(super) async fn record_to_summary_checked(r: &SessionRecord) -> SessionSumma
     let mut summary = record_to_summary(r);
     summary.unresumable = crate::session_manager::resume_workdir::is_unresumable(r).await;
     summary
+}
+
+/// [`record_to_summary`] for MANY records, running each `unresumable` probe
+/// concurrently rather than one-at-a-time (#2595 review, MEDIUM finding 4).
+///
+/// Why: `list_managed_sessions` originally awaited [`record_to_summary_checked`]
+/// sequentially in a `for` loop — for a fleet of N sessions that serializes N
+/// `tokio::fs::try_exists`-backed round trips even though they are entirely
+/// independent. `is_unresumable` already short-circuits with NO I/O for any
+/// state other than `Stopped`/`Errored` (the state gate), so only that subset
+/// ever pays the probe cost — fan out exactly those via `tokio::task::JoinSet`
+/// (unconditional `tokio` dependency; the workspace's optional `futures` crate
+/// is feature-gated and not assumed available to every daemon route) rather
+/// than every record.
+/// What: builds every summary synchronously first via [`record_to_summary`]
+/// (cheap, no I/O — preserves `records`' order), then spawns one
+/// `is_unresumable` task per `Stopped`/`Errored` record (each tagged with its
+/// original index so `JoinSet`'s out-of-completion-order yield can never
+/// reorder the response), and patches each result back into its slot as
+/// tasks complete. A panicking probe task is dropped silently — that summary
+/// simply keeps its `record_to_summary` default (`unresumable: false`)
+/// rather than failing the whole list response.
+/// Test: `checked_summaries_preserves_input_order_and_flags_only_dead_sessions`
+/// in `super::tests`; end-to-end coverage via `list_marks_dead_stopped_session_unresumable`,
+/// `list_leaves_live_and_healthy_stopped_sessions_unmarked` in
+/// `tests/session_manager_mvp.rs`.
+pub(super) async fn checked_summaries(records: &[SessionRecord]) -> Vec<SessionSummary> {
+    let mut summaries: Vec<SessionSummary> = records.iter().map(record_to_summary).collect();
+
+    let mut probes = tokio::task::JoinSet::new();
+    for (idx, r) in records.iter().enumerate() {
+        if matches!(
+            r.state,
+            ManagedSessionState::Stopped | ManagedSessionState::Errored
+        ) {
+            let r = r.clone();
+            probes.spawn(async move {
+                let unresumable = crate::session_manager::resume_workdir::is_unresumable(&r).await;
+                (idx, unresumable)
+            });
+        }
+    }
+    while let Some(res) = probes.join_next().await {
+        if let Ok((idx, unresumable)) = res {
+            summaries[idx].unresumable = unresumable;
+        }
+    }
+    summaries
 }
 
 /// Build the tmux attach command string for a session.

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -75,7 +75,14 @@ fn injection_status_wire(status: InjectionStatus) -> Option<String> {
 ///
 /// Why: the API exposes a flat, string-typed summary so clients don't depend on
 /// the internal record shape.
-/// What: maps every record field to its serialized form.
+/// What: maps every record field to its serialized form. `unresumable` always
+/// starts `false` here — it requires an async filesystem probe
+/// (`session_manager::resume_workdir::is_unresumable`), which this function
+/// cannot perform since it is a pure/sync conversion shared by handlers that
+/// have no reason to pay that cost (spawn/reactivate/decommission are never
+/// mid-flight through the dead-workspace predicate). The list/get handlers
+/// (#2595) overwrite the field on the returned value when they can await the
+/// probe.
 /// Test: covered by the list/get handler tests.
 pub(super) fn record_to_summary(r: &SessionRecord) -> SessionSummary {
     SessionSummary {
@@ -99,7 +106,25 @@ pub(super) fn record_to_summary(r: &SessionRecord) -> SessionSummary {
         deliverable_id: r.deliverable_id.map(|id| id.to_string()),
         pane_id: r.pane_id.clone(),
         injection_status: injection_status_wire(r.injection_status),
+        unresumable: false,
     }
+}
+
+/// [`record_to_summary`] plus the async `unresumable` probe (#2595).
+///
+/// Why: `list_managed_sessions`/`get_managed_session` are the two handlers
+/// that can afford the filesystem probe (both already `.await` the session
+/// manager). Folding "convert, then overwrite the flag" into one call here —
+/// rather than repeating it inline at each handler — keeps `mod.rs`'s handler
+/// bodies a single line each (`mod.rs` sits at its 500-SLOC production cap).
+/// What: [`record_to_summary`], then overwrites `unresumable` via
+/// `session_manager::resume_workdir::is_unresumable`.
+/// Test: `list_marks_dead_stopped_session_unresumable`,
+/// `list_leaves_live_and_healthy_stopped_sessions_unmarked` in `super::tests`.
+pub(super) async fn record_to_summary_checked(r: &SessionRecord) -> SessionSummary {
+    let mut summary = record_to_summary(r);
+    summary.unresumable = crate::session_manager::resume_workdir::is_unresumable(r).await;
+    summary
 }
 
 /// Build the tmux attach command string for a session.

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 use chrono::Utc;
 
-use super::{record_to_json, record_to_summary};
+use super::{checked_summaries, record_to_json, record_to_summary};
 use crate::session_manager::{
     InjectionStatus, ManagedSessionId, ManagedSessionState, SessionRecord,
 };
@@ -287,3 +287,66 @@ fn injection_status_wire_stringifies_other_variants() {
 // `unresumable_response`'s header-tagging behavior is unit-tested beside its
 // definition in `resume_error.rs` (#2577 review) — see
 // `resume_error::tests::unresumable_response_tags_reason_header_per_failure_class`.
+
+/// #2595 review (PR #2652, MEDIUM finding 4): [`checked_summaries`] fans its
+/// per-record `unresumable` probes out concurrently via `JoinSet`, which
+/// yields completed tasks in COMPLETION order, not submission order — this
+/// pins that the returned `Vec<SessionSummary>` is nonetheless rebuilt in the
+/// SAME order as the input `records` slice, and that only the genuinely-dead
+/// record among a live/dead/healthy-stopped trio gets flagged.
+#[tokio::test]
+async fn checked_summaries_preserves_input_order_and_flags_only_dead_sessions() {
+    // r0: Active — the state gate alone skips the filesystem probe.
+    let mut r0 = make_record(None);
+    r0.state = ManagedSessionState::Active;
+
+    // r1: Stopped with NO existing workdir candidate — must end up dead.
+    let mut r1 = make_record(None);
+    r1.state = ManagedSessionState::Stopped;
+    r1.cwd = PathBuf::from("/nonexistent/checked-summaries-order-r1");
+    r1.workspace_path = None;
+    r1.last_cwd = None;
+
+    // r2: Errored but its `cwd` genuinely exists — must stay resumable.
+    let real_dir = tempfile::TempDir::new().expect("tempdir for r2");
+    let mut r2 = make_record(None);
+    r2.state = ManagedSessionState::Errored;
+    r2.cwd = real_dir.path().to_path_buf();
+    r2.workspace_path = None;
+    r2.last_cwd = None;
+
+    let records = vec![r0.clone(), r1.clone(), r2.clone()];
+    let summaries = checked_summaries(&records).await;
+
+    assert_eq!(summaries.len(), 3, "one summary per input record");
+    // Order must match the input slice exactly, regardless of which probe
+    // task happened to finish first.
+    assert_eq!(
+        summaries[0].id,
+        r0.id.to_string(),
+        "r0 must stay at index 0"
+    );
+    assert_eq!(
+        summaries[1].id,
+        r1.id.to_string(),
+        "r1 must stay at index 1"
+    );
+    assert_eq!(
+        summaries[2].id,
+        r2.id.to_string(),
+        "r2 must stay at index 2"
+    );
+
+    assert!(
+        !summaries[0].unresumable,
+        "an Active session must never be flagged, regardless of probe fan-out"
+    );
+    assert!(
+        summaries[1].unresumable,
+        "a stopped session with no existing workdir candidate must be flagged dead"
+    );
+    assert!(
+        !summaries[2].unresumable,
+        "an errored session with a REAL existing cwd must stay resumable"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -172,6 +172,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         deliverable_id: None,
         pane_id: None,
         injection_status: None,
+        unresumable: false,
     };
     let resp_owned = DecommissionResponse {
         summary: owned_summary,
@@ -205,6 +206,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         deliverable_id: None,
         pane_id: None,
         injection_status: None,
+        unresumable: false,
     };
     let resp_unowned = DecommissionResponse {
         summary: unowned_summary,

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -23,7 +23,7 @@ pub mod reactivate;
 mod reconcile;
 pub mod record;
 pub mod restart_ops;
-mod resume_workdir;
+pub(crate) mod resume_workdir;
 pub mod search_gc;
 pub mod session_guard;
 pub mod snapshot;

--- a/crates/trusty-mpm/src/session_manager/resume_workdir.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_workdir.rs
@@ -105,11 +105,29 @@ pub(super) async fn resolve_existing_workdir(
 /// `Stopped`/`Errored` (no I/O). For `Stopped`/`Errored`, probes the SAME
 /// three candidates [`resolve_existing_workdir`] does (via
 /// [`workdir_candidates`]) with `tokio::fs::try_exists`; returns `true` only
-/// when NONE exist — i.e. exactly the condition under which
-/// `resolve_existing_workdir` would return `WorkspaceMissing`.
+/// when every candidate probe comes back `Ok(false)` (definitively absent).
+///
+/// **Deliberately diverges from [`resolve_existing_workdir`] on a probe
+/// `Err`** (PR #2652 review, MEDIUM finding 3): this predicate is FAIL-OPEN —
+/// a transient I/O/permission/network-volume error on any candidate is
+/// treated as "possibly present" and short-circuits to `false` (never
+/// flagged dead), the same as `Ok(true)`. `resolve_existing_workdir` keeps
+/// its existing `Err → treat as absent` behavior (`.unwrap_or(false)`)
+/// UNCHANGED — the two callers have opposite failure trade-offs by design:
+/// `resolve_existing_workdir` guards an ACTUAL resume attempt, where refusing
+/// to hand tmux a possibly-bad path on an unprobable candidate is the SAFE
+/// failure mode (#2250's original "never silently fall back" intent), and the
+/// #2594 422 the operator sees is retryable. This predicate instead gates
+/// whether a session is even OFFERED in a picker — wrongly flagging it dead
+/// on a transient probe error leaves the operator with only a destructive
+/// delete as the way out, which is the wrong trade-off for a condition that
+/// may clear on the next poll. `workdir_candidates` (the candidate LIST) is
+/// still shared so the two can never disagree about WHICH paths to check —
+/// only how an inconclusive probe on one of them is interpreted.
 /// Test: `is_unresumable_true_when_all_candidates_missing_and_stopped`,
 /// `is_unresumable_false_when_any_candidate_exists`,
-/// `is_unresumable_false_for_non_stopped_states_even_when_all_missing`.
+/// `is_unresumable_false_for_non_stopped_states_even_when_all_missing`,
+/// `is_unresumable_fails_open_on_probe_error`.
 pub(crate) async fn is_unresumable(record: &SessionRecord) -> bool {
     if !matches!(
         record.state,
@@ -118,8 +136,12 @@ pub(crate) async fn is_unresumable(record: &SessionRecord) -> bool {
         return false;
     }
     for candidate in workdir_candidates(record).into_iter().flatten() {
-        if tokio::fs::try_exists(candidate).await.unwrap_or(false) {
-            return false;
+        match tokio::fs::try_exists(candidate).await {
+            // Definitively present, or the probe itself couldn't tell
+            // (permission denied, transient I/O, an unmounted network
+            // volume, …) — either way, do NOT flag this session dead.
+            Ok(true) | Err(_) => return false,
+            Ok(false) => continue,
         }
     }
     true
@@ -369,6 +391,41 @@ mod tests {
                 record.state
             );
         }
+    }
+
+    /// #2595 (PR #2652 review, MEDIUM finding 3): a probe `Err` on a
+    /// candidate — NOT "not found", a genuine I/O failure — must fail OPEN
+    /// (never flag the session dead), the opposite of `resolve_existing_workdir`'s
+    /// `Err → treat as absent` behavior (see [`is_unresumable`]'s doc for why
+    /// the two callers deliberately diverge here).
+    #[tokio::test]
+    async fn is_unresumable_fails_open_on_probe_error() {
+        // A regular FILE used as a directory component makes any stat of a
+        // path beneath it fail with ENOTDIR — a genuine I/O error, not
+        // "not found" — which is a reliable, cross-platform way to force
+        // `tokio::fs::try_exists` into its `Err` branch rather than `Ok(false)`.
+        let dir = TempDir::new().unwrap();
+        let not_a_dir = dir.path().join("this-is-a-file-not-a-dir");
+        std::fs::write(&not_a_dir, b"x").expect("write stand-in file");
+        let unprobable = not_a_dir.join("child-cannot-be-stat-ed");
+
+        // Placed as `last_cwd` — the FIRST candidate checked — so the
+        // fail-open short-circuit fires before `workspace_path`/`cwd` (both
+        // definitely-missing) are ever reached.
+        let mut record = make_record(
+            PathBuf::from("/nonexistent/cwd-2595-failopen"),
+            Some(PathBuf::from("/nonexistent/workspace-2595-failopen")),
+            Some(unprobable),
+        );
+        record.state = ManagedSessionState::Stopped;
+
+        assert!(
+            !is_unresumable(&record).await,
+            "a probe error on any candidate must fail OPEN (never flag dead) — a \
+             transient I/O/permission/network-volume error is not proof the \
+             workspace is gone, and the picker's only override would otherwise \
+             be a destructive delete"
+        );
     }
 
     /// Minimal `ManagedTmuxDriver` test double whose `get_pane_cwd` is

--- a/crates/trusty-mpm/src/session_manager/resume_workdir.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_workdir.rs
@@ -24,15 +24,34 @@
 //! `resolve_existing_workdir_falls_back_through_candidates`,
 //! `resolve_existing_workdir_errors_when_all_missing`,
 //! `verify_pane_cwd_ok_on_match`, `verify_pane_cwd_ok_when_unknown`,
-//! `verify_pane_cwd_errors_on_mismatch` (this file's `#[cfg(test)]` module);
-//! end-to-end coverage of the recreate branch lives in
+//! `verify_pane_cwd_errors_on_mismatch`, `is_unresumable_*` (this file's
+//! `#[cfg(test)]` module); end-to-end coverage of the recreate branch lives in
 //! `resume_reattach_tests.rs`.
 
 use std::path::{Path, PathBuf};
 
 use super::ManagedTmuxDriver;
 use super::manager::ManagedError;
-use super::record::{ManagedSessionId, SessionRecord};
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+/// The three resume-workdir candidates for `record`, in priority order.
+///
+/// Why: [`resolve_existing_workdir`] and [`is_unresumable`] (#2595) must probe
+/// the EXACT same candidates in the EXACT same order — a divergence here would
+/// mean a session `resolve_existing_workdir` can still resume gets flagged
+/// dead (or vice versa). Factoring the candidate list out of both callers
+/// makes that impossible.
+/// What: `[last_cwd, workspace_path, cwd]`, `None`-filtered by the caller via
+/// `.into_iter().flatten()`.
+/// Test: exercised transitively by every `resolve_existing_workdir_*` and
+/// `is_unresumable_*` test.
+fn workdir_candidates(record: &SessionRecord) -> [Option<&Path>; 3] {
+    [
+        record.last_cwd.as_deref(),
+        record.workspace_path.as_deref(),
+        Some(record.cwd.as_path()),
+    ]
+}
 
 /// Pick the first candidate workdir that exists on disk, in priority order.
 ///
@@ -43,11 +62,11 @@ use super::record::{ManagedSessionId, SessionRecord};
 /// parameters) purely to keep the call site in `manager.rs` — already at its
 /// 500-SLOC cap — a single short line.
 /// What: checks `record.last_cwd`, then `record.workspace_path`, then
-/// `record.cwd` in order via `tokio::fs::try_exists` (non-blocking); returns
-/// the first that exists. When none do, returns
-/// [`ManagedError::WorkspaceMissing`] carrying `id` and the most-informative
-/// candidate (`workspace_path` if set, else `cwd`) so the operator knows
-/// exactly which directory vanished.
+/// `record.cwd` in order (via [`workdir_candidates`]) using
+/// `tokio::fs::try_exists` (non-blocking); returns the first that exists.
+/// When none do, returns [`ManagedError::WorkspaceMissing`] carrying `id` and
+/// the most-informative candidate (`workspace_path` if set, else `cwd`) so the
+/// operator knows exactly which directory vanished.
 /// Test: `resolve_existing_workdir_prefers_first_existing`,
 /// `resolve_existing_workdir_falls_back_through_candidates`,
 /// `resolve_existing_workdir_errors_when_all_missing`.
@@ -55,21 +74,55 @@ pub(super) async fn resolve_existing_workdir(
     id: &ManagedSessionId,
     record: &SessionRecord,
 ) -> Result<PathBuf, ManagedError> {
-    let (last_cwd, workspace_path, cwd) = (
-        record.last_cwd.as_deref(),
-        record.workspace_path.as_deref(),
-        record.cwd.as_path(),
-    );
-    for candidate in [last_cwd, workspace_path, Some(cwd)].into_iter().flatten() {
+    for candidate in workdir_candidates(record).into_iter().flatten() {
         if tokio::fs::try_exists(candidate).await.unwrap_or(false) {
             return Ok(candidate.to_path_buf());
         }
     }
-    let missing = workspace_path.unwrap_or(cwd);
+    let missing = record.workspace_path.as_deref().unwrap_or(&record.cwd);
     Err(ManagedError::WorkspaceMissing(
         id.to_string(),
         missing.display().to_string(),
     ))
+}
+
+/// The shared "unresumable" predicate (#2595): true when a stopped/errored
+/// session has NO workdir candidate left on disk, meaning any resume attempt
+/// is guaranteed to fail with [`ManagedError::WorkspaceMissing`].
+///
+/// Why (#2595, builds on #2594's `ResumeManagedError::Unresumable` semantics):
+/// before this, an operator-facing session picker offered "restart" for a
+/// session whose workspace had been GC-pruned — the restart could only ever
+/// 422. #2594 fixed the ERROR response; this predicate lets every LISTING
+/// surface (the bare-`tm` guided default, `tm ls`, `tm sessions ls` — all of
+/// which read `GET /api/v1/sessions/managed`) exclude/flag the session
+/// BEFORE the operator ever selects it, instead of only failing loudly after
+/// the fact. Gated to `Stopped`/`Errored` (mirrors the CLI's own
+/// `guided_resume::needs_restart`) because a live/provisioning session has (or
+/// is about to have) a real tmux pane — whether its ORIGINAL workdir still
+/// exists is irrelevant to whether it can be resumed (reattached).
+/// What: returns `false` immediately for any state other than
+/// `Stopped`/`Errored` (no I/O). For `Stopped`/`Errored`, probes the SAME
+/// three candidates [`resolve_existing_workdir`] does (via
+/// [`workdir_candidates`]) with `tokio::fs::try_exists`; returns `true` only
+/// when NONE exist — i.e. exactly the condition under which
+/// `resolve_existing_workdir` would return `WorkspaceMissing`.
+/// Test: `is_unresumable_true_when_all_candidates_missing_and_stopped`,
+/// `is_unresumable_false_when_any_candidate_exists`,
+/// `is_unresumable_false_for_non_stopped_states_even_when_all_missing`.
+pub(crate) async fn is_unresumable(record: &SessionRecord) -> bool {
+    if !matches!(
+        record.state,
+        ManagedSessionState::Stopped | ManagedSessionState::Errored
+    ) {
+        return false;
+    }
+    for candidate in workdir_candidates(record).into_iter().flatten() {
+        if tokio::fs::try_exists(candidate).await.unwrap_or(false) {
+            return false;
+        }
+    }
+    true
 }
 
 /// Verify a freshly created tmux pane actually landed at `expected`.
@@ -250,6 +303,71 @@ mod tests {
                 assert_eq!(path, missing_workspace.display().to_string());
             }
             other => panic!("expected WorkspaceMissing, got {other:?}"),
+        }
+    }
+
+    // ── is_unresumable (#2595) ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn is_unresumable_true_when_all_candidates_missing_and_stopped() {
+        let mut record = make_record(
+            PathBuf::from("/nonexistent/cwd-2595"),
+            Some(PathBuf::from("/nonexistent/workspace-2595")),
+            Some(PathBuf::from("/nonexistent/last-cwd-2595")),
+        );
+        record.state = ManagedSessionState::Stopped;
+        assert!(
+            is_unresumable(&record).await,
+            "stopped session with no existing candidate must be unresumable"
+        );
+
+        // Errored is the sibling resumable-from state and must behave identically.
+        record.state = ManagedSessionState::Errored;
+        assert!(
+            is_unresumable(&record).await,
+            "errored session with no existing candidate must be unresumable"
+        );
+    }
+
+    #[tokio::test]
+    async fn is_unresumable_false_when_any_candidate_exists() {
+        let cwd = TempDir::new().unwrap();
+        // Only `cwd` (the last-resort candidate) exists on disk; last_cwd and
+        // workspace_path are both gone — this must still be resumable, exactly
+        // mirroring `resolve_existing_workdir`'s fallback-to-cwd behavior.
+        let mut record = make_record(
+            cwd.path().to_owned(),
+            Some(PathBuf::from("/nonexistent/workspace-2595")),
+            Some(PathBuf::from("/nonexistent/last-cwd-2595")),
+        );
+        record.state = ManagedSessionState::Stopped;
+        assert!(
+            !is_unresumable(&record).await,
+            "a session with ANY existing candidate must not be flagged unresumable"
+        );
+    }
+
+    #[tokio::test]
+    async fn is_unresumable_false_for_non_stopped_states_even_when_all_missing() {
+        // Why: a live/provisioning session already has (or is about to have) a
+        // real tmux pane; whether its original workdir still exists on disk is
+        // irrelevant to whether it can be resumed (reattached). The predicate
+        // must short-circuit to `false` WITHOUT probing the filesystem.
+        let mut record = make_record(
+            PathBuf::from("/nonexistent/cwd-2595"),
+            Some(PathBuf::from("/nonexistent/workspace-2595")),
+            Some(PathBuf::from("/nonexistent/last-cwd-2595")),
+        );
+        for state in [
+            ManagedSessionState::Active,
+            ManagedSessionState::Provisioning,
+        ] {
+            record.state = state;
+            assert!(
+                !is_unresumable(&record).await,
+                "state {:?} must never be flagged unresumable regardless of workdir",
+                record.state
+            );
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/events/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/events/mod.rs
@@ -230,9 +230,7 @@ pub fn handle_key(state: &mut ProjectCtlState, key: KeyEvent) -> Option<PendingA
             }
         }
         KeyCode::Char('k') if state.focus == Pane::Sessions => request_kill(state),
-        KeyCode::Char('r') if state.focus == Pane::Sessions => {
-            selected_session_action(state, PendingAction::Resume)
-        }
+        KeyCode::Char('r') if state.focus == Pane::Sessions => request_resume(state),
         KeyCode::Char('d') if state.focus == Pane::Sessions => request_decommission(state),
         KeyCode::Char('a') if state.focus == Pane::Sessions => {
             selected_session_action(state, PendingAction::Attach)
@@ -295,6 +293,40 @@ fn request_kill(state: &mut ProjectCtlState) -> Option<PendingAction> {
     }
 }
 
+/// `r` in the Sessions pane: resume the selected session.
+///
+/// Why (#2595): a session flagged `unresumable` — `stopped`/`errored` with no
+/// `last_cwd`/`workspace_path`/`cwd` candidate left on disk — can never
+/// actually resume; the daemon's `/resume` would only return the #2594 422.
+/// Mirrors the CLI picker's `PickerDecision::Unresumable` guard
+/// (`bin/tm/commands/session_picker.rs`), adapted to the TUI's
+/// notice-instead-of-daemon-round-trip idiom: no confirm gate is needed here
+/// (nothing destructive to confirm) — just a refusal with the same
+/// "workspace removed — remove the record instead" remedy the picker gives,
+/// pointing at the TUI's own `d` (decommission) key rather than the CLI's
+/// `d<N>` delete verb.
+/// What: no selection → notice, `None`. `unresumable` → sets the dead-session
+/// notice, `None`, no daemon round trip. Otherwise →
+/// `Some(PendingAction::Resume(id))` immediately.
+/// Test: `super::tests::resume_on_unresumable_session_is_blocked`,
+/// `super::tests::resume_on_healthy_session_fires_immediately`.
+fn request_resume(state: &mut ProjectCtlState) -> Option<PendingAction> {
+    let Some(session) = state.selected_session().cloned() else {
+        state.set_notice("select a session first");
+        return None;
+    };
+    if session.unresumable {
+        state.set_notice(format!(
+            "'{}' is dead — its workspace no longer exists on disk; resuming it would only \
+             fail. Press [d] to decommission it instead.",
+            session.name
+        ));
+        None
+    } else {
+        Some(PendingAction::Resume(session.id))
+    }
+}
+
 /// `d` in the Sessions pane: decommission the selected session.
 ///
 /// Why: DOC-35 §5.2 — decommission ALWAYS requires a confirmation gate
@@ -347,9 +379,14 @@ fn move_selection(state: &mut ProjectCtlState, dir: Direction) {
 /// Build a session-targeted [`PendingAction`] from the current selection, or
 /// set an explanatory notice when none is selected.
 ///
-/// Why: `k`/`r`/`d`/`a` share the identical "need a selected session" guard;
-/// factoring it out keeps [`handle_key`]'s match arms one line each.
-/// What: `build` is a tuple-variant constructor (e.g. `PendingAction::Kill`);
+/// Why: `a` (and, before #2595 added its own `unresumable` gate, `r` too)
+/// needs the identical "need a selected session" guard; factoring it out
+/// keeps [`handle_key`]'s match arm one line. `k`/`d`/`r` each layer an
+/// additional gate on top (`request_kill`'s Active-confirm,
+/// `request_decommission`'s unconditional confirm, `request_resume`'s
+/// #2595 dead-session refusal) and so implement the same "no selection →
+/// notice" check themselves rather than calling this helper.
+/// What: `build` is a tuple-variant constructor (e.g. `PendingAction::Attach`);
 /// returns `Some(build(selected session id))` or sets a notice and returns
 /// `None`.
 fn selected_session_action(

--- a/crates/trusty-mpm/src/tui/project_ctl/events/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/events/tests.rs
@@ -81,6 +81,7 @@ fn seeded_state() -> ProjectCtlState {
             pending_decision: None,
             proposed_default: None,
             deliverable_id: None,
+            unresumable: false,
         }],
     );
     state.projects_nav.sync_len(state.projects.len());
@@ -170,6 +171,48 @@ fn resume_and_attach_target_selected_session_immediately() {
         Some(PendingAction::Attach("sess-1".to_string()))
     );
     assert!(state.pending_confirm.is_none());
+}
+
+/// #2595: `r` on a session flagged `unresumable` must NOT fire
+/// `PendingAction::Resume` — its workspace is gone for good, so the daemon
+/// round trip can only 422 (#2594). Mirrors the CLI picker's
+/// `PickerDecision::Unresumable` guard, adapted to the TUI's notice idiom: no
+/// confirm gate, just a refusal pointing at `d` (decommission) instead.
+#[test]
+fn resume_on_unresumable_session_is_blocked() {
+    let mut state = seeded_state();
+    state.focus = Pane::Sessions;
+    state.sessions_by_project.get_mut("alpha").unwrap()[0].unresumable = true;
+
+    let action = handle_key(&mut state, key(KeyCode::Char('r')));
+    assert!(
+        action.is_none(),
+        "a dead session must never produce PendingAction::Resume"
+    );
+    assert!(state.pending_confirm.is_none());
+    let notice = state.notice.as_deref().unwrap_or_default();
+    assert!(
+        notice.contains("dead") || notice.to_lowercase().contains("workspace"),
+        "notice should explain the session is dead / workspace missing, got {notice:?}"
+    );
+    assert!(
+        notice.contains('d'),
+        "notice should point at the [d] decommission remedy, got {notice:?}"
+    );
+}
+
+/// #2595 counterpart: a HEALTHY session (`unresumable: false`, the default)
+/// must still fire `PendingAction::Resume` immediately — the guard must not
+/// over-fire and block ordinary resumes.
+#[test]
+fn resume_on_healthy_session_fires_immediately() {
+    let mut state = seeded_state();
+    state.focus = Pane::Sessions;
+    assert_eq!(
+        handle_key(&mut state, key(KeyCode::Char('r'))),
+        Some(PendingAction::Resume("sess-1".to_string()))
+    );
+    assert!(state.notice.is_none());
 }
 
 // ---- DOC-35 §6 config form (#2120) --------------------------------------

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/activity.rs
@@ -190,6 +190,7 @@ mod tests {
             pending_decision: None,
             proposed_default: None,
             deliverable_id: None,
+            unresumable: false,
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/sessions.rs
@@ -233,6 +233,7 @@ mod tests {
             pending_decision: None,
             proposed_default: None,
             deliverable_id: None,
+            unresumable: false,
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
@@ -98,9 +98,11 @@ pub(crate) fn live_session_rows(sessions: Vec<ManagedSessionSummary>) -> Vec<Ses
 /// [`super::refresh_activity`]), never the whole list.
 /// What: derives the 8-hex short id via [`session_short_id`] and copies the
 /// rest through unchanged, including `deliverable_id` (DOC-35 §10.6, #2383 —
-/// drives the Sessions-pane deliverable glyph).
+/// drives the Sessions-pane deliverable glyph) and `unresumable` (#2595 —
+/// gates the `r` resume key).
 /// Test: `session_to_row_derives_short_id_and_copies_fields`,
-/// `session_to_row_carries_deliverable_id`.
+/// `session_to_row_carries_deliverable_id`,
+/// `session_to_row_carries_unresumable_flag`.
 pub(crate) fn session_to_row(s: ManagedSessionSummary) -> SessionRow {
     let short_id = session_short_id(&s.id);
     SessionRow {
@@ -113,6 +115,7 @@ pub(crate) fn session_to_row(s: ManagedSessionSummary) -> SessionRow {
         pending_decision: s.pending_decision,
         proposed_default: s.proposed_default,
         deliverable_id: s.deliverable_id,
+        unresumable: s.unresumable,
     }
 }
 
@@ -251,6 +254,22 @@ mod tests {
 
         let none_row = session_to_row(summary("aaaaaaaabbbb", "active"));
         assert!(none_row.deliverable_id.is_none());
+    }
+
+    /// #2595: the `unresumable` flag must survive the DTO → row projection —
+    /// this is what lets `events::request_resume` refuse a dead session.
+    #[test]
+    fn session_to_row_carries_unresumable_flag() {
+        let mut s = summary("dead0001", "stopped");
+        s.unresumable = true;
+        let row = session_to_row(s);
+        assert!(row.unresumable, "unresumable must copy through as true");
+
+        let healthy_row = session_to_row(summary("healthy1", "stopped"));
+        assert!(
+            !healthy_row.unresumable,
+            "a healthy session must copy through as false"
+        );
     }
 
     // ---- #2476: decommissioned sessions never reach the Sessions pane ----

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
@@ -199,6 +199,7 @@ mod tests {
             deliverable_id: None,
             pane_id: None,
             injection_status: None,
+            unresumable: false,
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs
@@ -37,6 +37,7 @@ fn summary(id: &str, state: &str) -> ManagedSessionSummary {
         deliverable_id: None,
         pane_id: None,
         injection_status: None,
+        unresumable: false,
     }
 }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/state/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/state/mod.rs
@@ -138,6 +138,19 @@ pub struct SessionRow {
     /// here, so a poll-driven change in the deliverable set is picked up on
     /// the very next frame without re-deriving this row.
     pub deliverable_id: Option<String>,
+    /// True when this session is a dead pick — `stopped`/`errored` with no
+    /// workdir candidate left on disk, so a resume is guaranteed to fail
+    /// (mirrors `ManagedSessionSummary::unresumable`, #2595).
+    ///
+    /// Why: the Sessions pane's `r` (resume) key must refuse a dead session
+    /// with the same "workspace removed — decommission instead" guidance the
+    /// CLI picker gives (`bin/tm/commands/session_picker.rs`'s
+    /// `PickerDecision::Unresumable`), rather than firing a daemon round trip
+    /// that can only 422.
+    /// What: copied verbatim from the fleet DTO by
+    /// [`crate::tui::project_ctl::poll::rows::session_to_row`].
+    /// Test: `crate::tui::project_ctl::events::tests::resume_on_unresumable_session_is_blocked`.
+    pub unresumable: bool,
 }
 
 /// Live per-session activity fetched from `GET .../{id}/activity` (DOC-35
@@ -638,6 +651,7 @@ mod tests {
             pending_decision: None,
             proposed_default: None,
             deliverable_id: None,
+            unresumable: false,
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -52,6 +52,7 @@ fn summary(id: &str, state: &str) -> ManagedSessionSummary {
         deliverable_id: None,
         pane_id: None,
         injection_status: None,
+        unresumable: false,
     }
 }
 

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -1815,6 +1815,169 @@ async fn list_managed_sessions_source_id_filter() {
     );
 }
 
+/// #2595: a stopped/errored session whose workspace has been GC-pruned must be
+/// flagged `unresumable: true` on the LIST endpoint — the same endpoint the
+/// bare-`tm` guided default, the `tm ls` picker, and `tm sessions ls` all read.
+///
+/// Why: #2577/#2594 fixed the ERROR an operator saw after picking such a
+/// session to restart (bare 500 → actionable 422); this predicate lets the
+/// listing surfaces exclude/mark the session BEFORE it is ever offered as a
+/// restart option, closing the deeper UX defect the issue reports.
+/// What: seeds a session whose `workspace_path`/`cwd` point at a directory
+/// that is never created on disk (mirrors
+/// `resume_managed_typed_missing_workspace_is_unprocessable` in
+/// `resume_unresumable_mapping.rs`), drives it to `Errored` via
+/// `mark_errored` (a resumable state, satisfying the predicate's state gate),
+/// then asserts the LIST endpoint's summary for that id carries
+/// `unresumable: true`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn list_marks_dead_stopped_session_unresumable() {
+    use std::collections::HashMap;
+    use trusty_mpm::daemon::managed_routes::list_managed_sessions;
+
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+    let mgr = state.session_manager().await;
+
+    let id = ResumeSessionId::new();
+    let gone = root.path().join(format!("{id}-pruned-worktree"));
+    mgr.create_with_id(
+        id,
+        "regression: #2595 dead session must be flagged unresumable".to_string(),
+        Some(gone.clone()),
+        None,
+        Some(gone.clone()),
+        Some("https://example.com/r.git".to_string()),
+        Some("main".to_string()),
+        ResumeRuntimeKind::default(),
+        false,
+        false,
+    )
+    .await
+    .expect("seed session");
+    mgr.mark_errored(&id, "regression: simulate prior spawn failure")
+        .await
+        .expect("mark errored");
+    assert!(
+        !gone.exists(),
+        "test precondition: the workspace path must NOT exist on disk"
+    );
+
+    let q: HashMap<String, String> = HashMap::new();
+    let (status, body) = decode_response(
+        list_managed_sessions(axum::extract::State(state.clone()), axum::extract::Query(q)).await,
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    let sessions = body["sessions"].as_array().expect("sessions array");
+    let row = sessions
+        .iter()
+        .find(|s| s["id"].as_str() == Some(id.to_string().as_str()))
+        .unwrap_or_else(|| panic!("seeded session must appear in the list, got {body}"));
+    assert_eq!(
+        row["unresumable"].as_bool(),
+        Some(true),
+        "a stopped/errored session with no workdir candidate on disk must be \
+         flagged unresumable, got {row}"
+    );
+}
+
+/// #2595 counterpart: a HEALTHY stopped session (workspace still on disk) and
+/// a LIVE/provisioning session (workspace missing, but the state gate means
+/// the predicate never even probes the filesystem) must both come back
+/// `unresumable: false` — the predicate must never over-fire.
+///
+/// Why: without this counterpart, `list_marks_dead_stopped_session_unresumable`
+/// alone could pass even if the predicate always returned `true` — this test
+/// pins the negative cases the picker/table depend on (issue #2595's own
+/// acceptance criterion: "healthy stopped sessions unaffected").
+/// What: seeds session A `Errored` with a REAL `TempDir` workspace (an existing
+/// candidate) and session B left in its default `Provisioning` state with a
+/// workspace path that is never created (so the state gate — not a filesystem
+/// check — is what saves it); asserts BOTH come back `unresumable: false`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn list_leaves_live_and_healthy_stopped_sessions_unmarked() {
+    use std::collections::HashMap;
+    use trusty_mpm::daemon::managed_routes::list_managed_sessions;
+
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+    let mgr = state.session_manager().await;
+
+    // Session A: Errored, but its workspace genuinely still exists on disk.
+    let id_a = ResumeSessionId::new();
+    let ws_a = root.path().join(format!("{id_a}-healthy-ws"));
+    std::fs::create_dir_all(&ws_a).expect("create real workspace dir for session A");
+    mgr.create_with_id(
+        id_a,
+        "regression: #2595 healthy errored session stays resumable".to_string(),
+        Some(ws_a.clone()),
+        None,
+        Some(ws_a),
+        Some("https://example.com/r.git".to_string()),
+        Some("main".to_string()),
+        ResumeRuntimeKind::default(),
+        false,
+        false,
+    )
+    .await
+    .expect("seed session A");
+    mgr.mark_errored(&id_a, "regression: simulate prior spawn failure")
+        .await
+        .expect("mark errored A");
+
+    // Session B: left Provisioning (create_with_id's default) with a workspace
+    // path that is never created — the state gate alone must save it.
+    let id_b = ResumeSessionId::new();
+    let gone_b = root.path().join(format!("{id_b}-never-created"));
+    mgr.create_with_id(
+        id_b,
+        "regression: #2595 provisioning session with missing workdir stays unflagged".to_string(),
+        Some(gone_b.clone()),
+        None,
+        Some(gone_b),
+        Some("https://example.com/r.git".to_string()),
+        Some("main".to_string()),
+        ResumeRuntimeKind::default(),
+        false,
+        false,
+    )
+    .await
+    .expect("seed session B");
+
+    let q: HashMap<String, String> = HashMap::new();
+    let (status, body) = decode_response(
+        list_managed_sessions(axum::extract::State(state.clone()), axum::extract::Query(q)).await,
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    let sessions = body["sessions"].as_array().expect("sessions array");
+
+    let row_a = sessions
+        .iter()
+        .find(|s| s["id"].as_str() == Some(id_a.to_string().as_str()))
+        .unwrap_or_else(|| panic!("session A must appear in the list, got {body}"));
+    assert_eq!(
+        row_a["unresumable"].as_bool(),
+        Some(false),
+        "an errored session with an EXISTING workspace must not be flagged unresumable, \
+         got {row_a}"
+    );
+
+    let row_b = sessions
+        .iter()
+        .find(|s| s["id"].as_str() == Some(id_b.to_string().as_str()))
+        .unwrap_or_else(|| panic!("session B must appear in the list, got {body}"));
+    assert_eq!(
+        row_b["unresumable"].as_bool(),
+        Some(false),
+        "a provisioning/live session must never be flagged unresumable regardless \
+         of workdir, got {row_b}"
+    );
+}
+
 /// A GitHub `repo_url` must produce a project-identifiable session name (#1789).
 ///
 /// Why: pins the `parse_github_path → gh.repo → build_managed_session_name`

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -1815,21 +1815,78 @@ async fn list_managed_sessions_source_id_filter() {
     );
 }
 
+/// Shared #2595-test fixtures: seed a session with a given workspace, find a
+/// row by id in a decoded JSON array, and seed the "dead" (Errored,
+/// workspace-never-created) case those three tests below all need.
+///
+/// Why: `list_marks_dead_stopped_session_unresumable`,
+/// `list_leaves_live_and_healthy_stopped_sessions_unmarked`, and
+/// `fleet_route_marks_dead_session_unresumable` share near-identical
+/// seed/lookup steps; factoring them out keeps this file under its
+/// 1500-SLOC test-cap budget while keeping each test's own body focused on
+/// what it actually asserts.
+/// What: [`seed_session_with_workspace`] wraps `create_with_id` with a single
+/// `workspace_path == cwd` candidate; [`find_row`] locates a session/project
+/// row by `id`/`project_name` in a decoded JSON array or panics with the
+/// full array for debuggability; [`seed_dead_errored_session`] composes the
+/// first with `mark_errored` (mirrors
+/// `resume_managed_typed_missing_workspace_is_unprocessable` in
+/// `resume_unresumable_mapping.rs`) plus the "path really doesn't exist"
+/// precondition assert.
+async fn seed_session_with_workspace(
+    mgr: &trusty_mpm::session_manager::SessionManager,
+    workspace: std::path::PathBuf,
+    repo_url: &str,
+    label: &str,
+) -> ResumeSessionId {
+    let id = ResumeSessionId::new();
+    mgr.create_with_id(
+        id,
+        format!("regression: #2595 {label}"),
+        Some(workspace.clone()),
+        None,
+        Some(workspace),
+        Some(repo_url.to_string()),
+        Some("main".to_string()),
+        ResumeRuntimeKind::default(),
+        false,
+        false,
+    )
+    .await
+    .expect("seed session");
+    id
+}
+
+fn find_row<'a>(rows: &'a [serde_json::Value], key: &str, want: &str) -> &'a serde_json::Value {
+    rows.iter()
+        .find(|r| r[key].as_str() == Some(want))
+        .unwrap_or_else(|| panic!("row with {key}={want:?} must be present, got {rows:?}"))
+}
+
+async fn seed_dead_errored_session(
+    mgr: &trusty_mpm::session_manager::SessionManager,
+    root: &std::path::Path,
+    repo_url: &str,
+    label: &str,
+) -> ResumeSessionId {
+    let gone = root.join(format!("dead-{label}"));
+    let id = seed_session_with_workspace(mgr, gone.clone(), repo_url, label).await;
+    mgr.mark_errored(&id, "regression: simulate prior spawn failure")
+        .await
+        .expect("mark errored");
+    assert!(!gone.exists(), "test precondition: path must not exist");
+    id
+}
+
 /// #2595: a stopped/errored session whose workspace has been GC-pruned must be
 /// flagged `unresumable: true` on the LIST endpoint — the same endpoint the
 /// bare-`tm` guided default, the `tm ls` picker, and `tm sessions ls` all read.
-///
 /// Why: #2577/#2594 fixed the ERROR an operator saw after picking such a
 /// session to restart (bare 500 → actionable 422); this predicate lets the
 /// listing surfaces exclude/mark the session BEFORE it is ever offered as a
 /// restart option, closing the deeper UX defect the issue reports.
-/// What: seeds a session whose `workspace_path`/`cwd` point at a directory
-/// that is never created on disk (mirrors
-/// `resume_managed_typed_missing_workspace_is_unprocessable` in
-/// `resume_unresumable_mapping.rs`), drives it to `Errored` via
-/// `mark_errored` (a resumable state, satisfying the predicate's state gate),
-/// then asserts the LIST endpoint's summary for that id carries
-/// `unresumable: true`.
+/// What: seeds a dead session via [`seed_dead_errored_session`], then asserts
+/// the LIST endpoint's summary for that id carries `unresumable: true`.
 /// Test: this function IS the test.
 #[tokio::test]
 async fn list_marks_dead_stopped_session_unresumable() {
@@ -1839,42 +1896,20 @@ async fn list_marks_dead_stopped_session_unresumable() {
     let root = TempDir::new().unwrap();
     let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
     let mgr = state.session_manager().await;
+    let id =
+        seed_dead_errored_session(&mgr, root.path(), "https://example.com/r.git", "list").await;
 
-    let id = ResumeSessionId::new();
-    let gone = root.path().join(format!("{id}-pruned-worktree"));
-    mgr.create_with_id(
-        id,
-        "regression: #2595 dead session must be flagged unresumable".to_string(),
-        Some(gone.clone()),
-        None,
-        Some(gone.clone()),
-        Some("https://example.com/r.git".to_string()),
-        Some("main".to_string()),
-        ResumeRuntimeKind::default(),
-        false,
-        false,
-    )
-    .await
-    .expect("seed session");
-    mgr.mark_errored(&id, "regression: simulate prior spawn failure")
-        .await
-        .expect("mark errored");
-    assert!(
-        !gone.exists(),
-        "test precondition: the workspace path must NOT exist on disk"
-    );
-
-    let q: HashMap<String, String> = HashMap::new();
     let (status, body) = decode_response(
-        list_managed_sessions(axum::extract::State(state.clone()), axum::extract::Query(q)).await,
+        list_managed_sessions(
+            axum::extract::State(state.clone()),
+            axum::extract::Query(HashMap::new()),
+        )
+        .await,
     )
     .await;
     assert_eq!(status, axum::http::StatusCode::OK);
     let sessions = body["sessions"].as_array().expect("sessions array");
-    let row = sessions
-        .iter()
-        .find(|s| s["id"].as_str() == Some(id.to_string().as_str()))
-        .unwrap_or_else(|| panic!("seeded session must appear in the list, got {body}"));
+    let row = find_row(sessions, "id", &id.to_string());
     assert_eq!(
         row["unresumable"].as_bool(),
         Some(true),
@@ -1886,16 +1921,12 @@ async fn list_marks_dead_stopped_session_unresumable() {
 /// #2595 counterpart: a HEALTHY stopped session (workspace still on disk) and
 /// a LIVE/provisioning session (workspace missing, but the state gate means
 /// the predicate never even probes the filesystem) must both come back
-/// `unresumable: false` — the predicate must never over-fire.
-///
-/// Why: without this counterpart, `list_marks_dead_stopped_session_unresumable`
-/// alone could pass even if the predicate always returned `true` — this test
-/// pins the negative cases the picker/table depend on (issue #2595's own
-/// acceptance criterion: "healthy stopped sessions unaffected").
-/// What: seeds session A `Errored` with a REAL `TempDir` workspace (an existing
-/// candidate) and session B left in its default `Provisioning` state with a
-/// workspace path that is never created (so the state gate — not a filesystem
-/// check — is what saves it); asserts BOTH come back `unresumable: false`.
+/// `unresumable: false` — the predicate must never over-fire (issue #2595's
+/// own acceptance criterion: "healthy stopped sessions unaffected").
+/// What: session A is `Errored` with a REAL `TempDir` workspace (an existing
+/// candidate); session B is left in its default `Provisioning` state with a
+/// workspace path that is never created (the state gate, not a filesystem
+/// check, is what saves it). Both must come back `unresumable: false`.
 /// Test: this function IS the test.
 #[tokio::test]
 async fn list_leaves_live_and_healthy_stopped_sessions_unmarked() {
@@ -1905,76 +1936,96 @@ async fn list_leaves_live_and_healthy_stopped_sessions_unmarked() {
     let root = TempDir::new().unwrap();
     let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
     let mgr = state.session_manager().await;
+    let repo_url = "https://example.com/r.git";
 
-    // Session A: Errored, but its workspace genuinely still exists on disk.
-    let id_a = ResumeSessionId::new();
-    let ws_a = root.path().join(format!("{id_a}-healthy-ws"));
+    let ws_a = root.path().join("healthy-ws");
     std::fs::create_dir_all(&ws_a).expect("create real workspace dir for session A");
-    mgr.create_with_id(
-        id_a,
-        "regression: #2595 healthy errored session stays resumable".to_string(),
-        Some(ws_a.clone()),
-        None,
-        Some(ws_a),
-        Some("https://example.com/r.git".to_string()),
-        Some("main".to_string()),
-        ResumeRuntimeKind::default(),
-        false,
-        false,
-    )
-    .await
-    .expect("seed session A");
+    let id_a = seed_session_with_workspace(&mgr, ws_a, repo_url, "healthy-errored").await;
     mgr.mark_errored(&id_a, "regression: simulate prior spawn failure")
         .await
         .expect("mark errored A");
 
-    // Session B: left Provisioning (create_with_id's default) with a workspace
-    // path that is never created — the state gate alone must save it.
-    let id_b = ResumeSessionId::new();
-    let gone_b = root.path().join(format!("{id_b}-never-created"));
-    mgr.create_with_id(
-        id_b,
-        "regression: #2595 provisioning session with missing workdir stays unflagged".to_string(),
-        Some(gone_b.clone()),
-        None,
-        Some(gone_b),
-        Some("https://example.com/r.git".to_string()),
-        Some("main".to_string()),
-        ResumeRuntimeKind::default(),
-        false,
-        false,
-    )
-    .await
-    .expect("seed session B");
+    let gone_b = root.path().join("never-created");
+    let id_b = seed_session_with_workspace(&mgr, gone_b, repo_url, "provisioning-missing").await;
 
-    let q: HashMap<String, String> = HashMap::new();
     let (status, body) = decode_response(
-        list_managed_sessions(axum::extract::State(state.clone()), axum::extract::Query(q)).await,
+        list_managed_sessions(
+            axum::extract::State(state.clone()),
+            axum::extract::Query(HashMap::new()),
+        )
+        .await,
     )
     .await;
     assert_eq!(status, axum::http::StatusCode::OK);
     let sessions = body["sessions"].as_array().expect("sessions array");
 
-    let row_a = sessions
-        .iter()
-        .find(|s| s["id"].as_str() == Some(id_a.to_string().as_str()))
-        .unwrap_or_else(|| panic!("session A must appear in the list, got {body}"));
     assert_eq!(
-        row_a["unresumable"].as_bool(),
+        find_row(sessions, "id", &id_a.to_string())["unresumable"].as_bool(),
         Some(false),
-        "an errored session with an EXISTING workspace must not be flagged unresumable, \
-         got {row_a}"
+        "an errored session with an EXISTING workspace must not be flagged unresumable"
     );
-
-    let row_b = sessions
-        .iter()
-        .find(|s| s["id"].as_str() == Some(id_b.to_string().as_str()))
-        .unwrap_or_else(|| panic!("session B must appear in the list, got {body}"));
     assert_eq!(
-        row_b["unresumable"].as_bool(),
+        find_row(sessions, "id", &id_b.to_string())["unresumable"].as_bool(),
         Some(false),
-        "a provisioning/live session must never be flagged unresumable regardless \
-         of workdir, got {row_b}"
+        "a provisioning/live session must never be flagged unresumable regardless of workdir"
+    );
+}
+
+/// #2595 (code-critic PR #2652 finding 2): `GET /sessions/managed/fleet` — the
+/// endpoint the `tm projects` TUI polls — must ALSO flag a dead session
+/// `unresumable: true`, not just the flat `list`/`get` endpoints.
+/// Why: the fleet route used the unchecked `record_to_summary` (no
+/// filesystem probe), so `unresumable` was always `false` there regardless of
+/// a session's real state — the TUI's `r` (resume) key had no signal to
+/// refuse a dead session. This pins the fix: the fleet route now goes
+/// through the same checked, concurrently-probed conversion the list/get
+/// handlers use ([`trusty_mpm::daemon::managed_routes`]-internal).
+/// What: registers a project, seeds a dead session bound to it (matching
+/// `repo_url`) via [`seed_dead_errored_session`], calls
+/// `fleet_by_project_route`, and asserts the session inside the matching
+/// project's group carries `unresumable: true`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn fleet_route_marks_dead_session_unresumable() {
+    use trusty_mpm::daemon::managed_routes::fleet_by_project_route;
+    use trusty_mpm::project::Project;
+
+    let root = TempDir::new().unwrap();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+    let mgr = state.session_manager().await;
+
+    let repo_url = "https://github.com/acme/widget".to_string();
+    state
+        .project_registry()
+        .await
+        .register(Project {
+            name: "widget".into(),
+            repo_url: repo_url.clone(),
+            default_branch: "main".into(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+        })
+        .await
+        .expect("register project");
+
+    let id = seed_dead_errored_session(&mgr, root.path(), &repo_url, "fleet").await;
+
+    let (status, body) =
+        decode_response(fleet_by_project_route(axum::extract::State(state.clone())).await).await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    let projects = body["projects"].as_array().expect("projects array");
+    let widget = find_row(projects, "project_name", "widget");
+    let sessions = widget["sessions"].as_array().expect("sessions array");
+    let row = find_row(sessions, "id", &id.to_string());
+    assert_eq!(
+        row["unresumable"].as_bool(),
+        Some(true),
+        "the fleet route must flag a dead session unresumable, same as list/get, got {row}"
     );
 }
 


### PR DESCRIPTION
## Summary

Owner directive (#2595, builds on #2577/PR #2594): a stopped/errored managed
session whose workspace has been GC-pruned (no existing candidate across
`last_cwd`/`workspace_path`/`cwd`) was still offered as a restart option in
the bare-`tm` guided default, the `tm ls` picker, and `tm sessions ls` — the
restart could only ever fail with the 422 #2594 introduced. #2594 fixed the
error message; this closes the deeper UX defect: "it shouldn't have been a
session option in that case."

## Changes

- **Shared predicate** (`session_manager::resume_workdir::is_unresumable`,
  `crates/trusty-mpm/src/session_manager/resume_workdir.rs`): reuses the
  exact same `last_cwd → workspace_path → cwd` candidate check
  `resolve_existing_workdir` uses (factored into a shared
  `workdir_candidates` helper so the two can never diverge). Gated to
  `Stopped`/`Errored` — short-circuits to `false` with zero I/O for every
  other state. **Fails open on a probe error**: a transient
  I/O/permission/network-volume `Err` on any candidate is treated as
  possibly-present (never flags the session dead) — `resolve_existing_workdir`
  keeps its own `Err → treat as absent` behavior unchanged, since that guards
  an actual resume attempt where refusing a possibly-bad path is the safe
  failure mode; this predicate instead gates whether a session is even
  *offered*, where wrongly flagging it dead leaves only a destructive delete
  as the way out.
- **Wire field** (`unresumable: bool`, additive): added to
  `daemon::managed_routes::SessionSummary` and the client's
  `ManagedSessionSummary`. Computed per session via `summary::record_to_summary_checked`
  (single record: `list`/`get`) and `summary::checked_summaries` (many
  records: `list_managed_sessions` and the `fleet` route) — the latter fans
  the per-session filesystem probes out concurrently via
  `tokio::task::JoinSet`, restricted to the `Stopped`/`Errored` subset that
  actually pays the I/O cost, rather than one-at-a-time.
- **Picker** (`bin/tm/commands/session_picker.rs`, shared by the bare-`tm`
  guided default AND `tm ls` — both funnel through `run_tty_picker`): dead
  sessions are marked in the menu (`DEAD: workspace removed; use [dN] ...`)
  and a new `PickerDecision::Unresumable` blocks BOTH bare-Enter and an
  EXPLICIT numeric choice from resuming them — no daemon round-trip, no
  guaranteed-to-fail 422.
- **`tm sessions ls`** (`bin/tm/commands/managed.rs`): the STATE column
  appends `[dead]` via a new pure `format_state_column` helper (extracted so
  the marker is unit-testable without capturing `println!` output).
- **`tm projects` TUI** (`tui/project_ctl/`): the fleet route (what the TUI
  polls) now goes through the same checked path as `list`/`get`, so
  `SessionRow::unresumable` is accurate; the `r` (resume) key gains its own
  guard (`events::request_resume`) refusing a dead session with the same
  "workspace removed" messaging the CLI picker gives, adapted to the TUI's
  notice idiom and pointing at the TUI's own `d` (decommission) key.

**Why `d<N>` (delete the store record) rather than decommission, as the
picker's remedy for a dead session**: a dead session's workspace is *already
gone from disk* — there is nothing left to protect or tear down.
`decommission`'s job is to remove a still-present, SM-owned workspace
directory and then tombstone the record; running it here would be a no-op
teardown plus a state transition, when the record itself is what needs to
go. The CLI's existing `d<N>` (`tm`'s picker-local store delete, #2304) is
the lighter, already-safe verb for "this record no longer points at
anything real" and needed no new destructive flow. (The TUI has no
equivalent lightweight delete verb, so its guard points at `d`/decommission
instead — see the TUI bullet above.)

## Tests (hermetic)

- `session_manager/resume_workdir.rs`: `is_unresumable_true_when_all_candidates_missing_and_stopped`,
  `is_unresumable_false_when_any_candidate_exists`,
  `is_unresumable_false_for_non_stopped_states_even_when_all_missing`,
  `is_unresumable_fails_open_on_probe_error`.
- `daemon/managed_routes/tests.rs`: `checked_summaries_preserves_input_order_and_flags_only_dead_sessions`.
- `tests/session_manager_mvp.rs` (full daemon HTTP-handler round trip):
  `list_marks_dead_stopped_session_unresumable`,
  `list_leaves_live_and_healthy_stopped_sessions_unmarked` (healthy stopped +
  live/provisioning-with-missing-workdir both stay unflagged),
  `fleet_route_marks_dead_session_unresumable`.
- `bin/tm/tests_behavior_c_tests.rs`: `guided_picker_bare_enter_unresumable_session_blocked`,
  `guided_picker_numeric_unresumable_session_blocked`.
- `bin/tm/commands/managed_tests.rs`: `format_state_column_appends_dead_marker`,
  `format_state_column_leaves_healthy_state_unchanged`.
- `client/http_client/tests.rs`: `managed_session_summary_deserializes_unresumable_flag`.
- `tui/project_ctl/`: `events::tests::resume_on_unresumable_session_is_blocked`,
  `events::tests::resume_on_healthy_session_fires_immediately`,
  `poll/rows.rs::session_to_row_carries_unresumable_flag`.

## Scope note

Did not touch `bin/tm/cli.rs` (sibling engineer splitting it for #2603) or
`daemon/manager/chat_store.rs` (#2602) — no overlap with this diff.

## Gate (raw)

- `cargo build --workspace` → Finished, exit 0
- `cargo test -p trusty-mpm` → `3127 passed; 0 failed` (lib) + every
  integration-test binary `0 failed` (incl. `session_manager_mvp.rs`:
  `28 passed; 0 failed`)
- `cargo test --workspace` → one intermittent failure in local full-workspace
  runs, `trusty-search::list_indexes_repo_identity_details_and_filter`
  (crate untouched by this diff); not reproduced on main CI (reviewer
  verified main CI green on that test) and passes in isolation locally
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0, 0 errors
- `cargo fmt --check` → clean
- `bash scripts/check_line_cap.sh` → `0 violations — OK`
- `bash scripts/check_test_pointers.sh` → `0 dangling pointers — OK`

## Review history

code-critic BLOCK on the first revision (missing test for a doc-comment
pointer; fleet route + TUI resume action not covered; predicate needed to
fail open on probe errors; sequential per-session I/O). All four addressed
in the follow-up commit — see the "Changes"/"Tests" sections above, which
describe the current (post-fix) state.

Closes #2595

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
