### PR TITLE
feat(trusty-code): add glob/grep/list_dir tools + batch file writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10834,6 +10834,8 @@ dependencies = [
  "chrono",
  "clap",
  "futures-util",
+ "globset",
+ "ignore",
  "libc",
  "regex",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,12 @@ indicatif = "0.17"
 # Misc utilities used across crates.
 dashmap = "6"
 walkdir = "2"
+# gitignore-aware recursive file walking (ripgrep's walker) + glob matching —
+# power the tcode engineer's native glob/grep exploration tools (#1027). Both
+# are already in the workspace lockfile (transitive via trusty-search), so
+# promoting them to explicit workspace deps adds no new lockfile entries.
+ignore = "0.4"
+globset = "0.4"
 regex = "1"
 gray_matter = "0.2"
 notify = "6"

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -58,7 +58,13 @@ libc = { workspace = true }
 
 # verify_gate (#2279): matches a `bash` tool call's command against the
 # finalized test-invocation patterns (`pytest\s+\S+`, `cargo test`, …).
+# Also powers the `grep` exploration tool's content regex matching (#1027).
 regex = { workspace = true }
+
+# Native exploration tools (#1027): `ignore` provides gitignore-aware recursive
+# walking for the `glob`/`grep` tools; `globset` compiles the glob patterns.
+ignore = { workspace = true }
+globset = { workspace = true }
 
 # DOC-28 catch-up digest for PM prompt seed context (#1762 PR2), plus the
 # shared JSON-RPC 2.0 / MCP wire types + STDIO loop (#2053) so `tcode serve

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -1512,6 +1512,10 @@ mod gate_intercept;
 // a focused child module to keep this file under its SLOC cap.
 mod batched_multi_tool;
 
+// Batch file-write regression guards (#2681 — turn-count/file-count decoupling)
+// live in a focused child module to keep this file under its SLOC cap.
+mod write_batch;
+
 /// Live OpenRouter test: trivial task through the real client + a real tool.
 ///
 /// Why: End-to-end confidence that the loop drives a real model to a final

--- a/crates/trusty-code/src/agent_loop/tests/write_batch.rs
+++ b/crates/trusty-code/src/agent_loop/tests/write_batch.rs
@@ -1,0 +1,189 @@
+//! Regression guards for batched file writes (#2681 — decoupling agent
+//! turn-count from file-count).
+//!
+//! Why: On every bake-off run the number of files a solution needed equalled the
+//! number of write-turns 1:1 (an 8-file scaffold cost 8 turns), the single
+//! biggest driver of tcode's high agent-turn count. Two levers fix this: (1) the
+//! loop's `dispatch_all` executes N `write_file` calls emitted in ONE turn, and
+//! (2) the dedicated `write_files` tool writes an array of files in a single
+//! call. These tests pin BOTH so a future loop/tool change cannot silently
+//! reintroduce one-file-per-turn behaviour. Split into this focused child module
+//! (from `agent_loop::tests`) to keep the parent file under its SLOC cap while
+//! reusing its scripted-LLM harness verbatim via `use super::*`.
+//! What: Reuses the parent module's `ScriptedLlm`, `stop_response`, and
+//! `make_loop` helpers; registers the real `WriteFileTool`/`WriteFilesTool` over
+//! a tempdir and asserts a single turn writes every file.
+//! Test: this module is itself the test surface.
+
+use super::*;
+use crate::tools::{WriteFileTool, WriteFilesTool};
+
+/// Build a response carrying MULTIPLE `write_file` tool calls in one assistant
+/// choice.
+///
+/// Why: Proves a single turn emitting N `write_file` calls writes all N files —
+/// the batching lever's first form.
+/// What: Emits one assistant message whose `tool_calls` array names `write_file`
+/// once per `(call_id, path, content)` triple, with `finish_reason ==
+/// "tool_calls"`.
+/// Test: `batched_write_file_calls_write_all_files_in_one_turn`.
+fn multi_write_file_response(files: &[(&str, &str, &str)]) -> Value {
+    let tool_calls: Vec<Value> = files
+        .iter()
+        .map(|(id, path, content)| {
+            let arguments = json!({ "path": path, "content": content }).to_string();
+            json!({
+                "id": id,
+                "type": "function",
+                "function": { "name": "write_file", "arguments": arguments }
+            })
+        })
+        .collect();
+    json!({
+        "id": "gen-multi-write",
+        "choices": [{
+            "message": { "role": "assistant", "content": null, "tool_calls": tool_calls },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 20, "completion_tokens": 15, "total_tokens": 35 }
+    })
+}
+
+/// Build a response carrying ONE `write_files` batch tool call.
+///
+/// Why: Proves the dedicated batch tool writes an array of files in a single
+/// call — the batching lever's second, structural form.
+/// What: Emits one assistant message whose single `write_files` tool call
+/// carries a `files` array built from the `(path, content)` pairs.
+/// Test: `write_files_tool_writes_all_files_in_one_turn`.
+fn write_files_call_response(call_id: &str, files: &[(&str, &str)]) -> Value {
+    let arr: Vec<Value> = files
+        .iter()
+        .map(|(path, content)| json!({ "path": path, "content": content }))
+        .collect();
+    let arguments = json!({ "files": arr }).to_string();
+    json!({
+        "id": "gen-write-files",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": { "name": "write_files", "arguments": arguments }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 20, "completion_tokens": 15, "total_tokens": 35 }
+    })
+}
+
+/// A single turn emitting N `write_file` calls writes ALL N files, in one turn.
+///
+/// Why: This is lever 1 of the turn-count/file-count decoupling — the model may
+/// batch several `write_file` calls into one turn and the loop must execute
+/// every one. Regression guard against a return to one-file-per-turn.
+/// What: Registers the real `WriteFileTool` over a tempdir, scripts ONE response
+/// with three `write_file` calls, then a stop. Asserts exactly two chat calls
+/// (one batch turn + one stop) and that all three files exist on disk with the
+/// right content.
+/// Test: this test.
+#[tokio::test]
+async fn batched_write_file_calls_write_all_files_in_one_turn() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut reg = ToolRegistry::new();
+    reg.register(Arc::new(WriteFileTool::new(tmp.path())));
+    let registry = Arc::new(reg);
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        multi_write_file_response(&[
+            ("w1", "a.py", "# a"),
+            ("w2", "pkg/b.py", "# b"),
+            ("w3", "src/main.rs", "fn main() {}"),
+        ]),
+        stop_response("scaffolded three files in one turn"),
+    ]));
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default());
+
+    let out = agent
+        .run("system", "scaffold three files")
+        .await
+        .expect("batched write turn should complete");
+
+    assert_eq!(out.content, "scaffolded three files in one turn");
+    assert_eq!(
+        llm.calls(),
+        2,
+        "all three writes must happen in ONE turn, then one stop — not three turns"
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.py")).unwrap(),
+        "# a"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("pkg/b.py")).unwrap(),
+        "# b"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("src/main.rs")).unwrap(),
+        "fn main() {}"
+    );
+}
+
+/// A single `write_files` call writes ALL files in the array, in one turn.
+///
+/// Why: This is lever 2 — the dedicated batch tool structurally decouples
+/// turn-count from file-count even when the model does not batch separate calls.
+/// What: Registers the real `WriteFilesTool` over a tempdir, scripts ONE
+/// response with a single `write_files` call carrying four files, then a stop.
+/// Asserts exactly two chat calls and that all four files exist on disk.
+/// Test: this test.
+#[tokio::test]
+async fn write_files_tool_writes_all_files_in_one_turn() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut reg = ToolRegistry::new();
+    reg.register(Arc::new(WriteFilesTool::new(tmp.path())));
+    let registry = Arc::new(reg);
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        write_files_call_response(
+            "wf1",
+            &[
+                ("app/__init__.py", ""),
+                ("app/main.py", "print('hi')"),
+                ("app/models.py", "# models"),
+                ("tests/test_main.py", "def test(): pass"),
+            ],
+        ),
+        stop_response("wrote the whole scaffold in one call"),
+    ]));
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default());
+
+    let out = agent
+        .run("system", "scaffold the app")
+        .await
+        .expect("write_files turn should complete");
+
+    assert_eq!(out.content, "wrote the whole scaffold in one call");
+    assert_eq!(
+        llm.calls(),
+        2,
+        "one write_files call writes every file in ONE turn, then one stop"
+    );
+
+    for (path, content) in [
+        ("app/__init__.py", ""),
+        ("app/main.py", "print('hi')"),
+        ("app/models.py", "# models"),
+        ("tests/test_main.py", "def test(): pass"),
+    ] {
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(path)).unwrap(),
+            content,
+            "file {path} must be written by the single write_files call"
+        );
+    }
+}

--- a/crates/trusty-code/src/prompt/preamble.rs
+++ b/crates/trusty-code/src/prompt/preamble.rs
@@ -46,10 +46,16 @@ before bash).
 seen yet — e.g. you cannot `write_file` content derived from a `read_file` \
 whose result you don't yet have. Sequence those across turns: emit the read, \
 wait for its result, then decide the next step based on what actually happened.
-- When you are scaffolding SEVERAL independent files, do not spend one turn per \
-file. Either emit all their `write_file` calls in a SINGLE turn (batching, as \
-above), or use the `write_files` tool, which takes an array of files and writes \
-them all in one call — an N-file scaffold should cost ONE turn, not N.
+- When creating TWO OR MORE new files, you MUST put them ALL into a SINGLE \
+`write_files` call, each with its COMPLETE final contents. This is a directive, \
+not a suggestion: do NOT call `write_files` as a scaffolding or placeholder step \
+and then follow it with individual `write_file` calls to fill in or rewrite \
+those same files — that defeats the entire purpose of `write_files` and costs \
+exactly as many turns as not using it at all. Plan every new file's full content \
+BEFORE emitting the call, then emit ONE `write_files` call carrying every file. \
+`write_file` (singular) is for a SINGLE file: editing or adding one file after \
+the initial multi-file batch already exists via `write_files`. An N-file \
+from-scratch task should therefore cost ONE write turn, not N.
 - If one call in a batch fails, you still receive results for every other call \
 plus the failure — use them together to decide the next step.
 - Every tool call's arguments MUST validate against that tool's provided JSON \

--- a/crates/trusty-code/src/prompt/preamble.rs
+++ b/crates/trusty-code/src/prompt/preamble.rs
@@ -46,16 +46,10 @@ before bash).
 seen yet — e.g. you cannot `write_file` content derived from a `read_file` \
 whose result you don't yet have. Sequence those across turns: emit the read, \
 wait for its result, then decide the next step based on what actually happened.
-- When creating TWO OR MORE new files, you MUST put them ALL into a SINGLE \
-`write_files` call, each with its COMPLETE final contents. This is a directive, \
-not a suggestion: do NOT call `write_files` as a scaffolding or placeholder step \
-and then follow it with individual `write_file` calls to fill in or rewrite \
-those same files — that defeats the entire purpose of `write_files` and costs \
-exactly as many turns as not using it at all. Plan every new file's full content \
-BEFORE emitting the call, then emit ONE `write_files` call carrying every file. \
-`write_file` (singular) is for a SINGLE file: editing or adding one file after \
-the initial multi-file batch already exists via `write_files`. An N-file \
-from-scratch task should therefore cost ONE write turn, not N.
+- When you are scaffolding SEVERAL independent files, do not spend one turn per \
+file. Either emit all their `write_file` calls in a SINGLE turn (batching, as \
+above), or use the `write_files` tool, which takes an array of files and writes \
+them all in one call — an N-file scaffold should cost ONE turn, not N.
 - If one call in a batch fails, you still receive results for every other call \
 plus the failure — use them together to decide the next step.
 - Every tool call's arguments MUST validate against that tool's provided JSON \

--- a/crates/trusty-code/src/prompt/preamble.rs
+++ b/crates/trusty-code/src/prompt/preamble.rs
@@ -46,6 +46,10 @@ before bash).
 seen yet — e.g. you cannot `write_file` content derived from a `read_file` \
 whose result you don't yet have. Sequence those across turns: emit the read, \
 wait for its result, then decide the next step based on what actually happened.
+- When you are scaffolding SEVERAL independent files, do not spend one turn per \
+file. Either emit all their `write_file` calls in a SINGLE turn (batching, as \
+above), or use the `write_files` tool, which takes an array of files and writes \
+them all in one call — an N-file scaffold should cost ONE turn, not N.
 - If one call in a batch fails, you still receive results for every other call \
 plus the failure — use them together to decide the next step.
 - Every tool call's arguments MUST validate against that tool's provided JSON \
@@ -53,6 +57,15 @@ Schema. Supply all required fields and respect declared types.
 - A tool result may report an error. When it does, recover: retry with \
 corrected arguments, choose a different tool, or explain why you cannot \
 proceed. Do not repeat the same failing call unchanged.
+
+## File discovery
+
+- To explore the project, prefer the dedicated discovery tools over shelling \
+out: `glob` finds files by pattern (e.g. `**/*.py`, `src/*.rs`), `grep` \
+searches file contents by regular expression, and `list_dir` lists a \
+directory's entries. They return structured, project-scoped results and are \
+cheaper than a shell command. Reach for the shell tool only for actions these \
+do not cover (running builds, tests, or other commands).
 
 ## Filesystem-safety contract
 

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -335,7 +335,7 @@ fn base_preamble_version_is_semver_shaped() {
 /// Expected FNV-1a-style fold of [`BASE_PREAMBLE`]'s bytes, folded with its
 /// byte length. Regenerate this whenever the preamble legitimately changes
 /// (see [`base_preamble_hash_tripwire`] for the contributor instructions).
-const EXPECTED_PREAMBLE_HASH: u64 = 0x8e07_dc8d_bbf6_a7a1;
+const EXPECTED_PREAMBLE_HASH: u64 = 0x513f_fb3d_a209_0524;
 
 /// Test-time guard coupling `BASE_PREAMBLE` *content* to its version constant.
 ///

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -335,7 +335,7 @@ fn base_preamble_version_is_semver_shaped() {
 /// Expected FNV-1a-style fold of [`BASE_PREAMBLE`]'s bytes, folded with its
 /// byte length. Regenerate this whenever the preamble legitimately changes
 /// (see [`base_preamble_hash_tripwire`] for the contributor instructions).
-const EXPECTED_PREAMBLE_HASH: u64 = 0x513f_fb3d_a209_0524;
+const EXPECTED_PREAMBLE_HASH: u64 = 0x199b_808b_e2bc_6730;
 
 /// Test-time guard coupling `BASE_PREAMBLE` *content* to its version constant.
 ///

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -335,7 +335,7 @@ fn base_preamble_version_is_semver_shaped() {
 /// Expected FNV-1a-style fold of [`BASE_PREAMBLE`]'s bytes, folded with its
 /// byte length. Regenerate this whenever the preamble legitimately changes
 /// (see [`base_preamble_hash_tripwire`] for the contributor instructions).
-const EXPECTED_PREAMBLE_HASH: u64 = 0x199b_808b_e2bc_6730;
+const EXPECTED_PREAMBLE_HASH: u64 = 0x513f_fb3d_a209_0524;
 
 /// Test-time guard coupling `BASE_PREAMBLE` *content* to its version constant.
 ///

--- a/crates/trusty-code/src/prompt/version.rs
+++ b/crates/trusty-code/src/prompt/version.rs
@@ -18,4 +18,4 @@
 /// `BASE_PREAMBLE` text so reports referencing an old run remain interpretable.
 /// Test: `prompt::tests::base_preamble_version_is_semver_shaped` asserts the
 /// three-component shape.
-pub const BASE_PREAMBLE_VERSION: &str = "1.6.0";
+pub const BASE_PREAMBLE_VERSION: &str = "1.7.0";

--- a/crates/trusty-code/src/prompt/version.rs
+++ b/crates/trusty-code/src/prompt/version.rs
@@ -18,4 +18,4 @@
 /// `BASE_PREAMBLE` text so reports referencing an old run remain interpretable.
 /// Test: `prompt::tests::base_preamble_version_is_semver_shaped` asserts the
 /// three-component shape.
-pub const BASE_PREAMBLE_VERSION: &str = "1.5.0";
+pub const BASE_PREAMBLE_VERSION: &str = "1.6.0";

--- a/crates/trusty-code/src/prompt/version.rs
+++ b/crates/trusty-code/src/prompt/version.rs
@@ -18,4 +18,4 @@
 /// `BASE_PREAMBLE` text so reports referencing an old run remain interpretable.
 /// Test: `prompt::tests::base_preamble_version_is_semver_shaped` asserts the
 /// three-component shape.
-pub const BASE_PREAMBLE_VERSION: &str = "1.7.0";
+pub const BASE_PREAMBLE_VERSION: &str = "1.6.0";

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -38,8 +38,8 @@ use crate::provider::{
 };
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
 use crate::tools::{
-    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, FinishTaskTool,
-    ReadFileTool, RunContext, ToolRegistry, WriteFileTool,
+    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, FinishTaskTool, GlobTool,
+    GrepTool, ListDirTool, ReadFileTool, RunContext, ToolRegistry, WriteFileTool, WriteFilesTool,
 };
 
 pub use recorder::{RecordingLlmClient, SharedTranscript, TurnRecord};
@@ -314,11 +314,12 @@ fn build_engineer_runner(
 /// Why: The engineer needs real file and shell tools that cannot escape the
 /// project root, plus (#2072) `finish_task` so it can signal completion with a
 /// structured report. This factory constructs `read_file`, `write_file`,
-/// `edit`, and `bash` all scoped to `self.project`, so the engineer operates
-/// only inside the project working tree; `finish_task` has no filesystem
-/// footprint and needs no scoping.
+/// `write_files` (#2681 batch write), `edit`, the `glob`/`grep`/`list_dir`
+/// exploration tools (#1027), and `bash` all scoped to `self.project`, so the
+/// engineer operates only inside the project working tree; `finish_task` has no
+/// filesystem footprint and needs no scoping.
 /// What: Implements `RegistryFactory::build`, returning an `Arc<ToolRegistry>`
-/// with all five tools; the runner then gates them by the engineer's
+/// with every tool; the runner then gates them by the engineer's
 /// `tools.allowed`.
 /// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer` (the engineer's
 /// `write_file` actually writes into the project).
@@ -336,9 +337,16 @@ impl RegistryFactory for ProjectToolFactory {
         let mut reg = ToolRegistry::new();
         reg.register(Arc::new(ReadFileTool::new(&self.project)));
         reg.register(Arc::new(WriteFileTool::new(&self.project)));
+        // #2681: batch-write decouples turn-count from file-count.
+        reg.register(Arc::new(WriteFilesTool::new(&self.project)));
         reg.register(Arc::new(
             EditTool::new(&self.project).with_model_slug(model_slug),
         ));
+        // #1027: native file discovery so the engineer stops shelling out to
+        // find/grep/ls (the dominant bake-off agent-turn sink).
+        reg.register(Arc::new(GlobTool::new(&self.project)));
+        reg.register(Arc::new(GrepTool::new(&self.project)));
+        reg.register(Arc::new(ListDirTool::new(&self.project)));
         reg.register(Arc::new(BashTool::new(
             Some(self.project.clone()),
             Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -57,8 +57,8 @@ use crate::session::{SessionRegistry, SessionStatus};
 use crate::skills::{FsSkillResolver, format_skill_catalog, locate_skills_dir};
 use crate::tools::{
     AgentOutput, AgentRunner, BashTool, ClearGoalTool, DelegateToAgentTool, EditTool,
-    FinishTaskTool, ReadFileTool, RecallSessionTool, RunContext, SetGoalTool, SkillResolver,
-    ToolRegistry, UseSkillTool, WriteFileTool,
+    FinishTaskTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, RecallSessionTool, RunContext,
+    SetGoalTool, SkillResolver, ToolRegistry, UseSkillTool, WriteFileTool, WriteFilesTool,
 };
 
 use super::sink::SessionToolEventSink;
@@ -496,11 +496,18 @@ impl RegistryFactory for ProjectToolFactory {
         let mut reg = ToolRegistry::new();
         reg.register(Arc::new(ReadFileTool::new(&self.project)));
         reg.register(Arc::new(WriteFileTool::new(&self.project)));
+        // #2681: batch-write decouples turn-count from file-count.
+        reg.register(Arc::new(WriteFilesTool::new(&self.project)));
         reg.register(Arc::new(
             EditTool::new(&self.project)
                 .with_model_slug(model_slug)
                 .with_mode(self.mode),
         ));
+        // #1027: native file discovery so the engineer stops shelling out to
+        // find/grep/ls (the dominant bake-off agent-turn sink).
+        reg.register(Arc::new(GlobTool::new(&self.project)));
+        reg.register(Arc::new(GrepTool::new(&self.project)));
+        reg.register(Arc::new(ListDirTool::new(&self.project)));
         reg.register(Arc::new(BashTool::new(
             Some(self.project.clone()),
             Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),

--- a/crates/trusty-code/src/tools/fs/glob.rs
+++ b/crates/trusty-code/src/tools/fs/glob.rs
@@ -1,0 +1,366 @@
+//! `glob` tool — find files by glob pattern (e.g. `**/*.py`, `src/*.rs`).
+//!
+//! Why: The engineer's tool registry historically had NO native file discovery,
+//! so every `find`/`ls -R` went through the `bash` tool — the dominant agent-turn
+//! sink on the L1 bake-off (bash was 53-71% of every turn). A structured `glob`
+//! tool lets the model enumerate files in one typed call whose result the harness
+//! can pin and reason about, instead of parsing arbitrary shell output. (#1027.)
+//! What: `GlobTool` walks the working directory with a gitignore-aware walker
+//! (ripgrep's `ignore` crate — hidden files and `.gitignore`d paths are skipped
+//! by default) and returns every project-relative path matching the supplied
+//! glob. An optional `path` scopes the walk to a subdirectory.
+//! Test: See `#[cfg(test)]` below — covers a recursive match, a single-level
+//! match, subdirectory scoping, no-match, and path traversal.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use globset::{Glob, GlobMatcher};
+use ignore::WalkBuilder;
+use serde_json::{Value, json};
+
+use crate::tools::fs::{FsError, scoped_path};
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// Maximum number of paths `GlobTool` returns in a single call.
+///
+/// Why: An unbounded match set (`**/*` on a huge tree) would blow the LLM
+/// context window. Capping and flagging truncation keeps the result bounded and
+/// honest.
+/// What: Constant used to truncate the sorted match list.
+/// Test: `glob_truncates_large_result_sets`.
+pub const MAX_GLOB_MATCHES: usize = 500;
+
+/// `ToolExecutor` that lists files matching a glob pattern.
+///
+/// Why: Gives agents a native, sandboxed file-discovery primitive so they stop
+/// shelling out to `find`, cutting round-trips.
+/// What: Implements `ToolExecutor` with `name = "glob"`, scoped to
+/// `working_dir`; rejects traversal attempts in the optional `path` argument.
+/// Test: `cargo test -p trusty-code -- tools::fs::glob`.
+pub struct GlobTool {
+    working_dir: PathBuf,
+}
+
+impl GlobTool {
+    /// Construct a new `GlobTool` scoped to `working_dir`.
+    ///
+    /// Why: The working directory is the security boundary; set once at
+    /// construction so the LLM cannot widen it per-call.
+    /// What: Stores `working_dir`.
+    /// Test: `glob_finds_files_recursively`, et al.
+    pub fn new(working_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            working_dir: working_dir.into(),
+        }
+    }
+
+    /// Walk `root` and collect project-relative paths matching `matcher`.
+    ///
+    /// Why: Centralises the walk + match so `execute` stays short and the cap /
+    /// sort / truncation policy lives in one place.
+    /// What: Uses a gitignore-aware `WalkBuilder`, matches each file's path
+    /// relative to `self.working_dir` against `matcher`, returns sorted matches
+    /// and whether the set was truncated at `MAX_GLOB_MATCHES`.
+    /// Test: All `GlobTool` unit tests.
+    fn collect(&self, root: &Path, matcher: &GlobMatcher) -> (Vec<String>, bool) {
+        // Strip against the CANONICAL working dir: `root` came from `scoped_path`
+        // (canonicalized), so on macOS its entries carry the `/private/var/…`
+        // prefix while `self.working_dir` may be the `/var/…` symlink form —
+        // stripping the raw form would fail and leak absolute paths into the
+        // matcher, breaking single-segment patterns like `src/*.rs`.
+        let base =
+            std::fs::canonicalize(&self.working_dir).unwrap_or_else(|_| self.working_dir.clone());
+        let mut matches = Vec::new();
+        for entry in WalkBuilder::new(root).hidden(true).build().flatten() {
+            // Only match files, not directories.
+            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                continue;
+            }
+            let rel = entry.path().strip_prefix(&base).unwrap_or(entry.path());
+            if matcher.is_match(rel) {
+                matches.push(rel.to_string_lossy().into_owned());
+            }
+        }
+        matches.sort();
+        let truncated = matches.len() > MAX_GLOB_MATCHES;
+        matches.truncate(MAX_GLOB_MATCHES);
+        (matches, truncated)
+    }
+
+    /// Resolve the scoped root, compile the glob, and run the walk.
+    ///
+    /// Why: Keeps error handling (traversal, bad pattern) in one place returning
+    /// a single `Result` for `execute` to format.
+    /// What: Scopes `path` (default `working_dir`), compiles `pattern` into a
+    /// `GlobMatcher`, walks, and returns the formatted match listing.
+    /// Test: All `GlobTool` unit tests.
+    fn glob_inner(&self, pattern: &str, sub_path: Option<&str>) -> Result<String, FsError> {
+        let root = match sub_path {
+            Some(p) => scoped_path(&self.working_dir, Path::new(p))?,
+            None => scoped_path(&self.working_dir, Path::new("."))?,
+        };
+
+        let matcher = Glob::new(pattern)
+            .map_err(|e| FsError::GlobPattern {
+                pattern: pattern.to_string(),
+                reason: e.to_string(),
+            })?
+            .compile_matcher();
+
+        let (matches, truncated) = self.collect(&root, &matcher);
+
+        if matches.is_empty() {
+            return Ok(format!("no files matched pattern '{pattern}'"));
+        }
+
+        let mut out = matches.join("\n");
+        if truncated {
+            out.push_str(&format!(
+                "\n… (truncated at {MAX_GLOB_MATCHES} matches; refine the pattern)"
+            ));
+        }
+        Ok(out)
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for GlobTool {
+    fn name(&self) -> &str {
+        "glob"
+    }
+
+    /// OpenAI function-call schema for `glob`.
+    ///
+    /// Why: The LLM constructs its call from this schema; parameters mirror the
+    /// `execute` contract exactly.
+    /// What: JSON object with `pattern` (required) and `path` (optional
+    /// subdirectory to scope the walk).
+    /// Test: `schema_has_required_pattern`.
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "glob",
+                "description": "Find files by glob pattern (e.g. '**/*.py', 'src/*.rs'). Returns matching project-relative paths, one per line. Hidden and .gitignore'd files are skipped. Prefer this over shelling out to 'find'.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "pattern": {
+                            "type": "string",
+                            "description": "Glob pattern to match against project-relative paths. '**' matches any number of directories; '*' matches within a path segment."
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Optional subdirectory (relative to the working directory) to scope the search. Defaults to the whole project."
+                        }
+                    },
+                    "required": ["pattern"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    /// Execute a `glob` tool call.
+    ///
+    /// Why: Enumerates files matching `pattern` within the working directory.
+    /// What: Parses `{pattern, path?}` from `args`, calls `glob_inner`, converts
+    /// the result into a `ToolResult`.
+    /// Test: `glob_finds_files_recursively`, etc.
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(pattern) = args.get("pattern").and_then(Value::as_str) else {
+            return ToolResult::err("glob: missing required argument 'pattern'");
+        };
+        let sub_path = args.get("path").and_then(Value::as_str);
+
+        match self.glob_inner(pattern, sub_path) {
+            Ok(listing) => ToolResult::ok(listing),
+            Err(e) => ToolResult::err(e.to_string()),
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::tools::traits::ToolExecutor;
+
+    /// Seed a small tree: `a.py`, `pkg/b.py`, `pkg/c.txt`, `src/main.rs`.
+    fn seed(tmp: &tempfile::TempDir) {
+        fs::write(tmp.path().join("a.py"), "x = 1\n").expect("write");
+        fs::create_dir_all(tmp.path().join("pkg")).expect("mkdir");
+        fs::write(tmp.path().join("pkg/b.py"), "y = 2\n").expect("write");
+        fs::write(tmp.path().join("pkg/c.txt"), "text\n").expect("write");
+        fs::create_dir_all(tmp.path().join("src")).expect("mkdir");
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").expect("write");
+    }
+
+    /// `glob` with `**/*.py` finds every Python file, at any depth.
+    ///
+    /// Why: The `**` recursive-match is the core of #1027.
+    /// What: Seeds a tree, globs `**/*.py`, asserts both `.py` files appear and
+    /// the `.txt`/`.rs` files do not.
+    /// Test: This test.
+    #[tokio::test]
+    async fn glob_finds_files_recursively() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        seed(&tmp);
+        let tool = GlobTool::new(tmp.path());
+        let result = tool.execute(json!({"pattern": "**/*.py"})).await;
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        let out = result.content();
+        assert!(out.contains("a.py"), "top-level a.py missing: {out}");
+        assert!(out.contains("pkg/b.py"), "nested pkg/b.py missing: {out}");
+        assert!(!out.contains("c.txt"), "non-matching c.txt present: {out}");
+        assert!(
+            !out.contains("main.rs"),
+            "non-matching main.rs present: {out}"
+        );
+    }
+
+    /// `glob` with `src/*.rs` matches only files directly under `src`.
+    ///
+    /// Why: Single-segment `*` must not cross directory boundaries.
+    /// What: Globs `src/*.rs`, asserts `src/main.rs` matches and `a.py` does not.
+    /// Test: This test.
+    #[tokio::test]
+    async fn glob_single_level_pattern() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        seed(&tmp);
+        let tool = GlobTool::new(tmp.path());
+        let result = tool.execute(json!({"pattern": "src/*.rs"})).await;
+        assert!(!result.is_error());
+        let out = result.content();
+        assert!(out.contains("src/main.rs"), "src/main.rs missing: {out}");
+        assert!(
+            !out.contains("a.py"),
+            "a.py should not match src/*.rs: {out}"
+        );
+    }
+
+    /// `glob` scoped to a subdirectory only walks that subtree.
+    ///
+    /// Why: The optional `path` argument lets the agent narrow the search.
+    /// What: Globs `*.py` scoped to `pkg`, asserts `pkg/b.py` matches and the
+    /// top-level `a.py` does not.
+    /// Test: This test.
+    #[tokio::test]
+    async fn glob_scoped_to_subdirectory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        seed(&tmp);
+        let tool = GlobTool::new(tmp.path());
+        let result = tool
+            .execute(json!({"pattern": "**/*.py", "path": "pkg"}))
+            .await;
+        assert!(!result.is_error(), "{}", result.content());
+        let out = result.content();
+        assert!(out.contains("pkg/b.py"), "pkg/b.py missing: {out}");
+        assert!(!out.contains("a.py"), "a.py is outside scoped path: {out}");
+    }
+
+    /// `glob` with no matches returns a clear message, not an error.
+    ///
+    /// Why: "No results" is a normal outcome the model must be able to read.
+    /// What: Globs `**/*.java` over a tree with none, expects the no-match text.
+    /// Test: This test.
+    #[tokio::test]
+    async fn glob_no_matches_reports_clearly() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        seed(&tmp);
+        let tool = GlobTool::new(tmp.path());
+        let result = tool.execute(json!({"pattern": "**/*.java"})).await;
+        assert!(!result.is_error());
+        assert!(
+            result.content().contains("no files matched"),
+            "unexpected message: {}",
+            result.content()
+        );
+    }
+
+    /// `glob` rejects a `path` that escapes the working directory.
+    ///
+    /// Why: Path traversal must be blocked at the tool boundary.
+    /// What: `execute({pattern:"*", path:"../.."})` must return an error.
+    /// Test: This test.
+    #[tokio::test]
+    async fn glob_path_traversal_is_rejected() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = GlobTool::new(tmp.path());
+        let result = tool
+            .execute(json!({"pattern": "*", "path": "../../etc"}))
+            .await;
+        assert!(result.is_error());
+        assert!(
+            result.content().contains("escapes"),
+            "unexpected message: {}",
+            result.content()
+        );
+    }
+
+    /// `glob` reports a bad glob pattern as a recoverable error.
+    ///
+    /// Why: A malformed pattern must surface as a structured error the model can
+    /// correct, not a panic.
+    /// What: `execute({pattern:"[unclosed"})` returns an error mentioning the
+    /// pattern.
+    /// Test: This test.
+    #[tokio::test]
+    async fn glob_bad_pattern_errors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = GlobTool::new(tmp.path());
+        let result = tool.execute(json!({"pattern": "[unclosed"})).await;
+        assert!(result.is_error());
+        assert!(
+            result.content().contains("glob"),
+            "unexpected message: {}",
+            result.content()
+        );
+    }
+
+    /// `glob` truncates match sets larger than `MAX_GLOB_MATCHES`.
+    ///
+    /// Why: An unbounded result would overflow the context window.
+    /// What: Seeds `MAX_GLOB_MATCHES + 5` files, globs `**/*.py`, asserts the
+    /// truncation notice appears and at most the cap of paths is listed.
+    /// Test: This test.
+    #[tokio::test]
+    async fn glob_truncates_large_result_sets() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for i in 0..(MAX_GLOB_MATCHES + 5) {
+            fs::write(tmp.path().join(format!("f{i}.py")), "x\n").expect("write");
+        }
+        let tool = GlobTool::new(tmp.path());
+        let result = tool.execute(json!({"pattern": "**/*.py"})).await;
+        assert!(!result.is_error());
+        assert!(
+            result.content().contains("truncated"),
+            "expected truncation notice"
+        );
+    }
+
+    /// The schema lists `pattern` as required.
+    ///
+    /// Why: The LLM omits non-required args; `pattern` must be required.
+    /// What: Parses `schema()` and checks `required` contains "pattern".
+    /// Test: This test.
+    #[test]
+    fn schema_has_required_pattern() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = GlobTool::new(tmp.path());
+        let schema = tool.schema();
+        let required = schema["function"]["parameters"]["required"]
+            .as_array()
+            .expect("required array");
+        assert!(
+            required.iter().any(|v| v.as_str() == Some("pattern")),
+            "schema must list 'pattern' as required"
+        );
+    }
+}

--- a/crates/trusty-code/src/tools/fs/grep.rs
+++ b/crates/trusty-code/src/tools/fs/grep.rs
@@ -1,0 +1,417 @@
+//! `grep` tool — search file contents by regex across the project.
+//!
+//! Why: Content search is the other discovery primitive the engineer lacked, so
+//! every `grep -r` went through the `bash` tool — part of the dominant agent-turn
+//! sink on the L1 bake-off. A structured `grep` tool returns `file:line: text`
+//! hits the harness can pin, instead of raw shell output. (#1027.)
+//! What: `GrepTool` walks the working directory with a gitignore-aware walker
+//! (ripgrep's `ignore` crate) and returns each line matching the supplied regex.
+//! An optional `path` scopes the walk and an optional `glob` filters which files
+//! are searched.
+//! Test: See `#[cfg(test)]` below — covers a content hit, regex semantics, the
+//! glob filter, subdirectory scoping, no-match, bad-regex, and path traversal.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use globset::{Glob, GlobMatcher};
+use ignore::WalkBuilder;
+use regex::Regex;
+use serde_json::{Value, json};
+
+use crate::tools::fs::{FsError, scoped_path};
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// Maximum number of matching lines `GrepTool` returns in a single call.
+///
+/// Why: A broad regex over a large tree could return thousands of hits and blow
+/// the LLM context window. Capping and flagging truncation keeps it bounded.
+/// What: Constant used to stop collecting hits.
+/// Test: `grep_truncates_large_result_sets`.
+pub const MAX_GREP_HITS: usize = 200;
+
+/// Skip files larger than this (bytes) — they are almost always assets/binaries.
+///
+/// Why: Reading a multi-MiB blob line-by-line to regex-match is wasteful and
+/// risks non-UTF-8 content; bounding the per-file size keeps grep fast.
+/// What: Files whose metadata length exceeds this are skipped.
+/// Test: Exercised indirectly by the content-hit tests (all small files).
+const MAX_GREP_FILE_BYTES: u64 = 1024 * 1024; // 1 MiB
+
+/// `ToolExecutor` that searches file contents by regex.
+///
+/// Why: Gives agents a native, sandboxed content-search primitive so they stop
+/// shelling out to `grep -r`, cutting round-trips.
+/// What: Implements `ToolExecutor` with `name = "grep"`, scoped to
+/// `working_dir`; rejects traversal attempts in the optional `path` argument.
+/// Test: `cargo test -p trusty-code -- tools::fs::grep`.
+pub struct GrepTool {
+    working_dir: PathBuf,
+}
+
+impl GrepTool {
+    /// Construct a new `GrepTool` scoped to `working_dir`.
+    ///
+    /// Why: The working directory is the security boundary; set once at
+    /// construction so the LLM cannot widen it per-call.
+    /// What: Stores `working_dir`.
+    /// Test: `grep_finds_matching_lines`, et al.
+    pub fn new(working_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            working_dir: working_dir.into(),
+        }
+    }
+
+    /// Walk `root` and collect `file:line: text` hits for `re`.
+    ///
+    /// Why: Centralises the walk + per-line match so `execute` stays short and
+    /// the cap / file-filter / size-skip policy lives in one place.
+    /// What: Uses a gitignore-aware `WalkBuilder`; for each file (optionally
+    /// filtered by `glob`) reads its text and records every line matching `re`,
+    /// stopping at `MAX_GREP_HITS`. Returns hits and whether truncated.
+    /// Test: All `GrepTool` unit tests.
+    fn collect(&self, root: &Path, re: &Regex, glob: Option<&GlobMatcher>) -> (Vec<String>, bool) {
+        // Strip against the CANONICAL working dir (see `GlobTool::collect` for the
+        // macOS `/var` vs `/private/var` rationale) so the optional `glob` file
+        // filter and the `path:line:` display use clean project-relative paths.
+        let base =
+            std::fs::canonicalize(&self.working_dir).unwrap_or_else(|_| self.working_dir.clone());
+        let mut hits = Vec::new();
+        let mut truncated = false;
+
+        'walk: for entry in WalkBuilder::new(root).hidden(true).build().flatten() {
+            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                continue;
+            }
+            let path = entry.path();
+            let rel = path.strip_prefix(&base).unwrap_or(path);
+
+            if let Some(g) = glob
+                && !g.is_match(rel)
+            {
+                continue;
+            }
+
+            // Skip oversized files (assets/binaries).
+            if std::fs::metadata(path).is_ok_and(|m| m.len() > MAX_GREP_FILE_BYTES) {
+                continue;
+            }
+
+            // Non-UTF-8 files are skipped silently (read_to_string errors).
+            let Ok(content) = std::fs::read_to_string(path) else {
+                continue;
+            };
+
+            let rel_display = rel.to_string_lossy();
+            for (idx, line) in content.lines().enumerate() {
+                if re.is_match(line) {
+                    if hits.len() >= MAX_GREP_HITS {
+                        truncated = true;
+                        break 'walk;
+                    }
+                    // 1-based line numbers; trim to keep results compact.
+                    hits.push(format!("{}:{}: {}", rel_display, idx + 1, line.trim_end()));
+                }
+            }
+        }
+        (hits, truncated)
+    }
+
+    /// Resolve the scoped root, compile the regex + optional glob, and search.
+    ///
+    /// Why: Keeps error handling (traversal, bad regex, bad glob) in one place
+    /// returning a single `Result` for `execute` to format.
+    /// What: Scopes `path` (default `working_dir`), compiles `pattern` into a
+    /// `Regex` and the optional `glob` into a `GlobMatcher`, walks, and returns
+    /// the formatted hit listing.
+    /// Test: All `GrepTool` unit tests.
+    fn grep_inner(
+        &self,
+        pattern: &str,
+        sub_path: Option<&str>,
+        glob: Option<&str>,
+    ) -> Result<String, FsError> {
+        let root = match sub_path {
+            Some(p) => scoped_path(&self.working_dir, Path::new(p))?,
+            None => scoped_path(&self.working_dir, Path::new("."))?,
+        };
+
+        let re = Regex::new(pattern).map_err(|e| FsError::GrepPattern {
+            pattern: pattern.to_string(),
+            reason: e.to_string(),
+        })?;
+
+        let matcher = match glob {
+            Some(g) => Some(
+                Glob::new(g)
+                    .map_err(|e| FsError::GlobPattern {
+                        pattern: g.to_string(),
+                        reason: e.to_string(),
+                    })?
+                    .compile_matcher(),
+            ),
+            None => None,
+        };
+
+        let (hits, truncated) = self.collect(&root, &re, matcher.as_ref());
+
+        if hits.is_empty() {
+            return Ok(format!("no matches for pattern '{pattern}'"));
+        }
+
+        let mut out = hits.join("\n");
+        if truncated {
+            out.push_str(&format!(
+                "\n… (truncated at {MAX_GREP_HITS} matches; refine the pattern)"
+            ));
+        }
+        Ok(out)
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for GrepTool {
+    fn name(&self) -> &str {
+        "grep"
+    }
+
+    /// OpenAI function-call schema for `grep`.
+    ///
+    /// Why: The LLM constructs its call from this schema; parameters mirror the
+    /// `execute` contract exactly.
+    /// What: JSON object with `pattern` (required regex), `path` (optional
+    /// subdirectory), and `glob` (optional file filter).
+    /// Test: `schema_has_required_pattern`.
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "grep",
+                "description": "Search file contents by regular expression across the project. Returns matching 'path:line: text' hits, one per line. Hidden and .gitignore'd files are skipped. Prefer this over shelling out to 'grep'.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "pattern": {
+                            "type": "string",
+                            "description": "Regular expression to match against each line of file contents."
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Optional subdirectory (relative to the working directory) to scope the search. Defaults to the whole project."
+                        },
+                        "glob": {
+                            "type": "string",
+                            "description": "Optional glob (e.g. '**/*.py') restricting which files are searched."
+                        }
+                    },
+                    "required": ["pattern"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    /// Execute a `grep` tool call.
+    ///
+    /// Why: Searches file contents for `pattern` within the working directory.
+    /// What: Parses `{pattern, path?, glob?}` from `args`, calls `grep_inner`,
+    /// converts the result into a `ToolResult`.
+    /// Test: `grep_finds_matching_lines`, etc.
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(pattern) = args.get("pattern").and_then(Value::as_str) else {
+            return ToolResult::err("grep: missing required argument 'pattern'");
+        };
+        let sub_path = args.get("path").and_then(Value::as_str);
+        let glob = args.get("glob").and_then(Value::as_str);
+
+        match self.grep_inner(pattern, sub_path, glob) {
+            Ok(listing) => ToolResult::ok(listing),
+            Err(e) => ToolResult::err(e.to_string()),
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::tools::traits::ToolExecutor;
+
+    /// Seed a tree with searchable content.
+    fn seed(tmp: &tempfile::TempDir) {
+        fs::write(
+            tmp.path().join("app.py"),
+            "import os\ndef handler():\n    return TODO_FIXME\n",
+        )
+        .expect("write");
+        fs::create_dir_all(tmp.path().join("lib")).expect("mkdir");
+        fs::write(
+            tmp.path().join("lib/util.rs"),
+            "fn helper() {}\n// TODO_FIXME later\n",
+        )
+        .expect("write");
+    }
+
+    /// `grep` finds a literal substring and reports `path:line: text`.
+    ///
+    /// Why: Basic content-search contract, the core of #1027.
+    /// What: Seeds files containing `TODO_FIXME`, greps for it, asserts both
+    /// files and their line numbers appear.
+    /// Test: This test.
+    #[tokio::test]
+    async fn grep_finds_matching_lines() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        seed(&tmp);
+        let tool = GrepTool::new(tmp.path());
+        let result = tool.execute(json!({"pattern": "TODO_FIXME"})).await;
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        let out = result.content();
+        assert!(out.contains("app.py:3:"), "app.py hit missing: {out}");
+        assert!(out.contains("lib/util.rs:2:"), "util.rs hit missing: {out}");
+    }
+
+    /// `grep` honours regex semantics, not just literal substrings.
+    ///
+    /// Why: The pattern is a regex; anchors/character classes must work.
+    /// What: Greps `^def ` (line starting with `def `), asserts only the
+    /// function-definition line matches.
+    /// Test: This test.
+    #[tokio::test]
+    async fn grep_uses_regex_semantics() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        seed(&tmp);
+        let tool = GrepTool::new(tmp.path());
+        let result = tool.execute(json!({"pattern": "^def "})).await;
+        assert!(!result.is_error());
+        let out = result.content();
+        assert!(out.contains("def handler"), "def line missing: {out}");
+        assert!(
+            !out.contains("import os"),
+            "import line must not match: {out}"
+        );
+    }
+
+    /// `grep` with a `glob` filter searches only matching files.
+    ///
+    /// Why: The optional glob narrows the file set (e.g. only `.rs`).
+    /// What: Greps `TODO_FIXME` restricted to `**/*.rs`, asserts the `.rs` hit
+    /// appears and the `.py` hit does not.
+    /// Test: This test.
+    #[tokio::test]
+    async fn grep_glob_filter_restricts_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        seed(&tmp);
+        let tool = GrepTool::new(tmp.path());
+        let result = tool
+            .execute(json!({"pattern": "TODO_FIXME", "glob": "**/*.rs"}))
+            .await;
+        assert!(!result.is_error());
+        let out = result.content();
+        assert!(out.contains("lib/util.rs"), "rs hit missing: {out}");
+        assert!(
+            !out.contains("app.py"),
+            "py file must be filtered out: {out}"
+        );
+    }
+
+    /// `grep` scoped to a subdirectory only searches that subtree.
+    ///
+    /// Why: The optional `path` argument narrows the search.
+    /// What: Greps `TODO_FIXME` scoped to `lib`, asserts only the `lib` hit.
+    /// Test: This test.
+    #[tokio::test]
+    async fn grep_scoped_to_subdirectory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        seed(&tmp);
+        let tool = GrepTool::new(tmp.path());
+        let result = tool
+            .execute(json!({"pattern": "TODO_FIXME", "path": "lib"}))
+            .await;
+        assert!(!result.is_error());
+        let out = result.content();
+        assert!(out.contains("lib/util.rs"), "lib hit missing: {out}");
+        assert!(!out.contains("app.py"), "app.py is outside scope: {out}");
+    }
+
+    /// `grep` with no matches returns a clear message, not an error.
+    ///
+    /// Why: "No results" is a normal outcome the model must read.
+    /// What: Greps a pattern present in no file, expects the no-match text.
+    /// Test: This test.
+    #[tokio::test]
+    async fn grep_no_matches_reports_clearly() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        seed(&tmp);
+        let tool = GrepTool::new(tmp.path());
+        let result = tool.execute(json!({"pattern": "ZZZ_NOT_PRESENT"})).await;
+        assert!(!result.is_error());
+        assert!(
+            result.content().contains("no matches"),
+            "unexpected message: {}",
+            result.content()
+        );
+    }
+
+    /// `grep` reports a bad regex as a recoverable error.
+    ///
+    /// Why: A malformed pattern must surface as a structured error the model can
+    /// correct, not a panic.
+    /// What: `execute({pattern:"(unclosed"})` returns an error mentioning grep.
+    /// Test: This test.
+    #[tokio::test]
+    async fn grep_bad_regex_errors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = GrepTool::new(tmp.path());
+        let result = tool.execute(json!({"pattern": "(unclosed"})).await;
+        assert!(result.is_error());
+        assert!(
+            result.content().contains("grep"),
+            "unexpected message: {}",
+            result.content()
+        );
+    }
+
+    /// `grep` rejects a `path` that escapes the working directory.
+    ///
+    /// Why: Path traversal must be blocked at the tool boundary.
+    /// What: `execute({pattern:"x", path:"../.."})` must return an error.
+    /// Test: This test.
+    #[tokio::test]
+    async fn grep_path_traversal_is_rejected() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = GrepTool::new(tmp.path());
+        let result = tool
+            .execute(json!({"pattern": "x", "path": "../../etc"}))
+            .await;
+        assert!(result.is_error());
+        assert!(
+            result.content().contains("escapes"),
+            "unexpected message: {}",
+            result.content()
+        );
+    }
+
+    /// The schema lists `pattern` as required.
+    ///
+    /// Why: The LLM omits non-required args; `pattern` must be required.
+    /// What: Parses `schema()` and checks `required` contains "pattern".
+    /// Test: This test.
+    #[test]
+    fn schema_has_required_pattern() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = GrepTool::new(tmp.path());
+        let schema = tool.schema();
+        let required = schema["function"]["parameters"]["required"]
+            .as_array()
+            .expect("required array");
+        assert!(
+            required.iter().any(|v| v.as_str() == Some("pattern")),
+            "schema must list 'pattern' as required"
+        );
+    }
+}

--- a/crates/trusty-code/src/tools/fs/grep.rs
+++ b/crates/trusty-code/src/tools/fs/grep.rs
@@ -357,6 +357,31 @@ mod tests {
         );
     }
 
+    /// `grep` truncates match sets larger than `MAX_GREP_HITS`.
+    ///
+    /// Why: An unbounded result would overflow the context window — this is the
+    /// exact guarantee `MAX_GREP_HITS`'s doc comment promises.
+    /// What: Seeds a single file with `MAX_GREP_HITS + 5` matching lines, greps
+    /// for the shared marker, asserts the truncation notice appears.
+    /// Test: This test.
+    #[tokio::test]
+    async fn grep_truncates_large_result_sets() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut content = String::new();
+        for i in 0..(MAX_GREP_HITS + 5) {
+            content.push_str(&format!("MATCH_MARKER line {i}\n"));
+        }
+        fs::write(tmp.path().join("big.txt"), content).expect("write");
+        let tool = GrepTool::new(tmp.path());
+        let result = tool.execute(json!({"pattern": "MATCH_MARKER"})).await;
+        assert!(!result.is_error(), "{}", result.content());
+        assert!(
+            result.content().contains("truncated"),
+            "expected truncation notice: {}",
+            result.content()
+        );
+    }
+
     /// `grep` reports a bad regex as a recoverable error.
     ///
     /// Why: A malformed pattern must surface as a structured error the model can

--- a/crates/trusty-code/src/tools/fs/list_dir.rs
+++ b/crates/trusty-code/src/tools/fs/list_dir.rs
@@ -1,0 +1,283 @@
+//! `list_dir` tool — list the entries of a single directory.
+//!
+//! Why: Complements `glob`/`grep` (#1027) — the cheapest discovery primitive is
+//! "what's in this directory?", which the engineer previously could only get by
+//! shelling out to `ls`. A structured, non-recursive listing lets the model
+//! orient itself in one typed call instead of a bash round-trip.
+//! What: `ListDirTool` reads one directory (default: the working-directory root)
+//! and returns its immediate entries, each tagged as a directory (`name/`) or a
+//! file (`name`). Non-recursive by design — recursion is `glob`'s job.
+//! Test: See `#[cfg(test)]` below — covers a mixed listing, subdirectory
+//! listing, missing directory, not-a-directory, and path traversal.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::fs::{FsError, scoped_path};
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// `ToolExecutor` that lists the immediate entries of a directory.
+///
+/// Why: Gives agents a native, sandboxed directory-listing primitive so they
+/// stop shelling out to `ls`, cutting round-trips.
+/// What: Implements `ToolExecutor` with `name = "list_dir"`, scoped to
+/// `working_dir`; rejects traversal attempts in the optional `path` argument.
+/// Test: `cargo test -p trusty-code -- tools::fs::list_dir`.
+pub struct ListDirTool {
+    working_dir: PathBuf,
+}
+
+impl ListDirTool {
+    /// Construct a new `ListDirTool` scoped to `working_dir`.
+    ///
+    /// Why: The working directory is the security boundary; set once at
+    /// construction so the LLM cannot widen it per-call.
+    /// What: Stores `working_dir`.
+    /// Test: `list_dir_lists_entries`, et al.
+    pub fn new(working_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            working_dir: working_dir.into(),
+        }
+    }
+
+    /// List the immediate entries of `sub_path` (default: the working dir).
+    ///
+    /// Why: Centralises the scope + read_dir + formatting so `execute` stays
+    /// short.
+    /// What: Scopes the path, verifies it is a directory, reads its entries,
+    /// tags each as `name/` (dir) or `name` (file), and returns them sorted.
+    /// Test: All `ListDirTool` unit tests.
+    fn list_inner(&self, sub_path: Option<&str>) -> Result<String, FsError> {
+        let target = match sub_path {
+            Some(p) => scoped_path(&self.working_dir, Path::new(p))?,
+            None => scoped_path(&self.working_dir, Path::new("."))?,
+        };
+
+        let meta = std::fs::metadata(&target).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                FsError::NotFound(target.clone())
+            } else {
+                FsError::io(&target, e)
+            }
+        })?;
+
+        if !meta.is_dir() {
+            return Err(FsError::NotADirectory(target));
+        }
+
+        let read = std::fs::read_dir(&target).map_err(|e| FsError::io(&target, e))?;
+        let mut entries = Vec::new();
+        for dirent in read {
+            let dirent = dirent.map_err(|e| FsError::io(&target, e))?;
+            let name = dirent.file_name().to_string_lossy().into_owned();
+            // A trailing slash marks directories so the model can tell them
+            // apart without a second call.
+            let is_dir = dirent.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+            if is_dir {
+                entries.push(format!("{name}/"));
+            } else {
+                entries.push(name);
+            }
+        }
+
+        if entries.is_empty() {
+            return Ok("(empty directory)".to_string());
+        }
+
+        entries.sort();
+        Ok(entries.join("\n"))
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for ListDirTool {
+    fn name(&self) -> &str {
+        "list_dir"
+    }
+
+    /// OpenAI function-call schema for `list_dir`.
+    ///
+    /// Why: The LLM constructs its call from this schema; parameters mirror the
+    /// `execute` contract exactly.
+    /// What: JSON object with an optional `path` (directory to list; defaults to
+    /// the working-directory root).
+    /// Test: `schema_has_no_required_fields`.
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "list_dir",
+                "description": "List the immediate entries of a directory (non-recursive). Directories are suffixed with '/'. Defaults to the project root. Prefer this over shelling out to 'ls'.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Directory to list, relative to the working directory. Defaults to the project root."
+                        }
+                    },
+                    "required": [],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    /// Execute a `list_dir` tool call.
+    ///
+    /// Why: Lists the entries of a directory within the working directory.
+    /// What: Parses the optional `{path}` from `args`, calls `list_inner`,
+    /// converts the result into a `ToolResult`.
+    /// Test: `list_dir_lists_entries`, etc.
+    async fn execute(&self, args: Value) -> ToolResult {
+        let sub_path = args.get("path").and_then(Value::as_str);
+        match self.list_inner(sub_path) {
+            Ok(listing) => ToolResult::ok(listing),
+            Err(e) => ToolResult::err(e.to_string()),
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::tools::traits::ToolExecutor;
+
+    /// `list_dir` at the root lists files and directories, tagging dirs with `/`.
+    ///
+    /// Why: Basic listing contract, the core of the complement to #1027.
+    /// What: Seeds a file and a subdir, lists the root, asserts both appear with
+    /// the directory tagged by a trailing slash.
+    /// Test: This test.
+    #[tokio::test]
+    async fn list_dir_lists_entries() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("main.py"), "x\n").expect("write");
+        fs::create_dir_all(tmp.path().join("pkg")).expect("mkdir");
+        let tool = ListDirTool::new(tmp.path());
+        let result = tool.execute(json!({})).await;
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        let out = result.content();
+        assert!(out.contains("main.py"), "file missing: {out}");
+        assert!(out.contains("pkg/"), "dir must be tagged with '/': {out}");
+    }
+
+    /// `list_dir` scoped to a subdirectory lists that directory's entries.
+    ///
+    /// Why: The optional `path` argument narrows the listing.
+    /// What: Seeds `pkg/mod.py`, lists `pkg`, asserts `mod.py` appears and the
+    /// root's `main.py` does not.
+    /// Test: This test.
+    #[tokio::test]
+    async fn list_dir_scoped_to_subdirectory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("main.py"), "x\n").expect("write");
+        fs::create_dir_all(tmp.path().join("pkg")).expect("mkdir");
+        fs::write(tmp.path().join("pkg/mod.py"), "y\n").expect("write");
+        let tool = ListDirTool::new(tmp.path());
+        let result = tool.execute(json!({"path": "pkg"})).await;
+        assert!(!result.is_error());
+        let out = result.content();
+        assert!(out.contains("mod.py"), "pkg/mod.py entry missing: {out}");
+        assert!(!out.contains("main.py"), "root file must not appear: {out}");
+    }
+
+    /// `list_dir` on an empty directory returns a clear marker.
+    ///
+    /// Why: An empty listing must be distinguishable from an error.
+    /// What: Lists an empty subdir, expects the empty-directory marker.
+    /// Test: This test.
+    #[tokio::test]
+    async fn list_dir_empty_directory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::create_dir_all(tmp.path().join("empty")).expect("mkdir");
+        let tool = ListDirTool::new(tmp.path());
+        let result = tool.execute(json!({"path": "empty"})).await;
+        assert!(!result.is_error());
+        assert!(
+            result.content().contains("empty directory"),
+            "unexpected message: {}",
+            result.content()
+        );
+    }
+
+    /// `list_dir` on a missing directory returns a not-found error.
+    ///
+    /// Why: Missing paths must surface as `ToolResult::Error`, not panic.
+    /// What: Lists a non-existent subdir, expects a "not found" error.
+    /// Test: This test.
+    #[tokio::test]
+    async fn list_dir_missing_directory_errors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = ListDirTool::new(tmp.path());
+        let result = tool.execute(json!({"path": "does_not_exist"})).await;
+        assert!(result.is_error());
+        assert!(
+            result.content().contains("not found"),
+            "unexpected message: {}",
+            result.content()
+        );
+    }
+
+    /// `list_dir` on a file (not a directory) returns a clear error.
+    ///
+    /// Why: Listing a file makes no sense; the error must say so.
+    /// What: Seeds a file, lists it as if a directory, expects a not-a-directory
+    /// error.
+    /// Test: This test.
+    #[tokio::test]
+    async fn list_dir_on_file_errors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("f.txt"), "x\n").expect("write");
+        let tool = ListDirTool::new(tmp.path());
+        let result = tool.execute(json!({"path": "f.txt"})).await;
+        assert!(result.is_error());
+        assert!(
+            result.content().contains("not a directory"),
+            "unexpected message: {}",
+            result.content()
+        );
+    }
+
+    /// `list_dir` rejects a `path` that escapes the working directory.
+    ///
+    /// Why: Path traversal must be blocked at the tool boundary.
+    /// What: `execute({path:"../.."})` must return an error.
+    /// Test: This test.
+    #[tokio::test]
+    async fn list_dir_path_traversal_is_rejected() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = ListDirTool::new(tmp.path());
+        let result = tool.execute(json!({"path": "../../etc"})).await;
+        assert!(result.is_error());
+        assert!(
+            result.content().contains("escapes"),
+            "unexpected message: {}",
+            result.content()
+        );
+    }
+
+    /// The schema declares `path` optional (empty `required` list).
+    ///
+    /// Why: `list_dir` must work with zero arguments (list the root).
+    /// What: Parses `schema()` and asserts `required` is empty.
+    /// Test: This test.
+    #[test]
+    fn schema_has_no_required_fields() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = ListDirTool::new(tmp.path());
+        let schema = tool.schema();
+        let required = schema["function"]["parameters"]["required"]
+            .as_array()
+            .expect("required array");
+        assert!(required.is_empty(), "list_dir must have no required fields");
+    }
+}

--- a/crates/trusty-code/src/tools/fs/mod.rs
+++ b/crates/trusty-code/src/tools/fs/mod.rs
@@ -5,24 +5,37 @@
 //! `ToolExecutor` implementations instead of raw shell-exec keeps error handling
 //! structured, scoping to a working directory enforced, and path traversal
 //! impossible.
-//! What: Three `ToolExecutor` impls — `ReadFileTool`, `WriteFileTool`, and
-//! `EditTool` — each with an OpenAI-function-call schema and registration helpers.
-//! `EditTool` (#2068) supports three edit wire formats — SEARCH/REPLACE,
-//! unified-diff, and whole-file — selected per-model via `edit_format`.
-//! Errors use `thiserror` for clean structured error types.
-//! Test: `read.rs`, `write.rs`, and `edit.rs` each carry tempdir-based unit
-//! tests; `edit_format` carries its own matrix/application tests;
-//! `registry_tests` verifies all three tools appear in `schemas()` and
-//! dispatch through `dispatch_gated`.
+//! What: `ToolExecutor` impls for the engineer's filesystem surface —
+//! `ReadFileTool`, `WriteFileTool`, `EditTool`, plus the batch-write and
+//! exploration tools `WriteFilesTool` (#2681), `GlobTool`, `GrepTool`, and
+//! `ListDirTool` (#1027) — each with an OpenAI-function-call schema and
+//! registration helpers. `EditTool` (#2068) supports three edit wire formats —
+//! SEARCH/REPLACE, unified-diff, and whole-file — selected per-model via
+//! `edit_format`. The exploration tools give the engineer native file discovery
+//! so it no longer shells out to `find`/`grep`/`ls` (the dominant bake-off
+//! agent-turn sink). Errors use `thiserror` for clean structured error types.
+//! Test: `read.rs`, `write.rs`, `write_files.rs`, `glob.rs`, `grep.rs`,
+//! `list_dir.rs`, and `edit.rs` each carry tempdir-based unit tests;
+//! `edit_format` carries its own matrix/application tests; `registry_tests`
+//! verifies the tools appear in `schemas()` and dispatch through
+//! `dispatch_gated`.
 
 pub mod edit;
 pub mod edit_format;
+pub mod glob;
+pub mod grep;
+pub mod list_dir;
 pub mod read;
 pub mod write;
+pub mod write_files;
 
 pub use edit::EditTool;
+pub use glob::GlobTool;
+pub use grep::GrepTool;
+pub use list_dir::ListDirTool;
 pub use read::ReadFileTool;
 pub use write::WriteFileTool;
+pub use write_files::{WRITE_FILES_TOOL_NAME, WriteFilesTool};
 
 use std::path::{Path, PathBuf};
 
@@ -44,6 +57,18 @@ pub enum FsError {
     /// The file or directory was not found.
     #[error("not found: {0}")]
     NotFound(PathBuf),
+
+    /// `list_dir` was pointed at a path that is not a directory.
+    #[error("not a directory: {0}")]
+    NotADirectory(PathBuf),
+
+    /// A `glob`/`grep` glob pattern failed to compile.
+    #[error("glob: invalid pattern '{pattern}': {reason}")]
+    GlobPattern { pattern: String, reason: String },
+
+    /// A `grep` regular expression failed to compile.
+    #[error("grep: invalid pattern '{pattern}': {reason}")]
+    GrepPattern { pattern: String, reason: String },
 
     /// The file exceeds the maximum allowed read size.
     #[error("file too large ({bytes} bytes, max {max} bytes): {path}")]

--- a/crates/trusty-code/src/tools/fs/write.rs
+++ b/crates/trusty-code/src/tools/fs/write.rs
@@ -77,7 +77,7 @@ impl ToolExecutor for WriteFileTool {
             "type": "function",
             "function": {
                 "name": "write_file",
-                "description": "Create or overwrite a SINGLE file with the provided content. Parent directories are created automatically. The path must be inside the working directory. If you need to create TWO OR MORE new files, do not call this repeatedly — use write_files instead, passing all of them in one call.",
+                "description": "Create or overwrite a file with the provided content. Parent directories are created automatically. The path must be inside the working directory.",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/crates/trusty-code/src/tools/fs/write.rs
+++ b/crates/trusty-code/src/tools/fs/write.rs
@@ -77,7 +77,7 @@ impl ToolExecutor for WriteFileTool {
             "type": "function",
             "function": {
                 "name": "write_file",
-                "description": "Create or overwrite a file with the provided content. Parent directories are created automatically. The path must be inside the working directory.",
+                "description": "Create or overwrite a SINGLE file with the provided content. Parent directories are created automatically. The path must be inside the working directory. If you need to create TWO OR MORE new files, do not call this repeatedly — use write_files instead, passing all of them in one call.",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/crates/trusty-code/src/tools/fs/write_files.rs
+++ b/crates/trusty-code/src/tools/fs/write_files.rs
@@ -87,7 +87,7 @@ impl ToolExecutor for WriteFilesTool {
             "type": "function",
             "function": {
                 "name": WRITE_FILES_TOOL_NAME,
-                "description": "Create or overwrite MULTIPLE files in a single call. Prefer this over several separate write_file calls when scaffolding independent files — it writes them all in one turn. Parent directories are created automatically. Each path must be inside the working directory.",
+                "description": "THE way to create two or more new files: pass every file's COMPLETE final content in ONE call and they are all written in a single turn. This is not a scaffolding or placeholder step — do not follow it with individual write_file calls to fill in or rewrite the same files; that costs as many turns as never using write_files. If you are about to emit two or more write_file calls in the same task, stop and use this tool instead with all of them included. Parent directories are created automatically. Each path must be inside the working directory.",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/crates/trusty-code/src/tools/fs/write_files.rs
+++ b/crates/trusty-code/src/tools/fs/write_files.rs
@@ -87,7 +87,7 @@ impl ToolExecutor for WriteFilesTool {
             "type": "function",
             "function": {
                 "name": WRITE_FILES_TOOL_NAME,
-                "description": "THE way to create two or more new files: pass every file's COMPLETE final content in ONE call and they are all written in a single turn. This is not a scaffolding or placeholder step — do not follow it with individual write_file calls to fill in or rewrite the same files; that costs as many turns as never using write_files. If you are about to emit two or more write_file calls in the same task, stop and use this tool instead with all of them included. Parent directories are created automatically. Each path must be inside the working directory.",
+                "description": "Create or overwrite MULTIPLE files in a single call. Prefer this over several separate write_file calls when scaffolding independent files — it writes them all in one turn. Parent directories are created automatically. Each path must be inside the working directory.",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/crates/trusty-code/src/tools/fs/write_files.rs
+++ b/crates/trusty-code/src/tools/fs/write_files.rs
@@ -1,0 +1,295 @@
+//! `write_files` tool — create or overwrite MANY files in a single call.
+//!
+//! Why: `write_file` is one-file-per-call, and on every bake-off run the file
+//! count equalled the write-turn count 1:1 — an 8-file scaffold cost 8 turns,
+//! the single biggest driver of tcode's high agent-turn count. PR #2666 lets the
+//! loop execute several tool calls per turn, but the model does not always batch;
+//! a dedicated `write_files` tool decouples turn-count from file-count
+//! STRUCTURALLY — one call writes N files regardless of whether the model
+//! batches. (#2681.)
+//! What: `WriteFilesTool` takes a `files` array of `{path, content}` objects,
+//! writes each (creating parent dirs) scoped to `working_dir`, and reports a
+//! per-file result. A failure on one file does not abort the others — every
+//! file's outcome is reported so the model can retry only what failed.
+//! Test: See `#[cfg(test)]` below — covers a multi-file write, partial failure,
+//! empty array, and path traversal.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::fs::{FsError, scoped_path};
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// Canonical name of the batch-write tool.
+///
+/// Why: Referenced by the registry wiring and by tests that assert the tool is
+/// registered; a shared constant avoids stringly-typed drift.
+/// What: The function name exposed to the LLM.
+/// Test: `crate::tools::fs_registry_tests` (batch-write registration).
+pub const WRITE_FILES_TOOL_NAME: &str = "write_files";
+
+/// `ToolExecutor` that creates or overwrites a batch of files in one call.
+///
+/// Why: Structurally decouples turn-count from file-count so an N-file scaffold
+/// is one turn, not N (the dominant bake-off turn sink).
+/// What: Implements `ToolExecutor` with `name = "write_files"`; scopes every
+/// write to `working_dir`; rejects traversal per-file without aborting siblings.
+/// Test: `cargo test -p trusty-code -- tools::fs::write_files`.
+pub struct WriteFilesTool {
+    working_dir: PathBuf,
+}
+
+impl WriteFilesTool {
+    /// Construct a new `WriteFilesTool` scoped to `working_dir`.
+    ///
+    /// Why: The working directory is the security boundary; set once at
+    /// construction so the LLM cannot widen it per-call.
+    /// What: Stores `working_dir`.
+    /// Test: `write_files_writes_all`, et al.
+    pub fn new(working_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            working_dir: working_dir.into(),
+        }
+    }
+
+    /// Write a single `{path, content}` entry, creating parent dirs as needed.
+    ///
+    /// Why: Reuses the same scoped-write contract as `WriteFileTool` so batch and
+    /// single writes behave identically per-file.
+    /// What: Scopes path, creates parent dirs, writes bytes.
+    /// Test: Exercised by all `WriteFilesTool` unit tests.
+    fn write_one(&self, path: &str, content: &str) -> Result<(), FsError> {
+        let scoped = scoped_path(&self.working_dir, std::path::Path::new(path))?;
+        if let Some(parent) = scoped.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| FsError::io(parent, e))?;
+        }
+        std::fs::write(&scoped, content).map_err(|e| FsError::io(&scoped, e))?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for WriteFilesTool {
+    fn name(&self) -> &str {
+        WRITE_FILES_TOOL_NAME
+    }
+
+    /// OpenAI function-call schema for `write_files`.
+    ///
+    /// Why: The LLM constructs its call from this schema; the `files` array
+    /// mirrors the `execute` contract exactly.
+    /// What: JSON object with a required `files` array of `{path, content}`.
+    /// Test: `schema_requires_files_array`.
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": WRITE_FILES_TOOL_NAME,
+                "description": "Create or overwrite MULTIPLE files in a single call. Prefer this over several separate write_file calls when scaffolding independent files — it writes them all in one turn. Parent directories are created automatically. Each path must be inside the working directory.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "type": "array",
+                            "description": "The files to write. Each element is an object with a path and its full content.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Relative or absolute path (must be inside the working directory)."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "description": "Full text content to write to the file."
+                                    }
+                                },
+                                "required": ["path", "content"],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": ["files"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    /// Execute a `write_files` tool call.
+    ///
+    /// Why: Writes every file in the batch, reporting each outcome so a single
+    /// bad entry does not lose the successful writes.
+    /// What: Parses `{files:[{path, content}, …]}`, writes each, and returns a
+    /// per-file summary. Returns an error only when `files` is missing/not an
+    /// array, or when EVERY write failed.
+    /// Test: `write_files_writes_all`, `write_files_partial_failure`.
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(files) = args.get("files").and_then(Value::as_array) else {
+            return ToolResult::err("write_files: missing required argument 'files' (an array)");
+        };
+        if files.is_empty() {
+            return ToolResult::err("write_files: 'files' array is empty — nothing to write");
+        }
+
+        let mut lines = Vec::with_capacity(files.len());
+        let mut ok_count = 0usize;
+        for (i, entry) in files.iter().enumerate() {
+            let path = entry.get("path").and_then(Value::as_str);
+            let content = entry.get("content").and_then(Value::as_str);
+            match (path, content) {
+                (Some(p), Some(c)) => match self.write_one(p, c) {
+                    Ok(()) => {
+                        ok_count += 1;
+                        lines.push(format!("wrote {p}"));
+                    }
+                    Err(e) => lines.push(format!("FAILED {p}: {e}")),
+                },
+                _ => lines.push(format!(
+                    "FAILED entry {i}: each element needs both 'path' and 'content'"
+                )),
+            }
+        }
+
+        let summary = lines.join("\n");
+        if ok_count == 0 {
+            // Every write failed — surface as a recoverable error so the model
+            // retries rather than treating the batch as done.
+            ToolResult::err(summary)
+        } else {
+            ToolResult::ok(format!(
+                "{summary}\n({ok_count}/{} files written)",
+                files.len()
+            ))
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::tools::traits::ToolExecutor;
+
+    /// `write_files` writes every file in the batch in a single call.
+    ///
+    /// Why: This is the structural turn-count/file-count decoupling — one call,
+    /// N files (#2681).
+    /// What: Writes three files (one nested), asserts all three land on disk with
+    /// the right content and the summary reports 3/3.
+    /// Test: This test.
+    #[tokio::test]
+    async fn write_files_writes_all() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = WriteFilesTool::new(tmp.path());
+        let result = tool
+            .execute(json!({
+                "files": [
+                    {"path": "a.py", "content": "# a"},
+                    {"path": "pkg/b.py", "content": "# b"},
+                    {"path": "src/main.rs", "content": "fn main() {}"}
+                ]
+            }))
+            .await;
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        assert_eq!(fs::read_to_string(tmp.path().join("a.py")).unwrap(), "# a");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("pkg/b.py")).unwrap(),
+            "# b"
+        );
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("src/main.rs")).unwrap(),
+            "fn main() {}"
+        );
+        assert!(result.content().contains("3/3"), "{}", result.content());
+    }
+
+    /// A single bad entry does not abort the successful writes.
+    ///
+    /// Why: Partial failure must preserve the good writes and report the bad one,
+    /// mirroring the batched-tool-dispatch contract.
+    /// What: Batches a valid file and a traversal-escaping file; asserts the valid
+    /// one is written and the summary flags the failure.
+    /// Test: This test.
+    #[tokio::test]
+    async fn write_files_partial_failure() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = WriteFilesTool::new(tmp.path());
+        let result = tool
+            .execute(json!({
+                "files": [
+                    {"path": "good.py", "content": "ok"},
+                    {"path": "../../evil.sh", "content": "harm"}
+                ]
+            }))
+            .await;
+        // At least one succeeded → overall success with a per-file summary.
+        assert!(!result.is_error(), "{}", result.content());
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("good.py")).unwrap(),
+            "ok"
+        );
+        assert!(result.content().contains("wrote good.py"));
+        assert!(
+            result.content().contains("FAILED"),
+            "must flag the failed entry: {}",
+            result.content()
+        );
+    }
+
+    /// An entirely-failing batch surfaces as an error.
+    ///
+    /// Why: If nothing was written, the model must retry, not treat it as done.
+    /// What: Batches a single traversal-escaping file; asserts an error result.
+    /// Test: This test.
+    #[tokio::test]
+    async fn write_files_all_fail_is_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = WriteFilesTool::new(tmp.path());
+        let result = tool
+            .execute(json!({"files": [{"path": "../../evil.sh", "content": "x"}]}))
+            .await;
+        assert!(result.is_error());
+        assert!(result.content().contains("FAILED"));
+    }
+
+    /// An empty `files` array is a recoverable error.
+    ///
+    /// Why: Nothing to write is a caller mistake worth surfacing.
+    /// What: `execute({files: []})` returns an error.
+    /// Test: This test.
+    #[tokio::test]
+    async fn write_files_empty_array_errors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = WriteFilesTool::new(tmp.path());
+        let result = tool.execute(json!({"files": []})).await;
+        assert!(result.is_error());
+        assert!(result.content().contains("empty"));
+    }
+
+    /// The schema requires the `files` array.
+    ///
+    /// Why: The LLM must always provide the batch.
+    /// What: Parses `schema()` and checks `required` contains "files".
+    /// Test: This test.
+    #[test]
+    fn schema_requires_files_array() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = WriteFilesTool::new(tmp.path());
+        let schema = tool.schema();
+        let required = schema["function"]["parameters"]["required"]
+            .as_array()
+            .expect("required array");
+        assert!(
+            required.iter().any(|v| v.as_str() == Some("files")),
+            "schema must list 'files' as required"
+        );
+    }
+}

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -41,7 +41,10 @@ pub use delegate::DelegateToAgentTool;
 pub use finish_task::{
     FINISH_TASK_TOOL_NAME, FinishTaskArgs, FinishTaskTool, render_finish_summary,
 };
-pub use fs::{EditTool, ReadFileTool, WriteFileTool};
+pub use fs::{
+    EditTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, WRITE_FILES_TOOL_NAME, WriteFileTool,
+    WriteFilesTool,
+};
 pub use goals::{CLEAR_GOAL_TOOL_NAME, ClearGoalTool, SET_GOAL_TOOL_NAME, SetGoalTool};
 pub use recall_session::{RECALL_SESSION_TOOL_NAME, RecallSessionTool};
 pub use registry::ToolRegistry;


### PR DESCRIPTION
Two token-efficiency levers in **trusty-code** targeting tcode's high agent-turn count on the L1 bake-off. Root cause: the engineer has no discovery tools (so `bash` was 53-71% of every turn) and `write_file` is one-file-per-call (file-count == write-turn-count 1:1, so an 8-file solution costs 8 turns).

## Lever 1 — native exploration tools (Closes #1027)
The engineer's registry had only 5 tools (read_file, write_file, edit, bash, finish_task) with no file discovery. Adds three native `ToolExecutor`s, mirroring the existing `tools/fs/` pattern (working-dir scoped, traversal-guarded, structured errors):

- **`glob`** — find files by glob pattern (`**/*.py`, `src/*.rs`); returns matching project-relative paths.
- **`grep`** — search contents by regex; returns `path:line: text` hits, with an optional `glob` file filter.
- **`list_dir`** — non-recursive directory listing (dirs suffixed `/`).

All three use ripgrep's `ignore` walker (gitignore-aware, skips hidden files), `globset` for pattern matching, and the already-present `regex` for content matching. Results are truncation-bounded to protect the context window. Wired into both `ProjectToolFactory` registries (`run_task/mod.rs` and `task/executor.rs`).

## Lever 2 — batch file writes (Closes #2681)
Belt-and-suspenders to decouple turn-count from file-count:
1. **`write_files`** batch tool — takes an array of `{path, content}` and writes them all in one call; partial failures are reported per-file without aborting siblings.
2. **Preamble nudge** — instructs the model to batch independent `write_file` calls into a single turn (now supported by #2666) or use `write_files`, and to prefer glob/grep/list_dir over bash for discovery.

`BASE_PREAMBLE_VERSION` 1.5.0 → **1.6.0**; preamble-hash tripwire refreshed.

I added the dedicated `write_files` tool (not just the prompt nudge) because run-8 showed the model sometimes doesn't batch at all — a structural one-call-N-files tool guarantees the decoupling regardless of model behavior.

## Tests
- Unit tests for each new executor (match/search/list, scoping, no-match, traversal, bad-pattern, truncation).
- `agent_loop` ScriptedLlm tests proving a single turn writes N files, via both N `write_file` calls and one `write_files` call.

## Quality gate (all green from the worktree)
- `cargo build -p trusty-code` ✅
- `cargo test -p trusty-code` — 900 lib + integration tests pass, 0 failed ✅
- `cargo clippy -p trusty-code --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- `bash scripts/check_line_cap.sh` — 0 violations ✅

Cargo.lock churn is minimal: `globset` and `ignore` were already transitively in the lockfile, so this only adds them to trusty-code's dep list (no new package versions).

**Do NOT merge yet** — validate the turn drop via the bake-off first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)