### PR TITLE
fix(trusty-mpm): pm_guard recognizes git global flags and stops scanning quoted content (closes #2734)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11122,6 +11122,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "sha2 0.10.9",
+ "shlex",
  "sysinfo",
  "teloxide 0.13.0",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,11 @@ walkdir = "2"
 ignore = "0.4"
 globset = "0.4"
 regex = "1"
+# POSIX shell word-splitting for the PM Bash guard's git-argv parsing (#2734):
+# quote-aware tokenization so quoted `-m` message content is not mistaken for
+# shell operators, and git global flags (`-C <path>`, `-c <kv>`, …) are skipped
+# to resolve the real subcommand.
+shlex = "1.3"
 gray_matter = "0.2"
 notify = "6"
 # Process / system introspection (RSS, CPU sampling for daemon /health).

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -211,6 +211,9 @@ dirs.workspace = true
 tempfile.workspace = true
 sha2.workspace = true
 regex.workspace = true
+# #2734: quote-aware shell word-splitting for the PM Bash guard's git-argv
+# parsing (`src/bin/tm/commands/pm_guard_bash/shell_lex.rs`).
+shlex.workspace = true
 jsonwebtoken.workspace = true
 utoipa.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -24,8 +24,10 @@
 //! `sed_awk::tests` for the sed/awk-specific safety analysis.
 
 mod sed_awk;
+mod shell_lex;
 
 use crate::commands::hook_rewrite::{effective_tool_name, first_command_token};
+use shell_lex::QuoteScan;
 
 /// Deny reason for editing files through a shell tool (sed/awk/patch/git apply/redirection).
 pub(crate) const SHELL_EDIT_REASON: &str = "PM must not edit files via shell tools \
@@ -110,16 +112,28 @@ fn evaluate_bash_command_inner(command: &str, depth: usize) -> Option<&'static s
 /// `classify_bash_segment` trims. A bare `&` is NOT a split when it is a
 /// redirection fd-dup (`>&`, `&>`, `2>&1`) or when nothing but whitespace
 /// follows it (trailing background `foo &`), so those stay one segment.
-/// Deliberately quote-unaware — see [`evaluate_bash_command`].
+/// Quote-aware (#2734): an operator that lies inside a quoted string is literal
+/// data (`git commit -m 'a | b'`), not a separator, so it never splits — UNLESS
+/// the command's quotes are unbalanced, in which case the [`QuoteScan`] map is
+/// untrustworthy and we fall back to the original quote-unaware split (the
+/// conservative, over-splitting direction that the sed/awk co-process detection
+/// still relies on).
 /// Test: `split_shell_segments_splits_operators`,
 /// `split_shell_segments_splits_bare_ampersand`,
-/// `split_shell_segments_single_command`.
+/// `split_shell_segments_single_command`,
+/// `split_shell_segments_ignores_quoted_operators`.
 fn split_shell_segments(command: &str) -> Vec<&str> {
+    let scan = QuoteScan::new(command);
+    let quoted = |i: usize| scan.balanced && !scan.is_unquoted(i);
     let bytes = command.as_bytes();
     let mut segments = Vec::new();
     let mut start = 0;
     let mut i = 0;
     while i < bytes.len() {
+        if quoted(i) {
+            i += 1;
+            continue;
+        }
         let two = command.get(i..i + 2);
         if two == Some("&&") || two == Some("||") {
             segments.push(&command[start..i]);
@@ -186,13 +200,22 @@ fn classify_bash_segment(segment: &str, depth: usize) -> Option<&'static str> {
             }
             "curl" | "wget" => return Some(NETWORK_REASON),
             "make" | "pytest" => return Some(BUILD_TEST_REASON),
+            // `git apply` edits files. Resolve the real subcommand through any
+            // leading git global flags (`-C <path>`, `-c <kv>`, `--git-dir=…`)
+            // via [`shell_lex::git_subcommand`] (#2734) so `git -C <path> apply`
+            // is still caught and `git -C <path> commit` is NOT mis-denied — the
+            // two-token `effective_tool_name` matcher below cannot see past the
+            // global flags. On unbalanced quotes `git_subcommand` yields `None`
+            // and we simply don't treat it as `git apply` (matching the prior
+            // allow-on-ambiguous-git-command behaviour).
+            "git" if shell_lex::git_subcommand(trimmed).as_deref() == Some("apply") => {
+                return Some(SHELL_EDIT_REASON);
+            }
             _ => {}
         }
     }
-    match effective_tool_name(trimmed).as_str() {
-        "git apply" => return Some(SHELL_EDIT_REASON),
-        "npm test" => return Some(BUILD_TEST_REASON),
-        _ => {}
+    if effective_tool_name(trimmed) == "npm test" {
+        return Some(BUILD_TEST_REASON);
     }
     classify_command_substitutions(trimmed, depth)
 }
@@ -214,19 +237,31 @@ fn classify_bash_segment(segment: &str, depth: usize) -> Option<&'static str> {
 /// Otherwise byte-scans for `$(` (matching `)` with paren-depth tracking) and
 /// backtick pairs, recursively evaluates each balanced body at `depth + 1`, and
 /// propagates a deny; unbalanced substitutions return [`SHELL_EDIT_REASON`].
+/// Quote-aware (#2734): a `$(`/backtick inside SINGLE quotes is literal text
+/// (`git commit -m 'costs $(x)'`) and is skipped — but double quotes do NOT
+/// suppress substitution (`echo "$(sed -i …)"` still runs `sed`), so those stay
+/// scanned. On unbalanced quotes the map is untrustworthy and every position is
+/// scanned (the original conservative behaviour).
 /// Test: `evaluate_bash_command_denies_hidden_substitution_verb`,
 /// `evaluate_bash_command_allows_benign_substitution`,
 /// `evaluate_bash_command_denies_unbalanced_substitution`,
-/// `evaluate_bash_command_bounds_deep_substitution_nesting`.
+/// `evaluate_bash_command_bounds_deep_substitution_nesting`,
+/// `evaluate_bash_command_allows_quoted_substitution_prose`.
 fn classify_command_substitutions(segment: &str, depth: usize) -> Option<&'static str> {
     if depth >= MAX_SUBSTITUTION_DEPTH {
         // Too deeply nested to safely decompose — deny conservatively rather
         // than recurse further and risk a stack overflow.
         return Some(SHELL_EDIT_REASON);
     }
+    let scan = QuoteScan::new(segment);
+    let live = |i: usize| !scan.balanced || scan.allows_substitution(i);
     let bytes = segment.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
+        if !live(i) {
+            i += 1;
+            continue;
+        }
         if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'(' {
             let mut paren = 1usize;
             let mut j = i + 2;
@@ -282,18 +317,29 @@ fn classify_command_substitutions(segment: &str, depth: usize) -> Option<&'stati
 /// treats `/dev/null` as benign (output discard, e.g. `2>/dev/null` /
 /// `>/dev/null` / `&>/dev/null`) — allow, keep scanning. Any other `>` is a
 /// file-write redirect → `true`.
-/// A pragmatic byte scan (a `>` inside a quoted string can false-positive) that
-/// errs toward blocking, matching the conservative posture of the sibling
-/// `hook_rewrite::has_unsafe_pipe_composition`.
+/// Quote-aware (#2734): a `>` inside a quoted string is literal argument content
+/// (`git commit -m 'spec -> code'` — Bob's live false positive), not a
+/// redirection, and is skipped — UNLESS the command's quotes are unbalanced, in
+/// which case the [`QuoteScan`] map is untrustworthy and every `>` is scanned
+/// (the original conservative, over-blocking behaviour). Shell-level redirects
+/// (`echo x > f`) are unquoted and still caught. NOTE: an in-quote `>` that is
+/// genuinely dangerous — an `awk 'BEGIN{print > "f"}'` in-program file write —
+/// is caught by [`sed_awk::awk_is_readonly`], not here.
 /// Test: `has_file_write_redirection_detects_write`,
 /// `has_file_write_redirection_detects_append`,
 /// `has_file_write_redirection_ignores_fd_dup`,
 /// `has_file_write_redirection_ignores_dev_null`,
+/// `has_file_write_redirection_ignores_quoted_gt`,
 /// `has_file_write_redirection_false_for_plain_command`.
 pub(crate) fn has_file_write_redirection(command: &str) -> bool {
+    let scan = QuoteScan::new(command);
     let bytes = command.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
+        if scan.balanced && !scan.is_unquoted(i) {
+            i += 1;
+            continue;
+        }
         if bytes[i] == b'>' {
             let mut j = i + 1;
             // `>>` append is still a file write; skip the second `>`.
@@ -327,408 +373,4 @@ pub(crate) fn has_file_write_redirection(command: &str) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn evaluate_bash_command_denies_shell_edit_verbs() {
-        for cmd in [
-            "sed -i s/a/b/ src/lib.rs",
-            "sed -i.bak s/a/b/ src/lib.rs",
-            "awk -i inplace '{print}' f",
-            "patch -p1 < d.patch",
-            "git apply my.patch",
-            "FOO=1 sed -i s/a/b/ f",
-            "sudo patch -p0 x",
-        ] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                Some(SHELL_EDIT_REASON),
-                "expected shell-edit deny for: {cmd}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_allows_readonly_sed_awk() {
-        // #2664: sed/awk used as narrowly read-only stream filters (no
-        // in-place flag, no external script, no write/exec construct,
-        // balanced quotes) must not be blanket-denied by name.
-        for cmd in [
-            "git status --porcelain | awk '{print $1}' | sort | uniq -c",
-            "sed -n '1,5p' file.txt",
-            "git log | awk '{print $1}'",
-            "cat f | sed 's/a/b/'",
-            "sed 's/a/b/g' f | grep x",
-            // Code-critic re-review MEDIUM: an apostrophe/single-quote inside
-            // a double-quoted read-only script must not be over-denied.
-            r#"sed "s/can't/cannot/" f"#,
-            r#"awk -F"'" '{print $2}'"#,
-        ] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                None,
-                "expected allow for read-only sed/awk: {cmd:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_awk_shell_escape_holes() {
-        // Code-critic BLOCK on PR #2677: awk's `system()` builtin runs an
-        // arbitrary shell command with no `-i` and no `>` — the
-        // allow-by-default design missed this entirely.
-        for cmd in [
-            r#"awk 'BEGIN{system("touch /tmp/x")}'"#,
-            r#"awk 'BEGIN{system("curl https://evil/x")}'"#,
-            // Code-critic re-review CRITICAL: AWK tolerates whitespace
-            // between a builtin name and its `(` — `system ("...")` (space)
-            // executes exactly like `system("...")` and was missed by a
-            // no-space-only substring check.
-            r#"awk 'BEGIN{system ("touch /tmp/x")}'"#,
-            "awk 'BEGIN{system\t(\"echo x\")}'",
-            // A co-process pipe/read inside the awk program is itself a
-            // bare `|`/`;` from the (quote-unaware) segment splitter's point
-            // of view, so it fragments the quoted program and leaves an
-            // unbalanced quote count in the resulting segment — denied.
-            r#"awk 'BEGIN{print | "sort"}'"#,
-            r#"awk 'BEGIN{"date" | getline}'"#,
-        ] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                Some(SHELL_EDIT_REASON),
-                "expected shell-edit deny for awk shell-escape: {cmd}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_sed_e_w_commands() {
-        // sed's `e` (execute) and `w`/`W` (write-to-file) commands need no
-        // `-i` and no `>` — a bare verb-name deny-list miss, closed by
-        // deny-by-default + script-content analysis in `sed_awk`.
-        for cmd in [
-            "sed '1e touch /tmp/x' f",
-            "sed -n '1,5w /tmp/out' f",
-            "sed 's/a/b/e' f",
-            "sed 's/a/b/w /tmp/out' f",
-        ] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                Some(SHELL_EDIT_REASON),
-                "expected shell-edit deny for sed e/w command: {cmd}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_external_script_load() {
-        // `-f`/`--file` loads a script the guard cannot see — it may contain
-        // any of the w/e/system holes above, so deny unconditionally.
-        for cmd in ["sed -f script.sed f", "awk -f script.awk f"] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                Some(SHELL_EDIT_REASON),
-                "expected shell-edit deny for external script load: {cmd}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_sed_in_place_abbreviations() {
-        // GNU getopt long-option abbreviations of `--in-place` must still
-        // deny, not just the exact spelling.
-        for cmd in [
-            "sed --in s/a/b/ f",
-            "sed --in-p s/a/b/ f",
-            "sed --in=bak s/a/b/ f",
-        ] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                Some(SHELL_EDIT_REASON),
-                "expected shell-edit deny for --in-place abbreviation: {cmd}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_awk_family_verbs() {
-        // gawk/nawk/mawk are the same in-place-edit-capable interpreter
-        // family as awk and must be classified identically.
-        assert_eq!(
-            evaluate_bash_command("gawk -i inplace '{print}' f"),
-            Some(SHELL_EDIT_REASON)
-        );
-        assert_eq!(
-            evaluate_bash_command(r#"nawk 'BEGIN{system("id")}'"#),
-            Some(SHELL_EDIT_REASON)
-        );
-        assert_eq!(
-            evaluate_bash_command("gawk '{print $1}'"),
-            None,
-            "read-only gawk must still allow"
-        );
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_redirection_write() {
-        assert_eq!(
-            evaluate_bash_command("echo 'code' > src/lib.rs"),
-            Some(SHELL_EDIT_REASON)
-        );
-        assert_eq!(
-            evaluate_bash_command("printf x >> notes.txt"),
-            Some(SHELL_EDIT_REASON)
-        );
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_build_and_test() {
-        for cmd in ["make build", "pytest -q", "npm test"] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                Some(BUILD_TEST_REASON),
-                "expected build/test deny for: {cmd}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_network() {
-        for cmd in ["curl https://example.com", "wget https://example.com/x"] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                Some(NETWORK_REASON),
-                "expected network deny for: {cmd}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_allows_normal_shell() {
-        for cmd in [
-            "",
-            "   ",
-            "git status",
-            "git add -A",
-            "git commit -m x",
-            "git log --oneline",
-            "git diff",
-            "git push",
-            "ls -la",
-            "grep -rn foo src",
-            "cat README.md",
-            "cargo tree 2>&1", // fd-dup, not a file write
-        ] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                None,
-                "expected allow for: {cmd:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_composition_hidden_verbs() {
-        // A benign leading verb must NOT hide a forbidden verb in a later
-        // composed segment (the shell-composition bypass, PR #1985).
-        assert_eq!(
-            evaluate_bash_command("cd repo && sed -i s/a/b/ f"),
-            Some(SHELL_EDIT_REASON)
-        );
-        assert_eq!(
-            evaluate_bash_command("true; make build"),
-            Some(BUILD_TEST_REASON)
-        );
-        assert_eq!(
-            evaluate_bash_command("x || pytest"),
-            Some(BUILD_TEST_REASON)
-        );
-        assert_eq!(
-            evaluate_bash_command("ls && git apply p.diff"),
-            Some(SHELL_EDIT_REASON)
-        );
-        // Redirection hidden after a benign first segment still denies.
-        assert_eq!(
-            evaluate_bash_command("cd repo && echo x > out.txt"),
-            Some(SHELL_EDIT_REASON)
-        );
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_bare_ampersand_composition() {
-        // A bare `&` (background separator) must NOT hide a forbidden trailing
-        // verb — the bare-`&` composition bypass (second adversarial review).
-        assert_eq!(
-            evaluate_bash_command("true & sed -i s/a/b/ f"),
-            Some(SHELL_EDIT_REASON)
-        );
-        assert_eq!(
-            evaluate_bash_command("cd x & make build"),
-            Some(BUILD_TEST_REASON)
-        );
-        assert_eq!(evaluate_bash_command("x & pytest"), Some(BUILD_TEST_REASON));
-        // Newline is a separator too.
-        assert_eq!(
-            evaluate_bash_command("cd repo\nsed -i s/a/b/ f"),
-            Some(SHELL_EDIT_REASON)
-        );
-    }
-
-    #[test]
-    fn evaluate_bash_command_allows_trailing_background() {
-        // Trailing background `&` with nothing after must not become a spurious
-        // forbidden segment, and fd-dups must not be treated as separators.
-        for cmd in ["sleep 1 &", "cargo tree 2>&1", "foo >&2"] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                None,
-                "expected allow for: {cmd:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_allows_benign_pipes() {
-        // Composition where NO segment is a forbidden verb must still allow —
-        // we do not blanket-deny all composition.
-        for cmd in [
-            "git log | head",
-            "cat f | grep x",
-            "ls | wc -l",
-            "git diff && git status",
-            "cd repo; ls -la",
-        ] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                None,
-                "expected allow for benign composition: {cmd:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_allows_dev_null_redirect() {
-        // `/dev/null` is an output-discard sink, not a file write.
-        for cmd in ["which cargo 2>/dev/null", "command -v foo >/dev/null"] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                None,
-                "expected allow for /dev/null discard: {cmd:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_hidden_substitution_verb() {
-        // A forbidden verb inside a command substitution must be caught.
-        assert_eq!(
-            evaluate_bash_command("echo \"$(sed -i s/a/b/ f)\""),
-            Some(SHELL_EDIT_REASON)
-        );
-        assert_eq!(
-            evaluate_bash_command("x=`make build`"),
-            Some(BUILD_TEST_REASON)
-        );
-    }
-
-    #[test]
-    fn evaluate_bash_command_allows_benign_substitution() {
-        // Trivial substitutions with benign bodies must not be over-blocked.
-        for cmd in [
-            "echo \"$(date)\"",
-            "cd \"$(git rev-parse --show-toplevel)\"",
-        ] {
-            assert_eq!(
-                evaluate_bash_command(cmd),
-                None,
-                "expected allow for benign substitution: {cmd:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn evaluate_bash_command_denies_unbalanced_substitution() {
-        // An unbalanced substitution we cannot decompose denies conservatively.
-        assert_eq!(
-            evaluate_bash_command("echo $(sed -i"),
-            Some(SHELL_EDIT_REASON)
-        );
-        assert_eq!(evaluate_bash_command("echo `foo"), Some(SHELL_EDIT_REASON));
-    }
-
-    #[test]
-    fn evaluate_bash_command_bounds_deep_substitution_nesting() {
-        // Adversarial deep `$(` nesting must return a decision without panicking
-        // (stack-exhaustion guard). A deny is the acceptable safe outcome.
-        let deep = format!("echo {}", "$(".repeat(200));
-        let decision = evaluate_bash_command(&deep);
-        assert!(decision.is_some(), "deep nesting must deny, got allow");
-        // Balanced-but-deep nesting is also bounded (no panic, returns a value).
-        let balanced = format!("echo {}date{}", "$(".repeat(200), ")".repeat(200));
-        let _ = evaluate_bash_command(&balanced);
-    }
-
-    #[test]
-    fn split_shell_segments_splits_operators() {
-        assert_eq!(
-            split_shell_segments("a && b || c ; d | e"),
-            vec!["a ", " b ", " c ", " d ", " e"]
-        );
-    }
-
-    #[test]
-    fn split_shell_segments_splits_bare_ampersand() {
-        // A bare `&` with a following command splits; fd-dups and trailing
-        // background do not.
-        assert_eq!(split_shell_segments("a & b"), vec!["a ", " b"]);
-        assert_eq!(split_shell_segments("foo &"), vec!["foo &"]);
-        assert_eq!(
-            split_shell_segments("cargo test 2>&1"),
-            vec!["cargo test 2>&1"]
-        );
-        assert_eq!(split_shell_segments("foo >&2"), vec!["foo >&2"]);
-        // Newline splits.
-        assert_eq!(split_shell_segments("a\nb"), vec!["a", "b"]);
-    }
-
-    #[test]
-    fn split_shell_segments_single_command() {
-        assert_eq!(split_shell_segments("git status"), vec!["git status"]);
-        // Backgrounding `&` (nothing after) is not a split point.
-        assert_eq!(split_shell_segments("foo &"), vec!["foo &"]);
-    }
-
-    #[test]
-    fn has_file_write_redirection_detects_write() {
-        assert!(has_file_write_redirection("echo x > f"));
-        assert!(has_file_write_redirection("echo x >f.rs"));
-    }
-
-    #[test]
-    fn has_file_write_redirection_detects_append() {
-        assert!(has_file_write_redirection("echo x >> f"));
-    }
-
-    #[test]
-    fn has_file_write_redirection_ignores_fd_dup() {
-        assert!(!has_file_write_redirection("cargo test 2>&1"));
-        assert!(!has_file_write_redirection("foo >&2"));
-    }
-
-    #[test]
-    fn has_file_write_redirection_ignores_dev_null() {
-        // Discarding output to /dev/null is not a file write.
-        assert!(!has_file_write_redirection("which cargo 2>/dev/null"));
-        assert!(!has_file_write_redirection("command -v foo >/dev/null"));
-        assert!(!has_file_write_redirection("foo &>/dev/null"));
-        // A real file write with the same shape still denies.
-        assert!(has_file_write_redirection("echo x > /dev/null.txt"));
-        assert!(has_file_write_redirection("echo x > out.txt"));
-    }
-
-    #[test]
-    fn has_file_write_redirection_false_for_plain_command() {
-        assert!(!has_file_write_redirection("git status"));
-    }
-}
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/sed_awk.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/sed_awk.rs
@@ -63,7 +63,8 @@ pub(super) fn sed_is_readonly(segment: &str) -> bool {
 /// flag alone.
 /// What: mirrors [`sed_is_readonly`]'s short-circuit shape for the
 /// awk-specific checks: [`has_unbalanced_quotes`], [`awk_has_inplace_flag`],
-/// [`awk_has_external_script_flag`], and [`awk_program_has_system_call`].
+/// [`awk_has_external_script_flag`], [`awk_program_has_system_call`], and
+/// [`awk_program_has_quoted_pipe_or_redirect`].
 /// Test: `awk_is_readonly_allows_stream_filters`,
 /// `awk_is_readonly_denies_in_place`, `awk_is_readonly_denies_external_script`,
 /// `awk_is_readonly_denies_system_call`, `awk_is_readonly_denies_coprocess`.
@@ -78,6 +79,9 @@ pub(super) fn awk_is_readonly(segment: &str) -> bool {
         return false;
     }
     if awk_program_has_system_call(segment) {
+        return false;
+    }
+    if awk_program_has_quoted_pipe_or_redirect(segment) {
         return false;
     }
     true
@@ -456,6 +460,40 @@ fn awk_program_has_system_call(segment: &str) -> bool {
     false
 }
 
+/// Whether an `awk`-family segment has a `|` or `>` INSIDE a quoted region — an
+/// in-program co-process pipe or an output redirect.
+///
+/// Why (issue #2734): the outer guard scanners (`super::split_shell_segments`,
+/// `super::has_file_write_redirection`) became quote-aware to stop mis-reading a
+/// PM's quoted `-m` message content as shell syntax. That removed the
+/// *incidental* protection they used to give awk: a co-process
+/// `awk 'BEGIN{print | "sort"}'` no longer gets its quoted `|` split off into an
+/// unbalanced fragment, and an in-program `awk '{print > "f"}'` file write no
+/// longer trips the quote-unaware `>` scan. Both are full shell/file-write
+/// escapes needing no `-i` and no shell-level redirect, so awk must detect them
+/// itself. A `|`/`>` that is *unquoted* is a shell-level pipe/redirect handled
+/// upstream (the read-only `git log | awk '{print $1}'` pipeline splits there),
+/// so only *quoted* occurrences are this module's concern.
+/// What: a single left-to-right scan tracking single-/double-quote state (the
+/// same mutually-exclusive shape as [`has_unbalanced_quotes`]); returns `true`
+/// on the first `|` or `>` seen while inside either quote kind. Conservatively
+/// also flags an in-program `>` comparison (`awk '$1 > 5'`) — matching the prior
+/// quote-unaware behaviour, which already denied it — rather than parse awk.
+/// Test: `awk_is_readonly_denies_coprocess`, `awk_is_readonly_denies_in_program_redirect`.
+fn awk_program_has_quoted_pipe_or_redirect(segment: &str) -> bool {
+    let mut in_single = false;
+    let mut in_double = false;
+    for b in segment.bytes() {
+        match b {
+            b'\'' if !in_double => in_single = !in_single,
+            b'"' if !in_single => in_double = !in_double,
+            b'|' | b'>' if in_single || in_double => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -616,25 +654,33 @@ mod tests {
 
     #[test]
     fn awk_is_readonly_denies_coprocess() {
-        // A co-process `|` inside a quoted awk program is itself a bare `|`
-        // to the (quote-unaware) upstream segment splitter, so it gets cut
-        // in half. Exercise `awk_is_readonly` on the resulting fragment —
-        // the shape `evaluate_bash_command` actually hands it — rather than
-        // the pre-split whole command, which has balanced quotes and would
-        // pass this check by construction.
+        // A co-process `|` inside a quoted awk program is a full shell escape
+        // (`print | "cmd"`, `"cmd" | getline`). Since #2734 the upstream
+        // splitter is quote-aware and no longer cuts the quoted `|` into an
+        // unbalanced fragment, so `awk_program_has_quoted_pipe_or_redirect`
+        // must detect the in-quote `|` directly on the whole segment.
         for cmd in [
             r#"awk 'BEGIN{print | "sort"}'"#,
             r#"awk 'BEGIN{"date" | getline}'"#,
         ] {
-            for fragment in super::super::split_shell_segments(cmd) {
-                let trimmed = fragment.trim();
-                if trimmed.starts_with("awk") {
-                    assert!(
-                        !awk_is_readonly(trimmed),
-                        "expected deny for split co-process fragment: {trimmed:?} (from {cmd})"
-                    );
-                }
-            }
+            assert!(
+                !awk_is_readonly(cmd),
+                "expected deny for co-process awk: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn awk_is_readonly_denies_in_program_redirect() {
+        // An in-program `print > "file"` / `>>` writes a file with no `-i` and
+        // no shell-level `>`; the now quote-aware outer redirection scan skips
+        // the quoted `>`, so awk must catch it itself (#2734).
+        for cmd in [
+            r#"awk '{print > "out.txt"}'"#,
+            r#"awk '{print $0 >> "log"}'"#,
+            r#"awk '{printf "%s", $1 > "f"}'"#,
+        ] {
+            assert!(!awk_is_readonly(cmd), "expected deny (in-program >): {cmd}");
         }
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
@@ -1,0 +1,369 @@
+//! Quote-aware shell lexing helpers for the PM Bash guard (issue #2734).
+//!
+//! Why: the original guard byte-scanned the RAW command string for composition
+//! operators, `>` redirections, and `$(`/backtick substitutions WITHOUT
+//! tracking quotes. That over-blocked legitimate PM commands whose *quoted
+//! argument content* merely contained those characters — most visibly
+//! `git commit -m 'spec -> code'`, whose `>`/`->` inside the single-quoted
+//! message tripped the file-write-redirection heuristic (Bob's live repro). It
+//! also mis-parsed `git`'s own global flags: a leading `-C <path>` (or
+//! `-c <kv>`, `--git-dir=…`) hid the real subcommand from the two-token
+//! matcher, so `git -C <path> commit` wasn't recognised as the allowlisted
+//! `git commit` and `git -C <path> apply` wasn't recognised as the forbidden
+//! `git apply` (a true-positive miss). This module centralises the quote-state
+//! tracking and git-argv parsing the scanners need to make policy decisions on
+//! command *structure*, not substrings of string literals.
+//! What: [`QuoteScan`] records, per byte, whether it lies inside a single- or
+//! double-quoted span (with a balanced-quote flag); [`git_subcommand`]
+//! shlex-splits a segment and returns the real git subcommand after skipping
+//! leading env/`sudo` noise and git global options.
+//! Test: `shell_lex::tests`.
+
+/// Quote context of a single byte of a shell command.
+///
+/// Why: the guard's operator/redirection/substitution scanners must treat a
+/// metacharacter inside quotes as literal data, not shell syntax. `Single` and
+/// `Double` differ because command substitution (`$(…)`, backticks) is still
+/// active inside double quotes but fully suppressed inside single quotes.
+/// What: the three POSIX quoting states.
+/// Test: `shell_lex::tests` (via [`QuoteScan`]).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum Quote {
+    /// Outside any quotes — metacharacters are live shell syntax.
+    None,
+    /// Inside `'…'` — everything literal, no substitution, no operators.
+    Single,
+    /// Inside `"…"` — operators literal, but `$(…)`/backticks still active.
+    Double,
+}
+
+/// Per-byte quote-context map of a shell command, plus a balanced flag.
+///
+/// Why: lets the sibling scanners ask "is byte `i` inside quotes?" so a `>`,
+/// `|`, `&&`, `$(`, or backtick that is merely quoted argument content is not
+/// mistaken for shell syntax. When quotes are *unbalanced* the parse is
+/// untrustworthy, so callers fall back to their proven quote-unaware scan (the
+/// conservative, over-blocking direction) rather than trust a partial map.
+/// What: [`QuoteScan::new`] walks the bytes once tracking quote state (POSIX
+/// backslash-escaping honoured outside single quotes), recording each byte's
+/// context; `balanced` is `true` iff every opened quote was closed.
+/// Test: `quote_scan_*`.
+pub(super) struct QuoteScan {
+    states: Vec<Quote>,
+    /// `true` when the command's quotes are all closed.
+    pub(super) balanced: bool,
+}
+
+impl QuoteScan {
+    /// Build the per-byte quote map for `command`.
+    ///
+    /// Why: single left-to-right pass so every scanner shares one definition of
+    /// "what is quoted", matching real shell tokenisation closely enough to
+    /// exclude quoted content while erring toward `None` (live syntax) on any
+    /// ambiguity.
+    /// What: tracks the current [`Quote`] state; outside single quotes a `\`
+    /// escapes the next byte (recorded in the same state); `'`/`"` open/close
+    /// their span only when not already inside the other kind. Records one
+    /// [`Quote`] per byte so `states[i]` is byte `i`'s context.
+    /// Test: `quote_scan_marks_single_and_double`, `quote_scan_backslash_escape`,
+    /// `quote_scan_reports_unbalanced`.
+    pub(super) fn new(command: &str) -> Self {
+        let bytes = command.as_bytes();
+        let mut states = Vec::with_capacity(bytes.len());
+        let mut cur = Quote::None;
+        let mut i = 0;
+        while i < bytes.len() {
+            let c = bytes[i];
+            match cur {
+                Quote::Single => {
+                    states.push(Quote::Single);
+                    if c == b'\'' {
+                        cur = Quote::None;
+                    }
+                    i += 1;
+                }
+                Quote::Double => {
+                    states.push(Quote::Double);
+                    if c == b'\\' && i + 1 < bytes.len() {
+                        // Backslash escapes the next byte inside double quotes.
+                        states.push(Quote::Double);
+                        i += 2;
+                    } else {
+                        if c == b'"' {
+                            cur = Quote::None;
+                        }
+                        i += 1;
+                    }
+                }
+                Quote::None => {
+                    if c == b'\\' && i + 1 < bytes.len() {
+                        states.push(Quote::None);
+                        states.push(Quote::None);
+                        i += 2;
+                    } else if c == b'\'' {
+                        states.push(Quote::Single);
+                        cur = Quote::Single;
+                        i += 1;
+                    } else if c == b'"' {
+                        states.push(Quote::Double);
+                        cur = Quote::Double;
+                        i += 1;
+                    } else {
+                        states.push(Quote::None);
+                        i += 1;
+                    }
+                }
+            }
+        }
+        QuoteScan {
+            states,
+            balanced: cur == Quote::None,
+        }
+    }
+
+    /// Quote context of byte `idx` (defaults to `None` past the end).
+    fn at(&self, idx: usize) -> Quote {
+        self.states.get(idx).copied().unwrap_or(Quote::None)
+    }
+
+    /// Whether byte `idx` is outside all quotes (a live shell metacharacter).
+    ///
+    /// Why: composition operators (`|`, `&&`, `;`, `&`, newline) and file-write
+    /// redirection (`>`) are only real syntax when unquoted.
+    /// What: `true` iff `at(idx) == None`.
+    /// Test: `quote_scan_marks_single_and_double`.
+    pub(super) fn is_unquoted(&self, idx: usize) -> bool {
+        self.at(idx) == Quote::None
+    }
+
+    /// Whether a command substitution (`$(`, backtick) at byte `idx` is live.
+    ///
+    /// Why: single quotes suppress substitution entirely, but double quotes do
+    /// NOT — `echo "$(sed -i …)"` still runs `sed`, so that case must remain
+    /// scannable while `echo '$(sed -i …)'` (literal) is excluded.
+    /// What: `true` when the byte is not inside single quotes.
+    /// Test: `quote_scan_substitution_live_in_double_quotes`.
+    pub(super) fn allows_substitution(&self, idx: usize) -> bool {
+        self.at(idx) != Quote::Single
+    }
+}
+
+/// Git global options that consume a following *separate* argv token.
+///
+/// Why: to reach the real subcommand the parser must skip both the flag and its
+/// argument (`git -C /path commit` → skip `-C` and `/path`, land on `commit`).
+/// The `=`-joined forms (`--git-dir=/p`) carry their value in the same token
+/// and are handled separately.
+/// What: the exhaustive set of value-taking git global options in their
+/// space-separated spelling.
+const GIT_GLOBAL_OPTS_WITH_ARG: &[&str] = &[
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--super-prefix",
+    "--config-env",
+];
+
+/// Resolve the real `git` subcommand of a single pipeline segment.
+///
+/// Why (issue #2734): the guard must recognise an allowlisted git subcommand
+/// (`commit`, `status`, …) — and the one forbidden one (`apply`) — through any
+/// leading git global flags, which the earlier two-token `effective_tool_name`
+/// matcher could not see past. Parsing the argv properly closes both the
+/// `git -C <path> commit` false positive and the `git -C <path> apply`
+/// false negative.
+/// What: shlex-splits `segment` (quote-aware; `None` on unbalanced quotes →
+/// caller falls back), skips leading `KEY=value`/`sudo`/`env` prefixes, requires
+/// the program basename to be `git`, then walks past global options — those in
+/// [`GIT_GLOBAL_OPTS_WITH_ARG`] consume an extra token, `=`-joined long options
+/// consume none, other dash-prefixed tokens are valueless global flags — and
+/// returns the first non-option token (the subcommand). `None` when the segment
+/// is not `git`, is unparseable, or has no subcommand after the options.
+/// Test: `git_subcommand_skips_global_flags`, `git_subcommand_plain`,
+/// `git_subcommand_none_for_non_git`, `git_subcommand_none_when_unbalanced`.
+pub(super) fn git_subcommand(segment: &str) -> Option<String> {
+    let argv = shlex::split(segment)?;
+    let mut i = 0;
+    // Skip env-assignment / sudo / env prefixes (mirrors first_command_token).
+    while i < argv.len() {
+        let tok = &argv[i];
+        if is_env_assignment(tok) {
+            i += 1;
+            continue;
+        }
+        if tok == "sudo" || tok == "env" {
+            match argv.get(i + 1) {
+                Some(next) if !next.starts_with('-') => {
+                    i += 1;
+                    continue;
+                }
+                // Flag or nothing after sudo/env — needs arg-aware parsing we
+                // don't do; not resolvable as git.
+                _ => return None,
+            }
+        }
+        break;
+    }
+    let program = argv.get(i)?;
+    if program.rsplit('/').next().unwrap_or(program) != "git" {
+        return None;
+    }
+    i += 1;
+    // Skip git global options to reach the subcommand.
+    while i < argv.len() {
+        let tok = &argv[i];
+        if tok == "--" {
+            // POSIX end-of-options; git has no subcommand before `--`, so
+            // whatever follows is not a subcommand context we allowlist.
+            return None;
+        }
+        if tok.starts_with("--") {
+            if tok.contains('=') {
+                i += 1;
+                continue;
+            }
+            if GIT_GLOBAL_OPTS_WITH_ARG.contains(&tok.as_str()) {
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        if tok.starts_with('-') && tok.len() > 1 {
+            if GIT_GLOBAL_OPTS_WITH_ARG.contains(&tok.as_str()) {
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        return Some(tok.clone());
+    }
+    None
+}
+
+/// Whether `token` looks like a `KEY=value` shell environment assignment.
+///
+/// Why: a leading env assignment (`FOO=bar git …`) must be skipped before the
+/// `git` program token, mirroring `hook_rewrite::first_command_token`'s rule so
+/// both code paths agree on what a prefix is.
+/// What: `KEY` non-empty, starting with a letter/underscore, alphanumerics or
+/// underscores up to the first `=`.
+/// Test: covered via `git_subcommand_skips_global_flags`.
+fn is_env_assignment(token: &str) -> bool {
+    let Some((key, _)) = token.split_once('=') else {
+        return false;
+    };
+    let mut chars = key.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quote_scan_marks_single_and_double() {
+        let scan = QuoteScan::new("a '>' b \">\" c");
+        assert!(scan.balanced);
+        // Byte 0 'a' unquoted; the two `>` are inside quotes.
+        assert!(scan.is_unquoted(0));
+        let s: String = "a '>' b \">\" c".to_string();
+        let first_gt = s.find('>').unwrap();
+        let last_gt = s.rfind('>').unwrap();
+        assert!(!scan.is_unquoted(first_gt), "first > is single-quoted");
+        assert!(!scan.is_unquoted(last_gt), "second > is double-quoted");
+    }
+
+    #[test]
+    fn quote_scan_backslash_escape() {
+        // An escaped quote outside quotes must NOT open a span.
+        let scan = QuoteScan::new(r#"echo \" ok"#);
+        assert!(scan.balanced, "escaped quote must not open a span");
+    }
+
+    #[test]
+    fn quote_scan_reports_unbalanced() {
+        assert!(!QuoteScan::new("echo 'unterminated").balanced);
+        assert!(!QuoteScan::new("echo \"unterminated").balanced);
+        assert!(QuoteScan::new("echo 'closed'").balanced);
+    }
+
+    #[test]
+    fn quote_scan_substitution_live_in_double_quotes() {
+        // `$(` inside double quotes is still live; inside single quotes it is
+        // literal.
+        let dq = "echo \"$(x)\"";
+        let scan = QuoteScan::new(dq);
+        let dollar = dq.find('$').unwrap();
+        assert!(scan.allows_substitution(dollar), "double-quoted $( is live");
+
+        let sq = "echo '$(x)'";
+        let scan = QuoteScan::new(sq);
+        let dollar = sq.find('$').unwrap();
+        assert!(
+            !scan.allows_substitution(dollar),
+            "single-quoted $( is literal"
+        );
+    }
+
+    #[test]
+    fn git_subcommand_plain() {
+        assert_eq!(git_subcommand("git commit -m x").as_deref(), Some("commit"));
+        assert_eq!(git_subcommand("git status").as_deref(), Some("status"));
+        assert_eq!(git_subcommand("git log --oneline").as_deref(), Some("log"));
+        assert_eq!(git_subcommand("git apply p.diff").as_deref(), Some("apply"));
+    }
+
+    #[test]
+    fn git_subcommand_skips_global_flags() {
+        assert_eq!(
+            git_subcommand("git -C /some/path commit -m x").as_deref(),
+            Some("commit")
+        );
+        assert_eq!(
+            git_subcommand("git -C /some/path apply p.diff").as_deref(),
+            Some("apply")
+        );
+        assert_eq!(
+            git_subcommand("git -c user.name=x commit").as_deref(),
+            Some("commit")
+        );
+        assert_eq!(
+            git_subcommand("git --git-dir=/p/.git status").as_deref(),
+            Some("status")
+        );
+        assert_eq!(
+            git_subcommand("git --work-tree /p -C /p diff").as_deref(),
+            Some("diff")
+        );
+        assert_eq!(
+            git_subcommand("FOO=bar git -C /p push").as_deref(),
+            Some("push")
+        );
+    }
+
+    #[test]
+    fn git_subcommand_none_for_non_git() {
+        assert_eq!(git_subcommand("ls -la"), None);
+        assert_eq!(git_subcommand("cargo test"), None);
+        assert_eq!(git_subcommand("gitfoo status"), None);
+    }
+
+    #[test]
+    fn git_subcommand_none_when_unbalanced() {
+        // Unbalanced quotes → shlex returns None → caller falls back.
+        assert_eq!(git_subcommand("git commit -m 'unterminated"), None);
+    }
+
+    #[test]
+    fn git_subcommand_resolves_path_program() {
+        assert_eq!(
+            git_subcommand("/usr/bin/git -C /p commit").as_deref(),
+            Some("commit")
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -1,0 +1,564 @@
+//! Unit tests for the PM Bash-command classifier (`super`), relocated out of
+//! `mod.rs` (issue #2734) so the production file stays under the 500-SLOC cap.
+//! `tests.rs` is classified as a test file (1500-SLOC cap).
+
+use super::*;
+
+#[test]
+fn evaluate_bash_command_denies_shell_edit_verbs() {
+    for cmd in [
+        "sed -i s/a/b/ src/lib.rs",
+        "sed -i.bak s/a/b/ src/lib.rs",
+        "awk -i inplace '{print}' f",
+        "patch -p1 < d.patch",
+        "git apply my.patch",
+        "FOO=1 sed -i s/a/b/ f",
+        "sudo patch -p0 x",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            Some(SHELL_EDIT_REASON),
+            "expected shell-edit deny for: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_allows_readonly_sed_awk() {
+    // #2664: sed/awk used as narrowly read-only stream filters (no
+    // in-place flag, no external script, no write/exec construct,
+    // balanced quotes) must not be blanket-denied by name.
+    for cmd in [
+        "git status --porcelain | awk '{print $1}' | sort | uniq -c",
+        "sed -n '1,5p' file.txt",
+        "git log | awk '{print $1}'",
+        "cat f | sed 's/a/b/'",
+        "sed 's/a/b/g' f | grep x",
+        // Code-critic re-review MEDIUM: an apostrophe/single-quote inside
+        // a double-quoted read-only script must not be over-denied.
+        r#"sed "s/can't/cannot/" f"#,
+        r#"awk -F"'" '{print $2}'"#,
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "expected allow for read-only sed/awk: {cmd:?}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_awk_shell_escape_holes() {
+    // Code-critic BLOCK on PR #2677: awk's `system()` builtin runs an
+    // arbitrary shell command with no `-i` and no `>` — the
+    // allow-by-default design missed this entirely.
+    for cmd in [
+        r#"awk 'BEGIN{system("touch /tmp/x")}'"#,
+        r#"awk 'BEGIN{system("curl https://evil/x")}'"#,
+        // Code-critic re-review CRITICAL: AWK tolerates whitespace
+        // between a builtin name and its `(` — `system ("...")` (space)
+        // executes exactly like `system("...")` and was missed by a
+        // no-space-only substring check.
+        r#"awk 'BEGIN{system ("touch /tmp/x")}'"#,
+        "awk 'BEGIN{system\t(\"echo x\")}'",
+        // A co-process pipe/read inside the awk program is itself a
+        // bare `|`/`;` from the (quote-unaware) segment splitter's point
+        // of view, so it fragments the quoted program and leaves an
+        // unbalanced quote count in the resulting segment — denied.
+        r#"awk 'BEGIN{print | "sort"}'"#,
+        r#"awk 'BEGIN{"date" | getline}'"#,
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            Some(SHELL_EDIT_REASON),
+            "expected shell-edit deny for awk shell-escape: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_sed_e_w_commands() {
+    // sed's `e` (execute) and `w`/`W` (write-to-file) commands need no
+    // `-i` and no `>` — a bare verb-name deny-list miss, closed by
+    // deny-by-default + script-content analysis in `sed_awk`.
+    for cmd in [
+        "sed '1e touch /tmp/x' f",
+        "sed -n '1,5w /tmp/out' f",
+        "sed 's/a/b/e' f",
+        "sed 's/a/b/w /tmp/out' f",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            Some(SHELL_EDIT_REASON),
+            "expected shell-edit deny for sed e/w command: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_external_script_load() {
+    // `-f`/`--file` loads a script the guard cannot see — it may contain
+    // any of the w/e/system holes above, so deny unconditionally.
+    for cmd in ["sed -f script.sed f", "awk -f script.awk f"] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            Some(SHELL_EDIT_REASON),
+            "expected shell-edit deny for external script load: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_sed_in_place_abbreviations() {
+    // GNU getopt long-option abbreviations of `--in-place` must still
+    // deny, not just the exact spelling.
+    for cmd in [
+        "sed --in s/a/b/ f",
+        "sed --in-p s/a/b/ f",
+        "sed --in=bak s/a/b/ f",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            Some(SHELL_EDIT_REASON),
+            "expected shell-edit deny for --in-place abbreviation: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_awk_family_verbs() {
+    // gawk/nawk/mawk are the same in-place-edit-capable interpreter
+    // family as awk and must be classified identically.
+    assert_eq!(
+        evaluate_bash_command("gawk -i inplace '{print}' f"),
+        Some(SHELL_EDIT_REASON)
+    );
+    assert_eq!(
+        evaluate_bash_command(r#"nawk 'BEGIN{system("id")}'"#),
+        Some(SHELL_EDIT_REASON)
+    );
+    assert_eq!(
+        evaluate_bash_command("gawk '{print $1}'"),
+        None,
+        "read-only gawk must still allow"
+    );
+}
+
+#[test]
+fn evaluate_bash_command_denies_redirection_write() {
+    assert_eq!(
+        evaluate_bash_command("echo 'code' > src/lib.rs"),
+        Some(SHELL_EDIT_REASON)
+    );
+    assert_eq!(
+        evaluate_bash_command("printf x >> notes.txt"),
+        Some(SHELL_EDIT_REASON)
+    );
+}
+
+#[test]
+fn evaluate_bash_command_denies_build_and_test() {
+    for cmd in ["make build", "pytest -q", "npm test"] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            Some(BUILD_TEST_REASON),
+            "expected build/test deny for: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_network() {
+    for cmd in ["curl https://example.com", "wget https://example.com/x"] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            Some(NETWORK_REASON),
+            "expected network deny for: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_allows_normal_shell() {
+    for cmd in [
+        "",
+        "   ",
+        "git status",
+        "git add -A",
+        "git commit -m x",
+        "git log --oneline",
+        "git diff",
+        "git push",
+        "ls -la",
+        "grep -rn foo src",
+        "cat README.md",
+        "cargo tree 2>&1", // fd-dup, not a file write
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "expected allow for: {cmd:?}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_composition_hidden_verbs() {
+    // A benign leading verb must NOT hide a forbidden verb in a later
+    // composed segment (the shell-composition bypass, PR #1985).
+    assert_eq!(
+        evaluate_bash_command("cd repo && sed -i s/a/b/ f"),
+        Some(SHELL_EDIT_REASON)
+    );
+    assert_eq!(
+        evaluate_bash_command("true; make build"),
+        Some(BUILD_TEST_REASON)
+    );
+    assert_eq!(
+        evaluate_bash_command("x || pytest"),
+        Some(BUILD_TEST_REASON)
+    );
+    assert_eq!(
+        evaluate_bash_command("ls && git apply p.diff"),
+        Some(SHELL_EDIT_REASON)
+    );
+    // Redirection hidden after a benign first segment still denies.
+    assert_eq!(
+        evaluate_bash_command("cd repo && echo x > out.txt"),
+        Some(SHELL_EDIT_REASON)
+    );
+}
+
+#[test]
+fn evaluate_bash_command_denies_bare_ampersand_composition() {
+    // A bare `&` (background separator) must NOT hide a forbidden trailing
+    // verb — the bare-`&` composition bypass (second adversarial review).
+    assert_eq!(
+        evaluate_bash_command("true & sed -i s/a/b/ f"),
+        Some(SHELL_EDIT_REASON)
+    );
+    assert_eq!(
+        evaluate_bash_command("cd x & make build"),
+        Some(BUILD_TEST_REASON)
+    );
+    assert_eq!(evaluate_bash_command("x & pytest"), Some(BUILD_TEST_REASON));
+    // Newline is a separator too.
+    assert_eq!(
+        evaluate_bash_command("cd repo\nsed -i s/a/b/ f"),
+        Some(SHELL_EDIT_REASON)
+    );
+}
+
+#[test]
+fn evaluate_bash_command_allows_trailing_background() {
+    // Trailing background `&` with nothing after must not become a spurious
+    // forbidden segment, and fd-dups must not be treated as separators.
+    for cmd in ["sleep 1 &", "cargo tree 2>&1", "foo >&2"] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "expected allow for: {cmd:?}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_allows_benign_pipes() {
+    // Composition where NO segment is a forbidden verb must still allow —
+    // we do not blanket-deny all composition.
+    for cmd in [
+        "git log | head",
+        "cat f | grep x",
+        "ls | wc -l",
+        "git diff && git status",
+        "cd repo; ls -la",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "expected allow for benign composition: {cmd:?}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_allows_dev_null_redirect() {
+    // `/dev/null` is an output-discard sink, not a file write.
+    for cmd in ["which cargo 2>/dev/null", "command -v foo >/dev/null"] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "expected allow for /dev/null discard: {cmd:?}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_hidden_substitution_verb() {
+    // A forbidden verb inside a command substitution must be caught.
+    assert_eq!(
+        evaluate_bash_command("echo \"$(sed -i s/a/b/ f)\""),
+        Some(SHELL_EDIT_REASON)
+    );
+    assert_eq!(
+        evaluate_bash_command("x=`make build`"),
+        Some(BUILD_TEST_REASON)
+    );
+}
+
+#[test]
+fn evaluate_bash_command_allows_benign_substitution() {
+    // Trivial substitutions with benign bodies must not be over-blocked.
+    for cmd in [
+        "echo \"$(date)\"",
+        "cd \"$(git rev-parse --show-toplevel)\"",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "expected allow for benign substitution: {cmd:?}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_unbalanced_substitution() {
+    // An unbalanced substitution we cannot decompose denies conservatively.
+    assert_eq!(
+        evaluate_bash_command("echo $(sed -i"),
+        Some(SHELL_EDIT_REASON)
+    );
+    assert_eq!(evaluate_bash_command("echo `foo"), Some(SHELL_EDIT_REASON));
+}
+
+#[test]
+fn evaluate_bash_command_bounds_deep_substitution_nesting() {
+    // Adversarial deep `$(` nesting must return a decision without panicking
+    // (stack-exhaustion guard). A deny is the acceptable safe outcome.
+    let deep = format!("echo {}", "$(".repeat(200));
+    let decision = evaluate_bash_command(&deep);
+    assert!(decision.is_some(), "deep nesting must deny, got allow");
+    // Balanced-but-deep nesting is also bounded (no panic, returns a value).
+    let balanced = format!("echo {}date{}", "$(".repeat(200), ")".repeat(200));
+    let _ = evaluate_bash_command(&balanced);
+}
+
+#[test]
+fn split_shell_segments_splits_operators() {
+    assert_eq!(
+        split_shell_segments("a && b || c ; d | e"),
+        vec!["a ", " b ", " c ", " d ", " e"]
+    );
+}
+
+#[test]
+fn split_shell_segments_splits_bare_ampersand() {
+    // A bare `&` with a following command splits; fd-dups and trailing
+    // background do not.
+    assert_eq!(split_shell_segments("a & b"), vec!["a ", " b"]);
+    assert_eq!(split_shell_segments("foo &"), vec!["foo &"]);
+    assert_eq!(
+        split_shell_segments("cargo test 2>&1"),
+        vec!["cargo test 2>&1"]
+    );
+    assert_eq!(split_shell_segments("foo >&2"), vec!["foo >&2"]);
+    // Newline splits.
+    assert_eq!(split_shell_segments("a\nb"), vec!["a", "b"]);
+}
+
+#[test]
+fn split_shell_segments_single_command() {
+    assert_eq!(split_shell_segments("git status"), vec!["git status"]);
+    // Backgrounding `&` (nothing after) is not a split point.
+    assert_eq!(split_shell_segments("foo &"), vec!["foo &"]);
+}
+
+#[test]
+fn has_file_write_redirection_detects_write() {
+    assert!(has_file_write_redirection("echo x > f"));
+    assert!(has_file_write_redirection("echo x >f.rs"));
+}
+
+#[test]
+fn has_file_write_redirection_detects_append() {
+    assert!(has_file_write_redirection("echo x >> f"));
+}
+
+#[test]
+fn has_file_write_redirection_ignores_fd_dup() {
+    assert!(!has_file_write_redirection("cargo test 2>&1"));
+    assert!(!has_file_write_redirection("foo >&2"));
+}
+
+#[test]
+fn has_file_write_redirection_ignores_dev_null() {
+    // Discarding output to /dev/null is not a file write.
+    assert!(!has_file_write_redirection("which cargo 2>/dev/null"));
+    assert!(!has_file_write_redirection("command -v foo >/dev/null"));
+    assert!(!has_file_write_redirection("foo &>/dev/null"));
+    // A real file write with the same shape still denies.
+    assert!(has_file_write_redirection("echo x > /dev/null.txt"));
+    assert!(has_file_write_redirection("echo x > out.txt"));
+}
+
+#[test]
+fn has_file_write_redirection_false_for_plain_command() {
+    assert!(!has_file_write_redirection("git status"));
+}
+
+// ---- #2734: git global flags + quoted-content false positives -----------
+
+#[test]
+fn evaluate_bash_command_allows_bob_git_commit_repro() {
+    // Bob's live repro: an allowlisted `git commit` denied as a shell edit
+    // because a `>` / `->` inside the single-quoted `-m` body tripped the
+    // (then quote-unaware) file-write-redirection scan, compounded by the
+    // leading `-C <path>` global flag hiding the `commit` subcommand.
+    let cmd = r#"git -C /Users/masa/trusty-mpm-projects/bobmatnyc/writing commit -q -m 'feat(hyperdev): draft "SDD: When The Spec Becomes Part Of The Code"' -m 'HyperDev deep-dive: the spec IS the code — SDD flips the pipeline so spec > impl'"#;
+    assert_eq!(
+        evaluate_bash_command(cmd),
+        None,
+        "Bob's git commit with quoted prose must be allowed"
+    );
+}
+
+#[test]
+fn evaluate_bash_command_allows_git_commit_with_quoted_operators() {
+    // A `-m` message may legitimately contain any shell metacharacter as prose;
+    // none of it is shell syntax, so the commit stays allowed.
+    for cmd in [
+        r#"git commit -m 'spec -> code'"#,
+        r#"git commit -m 'a > b'"#,
+        r#"git commit -m 'pipe a | b then c'"#,
+        r#"git commit -m 'run make && test'"#,
+        r#"git commit -m 'costs $(x) or `y`'"#,
+        r#"git commit -m 'use sed -i to fix; then awk'"#,
+        r#"git commit -m "double > quoted -> ok""#,
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "quoted prose must not trip a deny: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_allows_git_global_flags() {
+    // Allowlisted git subcommands must be recognised through leading global
+    // flags (`-C <path>`, `-c <kv>`, `--git-dir=…`).
+    for cmd in [
+        "git -C /some/path status",
+        "git -C /some/path log --oneline",
+        "git -C /some/path diff",
+        "git -C /some/path commit -m x",
+        "git -c user.name=x -c user.email=y@z commit -m x",
+        "git --git-dir=/p/.git --work-tree=/p status",
+        "git -C /some/path push --force",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "git through global flags must be allowed: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_git_apply_through_global_flags() {
+    // The one forbidden git subcommand must still be caught through global
+    // flags — closing the `git -C <path> apply` under-deny hole.
+    for cmd in [
+        "git apply my.patch",
+        "git -C /some/path apply my.patch",
+        "git -c core.pager=x apply my.patch",
+        "git --git-dir=/p/.git apply my.patch",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            Some(SHELL_EDIT_REASON),
+            "git apply must deny through global flags: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_preserves_true_positives_after_quote_awareness() {
+    // Quote-awareness must NOT weaken real shell-level edits/pipes/redirects.
+    let shell_edit = [
+        "sed -i s/a/b/ src/lib.rs",
+        "echo 'code' > src/lib.rs",
+        "printf x >> src/lib.rs",
+        r#"awk '{print}' > out.rs"#,      // unquoted redirect
+        r#"awk 'BEGIN{print | "sort"}'"#, // quoted co-process
+        r#"awk '{print > "out.rs"}'"#,    // in-program redirect
+        "git apply p.diff",
+        "cat f | sed -i s/a/b/ g", // forbidden verb in a real pipe
+    ];
+    for cmd in shell_edit {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            Some(SHELL_EDIT_REASON),
+            "must still deny shell edit: {cmd}"
+        );
+    }
+    // #2664 read-only sed/awk carve-out still ALLOWS.
+    for cmd in [
+        "git status --porcelain | awk '{print $1}' | sort | uniq -c",
+        "sed -n '1,5p' file.txt",
+        "cat f | sed 's/a/b/'",
+        r#"sed "s/can't/cannot/" f"#,
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "read-only sed/awk must still allow: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn split_shell_segments_ignores_quoted_operators() {
+    // Operators inside quotes are literal data, not separators.
+    assert_eq!(
+        split_shell_segments("git commit -m 'a | b'"),
+        vec!["git commit -m 'a | b'"]
+    );
+    assert_eq!(
+        split_shell_segments("echo 'x && y ; z'"),
+        vec!["echo 'x && y ; z'"]
+    );
+    // Unquoted operators still split.
+    assert_eq!(split_shell_segments("a | b"), vec!["a ", " b"]);
+    // Unbalanced quotes fall back to the quote-unaware split.
+    assert_eq!(
+        split_shell_segments("echo 'unterminated | b"),
+        vec!["echo 'unterminated ", " b"]
+    );
+}
+
+#[test]
+fn has_file_write_redirection_ignores_quoted_gt() {
+    // A `>` inside quotes is literal; an unquoted one is a real redirect.
+    assert!(!has_file_write_redirection("git commit -m 'spec > code'"));
+    assert!(!has_file_write_redirection(r#"echo "a -> b""#));
+    assert!(has_file_write_redirection("echo x > f.rs"));
+    // Unbalanced quotes fall back to scanning all bytes.
+    assert!(has_file_write_redirection("echo 'oops > f.rs"));
+}
+
+#[test]
+fn evaluate_bash_command_allows_quoted_substitution_prose() {
+    // `$(`/backtick inside SINGLE quotes is literal; inside DOUBLE quotes it is
+    // still live and a forbidden body still denies.
+    assert_eq!(
+        evaluate_bash_command(r#"git commit -m 'run $(sed -i x) maybe'"#),
+        None,
+        "single-quoted substitution is literal prose"
+    );
+    assert_eq!(
+        evaluate_bash_command(r#"echo "$(sed -i s/a/b/ f)""#),
+        Some(SHELL_EDIT_REASON),
+        "double-quoted substitution is still live"
+    );
+}


### PR DESCRIPTION
## Problem (Bob's live repro)

The PM Bash guard (`tm hook --pm-guard`) denied a plain, allowlisted `git commit` as a shell edit:

```
git -C /Users/masa/trusty-mpm-projects/bobmatnyc/writing commit -q -m 'feat(hyperdev): draft "SDD: When The Spec Becomes Part Of The Code"' -m 'HyperDev deep-di…'
```

> PM must not edit files via shell tools (sed/awk/patch/git apply/redirection) (prohibitions P1–P3). Delegate the change to rust-engineer via the Task/Agent tool.

`git commit` is explicitly PM-allowlisted. False positive. Closes #2734.

## Root cause found (hypothesis (b), plus latent (a))

Empirically confirmed against `crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/`:

- **(b) fired for Bob's command.** `has_file_write_redirection` byte-scans the RAW command including quoted content, so a `>` / `->` inside the single-quoted `-m` body read as a file-write redirect. Reproduced: `… -m 'spec -> code'` and `… -m 'spec > code'` both deny; the title-only prefix allows.
- **(a) is a real latent hole.** `git -C /path apply foo.patch` returned *allow* (should deny) — the `-C <path>` global flag hid the `apply` subcommand from the two-token `effective_tool_name` matcher. Fixed here too.

## Fix design

New `pm_guard_bash/shell_lex.rs`:

- **`QuoteScan`** — per-byte single/double-quote map (+ `balanced` flag). The segment splitter, redirection scan, and substitution scan now skip quoted bytes **when quotes are balanced**, and **fall back to the original quote-unaware scan when unbalanced** (the conservative, over-blocking direction the sed/awk detection historically relied on). Single quotes suppress substitution; double quotes do not (`echo "$(sed -i …)"` still denies).
- **`git_subcommand`** — shlex-splits the segment and resolves the real git subcommand past global flags (`-C <path>`, `-c <kv>`, `--git-dir=…`, `--work-tree`, …). `git -C <path> commit` → allowed; `git -C <path> apply` → denied.
- **Compensating control** in `sed_awk::awk_is_readonly`: because the outer scanners no longer see quoted `|`/`>`, awk now detects in-program co-process pipes (`print | "cmd"`, `"cmd" | getline`) and output redirects (`print > "file"`) itself — preserving those true positives.
- mod.rs inline tests relocated to a sibling `tests.rs` (1500-SLOC test-file cap) to keep the production file under the 500-SLOC cap.

## Deny / allow test matrix

**Now ALLOWED (were false-denied):**
- Bob's exact repro (`git -C … commit -q -m '…' -m '…spec > impl'`)
- `git commit -m 'spec -> code'`, `'a > b'`, `'pipe a | b'`, `'run make && test'`, `'costs $(x) or \`y\`'`, `'use sed -i to fix; then awk'`
- `git -C /p status|log|diff|commit`, `git -c k=v commit`, `git --git-dir=… --work-tree=… status`, `git -C /p push --force`
- `git commit -m 'run $(sed -i x) maybe'` (single-quoted substitution is literal)

**Still DENIED (true positives preserved):**
- `sed -i s/a/b/ src/lib.rs`, `echo x > src/lib.rs`, `printf x >> f`, `git apply p.diff`
- `git -C /p apply p.diff`, `git -c core.pager=x apply p.diff`, `git --git-dir=… apply p.diff` (closes the under-deny hole)
- `awk '{print}' > out.rs` (unquoted redirect), `awk 'BEGIN{print | "sort"}'` (co-process), `awk '{print > "out.rs"}'` (in-program write)
- `echo "$(sed -i s/a/b/ f)"` (double-quoted substitution is live)

**Read-only #2664 carve-out still ALLOWS:** `git status --porcelain | awk '{print $1}' | sort | uniq -c`, `sed -n '1,5p' f`, `cat f | sed 's/a/b/'`, `sed "s/can't/cannot/" f`.

## Gates (raw)

- `cargo build --workspace` → ok
- `cargo test -p trusty-mpm` → ok (all green; pm_guard_bash: 64 passed)
- `cargo test --workspace` → ok (0 failed)
- `cargo clippy --workspace --all-targets -- -D warnings` → ok (exit 0)
- `cargo fmt --check` → ok
- `bash scripts/check_line_cap.sh` → OK (0 violations)
- `bash scripts/check_test_pointers.sh` → ok (exit 0)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
