### PR TITLE
feat(trusty-gworkspace): add Docs tabs/lists/images/tables/templates tools (parity)

### DIFF
--- a/crates/trusty-gworkspace/src/api/services/docs/header_footer.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/header_footer.rs
@@ -1,0 +1,250 @@
+//! Docs header / footer management.
+//!
+//! Why: Headers and footers are a distinct Docs segment surface
+//! (`createHeader`/`createFooter`, segment-scoped `insertText`, `deleteHeader`/
+//! `deleteFooter`) that agents need for page furniture.
+//! What: `manage_document_header_footer` with a get/create/update/delete action
+//! enum over both headers and footers.
+//! Test: Pure request builders are unit-tested below; the round-trip is
+//! live-only.
+
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+
+use crate::api::client::BaseClient;
+use crate::api::constants::DOCS_API_BASE;
+use crate::api::services::{account_of, require_str};
+
+/// Why: `create_header` and `create_footer` differ only by request key/type.
+/// What: Builds a `createHeader`/`createFooter` request anchored at index 0.
+/// Test: `create_header_footer_request` below.
+pub(crate) fn build_create_segment_request(is_header: bool) -> Value {
+    let key = if is_header {
+        "createHeader"
+    } else {
+        "createFooter"
+    };
+    json!({ key: { "type": "DEFAULT", "sectionBreakLocation": { "index": 0 } } })
+}
+
+/// Why: Updating a header/footer inserts text scoped to that segment id.
+/// What: Builds an `insertText` request with a `segmentId` in its location.
+/// Test: `update_segment_request` below.
+pub(crate) fn build_update_segment_request(segment_id: &str, text: &str) -> Value {
+    json!({
+        "insertText": {
+            "location": { "index": 0, "segmentId": segment_id },
+            "text": text,
+        }
+    })
+}
+
+/// Why: Deletion differs only by request key and id field between the two kinds.
+/// What: Builds a `deleteHeader`/`deleteFooter` request for the given id.
+/// Test: `delete_segment_request` below.
+pub(crate) fn build_delete_segment_request(is_header: bool, segment_id: &str) -> Value {
+    if is_header {
+        json!({ "deleteHeader": { "headerId": segment_id } })
+    } else {
+        json!({ "deleteFooter": { "footerId": segment_id } })
+    }
+}
+
+/// Extract concatenated plain text from a header/footer segment.
+///
+/// Why: `get` returns a short content preview per segment.
+/// What: Walks `content -> paragraph -> elements -> textRun` and concatenates.
+/// Test: `extract_segment_text_concatenates` below.
+pub(crate) fn extract_segment_text(segment: &Value) -> String {
+    let mut out = String::new();
+    if let Some(content) = segment.get("content").and_then(|c| c.as_array()) {
+        for el in content {
+            if let Some(elements) = el
+                .get("paragraph")
+                .and_then(|p| p.get("elements"))
+                .and_then(|e| e.as_array())
+            {
+                for pe in elements {
+                    if let Some(text) = pe
+                        .get("textRun")
+                        .and_then(|t| t.get("content"))
+                        .and_then(|c| c.as_str())
+                    {
+                        out.push_str(text);
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+fn preview(text: String) -> String {
+    if text.chars().count() > 200 {
+        let truncated: String = text.chars().take(200).collect();
+        format!("{truncated}...")
+    } else {
+        text
+    }
+}
+
+/// Why: All header/footer verbs live behind one action enum for a compact tool
+/// surface.
+/// What: Dispatches get/create_header/create_footer/update_header/update_footer/
+/// delete_header/delete_footer to the Docs API.
+/// Test: Request builders are unit-tested; dispatch is live-only.
+pub async fn manage_document_header_footer(client: &BaseClient, args: Value) -> Result<Value> {
+    let action = require_str(&args, "action")?;
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let batch_url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+
+    match action {
+        "get" => {
+            let url =
+                format!("{DOCS_API_BASE}/documents/{id}?fields=documentStyle,headers,footers");
+            let doc = client.get(&url, account).await?;
+            let doc_style = doc
+                .get("documentStyle")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+
+            let collect = |field: &str, id_key: &str| -> Vec<Value> {
+                doc.get(field)
+                    .and_then(|o| o.as_object())
+                    .map(|map| {
+                        map.iter()
+                            .map(|(seg_id, seg)| {
+                                json!({
+                                    id_key: seg_id,
+                                    "content_preview": preview(extract_segment_text(seg)),
+                                })
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            };
+
+            Ok(json!({
+                "document_id": id,
+                "default_header_id": doc_style.get("defaultHeaderId"),
+                "default_footer_id": doc_style.get("defaultFooterId"),
+                "headers": collect("headers", "header_id"),
+                "footers": collect("footers", "footer_id"),
+            }))
+        }
+        "create_header" | "create_footer" => {
+            let is_header = action == "create_header";
+            let req = build_create_segment_request(is_header);
+            let resp = client
+                .post(&batch_url, json!({ "requests": [req] }), account)
+                .await?;
+            let reply = resp
+                .get("replies")
+                .and_then(|r| r.as_array())
+                .and_then(|a| a.first());
+            let new_id = if is_header {
+                reply
+                    .and_then(|r| r.get("createHeader"))
+                    .and_then(|c| c.get("headerId"))
+            } else {
+                reply
+                    .and_then(|r| r.get("createFooter"))
+                    .and_then(|c| c.get("footerId"))
+            };
+            let key = if is_header { "header_id" } else { "footer_id" };
+            Ok(json!({
+                "status": "created",
+                "action": action,
+                "document_id": id,
+                key: new_id.cloned(),
+            }))
+        }
+        "update_header" | "update_footer" => {
+            let is_header = action == "update_header";
+            let text = require_str(&args, "text")?;
+            let seg_key = if is_header { "header_id" } else { "footer_id" };
+            let segment_id = require_str(&args, seg_key)?;
+            let req = build_update_segment_request(segment_id, text);
+            client
+                .post(&batch_url, json!({ "requests": [req] }), account)
+                .await?;
+            Ok(json!({
+                "status": "updated",
+                "action": action,
+                "document_id": id,
+                seg_key: segment_id,
+                "text_length": text.chars().count(),
+            }))
+        }
+        "delete_header" | "delete_footer" => {
+            let is_header = action == "delete_header";
+            let seg_key = if is_header { "header_id" } else { "footer_id" };
+            let segment_id = require_str(&args, seg_key)?;
+            let req = build_delete_segment_request(is_header, segment_id);
+            client
+                .post(&batch_url, json!({ "requests": [req] }), account)
+                .await?;
+            Ok(json!({
+                "status": "deleted",
+                "action": action,
+                "document_id": id,
+                seg_key: segment_id,
+            }))
+        }
+        other => Err(anyhow!(
+            "unknown action for manage_document_header_footer: {other}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_header_footer_request() {
+        let h = build_create_segment_request(true);
+        assert_eq!(h["createHeader"]["type"], "DEFAULT");
+        assert_eq!(h["createHeader"]["sectionBreakLocation"]["index"], 0);
+        let f = build_create_segment_request(false);
+        assert!(f.get("createFooter").is_some());
+    }
+
+    #[test]
+    fn update_segment_request() {
+        let r = build_update_segment_request("kix.h1", "Page header");
+        assert_eq!(r["insertText"]["location"]["segmentId"], "kix.h1");
+        assert_eq!(r["insertText"]["location"]["index"], 0);
+        assert_eq!(r["insertText"]["text"], "Page header");
+    }
+
+    #[test]
+    fn delete_segment_request() {
+        let h = build_delete_segment_request(true, "kix.h1");
+        assert_eq!(h["deleteHeader"]["headerId"], "kix.h1");
+        let f = build_delete_segment_request(false, "kix.f1");
+        assert_eq!(f["deleteFooter"]["footerId"], "kix.f1");
+    }
+
+    #[test]
+    fn extract_segment_text_concatenates() {
+        let seg = json!({
+            "content": [
+                { "paragraph": { "elements": [
+                    { "textRun": { "content": "Draft " } },
+                    { "textRun": { "content": "v2" } },
+                ] } },
+            ]
+        });
+        assert_eq!(extract_segment_text(&seg), "Draft v2");
+    }
+
+    #[test]
+    fn preview_truncates_long_text() {
+        let long = "x".repeat(250);
+        let p = preview(long);
+        assert!(p.ends_with("..."));
+        assert_eq!(p.chars().count(), 203);
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/docs/header_footer.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/header_footer.rs
@@ -29,6 +29,13 @@ pub(crate) fn build_create_segment_request(is_header: bool) -> Value {
 
 /// Why: Updating a header/footer inserts text scoped to that segment id.
 /// What: Builds an `insertText` request with a `segmentId` in its location.
+/// NOTE (non-blocking): the insert location is always index 0 within the
+/// segment, matching upstream. This means repeated `update_header`/
+/// `update_footer` calls on the same segment PREPEND rather than append —
+/// each call's text lands before whatever was inserted by the previous call.
+/// Callers that want to append should read the segment first (`action:
+/// "get"`) and compute an explicit trailing index instead of relying on this
+/// tool to accumulate text.
 /// Test: `update_segment_request` below.
 pub(crate) fn build_update_segment_request(segment_id: &str, text: &str) -> Value {
     json!({

--- a/crates/trusty-gworkspace/src/api/services/docs/images.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/images.rs
@@ -1,0 +1,100 @@
+//! Docs inline-image insertion.
+//!
+//! Why: Agents embed diagrams/screenshots by URL; this wraps the
+//! `insertInlineImage` batchUpdate request.
+//! What: `insert_image_in_document` inserts a publicly-reachable image URI at a
+//! given index, with optional point-sized dimensions.
+//! Test: The pure request builder is unit-tested below; the call is live-only.
+
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+
+use crate::api::client::BaseClient;
+use crate::api::constants::DOCS_API_BASE;
+use crate::api::services::{account_of, require_str};
+
+/// Why: The `objectSize` sub-object is only present when a dimension is given.
+/// What: Builds an `insertInlineImage` request carrying `uri`, `location`, and
+/// an optional `objectSize` with width/height in PT.
+/// Test: `image_request_*` below.
+pub(crate) fn build_insert_image_request(
+    insert_index: i64,
+    image_uri: &str,
+    width_pt: Option<f64>,
+    height_pt: Option<f64>,
+) -> Value {
+    let mut inner = json!({
+        "location": { "index": insert_index },
+        "uri": image_uri,
+    });
+    if width_pt.is_some() || height_pt.is_some() {
+        let mut size = json!({});
+        if let Some(w) = width_pt {
+            size["width"] = json!({ "magnitude": w, "unit": "PT" });
+        }
+        if let Some(h) = height_pt {
+            size["height"] = json!({ "magnitude": h, "unit": "PT" });
+        }
+        inner["objectSize"] = size;
+    }
+    json!({ "insertInlineImage": inner })
+}
+
+/// Why: Inline images are a first-class content element with a typed request.
+/// What: Posts a single `insertInlineImage` batchUpdate.
+/// Test: `build_insert_image_request` is unit-tested; the call is live-only.
+pub async fn insert_image_in_document(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let insert_index = args
+        .get("insert_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing insert_index"))?;
+    let image_uri = require_str(&args, "image_uri")?;
+    let width_pt = args.get("width_pt").and_then(|v| v.as_f64());
+    let height_pt = args.get("height_pt").and_then(|v| v.as_f64());
+
+    let req = build_insert_image_request(insert_index, image_uri, width_pt, height_pt);
+    let url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+    client
+        .post(&url, json!({ "requests": [req] }), account)
+        .await?;
+    Ok(json!({
+        "status": "inserted",
+        "document_id": id,
+        "insert_index": insert_index,
+        "image_uri": image_uri,
+        "width_pt": width_pt,
+        "height_pt": height_pt,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_request_without_size() {
+        let r = build_insert_image_request(3, "https://x/y.png", None, None);
+        assert_eq!(r["insertInlineImage"]["uri"], "https://x/y.png");
+        assert_eq!(r["insertInlineImage"]["location"]["index"], 3);
+        assert!(r["insertInlineImage"].get("objectSize").is_none());
+    }
+
+    #[test]
+    fn image_request_with_dimensions() {
+        let r = build_insert_image_request(1, "https://x/y.png", Some(200.0), Some(100.0));
+        let size = &r["insertInlineImage"]["objectSize"];
+        assert_eq!(size["width"]["magnitude"], 200.0);
+        assert_eq!(size["width"]["unit"], "PT");
+        assert_eq!(size["height"]["magnitude"], 100.0);
+    }
+
+    #[test]
+    fn image_request_width_only() {
+        let r = build_insert_image_request(1, "https://x/y.png", Some(150.0), None);
+        let size = &r["insertInlineImage"]["objectSize"];
+        assert_eq!(size["width"]["magnitude"], 150.0);
+        assert!(size.get("height").is_none());
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/docs/mod.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/mod.rs
@@ -9,4 +9,12 @@
 pub mod comments;
 pub mod core;
 pub mod formatting;
+pub mod header_footer;
+pub mod images;
+pub mod paragraphs;
+pub mod table_format;
 pub mod table_ops;
+pub mod table_preset;
+pub mod table_style;
+pub mod tabs;
+pub mod templates;

--- a/crates/trusty-gworkspace/src/api/services/docs/paragraphs.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/paragraphs.rs
@@ -159,7 +159,11 @@ pub(crate) fn build_create_list_requests(
         list_text.push_str(item);
         list_text.push('\n');
     }
-    let end_index = insert_index + list_text.chars().count() as i64;
+    // Docs indices are UTF-16 code units, not Unicode scalar values — a
+    // `chars().count()` here would under-count for any text outside the BMP
+    // (e.g. emoji) and desync the createParagraphBullets range from the
+    // actually-inserted text.
+    let end_index = insert_index + list_text.encode_utf16().count() as i64;
     let preset = if list_type == "NUMBERED" {
         "NUMBERED_DECIMAL_ALPHA_ROMAN"
     } else {
@@ -387,6 +391,21 @@ mod tests {
         assert_eq!(
             r["requests"][1]["createParagraphBullets"]["bulletPreset"],
             "NUMBERED_DECIMAL_ALPHA_ROMAN"
+        );
+    }
+
+    #[test]
+    fn create_list_requests_end_index_counts_utf16_units() {
+        // "🎉" is outside the BMP: 1 Unicode scalar value but 2 UTF-16 code
+        // units. Docs indices are UTF-16 code units, so the end index must
+        // reflect that — chars().count() would under-count by 1 per emoji
+        // and desync the createParagraphBullets range from the inserted text.
+        let items = vec!["🎉".to_string()];
+        let r = build_create_list_requests(10, "BULLETED", &items);
+        // text = "🎉\n" -> 2 (surrogate pair) + 1 (newline) = 3 UTF-16 units.
+        assert_eq!(
+            r["requests"][1]["createParagraphBullets"]["range"]["endIndex"],
+            13
         );
     }
 }

--- a/crates/trusty-gworkspace/src/api/services/docs/paragraphs.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/paragraphs.rs
@@ -1,0 +1,392 @@
+//! Docs paragraph / list operations.
+//!
+//! Why: Index-based editing needs paragraph reordering, paragraph-level styling
+//! and list creation as first-class tools beyond raw text/range edits.
+//! What: `move_paragraph_in_document` (read+insert+delete), `format_paragraph_in_document`
+//! (`updateParagraphStyle`), and `create_list_in_document` (`insertText` +
+//! `createParagraphBullets`).
+//! Test: Pure builders and the index-shift computation are unit-tested below;
+//! the network round-trip is live-only.
+
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+
+use crate::api::client::BaseClient;
+use crate::api::constants::DOCS_API_BASE;
+use crate::api::services::{account_of, opt_str, require_str};
+
+/// Why: A moved paragraph shifts index space; the delete range must account for
+/// whether the insertion happened before or after the source range.
+/// What: Returns the `(delete_start, delete_end)` for the original range. When
+/// the destination lands before the source, the source shifts forward by its
+/// own length; when after, it is unaffected. A destination strictly inside the
+/// source range is ambiguous and rejected.
+/// Test: `delete_range_before/after/inside` below.
+pub(crate) fn compute_move_delete_range(
+    source_start: i64,
+    source_end: i64,
+    destination: i64,
+) -> Result<(i64, i64)> {
+    let text_len = source_end - source_start;
+    if destination <= source_start {
+        Ok((source_start + text_len, source_end + text_len))
+    } else if destination >= source_end {
+        Ok((source_start, source_end))
+    } else {
+        Err(anyhow!(
+            "destination_index must lie outside [source_start_index, source_end_index]"
+        ))
+    }
+}
+
+/// Why: Moving a paragraph first needs its text, gathered from every paragraph
+/// element fully contained in the source range.
+/// What: Concatenates `textRun` content from body elements whose
+/// `[startIndex, endIndex)` is within `[source_start, source_end]`.
+/// Test: `extract_range_text_gathers_contained_paragraphs` below.
+pub(crate) fn extract_range_text(body: &Value, source_start: i64, source_end: i64) -> String {
+    let mut moved = String::new();
+    let Some(content) = body.get("content").and_then(|c| c.as_array()) else {
+        return moved;
+    };
+    for el in content {
+        let (Some(el_start), Some(el_end)) = (
+            el.get("startIndex").and_then(|v| v.as_i64()),
+            el.get("endIndex").and_then(|v| v.as_i64()),
+        ) else {
+            continue;
+        };
+        if el_start >= source_start
+            && el_end <= source_end
+            && let Some(elements) = el
+                .get("paragraph")
+                .and_then(|p| p.get("elements"))
+                .and_then(|e| e.as_array())
+        {
+            for pe in elements {
+                if let Some(text) = pe
+                    .get("textRun")
+                    .and_then(|t| t.get("content"))
+                    .and_then(|c| c.as_str())
+                {
+                    moved.push_str(text);
+                }
+            }
+        }
+    }
+    moved
+}
+
+/// Why: The move is a single batch of insert-at-destination then delete-source.
+/// What: Builds the two-request `requests` array.
+/// Test: `move_requests_shape` below.
+pub(crate) fn build_move_requests(
+    moved_text: &str,
+    destination: i64,
+    delete_start: i64,
+    delete_end: i64,
+) -> Value {
+    json!({
+        "requests": [
+            { "insertText": { "location": { "index": destination }, "text": moved_text } },
+            { "deleteContentRange": { "range": { "startIndex": delete_start, "endIndex": delete_end } } },
+        ]
+    })
+}
+
+/// Why: Paragraph styling maps a handful of ergonomic args onto the verbose
+/// `updateParagraphStyle` shape with a matching field mask.
+/// What: Populates only supplied properties (named style, alignment, indents,
+/// spacing) and errors when none are provided.
+/// Test: `format_paragraph_request_*` below.
+pub(crate) fn build_format_paragraph_request(start: i64, end: i64, args: &Value) -> Result<Value> {
+    let mut style = json!({});
+    let mut fields = Vec::<&str>::new();
+
+    if let Some(h) = opt_str(args, "heading_style") {
+        style["namedStyleType"] = json!(h);
+        fields.push("namedStyleType");
+    }
+    if let Some(a) = opt_str(args, "alignment") {
+        style["alignment"] = json!(a);
+        fields.push("alignment");
+    }
+    let pt = |key: &str| args.get(key).and_then(|v| v.as_f64());
+    if let Some(v) = pt("indent_first_line_pt") {
+        style["indentFirstLine"] = json!({ "magnitude": v, "unit": "PT" });
+        fields.push("indentFirstLine");
+    }
+    if let Some(v) = pt("indent_start_pt") {
+        style["indentStart"] = json!({ "magnitude": v, "unit": "PT" });
+        fields.push("indentStart");
+    }
+    if let Some(v) = pt("space_above_pt") {
+        style["spaceAbove"] = json!({ "magnitude": v, "unit": "PT" });
+        fields.push("spaceAbove");
+    }
+    if let Some(v) = pt("space_below_pt") {
+        style["spaceBelow"] = json!({ "magnitude": v, "unit": "PT" });
+        fields.push("spaceBelow");
+    }
+
+    if fields.is_empty() {
+        return Err(anyhow!(
+            "at least one of heading_style, alignment, indent_first_line_pt, \
+             indent_start_pt, space_above_pt, space_below_pt must be provided"
+        ));
+    }
+    Ok(json!({
+        "updateParagraphStyle": {
+            "range": { "startIndex": start, "endIndex": end },
+            "paragraphStyle": style,
+            "fields": fields.join(","),
+        }
+    }))
+}
+
+/// Why: A list is text-plus-bullets: insert the newline-joined items, then apply
+/// the bullet preset over the inserted range.
+/// What: Builds the `insertText` + `createParagraphBullets` request pair. The
+/// preset is chosen from `list_type` (BULLETED vs NUMBERED).
+/// Test: `create_list_requests_*` below.
+pub(crate) fn build_create_list_requests(
+    insert_index: i64,
+    list_type: &str,
+    items: &[String],
+) -> Value {
+    let mut list_text = String::new();
+    for item in items {
+        list_text.push_str(item);
+        list_text.push('\n');
+    }
+    let end_index = insert_index + list_text.chars().count() as i64;
+    let preset = if list_type == "NUMBERED" {
+        "NUMBERED_DECIMAL_ALPHA_ROMAN"
+    } else {
+        "BULLET_DISC_CIRCLE_SQUARE"
+    };
+    json!({
+        "requests": [
+            { "insertText": { "location": { "index": insert_index }, "text": list_text } },
+            {
+                "createParagraphBullets": {
+                    "range": { "startIndex": insert_index, "endIndex": end_index },
+                    "bulletPreset": preset,
+                }
+            },
+        ]
+    })
+}
+
+/// Why: Reordering paragraphs is a common edit requiring a careful read → insert
+/// → delete sequence.
+/// What: Reads the source text, computes the shift-adjusted delete range, and
+/// posts a single batch.
+/// Test: Pure helpers above are unit-tested; the call is live-only.
+pub async fn move_paragraph_in_document(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let source_start = args
+        .get("source_start_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing source_start_index"))?;
+    let source_end = args
+        .get("source_end_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing source_end_index"))?;
+    let destination = args
+        .get("destination_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing destination_index"))?;
+
+    let doc = client
+        .get(&format!("{DOCS_API_BASE}/documents/{id}"), account)
+        .await?;
+    let body = doc.get("body").cloned().unwrap_or_else(|| json!({}));
+    let moved_text = extract_range_text(&body, source_start, source_end);
+    if moved_text.is_empty() {
+        return Ok(json!({
+            "success": false,
+            "error": "No paragraph text found in source range",
+            "source_start_index": source_start,
+            "source_end_index": source_end,
+        }));
+    }
+
+    let (delete_start, delete_end) =
+        compute_move_delete_range(source_start, source_end, destination)?;
+    let body_req = build_move_requests(&moved_text, destination, delete_start, delete_end);
+    let url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+    client.post(&url, body_req, account).await?;
+
+    let preview: String = moved_text.chars().take(100).collect();
+    Ok(json!({ "success": true, "moved_text": preview }))
+}
+
+/// Why: Focused paragraph styling (heading/alignment/indent/spacing) in one call.
+/// What: Builds and posts a single `updateParagraphStyle` request.
+/// Test: `build_format_paragraph_request` is unit-tested; the call is live-only.
+pub async fn format_paragraph_in_document(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let start = args
+        .get("start_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing start_index"))?;
+    let end = args
+        .get("end_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing end_index"))?;
+
+    let req = build_format_paragraph_request(start, end, &args)?;
+    let url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+    client
+        .post(&url, json!({ "requests": [req] }), account)
+        .await?;
+    Ok(json!({
+        "success": true,
+        "start_index": start,
+        "end_index": end,
+    }))
+}
+
+/// Why: Bulleted / numbered lists are a common authoring primitive.
+/// What: Inserts the items and applies the matching bullet preset.
+/// Test: `build_create_list_requests` is unit-tested; the call is live-only.
+pub async fn create_list_in_document(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let insert_index = args
+        .get("insert_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing insert_index"))?;
+    let list_type = require_str(&args, "list_type")?;
+    let items: Vec<String> = args
+        .get("items")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    if items.is_empty() {
+        return Err(anyhow!("items must be a non-empty array of strings"));
+    }
+
+    let body = build_create_list_requests(insert_index, list_type, &items);
+    let url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+    client.post(&url, body, account).await?;
+    Ok(json!({
+        "status": "created",
+        "document_id": id,
+        "list_type": list_type,
+        "insert_index": insert_index,
+        "items_count": items.len(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_range_before_shifts_forward() {
+        // destination before source: source range shifts by its length (10).
+        assert_eq!(compute_move_delete_range(20, 30, 5).unwrap(), (30, 40));
+    }
+
+    #[test]
+    fn delete_range_after_unaffected() {
+        assert_eq!(compute_move_delete_range(20, 30, 40).unwrap(), (20, 30));
+    }
+
+    #[test]
+    fn delete_range_inside_is_rejected() {
+        assert!(compute_move_delete_range(20, 30, 25).is_err());
+    }
+
+    #[test]
+    fn extract_range_text_gathers_contained_paragraphs() {
+        let body = json!({
+            "content": [
+                { "startIndex": 1, "endIndex": 6, "paragraph": { "elements": [
+                    { "textRun": { "content": "abcde" } } ] } },
+                { "startIndex": 6, "endIndex": 12, "paragraph": { "elements": [
+                    { "textRun": { "content": "fghij" } } ] } },
+            ]
+        });
+        // Only the first paragraph is within [1, 6].
+        assert_eq!(extract_range_text(&body, 1, 6), "abcde");
+    }
+
+    #[test]
+    fn move_requests_shape() {
+        let r = build_move_requests("hi", 50, 20, 30);
+        assert_eq!(r["requests"][0]["insertText"]["location"]["index"], 50);
+        assert_eq!(r["requests"][0]["insertText"]["text"], "hi");
+        assert_eq!(
+            r["requests"][1]["deleteContentRange"]["range"]["startIndex"],
+            20
+        );
+        assert_eq!(
+            r["requests"][1]["deleteContentRange"]["range"]["endIndex"],
+            30
+        );
+    }
+
+    #[test]
+    fn format_paragraph_request_builds_field_mask() {
+        let args = json!({ "alignment": "CENTER", "heading_style": "HEADING_2" });
+        let r = build_format_paragraph_request(1, 10, &args).unwrap();
+        let fields = r["updateParagraphStyle"]["fields"].as_str().unwrap();
+        assert!(fields.contains("namedStyleType"));
+        assert!(fields.contains("alignment"));
+        assert_eq!(
+            r["updateParagraphStyle"]["paragraphStyle"]["alignment"],
+            "CENTER"
+        );
+    }
+
+    #[test]
+    fn format_paragraph_request_indents_and_spacing() {
+        let args = json!({ "indent_start_pt": 18.0, "space_below_pt": 6.0 });
+        let r = build_format_paragraph_request(1, 10, &args).unwrap();
+        let ps = &r["updateParagraphStyle"]["paragraphStyle"];
+        assert_eq!(ps["indentStart"]["magnitude"], 18.0);
+        assert_eq!(ps["indentStart"]["unit"], "PT");
+        assert_eq!(ps["spaceBelow"]["magnitude"], 6.0);
+    }
+
+    #[test]
+    fn format_paragraph_request_requires_a_field() {
+        assert!(build_format_paragraph_request(1, 10, &json!({})).is_err());
+    }
+
+    #[test]
+    fn create_list_requests_bulleted() {
+        let items = vec!["one".to_string(), "two".to_string()];
+        let r = build_create_list_requests(5, "BULLETED", &items);
+        assert_eq!(r["requests"][0]["insertText"]["text"], "one\ntwo\n");
+        assert_eq!(r["requests"][0]["insertText"]["location"]["index"], 5);
+        // end index = 5 + len("one\ntwo\n") = 5 + 8 = 13
+        assert_eq!(
+            r["requests"][1]["createParagraphBullets"]["range"]["endIndex"],
+            13
+        );
+        assert_eq!(
+            r["requests"][1]["createParagraphBullets"]["bulletPreset"],
+            "BULLET_DISC_CIRCLE_SQUARE"
+        );
+    }
+
+    #[test]
+    fn create_list_requests_numbered_preset() {
+        let items = vec!["a".to_string()];
+        let r = build_create_list_requests(1, "NUMBERED", &items);
+        assert_eq!(
+            r["requests"][1]["createParagraphBullets"]["bulletPreset"],
+            "NUMBERED_DECIMAL_ALPHA_ROMAN"
+        );
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/docs/table_format.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/table_format.rs
@@ -65,6 +65,19 @@ pub(crate) fn compute_content_aware_widths(
     let mut clamped = vec![false; num_cols];
     let mut remaining = usable_width;
 
+    // NOTE (non-blocking, matches the Python upstream algorithm verbatim):
+    // `free_weight` is recomputed once per outer pass, then reused as the
+    // denominator for every column checked within that SAME inner loop —
+    // including columns that get clamped partway through the pass. On a
+    // wide table with many columns this can under-allocate a column that
+    // is checked late in a pass (its provisional share is computed against
+    // a `free_weight` that hasn't yet shed the weight of columns clamped
+    // earlier in the same pass), pushing it slightly below `min_col_pt`
+    // before the final renormalisation pass runs. This never panics and
+    // the post-loop renormalisation still makes the total sum to
+    // `usable_width` exactly; only the very last column(s) processed in a
+    // pass could end up marginally under the nominal minimum on pathological
+    // (very-wide, many-column) inputs.
     for _ in 0..=num_cols {
         let free_weight: f64 = (0..num_cols)
             .filter(|&i| !clamped[i])

--- a/crates/trusty-gworkspace/src/api/services/docs/table_format.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/table_format.rs
@@ -1,0 +1,538 @@
+//! Docs whole-document table beautifier.
+//!
+//! Why: A post-processing pass that walks every table in a doc and applies
+//! borders, a styled header row, and content-aware column widths saves callers
+//! from computing per-table geometry.
+//! What: `format_document_tables` reads the doc once, then for each table emits
+//! border/header/width `batchUpdate` requests (chunked under the API limit).
+//! Test: `compute_content_aware_widths` and the request builders are unit-tested
+//! below; the round-trip is live-only.
+
+use anyhow::Result;
+use serde_json::{Value, json};
+
+use crate::api::client::BaseClient;
+use crate::api::constants::DOCS_API_BASE;
+use crate::api::services::{account_of, require_str};
+
+const CONTENT_CAP: usize = 60;
+const MIN_COL_PT: f64 = 40.0;
+const FALLBACK_WIDTH: f64 = 468.0;
+const BORDER_WIDTH_PT: f64 = 1.0;
+const BATCH_CHUNK: usize = 200;
+
+fn border_color() -> Value {
+    json!({ "red": 0.4, "green": 0.4, "blue": 0.4 })
+}
+fn header_bg() -> Value {
+    json!({ "red": 0.9, "green": 0.9, "blue": 0.9 })
+}
+
+/// Why: Text-heavy columns should be wider than narrow numeric ones without a
+/// font engine; a capped content-length weighting approximates that.
+/// What: Weights each column by `min(max_chars, cap)`, distributes
+/// `usable_width` proportionally, clamps to `MIN_COL_PT`, and renormalises so
+/// widths sum to `usable_width`.
+/// Test: `content_aware_widths_*` below.
+pub(crate) fn compute_content_aware_widths(
+    table_cells: &[Vec<String>],
+    usable_width: f64,
+    cap: usize,
+    min_col_pt: f64,
+) -> Vec<f64> {
+    if table_cells.is_empty() {
+        return Vec::new();
+    }
+    let num_cols = table_cells.iter().map(|r| r.len()).max().unwrap_or(0);
+    if num_cols == 0 {
+        return Vec::new();
+    }
+
+    let weights: Vec<f64> = (0..num_cols)
+        .map(|c| {
+            let max_chars = table_cells
+                .iter()
+                .filter_map(|row| row.get(c))
+                .map(|cell| cell.chars().count())
+                .max()
+                .unwrap_or(1)
+                .max(1);
+            max_chars.min(cap) as f64
+        })
+        .collect();
+
+    let mut final_widths = vec![0.0f64; num_cols];
+    let mut clamped = vec![false; num_cols];
+    let mut remaining = usable_width;
+
+    for _ in 0..=num_cols {
+        let free_weight: f64 = (0..num_cols)
+            .filter(|&i| !clamped[i])
+            .map(|i| weights[i])
+            .sum();
+        if free_weight <= 0.0 {
+            break;
+        }
+        let mut newly_clamped = false;
+        for i in 0..num_cols {
+            if clamped[i] {
+                continue;
+            }
+            let provisional = remaining * weights[i] / free_weight;
+            if provisional < min_col_pt {
+                final_widths[i] = min_col_pt;
+                clamped[i] = true;
+                remaining -= min_col_pt;
+                newly_clamped = true;
+            }
+        }
+        if !newly_clamped {
+            for i in 0..num_cols {
+                if !clamped[i] {
+                    final_widths[i] = remaining * weights[i] / free_weight;
+                }
+            }
+            break;
+        }
+    }
+
+    for w in &mut final_widths {
+        if *w == 0.0 {
+            *w = min_col_pt;
+        }
+    }
+
+    // Renormalise so the widths sum to usable_width exactly.
+    let total_clamped: f64 = (0..num_cols)
+        .filter(|&i| clamped[i])
+        .map(|i| final_widths[i])
+        .sum();
+    let free_cols: Vec<usize> = (0..num_cols).filter(|&i| !clamped[i]).collect();
+    if !free_cols.is_empty() {
+        let remaining_for_free = usable_width - total_clamped;
+        let current_free_total: f64 = free_cols.iter().map(|&i| final_widths[i]).sum();
+        if current_free_total > 0.0 && remaining_for_free > 0.0 {
+            let scale = remaining_for_free / current_free_total;
+            for &i in &free_cols {
+                final_widths[i] *= scale;
+            }
+        }
+    } else {
+        let total: f64 = final_widths.iter().sum();
+        if total > 0.0 {
+            let scale = usable_width / total;
+            for w in &mut final_widths {
+                *w *= scale;
+            }
+        }
+    }
+
+    final_widths
+}
+
+/// Return the concatenated, trimmed plain text of a table cell.
+pub(crate) fn extract_cell_text(cell: &Value) -> String {
+    let mut parts = String::new();
+    if let Some(content) = cell.get("content").and_then(|c| c.as_array()) {
+        for el in content {
+            if let Some(elements) = el
+                .get("paragraph")
+                .and_then(|p| p.get("elements"))
+                .and_then(|e| e.as_array())
+            {
+                for pe in elements {
+                    if let Some(t) = pe
+                        .get("textRun")
+                        .and_then(|t| t.get("content"))
+                        .and_then(|c| c.as_str())
+                    {
+                        parts.push_str(t);
+                    }
+                }
+            }
+        }
+    }
+    parts.trim().to_string()
+}
+
+/// Extract usable page width (page width minus L/R margins) or a fallback.
+pub(crate) fn get_usable_width(doc: &Value) -> f64 {
+    let ds = doc.get("documentStyle");
+    let mag = |path: &[&str]| -> f64 {
+        let mut cur = ds;
+        for p in path {
+            cur = cur.and_then(|v| v.get(p));
+        }
+        cur.and_then(|v| v.get("magnitude"))
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0)
+    };
+    let page_width = mag(&["pageSize", "width"]);
+    let margin_left = mag(&["marginLeft"]);
+    let margin_right = mag(&["marginRight"]);
+    if page_width > 0.0 && (margin_left + margin_right) < page_width {
+        page_width - margin_left - margin_right
+    } else {
+        FALLBACK_WIDTH
+    }
+}
+
+/// Build 1pt-solid border requests for every cell in a table.
+pub(crate) fn build_border_requests(
+    table_start_index: i64,
+    num_rows: i64,
+    num_cols: i64,
+) -> Vec<Value> {
+    let border_obj = json!({
+        "color": { "color": { "rgbColor": border_color() } },
+        "width": { "magnitude": BORDER_WIDTH_PT, "unit": "PT" },
+        "dashStyle": "SOLID",
+    });
+    let mut requests = Vec::new();
+    for row_idx in 0..num_rows {
+        for col_idx in 0..num_cols {
+            requests.push(json!({
+                "updateTableCellStyle": {
+                    "tableCellStyle": {
+                        "borderTop": border_obj,
+                        "borderBottom": border_obj,
+                        "borderLeft": border_obj,
+                        "borderRight": border_obj,
+                    },
+                    "fields": "borderTop,borderBottom,borderLeft,borderRight",
+                    "tableRange": {
+                        "tableCellLocation": {
+                            "tableStartLocation": { "index": table_start_index },
+                            "rowIndex": row_idx,
+                            "columnIndex": col_idx,
+                        },
+                        "rowSpan": 1,
+                        "columnSpan": 1,
+                    },
+                }
+            }));
+        }
+    }
+    requests
+}
+
+/// Build header-row requests: light-grey background per column + bold over each
+/// header cell's full text range.
+pub(crate) fn build_header_requests(
+    table_start_index: i64,
+    num_cols: i64,
+    header_cell_ranges: &[(i64, i64)],
+) -> Vec<Value> {
+    let mut requests = Vec::new();
+    for col_idx in 0..num_cols {
+        requests.push(json!({
+            "updateTableCellStyle": {
+                "tableCellStyle": { "backgroundColor": { "color": { "rgbColor": header_bg() } } },
+                "fields": "backgroundColor",
+                "tableRange": {
+                    "tableCellLocation": {
+                        "tableStartLocation": { "index": table_start_index },
+                        "rowIndex": 0,
+                        "columnIndex": col_idx,
+                    },
+                    "rowSpan": 1,
+                    "columnSpan": 1,
+                },
+            }
+        }));
+    }
+    for &(start, end) in header_cell_ranges {
+        if start > 0 && end > start {
+            requests.push(json!({
+                "updateTextStyle": {
+                    "range": { "startIndex": start, "endIndex": end },
+                    "textStyle": { "bold": true },
+                    "fields": "bold",
+                }
+            }));
+        }
+    }
+    requests
+}
+
+/// Build fixed-width `updateTableColumnProperties` requests.
+pub(crate) fn build_column_width_requests(table_start_index: i64, widths: &[f64]) -> Vec<Value> {
+    widths
+        .iter()
+        .enumerate()
+        .map(|(col_idx, &w)| {
+            json!({
+                "updateTableColumnProperties": {
+                    "tableStartLocation": { "index": table_start_index },
+                    "columnIndices": [col_idx as i64],
+                    "tableColumnProperties": {
+                        "widthType": "FIXED_WIDTH",
+                        "width": { "magnitude": w, "unit": "PT" },
+                    },
+                    "fields": "widthType,width",
+                }
+            })
+        })
+        .collect()
+}
+
+/// Return `(startIndex, endIndex)` of the first paragraph of each header cell.
+pub(crate) fn find_header_cell_ranges(
+    body_content: &[Value],
+    table_start_index: i64,
+) -> Vec<(i64, i64)> {
+    for element in body_content {
+        let Some(table) = element.get("table") else {
+            continue;
+        };
+        if element.get("startIndex").and_then(|v| v.as_i64()) != Some(table_start_index) {
+            continue;
+        }
+        let rows = table.get("tableRows").and_then(|r| r.as_array());
+        let Some(rows) = rows else { return Vec::new() };
+        let Some(first_row) = rows.first() else {
+            return Vec::new();
+        };
+        let mut ranges = Vec::new();
+        if let Some(cells) = first_row.get("tableCells").and_then(|c| c.as_array()) {
+            for cell in cells {
+                let content = cell
+                    .get("content")
+                    .and_then(|c| c.as_array())
+                    .and_then(|a| a.first());
+                let start = content
+                    .and_then(|c| c.get("startIndex"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let end = content
+                    .and_then(|c| c.get("endIndex"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(start);
+                ranges.push((start, end));
+            }
+        }
+        return ranges;
+    }
+    Vec::new()
+}
+
+/// Why: One call to normalise the appearance of every table in a doc.
+/// What: Reads the doc, gathers tables, and posts border+header+width requests
+/// per table in chunks under the batchUpdate limit.
+/// Test: The pure builders above are unit-tested; the round-trip is live-only.
+pub async fn format_document_tables(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let doc = client
+        .get(&format!("{DOCS_API_BASE}/documents/{id}"), account)
+        .await?;
+    let batch_url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+
+    let usable_width = get_usable_width(&doc);
+    let empty = Vec::new();
+    let body_content = doc
+        .get("body")
+        .and_then(|b| b.get("content"))
+        .and_then(|c| c.as_array())
+        .unwrap_or(&empty);
+
+    // Gather tables: (start_index, num_rows, num_cols, cell_texts).
+    struct TableInfo {
+        start_index: i64,
+        num_rows: i64,
+        num_cols: i64,
+        cell_texts: Vec<Vec<String>>,
+    }
+    let mut tables = Vec::<TableInfo>::new();
+    for element in body_content {
+        let Some(table) = element.get("table") else {
+            continue;
+        };
+        let rows = table.get("tableRows").and_then(|r| r.as_array());
+        let Some(rows) = rows else { continue };
+        let num_rows = rows.len() as i64;
+        let num_cols = rows
+            .iter()
+            .map(|r| {
+                r.get("tableCells")
+                    .and_then(|c| c.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0)
+            })
+            .max()
+            .unwrap_or(0) as i64;
+        if num_rows == 0 || num_cols == 0 {
+            continue;
+        }
+        let cell_texts: Vec<Vec<String>> = rows
+            .iter()
+            .map(|row| {
+                row.get("tableCells")
+                    .and_then(|c| c.as_array())
+                    .map(|cells| cells.iter().map(extract_cell_text).collect())
+                    .unwrap_or_default()
+            })
+            .collect();
+        let start_index = element
+            .get("startIndex")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        tables.push(TableInfo {
+            start_index,
+            num_rows,
+            num_cols,
+            cell_texts,
+        });
+    }
+
+    if tables.is_empty() {
+        return Ok(json!({
+            "status": "no_tables_found",
+            "document_id": id,
+            "tables_processed": 0,
+        }));
+    }
+
+    let mut total_requests_sent = 0usize;
+    for table in &tables {
+        let mut all_requests =
+            build_border_requests(table.start_index, table.num_rows, table.num_cols);
+        let header_ranges = find_header_cell_ranges(body_content, table.start_index);
+        all_requests.extend(build_header_requests(
+            table.start_index,
+            table.num_cols,
+            &header_ranges,
+        ));
+        let widths =
+            compute_content_aware_widths(&table.cell_texts, usable_width, CONTENT_CAP, MIN_COL_PT);
+        all_requests.extend(build_column_width_requests(table.start_index, &widths));
+
+        for chunk in all_requests.chunks(BATCH_CHUNK) {
+            client
+                .post(&batch_url, json!({ "requests": chunk }), account)
+                .await?;
+            total_requests_sent += chunk.len();
+        }
+    }
+
+    Ok(json!({
+        "status": "formatted",
+        "document_id": id,
+        "document_url": format!("https://docs.google.com/document/d/{id}/edit"),
+        "tables_processed": tables.len(),
+        "usable_width_pt": usable_width,
+        "total_requests_sent": total_requests_sent,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cells(grid: &[&[&str]]) -> Vec<Vec<String>> {
+        grid.iter()
+            .map(|r| r.iter().map(|s| s.to_string()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn content_aware_widths_sum_to_usable() {
+        let data = cells(&[
+            &["a", "much longer content here"],
+            &["b", "another wide body"],
+        ]);
+        let widths = compute_content_aware_widths(&data, 468.0, CONTENT_CAP, MIN_COL_PT);
+        assert_eq!(widths.len(), 2);
+        let total: f64 = widths.iter().sum();
+        assert!((total - 468.0).abs() < 0.01, "total {total} != 468");
+        // Text-heavy column 1 wider than the narrow column 0.
+        assert!(widths[1] > widths[0]);
+    }
+
+    #[test]
+    fn content_aware_widths_respect_min_clamp() {
+        let data = cells(&[&["x", "y", "z"]]);
+        let widths = compute_content_aware_widths(&data, 468.0, CONTENT_CAP, MIN_COL_PT);
+        assert!(widths.iter().all(|w| *w >= MIN_COL_PT - 0.01));
+    }
+
+    #[test]
+    fn content_aware_widths_empty() {
+        assert!(compute_content_aware_widths(&[], 468.0, CONTENT_CAP, MIN_COL_PT).is_empty());
+    }
+
+    #[test]
+    fn border_requests_one_per_cell() {
+        let reqs = build_border_requests(10, 2, 3);
+        assert_eq!(reqs.len(), 6);
+        assert_eq!(
+            reqs[0]["updateTableCellStyle"]["fields"],
+            "borderTop,borderBottom,borderLeft,borderRight"
+        );
+    }
+
+    #[test]
+    fn header_requests_bg_plus_bold() {
+        let reqs = build_header_requests(0, 2, &[(3, 8), (9, 14)]);
+        // 2 background requests + 2 bold requests.
+        assert_eq!(reqs.len(), 4);
+        assert_eq!(reqs[2]["updateTextStyle"]["range"]["startIndex"], 3);
+        assert_eq!(reqs[2]["updateTextStyle"]["range"]["endIndex"], 8);
+    }
+
+    #[test]
+    fn header_requests_skip_empty_ranges() {
+        let reqs = build_header_requests(0, 1, &[(0, 0), (5, 5)]);
+        // Only 1 background request; both bold ranges are degenerate.
+        assert_eq!(reqs.len(), 1);
+    }
+
+    #[test]
+    fn column_width_requests_fixed() {
+        let reqs = build_column_width_requests(7, &[80.0, 120.0]);
+        assert_eq!(reqs.len(), 2);
+        assert_eq!(
+            reqs[1]["updateTableColumnProperties"]["tableColumnProperties"]["width"]["magnitude"],
+            120.0
+        );
+    }
+
+    #[test]
+    fn usable_width_from_document_style() {
+        let doc = json!({
+            "documentStyle": {
+                "pageSize": { "width": { "magnitude": 612.0 } },
+                "marginLeft": { "magnitude": 72.0 },
+                "marginRight": { "magnitude": 72.0 },
+            }
+        });
+        assert_eq!(get_usable_width(&doc), 468.0);
+    }
+
+    #[test]
+    fn usable_width_fallback() {
+        assert_eq!(get_usable_width(&json!({})), FALLBACK_WIDTH);
+    }
+
+    #[test]
+    fn extract_cell_text_trims() {
+        let cell = json!({
+            "content": [ { "paragraph": { "elements": [ { "textRun": { "content": " Name \n" } } ] } } ]
+        });
+        assert_eq!(extract_cell_text(&cell), "Name");
+    }
+
+    #[test]
+    fn header_cell_ranges_from_body() {
+        let body = vec![json!({
+            "startIndex": 5,
+            "table": { "tableRows": [
+                { "tableCells": [
+                    { "content": [{ "startIndex": 7, "endIndex": 12 }] },
+                    { "content": [{ "startIndex": 12, "endIndex": 15 }] },
+                ] },
+            ] }
+        })];
+        assert_eq!(find_header_cell_ranges(&body, 5), vec![(7, 12), (12, 15)]);
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/docs/table_preset.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/table_preset.rs
@@ -1,0 +1,383 @@
+//! Docs whole-table style presets.
+//!
+//! Why: Applying a coherent look (borders + header + zebra striping) to a whole
+//! table by hand is many `updateTableCellStyle` requests; named presets make it
+//! one call.
+//! What: `apply_table_style` merges a named preset (`minimal`, `bordered`,
+//! `striped`, `professional`, `plain`) with optional custom overrides and emits
+//! per-cell style requests plus optional header-bold text styling.
+//! Test: The preset table, merge, and per-cell request builder are unit-tested
+//! below; the round-trip is live-only.
+
+use anyhow::{Result, anyhow};
+use serde_json::{Map, Value, json};
+
+use crate::api::client::BaseClient;
+use crate::api::constants::DOCS_API_BASE;
+use crate::api::services::{account_of, require_str};
+
+/// Why: Presets encode sensible border/padding/background defaults so callers
+/// pick a name rather than assembling colours by hand.
+/// What: Returns the style object for a named preset (empty for `plain`/unknown).
+/// Test: `preset_lookup` below.
+pub(crate) fn table_style_preset(name: &str) -> Value {
+    match name {
+        "minimal" => json!({
+            "border_color": { "red": 0.9, "green": 0.9, "blue": 0.9 },
+            "border_width": 0.5,
+            "border_dash_style": "SOLID",
+            "cell_padding": { "top": 4, "bottom": 4, "left": 6, "right": 6 },
+        }),
+        "bordered" => json!({
+            "border_color": { "red": 0.4, "green": 0.4, "blue": 0.4 },
+            "border_width": 1.0,
+            "border_dash_style": "SOLID",
+            "cell_padding": { "top": 4, "bottom": 4, "left": 6, "right": 6 },
+        }),
+        "striped" => json!({
+            "border_color": { "red": 0.85, "green": 0.85, "blue": 0.85 },
+            "border_width": 0.5,
+            "border_dash_style": "SOLID",
+            "odd_row_background": { "red": 1.0, "green": 1.0, "blue": 1.0 },
+            "even_row_background": { "red": 0.95, "green": 0.95, "blue": 0.97 },
+            "cell_padding": { "top": 4, "bottom": 4, "left": 6, "right": 6 },
+        }),
+        "professional" => json!({
+            "header_background": { "red": 0.2, "green": 0.35, "blue": 0.6 },
+            "header_text_bold": true,
+            "odd_row_background": { "red": 1.0, "green": 1.0, "blue": 1.0 },
+            "even_row_background": { "red": 0.93, "green": 0.95, "blue": 0.98 },
+            "border_color": { "red": 0.7, "green": 0.75, "blue": 0.85 },
+            "border_width": 0.75,
+            "border_dash_style": "SOLID",
+            "cell_padding": { "top": 5, "bottom": 5, "left": 8, "right": 8 },
+        }),
+        // "plain" and unknown -> Google Docs default (no changes).
+        _ => json!({}),
+    }
+}
+
+/// Why: `custom` overrides individual preset fields; a plain merge captures that.
+/// What: Returns preset with every key from `custom` overwriting it.
+/// Test: `merge_style_overrides` below.
+pub(crate) fn merge_style(preset: Value, custom: &Value) -> Value {
+    let mut base: Map<String, Value> = preset.as_object().cloned().unwrap_or_default();
+    if let Some(over) = custom.as_object() {
+        for (k, v) in over {
+            base.insert(k.clone(), v.clone());
+        }
+    }
+    Value::Object(base)
+}
+
+/// Walk the doc body for a table at `table_start_index`, returning each cell's
+/// first-paragraph start index as a `[row][col]` grid.
+///
+/// Why: Header-bold styling needs the text start index of each header cell.
+/// What: Locates the table element and reads `content[0].startIndex` per cell.
+/// Test: `find_cell_indices_grid` below.
+pub(crate) fn find_table_cell_indices(
+    body_content: &[Value],
+    table_start_index: i64,
+) -> Vec<Vec<i64>> {
+    for element in body_content {
+        let Some(table) = element.get("table") else {
+            continue;
+        };
+        if element.get("startIndex").and_then(|v| v.as_i64()) != Some(table_start_index) {
+            continue;
+        }
+        let mut grid = Vec::new();
+        if let Some(rows) = table.get("tableRows").and_then(|r| r.as_array()) {
+            for row in rows {
+                let mut row_cells = Vec::new();
+                if let Some(cells) = row.get("tableCells").and_then(|c| c.as_array()) {
+                    for cell in cells {
+                        let idx = cell
+                            .get("content")
+                            .and_then(|c| c.as_array())
+                            .and_then(|a| a.first())
+                            .and_then(|c| c.get("startIndex"))
+                            .and_then(|v| v.as_i64())
+                            .unwrap_or(0);
+                        row_cells.push(idx);
+                    }
+                }
+                grid.push(row_cells);
+            }
+        }
+        return grid;
+    }
+    Vec::new()
+}
+
+/// Build the per-cell `updateTableCellStyle` requests for a merged style.
+///
+/// Why: Isolating the request assembly keeps it pure and unit-testable.
+/// What: For each cell applies border (if color+width), padding, and row
+/// background (header/odd/even), emitting a request only when something is set.
+/// Test: `style_requests_*` below.
+pub(crate) fn build_table_style_requests(
+    table_start_index: i64,
+    num_rows: i64,
+    num_columns: i64,
+    header_row: bool,
+    style: &Value,
+) -> Vec<Value> {
+    let border_color = style.get("border_color");
+    let border_width = style.get("border_width").and_then(|v| v.as_f64());
+    let border_dash = style
+        .get("border_dash_style")
+        .and_then(|v| v.as_str())
+        .unwrap_or("SOLID");
+    let cell_padding = style.get("cell_padding");
+    let header_background = style.get("header_background");
+    let odd_row_background = style.get("odd_row_background");
+    let even_row_background = style.get("even_row_background");
+
+    let mut requests = Vec::new();
+    for row_idx in 0..num_rows {
+        let is_header = header_row && row_idx == 0;
+        let row_bg: Option<&Value> = if is_header {
+            header_background
+        } else if row_idx % 2 == 0 {
+            even_row_background
+        } else {
+            odd_row_background
+        };
+
+        for col_idx in 0..num_columns {
+            let mut cell_style = json!({});
+            let mut fields = Vec::<&str>::new();
+
+            if let (Some(color), Some(width)) = (border_color, border_width) {
+                let border_obj = json!({
+                    "color": { "color": { "rgbColor": color } },
+                    "width": { "magnitude": width, "unit": "PT" },
+                    "dashStyle": border_dash,
+                });
+                for key in ["borderTop", "borderBottom", "borderLeft", "borderRight"] {
+                    cell_style[key] = border_obj.clone();
+                    fields.push(key);
+                }
+            }
+
+            if let Some(pad) = cell_padding {
+                for (side, key) in [
+                    ("top", "paddingTop"),
+                    ("bottom", "paddingBottom"),
+                    ("left", "paddingLeft"),
+                    ("right", "paddingRight"),
+                ] {
+                    let mag = pad.get(side).and_then(|v| v.as_f64()).unwrap_or(0.0);
+                    cell_style[key] = json!({ "magnitude": mag, "unit": "PT" });
+                    fields.push(key);
+                }
+            }
+
+            if let Some(bg) = row_bg {
+                cell_style["backgroundColor"] = json!({ "color": { "rgbColor": bg } });
+                fields.push("backgroundColor");
+            }
+
+            if !fields.is_empty() {
+                requests.push(json!({
+                    "updateTableCellStyle": {
+                        "tableCellStyle": cell_style,
+                        "fields": fields.join(","),
+                        "tableRange": {
+                            "tableCellLocation": {
+                                "tableStartLocation": { "index": table_start_index },
+                                "rowIndex": row_idx,
+                                "columnIndex": col_idx,
+                            },
+                            "rowSpan": 1,
+                            "columnSpan": 1,
+                        },
+                    }
+                }));
+            }
+        }
+    }
+    requests
+}
+
+/// Why: Present a whole-table styling verb keyed by a named preset.
+/// What: Merges preset+custom, builds per-cell requests, optionally fetches the
+/// doc to bold header cells, then posts one batch.
+/// Test: The builders above are unit-tested; the call is live-only.
+pub async fn apply_table_style(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let table_start_index = args
+        .get("table_start_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing table_start_index"))?;
+    let num_rows = args
+        .get("num_rows")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing num_rows"))?;
+    let num_columns = args
+        .get("num_columns")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing num_columns"))?;
+    let header_row = args
+        .get("header_row")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let preset_name = args
+        .get("preset")
+        .and_then(|v| v.as_str())
+        .unwrap_or("plain");
+    let custom = args.get("custom").cloned().unwrap_or_else(|| json!({}));
+
+    let style = merge_style(table_style_preset(preset_name), &custom);
+    if style.as_object().map(|o| o.is_empty()).unwrap_or(true) {
+        return Ok(
+            json!({ "status": "no_style_applied", "preset": preset_name, "document_id": id }),
+        );
+    }
+
+    let mut requests =
+        build_table_style_requests(table_start_index, num_rows, num_columns, header_row, &style);
+
+    // Header bold requires the doc to resolve cell text start indices.
+    let header_text_bold = style
+        .get("header_text_bold")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if header_row && header_text_bold {
+        let url = format!("{DOCS_API_BASE}/documents/{id}?fields=body");
+        let doc = client.get(&url, account).await?;
+        let empty = Vec::new();
+        let body_content = doc
+            .get("body")
+            .and_then(|b| b.get("content"))
+            .and_then(|c| c.as_array())
+            .unwrap_or(&empty);
+        let grid = find_table_cell_indices(body_content, table_start_index);
+        if let Some(first_row) = grid.first() {
+            for &start_idx in first_row {
+                if start_idx > 0 {
+                    requests.push(json!({
+                        "updateTextStyle": {
+                            "range": { "startIndex": start_idx, "endIndex": start_idx + 1 },
+                            "textStyle": { "bold": true },
+                            "fields": "bold",
+                        }
+                    }));
+                }
+            }
+        }
+    }
+
+    if requests.is_empty() {
+        return Ok(
+            json!({ "status": "no_style_applied", "preset": preset_name, "document_id": id }),
+        );
+    }
+    let url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+    client
+        .post(&url, json!({ "requests": requests.clone() }), account)
+        .await?;
+    Ok(json!({
+        "status": "styled",
+        "document_id": id,
+        "table_start_index": table_start_index,
+        "preset": preset_name,
+        "num_rows": num_rows,
+        "num_columns": num_columns,
+        "header_row": header_row,
+        "requests_sent": requests.len(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preset_lookup() {
+        assert!(table_style_preset("plain").as_object().unwrap().is_empty());
+        assert_eq!(table_style_preset("bordered")["border_width"], 1.0);
+        assert_eq!(table_style_preset("professional")["header_text_bold"], true);
+        assert!(table_style_preset("nope").as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn merge_style_overrides() {
+        let merged = merge_style(
+            table_style_preset("bordered"),
+            &json!({ "border_width": 3.0, "header_text_bold": true }),
+        );
+        assert_eq!(merged["border_width"], 3.0);
+        assert_eq!(merged["header_text_bold"], true);
+        // Untouched preset key survives.
+        assert_eq!(merged["border_dash_style"], "SOLID");
+    }
+
+    #[test]
+    fn style_requests_border_and_padding() {
+        let style = table_style_preset("bordered");
+        let reqs = build_table_style_requests(10, 2, 2, true, &style);
+        // 2x2 cells, each with border+padding -> 4 requests.
+        assert_eq!(reqs.len(), 4);
+        let fields = reqs[0]["updateTableCellStyle"]["fields"].as_str().unwrap();
+        assert!(fields.contains("borderTop"));
+        assert!(fields.contains("paddingTop"));
+    }
+
+    #[test]
+    fn style_requests_zebra_backgrounds() {
+        let style = table_style_preset("striped");
+        let reqs = build_table_style_requests(0, 3, 1, false, &style);
+        // Row 0 (even) gets even_row_background; row 1 (odd) gets odd.
+        assert_eq!(
+            reqs[0]["updateTableCellStyle"]["tableCellStyle"]["backgroundColor"]["color"]["rgbColor"]
+                ["blue"],
+            0.97
+        );
+        assert_eq!(
+            reqs[1]["updateTableCellStyle"]["tableCellStyle"]["backgroundColor"]["color"]["rgbColor"]
+                ["blue"],
+            1.0
+        );
+    }
+
+    #[test]
+    fn style_requests_header_background() {
+        let style = table_style_preset("professional");
+        let reqs = build_table_style_requests(0, 2, 1, true, &style);
+        // Header row 0 gets header_background (blue 0.6).
+        assert_eq!(
+            reqs[0]["updateTableCellStyle"]["tableCellStyle"]["backgroundColor"]["color"]["rgbColor"]
+                ["blue"],
+            0.6
+        );
+    }
+
+    #[test]
+    fn style_requests_empty_for_plain() {
+        let reqs = build_table_style_requests(0, 2, 2, true, &json!({}));
+        assert!(reqs.is_empty());
+    }
+
+    #[test]
+    fn find_cell_indices_grid() {
+        let body = vec![json!({
+            "startIndex": 5,
+            "table": {
+                "tableRows": [
+                    { "tableCells": [
+                        { "content": [{ "startIndex": 7 }] },
+                        { "content": [{ "startIndex": 12 }] },
+                    ] },
+                ]
+            }
+        })];
+        let grid = find_table_cell_indices(&body, 5);
+        assert_eq!(grid, vec![vec![7, 12]]);
+        // Wrong index => empty.
+        assert!(find_table_cell_indices(&body, 99).is_empty());
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/docs/table_preset.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/table_preset.rs
@@ -71,15 +71,18 @@ pub(crate) fn merge_style(preset: Value, custom: &Value) -> Value {
 }
 
 /// Walk the doc body for a table at `table_start_index`, returning each cell's
-/// first-paragraph start index as a `[row][col]` grid.
+/// first-paragraph `(startIndex, endIndex)` as a `[row][col]` grid.
 ///
-/// Why: Header-bold styling needs the text start index of each header cell.
-/// What: Locates the table element and reads `content[0].startIndex` per cell.
+/// Why: Header-bold styling needs the FULL text range of each header cell —
+/// capturing only `startIndex` (as an earlier revision did) bolds just the
+/// first character. Mirrors `table_format::find_header_cell_ranges`.
+/// What: Locates the table element and reads `content[0].{startIndex,endIndex}`
+/// per cell.
 /// Test: `find_cell_indices_grid` below.
 pub(crate) fn find_table_cell_indices(
     body_content: &[Value],
     table_start_index: i64,
-) -> Vec<Vec<i64>> {
+) -> Vec<Vec<(i64, i64)>> {
     for element in body_content {
         let Some(table) = element.get("table") else {
             continue;
@@ -93,14 +96,19 @@ pub(crate) fn find_table_cell_indices(
                 let mut row_cells = Vec::new();
                 if let Some(cells) = row.get("tableCells").and_then(|c| c.as_array()) {
                     for cell in cells {
-                        let idx = cell
+                        let content = cell
                             .get("content")
                             .and_then(|c| c.as_array())
-                            .and_then(|a| a.first())
+                            .and_then(|a| a.first());
+                        let start = content
                             .and_then(|c| c.get("startIndex"))
                             .and_then(|v| v.as_i64())
                             .unwrap_or(0);
-                        row_cells.push(idx);
+                        let end = content
+                            .and_then(|c| c.get("endIndex"))
+                            .and_then(|v| v.as_i64())
+                            .unwrap_or(start);
+                        row_cells.push((start, end));
                     }
                 }
                 grid.push(row_cells);
@@ -257,11 +265,11 @@ pub async fn apply_table_style(client: &BaseClient, args: Value) -> Result<Value
             .unwrap_or(&empty);
         let grid = find_table_cell_indices(body_content, table_start_index);
         if let Some(first_row) = grid.first() {
-            for &start_idx in first_row {
-                if start_idx > 0 {
+            for &(start_idx, end_idx) in first_row {
+                if start_idx > 0 && end_idx > start_idx {
                     requests.push(json!({
                         "updateTextStyle": {
-                            "range": { "startIndex": start_idx, "endIndex": start_idx + 1 },
+                            "range": { "startIndex": start_idx, "endIndex": end_idx },
                             "textStyle": { "bold": true },
                             "fields": "bold",
                         }
@@ -369,15 +377,39 @@ mod tests {
             "table": {
                 "tableRows": [
                     { "tableCells": [
-                        { "content": [{ "startIndex": 7 }] },
-                        { "content": [{ "startIndex": 12 }] },
+                        { "content": [{ "startIndex": 7, "endIndex": 14 }] },
+                        { "content": [{ "startIndex": 15, "endIndex": 22 }] },
                     ] },
                 ]
             }
         })];
         let grid = find_table_cell_indices(&body, 5);
-        assert_eq!(grid, vec![vec![7, 12]]);
+        // Full (start, end) ranges are captured, not just the start index.
+        assert_eq!(grid, vec![vec![(7, 14), (15, 22)]]);
         // Wrong index => empty.
         assert!(find_table_cell_indices(&body, 99).is_empty());
+    }
+
+    #[test]
+    fn apply_table_style_bolds_full_header_cell_range_not_one_char() {
+        // Regression for the MEDIUM finding: header-bold must cover the
+        // entire header cell text, not just its first character.
+        let header_ranges = [(7, 20), (21, 30)];
+        let requests: Vec<Value> = header_ranges
+            .iter()
+            .filter(|&&(s, e)| s > 0 && e > s)
+            .map(|&(s, e)| {
+                json!({
+                    "updateTextStyle": {
+                        "range": { "startIndex": s, "endIndex": e },
+                        "textStyle": { "bold": true },
+                        "fields": "bold",
+                    }
+                })
+            })
+            .collect();
+        assert_eq!(requests[0]["updateTextStyle"]["range"]["endIndex"], 20);
+        assert_ne!(requests[0]["updateTextStyle"]["range"]["endIndex"], 8);
+        assert_eq!(requests[1]["updateTextStyle"]["range"]["endIndex"], 30);
     }
 }

--- a/crates/trusty-gworkspace/src/api/services/docs/table_style.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/table_style.rs
@@ -1,0 +1,562 @@
+//! Docs table cell styling and column widths.
+//!
+//! Why: Beyond structural row/column edits, agents need per-cell styling
+//! (padding, borders, fill, vertical alignment) and explicit or auto-balanced
+//! column widths.
+//! What: `format_table_cells` (`updateTableCellStyle`) and
+//! `set_table_column_widths` (`updateTableColumnProperties`), sharing the pure
+//! cell-style builder and the `balance_column_widths` algorithm.
+//! Test: The builders and the balancing algorithm are unit-tested below; the
+//! round-trip is live-only.
+
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+
+use crate::api::client::BaseClient;
+use crate::api::constants::DOCS_API_BASE;
+use crate::api::services::{account_of, require_str};
+
+const DEFAULT_AVAILABLE_WIDTH: f64 = 468.0;
+const DEFAULT_FONT_SIZE: f64 = 11.0;
+const DEFAULT_MIN_COL_WIDTH: f64 = 60.0;
+
+/// Why: Cell styling (padding/border/background/alignment) is shared by
+/// `format_table_cells` and, conceptually, the table-preset pass.
+/// What: Builds one `updateTableCellStyle` request for `(row, col)` populating
+/// only the supplied properties and its field mask; returns `None` when nothing
+/// was set.
+/// Test: `cell_style_request_*` below.
+pub(crate) fn build_cell_style_request(
+    table_start_index: i64,
+    row_idx: i64,
+    col_idx: i64,
+    padding: Option<&Value>,
+    border: Option<&Value>,
+    background_color: Option<&Value>,
+    content_alignment: Option<&str>,
+) -> Option<Value> {
+    let mut cell_style = json!({});
+    let mut fields = Vec::<String>::new();
+
+    if let Some(pad) = padding {
+        for side in ["top", "bottom", "left", "right"] {
+            if let Some(mag) = pad.get(side).and_then(|v| v.as_f64()) {
+                let key = format!("padding{}", capitalize(side));
+                cell_style[&key] = json!({ "magnitude": mag, "unit": "PT" });
+                fields.push(key);
+            }
+        }
+    }
+
+    if let Some(b) = border {
+        let color = b
+            .get("color")
+            .cloned()
+            .unwrap_or_else(|| json!({ "red": 0.0, "green": 0.0, "blue": 0.0 }));
+        let width = b.get("width").and_then(|v| v.as_f64()).unwrap_or(1.0);
+        let dash = b
+            .get("dash_style")
+            .and_then(|v| v.as_str())
+            .unwrap_or("SOLID");
+        let border_obj = json!({
+            "color": { "color": { "rgbColor": color } },
+            "width": { "magnitude": width, "unit": "PT" },
+            "dashStyle": dash,
+        });
+        let default_sides = vec![json!("top"), json!("bottom"), json!("left"), json!("right")];
+        let sides = b
+            .get("sides")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or(default_sides);
+        for side in sides {
+            if let Some(s) = side.as_str() {
+                let key = format!("border{}", capitalize(s));
+                cell_style[&key] = border_obj.clone();
+                fields.push(key);
+            }
+        }
+    }
+
+    if let Some(bg) = background_color {
+        cell_style["backgroundColor"] = json!({ "color": { "rgbColor": bg } });
+        fields.push("backgroundColor".to_string());
+    }
+
+    if let Some(align) = content_alignment {
+        cell_style["contentAlignment"] = json!(align);
+        fields.push("contentAlignment".to_string());
+    }
+
+    if fields.is_empty() {
+        return None;
+    }
+
+    Some(json!({
+        "updateTableCellStyle": {
+            "tableCellStyle": cell_style,
+            "fields": fields.join(","),
+            "tableRange": {
+                "tableCellLocation": {
+                    "tableStartLocation": { "index": table_start_index },
+                    "rowIndex": row_idx,
+                    "columnIndex": col_idx,
+                },
+                "rowSpan": 1,
+                "columnSpan": 1,
+            },
+        }
+    }))
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// Why: One column-width request either fixes a width or reverts a column to
+/// even distribution (null / non-positive width).
+/// What: Builds an `updateTableColumnProperties` request for `col_idx`.
+/// Test: `column_width_request_*` below.
+pub(crate) fn build_column_width_request(
+    table_start_index: i64,
+    col_idx: i64,
+    width: Option<f64>,
+) -> Value {
+    match width {
+        Some(w) if w > 0.0 => json!({
+            "updateTableColumnProperties": {
+                "tableStartLocation": { "index": table_start_index },
+                "columnIndices": [col_idx],
+                "tableColumnProperties": {
+                    "widthType": "FIXED_WIDTH",
+                    "width": { "magnitude": w, "unit": "PT" },
+                },
+                "fields": "widthType,width",
+            }
+        }),
+        _ => json!({
+            "updateTableColumnProperties": {
+                "tableStartLocation": { "index": table_start_index },
+                "columnIndices": [col_idx],
+                "tableColumnProperties": { "widthType": "EVENLY_DISTRIBUTED" },
+                "fields": "widthType",
+            }
+        }),
+    }
+}
+
+/// Why: Auto-balancing spreads available width so text-heavy columns get more
+/// room; three algorithms trade off content-fit vs simplicity.
+/// What: Returns per-column PT widths for `data` (row-major). `equalize` binary-
+/// searches a target line-count; `sqrt`/`proportional` weight by char counts.
+/// Widths are clamped to `min_col_width` and rescaled to fit `available_width`.
+/// Test: `balance_widths_*` below.
+pub(crate) fn balance_column_widths(
+    data: &[Vec<String>],
+    available_width: f64,
+    font_size: f64,
+    min_col_width: f64,
+    algorithm: &str,
+) -> Vec<f64> {
+    if data.is_empty() || data[0].is_empty() {
+        return Vec::new();
+    }
+    let num_cols = data.iter().map(|r| r.len()).max().unwrap_or(0);
+    if num_cols == 0 {
+        return Vec::new();
+    }
+    let char_width = font_size * 0.55;
+
+    let mut max_chars = vec![0usize; num_cols];
+    let mut max_word_len = vec![0usize; num_cols];
+    for (c, mc) in max_chars.iter_mut().enumerate() {
+        let mut col_max = 0usize;
+        let mut col_word_max = 0usize;
+        for row in data {
+            if let Some(cell) = row.get(c) {
+                col_max = col_max.max(cell.chars().count());
+                if let Some(w) = cell.split_whitespace().map(|w| w.chars().count()).max() {
+                    col_word_max = col_word_max.max(w);
+                }
+            }
+        }
+        *mc = col_max.max(1);
+        max_word_len[c] = col_word_max.max(1);
+    }
+
+    let min_widths: Vec<f64> = max_word_len
+        .iter()
+        .map(|w| (*w as f64 * char_width).max(min_col_width))
+        .collect();
+
+    let mut widths: Vec<f64> = match algorithm {
+        "equalize" => equalize_widths(&max_chars, &min_widths, char_width, available_width),
+        "sqrt" => {
+            let weights: Vec<f64> = max_chars
+                .iter()
+                .map(|mc| (*mc as f64).sqrt().max(1.0))
+                .collect();
+            let total: f64 = weights.iter().sum();
+            weights
+                .iter()
+                .map(|w| (available_width * w / total).max(min_col_width))
+                .collect()
+        }
+        _ => {
+            let weights: Vec<f64> = max_chars.iter().map(|mc| (*mc as f64).max(1.0)).collect();
+            let total: f64 = weights.iter().sum();
+            weights
+                .iter()
+                .map(|w| (available_width * w / total).max(min_col_width))
+                .collect()
+        }
+    };
+
+    let total: f64 = widths.iter().sum();
+    if total > available_width {
+        let factor = available_width / total;
+        for w in &mut widths {
+            *w *= factor;
+        }
+    }
+    widths
+}
+
+/// Equalize line counts via binary search on the target line count.
+///
+/// Why: Balancing by line count keeps rows visually even without a font metric
+/// engine.
+/// What: Finds the largest `T` such that `sum(ceil(chars/T)*char_width)` clamped
+/// to `min_widths` fits `available_width`, then distributes leftover space.
+/// Test: covered via `balance_widths_equalize` below.
+pub(crate) fn equalize_widths(
+    max_chars: &[usize],
+    min_widths: &[f64],
+    char_width: f64,
+    available_width: f64,
+) -> Vec<f64> {
+    let num_cols = max_chars.len();
+    let overall_max = *max_chars.iter().max().unwrap_or(&1);
+    let mut best = vec![available_width / num_cols as f64; num_cols];
+
+    let (mut lo, mut hi) = (1i64, overall_max as i64);
+    while lo <= hi {
+        let t = (lo + hi) / 2;
+        let clamped: Vec<f64> = max_chars
+            .iter()
+            .zip(min_widths)
+            .map(|(mc, mw)| {
+                let lines = ((*mc as f64) / (t as f64)).ceil();
+                (lines * char_width).max(*mw)
+            })
+            .collect();
+        if clamped.iter().sum::<f64>() <= available_width {
+            best = clamped;
+            lo = t + 1;
+        } else {
+            hi = t - 1;
+        }
+    }
+
+    let leftover = available_width - best.iter().sum::<f64>();
+    if leftover > 0.5 {
+        let mut benefiting: Vec<usize> = (0..num_cols)
+            .filter(|&i| best[i] < max_chars[i] as f64 * char_width)
+            .collect();
+        if benefiting.is_empty() {
+            benefiting = (0..num_cols).collect();
+        }
+        let share = leftover / benefiting.len() as f64;
+        for i in benefiting {
+            best[i] += share;
+        }
+    }
+    best
+}
+
+fn f64_arg(args: &Value, key: &str, default: f64) -> f64 {
+    args.get(key).and_then(|v| v.as_f64()).unwrap_or(default)
+}
+
+/// Why: Apply padding/border/background/alignment to a rectangular selection of
+/// cells; `-1` targets all rows/columns.
+/// What: Expands the target set and posts one `updateTableCellStyle` per cell.
+/// Test: `build_cell_style_request` is unit-tested; the call is live-only.
+pub async fn format_table_cells(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let table_start_index = args
+        .get("table_start_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing table_start_index"))?;
+    let row_index = args
+        .get("row_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing row_index"))?;
+    let column_index = args
+        .get("column_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing column_index"))?;
+    let num_rows = args.get("num_rows").and_then(|v| v.as_i64()).unwrap_or(0);
+    let num_columns = args
+        .get("num_columns")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    let padding = args.get("padding");
+    let border = args.get("border");
+    let background_color = args.get("background_color");
+    let content_alignment = args.get("content_alignment").and_then(|v| v.as_str());
+
+    let targets: Vec<(i64, i64)> = match (row_index, column_index) {
+        (-1, -1) => (0..num_rows)
+            .flat_map(|r| (0..num_columns).map(move |c| (r, c)))
+            .collect(),
+        (-1, c) => (0..num_rows).map(|r| (r, c)).collect(),
+        (r, -1) => (0..num_columns).map(|c| (r, c)).collect(),
+        (r, c) => vec![(r, c)],
+    };
+
+    let requests: Vec<Value> = targets
+        .iter()
+        .filter_map(|&(r, c)| {
+            build_cell_style_request(
+                table_start_index,
+                r,
+                c,
+                padding,
+                border,
+                background_color,
+                content_alignment,
+            )
+        })
+        .collect();
+
+    if requests.is_empty() {
+        return Ok(json!({ "status": "no_formatting_applied", "document_id": id }));
+    }
+    let url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+    client
+        .post(&url, json!({ "requests": requests }), account)
+        .await?;
+    Ok(json!({
+        "status": "formatted",
+        "document_id": id,
+        "table_start_index": table_start_index,
+        "cells_updated": requests.len(),
+    }))
+}
+
+/// Why: Explicit or auto-balanced column widths control table layout.
+/// What: Either balances from `data` or applies the supplied `column_widths`
+/// (null = evenly distributed) as `updateTableColumnProperties` requests.
+/// Test: `balance_column_widths` / `build_column_width_request` are unit-tested;
+/// the call is live-only.
+pub async fn set_table_column_widths(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let table_start_index = args
+        .get("table_start_index")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow!("missing table_start_index"))?;
+    let auto_balance = args
+        .get("auto_balance")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let algorithm = args
+        .get("algorithm")
+        .and_then(|v| v.as_str())
+        .unwrap_or("equalize");
+
+    // widths: each entry is Some(w) for a fixed width or None for evenly distributed.
+    let widths: Vec<Option<f64>> = if auto_balance {
+        let data = parse_2d_strings(args.get("data"));
+        if data.is_empty() {
+            return Ok(
+                json!({ "status": "error", "message": "data is required when auto_balance=true" }),
+            );
+        }
+        balance_column_widths(
+            &data,
+            f64_arg(&args, "available_width", DEFAULT_AVAILABLE_WIDTH),
+            f64_arg(&args, "font_size", DEFAULT_FONT_SIZE),
+            f64_arg(&args, "min_col_width", DEFAULT_MIN_COL_WIDTH),
+            algorithm,
+        )
+        .into_iter()
+        .map(Some)
+        .collect()
+    } else {
+        args.get("column_widths")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().map(|v| v.as_f64()).collect())
+            .unwrap_or_default()
+    };
+
+    if widths.is_empty() {
+        return Ok(json!({ "status": "no_widths_applied", "document_id": id }));
+    }
+    let requests: Vec<Value> = widths
+        .iter()
+        .enumerate()
+        .map(|(i, w)| build_column_width_request(table_start_index, i as i64, *w))
+        .collect();
+    let url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+    client
+        .post(&url, json!({ "requests": requests }), account)
+        .await?;
+    Ok(json!({
+        "status": "applied",
+        "document_id": id,
+        "table_start_index": table_start_index,
+        "columns_updated": requests.len(),
+        "auto_balance": auto_balance,
+        "algorithm": if auto_balance { Value::from(algorithm) } else { Value::Null },
+    }))
+}
+
+/// Parse a JSON 2-D array of strings into `Vec<Vec<String>>` (best-effort).
+pub(crate) fn parse_2d_strings(value: Option<&Value>) -> Vec<Vec<String>> {
+    value
+        .and_then(|v| v.as_array())
+        .map(|rows| {
+            rows.iter()
+                .map(|row| {
+                    row.as_array()
+                        .map(|cells| {
+                            cells
+                                .iter()
+                                .map(|c| c.as_str().unwrap_or("").to_string())
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cell_style_request_padding_and_fields() {
+        let padding = json!({ "top": 4, "left": 6 });
+        let r = build_cell_style_request(10, 1, 2, Some(&padding), None, None, None).unwrap();
+        let inner = &r["updateTableCellStyle"];
+        let fields = inner["fields"].as_str().unwrap();
+        assert!(fields.contains("paddingTop"));
+        assert!(fields.contains("paddingLeft"));
+        assert_eq!(inner["tableCellStyle"]["paddingTop"]["magnitude"], 4.0);
+        assert_eq!(
+            inner["tableRange"]["tableCellLocation"]["tableStartLocation"]["index"],
+            10
+        );
+    }
+
+    #[test]
+    fn cell_style_request_border_default_sides() {
+        let border = json!({ "color": { "red": 0.4 }, "width": 1.0 });
+        let r = build_cell_style_request(0, 0, 0, None, Some(&border), None, None).unwrap();
+        let fields = r["updateTableCellStyle"]["fields"].as_str().unwrap();
+        for side in ["borderTop", "borderBottom", "borderLeft", "borderRight"] {
+            assert!(fields.contains(side), "missing {side}");
+        }
+        assert_eq!(
+            r["updateTableCellStyle"]["tableCellStyle"]["borderTop"]["dashStyle"],
+            "SOLID"
+        );
+    }
+
+    #[test]
+    fn cell_style_request_border_explicit_sides() {
+        let border = json!({ "sides": ["top"], "width": 2.0 });
+        let r = build_cell_style_request(0, 0, 0, None, Some(&border), None, None).unwrap();
+        let fields = r["updateTableCellStyle"]["fields"].as_str().unwrap();
+        assert_eq!(fields, "borderTop");
+    }
+
+    #[test]
+    fn cell_style_request_background_and_alignment() {
+        let bg = json!({ "red": 0.9, "green": 0.9, "blue": 0.9 });
+        let r = build_cell_style_request(0, 0, 0, None, None, Some(&bg), Some("MIDDLE")).unwrap();
+        let fields = r["updateTableCellStyle"]["fields"].as_str().unwrap();
+        assert!(fields.contains("backgroundColor"));
+        assert!(fields.contains("contentAlignment"));
+        assert_eq!(
+            r["updateTableCellStyle"]["tableCellStyle"]["contentAlignment"],
+            "MIDDLE"
+        );
+    }
+
+    #[test]
+    fn cell_style_request_none_when_empty() {
+        assert!(build_cell_style_request(0, 0, 0, None, None, None, None).is_none());
+    }
+
+    #[test]
+    fn column_width_request_fixed() {
+        let r = build_column_width_request(5, 1, Some(120.0));
+        let props = &r["updateTableColumnProperties"]["tableColumnProperties"];
+        assert_eq!(props["widthType"], "FIXED_WIDTH");
+        assert_eq!(props["width"]["magnitude"], 120.0);
+        assert_eq!(r["updateTableColumnProperties"]["columnIndices"][0], 1);
+    }
+
+    #[test]
+    fn column_width_request_evenly_distributed_for_null() {
+        let r = build_column_width_request(5, 0, None);
+        assert_eq!(
+            r["updateTableColumnProperties"]["tableColumnProperties"]["widthType"],
+            "EVENLY_DISTRIBUTED"
+        );
+        let r2 = build_column_width_request(5, 0, Some(0.0));
+        assert_eq!(
+            r2["updateTableColumnProperties"]["tableColumnProperties"]["widthType"],
+            "EVENLY_DISTRIBUTED"
+        );
+    }
+
+    #[test]
+    fn balance_widths_equalize_sums_within_available() {
+        let data = vec![
+            vec![
+                "short".to_string(),
+                "a much longer cell of content".to_string(),
+            ],
+            vec![
+                "x".to_string(),
+                "another long body of text here".to_string(),
+            ],
+        ];
+        let widths = balance_column_widths(&data, 468.0, 11.0, 60.0, "equalize");
+        assert_eq!(widths.len(), 2);
+        let total: f64 = widths.iter().sum();
+        assert!(total <= 468.0 + 0.01, "total {total} exceeds available");
+        assert!(widths.iter().all(|w| *w > 0.0));
+    }
+
+    #[test]
+    fn balance_widths_proportional_wider_for_longer_column() {
+        let data = vec![vec!["a".to_string(), "aaaaaaaaaaaaaaaaaaaa".to_string()]];
+        let widths = balance_column_widths(&data, 468.0, 11.0, 20.0, "proportional");
+        assert!(widths[1] > widths[0], "longer column should be wider");
+    }
+
+    #[test]
+    fn balance_widths_empty_data() {
+        assert!(balance_column_widths(&[], 468.0, 11.0, 60.0, "equalize").is_empty());
+    }
+
+    #[test]
+    fn parse_2d_strings_reads_grid() {
+        let v = json!([["a", "b"], ["c"]]);
+        let grid = parse_2d_strings(Some(&v));
+        assert_eq!(grid, vec![vec!["a", "b"], vec!["c"]]);
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/docs/tabs.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/tabs.rs
@@ -138,6 +138,24 @@ pub(crate) fn format_tabs(tabs: &[Value]) -> Vec<Value> {
         .collect()
 }
 
+/// Why: Nested tabs live in each tab's `childTabs` array (per Google's "Work
+/// with tabs" guide), not in a single flat top-level list. `list` and
+/// `get_content` must see the whole tree or child tabs are invisible and
+/// `get_content`/lookups on a nested `tab_id` wrongly report "not found".
+/// What: Depth-first flattens `tabs` together with each tab's `childTabs`,
+/// recursively, into one vec (parent before its children).
+/// Test: `flatten_tabs_includes_nested_children` below.
+pub(crate) fn flatten_tabs(tabs: &[Value]) -> Vec<Value> {
+    let mut out = Vec::new();
+    for tab in tabs {
+        out.push(tab.clone());
+        if let Some(children) = tab.get("childTabs").and_then(|c| c.as_array()) {
+            out.extend(flatten_tabs(children));
+        }
+    }
+    out
+}
+
 /// Extract concatenated plain text from a Docs body-like structure.
 ///
 /// Why: `get_content` returns a tab's text; tab bodies use the same
@@ -182,11 +200,12 @@ pub async fn manage_document_tabs(client: &BaseClient, args: Value) -> Result<Va
     match action {
         "list" => {
             let resp = client.get(&tabs_url, account).await?;
-            let tabs = resp
+            let top_level = resp
                 .get("tabs")
                 .and_then(|t| t.as_array())
                 .cloned()
                 .unwrap_or_default();
+            let tabs = flatten_tabs(&top_level);
             if tabs.is_empty() {
                 return Ok(json!({
                     "document_id": id,
@@ -201,11 +220,12 @@ pub async fn manage_document_tabs(client: &BaseClient, args: Value) -> Result<Va
         "get_content" => {
             let tab_id = require_str(&args, "tab_id")?;
             let resp = client.get(&tabs_url, account).await?;
-            let empty = Vec::new();
-            let tabs = resp
+            let top_level = resp
                 .get("tabs")
                 .and_then(|t| t.as_array())
-                .unwrap_or(&empty);
+                .cloned()
+                .unwrap_or_default();
+            let tabs = flatten_tabs(&top_level);
             let target = tabs.iter().find(|t| {
                 t.get("tabProperties")
                     .and_then(|p| p.get("tabId"))
@@ -422,6 +442,69 @@ mod tests {
         assert!(out[0].get("icon_emoji").is_none());
         assert!(out[0].get("parent_tab_id").is_none());
         assert_eq!(out[0]["index"], 0);
+    }
+
+    #[test]
+    fn flatten_tabs_includes_nested_children() {
+        let tabs = vec![json!({
+            "tabProperties": { "tabId": "root1", "title": "Root" },
+            "childTabs": [
+                {
+                    "tabProperties": { "tabId": "child1", "title": "Child" },
+                    "childTabs": [
+                        { "tabProperties": { "tabId": "grandchild1", "title": "Grandchild" } }
+                    ]
+                },
+                { "tabProperties": { "tabId": "child2", "title": "Child2" } },
+            ]
+        })];
+        let flat = flatten_tabs(&tabs);
+        let ids: Vec<&str> = flat
+            .iter()
+            .map(|t| t["tabProperties"]["tabId"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["root1", "child1", "grandchild1", "child2"]);
+    }
+
+    #[test]
+    fn flatten_tabs_no_children_is_identity() {
+        let tabs = vec![json!({ "tabProperties": { "tabId": "t1" } })];
+        assert_eq!(flatten_tabs(&tabs).len(), 1);
+    }
+
+    #[test]
+    fn get_content_finds_nested_tab_by_id() {
+        // Regression for the HIGH finding: get_content must find a tab_id
+        // that lives inside childTabs, not just the top-level array.
+        let top_level = vec![json!({
+            "tabProperties": { "tabId": "root1", "title": "Root" },
+            "documentTab": { "body": { "content": [] } },
+            "childTabs": [
+                {
+                    "tabProperties": { "tabId": "nested1", "title": "Nested" },
+                    "documentTab": { "body": { "content": [
+                        { "paragraph": { "elements": [ { "textRun": { "content": "hi" } } ] } }
+                    ] } },
+                }
+            ]
+        })];
+        let flat = flatten_tabs(&top_level);
+        let found = flat.iter().find(|t| {
+            t.get("tabProperties")
+                .and_then(|p| p.get("tabId"))
+                .and_then(|v| v.as_str())
+                == Some("nested1")
+        });
+        assert!(
+            found.is_some(),
+            "nested tab must be discoverable after flattening"
+        );
+        let body = found
+            .unwrap()
+            .get("documentTab")
+            .and_then(|d| d.get("body"))
+            .unwrap();
+        assert_eq!(extract_body_text(body), "hi");
     }
 
     #[test]

--- a/crates/trusty-gworkspace/src/api/services/docs/tabs.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/tabs.rs
@@ -1,0 +1,440 @@
+//! Google Docs tab management.
+//!
+//! Why: Docs added multi-tab documents; agents need to list, read, create,
+//! rename and reorder tabs. These are `createTab` / `updateTabProperties`
+//! batchUpdate requests plus `includeTabsContent=true` reads.
+//! What: `manage_document_tabs` (list/get_content/create/update/move) and the
+//! standalone `create_document_tab` convenience tool.
+//! Test: Pure request/response builders are unit-tested below; the network
+//! round-trip is live-only.
+
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+
+use crate::api::client::BaseClient;
+use crate::api::constants::DOCS_API_BASE;
+use crate::api::services::{account_of, opt_str, require_str};
+
+/// Why: `create` and the standalone `create_document_tab` share one request shape.
+/// What: Builds a `createTab` request, attaching only the supplied optional
+/// `tabProperties` (iconEmoji, parentTabId, index).
+/// Test: `create_tab_request_*` below.
+pub(crate) fn build_create_tab_request(
+    title: &str,
+    icon_emoji: Option<&str>,
+    parent_tab_id: Option<&str>,
+    index: Option<i64>,
+) -> Value {
+    let mut props = json!({ "title": title });
+    if let Some(icon) = icon_emoji {
+        props["iconEmoji"] = json!(icon);
+    }
+    if let Some(parent) = parent_tab_id {
+        props["parentTabId"] = json!(parent);
+    }
+    if let Some(i) = index {
+        props["index"] = json!(i);
+    }
+    json!({ "createTab": { "tabProperties": props } })
+}
+
+/// Why: `update` mutates title and/or icon and must set the matching field mask.
+/// What: Builds an `updateTabProperties` request; errors when neither field is
+/// supplied so the caller reports a clean validation error.
+/// Test: `update_tab_request_*` below.
+pub(crate) fn build_update_tab_request(
+    tab_id: &str,
+    title: Option<&str>,
+    icon_emoji: Option<&str>,
+) -> Result<Value> {
+    let mut props = json!({});
+    let mut fields = Vec::<&str>::new();
+    if let Some(t) = title {
+        props["title"] = json!(t);
+        fields.push("title");
+    }
+    if let Some(icon) = icon_emoji {
+        props["iconEmoji"] = json!(icon);
+        fields.push("iconEmoji");
+    }
+    if fields.is_empty() {
+        return Err(anyhow!(
+            "at least one of 'title' or 'icon_emoji' must be provided"
+        ));
+    }
+    Ok(json!({
+        "updateTabProperties": {
+            "tabId": tab_id,
+            "tabProperties": props,
+            "fields": fields.join(","),
+        }
+    }))
+}
+
+/// Why: `move` re-parents / re-orders a tab; an empty `new_parent_tab_id`
+/// promotes the tab to root level (JSON null parentTabId).
+/// What: Builds an `updateTabProperties` request carrying parentTabId and/or
+/// index with the matching field mask.
+/// Test: `move_tab_request_*` below.
+pub(crate) fn build_move_tab_request(
+    tab_id: &str,
+    new_parent_tab_id: Option<&str>,
+    new_index: Option<i64>,
+) -> Result<Value> {
+    let mut props = json!({});
+    let mut fields = Vec::<&str>::new();
+    if let Some(parent) = new_parent_tab_id {
+        // Empty string => move to root: send explicit null.
+        props["parentTabId"] = if parent.is_empty() {
+            Value::Null
+        } else {
+            json!(parent)
+        };
+        fields.push("parentTabId");
+    }
+    if let Some(i) = new_index {
+        props["index"] = json!(i);
+        fields.push("index");
+    }
+    if fields.is_empty() {
+        return Err(anyhow!(
+            "at least one of 'new_parent_tab_id' or 'new_index' must be provided"
+        ));
+    }
+    Ok(json!({
+        "updateTabProperties": {
+            "tabId": tab_id,
+            "tabProperties": props,
+            "fields": fields.join(","),
+        }
+    }))
+}
+
+/// Why: The raw Docs `tabProperties` shape is verbose; callers want a compact list.
+/// What: Maps each tab's `tabProperties` to snake_case fields, omitting absent
+/// optional keys (icon_emoji, parent_tab_id).
+/// Test: `format_tabs_maps_properties` below.
+pub(crate) fn format_tabs(tabs: &[Value]) -> Vec<Value> {
+    tabs.iter()
+        .map(|tab| {
+            let props = tab
+                .get("tabProperties")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let mut out = json!({
+                "tab_id": props.get("tabId"),
+                "title": props.get("title").cloned().unwrap_or_else(|| json!("")),
+                "index": props.get("index").cloned().unwrap_or_else(|| json!(0)),
+                "nesting_level": props.get("nestingLevel").cloned().unwrap_or_else(|| json!(0)),
+            });
+            if let Some(icon) = props.get("iconEmoji") {
+                out["icon_emoji"] = icon.clone();
+            }
+            if let Some(parent) = props.get("parentTabId") {
+                out["parent_tab_id"] = parent.clone();
+            }
+            out
+        })
+        .collect()
+}
+
+/// Extract concatenated plain text from a Docs body-like structure.
+///
+/// Why: `get_content` returns a tab's text; tab bodies use the same
+/// `content -> paragraph -> elements -> textRun` shape as the document body.
+/// What: Walks paragraph text runs and concatenates their content.
+/// Test: `extract_body_text_concatenates_runs` below.
+pub(crate) fn extract_body_text(body: &Value) -> String {
+    let mut out = String::new();
+    if let Some(content) = body.get("content").and_then(|c| c.as_array()) {
+        for el in content {
+            if let Some(elements) = el
+                .get("paragraph")
+                .and_then(|p| p.get("elements"))
+                .and_then(|e| e.as_array())
+            {
+                for pe in elements {
+                    if let Some(text) = pe
+                        .get("textRun")
+                        .and_then(|t| t.get("content"))
+                        .and_then(|c| c.as_str())
+                    {
+                        out.push_str(text);
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Why: Tab operations share one action enum so callers reach them through a
+/// single tool with a small, discoverable surface.
+/// What: Dispatches `list|get_content|create|update|move` to the Docs API.
+/// Test: Builders above are unit-tested; dispatch is live-only.
+pub async fn manage_document_tabs(client: &BaseClient, args: Value) -> Result<Value> {
+    let action = require_str(&args, "action")?;
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let batch_url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+    let tabs_url = format!("{DOCS_API_BASE}/documents/{id}?includeTabsContent=true");
+
+    match action {
+        "list" => {
+            let resp = client.get(&tabs_url, account).await?;
+            let tabs = resp
+                .get("tabs")
+                .and_then(|t| t.as_array())
+                .cloned()
+                .unwrap_or_default();
+            if tabs.is_empty() {
+                return Ok(json!({
+                    "document_id": id,
+                    "tabs": [],
+                    "count": 0,
+                    "message": "Document has no tabs or only a single tab",
+                }));
+            }
+            let formatted = format_tabs(&tabs);
+            Ok(json!({ "document_id": id, "count": formatted.len(), "tabs": formatted }))
+        }
+        "get_content" => {
+            let tab_id = require_str(&args, "tab_id")?;
+            let resp = client.get(&tabs_url, account).await?;
+            let empty = Vec::new();
+            let tabs = resp
+                .get("tabs")
+                .and_then(|t| t.as_array())
+                .unwrap_or(&empty);
+            let target = tabs.iter().find(|t| {
+                t.get("tabProperties")
+                    .and_then(|p| p.get("tabId"))
+                    .and_then(|v| v.as_str())
+                    == Some(tab_id)
+            });
+            let Some(target) = target else {
+                let available: Vec<Value> = tabs
+                    .iter()
+                    .filter_map(|t| t.get("tabProperties").and_then(|p| p.get("tabId")).cloned())
+                    .collect();
+                return Ok(json!({
+                    "error": format!("Tab '{tab_id}' not found in document"),
+                    "document_id": id,
+                    "available_tabs": available,
+                }));
+            };
+            let props = target
+                .get("tabProperties")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let tab_body = target
+                .get("documentTab")
+                .and_then(|d| d.get("body"))
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let mut result = json!({
+                "document_id": id,
+                "tab_id": tab_id,
+                "title": props.get("title").cloned().unwrap_or_else(|| json!("")),
+                "index": props.get("index").cloned().unwrap_or_else(|| json!(0)),
+                "nesting_level": props.get("nestingLevel").cloned().unwrap_or_else(|| json!(0)),
+                "text_content": extract_body_text(&tab_body),
+            });
+            if let Some(icon) = props.get("iconEmoji") {
+                result["icon_emoji"] = icon.clone();
+            }
+            if let Some(parent) = props.get("parentTabId") {
+                result["parent_tab_id"] = parent.clone();
+            }
+            Ok(result)
+        }
+        "create" => {
+            let title = require_str(&args, "title")?;
+            let req = build_create_tab_request(
+                title,
+                opt_str(&args, "icon_emoji"),
+                opt_str(&args, "parent_tab_id"),
+                args.get("index").and_then(|v| v.as_i64()),
+            );
+            let resp = client
+                .post(&batch_url, json!({ "requests": [req] }), account)
+                .await?;
+            let new_tab_id = resp
+                .get("replies")
+                .and_then(|r| r.as_array())
+                .and_then(|a| a.first())
+                .and_then(|r| r.get("createTab"))
+                .and_then(|c| c.get("tabId"))
+                .cloned();
+            Ok(json!({
+                "status": "created",
+                "document_id": id,
+                "tab_id": new_tab_id,
+                "title": title,
+            }))
+        }
+        "update" => {
+            let tab_id = require_str(&args, "tab_id")?;
+            let req = build_update_tab_request(
+                tab_id,
+                opt_str(&args, "title"),
+                opt_str(&args, "icon_emoji"),
+            )?;
+            client
+                .post(&batch_url, json!({ "requests": [req] }), account)
+                .await?;
+            Ok(json!({ "status": "updated", "document_id": id, "tab_id": tab_id }))
+        }
+        "move" => {
+            let tab_id = require_str(&args, "tab_id")?;
+            // `new_parent_tab_id` may legitimately be the empty string (root),
+            // so read it as a raw optional string rather than via opt_str.
+            let new_parent = args.get("new_parent_tab_id").and_then(|v| v.as_str());
+            let req = build_move_tab_request(
+                tab_id,
+                new_parent,
+                args.get("new_index").and_then(|v| v.as_i64()),
+            )?;
+            client
+                .post(&batch_url, json!({ "requests": [req] }), account)
+                .await?;
+            Ok(json!({ "status": "moved", "document_id": id, "tab_id": tab_id }))
+        }
+        other => Err(anyhow!("unknown action for manage_document_tabs: {other}")),
+    }
+}
+
+/// Why: A dedicated create tool mirrors the upstream convenience entry point.
+/// What: Builds one `createTab` request and returns the new tab id.
+/// Test: `build_create_tab_request` is unit-tested; the call is live-only.
+pub async fn create_document_tab(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let title = require_str(&args, "title")?;
+    let req = build_create_tab_request(
+        title,
+        opt_str(&args, "icon_emoji"),
+        opt_str(&args, "parent_tab_id"),
+        args.get("index").and_then(|v| v.as_i64()),
+    );
+    let url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+    let resp = client
+        .post(&url, json!({ "requests": [req] }), account)
+        .await?;
+    let new_tab_id = resp
+        .get("replies")
+        .and_then(|r| r.as_array())
+        .and_then(|a| a.first())
+        .and_then(|r| r.get("createTab"))
+        .and_then(|c| c.get("tabId"))
+        .cloned();
+    Ok(json!({
+        "status": "created",
+        "document_id": id,
+        "tab_id": new_tab_id,
+        "title": title,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_tab_request_minimal() {
+        let r = build_create_tab_request("Intro", None, None, None);
+        assert_eq!(r["createTab"]["tabProperties"]["title"], "Intro");
+        assert!(r["createTab"]["tabProperties"].get("iconEmoji").is_none());
+        assert!(r["createTab"]["tabProperties"].get("index").is_none());
+    }
+
+    #[test]
+    fn create_tab_request_full() {
+        let r = build_create_tab_request("Ch1", Some("📘"), Some("parent-1"), Some(2));
+        let props = &r["createTab"]["tabProperties"];
+        assert_eq!(props["iconEmoji"], "📘");
+        assert_eq!(props["parentTabId"], "parent-1");
+        assert_eq!(props["index"], 2);
+    }
+
+    #[test]
+    fn update_tab_request_sets_field_mask() {
+        let r = build_update_tab_request("t1", Some("New"), None).unwrap();
+        assert_eq!(r["updateTabProperties"]["fields"], "title");
+        assert_eq!(r["updateTabProperties"]["tabProperties"]["title"], "New");
+
+        let both = build_update_tab_request("t1", Some("N"), Some("📗")).unwrap();
+        assert_eq!(both["updateTabProperties"]["fields"], "title,iconEmoji");
+    }
+
+    #[test]
+    fn update_tab_request_requires_a_field() {
+        assert!(build_update_tab_request("t1", None, None).is_err());
+    }
+
+    #[test]
+    fn move_tab_request_root_sends_null_parent() {
+        let r = build_move_tab_request("t1", Some(""), None).unwrap();
+        assert!(r["updateTabProperties"]["tabProperties"]["parentTabId"].is_null());
+        assert_eq!(r["updateTabProperties"]["fields"], "parentTabId");
+    }
+
+    #[test]
+    fn move_tab_request_parent_and_index() {
+        let r = build_move_tab_request("t1", Some("p2"), Some(3)).unwrap();
+        assert_eq!(
+            r["updateTabProperties"]["tabProperties"]["parentTabId"],
+            "p2"
+        );
+        assert_eq!(r["updateTabProperties"]["tabProperties"]["index"], 3);
+        assert_eq!(r["updateTabProperties"]["fields"], "parentTabId,index");
+    }
+
+    #[test]
+    fn move_tab_request_requires_a_field() {
+        assert!(build_move_tab_request("t1", None, None).is_err());
+    }
+
+    #[test]
+    fn format_tabs_maps_properties() {
+        let tabs = vec![json!({
+            "tabProperties": {
+                "tabId": "t1",
+                "title": "Overview",
+                "index": 0,
+                "nestingLevel": 1,
+                "iconEmoji": "📘",
+                "parentTabId": "root",
+            }
+        })];
+        let out = format_tabs(&tabs);
+        assert_eq!(out[0]["tab_id"], "t1");
+        assert_eq!(out[0]["title"], "Overview");
+        assert_eq!(out[0]["nesting_level"], 1);
+        assert_eq!(out[0]["icon_emoji"], "📘");
+        assert_eq!(out[0]["parent_tab_id"], "root");
+    }
+
+    #[test]
+    fn format_tabs_omits_absent_optionals() {
+        let tabs = vec![json!({ "tabProperties": { "tabId": "t2", "title": "Body" } })];
+        let out = format_tabs(&tabs);
+        assert!(out[0].get("icon_emoji").is_none());
+        assert!(out[0].get("parent_tab_id").is_none());
+        assert_eq!(out[0]["index"], 0);
+    }
+
+    #[test]
+    fn extract_body_text_concatenates_runs() {
+        let body = json!({
+            "content": [
+                { "paragraph": { "elements": [
+                    { "textRun": { "content": "Hello " } },
+                    { "textRun": { "content": "world" } },
+                ] } },
+                { "paragraph": { "elements": [ { "textRun": { "content": "!" } } ] } },
+            ]
+        });
+        assert_eq!(extract_body_text(&body), "Hello world!");
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/docs/templates.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/templates.rs
@@ -39,8 +39,12 @@ pub(crate) fn build_replacement_requests(replacements: &Value) -> Vec<Value> {
 }
 
 /// Why: A named-style update must translate ergonomic snake_case fields into the
-/// Docs `updateNamedStyle` shape and emit separate text/paragraph field masks.
-/// What: Builds one `updateNamedStyle` request from a spec, returning `None`
+/// Docs `updateNamedStyle` shape. The real `UpdateNamedStyleRequest` has a
+/// single `fields` FieldMask on the request (not separate `textStyleFields`/
+/// `paragraphStyleFields` keys, which don't exist in the API) — each changed
+/// leaf must be addressed as `textStyle.<field>` or `paragraphStyle.<field>`.
+/// What: Builds one `updateNamedStyle` request from a spec, joining every
+/// changed text/paragraph field into one dotted `fields` mask. Returns `None`
 /// when neither a text nor paragraph field is supplied.
 /// Test: `named_style_request_*` below.
 pub(crate) fn build_named_style_request(spec: &Value) -> Option<Value> {
@@ -108,13 +112,21 @@ pub(crate) fn build_named_style_request(spec: &Value) -> Option<Value> {
         named_style["paragraphStyle"] = paragraph_style;
     }
 
-    let mut request = json!({ "updateNamedStyle": { "namedStyle": named_style } });
-    if !text_fields.is_empty() {
-        request["updateNamedStyle"]["textStyleFields"] = json!(text_fields.join(","));
-    }
-    if !para_fields.is_empty() {
-        request["updateNamedStyle"]["paragraphStyleFields"] = json!(para_fields.join(","));
-    }
+    // The Docs API's UpdateNamedStyleRequest has exactly one `fields`
+    // FieldMask on the request itself; nested textStyle/paragraphStyle
+    // fields are addressed with a dotted prefix.
+    let mut mask_parts: Vec<String> = text_fields
+        .iter()
+        .map(|f| format!("textStyle.{f}"))
+        .collect();
+    mask_parts.extend(para_fields.iter().map(|f| format!("paragraphStyle.{f}")));
+
+    let request = json!({
+        "updateNamedStyle": {
+            "namedStyle": named_style,
+            "fields": mask_parts.join(","),
+        }
+    });
     Some(request)
 }
 
@@ -297,16 +309,27 @@ mod tests {
         let r = build_named_style_request(&spec).unwrap();
         let inner = &r["updateNamedStyle"];
         assert_eq!(inner["namedStyle"]["namedStyleType"], "HEADING_1");
-        let tf = inner["textStyleFields"].as_str().unwrap();
-        assert!(tf.contains("bold"));
-        assert!(tf.contains("fontSize"));
-        let pf = inner["paragraphStyleFields"].as_str().unwrap();
-        assert!(pf.contains("alignment"));
-        assert!(pf.contains("spaceAbove"));
+        // A single dotted `fields` FieldMask on the request — not the
+        // nonexistent textStyleFields/paragraphStyleFields keys.
+        assert!(inner.get("textStyleFields").is_none());
+        assert!(inner.get("paragraphStyleFields").is_none());
+        let fields = inner["fields"].as_str().unwrap();
+        assert!(fields.contains("textStyle.bold"));
+        assert!(fields.contains("textStyle.fontSize"));
+        assert!(fields.contains("paragraphStyle.alignment"));
+        assert!(fields.contains("paragraphStyle.spaceAbove"));
         assert_eq!(
             inner["namedStyle"]["textStyle"]["fontSize"]["magnitude"],
             20.0
         );
+    }
+
+    #[test]
+    fn named_style_request_text_only_omits_paragraph_prefix() {
+        let spec = json!({ "named_style_type": "NORMAL_TEXT", "text_style": { "italic": true } });
+        let r = build_named_style_request(&spec).unwrap();
+        let fields = r["updateNamedStyle"]["fields"].as_str().unwrap();
+        assert_eq!(fields, "textStyle.italic");
     }
 
     #[test]

--- a/crates/trusty-gworkspace/src/api/services/docs/templates.rs
+++ b/crates/trusty-gworkspace/src/api/services/docs/templates.rs
@@ -1,0 +1,347 @@
+//! Docs templates and named-style management.
+//!
+//! Why: Template-driven document creation and named-style editing are common
+//! authoring flows: copy a source doc + `replaceAllText` placeholders, and
+//! read/update the `namedStyles` definitions.
+//! What: `create_document_from_template` (Drive copy + placeholder fill),
+//! `get_document_named_styles`, and `update_document_named_styles`
+//! (`updateNamedStyle`).
+//! Test: Pure request builders / response parsers are unit-tested below; the
+//! round-trip is live-only.
+
+use anyhow::Result;
+use serde_json::{Value, json};
+
+use crate::api::client::BaseClient;
+use crate::api::constants::{DOCS_API_BASE, DRIVE_API_BASE};
+use crate::api::services::{account_of, require_str};
+
+/// Why: Placeholders are matched literally as `{{KEY}}`; each becomes a
+/// case-sensitive `replaceAllText` request.
+/// What: Maps a `{key: value}` object into a vec of `replaceAllText` requests.
+/// Test: `replacement_requests_wrap_keys` below.
+pub(crate) fn build_replacement_requests(replacements: &Value) -> Vec<Value> {
+    let Some(map) = replacements.as_object() else {
+        return Vec::new();
+    };
+    map.iter()
+        .filter_map(|(key, value)| {
+            value.as_str().map(|v| {
+                json!({
+                    "replaceAllText": {
+                        "containsText": { "text": format!("{{{{{key}}}}}"), "matchCase": true },
+                        "replaceText": v,
+                    }
+                })
+            })
+        })
+        .collect()
+}
+
+/// Why: A named-style update must translate ergonomic snake_case fields into the
+/// Docs `updateNamedStyle` shape and emit separate text/paragraph field masks.
+/// What: Builds one `updateNamedStyle` request from a spec, returning `None`
+/// when neither a text nor paragraph field is supplied.
+/// Test: `named_style_request_*` below.
+pub(crate) fn build_named_style_request(spec: &Value) -> Option<Value> {
+    let named_style_type = spec.get("named_style_type").and_then(|v| v.as_str())?;
+
+    let ts = spec.get("text_style").cloned().unwrap_or_else(|| json!({}));
+    let ps = spec
+        .get("paragraph_style")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    let mut text_style = json!({});
+    let mut text_fields = Vec::<&str>::new();
+    for (arg, field) in [
+        ("bold", "bold"),
+        ("italic", "italic"),
+        ("underline", "underline"),
+    ] {
+        if let Some(b) = ts.get(arg).and_then(|v| v.as_bool()) {
+            text_style[field] = json!(b);
+            text_fields.push(field);
+        }
+    }
+    if let Some(size) = ts.get("font_size").and_then(|v| v.as_f64()) {
+        text_style["fontSize"] = json!({ "magnitude": size, "unit": "PT" });
+        text_fields.push("fontSize");
+    }
+    if let Some(family) = ts.get("font_family").and_then(|v| v.as_str()) {
+        text_style["weightedFontFamily"] = json!({ "fontFamily": family });
+        text_fields.push("weightedFontFamily");
+    }
+    if let Some(color) = ts.get("text_color") {
+        text_style["foregroundColor"] = json!({ "color": { "rgbColor": color } });
+        text_fields.push("foregroundColor");
+    }
+
+    let mut paragraph_style = json!({});
+    let mut para_fields = Vec::<&str>::new();
+    if let Some(a) = ps.get("alignment").and_then(|v| v.as_str()) {
+        paragraph_style["alignment"] = json!(a);
+        para_fields.push("alignment");
+    }
+    if let Some(ls) = ps.get("line_spacing").and_then(|v| v.as_f64()) {
+        paragraph_style["lineSpacing"] = json!(ls);
+        para_fields.push("lineSpacing");
+    }
+    if let Some(sa) = ps.get("space_above").and_then(|v| v.as_f64()) {
+        paragraph_style["spaceAbove"] = json!({ "magnitude": sa, "unit": "PT" });
+        para_fields.push("spaceAbove");
+    }
+    if let Some(sb) = ps.get("space_below").and_then(|v| v.as_f64()) {
+        paragraph_style["spaceBelow"] = json!({ "magnitude": sb, "unit": "PT" });
+        para_fields.push("spaceBelow");
+    }
+
+    if text_fields.is_empty() && para_fields.is_empty() {
+        return None;
+    }
+
+    let mut named_style = json!({ "namedStyleType": named_style_type });
+    if !text_fields.is_empty() {
+        named_style["textStyle"] = text_style;
+    }
+    if !para_fields.is_empty() {
+        named_style["paragraphStyle"] = paragraph_style;
+    }
+
+    let mut request = json!({ "updateNamedStyle": { "namedStyle": named_style } });
+    if !text_fields.is_empty() {
+        request["updateNamedStyle"]["textStyleFields"] = json!(text_fields.join(","));
+    }
+    if !para_fields.is_empty() {
+        request["updateNamedStyle"]["paragraphStyleFields"] = json!(para_fields.join(","));
+    }
+    Some(request)
+}
+
+/// Why: The raw `namedStyles` payload is deeply nested; callers want a compact
+/// per-style summary.
+/// What: Parses `namedStyles.styles` into snake_case text/paragraph summaries.
+/// Test: `parse_named_styles_extracts_summary` below.
+pub(crate) fn parse_named_styles(doc: &Value) -> Vec<Value> {
+    let styles = doc
+        .get("namedStyles")
+        .and_then(|n| n.get("styles"))
+        .and_then(|s| s.as_array())
+        .cloned()
+        .unwrap_or_default();
+    styles
+        .iter()
+        .map(|style| {
+            let ts = style.get("textStyle").cloned().unwrap_or_else(|| json!({}));
+            let ps = style
+                .get("paragraphStyle")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let weighted = ts.get("weightedFontFamily").cloned().unwrap_or_else(|| json!({}));
+            json!({
+                "named_style_type": style.get("namedStyleType"),
+                "text_style": {
+                    "font_family": weighted.get("fontFamily"),
+                    "font_weight": weighted.get("weight"),
+                    "font_size": ts.get("fontSize").and_then(|f| f.get("magnitude")),
+                    "bold": ts.get("bold"),
+                    "italic": ts.get("italic"),
+                    "underline": ts.get("underline"),
+                    "foreground_color": ts.get("foregroundColor").and_then(|c| c.get("color")).and_then(|c| c.get("rgbColor")),
+                },
+                "paragraph_style": {
+                    "alignment": ps.get("alignment"),
+                    "line_spacing": ps.get("lineSpacing"),
+                    "space_above": ps.get("spaceAbove").and_then(|s| s.get("magnitude")),
+                    "space_below": ps.get("spaceBelow").and_then(|s| s.get("magnitude")),
+                },
+            })
+        })
+        .collect()
+}
+
+/// Why: Templating a doc = copy the source via Drive then fill placeholders.
+/// What: POSTs a Drive `files/{id}/copy`, then a `replaceAllText` batch for each
+/// replacement.
+/// Test: `build_replacement_requests` is unit-tested; the call is live-only.
+pub async fn create_document_from_template(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let template_id = require_str(&args, "template_id")?;
+    let title = require_str(&args, "title")?;
+
+    let mut copy_body = json!({ "name": title });
+    if let Some(folder) = args
+        .get("destination_folder_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        copy_body["parents"] = json!([folder]);
+    }
+    let copy_url = format!("{DRIVE_API_BASE}/files/{template_id}/copy?fields=id,name,webViewLink");
+    let copy_resp = client.post(&copy_url, copy_body, account).await?;
+    let new_doc_id = copy_resp.get("id").and_then(|v| v.as_str());
+    let web_view_link = copy_resp
+        .get("webViewLink")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let mut replacements_applied = 0usize;
+    if let Some(new_id) = new_doc_id {
+        let replacements = args
+            .get("replacements")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let requests = build_replacement_requests(&replacements);
+        if !requests.is_empty() {
+            replacements_applied = requests.len();
+            let batch_url = format!("{DOCS_API_BASE}/documents/{new_id}:batchUpdate");
+            client
+                .post(&batch_url, json!({ "requests": requests }), account)
+                .await?;
+        }
+    }
+
+    Ok(json!({
+        "status": "created",
+        "document_id": new_doc_id,
+        "title": copy_resp.get("name").and_then(|v| v.as_str()).unwrap_or(title),
+        "web_view_link": web_view_link,
+        "replacements_applied": replacements_applied,
+    }))
+}
+
+/// Why: Callers inspect a doc's named-style definitions before overriding them.
+/// What: GETs `namedStyles` and returns the parsed per-style summary.
+/// Test: `parse_named_styles` is unit-tested; the call is live-only.
+pub async fn get_document_named_styles(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let url = format!("{DOCS_API_BASE}/documents/{id}?fields=namedStyles");
+    let doc = client.get(&url, account).await?;
+    let parsed = parse_named_styles(&doc);
+    Ok(json!({ "count": parsed.len(), "named_styles": parsed }))
+}
+
+/// Why: Bulk-editing named styles keeps a whole document visually consistent.
+/// What: Builds one `updateNamedStyle` request per spec and posts them together.
+/// Test: `build_named_style_request` is unit-tested; the call is live-only.
+pub async fn update_document_named_styles(client: &BaseClient, args: Value) -> Result<Value> {
+    let account = account_of(&args);
+    let id = require_str(&args, "document_id")?;
+    let specs = args
+        .get("styles")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut requests = Vec::<Value>::new();
+    let mut applied = Vec::<Value>::new();
+    for spec in &specs {
+        if let Some(req) = build_named_style_request(spec) {
+            requests.push(req);
+            applied.push(spec.get("named_style_type").cloned().unwrap_or(Value::Null));
+        }
+    }
+
+    if requests.is_empty() {
+        return Ok(json!({ "status": "no_styles_applied", "document_id": id }));
+    }
+    let url = format!("{DOCS_API_BASE}/documents/{id}:batchUpdate");
+    client
+        .post(&url, json!({ "requests": requests }), account)
+        .await?;
+    Ok(json!({
+        "status": "updated",
+        "document_id": id,
+        "count": applied.len(),
+        "styles_applied": applied,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replacement_requests_wrap_keys() {
+        let reps = json!({ "NAME": "Ada", "ROLE": "Engineer" });
+        let reqs = build_replacement_requests(&reps);
+        assert_eq!(reqs.len(), 2);
+        // Each key is wrapped in double curly braces and matchCase is true.
+        let texts: Vec<String> = reqs
+            .iter()
+            .map(|r| {
+                r["replaceAllText"]["containsText"]["text"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert!(texts.contains(&"{{NAME}}".to_string()));
+        assert!(texts.contains(&"{{ROLE}}".to_string()));
+        assert_eq!(reqs[0]["replaceAllText"]["containsText"]["matchCase"], true);
+    }
+
+    #[test]
+    fn replacement_requests_empty_when_not_object() {
+        assert!(build_replacement_requests(&json!(null)).is_empty());
+    }
+
+    #[test]
+    fn named_style_request_text_and_paragraph_masks() {
+        let spec = json!({
+            "named_style_type": "HEADING_1",
+            "text_style": { "bold": true, "font_size": 20.0 },
+            "paragraph_style": { "alignment": "CENTER", "space_above": 12.0 },
+        });
+        let r = build_named_style_request(&spec).unwrap();
+        let inner = &r["updateNamedStyle"];
+        assert_eq!(inner["namedStyle"]["namedStyleType"], "HEADING_1");
+        let tf = inner["textStyleFields"].as_str().unwrap();
+        assert!(tf.contains("bold"));
+        assert!(tf.contains("fontSize"));
+        let pf = inner["paragraphStyleFields"].as_str().unwrap();
+        assert!(pf.contains("alignment"));
+        assert!(pf.contains("spaceAbove"));
+        assert_eq!(
+            inner["namedStyle"]["textStyle"]["fontSize"]["magnitude"],
+            20.0
+        );
+    }
+
+    #[test]
+    fn named_style_request_none_when_empty() {
+        let spec = json!({ "named_style_type": "NORMAL_TEXT" });
+        assert!(build_named_style_request(&spec).is_none());
+    }
+
+    #[test]
+    fn named_style_request_none_without_type() {
+        let spec = json!({ "text_style": { "bold": true } });
+        assert!(build_named_style_request(&spec).is_none());
+    }
+
+    #[test]
+    fn parse_named_styles_extracts_summary() {
+        let doc = json!({
+            "namedStyles": { "styles": [
+                {
+                    "namedStyleType": "TITLE",
+                    "textStyle": {
+                        "bold": true,
+                        "fontSize": { "magnitude": 26.0, "unit": "PT" },
+                        "weightedFontFamily": { "fontFamily": "Arial", "weight": 400 },
+                    },
+                    "paragraphStyle": { "alignment": "CENTER", "spaceAbove": { "magnitude": 4.0 } },
+                }
+            ] }
+        });
+        let out = parse_named_styles(&doc);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["named_style_type"], "TITLE");
+        assert_eq!(out[0]["text_style"]["font_family"], "Arial");
+        assert_eq!(out[0]["text_style"]["font_size"], 26.0);
+        assert_eq!(out[0]["paragraph_style"]["alignment"], "CENTER");
+        assert_eq!(out[0]["paragraph_style"]["space_above"], 4.0);
+    }
+}

--- a/crates/trusty-gworkspace/src/openrpc.rs
+++ b/crates/trusty-gworkspace/src/openrpc.rs
@@ -101,7 +101,21 @@ pub fn scopes_for_tool(name: &str) -> &'static [&'static str] {
         | "set_document_style"
         | "insert_table_in_document"
         | "find_tables_in_document"
-        | "manage_table_structure" => &[DOCUMENTS, DRIVE],
+        | "manage_table_structure"
+        | "manage_document_tabs"
+        | "create_document_tab"
+        | "move_paragraph_in_document"
+        | "format_paragraph_in_document"
+        | "create_list_in_document"
+        | "insert_image_in_document"
+        | "format_table_cells"
+        | "set_table_column_widths"
+        | "apply_table_style"
+        | "format_document_tables"
+        | "manage_document_header_footer"
+        | "create_document_from_template"
+        | "get_document_named_styles"
+        | "update_document_named_styles" => &[DOCUMENTS, DRIVE],
 
         // Sheets
         "get_spreadsheet"

--- a/crates/trusty-gworkspace/src/server.rs
+++ b/crates/trusty-gworkspace/src/server.rs
@@ -128,6 +128,48 @@ pub async fn handle_tool_call(state: &AppState, name: &str, args: Value) -> Valu
         "manage_table_structure" => {
             services::docs::table_ops::manage_table_structure(&state.client, args).await
         }
+        "manage_document_tabs" => {
+            services::docs::tabs::manage_document_tabs(&state.client, args).await
+        }
+        "create_document_tab" => {
+            services::docs::tabs::create_document_tab(&state.client, args).await
+        }
+        "move_paragraph_in_document" => {
+            services::docs::paragraphs::move_paragraph_in_document(&state.client, args).await
+        }
+        "format_paragraph_in_document" => {
+            services::docs::paragraphs::format_paragraph_in_document(&state.client, args).await
+        }
+        "create_list_in_document" => {
+            services::docs::paragraphs::create_list_in_document(&state.client, args).await
+        }
+        "insert_image_in_document" => {
+            services::docs::images::insert_image_in_document(&state.client, args).await
+        }
+        "format_table_cells" => {
+            services::docs::table_style::format_table_cells(&state.client, args).await
+        }
+        "set_table_column_widths" => {
+            services::docs::table_style::set_table_column_widths(&state.client, args).await
+        }
+        "apply_table_style" => {
+            services::docs::table_preset::apply_table_style(&state.client, args).await
+        }
+        "format_document_tables" => {
+            services::docs::table_format::format_document_tables(&state.client, args).await
+        }
+        "manage_document_header_footer" => {
+            services::docs::header_footer::manage_document_header_footer(&state.client, args).await
+        }
+        "create_document_from_template" => {
+            services::docs::templates::create_document_from_template(&state.client, args).await
+        }
+        "get_document_named_styles" => {
+            services::docs::templates::get_document_named_styles(&state.client, args).await
+        }
+        "update_document_named_styles" => {
+            services::docs::templates::update_document_named_styles(&state.client, args).await
+        }
 
         // Sheets
         "get_spreadsheet" => services::sheets::core::get_spreadsheet(&state.client, args).await,

--- a/crates/trusty-gworkspace/src/tools/docs/extra.rs
+++ b/crates/trusty-gworkspace/src/tools/docs/extra.rs
@@ -1,0 +1,244 @@
+//! Extended Google Docs tool definitions (parity with the Python upstream).
+//!
+//! Why: The base `docs` group covers create/read/edit/format/table basics; this
+//! module adds the tabs, list, image, deep-table, header/footer and template
+//! tools so the Rust server reaches feature parity with `gworkspace-mcp`.
+//! What: Appends the extended Docs tool group to the shared registry vector.
+//! Test: Covered via `tool_list_response()` in `tools::tests`.
+
+use crate::tools::schema::{account_schema, action_enum, tool};
+use serde_json::{Value, json};
+
+/// Append the extended Docs tools to the registry.
+///
+/// Why: Keeps the parity tools grouped and off the base `docs/mod.rs` file to
+/// respect the SLOC cap.
+/// What: Pushes tabs/paragraph/list/image/deep-table/header-footer/template tools.
+/// Test: Covered via `tool_list_response()` in `tools::tests`.
+pub(super) fn append(tools: &mut Vec<Value>) {
+    // ---- Tabs ----
+    tools.push(tool(
+        "manage_document_tabs",
+        "Manage tabs in a Google Doc: list, get_content, create, update (title/icon), or move (reparent/reorder).",
+        json!({
+            "account": account_schema(),
+            "action": action_enum(&["list", "get_content", "create", "update", "move"]),
+            "document_id": { "type": "string" },
+            "tab_id": { "type": "string", "description": "Required for get_content, update, move." },
+            "title": { "type": "string", "description": "Tab title (create; optional for update)." },
+            "icon_emoji": { "type": "string", "description": "Icon emoji (create/update, optional)." },
+            "parent_tab_id": { "type": "string", "description": "Parent tab for nesting (create)." },
+            "index": { "type": "integer", "description": "Position index (create)." },
+            "new_parent_tab_id": { "type": "string", "description": "Move target parent; empty string = root." },
+            "new_index": { "type": "integer", "description": "Move target position index." },
+        }),
+        &["action", "document_id"],
+    ));
+    tools.push(tool(
+        "create_document_tab",
+        "Create a new tab in a Google Doc with a title and optional icon/parent/index.",
+        json!({
+            "account": account_schema(),
+            "document_id": { "type": "string" },
+            "title": { "type": "string" },
+            "icon_emoji": { "type": "string" },
+            "parent_tab_id": { "type": "string" },
+            "index": { "type": "integer" },
+        }),
+        &["document_id", "title"],
+    ));
+
+    // ---- Paragraph / list ----
+    tools.push(tool(
+        "move_paragraph_in_document",
+        "Move a paragraph (cut-and-paste) from a source index range to a destination index in a Google Doc.",
+        json!({
+            "account": account_schema(),
+            "document_id": { "type": "string" },
+            "source_start_index": { "type": "integer" },
+            "source_end_index": { "type": "integer" },
+            "destination_index": { "type": "integer" },
+        }),
+        &["document_id", "source_start_index", "source_end_index", "destination_index"],
+    ));
+    tools.push(tool(
+        "format_paragraph_in_document",
+        "Apply paragraph-level formatting (named/heading style, alignment, indentation, spacing) to a range.",
+        json!({
+            "account": account_schema(),
+            "document_id": { "type": "string" },
+            "start_index": { "type": "integer" },
+            "end_index": { "type": "integer" },
+            "heading_style": { "type": "string", "description": "NORMAL_TEXT, HEADING_1..6, TITLE, SUBTITLE." },
+            "alignment": { "type": "string", "enum": ["START", "CENTER", "END", "JUSTIFIED"] },
+            "indent_first_line_pt": { "type": "number" },
+            "indent_start_pt": { "type": "number" },
+            "space_above_pt": { "type": "number" },
+            "space_below_pt": { "type": "number" },
+        }),
+        &["document_id", "start_index", "end_index"],
+    ));
+    tools.push(tool(
+        "create_list_in_document",
+        "Create a bulleted or numbered list at a given index in a Google Doc.",
+        json!({
+            "account": account_schema(),
+            "document_id": { "type": "string" },
+            "insert_index": { "type": "integer" },
+            "list_type": { "type": "string", "enum": ["BULLETED", "NUMBERED"] },
+            "items": { "type": "array", "items": { "type": "string" } },
+        }),
+        &["document_id", "insert_index", "list_type", "items"],
+    ));
+
+    // ---- Images ----
+    tools.push(tool(
+        "insert_image_in_document",
+        "Insert an inline image (from a public https URL) at a given index, with optional width/height in points.",
+        json!({
+            "account": account_schema(),
+            "document_id": { "type": "string" },
+            "insert_index": { "type": "integer" },
+            "image_uri": { "type": "string", "description": "Publicly accessible image URL." },
+            "width_pt": { "type": "number" },
+            "height_pt": { "type": "number" },
+        }),
+        &["document_id", "insert_index", "image_uri"],
+    ));
+
+    // ---- Deep table styling ----
+    tools.push(tool(
+        "format_table_cells",
+        "Apply padding/border/background/content-alignment to a cell range. Use row_index=-1 or column_index=-1 to target all rows/columns.",
+        json!({
+            "account": account_schema(),
+            "document_id": { "type": "string" },
+            "table_start_index": { "type": "integer" },
+            "row_index": { "type": "integer", "description": "0-based; -1 = all rows." },
+            "column_index": { "type": "integer", "description": "0-based; -1 = all columns." },
+            "num_rows": { "type": "integer", "description": "Required when row_index=-1." },
+            "num_columns": { "type": "integer", "description": "Required when column_index=-1." },
+            "padding": {
+                "type": "object",
+                "properties": {
+                    "top": { "type": "number" }, "bottom": { "type": "number" },
+                    "left": { "type": "number" }, "right": { "type": "number" },
+                },
+            },
+            "border": {
+                "type": "object",
+                "properties": {
+                    "color": { "type": "object", "description": "{red,green,blue} 0..1." },
+                    "width": { "type": "number" },
+                    "dash_style": { "type": "string", "enum": ["SOLID", "DOT", "DASH"] },
+                    "sides": { "type": "array", "items": { "type": "string", "enum": ["top", "bottom", "left", "right"] } },
+                },
+            },
+            "background_color": { "type": "object", "description": "{red,green,blue} 0..1." },
+            "content_alignment": { "type": "string", "enum": ["TOP", "MIDDLE", "BOTTOM"] },
+        }),
+        &["document_id", "table_start_index", "row_index", "column_index"],
+    ));
+    tools.push(tool(
+        "set_table_column_widths",
+        "Set explicit column widths (PT; null = evenly distributed) or auto-balance from cell data.",
+        json!({
+            "account": account_schema(),
+            "document_id": { "type": "string" },
+            "table_start_index": { "type": "integer" },
+            "column_widths": { "type": "array", "items": { "type": ["number", "null"] } },
+            "auto_balance": { "type": "boolean" },
+            "data": { "type": "array", "items": { "type": "array", "items": { "type": "string" } }, "description": "Required when auto_balance=true." },
+            "available_width": { "type": "number", "description": "Usable page width in PT (default 468)." },
+            "font_size": { "type": "number", "description": "Font size in PT for the balance algorithm (default 11)." },
+            "min_col_width": { "type": "number", "description": "Minimum column width in PT (default 60)." },
+            "algorithm": { "type": "string", "enum": ["equalize", "sqrt", "proportional"] },
+        }),
+        &["document_id", "table_start_index"],
+    ));
+    tools.push(tool(
+        "apply_table_style",
+        "Apply a named style preset (minimal, bordered, striped, professional, plain) or custom overrides to an entire table.",
+        json!({
+            "account": account_schema(),
+            "document_id": { "type": "string" },
+            "table_start_index": { "type": "integer" },
+            "num_rows": { "type": "integer" },
+            "num_columns": { "type": "integer" },
+            "preset": { "type": "string", "enum": ["minimal", "bordered", "striped", "professional", "plain"] },
+            "header_row": { "type": "boolean" },
+            "custom": { "type": "object", "description": "Override preset fields (header_background, header_text_bold, odd/even_row_background, border_color, border_width, border_dash_style, cell_padding)." },
+        }),
+        &["document_id", "table_start_index", "num_rows", "num_columns"],
+    ));
+    tools.push(tool(
+        "format_document_tables",
+        "Post-processing pass: apply borders, a styled header row, and content-aware column widths to ALL tables in a Google Doc.",
+        json!({ "account": account_schema(), "document_id": { "type": "string" } }),
+        &["document_id"],
+    ));
+
+    // ---- Header / footer ----
+    tools.push(tool(
+        "manage_document_header_footer",
+        "Manage headers/footers: get, create_header, create_footer, update_header, update_footer, delete_header, delete_footer.",
+        json!({
+            "account": account_schema(),
+            "action": action_enum(&[
+                "get", "create_header", "create_footer",
+                "update_header", "update_footer", "delete_header", "delete_footer",
+            ]),
+            "document_id": { "type": "string" },
+            "header_id": { "type": "string", "description": "Required for update_header/delete_header." },
+            "footer_id": { "type": "string", "description": "Required for update_footer/delete_footer." },
+            "text": { "type": "string", "description": "Required for update_header/update_footer." },
+        }),
+        &["action", "document_id"],
+    ));
+
+    // ---- Templates / named styles ----
+    tools.push(tool(
+        "create_document_from_template",
+        "Create a Google Doc by copying a template, replacing {{PLACEHOLDER}} strings from a replacements map.",
+        json!({
+            "account": account_schema(),
+            "template_id": { "type": "string" },
+            "title": { "type": "string" },
+            "replacements": { "type": "object", "description": "Map of placeholder name (without braces) to value; each KEY is matched as {{KEY}}." },
+            "destination_folder_id": { "type": "string" },
+        }),
+        &["template_id", "title"],
+    ));
+    tools.push(tool(
+        "get_document_named_styles",
+        "Get the named style definitions (NORMAL_TEXT, TITLE, SUBTITLE, HEADING_1..6) for a Google Doc.",
+        json!({ "account": account_schema(), "document_id": { "type": "string" } }),
+        &["document_id"],
+    ));
+    tools.push(tool(
+        "update_document_named_styles",
+        "Update one or more named style definitions (text and/or paragraph formatting) in a Google Doc.",
+        json!({
+            "account": account_schema(),
+            "document_id": { "type": "string" },
+            "styles": {
+                "type": "array",
+                "description": "List of {named_style_type, text_style?, paragraph_style?} updates.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "named_style_type": { "type": "string", "enum": [
+                            "NORMAL_TEXT", "TITLE", "SUBTITLE",
+                            "HEADING_1", "HEADING_2", "HEADING_3",
+                            "HEADING_4", "HEADING_5", "HEADING_6",
+                        ] },
+                        "text_style": { "type": "object", "description": "bold, italic, underline, font_size, font_family, text_color{red,green,blue}." },
+                        "paragraph_style": { "type": "object", "description": "alignment, line_spacing, space_above, space_below." },
+                    },
+                    "required": ["named_style_type"],
+                },
+            },
+        }),
+        &["document_id", "styles"],
+    ));
+}

--- a/crates/trusty-gworkspace/src/tools/docs/extra.rs
+++ b/crates/trusty-gworkspace/src/tools/docs/extra.rs
@@ -181,7 +181,7 @@ pub(super) fn append(tools: &mut Vec<Value>) {
     // ---- Header / footer ----
     tools.push(tool(
         "manage_document_header_footer",
-        "Manage headers/footers: get, create_header, create_footer, update_header, update_footer, delete_header, delete_footer.",
+        "Manage headers/footers: get, create_header, create_footer, update_header, update_footer, delete_header, delete_footer. NOTE: update_header/update_footer always insert at the start of the segment, so repeated calls PREPEND rather than append.",
         json!({
             "account": account_schema(),
             "action": action_enum(&[
@@ -191,7 +191,7 @@ pub(super) fn append(tools: &mut Vec<Value>) {
             "document_id": { "type": "string" },
             "header_id": { "type": "string", "description": "Required for update_header/delete_header." },
             "footer_id": { "type": "string", "description": "Required for update_footer/delete_footer." },
-            "text": { "type": "string", "description": "Required for update_header/update_footer." },
+            "text": { "type": "string", "description": "Required for update_header/update_footer. Inserted at segment index 0 — repeated calls prepend, they do not append." },
         }),
         &["action", "document_id"],
     ));

--- a/crates/trusty-gworkspace/src/tools/docs/mod.rs
+++ b/crates/trusty-gworkspace/src/tools/docs/mod.rs
@@ -4,13 +4,16 @@
 //! What: Appends the Docs tool group to the shared registry vector.
 //! Test: Covered via `tool_list_response()` in `tools::tests`.
 
+mod extra;
+
 use super::schema::{account_schema, action_enum, tool};
 use serde_json::{Value, json};
 
 /// Append the Docs tool group to the registry.
 ///
 /// Why: Keeps Docs-related tools colocated.
-/// What: Pushes the document create/edit/format/table tools.
+/// What: Pushes the document create/edit/format/table tools, plus the extended
+/// tabs/lists/images/tables/templates parity tools (`extra` submodule).
 /// Test: Covered via `tool_list_response()` in `tools::tests`.
 pub(super) fn append(tools: &mut Vec<Value>) {
     tools.push(tool(
@@ -146,4 +149,6 @@ pub(super) fn append(tools: &mut Vec<Value>) {
         }),
         &["action", "document_id", "table_start_index"],
     ));
+
+    extra::append(tools);
 }


### PR DESCRIPTION
Ports the pure-API Google Docs tools that `crates/trusty-gworkspace` was missing versus the Python upstream `gworkspace-mcp` (`server/services/docs/*`), mirroring its `batchUpdate`/get request shapes. Verified each against the upstream at `bobmatnyc/gworkspace-mcp`.

**Excludes** the Markdown/Mermaid pipeline (`render_mermaid_to_doc`, `publish_markdown_to_doc`, `markdown_file_to_doc`, `sync_markdown_doc`) — those are deferred to a separate managed-Python-sidecar track, not this PR.

## Tools added (14)

- **Tabs:** `manage_document_tabs` (list/get_content/create/update/move), `create_document_tab`
- **Paragraph/list:** `move_paragraph_in_document`, `format_paragraph_in_document`, `create_list_in_document` (bulleted/numbered)
- **Deep tables:** `format_table_cells`, `set_table_column_widths` (explicit + auto-balance), `apply_table_style` (preset + custom), `format_document_tables`
- **Images:** `insert_image_in_document`
- **Header/footer:** `manage_document_header_footer`
- **Templates/styles:** `create_document_from_template`, `get_document_named_styles`, `update_document_named_styles`

## Structure

Implementations split into focused submodules under `crates/trusty-gworkspace/src/api/services/docs/` (`tabs`, `paragraphs`, `images`, `header_footer`, `table_style`, `table_preset`, `table_format`, `templates`) to respect the 500-SLOC cap. Tool schemas moved into `tools/docs/{mod,extra}.rs`; server dispatch arms and OpenRPC scope mappings updated (`DOCUMENTS`, `DRIVE`).

Request-construction and response-parsing logic is factored into pure builder functions and unit-tested.

## Verification

- `cargo build/test/clippy(-D warnings)/fmt -p trusty-gworkspace`: green — **97 lib tests pass**, clippy clean, fmt clean
- `bash scripts/check_line_cap.sh`: 0 violations
- `cargo check --workspace`: green

**Deferred-live note:** Live Google API round-trips are **not verified this session** (expired OAuth tokens). Coverage is request-construction / schema / response-parse unit tests only; no live verification is claimed.

Part of #2626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)