### PR TITLE
feat(trusty-gworkspace): structured in-session re-auth UX (#2742)

### DIFF
--- a/crates/trusty-gworkspace/README.md
+++ b/crates/trusty-gworkspace/README.md
@@ -5,9 +5,10 @@ Python [`gworkspace-mcp`](https://pypi.org/project/gworkspace-mcp/) project.
 
 Exposes 43 [Model Context Protocol](https://modelcontextprotocol.io/) tools
 across Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, and Accounts.
-Reads OAuth tokens from `~/.gworkspace-mcp/tokens.json`, so a user who
-already authenticated with the Python CLI can switch to this Rust binary
-without re-auth.
+Authentication is fully native: the `gworkspace-mcp` binary runs the OAuth
+consent flow itself and reads/writes `~/.gworkspace-mcp/tokens.json` — no
+external CLI is required. The token file is wire-compatible with the original
+Python `gworkspace-mcp`, so an existing token file is picked up unchanged.
 
 ## Installation
 
@@ -15,63 +16,155 @@ without re-auth.
 cargo install --path crates/trusty-gworkspace
 ```
 
-This installs the `gworkspace-mcp` binary into `~/.cargo/bin`.
+This installs the `gworkspace-mcp` binary into `~/.cargo/bin`. The same binary
+is both the MCP stdio server (run with no subcommand) and the onboarding CLI
+(`setup` / `doctor` / `accounts`).
 
-## Quick Start
+## Authentication
 
-1. **Authenticate** using the Python CLI (one-time):
+### 1. Provide an OAuth client
 
-   ```sh
-   pipx install gworkspace-mcp
-   gworkspace-mcp auth
-   ```
+`setup` needs a Google OAuth **client id + secret** (a "Desktop app" /
+installed-app client from the Google Cloud console). Supply them either via
+environment variables:
 
-   This writes `~/.gworkspace-mcp/tokens.json`. Token refresh is handled
-   automatically by `trusty-gworkspace` afterward (via `GOOGLE_CLIENT_ID` /
-   `GOOGLE_CLIENT_SECRET` env vars when refresh is needed).
+```sh
+export GOOGLE_OAUTH_CLIENT_ID="…apps.googleusercontent.com"
+export GOOGLE_OAUTH_CLIENT_SECRET="…"
+```
 
-2. **Wire into Claude Code** (or any MCP client):
-
-   ```jsonc
-   // ~/.claude.json
-   {
-     "mcpServers": {
-       "gworkspace": {
-         "command": "gworkspace-mcp"
-       }
-     }
-   }
-   ```
-
-3. **Use from Claude Code:** the model can now call `search_gmail_messages`,
-   `manage_events`, `create_document`, `manage_slides`, etc.
-
-## Configuration
-
-| Env var                       | Purpose                                                    |
-|-------------------------------|------------------------------------------------------------|
-| `GOOGLE_CLIENT_ID`            | OAuth client ID (only required when refreshing tokens)     |
-| `GOOGLE_CLIENT_SECRET`        | OAuth client secret (only required when refreshing tokens) |
-| `GWORKSPACE_TOKENS_DIR`       | Override token storage directory (default `~/.gworkspace-mcp`) |
-| `RUST_LOG`                    | Standard `tracing` filter (e.g. `trusty_gworkspace=debug`) |
-
-Token files use the same format as the Python project:
+…or by writing `~/.gworkspace-mcp/oauth_client.json`. Both a flat shape and the
+console's downloaded shape are accepted:
 
 ```json
+{ "client_id": "…apps.googleusercontent.com", "client_secret": "…" }
+```
+
+```json
+{ "installed": { "client_id": "…", "client_secret": "…" } }
+```
+
+(`web` is accepted in place of `installed`.) Environment variables take
+precedence over the file.
+
+### 2. Authorize an account
+
+```sh
+gworkspace-mcp setup                       # authorize the default profile
+gworkspace-mcp setup --profile work        # authorize a named profile
+```
+
+`setup` opens your browser to Google's consent screen, captures the redirect on
+a loopback listener, and writes the minted token to `~/.gworkspace-mcp/tokens.json`.
+Access tokens are then refreshed automatically by the server; you only re-run
+`setup` when the refresh token itself is revoked or expired.
+
+Default-profile rules: the first profile you authorize becomes the default; a
+later `setup` of a *different* profile leaves the existing default untouched.
+Use `--make-default` to switch it deliberately, or `--no-default` to guarantee
+it is never changed.
+
+### 3. Wire into Claude Code (or any MCP client)
+
+```jsonc
+// ~/.claude.json
 {
-  "version": 1,
-  "metadata": { "default": "gworkspace-mcp" },
-  "tokens": {
-    "gworkspace-mcp": {
-      "metadata": { "email": "user@example.com", "is_default": true },
-      "token": { "access_token": "...", "refresh_token": "...", "expires_at": "..." }
+  "mcpServers": {
+    "gworkspace": {
+      "command": "gworkspace-mcp"
     }
   }
 }
 ```
 
-Multi-account support: any number of named profiles in `tokens.json`. Pass
-`account = "<profile-name>"` to any tool to switch.
+The model can now call `search_gmail_messages`, `manage_events`,
+`create_document`, `manage_slides`, etc. Pass `account = "<profile-name>"` to
+any tool to target a non-default profile.
+
+## Re-authenticating from within a session
+
+When a refresh token dies mid-session (Google returns `invalid_grant`), tools
+fail with an actionable message naming the exact fix, e.g.:
+
+```
+Google refresh token for profile 'work' is expired or revoked — re-authenticate
+with: gworkspace-mcp setup --profile work (400 Bad Request invalid_grant: …)
+```
+
+You can run the fix without leaving the session:
+
+```sh
+! gworkspace-mcp setup --profile work        # interactive browser consent
+! gworkspace-mcp setup --profile work --print-url   # headless: prints the URL
+```
+
+`--print-url` (alias `--no-browser`) skips the browser launch and prints the
+full consent URL for you to open manually — the loopback callback still binds
+and captures the redirect exactly as the interactive path does. This is the
+path to use from a headless or in-session context where no browser can be
+spawned for you.
+
+## Diagnosing token health
+
+`doctor` reports the static config checks **and** live-probes each stored
+profile's refresh token, classifying it OK / DEAD / UNKNOWN:
+
+```sh
+gworkspace-mcp doctor
+```
+
+For any DEAD profile it prints the exact `gworkspace-mcp setup --profile <name>`
+command to fix it. The probe is read-only (it never rewrites `tokens.json`),
+bounded by a short per-profile timeout, and degrades to UNKNOWN when Google is
+unreachable rather than failing the whole diagnostic.
+
+## Managing accounts
+
+```sh
+gworkspace-mcp accounts list                 # show profiles + which is default
+gworkspace-mcp accounts default work         # switch the default profile
+gworkspace-mcp accounts remove work          # forget a local token (no revoke)
+```
+
+## Configuration
+
+| Env var                       | Purpose                                                        |
+|-------------------------------|----------------------------------------------------------------|
+| `GOOGLE_OAUTH_CLIENT_ID`      | OAuth client ID (required to run `setup` and to refresh)       |
+| `GOOGLE_OAUTH_CLIENT_SECRET`  | OAuth client secret (required to run `setup` and to refresh)   |
+| `RUST_LOG`                    | Standard `tracing` filter (e.g. `trusty_gworkspace=debug`)     |
+
+### Token file shape
+
+`~/.gworkspace-mcp/tokens.json` is a **flat JSON object mapping profile name →
+stored token** (created 0600 on Unix). Multi-account support is any number of
+named keys in this map:
+
+```json
+{
+  "gworkspace-mcp": {
+    "version": 1,
+    "metadata": {
+      "service_name": "gworkspace-mcp",
+      "provider": "google",
+      "created_at": "2026-01-01T00:00:00Z",
+      "last_refreshed": null,
+      "email": "user@example.com",
+      "is_default": true
+    },
+    "token": {
+      "access_token": "ya29.…",
+      "refresh_token": "1//…",
+      "expires_at": "2026-01-01T01:00:00Z",
+      "scopes": ["openid", "https://www.googleapis.com/auth/gmail.modify"],
+      "token_type": "Bearer"
+    }
+  }
+}
+```
+
+A project-level `./.gworkspace-mcp/tokens.json` overrides the user-level file
+per profile (two-tier lookup) — useful for per-project accounts.
 
 ## Tool Surface
 
@@ -121,12 +214,14 @@ adding a new tool means: write the function, add a `match` arm in
 
 ## Design Notes
 
-- **Token format compatibility.** Wire-compatible with the Python project
-  so a single auth flow serves both implementations. See
-  [`src/api/auth/models.rs`](src/api/auth/models.rs).
-- **No interactive OAuth.** Refresh is implemented in Rust; the initial
-  consent flow is delegated to the Python CLI. This keeps the binary
-  headless and CI-friendly.
+- **Token format compatibility.** Wire-compatible with the original Python
+  `gworkspace-mcp` token file, so an existing `tokens.json` is read unchanged.
+  See [`src/api/auth/models.rs`](src/api/auth/models.rs).
+- **Native interactive OAuth.** The authorization-code + PKCE consent flow is
+  implemented in Rust (`src/api/auth/oauth/`): `setup` binds a loopback
+  redirect listener, opens the browser (or, with `--print-url`, prints the URL
+  for headless use), and mints the token itself. Access-token refresh is also
+  native; no external CLI is involved.
 - **Two-tier token lookup.** `./.gworkspace-mcp/tokens.json` overrides
   `~/.gworkspace-mcp/tokens.json` — useful for per-project profiles.
 - **Errors as data.** Tool failures return `{"error": "..."}` inside the

--- a/crates/trusty-gworkspace/src/api/auth/manager.rs
+++ b/crates/trusty-gworkspace/src/api/auth/manager.rs
@@ -1,18 +1,24 @@
 //! OAuth refresh manager — exchanges a refresh token for a new access token.
 //!
-//! Why: Access tokens expire ~1 hour. We don't run the interactive flow
-//! here (that's the Python CLI's job for now) but we *do* need to refresh
-//! before requests go stale.
-//! What: POSTs `grant_type=refresh_token` to Google's OAuth token endpoint
-//! and updates the on-disk record.
-//! Test: Manual — requires real Google credentials. Logic-only branches
-//! (env-var presence, JSON shape) are exercised indirectly by `BaseClient`.
+//! Why: Access tokens expire ~1 hour, so we refresh before requests go stale.
+//! When the *refresh* token itself is expired or revoked Google replies with
+//! `invalid_grant`; the only fix is interactive re-consent, so this path must
+//! surface the exact `gworkspace-mcp setup --profile <name>` command rather
+//! than an opaque HTTP body.
+//! What: POSTs `grant_type=refresh_token` to Google's OAuth token endpoint,
+//! updates the on-disk record on success, and routes failures through the
+//! shared [`refresh_failure_message`] helper (actionable re-auth hint on
+//! `invalid_grant`, sanitized error otherwise).
+//! Test: Manual — requires real Google credentials. The failure-message mapping
+//! is unit-tested in `oauth::errors`
+//! (`refresh_failure_message_names_profile_and_setup_command`).
 
 use anyhow::{Context, Result, anyhow};
 use chrono::{Duration, Utc};
 use serde::Deserialize;
 
 use super::models::{OAuthToken, StoredToken};
+use super::oauth::errors::refresh_failure_message;
 use super::storage::TokenStorage;
 use crate::api::constants::OAUTH_TOKEN_URL;
 
@@ -64,8 +70,11 @@ impl OAuthManager {
     /// before the next API call.
     /// What: POSTs to Google's OAuth endpoint with `grant_type=refresh_token`,
     /// parses the response, updates `expires_at` to `now + expires_in`, and
-    /// writes the updated `StoredToken` back to disk.
-    /// Test: integration with real Google creds only.
+    /// writes the updated `StoredToken` back to disk. On an HTTP failure it
+    /// returns [`refresh_failure_message`]'s actionable error (naming the exact
+    /// re-auth command on `invalid_grant`).
+    /// Test: live path needs real Google creds; the failure-message mapping is
+    /// covered by `refresh_failure_message_names_profile_and_setup_command`.
     pub async fn refresh(&self, storage: &TokenStorage, profile: &str) -> Result<OAuthToken> {
         let mut stored: StoredToken = storage
             .get_profile(profile)?
@@ -92,7 +101,10 @@ impl OAuthManager {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
         if !status.is_success() {
-            return Err(anyhow!("token refresh failed ({status}): {body}"));
+            return Err(anyhow!(
+                "{}",
+                refresh_failure_message(status, &body, profile)
+            ));
         }
         let parsed: GoogleTokenResponse =
             serde_json::from_str(&body).with_context(|| format!("parse token response: {body}"))?;

--- a/crates/trusty-gworkspace/src/api/auth/oauth/errors.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/errors.rs
@@ -1,0 +1,204 @@
+//! Shared OAuth error-body parsing and actionable re-auth hints.
+//!
+//! Why: Both the interactive consent flow (`flow.rs`) and the background token
+//! refresh (`manager.rs`) can receive an error response from Google's token
+//! endpoint. They must surface it the *same* way — bounded, sanitized, and (for
+//! the one recoverable failure mode, a dead refresh token) with an actionable
+//! hint naming the exact `setup` command to run. Previously only the consent
+//! path sanitized its error body and the refresh path echoed the raw body with
+//! no re-auth guidance; centralising the logic here keeps the two in lockstep.
+//! What: `sanitize_oauth_error` parses Google's RFC 6749 §5.2 error body and
+//! returns a bounded, safe string; `is_invalid_grant` detects the
+//! expired/revoked-refresh-token case; `refresh_failure_message` composes the
+//! full message the refresh path returns, appending the exact re-auth command
+//! (with profile name) when the failure is an `invalid_grant`.
+//! Test: `sanitizes_oauth_error_json`, `sanitizes_oauth_error_json_without_description`,
+//! `truncates_unparseable_body`, `detects_invalid_grant`, `ignores_non_invalid_grant`,
+//! `refresh_failure_message_names_profile_and_setup_command`,
+//! `refresh_failure_message_non_invalid_grant_has_no_hint`.
+
+use serde::Deserialize;
+
+/// Google's RFC 6749 §5.2 error-response shape (`error` + optional
+/// `error_description`).
+///
+/// Why: Google returns machine-readable OAuth failures as
+/// `{"error": "...", "error_description": "..."}`; parsing that lets us surface
+/// only the structured fields instead of an arbitrary response body.
+/// What: A minimal serde view over the two fields we care about.
+/// Test: Exercised via `sanitizes_oauth_error_json` and `detects_invalid_grant`.
+#[derive(Debug, Deserialize)]
+struct OAuthErrorBody {
+    error: String,
+    #[serde(default)]
+    error_description: Option<String>,
+}
+
+/// Maximum characters of an unparseable error body to surface.
+const MAX_ERROR_BODY_CHARS: usize = 200;
+
+/// Extract a safe, bounded error message from a Google OAuth error response.
+///
+/// Why: The raw response body can be arbitrary third-party text (an HTML
+/// error page, a verbose diagnostic dump) that ends up inside an `anyhow`
+/// error chain and may be printed to the terminal or captured in crash
+/// reports. Surfacing only the structured `error`/`error_description` (or a
+/// short truncated fallback) keeps that surface bounded and predictable.
+/// What: Parses `body` as `{"error": "...", "error_description": "..."}`;
+/// falls back to a message truncated to [`MAX_ERROR_BODY_CHARS`] characters
+/// when the body isn't that shape.
+/// Test: `sanitizes_oauth_error_json`, `truncates_unparseable_body`.
+pub(crate) fn sanitize_oauth_error(status: reqwest::StatusCode, body: &str) -> String {
+    if let Ok(parsed) = serde_json::from_str::<OAuthErrorBody>(body) {
+        return match parsed.error_description {
+            Some(desc) => format!("{status} {}: {desc}", parsed.error),
+            None => format!("{status} {}", parsed.error),
+        };
+    }
+    let char_count = body.chars().count();
+    let truncated: String = body.chars().take(MAX_ERROR_BODY_CHARS).collect();
+    if char_count > MAX_ERROR_BODY_CHARS {
+        format!("{status} (unparseable error body, truncated): {truncated}...")
+    } else {
+        format!("{status} (unparseable error body): {truncated}")
+    }
+}
+
+/// True when `body` is a structured OAuth error whose `error` is `invalid_grant`.
+///
+/// Why: `invalid_grant` is Google's signal that a *refresh token* is expired or
+/// revoked — the one refresh failure a user can fix themselves by
+/// re-authenticating. Distinguishing it from transient/other failures lets us
+/// attach the re-auth hint only when it actually applies (avoiding
+/// misattribution on, say, a 500 or a rate-limit).
+/// What: Parses `body` as an [`OAuthErrorBody`] and compares its `error` field.
+/// Test: `detects_invalid_grant`, `ignores_non_invalid_grant`.
+pub(crate) fn is_invalid_grant(body: &str) -> bool {
+    serde_json::from_str::<OAuthErrorBody>(body)
+        .map(|b| b.error == "invalid_grant")
+        .unwrap_or(false)
+}
+
+/// Build the error message for a failed refresh-token exchange.
+///
+/// Why: When a background refresh fails with `invalid_grant` the user's only
+/// recovery is to re-run consent; the message must name the EXACT command
+/// (including the profile) so the fix is copy-pasteable, while still routing the
+/// raw failure through [`sanitize_oauth_error`] for a bounded diagnostic. For
+/// any other failure we return a sanitized error without the re-auth hint, so a
+/// transient/server error is never misattributed to a dead token.
+/// What: For `invalid_grant`, returns
+/// `Google refresh token for profile '<name>' is expired or revoked —
+/// re-authenticate with: gworkspace-mcp setup --profile <name> (<sanitized>)`;
+/// otherwise returns `token refresh failed: <sanitized>`.
+/// Test: `refresh_failure_message_names_profile_and_setup_command`,
+/// `refresh_failure_message_non_invalid_grant_has_no_hint`.
+pub(crate) fn refresh_failure_message(
+    status: reqwest::StatusCode,
+    body: &str,
+    profile: &str,
+) -> String {
+    let sanitized = sanitize_oauth_error(status, body);
+    if is_invalid_grant(body) {
+        format!(
+            "Google refresh token for profile '{profile}' is expired or revoked — \
+             re-authenticate with: gworkspace-mcp setup --profile {profile} ({sanitized})"
+        )
+    } else {
+        format!("token refresh failed: {sanitized}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizes_oauth_error_json() {
+        let msg = sanitize_oauth_error(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":"invalid_grant","error_description":"Bad Request"}"#,
+        );
+        assert!(msg.contains("invalid_grant"));
+        assert!(msg.contains("Bad Request"));
+    }
+
+    #[test]
+    fn sanitizes_oauth_error_json_without_description() {
+        let msg = sanitize_oauth_error(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":"invalid_grant"}"#,
+        );
+        assert!(msg.contains("invalid_grant"));
+    }
+
+    #[test]
+    fn truncates_unparseable_body() {
+        let long_body = "x".repeat(500);
+        let msg = sanitize_oauth_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, &long_body);
+        assert!(
+            msg.len() < long_body.len(),
+            "message must be shorter than the raw body"
+        );
+        assert!(msg.contains("truncated"));
+    }
+
+    #[test]
+    fn detects_invalid_grant() {
+        assert!(is_invalid_grant(
+            r#"{"error":"invalid_grant","error_description":"Token has been expired or revoked."}"#
+        ));
+    }
+
+    #[test]
+    fn ignores_non_invalid_grant() {
+        assert!(!is_invalid_grant(r#"{"error":"invalid_client"}"#));
+        assert!(!is_invalid_grant("not json at all"));
+        assert!(!is_invalid_grant("<html>500</html>"));
+    }
+
+    #[test]
+    fn refresh_failure_message_names_profile_and_setup_command() {
+        let msg = refresh_failure_message(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":"invalid_grant","error_description":"Token has been expired or revoked."}"#,
+            "work",
+        );
+        // Actionable hint must name the profile AND the exact setup command.
+        assert!(
+            msg.contains("profile 'work'"),
+            "message must name the profile: {msg}"
+        );
+        assert!(
+            msg.contains("gworkspace-mcp setup --profile work"),
+            "message must name the exact re-auth command: {msg}"
+        );
+        assert!(
+            msg.contains("expired or revoked"),
+            "message must explain the cause: {msg}"
+        );
+        // Sanitized diagnostic is still routed through.
+        assert!(
+            msg.contains("invalid_grant"),
+            "sanitized body retained: {msg}"
+        );
+    }
+
+    #[test]
+    fn refresh_failure_message_non_invalid_grant_has_no_hint() {
+        let msg = refresh_failure_message(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            r#"{"error":"internal_failure"}"#,
+            "work",
+        );
+        assert!(
+            !msg.contains("setup --profile"),
+            "non-invalid_grant failure must NOT suggest re-auth: {msg}"
+        );
+        assert!(
+            msg.contains("token refresh failed"),
+            "must stay a sanitized error: {msg}"
+        );
+        assert!(msg.contains("internal_failure"));
+    }
+}

--- a/crates/trusty-gworkspace/src/api/auth/oauth/flow/mod.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/flow/mod.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use tracing::{info, warn};
 
 use super::callback;
+use super::errors::sanitize_oauth_error;
 use super::pkce::{self, Pkce};
 use crate::api::auth::models::{OAuthToken, StoredToken, TokenMetadata};
 use crate::api::auth::storage::TokenStorage;
@@ -256,23 +257,61 @@ struct TokenResponse {
 /// a much shorter duration.
 const CONSENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
+/// Compose the user-facing consent prompt lines (printed to stderr).
+///
+/// Why: `setup` runs both interactively (auto-open the browser) and in
+/// headless / in-session contexts (`--print-url` / `--no-browser`, where no
+/// browser can be launched). Both modes must display the SAME consent URL — the
+/// only thing that changes is whether we also spawn the browser and how we word
+/// the instruction. Isolating the wording here (a) keeps the URL provably
+/// identical across modes and (b) makes that contract unit-testable without a
+/// live network round-trip.
+/// What: Returns the ordered prompt lines. When `open_browser` is true the
+/// first line announces the launch; otherwise it instructs the user to open the
+/// URL manually. `auth_url` is embedded verbatim in every mode.
+/// Test: `consent_prompt_url_is_identical_regardless_of_browser_mode`,
+/// `consent_prompt_wording_differs_by_mode`.
+fn consent_prompt_lines(auth_url: &str, open_browser: bool, timeout_secs: u64) -> Vec<String> {
+    let mut lines = Vec::new();
+    if open_browser {
+        lines.push("Opening your browser to authorize trusty-gworkspace...".to_string());
+        lines.push(format!(
+            "If it does not open, open this URL manually:\n\n{auth_url}\n"
+        ));
+    } else {
+        lines.push(
+            "Open this URL in a browser to authorize trusty-gworkspace \
+             (no browser will be launched):"
+                .to_string(),
+        );
+        lines.push(format!("\n{auth_url}\n"));
+    }
+    lines.push(format!(
+        "Waiting up to {timeout_secs}s for you to finish in the browser..."
+    ));
+    lines
+}
+
 /// Run the full interactive consent flow and persist the minted token.
 ///
 /// Why: The single entry point the `setup` CLI calls — orchestrates the
 /// browser consent, code capture, token exchange, email resolution, and
 /// persistence so the caller only decides profile name / default mode.
-/// What: Generates PKCE + state, binds a loopback callback, opens the system
-/// browser (falling back to printing the URL), waits (bounded by
-/// [`CONSENT_TIMEOUT`]) for the redirect, exchanges the code, resolves the
-/// email, and writes a wire-compatible `StoredToken`. The default-profile
-/// decision is resolved up front (from on-disk state, before any network
-/// call) so a would-be-displaced default can be warned about immediately.
+/// What: Generates PKCE + state, binds a loopback callback, prints the consent
+/// URL and — when `open_browser` is true — opens the system browser (passing
+/// `false`, via `setup --print-url` / `--no-browser`, prints the URL only, for
+/// headless / in-session re-auth). Waits (bounded by [`CONSENT_TIMEOUT`]) for
+/// the redirect, exchanges the code, resolves the email, and writes a
+/// wire-compatible `StoredToken`. The default-profile decision is resolved up
+/// front (from on-disk state, before any network call) so a would-be-displaced
+/// default can be warned about immediately.
 /// Test: Deferred (needs a live Google client + browser). Constituent pure
-/// helpers are unit-tested.
+/// helpers are unit-tested (`consent_prompt_url_is_identical_regardless_of_browser_mode`).
 pub async fn run_consent(
     storage: &TokenStorage,
     profile: &str,
     default_mode: DefaultMode,
+    open_browser: bool,
 ) -> Result<ConsentOutcome> {
     let creds = resolve_client_creds()?;
 
@@ -305,13 +344,10 @@ pub async fn run_consent(
         &state,
     );
 
-    eprintln!("Opening your browser to authorize trusty-gworkspace...");
-    eprintln!("If it does not open, visit this URL manually:\n\n{auth_url}\n");
-    eprintln!(
-        "Waiting up to {}s for you to finish in the browser...",
-        CONSENT_TIMEOUT.as_secs()
-    );
-    if let Err(e) = open::that(&auth_url) {
+    for line in consent_prompt_lines(&auth_url, open_browser, CONSENT_TIMEOUT.as_secs()) {
+        eprintln!("{line}");
+    }
+    if open_browser && let Err(e) = open::that(&auth_url) {
         warn!(error = %e, "failed to launch browser; user must open the URL manually");
     }
 
@@ -369,45 +405,6 @@ async fn exchange_code(
         ));
     }
     serde_json::from_str(&body).with_context(|| format!("parse token response: {body}"))
-}
-
-/// Google's RFC 6749 §5.2 error-response shape (`error` + optional
-/// `error_description`).
-#[derive(Debug, Deserialize)]
-struct OAuthErrorBody {
-    error: String,
-    #[serde(default)]
-    error_description: Option<String>,
-}
-
-/// Maximum characters of an unparseable error body to surface.
-const MAX_ERROR_BODY_CHARS: usize = 200;
-
-/// Extract a safe, bounded error message from a Google OAuth error response.
-///
-/// Why: The raw response body can be arbitrary third-party text (an HTML
-/// error page, a verbose diagnostic dump) that ends up inside an `anyhow`
-/// error chain and may be printed to the terminal or captured in crash
-/// reports. Surfacing only the structured `error`/`error_description` (or a
-/// short truncated fallback) keeps that surface bounded and predictable.
-/// What: Parses `body` as `{"error": "...", "error_description": "..."}`;
-/// falls back to a message truncated to [`MAX_ERROR_BODY_CHARS`] characters
-/// when the body isn't that shape.
-/// Test: `sanitizes_oauth_error_json`, `truncates_unparseable_body`.
-fn sanitize_oauth_error(status: reqwest::StatusCode, body: &str) -> String {
-    if let Ok(parsed) = serde_json::from_str::<OAuthErrorBody>(body) {
-        return match parsed.error_description {
-            Some(desc) => format!("{status} {}: {desc}", parsed.error),
-            None => format!("{status} {}", parsed.error),
-        };
-    }
-    let char_count = body.chars().count();
-    let truncated: String = body.chars().take(MAX_ERROR_BODY_CHARS).collect();
-    if char_count > MAX_ERROR_BODY_CHARS {
-        format!("{status} (unparseable error body, truncated): {truncated}...")
-    } else {
-        format!("{status} (unparseable error body): {truncated}")
-    }
 }
 
 /// Resolve the account email: `id_token` claim first, then userinfo endpoint.
@@ -505,193 +502,4 @@ pub fn effective_profile(override_name: Option<&str>) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn scope_string_matches_constant_set() {
-        let s = assemble_scope_string();
-        assert!(s.starts_with("openid "));
-        assert!(s.contains("https://www.googleapis.com/auth/gmail.modify"));
-        assert!(s.contains("https://www.googleapis.com/auth/presentations"));
-        assert_eq!(s.split(' ').count(), OAUTH_SCOPES.len());
-    }
-
-    #[test]
-    fn build_auth_url_contains_all_params() {
-        let url = build_auth_url(
-            "cid.apps.googleusercontent.com",
-            "http://127.0.0.1:5000",
-            "openid https://www.googleapis.com/auth/calendar",
-            "CHALLENGE",
-            "STATE",
-        );
-        assert!(url.starts_with(OAUTH_AUTH_URL));
-        assert!(url.contains("client_id=cid.apps.googleusercontent.com"));
-        assert!(url.contains("code_challenge=CHALLENGE"));
-        assert!(url.contains("code_challenge_method=S256"));
-        assert!(url.contains("state=STATE"));
-        assert!(url.contains("access_type=offline"));
-        assert!(url.contains("prompt=consent"));
-        // redirect_uri and scope must be percent-encoded.
-        assert!(url.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A5000"));
-        assert!(url.contains("scope=openid%20https"));
-    }
-
-    #[test]
-    fn parses_flat_creds() {
-        let c = parse_client_creds_json(r#"{"client_id":"a","client_secret":"b"}"#).unwrap();
-        assert_eq!(c.client_id, "a");
-        assert_eq!(c.client_secret, "b");
-    }
-
-    #[test]
-    fn parses_installed_creds() {
-        let c = parse_client_creds_json(
-            r#"{"installed":{"client_id":"x","client_secret":"y","redirect_uris":["http://localhost"]}}"#,
-        )
-        .unwrap();
-        assert_eq!(c.client_id, "x");
-        assert_eq!(c.client_secret, "y");
-    }
-
-    #[test]
-    fn default_profile_falls_back() {
-        assert_eq!(effective_profile(None), DEFAULT_PROFILE);
-        assert_eq!(effective_profile(Some("  ")), DEFAULT_PROFILE);
-        assert_eq!(effective_profile(Some("work")), "work");
-    }
-
-    fn make_stored(name: &str, is_default: bool) -> StoredToken {
-        StoredToken {
-            version: 1,
-            metadata: TokenMetadata {
-                service_name: name.to_string(),
-                provider: "google".into(),
-                created_at: Utc::now(),
-                last_refreshed: None,
-                email: Some(format!("{name}@example.com")),
-                is_default,
-            },
-            token: OAuthToken {
-                access_token: "a".into(),
-                refresh_token: Some("r".into()),
-                expires_at: Utc::now() + Duration::seconds(3600),
-                scopes: vec!["openid".into()],
-                token_type: "Bearer".into(),
-            },
-        }
-    }
-
-    #[test]
-    fn persist_marks_single_default() {
-        let dir = std::env::temp_dir().join(format!("gw-persist-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let storage = TokenStorage::with_path(dir.join("tokens.json"));
-
-        persist(&storage, "first", make_stored("first", false), true).unwrap();
-        persist(&storage, "second", make_stored("second", false), true).unwrap();
-
-        let all = storage.load().unwrap();
-        assert_eq!(all.len(), 2);
-        assert!(!all["first"].metadata.is_default, "old default cleared");
-        assert!(all["second"].metadata.is_default, "new entry is default");
-    }
-
-    #[test]
-    fn persist_false_does_not_steal_existing_default() {
-        // Regression test: a second `setup` run with set_default=false (the
-        // outcome of DefaultMode::Auto when a default already exists on a
-        // different profile) must leave the existing default untouched.
-        let dir = std::env::temp_dir().join(format!("gw-persist2-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let storage = TokenStorage::with_path(dir.join("tokens.json"));
-
-        persist(&storage, "first", make_stored("first", false), true).unwrap();
-        persist(&storage, "second", make_stored("second", false), false).unwrap();
-
-        let all = storage.load().unwrap();
-        assert_eq!(all.len(), 2);
-        assert!(
-            all["first"].metadata.is_default,
-            "first must remain default — it was not stolen"
-        );
-        assert!(!all["second"].metadata.is_default);
-    }
-
-    #[test]
-    fn auto_sets_default_only_when_absent() {
-        let existing: HashMap<String, StoredToken> = HashMap::new();
-        assert!(should_set_default(DefaultMode::Auto, "first", &existing));
-    }
-
-    #[test]
-    fn auto_does_not_steal_existing_default() {
-        let mut existing = HashMap::new();
-        existing.insert("first".to_string(), make_stored("first", true));
-        assert!(
-            !should_set_default(DefaultMode::Auto, "second", &existing),
-            "second account must not silently steal the default"
-        );
-    }
-
-    #[test]
-    fn auto_keeps_default_on_reauth_of_default_profile() {
-        let mut existing = HashMap::new();
-        existing.insert("first".to_string(), make_stored("first", true));
-        assert!(
-            should_set_default(DefaultMode::Auto, "first", &existing),
-            "re-authorizing the existing default profile should keep it default"
-        );
-    }
-
-    #[test]
-    fn force_overrides_existing_default() {
-        let mut existing = HashMap::new();
-        existing.insert("first".to_string(), make_stored("first", true));
-        assert!(should_set_default(DefaultMode::Force, "second", &existing));
-    }
-
-    #[test]
-    fn never_keeps_existing_default() {
-        let existing: HashMap<String, StoredToken> = HashMap::new();
-        assert!(!should_set_default(DefaultMode::Never, "first", &existing));
-        let mut with_default = HashMap::new();
-        with_default.insert("first".to_string(), make_stored("first", true));
-        assert!(!should_set_default(
-            DefaultMode::Never,
-            "second",
-            &with_default
-        ));
-    }
-
-    #[test]
-    fn sanitizes_oauth_error_json() {
-        let msg = sanitize_oauth_error(
-            reqwest::StatusCode::BAD_REQUEST,
-            r#"{"error":"invalid_grant","error_description":"Bad Request"}"#,
-        );
-        assert!(msg.contains("invalid_grant"));
-        assert!(msg.contains("Bad Request"));
-    }
-
-    #[test]
-    fn sanitizes_oauth_error_json_without_description() {
-        let msg = sanitize_oauth_error(
-            reqwest::StatusCode::BAD_REQUEST,
-            r#"{"error":"invalid_grant"}"#,
-        );
-        assert!(msg.contains("invalid_grant"));
-    }
-
-    #[test]
-    fn truncates_unparseable_body() {
-        let long_body = "x".repeat(500);
-        let msg = sanitize_oauth_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, &long_body);
-        assert!(
-            msg.len() < long_body.len(),
-            "message must be shorter than the raw body"
-        );
-        assert!(msg.contains("truncated"));
-    }
-}
+mod tests;

--- a/crates/trusty-gworkspace/src/api/auth/oauth/flow/tests.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/flow/tests.rs
@@ -1,0 +1,224 @@
+//! Unit tests for the `flow` consent orchestration module.
+//!
+//! Why: split out of `flow/mod.rs` to keep the production file under the
+//! 500-SLOC cap (the pure helpers here carry a large, valuable test body).
+//! What: exercises the offline-testable helpers — scope assembly, auth-URL
+//! construction, client-creds parsing, default-mode decisions, and the
+//! browser-vs-print-url consent prompt.
+//! Test: this file IS the test module for `flow`.
+
+use super::*;
+
+#[test]
+fn scope_string_matches_constant_set() {
+    let s = assemble_scope_string();
+    assert!(s.starts_with("openid "));
+    assert!(s.contains("https://www.googleapis.com/auth/gmail.modify"));
+    assert!(s.contains("https://www.googleapis.com/auth/presentations"));
+    assert_eq!(s.split(' ').count(), OAUTH_SCOPES.len());
+}
+
+#[test]
+fn build_auth_url_contains_all_params() {
+    let url = build_auth_url(
+        "cid.apps.googleusercontent.com",
+        "http://127.0.0.1:5000",
+        "openid https://www.googleapis.com/auth/calendar",
+        "CHALLENGE",
+        "STATE",
+    );
+    assert!(url.starts_with(OAUTH_AUTH_URL));
+    assert!(url.contains("client_id=cid.apps.googleusercontent.com"));
+    assert!(url.contains("code_challenge=CHALLENGE"));
+    assert!(url.contains("code_challenge_method=S256"));
+    assert!(url.contains("state=STATE"));
+    assert!(url.contains("access_type=offline"));
+    assert!(url.contains("prompt=consent"));
+    // redirect_uri and scope must be percent-encoded.
+    assert!(url.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A5000"));
+    assert!(url.contains("scope=openid%20https"));
+}
+
+#[test]
+fn parses_flat_creds() {
+    let c = parse_client_creds_json(r#"{"client_id":"a","client_secret":"b"}"#).unwrap();
+    assert_eq!(c.client_id, "a");
+    assert_eq!(c.client_secret, "b");
+}
+
+#[test]
+fn parses_installed_creds() {
+    let c = parse_client_creds_json(
+            r#"{"installed":{"client_id":"x","client_secret":"y","redirect_uris":["http://localhost"]}}"#,
+        )
+        .unwrap();
+    assert_eq!(c.client_id, "x");
+    assert_eq!(c.client_secret, "y");
+}
+
+#[test]
+fn default_profile_falls_back() {
+    assert_eq!(effective_profile(None), DEFAULT_PROFILE);
+    assert_eq!(effective_profile(Some("  ")), DEFAULT_PROFILE);
+    assert_eq!(effective_profile(Some("work")), "work");
+}
+
+fn make_stored(name: &str, is_default: bool) -> StoredToken {
+    StoredToken {
+        version: 1,
+        metadata: TokenMetadata {
+            service_name: name.to_string(),
+            provider: "google".into(),
+            created_at: Utc::now(),
+            last_refreshed: None,
+            email: Some(format!("{name}@example.com")),
+            is_default,
+        },
+        token: OAuthToken {
+            access_token: "a".into(),
+            refresh_token: Some("r".into()),
+            expires_at: Utc::now() + Duration::seconds(3600),
+            scopes: vec!["openid".into()],
+            token_type: "Bearer".into(),
+        },
+    }
+}
+
+#[test]
+fn persist_marks_single_default() {
+    let dir = std::env::temp_dir().join(format!("gw-persist-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let storage = TokenStorage::with_path(dir.join("tokens.json"));
+
+    persist(&storage, "first", make_stored("first", false), true).unwrap();
+    persist(&storage, "second", make_stored("second", false), true).unwrap();
+
+    let all = storage.load().unwrap();
+    assert_eq!(all.len(), 2);
+    assert!(!all["first"].metadata.is_default, "old default cleared");
+    assert!(all["second"].metadata.is_default, "new entry is default");
+}
+
+#[test]
+fn persist_false_does_not_steal_existing_default() {
+    // Regression test: a second `setup` run with set_default=false (the
+    // outcome of DefaultMode::Auto when a default already exists on a
+    // different profile) must leave the existing default untouched.
+    let dir = std::env::temp_dir().join(format!("gw-persist2-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let storage = TokenStorage::with_path(dir.join("tokens.json"));
+
+    persist(&storage, "first", make_stored("first", false), true).unwrap();
+    persist(&storage, "second", make_stored("second", false), false).unwrap();
+
+    let all = storage.load().unwrap();
+    assert_eq!(all.len(), 2);
+    assert!(
+        all["first"].metadata.is_default,
+        "first must remain default — it was not stolen"
+    );
+    assert!(!all["second"].metadata.is_default);
+}
+
+#[test]
+fn auto_sets_default_only_when_absent() {
+    let existing: HashMap<String, StoredToken> = HashMap::new();
+    assert!(should_set_default(DefaultMode::Auto, "first", &existing));
+}
+
+#[test]
+fn auto_does_not_steal_existing_default() {
+    let mut existing = HashMap::new();
+    existing.insert("first".to_string(), make_stored("first", true));
+    assert!(
+        !should_set_default(DefaultMode::Auto, "second", &existing),
+        "second account must not silently steal the default"
+    );
+}
+
+#[test]
+fn auto_keeps_default_on_reauth_of_default_profile() {
+    let mut existing = HashMap::new();
+    existing.insert("first".to_string(), make_stored("first", true));
+    assert!(
+        should_set_default(DefaultMode::Auto, "first", &existing),
+        "re-authorizing the existing default profile should keep it default"
+    );
+}
+
+#[test]
+fn force_overrides_existing_default() {
+    let mut existing = HashMap::new();
+    existing.insert("first".to_string(), make_stored("first", true));
+    assert!(should_set_default(DefaultMode::Force, "second", &existing));
+}
+
+#[test]
+fn never_keeps_existing_default() {
+    let existing: HashMap<String, StoredToken> = HashMap::new();
+    assert!(!should_set_default(DefaultMode::Never, "first", &existing));
+    let mut with_default = HashMap::new();
+    with_default.insert("first".to_string(), make_stored("first", true));
+    assert!(!should_set_default(
+        DefaultMode::Never,
+        "second",
+        &with_default
+    ));
+}
+
+#[test]
+fn consent_prompt_url_is_identical_regardless_of_browser_mode() {
+    // Item 3 contract: the --print-url (no-browser) path must show the
+    // EXACT same consent URL as the auto-open path. The URL is built once
+    // and only the browser-launch decision is gated by the flag, so the
+    // rendered prompt embeds a byte-identical URL either way.
+    let url = build_auth_url(
+        "cid.apps.googleusercontent.com",
+        "http://127.0.0.1:5000",
+        "openid https://www.googleapis.com/auth/calendar",
+        "CHALLENGE",
+        "STATE",
+    );
+    let opened = consent_prompt_lines(&url, true, 300).join("\n");
+    let printed = consent_prompt_lines(&url, false, 300).join("\n");
+
+    assert!(
+        opened.contains(&url),
+        "auto-open prompt must embed the consent URL"
+    );
+    assert!(
+        printed.contains(&url),
+        "print-url prompt must embed the consent URL"
+    );
+    // The same URL appears in both — the flag never changes what is built.
+    let extract = |s: &str| -> String {
+        s.lines()
+            .find(|l| l.contains(OAUTH_AUTH_URL))
+            .unwrap_or_default()
+            .to_string()
+    };
+    assert_eq!(
+        extract(&opened),
+        extract(&printed),
+        "print-url URL must match the auto-open URL exactly"
+    );
+}
+
+#[test]
+fn consent_prompt_wording_differs_by_mode() {
+    let url = "https://accounts.google.com/o/oauth2/v2/auth?x=1";
+    let opened = consent_prompt_lines(url, true, 300).join("\n");
+    let printed = consent_prompt_lines(url, false, 300).join("\n");
+    assert!(
+        opened.to_lowercase().contains("opening your browser"),
+        "auto-open must announce the browser launch: {opened}"
+    );
+    assert!(
+        !printed.to_lowercase().contains("opening your browser"),
+        "print-url must NOT claim to open a browser: {printed}"
+    );
+    assert!(
+        printed.to_lowercase().contains("open this url"),
+        "print-url must instruct the user to open the URL: {printed}"
+    );
+}

--- a/crates/trusty-gworkspace/src/api/auth/oauth/mod.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/mod.rs
@@ -11,7 +11,8 @@
 //! the live browser round-trip is deferred (needs real Google creds).
 
 pub mod callback;
+pub mod errors;
 pub mod flow;
 pub mod pkce;
 
-pub use flow::{ConsentOutcome, DefaultMode, resolve_client_creds, run_consent};
+pub use flow::{ClientCreds, ConsentOutcome, DefaultMode, resolve_client_creds, run_consent};

--- a/crates/trusty-gworkspace/src/cli/doctor.rs
+++ b/crates/trusty-gworkspace/src/cli/doctor.rs
@@ -1,36 +1,151 @@
-//! `doctor` subcommand: config / credentials health check.
+//! `doctor` subcommand: config / credentials health check + live token probe.
 //!
 //! Why: OAuth onboarding fails in a handful of predictable ways (missing
-//! client creds, no tokens, expired refresh). A one-shot diagnostic tells the
-//! user exactly what to fix before they hit a cryptic API error.
-//! What: Checks client-credential resolution and the tokens.json state, then
-//! prints a checklist. Never mutates anything; read-only.
-//! Test: `report_lines` builds the checklist from injected state so the output
-//! is asserted without touching the environment.
+//! client creds, no tokens, an expired/revoked refresh token). A one-shot
+//! diagnostic tells the user exactly what to fix — and, crucially, for a dead
+//! refresh token it names the exact `gworkspace-mcp setup --profile <name>`
+//! command to run — before they hit a cryptic API error mid-session.
+//! What: Checks client-credential resolution and tokens.json state (read-only),
+//! then, when credentials are available, live-probes each stored profile's
+//! refresh token against Google's token endpoint (bounded per-profile timeout,
+//! no persistence) and reports OK / DEAD / UNKNOWN per profile.
+//! Test: `report_lines` (static checks) and `health_lines` (per-profile
+//! classification) build their output from injected state so the exact wording
+//! is asserted without touching the network. See `report_lines_flags_missing_creds`,
+//! `report_lines_all_green`, `single_account_counts_as_default`,
+//! `health_lines_ok_shows_email`, `health_lines_dead_names_setup_command`,
+//! `health_lines_unknown_is_graceful`.
+
+use std::time::Duration;
 
 use anyhow::Result;
 
 use crate::api::auth::TokenStorage;
+use crate::api::auth::oauth::errors::is_invalid_grant;
+use crate::api::auth::oauth::flow::ClientCreds;
 use crate::api::auth::oauth::resolve_client_creds;
+use crate::api::constants::OAUTH_TOKEN_URL;
+
+/// Per-profile refresh-token health, as classified by the live probe.
+///
+/// Why: The doctor must distinguish a genuinely dead refresh token (actionable:
+/// re-auth) from a transient network failure (not actionable: try again later),
+/// and never hard-fail the whole diagnostic because Google was unreachable.
+/// What: `Live` — the refresh token minted a fresh access token (with its
+/// lifetime); `Dead` — Google returned `invalid_grant`; `Unknown` — offline,
+/// timed out, or an unexpected non-`invalid_grant` error.
+/// Test: `health_lines_ok_shows_email`, `health_lines_dead_names_setup_command`,
+/// `health_lines_unknown_is_graceful`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeResult {
+    /// Refresh succeeded; the new access token lives `expires_in` seconds.
+    Live { expires_in: Option<i64> },
+    /// Google rejected the refresh token as expired or revoked.
+    Dead,
+    /// Could not determine validity (offline, timeout, or unexpected error).
+    Unknown,
+}
+
+/// Per-profile probe timeout. Bounds each network check so `doctor` stays
+/// responsive even with many profiles or a flaky connection.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(6);
 
 /// Run the doctor check and print a report to stdout.
 ///
 /// Why: Human-facing entry point for `gworkspace-mcp doctor`.
-/// What: Probes credentials + storage, prints each line from [`report_lines`],
-/// and returns `Ok` regardless of findings (the report *is* the result).
-/// Test: Delegates to `report_lines`, which is unit-tested.
-pub fn run(storage: &TokenStorage) -> Result<()> {
-    let creds_ok = resolve_client_creds().is_ok();
+/// What: Prints the static credential/storage checks, then — when client
+/// credentials resolve — live-probes each stored profile and prints its health.
+/// Always returns `Ok` (the report *is* the result); never mutates tokens.json.
+/// Test: Delegates to `report_lines` and `health_lines`, both unit-tested.
+pub async fn run(storage: &TokenStorage) -> Result<()> {
+    let creds = resolve_client_creds().ok();
     let accounts = storage.list_accounts().unwrap_or_default();
     let has_default = accounts.iter().any(|(_, _, d)| *d);
 
-    for line in report_lines(creds_ok, accounts.len(), has_default) {
+    for line in report_lines(creds.is_some(), accounts.len(), has_default) {
         println!("{line}");
     }
+
+    if accounts.is_empty() {
+        return Ok(());
+    }
+
+    println!();
+    println!("Per-profile refresh-token health:");
+    match &creds {
+        Some(creds) => {
+            let http = reqwest::Client::builder()
+                .timeout(PROBE_TIMEOUT)
+                .build()
+                .unwrap_or_default();
+            for (name, email, _is_default) in &accounts {
+                let result = probe_profile(&http, storage, creds, name).await;
+                for line in health_lines(name, email.as_deref(), &result) {
+                    println!("{line}");
+                }
+            }
+        }
+        None => {
+            println!(
+                "      Skipped — set OAuth client credentials to enable live probing \
+                 (see the check above)."
+            );
+        }
+    }
+
     Ok(())
 }
 
-/// Build the diagnostic checklist lines from resolved state.
+/// Live-probe a single profile's refresh token without persisting anything.
+///
+/// Why: The durable credential is the refresh token; validating it (by minting
+/// a throwaway access token) is the only reliable "is this account still
+/// usable?" check. Doctor is read-only, so this deliberately does NOT call
+/// `OAuthManager::refresh` (which would rewrite tokens.json).
+/// What: Loads the stored refresh token, POSTs `grant_type=refresh_token`, and
+/// classifies the outcome into a [`ProbeResult`]. Any network/timeout error or
+/// missing refresh token becomes `Unknown`; `invalid_grant` becomes `Dead`.
+/// Test: Network path is integration-only; the classification wording is
+/// covered via `health_lines_*`.
+async fn probe_profile(
+    http: &reqwest::Client,
+    storage: &TokenStorage,
+    creds: &ClientCreds,
+    profile: &str,
+) -> ProbeResult {
+    let refresh_token = match storage.get_profile(profile) {
+        Ok(Some(stored)) => match stored.token.refresh_token {
+            Some(rt) => rt,
+            None => return ProbeResult::Unknown,
+        },
+        _ => return ProbeResult::Unknown,
+    };
+
+    let params = [
+        ("client_id", creds.client_id.as_str()),
+        ("client_secret", creds.client_secret.as_str()),
+        ("refresh_token", refresh_token.as_str()),
+        ("grant_type", "refresh_token"),
+    ];
+    let resp = match http.post(OAUTH_TOKEN_URL).form(&params).send().await {
+        Ok(r) => r,
+        Err(_) => return ProbeResult::Unknown,
+    };
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    if status.is_success() {
+        let expires_in = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| v.get("expires_in").and_then(|x| x.as_i64()));
+        ProbeResult::Live { expires_in }
+    } else if is_invalid_grant(&body) {
+        ProbeResult::Dead
+    } else {
+        ProbeResult::Unknown
+    }
+}
+
+/// Build the static (offline) diagnostic checklist lines from resolved state.
 ///
 /// Why: Separating formatting from I/O makes the exact wording testable and
 /// keeps `run` trivial.
@@ -72,6 +187,36 @@ pub fn report_lines(creds_ok: bool, account_count: usize, has_default: bool) -> 
     lines
 }
 
+/// Build the per-profile health lines from a probe result.
+///
+/// Why: The live-probe verdict must render identically whether it came from a
+/// real network call or a test — and a `Dead` profile must always print the
+/// exact re-auth command so the fix is copy-pasteable.
+/// What: `Live` → one OK line (email + access-token lifetime); `Dead` → a
+/// failure line plus the `gworkspace-mcp setup --profile <name>` command;
+/// `Unknown` → one graceful "could not determine" line (never fatal).
+/// Test: `health_lines_ok_shows_email`, `health_lines_dead_names_setup_command`,
+/// `health_lines_unknown_is_graceful`.
+pub fn health_lines(profile: &str, email: Option<&str>, result: &ProbeResult) -> Vec<String> {
+    let who = email.unwrap_or("email unknown");
+    match result {
+        ProbeResult::Live { expires_in } => {
+            let expiry = match expires_in {
+                Some(secs) => format!("access token valid ~{secs}s"),
+                None => "access token valid".to_string(),
+            };
+            vec![format!("[+] {profile}: OK ({who}, {expiry})")]
+        }
+        ProbeResult::Dead => vec![
+            format!("[!] {profile}: DEAD — refresh token for {who} is expired or revoked"),
+            format!("      re-authenticate with: gworkspace-mcp setup --profile {profile}"),
+        ],
+        ProbeResult::Unknown => vec![format!(
+            "[?] {profile}: UNKNOWN — could not reach Google to verify ({who}); check your connection"
+        )],
+    }
+}
+
 /// Render a pass/fail check mark.
 fn mark(ok: bool) -> char {
     if ok { '+' } else { '!' }
@@ -108,6 +253,56 @@ mod tests {
             lines
                 .iter()
                 .any(|l| l.contains("[+] Default profile selected"))
+        );
+    }
+
+    #[test]
+    fn health_lines_ok_shows_email() {
+        let lines = health_lines(
+            "work",
+            Some("user@example.com"),
+            &ProbeResult::Live {
+                expires_in: Some(3599),
+            },
+        );
+        let joined = lines.join("\n");
+        assert!(joined.contains("[+] work: OK"), "OK marker: {joined}");
+        assert!(joined.contains("user@example.com"), "email shown: {joined}");
+        assert!(joined.contains("3599s"), "expiry shown: {joined}");
+        assert!(
+            !joined.contains("setup --profile"),
+            "a healthy profile must not suggest re-auth: {joined}"
+        );
+    }
+
+    #[test]
+    fn health_lines_dead_names_setup_command() {
+        let lines = health_lines("work", Some("user@example.com"), &ProbeResult::Dead);
+        let joined = lines.join("\n");
+        assert!(joined.contains("DEAD"), "dead marker: {joined}");
+        assert!(joined.contains("expired or revoked"), "cause: {joined}");
+        assert!(
+            joined.contains("gworkspace-mcp setup --profile work"),
+            "must name the exact re-auth command for the dead profile: {joined}"
+        );
+    }
+
+    #[test]
+    fn health_lines_unknown_is_graceful() {
+        let lines = health_lines("work", None, &ProbeResult::Unknown);
+        let joined = lines.join("\n");
+        assert!(joined.contains("UNKNOWN"), "unknown marker: {joined}");
+        assert!(
+            joined.contains("could not reach Google"),
+            "graceful offline wording: {joined}"
+        );
+        assert!(
+            !joined.contains("DEAD"),
+            "unreachable must not be misreported as dead: {joined}"
+        );
+        assert!(
+            !joined.contains("setup --profile"),
+            "unknown must not push a re-auth (token may be fine): {joined}"
         );
     }
 }

--- a/crates/trusty-gworkspace/src/cli/mod.rs
+++ b/crates/trusty-gworkspace/src/cli/mod.rs
@@ -66,6 +66,11 @@ pub enum Command {
         /// one (a warning is printed naming the displaced profile).
         #[arg(long, conflicts_with = "no_default")]
         make_default: bool,
+        /// Do NOT launch a browser; print the consent URL for you to open
+        /// manually. Enables re-authenticating from a headless / in-session
+        /// context (the loopback callback still captures the redirect).
+        #[arg(long = "no-browser", visible_alias = "print-url")]
+        no_browser: bool,
     },
     /// Check OAuth client credentials and token state.
     Doctor,
@@ -111,6 +116,7 @@ pub async fn dispatch(command: Command) -> Result<()> {
             profile,
             no_default,
             make_default,
+            no_browser,
         } => {
             let profile = flow::effective_profile(profile.as_deref());
             let mode = if no_default {
@@ -120,7 +126,7 @@ pub async fn dispatch(command: Command) -> Result<()> {
             } else {
                 DefaultMode::Auto
             };
-            let outcome = run_consent(&storage, &profile, mode).await?;
+            let outcome = run_consent(&storage, &profile, mode, !no_browser).await?;
             let suffix = if outcome.default_applied {
                 " (default)"
             } else {
@@ -140,7 +146,7 @@ pub async fn dispatch(command: Command) -> Result<()> {
             }
             Ok(())
         }
-        Command::Doctor => doctor::run(&storage),
+        Command::Doctor => doctor::run(&storage).await,
         Command::Accounts { action } => match action {
             AccountsAction::List => accounts::list(&storage),
             AccountsAction::Default { name } => accounts::set_default(&storage, &name),
@@ -168,7 +174,7 @@ mod tests {
             Cli::try_parse_from(["gworkspace-mcp", "setup", "--profile", "work"]).expect("setup");
         assert!(matches!(
             setup.command,
-            Some(Command::Setup { profile: Some(p), no_default: false, make_default: false }) if p == "work"
+            Some(Command::Setup { profile: Some(p), no_default: false, make_default: false, no_browser: false }) if p == "work"
         ));
 
         let doctor = Cli::try_parse_from(["gworkspace-mcp", "doctor"]).expect("doctor");
@@ -206,6 +212,7 @@ mod tests {
                 profile: None,
                 no_default: true,
                 make_default: false,
+                no_browser: false,
             })
         ));
     }
@@ -220,6 +227,31 @@ mod tests {
                 profile: None,
                 no_default: false,
                 make_default: true,
+                no_browser: false,
+            })
+        ));
+    }
+
+    #[test]
+    fn setup_no_browser_flag_parses() {
+        let cli = Cli::try_parse_from(["gworkspace-mcp", "setup", "--no-browser"]).expect("parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Setup {
+                no_browser: true,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn setup_print_url_alias_parses() {
+        let cli = Cli::try_parse_from(["gworkspace-mcp", "setup", "--print-url"]).expect("parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Setup {
+                no_browser: true,
+                ..
             })
         ));
     }


### PR DESCRIPTION
Polishes the native re-auth path (`gworkspace-mcp setup`, #2659) so it is discoverable and runnable from within a Claude/tm session. Four items:

## 1. Actionable `invalid_grant` error in `refresh()`
`OAuthManager::refresh()` previously echoed the raw HTTP body with no guidance. It now routes failures through the **same** `sanitize_oauth_error` helper the consent path uses (extracted, with `is_invalid_grant` + `refresh_failure_message`, into a new shared `api/auth/oauth/errors.rs`). On `invalid_grant` it returns:

```
Google refresh token for profile 'work' is expired or revoked — re-authenticate with: gworkspace-mcp setup --profile work (400 Bad Request invalid_grant: Token has been expired or revoked.)
```

Non-`invalid_grant` failures stay a sanitized error with **no** re-auth hint (no misattribution).

## 2. `doctor` live-probe
`doctor` now live-probes each stored profile's refresh token (read-only — never rewrites `tokens.json`, bounded per-profile timeout) and reports **OK** (email + access-token lifetime) / **DEAD** / **UNKNOWN**. A DEAD profile prints the exact `gworkspace-mcp setup --profile <name>` command; when Google is unreachable it degrades to UNKNOWN instead of failing the diagnostic. Static creds/accounts/default checks preserved. `doctor::run` is now async.

## 3. `setup --print-url` (no-browser) mode
New `--print-url` flag (alias `--no-browser`) skips the browser launch and prints the full consent URL (PKCE challenge, state, redirect_uri) for the user to open manually — enabling re-auth from a headless / in-session context. The loopback callback still binds and captures the redirect exactly as today. The printed URL is byte-identical to the auto-open URL (only the browser-launch step is gated by the flag).

## 4. README refresh
Auth section rewritten for the native flow (`setup`/`doctor`/`accounts`), correct env vars (`GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET`), correct **flat** `tokens.json` (profile→StoredToken) and `oauth_client.json` shapes, multi-profile usage, and a "re-authenticating from within a session" note. Stale Python-delegation content removed.

## Notes
- `flow.rs` split into `flow/mod.rs` + `flow/tests.rs` to stay under the 500-SLOC production cap.
- New unit tests: `refresh_failure_message_names_profile_and_setup_command`, `refresh_failure_message_non_invalid_grant_has_no_hint`, `detects_invalid_grant`, `health_lines_{ok,dead,unknown}_*`, `consent_prompt_url_is_identical_regardless_of_browser_mode`, `setup_no_browser_flag_parses` / `setup_print_url_alias_parses`.

## Verification
- `cargo build --workspace` — clean
- `cargo test -p trusty-gworkspace` — 217 passed
- `cargo test --workspace` — 14917 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations
- `bash scripts/check_test_pointers.sh` — 0 dangling pointers

Closes #2742

🤖 Generated with [Claude Code](https://claude.com/claude-code)