### PR TITLE
feat(trusty-search): explicit allow_sensitive_path bypass for index creation

### DIFF
--- a/crates/trusty-common/src/search_index.rs
+++ b/crates/trusty-common/src/search_index.rs
@@ -86,6 +86,34 @@ pub fn ensure_project_indexed(project_root: &Path) -> Option<String> {
     Some(index_id)
 }
 
+/// Build the JSON body for the `POST /indexes` find-or-create call.
+///
+/// Why: extracted from `best_effort_create_index` so the request shape —
+/// specifically, that `allow_sensitive_path` is always `true` here — is
+/// unit-testable without a live daemon or a spawned thread.
+/// What: `allow_sensitive_path: true` (explicit-index-sensitive-path-bypass):
+/// this is ONLY reached from `ensure_project_indexed`, which is ONLY ever
+/// called with one specific project root a client explicitly wants indexed
+/// (tcode's/trusty-mpm's own working project) — never from trusty-search's
+/// auto/broad-discovery paths, which keep the full denylist. That makes this
+/// the "explicit request" case the flag exists for: it lets trusty-search
+/// index a bake-off scratch project living under an OS-temp prefix (e.g.
+/// `/var/folders/…`) instead of hard-rejecting it with 400. Harmless for
+/// ordinary project roots (trusty-mpm worktrees, checked-out repos): none of
+/// those live under `SENSITIVE_PATH_PREFIXES`, so the flag is a no-op for
+/// them, and it never bypasses the OTHER denylist checks (credential dirs,
+/// sensitive file names, top-level home dirs) — see
+/// `trusty-search::allowlist::is_denied_allowing_sensitive_path`'s doc comment
+/// for exactly what stays enforced.
+/// Test: `create_index_request_body_sets_allow_sensitive_path`.
+fn create_index_request_body(index_id: &str, root: &Path) -> serde_json::Value {
+    serde_json::json!({
+        "id": index_id,
+        "root_path": root.to_string_lossy(),
+        "allow_sensitive_path": true,
+    })
+}
+
 /// POST `/indexes` to find-or-create `index_id`; failures are logged, never
 /// propagated (issue #1373).
 ///
@@ -94,21 +122,23 @@ pub fn ensure_project_indexed(project_root: &Path) -> Option<String> {
 /// here keeps [`ensure_project_indexed`] readable and the error handling in one
 /// place.
 /// What: issues a short-timeout blocking `POST {base}/indexes` with body
-/// `{id, root_path}` ON A DEDICATED OS THREAD. Callers are frequently inside a
-/// tokio runtime; creating `reqwest::blocking`'s internal runtime directly there
-/// panics with "Cannot drop a runtime in a context where blocking is not
-/// allowed". Running the blocking client on a freshly-spawned `std::thread`
-/// (joined here) keeps that nested runtime entirely off the async worker, so the
-/// call is safe from both sync and async callers. A non-2xx response or
-/// transport error is logged at warn/debug and swallowed; the daemon endpoint is
-/// idempotent so re-creates are harmless. The client uses a tight ~1s overall
-/// timeout (750 ms connect) so the joined thread returns quickly: this call sits
-/// on a hot path and must NOT stall when the daemon is slow or unreachable.
+/// `{id, root_path, allow_sensitive_path}` (built by
+/// [`create_index_request_body`]) ON A DEDICATED OS THREAD. Callers are
+/// frequently inside a tokio runtime; creating `reqwest::blocking`'s internal
+/// runtime directly there panics with "Cannot drop a runtime in a context
+/// where blocking is not allowed". Running the blocking client on a
+/// freshly-spawned `std::thread` (joined here) keeps that nested runtime
+/// entirely off the async worker, so the call is safe from both sync and
+/// async callers. A non-2xx response or transport error is logged at
+/// warn/debug and swallowed; the daemon endpoint is idempotent so re-creates
+/// are harmless. The client uses a tight ~1s overall timeout (750 ms connect)
+/// so the joined thread returns quickly: this call sits on a hot path and
+/// must NOT stall when the daemon is slow or unreachable.
 /// Test: exercised via `ensure_project_indexed_returns_derived_id_when_daemon_down`
 /// (daemon-down path); the live HTTP path is covered by integration use.
 fn best_effort_create_index(base: &str, index_id: &str, root: &Path) {
     let url = format!("{base}/indexes");
-    let body = serde_json::json!({ "id": index_id, "root_path": root.to_string_lossy() });
+    let body = create_index_request_body(index_id, root);
     let index_id = index_id.to_string();
     let root_display = root.display().to_string();
 
@@ -314,6 +344,39 @@ mod tests {
         // Derivation yields an empty id for the filesystem root, so the helper
         // returns None without touching the daemon.
         assert_eq!(ensure_project_indexed(Path::new("/")), None);
+    }
+
+    /// `ensure_project_indexed`'s `POST /indexes` request body always sets
+    /// `allow_sensitive_path: true` (owner directive: explicit index requests
+    /// bypass the temp-dir denylist).
+    ///
+    /// Why: this is the trusty-common-side half of the bypass — without it,
+    /// trusty-search would still hard-reject a tcode bake-off project living
+    /// under an OS-temp prefix even after the daemon-side opt-in field exists.
+    /// Exercising `create_index_request_body` directly (rather than spawning a
+    /// thread and standing up a live daemon) keeps this test fast and offline.
+    /// What: builds the request body for both a plain project root and a
+    /// `/var/folders/…`-style scratch root, and asserts `allow_sensitive_path`
+    /// is `true` in both cases (the flag is unconditional, not path-dependent —
+    /// the daemon is the one that decides what it means).
+    /// Test: this test.
+    #[test]
+    fn create_index_request_body_sets_allow_sensitive_path() {
+        for root in [
+            Path::new("/Users/dev/projects/my-repo"),
+            Path::new("/private/var/folders/xx/scratch-project"),
+        ] {
+            let body = create_index_request_body("my-index", root);
+            assert_eq!(
+                body.get("allow_sensitive_path"),
+                Some(&serde_json::Value::Bool(true)),
+                "request body for root {root:?} must set allow_sensitive_path: true"
+            );
+            assert_eq!(
+                body.get("id").and_then(serde_json::Value::as_str),
+                Some("my-index")
+            );
+        }
     }
 
     #[test]

--- a/crates/trusty-search/src/allowlist/mod.rs
+++ b/crates/trusty-search/src/allowlist/mod.rs
@@ -418,29 +418,77 @@ pub fn remove_from_allowlist(path: &Path, allowlist_path: Option<&Path>) -> Resu
 /// `None` when the path is safe.
 ///
 /// Why: extracted from `check_path` so tests can assert against the raw
-/// denylist logic without constructing a full config file.
+/// denylist logic without constructing a full config file. This is the
+/// DEFAULT-behaviour entry point — every existing caller (auto-discovery,
+/// the CLI, `add_to_allowlist`, `check_path`) gets the full four-check
+/// denylist, unchanged. Callers that need the opt-in temp-dir bypass (see
+/// [`is_denied_allowing_sensitive_path`]) must ask for it explicitly.
 /// What: applies four anchored checks in order — (1) fixed path-prefix
 /// patterns from `SENSITIVE_PATH_PREFIXES`; (2) whole-component matching
 /// against `SENSITIVE_COMPONENT_NAMES` using `Path::components()` so that
 /// `/Projects/secrets-manager` is NOT denied but `/etc/secrets` IS denied;
 /// (3) exact file-name match against `SENSITIVE_FILE_NAMES`; (4) home-relative
-/// top-level dirs from `SENSITIVE_HOME_TOP_DIRS`.
+/// top-level dirs from `SENSITIVE_HOME_TOP_DIRS`. Delegates to
+/// [`is_denied_inner`] with `allow_sensitive_path: false`.
 /// Test: `denylist_blocks_ssh_dir`, `denylist_blocks_tmp`,
 /// `denylist_blocks_home_toplevel`, `denylist_allows_safe_path`,
 /// `denylist_allows_path_with_sensitive_word_in_name` in `tests.rs`.
 pub fn is_denied(path: &Path) -> Option<String> {
+    is_denied_inner(path, false)
+}
+
+/// Like [`is_denied`], but SKIPS check (1) — the `SENSITIVE_PATH_PREFIXES`
+/// OS-temp-dir / app-support-dir check — while still enforcing checks (2)-(4)
+/// (credential directories, sensitive file names, and top-level home dirs).
+///
+/// Why (owner directive, issue: explicit-index-sensitive-path-bypass): tcode's
+/// working project is frequently a bake-off scratch directory under
+/// `/var/folders/…` — an OS temp path that the broad/auto-discovery denylist
+/// correctly refuses, but that IS the exact project root a caller like
+/// `ensure_project_indexed` explicitly named. The denylist exists to stop
+/// unrequested, broad indexing of ephemeral or system directories; it is not
+/// meant to block a client that names one specific root on purpose. This
+/// function is for that one case: an EXPLICIT, single-root index request that
+/// opts in via `allow_sensitive_path: true`.
+/// What: an explicit request bypasses the WHOLE `SENSITIVE_PATH_PREFIXES` list
+/// (temp dirs AND `/Library/Application Support`), not a partial subset —
+/// the caller named this exact root, so it is honored rather than second-guessed
+/// with a narrower carve-out. Checks (2)-(4) (credential directories like
+/// `.ssh`/`.aws`, sensitive file names like `.env`, and top-level home
+/// directories like `~/Desktop`) are NEVER bypassed — those protect against a
+/// genuinely dangerous root regardless of how explicitly it was requested.
+/// Delegates to [`is_denied_inner`] with `allow_sensitive_path: true`.
+/// Test: `denylist_allowing_sensitive_path_permits_tmp_and_var_folders`,
+/// `denylist_allowing_sensitive_path_still_blocks_ssh_and_home` in `tests.rs`.
+pub fn is_denied_allowing_sensitive_path(path: &Path) -> Option<String> {
+    is_denied_inner(path, true)
+}
+
+/// Shared implementation for [`is_denied`] and [`is_denied_allowing_sensitive_path`].
+///
+/// Why: keeps the four-check denylist logic in exactly one place so the two
+/// public entry points can never drift out of sync on checks (2)-(4).
+/// What: identical to the four checks documented on [`is_denied`], except
+/// check (1) (`SENSITIVE_PATH_PREFIXES`) only runs when `allow_sensitive_path`
+/// is `false`.
+/// Test: exercised transitively via both public wrappers' tests.
+fn is_denied_inner(path: &Path, allow_sensitive_path: bool) -> Option<String> {
     let path_str = path.to_string_lossy();
     // Normalise separators so prefix checks work on Windows too.
     let normalised = path_str.replace('\\', "/");
 
     // 1. Fixed path-prefix patterns (OS-managed temporaries, macOS system dirs).
-    for &prefix in SENSITIVE_PATH_PREFIXES {
-        if normalised.starts_with(prefix) {
-            return Some(format!(
-                "path '{}' is under sensitive prefix '{}'; indexing refused",
-                path.display(),
-                prefix
-            ));
+    // Skipped entirely for an explicit, opted-in single-root request — see
+    // `is_denied_allowing_sensitive_path`'s doc comment for the rationale.
+    if !allow_sensitive_path {
+        for &prefix in SENSITIVE_PATH_PREFIXES {
+            if normalised.starts_with(prefix) {
+                return Some(format!(
+                    "path '{}' is under sensitive prefix '{}'; indexing refused",
+                    path.display(),
+                    prefix
+                ));
+            }
         }
     }
 

--- a/crates/trusty-search/src/allowlist/tests.rs
+++ b/crates/trusty-search/src/allowlist/tests.rs
@@ -68,6 +68,62 @@ fn denylist_blocks_tmp() {
     assert!(super::is_denied(&path).is_some());
 }
 
+/// `is_denied_allowing_sensitive_path` permits every OS-temp / app-support
+/// prefix that plain `is_denied` refuses (owner directive: explicit index
+/// requests may opt into indexing a scratch directory).
+///
+/// Why: this is the exact bypass tcode's `ensure_project_indexed` relies on —
+/// a bake-off scratch project living under `/var/folders/…` must be indexable
+/// when the client explicitly named that root.
+/// What: asserts `is_denied` still refuses each `SENSITIVE_PATH_PREFIXES`
+/// example, but `is_denied_allowing_sensitive_path` passes every one of them.
+/// Test: this test.
+#[test]
+fn denylist_allowing_sensitive_path_permits_tmp_and_var_folders() {
+    let examples = [
+        "/tmp/my-project",
+        "/private/tmp/my-project",
+        "/var/folders/xx/scratch-project",
+        "/private/var/folders/xx/scratch-project",
+        "/Library/Application Support/my-project",
+    ];
+    for path_str in examples {
+        let path = PathBuf::from(path_str);
+        assert!(
+            super::is_denied(&path).is_some(),
+            "sanity: {path_str:?} must still be denied by default is_denied"
+        );
+        assert!(
+            super::is_denied_allowing_sensitive_path(&path).is_none(),
+            "{path_str:?} must be permitted when allow_sensitive_path is set"
+        );
+    }
+}
+
+/// `is_denied_allowing_sensitive_path` still blocks credential directories
+/// and top-level home directories — the bypass is scoped to
+/// `SENSITIVE_PATH_PREFIXES` only, never the other three checks.
+///
+/// Why: an explicit index request naming ITS scratch root must not become a
+/// backdoor for indexing `~/.ssh` or `~/Desktop` — those dangers are
+/// independent of whether the path happens to live under a temp prefix.
+/// What: asserts `is_denied_allowing_sensitive_path` still returns `Some` for
+/// `~/.ssh` and for `$HOME` itself.
+/// Test: this test.
+#[test]
+fn denylist_allowing_sensitive_path_still_blocks_ssh_and_home() {
+    let home = dirs::home_dir().unwrap();
+    let ssh = home.join(".ssh");
+    assert!(
+        super::is_denied_allowing_sensitive_path(&ssh).is_some(),
+        "~/.ssh must still be denied even with allow_sensitive_path"
+    );
+    assert!(
+        super::is_denied_allowing_sensitive_path(&home).is_some(),
+        "$HOME itself must still be denied even with allow_sensitive_path"
+    );
+}
+
 #[test]
 fn denylist_blocks_env_file_in_path() {
     // Why: a path containing /.env indicates a directory that holds env files.

--- a/crates/trusty-search/src/service/server/helpers.rs
+++ b/crates/trusty-search/src/service/server/helpers.rs
@@ -37,13 +37,23 @@ use crate::core::registry::{IndexHandle, IndexId};
 ///
 /// What: in order — (1) rejects empty/non-absolute paths (no I/O); (2)
 /// checks `is_dir` via `tokio::fs::metadata`; (3) canonicalizes via
-/// `tokio::fs::canonicalize`; (4) calls `crate::allowlist::is_denied` on the
-/// canonical path and returns 400 with the denial reason when matched.
+/// `tokio::fs::canonicalize`; (4) calls `crate::allowlist::is_denied` (or, when
+/// `allow_sensitive_path` is `true`, `crate::allowlist::is_denied_allowing_sensitive_path`
+/// — see that function's doc comment for exactly what is and is not skipped)
+/// on the canonical path and returns 400 with the denial reason when matched.
+/// `allow_sensitive_path` should be `true` ONLY for an explicit, single-root
+/// create-index request that opted in (`CreateIndexRequest::allow_sensitive_path`);
+/// every other caller (reindex/relocate root validation) passes `false` to
+/// preserve today's behaviour exactly.
 /// Test: `validate_root_path_denylist_rejects_ssh`, `_rejects_home`,
-/// `_rejects_tmp`, `_accepts_project_dir` in `tests_denylist.rs`.
+/// `_rejects_tmp`, `_accepts_project_dir` in `tests_denylist.rs`;
+/// `create_index_allows_sensitive_path_when_opted_in`,
+/// `create_index_still_rejects_sensitive_path_by_default` in
+/// `tests_denylist.rs`.
 #[allow(clippy::result_large_err)]
 pub(super) async fn validate_root_path(
     path: &std::path::Path,
+    allow_sensitive_path: bool,
 ) -> Result<std::path::PathBuf, Response> {
     if path.as_os_str().is_empty() {
         return Err((
@@ -115,7 +125,17 @@ pub(super) async fn validate_root_path(
     // enforces the policy for direct HTTP callers, MCP tool invocations, and
     // scripts that bypass the CLI. Both checks are intentional — neither is
     // redundant.
-    if let Some(reason) = crate::allowlist::is_denied(&canonical) {
+    //
+    // `allow_sensitive_path` (explicit-index-sensitive-path-bypass): only the
+    // temp-dir/app-support PREFIX check is skippable, and only when the caller
+    // opted in — see `allowlist::is_denied_allowing_sensitive_path`'s doc
+    // comment.
+    let denial = if allow_sensitive_path {
+        crate::allowlist::is_denied_allowing_sensitive_path(&canonical)
+    } else {
+        crate::allowlist::is_denied(&canonical)
+    };
+    if let Some(reason) = denial {
         tracing::warn!(
             path = %canonical.display(),
             %reason,

--- a/crates/trusty-search/src/service/server/indexes.rs
+++ b/crates/trusty-search/src/service/server/indexes.rs
@@ -230,7 +230,7 @@ pub(super) async fn create_index_handler(
     // the canonical mount returned zero hits.
     // Issue #829: validate_root_path is now async (uses tokio::fs::canonicalize
     // and tokio::fs::metadata to avoid blocking the executor thread).
-    let canonical_root = match validate_root_path(&req.root_path).await {
+    let canonical_root = match validate_root_path(&req.root_path, req.allow_sensitive_path).await {
         Ok(p) => p,
         Err(resp) => return resp,
     };

--- a/crates/trusty-search/src/service/server/indexes_relocate.rs
+++ b/crates/trusty-search/src/service/server/indexes_relocate.rs
@@ -112,8 +112,10 @@ pub(super) async fn relocate_index_handler(
         }
     };
 
-    // Validate and canonicalize the new root path.
-    let new_root = match validate_root_path(&req.root_path).await {
+    // Validate and canonicalize the new root path. Relocate has no
+    // `allow_sensitive_path` opt-in on its request type, so this always
+    // enforces the full denylist (`false`) — unchanged from before.
+    let new_root = match validate_root_path(&req.root_path, false).await {
         Ok(p) => p,
         Err(resp) => return resp,
     };

--- a/crates/trusty-search/src/service/server/reindex_handlers.rs
+++ b/crates/trusty-search/src/service/server/reindex_handlers.rs
@@ -117,8 +117,10 @@ pub(super) async fn reindex_handler(
             // Issue (indexed-paths-mismatch): use the canonical form so a
             // re-register via a symlink alias normalises to the same identity
             // the original `POST /indexes` stored.
-            // Issue #829: validate_root_path is now async.
-            let new_root = match validate_root_path(&new_root).await {
+            // Issue #829: validate_root_path is now async. Reindex's root
+            // override has no `allow_sensitive_path` opt-in, so this always
+            // enforces the full denylist (`false`) — unchanged from before.
+            let new_root = match validate_root_path(&new_root, false).await {
                 Ok(canonical) => canonical,
                 Err(resp) => {
                     let (parts, body) = resp.into_parts();

--- a/crates/trusty-search/src/service/server/router.rs
+++ b/crates/trusty-search/src/service/server/router.rs
@@ -185,6 +185,32 @@ pub struct CreateIndexRequest {
     /// Test: `create_index_threads_hygiene_fields` in `service::server::tests_index`.
     #[serde(default)]
     pub data_file_max_bytes: Option<u64>,
+
+    /// Opt-in bypass of the `SENSITIVE_PATH_PREFIXES` hard-denylist check
+    /// (OS-temp dirs like `/tmp`/`/var/folders` and `/Library/Application
+    /// Support`) for THIS request only. `false`/missing (the default)
+    /// preserves today's behaviour exactly — auto-discovery and every
+    /// pre-existing caller still get the full denylist.
+    ///
+    /// Why (owner directive): trusty-search must be able to index a scratch
+    /// directory (e.g. a tcode bake-off working project under
+    /// `/var/folders/…`) when a client EXPLICITLY names that exact root —
+    /// the denylist exists to block unrequested/broad indexing of ephemeral
+    /// or system paths, not to second-guess a caller that named this one
+    /// root on purpose. `trusty_common::search_index::ensure_project_indexed`
+    /// sets this to `true` because it is, by construction, always called
+    /// with one specific project root the caller wants indexed.
+    /// What: threaded through to `validate_root_path`, which — only when
+    /// `true` — calls `allowlist::is_denied_allowing_sensitive_path` instead
+    /// of `allowlist::is_denied`. Every OTHER denylist check (credential
+    /// directories like `.ssh`/`.aws`, sensitive file names like `.env`, and
+    /// top-level home directories like `~/Desktop`) still applies regardless
+    /// of this flag — only the temp/app-support PREFIX check is skippable.
+    /// Test: `create_index_allows_sensitive_path_when_opted_in`,
+    /// `create_index_still_rejects_sensitive_path_by_default` in
+    /// `service::server::tests_denylist`.
+    #[serde(default)]
+    pub allow_sensitive_path: bool,
 }
 
 #[derive(Deserialize)]

--- a/crates/trusty-search/src/service/server/tests_1073.rs
+++ b/crates/trusty-search/src/service/server/tests_1073.rs
@@ -111,6 +111,7 @@ async fn relocate_index_updates_root_path() {
             defer_embed: None,
             extra_skip_dirs: None,
             data_file_max_bytes: None,
+            allow_sensitive_path: false,
         }),
     )
     .await;

--- a/crates/trusty-search/src/service/server/tests_2336.rs
+++ b/crates/trusty-search/src/service/server/tests_2336.rs
@@ -44,6 +44,7 @@ fn create_req(id: &str, root_path: std::path::PathBuf) -> super::router::CreateI
         defer_embed: None,
         extra_skip_dirs: None,
         data_file_max_bytes: None,
+        allow_sensitive_path: false,
     }
 }
 

--- a/crates/trusty-search/src/service/server/tests_829.rs
+++ b/crates/trusty-search/src/service/server/tests_829.rs
@@ -133,16 +133,17 @@ async fn validate_root_path_is_non_blocking_and_async() {
     use std::path::Path;
 
     // Empty path — rejected before any I/O (fast path).
-    let result = super::helpers::validate_root_path(Path::new("")).await;
+    let result = super::helpers::validate_root_path(Path::new(""), false).await;
     assert!(result.is_err(), "empty path must be rejected");
 
     // Relative path — rejected before any I/O (no is_absolute check, fast path).
-    let result = super::helpers::validate_root_path(Path::new("relative/path")).await;
+    let result = super::helpers::validate_root_path(Path::new("relative/path"), false).await;
     assert!(result.is_err(), "relative path must be rejected");
 
     // Non-existent absolute path — exercises the async metadata check.
     let result =
-        super::helpers::validate_root_path(Path::new("/this/path/does/not/exist/issue829")).await;
+        super::helpers::validate_root_path(Path::new("/this/path/does/not/exist/issue829"), false)
+            .await;
     assert!(result.is_err(), "non-existent path must be rejected");
 }
 

--- a/crates/trusty-search/src/service/server/tests_denylist.rs
+++ b/crates/trusty-search/src/service/server/tests_denylist.rs
@@ -59,6 +59,7 @@ async fn validate_root_path_denylist_rejects_ssh() {
             defer_embed: None,
             extra_skip_dirs: None,
             data_file_max_bytes: None,
+            allow_sensitive_path: false,
         }),
     )
     .await;
@@ -93,7 +94,7 @@ async fn validate_root_path_denylist_rejects_home() {
     if !home.is_dir() {
         return;
     }
-    let result = super::helpers::validate_root_path(&home).await;
+    let result = super::helpers::validate_root_path(&home, false).await;
     assert!(
         result.is_err(),
         "$HOME itself must be rejected by validate_root_path"
@@ -179,7 +180,7 @@ async fn validate_root_path_accepts_safe_project_dir() {
     .copied();
 
     if let Some(path) = candidate {
-        let result = super::helpers::validate_root_path(path).await;
+        let result = super::helpers::validate_root_path(path, false).await;
         assert!(
             result.is_ok(),
             "expected Ok for safe directory {:?}, got Err",
@@ -187,6 +188,130 @@ async fn validate_root_path_accepts_safe_project_dir() {
         );
     }
     // If none of the well-known paths exist (unusual CI environment), skip gracefully.
+}
+
+/// By default, `create_index_handler` still refuses a real directory living
+/// under an OS-temp prefix (`allow_sensitive_path` omitted / `false`) —
+/// unchanged behaviour (owner directive: auto/broad indexing keeps the
+/// denylist).
+///
+/// Why: regression guard that the new opt-in flag does not accidentally
+/// relax the default path — every pre-existing caller (auto-discovery, the
+/// CLI, MCP) must still be refused for a scratch directory unless it
+/// explicitly opts in.
+/// What: creates a REAL directory via `tempfile::tempdir()` (which on macOS
+/// resolves under `/private/var/folders/…`, a `SENSITIVE_PATH_PREFIXES`
+/// entry), calls `create_index_handler` with `allow_sensitive_path: false`,
+/// and asserts 400 with "indexing refused".
+/// Test: this test.
+#[tokio::test]
+async fn create_index_still_rejects_sensitive_path_by_default() {
+    use crate::core::registry::IndexRegistry;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = SearchAppState::new(IndexRegistry::new());
+    let embedder: Arc<dyn Embedder> = Arc::new(crate::core::embed::MockEmbedder::new(8));
+    state.install_embedder(embedder).await;
+    let state_arc = Arc::new(state);
+
+    let resp = create_index_handler(
+        State(Arc::clone(&state_arc)),
+        Json(CreateIndexRequest {
+            id: "scratch-default-denied".into(),
+            root_path: tmp.path().to_path_buf(),
+            include_paths: None,
+            exclude_globs: None,
+            extensions: None,
+            domain_terms: None,
+            path_filter: None,
+            include_docs: None,
+            respect_gitignore: None,
+            follow_links: None,
+            lexical_only: None,
+            skip_kg: None,
+            defer_embed: None,
+            extra_skip_dirs: None,
+            data_file_max_bytes: None,
+            allow_sensitive_path: false,
+        }),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a temp-dir root must still be refused by default"
+    );
+    let body = axum::body::to_bytes(resp.into_body(), 65536)
+        .await
+        .expect("body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("json");
+    let err = json.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("indexing refused"),
+        "error must mention 'indexing refused', got: {err:?}"
+    );
+}
+
+/// `create_index_handler` ACCEPTS a real directory under an OS-temp prefix
+/// when the request opts in via `allow_sensitive_path: true` (owner
+/// directive: an explicit index request may name a scratch working
+/// directory — e.g. tcode's bake-off project root).
+///
+/// Why: this is the core acceptance criterion for the bypass — without it,
+/// `ensure_project_indexed` could never register a tempdir-backed project,
+/// even though the caller named that exact root on purpose.
+/// What: creates a REAL directory via `tempfile::tempdir()`, calls
+/// `create_index_handler` with `allow_sensitive_path: true`, and asserts
+/// `200 {"created": true}` plus that the registry stores the canonicalized
+/// temp-dir root.
+/// Test: this test.
+#[tokio::test]
+async fn create_index_allows_sensitive_path_when_opted_in() {
+    use crate::core::registry::{IndexId, IndexRegistry};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical_root = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+    let state = SearchAppState::new(IndexRegistry::new());
+    let embedder: Arc<dyn Embedder> = Arc::new(crate::core::embed::MockEmbedder::new(8));
+    state.install_embedder(embedder).await;
+    let state_arc = Arc::new(state);
+
+    let resp = create_index_handler(
+        State(Arc::clone(&state_arc)),
+        Json(CreateIndexRequest {
+            id: "scratch-explicitly-allowed".into(),
+            root_path: tmp.path().to_path_buf(),
+            include_paths: None,
+            exclude_globs: None,
+            extensions: None,
+            domain_terms: None,
+            path_filter: None,
+            include_docs: None,
+            respect_gitignore: None,
+            follow_links: None,
+            lexical_only: None,
+            skip_kg: None,
+            defer_embed: None,
+            extra_skip_dirs: None,
+            data_file_max_bytes: None,
+            allow_sensitive_path: true,
+        }),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a temp-dir root must be accepted when allow_sensitive_path is true"
+    );
+
+    let handle = state_arc
+        .registry
+        .get(&IndexId::new("scratch-explicitly-allowed"))
+        .expect("registered handle");
+    assert_eq!(
+        handle.root_path, canonical_root,
+        "registry must store the canonicalized temp-dir root"
+    );
 }
 
 /// Symlink-bypass test: a symlink pointing at ~/.ssh must still be refused.
@@ -217,7 +342,7 @@ async fn validate_root_path_denylist_blocks_symlink_to_ssh() {
     if std::os::unix::fs::symlink(&ssh, &link).is_err() {
         return; // Cannot create symlink — skip.
     }
-    let result = super::helpers::validate_root_path(&link).await;
+    let result = super::helpers::validate_root_path(&link, false).await;
     let _ = std::fs::remove_file(&link);
     assert!(
         result.is_err(),

--- a/crates/trusty-search/src/service/server/tests_index.rs
+++ b/crates/trusty-search/src/service/server/tests_index.rs
@@ -196,6 +196,7 @@ async fn create_index_rejects_relative_root_path() {
             defer_embed: None,
             extra_skip_dirs: None,
             data_file_max_bytes: None,
+            allow_sensitive_path: false,
         }),
     )
     .await;
@@ -239,6 +240,7 @@ async fn create_index_rejects_nonexistent_root_path() {
             defer_embed: None,
             extra_skip_dirs: None,
             data_file_max_bytes: None,
+            allow_sensitive_path: false,
         }),
     )
     .await;
@@ -311,6 +313,7 @@ async fn create_index_canonicalizes_symlinked_root_path() {
             defer_embed: None,
             extra_skip_dirs: None,
             data_file_max_bytes: None,
+            allow_sensitive_path: false,
         }),
     )
     .await;
@@ -373,6 +376,7 @@ async fn create_index_accepts_valid_absolute_root_path() {
             defer_embed: None,
             extra_skip_dirs: None,
             data_file_max_bytes: None,
+            allow_sensitive_path: false,
         }),
     )
     .await;

--- a/crates/trusty-search/src/service/server/tests_state.rs
+++ b/crates/trusty-search/src/service/server/tests_state.rs
@@ -65,6 +65,7 @@ async fn create_index_returns_503_with_error_when_embedder_failed() {
             defer_embed: None,
             extra_skip_dirs: None,
             data_file_max_bytes: None,
+            allow_sensitive_path: false,
         }),
     )
     .await;


### PR DESCRIPTION
Closes #2746.

Owner directive: trusty-search must let an EXPLICIT client index-request index a project root even under an OS-temp prefix, while KEEPING the denylist for all auto/broad indexing.

## Problem

`POST /indexes` hard-rejects (400) any root under `SENSITIVE_PATH_PREFIXES` (`/tmp`, `/private/tmp`, `/var/folders`, `/private/var/folders`, `/Library/Application Support`) regardless of caller. This blocks tcode from indexing its own working project whenever that project is a bake-off scratch dir (`/var/folders/…` on macOS).

## Design

1. **`CreateIndexRequest.allow_sensitive_path: bool`** (`#[serde(default)]`, `crates/trusty-search/src/service/server/router.rs`) — opt-in, per-request, backward-compatible (omitted = `false`, unchanged behavior).
2. **Enforcement point gated**: `validate_root_path` (`crates/trusty-search/src/service/server/helpers.rs`) now takes `allow_sensitive_path: bool` and calls the new `allowlist::is_denied_allowing_sensitive_path` instead of `allowlist::is_denied` when `true`. That new function (`crates/trusty-search/src/allowlist/mod.rs`) skips ONLY check (1) — `SENSITIVE_PATH_PREFIXES` — via a shared `is_denied_inner`; checks (2)-(4) (credential dirs like `.ssh`/`.aws`, sensitive file names like `.env`, top-level home dirs like `~/Desktop`) are never bypassed, regardless of the flag.
3. **`/Library/Application Support` decision**: an explicit request bypasses the WHOLE `SENSITIVE_PATH_PREFIXES` list, not a narrower carve-out — the client named this exact root, so it's honored rather than second-guessed with a partial denylist. Documented in the `is_denied_allowing_sensitive_path` doc comment.
4. **Other `validate_root_path` callers unaffected**: reindex root-override (`reindex_handlers.rs`) and relocate (`indexes_relocate.rs`) both pass `false` explicitly — no opt-in surface on those request types, so behavior there is byte-identical to before.
5. **`trusty_common::search_index::ensure_project_indexed`** (`crates/trusty-common/src/search_index.rs`) sets `allow_sensitive_path: true` on its `POST /indexes` body — extracted into a small `create_index_request_body` helper so the flag is unit-testable without a live daemon. This helper is the ONE shared entry point tcode and trusty-mpm both call to explicitly register their own working project, so it's exactly the "explicit request" case the flag exists for. It's a no-op for trusty-mpm (worktree paths never live under the denylist).
6. **No `tcode`/`trusty-mpm` call-site changes** — both route through the helper. Confirmed both still build/test clean.

No version bump: per this repo's convention, version bumps happen at deliberate release time via `scripts/bump-version.sh`, not bundled into feature PRs.

## Tests (5 new)
- `trusty-search`: `allowlist::tests::denylist_allowing_sensitive_path_permits_tmp_and_var_folders`, `denylist_allowing_sensitive_path_still_blocks_ssh_and_home`, `service::server::tests_denylist::create_index_still_rejects_sensitive_path_by_default` (400 by default), `create_index_allows_sensitive_path_when_opted_in` (200 + registry stores canonical temp-dir root when opted in).
- `trusty-common`: `search_index::tests::create_index_request_body_sets_allow_sensitive_path`.

## Quality gate (all green, from the worktree)
- `cargo build -p trusty-search -p trusty-common -p trusty-code -p trusty-mpm` — clean.
- `cargo test -p trusty-search -p trusty-common -p trusty-code -p trusty-mpm` — every test binary `ok`, 0 failed (74 `test result: ok` lines total).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (0 errors; remaining warnings are pre-existing/unrelated: MSRV note, `tga`'s own warning, pnpm placeholder).
- `cargo fmt --check` — clean.
- `bash scripts/check_line_cap.sh` — 0 violations.
- `bash scripts/check_test_pointers.sh` — 0 dangling pointers.
- `cargo check --workspace` — clean.

**Do NOT merge** — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)