### PR TITLE
fix(deps): security update wave — resolve Dependabot lock-only alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8574,9 +8574,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -8588,7 +8588,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
- "serde_with_macros 3.20.0",
+ "serde_with_macros 3.21.0",
  "time",
 ]
 
@@ -8606,9 +8606,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -9563,7 +9563,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "serde_json",
- "serde_with 3.20.0",
+ "serde_with 3.21.0",
  "swift-rs",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
@@ -9701,7 +9701,7 @@ dependencies = [
  "rgb",
  "serde",
  "serde_json",
- "serde_with 3.20.0",
+ "serde_with 3.21.0",
  "stacker",
  "take_mut",
  "takecell",


### PR DESCRIPTION
## Summary

Manual audit of all 67 open Dependabot alerts on `main` (2 critical, 12 high, 48 medium, 5 low). This PR applies the **only** fix achievable via a `Cargo.lock`-only update within the workspace's existing `Cargo.toml` semver ranges. Every other open alert requires either a manifest change (direct dependency version bump) or has no patched version available — those are filed as separate issues (see below), not included here.

## Resolves

| # | Severity | Package | GHSA | Old → New |
|---|----------|---------|------|-----------|
| #76 | medium | `serde_with` | [GHSA-7gcf-g7xr-8hxj](https://github.com/advisories/GHSA-7gcf-g7xr-8hxj) | 3.20.0 → 3.21.0 |

`serde_with_macros` was bumped in lockstep (3.20.0 → 3.21.0) as required by the crate's internal version pinning.

**Note:** the Dependabot alert's raw vulnerable-version range (`< 3.21.0`) technically also matches a second, independently-locked `serde_with` instance at `1.14.0` (pulled in via `teloxide-core 0.10.1` ← `teloxide 0.13` ← `trusty-mpm`, semver-incompatible with the 3.x line used by `tauri-utils`, so `cargo update` cannot merge them). The advisory's `KeyValueMap` serializer API did not exist in the 1.x line, so that instance is almost certainly unaffected — but GitHub may not auto-close alert #76 until this is verified or the instance is unified via a `teloxide` bump (tracked separately, see below).

## Verification

- `cargo check --workspace` — clean build, no errors (see tail below).
- `cargo test -p trusty-common` — 151 passed, 0 failed, 6 ignored (smoke test only; full suite runs in CI).

```
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 46s
```

```
test result: ok. 151 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.23s
```

## Out of scope (filed as follow-up issues)

The remaining 66 open alerts need a manifest change, are blocked on an upstream transitive dependency, or have no patched version. Issues filed for each cluster — see PM follow-up for issue numbers.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools