### PR TITLE
feat(trusty-gworkspace): Sheets create_chart + structured format_sheet actions (parity)

### DIFF
--- a/crates/trusty-gworkspace/src/api/services/sheets/charts.rs
+++ b/crates/trusty-gworkspace/src/api/services/sheets/charts.rs
@@ -1,0 +1,288 @@
+//! Sheets chart creation (`addChart` batchUpdate).
+//!
+//! Why: Charts are a first-class Sheets deliverable in agent workflows, yet the
+//! raw `addChart` request shape (nested chart spec + grid-range sources +
+//! domain/series split) is fiddly to hand-write. Mirroring the Python
+//! `services/sheets/core.create_chart` surface lets callers ask for a
+//! bar/column/line/area/pie chart over a data grid without knowing the API.
+//! What: `create_chart` builds an `addChart` batchUpdate request from a source
+//! `GridRange` (first column = domain, remaining columns = series) and POSTs it.
+//! Test: `#[cfg(test)]` module below covers request construction for basic and
+//! pie charts, header handling, axis titles, and overlay vs new-sheet position.
+
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+
+use crate::api::client::BaseClient;
+use crate::api::constants::SHEETS_API_BASE;
+use crate::api::services::{account_of, opt_str, require_str};
+
+/// Why: Callers pass friendly chart-type names; the API wants a fixed enum and
+/// a basic-vs-pie distinction that selects a different spec key.
+/// What: Case-insensitively maps a name to `(chartType, is_pie)`.
+/// Test: `chart_type_maps` below.
+fn normalize_chart_type(s: &str) -> Result<(&'static str, bool)> {
+    match s.to_ascii_lowercase().as_str() {
+        "column" | "col" => Ok(("COLUMN", false)),
+        "bar" => Ok(("BAR", false)),
+        "line" => Ok(("LINE", false)),
+        "area" => Ok(("AREA", false)),
+        "scatter" => Ok(("SCATTER", false)),
+        "pie" => Ok(("PIE", true)),
+        other => Err(anyhow!(
+            "unknown chart_type '{other}' (expected bar|column|line|area|scatter|pie)"
+        )),
+    }
+}
+
+/// Why: Every domain/series source references a single-column `GridRange`.
+/// What: Builds the half-open, 0-based `GridRange` object for one column band.
+/// Test: Exercised via `basic_chart_request_shape` below.
+fn grid_range(sheet_id: i64, sr: i64, er: i64, sc: i64, ec: i64) -> Value {
+    json!({
+        "sheetId": sheet_id,
+        "startRowIndex": sr,
+        "endRowIndex": er,
+        "startColumnIndex": sc,
+        "endColumnIndex": ec,
+    })
+}
+
+/// Why: Extract a required integer field with a precise error message.
+/// What: Reads `key` as an i64, erroring if absent/non-integer.
+/// Test: Error path covered by `missing_source_field_errors` below.
+fn require_i64(args: &Value, key: &str) -> Result<i64> {
+    args.get(key)
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow!("missing required integer field: {key}"))
+}
+
+/// Why: Isolating the pure request builder makes the `addChart` shape unit
+/// testable without a live client or network.
+/// What: Builds the full `{"requests":[{"addChart":…}]}` batchUpdate body from
+/// the tool arguments; first data column is the domain, the rest are series.
+/// Test: `basic_chart_request_shape`, `pie_chart_request_shape`,
+/// `no_headers_sets_zero_header_count`, `overlay_position_when_not_new_sheet`.
+fn build_chart_request(args: &Value) -> Result<Value> {
+    let (chart_type, is_pie) = normalize_chart_type(require_str(args, "chart_type")?)?;
+    let source_sheet = require_i64(args, "source_sheet_id")?;
+    let sr = require_i64(args, "start_row_index")?;
+    let er = require_i64(args, "end_row_index")?;
+    let sc = require_i64(args, "start_column_index")?;
+    let ec = require_i64(args, "end_column_index")?;
+    if ec <= sc {
+        return Err(anyhow!(
+            "end_column_index ({ec}) must be greater than start_column_index ({sc})"
+        ));
+    }
+
+    // First column is the domain; each remaining column is one series.
+    let domain_source = json!({
+        "sourceRange": { "sources": [grid_range(source_sheet, sr, er, sc, sc + 1)] }
+    });
+    let series: Vec<Value> = (sc + 1..ec)
+        .map(|col| {
+            json!({
+                "series": { "sourceRange": { "sources": [grid_range(source_sheet, sr, er, col, col + 1)] } }
+            })
+        })
+        .collect();
+
+    let has_headers = args
+        .get("has_headers")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let header_count = if has_headers { 1 } else { 0 };
+    let legend = opt_str(args, "legend_position").unwrap_or("BOTTOM_LEGEND");
+
+    let mut spec = json!({});
+    if let Some(title) = opt_str(args, "title") {
+        spec["title"] = json!(title);
+    }
+
+    if is_pie {
+        let first_series = series
+            .first()
+            .cloned()
+            .ok_or_else(|| anyhow!("pie chart needs at least two columns (labels + values)"))?;
+        spec["pieChart"] = json!({
+            "legendPosition": legend,
+            "domain": domain_source,
+            "series": first_series["series"].clone(),
+        });
+    } else {
+        let mut axis = Vec::<Value>::new();
+        if let Some(t) = opt_str(args, "x_axis_title") {
+            axis.push(json!({ "position": "BOTTOM_AXIS", "title": t }));
+        }
+        if let Some(t) = opt_str(args, "y_axis_title") {
+            axis.push(json!({ "position": "LEFT_AXIS", "title": t }));
+        }
+        let mut basic = json!({
+            "chartType": chart_type,
+            "legendPosition": legend,
+            "headerCount": header_count,
+            "domains": [{ "domain": domain_source }],
+            "series": series,
+        });
+        if !axis.is_empty() {
+            basic["axis"] = json!(axis);
+        }
+        spec["basicChart"] = basic;
+    }
+
+    // Position: default a new sheet; otherwise overlay on an anchor cell.
+    let new_sheet = args
+        .get("new_sheet")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let position = if new_sheet {
+        json!({ "newSheet": true })
+    } else {
+        let anchor_sheet = args
+            .get("position_sheet_id")
+            .and_then(Value::as_i64)
+            .unwrap_or(source_sheet);
+        let anchor_row = args.get("anchor_row").and_then(Value::as_i64).unwrap_or(0);
+        let anchor_col = args
+            .get("anchor_column")
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+        json!({
+            "overlayPosition": {
+                "anchorCell": {
+                    "sheetId": anchor_sheet,
+                    "rowIndex": anchor_row,
+                    "columnIndex": anchor_col,
+                }
+            }
+        })
+    };
+
+    Ok(json!({
+        "requests": [{
+            "addChart": { "chart": { "spec": spec, "position": position } }
+        }]
+    }))
+}
+
+/// Why: Charts round out the Sheets tool surface at parity with the Python
+/// upstream; agents can visualise a data range in one call.
+/// What: Builds the `addChart` batchUpdate body and POSTs it to the spreadsheet.
+/// Test: Body construction covered by the `#[cfg(test)]` module; the POST leg is
+/// live-only.
+pub async fn create_chart(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "spreadsheet_id")?;
+    let body = build_chart_request(&args)?;
+    let url = format!("{SHEETS_API_BASE}/spreadsheets/{id}:batchUpdate");
+    client.post(&url, body, account).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_args(chart_type: &str) -> Value {
+        json!({
+            "spreadsheet_id": "SS",
+            "chart_type": chart_type,
+            "source_sheet_id": 0,
+            "start_row_index": 0,
+            "end_row_index": 5,
+            "start_column_index": 0,
+            "end_column_index": 3,
+        })
+    }
+
+    #[test]
+    fn chart_type_maps() {
+        assert_eq!(normalize_chart_type("Column").unwrap(), ("COLUMN", false));
+        assert_eq!(normalize_chart_type("PIE").unwrap(), ("PIE", true));
+        assert_eq!(normalize_chart_type("area").unwrap(), ("AREA", false));
+        assert!(normalize_chart_type("donut").is_err());
+    }
+
+    #[test]
+    fn basic_chart_request_shape() {
+        let mut args = base_args("column");
+        args["title"] = json!("Sales");
+        args["x_axis_title"] = json!("Month");
+        args["y_axis_title"] = json!("Revenue");
+        let body = build_chart_request(&args).unwrap();
+        let spec = &body["requests"][0]["addChart"]["chart"]["spec"];
+        assert_eq!(spec["title"], "Sales");
+        let basic = &spec["basicChart"];
+        assert_eq!(basic["chartType"], "COLUMN");
+        assert_eq!(basic["headerCount"], 1);
+        // Domain = column 0; series = columns 1 and 2 (two series).
+        assert_eq!(basic["series"].as_array().unwrap().len(), 2);
+        let domain_src = &basic["domains"][0]["domain"]["sourceRange"]["sources"][0];
+        assert_eq!(domain_src["startColumnIndex"], 0);
+        assert_eq!(domain_src["endColumnIndex"], 1);
+        let s1 = &basic["series"][0]["series"]["sourceRange"]["sources"][0];
+        assert_eq!(s1["startColumnIndex"], 1);
+        assert_eq!(s1["endColumnIndex"], 2);
+        assert_eq!(basic["axis"].as_array().unwrap().len(), 2);
+        // Default position is a new sheet.
+        assert_eq!(
+            body["requests"][0]["addChart"]["chart"]["position"]["newSheet"],
+            true
+        );
+    }
+
+    #[test]
+    fn pie_chart_request_shape() {
+        let body = build_chart_request(&base_args("pie")).unwrap();
+        let spec = &body["requests"][0]["addChart"]["chart"]["spec"];
+        assert!(spec.get("basicChart").is_none());
+        let pie = &spec["pieChart"];
+        assert_eq!(pie["legendPosition"], "BOTTOM_LEGEND");
+        // Pie domain = column 0, series = first value column (column 1).
+        let dom = &pie["domain"]["sourceRange"]["sources"][0];
+        assert_eq!(dom["startColumnIndex"], 0);
+        let ser = &pie["series"]["sourceRange"]["sources"][0];
+        assert_eq!(ser["startColumnIndex"], 1);
+        assert_eq!(ser["endColumnIndex"], 2);
+    }
+
+    #[test]
+    fn no_headers_sets_zero_header_count() {
+        let mut args = base_args("bar");
+        args["has_headers"] = json!(false);
+        let body = build_chart_request(&args).unwrap();
+        assert_eq!(
+            body["requests"][0]["addChart"]["chart"]["spec"]["basicChart"]["headerCount"],
+            0
+        );
+    }
+
+    #[test]
+    fn overlay_position_when_not_new_sheet() {
+        let mut args = base_args("line");
+        args["new_sheet"] = json!(false);
+        args["position_sheet_id"] = json!(7);
+        args["anchor_row"] = json!(2);
+        args["anchor_column"] = json!(4);
+        let body = build_chart_request(&args).unwrap();
+        let anchor =
+            &body["requests"][0]["addChart"]["chart"]["position"]["overlayPosition"]["anchorCell"];
+        assert_eq!(anchor["sheetId"], 7);
+        assert_eq!(anchor["rowIndex"], 2);
+        assert_eq!(anchor["columnIndex"], 4);
+    }
+
+    #[test]
+    fn missing_source_field_errors() {
+        let mut args = base_args("column");
+        args.as_object_mut().unwrap().remove("end_row_index");
+        assert!(build_chart_request(&args).is_err());
+    }
+
+    #[test]
+    fn empty_column_span_errors() {
+        let mut args = base_args("column");
+        args["end_column_index"] = json!(0);
+        assert!(build_chart_request(&args).is_err());
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/sheets/charts.rs
+++ b/crates/trusty-gworkspace/src/api/services/sheets/charts.rs
@@ -61,8 +61,13 @@ fn require_i64(args: &Value, key: &str) -> Result<i64> {
 /// testable without a live client or network.
 /// What: Builds the full `{"requests":[{"addChart":…}]}` batchUpdate body from
 /// the tool arguments; first data column is the domain, the rest are series.
+/// `PieChartSpec` has no `headerCount` field (unlike `BasicChartSpec`), so for
+/// pie charts the header row is excluded by bumping the effective start row
+/// instead of relying on the API to skip it.
 /// Test: `basic_chart_request_shape`, `pie_chart_request_shape`,
-/// `no_headers_sets_zero_header_count`, `overlay_position_when_not_new_sheet`.
+/// `pie_domain_and_series_offset_when_headers_present`,
+/// `pie_domain_not_offset_when_no_headers`, `no_headers_sets_zero_header_count`,
+/// `overlay_position_when_not_new_sheet`, `column_chart_missing_series_errors`.
 fn build_chart_request(args: &Value) -> Result<Value> {
     let (chart_type, is_pie) = normalize_chart_type(require_str(args, "chart_type")?)?;
     let source_sheet = require_i64(args, "source_sheet_id")?;
@@ -75,24 +80,43 @@ fn build_chart_request(args: &Value) -> Result<Value> {
             "end_column_index ({ec}) must be greater than start_column_index ({sc})"
         ));
     }
-
-    // First column is the domain; each remaining column is one series.
-    let domain_source = json!({
-        "sourceRange": { "sources": [grid_range(source_sheet, sr, er, sc, sc + 1)] }
-    });
-    let series: Vec<Value> = (sc + 1..ec)
-        .map(|col| {
-            json!({
-                "series": { "sourceRange": { "sources": [grid_range(source_sheet, sr, er, col, col + 1)] } }
-            })
-        })
-        .collect();
+    // Need at least one domain column plus one series column.
+    if ec - sc < 2 {
+        return Err(anyhow!(
+            "chart source range needs at least 2 columns (1 domain + >=1 series), got {}",
+            ec - sc
+        ));
+    }
 
     let has_headers = args
         .get("has_headers")
         .and_then(Value::as_bool)
         .unwrap_or(true);
     let header_count = if has_headers { 1 } else { 0 };
+
+    // BasicChartSpec has a headerCount field so the API skips the header row
+    // itself; PieChartSpec does not, so pie ranges must exclude it manually or
+    // the header label shows up as a bogus extra slice.
+    let pie_sr = sr + header_count;
+    if is_pie && pie_sr >= er {
+        return Err(anyhow!(
+            "chart source range has no data rows left after excluding the header row"
+        ));
+    }
+    let effective_sr = if is_pie { pie_sr } else { sr };
+
+    // First column is the domain; each remaining column is one series.
+    let domain_source = json!({
+        "sourceRange": { "sources": [grid_range(source_sheet, effective_sr, er, sc, sc + 1)] }
+    });
+    let series: Vec<Value> = (sc + 1..ec)
+        .map(|col| {
+            json!({
+                "series": { "sourceRange": { "sources": [grid_range(source_sheet, effective_sr, er, col, col + 1)] } }
+            })
+        })
+        .collect();
+
     let legend = opt_str(args, "legend_position").unwrap_or("BOTTOM_LEGEND");
 
     let mut spec = json!({});
@@ -101,10 +125,12 @@ fn build_chart_request(args: &Value) -> Result<Value> {
     }
 
     if is_pie {
+        // Guaranteed non-empty by the `ec - sc < 2` check above; the
+        // `ok_or_else` is a defensive invariant, not a reachable error path.
         let first_series = series
             .first()
             .cloned()
-            .ok_or_else(|| anyhow!("pie chart needs at least two columns (labels + values)"))?;
+            .ok_or_else(|| anyhow!("pie chart needs at least one series column"))?;
         spec["pieChart"] = json!({
             "legendPosition": legend,
             "domain": domain_source,
@@ -247,6 +273,39 @@ mod tests {
     }
 
     #[test]
+    fn pie_domain_and_series_offset_when_headers_present() {
+        // has_headers defaults to true; the header row (row 0) must be
+        // excluded from both the pie domain and series ranges, or the header
+        // label shows up as a bogus extra slice.
+        let body = build_chart_request(&base_args("pie")).unwrap();
+        let spec = &body["requests"][0]["addChart"]["chart"]["spec"];
+        let dom = &spec["pieChart"]["domain"]["sourceRange"]["sources"][0];
+        assert_eq!(dom["startRowIndex"], 1);
+        let ser = &spec["pieChart"]["series"]["sourceRange"]["sources"][0];
+        assert_eq!(ser["startRowIndex"], 1);
+    }
+
+    #[test]
+    fn pie_domain_not_offset_when_no_headers() {
+        let mut args = base_args("pie");
+        args["has_headers"] = json!(false);
+        let body = build_chart_request(&args).unwrap();
+        let spec = &body["requests"][0]["addChart"]["chart"]["spec"];
+        let dom = &spec["pieChart"]["domain"]["sourceRange"]["sources"][0];
+        assert_eq!(dom["startRowIndex"], 0);
+        let ser = &spec["pieChart"]["series"]["sourceRange"]["sources"][0];
+        assert_eq!(ser["startRowIndex"], 0);
+    }
+
+    #[test]
+    fn pie_all_rows_consumed_by_header_errors() {
+        let mut args = base_args("pie");
+        args["start_row_index"] = json!(4);
+        args["end_row_index"] = json!(5); // single row, which is the header
+        assert!(build_chart_request(&args).is_err());
+    }
+
+    #[test]
     fn no_headers_sets_zero_header_count() {
         let mut args = base_args("bar");
         args["has_headers"] = json!(false);
@@ -283,6 +342,16 @@ mod tests {
     fn empty_column_span_errors() {
         let mut args = base_args("column");
         args["end_column_index"] = json!(0);
+        assert!(build_chart_request(&args).is_err());
+    }
+
+    #[test]
+    fn column_chart_missing_series_errors() {
+        // Domain-only range (end_col == start_col + 1) leaves zero series
+        // columns for a non-pie chart too — must be rejected locally rather
+        // than sent to the API with an empty `series: []`.
+        let mut args = base_args("column");
+        args["end_column_index"] = json!(1);
         assert!(build_chart_request(&args).is_err());
     }
 }

--- a/crates/trusty-gworkspace/src/api/services/sheets/core.rs
+++ b/crates/trusty-gworkspace/src/api/services/sheets/core.rs
@@ -1,8 +1,8 @@
 //! Sheets v4 core operations.
 //!
-//! Why: Get spreadsheet metadata; create spreadsheets; read/write cell
-//! values; apply formatting via batchUpdate.
-//! What: Four tool functions matching the Python service surface.
+//! Why: Get spreadsheet metadata; create spreadsheets; read/write cell values.
+//! What: Three tool functions matching the Python service surface (formatting
+//! and charts live in sibling `formatting`/`charts` modules).
 //! Test: Live only.
 
 use anyhow::{Result, anyhow};
@@ -115,19 +115,4 @@ pub async fn modify_sheet_values(client: &BaseClient, args: Value) -> Result<Val
         }
         other => Err(anyhow!("unknown action for modify_sheet_values: {other}")),
     }
-}
-
-/// Why: Cell formatting (bold, colours, number format) is a batchUpdate surface.
-/// What: Builds a `repeatCell` request from the supplied style fields and POSTs batchUpdate.
-/// Test: Live API.
-pub async fn format_sheet(client: &BaseClient, args: Value) -> Result<Value> {
-    let account = account_of(&args);
-    let id = require_str(&args, "spreadsheet_id")?;
-    let requests = args
-        .get("requests")
-        .cloned()
-        .ok_or_else(|| anyhow!("missing 'requests' array (sheets batchUpdate requests)"))?;
-    let body = json!({ "requests": requests });
-    let url = format!("{SHEETS_API_BASE}/spreadsheets/{id}:batchUpdate");
-    client.post(&url, body, account).await
 }

--- a/crates/trusty-gworkspace/src/api/services/sheets/formatting.rs
+++ b/crates/trusty-gworkspace/src/api/services/sheets/formatting.rs
@@ -1,0 +1,345 @@
+//! Structured Sheets formatting (`format_sheet`).
+//!
+//! Why: The raw batchUpdate `requests` passthrough is powerful but forces the
+//! caller to hand-author deeply nested Sheets JSON. Mirroring the Python
+//! `services/sheets/formatting` surface, this module adds discrete,
+//! schema-guided actions (`format_cells`, `set_number_format`, `merge`,
+//! `set_column_width`) that build the correct request + field mask from a few
+//! typed params — while keeping `raw` as an escape hatch so nothing regresses.
+//! What: `format_sheet` dispatches on `action`, builds the batchUpdate
+//! `requests` array via a pure per-action builder, and POSTs it.
+//! Test: `#[cfg(test)]` module covers each action's request/field-mask shape and
+//! the raw passthrough.
+
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+
+use crate::api::client::BaseClient;
+use crate::api::constants::SHEETS_API_BASE;
+use crate::api::services::{account_of, opt_str, require_str};
+
+/// Why: Every cell-scoped action targets a half-open, 0-based `GridRange`.
+/// What: Builds the `GridRange` from `sheet_id` (required) plus optional
+/// start/end row/column indices (absent bounds mean "unbounded" per the API).
+/// Test: `grid_range_includes_only_present_bounds` below.
+fn parse_grid_range(args: &Value) -> Result<Value> {
+    let sheet_id = args
+        .get("sheet_id")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow!("missing required integer field: sheet_id"))?;
+    let mut range = json!({ "sheetId": sheet_id });
+    for (arg_key, api_key) in [
+        ("start_row_index", "startRowIndex"),
+        ("end_row_index", "endRowIndex"),
+        ("start_column_index", "startColumnIndex"),
+        ("end_column_index", "endColumnIndex"),
+    ] {
+        if let Some(v) = args.get(arg_key).and_then(Value::as_i64) {
+            range[api_key] = json!(v);
+        }
+    }
+    Ok(range)
+}
+
+/// Why: Colours arrive either as an RGB(A) array or a `{red,green,blue,alpha}`
+/// object; the API always wants the object form with 0.0–1.0 channels.
+/// What: Normalises an array `[r,g,b(,a)]` to the object form, or passes an
+/// object through unchanged.
+/// Test: `color_array_normalises` below.
+fn parse_color(v: &Value) -> Option<Value> {
+    if v.is_object() {
+        return Some(v.clone());
+    }
+    let arr = v.as_array()?;
+    let ch = |i: usize| arr.get(i).and_then(Value::as_f64).unwrap_or(0.0);
+    let mut color = json!({ "red": ch(0), "green": ch(1), "blue": ch(2) });
+    if let Some(a) = arr.get(3).and_then(Value::as_f64) {
+        color["alpha"] = json!(a);
+    }
+    Some(color)
+}
+
+/// Why: `repeatCell` for cell styling needs both a `userEnteredFormat` object
+/// and a precise field mask listing exactly the subfields set, or unset fields
+/// get clobbered.
+/// What: Builds the `format_cells` request from bold/italic/font_size/colours/
+/// alignment/wrap params, emitting only the touched field paths.
+/// Test: `format_cells_field_mask_is_precise` below.
+fn build_format_cells(args: &Value) -> Result<Vec<Value>> {
+    let range = parse_grid_range(args)?;
+    let mut text_format = json!({});
+    let mut fields = Vec::<String>::new();
+
+    if let Some(b) = args.get("bold").and_then(Value::as_bool) {
+        text_format["bold"] = json!(b);
+        fields.push("userEnteredFormat.textFormat.bold".into());
+    }
+    if let Some(i) = args.get("italic").and_then(Value::as_bool) {
+        text_format["italic"] = json!(i);
+        fields.push("userEnteredFormat.textFormat.italic".into());
+    }
+    if let Some(s) = args.get("font_size").and_then(Value::as_f64) {
+        text_format["fontSize"] = json!(s);
+        fields.push("userEnteredFormat.textFormat.fontSize".into());
+    }
+    if let Some(c) = args.get("text_color").and_then(parse_color) {
+        text_format["foregroundColor"] = c;
+        fields.push("userEnteredFormat.textFormat.foregroundColor".into());
+    }
+
+    let mut cell_format = json!({});
+    if text_format.as_object().is_some_and(|o| !o.is_empty()) {
+        cell_format["textFormat"] = text_format;
+    }
+    if let Some(c) = args.get("background_color").and_then(parse_color) {
+        cell_format["backgroundColor"] = c;
+        fields.push("userEnteredFormat.backgroundColor".into());
+    }
+    if let Some(a) = opt_str(args, "horizontal_alignment") {
+        cell_format["horizontalAlignment"] = json!(a);
+        fields.push("userEnteredFormat.horizontalAlignment".into());
+    }
+    if let Some(a) = opt_str(args, "vertical_alignment") {
+        cell_format["verticalAlignment"] = json!(a);
+        fields.push("userEnteredFormat.verticalAlignment".into());
+    }
+    if let Some(w) = opt_str(args, "wrap_strategy") {
+        cell_format["wrapStrategy"] = json!(w);
+        fields.push("userEnteredFormat.wrapStrategy".into());
+    }
+
+    if fields.is_empty() {
+        return Err(anyhow!(
+            "format_cells requires at least one style field (bold, italic, font_size, text_color, background_color, horizontal_alignment, vertical_alignment, wrap_strategy)"
+        ));
+    }
+    Ok(vec![json!({
+        "repeatCell": {
+            "range": range,
+            "cell": { "userEnteredFormat": cell_format },
+            "fields": fields.join(","),
+        }
+    })])
+}
+
+/// Why: Number/date/currency display formats are a distinct, common styling
+/// need with a small typed surface (type enum + optional pattern).
+/// What: Builds a `repeatCell` request that sets `numberFormat`.
+/// Test: `number_format_request_shape` below.
+fn build_number_format(args: &Value) -> Result<Vec<Value>> {
+    let range = parse_grid_range(args)?;
+    let fmt_type = require_str(args, "number_format_type")?;
+    let mut number_format = json!({ "type": fmt_type });
+    if let Some(pattern) = opt_str(args, "pattern") {
+        number_format["pattern"] = json!(pattern);
+    }
+    Ok(vec![json!({
+        "repeatCell": {
+            "range": range,
+            "cell": { "userEnteredFormat": { "numberFormat": number_format } },
+            "fields": "userEnteredFormat.numberFormat",
+        }
+    })])
+}
+
+/// Why: Merging a header banner or label block is a one-line intent that the
+/// raw API expresses as `mergeCells` with a merge-type enum.
+/// What: Builds a `mergeCells` request (default `MERGE_ALL`).
+/// Test: `merge_request_shape` below.
+fn build_merge(args: &Value) -> Result<Vec<Value>> {
+    let range = parse_grid_range(args)?;
+    let merge_type = opt_str(args, "merge_type").unwrap_or("MERGE_ALL");
+    Ok(vec![json!({
+        "mergeCells": { "range": range, "mergeType": merge_type }
+    })])
+}
+
+/// Why: Auto-fit is unavailable via the values API; explicit pixel widths are
+/// the reliable way to size columns (or, via `dimension`, rows).
+/// What: Builds an `updateDimensionProperties` request setting `pixelSize`.
+/// Test: `column_width_request_shape` below.
+fn build_column_width(args: &Value) -> Result<Vec<Value>> {
+    let sheet_id = args
+        .get("sheet_id")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow!("missing required integer field: sheet_id"))?;
+    let start = args
+        .get("start_index")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow!("missing required integer field: start_index"))?;
+    let end = args
+        .get("end_index")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow!("missing required integer field: end_index"))?;
+    let pixel_size = args
+        .get("pixel_size")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow!("missing required integer field: pixel_size"))?;
+    let dimension = opt_str(args, "dimension").unwrap_or("COLUMNS");
+    Ok(vec![json!({
+        "updateDimensionProperties": {
+            "range": {
+                "sheetId": sheet_id,
+                "dimension": dimension,
+                "startIndex": start,
+                "endIndex": end,
+            },
+            "properties": { "pixelSize": pixel_size },
+            "fields": "pixelSize",
+        }
+    })])
+}
+
+/// Why: One pure dispatcher keeps `format_sheet`'s async wrapper trivial and the
+/// per-action logic unit-testable without a client.
+/// What: Maps `action` to the matching request builder; `raw` returns the
+/// caller-supplied `requests` passthrough unchanged.
+/// Test: Every branch is covered by the `#[cfg(test)]` module.
+fn build_format_requests(action: &str, args: &Value) -> Result<Vec<Value>> {
+    match action {
+        "format_cells" => build_format_cells(args),
+        "set_number_format" => build_number_format(args),
+        "merge" => build_merge(args),
+        "set_column_width" => build_column_width(args),
+        "raw" => {
+            let requests = args
+                .get("requests")
+                .and_then(Value::as_array)
+                .cloned()
+                .ok_or_else(|| anyhow!("action 'raw' requires a 'requests' array"))?;
+            Ok(requests)
+        }
+        other => Err(anyhow!("unknown action for format_sheet: {other}")),
+    }
+}
+
+/// Why: Cell formatting is a batchUpdate surface; discrete typed actions cover
+/// the common cases while `raw` remains a full-power escape hatch.
+/// What: Dispatches on `action` (defaulting to `raw` when a `requests` array is
+/// supplied without an explicit action, preserving the prior contract), builds
+/// the `requests`, and POSTs a single batchUpdate.
+/// Test: Body building via the `#[cfg(test)]` module; the POST leg is live-only.
+pub async fn format_sheet(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "spreadsheet_id")?;
+    // Back-compat: a bare `requests` array with no `action` means `raw`.
+    let action = opt_str(&args, "action").unwrap_or(if args.get("requests").is_some() {
+        "raw"
+    } else {
+        ""
+    });
+    let requests = build_format_requests(action, &args)?;
+    let body = json!({ "requests": requests });
+    let url = format!("{SHEETS_API_BASE}/spreadsheets/{id}:batchUpdate");
+    client.post(&url, body, account).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grid_range_includes_only_present_bounds() {
+        let args = json!({ "sheet_id": 3, "start_row_index": 1, "end_column_index": 4 });
+        let r = parse_grid_range(&args).unwrap();
+        assert_eq!(r["sheetId"], 3);
+        assert_eq!(r["startRowIndex"], 1);
+        assert_eq!(r["endColumnIndex"], 4);
+        assert!(r.get("endRowIndex").is_none());
+        assert!(parse_grid_range(&json!({})).is_err());
+    }
+
+    #[test]
+    fn color_array_normalises() {
+        let c = parse_color(&json!([1.0, 0.5, 0.0, 0.8])).unwrap();
+        assert_eq!(c["red"], 1.0);
+        assert_eq!(c["green"], 0.5);
+        assert_eq!(c["blue"], 0.0);
+        assert_eq!(c["alpha"], 0.8);
+        // Object form passes through.
+        let obj = parse_color(&json!({ "red": 0.2 })).unwrap();
+        assert_eq!(obj["red"], 0.2);
+    }
+
+    #[test]
+    fn format_cells_field_mask_is_precise() {
+        let args = json!({
+            "sheet_id": 0,
+            "start_row_index": 0, "end_row_index": 1,
+            "bold": true,
+            "background_color": [0.9, 0.9, 0.9],
+            "horizontal_alignment": "CENTER",
+        });
+        let reqs = build_format_cells(&args).unwrap();
+        let req = &reqs[0]["repeatCell"];
+        let cf = &req["cell"]["userEnteredFormat"];
+        assert_eq!(cf["textFormat"]["bold"], true);
+        assert_eq!(cf["backgroundColor"]["red"], 0.9);
+        assert_eq!(cf["horizontalAlignment"], "CENTER");
+        let mask = req["fields"].as_str().unwrap();
+        assert!(mask.contains("userEnteredFormat.textFormat.bold"));
+        assert!(mask.contains("userEnteredFormat.backgroundColor"));
+        assert!(mask.contains("userEnteredFormat.horizontalAlignment"));
+        // Untouched subfields are absent from the mask.
+        assert!(!mask.contains("italic"));
+        assert!(!mask.contains("verticalAlignment"));
+    }
+
+    #[test]
+    fn format_cells_requires_a_field() {
+        assert!(build_format_cells(&json!({ "sheet_id": 0 })).is_err());
+    }
+
+    #[test]
+    fn number_format_request_shape() {
+        let args = json!({
+            "sheet_id": 0,
+            "number_format_type": "CURRENCY",
+            "pattern": "$#,##0.00",
+        });
+        let reqs = build_number_format(&args).unwrap();
+        let nf = &reqs[0]["repeatCell"]["cell"]["userEnteredFormat"]["numberFormat"];
+        assert_eq!(nf["type"], "CURRENCY");
+        assert_eq!(nf["pattern"], "$#,##0.00");
+        assert_eq!(
+            reqs[0]["repeatCell"]["fields"],
+            "userEnteredFormat.numberFormat"
+        );
+    }
+
+    #[test]
+    fn merge_request_shape() {
+        let reqs = build_merge(&json!({ "sheet_id": 0, "end_column_index": 3 })).unwrap();
+        assert_eq!(reqs[0]["mergeCells"]["mergeType"], "MERGE_ALL");
+        let reqs2 = build_merge(&json!({ "sheet_id": 0, "merge_type": "MERGE_COLUMNS" })).unwrap();
+        assert_eq!(reqs2[0]["mergeCells"]["mergeType"], "MERGE_COLUMNS");
+    }
+
+    #[test]
+    fn column_width_request_shape() {
+        let args = json!({
+            "sheet_id": 2,
+            "start_index": 0, "end_index": 2,
+            "pixel_size": 160,
+        });
+        let reqs = build_column_width(&args).unwrap();
+        let req = &reqs[0]["updateDimensionProperties"];
+        assert_eq!(req["range"]["dimension"], "COLUMNS");
+        assert_eq!(req["range"]["startIndex"], 0);
+        assert_eq!(req["properties"]["pixelSize"], 160);
+        assert_eq!(req["fields"], "pixelSize");
+        assert!(build_column_width(&json!({ "sheet_id": 2 })).is_err());
+    }
+
+    #[test]
+    fn raw_passthrough_preserved() {
+        let raw = json!([{ "some": "batchUpdateRequest" }]);
+        let out = build_format_requests("raw", &json!({ "requests": raw.clone() })).unwrap();
+        assert_eq!(json!(out), raw);
+    }
+
+    #[test]
+    fn unknown_action_errors() {
+        assert!(build_format_requests("bogus", &json!({})).is_err());
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/sheets/formatting.rs
+++ b/crates/trusty-gworkspace/src/api/services/sheets/formatting.rs
@@ -20,7 +20,9 @@ use crate::api::services::{account_of, opt_str, require_str};
 
 /// Why: Every cell-scoped action targets a half-open, 0-based `GridRange`.
 /// What: Builds the `GridRange` from `sheet_id` (required) plus optional
-/// start/end row/column indices (absent bounds mean "unbounded" per the API).
+/// start/end row/column indices (absent bounds mean "unbounded" per the API —
+/// callers that need a fully-bounded range must additionally call
+/// `require_bounded_range`).
 /// Test: `grid_range_includes_only_present_bounds` below.
 fn parse_grid_range(args: &Value) -> Result<Value> {
     let sheet_id = args
@@ -41,32 +43,103 @@ fn parse_grid_range(args: &Value) -> Result<Value> {
     Ok(range)
 }
 
+/// Why: An unbounded `GridRange` (any of the four row/column bounds omitted)
+/// means "the rest of the sheet" to the Sheets API. For `merge` this is
+/// destructive — `MERGE_ALL` over an unbounded range merges the entire tab
+/// into one cell, silently discarding every non-top-left value — and for
+/// `format_cells`/`set_number_format` it silently restyles far more of the
+/// sheet than an LLM caller that omitted a bound likely intended. Rejecting
+/// locally turns a silent data-loss/over-broad-mutation bug into a clear
+/// caller-facing error.
+/// What: Errors unless all four of start/end row/column index are present on
+/// the built range.
+/// Test: `merge_without_bounds_is_rejected`,
+/// `format_cells_without_bounds_is_rejected`,
+/// `number_format_without_bounds_is_rejected` below.
+fn require_bounded_range(range: &Value) -> Result<()> {
+    for key in [
+        "startRowIndex",
+        "endRowIndex",
+        "startColumnIndex",
+        "endColumnIndex",
+    ] {
+        if range.get(key).is_none() {
+            return Err(anyhow!(
+                "explicit start_row_index, end_row_index, start_column_index, and \
+                 end_column_index are all required for this action (missing '{key}') — \
+                 omitting a bound would apply to the rest of the sheet"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Why: A single numeric colour channel must be a number in `[0.0, 1.0]`;
+/// silently defaulting a missing/non-numeric/out-of-range channel to `0.0`
+/// (as an `unwrap_or`-based parse would) turns a caller typo (e.g. passing
+/// `255` instead of `1.0`) into a silently-wrong colour applied to the sheet.
+/// What: Extracts `v` as an `f64` and validates it falls within `[0.0, 1.0]`.
+/// Test: Covered via `parse_color` tests below.
+fn parse_channel(v: &Value, name: &str) -> Result<f64> {
+    let n = v
+        .as_f64()
+        .ok_or_else(|| anyhow!("color channel '{name}' must be a number in [0.0, 1.0]"))?;
+    if !(0.0..=1.0).contains(&n) {
+        return Err(anyhow!(
+            "color channel '{name}' must be in [0.0, 1.0], got {n}"
+        ));
+    }
+    Ok(n)
+}
+
 /// Why: Colours arrive either as an RGB(A) array or a `{red,green,blue,alpha}`
-/// object; the API always wants the object form with 0.0–1.0 channels.
-/// What: Normalises an array `[r,g,b(,a)]` to the object form, or passes an
-/// object through unchanged.
-/// Test: `color_array_normalises` below.
-fn parse_color(v: &Value) -> Option<Value> {
-    if v.is_object() {
-        return Some(v.clone());
+/// object; the API always wants the object form with validated 0.0–1.0
+/// channels — malformed input (missing/non-numeric/out-of-range channels)
+/// must be rejected rather than silently coerced to black (see
+/// `parse_channel`).
+/// What: Normalises an array `[r,g,b(,a)]` to the object form (validating
+/// each channel), or validates-and-passes-through an object's present
+/// channels.
+/// Test: `color_array_normalises`, `color_array_rejects_out_of_range`,
+/// `color_array_rejects_non_numeric` below.
+fn parse_color(v: &Value) -> Result<Value> {
+    if let Some(obj) = v.as_object() {
+        let mut color = json!({});
+        for key in ["red", "green", "blue", "alpha"] {
+            if let Some(channel) = obj.get(key) {
+                color[key] = json!(parse_channel(channel, key)?);
+            }
+        }
+        return Ok(color);
     }
-    let arr = v.as_array()?;
-    let ch = |i: usize| arr.get(i).and_then(Value::as_f64).unwrap_or(0.0);
-    let mut color = json!({ "red": ch(0), "green": ch(1), "blue": ch(2) });
-    if let Some(a) = arr.get(3).and_then(Value::as_f64) {
-        color["alpha"] = json!(a);
+    let arr = v.as_array().ok_or_else(|| {
+        anyhow!("color must be an array [r,g,b(,a)] or a {{red,green,blue,alpha}} object")
+    })?;
+    if arr.len() < 3 {
+        return Err(anyhow!("color array must have at least 3 channels [r,g,b]"));
     }
-    Some(color)
+    let mut color = json!({
+        "red": parse_channel(&arr[0], "red")?,
+        "green": parse_channel(&arr[1], "green")?,
+        "blue": parse_channel(&arr[2], "blue")?,
+    });
+    if let Some(a) = arr.get(3) {
+        color["alpha"] = json!(parse_channel(a, "alpha")?);
+    }
+    Ok(color)
 }
 
 /// Why: `repeatCell` for cell styling needs both a `userEnteredFormat` object
 /// and a precise field mask listing exactly the subfields set, or unset fields
-/// get clobbered.
+/// get clobbered. It must also target an explicitly-bounded range — an
+/// omitted bound would silently restyle the rest of the sheet.
 /// What: Builds the `format_cells` request from bold/italic/font_size/colours/
 /// alignment/wrap params, emitting only the touched field paths.
-/// Test: `format_cells_field_mask_is_precise` below.
+/// Test: `format_cells_field_mask_is_precise`,
+/// `format_cells_without_bounds_is_rejected` below.
 fn build_format_cells(args: &Value) -> Result<Vec<Value>> {
     let range = parse_grid_range(args)?;
+    require_bounded_range(&range)?;
     let mut text_format = json!({});
     let mut fields = Vec::<String>::new();
 
@@ -82,8 +155,8 @@ fn build_format_cells(args: &Value) -> Result<Vec<Value>> {
         text_format["fontSize"] = json!(s);
         fields.push("userEnteredFormat.textFormat.fontSize".into());
     }
-    if let Some(c) = args.get("text_color").and_then(parse_color) {
-        text_format["foregroundColor"] = c;
+    if let Some(v) = args.get("text_color") {
+        text_format["foregroundColor"] = parse_color(v)?;
         fields.push("userEnteredFormat.textFormat.foregroundColor".into());
     }
 
@@ -91,8 +164,8 @@ fn build_format_cells(args: &Value) -> Result<Vec<Value>> {
     if text_format.as_object().is_some_and(|o| !o.is_empty()) {
         cell_format["textFormat"] = text_format;
     }
-    if let Some(c) = args.get("background_color").and_then(parse_color) {
-        cell_format["backgroundColor"] = c;
+    if let Some(v) = args.get("background_color") {
+        cell_format["backgroundColor"] = parse_color(v)?;
         fields.push("userEnteredFormat.backgroundColor".into());
     }
     if let Some(a) = opt_str(args, "horizontal_alignment") {
@@ -123,11 +196,15 @@ fn build_format_cells(args: &Value) -> Result<Vec<Value>> {
 }
 
 /// Why: Number/date/currency display formats are a distinct, common styling
-/// need with a small typed surface (type enum + optional pattern).
+/// need with a small typed surface (type enum + optional pattern). It must
+/// also target an explicitly-bounded range — an omitted bound would silently
+/// reformat the rest of the sheet.
 /// What: Builds a `repeatCell` request that sets `numberFormat`.
-/// Test: `number_format_request_shape` below.
+/// Test: `number_format_request_shape`, `number_format_without_bounds_is_rejected`
+/// below.
 fn build_number_format(args: &Value) -> Result<Vec<Value>> {
     let range = parse_grid_range(args)?;
+    require_bounded_range(&range)?;
     let fmt_type = require_str(args, "number_format_type")?;
     let mut number_format = json!({ "type": fmt_type });
     if let Some(pattern) = opt_str(args, "pattern") {
@@ -143,11 +220,17 @@ fn build_number_format(args: &Value) -> Result<Vec<Value>> {
 }
 
 /// Why: Merging a header banner or label block is a one-line intent that the
-/// raw API expresses as `mergeCells` with a merge-type enum.
-/// What: Builds a `mergeCells` request (default `MERGE_ALL`).
-/// Test: `merge_request_shape` below.
+/// raw API expresses as `mergeCells` with a merge-type enum. This is the
+/// single most destructive structured action — `MERGE_ALL` over an unbounded
+/// range merges the *entire tab* into one cell, silently discarding every
+/// non-top-left cell's value — so an explicitly-bounded range is mandatory,
+/// not optional.
+/// What: Builds a `mergeCells` request (default `MERGE_ALL`) over a fully
+/// bounded range.
+/// Test: `merge_request_shape`, `merge_without_bounds_is_rejected` below.
 fn build_merge(args: &Value) -> Result<Vec<Value>> {
     let range = parse_grid_range(args)?;
+    require_bounded_range(&range)?;
     let merge_type = opt_str(args, "merge_type").unwrap_or("MERGE_ALL");
     Ok(vec![json!({
         "mergeCells": { "range": range, "mergeType": merge_type }
@@ -249,6 +332,15 @@ mod tests {
         assert!(parse_grid_range(&json!({})).is_err());
     }
 
+    /// Shared fully-bounded range fragment for actions that require one.
+    fn bounded_range_args() -> Value {
+        json!({
+            "sheet_id": 0,
+            "start_row_index": 0, "end_row_index": 1,
+            "start_column_index": 0, "end_column_index": 1,
+        })
+    }
+
     #[test]
     fn color_array_normalises() {
         let c = parse_color(&json!([1.0, 0.5, 0.0, 0.8])).unwrap();
@@ -256,20 +348,35 @@ mod tests {
         assert_eq!(c["green"], 0.5);
         assert_eq!(c["blue"], 0.0);
         assert_eq!(c["alpha"], 0.8);
-        // Object form passes through.
+        // Object form passes through (partial channels allowed).
         let obj = parse_color(&json!({ "red": 0.2 })).unwrap();
         assert_eq!(obj["red"], 0.2);
     }
 
     #[test]
+    fn color_array_rejects_out_of_range() {
+        // 255 is a common caller mistake (0-255 scale instead of 0.0-1.0).
+        assert!(parse_color(&json!([255, 0, 0])).is_err());
+        assert!(parse_color(&json!([1.0, 1.5, 0.0])).is_err());
+        assert!(parse_color(&json!({ "red": -0.1 })).is_err());
+    }
+
+    #[test]
+    fn color_array_rejects_non_numeric() {
+        assert!(parse_color(&json!(["red", 0, 0])).is_err());
+        assert!(
+            parse_color(&json!([1.0, 0.0])).is_err(),
+            "needs >= 3 channels"
+        );
+        assert!(parse_color(&json!("red")).is_err());
+    }
+
+    #[test]
     fn format_cells_field_mask_is_precise() {
-        let args = json!({
-            "sheet_id": 0,
-            "start_row_index": 0, "end_row_index": 1,
-            "bold": true,
-            "background_color": [0.9, 0.9, 0.9],
-            "horizontal_alignment": "CENTER",
-        });
+        let mut args = bounded_range_args();
+        args["bold"] = json!(true);
+        args["background_color"] = json!([0.9, 0.9, 0.9]);
+        args["horizontal_alignment"] = json!("CENTER");
         let reqs = build_format_cells(&args).unwrap();
         let req = &reqs[0]["repeatCell"];
         let cf = &req["cell"]["userEnteredFormat"];
@@ -287,16 +394,22 @@ mod tests {
 
     #[test]
     fn format_cells_requires_a_field() {
-        assert!(build_format_cells(&json!({ "sheet_id": 0 })).is_err());
+        // Bounded range but no style field set at all.
+        assert!(build_format_cells(&bounded_range_args()).is_err());
+    }
+
+    #[test]
+    fn format_cells_without_bounds_is_rejected() {
+        let args = json!({ "sheet_id": 0, "bold": true });
+        let err = build_format_cells(&args).unwrap_err().to_string();
+        assert!(err.contains("required"), "unexpected message: {err}");
     }
 
     #[test]
     fn number_format_request_shape() {
-        let args = json!({
-            "sheet_id": 0,
-            "number_format_type": "CURRENCY",
-            "pattern": "$#,##0.00",
-        });
+        let mut args = bounded_range_args();
+        args["number_format_type"] = json!("CURRENCY");
+        args["pattern"] = json!("$#,##0.00");
         let reqs = build_number_format(&args).unwrap();
         let nf = &reqs[0]["repeatCell"]["cell"]["userEnteredFormat"]["numberFormat"];
         assert_eq!(nf["type"], "CURRENCY");
@@ -308,11 +421,37 @@ mod tests {
     }
 
     #[test]
+    fn number_format_without_bounds_is_rejected() {
+        let args = json!({ "sheet_id": 0, "number_format_type": "CURRENCY" });
+        assert!(build_number_format(&args).is_err());
+    }
+
+    #[test]
     fn merge_request_shape() {
-        let reqs = build_merge(&json!({ "sheet_id": 0, "end_column_index": 3 })).unwrap();
+        let reqs = build_merge(&bounded_range_args()).unwrap();
         assert_eq!(reqs[0]["mergeCells"]["mergeType"], "MERGE_ALL");
-        let reqs2 = build_merge(&json!({ "sheet_id": 0, "merge_type": "MERGE_COLUMNS" })).unwrap();
+        let mut args2 = bounded_range_args();
+        args2["merge_type"] = json!("MERGE_COLUMNS");
+        let reqs2 = build_merge(&args2).unwrap();
         assert_eq!(reqs2[0]["mergeCells"]["mergeType"], "MERGE_COLUMNS");
+    }
+
+    #[test]
+    fn merge_without_bounds_is_rejected() {
+        // CRITICAL regression guard: omitting any bound must NOT silently
+        // build an unbounded GridRange — MERGE_ALL over the whole sheet
+        // would discard every non-top-left cell's value.
+        let err = build_merge(&json!({ "sheet_id": 0 }))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("required"), "unexpected message: {err}");
+
+        // Partial bounds (missing end_column_index) must also be rejected.
+        let partial = json!({
+            "sheet_id": 0,
+            "start_row_index": 0, "end_row_index": 5, "start_column_index": 0,
+        });
+        assert!(build_merge(&partial).is_err());
     }
 
     #[test]

--- a/crates/trusty-gworkspace/src/api/services/sheets/mod.rs
+++ b/crates/trusty-gworkspace/src/api/services/sheets/mod.rs
@@ -1,9 +1,12 @@
 //! Google Sheets service.
 //!
-//! Why: Sheets v4 surface is large but agent workflows typically need
-//! get/create/read values/write values/format — exactly the four tools we
-//! expose.
-//! What: Re-exports `core` sub-module.
+//! Why: Sheets v4 surface is large; agent workflows need get/create/read
+//! values/write values plus structured formatting and charts — which the
+//! `core`, `formatting`, and `charts` sub-modules cover at parity with the
+//! Python upstream.
+//! What: Re-exports the `core`, `formatting`, and `charts` sub-modules.
 //! Test: Per-sub-module.
 
+pub mod charts;
 pub mod core;
+pub mod formatting;

--- a/crates/trusty-gworkspace/src/openrpc.rs
+++ b/crates/trusty-gworkspace/src/openrpc.rs
@@ -104,9 +104,11 @@ pub fn scopes_for_tool(name: &str) -> &'static [&'static str] {
         | "manage_table_structure" => &[DOCUMENTS, DRIVE],
 
         // Sheets
-        "get_spreadsheet" | "manage_spreadsheet" | "modify_sheet_values" | "format_sheet" => {
-            &[SPREADSHEETS, DRIVE]
-        }
+        "get_spreadsheet"
+        | "manage_spreadsheet"
+        | "modify_sheet_values"
+        | "format_sheet"
+        | "create_chart" => &[SPREADSHEETS, DRIVE],
 
         // Slides
         "get_slides" | "manage_slides" | "add_slide_content" => &[PRESENTATIONS, DRIVE],

--- a/crates/trusty-gworkspace/src/server.rs
+++ b/crates/trusty-gworkspace/src/server.rs
@@ -137,7 +137,8 @@ pub async fn handle_tool_call(state: &AppState, name: &str, args: Value) -> Valu
         "modify_sheet_values" => {
             services::sheets::core::modify_sheet_values(&state.client, args).await
         }
-        "format_sheet" => services::sheets::core::format_sheet(&state.client, args).await,
+        "format_sheet" => services::sheets::formatting::format_sheet(&state.client, args).await,
+        "create_chart" => services::sheets::charts::create_chart(&state.client, args).await,
 
         // Slides
         "get_slides" => services::slides::core::get_slides(&state.client, args).await,

--- a/crates/trusty-gworkspace/src/tools/sheets.rs
+++ b/crates/trusty-gworkspace/src/tools/sheets.rs
@@ -49,12 +49,94 @@ pub(super) fn append(tools: &mut Vec<Value>) {
     ));
     tools.push(tool(
         "format_sheet",
-        "Apply a batchUpdate to a spreadsheet (formatting, conditional rules, etc.).",
+        "Format a range via a discrete action (format_cells, set_number_format, \
+         merge, set_column_width) or 'raw' to pass batchUpdate requests directly.",
         json!({
             "account": account_schema(),
             "spreadsheet_id": { "type": "string" },
+            "action": action_enum(&[
+                "format_cells", "set_number_format", "merge", "set_column_width", "raw",
+            ]),
+            // GridRange (0-based, half-open) — used by format_cells / set_number_format / merge.
+            "sheet_id": { "type": "integer", "description": "Sheet (tab) id the range lives in." },
+            "start_row_index": { "type": "integer" },
+            "end_row_index": { "type": "integer" },
+            "start_column_index": { "type": "integer" },
+            "end_column_index": { "type": "integer" },
+            // format_cells params.
+            "bold": { "type": "boolean" },
+            "italic": { "type": "boolean" },
+            "font_size": { "type": "number" },
+            "text_color": {
+                "description": "RGB(A) array [r,g,b(,a)] (0..1) or {red,green,blue,alpha} object.",
+                "oneOf": [{ "type": "array" }, { "type": "object" }],
+            },
+            "background_color": {
+                "description": "RGB(A) array [r,g,b(,a)] (0..1) or {red,green,blue,alpha} object.",
+                "oneOf": [{ "type": "array" }, { "type": "object" }],
+            },
+            "horizontal_alignment": {
+                "type": "string", "enum": ["LEFT", "CENTER", "RIGHT"],
+            },
+            "vertical_alignment": {
+                "type": "string", "enum": ["TOP", "MIDDLE", "BOTTOM"],
+            },
+            "wrap_strategy": {
+                "type": "string",
+                "enum": ["OVERFLOW_CELL", "LEGACY_WRAP", "CLIP", "WRAP"],
+            },
+            // set_number_format params.
+            "number_format_type": {
+                "type": "string",
+                "enum": ["TEXT", "NUMBER", "PERCENT", "CURRENCY", "DATE", "TIME", "DATE_TIME", "SCIENTIFIC"],
+            },
+            "pattern": { "type": "string", "description": "Number/date format pattern." },
+            // merge params.
+            "merge_type": {
+                "type": "string", "enum": ["MERGE_ALL", "MERGE_COLUMNS", "MERGE_ROWS"],
+            },
+            // set_column_width params (DimensionRange).
+            "dimension": { "type": "string", "enum": ["COLUMNS", "ROWS"] },
+            "start_index": { "type": "integer" },
+            "end_index": { "type": "integer" },
+            "pixel_size": { "type": "integer" },
+            // raw escape hatch.
             "requests": { "type": "array", "items": { "type": "object" } },
         }),
-        &["spreadsheet_id", "requests"],
+        &["spreadsheet_id"],
+    ));
+    tools.push(tool(
+        "create_chart",
+        "Add a bar/column/line/area/pie chart over a data grid (first column = \
+         labels/domain, remaining columns = series).",
+        json!({
+            "account": account_schema(),
+            "spreadsheet_id": { "type": "string" },
+            "chart_type": {
+                "type": "string",
+                "enum": ["column", "bar", "line", "area", "scatter", "pie"],
+            },
+            "source_sheet_id": { "type": "integer", "description": "Sheet id holding the source data." },
+            "start_row_index": { "type": "integer" },
+            "end_row_index": { "type": "integer" },
+            "start_column_index": { "type": "integer" },
+            "end_column_index": { "type": "integer" },
+            "title": { "type": "string" },
+            "x_axis_title": { "type": "string" },
+            "y_axis_title": { "type": "string" },
+            "has_headers": { "type": "boolean", "description": "First data row is a header (default true)." },
+            "legend_position": {
+                "type": "string",
+                "enum": ["BOTTOM_LEGEND", "LEFT_LEGEND", "RIGHT_LEGEND", "TOP_LEGEND", "NO_LEGEND"],
+            },
+            "new_sheet": { "type": "boolean", "description": "Place chart on a new sheet (default true)." },
+            "position_sheet_id": { "type": "integer", "description": "Overlay target sheet when new_sheet=false." },
+            "anchor_row": { "type": "integer" },
+            "anchor_column": { "type": "integer" },
+        }),
+        &[
+            "spreadsheet_id", "chart_type", "source_sheet_id",
+            "start_row_index", "end_row_index", "start_column_index", "end_column_index",
+        ],
     ));
 }

--- a/crates/trusty-gworkspace/src/tools/sheets.rs
+++ b/crates/trusty-gworkspace/src/tools/sheets.rs
@@ -50,7 +50,12 @@ pub(super) fn append(tools: &mut Vec<Value>) {
     tools.push(tool(
         "format_sheet",
         "Format a range via a discrete action (format_cells, set_number_format, \
-         merge, set_column_width) or 'raw' to pass batchUpdate requests directly.",
+         merge, set_column_width) or 'raw' to pass batchUpdate requests directly. \
+         format_cells, set_number_format, and merge REQUIRE all four of \
+         start_row_index/end_row_index/start_column_index/end_column_index — an \
+         omitted bound is rejected rather than silently applied to the rest of \
+         the sheet (this matters most for merge, which would otherwise merge \
+         the entire tab into one cell and discard the other cells' values).",
         json!({
             "account": account_schema(),
             "spreadsheet_id": { "type": "string" },
@@ -58,6 +63,7 @@ pub(super) fn append(tools: &mut Vec<Value>) {
                 "format_cells", "set_number_format", "merge", "set_column_width", "raw",
             ]),
             // GridRange (0-based, half-open) — used by format_cells / set_number_format / merge.
+            // All four bounds are required for these three actions (see description).
             "sheet_id": { "type": "integer", "description": "Sheet (tab) id the range lives in." },
             "start_row_index": { "type": "integer" },
             "end_row_index": { "type": "integer" },
@@ -66,7 +72,7 @@ pub(super) fn append(tools: &mut Vec<Value>) {
             // format_cells params.
             "bold": { "type": "boolean" },
             "italic": { "type": "boolean" },
-            "font_size": { "type": "number" },
+            "font_size": { "type": "integer" },
             "text_color": {
                 "description": "RGB(A) array [r,g,b(,a)] (0..1) or {red,green,blue,alpha} object.",
                 "oneOf": [{ "type": "array" }, { "type": "object" }],
@@ -127,7 +133,11 @@ pub(super) fn append(tools: &mut Vec<Value>) {
             "has_headers": { "type": "boolean", "description": "First data row is a header (default true)." },
             "legend_position": {
                 "type": "string",
-                "enum": ["BOTTOM_LEGEND", "LEFT_LEGEND", "RIGHT_LEGEND", "TOP_LEGEND", "NO_LEGEND"],
+                "enum": [
+                    "BOTTOM_LEGEND", "LEFT_LEGEND", "RIGHT_LEGEND", "TOP_LEGEND",
+                    "NO_LEGEND", "LABELED_LEGEND",
+                ],
+                "description": "LABELED_LEGEND (labels drawn next to each slice) is only valid for pie charts.",
             },
             "new_sheet": { "type": "boolean", "description": "Place chart on a new sheet (default true)." },
             "position_sheet_id": { "type": "integer", "description": "Overlay target sheet when new_sheet=false." },


### PR DESCRIPTION
## Summary

Adds the missing Google Sheets capabilities to `crates/trusty-gworkspace`, mirroring the Python upstream (`server/services/sheets/{core,formatting}.py`).

### 1. `create_chart` (new tool)
Builds an `addChart` batchUpdate request for **bar / column / line / area / scatter / pie** charts over a source `GridRange`. Convention: first column of the range is the domain/labels, each remaining column is a series. Supports:
- `title`, `x_axis_title`, `y_axis_title`, `legend_position`
- `has_headers` (header count)
- `new_sheet` (default) vs overlay positioning (`position_sheet_id` + `anchor_row`/`anchor_column`)

### 2. Structured `format_sheet`
The raw `requests` passthrough forced callers to hand-author nested Sheets JSON. Added discrete, schema-guided, enum-constrained actions with precise field masks:
- `format_cells` — bold/italic/font_size/text_color/background_color/alignment/wrap
- `set_number_format` — type enum + optional pattern
- `merge` — merge-type enum
- `set_column_width` — pixel size over a COLUMNS/ROWS dimension range

**`raw` is preserved as an escape hatch** — a bare `requests` array with no `action` still routes to `raw`, so the prior contract does not regress.

## Structure
- New `src/api/services/sheets/charts.rs` and `.../formatting.rs`; `format_sheet` moved out of `core.rs`.
- Dispatch wired in `server.rs`; OAuth scopes added in `openrpc.rs`.
- Schemas expanded/added in `src/tools/sheets.rs`.
- Pure Sheets API — no external deps.

## Testing
Not live-verifiable (expired OAuth tokens) — **live validation deferred**. Request/schema construction is unit-tested (basic + pie chart shapes, header/axis/position handling, per-action field masks, raw passthrough, error paths). The POST leg remains live-only.

Gate (all green):
- `cargo build/test (52 pass)/clippy -D warnings/fmt --check -p trusty-gworkspace`
- `bash scripts/check_line_cap.sh` — 0 violations
- `cargo check --workspace` — clean

Part of #2626

🤖 Generated with [Claude Code](https://claude.com/claude-code)