### PR TITLE
fix(trusty-mpm): framework workflow conventions — per-session session log, issue/PR assignee+label defaults, trusty-mpm attribution footer

### DIFF
--- a/crates/trusty-common/src/catchup/mod.rs
+++ b/crates/trusty-common/src/catchup/mod.rs
@@ -17,6 +17,7 @@ pub mod mpm_registry;
 pub mod mpm_session;
 pub mod palace;
 pub mod session_finder;
+pub mod session_log;
 pub mod state;
 
 use std::path::{Path, PathBuf};

--- a/crates/trusty-common/src/catchup/mpm_registry.rs
+++ b/crates/trusty-common/src/catchup/mpm_registry.rs
@@ -84,8 +84,9 @@ pub fn default_registry_path() -> PathBuf {
 /// Why: the ground-truth indicator that a project is actually paused (rather than
 /// merely having been used in the past) is the presence of a session JSON file
 /// under `.claude-mpm/sessions/`.
-/// What: checks for `LATEST-SESSION.txt` first (cheapest), then falls back to
-/// any `session-*.json` glob. Returns false on any I/O error (fail-open).
+/// What: checks for the append-only `sessions-log.jsonl` first, then the legacy
+/// `LATEST-SESSION.txt` pointer, then falls back to any `session-*.json` glob.
+/// Returns false on any I/O error (fail-open).
 /// Test: covered transitively by `discover_filters_missing_dirs`.
 ///
 // CUTOVER BRIDGE — remove post-migration (#1762)
@@ -94,8 +95,15 @@ fn has_live_pause_file(project_dir: &Path) -> bool {
     if !sessions_dir.is_dir() {
         return false;
     }
-    // Fast path: LATEST-SESSION.txt is written at pause time.
-    if sessions_dir.join("LATEST-SESSION.txt").exists() {
+    // Fast path: the append-only session log, or the legacy pointer, is written
+    // at pause time.
+    if sessions_dir
+        .join(crate::catchup::session_log::SESSION_LOG_FILENAME)
+        .exists()
+        || sessions_dir
+            .join(crate::catchup::session_log::LEGACY_POINTER_FILENAME)
+            .exists()
+    {
         return true;
     }
     // Fallback: any session-*.json file.

--- a/crates/trusty-common/src/catchup/mpm_session.rs
+++ b/crates/trusty-common/src/catchup/mpm_session.rs
@@ -12,7 +12,7 @@
 //!
 // CUTOVER BRIDGE — remove post-migration (#1762)
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Context as _;
 use serde::Deserialize;
@@ -73,9 +73,11 @@ pub struct ClaudeMpmSession {
 ///
 /// Why: callers (the resume bridge) want a single "best guess" session for a
 /// given project without iterating all files themselves.
-/// What: reads `<project_dir>/.claude-mpm/sessions/LATEST-SESSION.txt`; if it
-/// contains a filename, loads that file. Otherwise falls back to the session-*.json
-/// file with the most-recent mtime. Returns `Ok(None)` when no sessions exist.
+/// What: resolves the latest snapshot in `<project_dir>/.claude-mpm/sessions/`
+/// via the shared [`session_log`] fallback chain — the append-only
+/// `sessions-log.jsonl` first, then the legacy `LATEST-SESSION.txt` pointer,
+/// then the newest `session-*.json` by mtime — and parses it. Returns `Ok(None)`
+/// when no sessions exist.
 /// Test: `load_latest_uses_pointer`, `load_latest_falls_back_to_newest_mtime`.
 ///
 // CUTOVER BRIDGE — remove post-migration (#1762)
@@ -83,41 +85,10 @@ pub fn load_latest_claude_mpm_session(
     project_dir: &Path,
 ) -> anyhow::Result<Option<ClaudeMpmSession>> {
     let sessions_dir = project_dir.join(".claude-mpm").join("sessions");
-    if !sessions_dir.is_dir() {
-        return Ok(None);
+    match crate::catchup::session_log::resolve_latest_snapshot(&sessions_dir, "json") {
+        Some(path) => Ok(Some(parse_session_file(&path)?)),
+        None => Ok(None),
     }
-
-    // Try the LATEST-SESSION.txt pointer first.
-    let pointer = sessions_dir.join("LATEST-SESSION.txt");
-    if let Ok(content) = std::fs::read_to_string(&pointer) {
-        // The pointer may be a bare filename OR a multi-line human-readable text;
-        // extract the first token that ends with ".json".
-        let candidate = content
-            .lines()
-            .find(|l| l.trim().ends_with(".json"))
-            .map(|l| l.trim().to_owned());
-        if let Some(fname) = candidate {
-            let path = sessions_dir.join(&fname);
-            if path.exists() {
-                let session = parse_session_file(&path)?;
-                return Ok(Some(session));
-            }
-        }
-        // Some pointer files contain just the filename on the first line.
-        let first_line = content.lines().next().unwrap_or("").trim().to_owned();
-        if !first_line.is_empty() {
-            let path = sessions_dir.join(&first_line);
-            if path.exists() && first_line.ends_with(".json") {
-                let session = parse_session_file(&path)?;
-                return Ok(Some(session));
-            }
-        }
-    }
-
-    // Fallback: pick the session-*.json file with the newest mtime.
-    newest_session_file(&sessions_dir)
-        .map(|opt| opt.map(|p| parse_session_file(&p)).transpose())
-        .unwrap_or(Ok(None))
 }
 
 /// Load all paused claude-mpm sessions for a project directory.
@@ -187,33 +158,11 @@ fn parse_session_file(path: &Path) -> anyhow::Result<ClaudeMpmSession> {
         .with_context(|| format!("parsing session file {}", path.display()))
 }
 
-/// Return the `session-*.json` file with the most-recent mtime, if any.
-///
-/// Why: provides the fallback discovery path when no LATEST-SESSION.txt pointer
-/// is available.
-/// What: reads the directory, filters to `session-*.json` filenames, and picks
-/// the entry with the greatest `modified()` timestamp. Returns `None` when none
-/// exist.
-/// Test: covered by `load_latest_falls_back_to_newest_mtime`.
-///
-// CUTOVER BRIDGE — remove post-migration (#1762)
-fn newest_session_file(sessions_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
-    let best = std::fs::read_dir(sessions_dir)
-        .with_context(|| format!("reading {}", sessions_dir.display()))?
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().into_string().unwrap_or_default();
-            name.starts_with("session-") && name.ends_with(".json")
-        })
-        .max_by_key(|e| e.metadata().and_then(|m| m.modified()).ok());
-
-    Ok(best.map(|e| e.path()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
+    use std::path::PathBuf;
     use tempfile::TempDir;
 
     fn write_session(dir: &Path, filename: &str, json: &str) -> PathBuf {

--- a/crates/trusty-common/src/catchup/session_finder.rs
+++ b/crates/trusty-common/src/catchup/session_finder.rs
@@ -119,6 +119,34 @@ pub fn find_paused_sessions(project_dir: &Path) -> anyhow::Result<Vec<PausedSess
     Ok(sessions)
 }
 
+/// Resolve the latest native `.trusty-mpm` snapshot, preferring the per-session
+/// log entry when a session id is known.
+///
+/// Why: with concurrent `tm` sessions in one project, resume must reload the
+/// current session's own newest snapshot, not whichever session paused last.
+/// The append-only `sessions-log.jsonl` makes that recoverable; this is the
+/// read side of the global-pointer fix.
+/// What: when `session_id` is `Some`, returns the newest `pause` snapshot logged
+/// for that id (if its file still exists); otherwise, or when that session has
+/// no log entry, falls back to the shared resolver chain
+/// (log-overall → legacy `LATEST-SESSION.txt` → newest `session-*.md` by mtime)
+/// against `<project_dir>/.trusty-mpm/sessions/`. Returns `None` when nothing
+/// resolves.
+/// Test: `latest_snapshot_prefers_session_log`, `latest_snapshot_falls_back`.
+pub fn latest_trusty_mpm_snapshot(project_dir: &Path, session_id: Option<&str>) -> Option<PathBuf> {
+    let sessions_dir = project_dir.join(".trusty-mpm").join("sessions");
+    if let Some(id) = session_id
+        && let Some(name) =
+            crate::catchup::session_log::latest_snapshot_for_session(&sessions_dir, id)
+    {
+        let path = sessions_dir.join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    crate::catchup::session_log::resolve_latest_snapshot(&sessions_dir, "md")
+}
+
 /// Render a markdown catch-up digest for a slice of paused sessions.
 ///
 /// Why: `tm session catchup` prints this digest to stdout so the operator (or
@@ -520,6 +548,48 @@ mod tests {
             !output.contains("Tmux Window"),
             "absent window must not render a line"
         );
+    }
+
+    #[test]
+    fn latest_snapshot_prefers_session_log() {
+        use crate::catchup::session_log::{SessionLogEntry, append_entry};
+        let tmp = TempDir::new().unwrap();
+        let sdir = tmp.path().join(".trusty-mpm").join("sessions");
+        fs::create_dir_all(&sdir).unwrap();
+
+        // Two sessions interleave; each snapshot file exists on disk.
+        write_file(&sdir, "session-A.md", "## Summary\nS1 work");
+        write_file(&sdir, "session-B.md", "## Summary\nS2 work");
+        let mk = |id: &str, snap: &str, ts: &str| SessionLogEntry {
+            session_id: id.to_string(),
+            event: "pause".to_string(),
+            snapshot: snap.to_string(),
+            timestamp: ts.to_string(),
+        };
+        append_entry(&sdir, &mk("s1", "session-A.md", "t1")).unwrap();
+        append_entry(&sdir, &mk("s2", "session-B.md", "t2")).unwrap();
+
+        // s1 resumes its own snapshot even though s2 paused last.
+        let got = latest_trusty_mpm_snapshot(tmp.path(), Some("s1")).unwrap();
+        assert_eq!(got.file_name().unwrap(), "session-A.md");
+        // No id → latest overall (s2's).
+        let got = latest_trusty_mpm_snapshot(tmp.path(), None).unwrap();
+        assert_eq!(got.file_name().unwrap(), "session-B.md");
+    }
+
+    #[test]
+    fn latest_snapshot_falls_back() {
+        let tmp = TempDir::new().unwrap();
+        let sdir = tmp.path().join(".trusty-mpm").join("sessions");
+        fs::create_dir_all(&sdir).unwrap();
+        // No log at all → mtime scan of session-*.md.
+        write_file(&sdir, "session-20260101-000000.md", "## Summary\nold");
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        write_file(&sdir, "session-20260202-000000.md", "## Summary\nnew");
+        let got = latest_trusty_mpm_snapshot(tmp.path(), Some("unknown-id")).unwrap();
+        assert_eq!(got.file_name().unwrap(), "session-20260202-000000.md");
+        // Missing project dir → None.
+        assert!(latest_trusty_mpm_snapshot(&tmp.path().join("nope"), None).is_none());
     }
 
     #[test]

--- a/crates/trusty-common/src/catchup/session_log.rs
+++ b/crates/trusty-common/src/catchup/session_log.rs
@@ -1,0 +1,373 @@
+//! Append-only per-session snapshot log (`sessions-log.jsonl`).
+//!
+//! Why: the old resume model relied on a single global `LATEST-SESSION.txt`
+//! pointer, which concurrent `tm` sessions in the same project clobber — each
+//! pause overwrote the pointer, so a resume could target another session's
+//! snapshot. An append-only log records one line per pause/resume event, so
+//! concurrent sessions never overwrite each other's resume target and the
+//! latest snapshot for a *specific* session id is always recoverable.
+//! What: [`SessionLogEntry`] models one JSONL line; [`read_log`] parses the
+//! file (fail-open, skipping malformed lines); [`latest_snapshot_for_session`]
+//! and [`latest_snapshot_overall`] resolve the newest pause snapshot;
+//! [`resolve_latest_snapshot`] implements the full fallback chain
+//! (log → legacy `LATEST-SESSION.txt` pointer → mtime scan); [`append_entry`]
+//! writes a new line without truncating.
+//! Test: inline `#[cfg(test)]` module (`read_log_*`, `latest_*`, `resolve_*`,
+//! `append_*`).
+//!
+// CUTOVER BRIDGE note: the legacy-pointer fallback exists for back-compat with
+// snapshots written before the log was introduced; it can be dropped once no
+// project on disk still carries a `LATEST-SESSION.txt`.
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Filename of the append-only session log inside a `sessions/` directory.
+pub const SESSION_LOG_FILENAME: &str = "sessions-log.jsonl";
+
+/// Filename of the legacy global pointer, kept only as a read-side fallback.
+pub const LEGACY_POINTER_FILENAME: &str = "LATEST-SESSION.txt";
+
+/// The `event` value recorded when a session is paused (a new snapshot).
+pub const EVENT_PAUSE: &str = "pause";
+
+/// The `event` value recorded when a session is resumed.
+pub const EVENT_RESUME: &str = "resume";
+
+/// One line in `sessions-log.jsonl`.
+///
+/// Why: a structured, append-only record lets resume resolve the latest
+/// snapshot for a specific session id — impossible with a single overwritten
+/// pointer once two sessions run concurrently.
+/// What: mirrors the JSON object the pause/resume skills append:
+/// `{"session_id","event","snapshot","timestamp"}`. Unknown fields are ignored
+/// on read (serde default), so the schema can grow without breaking old logs.
+/// Test: `read_log_parses_valid_lines`, `read_log_skips_malformed`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionLogEntry {
+    /// The originating session's id (e.g. a UUID or tmux session name).
+    pub session_id: String,
+    /// The lifecycle event: `"pause"` or `"resume"`.
+    pub event: String,
+    /// The snapshot filename this event refers to (e.g. `session-<ts>.md`).
+    pub snapshot: String,
+    /// ISO-8601 timestamp of the event.
+    pub timestamp: String,
+}
+
+/// Parse every well-formed entry from `<sessions_dir>/sessions-log.jsonl`.
+///
+/// Why: callers need the raw event stream to resolve snapshots; parsing must be
+/// fail-open so a single corrupt line (partial write, manual edit) never blocks
+/// resume of the remaining valid history.
+/// What: reads the log file if present and returns entries in file order
+/// (oldest-first). Blank lines and lines that fail to deserialize are skipped;
+/// a missing file yields an empty vec (not an error).
+/// Test: `read_log_parses_valid_lines`, `read_log_skips_malformed`,
+/// `read_log_absent_is_empty`.
+pub fn read_log(sessions_dir: &Path) -> Vec<SessionLogEntry> {
+    let log_path = sessions_dir.join(SESSION_LOG_FILENAME);
+    let Ok(content) = std::fs::read_to_string(&log_path) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<SessionLogEntry>(l).ok())
+        .collect()
+}
+
+/// Return the newest `pause` snapshot recorded for `session_id`, if any.
+///
+/// Why: on resume, a session should reload *its own* latest snapshot rather than
+/// whichever session happened to pause last — this is the concurrency fix.
+/// What: scans the log newest-first and returns the `snapshot` of the last
+/// `pause` entry whose `session_id` matches. Returns `None` when the session has
+/// no pause entry.
+/// Test: `latest_snapshot_for_session_picks_own`.
+pub fn latest_snapshot_for_session(sessions_dir: &Path, session_id: &str) -> Option<String> {
+    read_log(sessions_dir)
+        .into_iter()
+        .rev()
+        .find(|e| e.event == EVENT_PAUSE && e.session_id == session_id)
+        .map(|e| e.snapshot)
+}
+
+/// Return the newest `pause` snapshot across all sessions, if any.
+///
+/// Why: when no current session id is known (a cold catch-up), "latest overall"
+/// is the best resume target — the last pause line in the log.
+/// What: scans the log newest-first and returns the `snapshot` of the last
+/// `pause` entry regardless of session id.
+/// Test: `latest_snapshot_overall_picks_last_pause`.
+pub fn latest_snapshot_overall(sessions_dir: &Path) -> Option<String> {
+    read_log(sessions_dir)
+        .into_iter()
+        .rev()
+        .find(|e| e.event == EVENT_PAUSE)
+        .map(|e| e.snapshot)
+}
+
+/// Resolve the latest snapshot file, applying the full back-compat fallback.
+///
+/// Why: a project may carry snapshots from before the log existed; resume must
+/// still find them without a log. This centralises the ordered fallback chain so
+/// every reader behaves identically.
+/// What: tries, in order — (1) the newest `pause` snapshot in
+/// `sessions-log.jsonl`; (2) the legacy `LATEST-SESSION.txt` pointer (first line
+/// or token ending in `.<ext>`); (3) an mtime scan for the newest
+/// `session-*.<ext>` file. Returns the resolved path only when it exists on
+/// disk; `None` when nothing resolves. `ext` is the snapshot extension without
+/// the leading dot (e.g. `"md"` for the native store, `"json"` for the legacy
+/// claude-mpm store).
+/// Test: `resolve_prefers_log`, `resolve_falls_back_to_pointer`,
+/// `resolve_falls_back_to_mtime`, `resolve_none_when_empty`.
+pub fn resolve_latest_snapshot(sessions_dir: &Path, ext: &str) -> Option<PathBuf> {
+    if !sessions_dir.is_dir() {
+        return None;
+    }
+
+    // (1) Log — the authoritative, concurrency-safe source.
+    if let Some(name) = latest_snapshot_overall(sessions_dir) {
+        let path = sessions_dir.join(&name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    // (2) Legacy global pointer.
+    if let Some(name) = read_legacy_pointer(sessions_dir, ext) {
+        let path = sessions_dir.join(&name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    // (3) mtime scan of session-*.<ext>.
+    newest_session_file(sessions_dir, ext)
+}
+
+/// Append a single entry to `<sessions_dir>/sessions-log.jsonl`.
+///
+/// Why: pause must never overwrite prior history; appending preserves every
+/// session's snapshots so a concurrent session's resume target survives.
+/// What: creates `sessions_dir` if needed, opens the log in append mode, and
+/// writes the serialized entry followed by a newline. Used by tooling and tests;
+/// the pause skill appends the same shape via the shell.
+/// Test: `append_then_read_roundtrips`, `append_is_additive`.
+pub fn append_entry(sessions_dir: &Path, entry: &SessionLogEntry) -> std::io::Result<()> {
+    std::fs::create_dir_all(sessions_dir)?;
+    let line = serde_json::to_string(entry)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(sessions_dir.join(SESSION_LOG_FILENAME))?;
+    writeln!(f, "{line}")
+}
+
+/// Read the legacy `LATEST-SESSION.txt` pointer, extracting a `session-*.<ext>`
+/// filename.
+///
+/// Why: older snapshots recorded the latest file only via this pointer; keep
+/// reading it so pre-log projects still resume.
+/// What: returns the first trimmed line that ends in `.<ext>` (handles both a
+/// bare-filename pointer and a multi-line human-readable one). `None` when the
+/// pointer is absent or carries no matching token.
+/// Test: covered by `resolve_falls_back_to_pointer`.
+fn read_legacy_pointer(sessions_dir: &Path, ext: &str) -> Option<String> {
+    let content = std::fs::read_to_string(sessions_dir.join(LEGACY_POINTER_FILENAME)).ok()?;
+    let suffix = format!(".{ext}");
+    content
+        .lines()
+        .map(str::trim)
+        .find(|l| l.ends_with(&suffix))
+        .map(str::to_owned)
+}
+
+/// Return the `session-*.<ext>` file with the newest mtime, if any.
+///
+/// Why: the last-resort fallback when neither a log nor a pointer exists.
+/// What: scans `sessions_dir` for `session-*.<ext>` entries and returns the one
+/// with the greatest `modified()` time. `None` when none exist.
+/// Test: covered by `resolve_falls_back_to_mtime`.
+fn newest_session_file(sessions_dir: &Path, ext: &str) -> Option<PathBuf> {
+    let suffix = format!(".{ext}");
+    std::fs::read_dir(sessions_dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().into_string().unwrap_or_default();
+            name.starts_with("session-") && name.ends_with(&suffix)
+        })
+        .max_by_key(|e| e.metadata().and_then(|m| m.modified()).ok())
+        .map(|e| e.path())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn entry(session_id: &str, event: &str, snapshot: &str, ts: &str) -> SessionLogEntry {
+        SessionLogEntry {
+            session_id: session_id.to_string(),
+            event: event.to_string(),
+            snapshot: snapshot.to_string(),
+            timestamp: ts.to_string(),
+        }
+    }
+
+    #[test]
+    fn read_log_absent_is_empty() {
+        let tmp = TempDir::new().unwrap();
+        assert!(read_log(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn read_log_parses_valid_lines() {
+        let tmp = TempDir::new().unwrap();
+        let log = tmp.path().join(SESSION_LOG_FILENAME);
+        fs::write(
+            &log,
+            "{\"session_id\":\"a\",\"event\":\"pause\",\"snapshot\":\"session-1.md\",\"timestamp\":\"2026-07-15T10:00:00Z\"}\n\
+             {\"session_id\":\"a\",\"event\":\"resume\",\"snapshot\":\"session-1.md\",\"timestamp\":\"2026-07-15T11:00:00Z\"}\n",
+        )
+        .unwrap();
+        let entries = read_log(tmp.path());
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].event, "pause");
+        assert_eq!(entries[1].event, "resume");
+    }
+
+    #[test]
+    fn read_log_skips_malformed() {
+        let tmp = TempDir::new().unwrap();
+        let log = tmp.path().join(SESSION_LOG_FILENAME);
+        // One valid line, one truncated/garbage line, one blank line.
+        fs::write(
+            &log,
+            "{\"session_id\":\"a\",\"event\":\"pause\",\"snapshot\":\"session-1.md\",\"timestamp\":\"t\"}\n\
+             {\"session_id\":\n\
+             \n",
+        )
+        .unwrap();
+        let entries = read_log(tmp.path());
+        assert_eq!(entries.len(), 1, "malformed + blank lines skipped");
+        assert_eq!(entries[0].snapshot, "session-1.md");
+    }
+
+    #[test]
+    fn latest_snapshot_for_session_picks_own() {
+        let tmp = TempDir::new().unwrap();
+        // Two concurrent sessions interleave pauses; each must recover its own.
+        append_entry(tmp.path(), &entry("s1", "pause", "session-A.md", "t1")).unwrap();
+        append_entry(tmp.path(), &entry("s2", "pause", "session-B.md", "t2")).unwrap();
+        append_entry(tmp.path(), &entry("s1", "pause", "session-C.md", "t3")).unwrap();
+
+        assert_eq!(
+            latest_snapshot_for_session(tmp.path(), "s1").as_deref(),
+            Some("session-C.md"),
+            "s1 gets its own newest pause, not s2's"
+        );
+        assert_eq!(
+            latest_snapshot_for_session(tmp.path(), "s2").as_deref(),
+            Some("session-B.md")
+        );
+        assert!(latest_snapshot_for_session(tmp.path(), "missing").is_none());
+    }
+
+    #[test]
+    fn latest_snapshot_overall_picks_last_pause() {
+        let tmp = TempDir::new().unwrap();
+        append_entry(tmp.path(), &entry("s1", "pause", "session-A.md", "t1")).unwrap();
+        append_entry(tmp.path(), &entry("s2", "pause", "session-B.md", "t2")).unwrap();
+        // A resume event must NOT be treated as the latest snapshot.
+        append_entry(tmp.path(), &entry("s1", "resume", "session-A.md", "t3")).unwrap();
+        assert_eq!(
+            latest_snapshot_overall(tmp.path()).as_deref(),
+            Some("session-B.md")
+        );
+    }
+
+    #[test]
+    fn append_then_read_roundtrips() {
+        let tmp = TempDir::new().unwrap();
+        let e = entry("s1", "pause", "session-1.md", "2026-07-15T10:00:00Z");
+        append_entry(tmp.path(), &e).unwrap();
+        let entries = read_log(tmp.path());
+        assert_eq!(entries, vec![e]);
+    }
+
+    #[test]
+    fn append_is_additive() {
+        let tmp = TempDir::new().unwrap();
+        append_entry(tmp.path(), &entry("s1", "pause", "session-1.md", "t1")).unwrap();
+        append_entry(tmp.path(), &entry("s1", "pause", "session-2.md", "t2")).unwrap();
+        assert_eq!(
+            read_log(tmp.path()).len(),
+            2,
+            "second append does not truncate"
+        );
+    }
+
+    #[test]
+    fn resolve_prefers_log() {
+        let tmp = TempDir::new().unwrap();
+        // Real snapshot file the log points at.
+        fs::write(tmp.path().join("session-log.md"), b"snap").unwrap();
+        append_entry(tmp.path(), &entry("s1", "pause", "session-log.md", "t1")).unwrap();
+        // A decoy pointer + a newer file that the log should override.
+        fs::write(tmp.path().join(LEGACY_POINTER_FILENAME), "session-ptr.md").unwrap();
+        fs::write(tmp.path().join("session-ptr.md"), b"decoy").unwrap();
+
+        let got = resolve_latest_snapshot(tmp.path(), "md").unwrap();
+        assert_eq!(got.file_name().unwrap(), "session-log.md");
+    }
+
+    #[test]
+    fn resolve_falls_back_to_pointer() {
+        let tmp = TempDir::new().unwrap();
+        // No log; a multi-line human-readable pointer + the file it names.
+        fs::write(tmp.path().join("session-ptr.md"), b"snap").unwrap();
+        fs::write(
+            tmp.path().join(LEGACY_POINTER_FILENAME),
+            "Resume with this file:\nsession-ptr.md\n",
+        )
+        .unwrap();
+        let got = resolve_latest_snapshot(tmp.path(), "md").unwrap();
+        assert_eq!(got.file_name().unwrap(), "session-ptr.md");
+    }
+
+    #[test]
+    fn resolve_falls_back_to_mtime() {
+        let tmp = TempDir::new().unwrap();
+        // Neither log nor pointer: newest session-*.md by mtime wins.
+        fs::write(tmp.path().join("session-old.md"), b"old").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        fs::write(tmp.path().join("session-new.md"), b"new").unwrap();
+        let got = resolve_latest_snapshot(tmp.path(), "md").unwrap();
+        assert_eq!(got.file_name().unwrap(), "session-new.md");
+    }
+
+    #[test]
+    fn resolve_none_when_empty() {
+        let tmp = TempDir::new().unwrap();
+        assert!(resolve_latest_snapshot(tmp.path(), "md").is_none());
+        // Log points at a missing file → must not resolve to a phantom path.
+        append_entry(tmp.path(), &entry("s1", "pause", "gone.md", "t1")).unwrap();
+        assert!(resolve_latest_snapshot(tmp.path(), "md").is_none());
+    }
+
+    #[test]
+    fn resolve_supports_json_ext() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("session-1.json"), b"{}").unwrap();
+        fs::write(tmp.path().join(LEGACY_POINTER_FILENAME), "session-1.json").unwrap();
+        let got = resolve_latest_snapshot(tmp.path(), "json").unwrap();
+        assert_eq!(got.file_name().unwrap(), "session-1.json");
+    }
+}

--- a/crates/trusty-mpm/src/assets/instructions/PM_INSTRUCTIONS.md
+++ b/crates/trusty-mpm/src/assets/instructions/PM_INSTRUCTIONS.md
@@ -1,4 +1,4 @@
-<!-- PM_INSTRUCTIONS_VERSION: 0016 -->
+<!-- PM_INSTRUCTIONS_VERSION: 0017 -->
 <!-- PURPOSE: Token-optimized PM instructions. All rules preserved, compressed format. -->
 
 # PM Agent -- Trusty MPM
@@ -265,6 +265,37 @@ BLOCKING: Cannot mark todo complete until files tracked.
 Sequence: `git status` -> `git add` -> `git commit` after every agent creates files.
 Track: source, config, tests, scripts. Skip: temp, gitignored, build artifacts.
 Final `git status` before session end.
+
+## Commits & Issues (shipped defaults — override any harness default)
+
+These are trusty-mpm framework defaults; they take precedence over whatever the
+underlying harness (e.g. native Claude Code) would otherwise emit.
+
+**Attribution footer.** Every commit message and PR body ends with exactly:
+
+```
+🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
+```
+
+NEVER emit `🤖 Generated with Claude Code` or a `Co-Authored-By: Claude …`
+trailer — replace the harness default with the footer above.
+
+**Issue / PR ownership (multi-harness support).** When creating a GitHub issue
+or PR, the default is `--assignee @me --label trusty-mpm` so a trusty-mpm
+session can identify the issues/PRs it owns and should pick up. Create the label
+first if it does not exist:
+
+```bash
+gh label create trusty-mpm \
+  --description "Created/managed by a trusty-mpm session" --color 8250df \
+  2>/dev/null || true
+gh issue create --assignee @me --label trusty-mpm  --title "…" --body "…"
+gh pr    create --assignee @me --label trusty-mpm  --title "…" --body "…"
+```
+
+The mechanical `gh` calls are delegated to the Version Control agent (CB#6); the
+`--assignee @me --label trusty-mpm` default and the footer are part of that
+delegation prompt.
 
 ## PR Workflow
 

--- a/crates/trusty-mpm/src/assets/instructions/WORKFLOW.md
+++ b/crates/trusty-mpm/src/assets/instructions/WORKFLOW.md
@@ -106,6 +106,19 @@ Scan for: API keys, passwords, private keys, tokens
 Return: Clean or list of blocked items
 ```
 
+## Commits, Issues & PRs (Shipped Defaults)
+
+See `PM_INSTRUCTIONS.md` § "Commits & Issues" (canonical). In short, overriding
+any harness default:
+
+- Every commit message and PR body ends with the trusty-mpm attribution footer:
+  `🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools`.
+  Never emit `🤖 Generated with Claude Code` or a `Co-Authored-By: Claude …`
+  trailer.
+- Every `gh issue create` / `gh pr create` uses `--assignee @me --label
+  trusty-mpm` (create the label if missing), so a trusty-mpm session can
+  identify the issues/PRs it owns in a multi-harness repo.
+
 ## Publish and Release Workflow
 
 **CRITICAL**: PM MUST DELEGATE all version bumps and releases to Local Ops. PM never edits version files (pyproject.toml, package.json, VERSION) directly.

--- a/crates/trusty-mpm/src/assets/skills/tm-bug-reporting.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-bug-reporting.md
@@ -55,9 +55,12 @@ instruction file, a UX gap the user reports directly) have no corresponding
 daemon-captured error event — `list_recent_errors` will not surface them.
 For these, delegate to the **Version Control** agent to file a `gh issue
 create` against `bobmatnyc/trusty-tools` directly, using the same
-information standard below (title, labels, structured body). The MCP
-pipeline is preferred whenever a fingerprint exists; the manual path is the
-fallback, not the default.
+information standard below (title, labels, structured body). Apply the shipped
+issue defaults — `--assignee @me --label trusty-mpm` (create the label first if
+missing: `gh label create trusty-mpm --description "Created/managed by a
+trusty-mpm session" --color 8250df`) — **in addition to** the `bug` label and
+any context labels below. The MCP pipeline is preferred whenever a fingerprint
+exists; the manual path is the fallback, not the default.
 
 ## Bug Report Content Standard
 

--- a/crates/trusty-mpm/src/assets/skills/tm-git-file-tracking.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-git-file-tracking.md
@@ -49,7 +49,10 @@ ONLY NOW: mark the todo complete
 ## Commit Message Format
 
 Follow this repo's conventional-commit style (see the root `CLAUDE.md` git
-workflow section). A typical agent-tracked commit:
+workflow section). Every trusty-mpm commit and PR body **ends with the
+trusty-mpm attribution footer** (see `tm-pr-workflow`) — this overrides any
+harness default (do **not** emit `🤖 Generated with Claude Code` or a
+`Co-Authored-By: Claude …` trailer). A typical agent-tracked commit:
 
 ```
 feat(trusty-mpm): add skill-source doctor probe (A2)
@@ -58,7 +61,7 @@ feat(trusty-mpm): add skill-source doctor probe (A2)
 - Warns via tracing::warn! on missing/empty skill source
 - Part of the /tm- skills portfolio epic
 
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
 ```
 
 ## Before Ending Any Session
@@ -89,7 +92,7 @@ git status
 git add src/<module>/<file-a> src/<module>/<file-b>
 git commit -m "fix(<scope>): warn instead of silent no-op on empty input
 
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools"
 
 git status   # clean
 ```

--- a/crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md
@@ -71,6 +71,33 @@ mcp__trusty-review__review_pr     # open-PR review (correctness/design/security)
 This is CB#8's evidence for a PR-shaped completion claim — "the PR is ready"
 requires a review verdict (or human approval), not just green CI.
 
+## Shipped Defaults: Assignee, Label, and Attribution Footer
+
+These trusty-mpm framework defaults override any harness default and apply to
+both the linked issue and the PR:
+
+- **`--assignee @me --label trusty-mpm`** on every `gh issue create` and
+  `gh pr create`. This is multi-harness support: the assignee + `trusty-mpm`
+  label identify which issues/PRs a trusty-mpm session owns and should pick up.
+  Create the label first if missing:
+
+  ```bash
+  gh label create trusty-mpm \
+    --description "Created/managed by a trusty-mpm session" --color 8250df \
+    2>/dev/null || true
+  gh issue create --assignee @me --label trusty-mpm --title "…" --body "…"
+  gh pr    create --assignee @me --label trusty-mpm --title "…" --body "…"
+  ```
+
+- **Attribution footer** — every commit message and PR body ends with exactly:
+
+  ```
+  🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
+  ```
+
+  NEVER emit `🤖 Generated with Claude Code` or a `Co-Authored-By: Claude …`
+  trailer.
+
 ## Squash-Merge Is Required
 
 PRs merge via **squash-merge only** — one clean commit on `main` per PR.
@@ -89,10 +116,11 @@ the merge failed; see `docs/reference/worktree-discipline.md`.
 
 PR creation itself (branch push, `gh pr create`, description, linking the
 issue, requesting reviews) delegates to the **Version Control** agent —
-provide it: work summary, files changed, test status, and the trusty-review
-verdict. The PM constructs the delegation prompt; it does not run `gh pr
-create` itself (CB#6 boundary — the PM stays out of `gh pr`/`gh issue`
-tooling).
+provide it: work summary, files changed, test status, the trusty-review
+verdict, and the shipped defaults above (`--assignee @me --label trusty-mpm`
+plus the trusty-mpm attribution footer on the PR body). The PM constructs the
+delegation prompt; it does not run `gh pr create` itself (CB#6 boundary — the
+PM stays out of `gh pr`/`gh issue` tooling).
 
 ## Related Skills
 

--- a/crates/trusty-mpm/src/assets/skills/tm-session-management.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-session-management.md
@@ -44,9 +44,17 @@ Sessions are stored **project-local**, not under the user's home directory:
 
 ```
 <project-root>/.trusty-mpm/sessions/
-├── LATEST-SESSION.txt          # pointer to the most recent session
+├── sessions-log.jsonl          # append-only per-session pause/resume log
 └── session-YYYYMMDD-HHMMSS.md  # human-readable snapshot
 ```
+
+Pausing **appends** one `pause` line per snapshot to `sessions-log.jsonl`
+(`{"session_id","event","snapshot","timestamp"}`) instead of overwriting a
+single global pointer — so concurrent `tm` sessions in the same project never
+clobber each other's resume target. Resume resolves the latest snapshot for the
+current session id from the log (latest-overall = last `pause` line), with the
+legacy `LATEST-SESSION.txt` pointer and an mtime scan of `session-*.md` as
+back-compat fallbacks. `LATEST-SESSION.txt` is **no longer written**.
 
 Add `.trusty-mpm/sessions/` to `.gitignore` — this is machine-local state,
 not a deliverable.
@@ -85,7 +93,8 @@ re-align to it. Capture it ONLY when inside tmux (`[ -n "$TMUX" ]`) via
 Procedure: `git status` + `git log --oneline -10` for context → `mkdir -p
 .trusty-mpm/sessions` → when inside tmux, capture the window string (above) →
 write `session-{timestamp}.md` (include `## Tmux Window` only if captured) →
-update `LATEST-SESSION.txt` → report the path to the user.
+**append** one `pause` line to `sessions-log.jsonl` (never overwrite; do not
+write `LATEST-SESSION.txt`) → report the path to the user.
 
 ## Resuming: `tm session catchup`
 

--- a/crates/trusty-mpm/src/assets/skills/tm-session-pause.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-session-pause.md
@@ -21,7 +21,9 @@ When invoked, this skill:
    context summary (plus any message you pass after the command).
 2. Writes a project-local snapshot at
    `.trusty-mpm/sessions/session-{timestamp}.md`.
-3. Updates the `.trusty-mpm/sessions/LATEST-SESSION.txt` pointer.
+3. **Appends** a `pause` line to the append-only
+   `.trusty-mpm/sessions/sessions-log.jsonl` (never overwrites — so concurrent
+   `tm` sessions in the same project don't clobber each other's resume target).
 4. **Prunes stale git worktrees** left behind by decommissioned managed
    sessions (see below).
 5. Prints the snapshot path so you can resume later.
@@ -46,9 +48,24 @@ so pausing in project A and opening project B never loads project A's state:
 
 ```
 <project-root>/.trusty-mpm/sessions/
-├── LATEST-SESSION.txt          # pointer to the most recent session
+├── sessions-log.jsonl          # append-only per-session pause/resume log
 └── session-YYYYMMDD-HHMMSS.md  # human-readable snapshot
 ```
+
+`sessions-log.jsonl` holds one JSON object per line — one per pause/resume
+event:
+
+```json
+{"session_id":"<id>","event":"pause","snapshot":"session-20260715-101500.md","timestamp":"2026-07-15T10:15:00Z"}
+```
+
+Because it is **append-only**, two `tm` sessions pausing in the same project
+each keep their own history: resume resolves the latest snapshot for the
+*current* session id, and "latest overall" is simply the last `pause` line. The
+legacy global `LATEST-SESSION.txt` pointer is **no longer written** (a single
+overwritten pointer let concurrent sessions clobber each other's resume target);
+resume still reads it, and an mtime scan of `session-*.md`, as back-compat
+fallbacks when no log is present.
 
 Add `.trusty-mpm/sessions/` to `.gitignore` — this is machine-local state, not
 a deliverable. No git commit is created by pausing.
@@ -96,10 +113,22 @@ if [ -n "$TMUX" ]; then
   tmux display-message -p '#{session_name}:#{window_index}:#{window_id}'
 fi
 
-# write session-{timestamp}.md using the format above — include a `## Tmux Window`
-# section holding the captured string ONLY if the command above printed one, then:
-# echo "session-{timestamp}.md" > .trusty-mpm/sessions/LATEST-SESSION.txt
+# Resolve a stable session id for the log: prefer $TM_SESSION_ID, else the tmux
+# session:window (stable within a session), else "default".
+SID="${TM_SESSION_ID:-$([ -n "$TMUX" ] && tmux display-message -p '#{session_name}:#{window_index}' || echo default)}"
+SNAP="session-$(date +%Y%m%d-%H%M%S).md"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# write $SNAP using the format above — include a `## Tmux Window` section holding
+# the captured string ONLY if the command above printed one, then APPEND (never
+# overwrite) one pause line to the log:
+printf '{"session_id":"%s","event":"pause","snapshot":"%s","timestamp":"%s"}\n' \
+  "$SID" "$SNAP" "$TS" >> .trusty-mpm/sessions/sessions-log.jsonl
 ```
+
+**Do not** write `LATEST-SESSION.txt` — the append-only log replaces it. Use
+`>>` (append), never `>` (truncate), so a concurrent session's history is
+preserved.
 
 Reconcile the todo list against `git status` first — mark blockers explicitly —
 so the snapshot reflects the *current* state, not a stale one. Then report the

--- a/crates/trusty-mpm/src/assets/skills/tm-session-resume.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-session-resume.md
@@ -19,8 +19,10 @@ live in `/tm-session-management`.
 When invoked, this skill:
 1. Scans the project-local session store at `.trusty-mpm/sessions/` for paused
    snapshots.
-2. Loads the most recent session (by the `LATEST-SESSION.txt` pointer / file
-   modification time) **or** a specific one chosen with `--select`.
+2. Loads the most recent session — for the current session id when known, via
+   the append-only `sessions-log.jsonl`; otherwise the latest overall (last
+   `pause` line), with `LATEST-SESSION.txt` / mtime as back-compat fallbacks —
+   **or** a specific one chosen with `--select`.
 3. **Validates** that the session belongs to the *current* project — snapshots
    whose recorded project path does not match the working directory are skipped,
    so you never accidentally resume another checkout's state.
@@ -87,12 +89,16 @@ attach sessions here; only align within the current tmux client.
 
 ```
 <project-root>/.trusty-mpm/sessions/
-├── LATEST-SESSION.txt          # pointer to the most recent session
+├── sessions-log.jsonl          # append-only per-session pause/resume log
 └── session-YYYYMMDD-HHMMSS.md  # human-readable snapshot (written by pause)
 ```
 
-Resume reads existing snapshots only — it never creates files, and snapshots are
-kept after resume so you can resume more than once.
+Resolution order for "latest": the newest `pause` snapshot for the current
+session id in `sessions-log.jsonl` → the last `pause` line overall → the legacy
+`LATEST-SESSION.txt` pointer → an mtime scan of `session-*.md`. Resume reads
+existing snapshots only — it never creates snapshot files. It MAY append a
+`resume` line to `sessions-log.jsonl` for audit, but snapshots are kept after
+resume so you can resume more than once.
 
 ## No Sessions Found
 

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -62,6 +62,12 @@ Ask: "I didn't find an existing issue for [topic]. Create one, or did you
 mean a different one?" Auto-create only on explicit "create a
 ticket/issue for X."
 
+When a GitHub issue *is* created, apply the shipped trusty-mpm defaults:
+`--assignee @me --label trusty-mpm` (create the label first if missing:
+`gh label create trusty-mpm --description "Created/managed by a trusty-mpm
+session" --color 8250df`). This is multi-harness support — the assignee +
+`trusty-mpm` label mark which issues a trusty-mpm session owns.
+
 ## Ticket-Driven Development Protocol (TkDD)
 
 When a ticket/issue reference is detected (an ID pattern, a URL, "work on


### PR DESCRIPTION
Three FRAMEWORK-default fixes to trusty-mpm's bundled assets (shipped defaults for every project). Closes #2731, #2732, #2733.

## Fix 1 — Per-session, log-based session snapshots (#2731)
Pause now **appends** to an append-only `.trusty-mpm/sessions/sessions-log.jsonl` (one `{"session_id","event","snapshot","timestamp"}` line per event) instead of overwriting a single global `LATEST-SESSION.txt`. Concurrent `tm` sessions in one project no longer clobber each other's resume target; resume resolves the latest snapshot for the current session id (latest-overall = last `pause` line), with `LATEST-SESSION.txt` then an mtime scan as back-compat fallbacks. `LATEST-SESSION.txt` is no longer written.

- New shared, fully-tested module `trusty_common::catchup::session_log` (log parser + `resolve_latest_snapshot` fallback chain, filename-agnostic over `.md`/`.json`).
- Wired into `mpm_session.rs` (legacy `.claude-mpm` JSON reader — de-duplicated its pointer/mtime logic into the shared resolver), `mpm_registry.rs` (`has_live_pause_file`), and `session_finder.rs` (new `latest_trusty_mpm_snapshot(project_dir, session_id)` for the native `.trusty-mpm` store).
- Skills `tm-session-pause` / `tm-session-resume` / `tm-session-management` updated to append the log and stop writing the pointer.

**Design note / deviation:** the two files named in the request (`mpm_session.rs`, `mpm_registry.rs`) are the **legacy `.claude-mpm/` cutover bridge** (#1762, JSON store), a *different* store from the native `.trusty-mpm/` markdown store the pause/resume skills use. The `sessions-log.jsonl` design is a `.trusty-mpm/` artifact, and its real Rust reader is `session_finder.rs` — which already avoided the global-pointer clobber (it globs all `session-*.md` newest-first and never read the pointer). Rather than cross store boundaries, the fix factors the log format + fallback chain into one shared `session_log` module and wires **all three** readers to it (the legacy readers gain harmless log-awareness so a `.claude-mpm/sessions-log.jsonl` would also be honored), giving one tested implementation.

## Fix 2 — Issue/PR assignee + `trusty-mpm` label (#2732)
Bundled PM instructions (`PM_INSTRUCTIONS.md` new "Commits & Issues" section, `WORKFLOW.md`) and skills (`tm-pr-workflow`, `tm-bug-reporting`, `tm-ticketing`) now default issue/PR creation to `--assignee @me --label trusty-mpm`, creating the label if missing (`gh label create trusty-mpm --description "Created/managed by a trusty-mpm session" --color 8250df`). Multi-harness support: assignee + label mark which issues/PRs a trusty-mpm session owns. (`tm-issues-prune` only lists/closes/edits — no creation — so it's unchanged.)

## Fix 3 — Attribution footer regression (#2733)
Pinned the three-robot footer as the explicit shipped default for commits and PR bodies, overriding the harness default (which was leaking `🤖 Generated with Claude Code`). Removed the `Co-Authored-By: Claude …` trailer from `tm-git-file-tracking` examples; added the canonical footer to `PM_INSTRUCTIONS`, `WORKFLOW`, `tm-pr-workflow`, `tm-git-file-tracking`:

```
🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
```

## Verification
- `cargo build --workspace` — clean (exit 0).
- `make check` (cargo test --workspace + clippy --workspace --all-targets -D warnings + cargo fmt --check) — **exit 0**. `trusty-common` lib: 1248 passed, 0 failed. New `catchup::session_log` (11 tests) and `session_finder` per-session tests all pass.
- `bash scripts/check_line_cap.sh` — OK (0 violations).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools