### PR TITLE
fix(trusty-channels): LOW hardening — limit clamps + doc fixes (#2713)

### DIFF
--- a/crates/trusty-channels/src/slack/handlers.rs
+++ b/crates/trusty-channels/src/slack/handlers.rs
@@ -44,6 +44,13 @@ const DEFAULT_SEARCH_COUNT: i64 = 20;
 /// `conversations.list` locally, so bound how many the API returns).
 const DEFAULT_CHANNEL_SCAN_LIMIT: i64 = 200;
 
+/// Lower bound on a caller-supplied page size (`limit`/`count`).
+const MIN_PAGE_SIZE: i64 = 1;
+
+/// Upper bound on a caller-supplied page size (`limit`/`count`); matches the
+/// widest window Slack's paged read/search methods accept.
+const MAX_PAGE_SIZE: i64 = 1000;
+
 // Slack Web API method paths. Appended to the client's base URL.
 const CHAT_POST_MESSAGE: &str = "chat.postMessage";
 const CONVERSATIONS_HISTORY: &str = "conversations.history";
@@ -115,12 +122,14 @@ async fn send_message(client: &BaseClient, args: Value) -> Result<Value, ToolCal
 ///
 /// Why: the primary inbound read tool. Message text is untrusted, so it is
 /// markup-escaped before it reaches the model.
-/// What: requires `channel`; honours `limit` (default [`DEFAULT_READ_LIMIT`]);
-/// returns `{channel, count, messages:[{user, ts, text}]}` with escaped text.
+/// What: requires `channel`; honours `limit` (default [`DEFAULT_READ_LIMIT`],
+/// clamped to `MIN_PAGE_SIZE..=MAX_PAGE_SIZE`); returns
+/// `{channel, count, messages:[{user, ts, text}]}` with escaped text. Results
+/// are a single page (`conversations.history` is not cursor-followed here).
 /// Test: `tests/tools_http.rs::read_channel_escapes_message_text`.
 async fn read_channel(client: &BaseClient, args: Value) -> Result<Value, ToolCallError> {
     let channel = require_str(&args, "channel")?;
-    let limit = opt_i64(&args, "limit").unwrap_or(DEFAULT_READ_LIMIT);
+    let limit = clamp_page_size(opt_i64(&args, "limit").unwrap_or(DEFAULT_READ_LIMIT));
     let body = json!({ "channel": channel.as_str(), "limit": limit });
     let resp = client.call_method(CONVERSATIONS_HISTORY, &body).await?;
     let messages = clean_messages(&resp);
@@ -133,6 +142,8 @@ async fn read_channel(client: &BaseClient, args: Value) -> Result<Value, ToolCal
 /// selects the thread. Reply text is untrusted → escaped.
 /// What: requires `channel` + `thread_ts`; returns
 /// `{channel, thread_ts, count, messages:[{user, ts, text}]}` with escaped text.
+/// Results are a single page (`conversations.replies` is not cursor-followed
+/// here), so a very long thread may truncate.
 /// Test: `tests/tools_http.rs::read_thread_returns_replies`.
 async fn read_thread(client: &BaseClient, args: Value) -> Result<Value, ToolCallError> {
     let channel = require_str(&args, "channel")?;
@@ -208,15 +219,17 @@ async fn get_user(client: &BaseClient, args: Value) -> Result<Value, ToolCallErr
 /// [`crate::slack::api::error::SlackError::MissingUserToken`] *before* any
 /// network call, which surfaces here as a clear typed tool error rather than a
 /// confusing Slack rejection or a silent bot-token fallback.
-/// What: requires `query`; honours `count` (default [`DEFAULT_SEARCH_COUNT`]);
-/// returns `{query, count, matches:[{channel_id, channel_name, user, ts, text,
-/// permalink}]}`. Result `text`, `channel_name`, and `username` are untrusted
-/// (authored by arbitrary workspace members) → markup-escaped.
+/// What: requires `query`; honours `count` (default [`DEFAULT_SEARCH_COUNT`],
+/// clamped to `MIN_PAGE_SIZE..=MAX_PAGE_SIZE`); returns
+/// `{query, count, matches:[{channel_id, channel_name, user, ts, text,
+/// permalink}]}`. Result `text` and `channel_name` are untrusted (authored by
+/// arbitrary workspace members) → markup-escaped; `user` is a platform-controlled
+/// Slack user ID, forwarded verbatim.
 /// Test: `tests/tools_http.rs::search_messages_with_user_token_returns_matches`,
 /// `::search_messages_without_user_token_errors`.
 async fn search_messages(client: &BaseClient, args: Value) -> Result<Value, ToolCallError> {
     let query = require_str(&args, "query")?;
-    let count = opt_i64(&args, "count").unwrap_or(DEFAULT_SEARCH_COUNT);
+    let count = clamp_page_size(opt_i64(&args, "count").unwrap_or(DEFAULT_SEARCH_COUNT));
     let body = json!({ "query": query.as_str(), "count": count });
     let resp = client.call_method_user(SEARCH_MESSAGES, &body).await?;
     let matches = clean_search_matches(&resp);
@@ -288,6 +301,18 @@ fn opt_str(args: &Value, key: &str) -> Option<String> {
 /// Read an optional integer argument (absent or wrong-typed → `None`).
 fn opt_i64(args: &Value, key: &str) -> Option<i64> {
     args.get(key).and_then(Value::as_i64)
+}
+
+/// Clamp a caller-supplied page size into Slack's accepted range.
+///
+/// Why: Slack validates page size server-side, but forwarding an out-of-range
+/// value (a negative, zero, or absurdly large `limit`/`count`) is sloppy —
+/// clamp it to `[MIN_PAGE_SIZE, MAX_PAGE_SIZE]` as defense-in-depth so the body
+/// we build is always well-formed before it ever reaches the network.
+/// What: returns `n` clamped to `MIN_PAGE_SIZE..=MAX_PAGE_SIZE`.
+/// Test: `clamp_page_size_bounds_hostile_values`.
+fn clamp_page_size(n: i64) -> i64 {
+    n.clamp(MIN_PAGE_SIZE, MAX_PAGE_SIZE)
 }
 
 // ── Response cleaning (untrusted text is escaped here) ─────────────────────
@@ -478,6 +503,34 @@ mod tests {
         assert_eq!(opt_str(&args, "missing"), None);
         assert_eq!(opt_i64(&args, "limit"), Some(7));
         assert_eq!(opt_i64(&args, "missing"), None);
+    }
+
+    #[test]
+    fn clamp_page_size_bounds_hostile_values() {
+        // Hostile / degenerate inputs are pulled into the valid window before a
+        // request body is ever built.
+        assert_eq!(clamp_page_size(i64::MIN), MIN_PAGE_SIZE);
+        assert_eq!(clamp_page_size(-100), MIN_PAGE_SIZE);
+        assert_eq!(clamp_page_size(0), MIN_PAGE_SIZE);
+        // In-range values pass through untouched.
+        assert_eq!(clamp_page_size(1), 1);
+        assert_eq!(clamp_page_size(DEFAULT_READ_LIMIT), DEFAULT_READ_LIMIT);
+        assert_eq!(clamp_page_size(MAX_PAGE_SIZE), MAX_PAGE_SIZE);
+        // Absurdly large values collapse to the upper bound.
+        assert_eq!(clamp_page_size(1_000_000), MAX_PAGE_SIZE);
+        assert_eq!(clamp_page_size(i64::MAX), MAX_PAGE_SIZE);
+    }
+
+    #[test]
+    fn read_channel_clamps_limit_into_body() {
+        // A hostile `limit` is clamped before it reaches the request body.
+        let huge = clamp_page_size(opt_i64(&json!({ "limit": 9_999_999 }), "limit").unwrap());
+        assert_eq!(huge, MAX_PAGE_SIZE);
+        let negative = clamp_page_size(opt_i64(&json!({ "limit": -5 }), "limit").unwrap());
+        assert_eq!(negative, MIN_PAGE_SIZE);
+        // Absent `limit` falls back to the default (itself in range).
+        let default = clamp_page_size(opt_i64(&json!({}), "limit").unwrap_or(DEFAULT_READ_LIMIT));
+        assert_eq!(default, DEFAULT_READ_LIMIT);
     }
 
     #[test]

--- a/crates/trusty-channels/src/slack/tools.rs
+++ b/crates/trusty-channels/src/slack/tools.rs
@@ -91,7 +91,8 @@ pub fn tool_list_response() -> Value {
         ),
         tool(
             "slack_read_channel",
-            "Read recent messages from a Slack channel.",
+            "Read recent messages from a Slack channel. Returns a single page \
+             (no cursor pagination); a busy channel may truncate at `limit`.",
             json!({
                 "channel": channel_prop(),
                 "limit": {
@@ -103,7 +104,8 @@ pub fn tool_list_response() -> Value {
         ),
         tool(
             "slack_read_thread",
-            "Read all replies in a Slack thread.",
+            "Read replies in a Slack thread. Returns a single page (no cursor \
+             pagination); a very long thread may truncate.",
             json!({
                 "channel": channel_prop(),
                 "thread_ts": {
@@ -143,7 +145,9 @@ pub fn tool_list_response() -> Value {
         ),
         tool(
             "slack_search_channels",
-            "Search channels by name or topic.",
+            "Search channels by name or topic. Scans a single page of up to 200 \
+             channels client-side (no cursor pagination); a large workspace may \
+             truncate.",
             json!({
                 "query": { "type": "string", "description": "Channel search query string." },
             }),


### PR DESCRIPTION
Implements the three LOW-severity defense-in-depth/polish items from #2713 (residual from epic #2636 first-wave review). None gate merge.

## Changes

1. **Clamp `limit`/`count` (defense-in-depth).** New `clamp_page_size()` pulls a caller-supplied page size into `[1, 1000]` before the request body is built. Applied in `slack_read_channel` (`limit`) and `slack_search_messages` (`count`). `slack_read_thread` forwards no page-size param today, so there is nothing to clamp there. Belt-and-suspenders — Slack still validates server-side.

2. **Document the single-page bound.** `slack_read_channel`, `slack_read_thread`, and `slack_search_channels` are single-request/single-page (no cursor follow). Their schema `description`s in `slack/tools.rs` now say so, so callers know results may truncate. Full cursor pagination is deliberately **deferred** (a larger future enhancement, not this ticket).

3. **Doc drift fix.** `slack_search_messages`'s What-doc claimed the result `username` is escaped; the surfaced field is the Slack user *ID* (`user`, e.g. `U1`), a platform-controlled ID correctly forwarded verbatim. Corrected the comment to match the code.

## Tests
Added `clamp_page_size_bounds_hostile_values` (negative/zero/`i64::MIN`/huge/`i64::MAX` all clamp into range; in-range values pass through) and `read_channel_clamps_limit_into_body` (a hostile `limit` is clamped before the body is built; absent falls back to the in-range default).

Existing mrkdwn-escape behavior is unchanged.

## Gate (crate-scoped, all green)
- `cargo build -p trusty-channels` — ok
- `cargo test -p trusty-channels` — 25 unit + 13 http tests pass, 0 failed
- `cargo clippy -p trusty-channels --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `scripts/check_line_cap.sh` — 0 violations
- `scripts/check_test_pointers.sh` — 0 dangling pointers

Closes #2713

🤖 Generated with [Claude Code](https://claude.com/claude-code)