### PR TITLE
feat(trusty-channels): Telegram module (#2641)

### DIFF
--- a/crates/trusty-channels/Cargo.toml
+++ b/crates/trusty-channels/Cargo.toml
@@ -13,6 +13,10 @@ crate-type = ["rlib"]
 name = "slack-mcp"
 path = "src/bin/slack-mcp.rs"
 
+[[bin]]
+name = "telegram-mcp"
+path = "src/bin/telegram-mcp.rs"
+
 [dependencies]
 trusty-common = { workspace = true, features = ["mcp", "credentials"] }
 anyhow = { workspace = true }

--- a/crates/trusty-channels/src/bin/telegram-mcp.rs
+++ b/crates/trusty-channels/src/bin/telegram-mcp.rs
@@ -1,0 +1,24 @@
+//! `telegram-mcp` binary — stdio MCP server (scaffold).
+//!
+//! Why: Claude Code (and other MCP hosts) launch this process per session and
+//! talk to it over stdin/stdout JSON-RPC.
+//! What: Initialises tracing (to stderr, keeping stdout clean for JSON-RPC
+//! framing), builds an `AppState` with a shared `BaseClient`, then runs the
+//! stdio loop until EOF. Tool calls currently return a `not-yet-implemented`
+//! MCP error — live Telegram Bot API calls are deferred (see issue #2641).
+//! Test: Manual via `claude mcp add` / direct stdin piping.
+
+use std::sync::Arc;
+
+use trusty_channels::telegram::api::client::BaseClient;
+use trusty_channels::telegram::server::{run_stdio, AppState};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    trusty_common::init_tracing(0);
+    let client = BaseClient::new()?;
+    let state = AppState {
+        client: Arc::new(client),
+    };
+    run_stdio(state).await
+}

--- a/crates/trusty-channels/src/lib.rs
+++ b/crates/trusty-channels/src/lib.rs
@@ -15,3 +15,4 @@
 //! handshake, and tool registry.
 
 pub mod slack;
+pub mod telegram;

--- a/crates/trusty-channels/src/telegram/api/client.rs
+++ b/crates/trusty-channels/src/telegram/api/client.rs
@@ -223,7 +223,7 @@ fn classify_transport_error(e: &reqwest::Error) -> String {
 /// What: returns `Ok(value)` when `ok` is `true`; maps `error_code:401` to
 /// [`TelegramError::Auth`] and every other `ok:false` to [`TelegramError::Api`]
 /// carrying the `description`.
-/// Test: `tests/telegram_client_http.rs::auth_ok_false`, `::api_error_ok_false`.
+/// Test: `auth_ok_false_maps_to_auth_error`, `api_ok_false_maps_to_api_error`.
 fn interpret_envelope(status: u16, value: Value) -> Result<Value, TelegramError> {
     if value.get("ok").and_then(Value::as_bool) == Some(true) {
         return Ok(value);

--- a/crates/trusty-channels/src/telegram/api/client.rs
+++ b/crates/trusty-channels/src/telegram/api/client.rs
@@ -1,0 +1,324 @@
+//! BaseClient: authenticated HTTP wrapper over the Telegram Bot API.
+//!
+//! Why: Every Bot API method (`sendMessage`, `getMe`, `getChat`, …) needs the
+//! same token resolution, URL assembly, JSON-envelope unwrapping, and
+//! rate-limit handling. Centralising it here (mirroring
+//! `slack::api::client::BaseClient`) means each future tool handler only encodes
+//! its own request/response shape. Unlike Slack, the Bot API carries the token
+//! in the URL path (`/bot<token>/<method>`), not a bearer header, so the token
+//! is spliced into the request URL rather than an `Authorization` header.
+//! What: Holds a `reqwest::Client`, a resolved bot token (or `None`), and the
+//! API host base. `new()` resolves the token via the shared credential
+//! resolver; [`BaseClient::call_method`] performs a hardened POST that surfaces
+//! auth failures as a typed error (never a silent anonymous retry) and honours
+//! `429` retry hints (`parameters.retry_after` in the body, or the `Retry-After`
+//! header) with a bounded backoff.
+//! Test: `new_succeeds_without_token` (constructor, CI-safe) here;
+//! `retry_after_*` here; the full request path (200 / 401 / `ok:false` / 429) is
+//! covered in `tests/telegram_client_http.rs`.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use reqwest::header::{HeaderMap, RETRY_AFTER};
+use reqwest::StatusCode;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::telegram::api::constants::{
+    DEFAULT_RETRY_AFTER, MAX_RATE_LIMIT_RETRIES, MAX_RETRY_AFTER, TELEGRAM_API_BASE,
+    TELEGRAM_PROVIDER,
+};
+use crate::telegram::api::error::TelegramError;
+
+/// Authenticated Telegram Bot API client.
+///
+/// Why: One handle per process; live request methods splice the bot token into
+/// the URL on every call and unwrap Telegram's `{"ok": bool, ...}` envelope in
+/// one place.
+/// What: Wraps a `reqwest::Client`, the resolved token (`None` when
+/// unconfigured — construction still succeeds so `tools/list` and the MCP
+/// handshake work without secrets), and the API host base (overridable for
+/// tests).
+/// Test: `new_succeeds_without_token`; request behaviour in
+/// `tests/telegram_client_http.rs`.
+pub struct BaseClient {
+    /// Shared HTTP client / connection pool.
+    http: reqwest::Client,
+    /// Resolved Telegram bot token, or `None` when unconfigured.
+    token: Option<String>,
+    /// API host root the `bot<token>/<method>` segment is appended to.
+    /// Defaults to [`TELEGRAM_API_BASE`].
+    base_url: String,
+}
+
+impl BaseClient {
+    /// Construct with a shared HTTP client and a resolved Telegram token.
+    ///
+    /// Why: The binary builds exactly one client at startup. Keeping it
+    /// infallible-on-missing-token (returns `Ok` with `token: None`) means the
+    /// server boots for `tools/list` without credentials; the `MissingToken`
+    /// error is deferred to the first call that actually needs auth.
+    /// What: Builds the `reqwest::Client` and resolves the bot token through
+    /// `trusty_common::inference::credentials::resolve_key(TELEGRAM_PROVIDER)` —
+    /// process env (`TELEGRAM_BOT_TOKEN`) → `.env.local` → secure store, in that
+    /// order. Returns `Err` only if the HTTP client fails to build.
+    /// Test: `new_succeeds_without_token`; env-tier pickup in
+    /// `tests/telegram_client_http.rs`.
+    pub fn new() -> Result<Self> {
+        let http = build_http_client()?;
+        let token = trusty_common::inference::credentials::resolve_key(TELEGRAM_PROVIDER);
+        Ok(Self {
+            http,
+            token,
+            base_url: TELEGRAM_API_BASE.to_string(),
+        })
+    }
+
+    /// Construct against an explicit base URL and token.
+    ///
+    /// Why: lets tests point the client at a local mock server without touching
+    /// the network or a real bot token.
+    /// What: same as [`BaseClient::new`] but takes the base URL and token
+    /// directly instead of resolving them.
+    /// Test: the constructor used by every case in
+    /// `tests/telegram_client_http.rs`.
+    pub fn with_endpoint(base_url: impl Into<String>, token: Option<String>) -> Result<Self> {
+        Ok(Self {
+            http: build_http_client()?,
+            token,
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Whether a token was resolved (a live call can be attempted).
+    ///
+    /// Why: callers and tests need to know if auth is configured without
+    /// exposing the secret value itself.
+    /// What: `true` iff a non-`None` token is held.
+    /// Test: `tests/telegram_client_http.rs::base_client_new_resolves_env_token`.
+    pub fn has_token(&self) -> bool {
+        self.token.is_some()
+    }
+
+    /// Call a Telegram Bot API `method` with a JSON `body`, returning the
+    /// decoded response envelope on success.
+    ///
+    /// Why: the single hardened request primitive every future tool handler
+    /// reuses — one place for token assembly, error classification, and
+    /// rate-limit backoff, so no handler re-implements (or forgets) them.
+    /// What: POSTs `{base_url}/bot{token}/{method}`. Maps HTTP 401 and body
+    /// `error_code:401` to [`TelegramError::Auth`] (never retried as anonymous);
+    /// honours `429` retry hints with a bounded backoff up to
+    /// [`MAX_RATE_LIMIT_RETRIES`], then returns [`TelegramError::RateLimited`];
+    /// returns [`TelegramError::Api`] for other `ok:false` bodies and the
+    /// decoded `Value` when `ok:true`.
+    /// Test: `tests/telegram_client_http.rs` (`send_ok`, `auth_401`,
+    /// `auth_ok_false`, `rate_limit_retries_then_succeeds`,
+    /// `rate_limit_exhausted`).
+    pub async fn call_method<B>(&self, method: &str, body: &B) -> Result<Value, TelegramError>
+    where
+        B: Serialize + ?Sized,
+    {
+        let token = self.token.as_deref().ok_or(TelegramError::MissingToken)?;
+        let url = format!(
+            "{}/bot{}/{}",
+            self.base_url.trim_end_matches('/'),
+            token,
+            method
+        );
+
+        let mut retries: u32 = 0;
+        loop {
+            let response = self.http.post(&url).json(body).send().await.map_err(|e| {
+                TelegramError::Transport {
+                    reason: classify_transport_error(&e),
+                }
+            })?;
+            let status = response.status();
+
+            if status == StatusCode::UNAUTHORIZED {
+                return Err(TelegramError::Auth {
+                    status: status.as_u16(),
+                    reason: "HTTP 401 Unauthorized".to_string(),
+                });
+            }
+
+            if status == StatusCode::TOO_MANY_REQUESTS {
+                let headers = response.headers().clone();
+                let body: Value = response.json().await.unwrap_or(Value::Null);
+                let retry_after = retry_after_from_response(&headers, &body);
+                if retries >= MAX_RATE_LIMIT_RETRIES {
+                    return Err(TelegramError::RateLimited {
+                        retries,
+                        retry_after,
+                    });
+                }
+                retries += 1;
+                tokio::time::sleep(retry_after).await;
+                continue;
+            }
+
+            if !status.is_success() {
+                return Err(TelegramError::UnexpectedStatus(status.as_u16()));
+            }
+
+            let value: Value = response
+                .json()
+                .await
+                .map_err(|e| TelegramError::Decode(e.to_string()))?;
+            return interpret_envelope(status.as_u16(), value);
+        }
+    }
+}
+
+/// Build the shared `reqwest::Client` used by every `BaseClient`.
+///
+/// Why: one place for the user-agent and (future) timeout/pool tuning.
+/// What: sets a versioned user-agent; returns the transport build error as
+/// `anyhow` context.
+/// Test: covered implicitly by `new_succeeds_without_token`.
+fn build_http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent(concat!(
+            "trusty-channels-telegram/",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .build()
+        .context("build reqwest client")
+}
+
+/// Classify a transport-level `reqwest::Error` into a short, URL-free reason.
+///
+/// Why: the Bot API token lives in the request URL path
+/// (`/bot<token>/<method>`), and `reqwest::Error`'s `Display`/`Debug` both
+/// render the attached request URL verbatim (`with_url`, reqwest 0.12). Never
+/// call `.to_string()`, `{:?}`, or otherwise format the error itself — build
+/// the reason purely from its boolean predicates and status so the token can
+/// never reach a log line or a `?`-propagated message.
+/// What: returns one of a small set of static/short reasons based on
+/// `is_timeout()` / `is_connect()` / `is_body()` / `is_decode()` / `status()`,
+/// falling back to a generic "request error" label.
+/// Test: `transport_error_display_and_debug_never_contain_the_bot_token`.
+fn classify_transport_error(e: &reqwest::Error) -> String {
+    if e.is_timeout() {
+        "timeout".to_string()
+    } else if e.is_connect() {
+        "connect error".to_string()
+    } else if e.is_body() {
+        "body error".to_string()
+    } else if e.is_decode() {
+        "decode error".to_string()
+    } else if let Some(status) = e.status() {
+        format!("HTTP error (status {status})")
+    } else {
+        "request error".to_string()
+    }
+}
+
+/// Interpret a decoded Telegram response envelope.
+///
+/// Why: the Bot API signals failures with `{"ok": false, "error_code": N,
+/// "description": "..."}`, so success is not implied by the HTTP status alone.
+/// What: returns `Ok(value)` when `ok` is `true`; maps `error_code:401` to
+/// [`TelegramError::Auth`] and every other `ok:false` to [`TelegramError::Api`]
+/// carrying the `description`.
+/// Test: `tests/telegram_client_http.rs::auth_ok_false`, `::api_error_ok_false`.
+fn interpret_envelope(status: u16, value: Value) -> Result<Value, TelegramError> {
+    if value.get("ok").and_then(Value::as_bool) == Some(true) {
+        return Ok(value);
+    }
+    let description = value
+        .get("description")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown_error")
+        .to_string();
+    let error_code = value.get("error_code").and_then(Value::as_u64);
+    if error_code == Some(401) {
+        return Err(TelegramError::Auth {
+            status,
+            reason: description,
+        });
+    }
+    Err(TelegramError::Api(description))
+}
+
+/// Resolve a `429` retry delay from the response, preferring the Bot API's
+/// idiomatic body hint over the header.
+///
+/// Why: honour Telegram's advertised backoff, but never let a malformed or
+/// hostile value force an unbounded (or zero-cost busy-loop) wait.
+/// What: reads `parameters.retry_after` (integer seconds) from the JSON body
+/// first — the canonical Bot API signal — then the `Retry-After` header, then
+/// falls back to [`DEFAULT_RETRY_AFTER`]; the result is clamped to
+/// `[0, MAX_RETRY_AFTER]`.
+/// Test: `retry_after_from_body_hint`, `retry_after_from_header`,
+/// `retry_after_defaults`.
+fn retry_after_from_response(headers: &HeaderMap, body: &Value) -> Duration {
+    if let Some(secs) = body
+        .get("parameters")
+        .and_then(|p| p.get("retry_after"))
+        .and_then(Value::as_u64)
+    {
+        return Duration::from_secs(secs).min(MAX_RETRY_AFTER);
+    }
+    if let Some(secs) = headers
+        .get(RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<u64>().ok())
+    {
+        return Duration::from_secs(secs).min(MAX_RETRY_AFTER);
+    }
+    DEFAULT_RETRY_AFTER
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn new_succeeds_without_token() {
+        // Constructing must not require Telegram credentials so the MCP
+        // handshake and tools/list work in CI without secrets.
+        let client = BaseClient::new().expect("construct base client");
+        let _ = client.has_token();
+    }
+
+    #[test]
+    fn retry_after_from_body_hint() {
+        let body = json!({ "parameters": { "retry_after": 2 } });
+        assert_eq!(
+            retry_after_from_response(&HeaderMap::new(), &body),
+            Duration::from_secs(2)
+        );
+    }
+
+    #[test]
+    fn retry_after_from_header() {
+        let mut h = HeaderMap::new();
+        h.insert(RETRY_AFTER, "3".parse().unwrap());
+        assert_eq!(
+            retry_after_from_response(&h, &Value::Null),
+            Duration::from_secs(3)
+        );
+    }
+
+    #[test]
+    fn retry_after_clamps() {
+        let body = json!({ "parameters": { "retry_after": 99999 } });
+        assert_eq!(
+            retry_after_from_response(&HeaderMap::new(), &body),
+            MAX_RETRY_AFTER
+        );
+    }
+
+    #[test]
+    fn retry_after_defaults() {
+        // No body hint and no header → default.
+        assert_eq!(
+            retry_after_from_response(&HeaderMap::new(), &Value::Null),
+            DEFAULT_RETRY_AFTER
+        );
+    }
+}

--- a/crates/trusty-channels/src/telegram/api/constants.rs
+++ b/crates/trusty-channels/src/telegram/api/constants.rs
@@ -1,0 +1,58 @@
+//! Telegram Bot API endpoint constants and request-hardening tunables.
+//!
+//! Why: Centralise the API root, the credential-provider identifier, and the
+//! rate-limit budget so future method modules don't drift on path roots or
+//! retry policy. The Telegram Bot API embeds the token in the URL path
+//! (`/bot<token>/<method>`) rather than an auth header, so the root here is the
+//! host prefix only — the `bot<token>` segment is assembled by `client`.
+//! What: `const`s for the Bot API host root, the credential-resolver provider
+//! key, its canonical env var, and the bounded-backoff limits honoured by
+//! `client::BaseClient`. No string interpolation here — `client` appends the
+//! `bot<token>/<method>` segments.
+//! Test: `base_url_parses` asserts the root parses as a valid `reqwest::Url`;
+//! the retry constants are exercised via `tests/telegram_client_http.rs`.
+
+use std::time::Duration;
+
+/// Telegram Bot API host root. The client appends `/bot<token>/<method>`, e.g.
+/// `{TELEGRAM_API_BASE}/bot123:ABC/sendMessage`.
+pub const TELEGRAM_API_BASE: &str = "https://api.telegram.org";
+
+/// Provider identifier passed to
+/// `trusty_common::inference::credentials::resolve_key` to obtain the Telegram
+/// bot token. Telegram is not an inference provider, but the resolver's
+/// provider→key mapping (`env_var_for`) is the supported, non-parallel path for
+/// any token: this key resolves the process-env → `.env.local` → secure-store
+/// precedence against [`TELEGRAM_TOKEN_ENV`]. Keep it in sync with the
+/// `"telegram"` arm of `credentials::resolver::env_var_for`.
+pub const TELEGRAM_PROVIDER: &str = "telegram";
+
+/// Canonical environment variable holding the Telegram bot token. This is the
+/// same name the credential resolver's `env_var_for("telegram")` returns, so
+/// setting it in the process env or `.env.local` is honoured by `resolve_key`.
+pub const TELEGRAM_TOKEN_ENV: &str = "TELEGRAM_BOT_TOKEN";
+
+/// Maximum number of automatic retries after a `429 Too Many Requests` before
+/// giving up with [`crate::telegram::api::error::TelegramError::RateLimited`].
+/// Bounds the worst-case latency of a rate-limited call.
+pub const MAX_RATE_LIMIT_RETRIES: u32 = 3;
+
+/// Upper bound applied to any advertised retry delay. A hostile or buggy server
+/// cannot force an unbounded sleep; waits are clamped to this ceiling.
+pub const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
+
+/// Fallback wait used when a `429` omits a parseable `retry_after` (neither in
+/// the JSON `parameters` object nor the `Retry-After` header).
+pub const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(1);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_url_parses() {
+        let url = reqwest::Url::parse(TELEGRAM_API_BASE).expect("TELEGRAM_API_BASE is a valid URL");
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), Some("api.telegram.org"));
+    }
+}

--- a/crates/trusty-channels/src/telegram/api/error.rs
+++ b/crates/trusty-channels/src/telegram/api/error.rs
@@ -1,0 +1,102 @@
+//! Typed errors for live Telegram Bot API calls.
+//!
+//! Why: `BaseClient`'s request path has several distinct failure modes a caller
+//! must react to differently — an auth failure is unrecoverable and must never
+//! be silently retried anonymously, a rate-limit is transient, a Telegram
+//! `ok:false` envelope is an application error, and a transport error is
+//! infrastructural. A single `anyhow` blob would collapse all of these into an
+//! opaque string; a `thiserror` enum keeps them matchable (library convention),
+//! mirroring `slack::api::error::SlackError`.
+//! What: [`TelegramError`] enumerates every failure `BaseClient::call_method`
+//! can surface. `Transport` carries only a URL-free classification string — see
+//! its own doc for why the raw `reqwest::Error` must never be held here; the
+//! rest are semantic classifications derived from the HTTP status or Bot API
+//! `{"ok": false, "error_code": N, "description": "..."}` envelope.
+//! Test: exercised end-to-end against a mocked Bot API server in
+//! `tests/telegram_client_http.rs` (`auth_*`, `rate_limit_*`, `api_*`,
+//! `transport_error_display_and_debug_never_contain_the_bot_token`).
+
+use std::time::Duration;
+
+/// A failure raised while calling a Telegram Bot API method.
+///
+/// Why: callers (the tool handlers, once live) branch on the failure class —
+/// surface `Auth` to the operator, back off on `RateLimited`, report
+/// `Api`/`UnexpectedStatus` as a tool error. Keeping these variants distinct is
+/// the whole point of not returning `anyhow::Error` from the request path.
+/// What: a structured error enum. `Transport` deliberately does NOT hold (or
+/// derive `#[from]`) a raw `reqwest::Error` — see its own doc.
+/// Test: each variant is asserted in `tests/telegram_client_http.rs`.
+#[derive(Debug, thiserror::Error)]
+pub enum TelegramError {
+    /// No token was configured, so a live call cannot be attempted.
+    /// Construction of `BaseClient` still succeeds without a token (so
+    /// `tools/list` works); this is only raised when a method that *requires*
+    /// auth is invoked.
+    #[error(
+        "no Telegram token configured: set {} (process env or .env.local), \
+         or store it via the credential resolver",
+        crate::telegram::api::constants::TELEGRAM_TOKEN_ENV
+    )]
+    MissingToken,
+
+    /// Telegram rejected the credentials. Raised on an HTTP 401 **or** a body
+    /// carrying `error_code: 401` (`Unauthorized`). Never retried — a bad token
+    /// will not become good on retry, and silently retrying anonymously would
+    /// mask the misconfiguration.
+    #[error("Telegram authentication failed (status {status}): {reason}")]
+    Auth {
+        /// HTTP status observed (401, or the body's `error_code` when signalled
+        /// there).
+        status: u16,
+        /// Telegram's `description` or a short description of the auth failure.
+        reason: String,
+    },
+
+    /// Rate limiting persisted past the bounded retry budget. Carries the number
+    /// of retries attempted and the last `retry_after` the server advertised.
+    #[error(
+        "Telegram rate limit not cleared after {retries} retries (last retry_after: {retry_after:?})"
+    )]
+    RateLimited {
+        /// How many retries were attempted before giving up.
+        retries: u32,
+        /// The `retry_after` duration advertised on the final 429.
+        retry_after: Duration,
+    },
+
+    /// Telegram returned `ok:false` for a non-auth reason (e.g.
+    /// `chat not found`, `Bad Request: ...`). Carries the `description` text.
+    #[error("Telegram API error: {0}")]
+    Api(String),
+
+    /// An HTTP status neither success, 401, nor 429 — e.g. a 5xx or an
+    /// unexpected 4xx. Carries the numeric status for the caller to log.
+    #[error("unexpected Telegram HTTP status: {0}")]
+    UnexpectedStatus(u16),
+
+    /// The transport failed (DNS, TLS, connect, or a body-read error).
+    ///
+    /// Why: the Telegram Bot API embeds the bot token IN THE URL PATH
+    /// (`/bot<token>/<method>`), unlike Slack's bearer-header auth. `reqwest`
+    /// 0.12 attaches the request URL to send/timeout/connect errors via
+    /// `with_url`, and `reqwest::Error`'s `Display` **and** its derived `Debug`
+    /// both render that URL verbatim — so holding (or `#[from]`-converting) the
+    /// raw `reqwest::Error` here would leak the live bot token into any log or
+    /// `?`-propagated error message. This variant instead carries only a short,
+    /// URL-free classification derived from the error's `is_timeout()` /
+    /// `is_connect()` / `is_body()` / `is_decode()` predicates and status (see
+    /// `client::classify_transport_error`) — never the error itself, never its
+    /// `Display`/`Debug`/`to_string()`.
+    /// What: a plain `String` reason with no request context attached.
+    /// Test: `transport_error_display_and_debug_never_contain_the_bot_token`.
+    #[error("Telegram HTTP transport error: {reason}")]
+    Transport {
+        /// URL-free classification (e.g. "timeout", "connect error").
+        reason: String,
+    },
+
+    /// The response body was not the expected JSON envelope.
+    #[error("could not decode Telegram response body: {0}")]
+    Decode(String),
+}

--- a/crates/trusty-channels/src/telegram/api/mod.rs
+++ b/crates/trusty-channels/src/telegram/api/mod.rs
@@ -1,0 +1,13 @@
+//! Telegram Bot API client layer.
+//!
+//! Why: Keep the pure HTTP/auth concerns isolated from MCP framing so the same
+//! client can be reused outside of MCP (CLI tools, tests, a future daemon),
+//! matching the `slack::api` split.
+//! What: Re-exports the endpoint constants, the typed [`error::TelegramError`],
+//! and the `BaseClient` HTTP wrapper.
+//! Test: Constants are smoke-tested in `constants`; the client constructor and
+//! request path are tested in `client` + `tests/telegram_client_http.rs`.
+
+pub mod client;
+pub mod constants;
+pub mod error;

--- a/crates/trusty-channels/src/telegram/mod.rs
+++ b/crates/trusty-channels/src/telegram/mod.rs
@@ -1,0 +1,22 @@
+//! Telegram channel: native Telegram Bot API client + MCP server (scaffold).
+//!
+//! Why: The Telegram surface mirrors the sibling `slack` module — a pure Bot
+//! API client isolated from MCP framing so it can be reused (CLI, tests, a
+//! future daemon), plus a stdio MCP server exposing chat-as-tools. Grouping it
+//! under this one `telegram` module (rather than a standalone crate) is the
+//! epic #2636 topology decision. See ADR-0014.
+//! What: [`api`] holds the endpoint constants, the typed
+//! [`api::error::TelegramError`], and the `BaseClient` HTTP wrapper (token in
+//! the URL path + 401/429 hardening, issue #2641); [`server`] is the JSON-RPC
+//! dispatcher wired into `bin/telegram-mcp.rs`; [`tools`] is the authoritative
+//! `tools/list` registry. The surface is send/info-only by design — a Telegram
+//! bot cannot read or search prior chat history via the Bot API. Every
+//! `tools/call` handler is still a `not-yet-implemented` stub (live calls land
+//! in follow-up work).
+//! Test: `cargo test -p trusty-channels` covers the `initialize` handshake, the
+//! `tools/list` shape/count + history-limitation note, the stub-error path, and
+//! the client's auth/HTTP behaviour (`tests/telegram_client_http.rs`).
+
+pub mod api;
+pub mod server;
+pub mod tools;

--- a/crates/trusty-channels/src/telegram/server.rs
+++ b/crates/trusty-channels/src/telegram/server.rs
@@ -1,0 +1,229 @@
+//! MCP JSON-RPC dispatch + stdio loop for `telegram-mcp`.
+//!
+//! Why: Every trusty-* MCP server shares the same shape — `initialize`,
+//! `tools/list`, `tools/call`, with notifications suppressed. Centralising it
+//! here means future Telegram tool handlers focus on Bot API specifics.
+//! What: `AppState` holds an `Arc<BaseClient>`; `handle_message` is the pure
+//! JSON-RPC dispatcher; `handle_tool_call` is the (currently all-stub) tool
+//! router; `run_stdio` wires it into `trusty_common::mcp::run_stdio_loop`.
+//! Test: `handle_message_initialize_returns_server_info`,
+//! `handle_message_tools_list_returns_tools`, and
+//! `tools_call_returns_not_implemented` in `mod tests`.
+
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+use thiserror::Error;
+
+use crate::telegram::api::client::BaseClient;
+use trusty_common::mcp::{error_codes, initialize_response, run_stdio_loop, Request, Response};
+
+/// Shared state passed to every dispatcher invocation.
+///
+/// Why: Tool handlers will need the Telegram client; nothing else is shared yet.
+/// What: `Clone`-able via `Arc<BaseClient>`.
+/// Test: Smoke-constructed in `mod tests`.
+#[derive(Clone)]
+pub struct AppState {
+    pub client: Arc<BaseClient>,
+}
+
+/// Error returned by the tool dispatcher.
+///
+/// Why: The scaffold must distinguish a known-but-unimplemented tool from a
+/// genuinely unknown one, and surface each as a proper JSON-RPC error rather
+/// than a panic (`todo!()`/`unimplemented!()` are banned here).
+/// What: A `thiserror` enum whose `code()` maps to a JSON-RPC error code.
+/// Test: `tools_call_returns_not_implemented` and
+/// `tools_call_unknown_tool_returns_method_not_found`.
+#[derive(Debug, Error)]
+pub enum ToolCallError {
+    /// A planned tool whose live handler has not been implemented yet.
+    #[error(
+        "tool '{0}' is not yet implemented: live Telegram Bot API calls are deferred (see issue #2641)"
+    )]
+    NotImplemented(String),
+    /// A tool name that is not part of the planned surface at all.
+    #[error("unknown tool: {0}")]
+    UnknownTool(String),
+}
+
+impl ToolCallError {
+    /// JSON-RPC error code for this failure.
+    ///
+    /// Why: `handle_message` needs a numeric code for the wire response.
+    /// What: Unknown tools map to `METHOD_NOT_FOUND`; unimplemented (but
+    /// planned) tools map to `INTERNAL_ERROR`.
+    /// Test: Covered by the dispatcher tests.
+    pub fn code(&self) -> i32 {
+        match self {
+            ToolCallError::NotImplemented(_) => error_codes::INTERNAL_ERROR,
+            ToolCallError::UnknownTool(_) => error_codes::METHOD_NOT_FOUND,
+        }
+    }
+}
+
+/// Dispatch a single tool call by name.
+///
+/// Why: One routing table keeps the tool surface greppable; live handlers land
+/// on the matching arm here as each Bot API method is implemented.
+/// What: Every planned tool currently routes to a `NotImplemented` stub;
+/// anything else is `UnknownTool`. The `_state`/`_args` are accepted now so the
+/// signature is stable when real handlers replace the stubs.
+/// Test: `tools_call_returns_not_implemented`.
+pub async fn handle_tool_call(
+    _state: &AppState,
+    name: &str,
+    _args: Value,
+) -> Result<Value, ToolCallError> {
+    if crate::telegram::tools::is_known_tool(name) {
+        // Stub: schema is authoritative, live call deferred (see issue #2641).
+        return Err(ToolCallError::NotImplemented(name.to_string()));
+    }
+    Err(ToolCallError::UnknownTool(name.to_string()))
+}
+
+/// Translate a parsed JSON-RPC request into a JSON-RPC response payload.
+///
+/// Why: Same shape used across the trusty-* family — handle init, ping,
+/// notifications, tools/list, tools/call.
+/// What: Returns `Value::Null` for notifications (suppressed); returns an
+/// `{"error": {code, message}}` map for tool failures and unknown methods so
+/// `run_stdio` can emit a proper JSON-RPC error.
+/// Test: `handle_message_initialize_returns_server_info`,
+/// `tools_call_returns_not_implemented`, `unknown_method_returns_error_payload`.
+pub async fn handle_message(state: AppState, req: Value) -> Value {
+    let method = req["method"].as_str().unwrap_or("");
+    match method {
+        "initialize" => initialize_response("telegram-mcp", env!("CARGO_PKG_VERSION"), None),
+        "notifications/initialized" | "notifications/cancelled" => Value::Null,
+        "ping" => json!({}),
+        "tools/list" => crate::telegram::tools::tool_list_response(),
+        "tools/call" => {
+            let params = &req["params"];
+            let name = params["name"].as_str().unwrap_or("");
+            let args = params.get("arguments").cloned().unwrap_or(Value::Null);
+            let args = if args.is_null() { json!({}) } else { args };
+            match handle_tool_call(&state, name, args).await {
+                Ok(result) => {
+                    let text = serde_json::to_string(&result).unwrap_or_default();
+                    json!({ "content": [{ "type": "text", "text": text }] })
+                }
+                Err(e) => json!({
+                    "error": { "code": e.code(), "message": e.to_string() }
+                }),
+            }
+        }
+        _ => json!({
+            "error": {
+                "code": error_codes::METHOD_NOT_FOUND,
+                "message": format!("Method not found: {method}"),
+            }
+        }),
+    }
+}
+
+/// Run the stdio MCP loop wired to this server.
+///
+/// Why: Single entry point for `bin/telegram-mcp.rs`.
+/// What: Forwards every parsed `Request` to `handle_message` and wraps the
+/// JSON result back into a `Response` (or a JSON-RPC error / suppressed reply).
+/// Test: Manual — driven from Claude Code; the stdio loop itself is tested in
+/// `trusty-common`.
+pub async fn run_stdio(state: AppState) -> anyhow::Result<()> {
+    run_stdio_loop(move |req: Request| {
+        let state = state.clone();
+        async move {
+            let id = req.id.clone();
+            let raw = serde_json::to_value(&req).unwrap_or(Value::Null);
+            let resp = handle_message(state, raw).await;
+            if resp.is_null() {
+                return Response::suppressed();
+            }
+            if let Some(err) = resp.get("error") {
+                let code =
+                    err.get("code")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(error_codes::INTERNAL_ERROR as i64) as i32;
+                let message = err
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Internal error")
+                    .to_string();
+                return Response::err(id, code, message);
+            }
+            Response::ok(id, resp)
+        }
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_state() -> AppState {
+        // BaseClient::new() reads no required env vars and returns Ok, so this
+        // works in CI without any Telegram credentials.
+        let client = BaseClient::new().expect("construct base client");
+        AppState {
+            client: Arc::new(client),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn handle_message_initialize_returns_server_info() {
+        let state = make_state();
+        let req = json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} });
+        let resp = handle_message(state, req).await;
+        assert_eq!(resp["serverInfo"]["name"], "telegram-mcp");
+        assert!(resp["capabilities"]["tools"].is_object());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn handle_message_tools_list_returns_tools() {
+        let state = make_state();
+        let req = json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" });
+        let resp = handle_message(state, req).await;
+        let tools = resp["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), crate::telegram::tools::TOOL_NAMES.len());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tools_call_returns_not_implemented() {
+        let state = make_state();
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": { "name": "telegram_send_message", "arguments": { "chat_id": "123", "text": "hi" } }
+        });
+        let resp = handle_message(state, req).await;
+        assert_eq!(resp["error"]["code"], error_codes::INTERNAL_ERROR);
+        assert!(resp["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("not yet implemented"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tools_call_unknown_tool_returns_method_not_found() {
+        let state = make_state();
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": { "name": "telegram_not_a_tool", "arguments": {} }
+        });
+        let resp = handle_message(state, req).await;
+        assert_eq!(resp["error"]["code"], error_codes::METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn unknown_method_returns_error_payload() {
+        let state = make_state();
+        let req = json!({ "jsonrpc": "2.0", "id": 5, "method": "no/such/method" });
+        let resp = handle_message(state, req).await;
+        assert_eq!(resp["error"]["code"], error_codes::METHOD_NOT_FOUND);
+    }
+}

--- a/crates/trusty-channels/src/telegram/tools.rs
+++ b/crates/trusty-channels/src/telegram/tools.rs
@@ -1,0 +1,195 @@
+//! MCP `tools/list` response — JSON Schema for every planned Telegram tool.
+//!
+//! Why: Claude Code (and any MCP client) needs a machine-readable contract
+//! describing each tool's arguments so the model can fill them correctly. This
+//! is the single source of truth for the Telegram MCP surface; the dispatcher
+//! in `server` routes on the same names. Every schema here is authoritative even
+//! though the handlers are still stubs (live calls deferred, see issue #2641).
+//! What: `tool_list_response()` returns `{"tools": [{name, description,
+//! inputSchema}, ...]}`; `is_known_tool()` reports whether a name is part of the
+//! planned surface so the dispatcher can distinguish "not yet implemented" from
+//! "unknown tool". The reduced Telegram surface is send/info-only by design: a
+//! Telegram *bot* cannot read or search prior chat history via the Bot API — it
+//! can only send messages and query chat/bot metadata. Each tool's description
+//! restates that limitation so callers see it without reading source.
+//! Test: Unit tests below assert the tool count, required-field shape, name
+//! uniqueness, the history-limitation note on every description, and
+//! `is_known_tool` agreement with the registry.
+
+use serde_json::{json, Value};
+
+/// Shared clause restating the Bot API history/search limitation. Appended to
+/// every tool description so an MCP client sees the constraint inline.
+const HISTORY_LIMIT_NOTE: &str = " Note: a Telegram bot cannot read or search \
+prior chat history via the Bot API — it can only send messages and query \
+chat/bot metadata.";
+
+/// The authoritative list of planned Telegram tool names.
+///
+/// Why: Both `tool_list_response` (indirectly) and `is_known_tool` must agree
+/// on the exact surface; a single constant array prevents drift.
+/// What: The three send/info-only chat-as-tools operations planned for the
+/// native Telegram MCP (reduced scope, issue #2641).
+/// Test: `known_tools_match_registry` cross-checks this against the built list.
+pub const TOOL_NAMES: &[&str] = &[
+    "telegram_send_message",
+    "telegram_get_bot_info",
+    "telegram_get_chat",
+];
+
+/// Report whether `name` is a planned Telegram tool.
+///
+/// Why: The dispatcher returns a distinct MCP error for an unknown tool vs a
+/// known-but-unimplemented one; this predicate draws that line.
+/// What: Linear membership check against `TOOL_NAMES`.
+/// Test: `known_tools_match_registry`.
+pub fn is_known_tool(name: &str) -> bool {
+    TOOL_NAMES.contains(&name)
+}
+
+/// Assemble a single MCP tool definition.
+///
+/// Why: The `tools/list` response requires a uniform `{name, description,
+/// inputSchema}` object per tool; centralising avoids drift.
+/// What: Wraps `properties` and `required` into an object-typed input schema
+/// alongside the name and description.
+/// Test: Covered via `tool_list_response()` in `tests`.
+fn tool(name: &str, description: &str, properties: Value, required: &[&str]) -> Value {
+    json!({
+        "name": name,
+        "description": description,
+        "inputSchema": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        }
+    })
+}
+
+/// A `chat_id` string-schema fragment shared by several tools.
+fn chat_id_prop() -> Value {
+    json!({
+        "type": "string",
+        "description": "Target chat: a numeric chat ID (e.g. 123456789) or an \
+                        @channelusername.",
+    })
+}
+
+/// Build the full `tools/list` response.
+///
+/// Why: One function = one source of truth for the MCP contract.
+/// What: Returns the three planned Telegram tools with minimal-but-valid
+/// schemas; each description ends with the history-limitation note.
+/// Test: `tool_list_has_expected_count` asserts exactly three tools.
+pub fn tool_list_response() -> Value {
+    let tools = vec![
+        tool(
+            "telegram_send_message",
+            &format!(
+                "Send a text message to a Telegram chat (the bot must already be \
+                 a member/admin of the target chat).{HISTORY_LIMIT_NOTE}"
+            ),
+            json!({
+                "chat_id": chat_id_prop(),
+                "text": { "type": "string", "description": "Message text to send." },
+                "parse_mode": {
+                    "type": "string",
+                    "description": "Optional text formatting mode (e.g. MarkdownV2 or HTML).",
+                },
+                "reply_to_message_id": {
+                    "type": "integer",
+                    "description": "Optional message ID to reply to within the chat.",
+                },
+            }),
+            &["chat_id", "text"],
+        ),
+        tool(
+            "telegram_get_bot_info",
+            &format!(
+                "Fetch the authenticated bot's own identity/metadata (Bot API \
+                 getMe).{HISTORY_LIMIT_NOTE}"
+            ),
+            json!({}),
+            &[],
+        ),
+        tool(
+            "telegram_get_chat",
+            &format!(
+                "Fetch metadata for a chat the bot can see (title, type, member \
+                 counts; Bot API getChat).{HISTORY_LIMIT_NOTE}"
+            ),
+            json!({
+                "chat_id": chat_id_prop(),
+            }),
+            &["chat_id"],
+        ),
+    ];
+    json!({ "tools": tools })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn tool_list_has_expected_count() {
+        let v = tool_list_response();
+        let tools = v["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), TOOL_NAMES.len(), "expected all planned tools");
+        for t in tools {
+            assert!(t["name"].is_string(), "every tool has a name");
+            assert!(t["description"].is_string(), "every tool has a description");
+            assert_eq!(
+                t["inputSchema"]["type"], "object",
+                "every tool has an object inputSchema"
+            );
+            assert!(
+                t["inputSchema"]["required"].is_array(),
+                "every tool declares a required array"
+            );
+        }
+    }
+
+    #[test]
+    fn every_description_documents_history_limit() {
+        // The Bot-API history/search limitation must be visible on every tool
+        // description (issue #2641 acceptance criterion).
+        let v = tool_list_response();
+        for t in v["tools"].as_array().unwrap() {
+            let desc = t["description"].as_str().unwrap();
+            assert!(
+                desc.contains("cannot read or search"),
+                "tool {} must document the history limitation",
+                t["name"]
+            );
+        }
+    }
+
+    #[test]
+    fn every_tool_name_is_unique() {
+        let v = tool_list_response();
+        let mut seen = HashSet::new();
+        for t in v["tools"].as_array().unwrap() {
+            let name = t["name"].as_str().unwrap().to_string();
+            assert!(seen.insert(name.clone()), "duplicate tool: {name}");
+        }
+    }
+
+    #[test]
+    fn known_tools_match_registry() {
+        let v = tool_list_response();
+        let built: HashSet<&str> = v["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        let declared: HashSet<&str> = TOOL_NAMES.iter().copied().collect();
+        assert_eq!(built, declared, "TOOL_NAMES must match the built registry");
+        for name in TOOL_NAMES {
+            assert!(is_known_tool(name), "{name} must be a known tool");
+        }
+        assert!(!is_known_tool("telegram_not_a_tool"));
+    }
+}

--- a/crates/trusty-channels/tests/telegram_client_http.rs
+++ b/crates/trusty-channels/tests/telegram_client_http.rs
@@ -1,0 +1,321 @@
+//! Hermetic tests for the Telegram `BaseClient`: credential resolution + HTTP
+//! hardening.
+//!
+//! Why: `BaseClient` must resolve its token through the shared credential
+//! resolver (env → `.env.local` → store) and must classify Bot API responses
+//! correctly — never silently retrying an auth failure anonymously, and
+//! honouring `429` retry hints with a bounded backoff. These are exactly the
+//! behaviours issue #2641 wires, so they need coverage that runs in CI with no
+//! live Telegram token.
+//! What: the credential cases use `resolve_key_with` + a `MemoryKeyStore` fake
+//! (no filesystem, no keychain, no network); the HTTP cases point the client at
+//! a local `wiremock` server returning 200 / 401 / `ok:false` / 429. The Bot API
+//! embeds the token in the URL path (`/bot<token>/<method>`), so the mocked
+//! paths include the fixed test token.
+//! Test: this file is the test.
+
+use serial_test::serial;
+use trusty_channels::telegram::api::client::BaseClient;
+use trusty_channels::telegram::api::constants::{TELEGRAM_PROVIDER, TELEGRAM_TOKEN_ENV};
+use trusty_channels::telegram::api::error::TelegramError;
+use trusty_common::inference::credentials::{
+    env_var_for, resolve_key_with, KeyStore, MemoryKeyStore,
+};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// The fixed token every HTTP case uses; the Bot API puts it in the URL path.
+const TEST_TOKEN: &str = "123456:test-token";
+
+// ── Credential resolution (fake KeyStore — no live token) ─────────────────
+
+/// The provider identifier the client uses must resolve from the store tier
+/// when no env var is set.
+#[test]
+#[serial(telegram_credential_env)]
+fn telegram_provider_resolves_from_store() {
+    // SAFETY (edition 2021): set/remove_var is safe; #[serial] prevents races
+    // with the env-setting tests in the same group.
+    std::env::remove_var(TELEGRAM_TOKEN_ENV);
+    let store = MemoryKeyStore::new();
+    store.set(TELEGRAM_PROVIDER, "fake-store-token").unwrap();
+    // Fake store injected directly — no process env, no filesystem, no network.
+    assert_eq!(
+        resolve_key_with(TELEGRAM_PROVIDER, &store),
+        Some("fake-store-token".to_string())
+    );
+}
+
+/// The Telegram provider is registered in the resolver's env-var map, so the
+/// process-env / `.env.local` tier applies (not just the store tier).
+#[test]
+fn telegram_env_var_is_registered() {
+    assert_eq!(env_var_for(TELEGRAM_PROVIDER), Some(TELEGRAM_TOKEN_ENV));
+}
+
+/// The env tier wins over the store tier for the Telegram provider — proving
+/// the documented precedence holds for a non-inference token too.
+#[test]
+#[serial(telegram_credential_env)]
+fn env_token_beats_store() {
+    // SAFETY (edition 2021): set_var is safe; #[serial] prevents env races.
+    std::env::set_var(TELEGRAM_TOKEN_ENV, "from-env-token");
+    let store = MemoryKeyStore::new();
+    store.set(TELEGRAM_PROVIDER, "from-store-token").unwrap();
+    assert_eq!(
+        resolve_key_with(TELEGRAM_PROVIDER, &store),
+        Some("from-env-token".to_string())
+    );
+    std::env::remove_var(TELEGRAM_TOKEN_ENV);
+}
+
+/// `BaseClient::new()` picks up the token via the real resolver's env tier.
+#[test]
+#[serial(telegram_credential_env)]
+fn base_client_new_resolves_env_token() {
+    std::env::set_var(TELEGRAM_TOKEN_ENV, "from-env-token");
+    let client = BaseClient::new().expect("construct client");
+    assert!(
+        client.has_token(),
+        "token should resolve from TELEGRAM_BOT_TOKEN"
+    );
+    std::env::remove_var(TELEGRAM_TOKEN_ENV);
+}
+
+// ── HTTP hardening (wiremock — no live Telegram) ──────────────────────────
+
+/// A client wired to the mock server with a fixed token.
+async fn client_for(server: &MockServer) -> BaseClient {
+    BaseClient::with_endpoint(server.uri(), Some(TEST_TOKEN.to_string())).expect("construct client")
+}
+
+/// The URL path the mock must match for `method` (token is in the path).
+fn method_path(m: &str) -> String {
+    format!("/bot{TEST_TOKEN}/{m}")
+}
+
+#[tokio::test]
+async fn send_ok_returns_envelope() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(method_path("sendMessage")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "result": { "message_id": 42 },
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server).await;
+    let value = client
+        .call_method(
+            "sendMessage",
+            &serde_json::json!({"chat_id": "123", "text": "hi"}),
+        )
+        .await
+        .expect("ok response");
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["result"]["message_id"], 42);
+}
+
+#[tokio::test]
+async fn auth_401_is_typed_error_no_retry() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(method_path("getMe")))
+        // expect exactly one hit — an auth failure must NOT be retried.
+        .respond_with(ResponseTemplate::new(401))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server).await;
+    let err = client
+        .call_method("getMe", &serde_json::json!({}))
+        .await
+        .expect_err("401 should error");
+    match err {
+        TelegramError::Auth { status, .. } => assert_eq!(status, 401),
+        other => panic!("expected Auth, got {other:?}"),
+    }
+    // `expect(1)` is verified on drop: no anonymous retry occurred.
+}
+
+#[tokio::test]
+async fn auth_ok_false_maps_to_auth_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(method_path("getMe")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": false,
+            "error_code": 401,
+            "description": "Unauthorized",
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server).await;
+    let err = client
+        .call_method("getMe", &serde_json::json!({}))
+        .await
+        .expect_err("error_code 401 should error");
+    match err {
+        TelegramError::Auth { reason, .. } => assert_eq!(reason, "Unauthorized"),
+        other => panic!("expected Auth, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn api_ok_false_maps_to_api_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(method_path("getChat")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": false,
+            "error_code": 400,
+            "description": "Bad Request: chat not found",
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server).await;
+    let err = client
+        .call_method("getChat", &serde_json::json!({"chat_id": "nope"}))
+        .await
+        .expect_err("chat not found should error");
+    match err {
+        TelegramError::Api(desc) => assert_eq!(desc, "Bad Request: chat not found"),
+        other => panic!("expected Api, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rate_limit_retries_then_succeeds() {
+    let server = MockServer::start().await;
+    // Fallback 200 (mounted first → lower precedence).
+    Mock::given(method("POST"))
+        .and(path(method_path("sendMessage")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .mount(&server)
+        .await;
+    // One 429 with a body retry_after: 0 (mounted last → matched first, once).
+    Mock::given(method("POST"))
+        .and(path(method_path("sendMessage")))
+        .respond_with(ResponseTemplate::new(429).set_body_json(serde_json::json!({
+            "ok": false,
+            "error_code": 429,
+            "description": "Too Many Requests",
+            "parameters": { "retry_after": 0 },
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server).await;
+    let value = client
+        .call_method("sendMessage", &serde_json::json!({}))
+        .await
+        .expect("should succeed after honoring retry_after");
+    assert_eq!(value["ok"], true);
+}
+
+#[tokio::test]
+async fn rate_limit_exhausted_returns_typed_error() {
+    let server = MockServer::start().await;
+    // Persistent 429 (retry_after: 0 keeps the test fast).
+    Mock::given(method("POST"))
+        .and(path(method_path("sendMessage")))
+        .respond_with(ResponseTemplate::new(429).set_body_json(serde_json::json!({
+            "ok": false,
+            "error_code": 429,
+            "description": "Too Many Requests",
+            "parameters": { "retry_after": 0 },
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server).await;
+    let err = client
+        .call_method("sendMessage", &serde_json::json!({}))
+        .await
+        .expect_err("persistent 429 should error");
+    match err {
+        TelegramError::RateLimited { retries, .. } => assert_eq!(retries, 3),
+        other => panic!("expected RateLimited, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn missing_token_errors_before_network() {
+    // No token, and a server that would fail the test if ever hit.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let client = BaseClient::with_endpoint(server.uri(), None).expect("construct client");
+    let err = client
+        .call_method("sendMessage", &serde_json::json!({}))
+        .await
+        .expect_err("no token should error");
+    assert!(matches!(err, TelegramError::MissingToken));
+}
+
+/// Regression test for the HIGH finding: the Bot API puts the token in the
+/// URL PATH (`/bot<token>/<method>`), and `reqwest::Error`'s `Display` *and*
+/// derived `Debug` both render the attached request URL verbatim (reqwest 0.12
+/// `with_url`). If `TelegramError::Transport` ever goes back to holding (or
+/// `#[from]`-converting) the raw `reqwest::Error`, a transport-class failure
+/// would leak the live bot token into any log line or `?`-propagated error
+/// message. This forces a genuine connect-class transport error against a
+/// token-bearing URL and asserts the sentinel token appears in NEITHER
+/// `Display` NOR `Debug` of the resulting error.
+#[tokio::test]
+async fn transport_error_display_and_debug_never_contain_the_bot_token() {
+    // Bind an ephemeral local port, then immediately drop the listener so
+    // nothing is listening — the next connect attempt fails fast with
+    // "connection refused" (a genuine transport-class reqwest::Error), with no
+    // live network dependency and no flakiness.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local addr");
+    drop(listener);
+
+    let sentinel_token = "123456:SECRET-SENTINEL-TOKEN";
+    let client =
+        BaseClient::with_endpoint(format!("http://{addr}"), Some(sentinel_token.to_string()))
+            .expect("construct client");
+
+    let err = client
+        .call_method("sendMessage", &serde_json::json!({}))
+        .await
+        .expect_err("connecting to a closed local port must fail");
+
+    assert!(
+        matches!(&err, TelegramError::Transport { .. }),
+        "expected Transport, got {err:?}"
+    );
+
+    let display = format!("{err}");
+    let debug = format!("{err:?}");
+    assert!(
+        !display.contains(sentinel_token),
+        "Display leaked the bot token: {display}"
+    );
+    assert!(
+        !debug.contains(sentinel_token),
+        "Debug leaked the bot token: {debug}"
+    );
+    // Broader signal: neither rendering should carry the request's host:port
+    // either — a hint that no raw request/URL context leaked through at all.
+    let addr_str = addr.to_string();
+    assert!(
+        !display.contains(&addr_str),
+        "Display leaked the request URL: {display}"
+    );
+    assert!(
+        !debug.contains(&addr_str),
+        "Debug leaked the request URL: {debug}"
+    );
+}

--- a/crates/trusty-common/src/inference/credentials/resolver.rs
+++ b/crates/trusty-common/src/inference/credentials/resolver.rs
@@ -50,6 +50,7 @@ pub fn env_var_for(provider: &str) -> Option<&'static str> {
         "together" => Some("TOGETHER_API_KEY"),
         "atlascloud" => Some("ATLASCLOUD_API_KEY"),
         "slack" => Some("SLACK_BOT_TOKEN"),
+        "telegram" => Some("TELEGRAM_BOT_TOKEN"),
         _ => None,
     }
 }
@@ -145,6 +146,8 @@ mod tests {
         // Non-inference token: the native Slack MCP server (issue #2638).
         assert_eq!(env_var_for("slack"), Some("SLACK_BOT_TOKEN"));
         assert_eq!(env_var_for("Slack"), Some("SLACK_BOT_TOKEN"));
+        // Non-inference token: the native Telegram MCP server (issue #2641).
+        assert_eq!(env_var_for("telegram"), Some("TELEGRAM_BOT_TOKEN"));
     }
 
     /// Why: an unmapped provider must not panic or synthesise a guess.


### PR DESCRIPTION
## Summary

Adds a **Telegram module** to the unified `trusty-channels` crate, mirroring the Slack module scaffold from #2637/#2638. Per the epic #2636 topology decision (ADR-0014), Telegram is a **module inside `trusty-channels`, NOT a standalone `trusty-telegram` crate** — one crate, one module per channel, sharing MCP framing, HTTP-client hardening, and credential wiring.

Stacked on **#2706** (`feat-2638-slack-auth`), which is where the `trusty-channels` crate lives. PR base is `feat-2638-slack-auth`, not `main`.

Closes #2641. Part of epic #2636.

## What's included

**New `crates/trusty-channels/src/telegram/` module** (mirrors `slack/`):
- `api/constants.rs` — Bot API host root, provider key (`telegram` → `TELEGRAM_BOT_TOKEN`), bounded-backoff tunables.
- `api/error.rs` — typed `thiserror` `TelegramError` (MissingToken / Auth / RateLimited / Api / UnexpectedStatus / Transport / Decode).
- `api/client.rs` — `BaseClient` HTTP wrapper. Unlike Slack, the Bot API carries the token **in the URL path** (`/bot<token>/<method>`), not a bearer header. Hardened request path: HTTP 401 **and** body `error_code:401` → `Auth` (never a silent anonymous retry); `429` honoured with a bounded backoff, preferring the idiomatic body hint `parameters.retry_after` over the `Retry-After` header; `ok:false` envelopes → `Api(description)`.
- `server.rs` — JSON-RPC stdio dispatch (`initialize` / `tools/list` / `tools/call`), notifications suppressed. Every `tools/call` returns a typed `NotImplemented` error (not `unimplemented!()`) per the issue's reduced scope.
- `tools.rs` — authoritative `tools/list` registry for the **send/info-only** surface: `telegram_send_message`, `telegram_get_bot_info`, `telegram_get_chat`. Each tool description restates the Bot-API constraint inline: *a Telegram bot cannot read or search prior chat history — it can only send messages and query chat/bot metadata* (issue acceptance criterion).

**New `src/bin/telegram-mcp.rs`** — stdio MCP binary (mirrors `slack-mcp.rs`), binary name `telegram-mcp`.

**Auth wiring** — one additive arm in `trusty_common::inference::credentials::resolver::env_var_for` (`"telegram"` → `TELEGRAM_BOT_TOKEN`), mirroring the existing `"slack"` arm, so the token resolves through the shared 3-tier resolver (process env → `.env.local` → secure store).

**Shared-file edits kept minimal:** the only shared edits are the single additive `pub mod telegram;` line in `src/lib.rs`, one `[[bin]]` block in `Cargo.toml`, and the one resolver arm (+ one test assertion) in `trusty-common`. All other work is confined to the new `telegram/` module + its own binary + its own integration test, to avoid collisions with the parallel Slack-module work in #2639.

## Tests (hermetic, no live token)

- Unit: `tools/list` schema/count, history-limitation note on every description, dispatch (`initialize` / `tools/list` / not-implemented / unknown-tool / unknown-method), retry-after resolution, constants.
- Integration (`tests/telegram_client_http.rs`): credential resolution via a fake `MemoryKeyStore` + `wiremock` HTTP cases (200 / 401 / `ok:false` / 429-retry-then-succeed / 429-exhausted / missing-token-before-network).

Full workspace gate green: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `bash scripts/check_line_cap.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)