### PR TITLE
feat(trusty-mpm): propagate native trusty MCP servers to fleet sessions (#2739)

### DIFF
--- a/crates/trusty-mpm/src/assets/skills/tm-cli-operations.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-cli-operations.md
@@ -41,10 +41,23 @@ dir's `.claude.json`:
   (same precedence chain as `tm register`/`tm ls`:
   `--root` > `TRUSTY_MPM_ROOT` env > `[standalone] root` in config > `~/.trusty-mpm`).
 
-This map is **user scope** — "available in all your projects." Every tm-managed
-session sees these servers, with no per-project approval dialog. There is
-deliberately **no `--scope` flag**: `tm mcp` is inherently user scope. (Stock
-`claude mcp add` cannot target this relocated dir, which is why `tm mcp` exists.)
+This map is **user scope**. There is deliberately **no `--scope` flag**:
+`tm mcp` is inherently user scope. (Stock `claude mcp add` cannot target this
+relocated dir, which is why `tm mcp` exists.)
+
+**Where these servers actually reach (issue #2739):**
+
+- The **standalone `tm run` driver** reads this user-scope map directly, so it
+  sees **every** server you add here.
+- **Daemon-managed / fleet sessions** (`tm session new`) launch
+  `claude --setting-sources project,local`, which does NOT read the user tier.
+  For them, only **native trusty MCP servers** are bridged into each session's
+  workspace `.mcp.json` at spawn — currently the allowlist
+  `slack-mcp`, `telegram-mcp`, `gworkspace-mcp`, `trusty-analyze`
+  (plus the always-provisioned `trusty-memory` / `trusty-search`, which have
+  their own dedicated injectors). Non-native/third-party or HTTP servers you add
+  (e.g. `github`, remote endpoints) apply to the standalone driver only and are
+  **not** injected into fleet sessions.
 
 ### The 3 auto-provisioned framework built-ins
 

--- a/crates/trusty-mpm/src/bin/tm/commands/mcp.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mcp.rs
@@ -223,7 +223,15 @@ pub(crate) fn get_cmd(root: Option<&str>, name: &str, json: bool) -> Result<()> 
         println!("{name}:");
         println!("  Type:   {}", entry_type(&entry));
         println!("  Target: {}", entry_target(&entry));
-        println!("  Scope:  User config (available in all managed sessions)");
+        println!("  Scope:  User config");
+        // #2739: the "available everywhere" claim was misleading. Native trusty
+        // servers are bridged into every daemon-managed/fleet session's
+        // `.mcp.json`; non-native (third-party/HTTP) managed servers reach only
+        // the standalone `tm run` driver, NOT fleet sessions.
+        println!(
+            "          Native trusty servers reach all managed/fleet sessions; \
+             non-native managed servers apply to the standalone `tm run` driver only."
+        );
     }
     Ok(())
 }

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -14,11 +14,17 @@
 //! Test: `prepare_session_writes_claude_md_and_stash` and
 //! `prepare_session_is_idempotent` in this module's tests.
 
+mod native_mcp;
 mod palace_alias;
 mod search_index;
 mod settings;
 #[cfg(test)]
 mod tests;
+// Injector-specific unit tests live in a dedicated `_tests.rs` file (1500-SLOC
+// test cap) rather than inline in `native_mcp.rs` (500-SLOC production cap).
+#[cfg(test)]
+#[path = "native_mcp_tests.rs"]
+mod native_mcp_tests;
 mod worktree_sync;
 // Split out of `tests.rs` to keep it under the 1500-SLOC test-file cap
 // (issue #2149 roster-deploy-failure-continues coverage) — mirrors the
@@ -33,6 +39,7 @@ use crate::core::agent_deployer::{DeployResult, deploy_agents_filtered};
 use crate::core::instruction_pipeline::{PipelineInput, PipelineOutput, build_instructions};
 use crate::core::paths::FrameworkPaths;
 use crate::core::skill_deployer::{DeployStats, deploy_skills_filtered};
+use native_mcp::inject_native_trusty_mcps;
 use search_index::{inject_trusty_search_mcp, register_project_index};
 use settings::{
     deploy_output_style, inject_trusty_memory_mcp, preseed_workspace_trust_home,
@@ -550,6 +557,22 @@ fn prepare_session_inner(
         }
     } else {
         tracing::debug!("manifest disables trusty-search MCP injection");
+    }
+
+    // Inject NATIVE trusty MCP servers registered via `tm mcp add` (e.g.
+    // slack-mcp, gworkspace-mcp, trusty-analyze) into the workspace `.mcp.json`
+    // (issue #2739). Fleet sessions launch `claude --setting-sources
+    // project,local`, which never reads the managed `.claude.json` `mcpServers`
+    // map where `tm mcp` writes — so without this bridge those servers are
+    // invisible to managed sessions. Scope is the native-trusty allowlist ONLY
+    // (third-party/HTTP managed servers are deliberately excluded); the memory
+    // and search injectors above already own their own pinned entries and are
+    // excluded from the allowlist. MUST run BEFORE the trust pre-seed below so
+    // the injected names flow into `enabledMcpjsonServers` and skip the "new MCP
+    // servers found" dialog. Non-fatal: a failure only means those extra tools
+    // are absent from this session.
+    if let Err(err) = inject_native_trusty_mcps(fw, project_dir) {
+        tracing::warn!("failed to inject native trusty MCP servers: {err}");
     }
 
     // Pre-seed per-directory trust for this workspace in `~/.claude.json`

--- a/crates/trusty-mpm/src/core/session_launch/native_mcp.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp.rs
@@ -35,17 +35,26 @@
 //! project-scope `.mcp.json` entry, and the same premise
 //! `inject_trusty_memory_mcp`'s cwd-based palace fallback already depends on.
 //! Because `.gitignore`/`.git/info/exclude` do not retroactively protect an
-//! ALREADY-tracked file (`.mcp.json`'s problem), but `.env.local` is a NEW file
-//! we create, excluding it via `.git/info/exclude` genuinely keeps it out of
-//! `git add -A` — mirroring the proven pattern in
-//! `daemon::managed_routes::inproject::untracked_sync::append_to_git_exclude`
+//! ALREADY-tracked file (`.mcp.json`'s problem), but `.env.local` is USUALLY a
+//! NEW, never-tracked file, excluding it via `.git/info/exclude`
+//! ([`ensure_env_local_git_excluded`]) closes that case — mirroring the proven
+//! pattern in `daemon::managed_routes::inproject::untracked_sync::append_to_git_exclude`
 //! (that helper is daemon-private and unreachable from this `core`-layer
-//! module, so [`ensure_env_local_git_excluded`] re-implements the same
+//! module, so `ensure_env_local_git_excluded` re-implements the same
 //! `git rev-parse --git-path info/exclude` + idempotent-append technique rather
 //! than introducing a `core` → `daemon` dependency; flagged here as a future
-//! consolidation candidate). The exclude entry is written BEFORE any secret
-//! content, so there is never a window where an un-excluded file holds a live
-//! token.
+//! consolidation candidate). But `tm` ships into ARBITRARY target repos —
+//! including ones that already TRACK a file literally named `.env.local` (a
+//! second code-critic pass empirically reproduced exactly this: appending to
+//! `info/exclude` is a no-op for an already-tracked path). So
+//! [`route_native_mcp_secrets`] adds a second, independent gate AFTER the
+//! exclude-file write: [`is_env_local_actually_ignored`] asks git itself —
+//! `git check-ignore -q -- .env.local` — whether the path would actually be
+//! staged, and skips secret delivery entirely (fail-closed, same "servers
+//! launch without credentials this session" contract as the not-a-git-repo
+//! case) unless git confirms it is ignored. Both gates run BEFORE any secret
+//! content is written, so there is never a window where a live token sits in a
+//! file git would stage.
 //!
 //! What: [`inject_native_trusty_mcps`] reads the managed `.claude.json`
 //! `mcpServers` map (via the SAME [`crate::core::mcp_config`] reader `tm mcp`
@@ -65,7 +74,8 @@
 //! `inject_native_env_local_routing_is_idempotent`, `inject_native_skips_non_native`,
 //! `inject_native_trust_preseed_covers_injected`,
 //! `inject_native_absent_config_is_noop`,
-//! `inject_native_no_secrets_writes_no_env_local`).
+//! `inject_native_no_secrets_writes_no_env_local`,
+//! `inject_native_skips_secrets_when_env_local_is_tracked`).
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -254,24 +264,38 @@ pub(super) fn split_public_and_secret_env(
 }
 
 /// Merge collected native-server secrets into the workspace `.env.local`,
-/// after confirming that file is git-excluded.
+/// after confirming — via git itself, not just our own exclude-file write —
+/// that the file is genuinely ignored.
 ///
 /// Why: the delivery half of the #2739 secret-leak fix — this is the ONLY
 /// place a raw token value from the managed registry is ever written to disk
 /// inside the workspace, so it alone carries the exclusion guarantee.
+/// [`ensure_env_local_git_excluded`] appending a line to `info/exclude` is
+/// necessary but NOT sufficient: a code-critic re-review (residual HIGH,
+/// #2739) reproduced a second leak of the SAME class — if the target repo
+/// already TRACKS a file literally named `.env.local` (empirically plausible;
+/// `tm` ships to arbitrary repos, including ones that never adopted the
+/// `.env.local`-is-gitignored convention), `info/exclude` does nothing for an
+/// already-tracked path, so merging a token into it and a routine `git add -A`
+/// would stage — and a commit would leak — the secret. Asking git directly
+/// (`git check-ignore`) is the only check that actually reflects git's own
+/// staging decision, catching both a tracked `.env.local` AND the case where
+/// the exclude append silently didn't take effect (e.g. a `.gitignore`
+/// negation pattern elsewhere overriding it).
 /// What: resolves + ensures the `.env.local` git-exclude entry via
 /// [`ensure_env_local_git_excluded`] FIRST; on failure (not a git repo, `git`
-/// missing, a permissions error) logs a `warn!` and returns `Ok(())` WITHOUT
-/// writing anything — this session's native servers simply lack credentials
-/// (matching the "non-fatal, tools absent" contract every other injector in
-/// this module already has) rather than risk an un-excluded secret file. On
-/// success, reads any existing `<project_path>/.env.local` (missing file →
-/// empty), merges in `secrets` via [`merge_env_file`], and skips the write
-/// entirely when the merge is a byte-for-byte no-op (idempotency).
+/// missing, a permissions error) logs a `warn!` and returns `Ok(())`. THEN —
+/// even after that succeeds — runs `git -C <project_path> check-ignore -q --
+/// .env.local` (git's own authority on whether a path would be staged) and
+/// bails out the SAME way (`warn!` + `Ok(())`, no write) unless it exits `0`.
+/// Only past both gates does it read any existing `<project_path>/.env.local`
+/// (missing file → empty), merge in `secrets` via [`merge_env_file`], and skip
+/// the write entirely when the merge is a byte-for-byte no-op (idempotency).
 /// Test: `inject_native_delivers_secrets_via_env_local`,
 /// `inject_native_env_local_is_git_excluded_and_unstaged`,
 /// `inject_native_env_local_routing_is_idempotent`,
-/// `inject_native_secrets_skipped_outside_git_repo`.
+/// `inject_native_secrets_skipped_outside_git_repo`,
+/// `inject_native_skips_secrets_when_env_local_is_tracked`.
 fn route_native_mcp_secrets(
     project_path: &Path,
     secrets: &BTreeMap<String, String>,
@@ -281,6 +305,17 @@ fn route_native_mcp_secrets(
             "skipping native trusty MCP secret delivery: could not confirm `{}` is \
              git-excluded in {} ({err}) — those servers will launch without credentials \
              this session",
+            ENV_LOCAL_FILENAME,
+            project_path.display()
+        );
+        return Ok(());
+    }
+
+    if !is_env_local_actually_ignored(project_path) {
+        tracing::warn!(
+            "skipping native trusty MCP secret delivery: `{}` in {} is NOT recognised as \
+             git-ignored (it may already be tracked in this repo) — those servers will \
+             launch without credentials this session rather than risk staging a secret",
             ENV_LOCAL_FILENAME,
             project_path.display()
         );
@@ -297,6 +332,33 @@ fn route_native_mcp_secrets(
         path: env_local_path,
         source,
     })
+}
+
+/// Ask git itself whether `.env.local` is ignored (and therefore would never
+/// be staged by `git add -A`) in `project_path`.
+///
+/// Why: the fail-closed gate that catches an already-TRACKED `.env.local` —
+/// the case [`ensure_env_local_git_excluded`] cannot detect on its own, since
+/// appending a line to `info/exclude` succeeds unconditionally regardless of
+/// whether the path is already tracked. `git check-ignore` is git's OWN
+/// authority on whether a path would be excluded from `git add`, so this is
+/// the same check a human would run to verify the guarantee, not a
+/// reimplementation of git's ignore-resolution rules.
+/// What: runs `git -C <project_path> check-ignore -q -- .env.local` and
+/// returns whether it exited `0` (ignored). Any non-zero exit — including
+/// "not ignored" (which is what a tracked file, or a file with no matching
+/// ignore rule, both report) and a hard error (not a repo, no `git` binary) —
+/// is treated as `false`. Never panics.
+/// Test: `inject_native_skips_secrets_when_env_local_is_tracked`,
+/// `is_env_local_actually_ignored_true_when_excluded`,
+/// `is_env_local_actually_ignored_false_when_tracked`.
+pub(super) fn is_env_local_actually_ignored(project_path: &Path) -> bool {
+    std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .args(["check-ignore", "-q", "--", ENV_LOCAL_FILENAME])
+        .status()
+        .is_ok_and(|status| status.success())
 }
 
 /// Ensure `.env.local` is listed in the workspace's real `info/exclude` file.

--- a/crates/trusty-mpm/src/core/session_launch/native_mcp.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp.rs
@@ -1,0 +1,449 @@
+//! Inject NATIVE trusty MCP servers from the managed registry into a fleet
+//! session's workspace `.mcp.json` (issue #2739), with secrets routed OUT of
+//! that tracked file (issue #2739 follow-up — code-critic BLOCK).
+//!
+//! Why: `tm mcp add` writes user-scope MCP servers into the tm-owned
+//! `CLAUDE_CONFIG_DIR/.claude.json` `mcpServers` map (see [`crate::core::mcp_config`]),
+//! and its help text claims they are "available in all your projects". That is
+//! TRUE for the standalone `tm run` driver but FALSE for daemon-managed fleet
+//! sessions (`tm session new`): those launch `claude --setting-sources
+//! project,local`, which excludes the `user` tier where that map lives, so the
+//! managed servers are never read. The workspace `.mcp.json` is regenerated on
+//! every spawn by `prepare_session` via two hardcoded injectors
+//! (`trusty-memory`, `trusty-search`) and nothing bridges the `tm mcp` registry
+//! into the project layer — so a `tm mcp add`-ed server (e.g. `slack-mcp`) is
+//! invisible to fleet sessions. This module closes that gap.
+//!
+//! `<workspace>/.mcp.json` is git-TRACKED in every real project (confirmed: it
+//! is tracked in this very repo). A fleet agent's mandated `git add -A &&
+//! commit && push` workflow would therefore commit any secret written into it
+//! straight into remote history. So a server's `env` block (e.g.
+//! `SLACK_BOT_TOKEN`, `SLACK_USER_TOKEN`, `TELEGRAM_BOT_TOKEN`) is NEVER written
+//! into `.mcp.json` — see [`split_public_and_secret_env`]. Instead it is
+//! delivered out-of-band via a workspace-root `.env.local`
+//! ([`route_native_mcp_secrets`]), which the native binaries' own credential
+//! resolver (`trusty_common::inference::credentials::resolve_key`, confirmed at
+//! `crates/trusty-channels/src/{slack,telegram}/api/client.rs`) already reads
+//! via env → `.env.local` → secure-store precedence
+//! (`trusty_common::inference::credentials::dotenv::load_env_local_once`,
+//! `find_workspace_env_local`). That loader searches upward from the spawned
+//! process's cwd and — critically — checks the STARTING directory itself before
+//! any repo-root boundary test (`dotenv.rs`'s
+//! `walk_finds_env_local_at_the_boundary_itself` covers exactly this), so an
+//! `.env.local` written at the workspace root is found by an MCP server Claude
+//! Code spawns with that workspace as cwd — the documented behaviour for a
+//! project-scope `.mcp.json` entry, and the same premise
+//! `inject_trusty_memory_mcp`'s cwd-based palace fallback already depends on.
+//! Because `.gitignore`/`.git/info/exclude` do not retroactively protect an
+//! ALREADY-tracked file (`.mcp.json`'s problem), but `.env.local` is a NEW file
+//! we create, excluding it via `.git/info/exclude` genuinely keeps it out of
+//! `git add -A` — mirroring the proven pattern in
+//! `daemon::managed_routes::inproject::untracked_sync::append_to_git_exclude`
+//! (that helper is daemon-private and unreachable from this `core`-layer
+//! module, so [`ensure_env_local_git_excluded`] re-implements the same
+//! `git rev-parse --git-path info/exclude` + idempotent-append technique rather
+//! than introducing a `core` → `daemon` dependency; flagged here as a future
+//! consolidation candidate). The exclude entry is written BEFORE any secret
+//! content, so there is never a window where an un-excluded file holds a live
+//! token.
+//!
+//! What: [`inject_native_trusty_mcps`] reads the managed `.claude.json`
+//! `mcpServers` map (via the SAME [`crate::core::mcp_config`] reader `tm mcp`
+//! uses), filters it to the [`NATIVE_TRUSTY_MCP_SERVERS`] allowlist, and for
+//! each match splits the entry via [`split_public_and_secret_env`]: the
+//! `env`-free command/args/type shape merges idempotently into
+//! `<workspace>/.mcp.json` via [`super::settings::inject_mcp_server`]; any `env`
+//! entries are collected and merged into `<workspace>/.env.local` via
+//! [`route_native_mcp_secrets`]. Because it runs BEFORE
+//! `preseed_workspace_trust_home`, the injected `.mcp.json` names still flow
+//! into the `enabledMcpjsonServers` trust list, so no "new MCP servers found"
+//! dialog fires.
+//! Test: `native_mcp_tests.rs` (`inject_native_only_injects_allowlisted`,
+//! `inject_native_strips_secret_env_from_mcp_json`,
+//! `inject_native_delivers_secrets_via_env_local`,
+//! `inject_native_env_local_is_git_excluded_and_unstaged`,
+//! `inject_native_env_local_routing_is_idempotent`, `inject_native_skips_non_native`,
+//! `inject_native_trust_preseed_covers_injected`,
+//! `inject_native_absent_config_is_noop`,
+//! `inject_native_no_secrets_writes_no_env_local`).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::PrepError;
+use super::settings::inject_mcp_server;
+use crate::core::mcp_config;
+use crate::core::paths::FrameworkPaths;
+use crate::core::trusty_tools_config::managed_claude_config_dir_at;
+
+/// Basename of the git-excluded file native MCP server secrets are delivered
+/// through.
+///
+/// Why: must be exactly the filename
+/// `trusty_common::inference::credentials::dotenv` searches for — that loader
+/// hardcodes `.env.local`, so this cannot be an arbitrary/dedicated filename.
+/// What: `.env.local`.
+/// Test: `inject_native_delivers_secrets_via_env_local`.
+const ENV_LOCAL_FILENAME: &str = ".env.local";
+
+/// The allowlist of NATIVE trusty MCP server names eligible for fleet injection.
+///
+/// Why (owner decision, issue #2739): only trusty-family native MCP servers are
+/// propagated into managed sessions — third-party/HTTP managed servers (github,
+/// chrome-devtools, Duetto endpoints, …) are deliberately NOT injected, so a
+/// remote/opaque endpoint added to the standalone `tm run` driver never silently
+/// lands in every fleet session. The operator still controls PRESENCE via
+/// `tm mcp add`/`tm mcp remove`; this allowlist only FILTERS the managed registry
+/// down to the trusty natives. Keeping it an explicit, documented constant makes
+/// it trivially extensible: adding a new native trusty MCP binary is a one-line
+/// change here.
+/// What: the fixed set of native trusty MCP server names to inject when present
+/// in the managed registry. `trusty-memory` and `trusty-search` are EXCLUDED on
+/// purpose — they already have dedicated, palace/index-pinning injectors
+/// (`inject_trusty_memory_mcp` / `inject_trusty_search_mcp`) that must own their
+/// entries; re-injecting them here (unpinned) would clobber that pinning.
+/// `trusty-review` is likewise omitted (it is a built-in framework server the
+/// managed `.mcp.json` provisions directly, not a `tm mcp add` native). Every
+/// server here has its `env` block routed to `.env.local` instead of
+/// `.mcp.json` — see the module docs — so adding a server whose credentials
+/// should stay in `.mcp.json` (there is no such case today) would need an
+/// explicit carve-out, not just an allowlist entry.
+/// Test: `inject_native_only_injects_allowlisted`,
+/// `inject_native_skips_non_native` in `native_mcp_tests.rs`.
+pub(super) const NATIVE_TRUSTY_MCP_SERVERS: &[&str] = &[
+    "slack-mcp",
+    "telegram-mcp",
+    "gworkspace-mcp",
+    "trusty-analyze",
+];
+
+/// Inject the allowlisted native trusty MCP servers from the managed registry
+/// into the workspace `.mcp.json` (issue #2739).
+///
+/// Why: this is the `prepare_session` call site. It resolves the tm-owned managed
+/// config dir — the SAME `.claude.json` the `tm mcp` CLI reads and writes —
+/// relative to `fw`'s home base rather than the ambient process env. Using `fw`
+/// (not `CLAUDE_CONFIG_DIR`) keeps this hermetic: production managed sessions
+/// build `fw` under the real home, so it resolves to the real managed dir; test
+/// `FrameworkPaths::under(tempdir)` callers stay confined to the temp dir instead
+/// of leaking the operator's real registry into a fixture (mirroring the
+/// `deploy_output_style(&fw.claude_home_dir())` isolation pattern). `tm mcp`
+/// likewise resolves this dir home-relative via
+/// [`crate::core::trusty_tools_config::managed_claude_config_dir`] — it does not
+/// consult `CLAUDE_CONFIG_DIR` — so the two see the same file.
+/// What: computes
+/// [`managed_claude_config_dir_at`]`(fw.claude_home_dir())` and delegates to
+/// [`inject_native_trusty_mcps_from`]. A missing/empty managed `.claude.json`
+/// makes the delegate a no-op.
+/// Test: covered end-to-end via the `inject_native_*` tests, which drive the
+/// hermetic `_from` core directly with a tempdir config dir, and by
+/// `prepare_session_preseeds_enabled_mcp_servers` (which asserts an isolated `fw`
+/// injects no natives).
+pub(super) fn inject_native_trusty_mcps(
+    fw: &FrameworkPaths,
+    project_path: &Path,
+) -> Result<(), PrepError> {
+    let config_dir = managed_claude_config_dir_at(&fw.claude_home_dir());
+    inject_native_trusty_mcps_from(project_path, &config_dir)
+}
+
+/// Hermetic core: inject allowlisted native trusty MCP servers from
+/// `managed_config_dir/.claude.json` into `<project_path>/.mcp.json`, routing
+/// any secret `env` values through `.env.local` instead.
+///
+/// Why: split from [`inject_native_trusty_mcps`] so tests can drive it against a
+/// tempdir `CLAUDE_CONFIG_DIR` + tempdir workspace without touching the real
+/// home or the daemon.
+/// What: reads the managed `mcpServers` map via [`mcp_config::list_servers`]
+/// (which quarantines a malformed `.claude.json` and yields an empty map when the
+/// file is absent). For each entry whose NAME is in
+/// [`NATIVE_TRUSTY_MCP_SERVERS`], [`split_public_and_secret_env`] separates the
+/// entry into an `env`-free public shape (merged into `.mcp.json` via
+/// [`inject_mcp_server`]) and its `env` map (collected across all matched
+/// servers). When any secrets were collected, [`route_native_mcp_secrets`]
+/// merges them into the workspace `.env.local`. Non-allowlisted
+/// (third-party/HTTP) servers are skipped, and `trusty-memory` / `trusty-search`
+/// are never touched here (their dedicated injectors own them). Injection order
+/// is deterministic (allowlist order) so `.mcp.json` is stable across runs; the
+/// secret map is a `BTreeMap` for the same reason. A read error on the registry
+/// is surfaced as [`PrepError::Deploy`]; the `prepare_session` call site treats
+/// the whole step as non-fatal.
+/// Test: `inject_native_only_injects_allowlisted`,
+/// `inject_native_strips_secret_env_from_mcp_json`,
+/// `inject_native_delivers_secrets_via_env_local`,
+/// `inject_native_env_local_routing_is_idempotent`,
+/// `inject_native_skips_non_native`, `inject_native_absent_config_is_noop` in
+/// `native_mcp_tests.rs`.
+pub(super) fn inject_native_trusty_mcps_from(
+    project_path: &Path,
+    managed_config_dir: &Path,
+) -> Result<(), PrepError> {
+    let servers = mcp_config::list_servers(managed_config_dir)
+        .map_err(|err| PrepError::Deploy(format!("reading managed MCP registry: {err}")))?;
+
+    // Iterate the allowlist (not the registry) so injection order is deterministic
+    // and only trusty natives are ever considered.
+    let mut secret_env: BTreeMap<String, String> = BTreeMap::new();
+    for &name in NATIVE_TRUSTY_MCP_SERVERS {
+        if let Some(entry) = servers.get(name) {
+            let (public_entry, env) = split_public_and_secret_env(entry, name);
+            inject_mcp_server(project_path, name, public_entry)?;
+            secret_env.extend(env);
+        }
+    }
+
+    if !secret_env.is_empty() {
+        route_native_mcp_secrets(project_path, &secret_env)?;
+    }
+    Ok(())
+}
+
+/// Split a managed registry entry into an `env`-free public shape and its
+/// secret `env` map.
+///
+/// Why (code-critic BLOCK on #2739): the managed registry's `env` block is
+/// where live secrets (`SLACK_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN`, …) live. Every
+/// value there is treated as a secret categorically — never split by a
+/// key-name heuristic (`*_TOKEN`, `*_SECRET`, …) — because a heuristic has
+/// false negatives and a single missed key is a real credential leak into a
+/// tracked file; a category-wide rule can't have that failure mode. Today none
+/// of the four allowlisted servers need a non-secret env var in `.mcp.json`
+/// (`gworkspace-mcp`/`trusty-analyze` carry no `env` at all in practice), so
+/// this costs nothing real yet — a future native server that legitimately needs
+/// a non-secret, committable env var would need an explicit carve-out here, not
+/// silent inclusion.
+/// What: clones `entry`, removes its top-level `env` key (if any and if it is a
+/// JSON object) from the clone, and returns `(entry_without_env,
+/// string_valued_env_map)`. A non-string env value is skipped with a `warn!`
+/// (never propagated into `.mcp.json` either) — the `env` schema for an MCP
+/// server is always `Record<string, string>`, so a non-string value indicates a
+/// malformed registry entry, not a legitimate secret to route.
+/// Test: `inject_native_strips_secret_env_from_mcp_json`,
+/// `inject_native_no_env_key_when_source_has_none`,
+/// `split_public_and_secret_env_separates_env_from_shape`,
+/// `split_public_and_secret_env_skips_non_string_values`.
+pub(super) fn split_public_and_secret_env(
+    entry: &Value,
+    server_name: &str,
+) -> (Value, BTreeMap<String, String>) {
+    let mut public_entry = entry.clone();
+    let mut secret_env = BTreeMap::new();
+
+    if let Some(obj) = public_entry.as_object_mut()
+        && let Some(env_value) = obj.remove("env")
+        && let Some(env_obj) = env_value.as_object()
+    {
+        for (key, value) in env_obj {
+            match value.as_str() {
+                Some(s) => {
+                    secret_env.insert(key.clone(), s.to_string());
+                }
+                None => tracing::warn!(
+                    server = server_name,
+                    env_key = %key,
+                    "native trusty MCP env value is not a string; skipping \
+                     (never routed to .mcp.json or .env.local)"
+                ),
+            }
+        }
+    }
+
+    (public_entry, secret_env)
+}
+
+/// Merge collected native-server secrets into the workspace `.env.local`,
+/// after confirming that file is git-excluded.
+///
+/// Why: the delivery half of the #2739 secret-leak fix — this is the ONLY
+/// place a raw token value from the managed registry is ever written to disk
+/// inside the workspace, so it alone carries the exclusion guarantee.
+/// What: resolves + ensures the `.env.local` git-exclude entry via
+/// [`ensure_env_local_git_excluded`] FIRST; on failure (not a git repo, `git`
+/// missing, a permissions error) logs a `warn!` and returns `Ok(())` WITHOUT
+/// writing anything — this session's native servers simply lack credentials
+/// (matching the "non-fatal, tools absent" contract every other injector in
+/// this module already has) rather than risk an un-excluded secret file. On
+/// success, reads any existing `<project_path>/.env.local` (missing file →
+/// empty), merges in `secrets` via [`merge_env_file`], and skips the write
+/// entirely when the merge is a byte-for-byte no-op (idempotency).
+/// Test: `inject_native_delivers_secrets_via_env_local`,
+/// `inject_native_env_local_is_git_excluded_and_unstaged`,
+/// `inject_native_env_local_routing_is_idempotent`,
+/// `inject_native_secrets_skipped_outside_git_repo`.
+fn route_native_mcp_secrets(
+    project_path: &Path,
+    secrets: &BTreeMap<String, String>,
+) -> Result<(), PrepError> {
+    if let Err(err) = ensure_env_local_git_excluded(project_path) {
+        tracing::warn!(
+            "skipping native trusty MCP secret delivery: could not confirm `{}` is \
+             git-excluded in {} ({err}) — those servers will launch without credentials \
+             this session",
+            ENV_LOCAL_FILENAME,
+            project_path.display()
+        );
+        return Ok(());
+    }
+
+    let env_local_path = project_path.join(ENV_LOCAL_FILENAME);
+    let existing = std::fs::read_to_string(&env_local_path).unwrap_or_default();
+    let merged = merge_env_file(&existing, secrets);
+    if merged == existing {
+        return Ok(());
+    }
+    std::fs::write(&env_local_path, merged).map_err(|source| PrepError::Io {
+        path: env_local_path,
+        source,
+    })
+}
+
+/// Ensure `.env.local` is listed in the workspace's real `info/exclude` file.
+///
+/// Why: `.gitignore`/a tracked ignore file cannot protect a NEW file any
+/// differently than `.git/info/exclude` can, but unlike a tracked `.gitignore`
+/// change, appending to `info/exclude` is itself never committed — it is git's
+/// own mechanism for a local, per-checkout ignore rule. Resolving the real path
+/// via `git rev-parse --git-path info/exclude` (rather than assuming
+/// `<project_path>/.git/info/exclude`) is required because a linked git
+/// worktree's `.git` is a FILE (a gitlink), and `info/exclude` lives in the
+/// SHARED common git dir — this mirrors
+/// `daemon::managed_routes::inproject::untracked_sync::append_to_git_exclude`,
+/// which solves the identical problem for a different call site (see the
+/// module docs for why that helper isn't called directly).
+/// What: runs `git -C <project_path> rev-parse --git-path info/exclude`;
+/// resolves a relative result against `project_path` (an absolute result, the
+/// linked-worktree case, is used as-is); creates the exclude file's parent dir;
+/// and appends a `.env.local` line only when not already present (idempotent).
+/// Returns `Err` (a descriptive string, never a panic) on any failure —
+/// `project_path` is not a git repo, `git` is not on `PATH`, or the exclude
+/// file could not be created/written. The caller treats `Err` as "skip secret
+/// delivery entirely", never as license to write the secret file unexcluded.
+/// Test: `inject_native_env_local_is_git_excluded_and_unstaged`,
+/// `inject_native_secrets_skipped_outside_git_repo`,
+/// `ensure_env_local_git_excluded_is_idempotent`,
+/// `ensure_env_local_git_excluded_fails_outside_git_repo`.
+pub(super) fn ensure_env_local_git_excluded(project_path: &Path) -> Result<(), String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .args(["rev-parse", "--git-path", "info/exclude"])
+        .output()
+        .map_err(|e| format!("git rev-parse failed to spawn: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "git rev-parse --git-path info/exclude failed ({}): {stderr}",
+            output.status
+        ));
+    }
+
+    let raw_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw_path.is_empty() {
+        return Err("git rev-parse returned an empty path".to_string());
+    }
+    let exclude_path = {
+        let p = PathBuf::from(&raw_path);
+        if p.is_absolute() {
+            p
+        } else {
+            project_path.join(p)
+        }
+    };
+
+    if let Some(parent) = exclude_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("could not create {}: {e}", parent.display()))?;
+    }
+
+    let existing = std::fs::read_to_string(&exclude_path).unwrap_or_default();
+    if existing
+        .lines()
+        .any(|line| line.trim() == ENV_LOCAL_FILENAME)
+    {
+        return Ok(());
+    }
+
+    let entry = if existing.is_empty() || existing.ends_with('\n') {
+        format!("{ENV_LOCAL_FILENAME}\n")
+    } else {
+        format!("\n{ENV_LOCAL_FILENAME}\n")
+    };
+
+    use std::io::Write as _;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&exclude_path)
+        .map_err(|e| format!("could not open {}: {e}", exclude_path.display()))?;
+    file.write_all(entry.as_bytes())
+        .map_err(|e| format!("could not write {}: {e}", exclude_path.display()))
+}
+
+/// Merge `updates` into an existing `.env.local`'s textual content, preserving
+/// every other line untouched.
+///
+/// Why: `.env.local` may already carry the operator's own values (hand-edited,
+/// or copied in by
+/// `daemon::managed_routes::inproject::untracked_sync::sync_untracked_files`
+/// for in-project spawns) — a blind overwrite would destroy them. Per-key
+/// replacement keeps this additive and idempotent: re-running with the same
+/// `updates` against already-merged content reproduces the identical string, so
+/// the caller's byte-equality check can skip the write.
+/// What: walks `existing` line by line; a non-comment `KEY=...` line whose
+/// `KEY` is in `updates` is replaced with a freshly quoted `KEY="value"` line
+/// (quoting guards against a value containing `#`/whitespace/`=` being
+/// misparsed); every other line (including comments and unrelated keys) passes
+/// through verbatim. Any `updates` key not found in `existing` is appended at
+/// the end. Embedded `\n`/`\r` in a value are stripped (a token is always
+/// single-line; keeping them out prevents a malformed value from injecting an
+/// extra line) and `\`/`"` are backslash-escaped. Returns a string always
+/// ending in a single trailing newline when non-empty.
+/// Test: `merge_env_file_adds_new_keys`, `merge_env_file_replaces_existing_key`,
+/// `merge_env_file_preserves_unrelated_lines`,
+/// `merge_env_file_is_idempotent_when_unchanged`.
+pub(super) fn merge_env_file(existing: &str, updates: &BTreeMap<String, String>) -> String {
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut lines: Vec<String> = Vec::new();
+
+    for line in existing.lines() {
+        let is_comment = line.trim_start().starts_with('#');
+        if !is_comment
+            && let Some((key, _)) = line.split_once('=')
+            && let Some(new_val) = updates.get(key.trim())
+        {
+            let key = key.trim();
+            lines.push(format!("{key}={}", quote_env_value(new_val)));
+            seen.insert(key);
+            continue;
+        }
+        lines.push(line.to_string());
+    }
+
+    for (key, val) in updates {
+        if !seen.contains(key.as_str()) {
+            lines.push(format!("{key}={}", quote_env_value(val)));
+        }
+    }
+
+    let mut out = lines.join("\n");
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
+/// Render a single `.env.local` value as a double-quoted, escaped literal.
+///
+/// Why: shared by every [`merge_env_file`] write path so quoting rules never
+/// drift between the "replace" and "append" branches.
+/// What: strips embedded `\n`/`\r`, backslash-escapes `\` and `"`, and wraps the
+/// result in `"…"`.
+/// Test: covered via `merge_env_file_*` (no separate unit test — this is a
+/// private one-line formatting helper with no independent branch logic).
+fn quote_env_value(value: &str) -> String {
+    let sanitized: String = value.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+    let escaped = sanitized.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}

--- a/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
@@ -1,0 +1,597 @@
+//! Unit tests for the native trusty MCP fleet injector (issue #2739) and its
+//! secret-routing fix (code-critic BLOCK follow-up).
+//!
+//! Why: split out of the injector module (`native_mcp.rs`, a 500-SLOC-capped
+//! production file) so the coverage can grow under the 1500-SLOC test cap,
+//! mirroring the `tests_roster.rs` split.
+//! What: drives the hermetic [`super::native_mcp::inject_native_trusty_mcps_from`]
+//! core against a tempdir `CLAUDE_CONFIG_DIR` + a REAL git-initialised
+//! workspace (secret routing needs an actual `.git` for `git rev-parse
+//! --git-path info/exclude` to resolve), plus the trust preseed and the
+//! smaller private helpers exposed `pub(super)` for direct unit coverage. The
+//! headline regression coverage (mandated by the code-critic BLOCK) proves NO
+//! raw token value ever lands in `.mcp.json`, that `.env.local` carries the
+//! real values, and that `.env.local` is genuinely git-excluded — including a
+//! literal `git add -A` + status check reproducing the exact leak scenario the
+//! review described.
+//! Test: this file IS the test module.
+
+use super::native_mcp::{
+    NATIVE_TRUSTY_MCP_SERVERS, ensure_env_local_git_excluded, inject_native_trusty_mcps_from,
+    merge_env_file, split_public_and_secret_env,
+};
+use super::settings::preseed_workspace_trust;
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::path::Path;
+use tempfile::tempdir;
+
+/// Token value used by every fixture below — chosen to be unmistakably a raw
+/// secret in a grep/contains assertion.
+const FAKE_SLACK_TOKEN: &str = "xoxb-verbatim-secret-DO-NOT-COMMIT";
+
+/// `git init -q` a workspace directory so the secret-routing git-exclude path
+/// actually executes (it no-ops on a non-repo).
+///
+/// Why: every test that exercises [`super::native_mcp::route_native_mcp_secrets`]
+/// (indirectly, via `inject_native_trusty_mcps_from`) needs a real `.git` for
+/// `git rev-parse --git-path info/exclude` to resolve — a plain tempdir is not
+/// a repo, so that step would silently skip (tested separately, see
+/// `inject_native_secrets_skipped_outside_git_repo`).
+/// What: runs `git init -q` in `dir`, with a pinned local git identity so this
+/// never depends on the host's global git config.
+/// Test: used by every git-backed test below.
+fn git_init(dir: &Path) {
+    let status = std::process::Command::new("git")
+        .arg("init")
+        .arg("-q")
+        .arg(dir)
+        .status()
+        .expect("git must be on PATH to run this test");
+    assert!(status.success(), "git init failed");
+}
+
+/// Write a managed `.claude.json` with a MIX of native + non-native +
+/// already-injected servers into `config_dir` and return the two temp roots.
+///
+/// Why: every injector test needs the same realistic managed registry — the
+/// mixed shape is the point of the issue's mandated coverage (only natives get
+/// through, and their secrets never land in `.mcp.json`). Centralising it keeps
+/// each test focused on one assertion.
+/// What: creates `<config_dir>/.claude.json` with `slack-mcp` (native, has
+/// secret env), `gworkspace-mcp` (native, no env), `github` (non-native
+/// stdio), a Duetto HTTP endpoint (non-native http), and `trusty-memory`
+/// (dedicated-injector, must be ignored here). Returns nothing beyond the side
+/// effect (the caller owns the dirs).
+/// Test: used by every `inject_native_*` test below.
+fn seed_managed_registry(config_dir: &std::path::Path) {
+    std::fs::create_dir_all(config_dir).unwrap();
+    let registry = json!({
+        "oauthAccount": { "keep": "me" },
+        "mcpServers": {
+            "slack-mcp": {
+                "type": "stdio",
+                "command": "slack-mcp",
+                "args": ["serve"],
+                "env": { "SLACK_BOT_TOKEN": FAKE_SLACK_TOKEN }
+            },
+            "gworkspace-mcp": {
+                "type": "stdio",
+                "command": "gworkspace-mcp",
+                "args": []
+            },
+            "github": {
+                "type": "stdio",
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-github"]
+            },
+            "duetto-endpoint": {
+                "type": "http",
+                "url": "https://duetto.example/mcp"
+            },
+            "trusty-memory": {
+                "type": "stdio",
+                "command": "trusty-memory",
+                "args": ["serve", "--stdio"]
+            }
+        }
+    });
+    std::fs::write(
+        config_dir.join(".claude.json"),
+        serde_json::to_string_pretty(&registry).unwrap(),
+    )
+    .unwrap();
+}
+
+/// Read the workspace `.mcp.json` `mcpServers` object.
+///
+/// Why: shared assertion helper for the post-injection state.
+/// What: parses `<workspace>/.mcp.json` and returns its `mcpServers` map; panics
+/// (test-only) if the file or key is missing.
+/// Test: used by every `inject_native_*` test below.
+fn read_injected(workspace: &std::path::Path) -> serde_json::Map<String, Value> {
+    let text = std::fs::read_to_string(workspace.join(".mcp.json")).unwrap();
+    let value: Value = serde_json::from_str(&text).unwrap();
+    value["mcpServers"].as_object().cloned().unwrap()
+}
+
+#[test]
+fn inject_native_only_injects_allowlisted() {
+    // Why (#2739): the injector must bridge ONLY native trusty servers from the
+    // managed registry into the workspace — not the whole registry.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    seed_managed_registry(cfg.path());
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection succeeds");
+
+    let servers = read_injected(ws.path());
+    assert!(servers.contains_key("slack-mcp"), "native slack injected");
+    assert!(
+        servers.contains_key("gworkspace-mcp"),
+        "native gworkspace injected"
+    );
+    // trusty-analyze and telegram-mcp are allowlisted but absent from the
+    // registry → not injected (only the intersection lands).
+    assert!(!servers.contains_key("trusty-analyze"));
+    assert!(!servers.contains_key("telegram-mcp"));
+}
+
+#[test]
+fn inject_native_skips_non_native() {
+    // Why (#2739, owner decision): third-party/HTTP managed servers must NEVER be
+    // propagated to fleet sessions, and the dedicated-injector servers must be
+    // left for their own injectors.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    seed_managed_registry(cfg.path());
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection succeeds");
+
+    let servers = read_injected(ws.path());
+    assert!(
+        !servers.contains_key("github"),
+        "non-native github excluded"
+    );
+    assert!(
+        !servers.contains_key("duetto-endpoint"),
+        "non-native HTTP endpoint excluded"
+    );
+    assert!(
+        !servers.contains_key("trusty-memory"),
+        "trusty-memory owned by its dedicated injector, not this one"
+    );
+    // Exactly the two present natives, nothing else.
+    assert_eq!(servers.len(), 2, "only the two present natives injected");
+}
+
+#[test]
+fn inject_native_strips_secret_env_from_mcp_json() {
+    // Why (code-critic BLOCK, #2739): `.mcp.json` is git-TRACKED — a raw token
+    // written there is one `git add -A && commit && push` away from leaking
+    // into remote history. The injector must NEVER write a native server's
+    // `env` block into `.mcp.json`, regardless of whether the workspace is a
+    // git repo (this assertion holds even with no `git init`, proving the
+    // guarantee doesn't depend on the git-exclude step succeeding).
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    seed_managed_registry(cfg.path());
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection succeeds");
+
+    let raw = std::fs::read_to_string(ws.path().join(".mcp.json")).unwrap();
+    assert!(
+        !raw.contains(FAKE_SLACK_TOKEN),
+        ".mcp.json must never contain the raw token value: {raw}"
+    );
+    assert!(
+        !raw.contains("SLACK_BOT_TOKEN"),
+        ".mcp.json must not even name the secret env key: {raw}"
+    );
+
+    let servers = read_injected(ws.path());
+    let slack = &servers["slack-mcp"];
+    assert!(
+        slack.get("env").is_none(),
+        "slack-mcp entry must carry no env block at all in .mcp.json"
+    );
+    assert_eq!(slack["command"], json!("slack-mcp"));
+    assert_eq!(slack["args"], json!(["serve"]));
+}
+
+#[test]
+fn inject_native_no_env_key_when_source_has_none() {
+    // Why: a native server with no `env` in the managed registry (gworkspace-mcp
+    // in the fixture) must round-trip with no `env` key at all — not an empty
+    // `{}` — matching the pre-existing `.mcp.json` shape.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    seed_managed_registry(cfg.path());
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection succeeds");
+
+    let servers = read_injected(ws.path());
+    assert!(servers["gworkspace-mcp"].get("env").is_none());
+}
+
+#[test]
+fn inject_native_delivers_secrets_via_env_local() {
+    // Why (code-critic BLOCK, #2739): the token must still reach the native
+    // server somehow — this proves the OTHER half of the fix: the real value
+    // lands in the workspace-root `.env.local`, which
+    // `trusty_common::inference::credentials::resolve_key` reads via its
+    // env → .env.local → store precedence.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    git_init(ws.path());
+    seed_managed_registry(cfg.path());
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection succeeds");
+
+    let env_local = std::fs::read_to_string(ws.path().join(".env.local"))
+        .expect(".env.local must be written when a native server carries secret env");
+    assert!(
+        env_local.contains("SLACK_BOT_TOKEN"),
+        ".env.local must name the key: {env_local}"
+    );
+    assert!(
+        env_local.contains(FAKE_SLACK_TOKEN),
+        ".env.local must carry the real value: {env_local}"
+    );
+
+    // And still never in .mcp.json.
+    let mcp_json = std::fs::read_to_string(ws.path().join(".mcp.json")).unwrap();
+    assert!(!mcp_json.contains(FAKE_SLACK_TOKEN));
+}
+
+#[test]
+fn inject_native_env_local_is_git_excluded_and_unstaged() {
+    // Why (code-critic BLOCK, #2739): the literal leak scenario the review
+    // described — a fleet agent running `git add -A && commit && push`. This
+    // test reproduces exactly that sequence against the real `.env.local` the
+    // injector wrote and proves the token can never be staged, let alone
+    // committed.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    git_init(ws.path());
+    seed_managed_registry(cfg.path());
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection succeeds");
+
+    // `git check-ignore` is git's own authority on whether a path is excluded.
+    let check_ignore = std::process::Command::new("git")
+        .arg("-C")
+        .arg(ws.path())
+        .args(["check-ignore", "-q", ".env.local"])
+        .status()
+        .expect("git check-ignore must run");
+    assert!(
+        check_ignore.success(),
+        ".env.local must be recognised as git-excluded"
+    );
+
+    // The literal reproduction: stage everything, then prove .env.local never
+    // made it into the index.
+    let add = std::process::Command::new("git")
+        .arg("-C")
+        .arg(ws.path())
+        .args(["add", "-A"])
+        .status()
+        .expect("git add must run");
+    assert!(add.success());
+
+    let staged = std::process::Command::new("git")
+        .arg("-C")
+        .arg(ws.path())
+        .args(["diff", "--cached", "--name-only"])
+        .output()
+        .expect("git diff --cached must run");
+    let staged_files = String::from_utf8_lossy(&staged.stdout);
+    assert!(
+        !staged_files.contains(".env.local"),
+        "`git add -A` must never stage .env.local: staged files were: {staged_files}"
+    );
+
+    // .mcp.json, by contrast, IS staged (it's the whole point of the feature —
+    // native servers' non-secret shape is meant to be committed).
+    assert!(
+        staged_files.contains(".mcp.json"),
+        "sanity: .mcp.json should still be a normal staged file"
+    );
+}
+
+#[test]
+fn inject_native_env_local_routing_is_idempotent() {
+    // Why (#2739): prep runs on every spawn; a second run against an unchanged
+    // registry must leave BOTH `.mcp.json` and `.env.local` byte-identical.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    git_init(ws.path());
+    seed_managed_registry(cfg.path());
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("first injection");
+    let mcp_json_1 = std::fs::read_to_string(ws.path().join(".mcp.json")).unwrap();
+    let env_local_1 = std::fs::read_to_string(ws.path().join(".env.local")).unwrap();
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("second injection");
+    let mcp_json_2 = std::fs::read_to_string(ws.path().join(".mcp.json")).unwrap();
+    let env_local_2 = std::fs::read_to_string(ws.path().join(".env.local")).unwrap();
+
+    assert_eq!(mcp_json_1, mcp_json_2, ".mcp.json is a no-op on rerun");
+    assert_eq!(env_local_1, env_local_2, ".env.local is a no-op on rerun");
+}
+
+#[test]
+fn inject_native_secrets_skipped_outside_git_repo() {
+    // Why (#2739): when the workspace is NOT a git repo, the injector must not
+    // write `.env.local` at all (there is no exclusion guarantee it could
+    // confirm) — it degrades to "native servers launch without credentials"
+    // rather than ever risking an un-excluded secret file. `.mcp.json` still
+    // gets written normally.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    // Deliberately no git_init(ws.path()).
+    seed_managed_registry(cfg.path());
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection still succeeds");
+
+    assert!(
+        !ws.path().join(".env.local").exists(),
+        ".env.local must not be created when git-exclusion cannot be confirmed"
+    );
+    assert!(
+        ws.path().join(".mcp.json").exists(),
+        ".mcp.json injection must still proceed independently"
+    );
+}
+
+#[test]
+fn inject_native_no_secrets_writes_no_env_local() {
+    // Why (#2739): a native server with no secret env (only gworkspace-mcp
+    // present) must never create a `.env.local` at all — nothing to route.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    git_init(ws.path());
+    std::fs::create_dir_all(cfg.path()).unwrap();
+    std::fs::write(
+        cfg.path().join(".claude.json"),
+        serde_json::to_string_pretty(&json!({
+            "mcpServers": {
+                "gworkspace-mcp": { "type": "stdio", "command": "gworkspace-mcp", "args": [] }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection succeeds");
+
+    assert!(
+        !ws.path().join(".env.local").exists(),
+        "no secrets collected → no .env.local written"
+    );
+    assert!(read_injected(ws.path()).contains_key("gworkspace-mcp"));
+}
+
+#[test]
+fn inject_native_preserves_existing_injectors() {
+    // Why (#2739): the native injector runs alongside the memory/search
+    // injectors; it must merge into (never clobber) an existing `.mcp.json`.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    seed_managed_registry(cfg.path());
+    // Pretend the memory/search injectors already ran.
+    std::fs::write(
+        ws.path().join(".mcp.json"),
+        r#"{"mcpServers":{"trusty-memory":{"command":"trusty-memory"},"trusty-search":{"command":"trusty-search"}}}"#,
+    )
+    .unwrap();
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection succeeds");
+
+    let servers = read_injected(ws.path());
+    assert!(servers.contains_key("trusty-memory"), "memory survives");
+    assert!(servers.contains_key("trusty-search"), "search survives");
+    assert!(servers.contains_key("slack-mcp"), "native added");
+}
+
+#[test]
+fn inject_native_trust_preseed_covers_injected() {
+    // Why (#2739 + #1296): the injected native names must flow into the workspace
+    // trust preseed's `enabledMcpjsonServers` so Claude Code does not block the
+    // fleet session on the "new MCP servers found" dialog. This mirrors the real
+    // ordering in `prepare_session`: inject first, THEN preseed trust.
+    let cfg = tempdir().unwrap();
+    let ws_root = tempdir().unwrap();
+    let workspace = ws_root.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let claude_json = ws_root.path().join(".claude.json");
+    seed_managed_registry(cfg.path());
+
+    inject_native_trusty_mcps_from(&workspace, cfg.path()).expect("injection succeeds");
+    preseed_workspace_trust(&claude_json, &workspace).expect("trust preseed succeeds");
+
+    let value: Value =
+        serde_json::from_str(&std::fs::read_to_string(&claude_json).unwrap()).unwrap();
+    let key = workspace.to_string_lossy().to_string();
+    let enabled: Vec<&str> = value["projects"][&key]["enabledMcpjsonServers"]
+        .as_array()
+        .expect("enabledMcpjsonServers is an array")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        enabled.contains(&"slack-mcp"),
+        "injected native flows into trust preseed"
+    );
+    assert!(enabled.contains(&"gworkspace-mcp"));
+    assert!(
+        !enabled.contains(&"github"),
+        "non-native never reaches the workspace, so never trusted here"
+    );
+}
+
+#[test]
+fn inject_native_absent_config_is_noop() {
+    // Why (#2739): a config dir with no `.claude.json` (fresh install, no
+    // `tm mcp add` yet) must not error and must not create a workspace `.mcp.json`.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    // Note: no seed — the managed dir has no `.claude.json`.
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("no-op succeeds");
+
+    assert!(
+        !ws.path().join(".mcp.json").exists(),
+        "nothing to inject → no workspace .mcp.json written"
+    );
+}
+
+#[test]
+fn native_allowlist_excludes_dedicated_injector_servers() {
+    // Why (#2739): trusty-memory / trusty-search have dedicated pinning injectors
+    // and MUST NOT appear in this allowlist, or this injector would clobber their
+    // palace/index pinning.
+    assert!(!NATIVE_TRUSTY_MCP_SERVERS.contains(&"trusty-memory"));
+    assert!(!NATIVE_TRUSTY_MCP_SERVERS.contains(&"trusty-search"));
+    assert!(NATIVE_TRUSTY_MCP_SERVERS.contains(&"slack-mcp"));
+    assert!(NATIVE_TRUSTY_MCP_SERVERS.contains(&"trusty-analyze"));
+}
+
+// ── split_public_and_secret_env: direct unit coverage ──────────────────────
+
+#[test]
+fn split_public_and_secret_env_separates_env_from_shape() {
+    let entry = json!({
+        "type": "stdio",
+        "command": "slack-mcp",
+        "args": ["serve"],
+        "env": { "SLACK_BOT_TOKEN": FAKE_SLACK_TOKEN, "SLACK_USER_TOKEN": "xoxp-also-secret" }
+    });
+
+    let (public, secrets) = split_public_and_secret_env(&entry, "slack-mcp");
+
+    assert!(
+        public.get("env").is_none(),
+        "env stripped from public shape"
+    );
+    assert_eq!(public["command"], json!("slack-mcp"));
+    assert_eq!(public["args"], json!(["serve"]));
+    assert_eq!(
+        secrets.get("SLACK_BOT_TOKEN").map(String::as_str),
+        Some(FAKE_SLACK_TOKEN)
+    );
+    assert_eq!(
+        secrets.get("SLACK_USER_TOKEN").map(String::as_str),
+        Some("xoxp-also-secret")
+    );
+}
+
+#[test]
+fn split_public_and_secret_env_skips_non_string_values() {
+    // Why: the `env` schema is always Record<string,string>; a malformed
+    // registry entry with a non-string value must never be silently coerced
+    // into either output — it is dropped (with a warning) on both sides.
+    let entry = json!({
+        "type": "stdio",
+        "command": "weird-mcp",
+        "args": [],
+        "env": { "GOOD": "value", "BAD": 42 }
+    });
+
+    let (public, secrets) = split_public_and_secret_env(&entry, "weird-mcp");
+
+    assert!(public.get("env").is_none());
+    assert_eq!(secrets.get("GOOD").map(String::as_str), Some("value"));
+    assert!(!secrets.contains_key("BAD"), "non-string value dropped");
+}
+
+// ── ensure_env_local_git_excluded: direct unit coverage ─────────────────────
+
+#[test]
+fn ensure_env_local_git_excluded_is_idempotent() {
+    let ws = tempdir().unwrap();
+    git_init(ws.path());
+
+    ensure_env_local_git_excluded(ws.path()).expect("first call succeeds");
+    let exclude_path_1 = std::process::Command::new("git")
+        .arg("-C")
+        .arg(ws.path())
+        .args(["rev-parse", "--git-path", "info/exclude"])
+        .output()
+        .unwrap();
+    let path_1 = String::from_utf8_lossy(&exclude_path_1.stdout)
+        .trim()
+        .to_string();
+    let content_1 = std::fs::read_to_string(ws.path().join(&path_1)).unwrap();
+
+    ensure_env_local_git_excluded(ws.path()).expect("second call succeeds");
+    let content_2 = std::fs::read_to_string(ws.path().join(&path_1)).unwrap();
+
+    assert_eq!(content_1, content_2, "second call is a no-op");
+    assert_eq!(
+        content_1
+            .lines()
+            .filter(|l| l.trim() == ".env.local")
+            .count(),
+        1,
+        ".env.local listed exactly once, not duplicated"
+    );
+}
+
+#[test]
+fn ensure_env_local_git_excluded_fails_outside_git_repo() {
+    let ws = tempdir().unwrap();
+    // No git_init: this must fail, not panic.
+    let result = ensure_env_local_git_excluded(ws.path());
+    assert!(result.is_err(), "a non-repo directory must return Err");
+}
+
+// ── merge_env_file: direct unit coverage ────────────────────────────────────
+
+#[test]
+fn merge_env_file_adds_new_keys() {
+    let mut updates = BTreeMap::new();
+    updates.insert("SLACK_BOT_TOKEN".to_string(), FAKE_SLACK_TOKEN.to_string());
+
+    let merged = merge_env_file("", &updates);
+
+    assert_eq!(merged, format!("SLACK_BOT_TOKEN=\"{FAKE_SLACK_TOKEN}\"\n"));
+}
+
+#[test]
+fn merge_env_file_replaces_existing_key() {
+    let mut updates = BTreeMap::new();
+    updates.insert("SLACK_BOT_TOKEN".to_string(), "new-value".to_string());
+
+    let merged = merge_env_file("SLACK_BOT_TOKEN=\"old-value\"\n", &updates);
+
+    assert_eq!(merged, "SLACK_BOT_TOKEN=\"new-value\"\n");
+}
+
+#[test]
+fn merge_env_file_preserves_unrelated_lines() {
+    let mut updates = BTreeMap::new();
+    updates.insert("SLACK_BOT_TOKEN".to_string(), FAKE_SLACK_TOKEN.to_string());
+
+    let existing = "# operator's own comment\nOPENAI_API_KEY=\"sk-operator-owns-this\"\n";
+    let merged = merge_env_file(existing, &updates);
+
+    assert!(merged.contains("# operator's own comment"));
+    assert!(merged.contains("OPENAI_API_KEY=\"sk-operator-owns-this\""));
+    assert!(merged.contains(&format!("SLACK_BOT_TOKEN=\"{FAKE_SLACK_TOKEN}\"")));
+}
+
+#[test]
+fn merge_env_file_is_idempotent_when_unchanged() {
+    let mut updates = BTreeMap::new();
+    updates.insert("SLACK_BOT_TOKEN".to_string(), FAKE_SLACK_TOKEN.to_string());
+
+    let first = merge_env_file("", &updates);
+    let second = merge_env_file(&first, &updates);
+
+    assert_eq!(
+        first, second,
+        "re-merging already-merged content is a no-op"
+    );
+}

--- a/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
@@ -18,7 +18,7 @@
 
 use super::native_mcp::{
     NATIVE_TRUSTY_MCP_SERVERS, ensure_env_local_git_excluded, inject_native_trusty_mcps_from,
-    merge_env_file, split_public_and_secret_env,
+    is_env_local_actually_ignored, merge_env_file, split_public_and_secret_env,
 };
 use super::settings::preseed_workspace_trust;
 use serde_json::{Value, json};
@@ -343,6 +343,130 @@ fn inject_native_secrets_skipped_outside_git_repo() {
         ws.path().join(".mcp.json").exists(),
         ".mcp.json injection must still proceed independently"
     );
+}
+
+/// `git add -f <path> && git commit` a file, so it becomes genuinely TRACKED.
+///
+/// Why: the residual-HIGH regression fixture needs a `.env.local` that git
+/// considers tracked, not merely present on disk — `info/exclude` is a no-op
+/// for a tracked path, which is exactly the gap this test proves is now
+/// closed. `-f` is required here (empirically verified against real git,
+/// version 2.54): a PLAIN `git add` on a path already matching an
+/// `info/exclude` pattern refuses with "paths are ignored ... Use -f if you
+/// really want to add them" and adds nothing — some call sites in this file
+/// add the exclude entry BEFORE constructing the tracked fixture, so this
+/// helper must force past that regardless of ordering.
+/// What: force-stages and commits `path` (relative to `dir`) with a pinned
+/// local identity, matching [`git_init`]'s isolation.
+/// Test: used by `inject_native_skips_secrets_when_env_local_is_tracked`,
+/// `is_env_local_actually_ignored_false_when_tracked`.
+fn git_commit_file(dir: &Path, path: &str) {
+    let run = |args: &[&str]| {
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "trusty-tools-test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.invalid")
+            .env("GIT_COMMITTER_NAME", "trusty-tools-test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.invalid")
+            .status()
+            .expect("git must be on PATH to run this test");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    run(&["add", "-f", path]);
+    run(&["commit", "-q", "-m", "seed a tracked file"]);
+}
+
+#[test]
+fn inject_native_skips_secrets_when_env_local_is_tracked() {
+    // Why (code-critic re-review, residual HIGH on #2739): `info/exclude`
+    // cannot un-track an already-tracked file. If the TARGET repo (tm ships to
+    // arbitrary repos, including Duetto ones) already commits a file literally
+    // named `.env.local`, `ensure_env_local_git_excluded` still "succeeds" (the
+    // append itself never errors), so without the `git check-ignore` gate the
+    // injector would merge the real token into that tracked file and a routine
+    // `git add -A` would stage it — the exact same leak class, relocated. This
+    // reproduces that scenario end-to-end and asserts secret delivery is
+    // correctly SKIPPED.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    git_init(ws.path());
+    let pre_existing_content = "PRE_EXISTING=\"operator committed this\"\n";
+    std::fs::write(ws.path().join(".env.local"), pre_existing_content).unwrap();
+    git_commit_file(ws.path(), ".env.local");
+    seed_managed_registry(cfg.path());
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection still succeeds");
+
+    // (a) The tracked file's committed content is unchanged — no token was
+    // merged into it.
+    let content_after = std::fs::read_to_string(ws.path().join(".env.local")).unwrap();
+    assert_eq!(
+        content_after, pre_existing_content,
+        ".env.local content must be untouched when it is tracked"
+    );
+    assert!(!content_after.contains(FAKE_SLACK_TOKEN));
+    assert!(!content_after.contains("SLACK_BOT_TOKEN"));
+
+    // (b) `git add -A` must not stage any token-bearing change — i.e. there is
+    // no diff to stage at all, since the file was never written to.
+    let add = std::process::Command::new("git")
+        .arg("-C")
+        .arg(ws.path())
+        .args(["add", "-A"])
+        .status()
+        .expect("git add must run");
+    assert!(add.success());
+    let staged = std::process::Command::new("git")
+        .arg("-C")
+        .arg(ws.path())
+        .args(["diff", "--cached", "--name-only"])
+        .output()
+        .expect("git diff --cached must run");
+    let staged_files = String::from_utf8_lossy(&staged.stdout);
+    assert!(
+        !staged_files.contains(".env.local"),
+        ".env.local must have no pending changes to stage: {staged_files}"
+    );
+
+    // Sanity: `.mcp.json` injection still proceeded (only secret delivery was
+    // skipped), and still carries no raw token either.
+    let mcp_json = std::fs::read_to_string(ws.path().join(".mcp.json")).unwrap();
+    assert!(!mcp_json.contains(FAKE_SLACK_TOKEN));
+}
+
+#[test]
+fn is_env_local_actually_ignored_true_when_excluded() {
+    let ws = tempdir().unwrap();
+    git_init(ws.path());
+    ensure_env_local_git_excluded(ws.path()).expect("exclude write succeeds");
+
+    assert!(is_env_local_actually_ignored(ws.path()));
+}
+
+#[test]
+fn is_env_local_actually_ignored_false_when_tracked() {
+    let ws = tempdir().unwrap();
+    git_init(ws.path());
+    // Excluded via info/exclude AND tracked at the same time — git's own
+    // ls-files/staging behaviour wins: a tracked path is never "ignored" in
+    // the sense that matters (it will still be staged by `git add -A`).
+    ensure_env_local_git_excluded(ws.path()).expect("exclude write succeeds");
+    std::fs::write(ws.path().join(".env.local"), "X=1\n").unwrap();
+    git_commit_file(ws.path(), ".env.local");
+
+    assert!(!is_env_local_actually_ignored(ws.path()));
+}
+
+#[test]
+fn is_env_local_actually_ignored_false_when_not_excluded_at_all() {
+    let ws = tempdir().unwrap();
+    git_init(ws.path());
+    // No ensure_env_local_git_excluded call — nothing lists .env.local in
+    // info/exclude, and it isn't tracked either.
+
+    assert!(!is_env_local_actually_ignored(ws.path()));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`tm mcp add` writes user-scope MCP servers into the tm-owned
`CLAUDE_CONFIG_DIR/.claude.json` `mcpServers` map and claims they are "available
in all your projects." That is TRUE for the standalone `tm run` driver but FALSE
for daemon-managed fleet sessions (`tm session new`): those launch
`claude --setting-sources project,local`, which excludes the `user` tier where
that map lives. The workspace `.mcp.json` is regenerated on every spawn by
`prepare_session` via two hardcoded injectors (`trusty-memory`, `trusty-search`)
and nothing bridged the `tm mcp` registry into the project layer — so servers
like `slack-mcp` / `gworkspace-mcp` were invisible to fleet sessions.

## Fix

**New injector** — `session_launch::native_mcp::inject_native_trusty_mcps`,
called from `prepare_session` alongside the memory/search injectors:

- Reads the managed registry via the SAME `core::mcp_config` reader `tm mcp`
  uses (`list_servers`) — no re-implemented config-dir discovery. The managed
  dir resolves home-relative from `FrameworkPaths` (exactly as `tm mcp`'s
  `managed_claude_config_dir` does, and hermetic under test isolation), NOT the
  ambient `CLAUDE_CONFIG_DIR` env.
- **Scope = native trusty servers ONLY** via an explicit, documented,
  easily-extensible allowlist:
  `NATIVE_TRUSTY_MCP_SERVERS = ["slack-mcp", "telegram-mcp", "gworkspace-mcp", "trusty-analyze"]`
  (defined in `native_mcp.rs`). The injected set = managed registry ∩ allowlist,
  so the operator still controls presence via `tm mcp add`. Third-party/HTTP
  managed servers (github, Duetto endpoints, chrome-devtools, …) are NOT
  injected. `trusty-memory` / `trusty-search` are excluded — their dedicated
  palace/index-pinning injectors own those entries.

**Secrets are never written into `.mcp.json` (code-critic BLOCK fix)** —
`.mcp.json` is git-TRACKED in every real project, so a native server's `env`
block (`SLACK_BOT_TOKEN`, `SLACK_USER_TOKEN`, `TELEGRAM_BOT_TOKEN`, …) is never
written there; a fleet agent's routine `git add -A && commit && push` would
otherwise leak a live token into remote history.

- `split_public_and_secret_env` strips the ENTIRE `env` block from the
  `.mcp.json` entry — categorically, not by a key-name heuristic, so there is no
  false-negative leak path. Only `type`/`command`/`args` are written to
  `.mcp.json`.
- `route_native_mcp_secrets` delivers the real values via a workspace-root
  `.env.local`, merging additively (never clobbering an operator's own
  `.env.local` content) and skipping the write when nothing changed.
- **Verified this actually delivers a working credential**: `slack-mcp` and
  `telegram-mcp` call `trusty_common::inference::credentials::resolve_key`
  directly (`crates/trusty-channels/src/{slack,telegram}/api/client.rs`), whose
  env → `.env.local` → secure-store precedence loader
  (`credentials::dotenv::load_env_local_once` /
  `find_workspace_env_local`) searches upward from the spawned process's cwd and
  checks the starting directory itself before any repo-root boundary test — so
  an `.env.local` at the workspace root is found by an MCP server Claude Code
  spawns with that workspace as cwd (the same cwd-based premise
  `inject_trusty_memory_mcp`'s palace fallback already depends on).
- **Verified genuine git-exclusion**: before writing any secret content,
  `ensure_env_local_git_excluded` resolves the workspace's REAL
  `git rev-parse --git-path info/exclude` file (correct for linked worktrees,
  whose `.git` is a gitlink) and idempotently appends `.env.local` to it —
  mirroring the proven pattern in
  `daemon::managed_routes::inproject::untracked_sync::append_to_git_exclude`
  (that helper is daemon-private and unreachable from this `core`-layer module,
  so the technique is re-implemented rather than introducing a `core → daemon`
  dependency; flagged in the module docs as a future consolidation candidate).
  If exclusion can't be confirmed (not a git repo), secret delivery is skipped
  entirely — the native server just launches without credentials that session,
  rather than ever risking an unexcluded secret file.
- A regression test reproduces the exact leak scenario: `git add -A` then
  `git diff --cached --name-only` proves `.env.local` is never staged, while
  `.mcp.json` is (see `inject_native_env_local_is_git_excluded_and_unstaged`).

**Trust-seeding** — the injector runs BEFORE `preseed_workspace_trust_home`, so
the injected `.mcp.json` names (never the secrets) flow through
`mcp_server_names` into `enabledMcpjsonServers`. No "new MCP servers found"
dialog fires.

**Doc corrections** — `tm mcp get` scope print (`bin/tm/commands/mcp.rs`) and
`assets/skills/tm-cli-operations.md` now clarify that native trusty servers
reach all managed/fleet sessions while non-native managed servers apply to the
standalone `tm run` driver only.

## Tests (30 total: 21 injector tests + 9 pre-existing suite updates)

- `inject_native_only_injects_allowlisted`, `inject_native_skips_non_native` —
  allowlist filtering.
- `inject_native_strips_secret_env_from_mcp_json`,
  `inject_native_no_env_key_when_source_has_none` — NO raw token or secret key
  name ever appears in `.mcp.json`.
- `inject_native_delivers_secrets_via_env_local` — the real value lands in
  `.env.local`.
- `inject_native_env_local_is_git_excluded_and_unstaged` — the literal
  `git add -A` + `git diff --cached` leak reproduction.
- `inject_native_env_local_routing_is_idempotent`,
  `inject_native_secrets_skipped_outside_git_repo`,
  `inject_native_no_secrets_writes_no_env_local`,
  `inject_native_preserves_existing_injectors`,
  `inject_native_trust_preseed_covers_injected`,
  `inject_native_absent_config_is_noop` — idempotency, fail-safe, and
  trust-preseed coverage.
- Direct unit coverage for `split_public_and_secret_env`,
  `ensure_env_local_git_excluded`, and `merge_env_file`.

## Verification

- `cargo build --workspace` — OK
- `cargo test -p trusty-mpm` — 3163 passed; 0 failed (incl. 21 native_mcp tests)
- `cargo test --workspace` — 158 test-result blocks, all `ok`, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — OK
- `scripts/check_line_cap.sh` — 0 violations
- `scripts/check_test_pointers.sh` — 0 dangling pointers

Closes #2739

🤖 Generated with [Claude Code](https://claude.com/claude-code)