### PR TITLE
fix(trusty-installer): sign the `tm` binary too so App-Data TCC grant survives reinstalls (closes #2721)

### DIFF
--- a/crates/trusty-installer/src/commands/macos_signing.rs
+++ b/crates/trusty-installer/src/commands/macos_signing.rs
@@ -61,7 +61,17 @@
 /// The `trusty-search` signable set: `trusty-search` + its bundled `trusty-embedderd`.
 pub const SEARCH_SET: &str = "trusty-search";
 
-/// The `trusty-mpm` signable set: `trusty-mpm` alone.
+/// The `trusty-mpm` signable set: both binaries `cargo install --path
+/// crates/trusty-mpm` produces — the `trusty-mpm` MCP-bridge binary AND its
+/// `tm` CLI/daemon binary.
+///
+/// Why (#2721): `cargo install` installs `trusty-mpm` and `tm` side by side and
+/// both are ad-hoc/linker-signed with a churning cdhash. Signing only
+/// `trusty-mpm` left `tm` — the primary user-facing binary that also runs the
+/// daemon (`tm daemon`/`tm supervisor`) — ad-hoc, so its App-Data TCC grant kept
+/// being revoked on every reinstall and the "'trusty-mpm' would like to access
+/// data from other apps" prompt still recurred. Both binaries must carry a
+/// stable Developer-ID `--identifier` for the grant to survive.
 pub const MPM_SET: &str = "trusty-mpm";
 
 /// The master table: every signable binary → (its set, its codesign identifier).
@@ -85,6 +95,12 @@ const SIGNABLE_BINARIES: &[(&str, &str, &str)] = &[
         "com.trusty.trusty-embedderd",
     ),
     ("trusty-mpm", MPM_SET, "com.trusty.trusty-mpm"),
+    // `tm` is installed alongside `trusty-mpm` by the same `cargo install --path
+    // crates/trusty-mpm` and is the primary user-facing/daemon binary. It MUST
+    // be signed too or its App-Data TCC grant is revoked on every reinstall
+    // (#2721). Ordered after `trusty-mpm` so `binaries_for_set(MPM_SET).first()`
+    // — the binary whose path the guidance/prompt names — stays `trusty-mpm`.
+    ("tm", MPM_SET, "com.trusty.tm"),
 ];
 
 /// Resolve the binaries that make up a named Developer-ID-signable set.
@@ -654,8 +670,12 @@ pub fn post_install_mpm(install_dir: &std::path::Path, json: bool) {
 mod tests {
     use super::*;
 
-    /// Why: Both signable sets must resolve to their documented binaries.
-    /// What: Asserts `trusty-search` covers search+embedderd, `trusty-mpm` covers mpm alone.
+    /// Why: Both signable sets must resolve to their documented binaries. The
+    /// `trusty-mpm` set MUST include `tm` (#2721) — omitting it left the primary
+    /// `tm` binary ad-hoc and the App-Data TCC prompt kept recurring. Order
+    /// matters: `trusty-mpm` first so it stays the guidance/prompt "primary".
+    /// What: Asserts `trusty-search` covers search+embedderd, `trusty-mpm` covers
+    /// both `trusty-mpm` and `tm` in that order.
     /// Test: This is the test.
     #[test]
     fn binaries_for_set_covers_search_and_mpm() {
@@ -663,7 +683,7 @@ mod tests {
             binaries_for_set(SEARCH_SET),
             vec!["trusty-search", "trusty-embedderd"]
         );
-        assert_eq!(binaries_for_set(MPM_SET), vec!["trusty-mpm"]);
+        assert_eq!(binaries_for_set(MPM_SET), vec!["trusty-mpm", "tm"]);
     }
 
     /// Why: An unrecognised set name must not silently sign nothing without
@@ -680,7 +700,8 @@ mod tests {
     /// `com.trusty.trusty-<binary>` scheme used by `plist_label.rs` and the
     /// release-workflow docs (the pre-#2558 short-form identifiers were the
     /// drift this module fixes).
-    /// What: Asserts all three target binaries map to the expected IDs.
+    /// What: Asserts all four target binaries map to the expected IDs, including
+    /// the `tm` binary (`com.trusty.tm`, #2721) that shares the trusty-mpm set.
     /// Test: This is the test.
     #[test]
     fn identifier_map_covers_all_signable_binaries() {
@@ -693,6 +714,7 @@ mod tests {
             "com.trusty.trusty-embedderd"
         );
         assert_eq!(codesign_identifier("trusty-mpm"), "com.trusty.trusty-mpm");
+        assert_eq!(codesign_identifier("tm"), "com.trusty.tm");
     }
 
     /// Why: PR #2657 review MEDIUM — with set membership and identifier now

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -256,18 +256,18 @@ the Developer ID identity (or honours `TRUSTY_SIGN_IDENTITY`), then codesigns
 `--identifier com.trusty.trusty-mpm` and `~/.cargo/bin/tm` with `--identifier
 com.trusty.tm`.
 
-🟡 **Why a dedicated script and not just `tctl sign trusty-mpm`?** (#2721) —
-`tctl install trusty-mpm` / `tctl sign trusty-mpm` already sign the
-`trusty-mpm` binary with `com.trusty.trusty-mpm` (same flags), but `tctl`'s
-`SIGNABLE_BINARIES` table does **not** yet include the `tm` alias binary, so
-`tm` stays ad-hoc-signed and keeps re-triggering the App-Data prompt on every
-reinstall. The script closes that gap by signing `tm` (`com.trusty.tm`) too.
-`tctl sign trusty-mpm` remains valid for signing just the `trusty-mpm` binary
-in place:
+🟡 **Script vs. `tctl sign trusty-mpm`?** (#2721) — as of the part-2 fix, `tctl`'s
+`SIGNABLE_BINARIES` table covers the **full** trusty-mpm set: both
+`trusty-mpm` (`com.trusty.trusty-mpm`) AND the `tm` binary (`com.trusty.tm`).
+So `tctl install trusty-mpm` (automatic post-install hook) and
+`tctl sign trusty-mpm` (explicit) now sign **both** binaries — closing the gap
+where the primary `tm` binary stayed ad-hoc and kept re-triggering the App-Data
+prompt on every reinstall. The dedicated script signs the same two binaries and
+remains as a cert-guidance-friendly wrapper for local-source installs:
 
 ```bash
 cargo install --path crates/trusty-mpm --locked
-tctl sign trusty-mpm   # signs the trusty-mpm binary only; does NOT sign `tm`
+tctl sign trusty-mpm   # signs BOTH trusty-mpm (com.trusty.trusty-mpm) and tm (com.trusty.tm)
 ```
 
 Both paths print the App-Data-TCC guidance: approve the next `'trusty-mpm'

--- a/scripts/install-trusty-mpm-signed.sh
+++ b/scripts/install-trusty-mpm-signed.sh
@@ -20,14 +20,15 @@
 #
 # CANONICAL SCHEME NOTE: The single source of truth for trusty-* codesign
 # flags/identifiers is `tctl sign` (crates/trusty-installer/src/commands/
-# macos_signing.rs, #2558). `tctl sign trusty-mpm` already signs the
-# `trusty-mpm` binary with `com.trusty.trusty-mpm`, but its SIGNABLE_BINARIES
-# table does NOT include the `tm` alias binary — so `tm` stays ad-hoc-signed and
-# keeps re-prompting. This script therefore signs BOTH binaries directly,
-# mirroring that canonical scheme exactly (identifiers, `--options runtime
-# --timestamp`, `--verify --deep --strict`, and the identifier-change safety
-# notice). Once `tm` is added to the `tctl` table, this script's signing loop
-# can be replaced with a delegation to `tctl sign trusty-mpm` (see #2721).
+# macos_signing.rs, #2558). As of #2721 the `SIGNABLE_BINARIES` table covers the
+# FULL trusty-mpm set — both `trusty-mpm` (`com.trusty.trusty-mpm`) AND the `tm`
+# binary (`com.trusty.tm`) — so `tctl sign trusty-mpm` and the `tctl install`
+# post-install hook now sign both. This script signs the same two binaries
+# directly, mirroring that canonical scheme exactly (identifiers, `--options
+# runtime --timestamp`, `--verify --deep --strict`, and the identifier-change
+# safety notice); it stays as a cert-guidance-friendly wrapper for local-source
+# installs and can, if desired, be reduced to a delegation to
+# `tctl sign trusty-mpm` now that the table is complete.
 #
 # Hardened Runtime: `--options runtime --timestamp` is applied to both binaries.
 # Unlike trusty-search/trusty-embedderd (which load an ONNX runtime dylib and so


### PR DESCRIPTION
## Summary

Part 2 of #2721 (the recurring **"'trusty-mpm' would like to access data from other apps"** TCC prompt Bob keeps seeing after every `cargo install`).

Part 1 (#2723) added the standalone `install-trusty-mpm-signed.sh` script + `make install-mpm-signed`, which sign **both** `trusty-mpm` and `tm`. But the **`tctl` "single source of truth"** path was left incomplete: the `SIGNABLE_BINARIES` table in `crates/trusty-installer/src/commands/macos_signing.rs` only listed `trusty-mpm`, so `tctl install trusty-mpm` (the automatic post-install sign hook) and `tctl sign trusty-mpm` signed **only** `trusty-mpm` and left the primary `tm` binary ad-hoc/linker-signed. `tm`'s cdhash churns on every rebuild → macOS revokes its App-Data grant → the prompt recurs.

## Root cause (evidence)

- `codesign -dvvv ~/.cargo/bin/{trusty-mpm,tm}`: both `flags=0x20002(adhoc,linker-signed)`, `TeamIdentifier=not set`, distinct per-build CDHashes (0.19.14 installed today via bare `cargo install`).
- Prior-session sandbox-log evidence on #2721: 93 `sandboxd TCCAccessRequestIndirectWithOptions` events attributed to `~/.cargo/bin/trusty-mpm`, targeting File-Provider domains `com.apple.CloudDocs.iCloudDriveFileProvider` + three `com.google.drivefs.fpext/gdrive-*`. This session confirmed the host has exactly those mounts (`~/Library/CloudStorage/GoogleDrive-*` ×3 + active iCloud Drive).
- **Two independent static inspections found NO cloud-path read in tm's Rust source** (no `CloudStorage`/`FileProvider`/`desktop_dir`/`document_dir`/full-home-`read_dir`/`WalkDir`). The File-Provider access is indirect (subprocess/framework-level) and only pinpointable with root `fs_usage`/`dtrace`. So the original "scope away the read" sub-goal has no source site to patch — the correct, robust fix is **stable-identity signing of every installed binary**, which makes ALL of tm's TCC grants survive reinstalls regardless of which path triggers them.

## Fix

Add `("tm", MPM_SET, "com.trusty.tm")` to `SIGNABLE_BINARIES` (after `trusty-mpm`, so `binaries_for_set(MPM_SET).first()` — the binary whose path the guidance/prompt names — stays `trusty-mpm`). Both `sign_set_strict` and the fail-soft `post_install_signed_set` iterate `binaries_for_set`, so `tctl` now signs `tm` with a fixed `--identifier com.trusty.tm`, matching the script and the docs.

- `macos_signing.rs`: table entry + `MPM_SET` doc; tests `binaries_for_set_covers_search_and_mpm` and `identifier_map_covers_all_signable_binaries` updated (`every_set_member_has_a_real_identifier` covers `tm` automatically).
- `install-trusty-mpm-signed.sh` + `release-workflow.md`: drop the now-stale "table omits `tm`" note.

## Verification

- `cargo test -p trusty-installer`: **374 passed; 0 failed; 3 ignored**.
- `cargo clippy -p trusty-installer --all-targets -- -D warnings`: clean.
- `cargo fmt -p trusty-installer -- --check`: clean. `bash -n scripts/install-trusty-mpm-signed.sh`: OK. `check_line_cap.sh`: 0 violations.

## Operational note for the maintainer

Bob's currently-installed 0.19.14 binaries are ad-hoc (bare `cargo install`). One-time remedy after this lands: reinstall via `make install-mpm-signed` (or `tctl install trusty-mpm` with the fix), then approve the App-Data prompt one final time — the stable Developer-ID identity (Bob Matsuoka, 4JH68XUHC5) makes it persist across all future reinstalls.

Closes #2721.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools