### PR TITLE
feat-2639: slack send/read (rebase)

### DIFF
--- a/crates/trusty-channels/src/slack/handlers.rs
+++ b/crates/trusty-channels/src/slack/handlers.rs
@@ -1,0 +1,338 @@
+//! Live `tools/call` handlers for the send + read Slack tools (issue #2639).
+//!
+//! Why: the MCP dispatcher in [`crate::slack::server`] routes a `tools/call` by
+//! name; the actual Slack Web API work — request shaping, response cleaning, and
+//! markup-escaping of untrusted inbound text — belongs in one focused module so
+//! the dispatcher stays a thin table and each handler is unit-testable. This
+//! module implements the six send/read/list tools; the search + reaction tools
+//! remain deferred to #2640 and fall through to [`ToolCallError::NotImplemented`].
+//! What: [`dispatch`] matches the tool name to a handler; each handler validates
+//! its arguments (missing/typed args → [`ToolCallError::InvalidArgs`] *before*
+//! any network call), POSTs the matching Slack method through the authenticated
+//! [`BaseClient`], and returns a compact structured result. Every field of
+//! inbound, user-authored text (message bodies, channel/user display names) is
+//! passed through [`trusty_common::slack_format::mrkdwn_escape`] so a hostile
+//! message (e.g. one containing a `<!channel>` broadcast span) cannot inject live
+//! markup into the model-facing output. The outbound `send_message` text is the
+//! caller's own composed message and is forwarded verbatim (the caller owns its
+//! content; Slack renders it as `mrkdwn`).
+//! Test: pure argument-parsing and response-cleaning helpers are unit-tested
+//! inline; the full request path (200 / `ok:false` / auth) is covered against a
+//! `wiremock` Slack in `tests/tools_http.rs`.
+
+use serde_json::{json, Value};
+
+use crate::slack::api::client::BaseClient;
+use crate::slack::server::ToolCallError;
+use trusty_common::slack_format::mrkdwn_escape;
+
+/// Default number of messages returned by `slack_read_channel` when the caller
+/// omits `limit` (mirrors the tool's declared schema default).
+const DEFAULT_READ_LIMIT: i64 = 50;
+
+// Slack Web API method paths. Appended to the client's base URL.
+const CHAT_POST_MESSAGE: &str = "chat.postMessage";
+const CONVERSATIONS_HISTORY: &str = "conversations.history";
+const CONVERSATIONS_REPLIES: &str = "conversations.replies";
+const CONVERSATIONS_LIST: &str = "conversations.list";
+const USERS_LIST: &str = "users.list";
+const USERS_INFO: &str = "users.info";
+
+/// Route a known Slack tool call to its handler.
+///
+/// Why: keeps the name→handler table in one place; the caller
+/// ([`crate::slack::server::handle_tool_call`]) has already rejected unknown
+/// names, so anything not matched here is a *planned* tool whose live handler is
+/// deferred to #2640.
+/// What: dispatches the six implemented send/read/list tools; returns
+/// [`ToolCallError::NotImplemented`] for the still-deferred search + reaction
+/// tools.
+/// Test: `tests/tools_http.rs` drives each implemented arm; the deferred arm is
+/// covered by `server::tests::tools_call_returns_not_implemented`.
+pub async fn dispatch(
+    client: &BaseClient,
+    name: &str,
+    args: Value,
+) -> Result<Value, ToolCallError> {
+    match name {
+        "slack_send_message" => send_message(client, args).await,
+        "slack_read_channel" => read_channel(client, args).await,
+        "slack_read_thread" => read_thread(client, args).await,
+        "slack_list_channels" => list_channels(client, args).await,
+        "slack_list_users" => list_users(client, args).await,
+        "slack_get_user" => get_user(client, args).await,
+        // Search + reactions land in #2640.
+        other => Err(ToolCallError::NotImplemented(other.to_string())),
+    }
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────
+
+/// Post a message to a channel (optionally threaded) via `chat.postMessage`.
+///
+/// Why: the core outbound tool. The caller's `text` is their own composed
+/// message, forwarded verbatim so intentional `mrkdwn` (bold, links, code)
+/// renders as written; only inbound text is escaped elsewhere.
+/// What: requires `channel` + `text`; includes `thread_ts` when present; returns
+/// `{ok, channel, ts}` from Slack's response.
+/// Test: `tests/tools_http.rs::send_message_posts_and_returns_ts`.
+async fn send_message(client: &BaseClient, args: Value) -> Result<Value, ToolCallError> {
+    let channel = require_str(&args, "channel")?;
+    let text = require_str(&args, "text")?;
+    let mut body = json!({ "channel": channel.as_str(), "text": text.as_str() });
+    if let Some(ts) = opt_str(&args, "thread_ts") {
+        body["thread_ts"] = json!(ts);
+    }
+    let resp = client.call_method(CHAT_POST_MESSAGE, &body).await?;
+    Ok(json!({
+        "ok": true,
+        "channel": field_str(&resp, "channel"),
+        "ts": field_str(&resp, "ts"),
+    }))
+}
+
+/// Read recent messages from a channel via `conversations.history`.
+///
+/// Why: the primary inbound read tool. Message text is untrusted, so it is
+/// markup-escaped before it reaches the model.
+/// What: requires `channel`; honours `limit` (default [`DEFAULT_READ_LIMIT`]);
+/// returns `{channel, count, messages:[{user, ts, text}]}` with escaped text.
+/// Test: `tests/tools_http.rs::read_channel_escapes_message_text`.
+async fn read_channel(client: &BaseClient, args: Value) -> Result<Value, ToolCallError> {
+    let channel = require_str(&args, "channel")?;
+    let limit = opt_i64(&args, "limit").unwrap_or(DEFAULT_READ_LIMIT);
+    let body = json!({ "channel": channel.as_str(), "limit": limit });
+    let resp = client.call_method(CONVERSATIONS_HISTORY, &body).await?;
+    let messages = clean_messages(&resp);
+    Ok(json!({ "channel": channel, "count": messages.len(), "messages": messages }))
+}
+
+/// Read every reply in a thread via `conversations.replies`.
+///
+/// Why: threads are read separately from the channel timeline; the parent `ts`
+/// selects the thread. Reply text is untrusted → escaped.
+/// What: requires `channel` + `thread_ts`; returns
+/// `{channel, thread_ts, count, messages:[{user, ts, text}]}` with escaped text.
+/// Test: `tests/tools_http.rs::read_thread_returns_replies`.
+async fn read_thread(client: &BaseClient, args: Value) -> Result<Value, ToolCallError> {
+    let channel = require_str(&args, "channel")?;
+    let thread_ts = require_str(&args, "thread_ts")?;
+    let body = json!({ "channel": channel.as_str(), "ts": thread_ts.as_str() });
+    let resp = client.call_method(CONVERSATIONS_REPLIES, &body).await?;
+    let messages = clean_messages(&resp);
+    Ok(json!({
+        "channel": channel,
+        "thread_ts": thread_ts,
+        "count": messages.len(),
+        "messages": messages,
+    }))
+}
+
+/// List channels via `conversations.list`.
+///
+/// Why: lets an agent discover channel ids/names to send to. Channel names are
+/// workspace-controlled but still escaped for defence in depth.
+/// What: honours optional `types` + `limit`; returns
+/// `{count, channels:[{id, name, is_private}]}` with escaped names.
+/// Test: `tests/tools_http.rs::list_channels_returns_entries`.
+async fn list_channels(client: &BaseClient, args: Value) -> Result<Value, ToolCallError> {
+    let mut body = json!({});
+    if let Some(types) = opt_str(&args, "types") {
+        body["types"] = json!(types);
+    }
+    if let Some(limit) = opt_i64(&args, "limit") {
+        body["limit"] = json!(limit);
+    }
+    let resp = client.call_method(CONVERSATIONS_LIST, &body).await?;
+    let channels = clean_channels(&resp);
+    Ok(json!({ "count": channels.len(), "channels": channels }))
+}
+
+/// List workspace users via `users.list`.
+///
+/// Why: lets an agent resolve user ids/names. Display names are user-authored →
+/// escaped.
+/// What: honours optional `limit`; returns
+/// `{count, users:[{id, name, real_name}]}` with escaped names.
+/// Test: `tests/tools_http.rs::list_users_escapes_display_names`.
+async fn list_users(client: &BaseClient, args: Value) -> Result<Value, ToolCallError> {
+    let mut body = json!({});
+    if let Some(limit) = opt_i64(&args, "limit") {
+        body["limit"] = json!(limit);
+    }
+    let resp = client.call_method(USERS_LIST, &body).await?;
+    let users = clean_users(&resp);
+    Ok(json!({ "count": users.len(), "users": users }))
+}
+
+/// Fetch a single user's profile via `users.info`.
+///
+/// Why: a targeted lookup when only one user id is known. Display names are
+/// user-authored → escaped.
+/// What: requires `user`; returns `{user:{id, name, real_name}}` with escaped
+/// names.
+/// Test: `tests/tools_http.rs::get_user_returns_profile`.
+async fn get_user(client: &BaseClient, args: Value) -> Result<Value, ToolCallError> {
+    let user = require_str(&args, "user")?;
+    let body = json!({ "user": user.as_str() });
+    let resp = client.call_method(USERS_INFO, &body).await?;
+    let user_obj = resp.get("user").map(clean_user).unwrap_or(Value::Null);
+    Ok(json!({ "user": user_obj }))
+}
+
+// ── Argument extraction ───────────────────────────────────────────────────
+
+/// Require a string argument, erroring before any network call if absent.
+///
+/// Why: a missing required argument is a caller error (`INVALID_PARAMS`), never
+/// a Slack API error — surface it distinctly and early.
+/// What: returns the owned string, or [`ToolCallError::InvalidArgs`].
+/// Test: `require_str_errors_when_missing`.
+fn require_str(args: &Value, key: &str) -> Result<String, ToolCallError> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            ToolCallError::InvalidArgs(format!("missing required string argument '{key}'"))
+        })
+}
+
+/// Read an optional string argument (absent or wrong-typed → `None`).
+fn opt_str(args: &Value, key: &str) -> Option<String> {
+    args.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+/// Read an optional integer argument (absent or wrong-typed → `None`).
+fn opt_i64(args: &Value, key: &str) -> Option<i64> {
+    args.get(key).and_then(Value::as_i64)
+}
+
+// ── Response cleaning (untrusted text is escaped here) ─────────────────────
+
+/// Extract a string field of a Slack response object, defaulting to `""`.
+fn field_str(v: &Value, key: &str) -> String {
+    v.get(key).and_then(Value::as_str).unwrap_or("").to_string()
+}
+
+/// Clean a Slack `messages` array into escaped `{user, ts, text}` entries.
+///
+/// Why: the raw Slack envelope is large and its `text` is untrusted; the model
+/// only needs author, timestamp, and markup-neutralised text.
+/// What: maps each element through [`clean_message`]; a missing/!array field
+/// yields an empty vec.
+/// Test: `clean_messages_escapes_and_shapes`.
+fn clean_messages(resp: &Value) -> Vec<Value> {
+    resp.get("messages")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().map(clean_message).collect())
+        .unwrap_or_default()
+}
+
+/// Shape one Slack message into `{user, ts, text}` with escaped text.
+fn clean_message(m: &Value) -> Value {
+    json!({
+        "user": field_str(m, "user"),
+        "ts": field_str(m, "ts"),
+        "text": mrkdwn_escape(m.get("text").and_then(Value::as_str).unwrap_or("")),
+    })
+}
+
+/// Clean a Slack `channels` array into `{id, name, is_private}` with escaped names.
+fn clean_channels(resp: &Value) -> Vec<Value> {
+    resp.get("channels")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .map(|c| {
+                    json!({
+                        "id": field_str(c, "id"),
+                        "name": mrkdwn_escape(c.get("name").and_then(Value::as_str).unwrap_or("")),
+                        "is_private": c.get("is_private").and_then(Value::as_bool).unwrap_or(false),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Clean a Slack `members` array into escaped `{id, name, real_name}` entries.
+fn clean_users(resp: &Value) -> Vec<Value> {
+    resp.get("members")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().map(clean_user).collect())
+        .unwrap_or_default()
+}
+
+/// Shape one Slack user object into `{id, name, real_name}` with escaped names.
+///
+/// Why: `real_name` may live at the top level or under `profile`; both are
+/// user-authored and must be escaped.
+/// What: prefers top-level `real_name`, falling back to `profile.real_name`.
+/// Test: `clean_user_escapes_names`.
+fn clean_user(u: &Value) -> Value {
+    let real_name = u
+        .get("real_name")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            u.get("profile")
+                .and_then(|p| p.get("real_name"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("");
+    json!({
+        "id": field_str(u, "id"),
+        "name": mrkdwn_escape(u.get("name").and_then(Value::as_str).unwrap_or("")),
+        "real_name": mrkdwn_escape(real_name),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_str_errors_when_missing() {
+        let args = json!({ "channel": "C1" });
+        assert!(require_str(&args, "channel").is_ok());
+        let err = require_str(&args, "text").expect_err("missing text");
+        assert!(matches!(err, ToolCallError::InvalidArgs(_)));
+    }
+
+    #[test]
+    fn opt_helpers_read_present_and_absent() {
+        let args = json!({ "types": "public_channel", "limit": 7 });
+        assert_eq!(opt_str(&args, "types").as_deref(), Some("public_channel"));
+        assert_eq!(opt_str(&args, "missing"), None);
+        assert_eq!(opt_i64(&args, "limit"), Some(7));
+        assert_eq!(opt_i64(&args, "missing"), None);
+    }
+
+    #[test]
+    fn clean_messages_escapes_and_shapes() {
+        let resp = json!({
+            "messages": [
+                { "user": "U1", "ts": "1.1", "text": "<!channel> hi & bye" },
+                { "user": "U2", "ts": "2.2", "text": "plain" },
+            ]
+        });
+        let out = clean_messages(&resp);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0]["text"], "&lt;!channel&gt; hi &amp; bye");
+        assert_eq!(out[0]["user"], "U1");
+        assert_eq!(out[1]["text"], "plain");
+    }
+
+    #[test]
+    fn clean_messages_missing_array_is_empty() {
+        assert!(clean_messages(&json!({ "ok": true })).is_empty());
+    }
+
+    #[test]
+    fn clean_user_escapes_names() {
+        let u = json!({ "id": "U1", "name": "<b>", "profile": { "real_name": "A & B" } });
+        let out = clean_user(&u);
+        assert_eq!(out["id"], "U1");
+        assert_eq!(out["name"], "&lt;b&gt;");
+        assert_eq!(out["real_name"], "A &amp; B");
+    }
+}

--- a/crates/trusty-channels/src/slack/mod.rs
+++ b/crates/trusty-channels/src/slack/mod.rs
@@ -8,12 +8,15 @@
 //! What: [`api`] holds the endpoint constants, the typed [`api::error::SlackError`],
 //! and the `BaseClient` HTTP wrapper (auth + 401/429 hardening, issue #2638);
 //! [`server`] is the JSON-RPC dispatcher wired into `bin/slack-mcp.rs`;
-//! [`tools`] is the authoritative `tools/list` registry. Every `tools/call`
-//! handler is still a `not-yet-implemented` stub (live calls land in #2639/#2640).
+//! [`tools`] is the authoritative `tools/list` registry; [`handlers`] holds the
+//! live send/read/list `tools/call` bodies (issue #2639). The search + reaction
+//! tools remain deferred stubs (they land in #2640).
 //! Test: `cargo test -p trusty-channels` covers the `initialize` handshake, the
-//! `tools/list` shape/count, the stub-error path, and the client's auth/HTTP
-//! behaviour (`tests/client_http.rs`).
+//! `tools/list` shape/count, the client's auth/HTTP behaviour
+//! (`tests/client_http.rs`), and the send/read tool request paths
+//! (`tests/tools_http.rs`).
 
 pub mod api;
+pub mod handlers;
 pub mod server;
 pub mod tools;

--- a/crates/trusty-channels/src/slack/server.rs
+++ b/crates/trusty-channels/src/slack/server.rs
@@ -16,6 +16,7 @@ use serde_json::{json, Value};
 use thiserror::Error;
 
 use crate::slack::api::client::BaseClient;
+use crate::slack::api::error::SlackError;
 use trusty_common::mcp::{error_codes, initialize_response, run_stdio_loop, Request, Response};
 
 /// Shared state passed to every dispatcher invocation.
@@ -38,47 +39,58 @@ pub struct AppState {
 /// `tools_call_unknown_tool_returns_method_not_found`.
 #[derive(Debug, Error)]
 pub enum ToolCallError {
-    /// A planned tool whose live handler has not been implemented yet.
-    #[error("tool '{0}' is not yet implemented: live Slack API calls are deferred pending the token decision (see ADR-0014)")]
+    /// A planned tool whose live handler has not been implemented yet
+    /// (currently the search + reaction tools — those land in #2640).
+    #[error("tool '{0}' is not yet implemented (search + reactions land in #2640)")]
     NotImplemented(String),
     /// A tool name that is not part of the planned surface at all.
     #[error("unknown tool: {0}")]
     UnknownTool(String),
+    /// A required argument was missing or the wrong JSON type.
+    #[error("invalid arguments: {0}")]
+    InvalidArgs(String),
+    /// The live Slack Web API call failed (auth, rate-limit, `ok:false`, …).
+    #[error(transparent)]
+    Slack(#[from] SlackError),
 }
 
 impl ToolCallError {
     /// JSON-RPC error code for this failure.
     ///
     /// Why: `handle_message` needs a numeric code for the wire response.
-    /// What: Unknown tools map to `METHOD_NOT_FOUND`; unimplemented (but
-    /// planned) tools map to `INTERNAL_ERROR`.
-    /// Test: Covered by the dispatcher tests.
+    /// What: Unknown tools map to `METHOD_NOT_FOUND`; bad arguments map to
+    /// `INVALID_PARAMS`; unimplemented (but planned) tools and live Slack API
+    /// failures map to `INTERNAL_ERROR`.
+    /// Test: Covered by the dispatcher tests and `tests/tools_http.rs`.
     pub fn code(&self) -> i32 {
         match self {
             ToolCallError::NotImplemented(_) => error_codes::INTERNAL_ERROR,
             ToolCallError::UnknownTool(_) => error_codes::METHOD_NOT_FOUND,
+            ToolCallError::InvalidArgs(_) => error_codes::INVALID_PARAMS,
+            ToolCallError::Slack(_) => error_codes::INTERNAL_ERROR,
         }
     }
 }
 
 /// Dispatch a single tool call by name.
 ///
-/// Why: One routing table keeps the tool surface greppable; live handlers land
-/// on the matching arm here as each Slack method is implemented.
-/// What: Every planned tool currently routes to a `NotImplemented` stub;
-/// anything else is `UnknownTool`. The `_state`/`_args` are accepted now so the
-/// signature is stable when real handlers replace the stubs.
-/// Test: `tools_call_returns_not_implemented`.
+/// Why: One routing table keeps the tool surface greppable; the send/read/list
+/// handlers (#2639) run live Slack calls here, while the still-planned search +
+/// reaction tools remain `NotImplemented` until #2640.
+/// What: rejects an unknown name with `UnknownTool`, then delegates every known
+/// name to [`crate::slack::handlers::dispatch`], which runs the implemented
+/// handlers and returns `NotImplemented` for the deferred ones.
+/// Test: `tools_call_returns_not_implemented`,
+/// `tools_call_unknown_tool_returns_method_not_found`, `tests/tools_http.rs`.
 pub async fn handle_tool_call(
-    _state: &AppState,
+    state: &AppState,
     name: &str,
-    _args: Value,
+    args: Value,
 ) -> Result<Value, ToolCallError> {
-    if crate::slack::tools::is_known_tool(name) {
-        // Stub: schema is authoritative, live call deferred (see ADR-0014).
-        return Err(ToolCallError::NotImplemented(name.to_string()));
+    if !crate::slack::tools::is_known_tool(name) {
+        return Err(ToolCallError::UnknownTool(name.to_string()));
     }
-    Err(ToolCallError::UnknownTool(name.to_string()))
+    crate::slack::handlers::dispatch(&state.client, name, args).await
 }
 
 /// Translate a parsed JSON-RPC request into a JSON-RPC response payload.
@@ -189,12 +201,14 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn tools_call_returns_not_implemented() {
+        // `slack_add_reaction` is a known tool whose handler is deferred to
+        // #2640, so it must still surface the `NotImplemented` error.
         let state = make_state();
         let req = json!({
             "jsonrpc": "2.0",
             "id": 3,
             "method": "tools/call",
-            "params": { "name": "slack_send_message", "arguments": { "channel": "C1", "text": "hi" } }
+            "params": { "name": "slack_add_reaction", "arguments": { "channel": "C1", "timestamp": "1.2", "name": "eyes" } }
         });
         let resp = handle_message(state, req).await;
         assert_eq!(resp["error"]["code"], error_codes::INTERNAL_ERROR);
@@ -202,6 +216,21 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("not yet implemented"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tools_call_missing_required_arg_is_invalid_params() {
+        // `slack_send_message` requires `text`; omitting it must be an
+        // INVALID_PARAMS error *before* any network call is attempted.
+        let state = make_state();
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": { "name": "slack_send_message", "arguments": { "channel": "C1" } }
+        });
+        let resp = handle_message(state, req).await;
+        assert_eq!(resp["error"]["code"], error_codes::INVALID_PARAMS);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/trusty-channels/tests/tools_http.rs
+++ b/crates/trusty-channels/tests/tools_http.rs
@@ -1,0 +1,238 @@
+//! Hermetic tests for the send + read Slack tool handlers (issue #2639).
+//!
+//! Why: the send/read/list handlers must POST the correct Slack method, shape a
+//! compact result, and — critically — markup-escape untrusted inbound text so a
+//! hostile message cannot inject a `<!channel>` broadcast span into the
+//! model-facing output. These behaviours need coverage that runs in CI with no
+//! live Slack token.
+//! What: each case points a `BaseClient` at a local `wiremock` server that
+//! returns a canned Slack envelope, then drives the handler through the public
+//! `dispatch` entry point and asserts the cleaned/escaped result. An `ok:false`
+//! body and a missing-argument case pin the error mapping.
+//! Test: this file is the test.
+
+use serde_json::json;
+use trusty_channels::slack::api::client::BaseClient;
+use trusty_channels::slack::handlers::dispatch;
+use trusty_channels::slack::server::ToolCallError;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A client wired to the mock server with a fixed token.
+fn client_for(server: &MockServer) -> BaseClient {
+    BaseClient::with_endpoint(server.uri(), Some("xoxb-test".to_string()))
+        .expect("construct client")
+}
+
+/// Mount a single POST route returning a 200 + JSON body.
+async fn mount_ok(server: &MockServer, method_path: &str, body: serde_json::Value) {
+    Mock::given(method("POST"))
+        .and(path(format!("/{method_path}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn send_message_posts_and_returns_ts() {
+    let server = MockServer::start().await;
+    mount_ok(
+        &server,
+        "chat.postMessage",
+        json!({ "ok": true, "channel": "C123", "ts": "1700000000.000100" }),
+    )
+    .await;
+
+    let client = client_for(&server);
+    let out = dispatch(
+        &client,
+        "slack_send_message",
+        json!({ "channel": "C123", "text": "hello world" }),
+    )
+    .await
+    .expect("send should succeed");
+
+    assert_eq!(out["ok"], true);
+    assert_eq!(out["channel"], "C123");
+    assert_eq!(out["ts"], "1700000000.000100");
+}
+
+#[tokio::test]
+async fn read_channel_escapes_message_text() {
+    let server = MockServer::start().await;
+    mount_ok(
+        &server,
+        "conversations.history",
+        json!({
+            "ok": true,
+            "messages": [
+                { "user": "U1", "ts": "1.1", "text": "<!channel> ping & <@U2>" },
+                { "user": "U2", "ts": "2.2", "text": "normal message" },
+            ]
+        }),
+    )
+    .await;
+
+    let client = client_for(&server);
+    let out = dispatch(&client, "slack_read_channel", json!({ "channel": "C1" }))
+        .await
+        .expect("read should succeed");
+
+    assert_eq!(out["channel"], "C1");
+    assert_eq!(out["count"], 2);
+    // Hostile broadcast/mention markup must be neutralised.
+    assert_eq!(
+        out["messages"][0]["text"],
+        "&lt;!channel&gt; ping &amp; &lt;@U2&gt;"
+    );
+    assert!(!out["messages"][0]["text"].as_str().unwrap().contains('<'));
+    assert_eq!(out["messages"][1]["text"], "normal message");
+    assert_eq!(out["messages"][0]["user"], "U1");
+}
+
+#[tokio::test]
+async fn read_thread_returns_replies() {
+    let server = MockServer::start().await;
+    mount_ok(
+        &server,
+        "conversations.replies",
+        json!({
+            "ok": true,
+            "messages": [
+                { "user": "U1", "ts": "1.1", "text": "parent" },
+                { "user": "U2", "ts": "1.2", "text": "reply" },
+            ]
+        }),
+    )
+    .await;
+
+    let client = client_for(&server);
+    let out = dispatch(
+        &client,
+        "slack_read_thread",
+        json!({ "channel": "C1", "thread_ts": "1.1" }),
+    )
+    .await
+    .expect("read thread should succeed");
+
+    assert_eq!(out["thread_ts"], "1.1");
+    assert_eq!(out["count"], 2);
+    assert_eq!(out["messages"][1]["text"], "reply");
+}
+
+#[tokio::test]
+async fn list_channels_returns_entries() {
+    let server = MockServer::start().await;
+    mount_ok(
+        &server,
+        "conversations.list",
+        json!({
+            "ok": true,
+            "channels": [
+                { "id": "C1", "name": "general", "is_private": false },
+                { "id": "C2", "name": "secret", "is_private": true },
+            ]
+        }),
+    )
+    .await;
+
+    let client = client_for(&server);
+    let out = dispatch(
+        &client,
+        "slack_list_channels",
+        json!({ "types": "public_channel,private_channel" }),
+    )
+    .await
+    .expect("list channels should succeed");
+
+    assert_eq!(out["count"], 2);
+    assert_eq!(out["channels"][0]["id"], "C1");
+    assert_eq!(out["channels"][0]["name"], "general");
+    assert_eq!(out["channels"][1]["is_private"], true);
+}
+
+#[tokio::test]
+async fn list_users_escapes_display_names() {
+    let server = MockServer::start().await;
+    mount_ok(
+        &server,
+        "users.list",
+        json!({
+            "ok": true,
+            "members": [
+                { "id": "U1", "name": "alice", "real_name": "Alice <A>" },
+            ]
+        }),
+    )
+    .await;
+
+    let client = client_for(&server);
+    let out = dispatch(&client, "slack_list_users", json!({}))
+        .await
+        .expect("list users should succeed");
+
+    assert_eq!(out["count"], 1);
+    assert_eq!(out["users"][0]["id"], "U1");
+    assert_eq!(out["users"][0]["real_name"], "Alice &lt;A&gt;");
+}
+
+#[tokio::test]
+async fn get_user_returns_profile() {
+    let server = MockServer::start().await;
+    mount_ok(
+        &server,
+        "users.info",
+        json!({
+            "ok": true,
+            "user": { "id": "U1", "name": "alice", "profile": { "real_name": "Alice & Co" } }
+        }),
+    )
+    .await;
+
+    let client = client_for(&server);
+    let out = dispatch(&client, "slack_get_user", json!({ "user": "U1" }))
+        .await
+        .expect("get user should succeed");
+
+    assert_eq!(out["user"]["id"], "U1");
+    assert_eq!(out["user"]["real_name"], "Alice &amp; Co");
+}
+
+#[tokio::test]
+async fn ok_false_maps_to_slack_error() {
+    let server = MockServer::start().await;
+    mount_ok(
+        &server,
+        "chat.postMessage",
+        json!({ "ok": false, "error": "channel_not_found" }),
+    )
+    .await;
+
+    let client = client_for(&server);
+    let err = dispatch(
+        &client,
+        "slack_send_message",
+        json!({ "channel": "nope", "text": "hi" }),
+    )
+    .await
+    .expect_err("ok:false should error");
+    assert!(matches!(err, ToolCallError::Slack(_)));
+}
+
+#[tokio::test]
+async fn missing_required_arg_errors_before_network() {
+    // A server that fails the test if it is ever hit — validation must happen first.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat.postMessage"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let err = dispatch(&client, "slack_send_message", json!({ "channel": "C1" }))
+        .await
+        .expect_err("missing text should error");
+    assert!(matches!(err, ToolCallError::InvalidArgs(_)));
+}

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -501,6 +501,20 @@ pub mod github_path;
 /// Test: `cargo test -p trusty-common -- repo_identity::tests`.
 pub mod repo_identity;
 
+/// Shared Slack `mrkdwn` formatting/escaping primitives (epic #2636).
+///
+/// Why: the `mrkdwn` escape rule and code-fence helpers were born in
+/// trusty-mpm's inbound Slack gateway; the native Slack MCP server in
+/// trusty-channels now needs the byte-identical escaping to neutralise markup
+/// injection from untrusted channel/user text. Centralising the pure primitives
+/// here — the crate both already depend on — keeps them from diverging without a
+/// trusty-channels → trusty-mpm dependency edge.
+/// What: exposes [`slack_format::mrkdwn_escape`], [`slack_format::code_block`],
+/// and [`slack_format::code_inline`]. Pure `std` string ops — no dependencies,
+/// no feature gate.
+/// Test: `cargo test -p trusty-common -- slack_format::tests`.
+pub mod slack_format;
+
 /// Data-directory resolution and filesystem utilities.
 ///
 /// Why: All trusty-* tools share the same per-app data-directory resolution

--- a/crates/trusty-common/src/slack_format.rs
+++ b/crates/trusty-common/src/slack_format.rs
@@ -1,0 +1,104 @@
+//! Shared Slack `mrkdwn` formatting/escaping primitives.
+//!
+//! Why: the Slack `mrkdwn` escaping and code-fence helpers were born inside
+//! trusty-mpm's `slack::formatter` (the inbound `/command` gateway renders
+//! `CommandResult`s to `mrkdwn`). A second consumer now exists — the native
+//! Slack MCP server in `trusty-channels` (epic #2636, ADR-0014) must apply the
+//! identical escaping to untrusted channel/user text so a hostile message
+//! cannot inject markup (e.g. a `<!channel>` broadcast span) into rendered
+//! output. Re-implementing the escape rule in a second crate would risk the two
+//! diverging on the exact substitution set, so the reusable, domain-free
+//! primitives live here (the crate both already depend on) as the single source
+//! of truth. The `CommandResult`-rendering `SlackFormatter` itself stays in
+//! trusty-mpm because it is coupled to trusty-mpm's domain types; only these
+//! pure helpers are shared.
+//! What: [`mrkdwn_escape`] neutralises the three `mrkdwn`-significant characters;
+//! [`code_block`] wraps text in a triple-backtick fence; [`code_inline`] wraps a
+//! span in single backticks. All are pure `std` string operations — no
+//! dependencies, no feature gate.
+//! Test: the unit tests in this module cover each helper; trusty-mpm's
+//! `slack::formatter::tests` and trusty-channels' handler tests exercise them
+//! through their re-exports.
+
+/// Escape the three `mrkdwn`-significant characters for a Slack message body.
+///
+/// Why: any backend- or user-controlled text interpolated into a Slack
+/// `mrkdwn` reply (a session name, a channel message read back from Slack, an
+/// error string) can carry Slack's special `<...>` link/mention/broadcast
+/// markup. `<!channel>` broadcast-pings the whole channel and `<@U123>` mentions
+/// a user; an unescaped message containing `<!channel>` would broadcast-ping the
+/// channel from every rendered reply. Escaping the delimiters neutralises the
+/// injection while leaving the visible text intact.
+/// What: replaces `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, in that order (so
+/// the `&` produced by the `<`/`>` substitutions is never re-escaped). Slack
+/// unescapes exactly these three entities in `mrkdwn` bodies, matching Slack's
+/// own documented escaping contract for `chat.postMessage`.
+/// Test: `mrkdwn_escape_escapes_ampersand_lt_gt`,
+/// `mrkdwn_escape_neutralizes_channel_broadcast_span`.
+pub fn mrkdwn_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Wrap text in a Slack triple-backtick code fence.
+///
+/// Why: pane output and captured command/message output should render
+/// monospaced in Slack; `mrkdwn` uses triple backticks for that.
+/// What: returns ```` ```\n<text>\n``` ````.
+/// Test: `code_block_wraps_in_triple_backticks`.
+pub fn code_block(text: &str) -> String {
+    format!("```\n{text}\n```")
+}
+
+/// Wrap a short span in a single-backtick inline-code run.
+///
+/// Why: ids, channel names, and other literal tokens read best monospaced
+/// inline rather than as a full fenced block.
+/// What: returns `` `<s>` ``. The caller is responsible for ensuring the span
+/// contains no backticks (ids/names never do).
+/// Test: `code_inline_wraps_in_single_backticks`.
+pub fn code_inline(s: &str) -> String {
+    format!("`{s}`")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mrkdwn_escape_escapes_ampersand_lt_gt() {
+        assert_eq!(mrkdwn_escape("a & b"), "a &amp; b");
+        assert_eq!(mrkdwn_escape("<tag>"), "&lt;tag&gt;");
+        assert_eq!(mrkdwn_escape("a < b & c > d"), "a &lt; b &amp; c &gt; d");
+        // plain text is unchanged
+        assert_eq!(mrkdwn_escape("plain text"), "plain text");
+    }
+
+    #[test]
+    fn mrkdwn_escape_neutralizes_channel_broadcast_span() {
+        // A hostile message name must not survive as a live broadcast span.
+        let hostile = "<!channel> everybody";
+        let escaped = mrkdwn_escape(hostile);
+        assert!(!escaped.contains('<'), "no raw < survives");
+        assert!(!escaped.contains('>'), "no raw > survives");
+        assert_eq!(escaped, "&lt;!channel&gt; everybody");
+    }
+
+    #[test]
+    fn mrkdwn_escape_does_not_double_escape_ampersand() {
+        // The `&` from the <-substitution must not be re-escaped into `&amp;lt;`.
+        assert_eq!(mrkdwn_escape("<"), "&lt;");
+        assert_eq!(mrkdwn_escape(">"), "&gt;");
+    }
+
+    #[test]
+    fn code_block_wraps_in_triple_backticks() {
+        assert_eq!(code_block("hello"), "```\nhello\n```");
+    }
+
+    #[test]
+    fn code_inline_wraps_in_single_backticks() {
+        assert_eq!(code_inline("C123"), "`C123`");
+    }
+}

--- a/crates/trusty-mpm/src/slack/formatter/mod.rs
+++ b/crates/trusty-mpm/src/slack/formatter/mod.rs
@@ -16,6 +16,14 @@ use crate::client::{
     fleet_state_glyph,
 };
 
+// The pure `mrkdwn` primitives were extracted to `trusty_common::slack_format`
+// (epic #2636) so the native Slack MCP server in `trusty-channels` can reuse the
+// byte-identical escaping without depending on this crate. Re-exported here so
+// every existing call site (`code_block(...)` below, `focus.rs`'s
+// `super::formatter::mrkdwn_escape`, and the module tests) is unchanged — this
+// move is behaviour-neutral for trusty-mpm.
+pub(crate) use trusty_common::slack_format::{code_block, mrkdwn_escape};
+
 #[cfg(test)]
 mod tests;
 
@@ -458,16 +466,6 @@ fn tail_lines(output: &str) -> String {
     lines[lines.len().saturating_sub(MAX_OUTPUT_LINES)..].join("\n")
 }
 
-/// Wrap text in a Slack triple-backtick code fence.
-///
-/// Why: pane output and captured command output should render monospaced in
-/// Slack; `mrkdwn` uses triple backticks for that.
-/// What: returns ```` ```\n<text>\n``` ````.
-/// Test: covered by `format_command_sent_uses_code_block`.
-fn code_block(text: &str) -> String {
-    format!("```\n{text}\n```")
-}
-
 /// Render managed sessions grouped by project as a Slack `mrkdwn` body.
 ///
 /// Why: `/fleet` (WI-B, #1586) shows a per-project breakdown of live sessions
@@ -521,27 +519,4 @@ pub(crate) fn short_id(id: &str) -> String {
     } else {
         head
     }
-}
-
-/// Escape the three `mrkdwn`-significant characters for a Slack message body.
-///
-/// Why (#2565 review): the proxy binding (`slack::focus`) interpolates
-/// backend-controlled and operator-supplied text — session names, `/focus`
-/// arguments, error strings, activity summaries — directly into `mrkdwn`
-/// replies. Slack's markup treats `<...>` as a special link/mention/broadcast
-/// span (e.g. `<!channel>` broadcast-pings the whole channel, `<@U123>`
-/// mentions a user); an unescaped session named `<!channel> pwned` would
-/// broadcast-ping the channel from every proxy reply. Mirrors the Telegram
-/// binding's `html_escape` (`telegram::formatter::html_escape`), which the
-/// Telegram proxy binding applies to the identical set of fields.
-/// What: replaces `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, in that order (so
-/// the `&` produced by the `<`/`>` substitutions is never re-escaped). Slack
-/// unescapes exactly these three entities in `mrkdwn` bodies, matching
-/// Slack's own documented escaping contract for `chat.postMessage`.
-/// Test: `mrkdwn_escape_escapes_ampersand_lt_gt`,
-/// `mrkdwn_escape_neutralizes_channel_broadcast_span`.
-pub(crate) fn mrkdwn_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
 }


### PR DESCRIPTION
Re-created PR after stacked-base rebasing. Original #2711 auto-closed when #2706 merged.