### PR TITLE
fix(trusty-mpm): never traverse $HOME/TCC-protected folders (closes #2759)

### DIFF
--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -68,6 +68,7 @@ pub mod process;
 pub mod project;
 pub mod project_aliases;
 pub mod project_discovery;
+pub mod protected_dirs;
 pub mod provisioning_stage;
 pub mod session;
 pub mod session_launch;

--- a/crates/trusty-mpm/src/core/protected_dirs.rs
+++ b/crates/trusty-mpm/src/core/protected_dirs.rs
@@ -1,0 +1,174 @@
+//! Guards against traversing `$HOME` or macOS TCC-protected user folders.
+//!
+//! Why: tm's remit is git worktrees under the managed projects root — it never
+//! legitimately walks, watches, or runs a session in the user's home directory
+//! or a TCC-protected folder (Downloads, Desktop, Documents, Pictures, Movies,
+//! Music, `~/Library`). When it does, macOS surfaces a cascade of "trusty-mpm
+//! would like to access your Downloads/Photos/… folder" consent prompts — one
+//! per protected subfolder — because a recursive watch/scan of `$HOME` touches
+//! each guarded folder in turn (issue #2758). The two culprits are (a) the file
+//! watcher registering a RECURSIVE `notify` watch on a session workdir and
+//! (b) a managed session whose cwd defaulted to `$HOME` (no explicit cwd). This
+//! module centralises the "is this a home/protected root?" decision so both call
+//! sites — and any future scan — share one definition rather than drifting.
+//! What: [`PROTECTED_HOME_SUBDIRS`] lists the guarded top-level folders;
+//! [`is_home_or_protected_dir`] is the pure lexical predicate; [`safe_session_cwd`]
+//! resolves a managed session's cwd to a value that is never `$HOME`/protected/`/`.
+//! Test: unit tests in this module.
+
+use std::path::{Path, PathBuf};
+
+use tracing::warn;
+
+/// Top-level `$HOME` subdirectories that macOS guards behind a per-folder TCC
+/// consent prompt, plus the broad media/`Library` folders a code tool never
+/// wants to traverse.
+///
+/// Why: recursively watching/scanning any of these — or `$HOME` itself — makes
+/// macOS pop a "would like to access …" folder prompt and drags the whole home
+/// tree into the operation. `Pictures` covers the Photos Library
+/// (`kTCCServicePhotos`); `Downloads`/`Desktop`/`Documents` are the classic
+/// `SystemPolicy*Folder` services.
+/// What: bare directory base-names joined onto the resolved home directory by
+/// [`is_home_or_protected_dir`].
+/// Test: `is_home_or_protected_dir_rejects_home_and_tcc_dirs`.
+pub const PROTECTED_HOME_SUBDIRS: &[&str] = &[
+    "Downloads",
+    "Desktop",
+    "Documents",
+    "Library",
+    "Movies",
+    "Music",
+    "Pictures",
+    "Public",
+];
+
+/// True when `path` must NEVER be used as a recursive scan/watch/run root.
+///
+/// Why: a recursive traversal rooted at `$HOME` (or a TCC-protected subfolder)
+/// triggers the macOS folder-access prompt cascade described in the module docs.
+/// What: returns true when `path` is the filesystem root `/`, equals `home`, or
+/// equals `home/<one of PROTECTED_HOME_SUBDIRS>`. Comparison is purely lexical —
+/// it never stats or canonicalizes `path`, so this check can never itself trip a
+/// TCC prompt. A path that merely lives *inside* one of these folders (deeper
+/// than the bare directory — an operator's explicit choice) is NOT rejected.
+/// When `home` is `None` only `/` is rejected.
+/// Test: `is_home_or_protected_dir_rejects_home_and_tcc_dirs`,
+/// `is_home_or_protected_dir_allows_normal_project`.
+pub fn is_home_or_protected_dir(path: &Path, home: Option<&Path>) -> bool {
+    if path == Path::new("/") {
+        return true;
+    }
+    let Some(home) = home else {
+        return false;
+    };
+    if path == home {
+        return true;
+    }
+    PROTECTED_HOME_SUBDIRS
+        .iter()
+        .any(|name| path == home.join(name))
+}
+
+/// Resolve a managed session's working directory to a value that is never
+/// `$HOME`, a TCC-protected folder, or `/`.
+///
+/// Why: [`crate::session_manager`] previously defaulted a session with no
+/// explicit cwd to `dirs::home_dir()`. Such a session runs (and is recursively
+/// watched) in `$HOME`, causing the macOS folder-access prompt cascade. Routing
+/// every managed cwd through this helper guarantees a session never traverses the
+/// home tree, keeping scan/watch/run roots explicit rather than `$HOME`-wide.
+/// What: returns `cwd` unchanged when it is `Some` and NOT a home/protected/`/`
+/// root; otherwise (missing, or resolving to such a root) logs a warning and
+/// returns a neutral per-process scratch directory ([`std::env::temp_dir`]). The
+/// scratch dir is writable and outside every TCC-protected location.
+/// Test: `safe_session_cwd_replaces_home_and_missing`,
+/// `safe_session_cwd_keeps_explicit_project_dir`.
+pub fn safe_session_cwd(cwd: Option<PathBuf>) -> PathBuf {
+    let home = dirs::home_dir();
+    match cwd {
+        Some(p) if !is_home_or_protected_dir(&p, home.as_deref()) => p,
+        other => {
+            let fallback = std::env::temp_dir();
+            match other {
+                Some(p) => warn!(
+                    requested = %p.display(),
+                    fallback = %fallback.display(),
+                    "managed session cwd resolves to $HOME or a TCC-protected folder; \
+                     using a scratch dir to avoid recursive home traversal / macOS \
+                     folder-access prompts"
+                ),
+                None => warn!(
+                    fallback = %fallback.display(),
+                    "no managed session cwd supplied; using a scratch dir instead of $HOME"
+                ),
+            }
+            fallback
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_home_or_protected_dir_rejects_home_and_tcc_dirs() {
+        let home = Path::new("/Users/tester");
+        assert!(is_home_or_protected_dir(Path::new("/"), Some(home)));
+        assert!(is_home_or_protected_dir(home, Some(home)));
+        for d in PROTECTED_HOME_SUBDIRS {
+            assert!(
+                is_home_or_protected_dir(&home.join(d), Some(home)),
+                "bare ~/{d} must be rejected"
+            );
+        }
+        // A trailing slash still matches (Path comparison is component-wise).
+        assert!(is_home_or_protected_dir(
+            Path::new("/Users/tester/Downloads/"),
+            Some(home)
+        ));
+    }
+
+    #[test]
+    fn is_home_or_protected_dir_allows_normal_project() {
+        let home = Path::new("/Users/tester");
+        // The managed projects root and its worktrees are always allowed.
+        assert!(!is_home_or_protected_dir(
+            Path::new("/Users/tester/trusty-mpm-projects/owner/repo/.worktrees/x"),
+            Some(home)
+        ));
+        // A project living INSIDE Downloads (deeper than the bare folder) is an
+        // explicit operator choice and is NOT rejected.
+        assert!(!is_home_or_protected_dir(
+            &home.join("Downloads").join("my-project"),
+            Some(home)
+        ));
+        // With no resolvable home only "/" is rejected.
+        assert!(!is_home_or_protected_dir(
+            Path::new("/Users/tester/Downloads"),
+            None
+        ));
+    }
+
+    #[test]
+    fn safe_session_cwd_keeps_explicit_project_dir() {
+        let p = PathBuf::from("/Users/tester/trusty-mpm-projects/o/r/.worktrees/s");
+        assert_eq!(safe_session_cwd(Some(p.clone())), p);
+    }
+
+    #[test]
+    fn safe_session_cwd_replaces_home_and_missing() {
+        let scratch = std::env::temp_dir();
+        // Missing cwd → scratch, never $HOME.
+        assert_eq!(safe_session_cwd(None), scratch);
+        if let Some(home) = dirs::home_dir() {
+            // Explicit $HOME → scratch.
+            assert_eq!(safe_session_cwd(Some(home.clone())), scratch);
+            // Explicit ~/Downloads → scratch.
+            assert_eq!(safe_session_cwd(Some(home.join("Downloads"))), scratch);
+        }
+        // Filesystem root → scratch.
+        assert_eq!(safe_session_cwd(Some(PathBuf::from("/"))), scratch);
+    }
+}

--- a/crates/trusty-mpm/src/daemon/watcher.rs
+++ b/crates/trusty-mpm/src/daemon/watcher.rs
@@ -52,10 +52,26 @@ impl FileWatcher {
     ///
     /// Why: each session has its own workdir; the dashboard shows file changes
     /// per session, so the watcher must know which root maps to which session.
-    /// What: records the `session → root` mapping; returns the previous root
-    /// if the session was already watching something.
-    /// Test: `register_and_unregister_roots`.
+    /// A workdir that resolves to `$HOME` or a TCC-protected user folder must be
+    /// rejected here: [`spawn`](Self::spawn) registers every root as a RECURSIVE
+    /// `notify` watch, and on macOS a recursive watch of `$HOME` / `~/Downloads`
+    /// triggers a "trusty-mpm would like to access your Downloads folder" consent
+    /// prompt — even though tm only ever manages git worktrees under the projects
+    /// root (see [`crate::core::protected_dirs::is_home_or_protected_dir`]).
+    /// What: rejects protected/home roots (logs a warning, returns `None` without
+    /// recording anything); otherwise records the `session → root` mapping and
+    /// returns the previous root if the session was already watching something.
+    /// Test: `register_and_unregister_roots`, `watch_session_skips_protected_roots`.
     pub fn watch_session(&self, session: SessionId, root: PathBuf) -> Option<PathBuf> {
+        if crate::core::protected_dirs::is_home_or_protected_dir(&root, dirs::home_dir().as_deref())
+        {
+            warn!(
+                root = %root.display(),
+                "refusing to recursively watch a home/TCC-protected root \
+                 (would trigger a macOS folder-access prompt); skipping session watch"
+            );
+            return None;
+        }
         self.roots.lock().insert(session, root)
     }
 
@@ -230,6 +246,39 @@ mod tests {
         assert_eq!(watcher.watched_count(), 1);
         assert_eq!(watcher.unwatch_session(s), Some(PathBuf::from("/tmp/proj")));
         assert_eq!(watcher.watched_count(), 0);
+    }
+
+    #[test]
+    fn watch_session_skips_protected_roots() {
+        // A home/protected root is refused (not recorded); a normal path is.
+        let watcher = FileWatcher::new(DaemonState::shared());
+        if let Some(home) = dirs::home_dir() {
+            let s = SessionId::new();
+            assert!(
+                watcher.watch_session(s, home).is_none(),
+                "home root must be refused"
+            );
+            let downloads = SessionId::new();
+            assert!(
+                watcher
+                    .watch_session(downloads, dirs::home_dir().unwrap().join("Downloads"))
+                    .is_none(),
+                "~/Downloads must be refused"
+            );
+            assert_eq!(
+                watcher.watched_count(),
+                0,
+                "no protected root may enter the watch set"
+            );
+        }
+        // A safe path is still registered normally.
+        let safe = SessionId::new();
+        assert!(
+            watcher
+                .watch_session(safe, PathBuf::from("/tmp/tm-watch-safe"))
+                .is_none()
+        );
+        assert_eq!(watcher.watched_count(), 1);
     }
 
     #[test]

--- a/crates/trusty-mpm/src/session_manager/create.rs
+++ b/crates/trusty-mpm/src/session_manager/create.rs
@@ -69,7 +69,11 @@ impl SessionManager {
         ephemeral: bool,
         owned: bool,
     ) -> Result<SessionRecord, ManagedError> {
-        let cwd = cwd.unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp")));
+        // Never run (and therefore never recursively watch/scan) a managed
+        // session in `$HOME` or a TCC-protected folder — that triggers a cascade
+        // of macOS "trusty-mpm would like to access …" folder prompts (#2758).
+        // A missing or unsafe cwd resolves to a neutral scratch dir, never $HOME.
+        let cwd = crate::core::protected_dirs::safe_session_cwd(cwd);
         let github_project = repo_url
             .as_deref()
             .and_then(trusty_common::github_path::parse_github_path)
@@ -128,7 +132,11 @@ impl SessionManager {
         ephemeral: bool,
         owned: bool,
     ) -> Result<SessionRecord, ManagedError> {
-        let cwd = cwd.unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp")));
+        // Never run (and therefore never recursively watch/scan) a managed
+        // session in `$HOME` or a TCC-protected folder — that triggers a cascade
+        // of macOS "trusty-mpm would like to access …" folder prompts (#2758).
+        // A missing or unsafe cwd resolves to a neutral scratch dir, never $HOME.
+        let cwd = crate::core::protected_dirs::safe_session_cwd(cwd);
         self.create_with_resolved_name(
             id,
             reserved_name,


### PR DESCRIPTION
## Problem
After the signed trusty-mpm 0.19.x install + daemon restart, macOS surfaced a **cascade** of per-folder TCC prompts attributed to `trusty-mpm`: **Downloads** (`kTCCServiceSystemPolicyDownloadsFolder`), then minutes later **Photos/Pictures** (`kTCCServicePhotos`), with Desktop/Documents likely next. A *sequence* of distinct protected folders is the signature of a **recursive traversal rooted at `$HOME`**.

Closes #2759.

## Diagnosis
No trusty-mpm code enumerates `$HOME` and no persisted state references a protected folder as a scan root (audited registries, `project-paths.json`, registry-B, claude-mpm DB, `~/.claude/projects`, SM/legacy stores). `$HOME` is not a git repo; `repos_root`/`workspace_root` = `~/trusty-mpm-projects`. The signing change (#2736) only stabilized the binary identity, so macOS now surfaces prompts that were previously suppressed under the ad-hoc cdhash — the access is not new.

The one latent tm mechanism that produces a daemon-attributed recursive-`$HOME` traversal:
1. `session_manager/create.rs` (x2) defaulted a session with no explicit `cwd` to `dirs::home_dir()` → the session **runs in `$HOME`** (cwd is the tmux workdir).
2. `daemon/watcher.rs` registers a **`RecursiveMode::Recursive`** notify watch on every session workdir with no guard → recursively watching `$HOME` prompts for each guarded subfolder as it's touched.

## Fix (general, not Downloads-specific)
- **New `core::protected_dirs`**: `is_home_or_protected_dir()` skips `/`, `$HOME`, and `~/{Downloads,Desktop,Documents,Library,Movies,Music,Pictures,Public}` (a path explicitly launched *inside* such a folder is **not** skipped — honours operator intent). `safe_session_cwd()` resolves a managed cwd to a value that is never `$HOME`/protected/`/`.
- **`FileWatcher::watch_session`** refuses to recursively watch a home/protected root (warn + skip).
- **`create.rs`** routes both spawn sites' cwd through `safe_session_cwd` → a session never defaults to `$HOME`; missing/unsafe cwd → neutral scratch dir.
- `PermissionDenied` stays graceful (watch → warn; read_dir → skip) — no crash/spin on denial.

## Tests
- `core::protected_dirs`: predicate accepts normal/deeper-inside-Downloads paths, rejects `$HOME`/protected/`/`; `safe_session_cwd` replaces home/missing/`/` with scratch, keeps explicit project dirs.
- `daemon::watcher::watch_session_skips_protected_roots`: `$HOME` and `~/Downloads` refused, safe path registered.

## Gates (raw)
- `cargo test -p trusty-mpm --lib`: `test result: ok. 3175 passed; 0 failed; 5 ignored`
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: Finished, no trusty-mpm warnings
- `cargo fmt --check` OK · `bash scripts/check_line_cap.sh` → `9 allowlisted, 0 violations — OK` · `cargo check --workspace` OK

## Note on the live prompt / guidance
No `$HOME`-cwd session (`tm-masa-*`) is currently in the store, so Bob's *specific* live prompts may be a managed `claude` child session's own user-directed access to `~/Downloads`/`~/Pictures`, attributed to the signed ancestor `trusty-mpm`. That is legitimate and safe to **deny** — the daemon handles denial gracefully. This fix closes the tm-side latent path that could otherwise cause a daemon-attributed cascade. Reaches the installed daemon only at the next release+install.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
