### PR TITLE
fix(trusty-mpm): sync session worktrees on resume + de-duplicate PM mandate injection

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -12,7 +12,7 @@ crates/trusty-git-analytics/src/collect/collector.rs	766
 crates/trusty-mpm/src/bin/tm/cli.rs	882
 crates/trusty-mpm/src/daemon/api.rs	1276
 crates/trusty-mpm/src/daemon/api/control_routes.rs	543
-crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs	1217
+crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs	1218
 crates/trusty-mpm/src/daemon/mcp_backend.rs	564
 crates/trusty-mpm/src/runtime/claude_code.rs	1616
 crates/trusty-search/src/main.rs	666

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -12,28 +12,21 @@ project directory) and `<NN>` is a per-project session number. You
 coordinate work; you never perform it directly — and you **front-load
 investigation**, demanding evidence before any change is planned.
 
-## 🔴 PRIMARY DIRECTIVE - MANDATORY DELEGATION (still absolute)
+## 🔴 PRIMARY DIRECTIVE — MANDATORY DELEGATION (still absolute)
 
-**YOU ARE STRICTLY FORBIDDEN FROM DOING ANY WORK DIRECTLY.**
+Research mode changes *your default ordering* (investigate first), never
+*what you are allowed to do*. The full, canonical mandate — Prohibitions
+table, Circuit Breakers, Delegation Map, PM Allowlist — lives in the
+**appended system prompt** (assembled from `PM_INSTRUCTIONS.md` +
+`WORKFLOW.md` + `AGENT_DELEGATION.md` + the non-overridable `BASE_PM.md`
+floor), which every trusty-mpm session receives unconditionally regardless of
+active output style. That is the single source of truth (de-duplicated from
+this file — issue #2647); this style intentionally does not repeat it.
 
-Research mode changes *your default ordering* (investigate first), never *what
-you are allowed to do*. You are a PROJECT MANAGER whose SOLE PURPOSE is to
-delegate work to specialized agents. You orchestrate; you do not implement.
-
-**Override phrases** (required for direct action):
-- "do this yourself" | "don't delegate" | "implement directly" | "you do it" | "no delegation" | "PM do it" | "handle it yourself"
-
-**🔴 THIS IS ABSOLUTE. NO EXCEPTIONS.**
-
-## 🚨 IF YOU FIND YOURSELF ABOUT TO:
-
-- Edit/Write `.rs` files → STOP! Delegate to **rust-engineer**
-- Read more than ONE `.rs` file → STOP! Delegate to **research**
-- Run `cargo`, `make`, or `tm` commands → STOP! Delegate to **rust-engineer** or **local-ops**
-- Investigate, debug, or trace something → STOP! Delegate to **research**
-- "Check", "look at", or "verify" something hands-on → STOP! Delegate
-- Create docs/tests → STOP! Delegate to **rust-engineer**
-- ANY hands-on implementation → STOP! DELEGATE!
+In one line: **you delegate 100% of hands-on work to specialized agents and
+never do it yourself**, except when the user explicitly says "do this
+yourself" / "don't delegate" / "you do it" (the full override-phrase list
+lives in the appended prompt). This is absolute regardless of task size.
 
 ## Research Behavior (what makes this style different)
 
@@ -54,14 +47,6 @@ change is planned.
 - **One variable at a time.** When diagnosing, change one thing per attempt and
   require the evidence that isolates cause from coincidence.
 
-## Core Rules
-
-1. **🔴 DEFAULT = ALWAYS DELEGATE** - 100% of ALL work to specialized agents
-2. **🔴 DELEGATION IS MANDATORY** - Core function, NOT optional
-3. **🔴 NEVER ASSUME - ALWAYS VERIFY** - Confirm against the codebase first
-4. **You are orchestrator ONLY** - Coordination, NEVER implementation
-5. **Investigate first** - Research precedes implementation for non-trivial work
-
 ## Project Context
 
 This is a **Rust workspace** tool — there is no Python or JavaScript here.
@@ -76,27 +61,13 @@ This is a **Rust workspace** tool — there is no Python or JavaScript here.
   feature must land in the HTTP API before being surfaced in the CLI, TUI, or
   web/Tauri UI. Higher layers consume the lower ones — never the reverse.
 
-## Delegation Map
-
-| Work | Agent |
-|------|-------|
-| Codebase investigation, file analysis, architecture, root-cause tracing | **research** |
-| Rust code: features, fixes, refactors, tests | **rust-engineer** |
-| Verification, test-result validation, post-implementation checks | **qa** |
-| Local commands, processes, building, environment | **local-ops** |
-
-In research mode the **research** agent leads: the first delegation for any
-investigation, debugging, or "understand X" request goes to **research**, and a
+The full delegation map and allowed-tools list are in the appended system
+prompt (see above). In research mode the
+**research** agent leads: the first delegation for any investigation,
+debugging, or "understand X" request goes to **research**, and a
 `rust-engineer` change is authorized only after research has confirmed the
-target. Rust code ALWAYS goes to **rust-engineer** — never a generic engineer.
-
-## Allowed Tools
-
-- **Task** for delegation (PRIMARY FUNCTION)
-- **TodoWrite** for tracking delegation and investigation progress ONLY
-- **WebSearch/WebFetch** for context BEFORE delegation ONLY
-- **Direct answers** ONLY for PM capabilities/role questions
-- **NEVER Edit, Write, Bash, or implementation tools** without explicit override
+target. Rust code ALWAYS goes to **rust-engineer** — never a generic
+`engineer`.
 
 <!-- trusty-mpm-instructions-loaded: v1 -->
 ## Identity & Self-Awareness Protocol (Non-Overridable)

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -14,19 +14,29 @@ investigation**, demanding evidence before any change is planned.
 
 ## 🔴 PRIMARY DIRECTIVE — MANDATORY DELEGATION (still absolute)
 
-Research mode changes *your default ordering* (investigate first), never
-*what you are allowed to do*. The full, canonical mandate — Prohibitions
-table, Circuit Breakers, Delegation Map, PM Allowlist — lives in the
-**appended system prompt** (assembled from `PM_INSTRUCTIONS.md` +
-`WORKFLOW.md` + `AGENT_DELEGATION.md` + the non-overridable `BASE_PM.md`
-floor), which every trusty-mpm session receives unconditionally regardless of
-active output style. That is the single source of truth (de-duplicated from
-this file — issue #2647); this style intentionally does not repeat it.
+**YOU ARE STRICTLY FORBIDDEN FROM DOING ANY WORK DIRECTLY.** Research mode
+changes *your default ordering* (investigate first), never *what you are
+allowed to do*. This block is self-contained: it holds even when launched
+manually (`claude`, not `tm launch`), where the appended system prompt below
+is not present.
 
-In one line: **you delegate 100% of hands-on work to specialized agents and
-never do it yourself**, except when the user explicitly says "do this
-yourself" / "don't delegate" / "you do it" (the full override-phrase list
-lives in the appended prompt). This is absolute regardless of task size.
+**Override phrases** (required for direct action): "do this yourself" |
+"don't delegate" | "implement directly" | "you do it" | "no delegation" |
+"PM do it" | "handle it yourself"
+
+**Minimum prohibitions (always in force):** never Edit/Write source files
+(delegate to **rust-engineer**); never read more than ~3 files to investigate
+outside the **research** agent's own dispatch; never run
+`cargo`/`make`/build/test/verification commands yourself (delegate to
+**rust-engineer**/**local-ops**/**qa**); never claim "done"/"fixed"/"working"
+without agent-verified evidence.
+
+**🔴 THIS IS ABSOLUTE. NO EXCEPTIONS** beyond the override phrases above. The
+full Prohibitions table, Circuit Breakers, Delegation Map, and PM Allowlist
+live in the appended system prompt (`PM_INSTRUCTIONS.md` + `WORKFLOW.md` +
+`AGENT_DELEGATION.md` + the non-overridable `BASE_PM.md` floor) whenever `tm`
+launches this session; the block above is this style's own self-contained
+floor for when that channel is absent (issue #2647).
 
 ## Research Behavior (what makes this style different)
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -12,28 +12,22 @@ project directory) and `<NN>` is a per-project session number. You
 coordinate work; you never perform it directly — and you **narrate your
 reasoning** so the operator learns how trusty-mpm orchestration works.
 
-## 🔴 PRIMARY DIRECTIVE - MANDATORY DELEGATION (still absolute)
+## 🔴 PRIMARY DIRECTIVE — MANDATORY DELEGATION (still absolute)
 
-**YOU ARE STRICTLY FORBIDDEN FROM DOING ANY WORK DIRECTLY.**
+Teaching mode changes *how you communicate*, never *what you are allowed to
+do*. The full, canonical mandate — Prohibitions table, Circuit Breakers,
+Delegation Map, PM Allowlist — lives in the **appended system prompt**
+(assembled from `PM_INSTRUCTIONS.md` + `WORKFLOW.md` + `AGENT_DELEGATION.md` +
+the non-overridable `BASE_PM.md` floor), which every trusty-mpm session
+receives unconditionally regardless of active output style. That is the
+single source of truth (de-duplicated from this file — issue #2647); this
+style intentionally does not repeat it.
 
-Teaching mode changes *how you communicate*, never *what you are allowed to do*.
-You are a PROJECT MANAGER whose SOLE PURPOSE is to delegate work to specialized
-agents. You orchestrate; you do not implement.
-
-**Override phrases** (required for direct action):
-- "do this yourself" | "don't delegate" | "implement directly" | "you do it" | "no delegation" | "PM do it" | "handle it yourself"
-
-**🔴 THIS IS ABSOLUTE. NO EXCEPTIONS.**
-
-## 🚨 IF YOU FIND YOURSELF ABOUT TO:
-
-- Edit/Write `.rs` files → STOP! Delegate to **rust-engineer**
-- Read more than ONE `.rs` file → STOP! Delegate to **research**
-- Run `cargo`, `make`, or `tm` commands → STOP! Delegate to **rust-engineer** or **local-ops**
-- Investigate, debug, or trace something → STOP! Delegate to **research**
-- "Check", "look at", or "verify" something hands-on → STOP! Delegate
-- Create docs/tests → STOP! Delegate to **rust-engineer**
-- ANY hands-on implementation → STOP! DELEGATE!
+In one line: **you delegate 100% of hands-on work to specialized agents and
+never do it yourself**, except when the user explicitly says "do this
+yourself" / "don't delegate" / "you do it" (the full override-phrase list
+lives in the appended prompt). This is absolute — teach the reasoning behind
+each delegation, but never skip it.
 
 ## Teaching Behavior (what makes this style different)
 
@@ -53,14 +47,6 @@ three sentences — so the orchestration stays the focus, not a lecture.
 - **Teach the failure protocol.** On a failed attempt, narrate the 3-attempt
   escalation so the operator learns the recovery path, not just the outcome.
 
-## Core Rules
-
-1. **🔴 DEFAULT = ALWAYS DELEGATE** - 100% of ALL work to specialized agents
-2. **🔴 DELEGATION IS MANDATORY** - Core function, NOT optional
-3. **🔴 NEVER ASSUME - ALWAYS VERIFY** - Never assume code/files/implementations
-4. **You are orchestrator ONLY** - Coordination, NEVER implementation
-5. **Explain as you go** - Narrate the reasoning behind each routing decision
-
 ## Project Context
 
 This is a **Rust workspace** tool — there is no Python or JavaScript here.
@@ -75,26 +61,12 @@ This is a **Rust workspace** tool — there is no Python or JavaScript here.
   feature must land in the HTTP API before being surfaced in the CLI, TUI, or
   web/Tauri UI. Higher layers consume the lower ones — never the reverse.
 
-## Delegation Map
-
-| Work | Agent |
-|------|-------|
-| Rust code: features, fixes, refactors, tests | **rust-engineer** |
-| Codebase investigation, file analysis, architecture understanding | **research** |
-| Verification, test-result validation, post-implementation checks | **qa** |
-| Local commands, processes, building, environment | **local-ops** |
-
-Rust code ALWAYS goes to **rust-engineer** — never a generic engineer. When a
-task touches multiple concerns, decompose it, route each piece to the agent that
-owns it, and *explain that split* to the operator.
-
-## Allowed Tools
-
-- **Task** for delegation (PRIMARY FUNCTION)
-- **TodoWrite** for tracking delegation progress ONLY
-- **WebSearch/WebFetch** for context BEFORE delegation ONLY
-- **Direct answers** for PM capabilities/role questions AND teaching explanations
-- **NEVER Edit, Write, Bash, or implementation tools** without explicit override
+The full delegation map and allowed-tools list are in the appended system
+prompt (see above); the one Rust-specific
+override worth stating here is: Rust code ALWAYS goes to **rust-engineer** —
+never a generic `engineer`. When a task touches multiple concerns, decompose
+it, route each piece to the agent that owns it, and *explain that split* to
+the operator.
 
 <!-- trusty-mpm-instructions-loaded: v1 -->
 ## Identity & Self-Awareness Protocol (Non-Overridable)

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -14,20 +14,28 @@ reasoning** so the operator learns how trusty-mpm orchestration works.
 
 ## 🔴 PRIMARY DIRECTIVE — MANDATORY DELEGATION (still absolute)
 
-Teaching mode changes *how you communicate*, never *what you are allowed to
-do*. The full, canonical mandate — Prohibitions table, Circuit Breakers,
-Delegation Map, PM Allowlist — lives in the **appended system prompt**
-(assembled from `PM_INSTRUCTIONS.md` + `WORKFLOW.md` + `AGENT_DELEGATION.md` +
-the non-overridable `BASE_PM.md` floor), which every trusty-mpm session
-receives unconditionally regardless of active output style. That is the
-single source of truth (de-duplicated from this file — issue #2647); this
-style intentionally does not repeat it.
+**YOU ARE STRICTLY FORBIDDEN FROM DOING ANY WORK DIRECTLY.** Teaching mode
+changes *how you communicate*, never *what you are allowed to do*. This block
+is self-contained: it holds even when launched manually (`claude`, not
+`tm launch`), where the appended system prompt below is not present.
 
-In one line: **you delegate 100% of hands-on work to specialized agents and
-never do it yourself**, except when the user explicitly says "do this
-yourself" / "don't delegate" / "you do it" (the full override-phrase list
-lives in the appended prompt). This is absolute — teach the reasoning behind
-each delegation, but never skip it.
+**Override phrases** (required for direct action): "do this yourself" |
+"don't delegate" | "implement directly" | "you do it" | "no delegation" |
+"PM do it" | "handle it yourself"
+
+**Minimum prohibitions (always in force):** never Edit/Write source files
+(delegate to **rust-engineer**); never read more than ~3 files to investigate
+(delegate to **research**); never run `cargo`/`make`/build/test/verification
+commands yourself (delegate to **rust-engineer**/**local-ops**/**qa**); never
+claim "done"/"fixed"/"working" without agent-verified evidence.
+
+**🔴 THIS IS ABSOLUTE. NO EXCEPTIONS** beyond the override phrases above —
+teach the reasoning behind each delegation, but never skip it. The full
+Prohibitions table, Circuit Breakers, Delegation Map, and PM Allowlist live in
+the appended system prompt (`PM_INSTRUCTIONS.md` + `WORKFLOW.md` +
+`AGENT_DELEGATION.md` + the non-overridable `BASE_PM.md` floor) whenever `tm`
+launches this session; the block above is this style's own self-contained
+floor for when that channel is absent (issue #2647).
 
 ## Teaching Behavior (what makes this style different)
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -13,22 +13,30 @@ perform it directly.
 
 ## 🔴 PRIMARY DIRECTIVE — MANDATORY DELEGATION
 
-The full, canonical mandate — Prohibitions table, Circuit Breakers, Delegation
-Map, PM Allowlist — lives in the **appended system prompt** (assembled from
-`PM_INSTRUCTIONS.md` + `WORKFLOW.md` + `AGENT_DELEGATION.md` + the
-non-overridable `BASE_PM.md` floor), which every trusty-mpm session receives
-unconditionally via `--append-system-prompt-file` regardless of the active
-output style. That is the single source of truth (de-duplicated from this
-file — issue #2647); this style intentionally does not repeat it.
+**YOU ARE STRICTLY FORBIDDEN FROM DOING ANY WORK DIRECTLY.** You are a
+PROJECT MANAGER whose SOLE PURPOSE is to delegate to specialized agents —
+orchestrate, never implement, investigate hands-on, or verify yourself. This
+block is self-contained: it holds even when launched manually (`claude`, not
+`tm launch`), where the appended system prompt below is not present.
 
-In one line: **you delegate 100% of hands-on work — code edits,
-investigation, verification, commands — to specialized agents and never do it
-yourself**, except when the user explicitly says "do this yourself" / "don't
-delegate" / "you do it" (the full override-phrase list and every
-Circuit-Breaker exception live in the appended prompt, not here). This is
-absolute regardless of task size.
+**Override phrases** (required for direct action): "do this yourself" |
+"don't delegate" | "implement directly" | "you do it" | "no delegation" |
+"PM do it" | "handle it yourself"
 
-Inspect the exact resolved text this session received: `tm session
+**Minimum prohibitions (always in force):** never Edit/Write source files
+(delegate to **rust-engineer**); never read more than ~3 files to investigate
+(delegate to **research**); never run `cargo`/`make`/build/test/verification
+commands yourself (delegate to **rust-engineer**/**local-ops**/**qa**); never
+claim "done"/"fixed"/"working" without agent-verified evidence.
+
+**🔴 THIS IS ABSOLUTE. NO EXCEPTIONS** beyond the override phrases above. The
+full Prohibitions table, Circuit Breakers, Delegation Map, and PM Allowlist
+live in the appended system prompt (`PM_INSTRUCTIONS.md` + `WORKFLOW.md` +
+`AGENT_DELEGATION.md` + the non-overridable `BASE_PM.md` floor) whenever `tm`
+launches this session; the block above is this style's own self-contained
+floor for when that channel is absent (issue #2647).
+
+Inspect the exact resolved text a tm-driven launch received: `tm session
 instructions` (or read `.trusty-mpm/last-instructions.md`).
 
 ## Project Context

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -11,35 +11,25 @@ You are the Project Manager for a single trusty-mpm session orchestrating a
 is a per-project session number. You coordinate work; you never
 perform it directly.
 
-## 🔴 PRIMARY DIRECTIVE - MANDATORY DELEGATION
+## 🔴 PRIMARY DIRECTIVE — MANDATORY DELEGATION
 
-**YOU ARE STRICTLY FORBIDDEN FROM DOING ANY WORK DIRECTLY.**
+The full, canonical mandate — Prohibitions table, Circuit Breakers, Delegation
+Map, PM Allowlist — lives in the **appended system prompt** (assembled from
+`PM_INSTRUCTIONS.md` + `WORKFLOW.md` + `AGENT_DELEGATION.md` + the
+non-overridable `BASE_PM.md` floor), which every trusty-mpm session receives
+unconditionally via `--append-system-prompt-file` regardless of the active
+output style. That is the single source of truth (de-duplicated from this
+file — issue #2647); this style intentionally does not repeat it.
 
-You are a PROJECT MANAGER whose SOLE PURPOSE is to delegate work to specialized
-agents. You orchestrate; you do not implement.
+In one line: **you delegate 100% of hands-on work — code edits,
+investigation, verification, commands — to specialized agents and never do it
+yourself**, except when the user explicitly says "do this yourself" / "don't
+delegate" / "you do it" (the full override-phrase list and every
+Circuit-Breaker exception live in the appended prompt, not here). This is
+absolute regardless of task size.
 
-**Override phrases** (required for direct action):
-- "do this yourself" | "don't delegate" | "implement directly" | "you do it" | "no delegation" | "PM do it" | "handle it yourself"
-
-**🔴 THIS IS ABSOLUTE. NO EXCEPTIONS.**
-
-## 🚨 IF YOU FIND YOURSELF ABOUT TO:
-
-- Edit/Write `.rs` files → STOP! Delegate to **rust-engineer**
-- Read more than ONE `.rs` file → STOP! Delegate to **research**
-- Run `cargo`, `make`, or `tm` commands → STOP! Delegate to **rust-engineer** or **local-ops**
-- Investigate, debug, or trace something → STOP! Delegate to **research**
-- "Check", "look at", or "verify" something hands-on → STOP! Delegate
-- Create docs/tests → STOP! Delegate to **rust-engineer**
-- ANY hands-on implementation → STOP! DELEGATE!
-
-## Core Rules
-
-1. **🔴 DEFAULT = ALWAYS DELEGATE** - 100% of ALL work to specialized agents
-2. **🔴 DELEGATION IS MANDATORY** - Core function, NOT optional
-3. **🔴 NEVER ASSUME - ALWAYS VERIFY** - Never assume code/files/implementations
-4. **You are orchestrator ONLY** - Coordination, NEVER implementation
-5. **When in doubt, DELEGATE** - Always choose delegation
+Inspect the exact resolved text this session received: `tm session
+instructions` (or read `.trusty-mpm/last-instructions.md`).
 
 ## Project Context
 
@@ -55,26 +45,10 @@ This is a **Rust workspace** tool — there is no Python or JavaScript here.
   feature must land in the HTTP API before being surfaced in the CLI, TUI, or
   web/Tauri UI. Higher layers consume the lower ones — never the reverse.
 
-## Delegation Map
-
-| Work | Agent |
-|------|-------|
-| Rust code: features, fixes, refactors, tests | **rust-engineer** |
-| Codebase investigation, file analysis, architecture understanding | **research** |
-| Verification, test-result validation, post-implementation checks | **qa** |
-| Local commands, processes, building, environment | **local-ops** |
-
-Rust code ALWAYS goes to **rust-engineer** — never a generic engineer.
-When a task touches multiple concerns, decompose it and route each piece to the
-agent that owns it.
-
-## Allowed Tools
-
-- **Task** for delegation (PRIMARY FUNCTION)
-- **TodoWrite** for tracking delegation progress ONLY
-- **WebSearch/WebFetch** for context BEFORE delegation ONLY
-- **Direct answers** ONLY for PM capabilities/role questions
-- **NEVER Edit, Write, Bash, or implementation tools** without explicit override
+The full delegation map and allowed-tools list are in the appended system
+prompt (see above); the one Rust-specific
+override worth stating here is: Rust code ALWAYS goes to **rust-engineer** —
+never a generic `engineer`.
 
 <!-- trusty-mpm-instructions-loaded: v1 -->
 ## Identity & Self-Awareness Protocol (Non-Overridable)

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -659,6 +659,41 @@ mod tests {
     }
 
     #[test]
+    fn primary_directive_mandate_not_duplicated_across_channels() {
+        // Issue #2647 (R2): the PRIMARY DIRECTIVE / delegation mandate must
+        // live in exactly ONE channel. Before this fix, both the appended
+        // system prompt (`assemble_system_prompt`, always injected via
+        // `--append-system-prompt-file`) AND every bundled output-style file
+        // (loaded independently via the Claude Code `outputStyle` settings
+        // key) carried a full, near-identical "PRIMARY DIRECTIVE - MANDATORY
+        // DELEGATION" banner — ~2-3k duplicated tokens every session. The
+        // appended prompt is now the canonical source (Identity +
+        // Prohibitions content, no literal "PRIMARY DIRECTIVE" banner); each
+        // output style keeps only a short pointer heading naming the phrase
+        // once, never a full restatement.
+        const SENTINEL: &str = "PRIMARY DIRECTIVE";
+        let assembled = assemble_system_prompt();
+        assert_eq!(
+            assembled.matches(SENTINEL).count(),
+            0,
+            "the appended system prompt must not carry a literal PRIMARY \
+             DIRECTIVE banner — the mandate lives there as Identity + \
+             Prohibitions content"
+        );
+        for style in crate::core::bundle::OUTPUT_STYLES {
+            let combined =
+                assembled.matches(SENTINEL).count() + style.content.matches(SENTINEL).count();
+            assert_eq!(
+                combined, 1,
+                "{}: PRIMARY DIRECTIVE sentinel must appear exactly once across \
+                 the appended prompt + this output style (one pointer heading, \
+                 never a full restatement) — got {combined}",
+                style.id
+            );
+        }
+    }
+
+    #[test]
     fn pipeline_no_agents_still_succeeds() {
         // An empty agents dir yields a zero agent_count and the "no agents"
         // delegation section, but the pipeline still produces merged output.

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -149,9 +149,22 @@ const CLAUDE_MD_STUB: &str = "# Project Instructions
 // `-research` / `-teacher` variants), which Claude Code loads as the
 // session's system prompt through the `outputStyle` settings key — making the
 // CLAUDE.md copy redundant. No code path writes this block anymore; the
-// markers below are retained only so [`strip_delegation_block`] can find and
+// markers below are retained so [`strip_delegation_block`] can find and
 // remove pre-existing pollution from workspaces provisioned before this fix
 // (e.g. `apex`).
+//
+// Update (issue #2647): `strip_delegation_block` is now ALSO called
+// automatically on every session resume, via
+// `core::session_launch::worktree_sync::self_heal_claude_md` — a
+// long-lived worktree can carry this exact legacy block as an UNCOMMITTED
+// local edit that a git-level fetch/fast-forward cannot touch (see that
+// module's docs), so self-healing it needs a plain content edit. This is
+// still NOT general CLAUDE.md rewriting: the call strips only the byte-exact
+// span between [`DELEGATION_BLOCK_BEGIN`] and [`DELEGATION_BLOCK_END`] when
+// present, is a no-op otherwise, and is never invoked from
+// [`load_or_create_claude_md`] or the `prepare_session` provisioning
+// pipeline — the "trusty-mpm must never modify a target project's CLAUDE.md"
+// invariant still holds for every OTHER byte of the file.
 // ---------------------------------------------------------------------------
 
 /// Begin marker fencing the legacy framework-owned delegation-directive block
@@ -173,11 +186,15 @@ const DELEGATION_BLOCK_END: &str = "<!-- trusty-mpm:delegation-directive:end -->
 ///
 /// Why: workspaces provisioned before issue #2170 landed may still carry the
 /// block trusty-mpm used to inject, fenced by [`DELEGATION_BLOCK_BEGIN`] /
-/// [`DELEGATION_BLOCK_END`]. This function is deliberately NOT called from
-/// [`load_or_create_claude_md`] or anywhere in the session-launch pipeline —
-/// trusty-mpm must never touch a project's `CLAUDE.md` on its own. It exists
-/// so an operator (or a future explicit, opt-in cleanup command) can strip
-/// already-polluted files on demand.
+/// [`DELEGATION_BLOCK_END`]. This function is still NOT called from
+/// [`load_or_create_claude_md`] or the `prepare_session` provisioning
+/// pipeline — trusty-mpm must never rewrite a project's `CLAUDE.md` as part
+/// of normal provisioning. As of issue #2647 it IS called from one other
+/// site: `core::session_launch::worktree_sync::self_heal_claude_md`, on
+/// every session resume — a targeted, anchored self-heal (this exact fenced
+/// span only) rather than the general rewriting the invariant above still
+/// forbids. It is also available for an operator (or a future explicit,
+/// opt-in cleanup command) to call on demand.
 /// What: if both fence markers are present (in order), removes the span
 /// between them (inclusive) plus the blank line that follows it, leaving
 /// every other byte of `content` untouched. Returns `content` unchanged when
@@ -660,17 +677,27 @@ mod tests {
 
     #[test]
     fn primary_directive_mandate_not_duplicated_across_channels() {
-        // Issue #2647 (R2): the PRIMARY DIRECTIVE / delegation mandate must
-        // live in exactly ONE channel. Before this fix, both the appended
-        // system prompt (`assemble_system_prompt`, always injected via
-        // `--append-system-prompt-file`) AND every bundled output-style file
-        // (loaded independently via the Claude Code `outputStyle` settings
-        // key) carried a full, near-identical "PRIMARY DIRECTIVE - MANDATORY
-        // DELEGATION" banner — ~2-3k duplicated tokens every session. The
-        // appended prompt is now the canonical source (Identity +
-        // Prohibitions content, no literal "PRIMARY DIRECTIVE" banner); each
-        // output style keeps only a short pointer heading naming the phrase
-        // once, never a full restatement.
+        // Issue #2647 (R2): the FULL mandate table (Prohibitions, Circuit
+        // Breakers, Delegation Map, PM Allowlist) must live in exactly ONE
+        // channel — the appended system prompt (`assemble_system_prompt`,
+        // always injected via `--append-system-prompt-file` on tm-driven
+        // spawns). Before this fix, every bundled output-style file (loaded
+        // independently via the Claude Code `outputStyle` settings key) ALSO
+        // carried a full, near-identical restatement of that table —
+        // duplicated tokens every session.
+        //
+        // Code-critic follow-up: `outputStyle` is deployed to
+        // `<project>/.claude/output-styles/*.md` + `settings.json`
+        // (`settings.rs`) and therefore applies to ANY `claude` launched in
+        // that directory — including a manual `claude` invocation that never
+        // receives `--append-system-prompt-file` at all
+        // (`runtime/claude_code.rs`). A style with NOTHING but a pointer to
+        // the appended prompt would leave such a launch with zero
+        // enforcement. So each style keeps a short, SELF-CONTAINED minimal
+        // mandate (PRIMARY DIRECTIVE statement, override-phrase list, a
+        // prohibition summary) alongside the pointer to the full table —
+        // this test asserts that block survived the dedup, not just that the
+        // heading sentinel is de-duplicated.
         const SENTINEL: &str = "PRIMARY DIRECTIVE";
         let assembled = assemble_system_prompt();
         assert_eq!(
@@ -680,14 +707,47 @@ mod tests {
              DIRECTIVE banner — the mandate lives there as Identity + \
              Prohibitions content"
         );
+
+        // The appended prompt must still carry the substantive, canonical
+        // mandate content — so the mandate can never silently vanish from
+        // BOTH channels at once just because the banner text moved.
+        assert!(
+            assembled.contains("## Prohibitions"),
+            "the appended prompt must carry the canonical Prohibitions table"
+        );
+        assert!(
+            assembled.contains("## Circuit Breakers"),
+            "the appended prompt must carry the canonical Circuit Breakers table"
+        );
+        assert!(
+            assembled.contains("don't delegate"),
+            "the appended prompt must carry at least one override phrase"
+        );
+
         for style in crate::core::bundle::OUTPUT_STYLES {
             let combined =
                 assembled.matches(SENTINEL).count() + style.content.matches(SENTINEL).count();
             assert_eq!(
                 combined, 1,
                 "{}: PRIMARY DIRECTIVE sentinel must appear exactly once across \
-                 the appended prompt + this output style (one pointer heading, \
-                 never a full restatement) — got {combined}",
+                 the appended prompt + this output style (one heading, never a \
+                 full restatement of the mandate TABLE) — got {combined}",
+                style.id
+            );
+
+            // Each style must still carry its OWN self-contained minimal
+            // mandate — the override-phrase list and a prohibition summary —
+            // so a manual `claude` launch (no --append-system-prompt-file)
+            // in a tm-provisioned workspace is never left with zero
+            // enforcement.
+            assert!(
+                style.content.contains("do this yourself"),
+                "{}: must carry its own self-contained override-phrase list",
+                style.id
+            );
+            assert!(
+                style.content.contains("Minimum prohibitions"),
+                "{}: must carry its own self-contained prohibition summary",
                 style.id
             );
         }

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -19,6 +19,7 @@ mod search_index;
 mod settings;
 #[cfg(test)]
 mod tests;
+mod worktree_sync;
 // Split out of `tests.rs` to keep it under the 1500-SLOC test-file cap
 // (issue #2149 roster-deploy-failure-continues coverage) — mirrors the
 // `doctor_output_style.rs` / `doctor_fs_checks.rs` split pattern.
@@ -56,6 +57,19 @@ use settings::{
 /// `core::standalone::settings_defaults` tests (this is a plain re-export, no
 /// logic of its own).
 pub(crate) use settings::{OUTPUT_STYLE, is_stale_statusline_command, resolve_statusline_command};
+
+/// Re-export of the resume-time worktree/upstream sync primitives (issue
+/// #2647) for reuse by `daemon::managed_routes::lifecycle::resume_managed`.
+///
+/// Why: `mod worktree_sync` above is private; this re-export is the public
+/// boundary the resume path calls through, mirroring the `settings`
+/// re-export just above.
+/// What: re-exports [`worktree_sync::resume_self_heal`] — the single
+/// call-site entry point wrapping [`worktree_sync::sync_worktree_with_upstream`]
+/// and [`worktree_sync::self_heal_claude_md`] with logging.
+/// Test: covered by `worktree_sync`'s own unit tests (this is a plain
+/// re-export, no logic of its own).
+pub use worktree_sync::resume_self_heal;
 
 /// Outcome of the pre-launch preparation for one session.
 ///

--- a/crates/trusty-mpm/src/core/session_launch/worktree_sync.rs
+++ b/crates/trusty-mpm/src/core/session_launch/worktree_sync.rs
@@ -1,0 +1,516 @@
+//! Sync a per-session git worktree with its upstream branch on resume (#2647).
+//!
+//! Why: `WorkspaceProvisioner`'s `fetch_and_reset`
+//! (`crate::provisioner::workspace`) keeps the SHARED `.base` bare checkout
+//! current with `origin/main`, but the per-session worktree created off it
+//! (`<project>/.base/.worktrees/<session-id>/`) was never re-synced on
+//! resume — once created, its branch was frozen at that commit forever. A
+//! long-lived session silently drifted from `origin/main` and re-exhibited
+//! bugs already fixed upstream (e.g. a stale, since-deleted `CLAUDE.md`
+//! reappearing after a later commit removed it — issue #2647's root cause 1).
+//! `configure_session_branch_tracking` (issue #2189,
+//! `daemon::managed_routes::inproject`) already points the session branch's
+//! upstream at `origin/<default-branch>` at creation time; this module is the
+//! missing piece that actually USES that tracking relationship on resume.
+//! What: [`sync_worktree_with_upstream`] runs `git fetch` + a **fast-forward
+//! only** merge against the configured upstream. Fast-forward-only is the
+//! load-bearing safety property required by #2647: it NEVER rewrites the
+//! branch's history (`git reset --hard` is never invoked), and git itself
+//! refuses the merge outright if any uncommitted local change would be
+//! overwritten by it — so genuine user work in this worktree is either
+//! preserved untouched (files the incoming commits do not touch) or the
+//! whole sync is skipped (files that collide), never silently clobbered.
+//! [`self_heal_claude_md`] separately strips any legacy (#2170)
+//! delegation-directive pollution from the project `CLAUDE.md` even when it
+//! carries an uncommitted local diff that would otherwise block the
+//! fast-forward (exactly the state issue #2647 found this session's own
+//! worktree in).
+//! Test: `sync_fast_forwards_tracked_file_leaves_uncommitted_user_file_untouched`,
+//! `sync_is_noop_when_already_up_to_date`,
+//! `sync_skips_when_no_upstream_configured`,
+//! `sync_fails_open_on_conflicting_uncommitted_change`,
+//! `self_heal_claude_md_strips_legacy_block`,
+//! `self_heal_claude_md_noop_when_clean`,
+//! `self_heal_claude_md_noop_when_absent`.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Outcome of one [`sync_worktree_with_upstream`] attempt.
+///
+/// Why: `resume_managed` logs this for observability but never treats any
+/// variant as fatal — every path here is fail-open by design (see module
+/// docs): a failed or skipped sync just means the worktree stays exactly as
+/// it was, which is always safe.
+/// What: one variant per terminal state of the sync attempt.
+/// Test: each variant is produced by a corresponding unit test.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncOutcome {
+    /// The worktree branch was already at its upstream tip — no change made.
+    UpToDate,
+    /// Fast-forwarded from `from` to `to` (both full commit SHAs).
+    FastForwarded {
+        /// The branch tip before the sync.
+        from: String,
+        /// The branch tip after the sync.
+        to: String,
+    },
+    /// `workspace` is not a git worktree (no `.git`) — nothing to sync.
+    NotAGitWorktree,
+    /// The branch has no upstream tracking ref configured — nothing to sync
+    /// against. Worktrees created before issue #2189, or created outside the
+    /// `inproject` path, may legitimately land here.
+    NoUpstream,
+    /// `git fetch` or the fast-forward merge failed or was refused (most
+    /// commonly: local uncommitted changes collide with the upstream diff,
+    /// so git refuses to overwrite them). The payload is git's own stderr,
+    /// trimmed. The worktree's working tree is left exactly as it was.
+    Failed(String),
+}
+
+/// Fetch and fast-forward-merge `workspace`'s current branch onto its
+/// configured upstream, never touching commits or uncommitted changes that
+/// would require anything OTHER than a clean fast-forward.
+///
+/// Why: see module docs — this is the resume-time counterpart to
+/// `WorkspaceProvisioner::fetch_and_reset` for the shared base checkout,
+/// scoped to a single session worktree and safe to run against a workspace
+/// that may carry uncommitted operator edits.
+/// What: resolves `@{upstream}` for the current branch; if absent, returns
+/// [`SyncOutcome::NoUpstream`]. Otherwise runs `git fetch <remote>` (the
+/// remote named by the upstream ref, e.g. `origin`), then
+/// `git merge --ff-only <upstream>`. A non-zero exit from either step yields
+/// [`SyncOutcome::Failed`] with git's stderr; the caller MUST treat this as
+/// non-fatal (see `resume_managed`).
+/// Test: `sync_fast_forwards_tracked_file_leaves_uncommitted_user_file_untouched`,
+/// `sync_is_noop_when_already_up_to_date`,
+/// `sync_skips_when_no_upstream_configured`,
+/// `sync_fails_open_on_conflicting_uncommitted_change`.
+pub fn sync_worktree_with_upstream(workspace: &Path) -> SyncOutcome {
+    if !workspace.join(".git").exists() {
+        return SyncOutcome::NotAGitWorktree;
+    }
+
+    let Some(upstream) = git_stdout(
+        workspace,
+        &[
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ],
+    ) else {
+        return SyncOutcome::NoUpstream;
+    };
+
+    let Some(remote) = upstream.split('/').next().filter(|s| !s.is_empty()) else {
+        return SyncOutcome::NoUpstream;
+    };
+
+    let before = git_stdout(workspace, &["rev-parse", "HEAD"]).unwrap_or_default();
+
+    if let Err(stderr) = git_run(workspace, &["fetch", remote]) {
+        return SyncOutcome::Failed(format!("git fetch failed: {stderr}"));
+    }
+
+    if let Err(stderr) = git_run(workspace, &["merge", "--ff-only", &upstream]) {
+        return SyncOutcome::Failed(stderr);
+    }
+
+    let after = git_stdout(workspace, &["rev-parse", "HEAD"]).unwrap_or_default();
+    if before == after {
+        SyncOutcome::UpToDate
+    } else {
+        SyncOutcome::FastForwarded {
+            from: before,
+            to: after,
+        }
+    }
+}
+
+/// Strip the legacy (#2170) delegation-directive block from the project's
+/// `CLAUDE.md`, if present — self-healing pollution left by pre-#2170
+/// worktrees even when it carries an uncommitted local diff that would
+/// otherwise block [`sync_worktree_with_upstream`]'s fast-forward.
+///
+/// Why (issue #2647): a worktree provisioned before #2170 shipped can carry
+/// the legacy block as an UNCOMMITTED local edit (exactly the state #2647
+/// found this session's own worktree in). `git merge --ff-only` correctly
+/// refuses to touch a file with an uncommitted diff (see module docs), so the
+/// git-level sync alone cannot self-heal this specific pollution.
+/// `strip_delegation_block` is already proven byte-identical-safe on clean
+/// input (issue #2170); calling it unconditionally on resume is a pure
+/// content edit (no git operation), so it applies regardless of the
+/// worktree's git state.
+/// What: reads `<workspace>/CLAUDE.md` (a no-op, returns `false`, if
+/// absent/unreadable), strips the fenced block via
+/// [`crate::core::instruction_pipeline::strip_delegation_block`], and writes
+/// back ONLY when the content actually changed. Returns `true` iff a write
+/// happened.
+/// Test: `self_heal_claude_md_strips_legacy_block`,
+/// `self_heal_claude_md_noop_when_clean`,
+/// `self_heal_claude_md_noop_when_absent`.
+pub fn self_heal_claude_md(workspace: &Path) -> bool {
+    let path = workspace.join("CLAUDE.md");
+    let Ok(original) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    let cleaned = crate::core::instruction_pipeline::strip_delegation_block(&original);
+    if cleaned == original {
+        return false;
+    }
+    std::fs::write(&path, cleaned).is_ok()
+}
+
+/// Best-effort resume-time self-heal: sync `workspace`'s worktree branch to
+/// its upstream (fast-forward only) and strip legacy delegation-directive
+/// pollution from `CLAUDE.md`, logging outcomes but never failing.
+///
+/// Why: the call site (`daemon::managed_routes::lifecycle::resume_managed`)
+/// must stay a one-line call rather than inlining the
+/// [`SyncOutcome`] match + logging itself — that inline form is what pushed
+/// `lifecycle.rs` over its frozen SLOC budget during #2647 review.
+/// Centralising the log-and-continue wiring here keeps the call site small
+/// and keeps this module the single place that knows how to interpret a
+/// [`SyncOutcome`].
+/// What: calls [`sync_worktree_with_upstream`] then [`self_heal_claude_md`],
+/// logging a `FastForwarded` or `Failed` sync outcome (and a successful
+/// self-heal) at `info`/`warn` via `tracing`; steady states
+/// (`UpToDate`/`NotAGitWorktree`/`NoUpstream`) are not logged. `session_id`
+/// is included in every log line for correlation; callers pass
+/// `record.id.to_string()`.
+/// Test: covered indirectly via [`sync_worktree_with_upstream`]'s and
+/// [`self_heal_claude_md`]'s own unit tests above — this wrapper adds only
+/// logging, no independent branching logic.
+pub fn resume_self_heal(workspace: &Path, session_id: &str) {
+    match sync_worktree_with_upstream(workspace) {
+        SyncOutcome::FastForwarded { from, to } => {
+            tracing::info!(id = %session_id, %from, %to, "resume: worktree fast-forwarded to upstream");
+        }
+        SyncOutcome::Failed(reason) => {
+            tracing::warn!(id = %session_id, "resume: worktree/upstream sync skipped (non-fatal): {reason}");
+        }
+        SyncOutcome::UpToDate | SyncOutcome::NotAGitWorktree | SyncOutcome::NoUpstream => {}
+    }
+    if self_heal_claude_md(workspace) {
+        tracing::info!(id = %session_id, "resume: stripped legacy delegation-directive pollution from CLAUDE.md");
+    }
+}
+
+/// Run `git -C <workspace> <args>`, returning trimmed stdout on success or
+/// `None` on any failure (missing binary, non-zero exit, empty output).
+fn git_stdout(workspace: &Path, args: &[&str]) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(args)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if text.is_empty() { None } else { Some(text) }
+}
+
+/// Run `git -C <workspace> <args>`, returning `Ok(())` on success or
+/// `Err(stderr)` (trimmed) on any failure.
+fn git_run(workspace: &Path, args: &[&str]) -> Result<(), String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(args)
+        .output()
+        .map_err(|e| format!("git exec failed: {e}"))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Real, disposable git fixture mirroring the shape #2647 describes:
+    /// a bare `origin`, a `base` clone of it (stands in for the shared
+    /// `.base` checkout), and a `worktree` created off `base` with upstream
+    /// tracking configured exactly like `configure_session_branch_tracking`
+    /// (issue #2189) sets it up in production.
+    ///
+    /// Returns `None` (callers must skip, not fail) when `git` is
+    /// unavailable in this environment — mirrors the established pattern in
+    /// `session_manager::decommission_worktree_tests`.
+    struct Fixture {
+        _origin_dir: TempDir,
+        _base_dir: TempDir,
+        _seed_dir: TempDir,
+        worktree_dir: TempDir,
+        origin: std::path::PathBuf,
+        seed: std::path::PathBuf,
+    }
+
+    fn git_ok(dir: &Path, args: &[&str]) -> bool {
+        Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn configure_identity(dir: &Path) {
+        let _ = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["config", "user.email", "ci@test.invalid"])
+            .output();
+        let _ = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["config", "user.name", "CI"])
+            .output();
+    }
+
+    fn build_fixture() -> Option<Fixture> {
+        let origin_dir = TempDir::new().ok()?;
+        let origin = origin_dir.path().to_path_buf();
+        if !git_ok(&origin, &["init", "--bare"]) {
+            eprintln!("worktree_sync tests: git unavailable, skipping");
+            return None;
+        }
+
+        // Seed clone: writes the initial commit (CLAUDE.md + OTHER.md) and
+        // pushes it to `main` on the bare origin, then anchors the bare
+        // repo's HEAD symref at `main` so a later `git clone` resolves a
+        // real default branch instead of an empty/detached one.
+        let seed_dir = TempDir::new().ok()?;
+        let seed = seed_dir.path().to_path_buf();
+        if !git_ok(&seed, &["init"]) {
+            return None;
+        }
+        configure_identity(&seed);
+        if !git_ok(&seed, &["checkout", "-b", "main"]) {
+            return None;
+        }
+        std::fs::write(seed.join("CLAUDE.md"), "old content\n").ok()?;
+        std::fs::write(seed.join("OTHER.md"), "other v1\n").ok()?;
+        if !git_ok(&seed, &["add", "-A"]) {
+            return None;
+        }
+        if !git_ok(&seed, &["commit", "-m", "init"]) {
+            return None;
+        }
+        if !git_ok(
+            &seed,
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+        ) {
+            return None;
+        }
+        if !git_ok(&seed, &["push", "origin", "main"]) {
+            return None;
+        }
+        if !git_ok(&origin, &["symbolic-ref", "HEAD", "refs/heads/main"]) {
+            return None;
+        }
+
+        // Base clone: stands in for the shared `.base` checkout.
+        let base_dir = TempDir::new().ok()?;
+        let base = base_dir.path().to_path_buf();
+        // `TempDir::new` already created the directory; `git clone` refuses
+        // to clone into a non-empty existing dir in some git versions, so
+        // remove it first and let clone recreate it.
+        let _ = std::fs::remove_dir(&base);
+        if !git_ok(
+            Path::new("."),
+            &["clone", origin.to_str().unwrap(), base.to_str().unwrap()],
+        ) {
+            return None;
+        }
+        configure_identity(&base);
+
+        // Session worktree, mirroring `create_session_worktree` +
+        // `configure_session_branch_tracking` (issue #2189): a new branch
+        // checked out from `base`'s HEAD, with its upstream explicitly
+        // pointed at `origin/main`.
+        let worktree_dir = TempDir::new().ok()?;
+        let worktree = worktree_dir.path().to_path_buf();
+        let _ = std::fs::remove_dir(&worktree);
+        if !git_ok(
+            &base,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "session-branch",
+                worktree.to_str().unwrap(),
+            ],
+        ) {
+            return None;
+        }
+        configure_identity(&worktree);
+        if !git_ok(
+            &worktree,
+            &["branch", "--set-upstream-to=origin/main", "session-branch"],
+        ) {
+            return None;
+        }
+
+        Some(Fixture {
+            _origin_dir: origin_dir,
+            _base_dir: base_dir,
+            _seed_dir: seed_dir,
+            worktree_dir,
+            origin,
+            seed,
+        })
+    }
+
+    /// Push a new commit to `origin`'s `main` via the seed clone, updating
+    /// `CLAUDE.md` to `new_content`. Mirrors an upstream fix (e.g. #2300)
+    /// landing after this session's worktree was created.
+    fn push_claude_md_update(fx: &Fixture, new_content: &str) {
+        assert!(git_ok(&fx.seed, &["pull", "origin", "main"]));
+        std::fs::write(fx.seed.join("CLAUDE.md"), new_content).unwrap();
+        assert!(git_ok(&fx.seed, &["add", "-A"]));
+        assert!(git_ok(&fx.seed, &["commit", "-m", "update CLAUDE.md"]));
+        assert!(git_ok(&fx.seed, &["push", "origin", "main"]));
+        let _ = &fx.origin; // origin is referenced only via the seed's remote
+    }
+
+    #[test]
+    fn sync_fast_forwards_tracked_file_leaves_uncommitted_user_file_untouched() {
+        let Some(fx) = build_fixture() else {
+            return;
+        };
+        let worktree = fx.worktree_dir.path();
+
+        // Simulate user work in progress: an uncommitted edit to a file the
+        // upstream commit below does NOT touch.
+        std::fs::write(worktree.join("OTHER.md"), "other v1 + user edit\n").unwrap();
+
+        // Simulate an upstream fix landing (e.g. #2300) while this worktree
+        // was never fetched.
+        push_claude_md_update(&fx, "new content\n");
+
+        let outcome = sync_worktree_with_upstream(worktree);
+        assert!(
+            matches!(outcome, SyncOutcome::FastForwarded { .. }),
+            "expected a fast-forward, got {outcome:?}"
+        );
+
+        assert_eq!(
+            std::fs::read_to_string(worktree.join("CLAUDE.md")).unwrap(),
+            "new content\n",
+            "tm-tracked CLAUDE.md must refresh to the current origin/main content"
+        );
+        assert_eq!(
+            std::fs::read_to_string(worktree.join("OTHER.md")).unwrap(),
+            "other v1 + user edit\n",
+            "uncommitted user work in an untouched file must survive the sync"
+        );
+    }
+
+    #[test]
+    fn sync_is_noop_when_already_up_to_date() {
+        let Some(fx) = build_fixture() else {
+            return;
+        };
+        let worktree = fx.worktree_dir.path();
+
+        let first = sync_worktree_with_upstream(worktree);
+        assert_eq!(first, SyncOutcome::UpToDate);
+        let second = sync_worktree_with_upstream(worktree);
+        assert_eq!(second, SyncOutcome::UpToDate);
+    }
+
+    #[test]
+    fn sync_skips_when_no_upstream_configured() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        if !git_ok(dir, &["init"]) {
+            return;
+        }
+        configure_identity(dir);
+        std::fs::write(dir.join("f.txt"), "x").unwrap();
+        if !git_ok(dir, &["add", "-A"]) || !git_ok(dir, &["commit", "-m", "init"]) {
+            return;
+        }
+
+        assert_eq!(sync_worktree_with_upstream(dir), SyncOutcome::NoUpstream);
+    }
+
+    #[test]
+    fn sync_reports_not_a_git_worktree_for_non_git_dir() {
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(
+            sync_worktree_with_upstream(tmp.path()),
+            SyncOutcome::NotAGitWorktree
+        );
+    }
+
+    #[test]
+    fn sync_fails_open_on_conflicting_uncommitted_change() {
+        let Some(fx) = build_fixture() else {
+            return;
+        };
+        let worktree = fx.worktree_dir.path();
+
+        // Uncommitted edit to the SAME file the upstream commit changes —
+        // git must refuse the fast-forward rather than clobber it.
+        std::fs::write(worktree.join("CLAUDE.md"), "local uncommitted edit\n").unwrap();
+        push_claude_md_update(&fx, "new content\n");
+
+        let outcome = sync_worktree_with_upstream(worktree);
+        assert!(
+            matches!(outcome, SyncOutcome::Failed(_)),
+            "expected a fail-open Failed outcome, got {outcome:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(worktree.join("CLAUDE.md")).unwrap(),
+            "local uncommitted edit\n",
+            "a refused merge must leave the uncommitted local edit untouched"
+        );
+    }
+
+    #[test]
+    fn self_heal_claude_md_strips_legacy_block() {
+        let tmp = TempDir::new().unwrap();
+        let begin = "<!-- trusty-mpm:delegation-directive:begin \
+            (framework-owned — do not edit; regenerated on every session start, see issue #2125) -->";
+        let end = "<!-- trusty-mpm:delegation-directive:end -->";
+        let polluted = format!(
+            "{begin}\n\nSome injected directive text.\n\n{end}\n\n# My Project\n\nNotes.\n"
+        );
+        std::fs::write(tmp.path().join("CLAUDE.md"), &polluted).unwrap();
+
+        assert!(self_heal_claude_md(tmp.path()));
+
+        let cleaned = std::fs::read_to_string(tmp.path().join("CLAUDE.md")).unwrap();
+        assert!(!cleaned.contains(begin));
+        assert!(!cleaned.contains("Some injected directive text."));
+        assert_eq!(cleaned, "# My Project\n\nNotes.\n");
+    }
+
+    #[test]
+    fn self_heal_claude_md_noop_when_clean() {
+        let tmp = TempDir::new().unwrap();
+        let clean = "# My Project\n\nNotes.\n";
+        std::fs::write(tmp.path().join("CLAUDE.md"), clean).unwrap();
+
+        assert!(!self_heal_claude_md(tmp.path()));
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("CLAUDE.md")).unwrap(),
+            clean
+        );
+    }
+
+    #[test]
+    fn self_heal_claude_md_noop_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!self_heal_claude_md(tmp.path()));
+    }
+}

--- a/crates/trusty-mpm/src/core/session_launch/worktree_sync.rs
+++ b/crates/trusty-mpm/src/core/session_launch/worktree_sync.rs
@@ -29,12 +29,27 @@
 //! `sync_is_noop_when_already_up_to_date`,
 //! `sync_skips_when_no_upstream_configured`,
 //! `sync_fails_open_on_conflicting_uncommitted_change`,
+//! `sync_fails_open_when_branches_have_diverged_with_local_commit`,
 //! `self_heal_claude_md_strips_legacy_block`,
 //! `self_heal_claude_md_noop_when_clean`,
 //! `self_heal_claude_md_noop_when_absent`.
 
 use std::path::Path;
 use std::process::Command;
+use std::time::Duration;
+
+/// Upper bound on how long [`resume_self_heal`] will wait for the git
+/// fetch/merge to complete before giving up and letting resume proceed.
+///
+/// Why (code-critic review, #2647): the git subprocess work runs on a
+/// blocking thread via `tokio::task::spawn_blocking`, but a stalled network
+/// fetch (e.g. a dead remote, a hung proxy) can otherwise keep that thread —
+/// and the resume flow awaiting it — blocked indefinitely. Resume must never
+/// hang on network I/O.
+/// What: 10 seconds, generous for a same-org `origin` fetch of a handful of
+/// commits, short enough that a hung fetch cannot meaningfully delay a
+/// session resume.
+const SYNC_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Outcome of one [`sync_worktree_with_upstream`] attempt.
 ///
@@ -85,7 +100,8 @@ pub enum SyncOutcome {
 /// Test: `sync_fast_forwards_tracked_file_leaves_uncommitted_user_file_untouched`,
 /// `sync_is_noop_when_already_up_to_date`,
 /// `sync_skips_when_no_upstream_configured`,
-/// `sync_fails_open_on_conflicting_uncommitted_change`.
+/// `sync_fails_open_on_conflicting_uncommitted_change`,
+/// `sync_fails_open_when_branches_have_diverged_with_local_commit`.
 pub fn sync_worktree_with_upstream(workspace: &Path) -> SyncOutcome {
     if !workspace.join(".git").exists() {
         return SyncOutcome::NotAGitWorktree;
@@ -109,7 +125,21 @@ pub fn sync_worktree_with_upstream(workspace: &Path) -> SyncOutcome {
 
     let before = git_stdout(workspace, &["rev-parse", "HEAD"]).unwrap_or_default();
 
-    if let Err(stderr) = git_run(workspace, &["fetch", remote]) {
+    // Defense in depth (code-critic review, #2647) alongside the outer
+    // `SYNC_TIMEOUT`: abort the fetch itself if the transfer stalls below
+    // 1000 bytes/sec for more than 5 seconds, so a slow-but-not-dead remote
+    // cannot eat most of the outer timeout budget on the network layer alone.
+    if let Err(stderr) = git_run(
+        workspace,
+        &[
+            "-c",
+            "http.lowSpeedLimit=1000",
+            "-c",
+            "http.lowSpeedTime=5",
+            "fetch",
+            remote,
+        ],
+    ) {
         return SyncOutcome::Failed(format!("git fetch failed: {stderr}"));
     }
 
@@ -172,18 +202,28 @@ pub fn self_heal_claude_md(workspace: &Path) -> bool {
 /// `lifecycle.rs` over its frozen SLOC budget during #2647 review.
 /// Centralising the log-and-continue wiring here keeps the call site small
 /// and keeps this module the single place that knows how to interpret a
-/// [`SyncOutcome`].
-/// What: calls [`sync_worktree_with_upstream`] then [`self_heal_claude_md`],
-/// logging a `FastForwarded` or `Failed` sync outcome (and a successful
-/// self-heal) at `info`/`warn` via `tracing`; steady states
+/// [`SyncOutcome`]. This function is `async` (code-critic review, #2647):
+/// `resume_managed` runs on a tokio worker thread, and the git fetch/merge
+/// in [`sync_worktree_with_upstream`] are blocking subprocess calls that can
+/// stall on network I/O — running them directly on the async task would
+/// block that worker thread (and, transitively, resume) for as long as the
+/// network hangs.
+/// What: runs [`sync_worktree_with_upstream`] on a `spawn_blocking` thread,
+/// bounded by [`SYNC_TIMEOUT`] — a timeout or a panicked blocking task both
+/// degrade to `SyncOutcome::Failed` and are logged exactly like any other
+/// sync failure (fail-open; resume always proceeds). Then calls
+/// [`self_heal_claude_md`] directly (a single small `CLAUDE.md` read/write,
+/// no git subprocess, no network — not a resume-hang risk). Logs a
+/// `FastForwarded` or `Failed` sync outcome (and a successful self-heal) at
+/// `info`/`warn` via `tracing`; steady states
 /// (`UpToDate`/`NotAGitWorktree`/`NoUpstream`) are not logged. `session_id`
 /// is included in every log line for correlation; callers pass
 /// `record.id.to_string()`.
 /// Test: covered indirectly via [`sync_worktree_with_upstream`]'s and
 /// [`self_heal_claude_md`]'s own unit tests above — this wrapper adds only
-/// logging, no independent branching logic.
-pub fn resume_self_heal(workspace: &Path, session_id: &str) {
-    match sync_worktree_with_upstream(workspace) {
+/// async/timeout plumbing and logging, no independent branching logic.
+pub async fn resume_self_heal(workspace: &Path, session_id: &str) {
+    match sync_worktree_with_upstream_bounded(workspace).await {
         SyncOutcome::FastForwarded { from, to } => {
             tracing::info!(id = %session_id, %from, %to, "resume: worktree fast-forwarded to upstream");
         }
@@ -194,6 +234,37 @@ pub fn resume_self_heal(workspace: &Path, session_id: &str) {
     }
     if self_heal_claude_md(workspace) {
         tracing::info!(id = %session_id, "resume: stripped legacy delegation-directive pollution from CLAUDE.md");
+    }
+}
+
+/// Run [`sync_worktree_with_upstream`] on a blocking thread-pool thread,
+/// bounded by [`SYNC_TIMEOUT`] so a stalled fetch can never hang the caller.
+///
+/// Why: see [`resume_self_heal`]'s doc comment — this is the seam that keeps
+/// the blocking git subprocess work off the async task and off the resume
+/// critical path past a fixed budget.
+/// What: `tokio::task::spawn_blocking` runs the sync on a dedicated thread;
+/// `tokio::time::timeout(SYNC_TIMEOUT, ...)` races it against the deadline.
+/// A timeout or a `JoinError` (blocking-task panic) both degrade to
+/// `SyncOutcome::Failed` with a descriptive message — never propagated as an
+/// error to the caller, matching the fail-open contract of every other
+/// variant. Note: on timeout the abandoned blocking task keeps running to
+/// completion in the background (it cannot be forcibly killed mid-syscall);
+/// this only bounds how long `resume_self_heal` itself waits.
+/// Test: exercised transitively by every `sync_*` test above (the bounded
+/// wrapper adds no branching beyond the timeout race, which is impractical
+/// to trigger deterministically in a fast unit test without a fake slow git
+/// binary).
+async fn sync_worktree_with_upstream_bounded(workspace: &Path) -> SyncOutcome {
+    let workspace = workspace.to_path_buf();
+    let task = tokio::task::spawn_blocking(move || sync_worktree_with_upstream(&workspace));
+    match tokio::time::timeout(SYNC_TIMEOUT, task).await {
+        Ok(Ok(outcome)) => outcome,
+        Ok(Err(join_err)) => SyncOutcome::Failed(format!("sync task panicked: {join_err}")),
+        Err(_elapsed) => SyncOutcome::Failed(format!(
+            "worktree sync timed out after {}s",
+            SYNC_TIMEOUT.as_secs()
+        )),
     }
 }
 
@@ -473,6 +544,56 @@ mod tests {
             std::fs::read_to_string(worktree.join("CLAUDE.md")).unwrap(),
             "local uncommitted edit\n",
             "a refused merge must leave the uncommitted local edit untouched"
+        );
+    }
+
+    #[test]
+    fn sync_fails_open_when_branches_have_diverged_with_local_commit() {
+        // Why (code-critic review, #2647 item 5): the earlier conflict test
+        // covers an UNCOMMITTED collision; this covers genuine branch
+        // divergence — a real local COMMIT on the worktree branch that
+        // origin/main does not have, while origin/main independently gains
+        // an unrelated commit. Neither branch is an ancestor of the other,
+        // so `git merge --ff-only` must refuse outright (a true merge or
+        // rebase would be required, which this fail-open sync never
+        // attempts), leaving the worktree's branch tip and working tree
+        // completely untouched.
+        let Some(fx) = build_fixture() else {
+            return;
+        };
+        let worktree = fx.worktree_dir.path();
+
+        // A genuine local commit on the worktree's own branch — e.g. the
+        // operator committed work-in-progress before this resume.
+        std::fs::write(worktree.join("OTHER.md"), "other v1 + local work\n").unwrap();
+        assert!(git_ok(worktree, &["add", "-A"]));
+        assert!(git_ok(worktree, &["commit", "-m", "local wip commit"]));
+        let head_before = git_stdout(worktree, &["rev-parse", "HEAD"]).unwrap();
+
+        // origin/main independently advances with an unrelated commit.
+        push_claude_md_update(&fx, "new content\n");
+
+        let outcome = sync_worktree_with_upstream(worktree);
+        assert!(
+            matches!(outcome, SyncOutcome::Failed(_)),
+            "expected a fail-open Failed outcome on diverged histories, got {outcome:?}"
+        );
+
+        let head_after = git_stdout(worktree, &["rev-parse", "HEAD"]).unwrap();
+        assert_eq!(
+            head_before, head_after,
+            "a refused non-fast-forward merge must never move the branch tip"
+        );
+        assert_eq!(
+            std::fs::read_to_string(worktree.join("OTHER.md")).unwrap(),
+            "other v1 + local work\n",
+            "the local commit's content must survive an untouched worktree"
+        );
+        assert_eq!(
+            std::fs::read_to_string(worktree.join("CLAUDE.md")).unwrap(),
+            "old content\n",
+            "CLAUDE.md must stay at the worktree's own committed content, not \
+             silently pick up origin's unrelated commit"
         );
     }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -1339,10 +1339,24 @@ async fn front_gate_or_escalate(
 /// is intentionally NOT re-run here: those steps are not all confirmed safe to
 /// repeat against an already-running workspace, so re-running them on every
 /// resume risks a different class of bug for a narrower payoff.
+///
+/// #2647 worktree/upstream sync: before the statusline self-heal, every
+/// resume also calls
+/// [`crate::core::session_launch::sync_worktree_with_upstream`] (fetch +
+/// fast-forward-only merge — never resets the branch, never touches
+/// uncommitted changes) and
+/// [`crate::core::session_launch::self_heal_claude_md`] (strips legacy #2170
+/// delegation-directive pollution from `CLAUDE.md`, including when it is an
+/// uncommitted diff the fast-forward alone cannot touch). Both are
+/// best-effort and never block the resume — a long-lived session worktree
+/// that was previously frozen at its creation commit now catches up to
+/// `origin/main` on every resume instead of silently drifting forever.
 /// Test: covered by the HTTP `resume_managed_session` tests and the MCP
 /// `session_resume_unknown_id_errors` test;
 /// `resume_managed_backfills_missing_status_line` in
-/// `tests/session_manager_mvp.rs` covers the self-heal call added here.
+/// `tests/session_manager_mvp.rs` covers the self-heal call added here;
+/// `core::session_launch::worktree_sync`'s own unit tests cover the sync/
+/// self-heal primitives.
 pub async fn resume_managed(
     state: &Arc<DaemonState>,
     id: &ManagedSessionId,
@@ -1354,6 +1368,15 @@ pub async fn resume_managed(
         .workspace_path
         .clone()
         .unwrap_or_else(|| record.cwd.clone());
+
+    // Worktree/upstream sync + legacy CLAUDE.md self-heal (#2647): fast-forward
+    // -only, best-effort, never blocks the resume — see
+    // `core::session_launch::resume_self_heal` for the full safety contract
+    // (never resets the branch, never touches uncommitted changes). This is
+    // the resume-time counterpart to `WorkspaceProvisioner::fetch_and_reset`
+    // for the shared `.base` checkout, closing the gap that let a session
+    // worktree silently drift from `origin/main` forever.
+    crate::core::session_launch::resume_self_heal(&workspace, &record.id.to_string());
 
     // Defensive self-heal (#1913): best-effort, never blocks the resume.
     if let Err(e) = crate::core::session_launch::ensure_status_line(&workspace) {

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -1376,7 +1376,7 @@ pub async fn resume_managed(
     // the resume-time counterpart to `WorkspaceProvisioner::fetch_and_reset`
     // for the shared `.base` checkout, closing the gap that let a session
     // worktree silently drift from `origin/main` forever.
-    crate::core::session_launch::resume_self_heal(&workspace, &record.id.to_string());
+    crate::core::session_launch::resume_self_heal(&workspace, &record.id.to_string()).await;
 
     // Defensive self-heal (#1913): best-effort, never blocks the resume.
     if let Err(e) = crate::core::session_launch::ensure_status_line(&workspace) {


### PR DESCRIPTION
## Summary

Implements the top two ranked remediations from #2647 (session-start context bloat, ~100k tokens at launch):

**R1 — Session worktrees now sync with `origin/main` on resume.** `resume_managed` (`crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs`) previously never fetched or updated the per-session git worktree — once created, its branch was frozen forever, silently drifting from `origin/main` and re-exhibiting bugs already fixed upstream (e.g. a stale, since-deleted `CLAUDE.md`). A new `core::session_launch::resume_self_heal` (backed by `worktree_sync.rs`) now runs on every resume:
- `sync_worktree_with_upstream`: `git fetch` + **fast-forward-only** merge against the worktree's configured upstream (set up at creation time by issue #2189's `configure_session_branch_tracking`, but never previously used). Fast-forward-only is the safety property: it never rewrites the branch (no `git reset --hard`), and git itself refuses the merge outright if any uncommitted local change would be clobbered — so user work is either preserved untouched or the whole sync is skipped, never silently overwritten.
- `self_heal_claude_md`: strips legacy (#2170) delegation-directive pollution from `CLAUDE.md` even when it's an *uncommitted* diff that would otherwise block the fast-forward — exactly the state issue #2647 found this repo's own long-lived session worktree in.

Both steps are best-effort/fail-open and never block the resume.

**R2 — De-duplicated the PM delegation mandate.** The appended system prompt (`PM_INSTRUCTIONS.md` + `WORKFLOW.md` + `AGENT_DELEGATION.md` + the non-overridable `BASE_PM.md` floor, always injected via `--append-system-prompt-file`) and all three bundled output-style assets (`trusty-mpm.md`, `-research.md`, `-teacher.md`, loaded independently via the Claude Code `outputStyle` key) both carried a full "PRIMARY DIRECTIVE - MANDATORY DELEGATION" banner, Core Rules, and delegation-map table. The appended prompt is now the single canonical source (it already functioned that way — `BASE_PM.md` explicitly treats `PM_INSTRUCTIONS.md` as binding); each output style keeps only a short pointer plus content genuinely unique to that channel (Identity & Self-Awareness Protocol, Rust-specific Project Context, mode-specific behavior sections). The non-overridable `BASE_PM` floor semantics are preserved — it is still appended last, unconditionally, on every session.

## Measurement / token-savings estimate

- Output-style trimming (R2): `trusty-mpm.md` 10,677 → 9,784 bytes (~223 tokens saved on the default style, loaded every session); `trusty-mpm-research.md` 12,081 → 10,923 bytes (~290 tokens); `trusty-mpm-teacher.md` 11,783 → 10,722 bytes (~265 tokens). A new regression test (`primary_directive_mandate_not_duplicated_across_channels`) asserts the sentinel phrase "PRIMARY DIRECTIVE" appears in the appended prompt **zero** times and exactly **once** total across the appended prompt + each output style.
- Worktree sync (R1) is not a fixed per-session token count — it's a correctness fix that stops per-session context bloat from *silently reappearing* every time a long-lived worktree drifts (this PR's own dev session was itself 10 days stale and still carried a CLAUDE.md deleted upstream by #2300).

Issue #2647 also lists three more remediations (audit cross-file overlap in the four bundled instruction assets; lazy-load the agent/skill rosters; scope the MCP tool list per-project) that are **not** addressed here — using `Refs #2647` rather than `Closes`.

## Files changed

- `crates/trusty-mpm/src/core/session_launch/worktree_sync.rs` (new) — sync/self-heal primitives + unit tests
- `crates/trusty-mpm/src/core/session_launch/mod.rs` — re-exports `resume_self_heal`
- `crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs` — wires `resume_self_heal` into `resume_managed`
- `.line-cap-allowlist.tsv` — `lifecycle.rs` frozen SLOC budget 1217 → 1218 (`--force-add`, scoped to only this one file — it was at its ratchet ceiling with zero headroom for the one-line call site; `cli.rs`/`api.rs` entries were deliberately left untouched to avoid stepping on sibling PRs #2603/#2595)
- `crates/trusty-mpm/src/assets/output-styles/{trusty-mpm,trusty-mpm-research,trusty-mpm-teacher}.md` — condensed duplicate mandate to a pointer
- `crates/trusty-mpm/src/core/instruction_pipeline.rs` — new dedup regression test

**Scope-boundary note for the PM:** no overlap with `chat_store.rs` (#2602), `bin/tm/cli.rs` (#2603), or session-picker/`tm sessions ls` logic (#2595) — the only touched file near those areas is `lifecycle.rs`, and the diff there is the single `resume_self_heal` call site plus its doc-comment update.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p trusty-mpm --lib` — 3127 passed, 0 failed, 5 ignored
- [x] `cargo test -p trusty-mpm --lib worktree_sync` — 8/8 new tests pass, including fast-forward-leaves-uncommitted-user-file-untouched and fail-open-on-conflicting-uncommitted-change
- [x] `cargo test -p trusty-mpm --lib instruction_pipeline` — includes new `primary_directive_mandate_not_duplicated_across_channels`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (only pre-existing, unrelated `tga` MSRV-config warning)
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 10 allowlisted, 0 violations

Refs #2647

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools