### PR TITLE
fix(trusty-mpm): fleet-session injector reads managed registry from real home (#2756)

### DIFF
--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -571,7 +571,7 @@ fn prepare_session_inner(
     // the injected names flow into `enabledMcpjsonServers` and skip the "new MCP
     // servers found" dialog. Non-fatal: a failure only means those extra tools
     // are absent from this session.
-    if let Err(err) = inject_native_trusty_mcps(fw, project_dir) {
+    if let Err(err) = inject_native_trusty_mcps(project_dir) {
         tracing::warn!("failed to inject native trusty MCP servers: {err}");
     }
 

--- a/crates/trusty-mpm/src/core/session_launch/native_mcp.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp.rs
@@ -88,8 +88,7 @@ use serde_json::Value;
 use super::PrepError;
 use super::settings::inject_mcp_server;
 use crate::core::mcp_config;
-use crate::core::paths::FrameworkPaths;
-use crate::core::trusty_tools_config::managed_claude_config_dir_at;
+use crate::core::trusty_tools_config::managed_claude_config_dir;
 
 /// Basename of the git-excluded file native MCP server secrets are delivered
 /// through.
@@ -136,29 +135,41 @@ pub(super) const NATIVE_TRUSTY_MCP_SERVERS: &[&str] = &[
 /// into the workspace `.mcp.json` (issue #2739).
 ///
 /// Why: this is the `prepare_session` call site. It resolves the tm-owned managed
-/// config dir — the SAME `.claude.json` the `tm mcp` CLI reads and writes —
-/// relative to `fw`'s home base rather than the ambient process env. Using `fw`
-/// (not `CLAUDE_CONFIG_DIR`) keeps this hermetic: production managed sessions
-/// build `fw` under the real home, so it resolves to the real managed dir; test
-/// `FrameworkPaths::under(tempdir)` callers stay confined to the temp dir instead
-/// of leaking the operator's real registry into a fixture (mirroring the
-/// `deploy_output_style(&fw.claude_home_dir())` isolation pattern). `tm mcp`
-/// likewise resolves this dir home-relative via
-/// [`crate::core::trusty_tools_config::managed_claude_config_dir`] — it does not
-/// consult `CLAUDE_CONFIG_DIR` — so the two see the same file.
-/// What: computes
-/// [`managed_claude_config_dir_at`]`(fw.claude_home_dir())` and delegates to
-/// [`inject_native_trusty_mcps_from`]. A missing/empty managed `.claude.json`
-/// makes the delegate a no-op.
-/// Test: covered end-to-end via the `inject_native_*` tests, which drive the
-/// hermetic `_from` core directly with a tempdir config dir, and by
-/// `prepare_session_preseeds_enabled_mcp_servers` (which asserts an isolated `fw`
-/// injects no natives).
-pub(super) fn inject_native_trusty_mcps(
-    fw: &FrameworkPaths,
-    project_path: &Path,
-) -> Result<(), PrepError> {
-    let config_dir = managed_claude_config_dir_at(&fw.claude_home_dir());
+/// config dir — the SAME `.claude.json` the `tm mcp` CLI reads and writes — from
+/// the REAL operator home (`dirs::home_dir()`/`$HOME`), exactly as `tm mcp` does.
+///
+/// #2756: the original version resolved this relative to `fw.claude_home_dir()`,
+/// which is a NO-OP in every real daemon-managed fleet session. Managed spawns
+/// build `fw` via [`crate::core::paths::FrameworkPaths::for_managed_workspace`],
+/// which by design (#1931, for `CLAUDE_CONFIG_DIR` isolation of agent/skill
+/// deploy targets) makes `claude_home_dir()` return the WORKSPACE directory — NOT
+/// real `$HOME`. So the injector looked for
+/// `<workspace>/.trusty-tools/trusty-mpm/claude-config/.claude.json` — a path that
+/// never exists in a freshly cloned workspace — [`mcp_config::list_servers`]
+/// treated the missing file as an empty map, and nothing was ever injected. But
+/// the managed `.claude.json` registry `tm mcp add` writes is ALWAYS
+/// home-relative regardless of which workspace is being provisioned, so it must
+/// be read from the real home too. The `tm mcp` CLI resolves it identically via
+/// [`managed_claude_config_dir`] (which does not consult `CLAUDE_CONFIG_DIR`
+/// either), so the two see the same file. The daemon process runs under the real
+/// user, so real `$HOME` is available at spawn time.
+/// What: resolves [`managed_claude_config_dir`] (real home) and delegates to
+/// [`inject_native_trusty_mcps_from`]. If the home directory cannot be resolved
+/// (a stripped environment), logs a `warn!` and no-ops so the session still
+/// launches — just without the extra native servers. A missing/empty managed
+/// `.claude.json` likewise makes the delegate a no-op.
+/// Test: `inject_native_resolves_managed_registry_from_real_home` (#2756) drives
+/// the ACTUAL `for_managed_workspace` → real-home resolution end-to-end; the
+/// `inject_native_*` tests cover the hermetic `_from` core directly with a
+/// tempdir config dir.
+pub(super) fn inject_native_trusty_mcps(project_path: &Path) -> Result<(), PrepError> {
+    let Some(config_dir) = managed_claude_config_dir() else {
+        tracing::warn!(
+            "skipping native trusty MCP injection: cannot resolve the home directory for the \
+             managed claude config dir — native servers will be absent from this session"
+        );
+        return Ok(());
+    };
     inject_native_trusty_mcps_from(project_path, &config_dir)
 }
 

--- a/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
@@ -902,3 +902,116 @@ fn inject_native_rejects_url_bearing_allowlisted_server() {
         "no secret env collected → no .env.local"
     );
 }
+
+// ── #2756: real-home resolution of the PRODUCTION injector ──────────────────
+
+/// Redirect `$HOME` to a temp dir for the body, restoring it (or removing it)
+/// afterwards even on panic.
+///
+/// Why (#2756): the production injector resolves the managed registry from the
+/// real operator home (`dirs::home_dir()` → `$HOME`). To drive that resolution
+/// hermetically — without reading or polluting the operator's real
+/// `~/.trusty-tools/...` — the test must point `$HOME` at a fake home holding a
+/// seeded managed registry. A failed assertion must still restore `$HOME` so
+/// sibling `#[serial]` tests are not poisoned, so this mirrors
+/// `home_trust_seed::tests::with_fake_home`.
+/// What: snapshots `$HOME`, sets it to `home`, runs `body` under
+/// `catch_unwind`, restores the snapshot, then re-raises any panic. Callers MUST
+/// be `#[serial_test::serial]` so the process-global `$HOME` mutation cannot race.
+/// Test: used by `inject_native_resolves_managed_registry_from_real_home`.
+fn with_fake_home<F: FnOnce()>(home: &Path, body: F) {
+    let prev = std::env::var("HOME").ok();
+    // SAFETY: callers are `#[serial_test::serial]`, so no other thread races this
+    // set/restore; the restore below runs regardless of a panic in `body`.
+    unsafe { std::env::set_var("HOME", home) };
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));
+    match prev {
+        Some(p) => unsafe { std::env::set_var("HOME", p) },
+        None => unsafe { std::env::remove_var("HOME") },
+    }
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn inject_native_resolves_managed_registry_from_real_home() {
+    // Why (#2756): the PRODUCTION entry point `inject_native_trusty_mcps` must
+    // resolve the managed `.claude.json` registry from the REAL operator home,
+    // NOT from `fw.claude_home_dir()`. Every daemon-managed fleet session builds
+    // `fw` via `FrameworkPaths::for_managed_workspace(&workspace)`, which by
+    // design (#1931) makes `claude_home_dir()` return the WORKSPACE directory. The
+    // pre-fix injector therefore read
+    // `<workspace>/.trusty-tools/trusty-mpm/claude-config/.claude.json` (never
+    // present in a fresh clone) and silently injected nothing — invisible in CI
+    // because the older tests only drove the hermetic `_from` core against a
+    // tempdir. This test drives the ACTUAL `for_managed_workspace` construction
+    // + real-home resolution end-to-end: it FAILS against the old (fw-relative)
+    // code and PASSES after the fix.
+    let home = tempdir().unwrap();
+    let ws_root = tempdir().unwrap();
+    // A realistic managed workspace path: <root>/<owner>/<repo>/<session-id>.
+    let workspace = ws_root.path().join("bobmatnyc").join("repo").join("sess-1");
+    std::fs::create_dir_all(&workspace).unwrap();
+    git_init(&workspace);
+
+    // Seed the managed registry at the SAME real-home location `tm mcp add`
+    // writes to: <home>/.trusty-tools/trusty-mpm/claude-config/.claude.json.
+    let managed_dir = home
+        .path()
+        .join(".trusty-tools")
+        .join("trusty-mpm")
+        .join("claude-config");
+    seed_managed_registry(&managed_dir);
+
+    // Build `fw` exactly as the daemon managed-spawn path does
+    // (`provisioner::workspace`): its `claude_home_dir()` points at the
+    // WORKSPACE, not `$HOME` — precisely the config that made the bug a no-op.
+    let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&workspace);
+    // Precondition: the workspace-relative managed registry the buggy code read
+    // does NOT exist, so a green result below can ONLY come from the real-home
+    // read — the exact distinction this regression guards.
+    assert!(
+        !fw.claude_home_dir()
+            .join(".trusty-tools")
+            .join("trusty-mpm")
+            .join("claude-config")
+            .join(".claude.json")
+            .exists(),
+        "precondition: the workspace-relative managed registry must be absent"
+    );
+
+    with_fake_home(home.path(), || {
+        super::native_mcp::inject_native_trusty_mcps(&workspace)
+            .expect("injection succeeds from the real-home managed registry");
+    });
+
+    // The natives from the HOME registry landed in the WORKSPACE `.mcp.json`.
+    let servers = read_injected(&workspace);
+    assert!(
+        servers.contains_key("slack-mcp"),
+        "native slack-mcp must be injected from the real-home managed registry, \
+         not the (empty) workspace-relative path the pre-#2756 code read"
+    );
+    assert!(
+        servers.contains_key("gworkspace-mcp"),
+        "native gworkspace-mcp injected from the real-home registry too"
+    );
+    // Non-native servers are still excluded, proving the allowlist still applies.
+    assert!(
+        !servers.contains_key("github"),
+        "non-native github must not be injected"
+    );
+    // The slack secret was routed to `.env.local`, never into git-tracked
+    // `.mcp.json` — the #2739 guarantee still holds on the real-home path.
+    let mcp_json = std::fs::read_to_string(workspace.join(".mcp.json")).unwrap();
+    assert!(
+        !mcp_json.contains(FAKE_SLACK_TOKEN),
+        ".mcp.json must never carry the raw token: {mcp_json}"
+    );
+    assert!(
+        workspace.join(".env.local").exists(),
+        ".env.local must be written for the slack secret"
+    );
+}

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -1397,12 +1397,21 @@ fn preseed_trust_enables_empty_when_no_mcp_json() {
 }
 
 #[test]
+#[serial_test::serial]
 fn prepare_session_preseeds_enabled_mcp_servers() {
     // Why (#1296): the single launch-prep entry point injects trusty-memory and
     // trusty-search into `.mcp.json`, then seeds trust. The pre-seeded trust
     // entry in ~/.claude.json must list BOTH injected servers under
     // `enabledMcpjsonServers` so the spawned session runs non-interactively.
+    //
+    // #2756: `inject_native_trusty_mcps` now resolves the managed registry from
+    // the REAL `$HOME` (not `fw`), and `preseed_workspace_trust_home` writes to
+    // `$HOME/.claude.json`. Both are pointed at `tmp_home` here (via a serial
+    // `$HOME` override) so this test neither leaks into — nor is contaminated by
+    // — the operator's real registry (which on a dev box HAS native servers like
+    // slack-mcp registered, which would otherwise appear in the assertion below).
     let tmp_home = tempdir().unwrap();
+    let _home = EnvVarGuard::set("HOME", tmp_home.path());
     let tmp = tempdir().unwrap();
     let project = tmp.path();
     let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());


### PR DESCRIPTION
## Summary

The fleet-session native-MCP injector (shipped in #2739/#2748, trusty-mpm 0.19.16) was a no-op in every real daemon-managed session.

**Root cause:** `inject_native_trusty_mcps` (`crates/trusty-mpm/src/core/session_launch/native_mcp.rs`) resolved the managed `.claude.json` registry via `managed_claude_config_dir_at(&fw.claude_home_dir())`. But every daemon-managed fleet spawn builds `fw` via `FrameworkPaths::for_managed_workspace(&workspace_path)` (`crates/trusty-mpm/src/provisioner/workspace.rs:880`), which by design (#1931, for `CLAUDE_CONFIG_DIR` isolation of agent/skill deploy targets) makes `claude_home_dir()` return the **workspace directory**, not real `$HOME`. So in production the injector looked for `<workspace>/.trusty-tools/trusty-mpm/claude-config/.claude.json` — a path that never exists in a freshly cloned workspace — `mcp_config::list_servers` treated the missing file as an empty map, and nothing was ever injected. The real managed registry (the one `tm mcp add`/`tm mcp list` reads and writes) lives at `~/.trusty-tools/trusty-mpm/claude-config/.claude.json`, always home-relative regardless of which workspace is being provisioned.

This wasn't caught in CI because the existing tests drove the hermetic `inject_native_trusty_mcps_from` core directly against a tempdir config dir, bypassing the real `fw.claude_home_dir()` → `for_managed_workspace` resolution chain entirely.

## Fix

`inject_native_trusty_mcps` now resolves the managed config dir via `crate::core::trusty_tools_config::managed_claude_config_dir()` — the exact same real-home (`dirs::home_dir()`) resolver the `tm mcp` CLI already uses — instead of `fw.claude_home_dir()`. The daemon process runs under the real user, so real `$HOME` is available at spawn time. If home resolution fails (a stripped environment), the injector now logs a `warn!` and no-ops rather than panicking — the session still launches, just without the extra native servers. The allowlist filter, categorical env-strip, `.env.local` git-excluded secret routing, and the `check-ignore` fail-closed gate from #2748 are all unchanged — only the *source* path for the registry moved.

Also fixed the module doc comment, which incorrectly asserted that "production managed sessions build `fw` under the real home."

## Regression test

Added `inject_native_resolves_managed_registry_from_real_home` in `native_mcp_tests.rs`, which drives the **actual** production path end-to-end:
- Constructs `fw` via the real `FrameworkPaths::for_managed_workspace(&workspace)` (the exact constructor the daemon's managed-spawn code uses).
- Seeds a managed `.claude.json` (with `slack-mcp`, `gworkspace-mcp`, etc.) at a temp fake-home, and redirects `$HOME` to it for the test body (serialized via `#[serial_test::serial]`).
- Asserts a precondition that the workspace-relative path the old buggy code read is absent (so a pass can only come from the real-home read).
- Calls the production `inject_native_trusty_mcps(&workspace)` and asserts the native servers landed in the workspace `.mcp.json`, non-natives were excluded, and the slack secret was routed to `.env.local` rather than the tracked `.mcp.json`.

Verified the test fails on the pre-fix code: temporarily reverted `inject_native_trusty_mcps` to read from the workspace-relative path (the old bug) and confirmed the new test failed with a `NotFound` panic reading the (never-created) workspace `.mcp.json` — then reverted back to the fix and confirmed it passes.

Also added a `#[serial_test::serial]` + `$HOME` override to the pre-existing `prepare_session_preseeds_enabled_mcp_servers` test, since the injector (and `preseed_workspace_trust_home`) now touch real `$HOME`-relative paths and must not read/pollute the operator's actual registry during that test.

## Verification

- `cargo build -p trusty-mpm` — clean
- `cargo test -p trusty-mpm` — 3179 passed; 0 failed (plus all integration test binaries green)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 9 allowlisted, 0 violations
- `bash scripts/check_test_pointers.sh` — 0 dangling pointers

Closes #2756

🤖 Generated with [Claude Code](https://claude.com/claude-code)