### PR TITLE
fix(trusty-mpm): positive stdio field allowlist for fleet native-MCP injection (code-critic follow-up to #2748)

### DIFF
--- a/crates/trusty-mpm/src/core/session_launch/native_mcp.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp.rs
@@ -59,7 +59,10 @@
 //! What: [`inject_native_trusty_mcps`] reads the managed `.claude.json`
 //! `mcpServers` map (via the SAME [`crate::core::mcp_config`] reader `tm mcp`
 //! uses), filters it to the [`NATIVE_TRUSTY_MCP_SERVERS`] allowlist, and for
-//! each match splits the entry via [`split_public_and_secret_env`]: the
+//! each match splits the entry via [`split_public_and_secret_env`], which also
+//! validates it as a stdio + env-auth server (a positive field allowlist —
+//! `type`/`command`/`args`/`env` only — rejects any registration carrying a
+//! secret-bearing field like `url`/`headers`): the
 //! `env`-free command/args/type shape merges idempotently into
 //! `<workspace>/.mcp.json` via [`super::settings::inject_mcp_server`]; any `env`
 //! entries are collected and merged into `<workspace>/.env.local` via
@@ -169,10 +172,13 @@ pub(super) fn inject_native_trusty_mcps(
 /// What: reads the managed `mcpServers` map via [`mcp_config::list_servers`]
 /// (which quarantines a malformed `.claude.json` and yields an empty map when the
 /// file is absent). For each entry whose NAME is in
-/// [`NATIVE_TRUSTY_MCP_SERVERS`], [`split_public_and_secret_env`] separates the
-/// entry into an `env`-free public shape (merged into `.mcp.json` via
-/// [`inject_mcp_server`]) and its `env` map (collected across all matched
-/// servers). When any secrets were collected, [`route_native_mcp_secrets`]
+/// [`NATIVE_TRUSTY_MCP_SERVERS`], [`split_public_and_secret_env`] validates it as
+/// a stdio + env-auth server and separates the entry into an `env`-free public
+/// shape (merged into `.mcp.json` via [`inject_mcp_server`]) and its `env` map
+/// (collected across all matched servers); a registration that fails that
+/// validation (non-stdio `type`, missing `command`, or a non-allowlisted field
+/// like `url`/`headers`) is REJECTED wholesale — nothing is written for it.
+/// When any secrets were collected, [`route_native_mcp_secrets`]
 /// merges them into the workspace `.env.local`. Non-allowlisted
 /// (third-party/HTTP) servers are skipped, and `trusty-memory` / `trusty-search`
 /// are never touched here (their dedicated injectors own them). Injection order
@@ -198,9 +204,13 @@ pub(super) fn inject_native_trusty_mcps_from(
     let mut secret_env: BTreeMap<String, String> = BTreeMap::new();
     for &name in NATIVE_TRUSTY_MCP_SERVERS {
         if let Some(entry) = servers.get(name) {
-            let (public_entry, env) = split_public_and_secret_env(entry, name);
-            inject_mcp_server(project_path, name, public_entry)?;
-            secret_env.extend(env);
+            // `None` = the registration failed the stdio+env-auth validation
+            // (non-stdio type, missing command, or a non-allowlisted field like
+            // url/headers) and was rejected wholesale — nothing is written for it.
+            if let Some((public_entry, env)) = split_public_and_secret_env(entry, name) {
+                inject_mcp_server(project_path, name, public_entry)?;
+                secret_env.extend(env);
+            }
         }
     }
 
@@ -210,41 +220,139 @@ pub(super) fn inject_native_trusty_mcps_from(
     Ok(())
 }
 
-/// Split a managed registry entry into an `env`-free public shape and its
-/// secret `env` map.
+/// The ONLY top-level fields an injected native registration may carry.
 ///
-/// Why (code-critic BLOCK on #2739): the managed registry's `env` block is
-/// where live secrets (`SLACK_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN`, …) live. Every
-/// value there is treated as a secret categorically — never split by a
-/// key-name heuristic (`*_TOKEN`, `*_SECRET`, …) — because a heuristic has
-/// false negatives and a single missed key is a real credential leak into a
-/// tracked file; a category-wide rule can't have that failure mode. Today none
-/// of the four allowlisted servers need a non-secret env var in `.mcp.json`
-/// (`gworkspace-mcp`/`trusty-analyze` carry no `env` at all in practice), so
-/// this costs nothing real yet — a future native server that legitimately needs
-/// a non-secret, committable env var would need an explicit carve-out here, not
-/// silent inclusion.
-/// What: clones `entry`, removes its top-level `env` key (if any and if it is a
-/// JSON object) from the clone, and returns `(entry_without_env,
-/// string_valued_env_map)`. A non-string env value is skipped with a `warn!`
-/// (never propagated into `.mcp.json` either) — the `env` schema for an MCP
-/// server is always `Record<string, string>`, so a non-string value indicates a
-/// malformed registry entry, not a legitimate secret to route.
+/// Why (code-critic residual HIGH on #2739): stripping just the `env` key is
+/// not enough — a token can also ride in `url`, `headers`, or any other field
+/// of a registration, and those would pass verbatim into the git-tracked
+/// `.mcp.json`. Enumerating the permitted fields POSITIVELY (rather than
+/// blocklisting `url`/`headers`) means a NEW secret-bearing field invented
+/// upstream fails closed by default: it is not on this list, so the whole
+/// registration is rejected rather than leaked. Injection is thereby narrowed
+/// to exactly the stdio + env-auth shape — the only shape the four native
+/// servers actually use.
+/// What: `type`, `command`, `args`, `env`. `env` is extracted to `.env.local`
+/// (never written to `.mcp.json`); the rest form the committable public shape.
+/// Test: `split_public_and_secret_env_rejects_url_bearing_entry`,
+/// `split_public_and_secret_env_rejects_header_bearing_entry`,
+/// `split_public_and_secret_env_rejects_unknown_field`.
+const INJECTABLE_STDIO_FIELDS: &[&str] = &["type", "command", "args", "env"];
+
+/// Validate an allowlisted registration as a stdio + env-auth server and split
+/// it into an `env`-free public shape plus its secret `env` map — or reject it.
+///
+/// Why (code-critic BLOCK + residual HIGH on #2739): two distinct leak classes
+/// are closed here.
+///   (1) The managed registry's `env` block is where live secrets
+///   (`SLACK_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN`, …) live. Every value there is
+///   treated as a secret CATEGORICALLY — never split by a key-name heuristic
+///   (`*_TOKEN`, `*_SECRET`, …) — because a heuristic has false negatives and a
+///   single missed key is a real credential leak into a tracked file; a
+///   category-wide rule can't have that failure mode.
+///   (2) A token can also ride OUTSIDE `env` — in a `url`, `headers`, or any
+///   other field of the registration. Rather than stripping only `env` (which
+///   would pass such a field verbatim into `.mcp.json`), this constrains
+///   injection to the stdio + env-auth shape via a POSITIVE field allowlist
+///   ([`INJECTABLE_STDIO_FIELDS`]): a registration is REJECTED outright (skipped,
+///   with a `warn!` to stderr — never partially injected) when it declares a
+///   non-`stdio` `type`, omits a string `command`, or carries ANY field outside
+///   the allowlist (e.g. `url`/`headers`, the http-server shape). This is the
+///   actual guarantee: the ONLY bytes that ever reach `.mcp.json` are a
+///   `type`/`command`/`args` stdio triple; every secret channel (`env`, and now
+///   any out-of-band field) is either routed to `.env.local` or rejected
+///   wholesale. `args` is the one field passed through verbatim: it defines the
+///   stdio invocation itself, and argv is not a credential channel for these
+///   native servers (they all take secrets via `env`/`resolve_key`, and argv is
+///   world-readable via `ps` so no sane server accepts a token there) — a value
+///   the operator placed in `args` via their own `tm mcp add` is their explicit
+///   command shape, not a secret to strip.
+/// What: returns `Some((public_shape, secret_env))` for a valid stdio server, or
+/// `None` (logged) to reject. `public_shape` is built POSITIVELY from only the
+/// non-secret allowlisted fields present (`type`/`command`/`args`), so no
+/// unexpected field can survive even if the allowlist check is later loosened.
+/// A non-string `env` value is skipped with a `warn!` (never propagated to
+/// `.mcp.json` OR `.env.local`) — the `env` schema is always
+/// `Record<string, string>`, so a non-string value is a malformed entry, not a
+/// secret to route.
 /// Test: `inject_native_strips_secret_env_from_mcp_json`,
 /// `inject_native_no_env_key_when_source_has_none`,
 /// `split_public_and_secret_env_separates_env_from_shape`,
-/// `split_public_and_secret_env_skips_non_string_values`.
+/// `split_public_and_secret_env_skips_non_string_values`,
+/// `split_public_and_secret_env_rejects_url_bearing_entry`,
+/// `split_public_and_secret_env_rejects_header_bearing_entry`,
+/// `split_public_and_secret_env_rejects_unknown_field`,
+/// `split_public_and_secret_env_rejects_non_stdio_type`,
+/// `split_public_and_secret_env_rejects_missing_command`,
+/// `inject_native_rejects_url_bearing_allowlisted_server`.
 pub(super) fn split_public_and_secret_env(
     entry: &Value,
     server_name: &str,
-) -> (Value, BTreeMap<String, String>) {
-    let mut public_entry = entry.clone();
-    let mut secret_env = BTreeMap::new();
+) -> Option<(Value, BTreeMap<String, String>)> {
+    let Some(obj) = entry.as_object() else {
+        tracing::warn!(
+            server = server_name,
+            "refusing to inject native trusty MCP server: registration is not a JSON object \
+             (never routed to .mcp.json)"
+        );
+        return None;
+    };
 
-    if let Some(obj) = public_entry.as_object_mut()
-        && let Some(env_value) = obj.remove("env")
-        && let Some(env_obj) = env_value.as_object()
+    // Positive field allowlist: any field outside the stdio + env-auth shape
+    // (e.g. `url`/`headers` of an http server) means the registration could
+    // carry a secret we do NOT strip — reject the whole entry rather than leak.
+    if let Some(bad_field) = obj
+        .keys()
+        .find(|k| !INJECTABLE_STDIO_FIELDS.contains(&k.as_str()))
     {
+        tracing::warn!(
+            server = server_name,
+            field = %bad_field,
+            "refusing to inject native trusty MCP server: registration carries a field outside \
+             the stdio+env-auth allowlist (e.g. url/headers) that could hold a secret; only \
+             stdio command servers are injected (never routed to .mcp.json)"
+        );
+        return None;
+    }
+
+    // `type`, if present, must be exactly `stdio` (a token-bearing http/sse
+    // server declares `type: "http"` and carries its secret in url/headers).
+    if let Some(ty) = obj.get("type")
+        && ty.as_str() != Some("stdio")
+    {
+        tracing::warn!(
+            server = server_name,
+            "refusing to inject native trusty MCP server: `type` is not `stdio` \
+             (never routed to .mcp.json)"
+        );
+        return None;
+    }
+
+    // A stdio server MUST name a string command; without one there is nothing
+    // safe to inject.
+    let Some(command) = obj.get("command").filter(|c| c.is_string()) else {
+        tracing::warn!(
+            server = server_name,
+            "refusing to inject native trusty MCP server: no string `command` \
+             (never routed to .mcp.json)"
+        );
+        return None;
+    };
+
+    // Build the public shape POSITIVELY — only the non-secret allowlisted
+    // fields, so nothing unexpected can ride along even if the guard above is
+    // later relaxed.
+    let mut public = serde_json::Map::new();
+    if let Some(ty) = obj.get("type") {
+        public.insert("type".to_string(), ty.clone());
+    }
+    public.insert("command".to_string(), command.clone());
+    if let Some(args) = obj.get("args") {
+        public.insert("args".to_string(), args.clone());
+    }
+
+    // Extract the secret env map (routed to `.env.local`, never `.mcp.json`).
+    let mut secret_env = BTreeMap::new();
+    if let Some(env_obj) = obj.get("env").and_then(Value::as_object) {
         for (key, value) in env_obj {
             match value.as_str() {
                 Some(s) => {
@@ -260,7 +368,7 @@ pub(super) fn split_public_and_secret_env(
         }
     }
 
-    (public_entry, secret_env)
+    Some((Value::Object(public), secret_env))
 }
 
 /// Merge collected native-server secrets into the workspace `.env.local`,
@@ -344,11 +452,16 @@ fn route_native_mcp_secrets(
 /// authority on whether a path would be excluded from `git add`, so this is
 /// the same check a human would run to verify the guarantee, not a
 /// reimplementation of git's ignore-resolution rules.
-/// What: runs `git -C <project_path> check-ignore -q -- .env.local` and
-/// returns whether it exited `0` (ignored). Any non-zero exit — including
-/// "not ignored" (which is what a tracked file, or a file with no matching
-/// ignore rule, both report) and a hard error (not a repo, no `git` binary) —
-/// is treated as `false`. Never panics.
+/// What: runs `git -C <project_path> check-ignore -q -- .env.local` via
+/// `.output()` (NOT `.status()`) — capturing the child's stdout/stderr into
+/// buffers instead of letting them inherit this process's file descriptors —
+/// and returns whether it exited `0` (ignored). Capturing matters because this
+/// runs inside the daemon/MCP process whose stdout must stay clean for JSON-RPC
+/// framing (`-q` suppresses check-ignore's normal output, but `.output()`
+/// guarantees nothing the child writes can reach our stdout regardless). Any
+/// non-zero exit — including "not ignored" (which is what a tracked file, or a
+/// file with no matching ignore rule, both report) and a hard error (not a repo,
+/// no `git` binary) — is treated as `false`. Never panics.
 /// Test: `inject_native_skips_secrets_when_env_local_is_tracked`,
 /// `is_env_local_actually_ignored_true_when_excluded`,
 /// `is_env_local_actually_ignored_false_when_tracked`.
@@ -357,8 +470,8 @@ pub(super) fn is_env_local_actually_ignored(project_path: &Path) -> bool {
         .arg("-C")
         .arg(project_path)
         .args(["check-ignore", "-q", "--", ENV_LOCAL_FILENAME])
-        .status()
-        .is_ok_and(|status| status.success())
+        .output()
+        .is_ok_and(|output| output.status.success())
 }
 
 /// Ensure `.env.local` is listed in the workspace's real `info/exclude` file.

--- a/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
@@ -593,7 +593,8 @@ fn split_public_and_secret_env_separates_env_from_shape() {
         "env": { "SLACK_BOT_TOKEN": FAKE_SLACK_TOKEN, "SLACK_USER_TOKEN": "xoxp-also-secret" }
     });
 
-    let (public, secrets) = split_public_and_secret_env(&entry, "slack-mcp");
+    let (public, secrets) =
+        split_public_and_secret_env(&entry, "slack-mcp").expect("valid stdio server is accepted");
 
     assert!(
         public.get("env").is_none(),
@@ -623,11 +624,103 @@ fn split_public_and_secret_env_skips_non_string_values() {
         "env": { "GOOD": "value", "BAD": 42 }
     });
 
-    let (public, secrets) = split_public_and_secret_env(&entry, "weird-mcp");
+    let (public, secrets) =
+        split_public_and_secret_env(&entry, "weird-mcp").expect("valid stdio server is accepted");
 
     assert!(public.get("env").is_none());
     assert_eq!(secrets.get("GOOD").map(String::as_str), Some("value"));
     assert!(!secrets.contains_key("BAD"), "non-string value dropped");
+}
+
+// ── split_public_and_secret_env: positive field-allowlist rejection ─────────
+
+#[test]
+fn split_public_and_secret_env_rejects_url_bearing_entry() {
+    // Why (code-critic residual HIGH, #2739): a token can ride in `url`, not just
+    // `env`. An entry carrying a `url` field (the http-server shape) must be
+    // REJECTED wholesale — never partially injected — so the url (and any secret
+    // inside it) never reaches the git-tracked `.mcp.json`.
+    let entry = json!({
+        "type": "http",
+        "url": format!("https://evil.example/mcp?token={FAKE_SLACK_TOKEN}")
+    });
+
+    assert!(
+        split_public_and_secret_env(&entry, "poisoned-http").is_none(),
+        "a url-bearing (http) registration must be rejected, not injected"
+    );
+}
+
+#[test]
+fn split_public_and_secret_env_rejects_header_bearing_entry() {
+    // Why (#2739): an Authorization header is the classic HTTP secret channel.
+    // Even paired with a `command`, a `headers` field is outside the stdio
+    // allowlist → reject the whole entry.
+    let entry = json!({
+        "type": "stdio",
+        "command": "slack-mcp",
+        "headers": { "Authorization": format!("Bearer {FAKE_SLACK_TOKEN}") }
+    });
+
+    assert!(
+        split_public_and_secret_env(&entry, "poisoned-headers").is_none(),
+        "a headers-bearing registration must be rejected, not injected"
+    );
+}
+
+#[test]
+fn split_public_and_secret_env_rejects_unknown_field() {
+    // Why (#2739): the allowlist is POSITIVE — a brand-new field invented
+    // upstream fails closed. Anything outside type/command/args/env rejects.
+    let entry = json!({
+        "type": "stdio",
+        "command": "slack-mcp",
+        "authToken": FAKE_SLACK_TOKEN
+    });
+
+    assert!(
+        split_public_and_secret_env(&entry, "poisoned-unknown").is_none(),
+        "an entry with a field outside the allowlist must be rejected"
+    );
+}
+
+#[test]
+fn split_public_and_secret_env_rejects_non_stdio_type() {
+    // Why (#2739): a `type` other than `stdio` signals a transport that carries
+    // credentials outside `env` (http/sse) — reject.
+    let entry = json!({ "type": "sse", "command": "slack-mcp" });
+
+    assert!(
+        split_public_and_secret_env(&entry, "sse-server").is_none(),
+        "a non-stdio type must be rejected"
+    );
+}
+
+#[test]
+fn split_public_and_secret_env_rejects_missing_command() {
+    // Why (#2739): a stdio server with no string `command` has nothing safe to
+    // inject — reject rather than emit a malformed `.mcp.json` entry.
+    let entry = json!({ "type": "stdio", "args": ["serve"] });
+
+    assert!(
+        split_public_and_secret_env(&entry, "no-command").is_none(),
+        "a registration without a string command must be rejected"
+    );
+}
+
+#[test]
+fn split_public_and_secret_env_accepts_bare_stdio_without_type() {
+    // Why (#2739): `type` is optional in a stdio `.mcp.json` entry; a bare
+    // command+args entry (no explicit `type`) is the common shape and must be
+    // accepted, with the public shape carrying no synthesised `type`.
+    let entry = json!({ "command": "gworkspace-mcp", "args": [] });
+
+    let (public, secrets) = split_public_and_secret_env(&entry, "gworkspace-mcp")
+        .expect("a bare stdio command entry is accepted");
+
+    assert!(public.get("type").is_none(), "no type synthesised");
+    assert_eq!(public["command"], json!("gworkspace-mcp"));
+    assert!(secrets.is_empty());
 }
 
 // ── ensure_env_local_git_excluded: direct unit coverage ─────────────────────
@@ -717,5 +810,95 @@ fn merge_env_file_is_idempotent_when_unchanged() {
     assert_eq!(
         first, second,
         "re-merging already-merged content is a no-op"
+    );
+}
+
+#[test]
+fn quote_env_value_round_trips_special_characters_through_dotenvy() {
+    // Why (code-critic LOW, #2739): the whole secret-delivery path is worthless
+    // if a token with shell/env-syntax metacharacters (`"`, `\`, `#`) round-trips
+    // to a DIFFERENT value than what the operator's `tm mcp add` stored. This
+    // proves the exact contract: a value written by `quote_env_value` (via
+    // `merge_env_file`) into a real `.env.local` is read back BYTE-FOR-BYTE by
+    // the SAME reader the native servers use —
+    // `trusty_common::inference::credentials::read_var_from_env_local` (dotenvy).
+    let ws = tempdir().unwrap();
+    let nasty_token = r#"xoxb-a"b\c#d-token"#;
+    let mut updates = BTreeMap::new();
+    updates.insert("SLACK_BOT_TOKEN".to_string(), nasty_token.to_string());
+
+    // Write it exactly as the injector would.
+    let content = merge_env_file("", &updates);
+    let env_local = ws.path().join(".env.local");
+    std::fs::write(&env_local, &content).unwrap();
+
+    // Read it back via the production reader (dotenvy) — must be verbatim.
+    let read_back = trusty_common::inference::credentials::read_var_from_env_local(
+        &env_local,
+        "SLACK_BOT_TOKEN",
+    )
+    .expect("the reader must find the key");
+    assert_eq!(
+        read_back, nasty_token,
+        "a token with \", \\ and # must round-trip verbatim through .env.local; \
+         file content was: {content}"
+    );
+}
+
+#[test]
+fn inject_native_rejects_url_bearing_allowlisted_server() {
+    // Why (code-critic residual HIGH, #2739): the leak scenario end-to-end — an
+    // ALLOWLISTED server name (`slack-mcp`) whose managed registration was
+    // poisoned with a token-bearing `url` (the http shape). The positive field
+    // allowlist must reject it wholesale: neither the url NOR the token may reach
+    // the git-tracked `.mcp.json`, and no `.env.local` is written for it either.
+    let cfg = tempdir().unwrap();
+    let ws = tempdir().unwrap();
+    git_init(ws.path());
+    std::fs::create_dir_all(cfg.path()).unwrap();
+    std::fs::write(
+        cfg.path().join(".claude.json"),
+        serde_json::to_string_pretty(&json!({
+            "mcpServers": {
+                "slack-mcp": {
+                    "type": "http",
+                    "url": format!("https://evil.example/mcp?token={FAKE_SLACK_TOKEN}")
+                },
+                "gworkspace-mcp": { "type": "stdio", "command": "gworkspace-mcp", "args": [] }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    inject_native_trusty_mcps_from(ws.path(), cfg.path()).expect("injection succeeds");
+
+    // The poisoned server was rejected; only the clean stdio native landed.
+    let servers = read_injected(ws.path());
+    assert!(
+        !servers.contains_key("slack-mcp"),
+        "a url-bearing allowlisted server must be rejected, not injected"
+    );
+    assert!(
+        servers.contains_key("gworkspace-mcp"),
+        "clean native still lands"
+    );
+
+    // The raw token never reaches .mcp.json in any form.
+    let mcp_json = std::fs::read_to_string(ws.path().join(".mcp.json")).unwrap();
+    assert!(
+        !mcp_json.contains(FAKE_SLACK_TOKEN),
+        ".mcp.json must not contain the url-borne token: {mcp_json}"
+    );
+    assert!(
+        !mcp_json.contains("evil.example"),
+        ".mcp.json must not contain the poisoned url: {mcp_json}"
+    );
+
+    // And no .env.local was written for the rejected server (it had no `env`,
+    // and gworkspace-mcp carries no secret either).
+    assert!(
+        !ws.path().join(".env.local").exists(),
+        "no secret env collected → no .env.local"
     );
 }


### PR DESCRIPTION
## Context

Follow-up to **PR #2748** (fleet native-MCP propagation with `.env.local` secret routing, closes #2739), which was squash-merged to `main` (commit `0a87f1d7`) carrying the ORIGINAL code — so an adversarial **code-critic WARN** on that PR is now live in `main` and unaddressed. This PR addresses it.

## REQUIRED-1 (HIGH) — env-only strip leaked out-of-band token channels

`split_public_and_secret_env` previously removed ONLY the `env` key, so a token carried in `url`, `headers`, or any other field of an allowlisted registration passed verbatim into the git-tracked `.mcp.json` (one `git add -A && push` from leaking).

**Fix:** replace the env-only strip with a **positive field allowlist** (`type`/`command`/`args`/`env`). A registration is now **rejected wholesale** (skipped + `warn!` to stderr, never partially injected) when it:
- declares a `type` other than `stdio`,
- omits a string `command`, or
- carries ANY field outside the allowlist (e.g. `url`/`headers` — the http-server shape).

The public shape written to `.mcp.json` is **built positively** from only the non-secret allowlisted fields, so nothing unexpected survives even if the guard is later loosened. Injection is thereby narrowed to exactly the stdio + env-auth shape the four native servers actually use.

**`args` policy (documented):** `args` passes through verbatim — it defines the stdio invocation itself, and argv is not a credential channel for these native servers (they all take secrets via `env`/`resolve_key`, and argv is world-readable via `ps`). A value the operator placed in `args` via their own `tm mcp add` is their explicit command shape, not a secret to strip.

The module/function doc overclaim was corrected to state the actual guarantee (a positive allowlist that fails closed), not a heuristic claim.

## REQUIRED-2 (HIGH) — VERIFIED: native servers DO read `.env.local`

The critic flagged that `trusty-channels` was "not in this workspace" with `resolve_key` having "zero in-repo callers". **That is stale** — verified against reality:

- `trusty-channels` **IS** in the workspace (`crates/trusty-channels/`) and produces the `slack-mcp` / `telegram-mcp` binaries (confirmed via `cargo install --list` → `trusty-channels v0.1.0 … slack-mcp, telegram-mcp`).
- Its clients call `resolve_key`: `crates/trusty-channels/src/slack/api/client.rs:88-89` (`SLACK_PROVIDER`, `SLACK_USER_PROVIDER`) and `.../telegram/api/client.rs:70` (`TELEGRAM_PROVIDER`).
- `resolve_key` (`crates/trusty-common/src/inference/credentials/resolver.rs:73`) calls `dotenv::load_env_local_once()`, which searches upward from the process cwd via `find_workspace_env_local` and loads `.env.local` through `dotenvy::from_path` — then `resolve_key_with` → `env_tier` → `std::env::var(SLACK_BOT_TOKEN)` reflects the loaded value. `env_var_for` maps `slack`→`SLACK_BOT_TOKEN`, `slack-user`→`SLACK_USER_TOKEN`, `telegram`→`TELEGRAM_BOT_TOKEN`.

**Conclusion:** an `.env.local` written at the workspace root IS read by `slack-mcp`/`telegram-mcp` when Claude Code spawns them with the workspace as cwd. The design premise holds; no rework needed.

## Cheap LOWs

- (a) `is_env_local_actually_ignored` now uses `.output()` instead of `.status()` so the `git check-ignore` child never inherits the daemon's stdout (JSON-RPC framing must stay clean).
- (b) Added a round-trip test proving a token containing `"`, `\`, `#` written by `quote_env_value` reads back **verbatim** through dotenvy via the production reader `read_var_from_env_local`.

## Tests added

`split_public_and_secret_env_rejects_{url_bearing,header_bearing,unknown_field,non_stdio_type,missing_command}_*`, `split_public_and_secret_env_accepts_bare_stdio_without_type`, `inject_native_rejects_url_bearing_allowlisted_server` (end-to-end poisoned allowlisted server), `quote_env_value_round_trips_special_characters_through_dotenvy`.

## Deferred (follow-up #2754)

Two MEDIUMs, both latent today (gworkspace-mcp/trusty-analyze carry no `env` in practice): (i) those two read creds via plain `std::env::var`, not `.env.local`, so categorical env-stripping would silently break them if they ever carry env; (ii) name-based allowlist + trust preseed auto-trusts an injected `command` path — add a command-path sanity gate.

## Gates (raw)

- `cargo build -p trusty-mpm` → Finished OK
- `cargo test -p trusty-mpm` → 34 `test result: ok`, 0 FAILED (exit 0)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` → exit 0
- `cargo fmt --check -p trusty-mpm` → exit 0
- `bash scripts/check_line_cap.sh` → `9 allowlisted, 0 violations — OK`
- `cargo check --workspace` → exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools