### PR TITLE
fix(trusty-mpm): tm sessions resume hands terminal to the resumed session's tmux window

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
@@ -10,13 +10,23 @@
 //! both files under the 500-SLOC production cap.
 //!
 //! What: [`plan_resume`] is the pure branch selector over [`is_zombie`] /
-//! [`needs_restart`]; [`resume_guided_session`] is the I/O driver that dispatches
-//! on it, delegating the two daemon round-trips to [`reconcile_zombie_stop`]
+//! [`needs_restart`]; [`resume_session`] is the I/O driver that dispatches on
+//! it, delegating the two daemon round-trips to [`reconcile_zombie_stop`]
 //! (POST `/runtime-stop`) and [`restart_via_daemon`] (POST `/resume`).
+//! [`resume_guided_session`] is a thin always-attach wrapper over
+//! [`resume_session`] for the picker's own call sites, which are already
+//! TTY-gated upstream (`guided::tty_gate`). `tm session(s) resume <id>`
+//! (`commands::managed::session_resume`, #2649) calls [`resume_session`]
+//! directly with `no_attach` derived from `std::io::stdin().is_terminal()`,
+//! so a headless/scripted invocation still gets the daemon-side restart but
+//! never attempts a real tmux attach with no controlling terminal to move
+//! (code-critic HIGH, #2649 review).
 //!
 //! Test: the pure seams (`needs_restart`, `is_zombie`, `plan_resume`) are
 //! exhaustively unit-tested in `tests_behavior_c_tests.rs`; the HTTP paths are
-//! exercised by the e2e suite and manual smoke tests.
+//! exercised by the e2e suite and manual smoke tests; the `no_attach` gate is
+//! covered by `managed_tests.rs`'s
+//! `session_resume_headless_active_live_tmux_skips_restart_and_attach`.
 
 use anyhow::Context as _;
 
@@ -131,6 +141,56 @@ pub(crate) async fn resume_guided_session(
     url: &str,
     session: &trusty_mpm::client::ManagedSessionSummary,
 ) -> anyhow::Result<()> {
+    // The picker is only ever reached after its own upstream TTY gate
+    // (`guided::tty_gate`, checked before the picker renders at all) — always
+    // attach here. `no_attach` gating lives in `resume_session`, used by the
+    // explicit `tm session(s) resume <id>` verb, which has no such upstream
+    // gate (#2649 review).
+    resume_session(client, url, session, false).await
+}
+
+/// Same state machine as [`resume_guided_session`], but TTY-gated: skips the
+/// final terminal hand-off (and prints a status line instead) when the caller
+/// has no controlling terminal to move.
+///
+/// Why (code-critic HIGH, #2649 review): every branch of the resume flow
+/// unconditionally ended in [`tmux_attach`], which shells out to a REAL
+/// `tmux attach-session`/`switch-client`. That is correct for the interactive
+/// picker (always run at a real terminal — gated upstream, see
+/// [`resume_guided_session`]'s doc) but wrong for the explicit `tm
+/// session(s) resume <id>` verb: that verb is also a legitimate
+/// scripted/headless entry point (CI, a supervisor process, a piped
+/// invocation) with no controlling terminal at all. Attaching there is at
+/// best a silent no-op and at worst an actively confusing tmux error —
+/// even though the daemon-side resume already succeeded. Mirrors the
+/// `tty_gate` idiom (`guided.rs`, `std::io::stdin().is_terminal()`), but
+/// since the gated action here is an OUTPUT step (attach) rather than an
+/// input read, the caller passes the already-resolved `no_attach` bool
+/// instead of this function reading `stdin` itself — keeping the gate at the
+/// actual I/O boundary and this function fully testable without a TTY.
+/// What: identical branch selection to `resume_guided_session`
+/// (`plan_resume` / zombie-reconcile / restart via `restart_via_daemon`).
+/// When `no_attach` is `true`, skips [`tmux_attach`] and instead prints the
+/// same `resumed <name> (<id>) [<state>]` status line the pre-#2649
+/// direct-POST implementation printed — using the daemon's authoritative
+/// post-restart record when a restart happened, or the caller's own summary
+/// otherwise (the plain `Attach` branch never touches the daemon, so nothing
+/// changed). Returns `Ok(())` in both cases once the daemon-side state is
+/// confirmed good — a headless caller only sees a non-zero exit when the
+/// daemon-side resume/reconcile itself failed.
+/// Test: `needs_restart`/`is_zombie`/`plan_resume` are the testable pure
+/// seams (`guided_resume_plan_active_live_tmux_attaches` proves the Attach
+/// branch selection this depends on); `managed_tests.rs`'s
+/// `session_resume_headless_active_live_tmux_skips_restart_and_attach`
+/// (#2649) drives this function's Attach branch end-to-end in a non-TTY test
+/// process and asserts no daemon-side mutation occurred; the restart I/O
+/// path is exercised by the e2e suite and manual smoke tests.
+pub(crate) async fn resume_session(
+    client: &reqwest::Client,
+    url: &str,
+    session: &trusty_mpm::client::ManagedSessionSummary,
+    no_attach: bool,
+) -> anyhow::Result<()> {
     let tmux_live = tmux_has_session(&session.name);
     let action = plan_resume(&session.state, tmux_live);
 
@@ -147,6 +207,11 @@ pub(crate) async fn resume_guided_session(
         );
         reconcile_zombie_stop(client, url, session).await?;
     }
+
+    // `resumed` reflects the daemon's authoritative post-restart record when a
+    // restart happened below; otherwise (the plain Attach branch) it is just
+    // the caller's own summary — nothing on the daemon side changed.
+    let mut resumed = session.clone();
 
     // Restart path — shared by the plain Restart branch and the reconciled zombie.
     if matches!(
@@ -170,9 +235,17 @@ pub(crate) async fn resume_guided_session(
                 );
             }
         }
-        restart_via_daemon(client, url, session).await?;
+        resumed = restart_via_daemon(client, url, session).await?;
     }
-    tmux_attach(&session.name)
+
+    if no_attach {
+        println!(
+            "resumed {} ({}) [{}]",
+            resumed.name, resumed.id, resumed.state
+        );
+        return Ok(());
+    }
+    tmux_attach(&resumed.name)
 }
 
 /// Auto-stop a zombie session so the daemon record resets to `Stopped` (#2001).
@@ -250,14 +323,17 @@ async fn reconcile_zombie_stop(
 /// concrete reason (e.g. "workspace directory … no longer exists") instead of a
 /// bare status code. On HTTP 200 the body is parsed
 /// and, if `state=errored`, the async runtime spawn failed → bail directing the
-/// operator to `tm session info`. Success prints "restarted — attaching…" and
-/// returns `Ok(())`; the caller then attaches.
+/// operator to `tm session info`. Success prints "session restarted." and
+/// returns the daemon's authoritative post-restart [`ManagedSessionSummary`]
+/// (#2649 review: the caller needs this to print an accurate final state in
+/// headless/`no_attach` mode, rather than assuming `state == "active"`); the
+/// interactive caller uses it to attach.
 /// Test: I/O path exercised by the e2e suite; branch selection is [`plan_resume`].
 async fn restart_via_daemon(
     client: &reqwest::Client,
     url: &str,
     session: &trusty_mpm::client::ManagedSessionSummary,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<trusty_mpm::client::ManagedSessionSummary> {
     // POST with a 30-second timeout — a hung daemon must not freeze the CLI.
     let resp = match client
         .post(format!(
@@ -392,8 +468,8 @@ async fn restart_via_daemon(
                     session.name
                 );
             }
-            eprintln!("tm: session restarted — attaching…");
-            Ok(())
+            eprintln!("tm: session restarted.");
+            Ok(body)
         }
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -306,43 +306,57 @@ pub(crate) async fn session_stop(
     Ok(())
 }
 
-/// `tm session resume <id>` — resume a stopped managed session in its existing workspace.
+/// `tm session resume <id>` — resume a stopped managed session in its existing
+/// workspace AND hand the terminal over to it.
 ///
-/// Why: after `stop`, the workspace is still on disk; `resume` re-spawns the
-/// runtime there without re-cloning. Renamed from the verbose `managed-resume`
-/// in #1205 (which remains a deprecated alias). A missing id or a rejected
-/// resume (daemon `InvalidState`, e.g. the session isn't stopped) are both
-/// genuine failures to perform the requested resume (#2457) — printing a
-/// message and returning `Ok(())` let a script/CI check treat either as
-/// success, so both now return `Err` (non-zero exit) instead, mirroring the
-/// symmetric project-session resume path's own 404 handling just above this
-/// call site in `session.rs`.
-/// What: POSTs `/api/v1/sessions/managed/{id}/resume`; a 404 or 409 bails with
-/// an error instead of printing a status line.
+/// Why (#2649): after `stop`, the workspace is still on disk; `resume`
+/// re-spawns the runtime there without re-cloning. Renamed from the verbose
+/// `managed-resume` in #1205 (which remains a deprecated alias). Before #2649
+/// this handler only printed a status line after the daemon-side resume — the
+/// operator's terminal never moved into the resumed session's tmux window,
+/// unlike the bare-`tm` guided picker's resume path (fixed across #1742/#2001/
+/// #2148/#2453/#2456/#2467). Rather than re-implement that whole state
+/// machine, this now fetches the session record and delegates to the SAME
+/// [`crate::commands::guided_resume::resume_guided_session`] helper the picker
+/// uses, so the two entry points ("resume a session I just picked" and
+/// "resume a session I already know the id of") can never drift apart again —
+/// the exact gap that let this bug survive five rounds of fixes to the
+/// sibling path. That helper also ports the #2001 zombie/stale-Active
+/// auto-reconcile: a session the daemon still marks active/provisioning but
+/// whose tmux pane is gone is auto-stopped then restarted, rather than
+/// dead-ending on a 409. A missing id is still a genuine failure to perform
+/// the requested resume (#2457) — bailing instead of printing a message and
+/// returning `Ok(())`.
+/// What: GETs `/api/v1/sessions/managed/{id}` (a 404 bails with an error); on
+/// success, hands the resulting [`ManagedSessionSummary`] to
+/// `resume_guided_session`, which picks the right action (attach directly /
+/// restart via the daemon `/resume` endpoint / auto-reconcile a zombie then
+/// restart) purely from the record's state and live tmux liveness, then
+/// attaches (or `switch-client`s, when already inside tmux) the caller's
+/// terminal into the session's tmux window.
 /// Test: HTTP path covered by the integration test; parse by
 /// `cli_parses_session_managed_resume_verb`; `session_resume_not_found_errors`
-/// covers the #2457 exit-code fix for the 404 branch; `session_resume_conflict_state_errors`
-/// (in `managed_tests.rs`, #2521) covers the identical 409/conflict fix by
-/// seeding a session into a non-resumable state.
+/// covers the #2457 exit-code fix for the 404 branch;
+/// `session_resume_restart_failure_errors` (in `managed_tests.rs`, #2649)
+/// covers the same non-swallowing guarantee for a daemon-rejected restart now
+/// that this handler routes through the shared restart/attach helper instead
+/// of POSTing `/resume` directly; `plan_resume`/`needs_restart`/`is_zombie`
+/// in `guided_resume.rs`'s own tests exhaustively cover the branch selection
+/// this handler now shares.
 pub(crate) async fn session_resume(
     client: &reqwest::Client,
     url: &str,
     id: String,
 ) -> anyhow::Result<()> {
     let resp = client
-        .post(format!("{url}/api/v1/sessions/managed/{id}/resume"))
+        .get(format!("{url}/api/v1/sessions/managed/{id}"))
         .send()
         .await?;
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
         anyhow::bail!("managed session '{id}' not found");
     }
-    if resp.status() == reqwest::StatusCode::CONFLICT {
-        let msg = resp.text().await.unwrap_or_default();
-        anyhow::bail!("cannot resume: {msg}");
-    }
-    let body: ManagedSessionSummary = resp.error_for_status()?.json().await?;
-    println!("resumed {} ({}) [{}]", body.name, body.id, body.state);
-    Ok(())
+    let session: ManagedSessionSummary = resp.error_for_status()?.json().await?;
+    crate::commands::guided_resume::resume_guided_session(client, url, &session).await
 }
 
 /// `tm session decommission <id>` — full teardown (may or may not remove workspace).

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -15,6 +15,8 @@
 //! Test: `cli_parses_catalog_sync` exercises the parse path; the HTTP round-trip
 //! is covered by `tests/session_manager_mvp.rs`.
 
+use std::io::IsTerminal as _;
+
 use trusty_mpm::client::ManagedSessionSummary;
 
 use crate::cli::CatalogAction;
@@ -329,20 +331,39 @@ pub(crate) async fn session_stop(
 /// returning `Ok(())`.
 /// What: GETs `/api/v1/sessions/managed/{id}` (a 404 bails with an error); on
 /// success, hands the resulting [`ManagedSessionSummary`] to
-/// `resume_guided_session`, which picks the right action (attach directly /
-/// restart via the daemon `/resume` endpoint / auto-reconcile a zombie then
-/// restart) purely from the record's state and live tmux liveness, then
-/// attaches (or `switch-client`s, when already inside tmux) the caller's
-/// terminal into the session's tmux window.
+/// [`crate::commands::guided_resume::resume_session`], which picks the right
+/// action (attach directly / restart via the daemon `/resume` endpoint /
+/// auto-reconcile a zombie then restart) purely from the record's state and
+/// live tmux liveness. When stdin is a real terminal, it then attaches (or
+/// `switch-client`s, when already inside tmux) the caller's terminal into the
+/// session's tmux window; otherwise (code-critic HIGH, #2649 review — a
+/// headless/scripted invocation has no controlling terminal to move) it
+/// still performs the daemon-side restart/reconcile but skips the attach and
+/// prints the resulting `resumed <name> (<id>) [<state>]` status line
+/// instead, returning `Ok(())` on daemon-side success either way.
+///
+/// #2649 review, PM-accepted UX change: an `Active` session with a live tmux
+/// pane now resolves to `ResumeAction::Attach` — no `/resume` POST at all,
+/// just an idempotent (re)attach — rather than the pre-#2649 behavior of
+/// bailing with the daemon's raw 409 ("cannot resume a session in state
+/// 'active'"). This makes `tm session resume <id>` idempotent for an
+/// already-running session: "resume" now means "get me into this session",
+/// matching the guided picker's long-standing behavior, instead of treating
+/// an already-active session as a usage error.
 /// Test: HTTP path covered by the integration test; parse by
 /// `cli_parses_session_managed_resume_verb`; `session_resume_not_found_errors`
 /// covers the #2457 exit-code fix for the 404 branch;
 /// `session_resume_restart_failure_errors` (in `managed_tests.rs`, #2649)
 /// covers the same non-swallowing guarantee for a daemon-rejected restart now
 /// that this handler routes through the shared restart/attach helper instead
-/// of POSTing `/resume` directly; `plan_resume`/`needs_restart`/`is_zombie`
-/// in `guided_resume.rs`'s own tests exhaustively cover the branch selection
-/// this handler now shares.
+/// of POSTing `/resume` directly; `session_resume_headless_active_live_tmux_skips_restart_and_attach`
+/// (`managed_tests.rs`, #2649) proves the new Active+live-tmux idempotent-attach
+/// UX never issues a `/resume` POST (asserted via the record's state staying
+/// unchanged) and that headless mode exits `Ok(())` without attempting a real
+/// tmux attach; `plan_resume`/`needs_restart`/`is_zombie` in
+/// `guided_resume.rs`'s own tests (including
+/// `guided_resume_plan_active_live_tmux_attaches`) exhaustively cover the
+/// branch selection this handler now shares.
 pub(crate) async fn session_resume(
     client: &reqwest::Client,
     url: &str,
@@ -356,7 +377,11 @@ pub(crate) async fn session_resume(
         anyhow::bail!("managed session '{id}' not found");
     }
     let session: ManagedSessionSummary = resp.error_for_status()?.json().await?;
-    crate::commands::guided_resume::resume_guided_session(client, url, &session).await
+    // #2649 review (code-critic HIGH): gate the terminal hand-off on actually
+    // having a terminal — a headless/scripted caller (no stdin TTY) still gets
+    // the daemon-side restart/reconcile, just never a doomed real tmux attach.
+    let no_attach = !std::io::stdin().is_terminal();
+    crate::commands::guided_resume::resume_session(client, url, &session, no_attach).await
 }
 
 /// `tm session decommission <id>` — full teardown (may or may not remove workspace).

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -210,11 +210,11 @@ async fn spawn_test_daemon_with_unrestartable_stopped_session() -> (String, Stri
 
 /// #2649: a daemon-rejected restart (422 — the seeded workspace directory was
 /// never created on disk) must still propagate as `Err` at the CLI layer now
-/// that `session_resume` delegates to `resume_guided_session` — the same
+/// that `session_resume` delegates to `resume_session` — the same
 /// non-swallowing guarantee #2457/#2521 established for the old direct-POST
 /// implementation. Deterministic and tmux/TTY-independent: the failure fires
-/// inside `restart_via_daemon`, BEFORE `resume_guided_session` would ever
-/// reach the terminal hand-off (`tmux_attach`).
+/// inside `restart_via_daemon`, BEFORE `resume_session` would ever reach the
+/// terminal hand-off (`tmux_attach`).
 #[tokio::test]
 async fn session_resume_restart_failure_errors() {
     let (url, id) = spawn_test_daemon_with_unrestartable_stopped_session().await;
@@ -225,6 +225,121 @@ async fn session_resume_restart_failure_errors() {
     assert!(
         err.to_string().contains("cannot restart"),
         "error should surface the daemon's rejection: {err}"
+    );
+}
+
+/// #2649 code-critic review, HIGH #1 + HIGH #2: a session that is NOT
+/// stopped/errored (e.g. `active`/`provisioning`) WITH a live tmux pane must
+/// resolve to `ResumeAction::Attach` — no `/resume` POST, no daemon-side
+/// mutation at all — the PM-accepted idempotent "resume = get me into this
+/// session" UX (see `session_resume`'s doc for the full rationale; this
+/// SUPERSEDES the pre-#2649 behavior of bailing with the daemon's raw 409
+/// "cannot resume a session in state 'active'"). It also proves the HIGH #1
+/// `no_attach` gate: under `cargo test`, stdin is never a TTY, so
+/// `session_resume` must still return `Ok(())` (headless success) rather
+/// than attempting (and presumably failing/hanging on) a real tmux attach
+/// with no controlling terminal to move.
+///
+/// Why `provisioning` and not the literal `active` string: branch selection
+/// here is state-string-independent — both `active` and `provisioning` fail
+/// `needs_restart` identically, so the `Provisioning` state `create_with_id`
+/// naturally leaves a freshly-seeded record in is an equally valid stand-in.
+/// Getting a record into `Active` through public API surface alone would
+/// require the separate `/reactivate` machinery (#2453), adding seeding
+/// complexity with no additional coverage — the literal `"active"` string is
+/// already exhaustively covered at the pure-function layer by
+/// `guided_resume_plan_active_live_tmux_attaches` in `tests_behavior_c_tests.rs`.
+///
+/// What: seeds a session via `create_with_id` (left in its default
+/// `Provisioning` state), then spins up a REAL (not the daemon's fake) tmux
+/// session with the record's EXACT `tmux_name` — the CLI's own client-side
+/// `tmux_has_session` liveness probe always shells to the real system tmux
+/// regardless of what driver the (isolated, fake-driven) daemon uses
+/// server-side, so this is the one deterministic way to make that probe
+/// report "live" without depending on this test process's own tmux/TTY
+/// environment for the OUTCOME (only tmux's presence on `PATH`, already a
+/// hard dependency of this workspace's test suite — see
+/// `session_manager/tests.rs`). Calls the real `session_resume` CLI function
+/// and asserts: (1) `Ok(())` — headless success; (2) the daemon's own record
+/// of the session state is UNCHANGED afterward (still `provisioning`) — the
+/// only way to prove NO `/resume` POST landed, since a successful restart
+/// always flips state to `active`. The real tmux session is killed
+/// unconditionally (even on assertion failure) before returning.
+#[tokio::test]
+async fn session_resume_headless_active_live_tmux_skips_restart_and_attach() {
+    use trusty_mpm::daemon::{api, state::DaemonState};
+    use trusty_mpm::runtime::RuntimeKind;
+    use trusty_mpm::session_manager::ManagedSessionId;
+
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = std::sync::Arc::new(DaemonState::with_root_isolated_managed(root.clone()).await);
+    let id = ManagedSessionId::new();
+    let ws = root.join(format!("{id}-headless-attach-ws"));
+    let mgr = state.session_manager().await;
+    let record = mgr
+        .create_with_id(
+            id,
+            "regression: #2649 headless active-live-tmux CLI test".to_string(),
+            Some(ws.clone()),
+            None,
+            Some(ws),
+            Some("https://example.com/r.git".to_string()),
+            Some("main".to_string()),
+            RuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session");
+    assert_eq!(
+        record.state.to_string(),
+        "provisioning",
+        "sanity: create_with_id must leave a fresh record un-stopped/un-errored"
+    );
+
+    let tmux_bin = trusty_mpm::core::tmux::resolve_tmux_binary_or_bare();
+    let create_status = std::process::Command::new(&tmux_bin)
+        .args(["new-session", "-d", "-s", &record.tmux_name])
+        .status()
+        .expect("spawn real tmux session for the liveness probe");
+    assert!(
+        create_status.success(),
+        "failed to create the real scratch tmux session"
+    );
+
+    let router = api::router(std::sync::Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    let url = format!("http://{addr}");
+    let client = reqwest::Client::new();
+
+    let result = session_resume(&client, &url, id.to_string()).await;
+
+    // Unconditional cleanup of the real tmux session, even if an assertion
+    // below panics.
+    let _ = std::process::Command::new(&tmux_bin)
+        .args(["kill-session", "-t", &record.tmux_name])
+        .output();
+
+    result.expect(
+        "headless resume of an already-live, non-stopped/errored session must succeed (Ok), \
+         not error",
+    );
+
+    let after: serde_json::Value = client
+        .get(format!("{url}/api/v1/sessions/managed/{id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        after.get("state").and_then(|v| v.as_str()),
+        Some("provisioning"),
+        "state must be UNCHANGED — a /resume POST would have flipped it to 'active'; this \
+         proves the Attach branch never issued a daemon-side restart"
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -9,14 +9,19 @@
 //! against a real hermetic daemon (mirroring `client::executor::tests`'s
 //! `spawn_test_daemon` pattern) and assert `Err` is returned instead.
 //! What: the `session_*_not_found_errors` tests cover the 404 exit-code fix.
-//! `session_resume`'s 409/conflict branch got the identical mechanical fix —
-//! print+`Ok(())` to `bail!` — and is now ALSO covered at this CLI layer by
-//! `session_resume_conflict_state_errors`, which seeds a session in a
-//! non-resumable (`Provisioning`) state via
-//! `spawn_test_daemon_with_unresumable_session` (#2521 review; previously left
-//! only to the daemon-layer `resume_managed_typed_invalid_state_is_conflict`
-//! test in `tests/session_manager_mvp.rs`, which exercises the typed
-//! `resume_managed` helper directly rather than the CLI's `session_resume`).
+//! `session_resume` no longer POSTs `/resume` directly (#2649) — it now
+//! fetches the record and delegates to the shared
+//! `guided_resume::resume_guided_session` helper (also used by the bare-`tm`
+//! picker), so its restart/attach decision and error propagation are
+//! primarily covered by that module's own `plan_resume`/`needs_restart`/
+//! `is_zombie` unit tests plus the e2e suite. `session_resume_restart_failure_errors`
+//! covers the ONE thing specific to this CLI-layer wrapper: a daemon-rejected
+//! restart still surfaces as `Err`, not a swallowed `Ok(())` — the same
+//! guarantee #2457/#2521's `session_resume_conflict_state_errors` (now
+//! superseded — see `spawn_test_daemon_with_unrestartable_stopped_session`'s
+//! doc for why the old `Provisioning`-seed/409 scenario no longer applies
+//! cleanly at this layer) established for the prior direct-POST
+//! implementation.
 //! The pre-existing `truncate_*`/`short_timestamp_*`/
 //! `decommission_message_reflects_workspace_removed` unit tests are carried
 //! over unchanged from the inline module this file replaced.
@@ -126,27 +131,47 @@ async fn session_resume_not_found_errors() {
     );
 }
 
-/// Spawn the daemon's real HTTP API with ONE managed session already seeded in
-/// `Provisioning` — a non-resumable state — so a `resume` call against it is a
-/// genuine 409 from the daemon, not a hand-rolled stub response.
+/// Spawn the daemon's real HTTP API with ONE managed session seeded `Stopped`
+/// whose workspace/cwd directory was never created on disk, so a `resume`
+/// call against it is a genuine, deterministic daemon-side restart failure
+/// (`ManagedError::WorkspaceMissing` -> HTTP 422) — not a hand-rolled stub
+/// response, and not dependent on this test process's own tmux/TTY
+/// environment.
 ///
-/// Why: #2521 review — `session_resume`'s 409/conflict branch (managed.rs
-/// L337-339) had no CLI-layer test proving it returns `Err`; the module doc
-/// above explained this was left uncovered because seeding a non-resumable
-/// session needs `SessionManager::create_with_id` scaffolding. That
-/// scaffolding is exactly what `tests/session_manager_mvp.rs`'s
-/// `resume_managed_typed_invalid_state_is_conflict` already uses (a freshly
-/// created record starts in `Provisioning`, which is not `Stopped`/`Errored`,
-/// so resuming it is an invalid state transition). This slots the SAME seeding
-/// approach into `managed_tests.rs`'s hermetic HTTP-round-trip harness
-/// (mirroring `spawn_test_daemon`) so the CLI-layer `session_resume` function
-/// itself — not just the daemon's typed `resume_managed` — is proven to
-/// surface the 409 as an `Err`.
-/// What: builds the isolated daemon state directly (so the seeded session can
-/// be created against it before the router starts serving), creates ONE
-/// session via `create_with_id` (left in its initial `Provisioning` state,
-/// never started/stopped), serves the router, and returns `(base_url, id)`.
-async fn spawn_test_daemon_with_unresumable_session() -> (String, String) {
+/// Why (#2649 — supersedes the old #2521 `spawn_test_daemon_with_unresumable_session`
+/// helper): `session_resume` no longer POSTs `/resume` directly — it now
+/// fetches the record and delegates to
+/// `guided_resume::resume_guided_session`, the SAME helper the bare-`tm`
+/// picker uses, so both entry points share one "restart, then hand the
+/// terminal to the tmux window" implementation instead of maintaining two
+/// (the exact duplication that let this bug survive five rounds of fixes to
+/// the picker's sibling path). That helper picks its action purely from
+/// state + live tmux liveness (`plan_resume`): seeding a record in a
+/// non-`Stopped`/`Errored` state (the old `Provisioning` seed) no longer
+/// reaches a raw 409 here — it is classified a "zombie" (record not
+/// stopped/errored, tmux pane gone) and AUTO-RECONCILED via `/runtime-stop`
+/// then `/resume`, exactly the #2001 behavior this fix ports to the
+/// explicit-id verb. Driving a test through that path would, on success,
+/// reach a REAL tmux `switch-client`/`attach-session` call whose outcome
+/// depends on whether this test process has a real attached tmux client —
+/// which it never does under `cargo test` — making the assertion flaky by
+/// construction. Seeding directly into `Stopped` sidesteps the zombie branch
+/// entirely (`needs_restart` is `true` regardless of tmux liveness), so the
+/// only variable left is the daemon's `/resume` response.
+/// What: `with_root_isolated_managed` seeds the `SessionManager` with
+/// [`trusty_mpm::session_manager::real_tmux::FakeNoopTmuxDriver`] — no real
+/// tmux process is ever spawned server-side, so nothing here depends on this
+/// test process's own tmux/TTY environment. `create_with_id` does NOT touch
+/// the filesystem itself (`ws` genuinely does not exist afterward), but
+/// `SessionManager::stop`'s non-fatal pre-kill snapshot capture DOES:
+/// `capture_into` unconditionally `mkdir -p`'s `<workspace_path>/.trusty-mpm/`
+/// to write a (here, empty — the fake driver's `capture` returns `""`)
+/// scrollback file, which recreates `ws` as a side effect (confirmed
+/// empirically). So the directory is removed a SECOND time, after `stop`,
+/// immediately before the router starts serving, to end up with a record
+/// that is genuinely `Stopped` AND genuinely workspace-less at `/resume`
+/// time. Returns `(base_url, id)`.
+async fn spawn_test_daemon_with_unrestartable_stopped_session() -> (String, String) {
     use trusty_mpm::daemon::{api, state::DaemonState};
     use trusty_mpm::runtime::RuntimeKind;
     use trusty_mpm::session_manager::ManagedSessionId;
@@ -155,24 +180,26 @@ async fn spawn_test_daemon_with_unresumable_session() -> (String, String) {
     let state = std::sync::Arc::new(DaemonState::with_root_isolated_managed(root.clone()).await);
 
     let id = ManagedSessionId::new();
-    let ws = root.join(format!("{id}-resume-conflict-ws"));
-    state
-        .session_manager()
+    let ws = root.join(format!("{id}-resume-missing-ws"));
+    let mgr = state.session_manager().await;
+    mgr.create_with_id(
+        id,
+        "regression: #2649 resume-restart-failure CLI test".to_string(),
+        Some(ws.clone()),
+        None,
+        Some(ws.clone()),
+        Some("https://example.com/r.git".to_string()),
+        Some("main".to_string()),
+        RuntimeKind::default(),
+        false,
+        false,
+    )
+    .await
+    .expect("seed session");
+    mgr.stop(&id).await.expect("mark seeded session Stopped");
+    tokio::fs::remove_dir_all(&ws)
         .await
-        .create_with_id(
-            id,
-            "regression: #2521 409 resume CLI test".to_string(),
-            Some(ws.clone()),
-            None,
-            Some(ws),
-            Some("https://example.com/r.git".to_string()),
-            Some("main".to_string()),
-            RuntimeKind::default(),
-            false,
-            false,
-        )
-        .await
-        .expect("seed non-resumable session");
+        .expect("remove the dir stop()'s snapshot capture recreated, so it is genuinely absent");
 
     let router = api::router(std::sync::Arc::clone(&state));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -181,19 +208,23 @@ async fn spawn_test_daemon_with_unresumable_session() -> (String, String) {
     (format!("http://{addr}"), id.to_string())
 }
 
-/// #2521 review: a 409 from `resume` (session exists but is in a non-resumable
-/// state) must propagate as `Err` at the CLI layer — the same layer #2457
-/// changed from "print + `Ok(())`" to "bail".
+/// #2649: a daemon-rejected restart (422 — the seeded workspace directory was
+/// never created on disk) must still propagate as `Err` at the CLI layer now
+/// that `session_resume` delegates to `resume_guided_session` — the same
+/// non-swallowing guarantee #2457/#2521 established for the old direct-POST
+/// implementation. Deterministic and tmux/TTY-independent: the failure fires
+/// inside `restart_via_daemon`, BEFORE `resume_guided_session` would ever
+/// reach the terminal hand-off (`tmux_attach`).
 #[tokio::test]
-async fn session_resume_conflict_state_errors() {
-    let (url, id) = spawn_test_daemon_with_unresumable_session().await;
+async fn session_resume_restart_failure_errors() {
+    let (url, id) = spawn_test_daemon_with_unrestartable_stopped_session().await;
     let client = reqwest::Client::new();
     let err = session_resume(&client, &url, id)
         .await
-        .expect_err("resuming a non-resumable session must be a hard failure, not Ok(())");
+        .expect_err("a daemon-rejected restart must be a hard failure, not Ok(())");
     assert!(
-        err.to_string().contains("cannot resume"),
-        "error should surface the daemon's 409 conflict message: {err}"
+        err.to_string().contains("cannot restart"),
+        "error should surface the daemon's rejection: {err}"
     );
 }
 


### PR DESCRIPTION
## Summary

`tm sessions resume <id>` (and its singular/deprecated aliases) resumed the managed session daemon-side but never handed the operator's terminal over to the session's tmux window — the operator stayed wherever they were. Live-reproduced on tm 0.19.11 (see #2649 for the full repro and root-cause writeup).

**Root cause:** `crates/trusty-mpm/src/bin/tm/commands/managed.rs`'s `session_resume` POSTed `/api/v1/sessions/managed/{id}/resume` and only printed a status line. The sibling guided-picker path (`guided_resume.rs::resume_guided_session`) — fixed across #1742/#2001/#2148/#2453/#2456/#2467 — always finishes by calling `tmux_attach`, but that whole fix chain only ever touched the bare-`tm` picker path. The explicit `tm session(s) resume <id>` verb, dispatched via a completely separate call site in `session.rs`, was never touched by any of those fixes and also lacked the #2001 zombie/stale-Active auto-reconcile.

**Fix:** `session_resume` now GETs the session record, then delegates to `guided_resume::resume_session` — a TTY-gated sibling of the picker's own `resume_guided_session` (both now share the same underlying state machine) — so both entry points ("resume a session I just picked" vs. "resume a session I already know the id of") share one implementation of "restart via the daemon, then hand the terminal to the tmux window" instead of maintaining two independently-drifting copies (the exact duplication that let this bug survive five rounds of fixes to the sibling path). This also ports the #2001 zombie/stale-Active auto-reconcile to the explicit-id verb for free: a session the daemon still marks active/provisioning but whose tmux pane is gone is now auto-stopped then restarted, rather than dead-ending on a raw 409.

No `--no-attach` flag was added — there is no existing precedent for one on any attach-side verb in this codebase, and the issue doesn't call for one.

## Review round 2 (code-critic WARN, two HIGHs) — addressed

1. **HIGH — missing TTY gate.** `resume_guided_session`'s every branch unconditionally ended in a real `tmux attach-session`/`switch-client` call, with no `is_terminal()` check — a headless/scripted `tm session resume <id>` (CI, a supervisor process, a piped invocation) would attempt a doomed attach even though the daemon-side resume had already succeeded. Fixed by splitting the flow: `resume_session(client, url, session, no_attach)` is the new TTY-gated core (mirrors the `tty_gate` idiom at `guided.rs`, `std::io::stdin().is_terminal()`, but the gate lives at the point of use since attach is an output step, not an input read); `resume_guided_session` becomes a thin always-attach wrapper (`no_attach = false`) preserving the picker's exact existing behavior (it's already TTY-gated upstream by `guided::tty_gate` before the picker ever renders). `managed.rs::session_resume` derives `no_attach = !std::io::stdin().is_terminal()` and calls `resume_session` directly. When headless, the daemon-side restart/reconcile still runs to completion and the CLI prints `resumed <name> (<id>) [<state>]` (the pre-#2649 status-line format) instead of attaching, returning `Ok(())` — a headless caller now only sees a non-zero exit when the daemon-side resume itself fails, never because of a terminal that was never there.

2. **HIGH (PM-accepted behavior — documented + tested).** A side effect of routing through the shared state machine: an `Active` (or `Provisioning`) session with a **live** tmux pane now resolves to `ResumeAction::Attach` — no `/resume` POST at all, just an idempotent (re)attach (or, headless, a status-line print) — instead of the pre-#2649 behavior of bailing with the daemon's raw 409 (`cannot resume a session in state 'active'`, the #2457/#2521 behavior). **This is intentional and accepted**: `tm session resume <id>` now means "get me into this session" — idempotent whether the session was already running or not — matching the picker's long-standing semantics, rather than treating "it's already running" as a usage error.
   - Old: `tm session resume <id>` on an active/live session → `Err`, exit 1, "cannot resume: cannot resume a session in state 'active'; only Stopped or Errored sessions can be resumed".
   - New: same call → `Ok`, exit 0. Interactive: re-attaches/switch-clients into the already-running session. Headless: prints `resumed <name> (<id>) [active]` and exits 0.
   - Test: `session_resume_headless_active_live_tmux_skips_restart_and_attach` (`managed_tests.rs`) drives this through the real `session_resume` CLI function — seeds a session left in its default un-stopped/un-errored state, spins up a REAL system tmux session with the matching name (independent of the daemon's fake test driver) so the CLI's client-side liveness probe reports it live, and asserts (a) `Ok(())` under `cargo test`'s always-non-TTY stdin, and (b) the daemon's own record of the session state is **unchanged** afterward — the only way to prove no `/resume` POST landed, since a successful restart always flips state to `active`. The literal `"active"` state string is separately covered at the pure `plan_resume` layer by the pre-existing `guided_resume_plan_active_live_tmux_attaches` (`tests_behavior_c_tests.rs`).

3. **MEDIUM** — covered by the same test above (item 2).

4. **LOW — overlap note for merge sequencing.** PR #2652 (`fix/2595-dead-session-picker`) also touches `crates/trusty-mpm/src/bin/tm/commands/managed.rs` (+29/-2) and `managed_tests.rs` (+18/-1) — different functions (its diff is scoped to the picker/`render_session_table`-adjacent dead-session filtering, this PR's is scoped to `session_resume`), but both PRs edit the same two files, so whichever merges second will need a straightforward rebase/conflict-resolve pass rather than being a clean fast-forward. Flagging here so merge order is deliberate, not a surprise.

## Files changed
- `crates/trusty-mpm/src/bin/tm/commands/managed.rs` — `session_resume` rewritten to GET + delegate (to `guided_resume::resume_session`, TTY-gated) instead of POST + print.
- `crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs` — `resume_guided_session`'s core logic extracted into a new `resume_session(client, url, session, no_attach)`; `resume_guided_session` becomes a thin always-attach wrapper over it. `restart_via_daemon` now returns the daemon's post-restart `ManagedSessionSummary` (needed to print an accurate final state in headless mode) instead of `()`.
- `crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs` — `session_resume_conflict_state_errors` (which asserted a raw 409 from a direct POST) replaced with `session_resume_restart_failure_errors`, which deterministically drives a daemon-rejected restart (missing on-disk workspace) through the new delegated path without depending on a real attached tmux client (confirmed empirically that hitting the zombie-reconcile branch with a live tmux hand-off is flaky under `cargo test`, matching why `guided_resume.rs`'s own tests never unit-test that I/O leg either); new `session_resume_headless_active_live_tmux_skips_restart_and_attach` covers the round-2 HIGH #2 behavior (see above).

No overlap with the concurrent `cli.rs` split (#2603), or `core/session_launch`/`instruction_pipeline` (#2647) work. Overlap with `#2595`'s PR #2652 noted above (LOW, item 4).

## Test plan
- [x] `cargo build --workspace` — clean.
- [x] `cargo test --workspace` — `trusty-mpm`: 3118 lib tests + all integration binaries pass, 0 failed (927 in the `tm` binary's own suite, up from 926 pre-review with the new headless-attach test). (Two unrelated `trusty-agents` tests flake under full-workspace parallel execution due to shared global state; both pass in isolation and are untouched by this diff.)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `bash scripts/check_line_cap.sh` — 0 violations.
- [x] `bash scripts/check_test_pointers.sh` — 0 dangling pointers.
- [x] Manual end-to-end verification against the live daemon with a throwaway scratch session (`tm-verify-2649-scratch-01`, created/stopped/resumed/decommissioned during this work, no production session touched): after this fix, `tm sessions resume <id>` on a stopped session now prints `restarting via daemon…` → `session restarted.` → `switching client to session '...'` and invokes the real tmux hand-off — previously it printed only a bare `resumed <name> (<id>) [<state>]` status line with no tmux interaction at all.

Closes #2649

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
