### PR TITLE
fix(trusty-search): deterministic reindex-completion rendezvous in tests, replacing wall-clock polls

### DIFF
--- a/crates/trusty-search/src/service/reindex/mod.rs
+++ b/crates/trusty-search/src/service/reindex/mod.rs
@@ -101,6 +101,10 @@ pub(crate) use batch::inprocess_embedder_ever_ready_for_tests;
 pub(crate) use batch::reset_inprocess_embedder_flag_for_tests;
 #[cfg(test)]
 pub(crate) use guard::ReindexTerminationGuard;
+// Issue #2730: deterministic-rendezvous spawn seam for tests — await the task
+// instead of polling `progress.status` on a wall-clock budget.
+#[cfg(test)]
+pub(crate) use orchestrator::spawn_reindex_awaitable;
 #[cfg(test)]
 pub(crate) use semaphore::{
     reindex_semaphore_for, BACKGROUND_QUEUE_DEPTH, MAX_PARALLEL_BACKGROUND_REINDEXES,

--- a/crates/trusty-search/src/service/reindex/orchestrator.rs
+++ b/crates/trusty-search/src/service/reindex/orchestrator.rs
@@ -37,6 +37,35 @@ pub fn spawn_reindex(handle: Arc<IndexHandle>, progress: Arc<ReindexProgress>, f
     spawn_reindex_with_cleanup(handle, progress, force, None, None, None, true, None);
 }
 
+/// Test-only variant of [`spawn_reindex`] that hands back the task's
+/// `JoinHandle` so tests can `.await` deterministic completion.
+///
+/// Why: production [`spawn_reindex`] is fire-and-forget (returns `()`), so
+/// tests historically polled `progress.status` on a fixed wall-clock budget
+/// (`for _ in 0..N { sleep(ms) }`). Under a loaded host the reindex task first
+/// queues on the process-global 2-permit interactive semaphore
+/// (`semaphore::reindex_semaphore`) and is then CPU-starved, so that budget can
+/// elapse *before* the task reaches a terminal status — surfacing as spurious
+/// `left: Running, right: Complete/Failed` assertion failures (issue #2730).
+/// Awaiting the real `JoinHandle` is a rendezvous with no timing assumption.
+/// What: spawns exactly the same task as [`spawn_reindex`] (interactive
+/// priority, no cleanup / aborted maps / embedderd pid slot / quarantine) but
+/// returns the `tokio::task::JoinHandle`. `run_reindex` always sets a terminal
+/// status (`Complete`/`Failed`/`AbortedMemory`) and flushes every side effect
+/// (prune, corpus swap, terminal SSE event, stage marks) before returning, so
+/// once the handle resolves the status and all observable state are final.
+/// Test: `root_hijack_tests` and every terminal-wait test in `reindex::tests`.
+#[cfg(test)]
+pub(crate) fn spawn_reindex_awaitable(
+    handle: Arc<IndexHandle>,
+    progress: Arc<ReindexProgress>,
+    force: bool,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(super::runner::run_reindex(
+        handle, progress, force, None, None, None, true, None,
+    ))
+}
+
 /// Walk every configured subtree under `handle.root_path`, apply repo-config
 /// filters (`exclude_globs`, `extensions`), and de-duplicate.
 ///

--- a/crates/trusty-search/src/service/reindex/root_hijack_tests.rs
+++ b/crates/trusty-search/src/service/reindex/root_hijack_tests.rs
@@ -58,17 +58,6 @@ fn chunk(file: &str, id: &str) -> RawChunk {
     }
 }
 
-/// Wait up to 5s for `progress` to reach a terminal status.
-async fn wait_for_terminal(progress: &ReindexProgress) {
-    for _ in 0..100 {
-        let status = progress.status.load();
-        if status == ReindexStatus::Failed || status == ReindexStatus::Complete {
-            return;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
-}
-
 /// THE core #2178 regression: an in-memory handle whose `root_path` diverges
 /// from both the corpus's own persisted `indexed_root` AND the durably
 /// persisted `indexes.toml` `root_path` must NEVER be trusted enough to walk
@@ -154,8 +143,15 @@ async fn reindex_refuses_untrusted_root_move_and_preserves_corpus() {
     .expect("persist indexes.toml entry");
 
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-    wait_for_terminal(&progress).await;
+    // Issue #2730: await the reindex task's JoinHandle rather than polling
+    // `progress.status` on a wall-clock budget. Under load the task queues on
+    // the global 2-permit interactive semaphore and is CPU-starved, so a fixed
+    // poll could time out with the status still `Running`. Awaiting is a
+    // deterministic rendezvous — `run_reindex` has set a terminal status before
+    // the handle resolves.
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
 
     assert_eq!(
         progress.status.load(),
@@ -245,8 +241,11 @@ async fn reindex_accepts_root_move_that_matches_persisted_config() {
     .expect("persist indexes.toml entry");
 
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-    wait_for_terminal(&progress).await;
+    // Issue #2730: deterministic rendezvous — await the task instead of polling
+    // status on a wall-clock budget (see the hijack test above).
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
 
     assert_eq!(
         progress.status.load(),

--- a/crates/trusty-search/src/service/reindex/tests.rs
+++ b/crates/trusty-search/src/service/reindex/tests.rs
@@ -55,15 +55,10 @@ async fn reindex_honours_include_paths_filter() {
         )),
     });
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-
-    // Wait up to 10s for completion.
-    for _ in 0..100 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+    // Issue #2730: deterministic rendezvous — await the task instead of polling.
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
     assert_eq!(
         progress.total_files.load(Ordering::Acquire),
@@ -141,14 +136,9 @@ async fn reindex_honours_path_filter() {
         )),
     });
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-
-    for _ in 0..100 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
     assert_eq!(
         progress.total_files.load(Ordering::Acquire),
@@ -200,15 +190,10 @@ async fn reindex_walks_directory_and_emits_events() {
         root.clone(),
     ));
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle, progress.clone(), false);
-
-    // Wait up to 10s for completion.
-    for _ in 0..100 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+    // Issue #2730: deterministic rendezvous — await the task instead of polling.
+    spawn_reindex_awaitable(handle, progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
     assert_eq!(progress.total_files.load(Ordering::Acquire), 2);
     assert_eq!(progress.indexed.load(Ordering::Acquire), 2);
@@ -306,13 +291,9 @@ async fn reindex_persists_chunks_end_to_end() {
 
     // ----- First reindex: cold cache, chunks must be produced. -----
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-    for _ in 0..100 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
 
     // Walker yields exactly one file (`crates/foo/src/lib.rs`).
@@ -408,13 +389,9 @@ async fn reindex_persists_chunks_end_to_end() {
     // intentionally bypassed. Pin this behaviour so the next bisection
     // doesn't waste another round chasing a non-existent walker bug.
     let progress2 = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress2.clone(), false);
-    for _ in 0..100 {
-        if progress2.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress2.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress2.status.load(), ReindexStatus::Complete);
     assert_eq!(
         progress2.total_files.load(Ordering::Acquire),
@@ -472,14 +449,9 @@ async fn context_embedding_populated_after_reindex() {
         root.clone(),
     ));
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-
-    for _ in 0..100 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
 
     let ctx = handle.context_embedding.read().await.clone();
@@ -566,20 +538,14 @@ async fn reindex_marks_failed_on_zero_vectors_and_preserves_corpus() {
     handle_inner.defer_embed = false;
     let handle = Arc::new(handle_inner);
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
+    // Issue #2730: await the task's completion (deterministic rendezvous)
+    // rather than polling `progress.status` on a wall-clock budget.
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
 
-    // Wait for a terminal state (Failed expected).
-    let mut terminal = ReindexStatus::Running;
-    for _ in 0..100 {
-        let s = progress.status.load();
-        if s != ReindexStatus::Running {
-            terminal = s;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
     assert_eq!(
-        terminal,
+        progress.status.load(),
         ReindexStatus::Failed,
         "embed failure must mark the reindex Failed, not Complete"
     );
@@ -693,15 +659,13 @@ async fn defer_embed_semantic_stage_not_ready_before_background_pass_completes()
         "precondition: defer_embed must default true"
     );
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-
-    // Wait for the fast pass to complete (lexical/BM25/KG done, embedding deferred).
-    for _ in 0..200 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-    }
+    // Issue #2730: await the fast pass deterministically. `run_reindex` returns
+    // once the fast pass has set `Complete` and spawned the deferred embed pass;
+    // the deferred pass runs as a separate task (polled for below). This
+    // replaces a wall-clock poll that could time out under load.
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
 
     // Issue #2211: right after the fast pass, the background embed pass has
@@ -753,14 +717,9 @@ async fn context_embedding_none_when_no_metadata() {
         root.clone(),
     ));
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-
-    for _ in 0..100 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
     assert!(handle.context_embedding.read().await.is_none());
     assert!(handle.context_summary.read().await.is_none());
@@ -867,14 +826,9 @@ async fn stage_1_completes_and_search_works_before_embedding() {
     // search capabilities must advertise the lexical lane.
     let handle = make_handle_with_flag("stage1-test", root.clone(), false);
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-
-    for _ in 0..200 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
 
     // Lexical lane must be Ready (and so should the others — Stage 1
@@ -930,13 +884,9 @@ async fn lexical_only_index_never_runs_stage_2() {
     );
 
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-    for _ in 0..200 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
 
     // The reindex finished but semantic + graph must STILL be Skipped.
@@ -1017,13 +967,9 @@ async fn skip_kg_index_never_runs_phase3() {
     );
 
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-    for _ in 0..200 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
 
     // After reindex: graph must STILL be Skipped.
@@ -1110,14 +1056,9 @@ async fn walk_diagnostics_populated_after_reindex() {
 
     let handle = make_handle_with_flag("diag-test", root.clone(), false);
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-
-    for _ in 0..100 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
 
     let diag = handle.walk_diagnostics.read().await.clone();
@@ -1155,14 +1096,9 @@ async fn walk_diagnostics_error_set_when_zero_files() {
 
     let handle = make_handle_with_flag("diag-zero-test", root.clone(), false);
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-
-    for _ in 0..100 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
 
     let diag = handle.walk_diagnostics.read().await.clone();
@@ -1787,14 +1723,9 @@ async fn last_indexed_stamped_after_reindex() {
 
     let handle = make_handle_with_flag("li-stamp-test", root, false);
     let progress = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress.clone(), false);
-
-    for _ in 0..200 {
-        if progress.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress.status.load(), ReindexStatus::Complete);
 
     let ts = handle.last_indexed_at.read().await.clone();
@@ -1837,13 +1768,9 @@ async fn lexical_chunks_reports_corpus_total_not_pass_count() {
 
     // ── First reindex: commits real chunks ────────────────────────────────
     let progress1 = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress1.clone(), false);
-    for _ in 0..200 {
-        if progress1.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress1.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress1.status.load(), ReindexStatus::Complete);
     let chunks_pass1 = progress1.total_chunks.load(Ordering::Acquire);
     assert!(
@@ -1861,13 +1788,9 @@ async fn lexical_chunks_reports_corpus_total_not_pass_count() {
 
     // ── Second reindex: no-change (all files hash-skipped, 0 new chunks) ─
     let progress2 = Arc::new(ReindexProgress::new());
-    spawn_reindex(handle.clone(), progress2.clone(), false);
-    for _ in 0..200 {
-        if progress2.status.load() == ReindexStatus::Complete {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
+    spawn_reindex_awaitable(handle.clone(), progress2.clone(), false)
+        .await
+        .expect("reindex task must not panic");
     assert_eq!(progress2.status.load(), ReindexStatus::Complete);
     let chunks_pass2 = progress2.total_chunks.load(Ordering::Acquire);
     assert_eq!(


### PR DESCRIPTION
Closes #2730

## Root cause (confirmed by live reproduction)

`root_hijack_tests` (and 17 sibling tests in `reindex/tests.rs`) waited for reindex completion by polling `progress.status` on a **fixed wall-clock budget** (`for _ in 0..N { sleep(50-100ms) }`, 5-10s). But `run_reindex` first queues on the **process-global 2-permit interactive semaphore** (`reindex/semaphore.rs`) before doing any work, so in a full `--lib` run on a loaded host the task can still be queued or CPU-starved when the budget elapses. The assertion then fires with the status still `Running` — the reported `left: Running, right: Failed/Complete` flake. Not an env-var or shared-state collision; the `#[serial]` env handling was correct.

**Reproduction** (8 busy-loop CPU hogs + `--test-threads=64`, reindex test group): **2/15 runs failed pre-fix** — once in `reindex_accepts_root_move_that_matches_persisted_config` (root_hijack_tests.rs:251) and once in the same-class sibling `defer_embed_semantic_stage_not_ready_before_background_pass_completes` (tests.rs:705), both `left: Running`.

## Fix — deterministic rendezvous, no timing assumptions

- `orchestrator.rs`: new `#[cfg(test)] spawn_reindex_awaitable(...) -> JoinHandle<()>` — spawns the identical task as `spawn_reindex` but returns the handle. `run_reindex` always sets a terminal status and flushes all side effects before returning, so awaiting the handle is a race-free rendezvous. Zero production-behavior change.
- `root_hijack_tests.rs`: both tests await the handle; the `wait_for_terminal` poll helper is deleted.
- `tests.rs`: all 17 sibling wall-clock-poll sites converted to the seam (fixes the whole hazard class, not just the reported symptom). The one legitimate poll — defer_embed's second loop, which waits on a separately-spawned deferred embed pass — is kept.

Net **-45 lines** (107 insertions, 152 deletions).

## Stability evidence (post-fix)

| Scenario | Result |
|---|---|
| 50 consecutive reindex-module runs, default parallelism | **50/50 green** |
| 19 runs under the exact load that failed 2/15 pre-fix (8 busy-loops, `--test-threads=64`) | **19/19 green** |
| 10 full `cargo test -p trusty-search --lib` runs under 6 concurrent busy-loops | **10/10 green** (1054 passed, 0 failed each) |

Gates: `cargo clippy -p trusty-search --all-targets -- -D warnings` clean; `cargo fmt --check` clean; line-cap gate 0 violations. Rebased onto `origin/main` (post-#2725) and re-verified green.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools