### PR TITLE
docs(trusty-channels): save CTO Assistant Slack app manifest

### DIFF
--- a/crates/trusty-channels/docs/slack-app-cto-assistant.manifest.json
+++ b/crates/trusty-channels/docs/slack-app-cto-assistant.manifest.json
@@ -1,0 +1,74 @@
+{
+    "display_information": {
+        "name": "CTO Assistant",
+        "description": "Private AI assistant for Duetto R&D leadership. Team, budget, compliance, GFA reports, architecture, calendar, and meeting intelligence.",
+        "background_color": "#1a1a2e",
+        "long_description": "CTO Assistant is a private AI tool for Robert Matsuoka (CTO) and the Duetto R&D leadership team. Powered by Claude Sonnet 4 via AWS Bedrock. DM-only — unauthorized users are silently redirected to a public Virtual CTO persona.\n\nCapabilities:\n• Team & org structure — headcount, contractors, pods, managers\n• R&D budget — cost centers, work-type allocation (KTLO/feature/platform)\n• GFA reports — velocity, quality, AI usage, work classification, pod rollup, risks\n• Compliance & AI adoption analytics — assessment scores, Cursor/Claude usage by department\n• Architecture & engineering — Confluence search (1,700+ pages), JIRA (856+ issues), 148 git repos\n• Calendar — Google Calendar events and free/busy queries\n• Meeting intelligence — Granola meeting notes and transcripts\n• GitHub issue filing — routes to appropriate Duetto repos\n• Canvas support — create and sync Slack Canvases from markdown files\n• Memory — persistent project context via kuzu graph DB\n• Slack channel intelligence — AI adoption signals from engineering channels (D5 scoring)"
+    },
+    "features": {
+        "app_home": {
+            "home_tab_enabled": false,
+            "messages_tab_enabled": true,
+            "messages_tab_read_only_enabled": false
+        },
+        "bot_user": {
+            "display_name": "CTO Assistant",
+            "always_online": true
+        }
+    },
+    "oauth_config": {
+        "scopes": {
+            "user": [
+                "channels:write",
+                "groups:write",
+                "channels:read",
+                "groups:read",
+                "im:read",
+                "mpim:read",
+                "channels:history",
+                "groups:history",
+                "im:history",
+                "mpim:history",
+                "search:read"
+            ],
+            "bot": [
+                "im:history",
+                "im:read",
+                "im:write",
+                "mpim:history",
+                "mpim:read",
+                "mpim:write",
+                "channels:read",
+                "channels:history",
+                "groups:read",
+                "groups:history",
+                "chat:write",
+                "reactions:write",
+                "reactions:read",
+                "users:read",
+                "users:read.email",
+                "files:write",
+                "files:read",
+                "canvases:write",
+                "canvases:read"
+            ]
+        },
+        "pkce_enabled": false
+    },
+    "settings": {
+        "event_subscriptions": {
+            "bot_events": [
+                "message.im",
+                "message.mpim",
+                "file_change"
+            ]
+        },
+        "interactivity": {
+            "is_enabled": true
+        },
+        "org_deploy_enabled": false,
+        "socket_mode_enabled": true,
+        "token_rotation_enabled": false,
+        "is_mcp_enabled": true
+    }
+}

--- a/crates/trusty-channels/docs/slack-app-cto-assistant.md
+++ b/crates/trusty-channels/docs/slack-app-cto-assistant.md
@@ -1,0 +1,5 @@
+# CTO Assistant — Slack App Manifest
+
+This is the saved Slack app manifest for the **CTO Assistant** app (app_id `A0AMPRM4W0J`) in the Duetto workspace. The manifest defines OAuth scopes, bot user settings, socket-mode configuration, and MCP enablement for the native `slack-mcp` server that drives the app.
+
+The manifest contains no secrets — only configuration and scopes. It can be used to recreate or update the app via Slack's "Create from manifest" flow at [api.slack.com/apps](https://api.slack.com/apps). Note that the user scopes include `search:read`, which is required for message search functionality via `slack_search_messages`.


### PR DESCRIPTION
Reference Slack app manifest for the native slack-mcp integration — saved configuration (OAuth scopes, bot settings, socket-mode, MCP enablement) for the CTO Assistant app (app_id A0AMPRM4W0J) in the Duetto workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)