### PR TITLE
feat(trusty-gworkspace): typed manage_events fields (start/end/attendees/location/timezone/recurrence) (parity)

### DIFF
--- a/crates/trusty-gworkspace/src/api/services/calendar.rs
+++ b/crates/trusty-gworkspace/src/api/services/calendar.rs
@@ -7,7 +7,7 @@
 //! Test: Integration only.
 
 use anyhow::{Result, anyhow};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 use crate::api::client::BaseClient;
 use crate::api::constants::CALENDAR_API_BASE;
@@ -84,16 +84,22 @@ pub async fn manage_events(client: &BaseClient, args: Value) -> Result<Value> {
             client.get(&url, account).await
         }
         "create" => {
-            let body = args
-                .get("event")
-                .cloned()
-                .ok_or_else(|| anyhow!("missing 'event' object"))?;
+            let base = args.get("event").cloned().unwrap_or_else(|| json!({}));
+            let body = build_event_body(base, &args);
+            if body.as_object().map(Map::is_empty).unwrap_or(true) {
+                return Err(anyhow!(
+                    "no event fields provided: supply typed fields \
+                     (start_time, end_time, attendees, location, timezone, \
+                     recurrence) or a raw 'event' object"
+                ));
+            }
             let url = format!("{CALENDAR_API_BASE}/calendars/{calendar_id}/events");
             client.post(&url, body, account).await
         }
         "update" => {
             let event_id = require_str(&args, "event_id")?;
-            let body = args.get("updates").cloned().unwrap_or_else(|| json!({}));
+            let base = args.get("updates").cloned().unwrap_or_else(|| json!({}));
+            let body = build_event_body(base, &args);
             let url = format!("{CALENDAR_API_BASE}/calendars/{calendar_id}/events/{event_id}");
             client.patch(&url, body, account).await
         }
@@ -103,6 +109,144 @@ pub async fn manage_events(client: &BaseClient, args: Value) -> Result<Value> {
             client.delete(&url, account).await
         }
         other => Err(anyhow!("unknown action for manage_events: {other}")),
+    }
+}
+
+/// Overlay declared typed event fields onto a base event body.
+///
+/// Why: Python's upstream `manage_events` exposes explicit typed properties
+/// (`start_time`, `end_time`, `attendees`, `location`, `timezone`,
+/// `recurrence`) so the tool schema is self-documenting, while our original
+/// Rust port only accepted an opaque `event`/`updates` object. This gives
+/// schema-discoverability parity without losing the raw escape hatch: the
+/// base object is still honoured and typed fields take precedence, merging
+/// sensibly into it.
+/// What: Starts from `base` (the caller's raw `event`/`updates` object, or an
+/// empty object) and, for each typed field present in `args`, maps it into the
+/// Calendar v3 event body shape — `start`/`end` become `{dateTime, timeZone}`
+/// objects, `attendees` string emails become `[{email}]`, `recurrence` strings
+/// are normalised to RRULE lines. A non-object `base` is discarded in favour of
+/// an empty object so a malformed escape hatch can never corrupt the body.
+/// Test: `build_event_body_*` unit tests below.
+fn build_event_body(base: Value, args: &Value) -> Value {
+    let mut body = if base.is_object() { base } else { json!({}) };
+    let Some(map) = body.as_object_mut() else {
+        // Unreachable: guarded to be an object above. Return an empty object
+        // rather than panic to honour the no-unwrap-in-library rule.
+        return json!({});
+    };
+    let timezone = opt_str(args, "timezone");
+
+    // start / end: typed timestamp wins; a lone timezone only decorates an
+    // already-present start/end so we never emit a timeZone-only slot (invalid).
+    if let Some(start) = opt_str(args, "start_time") {
+        map.insert("start".into(), time_field(start, timezone));
+    } else if let Some(tz) = timezone {
+        set_timezone_only(map, "start", tz);
+    }
+    if let Some(end) = opt_str(args, "end_time") {
+        map.insert("end".into(), time_field(end, timezone));
+    } else if let Some(tz) = timezone {
+        set_timezone_only(map, "end", tz);
+    }
+
+    if let Some(location) = opt_str(args, "location") {
+        map.insert("location".into(), json!(location));
+    }
+    if let Some(attendees) = build_attendees(args) {
+        map.insert("attendees".into(), attendees);
+    }
+    if let Some(recurrence) = build_recurrence(args) {
+        map.insert("recurrence".into(), recurrence);
+    }
+    body
+}
+
+/// Build a Calendar `{dateTime, timeZone}` time field.
+///
+/// Why: `start`/`end` in the Calendar v3 API are objects, not bare strings.
+/// What: Emits `dateTime`, plus `timeZone` only when a timezone is supplied.
+/// Test: Covered via `build_event_body_*` below.
+fn time_field(date_time: &str, timezone: Option<&str>) -> Value {
+    match timezone {
+        Some(tz) => json!({ "dateTime": date_time, "timeZone": tz }),
+        None => json!({ "dateTime": date_time }),
+    }
+}
+
+/// Decorate an existing start/end object with a timezone, if it exists.
+///
+/// Why: A caller may pass `timezone` alongside a raw `event.start` that already
+/// carries a `dateTime`/`date`; the typed timezone should still apply. We do
+/// NOT create the slot from scratch, since a `{timeZone}`-only object with no
+/// `dateTime`/`date` is rejected by the API.
+/// What: When `map[key]` is already an object, inserts/overwrites `timeZone`.
+/// Test: `build_event_body_timezone_only_decorates_existing` below.
+fn set_timezone_only(map: &mut Map<String, Value>, key: &str, timezone: &str) {
+    if let Some(Value::Object(slot)) = map.get_mut(key) {
+        slot.insert("timeZone".into(), json!(timezone));
+    }
+}
+
+/// Normalise the `attendees` field into Calendar `[{email}]` objects.
+///
+/// Why: The typed schema accepts a plain list of email strings (the common
+/// case), while the raw API wants attendee objects; passing through objects
+/// verbatim preserves advanced fields (`responseStatus`, `optional`, …).
+/// What: Returns `Some(array)` when `attendees` is an array — string entries
+/// become `{email}`, non-string entries are cloned through unchanged; returns
+/// `None` (skip) when the field is absent or not an array.
+/// Test: `build_event_body_attendees_*` below.
+fn build_attendees(args: &Value) -> Option<Value> {
+    let arr = args.get("attendees")?.as_array()?;
+    let list: Vec<Value> = arr
+        .iter()
+        .map(|entry| match entry.as_str() {
+            Some(email) => json!({ "email": email }),
+            None => entry.clone(),
+        })
+        .collect();
+    Some(Value::Array(list))
+}
+
+/// Normalise the `recurrence` field into a list of RRULE lines.
+///
+/// Why: Google expects recurrence entries prefixed with a rule keyword
+/// (`RRULE:`, `RDATE:`, `EXDATE:`, `EXRULE:`); users routinely pass a bare
+/// `FREQ=…` string, so we prefix `RRULE:` when no keyword is present.
+/// What: Accepts either a single string or an array of strings; returns
+/// `Some(array)` of normalised lines, or `None` when absent/empty/wrong-typed.
+/// Test: `build_event_body_recurrence_*` below.
+fn build_recurrence(args: &Value) -> Option<Value> {
+    let value = args.get("recurrence")?;
+    let lines: Vec<Value> = match value {
+        Value::String(s) => vec![Value::String(normalize_rrule(s))],
+        Value::Array(arr) => arr
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(|s| Value::String(normalize_rrule(s)))
+            .collect(),
+        _ => return None,
+    };
+    if lines.is_empty() {
+        return None;
+    }
+    Some(Value::Array(lines))
+}
+
+/// Prefix `RRULE:` onto a recurrence rule that lacks a rule-type keyword.
+///
+/// Why: See `build_recurrence`. Keeps already-qualified lines untouched.
+/// What: Case-insensitively checks for a known prefix; prefixes `RRULE:` when
+/// none is found.
+/// Test: `build_event_body_recurrence_*` below.
+fn normalize_rrule(rule: &str) -> String {
+    const PREFIXES: [&str; 4] = ["RRULE:", "RDATE:", "EXDATE:", "EXRULE:"];
+    let upper = rule.trim_start().to_ascii_uppercase();
+    if PREFIXES.iter().any(|p| upper.starts_with(p)) {
+        rule.to_string()
+    } else {
+        format!("RRULE:{rule}")
     }
 }
 
@@ -131,4 +275,132 @@ pub async fn query_free_busy(client: &BaseClient, args: Value) -> Result<Value> 
     });
     let url = format!("{CALENDAR_API_BASE}/freeBusy");
     client.post(&url, body, account).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_event_body_maps_all_typed_fields() {
+        let args = json!({
+            "start_time": "2026-08-01T09:00:00-07:00",
+            "end_time": "2026-08-01T10:00:00-07:00",
+            "timezone": "America/Los_Angeles",
+            "location": "Room 4",
+            "attendees": ["a@example.com", "b@example.com"],
+            "recurrence": "FREQ=WEEKLY;COUNT=3",
+        });
+        let body = build_event_body(json!({}), &args);
+        assert_eq!(
+            body["start"],
+            json!({ "dateTime": "2026-08-01T09:00:00-07:00", "timeZone": "America/Los_Angeles" })
+        );
+        assert_eq!(
+            body["end"],
+            json!({ "dateTime": "2026-08-01T10:00:00-07:00", "timeZone": "America/Los_Angeles" })
+        );
+        assert_eq!(body["location"], json!("Room 4"));
+        assert_eq!(
+            body["attendees"],
+            json!([{ "email": "a@example.com" }, { "email": "b@example.com" }])
+        );
+        // Bare FREQ string is normalised to an RRULE line.
+        assert_eq!(body["recurrence"], json!(["RRULE:FREQ=WEEKLY;COUNT=3"]));
+    }
+
+    #[test]
+    fn build_event_body_start_without_timezone_omits_timezone() {
+        let args = json!({ "start_time": "2026-08-01T09:00:00Z" });
+        let body = build_event_body(json!({}), &args);
+        assert_eq!(body["start"], json!({ "dateTime": "2026-08-01T09:00:00Z" }));
+        assert!(body.get("end").is_none());
+    }
+
+    #[test]
+    fn build_event_body_typed_fields_override_raw_escape_hatch() {
+        // The raw `event` object is honoured, but typed fields win where they
+        // overlap and leave unrelated raw fields (summary) intact.
+        let base = json!({
+            "summary": "Standup",
+            "location": "old room",
+            "start": { "dateTime": "2000-01-01T00:00:00Z" },
+        });
+        let args = json!({
+            "start_time": "2026-08-01T09:00:00Z",
+            "location": "new room",
+        });
+        let body = build_event_body(base, &args);
+        assert_eq!(body["summary"], json!("Standup"));
+        assert_eq!(body["location"], json!("new room"));
+        assert_eq!(body["start"], json!({ "dateTime": "2026-08-01T09:00:00Z" }));
+    }
+
+    #[test]
+    fn build_event_body_raw_only_is_passed_through_unchanged() {
+        // No typed fields: the escape hatch must be returned verbatim so
+        // nothing regresses for existing callers.
+        let base = json!({
+            "summary": "Legacy",
+            "start": { "dateTime": "2026-08-01T09:00:00Z" },
+            "end": { "dateTime": "2026-08-01T10:00:00Z" },
+        });
+        let body = build_event_body(base.clone(), &json!({}));
+        assert_eq!(body, base);
+    }
+
+    #[test]
+    fn build_event_body_timezone_only_decorates_existing() {
+        // A lone timezone applies to a pre-existing start/end but must not
+        // fabricate a timeZone-only slot (which the API rejects).
+        let base = json!({ "start": { "dateTime": "2026-08-01T09:00:00Z" } });
+        let args = json!({ "timezone": "Europe/Paris" });
+        let body = build_event_body(base, &args);
+        assert_eq!(
+            body["start"],
+            json!({ "dateTime": "2026-08-01T09:00:00Z", "timeZone": "Europe/Paris" })
+        );
+        // No `end` existed, so none is invented.
+        assert!(body.get("end").is_none());
+    }
+
+    #[test]
+    fn build_event_body_attendee_objects_pass_through() {
+        // Advanced attendee objects are preserved; plain strings are wrapped.
+        let args = json!({
+            "attendees": [ "a@example.com", { "email": "b@example.com", "optional": true } ],
+        });
+        let body = build_event_body(json!({}), &args);
+        assert_eq!(
+            body["attendees"],
+            json!([
+                { "email": "a@example.com" },
+                { "email": "b@example.com", "optional": true }
+            ])
+        );
+    }
+
+    #[test]
+    fn build_event_body_recurrence_array_and_prefix_preserved() {
+        // Array form; an already-qualified RRULE/EXDATE line is left untouched.
+        let args = json!({
+            "recurrence": ["RRULE:FREQ=DAILY", "EXDATE:20260901T090000Z"],
+        });
+        let body = build_event_body(json!({}), &args);
+        assert_eq!(
+            body["recurrence"],
+            json!(["RRULE:FREQ=DAILY", "EXDATE:20260901T090000Z"])
+        );
+    }
+
+    #[test]
+    fn build_event_body_empty_stays_empty() {
+        // Neither raw nor typed fields → empty object (create-path guard relies
+        // on this to reject a content-free request).
+        let body = build_event_body(json!({}), &json!({}));
+        assert_eq!(body, json!({}));
+        // A non-object escape hatch is discarded rather than corrupting the body.
+        let body = build_event_body(json!("not-an-object"), &json!({}));
+        assert_eq!(body, json!({}));
+    }
 }

--- a/crates/trusty-gworkspace/src/api/services/calendar.rs
+++ b/crates/trusty-gworkspace/src/api/services/calendar.rs
@@ -193,9 +193,9 @@ fn set_timezone_only(map: &mut Map<String, Value>, key: &str, timezone: &str) {
 /// Why: The typed schema accepts a plain list of email strings (the common
 /// case), while the raw API wants attendee objects; passing through objects
 /// verbatim preserves advanced fields (`responseStatus`, `optional`, …).
-/// What: Returns `Some(array)` when `attendees` is an array — string entries
-/// become `{email}`, non-string entries are cloned through unchanged; returns
-/// `None` (skip) when the field is absent or not an array.
+/// What: Returns `Some(array)` when `attendees` is a non-empty array — string
+/// entries become `{email}`, non-string entries are cloned through unchanged;
+/// returns `None` (skip) when the field is absent, not an array, or empty.
 /// Test: `build_event_body_attendees_*` below.
 fn build_attendees(args: &Value) -> Option<Value> {
     let arr = args.get("attendees")?.as_array()?;
@@ -206,6 +206,12 @@ fn build_attendees(args: &Value) -> Option<Value> {
             None => entry.clone(),
         })
         .collect();
+    // An empty `attendees: []` must not count as "content provided" — otherwise
+    // it would bypass the create-path content-free-request guard and send a
+    // bodyless event to the API (mirrors `build_recurrence`'s empty check).
+    if list.is_empty() {
+        return None;
+    }
     Some(Value::Array(list))
 }
 
@@ -236,17 +242,20 @@ fn build_recurrence(args: &Value) -> Option<Value> {
 
 /// Prefix `RRULE:` onto a recurrence rule that lacks a rule-type keyword.
 ///
-/// Why: See `build_recurrence`. Keeps already-qualified lines untouched.
-/// What: Case-insensitively checks for a known prefix; prefixes `RRULE:` when
-/// none is found.
+/// Why: See `build_recurrence`. Keeps already-qualified lines untouched, but
+/// Google requires the keyword itself to be uppercase — a lowercase/mixed-case
+/// `rrule:` prefix is malformed and would otherwise pass through unnormalized.
+/// What: Case-insensitively detects a known prefix and canonicalizes its
+/// casing to the uppercase form while leaving the rest of the line untouched;
+/// prefixes `RRULE:` when no keyword prefix is found.
 /// Test: `build_event_body_recurrence_*` below.
 fn normalize_rrule(rule: &str) -> String {
     const PREFIXES: [&str; 4] = ["RRULE:", "RDATE:", "EXDATE:", "EXRULE:"];
-    let upper = rule.trim_start().to_ascii_uppercase();
-    if PREFIXES.iter().any(|p| upper.starts_with(p)) {
-        rule.to_string()
-    } else {
-        format!("RRULE:{rule}")
+    let trimmed = rule.trim_start();
+    let upper = trimmed.to_ascii_uppercase();
+    match PREFIXES.iter().find(|p| upper.starts_with(*p)) {
+        Some(p) => format!("{p}{}", &trimmed[p.len()..]),
+        None => format!("RRULE:{rule}"),
     }
 }
 
@@ -391,6 +400,31 @@ mod tests {
             body["recurrence"],
             json!(["RRULE:FREQ=DAILY", "EXDATE:20260901T090000Z"])
         );
+    }
+
+    #[test]
+    fn build_event_body_recurrence_lowercase_prefix_is_canonicalized() {
+        // A lowercase/mixed-case rule keyword is malformed for Google; the
+        // prefix itself must be canonicalized to uppercase while the rest of
+        // the line is left untouched.
+        let args = json!({
+            "recurrence": ["rrule:FREQ=DAILY", "ExDate:20260901T090000Z"],
+        });
+        let body = build_event_body(json!({}), &args);
+        assert_eq!(
+            body["recurrence"],
+            json!(["RRULE:FREQ=DAILY", "EXDATE:20260901T090000Z"])
+        );
+    }
+
+    #[test]
+    fn build_event_body_empty_attendees_does_not_count_as_content() {
+        // An `attendees: []`-only request must not bypass the create-path
+        // content-free-request guard — it must be treated the same as
+        // "no attendees field at all".
+        let body = build_event_body(json!({}), &json!({ "attendees": [] }));
+        assert_eq!(body, json!({}));
+        assert!(body.get("attendees").is_none());
     }
 
     #[test]

--- a/crates/trusty-gworkspace/src/tools/calendar.rs
+++ b/crates/trusty-gworkspace/src/tools/calendar.rs
@@ -43,13 +43,20 @@ pub(super) fn append(tools: &mut Vec<Value>) {
             "location": { "type": "string", "description": "Event location (create/update)." },
             "attendees": {
                 "type": "array",
-                "items": { "type": "string" },
-                "description": "Attendee email addresses (create/update). Each maps to an attendee {email} object."
+                "items": {
+                    "oneOf": [
+                        { "type": "string", "description": "Attendee email address; maps to {email}." },
+                        { "type": "object", "description": "Raw attendee object (e.g. {email, optional, responseStatus}), passed through unchanged." },
+                    ]
+                },
+                "description": "Attendees (create/update): email strings or raw attendee objects."
             },
             "recurrence": {
-                "type": "array",
-                "items": { "type": "string" },
-                "description": "Recurrence rules, e.g. 'FREQ=WEEKLY;COUNT=10' or a full 'RRULE:FREQ=...' line (create/update)."
+                "oneOf": [
+                    { "type": "string", "description": "A single recurrence rule, e.g. 'FREQ=WEEKLY;COUNT=10' or 'RRULE:FREQ=...'." },
+                    { "type": "array", "items": { "type": "string" }, "description": "Multiple recurrence/exclusion lines, e.g. RRULE/RDATE/EXDATE/EXRULE." },
+                ],
+                "description": "Recurrence rule(s) (create/update). Bare FREQ=... strings are normalised to an RRULE: line."
             },
             "time_min": { "type": "string", "description": "RFC3339 lower bound (list)." },
             "time_max": { "type": "string", "description": "RFC3339 upper bound (list)." },

--- a/crates/trusty-gworkspace/src/tools/calendar.rs
+++ b/crates/trusty-gworkspace/src/tools/calendar.rs
@@ -35,8 +35,22 @@ pub(super) fn append(tools: &mut Vec<Value>) {
             "action": action_enum(&["list", "create", "update", "delete"]),
             "calendar_id": { "type": "string", "description": "Calendar ID. Defaults to 'primary'." },
             "event_id": { "type": "string" },
-            "event": { "type": "object", "description": "Event resource (create)." },
-            "updates": { "type": "object" },
+            "event": { "type": "object", "description": "Raw event resource (create). Escape hatch; typed fields below take precedence." },
+            "updates": { "type": "object", "description": "Raw patch body (update). Escape hatch; typed fields below take precedence." },
+            "start_time": { "type": "string", "description": "Event start, RFC3339 (create/update). Maps to start.dateTime." },
+            "end_time": { "type": "string", "description": "Event end, RFC3339 (create/update). Maps to end.dateTime." },
+            "timezone": { "type": "string", "description": "IANA timezone (e.g. 'America/Los_Angeles') applied to start/end (create/update)." },
+            "location": { "type": "string", "description": "Event location (create/update)." },
+            "attendees": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Attendee email addresses (create/update). Each maps to an attendee {email} object."
+            },
+            "recurrence": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Recurrence rules, e.g. 'FREQ=WEEKLY;COUNT=10' or a full 'RRULE:FREQ=...' line (create/update)."
+            },
             "time_min": { "type": "string", "description": "RFC3339 lower bound (list)." },
             "time_max": { "type": "string", "description": "RFC3339 upper bound (list)." },
             "query": { "type": "string", "description": "Free-text search (list)." },


### PR DESCRIPTION
## Summary

Adds declared, self-documenting **typed event fields** to `manage_events`
create/update in `trusty-gworkspace`, for schema-discoverability parity with
the Python upstream. Previously the Rust port only accepted an opaque
`event`/`updates` JSON object passed straight to the Calendar API; the tool
schema advertised nothing about the event shape. Now the schema declares:

- `start_time` — RFC3339 → `start.dateTime`
- `end_time` — RFC3339 → `end.dateTime`
- `timezone` — IANA tz applied to `start`/`end` `timeZone`
- `location` — event location
- `attendees` — array of email strings → `[{email}]` (attendee objects pass through)
- `recurrence` — RRULE strings (bare `FREQ=…` normalised to an `RRULE:` line)

## Design

A new pure `build_event_body()` overlays typed fields onto the caller's raw
`event`/`updates` object:

- The raw object is **retained as an escape hatch**; typed fields **take
  precedence** and merge sensibly (unrelated raw keys such as `summary` are
  preserved). Nothing regresses for existing callers — a raw-only body is
  returned verbatim.
- A lone `timezone` only decorates an already-present `start`/`end` (never
  fabricates an invalid `timeZone`-only slot).
- `create` now rejects a content-free request (neither raw nor typed fields),
  replacing the old bare "missing 'event' object" check.

Pure Calendar v3 API — no external deps.

## Testing

Not live-verifiable (expired tokens); the event-body construction is fully
unit-tested. 8 new tests cover full field mapping, precedence/merge, raw
pass-through, timezone-only decoration, attendee-object pass-through,
recurrence prefix normalisation, and empty/malformed bodies.

Raw gate (all green):
- `cargo build/test -p trusty-gworkspace` — 42 tests pass (incl. 8 new)
- `cargo clippy -p trusty-gworkspace --all-targets -- -D warnings` — clean
- `cargo fmt -p trusty-gworkspace --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations
- `cargo check --workspace` — exit 0

Part of #2626

Deferred-live note: end-to-end verification against the live Google Calendar
API is deferred — the workspace OAuth tokens are expired, so this lands with
unit coverage of the body-construction logic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)