### PR TITLE
feat(trusty-gworkspace): Slides action/type depth (get_slide/get_text/update_text/formatted+image+bulleted content) (parity)

### DIFF
--- a/crates/trusty-gworkspace/src/api/services/slides/content.rs
+++ b/crates/trusty-gworkspace/src/api/services/slides/content.rs
@@ -1,0 +1,385 @@
+//! Slides content authoring: add typed content to a slide via batchUpdate.
+//!
+//! Why: Beyond a plain text box, agents need formatted text, images, and
+//! bulleted lists; a single `add_slide_content` tool routes across those
+//! content types so the mutation surface stays small.
+//! What: `add_slide_content` dispatches on the optional `type` field to build
+//! the appropriate `presentations:batchUpdate` request.
+//! Test: Every request builder is a pure function unit-tested below; the HTTP
+//! round-trip is live-only.
+
+use anyhow::{Result, anyhow, bail};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::api::client::BaseClient;
+use crate::api::constants::SLIDES_API_BASE;
+use crate::api::services::{account_of, opt_str, require_str};
+
+/// Why: Content authoring is the most common Slides op; one tool with a `type`
+/// selector keeps text/formatted-text/image/list creation together.
+/// What: Routes on `type` (default `text_box`) to a request builder, then POSTs
+/// to `presentations:batchUpdate`.
+/// Test: Builders unit-tested below; HTTP is live-only.
+pub async fn add_slide_content(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "presentation_id")?;
+    let content_type = opt_str(&args, "type").unwrap_or("text_box");
+
+    let body = match content_type {
+        "text_box" => {
+            let slide_id = require_str(&args, "slide_id")?;
+            let text = require_str(&args, "text")?;
+            text_box_request(slide_id, text)
+        }
+        "formatted_text_box" => {
+            let slide_id = require_str(&args, "slide_id")?;
+            let text = require_str(&args, "text")?;
+            formatted_text_box_request(slide_id, text, &args)?
+        }
+        "image" => {
+            let slide_id = require_str(&args, "slide_id")?;
+            let image_url = require_str(&args, "image_url")?;
+            image_request(slide_id, image_url)
+        }
+        "bulleted_list" => {
+            let items = extract_items(&args)?;
+            let layout = opt_str(&args, "layout").unwrap_or("BLANK");
+            bulleted_list_request(&items, layout)
+        }
+        other => bail!("unknown content type for add_slide_content: {other}"),
+    };
+
+    let url = format!("{SLIDES_API_BASE}/presentations/{id}:batchUpdate");
+    client.post(&url, body, account).await
+}
+
+/// Why: Every text/formatted-text box starts from the same shape; sharing the
+/// builder avoids drift in the default geometry.
+/// What: Builds a `createShape` TEXT_BOX request at a fixed position/size.
+/// Test: Exercised via the request-builder tests below.
+fn create_shape(box_id: &str, slide_id: &str) -> Value {
+    json!({
+        "createShape": {
+            "objectId": box_id,
+            "shapeType": "TEXT_BOX",
+            "elementProperties": {
+                "pageObjectId": slide_id,
+                "size": {
+                    "width": { "magnitude": 350, "unit": "PT" },
+                    "height": { "magnitude": 100, "unit": "PT" },
+                },
+                "transform": {
+                    "scaleX": 1, "scaleY": 1,
+                    "translateX": 50, "translateY": 50, "unit": "PT",
+                }
+            }
+        }
+    })
+}
+
+/// Why: The original plain-text-box behaviour is preserved as the default type.
+/// What: Builds a `createShape` + `insertText` batchUpdate body.
+/// Test: `text_box_request_*` below.
+fn text_box_request(slide_id: &str, text: &str) -> Value {
+    let box_id = new_id("textbox");
+    json!({
+        "requests": [
+            create_shape(&box_id, slide_id),
+            { "insertText": { "objectId": box_id, "text": text } }
+        ]
+    })
+}
+
+/// Why: Agents frequently want emphasised or sized text; a formatted box adds
+/// styling on top of the plain box in one round-trip.
+/// What: Builds `createShape` + `insertText` + an optional `updateTextStyle`
+/// (only when any style field is supplied), styling the full text range.
+/// Test: `formatted_text_box_request_*` below.
+fn formatted_text_box_request(slide_id: &str, text: &str, args: &Value) -> Result<Value> {
+    let box_id = new_id("textbox");
+    let mut requests = vec![
+        create_shape(&box_id, slide_id),
+        json!({ "insertText": { "objectId": box_id, "text": text } }),
+    ];
+    let (style, fields) = build_text_style(args)?;
+    if !fields.is_empty() {
+        requests.push(json!({
+            "updateTextStyle": {
+                "objectId": box_id,
+                "style": style,
+                "textRange": { "type": "ALL" },
+                "fields": fields.join(","),
+            }
+        }));
+    }
+    Ok(json!({ "requests": requests }))
+}
+
+/// Why: The Slides `updateTextStyle` request needs both a style object and a
+/// matching `fields` mask; building them together keeps them in sync.
+/// What: Reads `font_size`/`bold`/`italic`/`font_color` and returns the style
+/// value plus the list of set field paths.
+/// Test: `build_text_style_*` below.
+fn build_text_style(args: &Value) -> Result<(Value, Vec<String>)> {
+    let mut style = json!({});
+    let mut fields = Vec::new();
+    if let Some(size) = args.get("font_size").and_then(|v| v.as_f64()) {
+        style["fontSize"] = json!({ "magnitude": size, "unit": "PT" });
+        fields.push("fontSize".to_string());
+    }
+    if let Some(bold) = args.get("bold").and_then(|v| v.as_bool()) {
+        style["bold"] = json!(bold);
+        fields.push("bold".to_string());
+    }
+    if let Some(italic) = args.get("italic").and_then(|v| v.as_bool()) {
+        style["italic"] = json!(italic);
+        fields.push("italic".to_string());
+    }
+    if let Some(color) = opt_str(args, "font_color") {
+        style["foregroundColor"] = json!({ "opaqueColor": { "rgbColor": hex_to_rgb(color)? } });
+        fields.push("foregroundColor".to_string());
+    }
+    Ok((style, fields))
+}
+
+/// Why: Slides expresses colour as normalised RGB floats, not hex; callers pass
+/// the familiar `#RRGGBB`, so we convert.
+/// What: Parses a `#RRGGBB` (or `RRGGBB`) string into `{red,green,blue}` floats
+/// in `0.0..=1.0`.
+/// Test: `hex_to_rgb_*` below.
+fn hex_to_rgb(hex: &str) -> Result<Value> {
+    let h = hex.trim_start_matches('#');
+    if h.len() != 6 {
+        bail!("invalid hex color '{hex}'; expected #RRGGBB");
+    }
+    let parse = |slice: &str| -> Result<f64> {
+        let byte = u8::from_str_radix(slice, 16)
+            .map_err(|_| anyhow!("invalid hex color '{hex}'; expected #RRGGBB"))?;
+        Ok(f64::from(byte) / 255.0)
+    };
+    Ok(json!({
+        "red": parse(&h[0..2])?,
+        "green": parse(&h[2..4])?,
+        "blue": parse(&h[4..6])?,
+    }))
+}
+
+/// Why: Inserting an image from a URL is a distinct Slides request shape.
+/// What: Builds a `createImage` batchUpdate body at a fixed position/size.
+/// Test: `image_request_*` below.
+fn image_request(slide_id: &str, image_url: &str) -> Value {
+    let image_id = new_id("image");
+    json!({
+        "requests": [{
+            "createImage": {
+                "objectId": image_id,
+                "url": image_url,
+                "elementProperties": {
+                    "pageObjectId": slide_id,
+                    "size": {
+                        "width": { "magnitude": 400, "unit": "PT" },
+                        "height": { "magnitude": 300, "unit": "PT" },
+                    },
+                    "transform": {
+                        "scaleX": 1, "scaleY": 1,
+                        "translateX": 50, "translateY": 50, "unit": "PT",
+                    }
+                }
+            }
+        }]
+    })
+}
+
+/// Why: A bulleted list is the quickest way to seed a content slide; the
+/// parity behaviour creates a fresh slide and fills it with a bullet list.
+/// What: Builds `createSlide` + `createShape` + `insertText` (items joined by
+/// newlines) + `createParagraphBullets` over the full range.
+/// Test: `bulleted_list_request_*` below.
+fn bulleted_list_request(items: &[String], layout: &str) -> Value {
+    let slide_id = new_id("slide");
+    let box_id = new_id("textbox");
+    let text = items.join("\n");
+    json!({
+        "requests": [
+            {
+                "createSlide": {
+                    "objectId": slide_id,
+                    "slideLayoutReference": { "predefinedLayout": layout }
+                }
+            },
+            create_shape(&box_id, &slide_id),
+            { "insertText": { "objectId": box_id, "text": text } },
+            {
+                "createParagraphBullets": {
+                    "objectId": box_id,
+                    "textRange": { "type": "ALL" },
+                    "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE"
+                }
+            }
+        ]
+    })
+}
+
+/// Why: Bullet items may arrive as a JSON array or a single newline-delimited
+/// string; normalising both keeps the tool ergonomic.
+/// What: Prefers a non-empty `items` string array; falls back to splitting
+/// `text` on newlines; errors when neither yields entries.
+/// Test: `extract_items_*` below.
+fn extract_items(args: &Value) -> Result<Vec<String>> {
+    if let Some(arr) = args.get("items").and_then(|v| v.as_array()) {
+        let items: Vec<String> = arr
+            .iter()
+            .filter_map(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+        if !items.is_empty() {
+            return Ok(items);
+        }
+    }
+    if let Some(text) = opt_str(args, "text") {
+        let items: Vec<String> = text
+            .lines()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+        if !items.is_empty() {
+            return Ok(items);
+        }
+    }
+    bail!("bulleted_list requires a non-empty 'items' array or newline-delimited 'text'")
+}
+
+/// Why: Slides object IDs must be unique per presentation; a prefixed UUID
+/// keeps them readable while collision-free.
+/// What: Returns `<prefix>_<uuid-simple>`.
+/// Test: Exercised via the request-builder tests below.
+fn new_id(prefix: &str) -> String {
+    format!("{prefix}_{}", Uuid::new_v4().simple())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_box_request_has_shape_and_text() {
+        let body = text_box_request("slide_1", "hi");
+        let reqs = body["requests"].as_array().unwrap();
+        assert_eq!(reqs.len(), 2);
+        assert_eq!(reqs[0]["createShape"]["shapeType"], "TEXT_BOX");
+        assert_eq!(
+            reqs[0]["createShape"]["elementProperties"]["pageObjectId"],
+            "slide_1"
+        );
+        assert_eq!(reqs[1]["insertText"]["text"], "hi");
+        // The insertText objectId must match the created shape.
+        assert_eq!(
+            reqs[0]["createShape"]["objectId"],
+            reqs[1]["insertText"]["objectId"]
+        );
+    }
+
+    #[test]
+    fn formatted_text_box_applies_all_style_fields() {
+        let args = json!({
+            "font_size": 24, "bold": true, "italic": true, "font_color": "#FF0000"
+        });
+        let body = formatted_text_box_request("slide_1", "styled", &args).unwrap();
+        let reqs = body["requests"].as_array().unwrap();
+        assert_eq!(reqs.len(), 3);
+        let style = &reqs[2]["updateTextStyle"];
+        assert_eq!(style["textRange"]["type"], "ALL");
+        assert_eq!(style["style"]["fontSize"]["magnitude"], 24.0);
+        assert_eq!(style["style"]["bold"], true);
+        assert_eq!(style["style"]["italic"], true);
+        assert_eq!(
+            style["style"]["foregroundColor"]["opaqueColor"]["rgbColor"]["red"],
+            1.0
+        );
+        let fields = style["fields"].as_str().unwrap();
+        assert!(fields.contains("fontSize"));
+        assert!(fields.contains("foregroundColor"));
+    }
+
+    #[test]
+    fn formatted_text_box_without_style_omits_update() {
+        let body = formatted_text_box_request("slide_1", "plain", &json!({})).unwrap();
+        assert_eq!(body["requests"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn build_text_style_only_sets_supplied_fields() {
+        let (style, fields) = build_text_style(&json!({ "bold": true })).unwrap();
+        assert_eq!(fields, vec!["bold".to_string()]);
+        assert_eq!(style["bold"], true);
+        assert!(style.get("fontSize").is_none());
+    }
+
+    #[test]
+    fn hex_to_rgb_parses_channels() {
+        let rgb = hex_to_rgb("#00FF80").unwrap();
+        assert_eq!(rgb["red"], 0.0);
+        assert_eq!(rgb["green"], 1.0);
+        assert!((rgb["blue"].as_f64().unwrap() - 128.0 / 255.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn hex_to_rgb_rejects_bad_input() {
+        assert!(hex_to_rgb("#FFF").is_err());
+        assert!(hex_to_rgb("#GGGGGG").is_err());
+    }
+
+    #[test]
+    fn image_request_uses_url() {
+        let body = image_request("slide_1", "https://example.com/a.png");
+        let img = &body["requests"][0]["createImage"];
+        assert_eq!(img["url"], "https://example.com/a.png");
+        assert_eq!(img["elementProperties"]["pageObjectId"], "slide_1");
+    }
+
+    #[test]
+    fn bulleted_list_creates_slide_and_bullets() {
+        let items = vec!["one".to_string(), "two".to_string()];
+        let body = bulleted_list_request(&items, "TITLE_AND_BODY");
+        let reqs = body["requests"].as_array().unwrap();
+        assert_eq!(reqs.len(), 4);
+        assert_eq!(
+            reqs[0]["createSlide"]["slideLayoutReference"]["predefinedLayout"],
+            "TITLE_AND_BODY"
+        );
+        assert_eq!(reqs[2]["insertText"]["text"], "one\ntwo");
+        assert_eq!(
+            reqs[3]["createParagraphBullets"]["bulletPreset"],
+            "BULLET_DISC_CIRCLE_SQUARE"
+        );
+        // The bullets and text target the same shape created on the new slide.
+        assert_eq!(
+            reqs[1]["createShape"]["objectId"],
+            reqs[3]["createParagraphBullets"]["objectId"]
+        );
+    }
+
+    #[test]
+    fn extract_items_from_array() {
+        let items = extract_items(&json!({ "items": ["a", "", "b"] })).unwrap();
+        assert_eq!(items, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn extract_items_from_text_lines() {
+        let items = extract_items(&json!({ "text": "a\n\n  b  \nc" })).unwrap();
+        assert_eq!(
+            items,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_items_errors_when_empty() {
+        assert!(extract_items(&json!({ "items": [] })).is_err());
+        assert!(extract_items(&json!({})).is_err());
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/slides/content.rs
+++ b/crates/trusty-gworkspace/src/api/services/slides/content.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 
 use crate::api::client::BaseClient;
 use crate::api::constants::SLIDES_API_BASE;
+use crate::api::services::slides::core::validate_layout;
 use crate::api::services::{account_of, opt_str, require_str};
 
 /// Why: Content authoring is the most common Slides op; one tool with a `type`
@@ -42,11 +43,7 @@ pub async fn add_slide_content(client: &BaseClient, args: Value) -> Result<Value
             let image_url = require_str(&args, "image_url")?;
             image_request(slide_id, image_url)
         }
-        "bulleted_list" => {
-            let items = extract_items(&args)?;
-            let layout = opt_str(&args, "layout").unwrap_or("BLANK");
-            bulleted_list_request(&items, layout)
-        }
+        "bulleted_list" => build_bulleted_list_body(&args)?,
         other => bail!("unknown content type for add_slide_content: {other}"),
     };
 
@@ -189,6 +186,20 @@ fn image_request(slide_id: &str, image_url: &str) -> Value {
             }
         }]
     })
+}
+
+/// Why: `bulleted_list` accepts a caller-supplied `layout` just like
+/// `manage_slides`' `create_slide`; without validating it here too, an
+/// invalid value would surface as an opaque Slides API 400 instead of the
+/// same fail-fast error `create_slide` gives.
+/// What: Extracts items, resolves `layout` (default `BLANK`), validates it
+/// against `VALID_LAYOUTS`, then builds the request.
+/// Test: `build_bulleted_list_body_*` below.
+fn build_bulleted_list_body(args: &Value) -> Result<Value> {
+    let items = extract_items(args)?;
+    let layout = opt_str(args, "layout").unwrap_or("BLANK");
+    validate_layout(layout)?;
+    Ok(bulleted_list_request(&items, layout))
 }
 
 /// Why: A bulleted list is the quickest way to seed a content slide; the
@@ -359,6 +370,33 @@ mod tests {
         assert_eq!(
             reqs[1]["createShape"]["objectId"],
             reqs[3]["createParagraphBullets"]["objectId"]
+        );
+    }
+
+    #[test]
+    fn build_bulleted_list_body_accepts_valid_layout() {
+        let args = json!({ "items": ["a", "b"], "layout": "BIG_NUMBER" });
+        let body = build_bulleted_list_body(&args).unwrap();
+        assert_eq!(
+            body["requests"][0]["createSlide"]["slideLayoutReference"]["predefinedLayout"],
+            "BIG_NUMBER"
+        );
+    }
+
+    #[test]
+    fn build_bulleted_list_body_rejects_invalid_layout() {
+        let args = json!({ "items": ["a"], "layout": "NOT_A_LAYOUT" });
+        let err = build_bulleted_list_body(&args).unwrap_err().to_string();
+        assert!(err.contains("invalid layout 'NOT_A_LAYOUT'"));
+    }
+
+    #[test]
+    fn build_bulleted_list_body_defaults_layout_to_blank() {
+        let args = json!({ "items": ["a"] });
+        let body = build_bulleted_list_body(&args).unwrap();
+        assert_eq!(
+            body["requests"][0]["createSlide"]["slideLayoutReference"]["predefinedLayout"],
+            "BLANK"
         );
     }
 

--- a/crates/trusty-gworkspace/src/api/services/slides/core.rs
+++ b/crates/trusty-gworkspace/src/api/services/slides/core.rs
@@ -1,30 +1,89 @@
-//! Slides core: get deck, create/add slides, add content via batchUpdate.
+//! Slides core: fetch/search decks and structural slide ops via batchUpdate.
 //!
-//! Why: Minimum viable surface for an agent-authored slide deck workflow.
-//! What: Three tools: `get_slides`, `manage_slides`, `add_slide_content`.
-//! Test: Live only.
+//! Why: The entry surface for an agent-authored slide workflow — discover
+//! presentations, read a deck (whole, per-slide, or as plain text), and manage
+//! slide structure (create/delete/reorder, replace element text).
+//! What: Two tools: `get_slides` (action-routed read) and `manage_slides`
+//! (action-routed batchUpdate). Content authoring lives in `super::content`.
+//! Test: Pure request/extraction builders are unit-tested below; the network
+//! round-trips are live-only.
 
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use serde_json::{Value, json};
-use uuid::Uuid;
 
 use crate::api::client::BaseClient;
-use crate::api::constants::SLIDES_API_BASE;
+use crate::api::constants::{DRIVE_API_BASE, SLIDES_API_BASE};
+use crate::api::services::drive::files::encode;
 use crate::api::services::{account_of, opt_str, require_str};
 
-/// Why: Fetching a presentation's slide tree is the entry to every Slides workflow.
-/// What: GETs `/presentations/{id}` and returns the full Slides JSON.
-/// Test: Live API.
+/// Valid `predefinedLayout` values accepted by `create_slide`.
+///
+/// Why: The Slides API rejects unknown layout strings with an opaque 400;
+/// constraining the input to the known-good set (mirroring the Python
+/// upstream's 10 layouts) fails fast with an actionable message and lets the
+/// tool schema advertise the enum.
+/// What: The ten predefined Slides layouts exposed for slide creation.
+/// Test: `validate_layout_*` below.
+pub(crate) const VALID_LAYOUTS: &[&str] = &[
+    "BLANK",
+    "CAPTION_ONLY",
+    "TITLE",
+    "TITLE_AND_BODY",
+    "TITLE_AND_TWO_COLUMNS",
+    "TITLE_ONLY",
+    "SECTION_HEADER",
+    "SECTION_TITLE_AND_DESCRIPTION",
+    "ONE_COLUMN_TEXT",
+    "MAIN_POINT",
+];
+
+/// Why: Every Slides read starts here; the shape depends on how much detail the
+/// caller needs, so one tool routes across `list`/`get_presentation`/
+/// `get_slide`/`get_text`.
+/// What: Dispatches on the optional `action` field (default `get_presentation`)
+/// to a Drive search or a Slides GET (optionally post-processed).
+/// Test: Extraction helpers `extract_slide`/`extract_all_text` unit-tested
+/// below; the HTTP calls are live-only.
 pub async fn get_slides(client: &BaseClient, args: Value) -> Result<Value> {
     let account = account_of(&args);
-    let id = require_str(&args, "presentation_id")?;
-    let url = format!("{SLIDES_API_BASE}/presentations/{id}");
-    client.get(&url, account).await
+    let action = opt_str(&args, "action").unwrap_or("get_presentation");
+    match action {
+        "list" => {
+            let url = drive_list_url(&args);
+            client.get(&url, account).await
+        }
+        "get_presentation" => {
+            let id = require_str(&args, "presentation_id")?;
+            let url = format!("{SLIDES_API_BASE}/presentations/{id}");
+            client.get(&url, account).await
+        }
+        "get_slide" => {
+            let id = require_str(&args, "presentation_id")?;
+            let index = args
+                .get("slide_index")
+                .and_then(|v| v.as_i64())
+                .ok_or_else(|| anyhow!("missing required field: slide_index"))?;
+            let index = usize::try_from(index)
+                .map_err(|_| anyhow!("slide_index must be a non-negative integer"))?;
+            let url = format!("{SLIDES_API_BASE}/presentations/{id}");
+            let presentation = client.get(&url, account).await?;
+            extract_slide(&presentation, index)
+        }
+        "get_text" => {
+            let id = require_str(&args, "presentation_id")?;
+            let url = format!("{SLIDES_API_BASE}/presentations/{id}");
+            let presentation = client.get(&url, account).await?;
+            Ok(extract_all_text(&presentation))
+        }
+        other => bail!("unknown action for get_slides: {other}"),
+    }
 }
 
-/// Why: Slide-level structural ops (add, delete, duplicate, reorder) share one tool.
-/// What: Routes per-action requests to the Slides v1 `presentations:batchUpdate` endpoint.
-/// Test: Live API.
+/// Why: Slide-level structural ops share one tool so an agent has a single
+/// mutation entry point for a deck.
+/// What: Routes `create_presentation`/`create_slide`/`delete_slide`/
+/// `update_text` to the Slides create or `presentations:batchUpdate` endpoint.
+/// Test: Request builders unit-tested below; HTTP is live-only.
 pub async fn manage_slides(client: &BaseClient, args: Value) -> Result<Value> {
     let action = require_str(&args, "action")?;
     let account = account_of(&args);
@@ -38,13 +97,9 @@ pub async fn manage_slides(client: &BaseClient, args: Value) -> Result<Value> {
         "create_slide" => {
             let id = require_str(&args, "presentation_id")?;
             let layout = opt_str(&args, "layout").unwrap_or("BLANK");
-            let body = json!({
-                "requests": [{
-                    "createSlide": {
-                        "slideLayoutReference": { "predefinedLayout": layout }
-                    }
-                }]
-            });
+            validate_layout(layout)?;
+            let insertion_index = args.get("insertion_index").and_then(|v| v.as_i64());
+            let body = create_slide_request(layout, insertion_index);
             let url = format!("{SLIDES_API_BASE}/presentations/{id}:batchUpdate");
             client.post(&url, body, account).await
         }
@@ -57,50 +112,268 @@ pub async fn manage_slides(client: &BaseClient, args: Value) -> Result<Value> {
             let url = format!("{SLIDES_API_BASE}/presentations/{id}:batchUpdate");
             client.post(&url, body, account).await
         }
+        "update_text" => {
+            let id = require_str(&args, "presentation_id")?;
+            let object_id = require_str(&args, "object_id")?;
+            // Allow an empty string so callers can clear an element's text.
+            let text = args
+                .get("text")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow!("missing required field: text"))?;
+            let body = update_text_request(object_id, text);
+            let url = format!("{SLIDES_API_BASE}/presentations/{id}:batchUpdate");
+            client.post(&url, body, account).await
+        }
         other => Err(anyhow!("unknown action for manage_slides: {other}")),
     }
 }
 
-/// Why: Adding text/shapes/images to a slide is the most common authoring op.
-/// What: Builds typed Slides batchUpdate requests (`createShape`, `insertText`, ...) per mode.
-/// Test: Live API.
-pub async fn add_slide_content(client: &BaseClient, args: Value) -> Result<Value> {
-    let account = account_of(&args);
-    let id = require_str(&args, "presentation_id")?;
-    let slide_id = require_str(&args, "slide_id")?;
-    let text = require_str(&args, "text")?;
-    let textbox_id = format!("textbox_{}", Uuid::new_v4().simple());
+/// Why: The `list` action needs a Drive `files.list` query scoped to Slides
+/// presentations; centralising the URL build keeps `get_slides` readable and
+/// testable.
+/// What: Builds a Drive query filtering to presentation MIME type (optionally
+/// `name contains <query>`), URL-encoded, with a bounded page size.
+/// Test: `drive_list_url_*` below.
+fn drive_list_url(args: &Value) -> String {
+    let mut q = "mimeType='application/vnd.google-apps.presentation' and trashed=false".to_string();
+    if let Some(name) = opt_str(args, "query") {
+        // Escape single quotes to stay inside the Drive query string literal.
+        q.push_str(&format!(
+            " and name contains '{}'",
+            name.replace('\'', "\\'")
+        ));
+    }
+    let max = args
+        .get("max_results")
+        .and_then(|v| v.as_u64())
+        .filter(|n| *n > 0)
+        .unwrap_or(20);
+    format!(
+        "{DRIVE_API_BASE}/files?q={}&pageSize={max}&fields=files(id,name,modifiedTime,owners(displayName,emailAddress))&supportsAllDrives=true&includeItemsFromAllDrives=true",
+        encode(&q)
+    )
+}
 
-    let body = json!({
-        "requests": [
-            {
-                "createShape": {
-                    "objectId": textbox_id,
-                    "shapeType": "TEXT_BOX",
-                    "elementProperties": {
-                        "pageObjectId": slide_id,
-                        "size": {
-                            "width": { "magnitude": 350, "unit": "PT" },
-                            "height": { "magnitude": 100, "unit": "PT" },
-                        },
-                        "transform": {
-                            "scaleX": 1,
-                            "scaleY": 1,
-                            "translateX": 50,
-                            "translateY": 50,
-                            "unit": "PT",
-                        }
-                    }
-                }
-            },
-            {
-                "insertText": {
-                    "objectId": textbox_id,
-                    "text": text,
-                }
-            }
-        ]
+/// Why: `create_slide` differs from Python parity by supporting an explicit
+/// `insertionIndex`; the request shape is worth isolating for a pure test.
+/// What: Builds the `createSlide` batchUpdate body, adding `insertionIndex`
+/// only when supplied.
+/// Test: `create_slide_request_*` below.
+pub(crate) fn create_slide_request(layout: &str, insertion_index: Option<i64>) -> Value {
+    let mut create_slide = json!({
+        "slideLayoutReference": { "predefinedLayout": layout }
     });
-    let url = format!("{SLIDES_API_BASE}/presentations/{id}:batchUpdate");
-    client.post(&url, body, account).await
+    if let Some(idx) = insertion_index {
+        create_slide["insertionIndex"] = json!(idx);
+    }
+    json!({ "requests": [{ "createSlide": create_slide }] })
+}
+
+/// Why: Replacing an element's text is a delete-then-insert on the Slides API;
+/// packaging both requests keeps the semantics ("set the text to X") atomic.
+/// What: Builds a batchUpdate body that clears the element's text range and
+/// inserts the new text at index 0.
+/// Test: `update_text_request_*` below.
+pub(crate) fn update_text_request(object_id: &str, text: &str) -> Value {
+    let mut requests = vec![json!({
+        "deleteText": { "objectId": object_id, "textRange": { "type": "ALL" } }
+    })];
+    if !text.is_empty() {
+        requests.push(json!({
+            "insertText": { "objectId": object_id, "insertionIndex": 0, "text": text }
+        }));
+    }
+    json!({ "requests": requests })
+}
+
+/// Why: Guard `create_slide` against layout strings the API would reject.
+/// What: Returns an error listing the valid set when `layout` is unknown.
+/// Test: `validate_layout_*` below.
+pub(crate) fn validate_layout(layout: &str) -> Result<()> {
+    if VALID_LAYOUTS.contains(&layout) {
+        Ok(())
+    } else {
+        bail!(
+            "invalid layout '{layout}'; valid layouts: {}",
+            VALID_LAYOUTS.join(", ")
+        )
+    }
+}
+
+/// Why: `get_slide` returns one slide's full element detail without forcing the
+/// caller to parse the whole deck.
+/// What: Indexes into `presentation.slides[index]`, returning the slide object
+/// with its index and objectId, or a range error.
+/// Test: `extract_slide_*` below.
+fn extract_slide(presentation: &Value, index: usize) -> Result<Value> {
+    let slides = presentation
+        .get("slides")
+        .and_then(|s| s.as_array())
+        .ok_or_else(|| anyhow!("presentation has no slides"))?;
+    let slide = slides
+        .get(index)
+        .ok_or_else(|| anyhow!("slide index {index} out of range (0..{})", slides.len()))?;
+    Ok(json!({
+        "slideIndex": index,
+        "objectId": slide.get("objectId"),
+        "slide": slide,
+    }))
+}
+
+/// Why: `get_text` extracts all rendered text so an agent can summarise or
+/// diff a deck without walking the Slides element tree itself.
+/// What: Collects every `textRun.content` per slide, returning per-slide text
+/// plus the concatenation.
+/// Test: `extract_all_text_*` below.
+fn extract_all_text(presentation: &Value) -> Value {
+    let mut per_slide = Vec::new();
+    let mut all = String::new();
+    if let Some(slides) = presentation.get("slides").and_then(|s| s.as_array()) {
+        for (i, slide) in slides.iter().enumerate() {
+            let mut parts = Vec::new();
+            collect_text(slide, &mut parts);
+            let text = parts.join("");
+            all.push_str(&text);
+            per_slide.push(json!({
+                "slideIndex": i,
+                "objectId": slide.get("objectId"),
+                "text": text,
+            }));
+        }
+    }
+    json!({ "text": all, "slides": per_slide })
+}
+
+/// Why: Slides nests text arbitrarily deep (shapes, tables, groups); a generic
+/// walk is shorter and more robust than mirroring the element schema.
+/// What: Recursively pushes every `textRun.content` string into `out`.
+/// Test: Exercised via `extract_all_text_*` below.
+fn collect_text(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(content) = map
+                .get("textRun")
+                .and_then(|r| r.get("content"))
+                .and_then(|c| c.as_str())
+            {
+                out.push(content.to_string());
+            }
+            for child in map.values() {
+                collect_text(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_text(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_layout_accepts_known() {
+        assert!(validate_layout("TITLE_AND_BODY").is_ok());
+        assert!(validate_layout("BLANK").is_ok());
+    }
+
+    #[test]
+    fn validate_layout_rejects_unknown() {
+        let err = validate_layout("FANCY").unwrap_err().to_string();
+        assert!(err.contains("invalid layout 'FANCY'"));
+        assert!(err.contains("TITLE_AND_BODY"));
+    }
+
+    #[test]
+    fn create_slide_request_without_index_omits_it() {
+        let body = create_slide_request("BLANK", None);
+        let cs = &body["requests"][0]["createSlide"];
+        assert_eq!(cs["slideLayoutReference"]["predefinedLayout"], "BLANK");
+        assert!(cs.get("insertionIndex").is_none());
+    }
+
+    #[test]
+    fn create_slide_request_with_index_sets_it() {
+        let body = create_slide_request("TITLE", Some(2));
+        assert_eq!(body["requests"][0]["createSlide"]["insertionIndex"], 2);
+    }
+
+    #[test]
+    fn update_text_request_deletes_then_inserts() {
+        let body = update_text_request("elem_1", "hello");
+        let reqs = body["requests"].as_array().unwrap();
+        assert_eq!(reqs.len(), 2);
+        assert_eq!(reqs[0]["deleteText"]["objectId"], "elem_1");
+        assert_eq!(reqs[0]["deleteText"]["textRange"]["type"], "ALL");
+        assert_eq!(reqs[1]["insertText"]["text"], "hello");
+        assert_eq!(reqs[1]["insertText"]["insertionIndex"], 0);
+    }
+
+    #[test]
+    fn update_text_request_empty_only_deletes() {
+        let body = update_text_request("elem_1", "");
+        assert_eq!(body["requests"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn drive_list_url_defaults() {
+        let url = drive_list_url(&json!({}));
+        assert!(url.contains("/files?q="));
+        assert!(url.contains("pageSize=20"));
+        // `.`/`-` are unreserved in our encoder, so the MIME slug stays literal.
+        assert!(url.contains("google-apps.presentation"));
+    }
+
+    #[test]
+    fn drive_list_url_applies_query_and_max() {
+        let url = drive_list_url(&json!({ "query": "Q3", "max_results": 5 }));
+        assert!(url.contains("pageSize=5"));
+        // "name contains 'Q3'" is encoded (space -> %20, quote -> %27).
+        assert!(url.contains("name%20contains"));
+        assert!(url.contains("Q3"));
+    }
+
+    #[test]
+    fn extract_slide_returns_indexed_slide() {
+        let pres = json!({
+            "slides": [
+                { "objectId": "s0" },
+                { "objectId": "s1", "pageElements": [{ "objectId": "e1" }] }
+            ]
+        });
+        let out = extract_slide(&pres, 1).unwrap();
+        assert_eq!(out["slideIndex"], 1);
+        assert_eq!(out["objectId"], "s1");
+        assert_eq!(out["slide"]["pageElements"][0]["objectId"], "e1");
+    }
+
+    #[test]
+    fn extract_slide_out_of_range_errors() {
+        let pres = json!({ "slides": [{ "objectId": "s0" }] });
+        let err = extract_slide(&pres, 5).unwrap_err().to_string();
+        assert!(err.contains("out of range"));
+    }
+
+    #[test]
+    fn extract_all_text_collects_runs() {
+        let pres = json!({
+            "slides": [{
+                "objectId": "s0",
+                "pageElements": [{
+                    "shape": { "text": { "textElements": [
+                        { "textRun": { "content": "Hello " } },
+                        { "textRun": { "content": "World" } }
+                    ] } }
+                }]
+            }]
+        });
+        let out = extract_all_text(&pres);
+        assert_eq!(out["text"], "Hello World");
+        assert_eq!(out["slides"][0]["text"], "Hello World");
+        assert_eq!(out["slides"][0]["slideIndex"], 0);
+    }
 }

--- a/crates/trusty-gworkspace/src/api/services/slides/core.rs
+++ b/crates/trusty-gworkspace/src/api/services/slides/core.rs
@@ -19,10 +19,11 @@ use crate::api::services::{account_of, opt_str, require_str};
 /// Valid `predefinedLayout` values accepted by `create_slide`.
 ///
 /// Why: The Slides API rejects unknown layout strings with an opaque 400;
-/// constraining the input to the known-good set (mirroring the Python
-/// upstream's 10 layouts) fails fast with an actionable message and lets the
+/// constraining the input to the known-good set (the full 11-value
+/// `PredefinedLayout` enum, matching the Python upstream's `content.py`
+/// `apply_layout` set) fails fast with an actionable message and lets the
 /// tool schema advertise the enum.
-/// What: The ten predefined Slides layouts exposed for slide creation.
+/// What: The eleven predefined Slides layouts exposed for slide creation.
 /// Test: `validate_layout_*` below.
 pub(crate) const VALID_LAYOUTS: &[&str] = &[
     "BLANK",
@@ -35,6 +36,7 @@ pub(crate) const VALID_LAYOUTS: &[&str] = &[
     "SECTION_TITLE_AND_DESCRIPTION",
     "ONE_COLUMN_TEXT",
     "MAIN_POINT",
+    "BIG_NUMBER",
 ];
 
 /// Why: Every Slides read starts here; the shape depends on how much detail the
@@ -65,13 +67,23 @@ pub async fn get_slides(client: &BaseClient, args: Value) -> Result<Value> {
                 .ok_or_else(|| anyhow!("missing required field: slide_index"))?;
             let index = usize::try_from(index)
                 .map_err(|_| anyhow!("slide_index must be a non-negative integer"))?;
-            let url = format!("{SLIDES_API_BASE}/presentations/{id}");
+            let url = format!(
+                "{SLIDES_API_BASE}/presentations/{id}?fields={}",
+                encode("slides(objectId,pageElements)")
+            );
             let presentation = client.get(&url, account).await?;
             extract_slide(&presentation, index)
         }
         "get_text" => {
             let id = require_str(&args, "presentation_id")?;
-            let url = format!("{SLIDES_API_BASE}/presentations/{id}");
+            // Note: deliberately not narrowed to `shape.text` only — `collect_text`
+            // walks generically so it also picks up table-cell text, which nests
+            // under `pageElements.table...`; narrowing further would silently
+            // drop that text.
+            let url = format!(
+                "{SLIDES_API_BASE}/presentations/{id}?fields={}",
+                encode("slides(objectId,pageElements)")
+            );
             let presentation = client.get(&url, account).await?;
             Ok(extract_all_text(&presentation))
         }

--- a/crates/trusty-gworkspace/src/api/services/slides/mod.rs
+++ b/crates/trusty-gworkspace/src/api/services/slides/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! Why: Slides API surface is small for agent workflows: read deck, create
 //! deck/slide, add content. We expose those three tools.
-//! What: Re-exports `core` sub-module.
+//! What: Re-exports `core` (fetch/search + structural ops) and `content`
+//! (typed content authoring) sub-modules.
 //! Test: Per-sub-module.
 
+pub mod content;
 pub mod core;

--- a/crates/trusty-gworkspace/src/server.rs
+++ b/crates/trusty-gworkspace/src/server.rs
@@ -143,7 +143,9 @@ pub async fn handle_tool_call(state: &AppState, name: &str, args: Value) -> Valu
         // Slides
         "get_slides" => services::slides::core::get_slides(&state.client, args).await,
         "manage_slides" => services::slides::core::manage_slides(&state.client, args).await,
-        "add_slide_content" => services::slides::core::add_slide_content(&state.client, args).await,
+        "add_slide_content" => {
+            services::slides::content::add_slide_content(&state.client, args).await
+        }
 
         // Tasks
         "manage_task_lists" => services::tasks::manage_task_lists(&state.client, args).await,

--- a/crates/trusty-gworkspace/src/tools/slides.rs
+++ b/crates/trusty-gworkspace/src/tools/slides.rs
@@ -1,8 +1,12 @@
 //! Google Slides tool definitions.
 //!
-//! Why: Groups presentation fetch, slide management, and content tools.
-//! What: Appends the Slides tool group to the shared registry vector.
+//! Why: Groups presentation fetch/search, slide management, and typed content
+//! authoring so the MCP tool schemas stay next to their siblings.
+//! What: Appends the Slides tool group to the shared registry vector, mirroring
+//! the action/type depth of the Python upstream.
 //! Test: Covered via `tool_list_response()` in `tools::tests`.
+
+use crate::api::services::slides::core::VALID_LAYOUTS;
 
 use super::schema::{account_schema, action_enum, tool};
 use serde_json::{Value, json};
@@ -10,37 +14,115 @@ use serde_json::{Value, json};
 /// Append the Slides tool group to the registry.
 ///
 /// Why: Keeps Slides-related tools colocated.
-/// What: Pushes the presentation get/manage and content tools.
+/// What: Pushes the presentation get/manage and content tools with their full
+/// action/type parameter sets.
 /// Test: Covered via `tool_list_response()` in `tools::tests`.
 pub(super) fn append(tools: &mut Vec<Value>) {
     tools.push(tool(
         "get_slides",
-        "Fetch a Google Slides presentation JSON.",
-        json!({ "account": account_schema(), "presentation_id": { "type": "string" } }),
-        &["presentation_id"],
+        "Read Google Slides: list presentations, fetch a whole deck, a single \
+         slide by index, or all text.",
+        json!({
+            "account": account_schema(),
+            "action": action_enum(&["list", "get_presentation", "get_slide", "get_text"]),
+            "presentation_id": {
+                "type": "string",
+                "description": "Presentation id (required for all actions except `list`).",
+            },
+            "slide_index": {
+                "type": "integer",
+                "description": "Zero-based slide index for the `get_slide` action.",
+            },
+            "query": {
+                "type": "string",
+                "description": "Name substring to filter by for the `list` action.",
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Max presentations to return for `list` (default 20).",
+            },
+        }),
+        &[],
     ));
     tools.push(tool(
         "manage_slides",
-        "Create a presentation or create/delete slides within one.",
+        "Create a presentation, create/delete a slide, or replace an element's text.",
         json!({
             "account": account_schema(),
-            "action": action_enum(&["create_presentation", "create_slide", "delete_slide"]),
+            "action": action_enum(&[
+                "create_presentation",
+                "create_slide",
+                "delete_slide",
+                "update_text",
+            ]),
             "presentation_id": { "type": "string" },
             "slide_id": { "type": "string" },
+            "object_id": {
+                "type": "string",
+                "description": "Target element id for `update_text`.",
+            },
             "title": { "type": "string" },
-            "layout": { "type": "string" },
+            "text": {
+                "type": "string",
+                "description": "Replacement text for `update_text`.",
+            },
+            "insertion_index": {
+                "type": "integer",
+                "description": "Zero-based position for a new slide (`create_slide`).",
+            },
+            "layout": {
+                "type": "string",
+                "description": "Predefined slide layout for `create_slide` (default BLANK).",
+                "enum": VALID_LAYOUTS,
+            },
         }),
         &["action"],
     ));
     tools.push(tool(
         "add_slide_content",
-        "Add a text box with the given text to a slide.",
+        "Add content to a slide: a plain or formatted text box, an image from a \
+         URL, or a new bulleted-list slide.",
         json!({
             "account": account_schema(),
+            "type": {
+                "type": "string",
+                "description": "Content kind to add (default text_box).",
+                "enum": ["text_box", "formatted_text_box", "image", "bulleted_list"],
+            },
             "presentation_id": { "type": "string" },
-            "slide_id": { "type": "string" },
-            "text": { "type": "string" },
+            "slide_id": {
+                "type": "string",
+                "description": "Target slide id (text_box/formatted_text_box/image).",
+            },
+            "text": {
+                "type": "string",
+                "description": "Text for a text box, or newline-delimited bullet items.",
+            },
+            "font_size": {
+                "type": "number",
+                "description": "Point size for `formatted_text_box`.",
+            },
+            "bold": { "type": "boolean" },
+            "italic": { "type": "boolean" },
+            "font_color": {
+                "type": "string",
+                "description": "Hex color `#RRGGBB` for `formatted_text_box`.",
+            },
+            "image_url": {
+                "type": "string",
+                "description": "Publicly fetchable image URL for `type=image`.",
+            },
+            "items": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Bullet lines for `type=bulleted_list`.",
+            },
+            "layout": {
+                "type": "string",
+                "description": "Layout for the new slide created by `bulleted_list` (default BLANK).",
+                "enum": VALID_LAYOUTS,
+            },
         }),
-        &["presentation_id", "slide_id", "text"],
+        &["presentation_id"],
     ));
 }


### PR DESCRIPTION
## Summary

Closes the Slides action/type depth gap between `crates/trusty-gworkspace` and the Python upstream (`server/services/slides/{core,content}.py`). The three tool **names** already matched on both sides, but the Rust implementations exposed only a small subset of the actions/types.

### `get_slides` — new `action` routing
- `list` — search Drive for presentations (`mimeType='…presentation'`, optional `query` name filter, bounded `max_results`).
- `get_presentation` — the existing full-deck fetch (now the explicit default; behaviour unchanged when `action` is omitted).
- `get_slide` — single slide by `slide_index` with full element detail.
- `get_text` — extract all rendered text (per-slide + combined) by walking `textRun.content`.

### `manage_slides` — new action + constraints
- `update_text` — replace an element's text (delete-then-insert on `object_id`).
- `insertion_index` — optional zero-based position for `create_slide`.
- `layout` — constrained to the 10 valid `predefinedLayout` values (schema `enum` + runtime `validate_layout`) instead of a free string.

### `add_slide_content` — new content `type`s
- `formatted_text_box` — `font_size` / `bold` / `italic` / `font_color` (hex→rgb) via `updateTextStyle` with a matching field mask.
- `image` — `createImage` from a URL.
- `bulleted_list` — new slide + text box + `createParagraphBullets`.
- `text_box` remains the default and preserves the prior plain-text-box behaviour.

## Structure
Content authoring moved to a new `content.rs` sub-module (mirrors the Python `core`/`content` split), keeping both files well under the 500-SLOC cap. Dispatch in `server.rs` and schemas in `tools/slides.rs` updated accordingly.

## Testing
**Deferred live verification:** no valid OAuth tokens are available in this environment, so the API round-trips were not exercised live. Instead every pure request/extraction builder (URL/query construction, batchUpdate request shapes, text/slide extraction, hex→rgb, layout/item validation) is unit-tested.

Gate (raw output in the PR thread / commit):
- `cargo build -p trusty-gworkspace` — Finished
- `cargo test -p trusty-gworkspace` — `56 passed; 0 failed; 0 ignored`
- `cargo clippy -p trusty-gworkspace --all-targets -- -D warnings` — Finished, zero warnings
- `cargo fmt -p trusty-gworkspace --check` — clean
- `bash scripts/check_line_cap.sh` — `10 allowlisted, 0 violations — OK`
- `cargo check --workspace` — Finished (only a pre-existing unrelated `proc-macro-error2` future-incompat warning)

Part of #2626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)