### PR TITLE
fix(trusty-mpm): reconcile zombie-active sessions on in-place relaunch (closes #2743)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -101,54 +101,67 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
             // Safe to attempt: its daemon reactivate call independently
             // reconciles a stale-`Active` record whose pane is confirmed
             // idle (#2453 daemon-side fix, `daemon::managed_routes::
-            // reactivate::reconcile_stale_active_then_reactivate`) and
-            // refuses — falling through to the notice + reconnect below —
-            // when the runtime is still genuinely live.
+            // reactivate::reconcile_stale_active_then_reactivate`) — and, as
+            // of #2789, no longer 409s just because the requesting `tm` is
+            // this pane's own foreground command (the caller's pane_id is
+            // forwarded so the daemon treats it as idle). It still refuses
+            // when the runtime is genuinely live in a SIBLING window.
             match super::guided_inplace::run_inplace_relaunch(
                 client,
                 url,
                 &record.id,
                 record.clone(),
+                current_pane_id.as_deref(),
             )
             .await
             {
                 super::guided_inplace::InPlaceOutcome::Result(Ok(())) => return Ok(()),
                 super::guided_inplace::InPlaceOutcome::Result(Err(e)) => {
-                    // #2456 review finding 2: a failure here — whether it
-                    // happened BEFORE any daemon mutation (cwd resolution,
-                    // resolving the `claude` binary) or the `exec` syscall
-                    // itself failing AFTER a successful reactivate — must
-                    // not hard-fail this call site the way it correctly does
-                    // for `try_inplace_relaunch`'s OWN env-var entry point
-                    // (component C). Pre-#2453 this whole branch always fell
-                    // back to `resume_guided_session`'s switch-client
-                    // reconnect for every one of these scenarios; regressing
-                    // that to a hard non-zero exit — e.g. simply because
-                    // `claude` is not on THIS pane's `PATH` — would be worse
-                    // than the original bug. Report the concrete error and
-                    // fall back exactly like a daemon-refused reactivate.
-                    eprintln!("tm: in-place relaunch failed ({e}) — falling back to reconnect…");
+                    // #2789: we are provably inside THIS record's OWN pane
+                    // (`pane_identity_confirmed`). The pre-existing fallback —
+                    // `resume_guided_session` → `switch-client -t <this very
+                    // session>` — is a guaranteed NO-OP that strands the
+                    // operator in the bare shell they are already looking at
+                    // (the reported dead-end). Report the failure honestly and
+                    // tell them how to relaunch the agent in THIS pane, instead
+                    // of the misleading "switching client" no-op. A failure
+                    // here — pre-mutation (cwd/`claude`-binary resolution) or
+                    // the `exec` itself — must NOT hard-fail (exit non-zero),
+                    // matching the #2456 finding-2 contract for this call site.
+                    eprintln!("tm: in-place relaunch failed ({e})");
+                    eprintln!("{}", inplace_self_relaunch_hint(&record));
+                    return Ok(());
                 }
                 super::guided_inplace::InPlaceOutcome::FallThrough => {
+                    // #2789: the daemon still declined to reconcile — a
+                    // genuinely live sibling window keeps the tmux session
+                    // busy (the correct #2157 refusal), or the daemon predates
+                    // the caller-pane reconcile. Either way a switch-client to
+                    // the session this pane already belongs to is a no-op, so
+                    // do NOT offer it; give the honest self-relaunch hint.
                     eprintln!(
-                        "tm: in-place relaunch unavailable for '{}' (state={}) — {}",
-                        record.name,
-                        record.state,
-                        nested_guard_notice(&record.name)
+                        "tm: in-place relaunch unavailable for '{}' (state={})",
+                        record.name, record.state
                     );
+                    eprintln!("{}", inplace_self_relaunch_hint(&record));
+                    return Ok(());
                 }
             }
-        } else {
-            eprintln!(
-                "tm: this tmux session ('{}') is already a managed session (state={}) — {}",
-                record.name,
-                record.state,
-                nested_guard_notice(&record.name)
-            );
         }
+
+        // Session-name-only match: the operator is in a DIFFERENT pane/window of
+        // the SAME tmux session (not the record's own pane), so a switch-client
+        // reconnect to the managed session is legitimate — not a self no-op.
+        // Preserve the pre-existing refuse+reconnect behavior for that case.
         // Terminal entry point (not a loop) — the `AttachOutcome` only matters to
         // a looping caller like `run_tty_picker` (#2678); here, the hand-off (or
         // fail-closed skip) is this call's whole job, so discard it.
+        eprintln!(
+            "tm: this tmux session ('{}') is already a managed session (state={}) — {}",
+            record.name,
+            record.state,
+            nested_guard_notice(&record.name)
+        );
         super::guided_resume::resume_guided_session(client, url, &record).await?;
         return Ok(());
     }
@@ -426,6 +439,35 @@ pub(crate) fn pane_identity_confirmed(
 /// `nested_guard_notice_mentions_reconnect_target`.
 pub(crate) fn nested_guard_notice(name: &str) -> String {
     format!("not nesting a new session here; reconnecting to '{name}' instead…")
+}
+
+/// Actionable hint (#2789) printed when bare `tm` runs inside a managed
+/// session's OWN pane (pane identity confirmed) but the in-place relaunch could
+/// not proceed.
+///
+/// Why: reconnecting to the very session whose pane the operator is already
+/// inside is a `switch-client` no-op that strands them in a bare shell — the
+/// reported dead-end (`tm-cto-01` transcript). When the in-place relaunch
+/// cannot run (a genuinely live sibling window, a daemon predating the
+/// caller-pane reconcile, or a failed `exec`), the honest response is to tell
+/// the operator how to relaunch the agent in THIS pane themselves rather than
+/// pretend a reconnect happened.
+/// What: a single-line hint. When `record.claude_session_id` is present, it
+/// suggests `claude --resume <id>` (resume the exact conversation); otherwise a
+/// bare `claude`. Pure — takes an already-fetched record, returns the string.
+/// Test: `inplace_self_relaunch_hint_uses_resume_when_session_id_present`,
+/// `inplace_self_relaunch_hint_bare_claude_when_no_session_id`.
+pub(crate) fn inplace_self_relaunch_hint(
+    record: &trusty_mpm::client::ManagedSessionSummary,
+) -> String {
+    let relaunch = match record.claude_session_id.as_deref() {
+        Some(sid) if !sid.trim().is_empty() => format!("claude --resume {sid}"),
+        _ => "claude".to_string(),
+    };
+    format!(
+        "tm: you are already inside this session's pane — its agent has exited; \
+         relaunch it here with:  {relaunch}"
+    )
 }
 
 /// Fetch EVERY managed session, unfiltered — `GET /api/v1/sessions/managed`

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -301,13 +301,24 @@ async fn fetch_managed_session_until_stopped(
 /// now `Active`. Returns `false` on any other outcome (4xx/5xx or a network
 /// error), each logged with the concrete reason; the caller ABORTS the
 /// in-place path on `false` and falls through to the ordinary guided picker.
+/// When `caller_pane_id` is `Some`, it is forwarded as a `?caller_pane_id=`
+/// query param (#2789) so the daemon's stale-`Active` reconcile can treat THIS
+/// pane — whose foreground command is the requesting `tm` itself — as idle
+/// instead of counting it as a live runtime and returning 409.
 /// Test: I/O path; not unit-tested (requires a live daemon).
-async fn reactivate_managed_session(client: &reqwest::Client, url: &str, id: &str) -> bool {
-    let result = client
+async fn reactivate_managed_session(
+    client: &reqwest::Client,
+    url: &str,
+    id: &str,
+    caller_pane_id: Option<&str>,
+) -> bool {
+    let mut req = client
         .post(format!("{url}/api/v1/sessions/managed/{id}/reactivate"))
-        .timeout(PROBE_TIMEOUT)
-        .send()
-        .await;
+        .timeout(PROBE_TIMEOUT);
+    if let Some(pane_id) = caller_pane_id.filter(|s| !s.is_empty()) {
+        req = req.query(&[("caller_pane_id", pane_id)]);
+    }
+    let result = req.send().await;
     match result {
         Ok(resp) if resp.status().is_success() => true,
         Ok(resp) => {
@@ -431,6 +442,7 @@ pub(crate) async fn run_inplace_relaunch(
     url: &str,
     id: &str,
     record: trusty_mpm::client::ManagedSessionSummary,
+    caller_pane_id: Option<&str>,
 ) -> InPlaceOutcome {
     eprintln!("tm: this pane belongs to managed session {id} — relaunching in place…");
 
@@ -459,7 +471,9 @@ pub(crate) async fn run_inplace_relaunch(
 
     // Reactivate immediately before exec — and HONOR the result (#2027):
     // a refused/failed reactivate aborts rather than proceeding to exec.
-    if !reactivate_managed_session(client, url, id).await {
+    // #2789: forward this pane's own id so the daemon's stale-`Active`
+    // reconcile does not count the requesting `tm` process as a live runtime.
+    if !reactivate_managed_session(client, url, id, caller_pane_id).await {
         return InPlaceOutcome::FallThrough;
     }
 
@@ -553,7 +567,9 @@ pub(crate) async fn try_inplace_relaunch(
                 );
                 return None;
             }
-            match run_inplace_relaunch(client, url, &env_id, record).await {
+            match run_inplace_relaunch(client, url, &env_id, record, current_pane_id.as_deref())
+                .await
+            {
                 InPlaceOutcome::Result(r) => Some(r),
                 InPlaceOutcome::FallThrough => {
                     tracing::debug!(
@@ -578,353 +594,4 @@ pub(crate) async fn try_inplace_relaunch(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::{TcpListener, TcpStream};
-
-    use super::*;
-
-    const TEST_ID: &str = "11111111-2222-3333-4444-555555555555";
-
-    /// Spawn a background HTTP mock that replies `status_line` (+ empty JSON
-    /// body) to every connection, counting hits.
-    ///
-    /// Why: `reactivate_managed_session`'s status-code handling (#2027) needs
-    /// a real HTTP round-trip to exercise reqwest's response parsing; this
-    /// mirrors `core::sm::providers::test_support`'s "read the full request
-    /// before replying" mock convention (that helper is `pub(crate)` to the
-    /// `trusty-mpm` LIB crate and unreachable from this `bin/tm` BINARY crate
-    /// — a separate compilation unit — hence the small inline copy in
-    /// [`read_full_request`] below, rather than pulling in an external
-    /// mock-server dependency for one test file).
-    /// What: binds an ephemeral port, loops accepting connections, and for
-    /// each one increments the returned counter, drains the request, then
-    /// replies. Runs until the test's tokio runtime shuts down.
-    /// Test: used by `reactivate_*` and the command-build-ordering test.
-    async fn spawn_mock(status_line: &'static str) -> (String, Arc<AtomicUsize>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        let hits = Arc::new(AtomicUsize::new(0));
-        let hits_task = hits.clone();
-        tokio::spawn(async move {
-            loop {
-                let Ok((mut sock, _)) = listener.accept().await else {
-                    break;
-                };
-                hits_task.fetch_add(1, Ordering::SeqCst);
-                read_full_request(&mut sock).await;
-                let body = "{}";
-                let resp = format!(
-                    "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                    body.len(),
-                    body
-                );
-                let _ = sock.write_all(resp.as_bytes()).await;
-                let _ = sock.shutdown().await;
-            }
-        });
-        (format!("http://{addr}"), hits)
-    }
-
-    /// Read an entire HTTP/1.1 request (headers + any `Content-Length` body)
-    /// before the caller writes a response — avoids the connection-reset
-    /// flakiness a naive single `read` can cause (mirrors
-    /// `core::sm::providers::test_support::read_full_request`, unreachable
-    /// from this crate; see [`spawn_mock`]'s doc for why it is duplicated
-    /// here rather than shared).
-    async fn read_full_request(sock: &mut TcpStream) {
-        let mut buf: Vec<u8> = Vec::with_capacity(4096);
-        let mut chunk = [0u8; 4096];
-        let header_end = loop {
-            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
-                break pos + 4;
-            }
-            match sock.read(&mut chunk).await {
-                Ok(0) => return,
-                Ok(n) => buf.extend_from_slice(&chunk[..n]),
-                Err(_) => return,
-            }
-        };
-        let content_len: usize = String::from_utf8_lossy(&buf[..header_end])
-            .split("\r\n")
-            .find_map(|line| {
-                let (name, value) = line.split_once(':')?;
-                name.trim()
-                    .eq_ignore_ascii_case("content-length")
-                    .then(|| value.trim().parse().ok())?
-            })
-            .unwrap_or(0);
-        let want_total = header_end + content_len;
-        while buf.len() < want_total {
-            match sock.read(&mut chunk).await {
-                Ok(0) => return,
-                Ok(n) => buf.extend_from_slice(&chunk[..n]),
-                Err(_) => return,
-            }
-        }
-    }
-
-    /// Spawn a background HTTP mock that replies 200 OK with `{"state": ..}`,
-    /// walking through `states` one entry per connection (clamping to the last
-    /// entry once exhausted) — used to simulate a record transitioning
-    /// `Active` -> `Stopped` across retries (#2148).
-    ///
-    /// Why: [`fetch_managed_session_until_stopped`]'s retry behavior needs a
-    /// mock whose response changes across calls, unlike [`spawn_mock`]'s fixed
-    /// status line; this mirrors the same "read the full request before
-    /// replying" convention.
-    /// What: binds an ephemeral port, loops accepting connections, and for the
-    /// Nth connection replies with `states[min(N, states.len() - 1)]` as the
-    /// summary's `state` field. Runs until the test's tokio runtime shuts down.
-    /// Test: `fetch_until_stopped_*` below.
-    async fn spawn_state_mock(states: Vec<&'static str>) -> (String, Arc<AtomicUsize>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        let hits = Arc::new(AtomicUsize::new(0));
-        let hits_task = hits.clone();
-        tokio::spawn(async move {
-            loop {
-                let Ok((mut sock, _)) = listener.accept().await else {
-                    break;
-                };
-                let n = hits_task.fetch_add(1, Ordering::SeqCst);
-                read_full_request(&mut sock).await;
-                let idx = n.min(states.len().saturating_sub(1));
-                let state = states.get(idx).copied().unwrap_or("active");
-                let body = format!(r#"{{"id":"{TEST_ID}","name":"tm-test","state":"{state}"}}"#);
-                let resp = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                    body.len(),
-                    body
-                );
-                let _ = sock.write_all(resp.as_bytes()).await;
-                let _ = sock.shutdown().await;
-            }
-        });
-        (format!("http://{addr}"), hits)
-    }
-
-    #[tokio::test]
-    async fn fetch_until_stopped_returns_immediately_when_already_stopped() {
-        // #2148: the common case — no race — must not pay any retry delay.
-        let (url, hits) = spawn_state_mock(vec!["stopped"]).await;
-        let client = reqwest::Client::new();
-        let start = std::time::Instant::now();
-        let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
-        assert_eq!(record.map(|r| r.state), Some("stopped".to_string()));
-        assert_eq!(
-            hits.load(Ordering::SeqCst),
-            1,
-            "must not retry once the first fetch already reads stopped"
-        );
-        assert!(
-            start.elapsed() < FETCH_RETRY_BUDGET,
-            "must return promptly, not wait out the whole retry budget"
-        );
-    }
-
-    #[tokio::test]
-    async fn fetch_until_stopped_retries_past_transitioning_state() {
-        // #2148: the race this hardens against — the record briefly reads
-        // "active" while the SessionEnd stop is still in flight, then settles
-        // on "stopped" a couple of polls later.
-        let (url, hits) = spawn_state_mock(vec!["active", "active", "stopped"]).await;
-        let client = reqwest::Client::new();
-        let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
-        assert_eq!(record.map(|r| r.state), Some("stopped".to_string()));
-        assert!(
-            hits.load(Ordering::SeqCst) >= 3,
-            "must retry past the transitioning reads before accepting stopped"
-        );
-    }
-
-    #[tokio::test]
-    async fn fetch_until_stopped_gives_up_after_budget_when_never_stopped() {
-        // A genuinely non-stopped record (e.g. still active, or the id belongs
-        // to some other running session) must not retry forever — it gives up
-        // once the bounded budget elapses so the caller falls through promptly.
-        let (url, hits) = spawn_state_mock(vec!["active"]).await;
-        let client = reqwest::Client::new();
-        let start = std::time::Instant::now();
-        let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
-        let elapsed = start.elapsed();
-        assert_eq!(record.map(|r| r.state), Some("active".to_string()));
-        assert!(
-            elapsed >= FETCH_RETRY_BUDGET,
-            "must not give up before the retry budget elapses"
-        );
-        assert!(
-            elapsed < FETCH_RETRY_BUDGET + FETCH_RETRY_INTERVAL * 3,
-            "must not overrun the budget by more than a poll or two"
-        );
-        assert!(
-            hits.load(Ordering::SeqCst) > 1,
-            "must have retried at least once before giving up"
-        );
-    }
-
-    #[test]
-    fn parse_show_environment_value_extracts_id() {
-        assert_eq!(
-            parse_show_environment_value(
-                "TM_MANAGED_SESSION_ID=11111111-2222-3333-4444-555555555555\n"
-            ),
-            Some("11111111-2222-3333-4444-555555555555".to_string())
-        );
-    }
-
-    #[test]
-    fn parse_show_environment_value_none_when_unset() {
-        // tmux prints "-NAME" (no "=") when the variable is explicitly unset in
-        // the session.
-        assert_eq!(
-            parse_show_environment_value("-TM_MANAGED_SESSION_ID\n"),
-            None
-        );
-    }
-
-    #[test]
-    fn parse_show_environment_value_none_when_empty() {
-        assert_eq!(parse_show_environment_value(""), None);
-        assert_eq!(
-            parse_show_environment_value("TM_MANAGED_SESSION_ID=\n"),
-            None
-        );
-    }
-
-    #[test]
-    fn plan_inplace_selected_when_env_set_and_stopped() {
-        assert_eq!(
-            plan_inplace(Some(TEST_ID), Some("stopped")),
-            Some(ResumeAction::InPlace)
-        );
-    }
-
-    #[test]
-    fn plan_inplace_none_when_env_absent() {
-        assert_eq!(plan_inplace(None, Some("stopped")), None);
-        assert_eq!(plan_inplace(None, None), None);
-    }
-
-    #[test]
-    fn plan_inplace_none_when_env_set_but_unresolved() {
-        // Guard case (#2023 C item 4): a stale/unknown id must fall through to
-        // the ordinary guided picker rather than error.
-        assert_eq!(plan_inplace(Some(TEST_ID), None), None);
-    }
-
-    #[test]
-    fn plan_inplace_none_when_resolved_but_not_stopped() {
-        // Safety-boundary regression guard (#2027 code-critic WARN): a
-        // resolved-but-non-Stopped record (Active/Errored/Decommissioned —
-        // e.g. from a leaked/stale TM_MANAGED_SESSION_ID pointing at some
-        // OTHER, currently-running session) must NOT select the in-place
-        // path; it must fall through to the ordinary guided picker exactly
-        // like an unresolved id.
-        for state in ["active", "errored", "provisioning", "decommissioned"] {
-            assert_eq!(
-                plan_inplace(Some(TEST_ID), Some(state)),
-                None,
-                "state '{state}' must not select InPlace"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn reactivate_confirms_success_on_2xx() {
-        let (url, hits) = spawn_mock("HTTP/1.1 200 OK").await;
-        let client = reqwest::Client::new();
-        let ok = reactivate_managed_session(&client, &url, TEST_ID).await;
-        assert!(ok, "a 2xx response must confirm reactivation");
-        assert_eq!(hits.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn reactivate_aborts_on_409_conflict() {
-        // #2027 HIGH fix: a 409 (session not Stopped on the daemon's own
-        // re-check) must NOT be treated as confirmed — the caller must abort
-        // rather than proceeding to exec.
-        let (url, _hits) = spawn_mock("HTTP/1.1 409 Conflict").await;
-        let client = reqwest::Client::new();
-        let ok = reactivate_managed_session(&client, &url, TEST_ID).await;
-        assert!(!ok, "409 must NOT be treated as a confirmed reactivate");
-    }
-
-    #[tokio::test]
-    async fn reactivate_aborts_on_404_not_found() {
-        let (url, _hits) = spawn_mock("HTTP/1.1 404 Not Found").await;
-        let client = reqwest::Client::new();
-        let ok = reactivate_managed_session(&client, &url, TEST_ID).await;
-        assert!(!ok, "404 must NOT be treated as a confirmed reactivate");
-    }
-
-    #[tokio::test]
-    async fn reactivate_aborts_on_unreachable_daemon() {
-        // Nothing listens on a privileged low port -> immediate connection
-        // refused, exercising the network-error branch without waiting out
-        // the full PROBE_TIMEOUT.
-        let client = reqwest::Client::new();
-        let ok = reactivate_managed_session(&client, "http://127.0.0.1:1", TEST_ID).await;
-        assert!(
-            !ok,
-            "an unreachable daemon must NOT be treated as a confirmed reactivate"
-        );
-    }
-
-    #[tokio::test]
-    async fn run_inplace_relaunch_never_reactivates_when_command_build_fails() {
-        // #2027 MEDIUM fix: command resolution (resolve `claude` + build the
-        // resume argv) must happen BEFORE the daemon is ever asked to
-        // reactivate the record, so a missing-binary failure never flips a
-        // Stopped record to a false Active.
-        //
-        // This ordering guarantee can only be exercised end-to-end on a
-        // machine where `claude` is NOT resolvable — otherwise
-        // build_inplace_resume_command succeeds and this test would be
-        // vacuously true. Probe first; skip (don't fail) when claude IS
-        // present, mirroring the inverse of the "skip when claude absent"
-        // convention used throughout runtime::claude_code's own test suite.
-        let tmp = tempfile::tempdir().expect("tempdir");
-        if trusty_mpm::runtime::build_inplace_resume_command(tmp.path(), None).is_ok() {
-            return;
-        }
-
-        let (url, hits) = spawn_mock("HTTP/1.1 200 OK").await;
-        let record = trusty_mpm::client::ManagedSessionSummary {
-            id: TEST_ID.to_string(),
-            name: "tm-test".to_string(),
-            state: "stopped".to_string(),
-            workspace_path: Some(tmp.path().to_string_lossy().to_string()),
-            repo_url: None,
-            branch: None,
-            created_at: None,
-            last_activity_at: None,
-            pending_decision: None,
-            proposed_default: None,
-            source_id: None,
-            task: None,
-            cwd: None,
-            claude_session_id: None,
-            deliverable_id: None,
-            pane_id: None,
-            injection_status: None,
-            unresumable: false,
-        };
-        let client = reqwest::Client::new();
-
-        let outcome = run_inplace_relaunch(&client, &url, TEST_ID, record).await;
-
-        assert!(
-            matches!(outcome, InPlaceOutcome::Result(Err(_))),
-            "a command-build failure must surface as a hard error, not FallThrough"
-        );
-        assert_eq!(
-            hits.load(Ordering::SeqCst),
-            0,
-            "reactivate must NEVER be called when command resolution fails first (#2027)"
-        );
-    }
-}
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -1,0 +1,445 @@
+//! Unit tests for [`super`]'s in-place-relaunch client (#2023 C, #2789).
+//!
+//! Why: extracted from an inline `#[cfg(test)] mod tests` so the production
+//! `guided_inplace.rs` stays under the 500-SLOC cap while these tests keep the
+//! 1500-SLOC test budget (basename `tests.rs`).
+//! What: the local `TcpListener` HTTP mocks and every `plan_inplace_*` /
+//! `reactivate_*` / `fetch_until_stopped_*` case, moved verbatim.
+//! Test: this file IS the test module.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use super::*;
+
+const TEST_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+/// Spawn a background HTTP mock that replies `status_line` (+ empty JSON
+/// body) to every connection, counting hits.
+///
+/// Why: `reactivate_managed_session`'s status-code handling (#2027) needs
+/// a real HTTP round-trip to exercise reqwest's response parsing; this
+/// mirrors `core::sm::providers::test_support`'s "read the full request
+/// before replying" mock convention (that helper is `pub(crate)` to the
+/// `trusty-mpm` LIB crate and unreachable from this `bin/tm` BINARY crate
+/// — a separate compilation unit — hence the small inline copy in
+/// [`read_full_request`] below, rather than pulling in an external
+/// mock-server dependency for one test file).
+/// What: binds an ephemeral port, loops accepting connections, and for
+/// each one increments the returned counter, drains the request, then
+/// replies. Runs until the test's tokio runtime shuts down.
+/// Test: used by `reactivate_*` and the command-build-ordering test.
+async fn spawn_mock(status_line: &'static str) -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_task = hits.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            hits_task.fetch_add(1, Ordering::SeqCst);
+            read_full_request(&mut sock).await;
+            let body = "{}";
+            let resp = format!(
+                "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.shutdown().await;
+        }
+    });
+    (format!("http://{addr}"), hits)
+}
+
+/// Read an entire HTTP/1.1 request (headers + any `Content-Length` body)
+/// before the caller writes a response — avoids the connection-reset
+/// flakiness a naive single `read` can cause (mirrors
+/// `core::sm::providers::test_support::read_full_request`, unreachable
+/// from this crate; see [`spawn_mock`]'s doc for why it is duplicated
+/// here rather than shared).
+async fn read_full_request(sock: &mut TcpStream) {
+    let mut buf: Vec<u8> = Vec::with_capacity(4096);
+    let mut chunk = [0u8; 4096];
+    let header_end = loop {
+        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            break pos + 4;
+        }
+        match sock.read(&mut chunk).await {
+            Ok(0) => return,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(_) => return,
+        }
+    };
+    let content_len: usize = String::from_utf8_lossy(&buf[..header_end])
+        .split("\r\n")
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.trim()
+                .eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse().ok())?
+        })
+        .unwrap_or(0);
+    let want_total = header_end + content_len;
+    while buf.len() < want_total {
+        match sock.read(&mut chunk).await {
+            Ok(0) => return,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(_) => return,
+        }
+    }
+}
+
+/// Spawn a background HTTP mock that captures the FIRST request line (the
+/// `METHOD /path?query HTTP/1.1` line) of the first connection into the
+/// returned shared string, then replies `status_line`.
+///
+/// Why: [`spawn_mock`] drains the request but discards it, so it cannot
+/// prove which URL was requested. The #2789 wire contract — the caller's
+/// pane id reaching the daemon as a query param — is only meaningful if the
+/// exact request target is observable; this helper captures it.
+/// What: binds an ephemeral port; for the first connection reads until the
+/// end of the request headers, records the request line, then replies with
+/// `status_line` + an empty JSON body. Subsequent connections are still
+/// answered but not re-captured.
+/// Test: `reactivate_forwards_caller_pane_id_query`,
+/// `reactivate_omits_caller_pane_id_query_when_absent`.
+async fn spawn_capturing_mock(status_line: &'static str) -> (String, Arc<Mutex<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let request_line = Arc::new(Mutex::new(String::new()));
+    let request_line_task = request_line.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            let mut buf: Vec<u8> = Vec::with_capacity(4096);
+            let mut chunk = [0u8; 4096];
+            while !buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                match sock.read(&mut chunk).await {
+                    Ok(0) => break,
+                    Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                    Err(_) => break,
+                }
+            }
+            if let Ok(mut slot) = request_line_task.lock()
+                && slot.is_empty()
+            {
+                *slot = String::from_utf8_lossy(&buf)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+            }
+            let body = "{}";
+            let resp = format!(
+                "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.shutdown().await;
+        }
+    });
+    (format!("http://{addr}"), request_line)
+}
+
+/// Spawn a background HTTP mock that replies 200 OK with `{"state": ..}`,
+/// walking through `states` one entry per connection (clamping to the last
+/// entry once exhausted) — used to simulate a record transitioning
+/// `Active` -> `Stopped` across retries (#2148).
+///
+/// Why: [`fetch_managed_session_until_stopped`]'s retry behavior needs a
+/// mock whose response changes across calls, unlike [`spawn_mock`]'s fixed
+/// status line; this mirrors the same "read the full request before
+/// replying" convention.
+/// What: binds an ephemeral port, loops accepting connections, and for the
+/// Nth connection replies with `states[min(N, states.len() - 1)]` as the
+/// summary's `state` field. Runs until the test's tokio runtime shuts down.
+/// Test: `fetch_until_stopped_*` below.
+async fn spawn_state_mock(states: Vec<&'static str>) -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_task = hits.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            let n = hits_task.fetch_add(1, Ordering::SeqCst);
+            read_full_request(&mut sock).await;
+            let idx = n.min(states.len().saturating_sub(1));
+            let state = states.get(idx).copied().unwrap_or("active");
+            let body = format!(r#"{{"id":"{TEST_ID}","name":"tm-test","state":"{state}"}}"#);
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.shutdown().await;
+        }
+    });
+    (format!("http://{addr}"), hits)
+}
+
+#[tokio::test]
+async fn fetch_until_stopped_returns_immediately_when_already_stopped() {
+    // #2148: the common case — no race — must not pay any retry delay.
+    let (url, hits) = spawn_state_mock(vec!["stopped"]).await;
+    let client = reqwest::Client::new();
+    let start = std::time::Instant::now();
+    let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
+    assert_eq!(record.map(|r| r.state), Some("stopped".to_string()));
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "must not retry once the first fetch already reads stopped"
+    );
+    assert!(
+        start.elapsed() < FETCH_RETRY_BUDGET,
+        "must return promptly, not wait out the whole retry budget"
+    );
+}
+
+#[tokio::test]
+async fn fetch_until_stopped_retries_past_transitioning_state() {
+    // #2148: the race this hardens against — the record briefly reads
+    // "active" while the SessionEnd stop is still in flight, then settles
+    // on "stopped" a couple of polls later.
+    let (url, hits) = spawn_state_mock(vec!["active", "active", "stopped"]).await;
+    let client = reqwest::Client::new();
+    let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
+    assert_eq!(record.map(|r| r.state), Some("stopped".to_string()));
+    assert!(
+        hits.load(Ordering::SeqCst) >= 3,
+        "must retry past the transitioning reads before accepting stopped"
+    );
+}
+
+#[tokio::test]
+async fn fetch_until_stopped_gives_up_after_budget_when_never_stopped() {
+    // A genuinely non-stopped record (e.g. still active, or the id belongs
+    // to some other running session) must not retry forever — it gives up
+    // once the bounded budget elapses so the caller falls through promptly.
+    let (url, hits) = spawn_state_mock(vec!["active"]).await;
+    let client = reqwest::Client::new();
+    let start = std::time::Instant::now();
+    let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
+    let elapsed = start.elapsed();
+    assert_eq!(record.map(|r| r.state), Some("active".to_string()));
+    assert!(
+        elapsed >= FETCH_RETRY_BUDGET,
+        "must not give up before the retry budget elapses"
+    );
+    assert!(
+        elapsed < FETCH_RETRY_BUDGET + FETCH_RETRY_INTERVAL * 3,
+        "must not overrun the budget by more than a poll or two"
+    );
+    assert!(
+        hits.load(Ordering::SeqCst) > 1,
+        "must have retried at least once before giving up"
+    );
+}
+
+#[test]
+fn parse_show_environment_value_extracts_id() {
+    assert_eq!(
+        parse_show_environment_value(
+            "TM_MANAGED_SESSION_ID=11111111-2222-3333-4444-555555555555\n"
+        ),
+        Some("11111111-2222-3333-4444-555555555555".to_string())
+    );
+}
+
+#[test]
+fn parse_show_environment_value_none_when_unset() {
+    // tmux prints "-NAME" (no "=") when the variable is explicitly unset in
+    // the session.
+    assert_eq!(
+        parse_show_environment_value("-TM_MANAGED_SESSION_ID\n"),
+        None
+    );
+}
+
+#[test]
+fn parse_show_environment_value_none_when_empty() {
+    assert_eq!(parse_show_environment_value(""), None);
+    assert_eq!(
+        parse_show_environment_value("TM_MANAGED_SESSION_ID=\n"),
+        None
+    );
+}
+
+#[test]
+fn plan_inplace_selected_when_env_set_and_stopped() {
+    assert_eq!(
+        plan_inplace(Some(TEST_ID), Some("stopped")),
+        Some(ResumeAction::InPlace)
+    );
+}
+
+#[test]
+fn plan_inplace_none_when_env_absent() {
+    assert_eq!(plan_inplace(None, Some("stopped")), None);
+    assert_eq!(plan_inplace(None, None), None);
+}
+
+#[test]
+fn plan_inplace_none_when_env_set_but_unresolved() {
+    // Guard case (#2023 C item 4): a stale/unknown id must fall through to
+    // the ordinary guided picker rather than error.
+    assert_eq!(plan_inplace(Some(TEST_ID), None), None);
+}
+
+#[test]
+fn plan_inplace_none_when_resolved_but_not_stopped() {
+    // Safety-boundary regression guard (#2027 code-critic WARN): a
+    // resolved-but-non-Stopped record (Active/Errored/Decommissioned —
+    // e.g. from a leaked/stale TM_MANAGED_SESSION_ID pointing at some
+    // OTHER, currently-running session) must NOT select the in-place
+    // path; it must fall through to the ordinary guided picker exactly
+    // like an unresolved id.
+    for state in ["active", "errored", "provisioning", "decommissioned"] {
+        assert_eq!(
+            plan_inplace(Some(TEST_ID), Some(state)),
+            None,
+            "state '{state}' must not select InPlace"
+        );
+    }
+}
+
+#[tokio::test]
+async fn reactivate_confirms_success_on_2xx() {
+    let (url, hits) = spawn_mock("HTTP/1.1 200 OK").await;
+    let client = reqwest::Client::new();
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, None).await;
+    assert!(ok, "a 2xx response must confirm reactivation");
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn reactivate_aborts_on_409_conflict() {
+    // #2027 HIGH fix: a 409 (session not Stopped on the daemon's own
+    // re-check) must NOT be treated as confirmed — the caller must abort
+    // rather than proceeding to exec.
+    let (url, _hits) = spawn_mock("HTTP/1.1 409 Conflict").await;
+    let client = reqwest::Client::new();
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, None).await;
+    assert!(!ok, "409 must NOT be treated as a confirmed reactivate");
+}
+
+#[tokio::test]
+async fn reactivate_aborts_on_404_not_found() {
+    let (url, _hits) = spawn_mock("HTTP/1.1 404 Not Found").await;
+    let client = reqwest::Client::new();
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, None).await;
+    assert!(!ok, "404 must NOT be treated as a confirmed reactivate");
+}
+
+#[tokio::test]
+async fn reactivate_aborts_on_unreachable_daemon() {
+    // Nothing listens on a privileged low port -> immediate connection
+    // refused, exercising the network-error branch without waiting out
+    // the full PROBE_TIMEOUT.
+    let client = reqwest::Client::new();
+    let ok = reactivate_managed_session(&client, "http://127.0.0.1:1", TEST_ID, None).await;
+    assert!(
+        !ok,
+        "an unreachable daemon must NOT be treated as a confirmed reactivate"
+    );
+}
+
+#[tokio::test]
+async fn reactivate_forwards_caller_pane_id_query() {
+    // #2789: the caller's own tmux pane_id must reach the daemon as a
+    // `?caller_pane_id=` query param — that is the whole mechanism by which
+    // the daemon learns to treat the requesting `tm` pane as idle instead
+    // of 409'ing. Capture the raw request line and assert the (URL-encoded)
+    // pane id is present.
+    let (url, request_line) = spawn_capturing_mock("HTTP/1.1 200 OK").await;
+    let client = reqwest::Client::new();
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, Some("%3")).await;
+    assert!(ok, "a 2xx response must confirm reactivation");
+    let line = request_line.lock().expect("lock").clone();
+    assert!(
+        line.contains("caller_pane_id=%253"),
+        "the request line must carry the URL-encoded caller_pane_id (%3 -> %253); got: {line}"
+    );
+}
+
+#[tokio::test]
+async fn reactivate_omits_caller_pane_id_query_when_absent() {
+    // Backward compatibility: a non-tmux / pre-#2789 caller sends no
+    // caller_pane_id, and the request must carry no such query param.
+    let (url, request_line) = spawn_capturing_mock("HTTP/1.1 200 OK").await;
+    let client = reqwest::Client::new();
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, None).await;
+    assert!(ok);
+    let line = request_line.lock().expect("lock").clone();
+    assert!(
+        !line.contains("caller_pane_id"),
+        "no caller_pane_id query param may be sent when the caller passes None; got: {line}"
+    );
+}
+
+#[tokio::test]
+async fn run_inplace_relaunch_never_reactivates_when_command_build_fails() {
+    // #2027 MEDIUM fix: command resolution (resolve `claude` + build the
+    // resume argv) must happen BEFORE the daemon is ever asked to
+    // reactivate the record, so a missing-binary failure never flips a
+    // Stopped record to a false Active.
+    //
+    // This ordering guarantee can only be exercised end-to-end on a
+    // machine where `claude` is NOT resolvable — otherwise
+    // build_inplace_resume_command succeeds and this test would be
+    // vacuously true. Probe first; skip (don't fail) when claude IS
+    // present, mirroring the inverse of the "skip when claude absent"
+    // convention used throughout runtime::claude_code's own test suite.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    if trusty_mpm::runtime::build_inplace_resume_command(tmp.path(), None).is_ok() {
+        return;
+    }
+
+    let (url, hits) = spawn_mock("HTTP/1.1 200 OK").await;
+    let record = trusty_mpm::client::ManagedSessionSummary {
+        id: TEST_ID.to_string(),
+        name: "tm-test".to_string(),
+        state: "stopped".to_string(),
+        workspace_path: Some(tmp.path().to_string_lossy().to_string()),
+        repo_url: None,
+        branch: None,
+        created_at: None,
+        last_activity_at: None,
+        pending_decision: None,
+        proposed_default: None,
+        source_id: None,
+        task: None,
+        cwd: None,
+        claude_session_id: None,
+        deliverable_id: None,
+        pane_id: None,
+        injection_status: None,
+        unresumable: false,
+    };
+    let client = reqwest::Client::new();
+
+    let outcome = run_inplace_relaunch(&client, &url, TEST_ID, record, None).await;
+
+    assert!(
+        matches!(outcome, InPlaceOutcome::Result(Err(_))),
+        "a command-build failure must surface as a hard error, not FallThrough"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        0,
+        "reactivate must NEVER be called when command resolution fails first (#2027)"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -27,9 +27,9 @@ use crate::commands::first_run::needs_first_run_clone;
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 use crate::commands::guided::{
     CwdProject, classify_cwd_project, cwd_owns_git_entry, derive_project, fallback_protected,
-    github_host, is_github_remote, ls_tree_reports_tracked_dir, nested_guard_notice,
-    nested_managed_match, non_github_refusal_message, pane_identity_confirmed, print_non_tty_hint,
-    print_project_context, tty_gate, untracked_ancestor_message,
+    github_host, inplace_self_relaunch_hint, is_github_remote, ls_tree_reports_tracked_dir,
+    nested_guard_notice, nested_managed_match, non_github_refusal_message, pane_identity_confirmed,
+    print_non_tty_hint, print_project_context, tty_gate, untracked_ancestor_message,
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{ResumeAction, is_zombie, needs_restart, plan_resume};
@@ -1832,5 +1832,43 @@ fn nested_guard_notice_mentions_reconnect_target() {
     assert!(
         msg.contains("reconnecting"),
         "nested_guard_notice must still communicate the reconnect action: {msg:?}"
+    );
+}
+
+#[test]
+fn inplace_self_relaunch_hint_uses_resume_when_session_id_present() {
+    // #2789: when the record carries a claude_session_id, the honest
+    // self-relaunch hint must offer `claude --resume <id>` so the operator
+    // resumes the exact conversation instead of a self-switch no-op.
+    let mut record = make_session("tm-cto-01", "active", None);
+    record.claude_session_id = Some("bfc69db6-cb98-4aa7-a07d-89fd69ba710b".to_string());
+    let hint = inplace_self_relaunch_hint(&record);
+    assert!(
+        hint.contains("claude --resume bfc69db6-cb98-4aa7-a07d-89fd69ba710b"),
+        "hint must suggest resuming the exact claude session: {hint:?}"
+    );
+    assert!(
+        hint.contains("already inside this session's pane"),
+        "hint must explain why a reconnect would be a no-op: {hint:?}"
+    );
+}
+
+#[test]
+fn inplace_self_relaunch_hint_bare_claude_when_no_session_id() {
+    // Without a claude_session_id (or a blank one) the hint falls back to a
+    // bare `claude` rather than emitting `claude --resume ` with an empty arg.
+    let mut record = make_session("tm-cto-01", "active", None);
+    record.claude_session_id = None;
+    let hint = inplace_self_relaunch_hint(&record);
+    assert!(
+        hint.contains("claude") && !hint.contains("--resume"),
+        "hint must suggest a bare `claude` when no session id is known: {hint:?}"
+    );
+
+    record.claude_session_id = Some("   ".to_string());
+    let hint_blank = inplace_self_relaunch_hint(&record);
+    assert!(
+        !hint_blank.contains("--resume"),
+        "a blank claude_session_id must not produce `claude --resume`: {hint_blank:?}"
     );
 }

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1787,6 +1787,7 @@ fn pane_for_gate_test(name: &str, cmd: &str) -> crate::daemon::orphan_gc::PaneIn
         session_name: name.to_string(),
         pane_current_command: cmd.to_string(),
         pane_pid: Some(4242),
+        pane_id: None,
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
@@ -16,10 +16,11 @@ use std::sync::Arc;
 
 use axum::{
     Json,
-    extract::{Path as AxumPath, State},
+    extract::{Path as AxumPath, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
+use serde::Deserialize;
 
 use crate::daemon::orphan_gc::{ChildLivenessProbe, PaneInfo, ProcessTreeProbe};
 use crate::daemon::runtime_reap::find_runtime_exited;
@@ -29,6 +30,29 @@ use crate::session_manager::{
 };
 
 use super::{parse_id, record_to_summary};
+
+/// Query parameters for the reactivate route.
+///
+/// Why: an in-place-relaunch client (`bin/tm`'s `guided_inplace`) runs `tm`
+/// as the foreground process of the very pane it is relaunching. At the exact
+/// moment it POSTs here, `tmux list-panes` reports THAT pane's
+/// `pane_current_command` as `tm` (and its shell PID has `tm` as a live child)
+/// — so the daemon's own idleness classification would see the pane as "still
+/// running a runtime" and refuse the stale-`Active` reconcile with a 409, even
+/// though the agent has genuinely exited (#2789, the reported dead-end). The
+/// client therefore tells the daemon which pane is ITS OWN via the stable tmux
+/// `pane_id`, so [`reconcile_stale_active_then_reactivate`] can exclude that
+/// one self-referential pane from the liveness check.
+/// What: an optional `caller_pane_id` (tmux's `%N`). Absent for non-tmux or
+/// pre-#2789 clients, in which case reconciliation behaves exactly as before.
+/// Test: `should_reconcile_stale_active_true_when_only_caller_pane_busy`.
+#[derive(Debug, Default, Deserialize)]
+pub struct ReactivateQuery {
+    /// The stable tmux `pane_id` of the pane the reactivate request originates
+    /// from (the pane about to `exec` `claude` in place).
+    #[serde(default)]
+    pub caller_pane_id: Option<String>,
+}
 
 /// POST /api/v1/sessions/managed/{id}/reactivate — flip Stopped -> Active IN
 /// PLACE, with NO tmux mutation (#2023 component C).
@@ -47,14 +71,17 @@ use super::{parse_id, record_to_summary};
 /// exited but the periodic reap tick (or a racing `SessionEnd` hook) has not
 /// yet flipped the record's `state` to `Stopped`; still 409 when the record is
 /// genuinely not reconcilable (a live runtime, a different lifecycle state, or
-/// a sibling pane in the same tmux session that is still active). 200 with the
-/// updated summary on success either way.
+/// a sibling pane in the same tmux session that is still active). The optional
+/// `caller_pane_id` query param (#2789) lets an in-place-relaunch client name
+/// its OWN pane so the reconcile does not count the requesting `tm` process
+/// itself as a live runtime. 200 with the updated summary on success either way.
 /// Test: `mark_reactivated_flips_stopped_to_active`,
 /// `mark_reactivated_rejects_non_stopped` in `session_manager::reactivate_tests`;
 /// `should_reconcile_stale_active_*` below.
 pub async fn reactivate_managed_session(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
+    Query(params): Query<ReactivateQuery>,
 ) -> impl IntoResponse {
     let id = match parse_id(&id_str) {
         Ok(id) => id,
@@ -66,12 +93,16 @@ pub async fn reactivate_managed_session(
         Err(ManagedError::SessionNotFound(_)) => {
             (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
         }
-        Err(ManagedError::InvalidState(_, reason)) => {
-            match reconcile_stale_active_then_reactivate(&mgr, &id).await {
-                Some(record) => Json(record_to_summary(&record)).into_response(),
-                None => (StatusCode::CONFLICT, reason).into_response(),
-            }
-        }
+        Err(ManagedError::InvalidState(_, reason)) => match reconcile_stale_active_then_reactivate(
+            &mgr,
+            &id,
+            params.caller_pane_id.as_deref(),
+        )
+        .await
+        {
+            Some(record) => Json(record_to_summary(&record)).into_response(),
+            None => (StatusCode::CONFLICT, reason).into_response(),
+        },
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -94,10 +125,11 @@ pub async fn reactivate_managed_session(
 /// reap tick.
 /// What: re-fetches the record; bails (`None`) unless it is `Active` and
 /// [`should_reconcile_stale_active`] confirms every pane belonging to its tmux
-/// session is idle (a still-live pane — including a genuinely different,
-/// still-active sibling window in the SAME tmux session, #2157 — keeps the
-/// existing 409 refusal, preserving that safety boundary). On confirmation,
-/// calls [`SessionManager::mark_runtime_exited_stopped`] then
+/// session — EXCEPT the caller's own pane (`caller_pane_id`, #2789) — is idle
+/// (a still-live pane — including a genuinely different, still-active sibling
+/// window in the SAME tmux session, #2157 — keeps the existing 409 refusal,
+/// preserving that safety boundary). On confirmation, calls
+/// [`SessionManager::mark_runtime_exited_stopped`] then
 /// [`SessionManager::mark_reactivated`]; any failure at either step (tmux
 /// discovery, pane listing, or either state transition) also yields `None` so
 /// the caller falls back to the ordinary 409.
@@ -107,13 +139,14 @@ pub async fn reactivate_managed_session(
 async fn reconcile_stale_active_then_reactivate(
     mgr: &SessionManager,
     id: &ManagedSessionId,
+    caller_pane_id: Option<&str>,
 ) -> Option<SessionRecord> {
     let record = mgr.get(id).await.ok()?;
     let panes = crate::daemon::tmux::TmuxDriver::discover()
         .ok()?
         .list_managed_panes()
         .ok()?;
-    if !should_reconcile_stale_active(&record, &panes, &ProcessTreeProbe) {
+    if !should_reconcile_stale_active(&record, &panes, caller_pane_id, &ProcessTreeProbe) {
         return None;
     }
     mgr.mark_runtime_exited_stopped(id).await.ok()?;
@@ -132,23 +165,79 @@ async fn reconcile_stale_active_then_reactivate(
 /// different window, #2157) keeps the WHOLE session "live" and this predicate
 /// correctly returns `false`, preserving the existing refuse+switch-client
 /// contract for that case.
+///
+/// #2789: the caller's OWN pane is first neutralized to an idle shell via
+/// [`neutralize_caller_pane`]. Without this, an in-place-relaunch request is
+/// self-defeating: the requesting `tm` process is the foreground command of
+/// the pane being relaunched, so tmux reports that pane as running `tm` (a
+/// non-shell command, and its shell PID has `tm` as a live child) — which the
+/// unmodified liveness check reads as "runtime still alive", refusing the
+/// reconcile with a 409 and stranding the operator in a bare shell. Because a
+/// pane cannot simultaneously run `tm` in the foreground AND a live interactive
+/// `claude`, treating the caller's own pane as idle is SOUND, not merely a
+/// trust assumption — while every OTHER (sibling) pane is checked unchanged, so
+/// a genuinely live sibling window still blocks the reconcile.
 /// What: `true` only when `record.state == Active` AND `find_runtime_exited`
-/// (scoped to just this one record) selects it — i.e. its tmux session has at
-/// least one present pane and NONE of them are still running an agent.
+/// (scoped to just this one record, over the caller-neutralized pane list)
+/// selects it — i.e. its tmux session has at least one present pane and NONE of
+/// them (other than the caller's own) are still running an agent.
 /// `false` for every other state (Provisioning/Errored/Decommissioned — those
 /// fall through to the ordinary 409, matching `mark_reactivated`'s Stopped-only
-/// contract) and for a missing/still-live pane.
+/// contract) and for a missing/still-live-sibling pane.
 /// Test: `should_reconcile_stale_active_true_when_active_and_idle`,
 /// `should_reconcile_stale_active_false_when_pane_still_live`,
 /// `should_reconcile_stale_active_false_when_pane_missing`,
-/// `should_reconcile_stale_active_false_when_not_active`.
+/// `should_reconcile_stale_active_false_when_not_active`,
+/// `should_reconcile_stale_active_true_when_only_caller_pane_busy`,
+/// `should_reconcile_stale_active_false_when_sibling_pane_live_despite_caller`.
 pub(crate) fn should_reconcile_stale_active(
     record: &SessionRecord,
     panes: &[PaneInfo],
+    caller_pane_id: Option<&str>,
     probe: &dyn ChildLivenessProbe,
 ) -> bool {
-    record.state == ManagedSessionState::Active
-        && !find_runtime_exited(std::slice::from_ref(record), panes, probe).is_empty()
+    if record.state != ManagedSessionState::Active {
+        return false;
+    }
+    let neutralized = neutralize_caller_pane(panes, caller_pane_id);
+    !find_runtime_exited(std::slice::from_ref(record), &neutralized, probe).is_empty()
+}
+
+/// #2789: return `panes` with the caller's OWN pane rewritten to look like an
+/// idle shell, so the liveness aggregation does not count the requesting `tm`
+/// process against its own session.
+///
+/// Why: see [`should_reconcile_stale_active`]. The caller's pane is kept in the
+/// list (its session must still count as "present" for `find_runtime_exited` to
+/// consider it) but its command/PID are replaced so it reads as idle — as if
+/// the pane had already dropped back to the bare shell it will become the
+/// instant `tm` `exec`s `claude`. Matching is by the stable tmux `pane_id`
+/// (never reused across panes), so exactly one pane can match.
+/// What: when `caller_pane_id` is `None`/blank, or no pane matches it, returns
+/// the panes unchanged (behaviorally identical to the pre-#2789 path). When a
+/// pane matches, that entry's `pane_current_command` becomes a bare shell and
+/// its `pane_pid` becomes `None` (so [`ChildLivenessProbe`] reports no live
+/// child); all other panes are copied verbatim.
+/// Test: exercised via `should_reconcile_stale_active_true_when_only_caller_pane_busy`
+/// and `..._false_when_sibling_pane_live_despite_caller`.
+fn neutralize_caller_pane(panes: &[PaneInfo], caller_pane_id: Option<&str>) -> Vec<PaneInfo> {
+    let Some(caller) = caller_pane_id.filter(|s| !s.is_empty()) else {
+        return panes.to_vec();
+    };
+    panes
+        .iter()
+        .map(|p| {
+            if p.pane_id.as_deref() == Some(caller) {
+                PaneInfo {
+                    pane_current_command: "zsh".to_string(),
+                    pane_pid: None,
+                    ..p.clone()
+                }
+            } else {
+                p.clone()
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -194,6 +283,18 @@ mod tests {
             session_name: name.to_string(),
             pane_current_command: cmd.to_string(),
             pane_pid: Some(4242),
+            pane_id: None,
+        }
+    }
+
+    /// A pane carrying a stable tmux `pane_id` — needed to exercise the #2789
+    /// caller-pane neutralization.
+    fn pane_with_id(name: &str, cmd: &str, pane_id: &str) -> PaneInfo {
+        PaneInfo {
+            session_name: name.to_string(),
+            pane_current_command: cmd.to_string(),
+            pane_pid: Some(4242),
+            pane_id: Some(pane_id.to_string()),
         }
     }
 
@@ -206,6 +307,7 @@ mod tests {
         assert!(should_reconcile_stale_active(
             &record,
             &panes,
+            None,
             &AlwaysIdleProbe
         ));
     }
@@ -219,6 +321,7 @@ mod tests {
         assert!(!should_reconcile_stale_active(
             &record,
             &panes,
+            None,
             &AlwaysIdleProbe
         ));
     }
@@ -234,6 +337,7 @@ mod tests {
         assert!(!should_reconcile_stale_active(
             &record,
             &panes,
+            None,
             &AlwaysIdleProbe
         ));
     }
@@ -246,6 +350,7 @@ mod tests {
         assert!(!should_reconcile_stale_active(
             &record,
             &[],
+            None,
             &AlwaysIdleProbe
         ));
     }
@@ -263,9 +368,60 @@ mod tests {
             record.state = state.clone();
             let panes = vec![pane("tm-demo", "zsh")];
             assert!(
-                !should_reconcile_stale_active(&record, &panes, &AlwaysIdleProbe),
+                !should_reconcile_stale_active(&record, &panes, None, &AlwaysIdleProbe),
                 "state {state} must not be reconciled"
             );
         }
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_true_when_only_caller_pane_busy() {
+        // #2789 core repro: bare `tm` typed in the just-vacated pane runs as
+        // that pane's foreground command, so tmux reports it as running `tm`
+        // (NOT an idle shell). Without the caller-pane exclusion this reads as
+        // "runtime still alive" and 409s — the reported dead-end. Naming the
+        // caller's own pane_id neutralizes exactly that one pane, so the
+        // session reconciles.
+        let record = active_record("tm-cto-01");
+        let panes = vec![pane_with_id("tm-cto-01", "tm", "%3")];
+        assert!(
+            !should_reconcile_stale_active(&record, &panes, None, &AlwaysIdleProbe),
+            "pre-#2789 behavior (no caller_pane_id): the caller's own `tm` pane \
+             is still (wrongly) seen as live"
+        );
+        assert!(
+            should_reconcile_stale_active(&record, &panes, Some("%3"), &AlwaysIdleProbe),
+            "#2789: naming the caller's own pane must let its session reconcile"
+        );
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_false_when_sibling_pane_live_despite_caller() {
+        // #2789 genuine-conflict guard: neutralizing the caller's OWN pane must
+        // NOT hide a genuinely live claude in a DIFFERENT pane of the same tmux
+        // session (#2157). The sibling keeps the session live → 409 stands.
+        let record = active_record("tm-cto-01");
+        let panes = vec![
+            pane_with_id("tm-cto-01", "tm", "%3"),     // caller's own pane
+            pane_with_id("tm-cto-01", "claude", "%4"), // genuinely live sibling
+        ];
+        assert!(
+            !should_reconcile_stale_active(&record, &panes, Some("%3"), &AlwaysIdleProbe),
+            "a live sibling pane must still block reconcile even when the \
+             caller's own pane is excluded"
+        );
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_ignores_unmatched_caller_pane_id() {
+        // A caller_pane_id that matches no pane in the record's session must
+        // leave the liveness check unchanged — no accidental neutralization of
+        // an unrelated pane.
+        let record = active_record("tm-demo");
+        let panes = vec![pane_with_id("tm-demo", "claude", "%1")];
+        assert!(
+            !should_reconcile_stale_active(&record, &panes, Some("%99"), &AlwaysIdleProbe),
+            "an unmatched caller_pane_id must not force any pane idle"
+        );
     }
 }

--- a/crates/trusty-mpm/src/daemon/orphan_gc.rs
+++ b/crates/trusty-mpm/src/daemon/orphan_gc.rs
@@ -70,9 +70,15 @@ pub fn is_idle_shell(pane_command: &str) -> bool {
 /// Why: the reconciler needs the session name, what the pane is running, and
 /// (when cheaply available) the pane's shell PID so it can do a second liveness
 /// check before reaping. Bundling them keeps [`classify_session`] a pure
-/// function of plain data, fully testable without spawning tmux.
-/// What: the tmux `session_name`, its `pane_current_command`, and an optional
-/// `pane_pid` (the pane's shell PID, `None` when tmux did not report one).
+/// function of plain data, fully testable without spawning tmux. The stable
+/// tmux `pane_id` (#2789) additionally lets the reactivate-reconcile path
+/// (`daemon::managed_routes::reactivate`) identify the ONE pane that belongs to
+/// the caller making an in-place-relaunch request — see that module for why
+/// that pane must be treated as idle rather than as a live runtime.
+/// What: the tmux `session_name`, its `pane_current_command`, an optional
+/// `pane_pid` (the pane's shell PID, `None` when tmux did not report one), and
+/// an optional stable `pane_id` (tmux's `%N`, `None` when tmux did not report
+/// one or an older enumeration path did not capture it).
 /// Test: constructed throughout the `tests` submodule.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaneInfo {
@@ -82,6 +88,10 @@ pub struct PaneInfo {
     pub pane_current_command: String,
     /// The pane's shell PID, if tmux reported it.
     pub pane_pid: Option<u32>,
+    /// The pane's stable tmux id (e.g. `"%5"`), if the enumeration captured it.
+    /// Distinct from `pane_pid` (which the OS can reuse across a pane's
+    /// lifetime); never inherited across panes, unlike an env var.
+    pub pane_id: Option<String>,
 }
 
 /// The GC's verdict for a single tmux session.
@@ -558,6 +568,7 @@ mod tests {
             session_name: name.to_string(),
             pane_current_command: cmd.to_string(),
             pane_pid: Some(4242),
+            pane_id: None,
         }
     }
 
@@ -880,6 +891,7 @@ mod tests {
                 session_name: "tmpm-my-session".to_string(),
                 pane_current_command: "claude".to_string(),
                 pane_pid: Some(45162),
+                pane_id: None,
             },
             &tracked,
             &AlwaysIdleProbe,
@@ -897,6 +909,7 @@ mod tests {
                 session_name: "tmpm-orphan".to_string(),
                 pane_current_command: "zsh".to_string(),
                 pane_pid: Some(99999),
+                pane_id: None,
             },
             &tracked,
             &AlwaysIdleProbe,
@@ -913,6 +926,7 @@ mod tests {
                 session_name: "tmpm-my-session".to_string(),
                 pane_current_command: "zsh".to_string(),
                 pane_pid: Some(55555),
+                pane_id: None,
             },
             &tracked,
             &AlwaysIdleProbe,

--- a/crates/trusty-mpm/src/daemon/runtime_reap.rs
+++ b/crates/trusty-mpm/src/daemon/runtime_reap.rs
@@ -287,6 +287,7 @@ mod tests {
             session_name: name.to_string(),
             pane_current_command: cmd.to_string(),
             pane_pid: Some(4242),
+            pane_id: None,
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -459,10 +459,12 @@ impl TmuxDriver {
     /// Why: the orphan-GC must reconcile live tmux against the registries, and
     /// to decide whether a session is idle it needs each pane's
     /// `pane_current_command` (and, for the belt-and-braces liveness check, the
-    /// pane's shell PID). `list-panes -a` reports all of that across every
+    /// pane's shell PID). The reactivate-reconcile path (#2789) additionally
+    /// needs each pane's stable `pane_id` to identify the caller's OWN pane and
+    /// treat it as idle. `list-panes -a` reports all of that across every
     /// session in a single tmux call.
     /// What: runs
-    /// `tmux list-panes -a -F "#{session_name}\t#{pane_current_command}\t#{pane_pid}"`
+    /// `tmux list-panes -a -F "#{session_name}\t#{pane_current_command}\t#{pane_pid}\t#{pane_id}"`
     /// and parses each row into a [`orphan_gc::PaneInfo`]. A tab delimiter avoids
     /// colliding with the colons in session names. An empty tmux server (`no
     /// server running`) yields an empty `Vec` rather than an error, so a quiet
@@ -475,7 +477,7 @@ impl TmuxDriver {
                 "list-panes",
                 "-a",
                 "-F",
-                "#{session_name}\t#{pane_current_command}\t#{pane_pid}",
+                "#{session_name}\t#{pane_current_command}\t#{pane_pid}\t#{pane_id}",
             ])
             .output()?;
         if !output.status.success() {
@@ -493,23 +495,30 @@ impl TmuxDriver {
             .collect())
     }
 
-    /// Parse one `session_name\tpane_current_command\tpane_pid` row.
+    /// Parse one `session_name\tpane_current_command\tpane_pid\tpane_id` row.
     ///
     /// Why: keeping the parse separate from the subprocess call makes it
     /// unit-testable without spawning tmux.
     /// What: splits on the tab delimiter; a row missing the session name is
     /// dropped (`None`); a missing or unparsable PID degrades to `None` PID
-    /// rather than dropping the whole row (the command is the primary signal).
+    /// rather than dropping the whole row (the command is the primary signal);
+    /// a missing/blank `pane_id` degrades to `None` (an older tmux or a
+    /// truncated row still yields a usable pane for the idleness sweep).
     /// Test: `parses_managed_pane_row`.
     fn parse_managed_pane_row(line: &str) -> Option<crate::daemon::orphan_gc::PaneInfo> {
-        let mut parts = line.splitn(3, '\t');
+        let mut parts = line.splitn(4, '\t');
         let session_name = parts.next().filter(|s| !s.is_empty())?.to_string();
         let pane_current_command = parts.next().unwrap_or("").trim().to_string();
         let pane_pid = parts.next().and_then(|s| s.trim().parse::<u32>().ok());
+        let pane_id = parts
+            .next()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
         Some(crate::daemon::orphan_gc::PaneInfo {
             session_name,
             pane_current_command,
             pane_pid,
+            pane_id,
         })
     }
 
@@ -915,18 +924,27 @@ mod tests {
 
     #[test]
     fn parses_managed_pane_row() {
-        let row = TmuxDriver::parse_managed_pane_row("tmpm-brave-otter\tclaude\t12345").unwrap();
+        let row =
+            TmuxDriver::parse_managed_pane_row("tmpm-brave-otter\tclaude\t12345\t%7").unwrap();
         assert_eq!(row.session_name, "tmpm-brave-otter");
         assert_eq!(row.pane_current_command, "claude");
         assert_eq!(row.pane_pid, Some(12345));
+        assert_eq!(row.pane_id.as_deref(), Some("%7"));
 
         // Missing/garbage PID degrades to None but keeps the row (command is key).
-        let no_pid = TmuxDriver::parse_managed_pane_row("tmpm-x\tzsh\t").unwrap();
+        let no_pid = TmuxDriver::parse_managed_pane_row("tmpm-x\tzsh\t\t%9").unwrap();
         assert_eq!(no_pid.pane_pid, None);
         assert_eq!(no_pid.pane_current_command, "zsh");
+        assert_eq!(no_pid.pane_id.as_deref(), Some("%9"));
+
+        // A row from an older tmux with no pane_id column degrades to None
+        // pane_id rather than dropping the row.
+        let no_pane_id = TmuxDriver::parse_managed_pane_row("tmpm-y\tclaude\t222").unwrap();
+        assert_eq!(no_pane_id.pane_id, None);
+        assert_eq!(no_pane_id.pane_pid, Some(222));
 
         // Empty session name is dropped entirely.
-        assert!(TmuxDriver::parse_managed_pane_row("\tzsh\t1").is_none());
+        assert!(TmuxDriver::parse_managed_pane_row("\tzsh\t1\t%1").is_none());
     }
 
     #[test]

--- a/crates/trusty-mpm/tests/orphan_gc_sweep.rs
+++ b/crates/trusty-mpm/tests/orphan_gc_sweep.rs
@@ -57,6 +57,7 @@ fn pane(name: &str, cmd: &str) -> PaneInfo {
         session_name: name.to_string(),
         pane_current_command: cmd.to_string(),
         pane_pid: Some(9999),
+        pane_id: None,
     }
 }
 


### PR DESCRIPTION
## Problem

Bare `tm`, run inside a managed pane after its inner `claude` exited but before the daemon marked the record `stopped`, dead-ends (see #2743 for the live transcript): the in-place relaunch → daemon reactivate returns **409 Conflict** → fallback `switch-client` reconnects to the session the operator is **already inside** → bare shell, no Claude.

## Root cause

The #2453 stale-`Active` reconcile on the reactivate route is **self-referential**: it reconciles only when every pane of the record's tmux session is an idle shell, but at reactivate time the requesting `tm` **is** the pane's foreground command (`is_idle_shell("tm")` is false, and its shell PID has `tm` as a live child). So the pane reads as "runtime still alive" and the reconcile is refused with 409 — every time, for this path. `daemon/managed_routes/reactivate.rs::should_reconcile_stale_active`.

## Fix

- `PaneInfo` gains a stable tmux `pane_id`; `list_managed_panes` captures `#{pane_id}`.
- The reactivate route accepts `?caller_pane_id=`; the reconcile **neutralizes the caller's own pane** (treats it as idle) before the liveness check. A pane cannot run `tm` in the foreground *and* a live interactive `claude`, so this is sound — not merely a trust assumption. A genuinely live **sibling** window in the same tmux session still blocks the reconcile (409), preserving the #2157 safety boundary. Never kills a live session.
- `bin/tm` forwards its current pane_id on both in-place entry points (env-var path + nested-session guard).
- **Self-reconnect no-op fix**: when the operator is provably inside the record's own pane and the relaunch can't proceed, `tm` no longer performs the misleading `switch-client` no-op; it reports honestly and prints an actionable `claude --resume <id>` hint.
- Extracted `guided_inplace.rs`'s inline test module to a child `tests.rs` to stay under the 500-SLOC production cap.

## Tests

- `should_reconcile_stale_active_true_when_only_caller_pane_busy` — zombie-active in-place relaunch reconciles.
- `should_reconcile_stale_active_false_when_sibling_pane_live_despite_caller` — genuinely-live sibling still 409s.
- `should_reconcile_stale_active_ignores_unmatched_caller_pane_id`.
- `reactivate_forwards_caller_pane_id_query` / `..._omits_..._when_absent` — client wire contract.
- `inplace_self_relaunch_hint_*` — honest self-relaunch hint (with/without claude_session_id).
- `parses_managed_pane_row` — pane_id parse incl. older-tmux (no column) degradation.

Full gate (raw): `cargo build --workspace` ✅, `cargo check --workspace` exit 0, `cargo clippy -p trusty-mpm --all-targets -D warnings` exit 0, `cargo test -p trusty-mpm` → 5328 passed; 0 failed, `cargo fmt --check` clean, `check_line_cap.sh` → 0 violations.

## Deployment note

Requires a **daemon restart / new release** to take effect: the reactivate-route reconcile lives in the daemon, and the `caller_pane_id` forwarding lives in the `tm` client binary. Bob's installed `tm` + running daemon will not pick this up until reinstalled/restarted (install handled separately).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
