### PR TITLE
feat(trusty-code): incremental re-index of files written during a task

### DIFF
--- a/crates/trusty-code/src/tools/fs/edit.rs
+++ b/crates/trusty-code/src/tools/fs/edit.rs
@@ -14,7 +14,10 @@
 //! present in the tool-call arguments (`old_string`+`new_string`, `diff`, or
 //! `content`), and delegates to `edit_format::select_and_apply` to pick and
 //! apply the best-fit format, then writes the result back. All paths are
-//! scoped to the working directory.
+//! scoped to the working directory. On success it also best-effort fires a
+//! mid-task incremental trusty-search index update for the edited path (issue:
+//! mid-task incremental re-indexing) so `search_code` reflects the edit within
+//! the same task.
 //! Test: See `#[cfg(test)]` below — covers each format, zero/ambiguous
 //! SEARCH/REPLACE errors, malformed-diff errors, and path traversal.
 
@@ -202,7 +205,13 @@ impl ToolExecutor for EditTool {
     /// What: Builds an `EditPayload` for each format present in `args`
     /// (`old_string`+`new_string`, `diff`, `content`), errors if none are
     /// present or `old_string`/`new_string` are only partially supplied, then
-    /// calls `edit_inner` and converts the result into a `ToolResult`.
+    /// calls `edit_inner` and converts the result into a `ToolResult`. On
+    /// success, best-effort fires a mid-task incremental trusty-search index
+    /// update (issue: mid-task incremental re-indexing) for the edited path so
+    /// `search_code` reflects the edit within the same task — this never
+    /// affects the returned `ToolResult`; see
+    /// [`trusty_common::search_index::index_files_best_effort`]'s fail-open
+    /// contract.
     /// Test: `edit_replaces_unique_match`, `edit_errors_on_zero_matches`,
     /// `edit_applies_unified_diff`, `edit_applies_whole_file`, etc.
     async fn execute(&self, args: Value) -> ToolResult {
@@ -243,7 +252,13 @@ impl ToolExecutor for EditTool {
         }
 
         match self.edit_inner(std::path::Path::new(path_str), &payloads) {
-            Ok(format) => ToolResult::ok(format!("edited {path_str} ({format})")),
+            Ok(format) => {
+                trusty_common::search_index::index_files_best_effort(
+                    &self.working_dir,
+                    &[PathBuf::from(path_str)],
+                );
+                ToolResult::ok(format!("edited {path_str} ({format})"))
+            }
             Err(e) => ToolResult::err(e.to_string()),
         }
     }

--- a/crates/trusty-code/src/tools/fs/write.rs
+++ b/crates/trusty-code/src/tools/fs/write.rs
@@ -6,17 +6,44 @@
 //! before anything touches the filesystem.
 //! What: `WriteFileTool` writes `content` to `path` (relative or absolute within
 //! `working_dir`), creating all missing parent directories. Existing files are
-//! overwritten atomically.
+//! overwritten atomically. On success it also best-effort fires a mid-task
+//! incremental trusty-search index update for the written path (issue:
+//! mid-task incremental re-indexing) so `search_code` sees code written
+//! during the task, not just what existed at task start.
 //! Test: See `#[cfg(test)]` below — covers new file, parent dir creation,
 //! overwrite, and path traversal.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use crate::tools::fs::{FsError, scoped_path};
 use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// Signature for the mid-task incremental index hook fired after a successful
+/// write (issue: mid-task incremental re-indexing).
+///
+/// Why: boxed as a trait object (not called inline) so tests can inject a
+/// closure that records its arguments and observe that `execute` actually
+/// invokes it, WITHOUT depending on trusty-search's real, process-global
+/// daemon-discovery mechanism (`TRUSTY_DATA_DIR_OVERRIDE` + the on-disk
+/// `http_addr` file). That mechanism is unsafe to mutate from a single test in
+/// this crate's parallel suite: once this hook is wired into `execute`, EVERY
+/// concurrently-running write-tool test would also attempt to resolve and
+/// notify whatever daemon address a test-under-observation happened to have
+/// configured at that instant, causing nondeterministic cross-talk between
+/// unrelated tests (observed directly while developing this hook — a
+/// TCP-mock-daemon-based first draft of this test intermittently captured
+/// ANOTHER test's write instead of its own). Mirrors `RecallSessionTool`'s
+/// existing `rpc_url` constructor-injection precedent in this same crate,
+/// generalised to a full callback since `trusty_common::search_index` has no
+/// injectable base-URL parameter.
+/// What: `(working_dir, paths)` — the exact arguments
+/// [`trusty_common::search_index::index_files_best_effort`] expects; the
+/// default (production) notifier is that function itself.
+type IndexNotifier = Arc<dyn Fn(&std::path::Path, &[PathBuf]) + Send + Sync>;
 
 /// `ToolExecutor` that creates or overwrites a file.
 ///
@@ -28,6 +55,7 @@ use crate::tools::traits::{ToolExecutor, ToolResult};
 /// Test: `cargo test -p trusty-code -- tools::fs::write`.
 pub struct WriteFileTool {
     working_dir: PathBuf,
+    index_notifier: IndexNotifier,
 }
 
 impl WriteFileTool {
@@ -35,12 +63,33 @@ impl WriteFileTool {
     ///
     /// Why: The working directory is the security boundary; it must be set at
     /// construction time and cannot be overridden per-call by the LLM.
-    /// What: Stores `working_dir`.
+    /// What: Stores `working_dir`; wires `index_notifier` to the real
+    /// production hook, [`trusty_common::search_index::index_files_best_effort`].
     /// Test: `write_creates_new_file`, et al.
     pub fn new(working_dir: impl Into<PathBuf>) -> Self {
         Self {
             working_dir: working_dir.into(),
+            index_notifier: Arc::new(trusty_common::search_index::index_files_best_effort),
         }
+    }
+
+    /// Override the mid-task incremental-index hook for testing.
+    ///
+    /// Why: lets a test observe that `execute` invokes the hook (and with
+    /// what arguments) on a successful write, without touching trusty-search's
+    /// real, process-global daemon-discovery state — see [`IndexNotifier`]'s
+    /// doc comment for why that matters in this crate's parallel test suite.
+    /// What: replaces `index_notifier`. Test-only (`#[cfg(test)]`); no
+    /// production call site can reach this.
+    /// Test: `write_file_success_triggers_incremental_index_update`,
+    /// `write_file_failure_does_not_trigger_incremental_index_update`.
+    #[cfg(test)]
+    fn with_index_notifier(
+        mut self,
+        notifier: impl Fn(&std::path::Path, &[PathBuf]) + Send + Sync + 'static,
+    ) -> Self {
+        self.index_notifier = Arc::new(notifier);
+        self
     }
 
     /// Write `content` to `path`, creating parent directories as needed.
@@ -101,7 +150,12 @@ impl ToolExecutor for WriteFileTool {
     ///
     /// Why: Writes content to a file within the working directory.
     /// What: Parses `{path, content}` from `args`, calls `write_inner`, and
-    /// converts the result into a `ToolResult`.
+    /// converts the result into a `ToolResult`. On success, best-effort fires
+    /// a mid-task incremental trusty-search index update (issue: mid-task
+    /// incremental re-indexing) for the written path so `search_code` can see
+    /// it within the same task — this never affects the returned
+    /// `ToolResult`; see [`trusty_common::search_index::index_files_best_effort`]'s
+    /// fail-open contract.
     /// Test: `write_creates_new_file`, `write_creates_parent_dirs`, etc.
     async fn execute(&self, args: Value) -> ToolResult {
         let Some(path_str) = args.get("path").and_then(Value::as_str) else {
@@ -112,7 +166,10 @@ impl ToolExecutor for WriteFileTool {
         };
 
         match self.write_inner(std::path::Path::new(path_str), content) {
-            Ok(()) => ToolResult::ok(format!("wrote {path_str}")),
+            Ok(()) => {
+                (self.index_notifier)(&self.working_dir, &[PathBuf::from(path_str)]);
+                ToolResult::ok(format!("wrote {path_str}"))
+            }
             Err(e) => ToolResult::err(e.to_string()),
         }
     }
@@ -221,5 +278,87 @@ mod tests {
         let names: Vec<&str> = required.iter().filter_map(Value::as_str).collect();
         assert!(names.contains(&"path"), "must require 'path'");
         assert!(names.contains(&"content"), "must require 'content'");
+    }
+
+    // ── Mid-task incremental re-index hook ──────────────────────────────────
+
+    /// Recorded `(working_dir, paths)` arguments from a test's injected
+    /// `index_notifier` closure.
+    type RecordedCalls = Arc<std::sync::Mutex<Vec<(PathBuf, Vec<PathBuf>)>>>;
+
+    /// A successful `write_file` invokes the mid-task incremental
+    /// trusty-search index hook exactly once, with the working directory and
+    /// the written path.
+    ///
+    /// Why: this is the acceptance criterion for the "search_code sees code
+    /// written during the task" feature — without this hook, `search_code`
+    /// only ever reflects the project's state at task start. Uses the
+    /// injectable `index_notifier` seam (see its doc comment) rather than a
+    /// real network daemon, so this test has zero dependence on process-global
+    /// state and cannot race with any other test in this crate's parallel
+    /// suite.
+    /// What: constructs a `WriteFileTool` with a notifier that records its
+    /// arguments into a shared `Vec`, writes a file, asserts the write
+    /// succeeded, and asserts the notifier fired exactly once with the
+    /// tool's `working_dir` and `[path]`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn write_file_success_triggers_incremental_index_update() {
+        let calls: RecordedCalls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = calls.clone();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = WriteFileTool::new(tmp.path()).with_index_notifier(move |root, paths| {
+            recorder
+                .lock()
+                .expect("lock")
+                .push((root.to_path_buf(), paths.to_vec()));
+        });
+
+        let result = tool
+            .execute(json!({"path": "src/lib.rs", "content": "pub fn hi() {}\n"}))
+            .await;
+        assert!(!result.is_error(), "{}", result.content());
+
+        let recorded = calls.lock().expect("lock");
+        assert_eq!(
+            recorded.len(),
+            1,
+            "the incremental-index hook must fire exactly once for a successful write"
+        );
+        let (root, paths) = &recorded[0];
+        assert_eq!(root, tmp.path());
+        assert_eq!(paths, &[PathBuf::from("src/lib.rs")]);
+    }
+
+    /// A FAILED `write_file` (path traversal) does NOT invoke the
+    /// incremental-index hook.
+    ///
+    /// Why: the hook only makes sense for content that actually landed on
+    /// disk; firing it for a rejected write would post stale-or-nonexistent
+    /// file state to the index.
+    /// What: constructs a `WriteFileTool` with a recording notifier, attempts
+    /// a traversal-escaping write, asserts it errors, and asserts the
+    /// notifier never fired.
+    /// Test: this test.
+    #[tokio::test]
+    async fn write_file_failure_does_not_trigger_incremental_index_update() {
+        let calls: RecordedCalls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = calls.clone();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tool = WriteFileTool::new(tmp.path()).with_index_notifier(move |root, paths| {
+            recorder
+                .lock()
+                .expect("lock")
+                .push((root.to_path_buf(), paths.to_vec()));
+        });
+
+        let result = tool
+            .execute(json!({"path": "../../evil.sh", "content": "harm"}))
+            .await;
+        assert!(result.is_error());
+        assert!(
+            calls.lock().expect("lock").is_empty(),
+            "the incremental-index hook must not fire for a failed write"
+        );
     }
 }

--- a/crates/trusty-code/src/tools/fs/write_files.rs
+++ b/crates/trusty-code/src/tools/fs/write_files.rs
@@ -10,7 +10,10 @@
 //! What: `WriteFilesTool` takes a `files` array of `{path, content}` objects,
 //! writes each (creating parent dirs) scoped to `working_dir`, and reports a
 //! per-file result. A failure on one file does not abort the others — every
-//! file's outcome is reported so the model can retry only what failed.
+//! file's outcome is reported so the model can retry only what failed. Every
+//! successfully written path is batched into ONE best-effort mid-task
+//! incremental trusty-search index update (issue: mid-task incremental
+//! re-indexing) so `search_code` sees the whole batch within the same task.
 //! Test: See `#[cfg(test)]` below — covers a multi-file write, partial failure,
 //! empty array, and path traversal.
 
@@ -124,7 +127,13 @@ impl ToolExecutor for WriteFilesTool {
     /// bad entry does not lose the successful writes.
     /// What: Parses `{files:[{path, content}, …]}`, writes each, and returns a
     /// per-file summary. Returns an error only when `files` is missing/not an
-    /// array, or when EVERY write failed.
+    /// array, or when EVERY write failed. Batches every SUCCESSFULLY written
+    /// path into ONE best-effort mid-task incremental trusty-search index
+    /// update (issue: mid-task incremental re-indexing) so `search_code` can
+    /// see the whole batch within the same task — this never affects the
+    /// returned `ToolResult`; see
+    /// [`trusty_common::search_index::index_files_best_effort`]'s fail-open
+    /// contract.
     /// Test: `write_files_writes_all`, `write_files_partial_failure`.
     async fn execute(&self, args: Value) -> ToolResult {
         let Some(files) = args.get("files").and_then(Value::as_array) else {
@@ -136,6 +145,7 @@ impl ToolExecutor for WriteFilesTool {
 
         let mut lines = Vec::with_capacity(files.len());
         let mut ok_count = 0usize;
+        let mut written_paths = Vec::with_capacity(files.len());
         for (i, entry) in files.iter().enumerate() {
             let path = entry.get("path").and_then(Value::as_str);
             let content = entry.get("content").and_then(Value::as_str);
@@ -144,6 +154,7 @@ impl ToolExecutor for WriteFilesTool {
                     Ok(()) => {
                         ok_count += 1;
                         lines.push(format!("wrote {p}"));
+                        written_paths.push(PathBuf::from(p));
                     }
                     Err(e) => lines.push(format!("FAILED {p}: {e}")),
                 },
@@ -151,6 +162,10 @@ impl ToolExecutor for WriteFilesTool {
                     "FAILED entry {i}: each element needs both 'path' and 'content'"
                 )),
             }
+        }
+
+        if !written_paths.is_empty() {
+            trusty_common::search_index::index_files_best_effort(&self.working_dir, &written_paths);
         }
 
         let summary = lines.join("\n");

--- a/crates/trusty-common/src/search_index.rs
+++ b/crates/trusty-common/src/search_index.rs
@@ -23,9 +23,21 @@
 //! unreachable/slow search daemon. The blocking HTTP calls run on dedicated OS
 //! threads so the function is safe to call from inside a tokio runtime.
 //!
+//! Mid-task incremental re-indexing: [`ensure_project_indexed`] runs once, at
+//! task start — for a greenfield project that starts EMPTY, that means
+//! `search_code` finds nothing the engineer writes DURING the task.
+//! [`index_files_best_effort`] complements it: called after each successful
+//! file write/edit, it POSTs just that file's fresh content to the daemon's
+//! cheap per-file `POST /indexes/{id}/index-file` endpoint (never a full
+//! reindex walk), so the growing codebase stays searchable within the same
+//! task. Same fail-open contract, and non-blocking by construction (spawns its
+//! own detached thread rather than relying on the caller to wrap it, since
+//! its call sites are tcode's tool executors, not a one-shot task-start hook).
+//!
 //! Test: `ensure_project_indexed_returns_derived_id_when_daemon_down`,
-//! `ensure_project_indexed_none_for_root`, and the `index_is_fresh_*` predicate
-//! tests in the `tests` module below.
+//! `ensure_project_indexed_none_for_root`, the `index_is_fresh_*` predicate
+//! tests, and the `index_files_inner_*` / `relative_index_path_*` /
+//! `index_file_request_body_*` tests in the `tests` module below.
 
 use std::path::Path;
 
@@ -84,6 +96,188 @@ pub fn ensure_project_indexed(project_root: &Path) -> Option<String> {
     }
 
     Some(index_id)
+}
+
+/// Best-effort, non-blocking incremental re-index of specific files into an
+/// ALREADY-REGISTERED trusty-search index (mid-task incremental re-indexing).
+///
+/// Why: [`ensure_project_indexed`] runs once at task start, when a greenfield
+/// project is often EMPTY — so `search_code` finds nothing the engineer goes
+/// on to write during the task. Re-registering (or fully reindexing) the
+/// whole project after every write would mean a full-tree walk per file
+/// (expensive); the daemon's per-file `POST /indexes/{id}/index-file`
+/// endpoint lets a caller add or update ONE file's chunks cheaply, so the
+/// growing codebase stays searchable within the same task.
+/// What: spawns ONE detached OS thread and returns immediately — the caller
+/// (a tool executor mid-turn) must never block or fail because trusty-search
+/// is unreachable or slow. Inside the thread, [`index_files_inner`] derives
+/// the same `(root, index_id)` [`ensure_project_indexed`] would (so this
+/// always targets the same index a task-start call already created) and
+/// POSTs each of `paths` to the daemon. A no-op with zero thread spawn when
+/// `paths` is empty.
+///
+/// Sensitive-path note (issue #2747): unlike `POST /indexes`, the per-file
+/// `index-file` endpoint does NOT re-run the sensitive-path denylist — it
+/// looks the index up by id in the daemon's in-memory registry
+/// (`crates/trusty-search/src/service/server/files.rs`'s `index_file_handler`
+/// calls `state.registry.get(&index_id)`, never `allowlist::is_denied`), so
+/// an index created under the #2747 `allow_sensitive_path` bypass (a tempdir
+/// root) accepts incremental updates unconditionally. No bypass flag is
+/// threaded through here because none is needed.
+/// Test: this function is a thin spawn wrapper (side-effect only, no return
+/// to assert); its logic is [`index_files_inner`], which the
+/// `index_files_inner_*` tests below exercise directly (synchronously, off
+/// the spawned thread) for determinism.
+pub fn index_files_best_effort(project_root: &Path, paths: &[std::path::PathBuf]) {
+    if paths.is_empty() {
+        return;
+    }
+    let project_root = project_root.to_path_buf();
+    let paths = paths.to_vec();
+    std::thread::spawn(move || {
+        index_files_inner(&project_root, &paths);
+    });
+}
+
+/// Synchronous body of [`index_files_best_effort`], run on its detached
+/// thread (or called directly by tests for determinism).
+///
+/// Why: split out so tests can exercise the fail-open branches (empty index
+/// id, undiscoverable daemon) synchronously, without waiting on — or racing
+/// — a spawned thread.
+/// What: derives `(root, index_id)` via [`crate::resolve_project_root`] /
+/// [`crate::derive_index_id`]; returns early (logged at debug) when the id is
+/// empty or [`crate::resolve_daemon_base_url`] finds no running daemon;
+/// otherwise, for each path, resolves it against `root`, reads its current
+/// content from disk (an unreadable file — e.g. deleted since the write —
+/// is logged at debug and skipped, not fatal to the batch), and POSTs it via
+/// [`best_effort_index_one_file`]. Every step fails open.
+/// Test: `index_files_inner_is_noop_for_empty_paths`,
+/// `index_files_inner_skips_when_index_id_empty`,
+/// `index_files_inner_skips_gracefully_when_daemon_down`.
+fn index_files_inner(project_root: &Path, paths: &[std::path::PathBuf]) {
+    if paths.is_empty() {
+        return;
+    }
+    let root = crate::resolve_project_root(project_root);
+    let index_id = crate::derive_index_id(&root);
+    if index_id.trim().is_empty() {
+        tracing::debug!(
+            "skipping incremental trusty-search index update: empty index id for {}",
+            root.display()
+        );
+        return;
+    }
+    let Some(base) = crate::resolve_daemon_base_url("trusty-search") else {
+        tracing::debug!(
+            "trusty-search daemon address not found; skipping incremental index \
+             update for '{index_id}' ({} file(s))",
+            paths.len()
+        );
+        return;
+    };
+
+    for path in paths {
+        let abs = if path.is_absolute() {
+            path.clone()
+        } else {
+            root.join(path)
+        };
+        let rel = relative_index_path(&root, &abs);
+        let content = match std::fs::read_to_string(&abs) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(
+                    "skipping incremental index update for {}: {e}",
+                    abs.display()
+                );
+                continue;
+            }
+        };
+        best_effort_index_one_file(&base, &index_id, &rel, &content);
+    }
+}
+
+/// Resolve `abs` to the path string the corpus stores for a file under `root`.
+///
+/// Why: the reindex walker stores every chunk's `file` field relative to the
+/// index root (`crates/trusty-search/src/service/walker.rs` strips the
+/// canonical root prefix); posting an absolute path here would create a
+/// duplicate, differently-keyed corpus entry for the same file instead of
+/// updating the one the walker already produced.
+/// What: strips `root` as a prefix and forward-slash-normalises the
+/// remainder; falls back to `abs` itself (lossy) when it does not live under
+/// `root` — should not happen for a working-directory-scoped tool write, but
+/// fails safe rather than panicking or silently dropping the update.
+/// Test: `relative_index_path_strips_root_prefix`,
+/// `relative_index_path_falls_back_for_paths_outside_root`.
+fn relative_index_path(root: &Path, abs: &Path) -> String {
+    abs.strip_prefix(root)
+        .unwrap_or(abs)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// POST `/indexes/{id}/index-file` for a single file; failures are logged,
+/// never propagated.
+///
+/// Why: mirrors [`best_effort_create_index`]'s fail-open contract for the
+/// per-file endpoint.
+/// What: issues a short-timeout blocking `POST
+/// {base}/indexes/{index_id}/index-file` with body `{path, content}` (built
+/// by [`index_file_request_body`]). Unlike [`best_effort_create_index`],
+/// this does NOT spawn-and-join its own nested OS thread: it is only ever
+/// reached from inside [`index_files_inner`]'s own detached thread (spawned
+/// by [`index_files_best_effort`]), which is already off any tokio runtime,
+/// so a direct blocking call here cannot trigger the "cannot drop a runtime
+/// in a context where blocking is not allowed" panic — nesting another
+/// spawn+join per file would only double the thread count for no benefit. A
+/// non-2xx response (including 404 for an unregistered/unknown index — e.g.
+/// the daemon restarted since task start) or transport error is logged at
+/// warn and swallowed.
+/// Test: exercised via `index_files_inner_skips_gracefully_when_daemon_down`
+/// (daemon-down path, never reaches this function); the live HTTP path is
+/// covered by integration use.
+fn best_effort_index_one_file(base: &str, index_id: &str, rel_path: &str, content: &str) {
+    let url = format!("{base}/indexes/{index_id}/index-file");
+    let body = index_file_request_body(rel_path, content);
+
+    let result = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .connect_timeout(std::time::Duration::from_millis(750))
+        .build()
+        .and_then(|client| client.post(&url).json(&body).send());
+
+    match result {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::debug!("incrementally indexed '{rel_path}' into '{index_id}'");
+        }
+        Ok(resp) => {
+            tracing::warn!(
+                "incremental index update for '{rel_path}' in '{index_id}' returned HTTP {}",
+                resp.status()
+            );
+        }
+        Err(e) => {
+            tracing::warn!("incremental index update for '{rel_path}' in '{index_id}' failed: {e}");
+        }
+    }
+}
+
+/// Build the JSON body for the `POST /indexes/{id}/index-file` call.
+///
+/// Why: extracted so the request shape is unit-testable without a live
+/// daemon or a spawned thread — mirrors [`create_index_request_body`].
+/// What: `{path, content}` — the exact shape the per-file endpoint's
+/// `IndexFileRequest` expects (`crates/trusty-search/src/service/server/router.rs`).
+/// No `allow_sensitive_path` field: see [`index_files_best_effort`]'s doc
+/// comment for why the per-file endpoint needs no such opt-in.
+/// Test: `index_file_request_body_targets_relative_path_and_content`.
+fn index_file_request_body(rel_path: &str, content: &str) -> serde_json::Value {
+    serde_json::json!({
+        "path": rel_path,
+        "content": content,
+    })
 }
 
 /// Build the JSON body for the `POST /indexes` find-or-create call.
@@ -344,6 +538,143 @@ mod tests {
         // Derivation yields an empty id for the filesystem root, so the helper
         // returns None without touching the daemon.
         assert_eq!(ensure_project_indexed(Path::new("/")), None);
+    }
+
+    /// `index_files_inner` is a true no-op — no filesystem or network I/O —
+    /// when handed an empty path list.
+    ///
+    /// Why: [`index_files_best_effort`] is called from every successful write
+    /// tool executor; a batch write with zero files (should not normally
+    /// happen, but must not misbehave if it does) must not derive an index id
+    /// or attempt any I/O.
+    /// What: calls `index_files_inner` with `project_root = "/"` (which would
+    /// otherwise short-circuit on the empty-id path anyway) and an empty
+    /// `paths` slice; asserts it returns immediately without panicking.
+    /// Test: this test.
+    #[test]
+    fn index_files_inner_is_noop_for_empty_paths() {
+        index_files_inner(Path::new("/"), &[]);
+    }
+
+    /// `index_files_inner` skips cleanly when `derive_index_id` yields an
+    /// empty id (mirrors `ensure_project_indexed_none_for_root`'s "no index to
+    /// target" case for the incremental path).
+    ///
+    /// Why: the filesystem root has no meaningful basename to derive an id
+    /// from; posting to a daemon under an empty id would be meaningless. This
+    /// must be detected and skipped before any daemon lookup or file read.
+    /// What: calls `index_files_inner` with `project_root = "/"` and a
+    /// non-empty `paths` slice; asserts it returns without panicking (no
+    /// index id to target, so no I/O is attempted).
+    /// Test: this test.
+    #[test]
+    fn index_files_inner_skips_when_index_id_empty() {
+        index_files_inner(Path::new("/"), &[PathBuf::from("some/file.rs")]);
+    }
+
+    /// `index_files_inner` fails open — no panic, no propagated error — when
+    /// the trusty-search daemon is unreachable.
+    ///
+    /// Why: this is the core "never block or fail a tool result on index
+    /// error" contract the mid-task incremental re-index hook depends on. We
+    /// force the daemon-down path the same way
+    /// `ensure_project_indexed_returns_derived_id_when_daemon_down` does:
+    /// point the data dir at an empty temp dir so `resolve_daemon_base_url`
+    /// finds no address file, guaranteeing no HTTP call is attempted.
+    /// What: seeds a git-rooted scratch project with one real file, calls
+    /// `index_files_inner` with that file's path, and asserts it returns
+    /// promptly without panicking.
+    /// Test: this test.
+    #[test]
+    fn index_files_inner_skips_gracefully_when_daemon_down() {
+        let _guard = crate::data_dir::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let data_dir = scratch_dir("data-incr");
+        fs::create_dir_all(&data_dir).unwrap();
+        // SAFETY: guarded by ENV_LOCK; removed below before returning.
+        unsafe {
+            std::env::set_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV, &data_dir);
+        }
+
+        let project = scratch_dir("git-incr");
+        fs::create_dir_all(project.join(".git")).unwrap();
+        fs::write(project.join("main.rs"), "fn main() {}\n").unwrap();
+
+        index_files_inner(&project, &[PathBuf::from("main.rs")]);
+
+        unsafe {
+            std::env::remove_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV);
+        }
+        let _ = fs::remove_dir_all(&project);
+        let _ = fs::remove_dir_all(&data_dir);
+        // No assertion beyond "did not panic" — fail-open with no daemon
+        // means there is nothing further to observe from this call.
+    }
+
+    /// `relative_index_path` strips the project root prefix so the posted
+    /// path matches the corpus's existing `file` field convention.
+    ///
+    /// Why: the reindex walker stores chunk `file` fields relative to the
+    /// index root; posting an absolute path for an incremental update would
+    /// create a second, differently-keyed corpus entry for the same file
+    /// instead of updating the walker's original one.
+    /// What: builds `root/src/main.rs`, asserts `relative_index_path` returns
+    /// `"src/main.rs"`.
+    /// Test: this test.
+    #[test]
+    fn relative_index_path_strips_root_prefix() {
+        let root = Path::new("/Users/dev/my-project");
+        let abs = root.join("src/main.rs");
+        assert_eq!(relative_index_path(root, &abs), "src/main.rs");
+    }
+
+    /// `relative_index_path` falls back to the absolute path (lossy) rather
+    /// than panicking when the candidate does not live under `root`.
+    ///
+    /// Why: should not happen for a working-directory-scoped tool write, but
+    /// the fallback must fail safe, not crash the caller's thread.
+    /// What: passes a path with a different root; asserts the returned string
+    /// equals the absolute path.
+    /// Test: this test.
+    #[test]
+    fn relative_index_path_falls_back_for_paths_outside_root() {
+        let root = Path::new("/Users/dev/my-project");
+        let elsewhere = Path::new("/somewhere/else/file.py");
+        assert_eq!(
+            relative_index_path(root, elsewhere),
+            "/somewhere/else/file.py"
+        );
+    }
+
+    /// `index_file_request_body` targets exactly `{path, content}` with no
+    /// extraneous fields — in particular, no `allow_sensitive_path` (the
+    /// per-file endpoint does not consult the denylist at all; see
+    /// `index_files_best_effort`'s doc comment).
+    ///
+    /// Why: pins the wire shape the daemon's `IndexFileRequest`
+    /// (`crates/trusty-search/src/service/server/router.rs`) expects, and
+    /// documents — via a negative assertion — the Step 0 finding that this
+    /// endpoint needs no sensitive-path opt-in.
+    /// What: builds the body for a relative path + content, asserts both
+    /// fields round-trip and that no `allow_sensitive_path` key is present.
+    /// Test: this test.
+    #[test]
+    fn index_file_request_body_targets_relative_path_and_content() {
+        let body = index_file_request_body("src/main.rs", "fn main() {}\n");
+        assert_eq!(
+            body.get("path").and_then(serde_json::Value::as_str),
+            Some("src/main.rs")
+        );
+        assert_eq!(
+            body.get("content").and_then(serde_json::Value::as_str),
+            Some("fn main() {}\n")
+        );
+        assert!(
+            body.get("allow_sensitive_path").is_none(),
+            "the per-file endpoint does not re-check the denylist, so no bypass \
+             flag should be sent: {body:?}"
+        );
     }
 
     /// `ensure_project_indexed`'s `POST /indexes` request body always sets


### PR DESCRIPTION
Closes #2757.

## Problem

`ensure_project_indexed_in_background` indexes the working project ONCE, at task start. For a greenfield project that starts EMPTY, `search_code` finds nothing the engineer writes DURING the task.

## Step 0 investigation

- Per-file update API: `POST /indexes/{id}/index-file` (`index_file_handler`, `crates/trusty-search/src/service/server/files.rs`), backed by `Indexer::index_file(path, content)`. Request body is `{path, content}` — the CLIENT sends the file's content; the daemon does not read from disk.
- **Critical edge case, resolved**: does `index_file_handler` re-apply the #2747 sensitive-path denylist (which would reject an index registered under a `/var/folders/…` tempdir root)? **No.** It looks the index up by id in the daemon's in-memory registry (`state.registry.get(&index_id)`) and never calls `allowlist::is_denied`. So a tempdir-rooted index created under #2747's `allow_sensitive_path` bypass accepts incremental per-file updates unconditionally — **no bypass extension needed on this endpoint.**

## Design

- **`crates/trusty-common/src/search_index.rs`**: new `index_files_best_effort(project_root, paths)`, next to `ensure_project_indexed`. Derives the same `(root, index_id)` that function would, spawns ONE detached OS thread, and — when the daemon is discoverable — reads each path from disk and POSTs it to `/indexes/{id}/index-file`. Fail-open (log-and-swallow), non-blocking (returns immediately after spawning), no-op cleanly when the daemon is down, the index id is empty, or a file is unreadable. Reuses the module's existing HTTP/client plumbing (`resolve_daemon_base_url`, the same short-timeout `reqwest::blocking` pattern).
- **Hook placement — per-tool-executor (not a single agent-loop hook)**: chosen because the tools already own `working_dir` and know exactly which path(s) they just wrote, with no extra plumbing needed; a loop-level hook would have to re-derive "what changed" generically across three different tool shapes. Wired into:
  - `write_file` (`tools/fs/write.rs`) — one path, on success.
  - `write_files` (`tools/fs/write_files.rs`) — ALL successfully-written paths batched into ONE `index_files_best_effort` call (not one call per file).
  - `edit` (`tools/fs/edit.rs`) — one path, on success.
  
  Never fires on failure; never affects the returned `ToolResult` — a slow/unreachable daemon can't turn a successful write into a failure.

## A design detour worth flagging

My first draft tested the `write_file` hook against a real loopback TCP mock daemon (env-var + on-disk `http_addr` file pointing at it). That approach turned out to be unsafe: since the hook is now wired into every successful write, and this daemon-discovery mechanism is process-global, **every other concurrently-running write-tool test in the crate's parallel suite would also attempt to notify whatever fake address the test-under-observation had configured**, causing nondeterministic cross-talk (observed directly — one run captured a *different* test's write). Replaced with a small dependency-injection seam (`WriteFileTool::with_index_notifier`, test-only), mirroring this crate's existing `RecallSessionTool` `rpc_url`-injection precedent. Zero shared state, fully deterministic.

While investigating I also confirmed (by stashing my changes and testing against unmodified `origin/main`) that two `run_task` tests — `repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap` and `exit_code_reflects_run_failure` — are **pre-existing, environment-dependent flakes**, unrelated to this PR: this dev machine has real `trusty-search`/`trusty-memory` daemons running, and the already-merged #2728 (unconditional task-start indexing) causes those tests to occasionally hit them. Out of scope here; flagging for visibility.

## Tests (8 new)
- `trusty-common` (`search_index::tests`): `index_files_inner_is_noop_for_empty_paths`, `index_files_inner_skips_when_index_id_empty`, `index_files_inner_skips_gracefully_when_daemon_down`, `relative_index_path_strips_root_prefix`, `relative_index_path_falls_back_for_paths_outside_root`, `index_file_request_body_targets_relative_path_and_content` (also documents, via a negative assertion, that no `allow_sensitive_path` field is needed on this endpoint).
- `trusty-code` (`tools::fs::write::tests`): `write_file_success_triggers_incremental_index_update` (hook fires exactly once with the right `working_dir`+path), `write_file_failure_does_not_trigger_incremental_index_update`.

## Quality gate (all green, from the worktree)
- `cargo build -p trusty-common -p trusty-code -p trusty-search -p trusty-mpm` — clean.
- `cargo test -p trusty-common -p trusty-code -p trusty-search -p trusty-mpm` — every test binary `ok`, 0 failed.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (0 errors).
- `cargo fmt --check` — clean.
- `bash scripts/check_line_cap.sh` — 0 violations.
- `bash scripts/check_test_pointers.sh` — 0 dangling pointers.
- `cargo check --workspace` — clean.

**Do NOT merge** — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)