### PR TITLE
fix(trusty-search): deterministic no-starvation probe test replaces wall-clock deadline

### DIFF
--- a/crates/trusty-search/src/service/warm_boot/probe_tests.rs
+++ b/crates/trusty-search/src/service/warm_boot/probe_tests.rs
@@ -292,56 +292,111 @@ fn probe_all_volumes_parallel_bounded_time() {
 
 // ── multi-volume starvation regression ───────────────────────────────────────
 
-/// Helper: run the shared-channel collection loop with injected per-volume
-/// delays rather than real filesystem probes.
+/// Handle that keeps gated "slow" probe threads blocked until dropped.
+///
+/// Why: the slow volumes in the no-starvation regression must DETERMINISTICALLY
+/// miss the collection deadline regardless of machine load. Rather than racing a
+/// `std::thread::sleep` against a wall-clock deadline (the load-sensitive design
+/// that flaked in issue #2703), each slow thread blocks on its own gate channel
+/// and is released only after the collector has returned — so it can never
+/// report before the deadline no matter how contended the host is.
+/// What: owns the sender half of each slow thread's gate. Dropping it closes the
+/// gates, unblocking the slow threads for clean shutdown (they then exit without
+/// reporting, since the collector's receiver is already gone).
+/// Test: `probe_all_volumes_multi_volume_no_fast_starvation`.
+struct SlowGate(#[allow(dead_code)] Vec<std::sync::mpsc::Sender<()>>);
+
+/// Helper: run `probe_all_volumes`'s shared-channel collection loop with
+/// DETERMINISTIC (load-immune) volume completion instead of timed sleeps.
 ///
 /// Why: `probe_all_volumes` calls `std::fs::metadata`, which returns ENOENT
 /// instantly for non-existent paths — a genuinely slow probe cannot be created
-/// without special filesystem support.  This helper replicates the shared-
-/// channel design of `probe_all_volumes` but lets the test inject an artificial
-/// `probe_delay` per volume, enabling a deterministic starvation regression.
+/// without special filesystem support. The previous helper approximated one with
+/// `std::thread::sleep` and the test asserted a `< 2 × deadline` wall-clock
+/// bound; both the sleep-vs-deadline race and the elapsed-time assertion were
+/// sensitive to concurrent build/test load (issue #2703: observed 116–137 ms
+/// against a 100 ms bound). This helper removes ALL timing races:
+///   - FAST volumes report immediately and are JOINED before the collection
+///     deadline starts, so their results are guaranteed queued in the shared
+///     channel — no reliance on a short sleep landing inside the deadline.
+///   - SLOW volumes block on a per-volume gate the caller controls; they are
+///     released only AFTER the collector returns, so they DETERMINISTICALLY miss
+///     the deadline. The collector's own wall-clock deadline is what fires,
+///     exactly as in production.
 ///
-/// What: given `(vol_key, sample_path, probe_delay)` triples, spawns one bare
-/// OS thread per entry that sleeps for `probe_delay` then sends into a shared
-/// `mpsc::channel`, identical to `probe_all_volumes`.  Increments
-/// `PROBE_THREAD_FAILURES` once per timed-out volume (same invariant).
+/// `probe_all_volumes` is pure `std::thread` + `mpsc` (no tokio timers), so a
+/// `tokio::time::pause()` virtual clock cannot drive it; gate-based
+/// synchronization is the load-immune equivalent.
+///
+/// What: spawns `fast.len()` threads that send their key immediately (joined
+/// before the loop), and `slow.len()` threads that block on a dedicated gate
+/// channel. Runs the identical shared-`end` / break-on-`Err` collection loop as
+/// `probe_all_volumes` Phase 2, then marks every unreported volume inaccessible
+/// (incrementing `PROBE_THREAD_FAILURES` once each — same invariant). Returns
+/// `(inaccessible_set, gate)`; dropping the `SlowGate` releases the slow threads.
 ///
 /// Test: `probe_all_volumes_multi_volume_no_fast_starvation`.
-fn probe_with_injected_delays(
-    entries: Vec<(PathBuf, PathBuf, Duration)>,
+fn probe_with_gated_slow(
+    fast: &[PathBuf],
+    slow: &[PathBuf],
     deadline: Duration,
-) -> std::collections::HashSet<PathBuf> {
+) -> (std::collections::HashSet<PathBuf>, SlowGate) {
     use std::collections::HashSet;
     use std::sync::mpsc;
     use std::time::Instant;
 
-    if entries.is_empty() {
-        return HashSet::new();
+    let n = fast.len() + slow.len();
+    if n == 0 {
+        return (HashSet::new(), SlowGate(Vec::new()));
     }
 
-    let n = entries.len();
-    let end = Instant::now() + deadline;
     let (tx, rx) = mpsc::channel::<PathBuf>();
-
-    // Track all expected keys and their sample paths.
     let mut all_keys: HashSet<PathBuf> = HashSet::with_capacity(n);
-    let mut key_to_sample: std::collections::HashMap<PathBuf, PathBuf> =
-        std::collections::HashMap::with_capacity(n);
 
-    for (vol_key, sample_path, probe_delay) in entries {
-        all_keys.insert(vol_key.clone());
-        key_to_sample.insert(vol_key.clone(), sample_path);
+    // FAST volumes: spawn threads that send immediately, and JOIN them so their
+    // results are queued in the shared channel BEFORE the collection deadline
+    // starts. This exercises concurrent arrival while removing the
+    // fast-volume-vs-deadline race entirely.
+    let mut fast_handles = Vec::with_capacity(fast.len());
+    for key in fast {
+        all_keys.insert(key.clone());
         let tx = tx.clone();
-        let key = vol_key;
+        let key = key.clone();
+        fast_handles.push(std::thread::spawn(move || {
+            let _ = tx.send(key);
+        }));
+    }
+    for h in fast_handles {
+        let _ = h.join();
+    }
+
+    // SLOW volumes: each blocks on its own gate until the caller drops the
+    // returned `SlowGate`. Because that happens only after the collector returns,
+    // a slow volume can never report before the deadline — no timing race.
+    let mut gates: Vec<mpsc::Sender<()>> = Vec::with_capacity(slow.len());
+    for key in slow {
+        all_keys.insert(key.clone());
+        let (gate_tx, gate_rx) = mpsc::channel::<()>();
+        gates.push(gate_tx);
+        let tx = tx.clone();
+        let key = key.clone();
         let _ = std::thread::spawn(move || {
-            std::thread::sleep(probe_delay);
+            // Block until the gate closes; only then (well past the deadline) is
+            // any report attempted — and by then the receiver is gone.
+            let _ = gate_rx.recv();
             let _ = tx.send(key);
         });
     }
-    // Drop our sender clone so the channel closes when all threads finish.
+    // Drop our own tx clone. The slow threads still hold theirs, so the channel
+    // stays open and `recv_timeout` yields `Timeout` (not `Disconnected`) when
+    // the deadline fires — matching production `probe_all_volumes`.
     drop(tx);
 
-    // Collection loop — identical structure to probe_all_volumes Phase 2.
+    // Collection loop — identical structure to probe_all_volumes Phase 2: a
+    // single shared `end`, breaking on the FIRST timeout. This single shared
+    // deadline is what bounds total wait at ONE deadline regardless of how many
+    // volumes never report.
+    let end = Instant::now() + deadline;
     let mut reported: HashSet<PathBuf> = HashSet::with_capacity(n);
     loop {
         if reported.len() == n {
@@ -356,34 +411,45 @@ fn probe_with_injected_delays(
         }
     }
 
-    // Mark unreported volumes as inaccessible.
+    // Every unreported volume is inaccessible; increment the failure counter once
+    // each (same invariant as probe_all_volumes).
     let mut inaccessible: HashSet<PathBuf> = HashSet::new();
     for vol_key in &all_keys {
         if reported.contains(vol_key) {
             continue;
         }
-        let _sample = key_to_sample
-            .get(vol_key)
-            .map(|p| p.as_path())
-            .unwrap_or(vol_key.as_path());
         PROBE_THREAD_FAILURES.fetch_add(1, Ordering::Relaxed);
         inaccessible.insert(vol_key.clone());
     }
-    inaccessible
+
+    (inaccessible, SlowGate(gates))
 }
 
-/// Why (review #727 pass-3 HIGH — starvation regression): with the
-/// per-channel sequential design, if volume A's `recv_timeout` consumed the
-/// full budget, every subsequent volume got `Duration::ZERO` and was wrongly
-/// classified as inaccessible even though its probe thread had already
-/// finished.  This test proves the shared-channel design eliminates that bug.
+/// Why (review #727 pass-3 HIGH — starvation regression, made load-immune in
+/// issue #2703): with the per-channel sequential design, if a slow volume's
+/// `recv_timeout` consumed the full budget, every subsequent volume got
+/// `Duration::ZERO` and was wrongly classified as inaccessible even though its
+/// probe thread had already finished. This test proves the shared-channel design
+/// eliminates that starvation. The PROTECTED PROPERTY is fairness: a fast volume
+/// that has completed is never classified inaccessible merely because slow
+/// volumes are concurrently exhausting the deadline — NOT absolute speed.
 ///
-/// What: three volumes — one slow (sleeps 200 ms past the deadline) and two
-/// fast (complete in ≤10 ms).  Deadline is 50 ms.  Assert:
-///   - only the slow volume is in the inaccessible set,
-///   - the two fast volumes are NOT in the inaccessible set (not starved),
-///   - total elapsed < 2 × deadline (≈100 ms), proving ONE-deadline behaviour,
-///   - `PROBE_THREAD_FAILURES` increased by exactly 1 (one blocked volume).
+/// What: two FAST volumes (report immediately, joined before the deadline) and
+/// THREE SLOW volumes (gated — never report before the deadline). Deadline 50 ms.
+/// Assert, all load-IMMUNE (they depend on WHICH volumes reported — deterministic
+/// via the gate — not on wall-clock elapsed):
+///   - no fast volume is inaccessible (not starved);
+///   - every slow volume is inaccessible;
+///   - exactly the slow volumes are inaccessible;
+///   - `PROBE_THREAD_FAILURES` increased by exactly the slow-volume count — with
+///     THREE unreported volumes handled in a SINGLE deadline window, proving the
+///     shared-deadline (ONE-deadline-not-N) invariant that the earlier flaky
+///     `elapsed < 2 × deadline` upper bound was standing in for;
+///   - a load-IMMUNE LOWER bound (`elapsed >= deadline / 2`): the collector must
+///     actually honor the deadline for unreported volumes rather than giving up
+///     early. Concurrent load can only push elapsed HIGHER, never below the
+///     deadline, so unlike the removed upper bound this can never flake under
+///     load (issue #2703).
 ///
 /// Note: `serial` because this test reads/writes `PROBE_THREAD_FAILURES`.
 /// Test: this test.
@@ -392,63 +458,69 @@ fn probe_with_injected_delays(
 fn probe_all_volumes_multi_volume_no_fast_starvation() {
     let deadline = Duration::from_millis(50);
 
-    // Probe delays: fast volumes finish well inside the deadline; slow volume
-    // sleeps 5× the deadline so it never reports in time.
-    let fast_delay = Duration::from_millis(5);
-    let slow_delay = Duration::from_millis(250); // >> 50 ms deadline
-
-    let fast_vol_a = PathBuf::from("/tmp/trusty-723-fast-a");
-    let fast_vol_b = PathBuf::from("/tmp/trusty-723-fast-b");
-    let slow_vol = PathBuf::from("/tmp/trusty-723-slow");
-
-    let entries = vec![
-        (fast_vol_a.clone(), fast_vol_a.clone(), fast_delay),
-        (fast_vol_b.clone(), fast_vol_b.clone(), fast_delay),
-        (slow_vol.clone(), slow_vol.clone(), slow_delay),
+    let fast = vec![
+        PathBuf::from("/tmp/trusty-723-fast-a"),
+        PathBuf::from("/tmp/trusty-723-fast-b"),
+    ];
+    // Multiple slow volumes prove N unreported volumes are classified in ONE
+    // shared-deadline window, not one deadline each.
+    let slow = vec![
+        PathBuf::from("/tmp/trusty-723-slow-a"),
+        PathBuf::from("/tmp/trusty-723-slow-b"),
+        PathBuf::from("/tmp/trusty-723-slow-c"),
     ];
 
-    let before_leaked = PROBE_THREAD_FAILURES.load(Ordering::Relaxed);
+    let before_failures = PROBE_THREAD_FAILURES.load(Ordering::Relaxed);
     let start = std::time::Instant::now();
 
-    let inaccessible = probe_with_injected_delays(entries, deadline);
+    let (inaccessible, gate) = probe_with_gated_slow(&fast, &slow, deadline);
 
     let elapsed = start.elapsed();
-    let after_leaked = PROBE_THREAD_FAILURES.load(Ordering::Relaxed);
+    // Release the gated slow threads now that collection is done (clean shutdown).
+    drop(gate);
 
-    // Only the slow volume should be inaccessible.
-    assert!(
-        inaccessible.contains(&slow_vol),
-        "slow volume must be inaccessible; inaccessible={inaccessible:?}"
-    );
-    assert!(
-        !inaccessible.contains(&fast_vol_a),
-        "fast volume A must NOT be inaccessible (starvation bug); inaccessible={inaccessible:?}"
-    );
-    assert!(
-        !inaccessible.contains(&fast_vol_b),
-        "fast volume B must NOT be inaccessible (starvation bug); inaccessible={inaccessible:?}"
-    );
+    let after_failures = PROBE_THREAD_FAILURES.load(Ordering::Relaxed);
+
+    // ── Protected property: no starvation. Fast volumes that completed are never
+    //    classified inaccessible just because slow volumes are exhausting the
+    //    deadline concurrently. Deterministic via the gate — load-immune.
+    for f in &fast {
+        assert!(
+            !inaccessible.contains(f),
+            "fast volume {f:?} must NOT be starved; inaccessible={inaccessible:?}"
+        );
+    }
+    for s in &slow {
+        assert!(
+            inaccessible.contains(s),
+            "slow (gated) volume {s:?} must be inaccessible; inaccessible={inaccessible:?}"
+        );
+    }
     assert_eq!(
         inaccessible.len(),
-        1,
-        "exactly 1 volume must be inaccessible; got={inaccessible:?}"
+        slow.len(),
+        "exactly the slow volumes must be inaccessible; got={inaccessible:?}"
     );
 
-    // Total elapsed must be bounded at ≈ONE deadline, not N×deadline.
-    // We allow 2× deadline (100 ms) as a generous upper bound.
-    let upper_bound = deadline * 2;
-    assert!(
-        elapsed < upper_bound,
-        "total elapsed {elapsed:?} must be < 2× deadline {upper_bound:?} \
-         (shared-channel should NOT stall for each volume sequentially)"
-    );
-
-    // PROBE_THREAD_FAILURES counter must increment by exactly 1 (one blocked volume).
+    // ── One-deadline invariant: every unreported volume increments the counter
+    //    exactly once. THREE unreported volumes handled in a single deadline
+    //    window is the shared-deadline property (structurally: the collector
+    //    loops on a single shared `end` and breaks on the first timeout).
     assert_eq!(
-        after_leaked,
-        before_leaked + 1,
-        "PROBE_THREAD_FAILURES must increase by exactly 1 for the one blocked volume; \
-         before={before_leaked} after={after_leaked}"
+        after_failures,
+        before_failures + slow.len(),
+        "PROBE_THREAD_FAILURES must increase by exactly the slow-volume count; \
+         before={before_failures} after={after_failures}"
+    );
+
+    // ── Load-IMMUNE lower bound: the collector must actually wait ~one deadline
+    //    for the unreported volumes rather than giving up early. Load can only
+    //    raise elapsed, never lower it below the deadline, so this replaces the
+    //    old load-SENSITIVE `elapsed < 2 × deadline` upper bound (issue #2703).
+    assert!(
+        elapsed >= deadline / 2,
+        "collector must honor the shared deadline for unreported volumes; \
+         elapsed={elapsed:?} deadline={deadline:?}"
     );
 }
 

--- a/crates/trusty-search/src/service/warm_boot/probe_tests.rs
+++ b/crates/trusty-search/src/service/warm_boot/probe_tests.rs
@@ -435,28 +435,57 @@ fn probe_with_gated_slow(
 /// volumes are concurrently exhausting the deadline — NOT absolute speed.
 ///
 /// What: two FAST volumes (report immediately, joined before the deadline) and
-/// THREE SLOW volumes (gated — never report before the deadline). Deadline 50 ms.
-/// Assert, all load-IMMUNE (they depend on WHICH volumes reported — deterministic
-/// via the gate — not on wall-clock elapsed):
-///   - no fast volume is inaccessible (not starved);
-///   - every slow volume is inaccessible;
-///   - exactly the slow volumes are inaccessible;
-///   - `PROBE_THREAD_FAILURES` increased by exactly the slow-volume count — with
-///     THREE unreported volumes handled in a SINGLE deadline window, proving the
-///     shared-deadline (ONE-deadline-not-N) invariant that the earlier flaky
-///     `elapsed < 2 × deadline` upper bound was standing in for;
-///   - a load-IMMUNE LOWER bound (`elapsed >= deadline / 2`): the collector must
-///     actually honor the deadline for unreported volumes rather than giving up
-///     early. Concurrent load can only push elapsed HIGHER, never below the
-///     deadline, so unlike the removed upper bound this can never flake under
-///     load (issue #2703).
+/// THREE SLOW volumes (gated — never report before the deadline). Base deadline
+/// 150 ms (see the rationale comment at the `deadline` binding in the test body
+/// for why 150 ms rather than the originally-flaky 50 ms). Assert:
+///   - no fast volume is inaccessible (not starved) — deterministic via the gate,
+///     load-IMMUNE;
+///   - every slow volume is inaccessible — deterministic via the gate, load-IMMUNE;
+///   - exactly the slow volumes are inaccessible — deterministic, load-IMMUNE;
+///   - `PROBE_THREAD_FAILURES` increased by exactly the slow-volume count —
+///     deterministic, load-IMMUNE, but by itself does NOT discriminate a
+///     one-deadline design from an N-sequential-deadlines regression: both
+///     eventually count all 3 slow volumes as failures, they just take different
+///     WALL-CLOCK TIME to get there — which is exactly what the two elapsed-time
+///     bounds below check;
+///   - a LOWER bound (`elapsed >= deadline / 2`, i.e. >= 75 ms): the collector
+///     must actually honor the deadline for unreported volumes rather than
+///     giving up early. Concurrent load can only push elapsed HIGHER, never
+///     below the deadline, so this bound alone can never flake under load;
+///   - an UPPER bound (`elapsed < deadline * slow.len() as u32`, i.e. < 450 ms):
+///     the assertion that actually DISCRIMINATES the shared-deadline design from
+///     a reintroduced N-sequential-deadlines regression. A one-shared-deadline
+///     collector (the correct design) waits ≈1×deadline (≈150 ms) regardless of
+///     how many volumes are unreported, so 450 ms leaves ample scheduler-jitter
+///     margin (≈3×). A regression to the old per-channel *sequential* design
+///     would instead wait ≈N×deadline = 3×150 ms = 450 ms or more for the 3 slow
+///     volumes — this bound catches that because a genuine regression meets or
+///     exceeds the very threshold the one-deadline design comfortably clears.
+///     Scaling the bound by `slow.len()` (not a fixed constant) is what keeps it
+///     load-tolerant without being defeated by adding more slow volumes: the
+///     original flaky bound was a fixed `2 × deadline` sized for N=1 at a 50 ms
+///     base deadline (100 ms bound, issue #2703: 137 ms observed); even a
+///     deadline-scaled `1 × deadline × N` bound at the same 50 ms base deadline
+///     (150 ms) still flaked under mere default-test-harness parallelism
+///     (152-180 ms observed, no external load) — the 150 ms base deadline
+///     widens absolute headroom while preserving the same discriminating
+///     formula.
 ///
 /// Note: `serial` because this test reads/writes `PROBE_THREAD_FAILURES`.
 /// Test: this test.
 #[test]
 #[serial_test::serial]
 fn probe_all_volumes_multi_volume_no_fast_starvation() {
-    let deadline = Duration::from_millis(50);
+    // 150 ms (not 50 ms): empirically, even default-parallelism test-harness
+    // contention alone (other tests' threads competing for CPU in the same
+    // binary run, no external load) pushed a correct one-shared-deadline
+    // collector's elapsed time past a 150 ms upper bound derived from a 50 ms
+    // base deadline (observed 152-180 ms in 50 repeated runs). Scaling the base
+    // deadline to 150 ms keeps the SAME discriminating formula
+    // (`deadline * slow.len()`) but gives ample absolute headroom over realistic
+    // scheduling jitter while a genuine N-sequential-deadlines regression would
+    // still be caught at ~3x this deadline (450 ms).
+    let deadline = Duration::from_millis(150);
 
     let fast = vec![
         PathBuf::from("/tmp/trusty-723-fast-a"),
@@ -502,10 +531,12 @@ fn probe_all_volumes_multi_volume_no_fast_starvation() {
         "exactly the slow volumes must be inaccessible; got={inaccessible:?}"
     );
 
-    // ── One-deadline invariant: every unreported volume increments the counter
-    //    exactly once. THREE unreported volumes handled in a single deadline
-    //    window is the shared-deadline property (structurally: the collector
-    //    loops on a single shared `end` and breaks on the first timeout).
+    // ── Failure-count check: every unreported volume increments the counter
+    //    exactly once. This alone does NOT distinguish a one-shared-deadline
+    //    collector from a reintroduced N-sequential-deadlines regression — both
+    //    eventually count all 3 slow volumes as failures. Discriminating between
+    //    the two designs is what the upper-bound elapsed-time assertion below is
+    //    for.
     assert_eq!(
         after_failures,
         before_failures + slow.len(),
@@ -515,12 +546,29 @@ fn probe_all_volumes_multi_volume_no_fast_starvation() {
 
     // ── Load-IMMUNE lower bound: the collector must actually wait ~one deadline
     //    for the unreported volumes rather than giving up early. Load can only
-    //    raise elapsed, never lower it below the deadline, so this replaces the
-    //    old load-SENSITIVE `elapsed < 2 × deadline` upper bound (issue #2703).
+    //    raise elapsed, never lower it below the deadline, so this bound alone
+    //    can never flake under load.
     assert!(
         elapsed >= deadline / 2,
         "collector must honor the shared deadline for unreported volumes; \
          elapsed={elapsed:?} deadline={deadline:?}"
+    );
+
+    // ── Discriminating, load-tolerant upper bound: this is what actually proves
+    //    the shared-deadline (ONE-deadline-not-N) invariant. A one-shared-deadline
+    //    collector waits ≈1×deadline (≈50 ms) for the 3 slow volumes regardless of
+    //    N; a regression to the old per-channel *sequential* design would instead
+    //    wait ≈N×deadline (3×50 ms = 150 ms) or more. Scaling by `slow.len()`
+    //    (rather than a fixed constant sized for N=1, which is what flaked under
+    //    load in issue #2703 at 137 ms vs a 100 ms bound) gives a regression-catch
+    //    threshold with ample scheduler-jitter margin (≈3× the expected ≈50 ms).
+    let upper_bound = deadline * (slow.len() as u32);
+    assert!(
+        elapsed < upper_bound,
+        "total elapsed {elapsed:?} must be < {upper_bound:?} (deadline × slow-volume \
+         count) — a one-shared-deadline collector waits ≈1×deadline regardless of N; \
+         elapsed at or above N×deadline indicates a regression to per-volume \
+         sequential deadlines"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #2703 — flaky test `service::warm_boot::probe::tests::probe_all_volumes_multi_volume_no_fast_starvation` in trusty-search.

### Protected property

The test exercises `probe_all_volumes`'s shared-channel collection design (review #727 pass-3 HIGH fix). The property under test is **fairness / no-starvation**: a fast volume that has already reported must never be classified inaccessible merely because a slow (or blocked) volume is concurrently exhausting the shared deadline. It is explicitly **not** a claim about absolute wall-clock speed.

The old test conflated the property with a wall-clock stopwatch: it asserted `elapsed < 2 × deadline` (100 ms for a 50 ms deadline) around a `std::thread::sleep`-based slow-volume simulation. Under concurrent build/test load, scheduling delay alone (no bug) pushed elapsed past 100 ms — reproduced locally on the FIRST run pre-fix at 137 ms (see below), consistent with the three CI occurrences cited in the issue (116–123 ms).

### Approach chosen: (b) assert the property, not the wall-clock

Preference order per the task brief:
- **(a) virtual clock (`tokio::time::pause`/`advance`)** — ruled out. `probe_all_volumes` is pure `std::thread::spawn` + `std::sync::mpsc` (confirmed via `grep -rn "async\|tokio" .../probe.rs` — no hits besides doc-comment prose). There is no tokio timer driving these delays for `tokio::time::pause()` to intercept; the underlying probe primitive is deliberately a bare OS thread (so a frozen syscall never consumes a tokio blocking-pool slot), so this can't be converted without changing production code.
- **(b) assert the property via synchronization, not elapsed time** — **chosen**. Replaced the `std::thread::sleep`-based "slow" volume simulation with a **gate** (`std::sync::mpsc` rendezvous channel) that blocks slow-volume threads until the test explicitly releases them *after* the collector has already returned. This makes "slow volumes never report before the deadline" a structural guarantee instead of a timing race — deterministic under any scheduling load. Two "fast" volumes are spawned and `join()`-ed *before* the collection deadline starts, so their results are guaranteed to be queued in the shared channel (again, no race against a short sleep). The test then asserts, all load-immune:
  - no fast volume is ever in the inaccessible set (the actual no-starvation property),
  - every slow (gated) volume is in the inaccessible set,
  - `PROBE_THREAD_FAILURES` increases by exactly the slow-volume count (proves N unreported volumes are all handled within a single deadline window — the "one shared deadline, not N sequential deadlines" invariant that the old `< 2× deadline` upper bound was standing in for),
  - a **load-immune lower bound** `elapsed >= deadline / 2` — the collector must actually wait out its deadline for unreported volumes rather than giving up early. Concurrent load can only push `elapsed` *higher*, never lower, so unlike the old upper bound this assertion structurally cannot flake under load.
- (c) widened wall-clock budget — not needed; (b) was feasible and preserves the property deterministically, which the brief prefers.
- (d) `#[ignore]` perf lane — not needed; the property is fully testable deterministically in the default lane.

The production `probe_all_volumes` implementation in `crates/trusty-search/src/service/warm_boot/probe.rs` is **unchanged** — only the test harness (`probe_tests.rs`) changed.

### Sibling audit

Searched `crates/trusty-search/src/service/warm_boot/` for the same wall-clock-deadline-under-load hazard (`grep -rn "elapsed\|Instant::now"`). One sibling has a similar shape:

- `restore.rs::restore_bounded_multiple_timeouts_do_not_accumulate_indefinitely` (line ~230-234): asserts `start.elapsed() < Duration::from_secs(10)` for 3 sequential 1s-timeout restores (~3s of real work). This is a genuinely different subsystem (tokio-async `restore_one_index_bounded`, not the raw-thread probe path) with a much more generous margin (3.3×, not 2×), and has not been reported flaky. Flagging as a **follow-up candidate** for the same treatment (gate-based or tokio::time::pause since this one *is* tokio-async) rather than fixing preemptively, per the issue's narrow scope on #2703's specific test.

No other wall-clock-elapsed assertions exist in this module.

## Stability proof

**Pre-fix repro** (before any code change, first attempt, no deliberately injected load — ordinary build-tree contention was sufficient):
```
thread '...probe_all_volumes_multi_volume_no_fast_starvation' panicked at crates/trusty-search/src/service/warm_boot/probe_tests.rs:440:5:
total elapsed 137.033083ms must be < 2× deadline 100ms (shared-channel should NOT stall for each volume sequentially)
test result: FAILED. 11 passed; 1 failed; 0 ignored; 0 measured; 1042 filtered out; finished in 0.14s
```

**Post-fix, 50 consecutive single-test runs, default parallelism:**
```
PASS=50 FAIL=0
failed_runs:
```

**Post-fix, 50 consecutive full-module runs (all 12 `warm_boot::probe` tests), default parallelism:**
```
MODULE PASS=50 FAIL=0
failed_runs:
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 1042 filtered out; finished in 0.20s
```

**Post-fix, 15 consecutive module runs under deliberate heavy concurrent load** (12 CPU-saturating `yes` processes on a 16-core machine, run 1 measured 4.88s due to cold cache, subsequent runs 0.37–0.61s each):
```
LOADED PASS=15 FAIL=0
failed_runs:
```

## Quality gate (raw output)

```
$ cargo build --workspace
Finished ... (exit 0, only pre-existing proc-macro-error2 future-incompat warning)

$ cargo test -p trusty-search
test result: ok. 1053 passed; 0 failed; 1 ignored; ...
test result: ok. 255 passed; 0 failed; ...
(all suites green, exit 0)

$ cargo test --workspace
workspace test exit=0
(no "test result: FAILED" lines; no non-"0 failed" result lines)

$ cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile ... (exit 0)

$ cargo fmt --check
(exit 0)

$ bash scripts/check_line_cap.sh
line-cap: 9 allowlisted, 0 violations — OK.
```

## Files changed

- `crates/trusty-search/src/service/warm_boot/probe_tests.rs` — replaced `probe_with_injected_delays` (sleep-based) with `probe_with_gated_slow` (rendezvous-gate-based) and rewrote `probe_all_volumes_multi_volume_no_fast_starvation` to assert the no-starvation property directly instead of a wall-clock elapsed bound. +161/-89 lines, single file, 549 SLOC total (well under the 1500 test-file cap).

## Follow-up candidates

- `restore.rs::restore_bounded_multiple_timeouts_do_not_accumulate_indefinitely` — same wall-clock-elapsed-under-load shape (10s bound for ~3s of tokio-async work), not yet reported flaky, worth the same deterministic treatment proactively.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

---

## Amendment (code-critic HIGH finding addressed)

Code-critic review flagged: the failure-count assertion (`PROBE_THREAD_FAILURES` increased by exactly `slow.len()`) is timing-independent and passes identically whether the collector honors one shared deadline or regresses to N sequential per-volume deadlines — so the original docstring's claim that it "proves the shared-deadline (ONE-deadline-not-N) invariant" was not actually true of the assertions as written.

**Fix applied** (commit `97dca8f8`): added a discriminating, load-tolerant upper bound `elapsed < deadline * slow.len() as u32` alongside the existing load-immune lower bound (`elapsed >= deadline / 2`). A correct one-shared-deadline collector waits ≈1×deadline regardless of how many volumes are unreported; a regression to N-sequential-deadlines would take ≈N×deadline or more — the upper bound now actually catches that distinction. Docstrings were updated to match what the assertions verify.

While tuning, empirically found the originally-proposed 50ms base deadline (150ms upper bound) still flaked under **default test-harness parallelism alone** (no external load — other filtered tests running concurrently in the same binary run pushed elapsed to 152-180ms in 50 repeated runs). Widened the base deadline to 150ms (450ms upper bound, 75ms lower bound) — same discriminating formula, wider absolute margin.

**Also flagging the critic's informational finding as a follow-up ticket candidate**: the test helper (`probe_with_gated_slow`) hand-rolls a structural copy of `probe_all_volumes`'s shared-channel collection loop rather than calling production `probe_all_volumes` directly. This is a pre-existing limitation carried over from the original (pre-#2703) test design — a divergence between the test's copy and the production loop could go undetected. Worth a follow-up to refactor `probe_all_volumes` so its collection loop is unit-testable directly (e.g. extract a generic collector over an injectable stream of `(key, delay-or-gate)` producers) rather than reimplemented in the test.

**Re-verified stability proof on the amended test:**

Post-amendment, 50 consecutive full-module runs, default parallelism:
```
MODULE PASS=50 FAIL=0
failed_runs:
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 1042 filtered out; finished in 0.28s
```

Post-amendment, 10 consecutive module runs under deliberate heavy concurrent load (12 CPU-saturating `yes` processes on a 16-core machine):
```
LOADED PASS=10 FAIL=0
failed_runs:
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 1042 filtered out; finished in 0.28s
```

**Re-verified quality gate:**

```
$ cargo test -p trusty-search
test result: ok. 1053 passed; 0 failed; 1 ignored; ...
test result: ok. 255 passed; 0 failed; ...
(exit 0)

$ cargo clippy -p trusty-search --all-targets -- -D warnings
Finished ... (exit 0)

$ cargo clippy --workspace --all-targets -- -D warnings
Finished ... (exit 0)

$ cargo fmt --check
(exit 0)

$ bash scripts/check_line_cap.sh
line-cap: 9 allowlisted, 0 violations — OK.
```

Head SHA: `97dca8f8`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
