### PR TITLE
fix(trusty-agents): inject global-log path in mistake-log test to fix HOME env race (closes #2709)

### DIFF
--- a/crates/trusty-agents/src/mistake_log.rs
+++ b/crates/trusty-agents/src/mistake_log.rs
@@ -88,10 +88,29 @@ impl MistakeLog {
     /// missing.
     /// Test: `mistake_log_records_nonzero_exit` covers the happy path.
     pub async fn record(project_root: &Path, record: &MistakeRecord) -> Result<()> {
+        Self::record_at(project_root, &global_log_path()?, record).await
+    }
+
+    /// Append a mistake to a project-local log and an *injected* global log path.
+    ///
+    /// Why: `record` resolves the global log path from `$HOME` (via
+    /// `dirs::home_dir`). Tests used to sandbox that by mutating `$HOME` with
+    /// `std::env::set_var`, a process-global write that raced any parallel test
+    /// also touching `$HOME` and flaked this test (#2709, same class as #2688).
+    /// Splitting the env read out to the `record` boundary and taking the global
+    /// path as a parameter gives tests a hermetic seam: they inject a tempdir
+    /// path directly and never touch the process environment.
+    /// What: identical to `record` but writes the global mirror to `global_log`
+    /// instead of the `$HOME`-derived default. Both files are created if missing.
+    /// Test: `mistake_log_records_nonzero_exit` drives this with a tempdir path.
+    pub(crate) async fn record_at(
+        project_root: &Path,
+        global_log: &Path,
+        record: &MistakeRecord,
+    ) -> Result<()> {
         let local = local_log_path(project_root, &record.session_id);
-        let global = global_log_path()?;
         append_line(&local, record).await?;
-        append_line(&global, record).await?;
+        append_line(global_log, record).await?;
         Ok(())
     }
 
@@ -116,11 +135,23 @@ impl MistakeLog {
     /// trailing `n` rows in chronological (oldest-first) order.
     /// Test: Indirectly via the CLI subcommand.
     pub fn read_recent_global(n: usize) -> Result<Vec<MistakeRecord>> {
+        Self::read_recent_global_at(&global_log_path()?, n)
+    }
+
+    /// Read the N most recent mistakes from an *injected* global log path.
+    ///
+    /// Why: sibling seam to `record_at`. `read_recent_global` resolves the path
+    /// from `$HOME`; taking it as a parameter lets `mistake_log_records_nonzero_exit`
+    /// read back exactly the tempdir file it wrote without mutating the process
+    /// environment (#2709).
+    /// What: identical to `read_recent_global` but reads `global_log` instead of
+    /// the `$HOME`-derived default. A missing file yields an empty vec.
+    /// Test: `mistake_log_records_nonzero_exit`.
+    pub(crate) fn read_recent_global_at(global_log: &Path, n: usize) -> Result<Vec<MistakeRecord>> {
         if n == 0 {
             return Ok(Vec::new());
         }
-        let path = global_log_path()?;
-        let all = read_records(&path)?;
+        let all = read_records(global_log)?;
         let start = all.len().saturating_sub(n);
         Ok(all.into_iter().skip(start).collect())
     }
@@ -231,41 +262,24 @@ mod tests {
         }
     }
 
-    // Holding a `std::sync::MutexGuard` across `.await` is intentional here:
-    // the whole point of HOME_LOCK is to serialize HOME-mutating tests for
-    // their entire duration, including all async I/O. tokio's
-    // `await_holding_lock` lint flags the pattern as a deadlock risk for
-    // production code, but in this single-purpose test guard there are no
-    // other tasks contending for the same lock — so we silence it.
-    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn mistake_log_records_nonzero_exit() {
-        // Why: `MistakeLog::record` writes to BOTH a project-local path and
-        // a global path resolved via `dirs::home_dir()` (which honours
-        // `$HOME`). To make this test hermetic we sandbox `$HOME` to a
-        // tempdir. `std::env::set_var` is a process-wide mutation, so
-        // concurrent tests in other modules (e.g. `init::tests::*`) that
-        // also sandbox HOME would race with this one. `crate::test_env::HOME_LOCK`
-        // is a process-wide Mutex shared across modules that serializes
-        // any test mutating HOME — without it this test passes in isolation
-        // but flakes under `cargo test`.
-        let _guard = crate::test_env::HOME_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-
+        // Why: `MistakeLog::record` writes to BOTH a project-local path and a
+        // global path that production resolves from `$HOME`. Sandboxing that by
+        // mutating `$HOME` with `std::env::set_var` is a process-global write
+        // that raced parallel HOME-touching tests and flaked this test (#2709,
+        // same class as #2688 / PR #2702). Instead we inject both paths as
+        // tempdir values through the `record_at` / `read_recent_global_at` seam:
+        // fully hermetic, no env mutation, no cross-module lock.
         let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::var_os("HOME");
-        // SAFETY: HOME_LOCK is held for the entire test body; restoration
-        // runs before the guard is dropped, so no other test observes a
-        // half-set HOME.
-        unsafe {
-            std::env::set_var("HOME", tmp.path());
-        }
-
         let project = tmp.path().join("proj");
         std::fs::create_dir_all(&project).unwrap();
+        let global_log = tmp.path().join("global-mistakes.jsonl");
+
         let rec = sample_record("sess-1", "qa-agent");
-        MistakeLog::record(&project, &rec).await.unwrap();
+        MistakeLog::record_at(&project, &global_log, &rec)
+            .await
+            .unwrap();
 
         let session_records = MistakeLog::read_session(&project, "sess-1").unwrap();
         assert_eq!(session_records.len(), 1);
@@ -273,21 +287,13 @@ mod tests {
         assert_eq!(session_records[0].mistake_type, MistakeType::NonzeroExit);
         assert_eq!(session_records[0].exit_code, Some(1));
 
-        // Global log mirror — uses the sandboxed HOME, so we know exactly
-        // one record exists and it's the one we just wrote.
-        let recent = MistakeLog::read_recent_global(10).unwrap();
+        // Global log mirror — the injected tempdir path, so we know exactly one
+        // record exists and it's the one we just wrote.
+        let recent = MistakeLog::read_recent_global_at(&global_log, 10).unwrap();
         assert!(
             recent.iter().any(|r| r.agent == "qa-agent"),
             "global log should contain the recorded agent; recent={recent:?}"
         );
-
-        // SAFETY: HOME_LOCK still held; safe to mutate env.
-        unsafe {
-            match prev {
-                Some(h) => std::env::set_var("HOME", h),
-                None => std::env::remove_var("HOME"),
-            }
-        }
     }
 
     #[test]

--- a/crates/trusty-agents/src/test_env.rs
+++ b/crates/trusty-agents/src/test_env.rs
@@ -1,21 +1,24 @@
 //! Shared test-only synchronization primitives and executable-file helpers.
 //!
-//! Why: Multiple unit tests across different modules (`init::tests`,
-//! `mistake_log::tests`, etc.) sandbox `$HOME` with `std::env::set_var` to
-//! redirect file I/O into a tempdir. `set_var` is a process-wide mutation
-//! and `cargo test` runs unit tests on a multi-threaded executor by default,
-//! so two concurrent tests sandboxing HOME stomp on each other and one will
-//! observe the other's tempdir (or restore HOME mid-flight). The classic
-//! fix is a per-test-module `static Mutex`, but that only serializes tests
-//! WITHIN one module — cross-module races (e.g. `init::seed_skills_*` vs
-//! `mistake_log::mistake_log_records_nonzero_exit`) still flake.
+//! Why: Multiple unit tests across different modules (`init::tests`, etc.)
+//! sandbox `$HOME` with `std::env::set_var` to redirect file I/O into a
+//! tempdir. `set_var` is a process-wide mutation and `cargo test` runs unit
+//! tests on a multi-threaded executor by default, so two concurrent tests
+//! sandboxing HOME stomp on each other and one will observe the other's
+//! tempdir (or restore HOME mid-flight). The classic fix is a per-test-module
+//! `static Mutex`, but that only serializes tests WITHIN one module —
+//! cross-module races (e.g. `init::seed_skills_*` vs another module's
+//! HOME-mutating test) still flake, and a test that skips the lock races
+//! everyone. The durable fix is to inject the path instead of mutating HOME
+//! (see `mistake_log`'s `record_at` seam, #2709); `HOME_LOCK` remains for
+//! tests not yet migrated to injection.
 //! What: Exposes a single process-wide `HOME_LOCK` that every test mutating
 //! `$HOME` must hold. Also provides `write_executable_script` and
 //! `spawn_script` helpers to avoid ETXTBSY races (#1528).
 //! Compiled only under `#[cfg(test)]` so it costs nothing in release builds.
-//! Test: Used by `mistake_log::tests::mistake_log_records_nonzero_exit` and
-//! `init::tests::*`. The mistake_log test was order-dependent before this
-//! lock was introduced — passed in isolation, failed under `cargo test`.
+//! Test: Used by `init::tests::*` and other modules that still sandbox HOME.
+//! Such tests were order-dependent before this lock — passing in isolation but
+//! failing under `cargo test`.
 
 #![cfg(test)]
 


### PR DESCRIPTION
## Root cause

`mistake_log::tests::mistake_log_records_nonzero_exit` sandboxed the global mistake-log location by mutating `$HOME` with `std::env::set_var` — a **process-global** write. `MistakeLog::record` / `read_recent_global` resolve the global log path from `$HOME` via `dirs::home_dir()`, so the test wrote and read under the sandboxed HOME.

The existing `HOME_LOCK` mutex only serializes tests that *acquire* it. Three trusty-agents tests set `$HOME` **without** holding `HOME_LOCK`:
- `skills::global_cache::tests::refresh_global_cache_is_noop_on_missing_sources`
- `skills::registry::tests_persistence::load_with_index_merges_persisted_effectiveness`
- `ctrl::tests::config_tests::resolve_agent_config_returns_builtin_when_no_disk_config`

Under whole-crate parallel load, one of these flips `$HOME` in the window between the mistake-log test's global **write** and its subsequent **read** → the read resolves to the racer's tempdir, the file isn't there, and `read_recent_global` returns `[]`, failing `assert!(recent.iter().any(...))` at `mistake_log.rs:279`. Same disease class as #2688 (fixed by PR #2702) and #2634.

## Pre-fix reproduction

Ran the mistake-log test packed with the three non-locking HOME racers (libtest OR-filter forces near-simultaneous overlap), 60 iterations at default parallelism:

```
mistake_log_records_nonzero_exit panicked at mistake_log.rs:279:
  global log should contain the recorded agent; recent=[]
=> 23 / 60 iterations failed on the mistake-log test itself
```

## Fix (the #2702 pattern)

Split the `$HOME` read out to the existing `record` / `read_recent_global` boundary and add injection seams:
- `MistakeLog::record_at(project_root, global_log, record)` — global path is a **parameter**
- `MistakeLog::read_recent_global_at(global_log, n)` — reads the injected path

`record` / `read_recent_global` keep identical signatures (resolve `global_log_path()` from env **once**, then delegate), so production callers (`subprocess::spawn`, `runtime::postmortem`) are untouched. The test injects a tempdir path directly — **no `set_var`, no `unsafe`, no `HOME_LOCK`, no weakened assertions**. Stale `HOME_LOCK` doc references to the mistake-log test were updated in `test_env.rs`.

## Post-fix stability proof

- Anti-repro (same 3 racers, 60 iterations): **0 / 60** mistake-log failures (was 23/60).
- **50 / 50** consecutive `cargo test -p trusty-agents --lib mistake_log` runs — all green.
- **10 / 10** full `cargo test -p trusty-agents` runs — all green.

## Quality gates (all green)

- `cargo build --workspace` — exit 0
- `cargo test -p trusty-agents` — 10/10 green
- `cargo test --workspace` — only pre-existing **trusty-search** parallel-load flakes (`probe_all_volumes_multi_volume_no_fast_starvation` #2703, and `list_indexes_repo_identity_tree_filter`); both pass on rerun/isolation. trusty-agents fully green.
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — exit 0
- `bash scripts/check_line_cap.sh` — 0 violations

## Follow-up candidates (other modules, same HOME-`set_var` hazard — NOT fixed here)

Highest priority (these skip `HOME_LOCK` entirely — active racers):
- `crates/trusty-agents/src/skills/global_cache/tests.rs` (`refresh_global_cache_is_noop_on_missing_sources`)
- `crates/trusty-agents/src/skills/registry/tests_persistence.rs` (`load_with_index_merges_persisted_effectiveness`)
- `crates/trusty-agents/src/ctrl/tests/config_tests.rs` (`resolve_agent_config_returns_builtin_when_no_disk_config`)

Lower priority (serialized by `HOME_LOCK` today, but still mutate global env — migrate to injection when touched): `ctrl_session.rs`, `init/tests/mcp_tests.rs`, `init/tests/seed_tests.rs`, `tools/mcp_tools/mod.rs`, `agents/prompt_builder/tests.rs`, `agents/registry/tests.rs`, `mcp/config/tests/mod.rs`, `api/server/tests/*`, `skills/registry/tests.rs`.

Closes #2709

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools