### PR TITLE
chore(trusty-gworkspace): bump to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11007,7 +11007,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-gworkspace"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/tc-services/Cargo.toml
+++ b/crates/tc-services/Cargo.toml
@@ -25,7 +25,7 @@ trusty-cto-db = { path = "../trusty-cto-db", version = "0.1.3" }
 reqwest = { workspace = true }
 # `trusty-gworkspace` provides the authenticated Google API client; the
 # `gworkspace` module is a thin schema-emission + dispatch bridge over it.
-trusty-gworkspace = { path = "../trusty-gworkspace", version = "0.1.3" }
+trusty-gworkspace = { path = "../trusty-gworkspace", version = "0.2.0" }
 # `async-openai` is intentionally NOT a dependency: tc-services only emits
 # OpenAI-compatible function schemas as `serde_json::Value`. Hosts that need
 # the typed async-openai representation (e.g. open-mpm) own that bridge.

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-gworkspace"
-version = "0.1.3"
+version = "0.2.0"
 publish = false
 edition = "2024" # edition 2024 required: let-chains used in api/client.rs, api/services/gmail/, api/services/docs/ (issue #258)
 description = "Google Workspace MCP server for the Trusty suite"


### PR DESCRIPTION
## Summary
- Version bump for trusty-gworkspace: 0.1.3 -> 0.2.0 (minor), covering #2750's user-facing features (`setup --print-url`/`--no-browser`, `doctor` live-probe).
- Syncs the `tc-services` path-dep version pin to match.
- `publish = false` for this crate — install-only release, no crates.io publish.

## Test plan
- [x] `cargo test -p trusty-gworkspace` — 217 passed, 0 failed
- [x] `cargo clippy -p trusty-gworkspace -p tc-services -- -D warnings` — clean