### PR TITLE
feat(trusty-installer): unified Developer-ID signed install for search + tm, with plist bootstrap

### DIFF
--- a/.trusty-mpm/INSTRUCTIONS.md
+++ b/.trusty-mpm/INSTRUCTIONS.md
@@ -318,9 +318,11 @@ convention (i.e. `tga-v<version>`, matching the abbreviation table) works.
 
 🔴 **CRITICAL macOS note:** Never use `cp` to install release binaries on macOS — always use `cargo install`. See release workflow reference for the detailed explanation.
 
-### macOS Full Disk Access must be re-granted after every `cargo install` (issue #873)
+### macOS Full Disk Access / App Data TCC must be re-granted after every `cargo install` (issues #873, #2558)
 
-🟢 **Scope: `trusty-search` and external-volume daemons only.** `trusty-mpm` / `tm` does NOT require FDA re-granting because the daemon manages tmux sessions and git worktrees under `$HOME` only — it never reads TCC-protected or external (`/Volumes/…`) paths. FDA caveat applies only to daemons that index external volumes (currently `trusty-search`); `trusty-memory` and `trusty-analyze` read `$HOME` locations only and also do NOT require FDA. No `install-trusty-mpm-signed.sh` script exists because it is not needed.
+🟢 **Full Disk Access scope: `trusty-search` and external-volume daemons only.** `trusty-mpm` / `tm` does NOT require FDA re-granting because the daemon manages tmux sessions and git worktrees under `$HOME` only — it never reads TCC-protected or external (`/Volumes/…`) paths. FDA caveat applies only to daemons that index external volumes (currently `trusty-search`); `trusty-memory` and `trusty-analyze` read `$HOME` locations only and also do NOT require FDA.
+
+🟢 **App Data TCC scope (owner-authorized extension, #2558, 2026-07-14): `trusty-mpm` IS in scope.** This is a *different* TCC category than FDA above — `tm` reads other apps' `$HOME` containers (Claude config dirs, tmux state), so macOS re-prompts `'trusty-mpm' would like to access data from other apps` after every ad-hoc-signed `cargo install` rebuild, for the same cdhash-identity reason FDA does. `tctl install trusty-mpm` signs it with a stable Developer-ID identity automatically (fail-soft, same as trusty-search); for a local-source build run `cargo install --path crates/trusty-mpm --locked && tctl sign trusty-mpm`. No separate `install-trusty-mpm-signed.sh` script exists — `tctl sign trusty-mpm` (single source of truth in `crates/trusty-installer/src/commands/macos_signing.rs`) is the entry point. See `docs/reference/release-workflow.md#signed-install-trusty-mpm-2558`.
 
 On macOS, every `cargo install` of a binary writes a NEW file at
 `~/.cargo/bin/<binary>` with a new **cdhash** (code-signing hash). macOS TCC

--- a/crates/trusty-installer/src/cli.rs
+++ b/crates/trusty-installer/src/cli.rs
@@ -118,6 +118,44 @@ pub enum AnalyzeCoreArg {
     Skip,
 }
 
+/// CLI value for `trusty-installer sign <target>` (#2558).
+///
+/// Why: A clap-facing enum keeps the `sign` surface declarative and
+/// self-documenting (`--help` lists the two valid targets) while
+/// `commands::sign::run` and `commands::macos_signing` work in terms of the
+/// plain `&str` set names (`SEARCH_SET` / `MPM_SET`) so that module stays
+/// clap-independent.
+///
+/// What: `Search` → the `trusty-search` + `trusty-embedderd` set; `Mpm` → the
+/// `trusty-mpm` set (owner-authorized scope extension, #2558).
+///
+/// Test: `cli_tests::parse_sign` round-trips each value.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum SignTargetArg {
+    /// `trusty-search` + its bundled `trusty-embedderd`.
+    #[value(name = "trusty-search")]
+    Search,
+    /// `trusty-mpm`.
+    #[value(name = "trusty-mpm")]
+    Mpm,
+}
+
+impl SignTargetArg {
+    /// The plain set name `commands::macos_signing` expects.
+    ///
+    /// Why: Bridges the clap enum to the plain-`&str` set vocabulary used by
+    /// `macos_signing::binaries_for_set` / `sign_set_strict`, so that module
+    /// has no clap dependency.
+    /// What: `Search` → `"trusty-search"`, `Mpm` → `"trusty-mpm"`.
+    /// Test: `cli_tests::parse_sign` (indirectly, via the round-trip).
+    pub fn as_set_name(self) -> &'static str {
+        match self {
+            SignTargetArg::Search => "trusty-search",
+            SignTargetArg::Mpm => "trusty-mpm",
+        }
+    }
+}
+
 /// All `trusty-installer` subcommands.
 ///
 /// Why: A single enum over the entire DOC-5 §1.1 command tree lets the
@@ -315,6 +353,29 @@ pub enum Commands {
     /// no prebuilt is available. Prints a restart hint on success — does NOT
     /// re-exec the updated binary. Use `--yes` to skip the crates.io version check.
     SelfUpdate,
+
+    /// Developer-ID codesign a signable binary set — macOS only. (#2558)
+    ///
+    /// The single source of truth for the FDA/App-Data-TCC persistent-signing
+    /// story: `tctl install` already runs this automatically (fail-soft) after
+    /// `trusty-search` / `trusty-mpm` land, but this standalone verb lets an
+    /// operator (re-)sign binaries built from local source
+    /// (`cargo install --path …`) directly, and is what
+    /// `scripts/install-trusty-search-signed.sh` shells out to instead of
+    /// duplicating `codesign` flags in bash. Hard-fails (non-zero exit) when
+    /// no Developer ID Application certificate is available or signing fails —
+    /// unlike the fail-soft `tctl install` hook, this command is the operator
+    /// explicitly asking for signing to happen.
+    Sign {
+        /// Which signable set to sign.
+        #[arg(value_enum)]
+        target: SignTargetArg,
+
+        /// Directory containing the binaries (defaults to `$CARGO_HOME/bin` /
+        /// `~/.cargo/bin`).
+        #[arg(long)]
+        dir: Option<PathBuf>,
+    },
 
     /// Generic passthrough: `trusty-installer <tool> <verb> [args]` — any advertised verb. (DOC-1 D3c)
     ///

--- a/crates/trusty-installer/src/cli_tests.rs
+++ b/crates/trusty-installer/src/cli_tests.rs
@@ -13,7 +13,9 @@
 
 use clap::Parser;
 
-use crate::cli::{AnalyzeCoreArg, Cli, Commands, ConfigSubcommand, ScopeArg, StackCmd};
+use crate::cli::{
+    AnalyzeCoreArg, Cli, Commands, ConfigSubcommand, ScopeArg, SignTargetArg, StackCmd,
+};
 
 /// Parse `trusty-installer up` — selects `Commands::Up` with all flags defaulted off.
 #[test]
@@ -484,4 +486,58 @@ fn parse_self_update() {
 fn tctl_alias_self_update() {
     let cli = Cli::try_parse_from(["tctl", "self-update"]).expect("tctl self-update parses");
     assert!(matches!(cli.command, Commands::SelfUpdate));
+}
+
+/// `trusty-installer sign trusty-search` / `sign trusty-mpm` both parse and
+/// round-trip to the right `SignTargetArg` (#2558).
+#[test]
+fn parse_sign() {
+    let search = Cli::try_parse_from(["trusty-installer", "sign", "trusty-search"])
+        .expect("sign trusty-search parses");
+    match search.command {
+        Commands::Sign { target, dir } => {
+            assert_eq!(target, SignTargetArg::Search);
+            assert_eq!(target.as_set_name(), "trusty-search");
+            assert!(dir.is_none());
+        }
+        other => panic!("expected Sign, got {other:?}"),
+    }
+
+    let mpm = Cli::try_parse_from(["trusty-installer", "sign", "trusty-mpm"])
+        .expect("sign trusty-mpm parses");
+    match mpm.command {
+        Commands::Sign { target, .. } => {
+            assert_eq!(target, SignTargetArg::Mpm);
+            assert_eq!(target.as_set_name(), "trusty-mpm");
+        }
+        other => panic!("expected Sign, got {other:?}"),
+    }
+}
+
+/// `trusty-installer sign trusty-search --dir <path>` parses the override.
+#[test]
+fn parse_sign_dir_override() {
+    let cli = Cli::try_parse_from([
+        "trusty-installer",
+        "sign",
+        "trusty-search",
+        "--dir",
+        "/tmp/custom-bin",
+    ])
+    .expect("sign --dir parses");
+    if let Commands::Sign { dir, .. } = &cli.command {
+        assert_eq!(
+            dir.as_deref(),
+            Some(std::path::Path::new("/tmp/custom-bin"))
+        );
+    } else {
+        panic!("expected Sign");
+    }
+}
+
+/// An invalid `sign` target is rejected by clap (unknown `ValueEnum` variant).
+#[test]
+fn parse_sign_invalid_target_rejected() {
+    let result = Cli::try_parse_from(["trusty-installer", "sign", "not-a-target"]);
+    assert!(result.is_err(), "unknown sign target must be rejected");
 }

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -312,9 +312,20 @@ async fn install_all(
                         ));
                     }
                 }
-                // Phase 8: codesign + FDA guidance for trusty-search.
+                // Phase 8: codesign + FDA guidance for trusty-search (single
+                // source of truth: `macos_signing`, unified with
+                // `scripts/install-trusty-search-signed.sh` and `tctl sign` — #2558).
                 if m.crate_name == "trusty-search" {
                     super::macos_signing::post_install_search(&install_dir, json);
+                }
+                // Phase 8b: codesign + App-Data-TCC guidance for trusty-mpm.
+                // Owner-authorized scope extension (#2558, 2026-07-14): `tm`
+                // reads other apps' $HOME containers (Claude config dirs, tmux
+                // state), so macOS's App Data TCC category re-prompts on every
+                // ad-hoc-signed rebuild the same way FDA does for trusty-search;
+                // the same stable-identity Developer-ID signing fixes it.
+                if m.crate_name == "trusty-mpm" {
+                    super::macos_signing::post_install_mpm(&install_dir, json);
                 }
                 // Phase 7b (#2556): bootstrap the launchd plist for each shared
                 // daemon (search/memory/analyze/review/console) via its own

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -315,6 +315,13 @@ async fn install_all(
                 // Phase 8: codesign + FDA guidance for trusty-search (single
                 // source of truth: `macos_signing`, unified with
                 // `scripts/install-trusty-search-signed.sh` and `tctl sign` — #2558).
+                // PR #2657 review: this automatic hook signs WITHOUT Hardened
+                // Runtime (matching pre-PR behavior) because trusty-search's
+                // bundled ONNX runtime dylib load path under Hardened Runtime
+                // is not yet empirically verified — see
+                // `macos_signing::use_hardened_runtime`. `tctl sign trusty-search`
+                // / the wrapper script (explicit operator action) DO sign with
+                // Hardened Runtime, also matching pre-PR behavior.
                 if m.crate_name == "trusty-search" {
                     super::macos_signing::post_install_search(&install_dir, json);
                 }
@@ -323,7 +330,9 @@ async fn install_all(
                 // reads other apps' $HOME containers (Claude config dirs, tmux
                 // state), so macOS's App Data TCC category re-prompts on every
                 // ad-hoc-signed rebuild the same way FDA does for trusty-search;
-                // the same stable-identity Developer-ID signing fixes it.
+                // the same stable-identity Developer-ID signing fixes it. Unlike
+                // trusty-search, trusty-mpm loads no dylibs, so this automatic
+                // hook DOES sign with Hardened Runtime (low risk either way).
                 if m.crate_name == "trusty-mpm" {
                     super::macos_signing::post_install_mpm(&install_dir, json);
                 }

--- a/crates/trusty-installer/src/commands/macos_signing.rs
+++ b/crates/trusty-installer/src/commands/macos_signing.rs
@@ -17,13 +17,35 @@
 //! because `tm` reads other apps' `$HOME` containers (Claude config dirs, tmux
 //! state).
 //!
-//! What: [`binaries_for_set`] maps a named signable set (`"trusty-search"` →
-//! search + embedderd, `"trusty-mpm"` → mpm alone) to its binaries;
-//! [`codesign_identifier`] maps each binary to its fixed `--identifier`. Probes
-//! for a Developer ID Application certificate (env var `TRUSTY_SIGN_IDENTITY` >
-//! `security find-identity`), signs with `--options runtime --timestamp`
-//! (Hardened Runtime + secure timestamp, matching the script and required for
-//! notarization), and verifies with `codesign --verify --deep --strict`.
+//! PR #2657 code-critic review fixes (same day):
+//! - The canonicalization above is a SILENT IDENTIFIER MIGRATION for any host
+//!   previously signed by the pre-PR Rust hook's `com.trusty.search` — changing
+//!   the designated requirement invalidates that host's existing FDA grant with
+//!   no warning (reproducing #873's `indexes:2` symptom). [`current_identifier`]
+//!   reads the binary's on-disk identifier before signing and
+//!   [`identifier_migration_notice`] prints a loud, distinct callout when it is
+//!   about to change.
+//! - `--options runtime --timestamp` (Hardened Runtime) is now gated by
+//!   [`use_hardened_runtime`] rather than always-on: trusty-search/embedderd
+//!   load an ONNX runtime dylib at runtime, and Hardened Runtime's library
+//!   validation has NOT been empirically verified safe for that yet, so the
+//!   pre-PR automatic `tctl install` hook's behavior (no hardened runtime) is
+//!   preserved for the SEARCH set there, while the pre-PR script's behavior
+//!   (hardened runtime) is preserved for explicit signing
+//!   (`tctl sign trusty-search` / the wrapper script). trusty-mpm loads no
+//!   dylibs, so it gets hardened runtime unconditionally — see the follow-up
+//!   issue tracked in the PR for lifting this split once ONNX-under-Hardened-
+//!   Runtime is verified. TCC grant stability depends on `--identifier` + Team
+//!   ID, not on `--options runtime`, so this split does not reintroduce the
+//!   identifier drift above.
+//!
+//! What: [`binaries_for_set`] and [`codesign_identifier`] are both derived from
+//! the single [`SIGNABLE_BINARIES`] table (binary, set, identifier) so set
+//! membership and identifier mapping can never drift apart again.
+//! [`has_developer_id_cert`] probes for a cert (env var `TRUSTY_SIGN_IDENTITY` >
+//! `security find-identity`). [`sign_binary`] signs with `--options runtime
+//! --timestamp` only when `hardened` is `true` (see [`use_hardened_runtime`]),
+//! and [`verify_signature`] checks with `codesign --verify --deep --strict`.
 //! [`post_install_search`] / [`post_install_mpm`] are the fail-soft hooks
 //! `commands::install` calls after each member lands; [`sign_set_strict`] is the
 //! hard-failing primitive the standalone `tctl sign <target>` command
@@ -31,6 +53,7 @@
 //! shells out to instead of duplicating codesign flags in bash.
 //!
 //! Test: `tests` covers `binaries_for_set`, `codesign_identifier`,
+//! `use_hardened_runtime`, `identifier_migration_notice`,
 //! `has_developer_id_cert` identity-probe logic, and all guidance-text
 //! generation as pure functions; `codesign` / `security` are not invoked in
 //! tests (side-effecting, macOS-only).
@@ -41,6 +64,29 @@ pub const SEARCH_SET: &str = "trusty-search";
 /// The `trusty-mpm` signable set: `trusty-mpm` alone.
 pub const MPM_SET: &str = "trusty-mpm";
 
+/// The master table: every signable binary → (its set, its codesign identifier).
+///
+/// Why: PR #2657 review (MEDIUM) — `binaries_for_set` and `codesign_identifier`
+/// were two independently-maintained tables that could drift apart exactly the
+/// way the script and the pre-#2558 hook already had. Collapsing set
+/// membership and identifier mapping into one table makes that class of drift
+/// structurally impossible: every signable binary is declared exactly once.
+///
+/// What: `(binary, set, identifier)` triples. [`binaries_for_set`] filters on
+/// the middle field; [`codesign_identifier`] looks up the third field by the
+/// first.
+///
+/// Test: `tests::every_set_member_has_a_real_identifier`.
+const SIGNABLE_BINARIES: &[(&str, &str, &str)] = &[
+    ("trusty-search", SEARCH_SET, "com.trusty.trusty-search"),
+    (
+        "trusty-embedderd",
+        SEARCH_SET,
+        "com.trusty.trusty-embedderd",
+    ),
+    ("trusty-mpm", MPM_SET, "com.trusty.trusty-mpm"),
+];
+
 /// Resolve the binaries that make up a named Developer-ID-signable set.
 ///
 /// Why: `trusty-search` ships two binaries that must be signed together
@@ -49,20 +95,21 @@ pub const MPM_SET: &str = "trusty-mpm";
 /// install hooks and the strict `tctl sign` command) agrees on exactly which
 /// binaries a target name covers.
 ///
-/// What: Returns the binary names for `"trusty-search"` or `"trusty-mpm"`; an
-/// empty slice for any other input (the caller treats that as "unknown set").
+/// What: Returns the binary names whose [`SIGNABLE_BINARIES`] entry matches
+/// `set`, in table order. An empty `Vec` for any other input (the caller
+/// treats that as "unknown set").
 ///
 /// Test: `tests::binaries_for_set_covers_search_and_mpm`,
 /// `tests::binaries_for_set_unknown_is_empty`.
-pub fn binaries_for_set(set: &str) -> &'static [&'static str] {
-    match set {
-        SEARCH_SET => &["trusty-search", "trusty-embedderd"],
-        MPM_SET => &["trusty-mpm"],
-        _ => &[],
-    }
+pub fn binaries_for_set(set: &str) -> Vec<&'static str> {
+    SIGNABLE_BINARIES
+        .iter()
+        .filter(|(_, s, _)| *s == set)
+        .map(|(binary, _, _)| *binary)
+        .collect()
 }
 
-/// The codesign identifiers for every signable binary.
+/// The codesign identifier for a signable binary.
 ///
 /// Why: A fixed `--identifier` anchors the designated requirement (DR) to a
 /// stable value rather than the binary hash, so the FDA / App-Data TCC grant
@@ -71,18 +118,50 @@ pub fn binaries_for_set(set: &str) -> &'static [&'static str] {
 /// `com.trusty.trusty-search`) matches the launchd label convention in
 /// `plist_label.rs` and `docs/reference/release-workflow.md` — this is the
 /// canonical scheme; the pre-#2558 `com.trusty.search` (short form) used here
-/// was the drift this issue fixes.
+/// was the drift this issue fixes. Migrating an already-signed host from the
+/// old identifier is handled separately by [`identifier_migration_notice`].
 ///
-/// What: Maps binary name → codesign identifier.
+/// What: Looks up `binary` in [`SIGNABLE_BINARIES`]; falls back to
+/// `"com.trusty.unknown"` for anything not in the table.
 ///
-/// Test: `tests::identifier_map_covers_all_signable_binaries`.
+/// Test: `tests::identifier_map_covers_all_signable_binaries`,
+/// `tests::every_set_member_has_a_real_identifier`.
 pub fn codesign_identifier(binary: &str) -> &'static str {
-    match binary {
-        "trusty-search" => "com.trusty.trusty-search",
-        "trusty-embedderd" => "com.trusty.trusty-embedderd",
-        "trusty-mpm" => "com.trusty.trusty-mpm",
-        _ => "com.trusty.unknown",
-    }
+    SIGNABLE_BINARIES
+        .iter()
+        .find(|(b, _, _)| *b == binary)
+        .map(|(_, _, identifier)| *identifier)
+        .unwrap_or("com.trusty.unknown")
+}
+
+/// Whether to enable Hardened Runtime (`--options runtime --timestamp`) for a
+/// given signing context.
+///
+/// Why: PM decision, PR #2657 review (HIGH) — preserve BOTH pre-PR behaviors
+/// exactly rather than flipping a default. The pre-PR script (an explicit
+/// operator action) always signed with `--options runtime`; the pre-PR
+/// `tctl install` post-install hook (automatic, fail-soft, runs on every
+/// install with a cert present) never did. trusty-search/trusty-embedderd load
+/// an ONNX runtime dylib, and Hardened Runtime's library-validation
+/// restriction has not been empirically verified safe for that load path —
+/// flipping the automatic hook to hardened-by-default risks silently breaking
+/// `tctl install trusty-search` on every machine with a Developer ID cert
+/// already installed. trusty-mpm loads no dylibs, so Hardened Runtime is
+/// low-risk there in both contexts. Note: TCC grant stability (the actual
+/// bug #873/#2558 fix) depends on `--identifier` + Team ID, NOT on
+/// `--options runtime`, so this split does not reintroduce the identifier-drift
+/// problem — it only affects notarization eligibility and dylib-validation
+/// strictness.
+///
+/// What: `explicit` (the operator directly ran `tctl sign <target>`, or the
+/// wrapper script which shells out to it) → always `true`. Automatic
+/// (`tctl install`'s fail-soft hook, `explicit = false`) → `true` only for
+/// [`MPM_SET`]; `false` for [`SEARCH_SET`] until ONNX-under-Hardened-Runtime
+/// is verified (see the tracking issue referenced in PR #2657).
+///
+/// Test: `tests::hardened_runtime_policy`.
+pub fn use_hardened_runtime(set: &str, explicit: bool) -> bool {
+    explicit || set == MPM_SET
 }
 
 /// Check whether a Developer ID Application certificate is available.
@@ -121,40 +200,121 @@ pub fn has_developer_id_cert() -> Option<String> {
     None
 }
 
+/// Read a binary's CURRENT on-disk codesign identifier, if any.
+///
+/// Why: PR #2657 review (HIGH) — before (re-)signing with the canonical
+/// identifier, we must know whether the binary was already signed with a
+/// DIFFERENT identifier (e.g. the pre-#2558 `com.trusty.search` short form).
+/// Silently changing the DR invalidates any TCC grant keyed to the old value
+/// with no warning — exactly #873's `indexes:2` symptom, reintroduced by this
+/// PR's own canonicalization if left unchecked.
+///
+/// What: Runs `codesign -d <path>` (display mode) and parses the
+/// `Identifier=<value>` line from its stderr output (that is where `codesign
+/// -d` writes its human-readable summary). Returns `None` when the path does
+/// not exist, the binary is unsigned (no `Identifier=` line, non-zero exit),
+/// or `codesign` cannot be spawned.
+///
+/// Test: Not invoked in tests (side-effecting, requires a real signed
+/// binary); the comparison logic that consumes its output is tested via
+/// `identifier_migration_notice`.
+#[cfg(target_os = "macos")]
+pub fn current_identifier(path: &std::path::Path) -> Option<String> {
+    if !path.exists() {
+        return None;
+    }
+    let out = std::process::Command::new("codesign")
+        .args(["-d"])
+        .arg(path)
+        .output()
+        .ok()?;
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    stderr.lines().find_map(|line| {
+        line.strip_prefix("Identifier=")
+            .map(|s| s.trim().to_owned())
+    })
+}
+
+/// Build the identifier-migration warning, if `old_identifier` differs from
+/// the canonical identifier for `binary`.
+///
+/// Why: Extracted as a pure function (no system calls) so the exact wording
+/// and the "only warn on an actual change" decision are unit-tested directly.
+///
+/// What: Returns `None` when `old_identifier` is empty (never signed before)
+/// or already matches [`codesign_identifier`]; otherwise returns a loud,
+/// distinct notice explaining that existing FDA / App-Data grants keyed to
+/// the old identifier will stop matching.
+///
+/// Test: `tests::identifier_migration_notice_warns_on_change`,
+/// `tests::identifier_migration_notice_silent_when_unchanged_or_absent`.
+pub fn identifier_migration_notice(binary: &str, old_identifier: &str) -> Option<String> {
+    let canonical = codesign_identifier(binary);
+    if old_identifier.is_empty() || old_identifier == canonical {
+        return None;
+    }
+    Some(format!(
+        "\u{26A0} IDENTIFIER CHANGE for {binary}: {old_identifier} -> {canonical}. Existing \
+         macOS Full Disk Access / App Data grants keyed to the old identifier will STOP \
+         MATCHING after this signing — re-grant/re-approve once after this install."
+    ))
+}
+
+/// Print [`identifier_migration_notice`] to stderr when `path`'s current
+/// on-disk identifier differs from the canonical one for `binary`.
+///
+/// Why: Shared by both signing call sites ([`sign_set_strict`] and the
+/// fail-soft [`post_install_signed_set`]) so the warning fires regardless of
+/// which path re-signs an already-signed binary. Always printed (not gated by
+/// `json`) — this is safety-critical information about an existing TCC grant
+/// breaking, not routine narration.
+///
+/// What: Reads `path`'s current identifier via [`current_identifier`]; if a
+/// migration notice applies, prints it to stderr.
+///
+/// Test: Not invoked in tests (side-effecting); composes two independently
+/// tested pure/probe functions.
+#[cfg(target_os = "macos")]
+fn warn_on_identifier_change(path: &std::path::Path, binary: &str) {
+    if let Some(old) = current_identifier(path) {
+        if let Some(notice) = identifier_migration_notice(binary, &old) {
+            eprintln!("trusty-installer: {notice}");
+        }
+    }
+}
+
 /// Sign a binary with a Developer ID Application certificate.
 ///
 /// Why: Signing with `--identifier` anchors the DR so the TCC FDA / App-Data
 /// grant persists across reinstalls (no re-grant needed after `cargo install`).
-/// `--options runtime` enables the Hardened Runtime (required for
-/// notarization); `--timestamp` requests a secure timestamp from Apple's
-/// servers — both match the pre-#2558 script's flags, folded in here so the
-/// script no longer needs its own `codesign` invocation.
+/// `hardened` gates `--options runtime` (Hardened Runtime, required for
+/// notarization) + `--timestamp` (secure timestamp from Apple's servers) — see
+/// [`use_hardened_runtime`] for why this is no longer unconditional.
 ///
-/// What: Runs `codesign --force --options runtime --timestamp --identifier <id>
-/// --sign <identity> <path>`. Returns `Ok(())` on success, `Err` with the
+/// What: Runs `codesign --force [--options runtime --timestamp] --identifier
+/// <id> --sign <identity> <path>`. Returns `Ok(())` on success, `Err` with the
 /// `codesign` stderr on failure.
 ///
 /// Test: Not invoked in tests (side-effecting); the identifier mapping is
-/// tested via `codesign_identifier`.
+/// tested via `codesign_identifier`, the hardened-runtime gating via
+/// `use_hardened_runtime`.
 #[cfg(target_os = "macos")]
-pub fn sign_binary(path: &std::path::Path, identity: &str) -> anyhow::Result<()> {
+pub fn sign_binary(path: &std::path::Path, identity: &str, hardened: bool) -> anyhow::Result<()> {
     use anyhow::Context;
     let binary_name = path
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("unknown");
     let identifier = codesign_identifier(binary_name);
+
+    let mut args: Vec<&str> = vec!["--force"];
+    if hardened {
+        args.extend(["--options", "runtime", "--timestamp"]);
+    }
+    args.extend(["--identifier", identifier, "--sign", identity]);
+
     let out = std::process::Command::new("codesign")
-        .args([
-            "--force",
-            "--options",
-            "runtime",
-            "--timestamp",
-            "--identifier",
-            identifier,
-            "--sign",
-            identity,
-        ])
+        .args(&args)
         .arg(path)
         .output()
         .with_context(|| format!("running codesign on {}", path.display()))?;
@@ -194,6 +354,65 @@ pub fn verify_signature(path: &std::path::Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Typed error for [`sign_set_strict`].
+///
+/// Why: PR #2657 review (MEDIUM) — `commands::sign::run_macos` previously
+/// distinguished "no cert" from "signing failed" by substring-matching the
+/// error message, which is brittle (any future wording change silently breaks
+/// the branch that shows cert-setup guidance). A typed variant lets the caller
+/// match on the actual failure kind.
+///
+/// What: `UnknownSet` — `set` did not resolve to any binaries.
+/// `NoCertificate` — no Developer ID Application cert is available.
+/// `NoBinariesFound` — the set resolved, but none of its binaries exist under
+/// the install directory. `Sign` — signing or post-sign verification failed
+/// for a specific binary (wraps the underlying `anyhow::Error`).
+///
+/// Test: `tests::sign_set_error_display_is_distinct_per_variant`.
+#[derive(Debug)]
+pub enum SignSetError {
+    /// `set` did not resolve to any binaries via [`binaries_for_set`].
+    UnknownSet(String),
+    /// No Developer ID Application certificate is available (env override or keychain).
+    NoCertificate,
+    /// No binary from the resolved set exists under the install directory.
+    NoBinariesFound {
+        /// The signable-set name that was requested.
+        set: String,
+        /// The install directory searched.
+        dir: String,
+    },
+    /// Signing or post-sign verification failed for a specific binary.
+    Sign(anyhow::Error),
+}
+
+impl std::fmt::Display for SignSetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SignSetError::UnknownSet(set) => write!(
+                f,
+                "unknown signable set '{set}' (expected 'trusty-search' or 'trusty-mpm')"
+            ),
+            SignSetError::NoCertificate => {
+                write!(f, "no Developer ID Application certificate found")
+            }
+            SignSetError::NoBinariesFound { set, dir } => {
+                write!(f, "no binaries from set '{set}' found in {dir}")
+            }
+            SignSetError::Sign(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for SignSetError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SignSetError::Sign(e) => e.source(),
+            _ => None,
+        }
+    }
+}
+
 /// Sign and verify every binary in a named set, hard-failing on any problem.
 ///
 /// Why: The fail-soft `post_install_*` hooks below must never abort a `tctl
@@ -203,26 +422,29 @@ pub fn verify_signature(path: &std::path::Path) -> anyhow::Result<()> {
 /// for signing to happen — a silent partial failure there would be worse than a
 /// loud one, exactly like the pre-#2558 script's `set -euo pipefail` behaviour.
 ///
-/// What: Resolves the Developer ID identity (erroring if none is found), then
-/// for every binary in `binaries_for_set(set)` that exists under `install_dir`,
-/// signs it and verifies the signature — bailing out on the first failure.
-/// Returns the paths that were signed. Errors when the set name is unknown or
-/// no binary in the set was found on disk.
+/// What: Resolves the Developer ID identity (erroring with
+/// [`SignSetError::NoCertificate`] if none is found), warns on any
+/// identifier migration via [`warn_on_identifier_change`], then for every
+/// binary in `binaries_for_set(set)` that exists under `install_dir`, signs it
+/// (always with Hardened Runtime — `explicit = true` per
+/// [`use_hardened_runtime`]) and verifies the signature — bailing out on the
+/// first failure. Returns the paths that were signed. Errors on an unknown
+/// set name or when no binary in the set was found on disk.
 ///
 /// Test: Not invoked in tests (side-effecting); the set/identifier resolution
 /// it composes is tested independently via `binaries_for_set` /
-/// `codesign_identifier`.
+/// `codesign_identifier` / `use_hardened_runtime`.
 #[cfg(target_os = "macos")]
 pub fn sign_set_strict(
     install_dir: &std::path::Path,
     set: &str,
-) -> anyhow::Result<Vec<std::path::PathBuf>> {
+) -> Result<Vec<std::path::PathBuf>, SignSetError> {
     let binaries = binaries_for_set(set);
     if binaries.is_empty() {
-        anyhow::bail!("unknown signable set '{set}' (expected 'trusty-search' or 'trusty-mpm')");
+        return Err(SignSetError::UnknownSet(set.to_owned()));
     }
-    let identity = has_developer_id_cert()
-        .ok_or_else(|| anyhow::anyhow!("no Developer ID Application certificate found"))?;
+    let identity = has_developer_id_cert().ok_or(SignSetError::NoCertificate)?;
+    let hardened = use_hardened_runtime(set, true);
 
     let mut signed = Vec::new();
     for name in binaries {
@@ -230,15 +452,16 @@ pub fn sign_set_strict(
         if !path.exists() {
             continue;
         }
-        sign_binary(&path, &identity)?;
-        verify_signature(&path)?;
+        warn_on_identifier_change(&path, name);
+        sign_binary(&path, &identity, hardened).map_err(SignSetError::Sign)?;
+        verify_signature(&path).map_err(SignSetError::Sign)?;
         signed.push(path);
     }
     if signed.is_empty() {
-        anyhow::bail!(
-            "no binaries from set '{set}' found in {}",
-            install_dir.display()
-        );
+        return Err(SignSetError::NoBinariesFound {
+            set: set.to_owned(),
+            dir: install_dir.display().to_string(),
+        });
     }
     Ok(signed)
 }
@@ -330,10 +553,13 @@ pub fn app_data_guidance(binary_path: &str) -> String {
 /// Why: Shared by [`post_install_search`] and [`post_install_mpm`] so the
 /// probe/sign/guidance sequence is written once.
 ///
-/// What: On macOS: probes for a Developer ID cert; if found, signs + verifies
-/// every present binary in `set` and prints a success note; on cert-probe
-/// failure, prints the set-appropriate guidance (FDA for search, App Data TCC
-/// for mpm) using the set's first binary's path. Never aborts the caller.
+/// What: On macOS: probes for a Developer ID cert; if found, warns on any
+/// identifier migration ([`warn_on_identifier_change`]), then signs + verifies
+/// every present binary in `set` — with Hardened Runtime gated per
+/// [`use_hardened_runtime`] (`explicit = false`: on for [`MPM_SET`], off for
+/// [`SEARCH_SET`]) — and prints a success note; on cert-probe failure, prints
+/// the set-appropriate guidance (FDA for search, App Data TCC for mpm) using
+/// the set's first binary's path. Never aborts the caller.
 #[cfg(target_os = "macos")]
 fn post_install_signed_set(install_dir: &std::path::Path, set: &str, json: bool) {
     let binaries = binaries_for_set(set);
@@ -341,17 +567,19 @@ fn post_install_signed_set(install_dir: &std::path::Path, set: &str, json: bool)
         return;
     };
     let primary_path = install_dir.join(primary);
+    let hardened = use_hardened_runtime(set, false);
 
     match has_developer_id_cert() {
         Some(identity) => {
             let mut signed_ok = true;
-            for name in binaries {
+            for &name in &binaries {
                 let path = install_dir.join(name);
                 if !path.exists() {
                     // A bundled binary (e.g. embedderd) may not be present; skip gracefully.
                     continue;
                 }
-                if let Err(e) = sign_binary(&path, &identity) {
+                warn_on_identifier_change(&path, name);
+                if let Err(e) = sign_binary(&path, &identity, hardened) {
                     if !json {
                         eprintln!(
                             "trusty-installer: warning: codesign failed for {}: {e}",
@@ -433,14 +661,14 @@ mod tests {
     fn binaries_for_set_covers_search_and_mpm() {
         assert_eq!(
             binaries_for_set(SEARCH_SET),
-            &["trusty-search", "trusty-embedderd"]
+            vec!["trusty-search", "trusty-embedderd"]
         );
-        assert_eq!(binaries_for_set(MPM_SET), &["trusty-mpm"]);
+        assert_eq!(binaries_for_set(MPM_SET), vec!["trusty-mpm"]);
     }
 
     /// Why: An unrecognised set name must not silently sign nothing without
-    /// signal — callers detect "unknown set" via an empty slice.
-    /// What: Asserts a bogus name returns an empty slice.
+    /// signal — callers detect "unknown set" via an empty result.
+    /// What: Asserts a bogus name returns an empty `Vec`.
     /// Test: This is the test.
     #[test]
     fn binaries_for_set_unknown_is_empty() {
@@ -465,6 +693,67 @@ mod tests {
             "com.trusty.trusty-embedderd"
         );
         assert_eq!(codesign_identifier("trusty-mpm"), "com.trusty.trusty-mpm");
+    }
+
+    /// Why: PR #2657 review MEDIUM — with set membership and identifier now
+    /// derived from one table, this regression-guards that every binary
+    /// produced by `binaries_for_set` for EVERY known set has a real
+    /// (non-fallback) identifier, i.e. the two views of the table can never
+    /// silently disagree.
+    /// What: For each of `SEARCH_SET`/`MPM_SET`, asserts every member binary's
+    /// identifier is not the `"com.trusty.unknown"` fallback.
+    /// Test: This is the test.
+    #[test]
+    fn every_set_member_has_a_real_identifier() {
+        for set in [SEARCH_SET, MPM_SET] {
+            for binary in binaries_for_set(set) {
+                assert_ne!(
+                    codesign_identifier(binary),
+                    "com.trusty.unknown",
+                    "{binary} in set {set} has no real identifier"
+                );
+            }
+        }
+    }
+
+    /// Why: The PM decision (PR #2657 review HIGH) is a precise per-set,
+    /// per-context split — pin the truth table so a future edit cannot
+    /// silently flip either preserved pre-PR behavior.
+    /// What: explicit=true is always hardened (both sets); explicit=false is
+    /// hardened only for MPM_SET.
+    /// Test: This is the test.
+    #[test]
+    fn hardened_runtime_policy() {
+        assert!(use_hardened_runtime(SEARCH_SET, true));
+        assert!(use_hardened_runtime(MPM_SET, true));
+        assert!(!use_hardened_runtime(SEARCH_SET, false));
+        assert!(use_hardened_runtime(MPM_SET, false));
+    }
+
+    /// Why: The migration notice must actually fire when the on-disk
+    /// identifier differs from the canonical one — this is the #2657 review
+    /// HIGH fix; a silent no-op here would reproduce #873.
+    /// What: Asserts the pre-#2558 short-form identifier triggers a notice
+    /// naming both the old and new values.
+    /// Test: This is the test.
+    #[test]
+    fn identifier_migration_notice_warns_on_change() {
+        let notice = identifier_migration_notice("trusty-search", "com.trusty.search")
+            .expect("must warn on a real change");
+        assert!(notice.contains("com.trusty.search"));
+        assert!(notice.contains("com.trusty.trusty-search"));
+        assert!(notice.contains("Full Disk Access"));
+    }
+
+    /// Why: The notice must NOT fire for a fresh install (no prior identifier)
+    /// or when re-signing with the identifier unchanged — false-positive
+    /// alarms would train operators to ignore the real warning.
+    /// What: Asserts `None` for an empty old identifier and for a match.
+    /// Test: This is the test.
+    #[test]
+    fn identifier_migration_notice_silent_when_unchanged_or_absent() {
+        assert!(identifier_migration_notice("trusty-search", "").is_none());
+        assert!(identifier_migration_notice("trusty-search", "com.trusty.trusty-search").is_none());
     }
 
     /// Why: The FDA guidance must contain all 4 numbered steps and reference the
@@ -562,5 +851,30 @@ mod tests {
             assert!(g.contains(step), "{step} missing");
         }
         assert!(g.contains("tctl sign trusty-mpm"));
+    }
+
+    /// Why: `commands::sign::run_macos` matches on `SignSetError` variants
+    /// (PR #2657 review MEDIUM fix, replacing string-matching); the variants'
+    /// `Display` text must stay distinguishable from each other for any
+    /// fallback logging path that does print the message.
+    /// What: Asserts each variant's rendered message is non-empty and unique.
+    /// Test: This is the test.
+    #[test]
+    fn sign_set_error_display_is_distinct_per_variant() {
+        let variants: Vec<String> = vec![
+            SignSetError::UnknownSet("bogus".to_owned()).to_string(),
+            SignSetError::NoCertificate.to_string(),
+            SignSetError::NoBinariesFound {
+                set: "trusty-search".to_owned(),
+                dir: "/tmp".to_owned(),
+            }
+            .to_string(),
+            SignSetError::Sign(anyhow::anyhow!("boom")).to_string(),
+        ];
+        for v in &variants {
+            assert!(!v.is_empty());
+        }
+        let unique: std::collections::HashSet<&String> = variants.iter().collect();
+        assert_eq!(unique.len(), variants.len(), "variant messages collided");
     }
 }

--- a/crates/trusty-installer/src/commands/macos_signing.rs
+++ b/crates/trusty-installer/src/commands/macos_signing.rs
@@ -1,34 +1,86 @@
-//! macOS codesign + FDA guidance for trusty-search and trusty-embedderd (Phase 8).
+//! macOS Developer-ID codesign + FDA/TCC guidance — single source of truth (#2558).
 //!
-//! Why: On macOS, every `cargo install` writes a new binary with a new cdhash,
-//! invalidating the TCC Full Disk Access grant. Developer-ID signing with a fixed
-//! `--identifier` anchors the DR to the Team ID, not the binary hash, so the FDA
-//! grant persists across reinstalls. When no cert is available, the operator must
-//! re-grant FDA manually.
+//! Why: Before #2558 this logic was duplicated between this module (the
+//! `tctl install` post-install hook) and `scripts/install-trusty-search-signed.sh`
+//! (the documented manual "permanent fix"). The two implementations had already
+//! drifted — the script used `--identifier com.trusty.trusty-search` /
+//! `com.trusty.trusty-embedderd` (matching the real launchd label convention in
+//! `plist_label.rs` and the release-workflow docs) plus `--options runtime
+//! --timestamp` and post-sign verification, while this module used the shorter
+//! `com.trusty.search` / `com.trusty.embedderd` identifiers with none of the
+//! extra flags. Folding both into one module (and one set of tests) means the
+//! identifier scheme, signing flags, and guidance text can never diverge again.
+//! Owner-authorized scope extension (2026-07-14, issue #2558 comment): the same
+//! stable-identity signing now also covers `trusty-mpm` — macOS's App Data TCC
+//! category ("'trusty-mpm' would like to access data from other apps")
+//! re-prompts on every ad-hoc-signed rebuild for the same cdhash reason FDA does,
+//! because `tm` reads other apps' `$HOME` containers (Claude config dirs, tmux
+//! state).
 //!
-//! What: Probes for a Developer ID Application certificate (env var
-//! `TRUSTY_SIGN_IDENTITY` > `security find-identity`), signs BOTH
-//! `trusty-search` and `trusty-embedderd` in the install directory, and prints
-//! the appropriate guidance (persist-across-reinstall notice OR the 4-step manual
-//! FDA re-grant procedure).
+//! What: [`binaries_for_set`] maps a named signable set (`"trusty-search"` →
+//! search + embedderd, `"trusty-mpm"` → mpm alone) to its binaries;
+//! [`codesign_identifier`] maps each binary to its fixed `--identifier`. Probes
+//! for a Developer ID Application certificate (env var `TRUSTY_SIGN_IDENTITY` >
+//! `security find-identity`), signs with `--options runtime --timestamp`
+//! (Hardened Runtime + secure timestamp, matching the script and required for
+//! notarization), and verifies with `codesign --verify --deep --strict`.
+//! [`post_install_search`] / [`post_install_mpm`] are the fail-soft hooks
+//! `commands::install` calls after each member lands; [`sign_set_strict`] is the
+//! hard-failing primitive the standalone `tctl sign <target>` command
+//! (`commands::sign`) uses, which `scripts/install-trusty-search-signed.sh` now
+//! shells out to instead of duplicating codesign flags in bash.
 //!
-//! Test: `tests` covers `has_developer_id_cert` identity-probe logic and the
-//! FDA guidance text generation as pure functions; `codesign` and `security` are
-//! not invoked in tests.
+//! Test: `tests` covers `binaries_for_set`, `codesign_identifier`,
+//! `has_developer_id_cert` identity-probe logic, and all guidance-text
+//! generation as pure functions; `codesign` / `security` are not invoked in
+//! tests (side-effecting, macOS-only).
 
-/// The codesign identifiers for the two signed binaries.
+/// The `trusty-search` signable set: `trusty-search` + its bundled `trusty-embedderd`.
+pub const SEARCH_SET: &str = "trusty-search";
+
+/// The `trusty-mpm` signable set: `trusty-mpm` alone.
+pub const MPM_SET: &str = "trusty-mpm";
+
+/// Resolve the binaries that make up a named Developer-ID-signable set.
+///
+/// Why: `trusty-search` ships two binaries that must be signed together
+/// (`trusty-search` + the bundled `trusty-embedderd`); `trusty-mpm` is signed
+/// alone. Centralising the set membership means every caller (the fail-soft
+/// install hooks and the strict `tctl sign` command) agrees on exactly which
+/// binaries a target name covers.
+///
+/// What: Returns the binary names for `"trusty-search"` or `"trusty-mpm"`; an
+/// empty slice for any other input (the caller treats that as "unknown set").
+///
+/// Test: `tests::binaries_for_set_covers_search_and_mpm`,
+/// `tests::binaries_for_set_unknown_is_empty`.
+pub fn binaries_for_set(set: &str) -> &'static [&'static str] {
+    match set {
+        SEARCH_SET => &["trusty-search", "trusty-embedderd"],
+        MPM_SET => &["trusty-mpm"],
+        _ => &[],
+    }
+}
+
+/// The codesign identifiers for every signable binary.
 ///
 /// Why: A fixed `--identifier` anchors the designated requirement (DR) to a
-/// stable value rather than the binary hash, so the FDA grant survives a
-/// recompile even without a Developer ID cert.
+/// stable value rather than the binary hash, so the FDA / App-Data TCC grant
+/// survives a recompile even without a Developer ID cert. The scheme
+/// (`com.trusty.<binary>` with the binary's full name, e.g.
+/// `com.trusty.trusty-search`) matches the launchd label convention in
+/// `plist_label.rs` and `docs/reference/release-workflow.md` — this is the
+/// canonical scheme; the pre-#2558 `com.trusty.search` (short form) used here
+/// was the drift this issue fixes.
 ///
 /// What: Maps binary name → codesign identifier.
 ///
-/// Test: `tests::identifier_map_covers_both_binaries`.
+/// Test: `tests::identifier_map_covers_all_signable_binaries`.
 pub fn codesign_identifier(binary: &str) -> &'static str {
     match binary {
-        "trusty-search" => "com.trusty.search",
-        "trusty-embedderd" => "com.trusty.embedderd",
+        "trusty-search" => "com.trusty.trusty-search",
+        "trusty-embedderd" => "com.trusty.trusty-embedderd",
+        "trusty-mpm" => "com.trusty.trusty-mpm",
         _ => "com.trusty.unknown",
     }
 }
@@ -71,11 +123,16 @@ pub fn has_developer_id_cert() -> Option<String> {
 
 /// Sign a binary with a Developer ID Application certificate.
 ///
-/// Why: Signing with `--identifier` anchors the DR so the TCC FDA grant
-/// persists across reinstalls (no re-grant needed after `cargo install`).
+/// Why: Signing with `--identifier` anchors the DR so the TCC FDA / App-Data
+/// grant persists across reinstalls (no re-grant needed after `cargo install`).
+/// `--options runtime` enables the Hardened Runtime (required for
+/// notarization); `--timestamp` requests a secure timestamp from Apple's
+/// servers — both match the pre-#2558 script's flags, folded in here so the
+/// script no longer needs its own `codesign` invocation.
 ///
-/// What: Runs `codesign --force --sign <identity> --identifier <id> <path>`.
-/// Returns `Ok(())` on success, `Err` with the `codesign` stderr on failure.
+/// What: Runs `codesign --force --options runtime --timestamp --identifier <id>
+/// --sign <identity> <path>`. Returns `Ok(())` on success, `Err` with the
+/// `codesign` stderr on failure.
 ///
 /// Test: Not invoked in tests (side-effecting); the identifier mapping is
 /// tested via `codesign_identifier`.
@@ -88,7 +145,16 @@ pub fn sign_binary(path: &std::path::Path, identity: &str) -> anyhow::Result<()>
         .unwrap_or("unknown");
     let identifier = codesign_identifier(binary_name);
     let out = std::process::Command::new("codesign")
-        .args(["--force", "--sign", identity, "--identifier", identifier])
+        .args([
+            "--force",
+            "--options",
+            "runtime",
+            "--timestamp",
+            "--identifier",
+            identifier,
+            "--sign",
+            identity,
+        ])
         .arg(path)
         .output()
         .with_context(|| format!("running codesign on {}", path.display()))?;
@@ -97,6 +163,111 @@ pub fn sign_binary(path: &std::path::Path, identity: &str) -> anyhow::Result<()>
         anyhow::bail!("codesign failed for {}: {stderr}", path.display());
     }
     Ok(())
+}
+
+/// Verify a binary's signature immediately after signing.
+///
+/// Why: `set -e`-equivalent belt-and-suspenders — `sign_binary` already fails
+/// on a non-zero `codesign` exit, but a strict `--verify --deep --strict` pass
+/// catches subtler corruption (e.g. a truncated write) that the sign step alone
+/// might not (matches the script's post-sign check, issue #2322).
+///
+/// What: Runs `codesign --verify --deep --strict <path>`; `Ok(())` on a clean
+/// verification, `Err` with the verifier's output otherwise.
+///
+/// Test: Not invoked in tests (side-effecting, requires a real signed binary).
+#[cfg(target_os = "macos")]
+pub fn verify_signature(path: &std::path::Path) -> anyhow::Result<()> {
+    use anyhow::Context;
+    let out = std::process::Command::new("codesign")
+        .args(["--verify", "--deep", "--strict"])
+        .arg(path)
+        .output()
+        .with_context(|| format!("running codesign --verify on {}", path.display()))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        anyhow::bail!(
+            "post-sign verification failed for {}: {stderr}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Sign and verify every binary in a named set, hard-failing on any problem.
+///
+/// Why: The fail-soft `post_install_*` hooks below must never abort a `tctl
+/// install` run over a signing hiccup, but the standalone `tctl sign <target>`
+/// command (used directly, or shelled out to by
+/// `scripts/install-trusty-search-signed.sh`) is the operator explicitly asking
+/// for signing to happen — a silent partial failure there would be worse than a
+/// loud one, exactly like the pre-#2558 script's `set -euo pipefail` behaviour.
+///
+/// What: Resolves the Developer ID identity (erroring if none is found), then
+/// for every binary in `binaries_for_set(set)` that exists under `install_dir`,
+/// signs it and verifies the signature — bailing out on the first failure.
+/// Returns the paths that were signed. Errors when the set name is unknown or
+/// no binary in the set was found on disk.
+///
+/// Test: Not invoked in tests (side-effecting); the set/identifier resolution
+/// it composes is tested independently via `binaries_for_set` /
+/// `codesign_identifier`.
+#[cfg(target_os = "macos")]
+pub fn sign_set_strict(
+    install_dir: &std::path::Path,
+    set: &str,
+) -> anyhow::Result<Vec<std::path::PathBuf>> {
+    let binaries = binaries_for_set(set);
+    if binaries.is_empty() {
+        anyhow::bail!("unknown signable set '{set}' (expected 'trusty-search' or 'trusty-mpm')");
+    }
+    let identity = has_developer_id_cert()
+        .ok_or_else(|| anyhow::anyhow!("no Developer ID Application certificate found"))?;
+
+    let mut signed = Vec::new();
+    for name in binaries {
+        let path = install_dir.join(name);
+        if !path.exists() {
+            continue;
+        }
+        sign_binary(&path, &identity)?;
+        verify_signature(&path)?;
+        signed.push(path);
+    }
+    if signed.is_empty() {
+        anyhow::bail!(
+            "no binaries from set '{set}' found in {}",
+            install_dir.display()
+        );
+    }
+    Ok(signed)
+}
+
+/// The Developer ID certificate setup guidance (no cert found, strict path).
+///
+/// Why: Extracted as a pure function so the exact guidance text is unit-tested
+/// without any system calls; mirrors the script's `print_cert_setup_and_exit`.
+///
+/// What: Returns the 5-step "enroll → issue cert → install → verify → re-run"
+/// instructions for `tctl sign <target>`.
+///
+/// Test: `tests::cert_setup_guidance_contains_steps`.
+pub fn cert_setup_guidance(target: &str) -> String {
+    format!(
+        "No 'Developer ID Application' certificate found in the login keychain.\n\
+         \n\
+         To enable persistent signing (one-time setup):\n\
+         \n\
+         1. Enroll in the Apple Developer Program:\n\
+         \x20\x20\x20\x20https://developer.apple.com/programs/enroll/\n\
+         2. Issue a \"Developer ID Application\" certificate (Xcode -> Settings ->\n\
+         \x20\x20\x20\x20Accounts -> Manage Certificates -> \"+\", or\n\
+         \x20\x20\x20\x20https://developer.apple.com/account/resources/certificates/list).\n\
+         3. Download and double-click the .cer file to install it in your login\n\
+         \x20\x20\x20\x20keychain.\n\
+         4. Verify: security find-identity -v -p codesigning | grep 'Developer ID Application'\n\
+         5. Re-run: tctl sign {target}\n"
+    )
 }
 
 /// The 4-step FDA re-grant guidance (used when no Developer ID cert is found).
@@ -118,51 +289,69 @@ pub fn fda_guidance(binary_path: &str) -> String {
          2. Remove `{binary_path}` from the list (click the entry, then click -).\n\
          3. Re-add it (click +, navigate to `{binary_path}`).\n\
          4. Restart the daemon:\n\
-            launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.search.plist\n\
-            launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.search.plist\n\
+            launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist\n\
+            launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist\n\
          \n\
          Tip: install a Developer ID Application certificate and set TRUSTY_SIGN_IDENTITY\n\
          to make this grant persist across all future reinstalls."
     )
 }
 
-/// Run post-install codesign and FDA guidance for trusty-search.
+/// The App-Data TCC guidance for `trusty-mpm` (used when no Developer ID cert
+/// is found).
 ///
-/// Why: After trusty-search (and trusty-embedderd) are installed the installer
-/// should immediately sign them (if a cert is available) or print the FDA
-/// re-grant guidance so the operator knows what to do next.
+/// Why: `tm` re-prompts "'trusty-mpm' would like to access data from other
+/// apps" after every ad-hoc-signed rebuild, for the same cdhash-identity reason
+/// FDA does for trusty-search — but it is a different TCC category (App Data,
+/// not Full Disk Access) with no `System Settings` list entry to remove/re-add,
+/// so the guidance differs from [`fda_guidance`].
 ///
-/// What: On macOS: probes for a Developer ID cert via `has_developer_id_cert`;
-/// if found, signs BOTH `trusty-search` and `trusty-embedderd` in `install_dir`;
-/// on success prints that signing makes the FDA grant persist. On cert-probe
-/// failure, prints the 4-step FDA re-grant guidance with the actual path. On
-/// non-macOS: no-op.
+/// What: Returns guidance explaining that the next prompt must be approved once
+/// and that a Developer ID cert makes that approval persist.
 ///
-/// Test: `tests::fda_guidance_contains_steps` (pure); signing itself is not
-/// invoked in tests (side-effecting).
-pub fn post_install_search(install_dir: &std::path::Path, json: bool) {
-    #[cfg(target_os = "macos")]
-    post_install_search_macos(install_dir, json);
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = (install_dir, json); // suppress unused warnings on non-macOS
-    }
+/// Test: `tests::app_data_guidance_mentions_prompt`.
+pub fn app_data_guidance(binary_path: &str) -> String {
+    format!(
+        "trusty-mpm App Data TCC guidance (macOS):\n\
+         Every `cargo install` replaces the binary with a new cdhash, so macOS re-prompts\n\
+         \"'trusty-mpm' would like to access data from other apps\" (it reads other apps'\n\
+         $HOME containers — Claude config dirs, tmux state) after every reinstall.\n\
+         \n\
+         Approve the next prompt for `{binary_path}` when it appears — no manual\n\
+         System Settings step is required for this TCC category.\n\
+         \n\
+         Tip: install a Developer ID Application certificate and set TRUSTY_SIGN_IDENTITY\n\
+         to make that approval persist across all future reinstalls (run `tctl sign trusty-mpm`)."
+    )
 }
 
+/// Run the fail-soft post-install signing hook for a named set.
+///
+/// Why: Shared by [`post_install_search`] and [`post_install_mpm`] so the
+/// probe/sign/guidance sequence is written once.
+///
+/// What: On macOS: probes for a Developer ID cert; if found, signs + verifies
+/// every present binary in `set` and prints a success note; on cert-probe
+/// failure, prints the set-appropriate guidance (FDA for search, App Data TCC
+/// for mpm) using the set's first binary's path. Never aborts the caller.
 #[cfg(target_os = "macos")]
-fn post_install_search_macos(install_dir: &std::path::Path, json: bool) {
-    let search_path = install_dir.join("trusty-search");
-    let embedderd_path = install_dir.join("trusty-embedderd");
+fn post_install_signed_set(install_dir: &std::path::Path, set: &str, json: bool) {
+    let binaries = binaries_for_set(set);
+    let Some(&primary) = binaries.first() else {
+        return;
+    };
+    let primary_path = install_dir.join(primary);
 
     match has_developer_id_cert() {
         Some(identity) => {
             let mut signed_ok = true;
-            for path in [&search_path, &embedderd_path] {
+            for name in binaries {
+                let path = install_dir.join(name);
                 if !path.exists() {
-                    // embedderd may not be separately installed; skip gracefully.
+                    // A bundled binary (e.g. embedderd) may not be present; skip gracefully.
                     continue;
                 }
-                if let Err(e) = sign_binary(path, &identity) {
+                if let Err(e) = sign_binary(&path, &identity) {
                     if !json {
                         eprintln!(
                             "trusty-installer: warning: codesign failed for {}: {e}",
@@ -174,18 +363,62 @@ fn post_install_search_macos(install_dir: &std::path::Path, json: bool) {
             }
             if signed_ok && !json {
                 eprintln!(
-                    "trusty-search: signed with Developer ID. \
-                     The macOS Full Disk Access grant will persist across all future reinstalls."
+                    "{set}: signed with Developer ID. The macOS grant will persist across \
+                     all future reinstalls."
                 );
             }
         }
         None => {
-            // No cert — print the 4-step FDA re-grant guidance.
-            let path_str = search_path.to_string_lossy();
+            let path_str = primary_path.to_string_lossy();
             if !json {
-                eprintln!("{}", fda_guidance(&path_str));
+                let guidance = if set == MPM_SET {
+                    app_data_guidance(&path_str)
+                } else {
+                    fda_guidance(&path_str)
+                };
+                eprintln!("{guidance}");
             }
         }
+    }
+}
+
+/// Run post-install codesign and FDA guidance for trusty-search.
+///
+/// Why: After trusty-search (and trusty-embedderd) are installed the installer
+/// should immediately sign them (if a cert is available) or print the FDA
+/// re-grant guidance so the operator knows what to do next.
+///
+/// What: On macOS delegates to [`post_install_signed_set`] for [`SEARCH_SET`].
+/// On non-macOS: no-op.
+///
+/// Test: `tests::fda_guidance_contains_steps` (pure); signing itself is not
+/// invoked in tests (side-effecting).
+pub fn post_install_search(install_dir: &std::path::Path, json: bool) {
+    #[cfg(target_os = "macos")]
+    post_install_signed_set(install_dir, SEARCH_SET, json);
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (install_dir, json); // suppress unused warnings on non-macOS
+    }
+}
+
+/// Run post-install codesign and App-Data-TCC guidance for trusty-mpm.
+///
+/// Why: Owner-authorized scope extension (#2558, 2026-07-14) — `tm` needs the
+/// same stable-identity signing as trusty-search so the App Data TCC prompt
+/// does not re-fire on every `cargo install` rebuild.
+///
+/// What: On macOS delegates to [`post_install_signed_set`] for [`MPM_SET`]. On
+/// non-macOS: no-op.
+///
+/// Test: `tests::app_data_guidance_mentions_prompt` (pure); signing itself is
+/// not invoked in tests (side-effecting).
+pub fn post_install_mpm(install_dir: &std::path::Path, json: bool) {
+    #[cfg(target_os = "macos")]
+    post_install_signed_set(install_dir, MPM_SET, json);
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (install_dir, json); // suppress unused warnings on non-macOS
     }
 }
 
@@ -193,17 +426,45 @@ fn post_install_search_macos(install_dir: &std::path::Path, json: bool) {
 mod tests {
     use super::*;
 
-    /// Why: Both binary names must map to stable identifiers (contract for the
-    /// codesign `--identifier` flag).
-    /// What: Asserts the two target binaries map to the expected com.trusty.* IDs.
+    /// Why: Both signable sets must resolve to their documented binaries.
+    /// What: Asserts `trusty-search` covers search+embedderd, `trusty-mpm` covers mpm alone.
     /// Test: This is the test.
     #[test]
-    fn identifier_map_covers_both_binaries() {
-        assert_eq!(codesign_identifier("trusty-search"), "com.trusty.search");
+    fn binaries_for_set_covers_search_and_mpm() {
+        assert_eq!(
+            binaries_for_set(SEARCH_SET),
+            &["trusty-search", "trusty-embedderd"]
+        );
+        assert_eq!(binaries_for_set(MPM_SET), &["trusty-mpm"]);
+    }
+
+    /// Why: An unrecognised set name must not silently sign nothing without
+    /// signal — callers detect "unknown set" via an empty slice.
+    /// What: Asserts a bogus name returns an empty slice.
+    /// Test: This is the test.
+    #[test]
+    fn binaries_for_set_unknown_is_empty() {
+        assert!(binaries_for_set("not-a-set").is_empty());
+    }
+
+    /// Why: Every signable binary name must map to a stable identifier
+    /// (contract for the codesign `--identifier` flag), matching the
+    /// `com.trusty.trusty-<binary>` scheme used by `plist_label.rs` and the
+    /// release-workflow docs (the pre-#2558 short-form identifiers were the
+    /// drift this module fixes).
+    /// What: Asserts all three target binaries map to the expected IDs.
+    /// Test: This is the test.
+    #[test]
+    fn identifier_map_covers_all_signable_binaries() {
+        assert_eq!(
+            codesign_identifier("trusty-search"),
+            "com.trusty.trusty-search"
+        );
         assert_eq!(
             codesign_identifier("trusty-embedderd"),
-            "com.trusty.embedderd"
+            "com.trusty.trusty-embedderd"
         );
+        assert_eq!(codesign_identifier("trusty-mpm"), "com.trusty.trusty-mpm");
     }
 
     /// Why: The FDA guidance must contain all 4 numbered steps and reference the
@@ -270,5 +531,36 @@ mod tests {
             g.contains("Developer ID"),
             "tip about Developer ID cert missing"
         );
+    }
+
+    /// Why: The App-Data TCC guidance must reference the binary path and the
+    /// actual macOS prompt wording so the operator recognises it.
+    /// What: Calls `app_data_guidance` and checks the output.
+    /// Test: This is the test.
+    #[test]
+    fn app_data_guidance_mentions_prompt() {
+        let g = app_data_guidance("/usr/local/bin/trusty-mpm");
+        assert!(
+            g.contains("access data from other apps"),
+            "TCC prompt wording missing"
+        );
+        assert!(
+            g.contains("/usr/local/bin/trusty-mpm"),
+            "binary path missing"
+        );
+        assert!(g.contains("Developer ID"), "Developer ID tip missing");
+    }
+
+    /// Why: The cert-setup guidance must reference the exact `tctl sign`
+    /// invocation the operator should re-run, parameterised by target.
+    /// What: Asserts all 5 steps are present and the target is interpolated.
+    /// Test: This is the test.
+    #[test]
+    fn cert_setup_guidance_contains_steps() {
+        let g = cert_setup_guidance("trusty-mpm");
+        for step in ["1.", "2.", "3.", "4.", "5."] {
+            assert!(g.contains(step), "{step} missing");
+        }
+        assert!(g.contains("tctl sign trusty-mpm"));
     }
 }

--- a/crates/trusty-installer/src/commands/mod.rs
+++ b/crates/trusty-installer/src/commands/mod.rs
@@ -31,6 +31,7 @@ pub mod progress_ui;
 pub mod runtime;
 pub mod self_update;
 pub mod service_bootstrap;
+pub mod sign;
 pub mod stable_set;
 pub mod stack;
 pub mod status;

--- a/crates/trusty-installer/src/commands/sign.rs
+++ b/crates/trusty-installer/src/commands/sign.rs
@@ -19,8 +19,10 @@
 //! a no-op notice and returns 0 (codesign/TCC are Apple-specific).
 //!
 //! Test: `tests::run_unknown_target_is_error` covers the shared error path
-//! cross-platform (unknown target name); the macOS signing path is
-//! side-effecting (real `codesign`) and validated manually.
+//! cross-platform (unknown target name); `tests::run_known_target_is_noop_on_non_macos`
+//! (compiled and run only on non-macOS hosts — this workspace's CI runs on
+//! `ubuntu-latest`) covers the no-op path end to end; the macOS signing path
+//! itself is side-effecting (real `codesign`) and validated manually.
 
 use std::path::PathBuf;
 
@@ -86,14 +88,18 @@ fn run_macos(target: &str, dir: Option<PathBuf>, json: bool) -> i32 {
             }
             0
         }
-        Err(e) => {
-            let is_no_cert = e.to_string().contains("no Developer ID Application");
+        // PR #2657 review (MEDIUM): match on the typed `SignSetError` variant
+        // instead of substring-matching `e.to_string()` — brittle against any
+        // future wording change to the error message.
+        Err(macos_signing::SignSetError::NoCertificate) => {
             if !json {
-                if is_no_cert {
-                    eprintln!("{}", macos_signing::cert_setup_guidance(target));
-                } else {
-                    eprintln!("tctl sign: {e}");
-                }
+                eprintln!("{}", macos_signing::cert_setup_guidance(target));
+            }
+            1
+        }
+        Err(e) => {
+            if !json {
+                eprintln!("tctl sign: {e}");
             }
             1
         }
@@ -131,5 +137,22 @@ mod tests {
     fn run_unknown_target_is_error() {
         let code = run("not-a-real-target", None, true);
         assert_eq!(code, 2);
+    }
+
+    /// Why: PR #2657 review (LOW) — the non-macOS no-op path (codesign/TCC are
+    /// Apple-specific) must be exercised end to end, not just asserted by
+    /// inspection. This workspace's CI runs on `ubuntu-latest`, so this test
+    /// actually executes there; on a macOS dev machine it is compiled out
+    /// (`run` takes the `run_macos` branch instead, which is validated
+    /// manually — see the module doc comment).
+    /// What: A known target (`trusty-search`) on a non-macOS host returns exit
+    /// 0 without ever reaching the macOS-only `codesign` invocation (that code
+    /// path is not even compiled into this binary on non-macOS).
+    /// Test: This is the test.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn run_known_target_is_noop_on_non_macos() {
+        let code = run("trusty-search", None, false);
+        assert_eq!(code, 0);
     }
 }

--- a/crates/trusty-installer/src/commands/sign.rs
+++ b/crates/trusty-installer/src/commands/sign.rs
@@ -1,0 +1,135 @@
+//! `tctl sign <target>` — standalone Developer-ID signing entry point (#2558).
+//!
+//! Why: `tctl install` already signs `trusty-search`/`trusty-embedderd` and
+//! (since #2558's scope extension) `trusty-mpm` as a fail-soft post-install
+//! hook (`macos_signing::post_install_search` / `post_install_mpm`), but an
+//! operator who just built a binary from local source (`cargo install --path`)
+//! or wants to (re-)sign an already-installed binary without a full `tctl
+//! install` run needs a direct, HARD-failing entry point — this is that
+//! command. `scripts/install-trusty-search-signed.sh` shells out to it instead
+//! of duplicating the `codesign`/`security find-identity` invocations in bash,
+//! which is exactly the drift #2558 exists to close.
+//!
+//! What: Resolves the install directory (defaults to `$CARGO_HOME/bin` /
+//! `~/.cargo/bin`, since this command targets `cargo install`-produced
+//! binaries), then delegates to `macos_signing::sign_set_strict` for the
+//! requested target. Prints cert-setup guidance and returns a non-zero exit
+//! code when no Developer ID certificate is available or signing/verification
+//! fails; prints a success note and returns 0 otherwise. On non-macOS: prints
+//! a no-op notice and returns 0 (codesign/TCC are Apple-specific).
+//!
+//! Test: `tests::run_unknown_target_is_error` covers the shared error path
+//! cross-platform (unknown target name); the macOS signing path is
+//! side-effecting (real `codesign`) and validated manually.
+
+use std::path::PathBuf;
+
+use super::macos_signing;
+
+/// Handle `tctl sign <target>` (target: `trusty-search` or `trusty-mpm`).
+///
+/// Why: The CLI-facing entry point for standalone Developer-ID signing,
+/// separate from the fail-soft hooks `commands::install` runs automatically.
+///
+/// What: Validates `target` against `macos_signing::binaries_for_set`
+/// (non-empty = known), resolves `dir` (or the default cargo bin dir), and on
+/// macOS calls `sign_set_strict`. Returns the process exit code: `0` on
+/// success, `1` on a signing/verification/no-cert failure, `2` for an unknown
+/// target. On non-macOS this is always a `0` no-op.
+///
+/// Test: `tests::run_unknown_target_is_error`.
+pub fn run(target: &str, dir: Option<PathBuf>, json: bool) -> i32 {
+    if macos_signing::binaries_for_set(target).is_empty() {
+        eprintln!(
+            "tctl sign: unknown target '{target}' (expected 'trusty-search' or 'trusty-mpm')"
+        );
+        return 2;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        run_macos(target, dir, json)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (dir, json);
+        eprintln!("tctl sign: macOS-only (codesign/TCC are Apple-specific) — no-op.");
+        0
+    }
+}
+
+/// The macOS signing path, separated so it can hold `#[cfg(target_os =
+/// "macos")]` cleanly without splitting `run`'s argument validation.
+///
+/// Why: Keeps the always-available "unknown target" check in `run` shared
+/// across platforms while isolating the real `codesign` interaction.
+///
+/// What: Resolves the install dir, calls `sign_set_strict`, and maps the
+/// result to an exit code + human message (cert-setup guidance on failure,
+/// success note otherwise).
+///
+/// Test: Side-effecting (real `codesign`); not invoked in the test suite.
+#[cfg(target_os = "macos")]
+fn run_macos(target: &str, dir: Option<PathBuf>, json: bool) -> i32 {
+    let install_dir = dir.unwrap_or_else(default_bin_dir);
+
+    match macos_signing::sign_set_strict(&install_dir, target) {
+        Ok(signed) => {
+            if !json {
+                for path in &signed {
+                    eprintln!("tctl sign: signed and verified {}", path.display());
+                }
+                eprintln!(
+                    "{target}: signed with Developer ID. The macOS grant will persist across \
+                     all future reinstalls."
+                );
+            }
+            0
+        }
+        Err(e) => {
+            let is_no_cert = e.to_string().contains("no Developer ID Application");
+            if !json {
+                if is_no_cert {
+                    eprintln!("{}", macos_signing::cert_setup_guidance(target));
+                } else {
+                    eprintln!("tctl sign: {e}");
+                }
+            }
+            1
+        }
+    }
+}
+
+/// Default binary directory: `$CARGO_HOME/bin`, falling back to `~/.cargo/bin`.
+///
+/// Why: `cargo install` writes here; `tctl sign` (run standalone, without a
+/// preceding `tctl install`) needs the same default so it finds the binaries.
+///
+/// What: Reads `CARGO_HOME`; joins `bin`, or falls back to the home directory.
+///
+/// Test: Not unit-tested directly (thin env/home-dir read); the equivalent
+/// logic in `commands::install::cargo_bin_dir_from_env` is tested there.
+#[cfg(target_os = "macos")]
+fn default_bin_dir() -> PathBuf {
+    match std::env::var("CARGO_HOME") {
+        Ok(home) if !home.is_empty() => PathBuf::from(home).join("bin"),
+        _ => dirs::home_dir()
+            .map(|h| h.join(".cargo").join("bin"))
+            .unwrap_or_else(|| PathBuf::from("/usr/local/bin")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: An unrecognised target must be a clean, cross-platform error (exit
+    /// 2), not a signing attempt.
+    /// What: Calls `run` with a bogus target; asserts exit 2.
+    /// Test: This is the test.
+    #[test]
+    fn run_unknown_target_is_error() {
+        let code = run("not-a-real-target", None, true);
+        assert_eq!(code, 2);
+    }
+}

--- a/crates/trusty-installer/src/main.rs
+++ b/crates/trusty-installer/src/main.rs
@@ -19,7 +19,7 @@ use trusty_installer::{
     cli::{Cli, Commands, ConfigSubcommand, StackCmd},
     commands::{
         config, doctor, ensure, install, lifecycle, passthrough, port, run_up, runtime,
-        self_update, stack, status, ui, updates, upgrade, version,
+        self_update, sign, stack, status, ui, updates, upgrade, version,
     },
 };
 
@@ -175,6 +175,10 @@ fn dispatch(cli: Cli) {
 
         Commands::SelfUpdate => {
             std::process::exit(self_update::run(json));
+        }
+
+        Commands::Sign { target, dir } => {
+            std::process::exit(sign::run(target.as_set_name(), dir, json));
         }
 
         Commands::Passthrough(args) => {

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -104,20 +104,38 @@ and renames atomically, which keeps the cache consistent. If you must copy
 manually, follow it with `codesign --force --sign - ~/.cargo/bin/<binary>`
 to regenerate the ad-hoc signature against the final file.
 
-## Developer ID Signing for Persistent macOS FDA (fixes #873)
+## Developer ID Signing for Persistent macOS TCC Grants (fixes #873, #2558)
 
 ### The Problem
 
 `cargo install` produces a new binary with a new **cdhash** every time it
-runs (ad-hoc / linker-signed). macOS TCC keys the Full Disk Access grant by
-cdhash, so FDA is revoked after every reinstall. The workaround is to
-re-grant FDA manually each time — tedious and easy to forget.
+runs (ad-hoc / linker-signed). macOS TCC keys grants by cdhash, so every TCC
+category is revoked after every reinstall — Full Disk Access for
+`trusty-search` (`#873`), and (owner-authorized scope extension, 2026-07-14,
+#2558) App Data access for `trusty-mpm`: `tm` reads other apps' `$HOME`
+containers (Claude config dirs, tmux state), so macOS re-prompts `'trusty-mpm'
+would like to access data from other apps` on every ad-hoc-signed rebuild. The
+workaround for either category is to re-grant/re-approve manually each time —
+tedious and easy to forget.
 
 ### The Fix: Developer ID Application Signing
 
 Signing with a Developer ID Application certificate + a fixed `--identifier`
 per binary makes the **designated requirement (DR)** stable across rebuilds.
-TCC matches the DR, not the cdhash, so the FDA grant persists permanently.
+TCC matches the DR, not the cdhash, so the grant persists permanently — for
+both the FDA (search) and App Data (mpm) categories.
+
+### Single Source of Truth (#2558)
+
+The identifier scheme, signing flags, and guidance text live in exactly one
+place: `crates/trusty-installer/src/commands/macos_signing.rs`. Both
+`tctl install` (automatic, fail-soft post-install hook) and the standalone
+`tctl sign <target>` command (hard-failing, for local-source builds or
+re-signing) call into it — there is no second, independently-maintained
+implementation. `scripts/install-trusty-search-signed.sh` is a thin wrapper:
+it still runs `cargo install` from local source (the one thing `tctl install`
+cannot do), then shells out to `tctl sign trusty-search` for the actual
+codesign step.
 
 ### One-Time Certificate Setup
 
@@ -142,7 +160,7 @@ TCC matches the DR, not the cdhash, so the FDA grant persists permanently.
    # 1) AABBCCDDEEFF "Developer ID Application: Your Name (TEAM1234)"
    ```
 
-### Signed Install Script
+### Signed Install: trusty-search
 
 Use `scripts/install-trusty-search-signed.sh` (or `make install-search-signed`)
 instead of bare `cargo install`:
@@ -157,13 +175,43 @@ make install-search-signed
 The script:
 1. Runs `cargo install --path crates/trusty-search --locked` (installs both
    `trusty-search` and the bundled `trusty-embedderd` to `~/.cargo/bin/`).
-2. Auto-detects the Developer ID identity from the login keychain.
-3. Codesigns both binaries with:
-   - `--identifier com.trusty.trusty-search` / `com.trusty.trusty-embedderd`
-   - `--options runtime` (Hardened Runtime — required for notarization)
-   - `--timestamp` (secure timestamp from Apple's servers)
-4. Verifies signatures with `codesign --verify --strict`.
-5. Prints one-time FDA grant instructions and daemon restart commands.
+2. Shells out to `tctl sign trusty-search --dir ~/.cargo/bin`, which:
+   - Auto-detects the Developer ID identity from the login keychain (or honours
+     `TRUSTY_SIGN_IDENTITY`).
+   - Codesigns both binaries with:
+     - `--identifier com.trusty.trusty-search` / `com.trusty.trusty-embedderd`
+     - `--options runtime` (Hardened Runtime — required for notarization)
+     - `--timestamp` (secure timestamp from Apple's servers)
+   - Verifies signatures with `codesign --verify --deep --strict`.
+3. Prints one-time FDA grant instructions and daemon restart commands.
+
+Already have binaries on PATH and just want to (re-)sign them? Skip the cargo
+install step entirely:
+
+```bash
+tctl sign trusty-search
+```
+
+### Signed Install: trusty-mpm (#2558)
+
+`tctl install trusty-mpm` (or `tctl install`, which includes it in the stable
+set) already runs the App-Data-TCC signing hook automatically as a fail-soft
+post-install step — no separate script is needed for the common case. For a
+local-source build, run the same two-step pattern as trusty-search:
+
+```bash
+cargo install --path crates/trusty-mpm --locked
+tctl sign trusty-mpm
+```
+
+`tctl sign trusty-mpm` signs with `--identifier com.trusty.trusty-mpm` (same
+`--options runtime --timestamp` flags and `--verify --deep --strict` check as
+trusty-search) and prints the App-Data-TCC guidance: approve the next
+`'trusty-mpm' would like to access data from other apps` prompt once; a
+Developer ID cert makes that approval persist across every future reinstall.
+There is no separate `install-trusty-mpm-signed.sh` script — the local-source
+build case is covered by the two commands above, and the common (crates.io /
+prebuilt) case is covered by `tctl install trusty-mpm` alone.
 
 ### TRUSTY_SIGN_IDENTITY Override
 
@@ -173,6 +221,9 @@ org), specify which one to use:
 ```bash
 TRUSTY_SIGN_IDENTITY="Developer ID Application: Acme Corp (ABCDE12345)" \
   scripts/install-trusty-search-signed.sh
+# or, for the standalone signing verb:
+TRUSTY_SIGN_IDENTITY="Developer ID Application: Acme Corp (ABCDE12345)" \
+  tctl sign trusty-mpm
 ```
 
 ### Install from a Specific crates.io Version

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -137,6 +137,49 @@ it still runs `cargo install` from local source (the one thing `tctl install`
 cannot do), then shells out to `tctl sign trusty-search` for the actual
 codesign step.
 
+🔴 **Identifier migration notice (PR #2657 review):** #2558 canonicalized
+`trusty-search`'s / `trusty-embedderd`'s `--identifier` from the short-form
+`com.trusty.search` / `com.trusty.embedderd` (used by the pre-PR `tctl
+install` hook) to the full-form `com.trusty.trusty-search` /
+`com.trusty.trusty-embedderd` (matching the script and the launchd label
+convention). Changing the identifier changes the designated requirement (DR),
+which **invalidates any existing FDA/App-Data grant keyed to the old value** —
+the same `indexes:2` symptom #873 originally described. To avoid a *silent*
+re-break, every signing path (`tctl install`'s hook and `tctl sign`) now reads
+the binary's CURRENT on-disk identifier before re-signing
+(`macos_signing::current_identifier`, via `codesign -d`) and prints a loud,
+distinct notice when it is about to change:
+
+```
+trusty-installer: ⚠ IDENTIFIER CHANGE for trusty-search: com.trusty.search -> com.trusty.trusty-search.
+Existing macOS Full Disk Access / App Data grants keyed to the old identifier will STOP MATCHING
+after this signing — re-grant/re-approve once after this install.
+```
+
+If you see this notice, re-grant FDA (search) or re-approve the next App-Data
+prompt (mpm) exactly once — subsequent reinstalls will not re-trigger it,
+since the identifier is now stable at the canonical value.
+
+🟡 **Hardened Runtime split (PR #2657 review, PM decision):** `--options
+runtime --timestamp` (Hardened Runtime) is gated per binary set and signing
+context rather than always-on, to preserve BOTH pre-PR behaviors exactly:
+
+| Set | `tctl install` auto-hook | `tctl sign` / wrapper script (explicit) |
+|---|---|---|
+| `trusty-search` / `trusty-embedderd` | **off** (pre-PR hook behavior) | **on** (pre-PR script behavior) |
+| `trusty-mpm` | **on** | **on** |
+
+trusty-search/embedderd load an ONNX runtime dylib, and Hardened Runtime's
+library-validation restriction has not yet been empirically verified safe for
+that load path — flipping the automatic hook to hardened-by-default risked
+silently breaking `tctl install trusty-search` on every machine with a
+Developer ID cert already installed. trusty-mpm loads no dylibs, so it is
+hardened unconditionally. **This split does not affect TCC grant stability** —
+that depends on `--identifier` + Team ID, not `--options runtime` — only on
+notarization eligibility and dylib-validation strictness. See the tracking
+issue linked from PR #2657 for lifting this split once ONNX-under-Hardened-
+Runtime is verified.
+
 ### One-Time Certificate Setup
 
 1. **Enroll in the Apple Developer Program** (if not already enrolled):

--- a/scripts/install-trusty-search-signed.sh
+++ b/scripts/install-trusty-search-signed.sh
@@ -8,18 +8,19 @@
 # per binary makes the designated requirement (DR) stable across rebuilds, so
 # the FDA grant persists permanently.
 #
-# What: Runs `cargo install` for trusty-search (which also installs the bundled
-# trusty-embedderd binary), then codesigns BOTH installed binaries with a
-# Developer ID Application identity.  Auto-detects the identity from the login
-# keychain; accepts an override via TRUSTY_SIGN_IDENTITY.  Verifies the
-# signature and prints actionable guidance for the one-time FDA grant step.
-# If no Developer ID cert is found the cargo install still succeeds and the
-# script exits non-zero only for the signing step, printing clear setup
-# instructions.
+# What: Runs `cargo install` for trusty-search from local source (which also
+# installs the bundled trusty-embedderd binary) — this script's one job that
+# `tctl install` cannot replace, since `tctl install` only pulls prebuilt or
+# crates.io releases, never a local working tree. The actual codesign +
+# identity-detection + verification step (previously duplicated here in bash)
+# is now delegated to `tctl sign trusty-search` — the single source of truth
+# in `crates/trusty-installer/src/commands/macos_signing.rs` (#2558). This
+# closes the drift between this script and the `tctl install` post-install
+# hook (they previously used different --identifier values and signing flags).
 #
 # Test: Run `bash -n scripts/install-trusty-search-signed.sh` for syntax check.
 # Run with `TRUSTY_CODESIGN_DRY_RUN=1` to exercise the identity-detection and
-# guidance paths without running cargo install or codesign.  Run on a machine
+# guidance paths without running cargo install or `tctl sign`. Run on a machine
 # without a Developer ID cert to validate the no-cert error path and exit code.
 # Run `shellcheck scripts/install-trusty-search-signed.sh` for lint.
 #
@@ -37,8 +38,15 @@
 #   # Override cargo source path
 #   TRUSTY_INSTALL_PATH=/path/to/trusty-tools scripts/install-trusty-search-signed.sh
 #
-#   # Dry-run: skip cargo install and codesign, exercise guidance paths only
+#   # Dry-run: skip cargo install and signing, exercise guidance paths only
 #   TRUSTY_CODESIGN_DRY_RUN=1 scripts/install-trusty-search-signed.sh
+#
+# Sibling entry point: `tctl sign trusty-mpm` covers the same Developer-ID
+# signing for the trusty-mpm binary (owner-authorized scope extension, #2558)
+# — there is no separate `install-trusty-mpm-signed.sh` script because
+# `tctl install trusty-mpm` (not a local-source build) already covers the
+# common case; `cargo install --path crates/trusty-mpm --locked && tctl sign
+# trusty-mpm` covers the local-source case.
 
 set -euo pipefail
 
@@ -46,24 +54,20 @@ set -euo pipefail
 # Configuration (all overridable via environment)
 # ---------------------------------------------------------------------------
 
-# Identifier bundle IDs — must be stable across rebuilds; do NOT change these
-# after the first signed install or the DR will change and FDA will be lost.
-readonly SEARCH_IDENTIFIER="com.trusty.trusty-search"
-readonly EMBEDDERD_IDENTIFIER="com.trusty.trusty-embedderd"
-
 # Binaries installed by `cargo install trusty-search`
 CARGO_BIN_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
 readonly SEARCH_BIN="$CARGO_BIN_DIR/trusty-search"
 readonly EMBEDDERD_BIN="$CARGO_BIN_DIR/trusty-embedderd"
 
-# Sign identity: auto-detected if not set
+# Sign identity: auto-detected by `tctl sign` if not set
 TRUSTY_SIGN_IDENTITY="${TRUSTY_SIGN_IDENTITY:-}"
+export TRUSTY_SIGN_IDENTITY
 
 # Install source: path dep (default) or crates.io version
 TRUSTY_INSTALL_PATH="${TRUSTY_INSTALL_PATH:-}"
 TRUSTY_INSTALL_VERSION="${TRUSTY_INSTALL_VERSION:-}"
 
-# Dry-run mode: skip cargo install + codesign; exercise guidance paths only
+# Dry-run mode: skip cargo install + signing; exercise guidance paths only
 TRUSTY_CODESIGN_DRY_RUN="${TRUSTY_CODESIGN_DRY_RUN:-0}"
 
 # ---------------------------------------------------------------------------
@@ -71,12 +75,9 @@ TRUSTY_CODESIGN_DRY_RUN="${TRUSTY_CODESIGN_DRY_RUN:-0}"
 # ---------------------------------------------------------------------------
 
 # All log helpers write to stderr (issue #2322). This is not cosmetic: several
-# functions below (detect_identity, detect_repo_root) are called via command
-# substitution (`identity="$(detect_identity)"`), and anything these helpers
-# print to stdout gets silently concatenated into the captured value. That
-# previously corrupted the --sign identity string with log text, so codesign
-# failed with "no identity found" even though a valid Developer ID cert was
-# present.
+# functions below (detect_repo_root) are called via command substitution
+# (`repo_root="$(detect_repo_root)"`), and anything these helpers print to
+# stdout gets silently concatenated into the captured value.
 info()    { printf '\033[0;32m[install-signed] %s\033[0m\n' "$*" >&2; }
 warn()    { printf '\033[0;33m[install-signed] WARNING: %s\033[0m\n' "$*" >&2; }
 error()   { printf '\033[0;31m[install-signed] ERROR: %s\033[0m\n' "$*" >&2; }
@@ -91,137 +92,22 @@ detect_repo_root() {
     dirname "$script_dir"
 }
 
-# Print Developer ID cert setup instructions and exit with the given code.
-# Why: A clear, actionable error beats a cryptic codesign failure.
-print_cert_setup_and_exit() {
-    local exit_code="${1:-1}"
-    error "No 'Developer ID Application' certificate found in the login keychain."
-    printf >&2 '\n'
-    printf >&2 'To enable persistent FDA (one-time setup):\n'
-    printf >&2 '\n'
-    printf >&2 '  1. Enroll in the Apple Developer Program:\n'
-    printf >&2 '       https://developer.apple.com/programs/enroll/\n'
-    printf >&2 '\n'
-    printf >&2 '  2. Issue a "Developer ID Application" certificate:\n'
-    printf >&2 '       Xcode → Settings → Accounts → Manage Certificates →\n'
-    printf >&2 '       "+" → "Developer ID Application"\n'
-    printf >&2 '       — OR —\n'
-    printf >&2 '       https://developer.apple.com/account/resources/certificates/list\n'
-    printf >&2 '\n'
-    printf >&2 '  3. Download and double-click the .cer file to install it in\n'
-    printf >&2 '       your login keychain (Keychain Access will confirm).\n'
-    printf >&2 '\n'
-    printf >&2 '  4. Verify the cert is present:\n'
-    printf >&2 '       security find-identity -v -p codesigning | grep "Developer ID Application"\n'
-    printf >&2 '\n'
-    printf >&2 '  5. Re-run this script:\n'
-    printf >&2 '       scripts/install-trusty-search-signed.sh\n'
-    printf >&2 '\n'
-    printf >&2 'Note: trusty-search was installed successfully. The ONLY missing step\n'
-    printf >&2 'is the Developer ID signing that makes the FDA grant persistent.\n'
-    printf >&2 'You can continue using trusty-search now; re-run this script to sign\n'
-    printf >&2 'once you have a Developer ID Application certificate.\n'
-    exit "$exit_code"
-}
-
-# Detect the Developer ID Application identity from the login keychain.
-# Why: Avoids hardcoding the Team ID (which varies per developer account).
-# What: Parses `security find-identity` output, prefers the TRUSTY_SIGN_IDENTITY
-# override, falls back to auto-detection, errors if none found.
-detect_identity() {
-    if [[ -n "$TRUSTY_SIGN_IDENTITY" ]]; then
-        info "Using TRUSTY_SIGN_IDENTITY override: $TRUSTY_SIGN_IDENTITY"
-        echo "$TRUSTY_SIGN_IDENTITY"
+# Resolve the `tctl` (or `trusty-installer`) binary to run the sign step.
+# Why: The unified signing logic (#2558) lives in trusty-installer; this
+# script must not duplicate `codesign`/`security find-identity` calls. Prefers
+# an already-installed `tctl`/`trusty-installer` on PATH; falls back to
+# `cargo run -p trusty-installer` from the detected repo root so a fresh
+# checkout with no prior tctl install still works.
+resolve_tctl() {
+    if command -v tctl >/dev/null 2>&1; then
+        echo "tctl"
         return 0
     fi
-
-    info "Auto-detecting Developer ID Application identity..."
-    local identities
-    identities="$(security find-identity -v -p codesigning 2>/dev/null \
-        | grep 'Developer ID Application' \
-        | head -1 \
-        || true)"
-
-    if [[ -z "$identities" ]]; then
-        return 1
+    if command -v trusty-installer >/dev/null 2>&1; then
+        echo "trusty-installer"
+        return 0
     fi
-
-    # Extract the identity string between the first pair of double-quotes
-    # Example line: "  1) AABBCC1234 "Developer ID Application: Acme Corp (TEAM1234)""
-    local identity
-    identity="$(printf '%s' "$identities" | sed 's/.*"\(Developer ID Application[^"]*\)".*/\1/')"
-
-    if [[ -z "$identity" ]]; then
-        return 1
-    fi
-
-    info "Found identity: $identity"
-    echo "$identity"
-    return 0
-}
-
-# Sign a single binary with the Developer ID identity.
-# Why: Encapsulates codesign flags so they are applied identically to both binaries.
-# What: Runs codesign --force --options runtime --timestamp --identifier <id> --sign <identity>,
-# then immediately verifies the resulting signature (issue #2322) so a corrupted
-# --sign identity (e.g. from a stdout-capture bug) can never pass silently —
-# `set -e` means codesign itself already aborts on an outright invalid identity,
-# but this extra, explicit check fails loudly and immediately after each binary
-# is signed rather than deferring all verification to the later Step 4, and
-# guards against subtler corruption that codesign alone might not catch.
-# The --options runtime flag enables the Hardened Runtime, required for notarization.
-# The fixed --identifier keeps the DR stable across rebuilds.
-sign_binary() {
-    local binary="$1"
-    local identifier="$2"
-    local identity="$3"
-
-    info "Signing $binary"
-    info "  identifier: $identifier"
-    info "  identity:   $identity"
-
-    codesign \
-        --force \
-        --options runtime \
-        --timestamp \
-        --identifier "$identifier" \
-        --sign "$identity" \
-        "$binary"
-
-    local verify_output
-    if ! verify_output="$(codesign --verify --deep --strict "$binary" 2>&1)"; then
-        error "Post-sign verification FAILED for $binary"
-        error "codesign --verify --deep --strict output:"
-        printf '%s\n' "$verify_output" >&2
-        error "The signature is invalid or corrupted — refusing to continue."
-        exit 1
-    fi
-    info "Post-sign verification passed for $binary"
-}
-
-# Verify the signature on a binary and print the Authority/TeamIdentifier/Identifier.
-# Why: Gives the user immediate confirmation that signing succeeded and the DR is stable.
-verify_binary() {
-    local binary="$1"
-    local label="$2"
-
-    info "Verifying signature on $label..."
-
-    # Strict verification (checks all requirements, not just the signature)
-    if codesign --verify --strict "$binary" 2>&1; then
-        info "  codesign --verify --strict: PASSED"
-    else
-        error "Signature verification FAILED for $binary"
-        return 1
-    fi
-
-    # Print the key fields so the user can confirm the DR is correct
-    printf '\n  %s signature details:\n' "$label"
-    codesign -dvvv "$binary" 2>&1 \
-        | grep -E 'Authority|TeamIdentifier|Identifier|Format|Runtime' \
-        | sed 's/^/    /' \
-        || true
-    printf '\n'
+    return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -264,118 +150,29 @@ run_cargo_install() {
 }
 
 # ---------------------------------------------------------------------------
-# Step 2: identity detection
+# Step 2: sign (delegates to `tctl sign trusty-search` — #2558)
 # ---------------------------------------------------------------------------
 
-run_identity_detection() {
-    section "Step 2: Detect Developer ID signing identity"
+run_sign() {
+    section "Step 2: Codesign via 'tctl sign trusty-search'"
 
     if [[ "$TRUSTY_CODESIGN_DRY_RUN" == "1" ]]; then
-        info "[DRY RUN] Checking for Developer ID identity (no signing will occur)"
-    fi
-
-    local identity
-    if ! identity="$(detect_identity)"; then
-        # cargo install already succeeded; only the signing step is missing.
-        # Print setup instructions and exit non-zero for the signing failure.
-        warn "cargo install completed successfully."
-        print_cert_setup_and_exit 1
-    fi
-
-    # Export for use by subsequent steps
-    RESOLVED_IDENTITY="$identity"
-}
-
-# ---------------------------------------------------------------------------
-# Step 3: codesign both binaries
-# ---------------------------------------------------------------------------
-
-run_codesign() {
-    section "Step 3: Codesign binaries with Developer ID"
-
-    if [[ "$TRUSTY_CODESIGN_DRY_RUN" == "1" ]]; then
-        info "[DRY RUN] Would sign:"
-        info "  $SEARCH_BIN  (identifier: $SEARCH_IDENTIFIER)"
-        info "  $EMBEDDERD_BIN  (identifier: $EMBEDDERD_IDENTIFIER)"
+        info "[DRY RUN] Would run: tctl sign trusty-search --dir $CARGO_BIN_DIR"
         return 0
     fi
 
-    for bin in "$SEARCH_BIN" "$EMBEDDERD_BIN"; do
-        if [[ ! -f "$bin" ]]; then
-            warn "$bin not found — skipping (was it built and installed?)"
-        fi
-    done
-
-    sign_binary "$SEARCH_BIN"    "$SEARCH_IDENTIFIER"    "$RESOLVED_IDENTITY"
-    sign_binary "$EMBEDDERD_BIN" "$EMBEDDERD_IDENTIFIER" "$RESOLVED_IDENTITY"
-
-    info "Codesigning complete."
-}
-
-# ---------------------------------------------------------------------------
-# Step 4: verify signatures
-# ---------------------------------------------------------------------------
-
-run_verify() {
-    section "Step 4: Verify signatures"
-
-    if [[ "$TRUSTY_CODESIGN_DRY_RUN" == "1" ]]; then
-        info "[DRY RUN] Skipping verification"
-        return 0
+    local tctl_bin
+    if tctl_bin="$(resolve_tctl)"; then
+        info "Using $tctl_bin on PATH"
+        "$tctl_bin" sign trusty-search --dir "$CARGO_BIN_DIR"
+        return $?
     fi
 
-    verify_binary "$SEARCH_BIN"    "trusty-search"
-    verify_binary "$EMBEDDERD_BIN" "trusty-embedderd"
-}
-
-# ---------------------------------------------------------------------------
-# Step 5: user guidance
-# ---------------------------------------------------------------------------
-
-print_next_steps() {
-    section "Done — next steps"
-
-    if [[ "$TRUSTY_CODESIGN_DRY_RUN" == "1" ]]; then
-        info "[DRY RUN] Completed identity detection path. Run without DRY_RUN to install + sign."
-        return 0
-    fi
-
-    printf '
-Both binaries are now signed with a stable Developer ID.
-The designated requirement (DR) is anchored to the signing identity
-and the fixed --identifier, so it will NOT change on future reinstalls.
-
-'
-    # Detect whether FDA has been granted before (best-effort heuristic)
-    local fda_hint=""
-    if ! security find-generic-password -a trusty-search -s "trusty-fda-granted" \
-         -D "trusty marker" &>/dev/null 2>&1; then
-        fda_hint="(one-time)"
-    fi
-
-    printf 'FULL DISK ACCESS — %s grant:\n' "${fda_hint:-}"
-    printf '  1. Open System Settings → Privacy & Security → Full Disk Access\n'
-    printf '  2. Click the "+" button and navigate to:\n'
-    printf '       %s\n' "$SEARCH_BIN"
-    printf '  3. Enable the toggle for trusty-search.\n'
-    printf '\n'
-    printf 'After the one-time FDA grant, future "cargo install" rebuilds followed\n'
-    printf 'by this script will NOT require re-granting FDA — the DR is now stable.\n'
-    printf '\n'
-    printf 'RESTART the daemon to pick up the newly signed binary:\n'
-    # SC2016: single-quoted intentionally — these are example commands for the user to paste,
-    # not expressions to evaluate now. The $(id -u) and <label> are meant to be read literally.
-    # shellcheck disable=SC2016
-    printf '  launchctl bootout  gui/$(id -u) ~/Library/LaunchAgents/<label>.plist\n'
-    # shellcheck disable=SC2016
-    printf '  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/<label>.plist\n'
-    printf '\n'
-    printf 'Verify the daemon loaded all indexes:\n'
-    printf '  trusty-search status\n'
-    printf '\n'
-    printf 'OPTIONAL — notarize for distribution to OTHER machines:\n'
-    printf '  See docs/reference/release-workflow.md#notarization-appendix\n'
-    printf '  (Not required for local FDA persistence.)\n'
+    local repo_root
+    repo_root="$(detect_repo_root)"
+    warn "tctl/trusty-installer not found on PATH — running via 'cargo run -p trusty-installer'"
+    warn "(install trusty-installer once — cargo install --path $repo_root/crates/trusty-installer --locked — to skip this rebuild next time)"
+    (cd "$repo_root" && cargo run --quiet -p trusty-installer -- sign trusty-search --dir "$CARGO_BIN_DIR")
 }
 
 # ---------------------------------------------------------------------------
@@ -392,10 +189,21 @@ main() {
     fi
 
     run_cargo_install
-    run_identity_detection
-    run_codesign
-    run_verify
-    print_next_steps
+    run_sign
+
+    if [[ "$TRUSTY_CODESIGN_DRY_RUN" != "1" ]]; then
+        section "Done — next steps"
+        printf '\nRESTART the daemon to pick up the newly signed binary:\n'
+        # shellcheck disable=SC2016
+        printf '  launchctl bootout  gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist\n'
+        # shellcheck disable=SC2016
+        printf '  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist\n'
+        printf '\nVerify the daemon loaded all indexes:\n'
+        printf '  trusty-search status\n'
+        printf '\nOPTIONAL — notarize for distribution to OTHER machines:\n'
+        printf '  See docs/reference/release-workflow.md#notarization-appendix\n'
+        printf '  (Not required for local FDA persistence.)\n'
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

**Original scope (#2558):** `scripts/install-trusty-search-signed.sh` and `crates/trusty-installer/src/commands/macos_signing.rs::post_install_search` had drifted into two independent codesign implementations — different `--identifier` values (`com.trusty.search` vs `com.trusty.trusty-search`), the script had `--options runtime --timestamp` + post-sign verification the Rust hook lacked. `macos_signing.rs` is now the single source of truth:
- Canonicalized identifiers to the documented `com.trusty.trusty-<binary>` scheme (matches `plist_label.rs` / release-workflow docs) — fixes the drift.
- Folded in `--options runtime --timestamp` and `codesign --verify --deep --strict` post-sign verification (see the Hardened Runtime split below — this is now conditional).
- `scripts/install-trusty-search-signed.sh` is now a thin wrapper: it still runs `cargo install` from local source (the one thing `tctl install` can't do), then shells out to the new `tctl sign trusty-search` command for the actual codesign step.
- The search-plist-bootstrap gap the issue described was already resolved on `main` by #2556 (`service_bootstrap.rs`, wired into `install.rs`'s Phase 7b) — verified still wired correctly, no further change needed there.

**Owner-authorized scope extension (Bob, 2026-07-14 — see [issue comment](https://github.com/bobmatnyc/trusty-tools/issues/2558#issuecomment-4972844341)):** extends the same Developer-ID signing to `trusty-mpm`. macOS's App Data TCC category (`'trusty-mpm' would like to access data from other apps`) re-prompts on every `cargo install` rebuild for the same ad-hoc-signing/cdhash reason FDA does for trusty-search — `tm` reads other apps' `$HOME` containers (Claude config dirs, tmux state). This supersedes the stale `.trusty-mpm/INSTRUCTIONS.md` note claiming tm doesn't need signing (that note was scoped to Full Disk Access only, which is still true — tm does not need FDA — but is a different TCC category than App Data).

### New: `tctl sign <target>` command

- `target`: `trusty-search` (search + bundled embedderd) or `trusty-mpm`.
- Hard-fails (non-zero exit) on no cert / signing / verification failure — unlike the fail-soft `tctl install` post-install hook, this is the operator explicitly asking for signing to happen.
- `tctl install` (both `trusty-search` and `trusty-mpm` members) automatically runs the fail-soft signing hook as before — Phase 8 (search) and Phase 8b (mpm).

### Identifier scheme for tm

`--identifier com.trusty.trusty-mpm` — same `com.trusty.trusty-<binary>` convention as search/embedderd, signed with `--options runtime --timestamp` (always, see below), verified with `--verify --deep --strict`.

### How a user signs tm

```bash
# Common case — already covered automatically:
tctl install trusty-mpm

# Local-source build:
cargo install --path crates/trusty-mpm --locked
tctl sign trusty-mpm
```

No separate `install-trusty-mpm-signed.sh` script — `tctl sign trusty-mpm` is the single entry point (search's script still exists because it also handles the local-source `cargo install --path` step, which `tctl install` cannot do).

## Review round 2 — code-critic WARN, two HIGHs fixed

**HIGH — silent identifier migration (fixed):** hosts previously signed by the pre-PR Rust hook carry the old `com.trusty.search` identifier; blindly re-signing with the new canonical `com.trusty.trusty-search` changes the designated requirement and silently invalidates their existing FDA grant (reproducing #873's `indexes:2` symptom). Fixed by `macos_signing::current_identifier` (reads the binary's on-disk identifier via `codesign -d`, parsing the `Identifier=` line from stderr) + `identifier_migration_notice`, wired into both `sign_set_strict` and the fail-soft `post_install_signed_set` via `warn_on_identifier_change`. Prints a loud, distinct notice:
```
trusty-installer: ⚠ IDENTIFIER CHANGE for trusty-search: com.trusty.search -> com.trusty.trusty-search.
Existing macOS Full Disk Access / App Data grants keyed to the old identifier will STOP MATCHING
after this signing — re-grant/re-approve once after this install.
```
Documented in `docs/reference/release-workflow.md` under "Identifier migration notice".

**HIGH (PM decision) — preserve both pre-PR behaviors for Hardened Runtime (fixed):** `--options runtime --timestamp` is now gated per set + context via `macos_signing::use_hardened_runtime(set, explicit)`:

| Set | `tctl install` auto-hook | `tctl sign` / wrapper script (explicit) |
|---|---|---|
| `trusty-search` / `trusty-embedderd` | off (pre-PR hook behavior) | on (pre-PR script behavior) |
| `trusty-mpm` | on | on |

trusty-search/embedderd load an ONNX runtime dylib whose behavior under Hardened Runtime's library validation has not been empirically verified; flipping the automatic hook to hardened-by-default risked silently breaking `tctl install trusty-search` on every cert-equipped machine. TCC grant stability depends on `--identifier` + Team ID, not `--options runtime`, so this split does not reintroduce the identifier-drift problem. Follow-up tracking issue: **#2663** ("verify ONNX runtime dylib loading under Hardened Runtime for trusty-search; unify auto-hook signing options once verified" — references the `com.apple.security.cs.disable-library-validation` entitlement escape hatch).

**MEDIUM — single signing table (fixed):** `binaries_for_set` and `codesign_identifier` are now both derived from one `SIGNABLE_BINARIES: &[(&str, &str, &str)]` table (binary, set, identifier), plus a regression test (`every_set_member_has_a_real_identifier`) asserting no set member ever falls back to `"com.trusty.unknown"`.

**MEDIUM — typed error (fixed):** `sign_set_strict` now returns `Result<Vec<PathBuf>, SignSetError>` (an enum: `UnknownSet` / `NoCertificate` / `NoBinariesFound` / `Sign`) instead of `anyhow::Result`; `commands::sign::run_macos` matches on `SignSetError::NoCertificate` directly instead of substring-matching the error message.

**LOW — non-macOS no-op test (fixed):** `sign::tests::run_known_target_is_noop_on_non_macos` (`#[cfg(not(target_os = "macos"))]`) asserts exit 0 with no `codesign` invocation; runs on this workspace's `ubuntu-latest` CI.

## Files changed

- `crates/trusty-installer/src/commands/macos_signing.rs` — unified signing primitives (single `SIGNABLE_BINARIES` table, identifier-migration detection, hardened-runtime gating, typed `SignSetError`, `sign_set_strict`).
- `crates/trusty-installer/src/commands/sign.rs` — `tctl sign <target>` command handler + non-macOS no-op test.
- `crates/trusty-installer/src/commands/install.rs` — Phase 8 (search, no hardened runtime) + Phase 8b (mpm, hardened runtime) signing hooks.
- `crates/trusty-installer/src/commands/mod.rs`, `cli.rs`, `cli_tests.rs`, `main.rs` — wire the new `sign` subcommand + `SignTargetArg`.
- `scripts/install-trusty-search-signed.sh` — thin wrapper delegating to `tctl sign trusty-search`.
- `docs/reference/release-workflow.md`, `.trusty-mpm/INSTRUCTIONS.md` — document the unified path, tm coverage, identifier-migration notice, and the Hardened Runtime split.

Closes #2558

## Test plan

- [x] `cargo build --workspace` — clean (both review rounds).
- [x] `cargo test --workspace` — all green both rounds (one pre-existing/unrelated `trusty-agents::mistake_log` flake on round 1's first attempt, passed on retry and in isolation — not touched by this PR); round 2: zero `FAILED` blocks workspace-wide, `trusty-installer` 374 passed / 0 failed / 3 ignored.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean both rounds.
- [x] `cargo fmt --check` — clean (fixed drift both rounds via `cargo fmt`).
- [x] `bash scripts/check_line_cap.sh` — clean (0 violations).
- [x] `bash scripts/check_test_pointers.sh` — `0 dangling pointers — OK`.
- [x] `bash -n scripts/install-trusty-search-signed.sh` + `shellcheck` — clean.
- [ ] Manual live verification (real `codesign` + FDA/App-Data-TCC grant, including the identifier-migration notice on an already-signed host) — out of scope for this worktree per task constraints; to be verified under PM control.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools