### PR TITLE
feat(trusty-code): trusty-search-backed code discovery tool (DailyDriver)

### DIFF
--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -81,7 +81,11 @@ globset = { workspace = true }
 # (env > .env.local > secure store), and the capability registry. It composes
 # with `axum-server` to expose `inference::test_support::MockInferenceServer`
 # for the offline black-box e2e in `tests/inference_shared_adapter_e2e.rs`.
-trusty-common = { workspace = true, features = ["catchup", "mcp", "axum-server", "inference-client", "config-cli", "bedrock-client"] }
+# `stdio-mcp-client` provides the shared `StdioMcpClient` (spawn an MCP binary,
+# run the JSON-RPC-over-stdio handshake, call tools) the trusty-search-backed
+# code-discovery tool reuses instead of writing its own MCP transport
+# (common-entry-point principle) — mirrors trusty-agents' TrustySearchPlugin.
+trusty-common = { workspace = true, features = ["catchup", "mcp", "stdio-mcp-client", "axum-server", "inference-client", "config-cli", "bedrock-client"] }
 
 # `tcode serve --http`: POST /rpc + GET /health over axum (#2053). Per
 # CLAUDE.md, axum stays feature-gated in *library* crates

--- a/crates/trusty-code/src/prompt/assembler.rs
+++ b/crates/trusty-code/src/prompt/assembler.rs
@@ -25,6 +25,31 @@ use crate::prompt::preamble::BASE_PREAMBLE;
 /// on this exact value.
 const SECTION_SEPARATOR: &str = "\n\n---\n\n";
 
+/// DailyDriver-only discovery guidance (PR A, #2689) appended as a trailing
+/// section, mirroring the `skills_catalog` pattern.
+///
+/// Why: the engineer gains a trusty-search-backed `search_code` tool in
+/// DailyDriver mode; without steering, models default to shelling out or to the
+/// literal `grep`/`glob` tools even for conceptual questions. This section
+/// tells the model when to reach for semantic/call-graph discovery vs. exact
+/// literal search, and to fall back silently when trusty-search is unavailable.
+/// It is intentionally NOT in [`BASE_PREAMBLE`]: the parity spec forbids
+/// MCP/tool catalogs there, so the preamble hash must not change. Parity mode
+/// never appends it.
+/// What: a static Markdown section joined with [`SECTION_SEPARATOR`] in the
+/// `DailyDriver` arm of [`assemble_system_prompt_for_mode`].
+/// Test: `prompt::tests::daily_driver_appends_discovery_guidance`,
+/// `prompt::tests::parity_omits_discovery_guidance`.
+pub const DISCOVERY_GUIDANCE: &str = "## Code discovery\n\n\
+Prefer the `search_code` tool for CONCEPTUAL discovery — \"where is X\", \"how \
+does Y work\", \"what calls Z\", \"find the code that does <behaviour>\". It is \
+backed by trusty-search (semantic + call-graph indexing) and finds code by \
+meaning, not just literal text.\n\n\
+Use the local `grep` and `glob` tools when you already know the exact text — a \
+specific symbol name, a literal string, or a filename/path glob.\n\n\
+If `search_code` reports that trusty-search is unavailable, silently fall back \
+to `grep`/`glob` for the same query — do not retry `search_code`.";
+
 /// Assembles the parity system prompt from its constituent sections.
 ///
 /// Why: A named type gives call sites (the agent loop, the parity report) a
@@ -114,16 +139,17 @@ pub fn assemble_system_prompt(
 /// since parity-spec D2 requires byte-identical schemas/prompts for
 /// benchmark fairness and must never progressively disclose (#2069's own
 /// scope note: "Parity mode should NOT progressively disclose").
-/// `HarnessMode::DailyDriver` appends `skills_catalog` (the cheap,
-/// always-cached `skills::format_skill_catalog` output — NOT any skill's
-/// full body) as a trailing section when non-empty, via the same
-/// [`SECTION_SEPARATOR`] every other section uses; when `skills_catalog` is
-/// `None` or empty, `DailyDriver` output is still byte-identical to
-/// `Parity`, preserving the pre-#2069 M1 contract for projects with no
-/// `.claude/skills/` catalog.
-/// Test: `prompt::tests::assemble_system_prompt_for_mode_identical_when_no_skills`,
+/// `HarnessMode::DailyDriver` appends two trailing sections via the same
+/// [`SECTION_SEPARATOR`] every other section uses: (1) [`DISCOVERY_GUIDANCE`]
+/// (PR A, #2689) — always present, steering the model to the `search_code`
+/// tool for conceptual discovery; then (2) `skills_catalog` (the cheap,
+/// always-cached `skills::format_skill_catalog` output — NOT any skill's full
+/// body) when non-empty. `Parity` appends neither, keeping its schema/prompt
+/// byte-identical for benchmark fairness.
+/// Test: `prompt::tests::daily_driver_appends_discovery_guidance`,
 /// `prompt::tests::daily_driver_appends_skills_catalog`,
-/// `prompt::tests::parity_ignores_skills_catalog`.
+/// `prompt::tests::parity_ignores_skills_catalog`,
+/// `prompt::tests::parity_omits_discovery_guidance`.
 pub fn assemble_system_prompt_for_mode(
     mode: crate::mode::HarnessMode,
     config: &AgentConfig,
@@ -135,10 +161,14 @@ pub fn assemble_system_prompt_for_mode(
     match mode {
         crate::mode::HarnessMode::Parity => base,
         crate::mode::HarnessMode::DailyDriver => {
-            match skills_catalog.map(str::trim).filter(|s| !s.is_empty()) {
-                Some(catalog) => format!("{base}{SECTION_SEPARATOR}{catalog}"),
-                None => base,
+            // Discovery guidance (PR A) is always present in DailyDriver; the
+            // skills catalog is appended after it only when non-empty.
+            let mut out = format!("{base}{SECTION_SEPARATOR}{DISCOVERY_GUIDANCE}");
+            if let Some(catalog) = skills_catalog.map(str::trim).filter(|s| !s.is_empty()) {
+                out.push_str(SECTION_SEPARATOR);
+                out.push_str(catalog);
             }
+            out
         }
     }
 }

--- a/crates/trusty-code/src/prompt/mod.rs
+++ b/crates/trusty-code/src/prompt/mod.rs
@@ -19,6 +19,8 @@ mod assembler;
 mod preamble;
 mod version;
 
-pub use assembler::{PromptAssembler, assemble_system_prompt, assemble_system_prompt_for_mode};
+pub use assembler::{
+    DISCOVERY_GUIDANCE, PromptAssembler, assemble_system_prompt, assemble_system_prompt_for_mode,
+};
 pub use preamble::BASE_PREAMBLE;
 pub use version::BASE_PREAMBLE_VERSION;

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -11,8 +11,8 @@
 use crate::agents::AgentConfig;
 use crate::mode::HarnessMode;
 use crate::prompt::{
-    BASE_PREAMBLE, BASE_PREAMBLE_VERSION, PromptAssembler, assemble_system_prompt,
-    assemble_system_prompt_for_mode,
+    BASE_PREAMBLE, BASE_PREAMBLE_VERSION, DISCOVERY_GUIDANCE, PromptAssembler,
+    assemble_system_prompt, assemble_system_prompt_for_mode,
 };
 
 /// Build an `AgentConfig` whose `system_prompt.content` is the given string.
@@ -417,23 +417,90 @@ fn all_sections_present_when_supplied() {
 /// Why: pins the "byte-identical when there is nothing to progressively
 /// disclose" contract so a future change to the `DailyDriver` arm cannot
 /// silently regress projects with no skills.
-/// What: asserts `assemble_system_prompt_for_mode` with `skills_catalog:
-/// None` returns the exact same string as `assemble_system_prompt` for both
-/// `HarnessMode` variants.
+/// What: asserts `Parity` with `skills_catalog: None` returns the exact same
+/// string as `assemble_system_prompt`, and `DailyDriver` differs only by the
+/// always-present [`DISCOVERY_GUIDANCE`] trailing section (PR A, #2689).
 /// Test: this test.
 #[test]
 fn assemble_system_prompt_for_mode_identical_when_no_skills() {
     let cfg = config_with_prompt("AGENT");
     let baseline = assemble_system_prompt(&cfg, Some("PROJECT"), Some("FALLBACK"));
 
-    for mode in [HarnessMode::DailyDriver, HarnessMode::Parity] {
-        let via_mode =
-            assemble_system_prompt_for_mode(mode, &cfg, Some("PROJECT"), Some("FALLBACK"), None);
-        assert_eq!(
-            via_mode, baseline,
-            "mode {mode:?} must match baseline when there is no skills catalog"
-        );
-    }
+    let parity = assemble_system_prompt_for_mode(
+        HarnessMode::Parity,
+        &cfg,
+        Some("PROJECT"),
+        Some("FALLBACK"),
+        None,
+    );
+    assert_eq!(parity, baseline, "Parity must match baseline byte-for-byte");
+
+    let daily = assemble_system_prompt_for_mode(
+        HarnessMode::DailyDriver,
+        &cfg,
+        Some("PROJECT"),
+        Some("FALLBACK"),
+        None,
+    );
+    assert_eq!(
+        daily,
+        format!("{baseline}\n\n---\n\n{DISCOVERY_GUIDANCE}"),
+        "DailyDriver with no skills = baseline + discovery guidance"
+    );
+}
+
+/// `HarnessMode::DailyDriver` always appends [`DISCOVERY_GUIDANCE`] as a
+/// trailing section, before any skills catalog (PR A, #2689).
+///
+/// Why: the engineer's `search_code` tool needs the model steered toward it;
+/// the guidance is static (not project-dependent) so it is always present in
+/// DailyDriver.
+/// What: asserts the guidance appears after FALLBACK and, when a catalog is
+/// present, before the catalog.
+/// Test: this test.
+#[test]
+fn daily_driver_appends_discovery_guidance() {
+    let cfg = config_with_prompt("AGENT");
+    let catalog = "Available skills:\n- demo-skill: Does demo things";
+    let out = assemble_system_prompt_for_mode(
+        HarnessMode::DailyDriver,
+        &cfg,
+        Some("PROJECT"),
+        Some("FALLBACK"),
+        Some(catalog),
+    );
+    assert!(out.contains(DISCOVERY_GUIDANCE));
+    assert!(out.contains("search_code"));
+    let guidance_at = out.find("## Code discovery").expect("guidance present");
+    assert!(
+        out.find("FALLBACK").unwrap() < guidance_at,
+        "guidance after fallback"
+    );
+    assert!(
+        guidance_at < out.find(catalog).unwrap(),
+        "guidance before catalog"
+    );
+}
+
+/// `HarnessMode::Parity` never appends the discovery guidance — the parity
+/// spec forbids MCP/tool catalogs in the shared prompt.
+///
+/// Why: benchmark fairness (D2) requires a byte-identical prompt across models.
+/// What: asserts Parity output equals the plain baseline and omits the guidance.
+/// Test: this test.
+#[test]
+fn parity_omits_discovery_guidance() {
+    let cfg = config_with_prompt("AGENT");
+    let baseline = assemble_system_prompt(&cfg, Some("PROJECT"), Some("FALLBACK"));
+    let out = assemble_system_prompt_for_mode(
+        HarnessMode::Parity,
+        &cfg,
+        Some("PROJECT"),
+        Some("FALLBACK"),
+        Some("Available skills:\n- demo"),
+    );
+    assert_eq!(out, baseline);
+    assert!(!out.contains("## Code discovery"));
 }
 
 /// `HarnessMode::DailyDriver` appends a non-empty skills catalog as a

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -39,7 +39,8 @@ use crate::provider::{
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
 use crate::tools::{
     AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, FinishTaskTool, GlobTool,
-    GrepTool, ListDirTool, ReadFileTool, RunContext, ToolRegistry, WriteFileTool, WriteFilesTool,
+    GrepTool, ListDirTool, ReadFileTool, RunContext, ToolRegistry, TrustySearchTool, WriteFileTool,
+    WriteFilesTool,
 };
 
 pub use recorder::{RecordingLlmClient, SharedTranscript, TurnRecord};
@@ -347,6 +348,12 @@ impl RegistryFactory for ProjectToolFactory {
         reg.register(Arc::new(GlobTool::new(&self.project)));
         reg.register(Arc::new(GrepTool::new(&self.project)));
         reg.register(Arc::new(ListDirTool::new(&self.project)));
+        // PR A (#2689): trusty-search-backed conceptual discovery as the PRIMARY
+        // path; the local glob/grep tools above are the fail-open FALLBACK. The
+        // `run_task` CLI is always the daily-driver path (the parity benchmark
+        // runs through `task::executor`, which gates this on `HarnessMode`), so
+        // registration is unconditional here.
+        reg.register(Arc::new(TrustySearchTool::new(&self.project)));
         reg.register(Arc::new(BashTool::new(
             Some(self.project.clone()),
             Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -58,7 +58,8 @@ use crate::skills::{FsSkillResolver, format_skill_catalog, locate_skills_dir};
 use crate::tools::{
     AgentOutput, AgentRunner, BashTool, ClearGoalTool, DelegateToAgentTool, EditTool,
     FinishTaskTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, RecallSessionTool, RunContext,
-    SetGoalTool, SkillResolver, ToolRegistry, UseSkillTool, WriteFileTool, WriteFilesTool,
+    SetGoalTool, SkillResolver, ToolRegistry, TrustySearchTool, UseSkillTool, WriteFileTool,
+    WriteFilesTool,
 };
 
 use super::sink::SessionToolEventSink;
@@ -508,6 +509,14 @@ impl RegistryFactory for ProjectToolFactory {
         reg.register(Arc::new(GlobTool::new(&self.project)));
         reg.register(Arc::new(GrepTool::new(&self.project)));
         reg.register(Arc::new(ListDirTool::new(&self.project)));
+        // PR A (#2689): trusty-search-backed conceptual discovery as the PRIMARY
+        // path, with the local glob/grep tools above as the fail-open FALLBACK.
+        // DailyDriver ONLY — Parity must keep a byte-identical tool surface for
+        // benchmark fairness (it never sees MCP-backed tools), so this is gated
+        // on the delegating run's resolved `HarnessMode`.
+        if self.mode == HarnessMode::DailyDriver {
+            reg.register(Arc::new(TrustySearchTool::new(&self.project)));
+        }
         reg.register(Arc::new(BashTool::new(
             Some(self.project.clone()),
             Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -32,6 +32,7 @@ pub mod recall_session;
 pub mod registry;
 pub mod skill;
 pub mod traits;
+pub mod trusty_search;
 
 // Flat re-exports for `crate::tools::*` convenience.
 #[allow(unused_imports)]
@@ -53,6 +54,7 @@ pub use traits::{
     AgentOutput, AgentRunner, HistoryMessage, RunContext, SearchProvider, SearchResult,
     ServiceTier, SkillResolver, ToolExecutor, ToolResult,
 };
+pub use trusty_search::{SEARCH_CODE_TOOL_NAME, TrustySearchTool};
 
 // ── Registry integration tests for the FS tools ──────────────────────────────
 

--- a/crates/trusty-code/src/tools/trusty_search.rs
+++ b/crates/trusty-code/src/tools/trusty_search.rs
@@ -1,0 +1,408 @@
+//! `search_code` tool: trusty-search-backed code discovery (PR A).
+//!
+//! Why: local `glob`/`grep`/`list_dir` (#2685) find code by literal text only;
+//! the engineer routinely needs CONCEPTUAL discovery — "where is X", "how does
+//! Y work", "what calls Z" — which literal search cannot answer. trusty-search
+//! already indexes every registered project for semantic (embedding) and
+//! call-graph (KG) retrieval and ships as an MCP binary. This tool makes that
+//! the PRIMARY discovery path for the engineer while the local literal tools
+//! stay as the graceful-degrade FALLBACK: when trusty-search is not installed,
+//! not running, or its index is not ready, the tool returns a SUCCESSFUL
+//! "unavailable — use grep/glob" result rather than an error that would derail
+//! the agent loop (mirrors `recall_session`'s fail-open contract).
+//! What: [`TrustySearchTool`] implements `ToolExecutor`. It lazily spawns
+//! `trusty-search serve` via the SHARED `trusty_common::stdio_mcp_client`
+//! (never a bespoke MCP/HTTP client — common-entry-point principle, mirroring
+//! trusty-agents' `TrustySearchPlugin`), runs the MCP handshake, and resolves
+//! the project's index id from `list_indexes`. A single `search_code` tool with
+//! a `mode` param routes to trusty-search's real lanes: `semantic`
+//! (`search_semantic`), `symbol` (`search_kg`), and `grep` (`grep`). One tool
+//! keeps the advertised schema surface minimal and mirrors trusty-search's own
+//! lane taxonomy. Any spawn/handshake/timeout/`STAGE_NOT_READY`/missing-index
+//! condition is fail-open: a non-error `ToolResult` telling the model to use
+//! the local `grep`/`glob` tools instead.
+//! Test: `tests::pick_index_prefers_exact_match`,
+//! `tests::pick_index_falls_back_to_longest_ancestor`,
+//! `tests::execute_fail_open_when_binary_absent`,
+//! `tests::execute_rejects_malformed_args_recoverably`,
+//! `tests::schema_advertises_mode_and_query`, `tests::mcp_text_extracts_content`,
+//! `tests::is_mcp_error_detects_error_flag`.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::sync::{Mutex, OnceCell};
+use tracing::warn;
+use trusty_common::stdio_mcp_client::StdioMcpClient;
+
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// The tool's registered/advertised name.
+pub const SEARCH_CODE_TOOL_NAME: &str = "search_code";
+
+/// Binary spawned in MCP stdio mode (`trusty-search serve`).
+const SEARCH_BINARY: &str = "trusty-search";
+
+/// `clientInfo.name` advertised during the MCP handshake.
+const CLIENT_NAME: &str = "trusty-code";
+
+/// Default `top_k` when the model omits it.
+const DEFAULT_TOP_K: usize = 10;
+
+/// Hard cap on `top_k` regardless of what the model requests.
+const MAX_TOP_K: usize = 25;
+
+/// The fail-open message steering the model back to the local literal tools.
+const FALLBACK_HINT: &str =
+    "trusty-search is unavailable; use the local `grep` and `glob` tools for this query instead.";
+
+/// Parsed `search_code` tool-call arguments.
+#[derive(Debug, Deserialize)]
+struct SearchArgs {
+    query: String,
+    #[serde(default)]
+    mode: Option<String>,
+    #[serde(default)]
+    top_k: Option<usize>,
+}
+
+/// A live trusty-search MCP session plus the resolved project index.
+///
+/// Why: MCP requests are not concurrency-safe (one in-flight request per stdio
+/// pair), so the client sits behind an async `Mutex`. `index_id` is resolved
+/// once at spawn from `list_indexes` because the semantic/KG lanes require it.
+/// What: `index_id` is `None` when no registered index covers the project root
+/// — the search lanes then fail open rather than guess a wrong index.
+/// Test: exercised via `execute_*` and `pick_index_*` in `tests`.
+struct SearchSession {
+    client: Mutex<StdioMcpClient>,
+    index_id: Option<String>,
+}
+
+/// `ToolExecutor` for the `search_code` discovery tool (PR A).
+///
+/// Why: gives the engineer a semantic/call-graph discovery path backed by
+/// trusty-search, scoped to the delegating run's project root.
+/// What: holds the project root (for index resolution + scoping) and lazily
+/// initialises one [`SearchSession`] on first use, caching the (possibly
+/// absent) session in a `OnceCell` so a missing/unreachable daemon is probed at
+/// most once per tool instance.
+/// Test: `tests::execute_fail_open_when_binary_absent`.
+pub struct TrustySearchTool {
+    project: PathBuf,
+    binary: String,
+    session: OnceCell<Option<SearchSession>>,
+}
+
+impl TrustySearchTool {
+    /// Construct a tool scoped to `project`, spawning the real `trusty-search`.
+    ///
+    /// Why: the engineer's registry builds one per delegation, scoped to the
+    /// project working tree.
+    /// What: defers all process spawning to first `execute` — construction is
+    /// cheap and side-effect-free.
+    /// Test: `tests::schema_advertises_mode_and_query`.
+    pub fn new(project: impl Into<PathBuf>) -> Self {
+        Self {
+            project: project.into(),
+            binary: SEARCH_BINARY.to_string(),
+            session: OnceCell::new(),
+        }
+    }
+
+    /// Override the spawned binary name (tests point this at a name that is
+    /// guaranteed absent to exercise the fail-open path deterministically).
+    ///
+    /// Why: the daemon-absent path must be unit-testable without depending on
+    /// whether `trusty-search` happens to be on the dev machine's PATH.
+    /// What: replaces the binary the lazy spawn invokes.
+    /// Test: `tests::execute_fail_open_when_binary_absent`.
+    #[cfg(test)]
+    pub fn with_binary(mut self, binary: impl Into<String>) -> Self {
+        self.binary = binary.into();
+        self
+    }
+
+    /// Lazily spawn + handshake + resolve the index, caching the result.
+    ///
+    /// Why: probing a missing/broken daemon on every call would add per-turn
+    /// latency; caching the `Option` probes at most once.
+    /// What: returns `&None` when spawn or handshake fails (fail-open).
+    /// Test: `tests::execute_fail_open_when_binary_absent`.
+    async fn session(&self) -> &Option<SearchSession> {
+        self.session
+            .get_or_init(|| spawn_session(&self.binary, &self.project))
+            .await
+    }
+}
+
+/// Spawn `trusty-search serve`, run the handshake, and resolve the index id.
+///
+/// Why: isolates the fallible startup so `session` stays a thin cache and the
+/// whole flow degrades to `None` on the first failure.
+/// What: returns `None` if the binary is absent, the handshake fails, or the
+/// process cannot start; otherwise a [`SearchSession`] whose `index_id` may
+/// still be `None` when no index covers the project.
+/// Test: covered opportunistically — a missing binary yields `None`, asserted
+/// via `tests::execute_fail_open_when_binary_absent`.
+async fn spawn_session(binary: &str, project: &Path) -> Option<SearchSession> {
+    let mut client = match StdioMcpClient::spawn(binary, &["serve"], CLIENT_NAME).await {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, "search_code: trusty-search spawn failed (fail-open)");
+            return None;
+        }
+    };
+    if let Err(e) = client.initialize().await {
+        warn!(error = %e, "search_code: trusty-search handshake failed (fail-open)");
+        return None;
+    }
+    let index_id = resolve_index_id(&mut client, project).await;
+    Some(SearchSession {
+        client: Mutex::new(client),
+        index_id,
+    })
+}
+
+/// Resolve the project's index id from `list_indexes`.
+///
+/// Why: the semantic/KG lanes require an `index_id`; deriving it from the
+/// project root avoids making the model call `list_indexes` and guess.
+/// What: calls the `list_indexes` MCP tool, parses the `{ "indexes": [...] }`
+/// detail payload, and matches the project root against each index `root_path`
+/// via [`pick_index`]. Returns `None` on any RPC/parse failure or no match.
+/// Test: `tests::pick_index_prefers_exact_match`.
+async fn resolve_index_id(client: &mut StdioMcpClient, project: &Path) -> Option<String> {
+    let result = client.call_tool("list_indexes", json!({})).await.ok()?;
+    let text = mcp_text(&result)?;
+    let body: Value = serde_json::from_str(&text).ok()?;
+    let indexes = body.get("indexes")?.as_array()?;
+    pick_index(indexes, project)
+}
+
+/// Pick the index whose `root_path` best covers `project`.
+///
+/// Why: a worktree/subdirectory of a registered repo should resolve to that
+/// repo's index even when the paths are not byte-identical.
+/// What: prefers an exact canonical match; otherwise the registered index whose
+/// canonical `root_path` is the longest ancestor of `project`. `None` when no
+/// index covers the project.
+/// Test: `tests::pick_index_prefers_exact_match`,
+/// `tests::pick_index_falls_back_to_longest_ancestor`.
+fn pick_index(indexes: &[Value], project: &Path) -> Option<String> {
+    let target = canonicalize_best_effort(project);
+    let mut best: Option<(usize, String)> = None;
+    for entry in indexes {
+        let Some(id) = entry.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(root) = entry.get("root_path").and_then(Value::as_str) else {
+            continue;
+        };
+        let root = canonicalize_best_effort(Path::new(root));
+        if root == target {
+            return Some(id.to_string());
+        }
+        if target.starts_with(&root) {
+            let depth = root.components().count();
+            if best.as_ref().is_none_or(|(d, _)| depth > *d) {
+                best = Some((depth, id.to_string()));
+            }
+        }
+    }
+    best.map(|(_, id)| id)
+}
+
+/// Canonicalise `p`, falling back to the path as given when it does not exist.
+///
+/// Why: index roots and the project path may be symlinked (worktrees under
+/// `$HOME`); canonicalising both makes ancestor comparison robust.
+/// What: `std::fs::canonicalize` with a lossless fallback.
+/// Test: exercised via `pick_index_*`.
+fn canonicalize_best_effort(p: &Path) -> PathBuf {
+    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Extract the first text frame from an MCP `tools/call` result.
+///
+/// Why: trusty-search wraps every payload as `content[0].text` (a JSON string).
+/// What: returns that string, or `None` when the frame is missing.
+/// Test: `tests::mcp_text_extracts_content`.
+fn mcp_text(result: &Value) -> Option<String> {
+    result
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|items| items.first())
+        .and_then(|item| item.get("text"))
+        .and_then(|t| t.as_str())
+        .map(str::to_string)
+}
+
+/// Whether an MCP result carries the in-band `isError` flag (e.g.
+/// `STAGE_NOT_READY` when the semantic/KG lane is not yet built).
+///
+/// Why: trusty-search reports stage-not-ready as `isError: true` content rather
+/// than a JSON-RPC error, so `call_tool` returns `Ok`; we must inspect the flag
+/// to fail open.
+/// What: `true` when `result.isError == true`.
+/// Test: `tests::is_mcp_error_detects_error_flag`.
+fn is_mcp_error(result: &Value) -> bool {
+    result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Build the MCP arguments for `mode`, returning the tool name + params.
+///
+/// Why: keeps `execute` linear — each mode maps to one trusty-search lane with
+/// its own argument shape (`grep` takes `pattern`/`max_results` and an optional
+/// `index_id`; the semantic/KG lanes take `index_id`/`query`/`top_k`).
+/// What: returns `Err` with a fail-open message when a semantic/KG lane is
+/// requested but no index covers the project.
+/// Test: `tests::execute_fail_open_when_binary_absent` (mode routing is covered
+/// end-to-end where a live daemon is available).
+fn build_call(
+    mode: &str,
+    query: &str,
+    top_k: usize,
+    index_id: Option<&str>,
+) -> Result<(&'static str, Value), String> {
+    match mode {
+        "grep" => {
+            let mut params = json!({ "pattern": query, "max_results": top_k });
+            if let Some(id) = index_id {
+                params["index_id"] = json!(id);
+            }
+            Ok(("grep", params))
+        }
+        "symbol" => {
+            let id = index_id.ok_or_else(|| {
+                format!("no trusty-search index covers this project. {FALLBACK_HINT}")
+            })?;
+            Ok((
+                "search_kg",
+                json!({ "index_id": id, "query": query, "top_k": top_k }),
+            ))
+        }
+        // Default and "semantic".
+        _ => {
+            let id = index_id.ok_or_else(|| {
+                format!("no trusty-search index covers this project. {FALLBACK_HINT}")
+            })?;
+            Ok((
+                "search_semantic",
+                json!({ "index_id": id, "query": query, "top_k": top_k }),
+            ))
+        }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for TrustySearchTool {
+    fn name(&self) -> &str {
+        SEARCH_CODE_TOOL_NAME
+    }
+
+    /// JSON schema for `search_code`.
+    ///
+    /// Why: the description is a first-class LLM prompt — it tells the model to
+    /// prefer this tool for conceptual discovery and steers each `mode` to the
+    /// right lane, reusing trusty-search's own lane wording.
+    /// Test: `tests::schema_advertises_mode_and_query`.
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": SEARCH_CODE_TOOL_NAME,
+                "description": "PRIMARY code-discovery tool, backed by trusty-search's semantic + call-graph index. Use it for CONCEPTUAL queries where you don't already know the exact text: \"where is X\", \"how does Y work\", \"find the code that does <behaviour>\", \"what calls Z\". For exact symbol names, literal strings, or filename/path globs you already know, prefer the local `grep`/`glob` tools. If this tool reports trusty-search is unavailable, silently fall back to `grep`/`glob` — do not retry.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "For semantic: a natural-language description of the behaviour/concept. For symbol: a function or type name to expand its callers/callees. For grep: a regex or literal pattern."
+                        },
+                        "mode": {
+                            "type": "string",
+                            "enum": ["semantic", "symbol", "grep"],
+                            "default": "semantic",
+                            "description": "semantic (default): find code by meaning. symbol: explore what calls / is called by a known symbol (call graph). grep: regex/literal search over indexed files."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "description": "Maximum results (default 10, max 25)."
+                        }
+                    },
+                    "required": ["query"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    /// Execute a discovery query, fail-open on any unavailability.
+    ///
+    /// Why: an explicit model tool call must never derail the agent loop — a
+    /// missing/unready trusty-search surfaces as a SUCCESSFUL "use grep/glob"
+    /// result, not a tool error the model might retry-loop on.
+    /// Test: `tests::execute_fail_open_when_binary_absent`,
+    /// `tests::execute_rejects_malformed_args_recoverably`.
+    async fn execute(&self, args: Value) -> ToolResult {
+        let parsed: SearchArgs = match serde_json::from_value(args) {
+            Ok(p) => p,
+            Err(e) => {
+                return ToolResult::err(format!(
+                    "search_code arguments did not match the expected shape ({e}). \
+                     'query' (string) is required."
+                ));
+            }
+        };
+        let top_k = parsed.top_k.unwrap_or(DEFAULT_TOP_K).clamp(1, MAX_TOP_K);
+        let mode = parsed.mode.as_deref().unwrap_or("semantic");
+
+        let Some(session) = self.session().await else {
+            return ToolResult::ok(FALLBACK_HINT.to_string());
+        };
+
+        let (tool, params) =
+            match build_call(mode, &parsed.query, top_k, session.index_id.as_deref()) {
+                Ok(call) => call,
+                Err(msg) => return ToolResult::ok(msg),
+            };
+
+        let mut client = session.client.lock().await;
+        let result = match client.call_tool(tool, params).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(tool, error = %e, "search_code: trusty-search call failed (fail-open)");
+                return ToolResult::ok(format!("trusty-search call failed. {FALLBACK_HINT}"));
+            }
+        };
+
+        if is_mcp_error(&result) {
+            let detail = mcp_text(&result).unwrap_or_default();
+            warn!(
+                tool,
+                detail, "search_code: trusty-search returned an error (fail-open)"
+            );
+            return ToolResult::ok(format!(
+                "trusty-search could not serve this query (its index may still be building). \
+                 {FALLBACK_HINT}"
+            ));
+        }
+
+        match mcp_text(&result) {
+            Some(text) => ToolResult::ok(format!("trusty-search ({mode}) results:\n{text}")),
+            None => ToolResult::ok(format!(
+                "trusty-search returned no results. {FALLBACK_HINT}"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "trusty_search_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/tools/trusty_search_tests.rs
+++ b/crates/trusty-code/src/tools/trusty_search_tests.rs
@@ -1,0 +1,172 @@
+//! Tests for the `search_code` trusty-search discovery tool.
+//!
+//! Why: pins the pure index-resolution/parsing helpers and the fail-open
+//! contract (a missing daemon must yield a SUCCESSFUL "use grep/glob" result,
+//! never an error) so a regression in either can't silently derail the agent
+//! loop.
+//! What: covers `pick_index`, `mcp_text`, `is_mcp_error`, the tool schema, and
+//! `execute`'s daemon-absent / malformed-args paths. The live search lanes are
+//! not exercised here (they require a running trusty-search daemon + index);
+//! their routing is covered by `build_call`'s construction being unit-visible.
+//! Test: this module.
+
+use serde_json::json;
+
+use super::*;
+
+/// An index detail entry as returned by `list_indexes?details=true`.
+fn index_entry(id: &str, root_path: &str) -> Value {
+    json!({ "id": id, "root_path": root_path, "size_bytes": 0 })
+}
+
+// ── pick_index ──────────────────────────────────────────────────────────────
+
+/// Why: the common case — the project root is exactly a registered index root.
+#[test]
+fn pick_index_prefers_exact_match() {
+    let tmp = std::env::temp_dir();
+    let root = tmp.to_str().expect("utf8 temp dir");
+    let indexes = vec![
+        index_entry("other", "/nonexistent/elsewhere"),
+        index_entry("mine", root),
+    ];
+    assert_eq!(pick_index(&indexes, &tmp).as_deref(), Some("mine"));
+}
+
+/// Why: a subdirectory/worktree of a registered repo must resolve to that
+/// repo's index (longest ancestor wins over a shallower one).
+#[test]
+fn pick_index_falls_back_to_longest_ancestor() {
+    let base = std::env::temp_dir();
+    let nested = base.join("tcode-pick-index-nested");
+    std::fs::create_dir_all(&nested).expect("mkdir nested");
+
+    let shallow = base.to_str().expect("utf8");
+    let deep = nested.to_str().expect("utf8");
+    // Register both an ancestor (temp dir) and the exact nested dir; the exact
+    // match must win. Then drop the exact entry and the ancestor must be used.
+    let with_exact = vec![index_entry("ancestor", shallow), index_entry("exact", deep)];
+    assert_eq!(pick_index(&with_exact, &nested).as_deref(), Some("exact"));
+
+    let ancestor_only = vec![index_entry("ancestor", shallow)];
+    assert_eq!(
+        pick_index(&ancestor_only, &nested).as_deref(),
+        Some("ancestor")
+    );
+
+    let _ = std::fs::remove_dir_all(&nested);
+}
+
+/// Why: no registered index covers the project → `None`, so the search lanes
+/// fail open rather than guess a wrong index.
+#[test]
+fn pick_index_returns_none_when_uncovered() {
+    let indexes = vec![index_entry("elsewhere", "/nonexistent/elsewhere")];
+    assert_eq!(
+        pick_index(&indexes, Path::new("/nonexistent/project")),
+        None
+    );
+}
+
+// ── mcp_text / is_mcp_error ─────────────────────────────────────────────────
+
+/// Why: every trusty-search payload arrives as `content[0].text`; the extractor
+/// must return that inner string.
+#[test]
+fn mcp_text_extracts_content() {
+    let result = json!({ "content": [{ "type": "text", "text": "{\"indexes\":[]}" }] });
+    assert_eq!(mcp_text(&result).as_deref(), Some("{\"indexes\":[]}"));
+
+    let empty = json!({ "isError": false });
+    assert_eq!(mcp_text(&empty), None);
+}
+
+/// Why: `STAGE_NOT_READY` and friends arrive as in-band `isError: true`
+/// content (not a JSON-RPC error), so the flag must be detected to fail open.
+#[test]
+fn is_mcp_error_detects_error_flag() {
+    assert!(is_mcp_error(&json!({ "isError": true, "content": [] })));
+    assert!(!is_mcp_error(&json!({ "isError": false })));
+    assert!(!is_mcp_error(&json!({ "content": [] })));
+}
+
+// ── build_call ──────────────────────────────────────────────────────────────
+
+/// Why: each mode must route to trusty-search's real lane with the right
+/// argument shape; a wrong tool name or missing arg would silently 400.
+#[test]
+fn build_call_routes_each_mode() {
+    let (tool, params) = build_call("semantic", "how does auth work", 5, Some("idx")).expect("ok");
+    assert_eq!(tool, "search_semantic");
+    assert_eq!(params["index_id"], "idx");
+    assert_eq!(params["query"], "how does auth work");
+    assert_eq!(params["top_k"], 5);
+
+    let (tool, params) = build_call("symbol", "validate_token", 5, Some("idx")).expect("ok");
+    assert_eq!(tool, "search_kg");
+    assert_eq!(params["query"], "validate_token");
+
+    // grep works without an index (the daemon fans out across all indexes).
+    let (tool, params) = build_call("grep", "TODO", 7, None).expect("ok");
+    assert_eq!(tool, "grep");
+    assert_eq!(params["pattern"], "TODO");
+    assert_eq!(params["max_results"], 7);
+    assert!(params.get("index_id").is_none());
+}
+
+/// Why: semantic/symbol need an index; without one the call is a fail-open
+/// message steering the model back to the local tools.
+#[test]
+fn build_call_semantic_without_index_is_fallback() {
+    let err = build_call("semantic", "q", 5, None).expect_err("needs index");
+    assert!(err.contains("grep"), "must steer to local tools: {err}");
+}
+
+// ── schema ──────────────────────────────────────────────────────────────────
+
+/// Why: the model must see `query` as required and `mode` as an enum defaulting
+/// to semantic.
+#[test]
+fn schema_advertises_mode_and_query() {
+    let tool = TrustySearchTool::new(std::env::temp_dir());
+    let schema = tool.schema();
+    assert_eq!(schema["function"]["name"], SEARCH_CODE_TOOL_NAME);
+    let params = &schema["function"]["parameters"];
+    let required: Vec<&str> = params["required"]
+        .as_array()
+        .expect("required array")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert_eq!(required, vec!["query"]);
+    assert_eq!(params["properties"]["mode"]["default"], "semantic");
+    assert_eq!(params["additionalProperties"], json!(false));
+}
+
+// ── execute (fail-open) ─────────────────────────────────────────────────────
+
+/// Why: the daemon-absent path is the whole point of fail-open — a missing
+/// binary must yield a SUCCESSFUL "use grep/glob" result, never an error.
+#[tokio::test]
+async fn execute_fail_open_when_binary_absent() {
+    let tool = TrustySearchTool::new(std::env::temp_dir())
+        .with_binary("trusty-search-definitely-not-installed-xyzzy");
+    let result = tool.execute(json!({ "query": "how does auth work" })).await;
+    assert!(!result.is_error(), "must not surface as a tool error");
+    assert!(
+        result.content().contains("grep"),
+        "must steer to local tools: {}",
+        result.content()
+    );
+}
+
+/// Why: malformed args (missing `query`) must be a recoverable, non-fatal error
+/// the model can correct — mirrors `recall_session`'s contract.
+#[tokio::test]
+async fn execute_rejects_malformed_args_recoverably() {
+    let tool = TrustySearchTool::new(std::env::temp_dir())
+        .with_binary("trusty-search-definitely-not-installed-xyzzy");
+    let result = tool.execute(json!({ "mode": "semantic" })).await; // no query
+    assert!(result.is_error());
+    assert!(!result.is_fatal());
+}


### PR DESCRIPTION
## PR A — trusty-search-first code discovery

Makes trusty-search's semantic + call-graph index the **PRIMARY** code-discovery path for the `tcode` engineer, keeping the local `glob`/`grep`/`list_dir` tools (#2685) as the graceful-degrade **FALLBACK**.

Closes #2689.

### What changed
- **`TrustySearchTool`** (`crates/trusty-code/src/tools/trusty_search.rs`) wraps the shared `trusty_common::stdio_mcp_client::StdioMcpClient` (spawn `trusty-search serve`, MCP handshake, typed `tools/call`) — mirrors trusty-agents' `TrustySearchPlugin`, no bespoke MCP/HTTP client. It resolves the project's index id from `list_indexes` (exact-then-longest-ancestor root match).
- **Single `search_code` tool** with a `mode` param routing to trusty-search's real lanes:
  - `semantic` (default) → `search_semantic` — conceptual "where is X / how does Y work / find code that does Z"
  - `symbol` → `search_kg` — call-graph "what calls / is called by <symbol>"
  - `grep` → `grep` — regex/literal over indexed files
  - *Rationale:* one tool keeps the advertised schema minimal and mirrors trusty-search's own lane taxonomy vs. three separate tools.
- **Fail-open everywhere** (mirrors `recall_session`): binary-absent, spawn failure, handshake failure, call error/timeout, `STAGE_NOT_READY`, and missing-index all return a **successful** `ToolResult` telling the model trusty-search is unavailable and to use local `grep`/`glob` — never an `Err` that derails the agent loop.
- **DailyDriver-only registration** in `ProjectToolFactory::build` at both `run_task/mod.rs` (CLI path — always daily-driver) and `task/executor.rs` (gated on `HarnessMode::DailyDriver`). **Parity untouched** — byte-identical tool surface for benchmark fairness.
- **DailyDriver-only `DISCOVERY_GUIDANCE`** prompt section appended in `assemble_system_prompt_for_mode` (mirrors the `skills_catalog` trailing-section pattern). `BASE_PREAMBLE` and its hash are **unchanged** (parity spec forbids MCP catalogs in the preamble).
- Enables trusty-common's `stdio-mcp-client` feature on the tcode dependency.

### Local tools unchanged
`glob`/`grep`/`list_dir`/`write_files` remain as the fallback tier.

### Verification (from the worktree)
- `cargo build -p trusty-code` — clean
- `cargo test -p trusty-code` — **913 unit passed, 0 failed** (incl. new `trusty_search::tests::*` and prompt discovery-guidance tests); all integration suites green
- `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — OK (0 violations)
- `bash scripts/check_test_pointers.sh` — exit 0
- `base_preamble_hash_tripwire` — **passes unchanged**; no diff to `preamble.rs`/`version.rs`

### Coordination
Confined to the tool-registration path in `run_task`/`executor`; PR B's ensure-index changes live in different functions (task/session start), so no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)